### PR TITLE
fix: Bash 5.3 compatibility for associative array declaration

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -63,6 +63,10 @@ ENV_PREFIX="CLEO"
 
 # Map of environment variables to config paths
 # CLEO_* variables only - no legacy CLAUDE_TODO_* support (clean break)
+# NOTE: Temporarily disable -u because Bash 5.3+ interprets array keys as
+# variable references under set -u, causing "unbound variable" errors.
+# See: https://github.com/kryptobaseddev/cleo/issues/10
+set +u
 declare -A ENV_TO_CONFIG=(
     # Special case - short form
     ["CLEO_FORMAT"]="output.defaultFormat"
@@ -114,6 +118,7 @@ declare -A ENV_TO_CONFIG=(
     ["CLEO_CANCELLATION_ALLOW_CASCADE"]="cancellation.allowCascade"
     ["CLEO_CANCELLATION_DEFAULT_CHILD_STRATEGY"]="cancellation.defaultChildStrategy"
 )
+set -u  # Re-enable after array declaration
 
 # ============================================================================
 # UTILITY FUNCTIONS


### PR DESCRIPTION
## Summary

Fixes Bash 5.3+ compatibility issue where associative array declarations fail with "unbound variable" errors.

Bash 5.3 has stricter `set -u` handling where array keys like `["CLEO_FORMAT"]` are evaluated as variable references, causing:

```
/Users/.../.cleo/lib/config.sh: line 66: CLEO_FORMAT: unbound variable
```

## Changes

- Temporarily disable `set -u` around the `ENV_TO_CONFIG` array declaration in `lib/config.sh`
- Re-enable immediately after the declaration completes

## Test Plan

- [x] Tested on macOS with Bash 5.3.9 (Homebrew)
- [x] `cleo version` works
- [x] `cleo init` works
- [x] `cleo list` works

Fixes #10

🤖 Generated with [Claude Code](https://claude.ai/code)