### PR TITLE
fix(publish): move @cleocode/core to devDependencies (T5724)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
   ],
   "dependencies": {
     "@cleocode/caamp": "^1.7.0",
-    "@cleocode/core": "workspace:*",
     "@cleocode/lafs-protocol": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "ajv": "^8.18.0",
@@ -108,6 +107,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
+    "@cleocode/core": "workspace:*",
     "@biomejs/biome": "^2.4.6",
     "@types/node": "^22.19.11",
     "@types/proper-lockfile": "^4.1.4",


### PR DESCRIPTION
## Summary

- **Bug**: `npm install -g @cleocode/cleo@latest` crashes with `EUNSUPPORTEDPROTOCOL` because `@cleocode/core` was listed in `dependencies` as `workspace:*`
- **Root cause**: `workspace:*` is a pnpm/yarn protocol — npm doesn't understand it; it survives into the published tarball's `package.json`
- **Fix**: Move `@cleocode/core` from `dependencies` → `devDependencies`; it's already bundled inline by esbuild (mapped to `src/core/index.ts`) so it was never a runtime dep

## Why this is safe

`build.mjs:74` maps `@cleocode/core` → `src/core/index.ts` and bundles it inline — it is NOT in the `external` array. npm consumers of the published tarball never need to install it separately.

## Test plan
- [ ] `npm install -g @cleocode/cleo@latest` succeeds after publish
- [ ] `ct self-update` completes without EUNSUPPORTEDPROTOCOL
- [ ] CLI smoke test: `ct version`, `ct find`, `ct session start`
- [ ] MCP still works via `cleo-dev` channel

Fixes: `ct self-update` EUNSUPPORTEDPROTOCOL crash (T5724)

🤖 Generated with [Claude Code](https://claude.com/claude-code)