### PR TITLE
fix(T1138): wrapper script for real ExperimentalWarning suppression (followup to PR #99)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -274,10 +274,32 @@ const cleoBuildOptions = {
   format: 'esm',
   outdir: 'packages/cleo/dist',
   sourcemap: true,
+  // T1138: Keep node:sqlite external (unbundled) so it's always imported
+  // dynamically at runtime (after banner code runs). If bundled, esbuild
+  // converts all dynamic imports to static imports, which fire their warnings
+  // during the ESM loader phase (before any code executes).
+  external: ['node:sqlite'],
   // NOTE: src/cli/index.ts already carries `#!/usr/bin/env node` — esbuild
   // preserves it into dist when `preserveShebang` semantics apply. If shebang
   // was missing, assert-shebang postbuild would fail the build (T929).
-  banner: {},
+  // T1138: SQLite ExperimentalWarning suppression via process.emitWarning override.
+  // Node emits the warning during the ESM module resolution phase. Override
+  // process.emitWarning before node:sqlite is imported (which now happens at
+  // runtime, not during bundling, because we marked it external).
+  banner: {
+    js: `(() => {
+  const _origEmitWarning = process.emitWarning;
+  process.emitWarning = function(warning, type, code, ctor) {
+    if (typeof warning === 'object' && warning.name === 'ExperimentalWarning' && typeof warning.message === 'string' && /SQLite is an experimental feature/i.test(warning.message)) {
+      return;
+    }
+    if (typeof warning === 'string' && /SQLite is an experimental feature/i.test(warning)) {
+      return;
+    }
+    return _origEmitWarning.call(process, warning, type, code, ctor);
+  };
+})();`,
+  },
   plugins: [
     workspacePlugin('bundle-cleo-deps', {
       '@cleocode/contracts': resolve(__dirname, 'packages/contracts/src/index.ts'),

--- a/packages/cleo/bin/cleo.js
+++ b/packages/cleo/bin/cleo.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * T1138: Wrapper script for the CLEO CLI.
+ *
+ * This wrapper invokes the actual CLI bundle with Node.js flags to suppress
+ * the ExperimentalWarning for node:sqlite. The warning fires during ESM module
+ * resolution (before any JS code executes), so it must be suppressed at the
+ * Node runtime level, not in application code.
+ *
+ * See: https://github.com/kryptobaseddev/cleo/issues/XXX (T1138)
+ */
+
+import { execFileSync } from 'child_process';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = resolve(__dirname, '../dist/cli/index.js');
+const args = process.argv.slice(2);
+
+try {
+  execFileSync('node', ['--disable-warning=ExperimentalWarning', cliPath, ...args], {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  });
+} catch (error) {
+  process.exit(error.status || 1);
+}

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -8,8 +8,8 @@
     ".": "./dist/cli/index.js"
   },
   "bin": {
-    "cleo": "dist/cli/index.js",
-    "ct": "dist/cli/index.js"
+    "cleo": "bin/cleo.js",
+    "ct": "bin/cleo.js"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/cleo/src/cli/index.ts
+++ b/packages/cleo/src/cli/index.ts
@@ -6,32 +6,6 @@
  */
 
 // ---------------------------------------------------------------------------
-// ExperimentalWarning suppression for node:sqlite (T1138)
-// Node 24 is our minimum (enforced below) and node:sqlite is stable there,
-// but the runtime still emits ExperimentalWarning on every invocation. This
-// pollutes stderr for any consumer capturing 2>&1 (LLM agents, shell
-// pipelines). Swallow ONLY this specific warning — all other warnings
-// (security, real deprecations, etc.) propagate unchanged.
-// ---------------------------------------------------------------------------
-const _origEmit = process.emit.bind(process);
-process.emit = ((name: string | symbol, ...args: unknown[]): boolean => {
-  if (name === 'warning') {
-    const data = args[0] as { name?: string; message?: string } | undefined;
-    if (
-      data &&
-      typeof data === 'object' &&
-      data.name === 'ExperimentalWarning' &&
-      typeof data.message === 'string' &&
-      /SQLite is an experimental feature/i.test(data.message)
-    ) {
-      return false;
-    }
-  }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return _origEmit(name as any, ...(args as any[]));
-}) as typeof process.emit;
-
-// ---------------------------------------------------------------------------
 // Node version guard — MUST run before any import that touches node:sqlite.
 // CLEO requires Node >= 24 because packages/core/src/store/llmtxt-blob-adapter.ts
 // imports node:sqlite (DatabaseSync), which only became stable in Node 24.


### PR DESCRIPTION
Followup to PR #99 which merged only the ineffective TS-source filter. The correction commit with the actual working wrapper was never pushed to origin before PR #99 merged.

This PR adds the working fix: packages/cleo/bin/cleo.js wrapper invokes the CLI with --disable-warning=ExperimentalWarning. Wrapper approach is required because the warning fires during ESM module resolution, before any JS banner/filter can run.

Verified: node .../bin/cleo.js --version 2>&1 | grep -c ExperimentalWarning = 0.

Per D022 worktree+PR flow.