### PR TITLE
fix(brain): align Windows getCleoHome with env-paths Data subdir

### DIFF
--- a/docs/specs/DATABASE-ARCHITECTURE.md
+++ b/docs/specs/DATABASE-ARCHITECTURE.md
@@ -119,7 +119,7 @@ As of v2026.4.12, API keys use `HMAC-SHA256(machineKey || globalSalt, agentId)`.
 
 ### 5. `nexus.db` — Cross-Project Routing
 
-**Location**: `~/.local/share/cleo/nexus.db` (Linux: `~/.local/share/cleo/`, macOS: `~/Library/Application Support/cleo/`, Windows: `%APPDATA%/cleo/`)
+**Location**: `~/.local/share/cleo/nexus.db` (Linux: `~/.local/share/cleo/`, macOS: `~/Library/Application Support/cleo/`, Windows: `%LOCALAPPDATA%/cleo/Data/`)
 **ORM**: Drizzle ORM (TypeScript, node:sqlite `DatabaseSync`)
 **Migration**: Drizzle Kit
 **Purpose**: NEXUS cross-project task routing, project discovery, and multi-project workflow orchestration (warp chains).

--- a/packages/brain/src/cleo-home.ts
+++ b/packages/brain/src/cleo-home.ts
@@ -27,7 +27,7 @@ import { join } from 'node:path';
  *   1. `CLEO_HOME` env var
  *   2. Platform default:
  *      - macOS: `~/Library/Application Support/cleo`
- *      - Windows: `%LOCALAPPDATA%\cleo`
+ *      - Windows: `%LOCALAPPDATA%\cleo\Data`
  *      - Linux: `$XDG_DATA_HOME/cleo` (defaults to `~/.local/share/cleo`)
  */
 export function getCleoHome(): string {
@@ -41,7 +41,12 @@ export function getCleoHome(): string {
   }
   if (platform === 'win32') {
     const localAppData = process.env['LOCALAPPDATA'] ?? join(home, 'AppData', 'Local');
-    return join(localAppData, 'cleo');
+    // env-paths-style convention: append the Data subdir on Windows so this
+    // matches what `cleo admin paths --json` reports as `cleoHome` (e.g.
+    // `%LOCALAPPDATA%\cleo\Data`). Without the suffix, Brain looks for
+    // `nexus.db` and `signaldock.db` one directory shallower than where the
+    // CLI writes them.
+    return join(localAppData, 'cleo', 'Data');
   }
   const xdgDataHome = process.env['XDG_DATA_HOME'] ?? join(home, '.local', 'share');
   return join(xdgDataHome, 'cleo');

--- a/packages/studio/src/lib/server/cleo-home.ts
+++ b/packages/studio/src/lib/server/cleo-home.ts
@@ -25,7 +25,9 @@ export function getCleoHome(): string {
   }
   if (platform === 'win32') {
     const localAppData = process.env['LOCALAPPDATA'] ?? join(home, 'AppData', 'Local');
-    return join(localAppData, 'cleo');
+    // env-paths-style convention: append the Data subdir on Windows so this
+    // matches what `cleo admin paths --json` reports as `cleoHome`.
+    return join(localAppData, 'cleo', 'Data');
   }
   const xdgDataHome = process.env['XDG_DATA_HOME'] ?? join(home, '.local', 'share');
   return join(xdgDataHome, 'cleo');


### PR DESCRIPTION
## Target branch

- [ ] `develop` -- Normal feature/fix (default)
- [x] `main` -- Hotfix only (bypasses develop, requires back-merge to develop after)

> **Note on target:** I'd normally target `develop` per the PR template, but `develop` and `main` have no common ancestor (`gh api repos/kryptobaseddev/cleo/compare/develop...main` returns "No common ancestor"). `develop` is from 2026-03-08 and contains only `packages/ct-agents` and `packages/ct-skills` -- the Brain package extraction (commit `725fc423`, T969) doesn't exist on that branch. Targeting `main` as a hotfix per the template's exception. Happy to retarget if there's a different active branch I should use.

## Process compliance

- [x] I did **not** push directly to a protected branch
- [x] This PR comes from a `fix/...` branch
- [x] Commit messages use `<type>(<scope>): <subject>` (no T-id since this is an external bug; scope is the package)
- [x] No tag/release work in this PR

## Summary

- Fix `getCleoHome()` on Windows in both `@cleocode/brain` and `@cleocode/studio` to append the `Data` subdir, matching the `env-paths` convention the CLI uses.
- Correct `docs/specs/DATABASE-ARCHITECTURE.md` Windows path to match.
- One bug, three files, two commits.

## Change type

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Related issues

Closes #102

## Repro (before this PR)

Verified on this Windows host (`cleo@2026.4.158`, `@cleocode/brain@2026.4.161`, Node v24.13.0, Win 11):

```
cleo admin paths --json
# data.cleoHome = C:\Users\<user>\AppData\Local\cleo\Data    (correct: env-paths convention)

node --input-type=module -e "import('@cleocode/brain').then(m => console.log(m.getCleoHome()))"
# C:\Users\<user>\AppData\Local\cleo                          (wrong: missing 'Data')

ls "C:\Users\<user>\AppData\Local\cleo\nexus.db"             # NOT FOUND
ls "C:\Users\<user>\AppData\Local\cleo\Data\nexus.db"        # found, 256 KB
```

Result: `getNexusSubstrate()` / `getSignaldockSubstrate()` silently return 0 nodes despite populated DBs.

## After this PR

```
node --input-type=module -e "import('@cleocode/brain').then(m => console.log(m.getCleoHome()))"
# C:\Users\<user>\AppData\Local\cleo\Data                    (matches CLI)
```

## How was this tested

- [ ] Ran `pnpm test` (Vitest) -- not run; this is a Windows-host-only path resolution change with no existing tests for `cleo-home.ts` (no `__tests__/cleo-home.test.ts` in the brain package). Happy to add a test if you want one written.
- [ ] Ran `pnpm typecheck` -- not run locally
- [ ] Ran `pnpm build` -- not run locally
- [x] Tested manually on Windows. Verified that with the patched `dist/src/cleo-home.js` applied to a global install, `getCleoHome()` returns `%LOCALAPPDATA%\cleo\Data` and Brain's nexus/signaldock paths now resolve to existing files (`exists: true`). Project-tier substrates (tasks/brain/conduit) continue to work unchanged.

## CLEO-specific checklist

- [x] Atomic operations: N/A (no writes)
- [x] Validation: N/A (no schema-bearing code)
- [x] Error handling: N/A (pure path resolution)
- [x] No time estimates: confirmed
- [x] Commit messages: `fix(brain): ...` and `docs(database-architecture): ...` per CONTRIBUTING.md (T-id omitted because non-release; release-lint hook exits 0 for non-release commits per `scripts/hooks/commit-msg-release-lint.mjs`)
- [x] Verb standards: N/A (no new commands)

## Environment

```
CLEO version: 2026.4.158 (CLI), 2026.4.161 (@cleocode/brain)
Node version: v24.13.0
OS: Windows 11 Pro 10.0.26200
```

## AI agent disclosure

- [ ] This PR was written entirely by a human
- [ ] This PR was written with AI agent assistance (human reviewed)
- [x] This PR was written primarily by an AI agent (human supervised)

## Notes

Both commits include `Signed-off-by: Jordan Calabrese <calabresejordan@gmail.com>`.

`packages/brain/src/cleo-home.ts` notes in its header that it is "a trimmed mirror of `packages/studio/src/lib/server/cleo-home.ts` ... Kept in sync manually" -- both files are patched together so they stay in sync. Suggest a follow-up to either factor `getCleoHome` into a shared utility (perhaps in `packages/contracts`) or replace both with a direct dependency on `env-paths`, but that's out of scope here.