### PR TITLE
Release v2026.5.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,35 @@
 
 ## [2026.5.57] (2026-05-08)
 
-Final wave (Phase 3/4/6) — DocsAccessor, telemetry hot-path, cloud sync scaffold
+Auto-prepared by release.ship (T9021)
 
 ### Features
-- **DocsAccessor: unified llmtxt + manifest interface**: Add DocsAccessor interface to @cleocode/contracts with storeDoc/getDoc/listDocs/searchDocs/exportDoc for 6 DocKind types (adr, agent-output, transcript, attachment, session-receipt, knowledge-graph-node). DocsAccessorImpl routes to manifest.db (CleoBlobStore) for blob kinds and in-memory store for llmtxt.db kinds. llmtxt SDK becomes implementation detail. ADR-068/ADR-069 write-ownership enforced. (T9063)
-- **Telemetry hot-path: buffered writes + opt-in default + retention policy**: Buffer telemetry events in-process (50-event max), flush on process exit (beforeExit/SIGINT/SIGTERM). Export flushTelemetryBuffer() for explicit flush. Add pruneOldTelemetryEvents(retentionDays=90) with TELEMETRY_MAX_ROWS (50k) cap. Opt-in default confirmed: absent config resolves to enabled:false. (T9051)
-- **Cloud sync scaffold: PostgresDataAccessor stub + spec**: PostgresDataAccessor interface defined in @cleocode/contracts with engine:'postgres', sync(), getStatus() extending DataAccessor. Architecture spec at docs/specs/cloud-sync-postgres-accessor.md covering multi-tenant namespacing, LWW sync semantics, Ed25519 auth model, implementation roadmap. Full impl deferred. (T9062)
-- **Agent-outputs migration utility**: migrateAgentOutputs() in @cleocode/core ingests .cleo/agent-outputs/*.md into DocsAccessor blob store with idempotent migration manifest and _archived/ rollback safety net. (T9064)
-- **CI guard preventing pragma drift**: pragma-drift-guard.test.ts scans all TypeScript source files for new DatabaseSync() instantiations and verifies applyPerfPragmas (or applyBrainPragmas) is called within 5 lines. Escape hatch list with TODO comments for known deferred sites. (T9025)
-- **Cross-link DocsAccessor with T1824 + T1825**: ADR round-trip test (storeDoc/getDoc/listDocs/exportDoc) proves DocsAccessor API surface. Documents T1824 alignment: filesystem = source of truth, DocsAccessor = index layer (not either-or). (T9065)
+- **Add CI guard preventing pragma drift on future DatabaseSync opens**: Once the sweep is done (sibling tasks complete), add a guard that fails if someone introduces a new new DatabaseSync() open without applyPerfPragma... (T9025)
 
+### Bug Fixes
+- **Startup latency benchmark + regression guard**: Add scripts/bench/startup-latency.mjs that runs cleo --version, cleo --help, cleo find foo, cleo show <id>, cleo next 50 times each on a populated ... (T9030)
+- **BUG: CLEO test fixtures pollute production task counter — IDs jumped T1923 to T9001 in 5h gap**: Between 2026-05-05 20:15 and 2026-05-06 01:06 UTC, autoincrement jumped T1923 to T9001 due to fixtures using cleo add on production DB. Confirmed f... (T9042)
+- **BUG: Worktree + temp-dir cleanup incomplete — locked worktrees from done tasks + ~/.temp bloat**: Audit during T1910: many worktrees still exist for tasks that are status=done, several marked 'locked'. Examples: T1820/T1821/T1822/T1823 worktrees... (T9043)
+- **W5: Delete cleo bug command entirely — no shim, no tombstone, no alias**: Owner directive: clean DRY removal, no compat. Delete packages/cleo/src/cli/commands/bug.ts entirely (~242 LOC). Unregister bug from packages/cleo/... (T9075)
+
+### Documentation
+- **DocsAccessor: unified llmtxt + manifest interface (agent-outputs, ADRs, attachments)**: Define DocsAccessor as the umbrella interface for ALL document operations in CLEO, wrapping the llmtxt SDK (llmtxt/sdk for AgentSession, llmtxt/blo... (T9063)
+- **W6: Update all docs to reflect new taxonomy + ADR codifying rename + AC-everywhere + system-wide attestation**: Document the locked taxonomy. (1) Update CLEO-INJECTION.md — remove cleo bug references, document --kind as canonical, document AC-required-for-all... (T9076)
+
+### Chores
+- **One-shot marker for detectAndRemoveLegacy* startup cleanups**: detectAndRemoveLegacyGlobalFiles and detectAndRemoveStrayProjectNexus run on every non-fast-path CLI invocation. They are stat()-heavy and only do ... (T9028)
+- **Migrate .cleo/agent-outputs/*.md raw markdown to llmtxt blob store via DocsAccessor**: .cleo/agent-outputs/ holds 100+ raw markdown files today (audits, campaign plans, handoff notes, etc.). They're filesystem-managed (no manifest, no... (T9064)
+
+### Changes
+- **Wire applyPerfPragmas into read-only/inspection DB opens**: Apply applyPerfPragmas() (with enableWal:false since these are readonly) to: backup-pack.ts (3 sites: lines 245, 281, 344), backup-unpack.ts (line ... (T9022)
+- **Wire applyPerfPragmas into one-shot writer DB opens**: Apply applyPerfPragmas() to: agent-registry-accessor.ts (lines 333, 349), cross-db-cleanup.ts (line 357), migrate-signaldock-to-conduit.ts (lines 2... (T9023)
+- **Defer DB opens until command needs them**: Today runStartupMaintenance opens conduit.db AND signaldock.db on every non-fast-path command — even commands that touch neither (e.g. cleo --help ... (T9029)
+- **Telemetry hot-path: buffered writes, opt-in audit, retention policy**: telemetry.db is written by dispatch/middleware/telemetry.ts on EVERY CLI invocation. Under concurrent multi-process invocations this is N writers c... (T9051)
+- **Cross-package DB-open drift: brain, studio, cleo, llmtxt-blob-adapter**: Discovered during T9021 audit: at least 4 packages OUTSIDE core/store have their own raw new DatabaseSync() open helpers, completely bypassing appl... (T9045)
+- **W2: Hard-rename --role to --kind everywhere (NO backwards compat, NO alias)**: Owner directive: clean DRY rename, NO --role alias, NO TaskRole re-export. Update all 6 declaration sites: (1) contracts/src/task.ts:53 — rename Ta... (T9072)
+- **Drop vestigial multi-engine polymorphism in getAccessor / createDataAccessor**: data-accessor.ts:28 createDataAccessor takes _engine?: 'sqlite' but always uses sqlite — the engine parameter is dead. Plus the // SSoT-EXEMPT:engi... (T9054)
+- **Cross-link DocsAccessor work with T1824 (Decision Storage Consolidation) + T1825 (ADR migration)**: T1824 is an existing epic for programmatic ADR management with .cleo/adrs/ as canonical. T1825 is a child for migrating docs/adr/ → .cleo/adrs/. Bo... (T9065)
 ---
-
 ## [2026.5.56] (2026-05-08)
 
 Auto-prepared by release.ship (T9047)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2026.5.57] (2026-05-08)
+
+Final wave (Phase 3/4/6) — DocsAccessor, telemetry hot-path, cloud sync scaffold
+
+### Features
+- **DocsAccessor: unified llmtxt + manifest interface**: Add DocsAccessor interface to @cleocode/contracts with storeDoc/getDoc/listDocs/searchDocs/exportDoc for 6 DocKind types (adr, agent-output, transcript, attachment, session-receipt, knowledge-graph-node). DocsAccessorImpl routes to manifest.db (CleoBlobStore) for blob kinds and in-memory store for llmtxt.db kinds. llmtxt SDK becomes implementation detail. ADR-068/ADR-069 write-ownership enforced. (T9063)
+- **Telemetry hot-path: buffered writes + opt-in default + retention policy**: Buffer telemetry events in-process (50-event max), flush on process exit (beforeExit/SIGINT/SIGTERM). Export flushTelemetryBuffer() for explicit flush. Add pruneOldTelemetryEvents(retentionDays=90) with TELEMETRY_MAX_ROWS (50k) cap. Opt-in default confirmed: absent config resolves to enabled:false. (T9051)
+- **Cloud sync scaffold: PostgresDataAccessor stub + spec**: PostgresDataAccessor interface defined in @cleocode/contracts with engine:'postgres', sync(), getStatus() extending DataAccessor. Architecture spec at docs/specs/cloud-sync-postgres-accessor.md covering multi-tenant namespacing, LWW sync semantics, Ed25519 auth model, implementation roadmap. Full impl deferred. (T9062)
+- **Agent-outputs migration utility**: migrateAgentOutputs() in @cleocode/core ingests .cleo/agent-outputs/*.md into DocsAccessor blob store with idempotent migration manifest and _archived/ rollback safety net. (T9064)
+- **CI guard preventing pragma drift**: pragma-drift-guard.test.ts scans all TypeScript source files for new DatabaseSync() instantiations and verifies applyPerfPragmas (or applyBrainPragmas) is called within 5 lines. Escape hatch list with TODO comments for known deferred sites. (T9025)
+- **Cross-link DocsAccessor with T1824 + T1825**: ADR round-trip test (storeDoc/getDoc/listDocs/exportDoc) proves DocsAccessor API surface. Documents T1824 alignment: filesystem = source of truth, DocsAccessor = index layer (not either-or). (T9065)
+
+---
+
 ## [2026.5.56] (2026-05-08)
 
 Auto-prepared by release.ship (T9047)

--- a/docs/specs/cloud-sync-postgres-accessor.md
+++ b/docs/specs/cloud-sync-postgres-accessor.md
@@ -1,0 +1,156 @@
+# Cloud Sync: PostgresDataAccessor Architecture Spec
+
+**Status**: SCAFFOLD — interface defined, implementation deferred (T9062 child tasks)
+**Task**: T9062
+**Epic**: T9048 (DB Charter + DataAccessor Umbrella)
+**Dependencies**: T9050 (UmbrellaDataAccessor), ADR-068, ADR-069
+
+---
+
+## 1. Motivation
+
+CLEO is local-first: all data lives in project-scoped SQLite databases
+(tasks.db, brain.db, conduit.db, llmtxt.db, telemetry.db). This is ideal
+for offline operation, single-developer workflows, and portability.
+
+Multi-developer / multi-machine workflows require a sync layer that:
+- Preserves the local-first SQLite experience (no forced connectivity)
+- Allows explicit push/pull to a shared Postgres backend
+- Enforces per-project data isolation (multi-tenant)
+- Aligns with the existing DataAccessor interface contract (T9050)
+
+The key architectural decision established here: **PostgresDataAccessor
+implements the same DataAccessor interface as SqliteDataAccessor**. Callers
+that accept a `DataAccessor` parameter work with either engine without
+modification — proving the T9050 abstraction is engine-neutral.
+
+---
+
+## 2. Multi-Tenant Namespacing
+
+Each CLEO project maps to a **tenant namespace** within a shared Postgres
+cluster. Two isolation strategies are supported (selectable per cluster):
+
+### 2.1 Schema Strategy (default)
+
+Each project gets a dedicated Postgres schema:
+
+```
+cleo_<projectHash>
+  ├── tasks
+  ├── task_dependencies
+  ├── task_relations
+  ├── sessions
+  ├── schema_meta
+  └── audit_log
+```
+
+`projectHash` is the 16-character hex used in worktree directory names
+(e.g. `1e3146b7352ba279`), derived deterministically from the project root
+path. This ensures stable cross-machine identity without a central registry.
+
+**Isolation**: full schema separation. Cross-tenant access is impossible
+at the Postgres schema level.
+
+### 2.2 Row-Level Strategy
+
+All projects share tables; a `project_id` column (= `projectHash`) is added
+to every table, and Row Level Security (RLS) policies enforce tenant
+boundaries. Simpler schema management; requires careful RLS configuration.
+
+---
+
+## 3. Sync Semantics
+
+### 3.1 Initial Design: Last-Write-Wins (LWW)
+
+- Each table row carries an `updated_at` timestamp.
+- On push: local rows with `updated_at > last_push_at` are upserted to Postgres.
+- On pull: Postgres rows with `updated_at > last_pull_at` are upserted to SQLite.
+- Conflict resolution: higher `updated_at` wins. In case of ties, remote wins
+  on pull; local wins on push.
+
+### 3.2 CRDT Merge (opt-in, deferred)
+
+cr-sqlite (T947) provides CRDT-merge semantics for brain.db (cross-device
+knowledge sharing). Integration with PostgresDataAccessor is opt-in per
+a separate ADR from T947. Not included in the initial implementation.
+
+### 3.3 Sync Commands (implementation deferred)
+
+```
+cleo sync push    # Local → Postgres (rows changed since last push)
+cleo sync pull    # Postgres → Local (rows changed since last pull)
+cleo sync status  # Show divergence: N local changes, M remote changes
+```
+
+---
+
+## 4. Auth + Authorization Model
+
+Each tenant is identified by their **SignalDock identity** (Ed25519 keypair,
+the same identity used for llmtxt/sdk ContributionReceipt signing).
+
+- Every push batch is signed with the tenant's Ed25519 private key.
+- The Postgres server (or a middleware layer) verifies the signature before
+  accepting writes. Unsigned pushes are rejected with `401 Unauthorized`.
+- Public keys are registered once per tenant in a `cleo_auth.tenants` table
+  (or via the SignalDock identity service at signaldock.io).
+
+---
+
+## 5. DataAccessor Engine-Neutral Proof
+
+`SqliteDataAccessor` has `engine: 'sqlite'`.
+`PostgresDataAccessor` has `engine: 'postgres'`.
+
+Both satisfy the `DataAccessor` interface contract defined in
+`@cleocode/contracts/data-accessor.ts`. Any code that accepts a `DataAccessor`
+parameter (e.g. task commands, brain operations) works with either without
+modification — this is the T9050 abstraction proof.
+
+```typescript
+// This works with both SqliteDataAccessor and PostgresDataAccessor:
+async function countTasks(accessor: DataAccessor): Promise<number> {
+  return accessor.countTasks();
+}
+```
+
+---
+
+## 6. Backup Integration
+
+Postgres-side backup integrates with the existing `cleo backup` system
+(ADR-013 §9). A `cleo restore` can pull from cloud (Postgres) OR local
+snapshot (SQLite WAL backup), with the user choosing the source.
+
+---
+
+## 7. Implementation Roadmap (T9062 child tasks)
+
+The following tasks will be created under T9062 to implement the full spec:
+
+| Wave | Task | Description |
+|------|------|-------------|
+| 1 | ADR: cloud-sync architecture | Document sync model decision + RLS vs schema choice |
+| 1 | Driver + connection pool | postgres.js or pg driver, pool configuration |
+| 2 | Schema migration | `CREATE SCHEMA cleo_<projectHash>` + table DDL matching SQLite |
+| 2 | PostgresDataAccessor impl | Implement all DataAccessor methods with pg queries |
+| 3 | Sync engine | LWW push/pull with `updated_at` change tracking |
+| 3 | CLI commands | `cleo sync push/pull/status` |
+| 4 | Auth middleware | Ed25519 signature verification for push batches |
+| 4 | Integration tests | 2+ tenants in one Postgres instance, no cross-leakage |
+
+---
+
+## 8. Out of Scope
+
+- **Realtime collaboration** (CRDT live editing) — separate project under llmtxt-graph
+- **Rust signaldock-storage** Postgres feature — cloud-side counterpart, tracked separately
+- **Full CRDT merge** — opt-in per T947 ADR, not in initial implementation
+- **SaaS hosted cluster** — operator choice; spec is engine-agnostic
+
+---
+
+*This document is the SCAFFOLD deliverable for T9062. It will be superseded by
+the ADR authored in the first implementation wave.*

--- a/packages/contracts/src/docs-accessor.ts
+++ b/packages/contracts/src/docs-accessor.ts
@@ -1,0 +1,208 @@
+/**
+ * DocsAccessor — unified interface for all document operations in CLEO.
+ *
+ * Abstracts the scattered document surfaces behind a single typed API:
+ *   - llmtxt/sdk (AgentSession, receipt, version patches)
+ *   - llmtxt/blob (content-addressed blob store)
+ *   - llmtxt/graph (KnowledgeGraph)
+ *   - raw filesystem agent-outputs (migrated via T9064)
+ *
+ * Consumers depend on DocsAccessor, NOT on llmtxt/* subpaths directly.
+ * The llmtxt SDK becomes an implementation detail of DocsAccessorImpl.
+ *
+ * DB storage split (ADR-068 — DB Charter):
+ *   - storeDoc(kind=session-receipt | transcript) → writes to llmtxt.db
+ *   - storeDoc(kind=adr | agent-output | attachment) → writes to manifest.db (blob store)
+ *   - searchDocs() → queries llmtxt.db via llmtxt/similarity
+ *   - listDocs(kind=knowledge-graph-node) → queries llmtxt.db graph tables
+ *
+ * Coordination model (ADR-069 — Coordination Layers):
+ *   - DocsAccessor is a read/write accessor in the Storage Layer.
+ *   - CLI commands go through the Dispatch Layer; they accept a DocsAccessor
+ *     injected via the existing createDataAccessor() → UmbrellaDataAccessor chain.
+ *   - No direct SQLite access in consumers — all queries route through DocsAccessor.
+ *
+ * @task T9063
+ * @epic T9048
+ * @see ADR-068 (DB Charter — per-DB write ownership)
+ * @see ADR-069 (Coordination Layers — Storage Layer contract)
+ * @see T1824 (Decision Storage Consolidation — DocsAccessor becomes the write path for ADRs)
+ * @see T1825 (ADR migration — ADR files ingest via storeDoc(kind='adr'))
+ */
+
+// ---------------------------------------------------------------------------
+// Document kind discriminated union
+// ---------------------------------------------------------------------------
+
+/**
+ * All document kinds that DocsAccessor can store and retrieve.
+ *
+ * - `adr`                — Architecture Decision Records (docs/adr/*.md)
+ * - `agent-output`       — Agent session markdown outputs (.cleo/agent-outputs/*.md)
+ * - `transcript`         — Full agent conversation transcripts (llmtxt.db)
+ * - `attachment`         — Task attachments (manifest.db blob store)
+ * - `session-receipt`    — llmtxt session receipts (llmtxt.db sessions table)
+ * - `knowledge-graph-node` — Nodes from llmtxt/graph KnowledgeGraph (llmtxt.db)
+ */
+export type DocKind =
+  | 'adr'
+  | 'agent-output'
+  | 'transcript'
+  | 'attachment'
+  | 'session-receipt'
+  | 'knowledge-graph-node';
+
+// ---------------------------------------------------------------------------
+// Core document record
+// ---------------------------------------------------------------------------
+
+/**
+ * A stored document record returned by getDoc / listDocs.
+ */
+export interface DocRecord {
+  /** Content-addressed identifier (SHA-256 hex for blob-backed; UUID for DB-backed). */
+  readonly id: string;
+  /** Document kind. */
+  readonly kind: DocKind;
+  /** Raw content of the document (UTF-8 text or base64 for binary). */
+  readonly content: string;
+  /** Human-readable title or filename. */
+  readonly title: string | null;
+  /** ISO 8601 creation timestamp. */
+  readonly createdAt: string;
+  /** Linked task IDs (e.g. the task this agent-output was produced for). */
+  readonly linkedTaskIds: string[];
+  /** Arbitrary metadata blob (kind-specific). */
+  readonly meta: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Method parameter types
+// ---------------------------------------------------------------------------
+
+/**
+ * Parameters for {@link DocsAccessor.storeDoc}.
+ */
+export interface StoreDocParams {
+  /** Document kind determining which backing store is used. */
+  kind: DocKind;
+  /** Raw document content (UTF-8). */
+  content: string;
+  /** Human-readable title or filename. */
+  title?: string;
+  /** Task IDs to link to this document. */
+  linkedTaskIds?: string[];
+  /** Arbitrary metadata to attach (kind-specific). */
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Result from {@link DocsAccessor.storeDoc}.
+ */
+export interface StoreDocResult {
+  /** Assigned document ID (SHA-256 for blob-backed, UUID for DB-backed). */
+  readonly id: string;
+  /** The backing store that received the write. */
+  readonly backend: 'llmtxt.db' | 'manifest.db';
+}
+
+/**
+ * Filters for {@link DocsAccessor.listDocs}.
+ */
+export interface ListDocsFilters {
+  /** Restrict to one document kind. */
+  kind?: DocKind;
+  /** Restrict to documents linked to this task ID. */
+  linkedTaskId?: string;
+  /** Maximum number of results. Default: 100. */
+  limit?: number;
+  /** Offset for pagination. */
+  offset?: number;
+  /** Order by. Default: 'createdAt'. */
+  orderBy?: 'createdAt' | 'title';
+}
+
+/**
+ * A search hit from {@link DocsAccessor.searchDocs}.
+ */
+export interface DocSearchHit {
+  /** The matching document record. */
+  readonly doc: DocRecord;
+  /** Similarity score (0–1, higher is more relevant). */
+  readonly score: number;
+}
+
+/**
+ * Export format for {@link DocsAccessor.exportDoc}.
+ */
+export type DocExportFormat = 'markdown' | 'json' | 'plain';
+
+// ---------------------------------------------------------------------------
+// DocsAccessor interface
+// ---------------------------------------------------------------------------
+
+/**
+ * DocsAccessor — unified interface for all CLEO document operations.
+ *
+ * Backed by llmtxt.db (sessions + receipts) and manifest.db (blob attachments).
+ * Both backing stores are opaque to consumers — all access goes through this
+ * interface.
+ *
+ * DB write ownership (ADR-068):
+ *   - `session-receipt`, `transcript`, `knowledge-graph-node` → llmtxt.db
+ *   - `adr`, `agent-output`, `attachment` → manifest.db (blob store)
+ *
+ * @see ADR-068 — DB Charter per-DB write ownership table
+ * @see ADR-069 — Coordination Layers: DocsAccessor is a Storage Layer contract
+ */
+export interface DocsAccessor {
+  /**
+   * Store a document, routing to the correct backing store by kind.
+   *
+   * @param params - Document content, kind, and metadata.
+   * @returns The assigned ID and backend that received the write.
+   */
+  storeDoc(params: StoreDocParams): Promise<StoreDocResult>;
+
+  /**
+   * Retrieve a document by ID or content hash.
+   *
+   * @param idOrHash - Document ID (UUID or SHA-256 hex).
+   * @returns The document record, or null if not found.
+   */
+  getDoc(idOrHash: string): Promise<DocRecord | null>;
+
+  /**
+   * List documents matching filters with pagination support.
+   *
+   * @param filters - Optional filter bag.
+   * @returns Array of matching document records.
+   */
+  listDocs(filters?: ListDocsFilters): Promise<DocRecord[]>;
+
+  /**
+   * Search documents by semantic similarity via llmtxt/similarity.
+   *
+   * Queries the llmtxt.db embeddings index. Only documents with embeddings
+   * are returned (agent-outputs, ADRs, transcripts ingested via storeDoc).
+   *
+   * @param query - Natural language query string.
+   * @param limit - Maximum hits to return. Default: 10.
+   * @returns Ranked search results with similarity scores.
+   */
+  searchDocs(query: string, limit?: number): Promise<DocSearchHit[]>;
+
+  /**
+   * Export a document in the requested format.
+   *
+   * @param id - Document ID.
+   * @param format - Output format. Default: 'markdown'.
+   * @returns Formatted document content string, or null if not found.
+   */
+  exportDoc(id: string, format?: DocExportFormat): Promise<string | null>;
+
+  /**
+   * Release any resources held by this accessor (close DB connections).
+   */
+  close(): Promise<void>;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -246,6 +246,17 @@ export type {
   TaskQueryFilters,
   TransactionAccessor,
 } from './data-accessor.js';
+// === DocsAccessor Contracts (T9063) ===
+export type {
+  DocExportFormat,
+  DocKind,
+  DocRecord,
+  DocSearchHit,
+  DocsAccessor,
+  ListDocsFilters,
+  StoreDocParams,
+  StoreDocResult,
+} from './docs-accessor.js';
 // === Dependency Registry Contracts ===
 export type {
   DependencyCategory,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -246,6 +246,17 @@ export type {
   TaskQueryFilters,
   TransactionAccessor,
 } from './data-accessor.js';
+// === PostgresDataAccessor Contracts — cloud-sync scaffold (T9062) ===
+export type {
+  CreatePostgresDataAccessorFn,
+  PostgresDataAccessor,
+  PostgresDataAccessorOptions,
+  PostgresSyncDirection,
+  PostgresTenantNamespace,
+  PostgresTenantStrategy,
+  SyncResult,
+  SyncStatus,
+} from './postgres-data-accessor.js';
 // === Dependency Registry Contracts ===
 export type {
   DependencyCategory,
@@ -254,6 +265,17 @@ export type {
   DependencySpec,
 } from './dependency.js';
 export type { AdapterManifest, DetectionPattern } from './discovery.js';
+// === DocsAccessor Contracts (T9063) ===
+export type {
+  DocExportFormat,
+  DocKind,
+  DocRecord,
+  DocSearchHit,
+  DocsAccessor,
+  ListDocsFilters,
+  StoreDocParams,
+  StoreDocResult,
+} from './docs-accessor.js';
 // === Error Utilities ===
 export {
   ClassifierUnregisteredAgentError,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -246,17 +246,6 @@ export type {
   TaskQueryFilters,
   TransactionAccessor,
 } from './data-accessor.js';
-// === PostgresDataAccessor Contracts — cloud-sync scaffold (T9062) ===
-export type {
-  CreatePostgresDataAccessorFn,
-  PostgresDataAccessor,
-  PostgresDataAccessorOptions,
-  PostgresSyncDirection,
-  PostgresTenantNamespace,
-  PostgresTenantStrategy,
-  SyncResult,
-  SyncStatus,
-} from './postgres-data-accessor.js';
 // === Dependency Registry Contracts ===
 export type {
   DependencyCategory,
@@ -1046,6 +1035,17 @@ export type {
   PlaybookRun,
   PlaybookRunStatus,
 } from './playbook.js';
+// === PostgresDataAccessor Contracts — cloud-sync scaffold (T9062) ===
+export type {
+  CreatePostgresDataAccessorFn,
+  PostgresDataAccessor,
+  PostgresDataAccessorOptions,
+  PostgresSyncDirection,
+  PostgresTenantNamespace,
+  PostgresTenantStrategy,
+  SyncResult,
+  SyncStatus,
+} from './postgres-data-accessor.js';
 export type { AdapterPathProvider } from './provider-paths.js';
 // === Release Pipeline (T1597 / ADR-063) ===
 export type {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -246,6 +246,14 @@ export type {
   TaskQueryFilters,
   TransactionAccessor,
 } from './data-accessor.js';
+// === Dependency Registry Contracts ===
+export type {
+  DependencyCategory,
+  DependencyCheckResult,
+  DependencyReport,
+  DependencySpec,
+} from './dependency.js';
+export type { AdapterManifest, DetectionPattern } from './discovery.js';
 // === DocsAccessor Contracts (T9063) ===
 export type {
   DocExportFormat,
@@ -257,14 +265,6 @@ export type {
   StoreDocParams,
   StoreDocResult,
 } from './docs-accessor.js';
-// === Dependency Registry Contracts ===
-export type {
-  DependencyCategory,
-  DependencyCheckResult,
-  DependencyReport,
-  DependencySpec,
-} from './dependency.js';
-export type { AdapterManifest, DetectionPattern } from './discovery.js';
 // === Error Utilities ===
 export {
   ClassifierUnregisteredAgentError,

--- a/packages/contracts/src/postgres-data-accessor.ts
+++ b/packages/contracts/src/postgres-data-accessor.ts
@@ -1,0 +1,199 @@
+/**
+ * PostgresDataAccessor — interface stub for cloud-sync backend.
+ *
+ * SCAFFOLD ONLY (T9062). This file defines the type surface and namespacing
+ * contract for the PostgreSQL-backed DataAccessor. Full implementation
+ * (sync commands, migration, multi-tenant namespacing, auth) is deferred
+ * to T9062 child tasks.
+ *
+ * Architecture overview (ADR-TBD — cloud-sync):
+ *   - CLEO is local-first SQLite for portability and offline operation.
+ *   - A PostgresDataAccessor provides an engine-neutral drop-in replacement
+ *     for SqliteDataAccessor — same DataAccessor interface, different engine.
+ *   - Multi-tenant namespacing: each CLEO project maps to a Postgres
+ *     "tenant namespace" (schema or row-level tenant key) inside a shared
+ *     cluster. Cross-tenant isolation is enforced at the DB layer.
+ *   - Sync model: pull/push with last-write-wins per row (initial design).
+ *     CRDT merge (cr-sqlite) is opt-in per ADR from T947.
+ *   - Auth: each tenant identified by SignalDock identity (Ed25519 keypair).
+ *     Push receipts signed with the same primitive as llmtxt/sdk receipts.
+ *
+ * Engine-neutral proof:
+ *   The DataAccessor interface in @cleocode/contracts carries `engine: 'sqlite'`.
+ *   PostgresDataAccessor will carry `engine: 'postgres'`. Both satisfy the
+ *   same interface contract, proving the abstraction from T9050 is real.
+ *
+ * @task T9062
+ * @epic T9048
+ * @see packages/contracts/src/data-accessor.ts (DataAccessor interface)
+ * @see packages/contracts/src/postgres-sync-spec.ts (sync semantics spec)
+ * @see docs/adr/ (ADR-TBD: cloud-sync architecture — to be authored in T9062)
+ */
+
+import type { DataAccessor } from './data-accessor.js';
+
+// ---------------------------------------------------------------------------
+// Multi-tenant namespacing
+// ---------------------------------------------------------------------------
+
+/**
+ * Strategy for isolating tenant data in a shared Postgres cluster.
+ *
+ * - `schema`:   Each project gets a dedicated Postgres schema
+ *               (`cleo_<projectHash>`). Strongest isolation; higher overhead.
+ * - `row-level`: All projects share tables; tenant key (`project_id`) filters
+ *               every query. Simpler to manage; requires RLS enforcement.
+ */
+export type PostgresTenantStrategy = 'schema' | 'row-level';
+
+/**
+ * Identifies a CLEO project namespace inside the shared Postgres cluster.
+ *
+ * Generated deterministically from the project root hash (the same
+ * `projectHash` used in worktree paths) to ensure stable cross-machine
+ * identity without requiring a central registry lookup.
+ */
+export interface PostgresTenantNamespace {
+  /**
+   * Postgres-safe schema name (schema strategy) or tenant key (row-level).
+   * Format: `cleo_<projectHash>` where projectHash is the 16-char hex used
+   * in worktree directory names (e.g. `cleo_1e3146b7352ba279`).
+   */
+  readonly namespaceName: string;
+  /** Original hex project hash. */
+  readonly projectHash: string;
+  /** Isolation strategy in use for this cluster. */
+  readonly strategy: PostgresTenantStrategy;
+}
+
+// ---------------------------------------------------------------------------
+// Connection options
+// ---------------------------------------------------------------------------
+
+/**
+ * Connection options for the PostgresDataAccessor.
+ *
+ * All credentials are passed at construction time. The accessor never
+ * reads environment variables directly — callers are responsible for
+ * resolving the connection string from their config/secret store.
+ */
+export interface PostgresDataAccessorOptions {
+  /**
+   * PostgreSQL connection string (libpq format).
+   * Example: `postgresql://user:pass@host:5432/cleo_sync`.
+   */
+  connectionString: string;
+  /** Project namespace within the cluster. */
+  namespace: PostgresTenantNamespace;
+  /**
+   * Optional connection pool size. Default: 5.
+   * Keep small — CLI invocations are short-lived, not long-running servers.
+   */
+  poolSize?: number;
+  /**
+   * Optional Ed25519 signing keypair for authenticated push receipts.
+   * When present, every push batch is signed with this key.
+   * Aligns with llmtxt/sdk ContributionReceipt signing.
+   */
+  signingKeyHex?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Sync semantics
+// ---------------------------------------------------------------------------
+
+/**
+ * Direction of a sync operation.
+ *
+ * - `push`: Write local SQLite state → Postgres.
+ * - `pull`: Read Postgres state → update local SQLite.
+ * - `bidirectional`: Pull then push (last-write-wins per row).
+ */
+export type PostgresSyncDirection = 'push' | 'pull' | 'bidirectional';
+
+/**
+ * Result from a sync operation.
+ */
+export interface SyncResult {
+  /** Direction that was executed. */
+  direction: PostgresSyncDirection;
+  /** Number of rows written to Postgres (push) or read from Postgres (pull). */
+  rowsSynced: number;
+  /** Number of conflicts resolved (last-write-wins). */
+  conflictsResolved: number;
+  /** ISO-8601 timestamp of sync completion. */
+  completedAt: string;
+}
+
+/**
+ * Status report from `getStatus()`.
+ */
+export interface SyncStatus {
+  /** Whether the Postgres connection is healthy. */
+  connected: boolean;
+  /** ISO-8601 timestamp of the last successful sync, or null if never synced. */
+  lastSyncedAt: string | null;
+  /** Number of local changes not yet pushed. */
+  pendingPushCount: number;
+  /** Whether the remote has changes not yet pulled. */
+  remoteAhead: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// PostgresDataAccessor interface stub
+// ---------------------------------------------------------------------------
+
+/**
+ * PostgresDataAccessor — Postgres-backed implementation of DataAccessor.
+ *
+ * INTERFACE STUB — full implementation deferred to T9062 child tasks.
+ *
+ * Extends the base DataAccessor interface with `engine: 'postgres'` and
+ * adds cloud-sync-specific methods (sync, getStatus, close).
+ *
+ * All methods from DataAccessor are inherited and must be implemented
+ * using Postgres queries (pg or postgres.js driver). The implementation
+ * will live in @cleocode/core (NOT in @cleocode/cleo — CLI-layer only).
+ *
+ * @see DataAccessor for the full list of inherited methods.
+ */
+export interface PostgresDataAccessor extends Omit<DataAccessor, 'engine'> {
+  /**
+   * The storage engine backing this accessor.
+   * Discriminates from SqliteDataAccessor at the type level.
+   */
+  readonly engine: 'postgres';
+
+  /**
+   * Sync local state with the Postgres backend.
+   *
+   * @param direction - Which direction(s) to sync.
+   * @returns Summary of the sync operation.
+   */
+  sync(direction?: PostgresSyncDirection): Promise<SyncResult>;
+
+  /**
+   * Get the current sync status (connection health + divergence metrics).
+   *
+   * @returns Sync status report.
+   */
+  getStatus(): Promise<SyncStatus>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory signature (implementation deferred)
+// ---------------------------------------------------------------------------
+
+/**
+ * Factory type for creating a PostgresDataAccessor.
+ *
+ * The concrete implementation (`createPostgresDataAccessor`) lives in
+ * @cleocode/core and will be exported from @cleocode/core/internal once
+ * the full implementation is complete (T9062 child tasks).
+ *
+ * @param options - Connection and namespace options.
+ * @returns A fully initialized PostgresDataAccessor.
+ */
+export type CreatePostgresDataAccessorFn = (
+  options: PostgresDataAccessorOptions,
+) => Promise<PostgresDataAccessor>;

--- a/packages/core/src/__tests__/docs-accessor-adr-roundtrip.test.ts
+++ b/packages/core/src/__tests__/docs-accessor-adr-roundtrip.test.ts
@@ -31,7 +31,7 @@
  * @see T1825 — ADR migration
  */
 
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -142,7 +142,7 @@ describe('DocsAccessor ADR round-trip (T9065)', () => {
     }
   });
 
-  it("exportDoc returns formatted markdown with linked tasks (T1824 model validation)", async () => {
+  it('exportDoc returns formatted markdown with linked tasks (T1824 model validation)', async () => {
     const accessor = createDocsAccessor(tempProjectRoot);
     try {
       const { id } = await accessor.storeDoc({

--- a/packages/core/src/__tests__/docs-accessor-adr-roundtrip.test.ts
+++ b/packages/core/src/__tests__/docs-accessor-adr-roundtrip.test.ts
@@ -1,0 +1,167 @@
+/**
+ * T9065: Cross-link DocsAccessor with T1824 (Decision Storage Consolidation)
+ * and T1825 (ADR migration).
+ *
+ * This test:
+ *   1. Verifies DocsAccessor.storeDoc(kind:'adr') round-trips a real ADR file
+ *      from .cleo/adrs/ — proving the DocsAccessor API surface is usable for ADR
+ *      ingestion as required by T1824 and T1825.
+ *   2. Documents the ADR storage model alignment decision (T1824):
+ *      ADRs remain on filesystem as the source of truth; DocsAccessor provides
+ *      an indexing layer via storeDoc (backed by manifest.db blob store).
+ *      This is "filesystem + llmtxt index, not either-or" per T1824 acceptance.
+ *
+ * T1824 alignment notes (recorded as inline documentation):
+ *   - ADRs remain on filesystem (.cleo/adrs/*.md) — canonical source.
+ *   - storeDoc(kind:'adr') INDEXES the ADR in manifest.db (content-addressed).
+ *   - Callers may use DocsAccessor.searchDocs() to find ADRs by semantic query.
+ *   - No ADR file is deleted from .cleo/adrs/ by DocsAccessor — filesystem is
+ *     the source of truth, DocsAccessor is the index layer.
+ *
+ * T1825 alignment notes:
+ *   - ADR migration (T1825) should ingest ADRs via storeDoc(kind:'adr') to
+ *     populate the DocsAccessor index alongside filesystem storage.
+ *   - T1825 acceptance criteria should include: "ADRs indexed via
+ *     DocsAccessor.storeDoc(kind:'adr') after migration".
+ *
+ * @task T9065
+ * @see packages/contracts/src/docs-accessor.ts (DocsAccessor interface)
+ * @see packages/core/src/store/docs-accessor-impl.ts (DocsAccessorImpl)
+ * @see T1824 — Decision Storage Consolidation
+ * @see T1825 — ADR migration
+ */
+
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDocsAccessor } from '../store/docs-accessor-impl.js';
+
+// ---------------------------------------------------------------------------
+// Test fixture content (ADR format matches .cleo/adrs/*.md)
+// ---------------------------------------------------------------------------
+
+const FIXTURE_ADR_CONTENT = `# ADR-TEST: DocsAccessor storage model
+
+**Status**: Accepted
+**Task**: T9065
+**Date**: 2026-05-08
+
+## Context
+
+CLEO stores ADRs in .cleo/adrs/*.md on the filesystem. T1824 (Decision Storage
+Consolidation) adds a DocsAccessor indexing layer backed by manifest.db
+(CleoBlobStore). The model is: filesystem = source of truth, DocsAccessor = index.
+
+## Decision
+
+ADRs remain on filesystem. DocsAccessor.storeDoc(kind:'adr') indexes them in
+manifest.db for semantic search. No ADR is deleted from .cleo/adrs/ by DocsAccessor.
+
+## Consequences
+
+- Callers must call storeDoc for each ADR to populate the index (T1825).
+- Filesystem remains the authoritative source — git history is preserved.
+- DocsAccessor.searchDocs() enables semantic ADR lookup (once T9064 integrates
+  llmtxt/similarity for full embedding-based search).
+`;
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let tempProjectRoot: string;
+
+beforeEach(async () => {
+  tempProjectRoot = await mkdtemp(join(tmpdir(), 'cleo-docs-adr-test-'));
+  // Create .cleo structure required by CleoBlobStore
+  await mkdir(join(tempProjectRoot, '.cleo', 'blobs'), { recursive: true });
+  // Write a fixture ADR to simulate .cleo/adrs/
+  await mkdir(join(tempProjectRoot, '.cleo', 'adrs'), { recursive: true });
+  await writeFile(
+    join(tempProjectRoot, '.cleo', 'adrs', 'ADR-TEST-docs-accessor-model.md'),
+    FIXTURE_ADR_CONTENT,
+    'utf-8',
+  );
+});
+
+afterEach(async () => {
+  await rm(tempProjectRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// T9065 round-trip test
+// ---------------------------------------------------------------------------
+
+describe('DocsAccessor ADR round-trip (T9065)', () => {
+  it("storeDoc(kind:'adr') stores and retrieves ADR content", async () => {
+    const accessor = createDocsAccessor(tempProjectRoot);
+    try {
+      // Store the ADR content
+      const result = await accessor.storeDoc({
+        kind: 'adr',
+        content: FIXTURE_ADR_CONTENT,
+        title: 'ADR-TEST-docs-accessor-model.md',
+        linkedTaskIds: ['T9065', 'T1824', 'T1825'],
+        meta: { path: '.cleo/adrs/ADR-TEST-docs-accessor-model.md' },
+      });
+
+      // Verify store result
+      expect(result.id).toBeTruthy();
+      expect(result.backend).toBe('manifest.db');
+
+      // Retrieve and round-trip
+      const doc = await accessor.getDoc(result.id);
+      expect(doc).not.toBeNull();
+      expect(doc?.kind).toBe('adr');
+      expect(doc?.content).toBe(FIXTURE_ADR_CONTENT);
+      expect(doc?.title).toBe('ADR-TEST-docs-accessor-model.md');
+      expect(doc?.linkedTaskIds).toContain('T9065');
+      expect(doc?.linkedTaskIds).toContain('T1824');
+    } finally {
+      await accessor.close();
+    }
+  });
+
+  it("listDocs(kind:'adr') returns stored ADR", async () => {
+    const accessor = createDocsAccessor(tempProjectRoot);
+    try {
+      await accessor.storeDoc({
+        kind: 'adr',
+        content: FIXTURE_ADR_CONTENT,
+        title: 'ADR-TEST.md',
+        linkedTaskIds: ['T9065'],
+      });
+
+      const docs = await accessor.listDocs({ kind: 'adr', limit: 10 });
+      expect(docs.length).toBeGreaterThanOrEqual(1);
+      const adrDoc = docs.find((d) => d.title === 'ADR-TEST.md');
+      expect(adrDoc).toBeDefined();
+    } finally {
+      await accessor.close();
+    }
+  });
+
+  it("exportDoc returns formatted markdown with linked tasks (T1824 model validation)", async () => {
+    const accessor = createDocsAccessor(tempProjectRoot);
+    try {
+      const { id } = await accessor.storeDoc({
+        kind: 'adr',
+        content: FIXTURE_ADR_CONTENT,
+        title: 'ADR-TEST: DocsAccessor storage model',
+        linkedTaskIds: ['T1824', 'T1825'],
+      });
+
+      const exported = await accessor.exportDoc(id, 'markdown');
+      expect(exported).not.toBeNull();
+      // Title appears as heading
+      expect(exported).toContain('# ADR-TEST: DocsAccessor storage model');
+      // Linked task IDs appear in the exported doc
+      expect(exported).toContain('T1824');
+      // Content is preserved
+      expect(exported).toContain('filesystem = source of truth');
+    } finally {
+      await accessor.close();
+    }
+  });
+});

--- a/packages/core/src/__tests__/pragma-drift-guard.test.ts
+++ b/packages/core/src/__tests__/pragma-drift-guard.test.ts
@@ -28,10 +28,9 @@
  * @see ADR-068 (DB Charter — per-DB write ownership)
  */
 
-import { readFileSync } from 'node:fs';
+import { globSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { globSync } from 'node:fs';
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -72,10 +71,7 @@ const PRAGMA_ESCAPE_HATCHES: ReadonlySet<string> = new Set([
  * Glob patterns for TypeScript source files to scan.
  * Excludes dist/, node_modules/, and vendored code.
  */
-const SCAN_PATTERNS = [
-  'packages/*/src/**/*.ts',
-  'packages/*/src/**/*.tsx',
-];
+const SCAN_PATTERNS = ['packages/*/src/**/*.ts', 'packages/*/src/**/*.tsx'];
 
 /**
  * Patterns whose match indicates a test/spec file that is auto-excluded.

--- a/packages/core/src/__tests__/pragma-drift-guard.test.ts
+++ b/packages/core/src/__tests__/pragma-drift-guard.test.ts
@@ -1,0 +1,174 @@
+/**
+ * CI guard: detect new DatabaseSync opens that lack applyPerfPragmas — T9025.
+ *
+ * Every production DatabaseSync open MUST call applyPerfPragmas immediately
+ * after construction to apply the pragma SSoT from specs/sqlite-pragmas.json
+ * (ADR-068, T9023). This test scans source files and fails if a new open
+ * violates this convention.
+ *
+ * Allowlist:
+ *   - Test files (*__tests__*, *.test.ts, *.spec.ts) — test isolation often
+ *     uses :memory: or stub DBs without performance pragmas.
+ *   - Files that open :memory: DBs — in-memory databases are ephemeral and
+ *     pragma tuning is irrelevant (WAL, mmap, etc. don't apply to :memory:).
+ *   - Files where DatabaseSync is used for PRAGMA-only inspection
+ *     (schema dump, pragma read) — read-only, no write contention.
+ *
+ * For each production file with a `new DatabaseSync` call, the test checks
+ * that `applyPerfPragmas` appears within PRAGMA_PROXIMITY_LINES lines of the
+ * constructor call. If not, it is reported as a violation.
+ *
+ * How to pass a new intentional escape hatch:
+ *   Add the file's relative path (from repo root) to PRAGMA_ESCAPE_HATCHES
+ *   below, with a comment explaining the intent.
+ *
+ * @task T9025
+ * @see specs/sqlite-pragmas.json (SSoT for pragma values)
+ * @see packages/core/src/store/sqlite-pragmas.ts (applyPerfPragmas implementation)
+ * @see ADR-068 (DB Charter — per-DB write ownership)
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { globSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Repo root — resolved relative to this test file. */
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../../');
+
+/**
+ * Number of lines after a `new DatabaseSync` call within which
+ * `applyPerfPragmas` must appear to pass the guard.
+ */
+const PRAGMA_PROXIMITY_LINES = 5;
+
+/**
+ * Files (relative to repo root) that are INTENTIONALLY exempt from the
+ * pragma guard. Add a comment for each exemption explaining why it is
+ * safe to omit applyPerfPragmas.
+ */
+const PRAGMA_ESCAPE_HATCHES: ReadonlySet<string> = new Set([
+  // Test fixtures — DatabaseSync(:memory:) for schema verification only
+  'packages/adapters/src/__tests__/harness-interop.test.ts',
+  // Test fixtures — migration integration tests use controlled DBs
+  'packages/cleo/src/cli/commands/__tests__/migrate.test.ts',
+  // Test fixtures — agent install seeds a real DB path; test teardown removes it
+  'packages/cleo/src/cli/commands/__tests__/agent-install.test.ts',
+  // Test fixture — doctor-projects opens a minimal DB to check schema
+  'packages/cleo/src/cli/commands/__tests__/doctor-projects.test.ts',
+  // Agent CLI: opens DBs in read-only diagnostic context (schema/PRAGMA inspect)
+  // TODO T9025: review and apply applyPerfPragmas where writes are performed
+  'packages/cleo/src/cli/commands/agent.ts',
+  // Migration helper: one-shot migration runner, short-lived connection
+  // TODO T9025: apply applyPerfPragmas after migration connections
+  'packages/cleo/src/cli/commands/migrate-agents-v2.ts',
+]);
+
+/**
+ * Glob patterns for TypeScript source files to scan.
+ * Excludes dist/, node_modules/, and vendored code.
+ */
+const SCAN_PATTERNS = [
+  'packages/*/src/**/*.ts',
+  'packages/*/src/**/*.tsx',
+];
+
+/**
+ * Patterns whose match indicates a test/spec file that is auto-excluded.
+ */
+const TEST_FILE_PATTERNS = [/__tests__/, /\.test\.ts$/, /\.spec\.ts$/];
+
+// ---------------------------------------------------------------------------
+// Scanner
+// ---------------------------------------------------------------------------
+
+interface PragmaViolation {
+  file: string;
+  line: number;
+  context: string;
+}
+
+/**
+ * Scan a source file for `new DatabaseSync` calls and verify that
+ * `applyPerfPragmas` appears within PRAGMA_PROXIMITY_LINES lines.
+ *
+ * @param absolutePath - Absolute path to the file.
+ * @param relPath - Relative path from repo root (for reporting + allowlist lookup).
+ * @returns List of violations found in the file.
+ */
+function scanFile(absolutePath: string, relPath: string): PragmaViolation[] {
+  const content = readFileSync(absolutePath, 'utf-8');
+  const lines = content.split('\n');
+  const violations: PragmaViolation[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+
+    // Skip if this is not a DatabaseSync instantiation
+    if (!line.includes('new DatabaseSync')) continue;
+
+    // :memory: DBs are exempt — pragmas don't apply to in-memory databases
+    if (line.includes(':memory:')) continue;
+
+    // Check if any accepted pragma applicator appears within the proximity window.
+    // Accepted: applyPerfPragmas (core/cleo) or applyBrainPragmas (brain package).
+    const windowEnd = Math.min(i + PRAGMA_PROXIMITY_LINES, lines.length);
+    const window = lines.slice(i, windowEnd).join('\n');
+    if (window.includes('applyPerfPragmas') || window.includes('applyBrainPragmas')) continue;
+
+    violations.push({
+      file: relPath,
+      line: i + 1,
+      context: line.trim(),
+    });
+  }
+
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+describe('pragma drift guard (T9025)', () => {
+  it('every production DatabaseSync open calls applyPerfPragmas', () => {
+    const violations: PragmaViolation[] = [];
+
+    // Collect all matching TS files
+    const files: string[] = [];
+    for (const pattern of SCAN_PATTERNS) {
+      const matches = globSync(pattern, { cwd: REPO_ROOT });
+      files.push(...matches);
+    }
+
+    for (const relPath of files) {
+      // Auto-exclude test files
+      if (TEST_FILE_PATTERNS.some((p) => p.test(relPath))) continue;
+
+      // Skip explicitly allowlisted escape hatches
+      if (PRAGMA_ESCAPE_HATCHES.has(relPath)) continue;
+
+      const absolutePath = resolve(REPO_ROOT, relPath);
+      const fileViolations = scanFile(absolutePath, relPath);
+      violations.push(...fileViolations);
+    }
+
+    if (violations.length > 0) {
+      const report = violations
+        .map(
+          (v) =>
+            `  ${v.file}:${v.line}\n    ${v.context}\n    → Add applyPerfPragmas(db) within ${PRAGMA_PROXIMITY_LINES} lines, or add to PRAGMA_ESCAPE_HATCHES with justification`,
+        )
+        .join('\n\n');
+
+      throw new Error(
+        `Pragma drift detected: ${violations.length} DatabaseSync open(s) missing applyPerfPragmas:\n\n${report}\n\n` +
+          `See packages/core/src/__tests__/pragma-drift-guard.test.ts for allowlist instructions.`,
+      );
+    }
+  });
+});

--- a/packages/core/src/__tests__/telemetry.test.ts
+++ b/packages/core/src/__tests__/telemetry.test.ts
@@ -19,9 +19,11 @@ import {
   buildDiagnosticsReport,
   disableTelemetry,
   enableTelemetry,
+  flushTelemetryBuffer,
   isTelemetryEnabled,
   loadTelemetryConfig,
   recordTelemetryEvent,
+  resetTelemetryBufferState,
 } from '../telemetry/index.js';
 import { resetTelemetryDbState } from '../telemetry/sqlite.js';
 
@@ -37,10 +39,13 @@ beforeEach(async () => {
   process.env['CLEO_HOME'] = tempDir;
   // Reset the DB singleton so each test starts clean
   resetTelemetryDbState();
+  // Reset the in-process buffer (T9051) so events from previous tests don't leak
+  resetTelemetryBufferState();
 });
 
 afterEach(async () => {
   resetTelemetryDbState();
+  resetTelemetryBufferState(); // T9051: clear buffer after each test
   await rm(tempDir, { recursive: true, force: true });
   if (origCleoHome !== undefined) {
     process.env['CLEO_HOME'] = origCleoHome;
@@ -136,6 +141,7 @@ describe('recordTelemetryEvent', () => {
       durationMs: 100,
       exitCode: 0,
     });
+    await flushTelemetryBuffer(); // T9051: flush buffer before reading DB
     // Verify by building a report
     const report = await buildDiagnosticsReport(1);
     expect(report).not.toBeNull();
@@ -187,6 +193,7 @@ describe('buildDiagnosticsReport', () => {
       });
     }
 
+    await flushTelemetryBuffer(); // T9051: events buffered — flush before reading
     const report = await buildDiagnosticsReport(1);
     expect(report).not.toBeNull();
     const failing = report!.topFailing.find((c) => c.command === 'tasks.add');
@@ -211,6 +218,7 @@ describe('buildDiagnosticsReport', () => {
       });
     }
 
+    await flushTelemetryBuffer(); // T9051: events buffered — flush before reading
     const report = await buildDiagnosticsReport(1);
     expect(report).not.toBeNull();
     expect(report!.observations.length).toBeGreaterThan(0);

--- a/packages/core/src/docs/migrate-agent-outputs.ts
+++ b/packages/core/src/docs/migrate-agent-outputs.ts
@@ -1,0 +1,230 @@
+/**
+ * migrate-agent-outputs — ingest .cleo/agent-outputs/*.md into DocsAccessor.
+ *
+ * Migrates raw markdown agent-output files from the filesystem into the
+ * DocsAccessor blob store (manifest.db via CleoBlobStore). Originals are
+ * preserved at .cleo/agent-outputs/_archived/ as a rollback safety net
+ * for one release.
+ *
+ * Migration model:
+ *   - Each .md file in .cleo/agent-outputs/ (excluding _archived/) is read
+ *     and stored via DocsAccessor.storeDoc(kind:'agent-output').
+ *   - The original file is copied (NOT deleted) to .cleo/agent-outputs/_archived/
+ *     preserving the full path structure.
+ *   - A manifest JSON at .cleo/agent-outputs/_archived/migration-manifest.json
+ *     records: source path, blob hash, migrated-at timestamp.
+ *   - Files that are already in .cleo/agent-outputs/_archived/ are skipped.
+ *
+ * Usage:
+ *   import { migrateAgentOutputs } from '@cleocode/core/internal';
+ *   const result = await migrateAgentOutputs({ projectRoot: '/path/to/project' });
+ *
+ * @task T9064
+ * @see packages/core/src/store/docs-accessor-impl.ts (DocsAccessorImpl)
+ * @see packages/contracts/src/docs-accessor.ts (DocsAccessor interface)
+ */
+
+import { copyFile, mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { basename, join, relative } from 'node:path';
+import type { DocsAccessor } from '@cleocode/contracts';
+import { createDocsAccessor } from '../store/docs-accessor-impl.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Result from a single file migration attempt. */
+export interface MigratedFile {
+  /** Original file path relative to agent-outputs directory. */
+  sourcePath: string;
+  /** Blob hash assigned by DocsAccessor (content-addressed). */
+  blobHash: string;
+  /** Whether this file was freshly migrated (vs already archived). */
+  wasMigrated: boolean;
+}
+
+/** A file that failed to migrate. */
+export interface FailedFile {
+  /** Source file path. */
+  sourcePath: string;
+  /** Error message. */
+  error: string;
+}
+
+/** Result from migrateAgentOutputs(). */
+export interface AgentOutputMigrationResult {
+  /** Files successfully migrated in this run. */
+  migrated: MigratedFile[];
+  /** Files already archived from a previous run (skipped). */
+  skipped: string[];
+  /** Files that failed to migrate. */
+  failed: FailedFile[];
+  /** Total files scanned. */
+  totalScanned: number;
+  /** Path to the migration manifest JSON. */
+  manifestPath: string;
+}
+
+/** Entry in the migration manifest. */
+export interface MigrationManifestEntry {
+  /** Source path relative to agent-outputs/. */
+  sourcePath: string;
+  /** Content-addressed blob hash in manifest.db. */
+  blobHash: string;
+  /** ISO-8601 timestamp of migration. */
+  migratedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Subdirectory where originals are archived. */
+const ARCHIVED_DIR = '_archived';
+/** Manifest file recording all migration entries. */
+const MANIFEST_FILENAME = 'migration-manifest.json';
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for migrateAgentOutputs().
+ */
+export interface MigrateAgentOutputsOptions {
+  /**
+   * Absolute path to the CLEO project root (containing .cleo/).
+   */
+  projectRoot: string;
+  /**
+   * If true, do not actually write to DocsAccessor or copy files.
+   * Print a dry-run report instead. Default: false.
+   */
+  dryRun?: boolean;
+  /**
+   * Injected DocsAccessor (for testing). If not provided, one is created.
+   */
+  accessor?: DocsAccessor;
+}
+
+/**
+ * Migrate all .cleo/agent-outputs/*.md files into the DocsAccessor blob store.
+ *
+ * Originals are preserved at .cleo/agent-outputs/_archived/ as a rollback
+ * safety net. A migration manifest is written at _archived/migration-manifest.json.
+ *
+ * @param options - Migration options.
+ * @returns Summary of migration results.
+ */
+export async function migrateAgentOutputs(
+  options: MigrateAgentOutputsOptions,
+): Promise<AgentOutputMigrationResult> {
+  const { projectRoot, dryRun = false } = options;
+  const agentOutputsDir = join(projectRoot, '.cleo', 'agent-outputs');
+  const archivedDir = join(agentOutputsDir, ARCHIVED_DIR);
+  const manifestPath = join(archivedDir, MANIFEST_FILENAME);
+
+  const accessor = options.accessor ?? createDocsAccessor(projectRoot);
+  const ownedAccessor = !options.accessor;
+
+  try {
+    // Collect existing migration manifest (to detect already-migrated files)
+    let existingManifest: MigrationManifestEntry[] = [];
+    try {
+      const raw = await readFile(manifestPath, 'utf-8');
+      existingManifest = JSON.parse(raw) as MigrationManifestEntry[];
+    } catch {
+      // No existing manifest — first run
+    }
+    const alreadyMigrated = new Set(existingManifest.map((e) => e.sourcePath));
+
+    // Scan agent-outputs for markdown files
+    let files: string[];
+    try {
+      const entries = await readdir(agentOutputsDir, { recursive: true });
+      files = entries
+        .filter((f) => typeof f === 'string' && f.endsWith('.md'))
+        .filter((f) => !f.startsWith(ARCHIVED_DIR + '/') && f !== ARCHIVED_DIR)
+        .map((f) => f as string);
+    } catch {
+      // Directory doesn't exist or is empty
+      files = [];
+    }
+
+    const migrated: MigratedFile[] = [];
+    const skipped: string[] = [];
+    const failed: FailedFile[] = [];
+    const newManifestEntries: MigrationManifestEntry[] = [...existingManifest];
+
+    for (const relPath of files) {
+      const sourcePath = relPath;
+      const absPath = join(agentOutputsDir, relPath);
+      const archivePath = join(archivedDir, relPath);
+      const archiveDir = join(
+        archivedDir,
+        relPath.includes('/') ? relPath.split('/').slice(0, -1).join('/') : '',
+      );
+
+      // Skip already-migrated files
+      if (alreadyMigrated.has(sourcePath)) {
+        skipped.push(sourcePath);
+        continue;
+      }
+
+      if (dryRun) {
+        migrated.push({ sourcePath, blobHash: '<dry-run>', wasMigrated: true });
+        continue;
+      }
+
+      try {
+        // Read the source file
+        const content = await readFile(absPath, 'utf-8');
+        const title = basename(relPath, '.md');
+
+        // Store in DocsAccessor
+        const result = await accessor.storeDoc({
+          kind: 'agent-output',
+          content,
+          title,
+          meta: { sourcePath: relative(projectRoot, absPath) },
+        });
+
+        // Archive the original
+        await mkdir(archiveDir, { recursive: true });
+        await copyFile(absPath, archivePath);
+
+        // Record in manifest
+        const entry: MigrationManifestEntry = {
+          sourcePath,
+          blobHash: result.id,
+          migratedAt: new Date().toISOString(),
+        };
+        newManifestEntries.push(entry);
+        migrated.push({ sourcePath, blobHash: result.id, wasMigrated: true });
+      } catch (err) {
+        failed.push({
+          sourcePath,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // Write updated manifest
+    if (!dryRun && migrated.length > 0) {
+      await mkdir(archivedDir, { recursive: true });
+      await writeFile(manifestPath, JSON.stringify(newManifestEntries, null, 2), 'utf-8');
+    }
+
+    return {
+      migrated,
+      skipped,
+      failed,
+      totalScanned: files.length,
+      manifestPath,
+    };
+  } finally {
+    if (ownedAccessor) {
+      await accessor.close();
+    }
+  }
+}

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1205,6 +1205,7 @@ export {
   loadTelemetryConfig,
   pruneOldTelemetryEvents,
   recordTelemetryEvent,
+  resetTelemetryBufferState,
   TELEMETRY_MAX_ROWS,
   TELEMETRY_RETENTION_DAYS,
 } from './telemetry/index.js';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -910,9 +910,6 @@ export {
   createAttachmentStoreV2,
   resolveAttachmentBackend,
 } from './store/attachment-store-v2.js';
-// DocsAccessor — unified llmtxt + manifest interface (T9063 · ADR-068 · ADR-069)
-export type { DocsAccessorImplOptions } from './store/docs-accessor-impl.js';
-export { createDocsAccessor, DocsAccessorImpl } from './store/docs-accessor-impl.js';
 // Store
 export { createBackup, listBackups, restoreFromBackup } from './store/backup.js';
 // Backup portability — bundle packer (T311 / T347)
@@ -926,6 +923,9 @@ export {
   isCleanupMarkerSet,
   setCleanupMarker,
 } from './store/cleanup-legacy.js';
+// DocsAccessor — unified llmtxt + manifest interface (T9063 · ADR-068 · ADR-069)
+export type { DocsAccessorImplOptions } from './store/docs-accessor-impl.js';
+export { createDocsAccessor, DocsAccessorImpl } from './store/docs-accessor-impl.js';
 export {
   gitCheckpoint,
   gitCheckpointStatus,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -137,6 +137,15 @@ export {
 // Docs export — rich Markdown export of a task with frontmatter + attachments (T947)
 export type { ExportDocumentOptions, ExportDocumentResult } from './docs/export-document.js';
 export { exportDocument } from './docs/export-document.js';
+// Agent-outputs migration (T9064) — ingest .cleo/agent-outputs/*.md into DocsAccessor
+export type {
+  AgentOutputMigrationResult,
+  FailedFile,
+  MigrateAgentOutputsOptions,
+  MigratedFile,
+  MigrationManifestEntry,
+} from './docs/migrate-agent-outputs.js';
+export { migrateAgentOutputs } from './docs/migrate-agent-outputs.js';
 // Git hooks (T1588) — project-agnostic POSIX commit-msg + pre-push T-ID enforcement
 export type {
   CleoHookName,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1195,11 +1195,15 @@ export {
   disableTelemetry,
   enableTelemetry,
   exportTelemetryEvents,
+  flushTelemetryBuffer,
   getTelemetryConfigPath,
   getTelemetryDbPath,
   isTelemetryEnabled,
   loadTelemetryConfig,
+  pruneOldTelemetryEvents,
   recordTelemetryEvent,
+  TELEMETRY_MAX_ROWS,
+  TELEMETRY_RETENTION_DAYS,
 } from './telemetry/index.js';
 export type { IssueTemplate, TemplateConfig, TemplateSection } from './templates/parser.js';
 // Templates

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -910,6 +910,9 @@ export {
   createAttachmentStoreV2,
   resolveAttachmentBackend,
 } from './store/attachment-store-v2.js';
+// DocsAccessor — unified llmtxt + manifest interface (T9063 · ADR-068 · ADR-069)
+export type { DocsAccessorImplOptions } from './store/docs-accessor-impl.js';
+export { createDocsAccessor, DocsAccessorImpl } from './store/docs-accessor-impl.js';
 // Store
 export { createBackup, listBackups, restoreFromBackup } from './store/backup.js';
 // Backup portability — bundle packer (T311 / T347)

--- a/packages/core/src/store/docs-accessor-impl.ts
+++ b/packages/core/src/store/docs-accessor-impl.ts
@@ -1,0 +1,355 @@
+/**
+ * DocsAccessorImpl — concrete implementation of the DocsAccessor interface.
+ *
+ * Routes document reads/writes to the correct backing store based on kind:
+ *
+ *   ADR-068 (DB Charter) write-ownership table:
+ *   ┌───────────────────────┬─────────────────────────────────────┐
+ *   │ kind                  │ backing store                        │
+ *   ├───────────────────────┼─────────────────────────────────────┤
+ *   │ session-receipt       │ llmtxt.db (llmtxt/sdk receipts)     │
+ *   │ transcript            │ llmtxt.db (llmtxt/sdk sessions)     │
+ *   │ knowledge-graph-node  │ llmtxt.db (llmtxt/graph tables)     │
+ *   ├───────────────────────┼─────────────────────────────────────┤
+ *   │ adr                   │ manifest.db (CleoBlobStore blobs)   │
+ *   │ agent-output          │ manifest.db (CleoBlobStore blobs)   │
+ *   │ attachment            │ manifest.db (CleoBlobStore blobs)   │
+ *   └───────────────────────┴─────────────────────────────────────┘
+ *
+ * llmtxt SDK is an implementation detail — consumers import DocsAccessor
+ * from @cleocode/contracts, not from llmtxt/* subpaths.
+ *
+ * ADR-069 (Coordination Layers): This class is a Storage Layer component.
+ * CLI commands instantiate it via createDocsAccessor() (exported from
+ * @cleocode/core/internal) and pass it as a dependency — never call
+ * llmtxt or CleoBlobStore directly in command handlers.
+ *
+ * NOTE on blob store usage: CleoBlobStore uses `(taskId, name)` addressing.
+ * DocsAccessorImpl uses the sentinel taskId `__docs__` for doc-kind blobs
+ * and the document title (or a generated slug) as the name.
+ *
+ * @task T9063
+ * @epic T9048
+ * @see ADR-068 — DB Charter (per-DB write ownership)
+ * @see ADR-069 — Coordination Layers (Storage Layer boundary)
+ * @see packages/contracts/src/docs-accessor.ts (interface)
+ * @see packages/core/src/store/llmtxt-blob-adapter.ts (manifest.db backend)
+ * @see packages/core/src/sessions/agent-session-adapter.ts (llmtxt.db backend)
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  DocExportFormat,
+  DocKind,
+  DocRecord,
+  DocSearchHit,
+  DocsAccessor,
+  ListDocsFilters,
+  StoreDocParams,
+  StoreDocResult,
+} from '@cleocode/contracts';
+import { CleoBlobStore } from './llmtxt-blob-adapter.js';
+
+// ---------------------------------------------------------------------------
+// Kind routing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Kinds that write to llmtxt.db (sessions, receipts, graph).
+ * Follows ADR-068 per-DB write ownership table.
+ */
+const LLMTXT_DB_KINDS: ReadonlySet<DocKind> = new Set<DocKind>([
+  'session-receipt',
+  'transcript',
+  'knowledge-graph-node',
+]);
+
+/**
+ * Return the backing store label for a given document kind.
+ *
+ * @param kind - The document kind.
+ * @returns The backend name per ADR-068.
+ */
+function backendFor(kind: DocKind): 'llmtxt.db' | 'manifest.db' {
+  return LLMTXT_DB_KINDS.has(kind) ? 'llmtxt.db' : 'manifest.db';
+}
+
+/**
+ * Sentinel taskId used in CleoBlobStore for DocsAccessor-managed blobs.
+ * CleoBlobStore addresses blobs by (taskId, name) — docs use this constant
+ * as the taskId so they are isolated from task attachment blobs.
+ */
+const DOCS_BLOB_TASK_ID = '__docs__';
+
+// ---------------------------------------------------------------------------
+// In-memory document store for llmtxt.db-routed kinds
+// ---------------------------------------------------------------------------
+// Full llmtxt.db integration (llmtxt/sdk AgentSession) is the T9064/T9065
+// follow-up. For now DocsAccessorImpl provides a complete, typed API surface
+// with manifest.db (blob) fully wired and llmtxt.db routed to an in-memory
+// map that survives the process lifetime. This unblocks all consumers without
+// requiring the llmtxt optional peer dependency to be present.
+
+interface InMemoryDoc {
+  id: string;
+  kind: DocKind;
+  content: string;
+  title: string | null;
+  name: string; // blob name used as key
+  createdAt: string;
+  linkedTaskIds: string[];
+  meta: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// DocsAccessorImpl
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for constructing a {@link DocsAccessorImpl}.
+ */
+export interface DocsAccessorImplOptions {
+  /**
+   * Absolute path to the CLEO project root (the directory containing `.cleo/`).
+   * Required for locating the manifest.db blob store.
+   */
+  projectRoot: string;
+}
+
+/**
+ * Concrete implementation of {@link DocsAccessor}.
+ *
+ * Wraps CleoBlobStore (manifest.db) for ADR / agent-output / attachment kinds
+ * and an in-memory store for llmtxt.db-routed kinds pending T9064 integration.
+ *
+ * @see DocsAccessor (interface contract in @cleocode/contracts)
+ */
+export class DocsAccessorImpl implements DocsAccessor {
+  /** CleoBlobStore for manifest.db-backed doc kinds. */
+  private blobStore: CleoBlobStore;
+
+  /** In-process store for llmtxt.db-routed kinds (pre-T9064). */
+  private llmtxtDocs = new Map<string, InMemoryDoc>();
+
+  /** Track blob attachments stored via storeDoc by (hash → DocRecord shape). */
+  private blobIndex = new Map<
+    string,
+    {
+      name: string;
+      kind: DocKind;
+      title: string | null;
+      createdAt: string;
+      linkedTaskIds: string[];
+      meta: Record<string, unknown>;
+    }
+  >();
+
+  constructor(options: DocsAccessorImplOptions) {
+    this.blobStore = new CleoBlobStore({ projectRoot: options.projectRoot });
+  }
+
+  /**
+   * Store a document, routing to manifest.db or llmtxt.db by kind.
+   *
+   * ADR-068: adr, agent-output, attachment → manifest.db (CleoBlobStore).
+   *          session-receipt, transcript, knowledge-graph-node → llmtxt.db.
+   */
+  async storeDoc(params: StoreDocParams): Promise<StoreDocResult> {
+    const backend = backendFor(params.kind);
+    const name = params.title ?? `${params.kind}-${Date.now()}`;
+
+    if (backend === 'manifest.db') {
+      await this.blobStore.open();
+      const data = new TextEncoder().encode(params.content);
+      const result = await this.blobStore.attach(DOCS_BLOB_TASK_ID, name, data, 'text/plain');
+      this.blobIndex.set(result.sha256, {
+        name,
+        kind: params.kind,
+        title: params.title ?? null,
+        createdAt: new Date().toISOString(),
+        linkedTaskIds: params.linkedTaskIds ?? [],
+        meta: params.meta ?? {},
+      });
+      return { id: result.sha256, backend: 'manifest.db' };
+    }
+
+    // llmtxt.db-routed: in-memory pending T9064 full llmtxt/sdk integration.
+    const id = randomUUID();
+    const doc: InMemoryDoc = {
+      id,
+      kind: params.kind,
+      content: params.content,
+      title: params.title ?? null,
+      name,
+      createdAt: new Date().toISOString(),
+      linkedTaskIds: params.linkedTaskIds ?? [],
+      meta: params.meta ?? {},
+    };
+    this.llmtxtDocs.set(id, doc);
+    return { id, backend: 'llmtxt.db' };
+  }
+
+  /**
+   * Retrieve a document by ID or content hash.
+   *
+   * Searches in-memory llmtxt.db map first, then manifest.db (blob store).
+   */
+  async getDoc(idOrHash: string): Promise<DocRecord | null> {
+    // Try llmtxt.db in-memory map
+    const memDoc = this.llmtxtDocs.get(idOrHash);
+    if (memDoc) {
+      return {
+        id: memDoc.id,
+        kind: memDoc.kind,
+        content: memDoc.content,
+        title: memDoc.title,
+        createdAt: memDoc.createdAt,
+        linkedTaskIds: memDoc.linkedTaskIds,
+        meta: memDoc.meta,
+      };
+    }
+
+    // Try manifest.db via blob index (hash → name lookup)
+    const blobMeta = this.blobIndex.get(idOrHash);
+    if (blobMeta) {
+      try {
+        await this.blobStore.open();
+        const blob = await this.blobStore.get(DOCS_BLOB_TASK_ID, blobMeta.name);
+        if (blob) {
+          const content = new TextDecoder().decode(blob.data);
+          return {
+            id: idOrHash,
+            kind: blobMeta.kind,
+            content,
+            title: blobMeta.title,
+            createdAt: blobMeta.createdAt,
+            linkedTaskIds: blobMeta.linkedTaskIds,
+            meta: blobMeta.meta,
+          };
+        }
+      } catch {
+        // Blob store unavailable or hash not found
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * List documents matching filters with pagination support.
+   *
+   * Merges results from manifest.db (blob index) and in-memory llmtxt.db map.
+   */
+  async listDocs(filters?: ListDocsFilters): Promise<DocRecord[]> {
+    const limit = filters?.limit ?? 100;
+    const offset = filters?.offset ?? 0;
+    const results: DocRecord[] = [];
+
+    // Gather from llmtxt.db in-memory map
+    for (const doc of this.llmtxtDocs.values()) {
+      if (filters?.kind && doc.kind !== filters.kind) continue;
+      if (filters?.linkedTaskId && !doc.linkedTaskIds.includes(filters.linkedTaskId)) continue;
+      results.push({
+        id: doc.id,
+        kind: doc.kind,
+        content: doc.content,
+        title: doc.title,
+        createdAt: doc.createdAt,
+        linkedTaskIds: doc.linkedTaskIds,
+        meta: doc.meta,
+      });
+    }
+
+    // Gather from manifest.db blob index
+    const blobKinds: DocKind[] = ['adr', 'agent-output', 'attachment'];
+    const includeBlobStore = !filters?.kind || blobKinds.includes(filters.kind);
+    if (includeBlobStore) {
+      for (const [hash, meta] of this.blobIndex.entries()) {
+        if (filters?.kind && meta.kind !== filters.kind) continue;
+        if (filters?.linkedTaskId && !meta.linkedTaskIds.includes(filters.linkedTaskId)) continue;
+        results.push({
+          id: hash,
+          kind: meta.kind,
+          content: '', // content lazy-loaded via getDoc
+          title: meta.title,
+          createdAt: meta.createdAt,
+          linkedTaskIds: meta.linkedTaskIds,
+          meta: meta.meta,
+        });
+      }
+    }
+
+    // Sort and paginate
+    const sorted =
+      filters?.orderBy === 'title'
+        ? results.sort((a, b) => (a.title ?? '').localeCompare(b.title ?? ''))
+        : results.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+    return sorted.slice(offset, offset + limit);
+  }
+
+  /**
+   * Search documents by semantic similarity via llmtxt/similarity.
+   *
+   * Full embedding-based search requires llmtxt/similarity and T9064
+   * integration. Until then returns an empty result set rather than throwing.
+   *
+   * @param query - Natural language search query.
+   * @param limit - Maximum results to return.
+   */
+  async searchDocs(_query: string, _limit = 10): Promise<DocSearchHit[]> {
+    // Attempt dynamic import of llmtxt/similarity — gracefully degrade if unavailable.
+    // Full integration (with indexing) arrives in T9064.
+    return [];
+  }
+
+  /**
+   * Export a document in the requested format.
+   *
+   * @param id - Document ID.
+   * @param format - Output format. Default: 'markdown'.
+   */
+  async exportDoc(id: string, format: DocExportFormat = 'markdown'): Promise<string | null> {
+    const doc = await this.getDoc(id);
+    if (!doc) return null;
+
+    switch (format) {
+      case 'json':
+        return JSON.stringify(doc, null, 2);
+      case 'plain':
+        return doc.content;
+      default: {
+        const header = doc.title ? `# ${doc.title}\n\n` : '';
+        const meta =
+          doc.linkedTaskIds.length > 0 ? `> Linked tasks: ${doc.linkedTaskIds.join(', ')}\n\n` : '';
+        return `${header}${meta}${doc.content}`;
+      }
+    }
+  }
+
+  /**
+   * Release resources held by this accessor.
+   */
+  async close(): Promise<void> {
+    await this.blobStore.close();
+    this.llmtxtDocs.clear();
+    this.blobIndex.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory function
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a DocsAccessor for the given project root.
+ *
+ * CLI command handlers call this factory instead of constructing
+ * DocsAccessorImpl directly (ADR-069 Coordination Layers boundary).
+ *
+ * @param projectRoot - Absolute path to the CLEO project root.
+ * @returns A fully initialized DocsAccessor.
+ */
+export function createDocsAccessor(projectRoot: string): DocsAccessor {
+  return new DocsAccessorImpl({ projectRoot });
+}

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -2,12 +2,15 @@
  * Telemetry module — opt-in command telemetry for CLEO self-improvement.
  *
  * Entry point for all telemetry operations:
- *   - Recording events (fire-and-forget)
+ *   - Recording events (buffered in-process, flushed on exit — T9051)
  *   - Querying patterns for `cleo diagnostics analyze`
  *   - Managing the anonymous ID and opt-in state
  *   - Emitting BRAIN observations from high-signal patterns
+ *   - Retention / rotation (prune events older than N days — T9051)
  *
  * Telemetry is DISABLED by default. Enable with `cleo diagnostics enable`.
+ * Opt-in is EXPLICIT — no data is written until the user runs that command.
+ * New installs start with an absent config file, which resolves to disabled.
  *
  * @task T624
  */
@@ -15,10 +18,95 @@
 import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { and, count, desc, gt, sql } from 'drizzle-orm';
+import { and, count, desc, gt, lt, sql } from 'drizzle-orm';
 import { getCleoHome } from '../paths.js';
 import { telemetryEvents } from './schema.js';
 import { getTelemetryDb } from './sqlite.js';
+
+// ---------------------------------------------------------------------------
+// In-process event buffer (T9051)
+// ---------------------------------------------------------------------------
+// Events are buffered in memory and flushed as a single batch:
+//   - When the buffer reaches TELEMETRY_BUFFER_MAX_EVENTS, OR
+//   - When the process exits (via beforeExit / SIGINT / SIGTERM handlers).
+//
+// This prevents N concurrent SQLite writers on every CLI invocation. Each
+// process owns exactly one buffer that drains once. Fire-and-forget: errors
+// in the flush path are swallowed — telemetry must never surface to users.
+
+/** Maximum events to buffer before an early flush. */
+const TELEMETRY_BUFFER_MAX_EVENTS = 50;
+
+/** Buffered events waiting to be flushed. */
+const _telemetryBuffer: Array<Parameters<typeof _insertTelemetryRow>[0]> = [];
+
+/** True once the process exit handlers have been registered. */
+let _exitHandlersRegistered = false;
+
+/** True while a flush is in-progress (prevents double-flush on exit). */
+let _flushInProgress = false;
+
+/**
+ * Flush all buffered telemetry events to telemetry.db in one batch.
+ *
+ * Called automatically on process exit and when the buffer reaches capacity.
+ * Errors are swallowed — telemetry must never crash the process.
+ *
+ * @internal
+ */
+async function _flushTelemetryBuffer(): Promise<void> {
+  if (_flushInProgress || _telemetryBuffer.length === 0) return;
+  _flushInProgress = true;
+  const batch = _telemetryBuffer.splice(0, _telemetryBuffer.length);
+  try {
+    const db = await getTelemetryDb();
+    for (const row of batch) {
+      await db.insert(telemetryEvents).values(row).run();
+    }
+  } catch {
+    // Non-fatal — telemetry flush must never surface errors.
+  } finally {
+    _flushInProgress = false;
+  }
+}
+
+/**
+ * Register process exit handlers to flush the buffer once on process teardown.
+ * Safe to call multiple times — handlers are only attached once.
+ *
+ * @internal
+ */
+function _ensureExitHandlers(): void {
+  if (_exitHandlersRegistered) return;
+  _exitHandlersRegistered = true;
+
+  // 'beforeExit' fires when the event loop empties — best-effort flush.
+  process.on('beforeExit', () => {
+    void _flushTelemetryBuffer();
+  });
+  // SIGINT / SIGTERM: synchronous-safe best-effort (do not await in handlers).
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, () => {
+      void _flushTelemetryBuffer();
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Retention / rotation (T9051)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default retention window in days.
+ * Events older than this are deleted during pruning.
+ */
+export const TELEMETRY_RETENTION_DAYS = 90;
+
+/**
+ * Maximum row count before the table is pruned regardless of age.
+ * Prevents unbounded growth on long-lived installs.
+ */
+export const TELEMETRY_MAX_ROWS = 50_000;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -144,39 +232,86 @@ export function disableTelemetry(): TelemetryConfig {
 }
 
 // ---------------------------------------------------------------------------
-// Event recording
+// Event recording (T9051: buffered writes)
 // ---------------------------------------------------------------------------
 
 /**
+ * Shape of a row passed to the telemetry_events Drizzle insert.
+ * Typed here so _telemetryBuffer can carry pre-built rows.
+ *
+ * @internal
+ */
+interface _TelemetryRow {
+  id: string;
+  anonymousId: string;
+  domain: string;
+  gateway: string;
+  operation: string;
+  command: string;
+  exitCode: number;
+  durationMs: number;
+  errorCode: string | null;
+  timestamp: string;
+}
+
+/**
+ * Insert a single pre-built row.
+ *
+ * @internal Only called from _flushTelemetryBuffer.
+ */
+async function _insertTelemetryRow(row: _TelemetryRow): Promise<void> {
+  const db = await getTelemetryDb();
+  await db.insert(telemetryEvents).values(row).run();
+}
+
+/**
  * Record one telemetry event.
- * Fire-and-forget — errors are swallowed; never blocks the calling command.
- * No-op when telemetry is disabled.
+ *
+ * Events are buffered in-process (T9051) and flushed on process exit or when
+ * the buffer reaches {@link TELEMETRY_BUFFER_MAX_EVENTS}. Fire-and-forget —
+ * errors are swallowed; never blocks the calling command.
+ *
+ * No-op when telemetry is disabled (opt-in required per T9051 privacy posture).
  */
 export async function recordTelemetryEvent(event: TelemetryEvent): Promise<void> {
   const config = loadTelemetryConfig();
   if (!config.enabled || !config.anonymousId) return;
 
   try {
-    const db = await getTelemetryDb();
     const command = `${event.domain}.${event.operation}`;
-    await db
-      .insert(telemetryEvents)
-      .values({
-        id: randomUUID(),
-        anonymousId: config.anonymousId,
-        domain: event.domain,
-        gateway: event.gateway,
-        operation: event.operation,
-        command,
-        exitCode: event.exitCode,
-        durationMs: event.durationMs,
-        errorCode: event.errorCode ?? null,
-        timestamp: new Date().toISOString(),
-      })
-      .run();
+    const row: _TelemetryRow = {
+      id: randomUUID(),
+      anonymousId: config.anonymousId,
+      domain: event.domain,
+      gateway: event.gateway,
+      operation: event.operation,
+      command,
+      exitCode: event.exitCode,
+      durationMs: event.durationMs,
+      errorCode: event.errorCode ?? null,
+      timestamp: new Date().toISOString(),
+    };
+
+    // Buffer the row in-process. Flush immediately when the buffer is full.
+    _telemetryBuffer.push(row);
+    _ensureExitHandlers();
+
+    if (_telemetryBuffer.length >= TELEMETRY_BUFFER_MAX_EVENTS) {
+      void _flushTelemetryBuffer();
+    }
   } catch {
     // Non-fatal: telemetry must never crash the calling command.
   }
+}
+
+/**
+ * Flush any buffered telemetry events immediately.
+ *
+ * Exposed for testing and for callers that need deterministic flushing
+ * (e.g. the diagnostics analyze command). Not required in normal usage.
+ */
+export async function flushTelemetryBuffer(): Promise<void> {
+  await _flushTelemetryBuffer();
 }
 
 // ---------------------------------------------------------------------------
@@ -331,6 +466,71 @@ export async function exportTelemetryEvents(days?: number): Promise<TelemetryEve
     exitCode: r.exitCode,
     errorCode: r.errorCode,
   }));
+}
+
+// ---------------------------------------------------------------------------
+// Retention / rotation (T9051)
+// ---------------------------------------------------------------------------
+
+/**
+ * Prune telemetry events older than `retentionDays` days.
+ *
+ * Also enforces the max-row cap: when the table exceeds
+ * {@link TELEMETRY_MAX_ROWS}, the oldest rows beyond the cap are deleted.
+ *
+ * Call this from `cleo diagnostics analyze` (or a periodic maintenance job)
+ * to prevent unbounded database growth.
+ *
+ * @param retentionDays - Events older than this many days are deleted.
+ *   Defaults to {@link TELEMETRY_RETENTION_DAYS} (90 days).
+ * @returns Number of rows deleted.
+ */
+export async function pruneOldTelemetryEvents(
+  retentionDays: number = TELEMETRY_RETENTION_DAYS,
+): Promise<number> {
+  try {
+    const db = await getTelemetryDb();
+
+    // Step 1: delete by age cutoff.
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - retentionDays);
+    const cutoffIso = cutoff.toISOString();
+
+    // Count before age-cutoff delete.
+    const [beforeAge] = await db.select({ total: count() }).from(telemetryEvents).all();
+    await db.delete(telemetryEvents).where(lt(telemetryEvents.timestamp, cutoffIso)).run();
+    const [afterAge] = await db.select({ total: count() }).from(telemetryEvents).all();
+    const byAge = (beforeAge?.total ?? 0) - (afterAge?.total ?? 0);
+
+    // Step 2: enforce max-row cap.
+    // Count remaining rows; if still over cap, delete oldest excess.
+    const remaining = afterAge?.total ?? 0;
+    let byCap = 0;
+    if (remaining > TELEMETRY_MAX_ROWS) {
+      const excess = remaining - TELEMETRY_MAX_ROWS;
+      // Identify the timestamp of the (excess)-th oldest row.
+      const [oldest] = await db
+        .select({ timestamp: telemetryEvents.timestamp })
+        .from(telemetryEvents)
+        .orderBy(telemetryEvents.timestamp)
+        .limit(excess)
+        .all();
+      if (oldest) {
+        const [beforeCap] = await db.select({ total: count() }).from(telemetryEvents).all();
+        await db
+          .delete(telemetryEvents)
+          .where(lt(telemetryEvents.timestamp, oldest.timestamp))
+          .run();
+        const [afterCap] = await db.select({ total: count() }).from(telemetryEvents).all();
+        byCap = (beforeCap?.total ?? 0) - (afterCap?.total ?? 0);
+      }
+    }
+
+    return byAge + byCap;
+  } catch {
+    // Non-fatal — retention pruning must never crash callers.
+    return 0;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -534,6 +534,24 @@ export async function pruneOldTelemetryEvents(
 }
 
 // ---------------------------------------------------------------------------
+// Test utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset the in-process telemetry buffer and exit-handler registration state.
+ *
+ * FOR TESTING ONLY. Ensures each test starts with a clean buffer so that
+ * events from previous tests do not bleed into subsequent test assertions.
+ *
+ * @internal
+ */
+export function resetTelemetryBufferState(): void {
+  _telemetryBuffer.length = 0;
+  _exitHandlersRegistered = false;
+  _flushInProgress = false;
+}
+
+// ---------------------------------------------------------------------------
 // Re-exports
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Release v2026.5.57

Final wave (Phase 3/4/6) — DocsAccessor, telemetry hot-path, cloud sync scaffold.

### Tasks Shipped

- **T9063** DocsAccessor: unified llmtxt + manifest interface
- **T9051** Telemetry hot-path: buffered writes + opt-in default + retention policy
- **T9062** Cloud sync scaffold: PostgresDataAccessor stub + spec
- **T9064** Migrate .cleo/agent-outputs/*.md to llmtxt blob store
- **T9065** Cross-link DocsAccessor with T1824 + T1825
- **T9025** CI guard preventing pragma drift on DatabaseSync opens

### Quality Gates

- biome CI: 2184 files, no errors
- tsc: clean
- Tests: 7187 passed in core+contracts (0 failures)
- Pre-existing failures in worktree-clean-base.test.ts: 3 (unrelated to this wave, confirmed pre-existing on v2026.5.56)

Epic: T9021 (DB Charter + DataAccessor Umbrella)