### PR TITLE
fix(llm-creds): route Anthropic OAuth tokens via Bearer auth (P0)

### DIFF
--- a/packages/contracts/src/operations/llm.ts
+++ b/packages/contracts/src/operations/llm.ts
@@ -56,6 +56,15 @@ export interface ModelConfig {
   cachePolicy?: PromptCachePolicy | null;
   /** Fallback model config used on final retry attempt. */
   fallback?: Omit<ModelConfig, 'fallback'> | null;
+  /**
+   * Extra HTTP headers to attach to the provider client (merged into the SDK's
+   * `defaultHeaders`). Populated from `authHeaders(cred)` when a credential is
+   * resolved with `authType: 'oauth'` so the provider client uses the
+   * `Authorization: Bearer …` scheme instead of `x-api-key`.
+   *
+   * @task T-LLM-CRED-CENTRALIZATION Phase 1
+   */
+  extraHeaders?: Record<string, string> | null;
 }
 
 /** Parameters for a single LLM call. */

--- a/packages/core/src/deriver/deriver.ts
+++ b/packages/core/src/deriver/deriver.ts
@@ -80,14 +80,19 @@ function generateObsId(): string {
 }
 
 /**
- * Resolve the Anthropic API key without importing the full Anthropic SDK.
- * Returns null if no key is configured.
+ * Resolve the Anthropic credential without importing the full Anthropic SDK.
+ * Returns the full `CredentialResult` so the caller can pick the auth scheme
+ * (`api_key` vs `oauth`) when constructing the SDK client.
+ * Returns null if no credential is available.
  */
-async function tryResolveApiKey(): Promise<string | null> {
+async function tryResolveAnthropicCredential(): Promise<Awaited<
+  ReturnType<typeof import('../llm/credentials.js').resolveCredentials>
+> | null> {
   try {
     // Lazy import to avoid SDK load in tests
-    const { resolveAnthropicApiKey } = await import('../llm/credentials.js');
-    return resolveAnthropicApiKey();
+    const { resolveCredentials } = await import('../llm/credentials.js');
+    const cred = resolveCredentials('anthropic');
+    return cred.apiKey ? cred : null;
   } catch {
     return null;
   }
@@ -143,28 +148,32 @@ async function deriveFromObservation(
 
   // Attempt LLM synthesis; fall back to deterministic on failure
   let synthesisText: string;
-  const apiKey = await tryResolveApiKey();
+  const cred = await tryResolveAnthropicCredential();
 
-  if (apiKey) {
+  if (cred) {
     try {
-      const { default: Anthropic } = await import('@anthropic-ai/sdk');
-      const client = new Anthropic({ apiKey });
-      const prompt = `You are a memory synthesizer. Given these ${allSources.length} observations, produce ONE concise inductive insight (2-3 sentences) that captures the key pattern or learning:\n\n${allSources
-        .slice(0, 10)
-        .map((r, i) => `${i + 1}. ${r.title ?? ''}: ${(r.narrative ?? '').slice(0, 200)}`)
-        .join('\n')}\n\nProvide only the synthesis text, no preamble.`;
+      const { buildAnthropicSdkClient } = await import('../llm/registry.js');
+      const client = buildAnthropicSdkClient(cred);
+      if (!client) {
+        synthesisText = deterministicSynthesis(allSources);
+      } else {
+        const prompt = `You are a memory synthesizer. Given these ${allSources.length} observations, produce ONE concise inductive insight (2-3 sentences) that captures the key pattern or learning:\n\n${allSources
+          .slice(0, 10)
+          .map((r, i) => `${i + 1}. ${r.title ?? ''}: ${(r.narrative ?? '').slice(0, 200)}`)
+          .join('\n')}\n\nProvide only the synthesis text, no preamble.`;
 
-      const msg = await client.messages.create({
-        model: 'claude-haiku-4-5-20251001',
-        max_tokens: 256,
-        messages: [{ role: 'user', content: prompt }],
-      });
+        const msg = await client.messages.create({
+          model: 'claude-haiku-4-5-20251001',
+          max_tokens: 256,
+          messages: [{ role: 'user', content: prompt }],
+        });
 
-      const textBlock = msg.content.find((b) => b.type === 'text');
-      synthesisText =
-        textBlock && textBlock.type === 'text'
-          ? textBlock.text.trim()
-          : deterministicSynthesis(allSources);
+        const textBlock = msg.content.find((b) => b.type === 'text');
+        synthesisText =
+          textBlock && textBlock.type === 'text'
+            ? textBlock.text.trim()
+            : deterministicSynthesis(allSources);
+      }
     } catch {
       synthesisText = deterministicSynthesis(allSources);
     }

--- a/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
+++ b/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for `CredentialResult.authType` and the `authHeaders()` helper.
+ *
+ * Covers Phase 1 of T-LLM-CRED-CENTRALIZATION: every Anthropic call-site needs
+ * to send the correct auth scheme. Claude Code OAuth tokens require
+ * `Authorization: Bearer …` + `anthropic-beta: oauth-2025-04-20`; API keys
+ * require `x-api-key`. Sending the wrong scheme returns 401 from Anthropic.
+ *
+ * Filesystem isolation mirrors `credentials.test.ts`: a tmpdir XDG home plus
+ * env restoration around every test.
+ *
+ * @task T-LLM-CRED-CENTRALIZATION Phase 1
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { authHeaders, clearAnthropicKeyCache, resolveCredentials } from '../credentials.js';
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'MOONSHOT_API_KEY',
+  'XDG_DATA_HOME',
+  'HOME',
+  'CLEO_DIR',
+];
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+function clearEnv(): void {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+/**
+ * Point HOME at a tmpdir and seed `~/.claude/.credentials.json` with an
+ * OAuth token so tier 3 of the resolver picks it up.
+ */
+function seedClaudeOauth(accessToken: string): string {
+  const home = join(tmpdir(), `cleo-authtype-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const claudeDir = join(home, '.claude');
+  mkdirSync(claudeDir, { recursive: true });
+  writeFileSync(
+    join(claudeDir, '.credentials.json'),
+    JSON.stringify({
+      claudeAiOauth: { accessToken, expiresAt: Date.now() + 60 * 60_000 },
+    }),
+    'utf-8',
+  );
+  process.env['HOME'] = home;
+  return home;
+}
+
+beforeEach(() => {
+  saveEnv();
+  clearEnv();
+  clearAnthropicKeyCache();
+  // Isolate XDG so global config tier never reads developer credentials.
+  process.env['XDG_DATA_HOME'] = join(
+    tmpdir(),
+    `cleo-authtype-xdg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+});
+
+afterEach(() => {
+  restoreEnv();
+  clearAnthropicKeyCache();
+});
+
+describe('authType detection — anthropic', () => {
+  it('marks Claude Code OAuth tokens (tier 3) as oauth', () => {
+    seedClaudeOauth('sk-ant-oat-XXXXX');
+    const cred = resolveCredentials('anthropic');
+    expect(cred.apiKey).toBe('sk-ant-oat-XXXXX');
+    expect(cred.source).toBe('claude-creds');
+    expect(cred.authType).toBe('oauth');
+  });
+
+  it('marks env-var API keys (tier 2) as api_key', () => {
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-api03-XXXXX';
+    const cred = resolveCredentials('anthropic');
+    expect(cred.apiKey).toBe('sk-ant-api03-XXXXX');
+    expect(cred.source).toBe('env');
+    expect(cred.authType).toBe('api_key');
+  });
+
+  it('detects OAuth-prefixed tokens pasted into env as oauth', () => {
+    // User pastes their Claude Code OAuth access token into ANTHROPIC_API_KEY.
+    // The prefix heuristic should still route to the Bearer scheme.
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-oat-pasted-into-env';
+    const cred = resolveCredentials('anthropic');
+    expect(cred.source).toBe('env');
+    expect(cred.authType).toBe('oauth');
+  });
+
+  it('returns authType=api_key with null token when no credential is available', () => {
+    const cred = resolveCredentials('anthropic');
+    expect(cred.apiKey).toBeNull();
+    expect(cred.authType).toBe('api_key');
+  });
+});
+
+describe('authType detection — non-anthropic providers', () => {
+  it('always returns api_key for openai regardless of token shape', () => {
+    process.env['OPENAI_API_KEY'] = 'sk-ant-oat-not-actually-anthropic';
+    const cred = resolveCredentials('openai');
+    expect(cred.authType).toBe('api_key');
+  });
+
+  it('always returns api_key for gemini', () => {
+    process.env['GEMINI_API_KEY'] = 'AIza-XXXX';
+    const cred = resolveCredentials('gemini');
+    expect(cred.authType).toBe('api_key');
+  });
+});
+
+describe('authHeaders()', () => {
+  it('produces Bearer + anthropic-beta headers for anthropic oauth', () => {
+    seedClaudeOauth('sk-ant-oat-XXXXX');
+    const cred = resolveCredentials('anthropic');
+    const headers = authHeaders(cred);
+    expect(headers['Authorization']).toBe('Bearer sk-ant-oat-XXXXX');
+    expect(headers['anthropic-beta']).toBe('oauth-2025-04-20');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers['x-api-key']).toBeUndefined();
+  });
+
+  it('produces x-api-key header for anthropic api_key', () => {
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-api03-XXXXX';
+    const cred = resolveCredentials('anthropic');
+    const headers = authHeaders(cred);
+    expect(headers['x-api-key']).toBe('sk-ant-api03-XXXXX');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers['Authorization']).toBeUndefined();
+    expect(headers['anthropic-beta']).toBeUndefined();
+  });
+
+  it('produces Bearer auth for openai api_key (no anthropic headers)', () => {
+    process.env['OPENAI_API_KEY'] = 'sk-XXXXX';
+    const cred = resolveCredentials('openai');
+    const headers = authHeaders(cred);
+    expect(headers['Authorization']).toBe('Bearer sk-XXXXX');
+    expect(headers['x-api-key']).toBeUndefined();
+    expect(headers['anthropic-beta']).toBeUndefined();
+  });
+
+  it('returns an empty bag when the credential has no token', () => {
+    const cred = resolveCredentials('anthropic');
+    expect(cred.apiKey).toBeNull();
+    expect(authHeaders(cred)).toEqual({});
+  });
+});
+
+describe('registry imports with empty env', () => {
+  it('does not throw when registry is imported with no credentials present', async () => {
+    // Regression guard: prior to Phase 1 the registry's initDefaultClients() ran
+    // at module load. This test confirms the import side-effect is still safe
+    // when no environment keys are set.
+    await expect(import('../registry.js')).resolves.toBeDefined();
+  });
+});

--- a/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
+++ b/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
@@ -72,6 +72,14 @@ beforeEach(() => {
     tmpdir(),
     `cleo-authtype-xdg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
+  // Point HOME at an empty tmpdir so tier 3 (`~/.claude/.credentials.json`)
+  // cannot pick up the developer's real Claude Code OAuth token. Deleting HOME
+  // is not enough — Node's `os.homedir()` falls back to /etc/passwd. Tests that
+  // need a Claude creds file override this via seedClaudeOauth().
+  process.env['HOME'] = join(
+    tmpdir(),
+    `cleo-authtype-home-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
 });
 
 afterEach(() => {

--- a/packages/core/src/llm/credentials.ts
+++ b/packages/core/src/llm/credentials.ts
@@ -58,17 +58,41 @@ export type CredentialSource =
   | 'project-config';
 
 /**
+ * Authentication scheme used to send the credential to the provider.
+ *
+ * - `api_key` — provider-issued long-lived key sent as `x-api-key` (Anthropic)
+ *               or `Authorization: Bearer …` (OpenAI, Gemini, Moonshot).
+ * - `oauth`   — short-lived OAuth bearer token (Anthropic Claude Code) sent as
+ *               `Authorization: Bearer …` with the matching beta header.
+ *
+ * The set is intentionally small in Phase 1. Phase 3 widens it to add SDK-based
+ * auth (`aws_sdk`, `gcp_sdk`) alongside the Bedrock / Vertex transports.
+ *
+ * @task T-LLM-CRED-CENTRALIZATION Phase 1
+ */
+export type AuthType = 'api_key' | 'oauth';
+
+/**
  * Result returned by `resolveCredentials()`.
  *
  * `apiKey` is null only when all 5 tiers are exhausted without a match.
+ * `authType` indicates the scheme to use when sending the credential — callers
+ * should pass the result through `authHeaders(cred)` rather than hard-coding
+ * `x-api-key` or `Authorization` themselves.
  */
 export interface CredentialResult {
   /** Provider transport that was resolved for. */
   provider: ModelTransport;
-  /** API key string, or null when no key is available. */
+  /** API key or OAuth bearer token string, or null when no credential is available. */
   apiKey: string | null;
-  /** Which resolution tier produced the key (undefined when apiKey is null). */
+  /** Which resolution tier produced the credential (undefined when apiKey is null). */
   source: CredentialSource | undefined;
+  /**
+   * Scheme used to present this credential to the provider. Defaults to `'api_key'`
+   * for every source except `claude-creds`, and for tokens whose prefix marks
+   * them as Anthropic OAuth (`sk-ant-oat-*` access / `sk-ant-ort-*` refresh).
+   */
+  authType: AuthType;
 }
 
 /**
@@ -222,28 +246,40 @@ export function resolveCredentials(
 ): CredentialResult {
   // Tier 1 — explicit caller-supplied key
   if (options.apiKey?.trim()) {
-    return { provider, apiKey: options.apiKey.trim(), source: 'explicit' };
+    const token = options.apiKey.trim();
+    return {
+      provider,
+      apiKey: token,
+      source: 'explicit',
+      authType: detectAuthType(provider, token),
+    };
   }
 
   // Tier 2 — environment variable
   const envVar = ENV_VARS[provider];
   const envKey = process.env[envVar];
   if (envKey?.trim()) {
-    return { provider, apiKey: envKey.trim(), source: 'env' };
+    const token = envKey.trim();
+    return { provider, apiKey: token, source: 'env', authType: detectAuthType(provider, token) };
   }
 
   // Tier 3 — ~/.claude/.credentials.json (anthropic only)
   if (provider === 'anthropic') {
     const oauthToken = readClaudeCredsToken();
     if (oauthToken) {
-      return { provider, apiKey: oauthToken, source: 'claude-creds' };
+      return { provider, apiKey: oauthToken, source: 'claude-creds', authType: 'oauth' };
     }
   }
 
   // Tier 4a — global config (~/.local/share/cleo/config.json → llm.providers[p].apiKey)
   const globalKey = readProviderKeyFromConfig(globalConfigPath(), provider);
   if (globalKey) {
-    return { provider, apiKey: globalKey, source: 'global-config' };
+    return {
+      provider,
+      apiKey: globalKey,
+      source: 'global-config',
+      authType: detectAuthType(provider, globalKey),
+    };
   }
 
   // Tier 4b — legacy flat key file (~/.local/share/cleo/anthropic-key).
@@ -252,7 +288,12 @@ export function resolveCredentials(
   if (provider === 'anthropic') {
     const flatKey = readFlatAnthropicKey();
     if (flatKey) {
-      return { provider, apiKey: flatKey, source: 'global-config' };
+      return {
+        provider,
+        apiKey: flatKey,
+        source: 'global-config',
+        authType: detectAuthType(provider, flatKey),
+      };
     }
   }
 
@@ -260,11 +301,68 @@ export function resolveCredentials(
   if (options.projectRoot) {
     const projectKey = readProviderKeyFromConfig(projectConfigPath(options.projectRoot), provider);
     if (projectKey) {
-      return { provider, apiKey: projectKey, source: 'project-config' };
+      return {
+        provider,
+        apiKey: projectKey,
+        source: 'project-config',
+        authType: detectAuthType(provider, projectKey),
+      };
     }
   }
 
-  return { provider, apiKey: null, source: undefined };
+  return { provider, apiKey: null, source: undefined, authType: 'api_key' };
+}
+
+/**
+ * Detect whether a credential string is an Anthropic OAuth token by prefix.
+ *
+ * The Claude Code OAuth flow issues tokens with the prefixes:
+ * - `sk-ant-oat-*` — access token (used for API calls)
+ * - `sk-ant-ort-*` — refresh token (rare in direct calls, but recognized for safety)
+ *
+ * Every other provider in Phase 1 uses `api_key` authentication, so any
+ * non-Anthropic credential is treated as `api_key`. Tokens loaded from
+ * `claude-creds` are always `oauth` regardless of prefix (handled by the caller).
+ */
+function detectAuthType(provider: ModelTransport, token: string): AuthType {
+  if (provider !== 'anthropic') return 'api_key';
+  if (token.startsWith('sk-ant-oat-') || token.startsWith('sk-ant-ort-')) return 'oauth';
+  return 'api_key';
+}
+
+/**
+ * Build the authentication HTTP headers for a resolved credential.
+ *
+ * For raw-fetch call-sites (e.g. memory/sleep-consolidation, memory/observer-reflector)
+ * this returns the full bag of provider-specific auth headers including the
+ * `anthropic-version` or `anthropic-beta` markers that Anthropic requires.
+ * The caller still owns `Content-Type` and the request body.
+ *
+ * Returns an empty object when `cred.apiKey` is null — callers should never
+ * reach this helper without verifying they have a credential, but the no-op
+ * fallback avoids accidental `undefined` header injection.
+ *
+ * @task T-LLM-CRED-CENTRALIZATION Phase 1
+ */
+export function authHeaders(cred: CredentialResult): Record<string, string> {
+  if (!cred.apiKey) return {};
+
+  if (cred.provider === 'anthropic') {
+    if (cred.authType === 'oauth') {
+      return {
+        Authorization: `Bearer ${cred.apiKey}`,
+        'anthropic-beta': 'oauth-2025-04-20',
+        'anthropic-version': '2023-06-01',
+      };
+    }
+    return {
+      'x-api-key': cred.apiKey,
+      'anthropic-version': '2023-06-01',
+    };
+  }
+
+  // openai / gemini / moonshot — all use Bearer auth for API keys.
+  return { Authorization: `Bearer ${cred.apiKey}` };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -25,12 +25,14 @@ export { buildCacheKey, geminiCacheStore, InMemoryGeminiCacheStore } from './cac
 // Conversation utilities
 export { countMessageTokens, truncateMessagesToFit } from './conversation.js';
 export type {
+  AuthType,
   CredentialResolveOptions,
   CredentialResult,
   CredentialSource,
 } from './credentials.js';
-// Credential resolver (T1677)
+// Credential resolver (T1677 + T-LLM-CRED-CENTRALIZATION Phase 1)
 export {
+  authHeaders,
   clearAnthropicKeyCache,
   defaultTransportApiKey,
   resolveAnthropicApiKey,
@@ -48,7 +50,13 @@ export {
   OpenAIHistoryAdapter,
 } from './history-adapters.js';
 // Registry (for testing/DI)
-export { backendForProvider, CLIENTS, clientForModelConfig, getBackend } from './registry.js';
+export {
+  backendForProvider,
+  buildAnthropicSdkClient,
+  CLIENTS,
+  clientForModelConfig,
+  getBackend,
+} from './registry.js';
 // Runtime
 export type { AttemptPlan } from './runtime.js';
 export { effectiveTemperature, makeAttemptRef, planAttempt } from './runtime.js';

--- a/packages/core/src/llm/registry.ts
+++ b/packages/core/src/llm/registry.ts
@@ -17,6 +17,7 @@ import { AnthropicBackend } from './backends/anthropic.js';
 import { GeminiBackend } from './backends/gemini.js';
 import { MOONSHOT_BASE_URL, MoonshotBackend } from './backends/moonshot.js';
 import { OpenAIBackend } from './backends/openai.js';
+import type { CredentialResult } from './credentials.js';
 import { defaultTransportApiKey } from './credentials.js';
 import type { HistoryAdapter } from './history-adapters.js';
 import {
@@ -64,25 +65,107 @@ const _moonshotOverrideCache = new Map<string, OpenAI>();
 function makeOverrideKey(
   baseUrl: string | null | undefined,
   apiKey: string | null | undefined,
+  extraHeaders?: Record<string, string> | null,
 ): string {
-  return `${baseUrl ?? ''}::${apiKey ?? ''}`;
+  // Stable serialization of extraHeaders (sorted by key) so equivalent header
+  // bags hit the same cache entry.
+  let headerKey = '';
+  if (extraHeaders) {
+    const entries = Object.entries(extraHeaders).sort(([a], [b]) => a.localeCompare(b));
+    headerKey = entries.map(([k, v]) => `${k}=${v}`).join('|');
+  }
+  return `${baseUrl ?? ''}::${apiKey ?? ''}::${headerKey}`;
 }
 
-/** Get (or create) a cached Anthropic client for a specific (baseUrl, apiKey) pair. */
+/**
+ * Get (or create) a cached Anthropic client for a specific
+ * (baseUrl, apiKey, extraHeaders) tuple.
+ *
+ * When `extraHeaders.Authorization` is present (set by `authHeaders(cred)` for
+ * OAuth credentials), the SDK is constructed with `authToken` instead of
+ * `apiKey` so requests carry `Authorization: Bearer …` and omit the default
+ * `x-api-key`. The `anthropic-beta: oauth-2025-04-20` header is forwarded
+ * through `defaultHeaders`.
+ *
+ * @task T-LLM-CRED-CENTRALIZATION Phase 1
+ */
 export function getAnthropicOverrideClient(
   baseUrl: string | null | undefined,
   apiKey: string | null | undefined,
+  extraHeaders?: Record<string, string> | null,
 ): Anthropic {
-  const key = makeOverrideKey(baseUrl, apiKey);
+  const key = makeOverrideKey(baseUrl, apiKey, extraHeaders);
   const cached = _anthropicOverrideCache.get(key);
   if (cached) return cached;
+
+  const oauthMatch = extraHeaders ? extractBearerToken(extraHeaders) : null;
+  if (oauthMatch) {
+    // OAuth path: SDK uses authToken → `Authorization: Bearer …`.
+    // Critical: do NOT also pass apiKey — the SDK sends both `x-api-key` and
+    // `Authorization` when both are set, which Anthropic rejects with 401.
+    const oauthHeaders: Record<string, string> = {};
+    if (extraHeaders) {
+      for (const [k, v] of Object.entries(extraHeaders)) {
+        if (k.toLowerCase() === 'authorization') continue;
+        oauthHeaders[k] = v;
+      }
+    }
+    const client = new Anthropic({
+      authToken: oauthMatch,
+      baseURL: baseUrl ?? undefined,
+      timeout: 600_000,
+      defaultHeaders: oauthHeaders,
+    });
+    _anthropicOverrideCache.set(key, client);
+    return client;
+  }
+
   const client = new Anthropic({
     apiKey: apiKey ?? undefined,
     baseURL: baseUrl ?? undefined,
     timeout: 600_000,
+    defaultHeaders: extraHeaders ?? undefined,
   });
   _anthropicOverrideCache.set(key, client);
   return client;
+}
+
+/**
+ * Extract the bearer token from an `Authorization: Bearer <token>` header value.
+ * Header lookup is case-insensitive. Returns null when no Authorization header
+ * is present or when it does not use the Bearer scheme.
+ */
+function extractBearerToken(headers: Record<string, string>): string | null {
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() !== 'authorization') continue;
+    const match = /^Bearer\s+(.+)$/i.exec(v);
+    if (match?.[1]) return match[1].trim();
+  }
+  return null;
+}
+
+/**
+ * Build a fresh Anthropic SDK client for a resolved credential.
+ *
+ * Centralises the dynamic-import + constructor dance previously duplicated in
+ * `memory/llm-extraction.ts`, `sentient/dream-cycle.ts`, and `deriver/deriver.ts`.
+ * Honors `cred.authType` so OAuth tokens are passed via `authToken` (Bearer)
+ * and api_key credentials via `apiKey` (`x-api-key`).
+ *
+ * Returns null when the credential has no resolvable token.
+ *
+ * @task T-LLM-CRED-CENTRALIZATION Phase 1
+ */
+export function buildAnthropicSdkClient(cred: CredentialResult): Anthropic | null {
+  if (!cred.apiKey) return null;
+  if (cred.authType === 'oauth') {
+    return new Anthropic({
+      authToken: cred.apiKey,
+      timeout: 600_000,
+      defaultHeaders: { 'anthropic-beta': 'oauth-2025-04-20' },
+    });
+  }
+  return new Anthropic({ apiKey: cred.apiKey, timeout: 600_000 });
 }
 
 /** Get (or create) a cached OpenAI client for a specific (baseUrl, apiKey) pair. */
@@ -147,19 +230,23 @@ export function clientForModelConfig(
   provider: ModelTransport,
   modelConfig: ModelConfig,
 ): ProviderClient {
-  if (!modelConfig.apiKey && !modelConfig.baseUrl) {
+  // Fast path: no overrides at all → reuse the module-level default client.
+  // extraHeaders forces the override path because the default client has no
+  // OAuth-aware constructor wiring.
+  if (!modelConfig.apiKey && !modelConfig.baseUrl && !modelConfig.extraHeaders) {
     const existing = CLIENTS[provider];
     if (existing !== undefined) return existing;
   }
 
   const apiKey = modelConfig.apiKey ?? defaultTransportApiKey(provider);
   const baseUrl = modelConfig.baseUrl;
+  const extraHeaders = modelConfig.extraHeaders ?? null;
 
-  if (!apiKey) {
+  if (!apiKey && !extractBearerToken(extraHeaders ?? {})) {
     throw new Error(`Missing API key for ${provider} model config`);
   }
 
-  if (provider === 'anthropic') return getAnthropicOverrideClient(baseUrl, apiKey);
+  if (provider === 'anthropic') return getAnthropicOverrideClient(baseUrl, apiKey, extraHeaders);
   if (provider === 'openai') return getOpenAIOverrideClient(baseUrl, apiKey);
   if (provider === 'gemini') return getGeminiOverrideClient(baseUrl, apiKey);
   if (provider === 'moonshot') return getMoonshotOverrideClient(baseUrl, apiKey);

--- a/packages/core/src/memory/__tests__/llm-extraction.test.ts
+++ b/packages/core/src/memory/__tests__/llm-extraction.test.ts
@@ -61,12 +61,25 @@ vi.mock('@anthropic-ai/sdk/helpers/zod', () => ({
 
 // Mock the key resolver so tests don't depend on filesystem state
 // (~/.claude/.credentials.json, ~/.local/share/cleo/anthropic-key).
-// Default: no key. Tests that inject a client bypass this anyway.
+// Default: no credential. Tests that inject a client bypass this anyway.
 const mockResolveKey = vi.fn().mockReturnValue(null);
-vi.mock('../../llm/credentials.js', () => ({
-  resolveAnthropicApiKey: (...args: unknown[]) => mockResolveKey(...args),
-  clearAnthropicKeyCache: vi.fn(),
-}));
+const mockResolveCredentials = vi.fn().mockReturnValue({
+  provider: 'anthropic',
+  apiKey: null,
+  source: undefined,
+  authType: 'api_key' as const,
+});
+vi.mock('../../llm/credentials.js', async () => {
+  const actual = await vi.importActual<typeof import('../../llm/credentials.js')>(
+    '../../llm/credentials.js',
+  );
+  return {
+    ...actual,
+    resolveAnthropicApiKey: (...args: unknown[]) => mockResolveKey(...args),
+    resolveCredentials: (...args: unknown[]) => mockResolveCredentials(...args),
+    clearAnthropicKeyCache: vi.fn(),
+  };
+});
 
 // Mock the SDK entry point so buildAnthropicClient doesn't touch the network.
 // Tests that need this will inject a custom client via options.client instead.
@@ -76,14 +89,6 @@ vi.mock('@anthropic-ai/sdk', () => {
   }
   return { default: MockAnthropic };
 });
-
-// Mock the key resolver so tests don't depend on filesystem state
-// (~/.claude/.credentials.json, ~/.local/share/cleo/anthropic-key).
-// Default: no key. Tests that inject a client via options.client bypass this.
-vi.mock('../../llm/credentials.js', () => ({
-  resolveAnthropicApiKey: vi.fn().mockReturnValue(null),
-  clearAnthropicKeyCache: vi.fn(),
-}));
 
 // ---- imports after mocks --------------------------------------------------
 

--- a/packages/core/src/memory/__tests__/observer-reflector.test.ts
+++ b/packages/core/src/memory/__tests__/observer-reflector.test.ts
@@ -27,6 +27,7 @@ const {
   mockStorePattern,
   mockLoadConfig,
   mockResolveKey,
+  mockResolveCredentials,
 } = vi.hoisted(() => ({
   mockGetBrainDb: vi.fn().mockResolvedValue({}),
   mockGetBrainNativeDb: vi.fn(),
@@ -34,6 +35,12 @@ const {
   mockStorePattern: vi.fn().mockResolvedValue({ id: 'P-test-001' }),
   mockLoadConfig: vi.fn(),
   mockResolveKey: vi.fn().mockReturnValue(null),
+  mockResolveCredentials: vi.fn().mockReturnValue({
+    provider: 'anthropic',
+    apiKey: null,
+    source: undefined,
+    authType: 'api_key' as const,
+  }),
 }));
 
 vi.mock('../../store/memory-sqlite.js', () => ({
@@ -60,10 +67,17 @@ vi.mock('../../config.js', () => ({
 
 // Mock the key resolver so tests don't depend on filesystem state
 // (~/.claude/.credentials.json, ~/.local/share/cleo/anthropic-key).
-vi.mock('../../llm/credentials.js', () => ({
-  resolveAnthropicApiKey: (...args: unknown[]) => mockResolveKey(...args),
-  clearAnthropicKeyCache: vi.fn(),
-}));
+vi.mock('../../llm/credentials.js', async () => {
+  const actual = await vi.importActual<typeof import('../../llm/credentials.js')>(
+    '../../llm/credentials.js',
+  );
+  return {
+    ...actual,
+    resolveAnthropicApiKey: (...args: unknown[]) => mockResolveKey(...args),
+    resolveCredentials: (...args: unknown[]) => mockResolveCredentials(...args),
+    clearAnthropicKeyCache: vi.fn(),
+  };
+});
 
 // ============================================================================
 // Import module under test (after all mocks)
@@ -79,6 +93,12 @@ const FAKE_API_KEY = 'sk-ant-test-key';
 
 function setApiKey(key: string | undefined): void {
   mockResolveKey.mockReturnValue(key ?? null);
+  mockResolveCredentials.mockReturnValue({
+    provider: 'anthropic',
+    apiKey: key ?? null,
+    source: key ? ('env' as const) : undefined,
+    authType: 'api_key' as const,
+  });
 }
 
 type RawObs = {

--- a/packages/core/src/memory/__tests__/sleep-consolidation.test.ts
+++ b/packages/core/src/memory/__tests__/sleep-consolidation.test.ts
@@ -28,6 +28,7 @@ const {
   mockStorePattern,
   mockLoadConfig,
   mockResolveKey,
+  mockResolveCredentials,
 } = vi.hoisted(() => ({
   mockGetBrainDb: vi.fn().mockResolvedValue({}),
   mockGetBrainNativeDb: vi.fn(),
@@ -35,6 +36,12 @@ const {
   mockStorePattern: vi.fn().mockResolvedValue({ id: 'P-test-001' }),
   mockLoadConfig: vi.fn(),
   mockResolveKey: vi.fn().mockReturnValue(null),
+  mockResolveCredentials: vi.fn().mockReturnValue({
+    provider: 'anthropic',
+    apiKey: null,
+    source: undefined,
+    authType: 'api_key' as const,
+  }),
 }));
 
 vi.mock('../../store/memory-sqlite.js', () => ({
@@ -61,10 +68,17 @@ vi.mock('../../config.js', () => ({
 
 // Mock the key resolver so tests don't depend on filesystem state
 // (~/.claude/.credentials.json, ~/.local/share/cleo/anthropic-key).
-vi.mock('../../llm/credentials.js', () => ({
-  resolveAnthropicApiKey: (...args: unknown[]) => mockResolveKey(...args),
-  clearAnthropicKeyCache: vi.fn(),
-}));
+vi.mock('../../llm/credentials.js', async () => {
+  const actual = await vi.importActual<typeof import('../../llm/credentials.js')>(
+    '../../llm/credentials.js',
+  );
+  return {
+    ...actual,
+    resolveAnthropicApiKey: (...args: unknown[]) => mockResolveKey(...args),
+    resolveCredentials: (...args: unknown[]) => mockResolveCredentials(...args),
+    clearAnthropicKeyCache: vi.fn(),
+  };
+});
 
 // ============================================================================
 // Import module under test (after all mocks)
@@ -82,9 +96,21 @@ function setApiKey(key: string | undefined): void {
   if (key === undefined) {
     delete process.env['ANTHROPIC_API_KEY'];
     mockResolveKey.mockReturnValue(null);
+    mockResolveCredentials.mockReturnValue({
+      provider: 'anthropic',
+      apiKey: null,
+      source: undefined,
+      authType: 'api_key' as const,
+    });
   } else {
     process.env['ANTHROPIC_API_KEY'] = key;
     mockResolveKey.mockReturnValue(key);
+    mockResolveCredentials.mockReturnValue({
+      provider: 'anthropic',
+      apiKey: key,
+      source: 'env' as const,
+      authType: 'api_key' as const,
+    });
   }
 }
 

--- a/packages/core/src/memory/llm-extraction.ts
+++ b/packages/core/src/memory/llm-extraction.ts
@@ -27,7 +27,8 @@
 
 import type Anthropic from '@anthropic-ai/sdk';
 import { z } from 'zod';
-import { resolveAnthropicApiKey } from '../llm/credentials.js';
+import { resolveCredentials } from '../llm/credentials.js';
+import { buildAnthropicSdkClient } from '../llm/registry.js';
 import { checkHashDedup, type MemoryCandidate, verifyAndStore } from './extraction-gate.js';
 
 // ---------------------------------------------------------------------------
@@ -297,24 +298,21 @@ function mapImportanceToConfidence(importance: number): 'low' | 'medium' | 'high
 // ---------------------------------------------------------------------------
 
 /**
- * Lazily import and instantiate the Anthropic SDK.
+ * Lazily resolve credentials and instantiate the Anthropic SDK via the central
+ * `buildAnthropicSdkClient` helper.
  *
- * Resolves the API key from env or Claude Code credentials. Returns null
- * when no key is available so callers can gracefully degrade to no-op.
- * The SDK is imported via dynamic import so projects that do not use the
- * LLM extraction gate don't pay the load cost at startup.
+ * Honors `cred.authType` so OAuth tokens (Claude Code) are passed via the SDK's
+ * `authToken` field (→ `Authorization: Bearer`) instead of `apiKey` (→
+ * `x-api-key`), which Anthropic rejects for OAuth credentials.
+ * Returns null when no credential is available.
  */
 async function buildAnthropicClient(): Promise<Pick<Anthropic, 'messages'> | null> {
-  const apiKey = resolveAnthropicApiKey();
-  if (!apiKey) {
+  const cred = resolveCredentials('anthropic');
+  if (!cred.apiKey) {
     return null;
   }
   try {
-    const AnthropicModule = await import('@anthropic-ai/sdk');
-    const Ctor =
-      (AnthropicModule as { default?: typeof Anthropic }).default ??
-      (AnthropicModule as unknown as typeof Anthropic);
-    return new Ctor({ apiKey }) as Pick<Anthropic, 'messages'>;
+    return buildAnthropicSdkClient(cred) as Pick<Anthropic, 'messages'> | null;
   } catch {
     return null;
   }

--- a/packages/core/src/memory/observer-reflector.ts
+++ b/packages/core/src/memory/observer-reflector.ts
@@ -230,17 +230,20 @@ interface AnthropicResponse {
 /**
  * Call the Anthropic Messages API via native fetch.
  *
- * Uses `ANTHROPIC_API_KEY` from the environment. Returns null when the key is
- * not set or when the API call fails (caller handles graceful degradation).
+ * Uses `resolveCredentials('anthropic')` + `authHeaders(cred)` so the request
+ * carries the correct auth scheme — `x-api-key` for API keys, `Authorization`
+ * Bearer + `anthropic-beta: oauth-2025-04-20` for Claude Code OAuth tokens.
+ * Returns null when no credential is available or the API call fails (caller
+ * handles graceful degradation).
  *
  * @param systemPrompt - System instruction for the LLM.
  * @param userContent - User message content.
  * @returns The assistant response text, or null on failure.
  */
 async function callAnthropicLlm(systemPrompt: string, userContent: string): Promise<string | null> {
-  const { resolveAnthropicApiKey } = await import('../llm/credentials.js');
-  const apiKey = resolveAnthropicApiKey();
-  if (!apiKey) {
+  const { authHeaders, resolveCredentials } = await import('../llm/credentials.js');
+  const cred = resolveCredentials('anthropic');
+  if (!cred.apiKey) {
     return null;
   }
 
@@ -251,8 +254,7 @@ async function callAnthropicLlm(systemPrompt: string, userContent: string): Prom
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
+        ...authHeaders(cred),
       },
       body: JSON.stringify({
         model,

--- a/packages/core/src/memory/sleep-consolidation.ts
+++ b/packages/core/src/memory/sleep-consolidation.ts
@@ -32,7 +32,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { resolveAnthropicApiKey } from '../llm/credentials.js';
+import { authHeaders, resolveCredentials } from '../llm/credentials.js';
 import { getBrainNativeDb } from '../store/memory-sqlite.js';
 import { typedAll } from '../store/typed-query.js';
 import { storeLearning } from './learnings.js';
@@ -207,15 +207,17 @@ interface AnthropicResponse {
 /**
  * Call the Anthropic Messages API via native fetch using the cheap model.
  *
- * Uses `resolveAnthropicApiKey()` — never accesses ANTHROPIC_API_KEY directly.
- * Returns null when the key is unavailable or the call fails.
+ * Uses `resolveCredentials('anthropic')` + `authHeaders(cred)` so the request
+ * carries the correct scheme — `x-api-key` for API keys, `Authorization: Bearer`
+ * + `anthropic-beta: oauth-2025-04-20` for Claude Code OAuth tokens.
+ * Returns null when no credential is available or the call fails.
  *
  * @param systemPrompt - System instruction for the LLM.
  * @param userContent - User message content.
  */
 async function callLlm(systemPrompt: string, userContent: string): Promise<string | null> {
-  const apiKey = resolveAnthropicApiKey();
-  if (!apiKey) return null;
+  const cred = resolveCredentials('anthropic');
+  if (!cred.apiKey) return null;
 
   try {
     const response = await fetch('https://api.anthropic.com/v1/messages', {
@@ -225,8 +227,7 @@ async function callLlm(systemPrompt: string, userContent: string): Promise<strin
       signal: AbortSignal.timeout(30_000),
       headers: {
         'Content-Type': 'application/json',
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
+        ...authHeaders(cred),
       },
       body: JSON.stringify({
         model: SLEEP_MODEL,

--- a/packages/core/src/sentient/dream-cycle.ts
+++ b/packages/core/src/sentient/dream-cycle.ts
@@ -52,6 +52,7 @@ import { randomUUID } from 'node:crypto';
 import type Anthropic from '@anthropic-ai/sdk';
 import { z } from 'zod';
 import { resolveCredentials } from '../llm/credentials.js';
+import { buildAnthropicSdkClient } from '../llm/registry.js';
 import type { MemoryCandidate } from '../memory/extraction-gate.js';
 
 // ---------------------------------------------------------------------------
@@ -542,11 +543,9 @@ async function buildDaemonClient(projectRoot: string): Promise<Pick<Anthropic, '
     const cred = resolveCredentials('anthropic', { projectRoot });
     if (!cred.apiKey) return null;
 
-    const AnthropicModule = await import('@anthropic-ai/sdk');
-    const Ctor =
-      (AnthropicModule as { default?: typeof import('@anthropic-ai/sdk').default }).default ??
-      (AnthropicModule as unknown as typeof import('@anthropic-ai/sdk').default);
-    return new Ctor({ apiKey: cred.apiKey }) as Pick<Anthropic, 'messages'>;
+    // buildAnthropicSdkClient honors cred.authType so OAuth tokens use
+    // `authToken` (Bearer) and api_keys use `apiKey` (x-api-key).
+    return buildAnthropicSdkClient(cred) as Pick<Anthropic, 'messages'> | null;
   } catch {
     return null;
   }

--- a/packages/core/src/sentient/hygiene-scan.ts
+++ b/packages/core/src/sentient/hygiene-scan.ts
@@ -491,7 +491,7 @@ function readDaemonLlmConfig(): { provider: string; model: string } {
  */
 async function buildRealLlmCallFn(projectRoot: string): Promise<LlmEscalateCallFn | null> {
   try {
-    const { resolveCredentials } = await import('../llm/credentials.js');
+    const { authHeaders, resolveCredentials } = await import('../llm/credentials.js');
     const { getBackend } = await import('../llm/registry.js');
     const { repairResponseModelJson } = await import('../llm/structured-output.js');
 
@@ -509,11 +509,17 @@ async function buildRealLlmCallFn(projectRoot: string): Promise<LlmEscalateCallF
       return null;
     }
 
+    // For OAuth credentials, pass the Bearer headers through extraHeaders so
+    // the registry's getAnthropicOverrideClient uses `authToken` instead of
+    // `apiKey` when constructing the SDK client.
+    const extraHeaders = cred.authType === 'oauth' ? authHeaders(cred) : undefined;
+
     return async (findingText: string, taskContext: string): Promise<HygieneEscalationResult> => {
       const modelConfig = {
         transport: transport as 'anthropic' | 'openai' | 'gemini' | 'moonshot',
         model,
         apiKey: cred.apiKey,
+        extraHeaders,
       };
 
       const backend = getBackend(modelConfig);

--- a/packages/core/src/tasks/duplicate-detector.ts
+++ b/packages/core/src/tasks/duplicate-detector.ts
@@ -426,7 +426,7 @@ export async function callLlmDuplicateReasoning(
     const daemonProvider = config?.llm?.daemon?.provider ?? 'anthropic';
     const daemonModel = config?.llm?.daemon?.model ?? 'claude-haiku-4-5-20251001';
 
-    const { resolveCredentials } = await import('../llm/credentials.js');
+    const { authHeaders, resolveCredentials } = await import('../llm/credentials.js');
     const cred = resolveCredentials(daemonProvider, {
       projectRoot: cwd,
     });
@@ -445,11 +445,14 @@ export async function callLlmDuplicateReasoning(
       candidate.id,
     );
 
-    // Build ModelConfig for the daemon provider
+    // Build ModelConfig for the daemon provider. For OAuth credentials, attach
+    // the Bearer headers via extraHeaders so the registry constructs the SDK
+    // with `authToken` instead of `apiKey` (avoids the 401 from `x-api-key`).
     const modelConfig = {
       transport: daemonProvider,
       model: daemonModel,
       apiKey: cred.apiKey,
+      extraHeaders: cred.authType === 'oauth' ? authHeaders(cred) : undefined,
     };
 
     const { cleoLlmCall } = await import('../llm/api.js');


### PR DESCRIPTION
## Summary

The sentient daemon has been 401-failing every dream/sleep cycle for users whose only Anthropic credential is the Claude Code OAuth token. Tier 3 of the resolver returns a `sk-ant-oat-…` token, which Anthropic only accepts as `Authorization: Bearer …` + `anthropic-beta: oauth-2025-04-20` — but every call-site was sending it as `x-api-key`.

This is **Phase 1** of T-LLM-CRED-CENTRALIZATION: end-to-end fix for OAuth credentials at every Anthropic call-site in `@cleocode/core`. Phase 2 (role routing, credentials store, `cleo llm` CLI) and Phase 3 (plugin registry, OAuth depth, pool failover) follow in separate PRs.

## Changes

- `CredentialResult` gains an `authType: 'api_key' | 'oauth'` field, set from the source tier (`claude-creds` → `oauth`) plus a `sk-ant-oat-*` / `sk-ant-ort-*` prefix heuristic for tokens pasted into env / config.
- `authHeaders(cred)` produces the correct provider-specific auth headers bag. Raw-fetch call-sites spread it instead of hard-coding `x-api-key`.
- `ModelConfig` gains `extraHeaders`; the registry's `getAnthropicOverrideClient` detects OAuth headers and constructs the SDK with `authToken` (Bearer) instead of `apiKey` (x-api-key). **Critical:** the two cannot coexist — the SDK sends both and Anthropic 401s.
- `buildAnthropicSdkClient(cred)` centralises the dynamic-import + constructor dance previously duplicated in `memory/llm-extraction`, `sentient/dream-cycle`, and `deriver/deriver`.

### Files

| File | Change |
|------|--------|
| `packages/contracts/src/operations/llm.ts` | `ModelConfig.extraHeaders` field |
| `packages/core/src/llm/credentials.ts` | `AuthType`, `authType` field, `authHeaders()`, `detectAuthType()` |
| `packages/core/src/llm/registry.ts` | OAuth-aware `getAnthropicOverrideClient`, `buildAnthropicSdkClient()`, `extractBearerToken()` |
| `packages/core/src/llm/index.ts` | Re-exports |
| `packages/core/src/llm/__tests__/credentials-auth-type.test.ts` | **NEW** — 11 tests |
| `packages/core/src/memory/sleep-consolidation.ts` | Raw fetch via `authHeaders(cred)` |
| `packages/core/src/memory/observer-reflector.ts` | Raw fetch via `authHeaders(cred)` |
| `packages/core/src/memory/llm-extraction.ts` | SDK via `buildAnthropicSdkClient` |
| `packages/core/src/sentient/dream-cycle.ts` | SDK via `buildAnthropicSdkClient` |
| `packages/core/src/deriver/deriver.ts` | SDK via `buildAnthropicSdkClient` |
| `packages/core/src/sentient/hygiene-scan.ts` | `modelConfig.extraHeaders` populated |
| `packages/core/src/tasks/duplicate-detector.ts` | `modelConfig.extraHeaders` populated |
| `packages/core/src/memory/__tests__/{sleep,observer,llm-extraction}*.test.ts` | Mock updates |

## Test plan

- [x] `pnpm biome check` — clean on changed packages
- [x] `pnpm exec tsc --noEmit` — zero new errors in changed files (pre-existing `skills/` errors unrelated)
- [x] Vitest — **156/156 pass** across `credentials`, `credentials-auth-type`, `llm-layer`, `sleep-consolidation`, `observer-reflector`, `llm-extraction`, `dream-cycle`, `hygiene-scan`, `deriver-queue`, `duplicate-detector`
- [ ] Live unblock: restart sentient daemon, confirm no new `Anthropic API error 401` in `.cleo/logs/sentient.err` for 30 min
- [ ] Migration safety: existing `ANTHROPIC_API_KEY` env-var users continue to work (`api_key` path)

## Design lock-in

- `AuthType = 'api_key' | 'oauth'` only in Phase 1. Phase 3 widens to add `'aws_sdk'`. Use `switch` + `default: throw` so additions are non-breaking.
- `authType` lives on `CredentialResult` rather than a parallel `ResolvedCredential` type, to avoid two-API migration churn. Phase 2 may rename `apiKey → token` once role resolution lands.
- `resolveAnthropicApiKey()` stays a `string | null` shim forever for backward compat.

https://claude.ai/code/session_01KeqMEc6AU7HxcUiK79HM7n