### PR TITLE
chore(T9246): bump package.json versions to 2026.5.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.62",
+  "version": "2026.5.63",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
Follow-up to release ship 1ad59dd12 (merged via PR #122 at 2cb58d69c).

`cleo release ship` updated CHANGELOG.md but the version bump didn't propagate to package.json files — historically that's a separate step via `node scripts/version-all.mjs --set <version>`.

This PR brings all 21 package.json files (root + 20 workspace packages) from 2026.5.62 → 2026.5.63 to match the v2026.5.63 tag already on main.

Pure version-bump diff: 21 files changed, 21 insertions(+), 21 deletions(-).

Task: T9246

## Test plan
- [ ] CI green (no source-affecting tests — only the structural gates apply)
- [ ] After merge: `cleo --version` reports 2026.5.63