### PR TITLE
chore(T9261): add T-LLM-CRED-CENTRALIZATION epic verifier stub

### DIFF
--- a/scripts/verify-t-llm-cred-centralization.mjs
+++ b/scripts/verify-t-llm-cred-centralization.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// Verifier stub for T-LLM-CRED-CENTRALIZATION epic.
+// This epic is a roll-up — concrete acceptance lives in the child tasks:
+//   - T9246 Phase 1 (OAuth Bearer auth, shipped PR #120)
+//   - T9255 Phase 2 T-llm-1 (role-resolver + 7 call-sites)
+//   - T9256 Phase 2 T-llm-2 (LlmConfig.default + roles + RoleName)
+//   - T9257 Phase 2 T-llm-3 (credentials-store)
+//   - T9258 Phase 2 T-llm-4 (cleo llm CLI)
+//   - T9259 Phase 2 T-llm-5 (Phase 2 tests)
+//   - T9260 Phase 3 RCASD (Hermes-port plugin registry, deferred)
+// Child verifications carry the real evidence. Backfill with concrete
+// rollup checks via `cleo verify backfill <epic-id>` once Phase 3 ships.
+console.error(
+  'T-LLM-CRED-CENTRALIZATION epic verifier stub — child tasks carry concrete evidence. ' +
+    'Replace via `cleo verify backfill <epic-id>` to enforce rollup gates.',
+);
+process.exit(1);


### PR DESCRIPTION
Stub verifier referenced by the T9261 T-LLM-CRED-CENTRALIZATION epic (rollup of T9246 Phase 1 + T9255-T9259 Phase 2 + T9260 Phase 3). Concrete acceptance lives in child tasks; this stub satisfies ADR-070's requirement that type=epic tasks have a verifier path. Will be backfilled via `cleo verify backfill T9261` once Phase 3 ships.

Task: T9246, T9261

## Test plan
- [ ] CI green (no-op stub script)
- [ ] After merge: `cleo show T9261` resolves verifier from main