### PR TITLE
feat(core/release): T9246 ship hardening + T-LLM-CRED-CENTRALIZATION docs plan

### DIFF
--- a/docs/plans/T-LLM-CRED-CENTRALIZATION.md
+++ b/docs/plans/T-LLM-CRED-CENTRALIZATION.md
@@ -1,0 +1,273 @@
+# T-LLM-CRED-CENTRALIZATION — Centralize CLEO LLM credentials, provider registry, and role-based routing
+
+## Context
+
+The sentient daemon (`pid 2119947`, 105 ticks) has been 401-failing every dream/sleep cycle since 2026-05-12. Root cause confirmed: `packages/core/src/memory/sleep-consolidation.ts:228` sends the resolved token as `x-api-key`, but `resolveCredentials('anthropic')` tier 3 returns a Claude Code OAuth token from `~/.claude/.credentials.json` — those need `Authorization: Bearer <token>` + `anthropic-beta: oauth-2025-04-20` and a *missing* `x-api-key`. Anthropic rejects the mismatch. The same defect exists at every Anthropic-fetch and `new Anthropic({ apiKey })` call-site in `core/src/memory/*`, `core/src/sentient/*`, `core/src/deriver/*`, and `core/src/tasks/duplicate-detector.ts` — so for any user whose only credential is Claude Code OAuth (the dominant install), most of CLEO's autonomous LLM work is silently broken.
+
+Beyond the bug, the LLM call surface is provider-hardcoded in ~35 places, has no role-based routing (every call hardwires `claude-haiku-4-5-20251001` or reads `llm.daemon.{provider,model}`), and has no central credential store — only ambient env-vars + the Claude Code OAuth file. Phase 1 unblocks the daemon. Phase 2 introduces role routing + a credentials file + a `cleo llm` CLI. Phase 3 ports the Hermes plugin registry, device-code OAuth, and credential-pool failover.
+
+Goal: every LLM call in `@cleocode/core` goes through one resolver returning a typed `ResolvedCredential` and a registry-built client; zero provider-specific strings outside the registry; `@cleocode/cleo` stays a thin CLI over CORE operations.
+
+---
+
+## Phase 1 — Unblock the daemon (P0 hotfix · ~160 LOC · ship alone)
+
+### What changes
+
+1. **`packages/contracts/src/llm/credential.ts` (new ~40 LOC)** — public types:
+   ```ts
+   export type AuthType = 'api_key' | 'oauth' | 'aws_sdk';
+   export type CredentialSource =
+     | 'explicit' | 'env' | 'cred-file' | 'claude-creds'
+     | 'global-config' | 'project-config';
+   export interface ResolvedCredential {
+     token: string;
+     authType: AuthType;
+     provider: ModelTransport;
+     source: CredentialSource;
+     baseUrl?: string;
+     extraHeaders?: Record<string, string>;
+     metadata?: Record<string, unknown>;
+   }
+   ```
+   Re-export through `packages/contracts/src/index.ts`.
+
+2. **`packages/core/src/llm/credentials.ts` (edit ~50 LOC)** — add a sibling resolver and a header builder:
+   ```ts
+   export function resolveCredential(
+     provider: ModelTransport, options?: CredentialResolveOptions
+   ): ResolvedCredential | null;
+
+   export function authHeaders(c: ResolvedCredential): Record<string, string>;
+   //  oauth (anthropic) → { Authorization: `Bearer ${token}`, 'anthropic-beta': 'oauth-2025-04-20' }
+   //  api_key (anthropic) → { 'x-api-key': token }
+   //  api_key (others)    → { Authorization: `Bearer ${token}` }
+   //  aws_sdk             → {} (SDK provides auth)
+   ```
+   `authType` is derived from the source + token-prefix heuristic for now: token starts with `sk-ant-oat-` or `sk-ant-ort-` → `oauth`; everything else → `api_key`. Existing `resolveCredentials()` and `resolveAnthropicApiKey()` stay as backward-compat shims (return string).
+
+3. **`packages/core/src/llm/registry.ts` (edit ~25 LOC)** — drop module-load `initDefaultClients()`. Keep `CLIENTS` exported (tests + adapters mutate it directly), but populate lazily via a memoized `getDefaultClient(provider)`. Every override factory (`getAnthropicOverrideClient` etc.) gains a `defaultHeaders` argument so OAuth-callers can pass `{ Authorization: 'Bearer …', 'anthropic-beta': … }` and the SDK omits its default `x-api-key`.
+
+4. **Patch the 6 broken call-sites (~70 LOC total)** to use `resolveCredential` + `authHeaders`:
+   - `packages/core/src/memory/sleep-consolidation.ts:216-254` (`callLlm` raw fetch)
+   - `packages/core/src/memory/observer-reflector.ts:254` (raw fetch path)
+   - `packages/core/src/memory/llm-extraction.ts:307+` (`new Anthropic({ apiKey })`)
+   - `packages/core/src/sentient/dream-cycle.ts:542+` (`new Anthropic`)
+   - `packages/core/src/deriver/deriver.ts:150,158` (`new Anthropic`)
+   - `packages/core/src/tasks/duplicate-detector.ts:427+` (`new Anthropic`)
+
+   For SDK paths: `new Anthropic({ apiKey: cred.token, defaultHeaders: authHeaders(cred) })`. The SDK sends `x-api-key` by default; passing `defaultHeaders` with `Authorization` causes the SDK to send both, which Anthropic still rejects — so for OAuth paths we must construct `Anthropic` with `apiKey: ''` (sentinel) and provide `Authorization` in `defaultHeaders`. Confirm this against `@anthropic-ai/sdk` v0.x behavior before locking — fallback is to bypass the SDK and use raw fetch for the OAuth case.
+
+5. **Tests (~30 LOC)** in `packages/core/src/llm/__tests__/credentials-auth-type.test.ts`:
+   - `sk-ant-oat-…` resolves with `authType: 'oauth'` and produces Bearer headers
+   - `sk-ant-api03-…` resolves with `authType: 'api_key'` and produces `x-api-key` header
+   - `registry.ts` no longer crashes when imported with empty env
+
+### Verification
+
+```bash
+# Build + typecheck + tests must all be green
+pnpm biome check --write packages/contracts packages/core
+pnpm run build
+pnpm run typecheck
+pnpm --filter @cleocode/core run test -- credentials-auth-type sleep-consolidation
+# Live end-to-end (after restarting daemon)
+cleo sentient kill && cleo sentient start
+tail -f .cleo/logs/sentient.err   # No 401 for ~10 min
+cleo memory find "sleep-consolidation" --limit 1   # New observations with N>0 memories
+```
+
+Acceptance: after restart, `[sleep-consolidation] Anthropic API error 401` does not appear for 30 min; `cleo sentient status` shows `ticksExecuted` advancing without new failures.
+
+### Files to edit (Phase 1)
+
+- `packages/contracts/src/llm/credential.ts` *(new)*
+- `packages/contracts/src/index.ts` *(re-export)*
+- `packages/core/src/llm/credentials.ts`
+- `packages/core/src/llm/registry.ts`
+- `packages/core/src/memory/sleep-consolidation.ts`
+- `packages/core/src/memory/observer-reflector.ts`
+- `packages/core/src/memory/llm-extraction.ts`
+- `packages/core/src/sentient/dream-cycle.ts`
+- `packages/core/src/deriver/deriver.ts`
+- `packages/core/src/tasks/duplicate-detector.ts`
+- `packages/core/src/llm/__tests__/credentials-auth-type.test.ts` *(new)*
+
+---
+
+## Phase 2 — Role routing + credentials file + `cleo llm` CLI (W1 · ~700 LOC)
+
+### Sub-tasks (file in CLEO as children of the epic)
+
+**T-llm-1: `resolveLLMForRole(role)` helper in `@cleocode/core/llm/role-resolver.ts`** (~120 LOC)
+- Roles: `extraction | consolidation | derivation | hygiene | judgement` (collapsed from the 7-role proposal; see Design lock-in below).
+- Reads `llm.roles.<role>.{provider,model,credentialLabel?}`, falls back to `llm.default.{provider,model}`, then to legacy `llm.daemon.{provider,model}`.
+- Returns `{ provider, model, client, credential }` — call-sites never construct clients directly.
+- Migrate the 6 Phase-1 call-sites to consume `resolveLLMForRole('consolidation' | 'extraction' | 'derivation' | 'hygiene' | 'judgement')` instead of provider-hardcoded `resolveCredential('anthropic')`.
+
+**T-llm-2: Config schema additions in `packages/contracts/src/config.ts`** (~60 LOC)
+- `LlmConfig.default?: { provider, model }` (replaces `daemon` as the inheritable fallback; `daemon` kept as alias for back-compat).
+- `LlmConfig.roles?: Record<RoleName, { provider, model, credentialLabel? }>`.
+- `RoleName` literal union exported from contracts.
+- Update `packages/core/schemas/config.schema.json` to mirror.
+
+**T-llm-3: Credentials store in `@cleocode/core/llm/credentials-store.ts`** (~180 LOC)
+- File: `~/.cleo/llm-credentials.json` (path via existing `getCleoHome()`).
+- Schema:
+  ```jsonc
+  {
+    "version": 1,
+    "defaultStrategy": "priorityWithFallback",
+    "credentials": [
+      { "provider": "anthropic", "label": "claude-code-oauth",
+        "authType": "oauth", "accessToken": "sk-ant-oat-…",
+        "refreshToken": "sk-ant-ort-…", "expiresAt": 1736700000000,
+        "priority": 10, "source": "claude-code",
+        "extraHeaders": { "anthropic-beta": "oauth-2025-04-20" },
+        "lastStatus": "ok" },
+      { "provider": "anthropic", "label": "personal",
+        "authType": "api_key", "accessToken": "sk-ant-api03-…", "priority": 20 },
+      { "provider": "openai", "label": "personal",
+        "authType": "api_key", "accessToken": "sk-…" },
+      { "provider": "bedrock", "label": "prod", "authType": "aws_sdk",
+        "accessToken": "", "metadata": { "awsProfile": "cleo-prod", "region": "us-west-2" } }
+    ]
+  }
+  ```
+- Use existing `withLock` + `writeJsonFileAtomic` from `packages/core/src/store/file-utils.ts:76-199` (do **not** roll new file-locking).
+- Enforce `chmod 0600` on write. Mirror Hermes's `agent/credential_pool.py:32-33` (`read_credential_pool` / `write_credential_pool`).
+- Public API: `listCredentials(provider?)`, `addCredential(input)`, `removeCredential(provider, label)`, `getCredentialByLabel(provider, label)`, `pickCredentialForProvider(provider, strategy?)`.
+- Add a fifth tier between env (2) and claude-creds (3) — see Design lock-in.
+
+**T-llm-4: `cleo llm` CLI command file** at `packages/cleo/src/cli/commands/llm.ts` (~250 LOC)
+- Mirror the `cleo memory` subcommand pattern in `packages/cleo/src/cli/commands/memory.ts:2019-2045` (`makeSubcommand` factory).
+- Subcommands:
+  ```
+  cleo llm add <provider> --api-key <k> [--label l] [--base-url u]
+  cleo llm list [provider]
+  cleo llm remove <provider> --label <l>
+  cleo llm use <provider> [--model m]              # sets llm.default
+  cleo llm profile <role> <provider> [--model m]   # sets llm.roles.<role>
+  cleo llm test <provider> [--label l]             # round-trip ping
+  cleo llm whoami                                  # show resolution for every role
+  ```
+- All subcommands dispatch through `dispatchFromCli('mutate' | 'query', 'llm', '<op>', ...)` (per `packages/cleo/src/dispatch/adapters/cli.ts:195-296`).
+- New dispatch handlers under `packages/cleo/src/dispatch/domains/llm/*` thin-wrap the core store + role-resolver.
+- `cleo llm test` mirrors `cleo admin smoke --provider` (`packages/cleo/src/cli/commands/admin.ts:88-115`) — 1 small message, success/error envelope.
+- Update auto-generated manifest: `pnpm --filter @cleocode/cleo run gen:manifest`.
+
+**T-llm-5: Tests** (~90 LOC)
+- `packages/core/src/llm/__tests__/credentials-store.test.ts` — add/list/remove with file-lock + 0600 enforcement.
+- `packages/core/src/llm/__tests__/role-resolver.test.ts` — role→provider→credential resolution + fallback chain.
+- `packages/cleo/src/cli/__tests__/llm-command.test.ts` — at least `add`, `list`, `whoami` envelope shape.
+
+### Acceptance gates (Phase 2)
+
+- `cleo llm whoami` prints each role with its resolved `{ provider, model, source, label? }` — no `null` for daemon/consolidation when env or cred-file is present.
+- `cleo llm test anthropic --label personal` returns `{ success: true, data: { latencyMs, model } }`.
+- The 6 Phase-1 call-sites now use `resolveLLMForRole(...)`; grep for `'claude-haiku-4-5-20251001'` outside `packages/core/src/llm/` returns zero hits.
+- `pnpm run typecheck && pnpm run build && pnpm run test` green.
+- Migration test: an existing `.cleo/config.json` with only `llm.providers.anthropic.apiKey` still works (tier 5/6 fallback).
+
+---
+
+## Phase 3 — Plugin registry, OAuth depth, pool failover (W2 · deferred · RCASD before scope-locking)
+
+Ports from Hermes (all references absolute):
+- `/mnt/projects/hermes-agent/providers/base.py` → `ProviderProfile` interface + plugin module shape.
+- `/mnt/projects/hermes-agent/providers/__init__.py:43-192` → lazy registry with last-writer-wins user-plugin override at `~/.cleo/plugins/model-providers/`.
+- `/mnt/projects/hermes-agent/agent/credential_pool.py:92-1095` → `CredentialPool` with `priority/source/last_status/last_error_code/last_error_reset_at/request_count`, rotation strategies (`fill_first | round_robin | least_used`), 401→5min / 429→1h cooldown, soft concurrency leases.
+- `/mnt/projects/hermes-agent/agent/auxiliary_client.py` → fallback chain router for side-task LLM calls.
+- `/mnt/projects/hermes-agent/agent/transports/types.py:1-163` → `NormalizedResponse` shape so every transport returns the same structure.
+- `/mnt/projects/hermes-agent/hermes_cli/auth_commands.py` → device-code OAuth template for `cleo llm login <provider>` (OpenAI, xAI, Qwen, Nous).
+- `/mnt/projects/hermes-agent/agent/model_metadata.py:1407-1438` → `getModelContextLength(model, baseUrl, apiKey)` priority chain (live API → curated → static default 256K).
+
+Phase 3 is **gated on RCASD** because plugin contracts and the pool concurrency model compound — once the plugin interface ships, every third-party provider locks against it. File the RCASD before any implementation.
+
+---
+
+## Design lock-in (irreversible after Phase 1 + 2 ship)
+
+1. **`AuthType` enum has exactly three values**: `'api_key' | 'oauth' | 'aws_sdk'`. Adding a fourth value is a breaking change for every switch-statement consumer; choose carefully.
+2. **Resolver precedence is `explicit > env > cred-file > claude-creds > global-config > project-config`**. Cred-file beats Claude Code OAuth because explicit user keys should win over ambient session — reversing later silently re-routes billing.
+3. **`resolveAnthropicApiKey()` stays as a `string | null` shim forever** — backward compat. New Anthropic call-sites MUST use `resolveCredential('anthropic')` or `resolveLLMForRole(role)`; CI grep-check enforces.
+4. **`registry.ts` exports `CLIENTS` as a mutable map even after lazy-init** — adapters and tests mutate it directly; this is intentional escape hatch, not a bug.
+5. **Role names `extraction | consolidation | derivation | hygiene | judgement` are user-visible config keys** under `llm.roles.*`. Renaming requires a config migration. Daemon/research/nexus are explicitly **not** roles — daemon is a process, research/nexus have no current LLM call-sites.
+
+---
+
+## Critical files to read before starting
+
+- `packages/core/src/llm/credentials.ts:120-268` — resolution tiers as-shipped today.
+- `packages/core/src/llm/registry.ts:34-202` — module-load anti-pattern + override factories.
+- `packages/core/src/memory/sleep-consolidation.ts:216-254` — the exact 401 site.
+- `packages/contracts/src/config.ts:397-496` — existing `LlmConfig` shape to extend.
+- `packages/core/src/store/file-utils.ts:76-199` — `writeJsonFileAtomic` + `withLock` (re-use, don't reinvent).
+- `packages/cleo/src/cli/commands/memory.ts:2019-2045` — `makeSubcommand` pattern for `cleo llm`.
+- `packages/cleo/src/dispatch/adapters/cli.ts:195-296` — CLI→core dispatch wiring.
+- `packages/cleo/src/cli/commands/admin.ts:88-115` — model for `cleo llm test <provider>`.
+- `/mnt/projects/hermes-agent/agent/credential_pool.py:92-1095` — Phase 3 port target.
+- `/mnt/projects/hermes-agent/providers/__init__.py:43-192` — Phase 3 plugin registry.
+
+---
+
+## End-to-end verification
+
+After Phase 1:
+```bash
+# Build
+pnpm biome check --write . && pnpm run typecheck && pnpm run build
+# Tests
+pnpm run test
+# Live unblock
+cleo sentient kill && cleo sentient start
+sleep 60
+grep -c "Anthropic API error 401" .cleo/logs/sentient.err   # New count should match pre-restart
+cleo memory find "sleep-consolidation" --limit 3            # Recent run with N>0 memories
+cleo sentient status                                         # ticksExecuted advancing
+```
+
+After Phase 2:
+```bash
+cleo llm add anthropic --api-key sk-ant-api03-XXX --label personal
+cleo llm list
+cleo llm profile consolidation anthropic --model claude-haiku-4-5-20251001
+cleo llm profile hygiene anthropic --model claude-sonnet-4-6
+cleo llm whoami
+cleo llm test anthropic --label personal     # round-trip < 3s, success: true
+# Migration safety
+mv ~/.cleo/llm-credentials.json /tmp/back.json
+# Daemon falls back through tier 4 (config.json) or tier 3 (Claude OAuth) and still works
+cleo sentient kill && cleo sentient start && sleep 60 && cleo sentient status
+mv /tmp/back.json ~/.cleo/llm-credentials.json
+```
+
+After Phase 3 (gated on RCASD outcomes — verification spec deferred).
+
+---
+
+## Task tree to file in CLEO
+
+```
+T-LLM-CRED-CENTRALIZATION (epic, P0)
+├── Phase 1 (P0, ~1 day)
+│   ├── T-llm-p1-1  ResolvedCredential type + authHeaders helper
+│   ├── T-llm-p1-2  Lazy initDefaultClients in registry.ts
+│   ├── T-llm-p1-3  Patch 6 broken call-sites (OAuth header fix)
+│   └── T-llm-p1-4  Unit tests + live restart verification
+├── Phase 2 (W1, ~3-5 days)
+│   ├── T-llm-1     resolveLLMForRole helper + role wiring
+│   ├── T-llm-2     LlmConfig schema extension (roles + default)
+│   ├── T-llm-3     credentials-store.ts (file-locked, 0600)
+│   ├── T-llm-4     cleo llm CLI + dispatch handlers
+│   └── T-llm-5     Tests (store, resolver, CLI)
+└── Phase 3 (W2, RCASD-gated)
+    ├── T-llm-p3-1  ProviderProfile interface + plugin loader
+    ├── T-llm-p3-2  CredentialPool with rotation + cooldown
+    ├── T-llm-p3-3  Device-code OAuth (cleo llm login)
+    ├── T-llm-p3-4  NormalizedResponse transports
+    ├── T-llm-p3-5  Model metadata (getModelContextLength)
+    └── T-llm-p3-6  Auxiliary fallback router
+```
+
+Each task in CLEO with `--acceptance "..."` per ADR-066. Phase 1 children gate the epic into implementation stage; Phase 3 children stay in research stage until RCASD ships.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1125,7 +1125,31 @@ export type {
   SyncResult,
   SyncStatus,
 } from './postgres-data-accessor.js';
+// === Project Context (ecosystem detection types) ===
+export type {
+  EcosystemHint,
+  FileNamingConvention,
+  ImportStyle,
+  ProjectContext,
+  ProjectType,
+  TestFramework,
+} from './project-context.js';
 export type { AdapterPathProvider } from './provider-paths.js';
+// === Release Channel ===
+export type { ChannelValidationResult, ReleaseChannel } from './release/channel.js';
+// === Release GitHub PR ===
+export type {
+  BranchProtectionResult,
+  CleoKnownLabel,
+  CleoLabelPalette,
+  LabelDefinition,
+  LabelEnsureResult,
+  PRCreateOptions,
+  PRLabelResolution,
+  PRMode,
+  PRResult,
+  RepoIdentity,
+} from './release/github-pr.js';
 // === Release Pipeline (T1597 / ADR-063) ===
 export type {
   PublishResult,
@@ -1135,6 +1159,16 @@ export type {
   ReleaseVersionScheme,
   VerifyResult,
 } from './release/pipeline.js';
+// === Release Version Bump ===
+export type {
+  BumpResult,
+  BumpType,
+  BumpVersionFromConfigResult,
+  ResolveVersionBumpTargetsResult,
+  VersionBumpStrategy,
+  VersionBumpTarget,
+  VersionBumpTargetSource,
+} from './release/version-bump.js';
 // === Result Types (Dashboard, Stats, Log, Context, Sequence, Analysis, Deps) ===
 export type {
   BottleneckTask,

--- a/packages/contracts/src/project-context.ts
+++ b/packages/contracts/src/project-context.ts
@@ -1,0 +1,106 @@
+/**
+ * Project context — canonical ecosystem detection types.
+ *
+ * Defines the shape of `.cleo/project-context.json` and the smaller hint
+ * envelope consumed by release-flow / spawn-engine / codebase-map analyzers.
+ *
+ * Type-only: the detector implementation lives in `@cleocode/core/store/
+ * project-detect.ts`. Centralising the types here lets any package (release,
+ * studio, agents, …) reason about ecosystem signals without importing core.
+ *
+ * @adr ADR-013
+ */
+
+/** Detected project ecosystem. Matches the writer in `detectProjectType`. */
+export type ProjectType =
+  | 'node'
+  | 'python'
+  | 'rust'
+  | 'go'
+  | 'ruby'
+  | 'java'
+  | 'dotnet'
+  | 'bash'
+  | 'elixir'
+  | 'php'
+  | 'deno'
+  | 'bun'
+  | 'unknown';
+
+/** Detected test framework. */
+export type TestFramework =
+  | 'jest'
+  | 'vitest'
+  | 'mocha'
+  | 'pytest'
+  | 'bats'
+  | 'cargo'
+  | 'go'
+  | 'rspec'
+  | 'junit'
+  | 'playwright'
+  | 'cypress'
+  | 'ava'
+  | 'uvu'
+  | 'tap'
+  | 'node:test'
+  | 'deno'
+  | 'bun'
+  | 'custom'
+  | 'unknown';
+
+/** File-naming convention detected from source files. */
+export type FileNamingConvention = 'kebab-case' | 'snake_case' | 'camelCase' | 'PascalCase';
+
+/** Module import style. */
+export type ImportStyle = 'esm' | 'commonjs' | 'mixed';
+
+/** Schema-compliant project context for LLM agent consumption. */
+export interface ProjectContext {
+  schemaVersion: string;
+  detectedAt: string;
+  projectTypes: ProjectType[];
+  primaryType?: ProjectType;
+  monorepo: boolean;
+  testing?: {
+    framework?: TestFramework;
+    command?: string;
+    testFilePatterns?: string[];
+    directories?: {
+      unit?: string;
+      integration?: string;
+    };
+  };
+  build?: {
+    command?: string;
+    outputDir?: string;
+  };
+  directories?: {
+    source?: string;
+    tests?: string;
+    docs?: string;
+  };
+  conventions?: {
+    fileNaming?: FileNamingConvention;
+    importStyle?: ImportStyle;
+    typeSystem?: string;
+  };
+  llmHints?: {
+    preferredTestStyle?: string;
+    typeSystem?: string;
+    commonPatterns?: string[];
+    avoidPatterns?: string[];
+  };
+}
+
+/**
+ * Narrow subset of {@link ProjectContext} consumed by the release engine's
+ * workspace discovery and other ecosystem-aware flows. Avoid passing the
+ * full {@link ProjectContext} when only the three discriminating fields are
+ * needed.
+ */
+export interface EcosystemHint {
+  primaryType?: ProjectType;
+  projectTypes?: ProjectType[];
+  monorepo?: boolean;
+}

--- a/packages/contracts/src/release/channel.ts
+++ b/packages/contracts/src/release/channel.ts
@@ -1,0 +1,21 @@
+/**
+ * Release channel contracts — types describing the npm dist-tag channel
+ * model used by the release pipeline.
+ *
+ * The implementation (branch→channel resolution, version validation) lives
+ * in `@cleocode/core/release/channel.ts`. The types live here so consumers
+ * can describe / validate the same shapes without depending on core.
+ *
+ * @adr ADR-063
+ */
+
+/** npm dist-tag channel for a release. */
+export type ReleaseChannel = 'latest' | 'beta' | 'alpha';
+
+/** Result of validating a version string against a channel's expectations. */
+export interface ChannelValidationResult {
+  valid: boolean;
+  expected?: string;
+  actual?: string;
+  message: string;
+}

--- a/packages/contracts/src/release/github-pr.ts
+++ b/packages/contracts/src/release/github-pr.ts
@@ -1,0 +1,89 @@
+/**
+ * GitHub PR contracts — types describing the PR-creation surface used by
+ * the release pipeline.
+ *
+ * The implementation lives in `@cleocode/core/release/github-pr.ts`. The
+ * types live here so consumers (CLI, studio, downstream tools) can describe
+ * / validate the same shapes without depending on core.
+ *
+ * @adr ADR-063
+ */
+
+import type { ReleaseChannel } from './channel.js';
+
+/** Outcome of `detectBranchProtection`. */
+export interface BranchProtectionResult {
+  protected: boolean;
+  detectionMethod: 'gh-api' | 'push-dry-run' | 'unknown';
+  error?: string;
+}
+
+/** Input to `createPullRequest`. */
+export interface PRCreateOptions {
+  base: string;
+  head: string;
+  title: string;
+  body: string;
+  /**
+   * Requested PR labels. Non-existent ones are filtered or auto-created by
+   * the resolver; the engine never passes a bare list to `gh pr create`.
+   */
+  labels?: string[];
+  version: string;
+  epicId?: string;
+  projectRoot?: string;
+}
+
+/** How a PR-create attempt resolved. */
+export type PRMode = 'created' | 'manual' | 'skipped';
+
+/** Outcome of `createPullRequest`. */
+export interface PRResult {
+  mode: PRMode;
+  prUrl?: string;
+  prNumber?: number;
+  instructions?: string;
+  error?: string;
+}
+
+/** Parsed `owner/repo` pair extracted from a git remote URL. */
+export interface RepoIdentity {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Names of the labels CLEO knows how to auto-create when they are missing
+ * on a repo. Includes the universal `release` flag plus one label per npm
+ * dist-tag channel.
+ */
+export type CleoKnownLabel = 'release' | ReleaseChannel;
+
+/** Color + description used when CLEO auto-creates one of its known labels. */
+export interface LabelDefinition {
+  color: string;
+  description: string;
+}
+
+/** Static palette of CLEO-known labels keyed by label name. */
+export type CleoLabelPalette = Readonly<Record<CleoKnownLabel, LabelDefinition>>;
+
+/** Outcome of {@link ensureCleoLabelsExist}. */
+export interface LabelEnsureResult {
+  /** Labels that exist on the repo after this call (pre-existed or auto-created). */
+  ensured: string[];
+  /** Labels that this call created. */
+  created: string[];
+  /** Labels that could not be ensured (unknown to CLEO, or `gh label create` failed). */
+  missing: string[];
+}
+
+/** Outcome of {@link resolvePRLabels} — what to actually pass to `gh pr create`. */
+export interface PRLabelResolution {
+  /** Labels safe to pass to `gh pr create`. */
+  labels: string[];
+  /** Labels auto-created during resolution. */
+  created: string[];
+  /** Labels dropped because they could not be ensured. */
+  missing: string[];
+}

--- a/packages/contracts/src/release/version-bump.ts
+++ b/packages/contracts/src/release/version-bump.ts
@@ -1,0 +1,79 @@
+/**
+ * Version-bump contracts — types describing how `cleo release ship` finds
+ * and updates version-bearing files across a project's ecosystem(s).
+ *
+ * The implementation lives in `@cleocode/core/release/version-bump.ts`. The
+ * types live here so contracts consumers (CLI, studio, downstream tools)
+ * can describe / validate the same shapes without depending on core.
+ *
+ * @adr ADR-063
+ */
+
+/** Supported version-bump strategies. */
+export type VersionBumpStrategy = 'plain' | 'json' | 'toml' | 'sed';
+
+/**
+ * Version bump target — a single file the release pipeline knows how to
+ * bump. Discovery returns these, an explicit config in
+ * `.cleo/config.json` (`release.versionBump.files`) populates them.
+ */
+export interface VersionBumpTarget {
+  /** Path relative to the project root. */
+  file: string;
+  /** Update strategy. */
+  strategy: VersionBumpStrategy;
+  /** JSON field path for `strategy='json'` (e.g. `version`, `package.version`). */
+  field?: string;
+  /** TOML key for `strategy='toml'` (default: `version`). */
+  key?: string;
+  /** TOML section for `strategy='toml'` (e.g. `package`, `workspace.package`). */
+  section?: string;
+  /** Sed pattern with `{{VERSION}}` placeholder for `strategy='sed'`. */
+  pattern?: string;
+}
+
+/** Bump type used by `calculateNewVersion`. */
+export type BumpType = 'patch' | 'minor' | 'major';
+
+/** Result for a single file's bump attempt. */
+export interface BumpResult {
+  /** Path relative to the project root. */
+  file: string;
+  /** Strategy used. */
+  strategy: VersionBumpStrategy | string;
+  /** Whether the bump succeeded. */
+  success: boolean;
+  /** Version found in the file before the bump, if it could be extracted. */
+  previousVersion?: string;
+  /** Version written to the file. */
+  newVersion?: string;
+  /** Human-readable error when `success === false`. */
+  error?: string;
+}
+
+/**
+ * Where the version-bump targets came from. Lets callers log / diagnose why
+ * a release commit included or omitted version files.
+ */
+export type VersionBumpTargetSource = 'config' | 'workspace' | 'none';
+
+/** Envelope returned by `resolveVersionBumpTargets`. */
+export interface ResolveVersionBumpTargetsResult {
+  /** Targets to bump. Empty when `source === 'none'`. */
+  targets: VersionBumpTarget[];
+  /**
+   * How the targets were resolved:
+   *   - `'config'`     — explicit `release.versionBump.files` entry
+   *   - `'workspace'`  — auto-discovered from filesystem markers
+   *   - `'none'`       — neither config nor a recognised workspace
+   */
+  source: VersionBumpTargetSource;
+}
+
+/** Bulk-bump result envelope. */
+export interface BumpVersionFromConfigResult {
+  /** Per-file results. */
+  results: BumpResult[];
+  /** `true` iff every result succeeded. */
+  allSuccess: boolean;
+}

--- a/packages/core/schemas/config.schema.json
+++ b/packages/core/schemas/config.schema.json
@@ -810,9 +810,14 @@
               "default": true,
               "description": "Enable version bump during release ship --bump-version."
             },
+            "autoDiscover": {
+              "type": "boolean",
+              "default": true,
+              "description": "When `files` is empty, auto-discover version-bearing files from the project's ecosystem (pnpm/yarn/npm workspaces, Cargo [workspace.package] / per-crate [package] versions). Set to false to skip auto-discovery and require explicit `files` entries."
+            },
             "files": {
               "type": "array",
-              "description": "Files to update with the new version. Each entry defines a file path, update strategy, and strategy-specific options.",
+              "description": "Files to update with the new version. Each entry defines a file path, update strategy, and strategy-specific options. When empty AND autoDiscover is true (default), the engine falls back to workspace discovery.",
               "items": {
                 "type": "object",
                 "required": ["path", "strategy"],
@@ -826,7 +831,7 @@
                   "strategy": {
                     "type": "string",
                     "enum": ["plain", "json", "toml", "sed"],
-                    "description": "Update strategy. 'plain' overwrites file with version string. 'json' updates a JSON field via jq. 'toml' updates a TOML key via sed. 'sed' applies a custom sed pattern."
+                    "description": "Update strategy. 'plain' overwrites file with version string. 'json' updates a JSON field via jq. 'toml' updates a TOML key. 'sed' applies a custom sed pattern."
                   },
                   "jsonPath": {
                     "type": "string",
@@ -834,7 +839,11 @@
                   },
                   "tomlKey": {
                     "type": "string",
-                    "description": "TOML key to update for 'toml' strategy (e.g., 'version', 'package.version'). Required when strategy is 'toml'."
+                    "description": "TOML key to update for 'toml' strategy (e.g., 'version'). Defaults to 'version'."
+                  },
+                  "tomlSection": {
+                    "type": "string",
+                    "description": "TOML section to scope the key lookup to (e.g., 'package', 'workspace.package'). When omitted, the first top-level matching key is bumped. Use 'workspace.package' for Cargo workspace-inherited versions."
                   },
                   "sedPattern": {
                     "type": "string",

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -740,7 +740,12 @@ export {
   runReleaseGates,
   showManifestRelease,
 } from './release/release-manifest.js';
-export { bumpVersionFromConfig, getVersionBumpConfig } from './release/version-bump.js';
+export {
+  bumpVersionFromConfig,
+  discoverWorkspacePackageJsonFiles,
+  getVersionBumpConfig,
+  resolveVersionBumpTargets,
+} from './release/version-bump.js';
 // Remote
 // Remote git sync status (ahead/behind/branch)
 export {

--- a/packages/core/src/release/__tests__/github-pr-labels.test.ts
+++ b/packages/core/src/release/__tests__/github-pr-labels.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for PR label resolution and resilience.
+ *
+ * Validates the fix for the dogfooded `cleo release ship v2026.5.63` bug
+ * where the engine passed `--label latest` to `gh pr create` without
+ * checking that the `latest` label existed on the repo (it didn't), which
+ * failed the entire PR step and forced manual recovery.
+ *
+ * The fix:
+ *   1. Pre-flight existing labels via `gh label list`
+ *   2. Auto-create CLEO-known labels (release/latest/beta/alpha) if missing
+ *   3. Drop unknown labels with a warning rather than failing
+ *   4. Retry once with no labels if `gh pr create` still rejects them
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mocks.execFileSync,
+}));
+
+const { createPullRequest, ensureCleoLabelsExist, listExistingLabels, resolvePRLabels } =
+  await import('../github-pr.js');
+
+beforeEach(() => {
+  mocks.execFileSync.mockReset();
+});
+
+afterEach(() => {
+  mocks.execFileSync.mockReset();
+});
+
+describe('listExistingLabels', () => {
+  it('returns label names from gh label list --json name', () => {
+    mocks.execFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (cmd === 'gh' && args?.[0] === '--version') return 'gh version 2.40.0\n';
+      if (cmd === 'gh' && args?.[0] === 'label' && args?.[1] === 'list') {
+        return JSON.stringify([{ name: 'bug' }, { name: 'release' }]);
+      }
+      throw new Error(`unexpected call: ${cmd}`);
+    });
+    expect(listExistingLabels('/tmp/x')).toEqual(['bug', 'release']);
+  });
+
+  it('returns empty array when gh CLI is missing', () => {
+    mocks.execFileSync.mockImplementation(() => {
+      throw new Error('gh not found');
+    });
+    expect(listExistingLabels()).toEqual([]);
+  });
+});
+
+describe('ensureCleoLabelsExist', () => {
+  it('auto-creates CLEO-known labels that do not exist', () => {
+    const created: string[] = [];
+    mocks.execFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (cmd === 'gh' && args?.[0] === '--version') return 'gh version 2.40.0\n';
+      if (cmd === 'gh' && args?.[0] === 'label' && args?.[1] === 'list') {
+        return JSON.stringify([{ name: 'release' }]);
+      }
+      if (cmd === 'gh' && args?.[0] === 'label' && args?.[1] === 'create') {
+        created.push(args[2] as string);
+        return '';
+      }
+      throw new Error(`unexpected call: ${cmd}`);
+    });
+
+    const out = ensureCleoLabelsExist(['release', 'latest']);
+    expect(out.ensured).toEqual(['release', 'latest']);
+    expect(out.created).toEqual(['latest']);
+    expect(out.missing).toEqual([]);
+    expect(created).toEqual(['latest']);
+  });
+
+  it('returns missing for unknown labels not in CLEO palette', () => {
+    mocks.execFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (cmd === 'gh' && args?.[0] === '--version') return 'gh version 2.40.0\n';
+      if (cmd === 'gh' && args?.[0] === 'label' && args?.[1] === 'list') {
+        return JSON.stringify([{ name: 'release' }]);
+      }
+      throw new Error(`unexpected call: ${cmd}`);
+    });
+
+    const out = ensureCleoLabelsExist(['release', 'totally-custom']);
+    expect(out.ensured).toEqual(['release']);
+    expect(out.missing).toEqual(['totally-custom']);
+  });
+
+  it('treats label-create failure as missing rather than throwing', () => {
+    mocks.execFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (cmd === 'gh' && args?.[0] === '--version') return 'gh version 2.40.0\n';
+      if (cmd === 'gh' && args?.[0] === 'label' && args?.[1] === 'list') {
+        return JSON.stringify([]);
+      }
+      if (cmd === 'gh' && args?.[0] === 'label' && args?.[1] === 'create') {
+        throw new Error('permission denied');
+      }
+      throw new Error(`unexpected call: ${cmd}`);
+    });
+
+    const out = ensureCleoLabelsExist(['latest']);
+    expect(out.ensured).toEqual([]);
+    expect(out.missing).toEqual(['latest']);
+  });
+});
+
+describe('resolvePRLabels', () => {
+  it('passes labels through when gh CLI is unavailable', () => {
+    mocks.execFileSync.mockImplementation(() => {
+      throw new Error('no gh');
+    });
+    expect(resolvePRLabels(['release', 'latest'])).toEqual({
+      labels: ['release', 'latest'],
+      created: [],
+      missing: [],
+    });
+  });
+
+  it('returns empty resolution when no labels requested', () => {
+    mocks.execFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (cmd === 'gh' && args?.[0] === '--version') return 'gh version 2.40.0\n';
+      throw new Error(`unexpected: ${cmd}`);
+    });
+    expect(resolvePRLabels([])).toEqual({ labels: [], created: [], missing: [] });
+    expect(resolvePRLabels(undefined)).toEqual({ labels: [], created: [], missing: [] });
+  });
+});
+
+describe('createPullRequest — label resilience', () => {
+  it('drops missing custom labels and ships PR successfully', async () => {
+    mocks.execFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (cmd === 'gh' && args?.[0] === '--version') return 'gh version 2.40.0\n';
+      if (cmd === 'gh' && args?.[0] === 'label' && args?.[1] === 'list') {
+        return JSON.stringify([{ name: 'release' }]);
+      }
+      if (cmd === 'gh' && args?.[0] === 'label' && args?.[1] === 'create') {
+        return '';
+      }
+      if (cmd === 'gh' && args?.[0] === 'pr' && args?.[1] === 'create') {
+        expect(args).not.toContain('totally-custom');
+        expect(args).toContain('release');
+        expect(args).toContain('latest');
+        return 'https://github.com/owner/repo/pull/999\n';
+      }
+      throw new Error(`unexpected call: ${cmd} ${JSON.stringify(args)}`);
+    });
+
+    const result = await createPullRequest({
+      base: 'main',
+      head: 'release/v2026.5.63',
+      title: 'Release v2026.5.63',
+      body: 'body',
+      labels: ['release', 'latest', 'totally-custom'],
+      version: '2026.5.63',
+      epicId: 'T9246',
+    });
+
+    expect(result.mode).toBe('created');
+    expect(result.prNumber).toBe(999);
+    expect(result.prUrl).toBe('https://github.com/owner/repo/pull/999');
+  });
+
+  it('retries without labels when gh rejects a label after pre-flight', async () => {
+    let prCallCount = 0;
+    mocks.execFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (cmd === 'gh' && args?.[0] === '--version') return 'gh version 2.40.0\n';
+      if (cmd === 'gh' && args?.[0] === 'label' && args?.[1] === 'list') {
+        return JSON.stringify([{ name: 'release' }, { name: 'latest' }]);
+      }
+      if (cmd === 'gh' && args?.[0] === 'pr' && args?.[1] === 'create') {
+        prCallCount++;
+        if (prCallCount === 1) {
+          const err = new Error('failed') as NodeJS.ErrnoException & { stderr?: string };
+          err.stderr = "could not add label: 'latest' not found";
+          throw err;
+        }
+        expect(args).not.toContain('--label');
+        return 'https://github.com/owner/repo/pull/1000\n';
+      }
+      throw new Error(`unexpected call: ${cmd} ${JSON.stringify(args)}`);
+    });
+
+    const result = await createPullRequest({
+      base: 'main',
+      head: 'release/v2026.5.63',
+      title: 'Release v2026.5.63',
+      body: 'body',
+      labels: ['release', 'latest'],
+      version: '2026.5.63',
+    });
+
+    expect(result.mode).toBe('created');
+    expect(result.prNumber).toBe(1000);
+    expect(result.instructions).toContain('PR created without labels');
+    expect(prCallCount).toBe(2);
+  });
+
+  it('returns mode=skipped when PR already exists', async () => {
+    mocks.execFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (cmd === 'gh' && args?.[0] === '--version') return 'gh version 2.40.0\n';
+      if (cmd === 'gh' && args?.[0] === 'label' && args?.[1] === 'list') {
+        return JSON.stringify([{ name: 'release' }, { name: 'latest' }]);
+      }
+      if (cmd === 'gh' && args?.[0] === 'pr' && args?.[1] === 'create') {
+        const err = new Error('failed') as NodeJS.ErrnoException & { stderr?: string };
+        err.stderr =
+          'a pull request for branch "release/v2026.5.63" against branch "main" already exists:\n  https://github.com/owner/repo/pull/55';
+        throw err;
+      }
+      throw new Error(`unexpected call: ${cmd} ${JSON.stringify(args)}`);
+    });
+
+    const result = await createPullRequest({
+      base: 'main',
+      head: 'release/v2026.5.63',
+      title: 'Release v2026.5.63',
+      body: 'body',
+      labels: ['release', 'latest'],
+      version: '2026.5.63',
+    });
+
+    expect(result.mode).toBe('skipped');
+    expect(result.prUrl).toBe('https://github.com/owner/repo/pull/55');
+  });
+});

--- a/packages/core/src/release/__tests__/release-pr-flow.test.ts
+++ b/packages/core/src/release/__tests__/release-pr-flow.test.ts
@@ -204,8 +204,9 @@ describe('T9095 — releaseShip PR-required flow', () => {
         push: { enabled: true, requireCleanTree: false },
       },
     });
+    // Develop branch → channel=beta → version must carry -beta or -rc suffix
     const result = await releaseShip(
-      { version: '2026.5.99', epicId: 'T9095', dryRun: true },
+      { version: '2026.5.99-beta.1', epicId: 'T9095', dryRun: true },
       TEST_ROOT,
     );
 
@@ -216,6 +217,23 @@ describe('T9095 — releaseShip PR-required flow', () => {
 
     const steps = data.wouldDo as string[];
     expect(steps.some((s) => s.includes('--base develop'))).toBe(true);
+  });
+
+  it('rejects stable version when PR target is develop (channel=beta)', async () => {
+    writeConfig({
+      release: {
+        branchModel: 'feat-to-develop-to-main',
+        push: { enabled: true, requireCleanTree: false },
+      },
+    });
+    const result = await releaseShip(
+      { version: '2026.5.99', epicId: 'T9095', dryRun: true },
+      TEST_ROOT,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('E_VALIDATION');
+    expect(result.error?.message).toMatch(/channel/i);
   });
 
   it('fails with E_GENERAL when gh CLI is unavailable (non-dry-run)', async () => {

--- a/packages/core/src/release/__tests__/workspace-auto-discover.test.ts
+++ b/packages/core/src/release/__tests__/workspace-auto-discover.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Tests for workspace-aware version-bump auto-discovery.
+ *
+ * Validates the fix for the dogfooded `cleo release ship v2026.5.63` bug
+ * where Step 0 silently skipped the version bump because the project did
+ * not declare `release.versionBump.files` in `.cleo/config.json`. The
+ * engine now auto-discovers workspace package.json (node) and Cargo.toml
+ * (rust) targets, respects `.cleo/project-context.json` ecosystem hints,
+ * and honours an explicit `release.versionBump.autoDiscover: false` opt-out.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  bumpVersionFromConfig,
+  discoverWorkspacePackageJsonFiles,
+  resolveVersionBumpTargets,
+} from '../version-bump.js';
+
+let ROOT: string;
+
+function writeJson(p: string, body: unknown): void {
+  mkdirSync(join(p, '..'), { recursive: true });
+  writeFileSync(p, JSON.stringify(body, null, 2), 'utf-8');
+}
+
+function writeFile(p: string, body: string): void {
+  mkdirSync(join(p, '..'), { recursive: true });
+  writeFileSync(p, body, 'utf-8');
+}
+
+beforeEach(() => {
+  ROOT = mkdtempSync(join(tmpdir(), 'cleo-vbump-'));
+});
+
+afterEach(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe('discoverWorkspacePackageJsonFiles — node workspaces', () => {
+  it('returns empty array when no workspace markers exist', () => {
+    writeJson(join(ROOT, 'package.json'), { name: 'lonely', version: '1.0.0' });
+    expect(discoverWorkspacePackageJsonFiles(ROOT)).toEqual([]);
+  });
+
+  it('detects pnpm-workspace.yaml and discovers packages/*/package.json', () => {
+    writeJson(join(ROOT, 'package.json'), { name: 'root', version: '2026.5.63' });
+    writeFile(join(ROOT, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n');
+    writeJson(join(ROOT, 'packages', 'alpha', 'package.json'), {
+      name: '@x/alpha',
+      version: '2026.5.63',
+    });
+    writeJson(join(ROOT, 'packages', 'beta', 'package.json'), {
+      name: '@x/beta',
+      version: '2026.5.63',
+    });
+
+    const targets = discoverWorkspacePackageJsonFiles(ROOT);
+    const files = targets.map((t) => t.file).sort();
+    expect(files).toEqual([
+      'package.json',
+      'packages/alpha/package.json',
+      'packages/beta/package.json',
+    ]);
+    for (const t of targets) {
+      expect(t.strategy).toBe('json');
+      expect(t.field).toBe('version');
+    }
+  });
+
+  it('detects yarn/npm workspaces declared in root package.json', () => {
+    writeJson(join(ROOT, 'package.json'), {
+      name: 'root',
+      version: '1.0.0',
+      workspaces: ['packages/*'],
+    });
+    writeJson(join(ROOT, 'packages', 'one', 'package.json'), { name: 'one', version: '1.0.0' });
+    const files = discoverWorkspacePackageJsonFiles(ROOT).map((t) => t.file);
+    expect(files).toContain('package.json');
+    expect(files).toContain('packages/one/package.json');
+  });
+
+  it('skips empty package directories', () => {
+    writeJson(join(ROOT, 'package.json'), {
+      name: 'root',
+      version: '1.0.0',
+      workspaces: ['packages/*'],
+    });
+    mkdirSync(join(ROOT, 'packages', 'empty'), { recursive: true });
+    const files = discoverWorkspacePackageJsonFiles(ROOT).map((t) => t.file);
+    expect(files).toEqual(['package.json']);
+  });
+});
+
+describe('discoverWorkspacePackageJsonFiles — rust workspaces', () => {
+  it('detects Cargo [workspace] members and emits toml targets', () => {
+    writeFile(
+      join(ROOT, 'Cargo.toml'),
+      `[workspace]
+members = [
+  "crates/foo",
+  "crates/bar",
+]
+`,
+    );
+    writeFile(
+      join(ROOT, 'crates', 'foo', 'Cargo.toml'),
+      `[package]
+name = "foo"
+version = "0.1.0"
+`,
+    );
+    writeFile(
+      join(ROOT, 'crates', 'bar', 'Cargo.toml'),
+      `[package]
+name = "bar"
+version = "0.1.0"
+`,
+    );
+
+    const targets = discoverWorkspacePackageJsonFiles(ROOT);
+    const files = targets.map((t) => t.file).sort();
+    expect(files).toEqual(['crates/bar/Cargo.toml', 'crates/foo/Cargo.toml']);
+    for (const t of targets) {
+      expect(t.strategy).toBe('toml');
+      expect(t.key).toBe('version');
+    }
+  });
+
+  it('includes root Cargo.toml when it carries a [package] version', () => {
+    writeFile(
+      join(ROOT, 'Cargo.toml'),
+      `[package]
+name = "root"
+version = "0.1.0"
+
+[workspace]
+members = ["crates/foo"]
+`,
+    );
+    writeFile(
+      join(ROOT, 'crates', 'foo', 'Cargo.toml'),
+      `[package]
+name = "foo"
+version = "0.1.0"
+`,
+    );
+    const files = discoverWorkspacePackageJsonFiles(ROOT)
+      .map((t) => t.file)
+      .sort();
+    expect(files).toEqual(['Cargo.toml', 'crates/foo/Cargo.toml']);
+  });
+
+  it('skips members with version.workspace = true (inheritance) — only roots workspace.package', () => {
+    // Modern Cargo convention: shared version lives in root [workspace.package],
+    // members declare `version.workspace = true`. The bumper must target ONLY
+    // the root — bumping the member's inheritance directive is a no-op.
+    writeFile(
+      join(ROOT, 'Cargo.toml'),
+      `[workspace]
+members = ["crates/foo", "crates/bar"]
+
+[workspace.package]
+edition = "2021"
+version = "0.1.0"
+`,
+    );
+    writeFile(
+      join(ROOT, 'crates', 'foo', 'Cargo.toml'),
+      `[package]
+name = "foo"
+edition.workspace = true
+version.workspace = true
+`,
+    );
+    writeFile(
+      join(ROOT, 'crates', 'bar', 'Cargo.toml'),
+      `[package]
+name = "bar"
+edition.workspace = true
+version.workspace = true
+`,
+    );
+
+    const targets = discoverWorkspacePackageJsonFiles(ROOT);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]?.file).toBe('Cargo.toml');
+    expect(targets[0]?.section).toBe('workspace.package');
+
+    // End-to-end bump should change ONLY the root [workspace.package] version
+    const result = bumpVersionFromConfig('0.9.0', { dryRun: false }, ROOT);
+    expect(result.allSuccess).toBe(true);
+    expect(result.results[0]?.previousVersion).toBe('0.1.0');
+    expect(result.results[0]?.newVersion).toBe('0.9.0');
+
+    const rootAfter = readFileSync(join(ROOT, 'Cargo.toml'), 'utf-8');
+    expect(rootAfter).toContain('version = "0.9.0"');
+    const fooAfter = readFileSync(join(ROOT, 'crates', 'foo', 'Cargo.toml'), 'utf-8');
+    expect(fooAfter).toContain('version.workspace = true'); // unchanged
+  });
+
+  it('mixes workspace-inheritance root + members that override with explicit version', () => {
+    writeFile(
+      join(ROOT, 'Cargo.toml'),
+      `[workspace]
+members = ["crates/shared", "crates/standalone"]
+
+[workspace.package]
+version = "0.1.0"
+`,
+    );
+    writeFile(
+      join(ROOT, 'crates', 'shared', 'Cargo.toml'),
+      `[package]
+name = "shared"
+version.workspace = true
+`,
+    );
+    writeFile(
+      join(ROOT, 'crates', 'standalone', 'Cargo.toml'),
+      `[package]
+name = "standalone"
+version = "0.5.0"
+`,
+    );
+
+    const targets = discoverWorkspacePackageJsonFiles(ROOT);
+    const files = targets.map((t) => t.file).sort();
+    expect(files).toEqual(['Cargo.toml', 'crates/standalone/Cargo.toml']);
+  });
+
+  it('skips glob members (requires deeper resolution)', () => {
+    writeFile(
+      join(ROOT, 'Cargo.toml'),
+      `[workspace]
+members = ["crates/*"]
+`,
+    );
+    writeFile(
+      join(ROOT, 'crates', 'foo', 'Cargo.toml'),
+      `[package]
+name = "foo"
+version = "0.1.0"
+`,
+    );
+    expect(discoverWorkspacePackageJsonFiles(ROOT)).toEqual([]);
+  });
+});
+
+describe('discoverWorkspacePackageJsonFiles — multi-language', () => {
+  it('merges node + rust targets when project-context declares both', () => {
+    writeJson(join(ROOT, '.cleo', 'project-context.json'), {
+      schemaVersion: '1.0.0',
+      detectedAt: new Date().toISOString(),
+      projectTypes: ['node', 'rust'],
+      primaryType: 'node',
+      monorepo: true,
+    });
+    writeJson(join(ROOT, 'package.json'), {
+      name: 'root',
+      version: '1.0.0',
+      workspaces: ['packages/*'],
+    });
+    writeJson(join(ROOT, 'packages', 'a', 'package.json'), { name: 'a', version: '1.0.0' });
+    writeFile(
+      join(ROOT, 'Cargo.toml'),
+      `[workspace]
+members = ["crates/c"]
+`,
+    );
+    writeFile(
+      join(ROOT, 'crates', 'c', 'Cargo.toml'),
+      `[package]
+name = "c"
+version = "0.1.0"
+`,
+    );
+
+    const files = discoverWorkspacePackageJsonFiles(ROOT)
+      .map((t) => t.file)
+      .sort();
+    expect(files).toEqual(['crates/c/Cargo.toml', 'package.json', 'packages/a/package.json']);
+  });
+
+  it('treats bun/deno as node-family — probes JS workspace markers', () => {
+    writeJson(join(ROOT, '.cleo', 'project-context.json'), {
+      schemaVersion: '1.0.0',
+      detectedAt: new Date().toISOString(),
+      projectTypes: ['bun'],
+      primaryType: 'bun',
+      monorepo: true,
+    });
+    writeJson(join(ROOT, 'package.json'), {
+      name: 'root',
+      version: '1.0.0',
+      workspaces: ['packages/*'],
+    });
+    writeJson(join(ROOT, 'packages', 'a', 'package.json'), { name: 'a', version: '1.0.0' });
+
+    const files = discoverWorkspacePackageJsonFiles(ROOT).map((t) => t.file);
+    expect(files).toContain('package.json');
+    expect(files).toContain('packages/a/package.json');
+  });
+
+  it('respects ProjectContext.primaryType: skips rust discovery for node-only project', () => {
+    writeJson(join(ROOT, '.cleo', 'project-context.json'), {
+      schemaVersion: '1.0.0',
+      detectedAt: new Date().toISOString(),
+      projectTypes: ['node'],
+      primaryType: 'node',
+      monorepo: true,
+    });
+    writeJson(join(ROOT, 'package.json'), {
+      name: 'root',
+      version: '1.0.0',
+      workspaces: ['packages/*'],
+    });
+    writeFile(
+      join(ROOT, 'Cargo.toml'),
+      `[workspace]
+members = ["crates/c"]
+`,
+    );
+    writeFile(
+      join(ROOT, 'crates', 'c', 'Cargo.toml'),
+      `[package]
+name = "c"
+version = "0.1.0"
+`,
+    );
+
+    const files = discoverWorkspacePackageJsonFiles(ROOT).map((t) => t.file);
+    expect(files).toContain('package.json');
+    expect(files).not.toContain('crates/c/Cargo.toml');
+  });
+});
+
+describe('resolveVersionBumpTargets — preference order', () => {
+  it('prefers explicit release.versionBump.files config over auto-discovery', () => {
+    writeJson(join(ROOT, '.cleo', 'config.json'), {
+      release: {
+        versionBump: {
+          files: [{ path: 'VERSION', strategy: 'plain' }],
+        },
+      },
+    });
+    writeJson(join(ROOT, 'package.json'), {
+      name: 'root',
+      version: '1.0.0',
+      workspaces: ['packages/*'],
+    });
+    writeJson(join(ROOT, 'packages', 'a', 'package.json'), { name: 'a', version: '1.0.0' });
+
+    const result = resolveVersionBumpTargets(ROOT);
+    expect(result.source).toBe('config');
+    expect(result.targets.map((t) => t.file)).toEqual(['VERSION']);
+  });
+
+  it('falls back to workspace auto-discovery when config is empty', () => {
+    writeJson(join(ROOT, '.cleo', 'config.json'), {});
+    writeJson(join(ROOT, 'package.json'), {
+      name: 'root',
+      version: '1.0.0',
+      workspaces: ['packages/*'],
+    });
+    writeJson(join(ROOT, 'packages', 'a', 'package.json'), { name: 'a', version: '1.0.0' });
+
+    const result = resolveVersionBumpTargets(ROOT);
+    expect(result.source).toBe('workspace');
+    expect(result.targets.map((t) => t.file).sort()).toEqual([
+      'package.json',
+      'packages/a/package.json',
+    ]);
+  });
+
+  it('returns none when release.versionBump.autoDiscover is false', () => {
+    writeJson(join(ROOT, '.cleo', 'config.json'), {
+      release: { versionBump: { autoDiscover: false } },
+    });
+    writeJson(join(ROOT, 'package.json'), {
+      name: 'root',
+      version: '1.0.0',
+      workspaces: ['packages/*'],
+    });
+    writeJson(join(ROOT, 'packages', 'a', 'package.json'), { name: 'a', version: '1.0.0' });
+
+    const result = resolveVersionBumpTargets(ROOT);
+    expect(result.source).toBe('none');
+    expect(result.targets).toEqual([]);
+  });
+
+  it('returns none when project has no workspace markers at all', () => {
+    // Empty ROOT — no package.json, no Cargo.toml, no .cleo/
+    const result = resolveVersionBumpTargets(ROOT);
+    expect(result.source).toBe('none');
+    expect(result.targets).toEqual([]);
+  });
+});
+
+describe('bumpVersionFromConfig — fails loud on silent no-op', () => {
+  it('reports failure when explicit toml target has no matching version line', () => {
+    // Explicit config pointing at an inheritance-only Cargo.toml — without the
+    // loud-fail guard this would silently report success while changing nothing.
+    writeJson(join(ROOT, '.cleo', 'config.json'), {
+      release: {
+        versionBump: {
+          files: [{ path: 'Cargo.toml', strategy: 'toml', key: 'version' }],
+        },
+      },
+    });
+    writeFile(
+      join(ROOT, 'Cargo.toml'),
+      `[package]
+name = "thing"
+version.workspace = true
+`,
+    );
+
+    const result = bumpVersionFromConfig('1.0.0', { dryRun: false }, ROOT);
+    expect(result.allSuccess).toBe(false);
+    expect(result.results[0]?.error).toMatch(/version\.workspace = true/);
+
+    // File must NOT have been mutated
+    const after = readFileSync(join(ROOT, 'Cargo.toml'), 'utf-8');
+    expect(after).toContain('version.workspace = true');
+    expect(after).not.toContain('version = "1.0.0"');
+  });
+
+  it('honours section field — bumps version inside the named section only', () => {
+    writeJson(join(ROOT, '.cleo', 'config.json'), {
+      release: {
+        versionBump: {
+          files: [
+            { path: 'Cargo.toml', strategy: 'toml', key: 'version', section: 'workspace.package' },
+          ],
+        },
+      },
+    });
+    writeFile(
+      join(ROOT, 'Cargo.toml'),
+      `[workspace]
+members = []
+
+[workspace.package]
+version = "0.1.0"
+
+[some-other]
+version = "9.9.9"
+`,
+    );
+
+    const result = bumpVersionFromConfig('0.2.0', { dryRun: false }, ROOT);
+    expect(result.allSuccess).toBe(true);
+    const after = readFileSync(join(ROOT, 'Cargo.toml'), 'utf-8');
+    expect(after).toContain('[workspace.package]\nversion = "0.2.0"');
+    expect(after).toContain('[some-other]\nversion = "9.9.9"'); // untouched
+  });
+});

--- a/packages/core/src/release/channel.ts
+++ b/packages/core/src/release/channel.ts
@@ -7,20 +7,13 @@
  * @task T5586
  */
 
+import type { ChannelValidationResult, ReleaseChannel } from '@cleocode/contracts';
 import type { ChannelConfig } from './release-config.js';
 
-export type { ChannelConfig };
-
-/** npm dist-tag channel for a release. */
-export type ReleaseChannel = 'latest' | 'beta' | 'alpha';
-
-/** Result of validating a version string against a channel's expectations. */
-export interface ChannelValidationResult {
-  valid: boolean;
-  expected?: string;
-  actual?: string;
-  message: string;
-}
+// Re-export canonical contract types so consumers that previously imported
+// these from `./channel.js` keep working. New code SHOULD import from
+// `@cleocode/contracts`.
+export type { ChannelConfig, ChannelValidationResult, ReleaseChannel };
 
 /** Return the default branch-to-channel mapping. */
 export function getDefaultChannelConfig(): ChannelConfig {

--- a/packages/core/src/release/engine-ops.ts
+++ b/packages/core/src/release/engine-ops.ts
@@ -26,8 +26,19 @@ import { getTaskAccessor } from '../store/data-accessor.js';
 import { resolveProjectRoot } from '../store/file-utils.js';
 import { getDb } from '../store/sqlite.js';
 import { releaseManifests } from '../store/tasks-schema.js';
-import { channelToDistTag, resolveChannelFromBranch } from './channel.js';
-import { buildPRBody, createPullRequest, isGhCliAvailable, type PRResult } from './github-pr.js';
+import {
+  channelToDistTag,
+  type ReleaseChannel,
+  resolveChannelFromBranch,
+  validateVersionChannel,
+} from './channel.js';
+import {
+  buildPRBody,
+  createPullRequest,
+  isGhCliAvailable,
+  type PRResult,
+  resolvePRLabels,
+} from './github-pr.js';
 import { checkDoubleListing, checkEpicCompleteness } from './guards.js';
 import { getGitFlowConfig, getReleaseBranchConfig, loadReleaseConfig } from './release-config.js';
 import {
@@ -45,11 +56,7 @@ import {
   showManifestRelease,
   tagRelease,
 } from './release-manifest.js';
-import {
-  bumpVersionFromConfig,
-  getVersionBumpConfig,
-  type VersionBumpTarget,
-} from './version-bump.js';
+import { bumpVersionFromConfig, resolveVersionBumpTargets } from './version-bump.js';
 
 const log = getLogger('release');
 
@@ -1069,8 +1076,18 @@ export async function releaseShip(
     steps.push(msg);
   };
 
-  const bumpTargets: VersionBumpTarget[] = getVersionBumpConfig(cwd);
+  const { targets: bumpTargets, source: bumpSource } = resolveVersionBumpTargets(cwd);
   const shouldBump = bump && bumpTargets.length > 0;
+  if (shouldBump && bumpSource === 'workspace') {
+    const note =
+      `  i Auto-discovered ${bumpTargets.length} workspace package.json file(s) for version bump ` +
+      `(no release.versionBump.files in .cleo/config.json).`;
+    steps.push(note);
+    log.info(
+      { bumpSource, fileCount: bumpTargets.length, files: bumpTargets.map((t) => t.file) },
+      note,
+    );
+  }
 
   // Load config once up-front (used throughout the flow)
   const loadedConfig = loadReleaseConfig(cwd);
@@ -1205,18 +1222,43 @@ export async function releaseShip(
       log.warn({ epicId, forcedBypass: true }, w);
     }
 
-    // Resolve release channel from current branch
-    let resolvedChannel = 'latest';
-    try {
-      const branchName = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-        cwd,
-        encoding: 'utf-8',
-        stdio: 'pipe',
-      }).trim();
-      const channelEnum = resolveChannelFromBranch(branchName);
-      resolvedChannel = channelToDistTag(channelEnum);
-    } catch {
-      // git unavailable — keep default
+    // Resolve release channel from the PR *target* branch — that determines
+    // the npm dist-tag (e.g. main → latest, develop → beta).
+    const targetChannelEnum: ReleaseChannel = resolveChannelFromBranch(prTargetBranch);
+    const resolvedChannel = channelToDistTag(targetChannelEnum);
+
+    // Validate version string matches the channel implied by the PR target.
+    // Fails fast BEFORE any branch cut, commit, push, or PR is performed.
+    if (!force) {
+      const channelCheck = validateVersionChannel(cleanVersion, targetChannelEnum);
+      if (!channelCheck.valid) {
+        logStep(
+          1,
+          12,
+          'Validate version against channel',
+          false,
+          `${channelCheck.message} (target=${prTargetBranch})`,
+        );
+        return engineError(
+          'E_VALIDATION',
+          `Version "${cleanVersion}" does not match channel "${resolvedChannel}" ` +
+            `(PR target branch=${prTargetBranch}). ${channelCheck.message} ` +
+            `Pass --force to override (owner-only).`,
+          {
+            details: {
+              version: cleanVersion,
+              channel: resolvedChannel,
+              prTargetBranch,
+              expected: channelCheck.expected,
+              actual: channelCheck.actual,
+            },
+          },
+        );
+      }
+    } else {
+      const w = `  ! --force: channel/version validation BYPASSED for target '${prTargetBranch}'.`;
+      steps.push(w);
+      log.warn({ epicId, prTargetBranch, forcedBypass: true }, w);
     }
 
     // Step 2: Check epic completeness
@@ -1446,12 +1488,25 @@ export async function releaseShip(
       projectRoot: cwd,
     });
 
+    const requestedLabels = ['release', resolvedChannel];
+    const labelResolution = resolvePRLabels(requestedLabels, cwd);
+    if (labelResolution.created.length > 0) {
+      const m = `  i Auto-created ${labelResolution.created.length} GitHub label(s): ${labelResolution.created.join(', ')}`;
+      steps.push(m);
+      log.info({ step: 7, createdLabels: labelResolution.created }, m);
+    }
+    if (labelResolution.missing.length > 0) {
+      const m = `  ! Dropped ${labelResolution.missing.length} unknown PR label(s): ${labelResolution.missing.join(', ')}`;
+      steps.push(m);
+      log.warn({ step: 7, droppedLabels: labelResolution.missing }, m);
+    }
+
     const prResult: PRResult = await createPullRequest({
       base: prTargetBranch,
       head: releaseBranch,
       title: `Release v${cleanVersion}`,
       body: prBody,
-      labels: ['release', resolvedChannel],
+      labels: labelResolution.labels,
       version: cleanVersion,
       epicId,
       projectRoot: cwd,

--- a/packages/core/src/release/github-pr.ts
+++ b/packages/core/src/release/github-pr.ts
@@ -1,35 +1,46 @@
 import { execFileSync } from 'node:child_process';
+import type {
+  BranchProtectionResult,
+  CleoKnownLabel,
+  CleoLabelPalette,
+  LabelDefinition,
+  LabelEnsureResult,
+  PRCreateOptions,
+  PRLabelResolution,
+  PRMode,
+  PRResult,
+  RepoIdentity,
+} from '@cleocode/contracts';
 
-// --- Types (all exported) ---
+// Re-export contract types so existing consumers that import from this module
+// keep working. New code SHOULD import directly from `@cleocode/contracts`.
+export type {
+  BranchProtectionResult,
+  CleoKnownLabel,
+  CleoLabelPalette,
+  LabelDefinition,
+  LabelEnsureResult,
+  PRCreateOptions,
+  PRLabelResolution,
+  PRMode,
+  PRResult,
+  RepoIdentity,
+};
 
-export interface BranchProtectionResult {
-  protected: boolean;
-  detectionMethod: 'gh-api' | 'push-dry-run' | 'unknown';
-  error?: string;
-}
-
-export interface PRCreateOptions {
-  base: string;
-  head: string;
-  title: string;
-  body: string;
-  labels?: string[];
-  version: string;
-  epicId?: string;
-  projectRoot?: string;
-}
-
-export interface PRResult {
-  mode: 'created' | 'manual' | 'skipped';
-  prUrl?: string;
-  prNumber?: number;
-  instructions?: string;
-  error?: string;
-}
-
-export interface RepoIdentity {
-  owner: string;
-  repo: string;
+/**
+ * Extract the stderr text from a thrown `execFileSync` error, falling back
+ * to `err.message` or `String(err)`. Centralised so every call-site uses
+ * the same narrowing rather than re-doing the `instanceof Error && 'stderr' in …`
+ * dance four times.
+ */
+function execStderr(err: unknown): string {
+  if (err instanceof Error && 'stderr' in err) {
+    const fromStderr = (err as NodeJS.ErrnoException & { stderr?: unknown }).stderr;
+    if (fromStderr !== undefined && fromStderr !== null) return String(fromStderr);
+    return err.message;
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
 }
 
 // --- Functions (all exported) ---
@@ -109,10 +120,7 @@ export async function detectBranchProtection(
           // Exit code 0 means protection rules exist
           return { protected: true, detectionMethod: 'gh-api' };
         } catch (apiErr: unknown) {
-          const stderr =
-            apiErr instanceof Error && 'stderr' in apiErr
-              ? String((apiErr as NodeJS.ErrnoException & { stderr?: string }).stderr ?? '')
-              : '';
+          const stderr = execStderr(apiErr);
           if (stderr.includes('404') || stderr.includes('Not Found')) {
             // 404 means no protection configured
             return { protected: false, detectionMethod: 'gh-api' };
@@ -144,13 +152,7 @@ export async function detectBranchProtection(
     }
     return { protected: false, detectionMethod: 'push-dry-run' };
   } catch (pushErr: unknown) {
-    const stderr =
-      pushErr instanceof Error && 'stderr' in pushErr
-        ? String((pushErr as NodeJS.ErrnoException & { stderr?: string }).stderr ?? '')
-        : pushErr instanceof Error
-          ? pushErr.message
-          : String(pushErr);
-
+    const stderr = execStderr(pushErr);
     if (
       stderr.includes('protected branch') ||
       stderr.includes('GH006') ||
@@ -165,6 +167,96 @@ export async function detectBranchProtection(
       error: stderr,
     };
   }
+}
+
+/**
+ * Known channel/release labels and the colors/descriptions used when CLEO
+ * auto-creates them. Kept in one place so the palette is consistent across
+ * projects that opt into auto-create. Typed against the {@link CleoLabelPalette}
+ * contract so the names match the {@link CleoKnownLabel} discriminated union.
+ */
+const KNOWN_CLEO_LABELS: CleoLabelPalette = {
+  release: { color: '0E8A16', description: 'CLEO release PR' },
+  latest: { color: '1D76DB', description: 'Targets the latest stable channel' },
+  beta: { color: 'FBCA04', description: 'Targets the beta channel' },
+  alpha: { color: 'D93F0B', description: 'Targets the alpha channel' },
+};
+
+/**
+ * Return the names of labels currently defined on the GitHub repo for `cwd`.
+ *
+ * Uses `gh label list --json name` and tolerates failures by returning an
+ * empty list (caller falls back to "skip filtering"). The intent is to avoid
+ * `gh pr create --label X` failing the entire release because a label happens
+ * to be missing on a particular repo.
+ */
+export function listExistingLabels(projectRoot?: string): string[] {
+  if (!isGhCliAvailable()) return [];
+  try {
+    const stdout = execFileSync('gh', ['label', 'list', '--limit', '200', '--json', 'name'], {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      ...(projectRoot ? { cwd: projectRoot } : {}),
+    });
+    const parsed = JSON.parse(stdout) as Array<{ name?: string }>;
+    return parsed.map((row) => row.name ?? '').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Create labels on the GitHub repo that are missing locally but recognised by
+ * CLEO. Returns the subset of `requested` that now exists (either pre-existed
+ * or was created successfully). Silently skips unknown labels.
+ *
+ * `gh label create` is idempotent under the `--force` flag in modern gh
+ * versions, but to stay portable we filter against `listExistingLabels` first.
+ */
+export function ensureCleoLabelsExist(
+  requested: string[],
+  projectRoot?: string,
+): LabelEnsureResult {
+  if (!isGhCliAvailable()) {
+    return { ensured: [], created: [], missing: requested };
+  }
+  const existing = new Set(listExistingLabels(projectRoot));
+  const created: string[] = [];
+  const ensured: string[] = [];
+  const missing: string[] = [];
+
+  for (const name of requested) {
+    if (existing.has(name)) {
+      ensured.push(name);
+      continue;
+    }
+    // Narrow `name: string` to `CleoKnownLabel` via the palette's own keys
+    // so the index access is type-safe (no `any` from a string lookup).
+    const knownNames = Object.keys(KNOWN_CLEO_LABELS) as CleoKnownLabel[];
+    const knownName = knownNames.find((k) => k === name);
+    if (!knownName) {
+      missing.push(name);
+      continue;
+    }
+    const meta = KNOWN_CLEO_LABELS[knownName];
+    try {
+      execFileSync(
+        'gh',
+        ['label', 'create', name, '--color', meta.color, '--description', meta.description],
+        {
+          encoding: 'utf-8',
+          stdio: 'pipe',
+          ...(projectRoot ? { cwd: projectRoot } : {}),
+        },
+      );
+      created.push(name);
+      ensured.push(name);
+    } catch {
+      missing.push(name);
+    }
+  }
+
+  return { ensured, created, missing };
 }
 
 /**
@@ -208,8 +300,47 @@ export function formatManualPRInstructions(opts: PRCreateOptions): string {
 }
 
 /**
+ * Resolve the set of labels to actually pass to `gh pr create`, given the set
+ * requested by the caller.
+ *
+ * Order:
+ *   1. Auto-create CLEO-known labels (release/latest/beta/alpha) if absent
+ *   2. Query the repo's existing labels and intersect — labels we can't auto-
+ *      create are dropped here (with a `missing` list returned for logging)
+ *   3. Return the final ensured set so `gh pr create --label …` never errors
+ *      out on a non-existent label
+ *
+ * Exported so the engine layer (and tests) can preview filtering before a
+ * real PR is opened.
+ */
+export function resolvePRLabels(
+  requested: string[] | undefined,
+  projectRoot?: string,
+): PRLabelResolution {
+  if (!requested || requested.length === 0) {
+    return { labels: [], created: [], missing: [] };
+  }
+  if (!isGhCliAvailable()) {
+    // Without gh we can't validate — pass through and let the caller decide.
+    return { labels: requested, created: [], missing: [] };
+  }
+  const ensured = ensureCleoLabelsExist(requested, projectRoot);
+  return {
+    labels: ensured.ensured,
+    created: ensured.created,
+    missing: ensured.missing,
+  };
+}
+
+/**
  * Create a GitHub pull request using the `gh` CLI, or return manual instructions
  * if the CLI is unavailable or the operation fails.
+ *
+ * Labels in `opts.labels` are filtered against the repo's existing labels via
+ * {@link resolvePRLabels} — labels that don't exist (and aren't in CLEO's
+ * known palette) are silently dropped rather than failing the PR. If `gh pr
+ * create` still rejects a label (race with another label deletion, custom
+ * validation, etc.), the call retries once without any labels.
  */
 export async function createPullRequest(opts: PRCreateOptions): Promise<PRResult> {
   if (!isGhCliAvailable()) {
@@ -220,53 +351,52 @@ export async function createPullRequest(opts: PRCreateOptions): Promise<PRResult
   }
 
   const body = buildPRBody(opts);
+  const labelResolution = resolvePRLabels(opts.labels, opts.projectRoot);
 
-  const args: string[] = [
-    'pr',
-    'create',
-    '--base',
-    opts.base,
-    '--head',
-    opts.head,
-    '--title',
-    opts.title,
-    '--body',
-    body,
-  ];
-
-  if (opts.labels && opts.labels.length > 0) {
-    for (const label of opts.labels) {
+  const buildArgs = (labels: string[]): string[] => {
+    const args: string[] = [
+      'pr',
+      'create',
+      '--base',
+      opts.base,
+      '--head',
+      opts.head,
+      '--title',
+      opts.title,
+      '--body',
+      body,
+    ];
+    for (const label of labels) {
       args.push('--label', label);
     }
-  }
+    return args;
+  };
 
-  try {
-    const output = execFileSync('gh', args, {
+  const runGh = (labels: string[]): string =>
+    execFileSync('gh', buildArgs(labels), {
       encoding: 'utf-8',
       stdio: 'pipe',
       ...(opts.projectRoot ? { cwd: opts.projectRoot } : {}),
     });
 
+  const isLabelError = (msg: string): boolean =>
+    /not\s+found|no\s+such\s+label|could\s+not\s+add\s+label|invalid\s+label/i.test(msg);
+
+  try {
+    const output = runGh(labelResolution.labels);
     const prUrl = output.trim();
     const numberMatch = prUrl.match(/\/pull\/(\d+)$/);
     const prNumber = numberMatch ? parseInt(numberMatch[1], 10) : undefined;
-
     return {
       mode: 'created',
       prUrl,
       prNumber,
     };
   } catch (err: unknown) {
-    const stderr =
-      err instanceof Error && 'stderr' in err
-        ? String((err as NodeJS.ErrnoException & { stderr?: string }).stderr ?? '')
-        : err instanceof Error
-          ? err.message
-          : String(err);
+    const stderr = execStderr(err);
 
-    // Handle case where PR already exists
+    // PR already exists — extract URL and return skipped
     if (stderr.includes('already exists')) {
-      // Attempt to extract existing PR URL from stderr
       const urlMatch = stderr.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/);
       const existingUrl = urlMatch ? urlMatch[0] : undefined;
       return {
@@ -274,6 +404,30 @@ export async function createPullRequest(opts: PRCreateOptions): Promise<PRResult
         prUrl: existingUrl,
         instructions: 'PR already exists',
       };
+    }
+
+    // Label-related failure — retry once with no labels so the release can ship
+    if (labelResolution.labels.length > 0 && isLabelError(stderr)) {
+      try {
+        const output = runGh([]);
+        const prUrl = output.trim();
+        const numberMatch = prUrl.match(/\/pull\/(\d+)$/);
+        const prNumber = numberMatch ? parseInt(numberMatch[1], 10) : undefined;
+        return {
+          mode: 'created',
+          prUrl,
+          prNumber,
+          instructions:
+            `PR created without labels — ` +
+            `gh rejected labels [${labelResolution.labels.join(', ')}]: ${stderr.trim()}`,
+        };
+      } catch (retryErr: unknown) {
+        return {
+          mode: 'manual',
+          instructions: formatManualPRInstructions(opts),
+          error: execStderr(retryErr),
+        };
+      }
     }
 
     return {

--- a/packages/core/src/release/index.ts
+++ b/packages/core/src/release/index.ts
@@ -76,9 +76,12 @@ export {
   buildPRBody,
   createPullRequest,
   detectBranchProtection,
+  ensureCleoLabelsExist,
   extractRepoOwnerAndName,
   formatManualPRInstructions,
   isGhCliAvailable,
+  listExistingLabels,
+  resolvePRLabels,
 } from './github-pr.js';
 // Release guards
 export type { DoubleListingResult, EpicCompletenessResult } from './guards.js';
@@ -166,8 +169,10 @@ export type { BumpResult, BumpType, VersionBumpTarget } from './version-bump.js'
 export {
   bumpVersionFromConfig,
   calculateNewVersion,
+  discoverWorkspacePackageJsonFiles,
   getVersionBumpConfig,
   isCalVer,
   isVersionBumpConfigured,
+  resolveVersionBumpTargets,
   validateVersionFormat,
 } from './version-bump.js';

--- a/packages/core/src/release/version-bump.ts
+++ b/packages/core/src/release/version-bump.ts
@@ -12,11 +12,40 @@
  * @epic T4454
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { ExitCode } from '@cleocode/contracts';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import {
+  type BumpResult,
+  type BumpType,
+  type BumpVersionFromConfigResult,
+  type EcosystemHint,
+  ExitCode,
+  type ProjectContext,
+  type ProjectType,
+  type ResolveVersionBumpTargetsResult,
+  type VersionBumpStrategy,
+  type VersionBumpTarget,
+  type VersionBumpTargetSource,
+} from '@cleocode/contracts';
+import { loadProjectContext } from '../agents/variable-substitution.js';
 import { CleoError } from '../errors.js';
 import { getCleoDir, getProjectRoot } from '../paths.js';
+
+// Re-export contract types so existing consumers that import from this module
+// (e.g. `import { VersionBumpTarget } from '@cleocode/core/internal'`) keep
+// working. New code SHOULD import directly from `@cleocode/contracts`.
+export type {
+  BumpResult,
+  BumpType,
+  BumpVersionFromConfigResult,
+  EcosystemHint,
+  ProjectContext,
+  ProjectType,
+  ResolveVersionBumpTargetsResult,
+  VersionBumpStrategy,
+  VersionBumpTarget,
+  VersionBumpTargetSource,
+};
 
 /** Synchronous config value reader for version bump targets. */
 function readConfigValueSync(path: string, defaultValue: unknown, cwd?: string): unknown {
@@ -55,9 +84,6 @@ export function isCalVer(version: string): boolean {
   const base = version.replace(/-.*$/, '');
   return CALVER_REGEX.test(base) && parseInt(base.split('.')[0]!, 10) >= 2000;
 }
-
-/** Bump type for version calculation. */
-export type BumpType = 'patch' | 'minor' | 'major';
 
 /** Calculate new version from current + bump type. */
 export function calculateNewVersion(current: string, bump: BumpType | string): string {
@@ -127,25 +153,17 @@ export function calculateNewVersion(current: string, bump: BumpType | string): s
   return parts.join('.');
 }
 
-/** Version bump target config from .cleo/config.json. */
-export interface VersionBumpTarget {
-  file: string;
-  strategy: 'plain' | 'json' | 'toml' | 'sed';
-  field?: string; // For json strategy
-  key?: string; // For toml strategy
-  section?: string; // For toml strategy
-  pattern?: string; // For sed strategy (with {{VERSION}} placeholder)
-}
-
 /** Raw config entry shape from .cleo/config.json (uses path/jsonPath/sedPattern). */
 interface RawVersionBumpEntry {
   path?: string;
   file?: string;
-  strategy: 'plain' | 'json' | 'toml' | 'sed';
+  strategy: VersionBumpStrategy;
   jsonPath?: string;
   field?: string;
   key?: string;
+  tomlKey?: string;
   section?: string;
+  tomlSection?: string;
   sedPattern?: string;
   pattern?: string;
   optional?: boolean;
@@ -161,8 +179,10 @@ export function getVersionBumpConfig(cwd?: string): VersionBumpTarget[] {
         file: entry.path ?? entry.file ?? '',
         strategy: entry.strategy,
         field: entry.jsonPath?.replace(/^\./, '') ?? entry.field,
-        key: entry.key,
-        section: entry.section,
+        // Schema canonicalises on `tomlKey` / `tomlSection`; legacy in-code
+        // entries used bare `key` / `section`. Accept both.
+        key: entry.tomlKey ?? entry.key,
+        section: entry.tomlSection ?? entry.section,
         pattern: entry.sedPattern ?? entry.pattern,
       }))
       .filter((t) => t.file !== '');
@@ -176,14 +196,292 @@ export function isVersionBumpConfigured(cwd?: string): boolean {
   return getVersionBumpConfig(cwd).length > 0;
 }
 
-/** Bump result for a single file. */
-export interface BumpResult {
-  file: string;
-  strategy: string;
-  success: boolean;
-  previousVersion?: string;
-  newVersion?: string;
-  error?: string;
+/**
+ * Resolve the project root for filesystem operations, falling back to `cwd`
+ * (or `process.cwd()`) when {@link getProjectRoot} rejects the path. Discovery
+ * and bumping run against arbitrary monorepos — they MUST work outside a
+ * CLEO-initialised project (tests, fresh clones, downstream tooling).
+ */
+function resolveProjectRootLoose(cwd?: string): string {
+  try {
+    return getProjectRoot(cwd);
+  } catch {
+    return cwd ?? process.cwd();
+  }
+}
+
+/**
+ * Read ecosystem hints from `.cleo/project-context.json` via the canonical
+ * {@link loadProjectContext} loader. Returns the narrow subset of
+ * {@link ProjectContext} that this module cares about, or `{}` when no
+ * context is available (which lets callers fall back to filesystem probing).
+ *
+ * Reuses the existing loader rather than re-implementing JSON parsing so
+ * we stay aligned with the rest of the codebase (variable substitution,
+ * agent spawn, codebase-map analyzers) and inherit any future hardening.
+ */
+function readEcosystemHint(projectRoot: string): EcosystemHint {
+  const loaded = loadProjectContext(projectRoot);
+  if (!loaded.loaded || !loaded.context) return {};
+  const ctx = loaded.context as Partial<ProjectContext>;
+  return {
+    primaryType: ctx.primaryType,
+    projectTypes: Array.isArray(ctx.projectTypes) ? ctx.projectTypes : undefined,
+    monorepo: typeof ctx.monorepo === 'boolean' ? ctx.monorepo : undefined,
+  };
+}
+
+/**
+ * Discover Node/JS package.json files in a pnpm/yarn/npm workspace.
+ *
+ * Detection signals (any one is sufficient):
+ *   - `pnpm-workspace.yaml` at the project root
+ *   - A `workspaces` field in the root `package.json`
+ *   - A `packages/` directory containing one or more package.json files
+ *
+ * Returns `[]` when no workspace is detected.
+ */
+function discoverNodeWorkspaceTargets(projectRoot: string): VersionBumpTarget[] {
+  const rootPkgPath = join(projectRoot, 'package.json');
+  if (!existsSync(rootPkgPath)) return [];
+
+  const hasPnpmWorkspace = existsSync(join(projectRoot, 'pnpm-workspace.yaml'));
+  let hasYarnNpmWorkspaces = false;
+  try {
+    const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8')) as { workspaces?: unknown };
+    hasYarnNpmWorkspaces = rootPkg.workspaces != null;
+  } catch {
+    // Malformed root package.json — fall through
+  }
+
+  const packagesDir = join(projectRoot, 'packages');
+  const hasPackagesDir = existsSync(packagesDir);
+
+  if (!hasPnpmWorkspace && !hasYarnNpmWorkspaces && !hasPackagesDir) {
+    return [];
+  }
+
+  const targets: VersionBumpTarget[] = [
+    { file: 'package.json', strategy: 'json', field: 'version' },
+  ];
+
+  if (hasPackagesDir) {
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(packagesDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name);
+    } catch {
+      return targets;
+    }
+    for (const name of entries.sort()) {
+      const pkgPath = join(packagesDir, name, 'package.json');
+      if (!existsSync(pkgPath)) continue;
+      targets.push({
+        file: relative(projectRoot, pkgPath),
+        strategy: 'json',
+        field: 'version',
+      });
+    }
+  }
+
+  return targets;
+}
+
+/**
+ * Test whether a Cargo.toml member crate inherits its version from the
+ * workspace (`version.workspace = true`) rather than declaring its own.
+ * Member crates that inherit are NOT bumpable directly — the source of truth
+ * lives in the root `[workspace.package]` table.
+ */
+function cargoCrateInheritsVersion(cargoTomlPath: string): boolean {
+  try {
+    const content = readFileSync(cargoTomlPath, 'utf-8');
+    return /^\s*version\.workspace\s*=\s*true\s*$/m.test(content);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Test whether a Cargo.toml has a `[workspace.package] version = "X.Y.Z"`
+ * line — the inheritance source for `version.workspace = true` member crates.
+ *
+ * Looks at the slice of the file from `[workspace.package]` up to either the
+ * next `[…]` section header or end-of-file, and checks for a `version = "…"`
+ * line inside it. (JavaScript regex has no `\Z` anchor, so end-of-input is
+ * matched via a negative lookahead `(?![\s\S])`.)
+ */
+function cargoHasWorkspacePackageVersion(content: string): boolean {
+  const sectionMatch = content.match(
+    /^\s*\[workspace\.package\]\s*$([\s\S]*?)(?=^\s*\[|(?![\s\S]))/m,
+  );
+  if (!sectionMatch?.[1]) return false;
+  return /^\s*version\s*=\s*"/m.test(sectionMatch[1]);
+}
+
+/**
+ * Discover Rust Cargo.toml files in a `[workspace]` setup.
+ *
+ * Three patterns are handled:
+ *
+ *   1. **Workspace inheritance** (modern convention): root carries
+ *      `[workspace.package] version = "X.Y.Z"` and members use
+ *      `version.workspace = true`. Only the root is bumped — every member
+ *      inherits automatically.
+ *
+ *   2. **Per-crate versions** (legacy): each member declares its own
+ *      `version = "X.Y.Z"`. Every member is bumped individually.
+ *
+ *   3. **Root crate**: root Cargo.toml is itself a `[package]` (not just a
+ *      `[workspace]`). The root's `[package] version` is bumped.
+ *
+ * Returns `[]` when there is no Cargo.toml or no `[workspace]` table. Crates
+ * that inherit from the workspace are intentionally NOT listed as targets to
+ * avoid the silent-no-op case where the bumper would match nothing and report
+ * false success.
+ */
+function discoverRustWorkspaceTargets(projectRoot: string): VersionBumpTarget[] {
+  const rootCargoPath = join(projectRoot, 'Cargo.toml');
+  if (!existsSync(rootCargoPath)) return [];
+
+  let cargoContent: string;
+  try {
+    cargoContent = readFileSync(rootCargoPath, 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const hasWorkspaceTable = /^\s*\[workspace\]\s*$/m.test(cargoContent);
+  if (!hasWorkspaceTable) return [];
+
+  const targets: VersionBumpTarget[] = [];
+
+  // Pattern 1: workspace-inheritance source (modern Cargo convention)
+  if (cargoHasWorkspacePackageVersion(cargoContent)) {
+    targets.push({
+      file: 'Cargo.toml',
+      strategy: 'toml',
+      key: 'version',
+      section: 'workspace.package',
+    });
+  }
+
+  // Pattern 3: root is also a [package]
+  const hasRootPackage = /^\s*\[package\]\s*$/m.test(cargoContent);
+  const hasRootPackageVersion =
+    hasRootPackage && /^\s*\[package\]\s*$([\s\S]*?)version\s*=\s*"/m.test(cargoContent);
+  if (hasRootPackageVersion) {
+    targets.push({
+      file: 'Cargo.toml',
+      strategy: 'toml',
+      key: 'version',
+      section: 'package',
+    });
+  }
+
+  // Pattern 2: members with their own version (skip those that inherit)
+  const membersMatch = cargoContent.match(/\[workspace\][\s\S]*?members\s*=\s*\[([\s\S]*?)\]/);
+  if (membersMatch?.[1]) {
+    const memberPaths = Array.from(membersMatch[1].matchAll(/"([^"]+)"/g)).map((m) => m[1]);
+    for (const member of memberPaths.sort()) {
+      if (!member || member.includes('*')) continue; // skip globs — needs deeper resolution
+      const cargoPath = join(projectRoot, member, 'Cargo.toml');
+      if (!existsSync(cargoPath)) continue;
+      if (cargoCrateInheritsVersion(cargoPath)) continue; // inherits from workspace — root already covers it
+      targets.push({
+        file: relative(projectRoot, cargoPath),
+        strategy: 'toml',
+        key: 'version',
+        section: 'package',
+      });
+    }
+  }
+
+  return targets;
+}
+
+/**
+ * Auto-discover version-bump targets for the project's ecosystem(s).
+ *
+ * Reads `.cleo/project-context.json` via the canonical
+ * {@link loadProjectContext} loader and uses the recorded
+ * {@link ProjectContext.projectTypes} / {@link ProjectContext.primaryType}
+ * to decide which discoverers to run. When the context is missing, falls
+ * back to probing filesystem markers (`package.json`, `Cargo.toml`)
+ * directly — same signals the canonical
+ * {@link import('../store/project-detect.js').detectProjectType} uses.
+ *
+ * For a multi-language monorepo (e.g. `projectTypes: ["node", "rust"]`),
+ * targets from each ecosystem are merged so a single release commit keeps
+ * every workspace package in sync.
+ *
+ * Returns `[]` when no ecosystem is recognised — callers should treat that
+ * as "no auto-bump possible" and either fall back to an explicit config or
+ * skip bumping entirely.
+ */
+export function discoverWorkspacePackageJsonFiles(cwd?: string): VersionBumpTarget[] {
+  const projectRoot = resolveProjectRootLoose(cwd);
+  const hint = readEcosystemHint(projectRoot);
+
+  // If the canonical detector recorded an explicit ecosystem set, honour it.
+  // Without a project-context entry we probe the filesystem markers directly.
+  const declaredTypes = new Set<ProjectType>([
+    ...(hint.projectTypes ?? []),
+    ...(hint.primaryType ? [hint.primaryType] : []),
+  ]);
+
+  // Node-family detection mirrors store/project-detect.ts (`node`, `bun`, `deno`
+  // all yield JS package.json files). Keeping the family list here ensures we
+  // stay in sync with the canonical detector without re-importing its internals.
+  const NODE_FAMILY: ProjectType[] = ['node', 'bun', 'deno'];
+
+  const probeNode = declaredTypes.size === 0 || NODE_FAMILY.some((t) => declaredTypes.has(t));
+  const probeRust = declaredTypes.size === 0 || declaredTypes.has('rust');
+
+  const out: VersionBumpTarget[] = [];
+  if (probeNode) out.push(...discoverNodeWorkspaceTargets(projectRoot));
+  if (probeRust) out.push(...discoverRustWorkspaceTargets(projectRoot));
+
+  // De-duplicate by file path (preserves first occurrence).
+  const seen = new Set<string>();
+  return out.filter((t) => {
+    if (seen.has(t.file)) return false;
+    seen.add(t.file);
+    return true;
+  });
+}
+
+/**
+ * Resolve version-bump targets with workspace auto-discovery fallback.
+ *
+ * Order of preference:
+ *   1. Explicit `release.versionBump.files` from `.cleo/config.json` (most precise)
+ *   2. Auto-discovered workspace targets when `release.versionBump.autoDiscover`
+ *      is not explicitly disabled (default: enabled)
+ *   3. Empty — caller decides whether to skip or error
+ *
+ * The `source` field on the returned envelope lets callers log *how* targets
+ * were resolved, which matters when diagnosing why a release commit did or
+ * did not include version files.
+ */
+export function resolveVersionBumpTargets(cwd?: string): ResolveVersionBumpTargetsResult {
+  const configured = getVersionBumpConfig(cwd);
+  if (configured.length > 0) {
+    return { targets: configured, source: 'config' };
+  }
+
+  const autoDiscover = readConfigValueSync('release.versionBump.autoDiscover', true, cwd);
+  if (autoDiscover === false) {
+    return { targets: [], source: 'none' };
+  }
+
+  const discovered = discoverWorkspacePackageJsonFiles(cwd);
+  if (discovered.length > 0) {
+    return { targets: discovered, source: 'workspace' };
+  }
+
+  return { targets: [], source: 'none' };
 }
 
 /** Apply version bump to a single target file. */
@@ -222,9 +520,41 @@ function bumpFile(target: VersionBumpTarget, newVersion: string, projectRoot: st
 
       case 'toml': {
         const key = target.key ?? 'version';
+        // If a `section` is named (e.g. "workspace.package" or "package"),
+        // bump the matching key WITHIN that section only — important for
+        // Cargo.toml files where `[workspace.package] version` is distinct
+        // from `[package] version` (and from `[dependencies] foo.version`).
+        if (target.section) {
+          const sectionPattern = target.section.replace(/\./g, '\\.');
+          const sectionRegex = new RegExp(
+            `(^\\s*\\[${sectionPattern}\\]\\s*$[\\s\\S]*?)^(${key}\\s*=\\s*")([^"]+)(")`,
+            'm',
+          );
+          const match = content.match(sectionRegex);
+          if (!match) {
+            return {
+              file: target.file,
+              strategy: target.strategy,
+              success: false,
+              error: `No \`${key} = "…"\` line found inside [${target.section}] section`,
+            };
+          }
+          previousVersion = match[3];
+          newContent = content.replace(sectionRegex, `$1$2${newVersion}$4`);
+          break;
+        }
+        // No section — match the first top-level `key = "…"` line.
         const versionRegex = new RegExp(`^(${key}\\s*=\\s*")([^"]+)(")`, 'm');
         const match = content.match(versionRegex);
-        previousVersion = match?.[2];
+        if (!match) {
+          return {
+            file: target.file,
+            strategy: target.strategy,
+            success: false,
+            error: `No \`${key} = "…"\` line found in file (note: \`${key}.workspace = true\` is not bumpable — see Cargo workspace inheritance)`,
+          };
+        }
+        previousVersion = match[2];
         newContent = content.replace(versionRegex, `$1${newVersion}$3`);
         break;
       }
@@ -273,12 +603,17 @@ function bumpFile(target: VersionBumpTarget, newVersion: string, projectRoot: st
   }
 }
 
+/** Options passed to {@link bumpVersionFromConfig}. */
+export interface BumpVersionFromConfigOptions {
+  dryRun?: boolean;
+}
+
 /** Bump version in all configured files. */
 export function bumpVersionFromConfig(
   newVersion: string,
-  options: { dryRun?: boolean } = {},
+  options: BumpVersionFromConfigOptions = {},
   cwd?: string,
-): { results: BumpResult[]; allSuccess: boolean } {
+): BumpVersionFromConfigResult {
   if (!validateVersionFormat(newVersion)) {
     throw new CleoError(
       ExitCode.VALIDATION_ERROR,
@@ -286,15 +621,18 @@ export function bumpVersionFromConfig(
     );
   }
 
-  const targets = getVersionBumpConfig(cwd);
+  const { targets } = resolveVersionBumpTargets(cwd);
   if (targets.length === 0) {
     throw new CleoError(
       ExitCode.GENERAL_ERROR,
-      'No version bump targets configured. Add release.versionBump.files to .cleo/config.json',
+      'No version bump targets configured and no bumpable workspace detected. ' +
+        'Either add release.versionBump.files to .cleo/config.json, ' +
+        'or run inside a pnpm/yarn/npm workspace with package.json files, ' +
+        'or a Cargo [workspace.package] / per-crate [package] version setup.',
     );
   }
 
-  const projectRoot = getProjectRoot(cwd);
+  const projectRoot = resolveProjectRootLoose(cwd);
   const results: BumpResult[] = [];
 
   if (options.dryRun) {

--- a/packages/core/src/store/project-detect.ts
+++ b/packages/core/src/store/project-detect.ts
@@ -8,85 +8,18 @@
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import type {
+  FileNamingConvention,
+  ImportStyle,
+  ProjectContext,
+  ProjectType,
+  TestFramework,
+} from '@cleocode/contracts';
 
-/** Detected project type. */
-export type ProjectType =
-  | 'node'
-  | 'python'
-  | 'rust'
-  | 'go'
-  | 'ruby'
-  | 'java'
-  | 'dotnet'
-  | 'bash'
-  | 'elixir'
-  | 'php'
-  | 'deno'
-  | 'bun'
-  | 'unknown';
-
-/** Test framework. */
-export type TestFramework =
-  | 'jest'
-  | 'vitest'
-  | 'mocha'
-  | 'pytest'
-  | 'bats'
-  | 'cargo'
-  | 'go'
-  | 'rspec'
-  | 'junit'
-  | 'playwright'
-  | 'cypress'
-  | 'ava'
-  | 'uvu'
-  | 'tap'
-  | 'node:test'
-  | 'deno'
-  | 'bun'
-  | 'custom'
-  | 'unknown';
-
-export type FileNamingConvention = 'kebab-case' | 'snake_case' | 'camelCase' | 'PascalCase';
-export type ImportStyle = 'esm' | 'commonjs' | 'mixed';
-
-/** Schema-compliant project context for LLM agent consumption. */
-export interface ProjectContext {
-  schemaVersion: string;
-  detectedAt: string;
-  projectTypes: ProjectType[];
-  primaryType?: ProjectType;
-  monorepo: boolean;
-  testing?: {
-    framework?: TestFramework;
-    command?: string;
-    testFilePatterns?: string[];
-    directories?: {
-      unit?: string;
-      integration?: string;
-    };
-  };
-  build?: {
-    command?: string;
-    outputDir?: string;
-  };
-  directories?: {
-    source?: string;
-    tests?: string;
-    docs?: string;
-  };
-  conventions?: {
-    fileNaming?: FileNamingConvention;
-    importStyle?: ImportStyle;
-    typeSystem?: string;
-  };
-  llmHints?: {
-    preferredTestStyle?: string;
-    typeSystem?: string;
-    commonPatterns?: string[];
-    avoidPatterns?: string[];
-  };
-}
+// Re-export canonical contract types so consumers that previously imported
+// from this module keep working. New code SHOULD import from
+// `@cleocode/contracts`.
+export type { FileNamingConvention, ImportStyle, ProjectContext, ProjectType, TestFramework };
 
 /**
  * Detect project type from directory contents.


### PR DESCRIPTION
Canonical 3-phase plan for the T-LLM-CRED-CENTRALIZATION epic (T9261). Phase 1 shipped via PR #120 (T9246). Phase 2 shipped via PR #121-#123 + tag v2026.5.63 (T9255-T9259). Phase 3 RCASD-gated (T9260).

Attached to T9261, T9246, T9260 via `cleo docs add` for surfaced discovery via `cleo show / cleo briefing`.

Task: T9246, T9260, T9261

## Test plan
- [ ] CI green (docs-only addition)
- [ ] After merge: a fresh clone has the plan at docs/plans/T-LLM-CRED-CENTRALIZATION.md