### PR TITLE
fix(core/release): clean_working_tree gate (T9246) — include auto-discovered bump targets

### DIFF
--- a/packages/core/src/release/release-manifest.ts
+++ b/packages/core/src/release/release-manifest.ts
@@ -28,7 +28,7 @@ import {
   getPushMode,
   loadReleaseConfig,
 } from './release-config.js';
-import { getVersionBumpConfig } from './version-bump.js';
+import { resolveVersionBumpTargets } from './version-bump.js';
 
 async function getDb(cwd?: string): ReturnType<typeof import('../store/sqlite.js')['getDb']> {
   const { getDb: _getDb } = await import('../store/sqlite.js');
@@ -867,8 +867,11 @@ export async function runReleaseGates(
       message: 'Skipped in dry-run mode',
     });
   } else {
-    // Dynamically build exclusion set from configured version bump targets + CHANGELOG.md
-    const bumpTargets = getVersionBumpConfig(cwd);
+    // Dynamically build exclusion set from configured + workspace-auto-discovered
+    // version bump targets plus CHANGELOG.md. Using resolveVersionBumpTargets
+    // here (rather than getVersionBumpConfig) means auto-discovered package.json
+    // and Cargo.toml files are recognised as expected-dirty after step 0's bump.
+    const { targets: bumpTargets } = resolveVersionBumpTargets(cwd);
     const allowedDirty = new Set(['CHANGELOG.md', ...bumpTargets.map((t) => t.file)]);
     let workingTreeClean = true;
     let dirtyFiles: string[] = [];


### PR DESCRIPTION
## Summary

Follow-up to PR #125 — caught while dogfooding `cleo release ship 2026.5.64`.

The `clean_working_tree` gate built its allow-list from `getVersionBumpConfig` (explicit config only). Step 0's bump now writes to auto-discovered targets too (the workspace discovery introduced in 2a79e72f0), so on a project that relies on auto-discovery the gate flags all bumped files as "uncommitted changes" and fails the release.

Switch the gate to `resolveVersionBumpTargets` so the allow-list mirrors what Step 0 actually writes.

## Test plan

- [x] Verified gate now allows 22 auto-discovered targets in this repo (21 JS + Cargo)
- [x] Existing tests pass (145 release tests)

Task: T9246