### PR TITLE
feat(T9282): Phase 4 W0c — extend contracts + stub-add transports for compile parity

### DIFF
--- a/packages/contracts/src/llm/normalized-response.ts
+++ b/packages/contracts/src/llm/normalized-response.ts
@@ -11,10 +11,14 @@
  *
  * @module llm/normalized-response
  * @task T9263
+ * @task T9282 (W0c — Phase 4 multimodal + stream extensions)
  * @epic T-LLM-CRED-CENTRALIZATION
+ * @see ADR-072 §LlmTransport — pure wire level
  */
 
 import type { ModelTransport } from '../operations/llm.js';
+import type { NormalizedDelta, TransportContext } from './interfaces.js';
+import type { ApiMode } from './provider-id.js';
 
 /**
  * Token usage reported by the provider for a single API call.
@@ -100,16 +104,70 @@ export interface NormalizedResponse {
 }
 
 /**
+ * An image content block for multimodal messages.
+ *
+ * `source.type` determines how the image data is provided:
+ * - `'base64'` — raw image bytes encoded as base64, with `mediaType` identifying
+ *   the MIME type (e.g. `'image/png'`, `'image/jpeg'`).
+ * - `'url'` — a publicly accessible URL; `data` is the URL string and `mediaType`
+ *   is still populated (sniffed by {@link image-routing.ts} when not supplied by
+ *   the caller).
+ *
+ * @see ADR-072 §LlmTransport — pure wire level (W4d image routing)
+ */
+export interface TransportImageBlock {
+  /** Discriminant — always `'image'`. */
+  readonly type: 'image';
+  readonly source: {
+    /** How the image data is provided. */
+    readonly type: 'base64' | 'url';
+    /**
+     * Base64-encoded image bytes (when `type === 'base64'`) or a URL string
+     * (when `type === 'url'`).
+     */
+    readonly data: string;
+    /** MIME type, e.g. `'image/png'`, `'image/jpeg'`, `'image/webp'`. */
+    readonly mediaType: string;
+  };
+}
+
+/**
+ * A text content block for multimodal messages.
+ */
+export interface TransportTextBlock {
+  /** Discriminant — always `'text'`. */
+  readonly type: 'text';
+  /** Plain text string. */
+  readonly text: string;
+}
+
+/**
  * A single message in a provider-neutral conversation turn.
  *
  * `toolUseId` is required when `role` is `'tool'` — it identifies which
  * tool call this result resolves, matching {@link NormalizedToolCall.id}.
+ *
+ * `content` supports both the legacy plain-string form and a multimodal block
+ * array. When `content` is a string, the transport treats it as a single text
+ * block. When it is an array, each element is either a {@link TransportTextBlock}
+ * or a {@link TransportImageBlock} — enabling image routing (W4d) without
+ * breaking existing transport consumers that only read the string form.
  */
 export interface TransportMessage {
   /** Conversation turn role. */
   role: 'user' | 'assistant' | 'tool';
-  /** Message content as plain text. */
-  content: string;
+  /**
+   * Message content.
+   *
+   * - Plain `string` — backwards-compatible single-text-block form used by
+   *   all existing transports. Transports that do not support images receive
+   *   this form only.
+   * - `ReadonlyArray<TransportTextBlock | TransportImageBlock>` — multimodal
+   *   block array enabling image routing (ADR-072 W4d). Transports that do not
+   *   support images MUST stringify text blocks and drop image blocks (or throw
+   *   if `imageMode` on the request is `'native'` — see {@link TransportRequest}).
+   */
+  readonly content: string | ReadonlyArray<TransportTextBlock | TransportImageBlock>;
   /** Tool-result messages: id of the call this resolves. */
   toolUseId?: string;
 }
@@ -131,13 +189,16 @@ export interface TransportTool {
 }
 
 /**
- * Request parameters passed to {@link LlmTransport.complete}.
+ * Request parameters passed to {@link LlmTransport.complete} and
+ * {@link LlmTransport.stream}.
  *
  * `temperature` is normalized to the 0.0–1.0 range; each transport clamps it
  * to the provider's supported range before sending.
  *
  * `signal` may be used to abort in-flight requests (passed through to the
  * underlying fetch / SDK call where supported).
+ *
+ * @see ADR-072 §LlmTransport — pure wire level
  */
 export interface TransportRequest {
   /** Model identifier — provider-specific (e.g. `'claude-sonnet-4-6'`). */
@@ -154,6 +215,36 @@ export interface TransportRequest {
   temperature?: number;
   /** AbortSignal for request cancellation. */
   signal?: AbortSignal;
+  /**
+   * Prompt-cache breakpoint injection strategy.
+   *
+   * - `'system_and_3'` — inject cache breakpoints after the system prompt and
+   *   after the last 3 user messages (Anthropic extended-caching strategy).
+   * - `'prefix_and_2'` — inject at the shared prefix boundary and after the 2
+   *   most-recent turns (optimised for Gemini cached content).
+   * - `null` — no cache injection (default when not set).
+   *
+   * Transports apply the selected strategy before constructing the SDK request.
+   * Unsupported strategies on a given transport are silently ignored.
+   *
+   * @see ADR-072 §LlmTransport — pure wire level
+   */
+  readonly cacheStrategy?: 'system_and_3' | 'prefix_and_2' | null;
+  /**
+   * Image handling mode for multimodal content blocks in {@link TransportMessage.content}.
+   *
+   * - `'native'` — send image blocks as-is to the provider's multimodal API.
+   *   The transport MUST throw if the provider does not support native images.
+   * - `'text'` — strip all image blocks; only text blocks are sent. Useful for
+   *   text-only providers or when images are redundant.
+   * - `'auto'` — the transport decides based on provider capability (default).
+   *   Falls back to `'text'` for providers that do not support native images.
+   *
+   * Used by the image-routing layer (W4d) to select the per-turn input mode.
+   *
+   * @see ADR-072 §LlmTransport — pure wire level
+   */
+  readonly imageMode?: 'native' | 'text' | 'auto';
 }
 
 /**
@@ -163,6 +254,15 @@ export interface TransportRequest {
  * interface and maps provider-specific API shapes to/from
  * {@link NormalizedResponse}. Role-resolver and executor code works
  * exclusively against this interface so providers are swappable.
+ *
+ * As of Phase 4 (ADR-072) the interface gains two additional members:
+ * - {@link apiMode} — the wire protocol spoken by this transport.
+ * - {@link stream} — streaming completion returning {@link NormalizedDelta} chunks.
+ *
+ * Existing transport implementations MUST add stub implementations of both to
+ * maintain compile parity (W0c). Wave 1 migrations replace stubs with real impls.
+ *
+ * @see ADR-072 §LlmTransport — pure wire level
  */
 export interface LlmTransport {
   /**
@@ -170,6 +270,13 @@ export interface LlmTransport {
    * can select the correct transport at runtime.
    */
   readonly provider: ModelTransport;
+  /**
+   * Wire protocol this transport speaks. Used by the session and executor layers
+   * to select correct transports for providers that support multiple protocols.
+   *
+   * @see ADR-072 §Type lock-in — `ApiMode` closed 4-value union
+   */
+  readonly apiMode: ApiMode;
   /**
    * Execute a single completion call and return a normalized response.
    *
@@ -179,7 +286,28 @@ export interface LlmTransport {
    * - Map provider-specific stop reasons to the canonical set where possible.
    *
    * @param request - Provider-neutral request parameters.
+   * @param ctx - Contextual metadata (request ID, abort signal, feature flags).
    * @returns A promise that resolves to a {@link NormalizedResponse}.
    */
-  complete(request: TransportRequest): Promise<NormalizedResponse>;
+  complete(request: TransportRequest, ctx?: TransportContext): Promise<NormalizedResponse>;
+  /**
+   * Stream a completion. Each {@link NormalizedDelta} carries incremental text
+   * or reasoning content.
+   *
+   * Implementors MUST run streaming deltas through `StreamingThinkScrubber`
+   * before yielding them — reasoning content goes to `delta.reasoning`;
+   * visible text goes to `delta.text`. The final delta has a non-null
+   * `stopReason` and carries full usage stats in `delta.usage`.
+   *
+   * W0c transports carry a stub that throws until Wave 1 migration lands:
+   * ```ts
+   * throw new Error('STUB: W1 migration will implement stream() for <provider>');
+   * ```
+   *
+   * @param request - Provider-neutral request parameters.
+   * @param ctx - Contextual metadata (request ID, abort signal, feature flags).
+   * @returns An async iterable of normalized delta chunks.
+   * @see ADR-072 §LlmTransport — pure wire level
+   */
+  stream(request: TransportRequest, ctx: TransportContext): AsyncIterable<NormalizedDelta>;
 }

--- a/packages/contracts/src/llm/provider-profile.ts
+++ b/packages/contracts/src/llm/provider-profile.ts
@@ -11,6 +11,7 @@
  */
 
 import type { ModelTransport, StoredAuthTypeWire } from '../operations/llm.js';
+import type { TransportMessage, TransportTool } from './normalized-response.js';
 
 /**
  * Describes a single LLM provider — its auth capabilities, base URL,
@@ -85,6 +86,71 @@ export interface ProviderProfile {
    * @param signal - Optional abort signal for request cancellation.
    */
   fetchModels?: (apiKey: string, signal?: AbortSignal) => Promise<ReadonlyArray<string> | null>;
+
+  /**
+   * Hook: transform messages before they are passed to the SDK.
+   *
+   * Default behavior (when `undefined`): identity — messages are forwarded
+   * unchanged. Providers use this hook for shape conversions such as:
+   * - Gemini: hoisting the system message to `systemInstruction`.
+   * - Anthropic: injecting an assistant-prefill block for structured output.
+   * - OpenAI o-series: merging consecutive same-role messages.
+   *
+   * Port of Hermes `ProviderProfile.prepare_messages` (Hermes §3.1).
+   *
+   * @param messages - The transport-level messages prior to provider conversion.
+   * @param model - The resolved model identifier.
+   * @returns Possibly-modified messages array. Implementations MUST NOT mutate
+   *          the input array; return a new array if changes are needed.
+   */
+  readonly prepareMessages?: (
+    messages: readonly TransportMessage[],
+    model: string,
+  ) => readonly TransportMessage[];
+
+  /**
+   * Hook: contribute provider-specific extra body fields.
+   *
+   * The returned object is merged into the SDK request's `extra_body`
+   * (OpenAI-style) or equivalent provider field. Providers use this for:
+   * - Gemini: `thinkingConfig` for extended reasoning budget.
+   * - OpenRouter: Pareto router plugin parameters.
+   * - Anthropic-via-OpenRouter: fine-grained tool streaming control.
+   *
+   * Port of Hermes `ProviderProfile.build_extra_body`.
+   *
+   * @param model - The resolved model identifier.
+   * @param messages - The transport-level messages at call time.
+   * @param tools - The tool definitions at call time.
+   * @returns Object merged into the provider request's `extra_body` field.
+   */
+  readonly buildExtraBody?: (
+    model: string,
+    messages: readonly TransportMessage[],
+    tools: readonly TransportTool[],
+  ) => Readonly<Record<string, unknown>>;
+
+  /**
+   * Hook: contribute provider-specific top-level API kwargs.
+   *
+   * The returned object is shallow-merged into the SDK call kwargs. Providers
+   * use this for top-level fields that do not fit into `extra_body`:
+   * - xAI Grok: `x-grok-conv-id` conversation pinning header.
+   * - Kimi: `reasoning_effort` top-level reasoning control.
+   * - Moonshot: JSON-schema sanitization applied at the request level.
+   *
+   * Port of Hermes `ProviderProfile.build_api_kwargs_extras`.
+   *
+   * @param model - The resolved model identifier.
+   * @param messages - The transport-level messages at call time.
+   * @param tools - The tool definitions at call time.
+   * @returns Object shallow-merged into the SDK call kwargs.
+   */
+  readonly buildApiKwargsExtras?: (
+    model: string,
+    messages: readonly TransportMessage[],
+    tools: readonly TransportTool[],
+  ) => Readonly<Record<string, unknown>>;
 }
 
 /**

--- a/packages/contracts/src/operations/llm.ts
+++ b/packages/contracts/src/operations/llm.ts
@@ -9,8 +9,21 @@
  * @epic T1386
  */
 
-/** Supported provider transport names. */
-export type ModelTransport = 'anthropic' | 'openai' | 'gemini' | 'moonshot';
+import type { BuiltinProviderId, ProviderId } from '../llm/provider-id.js';
+
+/**
+ * @deprecated since Phase 4 (ADR-072). Use {@link ProviderId} from
+ * `@cleocode/contracts/llm/provider-id.js` for new code. This alias remains
+ * for one release cycle to ease migration of legacy callers, then is removed.
+ *
+ * The alias resolves to {@link BuiltinProviderId} — a superset of the previous
+ * closed literal union (`'anthropic' | 'openai' | 'gemini' | 'moonshot'`).
+ * All existing consumers that pattern-match on the previous four values continue
+ * to compile without changes.
+ *
+ * @see ADR-072 §Type lock-in — ModelTransport deprecation cycle
+ */
+export type ModelTransport = Extract<ProviderId, BuiltinProviderId>;
 
 /** Cache policy mode for prompt prefix caching. */
 export type PromptCachePolicyMode = 'gemini_cached_content';

--- a/packages/core/src/llm/credentials.ts
+++ b/packages/core/src/llm/credentials.ts
@@ -122,12 +122,24 @@ export interface CredentialResolveOptions {
 // Environment variable map
 // ---------------------------------------------------------------------------
 
-/** Maps each provider transport to its canonical environment variable name. */
+/**
+ * Maps each provider transport to its canonical environment variable name.
+ *
+ * NOTE: `bedrock` is informational — AWS Bedrock uses the AWS SDK credential
+ * chain (`AWS_PROFILE` / `~/.aws/credentials` / IAM role / SSO), not a single
+ * API-key env var. The credential-pool resolves Bedrock via `authType: 'aws_sdk'`
+ * and never reads the `accessToken` field from env.
+ */
 const ENV_VARS: Record<ModelTransport, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',
   gemini: 'GEMINI_API_KEY',
   moonshot: 'MOONSHOT_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+  bedrock: 'AWS_PROFILE',
+  deepseek: 'DEEPSEEK_API_KEY',
+  xai: 'XAI_API_KEY',
+  groq: 'GROQ_API_KEY',
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/llm/transports/anthropic.ts
+++ b/packages/core/src/llm/transports/anthropic.ts
@@ -9,8 +9,13 @@
  * where `defaultHeaders` carries OAuth `Authorization: Bearer …` headers when
  * the credential was resolved as `authType: 'oauth'`.
  *
+ * W0c adds stub `stream()` + `apiMode` for compile parity with the extended
+ * `LlmTransport` interface. Wave 1c migration (T-llm-p4-1c) replaces the stub
+ * with a real streaming implementation backed by the Anthropic SDK event stream.
+ *
  * @module llm/transports/anthropic
  * @task T9263
+ * @task T9282 (W0c — stub stream() + apiMode)
  * @epic T-LLM-CRED-CENTRALIZATION
  */
 
@@ -25,6 +30,7 @@ import type {
   ToolUseBlock,
 } from '@anthropic-ai/sdk/resources/messages/messages.js';
 
+import type { NormalizedDelta, TransportContext } from '@cleocode/contracts/llm/interfaces.js';
 import type {
   LlmTransport,
   NormalizedResponse,
@@ -34,6 +40,7 @@ import type {
   TransportRequest,
   TransportTool,
 } from '@cleocode/contracts/llm/normalized-response.js';
+import type { ApiMode } from '@cleocode/contracts/llm/provider-id.js';
 
 // ---------------------------------------------------------------------------
 // Constructor options
@@ -80,11 +87,37 @@ function isThinkingBlock(block: ContentBlock): block is ThinkingBlock {
 // ---------------------------------------------------------------------------
 
 /**
+ * Extract plain-text content from a message's `content` field.
+ *
+ * Handles the W0c multimodal union: when `content` is a string, returns it
+ * directly. When it is a block array, concatenates text blocks and drops image
+ * blocks. The Anthropic native multimodal path (sending actual image blocks in
+ * the API request) is wired in Wave 1c / Wave 4d.
+ *
+ * @param content - Message content field (string or block array).
+ * @returns Plain-text string for Anthropic SDK message params.
+ */
+function extractPlainText(content: TransportMessage['content']): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  return content
+    .filter(
+      (block): block is { readonly type: 'text'; readonly text: string } => block.type === 'text',
+    )
+    .map((block) => block.text)
+    .join('');
+}
+
+/**
  * Maps a provider-neutral {@link TransportMessage} array to the Anthropic
  * `MessageParam[]` format.
  *
  * Tool-result messages (`role: 'tool'`) are mapped to `role: 'user'` with a
  * `tool_result` content block, as required by the Anthropic Messages API.
+ *
+ * Multimodal content blocks (W0c extension): text blocks are concatenated;
+ * image blocks are dropped until Wave 1c wires native Anthropic image support.
  */
 function mapMessages(messages: TransportMessage[]): MessageParam[] {
   return messages.map((msg): MessageParam => {
@@ -95,14 +128,14 @@ function mapMessages(messages: TransportMessage[]): MessageParam[] {
           {
             type: 'tool_result',
             tool_use_id: msg.toolUseId ?? '',
-            content: msg.content,
+            content: extractPlainText(msg.content),
           },
         ],
       };
     }
     return {
       role: msg.role,
-      content: msg.content,
+      content: extractPlainText(msg.content),
     };
   });
 }
@@ -196,6 +229,13 @@ export class AnthropicTransport implements LlmTransport {
   /** Provider identifier — always `'anthropic'`. */
   readonly provider = 'anthropic' as const;
 
+  /**
+   * Wire protocol spoken by this transport — always `'anthropic_messages'`.
+   *
+   * @see ADR-072 §Type lock-in
+   */
+  readonly apiMode: ApiMode = 'anthropic_messages' as const;
+
   private readonly _client: Anthropic;
 
   /**
@@ -219,9 +259,12 @@ export class AnthropicTransport implements LlmTransport {
    * {@link NormalizedResponse}.
    *
    * @param request - Provider-neutral request parameters.
+   * @param _ctx - Transport context (request ID, abort signal). Currently unused
+   *   by this implementation; `request.signal` takes precedence for abort support.
+   *   Wave 1c wires `ctx.requestId` into provider telemetry.
    * @returns Normalized response including content, tool calls, usage, and raw SDK object.
    */
-  async complete(request: TransportRequest): Promise<NormalizedResponse> {
+  async complete(request: TransportRequest, _ctx?: TransportContext): Promise<NormalizedResponse> {
     const { model, messages, maxTokens, system, tools, temperature, signal } = request;
 
     const anthropicMessages = mapMessages(messages);
@@ -254,5 +297,29 @@ export class AnthropicTransport implements LlmTransport {
       ...(reasoning != null ? { reasoning } : {}),
       raw: response,
     };
+  }
+
+  /**
+   * Stream a completion against the Anthropic Messages API.
+   *
+   * STUB: W1 migration will implement stream() for anthropic.
+   *
+   * Wave 1c (T-llm-p4-1c) replaces this stub with a real implementation
+   * backed by the Anthropic SDK's streaming event source. The real
+   * implementation will run deltas through `StreamingThinkScrubber` before
+   * yielding, routing reasoning blocks to `delta.reasoning` and visible text
+   * to `delta.text`.
+   *
+   * @param _request - Ignored until Wave 1c implementation lands.
+   * @param _ctx - Ignored until Wave 1c implementation lands.
+   * @throws {Error} Always, until the real implementation lands in Wave 1c.
+   */
+  // biome-ignore lint/correctness/useYield: stub — Wave 1c replaces with real streaming impl
+  async *stream(
+    _request: TransportRequest,
+    _ctx: TransportContext,
+  ): AsyncIterable<NormalizedDelta> {
+    // STUB: W1 migration will implement stream() for anthropic
+    throw new Error('STUB: W1 migration will implement stream() for anthropic');
   }
 }

--- a/packages/core/src/llm/transports/chat-completions.ts
+++ b/packages/core/src/llm/transports/chat-completions.ts
@@ -13,25 +13,32 @@
  *
  * Deferred from MVP (documented as TODO):
  * - ProviderProfile hook callbacks (prepareMessages, buildExtraBody,
- *   buildApiKwargsExtras) — these require a breaking contract extension.
- *   Tracked as TODO(T9272+): wire ProviderProfile hooks once contract is
- *   extended (deferred to next session).
- * - Streaming (handled at the agent loop level by the auxiliary router).
+ *   buildApiKwargsExtras) — the contract is now extended in W0c. Wire-up is
+ *   tracked as T-llm-p4-1d (Wave 1d — Moonshot + chat-completions quirks
+ *   consolidation moves inline quirks into per-provider profile hooks).
  * - Multi-turn tool replay (agent loop responsibility).
+ *
+ * W0c adds stub `stream()` + `apiMode` for compile parity with the extended
+ * `LlmTransport` interface. Wave 1d migration (T-llm-p4-1d) replaces the stub
+ * with a real streaming implementation.
  *
  * @module llm/transports/chat-completions
  * @task T9272
+ * @task T9282 (W0c — stub stream() + apiMode)
  * @epic T9261 (T-LLM-CRED-CENTRALIZATION Phase 3)
  */
 
+import type { NormalizedDelta, TransportContext } from '@cleocode/contracts/llm/interfaces.js';
 import type {
   LlmTransport,
   NormalizedResponse,
   NormalizedToolCall,
   NormalizedUsage,
+  TransportMessage,
   TransportRequest,
   TransportTool,
 } from '@cleocode/contracts/llm/normalized-response.js';
+import type { ApiMode } from '@cleocode/contracts/llm/provider-id.js';
 import type { ModelTransport } from '@cleocode/contracts/operations/llm.js';
 import OpenAI from 'openai';
 
@@ -104,6 +111,16 @@ export class ChatCompletionsTransport implements LlmTransport {
    */
   readonly provider: ModelTransport;
 
+  /**
+   * Wire protocol spoken by this transport — always `'chat_completions'`.
+   *
+   * All providers served by this transport (OpenRouter, DeepSeek, xAI, Groq,
+   * Moonshot, Gemini-via-shim, etc.) use the OpenAI chat completions wire format.
+   *
+   * @see ADR-072 §Type lock-in
+   */
+  readonly apiMode: ApiMode = 'chat_completions' as const;
+
   /** Underlying OpenAI-compatible SDK client. */
   private readonly _client: OpenAI;
 
@@ -131,9 +148,11 @@ export class ChatCompletionsTransport implements LlmTransport {
    * raw SDK response into a {@link NormalizedResponse}.
    *
    * @param request - Provider-neutral request parameters.
+   * @param _ctx - Transport context (request ID, abort signal). Currently unused;
+   *   `request.signal` takes precedence for abort support.
    * @returns Normalized response envelope.
    */
-  async complete(request: TransportRequest): Promise<NormalizedResponse> {
+  async complete(request: TransportRequest, _ctx?: TransportContext): Promise<NormalizedResponse> {
     const messages = this._convertMessages(request);
     const tools =
       request.tools && request.tools.length > 0 ? this._convertTools(request.tools) : undefined;
@@ -169,8 +188,13 @@ export class ChatCompletionsTransport implements LlmTransport {
    * message, which is the canonical OpenAI representation understood by all
    * OpenAI-compatible providers.
    *
-   * TODO(T9272+): wire ProviderProfile.prepareMessages hook once the contract
-   * is extended (deferred to next session).
+   * Multimodal content blocks (W0c — {@link TransportMessage.content} union):
+   * when `content` is an array, text blocks are concatenated and image blocks
+   * are dropped (this transport currently operates in `'text'`-equivalent mode).
+   * Wave 1d wires `request.imageMode` and ProviderProfile hooks to control this.
+   *
+   * TODO(T9272+/W1d): wire ProviderProfile.prepareMessages + imageMode routing
+   * once Wave 1d migration lands.
    *
    * @param request - Full transport request.
    * @returns Array of OpenAI-compatible message objects.
@@ -181,7 +205,7 @@ export class ChatCompletionsTransport implements LlmTransport {
       msgs.push({ role: 'system', content: request.system });
     }
     for (const m of request.messages) {
-      msgs.push({ role: m.role, content: m.content });
+      msgs.push({ role: m.role, content: extractTextContent(m) });
     }
     return msgs;
   }
@@ -350,6 +374,57 @@ export class ChatCompletionsTransport implements LlmTransport {
       raw: response,
     };
   }
+
+  /**
+   * Stream a completion against the OpenAI-compatible chat completions endpoint.
+   *
+   * STUB: W1 migration will implement stream() for chat-completions.
+   *
+   * Wave 1d (T-llm-p4-1d) replaces this stub with a real streaming
+   * implementation that wires `ProviderProfile` hooks and routes deltas
+   * through `StreamingThinkScrubber`.
+   *
+   * @param _request - Ignored until Wave 1d implementation lands.
+   * @param _ctx - Ignored until Wave 1d implementation lands.
+   * @throws {Error} Always, until the real implementation lands in Wave 1d.
+   */
+  // biome-ignore lint/correctness/useYield: stub — Wave 1d replaces with real streaming impl
+  async *stream(
+    _request: TransportRequest,
+    _ctx: TransportContext,
+  ): AsyncIterable<NormalizedDelta> {
+    // STUB: W1 migration will implement stream() for chat-completions
+    throw new Error('STUB: W1 migration will implement stream() for chat-completions');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Content extraction helpers (module-private)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract plain-text content from a {@link TransportMessage}.
+ *
+ * When `content` is a plain string, returns it as-is. When it is a multimodal
+ * block array (W0c extension), concatenates all `text` blocks and drops `image`
+ * blocks. This transport currently operates in text-only mode for multimodal
+ * content; Wave 1d will wire `request.imageMode` and `ProviderProfile` hooks
+ * for native image support.
+ *
+ * @param message - The transport message to extract text from.
+ * @returns Plain text string for the OpenAI wire format.
+ */
+function extractTextContent(message: TransportMessage): string {
+  if (typeof message.content === 'string') {
+    return message.content;
+  }
+  // Multimodal array — concatenate text blocks, drop image blocks.
+  return message.content
+    .filter(
+      (block): block is { readonly type: 'text'; readonly text: string } => block.type === 'text',
+    )
+    .map((block) => block.text)
+    .join('');
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/llm/transports/gemini.ts
+++ b/packages/core/src/llm/transports/gemini.ts
@@ -7,16 +7,25 @@
  * `E_NOT_IMPLEMENTED` until T-llm-p3-X (future task) wires the real
  * Gemini implementation.
  *
+ * W0c adds stub `stream()` + `apiMode` for compile parity with the extended
+ * `LlmTransport` interface. Wave 1a migration (T-llm-p4-1a) replaces the stub
+ * with a real implementation that absorbs `backends/gemini.ts` logic. `apiMode`
+ * is `'chat_completions'` because Gemini currently routes through the
+ * OpenAI-compatible shim; a native Gemini ApiMode is deferred to Phase 5.
+ *
  * @module llm/transports/gemini
  * @task T9263
+ * @task T9282 (W0c — stub stream() + apiMode)
  * @epic T-LLM-CRED-CENTRALIZATION
  */
 
+import type { NormalizedDelta, TransportContext } from '@cleocode/contracts/llm/interfaces.js';
 import type {
   LlmTransport,
   NormalizedResponse,
   TransportRequest,
 } from '@cleocode/contracts/llm/normalized-response.js';
+import type { ApiMode } from '@cleocode/contracts/llm/provider-id.js';
 
 // ---------------------------------------------------------------------------
 // Constructor options (parallel to AnthropicTransportOptions)
@@ -68,7 +77,14 @@ export class GeminiNotImplementedError extends Error {
  *
  * Satisfies the {@link LlmTransport} interface but always throws
  * {@link GeminiNotImplementedError} from `complete()`. Replace with the real
- * implementation when T-llm-p3-X (future task) lands.
+ * implementation when T-llm-p4-1a (Wave 1a migration) lands.
+ *
+ * W0c adds stub `stream()` + `apiMode` for compile parity. Wave 1a replaces
+ * them with a real implementation that absorbs `backends/gemini.ts` logic,
+ * including Gemini caching via `geminiCacheStore`, schema sanitization
+ * (`GEMINI_ALLOWED_SCHEMA_KEYS`), and `GEMINI_BLOCKED_FINISH_REASONS` safety
+ * handling. `apiMode` is `'chat_completions'` because Gemini currently routes
+ * through the OpenAI-compatible shim; native Gemini ApiMode is Phase 5.
  *
  * @example
  * ```ts
@@ -81,6 +97,16 @@ export class GeminiTransport implements LlmTransport {
   /** Provider identifier — always `'gemini'`. */
   readonly provider = 'gemini' as const;
 
+  /**
+   * Wire protocol spoken by this transport — `'chat_completions'`.
+   *
+   * Gemini currently routes through the OpenAI-compatible shim. A native
+   * `'gemini_native'` ApiMode is deferred to Phase 5 per ADR-072.
+   *
+   * @see ADR-072 §Type lock-in
+   */
+  readonly apiMode: ApiMode = 'chat_completions' as const;
+
   /** @param _options - Accepted for constructor parity with AnthropicTransport. */
   constructor(_options: GeminiTransportOptions) {
     // Intentionally empty — real impl initialises the SDK client here.
@@ -90,13 +116,36 @@ export class GeminiTransport implements LlmTransport {
    * Not yet implemented — always throws {@link GeminiNotImplementedError}.
    *
    * @param _request - Ignored.
+   * @param _ctx - Ignored.
    * @throws {GeminiNotImplementedError} Always, until the real implementation lands.
    */
-  complete(_request: TransportRequest): Promise<NormalizedResponse> {
+  complete(_request: TransportRequest, _ctx?: TransportContext): Promise<NormalizedResponse> {
     return Promise.reject(
       new GeminiNotImplementedError(
-        'Gemini transport not yet wired — use Anthropic until T-llm-p3-X (future task) lands',
+        'Gemini transport not yet wired — use Anthropic until T-llm-p4-1a (Wave 1a migration) lands',
       ),
     );
+  }
+
+  /**
+   * Stream a completion against the Gemini API.
+   *
+   * STUB: W1 migration will implement stream() for gemini.
+   *
+   * Wave 1a (T-llm-p4-1a) replaces this stub with a real implementation
+   * that absorbs `backends/gemini.ts` streaming logic, Gemini safety-reason
+   * handling, and schema sanitization.
+   *
+   * @param _request - Ignored until Wave 1a implementation lands.
+   * @param _ctx - Ignored until Wave 1a implementation lands.
+   * @throws {Error} Always, until the real implementation lands in Wave 1a.
+   */
+  // biome-ignore lint/correctness/useYield: stub — Wave 1a replaces with real streaming impl
+  async *stream(
+    _request: TransportRequest,
+    _ctx: TransportContext,
+  ): AsyncIterable<NormalizedDelta> {
+    // STUB: W1 migration will implement stream() for gemini
+    throw new Error('STUB: W1 migration will implement stream() for gemini');
   }
 }

--- a/packages/core/src/llm/transports/openai.ts
+++ b/packages/core/src/llm/transports/openai.ts
@@ -7,16 +7,23 @@
  * `E_NOT_IMPLEMENTED` until T-llm-p3-X (future task) wires the real
  * OpenAI implementation.
  *
+ * W0c adds stub `stream()` + `apiMode` for compile parity with the extended
+ * `LlmTransport` interface. Wave 1b migration (T-llm-p4-1b) replaces the stub
+ * with a real implementation backed by the OpenAI SDK streaming API.
+ *
  * @module llm/transports/openai
  * @task T9263
+ * @task T9282 (W0c — stub stream() + apiMode)
  * @epic T-LLM-CRED-CENTRALIZATION
  */
 
+import type { NormalizedDelta, TransportContext } from '@cleocode/contracts/llm/interfaces.js';
 import type {
   LlmTransport,
   NormalizedResponse,
   TransportRequest,
 } from '@cleocode/contracts/llm/normalized-response.js';
+import type { ApiMode } from '@cleocode/contracts/llm/provider-id.js';
 
 // ---------------------------------------------------------------------------
 // Constructor options (parallel to AnthropicTransportOptions)
@@ -68,7 +75,12 @@ export class OpenAINotImplementedError extends Error {
  *
  * Satisfies the {@link LlmTransport} interface but always throws
  * {@link OpenAINotImplementedError} from `complete()`. Replace with the real
- * implementation when T-llm-p3-X (future task) lands.
+ * implementation when T-llm-p4-1b (Wave 1b migration) lands.
+ *
+ * W0c adds stub `stream()` + `apiMode` for compile parity. Wave 1b replaces
+ * them with a real implementation backed by the OpenAI SDK streaming API,
+ * including `usesMaxCompletionTokens` o-series branching and reasoning content
+ * extraction via `extractReasoningContent`.
  *
  * @example
  * ```ts
@@ -81,6 +93,13 @@ export class OpenAITransport implements LlmTransport {
   /** Provider identifier — always `'openai'`. */
   readonly provider = 'openai' as const;
 
+  /**
+   * Wire protocol spoken by this transport — always `'chat_completions'`.
+   *
+   * @see ADR-072 §Type lock-in
+   */
+  readonly apiMode: ApiMode = 'chat_completions' as const;
+
   /** @param _options - Accepted for constructor parity with AnthropicTransport. */
   constructor(_options: OpenAITransportOptions) {
     // Intentionally empty — real impl initialises the SDK client here.
@@ -90,13 +109,36 @@ export class OpenAITransport implements LlmTransport {
    * Not yet implemented — always throws {@link OpenAINotImplementedError}.
    *
    * @param _request - Ignored.
+   * @param _ctx - Ignored.
    * @throws {OpenAINotImplementedError} Always, until the real implementation lands.
    */
-  complete(_request: TransportRequest): Promise<NormalizedResponse> {
+  complete(_request: TransportRequest, _ctx?: TransportContext): Promise<NormalizedResponse> {
     return Promise.reject(
       new OpenAINotImplementedError(
-        'OpenAI transport not yet wired — use Anthropic until T-llm-p3-X (future task) lands',
+        'OpenAI transport not yet wired — use Anthropic until T-llm-p4-1b (Wave 1b migration) lands',
       ),
     );
+  }
+
+  /**
+   * Stream a completion against the OpenAI chat completions API.
+   *
+   * STUB: W1 migration will implement stream() for openai.
+   *
+   * Wave 1b (T-llm-p4-1b) replaces this stub with a real implementation
+   * backed by the OpenAI SDK streaming API, including `usesMaxCompletionTokens`
+   * o-series branching and `extractReasoningContent` try/catch handling.
+   *
+   * @param _request - Ignored until Wave 1b implementation lands.
+   * @param _ctx - Ignored until Wave 1b implementation lands.
+   * @throws {Error} Always, until the real implementation lands in Wave 1b.
+   */
+  // biome-ignore lint/correctness/useYield: stub — Wave 1b replaces with real streaming impl
+  async *stream(
+    _request: TransportRequest,
+    _ctx: TransportContext,
+  ): AsyncIterable<NormalizedDelta> {
+    // STUB: W1 migration will implement stream() for openai
+    throw new Error('STUB: W1 migration will implement stream() for openai');
   }
 }


### PR DESCRIPTION
## Summary

Hard gate before any Wave 1 PR can compile. Extends the existing Phase 3 contract types with Phase 4 interface members, and adds compile-time stubs to the 4 existing transport files so the codebase continues to typecheck.

**Contract extensions (additive — no breaking changes to existing fields):**
- `TransportRequest`: `cacheStrategy?` + `imageMode?` (W4d image routing + cache injection)
- `TransportMessage.content`: extended from `string` to `string | ReadonlyArray<TransportTextBlock | TransportImageBlock>` (multimodal block union; backwards-compatible)
- `LlmTransport`: `readonly apiMode: ApiMode` + `stream(request, ctx): AsyncIterable<NormalizedDelta>` (ADR-072 §Decision)
- `LlmTransport.complete()`: `ctx?: TransportContext` optional parameter added
- `ProviderProfile`: `prepareMessages?` + `buildExtraBody?` + `buildApiKwargsExtras?` optional hooks (Hermes §3.1 port)
- `ModelTransport`: deprecated alias `Extract<ProviderId, BuiltinProviderId>` (ADR-072 §Type lock-in)

**Transport stubs (compile parity — Wave 1 replaces each):**
- `anthropic.ts`: `apiMode = 'anthropic_messages'` + `stream()` stub + `extractPlainText()` multimodal helper
- `openai.ts`: `apiMode = 'chat_completions'` + `stream()` stub
- `gemini.ts`: `apiMode = 'chat_completions'` + `stream()` stub
- `chat-completions.ts`: `apiMode = 'chat_completions'` + `stream()` stub + `extractTextContent()` multimodal helper

## Test plan

- [x] `grep -c 'STUB: W1 migration' packages/core/src/llm/transports/{anthropic,openai,gemini,chat-completions}.ts` — each shows 3 hits (in TSDoc, biome suppression comment, and throw)
- [x] Biome check: 2 infos only (cosmetic empty-constructor suggestions), zero errors
- [x] Contracts LLM files typecheck standalone with tsc — clean
- [x] No new type errors in transport files beyond pre-existing missing-module issues (worktree environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)