### PR TITLE
fix(T9261): biome auto-fix release CI lint errors

### DIFF
--- a/packages/core/src/llm/cli-ops.ts
+++ b/packages/core/src/llm/cli-ops.ts
@@ -163,7 +163,7 @@ export async function llmAdd(params: LlmAddParams): Promise<EngineResult<LlmAddR
     return engineError('E_INVALID_INPUT', 'apiKey is required');
   }
   const authType = params.authType ?? detectAuthType(params.apiKey);
-  const label = params.label && params.label.trim() ? params.label.trim() : 'default';
+  const label = params.label?.trim() ? params.label.trim() : 'default';
 
   try {
     const stored = await addCredential({

--- a/packages/core/src/llm/role-executor.ts
+++ b/packages/core/src/llm/role-executor.ts
@@ -34,15 +34,11 @@ import type {
   NormalizedUsage,
   TransportRequest,
 } from '@cleocode/contracts/llm/normalized-response.js';
-
-import type { ModelTransport } from './types-config.js';
+import { getKimiCodeMshHeaders, isKimiCodeApiKey } from './provider-registry/builtin/kimi-code.js';
 import { resolveLLMForRole } from './role-resolver.js';
-import {
-  getKimiCodeMshHeaders,
-  isKimiCodeApiKey,
-} from './provider-registry/builtin/kimi-code.js';
 import { AnthropicTransport } from './transports/anthropic.js';
 import { ChatCompletionsTransport } from './transports/chat-completions.js';
+import type { ModelTransport } from './types-config.js';
 
 /** Kimi Code chat endpoint — speaks Anthropic Messages protocol. */
 const KIMI_CODE_BASE_URL = 'https://api.kimi.com/coding';

--- a/packages/core/src/sentient/daemon.ts
+++ b/packages/core/src/sentient/daemon.ts
@@ -669,7 +669,7 @@ export async function bootstrapDaemon(
         );
       } catch (err) {
         process.stderr.write(
-          `${new Date().toISOString()} [CLEO SENTIENT] tick error (caught at cron boundary): ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+          `${new Date().toISOString()} [CLEO SENTIENT] tick error (caught at cron boundary): ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
         );
       }
     },
@@ -697,7 +697,7 @@ export async function bootstrapDaemon(
         );
       } catch (err) {
         process.stderr.write(
-          `${new Date().toISOString()} [CLEO SENTIENT T2] propose error (caught at cron boundary): ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+          `${new Date().toISOString()} [CLEO SENTIENT T2] propose error (caught at cron boundary): ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
         );
       }
     },
@@ -741,7 +741,7 @@ export async function bootstrapDaemon(
         );
       } catch (err) {
         process.stderr.write(
-          `${new Date().toISOString()} [CLEO SENTIENT HYGIENE] error (caught at cron boundary): ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+          `${new Date().toISOString()} [CLEO SENTIENT HYGIENE] error (caught at cron boundary): ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
         );
       }
     },

--- a/scripts/brain-backfill-runner.ts
+++ b/scripts/brain-backfill-runner.ts
@@ -81,7 +81,7 @@ let result: {
 
 try {
   result = JSON.parse(jsonText) as typeof result;
-} catch (parseErr) {
+} catch (_parseErr) {
   console.error('Back-fill FAILED: Could not parse JSON output');
   console.error('Raw output:', rawOutput);
   process.exit(1);

--- a/scripts/migrate-memory-md-to-brain.ts
+++ b/scripts/migrate-memory-md-to-brain.ts
@@ -333,7 +333,7 @@ function importEntry(entry: ParsedMemoryFile, dryRun: boolean): boolean {
   }
 
   const result = callCleo(cmdArgs);
-  if (!result || !result.success) {
+  if (!result?.success) {
     console.error(`  [ERROR] ${entry.fileName}: ${result?.error ?? 'unknown error'}`);
     return false;
   }


### PR DESCRIPTION
Auto-fix from `biome check --write --unsafe` on the 6 errors that blocked v2026.5.67 release CI. No wiring or types changed — only style (sorted imports, optional chains, unused-var rename, parens around `err.stack ?? err.message` inside ternary).

Files: role-executor.ts, daemon.ts, cli-ops.ts, brain-backfill-runner.ts, migrate-memory-md-to-brain.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)