### PR TITLE
release: ship v2026.5.69 (T9261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [2026.5.69] (2026-05-15)
+
+Auto-prepared by release.ship (T9261)
+
+### Features
+- **T-llm-p4-2a: Implement ConcreteSession**: Wave 2a — ConcreteSession. The state-holder layer. Wires Phase 3 utilities at retry-loop hook points (W4a, W4e fill them in). (T9287)
+- **T-llm-p4-2b: Implement LlmSessionFactory**: Wave 2b — single entry point for session construction. Replaces scattered new Anthropic() + new OpenAI() patterns across the codebase. (T9288)
+- **T-llm-p4-3a: Implement ConcreteExecutor with optional ContextEngine**: Wave 3a — ConcreteExecutor. Critical: contextEngine is OPTIONAL (W6c injects default later). V3 caught this ordering gap — without explicit nullabl... (T9290)
+- **T-llm-p4-3b: Implement LlmExecutorFactory**: Wave 3b — single entry point for executor construction. (T9291)
+
+### Chores
+- **T-llm-p4-1a: Migrate backends/gemini.ts INTO transports/gemini.ts**: Wave 1a — Gemini migration. First in V2-recommended order (lowest blast radius). Zero autonomous consumers. Tests the wrapper pattern before high-r... (T9283)
+- **T-llm-p4-1b: Migrate backends/openai.ts INTO transports/openai.ts**: Wave 1b — OpenAI migration. Can be authored in parallel with W1c (different registry.ts branches) but MERGES after W1a. The usesMaxCompletionTokens... (T9284)
+- **T-llm-p4-1c: Migrate backends/anthropic.ts INTO transports/anthropic.ts**: Wave 1c — Anthropic migration. HIGHEST blast radius. 7 call chains, 5 autonomous. Runs LAST in Wave 1 order. Per V2 top risk: do NOT skip structure... (T9285)
+- **T-llm-p4-1d: Migrate backends/moonshot.ts to ProviderProfile hooks in chat-completions.ts**: Wave 1d — Moonshot + chat-completions quirks consolidation. Closes the TODO(T9272+) debt by moving inline _applyProviderQuirks logic into proper Pr... (T9286)
+- **T-llm-p4-5a: Migrate api.ts to LlmExecutorFactory**: Wave 5a — migrate api.ts call site. (T9298)
+- **T-llm-p4-5b: Migrate tool-loop.ts to executor.run() event stream**: Wave 5b — migrate tool-loop.ts. (T9299)
+- **T-llm-p4-5c: Migrate memory/sentient/tasks consumers to LlmExecutorFactory.createForRole**: Wave 5c — migrate all six Phase 1 call sites that originally bypassed unified architecture. May ship as 6 separate sub-PRs if needed for rollback g... (T9300)
+- **T-llm-p4-6c: ContextEngine interface + default LlmSummarizationEngine + sleep-consolidation refactor**: Wave 6c — ContextEngine (T9278 reframed). Default engine only; plugin registry surface is Phase 5. (T9304)
+- **T-llm-p4-7a: Remove daemon LLM config field + schema bump + role-resolver simplification**: Wave 7a — config cleanup. Deprecated since Phase 2; finally removed under Option C. (T9306)
+
+### Changes
+- **T-llm-p4-2c: Retire ProviderBackend interface + request-builder + runtime.planAttempt**: Wave 2c — retire the legacy interface and supporting modules. After Wave 1 + 2a + 2b land, these files are functionally dead. Combined Wave 1 + 2c ... (T9289)
+- **T-llm-p4-3c: Retire legacy executor.ts (cleoLlmCallInner)**: Wave 3c — retire executor.ts. Combines with W5a/W5b call-site migrations. (T9292)
+- **T-llm-p4-4a: Wire classifyError into ConcreteSession retry path (closes T9270 AC)**: Wave 4a — closes the T9270 AC violation. ClassifiedError flags drive retry decisions instead of raw status codes. Note: per ADR-072 the field is sh... (T9293)
+- **T-llm-p4-4b: Wire usage-pricing + session journal + cleo llm cost CLI (closes T9274 AC)**: Wave 4b — closes the T9274 AC violation. V3 identified session journal schema gap; this task defines + implements it. (T9294)
+- **T-llm-p4-4c: Wire think-scrubber into streaming (BREAKING API change to scrubber)**: Wave 4c — V1 caught that scrubber.feed() returns string and DISCARDS reasoning. Cannot produce delta.reasoning/delta.text split without breaking ch... (T9295)
+- **T-llm-p4-4d: Wire image-routing into LlmTransport.complete() validators**: Wave 4d — wire image-routing utility into transport validators. (T9296)
+- **T-llm-p4-4e: Wire CredentialPool + RateLimitGuard into session retry + storedToResolved adapter**: Wave 4e — pool + guard wiring. V1 caught the storedToResolved adapter gap (pool returns StoredCredential; session needs ResolvedCredential). This t... (T9297)
+- **T-llm-p4-5d: Auxiliary router consolidation — absorb routeAuxiliaryCall into ConcreteExecutor.auxiliary()**: Wave 5d — consolidate auxiliary routing. Default: delete auxiliary-router.ts after callers migrated. Owner can flip at PR review per plan §Open dec... (T9301)
+- **T-llm-p4-6a: OAuth PKCE flow + cleo llm login dispatcher**: Wave 6a — PKCE OAuth (T9277 reframed). Hermes anthropic_adapter §4.3.2 inspires the PKCE flow; we port only the protocol, not the 2080 LOC adapter. (T9302)
+- **T-llm-p4-6b: Adaptive thinking-budget calculator (wires model-metadata)**: Wave 6b — adaptive thinking budget. V1 caught that model-metadata.ts was missing from wire-up table; this closes the loop. (T9303)
+- **T-llm-p4-6d: Plugin LLM facade — pluginLlmComplete with redaction**: Wave 6d — plugin facade (T9279 reframed). MVP only; CLEO worktree isolation already covers sandboxing layer. (T9305)
+- **T-llm-p4-7b: Adapter circular-dep fix — parseClaudeCodeCredentials to contracts**: Wave 7b — break circular dep cleanly per V1 finding. Leaf module in contracts; both core and adapters import from there. (T9307)
+- **T-llm-p4-7c: Rename LlmTransport type alias to LlmProviderTransport**: Wave 7c — disambiguate the alias from the interface. V2 caught the naming conflict. (T9308)
+- T9321 follow-up: wire kimi-code to cleo llm login + CredentialPool refresh hook + llm-status resolvedSource (T9323)
+---
 ## [2026.5.68] (2026-05-15)
 
 Auto-prepared by release.ship (T9261)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.68"
+version = "2026.5.69"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.68",
+  "version": "2026.5.69",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
Phase 4 W5-W8 release: 13 commits across consumer migration (W5), Hermes deep ports (W6), cleanup (W7), Kimi closure (T9323). Merges of PR #143 (W1-W4) + PR #145 (W5-W8). Full SSoT, zero legacy debt. CHANGELOG auto-generated.

## Validation summary

- 16+11+5 = 32 unit tests verified locally + CI
- All CI checks green on PR #145 (the underlying merge)
- Repo-wide typecheck + biome ci green
- backend.ts types remain SSoT in core/llm/; legacy-types.ts deleted
- auxiliary-router.ts deleted (Option A)
- DaemonLLMConfig deleted; schema bumped 2.10.0 → 2.11.0
- parseClaudeCodeCredentials hoisted to @cleocode/contracts
- LlmTransport type alias → LlmProviderTransport (frees the new interface name)
- OAuth dispatcher: single _refreshOAuthCredential keyed on profile.oauth.mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)