### PR TITLE
fix(T9337): pre-clean dist/ to prevent orphan artifacts in tarballs · ship v2026.5.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2026.5.72] (2026-05-15)
+
+### Fixed
+
+- **build.mjs now wipes `packages/*/dist/` + `tsconfig.tsbuildinfo` before each
+  full build** (T9337 follow-up). The v2026.5.71 publish surfaced a latent
+  packaging bug: deleting `packages/core/src/tasks/verifier-runner.ts` and
+  `verifier-stub-generator.ts` left orphan `dist/tasks/verifier-runner.js`
+  and `verifier-stub-generator.js` artifacts (esbuild + tsc overwrite but do
+  not delete). npm shipped those orphans inside the @cleocode/core tarball
+  even though no source imported them. The pre-clean step makes the published
+  tarball reflect the live source tree exactly — files whose source has been
+  removed are guaranteed to be absent.
+
 ## [2026.5.71] (2026-05-15)
 
 ### Breaking Changes

--- a/build.mjs
+++ b/build.mjs
@@ -543,6 +543,41 @@ async function build() {
   // to ship silently (see validateCoreEntryPoints() above for details).
   validateCoreEntryPoints();
 
+  // Pre-build clean: wipe every packages/*/dist/ directory so files whose
+  // source has been deleted cannot survive into the next published tarball.
+  // Without this, deleting src/foo.ts leaves dist/foo.js orphaned and npm
+  // still ships it (the substrate-removal scenario at T9337 hit exactly
+  // this — v2026.5.71's @cleocode/core tarball still contained the stale
+  // verifier-runner.js after the source was deleted). The cost is ~1s for
+  // a full reinstall of the type-declaration cache on the next build.
+  console.log('[build] Pre-clean: wiping packages/*/dist + tsbuildinfo');
+  const PRE_CLEAN_PKGS = [
+    'adapters',
+    'caamp',
+    'cant',
+    'cleo',
+    'cleo-os',
+    'contracts',
+    'core',
+    'git-shim',
+    'lafs',
+    'mcp-adapter',
+    'nexus',
+    'paths',
+    'playbooks',
+    'runtime',
+    'worktree',
+  ];
+  const PRE_CLEAN_TARGETS = PRE_CLEAN_PKGS.flatMap((p) => [
+    `packages/${p}/dist`,
+    `packages/${p}/tsconfig.tsbuildinfo`,
+  ]);
+  await Promise.all(
+    PRE_CLEAN_TARGETS.map((p) =>
+      rm(resolve(__dirname, p), { recursive: true, force: true }),
+    ),
+  );
+
   // Build order is topological. Independent packages within each wave are
   // launched in parallel via Promise.all() to reduce wall-clock time.
   // Dependency constraints (each package must see its deps' dist/ before it

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.71",
+  "version": "2026.5.72",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Follow-up to PR #149 (v2026.5.71 verifier-substrate removal). Fixes a latent
packaging bug surfaced when validating the v2026.5.71 npm tarball.

**Symptom**: deleting `packages/core/src/tasks/verifier-runner.ts` and
`verifier-stub-generator.ts` left orphan `dist/tasks/verifier-runner.js` +
`.js.map` + `.d.ts` artifacts in the build output. esbuild and tsc overwrite
files when source compiles, but they do **not** delete dist files whose
source has been removed. The orphans rode along into `npm publish` because
`packages/core/package.json#files` includes `dist/`.

**Result**: `@cleocode/core@2026.5.71` on npm still contained
`verifier-runner.js` even though T9337 deleted the source. Dead code
shipped in production — not loaded by anything, but offensive to the
"no legacy, no tech debt" directive.

## Fix

`build.mjs` now runs a pre-clean pass that wipes every
`packages/*/dist/` directory AND `packages/*/tsconfig.tsbuildinfo` before
the first wave starts. `tsbuildinfo` must go too — tsc -b uses it for
incremental builds and would otherwise say "up to date" against a wiped
dist (the paths package hit this on the first attempt).

Cost: ~1s on the next build for the type-declaration cache to repopulate.

## Test plan

- [x] `pnpm run build` from main: green, ~53s end-to-end
- [x] `find packages -name "verifier-runner*" -o -name "verifier-stub-generator*"` returns zero results post-build
- [x] `pnpm biome ci packages/ scripts/` — green
- [ ] CI green on this PR (build + typecheck + unit tests)
- [ ] After merge + tag, verify the v2026.5.72 npm tarball contains no verifier-* files

## Refs

- T9337 (verifier-substrate removal)
- council run `20260515T211404Z-d3749e90`
- PR #149 (the original removal — this is the packaging follow-up)
- ADR-051

🤖 Generated with [Claude Code](https://claude.com/claude-code)