### PR TITLE
refactor(T9326): Anthropic OAuth placeholder hardening + stale device-code TODO sweep

### DIFF
--- a/packages/core/src/llm/__tests__/oauth-device-code.test.ts
+++ b/packages/core/src/llm/__tests__/oauth-device-code.test.ts
@@ -5,8 +5,9 @@
  * real HTTP requests are made. Vitest fake timers are used to advance past
  * polling intervals without wall-clock delays.
  *
- * @task T9266
- * @epic T-LLM-CRED-CENTRALIZATION
+ * @task T9321
+ * @task T9326
+ * @epic T9261 T-LLM-CRED-CENTRALIZATION
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -14,6 +15,8 @@ import {
   DeviceCodeAuthError,
   type DeviceCodeConfig,
   DeviceCodeTimeoutError,
+  getDeviceCodeConfig,
+  getKimiCodeDeviceCodeConfig,
   pollForToken,
   startDeviceCodeFlow,
 } from '../oauth/device-code.js';
@@ -383,5 +386,48 @@ describe('pollForToken — network error retry', () => {
     expect(result.ok).toBe(false);
     expect((result as { ok: false; error: unknown }).error).toBeInstanceOf(TypeError);
     expect(String((result as { ok: false; error: unknown }).error)).toContain('fetch failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider scope — kimi-code is the only device-code provider (T9326)
+// ---------------------------------------------------------------------------
+
+describe('getDeviceCodeConfig — provider scope', () => {
+  it('returns a config for kimi-code', () => {
+    const cfg = getDeviceCodeConfig('kimi-code');
+    expect(cfg.provider).toBe('kimi-code');
+    expect(cfg.deviceCodeUrl).toContain('device_authorization');
+    expect(cfg.tokenUrl).toContain('oauth/token');
+    expect(cfg.clientId).toBeTruthy();
+  });
+
+  it('throws for anthropic — device-code is not supported (PKCE is canonical)', () => {
+    expect(() => getDeviceCodeConfig('anthropic')).toThrow(
+      "No device-code config preset for provider 'anthropic'",
+    );
+  });
+
+  it('throws for unknown provider', () => {
+    expect(() => getDeviceCodeConfig('unknown-provider')).toThrow(
+      "No device-code config preset for provider 'unknown-provider'",
+    );
+  });
+});
+
+describe('getKimiCodeDeviceCodeConfig', () => {
+  it('uses KIMI_CODE_OAUTH_HOST env var when set', () => {
+    process.env['KIMI_CODE_OAUTH_HOST'] = 'https://custom-auth.example.com';
+    const cfg = getKimiCodeDeviceCodeConfig();
+    expect(cfg.deviceCodeUrl.startsWith('https://custom-auth.example.com')).toBe(true);
+    expect(cfg.tokenUrl.startsWith('https://custom-auth.example.com')).toBe(true);
+    delete process.env['KIMI_CODE_OAUTH_HOST'];
+  });
+
+  it('defaults to https://auth.kimi.com when env var is absent', () => {
+    delete process.env['KIMI_CODE_OAUTH_HOST'];
+    const cfg = getKimiCodeDeviceCodeConfig();
+    expect(cfg.deviceCodeUrl.startsWith('https://auth.kimi.com')).toBe(true);
+    expect(cfg.tokenUrl.startsWith('https://auth.kimi.com')).toBe(true);
   });
 });

--- a/packages/core/src/llm/__tests__/oauth/anthropic-client-id.test.ts
+++ b/packages/core/src/llm/__tests__/oauth/anthropic-client-id.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for Anthropic OAuth client ID resolution in the builtin provider profile.
+ *
+ * Verifies:
+ *   1. `CLEO_ANTHROPIC_OAUTH_CLIENT_ID` env var is honored when set.
+ *   2. A warning is emitted to stderr when the placeholder is used.
+ *   3. `ANTHROPIC_OAUTH_CLIENT_ID_PLACEHOLDER` exports the known placeholder value.
+ *
+ * Note: `anthropicProfile` is constructed at module load time, so tests must
+ * reset the module cache between runs (via `vi.resetModules()`) to exercise
+ * different env-var states.
+ *
+ * @task T9326
+ * @epic T9261 T-LLM-CRED-CENTRALIZATION
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ENV_KEY = 'CLEO_ANTHROPIC_OAUTH_CLIENT_ID';
+
+async function loadAnthropicModule() {
+  const mod = await import(
+    '../../provider-registry/builtin/anthropic.js?t=' + Date.now().toString()
+  );
+  return mod as typeof import('../../provider-registry/builtin/anthropic.js');
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let savedEnv: string | undefined;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  savedEnv = process.env[ENV_KEY];
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = savedEnv;
+  }
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ANTHROPIC_OAUTH_CLIENT_ID_PLACEHOLDER', () => {
+  it('exports the Hermes-sourced placeholder value', async () => {
+    delete process.env[ENV_KEY];
+    const { ANTHROPIC_OAUTH_CLIENT_ID_PLACEHOLDER } = await loadAnthropicModule();
+    expect(ANTHROPIC_OAUTH_CLIENT_ID_PLACEHOLDER).toBe('9d1c250a-e61b-44d9-88ed-5944d1962f5e');
+  });
+});
+
+describe('anthropicProfile.oauth.clientId — env override', () => {
+  it('uses CLEO_ANTHROPIC_OAUTH_CLIENT_ID when set', async () => {
+    process.env[ENV_KEY] = 'my-real-client-id';
+    const { anthropicProfile } = await loadAnthropicModule();
+    expect(anthropicProfile.oauth?.clientId).toBe('my-real-client-id');
+  });
+
+  it('does NOT emit a stderr warning when env override is set', async () => {
+    process.env[ENV_KEY] = 'my-real-client-id';
+    await loadAnthropicModule();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('anthropicProfile.oauth.clientId — placeholder fallback', () => {
+  it('falls back to the placeholder when env var is absent', async () => {
+    delete process.env[ENV_KEY];
+    const { anthropicProfile, ANTHROPIC_OAUTH_CLIENT_ID_PLACEHOLDER } = await loadAnthropicModule();
+    expect(anthropicProfile.oauth?.clientId).toBe(ANTHROPIC_OAUTH_CLIENT_ID_PLACEHOLDER);
+  });
+
+  it('emits a stderr warning that references T9341 when placeholder is used', async () => {
+    delete process.env[ENV_KEY];
+    await loadAnthropicModule();
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    const [msg] = stderrSpy.mock.calls[0] as [string];
+    expect(msg).toContain('[anthropic-oauth]');
+    expect(msg).toContain('CLEO_ANTHROPIC_OAUTH_CLIENT_ID');
+    expect(msg).toContain('T9341');
+  });
+});

--- a/packages/core/src/llm/oauth/device-code.ts
+++ b/packages/core/src/llm/oauth/device-code.ts
@@ -7,29 +7,15 @@
  *   2. Poll the token endpoint every `interval` seconds until the user
  *      approves, the code expires, or a non-recoverable error is returned.
  *
- * ## Anthropic OAuth status (TODO T9266)
+ * ## Provider scope
  *
- * As of 2026-05-13, Anthropic does **not** publicly document a device-code
- * OAuth endpoint. The Hermes reference implementation (`anthropic_adapter.py`)
- * uses PKCE (`/oauth/authorize` → authorization-code exchange), not
- * device-code. The `anthropic` preset below encodes our best-effort
- * understanding of where a device-code endpoint *would* live if Anthropic
- * exposes one in the future:
- *
- *   deviceCodeUrl:  https://console.anthropic.com/v1/oauth/device/code
- *   tokenUrl:       https://console.anthropic.com/v1/oauth/token
- *
- * These MUST be verified against official Anthropic documentation before
- * the `anthropic` provider can be considered production-ready in this flow.
- *
- * The client ID `"9d1c250a-e61b-44d9-88ed-5944d1962f5e"` is sourced from
- * the Hermes reference implementation (`hermes_cli/auth_commands.py`). It
- * is not an officially published Anthropic client ID and may need to be
- * replaced when CLEO registers its own OAuth application.
+ * Device-code OAuth is used by **kimi-code** only. Anthropic uses RFC 7636
+ * PKCE (see `pkce.ts` and `builtin/anthropic.ts`). The `anthropic` preset
+ * was removed in T9326 — PKCE is the canonical Anthropic OAuth path per T9302.
  *
  * @module llm/oauth/device-code
- * @task T9266
- * @epic T-LLM-CRED-CENTRALIZATION
+ * @task T9321
+ * @epic T9261 T-LLM-CRED-CENTRALIZATION
  */
 
 // ---------------------------------------------------------------------------
@@ -42,12 +28,10 @@
  * All URLs and client credentials are provider-specific; callers can pass
  * a preset from `getDeviceCodeConfig()` or build a custom config for any
  * provider that supports RFC 8628.
- *
- * @task T9266
  */
 export interface DeviceCodeConfig {
   /** Provider name (used only for logging / error messages). */
-  provider: 'anthropic' | string;
+  provider: 'kimi-code' | string;
   /**
    * Device authorization endpoint (RFC 8628 §3.1).
    *
@@ -77,8 +61,6 @@ export interface DeviceCodeConfig {
 
 /**
  * Response from the device authorization endpoint (RFC 8628 §3.2).
- *
- * @task T9266
  */
 export interface DeviceCodeStartResponse {
   /** Opaque device code used when polling the token endpoint. */
@@ -106,8 +88,6 @@ export interface DeviceCodeStartResponse {
 
 /**
  * Successful token response from the device-code polling endpoint.
- *
- * @task T9266
  */
 export interface DeviceCodeTokenResponse {
   /** Bearer access token. */
@@ -132,8 +112,6 @@ export interface DeviceCodeTokenResponse {
 /**
  * Thrown by `pollForToken` when the device code expires before the user
  * approves the request.
- *
- * @task T9266
  */
 export class DeviceCodeTimeoutError extends Error {
   readonly provider: string;
@@ -152,8 +130,6 @@ export class DeviceCodeTimeoutError extends Error {
 /**
  * Thrown by `pollForToken` when the provider returns an unrecoverable error
  * (anything other than `authorization_pending` or `slow_down`).
- *
- * @task T9266
  */
 export class DeviceCodeAuthError extends Error {
   readonly provider: string;
@@ -176,19 +152,12 @@ export class DeviceCodeAuthError extends Error {
 /**
  * Build a `DeviceCodeConfig` for a named provider.
  *
- * Currently only `'anthropic'` is wired. The Anthropic preset is based on
- * best-effort endpoint inference — see the module-level TODO for the
- * verification requirement.
+ * Currently only `'kimi-code'` is wired. Anthropic uses PKCE, not
+ * device-code — see `pkce.ts` and `builtin/anthropic.ts`.
  *
  * @throws {Error} When `provider` is not a known preset.
- * @task T9266
  */
-export function getDeviceCodeConfig(
-  provider: 'anthropic' | 'kimi-code' | string,
-): DeviceCodeConfig {
-  if (provider === 'anthropic') {
-    return getAnthropicDeviceCodeConfig();
-  }
+export function getDeviceCodeConfig(provider: 'kimi-code' | string): DeviceCodeConfig {
   if (provider === 'kimi-code') {
     return getKimiCodeDeviceCodeConfig();
   }
@@ -198,26 +167,6 @@ export function getDeviceCodeConfig(
   );
 }
 
-/**
- * Build the `DeviceCodeConfig` for Anthropic.
- *
- * ## TODO (T9266) — endpoint verification required
- *
- * Anthropic does not currently document a public device-code OAuth endpoint.
- * The URLs below are inferred from the Hermes reference and the standard
- * RFC 8628 path layout. They MUST be verified before marking this flow
- * production-ready.
- *
- * - `deviceCodeUrl`: https://console.anthropic.com/v1/oauth/device/code
- *   (TODO: verify; may not exist — Hermes uses PKCE, not device-code)
- * - `tokenUrl`: https://console.anthropic.com/v1/oauth/token
- *   (confirmed from Hermes `refresh_anthropic_oauth_pure`)
- * - `clientId`: `"9d1c250a-e61b-44d9-88ed-5944d1962f5e"`
- *   (sourced from Hermes — not officially published by Anthropic; CLEO
- *   may need to register its own application)
- *
- * @task T9266
- */
 /**
  * Build the `DeviceCodeConfig` for Kimi Code (kimi.com/code).
  *
@@ -255,27 +204,6 @@ export function getKimiCodeDeviceCodeConfig(): DeviceCodeConfig {
     // Scope is returned by the server as `kimi-code` but is not sent on the
     // device-authorization request per RFC 8628 §3.1 (optional). Including
     // it has no effect; the server ignores unknown scopes.
-  };
-}
-
-export function getAnthropicDeviceCodeConfig(): DeviceCodeConfig {
-  return {
-    provider: 'anthropic',
-    // TODO(T9266): verify this endpoint exists — Anthropic may not support
-    // device-code OAuth. Fall back to PKCE flow if this returns 404/405.
-    deviceCodeUrl: 'https://console.anthropic.com/v1/oauth/device/code',
-    // Confirmed from Hermes refresh_anthropic_oauth_pure — also tried:
-    // https://platform.claude.com/v1/oauth/token
-    tokenUrl: 'https://console.anthropic.com/v1/oauth/token',
-    // TODO(T9266): replace with CLEO's own registered client ID once
-    // Anthropic OAuth app registration is complete.
-    clientId: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
-    scope: 'org:create_api_key user:profile user:inference',
-    defaultHeaders: {
-      // TODO(T9266): verify the correct anthropic-beta header value for
-      // device-code OAuth (if the endpoint exists).
-      'anthropic-beta': 'oauth-2025-04-20',
-    },
   };
 }
 
@@ -322,7 +250,6 @@ function encodeForm(params: Record<string, string>): string {
  * poll with.
  *
  * @throws {Error} On HTTP errors or a response that is missing required fields.
- * @task T9266
  */
 export async function startDeviceCodeFlow(cfg: DeviceCodeConfig): Promise<DeviceCodeStartResponse> {
   const body: Record<string, string> = { client_id: cfg.clientId };
@@ -405,7 +332,6 @@ export async function startDeviceCodeFlow(cfg: DeviceCodeConfig): Promise<Device
  * @throws {DeviceCodeTimeoutError} When `expiresIn` is reached without approval.
  * @throws {DeviceCodeAuthError} When the provider returns a non-recoverable error.
  * @throws {Error} When network retries are exhausted.
- * @task T9266
  */
 export async function pollForToken(
   cfg: DeviceCodeConfig,

--- a/packages/core/src/llm/provider-registry/builtin/anthropic.ts
+++ b/packages/core/src/llm/provider-registry/builtin/anthropic.ts
@@ -14,24 +14,53 @@ import type { ProviderProfile } from '@cleocode/contracts';
 import type { ProviderOAuthConfig } from '@cleocode/contracts/llm/oauth.js';
 
 /**
+ * Placeholder Anthropic OAuth client ID sourced from the Hermes reference
+ * implementation (`hermes_cli/auth_commands.py`).
+ *
+ * This is NOT an officially published Anthropic client ID. CLEO must register
+ * its own OAuth application before end-to-end PKCE login can work against real
+ * Anthropic OAuth endpoints. See T9341 for the owner-action registration step.
+ *
+ * Override at runtime via `CLEO_ANTHROPIC_OAUTH_CLIENT_ID` env var once a real
+ * client ID is obtained — no code change required.
+ *
+ * @see T9341 — owner-action: register CLEO as an Anthropic OAuth application
+ */
+export const ANTHROPIC_OAUTH_CLIENT_ID_PLACEHOLDER = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+
+/**
+ * Resolve the Anthropic OAuth client ID.
+ *
+ * Prefers `CLEO_ANTHROPIC_OAUTH_CLIENT_ID` env var; falls back to the
+ * placeholder and emits a one-time stderr warning so operators know the
+ * placeholder is in use.
+ */
+function resolveAnthropicClientId(): string {
+  const envId = process.env['CLEO_ANTHROPIC_OAUTH_CLIENT_ID'];
+  if (envId) return envId;
+  process.stderr.write(
+    '[anthropic-oauth] Using placeholder client_id; set CLEO_ANTHROPIC_OAUTH_CLIENT_ID to your registered ID. See T9341.\n',
+  );
+  return ANTHROPIC_OAUTH_CLIENT_ID_PLACEHOLDER;
+}
+
+/**
  * Anthropic OAuth PKCE configuration.
  *
- * Anthropic uses RFC 7636 PKCE (not device-code). The client ID below is
- * sourced from the Hermes reference implementation (`hermes_cli/auth_commands.py`).
- * It is not an officially published Anthropic client ID — CLEO may need to
- * register its own OAuth application once Anthropic opens public registration.
+ * Anthropic uses RFC 7636 PKCE (not device-code). The client ID is resolved
+ * from `CLEO_ANTHROPIC_OAUTH_CLIENT_ID` env var at runtime, falling back to
+ * the Hermes-sourced placeholder when the env var is absent.
  *
  * Endpoints sourced from the Hermes `anthropic_adapter.py` PKCE flow:
  *   - authorizationEndpoint: https://claude.ai/oauth/authorize
  *   - tokenEndpoint:         https://console.anthropic.com/v1/oauth/token
  *
  * @task T9302
+ * @see T9341 — register CLEO as an Anthropic OAuth application (owner action)
  */
 const ANTHROPIC_OAUTH: ProviderOAuthConfig = {
   mode: 'pkce',
-  // TODO(T9302): replace with CLEO's own registered client ID once Anthropic
-  // OAuth app registration is complete.
-  clientId: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
+  clientId: resolveAnthropicClientId(),
   authorizationEndpoint: 'https://claude.ai/oauth/authorize',
   tokenEndpoint: 'https://console.anthropic.com/v1/oauth/token',
   scope: 'org:create_api_key user:profile user:inference',


### PR DESCRIPTION
## Summary

- Exports `ANTHROPIC_OAUTH_CLIENT_ID_PLACEHOLDER` constant and adds `CLEO_ANTHROPIC_OAUTH_CLIENT_ID` env override in `builtin/anthropic.ts` — operators can supply a real client ID without a code change once Anthropic OAuth app registration completes
- Emits a clear stderr warning `[anthropic-oauth] Using placeholder client_id; set CLEO_ANTHROPIC_OAUTH_CLIENT_ID to your registered ID. See T9341.` when placeholder is in use
- Deletes `getAnthropicDeviceCodeConfig()` + 5 stale `TODO(T9266)` markers from `device-code.ts` — Anthropic uses PKCE (T9302), device-code is kimi-code only
- Narrows `getDeviceCodeConfig()` signature to `'kimi-code' | string` and updates module header doc
- 9 new tests (5 anthropic client-id resolution + 4 device-code provider scope)

## Task links

- Closes T9326
- AC#3 (real client_id registered with Anthropic, end-to-end PKCE flow verified) deferred to **T9341** (owner-action: Anthropic OAuth app registration)
- Part of epic T9261 (T-LLM-CRED-CENTRALIZATION Phase 5)

## Test plan

- [x] 24/24 oauth tests pass (`pnpm --filter @cleocode/core exec vitest run src/llm/__tests__/oauth-device-code.test.ts src/llm/__tests__/oauth/anthropic-client-id.test.ts`)
- [x] `pnpm biome ci` clean on all 4 changed files
- [x] Pre-existing build failures in `validate-ops.ts` + `isolation.ts` confirmed present on `main` before this branch — not introduced by T9326

🤖 Generated with [Claude Code](https://claude.com/claude-code)