### PR TITLE
feat(T9319): multi-provider auxiliary fallback chain

### DIFF
--- a/packages/cleo/src/dispatch/domains/llm/index.ts
+++ b/packages/cleo/src/dispatch/domains/llm/index.ts
@@ -17,6 +17,7 @@
 
 import {
   llmAdd,
+  llmAuxiliaryStatus,
   llmList,
   llmProfile,
   llmRemove,
@@ -42,6 +43,7 @@ const coreOps = {
   list: llmList,
   test: llmTest,
   whoami: llmWhoami,
+  'auxiliary-status': llmAuxiliaryStatus,
   add: llmAdd,
   remove: llmRemove,
   use: llmUse,
@@ -91,6 +93,8 @@ const _llmTypedHandler = defineTypedHandler<LlmOps>('llm', {
   list: async (params) => wrap(coreOps['list'], params, 'list'),
   test: async (params) => wrap(coreOps['test'], params, 'test'),
   whoami: async (params) => wrap(coreOps['whoami'], params, 'whoami'),
+  'auxiliary-status': async (params) =>
+    wrap(coreOps['auxiliary-status'], params, 'auxiliary-status'),
 
   // -------------------------------------------------------------------------
   // Mutate ops
@@ -106,7 +110,7 @@ const _llmTypedHandler = defineTypedHandler<LlmOps>('llm', {
 // Op sets — validated before dispatch
 // ---------------------------------------------------------------------------
 
-const QUERY_OPS = new Set<string>(['list', 'test', 'whoami']);
+const QUERY_OPS = new Set<string>(['list', 'test', 'whoami', 'auxiliary-status']);
 const MUTATE_OPS = new Set<string>(['add', 'remove', 'use', 'profile']);
 
 // ---------------------------------------------------------------------------
@@ -127,7 +131,7 @@ export class LlmHandler implements DomainHandler {
   /** Declared operations for introspection and validation. */
   getSupportedOperations(): { query: string[]; mutate: string[] } {
     return {
-      query: ['list', 'test', 'whoami'],
+      query: ['list', 'test', 'whoami', 'auxiliary-status'],
       mutate: ['add', 'remove', 'use', 'profile'],
     };
   }

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -7111,6 +7111,27 @@ export const OPERATIONS: OperationDef[] = [
     ] satisfies ParamDef[],
   },
 
+  // llm query: auxiliary-status — show configured auxiliary fallback chain
+  {
+    gateway: 'query',
+    domain: 'llm',
+    operation: 'auxiliary-status',
+    description:
+      'llm.auxiliary-status (query) — show the active multi-provider auxiliary fallback chain and how to configure it (T9319)',
+    tier: 2,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: [],
+    params: [
+      {
+        name: 'projectRoot',
+        type: 'string',
+        required: false,
+        description: 'Optional project root for config resolution',
+      },
+    ] satisfies ParamDef[],
+  },
+
   // llm mutate: add — upsert credential into the pool
   {
     gateway: 'mutate',

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -682,6 +682,9 @@ export type {
   // `cleo llm` CLI / dispatch operation contracts (T9258)
   LlmAddParams,
   LlmAddResult,
+  LlmAuxiliaryChainEntry,
+  LlmAuxiliaryStatusParams,
+  LlmAuxiliaryStatusResult,
   LlmListParams,
   LlmListResult,
   LlmProfileParams,

--- a/packages/contracts/src/operations/llm.ts
+++ b/packages/contracts/src/operations/llm.ts
@@ -568,6 +568,59 @@ export interface LlmWhoamiResult {
 // generated entry as a plain ProviderProfile literal.
 
 // ---------------------------------------------------------------------------
+// llm auxiliary-status types (T9319)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single entry in the auxiliary fallback chain as surfaced by
+ * `cleo llm auxiliary-status`.
+ *
+ * @task T9319
+ */
+export interface LlmAuxiliaryChainEntry {
+  /** Provider transport identifier (e.g. `'anthropic'`, `'openrouter'`). */
+  provider: ModelTransport;
+  /** Optional pinned model for this provider. Omitted when using role-resolved default. */
+  model?: string;
+}
+
+/**
+ * Parameters for `llm.auxiliary-status` (query).
+ *
+ * @task T9319
+ */
+export interface LlmAuxiliaryStatusParams {
+  /** Optional project root for config resolution. */
+  projectRoot?: string;
+}
+
+/**
+ * Result envelope for `llm.auxiliary-status` (query).
+ *
+ * @task T9319
+ */
+export interface LlmAuxiliaryStatusResult {
+  /**
+   * The active auxiliary fallback chain.
+   *
+   * When `source === 'config'`, reflects `llm.auxiliaryFallback` in config.
+   * When `source === 'default'`, the built-in default chain is active.
+   */
+  chain: LlmAuxiliaryChainEntry[];
+  /**
+   * How the chain was resolved.
+   *
+   * - `'config'` — explicitly configured via `cleo config set llm.auxiliaryFallback`.
+   * - `'default'` — no config found; built-in default chain in use.
+   */
+  source: 'config' | 'default';
+  /** Human-readable config path users can set to change the chain. */
+  configKey: string;
+  /** Example value for the config key. */
+  configExample: string;
+}
+
+// ---------------------------------------------------------------------------
 // llm-status types (T9323)
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1691,12 +1691,14 @@ export {
 export { initCoreSkills, installHandoffRedirectStubs } from './init.js';
 export {
   llmAdd,
+  llmAuxiliaryStatus,
   llmList,
   llmProfile,
   llmRemove,
   llmTest,
   llmUse,
   llmWhoami,
+  resolveAuxiliaryFallbackChain,
 } from './llm/cli-ops.js';
 export type {
   CredentialResolveOptions,

--- a/packages/core/src/llm/__tests__/auxiliary-fallback.test.ts
+++ b/packages/core/src/llm/__tests__/auxiliary-fallback.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Unit tests for the multi-provider auxiliary fallback chain (T9319).
+ *
+ * Uses injected mock providers — no network calls.
+ *
+ * @task T9319
+ * @epic T9261 T-LLM-CRED-CENTRALIZATION
+ */
+
+import type { NormalizedResponse } from '@cleocode/contracts/llm/normalized-response.js';
+import { describe, expect, it } from 'vitest';
+import {
+  AllProvidersExhaustedError,
+  type AuxiliaryFallbackChain,
+  type AuxiliaryProvider,
+  DEFAULT_AUXILIARY_FALLBACK_CHAIN,
+  parseAuxiliaryFallbackChain,
+  runAuxiliaryWithFallback,
+} from '../auxiliary-fallback.js';
+import { PoolExhaustedError } from '../credential-pool.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResponse(provider: string): NormalizedResponse {
+  return {
+    id: `resp-${provider}`,
+    model: `model-${provider}`,
+    content: `Hello from ${provider}`,
+    toolCalls: null,
+    stopReason: 'end_turn',
+    usage: { inputTokens: 10, outputTokens: 5 },
+    raw: {},
+  };
+}
+
+function makeMessages() {
+  return [{ role: 'user' as const, content: 'ping' }];
+}
+
+/** Provider that always succeeds. */
+function successProvider(provider: string): AuxiliaryProvider {
+  return async (_entry, _messages, _opts) => makeResponse(provider);
+}
+
+/** Provider that always throws PoolExhaustedError. */
+function exhaustedProvider(provider: string): AuxiliaryProvider {
+  return async (entry, _messages, _opts) => {
+    throw new PoolExhaustedError(entry.provider, 1, Date.now() + 60_000);
+  };
+}
+
+/** Provider that always throws a generic network error. */
+function networkErrorProvider(message: string): AuxiliaryProvider {
+  return async (_entry, _messages, _opts) => {
+    const err = new Error(message);
+    (err as Error & { status?: number }).status = 500;
+    throw err;
+  };
+}
+
+/** Provider that succeeds on the Nth call (0-indexed). */
+function succeedOnCallProvider(successCallIndex: number, provider: string): AuxiliaryProvider {
+  let callCount = 0;
+  return async (entry, _messages, _opts) => {
+    const idx = callCount++;
+    if (idx === successCallIndex) return makeResponse(provider);
+    throw new PoolExhaustedError(entry.provider, 1, Date.now() + 60_000);
+  };
+}
+
+/** Dispatch provider: each entry in the chain gets its own mock. */
+function perProviderDispatch(providerMap: Record<string, AuxiliaryProvider>): AuxiliaryProvider {
+  return async (entry, messages, opts) => {
+    const mock = providerMap[entry.provider];
+    if (!mock) throw new PoolExhaustedError(entry.provider, 0, 0);
+    return mock(entry, messages, opts);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runAuxiliaryWithFallback
+// ---------------------------------------------------------------------------
+
+describe('runAuxiliaryWithFallback', () => {
+  it('returns response immediately when first provider succeeds', async () => {
+    const chain: AuxiliaryFallbackChain = [{ provider: 'anthropic' }, { provider: 'openrouter' }];
+    const result = await runAuxiliaryWithFallback(
+      chain,
+      makeMessages(),
+      undefined,
+      successProvider('anthropic'),
+    );
+
+    expect(result.content).toBe('Hello from anthropic');
+    expect(result.meta.fallbackChain).toHaveLength(1);
+    expect(result.meta.fallbackChain[0]).toMatchObject({
+      provider: 'anthropic',
+      outcome: 'success',
+    });
+  });
+
+  it('falls back to second provider when first pool is exhausted', async () => {
+    const chain: AuxiliaryFallbackChain = [{ provider: 'anthropic' }, { provider: 'openrouter' }];
+    const provider = perProviderDispatch({
+      anthropic: exhaustedProvider('anthropic'),
+      openrouter: successProvider('openrouter'),
+    });
+
+    const result = await runAuxiliaryWithFallback(chain, makeMessages(), undefined, provider);
+
+    expect(result.content).toBe('Hello from openrouter');
+    expect(result.meta.fallbackChain).toHaveLength(2);
+    expect(result.meta.fallbackChain[0]).toMatchObject({
+      provider: 'anthropic',
+      outcome: 'pool_exhausted',
+    });
+    expect(result.meta.fallbackChain[1]).toMatchObject({
+      provider: 'openrouter',
+      outcome: 'success',
+    });
+  });
+
+  it('falls back through two providers to the third', async () => {
+    const chain: AuxiliaryFallbackChain = [
+      { provider: 'anthropic' },
+      { provider: 'openrouter' },
+      { provider: 'groq' },
+    ];
+    const provider = perProviderDispatch({
+      anthropic: exhaustedProvider('anthropic'),
+      openrouter: exhaustedProvider('openrouter'),
+      groq: successProvider('groq'),
+    });
+
+    const result = await runAuxiliaryWithFallback(chain, makeMessages(), undefined, provider);
+
+    expect(result.content).toBe('Hello from groq');
+    expect(result.meta.fallbackChain).toHaveLength(3);
+    expect(result.meta.fallbackChain[2]).toMatchObject({
+      provider: 'groq',
+      outcome: 'success',
+    });
+  });
+
+  it('throws AllProvidersExhaustedError when entire chain is exhausted', async () => {
+    const chain: AuxiliaryFallbackChain = [
+      { provider: 'anthropic' },
+      { provider: 'openrouter' },
+      { provider: 'groq' },
+    ];
+
+    await expect(
+      runAuxiliaryWithFallback(chain, makeMessages(), undefined, exhaustedProvider('any')),
+    ).rejects.toBeInstanceOf(AllProvidersExhaustedError);
+  });
+
+  it('AllProvidersExhaustedError carries all steps', async () => {
+    const chain: AuxiliaryFallbackChain = [{ provider: 'anthropic' }, { provider: 'openrouter' }];
+
+    let caught: AllProvidersExhaustedError | null = null;
+    try {
+      await runAuxiliaryWithFallback(chain, makeMessages(), undefined, exhaustedProvider('any'));
+    } catch (err) {
+      if (err instanceof AllProvidersExhaustedError) caught = err;
+    }
+
+    expect(caught).not.toBeNull();
+    expect(caught!.steps).toHaveLength(2);
+    expect(caught!.steps.map((s) => s.provider)).toEqual(['anthropic', 'openrouter']);
+    expect(caught!.steps.every((s) => s.outcome === 'pool_exhausted')).toBe(true);
+    expect(caught!.code).toBe('E_LLM_ALL_PROVIDERS_EXHAUSTED');
+  });
+
+  it('also falls back on generic non-pool errors (network/5xx)', async () => {
+    const chain: AuxiliaryFallbackChain = [{ provider: 'anthropic' }, { provider: 'openrouter' }];
+    const provider = perProviderDispatch({
+      anthropic: networkErrorProvider('connection refused'),
+      openrouter: successProvider('openrouter'),
+    });
+
+    const result = await runAuxiliaryWithFallback(chain, makeMessages(), undefined, provider);
+
+    expect(result.content).toBe('Hello from openrouter');
+    expect(result.meta.fallbackChain[0]).toMatchObject({
+      provider: 'anthropic',
+      outcome: 'error',
+      errorMessage: 'connection refused',
+    });
+  });
+
+  it('throws AllProvidersExhaustedError on empty chain', async () => {
+    await expect(
+      runAuxiliaryWithFallback([], makeMessages(), undefined, successProvider('x')),
+    ).rejects.toBeInstanceOf(AllProvidersExhaustedError);
+  });
+
+  it('attaches meta to providerData on the response', async () => {
+    const chain: AuxiliaryFallbackChain = [{ provider: 'anthropic' }];
+    const result = await runAuxiliaryWithFallback(
+      chain,
+      makeMessages(),
+      undefined,
+      successProvider('anthropic'),
+    );
+
+    expect(result.providerData).toBeDefined();
+    expect(result.providerData!['__fallbackMeta']).toEqual(result.meta);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAuxiliaryFallbackChain
+// ---------------------------------------------------------------------------
+
+describe('parseAuxiliaryFallbackChain', () => {
+  it('parses comma-separated providers', () => {
+    const chain = parseAuxiliaryFallbackChain('anthropic,openrouter,groq');
+    expect(chain).toHaveLength(3);
+    expect(chain[0]).toEqual({ provider: 'anthropic' });
+    expect(chain[1]).toEqual({ provider: 'openrouter' });
+    expect(chain[2]).toEqual({ provider: 'groq' });
+  });
+
+  it('parses provider:model syntax', () => {
+    const chain = parseAuxiliaryFallbackChain(
+      'anthropic:claude-haiku-4-5-20251001,openrouter,groq:llama-3.1-8b',
+    );
+    expect(chain[0]).toEqual({ provider: 'anthropic', model: 'claude-haiku-4-5-20251001' });
+    expect(chain[1]).toEqual({ provider: 'openrouter' });
+    expect(chain[2]).toEqual({ provider: 'groq', model: 'llama-3.1-8b' });
+  });
+
+  it('trims whitespace around entries', () => {
+    const chain = parseAuxiliaryFallbackChain(' anthropic , openrouter , groq ');
+    expect(chain.map((e) => e.provider)).toEqual(['anthropic', 'openrouter', 'groq']);
+  });
+
+  it('falls back to default chain on empty input', () => {
+    const chain = parseAuxiliaryFallbackChain('');
+    expect(chain).toEqual(DEFAULT_AUXILIARY_FALLBACK_CHAIN);
+  });
+
+  it('falls back to default chain on whitespace-only input', () => {
+    const chain = parseAuxiliaryFallbackChain('   ');
+    expect(chain).toEqual(DEFAULT_AUXILIARY_FALLBACK_CHAIN);
+  });
+
+  it('silently drops empty entries from comma list', () => {
+    const chain = parseAuxiliaryFallbackChain('anthropic,,groq');
+    expect(chain.map((e) => e.provider)).toEqual(['anthropic', 'groq']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_AUXILIARY_FALLBACK_CHAIN
+// ---------------------------------------------------------------------------
+
+describe('DEFAULT_AUXILIARY_FALLBACK_CHAIN', () => {
+  it('has at least 3 providers', () => {
+    expect(DEFAULT_AUXILIARY_FALLBACK_CHAIN.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('starts with anthropic', () => {
+    expect(DEFAULT_AUXILIARY_FALLBACK_CHAIN[0]?.provider).toBe('anthropic');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AllProvidersExhaustedError
+// ---------------------------------------------------------------------------
+
+describe('AllProvidersExhaustedError', () => {
+  it('has stable error code', () => {
+    const err = new AllProvidersExhaustedError([]);
+    expect(err.code).toBe('E_LLM_ALL_PROVIDERS_EXHAUSTED');
+    expect(err.name).toBe('AllProvidersExhaustedError');
+  });
+
+  it('includes provider names in message', () => {
+    const err = new AllProvidersExhaustedError([
+      { provider: 'anthropic', outcome: 'pool_exhausted' },
+      { provider: 'groq', outcome: 'error', errorMessage: 'timeout' },
+    ]);
+    expect(err.message).toContain('anthropic');
+    expect(err.message).toContain('groq');
+  });
+});

--- a/packages/core/src/llm/auxiliary-fallback.ts
+++ b/packages/core/src/llm/auxiliary-fallback.ts
@@ -1,0 +1,436 @@
+/**
+ * Multi-provider auxiliary fallback chain for CLEO LLM auxiliary calls.
+ *
+ * When the configured provider's credential pool is exhausted (all credentials
+ * on cooldown due to 401/429/connection errors), {@link runAuxiliaryWithFallback}
+ * advances to the next provider in the chain and retries. This prevents auxiliary
+ * calls (context compression, brain dream cycles, hygiene scans) from failing
+ * silently when the primary provider is temporarily unavailable.
+ *
+ * ## Configuration
+ *
+ * Set via `cleo config set llm.auxiliaryFallback "anthropic,openrouter,groq"`.
+ *
+ * The default chain when no config is present: `['anthropic', 'openrouter', 'groq']`.
+ *
+ * @module llm/auxiliary-fallback
+ * @task T9319
+ * @epic T9261 T-LLM-CRED-CENTRALIZATION
+ */
+
+import type { SendOptions } from '@cleocode/contracts/llm/interfaces.js';
+import type {
+  LlmTransport,
+  NormalizedResponse,
+  TransportMessage,
+} from '@cleocode/contracts/llm/normalized-response.js';
+import { PoolExhaustedError } from './credential-pool.js';
+import { classifyError } from './error-classifier.js';
+import type { ModelTransport } from './types-config.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Default auxiliary fallback chain used when `llm.auxiliaryFallback` is not
+ * configured. Anthropic first (most capable for auxiliary tasks), then
+ * OpenRouter (aggregates many providers), then Groq (fast inference).
+ */
+export const DEFAULT_AUXILIARY_FALLBACK_CHAIN: readonly AuxiliaryFallbackEntry[] = [
+  { provider: 'anthropic' },
+  { provider: 'openrouter' },
+  { provider: 'groq' },
+];
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single entry in an {@link AuxiliaryFallbackChain}.
+ *
+ * @task T9319
+ */
+export interface AuxiliaryFallbackEntry {
+  /** Provider transport identifier. */
+  readonly provider: ModelTransport;
+  /**
+   * Optional model override for this provider.
+   *
+   * When omitted, the session factory resolves the model from config
+   * (via role-resolver's implicit-fallback chain).
+   */
+  readonly model?: string;
+}
+
+/**
+ * Ordered list of providers to try for auxiliary LLM calls.
+ *
+ * The chain is tried front-to-back. The first provider whose credential pool
+ * yields a successful response wins. The chain short-circuits immediately on
+ * success — if provider 1 succeeds, providers 2..N are never contacted.
+ *
+ * @task T9319
+ */
+export type AuxiliaryFallbackChain = readonly AuxiliaryFallbackEntry[];
+
+/**
+ * Successful result returned by {@link runAuxiliaryWithFallback}.
+ *
+ * Extends {@link NormalizedResponse} with `meta.fallbackChain` that records
+ * which providers were tried (in order) and which one ultimately succeeded.
+ *
+ * @task T9319
+ */
+export interface AuxiliaryFallbackResult extends NormalizedResponse {
+  /**
+   * Fallback metadata populated when at least one provider was attempted.
+   *
+   * Stored in `providerData['__fallbackMeta']` on the response so the shape
+   * is preserved through existing NormalizedResponse consumers. Access via the
+   * `.meta` shortcut on this interface.
+   */
+  readonly meta: AuxiliaryFallbackMeta;
+}
+
+/**
+ * Fallback path metadata attached to {@link AuxiliaryFallbackResult}.
+ *
+ * @task T9319
+ */
+export interface AuxiliaryFallbackMeta {
+  /**
+   * Ordered list of all providers in the chain that were tried.
+   *
+   * Includes both failed providers (pool-exhausted) and the final successful
+   * provider. The last entry is always the one that produced the response.
+   */
+  readonly fallbackChain: readonly FallbackChainStep[];
+}
+
+/**
+ * A single step in the recorded fallback chain.
+ *
+ * @task T9319
+ */
+export interface FallbackChainStep {
+  /** Provider transport identifier. */
+  readonly provider: ModelTransport;
+  /** Outcome for this provider attempt. */
+  readonly outcome: 'success' | 'pool_exhausted' | 'error';
+  /**
+   * Human-readable error message when `outcome !== 'success'`.
+   *
+   * Omitted on success to avoid leaking unnecessary detail.
+   */
+  readonly errorMessage?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Error class
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by {@link runAuxiliaryWithFallback} when every provider in the chain
+ * has been tried and all have exhausted their credential pools or returned errors.
+ *
+ * `steps` records the full fallback path taken so callers can surface a
+ * structured diagnostic to the user or log it for analysis.
+ *
+ * @task T9319
+ */
+export class AllProvidersExhaustedError extends Error {
+  /** Stable LAFS error code. */
+  readonly code = 'E_LLM_ALL_PROVIDERS_EXHAUSTED';
+
+  /**
+   * @param steps - Ordered record of every provider attempt made, with outcome.
+   */
+  constructor(public readonly steps: readonly FallbackChainStep[]) {
+    const providers = steps.map((s) => s.provider).join(', ');
+    super(
+      `E_LLM_ALL_PROVIDERS_EXHAUSTED: auxiliary call failed on all providers in chain [${providers}]. ` +
+        `Add credentials via 'cleo llm add <provider> <apiKey>' or extend the fallback chain.`,
+    );
+    this.name = 'AllProvidersExhaustedError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exhaustion detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether an error represents pool exhaustion (all credentials for
+ * a provider are on cooldown) or a connection-level failure that justifies
+ * falling through to the next provider in the chain.
+ *
+ * Exhaustion conditions:
+ * - `PoolExhaustedError` — thrown directly by `CredentialPool.pick()`.
+ * - `classifyError().shouldRotateCredential === true` — 401/429 after the pool
+ *   has already been fully rotated (ConcreteSession propagates this).
+ *
+ * Non-exhaustion errors (transient, model-level, etc.) are NOT re-thrown here
+ * because auxiliary calls are best-effort: a timeout or 500 from provider 1
+ * should still fall through to provider 2 so the call has a chance to succeed.
+ *
+ * @param err - The caught error value.
+ * @returns `true` when the chain should advance to the next provider.
+ *
+ * @task T9319
+ */
+function isProviderExhausted(err: unknown): boolean {
+  if (err instanceof PoolExhaustedError) return true;
+  const classified = classifyError(err);
+  return classified.shouldRotateCredential || classified.shouldFallback;
+}
+
+// ---------------------------------------------------------------------------
+// Session provider (injectable for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Function signature for providing a single-turn auxiliary response from a
+ * specific provider.
+ *
+ * Production code uses the DefaultLlmSessionFactory-based implementation.
+ * Tests inject a mock to control per-provider behaviour.
+ *
+ * @internal
+ */
+export type AuxiliaryProvider = (
+  entry: AuxiliaryFallbackEntry,
+  messages: TransportMessage[],
+  opts: SendOptions | undefined,
+) => Promise<NormalizedResponse>;
+
+// ---------------------------------------------------------------------------
+// Core fallback logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute an auxiliary LLM call with multi-provider fallback.
+ *
+ * Iterates through `chain` front-to-back:
+ * 1. Tries provider N's full credential pool (via `provider` fn).
+ * 2. If the pool is exhausted or the call returns a fallback-triggering error,
+ *    records the step as `'pool_exhausted'` and advances to N+1.
+ * 3. On non-exhaustion error (network blip, 500, timeout), records as `'error'`
+ *    and also advances — auxiliary calls are best-effort.
+ * 4. Returns on the first success, attaching `meta.fallbackChain` to the result.
+ * 5. When all providers are tried, throws {@link AllProvidersExhaustedError}.
+ *
+ * @param chain    - Ordered list of providers to try.
+ * @param messages - Messages to pass to the LLM.
+ * @param opts     - Per-call send options forwarded as-is to each provider.
+ * @param provider - Injectable provider function (defaults to session-factory impl).
+ * @returns The first successful {@link AuxiliaryFallbackResult}.
+ * @throws {AllProvidersExhaustedError} When every provider in the chain fails.
+ *
+ * @task T9319
+ */
+export async function runAuxiliaryWithFallback(
+  chain: AuxiliaryFallbackChain,
+  messages: TransportMessage[],
+  opts?: SendOptions,
+  provider?: AuxiliaryProvider,
+): Promise<AuxiliaryFallbackResult> {
+  if (chain.length === 0) {
+    throw new AllProvidersExhaustedError([]);
+  }
+
+  const resolvedProvider = provider ?? _defaultAuxiliaryProvider;
+  const steps: FallbackChainStep[] = [];
+
+  for (const entry of chain) {
+    try {
+      const response = await resolvedProvider(entry, messages, opts);
+      steps.push({ provider: entry.provider, outcome: 'success' });
+      const meta: AuxiliaryFallbackMeta = { fallbackChain: steps };
+      const result: AuxiliaryFallbackResult = {
+        ...response,
+        providerData: { ...(response.providerData ?? {}), __fallbackMeta: meta },
+        meta,
+      };
+      return result;
+    } catch (err: unknown) {
+      const outcome = isProviderExhausted(err) ? 'pool_exhausted' : 'error';
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      steps.push({ provider: entry.provider, outcome, errorMessage });
+    }
+  }
+
+  throw new AllProvidersExhaustedError(steps);
+}
+
+// ---------------------------------------------------------------------------
+// Config reader
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a comma-separated provider string (as stored in `llm.auxiliaryFallback`)
+ * into an {@link AuxiliaryFallbackChain}.
+ *
+ * Invalid/empty entries are silently dropped. If parsing results in an empty
+ * array, returns {@link DEFAULT_AUXILIARY_FALLBACK_CHAIN} as a safety fallback.
+ *
+ * Supports optional `provider:model` syntax per entry (e.g.
+ * `"anthropic:claude-haiku-4-5-20251001,openrouter,groq:llama-3.1-8b"`)
+ * for callers that want to pin specific models per provider.
+ *
+ * @param raw - Raw config string from `llm.auxiliaryFallback`.
+ * @returns Parsed chain, or the default chain when `raw` is empty/invalid.
+ *
+ * @task T9319
+ */
+export function parseAuxiliaryFallbackChain(raw: string): AuxiliaryFallbackChain {
+  const entries = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s): AuxiliaryFallbackEntry | null => {
+      const colonIdx = s.indexOf(':');
+      if (colonIdx === -1) {
+        return { provider: s as ModelTransport };
+      }
+      const providerPart = s.slice(0, colonIdx).trim();
+      const modelPart = s.slice(colonIdx + 1).trim();
+      if (!providerPart) return null;
+      return {
+        provider: providerPart as ModelTransport,
+        ...(modelPart ? { model: modelPart } : {}),
+      };
+    })
+    .filter((e): e is AuxiliaryFallbackEntry => e !== null);
+
+  return entries.length > 0 ? entries : DEFAULT_AUXILIARY_FALLBACK_CHAIN;
+}
+
+/**
+ * Resolve the active auxiliary fallback chain from project config.
+ *
+ * Reads `llm.auxiliaryFallback` from the CLEO config. Falls back to
+ * {@link DEFAULT_AUXILIARY_FALLBACK_CHAIN} when the key is absent.
+ *
+ * @param projectRoot - Optional project root for config resolution.
+ * @returns The resolved chain (never empty — always at least the default).
+ *
+ * @task T9319
+ */
+export async function resolveAuxiliaryFallbackChain(
+  projectRoot?: string,
+): Promise<AuxiliaryFallbackChain> {
+  try {
+    const { loadConfig } = await import('../config.js');
+    const config = await loadConfig(projectRoot);
+    const raw = (config.llm as Record<string, unknown> | undefined)?.['auxiliaryFallback'];
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+      return parseAuxiliaryFallbackChain(raw);
+    }
+  } catch {
+    // Config load failure is non-fatal — fall through to default.
+  }
+  return DEFAULT_AUXILIARY_FALLBACK_CHAIN;
+}
+
+// ---------------------------------------------------------------------------
+// Default auxiliary provider (uses session factory)
+// ---------------------------------------------------------------------------
+
+/**
+ * Production {@link AuxiliaryProvider} implementation.
+ *
+ * Lazily imports `DefaultLlmSessionFactory` to avoid circular dependency at
+ * module load time (session-factory → concrete-session → this module path
+ * would form a cycle via concrete-executor).
+ *
+ * @internal
+ */
+async function _defaultAuxiliaryProvider(
+  entry: AuxiliaryFallbackEntry,
+  messages: TransportMessage[],
+  opts: SendOptions | undefined,
+): Promise<NormalizedResponse> {
+  const { DefaultLlmSessionFactory } = await import('./session-factory.js');
+  const { resolveLLMForRole } = await import('./role-resolver.js');
+
+  // Resolve credential for the requested provider by probing the 'hygiene'
+  // role's credential store, then override the provider. This gives us a valid
+  // credential while still honouring the per-provider credential pool.
+  //
+  // For the fallback chain the role is always 'hygiene' (auxiliary work).
+  const resolved = await resolveLLMForRole('hygiene');
+
+  // If the requested provider differs from what role-resolver chose, try to
+  // build a session directly for the target provider. We use the session factory
+  // to drive the full credential-pool → transport wiring.
+  const factory = new DefaultLlmSessionFactory();
+
+  // Build session: use the resolved provider from the chain entry.
+  // Fall back to the role-resolved provider if the chain provider matches.
+  const targetProvider = entry.provider;
+
+  if (targetProvider === resolved.provider && resolved.credential?.apiKey) {
+    const session = await factory.createForRole('hygiene');
+    return session.send(messages, opts);
+  }
+
+  // For a different provider, try createForRole with a provider-matching role.
+  // If no credential exists for this provider, the factory will throw and the
+  // outer loop will catch it as a pool-exhaustion signal.
+  //
+  // We synthesise a temporary session by using the contracts layer directly:
+  // import the transport factory helpers from session-factory internals via
+  // the concrete-session constructor pattern used in role-executor.
+  const { AnthropicTransport } = await import('./transports/anthropic.js');
+  const { ChatCompletionsTransport } = await import('./transports/chat-completions.js');
+  const { GeminiTransport } = await import('./transports/gemini.js');
+  const { resolveCredentials } = await import('./credentials.js');
+  const { ConcreteSession } = await import('./concrete-session.js');
+
+  const credResult = await resolveCredentials(targetProvider, {});
+  if (!credResult.apiKey) {
+    // No credential for this provider — signal exhaustion to the outer loop.
+    throw new PoolExhaustedError(targetProvider, 0, 0);
+  }
+
+  let transport: LlmTransport;
+  if (targetProvider === 'anthropic') {
+    transport =
+      credResult.authType === 'oauth'
+        ? new AnthropicTransport({ authToken: credResult.apiKey })
+        : new AnthropicTransport({ apiKey: credResult.apiKey });
+  } else if (targetProvider === 'gemini') {
+    transport = new GeminiTransport({ apiKey: credResult.apiKey });
+  } else {
+    const defaultHeaders: Record<string, string> = {};
+    if (credResult.authType === 'oauth') {
+      defaultHeaders['Authorization'] = `Bearer ${credResult.apiKey}`;
+    }
+    transport = new ChatCompletionsTransport({
+      provider: targetProvider,
+      apiKey: credResult.apiKey,
+      ...(Object.keys(defaultHeaders).length ? { defaultHeaders } : {}),
+    });
+  }
+
+  const model = entry.model ?? resolved.model;
+  const session = new ConcreteSession({
+    transport,
+    model,
+    credential: {
+      provider: targetProvider,
+      label: 'fallback',
+      token: credResult.apiKey,
+      authType: credResult.authType === 'oauth' ? 'oauth' : 'api_key',
+      expiresAt: null,
+      refreshToken: null,
+      extraHeaders: {},
+      baseUrl: null,
+      awsProfile: null,
+    },
+  });
+
+  return session.send(messages, opts);
+}

--- a/packages/core/src/llm/cli-ops.ts
+++ b/packages/core/src/llm/cli-ops.ts
@@ -20,6 +20,8 @@
 import type {
   LlmAddParams,
   LlmAddResult,
+  LlmAuxiliaryStatusParams,
+  LlmAuxiliaryStatusResult,
   LlmListParams,
   LlmListResult,
   LlmProfileParams,
@@ -44,6 +46,11 @@ import { setConfigValue } from '../config.js';
 // contains a credential substring is automatically scrubbed before it
 // reaches the dispatch envelope or the audit log.
 import { redactContent } from '../memory/redaction.js';
+import {
+  DEFAULT_AUXILIARY_FALLBACK_CHAIN,
+  parseAuxiliaryFallbackChain,
+  resolveAuxiliaryFallbackChain,
+} from './auxiliary-fallback.js';
 import { authHeaders, resolveCredentials } from './credentials.js';
 import {
   addCredential,
@@ -432,3 +439,46 @@ export async function llmWhoami(params: LlmWhoamiParams): Promise<EngineResult<L
     return engineError('E_WHOAMI_FAILED', safeErrMessage(err));
   }
 }
+
+/**
+ * `llm.auxiliary-status` — report the active auxiliary fallback chain
+ * and how to configure it.
+ *
+ * The chain determines which providers are tried (in order) when an auxiliary
+ * LLM call fails due to pool exhaustion. Configured via:
+ *
+ * ```
+ * cleo config set llm.auxiliaryFallback "anthropic,openrouter,groq"
+ * ```
+ *
+ * Returns the resolved chain plus the config key and an example value so
+ * users can copy-paste to customise.
+ *
+ * @task T9319
+ */
+export async function llmAuxiliaryStatus(
+  params: LlmAuxiliaryStatusParams,
+): Promise<EngineResult<LlmAuxiliaryStatusResult>> {
+  try {
+    const { loadConfig } = await import('../config.js');
+    const config = await loadConfig(params.projectRoot);
+    const rawValue = (config.llm as Record<string, unknown> | undefined)?.['auxiliaryFallback'];
+    const hasConfig = typeof rawValue === 'string' && rawValue.trim().length > 0;
+
+    const chain = hasConfig
+      ? parseAuxiliaryFallbackChain(rawValue as string)
+      : DEFAULT_AUXILIARY_FALLBACK_CHAIN;
+
+    return engineSuccess({
+      chain: chain.map((e) => ({ provider: e.provider, ...(e.model ? { model: e.model } : {}) })),
+      source: hasConfig ? 'config' : 'default',
+      configKey: 'llm.auxiliaryFallback',
+      configExample: 'anthropic,openrouter,groq',
+    });
+  } catch (err) {
+    return engineError('E_AUXILIARY_STATUS_FAILED', safeErrMessage(err));
+  }
+}
+
+// Re-export for tree-shaking clarity (consumers import only what they use).
+export { resolveAuxiliaryFallbackChain };

--- a/packages/core/src/llm/concrete-executor.ts
+++ b/packages/core/src/llm/concrete-executor.ts
@@ -25,6 +25,8 @@ import type {
   NormalizedResponse,
   TransportMessage,
 } from '@cleocode/contracts/llm/normalized-response.js';
+import type { AuxiliaryFallbackChain, AuxiliaryFallbackResult } from './auxiliary-fallback.js';
+import { runAuxiliaryWithFallback } from './auxiliary-fallback.js';
 import { estimateTransportMessageTokens } from './message-utils.js';
 import { computeCost } from './usage-pricing.js';
 
@@ -52,6 +54,19 @@ export interface ConcreteExecutorOptions {
    * emitted and no errors are thrown.
    */
   readonly contextEngine?: ContextEngine;
+  /**
+   * Optional auxiliary fallback chain for cross-provider fallover.
+   *
+   * When set, {@link ConcreteExecutor.auxiliary} will fall through to the next
+   * provider in the chain when the primary provider's credential pool is
+   * exhausted. When absent, auxiliary calls use only the bound session's
+   * provider (original behaviour).
+   *
+   * Configure via `cleo config set llm.auxiliaryFallback "anthropic,openrouter,groq"`.
+   *
+   * @task T9319
+   */
+  readonly auxiliaryFallbackChain?: AuxiliaryFallbackChain;
 }
 
 /**
@@ -74,6 +89,7 @@ export class ConcreteExecutor implements LlmExecutor {
   readonly session: LlmSession;
 
   private readonly _contextEngine: ContextEngine | undefined;
+  private readonly _auxiliaryFallbackChain: AuxiliaryFallbackChain | undefined;
 
   /**
    * @param opts - Executor construction options.
@@ -81,6 +97,7 @@ export class ConcreteExecutor implements LlmExecutor {
   constructor(opts: ConcreteExecutorOptions) {
     this.session = opts.session;
     this._contextEngine = opts.contextEngine;
+    this._auxiliaryFallbackChain = opts.auxiliaryFallbackChain;
   }
 
   /**
@@ -259,11 +276,29 @@ export class ConcreteExecutor implements LlmExecutor {
    * hygiene scans). Uses the same underlying session but does NOT append messages
    * to the session history.
    *
+   * When {@link ConcreteExecutorOptions.auxiliaryFallbackChain} is configured,
+   * automatically falls through to the next provider in the chain when the
+   * primary provider's credential pool is exhausted (all credentials on cooldown
+   * due to 401/429 errors). Returns an {@link AuxiliaryFallbackResult} that
+   * includes `meta.fallbackChain` describing the path taken.
+   *
+   * Without a fallback chain, falls back to the original single-provider
+   * behaviour (calls the bound session directly).
+   *
    * @param messages - Messages to send.
    * @param opts - Optional per-call overrides.
-   * @returns The normalized provider response.
+   * @returns The normalized provider response (or AuxiliaryFallbackResult when
+   *   a fallback chain is active).
+   *
+   * @task T9319
    */
-  async auxiliary(messages: TransportMessage[], opts?: SendOptions): Promise<NormalizedResponse> {
+  async auxiliary(
+    messages: TransportMessage[],
+    opts?: SendOptions,
+  ): Promise<NormalizedResponse | AuxiliaryFallbackResult> {
+    if (this._auxiliaryFallbackChain !== undefined && this._auxiliaryFallbackChain.length > 0) {
+      return runAuxiliaryWithFallback(this._auxiliaryFallbackChain, messages, opts);
+    }
     return this.session.send(messages, opts);
   }
 }

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -12,6 +12,21 @@
 export type { CleoLlmCallParams } from './api.js';
 // Public entrypoint
 export { cleoLlmCall } from './api.js';
+// Multi-provider auxiliary fallback chain (T9319)
+export type {
+  AllProvidersExhaustedError,
+  AuxiliaryFallbackChain,
+  AuxiliaryFallbackEntry,
+  AuxiliaryFallbackMeta,
+  AuxiliaryFallbackResult,
+  AuxiliaryProvider,
+  FallbackChainStep,
+} from './auxiliary-fallback.js';
+export {
+  DEFAULT_AUXILIARY_FALLBACK_CHAIN,
+  parseAuxiliaryFallbackChain,
+  runAuxiliaryWithFallback,
+} from './auxiliary-fallback.js';
 // Backend types — canonical CompletionResult / ProviderBackend shapes used by request-builder, history-adapters, structured-output
 export type {
   BackendCallParams,
@@ -28,12 +43,14 @@ export { buildCacheKey, geminiCacheStore, InMemoryGeminiCacheStore } from './cac
 // `cleo llm` CLI / dispatch engine ops (T9258 — T-LLM-CRED Phase 2 / T-llm-4)
 export {
   llmAdd,
+  llmAuxiliaryStatus,
   llmList,
   llmProfile,
   llmRemove,
   llmTest,
   llmUse,
   llmWhoami,
+  resolveAuxiliaryFallbackChain,
 } from './cli-ops.js';
 // New Phase 4 executor layer (T9290/T9291)
 export type { ConcreteExecutorOptions } from './concrete-executor.js';


### PR DESCRIPTION
## Summary

- Adds cross-provider waterfall to `ConcreteExecutor.auxiliary()` so that when the primary provider's credential pool is exhausted (all credentials on 401/429 cooldown), the call falls through to the next configured provider
- New module `packages/core/src/llm/auxiliary-fallback.ts` exports `runAuxiliaryWithFallback`, `AuxiliaryFallbackChain`, `AllProvidersExhaustedError`, `parseAuxiliaryFallbackChain`, `resolveAuxiliaryFallbackChain`, and the default chain (anthropic → openrouter → groq)
- New `llm.auxiliary-status` query operation (`cleo llm auxiliary-status`) surfaces the active chain and config key
- 18 unit tests covering success, single/multi-step fallback, full-chain exhaustion, non-pool errors, empty chain, `meta.fallbackChain` attachment, and `parseAuxiliaryFallbackChain` edge cases

## Closes

T9319 (under epic T9261 Phase 5)

## Test plan

- [ ] `pnpm --filter @cleocode/core vitest run packages/core/src/llm/__tests__/auxiliary-fallback.test.ts` → 18 passed
- [ ] `pnpm biome ci .` in worktree → clean
- [ ] `pnpm run typecheck` → exit 0
- [ ] `cleo llm auxiliary-status` returns default chain JSON when no config set

🤖 Generated with [Claude Code](https://claude.com/claude-code)