### PR TITLE
feat(T9317): BedrockTransport (Converse API + cross-region + guardrail) — recovery PR

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -256,6 +256,13 @@ const sharedExternals = [
   // the runtime needs to load from node_modules anyway.
   '@anthropic-ai/sdk',
   /^@anthropic-ai\//,
+  // AWS SDK v3 modules — pull in @smithy/* runtime, node:buffer dynamic require,
+  // and large transitive CJS shims that crash with "Dynamic require of buffer
+  // is not supported" if inlined into the ESM bundle. (T9317)
+  '@aws-sdk/client-bedrock-runtime',
+  /^@aws-sdk\//,
+  '@smithy/types',
+  /^@smithy\//,
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -282,6 +282,8 @@
     "@ai-sdk/anthropic": "^3.0.69",
     "@ai-sdk/openai-compatible": "^2.0.41",
     "@anthropic-ai/sdk": "^0.88.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.0.0",
+    "@aws-sdk/credential-providers": "^3.0.0",
     "@cleocode/adapters": "workspace:*",
     "@cleocode/agents": "workspace:*",
     "@cleocode/caamp": "workspace:*",

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -149,9 +149,11 @@ export {
   StructuredOutputError,
   validateStructuredOutput,
 } from './structured-output.js';
-// Transports (Phase-4 LlmTransport implementations)
+// Transports (Phase-4/5 LlmTransport implementations)
 export type { AnthropicTransportOptions } from './transports/anthropic.js';
 export { AnthropicTransport } from './transports/anthropic.js';
+export type { BedrockTransportOptions } from './transports/bedrock.js';
+export { BedrockTransport } from './transports/bedrock.js';
 export type { GeminiTransportOptions } from './transports/gemini.js';
 export { GeminiTransport } from './transports/gemini.js';
 export type { OpenAITransportOptions } from './transports/openai.js';

--- a/packages/core/src/llm/provider-registry/builtin/bedrock.ts
+++ b/packages/core/src/llm/provider-registry/builtin/bedrock.ts
@@ -1,0 +1,39 @@
+/**
+ * Builtin provider profile for AWS Bedrock (Converse API).
+ *
+ * AWS Bedrock exposes many foundation models through a uniform Converse API.
+ * This profile covers the common model ID prefixes:
+ * - `anthropic.claude-*` — Anthropic Claude models on Bedrock
+ * - `amazon.nova-*`      — Amazon Nova series
+ * - `mistral.mistral-*`  — Mistral AI models on Bedrock
+ * - `meta.llama*`        — Meta Llama models on Bedrock
+ * - `cohere.command-*`   — Cohere Command models on Bedrock
+ *
+ * Credential auth for Bedrock uses the standard AWS credential chain
+ * (`fromNodeProviderChain`), not an API key. The `authTypes: ['aws_sdk']`
+ * declaration is informational — the actual resolution happens inside
+ * `BedrockTransport` via the AWS SDK credential chain.
+ *
+ * @task T9317
+ * @epic T9261 (T-LLM-CRED-CENTRALIZATION Phase 5)
+ */
+
+import type { ProviderProfile } from '@cleocode/contracts';
+
+/**
+ * AWS Bedrock provider profile.
+ *
+ * - `authTypes` is `['aws_sdk']` — informational for the credential store
+ *   UI. Actual resolution uses `fromNodeProviderChain()` inside the transport.
+ * - `fetchModels` is omitted — the Bedrock model catalog is large and
+ *   region-specific. Use `cleo llm refresh-catalog` (T9314) for discovery.
+ * - `defaultModel` targets Claude Sonnet 3.7, widely available across regions.
+ */
+export const bedrockProfile: ProviderProfile = {
+  name: 'bedrock',
+  displayName: 'AWS Bedrock',
+  authTypes: ['aws_sdk'],
+  baseUrl: 'https://bedrock-runtime.{region}.amazonaws.com',
+  defaultModel: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+  aliases: ['aws-bedrock', 'bedrock-converse'],
+};

--- a/packages/core/src/llm/provider-registry/index.ts
+++ b/packages/core/src/llm/provider-registry/index.ts
@@ -32,6 +32,7 @@
 
 import type { ProviderProfile } from '@cleocode/contracts';
 import { anthropicProfile } from './builtin/anthropic.js';
+import { bedrockProfile } from './builtin/bedrock.js';
 import { geminiProfile } from './builtin/gemini.js';
 import { kimiCodeProfile } from './builtin/kimi-code.js';
 import { moonshotProfile } from './builtin/moonshot.js';
@@ -66,6 +67,7 @@ let _discoveryPromise: Promise<void> | null = null;
  */
 const BUILTIN_PROFILES: ReadonlyArray<ProviderProfile> = [
   anthropicProfile,
+  bedrockProfile,
   geminiProfile,
   kimiCodeProfile,
   moonshotProfile,

--- a/packages/core/src/llm/session-factory.ts
+++ b/packages/core/src/llm/session-factory.ts
@@ -21,6 +21,7 @@ import type { ResolvedCredential } from '@cleocode/contracts/llm/resolved-creden
 import { ConcreteSession } from './concrete-session.js';
 import { resolveLLMForRole } from './role-resolver.js';
 import { AnthropicTransport } from './transports/anthropic.js';
+import { BedrockTransport } from './transports/bedrock.js';
 import { ChatCompletionsTransport } from './transports/chat-completions.js';
 import { GeminiTransport } from './transports/gemini.js';
 import type { ModelTransport } from './types-config.js';
@@ -34,6 +35,7 @@ import type { ModelTransport } from './types-config.js';
  *
  * Provider mapping:
  * - `'anthropic'` → {@link AnthropicTransport}
+ * - `'bedrock'` → {@link BedrockTransport} (AWS credential chain; token unused)
  * - `'gemini'` → {@link GeminiTransport}
  * - everything else → {@link ChatCompletionsTransport} (OpenAI-compatible)
  *
@@ -59,6 +61,14 @@ function transportForProvider(
     return new AnthropicTransport(opts);
   }
 
+  if (provider === 'bedrock') {
+    // BedrockTransport resolves credentials via fromNodeProviderChain() internally.
+    // The credential.awsProfile field carries the optional profile override.
+    return new BedrockTransport({
+      awsProfile: credential.awsProfile ?? undefined,
+    });
+  }
+
   if (provider === 'gemini') {
     return new GeminiTransport({
       apiKey: credential.token,
@@ -67,7 +77,7 @@ function transportForProvider(
   }
 
   // All other providers (openai, moonshot, openrouter, deepseek, xai, groq,
-  // kimi-code, bedrock, …) use ChatCompletionsTransport.
+  // kimi-code, …) use ChatCompletionsTransport.
   const defaultHeaders: Record<string, string> = { ...credential.extraHeaders };
   if (credential.authType === 'oauth') {
     defaultHeaders['Authorization'] = `Bearer ${credential.token}`;

--- a/packages/core/src/llm/transports/__tests__/bedrock.integration.test.ts
+++ b/packages/core/src/llm/transports/__tests__/bedrock.integration.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Integration tests for BedrockTransport against a real AWS Bedrock endpoint.
+ *
+ * These tests are SKIPPED unless the `AWS_BEDROCK_TEST_KEY` env var is set.
+ * Setting `AWS_BEDROCK_TEST_KEY=1` requires valid AWS credentials available
+ * through the standard provider chain (env vars, ~/.aws/credentials, IAM role).
+ *
+ * Live integration tests are tracked as T9342 (owner-action: provide AWS CI secrets).
+ *
+ * @task T9317
+ * @task T9342 (live integration owner-action)
+ * @epic T9261 (T-LLM-CRED-CENTRALIZATION Phase 5)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BedrockTransport } from '../bedrock.js';
+
+describe.skipIf(!process.env['AWS_BEDROCK_TEST_KEY'])(
+  'BedrockTransport — live integration (requires AWS_BEDROCK_TEST_KEY)',
+  () => {
+    const region = process.env['AWS_BEDROCK_REGION'] ?? 'us-east-1';
+    const model = process.env['AWS_BEDROCK_MODEL'] ?? 'anthropic.claude-3-5-haiku-20241022-v1:0';
+
+    it('completes a simple turn against the live Bedrock API', async () => {
+      const transport = new BedrockTransport({ region });
+      const response = await transport.complete({
+        model,
+        messages: [{ role: 'user', content: 'Say "CLEO integration test OK" and nothing else.' }],
+        maxTokens: 64,
+        temperature: 0,
+      });
+
+      expect(response.content).toBeTruthy();
+      expect(response.usage.inputTokens).toBeGreaterThan(0);
+      expect(response.usage.outputTokens).toBeGreaterThan(0);
+      expect(response.stopReason).toBeDefined();
+    });
+
+    it('streams a simple turn and receives text deltas', async () => {
+      const transport = new BedrockTransport({ region });
+      const chunks: string[] = [];
+
+      for await (const delta of transport.stream(
+        {
+          model,
+          messages: [{ role: 'user', content: 'Count from 1 to 3, one number per line.' }],
+          maxTokens: 64,
+          temperature: 0,
+        },
+        {} as never,
+      )) {
+        if (delta.text) chunks.push(delta.text);
+      }
+
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks.join('')).toContain('1');
+    });
+
+    it('invokes a tool via the Converse API', async () => {
+      const transport = new BedrockTransport({ region });
+      const response = await transport.complete({
+        model,
+        messages: [{ role: 'user', content: "What's the weather in Tokyo?" }],
+        maxTokens: 256,
+        tools: [
+          {
+            name: 'get_weather',
+            description: 'Returns current weather for a location',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                location: { type: 'string', description: 'City name' },
+              },
+              required: ['location'],
+            },
+          },
+        ],
+      });
+
+      expect(response.toolCalls).not.toBeNull();
+      expect(response.toolCalls![0]!.name).toBe('get_weather');
+    });
+  },
+);

--- a/packages/core/src/llm/transports/__tests__/bedrock.test.ts
+++ b/packages/core/src/llm/transports/__tests__/bedrock.test.ts
@@ -1,0 +1,561 @@
+/**
+ * Unit tests for BedrockTransport (T9317 — Converse API implementation).
+ *
+ * All AWS SDK calls are mocked via vi.mock. Tests cover:
+ * 1. Simple turn — complete() normalizes text response correctly
+ * 2. Tool use — ConverseCommand with toolConfig and ToolUseBlock in response
+ * 3. Streaming — ConverseStreamCommand yields text, reasoning, and final usage
+ * 4. Cross-region fallback — retries against fallbackRegions on AccessDeniedException
+ * 5. Guardrail passthrough — guardrailConfig forwarded from request meta
+ * 6. Credential resolution — fromNodeProviderChain called with awsProfile when set
+ *
+ * @task T9317
+ * @epic T9261 (T-LLM-CRED-CENTRALIZATION Phase 5)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock @aws-sdk/client-bedrock-runtime before imports
+// ---------------------------------------------------------------------------
+
+const { mockSend } = vi.hoisted(() => {
+  const mockSend = vi.fn();
+  return { mockSend };
+});
+
+vi.mock('@aws-sdk/client-bedrock-runtime', () => {
+  class MockBedrockRuntimeClient {
+    send = mockSend;
+  }
+  class MockConverseCommand {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+  class MockConverseStreamCommand {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+  return {
+    BedrockRuntimeClient: MockBedrockRuntimeClient,
+    ConverseCommand: MockConverseCommand,
+    ConverseStreamCommand: MockConverseStreamCommand,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock @aws-sdk/credential-providers
+// ---------------------------------------------------------------------------
+
+const { mockFromNodeProviderChain } = vi.hoisted(() => {
+  const mockFromNodeProviderChain = vi
+    .fn()
+    .mockReturnValue({ accessKeyId: 'test', secretAccessKey: 'test' });
+  return { mockFromNodeProviderChain };
+});
+
+vi.mock('@aws-sdk/credential-providers', () => ({
+  fromNodeProviderChain: mockFromNodeProviderChain,
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { BedrockTransport } from '../bedrock.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeConverseResponse(text: string, stopReason = 'end_turn') {
+  return {
+    output: {
+      message: {
+        role: 'assistant',
+        content: [{ text }],
+      },
+    },
+    stopReason,
+    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    metrics: { latencyMs: 100 },
+    $metadata: { requestId: 'req-test-001' },
+  };
+}
+
+function makeToolUseResponse(
+  toolUseId: string,
+  toolName: string,
+  toolInput: Record<string, unknown>,
+) {
+  return {
+    output: {
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            toolUse: {
+              toolUseId,
+              name: toolName,
+              input: toolInput,
+            },
+          },
+        ],
+      },
+    },
+    stopReason: 'tool_use',
+    usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 },
+    $metadata: { requestId: 'req-tool-001' },
+  };
+}
+
+async function* makeStreamEvents(events: Record<string, unknown>[]) {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function makeStreamResponse(events: Record<string, unknown>[]) {
+  return {
+    stream: makeStreamEvents(events),
+    $metadata: { requestId: 'req-stream-001' },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BedrockTransport', () => {
+  beforeEach(() => {
+    mockSend.mockClear();
+    mockFromNodeProviderChain.mockClear();
+  });
+
+  describe('provider and apiMode', () => {
+    it('exposes correct provider and apiMode constants', () => {
+      const t = new BedrockTransport();
+      expect(t.provider).toBe('bedrock');
+      expect(t.apiMode).toBe('bedrock_converse');
+    });
+  });
+
+  describe('complete() — simple turn', () => {
+    it('returns normalized response with text content', async () => {
+      mockSend.mockResolvedValueOnce(makeConverseResponse('Hello from Bedrock!'));
+
+      const t = new BedrockTransport({ region: 'us-east-1' });
+      const result = await t.complete({
+        model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        messages: [{ role: 'user', content: 'Hello' }],
+        maxTokens: 512,
+      });
+
+      expect(result.content).toBe('Hello from Bedrock!');
+      expect(result.stopReason).toBe('end_turn');
+      expect(result.usage.inputTokens).toBe(10);
+      expect(result.usage.outputTokens).toBe(5);
+      expect(result.id).toBe('req-test-001');
+      expect(result.toolCalls).toBeNull();
+    });
+
+    it('passes model, messages, maxTokens to ConverseCommand', async () => {
+      mockSend.mockResolvedValueOnce(makeConverseResponse('OK'));
+
+      const t = new BedrockTransport({ region: 'us-west-2' });
+      await t.complete({
+        model: 'amazon.nova-pro-v1:0',
+        messages: [{ role: 'user', content: 'Test' }],
+        maxTokens: 256,
+        temperature: 0.5,
+      });
+
+      const [[cmd]] = mockSend.mock.calls as [[{ input: Record<string, unknown> }]];
+      expect(cmd.input['modelId']).toBe('amazon.nova-pro-v1:0');
+      expect(cmd.input['inferenceConfig']).toMatchObject({ maxTokens: 256, temperature: 0.5 });
+    });
+
+    it('maps system prompt into systemContentBlocks', async () => {
+      mockSend.mockResolvedValueOnce(makeConverseResponse('Response'));
+
+      const t = new BedrockTransport();
+      await t.complete({
+        model: 'mistral.mistral-large-2402-v1:0',
+        messages: [{ role: 'user', content: 'Hi' }],
+        maxTokens: 128,
+        system: 'You are a helpful assistant.',
+      });
+
+      const [[cmd]] = mockSend.mock.calls as [[{ input: Record<string, unknown> }]];
+      const systemBlocks = cmd.input['system'] as Array<{ text: string }>;
+      expect(systemBlocks).toHaveLength(1);
+      expect(systemBlocks[0]!.text).toBe('You are a helpful assistant.');
+    });
+
+    it('maps tool-result message to toolResult content block', async () => {
+      mockSend.mockResolvedValueOnce(makeConverseResponse('Done'));
+
+      const t = new BedrockTransport();
+      await t.complete({
+        model: 'anthropic.claude-3-5-haiku-20241022-v1:0',
+        messages: [
+          { role: 'user', content: 'Call a tool' },
+          { role: 'tool', content: 'tool output', toolUseId: 'tu-001' },
+        ],
+        maxTokens: 128,
+      });
+
+      const [[cmd]] = mockSend.mock.calls as [[{ input: Record<string, unknown> }]];
+      const msgs = cmd.input['messages'] as Array<Record<string, unknown>>;
+      const toolResultMsg = msgs.find((m) => {
+        const content = m['content'] as Array<Record<string, unknown>>;
+        return content?.[0]?.['toolResult'] != null;
+      });
+      expect(toolResultMsg).toBeDefined();
+      expect(toolResultMsg!['role']).toBe('user');
+    });
+  });
+
+  describe('complete() — tool use', () => {
+    it('returns normalized tool calls', async () => {
+      mockSend.mockResolvedValueOnce(
+        makeToolUseResponse('tu-123', 'get_weather', { location: 'Seattle' }),
+      );
+
+      const t = new BedrockTransport();
+      const result = await t.complete({
+        model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        messages: [{ role: 'user', content: 'What is the weather?' }],
+        maxTokens: 512,
+        tools: [
+          {
+            name: 'get_weather',
+            description: 'Get the weather for a location',
+            inputSchema: {
+              type: 'object',
+              properties: { location: { type: 'string' } },
+              required: ['location'],
+            },
+          },
+        ],
+      });
+
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0]!.id).toBe('tu-123');
+      expect(result.toolCalls![0]!.name).toBe('get_weather');
+      expect(JSON.parse(result.toolCalls![0]!.arguments)).toEqual({ location: 'Seattle' });
+      expect(result.stopReason).toBe('tool_use');
+    });
+
+    it('passes toolConfig with tool spec to ConverseCommand', async () => {
+      mockSend.mockResolvedValueOnce(makeToolUseResponse('tu-456', 'my_tool', {}));
+
+      const t = new BedrockTransport();
+      await t.complete({
+        model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        messages: [{ role: 'user', content: 'Use tool' }],
+        maxTokens: 256,
+        tools: [
+          {
+            name: 'my_tool',
+            description: 'A test tool',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      });
+
+      const [[cmd]] = mockSend.mock.calls as [[{ input: Record<string, unknown> }]];
+      const toolConfig = cmd.input['toolConfig'] as Record<string, unknown>;
+      expect(toolConfig).toBeDefined();
+      const tools = toolConfig['tools'] as Array<Record<string, unknown>>;
+      expect(tools).toHaveLength(1);
+      const spec = tools[0]!['toolSpec'] as Record<string, unknown>;
+      expect(spec['name']).toBe('my_tool');
+    });
+  });
+
+  describe('stream()', () => {
+    it('yields text deltas and final usage', async () => {
+      mockSend.mockResolvedValueOnce(
+        makeStreamResponse([
+          { contentBlockDelta: { delta: { text: 'Hello' }, contentBlockIndex: 0 } },
+          { contentBlockDelta: { delta: { text: ' world' }, contentBlockIndex: 0 } },
+          { messageStop: { stopReason: 'end_turn' } },
+          { metadata: { usage: { inputTokens: 8, outputTokens: 4 } } },
+        ]),
+      );
+
+      const t = new BedrockTransport();
+      const deltas: Array<{ text: string; stopReason: string | null }> = [];
+
+      for await (const delta of t.stream(
+        {
+          model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+          messages: [{ role: 'user', content: 'Hi' }],
+          maxTokens: 128,
+        },
+        {} as never,
+      )) {
+        deltas.push({ text: delta.text, stopReason: delta.stopReason });
+      }
+
+      const textDeltas = deltas.filter((d) => d.text.length > 0);
+      expect(textDeltas.map((d) => d.text).join('')).toBe('Hello world');
+
+      const finalDelta = deltas[deltas.length - 1]!;
+      expect(finalDelta.stopReason).toBe('end_turn');
+      expect(finalDelta.text).toBe('');
+    });
+
+    it('yields reasoning content to delta.reasoning', async () => {
+      mockSend.mockResolvedValueOnce(
+        makeStreamResponse([
+          {
+            contentBlockDelta: {
+              delta: { reasoningContent: { text: 'I think...' } },
+              contentBlockIndex: 0,
+            },
+          },
+          { contentBlockDelta: { delta: { text: 'Answer' }, contentBlockIndex: 1 } },
+          { messageStop: { stopReason: 'end_turn' } },
+          { metadata: { usage: { inputTokens: 5, outputTokens: 2 } } },
+        ]),
+      );
+
+      const t = new BedrockTransport();
+      const deltas: Array<{ text: string; reasoning: string }> = [];
+
+      for await (const delta of t.stream(
+        {
+          model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+          messages: [{ role: 'user', content: 'Reason' }],
+          maxTokens: 256,
+        },
+        {} as never,
+      )) {
+        deltas.push({ text: delta.text, reasoning: delta.reasoning });
+      }
+
+      const reasoningDeltas = deltas.filter((d) => d.reasoning.length > 0);
+      expect(reasoningDeltas[0]!.reasoning).toBe('I think...');
+    });
+
+    it('drops toolUse streaming deltas', async () => {
+      mockSend.mockResolvedValueOnce(
+        makeStreamResponse([
+          {
+            contentBlockStart: {
+              start: { toolUse: { toolUseId: 'tu-1', name: 'fn' } },
+              contentBlockIndex: 0,
+            },
+          },
+          {
+            contentBlockDelta: { delta: { toolUse: { input: '{"x":' } }, contentBlockIndex: 0 },
+          },
+          { contentBlockDelta: { delta: { toolUse: { input: '1}' } }, contentBlockIndex: 0 } },
+          { messageStop: { stopReason: 'tool_use' } },
+          { metadata: { usage: { inputTokens: 5, outputTokens: 3 } } },
+        ]),
+      );
+
+      const t = new BedrockTransport();
+      const deltas: Array<{ text: string }> = [];
+
+      for await (const delta of t.stream(
+        {
+          model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+          messages: [{ role: 'user', content: 'Call tool' }],
+          maxTokens: 256,
+        },
+        {} as never,
+      )) {
+        deltas.push({ text: delta.text });
+      }
+
+      const textDeltas = deltas.filter((d) => d.text.length > 0);
+      expect(textDeltas).toHaveLength(0);
+    });
+  });
+
+  describe('cross-region fallback', () => {
+    it('retries on AccessDeniedException and succeeds on fallback region', async () => {
+      const accessDenied = Object.assign(new Error('Access denied'), {
+        name: 'AccessDeniedException',
+      });
+      mockSend
+        .mockRejectedValueOnce(accessDenied)
+        .mockResolvedValueOnce(makeConverseResponse('Fallback response'));
+
+      const t = new BedrockTransport({
+        region: 'us-east-1',
+        fallbackRegions: ['us-west-2'],
+      });
+
+      const result = await t.complete({
+        model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        messages: [{ role: 'user', content: 'Hello' }],
+        maxTokens: 128,
+      });
+
+      expect(result.content).toBe('Fallback response');
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws immediately on non-retryable error', async () => {
+      const networkErr = new Error('ECONNREFUSED');
+      mockSend.mockRejectedValueOnce(networkErr);
+
+      const t = new BedrockTransport({
+        region: 'us-east-1',
+        fallbackRegions: ['us-west-2'],
+      });
+
+      await expect(
+        t.complete({
+          model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+          messages: [{ role: 'user', content: 'Hello' }],
+          maxTokens: 128,
+        }),
+      ).rejects.toThrow('ECONNREFUSED');
+
+      // Should not have tried the fallback
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('exhausts all regions and throws last error', async () => {
+      const err1 = Object.assign(new Error('Throttled 1'), { name: 'ThrottlingException' });
+      const err2 = Object.assign(new Error('Throttled 2'), { name: 'ThrottlingException' });
+      mockSend.mockRejectedValueOnce(err1).mockRejectedValueOnce(err2);
+
+      const t = new BedrockTransport({
+        region: 'us-east-1',
+        fallbackRegions: ['eu-west-1'],
+      });
+
+      await expect(
+        t.complete({
+          model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+          messages: [{ role: 'user', content: 'Hello' }],
+          maxTokens: 128,
+        }),
+      ).rejects.toThrow('Throttled 2');
+
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('guardrail passthrough', () => {
+    it('passes guardrailConfig from request.guardrailConfig', async () => {
+      mockSend.mockResolvedValueOnce(makeConverseResponse('Protected response'));
+
+      const t = new BedrockTransport();
+      const guardrailConfig = {
+        guardrailIdentifier: 'gr-abc123',
+        guardrailVersion: '1',
+      };
+
+      await t.complete(
+        Object.assign(
+          {
+            model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+            messages: [{ role: 'user', content: 'Hello' }] as Parameters<
+              BedrockTransport['complete']
+            >[0]['messages'],
+            maxTokens: 128,
+          },
+          { guardrailConfig },
+        ) as Parameters<BedrockTransport['complete']>[0],
+      );
+
+      const [[cmd]] = mockSend.mock.calls as [[{ input: Record<string, unknown> }]];
+      expect(cmd.input['guardrailConfig']).toEqual(guardrailConfig);
+    });
+
+    it('passes guardrailConfig from request.meta.guardrailConfig', async () => {
+      mockSend.mockResolvedValueOnce(makeConverseResponse('Protected'));
+
+      const t = new BedrockTransport();
+      const guardrailConfig = {
+        guardrailIdentifier: 'gr-def456',
+        guardrailVersion: '2',
+      };
+
+      await t.complete(
+        Object.assign(
+          {
+            model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+            messages: [{ role: 'user', content: 'Test' }] as Parameters<
+              BedrockTransport['complete']
+            >[0]['messages'],
+            maxTokens: 128,
+          },
+          { meta: { guardrailConfig } },
+        ) as Parameters<BedrockTransport['complete']>[0],
+      );
+
+      const [[cmd]] = mockSend.mock.calls as [[{ input: Record<string, unknown> }]];
+      expect(cmd.input['guardrailConfig']).toEqual(guardrailConfig);
+    });
+  });
+
+  describe('credential resolution', () => {
+    it('calls fromNodeProviderChain without profile when awsProfile not set', () => {
+      mockFromNodeProviderChain.mockClear();
+      new BedrockTransport({ region: 'us-east-1' });
+      // Client is lazy — no credential resolution until first request
+      // Force client instantiation by checking _getClient indirectly
+      // through the class structure
+      expect(mockFromNodeProviderChain).not.toHaveBeenCalled(); // lazy
+    });
+
+    it('passes awsProfile to fromNodeProviderChain when set', async () => {
+      mockFromNodeProviderChain.mockClear();
+      mockSend.mockResolvedValueOnce(makeConverseResponse('OK'));
+
+      const t = new BedrockTransport({ region: 'us-east-1', awsProfile: 'my-work-profile' });
+      await t.complete({
+        model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        messages: [{ role: 'user', content: 'Hi' }],
+        maxTokens: 64,
+      });
+
+      expect(mockFromNodeProviderChain).toHaveBeenCalledWith({ profile: 'my-work-profile' });
+    });
+  });
+
+  describe('region defaults', () => {
+    it('defaults to us-east-1 when no region env vars set', () => {
+      const savedRegion = process.env['AWS_REGION'];
+      const savedDefault = process.env['AWS_DEFAULT_REGION'];
+      delete process.env['AWS_REGION'];
+      delete process.env['AWS_DEFAULT_REGION'];
+
+      const t = new BedrockTransport();
+      // Access internal _primaryRegion via type cast for testing
+      const internal = t as unknown as { _primaryRegion: string };
+      expect(internal._primaryRegion).toBe('us-east-1');
+
+      if (savedRegion !== undefined) process.env['AWS_REGION'] = savedRegion;
+      if (savedDefault !== undefined) process.env['AWS_DEFAULT_REGION'] = savedDefault;
+    });
+
+    it('picks up AWS_REGION env var', () => {
+      const saved = process.env['AWS_REGION'];
+      process.env['AWS_REGION'] = 'ap-northeast-1';
+
+      const t = new BedrockTransport();
+      const internal = t as unknown as { _primaryRegion: string };
+      expect(internal._primaryRegion).toBe('ap-northeast-1');
+
+      if (saved !== undefined) {
+        process.env['AWS_REGION'] = saved;
+      } else {
+        delete process.env['AWS_REGION'];
+      }
+    });
+  });
+});

--- a/packages/core/src/llm/transports/bedrock.ts
+++ b/packages/core/src/llm/transports/bedrock.ts
@@ -22,8 +22,8 @@
 import {
   BedrockRuntimeClient,
   ConverseCommand,
-  ConverseStreamCommand,
   type ConverseCommandOutput,
+  ConverseStreamCommand,
   type ConverseStreamCommandOutput,
   type GuardrailConfiguration,
   type InferenceConfiguration,
@@ -429,7 +429,10 @@ export class BedrockTransport implements LlmTransport {
   /**
    * Normalize a raw `ConverseCommandOutput` into a {@link NormalizedResponse}.
    */
-  private _normalizeResponse(response: ConverseCommandOutput, modelName: string): NormalizedResponse {
+  private _normalizeResponse(
+    response: ConverseCommandOutput,
+    modelName: string,
+  ): NormalizedResponse {
     const r = response as unknown as {
       output?: { message?: { content?: RawContentBlock[] } };
       stopReason?: string;

--- a/packages/core/src/llm/transports/bedrock.ts
+++ b/packages/core/src/llm/transports/bedrock.ts
@@ -1,0 +1,531 @@
+/**
+ * AWS Bedrock Converse API transport.
+ *
+ * Implements {@link LlmTransport} using the Bedrock Converse API
+ * (`ConverseCommand` + `ConverseStreamCommand`) for chat-format message
+ * exchange. Supports all models available through Bedrock's Converse surface
+ * (Claude, Nova, Mistral, Llama, etc.) without the model-specific invokeModel
+ * differences.
+ *
+ * Key behaviors:
+ * - AWS credential chain via `fromNodeProviderChain()` (env → ~/.aws/credentials → IAM → SSO)
+ * - Cross-region fallback: retries on `AccessDeniedException`/throttle against
+ *   a configured fallback region list
+ * - Guardrail integration: `guardrailConfig` from `request.meta`
+ * - Tool use (function calling) via Converse `toolConfig`
+ *
+ * @module llm/transports/bedrock
+ * @task T9317
+ * @epic T9261 (T-LLM-CRED-CENTRALIZATION Phase 5)
+ */
+
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+  ConverseStreamCommand,
+  type ConverseCommandOutput,
+  type ConverseStreamCommandOutput,
+  type GuardrailConfiguration,
+  type InferenceConfiguration,
+  type Message,
+  type SystemContentBlock,
+  type ToolConfiguration,
+  type ToolInputSchema,
+} from '@aws-sdk/client-bedrock-runtime';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import type { NormalizedDelta, TransportContext } from '@cleocode/contracts/llm/interfaces.js';
+import type {
+  LlmTransport,
+  NormalizedResponse,
+  NormalizedToolCall,
+  NormalizedUsage,
+  TransportMessage,
+  TransportRequest,
+  TransportTool,
+} from '@cleocode/contracts/llm/normalized-response.js';
+import type { ApiMode } from '@cleocode/contracts/llm/provider-id.js';
+
+// ---------------------------------------------------------------------------
+// Cross-region fallback configuration
+// ---------------------------------------------------------------------------
+
+/** Bedrock error codes that signal a region does not support the requested model. */
+const CROSS_REGION_RETRY_CODES = new Set([
+  'AccessDeniedException',
+  'ValidationException',
+  'ResourceNotFoundException',
+  'ThrottlingException',
+]);
+
+// ---------------------------------------------------------------------------
+// Constructor options
+// ---------------------------------------------------------------------------
+
+/**
+ * Options accepted by {@link BedrockTransport}.
+ *
+ * AWS credentials are resolved via the standard `fromNodeProviderChain()`
+ * (env vars → `~/.aws/credentials` → IAM instance metadata → SSO).
+ * Explicit profile override available via `awsProfile`.
+ *
+ * `fallbackRegions` is the cross-region retry list. When the primary region
+ * returns a denial or throttle, regions are tried in list order.
+ */
+export interface BedrockTransportOptions {
+  /** AWS region (defaults to `AWS_REGION` then `AWS_DEFAULT_REGION` env vars). */
+  region?: string;
+  /** Optional AWS credentials profile name (overrides default chain). */
+  awsProfile?: string;
+  /**
+   * Ordered list of fallback regions to try when the primary region returns
+   * a model-not-supported or throttle error.
+   */
+  fallbackRegions?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal type helpers
+// ---------------------------------------------------------------------------
+
+function isCrossRegionCandidate(err: unknown): boolean {
+  if (err == null || typeof err !== 'object') return false;
+  const name = (err as { name?: string }).name ?? '';
+  return CROSS_REGION_RETRY_CODES.has(name);
+}
+
+// ---------------------------------------------------------------------------
+// Message mapping helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract plain text from a {@link TransportMessage}'s content.
+ *
+ * Concatenates text blocks; drops image blocks (Bedrock image support is out
+ * of scope for this transport's initial implementation).
+ */
+function extractText(content: TransportMessage['content']): string {
+  if (typeof content === 'string') return content;
+  return content
+    .filter((b): b is { readonly type: 'text'; readonly text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+}
+
+/**
+ * Map provider-neutral {@link TransportMessage}[] to Bedrock `Message[]`.
+ *
+ * Tool-result messages (`role: 'tool'`) are mapped to `user` role with a
+ * `toolResult` content block, as required by the Converse API.
+ * System-role messages are extracted separately by {@link extractSystemBlocks}.
+ */
+function mapMessages(messages: TransportMessage[]): Message[] {
+  return messages
+    .filter((m) => (m as { role: string }).role !== 'system')
+    .map((m): Message => {
+      if ((m as { role: string }).role === 'tool') {
+        return {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: m.toolUseId ?? '',
+                content: [{ text: extractText(m.content) }],
+                status: 'success',
+              },
+            },
+          ],
+        };
+      }
+      return {
+        role: (m as { role: 'user' | 'assistant' }).role,
+        content: [{ text: extractText(m.content) }],
+      };
+    });
+}
+
+/**
+ * Extract system-role messages and any top-level `system` field into Bedrock
+ * `SystemContentBlock[]`.
+ */
+function extractSystemBlocks(messages: TransportMessage[], system?: string): SystemContentBlock[] {
+  const blocks: SystemContentBlock[] = [];
+  if (system) blocks.push({ text: system });
+  for (const m of messages) {
+    if ((m as { role: string }).role === 'system') {
+      blocks.push({ text: extractText(m.content) });
+    }
+  }
+  return blocks;
+}
+
+/**
+ * Map provider-neutral {@link TransportTool}[] to Bedrock `ToolConfiguration`.
+ */
+function mapToolConfig(tools: TransportTool[]): ToolConfiguration {
+  return {
+    tools: tools.map((t) => ({
+      toolSpec: {
+        name: t.name,
+        description: t.description,
+        inputSchema: { json: t.inputSchema } as ToolInputSchema,
+      },
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Response mapping helpers
+// ---------------------------------------------------------------------------
+
+/** Bedrock content block narrowed to the fields we access at runtime. */
+type RawContentBlock = Record<string, unknown>;
+
+/**
+ * Extract plain text from a Bedrock response's content block array.
+ *
+ * Uses `unknown → Record` casting via the intermediate `unknown` step to
+ * satisfy the SDK's closed discriminated union without needing exhaustive
+ * switch arms.
+ */
+function extractResponseText(blocks: RawContentBlock[]): string | null {
+  const parts: string[] = [];
+  for (const block of blocks) {
+    if (typeof block['text'] === 'string') parts.push(block['text'] as string);
+  }
+  return parts.length > 0 ? parts.join('') : null;
+}
+
+/**
+ * Extract tool-use blocks from a Bedrock response's content block array.
+ */
+function extractToolCalls(blocks: RawContentBlock[]): NormalizedToolCall[] | null {
+  const calls: NormalizedToolCall[] = [];
+  for (const block of blocks) {
+    const tu = block['toolUse'] as
+      | { toolUseId?: string; name?: string; input?: unknown }
+      | undefined;
+    if (tu != null) {
+      calls.push({
+        id: tu.toolUseId ?? null,
+        name: tu.name ?? '',
+        arguments: JSON.stringify(tu.input ?? {}),
+      });
+    }
+  }
+  return calls.length > 0 ? calls : null;
+}
+
+// ---------------------------------------------------------------------------
+// BedrockTransport
+// ---------------------------------------------------------------------------
+
+/**
+ * AWS Bedrock Converse API transport.
+ *
+ * Wraps `@aws-sdk/client-bedrock-runtime` and normalizes requests/responses
+ * to/from the provider-neutral {@link LlmTransport} interface. Uses the
+ * Converse API for a uniform chat-format surface across all Bedrock models.
+ *
+ * Credential resolution uses `fromNodeProviderChain()` which follows the
+ * standard AWS credential chain: env vars → `~/.aws/credentials` (profile)
+ * → ECS container metadata → EC2 instance profile → SSO.
+ *
+ * Cross-region fallback retries against `options.fallbackRegions` when the
+ * primary region returns an `AccessDeniedException`, `ValidationException`,
+ * `ResourceNotFoundException`, or `ThrottlingException`. This is the primary
+ * mechanism for handling cross-region inference profiles.
+ *
+ * @example
+ * ```ts
+ * const transport = new BedrockTransport({ region: 'us-east-1' });
+ * const response = await transport.complete({
+ *   model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+ *   messages: [{ role: 'user', content: 'Hello' }],
+ *   maxTokens: 512,
+ * });
+ * ```
+ */
+export class BedrockTransport implements LlmTransport {
+  /** Provider identifier — always `'bedrock'`. */
+  readonly provider = 'bedrock' as const;
+
+  /**
+   * Wire protocol spoken by this transport — always `'bedrock_converse'`.
+   *
+   * @see ADR-072 §Type lock-in
+   */
+  readonly apiMode: ApiMode = 'bedrock_converse' as const;
+
+  private readonly _primaryRegion: string;
+  private readonly _fallbackRegions: string[];
+  private readonly _awsProfile: string | undefined;
+
+  /** Lazily-constructed per-region client cache. */
+  private readonly _clients: Map<string, BedrockRuntimeClient> = new Map();
+
+  /**
+   * Create a `BedrockTransport`.
+   *
+   * @param options - AWS region, optional credential profile, and fallback region list.
+   */
+  constructor(options: BedrockTransportOptions = {}) {
+    this._primaryRegion =
+      options.region ??
+      process.env['AWS_REGION'] ??
+      process.env['AWS_DEFAULT_REGION'] ??
+      'us-east-1';
+    this._fallbackRegions = options.fallbackRegions ?? [];
+    this._awsProfile = options.awsProfile;
+  }
+
+  /**
+   * Execute a single completion against the Bedrock Converse API.
+   *
+   * Supports: tool use (function calling), guardrail passthrough,
+   * cross-region fallback, and AWS credential chain resolution.
+   *
+   * @param request - Provider-neutral request parameters. Guardrail config
+   *   can be passed via `(request as BedrockTransportRequest).guardrailConfig`.
+   * @param _ctx - Transport context (unused by this transport currently).
+   * @returns Normalized response including content, tool calls, usage, and raw SDK object.
+   */
+  async complete(request: TransportRequest, _ctx?: TransportContext): Promise<NormalizedResponse> {
+    const converseInput = this._buildConverseInput(request);
+    const regions = [this._primaryRegion, ...this._fallbackRegions];
+
+    let lastErr: unknown;
+    for (const region of regions) {
+      const client = this._getClient(region);
+      try {
+        const response: ConverseCommandOutput = await client.send(
+          new ConverseCommand(converseInput),
+        );
+        return this._normalizeResponse(response, request.model);
+      } catch (err) {
+        lastErr = err;
+        if (!isCrossRegionCandidate(err)) throw err;
+        // Try next region in fallback list
+      }
+    }
+    throw lastErr;
+  }
+
+  /**
+   * Stream a completion against the Bedrock Converse Stream API.
+   *
+   * Yields text deltas as they arrive. Reasoning content (when present) goes
+   * to `delta.reasoning`; visible text goes to `delta.text`. Tool-use content
+   * blocks are dropped from streaming output (only available on the final
+   * message stop event). The final delta carries `stopReason` and `usage`.
+   *
+   * @invariant stream tool-call yield contract — tool_use blocks are DROPPED
+   *   during streaming. Callers needing full tool call arguments MUST use
+   *   `complete()` for tool-call scenarios.
+   *
+   * @param request - Provider-neutral request parameters.
+   * @param _ctx - Transport context (unused by this transport currently).
+   * @returns An async iterable of normalized delta chunks.
+   */
+  async *stream(request: TransportRequest, _ctx: TransportContext): AsyncIterable<NormalizedDelta> {
+    const streamInput = this._buildConverseStreamInput(request);
+    const regions = [this._primaryRegion, ...this._fallbackRegions];
+
+    let lastErr: unknown;
+    for (const region of regions) {
+      const client = this._getClient(region);
+      try {
+        const response: ConverseStreamCommandOutput = await client.send(
+          new ConverseStreamCommand(streamInput),
+        );
+        if (!response.stream) return;
+        yield* this._readStream(
+          response.stream as unknown as AsyncIterable<Record<string, unknown>>,
+        );
+        return;
+      } catch (err) {
+        lastErr = err;
+        if (!isCrossRegionCandidate(err)) throw err;
+        // Try next region in fallback list
+      }
+    }
+    throw lastErr;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Return (or lazily create) a `BedrockRuntimeClient` for the given region.
+   *
+   * Clients are cached per region to avoid repeated credential resolution
+   * overhead on cross-region fallback retries.
+   *
+   * @param region - AWS region string.
+   */
+  private _getClient(region: string): BedrockRuntimeClient {
+    let client = this._clients.get(region);
+    if (!client) {
+      client = new BedrockRuntimeClient({
+        region,
+        credentials: fromNodeProviderChain(
+          this._awsProfile ? { profile: this._awsProfile } : undefined,
+        ),
+      });
+      this._clients.set(region, client);
+    }
+    return client;
+  }
+
+  /**
+   * Build the Bedrock `ConverseRequest` from a provider-neutral `TransportRequest`.
+   */
+  private _buildConverseInput(
+    request: TransportRequest,
+  ): ConstructorParameters<typeof ConverseCommand>[0] {
+    const messages = mapMessages(request.messages);
+    const systemBlocks = extractSystemBlocks(request.messages, request.system);
+
+    const inferenceConfig: InferenceConfiguration = {
+      maxTokens: request.maxTokens,
+    };
+    if (request.temperature != null) {
+      inferenceConfig.temperature = request.temperature;
+    }
+
+    const input: ConstructorParameters<typeof ConverseCommand>[0] = {
+      modelId: request.model,
+      messages,
+      inferenceConfig,
+    };
+
+    if (systemBlocks.length > 0) input.system = systemBlocks;
+
+    if (request.tools && request.tools.length > 0) {
+      input.toolConfig = mapToolConfig(request.tools);
+    }
+
+    // Guardrail passthrough from request extended fields or meta
+    const ext = request as TransportRequest & {
+      guardrailConfig?: GuardrailConfiguration;
+      meta?: { guardrailConfig?: GuardrailConfiguration };
+    };
+    const guardrail = ext.guardrailConfig ?? ext.meta?.guardrailConfig;
+    if (guardrail) input.guardrailConfig = guardrail;
+
+    return input;
+  }
+
+  /**
+   * Build the Bedrock `ConverseStreamRequest` from a provider-neutral `TransportRequest`.
+   */
+  private _buildConverseStreamInput(
+    request: TransportRequest,
+  ): ConstructorParameters<typeof ConverseStreamCommand>[0] {
+    const base = this._buildConverseInput(request);
+    return base as ConstructorParameters<typeof ConverseStreamCommand>[0];
+  }
+
+  /**
+   * Normalize a raw `ConverseCommandOutput` into a {@link NormalizedResponse}.
+   */
+  private _normalizeResponse(response: ConverseCommandOutput, modelName: string): NormalizedResponse {
+    const r = response as unknown as {
+      output?: { message?: { content?: RawContentBlock[] } };
+      stopReason?: string;
+      usage?: { inputTokens?: number; outputTokens?: number; cacheReadInputTokens?: number };
+      $metadata?: { requestId?: string };
+    };
+
+    const blocks = r.output?.message?.content ?? [];
+    const content = extractResponseText(blocks);
+    const toolCalls = extractToolCalls(blocks);
+
+    const usage: NormalizedUsage = {
+      inputTokens: r.usage?.inputTokens ?? 0,
+      outputTokens: r.usage?.outputTokens ?? 0,
+    };
+    if (r.usage?.cacheReadInputTokens) {
+      usage.cachedTokens = r.usage.cacheReadInputTokens;
+    }
+
+    const id = r.$metadata?.requestId ?? `bedrock-${Date.now().toString(36)}`;
+
+    return {
+      id,
+      model: modelName,
+      content,
+      toolCalls,
+      stopReason: r.stopReason ?? 'end_turn',
+      usage,
+      raw: response,
+    };
+  }
+
+  /**
+   * Consume a Bedrock `ConverseStreamOutput` async iterable and yield
+   * normalized deltas.
+   *
+   * @param stream - The async iterable from `ConverseStreamResponse.stream`.
+   */
+  private async *_readStream(
+    stream: AsyncIterable<Record<string, unknown>>,
+  ): AsyncIterable<NormalizedDelta> {
+    let stopReason: string | null = null;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cacheReadTokens: number | undefined;
+
+    for await (const event of stream) {
+      if (event['contentBlockDelta'] != null) {
+        const deltaEvent = event['contentBlockDelta'] as { delta?: Record<string, unknown> };
+        const delta = deltaEvent.delta;
+        if (!delta) continue;
+
+        if (typeof delta['text'] === 'string' && delta['text']) {
+          yield { text: delta['text'] as string, reasoning: '', stopReason: null, usage: null };
+          continue;
+        }
+
+        // reasoning content delta
+        const rc = delta['reasoningContent'] as Record<string, unknown> | undefined;
+        if (rc != null) {
+          if (typeof rc['text'] === 'string' && rc['text']) {
+            yield { text: '', reasoning: rc['text'] as string, stopReason: null, usage: null };
+          }
+          continue;
+        }
+
+        // toolUse delta — dropped per @invariant stream tool-call yield contract
+      }
+
+      if (event['messageStop'] != null) {
+        const stop = event['messageStop'] as { stopReason?: string };
+        stopReason = stop.stopReason ?? 'end_turn';
+      }
+
+      if (event['metadata'] != null) {
+        const meta = event['metadata'] as {
+          usage?: { inputTokens?: number; outputTokens?: number; cacheReadInputTokens?: number };
+        };
+        if (meta.usage) {
+          inputTokens = meta.usage.inputTokens ?? 0;
+          outputTokens = meta.usage.outputTokens ?? 0;
+          if (meta.usage.cacheReadInputTokens) {
+            cacheReadTokens = meta.usage.cacheReadInputTokens;
+          }
+        }
+      }
+    }
+
+    const finalUsage: NormalizedUsage = { inputTokens, outputTokens };
+    if (cacheReadTokens) finalUsage.cachedTokens = cacheReadTokens;
+
+    yield {
+      text: '',
+      reasoning: '',
+      stopReason: stopReason ?? 'end_turn',
+      usage: finalUsage,
+    };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,12 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.88.0
         version: 0.88.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime':
+        specifier: ^3.0.0
+        version: 3.1027.0
+      '@aws-sdk/credential-providers':
+        specifier: ^3.0.0
+        version: 3.1048.0
       '@cleocode/adapters':
         specifier: workspace:*
         version: link:../adapters
@@ -793,7 +799,7 @@ importers:
         version: 4.12.12
       llmtxt:
         specifier: '*'
-        version: 2026.4.13(@cleocode/lafs@2026.5.60)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9)
+        version: 2026.4.13(@cleocode/lafs@2026.5.72)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9)
       loro-crdt:
         specifier: '*'
         version: 1.11.0
@@ -975,40 +981,88 @@ packages:
     resolution: {integrity: sha512-Qcda5Z5Vb3LPVt7zNycEiiAo9Blk0JpEPJwz/sUBJby6/0zvTlo+/FIXlwYZ3TJHSgKCYiCaBqAB0WRlWDfLfQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-cognito-identity@3.1048.0':
+    resolution: {integrity: sha512-eJUSxEwhz9fKmjhRgOvFTuJ+SjCu15SpgYo3aSJ6rjs2IaWi2F8NcvOuejHb0a01a/J71/9bdjUDrQLH2kUmkg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.973.27':
     resolution: {integrity: sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.11':
+    resolution: {integrity: sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.34':
+    resolution: {integrity: sha512-hbOTV+vNi3kKo3J6qxylHSfcnSbnnVoMe1KA1VMjYazAEPmk+HSgLUksOemptoNldvSLTSj82ndB1mcZDMP3iQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.25':
     resolution: {integrity: sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.37':
+    resolution: {integrity: sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.27':
     resolution: {integrity: sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.39':
+    resolution: {integrity: sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.29':
     resolution: {integrity: sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.41':
+    resolution: {integrity: sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.29':
     resolution: {integrity: sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.41':
+    resolution: {integrity: sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.30':
     resolution: {integrity: sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.42':
+    resolution: {integrity: sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.25':
     resolution: {integrity: sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.37':
+    resolution: {integrity: sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.29':
     resolution: {integrity: sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.41':
+    resolution: {integrity: sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.29':
     resolution: {integrity: sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.41':
+    resolution: {integrity: sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1048.0':
+    resolution: {integrity: sha512-qradm+eSLJTWQLd/TOxlETL1rMQ/ozvr2iU7wga5hqoox/FiXV9VLtomv3Cqwa6GdpYGWI8ebfSu6mS18I1PyQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/eventstream-handler-node@3.972.13':
@@ -1043,8 +1097,16 @@ packages:
     resolution: {integrity: sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.9':
+    resolution: {integrity: sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.11':
     resolution: {integrity: sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    resolution: {integrity: sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1026.0':
@@ -1055,8 +1117,16 @@ packages:
     resolution: {integrity: sha512-mI3Jm14cM5sNKc7aNX3cqJe/rFQ2Zzx7x5W8WUtxj2lVxcH2RGYhqI3hK9nnImY6Ec5MeGXCVPjl/q6Mz5HmSA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.7':
     resolution: {integrity: sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.996.6':
@@ -1085,6 +1155,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.17':
     resolution: {integrity: sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.24':
+    resolution: {integrity: sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -1333,8 +1407,8 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  '@cleocode/lafs@2026.5.60':
-    resolution: {integrity: sha512-tRE9yKNUyzIAYR9WhCfZWnG/kypIIJ3Ff/hTJ0LiDZ7A43mK1d0JvmKqIAliH8SHX59XpHaT4rUu0UlR0FbkgA==}
+  '@cleocode/lafs@2026.5.72':
+    resolution: {integrity: sha512-385K9CbVXrSjuo5E79ihaqvXwqXTOXrczZN1U6ZNGPGA1ZebosagQMeMmAnzskJOUOYUFpPbwSYGohyqa1f31g==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1984,6 +2058,9 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2353,8 +2430,16 @@ packages:
     resolution: {integrity: sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.3':
+    resolution: {integrity: sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.13':
     resolution: {integrity: sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.3':
+    resolution: {integrity: sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.13':
@@ -2379,6 +2464,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.16':
     resolution: {integrity: sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.3':
+    resolution: {integrity: sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-node@4.2.13':
@@ -2425,6 +2514,10 @@ packages:
     resolution: {integrity: sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.13':
     resolution: {integrity: sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==}
     engines: {node: '>=18.0.0'}
@@ -2453,12 +2546,20 @@ packages:
     resolution: {integrity: sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.4.3':
+    resolution: {integrity: sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.9':
     resolution: {integrity: sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.0':
     resolution: {integrity: sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.13':
@@ -3749,8 +3850,15 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
   fast-xml-parser@5.5.8:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -5018,6 +5126,10 @@ packages:
     resolution: {integrity: sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==}
     engines: {node: '>=14.0.0'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -6078,6 +6190,10 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -6217,7 +6333,7 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/sha256-browser@5.2.0':
@@ -6298,6 +6414,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-cognito-identity@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/credential-provider-node': 3.972.42
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.973.27':
     dependencies:
       '@aws-sdk/types': 3.973.7
@@ -6314,12 +6443,39 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.24
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.34':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.25':
     dependencies:
       '@aws-sdk/core': 3.973.27
       '@aws-sdk/types': 3.973.7
       '@smithy/property-provider': 4.2.13
       '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.27':
@@ -6333,6 +6489,16 @@ snapshots:
       '@smithy/smithy-client': 4.12.9
       '@smithy/types': 4.14.0
       '@smithy/util-stream': 4.5.22
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.29':
@@ -6354,6 +6520,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/credential-provider-env': 3.972.37
+      '@aws-sdk/credential-provider-http': 3.972.39
+      '@aws-sdk/credential-provider-login': 3.972.41
+      '@aws-sdk/credential-provider-process': 3.972.37
+      '@aws-sdk/credential-provider-sso': 3.972.41
+      '@aws-sdk/credential-provider-web-identity': 3.972.41
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.29':
     dependencies:
       '@aws-sdk/core': 3.973.27
@@ -6366,6 +6548,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.30':
     dependencies:
@@ -6384,6 +6575,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.42':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.37
+      '@aws-sdk/credential-provider-http': 3.972.39
+      '@aws-sdk/credential-provider-ini': 3.972.41
+      '@aws-sdk/credential-provider-process': 3.972.37
+      '@aws-sdk/credential-provider-sso': 3.972.41
+      '@aws-sdk/credential-provider-web-identity': 3.972.41
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.25':
     dependencies:
       '@aws-sdk/core': 3.973.27
@@ -6391,6 +6596,14 @@ snapshots:
       '@smithy/property-provider': 4.2.13
       '@smithy/shared-ini-file-loader': 4.4.8
       '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.29':
@@ -6406,6 +6619,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.29':
     dependencies:
       '@aws-sdk/core': 3.973.27
@@ -6417,6 +6640,35 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.1048.0
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.34
+      '@aws-sdk/credential-provider-env': 3.972.37
+      '@aws-sdk/credential-provider-http': 3.972.39
+      '@aws-sdk/credential-provider-ini': 3.972.41
+      '@aws-sdk/credential-provider-login': 3.972.41
+      '@aws-sdk/credential-provider-node': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.37
+      '@aws-sdk/credential-provider-sso': 3.972.41
+      '@aws-sdk/credential-provider-web-identity': 3.972.41
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/eventstream-handler-node@3.972.13':
     dependencies:
@@ -6522,12 +6774,33 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.9':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.972.11':
     dependencies:
       '@aws-sdk/types': 3.973.7
       '@smithy/config-resolver': 4.4.14
       '@smithy/node-config-provider': 4.3.13
       '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1026.0':
@@ -6554,9 +6827,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.11
+      '@aws-sdk/nested-clients': 3.997.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.7':
     dependencies:
       '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.996.6':
@@ -6598,6 +6885,13 @@ snapshots:
     dependencies:
       '@smithy/types': 4.14.0
       fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.24':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -7017,7 +7311,7 @@ snapshots:
       - '@grpc/grpc-js'
       - supports-color
 
-  '@cleocode/lafs@2026.5.60':
+  '@cleocode/lafs@2026.5.72':
     dependencies:
       '@a2a-js/sdk': 0.3.13(express@5.2.1)
       ajv: 8.18.0
@@ -7675,6 +7969,8 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -7936,12 +8232,24 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.3':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.13':
     dependencies:
       '@smithy/node-config-provider': 4.3.13
       '@smithy/property-provider': 4.2.13
       '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.13
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.13':
@@ -7980,6 +8288,12 @@ snapshots:
       '@smithy/querystring-builder': 4.2.13
       '@smithy/types': 4.14.0
       '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/hash-node@4.2.13':
@@ -8058,6 +8372,12 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.13':
     dependencies:
       '@smithy/types': 4.14.0
@@ -8099,6 +8419,12 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.9':
     dependencies:
       '@smithy/core': 3.23.14
@@ -8110,6 +8436,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.14.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
     dependencies:
       tslib: 2.8.1
 
@@ -9425,10 +9755,22 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.4.0
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
   fast-xml-parser@5.5.8:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.4.0
+      strnum: 2.2.3
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
   fastest-levenshtein@1.0.16: {}
@@ -10068,7 +10410,7 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  llmtxt@2026.4.13(@cleocode/lafs@2026.5.60)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9):
+  llmtxt@2026.4.13(@cleocode/lafs@2026.5.72)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9):
     dependencies:
       '@noble/ed25519': 3.1.0
       '@noble/hashes': 2.2.0
@@ -10077,7 +10419,7 @@ snapshots:
       yjs: 13.6.30
       zod: 4.3.6
     optionalDependencies:
-      '@cleocode/lafs': 2026.5.60
+      '@cleocode/lafs': 2026.5.72
       better-sqlite3: 12.9.0
       drizzle-orm: 1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6)
       onnxruntime-node: 1.24.3
@@ -10918,6 +11260,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.4.0: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
 
@@ -12256,6 +12600,8 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
     optional: true
+
+  xml-naming@0.1.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
Recovers T9317 work into a proper PR after the original worker merged directly to local main without opening one (no force-push to origin occurred — local-only mishap). All Bedrock code intact, 19 unit tests pass, full build green.

Includes:
- `@aws-sdk/client-bedrock-runtime` + `@aws-sdk/credential-providers` workspace deps
- `BedrockTransport` implementing `LlmTransport` for `bedrock_converse` ApiMode (Converse API + cross-region fallback + guardrail)
- Provider profile `provider-registry/builtin/bedrock.ts` (model id prefixes: `anthropic.claude-`, `amazon.nova-`, `mistral.mistral-`, etc.)
- Registered in `transports/index.ts`
- Unit tests with mocked AWS SDK (19 tests pass)
- Live integration test stub gated on `AWS_BEDROCK_TEST_KEY` env var (T9342 owner-action follow-up)

Links: closes T9317, follow-up T9342 (owner-action: AWS Bedrock CI creds).

## Test plan
- [x] `pnpm run build` ✅
- [x] `pnpm --filter @cleocode/core test bedrock` ✅ 19/19
- [ ] CI green