### PR TITLE
feat(T9316): streaming tool-call deltas (anthropic + chat-completions)

### DIFF
--- a/packages/core/src/llm/transports/__tests__/streaming-tool-calls.test.ts
+++ b/packages/core/src/llm/transports/__tests__/streaming-tool-calls.test.ts
@@ -1,0 +1,538 @@
+/**
+ * Unit tests for streaming tool-call delta emission (T9316).
+ *
+ * Covers:
+ * 1. AnthropicTransport.stream() — tool_use sequence yields start/args/end deltas
+ * 2. ChatCompletionsTransport.stream() — OpenAI tool_calls yields incremental args
+ * 3. Consumers can accumulate argumentsChunk fragments to reconstruct full JSON
+ *
+ * @task T9316
+ * @epic T9261 (T-LLM-CRED-CENTRALIZATION Phase 5)
+ */
+
+import type { NormalizedDelta } from '@cleocode/contracts/llm/interfaces.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock transitive deps before any transport imports
+// ---------------------------------------------------------------------------
+
+vi.mock('jsonrepair', () => ({
+  jsonrepair: (s: string) => s,
+}));
+
+vi.mock('../../prompt-caching.js', () => ({
+  injectCacheBreakpoints: () => undefined,
+}));
+
+vi.mock('../../structured-output.js', () => ({
+  repairResponseModelJson: (s: string) => s,
+}));
+
+vi.mock('../think-scrubber.js', () => ({
+  StreamingThinkScrubber: class {
+    feed(text: string) {
+      return text;
+    }
+    flush() {
+      return '';
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock @anthropic-ai/sdk before any imports
+// ---------------------------------------------------------------------------
+
+const { mockMessagesStream } = vi.hoisted(() => {
+  const mockMessagesStream = vi.fn();
+  return { mockMessagesStream };
+});
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class MockAnthropic {
+    messages = {
+      stream: mockMessagesStream,
+    };
+  }
+  return { default: MockAnthropic };
+});
+
+// ---------------------------------------------------------------------------
+// Mock openai before any imports
+// ---------------------------------------------------------------------------
+
+const { mockChatCompletionsCreate } = vi.hoisted(() => {
+  const mockChatCompletionsCreate = vi.fn();
+  return { mockChatCompletionsCreate };
+});
+
+vi.mock('openai', () => {
+  class MockOpenAI {
+    chat = {
+      completions: {
+        create: mockChatCompletionsCreate,
+      },
+    };
+  }
+  return { default: MockOpenAI };
+});
+
+// ---------------------------------------------------------------------------
+// Mock image-routing (no-op for transport tests)
+// ---------------------------------------------------------------------------
+
+vi.mock('../../image-routing.js', () => ({
+  validateImagesForProvider: () => undefined,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { AnthropicTransport } from '../anthropic.js';
+import { ChatCompletionsTransport } from '../chat-completions.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Collect all deltas from an async iterable. */
+async function collectDeltas(iter: AsyncIterable<NormalizedDelta>): Promise<NormalizedDelta[]> {
+  const out: NormalizedDelta[] = [];
+  for await (const d of iter) out.push(d);
+  return out;
+}
+
+/** Build a minimal TransportContext for tests. */
+function makeCtx() {
+  return { requestId: 'test-req-001' };
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic streaming tool-call tests
+// ---------------------------------------------------------------------------
+
+describe('AnthropicTransport.stream() — tool-call deltas', () => {
+  let transport: AnthropicTransport;
+
+  beforeEach(() => {
+    transport = new AnthropicTransport({ apiKey: 'test-key' });
+    vi.clearAllMocks();
+  });
+
+  it('yields start, args, and end deltas for a single tool_use block', async () => {
+    // Simulate Anthropic SSE sequence for one tool call.
+    const events = [
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu_01', name: 'get_weather' },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"city":' },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '"Paris"}' },
+      },
+      { type: 'content_block_stop', index: 0 },
+    ];
+
+    const mockStream = {
+      [Symbol.asyncIterator]: () => {
+        let i = 0;
+        return {
+          next: async () =>
+            i < events.length
+              ? { value: events[i++], done: false }
+              : { value: undefined, done: true },
+        };
+      },
+      finalMessage: async () => ({
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 20, output_tokens: 10, cache_read_input_tokens: null },
+      }),
+    };
+    mockMessagesStream.mockReturnValue(mockStream);
+
+    const deltas = await collectDeltas(
+      transport.stream(
+        { model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }], maxTokens: 100 },
+        makeCtx(),
+      ),
+    );
+
+    // Filter to only tool-call deltas
+    const toolDeltas = deltas.filter((d) => d.toolCallDelta !== undefined);
+    expect(toolDeltas.length).toBeGreaterThanOrEqual(3);
+
+    // Start marker: name present, empty argumentsChunk
+    const start = toolDeltas[0];
+    expect(start.toolCallDelta?.index).toBe(0);
+    expect(start.toolCallDelta?.name).toBe('get_weather');
+    expect(start.toolCallDelta?.argumentsChunk).toBe('');
+
+    // Args chunks: contain partial JSON
+    const argChunks = toolDeltas.slice(1, -1);
+    const accumulated = argChunks.map((d) => d.toolCallDelta?.argumentsChunk ?? '').join('');
+    expect(accumulated).toBe('{"city":"Paris"}');
+
+    // End marker: no name, empty argumentsChunk
+    const end = toolDeltas[toolDeltas.length - 1];
+    expect(end.toolCallDelta?.index).toBe(0);
+    expect(end.toolCallDelta?.name).toBeUndefined();
+    expect(end.toolCallDelta?.argumentsChunk).toBe('');
+
+    // Final delta carries usage
+    const final = deltas[deltas.length - 1];
+    expect(final.stopReason).toBe('tool_use');
+    expect(final.usage?.inputTokens).toBe(20);
+  });
+
+  it('does not interfere with text deltas in a mixed stream', async () => {
+    const events = [
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text' },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'Hello ' },
+      },
+      { type: 'content_block_stop', index: 0 },
+      {
+        type: 'content_block_start',
+        index: 1,
+        content_block: { type: 'tool_use', id: 'toolu_02', name: 'calculator' },
+      },
+      {
+        type: 'content_block_delta',
+        index: 1,
+        delta: { type: 'input_json_delta', partial_json: '{"expr":"1+1"}' },
+      },
+      { type: 'content_block_stop', index: 1 },
+    ];
+
+    const mockStream = {
+      [Symbol.asyncIterator]: () => {
+        let i = 0;
+        return {
+          next: async () =>
+            i < events.length
+              ? { value: events[i++], done: false }
+              : { value: undefined, done: true },
+        };
+      },
+      finalMessage: async () => ({
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 5, output_tokens: 5, cache_read_input_tokens: null },
+      }),
+    };
+    mockMessagesStream.mockReturnValue(mockStream);
+
+    const deltas = await collectDeltas(
+      transport.stream(
+        {
+          model: 'claude-sonnet-4-6',
+          messages: [{ role: 'user', content: 'calc' }],
+          maxTokens: 100,
+        },
+        makeCtx(),
+      ),
+    );
+
+    const textDeltas = deltas.filter((d) => d.text.length > 0);
+    const toolDeltas = deltas.filter((d) => d.toolCallDelta !== undefined);
+
+    expect(textDeltas.map((d) => d.text).join('')).toBe('Hello ');
+    const toolStart = toolDeltas[0];
+    expect(toolStart.toolCallDelta?.name).toBe('calculator');
+    const argsChunk = toolDeltas
+      .slice(1, -1)
+      .map((d) => d.toolCallDelta?.argumentsChunk ?? '')
+      .join('');
+    expect(argsChunk).toBe('{"expr":"1+1"}');
+  });
+
+  it('consumer can reconstruct full arguments JSON from accumulated chunks', async () => {
+    const fullArgs = JSON.stringify({ query: 'climate change', limit: 10, format: 'json' });
+    // Split into 4 chunks to simulate realistic streaming
+    const chunk1 = fullArgs.slice(0, 10);
+    const chunk2 = fullArgs.slice(10, 30);
+    const chunk3 = fullArgs.slice(30, 50);
+    const chunk4 = fullArgs.slice(50);
+
+    const events = [
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu_03', name: 'web_search' },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: chunk1 },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: chunk2 },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: chunk3 },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: chunk4 },
+      },
+      { type: 'content_block_stop', index: 0 },
+    ];
+
+    const mockStream = {
+      [Symbol.asyncIterator]: () => {
+        let i = 0;
+        return {
+          next: async () =>
+            i < events.length
+              ? { value: events[i++], done: false }
+              : { value: undefined, done: true },
+        };
+      },
+      finalMessage: async () => ({
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 30, output_tokens: 15, cache_read_input_tokens: null },
+      }),
+    };
+    mockMessagesStream.mockReturnValue(mockStream);
+
+    const deltas = await collectDeltas(
+      transport.stream(
+        {
+          model: 'claude-sonnet-4-6',
+          messages: [{ role: 'user', content: 'search' }],
+          maxTokens: 200,
+        },
+        makeCtx(),
+      ),
+    );
+
+    // Accumulate all argument chunks (skip start/end markers which have empty argumentsChunk)
+    const toolDeltas = deltas.filter((d) => d.toolCallDelta !== undefined);
+    const accumulated = toolDeltas.map((d) => d.toolCallDelta?.argumentsChunk ?? '').join('');
+
+    const parsed = JSON.parse(accumulated) as Record<string, unknown>;
+    expect(parsed).toEqual({ query: 'climate change', limit: 10, format: 'json' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChatCompletionsTransport streaming tool-call tests
+// ---------------------------------------------------------------------------
+
+describe('ChatCompletionsTransport.stream() — tool-call deltas', () => {
+  let transport: ChatCompletionsTransport;
+
+  beforeEach(() => {
+    transport = new ChatCompletionsTransport({ provider: 'openai', apiKey: 'test-key' });
+    vi.clearAllMocks();
+  });
+
+  it('yields start and incremental args deltas for OpenAI-style tool_calls', async () => {
+    // Simulate OpenAI streaming tool-call chunks
+    const chunks = [
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [{ index: 0, function: { name: 'get_weather', arguments: '' } }],
+            },
+            finish_reason: null,
+          },
+        ],
+        usage: null,
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [{ index: 0, function: { name: '', arguments: '{"city":' } }],
+            },
+            finish_reason: null,
+          },
+        ],
+        usage: null,
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [{ index: 0, function: { name: '', arguments: '"London"}' } }],
+            },
+            finish_reason: null,
+          },
+        ],
+        usage: null,
+      },
+      {
+        choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+        usage: null,
+      },
+      {
+        choices: [{ delta: {}, finish_reason: null }],
+        usage: { prompt_tokens: 25, completion_tokens: 12 },
+      },
+    ];
+
+    mockChatCompletionsCreate.mockResolvedValue(
+      (async function* () {
+        for (const c of chunks) yield c;
+      })(),
+    );
+
+    const deltas = await collectDeltas(
+      transport.stream(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'weather?' }], maxTokens: 100 },
+        makeCtx(),
+      ),
+    );
+
+    const toolDeltas = deltas.filter((d) => d.toolCallDelta !== undefined);
+    expect(toolDeltas.length).toBeGreaterThanOrEqual(2);
+
+    // First chunk: start marker with name
+    const first = toolDeltas[0];
+    expect(first.toolCallDelta?.index).toBe(0);
+    expect(first.toolCallDelta?.name).toBe('get_weather');
+
+    // Subsequent: incremental argument JSON
+    const argText = toolDeltas
+      .slice(1)
+      .map((d) => d.toolCallDelta?.argumentsChunk ?? '')
+      .join('');
+    expect(argText).toBe('{"city":"London"}');
+
+    // Final delta has usage
+    const final = deltas[deltas.length - 1];
+    expect(final.stopReason).toBe('tool_calls');
+    expect(final.usage?.inputTokens).toBe(25);
+  });
+
+  it('handles multiple parallel tool calls at different indices', async () => {
+    const chunks = [
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, function: { name: 'tool_a', arguments: '' } },
+                { index: 1, function: { name: 'tool_b', arguments: '' } },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+        usage: null,
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, function: { name: '', arguments: '{"x":1}' } },
+                { index: 1, function: { name: '', arguments: '{"y":2}' } },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: null,
+      },
+      {
+        choices: [{ delta: {}, finish_reason: null }],
+        usage: { prompt_tokens: 10, completion_tokens: 8 },
+      },
+    ];
+
+    mockChatCompletionsCreate.mockResolvedValue(
+      (async function* () {
+        for (const c of chunks) yield c;
+      })(),
+    );
+
+    const deltas = await collectDeltas(
+      transport.stream(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'multi' }], maxTokens: 100 },
+        makeCtx(),
+      ),
+    );
+
+    const toolDeltas = deltas.filter((d) => d.toolCallDelta !== undefined);
+
+    // Should have start + args for both indices
+    const idx0 = toolDeltas.filter((d) => d.toolCallDelta?.index === 0);
+    const idx1 = toolDeltas.filter((d) => d.toolCallDelta?.index === 1);
+
+    expect(idx0[0].toolCallDelta?.name).toBe('tool_a');
+    expect(idx1[0].toolCallDelta?.name).toBe('tool_b');
+
+    const args0 = idx0
+      .slice(1)
+      .map((d) => d.toolCallDelta?.argumentsChunk ?? '')
+      .join('');
+    const args1 = idx1
+      .slice(1)
+      .map((d) => d.toolCallDelta?.argumentsChunk ?? '')
+      .join('');
+
+    expect(JSON.parse(args0)).toEqual({ x: 1 });
+    expect(JSON.parse(args1)).toEqual({ y: 2 });
+  });
+
+  it('existing text consumers (delta.text) still work unaffected by tool deltas', async () => {
+    const chunks = [
+      {
+        choices: [{ delta: { content: 'Hello' }, finish_reason: null }],
+        usage: null,
+      },
+      {
+        choices: [{ delta: { content: ' world' }, finish_reason: 'stop' }],
+        usage: null,
+      },
+      {
+        choices: [{ delta: {}, finish_reason: null }],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      },
+    ];
+
+    mockChatCompletionsCreate.mockResolvedValue(
+      (async function* () {
+        for (const c of chunks) yield c;
+      })(),
+    );
+
+    const deltas = await collectDeltas(
+      transport.stream(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'hi' }], maxTokens: 50 },
+        makeCtx(),
+      ),
+    );
+
+    const textContent = deltas
+      .filter((d) => d.text.length > 0)
+      .map((d) => d.text)
+      .join('');
+    expect(textContent).toBe('Hello world');
+
+    const toolDeltas = deltas.filter((d) => d.toolCallDelta !== undefined);
+    expect(toolDeltas).toHaveLength(0);
+  });
+});

--- a/packages/core/src/llm/transports/anthropic.ts
+++ b/packages/core/src/llm/transports/anthropic.ts
@@ -498,16 +498,22 @@ export class AnthropicTransport implements LlmTransport {
   /**
    * Stream a completion against the Anthropic Messages API.
    *
-   * Yields text deltas as they arrive. Thinking/reasoning blocks are routed to
-   * `delta.reasoning`; visible text goes to `delta.text`. Tool-use content
-   * blocks are dropped from streaming output (the full tool call is only
-   * available from the final message, which callers should fetch via
-   * `complete()` for tool-call scenarios).
+   * Yields text, reasoning, and tool-call argument deltas as they arrive.
+   * Thinking/reasoning blocks are routed to `delta.reasoning`; visible text
+   * goes to `delta.text`. Tool-use content blocks emit incremental
+   * `toolCallDelta` chunks so consumers can accumulate argument JSON in real
+   * time without waiting for the final message.
    *
-   * @invariant stream tool-call yield contract — text-only deltas are yielded
-   *   from streaming output; `tool_use` content blocks are DROPPED during
-   *   streaming. Callers that need tool call arguments MUST use `complete()`
-   *   instead of `stream()`, or accumulate deltas and parse the final message.
+   * Tool-call streaming sequence per tool-use block:
+   * 1. `content_block_start` (type=tool_use) → yields delta with `toolCallDelta`
+   *    carrying `{ index, name, argumentsChunk: '' }` (start marker).
+   * 2. `content_block_delta` (type=input_json_delta) → yields delta with
+   *    `toolCallDelta` carrying `{ index, argumentsChunk }` (incremental JSON).
+   * 3. `content_block_stop` → yields delta with `toolCallDelta` carrying
+   *    `{ index, argumentsChunk: '' }` and `stopReason: null` (end marker, no name).
+   *
+   * Consumers accumulate `argumentsChunk` fragments in index order to
+   * reconstruct the full arguments JSON string before invoking tool handlers.
    *
    * @invariant thinkingBudgetTokens vs useJsonPrefill MUTEX in stream() — same
    *   mutex as complete(): when `thinkingBudgetTokens` is set, `useJsonPrefill`
@@ -623,15 +629,31 @@ export class AnthropicTransport implements LlmTransport {
     );
 
     let inThinkingBlock = false;
+    // Tracks tool-use block state per content-block index.
+    // Maps index → tool name so we can emit the start delta with the name.
+    const toolBlockNames = new Map<number, string>();
 
     for await (const chunk of stream as AsyncIterable<MessageStreamEvent>) {
       const chunkAny = chunk as unknown as Record<string, unknown>;
       const chunkType = chunkAny['type'];
 
       if (chunkType === 'content_block_start') {
+        const index = Number(chunkAny['index'] ?? 0);
         const blockStart = chunkAny['content_block'] as Record<string, unknown> | undefined;
         if (blockStart?.['type'] === 'thinking') {
           inThinkingBlock = true;
+        } else if (blockStart?.['type'] === 'tool_use') {
+          inThinkingBlock = false;
+          const name = String(blockStart['name'] ?? '');
+          toolBlockNames.set(index, name);
+          // Emit start marker — name present, empty argumentsChunk.
+          yield {
+            text: '',
+            reasoning: '',
+            stopReason: null,
+            usage: null,
+            toolCallDelta: { index, name, argumentsChunk: '' },
+          };
         } else {
           inThinkingBlock = false;
         }
@@ -639,13 +661,24 @@ export class AnthropicTransport implements LlmTransport {
       }
 
       if (chunkType === 'content_block_stop') {
+        const index = Number(chunkAny['index'] ?? 0);
+        if (toolBlockNames.has(index)) {
+          // Emit end marker — no name, empty argumentsChunk.
+          yield {
+            text: '',
+            reasoning: '',
+            stopReason: null,
+            usage: null,
+            toolCallDelta: { index, argumentsChunk: '' },
+          };
+          toolBlockNames.delete(index);
+        }
         inThinkingBlock = false;
         continue;
       }
 
-      // @invariant stream tool-call yield contract — tool_use blocks are DROPPED.
-      // Only text deltas (and thinking deltas routed to delta.reasoning) are yielded.
       if (chunkType === 'content_block_delta') {
+        const index = Number(chunkAny['index'] ?? 0);
         const delta = chunkAny['delta'] as Record<string, unknown> | undefined;
         if (!delta) continue;
 
@@ -664,9 +697,19 @@ export class AnthropicTransport implements LlmTransport {
           if (text) {
             yield { text, reasoning: '', stopReason: null, usage: null };
           }
+          continue;
         }
 
-        // input_json_delta (tool_use streaming) — dropped per @invariant
+        if (deltaType === 'input_json_delta') {
+          const argumentsChunk = String(delta['partial_json'] ?? '');
+          yield {
+            text: '',
+            reasoning: '',
+            stopReason: null,
+            usage: null,
+            toolCallDelta: { index, argumentsChunk },
+          };
+        }
       }
     }
 

--- a/packages/core/src/llm/transports/chat-completions.ts
+++ b/packages/core/src/llm/transports/chat-completions.ts
@@ -478,6 +478,14 @@ export class ChatCompletionsTransport implements LlmTransport {
    * visible text before being yielded as {@link NormalizedDelta}. The final delta
    * carries `stopReason` and `usage`.
    *
+   * Tool-call streaming: when a chunk carries `delta.tool_calls[i]`, the
+   * transport emits `toolCallDelta` entries so consumers can accumulate partial
+   * argument JSON in real time. Sequence per tool call index:
+   * 1. First chunk for index `i` (`tool_calls[i].function.name` present) → yields
+   *    `toolCallDelta` with `{ index, name, argumentsChunk }`.
+   * 2. Subsequent chunks (name absent) → yields `toolCallDelta` with
+   *    `{ index, argumentsChunk }` containing the partial JSON fragment.
+   *
    * Provider quirks (`_applyProviderQuirks`) are applied to the request kwargs
    * before the stream is opened, matching the behaviour of {@link complete}.
    *
@@ -524,6 +532,8 @@ export class ChatCompletionsTransport implements LlmTransport {
     let finishReason: string | null = null;
     let usageChunkReceived = false;
     const scrubber = new StreamingThinkScrubber();
+    // Tracks which tool-call indices have already received a start delta (with name).
+    const seenToolCallIndices = new Set<number>();
 
     for await (const chunk of responseStream) {
       const delta = chunk.choices[0]?.delta;
@@ -545,6 +555,35 @@ export class ChatCompletionsTransport implements LlmTransport {
           : '';
       if (rawReasoning) {
         yield { text: '', reasoning: rawReasoning, stopReason: null, usage: null };
+      }
+
+      // Emit incremental tool-call argument deltas when the chunk carries them.
+      if (delta?.tool_calls && delta.tool_calls.length > 0) {
+        for (const tc of delta.tool_calls) {
+          const index = tc.index ?? 0;
+          const argumentsChunk = tc.function?.arguments ?? '';
+          const name = tc.function?.name;
+          if (!seenToolCallIndices.has(index)) {
+            // First delta for this index — always emit a start marker with name.
+            seenToolCallIndices.add(index);
+            yield {
+              text: '',
+              reasoning: '',
+              stopReason: null,
+              usage: null,
+              toolCallDelta: { index, name: name ?? '', argumentsChunk },
+            };
+          } else if (argumentsChunk) {
+            // Subsequent chunks — emit incremental arguments fragment.
+            yield {
+              text: '',
+              reasoning: '',
+              stopReason: null,
+              usage: null,
+              toolCallDelta: { index, argumentsChunk },
+            };
+          }
+        }
       }
 
       if (chunk.choices[0]?.finish_reason) {


### PR DESCRIPTION
## Summary

- Extended `AnthropicTransport.stream()` to emit `toolCallDelta` events for `tool_use` content blocks, yielding start markers (with tool name), incremental `input_json_delta` argument chunks, and end markers on `content_block_stop`
- Extended `ChatCompletionsTransport.stream()` to emit `toolCallDelta` events for OpenAI-style `delta.tool_calls` streaming, handling multiple parallel tool call indices
- Added 6 unit tests in `packages/core/src/llm/transports/__tests__/streaming-tool-calls.test.ts` covering both transports and the argument accumulation use case
- Backward compatible: existing `delta.text` consumers are completely unaffected; `toolCallDelta` is an optional field on `NormalizedDelta`

Note: `openai.ts` and `gemini.ts` symmetry deferred per 3-file cap — follow-up task filed.

## Test plan

- [x] All 6 new streaming tool-call tests pass
- [x] `pnpm biome ci` clean on changed files
- [x] Pre-existing test failures are unrelated environment issues (missing `@google/generative-ai`, `@a2a-js/sdk`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)