### PR TITLE
release: ship v2026.5.74 (T9344 Anthropic OAuth hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2026.5.74] (2026-05-16)
+
+Auto-prepared by release.ship (T9261)
+
+### Changes
+- **T9344: Hotfix Anthropic OAuth — drop false placeholder framing + fix redirectUri**: T9326 (shipped v2026.5.73) labeled the canonical public Anthropic PKCE client_id 9d1c250a-e61b-44d9-88ed-5944d1962f5e as a 'placeholder' and added ... (T9344)
+---
 ## [2026.5.73] (2026-05-16)
 
 Auto-prepared by release.ship (T9261)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "conduit-core",
  "nom",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "cant-core",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "serde",
  "serde_json",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "cant-core",
  "serde",
@@ -394,7 +394,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-llm-native"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "lafs-core",
  "serde",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-core"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "chrono",
  "conduit-core",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-payments"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-protocol"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "cant-core",
  "chrono",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-sdk"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-storage"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-transport"
-version = "2026.5.70"
+version = "2026.5.74"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.73"
+version = "2026.5.74"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.73",
+  "version": "2026.5.74",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Hotfix release for v2026.5.73. Closes T9344. Cancels T9341, T9342, T9343 as misconceived.

Key changes from T9344:
- Drop false "placeholder" framing on the canonical public Anthropic PKCE client_id (`9d1c250a-e61b-44d9-88ed-5944d1962f5e` — same ID Claude Code, pi-ai, OpenCode, Hermes use; no per-app registration required by Anthropic)
- Remove stderr warning that was spamming every `cleo` invocation
- Fix Anthropic OAuth `redirectUri` → `https://console.anthropic.com/oauth/code/callback` (matches Hermes/Claude Code paste-back flow), was incorrectly `http://localhost`

## Test plan
- [x] `pnpm --filter @cleocode/core test anthropic-client-id` 6/6 pass
- [x] `pnpm --filter @cleocode/core build` green
- [x] Source-side cleanup verified: zero references to `T9341` or `ANTHROPIC_OAUTH_CLIENT_ID_PLACEHOLDER` in TS source
- [ ] CI green
- [ ] npm `@cleocode/cleo@2026.5.74` published
- [ ] Global install verifies no stderr spam