### PR TITLE
fix(T9245): validateCommit content-intersect + critical-gate override revocation

### DIFF
--- a/packages/core/src/tasks/__tests__/evidence-content-intersect.test.ts
+++ b/packages/core/src/tasks/__tests__/evidence-content-intersect.test.ts
@@ -1,0 +1,337 @@
+/**
+ * T9245 — validateCommit content-intersect + critical-gate override rejection.
+ *
+ * Reproduces the loophole proven 2026-05-12: validateCommit at evidence.ts
+ * only checked SHA reachability, never the commit's diff against the task's
+ * AC-listed files. 13 mis-completed tasks across the 2026-05-11 campaign
+ * exploited this. This suite locks the fix in place.
+ *
+ * Test matrix:
+ *  - extractTaskAcFiles: pure-function unit tests over task.files / AC-parsing
+ *  - validateCommit content-intersect:
+ *      A) AC files declared, commit touches unrelated file → REJECT
+ *      B) AC files declared, commit touches AC file        → ACCEPT
+ *      C) No AC files declared                              → ACCEPT (legacy)
+ *      D) task.kind = 'research'                            → ACCEPT (no code)
+ *      E) Directory-style AC entry, commit inside it        → ACCEPT
+ *  - revalidateEvidence critical-gate override rejection:
+ *      F) implemented gate + override-only evidence → REJECT
+ *      G) testsPassed gate + override-only evidence → REJECT
+ *      H) qaPassed gate + override-only evidence    → ACCEPT (non-critical)
+ *      I) implemented gate + override + hard atom   → ACCEPT
+ *
+ * Audit: `.cleo/rcasd/campaign-validation-2026-05-12/SYNTHESIS.md`
+ *
+ * @task T9245
+ * @adr ADR-051
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Task } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, seedTasks, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import { resetDbState } from '../../store/sqlite.js';
+import {
+  CRITICAL_GATES_NO_OVERRIDE,
+  extractTaskAcFiles,
+  revalidateEvidence,
+  validateAtom,
+} from '../evidence.js';
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+function git(dir: string, args: string[]): string {
+  return execFileSync('git', args, { cwd: dir }).toString();
+}
+
+function initGitRepo(dir: string): void {
+  git(dir, ['init', '-q']);
+  git(dir, ['config', 'user.name', 'T9245 Probe']);
+  git(dir, ['config', 'user.email', 'probe@example.com']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+}
+
+function gitCommitFile(dir: string, relPath: string, content: string, message: string): string {
+  const fullPath = join(dir, relPath);
+  // Ensure parent dir exists.
+  const slash = relPath.lastIndexOf('/');
+  if (slash > 0) {
+    mkdirSync(join(dir, relPath.slice(0, slash)), { recursive: true });
+  }
+  writeFileSync(fullPath, content);
+  git(dir, ['add', relPath]);
+  git(dir, ['commit', '-q', '-m', message]);
+  return git(dir, ['rev-parse', 'HEAD']).trim();
+}
+
+// =============================================================================
+// extractTaskAcFiles — pure-function unit tests
+// =============================================================================
+
+describe('T9245 — extractTaskAcFiles', () => {
+  it('returns task.files when populated', () => {
+    const r = extractTaskAcFiles({
+      files: ['packages/core/src/a.ts', 'packages/core/src/b.ts'],
+      acceptance: ['ignored'],
+    });
+    expect(r).toEqual(['packages/core/src/a.ts', 'packages/core/src/b.ts']);
+  });
+
+  it('parses path-like tokens from AC strings when files empty', () => {
+    const r = extractTaskAcFiles({
+      files: [],
+      acceptance: [
+        'packages/core/src/tasks/evidence.ts contains validateCommit',
+        'Update packages/cleo/src/cli/commands/verify.ts',
+      ],
+    });
+    expect(r).toContain('packages/core/src/tasks/evidence.ts');
+    expect(r).toContain('packages/cleo/src/cli/commands/verify.ts');
+  });
+
+  it('returns null when neither files nor parseable AC paths', () => {
+    const r = extractTaskAcFiles({
+      files: [],
+      acceptance: ['Write some tests', 'Make it work'],
+    });
+    expect(r).toBeNull();
+  });
+
+  it('returns null on undefined inputs', () => {
+    expect(extractTaskAcFiles({})).toBeNull();
+  });
+
+  it('deduplicates path tokens across AC strings', () => {
+    const r = extractTaskAcFiles({
+      files: [],
+      acceptance: ['edit packages/core/src/x.ts', 'also test packages/core/src/x.ts'],
+    });
+    expect(r).toEqual(['packages/core/src/x.ts']);
+  });
+});
+
+// =============================================================================
+// validateCommit content-intersect — integration tests against real DB + git
+// =============================================================================
+
+describe('T9245 — validateCommit content-intersect (probe reproduction)', () => {
+  let env: TestDbEnv;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    // Initialize git repo at the same dir as the cleo DB so validateCommit
+    // resolves the same projectRoot for both.
+    initGitRepo(env.tempDir);
+    // First commit to anchor HEAD.
+    gitCommitFile(env.tempDir, 'README.md', 'init\n', 'init');
+  });
+
+  afterEach(async () => {
+    await env.cleanup();
+    resetDbState();
+  });
+
+  it('REJECTS commit that touches no AC files (probe scenario)', async () => {
+    // Seed a task whose AC declares one file path…
+    await seedTasks(env.accessor, [
+      {
+        id: 'T_PROBE',
+        title: 'probe',
+        description: 'probe-test',
+        status: 'pending',
+        priority: 'medium',
+        files: ['src/fileA.ts'],
+        acceptance: ['src/fileA.ts contains marker_A'],
+      } as Partial<Task> & { id: string },
+    ]);
+
+    // …then make a commit that ONLY touches an unrelated file.
+    const sha = gitCommitFile(env.tempDir, 'src/unrelated.ts', 'noise\n', 'unrelated commit');
+
+    const r = await validateAtom({ kind: 'commit', sha }, env.tempDir, 'T_PROBE');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.codeName).toBe('E_EVIDENCE_CONTENT_MISMATCH');
+      expect(r.reason).toMatch(/does not intersect/i);
+      expect(r.reason).toMatch(/T9245/);
+    }
+  });
+
+  it('ACCEPTS commit that touches a declared AC file', async () => {
+    await seedTasks(env.accessor, [
+      {
+        id: 'T_OK',
+        title: 'happy path',
+        description: 'happy-path-test',
+        status: 'pending',
+        priority: 'medium',
+        files: ['src/fileA.ts'],
+        acceptance: ['src/fileA.ts contains marker_A'],
+      } as Partial<Task> & { id: string },
+    ]);
+
+    const sha = gitCommitFile(env.tempDir, 'src/fileA.ts', 'marker_A\n', 'real implementation');
+
+    const r = await validateAtom({ kind: 'commit', sha }, env.tempDir, 'T_OK');
+    expect(r.ok).toBe(true);
+  });
+
+  it('ACCEPTS when task declares no AC files (legacy tolerance)', async () => {
+    await seedTasks(env.accessor, [
+      {
+        id: 'T_LEGACY',
+        title: 'legacy',
+        description: 'legacy-test',
+        status: 'pending',
+        priority: 'medium',
+        files: [],
+        acceptance: ['Make it work somehow'],
+      } as Partial<Task> & { id: string },
+    ]);
+
+    const sha = gitCommitFile(env.tempDir, 'anywhere.ts', 'x\n', 'unrelated');
+
+    const r = await validateAtom({ kind: 'commit', sha }, env.tempDir, 'T_LEGACY');
+    expect(r.ok).toBe(true);
+  });
+
+  it('ACCEPTS for research tasks regardless of diff', async () => {
+    await seedTasks(env.accessor, [
+      {
+        id: 'T_RES',
+        title: 'research-only',
+        description: 'research-test',
+        status: 'pending',
+        priority: 'medium',
+        kind: 'research',
+        files: ['src/never-touched.ts'],
+        acceptance: ['src/never-touched.ts must exist'],
+      } as Partial<Task> & { id: string },
+    ]);
+
+    const sha = gitCommitFile(env.tempDir, 'docs/notes.md', 'finding\n', 'research notes');
+
+    const r = await validateAtom({ kind: 'commit', sha }, env.tempDir, 'T_RES');
+    expect(r.ok).toBe(true);
+  });
+
+  it('ACCEPTS commit inside a directory-style AC entry', async () => {
+    await seedTasks(env.accessor, [
+      {
+        id: 'T_DIR',
+        title: 'dir-scope',
+        description: 'dir-scope-test',
+        status: 'pending',
+        priority: 'medium',
+        files: ['packages/core/src/tasks/'],
+        acceptance: ['change something under packages/core/src/tasks/'],
+      } as Partial<Task> & { id: string },
+    ]);
+
+    const sha = gitCommitFile(env.tempDir, 'packages/core/src/tasks/foo.ts', 'x\n', 'inside dir');
+
+    const r = await validateAtom({ kind: 'commit', sha }, env.tempDir, 'T_DIR');
+    expect(r.ok).toBe(true);
+  });
+
+  it('skips content-intersect entirely when no taskId is provided', async () => {
+    // Back-compat: callers that pass no taskId get the legacy
+    // reachability-only behavior.
+    const sha = gitCommitFile(env.tempDir, 'misc.ts', 'x\n', 'no-task-context');
+
+    const r = await validateAtom({ kind: 'commit', sha }, env.tempDir);
+    expect(r.ok).toBe(true);
+  });
+});
+
+// =============================================================================
+// revalidateEvidence critical-gate override rejection
+// =============================================================================
+
+describe('T9245 — revalidateEvidence rejects override-only on critical gates', () => {
+  it('exports CRITICAL_GATES_NO_OVERRIDE = [implemented, testsPassed]', () => {
+    expect(CRITICAL_GATES_NO_OVERRIDE).toEqual(['implemented', 'testsPassed']);
+  });
+
+  it('REJECTS override-only evidence on implemented gate', async () => {
+    const r = await revalidateEvidence(
+      {
+        atoms: [{ kind: 'override', reason: 'owner-override-test' }],
+        capturedAt: new Date().toISOString(),
+        capturedBy: 'owner',
+        override: true,
+        overrideReason: 'owner-override-test',
+      },
+      '/tmp',
+      'implemented',
+    );
+    expect(r.stillValid).toBe(false);
+    expect(r.failedAtoms[0]?.reason).toMatch(/T9245/);
+    expect(r.failedAtoms[0]?.reason).toMatch(/critical/i);
+  });
+
+  it('REJECTS override-only evidence on testsPassed gate', async () => {
+    const r = await revalidateEvidence(
+      {
+        atoms: [{ kind: 'override', reason: 'tests-bypass' }],
+        capturedAt: new Date().toISOString(),
+        capturedBy: 'owner',
+        override: true,
+        overrideReason: 'tests-bypass',
+      },
+      '/tmp',
+      'testsPassed',
+    );
+    expect(r.stillValid).toBe(false);
+    expect(r.failedAtoms[0]?.reason).toMatch(/testsPassed/);
+  });
+
+  it('ACCEPTS override-only evidence on qaPassed (non-critical)', async () => {
+    const r = await revalidateEvidence(
+      {
+        atoms: [{ kind: 'override', reason: 'qa-waiver' }],
+        capturedAt: new Date().toISOString(),
+        capturedBy: 'owner',
+        override: true,
+        overrideReason: 'qa-waiver',
+      },
+      '/tmp',
+      'qaPassed',
+    );
+    expect(r.stillValid).toBe(true);
+  });
+
+  it('ACCEPTS override-only evidence on documented (non-critical)', async () => {
+    const r = await revalidateEvidence(
+      {
+        atoms: [{ kind: 'override', reason: 'docs-trivial' }],
+        capturedAt: new Date().toISOString(),
+        capturedBy: 'owner',
+        override: true,
+        overrideReason: 'docs-trivial',
+      },
+      '/tmp',
+      'documented',
+    );
+    expect(r.stillValid).toBe(true);
+  });
+
+  it('skips override-rejection when gate parameter omitted (back-compat)', async () => {
+    // Pre-T9245 callers (no gate arg) still get the old override pass-through.
+    const r = await revalidateEvidence(
+      {
+        atoms: [{ kind: 'override', reason: 'legacy' }],
+        capturedAt: new Date().toISOString(),
+        capturedBy: 'owner',
+        override: true,
+        overrideReason: 'legacy',
+      },
+      '/tmp',
+    );
+    expect(r.stillValid).toBe(true);
+  });
+});

--- a/packages/core/src/tasks/complete.ts
+++ b/packages/core/src/tasks/complete.ts
@@ -910,7 +910,9 @@ export async function completeTaskStrict(
         const staleGates: Array<{ gate: string; failures: string[] }> = [];
         for (const [gate, ev] of evidenceEntries) {
           if (!ev) continue;
-          const check = await revalidateEvidence(ev, projectRoot);
+          // T9245: pass gate so revalidate can enforce the
+          // critical-gate override-rejection rule.
+          const check = await revalidateEvidence(ev, projectRoot, gate as VerificationGate);
           if (!check.stillValid) {
             staleGates.push({
               gate,

--- a/packages/core/src/tasks/evidence.ts
+++ b/packages/core/src/tasks/evidence.ts
@@ -423,7 +423,28 @@ export async function validateAtom(
   }
 }
 
-/** T9178: Validates commit is on task branch when taskId provided. */
+/**
+ * T9178: Validates commit is on task branch when taskId provided.
+ *
+ * T9245: ALSO validates commit's diff intersects the task's acceptance-criteria
+ * file list. Closes the content-mismatch loophole proven 2026-05-12: a worker
+ * could pass `--evidence commit:<sha>` with a SHA that touched zero AC files
+ * because validateCommit only ever checked SHA reachability. 13 mis-completed
+ * tasks across the 2026-05-11 campaign exploited this. Audit:
+ * `.cleo/rcasd/campaign-validation-2026-05-12/SYNTHESIS.md`.
+ *
+ * Content-intersect skips when:
+ *   - taskId is not provided (legacy call sites)
+ *   - task cannot be loaded (best-effort tolerance — do not break verify)
+ *   - task.kind ∈ {research, spike} (no code change expected)
+ *   - the task declares no AC file paths at all (neither task.files nor
+ *     parseable path tokens in task.acceptance strings) — see
+ *     {@link extractTaskAcFiles}
+ *
+ * @task T9178
+ * @task T9245
+ * @adr ADR-051
+ */
 async function validateCommit(
   sha: string,
   projectRoot: string,
@@ -479,12 +500,188 @@ async function validateCommit(
         };
       }
     }
+
+    // T9245: content-intersect check — diff MUST touch at least one AC file.
+    const intersectResult = await checkCommitContentIntersect(sha, taskId, projectRoot);
+    if (!intersectResult.ok) {
+      return intersectResult;
+    }
   }
   const short = await runCommand('git', ['rev-parse', '--short', sha], projectRoot);
   const shortSha = short.stdout.trim() || sha.slice(0, 7);
   const full = await runCommand('git', ['rev-parse', sha], projectRoot);
   const fullSha = full.stdout.trim() || sha;
   return { ok: true, atom: { kind: 'commit', sha: fullSha, shortSha } };
+}
+
+/**
+ * Path-token regex used by {@link extractTaskAcFiles} to recover AC file paths
+ * from free-text acceptance strings when {@link Task.files} is empty.
+ *
+ * Matches dotted/slashed tokens that look like a source path. Permissive on
+ * extension to allow `.md`, `.json`, `.sql`, etc. The orchestrator's preferred
+ * SSoT is the explicit `task.files` array — string-token parsing is a
+ * fallback for legacy tasks that predate the `--files` flag.
+ *
+ * @task T9245
+ */
+const AC_PATH_TOKEN =
+  /(?:^|[\s"'`([])([a-zA-Z0-9_\-./@]+\/[a-zA-Z0-9_\-./]+\.[a-zA-Z0-9]{1,8})(?=$|[\s"'`)\],;:])/g;
+
+/**
+ * Extract the canonical list of files a task's acceptance criteria declare.
+ *
+ * Resolution order:
+ *   1. `task.files` array — authoritative when populated (set via `--files`)
+ *   2. AC string parsing — extract path-like tokens from each
+ *      `task.acceptance` string
+ *
+ * Returns `null` when the task declares no AC files at all — caller MUST
+ * interpret this as "skip content-intersect" rather than "verify fails".
+ *
+ * @internal
+ * @task T9245
+ */
+export function extractTaskAcFiles(task: {
+  files?: string[] | null;
+  acceptance?: ReadonlyArray<unknown> | null;
+}): string[] | null {
+  // 1. Explicit files array wins.
+  if (task.files && task.files.length > 0) {
+    return [...task.files];
+  }
+  // 2. Parse path tokens from AC strings.
+  if (!task.acceptance || task.acceptance.length === 0) {
+    return null;
+  }
+  const parsed = new Set<string>();
+  for (const item of task.acceptance) {
+    if (typeof item !== 'string') continue;
+    // Reset regex state for each iteration (g flag).
+    AC_PATH_TOKEN.lastIndex = 0;
+    let m: RegExpExecArray | null = AC_PATH_TOKEN.exec(item);
+    while (m !== null) {
+      if (m[1]) parsed.add(m[1]);
+      m = AC_PATH_TOKEN.exec(item);
+    }
+  }
+  return parsed.size > 0 ? Array.from(parsed) : null;
+}
+
+/**
+ * Run `git show --name-only <sha>` and return the list of file paths the
+ * commit touched (added, modified, or deleted). Empty array on git failure.
+ *
+ * @internal
+ * @task T9245
+ */
+async function gitShowFiles(sha: string, projectRoot: string): Promise<string[]> {
+  const r = await runCommand('git', ['show', '--name-only', '--pretty=format:', sha], projectRoot);
+  if (r.exitCode !== 0) return [];
+  return r.stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Determine whether `<commit-diff> ∩ <task-AC-files>` is non-empty.
+ *
+ * Tolerates path mismatches caused by:
+ *   - leading `./` prefix
+ *   - trailing slashes (directories listed in AC)
+ *   - case-insensitive filesystems (rare on Linux/CI but defensive)
+ *
+ * @internal
+ * @task T9245
+ */
+function diffIntersectsAc(diffFiles: string[], acFiles: string[]): boolean {
+  const norm = (s: string): string => s.replace(/^\.\//, '').replace(/\/+$/, '').toLowerCase();
+  const acSet = new Set(acFiles.map(norm));
+  const acPrefixes = acFiles.map(norm).filter((p) => !p.includes('.') || p.endsWith('/'));
+  for (const f of diffFiles) {
+    const nf = norm(f);
+    if (acSet.has(nf)) return true;
+    // Directory-style AC entry: e.g. AC says `packages/core/src/tasks/`,
+    // diff touches `packages/core/src/tasks/evidence.ts`.
+    for (const prefix of acPrefixes) {
+      if (nf.startsWith(`${prefix}/`)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Content-intersect check for {@link validateCommit}.
+ *
+ * Loads the task by ID, derives the AC file list, runs
+ * `git show --name-only <sha>`, and verifies the intersection is non-empty.
+ *
+ * Returns `ok: true` (the no-op signal) when the task cannot be loaded or
+ * when AC file extraction returns null — these are tolerated to avoid
+ * breaking legacy / decision-only / research tasks.
+ *
+ * @internal
+ * @task T9245
+ */
+async function checkCommitContentIntersect(
+  sha: string,
+  taskId: string,
+  projectRoot: string,
+): Promise<AtomValidation> {
+  // Best-effort load — DB unavailability MUST NOT block verify.
+  let task: {
+    files?: string[] | null;
+    acceptance?: unknown[] | null;
+    kind?: string | null;
+  } | null = null;
+  try {
+    const { getTaskAccessor } = await import('../store/data-accessor.js');
+    const accessor = await getTaskAccessor(projectRoot);
+    task = await accessor.loadSingleTask(taskId);
+  } catch {
+    // Tolerate: legacy callers, init-time use, test stubs.
+    return { ok: true, atom: { kind: 'commit', sha, shortSha: sha.slice(0, 7) } };
+  }
+  if (!task) {
+    return { ok: true, atom: { kind: 'commit', sha, shortSha: sha.slice(0, 7) } };
+  }
+  // Research / spike tasks legitimately produce no code change.
+  if (task.kind === 'research' || task.kind === 'spike') {
+    return { ok: true, atom: { kind: 'commit', sha, shortSha: sha.slice(0, 7) } };
+  }
+  const acFiles = extractTaskAcFiles({
+    files: task.files,
+    acceptance: task.acceptance as ReadonlyArray<unknown> | null | undefined,
+  });
+  // No declared AC files — cannot enforce intersection (legacy tasks).
+  if (!acFiles || acFiles.length === 0) {
+    return { ok: true, atom: { kind: 'commit', sha, shortSha: sha.slice(0, 7) } };
+  }
+  const diffFiles = await gitShowFiles(sha, projectRoot);
+  if (diffFiles.length === 0) {
+    return {
+      ok: false,
+      reason:
+        `Commit ${sha.slice(0, 7)} touches no files — cannot satisfy implemented gate ` +
+        `for task ${taskId} (expected diff to include at least one of: ${acFiles.slice(0, 5).join(', ')}` +
+        `${acFiles.length > 5 ? '…' : ''})`,
+      codeName: 'E_EVIDENCE_CONTENT_MISMATCH',
+    };
+  }
+  if (!diffIntersectsAc(diffFiles, acFiles)) {
+    return {
+      ok: false,
+      reason:
+        `Commit ${sha.slice(0, 7)} diff does not intersect task ${taskId} AC files. ` +
+        `Diff touched: [${diffFiles.slice(0, 5).join(', ')}${diffFiles.length > 5 ? '…' : ''}]. ` +
+        `AC declared: [${acFiles.slice(0, 5).join(', ')}${acFiles.length > 5 ? '…' : ''}]. ` +
+        `T9245: the commit MUST modify at least one declared AC file.`,
+      codeName: 'E_EVIDENCE_CONTENT_MISMATCH',
+    };
+  }
+  // Pass — caller's outer validateCommit will produce the final atom.
+  return { ok: true, atom: { kind: 'commit', sha, shortSha: sha.slice(0, 7) } };
 }
 
 async function validateFiles(paths: string[], projectRoot: string): Promise<AtomValidation> {
@@ -1097,25 +1294,75 @@ export interface RevalidationResult {
 }
 
 /**
+ * Critical gates for which `override`-only evidence is NEVER accepted. Closes
+ * the override-loophole proven 2026-05-12 — 13 mis-completed tasks in the
+ * 2026-05-11 campaign passed `implemented`/`testsPassed` with override-only
+ * evidence. Audit: `.cleo/rcasd/campaign-validation-2026-05-12/SYNTHESIS.md`.
+ *
+ * Other gates (`qaPassed`, `documented`, `securityPassed`, `cleanupDone`,
+ * `nexusImpact`) MAY still accept `note:` waivers / overrides per ADR-051.
+ *
+ * @task T9245
+ * @adr ADR-051
+ */
+export const CRITICAL_GATES_NO_OVERRIDE: readonly VerificationGate[] = Object.freeze([
+  'implemented',
+  'testsPassed',
+]);
+
+/**
  * Re-validate stored evidence to detect tampering between verify and complete.
  *
  * Hard atoms (commit, files, test-run, tool) are re-executed. Soft atoms
  * (url, note, override) pass through unchanged.
  *
+ * T9245: when `gate` ∈ {@link CRITICAL_GATES_NO_OVERRIDE}, override-only
+ * evidence is rejected at re-validation time. Forces the worker to produce
+ * real programmatic proof for `implemented` and `testsPassed`.
+ *
  * @param evidence - Previously-stored evidence
  * @param projectRoot - Absolute path to project root
+ * @param gate - Optional gate name; when provided enables the critical-gate
+ *   override-rejection check (T9245). Omit for back-compat callers.
  * @returns Revalidation outcome
  *
  * @task T832
+ * @task T9245
  * @adr ADR-051 §5 / §8 (Decision 8)
  */
 export async function revalidateEvidence(
   evidence: GateEvidence,
   projectRoot: string,
+  gate?: VerificationGate,
 ): Promise<RevalidationResult> {
+  // T9245: critical-gate override rejection.
+  // When the gate is `implemented` or `testsPassed`, evidence that has no
+  // non-override hard atom is rejected outright. We define "override-only"
+  // as: evidence.override === true AND every recorded atom is either
+  // `kind: 'override'` or `kind: 'note'` (notes alone are insufficient too).
+  if (gate && CRITICAL_GATES_NO_OVERRIDE.includes(gate)) {
+    const hasHardAtom = evidence.atoms.some(
+      (a) => a.kind !== 'override' && a.kind !== 'note' && a.kind !== 'url',
+    );
+    if (evidence.override === true && !hasHardAtom) {
+      return {
+        stillValid: false,
+        failedAtoms: [
+          {
+            atom: { kind: 'override', reason: evidence.overrideReason ?? 'unspecified' },
+            reason:
+              `T9245: gate '${gate}' rejects override-only evidence. ` +
+              `Critical gates (${CRITICAL_GATES_NO_OVERRIDE.join(', ')}) require a hard atom ` +
+              `(commit/files/test-run/tool). Re-verify with real evidence.`,
+          },
+        ],
+      };
+    }
+  }
+
   if (evidence.override) {
-    // Override evidence is not re-validated — it had no programmatic proof
-    // to begin with.
+    // Override evidence on non-critical gates is not re-validated — it had no
+    // programmatic proof to begin with.
     return { stillValid: true, failedAtoms: [] };
   }
 

--- a/packages/core/src/validation/__tests__/gate-verify-hint.test.ts
+++ b/packages/core/src/validation/__tests__/gate-verify-hint.test.ts
@@ -15,6 +15,8 @@
  * @epic T911
  */
 
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -28,6 +30,30 @@ import { seedTasks } from '../../store/__tests__/test-db-helper.js';
 
 /** Absolute project root for each test — recreated per test. */
 let TEST_ROOT: string;
+
+/**
+ * Real commit SHA produced by initGitRepoWithCommit — used as `commit:` evidence
+ * so writes to critical gates (implemented/testsPassed) pass content-intersect
+ * (T9245) without relying on CLEO_OWNER_OVERRIDE (which T9245 also blocks).
+ */
+let SEED_COMMIT_SHA: string;
+
+/**
+ * Initialise a git repo at TEST_ROOT with a single commit touching the path
+ * declared by the task's AC. The commit SHA is captured in SEED_COMMIT_SHA
+ * and used as evidence in the verify calls below.
+ */
+function initGitRepoWithCommit(taskFile: string): void {
+  const git = (args: string[]): string => execFileSync('git', args, { cwd: TEST_ROOT }).toString();
+  git(['init', '-q']);
+  git(['config', 'user.name', 'gate-verify-hint test']);
+  git(['config', 'user.email', 'hint@example.com']);
+  git(['config', 'commit.gpgsign', 'false']);
+  writeFileSync(join(TEST_ROOT, taskFile), 'seed\n');
+  git(['add', taskFile]);
+  git(['commit', '-q', '-m', 'seed']);
+  SEED_COMMIT_SHA = git(['rev-parse', 'HEAD']).trim();
+}
 
 /**
  * Minimal config that:
@@ -64,10 +90,59 @@ async function seedTask(taskId: string): Promise<void> {
       status: 'active',
       priority: 'medium',
       acceptance: ['AC1'],
+      // T9245: declare an AC file so commit content-intersect can validate.
+      files: ['seed.ts'],
     },
   ]);
   await accessor.close();
   resetDbState();
+}
+
+/**
+ * Path to a synthetic vitest-format test-run JSON written under TEST_ROOT.
+ * Provides hard evidence for the `testsPassed` gate without invoking a real
+ * toolchain.
+ */
+let TEST_RUN_JSON_PATH: string;
+
+/**
+ * Write a synthetic vitest-format JSON file representing a passing test run.
+ * Captured in TEST_RUN_JSON_PATH for use as `test-run:` evidence.
+ */
+function writeTestRunJson(): void {
+  TEST_RUN_JSON_PATH = join(TEST_ROOT, 'test-run.json');
+  writeFileSync(
+    TEST_RUN_JSON_PATH,
+    JSON.stringify({
+      numTotalTests: 1,
+      numPassedTests: 1,
+      numFailedTests: 0,
+      numPendingTests: 0,
+      numTodoTests: 0,
+      testResults: [{ status: 'passed', name: 'seed' }],
+    }),
+  );
+}
+
+/**
+ * Returns the evidence string suitable for the requested critical gate.
+ * - implemented: commit + files (intersects task.files = ['seed.ts'])
+ * - testsPassed: test-run JSON anchored under TEST_ROOT
+ *
+ * Returns undefined for non-critical gates — caller can omit evidence safely.
+ */
+function evidenceFor(gate: string): string | undefined {
+  if (gate === 'implemented') return `commit:${SEED_COMMIT_SHA};files:seed.ts`;
+  if (gate === 'testsPassed') return `test-run:${TEST_RUN_JSON_PATH}`;
+  return undefined;
+}
+
+/**
+ * Build an evidence string for `all:true` (sets every required gate at once).
+ * Combines all hard atoms for implemented + testsPassed in a single payload.
+ */
+function evidenceForAll(): string {
+  return `commit:${SEED_COMMIT_SHA};files:seed.ts;test-run:${TEST_RUN_JSON_PATH}`;
 }
 
 describe('validateGateVerify — hint field (GH #94 / T919)', () => {
@@ -75,14 +150,14 @@ describe('validateGateVerify — hint field (GH #94 / T919)', () => {
     resetDbState();
     TEST_ROOT = await mkdtemp(join(tmpdir(), 'cleo-gate-hint-'));
     await setupTestRoot();
-    // Use CLEO_OWNER_OVERRIDE to bypass evidence validation in unit tests.
-    process.env['CLEO_OWNER_OVERRIDE'] = '1';
-    process.env['CLEO_OWNER_OVERRIDE_REASON'] = 'unit-test';
+    // T9245: real evidence is required for critical gates (implemented/
+    // testsPassed). Initialise a tiny git repo + synthetic test-run JSON so
+    // the verify calls below can supply hard atoms without override.
+    initGitRepoWithCommit('seed.ts');
+    writeTestRunJson();
   });
 
   afterEach(async () => {
-    delete process.env['CLEO_OWNER_OVERRIDE'];
-    delete process.env['CLEO_OWNER_OVERRIDE_REASON'];
     resetDbState();
     await rm(TEST_ROOT, { recursive: true, force: true });
   });
@@ -90,13 +165,19 @@ describe('validateGateVerify — hint field (GH #94 / T919)', () => {
   it('emits hint when setting the final gate drives verification.passed to true', async () => {
     await seedTask('T100');
     // First: set 'implemented'
-    await validateGateVerify(TEST_ROOT, { taskId: 'T100', gate: 'implemented', value: true });
+    await validateGateVerify(TEST_ROOT, {
+      taskId: 'T100',
+      gate: 'implemented',
+      value: true,
+      evidence: evidenceFor('implemented'),
+    });
     resetDbState();
     // Second: set 'testsPassed' — this is the final required gate
     const result = await validateGateVerify(TEST_ROOT, {
       taskId: 'T100',
       gate: 'testsPassed',
       value: true,
+      evidence: evidenceFor('testsPassed'),
     });
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;
@@ -112,6 +193,7 @@ describe('validateGateVerify — hint field (GH #94 / T919)', () => {
       taskId: 'T101',
       gate: 'implemented',
       value: true,
+      evidence: evidenceFor('implemented'),
     });
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;
@@ -132,9 +214,19 @@ describe('validateGateVerify — hint field (GH #94 / T919)', () => {
   it('does NOT emit hint on reset mode', async () => {
     await seedTask('T103');
     // First set all gates green
-    await validateGateVerify({ taskId: 'T103', gate: 'implemented', value: true }, TEST_ROOT);
+    await validateGateVerify(TEST_ROOT, {
+      taskId: 'T103',
+      gate: 'implemented',
+      value: true,
+      evidence: evidenceFor('implemented'),
+    });
     resetDbState();
-    await validateGateVerify(TEST_ROOT, { taskId: 'T103', gate: 'testsPassed', value: true });
+    await validateGateVerify(TEST_ROOT, {
+      taskId: 'T103',
+      gate: 'testsPassed',
+      value: true,
+      evidence: evidenceFor('testsPassed'),
+    });
     resetDbState();
     // Now reset — should not emit hint even though gates were green before
     const result = await validateGateVerify(TEST_ROOT, { taskId: 'T103', reset: true });
@@ -147,8 +239,13 @@ describe('validateGateVerify — hint field (GH #94 / T919)', () => {
 
   it('emits hint when --all is used and all gates become green', async () => {
     await seedTask('T104');
-    // Set all required gates at once via all=true
-    const result = await validateGateVerify(TEST_ROOT, { taskId: 'T104', all: true });
+    // Set all required gates at once via all=true. T9245 requires hard atoms
+    // for implemented + testsPassed; provide both in a single evidence string.
+    const result = await validateGateVerify(TEST_ROOT, {
+      taskId: 'T104',
+      all: true,
+      evidence: evidenceForAll(),
+    });
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;
     expect(data.passed).toBe(true);

--- a/packages/core/src/validation/engine-ops.ts
+++ b/packages/core/src/validation/engine-ops.ts
@@ -443,7 +443,27 @@ export async function validateGateVerify(
       // Parse evidence if provided.
       let validatedAtoms: EvidenceAtom[] = [];
       if (override.override) {
-        // Override — no evidence required.
+        // T9245: critical gates reject override-only evidence at VERIFY time.
+        // Closes the loophole proven 2026-05-12 (13 mis-completed tasks across
+        // the 2026-05-11 campaign passed `implemented`/`testsPassed` with
+        // CLEO_OWNER_OVERRIDE=1 alone). Audit:
+        // `.cleo/rcasd/campaign-validation-2026-05-12/SYNTHESIS.md`.
+        //
+        // Workers can still supply `--evidence` alongside the override (in
+        // which case parsedAtoms below would apply); the rejection only
+        // fires when no `--evidence` was provided.
+        const criticalTargets = targets.filter((g) => g === 'implemented' || g === 'testsPassed');
+        if (criticalTargets.length > 0 && !params.evidence) {
+          return engineError(
+            'E_CRITICAL_GATE_OVERRIDE_REJECTED',
+            `T9245: gate(s) ${criticalTargets.join(', ')} reject CLEO_OWNER_OVERRIDE-only ` +
+              `evidence. Critical gates require a hard atom (commit/files/test-run/tool). ` +
+              `Re-run 'cleo verify ${taskId} --gate ${criticalTargets[0]} --evidence "commit:<sha>;files:<paths>"' ` +
+              `with real evidence. Override may still bypass non-critical gates ` +
+              `(qaPassed, documented, securityPassed, cleanupDone).`,
+          );
+        }
+        // Override — no evidence required for non-critical gates.
         validatedAtoms = [{ kind: 'override', reason: override.reason }];
       } else {
         if (!params.evidence) {


### PR DESCRIPTION
## Summary

P0 hardening that closes the validateCommit content-mismatch loophole proven 2026-05-12. This loophole enabled 13 false-positive task completions across the 2026-05-11 campaign by accepting `commit:<sha>` evidence whose diff touched zero AC-declared files.

- **Content-intersect check** in `validateCommit` (packages/core/src/tasks/evidence.ts): the commit's `git show --name-only` output must intersect the task's `task.files` array (or path tokens parsed from AC strings). Returns `E_EVIDENCE_CONTENT_MISMATCH` on no overlap. Skips gracefully for research/spike tasks, legacy tasks with no declared AC files, and unloadable task contexts (best-effort tolerance).
- **Critical-gate override revocation** in `revalidateEvidence`: `implemented` and `testsPassed` no longer accept override-only evidence. The `CRITICAL_GATES_NO_OVERRIDE` export pins the policy. Non-critical gates (`qaPassed`, `documented`, `securityPassed`, `cleanupDone`, `nexusImpact`) retain ADR-051 waiver behavior.
- **17 new tests** in `evidence-content-intersect.test.ts` lock the fix: extractTaskAcFiles unit coverage, full content-intersect probe reproduction (REJECT/ACCEPT/legacy/research/directory-style), and critical-gate override-rejection invariants.

Audit: `.cleo/rcasd/campaign-validation-2026-05-12/SYNTHESIS.md`
ADRs: ADR-051

## Test plan

- [x] `pnpm biome check packages/core/src/tasks/evidence.ts packages/core/src/tasks/__tests__/evidence-content-intersect.test.ts` — clean
- [x] `pnpm run build` — exit 0 (854s)
- [x] `pnpm run typecheck` — exit 0
- [x] `pnpm --filter @cleocode/core test src/tasks/__tests__/evidence` — 51 passed (17 new + 34 existing)
- [ ] CI green on PR — pending
- [ ] Post-merge: T9245 verified with real commit + tool evidence (no override on `implemented`/`testsPassed`)