### PR TITLE
docs(T9363): plan-doc retro — record as-shipped filenames vs planned

### DIFF
--- a/.cleo/adrs/ADR-072-unified-llm-provider-architecture.md
+++ b/.cleo/adrs/ADR-072-unified-llm-provider-architecture.md
@@ -311,6 +311,10 @@ The following known debts are accepted and tracked:
 
 ## Implementation notes for W0b/W0c
 
+> **RETRO ANNOTATION (T9363 — 2026-05-16)**: The filenames below were the PLANNED names.
+> None of them exist at these paths in the shipped codebase.
+> See §As-Shipped Filename Addendum below for the actual file mapping.
+
 Contract types to add to `packages/contracts/src/llm/`:
 
 ```
@@ -326,6 +330,50 @@ All of the above are pure interface + type files. Zero implementation. The
 implementation lives in `packages/core/src/llm/` (W1-W3).
 
 Re-export through `packages/contracts/src/index.ts`.
+
+---
+
+## As-Shipped Filename Addendum (T9363 · 2026-05-16)
+
+The W0b/W0c implementation drifted from the planned filenames above.
+This section records the canonical as-shipped state for audit purposes.
+
+### packages/contracts/src/llm/ — actual shipped files
+
+| Planned | As-Shipped | Content |
+|---------|-----------|---------|
+| `credential.ts` | `resolved-credential.ts` | `ResolvedCredential` interface — named after the type to distinguish from credential-input shapes |
+| `transport.ts` | `normalized-response.ts` | `LlmTransport` + `NormalizedResponse` + `TransportMessage` + wire types — pre-dates ADR-072 (T9263) |
+| `session.ts` | `interfaces.ts` | `LlmSession` + `LlmExecutor` + `NormalizedDelta` + 10+ co-dependent supporting types |
+| `executor.ts` | `interfaces.ts` | Collapsed into `interfaces.ts` (co-dependent with `LlmSession`) |
+| `normalized-message.ts` | *(not created)* | Message types live as `TransportMessage` in `normalized-response.ts` and `NormalizedDelta` in `interfaces.ts` |
+
+Additional contract files not in the plan (added during Phases 4-5):
+- `provider-id.ts` — `ProviderId` / `ApiMode` / `BuiltinProviderId`
+- `provider-profile.ts` — `ProviderProfile` hooks
+- `failover-reason.ts` — `ClassifiedError` / `FailoverReason`
+- `oauth.ts` — OAuth PKCE types
+- `plugin-llm.ts` — Plugin facade types
+
+### packages/core/src/llm/ — Wave 2 actual shipped files
+
+| Planned | As-Shipped | Task |
+|---------|-----------|------|
+| `default-session.ts` | `concrete-session.ts` | T9287 — class `ConcreteSession` |
+| `default-executor.ts` | `concrete-executor.ts` | T9290 — class `ConcreteExecutor` |
+| *(implicit in executor)* | `session-factory.ts` | T9288 — class `DefaultLlmSessionFactory` |
+| *(implicit in executor)* | `executor-factory.ts` | T9291 — `getLlmExecutor()` singleton |
+
+Naming rationale: "Concrete*" chosen over "Default*" to signal non-abstract implementation
+(not "fallback among options"). Factory responsibilities split into two files per SRP.
+
+### core/src/llm/ — normalized-message-utils.ts
+
+`packages/core/src/llm/normalized-message-utils.ts` was **never created**.
+Message-format conversion is inlined per transport (anthropic.ts, gemini.ts, chat-completions.ts).
+A `message-utils.ts` exists for token-count estimation only (T9289 DRY cleanup).
+
+Full mapping and reasons: `.cleo/rcasd/T9363/specification/plan-doc-retro-spec.md`
 
 ---
 

--- a/.cleo/rcasd/T9363/specification/plan-doc-retro-spec.md
+++ b/.cleo/rcasd/T9363/specification/plan-doc-retro-spec.md
@@ -1,0 +1,227 @@
+# Plan-Doc Retro: Phase 4 Planned vs As-Shipped Filename Mapping
+
+> **Spec ID**: T9363-retro
+> **Task**: T9363
+> **Status**: Specification
+> **Date**: 2026-05-16
+> **Epic**: T9354 (T9261 closure)
+> **ADR**: ADR-072 (see annotation addendum below)
+
+---
+
+## Purpose
+
+This document records the divergence between filenames specified in
+`docs/plans/T-LLM-CRED-CENTRALIZATION.md` Phase 4 (Waves W0b, W0c, W2) and the
+filenames that were actually shipped during the Phase 4 implementation session
+(v2026.5.67–v2026.5.68). All future audit tooling MUST consult this retro
+before flagging "missing" files from the plan.
+
+---
+
+## Mapping: Planned → As-Shipped
+
+### contracts/src/llm/ — W0b Contract Types (T9281)
+
+| Planned Filename | As-Shipped Filename | Disposition |
+|-----------------|---------------------|-------------|
+| `credential.ts` | `resolved-credential.ts` | **Renamed** (see §Reasons) |
+| `transport.ts` | `normalized-response.ts` | **Renamed** (LlmTransport lives here + NormalizedResponse) |
+| `session.ts` | `interfaces.ts` | **Collapsed** into combined interfaces file |
+| `executor.ts` | `interfaces.ts` | **Collapsed** into combined interfaces file |
+| `normalized-message.ts` (W0c) | `interfaces.ts` (inline types) | **Absorbed** — NormalizedMessage-equivalent lives as `TransportMessage` in `normalized-response.ts`; delta types in `interfaces.ts` |
+| *(new)* | `provider-id.ts` | **Added** — ProviderId / ApiMode / BuiltinProviderId union type |
+| *(new)* | `provider-profile.ts` | **Added** — ProviderProfile hooks interface |
+| *(new)* | `failover-reason.ts` | **Added** — ClassifiedError / FailoverReason |
+| *(new)* | `oauth.ts` | **Added** — OAuth PKCE flow types |
+| *(new)* | `plugin-llm.ts` | **Added** — Plugin facade types |
+
+**Summary**: The plan called for 5 separate files (`credential.ts`, `transport.ts`,
+`session.ts`, `executor.ts`, `normalized-message.ts`). The implementation produced
+3 core files (`resolved-credential.ts`, `normalized-response.ts`, `interfaces.ts`)
+plus 5 additional files that were not in the plan.
+
+### core/src/llm/ — W2 Session + Executor (T9284 plan → T9287/T9288/T9290/T9291 actual)
+
+| Planned Filename | As-Shipped Filename | Task | Disposition |
+|-----------------|---------------------|------|-------------|
+| `default-session.ts` | `concrete-session.ts` | T9287 | **Renamed** (see §Reasons) |
+| `default-executor.ts` | `concrete-executor.ts` | T9290 | **Renamed** (see §Reasons) |
+| *(implicit singleton)* | `executor-factory.ts` | T9291 | **Split out** — singleton + factory extracted to own file |
+| *(implicit)* | `session-factory.ts` | T9288 | **Split out** — `LlmSessionFactory` implementation extracted |
+
+### core/src/llm/ — W0c NormalizedMessage helper (T9282 plan)
+
+| Planned Filename | As-Shipped Disposition |
+|-----------------|------------------------|
+| `normalized-message-utils.ts` (new) | **Never created** — conversion helpers were inlined into the individual transport files (`anthropic.ts`, `gemini.ts`, `chat-completions.ts`) rather than centralized. A `message-utils.ts` was later created for token-count estimation only (T9289/DRY cleanup) and does NOT perform message format conversion. |
+
+### Phase 1 — contracts/src/llm/ (pre-W0b)
+
+| Planned Filename | As-Shipped Filename | Context |
+|-----------------|---------------------|---------|
+| `packages/contracts/src/llm/credential.ts` (Phase 1 plan) | `packages/contracts/src/llm/resolved-credential.ts` | The Phase 1 plan specified `credential.ts` to hold `ResolvedCredential`. This file was **never created with that name**. When W0b (T9281) created the type, the implementer chose `resolved-credential.ts` to be unambiguous (the file holds the *resolved* credential, not a credential input). |
+
+---
+
+## Reasons for Divergence
+
+All divergences occurred during the same Phase 4 implementation session
+(2026-05-14 to 2026-05-15). No explicit decision record was filed at the time.
+The rationale is reconstructed from commit messages:
+
+### 1. `credential.ts` → `resolved-credential.ts`
+
+The plan file `T-LLM-CRED-CENTRALIZATION.md` §Phase 1 described the file as
+holding the `ResolvedCredential` type. The implementer named the file
+`resolved-credential.ts` (matching the type name) to avoid ambiguity with any
+potential future `credential.ts` that might hold credential *input* shapes
+(e.g., `CredentialInput`, `StoredCredential`). The distinction is intentional:
+`resolved-credential.ts` clearly signals "output of the resolution chain."
+
+Commit: `428414a85` (T9281)
+
+### 2. `transport.ts` → `normalized-response.ts` (and pre-dates W0b)
+
+`LlmTransport` was defined in `normalized-response.ts` before W0b, as part
+of T9263 (Phase 3 port of Hermes `agent/transports/types.py`). The T9263
+implementer placed `LlmTransport` alongside `NormalizedResponse` in a single
+file because the two types are tightly coupled at the wire level. By the time
+W0b ran, moving `LlmTransport` to a separate `transport.ts` would have required
+breaking all T9263 consumers. The implementer kept the established filename.
+
+Commit: `9faf9f36d` (T9263, pre-ADR-072)
+
+### 3. `session.ts` + `executor.ts` → `interfaces.ts`
+
+The W0b implementer (T9281) chose a single `interfaces.ts` because:
+- `LlmSession` and `LlmExecutor` are co-dependent (the executor holds a session
+  factory; the session requires the transport from the executor context). Splitting
+  into two files would create cross-imports immediately.
+- The single file makes it trivial to import the full three-interface stack with
+  one path: `import { LlmSession, LlmExecutor } from '@cleocode/contracts/llm/interfaces.js'`.
+- Following the Hermes `agent/transports/types.py` precedent of keeping related
+  interfaces in one module.
+
+Commit: `428414a85` (T9281)
+
+### 4. `normalized-message.ts` + `normalized-message-utils.ts` — never created
+
+The W0c plan called for a standalone `normalized-message.ts` in contracts and
+a `normalized-message-utils.ts` in core. Neither was created because:
+
+- The `NormalizedMessage` concept from the plan was implemented as two distinct
+  types during implementation: `TransportMessage` (the wire-level message in
+  `normalized-response.ts`) and `NormalizedDelta` (the streaming delta in
+  `interfaces.ts`). These reflect a deliberate design split between the
+  non-streaming request message format and the streaming response delta format.
+- The conversion utilities (Anthropic → normalized, OpenAI → normalized, etc.)
+  were inlined into each transport file's `complete()` and `stream()` methods
+  because they require provider-specific knowledge that makes centralization
+  awkward. A central `normalized-message-utils.ts` would have needed to import
+  from provider-specific SDK types, violating the transport isolation principle.
+- W0c (commit `8cdf10f79`) focused on extending `LlmTransport` with `stream()` +
+  `apiMode` rather than adding conversion utilities. The utilities were considered
+  an implementation detail of each transport, not a shared contract.
+
+**This planned file is officially superseded.** The conversion logic lives inline
+in each transport implementation (anthropic.ts, gemini.ts, openai.ts, chat-completions.ts).
+
+### 5. `default-session.ts` → `concrete-session.ts` and `default-executor.ts` → `concrete-executor.ts`
+
+The plan used `DefaultLlmSession` / `DefaultLlmExecutor` following the Java/Gang-of-Four
+"Default*" convention for concrete implementations of interfaces. The implementer
+chose `Concrete*` names for two reasons visible in the commit messages:
+- "Default" implies "one of many, used when no other is specified" — but the intent
+  is that these ARE the only concrete implementations (not a fallback among options).
+- "Concrete" is the DDD / hexagonal-architecture naming convention that more clearly
+  signals "this is the non-abstract thing that implements the interface."
+- The class names in the files are `ConcreteSession` and `ConcreteExecutor`
+  (not `DefaultLlmSession` / `DefaultLlmExecutor`), so the filenames match the class names.
+
+Commits: `89313ea0c` (T9287 ConcreteSession), `df370d2b7` (T9290 ConcreteExecutor)
+
+### 6. `executor-factory.ts` and `session-factory.ts` — split from planned monolith
+
+The plan described `DefaultLlmExecutor` as a "singleton factory" in a single file.
+The implementer split this into:
+- `session-factory.ts` — `DefaultLlmSessionFactory` implementing `LlmSessionFactory`
+  (T9288, W2b) — bridges `resolveLLMForRole` to `ConcreteSession` via transport routing.
+- `executor-factory.ts` — `getLlmExecutor` singleton + `ExecutorFactory` (T9291, W3b) —
+  per-process singleton with optional `ContextEngine` wiring.
+
+This split follows SRP: the session factory handles per-role transport routing; the
+executor factory handles the singleton lifecycle and context-engine wiring. The plan
+lumped these into one file for simplicity; the implementation recognized they have
+different change reasons.
+
+---
+
+## Impact on ADR-072
+
+ADR-072 §Implementation notes for W0b lists:
+
+```
+packages/contracts/src/llm/
+  transport.ts
+  session.ts
+  executor.ts
+  normalized-message.ts
+  index.ts
+```
+
+**None of these filenames exist as written.** The ADR-072 section contains the PLANNED
+names. The as-shipped names are:
+
+```
+packages/contracts/src/llm/
+  normalized-response.ts    (contains LlmTransport + NormalizedResponse + TransportMessage etc.)
+  interfaces.ts             (contains LlmSession + LlmExecutor + NormalizedDelta etc.)
+  resolved-credential.ts    (contains ResolvedCredential)
+  provider-id.ts            (contains ProviderId / ApiMode / BuiltinProviderId)
+  provider-profile.ts       (contains ProviderProfile)
+  failover-reason.ts        (contains ClassifiedError)
+  oauth.ts                  (OAuth PKCE types)
+  plugin-llm.ts             (plugin facade types)
+```
+
+ADR-072 §Migration strategy references "W0b/W0c" in terms of CONCEPTS (add contract types,
+add W0c extensions). The CONCEPTUAL description remains accurate; only the filenames
+listed in §Implementation notes are stale.
+
+An annotation addendum is appended to ADR-072 as part of this task (see plan-doc edits).
+
+---
+
+## Acceptance Criteria Verification
+
+| AC | Criterion | Status |
+|----|-----------|--------|
+| AC1 | Plan doc Phase 4 W0b/W0c/W2 sections annotated with 'as-shipped' filenames | DONE — see plan-doc edits |
+| AC2 | credential.ts -> resolved-credential.ts mapping documented | DONE — §Mapping above + plan doc annotation |
+| AC3 | transport.ts/session.ts/executor.ts -> interfaces.ts + normalized-response.ts mapping documented | DONE — §Mapping above |
+| AC4 | default-session.ts/default-executor.ts -> concrete-session.ts/concrete-executor.ts/executor-factory.ts mapping documented | DONE — §Mapping above |
+| AC5 | normalized-message-utils.ts marked as superseded by inline conversion in transports | DONE — §Reasons #4 above |
+| AC6 | Reason for divergence captured (decision drift during Phase 4 implementation) | DONE — §Reasons above |
+
+---
+
+## File Checklist: All Referenced Filenames
+
+| Filename | Exists? | Note |
+|----------|---------|------|
+| `packages/contracts/src/llm/credential.ts` | NO | Superseded by `resolved-credential.ts` |
+| `packages/contracts/src/llm/transport.ts` | NO | Superseded by `normalized-response.ts` |
+| `packages/contracts/src/llm/session.ts` | NO | Superseded by `interfaces.ts` |
+| `packages/contracts/src/llm/executor.ts` | NO | Superseded by `interfaces.ts` |
+| `packages/contracts/src/llm/normalized-message.ts` | NO | Superseded by `TransportMessage` in `normalized-response.ts` + inline types |
+| `packages/core/src/llm/normalized-message-utils.ts` | NO | Never created; conversion inlined per transport |
+| `packages/core/src/llm/default-session.ts` | NO | Superseded by `concrete-session.ts` |
+| `packages/core/src/llm/default-executor.ts` | NO | Superseded by `concrete-executor.ts` |
+| `packages/contracts/src/llm/resolved-credential.ts` | YES | As-shipped credential contract |
+| `packages/contracts/src/llm/normalized-response.ts` | YES | As-shipped transport contract |
+| `packages/contracts/src/llm/interfaces.ts` | YES | As-shipped session/executor contract |
+| `packages/core/src/llm/concrete-session.ts` | YES | As-shipped session implementation |
+| `packages/core/src/llm/concrete-executor.ts` | YES | As-shipped executor implementation |
+| `packages/core/src/llm/session-factory.ts` | YES | As-shipped session factory |
+| `packages/core/src/llm/executor-factory.ts` | YES | As-shipped executor factory/singleton |

--- a/docs/plans/T-LLM-CRED-CENTRALIZATION.md
+++ b/docs/plans/T-LLM-CRED-CENTRALIZATION.md
@@ -45,6 +45,15 @@ Goal: every LLM call in `@cleocode/core` goes through one resolver returning a t
    ```
    Re-export through `packages/contracts/src/index.ts`.
 
+   > **AS-SHIPPED (T9363 retro — 2026-05-16)**: `packages/contracts/src/llm/credential.ts` was
+   > **never created**. The `ResolvedCredential` type was created in W0b (T9281) as
+   > `packages/contracts/src/llm/resolved-credential.ts` to be unambiguous about the type's role
+   > as the OUTPUT of the resolution chain (not a credential input shape). The `AuthType` values
+   > shipped as defined here. `CredentialSource` was not included in the final type (credential
+   > source tracking is handled internally by the resolver, not exposed on `ResolvedCredential`).
+   > The shipped interface has `expiresAt`, `refreshToken`, `awsProfile`, and `baseUrl` fields
+   > that were refined from this plan.
+
 2. **`packages/core/src/llm/credentials.ts` (edit ~50 LOC)** — add a sibling resolver and a header builder:
    ```ts
    export function resolveCredential(
@@ -336,7 +345,7 @@ No code changes. Gates W0b/W0c from starting.
 
 **Goal**: Add the three interface files to `packages/contracts/src/llm/`. Zero implementation.
 
-**Files to create**:
+**Files to create** (planned):
 ```
 packages/contracts/src/llm/normalized-message.ts   — NormalizedMessage, ToolCall, NormalizedRole
 packages/contracts/src/llm/transport.ts            — LlmTransport, TransportRequestPayload, TransportChunk, NormalizedResponse, PingResult
@@ -344,6 +353,19 @@ packages/contracts/src/llm/session.ts              — LlmSession, SessionChunk,
 packages/contracts/src/llm/executor.ts             — LlmExecutor, ExecutorOptions, ExecutorChunk, SessionOptions
 packages/contracts/src/llm/index.ts                — re-exports all four above
 ```
+
+> **AS-SHIPPED (T9363 retro — 2026-05-16)**: None of the planned filenames above were created.
+> The implementation (T9281 + T9263 + T9282) produced a different but equivalent file set:
+> - `normalized-response.ts` — holds `LlmTransport` + `NormalizedResponse` + `TransportMessage` + related wire types (pre-ADR-072, T9263)
+> - `interfaces.ts` — holds `LlmSession` + `LlmExecutor` + `NormalizedDelta` + 10+ supporting types (T9281)
+> - `resolved-credential.ts` — holds `ResolvedCredential` (was planned as `credential.ts` in Phase 1; named after the type for clarity)
+> - `provider-id.ts` — holds `ProviderId` / `ApiMode` / `BuiltinProviderId` (not in original plan, added T9281)
+> - `provider-profile.ts` — holds `ProviderProfile` hooks (not in original plan, added via Phase 3 port)
+> - `failover-reason.ts`, `oauth.ts`, `plugin-llm.ts` — additional types added in Phase 5
+>
+> Reason for divergence: `LlmTransport` was established in `normalized-response.ts` by T9263 (pre-ADR-072).
+> When W0b ran, moving it would have broken existing consumers. `LlmSession`/`LlmExecutor` were collapsed
+> into a single `interfaces.ts` because they are co-dependent and share supporting types (see T9363 spec).
 
 **Files to edit**:
 - `packages/contracts/src/index.ts` — add `export * from './llm/index.js'`
@@ -361,9 +383,17 @@ packages/contracts/src/llm/index.ts                — re-exports all four above
 **Goal**: Add a `toNormalizedMessage(anthropicMsg)` conversion utility and update
 `packages/core/src/llm/` to use `NormalizedMessage` internally (no call-site changes yet).
 
-**Files to create/edit**:
+**Files to create/edit** (planned):
 - `packages/core/src/llm/normalized-message-utils.ts` *(new)* — conversion helpers
 - `packages/core/src/llm/__tests__/normalized-message.test.ts` *(new)* — 6+ unit tests
+
+> **AS-SHIPPED (T9363 retro — 2026-05-16)**: `normalized-message-utils.ts` was **never created**.
+> The W0c commit (T9282, `8cdf10f79`) focused on extending `LlmTransport` with `stream()` + `apiMode`
+> and adding `ProviderProfile` hooks — not adding a conversion helper. Message-format conversion was
+> inlined into each transport's `complete()` / `stream()` methods (anthropic.ts, gemini.ts,
+> chat-completions.ts) because conversion requires provider-specific SDK types. A `message-utils.ts`
+> was later extracted (T9289 DRY cleanup) for token-count estimation only, not message conversion.
+> **This planned file is superseded. Do not create it.**
 
 **Acceptance gates**:
 - Conversion helper covers Anthropic, OpenAI-compat, and Bedrock message formats.
@@ -406,12 +436,30 @@ packages/core/src/llm/__tests__/transports/             — unit tests (mock HTT
 
 **Goal**: Implement `DefaultLlmSession` and `DefaultLlmExecutor`. Wire to Phase 3 credential pool.
 
-**Files to create**:
+**Files to create** (planned):
 ```
 packages/core/src/llm/default-session.ts     — DefaultLlmSession
 packages/core/src/llm/default-executor.ts    — DefaultLlmExecutor (singleton factory)
 packages/core/src/llm/__tests__/executor/    — integration tests with mock transports
 ```
+
+> **AS-SHIPPED (T9363 retro — 2026-05-16)**: `default-session.ts` and `default-executor.ts` were
+> never created. The Wave 2 implementation was split across 4 tasks (T9287–T9291) and produced:
+> - `concrete-session.ts` (T9287 W2a) — implements `LlmSession` as `ConcreteSession`
+> - `session-factory.ts` (T9288 W2b) — implements `LlmSessionFactory` as `DefaultLlmSessionFactory`;
+>   bridges `resolveLLMForRole` → transport routing → `ConcreteSession`
+> - `concrete-executor.ts` (T9290 W3a) — implements `LlmExecutor` as `ConcreteExecutor`
+> - `executor-factory.ts` (T9291 W3b) — provides `getLlmExecutor()` singleton + `ExecutorFactory`
+>
+> Naming change: "Default*" → "Concrete*" because "Concrete" more clearly signals
+> "non-abstract implementation of an interface" vs "default fallback." The class name
+> and filename match (class `ConcreteSession` lives in `concrete-session.ts`).
+>
+> Split rationale: Session factory and executor factory have distinct responsibilities
+> (transport routing vs singleton lifecycle), so SRP favored two files over one.
+>
+> The singleton pattern (`getLlmExecutor()`) was preserved from the plan; it lives in
+> `executor-factory.ts` not the executor itself.
 
 **Key implementation notes**:
 - `DefaultLlmExecutor` is a singleton. `getLlmExecutor()` returns the shared instance.


### PR DESCRIPTION
Closes T9363 (Task in T9354 closure epic). See manifest entries for evidence.