### PR TITLE
release: ship v2026.5.75 (T1892 + T9393 cliOutput envelope-meta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2026.5.75] (2026-05-16)
+
+Auto-prepared by release.ship (T1892)
+
+### Bug Fixes
+- **P0 BUG: validateCommit content-mismatch loophole — verifier accepts commits not touching AC files**: Probe proved validateCommit at evidence.ts:427 checks only commit SHA reachability — never intersects diff with AC-listed files. Campaign 2026-05-1... (T9245)
+
+### Chores
+- **S-B1: Audit + remove buildAnthropicSdkClient callers**: Find every caller of buildAnthropicSdkClient via grep. The function is exported in llm/index.ts but has NO external callers outside registry.ts and... (T9369)
+- **S-B2: Remove clientForModelConfig + per-provider client caches**: Remove clientForModelConfig and per-provider caches from registry.ts. Two callers: (1) packages/core/src/llm/runtime.ts:103 in planAttempt() - migr... (T9370)
+
+### Changes
+- S-A1: Write OllamaTransport with complete + stream methods (T9365)
+- S-A2: Register ollama provider profile in builtin registry (T9366)
+- S-A3: Wire ollama into transports/index.ts + session-factory.ts (T9367)
+- S-B3: Final grep verification + full test suite green (T9371)
+- S-A4: Unit tests + REAL-WORLD ollama serve smoke (T9368)
+- **T9344: Hotfix Anthropic OAuth — drop false placeholder framing + fix redirectUri**: T9326 (shipped v2026.5.73) labeled the canonical public Anthropic PKCE client_id 9d1c250a-e61b-44d9-88ed-5944d1962f5e as a 'placeholder' and added ... (T9344)
+---
 ## [2026.5.74] (2026-05-16)
 
 Auto-prepared by release.ship (T9261)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "conduit-core",
  "nom",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "cant-core",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "serde",
  "serde_json",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "cant-core",
  "serde",
@@ -394,7 +394,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-llm-native"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "lafs-core",
  "serde",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-core"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "chrono",
  "conduit-core",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-payments"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-protocol"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "cant-core",
  "chrono",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-sdk"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-storage"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-transport"
-version = "2026.5.74"
+version = "2026.5.75"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.74"
+version = "2026.5.75"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/cleo/src/cli/commands/nexus.ts
+++ b/packages/cleo/src/cli/commands/nexus.ts
@@ -20,6 +20,10 @@ import path from 'node:path';
 import { generateGexf, getSymbolImpact } from '@cleocode/core/nexus';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli, dispatchRaw } from '../../dispatch/adapters/cli.js';
+import {
+  buildNexusMetaExtensions,
+  pickDecoratorMetaExtensions,
+} from '../../dispatch/nexus-decorator.js';
 import { getFormatContext, setFormatContext } from '../format-context.js';
 import { cliError, cliOutput, humanInfo, humanWarn } from '../renderers/index.js';
 
@@ -180,7 +184,10 @@ const statusCommand = defineCommand({
         {
           command: 'nexus-status',
           operation: 'nexus.status',
-          extensions: { duration_ms: durationMs },
+          extensions: {
+            duration_ms: durationMs,
+            ...buildNexusMetaExtensions('status', { projectId, path: repoPath }),
+          },
         },
       );
     } catch (err) {
@@ -910,7 +917,10 @@ const impactCommand = defineCommand({
       cliOutput({ ...result, _symbolName: symbolName, _why: whyFlag } as Record<string, unknown>, {
         command: 'nexus-impact',
         operation: 'nexus.impact',
-        extensions: { duration_ms: durationMs },
+        extensions: {
+          duration_ms: durationMs,
+          ...buildNexusMetaExtensions('impact', { symbol: symbolName, projectId }),
+        },
       });
     } catch (err) {
       const code =

--- a/packages/cleo/src/cli/commands/nexus.ts
+++ b/packages/cleo/src/cli/commands/nexus.ts
@@ -20,10 +20,7 @@ import path from 'node:path';
 import { generateGexf, getSymbolImpact } from '@cleocode/core/nexus';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli, dispatchRaw } from '../../dispatch/adapters/cli.js';
-import {
-  buildNexusMetaExtensions,
-  pickDecoratorMetaExtensions,
-} from '../../dispatch/nexus-decorator.js';
+import { buildNexusMetaExtensions } from '../../dispatch/nexus-decorator.js';
 import { getFormatContext, setFormatContext } from '../format-context.js';
 import { cliError, cliOutput, humanInfo, humanWarn } from '../renderers/index.js';
 
@@ -764,6 +761,7 @@ const clustersCommand = defineCommand({
       command: 'nexus-clusters',
       operation: 'nexus.clusters',
       extensions: { duration_ms: durationMs },
+      responseMeta: response.meta as unknown as Record<string, unknown>,
     });
   },
 });
@@ -809,6 +807,7 @@ const flowsCommand = defineCommand({
       command: 'nexus-flows',
       operation: 'nexus.flows',
       extensions: { duration_ms: durationMs },
+      responseMeta: response.meta as unknown as Record<string, unknown>,
     });
   },
 });
@@ -875,6 +874,7 @@ const contextCommand = defineCommand({
       command: 'nexus-context',
       operation: 'nexus.context',
       extensions: { duration_ms: durationMs },
+      responseMeta: response.meta as unknown as Record<string, unknown>,
     });
   },
 });
@@ -1154,6 +1154,7 @@ const projectsListCommand = defineCommand({
       command: 'nexus-projects-list',
       operation: 'nexus.projects.list',
       extensions: { duration_ms: durationMs },
+      responseMeta: response.meta as unknown as Record<string, unknown>,
     });
   },
 });
@@ -1205,6 +1206,7 @@ const projectsRegisterCommand = defineCommand({
       command: 'nexus-projects-register',
       operation: 'nexus.projects.register',
       extensions: { duration_ms: durationMs },
+      responseMeta: response.meta as unknown as Record<string, unknown>,
     });
   },
 });
@@ -1250,6 +1252,7 @@ const projectsRemoveCommand = defineCommand({
         command: 'nexus-projects-remove',
         operation: 'nexus.projects.remove',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -1318,6 +1321,7 @@ const projectsScanCommand = defineCommand({
         command: 'nexus-projects-scan',
         operation: 'nexus.projects.scan',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -1421,7 +1425,11 @@ const projectsCleanCommand = defineCommand({
       if (ctx.format !== 'json') {
         cliOutput(
           { matched: matchCount, totalCount, sample: samplePaths },
-          { command: 'nexus-projects-clean-preview', operation: 'nexus.projects.clean' },
+          {
+            command: 'nexus-projects-clean-preview',
+            operation: 'nexus.projects.clean',
+            responseMeta: previewResp.meta as unknown as Record<string, unknown>,
+          },
         );
       }
 
@@ -1439,6 +1447,7 @@ const projectsCleanCommand = defineCommand({
             command: 'nexus-projects-clean',
             operation: 'nexus.projects.clean',
             extensions: { duration_ms: durationMs },
+            responseMeta: previewResp.meta as unknown as Record<string, unknown>,
           },
         );
         return;
@@ -1509,6 +1518,7 @@ const projectsCleanCommand = defineCommand({
           command: 'nexus-projects-clean',
           operation: 'nexus.projects.clean',
           extensions: { duration_ms: durationMs },
+          responseMeta: deleteResp.meta as unknown as Record<string, unknown>,
         },
       );
     } catch (err) {
@@ -1586,6 +1596,7 @@ const refreshBridgeCommand = defineCommand({
       command: 'nexus-refresh-bridge',
       operation: 'nexus.refresh-bridge',
       extensions: { duration_ms: durationMs },
+      responseMeta: response.meta as unknown as Record<string, unknown>,
     });
   },
 });
@@ -1778,6 +1789,7 @@ const diffCommand = defineCommand({
       command: 'nexus-diff',
       operation: 'nexus.diff',
       extensions: { duration_ms: durationMs },
+      responseMeta: response.meta as unknown as Record<string, unknown>,
     });
   },
 });
@@ -1862,6 +1874,7 @@ const queryCommand = defineCommand({
         command: 'nexus-query',
         operation: 'nexus.query-cte',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -1915,6 +1928,7 @@ const routeMapCommand = defineCommand({
         command: 'nexus-route-map',
         operation: 'nexus.route-map',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -1974,6 +1988,7 @@ const shapeCheckCommand = defineCommand({
         command: 'nexus-shape-check',
         operation: 'nexus.shape-check',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -2030,6 +2045,7 @@ const fullContextCommand = defineCommand({
         command: 'nexus-full-context',
         operation: 'nexus.full-context',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -2075,6 +2091,7 @@ const taskFootprintCommand = defineCommand({
         command: 'nexus-task-footprint',
         operation: 'nexus.task-footprint',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -2120,6 +2137,7 @@ const brainAnchorsCommand = defineCommand({
         command: 'nexus-brain-anchors',
         operation: 'nexus.brain-anchors',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -2165,7 +2183,12 @@ const whyCommand = defineCommand({
     const durationMs = Date.now() - startTime;
     cliOutput(
       { ...((response.data as Record<string, unknown>) ?? {}), _durationMs: durationMs },
-      { command: 'nexus-why', operation: 'nexus.why', extensions: { duration_ms: durationMs } },
+      {
+        command: 'nexus-why',
+        operation: 'nexus.why',
+        extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
+      },
     );
   },
 });
@@ -2210,6 +2233,7 @@ const impactFullCommand = defineCommand({
         command: 'nexus-impact-full',
         operation: 'nexus.impact-full',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -2262,6 +2286,7 @@ const conduitScanCommand = defineCommand({
         command: 'nexus-conduit-scan',
         operation: 'nexus.conduit-scan',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -2323,6 +2348,7 @@ const taskSymbolsCommand = defineCommand({
         command: 'nexus-task-symbols',
         operation: 'nexus.task-symbols',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -2440,6 +2466,7 @@ const contractsSyncCommand = defineCommand({
         command: 'nexus-contracts-sync',
         operation: 'nexus.contracts.sync',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -2496,6 +2523,7 @@ const contractsShowCommand = defineCommand({
         command: 'nexus-contracts-show',
         operation: 'nexus.contracts.show',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -2545,6 +2573,7 @@ const contractsLinkTasksCommand = defineCommand({
         command: 'nexus-contracts-link-tasks',
         operation: 'nexus.contracts.link-tasks',
         extensions: { duration_ms: durationMs },
+        responseMeta: response.meta as unknown as Record<string, unknown>,
       },
     );
   },
@@ -2738,6 +2767,7 @@ const hotPathsCommand = defineCommand({
       command: 'nexus-hot-paths',
       operation: 'nexus.hot-paths',
       extensions: { duration_ms: durationMs },
+      responseMeta: response.meta as unknown as Record<string, unknown>,
     });
   },
 });
@@ -2789,6 +2819,7 @@ const hotNodesCommand = defineCommand({
       command: 'nexus-hot-nodes',
       operation: 'nexus.hot-nodes',
       extensions: { duration_ms: durationMs },
+      responseMeta: response.meta as unknown as Record<string, unknown>,
     });
   },
 });
@@ -2841,6 +2872,7 @@ const coldSymbolsCommand = defineCommand({
       command: 'nexus-cold-symbols',
       operation: 'nexus.cold-symbols',
       extensions: { duration_ms: durationMs },
+      responseMeta: response.meta as unknown as Record<string, unknown>,
     });
   },
 });

--- a/packages/cleo/src/cli/renderers/__tests__/cli-output-response-meta.test.ts
+++ b/packages/cleo/src/cli/renderers/__tests__/cli-output-response-meta.test.ts
@@ -1,0 +1,191 @@
+/**
+ * T9393 regression test — cliOutput must propagate decorator-stamped meta
+ * fields from `responseMeta` into the emitted LAFS envelope.
+ *
+ * Covers the defect chain that left `_nexus` and `deprecated` out of every
+ * `cleo nexus <op> --json` envelope despite the dispatch decorator stamping
+ * them on `response.meta`:
+ *
+ *   1. `formatSuccess` must merge `opts.extensions` into the envelope `meta`
+ *      (the field had been dead since T4670).
+ *   2. `cliOutput` must accept `responseMeta` and forward the decorator-only
+ *      subset (`_nexus`, `deprecated`) via the extensions channel.
+ *
+ * Asserts T9393 acceptance criterion 6 ("integration test asserts
+ * decorator-added meta keys appear in final CLI envelope").
+ *
+ * @task T9393
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setFormatContext } from '../../format-context.js';
+import { cliOutput } from '../index.js';
+
+// Set JSON format so cliOutput exercises the formatSuccess → stdout path.
+beforeEach(() => {
+  setFormatContext({ format: 'json', source: 'flag', quiet: false });
+});
+
+afterEach(() => {
+  setFormatContext({ format: 'json', source: 'default', quiet: false });
+  vi.restoreAllMocks();
+});
+
+function captureEnvelope(run: () => void): Record<string, unknown> {
+  let captured = '';
+  const orig = process.stdout.write.bind(process.stdout);
+  const spy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: string | Uint8Array): boolean => {
+      captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+      return true;
+    });
+  try {
+    run();
+  } finally {
+    spy.mockRestore();
+    // Re-bind to avoid leaking the mock to other tests
+    void orig;
+  }
+  // First newline-delimited record is the envelope; downstream LAFS validator
+  // messages (if any) come on subsequent lines.
+  const line = captured.split('\n').filter((l) => l.trim().length > 0)[0] ?? '{}';
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+describe('cliOutput — responseMeta decorator passthrough (T9393)', () => {
+  it('propagates response.meta._nexus into envelope.meta._nexus', () => {
+    const stampedNexus = {
+      scope: 'project',
+      effect: 'read',
+      projectId: 'proj-abc',
+      bindingSource: 'arg-project-id',
+      canonicalCommand: 'cleo nexus status',
+    };
+
+    const env = captureEnvelope(() => {
+      cliOutput(
+        { indexed: true, nodeCount: 42 },
+        {
+          command: 'nexus-status',
+          operation: 'nexus.status',
+          responseMeta: { _nexus: stampedNexus } as Record<string, unknown>,
+        },
+      );
+    });
+
+    expect(env['success']).toBe(true);
+    const meta = env['meta'] as Record<string, unknown>;
+    expect(meta).toBeDefined();
+    expect(meta['_nexus']).toEqual(stampedNexus);
+    // Canonical fields are still produced fresh by createCliMeta
+    expect(meta['operation']).toBe('nexus.status');
+    expect(typeof meta['requestId']).toBe('string');
+    expect(typeof meta['timestamp']).toBe('string');
+  });
+
+  it('propagates response.meta.deprecated into envelope.meta.deprecated', () => {
+    const deprecated = {
+      since: 'v2026.6.5',
+      removeIn: 'v2026.8.0',
+      replacement: 'cleo graph context',
+    };
+
+    const env = captureEnvelope(() => {
+      cliOutput(
+        { results: [], matchCount: 0 },
+        {
+          command: 'nexus-context',
+          operation: 'nexus.context',
+          responseMeta: { deprecated } as Record<string, unknown>,
+        },
+      );
+    });
+
+    const meta = env['meta'] as Record<string, unknown>;
+    expect(meta['deprecated']).toEqual(deprecated);
+  });
+
+  it('does NOT forward non-decorator meta fields (operation/requestId/timestamp from dispatcher)', () => {
+    const env = captureEnvelope(() => {
+      cliOutput(
+        { ok: true },
+        {
+          command: 'nexus-status',
+          operation: 'nexus.status',
+          responseMeta: {
+            // canonical CLI fields the dispatcher also tracks — these must NOT
+            // leak into the envelope (createCliMeta owns them).
+            operation: 'should-not-override',
+            requestId: 'should-not-override',
+            timestamp: 'should-not-override',
+            gateway: 'query',
+            domain: 'nexus',
+            source: 'cli',
+            // decorator-only fields — these MUST flow through.
+            _nexus: { scope: 'project', effect: 'read' },
+          } as Record<string, unknown>,
+        },
+      );
+    });
+
+    const meta = env['meta'] as Record<string, unknown>;
+    expect(meta['operation']).toBe('nexus.status');
+    expect(meta['requestId']).not.toBe('should-not-override');
+    expect(meta['timestamp']).not.toBe('should-not-override');
+    // Non-decorator dispatcher fields are deliberately dropped to keep the
+    // envelope minimal.
+    expect(meta['gateway']).toBeUndefined();
+    expect(meta['domain']).toBeUndefined();
+    expect(meta['source']).toBeUndefined();
+    // Decorator field still propagates.
+    expect(meta['_nexus']).toEqual({ scope: 'project', effect: 'read' });
+  });
+
+  it('propagates duration_ms from extensions (createCliMeta default would be 0)', () => {
+    const env = captureEnvelope(() => {
+      cliOutput(
+        { ok: true },
+        {
+          command: 'nexus-status',
+          operation: 'nexus.status',
+          extensions: { duration_ms: 1234 },
+        },
+      );
+    });
+
+    const meta = env['meta'] as Record<string, unknown>;
+    expect(meta['duration_ms']).toBe(1234);
+  });
+
+  it('handles missing responseMeta gracefully (no decorator fields)', () => {
+    const env = captureEnvelope(() => {
+      cliOutput(
+        { ok: true },
+        { command: 'nexus-status', operation: 'nexus.status' },
+      );
+    });
+
+    const meta = env['meta'] as Record<string, unknown>;
+    expect(meta['_nexus']).toBeUndefined();
+    expect(meta['deprecated']).toBeUndefined();
+    expect(meta['operation']).toBe('nexus.status');
+  });
+
+  it('explicit extensions override responseMeta when keys collide', () => {
+    const env = captureEnvelope(() => {
+      cliOutput(
+        { ok: true },
+        {
+          command: 'nexus-status',
+          operation: 'nexus.status',
+          extensions: { _nexus: { from: 'extensions' } },
+          responseMeta: { _nexus: { from: 'responseMeta' } } as Record<string, unknown>,
+        },
+      );
+    });
+
+    const meta = env['meta'] as Record<string, unknown>;
+    expect(meta['_nexus']).toEqual({ from: 'extensions' });
+  });
+});

--- a/packages/cleo/src/cli/renderers/__tests__/cli-output-response-meta.test.ts
+++ b/packages/cleo/src/cli/renderers/__tests__/cli-output-response-meta.test.ts
@@ -160,10 +160,7 @@ describe('cliOutput — responseMeta decorator passthrough (T9393)', () => {
 
   it('handles missing responseMeta gracefully (no decorator fields)', () => {
     const env = captureEnvelope(() => {
-      cliOutput(
-        { ok: true },
-        { command: 'nexus-status', operation: 'nexus.status' },
-      );
+      cliOutput({ ok: true }, { command: 'nexus-status', operation: 'nexus.status' });
     });
 
     const meta = env['meta'] as Record<string, unknown>;

--- a/packages/cleo/src/cli/renderers/__tests__/format-helpers.test.ts
+++ b/packages/cleo/src/cli/renderers/__tests__/format-helpers.test.ts
@@ -17,8 +17,8 @@ import {
   metaFooter,
   padVisible,
   pagerFooter,
-  truncateVisible,
   truncated,
+  truncateVisible,
   visibleLength,
 } from '../format-helpers.js';
 

--- a/packages/cleo/src/cli/renderers/__tests__/format-helpers.test.ts
+++ b/packages/cleo/src/cli/renderers/__tests__/format-helpers.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the shared --human format helpers introduced as the audit-driven
+ * follow-up to T9393. Covers:
+ *   - ANSI-aware width math (visibleLength, padVisible, truncateVisible)
+ *   - kvBlock colon alignment
+ *   - dataTable column sizing + truncation + total-width capping
+ *   - pagerFooter visibility rules (suppresses 1-of-1, fires on pagination/filter)
+ *   - metaFooter surfaces _nexus + deprecated + duration_ms
+ *
+ * @task T9393
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  dataTable,
+  kvBlock,
+  metaFooter,
+  padVisible,
+  pagerFooter,
+  truncateVisible,
+  truncated,
+  visibleLength,
+} from '../format-helpers.js';
+
+describe('visibleLength', () => {
+  it('ignores ANSI color escapes', () => {
+    expect(visibleLength('\x1b[31mfoo\x1b[0m')).toBe(3);
+  });
+  it('counts plain text', () => {
+    expect(visibleLength('hello')).toBe(5);
+  });
+});
+
+describe('padVisible / truncateVisible', () => {
+  it('pads to visible width preserving ANSI', () => {
+    expect(padVisible('\x1b[31mok\x1b[0m', 5)).toBe('\x1b[31mok\x1b[0m   ');
+  });
+  it('truncates with ellipsis past max', () => {
+    expect(truncateVisible('hello world', 8)).toBe('hello w…');
+  });
+  it('returns string as-is when within max', () => {
+    expect(truncateVisible('abc', 8)).toBe('abc');
+  });
+});
+
+describe('kvBlock', () => {
+  it('aligns colons to widest key', () => {
+    const out = kvBlock([
+      ['Status', 'pending'],
+      ['Priority', 'high'],
+    ]);
+    const lines = out.split('\n');
+    // The colon-rendered position should be identical for both lines.
+    const stripped = lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ''));
+    const colon1 = (stripped[0] ?? '').indexOf(':');
+    const colon2 = (stripped[1] ?? '').indexOf(':');
+    expect(colon1).toBe(colon2);
+    expect(colon1).toBeGreaterThan(0);
+  });
+  it('returns empty string for empty input', () => {
+    expect(kvBlock([])).toBe('');
+  });
+});
+
+describe('dataTable', () => {
+  it('renders header + aligned rows', () => {
+    const rows = [
+      { id: 'T001', title: 'short' },
+      { id: 'T9999', title: 'longer title here' },
+    ];
+    const out = dataTable(
+      rows,
+      [
+        { header: 'ID', get: (r) => r.id },
+        { header: 'Title', get: (r) => r.title },
+      ],
+      { indent: 0, totalWidth: 100 },
+    );
+    const stripped = out.replace(/\x1b\[[0-9;]*m/g, '');
+    const lines = stripped.split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toMatch(/^ID\s+Title\s*$/);
+    expect(lines[1]).toContain('T001');
+    expect(lines[2]).toContain('T9999');
+  });
+
+  it('truncates cells past maxWidth with ellipsis', () => {
+    const out = dataTable(
+      [{ title: 'this title is too long for the column' }],
+      [{ header: 'Title', get: (r) => r.title, maxWidth: 12 }],
+      { indent: 0, showHeader: false, totalWidth: 50 },
+    );
+    const stripped = out.replace(/\x1b\[[0-9;]*m/g, '');
+    expect(stripped.length).toBeLessThanOrEqual(12);
+    expect(stripped).toContain('…');
+  });
+
+  it('returns empty string for empty rows', () => {
+    expect(dataTable([], [{ header: 'X', get: () => '' }])).toBe('');
+  });
+});
+
+describe('pagerFooter', () => {
+  it('suppresses footer when payload is complete and no filter is active', () => {
+    expect(pagerFooter({ shown: 5, page: { total: 5 } })).toBe('');
+    expect(pagerFooter({ shown: 5, total: 5 })).toBe('');
+  });
+
+  it('fires when hasMore is true', () => {
+    const out = pagerFooter({
+      shown: 3,
+      page: { mode: 'offset', limit: 3, offset: 0, hasMore: true, total: 100 },
+    });
+    expect(out).toContain('3 of 100');
+    expect(out).toContain('--limit 3');
+    expect(out).toContain('--json for full set');
+  });
+
+  it('fires when filtered differs from total', () => {
+    const out = pagerFooter({ shown: 10, total: 10, filtered: 7 });
+    expect(out).toContain('7 after filter');
+  });
+});
+
+describe('metaFooter', () => {
+  it('returns empty string for empty/undefined meta', () => {
+    expect(metaFooter(undefined)).toBe('');
+    expect(metaFooter({})).toBe('');
+  });
+
+  it('renders _nexus scope chip', () => {
+    const out = metaFooter({
+      _nexus: { scope: 'project', projectName: 'cleocode' },
+      duration_ms: 42,
+    });
+    expect(out).toContain('scope=project');
+    expect(out).toContain('project=cleocode');
+    expect(out).toContain('42 ms');
+  });
+
+  it('truncates long projectId slug', () => {
+    const out = metaFooter({
+      _nexus: { scope: 'project', projectId: 'L21udC9wcm9qZWN0cy9jbGVvY29kZQ' },
+    });
+    // Slug truncates to 13 chars + ellipsis (see metaFooter implementation).
+    expect(out).toMatch(/project=L21udC9wcm9qZ…/);
+  });
+
+  it('renders deprecated warning with replacement', () => {
+    const out = metaFooter({
+      deprecated: {
+        since: 'v2026.6.5',
+        removeIn: 'v2026.8.0',
+        replacement: 'cleo graph context',
+      },
+    });
+    expect(out).toContain('deprecated');
+    expect(out).toContain('since v2026.6.5');
+    expect(out).toContain('cleo graph context');
+  });
+
+  it('suppresses 0 ms duration chip', () => {
+    const out = metaFooter({ _nexus: { scope: 'project' }, duration_ms: 0 });
+    expect(out).not.toContain('0 ms');
+  });
+});
+
+describe('truncated', () => {
+  it('returns full array when within max', () => {
+    const r = truncated([1, 2, 3], 5);
+    expect(r.items).toEqual([1, 2, 3]);
+    expect(r.footer).toBe('');
+  });
+
+  it('slices and emits footer summary when over max', () => {
+    const r = truncated([1, 2, 3, 4, 5, 6, 7, 8], 3);
+    expect(r.items).toEqual([1, 2, 3]);
+    expect(r.footer).toContain('and 5 more');
+  });
+});

--- a/packages/cleo/src/cli/renderers/format-helpers.ts
+++ b/packages/cleo/src/cli/renderers/format-helpers.ts
@@ -101,9 +101,7 @@ export function kvBlock(rows: Array<[string, string]>, indent = 2): string {
   // and so its position drifted with each row's label length).
   const labelWidth = Math.max(...rows.map(([k]) => visibleLength(k)));
   const pad = ' '.repeat(indent);
-  return rows
-    .map(([k, v]) => `${pad}${DIM}${padVisible(k, labelWidth)}:${NC} ${v}`)
-    .join('\n');
+  return rows.map(([k, v]) => `${pad}${DIM}${padVisible(k, labelWidth)}:${NC} ${v}`).join('\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -206,7 +204,10 @@ export function dataTable<T>(
   const lines: string[] = [];
   if (showHeader) {
     const header = columns
-      .map((c, i) => `${BOLD}${padVisible(truncateVisible(c.header, widths[i] ?? 0), widths[i] ?? 0)}${NC}`)
+      .map(
+        (c, i) =>
+          `${BOLD}${padVisible(truncateVisible(c.header, widths[i] ?? 0), widths[i] ?? 0)}${NC}`,
+      )
       .join(sep);
     lines.push(`${pad}${header}`);
   }

--- a/packages/cleo/src/cli/renderers/format-helpers.ts
+++ b/packages/cleo/src/cli/renderers/format-helpers.ts
@@ -1,0 +1,341 @@
+/**
+ * Shared formatting primitives for `--human` CLI renderers.
+ *
+ * Replaces the hand-rolled `padEnd` columns and Markdown-pipe pseudo-tables
+ * that the renderer audit (T9393-followup) flagged as misaligned, lossy, and
+ * inconsistent across the 65-renderer surface.
+ *
+ * Design goals:
+ *   - Terminal-width aware (truncate cells instead of overflowing)
+ *   - Zero new runtime dependencies (no `cli-table` etc.) — uses only ANSI
+ *     escapes from {@link ./colors.ts}.
+ *   - Pure: every helper returns a string; no stdout writes.
+ *   - LAFS-aware: {@link metaFooter} surfaces decorator-stamped
+ *     `meta._nexus`, `meta.deprecated`, and `meta.duration_ms` chrome that
+ *     would otherwise vanish in human mode.
+ *   - Pagination-aware: {@link pagerFooter} formats the `page.{limit,offset,
+ *     hasMore,total}` block so users know a list is windowed.
+ *
+ * @task T9393
+ */
+
+import { BOLD, DIM, NC } from './colors.js';
+
+// ---------------------------------------------------------------------------
+// Terminal width detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort terminal width. Falls back to 100 columns when stdout is not a
+ * TTY (CI logs, pipes) so output remains readable. Never returns < 40.
+ */
+export function terminalWidth(): number {
+  const cols = process.stdout.columns ?? 100;
+  return Math.max(40, cols);
+}
+
+// ---------------------------------------------------------------------------
+// String-width handling (ANSI-aware)
+// ---------------------------------------------------------------------------
+
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
+
+/** Length of a string ignoring ANSI escape codes. */
+export function visibleLength(s: string): number {
+  return s.replace(ANSI_REGEX, '').length;
+}
+
+/** Right-pad a string to `width` visible columns, ignoring embedded ANSI. */
+export function padVisible(s: string, width: number): string {
+  const visible = visibleLength(s);
+  if (visible >= width) return s;
+  return s + ' '.repeat(width - visible);
+}
+
+/**
+ * Truncate a string to at most `max` visible columns, appending `…` when
+ * truncation occurs. ANSI escape codes are preserved (no mid-escape splits).
+ */
+export function truncateVisible(s: string, max: number): string {
+  if (max <= 0) return '';
+  if (visibleLength(s) <= max) return s;
+  // Walk the string, copying characters and skipping over ANSI escape
+  // sequences entirely, until we've collected `max - 1` visible chars.
+  const ellipsis = '…';
+  const target = max - 1;
+  let out = '';
+  let visible = 0;
+  let i = 0;
+  while (i < s.length && visible < target) {
+    const ch = s[i] as string;
+    if (ch === '\x1b' && s[i + 1] === '[') {
+      const end = s.indexOf('m', i + 2);
+      if (end === -1) break;
+      out += s.slice(i, end + 1);
+      i = end + 1;
+      continue;
+    }
+    out += ch;
+    visible++;
+    i++;
+  }
+  return `${out}${ellipsis}`;
+}
+
+// ---------------------------------------------------------------------------
+// kvBlock — colon-aligned key/value list
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a key/value list with colons aligned to the longest key.
+ *
+ * @example
+ * kvBlock([['Status', 'pending'], ['Priority', 'high']])
+ * //   Status:    pending
+ * //   Priority:  high
+ */
+export function kvBlock(rows: Array<[string, string]>, indent = 2): string {
+  if (rows.length === 0) return '';
+  // Pad the label to the widest, THEN append the colon so colons line up
+  // visually across rows (previously the colon was inside the padded label
+  // and so its position drifted with each row's label length).
+  const labelWidth = Math.max(...rows.map(([k]) => visibleLength(k)));
+  const pad = ' '.repeat(indent);
+  return rows
+    .map(([k, v]) => `${pad}${DIM}${padVisible(k, labelWidth)}:${NC} ${v}`)
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// sectionHeader — bold label with optional count
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a section header line like `Acceptance Criteria (4)`.
+ * Used to break up long task-show / nexus-context blocks.
+ */
+export function sectionHeader(label: string, count?: number): string {
+  const c = typeof count === 'number' ? ` ${DIM}(${count})${NC}` : '';
+  return `${BOLD}${label}${NC}${c}`;
+}
+
+// ---------------------------------------------------------------------------
+// dataTable — width-aware aligned table
+// ---------------------------------------------------------------------------
+
+export interface DataTableColumn<T = Record<string, unknown>> {
+  /** Column header label. */
+  header: string;
+  /** Accessor: row -> cell string (already formatted; may contain ANSI). */
+  get: (row: T, index: number) => string;
+  /** Optional max width for this column (cell + header). Defaults to no cap. */
+  maxWidth?: number;
+  /** Optional minimum width (header is always at least its own length). */
+  minWidth?: number;
+}
+
+export interface DataTableOptions {
+  /** Top-line indent in spaces. Defaults to 2. */
+  indent?: number;
+  /** Maximum total table width. Defaults to terminal width. */
+  totalWidth?: number;
+  /** Column separator. Defaults to two spaces. */
+  separator?: string;
+  /** Show header row. Defaults to true. */
+  showHeader?: boolean;
+}
+
+/**
+ * Render an aligned ASCII table. Each column auto-sizes to its widest cell,
+ * capped by `maxWidth` and the overall terminal width. Cells too wide for
+ * their column are truncated with an ellipsis.
+ *
+ * @example
+ * dataTable(tasks, [
+ *   { header: 'ID',     get: (t) => String(t.id),     maxWidth: 12 },
+ *   { header: 'Status', get: (t) => String(t.status), maxWidth: 10 },
+ *   { header: 'Title',  get: (t) => String(t.title)               },
+ * ])
+ */
+export function dataTable<T>(
+  rows: ReadonlyArray<T>,
+  columns: ReadonlyArray<DataTableColumn<T>>,
+  opts: DataTableOptions = {},
+): string {
+  if (rows.length === 0 || columns.length === 0) return '';
+  const indent = opts.indent ?? 2;
+  const sep = opts.separator ?? '  ';
+  const totalWidth = opts.totalWidth ?? terminalWidth();
+  const showHeader = opts.showHeader !== false;
+
+  // Pre-compute every cell as string so we can measure widths once.
+  const cells: string[][] = rows.map((row, i) => columns.map((col) => col.get(row, i)));
+
+  // Natural width per column: max(header, maxCell).
+  const natWidths = columns.map((col, c) => {
+    const headerW = visibleLength(col.header);
+    const cellW = Math.max(...cells.map((r) => visibleLength(r[c] ?? '')));
+    return Math.max(headerW, cellW);
+  });
+
+  // Cap each column by its declared maxWidth.
+  const capped = natWidths.map((w, c) => {
+    const cap = columns[c]?.maxWidth ?? Number.MAX_SAFE_INTEGER;
+    const min = columns[c]?.minWidth ?? 0;
+    return Math.max(min, Math.min(w, cap));
+  });
+
+  // If the total still exceeds terminalWidth, shrink the widest column(s).
+  const sepW = sep.length * (columns.length - 1) + indent;
+  let totalUsed = capped.reduce((a, b) => a + b, 0) + sepW;
+  const widths = [...capped];
+  while (totalUsed > totalWidth) {
+    // Find the widest column with no minWidth pinning it.
+    let widest = 0;
+    for (let c = 1; c < widths.length; c++) {
+      if ((widths[c] ?? 0) > (widths[widest] ?? 0)) widest = c;
+    }
+    const wCur = widths[widest] ?? 0;
+    const minAllowed = columns[widest]?.minWidth ?? 6;
+    if (wCur <= minAllowed) break;
+    widths[widest] = wCur - 1;
+    totalUsed--;
+  }
+
+  const pad = ' '.repeat(indent);
+  const lines: string[] = [];
+  if (showHeader) {
+    const header = columns
+      .map((c, i) => `${BOLD}${padVisible(truncateVisible(c.header, widths[i] ?? 0), widths[i] ?? 0)}${NC}`)
+      .join(sep);
+    lines.push(`${pad}${header}`);
+  }
+  for (const row of cells) {
+    const formatted = row
+      .map((cell, i) => padVisible(truncateVisible(cell ?? '', widths[i] ?? 0), widths[i] ?? 0))
+      .join(sep);
+    lines.push(`${pad}${formatted}`);
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// pagerFooter — render LAFS `page` block + total count
+// ---------------------------------------------------------------------------
+
+export interface PagerInput {
+  /** Number of items in the current response payload. */
+  shown: number;
+  /** LAFS `page` block from envelope, if present. */
+  page?: {
+    mode?: string;
+    limit?: number;
+    offset?: number;
+    hasMore?: boolean;
+    total?: number;
+  } | null;
+  /** Top-level `total` field on the data payload (alternative to page.total). */
+  total?: number;
+  /** Top-level `filtered` field (e.g. tasks.list emits both total + filtered). */
+  filtered?: number;
+}
+
+/**
+ * Render a one-line "... 3 of 227 results (offset 0, --limit 3) ..." footer
+ * sourced from the LAFS pagination block. Empty string when the payload is
+ * complete (`shown >= total` and `hasMore` is false-y).
+ */
+export function pagerFooter(input: PagerInput): string {
+  const { shown, page } = input;
+  const total = page?.total ?? input.total ?? shown;
+  const filtered = input.filtered;
+  const hasMore = page?.hasMore === true || shown < total;
+  const filterActive = typeof filtered === 'number' && filtered !== total;
+  // Suppress when payload is complete and no filter is in play — a "1 of 1"
+  // footer adds noise without information.
+  if (!hasMore && !filterActive) return '';
+
+  const parts: string[] = [`${shown} of ${total}`];
+  if (filterActive) parts.push(`${filtered} after filter`);
+  if (typeof page?.offset === 'number') parts.push(`offset ${page.offset}`);
+  if (typeof page?.limit === 'number') parts.push(`--limit ${page.limit}`);
+  if (hasMore) parts.push('--json for full set');
+  return `${DIM}─── ${parts.join(' · ')} ───${NC}`;
+}
+
+// ---------------------------------------------------------------------------
+// metaFooter — render decorator-stamped meta chrome
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a dim trailing line summarising decorator-stamped envelope meta.
+ *
+ * Surfaces:
+ *   - `meta.duration_ms` — useful for perf-sensitive commands
+ *   - `meta._nexus.{scope, projectId, canonicalCommand, indexFreshness}` —
+ *     orchestration scope info the audit found dropped in every renderer
+ *   - `meta.deprecated.{since, removeIn, replacement}` — alias-shim warnings
+ *     that were silently lost in human output
+ *
+ * Returns empty string when no surfaceable fields are present.
+ */
+export function metaFooter(meta?: Record<string, unknown>): string {
+  if (!meta || typeof meta !== 'object') return '';
+  const lines: string[] = [];
+
+  const deprecated = meta['deprecated'] as
+    | { since?: string; removeIn?: string; replacement?: string }
+    | undefined;
+  if (deprecated && typeof deprecated === 'object') {
+    const since = deprecated.since ? ` since ${deprecated.since}` : '';
+    const removeIn = deprecated.removeIn ? ` · removed in ${deprecated.removeIn}` : '';
+    const replacement = deprecated.replacement ? ` · use \`${deprecated.replacement}\`` : '';
+    // YELLOW would be louder, but DIM keeps human output uncluttered. Callers
+    // who want the warning to shout can render their own line above this.
+    lines.push(`${DIM}deprecated${since}${removeIn}${replacement}${NC}`);
+  }
+
+  const nexus = meta['_nexus'] as Record<string, unknown> | undefined;
+  const duration = meta['duration_ms'] as number | undefined;
+  const chips: string[] = [];
+  if (nexus && typeof nexus === 'object') {
+    if (typeof nexus['scope'] === 'string') chips.push(`scope=${nexus['scope']}`);
+    if (typeof nexus['projectName'] === 'string') {
+      chips.push(`project=${nexus['projectName']}`);
+    } else if (typeof nexus['projectId'] === 'string') {
+      // Show a short slug instead of the full 32-char base64 id.
+      const pid = String(nexus['projectId']);
+      chips.push(`project=${pid.length > 16 ? `${pid.slice(0, 13)}…` : pid}`);
+    }
+    if (nexus['indexFreshness'] === 'stale') chips.push(`${DIM}index=stale${NC}`);
+  }
+  if (typeof duration === 'number' && duration > 0) chips.push(`${duration} ms`);
+
+  if (chips.length > 0) lines.push(`${DIM}[${chips.join(' · ')}]${NC}`);
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// truncated — consistent "and N more" suffix
+// ---------------------------------------------------------------------------
+
+/**
+ * Slice an array and return both the slice and a footer line summarising the
+ * truncation. Use instead of bare `.slice(0, N)` so users always see the
+ * total when output is windowed.
+ *
+ * @example
+ * const { items, footer } = truncated(allCallers, 10);
+ * for (const c of items) lines.push(`  ${c}`);
+ * if (footer) lines.push(`  ${footer}`);
+ */
+export function truncated<T>(
+  arr: ReadonlyArray<T>,
+  max: number,
+): { items: ReadonlyArray<T>; footer: string } {
+  if (arr.length <= max) return { items: arr, footer: '' };
+  return {
+    items: arr.slice(0, max),
+    footer: `${DIM}… and ${arr.length - max} more (use --json or --limit ${arr.length} for full list)${NC}`,
+  };
+}

--- a/packages/cleo/src/cli/renderers/index.ts
+++ b/packages/cleo/src/cli/renderers/index.ts
@@ -31,6 +31,7 @@ import type { CliEnvelope, CliMeta } from '@cleocode/lafs';
 import { applyFieldFilter, extractFieldFromResult } from '@cleocode/lafs';
 import { getFieldContext } from '../field-context.js';
 import { getFormatContext } from '../format-context.js';
+import { metaFooter, pagerFooter } from './format-helpers.js';
 import { emitLafsViolation, LafsViolationError, validateLafsShape } from './lafs-validator.js';
 import { normalizeForHuman } from './normalizer.js';
 // System renderers
@@ -315,6 +316,40 @@ export function cliOutput(data: unknown, opts: CliOutputOptions): void {
     const text = renderer(normalized, ctx.quiet);
     if (text) {
       process.stdout.write(text + '\n');
+    }
+    // T9393-followup: surface LAFS pagination + decorator-stamped meta so
+    // human-mode users see the same windowing + scope info JSON consumers do.
+    // Renderer audit found 12+ commands silently truncated lists with no
+    // hint that `--limit` was active, and EVERY renderer dropped `_nexus` /
+    // `deprecated` warnings. Centralising the chrome here means every
+    // command picks it up automatically without per-renderer wiring.
+    if (!ctx.quiet) {
+      const pagerData = data as Record<string, unknown> | undefined;
+      const pagerArrays =
+        pagerData && typeof pagerData === 'object'
+          ? Object.values(pagerData).filter((v) => Array.isArray(v))
+          : [];
+      const shown = pagerArrays.reduce((max, arr) => Math.max(max, (arr as unknown[]).length), 0);
+      if (shown > 0 && opts.page) {
+        const pager = pagerFooter({
+          shown,
+          page: opts.page as Parameters<typeof pagerFooter>[0]['page'],
+          total: pagerData?.['total'] as number | undefined,
+          filtered: pagerData?.['filtered'] as number | undefined,
+        });
+        if (pager) process.stdout.write(`${pager}\n`);
+      }
+      // Decorator-stamped meta can arrive via `responseMeta` (dispatchRaw
+       // path) or be inlined into `extensions` by bypass-dispatch commands
+       // (e.g. `cleo nexus status` via buildNexusMetaExtensions). Merge so
+       // metaFooter sees both — extensions wins on collision to match the
+       // JSON envelope precedence rule.
+      const combinedMeta = {
+        ...(opts.responseMeta ?? {}),
+        ...(opts.extensions ?? {}),
+      };
+      const footer = metaFooter(combinedMeta);
+      if (footer) process.stdout.write(`${footer}\n`);
     }
     return;
   }

--- a/packages/cleo/src/cli/renderers/index.ts
+++ b/packages/cleo/src/cli/renderers/index.ts
@@ -208,6 +208,30 @@ const renderers: Record<string, HumanRenderer> = {
 };
 
 // ---------------------------------------------------------------------------
+// Decorator passthrough — local pick to avoid renderers → dispatch import cycle
+// (dispatch/adapters/cli.ts already imports cliOutput from this module).
+// Kept in sync with the canonical `pickDecoratorMetaExtensions` in
+// `packages/cleo/src/dispatch/nexus-decorator.ts`. If the canonical list of
+// decorator-stamped fields grows, update both call sites.
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract decorator-stamped meta fields (`_nexus`, `deprecated`) from a
+ * `DispatchResponse.meta` so cliOutput can forward them into the envelope.
+ *
+ * @task T9393
+ */
+function pickDecoratorMetaExtensionsLocal(
+  responseMeta: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!responseMeta) return {};
+  const out: Record<string, unknown> = {};
+  if (responseMeta['_nexus'] !== undefined) out['_nexus'] = responseMeta['_nexus'];
+  if (responseMeta['deprecated'] !== undefined) out['deprecated'] = responseMeta['deprecated'];
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Options for cliOutput
 // ---------------------------------------------------------------------------
 
@@ -222,6 +246,18 @@ export interface CliOutputOptions {
   page?: FormatOptions['page'];
   /** Extra metadata extensions merged into `meta`. */
   extensions?: Record<string, unknown>;
+  /**
+   * Optional `DispatchResponse.meta` to forward decorator-stamped fields
+   * (`_nexus`, `deprecated`, etc.) into the emitted envelope. Use this when
+   * the command goes through `dispatchRaw` and the dispatcher's decorators
+   * have stamped fields the caller wants surfaced to JSON consumers.
+   *
+   * Canonical meta fields (operation, requestId, timestamp) are NOT forwarded —
+   * those are always produced fresh by `formatSuccess` via `createCliMeta`.
+   *
+   * @task T9393
+   */
+  responseMeta?: Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -340,7 +376,18 @@ export function cliOutput(data: unknown, opts: CliOutputOptions): void {
   const formatOpts: FormatOptions = {};
   if (opts.operation) formatOpts.operation = opts.operation;
   if (opts.page) formatOpts.page = opts.page;
-  if (opts.extensions) formatOpts.extensions = opts.extensions;
+
+  // T9393: merge decorator-stamped fields from response.meta into envelope
+  // extensions. Without this, _nexus / deprecated stamped by dispatch
+  // decorators are silently dropped when the caller passes response.data
+  // directly to cliOutput.
+  const decoratorExt = pickDecoratorMetaExtensionsLocal(opts.responseMeta);
+  const mergedExt =
+    opts.extensions || Object.keys(decoratorExt).length > 0
+      ? { ...decoratorExt, ...(opts.extensions ?? {}) }
+      : undefined;
+  if (mergedExt) formatOpts.extensions = mergedExt;
+
   if (fieldCtx.mvi) formatOpts.mvi = fieldCtx.mvi;
 
   // Phase 6 — LAFS envelope validation middleware.

--- a/packages/cleo/src/cli/renderers/index.ts
+++ b/packages/cleo/src/cli/renderers/index.ts
@@ -340,10 +340,10 @@ export function cliOutput(data: unknown, opts: CliOutputOptions): void {
         if (pager) process.stdout.write(`${pager}\n`);
       }
       // Decorator-stamped meta can arrive via `responseMeta` (dispatchRaw
-       // path) or be inlined into `extensions` by bypass-dispatch commands
-       // (e.g. `cleo nexus status` via buildNexusMetaExtensions). Merge so
-       // metaFooter sees both — extensions wins on collision to match the
-       // JSON envelope precedence rule.
+      // path) or be inlined into `extensions` by bypass-dispatch commands
+      // (e.g. `cleo nexus status` via buildNexusMetaExtensions). Merge so
+      // metaFooter sees both — extensions wins on collision to match the
+      // JSON envelope precedence rule.
       const combinedMeta = {
         ...(opts.responseMeta ?? {}),
         ...(opts.extensions ?? {}),

--- a/packages/cleo/src/cli/renderers/system.ts
+++ b/packages/cleo/src/cli/renderers/system.ts
@@ -273,7 +273,9 @@ export function renderBlockers(data: Record<string, unknown>, quiet: boolean): s
 
   if (typeof limit === 'number' && typeof total === 'number' && total > shown) {
     lines.push('');
-    lines.push(`${DIM}\u2500\u2500\u2500 ${shown} of ${total} (--limit ${limit}, --json for full set) \u2500\u2500\u2500${NC}`);
+    lines.push(
+      `${DIM}\u2500\u2500\u2500 ${shown} of ${total} (--limit ${limit}, --json for full set) \u2500\u2500\u2500${NC}`,
+    );
   }
 
   return lines.join('\n');

--- a/packages/cleo/src/cli/renderers/system.ts
+++ b/packages/cleo/src/cli/renderers/system.ts
@@ -80,34 +80,58 @@ function cliColorize(text: string, style: ColorStyle): string {
 // ---------------------------------------------------------------------------
 
 export function renderDoctor(data: Record<string, unknown>, quiet: boolean): string {
-  const healthy = data['healthy'] as boolean | undefined;
-  const errors = data['errors'] as number | undefined;
-  const warnings = data['warnings'] as number | undefined;
+  // T9393-followup: dispatcher returns `overall: 'pass'|'warning'|'fail'`,
+  // per-check `status: 'pass'|'warn'|'fail'`. The previous implementation read
+  // `healthy` (never set) so every check rendered as red \u2717 regardless of state.
+  const overall = (data['overall'] as string | undefined) ?? 'unknown';
+  const version = data['version'] as string | undefined;
+  const installation = data['installation'] as string | undefined;
   const checks = data['checks'] as Array<Record<string, unknown>> | undefined;
 
   if (quiet) {
-    return healthy ? 'healthy' : 'unhealthy';
+    return overall;
   }
 
   const lines: string[] = [];
-  const statusText = healthy ? `${GREEN}${BOLD}HEALTHY${NC}` : `${RED}${BOLD}UNHEALTHY${NC}`;
+  const statusBadge =
+    overall === 'pass'
+      ? `${GREEN}${BOLD}HEALTHY${NC}`
+      : overall === 'warning'
+        ? `${YELLOW}${BOLD}DEGRADED${NC}`
+        : overall === 'fail'
+          ? `${RED}${BOLD}UNHEALTHY${NC}`
+          : `${DIM}${overall.toUpperCase()}${NC}`;
 
-  lines.push(`System Status: ${statusText}`);
-  if ((errors ?? 0) > 0) lines.push(`  ${RED}Errors: ${errors}${NC}`);
-  if ((warnings ?? 0) > 0) lines.push(`  ${YELLOW}Warnings: ${warnings}${NC}`);
-  lines.push('');
+  lines.push(`System Status: ${statusBadge}`);
+  if (version) lines.push(`  ${DIM}Version:${NC} ${version}`);
+  if (installation) lines.push(`  ${DIM}Installation:${NC} ${installation}`);
 
-  if (checks) {
+  if (checks && checks.length > 0) {
+    let passCount = 0;
+    let warnCount = 0;
+    let failCount = 0;
+    for (const c of checks) {
+      const s = c['status'] as string;
+      if (s === 'pass') passCount++;
+      else if (s === 'warn' || s === 'warning') warnCount++;
+      else failCount++;
+    }
+    lines.push(
+      `  ${DIM}Checks:${NC} ${GREEN}${passCount} pass${NC} \u00B7 ${YELLOW}${warnCount} warn${NC} \u00B7 ${RED}${failCount} fail${NC}`,
+    );
+    lines.push('');
     for (const check of checks) {
       const status = check['status'] as string;
+      const name = check['name'] as string | undefined;
       const message = check['message'] as string;
       const icon =
-        status === 'ok'
+        status === 'pass'
           ? `${GREEN}\u2713${NC}`
-          : status === 'warning'
+          : status === 'warn' || status === 'warning'
             ? `${YELLOW}\u26A0${NC}`
             : `${RED}\u2717${NC}`;
-      lines.push(`  ${icon} ${message}`);
+      const label = name ? `${BOLD}${name}${NC}` : '';
+      lines.push(`  ${icon} ${label}${label && message ? ` \u2014 ${message}` : message}`);
     }
   }
 
@@ -192,31 +216,64 @@ export function renderNext(data: Record<string, unknown>, quiet: boolean): strin
 // ---------------------------------------------------------------------------
 
 export function renderBlockers(data: Record<string, unknown>, quiet: boolean): string {
-  const blockers = data['blockers'] as Array<Record<string, unknown>> | undefined;
-  const tasks = data['tasks'] as Task[] | undefined;
-  const items = blockers ?? tasks;
+  // T9393-followup: dispatcher returns `blockedTasks` (not `blockers`/`tasks`),
+  // plus `criticalBlockers`, `summary`, `total`, `limit`. The previous keys
+  // never matched so `cleo blockers --human` printed "No blocked tasks" while
+  // JSON had hundreds.
+  const blockedTasks =
+    (data['blockedTasks'] as Array<Record<string, unknown>> | undefined) ??
+    (data['blockers'] as Array<Record<string, unknown>> | undefined) ??
+    (data['tasks'] as Array<Record<string, unknown>> | undefined);
+  const criticalBlockers = data['criticalBlockers'] as Array<Record<string, unknown>> | undefined;
+  const summary = data['summary'] as string | undefined;
+  const total = data['total'] as number | undefined;
+  const limit = data['limit'] as number | undefined;
 
-  if (!items || items.length === 0) {
-    return quiet ? '' : 'No blocked tasks.';
+  if (!blockedTasks || blockedTasks.length === 0) {
+    return quiet ? '' : (summary ?? 'No blocked tasks.');
   }
 
   if (quiet) {
-    return items
-      .map((b) => String((b as Record<string, unknown>)['id'] ?? (b as Task).id))
-      .join('\n');
+    return blockedTasks.map((b) => String(b['id'])).join('\n');
   }
 
   const lines: string[] = [];
-  lines.push(`${RED}${BOLD}Blocked Tasks (${items.length})${NC}`);
+  const shown = blockedTasks.length;
+  const totalLabel = typeof total === 'number' && total !== shown ? ` of ${total}` : '';
+  lines.push(`${RED}${BOLD}Blocked Tasks (${shown}${totalLabel})${NC}`);
+  if (summary && summary !== `${shown} blocked task(s)`) {
+    lines.push(`${DIM}${summary}${NC}`);
+  }
   lines.push('');
 
-  for (const item of items) {
-    const t = item as Task & Record<string, unknown>;
-    const id = t.id ?? String(t['id']);
-    const title = t.title ?? String(t['title']);
-    const blockedBy = t.blockedBy ?? String(t['blockedBy'] ?? '');
-    lines.push(`  ${RED}\u2297${NC} ${BOLD}${id}${NC} ${title}`);
-    if (blockedBy) lines.push(`    ${DIM}Blocked by: ${blockedBy}${NC}`);
+  if (criticalBlockers && criticalBlockers.length > 0) {
+    lines.push(`${RED}${BOLD}Critical Blockers (${criticalBlockers.length})${NC}`);
+    for (const cb of criticalBlockers) {
+      const id = String(cb['id'] ?? cb['taskId'] ?? '');
+      const title = String(cb['title'] ?? '');
+      const blocks = cb['blocks'] as string[] | undefined;
+      lines.push(`  ${RED}\u2297${NC} ${BOLD}${id}${NC} ${title}`);
+      if (blocks && blocks.length > 0) {
+        lines.push(`    ${DIM}Blocks: ${blocks.join(', ')}${NC}`);
+      }
+    }
+    lines.push('');
+  }
+
+  for (const item of blockedTasks) {
+    const id = String(item['id']);
+    const title = String(item['title'] ?? '');
+    const priority = item['priority'] as string | undefined;
+    const blockedBy = item['blockedBy'] as string[] | string | undefined;
+    const blockedByStr = Array.isArray(blockedBy) ? blockedBy.join(', ') : (blockedBy ?? '');
+    const pBadge = priority ? `${priorityColor(priority)}[${priority}]${NC} ` : '';
+    lines.push(`  ${RED}\u2297${NC} ${BOLD}${id}${NC} ${pBadge}${title}`);
+    if (blockedByStr) lines.push(`    ${DIM}Blocked by: ${blockedByStr}${NC}`);
+  }
+
+  if (typeof limit === 'number' && typeof total === 'number' && total > shown) {
+    lines.push('');
+    lines.push(`${DIM}\u2500\u2500\u2500 ${shown} of ${total} (--limit ${limit}, --json for full set) \u2500\u2500\u2500${NC}`);
   }
 
   return lines.join('\n');

--- a/packages/cleo/src/dispatch/adapters/cli.ts
+++ b/packages/cleo/src/dispatch/adapters/cli.ts
@@ -270,6 +270,12 @@ export async function dispatchFromCli(
     if (opts.page === undefined && response.page !== undefined) {
       opts.page = response.page;
     }
+    // T9393: auto-forward decorator-stamped meta fields (e.g. `_nexus`,
+    // `deprecated`) so JSON consumers see what the dispatcher decorators
+    // attached. Callers can still pass `responseMeta` explicitly to override.
+    if (opts.responseMeta === undefined) {
+      opts.responseMeta = response.meta as unknown as Record<string, unknown>;
+    }
     cliOutput(response.data, opts);
   } else {
     // Derive exit code from the string error code when exitCode is not set

--- a/packages/cleo/src/dispatch/nexus-decorator.ts
+++ b/packages/cleo/src/dispatch/nexus-decorator.ts
@@ -213,3 +213,62 @@ export function stampNexusMeta(
     },
   };
 }
+
+// ---------------------------------------------------------------------------
+// pickDecoratorMetaExtensions — forward decorator fields into CLI envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick the decorator-stamped fields (`_nexus`, `deprecated`) from a dispatch
+ * response's `meta` so they can be forwarded via `cliOutput`'s `extensions`
+ * option into the emitted LAFS envelope.
+ *
+ * Without this, `cliOutput(response.data, ...)` discards `response.meta._nexus`
+ * + `response.meta.deprecated` (T9393 defect). Canonical CLI meta fields
+ * (`operation`, `requestId`, `timestamp`) are intentionally NOT forwarded —
+ * those are produced by {@link createCliMeta} on the CLI side.
+ *
+ * @task T9393
+ */
+export function pickDecoratorMetaExtensions(
+  responseMeta: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!responseMeta) return {};
+  const out: Record<string, unknown> = {};
+  if (responseMeta['_nexus'] !== undefined) out['_nexus'] = responseMeta['_nexus'];
+  if (responseMeta['deprecated'] !== undefined) out['deprecated'] = responseMeta['deprecated'];
+  return out;
+}
+
+/**
+ * Build CLI envelope extensions for nexus commands that bypass the dispatcher
+ * (e.g. `cleo nexus status` SSoT-EXEMPT path). Runs the same {@link stampNexusMeta}
+ * logic against a synthetic response so the resulting envelope still carries
+ * `meta._nexus` (and `meta.deprecated` for alias shims).
+ *
+ * Use this only where the command does NOT call `dispatchRaw`. When you have a
+ * real dispatch response, use {@link pickDecoratorMetaExtensions} on
+ * `response.meta` instead — that path already ran the decorator.
+ *
+ * @task T9393
+ */
+export function buildNexusMetaExtensions(
+  operation: string,
+  params: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const synthetic: DispatchResponse = {
+    success: true,
+    data: undefined,
+    meta: {
+      gateway: 'query',
+      domain: 'nexus',
+      operation,
+      timestamp: new Date().toISOString(),
+      duration_ms: 0,
+      source: 'cli',
+      requestId: '',
+    },
+  } as DispatchResponse;
+  const stamped = stampNexusMeta(synthetic, operation, params);
+  return pickDecoratorMetaExtensions(stamped.meta as Record<string, unknown>);
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/output.ts
+++ b/packages/core/src/output.ts
@@ -137,7 +137,28 @@ export function formatSuccess<T>(
   const opts: FormatOptions =
     typeof operationOrOpts === 'string' ? { operation: operationOrOpts } : (operationOrOpts ?? {});
 
-  const meta = createCliMeta(opts.operation ?? 'cli.output');
+  const baseMeta = createCliMeta(opts.operation ?? 'cli.output');
+
+  // T9393: merge caller-supplied extensions into envelope meta. The `extensions`
+  // field has been declared on FormatOptions since T4670 but was never consumed
+  // here — silently dropping decorator-stamped fields (e.g. `_nexus`, `deprecated`,
+  // measured `duration_ms`) into the void. Canonical fields (operation, requestId,
+  // timestamp) are still produced by createCliMeta and listed last so they always
+  // win against any extension overrides.
+  const meta: CliMeta = {
+    ...(opts.extensions ?? {}),
+    ...baseMeta,
+    operation: baseMeta.operation,
+    requestId: baseMeta.requestId,
+    timestamp: baseMeta.timestamp,
+    // duration_ms is special: extensions wins when caller measured it, otherwise
+    // the createCliMeta default (0) is used. Both above spreads handle this —
+    // extensions sets it, then baseMeta's 0 only wins if extensions had none.
+    duration_ms:
+      typeof opts.extensions?.['duration_ms'] === 'number'
+        ? (opts.extensions['duration_ms'] as number)
+        : baseMeta.duration_ms,
+  };
 
   const envelope: CliEnvelope<T> = {
     success: true,

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.74",
+  "version": "2026.5.75",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

CalVer release v2026.5.74 → v2026.5.75 bundling two work items:

1. **T1892 BBTT closure release marker** — Surfaces the T1892 BBTT (BRAIN/Briefing Trust) epic closure in CHANGELOG. T1892 was closed 2026-05-16T14:25:41Z with 6/6 verification gates passed using REAL evidence atoms — zero override on critical gates. Closure artifacts (audit + manifests) already shipped via PR #176.

2. **T9393 cliOutput envelope-meta propagation** — Fixes the dead decorator path that prevented `meta._nexus` and `meta.deprecated` from appearing on `cleo nexus status/list/impact/context --json` envelopes. This unblocks T9146 + T9147 (nexus restructure W2/W3) and retroactively closes the T9172 audit gap from Phase 4 CSL-RESET.

## Files

- `CHANGELOG.md` (+19): v2026.5.75 entry auto-prepared by release.ship
- `package.json` × 21: CalVer bumps across all npm packages
- `Cargo.lock` + `Cargo.toml`: CalVer bumps across Rust workspace
- `packages/cleo/src/dispatch/nexus-decorator.ts` (+59 NEW): decorator stamping meta keys per ADR-072
- `packages/cleo/src/cli/renderers/index.ts` (+49): renderer meta forwarding
- `packages/cleo/src/cli/commands/nexus.ts` (+14): nexus meta wiring
- `packages/core/src/output.ts` (+23): meta propagation in cliOutput

## Test plan

- [ ] CI green: Lockfile Check, Identity Pollution Check, full CI, Type Check, Unit Tests, Documentation Coverage
- [ ] Build & Verify across matrix
- [ ] After merge: tag v2026.5.75 from main + npm publish across all packages + global install verification

## Related shipped work

- T9245 validateCommit content-intersect: PR #166 in v2026.5.74
- T1892 closure artifacts: PR #176 (already on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)