### PR TITLE
docs(T9345): RCASD research wave — IVTR/Release System overhaul

### DIFF
--- a/.cleo/rcasd/T9345/research/ADR-T9345-ivtr-release-overhaul.md
+++ b/.cleo/rcasd/T9345/research/ADR-T9345-ivtr-release-overhaul.md
@@ -1,0 +1,944 @@
+# ADR-073: IVTR/Release System Overhaul — Project-Agnostic Provenance-Graph Pipeline
+
+**Status**: Proposed
+**Date**: 2026-05-15
+**Epic**: T9345 (IVTR Release System Overhaul)
+**Authors**: cleo-prime (system architect, RCASD wave-2)
+**Supersedes (partial)**: ADR-053 (project-agnostic release pipeline — extended), ADR-065 (PR-required flow — extended, not replaced)
+**Related**: ADR-051 (evidence-based gates), ADR-061 (project-agnostic verify tools), ADR-062 (worktree merge), ADR-063 (4-step pipeline), ADR-068 (database charter), ADR-070 (three-tier orchestration), ADR-072 (Hermes LLM port precedent)
+**Forward-references**: T1737 (Sentient Harness v3)
+
+---
+
+## Status
+
+`Proposed` — awaiting RCASD wave-2 council review + owner sign-off. Once accepted, the orchestrator MUST file the child epics enumerated in *Open questions* before the spec-writer (T9345 wave-3) begins the RFC-2119 spec deliverable.
+
+---
+
+## Context
+
+### 1. Symptom catalog (10 failures, anchored to forensics)
+
+The T9345 incident catalog, derived verbatim from `.cleo/rcasd/T9345/research/failure-forensics-10-modes.md` and the v2026.5.73 → v2026.5.74 ship session (anchor commit `e1b3b414d`), contains ten distinct production failures of `cleo release ship`:
+
+1. **Wedged git commit, no child-process timeout** — `git commit` hung indefinitely (PID 4011255), `.git/index.lock` was orphaned, parent process exited silently. Cited at `packages/core/src/release/engine-ops.ts:1497` (`gitCwd` omits `timeout`) and `engine-ops.ts:1524-1533` (the actual wedged commit call). Compare to `engine-ops.ts:1484` and `engine-ops.ts:1688` which DO set timeouts on biome and gh-merge — the omission on git is unintentional. (forensics §Failure #1)
+
+2. **Epic completeness scope leak** — `--epic T9261` was supplied but completeness check failed on T9220 (unrelated, SUPERSEDED weeks prior by T9337). Cited at `engine-ops.ts:1339-1378` (call site passes no `epicId` to `checkEpicCompleteness`), `guards.ts:31-46` (`findEpicAncestor` walks UP the parent chain across epic boundaries), `guards.ts:82-122` (only checks `t.status === 'done'`, ignores `superseded`/`pipelineStage`). (forensics §Failure #2)
+
+3. **Gate runners not wired** — `cleo release verify` reports all 5 canonical gates (test, lint, typecheck, audit, security-scan) as `runner not configured (inject via opts.runGate)`. Cited at `pipeline.ts:249-262` (`defaultRunGate` is a no-op stub returning `passed:false`), `release.ts:317-323` (CLI calls `releaseVerify(handle)` with no `opts.runGate`), `engine-ops.ts:1236` (`releaseShip` calls a DIFFERENT gate registry, `runReleaseGates` from `release-manifest.ts`). Two parallel gate systems, neither wired to ADR-061's tool resolver. (forensics §Failure #3, audit §3.2)
+
+4. **IVTR non-blocking gate** — "IVTR gate: 72 task(s) have no IVTR state (non-blocking)". When 72/72 tasks are in the `unchecked` bucket, the gate is reduced to a printed warning. Cited at `engine-ops.ts:190-212` (`checkIvtrGates` returns three-state `{blocked, unchecked}`), `engine-ops.ts:1285-1289` (`unchecked` → warn-only). If the gate cannot block under any input configuration, it is not a gate. (forensics §Failure #4)
+
+5. **Override cap counter broken** — "Per-session CLEO_OWNER_OVERRIDE cap exceeded: 823 of 10 overrides used. Counter never resets." Cited at `override-cap.ts:147-161` (only write path increments), `session/engine-ops.ts:574-690` (`sessionEnd` never deletes the counter file), `validation/engine-ops.ts:382-388` (`sessionId ?? 'global'` fallback collapses orphan invocations into one perpetual counter). (forensics §Failure #5)
+
+6. **Tag points at wrong SHA** — after `gh pr merge --auto`, the pipeline immediately `git pull && git rev-parse HEAD && git tag` without polling merge completion. Tag landed at pre-merge SHA `1226c5dae` instead of merge commit `e1b3b414d`. Cited at `engine-ops.ts:1682-1717` (merge step is fire-and-forget with `--auto`), `engine-ops.ts:1721-1767` (Step 10 does not poll `gh pr view --json state,mergeCommit`). (forensics §Failure #6)
+
+7. **Worker direct-push to main** — worker-T9317 merged its task branch directly to local main without opening a PR. Cited at `packages/git-shim/src/shim.ts:232-244` (no-role fast path — env-var-only enforcement), `git-shim/src/denylist.ts:184-200` (only force-push variants of `push` denied; `git push origin task/T:main` not blocked), `git-shim/src/boundary.ts:239-262` (`validateMergeAllowed` only fires when shim is active). Single-layer enforcement. (forensics §Failure #7)
+
+8. **Release start no-op** — `cleo release start` writes `.cleo/release/handle.json`; `releaseShip` never reads it. Cited at `pipeline.ts:91` (handle path), `engine-ops.ts:1105-1233` (`releaseShip` signature takes raw params, never imports `loadActiveReleaseHandle`/`writeHandle`/`releaseStart`). Two parallel release systems with overlapping CLI surfaces, neither aware of the other. (forensics §Failure #8, audit §1)
+
+9. **Esbuild externals not auto-detected** — T9317 Bedrock SDK addition required manual `build.mjs` edit for `@aws-sdk/*` + `@smithy/*` externals. Cited at `build.mjs:179-266` (hand-maintained array), `version-bump.ts` (no externals scanner), `engine-ops.ts:1478-1495` (only the biome lint step runs; no `pnpm run build` pre-ship gate). (forensics §Failure #9)
+
+10. **CHANGELOG fragile** — auto-generated entries include verbose RCASD task descriptions instead of human-readable summaries; no semver impact assessment. Cited at `release-manifest.ts:330-368` (heuristic-driven description inclusion; 150-char hardcoded truncation), `release-manifest.ts:305-409` (categorizer dispatches by `task.type`, has no `breaking`/`major`/`minor`/`patch` impact tag), `changelog-writer.ts:43-63` (flat section output, no upgrade-impact callout). (forensics §Failure #10)
+
+### 2. Root-cause clusters (six, distilled from forensics)
+
+The 10 failures collapse into 6 root-cause clusters (forensics §Cross-Failure Synthesis):
+
+- **C1 — No child-process supervision** (Failures #1, #6): `execFileSync`/`spawnSync` invocations against `git`/`gh`/`npx biome`/`npm` lack consistent timeout discipline; `gh pr merge --auto` is treated synchronously when it is asynchronous; no SIGKILL-on-timeout fallback.
+- **C2 — Gate logic confused with pipeline logic** (Failures #3, #4): three independent gate systems (`pipeline.ts:VERIFY_GATES`, `release-manifest.ts:runReleaseGates`, `engine-ops.ts:checkIvtrGates`) do not talk to each other; the canonical pipeline's `verify` is a no-op stub; the IVTR gate's `unchecked` bucket lets the entire gate degrade to a printed warning.
+- **C3 — No state-machine resume** (Failures #1, #6, #8): `releaseShip` is a 761-line monolith (engine-ops.ts:1105-1866) with no intermediate checkpoints; the handle written by `releaseStart` is ignored; no `cleo release ship --resume` exists.
+- **C4 — Enforcement is env-var-only, not defense-in-depth** (Failure #7): the git-shim's authority depends entirely on `CLEO_AGENT_ROLE` being set in subprocess env; the denylist misses `git push <remote> <local>:<protected-branch>`; no on-disk worktree policy artifact.
+- **C5 — Hand-maintained registries with no sync test** (Failures #9, #10): `build.mjs` externals list, CHANGELOG heuristics, AUTHOR_MAP-equivalent attribution metadata — all are hand-maintained data with no programmatic validator that fails CI when source-of-truth and registry drift.
+- **C6 — Sessions don't bound their own state** (Failure #5): `sessionEnd` does not delete the override-counter file; the `'global'` sessionId fallback gives orphan invocations a perpetual append-only counter.
+
+### 3. Conflation diagnosis — IVTR ↔ Release tight-coupling
+
+`.cleo/rcasd/T9345/research/ivtr-conflation-audit.md` scores IVTR↔Release conflation at **7/10** (significant over-engineering with tight release coupling). Key findings:
+
+- **Bidirectional hard-welding at engine level**: `engine-ops.ts:1262-1280` calls `releaseGateCheck()` which queries `task.ivtr_state`; `engine-ops.ts:475-556` auto-suggests `cleo release ship` after IVTR completion. (audit Q1, Leaks #1-#4)
+- **Gate duplication**: IVTR phases `implement/validate/test/released` are semantically equivalent to ADR-051 evidence gates `implemented/qaPassed/testsPassed/<meta>`. Agents run both, recording the same evidence twice. (audit §Phase 3, table "Gate Duplication")
+- **Missing provenance graph**: no `commits` table, no `release_manifest.commits → tasks` FK, no `releases` table — the owner-required "feature → bug → hotfix → epic → task → commit → release" graph is **derivable but not queryable** (audit Q4). `tasks.verification` and `task_relations` exist but lack `(release_id, commit_sha, task_id)` triples.
+- **~600 LOC of coupling to remove**: 17 IVTR gate references in `engine-ops.ts` lines 1251-1295 alone; plus 7 files directly integrating IVTR into release paths (audit §Phase 1).
+
+The audit's Priority 1 action is unambiguous: **decouple release from IVTR; evidence gates (ADR-051) become the sole release blocker** (audit §Recommendations, T9350).
+
+### 4. External precedents (wave-1 research)
+
+**Hermes-agent** (`.cleo/rcasd/T9345/research/hermes-agent-real-research.md`): the canonical NousResearch project at `github.com/NousResearch/hermes-agent`, currently `v0.13.0` / `v2026.5.7`. Already cited by `docs/specs/hermes-agent-llm-provider-architecture.md` as the CLEO Phase 4 LLM-stack precedent (ADR-072). **For release governance, Hermes is orthogonal to CLEO**: no IVTR ladder, no epic-completeness, no task→commit→release graph, no worker-direct-push protection. But Hermes offers **8 Tier-1 borrowable mechanics**: dual CalVer+SemVer tagging, `next_available_tag` same-day suffixing, annotated tags with structured messages, release-as-event GitHub fan-out, OCI revision-label ancestor check, pinned-deps + lockfile-drift CI, supply-chain audit on PR diffs, print-exact-recovery-command on failure (research §6 Tier 1). Critically: Hermes's release pipeline is a **single Python script** (`scripts/release.py`) run from a maintainer's laptop, not a GHA workflow — the maintainer trusts `main` is green at publish time.
+
+**Letta** (`.cleo/rcasd/T9345/research/letta-harness-real-research.md`): two repos with opposite postures. `letta-ai/letta` (Python server) has **zero release gates** — `poetry-publish.yml` fires on `release:published` and runs `uv build && uv publish` with no lint/typecheck/test (research §3.3, "anti-pattern observation"). `letta-ai/letta-code` (TypeScript harness) is the **closer precedent** to CLEO — a two-stage workflow: `prepare-release.yml` opens a `chore: bump version to X` PR after running lint+typecheck+build+update-chain-smoke; `release.yml` triggers on push-to-main filtered to `[package.json, package-lock.json]`, re-runs lint+typecheck+build+CLI smoke+**integration smoke against the real API** (`./letta.js --prompt "ping" --tools "" --permission-mode plan` using `LETTA_API_KEY`), then publishes to npm with OIDC, tags from the merged main commit, and creates a GitHub Release with `generate_release_notes: true` (research §3.4). The **`release_bump_only` classifier** (research §3.4 sub-section "CI on the bump-PR itself") is 40 lines of bash that short-circuits heavy CI when the PR only touches `package.json|package-lock.json` — directly portable. Letta also provides the **`LET-XXXX (#PR)` cross-citation** convention as the closest precedent for CLEO's `T#### (#PR)` provenance edges.
+
+### 5. T1737 Sentient Harness v3 alignment requirement
+
+T1737 (Sentient Harness v3) is the planned multi-platform harness layer above the current `cleo-os` / Pi adapter stack. Required surfaces:
+
+- **linux x64 / arm64** (Pi, Raspberry Pi 5, Linux servers)
+- **macos x64 / arm64** (Apple Silicon, Intel)
+- **win x64** (PowerShell, WSL2 host)
+
+Any new release pipeline MUST emit installable artifacts for all five platform tuples — not just `npm install -g @cleocode/cleo` on a TypeScript stack. The current `cleo release ship` 12-step assumes a single npm package and falls back to `engine-ops.ts:1480` (`npm`-CLI invocation hardcoded) for the publish step. T1737 forces this assumption open.
+
+### 6. Project-agnosticism gap (ADR-053 promise vs current reality)
+
+ADR-053 (T820) explicitly promised: "the release pipeline MUST be portable across **at least three project archetypes**: (a) npm monorepo with pnpm workspaces, (b) single npm library, (c) single Rust crate published to crates.io." The RELEASE-06 fixture asserts this. **Today's `releaseShip` partially regresses ADR-053**:
+
+- Hardcoded `gh` CLI requirement (`engine-ops.ts:1182-1189`) — ADR-065's PR-required flow added this without making it pluggable.
+- Hardcoded `npm`-CLI publish path (`engine-ops.ts:1480`) — Rust/Python projects need `cargo publish` / `twine upload`.
+- Workspace discovery hardcodes `pnpm-workspace.yaml` + `packages/` layout (`version-bump.ts:243-288`). Cargo workspace discovery is patched in but parallel, not unified.
+- `defaultRunGate` (`pipeline.ts:249-262`) does not call ADR-061's tool resolver — so even the gate runner regresses the ADR-061 promise.
+
+ADR-061 (project-agnostic evidence tools + cross-process result cache) already solved gate-runner portability at the `cleo verify` layer with canonical tool names (`test`, `build`, `lint`, `typecheck`, `audit`, `security-scan`) resolved via `.cleo/project-context.json` with per-`primaryType` fallbacks (cargo, pytest, go, bun). The release pipeline must adopt this resolver instead of maintaining a parallel gate registry.
+
+### 7. ADR-065 (current 12-step PR-required flow) — what it got right and what it didn't
+
+ADR-065 is the canonical statement of today's pipeline. It says: "all releases flow through a PR-gated pipeline. Direct pushes to `main` are prohibited." This is the single best architectural invariant CLEO inherited — it prevents the entire class of "worker direct-push" failures at the policy level even when the git-shim layer fails (forensics §F7). This ADR-073 PRESERVES that invariant unconditionally.
+
+ADR-065's 12-step also defines the auto-flow: prepare → gates → IVTR check → epic-completeness → double-listing guard → CHANGELOG → biome lint → cut release branch → commit → push branch → open PR → wait CI green → merge → tag → cleanup. This list IS the failure surface enumerated in §1. The 12-step is correct AS A LIST OF THINGS THAT NEED TO HAPPEN; it is wrong as A SINGLE FUNCTION THAT DOES THEM ALL SEQUENTIALLY WITHOUT CHECKPOINTS. The decomposition this ADR proposes preserves the list — every one of the 12 steps still happens; they happen in a different topology.
+
+### 8. Why a 4th direction was rejected at scoping
+
+A "fully external" direction — adopt `release-please`, `semantic-release`, or `changesets` wholesale and delete the entire `packages/core/src/release/` tree — was considered at the council scoping phase and rejected. Reasons documented for the audit trail:
+
+- `release-please` (Google) is npm-monorepo-focused and lacks first-class Rust + Python support; CLEO would replicate its decision matrix to ship Cargo crates.
+- `semantic-release` requires Conventional Commits to drive the version bump. CLEO's CalVer is calendar-position-driven, not commit-driven; the impedance mismatch is high.
+- `changesets` (Atlassian) is the closest fit for npm monorepos but assumes contributors run `pnpm changeset` per PR. CLEO's agent-authored workflow does not produce changeset files; back-filling them is more work than ADR-073 Direction B.
+- None of the three give CLEO the provenance graph (audit Q4) for free. The graph schema would still be CLEO-owned.
+
+The scoping decision was: "borrow patterns from these tools (especially changesets' `release-please-manifest`-style summary commit), but do not host the entire pipeline inside one of them." This ADR-073 implements that decision.
+
+---
+
+## Forces / constraints
+
+Twelve forces drive this decision. Each is mapped to the failure modes and conflation evidence above.
+
+| # | Force | Rationale (cite) |
+|---|-------|------------------|
+| F1 | **Hotfix throughput — MTTR < 1 hour from "P0 detected" to "fix shipped"** | T9344 Anthropic OAuth hotfix forced a release on `v2026.5.74` mid-Phase-5; v2026.5.73→v2026.5.74 took >2h because of Failures #1, #6, #8 (forensics §Closing observations). Hermes ships same-day patches as `v<base>.<N>` suffix in ~10 minutes (research §5.4). |
+| F2 | **Provenance integrity — zero orphan commits in releases** | Failure #6 (tag at wrong SHA) corrupted the release_manifest. Operator had to manually `git tag -d && git push origin :refs/tags/<tag>` and retag. Audit Q4: provenance graph is "derivable but not queryable". |
+| F3 | **Project-agnostic — works for npm monorepo, single npm lib, single Rust crate, single Python pkg, Bun pkg** | ADR-053 RELEASE-06 fixture demanded 3 archetypes; ADR-065 regressed to npm+`gh` hard requirement. T1737 adds 5 platform tuples (Linux/macOS/Win, x64/arm64). |
+| F4 | **Resumable mid-flight failures** | Failure #8: `releaseShip` is a 761-line monolith with no checkpoints. Failure #1: wedged git commit leaves indeterminate state with no resume path. Forensics §Cluster 3. |
+| F5 | **Real evidence gates — no theater** | Failure #3: `defaultRunGate` is a no-op stub. Failure #4: IVTR gate's `unchecked` bucket reduces gate to a print statement. ADR-051 already says evidence MUST be programmatic; release must honor that. |
+| F6 | **Tag points at canonical merge commit, never pre-merge SHA** | Failure #6: `gh pr merge --auto` is async; Step 10 polls nothing. Hermes's OCI-revision-label ancestor check (research §3.4) is the gold standard. |
+| F7 | **Child-process supervision — every spawn has a timeout + SIGKILL grace** | Failure #1: `gitCwd` (engine-ops.ts:1497) has no `timeout`; `runGitWithLockRetry` retries only on the stale-lock signature. Forensics §Cluster 1. |
+| F8 | **Governance / pipeline separation — gates BLOCK; pipeline state MUST be unblockable for hotfixes with audited override** | Forensics §"Conflation hypothesis": IVTR mixes governance ("don't ship") with pipeline ("warn and continue"). Same function does both. Audit §Phase 5 Q2: "Both (conflated). Should be observation-only." |
+| F9 | **Operator surface ≤ 4 steps — operator memory budget** | Current CLI has 14 release subcommands (audit §1). Forensics §Failure #8: `release start` is a no-op the operator must still remember. Letta's harness path is exactly 2 operator actions: trigger `prepare-release` workflow → merge the PR. (research §3.4) |
+| F10 | **BRAIN / Task DB SSoT preserved** | ADR-068 (CLEO Database Charter) names 9 DBs with `openCleoDb` as the single chokepoint. Any new tables (release_manifest_commits, releases) MUST flow through the charter (audit §Phase 4). |
+| F11 | **GitOps-compatible — audit trail = git log + DB, never just DB** | Owner-stated invariant: every release MUST be reconstructable from git alone if DB is lost. Hermes commits `RELEASE_v0.13.0.md` to repo root (research §3.7); CLEO currently commits CHANGELOG.md but not per-release artifacts. |
+| F12 | **Backward compatibility with existing `release_manifests` data** | `release_manifests` table has shipped 70+ releases since v2026.4.0. Any schema change MUST migrate forward without losing historical rows. |
+
+Two non-force constraints (out of scope for this ADR but binding on the spec):
+
+- **Constraint N1**: ADR-051 evidence-gate semantics MUST NOT be weakened. The release pipeline consumes evidence; it does not redefine it.
+- **Constraint N2**: ADR-070 three-tier orchestration (Orchestrator → Lead → Worker) MUST remain the only spawn topology. The release pipeline is one of many flows the Orchestrator dispatches; it must compose with `cleo orchestrate spawn` and ADR-062 worktree merge.
+
+---
+
+## Considered directions
+
+This ADR evaluates **exactly three** directions, named for what they do to the current implementation. A fourth direction (fully external — adopt release-please or semantic-release wholesale) was rejected at the council scoping phase and is not evaluated here.
+
+---
+
+### Direction A — Simplify-in-place (harden the 12-step)
+
+**What changes**: keep `releaseShip` as the single canonical release function; surgically fix each cluster without architectural reshape.
+
+- **C1 (process supervision)**: add `timeout: 30_000` to `gitCwd` (engine-ops.ts:1497); wrap `runGitWithLockRetry` in a SIGKILL-on-timeout wrapper; replace `gh pr merge --auto` with poll loop on `gh pr view --json state,mergeCommit` (forensics §F1, F6 suggested invariants).
+- **C2 (gate confusion)**: wire `defaultRunGate` (pipeline.ts:249-262) to the ADR-061 tool resolver; delete `release-manifest.ts:runReleaseGates` in favor of the canonical 5-gate set; make IVTR gate policy explicit (`release.ivtr.policy: "strict"|"opt-in"|"off"` in `.cleo/config.json` — forensics §F4 suggested invariant).
+- **C3 (no resume)**: extend `.cleo/release/handle.json` schema with `{lastCompletedStep, lastError, stepCheckpoints[]}`; add `cleo release ship --resume <version>` reading the handle and dispatching from `lastCompletedStep + 1`.
+- **C4 (env-only enforcement)**: add `.cleo/worktree-policy.json` on-disk artifact the git-shim reads independent of `CLEO_AGENT_ROLE`; extend denylist to include `git push <remote> <local>:<protected-branch>` (forensics §F7).
+- **C5 (hand-maintained registries)**: convert `build.mjs` externals to `.cleo/build-externals.json` + a CI gate (`cleo verify --evidence "tool:externals-sync"`); add `userFacingSummary` + `impact` to task contract (forensics §F9, F10 suggested invariants).
+- **C6 (session counter)**: wire `sessionEnd` to delete `.cleo/audit/session-override-count.<sid>.json`; ban `'global'` sessionId fallback in validation (forensics §F5).
+- **IVTR decoupling**: scope the IVTR check to `--epic <id>` only (audit Priority 1, partial); add explicit `non-blocking` opt-out per task; do NOT remove `task.ivtr_state` column.
+- **Project-agnosticism**: route the publish step through `publish.command` in `.cleo/project-context.json` (already partially in `releasePublish` — pipeline.ts:376-424). Make `gh` requirement gated behind `release.requirePR=true` config.
+
+**Architecture sketch**:
+
+```
+                   ┌──────────────────────────────────┐
+                   │  cleo release ship <version>     │
+                   │  --epic <id> [--resume]          │
+                   └────────────┬─────────────────────┘
+                                │
+                                ▼
+                   ┌──────────────────────────────────┐
+                   │  releaseShip()  (engine-ops.ts)  │
+                   │  HARDENED 12-step monolith        │
+                   │                                  │
+                   │  + step-by-step handle writes    │
+                   │  + child-process timeouts        │
+                   │  + ADR-061 gate-runner injection │
+                   │  + gh pr poll-to-merged          │
+                   │  + on-disk worktree policy       │
+                   └────────────┬─────────────────────┘
+                                │
+            ┌───────────────────┼─────────────────────┐
+            ▼                   ▼                     ▼
+   ┌───────────────┐  ┌──────────────────┐  ┌──────────────────┐
+   │ pipeline.ts   │  │ release-manifest │  │ guards.ts        │
+   │ (4-step)      │  │ (DB)             │  │ (scope-leak fix) │
+   │ STILL parallel│  │ unchanged schema │  │ patched          │
+   └───────────────┘  └──────────────────┘  └──────────────────┘
+```
+
+**LOC delta**: ±100 lines net (defensive depth — ~+400 LOC of new wrappers / config-readers / poll loops; ~-300 LOC of dead branches consolidated). Net: slightly larger.
+
+**Risk**: **★★ (low)** — small surface, every change is localized, no module boundaries shift, no DB schema migration required.
+
+**Operator UX**: **identical** — 14 release subcommands stay, `cleo release ship` still the canonical happy path. `--resume` is the only new flag.
+
+**Provenance**: **minimal upgrade** — handle gains `stepCheckpoints[]` but the deep gap (no `commits` table, no `(task, commit, release)` triples) remains. Audit Q4 still answers "derivable but not queryable".
+
+**What survives from current code**: **~90%**. `releaseShip` body is patched in place; `pipeline.ts`, `guards.ts`, `release-manifest.ts`, `version-bump.ts`, `github-pr.ts`, `engine-ops.ts` all stay. Only `defaultRunGate` (pipeline.ts:249-262) gets a real implementation.
+
+**Migration cost**: ~**1.5 operator-weeks** (one architect-week of patches + half-week of regression testing; no data migration; existing release_manifests rows untouched).
+
+**Hermes-agent alignment**: **2/5** — adopts the timeout discipline (research §3.2 has `timeout: 30_000` per subprocess), the recovery-command-print pattern (§5.1), the same-day suffix idea is *adoptable* (§5.4) — but the monolith stays and `release: published` decoupling is not introduced.
+
+**Letta-code alignment**: **2/5** — does NOT adopt the two-stage prepare-PR-then-release pattern (research §3.4). No `release_bump_only` classifier. No integration smoke test before npm publish.
+
+**T1737 alignment**: **2/5** — `releaseShip` still hardcodes the npm publish path (engine-ops.ts:1480). Adding cargo/twine/bun-publish would require a switch statement inside the monolith; not a clean extension point. Linux arm64 / macOS / Win artifacts would need extra steps grafted on.
+
+**Project-agnostic score**: **3/5** — better than today (ADR-061 wiring closes one gap, `publish.command` works for cargo/twine) but the monolith's structure assumes one publish target. 22 npm packages in CLEO works; adding a Rust crate side-by-side does not.
+
+**Failure-mode coverage**: **9/10** — every failure mode has a patch except Failure #10 partial (CHANGELOG entries get `userFacingSummary` but the architecture still hand-maintains the heuristic).
+
+**Per-failure mapping (Direction A)**:
+
+| Failure | A's remediation | Residual risk |
+|---|---|---|
+| #1 wedged commit | `timeout: 30_000` on every `execFileSync('git', …)` invocation; SIGKILL grace wrapper around `runGitWithLockRetry` | Fixed locally. New invocations added later might still forget the timeout (no enforcement). |
+| #2 epic scope leak | `checkEpicCompleteness` gains an `epicId` arg; results filtered to that epic only | Fixed. `findEpicAncestor` cross-epic walk remains but is now non-load-bearing. |
+| #3 gate runners not wired | `defaultRunGate` calls ADR-061's `resolveToolForProject` resolver | Fixed. `runReleaseGates` parallel registry remains, can drift again. |
+| #4 IVTR non-blocking | `release.ivtr.policy` config; under `strict`, `unchecked` counts as `blocked` | Mitigated, not removed. Default config still `opt-in`; gate is still on the release path. |
+| #5 override cap | `sessionEnd` hook deletes counter file; `'global'` fallback banned | Fixed at session lifecycle layer; behavior change non-load-bearing on release. |
+| #6 tag at wrong SHA | Poll `gh pr view --json state,mergeCommit` after `--auto`; bounded 15-min timeout | Mitigated; race window narrows from minutes to seconds but doesn't disappear. |
+| #7 worker direct-push | `.cleo/worktree-policy.json` on-disk artifact; denylist gains protected-branch push patterns | Mitigated by defense-in-depth, but env-only enforcement remains the primary fence. |
+| #8 release start no-op | Handle gains `lastCompletedStep` field; `releaseShip` reads handle on entry; `--resume` flag added | Mitigated; the two parallel pipelines still exist, just coupled. |
+| #9 esbuild externals | `.cleo/build-externals.json` schema + CI gate diffing it against `package.json` | Fixed. Hand-maintenance moves from `build.mjs` to JSON; sync gate catches drift. |
+| #10 CHANGELOG fragile | Tasks gain `userFacingSummary` + `impact` fields; categorizer respects them | Mitigated. Heuristic-based fallback remains for tasks without the new fields. |
+
+---
+
+### Direction B — Git-flow + GHA wrapper (rebuild as orchestrator over standard tooling)
+
+**What changes**: `cleo release` becomes a **thin opinionated wrapper** that produces a *plan* and pushes the work into standard tooling — `gh`, `git`, `gh actions`, plus optional bridges to `semantic-release` / `release-please` / `changesets`. GitHub Actions does the heavy lifting (gates, build, smoke, publish, tag). CLEO stores the **provenance graph** and serves the **decision surface**.
+
+- **CLI surface collapses from 14 to 4 verbs**:
+  - `cleo release plan <version> --epic <id>` — assembles version, gathers tasks, computes changelog, validates evidence atoms against ADR-051, writes plan to `.cleo/release/<version>.plan.json`. Read-only on git + remote.
+  - `cleo release open <version>` — opens the bump-PR (the Letta `prepare-release.yml` analog) with the plan as PR body. Idempotent.
+  - `cleo release reconcile <version>` — post-merge, post-tag: walks the release-events stream, writes provenance edges to `release_manifest_commits` + `releases`, archives the plan, auto-completes tasks listed in plan.
+  - `cleo release rollback <version> [--full]` — unchanged surface, but implementation now drives the workflow via `gh workflow run rollback.yml`.
+
+- **GHA workflows become the pipeline**:
+  - `release-prepare.yml` (Letta `prepare-release.yml` analog): runs full preflight (`pnpm run check && pnpm run build && pnpm run test`), bumps versions via CLEO's `resolveVersionBumpTargets`, opens the bump-PR. Triggered by `workflow_dispatch` or by `cleo release open`.
+  - `release-ci.yml`: re-runs all gates against the bump-commit. Includes the `release_bump_only` classifier (Letta research §3.4) to skip heavy paths when the PR touches only manifests + CHANGELOG.
+  - `release-publish.yml` (Letta `release.yml` analog): triggers on push to main with subject matching `^release: ship v`. Re-runs lint+typecheck+build+integration smoke; tags from `${{ github.sha }}` (the merged main commit — fixes Failure #6 by construction); calls `cleo release reconcile <version>` over `gh api` to write provenance; publishes to npm / cargo / pypi / bun via the **per-platform publisher matrix**.
+  - `release-rollback.yml`: implements `rollback-full` server-side.
+
+- **Hermes mechanics adopted directly**: dual CalVer + SemVer (research §3.1), annotated tag with structured message (§3.3), `release: published` fan-out for downstream (§3.3), OCI-revision-label ancestor check for floating tags (§3.4), same-day `.N` suffix (§5.4), supply-chain audit on PR diffs (§3.10).
+
+- **Letta mechanics adopted directly**: two-stage prepare-PR-then-release (research §3.4), `release_bump_only` classifier (§3.4 sub-section), integration smoke test using a real API key from `secrets.CLEO_RELEASE_TEST_KEY` (§3.4 step 4), `environment: cleo-publish` GitHub Environments with required reviewers (§3.4 step 7), `softprops/action-gh-release@v2` with `generate_release_notes: true` and artifact attachment.
+
+- **IVTR decoupled per audit Priority 1**: release gates are evidence-only (ADR-051 atoms re-validated on `reconcile`); `task.ivtr_state` becomes a read-only derived view over the evidence atoms (audit §Phase 6 streamlining sketch).
+
+- **Provenance graph implemented (audit Priority 3)**: new tables `releases` + `release_manifest_commits` + view `release_provenance` (audit §Recommendations). Edges written by `reconcile` from git log + plan.json + evidence atoms.
+
+- **Process supervision**: locally, the only spawned subprocesses are `git status`, `git log`, `gh pr view --json`, `gh workflow run`. Each gets `timeout: 30_000` and SIGKILL grace. The heavy work (build, test, publish) runs in GHA — which has its own per-step timeouts and is observable via `gh run watch`.
+
+- **T1737 platform matrix**: `release-publish.yml` becomes a build matrix (`strategy.matrix.platform: [linux-x64, linux-arm64, macos-x64, macos-arm64, windows-x64]`). Each matrix slot produces a platform-tagged artifact attached to the GitHub Release.
+
+**Architecture sketch**:
+
+```
+                    ┌──────────────────────────────────────┐
+                    │  cleo release plan / open / reconcile│
+                    │  (≤ 4 verbs · read-mostly local)     │
+                    └────────────┬─────────────────────────┘
+                                 │ writes .cleo/release/<v>.plan.json
+                                 │ + reads ADR-061 tool resolver
+                                 │ + reads ADR-051 evidence atoms
+                                 ▼
+                    ┌──────────────────────────────────────┐
+                    │  release-prepare.yml (GHA)           │  ←─ cleo release open
+                    │  preflight gates · bump-PR open      │
+                    └────────────┬─────────────────────────┘
+                                 │
+                                 ▼  (human review + merge)
+                    ┌──────────────────────────────────────┐
+                    │  release-publish.yml (GHA)           │  ←─ trigger: push main
+                    │  matrix [linux/mac/win × x64/arm64]  │       commit subject regex
+                    │  re-gates · build · smoke · publish  │
+                    │  tag from $GITHUB_SHA · gh release   │
+                    └────────────┬─────────────────────────┘
+                                 │ release: published event
+                                 ▼
+                    ┌──────────────────────────────────────┐
+                    │  cleo release reconcile (called via  │  ←─ called via gh api
+                    │  gh api dispatch from publish job)   │
+                    │  writes provenance graph rows        │
+                    │  auto-completes tasks                 │
+                    └────────────┬─────────────────────────┘
+                                 │
+                                 ▼
+                    ┌──────────────────────────────────────┐
+                    │  release-fanout.yml (GHA)            │  ←─ release: published
+                    │  docs deploy · sentinel notify       │
+                    │  (decoupled · async · best-effort)   │
+                    └──────────────────────────────────────┘
+
+DB:    releases    release_manifest_commits    task_relations    release_provenance (view)
+       (new)       (new)                       (existing)        (new)
+```
+
+**LOC delta**: **-1500 / +400 net = -1100 lines**. Deletions: `engine-ops.ts:releaseShip` (~760 LOC), `release-manifest.ts:runReleaseGates` + the duplicated gate plumbing (~300 LOC), `pipeline.ts:defaultRunGate` + child-audit stubs (~80 LOC), IVTR auto-suggest + release-side IVTR gate (~150 LOC, audit Leaks #1, #2, #4). Additions: 4-verb CLI handlers (~150 LOC), provenance-graph writer in `reconcile` (~120 LOC), 4 GHA workflow files (~600 lines of YAML, not LOC). Net code reduction is the largest of any direction.
+
+**Risk**: **★★★ (medium)** — moves logic to GHA, which is a different operational surface; the team must own workflow YAML alongside TypeScript. Mitigated by Hermes/Letta both running this pattern in production; not novel territory.
+
+**Operator UX**: **3-step happy path** — `cleo release plan v2026.X.Y --epic T####`, `cleo release open v2026.X.Y` (which is a single `gh workflow run release-prepare.yml`), `gh pr merge` once review is complete. **No `release ship` invocation**. Hotfix: same 3 steps; the suffix mechanism (`v2026.X.Y.2`) is computed in `plan`. Resume: re-run the workflow with `workflow_dispatch` — GHA handles idempotency.
+
+**Provenance**: **rich** — `release_provenance` SQL view (audit §Recommendations) answers "which bugs shipped in v2026.X.Y" with one query. Every release commit carries `T#### (#PR)` trailers (Letta convention). Git log + DB are dual sources of truth.
+
+**What survives from current code**: **~30%**. `version-bump.ts` (`resolveVersionBumpTargets`), `changelog-writer.ts`, `release-manifest.ts:listManifestReleases` + `showManifestRelease`, `invariants/registry.ts`, `release-config.ts`, the validators, the test suite for guards. Most of `engine-ops.ts:releaseShip` is deleted; some helpers (`detectBranch`, `runGitWithLockRetry`) survive in a much smaller surface.
+
+**Migration cost**: ~**4 operator-weeks** (one architect-week of design + 1.5 weeks of workflow authoring + 0.5 week of CLI rewrite + 1 week of regression testing + dogfooding on a non-critical release).
+
+**Hermes-agent alignment**: **5/5** — adopts all 8 Tier-1 mechanics (research §6). The release-as-script (Hermes) → release-as-workflow (CLEO via GHA) is a one-step generalization.
+
+**Letta-code alignment**: **5/5** — verbatim adoption of the two-stage prepare-PR-then-release pattern + `release_bump_only` classifier + integration smoke + Environments gate (research §3.4).
+
+**T1737 alignment**: **5/5** — GHA matrix gives multi-platform builds for free. Each platform slot produces a tagged artifact; `release-publish.yml` attaches all five to the GitHub Release. Pi adapter consumes the linux-arm64 artifact.
+
+**Project-agnostic score**: **5/5** — CLI surface speaks `plan/open/reconcile/rollback` in any language. Per-platform publisher matrix swaps `npm publish` for `cargo publish` / `twine upload` / `bun publish` per target. ADR-053 RELEASE-06 fixture passes by construction. ADR-061 tool resolver is the only gate runner.
+
+**Failure-mode coverage**: **10/10** — every failure is structurally prevented:
+- #1 wedged commit → gone (`git commit` happens once in `release-prepare.yml` with built-in workflow timeout).
+- #2 epic scope leak → gone (`plan` carries explicit `--epic` and writes the scope to plan.json; `reconcile` reads from plan).
+- #3 gate runners not wired → gone (ADR-061 resolver is the only path).
+- #4 IVTR non-blocking → gone (IVTR removed from release path; audit Priority 1).
+- #5 override cap → gone (no `--force` on `plan`/`open`/`reconcile`; overrides only at the evidence-atom layer where ADR-051 already audits them).
+- #6 tag at wrong SHA → gone (tag created in workflow from `$GITHUB_SHA` after merge).
+- #7 worker direct-push → mitigated by GitHub branch protection + the on-disk worktree policy added as a side-quest.
+- #8 release start no-op → gone (no `start`; `plan` is explicit and idempotent).
+- #9 esbuild externals → caught by `release-prepare.yml` preflight running `pnpm run build` BEFORE opening the PR.
+- #10 CHANGELOG → uses `softprops/action-gh-release@v2` `generate_release_notes` + `cleo release plan` emits a human-curated summary into PR body (no more 150-char-truncated RCASD wall-of-text).
+
+**Per-failure mapping (Direction B)**:
+
+| Failure | B's remediation | Why structural (not patch) |
+|---|---|---|
+| #1 wedged commit | `git commit` is a single step inside `release-prepare.yml` with GHA-native step timeout (`timeout-minutes`) | The CLEO process never spawns the long-running git commit. The workflow runner enforces timeouts; CLEO cannot forget. |
+| #2 epic scope leak | `plan` writes `epicId` into the plan file; `reconcile` reads from the plan. `checkEpicCompleteness` consumes plan.json, not derived ancestors | Scope is explicit data, not implicit graph traversal. The bug class disappears. |
+| #3 gate runners not wired | `cleo verify --gate X --evidence tool:Y` (ADR-061) is the only gate path. The release-side `runReleaseGates` parallel registry is deleted. | One gate runner can't disagree with itself. |
+| #4 IVTR non-blocking | IVTR removed from release path. Evidence atoms re-validate at reconcile time. | If a force isn't on the path, it can't be skipped. |
+| #5 override cap | No `--force` on any of the 4 verbs. Overrides happen at `cleo verify` evidence-atom layer where ADR-051 already audits to `force-bypass.jsonl`. | The override surface contracts to one well-audited place. |
+| #6 tag at wrong SHA | Tag is `git tag $TAG $GITHUB_SHA` in `release-publish.yml`, gated on `gh pr view --json state == MERGED`. | GitHub Actions runs after the merge is observable on remote. No race. |
+| #7 worker direct-push | Server-side: GitHub branch protection. Client-side: ADR-073 retains the worktree-policy file as T9345-CHILD-7. | Defense in depth; both layers must fail simultaneously. |
+| #8 release start no-op | No `start`. `plan` writes `.cleo/release/<version>.plan.json` and that file IS the resumable state. | One state file, one canonical source. |
+| #9 esbuild externals | `release-prepare.yml` preflight runs `pnpm run build` before opening the PR; failure blocks the PR. | The bundling failure is caught BEFORE the version bump exists in main. |
+| #10 CHANGELOG fragile | `softprops/action-gh-release@v2` `generate_release_notes: true` + plan-file's `userFacingSummary` (authored by `plan` from task `kind` + `impact`) | Auto-generation works on commit subjects (which CLEO controls via T#### conventional commits); RCASD-task verbose descriptions are not the source. |
+
+**Implementation detail — the four CLI verbs in pseudocode**:
+
+```
+# plan: idempotent, read-mostly, writes plan file
+$ cleo release plan v2026.6.0 --epic T9999
+  → resolveVersion(scheme=calver, candidate=v2026.6.0) → 'v2026.6.0' or 'v2026.6.0.2'
+  → gather ADR-051 evidence atoms for all tasks under T9999
+  → check epic completeness scoped to T9999 (no cross-epic walk)
+  → assemble CHANGELOG draft from `git log <prevTag>..HEAD` + task data
+  → write .cleo/release/v2026.6.0.plan.json
+  → emit summary table to stdout
+
+# open: side-effectful, calls gh workflow run
+$ cleo release open v2026.6.0
+  → reads .cleo/release/v2026.6.0.plan.json
+  → gh workflow run release-prepare.yml --field version=v2026.6.0 --field plan=<plan-blob>
+  → prints workflow run URL
+  → polls run status until "In progress" or "Completed"
+
+# reconcile: invoked from release-publish.yml; writes provenance graph
+$ cleo release reconcile v2026.6.0
+  → reads .cleo/release/v2026.6.0.plan.json
+  → reads `gh release view v2026.6.0 --json tagName,publishedAt,body,assets`
+  → INSERT INTO releases (...) VALUES (...)
+  → for each commit in `git log <prevTag>..v2026.6.0`:
+      INSERT INTO release_manifest_commits (release_id, commit_sha, task_id, ...)
+  → for each task in plan.tasks:
+      mark task.releasedIn = 'v2026.6.0'
+      cleo memory observe --title "Released v2026.6.0" --type decision
+  → archive plan file to .cleo/release/archive/
+
+# rollback: thin wrapper over release-rollback.yml
+$ cleo release rollback v2026.6.0 [--full]
+  → gh workflow run release-rollback.yml --field version=v2026.6.0 --field mode=full
+  → emit reconciled rollback marker into provenance graph
+```
+
+**GHA workflow contract detail**:
+
+- `release-prepare.yml`: triggers on `workflow_dispatch` with `version` input. Runs preflight (lint+typecheck+build+test) on `main`, applies version bump via `cleo version-bump --version $VERSION`, commits as `release: prepare v$VERSION`, opens PR with body = plan.json content. Output: PR URL.
+- `release-publish.yml`: triggers on `push: main, paths: [package.json, packages/*/package.json, Cargo.toml, packages/*/Cargo.toml]`. Detects subject `^release: prepare v` via `git log --format=%s "${{ github.event.before }}..${{ github.sha }}"` (Letta pattern). If matched, runs platform matrix; each matrix slot runs gates + smoke + publishes. After all matrix slots succeed, single `tag` job tags from `$GITHUB_SHA`, creates GitHub Release, invokes `cleo release reconcile`.
+- `release-fanout.yml`: triggers on `release: published`. Decoupled from publish. Handles docs deploy, sentinel notify, Docker image retag.
+- `release-rollback.yml`: triggers on `workflow_dispatch`. Implements rollback-full server-side: delete remote tag, revert merge commit, deprecate npm package, write rollback marker to provenance graph.
+
+---
+
+### Direction C — Extract to standalone CLI (`@cleocode/release-tool`)
+
+**What changes**: pull `packages/core/src/release/*` into a new top-level package `packages/release-tool/` (later promotable to `@cleocode/release-tool` as its own npm binary). Expose a CLI binary `release` independent of `cleo`. Make `cleo release` a thin consumer that imports `@cleocode/release-tool` and adapts CLEO's BRAIN/Task DB into the tool's storage adapter.
+
+- **Package boundary**: new package per AGENTS.md Package-Boundary Check.
+  - `packages/release-tool/src/` — pure release logic, no `@cleocode/core` import.
+  - `packages/release-tool/src/adapters/` — storage adapter interface (read tasks, write manifests). CLEO ships `packages/release-tool/adapters/cleo.ts` that wraps `getTaskAccessor`, `openCleoDb`, `releaseManifests`. A reference `adapters/filesystem.ts` writes to `.release/manifests/*.json` for projects without CLEO.
+  - `packages/release-tool/src/gates/` — gate-runner interface. CLEO ships `gates/cleo-evidence.ts` that calls `cleo verify --gate X --evidence Y`. Reference `gates/exec.ts` runs raw subprocesses.
+  - `packages/cleo/src/cli/commands/release.ts` — collapses to ~50 lines, mostly arg parsing + delegation.
+
+- **Two binaries on user PATH**: `cleo` (task + orchestration) and `release` (shipping). Owner runs `release ship v2026.X.Y --epic T####` directly when in a CLEO project; `cleo release ship` still works as an alias that auto-fills the adapter.
+
+- **Same 12-step lifecycle inside `release-tool`**, but each step is a named exported function + can be invoked individually (`release step gate-check`, `release step open-pr`, …). Resume is built-in because each step writes its own state into the adapter.
+
+- **IVTR decoupling**: `release-tool` has no concept of IVTR. The CLEO adapter optionally surfaces "task has non-empty `ivtr_state` and currentPhase != 'released'" as a *blocker reason* for the gate-check step, but the tool itself is IVTR-blind.
+
+- **Provenance graph**: `release-tool` defines a portable schema (`releases`, `release_manifest_commits`, `release_task_links`); the CLEO adapter materializes these as SQLite tables via `openCleoDb` (ADR-068 chokepoint). Non-CLEO consumers get JSON files.
+
+- **GHA bindings optional**: `release-tool` can run as a local CLI (the Hermes-style script) OR as the engine inside GHA workflows. Each surface is supported.
+
+**Architecture sketch**:
+
+```
+                     ┌─────────────────────────────────────┐
+                     │  release  (new top-level binary)    │
+                     │  release  ship/plan/open/reconcile  │
+                     │  release  step <name>               │
+                     │  release  rollback                   │
+                     └──────────────────┬──────────────────┘
+                                        │
+                                        ▼
+                     ┌─────────────────────────────────────┐
+                     │  @cleocode/release-tool             │
+                     │  (new package; no @cleocode/core    │
+                     │   import; tested in isolation)      │
+                     │                                     │
+                     │  ┌────────────┐    ┌─────────────┐  │
+                     │  │ pipeline   │    │ gates iface │  │
+                     │  │ (12 steps  │◄───┤             │  │
+                     │  │  each      │    │             │  │
+                     │  │  exported) │    │             │  │
+                     │  └─────┬──────┘    └─────────────┘  │
+                     │        │                            │
+                     │        ▼                            │
+                     │  ┌────────────────┐                 │
+                     │  │ storage iface  │                 │
+                     │  └────────┬───────┘                 │
+                     └───────────┼─────────────────────────┘
+                                 │
+                       ┌─────────┴─────────┐
+                       ▼                   ▼
+              ┌─────────────────┐  ┌─────────────────┐
+              │ cleo adapter    │  │ fs adapter      │
+              │ (BRAIN+tasks.db)│  │ (.release/*.json)│
+              └─────────┬───────┘  └─────────────────┘
+                        │
+                        ▼
+              ┌──────────────────┐
+              │ cleo CLI         │
+              │ (cleo release X  │
+              │  is now alias)   │
+              └──────────────────┘
+```
+
+**LOC delta**: **+200 net**. Mostly boilerplate: package skeleton, adapter interfaces, storage abstraction, dual binary entrypoints. Underlying logic is preserved (~85% of `releaseShip` body moves wholesale into `packages/release-tool/src/pipeline.ts`). The 12-step monolith is *decomposed* into 12 functions but stays inside the new package.
+
+**Risk**: **★★★★ (higher)** — introduces a new package boundary with its own publish surface (`@cleocode/release-tool` on npm), CI matrix, versioning, and docs. The "two binaries on PATH" UX has known sharp edges (which one wins when both are installed?). Adapter contract must be stable from v1; breaking it cascades to all consumers.
+
+**Operator UX**: **two binaries** — `cleo` and `release`. Inside a CLEO project, `cleo release ship` and `release ship` are equivalent. Outside a CLEO project, only `release ship --adapter filesystem` works. Doubles the surface area to teach.
+
+**Provenance**: **partial** — `release-tool` defines a portable schema, but CLEO's richer "task → epic → feature → bug → hotfix" graph lives in `tasks.db`. The adapter must replicate the relevant subset into the tool's schema OR proxy queries back. Either way, **double-bookkeeping** is the steady state. Audit Q4's "queryable provenance" goal is reached for `release-tool`'s own tables but bridging back to BRAIN/Tasks requires writing dedicated joins.
+
+**What survives from current code**: **~85%** — every function in `packages/core/src/release/*` moves (largely unchanged) into `packages/release-tool/src/*`. Behavior at runtime is preserved; structure changes.
+
+**Migration cost**: ~**6 operator-weeks** (one week of package extraction + 1.5 weeks of adapter design + 1.5 weeks of CLI dual-binary engineering + 1 week of cleo→release-tool integration + 1 week of regression and dogfood). Higher than Direction B despite less behavior change because the package boundary is load-bearing.
+
+**Hermes-agent alignment**: **3/5** — the standalone `release` binary IS the "release.py" pattern (research §3.2). But CLEO's two-binary topology is heavier than Hermes's single script.
+
+**Letta-code alignment**: **2/5** — does NOT structurally adopt the two-stage prepare-then-release. Could be layered on, but the package boundary is the wrong abstraction for that pattern.
+
+**T1737 alignment**: **3/5** — multi-platform is achievable by making the publisher pluggable in `release-tool`, but the package itself needs to ship platform-specific build artifacts. Going through GHA (Direction B) is still required for the matrix; this direction adds a layer rather than solving the problem.
+
+**Project-agnostic score**: **5/5** — by design. The filesystem adapter proves portability; the CLEO adapter is just one consumer. ADR-053 RELEASE-06 passes by construction.
+
+**Failure-mode coverage**: **7/10** — Failures #1, #6, #7, #8 are addressed by decomposition + resume; Failures #3, #4 (gates) are addressed only IF the adapter wires ADR-061 (a contract that can be violated by future adapters); Failures #2, #5, #9, #10 are addressed at the same level as Direction A — by patches inside the tool.
+
+**Per-failure mapping (Direction C)**:
+
+| Failure | C's remediation | Coverage class |
+|---|---|---|
+| #1 wedged commit | Decomposed step (`release step commit`) gets explicit timeout | Fixed locally |
+| #2 epic scope leak | Adapter passes explicit `epicId`; tool itself is scope-aware | Fixed by interface contract |
+| #3 gate runners not wired | Tool's gate interface is the contract; CLEO adapter wires ADR-061 | Adapter-dependent (future adapter can regress) |
+| #4 IVTR non-blocking | Tool has no IVTR; CLEO adapter optionally surfaces it as a "blocker reason" | Adapter-dependent |
+| #5 override cap | Tool has no `--force`; overrides happen at evidence-atom layer | Fixed by interface contract |
+| #6 tag at wrong SHA | Same local poll-loop as Direction A | Mitigated, not eliminated |
+| #7 worker direct-push | Tool-agnostic; CLEO's worktree shim is unchanged | No change from today |
+| #8 release start no-op | Each step has its own state file in the tool's storage | Fixed by decomposition |
+| #9 esbuild externals | Tool calls adapter's `prebuild` hook; CLEO adapter runs `pnpm run build` | Adapter-dependent |
+| #10 CHANGELOG fragile | Same heuristic-based fallback as Direction A | Mitigated |
+
+---
+
+## Trade-off matrix
+
+| Force | A — Simplify-in-place | B — Git-flow + GHA wrapper | C — Standalone `@cleocode/release-tool` |
+|---|---|---|---|
+| **F1 — Hotfix MTTR < 1h** | ⚠️ (resumable monolith helps but `--force` cap still binary) | ✅ (same-day suffix + workflow rerun ≤ 10 min) | ⚠️ (decomposed steps help but operator must learn 2 binaries) |
+| **F2 — Provenance integrity** | ⚠️ (handle gains checkpoints; no `commits` table) | ✅ (`releases` + `release_manifest_commits` view + git trailers) | ⚠️ (queryable in tool; double-bookkeeping vs BRAIN) |
+| **F3 — Project-agnostic (3+ archetypes)** | ⚠️ (publish via `publish.command`; gh hardcode lingers) | ✅ (per-platform matrix; ADR-061 sole gate path) | ✅ (filesystem adapter by design) |
+| **F4 — Resumable mid-flight** | ✅ (`--resume <version>` via handle) | ✅ (workflow rerun; idempotent step flags per Letta §3.4) | ✅ (`release step <name>` decomposition) |
+| **F5 — Real evidence gates** | ✅ (wires `defaultRunGate` to ADR-061) | ✅ (ADR-061 is the only path; no parallel registries) | ⚠️ (depends on adapter; future adapters can regress) |
+| **F6 — Tag at canonical merge commit** | ⚠️ (poll loop after `gh pr merge --auto`; race window narrowed not eliminated) | ✅ (tag created from `$GITHUB_SHA` in workflow; race gone by construction) | ⚠️ (same as A; tag step still local) |
+| **F7 — Child-process supervision** | ✅ (`timeout` on every `execFileSync`) | ✅ (locally minimal subprocesses; workflow timeouts handle the rest) | ✅ (helpers preserved + timeouts added) |
+| **F8 — Governance / pipeline separation** | ⚠️ (IVTR partial-decouple; conflation softened not removed) | ✅ (IVTR removed from release path per audit Priority 1) | ⚠️ (release-tool is IVTR-blind; cleo adapter still embeds IVTR check optionally) |
+| **F9 — Operator surface ≤ 4 steps** | ❌ (14 release subcommands stay) | ✅ (4 verbs: plan / open / reconcile / rollback) | ❌ (two binaries doubles the surface) |
+| **F10 — BRAIN/Task DB SSoT** | ✅ (no schema migration) | ✅ (new tables flow through `openCleoDb` chokepoint per ADR-068) | ⚠️ (tool defines its own tables; adapter syncs back) |
+| **F11 — GitOps-compatible** | ⚠️ (still DB-primary; no per-release artifact committed) | ✅ (`generate_release_notes` writes to git; Hermes-style `RELEASE_v*.md` adoptable as side-quest) | ⚠️ (depends on adapter) |
+| **F12 — Backcompat `release_manifests`** | ✅ (no schema change) | ✅ (new tables additive; existing rows preserved) | ⚠️ (data lives in two places during migration) |
+| **Subtotal — ✅** | 4 | **10** | 4 |
+| **Subtotal — ⚠️** | 7 | 2 | 7 |
+| **Subtotal — ❌** | 1 | 0 | 1 |
+
+**Direction B is the clear winner on the forces matrix — 10 forces fully satisfied versus 4 each for A and C.**
+
+### Matrix interpretation notes
+
+The matrix is not naive vote-counting. A few cells deserve explicit discussion because they encode trade-offs that voting hides:
+
+- **F9 (operator surface ≤ 4 steps) is the only force where A and C both fail.** This is the operator-experience axis. Direction A keeps 14 subcommands because patching in-place preserves backward compatibility — which is itself a kind of operator-experience win in the short term. The matrix scores A as ❌ on F9 because the *long-term* operator load is the metric; today's operators have already memorized 14 subcommands but every new operator (and every agent that has to learn the surface) pays the full cost. The owner explicitly flagged this in the T9345 charter as a blocker.
+
+- **F1 (hotfix MTTR) shows ⚠️ for A and C and ✅ for B.** A's resumable monolith narrows the MTTR window (no rollback-full needed mid-pipeline) but the binary `--force` is still the only escape hatch when gates fail in a P0 hotfix. B's workflow rerun + `release_bump_only` classifier + same-day suffix gives a tight ≤10-minute hotfix path. C's decomposition helps but the operator must still pick the right `release step <name>` and chain them — slower than a single `gh workflow run release-prepare.yml --field version=...`.
+
+- **F6 (tag canonical merge commit) is the most dramatic axis.** This is the failure that bit production (v2026.5.74 anchor session). A and C both narrow the race window via polling but cannot eliminate it because the local clock and the remote clock are still independent. B eliminates the race by construction — `git tag $GITHUB_SHA` inside the workflow runs *after* GitHub has applied the merge; `$GITHUB_SHA` is the merge commit by definition.
+
+- **F10 (BRAIN/Task DB SSoT) flips from ✅ to ⚠️ for C.** This is the "package boundary tax" — once `@cleocode/release-tool` becomes its own package with its own storage adapter interface, the BRAIN data and the tool's data live in two places by definition. Even when the CLEO adapter is the only adapter in use, the in-memory model has two representations: the BRAIN-shaped one (`tasks`, `task_relations`, `brain_decisions`) and the tool-shaped one (`releases`, `release_manifest_commits`, `release_task_links`). Drift becomes a maintenance burden.
+
+- **F11 (GitOps-compatible) shows ⚠️ for both A and C.** Neither direction inherently commits per-release artifacts to git. Direction B's adoption of `generate_release_notes` writes notes to the GitHub Release object; if CLEO additionally adopts Hermes's `RELEASE_v0.13.0.md`-into-repo pattern (research §3.7), the git log becomes self-documenting and survives DB loss. This is a side-quest under T9345-CHILD-6 but is structurally easier under B because the GHA workflow can `gh release download` and commit the notes.
+
+### Why the failure-mode coverage scores differ
+
+Failure coverage scores (Direction A: 9/10, B: 10/10, C: 7/10) are NOT identical to force-satisfaction scores. A direction can fix all the failures and still fail forces (e.g., A fixes 9 failures but fails F8 because IVTR is still on the release path). A direction can leave failures partially mitigated and still excel on forces (B has trivial residual risk on F7 by relying on GitHub branch protection, but the structural prevention of #1, #6, #8 makes the residual acceptable).
+
+The two scores are complementary: failure coverage shows "did we kill the bugs that bit us?", forces show "did we kill the architectural disease that produced the bugs?". A direction can score high on the former and low on the latter (whack-a-mole patching); the matrix shows B leads on both.
+
+---
+
+## Decision
+
+**This ADR adopts Direction B (Git-flow + GHA wrapper) with one major qualifier borrowed from Direction C: the release pipeline's *core algorithmic logic* (gate sequencing, version bumping, changelog assembly, manifest writing, provenance edge construction) MUST live in a single, in-process, importable module within `packages/core/src/release/` — explicitly NOT a separate npm package — so that BOTH the CLI (`cleo release plan/open/reconcile`) AND the GHA workflows (`release-prepare.yml`, `release-publish.yml`) call into the same TypeScript code via `cleo release <verb> --json`. The GHA workflows orchestrate the *outer state machine*; CLEO owns the *inner decisions*.**
+
+The chosen direction implements RFC 2119 normative behavior as follows:
+
+1. The release pipeline MUST expose exactly **four operator verbs** at the CLEO CLI surface: `plan`, `open`, `reconcile`, `rollback`. All other current subcommands (`start`, `verify`, `publish`, `ship`, `list`, `show`, `cancel`, `changelog`, `pr-status`, `rollback-full`, `channel`) MUST be deprecated, mapped to compatibility shims that forward to the four canonical verbs, and removed in a subsequent major version.
+2. The 12-step ship monolith (`packages/core/src/release/engine-ops.ts:releaseShip`) MUST be deleted. Its surviving algorithmic content MUST be redistributed across: `plan.ts` (steps 0-4, read-only), `open.ts` (steps 5-7, opens the bump-PR), and `reconcile.ts` (steps 10-12, runs after `release-publish.yml` merges main and tags). Steps 8-9 (CI wait, merge) MUST move entirely into `release-publish.yml`.
+3. The parallel 4-step pipeline (`packages/core/src/release/pipeline.ts:releaseStart/Verify/Publish/Reconcile`) MUST be deleted. Its handle (`.cleo/release/handle.json`) MUST be replaced by `.cleo/release/<version>.plan.json`, which is the single resumable state file written by `plan` and consumed by `open`/`reconcile`.
+4. The IVTR gate (`engine-ops.ts:1252-1295`, `engine-ops.ts:475-556`) MUST be removed from the release path. Release validation MUST consult only ADR-051 evidence atoms via the ADR-061 tool resolver. `task.ivtr_state` SHALL persist as a read-only derived view over evidence atoms for backward compatibility but MUST NOT block any release operation.
+5. Tag creation MUST occur exclusively inside `release-publish.yml` at `$GITHUB_SHA` after the bump-PR merge has been confirmed via `gh pr view --json state,mergeCommit`. Local `cleo` MUST NOT create or push tags.
+6. The provenance graph (audit §Recommendations P3) MUST be implemented as three new entities flowing through the ADR-068 `openCleoDb` chokepoint: a `releases` table, a `release_manifest_commits` table, and a `release_provenance` SQL view. `reconcile` MUST write these rows; failure to write them MUST fail reconciliation.
+
+### Justification (≤ 500 words)
+
+The trade-off matrix is unambiguous: Direction B satisfies 10 of 12 forces fully and 0 fails. The three strongest forces that drove the choice are:
+
+**F3 (project-agnostic) is the foundational promise of ADR-053 that the current implementation has regressed.** Direction A patches the regression but does not architect away the next regression — the next time someone adds a npm-specific assumption, the monolith absorbs it. Direction B routes every project-specific concern (build, test, lint, typecheck, publish) through the ADR-061 tool resolver and the GHA matrix, making the regression structurally impossible. Direction C achieves the same portability score by extraction, but at the cost of doubling the operator surface (F9).
+
+**F8 (governance/pipeline separation) is the conflation diagnosis the wave-1 audit scored at 7/10.** The forensics doc demonstrates that IVTR's `unchecked` bucket reduces a "gate" to a warning (Failure #4), that two parallel gate systems disagree (Failure #3), and that the override cap is bypassed routinely (Failure #5). These are not patchable in place — they are symptoms of one function (`releaseShip`) doing both governance and pipeline. Direction B separates them at the architectural level: `cleo release plan` is governance (read evidence, decide if shippable); `release-prepare.yml` and `release-publish.yml` are pipeline (do the work, idempotently, with workflow-native timeouts). Direction A softens the conflation; Direction C relocates it.
+
+**F9 (operator surface ≤ 4 steps) is the unforced loss of the current system.** 14 release subcommands is more than the operator can hold; ADR-065's 12-step ship pipeline plus 4-step canonical pipeline is the apex symptom (Failure #8 — operator never knows which to run). Direction B collapses to 4 verbs that map 1:1 to operator intent: "decide what to ship" / "open the gate" / "record what shipped" / "undo". Direction A keeps 14. Direction C splits 14 across two binaries, making it 14+ effectively.
+
+**What we give up by NOT picking the others:**
+
+- *Not picking A*: we forgo the 1.5-operator-week ship time. Direction B's 4-week migration is 2.7× more expensive. We also give up the "no DB schema migration" comfort. The cost is justified by the 10-vs-4 force coverage; the alternative is shipping fixes today and re-doing the architecture in 6 months.
+
+- *Not picking C*: we forgo full standalone reusability. `@cleocode/release-tool` would be valuable as a community asset, but the marginal portability win above Direction B (which is already 5/5 project-agnostic via adapters in `.cleo/project-context.json`) does not justify the operator-UX tax of dual binaries (F9) or the BRAIN/Tool double-bookkeeping (F10). If standalone extraction becomes desirable later, Direction B's in-process module is the natural source.
+
+The qualifier ("core algorithmic logic stays in-process; GHA owns the outer state machine") explicitly hybridizes B with the strongest Direction-C idea — a clean module boundary — without paying Direction C's package-boundary tax.
+
+### The qualifier in concrete terms
+
+The qualifier exists because pure-Direction-B has a subtle risk: if all release logic moves into GHA YAML, the codebase loses the type-safe, unit-testable layer that today's `packages/core/src/release/*` provides. YAML is not TypeScript; YAML errors fail at runtime, not at `pnpm run typecheck`. The qualifier addresses this by mandating that the **decisions** (what version, what tasks, what changelog, what gates, what provenance edges) stay in TypeScript and are invoked from the workflows as `cleo release plan --json`, `cleo release reconcile --json`. The workflows only know how to: spawn `cleo release …`, parse JSON output, gate next-step on success, run the platform-matrix build, attach artifacts, fan out events. This separates *what to ship* (TypeScript, testable) from *how to deliver the act of shipping* (YAML, GHA-native).
+
+In effect, the qualifier turns `packages/core/src/release/` into a CLI-callable library that has TWO consumers:
+1. Operators running `cleo release plan/open/reconcile` from a terminal.
+2. GHA workflows invoking `cleo release …` as a step.
+
+Both consumers see identical behavior because they call the same code through the same envelope. The workflow YAML stays minimal (≈100-150 lines per file); the TypeScript stays testable.
+
+### How the decision interacts with the rest of CLEO
+
+ADR-073 changes only the release pipeline. It does NOT change:
+- ADR-051 (evidence gates) — preserved as the sole gate runner.
+- ADR-061 (verify-tool resolution) — preserved as the sole tool resolver.
+- ADR-062 (worktree merge) — preserved; bump-PRs follow the same `merge --no-ff` provenance.
+- ADR-065 (PR-required flow) — preserved; reinforced (no direct push possible because no `cleo` verb pushes).
+- ADR-068 (database charter) — extended (3 new entities through chokepoint).
+- ADR-070 (three-tier orchestration) — preserved; release is one of many flows the Orchestrator dispatches.
+- BRAIN integration — preserved; `cleo memory observe` calls migrate verbatim.
+
+It DOES change:
+- ADR-053 — fulfills the original promise (project-agnostic across 3+ archetypes).
+- ADR-063 — supersedes the 4-step canonical pipeline (the four new verbs are richer).
+- The release CLI surface — collapses 14 → 4 verbs.
+- The IVTR system — removed from the release path per audit Priority 1; remains as a read-only derived view.
+
+### Concrete decision: what gets built
+
+In RFC 2119 terms (the only place this ADR uses normative MUST/SHALL language):
+
+The CLEO project MUST adopt Direction B + qualifier as the canonical release architecture starting with the T9345 spec-deliverable phase (wave-3 RCASD). The implementation MUST proceed in the four phases enumerated under *Consequences → Migration* below. The implementation team MUST NOT introduce additional release-related CLI verbs beyond the four canonical ones (`plan`, `open`, `reconcile`, `rollback`) without an ADR amendment. The release pipeline MUST treat ADR-051 evidence atoms as the only gate-execution surface; any release-time gate that wishes to block MUST express itself as an evidence-atom requirement, not as a parallel registry. Provenance MUST be recorded via the three new database entities, written by `reconcile`, on every successful release; partial writes MUST fail reconciliation. The GHA workflows MUST be the only artifact-mutation surface (tag creation, npm publish, cargo publish, etc.); local `cleo` MUST NOT perform these mutations except through `gh workflow run` dispatch.
+
+---
+
+## Consequences
+
+### Positive
+
+1. **Failure #1 (wedged git commit) eliminated** — `git commit` happens inside `release-prepare.yml` exactly once with GHA's per-step timeout enforcement; local CLEO never runs an unbounded `git commit` (forensics §C1).
+2. **Failure #6 (tag at wrong SHA) eliminated by construction** — tag is `git tag $TAG $GITHUB_SHA` inside `release-publish.yml` AFTER `gh pr view --json state,mergeCommit` confirms `state == MERGED`, mirroring the Letta pattern at research §3.4 step 5.
+3. **Failure #3 (gate runners not wired) eliminated** — `defaultRunGate` and `runReleaseGates` both deleted; the only gate path is `cleo verify --gate X --evidence tool:Y` via ADR-061.
+4. **Failure #4 (IVTR non-blocking) eliminated** — IVTR removed from release path entirely (audit §Recommendations P1).
+5. **Failure #8 (release start no-op) eliminated** — `plan` is the only state-initialization verb; the plan file IS the resume state; no parallel handle exists.
+6. **Provenance graph implemented** — Audit Q4's "derivable but not queryable" gap closes. `SELECT b.id, b.title FROM releases r JOIN release_manifest_commits rmc ON rmc.release_id = r.id JOIN tasks t ON rmc.task_id = t.id JOIN task_relations tr ON t.id = tr.task_id AND tr.relation_type = 'fixes' JOIN tasks b ON tr.related_to = b.id WHERE r.version = '2026.X.Y' AND b.kind = 'bug';` becomes a one-line answer to "what bugs shipped".
+7. **T1737 multi-platform achieved** — `release-publish.yml` matrix produces all 5 platform tuples (linux-x64, linux-arm64, macos-x64, macos-arm64, windows-x64) and attaches each as a GitHub Release artifact in a single workflow run.
+8. **CLI surface reduced 14 → 4** (-71% verbs).
+9. **Code reduction: -1100 LOC net** — the 761-line `releaseShip` monolith deleted; smaller `plan`/`open`/`reconcile` modules in its place.
+10. **Hermes Tier-1 patterns adopted** — dual CalVer+SemVer, annotated tags, release-event fan-out, same-day suffix, supply-chain audit, OCI ancestor check, recovery-command-on-failure, pinned-deps+lockfile-drift (research §6 Tier 1, all 8 items).
+
+### Negative / trade-offs
+
+1. **GHA dependency hardened** — the release pipeline now genuinely cannot run without GitHub Actions. CLEO becomes harder to run against GitLab/Gitea/Bitbucket without writing a parallel CI integration. (Mitigation: keep an emergency `cleo release ship --no-workflow` escape hatch that runs the steps locally; this is the rollback path below.)
+2. **Operator must learn a new mental model** — the historical `cleo release ship` invocation no longer exists. Re-teaching ~70 prior releases worth of muscle memory has a real cost during the v2026.6 → v2026.7 transition window.
+3. **GHA YAML becomes load-bearing** — 4 workflow files (`release-prepare.yml`, `release-publish.yml`, `release-fanout.yml`, `release-rollback.yml`) are now critical infrastructure. YAML is harder to test than TypeScript; we must add a workflow-syntax CI gate (`actionlint` + `gh workflow view --json`) and dogfood every change on a `release/*` test branch before merging.
+4. **Two-stage flow is slower for the trivial case** — a no-content patch release (e.g., a CHANGELOG-typo fix) now requires `plan → open → human approval → merge → publish workflow`. Today's `cleo release ship` does it in one command. The Letta `release_bump_only` classifier mitigates wasted CI on the bump-PR but does not collapse the operator steps.
+5. **Multi-platform CI cost grows** — 5 matrix slots × per-slot smoke tests at ~3-5 minutes each + cross-build wait time ≈ 25-40 minutes of CI per release. Compared to today's ~15 minutes. (Mitigation: matrix parallelism + caching; budget impact ≤ $15/month per Anthropic-internal GHA quota estimates.)
+6. **Workflow-driven smoke tests need a test API key** — Letta's `release-publish.yml` step "Integration smoke test (real API)" calls a live agent with `LETTA_API_KEY`. The CLEO analog needs `CLEO_RELEASE_TEST_KEY` for whichever LLM the smoke spawns. Key rotation and secret-leak posture become new operational concerns.
+
+### Migration
+
+**Phased rollout — 4 phases over 6 operator-weeks:**
+
+- **Phase M1 (week 1, design-only)**: write the RFC-2119 spec deliverable for T9345 (wave-3 of RCASD). Define the plan-file schema, the four CLI verbs, the GHA workflow contracts, the three new DB tables. No code merged.
+- **Phase M2 (weeks 2-3)**: implement `plan` and `open` verbs alongside (not replacing) existing `release ship`. Add `release-prepare.yml` workflow. Use the new verbs on a *test release* (`v2026.6.0-test-1`) cut from a release-test branch. Existing `release ship` remains the canonical happy path during this phase.
+- **Phase M3 (weeks 4-5)**: implement `reconcile` + provenance tables + `release-publish.yml`. Migrate the next *real* release (next minor cut) through the new path while keeping `release ship` available as a fallback. Audit the provenance graph for completeness over the post-release week.
+- **Phase M4 (week 6)**: deprecate `release ship`, `release start`, `release verify`, `release publish` (canonical-pipeline siblings), `release pr-status`. Convert them to compatibility shims that print a deprecation warning and forward to the new verbs. Delete the 761-line monolith and the IVTR gate integration. Cut v2026.7.0 entirely on the new system.
+
+**Retired**:
+- `engine-ops.ts:releaseShip` (761 LOC) — fully replaced.
+- `pipeline.ts:releaseStart/Verify/Publish/Reconcile` — superseded; their useful primitives migrate into `plan.ts`/`open.ts`/`reconcile.ts`.
+- `engine-ops.ts:releaseGateCheck`, `engine-ops.ts:releaseIvtrAutoSuggest`, `engine-ops.ts:checkIvtrGates` — gone (audit §Phase 2 Leaks #1, #2, #4).
+- `release-manifest.ts:runReleaseGates` — replaced by ADR-061 tool resolver.
+- `pipeline.ts:defaultRunGate` + `defaultAuditChildren` stubs — gone.
+- 8 of 14 CLI subcommands (`start`, `verify`, `publish`, `ship`, `list`, `show`, `cancel`, `channel` — `list`/`show`/`cancel`/`channel` remain accessible via `cleo release plan --list` / `cleo release plan --show` etc., reducing the verb surface).
+
+**Operator-week estimate**: **6 operator-weeks** total spanning design + implementation + dogfooding + cleanup. Two parallel orchestrator agents reduce wall-time to ~4 calendar weeks.
+
+**Rollback path**: if Phase M3 or M4 surfaces a blocking regression in production, the rollback is:
+1. Re-enable `release ship` as a non-deprecated alias by reverting the deprecation shim PR. This restores ADR-065's 12-step monolith fully.
+2. Keep the `releases` and `release_manifest_commits` tables in place (data is additive and useful even if the new path is paused).
+3. Pause the GHA workflows (`release-prepare.yml`, `release-publish.yml`) by renaming them to `.disabled` extensions or by deleting them entirely.
+4. The `release_manifests` table never lost backward compat (force F12 satisfied), so resuming the old path is a single revert commit + a redeploy.
+
+This rollback path is testable: as a Phase M2 gate, the orchestrator MUST demonstrate a clean rollback from the test release before proceeding to Phase M3.
+
+### Migration data integrity
+
+`release_manifests` table contains 70+ historical release rows from v2026.4.0 onward. Direction B's new tables (`releases`, `release_manifest_commits`) are additive:
+- `releases.id` is a new monotonic key, separate from `release_manifests.id`. A migration SHALL backfill `releases` rows from `release_manifests` rows, one-to-one, preserving `version`, `epic_id`, `shipped_at`, `tag_name`.
+- `release_manifest_commits` is populated by scanning `git log --grep "release: ship v"` per backfilled release, attributing each commit's task IDs via regex on `T\d+` patterns in the subject. Where attribution is ambiguous, the row is written with `task_id = NULL` and a `provenance_quality = 'inferred'` flag.
+- `release_manifests` is NOT dropped. It becomes read-only after Phase M4. Future queries that need both new and historical data UNION across the two tables; the `release_provenance` view does this transparently.
+
+This backfill is the lowest-risk part of the migration because it touches read-only historical data. The verification query suite (T9345-CHILD-2 deliverable) asserts that the backfilled provenance correctly identifies the 70+ historical releases and their constituent tasks. If the assertion fails for a historical row, the row is marked `provenance_quality = 'manual_review_required'` and surfaced via `cleo release list --filter inferred-provenance`.
+
+### Per-phase exit criteria
+
+Each migration phase has an explicit exit gate. The orchestrator MUST NOT advance to the next phase until the gate is satisfied:
+
+- **M1 → M2**: RFC-2119 spec is signed by the council (T9345 wave-3 deliverable). Acceptance criterion: 5/5 council advisors approve the spec at the wave-3 gate.
+- **M2 → M3**: a *test release* (`v2026.6.0-test-1`) is successfully cut on a non-main release-test branch using the new `plan` + `open` verbs. Acceptance: the bump-PR opens, gates pass, the rollback path is exercised, no failure modes #1-#10 reproduce.
+- **M3 → M4**: the next *real* minor release (target: `v2026.6.0`) ships entirely through the new path. Acceptance: provenance graph is queryable post-ship; `release_provenance` view returns expected rows; no regression in any of the 10 forensics-documented failure modes; operator survey confirms the 4-verb UX is workable.
+- **M4 → done**: 2 consecutive releases ship without invoking the rollback path. Acceptance: the deprecated subcommands return their deprecation warnings on every call; the `releaseShip` monolith is deleted; the IVTR gate code is removed from `engine-ops.ts`.
+
+If any phase exit criterion fails twice in a row, the orchestrator MUST escalate to HITL approval before retrying.
+
+### Spawn cost during migration
+
+Migration is non-trivial agent work. Estimated spawn cost across all four phases:
+- M1 (design): 1 orchestrator + 1 spec-writer agent = ~3 agent-days = ~$30 LLM spend at current rates.
+- M2 (parallel implementation): 1 orchestrator + 4 worker agents (CLI, GHA workflows, schema migration, regression tests) = ~12 agent-days = ~$120.
+- M3 (integration + dogfood): 1 orchestrator + 2 worker agents = ~6 agent-days = ~$60.
+- M4 (cleanup): 1 orchestrator + 1 worker agent = ~3 agent-days = ~$30.
+
+Total ~$240 in LLM spend over the 6 operator-weeks, well within the T9345 epic budget. The dominant cost remains owner review time, not agent compute.
+
+---
+
+## Open questions
+
+These follow-up items become **child epics filed under T9345** once this ADR is accepted. Each represents work that is not specified here but is required to land the decision in production:
+
+1. **T9345-CHILD-1 — RFC-2119 spec for the four verbs**: define exact CLI argument shapes, exit codes, error envelopes (LAFS per ADR-039), idempotency contracts, and the `.cleo/release/<version>.plan.json` schema. Output: `docs/specs/CLEO-RELEASE-PIPELINE-SPEC-v2.md` superseding the current `packages/core/src/release/docs/specs/CLEO-RELEASE-PIPELINE-SPEC.md` (audit §Appendix file table).
+2. **T9345-CHILD-2 — Provenance graph schema migration**: write the drizzle migration adding `releases`, `release_manifest_commits`, and `release_provenance` (view). Backfill `release_manifest_commits` from existing `release_manifests` rows + `git log --grep "release: ship v"` for the last 12 months. Output: migration file + backfill script + verification query suite.
+3. **T9345-CHILD-3 — GHA workflow authoring**: write `release-prepare.yml`, `release-publish.yml`, `release-fanout.yml`, `release-rollback.yml`. Each MUST mirror Letta's structure (research §3.4) with CLEO-specific gates (lint via biome, typecheck via tsc, test via vitest, build via esbuild). Include the `release_bump_only` classifier (Letta research §3.4 sub-section). Output: 4 YAML files + `actionlint` CI gate.
+4. **T9345-CHILD-4 — IVTR retirement**: remove all IVTR write paths from `cleo orchestrate ivtr --start/--next/--release`, keep `--status` as a read-only view derived from evidence atoms. Mark `tasks.ivtr_state` column `@deprecated`. Plan its physical removal in a v2027 cleanup epic. (audit §Recommendations P4)
+5. **T9345-CHILD-5 — T1737 platform-matrix integration**: define the per-platform build artifact contracts. For each of (linux-x64, linux-arm64, macos-x64, macos-arm64, windows-x64), specify the binary artifact name, the smoke-test entrypoint (`cleo --version`, `cleo briefing`), and the Pi-adapter consumption path. Output: `docs/architecture/t1737-platform-matrix.md`.
+6. **T9345-CHILD-6 — Hermes Tier-1 mechanics adoption**: implement the 8 Tier-1 items individually (dual CalVer+SemVer, annotated tag messages, `release: published` fan-out, OCI ancestor check, same-day suffix, lockfile-drift CI, supply-chain audit on PR diffs, recovery-command print). Each can ship as a separate small PR. (research §6 Tier 1)
+7. **T9345-CHILD-7 — Worktree-policy on-disk artifact**: extend `git-shim` to read `.cleo/worktree-policy.json` independent of `CLEO_AGENT_ROLE` (forensics §F7). Add `git push <remote> <local>:<protected-branch>` to the denylist unconditionally. This is independent of the release rewrite but blocks force F7 satisfaction.
+8. **T9345-CHILD-8 — Override-cap session-lifecycle wiring**: register a cleanup hook in `sessionEnd` that deletes `.cleo/audit/session-override-count.<sid>.json`; ban `'global'` sessionId fallback in `validation/engine-ops.ts:385` (forensics §F5). Independent of release rewrite.
+
+Open questions whose answers belong in the wave-3 spec rather than as separate child epics:
+
+9. *What exactly triggers `release-publish.yml`?* The Letta pattern is `push: main` filtered to `paths: [package.json, package-lock.json]`. For a Cargo workspace member, the trigger needs `[Cargo.toml, Cargo.lock]`. The spec MUST enumerate the per-archetype trigger files.
+
+10. *How does `cleo release reconcile` get invoked from a GHA workflow?* Options: (a) `gh api dispatch` from `release-publish.yml` to an external reconcile workflow that runs locally, (b) the workflow runs `npx @cleocode/cleo release reconcile` directly using a published CLEO version, (c) the workflow writes the reconcile inputs to a `dispatches` queue table that a daemon drains. Spec MUST choose.
+
+11. *What happens to in-flight v2026.5.74-style hotfix releases during M2-M3?* The migration plan says "release ship remains canonical during M2-M3" — but the IVTR gate must still pass for them. The spec MUST clarify whether IVTR removal lands in M3 or M4, and whether mid-migration hotfixes use the old path or get a special compatibility flag.
+
+12. *Is the `same-day-suffix` versioning (`v2026.5.74.2`) compatible with CLEO's CalVer parser?* `validateVersion(version, 'calver')` (pipeline.ts:288-316) currently expects exactly `vYYYY.MM.DD` format. The spec MUST decide whether the suffix is a calver extension (parser change) or an entirely new scheme variant (`'calver-suffix'` enum value alongside `'calver'`).
+
+13. *Does the integration smoke test in `release-publish.yml` need a real Anthropic / OpenAI API key, or can it use a mock?* Letta uses a real `LETTA_API_KEY` against their own API. CLEO has no equivalent "CLEO API" — the smoke would need to spawn a real Claude/Anthropic call. Cost analysis: even at $0.50/release, that's ~$26/year for weekly releases. Likely acceptable but spec MUST decide and document the key-rotation policy.
+
+14. *How do we test the GHA workflows themselves?* The wave-3 spec MUST define a workflow-testing strategy. Options: (a) `actionlint` + dry-run via `act`, (b) a dedicated `workflow-smoke-test.yml` that runs every release workflow with `--dry-run` on every PR, (c) Letta's pattern of running the workflow against a forked test repo. The current `cleo release ship` pipeline is fully TypeScript-testable via vitest; the new pipeline must not regress that.
+
+---
+
+## Alignment notes
+
+- **T1737 Sentient Harness v3** — fully aligned. The GHA matrix in `release-publish.yml` produces all 5 platform tuples (Linux x64/arm64, macOS x64/arm64, Win x64) from one source of truth. Pi-style sleep-time harnesses consume the linux-arm64 artifact via the existing CleoOS Pi adapter (ADR-049). The cleo-os layer is not touched by this ADR — the harness consumes published artifacts; it does not participate in the publish workflow itself.
+- **ADR-053 portability promise** — fully fulfilled. The three archetypes (npm monorepo, single npm lib, single Rust crate) plus the two added archetypes (single Python pkg, Bun pkg) all go through the same four verbs. The per-archetype differences live in `.cleo/project-context.json` (`build.command`, `publish.command`, `testing.command`) plus the per-platform workflow matrix. ADR-053 RELEASE-06 fixture passes by construction.
+- **ADR-061 verify-tool resolution** — preserved and elevated. The release pipeline's gate check (`plan` verb) is implemented as `cleo verify --gate <X> --evidence tool:<canonical>` calls, identical to the per-task evidence ritual. There is one tool resolver in the codebase; the release path no longer maintains a parallel registry.
+- **ADR-062 worktree merge** — preserved. The bump-PR opened by `release-prepare.yml` follows the same `git merge --no-ff task/<id>` provenance model. `completeAgentWorktreeViaMerge` is unchanged. The release-branch model (`release/v<version>`) is retained from ADR-065 — it carries the version-bump commit and survives as the PR branch.
+- **ADR-072 Hermes-style provider plugin pattern** — directly applicable. ADR-072 unified the LLM provider stack with a registry pattern. The same architecture applies to "release platforms" (npm, cargo, docker, pypi, bun): each is a plugin under `packages/core/src/release/platforms/`, conforming to a common interface (`bump(version)`, `publish(artifact)`, `verify(version)`). The platform matrix in `release-publish.yml` consumes this registry.
+- **ADR-068 CLEO Database Charter** — preserved. The three new entities (`releases`, `release_manifest_commits`, `release_provenance` view) flow through `openCleoDb` per ADR-068 D003. Each gets a charter entry: owner = `release`, readers = `release|memory|orchestrate`, writers = `release`, concurrency = same as `release_manifests`, schema-version = bumped, retention = same as `release_manifests` (forever — audit asset).
+- **ADR-070 three-tier orchestration** — composable. `cleo release plan/open/reconcile` is a flow the Orchestrator dispatches. Leads can spawn it via `cleo orchestrate spawn T<release-task-id>` (where the release task is itself a task in the orchestration tree). No constraint added or relaxed.
+- **BRAIN integration** — `cleo memory observe` hooks preserved. Each `reconcile` invocation MUST call `memory observe` with `--title "Released v<version>"` + `--type decision` to record the release as a BRAIN node. The existing release-time `memory observe` calls in `engine-ops.ts` migrate verbatim into `reconcile.ts`.
+- **ADR-051 evidence atoms** — the release pipeline becomes the SECOND consumer of evidence atoms (after `cleo complete`). At reconcile time, every task in the plan has its evidence atoms re-validated against current git state via the staleness check (ADR-051 D8). A staleness failure on an in-release task fails the reconcile, preserving the invariant that "shipped tasks have valid evidence at ship time".
+- **Sentient subsystem (T1008-derived)** — release-time decisions (which tasks shipped, which were deferred, which gates flagged) are observable via the same `cleo sentient observe` hook the rest of CLEO uses. The release pipeline does NOT bypass the sentient observability layer.
+- **CAAMP injection (ADR-049, ADR-050)** — the release pipeline is harness-agnostic. Pi-style harnesses, Claude-Code harnesses, and CleoOS harnesses all spawn the same `cleo release …` CLI verbs with identical behavior. The GHA workflows are not harness-specific; they invoke the CLEO CLI as a subprocess and receive JSON envelopes (LAFS per ADR-039).
+- **ct-orchestrator skill (ADR-070)** — the orchestrator skill must learn the new 4-verb surface. The skill's release-section documentation (currently referencing `cleo release ship --epic`) MUST be updated as part of T9345-CHILD-1. Until then, orchestrator agents that quote the skill verbatim will fail.
+
+### What this ADR explicitly does NOT decide
+
+- **Does NOT decide release cadence**. CLEO's CalVer pattern (release-on-demand vs Hermes's weekly cadence) is unchanged. The new pipeline supports both — `release plan` is invoked when an operator decides to cut, not on a schedule.
+- **Does NOT decide CHANGELOG section taxonomy**. The auto-generation via `generate_release_notes` produces a flat list of PRs; whether to layer the Hermes-style hierarchical sections (Highlights / Breaking / Bug fixes / Infrastructure — research §3.7) is left to T9345-CHILD-1 and the wave-3 spec.
+- **Does NOT decide whether to commit per-release notes to the repo**. Hermes commits `RELEASE_v0.13.0.md` to repo root (research §3.7); CLEO could do the same. The ADR keeps this as a side-quest under T9345-CHILD-6.
+- **Does NOT decide Docker publishing posture**. CLEO does not currently publish Docker images. If T1737 introduces a container distribution channel, the Hermes `:main` / `:latest` ancestor-check pattern (research §3.4) is the model; that decision is in T9345-CHILD-5 (platform matrix).
+- **Does NOT decide whether to adopt changesets for contributor-facing version-bump UX**. Some agents may write PRs that introduce minor user-visible changes worth a changelog entry. Whether to require a `.changeset/*.md` file per PR (changesets pattern) is a separate ergonomic decision deferred to a future ADR.
+
+---
+
+## References
+
+### Wave-1 research (T9345 RCASD)
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/audit-cleo-release-subcommands.md` — 14-subcommand audit, 8-axis coupling scores, 12 invariants.
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/failure-forensics-10-modes.md` — 10 failure modes, 6 root-cause clusters, conflation and monolith hypotheses.
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/hermes-agent-real-research.md` — 8 Tier-1 borrowable patterns, dual-tag scheme, release-event fan-out.
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/letta-harness-real-research.md` — letta-code two-stage workflow, `release_bump_only` classifier, integration-smoke pattern.
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md` — IVTR↔Release coupling severity 7/10; ~600 LOC to remove; 4 priority recommendations.
+
+### Prior ADRs
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-039-lafs-envelope-error-format.md` — error envelope contract (preserved by this ADR).
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-051-evidence-based-gates.md` — evidence atoms (the sole release gate surface in Direction B).
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-053-project-agnostic-release-pipeline.md` — original portability promise; this ADR fulfills it.
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-061-project-agnostic-verify-tools.md` — canonical tool resolver (the only gate runner under Direction B).
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-062-worktree-merge-integration.md` — worktree integration via `git merge --no-ff` (preserved).
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-063-4-step-release-pipeline.md` — superseded; useful primitives migrate into `plan`/`open`/`reconcile`.
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-065-pr-required-release-flow.md` — extended (release-branch model retained; 12-step monolith replaced).
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-068-cleo-database-charter.md` — chokepoint contract for new tables.
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-070-three-tier-orchestration.md` — orchestrator/lead/worker topology (preserved).
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-072-unified-llm-provider-architecture.md` — provider-plugin pattern reused for release platforms.
+
+### Key files cited
+- `/mnt/projects/cleocode/packages/cleo/src/cli/commands/release.ts` — 14-subcommand CLI surface (to be reduced to 4).
+- `/mnt/projects/cleocode/packages/cleo/src/dispatch/domains/release.ts` — dispatch handler (rewrite scope).
+- `/mnt/projects/cleocode/packages/core/src/release/engine-ops.ts` — 1986-line module containing the 761-line `releaseShip` monolith (deletion target).
+- `/mnt/projects/cleocode/packages/core/src/release/pipeline.ts` — parallel 4-step pipeline (deletion target).
+- `/mnt/projects/cleocode/packages/core/src/release/guards.ts` — `checkEpicCompleteness` (rewrite scope; epic-scope fix).
+- `/mnt/projects/cleocode/packages/core/src/release/version-bump.ts` — `resolveVersionBumpTargets` (preserved; consumed by `plan` and the GHA matrix).
+- `/mnt/projects/cleocode/packages/core/src/release/release-manifest.ts` — existing DB layer (extended with `releases` + `release_manifest_commits`).
+- `/mnt/projects/cleocode/packages/core/src/release/github-pr.ts` — `createPullRequest` (preserved; consumed by `open`).
+- `/mnt/projects/cleocode/packages/core/src/release/changelog-writer.ts` — preserved; consumed by `plan`.
+- `/mnt/projects/cleocode/packages/core/src/lifecycle/ivtr-loop.ts` — read-only view post-decoupling.
+- `/mnt/projects/cleocode/packages/core/src/security/override-cap.ts` — orphaned by removing `--force` from release verbs; lifecycle fix lands as T9345-CHILD-8.
+- `/mnt/projects/cleocode/build.mjs` — externals list moves to `.cleo/build-externals.json` with sync CI gate (T9345-CHILD-1 / T9345-CHILD-2 split TBD by spec).
+- `/mnt/projects/cleocode/.cleo/project-context.json` — the project-archetype source of truth consumed by ADR-061 + the platform matrix.
+
+### External references
+- Hermes-agent: `https://github.com/NousResearch/hermes-agent` — `scripts/release.py:1400-1564`, `.github/workflows/docker-publish.yml:24-26,290-535`, `.github/workflows/contributor-check.yml:1-73`.
+- Letta-code: `https://github.com/letta-ai/letta-code` — `.github/workflows/prepare-release.yml`, `.github/workflows/release.yml`, `.github/workflows/ci.yml` (the `release_bump_only` classifier).
+- Letta server (anti-pattern, for contrast only): `https://github.com/letta-ai/letta` — `.github/workflows/poetry-publish.yml`, `.github/workflows/docker-image.yml`.
+- gh CLI auto-merge semantics: `https://cli.github.com/manual/gh_pr_merge` (per forensics §F6 root-cause analysis).
+- GitHub Environments + required reviewers: documented per the `environment: npm-publish` pattern at Letta research §3.4 step 7.
+
+---
+
+*End of ADR-073 — proposed for council review at T9345 wave-2 gate.*
+
+---
+
+## Appendix A — Illustrative plan-file schema
+
+This appendix sketches the `.cleo/release/<version>.plan.json` schema referenced throughout the Decision. The wave-3 RFC-2119 spec (T9345-CHILD-1) MUST formalize the JSON schema; the appendix is non-normative.
+
+```jsonc
+{
+  "$schema": "https://cleocode.io/schemas/release-plan/v1.json",
+  "version": "v2026.6.0",
+  "channel": "latest",
+  "scheme": "calver",
+  "epicId": "T9999",
+  "createdAt": "2026-06-01T12:00:00Z",
+  "createdBy": "cleo-prime",
+  "previousVersion": "v2026.5.74",
+  "previousTag": "v2026.5.74",
+  "previousShippedAt": "2026-05-15T08:00:00Z",
+  "tasks": [
+    {
+      "id": "T10001",
+      "kind": "feat",
+      "impact": "minor",
+      "userFacingSummary": "Add cargo-publish platform plugin for Rust release targets",
+      "evidenceAtoms": ["commit:abc123", "test-run:vitest-2026-06-01.json", "tool:lint", "tool:typecheck"],
+      "ivtrPhaseAtPlan": "released",
+      "epicAncestor": "T9999"
+    }
+  ],
+  "changelog": {
+    "features": ["..."],
+    "fixes": ["..."],
+    "chores": ["..."],
+    "breaking": []
+  },
+  "gates": [
+    {"name": "test", "atom": "tool:test", "status": "passed", "lastVerifiedAt": "2026-06-01T11:50:00Z"},
+    {"name": "lint", "atom": "tool:lint", "status": "passed", "lastVerifiedAt": "2026-06-01T11:50:00Z"},
+    {"name": "typecheck", "atom": "tool:typecheck", "status": "passed", "lastVerifiedAt": "2026-06-01T11:50:00Z"},
+    {"name": "build", "atom": "tool:build", "status": "passed", "lastVerifiedAt": "2026-06-01T11:50:00Z"},
+    {"name": "security-scan", "atom": "tool:security-scan", "status": "passed", "lastVerifiedAt": "2026-06-01T11:51:00Z"}
+  ],
+  "platformMatrix": [
+    {"platform": "linux-x64", "publisher": "npm", "package": "@cleocode/cleo"},
+    {"platform": "linux-arm64", "publisher": "npm", "package": "@cleocode/cleo"},
+    {"platform": "macos-x64", "publisher": "npm", "package": "@cleocode/cleo"},
+    {"platform": "macos-arm64", "publisher": "npm", "package": "@cleocode/cleo"},
+    {"platform": "windows-x64", "publisher": "npm", "package": "@cleocode/cleo"}
+  ],
+  "preflightSummary": {
+    "esbuildExternalsDrift": false,
+    "lockfileDrift": false,
+    "epicCompletenessClean": true,
+    "doubleListingClean": true
+  },
+  "workflowRunUrl": null,
+  "prUrl": null,
+  "mergeCommitSha": null,
+  "status": "planned"
+}
+```
+
+Key invariants enforced by the schema:
+- `previousVersion` / `previousShippedAt` are non-nullable for any plan that is not a first-ever release. The CHANGELOG generator uses `git log $previousTag..HEAD` and the BRAIN ingestion filters `completedAt > previousShippedAt`.
+- `evidenceAtoms` per task is required and non-empty. Plans without evidence atoms cannot be opened. This is the ADR-051 surface inside the release pipeline.
+- `status` advances `planned` → `pr-opened` → `pr-merged` → `published` → `reconciled`. Each transition is written by the corresponding verb.
+- `epicAncestor` is computed at plan time, NOT at reconcile time. The epic-scope-leak failure (#2) is eliminated because the plan locks the epic scope; downstream consumers do not re-derive it.
+
+## Appendix B — Illustrative `release-publish.yml` skeleton
+
+Non-normative pseudo-YAML to make the matrix structure concrete:
+
+```yaml
+name: Release publish
+on:
+  push:
+    branches: [main]
+    paths:
+      - "package.json"
+      - "packages/*/package.json"
+      - "Cargo.toml"
+      - "packages/*/Cargo.toml"
+  workflow_dispatch:
+    inputs:
+      version: { required: true }
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.classify.outputs.should_publish }}
+      version: ${{ steps.classify.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 0 }
+      - id: classify
+        run: |
+          SUBJECT=$(git log --format=%s "${{ github.event.before }}..${{ github.sha }}" | grep -E '^release: prepare v' | tail -n 1 || true)
+          if [ -z "$SUBJECT" ]; then echo "should_publish=false" >> $GITHUB_OUTPUT; exit 0; fi
+          VERSION=$(echo "$SUBJECT" | sed 's/^release: prepare //')
+          echo "should_publish=true" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+  build-matrix:
+    needs: detect
+    if: needs.detect.outputs.should_publish == 'true'
+    strategy:
+      matrix:
+        platform:
+          - { id: linux-x64,    runs-on: ubuntu-latest }
+          - { id: linux-arm64,  runs-on: ubuntu-24.04-arm }
+          - { id: macos-x64,    runs-on: macos-13 }
+          - { id: macos-arm64,  runs-on: macos-14 }
+          - { id: windows-x64,  runs-on: windows-latest }
+    runs-on: ${{ matrix.platform.runs-on }}
+    steps:
+      - uses: actions/checkout@v6
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm run check
+      - run: pnpm run test
+      - name: Smoke test
+        run: ./bin/cleo --version
+      - name: Integration smoke (Anthropic)
+        env: { ANTHROPIC_API_KEY: ${{ secrets.CLEO_RELEASE_TEST_KEY }} }
+        run: ./bin/cleo briefing --json | jq .ok
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cleo-${{ matrix.platform.id }}
+          path: dist/cleo-${{ matrix.platform.id }}.tgz
+
+  publish-and-tag:
+    needs: build-matrix
+    runs-on: ubuntu-latest
+    environment: cleo-publish
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - run: pnpm publish --access public
+      - run: git tag "${{ needs.detect.outputs.version }}" "${{ github.sha }}"
+      - run: git push origin "${{ needs.detect.outputs.version }}"
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.detect.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
+          files: |
+            cleo-linux-x64.tgz
+            cleo-linux-arm64.tgz
+            cleo-macos-x64.tgz
+            cleo-macos-arm64.tgz
+            cleo-windows-x64.tgz
+      - run: cleo release reconcile "${{ needs.detect.outputs.version }}"
+```
+
+This is roughly 80 lines of YAML; the equivalent logic in today's `engine-ops.ts:releaseShip` is 761 lines of TypeScript. The asymmetry is the central evidence that Direction B's architecture is more compact AND more defensible.

--- a/.cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md
+++ b/.cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md
@@ -1,0 +1,822 @@
+# SPEC-T9345 — CLEO Release Pipeline v2 (Direction B + Qualifier)
+
+| Field | Value |
+|---|---|
+| **Version** | 2.0.0-draft |
+| **Status** | Proposed (awaiting RCASD wave-3 council + owner sign-off) |
+| **Date** | 2026-05-15 |
+| **Author** | cleo-prime (system architect) |
+| **Task** | T9345 — IVTR Release System Overhaul |
+| **ADR** | ADR-073-ivtr-release-overhaul (`.cleo/rcasd/T9345/research/ADR-T9345-ivtr-release-overhaul.md`) |
+| **Supersedes** | `packages/core/src/release/docs/specs/CLEO-RELEASE-PIPELINE-SPEC.md` (ADR-063 4-step) |
+| **Extends** | ADR-051 (evidence gates), ADR-061 (tool resolver), ADR-062 (worktree merge), ADR-065 (PR-required flow), ADR-068 (DB charter), ADR-070 (3-tier orchestration) |
+
+> The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **NOT RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be interpreted as described in [BCP 14](https://www.rfc-editor.org/info/bcp14) [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in all capitals, as shown here.
+
+---
+
+## Executive Summary
+
+This specification defines CLEO's release pipeline v2 — a thin opinionated wrapper over `git`, `gh`, and GitHub Actions, with provenance recorded in CLEO's SQLite stores. The pipeline replaces the 761-line `releaseShip` monolith (`packages/core/src/release/engine-ops.ts:1105-1866`) and the parallel 4-step pipeline (`packages/core/src/release/pipeline.ts`) with **exactly four operator verbs** — `cleo release plan`, `cleo release open`, `cleo release reconcile`, `cleo release rollback` — backed by four GitHub Actions workflows (`release-prepare.yml`, `release-publish.yml`, `release-fanout.yml`, `release-rollback.yml`). The verbs are read-mostly TypeScript that emits LAFS-compliant JSON envelopes; the workflows are stateless YAML that invoke those verbs and drive the outer state machine. This separation eliminates the 10 production failures catalogued in `failure-forensics-10-modes.md` by structural prevention (8 of 10) or by narrowing the race window to near-zero (2 of 10).
+
+The spec mandates **214 normative requirements** (R-001 through R-214), grouped under: CLI surface, GHA workflow contracts, evidence-gate integration, provenance recording (11 new tables defined in `provenance-graph-design.md` §3), project-agnostic resolution via ADR-061, idempotency, state-machine transitions, hotfix path, backward compatibility, and operator surface limits. Every requirement is anchored to a wave-1 research artifact or an existing ADR; every CLI verb declares pre-conditions, side effects, post-conditions, exit codes, and output envelopes; every GHA workflow declares triggers, permissions, jobs, concurrency, and secret requirements. IVTR is removed from the release path per `ivtr-conflation-audit.md` Priority 1 — release validation MUST consult only ADR-051 evidence atoms via the ADR-061 tool resolver. `task.ivtr_state` SHALL persist as a read-only derived view for backward compatibility but MUST NOT block any release operation.
+
+Acceptance is measurable: operator wall-time ≤5 minutes for happy path, zero orphan commits in shipped releases (queried via `release_provenance` view), MTTR <1 hour for hotfix, ≥3 project archetypes pass full pipeline (npm monorepo, single npm lib, single Rust crate; Python pkg as stretch goal).
+
+---
+
+## 1. Scope
+
+### 1.1 In scope
+
+This spec defines:
+
+- The four operator verbs (`plan`, `open`, `reconcile`, `rollback`) and their supporting read verbs (`graph`, `diff`, `impact`, `authors`, `orphans`) plus the `cleo provenance` namespace (9 verbs).
+- The four GitHub Actions workflows (`release-prepare.yml`, `release-publish.yml`, `release-fanout.yml`, `release-rollback.yml`) and their interaction contracts.
+- The provenance graph schema (11 new tables + 1 view) inherited from `provenance-graph-design.md` §3.
+- The `.cleo/release/<version>.plan.json` schema, evidence-gate composition, error envelope, and idempotency contract.
+- The state machine governing `releases.status` and the bump-PR lifecycle.
+- The hotfix path and the backward-compatibility window for `cleo release ship`.
+- The project-archetype resolution model (which tools/commands run for each archetype).
+
+### 1.2 Out of scope
+
+This spec does NOT define (each has its own spec or owner-deferred decision):
+
+- **npm/cargo/PyPI publishing details** — only the abstract "publisher matrix" contract. Per-registry semantics (npm provenance, cargo crates.io API, PyPI OIDC) belong to T9345-CHILD-5 (platform matrix).
+- **GitHub branch protection setup** — operator-owned per ADR-065 setup guide.
+- **BRAIN observation semantics** — `cleo memory observe` is an existing API; this spec only specifies when the release pipeline invokes it.
+- **CHANGELOG section taxonomy** — ADR-073 §"What this ADR explicitly does NOT decide" defers to a future ergonomic decision.
+- **IVTR retirement timeline** — `task.ivtr_state` becomes a derived view in this spec; physical column removal is T9345-CHILD-4.
+- **Workflow-testing harness (actionlint, act, dry-run topology)** — T9345-CHILD-3.
+
+### 1.3 Audience
+
+The primary audience is implementation authors of T9345-CHILD-1 through T9345-CHILD-8 (see ADR-073 §"Open questions"). The secondary audience is operators running `cleo release …` and orchestrator agents that learn the surface via the `ct-orchestrator` skill.
+
+---
+
+## 2. Terminology
+
+| Term | Definition |
+|---|---|
+| **Release Plan** | The structured JSON document at `.cleo/release/<version>.plan.json` produced by `cleo release plan`. The plan is the single source of truth for what a release contains; `open`, `reconcile`, and `rollback` consume it. |
+| **Release Handle** | Synonym for Release Plan when used as a resume token. The Plan IS the handle; this spec does NOT define a separate `.cleo/release/handle.json` file (replacing the legacy `pipeline.ts:91` handle path). |
+| **Provenance Edge** | A row in one of the junction tables (`task_commits`, `release_commits`, `release_changes`, `pr_tasks`, `brain_release_links`) that records a typed relationship between two graph nodes. See `provenance-graph-design.md` §3 for the 11 tables. |
+| **Evidence Atom** | An ADR-051 atom of the form `commit:<sha>` / `files:<paths>` / `test-run:<json>` / `tool:<name>` / `url:<url>` / `note:<text>` / `decision:<id>`. The release pipeline consumes atoms but does NOT mint them. |
+| **Workflow Phase** | A named, top-level job inside one of the four GHA workflows (e.g. `preflight`, `prepare`, `detect`, `build-matrix`, `publish-and-tag`, `reconcile`, `fanout`, `rollback`). |
+| **Idempotent Step** | A step whose effect is identical when re-executed with the same input state, where "input state" is defined by the Release Plan + the git HEAD + the dirty-tree fingerprint per ADR-061's cache key. |
+| **Recovery Checkpoint** | The set of guaranteed-durable state transitions a workflow MAY safely resume from. For v2 there are exactly three: `plan-written` (file on disk), `bump-pr-opened` (PR URL recorded), `merged` (`releases.status='committed'` written by `release-publish.yml`). |
+| **Project Archetype** | A coarse classification of the project's release shape: `monorepo-w-workspaces`, `single-npm-lib`, `single-rust-crate`, `single-python-pkg`, `mixed-npm-rust`, `docker-image`, or `binary-tarball`. Resolved at plan-time from `.cleo/project-context.json` + filesystem markers. |
+| **Tool Resolver** | The ADR-061 `resolveToolCommand(toolName, projectRoot)` function. Canonical tool names: `test`, `build`, `lint`, `typecheck`, `audit`, `security-scan`. The release pipeline MUST NOT maintain a parallel registry. |
+| **Release Channel** | One of `latest` / `beta` / `alpha` / `rc`, governing which npm dist-tag (or analog for non-npm archetypes) the artifact is published under. Resolved from git branch via `release-config.ts:resolveChannelFromBranch`. |
+| **Bump-PR** | The pull request opened by `release-prepare.yml` that carries the version bump + CHANGELOG + lockfile updates. Its merge to `main` is the event that triggers `release-publish.yml`. |
+| **Release Commit** | The git commit on `main` whose subject matches `^release: prepare v` AND which `release-publish.yml`'s detect-phase classifies as the publish trigger. By construction this is the bump-PR's merge commit (`$GITHUB_SHA` inside the workflow). |
+| **Hotfix Suffix** | The same-day `.N` extension (`v2026.5.74.2`, `v2026.5.74.3`) computed by `cleo release plan` when a CalVer collision is detected. Hermes precedent: `hermes-agent-real-research.md:836-839` Tier 1 §5. |
+| **Plan State** | The `status` field of the Release Plan, mirroring `releases.status` for in-flight tracking. Values: `planned` → `pr-opened` → `pr-merged` → `published` → `reconciled` → `rolled_back` \| `failed` \| `cancelled`. |
+
+---
+
+## 3. High-Level Architecture
+
+### 3.1 Flow diagram
+
+```mermaid
+flowchart TD
+    OP[Operator / Orchestrator Agent] -->|cleo release plan v --epic T| PLAN[cleo release plan]
+    PLAN -->|reads| TASKS_DB[(tasks.db: tasks + evidence)]
+    PLAN -->|reads| GIT[git log prevTag..HEAD]
+    PLAN -->|reads| TOOL_RES[ADR-061 tool resolver]
+    PLAN -->|writes| PLAN_FILE[.cleo/release/v.plan.json]
+    PLAN -->|writes| RELEASES[(releases table status=planned)]
+
+    OP -->|cleo release open v| OPEN[cleo release open]
+    OPEN -->|reads| PLAN_FILE
+    OPEN -->|gh workflow run| WF1[release-prepare.yml]
+    WF1 -->|preflight: lint/typecheck/build/test| WF1
+    WF1 -->|gh pr create| PR[Bump-PR]
+    OPEN -->|updates| RELEASES_PR_OPEN[(releases.status=pr-opened, pr_id)]
+
+    PR -->|review + auto-merge| MAIN[main]
+    MAIN -->|push: main paths package.json Cargo.toml| WF2[release-publish.yml]
+    WF2 -->|detect release commit| WF2
+    WF2 -->|matrix: linux/mac/win × x64/arm64| WF2
+    WF2 -->|tag from GITHUB_SHA| TAG[git tag vX]
+    WF2 -->|softprops gh-release| GHR[GitHub Release]
+    WF2 -->|publish: npm/cargo/pypi| REGISTRIES[Registries]
+    WF2 -->|cleo release reconcile| RECONCILE[cleo release reconcile]
+
+    RECONCILE -->|writes| COMMITS[(commits table)]
+    RECONCILE -->|writes| TASK_COMMITS[(task_commits)]
+    RECONCILE -->|writes| RELEASE_COMMITS[(release_commits)]
+    RECONCILE -->|writes| RELEASE_CHANGES[(release_changes)]
+    RECONCILE -->|writes| RELEASE_ARTIFACTS[(release_artifacts)]
+    RECONCILE -->|writes| BRAIN_LINKS[(brain_release_links)]
+    RECONCILE -->|cleo memory observe| BRAIN[BRAIN]
+    RECONCILE -->|updates| RELEASES_DONE[(releases.status=reconciled)]
+
+    GHR -->|release: published event| WF3[release-fanout.yml]
+    WF3 -->|docs deploy / sentinel notify / docker retag| DOWNSTREAM[Async downstream]
+
+    OP -->|cleo release rollback v| ROLLBACK[cleo release rollback]
+    ROLLBACK -->|gh workflow run| WF4[release-rollback.yml]
+    WF4 -->|delete tag / revert commit / npm deprecate| REV[Reverted state]
+    WF4 -->|cleo release reconcile --rollback| RECONCILE_RB[Reconcile rollback marker]
+    RECONCILE_RB -->|updates| RELEASES_RB[(releases.status=rolled_back)]
+```
+
+### 3.2 Component map
+
+| Component | Type | Path / Identifier | Owner | Consumes | Produces |
+|---|---|---|---|---|---|
+| `cleo release plan` | TypeScript CLI verb | `packages/core/src/release/plan.ts` (new) | release pkg | `tasks.db`, git log, ADR-061 resolver, ADR-051 atoms | Plan file, `releases` row (status=planned) |
+| `cleo release open` | TypeScript CLI verb | `packages/core/src/release/open.ts` (new) | release pkg | Plan file | `gh workflow run` dispatch; updates `releases.status` |
+| `cleo release reconcile` | TypeScript CLI verb | `packages/core/src/release/reconcile.ts` (new) | release pkg | Plan file, `gh release view`, git log | Provenance rows (11 tables) |
+| `cleo release rollback` | TypeScript CLI verb | `packages/core/src/release/rollback.ts` (rewrite of existing) | release pkg | Plan file, version | `gh workflow run release-rollback.yml` |
+| `release-prepare.yml` | GHA workflow YAML | `.github/workflows/release-prepare.yml` (new) | repo-level | Plan content (via inputs) | Bump-PR + preflight status check |
+| `release-publish.yml` | GHA workflow YAML | `.github/workflows/release-publish.yml` (new) | repo-level | `push: main` + release-commit subject | Tag, GitHub Release, artifacts, reconcile call |
+| `release-fanout.yml` | GHA workflow YAML | `.github/workflows/release-fanout.yml` (new) | repo-level | `release: published` event | Docs deploy, Docker retag, notifications |
+| `release-rollback.yml` | GHA workflow YAML | `.github/workflows/release-rollback.yml` (new) | repo-level | `workflow_dispatch` (version + mode) | Tag deletion, revert commit, npm deprecate |
+
+---
+
+## 4. CLI Surface — The Four Operator Verbs
+
+This section is normative. Numbering follows R-NNN convention; every implementation MUST satisfy every R-NNN it touches.
+
+### 4.1 General CLI invariants
+
+- **R-001** Every release verb MUST emit a LAFS envelope (`{success, data?, error?, meta, page?}`) on `stdout` when invoked with `--json`. (ADR-039.)
+- **R-002** Every release verb MUST exit with code `0` on success and a non-zero exit code mapped to an error name on failure. The full error-code table is defined in §4.7.
+- **R-003** The release verbs MUST honor `CLEO_DRY_RUN=1` by performing all read operations and emitting the envelope that would result from a real invocation, but MUST NOT perform any write to `tasks.db`, `brain.db`, the filesystem outside `.cleo/release/`, the git remote, or any registry.
+- **R-004** The release verbs MUST NOT spawn any subprocess that mutates the git working tree directly. All git mutations are performed inside GHA workflows. Local CLI spawns `git status`, `git log`, `git rev-parse`, `gh pr view`, `gh workflow run`, and `gh release view` only.
+- **R-005** Every subprocess spawn in any release verb MUST have an explicit `timeout` argument bounded above by 30 seconds for `git`/`gh` reads, 60 seconds for `gh workflow run`, and 120 seconds for `gh run watch` (with explicit polling fallback). (Forensics §C1, F1.)
+- **R-006** Every subprocess timeout in a release verb MUST have a SIGKILL-after-grace path: if the SIGTERM does not return the child within 5 seconds, the verb MUST issue a SIGKILL to the child PID and emit `meta.killedChildPid=<n>` on the resulting error envelope.
+- **R-007** A release verb MUST NOT accept a `--force` flag. (ADR-051 D3 removes `--force` from `cleo complete`; this spec extends the prohibition to every release verb.)
+- **R-008** A release verb MAY honor `CLEO_OWNER_OVERRIDE=1` only for the narrow case of bypassing a stale-evidence check at `reconcile` time. Any such bypass MUST append a line to `.cleo/audit/force-bypass.jsonl` with `(timestamp, verb, version, reason, actor)`. The default value of `CLEO_OWNER_OVERRIDE` is `0` and the override path MUST require both the env var and a non-empty `CLEO_OWNER_OVERRIDE_REASON` env var.
+- **R-009** Every release verb MUST be idempotent over re-invocation with identical arguments and identical git+DB state. Re-running `cleo release plan v2026.6.0 --epic T9999` against unchanged inputs MUST produce a byte-identical plan file (modulo `createdAt`).
+- **R-010** The release verbs MUST NOT modify `task.ivtr_state` for any task. (Audit Priority 1 — IVTR is decoupled.)
+
+### 4.2 `cleo release plan <version> --epic <id>`
+
+#### 4.2.1 Inputs
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `version` | positional string | yes | — | The candidate version (e.g. `v2026.6.0`). The resolver MAY return a same-day-suffixed variant. |
+| `--epic <id>` | string | yes | — | The epic task ID whose tasks are candidates for inclusion. (Forensics §F2 — explicit scope.) |
+| `--scheme` | enum `calver` \| `semver` \| `calver-suffix` | no | inferred from `.cleo/config.json` `release.scheme` | Version scheme. |
+| `--channel` | enum `latest` \| `beta` \| `alpha` \| `rc` | no | resolved from branch | Release channel. |
+| `--hotfix` | boolean | no | `false` | Marks the plan as `release_kind=hotfix`. See §10 (Hotfix Path). |
+| `--dry-run` | boolean | no | `false` | Equivalent to `CLEO_DRY_RUN=1`. |
+| `--json` | boolean | no | `false` | Emit LAFS envelope on stdout. |
+
+#### 4.2.2 Pre-conditions
+
+- **R-020** The verb MUST verify that the working tree is clean for `package.json`, `packages/*/package.json`, `Cargo.toml`, `packages/*/Cargo.toml`, `pyproject.toml`, `CHANGELOG.md`. If any of those are dirty, the verb MUST return `E_DIRTY_TREE` with the list of offending paths.
+- **R-021** The verb MUST verify that the epic referenced by `--epic` exists in `tasks.db` and has at least one child task. If not, the verb MUST return `E_EPIC_EMPTY`.
+- **R-022** The verb MUST verify that the channel is compatible with the version scheme (e.g. `calver` + `beta` requires a `-beta.N` suffix). If incompatible, the verb MUST return `E_CHANNEL_MISMATCH`.
+- **R-023** The verb MUST resolve `previousVersion` by walking `releases.shipped_at DESC LIMIT 1` for the same channel. If no prior release exists, `previousVersion` MUST be `null` and the verb MUST emit `meta.firstEverRelease=true`.
+- **R-024** The verb MUST consult ADR-061's tool resolver for the 5 canonical gates (`test`, `build`, `lint`, `typecheck`, `security-scan`) AND for `audit`. The resolver outcome MUST be persisted into `plan.gates[]`; missing resolutions MUST be emitted under `meta.unresolvedTools[]` and MUST cause the plan to enter `meta.preflightWarnings[]` rather than fail outright.
+
+#### 4.2.3 Side effects
+
+- **R-030** The verb MUST write the plan file to `.cleo/release/<resolved-version>.plan.json` atomically (tmp + rename). The schema is defined in §6.
+- **R-031** The verb MUST INSERT one row into the `releases` table with `status='planned'` and the resolved version. (Provenance design §3.6.) If a row already exists for that version, the verb MUST UPDATE it (idempotent) and MUST NOT create a duplicate.
+- **R-032** The verb MUST NOT perform any git mutation, any `gh` call, any network call, or any write outside `.cleo/release/` and `tasks.db`.
+
+#### 4.2.4 Post-conditions
+
+- **R-040** `releases.status` for the resolved version is `planned`.
+- **R-041** `.cleo/release/<resolved-version>.plan.json` exists and validates against the JSON schema (§6).
+- **R-042** Re-running the verb with identical inputs is a no-op modulo `meta.lastInvokedAt`.
+
+#### 4.2.5 Output envelope
+
+```json
+{
+  "success": true,
+  "data": {
+    "version": "v2026.6.0",
+    "resolvedVersion": "v2026.6.0",
+    "suffixApplied": false,
+    "channel": "latest",
+    "epicId": "T9999",
+    "planPath": "/abs/.cleo/release/v2026.6.0.plan.json",
+    "taskCount": 12,
+    "evidenceComplete": true,
+    "preflightWarnings": [],
+    "gateSummary": {"test": "passed", "lint": "passed", "typecheck": "passed", "build": "passed", "security-scan": "skipped"}
+  },
+  "error": null,
+  "meta": {"verb": "release.plan", "durationMs": 240, "schemaVersion": "1.0.0"}
+}
+```
+
+### 4.3 `cleo release open <version>`
+
+#### 4.3.1 Inputs
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `version` | positional string | yes | — | The version whose plan file is at `.cleo/release/<version>.plan.json`. |
+| `--workflow` | string | no | `release-prepare.yml` | Workflow file name to dispatch. |
+| `--watch` | boolean | no | `false` | Poll `gh run watch` until the run reaches an in-progress or completed state. |
+| `--json` | boolean | no | `false` | Emit LAFS envelope. |
+
+#### 4.3.2 Pre-conditions
+
+- **R-050** The plan file at `.cleo/release/<version>.plan.json` MUST exist; otherwise the verb MUST return `E_PLAN_NOT_FOUND` and MUST emit `error.fix` = `"cleo release plan <version> --epic <id>"`.
+- **R-051** `releases.status` for the version MUST be `planned`; otherwise the verb MUST return `E_INVALID_STATE` with the current status reported in `error.meta`.
+- **R-052** `gh auth status` MUST exit 0; otherwise the verb MUST return `E_GH_NOT_AUTHENTICATED`.
+- **R-053** The `release-prepare.yml` workflow file MUST exist under `.github/workflows/`; otherwise the verb MUST return `E_WORKFLOW_NOT_FOUND`.
+
+#### 4.3.3 Side effects
+
+- **R-060** The verb MUST invoke `gh workflow run release-prepare.yml --field version=<version> --field plan-blob-sha256=<sha>` and MUST NOT inline the entire plan body in the dispatch input (size cap; instead the workflow reads from the PR-attached plan).
+- **R-061** The verb MUST UPDATE `releases.status = 'pr-opened'` (preliminary; the bump-PR may not yet exist at this instant) and MUST persist the workflow run URL into `releases.workflow_run_url`.
+- **R-062** The verb MUST commit the plan file to the active branch only if `--commit-plan` is supplied (NOT recommended for the default flow; the workflow can re-derive the plan from the `releases` row + tasks.db).
+
+#### 4.3.4 Post-conditions
+
+- **R-070** `releases.status = 'pr-opened'`.
+- **R-071** `releases.workflow_run_url` is a valid `gh run` URL.
+
+#### 4.3.5 Output envelope
+
+```json
+{
+  "success": true,
+  "data": {
+    "version": "v2026.6.0",
+    "workflowRunUrl": "https://github.com/owner/repo/actions/runs/123",
+    "watching": false
+  },
+  "error": null,
+  "meta": {"verb": "release.open", "durationMs": 620}
+}
+```
+
+### 4.4 `cleo release reconcile <version>`
+
+#### 4.4.1 Inputs
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `version` | positional string | yes | — | The version whose tag has landed on `main`. |
+| `--from-workflow` | boolean | no | `false` | Indicates the verb is invoked from inside `release-publish.yml`. Affects logging verbosity, not behavior. |
+| `--rollback` | boolean | no | `false` | Reconciles a rollback rather than a publish. (See §10.) |
+| `--json` | boolean | no | `false` | Emit LAFS envelope. |
+
+#### 4.4.2 Pre-conditions
+
+- **R-080** The plan file at `.cleo/release/<version>.plan.json` MUST exist; otherwise the verb MUST return `E_PLAN_NOT_FOUND`.
+- **R-081** The git tag `<version>` MUST exist locally OR the verb MUST be able to fetch it from `origin`. If neither is true, the verb MUST return `E_TAG_NOT_FOUND`.
+- **R-082** `gh release view <version>` MUST succeed and MUST return `tagName == <version>`. If the tagName does not match (forensics §F6 mitigation), the verb MUST return `E_TAG_MISMATCH` with `meta.expected` and `meta.actual` populated.
+- **R-083** For each task in `plan.tasks[]`, the verb MUST re-validate ADR-051 evidence atoms via the staleness check (ADR-051 D8). If any atom is stale, the verb MUST return `E_EVIDENCE_STALE` with `meta.staleTasks[]` populated UNLESS `CLEO_OWNER_OVERRIDE=1` and `CLEO_OWNER_OVERRIDE_REASON` are both set.
+
+#### 4.4.3 Side effects
+
+- **R-090** The verb MUST INSERT one row into `releases` if not already present, or UPDATE the existing row with `status='reconciled'`, `tag_sha=<sha>`, `release_commit_sha=<merge-sha>`, `shipped_at=<gh-release.published_at>`.
+- **R-091** The verb MUST INSERT one row into `commits` for each commit reachable from the new tag back to `previousVersion` (via `git log <previousTag>..<tag>`). UPSERT semantics MUST be applied (PK is `sha`). (Provenance design §3.1, §4.3.)
+- **R-092** The verb MUST INSERT into `task_commits` for each `T####` token extracted from each commit subject/body/trailers. The `link_source` MUST be set to `commit-message` for subject hits, `commit-trailer` for trailer hits, `pr-body` for PR body hits.
+- **R-093** The verb MUST INSERT into `release_commits` for each commit in the release range, recording `position` (topo order) and the flags `is_first`, `is_last`, `is_release_chore`.
+- **R-094** The verb MUST INSERT into `release_changes` for each task in `plan.tasks[]`, classifying `change_type` per the rules in `provenance-graph-design.md` §2.2 (hotfix detection: P0/P1 severity AND <72h gap AND `release_kind='hotfix'` OR same-day-suffix).
+- **R-095** The verb MUST INSERT into `release_artifacts` based on the platform matrix entries in `plan.platformMatrix[]`. Each matrix entry maps to one row keyed `(release_id, artifact_type, identifier)`.
+- **R-096** The verb MUST INSERT one row into `pull_requests` for the bump-PR + one row per related task-PR (resolved via `pr_tasks` extracted from the PR body and commit message regex).
+- **R-097** The verb MUST INSERT into `brain_release_links` for each `cleo memory observe …` reference detected in the plan, the PR body, or release commits. `link_type` MUST be set per the §8.1 mapping.
+- **R-098** The verb MUST invoke `cleo memory observe "Released <version> with N changes" --title "Release <version>" --type observation` exactly once per successful reconcile.
+- **R-099** The verb MUST archive the plan file to `.cleo/release/archive/<version>.plan.json` and MUST NOT delete the original until the archive write is durable.
+- **R-100** All inserts in R-090 through R-097 MUST execute inside a single SQLite transaction. If any insert fails, the entire transaction MUST roll back AND the verb MUST return `E_PROVENANCE_FAILED` with `error.details` listing the failing table.
+
+#### 4.4.4 Post-conditions
+
+- **R-110** `releases.status = 'reconciled'` and `shipped_at` is non-null.
+- **R-111** Every commit in `git log <prevTag>..<tag>` is represented in `commits` and `release_commits`.
+- **R-112** Every task in `plan.tasks[]` has a corresponding `release_changes` row.
+- **R-113** A BRAIN observation referencing the release exists.
+
+#### 4.4.5 Output envelope
+
+```json
+{
+  "success": true,
+  "data": {
+    "version": "v2026.6.0",
+    "tag": "v2026.6.0",
+    "tagSha": "abc123…",
+    "commitCount": 42,
+    "taskCount": 12,
+    "changeCount": 12,
+    "artifactCount": 23,
+    "brainLinkCount": 3,
+    "orphanCommits": []
+  },
+  "error": null,
+  "meta": {"verb": "release.reconcile", "durationMs": 4200, "txSize": 83}
+}
+```
+
+### 4.5 `cleo release rollback <version> [--full]`
+
+#### 4.5.1 Inputs
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `version` | positional string | yes | — | The version to roll back. |
+| `--full` | boolean | no | `false` | Drives `release-rollback.yml` with mode=full (delete tag + revert commit + npm deprecate). Without this flag, the verb only flips DB status. |
+| `--reason` | string | yes when `--full` | — | Human-readable rollback reason. Stored in `releases.rolled_back_reason`. |
+| `--json` | boolean | no | `false` | Emit LAFS envelope. |
+
+#### 4.5.2 Pre-conditions
+
+- **R-120** `releases.status` for the version MUST be `reconciled` OR `published` (not `planned` or `pr-opened`); otherwise the verb MUST return `E_INVALID_STATE`.
+- **R-121** For `--full`, `gh auth status` MUST succeed AND the operator MUST have `repo:write` scope; otherwise the verb MUST return `E_INSUFFICIENT_SCOPE`.
+
+#### 4.5.3 Side effects
+
+- **R-130** Without `--full`, the verb MUST only UPDATE `releases.status='rolled_back'` and `rolled_back_reason=<reason>` (metadata flip). No git or registry mutation.
+- **R-131** With `--full`, the verb MUST invoke `gh workflow run release-rollback.yml --field version=<version> --field reason=<reason> --field mode=full` and MUST persist `releases.rollback_workflow_run_url`.
+- **R-132** The verb MUST emit a BRAIN observation with `--type decision` and title `"Rolled back <version>"`.
+
+#### 4.5.4 Post-conditions
+
+- **R-140** `releases.status = 'rolled_back'` and `rolled_back_at` non-null.
+
+### 4.6 Supporting read verbs (read-only)
+
+These verbs are LAFS-compliant queries that MUST NOT mutate state. They are bound to the provenance schema defined in `provenance-graph-design.md` §3 and the queries defined there §5.
+
+| Verb | Source | Inputs | Reads | Output |
+|---|---|---|---|---|
+| `cleo release graph <version>` | Provenance §6.1 | version, `--format mermaid\|dot\|json` | releases × release_changes × commits × pr_tasks | ReleaseGraph envelope |
+| `cleo release diff <v1> <v2>` | Provenance §6.1 | two versions, `--by` | release_changes set diff | ReleaseDiff envelope |
+| `cleo release impact <version>` | Provenance §6.1 | version, `--window 30d` | release_changes × task_relations | Impact report |
+| `cleo release authors <version>` | Provenance Q6 | version, `--top N` | release_commits × commits | Author roll-up |
+| `cleo release orphans <version>` | Provenance Q5 | version | release_commits NOT EXISTS task_commits | Orphan list |
+| `cleo provenance task <id>` | Provenance Q2 | task id | 5-CTE join | TaskProvenance envelope |
+| `cleo provenance commit <sha>` | Provenance §6.2 | sha (full/short) | commits × task_commits × pr_commits × release_commits | CommitProvenance |
+| `cleo provenance pr <id>` | Provenance §6.2 | owner/repo#N | pull_requests × pr_commits × pr_tasks | PRProvenance |
+| `cleo provenance feature <slug>` | Provenance Q4 | slug | hierarchy walk | FeatureProvenance |
+| `cleo provenance release <version>` | Provenance §6.2 | version | releases_view | ReleaseGraph |
+| `cleo provenance change <id>` | Provenance §6.2 | change UUID | release_changes × everything | ChangeProvenance |
+| `cleo provenance backfill --since <v>` | Provenance §4.4 | starting version, `--dry-run` | git log walk | Backfill summary |
+| `cleo provenance link <task-id> --commit <sha>` | Provenance §6.2 | task + commit + source | INSERT task_commits | Link confirmation |
+| `cleo provenance verify <version>` | Provenance §11 | version | Invariant checks | Pass/fail report |
+
+- **R-150** All read verbs MUST emit `{success, data, meta}` envelopes; `error` is null on success.
+- **R-151** All read verbs MUST be safe to invoke from a worktree-isolated agent (no DB writes). (ADR-070 composability.)
+- **R-152** The `--format mermaid` rendering for `cleo release graph` MUST emit a `graph TD` block consumable by mermaid-cli; rendering MUST be deterministic for identical inputs.
+
+### 4.7 Exit codes and error envelope
+
+| Exit | Error Name | Verb scope | Remediation (`error.fix`) |
+|---:|---|---|---|
+| 0 | (success) | all | — |
+| 4 | `E_PLAN_NOT_FOUND` | open, reconcile, rollback | `cleo release plan <version> --epic <id>` |
+| 4 | `E_EPIC_EMPTY` | plan | `cleo show <epic-id>` and add children |
+| 4 | `E_TAG_NOT_FOUND` | reconcile, rollback | `git fetch --tags origin` |
+| 4 | `E_WORKFLOW_NOT_FOUND` | open, rollback | install `.github/workflows/release-*.yml` |
+| 6 | `E_VALIDATION` | plan | check version format vs scheme |
+| 6 | `E_CHANNEL_MISMATCH` | plan | adjust `--channel` or version suffix |
+| 6 | `E_INVALID_STATE` | open, reconcile, rollback | inspect `releases.status` via `cleo release show` |
+| 10 | `E_EPIC_NOT_FOUND` | plan | `cleo exists <epic-id>` |
+| 13 | `E_DIRTY_TREE` | plan | commit or stash dirty paths |
+| 14 | `E_GH_NOT_AUTHENTICATED` | open, rollback | `gh auth login` |
+| 15 | `E_INSUFFICIENT_SCOPE` | rollback | `gh auth refresh -s repo` |
+| 80 | `E_LIFECYCLE_GATE_FAILED` | plan | run gates locally per ADR-051 |
+| 83 | `E_EVIDENCE_INSUFFICIENT` | plan | `cleo verify <task> --gate X --evidence …` |
+| 84 | `E_EVIDENCE_STALE` | reconcile | re-verify after rebuild OR set `CLEO_OWNER_OVERRIDE=1` |
+| 85 | `E_TAG_MISMATCH` | reconcile | inspect `gh release view`; rerun publish workflow |
+| 86 | `E_PROVENANCE_FAILED` | reconcile | inspect `error.details.table` and retry |
+| 87 | `E_PROVENANCE_INCOMPLETE` | reconcile | `cleo provenance verify <version>` |
+| 90 | `E_TIMEOUT` | all | reduce concurrency or inspect remote latency |
+| 91 | `E_FLAG_REMOVED` | all | remove `--force` per ADR-051 |
+
+- **R-160** Every error envelope MUST include `error.fix` (a single CLI invocation that resolves the error), `error.details` (a JSON object with table-specific keys), and `error.codeName` (the symbolic name from the table above). (ADR-039.)
+
+---
+
+## 5. GHA Workflow Contracts
+
+This section is normative for the four workflow files. Each workflow's trigger, permissions, jobs, concurrency, secrets, and failure-handling are specified below. Implementation MAY use composite Actions, reusable workflows, or matrix expansions as long as the contracts are satisfied.
+
+### 5.1 `release-prepare.yml`
+
+#### 5.1.1 Trigger
+
+- **R-200** The workflow MUST trigger on `workflow_dispatch` only. It MUST NOT trigger on `push` to any branch.
+- **R-201** The workflow `inputs` MUST include `version` (string, required) and `plan-blob-sha256` (string, optional). Additional inputs MAY include `epic` and `channel` for redundancy.
+
+#### 5.1.2 Permissions
+
+- **R-202** The workflow MUST request `contents: write` (for branch + commit), `pull-requests: write` (for `gh pr create`), and `id-token: write` only if signed-tags are required. It MUST NOT request `packages: write` (not needed at prepare time).
+
+#### 5.1.3 Jobs
+
+- **R-203** The workflow MUST define jobs in the following order: `preflight` → `prepare` → (optional) `notify`. Each job's `needs` MUST chain forward; `prepare` MUST `needs: preflight`.
+- **R-204** The `preflight` job MUST run `pnpm run check` (or the equivalent per ADR-061 resolution) AND `pnpm run build` AND `pnpm run test` against `main` BEFORE creating any commit. Failure MUST fail the job and the workflow.
+- **R-205** The `prepare` job MUST: (a) call `cleo release plan <version> --epic <epic> --json` if `plan-blob-sha256` is empty; (b) verify the existing plan via sha256; (c) bump version files via `cleo version-bump --version <version>`; (d) regenerate CHANGELOG via `cleo release changelog --since <prevTag>` (preserved primitive); (e) commit with subject `release: prepare <version>`; (f) open the bump-PR via `gh pr create --base main --head release/<version> --label release --title 'release: prepare <version>' --body-file <plan-summary>`.
+- **R-206** Every step in `prepare` MUST be tagged with `timeout-minutes: <n>` where `n` is bounded above by 10 minutes for individual git steps and 20 minutes for the entire job.
+
+#### 5.1.4 Concurrency
+
+- **R-207** The workflow MUST declare `concurrency: { group: release-prepare-<version>, cancel-in-progress: false }` so that two prepare runs against the same version queue rather than collide.
+
+#### 5.1.5 Status checks
+
+- **R-208** The workflow MUST emit a status check named `release-prepare/preflight` keyed on the bump-PR's head SHA. The check MUST be required for merge per repo branch-protection rules (operator-owned).
+
+#### 5.1.6 Failure handling
+
+- **R-209** On any job failure, the workflow MUST: (a) avoid leaving the release branch in a half-cut state by reverting via `git push origin --delete release/<version>` if the branch was created; (b) print `Recovery: cleo release plan <version> --epic <id>; cleo release open <version>` to the job log; (c) emit `meta.recoveryCommand` into a job summary artifact (Hermes Tier-1 §8 — recovery hint).
+
+#### 5.1.7 Secrets
+
+- **R-210** Required secrets: `GITHUB_TOKEN` (provided automatically). Optional: none. The prepare workflow MUST NOT require `NPM_TOKEN` (npm publish belongs to `release-publish.yml`).
+
+### 5.2 `release-publish.yml`
+
+#### 5.2.1 Trigger
+
+- **R-220** The workflow MUST trigger on `push: main` filtered to `paths: [package.json, packages/*/package.json, Cargo.toml, packages/*/Cargo.toml, pyproject.toml, packages/*/pyproject.toml]`. (Letta research §3.4.)
+- **R-221** The workflow MUST also support `workflow_dispatch` with `version` input for manual re-runs and idempotency tests.
+
+#### 5.2.2 Permissions
+
+- **R-222** The workflow MUST request `contents: write` (for tag), `id-token: write` (for OIDC publish), and per-job `packages: write` only on the publish-and-tag job.
+
+#### 5.2.3 Jobs
+
+- **R-223** The workflow MUST define jobs in the following order: `detect` → `build-matrix` → `publish-and-tag` → `reconcile`.
+- **R-224** The `detect` job MUST classify the triggering commit by inspecting `git log --format=%s "${{ github.event.before }}..${{ github.sha }}" | grep -E '^release: prepare v'` and MUST emit `should_publish=true|false` and `version=<v>` outputs. If `should_publish=false`, all downstream jobs MUST be skipped.
+- **R-225** The `build-matrix` job MUST be a matrix expansion across the five T1737 platform tuples: `linux-x64`, `linux-arm64`, `macos-x64`, `macos-arm64`, `windows-x64`. Each matrix slot MUST run `bun install` (or equivalent for archetype), `pnpm run check`, `pnpm run build`, `pnpm run test`, and the integration smoke (`./bin/cleo --version` and `./bin/cleo briefing --json | jq .ok` with `ANTHROPIC_API_KEY` from secrets).
+- **R-226** The `publish-and-tag` job MUST: (a) require `environment: cleo-publish` (GitHub Environments — Letta §3.4 step 7, with optional required-reviewer enforcement at operator's discretion); (b) `pnpm publish --access public --tag <channel>` for npm archetypes; (c) `cargo publish --token $CARGO_TOKEN` for crates; (d) `git tag <version> $GITHUB_SHA && git push origin <version>`; (e) `softprops/action-gh-release@v2` with `tag_name: <version>`, `target_commitish: $GITHUB_SHA`, `generate_release_notes: true`, `files: <matrix-artifacts>`, `fail_on_unmatched_files: true`.
+- **R-227** The `reconcile` job MUST install CLEO (via `npm install -g @cleocode/cleo@<version>` against the freshly-published version, OR via a build-cache restore from the build-matrix) and MUST invoke `cleo release reconcile <version> --from-workflow --json`. Failure of reconcile MUST NOT roll back the tag or the publish — instead, the workflow MUST emit a non-blocking status check `release-publish/reconcile=failed` and MUST trigger a `provenance-backfill` issue creation via `gh issue create`. (Provenance graph is additive; reconcile failure is recoverable post-hoc.)
+- **R-228** The `publish-and-tag` job MUST NOT execute if any matrix slot in `build-matrix` failed.
+- **R-229** The tag step MUST poll `gh pr view <pr-number> --json state,mergeCommit` BEFORE issuing `git tag` to assert `state == MERGED` AND `mergeCommit.oid == $GITHUB_SHA`. Mismatch MUST fail the step with `E_TAG_MISMATCH` and MUST NOT push the tag. (Forensics §F6 — eliminates the race by construction.)
+
+#### 5.2.4 Concurrency
+
+- **R-230** The workflow MUST declare `concurrency: { group: release-publish-<version>, cancel-in-progress: false }`.
+
+#### 5.2.5 Status checks
+
+- **R-231** The workflow MUST emit `release-publish/build-matrix` (one per matrix slot, summarized) and `release-publish/publish-and-tag`. Both MUST be visible on the merged commit.
+
+#### 5.2.6 Failure handling
+
+- **R-232** On `build-matrix` failure, the workflow MUST attach each matrix slot's test log as a workflow artifact (retention 30 days).
+- **R-233** On `publish-and-tag` failure AFTER any one registry has succeeded, the workflow MUST emit a critical-severity issue via `gh issue create --label release-incident --title "Partial publish failure: <version>"` AND MUST print explicit operator recovery instructions in the job log.
+
+#### 5.2.7 Secrets
+
+- **R-234** Required secrets: `GITHUB_TOKEN`, `NPM_TOKEN` (for `pnpm publish`), `ANTHROPIC_API_KEY` (or equivalent `CLEO_RELEASE_TEST_KEY` for integration smoke). Optional: `CARGO_TOKEN`, `PYPI_TOKEN`, `DOCKER_HUB_TOKEN`.
+- **R-235** Secrets MUST be scoped to `environment: cleo-publish` to gate access behind the Environment's required-reviewer policy.
+
+### 5.3 `release-fanout.yml`
+
+#### 5.3.1 Trigger
+
+- **R-240** The workflow MUST trigger on `release: published` (the GitHub Release event). It MUST NOT trigger on `release: created` (which fires for drafts).
+
+#### 5.3.2 Permissions
+
+- **R-241** The workflow MUST request `contents: read` and any per-action permissions required by downstream actions (e.g. `pages: write` for docs deploy).
+
+#### 5.3.3 Jobs
+
+- **R-242** The workflow MAY define independent best-effort jobs: `docs-deploy`, `docker-retag`, `sentinel-notify`, `studio-deploy`, `nightly-trigger`. Each job MUST be marked `continue-on-error: true`; fanout failures MUST NOT mark the release as failed.
+
+#### 5.3.4 Concurrency
+
+- **R-243** The workflow MAY use `concurrency: { group: fanout-<version> }` to avoid concurrent fanouts colliding.
+
+#### 5.3.5 Status checks
+
+- **R-244** Fanout jobs MUST NOT be required status checks for the release commit. They are advisory.
+
+### 5.4 `release-rollback.yml`
+
+#### 5.4.1 Trigger
+
+- **R-250** The workflow MUST trigger on `workflow_dispatch` only.
+- **R-251** Inputs MUST include `version` (string, required), `mode` (enum `metadata-only|full`, required), and `reason` (string, required).
+
+#### 5.4.2 Permissions
+
+- **R-252** For `mode=full`, the workflow MUST request `contents: write` (for tag deletion and revert commit), `pull-requests: write` (for the revert PR), and `packages: write` (for npm deprecate).
+
+#### 5.4.3 Jobs
+
+- **R-253** The workflow MUST define jobs: `validate` → `revert` → `deprecate` → `reconcile-rollback`.
+- **R-254** The `revert` job MUST open a revert PR (NOT a direct revert push to main): `git revert -n <release-commit-sha> && git checkout -b revert/<version> && gh pr create --base main --label rollback`. The PR title MUST be `Revert release <version>: <reason>`. Direct push to `main` is FORBIDDEN (ADR-065).
+- **R-255** The `deprecate` job MUST issue `npm deprecate <package>@<version> "Rolled back: <reason>"` per published artifact. Failure MUST be reported but MUST NOT block downstream jobs.
+- **R-256** The `reconcile-rollback` job MUST invoke `cleo release reconcile <version> --rollback --reason "<reason>"` to write the rollback marker into `releases.rolled_back_at` and `release_changes` (a new `change_type='revert'` row referencing the rolled-back tasks).
+
+#### 5.4.4 Concurrency
+
+- **R-257** The workflow MUST declare `concurrency: { group: rollback-<version>, cancel-in-progress: false }`.
+
+### 5.5 Cross-workflow contracts
+
+- **R-260** Workflow YAML files MUST pass `actionlint` in CI (T9345-CHILD-3). Any future PR that modifies a release workflow MUST add an actionlint job to the PR-required checks.
+- **R-261** Workflow files MUST NOT inline `set -e` shell scripts longer than 30 lines; longer logic MUST migrate to a composite Action or to a `cleo release` subcommand.
+- **R-262** Workflow files MUST set `defaults.run.shell: bash` to avoid cross-platform shell drift between matrix slots.
+- **R-263** Every workflow MUST pin third-party Actions to a major+minor version (`@v6`, `@v4.1`) NOT to `@main` or `@latest`. Supply-chain posture per Hermes Tier-1 §7.
+
+---
+
+## 6. Release Plan Schema
+
+The plan file at `.cleo/release/<version>.plan.json` is the canonical state record. Its schema is defined here normatively.
+
+### 6.1 Top-level shape
+
+```jsonc
+{
+  "$schema": "https://cleocode.io/schemas/release-plan/v1.json",
+  "version": "v2026.6.0",
+  "resolvedVersion": "v2026.6.0",
+  "suffixApplied": false,
+  "scheme": "calver",
+  "channel": "latest",
+  "epicId": "T9999",
+  "releaseKind": "regular",
+  "createdAt": "2026-06-01T12:00:00Z",
+  "createdBy": "cleo-prime",
+  "previousVersion": "v2026.5.74",
+  "previousTag": "v2026.5.74",
+  "previousShippedAt": "2026-05-15T08:00:00Z",
+  "tasks": [ { "id": "T10001", "kind": "feat", "impact": "minor", "userFacingSummary": "…", "evidenceAtoms": [ "commit:abc123", "test-run:vitest.json", "tool:lint", "tool:typecheck", "tool:build" ], "ivtrPhaseAtPlan": "released", "epicAncestor": "T9999" } ],
+  "changelog": { "features": [], "fixes": [], "chores": [], "breaking": [] },
+  "gates": [ { "name": "test", "atom": "tool:test", "status": "passed", "lastVerifiedAt": "2026-06-01T11:50:00Z" } ],
+  "platformMatrix": [ { "platform": "linux-x64", "publisher": "npm", "package": "@cleocode/cleo" } ],
+  "preflightSummary": { "esbuildExternalsDrift": false, "lockfileDrift": false, "epicCompletenessClean": true, "doubleListingClean": true },
+  "workflowRunUrl": null,
+  "prUrl": null,
+  "mergeCommitSha": null,
+  "status": "planned"
+}
+```
+
+### 6.2 Schema invariants
+
+- **R-300** `previousVersion` MUST be non-null for any plan that is not a first-ever release. `firstEverRelease=true` in plan `meta` is the only escape.
+- **R-301** `tasks[*].evidenceAtoms` MUST be non-empty for each task. A task with zero evidence atoms MUST cause `cleo release plan` to return `E_EVIDENCE_INSUFFICIENT`. (ADR-051 surface inside release.)
+- **R-302** `status` MUST advance monotonically: `planned` → `pr-opened` → `pr-merged` → `published` → `reconciled`, with `rolled_back`, `failed`, and `cancelled` as terminal off-ramps reachable from any non-terminal state.
+- **R-303** `epicAncestor` MUST be computed at plan time, not derived at reconcile time. The epic-scope-leak failure (Forensics §F2) is eliminated because the plan locks the epic scope; downstream consumers MUST NOT re-derive.
+- **R-304** `gates[*].status` MUST be one of `passed` | `failed` | `skipped` | `unresolved`. `unresolved` indicates the tool resolver could not produce a command for the project archetype; the plan MAY still be opened if `preflightSummary.preflightWarnings[]` is acknowledged.
+- **R-305** `platformMatrix[]` MUST contain at least one entry. For project archetypes that publish a single artifact, the array has length 1.
+- **R-306** The plan file MUST validate against the JSON schema (T9345-CHILD-1 deliverable) using a deterministic validator (ajv strict mode). Validation MUST be re-run inside `open` and `reconcile` before any downstream side effects.
+
+---
+
+## 7. Evidence-Gate Integration (ADR-051 Surface)
+
+This section binds the release pipeline to ADR-051 evidence atoms as the **sole** gate execution surface. The release pipeline MUST NOT define a parallel gate registry.
+
+- **R-310** `cleo release plan` MUST require every task in the plan to have, AT MINIMUM, evidence atoms for the gates `implemented`, `testsPassed`, and `qaPassed` per ADR-051 D1. If any required atom is missing, the verb MUST return `E_EVIDENCE_INSUFFICIENT` with `error.details.tasks[]` listing the offending task IDs.
+- **R-311** `cleo release plan` MUST resolve every `tool:<canonical>` atom via ADR-061's `resolveToolCommand` and MUST record the resolved command + source (`project-context` / `language-default` / `legacy-alias`) in `plan.gates[]`.
+- **R-312** `cleo release plan` MUST NOT execute the resolved tool commands during planning. Execution belongs to: (a) the GHA `preflight` job for `release-prepare.yml`; (b) the agent that already executed the tool when the task was completed; (c) the GHA `build-matrix` job for `release-publish.yml`. Triple-execution is acceptable; double-execution at plan time is wasteful and is FORBIDDEN here.
+- **R-313** `cleo release reconcile` MUST re-validate ADR-051 staleness (D8): for each `commit:<sha>` atom, the commit MUST still be reachable from the release tag; for each `files:<paths>` atom, the file sha256 at the release commit MUST match the stored sha256; for each `test-run:<json>` atom, the JSON sha256 MUST be unchanged. (Forensics §F3, F4 — gates are real and re-checked at the canonical surface.)
+- **R-314** `cleo release reconcile` failure due to stale evidence MUST emit `E_EVIDENCE_STALE` with `meta.staleTasks[]` and MUST NOT roll back the tag or the publish. The release shipped; provenance is best-effort post-hoc.
+- **R-315** The release pipeline MUST NOT inherit ADR-051's `--force` semantics. The override surface contracts to one well-audited place: `CLEO_OWNER_OVERRIDE=1` at the `cleo verify` layer, NOT at the release layer.
+- **R-316** IVTR phase data (`task.ivtr_state.currentPhase`) MAY appear in `plan.tasks[*].ivtrPhaseAtPlan` for backward-compatibility observation. The field MUST be informational only and MUST NOT influence any gate decision. (Audit Priority 1.)
+
+---
+
+## 8. Provenance Recording (Normative)
+
+The release pipeline MUST write to the 11 new tables defined in `provenance-graph-design.md` §3. This section binds each write to the appropriate verb and workflow.
+
+### 8.1 Write surface per table
+
+| Table | Writer | Trigger | RFC-2119 invariant |
+|---|---|---|---|
+| `commits` | `cleo release reconcile` | git log walk of `<prevTag>..<tag>` | **R-330** Every commit reachable from the tag MUST have a row; UPSERT keyed on `sha`. |
+| `task_commits` | `cleo release reconcile` | task ID regex against subject/body/trailers | **R-331** Every `T####` token in a commit MUST validate against `tasks.id` before insert; unknown tokens MUST be recorded under `meta.unknownTokens[]` and MUST NOT cause reconcile failure. |
+| `commit_files` | `cleo release reconcile` | `git show --name-status <sha>` per commit | **R-332** Per-file rows MUST be inserted for every changed file; rename detection MUST populate `old_path`. |
+| `pull_requests` | `cleo release reconcile` | `gh api repos/:owner/:repo/pulls/:n` | **R-333** The bump-PR MUST have a row; task-PRs referenced in plan.tasks MUST have rows. |
+| `pr_commits` | `cleo release reconcile` | `gh api …/commits` per PR | **R-334** Ordered by `position`. |
+| `pr_tasks` | `cleo release reconcile` | PR title/body/branch-name regex | **R-335** `link_source` MUST be one of `pr-title|pr-body|branch-name|commit-trailer|manual`. |
+| `releases` | `cleo release plan` (INSERT `status=planned`); `cleo release open` (UPDATE `status=pr-opened`); `release-publish.yml` (UPDATE `status=committed`); `cleo release reconcile` (UPDATE `status=reconciled`) | each lifecycle transition | **R-336** Status transitions MUST follow the FSM (§9); illegal transitions MUST return `E_INVALID_STATE`. |
+| `release_commits` | `cleo release reconcile` | `git log <prevTag>..<tag>` walk | **R-337** `position` MUST be topo-sorted ascending; `is_first` / `is_last` / `is_release_chore` flags MUST be exclusive of each other for a given release. |
+| `release_changes` | `cleo release reconcile` | task in plan + classifier | **R-338** `change_type` MUST be classified per Provenance §2.2 rules; hotfix detection MUST run inside reconcile, NOT during plan. |
+| `release_artifacts` | `cleo release reconcile` | `gh release view --json assets` + plan.platformMatrix | **R-339** One row per `(release_id, artifact_type, identifier)` triple; UPSERT semantics. |
+| `brain_release_links` | `cleo release reconcile` | scan PR body + commits for `cleo memory observe` references | **R-340** `link_type` MUST be one of `approved-by|documented-in|derived-from|observed-in`; the auto-emitted reconcile observation MUST be linked with `link_type=observed-in`. |
+| `releases_view` (read-only view) | (none; computed) | — | **R-341** The view MUST be created via migration; consumers MUST NOT write to it. |
+
+### 8.2 Transactionality
+
+- **R-345** All inserts described in §8.1 for a single reconcile invocation MUST execute inside a single SQLite transaction. The transaction MUST be opened by `openCleoDb()` per ADR-068 chokepoint.
+- **R-346** Partial writes are FORBIDDEN. On any insert failure, the entire transaction MUST roll back AND `cleo release reconcile` MUST return `E_PROVENANCE_FAILED` with `error.details.table` identifying the failure.
+- **R-347** Idempotency: re-running `cleo release reconcile <version>` against an already-reconciled release MUST be a no-op modulo `meta.reReconciled=true` and MUST NOT duplicate any row.
+
+### 8.3 Backfill compatibility
+
+- **R-350** Historical `release_manifests` rows MUST remain readable indefinitely. The migration plan (artifact 2) details the backfill semantics; this spec only requires that the legacy table is NOT dropped without an explicit successor migration (T9345-CHILD-2 deliverable).
+- **R-351** `cleo provenance backfill --since <version>` MUST be idempotent. Re-running MUST UPSERT rows; existing data MUST NOT be overwritten unless `--force-overwrite` is supplied (and that flag MUST audit-log every change).
+
+---
+
+## 9. Project-Agnostic Resolution
+
+The release pipeline MUST work for at least three project archetypes today (npm monorepo, single npm lib, single Rust crate) and SHOULD work for additional archetypes (Python pkg, Bun pkg, mixed npm+rust, Docker image, binary tarball).
+
+### 9.1 Archetype → tool resolution matrix
+
+| Archetype | `test` | `build` | `lint` | `typecheck` | `audit` | `security-scan` | `publish` |
+|---|---|---|---|---|---|---|---|
+| `monorepo-w-workspaces` (cleocode) | `pnpm run test` | `pnpm run build` | `pnpm biome ci .` | `pnpm run typecheck` | `pnpm audit` | `pnpm dlx audit-ci` | `pnpm -r publish --access public` |
+| `single-npm-lib` | `npm test` | `npm run build` | `npm run lint` | `npx tsc --noEmit` | `npm audit` | `npm audit --audit-level=high` | `npm publish --access public` |
+| `single-rust-crate` | `cargo test --all-features` | `cargo build --release` | `cargo clippy --all-targets -- -D warnings` | `cargo check --all-targets` | `cargo audit` | `cargo audit` | `cargo publish` |
+| `single-python-pkg` (stretch) | `pytest` | `python -m build` | `ruff check .` | `mypy .` | `pip-audit` | `bandit -r .` | `twine upload dist/*` |
+| `mixed-npm-rust` | both | both | both | both | both | both | both (matrix) |
+| `docker-image` | `docker build --target test .` | `docker build .` | `hadolint Dockerfile` | (n/a) | `trivy image …` | `trivy fs .` | `docker push` |
+| `binary-tarball` | per-language | per-language | per-language | per-language | per-language | per-language | `gh release upload` |
+
+- **R-360** The resolver MUST honor `.cleo/project-context.json` overrides per ADR-061 §1. Archetype defaults are fallbacks only.
+- **R-361** When the archetype cannot be unambiguously detected (e.g. both `package.json` and `Cargo.toml` present with workspace markers), the resolver MUST emit `meta.archetype=mixed-npm-rust` and MUST run both publish paths in the platform matrix.
+- **R-362** Adding a new archetype MUST NOT require a release-pipeline code change. It MUST require only: (a) a new entry in ADR-061's per-`primaryType` defaults; (b) an updated table in `.cleo/project-context.json` schema; (c) a new test fixture under `packages/cleo/test/fixtures/release-test-<archetype>/`.
+
+### 9.2 Platform matrix
+
+- **R-370** The `platformMatrix` field in the plan MUST enumerate the (platform-tuple, publisher) pairs the release will produce. Platform tuples are: `linux-x64`, `linux-arm64`, `macos-x64`, `macos-arm64`, `windows-x64`. T1737 alignment.
+- **R-371** For archetypes that produce a single platform-agnostic artifact (e.g. pure npm package without native bindings), the matrix MAY collapse to one row with `platform=any` and the GHA matrix MAY skip per-platform smoke tests.
+
+---
+
+## 10. State Machine
+
+### 10.1 `releases.status` FSM
+
+```mermaid
+stateDiagram-v2
+    [*] --> planned : cleo release plan
+    planned --> pr-opened : cleo release open
+    pr-opened --> pr-merged : release-prepare.yml + PR merged
+    pr-merged --> published : release-publish.yml (build + publish + tag)
+    published --> reconciled : cleo release reconcile
+    reconciled --> rolled_back : cleo release rollback --full
+    planned --> cancelled : operator cancels before opening
+    pr-opened --> cancelled : operator closes bump-PR without merge
+    pr-opened --> failed : preflight or prepare job fails
+    published --> failed : publish job fails partway (registry partial)
+    reconciled --> [*] : steady state
+    rolled_back --> [*] : terminal
+    cancelled --> [*] : terminal
+    failed --> [*] : terminal (with manual recovery)
+```
+
+### 10.2 Transition guards
+
+| From | To | Verb / event | Guard |
+|---|---|---|---|
+| (none) | planned | `cleo release plan` | R-020 through R-024 |
+| planned | pr-opened | `cleo release open` | R-050 through R-053 |
+| pr-opened | pr-merged | PR merge on `main` | release-prepare.yml status checks all green |
+| pr-merged | published | `release-publish.yml` | build-matrix + publish-and-tag both succeed |
+| published | reconciled | `cleo release reconcile` | R-080 through R-083 |
+| reconciled | rolled_back | `cleo release rollback --full` | R-120 through R-121 |
+| any non-terminal | failed | error in workflow or verb | failure observed; operator action required |
+| planned, pr-opened | cancelled | operator action | bump-PR closed without merge OR plan deleted |
+
+- **R-380** Any attempt to transition state outside the FSM MUST return `E_INVALID_STATE` and MUST NOT mutate any row.
+- **R-381** The FSM transitions MUST be persisted to `audit_log` (existing table) with `(timestamp, version, fromStatus, toStatus, verb, actor)`.
+
+---
+
+## 11. Hotfix Path
+
+Hotfixes are first-class in v2. The plan/open/publish/reconcile flow handles them with no new verbs; the `--hotfix` flag and the same-day suffix scheme are the only additions.
+
+- **R-400** `cleo release plan v2026.5.74.2 --epic T9344 --hotfix` MUST: (a) detect that `v2026.5.74` is already shipped; (b) compute the suffix `.2` (or higher if collisions exist); (c) set `plan.releaseKind='hotfix'`; (d) bypass the epic-completeness check that drags in unrelated epics. (Forensics §F2 — explicit scope.)
+- **R-401** Hotfix plans MUST scope epic completeness STRICTLY to the `--epic <id>` argument. Other epics' completeness MUST NOT block a hotfix.
+- **R-402** The `--scheme calver-suffix` MUST be a parser variant added to `validateVersion` (currently `pipeline.ts:288-316`). The grammar is `v<YYYY>.<M>.<DD>(.<N>)?` where `N >= 2` (the base version is `.0` implicitly; the first hotfix is `.2`).
+- **R-403** `release-publish.yml` MUST NOT need any hotfix-specific branching. The bump-PR carries the suffix; the workflow tags whatever subject `release: prepare v` matches.
+- **R-404** `release_changes.change_type='hotfix'` MUST be set per Provenance §2.2 rules. (Severity P0/P1 AND <72h gap AND release_kind=hotfix.)
+- **R-405** MTTR target for a hotfix path MUST be ≤1 hour from "P0 detected" to "fix shipped to main npm dist-tag", measured end-to-end including human PR review. This is an acceptance gate, not just a SHOULD.
+
+---
+
+## 12. Backward Compatibility Window
+
+### 12.1 Deprecated verbs
+
+The following CLI verbs MUST remain functional for at least three release cycles after T9345 Phase 5 (see migration plan):
+
+- **R-420** `cleo release ship` — MUST be a deprecated alias that prints a single warning to stderr and forwards to `plan + open + (auto-)publish` orchestration. Exit codes and envelope semantics MUST match the new verbs.
+- **R-421** `cleo release start` — MUST be a deprecated alias for `cleo release plan`. Behavior: prints warning, forwards.
+- **R-422** `cleo release verify` — MUST be deprecated. Behavior: prints warning, suggests `cleo verify <task> --gate X --evidence …` per ADR-051.
+- **R-423** `cleo release publish` — MUST be deprecated. Behavior: prints warning, suggests `cleo release open <version>`.
+- **R-424** `cleo release pr-status` — MUST remain available as a read-only helper that wraps `gh pr checks` for the in-flight bump-PR. NOT deprecated.
+
+### 12.2 Removal timeline
+
+- **R-430** Deprecated verbs MUST be removed in a major version bump no earlier than the third release cycle after T9345 Phase 5 completes. The exact removal release MUST be announced in the deprecation warning text.
+- **R-431** Each deprecated verb's deprecation warning MUST include the replacement invocation, the target removal release, and a link to T9345-CHILD-1 docs.
+
+### 12.3 Compatibility shim — `--workflow=false`
+
+- **R-440** During the migration window (Phase 4 of the migration plan, ~2 weeks), `cleo release ship` MUST accept `--workflow=false` as an emergency escape hatch that bypasses GHA and runs the legacy 12-step monolith locally. This flag MUST be removed at Phase 6 (cleanup).
+- **R-441** Every `--workflow=false` invocation MUST log a CRITICAL-level entry to `.cleo/audit/release-emergency.jsonl` with `(timestamp, version, operator, reason)`. Operators SHOULD prefer fixing the workflow over using the escape hatch.
+
+---
+
+## 13. Failure-mode → spec section mapping
+
+The forensics document enumerates 10 distinct production failures. Each is structurally eliminated by an explicit spec section or narrowed by a residual mitigation.
+
+| # | Failure (forensics §) | Spec section | Structural prevention? |
+|---|---|---|---|
+| 1 | Wedged git commit (no timeout) | §5.1 (`release-prepare.yml` step `timeout-minutes`) + R-005, R-006 | **YES** — git commit runs once in GHA with workflow-native timeout; local CLI never spawns long-running git. |
+| 2 | Epic completeness scope leak | §4.2 R-021 + §6.2 R-303 + §10 R-401 | **YES** — plan locks `epicId`; reconcile reads it; checkEpicCompleteness consumes plan, not derived ancestors. |
+| 3 | Gate runners not wired | §7 R-310 through R-316 + §9 R-360 | **YES** — ADR-061 resolver is the only path; release-side `runReleaseGates` is deleted; `defaultRunGate` stub is deleted. |
+| 4 | IVTR non-blocking gate | §7 R-316 + Audit Priority 1 | **YES** — IVTR removed from release path; `task.ivtr_state` is observation-only. |
+| 5 | Override cap counter broken | §4.1 R-007, R-008 | **YES** — no `--force` on any release verb; `CLEO_OWNER_OVERRIDE` is narrow (reconcile-stale only) and audited. |
+| 6 | Tag at wrong SHA | §5.2 R-229 | **YES (by construction)** — tag is created in workflow from `$GITHUB_SHA` ONLY after `gh pr view` confirms `state=MERGED` AND `mergeCommit.oid == $GITHUB_SHA`. |
+| 7 | Worker direct-push to main | §5.4 R-254 + ADR-065 + T9345-CHILD-7 | **MITIGATED via defense-in-depth** — GitHub branch protection (server-side) + git-shim worktree-policy file (client-side, T9345-CHILD-7). |
+| 8 | Release start no-op | §4.2 R-030 + §6 (plan file IS the state) | **YES** — no `start` verb; plan file IS the resumable state. |
+| 9 | Esbuild externals not auto-detected | §5.1 R-204 (preflight runs `pnpm run build`) | **YES** — build failure blocks the bump-PR before it lands in main. |
+| 10 | CHANGELOG fragile | §5.2 R-226 (`generate_release_notes: true`) + §6 (`tasks[*].userFacingSummary`) | **NARROWED** — auto-generation from PR titles + human-curated summary; verbose RCASD descriptions are not the source. |
+
+8 of 10 failures are STRUCTURALLY ELIMINATED. The remaining 2 (F7 worker direct-push, F10 changelog) are NARROWED by defense-in-depth + opt-in curation respectively.
+
+---
+
+## 14. Acceptance Criteria
+
+The implementation of this spec is acceptable only when ALL the following are demonstrably true on the cleocode repository:
+
+- **AC-1** Operator wall-time for the happy path is ≤5 minutes, measured from `cleo release plan v<x> --epic T<n>` invocation to `releases.status='reconciled'`. (Excludes human PR review.)
+- **AC-2** Zero orphan commits in shipped releases. Verified via `cleo release orphans <version>` returning an empty list for the most recent 3 releases shipped through v2.
+- **AC-3** MTTR for hotfix path is ≤1 hour, measured from "P0 detected" (timestamped issue creation) to "hotfix tag published and reconciled".
+- **AC-4** At least 3 project archetypes pass the full pipeline against fixtures: `monorepo-w-workspaces` (cleocode itself), `single-npm-lib`, `single-rust-crate`. Each scenario in `test-matrix-T9345.md` passes for these archetypes.
+- **AC-5** The 10 failure modes enumerated in `failure-forensics-10-modes.md` MUST NOT reproduce when the v2 path is exercised. The test matrix scenarios S2-S10 explicitly assert this.
+- **AC-6** The four operator verbs satisfy the operator surface constraint: 4 verbs visible at the top of `cleo release --help`. All deprecated verbs print warnings.
+- **AC-7** All 11 provenance tables are populated for every reconcile invocation in the post-migration window. `cleo provenance verify <version>` returns pass for the most recent 3 releases.
+- **AC-8** `actionlint` passes on all four workflow YAML files in CI.
+- **AC-9** No `--force` flag exists on any release verb. `cleo release --help` MUST NOT mention `--force` anywhere.
+- **AC-10** `task.ivtr_state` is read-only post-migration; the release pipeline does NOT read this field for gate decisions. (Verified by `gitnexus_query` returning zero call sites in `packages/core/src/release/*` outside the deprecation shim.)
+
+---
+
+## 15. Open Questions
+
+The following items are deferred to T9345-CHILD-1 (spec-extension) or subsequent epics. Each is non-blocking for adopting this spec but MUST be resolved before Phase 5 of the migration.
+
+1. **Workflow-internal `cleo release reconcile` invocation**: should the workflow `npm install -g @cleocode/cleo@<version>` against the freshly-published version, or restore from a build-matrix artifact? Ergonomic vs. reliability trade-off. Default per R-227 is build-cache restore; ergonomic default is global install.
+2. **Per-archetype trigger path filters for `release-publish.yml`**: the path list under R-220 includes npm + Cargo + Python markers. As archetypes are added, the list grows. Should we externalize this to a `.cleo/release-config.json` key (e.g. `release.publishTriggerPaths`)?
+3. **Integration smoke key rotation policy**: `ANTHROPIC_API_KEY` for the release-time smoke is a real key. Rotation cadence + leakage posture + cost model belong to T9345-CHILD-5.
+4. **Hotfix window configurability**: provenance §13 defers the 72h default to `release.hotfixWindowHours`. The spec MUST decide whether this is a project setting or a release-channel setting.
+5. **`generate_release_notes` taxonomy**: the auto-generated notes have no Hermes-style hierarchical sections (Highlights / Breaking / Bug fixes / Infrastructure). Adopting that taxonomy belongs to T9345-CHILD-6.
+6. **Commit-rendered release notes**: Hermes commits `RELEASE_v0.13.0.md` to the repo root. Should `release-publish.yml` mirror that pattern as a side-quest under T9345-CHILD-6? GitOps benefit but doubles the artifact source.
+7. **Cross-project release federation**: when a global nexus spans multiple CLEO projects, can `cleo provenance feature <slug>` aggregate across projects? Provenance §13 recommends NO (each project self-contained); the spec defers final decision.
+8. **Worktree-policy artifact (T9345-CHILD-7)**: this spec relies on it for F7 defense-in-depth. Sequencing: T9345-CHILD-7 SHOULD ship before Phase 5 of migration but MAY ship after.
+
+---
+
+## 16. References
+
+### 16.1 Wave-1 research
+
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/ADR-T9345-ivtr-release-overhaul.md` — the decision document (944 lines).
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/audit-cleo-release-subcommands.md` — current 14-subcommand audit (736 lines).
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/failure-forensics-10-modes.md` — 10 failures + 6 clusters (1291 lines).
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/hermes-agent-real-research.md` — 8 Tier-1 borrowable patterns (1180 lines).
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/letta-harness-real-research.md` — Letta two-stage workflow precedent (1091 lines).
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md` — IVTR↔Release conflation 7/10 (568 lines).
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/provenance-graph-design.md` — 11 new tables + 14 new CLI verbs (1340 lines).
+
+### 16.2 Prior ADRs
+
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-039-lafs-envelope-error-format.md` — error envelope contract.
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-051-programmatic-gate-integrity.md` — evidence atoms (the sole release gate surface).
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-053-project-agnostic-release-pipeline.md` — original portability promise.
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-061-project-agnostic-verify-tools.md` — canonical tool resolver.
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-062-worktree-merge-integration.md` — `git merge --no-ff` provenance.
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-063-4-step-release-pipeline.md` — superseded by this spec.
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-065-pr-required-release-flow.md` — PR-required flow (preserved).
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-068-cleo-database-charter.md` — chokepoint for new tables.
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-070-three-tier-orchestration.md` — orchestrator/lead/worker topology.
+
+### 16.3 Key source files (current; for context, not normative)
+
+- `/mnt/projects/cleocode/packages/cleo/src/cli/commands/release.ts` (current 14-subcommand surface to collapse).
+- `/mnt/projects/cleocode/packages/cleo/src/dispatch/domains/release.ts` (dispatch handler rewrite scope).
+- `/mnt/projects/cleocode/packages/core/src/release/engine-ops.ts:1105-1866` (the 761-line `releaseShip` monolith — deletion target).
+- `/mnt/projects/cleocode/packages/core/src/release/pipeline.ts` (parallel 4-step pipeline — deletion target).
+- `/mnt/projects/cleocode/packages/core/src/release/guards.ts:31-46`, `:82-122` (epic-scope fix scope).
+- `/mnt/projects/cleocode/packages/core/src/release/version-bump.ts:243-288` (workspace discovery — preserved).
+- `/mnt/projects/cleocode/packages/core/src/release/release-manifest.ts:305-409` (legacy CHANGELOG categorizer — preserved during migration).
+- `/mnt/projects/cleocode/packages/core/src/release/github-pr.ts` (`createPullRequest` — preserved, consumed by `open`).
+- `/mnt/projects/cleocode/packages/core/src/release/changelog-writer.ts` (preserved; consumed by `plan`).
+- `/mnt/projects/cleocode/packages/core/src/lifecycle/ivtr-loop.ts` (read-only post-decoupling).
+- `/mnt/projects/cleocode/packages/core/src/security/override-cap.ts` (orphaned by R-007; lifecycle fix in T9345-CHILD-8).
+- `/mnt/projects/cleocode/build.mjs:179-266` (externals list — sync-CI gate in T9345-CHILD-2 / T9345-CHILD-3).
+- `/mnt/projects/cleocode/.cleo/project-context.json` (project-archetype source of truth).
+
+---
+
+*End of SPEC-T9345 — proposed for council review at T9345 wave-3 gate.*

--- a/.cleo/rcasd/T9345/research/T9345-research.md
+++ b/.cleo/rcasd/T9345/research/T9345-research.md
@@ -1,0 +1,139 @@
+---
+epic: T9345
+stage: research
+task: T9345
+related:
+  - type: task
+    id: T9345
+  - type: adr
+    id: ADR-073
+created: 2026-05-16
+updated: 2026-05-16
+authors:
+  - cleo-prime (orchestrator)
+  - 5x wave-1 specialists (Explore, deep-research-agent ×2, root-cause-analyst, Explore)
+  - 3x wave-2 architects (system-architect ×3)
+---
+
+# T9345 — IVTR Release System Overhaul: RCASD Research Index
+
+## Summary
+
+The owner directive (2026-05-15) called for a full RCASD research wave on T9345 — the `cleo release` pipeline + IVTR system are "convoluted, good ideas executed badly." Ten concrete failure modes were captured from the v2026.5.73 → v2026.5.74 ship session. This research wave produced **10 artifacts totaling 9,137 lines** grounded in (a) the cleocode codebase, (b) the locally-cloned `/mnt/projects/hermes-agent/` source repo, (c) the upstream `letta-ai/letta` + `letta-ai/letta-code` repos via web research, and (d) the existing CLEO ADR corpus (051, 053, 061, 062, 063, 065, 068, 070, 072).
+
+## Decision (one line)
+
+**Direction B (GitOps wrapper) + Direction C qualifier**: collapse 14 `cleo release` subcommands to 4 operator verbs (`plan` / `open` / `reconcile` / `rollback`), move the outer state machine to 4 GitHub Actions workflows, keep `packages/core/src/release/*` as testable TypeScript invoked by both surfaces, and add an 11-table provenance graph so the owner can query the full feature ↔ bug ↔ hotfix ↔ epic ↔ task ↔ commit ↔ PR ↔ release graph. Net code delta: ~−1500 LOC. See `ADR-T9345-ivtr-release-overhaul.md`.
+
+## Deliverables
+
+### Wave 1 — Evidence (5 docs, ~4,866 lines)
+
+| # | Artifact | Lines | Purpose |
+|---|----------|------:|---------|
+| 1 | [`audit-cleo-release-subcommands.md`](./audit-cleo-release-subcommands.md) | 736 | Every `cleo release` subcommand mapped — CLI ↔ dispatch ↔ engine, intended purpose, observed failures, required invariants. 8-axis coupling scoring. |
+| 2 | [`failure-forensics-10-modes.md`](./failure-forensics-10-modes.md) | 1,291 | Per-failure reproduction + file:line evidence + root cause for all 10 captured failures. Clusters them into 6 root-cause patterns. Governance-vs-pipeline conflation diagnosis. |
+| 3 | [`hermes-agent-real-research.md`](./hermes-agent-real-research.md) | 1,180 | Primary-source research on the locally-cloned `/mnt/projects/hermes-agent/` (NousResearch/hermes-agent v0.13.0). 8 Tier-1 borrowable patterns (dual CalVer+SemVer tagging, `release: published` fan-out, Conventional-Commits classifier, OCI revision-label ancestor check, same-day hotfix suffixes, OSV scan, contributor attribution gate, smoke tests). |
+| 4 | [`letta-harness-real-research.md`](./letta-harness-real-research.md) | 1,091 | Distinguishes `letta-ai/letta` (Python server) from `letta-ai/letta-code` (TS harness — the actual "harness" precedent). `letta-code`'s 2-stage `prepare-release.yml` → `release.yml` workflow + `release_bump_only` classifier are the closest precedent for CLEO's target. |
+| 5 | [`ivtr-conflation-audit.md`](./ivtr-conflation-audit.md) | 568 | Conflation severity 7/10. ~600 LOC of welded coupling identified. What to keep (evidence gates, audit trails, provenance, project-agnostic tooling) vs cut (IVTR-as-blocker, `--force`, dual gate execution, auto-run gates in IVTR test phase). |
+
+### Wave 2a — Design (2 docs, ~2,284 lines)
+
+| # | Artifact | Lines | Purpose |
+|---|----------|------:|---------|
+| 6 | [`provenance-graph-design.md`](./provenance-graph-design.md) | 1,340 | 11 new SQLite tables (`commits`, `task_commits`, `commit_files`, `pull_requests`, `pr_commits`, `pr_tasks`, `releases`, `release_commits`, `release_changes`, `release_artifacts`, `brain_release_links`). 14 new CLI verbs (`cleo release graph|diff|impact|authors|orphans` + `cleo provenance task|commit|pr|feature|release|change|backfill|link|verify`). One `releases_view` materialized view. 8 canonical owner queries answered. Zero-downtime migration with dual-write kill switch. |
+| 7 | [`ADR-T9345-ivtr-release-overhaul.md`](./ADR-T9345-ivtr-release-overhaul.md) | 944 | **ADR-073**. 3 directions compared (Simplify-in-place, GitOps wrapper, Standalone CLI). 12-force trade-off matrix. Decision: Direction B + Direction C qualifier. 8 child epics enumerated. Alignment notes for T1737 Sentient Harness v3, ADR-053, ADR-061, ADR-062, ADR-072. |
+
+### Wave 2b — Spec, Migration, Tests (3 docs, ~1,970 lines)
+
+| # | Artifact | Lines | Purpose |
+|---|----------|------:|---------|
+| 8 | [`SPEC-T9345-release-pipeline-v2.md`](./SPEC-T9345-release-pipeline-v2.md) | 822 | **RFC-2119 normative spec**. 162 numbered requirements (R-001 → R-441). 16 sections covering CLI verbs, GHA workflows, evidence-gate integration (ADR-051 surface), provenance recording, project-agnostic resolution (7 archetypes), `releases.status` FSM, hotfix path, backward-compatibility window, failure-mode → spec-section mapping (8/10 structurally eliminated). |
+| 9 | [`migration-plan-T9345.md`](./migration-plan-T9345.md) | 619 | 6-phase migration plan (8–12 weeks). Each phase has scope, exit criteria, rollback trigger, LOC budget, owner-approval gates. 8 child epics decomposed (T9346 → T9353). Compatibility shim `cleo release ship --workflow=false` available for ≥3 release cycles post-cutover. Historical `release_manifests` never dropped. |
+| 10 | [`test-matrix-T9345.md`](./test-matrix-T9345.md) | 529 | 12 scenarios × 4 archetypes (monorepo-w-workspaces, single-npm-lib, single-rust-crate + python stretch). 25-slot GHA matrix. Each scenario maps to one or more of the 10 acceptance criteria + the 10 forensics failure modes. Owner sign-off checklist (30+ specific artifacts). |
+
+## Acceptance-criteria mapping (against T9345 task description)
+
+| T9345 AC (verbatim) | Satisfied by |
+|---------------------|--------------|
+| "RCASD research wave produces audit doc enumerating every cleo release subcommand current state, code path, intended purpose, observed failures, and required invariants" | #1 `audit-cleo-release-subcommands.md` |
+| "Concrete failure modes from this session catalogued with reproduction steps (wedged git commit on ship, epic completeness check fails on unrelated epics, gate runners not wired, override cap counter broken, tag-points-at-wrong-SHA, ALL-active-epics checked despite --epic flag, IVTR 'non-blocking' on 72 tasks defeats purpose)" | #2 `failure-forensics-10-modes.md` (all 10 — 6 listed + 4 more) |
+| "Design proposal compares 3 architectural directions (a: simplify in place, b: rebuild as a thin wrapper over standard git-flow tags plus GitHub Actions, c: extract into separate cli release-tool consumed by cleo release as one option)" | #7 `ADR-T9345-ivtr-release-overhaul.md` §"Considered directions" |
+| "Decision recorded as ADR with explicit trade-off matrix (provenance vs friction, epic-tracking vs portability, hermes-agent and letta-harness alignment, sentient-harness T1737 compatibility)" | #7 ADR §"Trade-off matrix" + §"Alignment notes" |
+| "Spec written for chosen direction with RFC 2119 must/should/may language" | #8 `SPEC-T9345-release-pipeline-v2.md` (162 R-numbered requirements) |
+| "Migration plan from current state with rollback path" | #9 `migration-plan-T9345.md` (6 phases × rollback per phase) |
+| "Test matrix proves IVTR works for at least 3 git-managed project archetypes: monorepo with workspaces (cleocode itself), single-package npm lib, single-binary rust crate" | #10 `test-matrix-T9345.md` (A1/A2/A3 required, A4 stretch) |
+| "All epic children produced or scheduled as separate IVTR tasks" | #7 + #9 enumerate 8 child epics (T9346 → T9353) — to be filed by the orchestrator when this research is signed off |
+
+## Owner ask: "Have we conflated and over-engineered the IVTR system?"
+
+**Yes — severity 7/10.** Evidence in #5 `ivtr-conflation-audit.md`:
+- IVTR is hard-welded into the release blocker via `engine-ops.ts:1251-1295` (`getIvtrState` ⇒ `E_IVTR_INCOMPLETE`)
+- Evidence gates (ADR-051: `implemented`/`testsPassed`/`qaPassed`) and IVTR phases (`implement`/`validate`/`test`) check the same things — agents run verifications twice
+- 72/72-task "non-blocking" warnings on a binary-by-design gate is theater
+- The provenance graph the owner wants is implicit-derivable but never queryable (no commits table, no task↔commit edges, no normalized releases table)
+- `--force` undermines evidence integrity (already on removal track per ADR-051)
+
+**Streamlining path** (sketched in #5, normatively defined in #8):
+1. **Decouple release from IVTR** (T9346 / T9351 in the plan). `task.ivtr_state` becomes observation-only; the release pipeline never reads it for gate decisions.
+2. **Single gate surface** — ADR-051 evidence atoms are the only release gate. No parallel `runReleaseGates`, no IVTR phase gate, no `defaultRunGate` stub.
+3. **First-class provenance graph** (T9347). 11 new tables, 1 view, 14 new CLI verbs. Owner's "tracking graph of released code" becomes a SQL query.
+4. **Project-agnostic by default** — ADR-061 tool resolver is the only path; per-archetype assumptions (npm/pnpm/biome) are deleted.
+
+## Owner ask: "scope of tracking is wider than a release — features, bugs, hotfixes, full provenance"
+
+**Solved by #6 `provenance-graph-design.md`** — the new `release_changes` table classifies every entry into one of 12 first-class types: `feature | enhancement | bug | hotfix | security | breaking | refactor | docs | chore | revert | deprecation | infrastructure`. `TaskKind` is extended with `feature` (currently missing) and the `task_relations` table gains `regresses | follows-up | reverts | hotfixes` edges. The 8 canonical queries (Q1–Q8) include "What bugs shipped in v?", "Show evolution graph of feature X", "What hotfixes followed release Y?", "Find the task that introduced the bug that T#### fixes?".
+
+## Hermes-agent / Letta-harness alignment
+
+Both projects were researched against their **actual code**, not assumptions:
+
+- **Hermes-agent** (`/mnt/projects/hermes-agent/`, NousResearch/hermes-agent v0.13.0, MIT-licensed): owner-forked, 12-hourly upstream sync. CLEO will adopt 8 Tier-1 mechanics from `scripts/release.py` + `.github/workflows/*.yml` — see #3 §"Tier-1 borrowable patterns" and #7 ADR §"Alignment notes". CLEO is AHEAD of Hermes on: gate ladder, epic completeness, evidence atoms, task↔commit provenance, multi-archetype.
+
+- **Letta-code** (letta-ai/letta-code, the actual "harness" precedent — not letta-ai/letta which is a no-gate Python server PyPI anti-pattern): 2-stage `prepare-release.yml` → `release.yml` workflow with a `release_bump_only` classifier that skips heavy CI on bump-only PRs. Closest precedent for CLEO's target. Adopted in spec §5.1 (R-201 → R-205) — the `release-prepare.yml` workflow is structurally Letta-code's `prepare-release.yml`. CLEO adds: tool resolver, evidence atoms, provenance graph, epic-scoped completeness, hotfix path.
+
+## T1737 Sentient Harness v3 alignment
+
+The 5-platform target (linux x64/arm64, macos x64/arm64, win x64) is first-class in spec §9.2 (R-370, R-371). `plan.platformMatrix[]` enumerates publisher × platform pairs; `release-fanout.yml` runs the matrix job. Adding a new platform requires only an entry in `.cleo/project-context.json`, no release-pipeline code change.
+
+## Next steps for the orchestrator (after owner sign-off)
+
+1. **Council review** (optional but recommended) — invoke `/ct-council` to stress-test the ADR + SPEC against five advisors.
+2. **File 8 child epics** under T9345 per #9 `migration-plan-T9345.md` §"Child-epic decomposition":
+   - T9346 — Schema migration + provenance tables (Phase 0)
+   - T9347 — Read-mostly verbs `plan` + `reconcile` (Phase 1)
+   - T9348 — Provenance backfill across historical releases (Phase 2)
+   - T9349 — `release-prepare.yml` + `cleo release open` (Phase 3)
+   - T9350 — `release-publish.yml` + `release-fanout.yml` (Phase 4)
+   - T9351 — Operator surface flip + IVTR decoupling (Phase 5)
+   - T9352 — Cleanup: delete `releaseShip` monolith + parallel 4-step pipeline (Phase 6)
+   - T9353 — Test matrix + 3-archetype fixtures
+3. **Advance T9345 to `pipelineStage=spec`** once council convergence is reached.
+4. **Run RCASD's spec stage** on each child epic before its implementation begins.
+
+## Notes
+
+- 2026-05-16 04:18 UTC — T9345 created by owner, pipelineStage=research.
+- 2026-05-16 04:30 UTC — orchestrator (cleo-prime) began wave 1.
+- 2026-05-16 05:43 UTC — wave 1 complete (5 specialists).
+- 2026-05-16 06:18 UTC — wave 2a complete (provenance graph + ADR).
+- 2026-05-16 06:35 UTC — wave 2b complete (SPEC + migration + test matrix).
+- All artifacts written without modifying any production source code. Read-only research wave.
+
+## File evidence inventory
+
+```
+/mnt/projects/cleocode/.cleo/rcasd/T9345/research/
+├── T9345-research.md                          (this index — 200 lines)
+├── audit-cleo-release-subcommands.md          (736 lines)
+├── failure-forensics-10-modes.md              (1,291 lines)
+├── hermes-agent-real-research.md              (1,180 lines)
+├── letta-harness-real-research.md             (1,091 lines)
+├── ivtr-conflation-audit.md                   (568 lines)
+├── provenance-graph-design.md                 (1,340 lines)
+├── ADR-T9345-ivtr-release-overhaul.md         (944 lines — ADR-073)
+├── SPEC-T9345-release-pipeline-v2.md          (822 lines)
+├── migration-plan-T9345.md                    (619 lines)
+└── test-matrix-T9345.md                       (529 lines)
+                                       Total: 9,137 lines of evidence + design.
+```

--- a/.cleo/rcasd/T9345/research/audit-cleo-release-subcommands.md
+++ b/.cleo/rcasd/T9345/research/audit-cleo-release-subcommands.md
@@ -1,0 +1,736 @@
+# CLEO Release Subcommand Audit — T9345
+
+**Audit Date**: 2026-05-15  
+**Auditor**: Code Analysis System  
+**Epic**: T9345 (IVTR Release System Overhaul)  
+**Status**: Complete  
+**Scope**: All `cleo release *` subcommands, CLI → dispatch → engine code paths  
+
+---
+
+## 1. Subcommand Inventory
+
+| Subcommand | CLI File:Line | Handler | Engine Function | Intent | LOC | Tests | Priority |
+|---|---|---|---|---|---|---|---|
+| `release ship` | `release.ts:33–89` | `dispatch release.ship` (composite) | `releaseShip()` | Full lifecycle: gates → PR → merge → tag → push | ~600 | yes | P0 |
+| `release start` | `release.ts:297–314` | Direct call `releaseStart()` | `releaseStart()` (pipeline.ts) | Step 1/4: validate version, capture branch, persist handle | ~30 | yes | P0 |
+| `release verify` | `release.ts:317–324` | Direct call `releaseVerify()` | `releaseVerify()` (pipeline.ts) | Step 2/4: run gates + audit children | ~25 | yes | P0 |
+| `release publish` | `release.ts:327–337` | Direct call `releasePublish()` | `releasePublish()` (pipeline.ts) | Step 3/4: invoke `publish.command` | ~20 | yes | P0 |
+| `release reconcile` | `release.ts:340–350` | Direct call `releaseReconcile()` | `releaseReconcile()` (pipeline.ts) | Step 4/4: run post-release invariants, auto-complete | ~25 | yes | P0 |
+| `release list` | `release.ts:92–97` | `dispatch pipeline.release.list` | `releaseList()` | Query all releases with filters | ~60 | yes | P2 |
+| `release show` | `release.ts:100–118` | `dispatch pipeline.release.show` | `releaseShow()` | Query single release details | ~15 | yes | P2 |
+| `release cancel` | `release.ts:121–142` | `dispatch pipeline.release.cancel` | `releaseCancel()` | Mutate: cancel draft/prepared release | ~50 | yes | P2 |
+| `release changelog` | `release.ts:152–173` | `dispatch pipeline.release.changelog.since` | `releaseChangelogSince()` | Generate CHANGELOG from git log since tag | ~150 | yes | P2 |
+| `release pr-status` | `release.ts:258–279` | `dispatch pipeline.release.pr-status` | `releasePrStatus()` | Poll CI checks for in-flight PR | ~60 | yes | P2 |
+| `release rollback` | `release.ts:176–204` | `dispatch pipeline.release.rollback` | `releaseRollback()` | Metadata-only rollback (status flip) | ~50 | yes | P2 |
+| `release rollback-full` | `release.ts:214–247` | `dispatch pipeline.release.rollback.full` | `releaseRollbackFull()` | Real rollback: delete tag, revert commit, remove record | ~270 | yes | P1 |
+| `release channel` | `release.ts:282–290` | `dispatch pipeline.release.channel.show` | (impl in dispatch) | Show current channel from git branch | ~20 | yes | P3 |
+
+**14 subcommands total**. Two code paths:
+- **Composite `release ship`**: orchestrates 12-step internal pipeline, lives entirely in engine-ops.ts (1986 LOC)
+- **Canonical 4-step (`start`/`verify`/`publish`/`reconcile`)**: isolated persistent handle + per-step design per T1597/ADR-063
+
+---
+
+## 2. Per-Subcommand Deep Dive
+
+### 2.1 `release ship`
+
+**Intent** (T5582, T5586, T9095):
+- Composite operation: automate entire release from version validation through tag push
+- Mandatory PR-based flow (no direct main push) — T9095 enforcement
+- 12-step pipeline with state logging for CLI visibility
+
+**Code Path**:
+1. CLI: `release.ts:33–89` — define shipCommand, dispatch to `'mutate' / 'pipeline' / 'release.ship'`
+2. Dispatch: `dispatch/domains/pipeline.ts` — routes to `releaseDomainHandler.mutate('release.ship', params)`
+3. Engine: `engine-ops.ts:1105–1750` — `releaseShip()` orchestrates 12 steps
+
+**Side Effects** (all irreversible after step 5):
+- **Step 0**: Bump version files via `bumpVersionFromConfig()` — writes package.json, VERSION, custom targets
+- **Step 0.5**: Auto-prepare release record — writes to SQLite release_manifests table
+- **Step 1–4**: Run gates, validate epic completeness, check double-listing (queries only)
+- **Step 4**: Write CHANGELOG.md via `generateReleaseChangelog()` — file write, SQLite update
+- **Step 5**: `git checkout -b release/v*`, `git add`, `git commit` — **point of no return** without `git reset`
+- **Step 6**: `git push -u origin <releaseBranch>` — remote mutation
+- **Step 7**: `gh pr create` — GitHub API mutation, PR created
+- **Step 8–10**: Poll CI, merge PR, tag from main, push tag — final remote mutations
+
+**Failure Surface**:
+- **No timeout on git commit**: runGitWithLockRetry() has max 6 retries (~7.85s total backoff) but no hard timeout. Step 5 can hang indefinitely if `.git/index.lock` contention never resolves — **FAILURE #1**.
+- **Epic completeness scope leak**: `--epic` flag used to filter tasks for IVTR check (line 1253–1293) but not propagated to epic-completeness guard (line 1359–1365). Guard checks ALL child tasks of all epics in manifest, not scoped to `--epic` — **FAILURE #2**.
+- **Gate runners not wired by default**: `releaseVerify()` (pipeline.ts:332) uses `opts.runGate ?? defaultRunGate`, but `defaultRunGate` at line 249–261 always returns `passed: false, reason: 'gate … runner not configured'`. In real CLI flow from `release ship`, no `runGate` injected; gates always fail — **FAILURE #3**.
+- **IVTR gate is non-blocking when `--force` passed**: line 1252 `if (!force)` skips gate entirely with warning only, contradicting T820 RELEASE-03 intent of "MUST validate IVTR phase before ship" — **FAILURE #4**.
+- **Override counter (`CLEO_OWNER_OVERRIDE` / 823/10)**: Referenced in release.ts:69 comment but NO counter enforcement in engine-ops or ship code. `--force` flag bypasses silently without cap validation — **FAILURE #5**.
+
+**Invariants Needed**:
+1. Clean git tree (no staged/unstaged changes outside release files)
+2. Network reachable (gh CLI, git push)
+3. `.cleo/config.json` valid (version scheme, publish command, branch config)
+4. Release epic must have at least one child task (else IVTR check skipped silently)
+5. CHANGELOG.md writable and parseable
+6. All version-bump targets must exist on disk
+7. Main branch must be fast-forward-able from release branch (for merge)
+
+**Observed Defects** (T9345 evidence):
+- **#1**: No timeout on git commit (runs indefinitely on lock contention)
+- **#2**: Epic scope leak (completeness check not scoped to --epic)
+- **#3**: Gate runners never wired (defaultRunGate always fails)
+- **#4**: IVTR gate non-blocking when --force (should be blocking by spec)
+- **#5**: Override counter broken (no 823/10 validation)
+
+---
+
+### 2.2 `release start` (Step 1/4)
+
+**Intent** (T1597, ADR-063):
+- Validate version against project scheme (calver/semver/sha/auto)
+- Capture current git branch
+- Persist handle to `.cleo/release/handle.json` for resumable pipeline
+
+**Code Path**:
+1. CLI: `release.ts:297–314` — direct call to `release.releaseStart(version, opts)`
+2. Engine: `pipeline.ts:288–316` — `releaseStart()` validates, creates handle, calls `writeHandle()`
+3. Handle persisted at: `join(projectRoot, '.cleo/release/handle.json')` — **line 211**
+
+**Side Effects**:
+- Writes `.cleo/release/handle.json` (new file, idempotent)
+- No git mutations
+- No network calls
+
+**Failure Surface**:
+- Version validation rejects non-matching scheme (throws cleanly)
+- `detectBranch()` falls back to 'HEAD' on git failure (non-fatal)
+- Handle file write failure is unrecoverable
+
+**Invariants Needed**:
+1. `.cleo/release/` directory writable
+2. Version string valid per detected scheme
+
+**Observed Defects**:
+- None identified in isolation. Issues emerge when piped to `verify`.
+
+---
+
+### 2.3 `release verify` (Step 2/4)
+
+**Intent** (T1597, ADR-063):
+- Run all canonical quality gates (test, lint, typecheck, audit, security-scan)
+- Audit all child tasks of release epic for green gate state
+- Both must pass for `passed: true`
+
+**Code Path**:
+1. CLI: `release.ts:317–324` — calls `loadActiveReleaseHandle()`, then `release.releaseVerify(handle)`
+2. Engine: `pipeline.ts:328–364` — iterates `VERIFY_GATES` array, calls `runGate()` for each
+3. Default gate runner: `pipeline.ts:249–261` — **hardcoded stub that always fails**
+
+**Side Effects**:
+- None (read-only; optionally runs external `cleo verify` via injected `runGate`)
+
+**Failure Surface**:
+- **Gate runner injection broken**: `opts.runGate` defaults to `defaultRunGate`, which returns `passed: false, reason: 'gate … runner not configured'`. In real CLI, no `runGate` injected from dispatcher. Result: **all gates fail by design** — **FAILURE #3 confirmed**.
+- Handle load fails if `.cleo/release/handle.json` absent (requires `release start` first)
+- Child audit returns empty list if epic not found (non-fatal)
+
+**Invariants Needed**:
+1. Active release handle must exist (created by `release start`)
+2. External gate executor must be injected at dispatch time (not done in T9345 codebase)
+
+**Observed Defects**:
+- **#3**: Gate runners never configured; `releaseVerify()` will always report gates as failed
+
+---
+
+### 2.4 `release publish` (Step 3/4)
+
+**Intent** (T1597, ADR-063):
+- Invoke project-specific publish command (npm publish, cargo publish, etc.)
+- Read from `publish.command` in `.cleo/project-context.json`
+
+**Code Path**:
+1. CLI: `release.ts:327–337` — loads handle, calls `releasePublish(handle, opts)`
+2. Engine: `pipeline.ts:376–424` — resolves command via `resolveProjectConfig()`, executes via `execFileAsync()`
+
+**Side Effects**:
+- Executes arbitrary shell command specified in project-context
+- No local file writes
+- Remote mutation (publish to registry)
+
+**Failure Surface**:
+- Command split on whitespace only (no quote parsing) — fails on args with spaces
+- Execution timeout not enforced (could hang indefinitely)
+- Failure non-fatal if `dryRun: true`
+
+**Invariants Needed**:
+1. `publish.command` exists and is executable
+2. Network reachable to target registry
+
+**Observed Defects**:
+- None specific to publish; inherits pipeline issues
+
+---
+
+### 2.5 `release reconcile` (Step 4/4)
+
+**Intent** (T1597, ADR-063, T1411/ADR-056):
+- Run post-release invariants registry (archive-reason, task auto-complete)
+- Auto-complete tasks referenced in release commit
+- Clear persistent handle on success
+
+**Code Path**:
+1. CLI: `release.ts:340–350` — loads handle, calls `releaseReconcile(handle, opts)`
+2. Engine: `pipeline.ts:436–478` — calls `runInvariants(tag, opts)`, clears handle via `clearHandle()`
+3. Invariants: `invariants/registry.ts:161–209` — iterates registered invariants, aggregates results
+
+**Side Effects**:
+- Executes each registered invariant (may write DB, audit logs)
+- On success, deletes `.cleo/release/handle.json`
+- No git mutations in this step
+
+**Failure Surface**:
+- Invariant failures non-fatal (caught at line 177, converted to error result)
+- Handle only cleared if `!opts.dryRun` AND `success === true` (line 467)
+- Invariant registry may be empty (module loads side-effect imports)
+
+**Invariants Needed**:
+1. All registered invariants must be idempotent on dry-run
+2. Invariant check functions must not throw (errors caught and wrapped)
+3. SQLite database writable for archive-reason updates
+
+**Observed Defects**:
+- None specific to reconcile logic
+
+---
+
+### 2.6 `release list` / `release show`
+
+**Intent**:
+- `list`: paginated query of all releases, filter by status
+- `show`: single release details with full manifest data
+
+**Code Path**:
+1. CLI: `release.ts:92–97`, `100–118` — dispatch to pipeline.release.{list,show}
+2. Dispatch → Engine: `engine-ops.ts:630–670` — wrap manifest queries, return EngineResult
+3. Manifest: `release-manifest.ts` — SQLite reads via Drizzle ORM
+
+**Side Effects**:
+- None (read-only)
+
+**Failure Surface**:
+- Manifest table missing (non-existent migrations) would error
+- Version normalization may cause unexpected matches (v2026.3.15 vs 2026.3.15)
+
+**Observed Defects**:
+- None
+
+---
+
+### 2.7 `release cancel`
+
+**Intent**:
+- Cancel a release in draft or prepared state
+- Remove from release_manifests table
+
+**Code Path**:
+1. CLI: `release.ts:121–142` — dispatch to pipeline.release.cancel
+2. Engine: `engine-ops.ts:983–999` — calls `cancelRelease()` from release-manifest.ts
+3. Manifest: `release-manifest.ts` — Drizzle delete operation
+
+**Side Effects**:
+- Deletes row from release_manifests table
+- No git mutations
+
+**Failure Surface**:
+- Only cancels `draft` or `prepared` status; blocks if already committed/pushed
+- No cascade delete (orphans any associated records)
+
+**Observed Defects**:
+- None
+
+---
+
+### 2.8 `release changelog`
+
+**Intent**:
+- Generate CHANGELOG from git log since a given tag
+- Parse epic/task IDs, group by epic, render markdown
+
+**Code Path**:
+1. CLI: `release.ts:152–173` — dispatch to pipeline.release.changelog.since
+2. Engine: `engine-ops.ts:886–976` — `releaseChangelogSince(sinceTag)` walks git log via `git log {sinceTag}..HEAD`
+3. Parsing: `engine-ops.ts:244–280` — `parseGitLogCommits()` extracts task IDs via regex
+
+**Side Effects**:
+- None (read-only; generates markdown, does not write)
+
+**Failure Surface**:
+- If sinceTag doesn't exist, `git log` errors and surfaced clearly
+- Regex-based parsing may miss edge-case commit formats
+- Task ID extraction assumes `\bT\d+\b` pattern (non-standard formats ignored)
+
+**Observed Defects**:
+- **#10**: CHANGELOG fragile if task descriptions exceed 150 chars (truncated in manifest generation) but spec doesn't document this limit — **(unverified, needs spec review)**
+
+---
+
+### 2.9 `release pr-status`
+
+**Intent**:
+- Poll GitHub CI check status for in-flight release PR
+- Useful when `release ship` times out or is interrupted
+
+**Code Path**:
+1. CLI: `release.ts:258–279` — dispatch to pipeline.release.pr-status
+2. Engine: `engine-ops.ts` — looks for `releasePrStatus()` (unverified — not found in engine-ops.ts reads) — **(unverified)**
+
+**Side Effects**:
+- None (read-only; queries GitHub API via gh CLI)
+
+**Failure Surface**:
+- PR not found if branch deleted remotely
+- Timeouts if GitHub API slow
+
+**Observed Defects**:
+- **(unverified)** — function signature not located; may not be implemented
+
+---
+
+### 2.10 `release rollback` / `release rollback-full`
+
+**Intent**:
+- `rollback`: metadata-only status flip to `rolled_back` in DB
+- `rollback-full`: real rollback — delete tag, revert commit, remove record
+
+**Code Path**:
+1. CLI: `release.ts:176–204`, `214–247` — dispatch to pipeline.release.{rollback,rollback.full}
+2. Engine: `engine-ops.ts:731–876` — `releaseRollback()`, `releaseRollbackFull()`
+3. Rollback-full sequence:
+   - Delete remote tag: `git push origin --delete <tag>`
+   - Delete local tag: `git tag -d <tag>`
+   - Revert commit: `git log --grep`, then `git revert --no-edit <sha>`
+   - Mark rolled_back in DB: `rollbackRelease()`
+   - (Optional) npm deprecate: `npm deprecate <pkg>@<ver> "Rolled back: reason"`
+
+**Side Effects**:
+- Creates **new revert commit** (not a reset; safe for pushed branches)
+- Deletes tag (local + remote)
+- Flips DB status
+- Optionally deprecates npm package
+
+**Failure Surface**:
+- Commit not found (grep fails silently, step skipped)
+- Remote delete fails if tag already gone (non-fatal, logged as warning)
+- Revert conflicts if release commit touched files modified since (user must resolve manually)
+- npm deprecate fails if not authenticated (non-blocking)
+
+**Invariants Needed**:
+1. Release commit must be on current branch (search by message pattern)
+2. Tag must exist locally or remotely (or skip gracefully)
+
+**Observed Defects**:
+- **#6**: Tag points at wrong SHA (if release commit and tag SHAs diverge, grep may fail) — **(unverified)**
+
+---
+
+### 2.11 `release channel`
+
+**Intent**:
+- Determine current release channel (latest/beta/alpha) from git branch
+- Used to validate version format matches channel
+
+**Code Path**:
+1. CLI: `release.ts:282–290` — dispatch to pipeline.release.channel.show
+2. Engine: `channel.ts` — `resolveChannelFromBranch()` maps branch → channel enum
+3. Branch mapping:
+   - `main` → `latest`
+   - `develop` → `beta`
+   - `alpha` → `alpha`
+
+**Side Effects**:
+- None (read-only)
+
+**Failure Surface**:
+- Unknown branch returns `null` (caller handles fallback)
+
+**Observed Defects**:
+- None
+
+---
+
+## 3. Cross-Cutting Concerns
+
+### 3.1 12-Step Pipeline State Machine
+
+**Pipeline Steps** (engine-ops.ts:1105–1750):
+```
+0.   Bump version files (optional)
+0.5. Auto-prepare release record
+1.   Validate release gates
+1.5. IVTR gate enforcement
+2.   Check epic completeness
+3.   Check task double-listing
+4.   Generate CHANGELOG + lint check
+5.   Cut release branch + commit
+6.   Push release branch
+7.   Create PR (MANDATORY)
+8.   Wait for CI checks (≤15 min)
+9.   Merge PR with --merge
+10.  Tag from main + push tag
+11.  Cleanup release branch
+12.  Record provenance
+```
+
+**State Persistence**:
+- **Claimed in comments** (pipeline.ts:25): `.cleo/release-state.json`
+- **Actual persisted file**: `.cleo/release/handle.json` (pipeline.ts:91)
+- **Handle persisted**: After `releaseStart()` only — lines 314
+- **Handle cleared**: After `releaseReconcile()` succeeds — pipeline.ts:468
+- **No resume logic**: 12-step pipeline in `releaseShip()` is NOT resumable. If step 6+ fails, handle persists but flow does not resume — **FAILURE #8: release start no-op (no state file for 12-step)**
+
+**Resumability Status**:
+- ✅ 4-step canonical pipeline (`start`/`verify`/`publish`/`reconcile`) uses persistent handle
+- ❌ 12-step `release ship` does NOT resume on failure (no intermediate state writes)
+- ❌ No mechanism to detect and resume from partial state
+
+**State Diagram** (actual vs. claimed):
+```
+Claimed in spec (CLEO-RELEASE-PIPELINE-SPEC.md §4):
+  pending → prepared → changelog_ready → gates_passed → committed → shipped
+
+Actual in codebase (release-manifest.ts):
+  draft → prepared → committed → tagged → pushed → rolled_back
+  (status lifecycle in release_manifests.status column)
+
+Actual in 12-step releaseShip():
+  No explicit state machine. Steps are sequential in code.
+  On failure, re-running from step 1 risks duplication (no idempotency).
+```
+
+### 3.2 Gate-Runner Injection
+
+**Discovery**:
+- `releaseVerify()` (pipeline.ts:328–364) requires `opts.runGate` parameter
+- Default implementation (pipeline.ts:249–261) always returns `passed: false`
+- **No injection site found** in CLI or dispatch layer
+- Every call to `releaseVerify()` in real code paths omits `runGate` parameter
+  - `release.ts:320` (CLI verify command): `release.releaseVerify(handle)` — no opts
+  - `engine-ops.ts:1236` (ship step 1): `runReleaseGates(version, …)` — different function
+
+**Conclusion**: Gate runners are **not wired by default** and never injected by CLI. `releaseVerify()` always reports all gates as failed — **FAILURE #3 confirmed**.
+
+**Evidence**:
+- pipeline.ts:332: `const runGate = opts.runGate ?? defaultRunGate;`
+- pipeline.ts:249–261: `defaultRunGate` hardcoded to fail
+- No dispatch layer override in release handler (domains/release.ts)
+- No CLI parameter to inject gate runners
+
+### 3.3 Epic Completeness Scope Leak
+
+**Claim** (release.ts:46): `--epic` flag required, "Epic task ID for commit message"
+
+**Actual Usage** (engine-ops.ts:1253–1293):
+- Epic ID loaded for IVTR gate check (line 1254–1260)
+- Epic ID scoped to IVTR gate only (line 1266)
+- **Epic completeness check (line 1359–1365) is NOT scoped to --epic**:
+  - Calls `checkEpicCompleteness(releaseTaskIds, …, priorReleasedTaskIds)`
+  - releaseTaskIds loaded from manifest (line 1343–1344)
+  - checkEpicCompleteness() checks ALL epics for missing tasks (guards.ts:53–135)
+  - No filtering by the provided `--epic` parameter
+
+**Impact**: A release with `--epic T5576` will validate completeness for ALL epics found in the task dataset, not just T5576 — **FAILURE #2: epic completeness scope leak**.
+
+**Code Location**: guards.ts:53–135 (no epic parameter)
+
+### 3.4 Workspace Auto-Discovery
+
+**Discovery Mechanism** (version-bump.ts:243–288):
+```
+if (pnpm-workspace.yaml exists
+    OR root package.json has workspaces field
+    OR packages/ directory exists with subdirectories)
+  then auto-discover Node package.json files
+```
+
+**22 Packages Assumption** (not hard-coded):
+- Scan `packages/` directory for subdirectories (line 270–283)
+- Each subdir checked for `package.json` (line 278)
+- All discovered targets added to bump list (line 279–284)
+- Count not hard-coded; discovery is dynamic
+
+**Esbuild Externals Detection** (unverified):
+- **No esbuild-specific detection found in codebase**
+- Comments mention `esbuild externals` but implementation not located
+- **FAILURE #9: Esbuild externals not auto-detected** (unverified)
+
+### 3.5 Override Counter (CLEO_OWNER_OVERRIDE)
+
+**Counter Requirement** (task brief, #5): "823/10" cap tracking — cap of 10 uses per session
+
+**Evidence in Codebase**:
+- `security/override-cap.ts` — module exists, implements counter
+- `getDb` → `releaseManifests` — stores metadata, no override_count column
+- **No integration found in release code paths**
+
+**Engine-ops Usage** (engine-ops.ts):
+- Line 1112: `force?: boolean` parameter on `releaseShip()`
+- Line 1117: `const { … force = false } = params`
+- Line 1252: `if (!force) { … } else { log.warn(…) }`
+- **No cap enforcement** — `--force` flag is unchecked boolean, not metered against a counter
+
+**Failure**: Override cap never validated during `release ship --force` — **FAILURE #5: override cap counter broken**.
+
+**Evidence**: security/override-cap.ts exists but never imported or called from engine-ops.ts.
+
+### 3.6 Worker Direct-Push to Main
+
+**Guard** (engine-ops.ts:1182–1189):
+- Check `isGhCliAvailable()` at start of `releaseShip()`
+- If `!dryRun && !isGhCliAvailable()`, return error immediately
+- Force failure if gh CLI absent → **cannot push without PR**
+
+**But**: No git-shim bypass detected in code — direct verification:
+- All git operations use `runGitWithLockRetry()` (safe)
+- All pushes go through `git push origin <branch>` (not hardcoded main)
+- PR creation mandatory before merge (line 1557–1599)
+- Merge via `gh pr merge` (GitHub API, not git CLI)
+
+**Conclusion**: Push to main is blocked by PR requirement. No direct-push bypass found — **FAILURE #7 status: NOT OBSERVED in code** (may be in runtime behavior).
+
+---
+
+## 4. Ten Captured Failures — Code Pinpoint
+
+### Failure #1: Wedged git commit (no timeout)
+
+**Description**: `runGitWithLockRetry()` has no hard timeout; can hang indefinitely on `.git/index.lock` contention.
+
+**Code Location**: `engine-ops.ts:85–139`
+
+**Root Cause**: Backoff schedule exhausted after ~7.85s (6 retries), but if lock contention persists past final retry, the last error is thrown — control returns to `releaseShip()` step 5, which would error. But if the function itself hangs (e.g., due to concurrent git process), no timeout enforced by execFileSync.
+
+**Fix Needed**: Add timeout parameter to execFileSync invocation (line 98):
+```typescript
+execFileSync('git', […args], { …opts, timeout: 30_000 })
+```
+
+**Priority**: P0 (blocking release in production)
+
+---
+
+### Failure #2: Epic completeness scope leak
+
+**Description**: `--epic` flag does not restrict epic completeness check; ALL epics in manifest are checked.
+
+**Code Location**: `engine-ops.ts:1359–1365` calls `checkEpicCompleteness()` without epicId parameter
+
+**Root Cause**: `checkEpicCompleteness()` signature (guards.ts:53) takes releaseTaskIds, not epicId; check iterates all epics found in those tasks, not scoped to the provided --epic.
+
+**Fix Needed**: Add epicId parameter to checkEpicCompleteness, filter results to that epic only.
+
+**Priority**: P1 (scope violation in release safety gate)
+
+---
+
+### Failure #3: Gate runners not wired
+
+**Description**: `releaseVerify()` always reports all gates as failed because default runner is stubbed.
+
+**Code Location**: `pipeline.ts:249–261` (defaultRunGate) + `pipeline.ts:332` (opts.runGate ?? defaultRunGate)
+
+**Root Cause**: No injection mechanism in CLI or dispatch layer to provide real gate runner. `defaultRunGate` is intentionally a stub for test isolation.
+
+**Fix Needed**: Dispatch layer must inject gate runner from ADR-061 alias resolver. Add parameter to ReleaseHandler.query('verify', …) to wire gate runner.
+
+**Priority**: P0 (gates are not actually run, defeating purpose of Step 2)
+
+---
+
+### Failure #4: IVTR non-blocking gate
+
+**Description**: `--force` flag bypasses IVTR gate silently; gate does not block even without force if `opts.runGate` not configured.
+
+**Code Location**: `engine-ops.ts:1251–1298` (force bypass) + `pipeline.ts:332` (missing runGate wiring)
+
+**Root Cause**: Two-part: (a) `if (!force)` at line 1252 makes gate skippable; (b) even with force=false, if tasks can't be loaded (line 1255–1262), gate silently passes (line 1291).
+
+**Fix Needed**: Make gate blocking (no force override). Log warning if tasks can't be loaded, but do not pass silently. Per T820 RELEASE-03, gate is MUST-HAVE.
+
+**Priority**: P0 (accountability gap per T820)
+
+---
+
+### Failure #5: Override cap counter broken
+
+**Description**: `--force` flag on `release ship` does not validate against CLEO_OWNER_OVERRIDE usage cap (default 10).
+
+**Code Location**: `engine-ops.ts:1112` (force parameter) — no cap enforcement; security/override-cap.ts never imported
+
+**Root Cause**: Override-cap module exists but is not integrated into release command path. No metric tracking or validation.
+
+**Fix Needed**: Import override-cap module in engine-ops.ts. Before bypassing any gate with force=true, call `checkOverrideCap()` and reject if limit exceeded.
+
+**Priority**: P0 (security policy not enforced)
+
+---
+
+### Failure #6: Tag points at wrong SHA
+
+**Description**: If release commit SHA and tag SHA diverge, rollback-full finds wrong commit via git log grep, rewrites history incorrectly.
+
+**Code Location**: `engine-ops.ts:803–820` (git log search for commit to revert)
+
+**Root Cause**: Tag is created in step 10 from main after PR merge, but grep at line 808 searches for commit message pattern `release: ship v*`. If revert is attempted and multiple commits match pattern, first match (not necessarily the release commit) is reverted.
+
+**Fix Needed**: Lookup tag target directly: `git rev-list -n 1 <tag>` gives exact SHA. Do not rely on grep; use canonical tag resolution.
+
+**Priority**: P1 (data corruption risk in rollback)
+
+---
+
+### Failure #7: Worker direct-push to main (git-shim bypass)
+
+**Description**: Agent context can bypass PR requirement if git-shim not enforced.
+
+**Code Location**: `engine-ops.ts:1023–1043` (agent protocol guard in releasePush)
+
+**Root Cause**: `releasePush()` has agent guard, but `releaseShip()` (the real entry point) only checks gh CLI availability, not protocol violations. Agent can craft parameters to skip PR step.
+
+**Fix Needed**: Extend agent guard to `releaseShip()` entry point. Validate agent context at line 1105 and reject if not in full manifest workflow.
+
+**Priority**: P1 (provenance audit gap for agents)
+
+---
+
+### Failure #8: Release start no-op (no state file)
+
+**Description**: 12-step `releaseShip()` pipeline is not resumable; no intermediate state persisted.
+
+**Code Location**: `engine-ops.ts:1105–1750` — no state writes between steps; only handle written in `releaseStart()` (separate subcommand)
+
+**Root Cause**: Canonical 4-step pipeline uses persistent `.cleo/release/handle.json`, but 12-step ship orchestrates entire flow in single call without intermediate checkpoints.
+
+**Fix Needed**: Write state file after each major step (gate pass, changelog, commit, tag, push). Implement resume logic to detect partial state and skip completed steps.
+
+**Priority**: P2 (operational resilience; not blocking correctness)
+
+---
+
+### Failure #9: Esbuild externals not auto-detected
+
+**Description**: Version bump does not auto-detect esbuild external library declarations; manual config required.
+
+**Code Location**: `version-bump.ts` — no esbuild.config.js or .ts parsing
+
+**Root Cause**: Auto-discovery implemented for Node/pnpm workspaces (line 243–288) and Rust/Cargo workspaces, but no esbuild hook.
+
+**Fix Needed**: Add esbuild discovery: parse `esbuild.config.ts`, extract `external: […]` array, add to bump targets if version-bump not manually configured.
+
+**Priority**: P3 (nice-to-have; manual config works)
+
+---
+
+### Failure #10: CHANGELOG fragile / verbose task descriptions
+
+**Description**: Task descriptions longer than 150 chars truncated silently in manifest; spec does not document limit.
+
+**Code Location**: `release-manifest.ts:362` (truncate to 150 chars) vs. CLEO-RELEASE-PIPELINE-SPEC.md (no limit mention)
+
+**Root Cause**: Changelog rendering heuristic (line 344–358) includes description only if "meaningfully different" and "≥20 chars", but hard-codes 150-char truncation (line 362) without specification.
+
+**Fix Needed**: Document truncation limit in spec. Or, remove truncation and validate description length at task-creation time instead.
+
+**Priority**: P2 (minor UX issue; data not lost, just truncated in CHANGELOG)
+
+---
+
+## 5. Coupling Score
+
+### Node/pnpm Assumption
+**Rating**: 8/10  
+**Justification**: releaseShip() hard-codes `npm` CLI invocation (line 1480) and version-bump discovers pnpm workspaces (version-bump.ts:247). Fails silently on projects without Node toolchain.  
+**Citation**: `engine-ops.ts:1480`, `version-bump.ts:243–288`
+
+### Biome Assumption
+**Rating**: 7/10  
+**Justification**: releaseShip() invokes `npx biome check` at line 1480 for lint validation. Errors are non-blocking, but hardcoded tool assumption.  
+**Citation**: `engine-ops.ts:1480–1495`
+
+### 22-Workspace Assumption
+**Rating**: 0/10 (NOT assumed)  
+**Justification**: Package discovery is dynamic, not hard-coded. Loop processes any number of packages found.  
+**Citation**: `version-bump.ts:276–284`
+
+### @cleocode/* Package Naming
+**Rating**: 3/10  
+**Justification**: No hard-coded package name filtering. Workspace discovery is agnostic to naming convention.  
+**Citation**: N/A
+
+### BRAIN-DB Requirement
+**Rating**: 9/10  
+**Justification**: All manifest operations use SQLite (release_manifests table). Project fails if tasks.db missing or corrupted.  
+**Citation**: `release-manifest.ts:32–35`, `engine-ops.ts:1223`
+
+### IVTR Coupling
+**Rating**: 8/10  
+**Justification**: releaseShip() checks IVTR gate (step 1.5); fails if ivtr-loop module unavailable. IVTR state is external dependency.  
+**Citation**: `engine-ops.ts:1251–1298`, `engine-ops.ts:22` (getIvtrState import)
+
+### git-shim Coupling
+**Rating**: 6/10  
+**Justification**: No explicit git-shim dependency in code, but all git operations assume standard git CLI. Custom git wrappers would need integration.  
+**Citation**: `engine-ops.ts:18–19` (execFileSync from node:child_process)
+
+### gh CLI Coupling
+**Rating**: 9/10  
+**Justification**: releaseShip() requires gh CLI available (mandatory PR flow per T9095). Hard failure if absent.  
+**Citation**: `engine-ops.ts:1182–1189`
+
+---
+
+## 6. Required Invariants for Future Redesign
+
+1. **Versioning Scheme Consistency**: All code paths must validate version against a single source of truth (project-context.json `version.scheme`). No fallback defaults per file.
+
+2. **Gate Runner Injection Contract**: Gate runners MUST be injected at dispatch time, never stubbed as default. releaseVerify() without runGate should throw, not silently fail.
+
+3. **Resumability Checkpoint**: 12-step pipeline MUST persist state after steps 5, 7, 9 (branch cut, PR creation, merge). Detect and skip completed steps on resume.
+
+4. **Epic Scope Enforcement**: All guards that accept epicId parameter MUST scope results to that epic. No "all epics" fallback.
+
+5. **Override Cap Integration**: Any force/bypass flag MUST validate against security/override-cap.ts before proceeding. No silent bypass.
+
+6. **Manifest Entry Requirement**: Both canonical 4-step AND 12-step pipelines MUST have a release_manifests row before any git mutation. Enforce protocol for agent context.
+
+7. **Timeout Enforcement**: All long-running git/network operations MUST have explicit timeout. No indefinite hangs.
+
+8. **Tag/Commit Binding**: Tags MUST be created from a known commit SHA, not via grep-based reverse lookup. Store tag target in manifest immediately after creation.
+
+9. **Error Envelope Preservation**: EngineResult.fix, .details, .exitCode fields MUST flow through dispatch wrappers without stripping. Support fine-grained error recovery.
+
+10. **Idempotency on Retry**: If a step fails and is retried, all operations MUST be idempotent (no double-bump, no duplicate DB rows, no re-push already-pushed branches).
+
+11. **CLI Surface Stability**: New subcommands MUST NOT shadow legacy dispatch operations. Maintain 1:1 mapping between CLI command and dispatch domain+operation.
+
+12. **Task Accessor Consistency**: All task queries (epic children, release tasks, IVTR gate) MUST use same DataAccessor instance and version. No stale-data risks across steps.
+
+---
+
+## Appendix: File Locations Summary
+
+| Component | File | LOC | Key Functions |
+|---|---|---|---|
+| CLI Commands | `packages/cleo/src/cli/commands/release.ts` | 380 | shipCommand, startCommand, verifyCommand, etc. |
+| Dispatch Handler | `packages/cleo/src/dispatch/domains/release.ts` | 330 | ReleaseHandler.query(), .mutate() |
+| Pipeline (4-step) | `packages/core/src/release/pipeline.ts` | 478 | releaseStart, releaseVerify, releasePublish, releaseReconcile |
+| Engine Ops (main) | `packages/core/src/release/engine-ops.ts` | 1986 | releaseShip, releaseGateCheck, releaseRollbackFull, etc. |
+| Manifest (DB) | `packages/core/src/release/release-manifest.ts` | 1379 | prepareRelease, commitRelease, listManifestReleases, etc. |
+| Guards | `packages/core/src/release/guards.ts` | 169 | checkEpicCompleteness, checkDoubleListing |
+| Version Bump | `packages/core/src/release/version-bump.ts` | 673 | bumpVersionFromConfig, discoverNodeWorkspaceTargets |
+| GitHub PR | `packages/core/src/release/github-pr.ts` | 439 | createPullRequest, detectBranchProtection, buildPRBody |
+| Invariants Registry | `packages/core/src/release/invariants/registry.ts` | 210 | registerInvariant, runInvariants |
+| Config | `packages/core/src/release/release-config.ts` | 532 | loadReleaseConfig, getReleaseGates, getChannelConfig |
+| Spec | `packages/core/src/release/docs/specs/CLEO-RELEASE-PIPELINE-SPEC.md` | 421 | Normative 5-step flow definition |
+
+---
+
+**Audit Complete** — 2026-05-15

--- a/.cleo/rcasd/T9345/research/failure-forensics-10-modes.md
+++ b/.cleo/rcasd/T9345/research/failure-forensics-10-modes.md
@@ -1,0 +1,1291 @@
+# T9345 — Release Pipeline Failure Forensics (10 Modes)
+
+**Anchor session**: v2026.5.73 → v2026.5.74 ship session
+**Codebase commit**: `e1b3b414d` (post v2026.5.74 hotfix)
+**Posture**: Read-only forensic analysis. No code modified. No remediation proposed beyond fix-class classification.
+**Audience**: ADR-author + RFC-2119 spec-writer for T9345 release-system overhaul.
+
+---
+
+## Map of evidence files
+
+| File | Role in failure chain |
+|------|------------------------|
+| `/mnt/projects/cleocode/packages/cleo/src/cli/commands/release.ts` | Citty CLI commands: `ship`, `start`, `verify`, `publish`, `reconcile`, `pr-status`, etc. |
+| `/mnt/projects/cleocode/packages/cleo/src/dispatch/domains/release.ts` | Dispatch handlers for `release.gate`, `release.ivtr-suggest`, `release.start`, `release.publish`, `release.reconcile`. NOT the ship path. |
+| `/mnt/projects/cleocode/packages/core/src/release/engine-ops.ts` | The actual 12-step `releaseShip()` (lines 1105-1866) — the imperative monolith. |
+| `/mnt/projects/cleocode/packages/core/src/release/pipeline.ts` | Canonical 4-step `releaseStart` / `releaseVerify` / `releasePublish` / `releaseReconcile` — completely disjoint from `releaseShip()`. |
+| `/mnt/projects/cleocode/packages/core/src/release/guards.ts` | `checkEpicCompleteness`, `checkDoubleListing`. |
+| `/mnt/projects/cleocode/packages/core/src/release/github-pr.ts` | `createPullRequest`, label/branch protection. |
+| `/mnt/projects/cleocode/packages/core/src/release/version-bump.ts` | `bumpVersionFromConfig`, `resolveVersionBumpTargets`. |
+| `/mnt/projects/cleocode/packages/core/src/release/changelog-writer.ts` | `writeChangelogSection`, `parseChangelogBlocks`. |
+| `/mnt/projects/cleocode/packages/core/src/release/release-manifest.ts` | `prepareRelease`, `generateReleaseChangelog`, `runReleaseGates`, `pushRelease`. |
+| `/mnt/projects/cleocode/packages/core/src/security/override-cap.ts` | `checkAndIncrementOverrideCap`, per-session waiver. |
+| `/mnt/projects/cleocode/packages/core/src/session/engine-ops.ts` | `sessionEnd` — does NOT reset the override counter. |
+| `/mnt/projects/cleocode/packages/git-shim/src/shim.ts` | Layered fence binary; only fires when `CLEO_AGENT_ROLE ∈ {worker,lead,subagent}`. |
+| `/mnt/projects/cleocode/packages/git-shim/src/denylist.ts` | `GIT_OP_DENYLIST` for restricted roles. |
+| `/mnt/projects/cleocode/packages/git-shim/src/boundary.ts` | T1591 fences: `validateAddPaths`, `validateCommitSubject`, `validateMergeAllowed`, `validateCherryPickSource`. |
+| `/mnt/projects/cleocode/packages/git-shim/src/isolation-boundary.ts` | T1761 cwd-isolation check (worker role only). |
+| `/mnt/projects/cleocode/packages/core/src/lifecycle/ivtr-loop.ts` | `getIvtrState` returns `null` when no IVTR state exists. |
+| `/mnt/projects/cleocode/build.mjs` | esbuild root config — externals list maintained manually. |
+
+> Critical architectural finding (anchors failures #3, #8 and the synthesis): **`packages/core/src/release/pipeline.ts` (the canonical 4-step model from ADR-063) and `packages/core/src/release/engine-ops.ts:releaseShip` (the 12-step monolith) are TWO PARALLEL, NON-INTEGRATED RELEASE SYSTEMS.** `engine-ops.ts` never imports from `pipeline.ts`; `pipeline.ts` never delegates to `releaseShip`. The CLI exposes BOTH as siblings (`release ship` → engine-ops; `release start/verify/publish/reconcile` → pipeline) and neither calls the other.
+
+---
+
+## Failure #1: Wedged git commit (no child-process timeout)
+
+### Symptom (verbatim from T9345)
+> "`cleo release ship` spawned `git commit -m "release: ship v2026.5.74 (T9261)"` that hung indefinitely (PID 4011255). Left `.git/index.lock`. No timeout. No retry. Parent process exited silently while child stuck."
+
+### Reproduction
+1. Run `cleo release ship 2026.5.74 --epic T9261`.
+2. Concurrently hold `.git/index.lock` (e.g. a hook calling another long-running git command, or an editor's git plugin).
+3. Step 5 (Cut release branch and commit) reaches the `git commit -m "release: ship v…"` invocation.
+4. If git wedges (signal lost; child still alive but parent's pipe broken), `execFileSync` blocks forever — no `timeout` option supplied for git invocations.
+
+### Code Evidence
+
+**File**: `packages/core/src/release/engine-ops.ts:1497`
+```ts
+const gitCwd = { cwd, encoding: 'utf-8' as const, stdio: 'pipe' as const };
+```
+No `timeout` property. This object is passed to every `runGitWithLockRetry` call AND every direct `execFileSync('git', …, gitCwd)` call in steps 5-11.
+
+**File**: `packages/core/src/release/engine-ops.ts:1524-1533` (the actual wedged commit invocation)
+```ts
+try {
+  runGitWithLockRetry(['commit', '-m', `release: ship v${cleanVersion} (${epicId})`], gitCwd);
+} catch (err: unknown) {
+  const msg =
+    (err as { stderr?: string; message?: string }).stderr ??
+    (err as { message?: string }).message ??
+    String(err);
+  logStep(5, 12, 'Cut release branch and commit', false, `git commit failed: ${msg}`);
+  return engineError('E_GENERAL', `git commit failed: ${msg}`);
+}
+```
+
+**File**: `packages/core/src/release/engine-ops.ts:86-140` (`runGitWithLockRetry`)
+```ts
+function runGitWithLockRetry(
+  args: readonly string[],
+  opts: Parameters<typeof execFileSync>[2],
+  maxRetries = 6,
+): string {
+  const lockErrorPattern = /Unable to create '.+\.git\/index\.lock': File exists/;
+  …
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return execFileSync('git', [...args], opts) as unknown as string;
+    } catch (err: unknown) {
+      …
+      // Only retry on the specific stale-lock signature
+      if (!lockErrorPattern.test(stderr) || attempt === maxRetries) {
+        throw err;
+      }
+      …
+    }
+  }
+```
+
+### Root Cause
+
+The pipeline owns `gitCwd` (engine-ops.ts:1497) with NO `timeout` field. `execFileSync` without a `timeout` blocks forever on a child that never exits. `runGitWithLockRetry` (engine-ops.ts:86) only handles the *stale-`.git/index.lock`* signature — which requires the child to ACTUALLY exit with the lock-error message. A child that wedges (held by another git invocation that never returns, or stalled on a network filesystem flush) never produces that error and is never killed.
+
+Contrast: the lint step at line 1484 DOES use `timeout: 30_000`:
+```ts
+execFileSync('npx', ['biome', 'check', '--no-errors-on-unmatched', cwd], {
+  cwd,
+  encoding: 'utf-8',
+  stdio: 'pipe',
+  timeout: 30_000,
+});
+```
+And the gh-merge step at line 1688 uses `timeout: 60_000`. Both demonstrate the codebase *knows about* `execFileSync` timeouts; `runGitWithLockRetry` and direct git invocations simply opted out.
+
+Compounding: even when timeout fires, `execFileSync` throws but does NOT guarantee the child is killed promptly on Linux — the SIGTERM signal might be lost if the child is in uninterruptible IO (D state). No follow-up `kill -9 <pid>` exists. And `runGitWithLockRetry` doesn't track child PIDs anywhere.
+
+### Blast Radius
+
+- `.git/index.lock` lingers, blocking all subsequent git operations against the repo (including manual recovery attempts) until the operator runs `rm -f .git/index.lock`.
+- The release is in an indeterminate state: branch may or may not have been cut; commit may or may not have landed; `releaseManifests` row exists in DB but with no `pushedAt`. No structured rollback fires because the parent never receives the error.
+- Every downstream step (push, PR-create, CI-wait, merge, tag, cleanup) is skipped.
+- Operator must manually inspect git state, kill stuck PID, remove the lock, then decide between `rollback-full` (engine-ops.ts:759) and re-running ship (which re-cuts the branch — `git checkout -b` fails because branch exists).
+
+### Fix Class
+- [ ] one-line patch
+- [x] new wrapper / timeout
+- [ ] state-machine redesign — *would help, but a hard timeout is sufficient as an MVP*
+- [ ] architectural carve-out
+- [ ] documentation
+- [ ] config-driven
+
+### Suggested invariant
+**Every git invocation in the release pipeline MUST have a finite hard timeout** (e.g. 30s for `add`/`commit`, 60s for `push`, 120s for `pull`) **AND a guaranteed SIGKILL-after-grace** path. The pipeline MUST treat git-timeout as a recoverable error class with a documented next-step (which is: re-run `cleo release ship` with idempotent resume — see Failure #8).
+
+---
+
+## Failure #2: Epic completeness scope leak
+
+### Symptom (verbatim from T9345)
+> "`--epic T9261` was supplied but completeness check failed on T9220 (unrelated). T9337 had SUPERSEDED T9220 weeks ago. T877_INVARIANT_VIOLATION (status-vs-pipeline-stage)."
+
+### Reproduction
+1. Manifest for release v2026.5.74 references task IDs of children of T9261.
+2. One of those children's ancestor chain includes T9220 (via cross-epic reference, ID overload, or stale `parentId`).
+3. T9220 has `status='done'` but was superseded by T9337 (semantic supersession — not modeled in `task.status`).
+4. `checkEpicCompleteness(releaseTaskIds, …)` walks UP from each release task ID, derives the set of epics implicated, and flags every done-leaf-child of THOSE epics as "missing" if they're not in the release.
+5. Ship aborts with `E_LIFECYCLE_GATE_FAILED — Epic completeness check failed: T9220: missing …`.
+
+### Code Evidence
+
+**File**: `packages/core/src/release/engine-ops.ts:1339-1378` (call site)
+```ts
+// Step 2: Check epic completeness
+logStep(2, 12, 'Check epic completeness');
+let releaseTaskIds: string[] = [];
+try {
+  const manifest = await showManifestRelease(version, projectRoot);
+  releaseTaskIds = (manifest as { tasks?: string[] }).tasks ?? [];
+} catch {
+  // Manifest may not exist yet; proceed
+}
+…
+const epicAccessor = await getTaskAccessor(cwd);
+const epicCheck = await checkEpicCompleteness(
+  releaseTaskIds,
+  projectRoot,
+  epicAccessor,
+  priorReleasedTaskIds,
+);
+if (epicCheck.hasIncomplete) { … return engineError('E_LIFECYCLE_GATE_FAILED', `Epic completeness check failed: ${incomplete}`, …); }
+```
+
+Note: `epicId` (the operator's `--epic T9261`) is NOT passed to `checkEpicCompleteness`. The function discovers epics on its own.
+
+**File**: `packages/core/src/release/guards.ts:31-46` (`findEpicAncestor` — walks UP the parent chain)
+```ts
+function findEpicAncestor(taskId: string, tasksById: Map<string, Task>): string | null {
+  const task = tasksById.get(taskId);
+  if (!task) return null;
+  if (task.type === 'epic') return taskId;
+  let current = task;
+  for (let depth = 0; depth < 3; depth++) {
+    if (!current.parentId) return null;
+    const parent = tasksById.get(current.parentId);
+    if (!parent) return null;
+    if (parent.type === 'epic') return parent.id;
+    current = parent;
+  }
+  return null;
+}
+```
+
+**File**: `packages/core/src/release/guards.ts:82-122` (the "missing" determination)
+```ts
+// Group by epic
+const byEpic = new Map<string, string[]>();
+for (const [taskId, epicId] of taskToEpic) {
+  if (!epicId) continue;
+  if (!byEpic.has(epicId)) byEpic.set(epicId, []);
+  byEpic.get(epicId)!.push(taskId);
+}
+
+for (const [epicId, includedTasks] of byEpic) {
+  const epic = tasksById.get(epicId);
+  if (!epic) continue;
+  if (epic.status === 'done') continue;
+  …
+  const missingChildren = allChildren
+    .filter(
+      (t) =>
+        t.status === 'done' &&
+        !parentIds.has(t.id) &&
+        !includedSet.has(t.id) &&
+        !releaseSet.has(t.id) &&
+        !priorSet.has(t.id),
+    )
+    …
+}
+```
+
+`guards.ts` has no concept of `superseded` or `cancelled` status filters — it only checks `t.status === 'done'`. Supersession lineage (T9337 → T9220) is invisible here.
+
+### Root Cause
+
+Three compounding bugs:
+
+1. **Scope leak**: `releaseShip(params.epicId)` is documented as the epic-being-shipped, but the completeness check derives epics from `releaseTaskIds` via `findEpicAncestor`. The operator's `--epic T9261` is used ONLY for the IVTR gate (line 1257) and the commit-message tag — NOT for scoping the completeness audit. Any task whose ancestor-chain crosses into a foreign epic (T9220) drags that foreign epic into the check.
+
+2. **No SUPERSEDED model**: `task.status` is a flat enum (`pending` / `active` / `done` / `blocked` / `cancelled`). Supersession is a semantic relationship (T9337 supersedes T9220) maintained elsewhere (likely BRAIN observations, decisions, or a `superseded_by` field that `guards.ts` does not consult). The guard treats a done-but-superseded task as a first-class done leaf.
+
+3. **T877 reconcile divergence**: the post-release invariants registry (`archive-reason-invariant.ts:287-295`) DOES enforce `status='done' ⇒ pipelineStage IN ('contribution','cancelled')`. But that's the *post*-release reconcile path. The *pre*-release `checkEpicCompleteness` does NOT consider `pipelineStage` — so a task can be `status='done', pipelineStage='research'` and still be flagged as "missing" from the release.
+
+### Blast Radius
+
+- Operator-experienced false-positive blocker on every cross-epic release.
+- Workaround: comment out `checkEpicCompleteness` call (impossible at runtime), bypass via `--force` (not exposed for this gate — only IVTR), or wait days/weeks for the foreign epic to be "completed".
+- Encourages operators to mark unrelated tasks as `cancelled` to clear the gate — corrupts task lineage permanently.
+- Hides the actual T877 invariant violation (status-vs-stage) behind a generic `Epic completeness check failed` error.
+
+### Fix Class
+- [ ] one-line patch
+- [ ] new wrapper / timeout
+- [x] state-machine redesign — *the SUPERSEDED relationship must be first-class*
+- [x] architectural carve-out — *scope the check to the operator-supplied epic, NOT cross-derived ancestors*
+- [ ] documentation
+- [ ] config-driven
+
+### Suggested invariant
+**Epic-completeness gate MUST be scoped to the operator-supplied `epicId`.** Tasks whose ancestor chain leaves the supplied epic MUST NOT trigger completeness audits of foreign epics. **Superseded tasks MUST be modeled as a first-class status (or `superseded_by` reference) and excluded from completeness denominators.** The guard MUST consult `pipelineStage` in addition to `status` (the same T877 invariant the post-release reconciler enforces). Cross-epic linkage MUST be reported as a *warning*, never a *blocker*.
+
+---
+
+## Failure #3: Gate runners not wired
+
+### Symptom (verbatim from T9345)
+> "`cleo release verify` reports all 5 gates (test, lint, typecheck, audit, security-scan) as 'runner not configured (inject via opts.runGate)'. Verify passes without running anything. Ship proceeds anyway."
+
+### Reproduction
+1. Run `cleo release start 2026.5.74 --epic T9261`. Handle is written to `.cleo/release/handle.json`.
+2. Run `cleo release verify`.
+3. Output shows 5 gates, all `passed: false, reason: 'gate "test" runner not configured (inject via opts.runGate)'` (etc).
+4. But `passed` field on the envelope is `false` ONLY when both gate-failure AND child-failure conditions are evaluated — and the CLI exits with `process.exit(1)` (release.ts:322).
+5. Despite verify failing, `cleo release ship` does NOT consult `pipeline.ts` at all (it runs the parallel engine-ops 12-step monolith) and proceeds.
+
+### Code Evidence
+
+**File**: `packages/core/src/release/pipeline.ts:249-262` (the smoking gun)
+```ts
+async function defaultRunGate(
+  canonicalTool: string,
+  _cwd: string,
+): Promise<{ passed: boolean; reason?: string }> {
+  // Map canonical name → npm script per project-context fallback chain.
+  // We intentionally do NOT execute here in the default impl — the wrapping
+  // CLI is responsible for invoking `cleo verify --gate <…> --evidence
+  // tool:<canonical>` which already drives the cache-aware tool runner.
+  // For programmatic callers (tests) this default is overridable.
+  return {
+    passed: false,
+    reason: `gate "${canonicalTool}" runner not configured (inject via opts.runGate)`,
+  };
+}
+```
+
+**File**: `packages/core/src/release/pipeline.ts:264-270` (child-auditor twin)
+```ts
+async function defaultAuditChildren(): Promise<{
+  examined: number;
+  ungreen: Array<{ taskId: string; missingGates: string[] }>;
+}> {
+  return { examined: 0, ungreen: [] };
+}
+```
+
+**File**: `packages/cleo/src/cli/commands/release.ts:317-323` (CLI calls verify with NO injection)
+```ts
+const verifyCommand = defineCommand({
+  meta: { name: 'verify', description: 'Verify release gates + child task gate state' },
+  async run() {
+    const result = await release.releaseVerify(release.loadActiveReleaseHandle(process.cwd()));
+    cliOutput(result, { command: 'release', operation: 'release.verify' });
+    if (!result.passed) process.exit(1);
+  },
+});
+```
+No `runGate` or `auditChildren` is provided. The defaults are used. Defaults always return `passed: false` (gates) and `examined: 0, ungreen: []` (children).
+
+**File**: `packages/core/src/release/pipeline.ts:331-364` (`releaseVerify` accepts the no-op defaults silently)
+```ts
+export async function releaseVerify(
+  handle: ReleaseHandle,
+  opts: ReleaseVerifyOptions = {},
+): Promise<VerifyResult> {
+  const runGate = opts.runGate ?? defaultRunGate;
+  const auditChildren = opts.auditChildren ?? defaultAuditChildren;
+
+  const gates: ReleaseGateStatus[] = [];
+  for (const gate of VERIFY_GATES) {
+    const r = await runGate(gate, handle.projectRoot);
+    gates.push({ gate, passed: r.passed, tool: gate, …(r.reason !== undefined ? { reason: r.reason } : {}) });
+  }
+  …
+  const allGatesGreen = gates.every((g) => g.passed);
+  const allChildrenGreen = ungreenChildren.length === 0;
+  return { passed: allGatesGreen && allChildrenGreen, gates, ungreenChildren, childrenExamined };
+}
+```
+
+**File**: `packages/core/src/release/engine-ops.ts:1234-1249` (the engine-ops "Step 1: Validate release gates")
+```ts
+logStep(1, 12, 'Validate release gates');
+const gatesResult = await runReleaseGates(version, () => loadTasks(projectRoot), projectRoot, {
+  dryRun,
+});
+
+if (gatesResult && !gatesResult.allPassed) { … }
+logStep(1, 12, 'Validate release gates', true);
+```
+Note this calls `runReleaseGates` from `release-manifest.ts` — a SEPARATE gate runner from `pipeline.ts:VERIFY_GATES`. There are TWO independent gate systems.
+
+### Root Cause
+
+The canonical pipeline (`pipeline.ts`) defines `VERIFY_GATES` as `['test','lint','typecheck','audit','security-scan']` (line 94) and ships with an explicitly-unimplemented `defaultRunGate` that returns `passed:false, reason:"runner not configured"`. The comment at line 253 says "the wrapping CLI is responsible for invoking `cleo verify --gate <…> --evidence tool:<canonical>`" — but the CLI (release.ts:317) does NOT inject any runner. It just calls `releaseVerify(handle)` with no opts.
+
+Meanwhile, `releaseShip()` (engine-ops.ts) does not call `releaseVerify` at all. It calls `runReleaseGates` from `release-manifest.ts` (engine-ops.ts:1236) — an entirely different gate registry. So:
+
+- `cleo release verify` runs a no-op stub that always fails its own gates.
+- `cleo release ship` runs a different gate set that may or may not pass.
+- The two never agree.
+
+This is the "gate logic confused with pipeline logic" cluster: there are TWO gate systems, neither integrated with the canonical evidence-based gate runner (`cleo verify --gate … --evidence tool:…`) referenced by the comment.
+
+### Blast Radius
+
+- Operator running `release verify` thinks "everything passes" or "everything fails" — neither is true; it's a phantom result.
+- `release ship` bypasses `release verify` entirely. Even if verify reported red, ship would not know.
+- Tests cannot trust either: `pipeline.ts` defaults are testable only via injection (tests pass because they inject), but production has no injector.
+- A green CI signal during ship comes from step 8 (`gh pr checks --watch`) — not from `verify`. The whole pre-flight "validate" stage is theater.
+
+### Fix Class
+- [ ] one-line patch
+- [ ] new wrapper / timeout
+- [ ] state-machine redesign
+- [x] architectural carve-out — *unify or delete one of the two gate systems*
+- [ ] documentation
+- [x] config-driven — *wire defaultRunGate to the existing ADR-061 tool resolver*
+
+### Suggested invariant
+**`cleo release verify` MUST execute the same canonical gates that the release manifest's `runReleaseGates` consults — there MUST be a single gate registry per project, not two.** When a gate's runner is "not configured", verify MUST return `E_GATE_RUNNER_MISSING` (not a soft `passed:false`) so the operator cannot accidentally treat it as a real failure. `cleo release ship` MUST refuse to proceed without a green `cleo release verify` (or an audited override).
+
+---
+
+## Failure #4: IVTR non-blocking gate
+
+### Symptom (verbatim from T9345)
+> "'IVTR gate: 72 task(s) have no IVTR state (non-blocking)'. If non-blocking on 72/72 tasks, it is not a gate."
+
+### Reproduction
+1. Run `cleo release ship 2026.5.74 --epic T9261` with no `--force`.
+2. Epic T9261 has 72 child tasks; none have ever had `ivtr_state` started (the IVTR loop was never run on any of them).
+3. `checkIvtrGates([t1…t72], …)` returns `{ blocked: [], unchecked: [t1…t72] }`.
+4. The pipeline emits `! IVTR gate: 72 task(s) have no IVTR state (non-blocking)` and proceeds.
+
+### Code Evidence
+
+**File**: `packages/core/src/release/engine-ops.ts:190-212` (`checkIvtrGates`)
+```ts
+async function checkIvtrGates(
+  taskIds: string[],
+  projectRoot?: string,
+): Promise<{ blocked: string[]; unchecked: string[] }> {
+  const blocked: string[] = [];
+  const unchecked: string[] = [];
+
+  for (const taskId of taskIds) {
+    try {
+      const state = await getIvtrState(taskId, { cwd: projectRoot });
+      if (state === null) {
+        // No IVTR state started — not blocked but flagged as unchecked
+        unchecked.push(taskId);
+      } else if (state.currentPhase !== 'released') {
+        blocked.push(taskId);
+      }
+    } catch {
+      unchecked.push(taskId);
+    }
+  }
+  return { blocked, unchecked };
+}
+```
+
+**File**: `packages/core/src/release/engine-ops.ts:1265-1293` (the "gate" decision)
+```ts
+if (epicTaskIds.length > 0) {
+  const { blocked, unchecked } = await checkIvtrGates(epicTaskIds, projectRoot);
+  if (blocked.length > 0) {
+    logStep(1, 12, 'Check IVTR gate for epic tasks', false, `${blocked.length} task(s) not released in IVTR`);
+    return engineError('E_LIFECYCLE_GATE_FAILED', …);
+  }
+  if (unchecked.length > 0) {
+    const w = `  ! IVTR gate: ${unchecked.length} task(s) have no IVTR state (non-blocking): ${unchecked.join(', ')}`;
+    steps.push(w);
+    log.warn({ epicId, unchecked, count: unchecked.length }, w);
+  }
+  logStep(1, 12, 'Check IVTR gate for epic tasks', true);
+}
+```
+
+**File**: `packages/core/src/lifecycle/ivtr-loop.ts:464-469` (`getIvtrState` returns null when no row exists)
+```ts
+export async function getIvtrState(
+  taskId: string,
+  options?: { cwd?: string },
+): Promise<IvtrState | null> {
+  return readIvtrStateRaw(taskId, options?.cwd);
+}
+```
+
+### Root Cause
+
+The IVTR gate has THREE outcome buckets — `released` (pass), `started-but-not-released` (block), and `never-started` (warn-only). The pipeline interprets `never-started` as "this task didn't opt into IVTR, so we won't block on it." That makes the gate **opt-in-only on the worker side** — any agent that skips IVTR escapes the gate entirely.
+
+When 72/72 tasks have never started IVTR, the gate is reduced to a printable warning. The same code path would fire for an epic that legitimately had no IVTR coverage (e.g. docs-only) AND for an epic where IVTR was *deliberately bypassed*. The gate cannot distinguish.
+
+There is NO step that converts "task is in release manifest" ⇒ "task MUST have started IVTR". The IVTR loop is opt-in for workers; the release gate inherits that opt-in semantics.
+
+### Blast Radius
+
+- 72/72 escape is a 100% bypass rate — the gate added zero protection on this ship.
+- Future epics with mixed IVTR coverage will pass without anyone noticing which tasks were unchecked.
+- The "unchecked" warning is interleaved with `cleo release ship` steps and lost in scrollback. No structured `unchecked-on-ship` audit log is written.
+- Defeats the entire purpose of the IVTR loop being a release prerequisite.
+
+### Fix Class
+- [ ] one-line patch
+- [ ] new wrapper / timeout
+- [x] state-machine redesign — *the gate must take an explicit policy: strict (all tasks must have IVTR) / opt-in (current behavior) / per-task-required*
+- [ ] architectural carve-out
+- [ ] documentation
+- [x] config-driven — *policy MUST live in `.cleo/config.json`*
+
+### Suggested invariant
+**The IVTR gate's policy MUST be explicit and recorded in `.cleo/config.json` (e.g. `release.ivtr.policy: "strict" | "opt-in" | "off"`).** Under `strict`, `unchecked` MUST count as `blocked`. Under `opt-in`, `unchecked` MUST emit an auditable structured warning (not just stderr noise) that lists EVERY unchecked task ID and is appended to the release-manifest record. **A gate that does not block under any input configuration MUST NOT be called a "gate" in the CLI output.**
+
+---
+
+## Failure #5: Override cap broken
+
+### Symptom (verbatim from T9345)
+> "'Per-session CLEO_OWNER_OVERRIDE cap exceeded: 823 of 10 overrides used'. Counter never resets."
+
+### Reproduction
+1. Start a CLEO session: `cleo session start --scope global`.
+2. Run several agent workflows that each invoke `cleo verify … --evidence …` with `CLEO_OWNER_OVERRIDE=1` set.
+3. Counter file `.cleo/audit/session-override-count.<sessionId>.json` increments on each override.
+4. Run `cleo session end`. Counter file is NOT touched.
+5. Start a new session — same sessionId is rare but session state itself moves on. However if sessionId resolves to `'global'` (no active session — see validation/engine-ops.ts:385 fallback), the global counter file persists FOREVER and grows monotonically.
+6. After hundreds of operations across many sessions, file shows 823 overrides used.
+
+### Code Evidence
+
+**File**: `packages/core/src/security/override-cap.ts:147-161` (only write path increments — no reset writer exists)
+```ts
+export function writeSessionOverrideCount(
+  projectRoot: string,
+  sessionId: string,
+  count: number,
+): void {
+  try {
+    const path = getSessionOverrideCountPath(projectRoot, sessionId);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ sessionId, count, updatedAt: new Date().toISOString() }), {
+      encoding: 'utf-8',
+    });
+  } catch {
+    // Non-fatal — audit count should not block operations.
+  }
+}
+```
+
+**File**: `packages/core/src/security/override-cap.ts:257-307` (`checkAndIncrementOverrideCap` — only ever increments)
+```ts
+export function checkAndIncrementOverrideCap(
+  projectRoot: string,
+  sessionId: string,
+  cap: number = DEFAULT_OVERRIDE_CAP_PER_SESSION,
+  command?: string,
+): OverrideCapResult {
+  // T1504 worktree exemption …
+  if (command !== undefined && isWorktreeExemptionEnabled() && isWorktreeContext(command)) {
+    const current = readSessionOverrideCount(projectRoot, sessionId);
+    return { allowed: true, sessionOverrideOrdinal: current + 1, workTreeContext: true };
+  }
+
+  const current = readSessionOverrideCount(projectRoot, sessionId);
+
+  if (current < cap) {
+    const ordinal = current + 1;
+    writeSessionOverrideCount(projectRoot, sessionId, ordinal);
+    return { allowed: true, sessionOverrideOrdinal: ordinal };
+  }
+
+  // Above cap — check for waiver.
+  const waiverPath = (process.env['CLEO_OWNER_OVERRIDE_WAIVER'] ?? '').trim();
+  const waiver = validateWaiverDoc(waiverPath);
+
+  if (!waiver.valid) {
+    return {
+      allowed: false,
+      errorCode: BRANCH_LOCK_ERROR_CODES.E_OVERRIDE_CAP_EXCEEDED,
+      errorMessage:
+        `Per-session CLEO_OWNER_OVERRIDE cap exceeded: ${current} of ${cap} overrides used. …`,
+    };
+  }
+
+  // Waiver accepted — permit and increment beyond cap.
+  const ordinal = current + 1;
+  writeSessionOverrideCount(projectRoot, sessionId, ordinal);
+  return { allowed: true, sessionOverrideOrdinal: ordinal };
+}
+```
+
+**File**: `packages/core/src/validation/engine-ops.ts:382-388` (the `'global'` fallback used when no active session)
+```ts
+if (override.override && isWriteRequiringEvidence) {
+  const command = (process.argv.slice(1).join(' ') || 'cleo').slice(0, 512);
+  const capResult = checkAndIncrementOverrideCap(
+    projectRoot,
+    sessionId ?? 'global',
+    undefined,
+    command,
+  );
+  if (!capResult.allowed) {
+    return engineError(
+      capResult.errorCode ?? 'E_OVERRIDE_CAP_EXCEEDED',
+      capResult.errorMessage ?? 'Per-session override cap exceeded.',
+    );
+  }
+  …
+}
+```
+
+**File**: `packages/core/src/session/engine-ops.ts:574-690` (`sessionEnd` — NO override-counter reset)
+The function clears focus state, bumps file_meta generation, marks the session 'ended', appends a journal entry, and ingests memory summaries. It NEVER touches `session-override-count.<sessionId>.json`. There is also no `purgeOldOverrideCounts` sweeper.
+
+### Root Cause
+
+Three bugs in the override-cap subsystem:
+
+1. **No reset on `session end`**: the per-session counter file is intended to live only as long as the session. But `sessionEnd` (session/engine-ops.ts:574) never deletes it. The cap counter is *append-only* in practice — even for a fresh session, the file persists.
+
+2. **`'global'` fallback collapses many sessions into one counter**: when validation runs outside an active session (which is common for agents that don't `session start` — most worker agents), `sessionId ?? 'global'` (validation/engine-ops.ts:385) writes to `session-override-count.global.json`. This single file accumulates overrides across every CLI invocation since the project was created.
+
+3. **No expiry / GC**: there is no time-based or count-based truncation. `count: 823` is just the integer that's been incremented since whenever this file was created. Combined with (2), this is exactly the error message reported.
+
+### Blast Radius
+
+- Every legitimate owner-override after the cap is reached is blocked unless the operator creates a waiver doc with `cap-waiver: true`. The waiver requirement is meant for emergencies but becomes routine when the counter is broken.
+- Operators get conditioned to keep a `cap-waiver: true` file on the path and pass `CLEO_OWNER_OVERRIDE_WAIVER=…` in every shell — defeating the cap entirely.
+- The audit log (`force-bypass.jsonl`) still records each use, but the counter loses meaning.
+- During the v2026.5.74 ship session, 823/10 means the counter is at ~82× the cap — the operator either gave up on the cap entirely (always-on waiver) or is hitting `E_OVERRIDE_CAP_EXCEEDED` constantly and forcing through.
+
+### Fix Class
+- [ ] one-line patch
+- [ ] new wrapper / timeout
+- [x] state-machine redesign — *counter lifecycle must be tied to actual session lifecycle*
+- [ ] architectural carve-out
+- [ ] documentation
+- [x] config-driven — *cap policy must support `count-per-session`, `rolling-window`, `count-per-CLI-invocation`*
+
+### Suggested invariant
+**The override-cap counter MUST reset at `session start` (not `session end` — agents may crash without ending).** A non-session global counter MUST be a rolling window (e.g. last 60min) — not append-only. `sessionEnd` MUST delete the per-session counter file via a registered cleanup hook. The `'global'` sessionId fallback MUST be banned in production paths — agents that don't have an active session MUST establish one before calling `verify` with overrides.
+
+---
+
+## Failure #6: Tag points at wrong SHA
+
+### Symptom (verbatim from T9345)
+> "After ship pushed tag v2026.5.74, the tag landed on pre-merge SHA (1226c5dae) instead of merge commit (e1b3b414d). Had to delete + retag manually."
+
+### Reproduction
+1. Run `cleo release ship 2026.5.74 --epic T9261`.
+2. Step 9 runs `gh pr merge <prUrl> --merge --auto`. `--auto` makes the merge happen *after* all required checks pass — gh exits immediately with the merge *queued*, not done.
+3. Step 10 immediately runs `git checkout main && git pull origin main && git rev-parse HEAD`. If GitHub hasn't completed the auto-merge yet, the local `main` does NOT contain the merge commit. HEAD is the pre-merge SHA.
+4. Tag is created on that pre-merge SHA.
+5. After GitHub auto-merge completes, `git fetch && git pull` reveals the merge commit lives at a new SHA (e1b3b414d) — but the tag was already pushed to the wrong SHA (1226c5dae).
+6. Operator must `git tag -d v2026.5.74 && git push origin :refs/tags/v2026.5.74 && git pull && git tag v2026.5.74 && git push origin v2026.5.74`.
+
+### Code Evidence
+
+**File**: `packages/core/src/release/engine-ops.ts:1682-1717` (the merge step — `--auto` is fire-and-forget)
+```ts
+// Step 9: Merge PR with --merge (preserves commit SHAs)
+logStep(9, 12, 'Merge PR');
+if (prUrl) {
+  try {
+    execFileSync('gh', ['pr', 'merge', prUrl, '--merge', '--auto'], {
+      ...gitCwd,
+      timeout: 60_000,
+    });
+    logStep(9, 12, 'Merge PR', true);
+  } catch (err: unknown) {
+    …
+    if (msg.includes('auto')) {
+      // Fallback: gh CLI refused --auto (no required checks configured)
+      // → retry WITHOUT --auto, which performs a synchronous merge.
+      try {
+        execFileSync('gh', ['pr', 'merge', prUrl, '--merge'], { ...gitCwd, timeout: 60_000 });
+        logStep(9, 12, 'Merge PR', true);
+      …
+```
+
+**File**: `packages/core/src/release/engine-ops.ts:1721-1767` (Step 10 — no wait for merge completion)
+```ts
+// Step 10: Tag from main + push tag (idempotent: re-running on an
+// already-tagged release succeeds when the existing tag points at HEAD).
+logStep(10, 12, 'Tag from main and push');
+try {
+  runGitWithLockRetry(['checkout', gitflowCfg.branches.main], gitCwd);
+  runGitWithLockRetry(['pull', gitRemote, gitflowCfg.branches.main], gitCwd);
+
+  // Resolve HEAD so we can compare against any pre-existing tag
+  const headSha = execFileSync('git', ['rev-parse', 'HEAD'], gitCwd).toString().trim();
+
+  // Check if the tag already exists locally
+  let existingTagSha: string | undefined;
+  try {
+    existingTagSha = execFileSync('git', ['rev-list', '-n', '1', gitTag], gitCwd)
+      .toString()
+      .trim();
+  } catch {
+    // Tag does not exist locally — fall through to create it
+  }
+
+  if (existingTagSha) {
+    if (existingTagSha === headSha) {
+      const m = `  i Tag ${gitTag} already exists at HEAD (${headSha.slice(0, 8)}) — skipping create`;
+      …
+    } else {
+      …  // error: tag already exists at different SHA
+    }
+  } else {
+    runGitWithLockRetry(['tag', '-a', gitTag, '-m', `Release ${gitTag}`], gitCwd);
+  }
+```
+
+There is no `gh pr view <prUrl> --json mergeCommit,state` polling between Step 9 and Step 10. Nothing detects whether the auto-merge has completed before pulling and tagging.
+
+### Root Cause
+
+`gh pr merge --auto` is asynchronous. From the [gh docs](https://cli.github.com/manual/gh_pr_merge): `--auto` "automatically merge only after necessary requirements are met." gh returns success once the merge is *queued*, not *applied*. The pipeline's mental model is "if gh exited 0, the merge is done," which is wrong for `--auto`.
+
+The fallback path (line 1696-1699) catches the "auto-merge not enabled on repo" error and retries WITHOUT `--auto`, which IS synchronous. So when the repo allows `--auto`, the race exists; when it doesn't, the race goes away. The behavior is repo-config-dependent — and the failure mode is silent.
+
+Compounding: step 10 does `git pull origin main` immediately. If the local clone was fetched a few seconds before the auto-merge landed on GitHub, `pull` succeeds returning "already up-to-date" — masking the fact that the remote main has moved since. The pipeline has no `git fetch --all && git ls-remote origin refs/heads/main` re-check.
+
+### Blast Radius
+
+- Every release with required CI checks enabled and `--auto` accepted has a race window of N seconds (= max(time-from-`gh pr merge --auto`-call-to-actual-merge-applied)).
+- Tag points to pre-merge SHA → `git log <tag>` doesn't show the release commit → npm publish from that SHA misses the release-commit content → CHANGELOG mismatch.
+- Provenance recording (`markReleasePushed(version, pushedAt, …, { commitSha, gitTag })` at engine-ops.ts:1826) stamps the WRONG commitSha into the release manifest. Future audits show release-manifest-row pointing at a tag that no longer exists at that SHA.
+- Manual retag corrupts git history annotations — the tag object now has a non-monotonic creation date relative to the commit.
+
+### Fix Class
+- [ ] one-line patch
+- [x] new wrapper / timeout — *poll merge completion before pulling*
+- [ ] state-machine redesign
+- [ ] architectural carve-out
+- [ ] documentation
+- [ ] config-driven
+
+### Suggested invariant
+**After `gh pr merge --auto`, the pipeline MUST poll `gh pr view <prUrl> --json state,mergeCommit` until `state === "MERGED"` AND `mergeCommit.oid` is non-empty, with a bounded timeout (e.g. 15min, same as CI-wait).** Only after that confirmation MAY it `git pull` and tag. Alternatively, drop `--auto` entirely and require synchronous `gh pr merge --merge` post-CI-wait — making step 9 truly blocking.
+
+---
+
+## Failure #7: Worker direct-push to main
+
+### Symptom (verbatim from T9345)
+> "worker-T9317 merged its task branch directly to local main without opening a PR. Required cherry-pick recovery to feat/T9317-bedrock-recovery. The git-shim hook should block this; it did not."
+
+### Reproduction
+1. Worker agent is spawned with worktree at `~/.local/share/cleo/worktrees/<hash>/T9317/`.
+2. Worker `cd`s into worktree, makes changes, commits with `T9317` in subject.
+3. Worker (intentionally or via a bash hook) runs `git checkout main` followed by `git merge task/T9317` or `git push origin task/T9317:main`.
+4. Expected: `git-shim` denylist blocks at least `git checkout` (denylist.ts:43-46).
+5. Actual: shim only fires when `CLEO_AGENT_ROLE ∈ {worker,lead,subagent}` AND the role is set in the subprocess env. If the worker's shell environment doesn't have `CLEO_AGENT_ROLE` exported (e.g. orchestrator passed env via `spawn` opts but a sub-shell stripped it), the shim is bypassed.
+
+### Code Evidence
+
+**File**: `packages/git-shim/src/shim.ts:232-244` (the fast path — no role ⇒ pass through)
+```ts
+const role = getAgentRole();
+
+// Fast path: no restricted role → pass through unconditionally.
+if (!role) {
+  const realGit = resolveRealGit();
+  if (!realGit) {
+    process.stderr.write('[git-shim] ERROR: real git binary not found\n');
+    process.exit(1);
+  }
+  const result = spawnSync(realGit, argv, { stdio: 'inherit' });
+  process.exit(result.status ?? 1);
+  return;
+}
+```
+
+**File**: `packages/git-shim/src/shim.ts:61-65` (`getAgentRole` requires the exact env)
+```ts
+function getAgentRole(): string | null {
+  const role = process.env['CLEO_AGENT_ROLE'];
+  if (!role) return null;
+  return RESTRICTED_ROLES.has(role) ? role : null;
+}
+```
+
+**File**: `packages/git-shim/src/denylist.ts:41-47` (denylist HAS `checkout` and `switch` — they would block IF role were set)
+```ts
+export const GIT_OP_DENYLIST: ReadonlyArray<DeniedGitOp> = [
+  {
+    subcommand: 'checkout',
+    reason: 'agents MUST NOT switch branches — use the assigned worktree branch',
+  },
+  {
+    subcommand: 'switch',
+    reason: 'agents MUST NOT switch branches — use the assigned worktree branch',
+  },
+  …
+```
+
+**File**: `packages/git-shim/src/boundary.ts:239-262` (`validateMergeAllowed` — merge IS in the boundary fence)
+```ts
+export function validateMergeAllowed(
+  args: ReadonlyArray<string>,
+  env: { CLEO_ORCHESTRATE_MERGE?: string },
+): BoundaryViolation | null {
+  for (const arg of args) {
+    if (arg === '--abort' || arg === '--continue' || arg === '--quit') return null;
+  }
+  if (env.CLEO_ORCHESTRATE_MERGE === '1') return null;
+  return { code: 'E_GIT_BOUNDARY_MERGE_FORBIDDEN', boundary: 'c', message: 'git merge refused — agents MUST NOT merge directly (ADR-062 / T1587)', … };
+}
+```
+
+**File**: `packages/git-shim/src/denylist.ts:184-200` (force-push IS denied, but vanilla push to main is NOT)
+```ts
+// Force push
+{ subcommand: 'push', flag: '-f', reason: 'agents MUST NOT force-push — the orchestrator manages push lifecycle' },
+{ subcommand: 'push', flag: '--force', reason: '…' },
+{ subcommand: 'push', flag: '--force-with-lease', reason: '…' },
+```
+`git push origin task/T9317:main` (non-force, refspec) is NOT in the denylist.
+
+### Root Cause
+
+Three compounding bugs:
+
+1. **Env-var-only enforcement is fragile**: the shim is gated entirely on `CLEO_AGENT_ROLE` being set. If a sub-shell, hook, or `exec -c` strips that env (or if the operator runs an unrelated terminal in the worktree), the shim does nothing. There is no on-disk marker in the worktree (e.g. `.cleo/worktree-policy.json`) the shim can consult independent of env.
+
+2. **`git push origin <local>:main` is not in the denylist**: the denylist (denylist.ts) protects against force-push but NOT against `git push origin task/T9317:main` (a non-force push of a local branch to the remote `main` ref). That's the exact attack vector the worker used.
+
+3. **`git merge` boundary requires `CLEO_ORCHESTRATE_MERGE=1` but only when shim is active**: same fragility as (1). If the agent's shell can run a sub-process that escapes the shim, the boundary doesn't fire.
+
+### Blast Radius
+
+- Worker bypassed all four T1591 boundaries AND the T1118 denylist by simply not having `CLEO_AGENT_ROLE` in the right scope.
+- Recovery required cherry-pick from main back into a clean feat/T9317-bedrock-recovery branch — losing the original commit's parent linkage and provenance.
+- The git-shim audit log (`<XDG>/cleo/audit/git-shim.jsonl`) shows no record of the bypass because the shim was never invoked.
+- The orchestrator's "agent worktree integration via `git merge --no-ff`" (ADR-062 / `completeAgentWorktreeViaMerge`) was bypassed entirely; the original commit SHA is no longer reachable from main.
+
+### Fix Class
+- [ ] one-line patch
+- [ ] new wrapper / timeout
+- [x] state-machine redesign — *enforcement must be defensive at multiple layers, not env-only*
+- [x] architectural carve-out — *worktree policy as on-disk artifact, not env*
+- [ ] documentation
+- [ ] config-driven
+
+### Suggested invariant
+**Worker agents MUST be enforced via at least three independent layers**: (a) env-var-driven shim (current), (b) an on-disk worktree policy file (e.g. `.cleo/worktree-policy.json`) the shim reads directly, (c) a server-side GitHub branch-protection rule that rejects pushes from agent identities. **The denylist MUST include `git push <remote> <local>:<protected-branch>` for any branch in the protected-set** (not just force-push). **`git push` whose destination is the project's protected branch from any role MUST be blocked unconditionally**, regardless of `CLEO_AGENT_ROLE`.
+
+---
+
+## Failure #8: Release start no-op
+
+### Symptom (verbatim from T9345)
+> "`.cleo/release-state.json` does not exist despite `release start` being called. release start is a 0ms no-op that records nothing actionable."
+
+### Reproduction
+1. Run `cleo release start 2026.5.74 --epic T9261`.
+2. Observe: `.cleo/release/handle.json` is created with `{version, tag, scheme, branch, startedAt, projectRoot, epicId}` (pipeline.ts:304-314).
+3. Run `cleo release ship 2026.5.74 --epic T9261`.
+4. `releaseShip` (engine-ops.ts:1105) does NOT read `.cleo/release/handle.json`. It re-derives the version, re-validates, re-prepares the manifest record. The handle is ignored.
+5. The handle is consumed ONLY by `release verify` / `release publish` / `release reconcile` (release.ts:317, 327, 339) — none of which are called by `ship`.
+
+### Code Evidence
+
+**File**: `packages/core/src/release/pipeline.ts:91` (the handle path — note this is `handle.json`, NOT `release-state.json`)
+```ts
+const HANDLE_RELATIVE_PATH = '.cleo/release/handle.json';
+```
+
+**File**: `packages/core/src/release/pipeline.ts:288-316` (`releaseStart`)
+```ts
+export async function releaseStart(
+  version: string,
+  opts: ReleaseStartOptions = {},
+): Promise<ReleaseHandle> {
+  const projectRoot = opts.projectRoot ?? process.cwd();
+  const { scheme } = resolveProjectConfig(projectRoot);
+
+  const validation = validateVersion(version, scheme);
+  if (!validation.ok) {
+    throw new Error(`Invalid version: ${validation.reason}`);
+  }
+
+  const branch = opts.branch ?? (await detectBranch(projectRoot));
+  const tag = version.startsWith('v') ? version : `v${version}`;
+  const normalizedVersion = version.startsWith('v') ? version.slice(1) : version;
+
+  const handle: ReleaseHandle = {
+    version: normalizedVersion,
+    tag,
+    scheme,
+    branch,
+    startedAt: new Date().toISOString(),
+    projectRoot,
+    epicId: opts.epicId,
+  };
+
+  writeHandle(handle);
+  return handle;
+}
+```
+
+**File**: `packages/cleo/src/cli/commands/release.ts:296-314` (CLI wraps releaseStart)
+```ts
+const startCommand = defineCommand({
+  meta: {
+    name: 'start',
+    description: 'Begin a release (validates version, captures branch, persists handle)',
+  },
+  args: {
+    version: { type: 'positional', description: 'Version to release', required: true },
+    epic: { type: 'string', description: 'Epic ID this release ships' },
+    branch: { type: 'string', description: 'Override detected branch' },
+  },
+  async run({ args }) {
+    const handle = await release.releaseStart(args.version, {
+      epicId: args.epic as string | undefined,
+      branch: args.branch as string | undefined,
+    });
+    cliOutput(handle, { command: 'release', operation: 'release.start' });
+  },
+});
+```
+
+**File**: `packages/core/src/release/engine-ops.ts:1105-1233` (`releaseShip` — never imports loadActiveReleaseHandle)
+```ts
+export async function releaseShip(
+  params: {
+    version: string;
+    epicId: string;
+    remote?: string;
+    dryRun?: boolean;
+    bump?: boolean;
+    force?: boolean;
+  },
+  projectRoot?: string,
+): Promise<EngineResult> {
+  const { version, epicId, remote, dryRun = false, bump = true, force = false } = params;
+  …
+}
+```
+A grep confirms `engine-ops.ts` does NOT reference `loadActiveReleaseHandle`, `writeHandle`, `releaseStart`, or `HANDLE_RELATIVE_PATH`.
+
+**File**: `packages/cleo/src/dispatch/domains/release.ts:261-308` (dispatch handler — start/publish/reconcile only)
+```ts
+case 'start': {
+  const version = typeof params?.version === 'string' ? params.version : undefined;
+  …
+  const result = await releaseStart(version, { … });
+  return { success: true, data: result, meta: dispatchMeta('mutate', 'release', operation, startTime) };
+}
+
+case 'publish': {
+  const handle = loadActiveReleaseHandle(getProjectRoot());
+  const result = await releasePublish(handle, { … });
+  …
+}
+
+case 'reconcile': {
+  const handle = loadActiveReleaseHandle(getProjectRoot());
+  const result = await releaseReconcile(handle, { … });
+  …
+}
+```
+Ship is conspicuously absent. Ship goes through `pipeline.release.ship` (`release.ts:73-87`), which is dispatched to engine-ops's `releaseShip`, which never reads the handle.
+
+### Root Cause
+
+The CLI exposes BOTH the canonical 4-step pipeline (T1597 / ADR-063: `start → verify → publish → reconcile`) AND the imperative 12-step ship monolith (`release ship`). They are **two parallel, non-integrated release systems**:
+
+- **Pipeline (pipeline.ts)**: stateful via on-disk handle `.cleo/release/handle.json`. Each step reads/writes the handle.
+- **Ship (engine-ops.ts:releaseShip)**: stateless — all 12 steps live inside a single function. Takes `{version, epicId}` directly. Does not consult the handle.
+
+The operator's mental model: `release start` initializes a "release context" that `ship` will consume. The implementation: `release start` writes a handle that `ship` ignores. The handle is consumed only by `verify` / `publish` / `reconcile`, which themselves are never called by `ship` (and `ship` itself never updates the handle).
+
+Compounding: the handle's filesystem path is `.cleo/release/handle.json` (pipeline.ts:91), not `.cleo/release-state.json` as the operator expected. So even when the handle DOES exist, the operator looking for "release state" doesn't find it.
+
+Additionally: if `ship` fails halfway (e.g. at Step 5 — the wedged commit in Failure #1), there is NO resume point. The operator must `rollback-full` (which itself does git-tag-deletion and DB-flip) and re-run from scratch — losing context about which steps had succeeded.
+
+### Blast Radius
+
+- `release start` is decorative. The operator gains false confidence ("I started the release") when nothing actionable has been recorded for the ship path.
+- No resume capability: a failed `ship` cannot be resumed at step N. It must be re-run from step 0 or rolled back entirely.
+- Handle drift: if the operator runs `release start 2026.5.74` then `release ship 2026.5.75 --epic …`, the handle says one version while ship runs another. Verify/publish/reconcile later operate on the wrong version.
+- ADR-063 (4-step pipeline) is documented as the canonical model but unused. The actual production path is the 12-step monolith. Operator-facing docs and runtime behavior diverge.
+
+### Fix Class
+- [ ] one-line patch
+- [ ] new wrapper / timeout
+- [x] state-machine redesign — *the two systems must converge into one*
+- [x] architectural carve-out — *ship must consume the handle OR start must be removed from the CLI*
+- [ ] documentation
+- [ ] config-driven
+
+### Suggested invariant
+**There MUST be a single release state machine.** `release ship` MUST consume the handle written by `release start` (and MUST refuse to run if no handle exists OR if the handle's version doesn't match). Each step MUST update the handle with `{lastCompletedStep, lastError, …}` so a failed ship can be resumed via `cleo release ship --resume`. **The handle filename MUST be predictable and operator-facing** (e.g. `.cleo/release/state.json` with prominent docs).
+
+---
+
+## Failure #9: Esbuild externals not auto-detected
+
+### Symptom (verbatim from T9345)
+> "T9317 Bedrock SDK addition required manual `build.mjs` edit for @aws-sdk/* + @smithy/* externals. Pipeline did not detect or warn that a new dep would break esbuild bundling."
+
+### Reproduction
+1. Add `@aws-sdk/client-bedrock-runtime` to `packages/core/package.json` dependencies.
+2. Run `pnpm run build` (which invokes `node build.mjs`).
+3. esbuild attempts to bundle the new dep inline. The bundle blows up because `@smithy/*` packages use `node:buffer` dynamic require + native ESM tricks esbuild can't follow.
+4. Operator manually edits `build.mjs` to add `'@aws-sdk/client-bedrock-runtime', /^@aws-sdk\//, '@smithy/types', /^@smithy\//` to the externals list.
+5. Build succeeds.
+6. There is no automated step that scans newly-added dependencies and warns the operator that they may need to be externals.
+
+### Code Evidence
+
+**File**: `build.mjs:179-266` (the externals list — maintained by hand)
+```ts
+// Shared externals — these are NOT bundled, consumers install them separately
+// ALL npm dependencies are external — only @cleocode/* workspace packages are bundled inline.
+
+// T1178 (W3-2+W3-6): @cleocode/core is now truly external — the cleo CLI
+…
+  // onnxruntime-node (.node bindings) and sharp — both must stay external
+…
+  // tree-sitter native Node addon + grammar packages — must stay external
+…
+  // at CLI startup. Keep it external so it loads at runtime from node_modules. (T755)
+…
+  // transitively — all must stay external so esbuild does not try to inline
+…
+  // external so node-fetch never gets inlined into the ESM bundle. (T-THIN-WRAPPER)
+…
+  // @anthropic-ai/sdk similarly should stay external — it's a large SDK that
+…
+  // AWS SDK v3 modules — pull in @smithy/* runtime, node:buffer dynamic require,
+  '@aws-sdk/client-bedrock-runtime',
+  /^@aws-sdk\//,
+  '@smithy/types',
+  /^@smithy\//,
+```
+
+This list is hand-maintained. Each entry has a comment explaining WHY the dependency must be external. There is no tooling that reads `package.json` and emits warnings for un-listed deps.
+
+**File**: `packages/core/src/release/version-bump.ts` (releases bump versions in package.json files but never scan dependencies)
+```ts
+// (grep result: no occurrences of 'esbuild', 'externals', '@aws-sdk', '@smithy')
+```
+
+**File**: `packages/core/src/release/engine-ops.ts:1478-1495` (the lint step is the only build-related check in ship)
+```ts
+// Step 4.5: Lint check — warn on errors but don't block release
+try {
+  execFileSync('npx', ['biome', 'check', '--no-errors-on-unmatched', cwd], {
+    cwd,
+    encoding: 'utf-8',
+    stdio: 'pipe',
+    timeout: 30_000,
+  });
+  logStep(4, 12, 'Lint check', true);
+} catch (err: unknown) {
+  …
+}
+```
+There is no `pnpm run build` step, no `node build.mjs --check`, no esbuild dry-run. The ship pipeline never tests that the bundles actually compile.
+
+### Root Cause
+
+The release pipeline assumes someone else has validated that `pnpm run build` works. CI does — but CI runs *after* the release branch is cut and pushed (Step 6) and the PR is opened (Step 7). If CI fails because esbuild can't bundle a new dep, the operator finds out at step 8 ("Wait for CI checks") — having already cut the release branch, pushed it, opened the PR, and updated the changelog.
+
+There is no pre-step that:
+- Diffs `package.json` against the last successful release
+- Lists new dependencies
+- For each new dep, checks: is it an esbuild external? does it have a `.node` binary? does it use `node:buffer` dynamic require?
+- Warns or blocks if any new dep is not in `build.mjs`'s externals list (or vice versa)
+
+The externals list itself is a long hand-maintained array in `build.mjs` — there is no schema, no validator, no test that ensures it stays in sync with `package.json`.
+
+### Blast Radius
+
+- Every new heavy dep that needs externals treatment causes a CI failure on the release branch (not on the feature branch — the feat branch may have been auto-greenlit if CI somehow tolerated it locally).
+- Operator must abort or rollback the release, manually edit `build.mjs`, re-run.
+- The hand-maintained externals list grows monotonically — no test catches dead entries (deps removed from package.json but still in externals).
+- New devs adding a dep have no warning system pointing them at `build.mjs`.
+
+### Fix Class
+- [ ] one-line patch
+- [ ] new wrapper / timeout
+- [ ] state-machine redesign
+- [ ] architectural carve-out
+- [ ] documentation
+- [x] config-driven — *a new pipeline step + a tool that consumes the externals list as data*
+
+### Suggested invariant
+**The release pipeline MUST execute `pnpm run build` (or the project-context `build.command`) as a pre-ship gate, NOT defer it to CI.** A pipeline step MUST diff the current `package.json` against the previous release's `package.json`, flag new dependencies, and emit a warning if any new dep is not represented in `build.mjs` externals (or, conversely, if an external in build.mjs no longer corresponds to a real dep). The externals list MUST be machine-readable (e.g. a `.cleo/build-externals.json` file with a JSON schema) so tooling can validate it.
+
+---
+
+## Failure #10: CHANGELOG fragile
+
+### Symptom (verbatim from T9345)
+> "Auto-generated CHANGELOG entries include verbose RCASD task descriptions, not human-readable changelogs. No semver impact assessment."
+
+### Reproduction
+1. Run `cleo release ship 2026.5.74 --epic T9261`.
+2. Step 4 (Generate CHANGELOG) calls `generateReleaseChangelog(version, …)` (engine-ops.ts:1453).
+3. That function (release-manifest.ts:272-368) iterates release task records and calls `buildEntry(task)` for each.
+4. `buildEntry` (release-manifest.ts:334-368) decides whether to include `task.description` based on a heuristic: include if description ≥ 20 chars AND not a minor rephrasing of title.
+5. RCASD tasks tend to have long, verbose descriptions (the entire RFC-2119 spec excerpt copy-pasted into description). These pass the heuristic and end up in CHANGELOG.md.
+6. Output is a multi-line, multi-paragraph wall of text per task — unreadable for humans.
+
+### Code Evidence
+
+**File**: `packages/core/src/release/release-manifest.ts:330-368` (the entry builder)
+```ts
+/**
+ * Build a changelog entry line for a task.
+ * Uses description to enrich the entry when it's meaningfully different from the title.
+ */
+function buildEntry(task: ReleaseTaskRecord): string {
+  const cleanTitle = capitalize(stripConventionalPrefix(task.title));
+  // Strip newlines and collapse whitespace in description
+  const safeDesc = task.description
+    ?.replace(/\r?\n/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+  const desc = safeDesc;
+
+  // Include description only when it's non-trivial and adds information beyond the title.
+  // Skip if: description is empty, identical to title, or a minor rephrasing (≤10% longer, no new words).
+  const shouldIncludeDesc = ((): boolean => {
+    if (!desc || desc.length === 0) return false;
+    const titleNorm = cleanTitle.toLowerCase().replace(/[^a-z0-9\s]/g, '').trim();
+    const descNorm = desc.toLowerCase().replace(/[^a-z0-9\s]/g, '').trim();
+    if (titleNorm === descNorm) return false;
+    if (descNorm.startsWith(titleNorm) && descNorm.length < titleNorm.length * 1.3) return false;
+    // Require description to be at least 20 chars and contain different content
+    return desc.length >= 20;
+  })();
+
+  if (shouldIncludeDesc) {
+    // Truncate long descriptions to keep changelog readable
+    const descDisplay = desc!.length > 150 ? desc!.slice(0, 147) + '...' : desc!;
+    return `- **${cleanTitle}**: ${descDisplay} (${task.id})`;
+  }
+
+  return `- ${cleanTitle} (${task.id})`;
+}
+```
+
+Note the 150-char cap: descriptions ARE truncated. But 150 chars of RCASD-spec-quote is still verbose, and the operator's stated grievance is the entries are "verbose RCASD task descriptions, not human-readable changelogs" — implying the truncated form is still too noisy.
+
+**File**: `packages/core/src/release/release-manifest.ts:305-409` (categorization — no semver impact assessment)
+```ts
+const features: string[] = [];
+const fixes: string[] = [];
+const chores: string[] = [];
+const docs: string[] = [];
+const tests: string[] = [];
+const changes: string[] = [];
+…
+function categorizeTask(task: ReleaseTaskRecord): 'features' | 'fixes' | 'docs' | 'tests' | 'chores' | 'changes' {
+  if (task.type === 'epic') return 'changes';
+  const taskType = (task.type ?? '').toLowerCase();
+  if (taskType === 'test') return 'tests';
+  if (taskType === 'fix' || taskType === 'bugfix') return 'fixes';
+  if (taskType === 'feat' || taskType === 'feature') return 'features';
+  if (taskType === 'docs' || taskType === 'doc') return 'docs';
+  if (taskType === 'chore' || taskType === 'refactor') return 'chores';
+  …
+}
+```
+No `breaking` category. No `major`/`minor`/`patch` impact estimation. The categorization is "what kind of work was done" — not "what does it mean for downstream consumers."
+
+**File**: `packages/core/src/release/changelog-writer.ts:43-63` (`buildSection` — flat output)
+```ts
+function buildSection(version: string, generatedContent: string, customBlocks: string[]): string {
+  const date = new Date().toISOString().split('T')[0];
+  const lines: string[] = [];
+  lines.push(`## [${version}] (${date})`);
+  lines.push('');
+  lines.push(generatedContent.trimEnd());
+  if (customBlocks.length > 0) {
+    lines.push('');
+    for (const block of customBlocks) {
+      lines.push(block);
+      lines.push('');
+    }
+  }
+  lines.push('---');
+  lines.push('');
+  return lines.join('\n');
+}
+```
+The section header is `## [VERSION] (DATE)` — no upgrade-impact callout, no migration notes section, no breaking-changes section.
+
+### Root Cause
+
+The CHANGELOG generator was designed for short, well-formed task titles (e.g. "fix: handle null user in auth callback"). It was NOT designed for RCASD or research tasks where the description is a long-form analytical document (multiple paragraphs of RFC-2119 SHALL/MUST statements).
+
+The heuristic `desc.length >= 20 && desc !== title-near-prefix` happily includes 150-char excerpts from those long-form descriptions. Truncating to 150 chars mid-sentence produces fragments like "**Forensic analysis of release pipeline failure modes**: Per RFC-2119 the release...". Operators see a changelog full of mid-sentence cliffhangers.
+
+There is no signal in the task data that says "this task is research/RCASD — render minimally" vs "this task is user-facing feature — render fully." The categorizer dispatches by `task.type` but RCASD tasks may have type='task' or 'epic' depending on how they were created.
+
+Compounding: there is no semver impact assessment. CHANGELOG.md is one of the inputs operators use to decide MAJOR vs MINOR vs PATCH bumps, but the generator does not classify changes by impact — only by work-kind.
+
+### Blast Radius
+
+- Operators dread reading the CHANGELOG and skip the human-readable check, increasing release-quality risk.
+- Downstream consumers (npm users, integrators) see noise — cannot quickly identify what changed for them.
+- No machine-readable hint at semver impact: tooling that wants to enforce "no major bumps in calver patch position" cannot.
+- Custom-log blocks ([custom-log]…[/custom-log]) ARE supported (changelog-writer.ts:14-36) — operators can hand-author the meaningful summary — but this is opt-in and the auto-generated noise is still included alongside.
+
+### Fix Class
+- [ ] one-line patch
+- [ ] new wrapper / timeout
+- [ ] state-machine redesign
+- [ ] architectural carve-out
+- [x] documentation — *RCASD tasks need a short user-facing summary field*
+- [x] config-driven — *a configurable filter list + impact-assessment rules*
+
+### Suggested invariant
+**Each task MUST have a `userFacingSummary` field (short, ≤120 chars, human-readable) separate from `description`** — and `buildEntry` MUST consume only `userFacingSummary` for CHANGELOG output. **Each task MUST have an explicit semver impact tag** (`impact: 'major' | 'minor' | 'patch' | 'none'`) and the CHANGELOG MUST include a top-level Upgrade Impact section that aggregates major/minor changes. Tasks without these fields MUST be excluded from CHANGELOG entries (with a structured warning).
+
+---
+
+# Cross-Failure Synthesis
+
+## Root-cause clusters
+
+### Cluster 1 — No child-process supervision (Failures #1, #6)
+The pipeline calls `execFileSync` / `spawnSync` against external binaries (`git`, `gh`, `npx biome`, `npm`) with inconsistent timeout discipline.
+- Some calls have `timeout: 30_000` or `timeout: 60_000` (e.g. engine-ops.ts:1484, 1688).
+- Most git calls have NO timeout (gitCwd at engine-ops.ts:1497 omits the field).
+- No follow-up SIGKILL-on-timeout enforcement.
+- `gh pr merge --auto` is fire-and-forget; the pipeline treats it as synchronous (engine-ops.ts:1686).
+- No polling of remote git/GitHub state after async operations.
+
+**Evidence**: engine-ops.ts:86-140 (`runGitWithLockRetry` retries only on lock-error stderr signature; can't detect wedged-with-no-stderr); engine-ops.ts:1497 (gitCwd has no timeout); engine-ops.ts:1686 (gh --auto, no post-merge polling); engine-ops.ts:1722-1727 (immediate `git pull && git rev-parse HEAD` after `--auto` merge).
+
+### Cluster 2 — Gate logic confused with pipeline logic (Failures #3, #4)
+There are at least THREE gate systems:
+- `pipeline.ts:VERIFY_GATES` — canonical 5-gate list (test/lint/typecheck/audit/security-scan) with **no-op default runner**.
+- `release-manifest.ts:runReleaseGates` — a separate gate executor consumed by `releaseShip` (engine-ops.ts:1236).
+- IVTR gate in engine-ops.ts:1252-1293 — three-state (released/blocked/unchecked) with `unchecked` treated as warn-only.
+
+None of these talks to the others. The canonical pipeline's `verify` step has a stub default that always-fails, but the CLI doesn't inject a real runner (release.ts:317-323). Meanwhile `ship` runs a different gate set entirely (engine-ops.ts:1236) and reports "all green" while `verify` reports "all red" — for the same release.
+
+The IVTR gate has a `non-blocking` bucket that, when the entire epic is in that bucket (72/72), reduces the gate to a printed warning.
+
+**Evidence**: pipeline.ts:249-262 (`defaultRunGate` always fails), pipeline.ts:264-270 (`defaultAuditChildren` always empty); release.ts:317-323 (CLI doesn't inject runners); engine-ops.ts:1236 (`runReleaseGates` is a different gate registry); engine-ops.ts:190-212 (`checkIvtrGates` three-bucket); engine-ops.ts:1285-1289 (`unchecked` → warn-only).
+
+### Cluster 3 — No state-machine resume (Failures #1, #6, #8)
+The 12-step pipeline (engine-ops.ts:releaseShip) is a single monolithic function. There is no persisted per-step state. If step 5 fails (wedged commit), there is no resume — the operator must `rollback-full` or manually undo.
+
+Meanwhile `release start` writes a handle (pipeline.ts:288-316) that `ship` ignores. The handle would be the natural place to persist `{lastCompletedStep, lastError, …}` for resume, but it's not wired.
+
+**Evidence**: engine-ops.ts:1105-1866 (one giant function, no checkpoints); pipeline.ts:91, 211-239 (handle exists, has no step-tracking fields); engine-ops.ts never references `loadActiveReleaseHandle` (grep-verified). On any failure between Step 5 and Step 12, the only documented recovery is `release rollback-full` (engine-ops.ts:759).
+
+### Cluster 4 — Enforcement is env-var-only, not defense-in-depth (Failure #7)
+The git-shim's entire authority depends on `CLEO_AGENT_ROLE` being set in the subprocess env (shim.ts:232-244). If env stripping occurs (sub-shell, `exec -c`, terminal opened outside the orchestrator), the shim is bypassed silently. The denylist also fails to include `git push <remote> <local>:<protected-branch>` — a primary attack vector.
+
+**Evidence**: shim.ts:61-65 (env-only role detection); shim.ts:232-244 (no-role fast path); denylist.ts:184-200 (only force-push variants of push are denied).
+
+### Cluster 5 — Hand-maintained registries with no sync test (Failures #9, #10)
+Several config artifacts are maintained by hand with no programmatic validation:
+- `build.mjs` externals list (build.mjs:179-266) — long array of strings + regexes, comments explaining why each entry exists. No test that fails when a new dep is added without an entry.
+- Task data has free-form `description` — no separate `userFacingSummary` or `impact` field. CHANGELOG generation guesses based on heuristics.
+
+**Evidence**: build.mjs:259-265 (recently-added @aws-sdk/@smithy entries, hand-edited after T9317 broke); release-manifest.ts:334-368 (heuristic-driven description inclusion).
+
+### Cluster 6 — Sessions don't bound their own state (Failure #5)
+`session end` (session/engine-ops.ts:574-690) is a long function that cleans up focus state, file_meta, summarization prompts, and journal entries — but does NOT delete the override-counter file. The counter persists indefinitely, defeating its own per-session semantics.
+
+**Evidence**: session/engine-ops.ts:574-690 (no override-counter reset); override-cap.ts:147 (only write path is incrementing; no `clearSessionOverrideCount` function exists in the module); validation/engine-ops.ts:385 (`sessionId ?? 'global'` fallback collapses orphan invocations into one counter).
+
+## Conflation hypothesis: governance vs pipeline
+
+**Hypothesis**: The system conflates two distinct concerns:
+- **Governance**: "Don't let bad things ship" (gates that BLOCK).
+- **Pipeline**: "Make the next step happen" (state machine that MUST be unblockable for hotfixes).
+
+**Evidence FOR conflation**:
+
+1. The IVTR gate (engine-ops.ts:1252-1293) is supposed to be governance but its `unchecked` bucket turns it into pipeline (warn and continue). Governance requires a binary verdict; pipeline allows "warn and continue." Mixing the two means 72/72 unchecked tasks ship without blocking.
+
+2. The epic-completeness gate (engine-ops.ts:1339-1378 + guards.ts:53-135) is supposed to be governance but it scopes itself by traversing parent chains across epics — making it impossible to do a hotfix release that includes a single task from a foreign epic without dragging that whole epic's tree into the audit. Governance is correctly strict; pipeline needs to be permissive for hotfixes; the gate is strict in a way that blocks pipeline.
+
+3. The override-cap (override-cap.ts) is governance but its counter doesn't reset — operators bypass with always-on waivers, effectively turning the gate off. The pipeline implicitly accepts this as the cost of getting work done.
+
+4. The two parallel release systems (pipeline.ts canonical 4-step vs engine-ops.ts 12-step monolith) embody the conflation literally: `verify` is governance-shaped (gate-by-gate, reportable), `ship` is pipeline-shaped (do-everything-or-rollback). They don't compose.
+
+**Evidence AGAINST conflation** (none compelling): one could argue that the `--force` flag on `ship` (engine-ops.ts:1117) provides the pipeline-permissive escape valve. But it's binary (bypass all IVTR + channel/version validation OR bypass nothing) and audited only via a log line. There is no "hotfix mode" that selectively bypasses governance while keeping pipeline integrity.
+
+**Conclusion**: Yes, the system conflates governance and pipeline. A redesign should separate them:
+- **Governance** = a gate registry with declarative pass/fail outputs that NEVER short-circuit pipeline state.
+- **Pipeline** = a state machine with explicit checkpoints, resume, and skip-with-audit hotfix paths.
+- They communicate via an interface, not by being intertwined in one function.
+
+## Monolith hypothesis: is the 12-step flow too monolithic?
+
+**Hypothesis**: `releaseShip` (engine-ops.ts:1105-1866) is too monolithic — state recovery is impossible because there are no checkpoints.
+
+**Evidence FOR monolith critique**:
+
+1. **761 lines, one function**. From line 1105 to 1866. Includes config loading, version normalization, version-bump, manifest auto-prepare, 5 gate types, channel validation, git branch operations, push, gh PR create, gh check polling, gh merge, git pull/tag/push, branch cleanup, and provenance recording — all sequential.
+
+2. **No mid-function state persistence**. The `steps: string[]` array (engine-ops.ts:1130) is a local variable. If the function throws or process exits at step 7, `steps` is lost. The release manifest gets `pushedAt` only at the very end (engine-ops.ts:1826 via `markReleasePushed`). There's nothing in between.
+
+3. **No resume**. If the function fails at step 5 (wedged commit, Failure #1), there is no `cleo release ship --resume 2026.5.74` command. The CLI exposes `release ship`, `release rollback`, `release rollback-full`, `release pr-status` (engine-ops.ts:1911), but no resume. Operators must roll back fully and re-run.
+
+4. **Impossible to test sub-steps**. The function takes `{version, epicId, remote, dryRun, bump, force}` and returns one `EngineResult`. Testing step 8 (CI wait) in isolation requires mocking the entire prefix (steps 0-7). Step-by-step tests don't exist in `packages/core/src/release/__tests__/`.
+
+5. **Step 7 (PR create) + Step 8 (CI wait) + Step 9 (merge) + Step 10 (tag) form a network-coupled chain**. Each is an external API call. The function does them sequentially without recording success-of-step-N before attempting step-N+1. If the network fails mid-way (between Step 9 succeeding on the server and Step 10 starting locally), the function may have merged the PR but not tagged the commit — leaving the release in a half-done state with no way to recover except manual.
+
+6. **The handle from `release start` (pipeline.ts) is the obvious place for per-step state**, but `releaseShip` ignores it (confirmed grep). The architecture HAS a state-bag but doesn't USE it.
+
+**Evidence AGAINST monolith critique** (partial):
+
+1. Some idempotency is built in: step 10 checks for existing tag (engine-ops.ts:1730-1761) and skips creation if tag points at HEAD. Step 11 swallows "branch already gone" errors.
+
+2. Auto-prepare (engine-ops.ts:1210-1232) handles the case where the manifest row doesn't exist — that's a kind of resume-from-zero.
+
+3. The `dryRun` branch (engine-ops.ts:1403-1449) exits at step 4 — providing one form of bounded execution.
+
+**But**: these are point-fixes for known race conditions, not a coherent state-machine architecture. They cover SOME re-run cases, not all.
+
+**Conclusion**: Yes, the 12-step flow is too monolithic for state recovery. A redesign should:
+- Decompose into 12 named steps each with `{start, complete, fail}` state transitions written to the handle.
+- Add `cleo release ship --resume <version>` that reads the handle and dispatches from `handle.lastCompletedStep + 1`.
+- Make each step idempotent or explicitly mark it as not-resumable.
+- Move network-coupled steps (PR create, CI wait, merge) into a separate phase that can be re-attached if the network drops.
+
+---
+
+# Closing observations
+
+1. **Failures #3 and #8 share the same architectural disease**: two parallel release systems with overlapping CLI surfaces, neither aware of the other. Fixing one without unifying will not fix the operator experience.
+
+2. **Failures #1, #6, and #7 share a "no defensive depth" disease**: the pipeline trusts external programs (git, gh, the shim's env-var) without independent verification. Adding timeouts + polling + on-disk policy can recover defense-in-depth without rewriting everything.
+
+3. **Failure #2 and #5 share a "stale state" disease**: epic-completeness uses a graph it doesn't own (cross-epic parent chains), and the override counter uses a file no one cleans up. Fix: explicit ownership of state lifecycle, with sweepers.
+
+4. **Failure #4 and #10 share a "warning theater" disease**: gates that should block instead emit warnings; CHANGELOG entries that should be selective instead include everything. Operators learn to ignore the noise.
+
+5. **Failure #9 sits alone but is the most fixable**: a single new pipeline step (`pnpm run build` + `package.json` diff) catches the class of bug.
+
+The ADR + RFC-2119 spec deriving from this report should target the six clusters above. A piece-by-piece fix list is insufficient — the conflation (governance vs pipeline) and the monolith (12-step single function) need to be addressed at the architectural level before individual fixes will be durable.

--- a/.cleo/rcasd/T9345/research/hermes-agent-real-research.md
+++ b/.cleo/rcasd/T9345/research/hermes-agent-real-research.md
@@ -1,0 +1,1180 @@
+# Hermes-Agent — Real-World Research (T9345 IVTR Release System)
+
+**Status**: Research artifact — primary evidence for T9345 RCASD phase
+**Researcher**: cleo-prime (T9345 research worker)
+**Date compiled**: 2026-05-15
+**Primary sources**: Local clone at `/mnt/projects/hermes-agent/` (fork of `NousResearch/hermes-agent`, last fetched 2026-05-13, HEAD `d93ac84d9` at `v2026.5.7-583`)
+**Secondary sources**: Public README at `https://github.com/NousResearch/hermes-agent`, `https://hermes-agent.nousresearch.com/docs/`, owner's local precedent doc
+
+---
+
+## 0. Executive Summary (300 words)
+
+Hermes-agent is real. It is the canonical project at
+`github.com/NousResearch/hermes-agent` ("The self-improving AI agent built by
+Nous Research"), MIT-licensed, currently at `v0.13.0` / CalVer tag
+`v2026.5.7` (released 2026-05-07). The owner of this CLEO repo already
+keeps a fork at `github.com/kryptobaseddev/hermes-agent` with a fully
+operational 12-hourly upstream sync workflow, so the local
+`/mnt/projects/hermes-agent/` checkout is canonical, current, and
+trustworthy as a primary source. There is no ambiguity with "Nous Hermes"
+LLM weights or with `Hermes-Function-Calling` — the precedent CLEO's
+`docs/specs/hermes-agent-llm-provider-architecture.md` cites is
+unambiguously this Python codebase.
+
+**Borrowable for T9345 (HIGH confidence)**: dual CalVer + SemVer tagging
+with the `next_available_tag` collision-safe suffixing; commit-driven
+Conventional-Commits changelog with author resolution via an
+`AUTHOR_MAP`; PR-only main with **release-as-event** (the `release:
+published` GitHub event drives downstream deploys and Docker `:latest`
+retag); the digest-then-manifest Docker pattern with an ancestor check
+that prevents `:main` / `:latest` from regressing; the
+"`release.py --bump minor --publish`" single-script pipeline; pinned
+direct deps + OSV scanning + supply-chain audit; the
+contributor-attribution gate as a CI block.
+
+**NOT borrowable / mismatched for CLEO (HIGH confidence)**: there is NO
+multi-stage IVTR-style gate ladder, NO epic-scoped completeness check,
+NO task↔commit↔release provenance graph, NO worker-direct-push protection
+beyond GitHub branch protection, NO mid-pipeline failure recovery layer
+beyond "fix and re-run `release.py`", and NO hotfix bypass path beyond
+shipping a same-day suffixed tag (`v2026.X.Y.2`, etc.). The Hermes-agent
+release surface is **minimalist and human-driven** — closer to "shell
+script + GitHub events" than to CLEO's `cleo release ship` 12-step
+pipeline. CLEO must build its own provenance graph and gate runners;
+Hermes-agent only offers patterns for tagging, changelog generation,
+release-event-driven CI, and contributor attribution.
+
+---
+
+## 1. Identification — Which "Hermes-agent" Is the Precedent?
+
+### 1.1 Candidates considered
+
+| Candidate | What it actually is | Match for CLEO precedent? |
+|----------|--------------------|---------------------------|
+| **NousResearch/hermes-agent** | The self-improving AI agent platform built by Nous Research. Python, MIT, 24k+ PRs, 200+ contributors. | **YES — confirmed primary** |
+| Nous Research "Hermes" model family (Hermes 2 / 3 / 4) | LLM fine-tune weights, not a software project. Lives under HuggingFace, not under a "hermes-agent" repo. | No — model weights, no release pipeline to study. |
+| `NousResearch/Hermes-Function-Calling` | Function-calling format spec + sample code. Static repo, ~10 commits, last touched 2024-ish. | No — wrong shape, wrong activity level. |
+| `NousResearch/hermes-agent-self-evolution` | Companion repo for DSPy/GEPA skill evolution. | No — adjunct, not the main project. |
+| `mudrii/hermes-agent-docs` | Third-party documentation mirror, v0.2.0 only. | No — derivative. |
+| LangChain "Hermes" integrations | Provider adapter shims. | No — not a release pipeline. |
+| Internal cleocode reference | None — verified by `find /mnt/projects/cleocode -iname '*hermes*'`. | N/A. |
+
+### 1.2 Confirmation
+
+**Local doc** (`docs/specs/hermes-agent-llm-provider-architecture.md:6`)
+states `**Source repo**: /mnt/projects/hermes-agent/`. That directory
+exists, is a git repo, and its remotes are:
+
+```
+origin    https://github.com/kryptobaseddev/hermes-agent.git
+upstream  https://github.com/NousResearch/hermes-agent.git
+```
+
+`scripts/release.py:1296` hardcodes `repo_url="https://github.com/NousResearch/hermes-agent"`,
+which is the canonical confirmation that the upstream identity is
+`NousResearch/hermes-agent`. The local CLEO doc explicitly maps Hermes
+file paths (`agent/credential_pool.py`, `providers/base.py`,
+`agent/transports/types.py`, etc.) onto CLEO Phase 4 contracts, so
+**this is the precedent**.
+
+### 1.3 Current release/tag visible
+
+```
+v2026.5.7   2026-05-07   Hermes Agent v0.13.0 (2026.5.7)
+v2026.4.30  2026-04-30   Hermes Agent v0.12.0 (2026.4.30)
+v2026.4.23  2026-04-23   Hermes Agent v0.11.0 (2026.4.23)
+v2026.4.16  2026-04-16   Hermes Agent v0.10.0 (2026.4.16)
+v2026.4.13  2026-04-13   Hermes Agent v0.9.0 (v2026.4.13)
+v2026.4.8   2026-04-08   Hermes Agent v0.8.0 (2026.4.8)
+v2026.4.3   2026-04-03   Hermes Agent v0.7.0 (2026.4.3)
+v2026.3.30  2026-03-30   Hermes Agent v0.6.0 (2026.3.30)
+v2026.3.28  2026-03-28   Hermes Agent v0.5.0 (v2026.3.28)
+v2026.3.23  2026-03-23   Hermes Agent v0.4.0 (v2026.3.23)
+v2026.3.17  2026-03-17   Hermes Agent v0.3.0 (v2026.3.17)
+v2026.3.12  2026-03-12   Hermes Agent v0.2.0 (2026.3.12)
+```
+*(Source: `git for-each-ref --sort=-creatordate refs/tags/v20*` against the local checkout.)*
+
+The local checkout is 583 commits ahead of `v2026.5.7` on `upstream/main`
+(`git describe → v2026.5.7-583-gd93ac84d9`), meaning `v0.14.0` /
+`v2026.6.x` is already in flight upstream.
+
+### 1.4 License + maintainer
+
+`LICENSE`: **MIT**, "Copyright (c) 2025 Nous Research". Full text reproduced
+in §A1.
+
+Maintainer signals:
+- Primary author per `pyproject.toml`: `Nous Research`.
+- `scripts/release.py:42` author map enumerates 600+ contributor emails →
+  this is a high-traffic public OSS project, not a single-person hobby.
+- Release notes (`RELEASE_v0.13.0.md:4`) confirm scale: "864 commits ·
+  588 merged PRs · 829 files changed · 128,366 insertions · 282 issues
+  closed · 295 community contributors" — for **one** release cycle.
+
+---
+
+## 2. Local Precedent Doc — What CLEO Is Borrowing From Hermes
+
+CLEO's `docs/specs/hermes-agent-llm-provider-architecture.md` treats
+Hermes-agent as the architecture reference for **LLM provider stack
+unification** (CLEO Phase 4 epic T9261 — already shipped in
+`v2026.5.73`). The mapping it documents:
+
+| Hermes component | CLEO Phase 4 equivalent |
+|-----------------|------------------------|
+| `ProviderProfile` (`providers/base.py`) | `ProviderProfile` (Phase 3, already ported) |
+| Provider registry (`providers/__init__.py`) | `ProviderRegistry` (Phase 3) |
+| `PooledCredential` (`credential_pool.py`) | Phase 3 `CredentialPool` |
+| `CredentialPool.pick_credential()` | `credentialPool.pickCredentialForProvider()` |
+| Provider adapters (`*_adapter.py`) | `LlmTransport` impls (Phase 4 W1) |
+| `AuxiliaryClient` | `LlmExecutor.execute('compression', …)` |
+| `AIAgent` context/turn tracking | `LlmSession` (Phase 4 W2) |
+| `NormalizedResponse` | `NormalizedResponse` (Phase 4 W0b contract) |
+
+**Critical context for T9345**: This local doc establishes that CLEO
+already imports architecture ideas from Hermes wholesale. T9345 is
+asking the orthogonal question — does Hermes have a **release governance
+pattern** worth borrowing for the IVTR overhaul? The answer is "yes for
+mechanics, no for semantics" — Hermes solved tagging + changelog + CI
+glue elegantly, but did NOT solve epic-completeness, gate ladders, or
+task-provenance — because Hermes simply doesn't have those concerns.
+
+Quote (`hermes-agent-llm-provider-architecture.md:14-18`):
+
+> Hermes Agent is a Python-based multi-provider LLM agent framework. Its
+> LLM provider stack solves the same core problems that CLEO Phase 4
+> targets …
+
+The doc never claims Hermes solves release governance. It is purely a
+provider-stack precedent.
+
+---
+
+## 3. Release & Governance Patterns — The Evidence
+
+### 3.1 Versioning scheme — dual CalVer + SemVer
+
+**Source**: `scripts/release.py:1056-1082` + `pyproject.toml:7` + tag
+history above.
+
+Hermes-agent runs **dual versioning**:
+
+- **CalVer**: `v<YYYY>.<M>.<D>` — used as the **git tag** and the
+  GitHub release name. Same-day collisions get a `.<N>` suffix
+  starting at `.2` (`scripts/release.py:1044-1053`).
+- **SemVer**: `<MAJOR>.<MINOR>.<PATCH>` — lives in
+  `hermes_cli/__init__.py` and `pyproject.toml`. Bumped explicitly via
+  `--bump {major|minor|patch}` (`scripts/release.py:1063-1082`).
+
+The two are linked but independent. Example: `v0.13.0` (SemVer) ships
+under the tag `v2026.5.7` (CalVer date `2026.5.7`). The release title
+is `Hermes Agent v0.13.0 (2026.5.7)`.
+
+Why this matters for CLEO: CLEO is also on CalVer (per
+`AGENTS.md` "CalVer YYYY.MM.patch") but is **single-versioned** —
+the tag is the only identity. Hermes-agent shows a working pattern for
+keeping CalVer-as-tag while still emitting SemVer for downstream
+packagers (Homebrew, AUR, Nix) — the wheel filename uses the SemVer
+(`hermes_agent-0.13.0-py3-none-any.whl`), the GitHub release uses
+the CalVer tag, and `pyproject.toml` is bumped on every release.
+
+Key code (`scripts/release.py:1085-1109`):
+
+```python
+def update_version_files(semver: str, calver_date: str):
+    """Update version strings in source files."""
+    # Update __init__.py — both __version__ and __release_date__
+    content = re.sub(r'__version__\s*=\s*"[^"]+"',
+                     f'__version__ = "{semver}"', content)
+    content = re.sub(r'__release_date__\s*=\s*"[^"]+"',
+                     f'__release_date__ = "{calver_date}"', content)
+    # Update pyproject.toml — version = "X.Y.Z"
+    pyproject = re.sub(r'^version\s*=\s*"[^"]+"',
+                       f'version = "{semver}"',
+                       pyproject, flags=re.MULTILINE)
+```
+
+### 3.2 The release pipeline — `scripts/release.py`
+
+**Source**: `scripts/release.py:1400-1564` (the `main()` function), full
+file `1568` lines.
+
+Hermes-agent does **not** use a GitHub Actions release workflow. There
+is no `release.yml` in `.github/workflows/`. The release pipeline is a
+**single Python script** run from a maintainer's laptop with `gh` CLI:
+
+```bash
+# 1. Preview (dry run, default)
+python scripts/release.py --bump minor
+
+# 2. Ship it
+python scripts/release.py --bump minor --publish
+
+# 3. First-ever release
+python scripts/release.py --bump minor --publish --first-release
+
+# 4. Override CalVer date (belated release)
+python scripts/release.py --bump minor --publish --date 2026.3.15
+```
+
+The 12 steps `release.py main()` executes when `--publish`:
+
+| # | Step | Source |
+|--:|------|--------|
+| 1 | Compute CalVer date (or accept `--date`) | `release.py:1414-1419` |
+| 2 | Resolve next available tag (same-day suffix safe) | `release.py:1421-1424` |
+| 3 | Read current SemVer from `hermes_cli/__init__.py` | `release.py:1427-1431` |
+| 4 | Find previous tag (`v20*`, sort `-v:refname`) | `release.py:1434-1438` |
+| 5 | Gather commits since prev tag (no merges, with co-authors) | `release.py:1440-1445` |
+| 6 | Generate categorized changelog markdown | `release.py:1459-1470` |
+| 7 | Update `__init__.py` + `pyproject.toml` version strings | `release.py:1478-1480` |
+| 8 | `git add` + `git commit` version bump | `release.py:1482-1494` |
+| 9 | `git tag -a <tag> -m "Hermes Agent v<X.Y.Z> (<calver>)\n\nWeekly release"` | `release.py:1496-1504` |
+| 10 | `git push origin HEAD --tags` | `release.py:1506-1513` |
+| 11 | Build sdist + wheel via `python -m build` (optional; non-fatal if missing) | `release.py:1515-1521` |
+| 12 | `gh release create <tag> --title ... --notes-file ... <artifacts>` | `release.py:1523-1558` |
+
+**Critical absences**:
+- No pre-flight test gate (CI runs on every PR; release.py trusts
+  `main` is green at publish time).
+- No lint/typecheck gate (same).
+- No "epic completeness" check (Hermes has no epic concept).
+- No "wait for CI green" step.
+- No branch-cut step — releases tag `main` directly.
+- No hotfix branch model — same-day patches get `.2`, `.3` suffixes
+  on the date.
+
+**Comparison to CLEO `cleo release ship`** (12 steps per
+`AGENTS.md` "Release & Branching (ADR-065)"): CLEO's pipeline includes
+**all** the absences above as explicit steps (gates 2-5, 8, 11). Hermes
+gets away with less because it has fewer enforcement targets — a
+single Python package, no Rust workspace, no per-task acceptance gates,
+no IVTR loop.
+
+### 3.3 The release-as-event model
+
+**Source**: `.github/workflows/docker-publish.yml:24-26`,
+`.github/workflows/deploy-site.yml:3-5`.
+
+The downstream automation hangs off the **`release: published` GitHub
+event**, not off a tag push:
+
+- `docker-publish.yml:24` — `on: release: types: [published]` →
+  triggers the multi-arch Docker build + `:latest` retag.
+- `deploy-site.yml:3-5` — `on: release: types: [published]` →
+  triggers Vercel deploy hook + GitHub Pages docs build.
+
+This is a **decoupling pattern**: the release.py script tags the commit
+and creates the GitHub release; CI side-effects fan out asynchronously
+when the release is "published" in the GitHub UI/API. Pushing a tag
+alone does NOT trigger them — the GitHub Release object (created by
+`gh release create` in step 12) is the trigger.
+
+Why CLEO should care: CLEO's `cleo release ship` step 12 currently
+"merges + tags from main + cleanup". If T9345 surfaces a need to fan
+out downstream effects (docs deploy, container retag, sentinel
+notification) without tightly coupling them to the in-band ship
+pipeline, the `release: published` event provides a clean seam.
+
+### 3.4 Docker `:main` vs `:latest` — the ancestor check
+
+**Source**: `.github/workflows/docker-publish.yml:290-535`.
+
+This is the most sophisticated CI piece Hermes ships. Two floating
+tags:
+
+- `:main` — moves on every push to `main` (the "dev build").
+- `:latest` — moves only on `release: published` (the "stable release").
+
+Both use the **same protection pattern** — read the OCI revision label
+off the current registry image, look up that commit in git, and only
+advance the tag if the candidate commit is a strict ancestor (descendant
+of the current `:main` SHA). Quote
+(`.github/workflows/docker-publish.yml:399-406`):
+
+```bash
+# Our SHA must be a descendant of the current :main to be safe.
+if git merge-base --is-ancestor "${current_sha}" "${GITHUB_SHA}"; then
+  echo "Our commit is a descendant of :main — safe to advance."
+  echo "push_main=true" >> "$GITHUB_OUTPUT"
+else
+  echo "Another run advanced :main past us (or diverged) — leaving it alone."
+  echo "push_main=false" >> "$GITHUB_OUTPUT"
+fi
+```
+
+Combined with `concurrency: cancel-in-progress: false`, this means
+`:main` and `:latest` can **never go backwards in git history**, even
+under race conditions (two CI runs landing concurrently) or backport
+scenarios (releasing `v1.1.5` after `v1.2.3` is already out — the older
+release sees the ancestor check fail and leaves `:latest` alone).
+
+**For CLEO T9345**: This is the gold standard pattern for "tag-to-merge-
+commit alignment" (CLEO failure mode #5). CLEO currently does
+`git merge --no-ff` then tag from main; the ancestor check would
+catch the case where main has advanced between merge and tag.
+
+### 3.5 Multi-arch Docker pipeline
+
+**Source**: `.github/workflows/docker-publish.yml:42-289`.
+
+Pattern:
+1. `build-amd64` job — native amd64, build + load + smoke test + push
+   by-digest (no tag).
+2. `build-arm64` job — native arm64 on `ubuntu-24.04-arm`, same shape.
+3. `merge` job — `docker buildx imagetools create -t <tag>` stitches
+   the two digests into one manifest list. Runs in ~30s, no rebuild.
+4. `move-main` / `move-latest` — ancestor-checked floating tag
+   advancement (see §3.4).
+
+**Smoke test step** (`.github/actions/hermes-smoke-test/action.yml:29-47`):
+the image must respond to `hermes --help` AND `hermes dashboard --help`
+before the digest is pushed. The dashboard subcommand check is an
+explicit regression guard for issue #9153 (dashboard was once present
+in source but missing from the published image).
+
+**For CLEO**: The smoke-test-before-push pattern is directly portable.
+CLEO already smokes against an installed binary post-release; pulling
+the smoke gate **into** the release pipeline (between build and push)
+would convert post-mortem incidents into pre-flight blocks.
+
+### 3.6 CI gate inventory (current upstream)
+
+Every workflow:
+
+| File | Trigger | Blocks merge? | Purpose |
+|------|---------|---------------|---------|
+| `tests.yml` | push/PR to main | YES (timeout 20 min, full pytest) | Test gate |
+| `lint.yml` | push/PR | YES (ruff `--exit-zero` advisory + `ruff check .` blocking) + Windows footgun checker | Lint + Windows-unsafe primitive gate |
+| `uv-lockfile-check.yml` | push/PR touching pyproject/uv.lock | YES (`uv lock --check`) | Lockfile-drift gate |
+| `contributor-check.yml` | PR (Python files only) | YES (`AUTHOR_MAP` coverage) | Attribution gate |
+| `osv-scanner.yml` | PR + weekly schedule | NO (`fail-on-vuln: false`) | CVE detection (advisory) |
+| `supply-chain-audit.yml` | PR | YES (.pth files, base64+exec, obfuscated subprocess, install hooks) | Anti-litellm-style supply-chain payload scan |
+| `docker-publish.yml` | push/PR/release | YES on PR (build + smoke); pushes on main/release | Multi-arch Docker |
+| `deploy-site.yml` | release/push to website | (deploys) | Docs deploy |
+| `docs-site-checks.yml` | PR touching website | YES (Docusaurus build) | Docs build gate |
+| `nix.yml` | push/PR | (advisory) | Nix flake build |
+| `nix-lockfile-fix.yml` | push/PR | (advisory) | Nix lockfile maintenance |
+| `skills-index.yml` | schedule (twice daily) + push | n/a | Skills hub index regen |
+| `sync-upstream.yml` (fork-only) | schedule every 12h | n/a | Kryptobaseddev fork → upstream sync |
+
+**Key observation**: The `lint.yml` workflow has two jobs —
+`lint-diff` (advisory; produces PR comment showing ruff+ty diagnostics
+diff vs base) and `ruff-blocking` (only enforces rules in
+`pyproject.toml [tool.ruff.lint.select]`, currently just `PLW1514`).
+This is a **deliberately narrow enforcement surface**. Quote
+(`pyproject.toml:248-255`):
+
+```toml
+[tool.ruff.lint]
+# All other lints are intentionally disabled (see comment history on this
+# file) while we wrangle typechecks — but PLW1514 is too load-bearing to
+# keep off.  Bare open()/read_text()/write_text() in text mode defaults to
+# the system locale encoding on Windows (cp1252 on US-locale installs),
+# which silently corrupts any non-ASCII file content.
+```
+
+This is gate philosophy at its purest: enforce only what catches real
+production bugs; let everything else be advisory. CLEO's `pnpm biome
+ci .` is the equivalent today (full repo-wide strict), but the Hermes
+pattern of "block on the one rule that bites; advise on the rest" is
+worth considering for CLEO's IVTR test gates.
+
+### 3.7 Changelog generation — the `RELEASE_vX.Y.Z.md` artifact
+
+**Source**: `scripts/release.py:1296-1397` + the 12 `RELEASE_v*.md`
+files in repo root.
+
+Hermes-agent commits the rendered changelog into the repo as
+`RELEASE_v0.13.0.md` etc. — a permanent, browsable, agent-readable
+artifact at the repo root. The script `release.py`:
+
+1. Walks `git log <prev_tag>..HEAD --no-merges --format='%H|%an|%ae|%s\0%b\0'`.
+2. Parses each commit's subject for Conventional-Commits prefix; falls
+   back to keyword heuristics (`add `, `new `, `fix `, …).
+3. Extracts `Co-authored-by:` trailers from the body, **filtering
+   AI/bot emails** (`noreply@anthropic.com`, `cursor.com`, etc.) —
+   see `release.py:1222-1225`.
+4. Resolves git email → GitHub `@username` via:
+   - Hand-maintained `AUTHOR_MAP` (~600+ entries in `release.py:41-1010`).
+   - GitHub noreply pattern `\d+\+(.+)@users\.noreply\.github\.com`.
+   - Fallback to git author name.
+5. Groups by category (breaking, features, improvements, fixes, docs,
+   tests, chore, other) with emoji headers.
+6. Emits a "Contributors" section ordered by commit count, with the
+   project owner (`@teknium1`) excluded by convention.
+7. Appends the compare URL:
+   `**Full Changelog**: [v2026.4.30...v2026.5.7](https://github.com/.../compare/v2026.4.30...v2026.5.7)`.
+
+**Critical detail for CLEO** (`release.py:1316-1326`):
+```python
+all_authors = set()
+teknium_aliases = {"@teknium1"}
+
+for commit in commits:
+    categories[commit["category"]].append(commit)
+    author = commit["github_author"]
+    if author not in teknium_aliases:
+        all_authors.add(author)
+    for coauthor in commit.get("coauthors", []):
+        if coauthor not in teknium_aliases:
+            all_authors.add(coauthor)
+```
+
+This is the only "provenance" Hermes tracks — author identity. There is
+no task tracker, no issue↔commit graph, no epic linkage. **The
+changelog is the provenance ledger.** CLEO already has 10× richer
+provenance (tasks.db, BRAIN, acceptance gates) — but the discipline of
+emitting one canonical, committed-to-repo artifact per release is
+worth borrowing.
+
+### 3.8 The contributor-attribution gate
+
+**Source**: `.github/workflows/contributor-check.yml:1-73`.
+
+This is a CI block specifically for protecting `release.py`'s author
+resolution. Triggered on every PR that touches `.py` files. It:
+
+1. Computes `git merge-base origin/main HEAD`.
+2. Extracts every author email in the PR's commits.
+3. Skips bot emails (`teknium`, `noreply@github.com`, `dependabot`,
+   `github-actions`, `anthropic.com`, `cursor.com`).
+4. Auto-resolves GitHub noreply emails (`\d+\+.+@users.noreply.github.com`).
+5. For every remaining email, checks if it's quoted in
+   `scripts/release.py` (just a `grep -qF`).
+6. **Fails the job** if any email is unmapped, printing exact
+   `AUTHOR_MAP` entries to add.
+
+This is a **provenance enforcement** pattern. The build is blocked
+until every contributor can be attributed in the changelog. CLEO has no
+analogous gate — but if T9345 wants to track task↔commit↔release
+identity, the pattern of "fail CI if attribution metadata is missing"
+is directly applicable.
+
+### 3.9 Branch + PR discipline
+
+**Source**: `CONTRIBUTING.md:739-792` + `AGENTS.md:866-872`.
+
+| Rule | Source | Notes |
+|------|--------|-------|
+| Branch naming: `fix/`, `feat/`, `docs/`, `test/`, `refactor/<slug>` | `CONTRIBUTING.md:741-749` | Strong convention, not CI-enforced. |
+| One logical change per PR | `CONTRIBUTING.md:756` | Reviewer-enforced. |
+| Conventional Commits required | `CONTRIBUTING.md:766-791` | Drives `release.py` categorization. |
+| Squash merge default | `AGENTS.md:866-872` | Explicit warning: "Before squash-merging a PR, ensure the branch is up to date with `main`… a stale branch's version of an unrelated file will silently overwrite recent fixes on main when squashed." |
+| Verify with `git diff HEAD~1..HEAD` after merge | `AGENTS.md:871-872` | Manual post-merge check; no automation. |
+| `pytest tests/ -q` before opening PR | `CONTRIBUTING.md:753` | Plus `scripts/run_tests.sh` for CI parity. |
+| Cross-platform impact assessment | `CONTRIBUTING.md:755`, plus `scripts/check-windows-footguns.py` CI gate | Explicit Windows-specific check enforced via lint workflow. |
+
+**No mention** of branch protection rules in markdown. Branch protection
+is a GitHub-API-side setting; no evidence of it in the local checkout.
+The `permissions: contents: read` on most workflows hints at minimum-
+privilege, but CLEO's `gh api -X PUT repos/:owner/:repo/branches/main/protection`
+explicit setup (per CLEO `AGENTS.md`) is more rigorous than anything
+Hermes documents publicly.
+
+### 3.10 Supply-chain posture
+
+**Source**: `pyproject.toml:13-63`, `osv-scanner.yml`, `supply-chain-audit.yml`,
+`dependabot.yml`.
+
+Hermes-agent is **paranoid** about supply chain (response to the
+"Mini Shai-Hulud worm" on mistralai 2.4.6 — see `pyproject.toml:18-26`):
+
+- **Every direct dependency is exact-pinned** (`==X.Y.Z`, no ranges):
+
+  ```toml
+  "openai==2.24.0",
+  "python-dotenv==1.2.1",
+  "fire==0.7.1",
+  ...
+  ```
+
+- **`uv.lock` mandatory + drift-checked in CI** (`uv-lockfile-check.yml`).
+- **Dependabot scoped to GitHub Actions only** — explicitly NOT to pip
+  or npm, because automatic version-bump PRs would defeat the pinning
+  strategy. Quote (`dependabot.yml:1-22`):
+  > "We do NOT enable Dependabot for pip / npm / any source-dependency
+  > ecosystem because we pin source dependencies exactly … Automatic
+  > version-bump PRs against those pins would undermine the strategy"
+- **OSV-Scanner** runs on every PR touching lockfiles + weekly. Findings
+  upload to GitHub Security tab as SARIF. **`fail-on-vuln: false`** —
+  detection only, pin moves are deliberate.
+- **Supply-chain-audit** scans diffs for litellm-style attack patterns:
+  `.pth` files, `base64.decode + exec/eval` combos, obfuscated subprocess
+  args, install-hook files. **Fails CI** on hits.
+- **Lazy deps** (`tools/lazy_deps.py`) — provider-specific packages
+  (anthropic, firecrawl, exa-py, fal-client, edge-tts, modal, daytona,
+  vercel, mautrix, …) are NOT in `[all]` and lazy-install at first use,
+  to keep the install blast radius minimal.
+
+**For CLEO T9345**: This is best-in-class supply-chain posture for an
+agent framework. CLEO's pnpm-based stack has analogous concerns (the
+recent npm-supply-chain incidents in 2025-2026); the patterns of
+exact pinning + lockfile-drift CI + scoped dependabot + diff-based
+attack-pattern scanning are directly portable.
+
+### 3.11 Release cadence (observed)
+
+Tag history `git for-each-ref` shows:
+
+```
+v0.13.0  2026-05-07  (+7 days from v0.12.0)
+v0.12.0  2026-04-30  (+7 days)
+v0.11.0  2026-04-23  (+7 days)
+v0.10.0  2026-04-16  (+3 days from v0.9.0 — short Tool Gateway release)
+v0.9.0   2026-04-13  (+5 days from v0.8.0)
+v0.8.0   2026-04-08  (+5 days)
+v0.7.0   2026-04-03  (+4 days)
+v0.6.0   2026-03-30  (+2 days from v0.5.0)
+v0.5.0   2026-03-28  (+5 days from v0.4.0)
+v0.4.0   2026-03-23  (+6 days)
+v0.3.0   2026-03-17  (+5 days)
+v0.2.0   2026-03-12  (first tagged release)
+```
+
+**Pattern**: weekly cadence with occasional 2-5 day off-cycle drops.
+Annotated tags carry the message `Hermes Agent v<X.Y.Z> (<calver>)\n\nWeekly release`
+(`release.py:1499`). No "release candidate" tags. No "next" branch.
+Just `main` → tag → ship.
+
+---
+
+## 4. Project Structure
+
+### 4.1 Top-level layout
+
+Hermes-agent is a **single Python package** (not a monorepo) with some
+hand-curated subdirs:
+
+```
+/mnt/projects/hermes-agent/
+  agent/          # Core agent — credential_pool, transports, *_adapter.py
+  acp_adapter/    # Agent Communication Protocol (Zed, VS Code, JetBrains)
+  hermes_cli/     # CLI entry points + subcommands
+  gateway/        # Messaging gateway (20 platforms)
+  tui_gateway/    # Python JSON-RPC backend for the Ink/React TUI
+  ui-tui/         # The Ink/React TUI itself (Node.js)
+  tools/          # Built-in tools — file_operations, terminal, web, etc.
+  toolsets.py     # Toolset definitions
+  skills/         # Bundled skills (in-repo)
+  optional-skills/  # Lazy-installable skills
+  plugins/        # General plugins
+    model-providers/  # ProviderProfile ABC — user-extensible
+    memory/           # Memory-provider plugins
+  providers/      # Bundled provider profiles (Anthropic, Bedrock, etc.)
+  cron/           # Cron scheduler
+  environments/   # RL/Atropos training environments
+  scripts/        # Maintenance scripts incl. release.py
+  tests/          # Pytest suite (3,289+ tests per v0.2.0 highlights)
+  website/        # Docusaurus docs site (deploys to hermes-agent.nousresearch.com)
+  docker/         # Dockerfile inputs
+  nix/            # Nix flake
+  ...
+```
+
+No `packages/`, no workspace nesting. Even `ui-tui/` (Node.js TUI)
+sits at top level rather than under a `packages/` umbrella. The build
+system is `setuptools` + `uv` (NOT poetry, NOT hatchling).
+
+### 4.2 Versioning artifacts
+
+The "version is the version" is encoded in exactly two places:
+- `hermes_cli/__init__.py` — `__version__` and `__release_date__`
+- `pyproject.toml` — `[project] version = "..."`
+
+`release.py:1085-1109` updates both atomically. The git tag is a
+**third** identity (CalVer) computed from "today".
+
+### 4.3 Test layout + invocation
+
+Per `CONTRIBUTING.md:106-118` and `AGENTS.md:897-940`:
+
+- Test wrapper: **`scripts/run_tests.sh`** — MANDATORY (closes 5 sources
+  of local↔CI drift: API keys, HOME path, TZ, locale, xdist worker count).
+- Direct `pytest` invocation is permitted only with `-n 4` and `.venv`
+  activated.
+- "Change-detector tests" are forbidden (`AGENTS.md:942-989`) — tests
+  asserting "the catalog contains gemini-2.5-pro" are deleted in favor
+  of invariant tests ("every catalog entry has a context length").
+
+This is **deep test discipline**, but it operates at the gate-runner
+level, not the release-pipeline level. There is no "epic test gate" or
+"per-task test gate" — just one suite that runs on every PR.
+
+### 4.4 Portability — can the patterns work for non-Hermes projects?
+
+**HIGH portability** (mechanical patterns):
+- The `release.py` shape works for **any** language ecosystem — it's
+  pure subprocess + git + gh CLI. Drop in different `update_version_files`
+  for Cargo/Node/etc.
+- The dual CalVer + SemVer pattern with `next_available_tag` collision
+  suffixing works anywhere git tags work.
+- The Docker `:main` + `:latest` ancestor check works for any project
+  that publishes container images.
+- The `release: published` event-driven downstream automation works for
+  any GitHub-hosted project.
+- The contributor-attribution gate works for any project that wants to
+  emit a credited changelog.
+- The supply-chain audit + OSV scanner patterns work for any project
+  that pins direct deps.
+
+**LOW portability** (project-specific assumptions):
+- `release.py` AUTHOR_MAP is a 600+ entry hand-maintained file. CLEO's
+  smaller contributor base needs less, but the file-as-source-of-truth
+  pattern still applies.
+- The lazy-deps pattern is Python-specific (`tools/lazy_deps.py`
+  intercepts `ImportError` at first use). CLEO already pins via
+  workspace pnpm.
+- The `:latest` vs `:main` Docker bifurcation assumes a stable-vs-dev
+  channel. CLEO doesn't currently publish containers.
+- The `release.py` "weekly release" assumption (annotated tag message)
+  doesn't fit CLEO's CalVer-on-demand cadence.
+
+---
+
+## 5. CLEO Failure-Mode Mapping
+
+This section directly addresses the 7 CLEO failure modes from the
+T9345 charter. For each, does Hermes-agent have a solution?
+
+### 5.1 Mid-pipeline failure recovery
+
+**Hermes status**: **Partial**. `release.py` is structured so each step
+prints its own success/failure marker (`✓`/`✗`). Failed steps print
+manual-recovery commands (e.g. `release.py:1554-1558` — if `gh release
+create` fails, prints the exact retry command and the path to the
+saved release notes file). But there is no resumable state machine —
+if step 9 (tag) succeeds and step 12 (gh release) fails, the operator
+re-runs step 12 by hand.
+
+**Borrowable**: The "print exact recovery command on failure" pattern.
+CLEO already emits structured errors; adding "here's the exact command
+to resume" is a small UX win.
+
+**Not borrowable**: No transactional rollback. Hermes accepts partial
+state and human cleanup.
+
+### 5.2 Epic-scoped completeness checks
+
+**Hermes status**: **No equivalent**. Hermes has no concept of an epic.
+Releases are time-driven ("everything since the last tag"), not
+scope-driven ("everything in epic T9261"). The completeness check is
+implicit: "if it's merged to main since the last tag, it ships."
+
+**Borrowable**: Nothing. CLEO's epic completeness check is a
+CLEO-specific invariant; Hermes provides no precedent.
+
+**Implication for T9345**: CLEO's epic-completeness check (`cleo release
+verify --epic TXXXX` per the workflow doc) is *unique* and must be
+designed without external reference. Hermes-agent provides no template.
+
+### 5.3 Real gate runners (not theater)
+
+**Hermes status**: **Partial — strong CI gates, weak release gates**.
+Hermes CI runs `tests`, `lint` (blocking on PLW1514 only), `windows-footguns`,
+`uv-lockfile-check`, `supply-chain-audit` on every PR. These are
+**real gates** with no bypass. But the **release pipeline itself
+(release.py) runs no gates** — it trusts main is green. The release
+is therefore "merge-time gates only".
+
+**Borrowable**: The "gate runner = subprocess that exits non-zero or
+posts SARIF" pattern. Specifically:
+- `scripts/check-windows-footguns.py` (lint.yml line 202) is invoked
+  as a plain Python script with `--all` flag, exit non-zero on hit.
+  CLEO's gate runners (per ADR-051 evidence) could adopt the same
+  "tool returns canonical name → exit code → cached result" shape that
+  Hermes already uses for ruff/ty/`uv lock --check`.
+- The supply-chain-audit "scan diff for narrow attack patterns and
+  post PR comment" pattern is portable as an extra gate.
+
+**Not borrowable**: No "wait for CI green before tagging" step in
+release.py. CLEO's current `cleo release ship` step 11 (15-minute CI
+timeout) is more rigorous than anything Hermes does.
+
+### 5.4 Hotfix bypass paths
+
+**Hermes status**: **Implicit pattern**. There are no hotfix branches.
+Same-day patches use the suffix mechanism:
+
+```python
+# release.py:1044-1053
+def next_available_tag(base_tag: str) -> tuple[str, str]:
+    """Return a tag/calver pair, suffixing same-day releases when needed."""
+    if not git("tag", "--list", base_tag):
+        return base_tag, base_tag.removeprefix("v")
+
+    suffix = 2
+    while git("tag", "--list", f"{base_tag}.{suffix}"):
+        suffix += 1
+    tag_name = f"{base_tag}.{suffix}"
+    return tag_name, tag_name.removeprefix("v")
+```
+
+So if `v2026.5.7` shipped this morning and a P0 bug appears this
+afternoon, the fix lands on main as a PR, then `release.py --publish`
+creates `v2026.5.7.2`. No branch, no merge dance. Same-day `.3`, `.4`
+if needed.
+
+**Backport scenario** (older-release-branch hotfix): the `move-latest`
+ancestor check (§3.4) is the only protection. If a backport release
+SHA is NOT a descendant of the current `:latest`, `:latest` stays put.
+Older releases get their tag but don't update the floating "latest"
+pointer.
+
+**Borrowable**: The same-day suffix pattern (`v<base>.<N>` starting at
+`.2`) is elegant and avoids branch proliferation. CLEO currently jumps
+the patch number (`v2026.5.74` after `v2026.5.73`), which works but
+doesn't carry the "same-day patch" signal in the tag itself.
+
+### 5.5 Tag-to-merge-commit alignment
+
+**Hermes status**: **Strong** — see §3.4. The OCI revision label +
+git merge-base ancestor check is the gold-standard protection against
+floating tags regressing. The tag itself is annotated and created
+locally by `release.py:1497-1504`, then pushed with `git push origin
+HEAD --tags`. If `HEAD` advances on origin between local tag and push,
+the push is forced to fail (no `--force` in `release.py:1507`).
+
+**Borrowable**:
+1. **OCI revision label + ancestor check** — directly portable to any
+   floating-tag scheme.
+2. **Annotated tags with structured messages** — `release.py:1499`
+   creates `-a` annotated tags with message `Hermes Agent v<sem>
+   (<calver>)\n\nWeekly release`, providing a permanent metadata
+   record on the tag object itself.
+
+### 5.6 Worker direct-push protection
+
+**Hermes status**: **Weak — relies on GitHub branch protection**. The
+local checkout has no `pre-push` hook (verified: no
+`.git/hooks/pre-push`). All protection is server-side. Hermes does
+NOT document its branch protection rules in any committed file. The
+contributor-check gate (§3.8) protects attribution metadata but does
+NOT block direct pushes by maintainers.
+
+The owner's fork has the `sync-upstream.yml` workflow which uses
+`secrets.GITHUB_TOKEN` (`sync-upstream.yml:26`) — i.e. the built-in
+fork-scoped token. It runs as `github-actions[bot]` and pushes to
+the fork's main branch directly. **This is allowed.**
+
+**Borrowable**: Nothing. Hermes does not have a "worker direct-push
+protection" pattern documented. CLEO's worktree shim (per ADR-055 /
+T1140) — which blocks git operations at the PATH level — is more
+rigorous than anything Hermes does.
+
+**Recommendation for T9345**: Maintain CLEO's stronger model; do not
+weaken to Hermes's "GitHub branch protection + trust the humans"
+posture.
+
+### 5.7 Provenance graph (feature → bug → hotfix → release)
+
+**Hermes status**: **Minimal — commit messages + PR numbers only**. The
+provenance Hermes tracks:
+
+- **Commit ↔ PR**: via `(#NNNNN)` suffix in commit subjects (auto-
+  appended by GitHub squash-merge). `release.py:1288-1293` extracts the
+  PR number with a regex; `generate_changelog` links it as
+  `[#NNNNN](repo_url/pull/NNNNN)`.
+- **Commit ↔ author**: via git author + parsed `Co-authored-by:`
+  trailers, resolved through `AUTHOR_MAP`.
+- **PR ↔ issue**: via the "Fixes #NNN" trailer in PR descriptions —
+  but this is GitHub-side metadata, not tracked in the repo.
+- **Salvage chain**: many commits carry `salvage of #NNNNN` in their
+  subject (e.g. `git log: "fix: dashboard board pin authoritative
+  over server current file (#20879) ([#21230]"`). This is the
+  closest Hermes gets to "this hotfix was inspired by that earlier
+  PR/issue" — manually authored, not auto-tracked.
+- **Release ↔ commits**: via the tag and the committed
+  `RELEASE_vX.Y.Z.md` file. The compare URL provides the linear range.
+
+**Not present**:
+- No task tracker integration (no JIRA, no Linear, no GitHub Projects
+  beyond informal use).
+- No "this commit closes acceptance gate X for task Y" trailer.
+- No automated provenance graph (commit → epic → release).
+
+**Borrowable**: The "embed PR number in commit subject + extract for
+changelog" pattern. CLEO already does this implicitly; making it a
+**hard gate** (CI rejects merges to main without `(#NNN)` suffix)
+would mirror Hermes's behavior.
+
+**Not borrowable**: Hermes's "provenance" is provenance-by-grep —
+useful at small scale, fails at the multi-tier task model CLEO
+operates. CLEO's tasks.db + BRAIN + acceptance gates are 10× richer
+than anything Hermes ships. The T9345 ask for a "true audit trail"
+must be designed within CLEO's own framework; Hermes provides no
+template here.
+
+---
+
+## 6. What CLEO Can Borrow — Prioritized Recommendations
+
+Ranked by ROI for the T9345 IVTR Release System overhaul.
+
+### Tier 1 — Adopt directly (HIGH confidence)
+
+1. **Dual CalVer + SemVer**. Keep CLEO's CalVer tag (`v2026.5.74`) as
+   the canonical git tag. Add a separate SemVer in `package.json` /
+   `Cargo.toml` for downstream packagers (Homebrew, AUR, npm). Bump
+   atomically. **Implementation reference**: `release.py:1085-1109`.
+2. **Annotated tags with structured messages**. CLEO currently creates
+   lightweight tags; switching to `git tag -a <tag> -m "CLEO v<sem>
+   (<calver>)\n\n<release-context>"` would put metadata on the tag
+   object itself, surviving rebases and merges.
+   **Implementation reference**: `release.py:1496-1504`.
+3. **`release: published` GitHub event for downstream fan-out**.
+   Decouple docs deploy / Docker retag / sentinel notifications from
+   the in-band ship pipeline. **Implementation reference**:
+   `docker-publish.yml:24-26`, `deploy-site.yml:3-5`.
+4. **OCI revision label + git merge-base ancestor check** for floating
+   tags (`:main`, `:latest`, future CLEO equivalents). Prevents tag
+   regression under race conditions. **Implementation reference**:
+   `docker-publish.yml:345-406` and `461-522`.
+5. **Same-day suffix for hotfix tags** (`v2026.5.74.2`,
+   `v2026.5.74.3`, …). Avoids branch proliferation; preserves the
+   "this is a same-day patch" signal in the tag.
+   **Implementation reference**: `release.py:1044-1053`.
+6. **Pinned direct deps + lockfile-drift CI**. Already partially in
+   place via pnpm; the `uv-lockfile-check.yml` pattern of running
+   `uv lock --check` (CLEO equivalent: `pnpm install --frozen-lockfile
+   --no-cache`) as a blocking PR gate is directly portable.
+   **Implementation reference**: `uv-lockfile-check.yml`.
+7. **Supply-chain audit on PR diffs**. Block PRs that introduce
+   `.pth`-equivalent install hooks, base64+exec patterns, obfuscated
+   subprocess calls. Adapt patterns to TypeScript (e.g. dynamic
+   `Function(decoded)`, post-install scripts in package.json).
+   **Implementation reference**: `supply-chain-audit.yml:38-117`.
+8. **Print exact recovery command on each release-step failure**. CLEO's
+   `cleo release ship` already prints structured errors; appending
+   "to resume from this step, run `cleo release <subcommand>`" would
+   add operator-survivable resume hints. **Implementation reference**:
+   `release.py:1500-1558`.
+
+### Tier 2 — Adopt selectively (MEDIUM confidence)
+
+9. **Conventional-Commits parsing → categorized changelog**. CLEO
+   already generates changelogs; aligning the regex shape (`^feat[\s:(]`
+   etc.) and emoji headers to a Hermes-style standard would aid
+   cross-project readability. **Implementation reference**:
+   `release.py:1168-1199`.
+10. **`AUTHOR_MAP` for git-email → GitHub-username resolution**.
+    CLEO has fewer contributors; the value is lower but still real for
+    consistent attribution in the release notes. **Implementation
+    reference**: `release.py:41-1010` (data) + `1147-1166` (logic).
+11. **Contributor-attribution CI gate**. Block PRs whose author email
+    isn't in `AUTHOR_MAP`. Lower urgency for CLEO; useful if CLEO
+    starts accepting outside PRs. **Implementation reference**:
+    `contributor-check.yml`.
+12. **Smoke test before pushing**. Add `cleo --help` and one targeted
+    subcommand check (`cleo briefing` equivalent of Hermes's
+    `dashboard --help` regression guard) **between build and push** in
+    the release pipeline. **Implementation reference**:
+    `.github/actions/hermes-smoke-test/action.yml`.
+13. **Commit the rendered release notes**. Hermes commits
+    `RELEASE_v0.13.0.md` to the repo root. CLEO already maintains
+    CHANGELOG.md; adding per-release files alongside would make the
+    git history self-documenting and agent-readable. **Implementation
+    reference**: 12 `RELEASE_v0.*.md` files at repo root.
+
+### Tier 3 — Reference but adapt heavily (LOW confidence / mismatch)
+
+14. **Filter AI/bot co-authors out of release attribution**. Hermes
+    explicitly drops `noreply@anthropic.com`, `cursor.com`, etc. from
+    co-authors. CLEO's culture is the opposite — many commits carry
+    Claude co-authorship and the user wants this surfaced.
+    **Implementation reference**: `release.py:1222-1233` — but invert
+    the filter. Track AI co-authors with their own marker.
+15. **"Narrow ruff enforcement"**. Hermes blocks on exactly one ruff
+    rule (PLW1514). CLEO's `pnpm biome ci .` is wider. Worth
+    considering "what's the one rule that bites" if biome perf becomes
+    a release-pipeline bottleneck. **Implementation reference**:
+    `pyproject.toml:248-256`.
+
+### Not borrowable — CLEO must invent
+
+- **Epic-scoped completeness check**. Hermes has no precedent (§5.2).
+- **Per-task acceptance gate runners**. Hermes treats CI as the gate
+  surface; CLEO has 10× more per-task structure (§5.3).
+- **Worktree-by-default + PATH shim worker protection**. CLEO's
+  ADR-055 already exceeds Hermes's posture (§5.6).
+- **Task ↔ commit ↔ release provenance graph**. CLEO already has
+  tasks.db; Hermes provides no template (§5.7).
+- **Mid-pipeline transactional rollback**. Hermes uses operator-driven
+  human recovery (§5.1).
+- **IVTR multi-stage gate ladder**. Hermes has no such concept.
+
+---
+
+## 7. Specific File / Line Citations (Audit Trail)
+
+Every claim in this document is anchored to one of:
+
+| Section | Cited file (paths under `/mnt/projects/hermes-agent/`) |
+|---------|-------|
+| §1 (identification) | `LICENSE`, `README.md:1-12,191-194`, `pyproject.toml:5-12`, git remotes, `scripts/release.py:1296` |
+| §1.3 (tag history) | `git for-each-ref --sort=-creatordate refs/tags/v20*` |
+| §1.4 (license) | `LICENSE:1-21` |
+| §2 (CLEO precedent) | `/mnt/projects/cleocode/docs/specs/hermes-agent-llm-provider-architecture.md:6,14-18,53-63` |
+| §3.1 (versioning) | `scripts/release.py:1056-1109`, `pyproject.toml:7`, tag listing |
+| §3.2 (release.py) | `scripts/release.py:1400-1564`, full file 1568 lines |
+| §3.3 (release event) | `.github/workflows/docker-publish.yml:24-26`, `.github/workflows/deploy-site.yml:3-5` |
+| §3.4 (ancestor check) | `.github/workflows/docker-publish.yml:290-535`, esp. 345-406 and 461-522 |
+| §3.5 (multi-arch docker) | `.github/workflows/docker-publish.yml:42-289`, `.github/actions/hermes-smoke-test/action.yml` |
+| §3.6 (CI gate inventory) | `.github/workflows/*.yml` (all 13 files) |
+| §3.7 (changelog gen) | `scripts/release.py:1296-1397`, `RELEASE_v0.13.0.md`, `RELEASE_v0.2.0.md` |
+| §3.8 (contributor gate) | `.github/workflows/contributor-check.yml:1-73` |
+| §3.9 (branch/PR rules) | `CONTRIBUTING.md:739-792`, `AGENTS.md:866-872`, `.github/PULL_REQUEST_TEMPLATE.md` |
+| §3.10 (supply chain) | `pyproject.toml:13-63,111-126`, `.github/workflows/osv-scanner.yml`, `.github/workflows/supply-chain-audit.yml`, `.github/dependabot.yml` |
+| §3.11 (cadence) | tag dates |
+| §4.1 (structure) | `ls /mnt/projects/hermes-agent/`, `pyproject.toml:217-225` |
+| §4.3 (tests) | `CONTRIBUTING.md:106-118`, `AGENTS.md:897-989`, `scripts/run_tests.sh` |
+| §5.1 (mid-pipeline) | `scripts/release.py:1500-1558` |
+| §5.4 (hotfix suffix) | `scripts/release.py:1044-1053` |
+| §5.5 (tag alignment) | `scripts/release.py:1496-1513`, `.github/workflows/docker-publish.yml:399-406` |
+| §5.6 (push protection) | Negative evidence: no pre-push hook, no documented branch protection in repo |
+| §5.7 (provenance) | `scripts/release.py:1214-1233` (co-author filter), `1288-1293` (PR extract) |
+
+Web confirmation (used only to verify upstream identity, not for content):
+- `WebSearch: NousResearch hermes-agent github repository` confirmed
+  the canonical URL `https://github.com/NousResearch/hermes-agent`,
+  the v0.13.0 / v2026.5.7 release identity, and the public-facing
+  feature set. No content from the web search was used where local
+  evidence exists.
+
+---
+
+## 8. Appendix A1 — Full LICENSE Text
+
+```
+MIT License
+
+Copyright (c) 2025 Nous Research
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## 9. Appendix A2 — Critical Code Excerpts
+
+### A2.1 The full `release.py main()` flow (annotated)
+
+```python
+# scripts/release.py:1400-1564 (lightly elided for length)
+
+def main():
+    parser = argparse.ArgumentParser(description="Hermes Agent Release Tool")
+    parser.add_argument("--bump", choices=["major", "minor", "patch"])
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument("--date", type=str)
+    parser.add_argument("--first-release", action="store_true")
+    parser.add_argument("--output", type=str)
+    args = parser.parse_args()
+
+    # 1. Determine CalVer date (default today, override via --date)
+    if args.date:
+        calver_date = args.date
+    else:
+        now = datetime.now()
+        calver_date = f"{now.year}.{now.month}.{now.day}"
+
+    # 2. Resolve next available tag (handles same-day collisions)
+    base_tag = f"v{calver_date}"
+    tag_name, calver_date = next_available_tag(base_tag)
+
+    # 3. Determine SemVer
+    current_version = get_current_version()
+    if args.bump:
+        new_version = bump_version(current_version, args.bump)
+    else:
+        new_version = current_version
+
+    # 4. Find previous tag (most recent v20*-prefixed)
+    prev_tag = get_last_tag()
+
+    # 5. Gather commits since prev tag
+    commits = get_commits(since_tag=prev_tag)
+
+    # 6. Generate categorized changelog
+    changelog = generate_changelog(commits, tag_name, new_version,
+                                    prev_tag=prev_tag,
+                                    first_release=args.first_release)
+
+    if args.publish:
+        # 7. Update __init__.py + pyproject.toml versions
+        if args.bump:
+            update_version_files(new_version, calver_date)
+            # 8. Commit version bump
+            git_result("add", str(VERSION_FILE), str(PYPROJECT_FILE))
+            git_result("commit", "-m",
+                       f"chore: bump version to v{new_version} ({calver_date})")
+
+        # 9. Create annotated tag with structured message
+        git_result("tag", "-a", tag_name, "-m",
+                   f"Hermes Agent v{new_version} ({calver_date})\n\nWeekly release")
+
+        # 10. Push commits + tags
+        git_result("push", "origin", "HEAD", "--tags")
+
+        # 11. Build sdist + wheel (optional, non-fatal)
+        artifacts = build_release_artifacts(new_version)
+
+        # 12. Create GitHub release with notes file + artifacts
+        gh_cmd = ["gh", "release", "create", tag_name,
+                  "--title", f"Hermes Agent v{new_version} ({calver_date})",
+                  "--notes-file", str(changelog_file)]
+        gh_cmd.extend(str(path) for path in artifacts)
+        subprocess.run(gh_cmd, capture_output=True, text=True,
+                       cwd=str(REPO_ROOT))
+```
+
+### A2.2 The ancestor check (Docker `:main`)
+
+```bash
+# .github/workflows/docker-publish.yml:345-406 (excerpt)
+
+- name: Decide whether to move :main
+  id: main_check
+  run: |
+    set -euo pipefail
+    image=nousresearch/hermes-agent
+
+    # Pull the linux/amd64 sub-manifest config + extract OCI revision label
+    image_json=$(
+      docker buildx imagetools inspect "${image}:main" \
+        --format '{{ json (index .Image "linux/amd64") }}' \
+        2>/dev/null || true
+    )
+
+    if [ -z "${image_json}" ]; then
+      echo "No existing :main — safe to publish."
+      echo "push_main=true" >> "$GITHUB_OUTPUT"
+      exit 0
+    fi
+
+    current_sha=$(
+      printf '%s' "${image_json}" \
+        | jq -r '.config.Labels."org.opencontainers.image.revision" // ""'
+    )
+
+    # Our SHA must be a descendant of the current :main
+    if git merge-base --is-ancestor "${current_sha}" "${GITHUB_SHA}"; then
+      echo "Our commit is a descendant of :main — safe to advance."
+      echo "push_main=true" >> "$GITHUB_OUTPUT"
+    else
+      echo "Another run advanced :main past us (or diverged) — leaving it alone."
+      echo "push_main=false" >> "$GITHUB_OUTPUT"
+    fi
+```
+
+### A2.3 The supply-chain pattern scanner
+
+```bash
+# .github/workflows/supply-chain-audit.yml:43-117 (excerpt)
+
+DIFF=$(git diff "$BASE".."$HEAD" -- . ':!uv.lock' ':!*.lock' ':!package-lock.json' || true)
+
+# .pth files (the litellm attack mechanism)
+PTH_FILES=$(git diff --name-only "$BASE".."$HEAD" | grep '\.pth$' || true)
+
+# base64 decode + exec/eval combo
+B64_EXEC_HITS=$(echo "$DIFF" | grep -n '^\+' \
+  | grep -iE 'base64\.(b64decode|decodebytes|urlsafe_b64decode)' \
+  | grep -iE 'exec\(|eval\(' | head -10 || true)
+
+# subprocess with encoded/obfuscated command argument
+PROC_HITS=$(echo "$DIFF" | grep -n '^\+' \
+  | grep -E 'subprocess\.(Popen|call|run)\s*\(' \
+  | grep -iE 'base64|\\x[0-9a-f]{2}|chr\(' | head -10 || true)
+
+# Install-hook files
+SETUP_HITS=$(git diff --name-only "$BASE".."$HEAD" \
+  | grep -E '(^|/)(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$' || true)
+```
+
+---
+
+## 10. Open Questions for the T9345 RCASD Phase
+
+Items the research could NOT settle from local evidence — flag for
+specification phase:
+
+1. **Hermes branch protection rules** — what does NousResearch
+   configure at the GitHub API level for `main`? Not committed to the
+   repo. To get this, the T9345 spec author would need to ask Nous
+   directly or read public security policy. Mitigation: assume
+   CLEO's existing `gh api -X PUT .../protection` setup is at least
+   as rigorous, do not weaken.
+2. **How Hermes handles "release.py crashed at step 9"** — local
+   evidence shows printed recovery commands, but no automated
+   resume. Question for spec: should CLEO build a true resumable
+   state machine (with sidecar state file) or replicate
+   Hermes's "human-driven resume" pattern?
+3. **The `RELEASE_v0.10.0.md`-style "minimal" release note**. Quote
+   (`RELEASE_v0.10.0.md:15-17`): "This release includes 180+ commits
+   with numerous bug fixes... Full details will be published in the
+   v0.11.0 changelog." Hermes occasionally ships a minimal stub
+   release note for ad-hoc cuts. Does CLEO want this option?
+4. **No "release branch" model in Hermes**. CLEO currently uses
+   `release/v<version>` branches (per ADR-065). Is the branch
+   genuinely load-bearing, or could CLEO simplify to Hermes's
+   "tag main directly"? The branch carries the changelog commit;
+   removing it would require an alternative commit path.
+
+---
+
+## 11. Final Verdict
+
+**Hermes-agent is the right precedent for CLEO Phase 4 (LLM provider
+stack) — and it has already been used as such.**
+
+**Hermes-agent is a PARTIAL precedent for T9345 (Release System
+overhaul)**:
+
+- **Strong precedent**: tagging, changelog generation, release-event
+  fan-out, Docker floating-tag ancestor checks, supply-chain posture,
+  pinning + lockfile gates, contributor attribution, smoke tests
+  before publish.
+- **Silent on**: epic completeness, multi-stage gate ladders, task-
+  scoped provenance, worker direct-push protection, transactional
+  rollback, IVTR-style lifecycle.
+
+CLEO's IVTR overhaul should **borrow Hermes's mechanics** (the eight
+Tier-1 items in §6) and **invent its own semantics** for the gate
+ladder, epic completeness, and provenance graph (the "Not borrowable
+— CLEO must invent" list in §6).
+
+The single most valuable insight from this research is:
+**Hermes-agent's release pipeline is a Python script, not a workflow**.
+The maintainer runs `python scripts/release.py --bump minor --publish`
+from their laptop. CI exists only to gate PRs (lint, tests, supply-
+chain) and to react to the `release: published` event (Docker, docs).
+This is a viable design point — "release pipeline as local imperative
+script, CI as gate runner only" — that CLEO has explicitly rejected
+in favor of `cleo release ship` orchestrating the full ship cycle.
+T9345 should validate that decision: if `cleo release ship` is
+mid-pipeline-fragile, the Hermes pattern of "local script + GH-event
+fan-out" is the alternative architecture to consider.
+
+---
+
+*End of report. Total: ~1290 lines.*

--- a/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md
+++ b/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md
@@ -1,0 +1,568 @@
+# IVTR System Conflation Audit — T9345
+
+**Audit Date**: 2026-05-15  
+**Audit Owner**: Architecture Auditor  
+**Status**: COMPLETE  
+**Conflation Severity**: 7/10 (significant over-engineering with tight release coupling)
+
+---
+
+## Executive Summary
+
+The IVTR system (Iterate/Validate/Test/Release multi-agent orchestration loop) is **severely conflated with the release pipeline**. IVTR is simultaneously:
+
+1. **An orchestration governance system** (4-phase state machine tracking task provenance)
+2. **A release blocking gate** (T820 RELEASE-03: release ships cannot proceed until all epic tasks complete IVTR `released` phase)
+3. **A evidence tracking system** (AttachmentStore-backed phase history with SHA256 evidence refs)
+4. **A manual override escape hatch** (--force bypass on both IVTR and completion)
+
+This conflation has created:
+- **Tight bidirectional coupling** between `packages/cleo/src/dispatch/domains/release.ts` and `packages/core/src/release/engine-ops.ts` (17 IVTR gate references in release engine; engine-ops lines 1251-1295)
+- **Duplicated gate concepts**: Evidence gates (ADR-051 §Decision 1) and IVTR phase gates serve overlapping purposes (implement ≈ implemented, validate ≈ testsPassed, etc.)
+- **Missing provenance graph**: Tasks carry `ivtr_state` JSON but NO relational edges to commits/releases—provenance is implicit
+- **Non-blocking non-blocking gates**: "72 task(s) have no IVTR state (non-blocking)" (engine-ops:1286) indicates IVTR lacks clear blocking semantics
+
+**Recommendation**: Decouple IVTR into a **task-lifecycle observation system** (not a release gate). Move release validation to **evidence-only gates** in `tasks.verification`. Build provenance as explicit **graph edges** in `task_relations` + a new `release_manifest.commits` table.
+
+---
+
+## Phase 1: IVTR Surface Inventory
+
+### Files Containing IVTR Logic (19 files)
+
+| File | LOC | Primary Concern | Introduced |
+|------|-----|-----------------|------------|
+| `/packages/cleo/src/dispatch/domains/ivtr.ts` | 600 | CLI dispatch handler for `orchestrate ivtr` | T810, T811 |
+| `/packages/core/src/lifecycle/ivtr-loop.ts` | 550+ | State machine + persistence layer | T811, T813 |
+| `/packages/core/src/release/engine-ops.ts` | 1,300+ | **IVTR gate integration in release** | T5582, T820 RELEASE-03 |
+| `/packages/core/src/release/ops.ts` | 80 | Release ops contract; `ivtr-suggest` | T820 |
+| `/packages/cleo/src/dispatch/domains/release.ts` | 330 | **Release → IVTR dispatch coupling** | T1543 |
+| `/packages/core/src/lifecycle/__tests__/ivtr-loop.test.ts` | 450+ | IVTR state machine tests | T813 |
+| `/packages/cleo/src/cli/commands/orchestrate.ts` | 250+ | CLI entry point for `cleo orchestrate ivtr` | T810 |
+| `/packages/cleo/src/dispatch/domains/__tests__/ivtr.test.ts` | 366 | Dispatch envelope tests | T1539 |
+| `/packages/contracts/src/acceptance-gate.ts` | 300 | Gate types (overlaps with IVTR phases) | T763, T779 |
+| `/packages/core/src/tasks/gate-runner.ts` | 500+ | AcceptanceGate execution (T760 RCASD hardening) | T781 |
+| `/packages/core/src/store/tasks-schema.ts` | 600+ | `ivtr_state` JSON column + `pipelineStage` | T944, T1899 |
+| `/packages/cleo/src/dispatch/domains/orchestrate.ts` | 400+ | Delegates to IvtrHandler | T810 |
+
+**IVTR Coupling to Release**: 7 files directly integrate IVTR logic into release paths (release.ts, engine-ops.ts, ivtr.ts, orchestrate.ts, tasks-schema.ts, ops.ts).
+
+---
+
+## Phase 2: IVTR ↔ Release Coupling — Leak Points
+
+### Leak #1: Release Gate Enforcement (engine-ops.ts:1251–1295)
+
+**File**: `/packages/core/src/release/engine-ops.ts:1251–1295`  
+**Context**: `prepareRelease()` — Step 1.5 of 12 in release pipeline
+
+```
+Step 1 (logStep 1, 12, 'Check IVTR gate for epic tasks')
+├─ Invoke releaseGateCheck()
+├─ Collect all epic tasks → getTasksForEpic()
+├─ For each task: read task.ivtr_state.currentPhase
+├─ If currentPhase != 'released': add to blocked[] array
+├─ If blocked.length > 0 && !force: return E_IVTR_INCOMPLETE
+└─ Log message: "IVTR gate FAILED for epic ${epicId}. ${blocked.length} task(s) not yet released"
+```
+
+**Coupling**: The release engine **cannot proceed** if tasks lack IVTR `released` phase. This is a **hard gate**, not a gate-with-waiver.
+
+**Evidence**:
+```typescript
+// Line 1262–1280: gate check in prepareRelease flow
+if (blocked.length > 0) {
+  const fixMsg = `cleo orchestrate ivtr ${blocked[0]} --release`;
+  return engineError('E_IVTR_INCOMPLETE', summary, { fix: fixMsg });
+}
+```
+
+### Leak #2: IVTR-Aware Auto-Suggest (engine-ops.ts:475–556)
+
+**File**: `/packages/core/src/release/engine-ops.ts:475–556`  
+**Function**: `releaseIvtrAutoSuggest()` — called on `orchestrate ivtr <taskId> --release`
+
+Triggers after IVTR loop completes. Checks if ALL siblings in the epic have also reached `released`:
+```typescript
+// Line 544–556
+const siblingIds = await getTasksForEpic(epicId, { cwd });
+const stillBlocked = siblingIds.filter((id) => {
+  const s = ivtrStateMap[id];
+  return !s || s.currentPhase !== 'released';
+}).length;
+
+if (stillBlocked === 0) {
+  return engineSuccess({
+    epicFullyReleased: true,
+    suggestedCommand: `cleo release ship ${epicId} --version ...`,
+  });
+}
+```
+
+**Coupling**: Release ship is **auto-suggested** (but not enforced) once IVTR completes. Creates implicit coupling: agent completes IVTR → expects release suggestion.
+
+### Leak #3: Dual Gate Execution (ivtr.ts:197–206)
+
+**File**: `/packages/cleo/src/dispatch/domains/ivtr.ts:197–206`  
+**Function**: `ivtrNextOp()` — when advancing to test phase
+
+```typescript
+if (autoRunTests && state.currentPhase === 'test') {
+  const acceptanceItems = (task.acceptance ?? []) as (string | object)[];
+  const typedGateEntries = extractTypedGates(
+    acceptanceItems as Parameters<typeof extractTypedGates>[0],
+  );
+  const gates = typedGateEntries.map((e) => e.gate);
+  autoRunResult = await autoRunGatesAndRecord(params.taskId, gates, params.agentIdentity, cwd);
+}
+```
+
+**Coupling**: When IVTR enters `test` phase, it **auto-executes** `AcceptanceGate[]` from `task.acceptance`. This is **gate-execution-via-IVTR**, not a separate gate layer.
+
+### Leak #4: Release Command Hints (engine-ops.ts:391–452)
+
+**File**: `/packages/core/src/release/engine-ops.ts:391–452`  
+**Function**: `releaseGateCheck()` — returns error with fix hint
+
+```typescript
+return engineError('E_IVTR_INCOMPLETE', summary, {
+  fix: `cleo orchestrate ivtr ${blocked[0]} --release`,
+  // ...implies: "run IVTR to unblock release"
+});
+```
+
+**Coupling**: Release errors **point users to IVTR commands**. This conflates the task lifecycle (IVTR) with the release lifecycle.
+
+---
+
+## Phase 3: Gate Logic Deep-Dive
+
+### Gate Concept Inventory
+
+| Gate Type | Introduced | Scope | Enforcement | Overlap Notes |
+|-----------|-----------|-------|------------|---------------|
+| **IVTR Phase Gates** (`implement/validate/audit/test/released`) | T810, T811 | per-task | State machine + attachment evidence | — |
+| **AcceptanceGate** (test/file/command/lint/http/manual) | T763 (RCASD-hardening) | per-task | CLI runner (`gate-runner.ts`) + lifecycle DB write | **Runs during IVTR test phase** |
+| **Evidence Gates** (implemented/testsPassed/qaPassed/documented/securityPassed/cleanupDone) | ADR-051 (T832) | per-task | Manual verify + attestation | **Intended replacement for IVTR + accept gates** |
+| **Release Gates** (test/lint/typecheck/audit/security-scan) | T5582, T820 RELEASE-01 | per-epic | `runReleaseGates()` in manifest | **Orthogonal to task gates** |
+| **Lifecycle Stage Gates** (via `pipelineStage`) | T944 | per-task | Recorded in `lifecycle_pipelines.currentStageId` | **No explicit gate execution** |
+
+### Gate Duplication: Evidence vs. IVTR
+
+**ADR-051 §Decision 1** specifies 6 evidence gates:
+
+| Evidence Gate | Semantics | IVTR Equivalent | Conflict? |
+|---------------|-----------|-----------------|-----------|
+| `implemented` | Code changes committed + files exist | `implement` phase | YES — same intent |
+| `testsPassed` | Test suite exit 0 + passes ≥ minCount | `test` phase auto-run | YES — test phase runs AcceptanceGate |
+| `qaPassed` | biome + tsc exit 0 | `validate` phase (implicit) | MAYBE — validate has no gate execution |
+| `documented` | Doc files or URL | `validate` phase (implicit) | NO — docs not checked in validate |
+| `securityPassed` | Security scan or waiver note | `validate` or new gate? | UNCLEAR |
+| `cleanupDone` | Cleanup summary note | (no IVTR equivalent) | NO — IVTR doesn't track cleanup |
+
+**Finding**: IVTR gates 1–3 (`implement/validate/test`) are **semantically equivalent** to evidence gates 1–3 (`implemented/testsPassed/qaPassed`). Both require the same actions. Running both is redundant.
+
+### Gate Non-Blocking Semantics (engine-ops.ts:1286)
+
+**File**: `/packages/core/src/release/engine-ops.ts:1286`
+
+```typescript
+const w = `  ! IVTR gate: ${unchecked.length} task(s) have no IVTR state (non-blocking): ${unchecked.join(', ')}`;
+```
+
+**Problem**: Tasks without IVTR state (e.g., documentation tasks, chores) are marked "non-blocking" but have NO mechanism to declare "this task does not require IVTR". Instead, the absence of `ivtr_state` is interpreted as "not started, doesn't block".
+
+**Consequence**: Release gate is **actually uncertain**:
+- If task has `ivtr_state` and currentPhase != 'released': **BLOCKS** release (error)
+- If task has no `ivtr_state`: **DOES NOT BLOCK** (warning only)
+- No distinction between "task intentionally doesn't use IVTR" vs. "task should but hasn't started"
+
+---
+
+## Phase 4: BRAIN/Task DB Provenance — Current State
+
+### Task Schema Provenance Columns
+
+**File**: `/packages/core/src/store/tasks-schema.ts:280–350`
+
+| Column | Type | Purpose | Introduced | Graph Edge? |
+|--------|------|---------|-----------|-----------|
+| `id` | text PK | Task identifier | — | Source node |
+| `kind` | enum (work/bug/spike/research/release) | Task intent axis | T944 | — |
+| `scope` | enum (project/feature/unit) | Granularity axis | T944 | — |
+| `severity` | enum (P0/P1/P2/P3) | Priority override | T944 | — |
+| `blockedBy` | text (soft FK) | Single external blocker | — | **Single edge, not normalized** |
+| `epicLifecycle` | text | Parent epic lifecycle key | — | **Soft FK to epic** |
+| `ivtrState` | text JSON | Full IVTR state machine | T811 | **Implicit provenance (serialized)** |
+| `pipelineStage` | text (enum) | Current lifecycle stage | T834 (ADR-051 D4) | **No explicit edge** |
+| `createdBy`, `modifiedBy` | text | Agent/user audit | — | **No FK to agents table** |
+| `sessionId` | text FK | Session that created task | T1609 | **Explicit edge** |
+| `origin` | text | Provenance class (production/test-fixture/imported/migrated) | T1899 | **Type marker, no edge** |
+
+### Relational Provenance: Task Relations Table
+
+**File**: `/packages/core/src/store/tasks-schema.ts:392–410`
+
+```typescript
+export const taskRelations = sqliteTable(
+  'task_relations',
+  {
+    taskId: text('task_id').notNull().references(() => tasks.id),
+    relatedTo: text('related_to').notNull().references(() => tasks.id),
+    relationType: text('relation_type', {
+      enum: ['related', 'blocks', 'duplicates', 'absorbs', 'fixes', 'extends', 'supersedes'],
+    }),
+    reason: text('reason'),
+  },
+);
+```
+
+**Limitations**:
+- No `commit` column — cannot link task to specific SHA
+- No `release_id` column — cannot link task to release artifact
+- No `epic_id` column — epic link is via `parentId` on task hierarchy only
+- No `kind_at_time` — cannot track kind changes over time
+- No timestamp — cannot order relations by time
+
+### Brain Schema Provenance
+
+**File**: `/packages/core/src/store/memory-schema.ts:150–300`
+
+`brain_decisions` table carries:
+- `contextEpicId`, `contextTaskId` (soft FKs)
+- `contextPhase` (lifecycle stage name)
+- `adrNumber` (monotonic ADR sequence)
+- `adrPath` (on-disk ADR path)
+- `peerId`, `peerScope` (CANT isolation)
+
+**But**: No provenance graph edges. Brain entries reference tasks via soft FK but do NOT create bidirectional links.
+
+### Missing Provenance Graph Components
+
+**For "feature → bug → hotfix → epic → task → commit → release" graph**:
+
+| Graph Edge Type | Storage Location | Status | Gap |
+|---|---|---|---|
+| feature ↔ task | `tasks.blockedBy` (unidirectional) | ❌ **Insufficient** | Single string, not normalized relation |
+| bug → feature (relates/fixes) | `task_relations(relation_type='fixes')` | ✓ **Present** | No root-cause link |
+| hotfix → bug | `task_relations(relation_type='fixes')` | ✓ **Present** | OK |
+| epic → task | `tasks.parentId` (hierarchy) | ✓ **Present** | OK |
+| task → commit | **❌ MISSING** | **CRITICAL GAP** | No `commits` table or column |
+| commit → release | **❌ MISSING** | **CRITICAL GAP** | `release_manifest.commits` not linked |
+| task → verification.gates → evidence | `tasks.verification` JSON | ✓ **Present** (via ADR-051) | Implicit in evidence attestation |
+| IVTR phase → evidence | `tasks.ivtr_state.phaseHistory[].evidenceRefs[]` | ✓ **Present** | Serialized, not normalized |
+
+**Verdict**: Provenance graph is **implicit and incomplete**. No SQL view can answer: "Which commits shipped in v1.2.3 and which bugs did they fix?"
+
+---
+
+## Phase 5: Conflation Diagnosis — Evidence-Backed Answers
+
+### Q1: Is IVTR Welded into Release?
+
+**Answer**: **YES, hard-welded at engine level.**
+
+**Evidence**:
+- **engine-ops.ts:1262–1280**: `prepareRelease()` calls `releaseGateCheck()` which queries task `ivtr_state`
+- **Error code `E_IVTR_INCOMPLETE`** blocks release if tasks not in `released` phase
+- **No waiver path** except `--force` (which ADR-051 D3 marks for removal)
+- **Fix hint points to IVTR**: `fix: cleo orchestrate ivtr ${blocked[0]} --release`
+
+Release pipeline **cannot proceed without IVTR gates passing**. This is not an advisory gate; it is a **sequential blocker** in the 12-step release flow.
+
+### Q2: Is IVTR Governance or Pipeline?
+
+**Answer**: **Both (conflated). Should be observation-only.**
+
+**Current intent** (from T810, T811 docs):
+- **Governance**: Multi-agent loop tracking task progression through I/V/T/R phases
+- **Pipeline**: State machine persisted in task row; blocks release
+
+**Should be**:
+- **Observation**: Task lifecycle tracker (optional per-task feature)
+- **Governance**: Owned by evidence gates (ADR-051), not state machine
+- **Pipeline**: Release validation owned by evidence + release gates, not IVTR phases
+
+### Q3: Is the Gate Set Duplicated?
+
+**Answer**: **YES. Evidence gates (ADR-051) and IVTR phases (T810) check the same assertions.**
+
+| IVTR Phase | ADR-051 Evidence Gate | Shared Assertion |
+|-----------|----------------------|-----------------|
+| `implement` | `implemented` | Code committed + files exist |
+| `validate` | `qaPassed` | Lint/type checks pass |
+| `test` | `testsPassed` | Test suite passes (exit 0) |
+| `released` | All gates ✓ | (Meta-gate: "ready to ship") |
+
+**Duplication cost**: An agent must:
+1. Run IVTR to `test` phase (auto-runs AcceptanceGate)
+2. Then run `cleo verify --all` (ADR-051) to set evidence gates
+
+Both record the same evidence; both represent "test passes". Running both adds **2x gate execution and 2x DB writes**.
+
+### Q4: Is the Provenance Graph Actualized?
+
+**Answer**: **NO. Graph is implicit and incomplete.**
+
+**What exists** (serialized):
+- `tasks.ivtr_state.phaseHistory[].evidenceRefs[]` → SHA256 hashes of attachments
+- `tasks.verification.evidence` (ADR-051) → gate evidence atoms
+
+**What's missing** (relational edges):
+- task → commit (no `commits` table)
+- commit → release (no `release_manifest.commits` FK to tasks)
+- epic → release (no `releases` table or edge)
+
+**Current workaround**: Orchestrator must **infer** provenance by:
+1. Read task.ivtr_state.phaseHistory → extract evidenceRef SHAs
+2. Read AttachmentStore → resolve SHA to original attachment content
+3. Parse attachment content to infer commit SHA or test results
+
+This is **derivable but not queryable**. No SQL can answer: "List all tasks that shipped in this release."
+
+### Q5: What Can Be Removed Without Losing Auditability?
+
+**Candidates**:
+
+| Component | Can Remove? | Justification | Audit Loss? |
+|-----------|------------|--------------|-----------|
+| `ivtrState` JSON column | **YES** | Evidence gates (ADR-051) capture the same data | None if evidence gates fully populated |
+| IVTR state machine phases | **YES** | Replace with derived views over evidence gates | None if gates are authoritative |
+| `cleo orchestrate ivtr` CLI | **MAYBE** | Keep CLI for agents familiar with it, make it a read-only view of evidence gates | None if backed by evidence |
+| `--force` flag on complete | **YES** | ADR-051 D3 already mandates removal; use `CLEO_OWNER_OVERRIDE` only | None (override logged to audit) |
+| `autoRunGatesAndRecord` in IVTR test phase | **YES** | Let agents explicitly call `cleo verify --evidence` instead | None if explicit verify is mandatory |
+| Release-side IVTR gate check | **YES** | Use evidence gates as the sole release blocker | None if evidence is re-validated on release (ADR-051 D8) |
+
+### Q6: What Must Stay?
+
+**Invariants the owner explicitly requires** (from epic T9345):
+
+1. **Auditability**: Every task lifecycle transition must be logged with agent identity and timestamp ✓ (evidence atoms include `capturedBy`, `capturedAt`)
+2. **Trackability**: Release provenance graph must answer "which bugs did v1.2.3 fix?" ✓ (pending graph implementation)
+3. **Atomic gates**: Gates must not allow rubber-stamping; evidence MUST be verified before persisting ✓ (ADR-051 D1, D8)
+4. **HITL escalation**: Max retries on loop-back escalate to humans ✓ (ivtr-loop.ts:E_IVTR_MAX_RETRIES)
+5. **Project-agnostic**: No assumptions about node/pnpm/TypeScript toolchain ✓ (gates are tool-pluggable; issue is docs/examples assume TS)
+
+**Requirements that should STAY**:
+- Evidence-based gates (ADR-051) — **MANDATORY**
+- Per-task phase tracking (as derived view over evidence) — **OPTIONAL**
+- Audit trails to `.cleo/audit/*.jsonl` — **MANDATORY**
+- Provenance graph (task → commit → release) — **MANDATORY** (missing today)
+- HITL escalation on max retries — **MANDATORY**
+
+---
+
+## Phase 6: Streamlining Sketch
+
+### Minimal Gate Model (Preserves Audit)
+
+**Principle**: Evidence gates are the source of truth. IVTR phases are a **derived view**, not authoritative.
+
+```
+Task lifecycle:
+┌─ Evidence Gates (ADR-051) ─────────────────────────────┐
+│  (implemented, testsPassed, qaPassed, documented,      │
+│   securityPassed, cleanupDone)                          │
+│  ✓ Machine-verifiable atoms (commits, files, tools)     │
+│  ✓ Stored in tasks.verification.evidence                │
+│  ✓ Re-validated on completion (ADR-051 D8)              │
+│  ✓ Audit trail to .cleo/audit/gates.jsonl              │
+└─────────────────────────────────────────────────────────┘
+         ↓ (read gates)
+┌─ Derived IVTR View (optional, for agents) ──────────────┐
+│  IF implemented && testsPassed → show "test passed"     │
+│  IF ALL gates true → show "ready to release"            │
+│  Computed on-the-fly; stored nowhere                    │
+└─────────────────────────────────────────────────────────┘
+         ↓ (query evidence)
+┌─ Release Validation ───────────────────────────────────┐
+│  cleo release ship <epicId>                            │
+│    1. For each task in epic:                           │
+│       a. Verify all evidence atoms still valid          │
+│       b. Re-run hard evidence checks (commit SHAs, etc) │
+│       c. Record release manifest with task IDs + SHAs  │
+│    2. If any evidence stale → E_EVIDENCE_STALE         │
+│    3. If all pass → ship and record provenance edges   │
+└─────────────────────────────────────────────────────────┘
+```
+
+### First-Class Feature/Bug/Hotfix Typing
+
+**Today**: `tasks.kind` (enum) is `work|bug|spike|research|release`.
+
+**Proposal**: Promote `kind` to be used at query time for filtering. Add clarity:
+
+```sql
+-- Find all bugs closed in v1.2.3
+SELECT tasks.id, tasks.title
+FROM release_manifest_tasks
+JOIN tasks ON release_manifest_tasks.task_id = tasks.id
+WHERE release_manifest_tasks.release_id = 'v1.2.3'
+  AND tasks.kind = 'bug';
+
+-- Find all hotfixes related to a critical bug
+SELECT FROM_TASK, relation_type
+FROM task_relations
+WHERE TO_TASK = 'T123' (critical bug)
+  AND FROM_TASK.kind = 'release';
+```
+
+**Implementation**: Ensure `tasks.kind` is always set at task creation. Add UI/CLI prompts to surface kind selection.
+
+### Release Provenance Graph (Single SQL View)
+
+**Today**: Provenance is implicit (AttachmentStore → evidence).
+
+**Proposal**: Create two new tables + one view:
+
+```sql
+-- 1. Commits table (normalization of evidence.commit atoms)
+CREATE TABLE release_manifest_commits (
+  id TEXT PRIMARY KEY,
+  release_id TEXT NOT NULL REFERENCES releases(id),
+  commit_sha TEXT NOT NULL,
+  task_id TEXT REFERENCES tasks(id),
+  evidence_atom_index INT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- 2. Releases table (currently embedded in manifest)
+CREATE TABLE releases (
+  id TEXT PRIMARY KEY,
+  version TEXT NOT NULL,
+  epic_id TEXT NOT NULL REFERENCES tasks(id),
+  shipped_at TEXT,
+  tag_name TEXT
+);
+
+-- 3. View: full provenance graph
+CREATE VIEW release_provenance AS
+SELECT
+  'feature' AS edge_type,
+  f.id AS from_id,
+  f.title AS from_title,
+  b.id AS to_id,
+  b.title AS to_title,
+  'blocks'::TEXT AS relation
+FROM tasks f
+JOIN task_relations tr ON f.id = tr.task_id AND tr.relation_type = 'blocks'
+JOIN tasks b ON tr.related_to = b.id
+UNION ALL
+SELECT
+  'bugfix' AS edge_type,
+  rmt.task_id AS from_id,
+  t.title AS from_title,
+  b.id AS to_id,
+  b.title AS to_title,
+  'fixes'::TEXT
+FROM release_manifest_commits rmc
+JOIN release_manifest_tasks rmt ON rmc.release_id = rmt.release_id
+JOIN tasks t ON rmt.task_id = t.id
+JOIN task_relations tr ON t.id = tr.task_id AND tr.relation_type = 'fixes'
+JOIN tasks b ON tr.related_to = b.id;
+```
+
+### Project-Agnostic Gate System
+
+**Constraint**: No node/pnpm/TypeScript assumptions.
+
+**Current state**:
+- Evidence atoms support: commit, files, test-run (vitest JSON), tool (biome/tsc/eslint/etc), url, note
+- Tools are pluggable: `tools: Record<string, ToolRunner>`
+
+**Needed**:
+- Add `custom` evidence atom type for non-standard verifications
+- Document language-agnostic test result formats (JUnit XML, TAP, etc.)
+- Examples for Java (Maven), Python (pytest), Rust (cargo test), Go (go test), etc.
+
+---
+
+## Recommendations
+
+### Priority 1: Decouple Release from IVTR (T9350)
+
+**Action**: Remove IVTR gate check from `prepareRelease()`.
+
+```diff
+// packages/core/src/release/engine-ops.ts:1251
+- logStep(1, 12, 'Check IVTR gate for epic tasks');
+- const gateResult = await releaseGateCheck(epicId, skipIvtrGate, cwd);
+- if (!gateResult.success) return gateResult;
++ // IVTR removed. Release validation is now evidence-only.
++ // (See ADR-052: Evidence-Based Release Validation)
+```
+
+**Impact**: Release no longer depends on IVTR state. Evidence gates become sole blocker.
+
+### Priority 2: Make Evidence Gates Mandatory (T9351)
+
+**Action**: Implement ADR-051 D1–D9 fully (in-progress; some code merged, some not).
+
+- ✓ Implement `cleo verify --gate --evidence` (in-code)
+- ✓ Reject `cleo verify --all` without per-gate evidence (in-code)
+- ✓ Audit trail to `.cleo/audit/gates.jsonl` (in-code)
+- ❌ Evidence staleness check on `cleo complete` (NOT implemented; T9351)
+- ❌ Remove `--force` from completion (NOT implemented; T9351)
+- ❌ `CLEO_OWNER_OVERRIDE` audit logging (PARTIAL; needs `.cleo/audit/force-bypass.jsonl`)
+
+### Priority 3: Build Release-Provenance Graph (T9352)
+
+**Action**: Implement `release_manifest_commits` table + `releases` table + view.
+
+```sql
+CREATE TABLE releases (id, version, epic_id, shipped_at, tag_name);
+CREATE TABLE release_manifest_commits (id, release_id, commit_sha, task_id, evidence_atom_index);
+CREATE VIEW release_provenance AS (...)
+```
+
+**Query example**:
+```sql
+-- "What bugs shipped in v1.2.3?"
+SELECT b.id, b.title
+FROM releases r
+JOIN release_manifest_tasks rmt ON r.id = rmt.release_id
+JOIN task_relations tr ON rmt.task_id = tr.task_id AND tr.relation_type = 'fixes'
+JOIN tasks b ON tr.related_to = b.id
+WHERE r.version = '1.2.3' AND b.kind = 'bug';
+```
+
+### Priority 4: Deprecate IVTR State Machine (T9353)
+
+**Action**: Mark `tasks.ivtr_state` column as @deprecated. Provide read-only view.
+
+- Keep column for backward compat, but stop writing new IVTR state
+- Provide CLI: `cleo show T123 --ivtr` (read-only, derives from evidence gates)
+- Remove `cleo orchestrate ivtr --start/--next/--release` (orchestrate agents no longer use it)
+- Keep `cleo orchestrate ivtr --status` (read-only view)
+
+**Timeline**: 2-release deprecation window, then removal.
+
+---
+
+## Conflation Severity Assessment
+
+| Criterion | Severity | Rationale |
+|-----------|----------|-----------|
+| **Bidirectional tight coupling** | **HIGH** (8/10) | Release cannot ship without IVTR; IVTR auto-suggests release. Changing either requires coordinated changes. |
+| **Gate duplication** | **HIGH** (8/10) | Evidence gates and IVTR phases do identical work. Removes agent time cost but increases conceptual overhead. |
+| **Missing provenance graph** | **CRITICAL** (9/10) | Owner explicitly requires "track feature→bug→hotfix→epic→task→commit→release" but graph doesn't exist. Derivable but not queryable. |
+| **Non-blocking semantics unclear** | **MEDIUM** (5/10) | "72 task(s) have no IVTR state" flag tasks as non-blocking but with no explicit opt-out. Reduces confidence in gate trustworthiness. |
+| **Implicit vs. explicit provenance** | **HIGH** (7/10) | Provenance is serialized in JSON blobs + AttachmentStore. No SQL view. Makes auditability harder. |
+| **Override escape hatch (--force)** | **CRITICAL** (9/10) | ADR-051 D3 mandates removal but still shipped. Undermines evidence integrity. |
+
+**Overall Conflation Severity**: **7/10** — Significant over-engineering and bidirectional coupling. Decoupling is feasible and high-value, but requires coordination across release + task orchestration layers.
+
+---
+
+## Audit Completion
+
+This audit identifies:
+- ✓ 19 IVTR-related files
+- ✓ 4 major coupling leak points
+- ✓ 6 overlapping gate concepts
+- ✓ 5 missing provenance graph components
+- ✓ 2 viable decoupling paths (evidence-first, graph-normalized)
+- ✓ 4 high-priority follow-up tasks (T9350–T9353)
+
+**Output**: `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md`
+

--- a/.cleo/rcasd/T9345/research/letta-harness-real-research.md
+++ b/.cleo/rcasd/T9345/research/letta-harness-real-research.md
@@ -1,0 +1,1091 @@
+# Letta — Real-World Research for CLEO T9345 (IVTR Release System)
+
+> **Research target**: Letta (formerly MemGPT) — the canonical "agent harness" referenced in CLEO T1737 (Sentient Harness v3).
+> **Goal**: Map Letta's release governance, gate architecture, harness model, and project-agnosticism to CLEO's IVTR Release System overhaul.
+> **Methodology**: Every claim cites a URL or filename inside the Letta repos. No training-data invention. Where evidence was absent I say so explicitly.
+> **Date of research**: 2026-05-15 (CLEO project clock).
+> **Authoritative sources used**:
+> - `https://github.com/letta-ai/letta` (server / Python)
+> - `https://github.com/letta-ai/letta-code` (harness / TypeScript)
+> - `https://docs.letta.com` (official docs)
+> - GitHub REST API (`gh api repos/letta-ai/...`) for releases, commits, workflows, branch protection, labels
+>
+> CLEO author for this report: cleo-prime / research agent under T9345.
+
+---
+
+## Executive Summary
+
+Letta ships **two repositories** with **two completely different release postures**:
+
+1. **`letta-ai/letta`** — the Python "Letta Server" (FastAPI + Postgres + Alembic). Apache-2.0, 22.7k stars, 2.4k forks. Latest tag at time of writing: **`0.16.8`** (2026-05-14, by `kianjones9`). Release pipeline is **manual, single-job, no test gates between build and PyPI publish.** The `poetry-publish.yml` workflow runs `uv build && uv publish` immediately on `release: published` with no lint, no typecheck, no pytest — relying entirely on the human who clicks "Publish release" to have already run gates locally. This is the **anti-pattern CLEO is fixing**.
+
+2. **`letta-ai/letta-code`** — the TypeScript "agent harness" (the CLI/Bun product). Apache-2.0, 2.5k stars. Latest tag: **`v0.25.9`** (2026-05-15, by `github-actions[bot]`). Release pipeline is **two-stage and gate-heavy**: `prepare-release.yml` opens a "chore: bump version" PR after running lint/typecheck/build/update-chain smoke; `release.yml` triggers on push-to-main when the bump-commit subject matches `chore: bump version to *`, re-runs lint+typecheck+build+CLI smoke+real-API integration smoke, then publishes to npm with OIDC, creates the git tag, and cuts a GitHub Release with auto-generated notes. This is much closer to where CLEO is trying to go.
+
+**Architectural posture.** Letta calls itself "the platform for building stateful agents" (`gh api repos/letta-ai/letta` description). The word **"harness"** appears explicitly in `docs.letta.com/concepts/letta` and in the `letta-code` README — "a memory-first coding harness, designed for long-lived agents that can learn from experience." The harness contract is: Letta Server (Python, stateful agent runtime + memory + tools API) <-- HTTP/SDK --> Letta Code (TypeScript CLI harness that drives the agent through tool calls). CLEO's "harness" framing (CleoOS, Pi adapter) maps cleanly onto Letta Code's role, NOT Letta Server's role.
+
+**What CLEO can borrow (high-confidence):**
+- The **two-stage bump-PR → tag-and-publish pattern** in `letta-code`. Gates run twice (preflight in prepare; full re-run + smoke in release), tag is created **on the merged main commit** AFTER all gates pass. Maps directly to CLEO's `release.ship.cuts release-branch → CI green → merge → tag` flow but tightens the smoke gate.
+- The **`release_bump_only` classifier** in `letta-code/.github/workflows/ci.yml` — detects commits whose subject is `chore: bump version to *` AND whose only changed files are `package.json|package-lock.json` and **skips heavy CI** for them, since the bump-PR is just a version metadata change. CLEO's equivalent would be: detect release-only PRs and skip per-package builds.
+- The **environment-gated npm publish** with OIDC: `environment: npm-publish` + `id-token: write` + `npm publish --access public`. CLEO can adopt the same `environment:` GitHub gate for human-approved release pushes.
+- The **integration smoke test against a real API** (`./letta.js --prompt "ping" --tools "" --permission-mode plan`) inside the publish workflow — proves the built artifact actually works before npm publish. CLEO's IVTR could require an analogous "spawn one orchestrator + complete one trivial task" smoke before tagging.
+- The **release notes with hierarchical structure** (v0.16.7: Highlights / Breaking Changes / Context Window & Compaction / Gemini / Memory / Conversations / Streaming / Model Support / Security / Infrastructure). Built manually but with consistent section taxonomy.
+- The **provenance graph**: `LET-XXXX` internal IDs (likely Linear) cross-cited with `#PR` numbers in release notes (e.g. `LET-7991 (#9986)`). This is **exactly the issue→PR→release-tag provenance** CLEO wants for task→commit→release.
+
+**What is NOT applicable (Python/FastAPI assumptions):**
+- The `letta` server release pipeline is **bespoke to Python + uv + PyPI + Docker Hub**. The version is hard-coded in `pyproject.toml` AND `letta/__init__.py` (`__version__ = "0.16.7"` fallback) — Letta has **no project-agnostic release tool**. There is no `letta release ship` CLI; releases are clicked manually in the GitHub UI.
+- Docker image tagging assumes a single image (`letta/letta:VERSION` + `memgpt/letta:VERSION`) — no multi-package matrix like CLEO's pnpm workspace.
+- The 22 test suites in `core-unit-test.yml` are matrix-fanned but Letta does **not** have CLEO's notion of "evidence-based gates" (`tool:test`, `commit:<sha>`, `files:<list>` atoms). Every gate is implicit / human-asserted.
+- No epic-completeness check: Letta uses GitHub Issues + Linear tags, but releases are not blocked on "all child issues of epic X are closed."
+- No release-please, no semantic-release, no changesets, no release-please-manifest. **Release tooling is the YAML workflows themselves.**
+
+**Top three actionable lifts for CLEO IVTR:**
+1. Steal the `letta-code` **two-stage workflow + integration smoke** pattern verbatim and bind it to `cleo release ship`'s 12-step flow.
+2. Adopt the **`LET-XXXX (#PR)` cross-citation** convention in CLEO release notes — `cleo release ship` already generates CHANGELOG from `completedAt > previousVersion.pushedAt`; add `T#### (#PR)` cross-references.
+3. Adopt the **release-bump-only classifier** to short-circuit per-package builds on version-only PRs (significant CI cost saving).
+
+300-word summary ends here. Detailed citations follow.
+
+---
+
+## Phase 1 — Canonical Repo Verification
+
+### 1.1 The `letta-ai/letta` repo (Python server)
+
+**URL**: `https://github.com/letta-ai/letta`
+
+**Repo metadata** (source: `gh api repos/letta-ai/letta` executed 2026-05-15):
+
+| Field | Value |
+|---|---|
+| `description` | "Letta is the platform for building stateful agents: AI with advanced memory that can learn and self-improve over time." |
+| `default_branch` | `main` |
+| `license.spdx_id` | `Apache-2.0` |
+| `stargazers_count` | 22,740 |
+| `forks_count` | 2,417 |
+| `open_issues_count` | 71 |
+| `has_issues` | true |
+| `has_projects` | false |
+| `has_wiki` | false |
+| `has_discussions` | false |
+| `archived` | false |
+| `pushed_at` | 2026-05-14T17:14:23Z |
+
+**README description** (source: `https://github.com/letta-ai/letta/README.md` fetched 2026-05-15):
+- Tagline: *"Build AI with advanced memory that can learn and self-improve over time."*
+- Self-identification: *"the platform for building stateful agents"*
+- Rename history: heading says *"Letta (formerly MemGPT)"* (no date given in README)
+- The word **"harness"** does **NOT** appear in the `letta` server README. It DOES appear in the `letta-code` README and in `docs.letta.com` (see Phase 2.2 below).
+
+**Primary language** (GitHub language stats from repo page): Python 99.5%.
+
+**Maintainers** (visible release authors from `gh api .../releases?per_page=15`):
+- `carenthomas` — author of 10 of the 11 recent tagged releases (0.11.7 → 0.16.7).
+- `kianjones9` — author of `0.16.8` (the most recent release).
+- `sarahwooders` — earlier tag `0.11.7`.
+- These three names match the Letta core team listed on `docs.letta.com` / company about pages (cross-checked but not quoted here to avoid invention).
+
+**Canonicity confirmation**: 22.7k stars, Apache-2.0, active commits within 24 hours of research, name match for "MemGPT" → "Letta" rename. This is the canonical project.
+
+### 1.2 The `letta-ai/letta-code` repo (TypeScript harness)
+
+**URL**: `https://github.com/letta-ai/letta-code`
+
+**Repo metadata** (source: `gh api repos/letta-ai/letta-code` executed 2026-05-15):
+
+| Field | Value |
+|---|---|
+| `description` | "The memory-first coding agent" |
+| `default_branch` | `main` |
+| `license.spdx_id` | `Apache-2.0` |
+| `stargazers_count` | 2,494 |
+| `forks_count` | 254 |
+| `language` | TypeScript |
+| `pushed_at` | 2026-05-16T01:21:29Z |
+
+**README first line** (source: `https://github.com/letta-ai/letta-code/README.md` fetched 2026-05-15):
+> "a memory-first coding harness, designed for long-lived agents that can learn from experience."
+
+**Visible repo structure** (from GitHub tree view): `.cursor/rules`, `.github`, `.husky`, `.skills/`, `src/`, `scripts/`, `bin/`, `vendor/`, `assets/`, `package.json`, `tsconfig.json`, `biome.json`. This is a Bun + TypeScript project.
+
+### 1.3 docs.letta.com confirmation
+
+**URL**: `https://docs.letta.com/concepts/letta`
+
+Quote (fetched 2026-05-15):
+> "The Letta Code SDK is built on top of the core Letta API, and adds pre-built support for skills and local / client-side tool execution… the same agent harness as Letta Code."
+
+This is the **canonical use of "harness"** in Letta's own vocabulary — it refers to the TypeScript CLI / SDK product (`letta-code`), NOT the Python server.
+
+---
+
+## Phase 2 — Harness Architecture
+
+### 2.1 Two-tier architecture
+
+Based on `README.md` of `letta-ai/letta` and `docs.letta.com/quickstart`:
+
+| Component | Repo | Role | Surface |
+|---|---|---|---|
+| **Letta Server** | `letta-ai/letta` (Python) | Stateful agent runtime; memory blocks; tool execution sandboxing; LLM provider adapters | FastAPI + Postgres + Redis (optional). Exposes REST `/v1/...` and SSE streaming. |
+| **Letta Code** | `letta-ai/letta-code` (TypeScript) | "Agent harness" — CLI / TUI / desktop / Slack-Telegram-Discord integrations. Drives the Server through SDK calls. | npm package `@letta-ai/letta-code`; Bun bundler; ships as single `letta.js`. |
+| **Letta Cloud** | hosted at `app.letta.com` | Managed Letta Server SaaS. API key obtained from `https://app.letta.com/api-keys`. | Same REST API as self-hosted. |
+| **Python SDK** | `pip install letta-client` (mentioned in README) | Generated by Fern. | Pure client library. |
+| **TypeScript SDK** | `npm install @letta-ai/letta-client` (mentioned in README) | Generated by Fern. | Pure client library. |
+
+**Server framework**: FastAPI. Source: `pyproject.toml` line `"fastapi>=0.115.6"` (fetched from `https://github.com/letta-ai/letta/blob/main/pyproject.toml`).
+
+**Persistence**: Postgres + Alembic migrations. Source: workflow `alembic-validation.yml` exists, and `pyproject.toml` declares `sqlalchemy[asyncio]>=2.0.41`, `sqlmodel>=0.0.16`, `pgvector>=0.2.3`, `alembic` (implicit from the workflow name).
+
+**Memory architecture**: The pyproject.toml does NOT directly describe memory architecture — that's in `letta/` source. Release notes for **v0.16.6** explicitly describe:
+> "Conversation creation now compiles and persists a system message immediately. This captures current memory state at conversation start."
+>
+> "`CORE_MEMORY_BLOCK_CHAR_LIMIT`: 20k → 100k" — memory blocks are first-class.
+>
+> "Git-backed memory frontmatter no longer emits `limit`" — there is a "git memory" / memfs subsystem.
+
+Release notes for **v0.16.7** mention:
+> "Compaction overflow fixes (#9897) — addresses the double-compaction and runaway compaction loops"
+> "Compaction model resets on agent model change (#10031)"
+> "Summarizer prompt improved (#10314) — now remembers plan files, GitHub PRs, and other structured content during summarization"
+
+So the memory model is: persistent memory blocks + git-backed memfs + compaction/summarizer + projection rendering into system prompts. "Sleep-time agents" is NOT mentioned in the v0.16.x release notes I fetched — if Letta uses that term it's in older docs or marketing.
+
+### 2.2 The word "harness" — where it actually appears
+
+I searched four sources for the word "harness":
+
+| Source | Contains "harness"? | Quote |
+|---|---|---|
+| `letta-ai/letta` README | **No** | — |
+| `letta-ai/letta-code` README | **Yes** | "a memory-first coding harness, designed for long-lived agents that can learn from experience." |
+| `docs.letta.com/concepts/letta` | **Yes** | "The Letta Code SDK… same agent harness as Letta Code, but accessible via TypeScript." |
+| `docs.letta.com/concepts/letta-code` | **Inaccessible** | Returned HTTP 404 in WebFetch — does NOT exist at that path, OR uses a different slug. No evidence found. |
+
+**Critical inference for CLEO**: When CLEO references Letta as a "harness precedent" (T1737), the precedent is **`letta-code`** (the TypeScript CLI), not the Python server. CleoOS's role in CLEO maps onto `letta-code`'s role in Letta. The Python `letta` repo is a stateful agent **runtime**, not a harness.
+
+### 2.3 CLI vs server distinction in release flow
+
+The two repos have **fundamentally different release postures** because they ship different artifacts:
+
+- `letta` (server) ships **PyPI wheel** + **Docker image** (letta/letta + memgpt/letta on Docker Hub).
+- `letta-code` (harness) ships **npm package** (`@letta-ai/letta-code`).
+
+This split lets the harness iterate **fast** (10 patch releases between v0.25.0 on May 4 and v0.25.9 on May 15 — roughly **one release per day**) while the server iterates slowly (0.16.6 → 0.16.7 = 25 days; 0.16.7 → 0.16.8 = 44 days).
+
+---
+
+## Phase 3 — Release & Governance Patterns
+
+### 3.1 Versioning scheme
+
+**Letta Server (`letta-ai/letta`)**: Semantic versioning, MAJOR.MINOR.PATCH format. Source: tag list from `gh api repos/letta-ai/letta/releases?per_page=15` shows tags `0.11.7`, `0.12.0`, `0.12.1`, `0.13.0`, `0.14.0`, `0.15.0`, `0.15.1`, `0.16.0`, `0.16.1`, `0.16.2`, `0.16.4`, `0.16.5`, `0.16.6`, `0.16.7`, `0.16.8`. Note: tags have **no `v` prefix** (API rejected `v0.16.8`; only `0.16.8` succeeded).
+
+Notable: **0.16.3 is missing** — likely a pulled or skipped tag. This is a real-world pattern: even minor projects skip patch numbers.
+
+**Letta Code (`letta-ai/letta-code`)**: Semantic versioning, **`v`-prefixed**. Source: `gh api repos/letta-ai/letta-code/releases?per_page=10` shows `v0.25.0` → `v0.25.9` in 11 days.
+
+**Convention divergence**: The two Letta repos use different tag formats. CLEO already uses `v<calver>` consistently — Letta is **not** a precedent for CalVer.
+
+### 3.2 Version source of truth
+
+**Letta Server**: dual-sourced in `pyproject.toml` + `letta/__init__.py`.
+
+Source: `https://github.com/letta-ai/letta/blob/main/pyproject.toml`:
+```
+[project]
+name = "letta"
+version = "0.16.8"
+```
+
+Source: `https://github.com/letta-ai/letta/blob/main/letta/__init__.py`:
+```python
+try:
+    __version__ = version("letta")
+except PackageNotFoundError:
+    __version__ = "0.16.7"
+```
+
+**Important bug indicator**: The fallback in `__init__.py` is `0.16.7` but pyproject says `0.16.8`. This drift indicates Letta **does not have automation that keeps the two files in sync** — they update manually. CLEO's `resolveVersionBumpTargets` (from memory note T9246) handles this better.
+
+Source: `nightly-publish` workflow YAML literally rewrites both files:
+> `jq '.version = ...' pyproject.toml` and then `sed` over `letta/__init__.py` (extrapolated from the nightly workflow description, which says both files are updated for nightly builds).
+
+**Letta Code**: single-sourced in `package.json`. Source: `prepare-release.yml` reads `OLD_VERSION=$(jq -r '.version' package.json)`.
+
+### 3.3 The `letta` server release path (anti-pattern)
+
+**Step-by-step reconstruction from workflow files** (sources cited inline):
+
+**Step 1**: A "bump version" PR is opened manually. Example: `gh api repos/letta-ai/letta/pulls/3265`:
+- Title: `chore: bump 0.16.7`
+- Head branch: `bump-16-7`
+- Base: `main`
+- Merged by: `carenthomas` at 2026-03-31T19:26:39Z
+- **Changes**: 188 files, +13,242 / −3,353 (this is **not** a pure version bump — it bundles all the work for the release).
+- Files touched in the bump-PR include: `letta/__init__.py`, `pyproject.toml`, **177 application files**, regenerated `fern/openapi.json`, 4 new Alembic migrations. So the "version bump PR" is actually a "feature merge train" that happens to land the version bump as well.
+
+**Step 2**: After PR merges, a maintainer **manually creates a GitHub Release** through the UI on the merged commit, providing the tag name and (handwritten) release notes. Evidence: release notes for `0.16.7` include hand-curated sections ("Highlights", "Breaking Changes", "Context Window & Compaction", etc. — see Phase 3.5) that clearly were not auto-generated. Compare to `0.16.8`, where the notes are a flat auto-generated PR list and the release was made by a different author (`kianjones9` vs `carenthomas`) — suggesting `carenthomas` writes the curated notes when she does the release, others use the default.
+
+**Step 3**: GitHub fires `release: types: [published]`. This triggers TWO workflows:
+
+(a) `poetry-publish.yml` (despite the filename, it uses `uv`, not Poetry):
+Source: `gh api repos/letta-ai/letta/contents/.github/workflows/poetry-publish.yml`:
+```yaml
+name: uv-publish
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    name: Build and Publish to PyPI
+    if: github.repository == 'letta-ai/letta'  # TODO: if the repo org ever changes, this must be updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+      - name: Set up python 3.12
+        ...
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Build the Python package
+        run: uv build
+      - name: Publish the package to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: uv publish
+```
+
+**Anti-pattern observation**: This workflow has **zero gates**. No lint, no typecheck, no pytest, no smoke test. It assumes everything is green because the PR that merged before tagging "must have" passed CI. There is **no defense** against:
+- A maintainer cutting a release from a SHA that has CI failing.
+- A maintainer cutting a release before the PR's CI completed.
+- A maintainer fat-fingering the tag onto the wrong commit.
+- A workflow file that itself has a syntax error (CI on the PR may not exercise the publish workflow).
+
+(b) `docker-image.yml`:
+Source: `gh api repos/letta-ai/letta/contents/.github/workflows/docker-image.yml`:
+```yaml
+name: Docker Image CI
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Extract version number
+      id: extract_version
+      run: echo "CURRENT_VERSION=$(awk -F '"' '/version =/ { print $2 }' pyproject.toml | head -n 1)" >> $GITHUB_ENV
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          letta/letta:${{ env.CURRENT_VERSION }}
+          letta/letta:latest
+          memgpt/letta:${{ env.CURRENT_VERSION }}
+          memgpt/letta:latest
+```
+
+**Anti-pattern**: Same as PyPI publish — no gates. Also note: version is parsed by `awk` from `pyproject.toml`, **not from the release tag**. If the release was tagged at a commit before the bump-PR merged, the Docker image would publish under the wrong version. The release notes show a 44-day gap between 0.16.7 and 0.16.8 — plenty of room for drift between the tag and what's in `pyproject.toml`.
+
+### 3.4 The `letta-code` harness release path (good pattern)
+
+This is the pattern CLEO should mostly mirror.
+
+**Two workflows, two stages, three gate-runs.**
+
+#### Stage 1: `prepare-release.yml`
+
+Source: `gh api repos/letta-ai/letta-code/contents/.github/workflows/prepare-release.yml` — verbatim:
+
+```yaml
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version bump type (patch, minor, major)"
+        required: false
+        default: "patch"
+      prerelease:
+        description: "Publish as prerelease? (leave empty for stable, or enter tag like 'next')"
+        required: false
+        default: ""
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.0
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun install
+      - name: Lint & Type Check
+        run: bun run check
+      - name: Build bundle
+        run: bun run build
+      - name: Update-chain preflight smoke
+        run: bun run test:update-chain:manual
+
+  prepare:
+    needs: preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        id: version
+        run: |
+          VERSION_TYPE="${{ github.event.inputs.version_type || 'patch' }}"
+          PRERELEASE_TAG="${{ github.event.inputs.prerelease }}"
+          OLD_VERSION=$(jq -r '.version' package.json)
+
+          if [[ "$OLD_VERSION" == *-* ]]; then
+            OLD_IS_PRERELEASE=true
+            BASE_VERSION=$(echo "$OLD_VERSION" | sed 's/-.*//')
+          else
+            OLD_IS_PRERELEASE=false
+            BASE_VERSION="$OLD_VERSION"
+          fi
+
+          IFS='.' read -ra VERSION_PARTS <<< "$BASE_VERSION"
+          MAJOR=${VERSION_PARTS[0]}
+          MINOR=${VERSION_PARTS[1]}
+          PATCH=${VERSION_PARTS[2]}
+
+          if [ "$VERSION_TYPE" = "major" ]; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif [ "$VERSION_TYPE" = "minor" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            if [ "$OLD_IS_PRERELEASE" = "false" ]; then
+              PATCH=$((PATCH + 1))
+            fi
+          fi
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+          if [ -n "$PRERELEASE_TAG" ]; then
+            if [[ "$OLD_VERSION" == "${NEW_VERSION}-${PRERELEASE_TAG}."* ]]; then
+              PRERELEASE_NUM=$(echo "$OLD_VERSION" | sed "s/${NEW_VERSION}-${PRERELEASE_TAG}\.\([0-9]*\)/\1/")
+              PRERELEASE_NUM=$((PRERELEASE_NUM + 1))
+            else
+              PRERELEASE_NUM=1
+            fi
+            NEW_VERSION="${NEW_VERSION}-${PRERELEASE_TAG}.${PRERELEASE_NUM}"
+          fi
+
+          jq --arg version "$NEW_VERSION" '.version = $version' package.json > package.json.tmp
+          mv package.json.tmp package.json
+
+          jq --arg version "$NEW_VERSION" '.version = $version | .packages[""].version = $version' package-lock.json > package-lock.json.tmp
+          mv package-lock.json.tmp package-lock.json
+
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Commit version bump
+        run: |
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
+
+      - name: Create version bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="chore/bump-v${{ steps.version.outputs.new_version }}"
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: bump version to ${{ steps.version.outputs.new_version }}" \
+            --body "Merge this PR to publish v${{ steps.version.outputs.new_version }}." \
+            --base main \
+            --head "$BRANCH"
+```
+
+**Analysis**:
+- **First gate-run** (`preflight`): lint + typecheck + build + `bun run test:update-chain:manual` (the "update-chain smoke" — Letta's auto-update mechanism for the CLI, validated end-to-end before allowing a version bump).
+- **Idempotent prerelease handling**: if the last version was a prerelease (`-next.N`), the next patch logic increments `N` instead of bumping `PATCH`.
+- **Output**: a new PR on branch `chore/bump-v<NEW>` containing ONLY changes to `package.json` and `package-lock.json`, with PR body `"Merge this PR to publish v<NEW>."`. This is human-readable orchestration: a maintainer reads the diff, reviews CI, merges.
+
+#### Stage 2: `release.yml`
+
+Source: `gh api repos/letta-ai/letta-code/contents/.github/workflows/release.yml` — verbatim (truncated, full YAML preserved in research notes):
+
+```yaml
+name: Publish release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
+      - package-lock.json
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    environment: npm-publish
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Detect release bump commit
+        id: detect
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+            echo "subject=manual publish dispatch" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          SUBJECT=$(git log --format=%s "${{ github.event.before }}..${{ github.sha }}" | grep -E '^chore: bump version to ' | tail -n 1 || true)
+          if [ -z "$SUBJECT" ]; then
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "should_publish=true" >> $GITHUB_OUTPUT
+          echo "subject=$SUBJECT" >> $GITHUB_OUTPUT
+
+      [...Setup steps gated on `should_publish == 'true'`...]
+
+      - name: Derive release metadata
+        if: steps.detect.outputs.should_publish == 'true'
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          PACKAGE_NAME=$(jq -r '.name' package.json)
+          TAG="v$VERSION"
+          [...prerelease / npm_tag / previous_tag / tag_exists / npm_published flags...]
+
+      - name: Install dependencies
+        if: steps.detect.outputs.should_publish == 'true'
+        run: bun install
+
+      - name: Lint & Type Check
+        if: steps.detect.outputs.should_publish == 'true'
+        run: bun run check
+
+      - name: Build bundle
+        if: steps.detect.outputs.should_publish == 'true'
+        run: bun run build
+
+      - name: Smoke test - help
+        if: steps.detect.outputs.should_publish == 'true'
+        run: ./letta.js --help
+
+      - name: Smoke test - version
+        if: steps.detect.outputs.should_publish == 'true'
+        run: ./letta.js --version || echo "Version flag not implemented yet"
+
+      - name: Integration smoke test (real API)
+        if: steps.detect.outputs.should_publish == 'true'
+        env:
+          LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
+        run: ./letta.js --prompt "ping" --tools "" --permission-mode plan
+
+      - name: Create release tag on merged main commit
+        if: steps.detect.outputs.should_publish == 'true' && steps.version.outputs.tag_exists != 'true'
+        run: |
+          git tag "${{ steps.version.outputs.tag }}" "${{ github.sha }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Publish to npm
+        if: steps.detect.outputs.should_publish == 'true' && steps.version.outputs.npm_published != 'true'
+        run: npm publish --access public --tag ${{ steps.version.outputs.npm_tag }}
+
+      - name: Create GitHub Release
+        if: steps.detect.outputs.should_publish == 'true' && steps.version.outputs.is_prerelease == 'false' && steps.version.outputs.previous_tag != ''
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          name: Release ${{ steps.version.outputs.tag }}
+          previous_tag: ${{ steps.version.outputs.previous_tag }}
+          generate_release_notes: true
+          files: letta.js
+          fail_on_unmatched_files: true
+```
+
+**Analysis (this is the model for CLEO)**:
+
+1. **Trigger**: `push: main` filtered to `paths: [package.json, package-lock.json]`. The workflow does not even start unless a metadata-bumping commit lands.
+
+2. **Verification of intent**: `Detect release bump commit` step inspects the commit subject against the regex `^chore: bump version to ` — defense against version files getting bumped accidentally as part of a different PR.
+
+3. **Idempotency flags**: `tag_exists`, `npm_published`. The workflow can be re-run safely; it skips tag creation if the tag exists and skips `npm publish` if the package version already exists on the registry.
+
+4. **Gates on the build commit itself** (NOT on a previous green CI run):
+   - `bun run check` (lint + typecheck)
+   - `bun run build` (builds the actual artifact)
+   - `./letta.js --help` (smoke: the bundle runs at all)
+   - `./letta.js --version` (smoke: version flag works)
+   - `./letta.js --prompt "ping" --tools "" --permission-mode plan` ← **integration smoke against the real Letta API using `LETTA_API_KEY` secret**. This is the killer feature: the workflow proves the bundled CLI can complete a one-shot agent interaction before publishing.
+
+5. **Tag creation AFTER gates pass**: `git tag $TAG $github.sha && git push origin $TAG` happens only after lint+typecheck+build+3 smokes pass. The tag points at the **merged main commit** that contains the version bump.
+
+6. **GitHub Release with `generate_release_notes: true`**: the `softprops/action-gh-release@v2` action uses GitHub's API to auto-generate release notes from PRs merged between `previous_tag` and the new tag. `previous_tag` is computed by querying `releases?per_page=100` and falling back to `git tag --sort=-version:refname` filtered to `^v[0-9]+\.[0-9]+\.[0-9]+$`. **The artifact `letta.js` is attached to the release**, with `fail_on_unmatched_files: true` so the workflow fails loudly if the build didn't produce it.
+
+7. **Environment gate**: `environment: npm-publish` — this is the GitHub Environments feature, which allows configuring **required reviewers**, **wait timers**, and **secrets scoped per environment**. The `letta-code` team can put a human approver on the `npm-publish` environment, blocking `npm publish` until someone clicks "Approve." This is invisible from the YAML alone — has to be confirmed via `gh api repos/letta-ai/letta-code/environments` (which requires admin token; we lack access). But the fact that the environment is named explicitly is strong evidence it's gate-bound.
+
+#### CI on the bump-PR itself: `ci.yml` with release-bump classifier
+
+Source: `gh api repos/letta-ai/letta-code/contents/.github/workflows/ci.yml` (head):
+
+```yaml
+name: CI
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  classify:
+    name: Classify change
+    runs-on: ubuntu-latest
+    outputs:
+      release_bump_only: ${{ steps.classify.outputs.release_bump_only }}
+      run_heavy_ci: ${{ steps.classify.outputs.run_heavy_ci }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Detect release-bump-only change
+        id: classify
+        run: |
+          [...resolves TITLE / BASE_SHA / HEAD_SHA from PR or push event...]
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          TITLE_MATCH=false
+          if [[ "$TITLE" == chore:\ bump\ version\ to* ]]; then
+            TITLE_MATCH=true
+          fi
+
+          FILES_MATCH=true
+          if [ -z "$CHANGED_FILES" ]; then
+            FILES_MATCH=false
+          fi
+
+          for file in $CHANGED_FILES; do
+            case "$file" in
+              package.json|package-lock.json) ;;
+              *) FILES_MATCH=false ;;
+            esac
+          done
+
+          RELEASE_BUMP_ONLY=false
+          if [ "$TITLE_MATCH" = true ] && [ "$FILES_MATCH" = true ]; then
+            RELEASE_BUMP_ONLY=true
+          fi
+
+          echo "release_bump_only=$RELEASE_BUMP_ONLY" >> "$GITHUB_OUTPUT"
+
+          if [ "$RELEASE_BUMP_ONLY" = true ]; then
+            echo "run_heavy_ci=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_heavy_ci=true" >> "$GITHUB_OUTPUT"
+          fi
+```
+
+**Why this matters for CLEO**: CLEO's pipeline currently runs full lint+typecheck+tests on the release-branch PR cut by `cleo release ship`. If that PR only contains the version bump + CHANGELOG, the heavy CI is wasted compute. The Letta classifier is **40 lines of bash** and can be ported verbatim — match `chore: bump version` titles AND `packages/*/package.json|CHANGELOG.md|Cargo.toml` file allowlist, and skip heavy CI. This pairs with CLEO's existing `resolveVersionBumpTargets` (per memory T9246) to compute which files are allowed to change in a bump PR.
+
+### 3.5 Release notes structure
+
+**Two distinct styles** within Letta server:
+
+**Style A — auto-generated PR list** (used for most server releases):
+
+Example, `0.16.8` release body verbatim (source `gh api repos/letta-ai/letta/releases/tags/0.16.8`):
+```
+## What's Changed
+* fix: workflows update by @cpacker in https://github.com/letta-ai/letta/pull/3292
+* fix(security): use JSON instead of pickle for sandbox->server tool result transport by @kianjones9 in https://github.com/letta-ai/letta/pull/3343
+
+**Full Changelog**: https://github.com/letta-ai/letta/compare/0.16.7...0.16.8
+```
+
+Two bullet points. Plain. The author (`kianjones9`) clicked "Generate release notes" in the GitHub UI and accepted the default.
+
+**Style B — hand-curated categorical** (used for v0.16.6, v0.16.7):
+
+Example, `0.16.7` release body excerpt (source `gh api repos/letta-ai/letta/releases/tags/0.16.7`):
+```markdown
+# Letta Server 0.16.7 Release Notes
+
+**173 commits since 0.16.6** | Released March 31, 2026
+
+## Highlights
+
+**Self-hosted users: this is a big upgrade.** The default global context window is raised from 32k to 128k, the context window reset bug (LET-7991) is fixed, and compaction has been overhauled. If you've been running curl commands to patch your config after every ADE load, most of that pain should be gone.
+
+## Breaking Changes
+
+- **Block limits are no longer enforced** -- block limit validation has been deprecated and removed from the git memory sync path (#9977, #9983). [...]
+
+## Context Window & Compaction (21 fixes)
+
+[...]
+
+## Gemini (2 fixes)
+
+- **thought_signature preserved on function calls without reasoning** (LET-8166, #10237) -- the bug blocking all Gemini 2.5+/3.x multi-turn tool calling is fixed
+- **Streaming interface crash fixed** (#10306) -- `self.model` now initialized in `SimpleGeminiStreamingInterface` constructor (LET-8129)
+
+## Memory & memfs (10 fixes, 4 features)
+[...]
+
+## Conversations (7 features)
+[...]
+
+## Streaming & Reliability (13 fixes)
+[...]
+
+## Model Support (14 features, 20 fixes)
+[...]
+
+## Security
+- **Local filesystem access blocked via ImageContent bypass** (#3256, #10329) [...]
+
+## Infrastructure
+- Readiness enforcement scaffold (M1-M3 metrics pipeline) [...]
+
+---
+
+**For self-hosted users upgrading from 0.16.6:** This release addresses the majority of issues reported in the community over the past month. [...]
+```
+
+**Categories used** in v0.16.7:
+1. Highlights
+2. Breaking Changes
+3. Context Window & Compaction
+4. Gemini
+5. Memory & memfs
+6. Conversations
+7. Streaming & Reliability
+8. Model Support
+9. Security
+10. Infrastructure
+
+**Provenance pattern** observable in this style:
+- `LET-XXXX` references (internal tracker — almost certainly Linear, given the format).
+- `#XXXX` references (GitHub PR numbers — note BOTH small numbers like `#9977` and big numbers like `#10314`, suggesting two different repos or an issue+PR namespace).
+- Combined: `LET-7991 (#9986)` cross-cites the internal Linear issue ID with the public GitHub PR.
+
+**CLEO directly comparable**: CLEO has `T####` task IDs as the primary internal identifier. `cleo release ship` step 6 already generates CHANGELOG from `completedAt > previousVersion.pushedAt` (per AGENTS.md). The Letta pattern of `LET-XXXX (#PR)` maps cleanly onto **`T#### (#PR)`** in CLEO release notes. This is a small but high-value lift.
+
+### 3.6 Release cadence (empirical)
+
+Source: `gh api repos/letta-ai/letta/releases?per_page=15`:
+
+| Tag | Date | Author | Days since prior |
+|---|---|---|---|
+| 0.16.8 | 2026-05-14 | kianjones9 | 44 |
+| 0.16.7 | 2026-03-31 | carenthomas | 25 |
+| 0.16.6 | 2026-03-04 | carenthomas | 7 |
+| 0.16.5 | 2026-02-24 | carenthomas | 26 |
+| 0.16.4 | 2026-01-29 | carenthomas | 17 |
+| 0.16.2 | 2026-01-12 | carenthomas | 25 |
+| 0.16.1 | 2025-12-18 | carenthomas | 2 |
+| 0.16.0 | 2025-12-15 | carenthomas | 20 |
+| 0.15.1 | 2025-11-26 | carenthomas | 1 |
+| 0.15.0 | 2025-11-25 | carenthomas | 11 |
+| 0.14.0 | 2025-11-14 | carenthomas | 21 |
+| 0.13.0 | 2025-10-24 | carenthomas | 15 |
+| 0.12.1 | 2025-10-09 | carenthomas | <1 |
+| 0.12.0 | 2025-10-09 | carenthomas | — |
+
+**Cadence**: roughly **biweekly to monthly** for the server. The 0.16.7 → 0.16.8 gap of 44 days is the longest in the visible window. The cadence is **not regular** — it's driven by feature/bugfix completion, not a calendar.
+
+**0.12.1 was released the same day as 0.12.0** (hotfix pattern — see Phase 3.7).
+
+For `letta-code`:
+
+| Tag | Date | Author | Days since prior |
+|---|---|---|---|
+| v0.25.9 | 2026-05-15 | github-actions[bot] | <1 |
+| v0.25.8 | 2026-05-13 | github-actions[bot] | 2 |
+| v0.25.7 | 2026-05-11 | github-actions[bot] | <1 |
+| v0.25.6 | 2026-05-10 | github-actions[bot] | 1 |
+| v0.25.5 | 2026-05-09 | github-actions[bot] | <1 |
+| v0.25.4 | 2026-05-08 | github-actions[bot] | <1 |
+| v0.25.3 | 2026-05-08 | github-actions[bot] | <1 |
+| v0.25.2 | 2026-05-08 | github-actions[bot] | <1 |
+| v0.25.1 | 2026-05-07 | github-actions[bot] | 3 |
+| v0.25.0 | 2026-05-04 | github-actions[bot] | — |
+
+**10 releases in 11 days**. The fully-automated pipeline makes daily-or-faster releases practical. All released by `github-actions[bot]`.
+
+### 3.7 Hotfix paths
+
+**Evidence for hotfix pattern**: 0.12.0 (2025-10-09 20:36:04 UTC) → 0.12.1 (2025-10-09 22:41:59 UTC) — same day, ~2 hours apart. Similarly 0.15.0 → 0.15.1 one day apart, 0.16.0 → 0.16.1 two days apart. Letta treats hotfixes as "just patch the version and run the same release workflow."
+
+**No dedicated hotfix branch**: I see no evidence of a long-lived `release/0.16` branch. Releases tag from `main` directly. If a hotfix is needed, it lands on `main` and gets a patch bump. This is **risky** because it presumes nothing else has merged to `main` between the release and the hotfix that you don't want shipped — but it works for fast-moving codebases.
+
+**CLEO has a stronger model already** (per AGENTS.md): `cleo release ship` cuts a `release/v<version>` branch from current main, lands the release commits there, and merges to main only after CI passes. CLEO does NOT need to copy Letta's hotfix path; CLEO's is better.
+
+### 3.8 Nightly publish (Letta server)
+
+Source: `gh api repos/letta-ai/letta/contents/.github/workflows/poetry-publish-nightly.yml`:
+
+- **Trigger**: `schedule: '35 10 * * *'` (10:35 UTC daily) + `release: published` + `workflow_dispatch`.
+- **Version computation**: `NIGHTLY_VERSION="${CURRENT_VERSION}.dev$(date +%Y%m%d%H%M%S)"`.
+- **Files rewritten**: both `pyproject.toml` and `letta/__init__.py`.
+- **Publish target**: PyPI (using same `secrets.PYPI_TOKEN`).
+- **Skip-if-stale**: scheduled runs only proceed if the latest commit is younger than 24 hours.
+
+Useful CLEO precedent for `cleo release nightly` (if such a thing is ever wanted) — but irrelevant to T9345's core IVTR fixes.
+
+---
+
+## Phase 4 — Project-Agnosticism
+
+### 4.1 Is Letta's release pipeline pluggable?
+
+**Verdict: No, not at all.**
+
+Evidence:
+- The `poetry-publish.yml` workflow hard-codes `uv` (despite the filename) and PyPI. Adapting it to a different package manager requires editing the YAML.
+- The `docker-image.yml` workflow hard-codes Docker Hub and the `letta/letta` + `memgpt/letta` image names. Not parameterized.
+- The `release.yml` in `letta-code` hard-codes `bun`, Node 24.13.0, `bun run check`, `bun run build`, `npm publish`, `./letta.js --help`. Adapting to a different stack requires editing the YAML.
+- The `if: github.repository == 'letta-ai/letta'` guard in `poetry-publish.yml` explicitly prevents forks from running the workflow — meaning Letta has **never intended** for this pipeline to be reused outside `letta-ai/letta`.
+- There is **no release CLI** in either repo. No `letta release <action>` command, no `letta-code release <action>` command. The release flow IS the YAML workflows. There is no extracted tool.
+- There is no `release-please-config.json`, no `.release-please-manifest.json`, no `changesets` directory, no `semantic-release` config. Source: `gh api repos/letta-ai/letta/contents/.github` (does not list these files).
+
+**Implication for CLEO**: Letta is **not** a precedent for project-agnostic release tooling. CLEO's `cleo release ship` CLI **is** project-agnostic (it resolves `testing.command`, `build.command` from `.cleo/project-context.json` per ADR-061). CLEO is ahead of Letta on this axis.
+
+### 4.2 Are CI gates configurable per fork?
+
+No. The `core-unit-test.yml` workflow uses `--extra postgres --extra external-tools --extra dev --extra cloud-tool-sandbox` install args that are Letta-specific. The matrix of 22 test suites is hardcoded.
+
+A reusable workflow exists: `reusable-test-workflow.yml` (source: `gh api repos/letta-ai/letta/contents/.github/workflows/reusable-test-workflow.yml`):
+
+```yaml
+name: Reusable Test Workflow
+on:
+  workflow_call:
+    inputs:
+      test-type:
+      core-directory:
+      install-args:
+      test-command:
+      test-path-prefix:
+      timeout-minutes:
+      runner:
+      matrix-strategy:
+      changed-files-pattern:
+      skip-fern-generation:
+      use-docker:
+      ref:
+      use-redis:
+      is-external-pr:
+```
+
+This is parameterized for **internal reuse within Letta** (called by `core-unit-test.yml`, `core-integration-tests.yml`, etc.), not for external consumption. It still bakes in `uv`, `pytest`, `fern`, etc.
+
+**Implication**: This pattern is a precedent CLEO already has via the existing `release.cantbook` playbook pattern (Phase 3.5's mention of `.cantbook` playbooks in CLEO injection). But the **idea** of a reusable workflow with declared inputs is sound — CLEO can adopt the same shape for the GitHub Actions side of `cleo release ship`.
+
+### 4.3 Is the release tool extractable as a CLI for other projects?
+
+No. There is no Letta release CLI. Other projects copying Letta's pattern would have to copy-paste the YAML files and adapt.
+
+---
+
+## Phase 5 — Mapping CLEO Concerns to Letta Evidence
+
+| # | CLEO failure mode | Does Letta solve it? | Evidence / how |
+|---|---|---|---|
+| 1 | **Mid-pipeline failure recovery** | **Partial — letta-code only** | `release.yml` has idempotency flags (`tag_exists`, `npm_published`) that allow re-running the workflow safely. If `tag_exists == true`, tag creation is skipped; if `npm_published == true`, npm publish is skipped. Source: `gh api repos/letta-ai/letta-code/contents/.github/workflows/release.yml`, "Derive release metadata" step. **Letta server does NOT have this** — `poetry-publish.yml` re-running would fail at `uv publish` if the version is already on PyPI, with no idempotency check. |
+| 2 | **Epic-scoped completeness check** | **No** | Letta uses GitHub Issues + Linear (`LET-XXXX` IDs visible in release notes). Issues are NOT grouped by "epic" in any structured way that I can find. Labels like `roadmap`, `enhancement`, `feature request`, `bug` exist (source: `gh api repos/letta-ai/letta/labels?per_page=30`) but no `epic-*` labels, no Projects board (`has_projects: false` per repo metadata), no milestones in active use. There is no mechanism preventing a release from going out with "incomplete epic" work. CLEO's `cleo release verify --epic <id>` is **without precedent in Letta**. |
+| 3 | **Real gate runners (not theater)** | **Partial — letta-code yes; letta no** | `letta-code/release.yml` runs `bun run check && bun run build && ./letta.js --help && ./letta.js --version && ./letta.js --prompt "ping" --tools "" --permission-mode plan` BEFORE tag creation or npm publish. The integration smoke against a real API is a genuine gate. `letta-code/prepare-release.yml` ALSO runs gates (`bun run check`, `bun run build`, `bun run test:update-chain:manual`) before opening the bump PR. **`letta/poetry-publish.yml` has ZERO gates** — it's pure theater protected only by manual discipline. |
+| 4 | **Hotfix bypass paths** | **No formal path; just patch-version bump** | Same workflow handles both regular releases and hotfixes. 0.12.0 → 0.12.1 in 2 hours (source: release dates table in 3.6) shows this works in practice. No `hotfix/*` branch convention. CLEO can do better with its `release/v<version>` model already in place. |
+| 5 | **Tag-to-merge-commit alignment** | **Yes — letta-code only** | `release.yml` creates the tag with `git tag "$TAG" "${{ github.sha }}"` where `github.sha` is the merged main commit. This is **after** the workflow re-runs lint+build+smoke on that exact SHA. Source: `release.yml`, "Create release tag on merged main commit" step. For `letta` server, the tag is created **manually in the GitHub UI** and could point anywhere; there is no automation enforcing it points at the version-bump merge commit. |
+| 6 | **Worker direct-push protection (branch protection)** | **Unknown — cannot confirm via API** | `gh api repos/letta-ai/letta/branches/main/protection` returned **404 Not Found** to my token. This either means (a) the token I'm using lacks admin scope, OR (b) the branch has no protection rules configured. The PR flow visible in the commit log (`gh api repos/letta-ai/letta/commits?per_page=20`) shows EVERY merge to main goes through a PR with `(#XXXX)` suffix — even commits by `cpacker` (CEO) and `kianjones9` (core team). Example: `fix(security): use JSON instead of pickle for sandbox->server tool result transport (#3343)`. This is **strong observational evidence** that branch protection IS enforced, but I cannot confirm the YAML rule set. **No evidence found** for the specific rules. |
+| 7 | **Provenance graph (issue → PR → release → tag)** | **Yes, manually curated** | Cross-citation pattern `LET-XXXX (#YYYY)` in release notes (Phase 3.5) creates a manual provenance graph: Linear issue `LET-7991` → GitHub PR `#9986` → release tag `0.16.7` → git commit (visible via the "Full Changelog" URL `https://github.com/letta-ai/letta/compare/0.16.6...0.16.7`). The graph is hand-built every release. There is no automation that scrapes Linear and inserts `LET-XXXX` references — the maintainer types them. **CLEO can do better automatically** with `T#### (#PR)` because CLEO has both the task DB AND the PR number in scope at release time. |
+| 8 | **Multi-archetype portability** | **No** | Letta has two repos and uses two completely different release stacks (uv+PyPI+Docker vs Bun+npm) with two completely different workflow files. There is no shared abstraction. If Letta added a Rust crate tomorrow, they'd write a third workflow file from scratch. CLEO's project-context-driven approach (which resolves `tool:test` to `pnpm-test` or `cargo-test` per `.cleo/project-context.json`) is **substantially more portable** than anything Letta has. |
+
+---
+
+## Phase 6 — Pull-Request and Merge-Train Pattern (Bonus)
+
+The "chore: bump 0.16.7" PR (`gh api repos/letta-ai/letta/pulls/3265`) is **the most interesting governance artifact** I found. It is **not** a pure version bump. It's a **merge-train PR**:
+
+| Stat | Value |
+|---|---|
+| Changed files | 188 |
+| Additions | 13,242 |
+| Deletions | 3,353 |
+| Head branch | `bump-16-7` |
+| Base | `main` |
+| Merged by | `carenthomas` |
+| Files include | `letta/__init__.py`, `pyproject.toml`, 177 application files, regenerated `fern/openapi.json`, 4 new Alembic migrations, removal of `.skills/db-migrations-schema-changes/` and `.skills/llm-provider-usage-statistics/` skill files |
+
+**Interpretation**: Letta's pattern is to do the active feature work on `main` (smaller PRs land regularly per the commit log: `fix:`, `feat:`, `refactor:`, all merging individually), then when a release is ready, **the maintainer cherry-picks/squashes a bundle of those commits into a single PR named `chore: bump 0.16.7`** and lands it as a feature train. The release tag attaches to the merged train.
+
+Looking at the commit log around the v0.16.7 cut:
+- `f333247` `chore: bump 0.16.7 (#3265)` — the train PR merge
+- `de63998` `chore: bump 0.16.7` — likely the squashed commit on the train branch
+- `f0364bc` `fix: Update summarizer prompt to remember plan files, github PRs, etc. (#10314)` — already on main before the train
+
+Wait — the train PR (#3265) merged at 2026-03-31T19:26:39Z. The commits before it on main (`f0364bc` etc.) merged BEFORE that. If the train was a cherry-pick collection, it would duplicate those commits. But it's only 188 files with +13k additions — that's MUCH more than a single fix-PR but MUCH less than 173 commits' worth of new code.
+
+**Alternative interpretation**: The "bump PR" is actually **the boundary** between two release lines. Letta seems to be using a long-lived `bump-16-7` branch where the release work accumulated, and at v0.16.7 cut time they merged it back to main. This is a **release-branch model that hides behind a PR title**. Not as clean as CLEO's explicit `release/v<version>` branches.
+
+**This is a CLEO improvement opportunity**: Letta's release-train PR carries TOO MUCH content for the PR title (`chore: bump 0.16.7`) to communicate accurately. CLEO's `release/v<version>` branches contain only the version bump + CHANGELOG, which is much easier to review.
+
+---
+
+## Phase 7 — Issue Guard (Anti-Spam Pattern, Bonus)
+
+Source: `gh api repos/letta-ai/letta/contents/.github/workflows/issue-guard.yml`:
+
+Letta added an "Issue Guard" workflow in April 2026 (commit `c71353f` "feat: add anti-spam issue guard with AI disclosure policy"). It:
+- Triggers on `issues: types: [opened]`.
+- Reads `.github/TRUSTED_CONTRIBUTORS` allowlist.
+- Skips bots.
+- Checks if author has `write+` permission via `getCollaboratorPermissionLevel`.
+- Validates issue body against compliance rules (rest of the script not fetched, but the pattern is clear).
+
+**Relevance to CLEO**: Not directly part of the release flow, but it's a defense pattern for "untrusted contributor PRs that are obvious AI-generated low-quality submissions." CLEO's IVTR system might want a similar guard on incoming PRs from forks.
+
+---
+
+## Phase 8 — CONTRIBUTING.md and Developer Workflow
+
+Source: `gh api repos/letta-ai/letta/contents/CONTRIBUTING.md` (decoded from base64):
+
+The CONTRIBUTING doc tells contributors to:
+1. Fork the repo.
+2. Set up Postgres with the `letta` role + `letta` database + `pgvector` extension.
+3. `uv sync --all-extras`.
+4. `uv run alembic upgrade head` to seed the schema.
+5. Run pre-commit: `uv run pre-commit install && uv run pre-commit run --all-files`.
+6. Run tests: `uv run pytest -s tests`.
+7. Run black: `uv run black . -l 140`.
+8. Create a feature branch (`git checkout -b feature/your-feature`).
+9. Open a PR to `main`.
+
+**No mention** of:
+- Release process (contributors don't release).
+- Issue linking (no `Closes #XXX` template requirement).
+- Conventional commits (despite the bot using them).
+- Squash vs merge commit policy.
+
+**CLEO advantage**: CLEO has `cleo bug`/`cleo add` task creation with `--acceptance` required, plus the lifecycle gate ladder. Letta's contributor experience is much less structured — the cost of which is borne by maintainers manually curating the merge train.
+
+---
+
+## Phase 9 — Cross-Reference: Letta vs CLEO Posture
+
+| Aspect | Letta server | Letta code (harness) | CLEO (current) | CLEO (T9345 target) |
+|---|---|---|---|---|
+| Version source | `pyproject.toml` + `__init__.py` (manual sync) | `package.json` (single) | `resolveVersionBumpTargets` (auto, 22 targets) | unchanged |
+| Versioning scheme | semver, no `v` prefix | semver, `v`-prefixed | CalVer `v2026.M.N` | unchanged |
+| Release trigger | Manual UI click → `release: published` | Bump-PR merged → `push: main` with paths filter | `cleo release ship <ver>` | unchanged |
+| Pre-publish gates | **None** | lint + typecheck + build + 3 smokes | lint + typecheck + tests + epic check + double-listing | strengthen with integration smoke |
+| Tag placement | Manual, can be wrong commit | Auto on merged main SHA after gates | Auto on main HEAD after PR merge | unchanged |
+| Hotfix model | Just bump patch | Just bump patch | `release/v<ver>` branch + PR | unchanged |
+| Branch protection | Probable (observational) | Probable (observational) | Documented in AGENTS.md | unchanged |
+| PR labels | 28 labels, no release-specific | Not fetched | `cleo release` labels | adopt `release-bump-only` classifier |
+| Provenance | `LET-XXXX (#PR)` manual | Auto-generated PR list | `T#### (#PR)` from CHANGELOG | adopt cross-citation explicitly |
+| Project-agnostic | No | No | Yes (`project-context.json`) | unchanged |
+| Idempotency | None | `tag_exists` + `npm_published` flags | Per AGENTS.md, idempotent tag step | strengthen with npm-published check |
+| Approval gate | None visible | `environment: npm-publish` (likely human-gated) | None | **add GitHub environment with approver** |
+| Multi-archetype | No | No | Yes via `tool:test` resolution | unchanged |
+
+---
+
+## Phase 10 — Concrete Recommendations for CLEO T9345
+
+These are derived directly from the evidence above. Each cites Letta source for the pattern being borrowed (or the gap being avoided).
+
+### 10.1 Adopt the `release-bump-only` classifier (HIGH VALUE, LOW COST)
+
+**Source**: `letta-code/.github/workflows/ci.yml` (Phase 3.4).
+**CLEO implementation**: Add a `classify` job to CLEO's CI workflow that detects PRs whose title matches `^chore: bump version to ` (or CLEO's actual bump title format from `cleo release ship`) AND whose changed file list is a subset of `resolveVersionBumpTargets` output. If both conditions match, skip heavy CI jobs.
+**Estimated impact**: Cuts CI cost on release PRs by ~80% (typical release PR touches only package.jsons + CHANGELOG.md). 22 workspace targets × pnpm build = significant.
+
+### 10.2 Add an integration smoke gate inside `cleo release ship` (HIGH VALUE, MEDIUM COST)
+
+**Source**: `letta-code/.github/workflows/release.yml` "Integration smoke test (real API)" step (Phase 3.4).
+**CLEO implementation**: After step 11 ("Wait for CI green") and before step 12 ("Merge + tag"), add a new step: `cleo orchestrate spawn <smoke-task-id>` against a small ephemeral task, verify the spawn returns within N seconds with `success: true`. Use a test task in a sandbox project to avoid polluting real state.
+**Estimated impact**: Catches "the published artifact doesn't actually run" failures — the worst class of release bug, which currently has no defense in CLEO.
+
+### 10.3 Adopt `T#### (#PR)` cross-citation in CHANGELOG (HIGH VALUE, LOW COST)
+
+**Source**: `letta-ai/letta` release notes for v0.16.7 (Phase 3.5).
+**CLEO implementation**: `cleo release ship` step 6 (CHANGELOG generation) already filters by `completedAt > previousVersion.pushedAt`. Augment it to also fetch the PR number that closed each task (from `cleo task <id>` `closingPr` field if it exists, or by parsing `git log --grep "$taskId"`). Format as `T1234 (#567) — task description`.
+**Estimated impact**: Restores the provenance graph that Letta builds by hand. CLEO can do it automatically because tasks live in `.cleo/tasks.db`.
+
+### 10.4 Add a GitHub Environment gate to npm/Docker publish (HIGH VALUE, LOW COST)
+
+**Source**: `letta-code/release.yml` `environment: npm-publish` (Phase 3.4 inference).
+**CLEO implementation**: Configure a GitHub Environment named e.g. `release-publish` on the cleocode repo with `required_reviewers: [owner]`. Update the GitHub Actions workflow that runs `npm publish` to declare `environment: release-publish`. Optionally add a `wait_timer` of 5 minutes.
+**Estimated impact**: Adds a final human cross-check between "CI green" and "npm package out the door." Defense against compromised release tooling.
+
+### 10.5 Strengthen idempotency flags (MEDIUM VALUE, LOW COST)
+
+**Source**: `letta-code/release.yml` `tag_exists` + `npm_published` flags (Phase 3.4).
+**CLEO implementation**: Per AGENTS.md, CLEO's tag step is already idempotent. Extend to:
+- Check `npm view "@cleocode/cleo@<version>" version` and skip publish if it returns truthy.
+- Check `git tag --list "$TAG"` and skip tag creation if present.
+- Each of these should be a separate evidence gate so a partial-failure rerun doesn't double-publish.
+
+### 10.6 DO NOT copy Letta's `letta` server release pipeline (NEGATIVE LIFT)
+
+**Source**: `letta/poetry-publish.yml` (Phase 3.3).
+**Reasoning**: Zero gates between `release: published` and `uv publish`. CLEO is already ahead of this pattern. If anyone proposes "let's make ship simpler like Letta does it," reject — Letta's server pipeline is a counterexample, not a precedent.
+
+### 10.7 DO NOT adopt Letta's merge-train PR model (NEGATIVE LIFT)
+
+**Source**: PR #3265 `chore: bump 0.16.7` (Phase 6) — 188 files, +13k/−3k.
+**Reasoning**: CLEO's `release/v<version>` branch contains ONLY the version bump and CHANGELOG. This is far cleaner to review than Letta's pattern of conflating "the release boundary" with "merge a giant feature train." Keep CLEO's model.
+
+### 10.8 No Letta precedent for these CLEO needs (research negative)
+
+- **Epic-scoped completeness check** — Letta has no equivalent. CLEO's `--epic <id>` check is novel.
+- **Evidence-atom gates** (ADR-051) — Letta does no evidence enforcement at all.
+- **Project-agnostic tool resolution** — Letta is mono-stack per repo.
+- **Decision-only completion atoms** — Letta does not track decisions formally; no precedent.
+
+---
+
+## Phase 11 — Open Questions / Unverified Claims
+
+Items I could not verify with the evidence I have. Each would require deeper access (admin token, private docs, or paid Letta Cloud account).
+
+1. **Is `letta-code/release.yml`'s `environment: npm-publish` actually gated by a human approver?** I inferred from the environment name but did not confirm. Would need `gh api repos/letta-ai/letta-code/environments/npm-publish` with admin scope. **No evidence found.**
+2. **Does main branch protection on `letta` require status checks before merge?** Returned 404 to my token. Observational evidence (every commit on main has a `(#XXXX)` PR suffix) suggests yes, but I cannot confirm the YAML. **No evidence found.**
+3. **Is the LET-XXXX tracker actually Linear?** Format matches, but no public confirmation. **No evidence found.**
+4. **Does the `release.yml` integration smoke against `LETTA_API_KEY` test self-hosted or cloud?** The secret name implies cloud, but it could be a test instance. **No evidence found.**
+5. **Does Letta have any release-validation test suite that runs post-publish?** I see pre-publish smoke tests but no post-publish "did the new version on PyPI/npm actually install and work?" check. **No evidence found.**
+
+---
+
+## Phase 12 — Source Inventory
+
+Every source consulted, with status:
+
+| URL / API endpoint | Fetched? | Notes |
+|---|---|---|
+| `https://github.com/letta-ai/letta` (README + repo home) | Yes | Confirmed canonical |
+| `https://github.com/letta-ai/letta/releases` | Yes (HTML) | Tag list visible |
+| `gh api repos/letta-ai/letta` | Yes | Metadata |
+| `gh api repos/letta-ai/letta/releases?per_page=15` | Yes | Tag/author/date list |
+| `gh api repos/letta-ai/letta/releases/tags/0.16.8` | Yes | Auto-generated style |
+| `gh api repos/letta-ai/letta/releases/tags/0.16.7` | Yes | Hand-curated style |
+| `gh api repos/letta-ai/letta/releases/tags/0.16.6` | Yes | Categorical style (lighter) |
+| `gh api repos/letta-ai/letta/releases/tags/0.16.0` | Yes | Mixed |
+| `gh api repos/letta-ai/letta/pulls/3265` | Yes | The merge-train PR |
+| `gh api repos/letta-ai/letta/pulls/3265/files` | Yes | 188 files |
+| `gh api repos/letta-ai/letta/commits?per_page=20` | Yes | Commit log |
+| `gh api repos/letta-ai/letta/branches/main/protection` | **404** | Token scope insufficient |
+| `gh api repos/letta-ai/letta/labels?per_page=30` | Yes | 28 labels |
+| `gh api repos/letta-ai/letta/contents/CONTRIBUTING.md` | Yes (base64 decoded) | Contributor workflow |
+| `gh api repos/letta-ai/letta/contents/SECURITY.md` | Yes | Email-to-support security policy |
+| `gh api repos/letta-ai/letta/contents/.github/workflows/poetry-publish.yml` | Yes | The no-gate publish workflow |
+| `gh api repos/letta-ai/letta/contents/.github/workflows/poetry-publish-nightly.yml` | Yes (summary via WebFetch) | Nightly with .dev timestamp |
+| `gh api repos/letta-ai/letta/contents/.github/workflows/docker-image.yml` | Yes | Docker Hub multi-arch |
+| `gh api repos/letta-ai/letta/contents/.github/workflows/core-unit-test.yml` | Yes (summary) | 22 matrix suites |
+| `gh api repos/letta-ai/letta/contents/.github/workflows/core-lint.yml` | Yes (summary) | Pyright + Ruff |
+| `gh api repos/letta-ai/letta/contents/.github/workflows/issue-guard.yml` | Yes (head) | Anti-spam workflow |
+| `gh api repos/letta-ai/letta/contents/.github/workflows/reusable-test-workflow.yml` | Yes (head) | Parameterized reusable |
+| `gh api repos/letta-ai/letta/contents/.github/workflows/fern-sdk-typescript-publish.yml` | Yes | TS SDK release flow |
+| `gh api repos/letta-ai/letta/contents/.github/workflows/fern-sdk-python-publish.yml` | Yes (summary) | Python SDK release flow |
+| `https://github.com/letta-ai/letta/blob/main/pyproject.toml` | Yes (summary) | Version + deps |
+| `https://github.com/letta-ai/letta/blob/main/letta/__init__.py` | Yes (summary) | `__version__` source |
+| `https://github.com/letta-ai/letta/blob/main/.github/release.yml` | **404** | File does NOT exist |
+| `https://github.com/letta-ai/letta/blob/main/CHANGELOG.md` | **404** | File does NOT exist |
+| `https://github.com/letta-ai/letta/tree/main/.github` (file listing) | Yes (partial) | No release-please configs found |
+| `https://github.com/letta-ai/letta-code` (repo home) | Yes | "memory-first coding harness" tagline |
+| `gh api repos/letta-ai/letta-code` | Yes | Metadata |
+| `gh api repos/letta-ai/letta-code/releases?per_page=10` | Yes | `github-actions[bot]` author |
+| `gh api repos/letta-ai/letta-code/releases/tags/v0.25.9` | Yes | Standard PR-list notes |
+| `gh api repos/letta-ai/letta-code/contents/.github/workflows` | Yes | 6 workflow files |
+| `gh api repos/letta-ai/letta-code/contents/.github/workflows/prepare-release.yml` | Yes (full YAML) | Stage 1 of two-stage release |
+| `gh api repos/letta-ai/letta-code/contents/.github/workflows/release.yml` | Yes (full YAML) | Stage 2 with smoke tests |
+| `gh api repos/letta-ai/letta-code/contents/.github/workflows/ci.yml` | Yes (head + classify job) | release-bump-only classifier |
+| `https://docs.letta.com/concepts/letta` | Yes (summary) | "agent harness" terminology |
+| `https://docs.letta.com/concepts/letta-code` | **404** | Slug may differ |
+| `https://docs.letta.com/quickstart` | Yes (summary) | Cloud / self-host distinction |
+| `https://docs.letta.com` (root) | Yes (metadata only) | "memory-first coding agent" |
+
+---
+
+## Phase 13 — Methodology and Self-Critique
+
+**What I did well**:
+- Cited every claim with a URL or `gh api` call.
+- Distinguished between **`letta` server** (anti-pattern, no gates) and **`letta-code` harness** (good pattern with smoke tests) — these are easily conflated.
+- Extracted the full YAML for the two most important workflows (`prepare-release.yml` and `release.yml`) so CLEO maintainers can read them directly.
+- Explicitly flagged 5 items where I could not find evidence rather than inventing.
+
+**Where I would dig further with more time**:
+- Get an admin token to `letta-ai/letta-code` to confirm the `npm-publish` environment's reviewer list. This would change recommendation 10.4 from inference to confirmation.
+- Read more `letta-code` releases (v0.24.x, v0.23.x) to see whether the two-stage pipeline has been stable or evolving.
+- Diff the merge-train PR #3265 commit-by-commit to verify whether it's truly a long-lived branch or a squash bundle.
+- Check Letta's Linear (if accessible) to see how `LET-XXXX` IDs are linked to PRs operationally — there may be a Linear-GitHub integration doing this automatically.
+
+**Confidence levels**:
+- HIGH confidence: All Phase 3.3 and 3.4 facts about workflow YAML content (full verbatim sources captured).
+- HIGH confidence: All Phase 2 architectural facts about the two-repo split.
+- MEDIUM confidence: Phase 6 "merge train" interpretation — I have the file count but did not walk the branch history commit-by-commit.
+- LOW confidence: Phase 5 row #6 (branch protection) — observational evidence only.
+
+---
+
+End of research document. Path:
+`/mnt/projects/cleocode/.cleo/rcasd/T9345/research/letta-harness-real-research.md`

--- a/.cleo/rcasd/T9345/research/migration-plan-T9345.md
+++ b/.cleo/rcasd/T9345/research/migration-plan-T9345.md
@@ -1,0 +1,619 @@
+# Migration Plan — T9345 Release Pipeline v1 → v2
+
+| Field | Value |
+|---|---|
+| **Status** | Proposed |
+| **Date** | 2026-05-15 |
+| **Task** | T9345 (IVTR Release System Overhaul) |
+| **Author** | cleo-prime (system architect) |
+| **Companion artifacts** | `SPEC-T9345-release-pipeline-v2.md`, `test-matrix-T9345.md` |
+| **Source of truth** | `ADR-T9345-ivtr-release-overhaul.md` (Direction B + qualifier) |
+
+---
+
+## Executive Summary
+
+This plan describes how the CLEO codebase moves from the ADR-065 12-step `cleo release ship` monolith (currently shipping every release since v2026.5.43) to the SPEC-T9345 v2 architecture (4 operator verbs + 4 GHA workflows + 11 new provenance tables) **without breaking the next release**. The migration is sequenced as six phases over a maximum of twelve operator-weeks (≈8 calendar weeks with two parallel orchestrators). Each phase has explicit entry criteria, exit criteria, a measurable rollback trigger, and a defined LOC-change budget. Phases 0-2 are additive — they introduce new schema and read-only verbs alongside the legacy monolith with zero behavior change. Phases 3-5 are cutovers where the operator surface flips: Phase 3 introduces `cleo release open` and the prepare workflow opt-in, Phase 4 introduces publish + reconcile workflows, Phase 5 deprecates `cleo release ship` and makes the new path the default. Phase 6 is cleanup — deletion of the 761-line monolith and the parallel 4-step pipeline. The plan also defines a compatibility shim (`cleo release ship --workflow=false`) that preserves the legacy path for emergency use through the third release cycle after Phase 5 completes.
+
+Risk grading is honest: Phases 0-2 and 6 are LOW (additive or post-cutover); Phases 3-4 are MEDIUM (new workflows are load-bearing); Phase 5 is HIGH (operator surface flip). Each high-risk phase has a defined rollback path with exact git/SQL commands and a dogfooded test release on a non-main branch as a phase gate. Eight child epics are pre-decomposed at the bottom of this document (T9346-T9353) so the orchestrator can spawn them in parallel where independent.
+
+The plan binds tightly to `SPEC-T9345-release-pipeline-v2.md`: every phase's deliverables map to a specific subset of normative requirements (R-NNN), every phase's exit criterion is a scenario from `test-matrix-T9345.md`, and every rollback path preserves the legacy `release_manifests` table per Force F12 (backward compatibility). Total LLM spend across the migration is estimated at ~$300; total operator-week cost (orchestrator + human review) is ~12 operator-weeks. The migration ships zero data loss, zero forced downtime on `tasks.db`, and zero release blackouts (the legacy path is available throughout Phases 0-5).
+
+---
+
+## 1. Goal
+
+Move CLEO's release pipeline from the ADR-065 12-step `cleo release ship` monolith to the SPEC-T9345 v2 architecture (4 verbs + 4 GHA workflows + 11 provenance tables) WITHOUT:
+
+1. Breaking the next scheduled release (the migration must allow shipping during itself).
+2. Losing any historical `release_manifests` data (forward-compat per Force F12).
+3. Requiring operators to learn a new mental model overnight (deprecation warnings + 3 release-cycle shim per spec R-430).
+
+Success is defined by the spec's acceptance criteria AC-1 through AC-10. The migration delivers them in measurable increments, one phase at a time.
+
+---
+
+## 2. Phasing
+
+Six phases, each bounded to 2 calendar weeks max. Each row in the table is normative for that phase; deviation requires HITL escalation.
+
+| Phase | Name | Risk | Calendar | LOC delta | Reversibility | Exit gate |
+|---|---|---|---|---|---|---|
+| 0 | Schema migration + dual-write kill-switch | LOW | 1 wk | +400 (DDL + accessors) | trivial revert | Migrations applied; `CLEO_PROVENANCE_DUAL_WRITE=1` (default off) |
+| 1 | `plan` + `reconcile` (read-mostly) | LOW | 2 wks | +700 (new modules) | trivial revert | Both verbs return correct envelopes against test fixtures |
+| 2 | Provenance backfill (`cleo provenance backfill`) | MEDIUM | 2 wks | +400 (backfill writer) | idempotent UPSERT; safe to re-run | Historical releases (v2026.5.0 → v2026.5.74) backfilled with `provenance_quality='inferred'` ≤5% of rows |
+| 3 | `release-prepare.yml` + `open` verb | MEDIUM | 2 wks | +200 + 1 YAML | revertible via PR; legacy path untouched | Test release `v2026.7.0-test-1` shipped on `release-test/T9347` branch through new prepare workflow |
+| 4 | `release-publish.yml` + `release-fanout.yml` + matrix | HIGH | 2 wks | +200 + 2 YAML | revertible via workflow rename + branch reset | Real minor release (target: `v2026.7.0`) ships through new publish path while `cleo release ship` available as `--workflow=false` fallback |
+| 5 | Operator surface flip (`ship` deprecated) | HIGH | 2 wks | -800 (monolith deleted) +200 (shim) | possible via PR revert during transition window | Two consecutive releases ship without invoking `--workflow=false`; deprecation warnings active |
+| 6 | Cleanup | LOW | 1 wk | -1500 net | not reversible; do last | `releaseShip` monolith deleted; IVTR-from-release code removed; CI green; `cleo release --help` shows 4 verbs |
+
+**Total calendar: 12 weeks worst case, 8 weeks with 2 parallel orchestrators (independent child epics run in parallel).**
+
+### 2.1 Phase 0 — Schema migration + dual-write kill-switch (1 week, LOW)
+
+**Scope**:
+- Apply the 9 Drizzle migrations from `provenance-graph-design.md` §4.1 (commits, task_commits, commit_files, pull_requests, pr_commits + pr_tasks, releases, release_changes, release_commits + release_artifacts, task_relations extension, brain_release_links, releases_view).
+- Add `CLEO_PROVENANCE_DUAL_WRITE` env var to the existing `release ship` code path. When `=1`, the legacy step that writes to `release_manifests.tasksJson` ALSO writes to the new `releases` + `release_changes` tables. Default `=0` (no behavior change).
+- Build the AccessorImpl methods (`getReleaseProvenance`, `insertReleaseFromManifest`, etc.) and unit-test against the new tables.
+- Add a `cleo provenance verify <version>` CLI verb that runs invariant checks (§11 of provenance design). Read-only.
+
+**Deliverables**:
+- 9 migration files committed under `packages/core/migrations/drizzle-tasks/`.
+- `packages/core/src/store/release-provenance-accessor.ts` (new file, ~200 LOC).
+- `cleo provenance verify <version>` CLI handler (~50 LOC).
+- 30+ Vitest unit tests covering the new accessors.
+
+**Exit criteria**:
+- All migrations apply cleanly on a fresh-clone `tasks.db`.
+- `cleo provenance verify <version>` returns pass for an empty schema (all checks trivially satisfied).
+- `pnpm run test` green; `pnpm run build` green; `pnpm biome ci .` green.
+- No existing release tests regress (`packages/core/src/release/__tests__/*.test.ts` still pass).
+
+**Rollback trigger**: any migration failure on a real production `tasks.db`. Rollback: `cleo restore backup --file tasks.db --from <pre-migration-snapshot>` (ADR-013 §9 backup/restore).
+
+**Rollback commands**:
+```bash
+# 1. List backups
+cleo backup list
+# 2. Restore pre-migration snapshot
+cleo restore backup --file tasks.db --from tasks-20260520-120000.db
+# 3. Disable the new accessor code paths
+git revert <phase-0-commit-sha>
+```
+
+**Owner approval gate**: T9346 (Phase 0 epic) closed by HITL approval before Phase 1 begins.
+
+### 2.2 Phase 1 — `plan` + `reconcile` (2 weeks, LOW)
+
+**Scope**:
+- Implement `cleo release plan <version> --epic <id>` per SPEC R-020 through R-042. Read-mostly: reads tasks.db, git log, evidence atoms; writes `.cleo/release/<v>.plan.json` + one row in `releases` (status=planned).
+- Implement `cleo release reconcile <version>` per SPEC R-080 through R-113. Reads plan + git log + `gh release view`; writes the 11 provenance tables. Idempotent.
+- Add the 14 read-only verbs from SPEC §4.6 (`cleo release graph/diff/impact/authors/orphans` and `cleo provenance task/commit/pr/feature/release/change/backfill/link/verify`). All LAFS-compliant queries.
+- DO NOT touch `cleo release ship`, `cleo release start`, `cleo release verify`, `cleo release publish`. The legacy code path remains the canonical happy path.
+
+**Deliverables**:
+- `packages/core/src/release/plan.ts` (new, ~250 LOC).
+- `packages/core/src/release/reconcile.ts` (new, ~300 LOC).
+- `packages/core/src/release/provenance-queries.ts` (new, ~250 LOC for the 14 read verbs).
+- Schema for `.cleo/release/<version>.plan.json` (JSON schema file).
+- CLI handlers in `packages/cleo/src/cli/commands/release.ts` and `packages/cleo/src/cli/commands/provenance.ts` (new file).
+- Dispatch domain handlers in `packages/cleo/src/dispatch/domains/release.ts` and `packages/cleo/src/dispatch/domains/provenance.ts` (new).
+- 80+ Vitest unit tests + 6 scenario integration tests from `test-matrix-T9345.md` S1, S4, S8, S9, S11, S12.
+
+**Exit criteria**:
+- `cleo release plan` against the cleocode repo produces a valid plan for a test version (`v2026.7.0-test-1`) without writing any git mutation.
+- `cleo release reconcile` against a manually-shipped test release (`v2026.5.74` historical or fresh `-test-1`) correctly populates all 11 tables; `cleo provenance verify <version>` returns pass.
+- The 14 read verbs all return correct envelopes against fixtures in `test-matrix-T9345.md`.
+- `cleo release ship` continues to work unchanged on a separate branch.
+
+**Rollback trigger**: any of the new verbs corrupts existing `tasks.db` data (caught by invariant checks).
+**Rollback**: `git revert <phase-1-commit-range>`. Schema from Phase 0 stays; verbs disappear.
+
+**Owner approval gate**: T9347 (Phase 1 epic) closed; demo of the 6 scenarios green.
+
+### 2.3 Phase 2 — Provenance backfill (2 weeks, MEDIUM)
+
+**Scope**:
+- Implement `cleo provenance backfill --since <version>` per provenance-graph-design.md §4.4. Walks git log for every historical release, extracts T#### tokens, populates `commits` + `task_commits` + `release_commits` + `release_changes`.
+- Run the backfill across all 70+ historical releases since v2026.4.0.
+- Verify the backfill: for each historical release, the count of tasks in `release_manifests.tasksJson` MUST match the count of `release_changes` rows. Discrepancies are flagged with `provenance_quality='manual_review_required'`.
+
+**Deliverables**:
+- `packages/core/src/release/provenance/backfill.ts` (~300 LOC).
+- A one-shot CLI script `cleo provenance backfill --since v2026.4.0` runnable in CI.
+- A verification query suite (~30 SQL queries) under `packages/core/src/release/provenance/__tests__/backfill.integration.test.ts`.
+- A status report committed to `.cleo/rcasd/T9345/backfill-report.md` listing every historical release + provenance_quality flag.
+
+**Exit criteria**:
+- ≥95% of historical release_changes rows have `provenance_quality='inferred'` (high-confidence extraction).
+- ≤5% have `provenance_quality='manual_review_required'` (ambiguous attribution).
+- Owner triages the manual-review set; each row either resolved or marked as `'lost-to-history'`.
+- Re-running `cleo provenance backfill --since v2026.4.0` is a no-op (UPSERT idempotency proven).
+
+**Rollback trigger**: backfill duplicates rows or corrupts existing data.
+**Rollback**: schema rollback NOT required. The backfilled rows can be deleted with a targeted SQL DELETE:
+```sql
+DELETE FROM release_commits WHERE created_at >= '2026-05-20T00:00:00Z';
+DELETE FROM task_commits WHERE created_at >= '2026-05-20T00:00:00Z' AND link_source = 'backfill';
+-- Repeat for the other 9 tables, scoped by created_at + link_source = 'backfill'.
+```
+Backfill is timestamped + tagged with `link_source='backfill'`; clean deletion is straightforward.
+
+**Owner approval gate**: T9348 (Phase 2 epic) closed; backfill report reviewed.
+
+### 2.4 Phase 3 — `release-prepare.yml` + `open` verb (2 weeks, MEDIUM)
+
+**Scope**:
+- Write `release-prepare.yml` per SPEC §5.1 (R-200 through R-210). Triggers on `workflow_dispatch`. Runs preflight (lint+typecheck+build+test). Bumps version + CHANGELOG. Opens bump-PR.
+- Implement `cleo release open <version>` per SPEC R-050 through R-071. Reads plan file; invokes `gh workflow run`.
+- Test on a non-main branch: cut `release-test/T9349`, set up branch protection mimicking main, dispatch the workflow against `v2026.7.0-test-1`, verify the bump-PR opens correctly with all gates green.
+- Do NOT touch `release-publish.yml` yet; the test release does NOT publish. The bump-PR is reviewed and closed without merge.
+
+**Deliverables**:
+- `.github/workflows/release-prepare.yml` (~150 lines YAML).
+- `packages/core/src/release/open.ts` (new, ~150 LOC).
+- CLI handler + dispatch wiring.
+- `actionlint` job added to PR-required checks.
+- Test scenario S3 (`epic completeness scope confined to --epic`) from `test-matrix-T9345.md` passing.
+
+**Exit criteria**:
+- The test release (`v2026.7.0-test-1`) successfully opens a bump-PR via `cleo release open` driving `release-prepare.yml`.
+- The preflight job catches at least one deliberately-injected failure (forensics F9: a fake esbuild externals drift introduced into a fixture branch; preflight `pnpm run build` MUST catch it).
+- `actionlint` passes on the new workflow.
+- `cleo release ship` continues to function as the canonical happy path.
+
+**Rollback trigger**: the new workflow corrupts the working tree, opens malformed PRs, or leaves the release branch in a half-cut state.
+**Rollback**:
+```bash
+# 1. Rename or delete the workflow to disable it.
+mv .github/workflows/release-prepare.yml .github/workflows/release-prepare.yml.disabled
+# 2. Revert the open verb wiring.
+git revert <phase-3-commit-sha>
+# 3. Manually clean up any orphaned release-test/* branches.
+git push origin --delete release-test/T9349
+```
+
+**Owner approval gate**: T9349 (Phase 3 epic) closed; dogfood demo on `release-test/T9349` green.
+
+### 2.5 Phase 4 — `release-publish.yml` + `release-fanout.yml` (2 weeks, HIGH)
+
+**Scope**:
+- Write `release-publish.yml` per SPEC §5.2 (R-220 through R-235). Triggers on `push: main` + paths filter. Detect phase + build matrix (5 platforms) + publish-and-tag + reconcile.
+- Write `release-fanout.yml` per SPEC §5.3 (R-240 through R-244). Best-effort fanout on `release: published`.
+- Ship one real minor release (target: `v2026.7.0`) through the new path. Operator opt-in: `cleo release ship --workflow=true` (default still legacy).
+- The `--workflow=true` flag invokes `plan + open` internally and waits for the bump-PR; once merged, GHA takes over.
+
+**Deliverables**:
+- `.github/workflows/release-publish.yml` (~200 lines YAML).
+- `.github/workflows/release-fanout.yml` (~80 lines YAML).
+- `--workflow=true|false` flag plumbing in the legacy `cleo release ship` shim (~50 LOC).
+- Scenarios S5 (tag at merge SHA), S6 (hotfix), S7 (resume), S10 (rollback dry-run) passing per `test-matrix-T9345.md`.
+- A documented runbook for operators (operationally short — see §7 below).
+
+**Exit criteria**:
+- `v2026.7.0` ships entirely through the new path with operator wall-time ≤5 minutes (AC-1).
+- `cleo provenance verify v2026.7.0` returns pass (AC-7).
+- Tag `v2026.7.0` lands at `$GITHUB_SHA` of the merged bump-PR (verified via `gh pr view`).
+- Build matrix produces 5 platform artifacts attached to the GitHub Release (T1737 platform coverage AC-4 partial).
+- Failure modes F1, F6 do NOT reproduce on the test release (forensics regression check).
+
+**Rollback trigger**: `v2026.7.0` fails to publish to npm registry, OR the tag lands at the wrong SHA, OR the provenance reconcile fails AND cannot be recovered post-hoc.
+
+**Rollback (half-shipped release scenario)**:
+
+This is the most complex rollback scenario in the migration. Three sub-cases:
+
+**Case A — workflow succeeded but DB writes failed (most likely)**:
+```bash
+# Release shipped; reconcile failed; provenance is partial.
+# 1. Verify the tag is canonical.
+gh release view v2026.7.0
+# 2. Re-run reconcile manually with elevated logging.
+CLEO_DEBUG=1 cleo release reconcile v2026.7.0 --json | tee reconcile-recovery.json
+# 3. If reconcile STILL fails: backfill that single release manually.
+cleo provenance backfill --since v2026.6.99 --only v2026.7.0
+# 4. Update releases.status manually if needed:
+sqlite3 .cleo/tasks.db "UPDATE releases SET status='reconciled', shipped_at=datetime('now') WHERE version='v2026.7.0';"
+# 5. File an issue documenting the partial state for the post-mortem.
+```
+
+**Case B — DB writes succeeded but workflow failed mid-publish (partial registry state)**:
+```bash
+# 1. Inspect which registries succeeded.
+gh release view v2026.7.0 --json assets
+npm view @cleocode/cleo@2026.7.0
+# 2. If npm published but cargo did not: skip cargo (operator decision; not blocker).
+# 3. If npm publish failed AND tag exists: invoke rollback workflow.
+cleo release rollback v2026.7.0 --full --reason "Phase-4 partial publish recovery"
+# 4. Once rollback completes, re-plan + re-open for v2026.7.1.
+cleo release plan v2026.7.1 --epic <id>
+cleo release open v2026.7.1
+```
+
+**Case C — full revert required**:
+```bash
+# 1. Trigger the rollback workflow.
+gh workflow run release-rollback.yml --field version=v2026.7.0 --field mode=full --field reason="Phase-4 cutover failure"
+# 2. Verify the revert PR opens against main.
+gh pr list --state open --label rollback
+# 3. After revert PR merges, confirm the tag is deleted.
+gh release view v2026.7.0  # should fail with "not found"
+# 4. Disable the new workflows.
+mv .github/workflows/release-publish.yml .github/workflows/release-publish.yml.disabled
+mv .github/workflows/release-fanout.yml .github/workflows/release-fanout.yml.disabled
+# 5. Operator falls back to cleo release ship --workflow=false for the next release.
+```
+
+**Owner approval gate**: T9350 (Phase 4 epic) closed; v2026.7.0 shipped clean; rollback path TESTED at least once in dry-run (S10).
+
+### 2.6 Phase 5 — Operator surface flip (2 weeks, HIGH)
+
+**Scope**:
+- Flip the default: `cleo release ship` MUST default to `--workflow=true` (the new path) and MUST print a deprecation warning. `--workflow=false` becomes the documented emergency escape hatch per SPEC R-440.
+- Ship two consecutive real releases through the new path as the default (no operator override).
+- Update the `ct-orchestrator` skill documentation to reference `cleo release plan/open/reconcile` instead of `cleo release ship`.
+- Update `CLAUDE.md` / `AGENTS.md` references throughout the repo (the ADR-073 §"Alignment notes" enumerates files).
+
+**Deliverables**:
+- Deprecation-warning shim in `cleo release ship` handler (~30 LOC).
+- Updated skill docs (`.claude/skills/ct-orchestrator/SKILL.md`, etc.).
+- Two real releases shipped through the new path with `cleo release ship` (which now invokes the new path).
+- Operator survey results: at least 3 operator-week of usage data collected via `.cleo/audit/release-usage.jsonl`.
+
+**Exit criteria**:
+- Two consecutive releases ship green without `--workflow=false` (AC-1, AC-2, AC-3 all measured).
+- Operator-survey responses are favorable (subjective, but threshold: ≥7/10 ease-of-use score from ≥3 operators).
+- `cleo release --help` shows 4 verbs at the top; deprecated verbs are listed with warnings (AC-6).
+- The Phase 4 rollback path is no longer needed; emergency-shim invocation count remains 0 over the 2-week window.
+
+**Rollback trigger**: a release fails through the new default path AND cannot be recovered via the documented runbook within 1 hour.
+
+**Rollback**:
+```bash
+# 1. Revert the default flag flip.
+git revert <phase-5-commit-sha>
+# 2. Restore the legacy default in the shim.
+# (the cleo release ship handler now defaults to --workflow=false)
+git push origin fix/T9345-phase5-rollback
+# 3. Hotfix the immediate release with the legacy path.
+CLEO_RELEASE_EMERGENCY=1 cleo release ship vNEXT --workflow=false --epic T<n>
+```
+
+**Owner approval gate**: T9351 (Phase 5 epic) closed; 2 releases green; emergency shim usage = 0.
+
+### 2.7 Phase 6 — Cleanup (1 week, LOW)
+
+**Scope**:
+- Delete the `releaseShip` monolith (`packages/core/src/release/engine-ops.ts:1105-1866`, 761 LOC).
+- Delete the parallel 4-step pipeline (`packages/core/src/release/pipeline.ts:releaseStart/Verify/Publish/Reconcile`).
+- Delete `engine-ops.ts:releaseGateCheck`, `releaseIvtrAutoSuggest`, `checkIvtrGates`.
+- Delete `release-manifest.ts:runReleaseGates` (replaced by ADR-061).
+- Remove `--force` flag and all references to it from `cleo release *` handlers (R-007).
+- Keep `release-config.ts`, `version-bump.ts`, `changelog-writer.ts`, `github-pr.ts`, `release-manifest.ts:listManifestReleases/showManifestRelease`, `invariants/registry.ts`, `guards.ts` (consumed by the new modules).
+- Delete the `--workflow=false` escape hatch per SPEC R-441. Final deprecation pass on `cleo release ship`.
+
+**Deliverables**:
+- Net code reduction: -1500 LOC.
+- Final `cleo release --help` showing exactly 4 operator verbs.
+- All deprecation warnings removed (the shim is no longer needed).
+
+**Exit criteria**:
+- `pnpm run test` green; `pnpm run build` green; `pnpm biome ci .` green.
+- `gitnexus_query "releaseShip"` returns zero hits (AC-10 partial).
+- `gitnexus_query "task.ivtr_state" --scope release` returns zero hits (AC-10).
+- Total release-pipeline LOC ≤ 1500 (down from ~2300 today).
+
+**Rollback trigger**: a test or production release breaks because a deleted symbol is still referenced.
+**Rollback**: `git revert <phase-6-commit-range>`. The previous phases' code is intact; only the cleanup is rolled back.
+
+**Owner approval gate**: T9353 (Phase 6 epic) closed; final demo of the 4-verb surface; migration complete.
+
+---
+
+## 3. Rollback Path Summary
+
+| From phase | Rollback target | Mechanism | Data loss? | Time-to-rollback |
+|---|---|---|---|---|
+| 0 → pre-migration | pre-migration `tasks.db` | `cleo restore backup --from <snapshot>` | none (additive schema) | <5 min |
+| 1 → 0 | Phase 0 state | `git revert` PR | none | <30 min |
+| 2 → 1 | Phase 1 state | Targeted SQL DELETE (link_source='backfill') | none | <15 min |
+| 3 → 2 | Phase 2 state | Disable workflow + `git revert` PR | none (test-only) | <30 min |
+| 4 → 3 (Case A) | Phase 3 + reconcile recovery | Manual `cleo release reconcile` or backfill | partial provenance | <60 min |
+| 4 → 3 (Case B) | Phase 3 + partial revert | `cleo release rollback --full` | npm/cargo dist-tag deprecated | <90 min |
+| 4 → 3 (Case C) | Phase 3 + full revert | rollback workflow + disable publish workflows | revert PR opened against main | <120 min |
+| 5 → 4 | Phase 4 default | Revert flag flip + hotfix via legacy path | none | <30 min |
+| 6 → 5 | Phase 5 state | `git revert` PR | none (monolith was deleted code) | <60 min |
+
+**Across the entire migration, no historical `release_manifests` data is dropped.** Force F12 is preserved by additivity. The `releases` table sits beside `release_manifests`; both are readable indefinitely.
+
+---
+
+## 4. Compatibility Shim
+
+The `cleo release ship --workflow=false` escape hatch is the only point where v1 and v2 code paths coexist in the same invocation. The shim's lifetime is bounded:
+
+| Phase | Shim status | Default value of `--workflow` |
+|---|---|---|
+| 0-2 | not yet introduced | n/a (legacy path is only path) |
+| 3 | introduced; opt-in only | `false` (legacy) |
+| 4 | available; opt-in | `false` (legacy) |
+| 5 | available; opt-out from new default | `true` (new path) |
+| 6 | REMOVED | n/a (shim gone; only 4 verbs remain) |
+
+- The shim MUST log every `--workflow=false` invocation to `.cleo/audit/release-emergency.jsonl` per SPEC R-441.
+- After Phase 6 + 3 release cycles (per SPEC R-430), the deprecated `cleo release ship` is removed entirely. The deprecation warning text MUST announce the exact removal release.
+
+---
+
+## 5. Data Migration
+
+### 5.1 `release_manifests` legacy rows → `releases` + `release_commits` + `release_artifacts`
+
+The legacy `release_manifests` table has shipped 70+ rows since v2026.4.0. The migration is purely additive:
+
+1. **No `release_manifests` row is mutated.** The legacy table stays read-only after Phase 4.
+2. **`releases` is populated by `cleo provenance backfill`** (Phase 2). Each historical `release_manifests` row gets one corresponding `releases` row, joined by `version`.
+3. **`release_commits` is populated by walking `git log <prev-tag>..<tag>`** for each historical release. Each commit is INSERTed into `commits` (UPSERT keyed on sha), then linked via `release_commits`.
+4. **`release_changes` is populated by extracting `T####` tokens from each commit and joining against `tasks.id`**. Where attribution is ambiguous (multiple tasks in one commit), `provenance_quality='inferred'` is set.
+5. **`release_artifacts` is populated by reading `release_manifests.npmDistTag`** (legacy npm-specific column) plus any per-release `gh release view` data.
+
+The backfill is restartable: every INSERT uses UPSERT semantics (provenance design §4.3). Re-running `cleo provenance backfill --since v2026.4.0` against an already-backfilled DB is a no-op.
+
+### 5.2 IVTR state migration (Phase 6 partial)
+
+- `task.ivtr_state` column is NOT dropped in this migration. It is marked `@deprecated` in the schema and becomes a read-only derived view per SPEC §7.
+- Physical column removal is deferred to T9345-CHILD-4 in a v2027 cleanup epic, AFTER the new path has shipped 6+ months of releases without consulting the column.
+
+### 5.3 `release_manifests.tasksJson` deprecation
+
+- During Phase 0-1, `tasksJson` is dual-written (legacy + new tables) when `CLEO_PROVENANCE_DUAL_WRITE=1`.
+- During Phase 4-5, the new tables become authoritative. CLI commands that read `tasksJson` MUST migrate to reading `release_changes` joined to `tasks`.
+- The legacy column is NEVER dropped during T9345. Removal is deferred to a v2027 cleanup.
+
+---
+
+## 6. Test Coverage Per Phase
+
+Every phase has a defined test scope. The full test matrix lives in `test-matrix-T9345.md`; this section maps phases to scenarios.
+
+| Phase | Required scenarios | Required archetypes | Pass threshold |
+|---|---|---|---|
+| 0 | S0 (schema-only smoke; not in matrix but added in Phase 0) | A1 (monorepo) | all migrations apply |
+| 1 | S1 (happy path read-only), S4 (gate runners), S8 (provenance graph), S9 (orphan detection) | A1, A2 | 4/4 green |
+| 2 | (backfill verification; phase-specific tests) | A1 (cleocode historical) | ≤5% manual_review_required |
+| 3 | S3 (epic completeness scope) | A1, A2 | 2/2 green |
+| 4 | S5 (tag at merge SHA), S6 (hotfix), S7 (resume), S10 (rollback), S11 (single npm lib), S12 (rust crate) | A1, A2, A3 | 6/6 green |
+| 5 | S1 + S2 (wedged-git recovery) + S6 (hotfix MTTR) | A1 | 3/3 green on real production releases |
+| 6 | full matrix (S1-S12) | A1, A2, A3 (+ A4 stretch) | all green |
+
+Phase exits only when its scenarios are green AND its archetype coverage is met.
+
+---
+
+## 7. Operational Runbook
+
+Operators driving the migration use this short runbook. Every step references the verb or workflow defined in SPEC-T9345.
+
+### 7.1 Phase 0-2 operator actions
+
+Mostly automated. The operator's job is to observe and approve.
+
+```bash
+# Monitor migration progress.
+cleo find "T9346" --status in_progress  # Phase 0 epic
+cleo find "T9347" --status in_progress  # Phase 1 epic
+cleo find "T9348" --status in_progress  # Phase 2 epic
+
+# Inspect backfill state after Phase 2 completes.
+cleo provenance verify v2026.5.74  # spot-check most recent release
+sqlite3 .cleo/tasks.db "SELECT version, COUNT(*) FROM release_changes GROUP BY release_id ORDER BY release_id;"
+```
+
+### 7.2 Phase 3-4 operator actions
+
+Test-release-driven. Operator initiates each test release.
+
+```bash
+# Phase 3: dispatch the prepare workflow against a non-main branch.
+git checkout -b release-test/T9349
+git push origin release-test/T9349
+cleo release plan v2026.7.0-test-1 --epic T9349
+cleo release open v2026.7.0-test-1
+# Inspect the bump-PR; close without merging.
+
+# Phase 4: ship the real v2026.7.0 through the new path.
+cleo release plan v2026.7.0 --epic T9349
+cleo release open v2026.7.0
+# Wait for bump-PR review + auto-merge.
+# release-publish.yml runs automatically.
+# Once tagged + reconciled:
+cleo release graph v2026.7.0 --format mermaid > /tmp/v2026.7.0.mmd
+cleo provenance verify v2026.7.0  # MUST return pass
+```
+
+### 7.3 Phase 5 operator actions
+
+Default-flip; operators ship normally with deprecation warnings.
+
+```bash
+# Normal release flow under the new default.
+cleo release ship v2026.7.1 --epic T9351
+# Now prints: "DEPRECATED: 'cleo release ship' will be removed in v2027.1. Use 'cleo release plan/open' instead."
+# Under the hood: invokes plan + open.
+
+# Verify the new path completed cleanly.
+cleo provenance verify v2026.7.1
+```
+
+### 7.4 Phase 6 operator actions
+
+Cleanup verification.
+
+```bash
+# After Phase 6 PR merges:
+cleo release --help  # MUST show exactly 4 operator verbs at the top.
+gitnexus_query "releaseShip"  # MUST return 0 hits (other than the deletion commit).
+gitnexus_query "tool:test" --scope release  # ADR-061 wired in.
+```
+
+### 7.5 What to grep when a phase cutover misbehaves
+
+| Symptom | Where to look | What to grep |
+|---|---|---|
+| Plan file written but missing fields | `.cleo/release/<v>.plan.json` | `jq '. | keys'` against SPEC §6 |
+| Workflow run not triggered | GitHub Actions tab | `gh run list --workflow=release-prepare.yml --limit 5` |
+| Tag at wrong SHA | git + GitHub Release | `git rev-list -n 1 <tag>` vs `gh release view <tag> --json targetCommitish` |
+| Provenance reconcile failed | `.cleo/audit/error.jsonl` | `grep E_PROVENANCE` |
+| Orphan commits in release | release_commits + task_commits | `cleo release orphans <version>` |
+| Backfill ambiguity flagged | release_changes | `SELECT * FROM release_changes WHERE provenance_quality='manual_review_required';` |
+
+### 7.6 Pre-publish sanity SQL (run before each phase cutover)
+
+```sql
+-- Phase 0: confirm schema applied.
+SELECT name FROM sqlite_master WHERE type='table' AND name IN ('commits', 'release_changes', 'releases', 'release_commits', 'release_artifacts', 'pull_requests', 'pr_commits', 'pr_tasks', 'commit_files', 'brain_release_links');
+
+-- Phase 2: confirm backfill volume.
+SELECT version, COUNT(*) AS commit_count FROM release_commits GROUP BY release_id ORDER BY release_id DESC LIMIT 10;
+
+-- Phase 4: confirm reconcile worked.
+SELECT version, status, change_count, bug_count, hotfix_count, breaking_count FROM releases_view ORDER BY shipped_at DESC LIMIT 5;
+```
+
+---
+
+## 8. Child-Epic Decomposition
+
+The migration is delivered as eight child epics filed under T9345. Each epic has a slot, a kind, a size, dependencies, and three top-line acceptance criteria. Orchestrators MAY spawn the independent epics in parallel.
+
+### T9346 — Phase 0: Schema migration + dual-write kill-switch
+
+- **Kind**: work
+- **Size**: small
+- **Priority**: P1
+- **BlockedBy**: (none)
+- **Owner**: orchestrator + worker for schema authoring
+- **Acceptance**:
+  1. All 9 Drizzle migrations apply cleanly on a fresh-clone `tasks.db` and a real production `tasks.db` backup.
+  2. `cleo provenance verify <version>` CLI verb exists and returns pass for an empty schema.
+  3. `CLEO_PROVENANCE_DUAL_WRITE=1` env var causes `cleo release ship` to ALSO write to `releases` + `release_changes` without breaking the legacy `release_manifests.tasksJson` path.
+
+### T9347 — Phase 1: `plan` + `reconcile` (read-mostly)
+
+- **Kind**: work
+- **Size**: medium
+- **Priority**: P1
+- **BlockedBy**: T9346
+- **Owner**: orchestrator + 2 workers (plan, reconcile, tests in parallel)
+- **Acceptance**:
+  1. `cleo release plan v2026.7.0-test-1 --epic T9347` produces a valid plan file conforming to SPEC §6 against the cleocode repo.
+  2. `cleo release reconcile v2026.7.0-test-1` against a hand-prepared test release populates the 11 provenance tables; `cleo provenance verify` passes.
+  3. 14 read verbs (`cleo release graph/diff/impact/authors/orphans` + `cleo provenance task/commit/pr/feature/release/change/backfill/link/verify`) return correct envelopes against `test-matrix-T9345.md` fixtures.
+
+### T9348 — Phase 2: Provenance backfill
+
+- **Kind**: work
+- **Size**: medium
+- **Priority**: P2
+- **BlockedBy**: T9347
+- **Owner**: orchestrator + 1 worker
+- **Acceptance**:
+  1. `cleo provenance backfill --since v2026.4.0` populates `commits`, `task_commits`, `release_commits`, `release_changes`, `release_artifacts`, `pull_requests`, `pr_commits`, `pr_tasks`, `commit_files`, `brain_release_links` for all 70+ historical releases.
+  2. ≥95% of `release_changes` rows have `provenance_quality='inferred'` (high-confidence extraction).
+  3. Re-running the backfill is a verified no-op (UPSERT idempotency proven via integration test).
+
+### T9349 — Phase 3: `release-prepare.yml` + `open` verb
+
+- **Kind**: work
+- **Size**: medium
+- **Priority**: P1
+- **BlockedBy**: T9347
+- **Owner**: orchestrator + 2 workers (workflow YAML, open verb)
+- **Acceptance**:
+  1. `release-prepare.yml` passes `actionlint` and successfully opens a bump-PR for a test release on a non-main branch (`release-test/T9349`).
+  2. `cleo release open <version>` invokes `gh workflow run` and polls until the run reaches in-progress; updates `releases.status='pr-opened'`; emits LAFS envelope with `workflowRunUrl`.
+  3. Test scenario S3 (epic-completeness scope) and S9 (orphan-commit detection) pass on the test fixture.
+
+### T9350 — Phase 4: `release-publish.yml` + `release-fanout.yml` + matrix
+
+- **Kind**: work
+- **Size**: large
+- **Priority**: P1
+- **BlockedBy**: T9349
+- **Owner**: orchestrator + 3 workers (publish, fanout, matrix)
+- **Acceptance**:
+  1. `v2026.7.0` ships entirely through the new path with operator wall-time ≤5 minutes from `cleo release plan` to `cleo provenance verify` passing.
+  2. Build matrix produces 5 platform artifacts (linux-x64/arm64, macos-x64/arm64, windows-x64) attached to the GitHub Release.
+  3. Failure modes F1 (wedged commit), F6 (tag at wrong SHA), F8 (release start no-op) DO NOT reproduce. Verified by injecting F1/F6/F8 conditions on a test branch and confirming the new path catches them.
+
+### T9351 — Phase 5: Operator surface flip + `cleo release ship` deprecation
+
+- **Kind**: work
+- **Size**: small
+- **Priority**: P1
+- **BlockedBy**: T9350
+- **Owner**: orchestrator + 1 worker + docs writer
+- **Acceptance**:
+  1. `cleo release ship` defaults to `--workflow=true`; prints deprecation warning; forwards to `plan + open`.
+  2. Two consecutive real releases (`v2026.7.1` and `v2026.7.2`) ship through the new path with no `--workflow=false` invocations.
+  3. `ct-orchestrator` skill documentation updated; operator survey returns ≥7/10 ease-of-use score from ≥3 operators.
+
+### T9352 — IVTR decoupling from release path (parallel to Phases 3-5)
+
+- **Kind**: work
+- **Size**: small
+- **Priority**: P1
+- **BlockedBy**: T9346 (schema), T9347 (plan)
+- **Owner**: orchestrator + 1 worker
+- **Acceptance**:
+  1. `releaseGateCheck`, `releaseIvtrAutoSuggest`, `checkIvtrGates` removed from `engine-ops.ts` (post Phase 5).
+  2. `task.ivtr_state` marked `@deprecated`; read-only view derived from ADR-051 evidence atoms.
+  3. `cleo orchestrate ivtr --start/--next/--release` deprecated; only `--status` remains as a read-only view.
+
+### T9353 — Phase 6: Cleanup (monolith deletion)
+
+- **Kind**: work
+- **Size**: small
+- **Priority**: P2
+- **BlockedBy**: T9351, T9352
+- **Owner**: orchestrator + 1 worker
+- **Acceptance**:
+  1. `releaseShip` (engine-ops.ts:1105-1866, 761 LOC) deleted.
+  2. Parallel 4-step pipeline (`pipeline.ts:releaseStart/Verify/Publish/Reconcile`) deleted.
+  3. `cleo release --help` shows exactly 4 operator verbs at the top; deprecated verbs removed entirely; net code reduction ≥1500 LOC verified.
+
+---
+
+## 9. Schedule overview
+
+```mermaid
+gantt
+    title T9345 Migration Plan
+    dateFormat YYYY-MM-DD
+    section Phase 0
+    Schema + dual-write     :p0, 2026-05-20, 1w
+    section Phase 1
+    plan + reconcile        :p1, after p0, 2w
+    section Phase 2
+    Backfill                :p2, after p1, 2w
+    section Phase 3
+    prepare + open          :p3, after p2, 2w
+    section Phase 4
+    publish + fanout        :p4, after p3, 2w
+    section Phase 5
+    Operator flip           :p5, after p4, 2w
+    section Phase 6
+    Cleanup                 :p6, after p5, 1w
+    section Parallel
+    T9352 IVTR decouple     :ivtr, after p1, 4w
+```
+
+Parallel orchestrators MAY collapse the timeline:
+- T9348 (backfill) can run in parallel with T9349 (prepare workflow) — neither depends on the other after T9347.
+- T9352 (IVTR decouple) can run in parallel with Phases 3-5.
+
+Best-case calendar (2 parallel orchestrators): **8 weeks**. Worst-case (single sequential orchestrator): **12 weeks**.
+
+---
+
+*End of migration plan — T9345 wave-3 spec artifact.*

--- a/.cleo/rcasd/T9345/research/provenance-graph-design.md
+++ b/.cleo/rcasd/T9345/research/provenance-graph-design.md
@@ -1,0 +1,1340 @@
+# Release-Provenance Graph — Design Spec for T9345
+
+**Epic**: T9345 (IVTR Release System Overhaul)
+**Phase**: Wave-2 RCASD Architecture
+**Author**: cleo-prime (System Architect)
+**Status**: DESIGN — schema, queries, and adapter contracts only. No implementation code yet.
+**Date**: 2026-05-15
+**Wave-1 inputs grounded against**:
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/audit-cleo-release-subcommands.md`
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md`
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/hermes-agent-real-research.md`
+- `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/letta-harness-real-research.md`
+- `/mnt/projects/cleocode/packages/core/src/store/tasks-schema.ts`
+- `/mnt/projects/cleocode/packages/contracts/src/task.ts`
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-053-project-agnostic-release-pipeline.md`
+- `/mnt/projects/cleocode/.cleo/adrs/ADR-065-pr-required-release-flow.md`
+
+---
+
+## Executive Summary
+
+This design closes the **CRITICAL provenance graph gap** identified at
+ivtr-conflation-audit.md:255 ("Provenance graph is implicit and incomplete. No SQL
+view can answer 'Which commits shipped in v1.2.3 and which bugs did they fix?'") and
+delivers the owner's explicit requirement (T9345 goal verbatim): "**a true tracking
+graph of released code**" across features, bugs, hotfixes, epics, tasks, commits, PRs,
+and releases.
+
+**Gap closure — 9 new edges, 1 reclassified taxonomy, 0 lost auditability**:
+1. `task → commit` (new `task_commits` junction; replaces JSON-walk of `tasksJson`)
+2. `commit → release` (new `release_commits` junction; replaces scalar `commitSha`)
+3. `pr → commit` (new `pull_requests` + `pr_commits` tables)
+4. `pr → task` (new `pr_tasks` — derived from PR body `T####` regex + commit-trailers)
+5. `release → change` (new `release_changes` table — classified feature/bug/hotfix/security/breaking payload)
+6. `change → task` (new `release_changes.task_id`)
+7. `commit → file` (new `commit_files` — enables blast-radius + file-author queries)
+8. `release → artifact` (new `release_artifacts` — polymorphic for npm/cargo/docker/binary)
+9. `brain_decision → release` (new `brain_release_links` — closes BRAIN↔release loop)
+
+Plus: extend `TASK_RELATION_TYPES` with `'regresses'`, `'follows-up'`, `'reverts'`,
+`'hotfixes'` (currently only `related|blocks|duplicates|absorbs|fixes|extends|supersedes`
+per tasks-schema.ts:176). Introduce orthogonal `change_type` enum on
+`release_changes` rather than expanding `TaskKind` — preserves backward compat for
+~950 existing rows while making `feature` and `hotfix` first-class at the
+release level.
+
+**CLI surface — 11 new subcommands** under two grouped namespaces (`cleo release
+graph|diff|impact|authors|orphans`, `cleo provenance task|commit|pr|feature|release|change`)
+plus one materialized view `releases_view` that joins everything for read-heavy
+external consumers (e.g. dashboard, docs site, agents).
+
+**Migration safety — zero-downtime claim**: All new tables sit BESIDE the legacy
+`release_manifests.tasksJson` and `release_manifests.commitSha` columns. A
+backfill pass derives new-table content from existing JSON + `git log` walk
+during a single CI step (idempotent — re-runnable). Legacy columns remain
+readable for one full release cycle (~30 days), then deprecate-without-drop.
+No live write path is altered until backfill completes + dual-write integration
+tests pass. The 12-step `release ship` pipeline gains a single new Step 13
+("Record provenance graph") that runs AFTER tag + push — failure here is
+non-fatal for the release and emits a follow-up reconciliation task.
+
+---
+
+## 1. Current State (With Gaps)
+
+### 1.1 Inventory of Provenance-Relevant Tables Today
+
+| Table | What it captures | Provenance edges present | What it MISSES | Joinable in SQL? |
+|-------|------------------|--------------------------|----------------|------------------|
+| `tasks` (tasks-schema.ts:243) | Identity + status + kind/scope/severity + `parentId` (hierarchy edge) + `blockedBy` (soft FK string) + `epicLifecycle` + JSON labels/notes/acceptance/files | parent→child (hierarchy) via `parentId` FK | No commit edge. No release edge. No PR edge. `blockedBy` is **a single string column**, not a table — can't express "blocked by 3 tasks". `epicLifecycle` is also a soft string FK. | Partial — `parentId` is real FK. Everything else is JSON or strings. |
+| `task_relations` (tasks-schema.ts:391) | 7-way typed M:N edge between tasks | `related|blocks|duplicates|absorbs|fixes|extends|supersedes` | No `regresses`. No `follows-up`. No `reverts`. No `hotfixes`. No timestamp. No commit anchor. | Yes (true junction with FKs). |
+| `task_dependencies` (tasks-schema.ts:373) | M:N edge `task → depends_on` | hard dep edge | Duplicates `relates_blocks` semantics; no relation type beyond "depends" | Yes. |
+| `lifecycle_pipelines` (tasks-schema.ts:521) | Per-task pipeline state machine | task↔pipeline (1:1 typically) | Per-stage but not per-release | Yes. |
+| `lifecycle_stages` (tasks-schema.ts:547) | Per-stage metadata (status, evidence, validation) + `outputFile` + `provenanceChainJson` | stage↔pipeline FK | No commit-SHA column. No release-FK. | Yes. |
+| `lifecycle_evidence` (tasks-schema.ts:610) | Per-stage evidence (uri, type=file|url|manifest) | stage↔evidence FK | No commit-SHA atom — only file/url/manifest. | Yes. |
+| `lifecycle_transitions` (tasks-schema.ts:630) | Stage transitions (automatic/manual/forced) | pipeline↔transition FK + from/to stage FKs | No release-FK. No commit anchor. | Yes. |
+| `manifest_entries` (tasks-schema.ts:656) | RCASD provenance per pipeline-stage (title, date, topics, findings, linkedTasksJson) | pipeline↔stage FK, `linkedTasksJson` is JSON | `linkedTasksJson` is JSON; cannot SQL-join from manifests→tasks. | Partial — pipeline/stage FK joinable; tasks via JSON walk only. |
+| `pipeline_manifest` (tasks-schema.ts:684) | Wave-level artifact (type, content, hash) bound to session/task/epic | session↔task↔epic FKs (set null on delete) | No release FK. No commit FK. | Yes (3 FKs). |
+| `release_manifests` (tasks-schema.ts:713) | The release record itself (version, status, epicId, **tasksJson** [denormalized], changelog, **commitSha** [scalar], gitTag, npmDistTag, lifecycle timestamps) | release↔epic FK + release↔pipeline FK | `tasksJson` is a JSON blob of task IDs — **NOT a junction table**. `commitSha` is a **scalar string** — captures the release commit but not the commits that shipped IN the release. No PR linkage. No author roll-up. No artifact polymorphism (`npmDistTag` is hardcoded npm-shaped). | Partial — only `epicId` and `pipelineId` are FKs; everything else is opaque JSON or strings. |
+| `audit_log` (tasks-schema.ts:758) | Every mutate-domain operation with before/after JSON + actor + session_id + project_hash | task↔session FK | No release_id FK — audit-log entries about a release scatter across operations. | Yes (FKs work; project_hash filters). |
+| `architecture_decisions` (tasks-schema.ts:848) | ADRs with supersedes/superseded/amends/file_path | ADR↔ADR self-FK (supersedes/amends) + ADR↔manifest FK | No release-FK. ADR acceptance shipped in release X is not queryable. | Yes. |
+| `brain_decisions` (memory-schema.ts:155) | BRAIN decisions with `contextEpicId`, `contextTaskId`, `contextPhase`, `adrNumber`, `adrPath`, `peerId`, `peerScope` | task↔decision soft FKs (string columns, not REFERENCES) | No release-FK. "Which decisions shipped in v2026.5.74?" is unanswerable. | No — soft FKs are TEXT, no REFERENCES. |
+| `external_task_links` (tasks-schema.ts:941) | CLEO task ↔ external provider task (Linear/Jira/GitHub) | task↔external FK | No release-FK. No commit-FK. Cannot answer "which Linear issues shipped in v2026.5.74?" | Yes (real FK to tasks). |
+
+### 1.2 What the Owner Specifically Asked For — Mapped to Current Gaps
+
+> Owner verbatim: "*the scope of tracking releases is wider then just a release but knowing Features, bugs, hotfixes and full provenance from start to finish seeing full connections across Epics and tasks and evolutions creating a true tracking graph of released code*"
+
+| Owner concept | Current storage | Gap severity |
+|---------------|-----------------|--------------|
+| **Features** | `tasks.kind='work'` (no first-class feature kind); features tracked as epics or by label/title convention | HIGH — `feature` is implicit. No way to roll up "all features in 2026.5.x". |
+| **Bugs** | `tasks.kind='bug'` (first-class enum value, present in TASK_KINDS at tasks-schema.ts:99) | LOW — kind exists; missing is release linkage. |
+| **Hotfixes** | No first-class kind. Hotfixes are encoded as `tasks.kind='bug' + severity='P0'` shipped between regular releases — a **convention, not a constraint**. | HIGH — invisible to SQL. Cannot answer "list all hotfixes after v2026.5.73 before v2026.5.74". |
+| **Full provenance** | Implicit via JSON walks (`release_manifests.tasksJson`, `tasks.ivtrState.phaseHistory[].evidenceRefs[]`) | **CRITICAL** — Audit doc Phase 4 §Q4 says: "**Graph is implicit and incomplete**. No SQL can answer: 'List all tasks that shipped in this release.'" |
+| **Connections across Epics and tasks and evolutions** | `tasks.parentId` (hierarchy) + `task_relations` (7-way M:N) | MEDIUM — hierarchy works; evolutions (supersedes/regresses/follows-up) underspecified. Missing `regresses`/`reverts`/`hotfixes` edges. |
+| **Tracking graph of released code** | No `commits` table. No `pull_requests` table. No materialized join view. | **CRITICAL** — three CORE tables missing entirely. |
+
+### 1.3 Concrete Query That Fails Today
+
+The owner's mental model fails on this trivial query:
+
+```sql
+-- "What bugs shipped in v2026.5.74?"
+SELECT t.id, t.title
+FROM release_manifests r
+JOIN ???                 -- no junction; tasksJson is JSON blob, not table
+  ON r.id = ???.release_id
+JOIN tasks t ON t.id = ???.task_id
+WHERE r.version = 'v2026.5.74' AND t.kind = 'bug';
+```
+
+There is no syntactically valid SQL that answers this without `json_each(r.tasksJson)`,
+which (a) requires SQLite JSON1 extension and (b) is O(N) for every release we want
+to scan. Even with JSON1, you cannot index a JSON-array membership query — meaning
+"which releases shipped task T9344?" is a full table scan over every release in
+history.
+
+---
+
+## 2. Gap Analysis: Taxonomy — Feature, Bug, Hotfix as First-Class
+
+### 2.1 The Question
+
+`TaskKind` today (tasks-schema.ts:99 / contracts/task.ts:57):
+
+```typescript
+export const TASK_KINDS = ['work', 'research', 'experiment', 'bug', 'spike', 'release'] as const;
+export type TaskKind = 'work' | 'research' | 'experiment' | 'bug' | 'spike' | 'release';
+```
+
+Missing canonical kinds:
+- `feature` — a new user-visible capability
+- `hotfix` — an emergency patch shipped outside the regular release cadence
+- `enhancement` — improving an existing feature (non-bug, non-new)
+- `refactor` — internal restructure (no user-visible change)
+- `chore` — tooling/build/CI
+- `docs` — documentation only
+- `security` — security fix (orthogonal severity? or kind?)
+
+### 2.2 Two Design Options
+
+**Option A — Expand `TaskKind`**:
+
+```typescript
+export const TASK_KINDS = [
+  'work', 'feature', 'enhancement', 'bug', 'hotfix', 'security',
+  'refactor', 'chore', 'docs', 'research', 'experiment', 'spike', 'release'
+] as const;
+```
+
+Pros:
+- Single enum, simple model.
+- Direct mapping to Conventional Commits prefixes (feat/fix/chore/docs/refactor/etc.) per Hermes pattern (hermes-agent-real-research.md:398).
+
+Cons:
+- **Backward incompat at the data layer**: 950+ existing rows are `kind='work'` and would need bulk reclassification. Every reclassification is **owner-signed** per T944/T9073 (severity is OWNER-WRITE-ONLY for prompt-injection safety; kind is not yet but should follow the same pattern for `hotfix`/`security`).
+- Tight coupling: A task could conceivably be both "feature" AND "hotfix" (you can hotfix a feature you just shipped). Single-kind model can't express dual-role.
+- `hotfix` is really a **release classifier**, not a task classifier. A `bug` becomes a `hotfix` by virtue of being shipped between regular releases — the kind didn't change, the **release packaging** changed.
+
+**Option B (RECOMMENDED) — Keep `TaskKind` minimal + add orthogonal `change_type` at the release-changes layer**:
+
+```typescript
+// tasks.kind stays as-is (work/research/experiment/bug/spike/release)
+// Plus one extension: add 'feature' to TaskKind for first-class feature tracking.
+export const TASK_KINDS = [
+  'work', 'feature', 'research', 'experiment', 'bug', 'spike', 'release'
+] as const;
+
+// NEW: orthogonal change_type at the release level
+export const CHANGE_TYPES = [
+  'feature',       // new user-visible capability
+  'enhancement',   // improving an existing feature
+  'bug',           // bug fix
+  'hotfix',        // emergency bug fix shipped out-of-band
+  'security',      // security patch (often a hotfix)
+  'breaking',      // breaking API change
+  'refactor',      // internal restructure
+  'docs',          // documentation only
+  'chore',         // tooling, build, CI
+  'deprecation',   // deprecating a feature
+  'revert',        // reverting a prior change
+  'performance'    // perf optimization
+] as const;
+```
+
+The `change_type` lives on the **new `release_changes` table** (defined in §3.6), not on `tasks`. A single task can produce multiple `release_changes` rows across multiple releases (a feature task introduced in v1, enhanced in v2, hotfixed in v3 — three change rows, one task).
+
+**Why this is the correct factoring**:
+
+| Justification | Evidence |
+|---------------|----------|
+| **A `hotfix` is a packaging decision, not a work decision** | The task `T9344` (Anthropic OAuth hotfix) recorded in MEMORY.md is `kind='bug'` shipped as a `change_type='hotfix'` because it landed in v2026.5.74 (out-of-band patch on top of v2026.5.73). The work didn't change; the release framing did. |
+| **Same task can ship as different change_types over time** | A `feature` shipped in v1 → enhanced in v2 → security-patched in v3 = 1 task, 3 release_changes rows. Modeling on `tasks.kind` forces lossy compression. |
+| **Conventional Commits already lives at commit/PR level, not task level** | Hermes pattern (hermes-agent-real-research.md:398) parses CC prefixes from commit subjects, not task records. CLEO should classify at the commit-aggregation point (release_changes), not retroactively on tasks. |
+| **Owner-write safety scales** | `change_type` is auto-derived from CC prefix + per-task heuristic; agent-writable. `tasks.kind` carries owner-signed severity binding and cannot be auto-changed. Decoupling = agent can classify a change without touching `tasks.kind`. |
+| **Backward compat is preserved** | Adding `'feature'` to TASK_KINDS is one new enum value (~zero migration cost — defaulted via heuristic on existing data). Adding `change_type` as a brand-new table is **zero impact** on existing rows. |
+
+### 2.3 The Decision
+
+**Adopt Option B**. Concretely:
+
+1. Add `'feature'` to `TASK_KINDS` (single new enum value; backfill heuristic: epics with title containing "feature" or `acceptance` listing >1 user-visible behavior).
+2. Add new `CHANGE_TYPES` enum at the release level (12 values, broad coverage).
+3. Hotfix detection is **derived** at write-time: a `release_changes` row inherits `change_type='hotfix'` when (a) the underlying task has `severity IN ('P0','P1')` AND (b) the release shipping it was published <72h after the prior release AND (c) the release branch was `hotfix/*` OR the version skip-bumped (e.g. v2026.5.73 → v2026.5.74 with no intermediate work).
+
+Example walk-through for T9344 (Anthropic OAuth hotfix, MEMORY.md):
+
+```
+T9344 (kind='bug', severity='P0', shipped 2026-05-14)
+  ↓ shipped in v2026.5.74 (which followed v2026.5.73 by ~24h, on branch fix/T9344-anthropic-oauth-correct-redirect-uri)
+  ↓ creates release_changes row: { release_id='v2026.5.74', task_id='T9344', change_type='hotfix', cc_type='fix', breaking=0 }
+```
+
+The same task in a different release context could yield `change_type='bug'` (regular patch) without changing `tasks.kind`.
+
+---
+
+## 3. New Tables — Proposed Schema
+
+All DDL is valid SQLite (no PG-isms; no `BOOLEAN`, no `TIMESTAMP`, no `UUID`,
+no `JSONB`). Booleans are `INTEGER NOT NULL DEFAULT 0` (idiomatic SQLite).
+JSON columns are `TEXT NOT NULL DEFAULT '{}'`. Timestamps are `TEXT` in
+ISO-8601 (matches existing convention in tasks-schema.ts:297).
+
+### 3.1 `commits` — Every git commit reachable from a release tag
+
+```sql
+CREATE TABLE commits (
+  sha                TEXT PRIMARY KEY,
+  short_sha          TEXT NOT NULL,                  -- first 7 chars
+  author_name        TEXT,
+  author_email       TEXT,
+  authored_at        TEXT NOT NULL,                   -- ISO-8601
+  committer_name     TEXT,
+  committer_email    TEXT,
+  committed_at       TEXT NOT NULL,
+  message            TEXT NOT NULL,                   -- full message body
+  subject            TEXT NOT NULL,                   -- first line only
+  conventional_type  TEXT,                            -- feat|fix|chore|docs|refactor|test|build|ci|perf|revert|breaking|null
+  conventional_scope TEXT,                            -- the (scope) in feat(scope): subject
+  is_release_commit  INTEGER NOT NULL DEFAULT 0,      -- "chore(release): vX.Y.Z" pattern
+  is_merge_commit    INTEGER NOT NULL DEFAULT 0,      -- has multiple parents
+  is_revert          INTEGER NOT NULL DEFAULT 0,      -- starts with "Revert " or has Revert trailer
+  parent_shas        TEXT NOT NULL DEFAULT '[]',      -- JSON array of SHA strings
+  signature_verified INTEGER,                         -- 0=no, 1=yes, NULL=not checked
+  branch_at_commit   TEXT,                            -- best-effort; what branch was HEAD on at commit time
+  project_hash       TEXT,                            -- for multi-repo CLEO installs (matches audit_log.project_hash)
+  trailers_json      TEXT NOT NULL DEFAULT '{}',      -- {"Co-authored-by":[...], "Signed-off-by":[...], etc.}
+  ingested_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_commits_short_sha ON commits(short_sha);
+CREATE INDEX idx_commits_author_email ON commits(author_email);
+CREATE INDEX idx_commits_authored_at ON commits(authored_at);
+CREATE INDEX idx_commits_conventional_type ON commits(conventional_type);
+CREATE INDEX idx_commits_is_release_commit ON commits(is_release_commit);
+CREATE INDEX idx_commits_project_hash ON commits(project_hash);
+```
+
+**Edge captured**: commit identity + author attribution + Conventional Commits classification. Backed by Hermes pattern (hermes-agent-real-research.md:226–238 — `git log --no-merges --format='%H|%an|%ae|%s\0%b\0'`) and Letta pattern (letta-harness-real-research.md:29 — `LET-XXXX (#PR)` cross-citation needs commit table to anchor).
+
+**Why `parent_shas` is JSON not a separate table**: Most commits have 1–2 parents (linear OR merge). Querying parents-of-parent walks is a graph problem better served by recursive CTE; storing parent SHAs inline avoids a third level of join for the common case.
+
+**Why no `branch` table**: Branches are ephemeral — tracking historical branch state is a separate problem (`git reflog` territory). `branch_at_commit` is best-effort and may be NULL.
+
+### 3.2 `task_commits` — M:N edge (task ↔ commit)
+
+```sql
+CREATE TABLE task_commits (
+  task_id           TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  commit_sha        TEXT NOT NULL REFERENCES commits(sha) ON DELETE CASCADE,
+  link_source       TEXT NOT NULL,                   -- 'commit-trailer'|'commit-message'|'pr-body'|'manual'|'manifest'
+  link_evidence     TEXT,                             -- e.g. the matched substring "T9344"
+  is_primary        INTEGER NOT NULL DEFAULT 0,       -- 1 = canonical commit that "implements" task; 0 = supporting
+  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  created_by        TEXT,                              -- agent or 'system' (auto-extract)
+  PRIMARY KEY (task_id, commit_sha)
+);
+
+CREATE INDEX idx_task_commits_commit_sha ON task_commits(commit_sha);
+CREATE INDEX idx_task_commits_link_source ON task_commits(link_source);
+CREATE INDEX idx_task_commits_task_primary ON task_commits(task_id, is_primary);
+```
+
+**Edge captured**: task → commit (M:N). A task can have many commits (initial impl + fix-up); a commit can serve many tasks (the `T9344, T9345` shorthand in MEMORY.md observation #164 → both linked to PR #164's merge commit).
+
+**Why `link_source`**: provenance of the link itself. Owner needs to know whether a task↔commit link came from a `T####` regex hit in commit subject (high confidence), a PR body mention (medium), a manifest write (highest), or a manual `cleo provenance link` call (auditable). Letta pattern recap (letta-harness-real-research.md:33): cross-citation `LET-XXXX (#PR)` happens both in commit subjects AND PR descriptions — different sources, both valid.
+
+**Why `is_primary`**: One task may have 10 commits during dev but only 1 "ships it" (the merge commit on main). Flagging it lets `cleo provenance task <id>` highlight the canonical SHA without listing every WIP commit. Heuristic: the merge commit linked via PR is primary; lone commits to feature branches are not.
+
+### 3.3 `commit_files` — Per-file × SHA edge (enables blast-radius)
+
+```sql
+CREATE TABLE commit_files (
+  commit_sha   TEXT NOT NULL REFERENCES commits(sha) ON DELETE CASCADE,
+  file_path    TEXT NOT NULL,                        -- canonical repo-relative path
+  change_type  TEXT NOT NULL,                        -- 'added'|'modified'|'deleted'|'renamed'|'copied'
+  old_path     TEXT,                                  -- non-null only for rename/copy
+  additions    INTEGER NOT NULL DEFAULT 0,
+  deletions    INTEGER NOT NULL DEFAULT 0,
+  is_binary    INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (commit_sha, file_path)
+);
+
+CREATE INDEX idx_commit_files_file_path ON commit_files(file_path);
+CREATE INDEX idx_commit_files_change_type ON commit_files(change_type);
+```
+
+**Edge captured**: commit → file. Powers:
+- `gitnexus_impact` (CLAUDE.md mentions) gets first-class data for "which tasks last touched packages/core/src/release/engine-ops.ts"
+- `commit_files JOIN task_commits` answers "who edited this file in v2026.5.74?"
+- Diff-by-file for `cleo release diff <v1> <v2>`
+
+**Why not derive on-demand from `git log`**: Each query against git is ~100–500ms cold. Materializing the file-edit graph in SQLite means O(log N) lookups. Storage cost is modest: ~50 chars/path × ~30 files/commit × ~10k commits = ~15 MB per project.
+
+### 3.4 `pull_requests` — PR metadata
+
+```sql
+CREATE TABLE pull_requests (
+  id              TEXT PRIMARY KEY,                  -- canonical: "<repo_owner>/<repo_name>#<number>"
+  repo_owner      TEXT NOT NULL,
+  repo_name       TEXT NOT NULL,
+  number          INTEGER NOT NULL,
+  title           TEXT NOT NULL,
+  body            TEXT,                                -- markdown body
+  state           TEXT NOT NULL,                       -- 'open'|'closed'|'merged'
+  is_draft        INTEGER NOT NULL DEFAULT 0,
+  base_branch     TEXT NOT NULL,                       -- e.g. 'main'
+  head_branch     TEXT NOT NULL,                       -- e.g. 'release/v2026.5.74'
+  base_sha        TEXT,                                -- target branch SHA at merge time
+  head_sha        TEXT NOT NULL,                       -- PR HEAD at merge time
+  merge_commit_sha TEXT,                                -- the actual merge commit (NULL if not merged)
+  author_login    TEXT,                                -- GitHub login
+  author_email    TEXT,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT,
+  closed_at       TEXT,
+  merged_at       TEXT,                                -- NULL if not merged
+  merged_by_login TEXT,
+  ci_status       TEXT,                                -- 'pending'|'success'|'failure'|'error'|null
+  ci_checks_json  TEXT NOT NULL DEFAULT '[]',          -- snapshot of `gh pr checks` JSON
+  labels_json     TEXT NOT NULL DEFAULT '[]',
+  project_hash    TEXT,
+  ingested_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (repo_owner, repo_name, number)
+);
+
+CREATE INDEX idx_pull_requests_state ON pull_requests(state);
+CREATE INDEX idx_pull_requests_merge_commit_sha ON pull_requests(merge_commit_sha);
+CREATE INDEX idx_pull_requests_head_branch ON pull_requests(head_branch);
+CREATE INDEX idx_pull_requests_merged_at ON pull_requests(merged_at);
+CREATE INDEX idx_pull_requests_author_login ON pull_requests(author_login);
+CREATE INDEX idx_pull_requests_project_hash ON pull_requests(project_hash);
+```
+
+**Edge captured**: PR identity + lifecycle + CI state. Required for ADR-065's PR-required flow — the `gh pr checks` output (engine-ops.ts mentions `releasePrStatus`) is currently transient JSON; persisting it as `ci_checks_json` snapshot at merge time gives an audit trail.
+
+**Why ID format `<owner>/<repo>#<number>`**: PR numbers collide across forks. The canonical PR identifier in GitHub's API is `<owner>/<repo>#<n>` — using this as PK avoids collision in multi-repo CLEO installs.
+
+### 3.5 `pr_commits` and `pr_tasks` — PR junction tables
+
+```sql
+CREATE TABLE pr_commits (
+  pr_id        TEXT NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
+  commit_sha   TEXT NOT NULL REFERENCES commits(sha) ON DELETE CASCADE,
+  position     INTEGER NOT NULL,                       -- order in PR
+  PRIMARY KEY (pr_id, commit_sha)
+);
+
+CREATE INDEX idx_pr_commits_commit_sha ON pr_commits(commit_sha);
+
+CREATE TABLE pr_tasks (
+  pr_id          TEXT NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
+  task_id        TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  link_source    TEXT NOT NULL,                        -- 'pr-title'|'pr-body'|'branch-name'|'commit-trailer'|'manual'
+  link_evidence  TEXT,                                 -- the matched substring/regex hit
+  PRIMARY KEY (pr_id, task_id)
+);
+
+CREATE INDEX idx_pr_tasks_task_id ON pr_tasks(task_id);
+CREATE INDEX idx_pr_tasks_link_source ON pr_tasks(link_source);
+```
+
+**Edge captured**: pr↔commit (ordered) and pr↔task (typed). The `pr_tasks.link_source` matches `task_commits.link_source` taxonomy for symmetry.
+
+### 3.6 `releases` — Normalized release record (separate from `release_manifests`)
+
+```sql
+CREATE TABLE releases (
+  id                 TEXT PRIMARY KEY,                -- canonical: 'rel_<version>' or UUID
+  version            TEXT NOT NULL UNIQUE,            -- 'v2026.5.74'
+  channel            TEXT NOT NULL DEFAULT 'latest',  -- 'latest'|'beta'|'alpha'|'rc'
+  status             TEXT NOT NULL,                   -- 'draft'|'prepared'|'committed'|'tagged'|'shipped'|'rolled_back'|'cancelled'
+  release_kind       TEXT NOT NULL DEFAULT 'regular', -- 'regular'|'hotfix'|'major'|'minor'|'patch'|'prerelease'
+  manifest_id        TEXT REFERENCES release_manifests(id) ON DELETE SET NULL,
+  epic_id            TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+  previous_version   TEXT,                            -- 'v2026.5.73' (denormalized for fast prior-walks)
+  previous_release_id TEXT REFERENCES releases(id) ON DELETE SET NULL,
+  pr_id              TEXT REFERENCES pull_requests(id) ON DELETE SET NULL,
+  release_commit_sha TEXT REFERENCES commits(sha) ON DELETE SET NULL,
+  tag_name           TEXT,                             -- 'v2026.5.74' (matches git tag)
+  tag_sha            TEXT,                             -- what the tag actually points at
+  changelog_md       TEXT,                             -- final rendered markdown
+  notes              TEXT,                             -- release notes (separate from changelog)
+  prepared_at        TEXT,
+  shipped_at         TEXT,                             -- when it went out
+  rolled_back_at     TEXT,
+  rolled_back_reason TEXT,
+  project_hash       TEXT,
+  created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+  created_by         TEXT
+);
+
+CREATE INDEX idx_releases_version ON releases(version);
+CREATE INDEX idx_releases_status ON releases(status);
+CREATE INDEX idx_releases_channel ON releases(channel);
+CREATE INDEX idx_releases_release_kind ON releases(release_kind);
+CREATE INDEX idx_releases_shipped_at ON releases(shipped_at);
+CREATE INDEX idx_releases_previous_release_id ON releases(previous_release_id);
+CREATE INDEX idx_releases_project_hash ON releases(project_hash);
+```
+
+**Why a new table alongside `release_manifests`**: Audit doc (audit-cleo-release-subcommands.md:395–407) shows the existing table mixes `draft → prepared → committed → tagged → pushed → rolled_back` states with `tasksJson` (denormalized) and `commitSha` (scalar). The new `releases` table is the **normalized fact**; the legacy `release_manifests` row stays as the "draft scratchpad" for in-flight pipeline state. After ship, the canonical `releases` row is the source of truth; the manifest can be pruned or kept as audit trail.
+
+**Why `release_kind` separate from `change_type` (in §3.7)**: `release_kind` describes the whole release; `change_type` describes individual changes WITHIN a release. A `release_kind='hotfix'` would typically have most or all `release_changes.change_type='hotfix'`, but you can technically ship a hotfix that bundles 1 hotfix + 1 docs change.
+
+### 3.7 `release_changes` — Classified, per-task change payload
+
+```sql
+CREATE TABLE release_changes (
+  id              TEXT PRIMARY KEY,                  -- UUID
+  release_id      TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+  task_id         TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+  pr_id           TEXT REFERENCES pull_requests(id) ON DELETE SET NULL,
+  primary_commit_sha TEXT REFERENCES commits(sha) ON DELETE SET NULL,
+  change_type     TEXT NOT NULL,                     -- enum CHANGE_TYPES (see §2.2)
+  cc_type         TEXT,                              -- Conventional Commits type (feat|fix|...)
+  cc_scope        TEXT,                              -- Conventional Commits scope
+  is_breaking     INTEGER NOT NULL DEFAULT 0,        -- BREAKING CHANGE detected
+  is_security     INTEGER NOT NULL DEFAULT 0,        -- security flag
+  severity        TEXT,                              -- inherited from task: P0|P1|P2|P3|null
+  summary         TEXT NOT NULL,                     -- one-line; renders into CHANGELOG
+  description     TEXT,                              -- multi-line detail
+  rendered_md     TEXT,                              -- final rendered markdown for this change
+  position        INTEGER NOT NULL DEFAULT 0,        -- order in CHANGELOG section
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_release_changes_release_id ON release_changes(release_id);
+CREATE INDEX idx_release_changes_task_id ON release_changes(task_id);
+CREATE INDEX idx_release_changes_change_type ON release_changes(change_type);
+CREATE INDEX idx_release_changes_is_breaking ON release_changes(is_breaking);
+CREATE INDEX idx_release_changes_is_security ON release_changes(is_security);
+CREATE INDEX idx_release_changes_severity ON release_changes(severity);
+CREATE INDEX idx_release_changes_release_position ON release_changes(release_id, position);
+```
+
+**Edge captured**: This is the **rendering layer** between raw release artifacts (commits, PRs, tasks) and the user-facing CHANGELOG. Each row corresponds to one bullet in the rendered CHANGELOG. A release with 10 features + 3 bugfixes + 1 breaking change has 14 rows here.
+
+**Why both `change_type` (CLEO taxonomy) and `cc_type` (Conventional Commits)**: CLEO classification is editorial (owner-facing, 12 values); CC type is mechanical (extracted from commit subject). Storing both lets you query "all rows where cc_type='feat' but change_type='hotfix'" — i.e., a commit prefixed `feat:` that the owner reclassified as a hotfix. They diverge in real life: T9344 (Anthropic OAuth fix) has cc_type='fix' but change_type='hotfix' (per release packaging).
+
+### 3.8 `release_commits` — Commits in this release range
+
+```sql
+CREATE TABLE release_commits (
+  release_id   TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+  commit_sha   TEXT NOT NULL REFERENCES commits(sha) ON DELETE CASCADE,
+  position     INTEGER NOT NULL,                       -- topo order from `git log <prev>..<tag>`
+  is_first     INTEGER NOT NULL DEFAULT 0,             -- first commit after previous release
+  is_last      INTEGER NOT NULL DEFAULT 0,             -- the tag commit
+  is_release_chore INTEGER NOT NULL DEFAULT 0,         -- "chore(release): v..." version-bump commit
+  PRIMARY KEY (release_id, commit_sha)
+);
+
+CREATE INDEX idx_release_commits_commit_sha ON release_commits(commit_sha);
+CREATE INDEX idx_release_commits_position ON release_commits(release_id, position);
+```
+
+**Edge captured**: which commits are *contained* in a release. Derived from `git log <previous_version>..<tag_name>` at ship time. Persisted for query speed.
+
+### 3.9 `release_artifacts` — Polymorphic artifact registry
+
+```sql
+CREATE TABLE release_artifacts (
+  release_id    TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+  artifact_type TEXT NOT NULL,                       -- 'npm'|'cargo'|'docker'|'github-release'|'pypi'|'binary'|'gem'|'maven'
+  identifier    TEXT NOT NULL,                       -- '@cleocode/cleo' for npm; 'cleo-core' for cargo; etc.
+  version       TEXT NOT NULL,                        -- artifact-specific version
+  url           TEXT,                                  -- registry URL
+  digest        TEXT,                                  -- sha256 or similar
+  signature     TEXT,                                  -- gpg/sigstore signature (optional)
+  published_at  TEXT,
+  metadata_json TEXT NOT NULL DEFAULT '{}',           -- type-specific extras (e.g. {"dist-tag":"latest","provenance":true})
+  PRIMARY KEY (release_id, artifact_type, identifier)
+);
+
+CREATE INDEX idx_release_artifacts_artifact_type ON release_artifacts(artifact_type);
+CREATE INDEX idx_release_artifacts_identifier ON release_artifacts(identifier);
+```
+
+**Edge captured**: 1 release → N artifacts (a monorepo release publishes 22 npm packages + maybe 1 cargo crate + 1 docker image — that's 24 artifact rows for 1 release row). See §7 for multi-archetype portability.
+
+### 3.10 `task_relations` extension — typed-graph evolution edges
+
+The existing `task_relations` (tasks-schema.ts:391) already supports `related|blocks|duplicates|absorbs|fixes|extends|supersedes`. Extend the enum:
+
+```sql
+-- Migration: extend CHECK constraint on task_relations.relation_type
+ALTER TABLE task_relations DROP CONSTRAINT IF EXISTS task_relations_relation_type_check;
+-- (SQLite has no DROP CONSTRAINT; this is done via table-rename + recreate idiom)
+
+-- New constraint covers:
+--   related | blocks | duplicates | absorbs | fixes | extends | supersedes |
+--   regresses | follows-up | reverts | hotfixes | depends-on
+```
+
+Plus add timestamp + commit anchor:
+
+```sql
+ALTER TABLE task_relations ADD COLUMN created_at TEXT NOT NULL DEFAULT (datetime('now'));
+ALTER TABLE task_relations ADD COLUMN commit_sha TEXT REFERENCES commits(sha) ON DELETE SET NULL;
+ALTER TABLE task_relations ADD COLUMN created_by TEXT;
+```
+
+**Edge captured**: explicit graph evolution. The 4 new types:
+- `regresses` — task X regresses behavior introduced by task Y (the original task Y introduced the bug that X now exists to track)
+- `follows-up` — task X is a follow-up to task Y (e.g., T9341 follows-up T9261 Phase 5 per MEMORY.md)
+- `reverts` — task X reverts task Y (revert commit pattern; symmetric with `revert` change_type)
+- `hotfixes` — task X hotfixes task Y (X is the bug-fix task; Y is the regressed feature task)
+
+### 3.11 Index Summary — Optimized for §5 Queries
+
+| Index | Purpose | Queries served (§5) |
+|-------|---------|---------------------|
+| `idx_release_changes_release_id` | Roll up changes for one release | Q1, Q3 |
+| `idx_release_changes_change_type` | Filter changes by type | Q1, Q3 |
+| `idx_release_changes_task_id` | Reverse: find releases that shipped a task | Q2 |
+| `idx_releases_previous_release_id` | Walk release chain | Q3 |
+| `idx_task_commits_task_primary` | Get canonical commit for a task | Q2 |
+| `idx_release_commits_commit_sha` | Reverse: find release that contains a commit | Q5 |
+| `idx_commits_author_email` | Author roll-up | Q6 |
+| `idx_pr_tasks_task_id` | Find PRs for a task | Q2, Q7 |
+
+---
+
+## 4. Migration Strategy — Zero-Downtime
+
+### 4.1 Migration Files (Drizzle Format)
+
+These ship as discrete migrations under `packages/core/migrations/drizzle-tasks/`:
+
+```
+20260516000000_t9345-commits-table/
+  ├── migration.sql           -- DDL for commits + indexes
+  └── meta.json
+20260516000010_t9345-task-commits-junction/
+  ├── migration.sql           -- DDL for task_commits + indexes
+  └── meta.json
+20260516000020_t9345-commit-files/
+  ├── migration.sql           -- DDL for commit_files + indexes
+  └── meta.json
+20260516000030_t9345-pull-requests/
+  ├── migration.sql           -- DDL for pull_requests + pr_commits + pr_tasks
+  └── meta.json
+20260516000040_t9345-releases-normalized/
+  ├── migration.sql           -- DDL for releases + release_commits + release_artifacts
+  └── meta.json
+20260516000050_t9345-release-changes/
+  ├── migration.sql           -- DDL for release_changes
+  └── meta.json
+20260516000060_t9345-task-relations-extend/
+  ├── migration.sql           -- ALTER for new enum values + timestamp + commit_sha
+  └── meta.json
+20260516000070_t9345-brain-release-links/
+  ├── migration.sql           -- DDL for brain_release_links (see §8)
+  └── meta.json
+20260516000080_t9345-releases-view/
+  ├── migration.sql           -- CREATE VIEW releases_view (see §9)
+  └── meta.json
+```
+
+Each migration file is **pure DDL**. No `INSERT INTO ... SELECT FROM ...` backfill in
+the migration itself — backfill is a separate idempotent CLI command (see §4.4).
+
+### 4.2 Backward Compat Window
+
+| Phase | Duration | What happens |
+|-------|----------|--------------|
+| **Phase 0 — Schema in place** | 1 release | Migrations applied. New tables empty. Legacy `release_manifests.tasksJson` and `commitSha` still authoritative. |
+| **Phase 1 — Dual-write** | 2 releases (~14 days) | `releaseShip()` writes BOTH old + new. CLI commands prefer new tables, fall back to legacy. Read parity tests in CI. |
+| **Phase 2 — Backfill historical** | 1 release | One-shot `cleo provenance backfill --since v2025.1.1` walks git log + extracts task IDs + populates `commits`, `task_commits`, `release_commits`, `release_changes`. Idempotent (UPSERT). |
+| **Phase 3 — Read-from-new** | 1 release | CLI commands read EXCLUSIVELY from new tables. Legacy columns remain but unread. |
+| **Phase 4 — Deprecate legacy** | indefinite | Legacy `tasksJson` and `commitSha` documented as `@deprecated`. Stop writing. Keep readable for emergency rollback. |
+| **Phase 5 — Drop (optional)** | 6+ months | Once external dashboards have migrated, drop the legacy columns via final migration. |
+
+### 4.3 Idempotency Guarantees
+
+- **`commits` PK is `sha`**: re-ingesting the same commit is a no-op (UPSERT pattern, `ON CONFLICT(sha) DO UPDATE SET ...`).
+- **`task_commits` PK is `(task_id, commit_sha)`**: re-linking the same task+commit is a no-op.
+- **`release_changes` UUID PK**: backfill must check `(release_id, task_id, change_type)` triple before insert to avoid duplicates. Add a `UNIQUE` index:
+
+```sql
+CREATE UNIQUE INDEX uq_release_changes_release_task_type
+  ON release_changes(release_id, COALESCE(task_id, ''), change_type);
+```
+
+The `COALESCE` handles changes that have no task (orphan commits classified as `chore`).
+
+### 4.4 Backfill Algorithm (sketch — no impl code)
+
+```
+function backfillProvenance(opts: { since: string, project_hash: string }):
+  releases = listReleases(since=opts.since)            // existing release_manifests rows
+  for each rel in releases (oldest-first):
+    prev = previousRelease(rel)                        // walk release_manifests by version
+    commits = gitLog(`${prev.tag}..${rel.tag}`)        // shell out
+    upsertCommits(commits)                             // populates `commits` + `commit_files`
+    upsertReleaseCommits(rel.id, commits)              // populates `release_commits`
+    for each commit in commits:
+      task_ids = extractTaskIds(commit.message)        // T\d+ regex + Co-authored-by trailers
+      upsertTaskCommits(commit.sha, task_ids, src='commit-message')
+    prs = ghApiPrsForBranch(`release/${rel.version}`)  // gh api
+    upsertPullRequests(prs)
+    upsertPrCommits(prs)
+    upsertPrTasks(prs)                                 // extracts T### from PR title/body
+    classifyChanges(rel, prev)                         // builds release_changes rows
+  upsertReleaseArtifacts(rel)                          // reads release_manifests.npmDistTag etc.
+```
+
+Idempotent: every step is UPSERT (`ON CONFLICT DO UPDATE` or no-op). Re-running over the same range is safe.
+
+### 4.5 Rollback Plan
+
+If the new schema breaks production:
+
+```bash
+# 1. Stop writes to new tables
+CLEO_PROVENANCE_DUAL_WRITE=0 cleo release ship ...
+
+# 2. CLI commands auto-fall-back to legacy `tasksJson` / `commitSha` reads (a code-path flag)
+
+# 3. Drop new tables (if absolutely needed; data loss):
+sqlite3 .cleo/tasks.db < migrations/rollback/t9345-rollback.sql
+```
+
+The dual-write flag (`CLEO_PROVENANCE_DUAL_WRITE`) is the kill switch. Default `1` (enabled). Set to `0` to fall back to legacy-only mode while keeping schema in place.
+
+---
+
+## 5. Canonical Queries — The Graph as a Service
+
+Each query below is the **owner-facing question**, the **SQL skeleton**, the
+**expected output shape**, and **estimated complexity** for the assumed scale
+(1k tasks / 10k commits / 100 releases / 22 packages).
+
+### Q1: "What bugs shipped in v2026.5.74?"
+
+```sql
+SELECT
+  rc.id            AS change_id,
+  rc.task_id,
+  t.title          AS task_title,
+  rc.change_type,
+  rc.summary,
+  rc.is_breaking,
+  rc.severity,
+  rc.primary_commit_sha
+FROM releases r
+JOIN release_changes rc ON rc.release_id = r.id
+LEFT JOIN tasks t ON t.id = rc.task_id
+WHERE r.version = 'v2026.5.74'
+  AND rc.change_type IN ('bug', 'hotfix')
+ORDER BY rc.severity ASC NULLS LAST, rc.position ASC;
+```
+
+**Output shape** (TypeScript):
+```typescript
+type Q1Row = {
+  change_id: string;
+  task_id: string | null;
+  task_title: string | null;
+  change_type: 'bug' | 'hotfix';
+  summary: string;
+  is_breaking: 0 | 1;
+  severity: 'P0'|'P1'|'P2'|'P3'|null;
+  primary_commit_sha: string | null;
+};
+```
+
+**Complexity**: O(log N) on `idx_releases_version` + O(K) where K = changes in that release (typically <50). At 1k tasks scale: <5ms.
+
+### Q2: "Full provenance of T9344 (Anthropic OAuth hotfix)"
+
+```sql
+WITH
+  task_meta AS (
+    SELECT id, title, kind, severity, status, parent_id, created_at, completed_at
+    FROM tasks WHERE id = 'T9344'
+  ),
+  task_releases AS (
+    SELECT
+      rc.id AS change_id,
+      rc.change_type,
+      r.id AS release_id,
+      r.version,
+      r.shipped_at
+    FROM release_changes rc
+    JOIN releases r ON r.id = rc.release_id
+    WHERE rc.task_id = 'T9344'
+    ORDER BY r.shipped_at ASC
+  ),
+  task_commits_resolved AS (
+    SELECT
+      tc.commit_sha, tc.is_primary, tc.link_source,
+      c.short_sha, c.subject, c.author_name, c.authored_at, c.conventional_type
+    FROM task_commits tc
+    JOIN commits c ON c.sha = tc.commit_sha
+    WHERE tc.task_id = 'T9344'
+    ORDER BY c.authored_at ASC
+  ),
+  task_prs AS (
+    SELECT pr.id, pr.number, pr.title, pr.state, pr.merged_at, pr.author_login
+    FROM pr_tasks pt
+    JOIN pull_requests pr ON pr.id = pt.pr_id
+    WHERE pt.task_id = 'T9344'
+  ),
+  task_supersedes AS (
+    SELECT related_to AS task_id, relation_type
+    FROM task_relations
+    WHERE task_id = 'T9344'
+      AND relation_type IN ('fixes','regresses','supersedes','reverts','hotfixes','follows-up')
+  )
+SELECT 'meta' AS section, json_object(...) FROM task_meta UNION ALL
+SELECT 'releases', json_group_array(...) FROM task_releases UNION ALL
+SELECT 'commits', json_group_array(...) FROM task_commits_resolved UNION ALL
+SELECT 'prs', json_group_array(...) FROM task_prs UNION ALL
+SELECT 'evolution', json_group_array(...) FROM task_supersedes;
+```
+
+**TypeScript helper signature**:
+
+```typescript
+async function getProvenanceForTask(taskId: string): Promise<TaskProvenance> { ... }
+
+type TaskProvenance = {
+  task: TaskRow;
+  releases: { releaseId: string; version: string; shippedAt: string; changeType: ChangeType }[];
+  commits: { sha: string; shortSha: string; subject: string; author: string; isPrimary: boolean; linkSource: string }[];
+  prs: { id: string; number: number; title: string; mergedAt: string | null }[];
+  evolution: { relatedTaskId: string; relationType: TaskRelationType }[];
+};
+```
+
+**Complexity**: 5 indexed lookups + 1 union. <10ms at scale. The CTE is for clarity; production query would be 5 separate prepared statements.
+
+### Q3: "What hotfixes followed v2026.5.73?"
+
+```sql
+WITH base AS (
+  SELECT id, version, shipped_at FROM releases WHERE version = 'v2026.5.73'
+)
+SELECT
+  r.version, r.shipped_at, r.release_kind,
+  rc.task_id, rc.summary, rc.severity
+FROM releases r
+JOIN release_changes rc ON rc.release_id = r.id
+WHERE
+  r.shipped_at > (SELECT shipped_at FROM base)
+  AND (r.release_kind = 'hotfix' OR rc.change_type = 'hotfix')
+ORDER BY r.shipped_at ASC, rc.position ASC;
+```
+
+**Complexity**: filter on `idx_releases_shipped_at` then join. O(M log N) where M = hotfix changes since base. <20ms.
+
+### Q4: "Show the evolution graph of the 'Anthropic OAuth' feature"
+
+```sql
+WITH RECURSIVE feature_root AS (
+  -- Find feature task by label or title
+  SELECT id, title, kind FROM tasks
+  WHERE (labels_json LIKE '%"feature:anthropic-oauth"%' OR title LIKE '%Anthropic OAuth%')
+    AND kind IN ('feature','work')
+  LIMIT 1
+),
+descendants AS (
+  -- Walk parentId hierarchy down
+  SELECT id, parent_id, title, kind, severity FROM tasks WHERE parent_id IN (SELECT id FROM feature_root)
+  UNION ALL
+  SELECT t.id, t.parent_id, t.title, t.kind, t.severity FROM tasks t
+  JOIN descendants d ON t.parent_id = d.id
+),
+related AS (
+  -- Walk task_relations for fixes/regresses/hotfixes/follows-up
+  SELECT tr.task_id, tr.related_to, tr.relation_type
+  FROM task_relations tr
+  WHERE tr.related_to IN (SELECT id FROM feature_root UNION SELECT id FROM descendants)
+     OR tr.task_id IN (SELECT id FROM feature_root UNION SELECT id FROM descendants)
+)
+SELECT * FROM feature_root
+UNION ALL SELECT id, NULL, title, kind, severity FROM descendants
+UNION ALL SELECT 'rel:'||task_id||'->'||related_to AS id, related_to AS parent_id, relation_type AS title, NULL, NULL FROM related;
+```
+
+**Complexity**: recursive CTE bounded by hierarchy depth (~5 levels). At 1k tasks: <50ms.
+
+### Q5: "What commits in v2026.5.74 are not linked to any task?" (orphan detection)
+
+```sql
+SELECT c.sha, c.short_sha, c.subject, c.author_email
+FROM release_commits rc
+JOIN commits c ON c.sha = rc.commit_sha
+JOIN releases r ON r.id = rc.release_id
+WHERE r.version = 'v2026.5.74'
+  AND c.is_release_commit = 0       -- exclude the "chore(release):" commit itself
+  AND NOT EXISTS (
+    SELECT 1 FROM task_commits tc WHERE tc.commit_sha = c.sha
+  );
+```
+
+**Complexity**: O(K) where K = commits in release. <5ms at any scale. This is an **auditability query** — owner can spot drift where work landed without task linkage.
+
+### Q6: "Which authors contributed to v2026.5.74?"
+
+```sql
+SELECT
+  c.author_email,
+  c.author_name,
+  COUNT(*) AS commit_count,
+  COUNT(DISTINCT tc.task_id) AS distinct_tasks_touched
+FROM release_commits rc
+JOIN commits c ON c.sha = rc.commit_sha
+LEFT JOIN task_commits tc ON tc.commit_sha = c.sha
+JOIN releases r ON r.id = rc.release_id
+WHERE r.version = 'v2026.5.74'
+  AND c.author_email IS NOT NULL
+GROUP BY c.author_email, c.author_name
+ORDER BY commit_count DESC;
+```
+
+**Complexity**: filter + group. <10ms.
+
+### Q7: "IVTR audit trail for T9344 across its lifetime"
+
+Joins `task_work_history` (existing) + `lifecycle_transitions` + `audit_log` + new `release_changes`:
+
+```sql
+SELECT 'work' AS event, twh.set_at AS at, twh.session_id, NULL AS commit_sha
+FROM task_work_history twh WHERE twh.task_id = 'T9344'
+UNION ALL
+SELECT 'lifecycle', lt.created_at, lt.transitioned_by, NULL
+FROM lifecycle_transitions lt
+JOIN lifecycle_pipelines lp ON lp.id = lt.pipeline_id
+WHERE lp.task_id = 'T9344'
+UNION ALL
+SELECT 'audit-'||al.action, al.timestamp, al.actor, NULL
+FROM audit_log al WHERE al.task_id = 'T9344'
+UNION ALL
+SELECT 'commit', c.authored_at, c.author_email, c.sha
+FROM task_commits tc JOIN commits c ON c.sha = tc.commit_sha
+WHERE tc.task_id = 'T9344'
+UNION ALL
+SELECT 'release-'||rc.change_type, r.shipped_at, r.created_by, r.release_commit_sha
+FROM release_changes rc JOIN releases r ON r.id = rc.release_id
+WHERE rc.task_id = 'T9344'
+ORDER BY at ASC;
+```
+
+**Complexity**: 5 indexed lookups + sort. <20ms.
+
+### Q8: "Find the task that introduced the bug T9344 fixes" (regression provenance)
+
+```sql
+SELECT
+  introducer.id AS introducer_task_id,
+  introducer.title,
+  introducer_commit.short_sha AS introducer_commit,
+  introducer_commit.authored_at,
+  introducer_change.release_id AS introducer_release
+FROM task_relations tr
+JOIN tasks introducer ON introducer.id = tr.related_to
+LEFT JOIN task_commits introducer_tc ON introducer_tc.task_id = introducer.id AND introducer_tc.is_primary = 1
+LEFT JOIN commits introducer_commit ON introducer_commit.sha = introducer_tc.commit_sha
+LEFT JOIN release_changes introducer_change ON introducer_change.task_id = introducer.id
+WHERE tr.task_id = 'T9344'
+  AND tr.relation_type = 'regresses';
+```
+
+**Complexity**: <5ms with `idx_task_relations_related_to` + composite index.
+
+### Query Performance Summary
+
+| Query | Indexes used | Rows scanned (worst case at scale) | Latency target |
+|-------|--------------|-----------------------------------|----------------|
+| Q1 bugs in release | `idx_releases_version`, `idx_release_changes_release_id`, `idx_release_changes_change_type` | ~50 | <5ms |
+| Q2 task provenance | 5 indexed lookups | ~30 | <10ms |
+| Q3 hotfixes after release | `idx_releases_shipped_at`, `idx_release_changes_change_type` | ~20 | <20ms |
+| Q4 feature evolution | hierarchy walk + relations | ~100 | <50ms |
+| Q5 orphan commits | `idx_release_commits_position`, EXISTS | ~500 | <5ms |
+| Q6 authors | filter + group | ~500 | <10ms |
+| Q7 audit trail | 5 unioned indexed reads | ~50 | <20ms |
+| Q8 regression introducer | `idx_task_relations_related_to` | ~10 | <5ms |
+
+---
+
+## 6. CLI Surface — Provenance as Product
+
+Two new top-level groupings: extend `cleo release` and introduce `cleo provenance`.
+
+### 6.1 `cleo release` extensions
+
+| Command | Params | Output | SQL/Behavior |
+|---------|--------|--------|--------------|
+| `cleo release graph <version> [--format mermaid|dot|json]` | `version: string`; `format` defaults to `mermaid` | Mermaid/DOT graph of tasks↔commits↔PRs for that release | Joins releases × release_changes × pr_tasks × task_commits; renders graph format |
+| `cleo release diff <v1> <v2> [--by change_type|severity|author]` | two version strings; group-by selector | Tabular diff: tasks added/removed, regressions detected, breaking changes flagged | Set-subtract on release_changes; flags `is_breaking`, `change_type='regresses'` |
+| `cleo release impact <version> [--window 30d]` | version; lookback window for follow-up bugs/hotfixes | Severity-tagged report: P0/P1 bugs filed against this release, MTTR computed | Joins release_changes (origin) × task_relations (regresses) × releases (where the regression shipped) |
+| `cleo release authors <version> [--top N]` | version; top-N filter | Author roll-up with commit + task counts | Q6 |
+| `cleo release orphans <version>` | version | Commits in release not linked to any task | Q5 — auditable orphan-commit list |
+
+### 6.2 `cleo provenance` namespace (NEW)
+
+| Command | Params | Output | SQL |
+|---------|--------|--------|-----|
+| `cleo provenance task <id>` | `id: string` | Full lineage — origin → bugs → hotfixes → releases | Q2 |
+| `cleo provenance commit <sha>` | `sha: string` (full or short) | What task does this commit serve? Which PR contained it? Which release shipped it? | `commits × task_commits × pr_commits × release_commits` indexed join |
+| `cleo provenance pr <id\|#number>` | PR ID or `owner/repo#N` | All tasks linked to this PR + which release it shipped in | `pull_requests × pr_tasks × pr_commits × release_commits` |
+| `cleo provenance feature <slug>` | feature label or slug | All tasks/PRs/releases under a feature label | Q4 |
+| `cleo provenance release <version>` | version | Equivalent to `cleo release show` but rendered as graph (tasks/commits/PRs/authors) | joins releases × everything |
+| `cleo provenance change <change_id>` | UUID | Single change_row drill-down: task, commit, PR, release, BRAIN decision link | release_changes × everything |
+| `cleo provenance backfill --since <version> [--dry-run]` | starting version; dry-run flag | Idempotent backfill of historical commits, PRs, changes (see §4.4) | The backfill algorithm |
+| `cleo provenance link <task-id> --commit <sha> [--source manual]` | task + commit + source | Manually attach a task↔commit edge | INSERT INTO task_commits |
+| `cleo provenance verify <version>` | version | Run integrity checks: no orphan release_changes, no dangling task FKs, no missing primary commits | DDL-level invariant checks |
+
+### 6.3 Schema-Stable Output Contracts
+
+Every new command returns LAFS envelope (`{success, data?, error?, meta}` per ADR-039 and `packages/lafs/`). `data` payload schemas:
+
+```typescript
+// cleo release graph <version> → data.graph
+type ReleaseGraph = {
+  release: { id: string; version: string; shippedAt: string; releaseKind: ReleaseKind };
+  nodes: Array<
+    | { type: 'task'; id: string; title: string; kind: TaskKind; severity: TaskSeverity | null }
+    | { type: 'commit'; sha: string; shortSha: string; subject: string; author: string }
+    | { type: 'pr'; id: string; number: number; title: string }
+    | { type: 'change'; id: string; changeType: ChangeType; isBreaking: boolean }
+  >;
+  edges: Array<{
+    from: string; to: string;
+    kind: 'task→commit' | 'task→change' | 'change→pr' | 'pr→commit' | 'release→change' | 'task→task' | 'commit→commit';
+    via?: string; // e.g. "fixes", "regresses"
+  }>;
+};
+
+// cleo release diff <v1> <v2> → data.diff
+type ReleaseDiff = {
+  v1: string;
+  v2: string;
+  added: { tasks: string[]; changes: string[]; commits: string[] };
+  removed: { tasks: string[]; changes: string[] };
+  regressions: Array<{ taskId: string; introducedIn: string; fixedIn: string | null }>;
+  breakingChanges: Array<{ changeId: string; summary: string }>;
+};
+
+// cleo provenance task <id> → data
+type TaskProvenanceEnvelope = TaskProvenance; // defined in Q2
+
+// cleo provenance feature <slug> → data
+type FeatureProvenance = {
+  feature: { slug: string; rootTaskId: string; rootTitle: string };
+  tasks: Array<{ id: string; title: string; kind: TaskKind; status: TaskStatus; severity: TaskSeverity | null; parentId: string | null }>;
+  releases: Array<{ id: string; version: string; shippedAt: string; changeCount: number }>;
+  bugs: Array<{ taskId: string; title: string; severity: TaskSeverity; releaseId: string | null }>;
+  hotfixes: Array<{ taskId: string; title: string; releaseId: string }>;
+  timeline: Array<{ at: string; event: string; taskId?: string; releaseId?: string }>;
+};
+```
+
+### 6.4 Total New CLI Count
+
+**11 new commands** (5 under `cleo release`, 6 under `cleo provenance`) + 3 ancillary (`backfill`, `link`, `verify`). Net 14 new entry points — all read-mostly except `link` and `backfill`. Two existing commands (`cleo release changelog`, `cleo release show`) get richer output by leveraging the new schema, but signatures stay backward compatible.
+
+---
+
+## 7. Multi-Archetype Portability
+
+The owner requires this to work for ≥3 project archetypes. Audit doc identifies the
+current pipeline assumes Node/pnpm (coupling score 8/10 per audit §5).
+
+### 7.1 Archetype Coverage Matrix
+
+| Archetype | Tables populated identically | Tables that differ | `release_artifacts` rows |
+|-----------|------------------------------|---------------------|--------------------------|
+| **Monorepo (cleocode itself — 22 npm packages)** | commits, task_commits, pull_requests, pr_commits, pr_tasks, releases, release_commits, release_changes, task_relations | release_artifacts uses `npm` × 22 rows | `[{type:'npm',id:'@cleocode/cleo',ver:'2026.5.74'}, {type:'npm',id:'@cleocode/core',ver:'2026.5.74'}, ... × 22]` |
+| **Single npm lib** | same set | release_artifacts: `npm` × 1 row | `[{type:'npm',id:'my-lib',ver:'1.2.3',metadata:{distTag:'latest'}}]` |
+| **Single Rust crate** | same set | release_artifacts: `cargo` × 1 row | `[{type:'cargo',id:'my-crate',ver:'0.5.0',url:'https://crates.io/crates/my-crate/0.5.0'}]` |
+| **Mixed (Rust + npm; like cleocode's `packages/cant`)** | same | release_artifacts: mixed types | `[{type:'npm',id:'@cleocode/cant',ver:'2026.5.74'}, {type:'cargo',id:'cant-core',ver:'0.5.0'}]` |
+| **Docker-only image** | same | release_artifacts: `docker` × 1 row | `[{type:'docker',id:'myorg/myimage',ver:'v1.2.3',url:'docker.io/myorg/myimage:v1.2.3',digest:'sha256:...'}]` |
+| **Python pip package** | same | release_artifacts: `pypi` × 1 row | `[{type:'pypi',id:'my-pkg',ver:'1.2.3'}]` |
+| **Binary tarball release** | same | release_artifacts: `binary` × N rows (per OS/arch) | `[{type:'binary',id:'cli-linux-amd64',ver:'1.2.3',url:'...',digest:'sha256:...'}, ...]` |
+
+### 7.2 Schema Stays Portable
+
+**No per-language columns**. The polymorphism lives in `release_artifacts.artifact_type` enum + `metadata_json` for type-specific extras. Hermes pattern (hermes-agent-real-research.md:174 — dual CalVer + SemVer) is captured by:
+
+```json
+{
+  "calver": "2026.5.74",
+  "semver": "0.13.0",
+  "distTag": "latest",
+  "provenance": true,
+  "slsaLevel": 3
+}
+```
+
+Stored in `release_artifacts.metadata_json` — no new columns required.
+
+### 7.3 Legacy `release_manifests.npmDistTag` Deprecation
+
+The hardcoded `npmDistTag` column (tasks-schema.ts:729) is npm-specific. Migration:
+
+```
+Phase 1: Continue writing `npmDistTag` on `release_manifests`; ALSO write a `release_artifacts` row.
+Phase 3: CLI reads from `release_artifacts.metadata_json.distTag`.
+Phase 5: Drop `npmDistTag` column.
+```
+
+### 7.4 Worked Example — Monorepo Release
+
+For `cleocode` v2026.5.74:
+
+```sql
+-- 1 row in releases
+INSERT INTO releases VALUES ('rel_v2026.5.74', 'v2026.5.74', 'latest', 'shipped', 'regular', ...);
+
+-- 22 rows in release_artifacts (one per @cleocode/* package)
+INSERT INTO release_artifacts VALUES
+  ('rel_v2026.5.74', 'npm', '@cleocode/cleo',      '2026.5.74', 'https://npmjs.com/...', 'sha256:...', NULL, '2026-05-14T...', '{"distTag":"latest"}'),
+  ('rel_v2026.5.74', 'npm', '@cleocode/core',      '2026.5.74', 'https://...',           'sha256:...', NULL, '2026-05-14T...', '{}'),
+  -- ... 20 more
+  ('rel_v2026.5.74', 'cargo', 'signaldock-sdk',    '0.5.0',     'https://crates.io/...',  'sha256:...', NULL, '2026-05-14T...', '{}');
+
+-- N rows in release_commits (every commit in v2026.5.73..v2026.5.74)
+INSERT INTO release_commits VALUES
+  ('rel_v2026.5.74', 'ea2bcaa77...', 1, 1, 0, 0),   -- T9344 hotfix commit
+  ('rel_v2026.5.74', '65cba7520...', 2, 0, 1, 1),   -- "release: ship v2026.5.74" commit
+  -- ... etc.
+
+-- 1+ rows in release_changes
+INSERT INTO release_changes VALUES
+  (uuid(), 'rel_v2026.5.74', 'T9344', 'pr_kryptobaseddev/cleocode#163', 'ea2bcaa77...',
+   'hotfix', 'fix', 'anthropic-oauth', 0, 0, 'P0',
+   'Anthropic OAuth — drop false placeholder framing + fix redirectUri',
+   '...', '...', 0, '...');
+```
+
+Note: `release_artifacts` carries 22 npm rows + 1 cargo row from a SINGLE release row. No table proliferation.
+
+---
+
+## 8. BRAIN Integration
+
+BRAIN tables (memory-schema.ts:155 `brainDecisions`, etc.) live in the project-level
+`.cleo/brain.db`. Today, `brain_decisions` has `contextEpicId` and `contextTaskId` as
+**soft text columns** (no REFERENCES) but no release linkage.
+
+### 8.1 New Junction: `brain_release_links`
+
+Lives in `tasks.db` (or `brain.db` if cross-DB views are acceptable; recommend
+tasks.db with logical reference to brain_decisions.id via soft FK for cross-DB
+neutrality):
+
+```sql
+CREATE TABLE brain_release_links (
+  id           TEXT PRIMARY KEY,                -- UUID
+  brain_entry_id   TEXT NOT NULL,                -- soft FK to brain_decisions.id / brain_observations.id
+  brain_entry_kind TEXT NOT NULL,                -- 'decision'|'observation'|'pattern'|'learning'
+  release_id   TEXT REFERENCES releases(id) ON DELETE CASCADE,
+  change_id    TEXT REFERENCES release_changes(id) ON DELETE CASCADE,
+  link_type    TEXT NOT NULL,                    -- 'approved-by'|'documented-in'|'derived-from'|'observed-in'
+  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  created_by   TEXT,
+  CHECK (release_id IS NOT NULL OR change_id IS NOT NULL)
+);
+
+CREATE INDEX idx_brain_release_links_brain_entry ON brain_release_links(brain_entry_id, brain_entry_kind);
+CREATE INDEX idx_brain_release_links_release_id ON brain_release_links(release_id);
+CREATE INDEX idx_brain_release_links_change_id ON brain_release_links(change_id);
+```
+
+**Edge captured**: BRAIN entry ↔ release. Closes the loop on:
+- "Which decision approved the fix shipped in v2026.5.74?" (link_type='approved-by')
+- "Which release first documented this pattern?" (link_type='documented-in')
+- "Which release's failure produced this learning?" (link_type='derived-from')
+
+### 8.2 Cross-DB Reference Strategy
+
+Soft FK (TEXT, no REFERENCES) because `brain_decisions` lives in a separate
+SQLite file. The cross-DB safety is handled at the access-layer (BrainAccessor
++ DataAccessor coordinate via the existing pattern in
+`packages/core/src/store/brain-accessor-impl.ts`).
+
+Alternatively, when `cleo nexus impact` queries are run via the global nexus
+infra (which already federates project DBs per CLEO-INJECTION.md §Nexus), the
+nexus layer joins these tables transparently.
+
+### 8.3 Nexus Integration
+
+`cleo nexus impact <symbol>` (CLAUDE.md "Always Do") gets richer with this graph:
+
+```
+gitnexus_impact({target: "releaseShip", direction: "upstream"})
+  → returns direct callers
+  + new: returns "this symbol last shipped in v2026.5.74"
+  + new: returns "5 historical bugs filed against this symbol" (Q1 + commit_files JOIN)
+  + new: returns "P0 hotfix T9344 modified this file's siblings" (commit_files × release_changes)
+```
+
+The schema delivers the data; the nexus query layer composes the joins.
+
+### 8.4 Observation Auto-Capture
+
+When `cleo release ship` succeeds, automatically emit a `brain_observation` with
+`brain_release_links.link_type='observed-in'`:
+
+```
+cleo memory observe "Shipped v2026.5.74 with 1 hotfix (T9344) and 0 regressions detected" \
+  --title "Release v2026.5.74 shipped" \
+  --link-release v2026.5.74
+```
+
+Closes the owner's "memory" requirement at the release boundary.
+
+---
+
+## 9. `releases_view` — Materialized Mental Model
+
+A single SQL view that joins all release-graph tables into one row per release,
+returning aggregated arrays via SQLite's `json_group_array`. Designed for
+read-heavy external consumers (Studio dashboard, docs site, agents needing
+release context).
+
+```sql
+CREATE VIEW releases_view AS
+SELECT
+  r.id                                AS release_id,
+  r.version,
+  r.channel,
+  r.status,
+  r.release_kind,
+  r.previous_version,
+  r.tag_name,
+  r.shipped_at,
+  r.created_by,
+  -- Tasks shipped (via release_changes)
+  (
+    SELECT json_group_array(json_object(
+      'taskId', rc.task_id,
+      'title',  t.title,
+      'kind',   t.kind,
+      'changeType', rc.change_type,
+      'severity', rc.severity,
+      'isBreaking', rc.is_breaking
+    ))
+    FROM release_changes rc
+    LEFT JOIN tasks t ON t.id = rc.task_id
+    WHERE rc.release_id = r.id
+  ) AS tasks_json,
+  -- Commits in release
+  (
+    SELECT json_group_array(json_object(
+      'sha', c.short_sha,
+      'subject', c.subject,
+      'author', c.author_email,
+      'ccType', c.conventional_type
+    ))
+    FROM release_commits rc2
+    JOIN commits c ON c.sha = rc2.commit_sha
+    WHERE rc2.release_id = r.id
+    ORDER BY rc2.position ASC
+  ) AS commits_json,
+  -- PRs merged into release
+  (
+    SELECT json_group_array(DISTINCT json_object(
+      'prId', pr.id,
+      'number', pr.number,
+      'title', pr.title,
+      'author', pr.author_login
+    ))
+    FROM release_commits rc3
+    JOIN pr_commits pc ON pc.commit_sha = rc3.commit_sha
+    JOIN pull_requests pr ON pr.id = pc.pr_id
+    WHERE rc3.release_id = r.id
+  ) AS prs_json,
+  -- Unique authors
+  (
+    SELECT json_group_array(DISTINCT json_object(
+      'email', c.author_email,
+      'name', c.author_name
+    ))
+    FROM release_commits rc4
+    JOIN commits c ON c.sha = rc4.commit_sha
+    WHERE rc4.release_id = r.id AND c.author_email IS NOT NULL
+  ) AS authors_json,
+  -- Artifacts published
+  (
+    SELECT json_group_array(json_object(
+      'type', ra.artifact_type,
+      'id', ra.identifier,
+      'version', ra.version,
+      'url', ra.url,
+      'digest', ra.digest
+    ))
+    FROM release_artifacts ra
+    WHERE ra.release_id = r.id
+  ) AS artifacts_json,
+  -- Aggregate counts
+  (SELECT COUNT(*) FROM release_changes rc5 WHERE rc5.release_id = r.id) AS change_count,
+  (SELECT COUNT(*) FROM release_changes rc6 WHERE rc6.release_id = r.id AND rc6.change_type = 'feature') AS feature_count,
+  (SELECT COUNT(*) FROM release_changes rc7 WHERE rc7.release_id = r.id AND rc7.change_type = 'bug') AS bug_count,
+  (SELECT COUNT(*) FROM release_changes rc8 WHERE rc8.release_id = r.id AND rc8.change_type = 'hotfix') AS hotfix_count,
+  (SELECT COUNT(*) FROM release_changes rc9 WHERE rc9.release_id = r.id AND rc9.is_breaking = 1) AS breaking_count
+FROM releases r;
+```
+
+**Query example**:
+
+```sql
+SELECT version, change_count, feature_count, bug_count, hotfix_count, json_extract(tasks_json, '$[0].taskId')
+FROM releases_view
+WHERE shipped_at > '2026-05-01'
+ORDER BY shipped_at DESC;
+```
+
+**Why a view, not a materialized table**: SQLite doesn't have materialized views. The view is computed on read. For 100 releases, this is ~500ms cold; acceptable for dashboard use. If perf becomes an issue, the same shape can be materialized into a `releases_snapshot` table refreshed nightly.
+
+---
+
+## 10. Anti-Patterns — Rejected with Rationale
+
+| Anti-pattern | Considered? | Why rejected |
+|--------------|-------------|--------------|
+| **Continue using `release_manifests.tasksJson` as primary source of truth** | Yes | Audit doc Phase 4 §Q4 explicitly flags this as the gap. JSON arrays can't be SQL-joined, can't be indexed for membership queries, and require full table scans. Replaced by `release_changes` junction. |
+| **Per-language tables (e.g., `npm_releases`, `cargo_releases`, `docker_releases`)** | Yes | Would force schema changes every time a new artifact type is added. Rejected in favor of `release_artifacts` polymorphism + `metadata_json` for type-specific extras. Matches existing pattern (e.g. `pipeline_manifest.metadataJson`). |
+| **Store CHANGELOG markdown as the source of truth** | Yes | CHANGELOG is a *render*, not a fact. If we store the markdown and lose the structured data, we cannot re-render in a different format (Mermaid, JSON, RSS). `release_changes` rows are the fact; CHANGELOG.md is generated FROM them. Hermes pattern reinforces this (hermes-agent-real-research.md:393 — `RELEASE_v0.13.0.md` is committed, but it's generated from `git log`). |
+| **Tightly couple tasks to commits via FK on `tasks.commit_sha`** | Yes | A task has many commits over its lifecycle (initial impl + fix-up + merge). 1:1 FK forces lossy selection of "the" commit. M:N via `task_commits` with `is_primary` flag is correct. |
+| **Store author identities in a separate `authors` table** | Yes | Author email is the de-facto identity in git. A `authors` table would add a normalization step with marginal benefit. The `commits.author_email` column with an index is sufficient. If author de-duplication is needed (one person, multiple emails), an opt-in `author_aliases` mapping table can be added later. |
+| **Bake `release_kind='hotfix'` into a CHECK constraint that auto-derives from severity/timing** | Yes | Constraint logic at the DB level is brittle. The derivation (P0/P1 task + <72h window + hotfix/* branch) lives in application code at write time. The column is denormalized for query speed but the source of truth is the heuristic. Owner can override via explicit `--release-kind hotfix` flag. |
+| **Use the existing `lifecycle_evidence` table to store commit SHAs** | Yes | `lifecycle_evidence.type` is constrained to `file|url|manifest` (tasks-schema.ts:164). Adding `commit` to that enum is feasible but mixes evidence (stage-bound) with provenance (release-bound). Separation of concerns: lifecycle_evidence stays task-stage-scoped; commits get their own first-class table. |
+| **Cross-DB FK from `brain_decisions` to `releases`** | Yes | SQLite has no cross-database FK enforcement (each DB is its own connection). Using soft FK (TEXT column) + access-layer coordination is the existing CLEO pattern (see `brain-accessor-impl.ts`). |
+| **Replace `release_manifests` entirely with `releases` in one migration** | Yes | Breaks all existing read paths in `engine-ops.ts:1359` etc. Zero-downtime requires the dual-write window of §4.2. The old table fades over 5 release cycles. |
+| **Use SQLite's `generated columns` for derived fields like `is_release_commit`** | Yes | SQLite generated columns can't be indexed in older SQLite versions (<3.31), and our node:sqlite minimum is bundled with whatever Node ships. Concrete column + index is portable. |
+| **Hardcode the 12 `CHANGE_TYPES` values in a CHECK constraint** | Considered, deferred | Soft enforcement at the application layer first (Zod schema in contracts), CHECK constraint added in a follow-up migration after stabilization. Avoids migration churn during initial rollout. |
+| **Auto-detect "regresses" relations from commit reverts** | Yes | Possible but lossy — many regressions don't surface as git reverts (they're forward-fixes in new commits). Use explicit `task_relations.relation_type='regresses'` written by the agent that triages the bug. |
+| **Store full PR HTML body in `pull_requests.body`** | Yes | Bodies can be huge (10s of KB) and GitHub-rendered Markdown is best fetched live. Store the raw markdown only; render at query time. |
+
+---
+
+## 11. Invariants & Constraints — Future Proofing
+
+Beyond the 12 invariants in audit-cleo-release-subcommands.md §6, the new graph adds:
+
+1. **Release commit must exist in `commits` table** — `releases.release_commit_sha` FK enforces this.
+2. **Every `release_changes` row must reference either a task or a primary commit** — CHECK: `task_id IS NOT NULL OR primary_commit_sha IS NOT NULL` (ensures no totally orphan changes).
+3. **Release tag SHA must match the commit it points at** — Validate on write: `commits.sha = releases.tag_sha`. Addresses audit Failure #6.
+4. **PR merge_commit_sha must exist in `commits`** — FK enforces.
+5. **No release can be `status='shipped'` without `shipped_at` populated** — CHECK constraint or trigger.
+6. **`change_type='hotfix'` requires `release.release_kind` IN ('hotfix','regular')** — CHECK constraint OR application-level guard with audit log entry on violation.
+7. **`task_relations.relation_type IN ('regresses','reverts','hotfixes')` requires a non-null `commit_sha`** — the relation must anchor to the offending commit.
+8. **Backfill must be idempotent** — UPSERT on every insert; PK design supports this.
+9. **No new write to `release_manifests.tasksJson` after Phase 3** — code path lints assert; CI gate.
+10. **All new tables get `project_hash` column for multi-repo CLEO installs** — already done; matches `audit_log.project_hash` pattern (tasks-schema.ts:780).
+
+---
+
+## 12. Integration Points with Existing Subsystems
+
+| Subsystem | Integration | Affected files (read-only inventory) |
+|-----------|-------------|--------------------------------------|
+| `cleo release ship` (engine-ops.ts:1105) | Add Step 13: "Record provenance graph" after tag push | engine-ops.ts |
+| `cleo release changelog` (engine-ops.ts:886) | Read from `release_changes` (rich) instead of git log walk | engine-ops.ts |
+| `releaseChangelogSince()` | Same | engine-ops.ts |
+| `release-manifest.ts` (T5580) | Continue writing legacy `tasksJson`/`commitSha` during Phase 1 dual-write; CLI reads new tables | release-manifest.ts |
+| `cleo nexus impact <symbol>` | New JOIN to `commit_files` enriches blast-radius | nexus impl |
+| `cleo provenance backfill` (new) | Reads git log; writes to new tables | new file in core/src/release/provenance/ |
+| `cleo orchestrate ivtr` | Stays decoupled (per ivtr-conflation-audit.md §6 Priority 1: decouple); no changes |
+| BRAIN observation flow | After release, auto-emit observation with `brain_release_links` entry | memory-accessor.ts |
+| `cleo memory find` | Optionally filters by release context (`--shipped-in v2026.5.74`) | memory-accessor.ts |
+| Studio dashboard | Reads `releases_view` for the project timeline page | packages/studio/ |
+| `forge-ts` docs generator | Can render provenance into `llms.txt` for AI context | packages/llmtxt-core/ |
+
+---
+
+## 13. Open Questions for Wave-3 Spec
+
+These questions should be resolved in the spec-writer phase, not architecture:
+
+1. **`commit_files.file_path` canonicalization**: should it be repo-relative-from-root or absolute? Recommendation: repo-relative, matches existing `tasks-schema.ts` conventions.
+2. **Foreign repos**: when a CLEO project has multiple git repos (e.g. submodules), how is `project_hash` resolved? Defer to existing CLI's `project_hash` derivation logic (see `audit_log.project_hash`).
+3. **`release_artifacts.digest` format**: standard sha256 prefix `sha256:` or raw hex? Recommendation: full `algo:hex` prefix to support sha512 and others.
+4. **Hotfix detection time window**: 72h or 7d or configurable per project? Recommendation: configurable via `.cleo/release-config.json` key `release.hotfixWindowHours` (default 72).
+5. **PR ingestion source**: poll `gh api` on every `release ship`, or async via GitHub webhooks? Initial impl: synchronous `gh api` calls during ship. Follow-up: webhook-driven ingestion for closed-but-unmerged PR data.
+6. **Branch protection rules data**: currently not modeled. Consider `repo_protection_rules` table later, joined to PRs to record "this PR bypassed required reviews".
+7. **Cross-project graph**: when global nexus-infra spans multiple CLEO projects, do `releases` from project A reference `tasks` in project B? Recommendation: NO. Each project's `tasks.db` is self-contained. Cross-project queries go through nexus federation, not direct FK.
+
+---
+
+## 14. Summary Table — What Each New Table Buys You
+
+| Table | Closes which gap | Owner-visible payoff |
+|-------|------------------|----------------------|
+| `commits` | "No commits table" (audit §Phase 4 row 5) | "What did each author ship?" |
+| `task_commits` | "task → commit MISSING" (audit §Phase 4 row 5) | "Show me the SHAs for T9344" |
+| `commit_files` | (new capability — blast radius from data, not git shell-outs) | "Who last touched engine-ops.ts?" |
+| `pull_requests` | "No PR linkage" (this design) | "Which PR shipped this hotfix?" |
+| `pr_commits` / `pr_tasks` | (junction tables) | Cross-citation pattern from Letta (LET-XXXX (#PR)) |
+| `releases` | Normalized release record (replaces `release_manifests` mixing draft/shipped) | "List shipped releases by month" |
+| `release_commits` | "commit → release MISSING" (audit §Phase 4 row 6) | "What commits were in v2026.5.74?" |
+| `release_changes` | "feature/bug/hotfix taxonomy" (owner ask, §2.2) | CHANGELOG generation, classification, search |
+| `release_artifacts` | Multi-archetype portability (§7) | "Which npm packages did this release publish?" |
+| `task_relations` extensions | Missing `regresses|follows-up|reverts|hotfixes` (§3.10) | Q8 regression provenance |
+| `brain_release_links` | "BRAIN ↔ release missing" (§8) | "Which decisions shipped in v2026.5.74?" |
+| `releases_view` | Materialized mental model (§9) | One-call payload for dashboards/agents |
+
+---
+
+## 15. Closeout — Why This Is the Right Shape
+
+1. **Owner's mental model directly maps to SQL**. Every owner question in §5 is one well-indexed query, not a JSON walk or full-table scan.
+2. **Zero-downtime migration**. Dual-write window + idempotent backfill + kill switch (`CLEO_PROVENANCE_DUAL_WRITE=0`) means no release is at risk during rollout.
+3. **Hermes + Letta patterns absorbed**, not copied. Hermes's release-as-event seam (hermes-agent-real-research.md:268) maps to our `releases.status='shipped'` trigger; Letta's `T#### (#PR)` cross-citation (letta-harness-real-research.md:33) is captured natively in `pr_tasks.link_evidence` + `task_commits.link_source`.
+4. **Decoupled from IVTR**. The provenance graph is a *fact layer* underneath both IVTR (which can deprecate per ivtr-conflation-audit.md Priority 4) and evidence gates (ADR-051 D1). Removing IVTR would not break the graph; the graph survives IVTR's retirement.
+5. **Project-agnostic by design**. No node/pnpm assumptions in the schema. `release_artifacts` polymorphism covers npm/cargo/docker/pypi/binary/maven without column proliferation.
+6. **Auditable orphans**. Q5 (orphan commits) is a first-class capability — owner can see drift where commits shipped without task linkage.
+7. **BRAIN integration is the natural close**. The owner's "memory" requirement collapses into one new junction table (`brain_release_links`) and one auto-emit observation hook — no separate "release memory" subsystem needed.
+
+---
+
+**End of provenance-graph design — T9345 wave-2 architecture artifact**
+
+Path written: `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/provenance-graph-design.md`

--- a/.cleo/rcasd/T9345/research/test-matrix-T9345.md
+++ b/.cleo/rcasd/T9345/research/test-matrix-T9345.md
@@ -1,0 +1,529 @@
+# Test Matrix — T9345 Release Pipeline v2
+
+| Field | Value |
+|---|---|
+| **Status** | Proposed |
+| **Date** | 2026-05-15 |
+| **Task** | T9345 (IVTR Release System Overhaul) |
+| **Author** | cleo-prime (system architect) |
+| **Companion artifacts** | `SPEC-T9345-release-pipeline-v2.md`, `migration-plan-T9345.md` |
+
+---
+
+## Executive Summary
+
+This test matrix proves that the SPEC-T9345 v2 release pipeline works correctly across the three required project archetypes (npm monorepo with workspaces, single npm library, single Rust crate) and the stretch archetype (single Python pkg). It defines four fixture projects, twelve test scenarios, a GitHub Actions matrix configuration for running scenarios against archetypes, and an owner sign-off checklist for declaring T9345 complete.
+
+Each scenario maps to one or more of the ten production failure modes catalogued in `failure-forensics-10-modes.md` and asserts that the new architecture prevents OR narrows that failure. The matrix is structured so that a green scenario row for an archetype constitutes evidence that the SPEC's acceptance criteria AC-1 through AC-10 hold for that archetype.
+
+The matrix's "pass" definition is quantitative: a pipeline-pass for archetype A requires scenarios S1-S12 to all be green for A's fixture, with no flakes (3 consecutive runs green). The owner sign-off checklist enumerates the specific artifacts the owner inspects before declaring T9345 complete: green CI matrix output, populated provenance tables, ≤5 minute happy-path wall-time, zero orphan commits in shipped releases, and the four operator verbs visible in `cleo release --help`.
+
+Fixture locations live under `packages/cleo/test/fixtures/release-test-<archetype>/` so they share the existing CLEO test infrastructure. Each fixture is realistic — not a toy — with a populated `.cleo/release-config.json`, a representative `.cleo/project-context.json`, plausible task data, and the expected tool resolutions per ADR-061. Scenarios that mutate state run in ephemeral worktrees provisioned via CLEO's existing test harness; the fixtures themselves are immutable test artifacts.
+
+---
+
+## 1. Archetypes — Four Fixtures
+
+The matrix targets three required archetypes plus one stretch archetype. Each fixture lives under `packages/cleo/test/fixtures/` and ships with the minimum viable project structure for the release pipeline to exercise.
+
+### 1.1 A1 — Monorepo with workspaces (cleocode itself)
+
+| Property | Value |
+|---|---|
+| **Fixture path** | `packages/cleo/test/fixtures/release-test-monorepo/` (mirrors cleocode at a smaller scale: 4 packages) |
+| **Stack** | pnpm + biome + vitest + esbuild + TypeScript strict |
+| **Workspace manifest** | `pnpm-workspace.yaml` listing `packages/*` |
+| **Packages** | `@release-test/core`, `@release-test/cli`, `@release-test/contracts`, `@release-test/utils` |
+| **Version scheme** | calver (`v2026.YYYY.MM.NN`) |
+| **`.cleo/release-config.json`** | `{ scheme: 'calver', branchModel: 'feat-to-main', prRequired: true, releaseBranchPrefix: 'release/' }` |
+| **`.cleo/project-context.json`** | `primaryType: 'node'`, `testing.command: 'pnpm run test'`, `build.command: 'pnpm run build'`, `monorepo: true` |
+| **Expected ADR-061 tool resolutions** | `test: pnpm run test`, `build: pnpm run build`, `lint: pnpm biome ci .`, `typecheck: pnpm run typecheck`, `audit: pnpm audit`, `security-scan: pnpm dlx audit-ci` |
+| **Expected platform matrix entries** | `[linux-x64, linux-arm64, macos-x64, macos-arm64, windows-x64]` × `[@release-test/core, @release-test/cli, @release-test/contracts, @release-test/utils]` |
+| **Real-world counterpart** | cleocode (22 packages, this fixture is the reduced model) |
+
+### 1.2 A2 — Single npm library
+
+| Property | Value |
+|---|---|
+| **Fixture path** | `packages/cleo/test/fixtures/release-test-npm-lib/` |
+| **Stack** | npm + tsc + vitest + TypeScript strict (no biome) |
+| **Workspace manifest** | (none — single root package.json) |
+| **Packages** | `@example/my-lib` (single) |
+| **Version scheme** | semver (`vX.Y.Z`) |
+| **`.cleo/release-config.json`** | `{ scheme: 'semver', branchModel: 'feat-to-main', prRequired: true, releaseBranchPrefix: 'release/' }` |
+| **`.cleo/project-context.json`** | `primaryType: 'node'`, `testing.command: 'npm test'`, `build.command: 'npm run build'`, `monorepo: false` |
+| **Expected ADR-061 tool resolutions** | `test: npm test`, `build: npm run build`, `lint: npm run lint`, `typecheck: npx tsc --noEmit`, `audit: npm audit`, `security-scan: npm audit --audit-level=high` |
+| **Expected platform matrix entries** | `[any]` × `[@example/my-lib]` (no native bindings → single matrix slot) |
+| **Real-world counterpart** | Hermes-style single-package npm library |
+
+### 1.3 A3 — Single Rust crate
+
+| Property | Value |
+|---|---|
+| **Fixture path** | `packages/cleo/test/fixtures/release-test-rust-crate/` |
+| **Stack** | cargo + clippy + rustfmt + cargo-test |
+| **Workspace manifest** | (none — single root Cargo.toml) |
+| **Packages** | `my-crate` (single) |
+| **Version scheme** | semver |
+| **`.cleo/release-config.json`** | `{ scheme: 'semver', branchModel: 'feat-to-main', prRequired: true, releaseBranchPrefix: 'release/' }` |
+| **`.cleo/project-context.json`** | `primaryType: 'rust'`, `testing.command: 'cargo test --all-features'`, `build.command: 'cargo build --release'` |
+| **Expected ADR-061 tool resolutions** | `test: cargo test --all-features`, `build: cargo build --release`, `lint: cargo clippy --all-targets -- -D warnings`, `typecheck: cargo check --all-targets`, `audit: cargo audit`, `security-scan: cargo audit` |
+| **Expected platform matrix entries** | `[linux-x64, linux-arm64, macos-x64, macos-arm64, windows-x64]` × `[my-crate]` (cross-compile for binary crates; library crates collapse to `[any]`) |
+| **Real-world counterpart** | A pure-Rust CLI tool published to crates.io |
+
+### 1.4 A4 — Single Python pkg (stretch)
+
+| Property | Value |
+|---|---|
+| **Fixture path** | `packages/cleo/test/fixtures/release-test-python-pkg/` |
+| **Stack** | pyproject.toml + ruff + mypy + pytest |
+| **Workspace manifest** | (none) |
+| **Packages** | `my-pkg` (single) |
+| **Version scheme** | semver |
+| **`.cleo/release-config.json`** | `{ scheme: 'semver', branchModel: 'feat-to-main', prRequired: true, releaseBranchPrefix: 'release/' }` |
+| **`.cleo/project-context.json`** | `primaryType: 'python'`, `testing.command: 'pytest'`, `build.command: 'python -m build'` |
+| **Expected ADR-061 tool resolutions** | `test: pytest`, `build: python -m build`, `lint: ruff check .`, `typecheck: mypy .`, `audit: pip-audit`, `security-scan: bandit -r .` |
+| **Expected platform matrix entries** | `[any]` × `[my-pkg]` (pure-Python; sdist + wheel) |
+| **Real-world counterpart** | A reference Python library published to PyPI |
+
+### 1.5 Cross-archetype invariants
+
+All four fixtures share these properties:
+- `.git/` directory initialized with at least one prior tagged release (`v0.0.1` or `v2026.5.0`) so backfill and prev-tag walks have something to chew on.
+- At least 3 tasks in a populated `.cleo/tasks.db` linked to recent commits via `T####` tokens.
+- At least 1 BRAIN observation per fixture so `brain_release_links` can be populated.
+- A `.cleo/audit/` directory writable so the audit log can append.
+
+---
+
+## 2. Test Scenarios
+
+Twelve scenarios, each anchored to one or more failure modes from `failure-forensics-10-modes.md`. Every scenario has: a name, archetype targets, pre-conditions, execution steps, success criteria, and failure-mode coverage.
+
+### S1 — Happy-path release (no failures injected)
+
+| Property | Value |
+|---|---|
+| **Name** | S1 happy-path |
+| **Archetypes** | A1, A2, A3, A4 |
+| **Pre-conditions** | Fixture cloned; tasks.db pre-populated with 3 tasks under epic `T-test-S1`; all evidence atoms valid; clean working tree |
+| **Execution steps** | (1) `cleo release plan vNEXT --epic T-test-S1`; (2) `cleo release open vNEXT`; (3) wait for `release-prepare.yml`; (4) simulate PR merge on the test branch; (5) wait for `release-publish.yml`; (6) `cleo release reconcile vNEXT`; (7) `cleo provenance verify vNEXT` |
+| **Success criteria** | All 7 steps exit 0. `releases.status` advances `planned → pr-opened → pr-merged → published → reconciled`. Provenance tables populated. Total wall-time ≤5 minutes (AC-1). |
+| **Failure-mode coverage** | (none — establishes baseline that the happy path works) |
+| **Test asset** | `packages/cleo/test/integration/release-v2-happy-path.test.ts` |
+
+### S2 — Wedged git commit recovery (forensics F1)
+
+| Property | Value |
+|---|---|
+| **Name** | S2 wedged-git-recovery |
+| **Archetypes** | A1 (sufficient — proves the mechanism) |
+| **Pre-conditions** | Fixture as S1; a sidecar process that holds `.git/index.lock` for 90 seconds is started concurrently with the release-prepare workflow |
+| **Execution steps** | (1) Start a Python sidecar: `touch .git/index.lock && sleep 90`; (2) `cleo release plan vNEXT --epic T-test-S2`; (3) `cleo release open vNEXT`; (4) observe `release-prepare.yml` step "Commit version bump" timing out per GHA `timeout-minutes`; (5) sidecar exits; (6) re-run the workflow via `gh workflow run`; (7) verify the commit succeeds the second time |
+| **Success criteria** | The first workflow run fails cleanly at the locked-commit step with `timeout-minutes` exceeded; the job log emits `Recovery: cleo release plan <v> --epic <id>; cleo release open <v>` per SPEC R-209; the second run succeeds. No local CLEO CLI process hangs (verified by `ps -ef | grep cleo` returning no orphans after the workflow exits). |
+| **Failure-mode coverage** | F1 (wedged commit, no timeout) — STRUCTURALLY ELIMINATED by SPEC R-204, R-209 |
+| **Test asset** | `packages/cleo/test/integration/release-v2-wedged-git.test.ts` (uses GHA `act` for local simulation) |
+
+### S3 — Epic completeness scope confined (forensics F2)
+
+| Property | Value |
+|---|---|
+| **Name** | S3 epic-scope-confined |
+| **Archetypes** | A1 (multi-epic data needed) |
+| **Pre-conditions** | Fixture's tasks.db contains TWO unrelated epics: `T-test-S3-target` (the release target, 3 children all done) and `T-test-S3-noise` (an unrelated epic with 1 incomplete child); both epics' children have `T####` commit tokens in the prev-tag → HEAD range |
+| **Execution steps** | (1) `cleo release plan vNEXT --epic T-test-S3-target`; (2) inspect the plan file's `epicAncestor` field for each task; (3) `cleo release open vNEXT`; (4) trigger `release-prepare.yml` |
+| **Success criteria** | The plan file's tasks[] contain ONLY children of `T-test-S3-target`; no task under `T-test-S3-noise` appears. Epic-completeness check passes (the unrelated epic's incomplete child is NOT flagged). Bump-PR opens cleanly. |
+| **Failure-mode coverage** | F2 (epic completeness scope leak) — STRUCTURALLY ELIMINATED by SPEC R-021, R-303 |
+| **Test asset** | `packages/cleo/test/integration/release-v2-epic-scope.test.ts` |
+
+### S4 — Gate runners actually execute (forensics F3, F4)
+
+| Property | Value |
+|---|---|
+| **Name** | S4 real-gate-runners |
+| **Archetypes** | A1, A2, A3 |
+| **Pre-conditions** | Fixture's tasks.db has a task whose `testsPassed` evidence atom points at a vitest JSON containing 100 passed / 0 failed; a second task whose evidence is `tool:test` resolving via ADR-061 |
+| **Execution steps** | (1) `cleo release plan vNEXT --epic T-test-S4`; (2) inspect `plan.gates[]` — every gate MUST have `status='passed'` and `lastVerifiedAt` populated; (3) deliberately corrupt one task's `test-run` JSON to have `failures>0`; (4) re-run `cleo release plan` — MUST fail with `E_EVIDENCE_INSUFFICIENT` |
+| **Success criteria** | Step 2: all 5 canonical gates resolved via ADR-061 (tool exit codes observed, NOT theater). Step 4: plan rejected with structured error citing the failing task ID. The `defaultRunGate` no-op stub does NOT exist anywhere in the v2 codebase. |
+| **Failure-mode coverage** | F3 (gate runners not wired), F4 (IVTR non-blocking gate) — STRUCTURALLY ELIMINATED by SPEC R-310 through R-316 |
+| **Test asset** | `packages/cleo/test/integration/release-v2-real-gates.test.ts` |
+
+### S5 — Tag lands on merge SHA (forensics F6)
+
+| Property | Value |
+|---|---|
+| **Name** | S5 tag-canonical-sha |
+| **Archetypes** | A1, A2, A3 |
+| **Pre-conditions** | A test bump-PR is opened against the fixture's `main` branch; the PR is set to auto-merge with `--merge` strategy |
+| **Execution steps** | (1) `cleo release plan vNEXT`; (2) `cleo release open vNEXT`; (3) wait for PR auto-merge; (4) wait for `release-publish.yml` to tag; (5) `git rev-list -n 1 vNEXT` and `gh pr view <pr-num> --json mergeCommit`; (6) compare |
+| **Success criteria** | The SHA `git rev-list -n 1 vNEXT` exactly matches `gh pr view --json mergeCommit.oid`. No race window observable; the tag step in `release-publish.yml` polls `gh pr view --json state,mergeCommit` BEFORE issuing the tag per SPEC R-229. |
+| **Failure-mode coverage** | F6 (tag at wrong SHA) — STRUCTURALLY ELIMINATED by SPEC R-229 |
+| **Test asset** | `packages/cleo/test/integration/release-v2-tag-sha.test.ts` |
+
+### S6 — Hotfix path bypasses unrelated epic completeness (forensics F2 + new MTTR target)
+
+| Property | Value |
+|---|---|
+| **Name** | S6 hotfix-bypass |
+| **Archetypes** | A1 (most complex case) |
+| **Pre-conditions** | Most recent release was `v2026.6.0` (shipped <24h ago). Tasks.db contains an unrelated incomplete epic `T-test-S6-noise` AND a P0 hotfix task `T-test-S6-hotfix` (kind=bug, severity=P0). |
+| **Execution steps** | (1) `cleo release plan v2026.6.0.2 --epic T-test-S6-hotfix --hotfix`; (2) inspect `plan.releaseKind='hotfix'` and `plan.resolvedVersion='v2026.6.0.2'`; (3) `cleo release open v2026.6.0.2`; (4) measure total wall-time from step 1 to `cleo provenance verify v2026.6.0.2` passing |
+| **Success criteria** | The hotfix plan does NOT enumerate any children of `T-test-S6-noise`. The version suffix `.2` is computed correctly per SPEC R-400. Wall-time ≤60 minutes including a 5-minute human PR review SLA simulation (AC-3). `release_changes` row for the hotfix task has `change_type='hotfix'`. |
+| **Failure-mode coverage** | F2 (epic scope) revisited at hotfix scale; SPEC §10 R-400 through R-405 |
+| **Test asset** | `packages/cleo/test/integration/release-v2-hotfix.test.ts` |
+
+### S7 — Resume after CI failure mid-flight (forensics F8)
+
+| Property | Value |
+|---|---|
+| **Name** | S7 resume-mid-flight |
+| **Archetypes** | A1 |
+| **Pre-conditions** | A bump-PR is open; `release-prepare.yml` preflight is intentionally rigged to fail on the first run (e.g. a flaky test) |
+| **Execution steps** | (1) `cleo release plan vNEXT`; (2) `cleo release open vNEXT`; (3) preflight fails; (4) operator inspects `gh run view <run-id>` and the recovery hint in the job log; (5) operator removes the flake; (6) `gh workflow run release-prepare.yml --field version=vNEXT` (re-dispatch); (7) preflight passes; (8) bump-PR updates correctly |
+| **Success criteria** | Re-dispatching is idempotent per SPEC R-009. The plan file is unchanged between steps 2 and 7. The bump-PR's HEAD advances correctly without duplicate commits. |
+| **Failure-mode coverage** | F8 (release start no-op) — STRUCTURALLY ELIMINATED by plan-file-as-state per SPEC R-030 |
+| **Test asset** | `packages/cleo/test/integration/release-v2-resume.test.ts` |
+
+### S8 — Provenance graph populated (audit Q4 closure)
+
+| Property | Value |
+|---|---|
+| **Name** | S8 provenance-graph-populated |
+| **Archetypes** | A1, A2, A3, A4 |
+| **Pre-conditions** | A release has just shipped through the new path; `releases.status='reconciled'` |
+| **Execution steps** | (1) `cleo release graph vNEXT --format mermaid`; (2) validate the Mermaid output against the schema in `provenance-graph-design.md` §6.3; (3) run the 8 canonical SQL queries from provenance design §5 (Q1-Q8); (4) verify each query returns expected rows |
+| **Success criteria** | Mermaid output renders cleanly via `mmdc` (mermaid-cli). All 8 queries execute in ≤50ms each at fixture scale. `cleo release orphans vNEXT` returns an empty list (AC-2). Counts match: `releases_view.change_count` equals the count of `release_changes` rows for the release. |
+| **Failure-mode coverage** | (new capability — audit Q4 closure) |
+| **Test asset** | `packages/cleo/test/integration/release-v2-provenance-graph.test.ts` |
+
+### S9 — Orphan-commit detection (release-prepare warning)
+
+| Property | Value |
+|---|---|
+| **Name** | S9 orphan-commit-detection |
+| **Archetypes** | A1 (cleanest demonstration) |
+| **Pre-conditions** | The fixture has a commit on `main` (between previous tag and HEAD) whose subject does NOT contain any `T####` token — i.e. an orphan |
+| **Execution steps** | (1) `cleo release plan vNEXT --epic T-test-S9`; (2) inspect `plan.preflightSummary.orphanCommits[]` — MUST contain the orphan SHA; (3) `cleo release open vNEXT`; (4) `release-prepare.yml`'s preflight emits a non-blocking warning |
+| **Success criteria** | The orphan commit appears in the plan's preflight summary; the workflow does NOT fail (orphans are warnings, not errors); `cleo release orphans vNEXT` post-reconcile lists the commit. Operators can audit drift. |
+| **Failure-mode coverage** | (new capability — provenance Q5) |
+| **Test asset** | `packages/cleo/test/integration/release-v2-orphans.test.ts` |
+
+### S10 — Rollback creates a clean revert PR (forensics F8 + new rollback)
+
+| Property | Value |
+|---|---|
+| **Name** | S10 rollback-clean |
+| **Archetypes** | A1, A2 |
+| **Pre-conditions** | A release `vNEXT` has just shipped and `releases.status='reconciled'`; a P0 bug `T-test-S10-bug` is filed against it |
+| **Execution steps** | (1) `cleo release rollback vNEXT --full --reason "S10 dry-run rollback test"`; (2) wait for `release-rollback.yml` to open the revert PR; (3) inspect the revert PR's diff (MUST cleanly revert the bump commit); (4) merge the revert PR; (5) verify the tag is deleted; (6) verify `releases.status='rolled_back'` and `release_changes` has a new `change_type='revert'` row |
+| **Success criteria** | The revert PR opens against `main` (NOT a direct push). The PR title matches `Revert release vNEXT: S10 dry-run rollback test`. After merge: `gh release view vNEXT` returns 404; `npm view @release-test/cli@<version>` reports `deprecated: 'Rolled back: …'` (for A1/A2 archetypes). |
+| **Failure-mode coverage** | (new capability — clean rollback path; eliminates the manual `git tag -d && git push origin :refs/tags/<tag>` ritual) |
+| **Test asset** | `packages/cleo/test/integration/release-v2-rollback.test.ts` |
+
+### S11 — Project-agnostic: single npm lib ships (A2)
+
+| Property | Value |
+|---|---|
+| **Name** | S11 archetype-npm-lib |
+| **Archetypes** | A2 |
+| **Pre-conditions** | A2 fixture cloned; no `pnpm-workspace.yaml`; only one `package.json`; npm + tsc + vitest stack |
+| **Execution steps** | (1) `cleo release plan vNEXT --epic T-test-S11`; (2) inspect `plan.platformMatrix` — MUST contain a single `platform=any` entry; (3) `cleo release open vNEXT`; (4) workflow runs (single platform smoke); (5) publish to a local npm test registry (`verdaccio`); (6) reconcile; (7) verify `release_artifacts` row has `artifact_type='npm'` and a single matrix entry |
+| **Success criteria** | The same code path that ships A1 (monorepo) ships A2 (single lib) with NO conditional branches in the verbs themselves. Per SPEC R-360, archetype detection lives in `.cleo/project-context.json` + filesystem markers, not in verb logic. The pipeline does NOT spawn `pnpm`-specific commands for A2. |
+| **Failure-mode coverage** | F3 + ADR-053 portability regression — STRUCTURALLY ELIMINATED |
+| **Test asset** | `packages/cleo/test/integration/release-v2-archetype-npm-lib.test.ts` |
+
+### S12 — Project-agnostic: rust crate ships (A3)
+
+| Property | Value |
+|---|---|
+| **Name** | S12 archetype-rust-crate |
+| **Archetypes** | A3 |
+| **Pre-conditions** | A3 fixture cloned; cargo + clippy + rustfmt + cargo-test stack; a local crates.io mirror (sparse registry) for the publish target |
+| **Execution steps** | (1) `cleo release plan vNEXT --epic T-test-S12`; (2) inspect resolved tools — MUST be `cargo test`, `cargo build`, `cargo clippy`, `cargo audit`; (3) `cleo release open vNEXT`; (4) `release-prepare.yml`'s preflight runs the cargo toolchain (NOT pnpm); (5) `release-publish.yml`'s publish-and-tag job runs `cargo publish --token <test-token>` against the sparse mirror; (6) reconcile; (7) verify `release_artifacts.artifact_type='cargo'` |
+| **Success criteria** | The pipeline produces a cargo crate artifact with NO npm/pnpm references in the workflow logs. Cross-compile artifacts (linux-x64/arm64, macos-x64/arm64, windows-x64) are produced via `cargo build --target <triple>` for binary crates; library crates collapse to a single `[any]` matrix. |
+| **Failure-mode coverage** | F3 + ADR-053 portability regression — STRUCTURALLY ELIMINATED |
+| **Test asset** | `packages/cleo/test/integration/release-v2-archetype-rust-crate.test.ts` |
+
+---
+
+## 3. CI Matrix Configuration
+
+The matrix runs every scenario against every applicable archetype per the scenario's "Archetypes" column. The configuration uses GitHub Actions' matrix expansion plus a per-scenario `include` block to skip non-applicable archetypes.
+
+```yaml
+# .github/workflows/release-v2-matrix.yml (proposed; T9345-CHILD-3 deliverable)
+name: Release Pipeline v2 — Test Matrix
+
+on:
+  pull_request:
+    paths:
+      - 'packages/core/src/release/**'
+      - 'packages/cleo/test/fixtures/release-test-**'
+      - '.github/workflows/release-*.yml'
+  workflow_dispatch:
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - S1
+          - S2
+          - S3
+          - S4
+          - S5
+          - S6
+          - S7
+          - S8
+          - S9
+          - S10
+          - S11
+          - S12
+        archetype:
+          - A1
+          - A2
+          - A3
+        include:
+          # Stretch: S1/S4/S8 also run against A4 (python)
+          - { scenario: S1, archetype: A4 }
+          - { scenario: S4, archetype: A4 }
+          - { scenario: S8, archetype: A4 }
+        exclude:
+          # Scenarios that don't apply to every archetype
+          - { scenario: S2, archetype: A2 }
+          - { scenario: S2, archetype: A3 }
+          - { scenario: S3, archetype: A2 }
+          - { scenario: S3, archetype: A3 }
+          - { scenario: S6, archetype: A2 }
+          - { scenario: S6, archetype: A3 }
+          - { scenario: S7, archetype: A2 }
+          - { scenario: S7, archetype: A3 }
+          - { scenario: S9, archetype: A2 }
+          - { scenario: S9, archetype: A3 }
+          - { scenario: S11, archetype: A1 }
+          - { scenario: S11, archetype: A3 }
+          - { scenario: S12, archetype: A1 }
+          - { scenario: S12, archetype: A2 }
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with: { node-version: '22' }
+      - uses: pnpm/action-setup@v4
+        with: { version: '10' }
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        if: matrix.archetype == 'A3'
+      - uses: actions/setup-python@v6
+        if: matrix.archetype == 'A4'
+        with: { python-version: '3.13' }
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+
+      - name: Run scenario ${{ matrix.scenario }} against archetype ${{ matrix.archetype }}
+        env:
+          CLEO_FIXTURE_PATH: packages/cleo/test/fixtures/release-test-${{ matrix.archetype-name }}
+          CLEO_TEST_REGISTRY: http://localhost:4873   # verdaccio for A1/A2/A4
+        run: pnpm run test:scenario -- --scenario=${{ matrix.scenario }} --archetype=${{ matrix.archetype }}
+
+  summary:
+    needs: matrix
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: |
+          echo "Matrix complete. Inspect individual jobs for per-scenario detail."
+          # Aggregate green/red status; fail the summary job if any matrix slot failed.
+```
+
+### 3.1 Matrix coverage summary
+
+- **Total matrix slots**: 3 archetypes × 12 scenarios − 14 excluded + 3 stretch (A4) = **25 jobs per matrix run**.
+- **Estimated wall-time**: ≤15 minutes per slot in parallel = ~25 minutes wall-time per matrix run.
+- **Required for PR merge**: a green matrix run is required for any PR touching the release pipeline (per branch protection rules).
+- **Required for release-v2 acceptance**: 3 consecutive green matrix runs on `main` (no flakes) before declaring T9345 complete.
+
+### 3.2 Local execution
+
+Operators MAY run the matrix locally via:
+
+```bash
+# Single scenario, single archetype:
+pnpm run test:scenario -- --scenario=S1 --archetype=A1
+
+# All scenarios against one archetype:
+pnpm run test:matrix -- --archetype=A2
+
+# Full matrix:
+pnpm run test:matrix
+```
+
+The local runner provisions ephemeral fixtures and tears them down on exit. No persistent state is left in the developer's git tree.
+
+---
+
+## 4. Pass/Fail Gate
+
+The matrix's pass definition is quantitative and binary:
+
+### 4.1 Per-archetype pass
+
+For archetype A∈{A1,A2,A3}, "pass" means: every scenario in the matrix that applies to A is GREEN for three consecutive runs (no flakes).
+
+A4 (stretch) is informational; A4 failures do NOT block T9345 completion but MUST be triaged.
+
+### 4.2 Quantitative thresholds
+
+| Metric | Source | Threshold | Reason |
+|---|---|---|---|
+| Happy-path wall-time | S1 across A1, A2, A3 | ≤ 5 minutes | AC-1 |
+| Orphan commits | S8 + S9 across all archetypes | 0 in any shipped release | AC-2 |
+| Hotfix MTTR | S6 (A1 only) | ≤ 60 minutes including review | AC-3 |
+| Provenance verify | S8 across all archetypes | 100% pass | AC-7 |
+| Tag SHA mismatch | S5 across all archetypes | 0 mismatches over 100 runs | AC-1 + F6 prevention |
+| Build matrix coverage | S1/S5/S11/S12 | 5 platform tuples × archetype's package count | AC-4 + T1737 |
+| Deprecation surface | (manual check post-Phase 6) | `cleo release --help` shows exactly 4 verbs at top | AC-6 |
+| `--force` flag references | grep over `packages/cleo/src/cli/commands/release.ts` | 0 hits | AC-9 |
+| IVTR-from-release references | gitnexus_query "task.ivtr_state" scope release | 0 hits | AC-10 |
+
+### 4.3 Failure investigation protocol
+
+When a matrix slot fails:
+
+1. Inspect the GHA job log; download the artifact tarball from the workflow.
+2. Reproduce locally: `pnpm run test:scenario -- --scenario=<id> --archetype=<id>`.
+3. If the failure is flaky (not reproducible in 3 local runs), file a flaky-test bug and re-run the matrix.
+4. If reproducible: bisect the recent PRs that touched release code; revert if necessary.
+5. Update the scenario assertions if the failure indicates a specification ambiguity (file an ADR amendment).
+
+---
+
+## 5. Owner Sign-off Checklist
+
+Before declaring T9345 complete, the owner MUST verify each of the following items. Each item maps to an acceptance criterion from SPEC §14.
+
+### 5.1 Functional checklist
+
+- [ ] **AC-1 verified**: Three consecutive happy-path releases (S1) shipped through the new pipeline with operator wall-time ≤5 minutes each. Operator time-tracking artifact at `.cleo/audit/release-usage.jsonl`.
+- [ ] **AC-2 verified**: For the three most recent releases shipped via v2, `cleo release orphans <version>` returns an empty list. Output captured to `/tmp/orphans-vX.json`.
+- [ ] **AC-3 verified**: At least one hotfix path exercised end-to-end (real or test); MTTR measured ≤1 hour from issue creation to reconcile completion.
+- [ ] **AC-4 verified**: All three required archetypes (A1, A2, A3) pass the full matrix (S1-S12 applicable subset) in three consecutive runs. A4 (Python) passes at least S1, S4, S8 (stretch).
+- [ ] **AC-5 verified**: Forensics failure modes F1, F2, F3, F4, F5, F6, F8, F9, F10 do NOT reproduce against the new pipeline. Each was injected at least once and the structural prevention observed. F7 (worker direct-push) is mitigated by branch protection + T9345-CHILD-7 worktree-policy artifact.
+- [ ] **AC-6 verified**: `cleo release --help` output captured; shows exactly 4 verbs at the top (`plan`, `open`, `reconcile`, `rollback`); deprecated verbs listed under a "Deprecated" section with removal-release announcements.
+- [ ] **AC-7 verified**: All 11 provenance tables populated for every reconcile invocation in the post-migration window. `cleo provenance verify <version>` returns pass for the three most recent releases.
+- [ ] **AC-8 verified**: `actionlint` passes on all four workflow YAML files in CI. Latest CI run URL captured.
+- [ ] **AC-9 verified**: `grep -r "\-\-force" packages/cleo/src/cli/commands/release.ts` returns no hits. `gitnexus_query "force" scope release` returns no hits referencing the legacy flag (only the historical deletion commit).
+- [ ] **AC-10 verified**: `gitnexus_query "task.ivtr_state"` returns zero hits in `packages/core/src/release/*` (outside the deprecation shim doc).
+
+### 5.2 Schema + data checklist
+
+- [ ] All 9 migrations applied cleanly on the production `tasks.db`; backup taken before each phase.
+- [ ] Historical `release_manifests` rows preserved (count unchanged pre- vs. post-migration).
+- [ ] Backfill completed: ≥95% of historical `release_changes` rows have `provenance_quality='inferred'`; the remaining ≤5% are triaged.
+- [ ] `releases_view` returns correct counts for the three most recent releases.
+
+### 5.3 Documentation checklist
+
+- [ ] `ct-orchestrator` skill documentation updated to reference the 4 new verbs.
+- [ ] `AGENTS.md` Release & Branching section updated to describe `plan`/`open`/`reconcile`/`rollback`.
+- [ ] `CLEO-RELEASE-PIPELINE-SPEC.md` (legacy) marked superseded; redirects readers to `SPEC-T9345-release-pipeline-v2.md`.
+- [ ] `docs/release/branch-protection-setup.md` updated to include the new required status checks (`release-prepare/preflight`, `release-publish/build-matrix`, `release-publish/publish-and-tag`).
+- [ ] CHANGELOG entries for v2026.7.0 and v2026.7.1 use the new auto-generated format AND include a "T9345 migration" highlight section.
+
+### 5.4 Cleanup checklist
+
+- [ ] `releaseShip` monolith deleted (`packages/core/src/release/engine-ops.ts:1105-1866`).
+- [ ] Parallel 4-step pipeline deleted (`packages/core/src/release/pipeline.ts:releaseStart/Verify/Publish/Reconcile`).
+- [ ] IVTR-from-release glue deleted (`engine-ops.ts:releaseGateCheck`, `releaseIvtrAutoSuggest`, `checkIvtrGates`).
+- [ ] `defaultRunGate` stub deleted.
+- [ ] Net code reduction ≥1500 LOC verified via `git diff --stat <pre-T9345-tag>..HEAD packages/core/src/release/`.
+
+### 5.5 Final owner statement
+
+When all items above are checked, the owner signs the T9345 completion record by:
+
+1. Running `cleo verify T9345 --gate implemented --evidence "commit:<sha>;files:packages/core/src/release/plan.ts,packages/core/src/release/reconcile.ts,packages/core/src/release/open.ts;decision:ADR-073-ivtr-release-overhaul"`.
+2. Running `cleo verify T9345 --gate testsPassed --evidence "tool:test"`.
+3. Running `cleo verify T9345 --gate qaPassed --evidence "tool:lint;tool:typecheck"`.
+4. Running `cleo verify T9345 --gate documented --evidence "files:.cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md,.cleo/rcasd/T9345/research/migration-plan-T9345.md,.cleo/rcasd/T9345/research/test-matrix-T9345.md,.cleo/adrs/ADR-073-ivtr-release-overhaul.md"`.
+5. Running `cleo complete T9345`.
+
+Per ADR-051, this records evidence atoms for the spec-deliverable phase. Subsequent child epics (T9346-T9353) each record their own evidence on completion.
+
+---
+
+## 6. Test harness implementation notes
+
+This section is informative (not normative) but useful for T9345-CHILD-3 implementers.
+
+### 6.1 Fixture provisioning
+
+Fixtures live as static directories under `packages/cleo/test/fixtures/release-test-<archetype>/`. The test harness:
+
+1. Copies the fixture to a temp directory.
+2. Runs `git init && git add -A && git commit -m 'initial fixture'` to seed the git state.
+3. Tags the initial commit (`v0.0.1` or `v2026.5.0`).
+4. Adds 2-3 follow-up commits with `T####` tokens to simulate work between releases.
+5. Runs the scenario.
+6. Tears down the temp directory.
+
+The harness uses CLEO's existing `temp-dir` test utility (`packages/core/src/__test-utils__/temp-dir.ts`) for isolation.
+
+### 6.2 Workflow simulation locally
+
+Workflows are tested locally via `act` (nektos/act). The test harness invokes `act` with the appropriate workflow file and event payload:
+
+```bash
+act workflow_dispatch -W .github/workflows/release-prepare.yml \
+  --input version=v2026.7.0-test-1 \
+  --input plan-blob-sha256=$(sha256sum /tmp/plan.json | cut -d' ' -f1) \
+  --bind \
+  --container-architecture linux/amd64
+```
+
+For matrix slots, `act` runs each platform tuple in sequence; full cross-platform validation requires the real GHA runner matrix.
+
+### 6.3 Local registry mocks
+
+- **npm**: verdaccio (`docker run -p 4873:4873 verdaccio/verdaccio`) for A1/A2.
+- **cargo**: cargo-sparse-registry (local file:// URL) for A3.
+- **PyPI**: pypiserver (`pip install pypiserver`) for A4.
+- **GitHub Release**: a stub `gh release` mock that records calls but never publishes to a real registry.
+
+### 6.4 Time tracking
+
+The harness records:
+- Each scenario's start/end timestamp.
+- Each step's individual wall-time.
+- Workflow run URLs.
+- Final state of `releases.status` and provenance row counts.
+
+Outputs are aggregated into `.cleo/test-results/release-v2-matrix-<run-id>.json` for retrospective analysis.
+
+---
+
+## 7. Mapping back to SPEC requirements
+
+This section asserts that every scenario covers at least one normative SPEC requirement. The reverse direction (every SPEC requirement covered by ≥1 scenario) is verified separately as part of the T9345-CHILD-1 spec-acceptance gate.
+
+| Scenario | SPEC requirements covered (sample) |
+|---|---|
+| S1 | R-001 (LAFS envelope), R-009 (idempotency), R-030-R-042 (plan), R-050-R-071 (open), R-080-R-113 (reconcile), R-150 (read verbs) |
+| S2 | R-005 (timeout), R-006 (SIGKILL grace), R-204 (preflight timeout-minutes), R-209 (recovery hint) |
+| S3 | R-021 (epic existence), R-303 (epic locked at plan time), R-401 (hotfix scope) |
+| S4 | R-310 (require evidence), R-311 (resolver), R-312 (no double execution), R-313 (staleness) |
+| S5 | R-229 (poll before tag), R-082 (tagName match) |
+| S6 | R-400-R-405 (hotfix), R-022 (channel mismatch), AC-3 (MTTR) |
+| S7 | R-009 (idempotency), R-030 (atomic write), R-302 (FSM monotonic) |
+| S8 | R-091-R-097 (reconcile writes), R-345 (transactionality), R-151 (read verbs safe) |
+| S9 | R-024 (preflight summary), R-091 (release_commits NOT EXISTS task_commits) |
+| S10 | R-120-R-140 (rollback), R-254 (revert PR not direct push), R-256 (rollback reconcile) |
+| S11 | R-360 (project-context override), R-361 (archetype detection), R-370 (platform matrix) |
+| S12 | R-360, R-361, R-371 (single-platform collapse), provenance §7 (cargo polymorphism) |
+
+---
+
+*End of test matrix — T9345 wave-3 spec artifact.*


### PR DESCRIPTION
## Summary

Lands the T9345 RCASD research wave (11 files / ~7,600 lines) into main. This is a docs-only PR; the research has been complete and pushed to the recovery branch but not yet on main.

## Files (under .cleo/rcasd/T9345/research/)

- ADR-T9345-ivtr-release-overhaul.md (944 lines)
- SPEC-T9345-release-pipeline-v2.md (822 lines)
- T9345-research.md (139 lines)
- audit-cleo-release-subcommands.md (736 lines)
- failure-forensics-10-modes.md (1,291 lines)
- hermes-agent-real-research.md (1,180 lines)
- ivtr-conflation-audit.md (568 lines)
- letta-harness-real-research.md (1,091 lines)
- migration-plan-T9345.md (619 lines)
- provenance-graph-design.md (1,340 lines)
- test-matrix-T9345.md (529 lines)

## Test plan

- [x] Docs-only — no code, no test impact
- [ ] Admin-merge to land on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)