### PR TITLE
feat(T9506): add commits + task_commits + commit_files tables (provenance graph 1/4)

### DIFF
--- a/.cleo/rcasd/T9345/research/ADR-T9345-ivtr-release-overhaul.md
+++ b/.cleo/rcasd/T9345/research/ADR-T9345-ivtr-release-overhaul.md
@@ -62,7 +62,7 @@ The 10 failures collapse into 6 root-cause clusters (forensics §Cross-Failure S
 - **Missing provenance graph**: no `commits` table, no `release_manifest.commits → tasks` FK, no `releases` table — the owner-required "feature → bug → hotfix → epic → task → commit → release" graph is **derivable but not queryable** (audit Q4). `tasks.verification` and `task_relations` exist but lack `(release_id, commit_sha, task_id)` triples.
 - **~600 LOC of coupling to remove**: 17 IVTR gate references in `engine-ops.ts` lines 1251-1295 alone; plus 7 files directly integrating IVTR into release paths (audit §Phase 1).
 
-The audit's Priority 1 action is unambiguous: **decouple release from IVTR; evidence gates (ADR-051) become the sole release blocker** (audit §Recommendations, T9350).
+The audit's Priority 1 action is unambiguous: **decouple release from IVTR; evidence gates (ADR-051) become the sole release blocker** (audit §Recommendations, T9497).
 
 ### 4. External precedents (wave-1 research)
 

--- a/.cleo/rcasd/T9345/research/T9345-research.md
+++ b/.cleo/rcasd/T9345/research/T9345-research.md
@@ -49,7 +49,7 @@ The owner directive (2026-05-15) called for a full RCASD research wave on T9345 
 | # | Artifact | Lines | Purpose |
 |---|----------|------:|---------|
 | 8 | [`SPEC-T9345-release-pipeline-v2.md`](./SPEC-T9345-release-pipeline-v2.md) | 822 | **RFC-2119 normative spec**. 162 numbered requirements (R-001 → R-441). 16 sections covering CLI verbs, GHA workflows, evidence-gate integration (ADR-051 surface), provenance recording, project-agnostic resolution (7 archetypes), `releases.status` FSM, hotfix path, backward-compatibility window, failure-mode → spec-section mapping (8/10 structurally eliminated). |
-| 9 | [`migration-plan-T9345.md`](./migration-plan-T9345.md) | 619 | 6-phase migration plan (8–12 weeks). Each phase has scope, exit criteria, rollback trigger, LOC budget, owner-approval gates. 8 child epics decomposed (T9346 → T9353). Compatibility shim `cleo release ship --workflow=false` available for ≥3 release cycles post-cutover. Historical `release_manifests` never dropped. |
+| 9 | [`migration-plan-T9345.md`](./migration-plan-T9345.md) | 619 | 6-phase migration plan (8–12 weeks). Each phase has scope, exit criteria, rollback trigger, LOC budget, owner-approval gates. 8 child epics decomposed (T9491–T9499 — Phase 0: T9491, Phase 1: T9492, Phase 2: T9493, Phase 3: T9494, Phase 4: T9497, Phase 5: T9498, Phase 6: T9499, Tests: T9495). Bonus parallel forensics-fixes epic: T9496. Compatibility shim `cleo release ship --workflow=false` available for ≥3 release cycles post-cutover. Historical `release_manifests` never dropped. |
 | 10 | [`test-matrix-T9345.md`](./test-matrix-T9345.md) | 529 | 12 scenarios × 4 archetypes (monorepo-w-workspaces, single-npm-lib, single-rust-crate + python stretch). 25-slot GHA matrix. Each scenario maps to one or more of the 10 acceptance criteria + the 10 forensics failure modes. Owner sign-off checklist (30+ specific artifacts). |
 
 ## Acceptance-criteria mapping (against T9345 task description)
@@ -63,7 +63,7 @@ The owner directive (2026-05-15) called for a full RCASD research wave on T9345 
 | "Spec written for chosen direction with RFC 2119 must/should/may language" | #8 `SPEC-T9345-release-pipeline-v2.md` (162 R-numbered requirements) |
 | "Migration plan from current state with rollback path" | #9 `migration-plan-T9345.md` (6 phases × rollback per phase) |
 | "Test matrix proves IVTR works for at least 3 git-managed project archetypes: monorepo with workspaces (cleocode itself), single-package npm lib, single-binary rust crate" | #10 `test-matrix-T9345.md` (A1/A2/A3 required, A4 stretch) |
-| "All epic children produced or scheduled as separate IVTR tasks" | #7 + #9 enumerate 8 child epics (T9346 → T9353) — to be filed by the orchestrator when this research is signed off |
+| "All epic children produced or scheduled as separate IVTR tasks" | #7 + #9 enumerate 8 child epics — filed as T9491 (Phase 0), T9492 (Phase 1), T9493 (Phase 2), T9494 (Phase 3), T9497 (Phase 4), T9498 (Phase 5), T9499 (Phase 6), T9495 (tests). Bonus T9496 (5 forensics bug fixes, parallelizable with Phase 0) |
 
 ## Owner ask: "Have we conflated and over-engineered the IVTR system?"
 
@@ -75,9 +75,9 @@ The owner directive (2026-05-15) called for a full RCASD research wave on T9345 
 - `--force` undermines evidence integrity (already on removal track per ADR-051)
 
 **Streamlining path** (sketched in #5, normatively defined in #8):
-1. **Decouple release from IVTR** (T9346 / T9351 in the plan). `task.ivtr_state` becomes observation-only; the release pipeline never reads it for gate decisions.
+1. **Decouple release from IVTR** (Phase 5 epic T9498). `task.ivtr_state` becomes observation-only; the release pipeline never reads it for gate decisions.
 2. **Single gate surface** — ADR-051 evidence atoms are the only release gate. No parallel `runReleaseGates`, no IVTR phase gate, no `defaultRunGate` stub.
-3. **First-class provenance graph** (T9347). 11 new tables, 1 view, 14 new CLI verbs. Owner's "tracking graph of released code" becomes a SQL query.
+3. **First-class provenance graph** (Phase 0 epic T9491 + Phase 1 epic T9492). 11 new tables, 1 view, 14 new CLI verbs. Owner's "tracking graph of released code" becomes a SQL query.
 4. **Project-agnostic by default** — ADR-061 tool resolver is the only path; per-archetype assumptions (npm/pnpm/biome) are deleted.
 
 ## Owner ask: "scope of tracking is wider than a release — features, bugs, hotfixes, full provenance"
@@ -96,20 +96,65 @@ Both projects were researched against their **actual code**, not assumptions:
 
 The 5-platform target (linux x64/arm64, macos x64/arm64, win x64) is first-class in spec §9.2 (R-370, R-371). `plan.platformMatrix[]` enumerates publisher × platform pairs; `release-fanout.yml` runs the matrix job. Adding a new platform requires only an entry in `.cleo/project-context.json`, no release-pipeline code change.
 
+## GHA workflow architecture (clarification — NOT cleocode-specific)
+
+The four YAML workflows referenced throughout the ADR + SPEC (`release-prepare.yml`,
+`release-publish.yml`, `release-fanout.yml`, `release-rollback.yml`) are **CLEO-templated
+artifacts that any consuming project receives** — they are NOT files unique to the cleocode
+monorepo. The design is:
+
+- **Templates live in CLEO** at `packages/cleo/templates/workflows/release-*.yml.tmpl` (new path).
+- **`cleo init` / `cleo upgrade workflows`** scaffolds them into the consuming project's
+  `.github/workflows/` directory, parameterized by `.cleo/release-config.json` +
+  `.cleo/project-context.json`.
+- **Workflow structure is universal** (same trigger events, same job names, same
+  concurrency policy, same status checks emitted). What differs across projects is the
+  *contents* of the steps — which is resolved via ADR-061's tool resolver
+  (`tool:test`, `tool:build`, `tool:lint`, `tool:typecheck`, `tool:audit`,
+  `tool:security-scan`, `tool:publish`). A Rust crate runs `cargo test`; a Python
+  package runs `pytest`; a pnpm monorepo runs `pnpm run test`. The workflow doesn't know
+  or care — it invokes `cleo release plan|open|reconcile|rollback` (CLEO's own verbs)
+  and those verbs invoke the resolved tool.
+- **Per-archetype matrix** lives in `release-fanout.yml` and reads `plan.platformMatrix[]`
+  from the plan JSON file. Adding a new platform (e.g. `aarch64-linux-android`) is one
+  entry in `.cleo/project-context.json` — no workflow code change required.
+- **Project-agnosticism is structurally enforced**: the SPEC's R-362 mandates that adding a
+  new archetype MUST NOT require a release-pipeline code change. The workflow templates
+  pass this test because every project-specific concern routes through tool resolution.
+- **Upgrade story**: when CLEO ships a new workflow template version, consuming projects
+  run `cleo upgrade workflows` to merge the new template against any local customizations
+  (3-way merge with `.workflow-overrides.yml` for project-specific tweaks).
+
+This is the "highly opinionated, spec-driven workflow system any project can use" promise
+that ADR-073 makes operational. The workflows are CLEO's opinion *encoded as scaffold*,
+not as one-off files in cleocode.
+
+---
+
 ## Next steps for the orchestrator (after owner sign-off)
 
 1. **Council review** (optional but recommended) — invoke `/ct-council` to stress-test the ADR + SPEC against five advisors.
-2. **File 8 child epics** under T9345 per #9 `migration-plan-T9345.md` §"Child-epic decomposition":
-   - T9346 — Schema migration + provenance tables (Phase 0)
-   - T9347 — Read-mostly verbs `plan` + `reconcile` (Phase 1)
-   - T9348 — Provenance backfill across historical releases (Phase 2)
-   - T9349 — `release-prepare.yml` + `cleo release open` (Phase 3)
-   - T9350 — `release-publish.yml` + `release-fanout.yml` (Phase 4)
-   - T9351 — Operator surface flip + IVTR decoupling (Phase 5)
-   - T9352 — Cleanup: delete `releaseShip` monolith + parallel 4-step pipeline (Phase 6)
-   - T9353 — Test matrix + 3-archetype fixtures
+2. **File 8 real child epics** under T9345 via `cleo add --parent T9345 --type epic --kind work --pipelineStage spec --acceptance "..."` — task IDs are assigned by CLEO at creation time. The intended decomposition (one epic per migration phase, plus the test-matrix epic) per `migration-plan-T9345.md` §"Child-epic decomposition" is:
+   - Schema migration + provenance tables (Phase 0)
+   - Read-mostly verbs `plan` + `reconcile` (Phase 1)
+   - Provenance backfill across historical releases (Phase 2)
+   - `release-prepare.yml` template + `cleo release open` verb (Phase 3)
+   - `release-publish.yml` + `release-fanout.yml` templates + `cleo init/upgrade workflows` scaffolding (Phase 4)
+   - Operator surface flip + IVTR decoupling (Phase 5)
+   - Cleanup: delete `releaseShip` monolith + parallel 4-step pipeline (Phase 6)
+   - Test matrix + 3-archetype fixtures (cross-phase)
+
+   The real IDs assigned by `cleo add` MUST be recorded back into this index and into `migration-plan-T9345.md` §"Child-epic decomposition" before any implementation work begins. **No fabricated IDs in any artifact.**
+
 3. **Advance T9345 to `pipelineStage=spec`** once council convergence is reached.
 4. **Run RCASD's spec stage** on each child epic before its implementation begins.
+
+---
+
+## Honest corrections (post-review, 2026-05-16)
+
+- **Prior version of this index named fabricated task IDs `T9346`–`T9353`.** Those were planning placeholders, NOT real tasks in `tasks.db`. They have been removed. Real IDs will be assigned by `cleo add` at the moment each child epic is filed.
+- **Prior version of this index did not explain that the GHA workflows are CLEO-templated scaffolds, not cleocode-only files.** The new "GHA workflow architecture" section above corrects this. The ADR-073 SPEC §5 always intended this — it just was not surfaced in the index.
 
 ## Notes
 

--- a/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md
+++ b/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md
@@ -479,7 +479,7 @@ JOIN tasks b ON tr.related_to = b.id;
 
 ## Recommendations
 
-### Priority 1: Decouple Release from IVTR (T9350)
+### Priority 1: Decouple Release from IVTR (Phase 5 — T9498)
 
 **Action**: Remove IVTR gate check from `prepareRelease()`.
 
@@ -494,18 +494,18 @@ JOIN tasks b ON tr.related_to = b.id;
 
 **Impact**: Release no longer depends on IVTR state. Evidence gates become sole blocker.
 
-### Priority 2: Make Evidence Gates Mandatory (T9351)
+### Priority 2: Make Evidence Gates Mandatory (Phase 5 — T9498)
 
 **Action**: Implement ADR-051 D1–D9 fully (in-progress; some code merged, some not).
 
 - ✓ Implement `cleo verify --gate --evidence` (in-code)
 - ✓ Reject `cleo verify --all` without per-gate evidence (in-code)
 - ✓ Audit trail to `.cleo/audit/gates.jsonl` (in-code)
-- ❌ Evidence staleness check on `cleo complete` (NOT implemented; T9351)
-- ❌ Remove `--force` from completion (NOT implemented; T9351)
+- ❌ Evidence staleness check on `cleo complete` (NOT implemented; T9498 — Phase 5)
+- ❌ Remove `--force` from completion (NOT implemented; T9498 — Phase 5)
 - ❌ `CLEO_OWNER_OVERRIDE` audit logging (PARTIAL; needs `.cleo/audit/force-bypass.jsonl`)
 
-### Priority 3: Build Release-Provenance Graph (T9352)
+### Priority 3: Build Release-Provenance Graph (Phase 0 — T9491)
 
 **Action**: Implement `release_manifest_commits` table + `releases` table + view.
 
@@ -526,7 +526,7 @@ JOIN tasks b ON tr.related_to = b.id
 WHERE r.version = '1.2.3' AND b.kind = 'bug';
 ```
 
-### Priority 4: Deprecate IVTR State Machine (T9353)
+### Priority 4: Deprecate IVTR State Machine (Phase 5 — T9498)
 
 **Action**: Mark `tasks.ivtr_state` column as @deprecated. Provide read-only view.
 
@@ -562,7 +562,7 @@ This audit identifies:
 - ✓ 6 overlapping gate concepts
 - ✓ 5 missing provenance graph components
 - ✓ 2 viable decoupling paths (evidence-first, graph-normalized)
-- ✓ 4 high-priority follow-up tasks (T9350–T9353)
+- ✓ 4 high-priority follow-up tasks (T9491, T9497, T9498, T9499)
 
 **Output**: `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md`
 

--- a/.cleo/rcasd/T9345/research/migration-plan-T9345.md
+++ b/.cleo/rcasd/T9345/research/migration-plan-T9345.md
@@ -15,7 +15,7 @@
 
 This plan describes how the CLEO codebase moves from the ADR-065 12-step `cleo release ship` monolith (currently shipping every release since v2026.5.43) to the SPEC-T9345 v2 architecture (4 operator verbs + 4 GHA workflows + 11 new provenance tables) **without breaking the next release**. The migration is sequenced as six phases over a maximum of twelve operator-weeks (≈8 calendar weeks with two parallel orchestrators). Each phase has explicit entry criteria, exit criteria, a measurable rollback trigger, and a defined LOC-change budget. Phases 0-2 are additive — they introduce new schema and read-only verbs alongside the legacy monolith with zero behavior change. Phases 3-5 are cutovers where the operator surface flips: Phase 3 introduces `cleo release open` and the prepare workflow opt-in, Phase 4 introduces publish + reconcile workflows, Phase 5 deprecates `cleo release ship` and makes the new path the default. Phase 6 is cleanup — deletion of the 761-line monolith and the parallel 4-step pipeline. The plan also defines a compatibility shim (`cleo release ship --workflow=false`) that preserves the legacy path for emergency use through the third release cycle after Phase 5 completes.
 
-Risk grading is honest: Phases 0-2 and 6 are LOW (additive or post-cutover); Phases 3-4 are MEDIUM (new workflows are load-bearing); Phase 5 is HIGH (operator surface flip). Each high-risk phase has a defined rollback path with exact git/SQL commands and a dogfooded test release on a non-main branch as a phase gate. Eight child epics are pre-decomposed at the bottom of this document (T9346-T9353) so the orchestrator can spawn them in parallel where independent.
+Risk grading is honest: Phases 0-2 and 6 are LOW (additive or post-cutover); Phases 3-4 are MEDIUM (new workflows are load-bearing); Phase 5 is HIGH (operator surface flip). Each high-risk phase has a defined rollback path with exact git/SQL commands and a dogfooded test release on a non-main branch as a phase gate. Eight child epics are pre-decomposed at the bottom of this document (T9491-T9495) so the orchestrator can spawn them in parallel where independent.
 
 The plan binds tightly to `SPEC-T9345-release-pipeline-v2.md`: every phase's deliverables map to a specific subset of normative requirements (R-NNN), every phase's exit criterion is a scenario from `test-matrix-T9345.md`, and every rollback path preserves the legacy `release_manifests` table per Force F12 (backward compatibility). Total LLM spend across the migration is estimated at ~$300; total operator-week cost (orchestrator + human review) is ~12 operator-weeks. The migration ships zero data loss, zero forced downtime on `tasks.db`, and zero release blackouts (the legacy path is available throughout Phases 0-5).
 
@@ -42,7 +42,7 @@ Six phases, each bounded to 2 calendar weeks max. Each row in the table is norma
 | 0 | Schema migration + dual-write kill-switch | LOW | 1 wk | +400 (DDL + accessors) | trivial revert | Migrations applied; `CLEO_PROVENANCE_DUAL_WRITE=1` (default off) |
 | 1 | `plan` + `reconcile` (read-mostly) | LOW | 2 wks | +700 (new modules) | trivial revert | Both verbs return correct envelopes against test fixtures |
 | 2 | Provenance backfill (`cleo provenance backfill`) | MEDIUM | 2 wks | +400 (backfill writer) | idempotent UPSERT; safe to re-run | Historical releases (v2026.5.0 → v2026.5.74) backfilled with `provenance_quality='inferred'` ≤5% of rows |
-| 3 | `release-prepare.yml` + `open` verb | MEDIUM | 2 wks | +200 + 1 YAML | revertible via PR; legacy path untouched | Test release `v2026.7.0-test-1` shipped on `release-test/T9347` branch through new prepare workflow |
+| 3 | `release-prepare.yml` + `open` verb | MEDIUM | 2 wks | +200 + 1 YAML | revertible via PR; legacy path untouched | Test release `v2026.7.0-test-1` shipped on `release-test/T9492` branch through new prepare workflow |
 | 4 | `release-publish.yml` + `release-fanout.yml` + matrix | HIGH | 2 wks | +200 + 2 YAML | revertible via workflow rename + branch reset | Real minor release (target: `v2026.7.0`) ships through new publish path while `cleo release ship` available as `--workflow=false` fallback |
 | 5 | Operator surface flip (`ship` deprecated) | HIGH | 2 wks | -800 (monolith deleted) +200 (shim) | possible via PR revert during transition window | Two consecutive releases ship without invoking `--workflow=false`; deprecation warnings active |
 | 6 | Cleanup | LOW | 1 wk | -1500 net | not reversible; do last | `releaseShip` monolith deleted; IVTR-from-release code removed; CI green; `cleo release --help` shows 4 verbs |
@@ -81,7 +81,7 @@ cleo restore backup --file tasks.db --from tasks-20260520-120000.db
 git revert <phase-0-commit-sha>
 ```
 
-**Owner approval gate**: T9346 (Phase 0 epic) closed by HITL approval before Phase 1 begins.
+**Owner approval gate**: T9491 (Phase 0 epic) closed by HITL approval before Phase 1 begins.
 
 ### 2.2 Phase 1 — `plan` + `reconcile` (2 weeks, LOW)
 
@@ -109,7 +109,7 @@ git revert <phase-0-commit-sha>
 **Rollback trigger**: any of the new verbs corrupts existing `tasks.db` data (caught by invariant checks).
 **Rollback**: `git revert <phase-1-commit-range>`. Schema from Phase 0 stays; verbs disappear.
 
-**Owner approval gate**: T9347 (Phase 1 epic) closed; demo of the 6 scenarios green.
+**Owner approval gate**: T9492 (Phase 1 epic) closed; demo of the 6 scenarios green.
 
 ### 2.3 Phase 2 — Provenance backfill (2 weeks, MEDIUM)
 
@@ -139,14 +139,14 @@ DELETE FROM task_commits WHERE created_at >= '2026-05-20T00:00:00Z' AND link_sou
 ```
 Backfill is timestamped + tagged with `link_source='backfill'`; clean deletion is straightforward.
 
-**Owner approval gate**: T9348 (Phase 2 epic) closed; backfill report reviewed.
+**Owner approval gate**: T9493 (Phase 2 epic) closed; backfill report reviewed.
 
 ### 2.4 Phase 3 — `release-prepare.yml` + `open` verb (2 weeks, MEDIUM)
 
 **Scope**:
 - Write `release-prepare.yml` per SPEC §5.1 (R-200 through R-210). Triggers on `workflow_dispatch`. Runs preflight (lint+typecheck+build+test). Bumps version + CHANGELOG. Opens bump-PR.
 - Implement `cleo release open <version>` per SPEC R-050 through R-071. Reads plan file; invokes `gh workflow run`.
-- Test on a non-main branch: cut `release-test/T9349`, set up branch protection mimicking main, dispatch the workflow against `v2026.7.0-test-1`, verify the bump-PR opens correctly with all gates green.
+- Test on a non-main branch: cut `release-test/T9494`, set up branch protection mimicking main, dispatch the workflow against `v2026.7.0-test-1`, verify the bump-PR opens correctly with all gates green.
 - Do NOT touch `release-publish.yml` yet; the test release does NOT publish. The bump-PR is reviewed and closed without merge.
 
 **Deliverables**:
@@ -170,10 +170,10 @@ mv .github/workflows/release-prepare.yml .github/workflows/release-prepare.yml.d
 # 2. Revert the open verb wiring.
 git revert <phase-3-commit-sha>
 # 3. Manually clean up any orphaned release-test/* branches.
-git push origin --delete release-test/T9349
+git push origin --delete release-test/T9494
 ```
 
-**Owner approval gate**: T9349 (Phase 3 epic) closed; dogfood demo on `release-test/T9349` green.
+**Owner approval gate**: T9494 (Phase 3 epic) closed; dogfood demo on `release-test/T9494` green.
 
 ### 2.5 Phase 4 — `release-publish.yml` + `release-fanout.yml` (2 weeks, HIGH)
 
@@ -244,7 +244,7 @@ mv .github/workflows/release-fanout.yml .github/workflows/release-fanout.yml.dis
 # 5. Operator falls back to cleo release ship --workflow=false for the next release.
 ```
 
-**Owner approval gate**: T9350 (Phase 4 epic) closed; v2026.7.0 shipped clean; rollback path TESTED at least once in dry-run (S10).
+**Owner approval gate**: T9497 (Phase 4 epic) closed; v2026.7.0 shipped clean; rollback path TESTED at least once in dry-run (S10).
 
 ### 2.6 Phase 5 — Operator surface flip (2 weeks, HIGH)
 
@@ -279,7 +279,7 @@ git push origin fix/T9345-phase5-rollback
 CLEO_RELEASE_EMERGENCY=1 cleo release ship vNEXT --workflow=false --epic T<n>
 ```
 
-**Owner approval gate**: T9351 (Phase 5 epic) closed; 2 releases green; emergency shim usage = 0.
+**Owner approval gate**: T9498 (Phase 5 epic) closed; 2 releases green; emergency shim usage = 0.
 
 ### 2.7 Phase 6 — Cleanup (1 week, LOW)
 
@@ -306,7 +306,7 @@ CLEO_RELEASE_EMERGENCY=1 cleo release ship vNEXT --workflow=false --epic T<n>
 **Rollback trigger**: a test or production release breaks because a deleted symbol is still referenced.
 **Rollback**: `git revert <phase-6-commit-range>`. The previous phases' code is intact; only the cleanup is rolled back.
 
-**Owner approval gate**: T9353 (Phase 6 epic) closed; final demo of the 4-verb surface; migration complete.
+**Owner approval gate**: T9495 (Phase 6 epic) closed; final demo of the 4-verb surface; migration complete.
 
 ---
 
@@ -400,9 +400,9 @@ Mostly automated. The operator's job is to observe and approve.
 
 ```bash
 # Monitor migration progress.
-cleo find "T9346" --status in_progress  # Phase 0 epic
-cleo find "T9347" --status in_progress  # Phase 1 epic
-cleo find "T9348" --status in_progress  # Phase 2 epic
+cleo find "T9491" --status in_progress  # Phase 0 epic
+cleo find "T9492" --status in_progress  # Phase 1 epic
+cleo find "T9493" --status in_progress  # Phase 2 epic
 
 # Inspect backfill state after Phase 2 completes.
 cleo provenance verify v2026.5.74  # spot-check most recent release
@@ -415,14 +415,14 @@ Test-release-driven. Operator initiates each test release.
 
 ```bash
 # Phase 3: dispatch the prepare workflow against a non-main branch.
-git checkout -b release-test/T9349
-git push origin release-test/T9349
-cleo release plan v2026.7.0-test-1 --epic T9349
+git checkout -b release-test/T9494
+git push origin release-test/T9494
+cleo release plan v2026.7.0-test-1 --epic T9494
 cleo release open v2026.7.0-test-1
 # Inspect the bump-PR; close without merging.
 
 # Phase 4: ship the real v2026.7.0 through the new path.
-cleo release plan v2026.7.0 --epic T9349
+cleo release plan v2026.7.0 --epic T9494
 cleo release open v2026.7.0
 # Wait for bump-PR review + auto-merge.
 # release-publish.yml runs automatically.
@@ -437,7 +437,7 @@ Default-flip; operators ship normally with deprecation warnings.
 
 ```bash
 # Normal release flow under the new default.
-cleo release ship v2026.7.1 --epic T9351
+cleo release ship v2026.7.1 --epic T9498
 # Now prints: "DEPRECATED: 'cleo release ship' will be removed in v2027.1. Use 'cleo release plan/open' instead."
 # Under the hood: invokes plan + open.
 
@@ -486,7 +486,7 @@ SELECT version, status, change_count, bug_count, hotfix_count, breaking_count FR
 
 The migration is delivered as eight child epics filed under T9345. Each epic has a slot, a kind, a size, dependencies, and three top-line acceptance criteria. Orchestrators MAY spawn the independent epics in parallel.
 
-### T9346 — Phase 0: Schema migration + dual-write kill-switch
+### T9491 — Phase 0: Schema migration + dual-write kill-switch
 
 - **Kind**: work
 - **Size**: small
@@ -498,84 +498,84 @@ The migration is delivered as eight child epics filed under T9345. Each epic has
   2. `cleo provenance verify <version>` CLI verb exists and returns pass for an empty schema.
   3. `CLEO_PROVENANCE_DUAL_WRITE=1` env var causes `cleo release ship` to ALSO write to `releases` + `release_changes` without breaking the legacy `release_manifests.tasksJson` path.
 
-### T9347 — Phase 1: `plan` + `reconcile` (read-mostly)
+### T9492 — Phase 1: `plan` + `reconcile` (read-mostly)
 
 - **Kind**: work
 - **Size**: medium
 - **Priority**: P1
-- **BlockedBy**: T9346
+- **BlockedBy**: T9491
 - **Owner**: orchestrator + 2 workers (plan, reconcile, tests in parallel)
 - **Acceptance**:
-  1. `cleo release plan v2026.7.0-test-1 --epic T9347` produces a valid plan file conforming to SPEC §6 against the cleocode repo.
+  1. `cleo release plan v2026.7.0-test-1 --epic T9492` produces a valid plan file conforming to SPEC §6 against the cleocode repo.
   2. `cleo release reconcile v2026.7.0-test-1` against a hand-prepared test release populates the 11 provenance tables; `cleo provenance verify` passes.
   3. 14 read verbs (`cleo release graph/diff/impact/authors/orphans` + `cleo provenance task/commit/pr/feature/release/change/backfill/link/verify`) return correct envelopes against `test-matrix-T9345.md` fixtures.
 
-### T9348 — Phase 2: Provenance backfill
+### T9493 — Phase 2: Provenance backfill
 
 - **Kind**: work
 - **Size**: medium
 - **Priority**: P2
-- **BlockedBy**: T9347
+- **BlockedBy**: T9492
 - **Owner**: orchestrator + 1 worker
 - **Acceptance**:
   1. `cleo provenance backfill --since v2026.4.0` populates `commits`, `task_commits`, `release_commits`, `release_changes`, `release_artifacts`, `pull_requests`, `pr_commits`, `pr_tasks`, `commit_files`, `brain_release_links` for all 70+ historical releases.
   2. ≥95% of `release_changes` rows have `provenance_quality='inferred'` (high-confidence extraction).
   3. Re-running the backfill is a verified no-op (UPSERT idempotency proven via integration test).
 
-### T9349 — Phase 3: `release-prepare.yml` + `open` verb
+### T9494 — Phase 3: `release-prepare.yml` + `open` verb
 
 - **Kind**: work
 - **Size**: medium
 - **Priority**: P1
-- **BlockedBy**: T9347
+- **BlockedBy**: T9492
 - **Owner**: orchestrator + 2 workers (workflow YAML, open verb)
 - **Acceptance**:
-  1. `release-prepare.yml` passes `actionlint` and successfully opens a bump-PR for a test release on a non-main branch (`release-test/T9349`).
+  1. `release-prepare.yml` passes `actionlint` and successfully opens a bump-PR for a test release on a non-main branch (`release-test/T9494`).
   2. `cleo release open <version>` invokes `gh workflow run` and polls until the run reaches in-progress; updates `releases.status='pr-opened'`; emits LAFS envelope with `workflowRunUrl`.
   3. Test scenario S3 (epic-completeness scope) and S9 (orphan-commit detection) pass on the test fixture.
 
-### T9350 — Phase 4: `release-publish.yml` + `release-fanout.yml` + matrix
+### T9497 — Phase 4: `release-publish.yml` + `release-fanout.yml` + matrix
 
 - **Kind**: work
 - **Size**: large
 - **Priority**: P1
-- **BlockedBy**: T9349
+- **BlockedBy**: T9494
 - **Owner**: orchestrator + 3 workers (publish, fanout, matrix)
 - **Acceptance**:
   1. `v2026.7.0` ships entirely through the new path with operator wall-time ≤5 minutes from `cleo release plan` to `cleo provenance verify` passing.
   2. Build matrix produces 5 platform artifacts (linux-x64/arm64, macos-x64/arm64, windows-x64) attached to the GitHub Release.
   3. Failure modes F1 (wedged commit), F6 (tag at wrong SHA), F8 (release start no-op) DO NOT reproduce. Verified by injecting F1/F6/F8 conditions on a test branch and confirming the new path catches them.
 
-### T9351 — Phase 5: Operator surface flip + `cleo release ship` deprecation
+### T9498 — Phase 5: Operator surface flip + `cleo release ship` deprecation
 
 - **Kind**: work
 - **Size**: small
 - **Priority**: P1
-- **BlockedBy**: T9350
+- **BlockedBy**: T9497
 - **Owner**: orchestrator + 1 worker + docs writer
 - **Acceptance**:
   1. `cleo release ship` defaults to `--workflow=true`; prints deprecation warning; forwards to `plan + open`.
   2. Two consecutive real releases (`v2026.7.1` and `v2026.7.2`) ship through the new path with no `--workflow=false` invocations.
   3. `ct-orchestrator` skill documentation updated; operator survey returns ≥7/10 ease-of-use score from ≥3 operators.
 
-### T9352 — IVTR decoupling from release path (parallel to Phases 3-5)
+### T9499 — IVTR decoupling from release path (parallel to Phases 3-5)
 
 - **Kind**: work
 - **Size**: small
 - **Priority**: P1
-- **BlockedBy**: T9346 (schema), T9347 (plan)
+- **BlockedBy**: T9491 (schema), T9492 (plan)
 - **Owner**: orchestrator + 1 worker
 - **Acceptance**:
   1. `releaseGateCheck`, `releaseIvtrAutoSuggest`, `checkIvtrGates` removed from `engine-ops.ts` (post Phase 5).
   2. `task.ivtr_state` marked `@deprecated`; read-only view derived from ADR-051 evidence atoms.
   3. `cleo orchestrate ivtr --start/--next/--release` deprecated; only `--status` remains as a read-only view.
 
-### T9353 — Phase 6: Cleanup (monolith deletion)
+### T9495 — Phase 6: Cleanup (monolith deletion)
 
 - **Kind**: work
 - **Size**: small
 - **Priority**: P2
-- **BlockedBy**: T9351, T9352
+- **BlockedBy**: T9498, T9499
 - **Owner**: orchestrator + 1 worker
 - **Acceptance**:
   1. `releaseShip` (engine-ops.ts:1105-1866, 761 LOC) deleted.
@@ -605,12 +605,12 @@ gantt
     section Phase 6
     Cleanup                 :p6, after p5, 1w
     section Parallel
-    T9352 IVTR decouple     :ivtr, after p1, 4w
+    T9499 IVTR decouple     :ivtr, after p1, 4w
 ```
 
 Parallel orchestrators MAY collapse the timeline:
-- T9348 (backfill) can run in parallel with T9349 (prepare workflow) — neither depends on the other after T9347.
-- T9352 (IVTR decouple) can run in parallel with Phases 3-5.
+- T9493 (backfill) can run in parallel with T9494 (prepare workflow) — neither depends on the other after T9492.
+- T9499 (IVTR decouple) can run in parallel with Phases 3-5.
 
 Best-case calendar (2 parallel orchestrators): **8 weeks**. Worst-case (single sequential orchestrator): **12 weeks**.
 

--- a/.cleo/rcasd/T9345/research/test-matrix-T9345.md
+++ b/.cleo/rcasd/T9345/research/test-matrix-T9345.md
@@ -451,7 +451,7 @@ When all items above are checked, the owner signs the T9345 completion record by
 4. Running `cleo verify T9345 --gate documented --evidence "files:.cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md,.cleo/rcasd/T9345/research/migration-plan-T9345.md,.cleo/rcasd/T9345/research/test-matrix-T9345.md,.cleo/adrs/ADR-073-ivtr-release-overhaul.md"`.
 5. Running `cleo complete T9345`.
 
-Per ADR-051, this records evidence atoms for the spec-deliverable phase. Subsequent child epics (T9346-T9353) each record their own evidence on completion.
+Per ADR-051, this records evidence atoms for the spec-deliverable phase. Subsequent child epics (T9491, T9492, T9493, T9494, T9495, T9496, T9497, T9498, T9499) each record their own evidence on completion.
 
 ---
 

--- a/packages/core/migrations/drizzle-tasks/20260516000000_t9506-add-commits-table/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260516000000_t9506-add-commits-table/migration.sql
@@ -1,0 +1,51 @@
+-- T9506 (1/4): Add `commits` table for provenance graph (ADR-073 / SPEC-T9345 §3.1).
+--
+-- Captures every git commit reachable from a release tag. Stores identity, author
+-- attribution, Conventional Commits classification, and project correlation so that
+-- SQL queries can answer "which commits shipped in release vX.Y.Z?" without shelling
+-- out to git at query time.
+--
+-- New edges enabled:
+--   commit → release  (via release_commits junction — shipped in 2/4)
+--   commit → task     (via task_commits junction — shipped in 2/4)
+--   commit → file     (via commit_files — shipped in 3/4)
+--
+-- All columns use SQLite-idiomatic types: TEXT for strings + ISO-8601 timestamps,
+-- INTEGER for booleans (0/1), NULL for truly optional fields.
+--
+-- @task T9506
+-- @epic T9491
+
+CREATE TABLE `commits` (
+  `sha`                TEXT PRIMARY KEY NOT NULL,
+  `short_sha`          TEXT NOT NULL,
+  `author_name`        TEXT,
+  `author_email`       TEXT,
+  `authored_at`        TEXT NOT NULL,
+  `committer_name`     TEXT,
+  `committer_email`    TEXT,
+  `committed_at`       TEXT NOT NULL,
+  `message`            TEXT NOT NULL,
+  `subject`            TEXT NOT NULL,
+  `conventional_type`  TEXT,
+  `is_release_commit`  INTEGER NOT NULL DEFAULT 0,
+  `is_merge_commit`    INTEGER NOT NULL DEFAULT 0,
+  `parent_shas`        TEXT NOT NULL DEFAULT '[]',
+  `signature_verified` INTEGER,
+  `branch_at_commit`   TEXT,
+  `project_hash`       TEXT,
+  `created_at`         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+--> statement-breakpoint
+
+CREATE INDEX `idx_commits_short_sha` ON `commits` (`short_sha`);
+--> statement-breakpoint
+CREATE INDEX `idx_commits_author_email` ON `commits` (`author_email`);
+--> statement-breakpoint
+CREATE INDEX `idx_commits_authored_at` ON `commits` (`authored_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_commits_conventional_type` ON `commits` (`conventional_type`);
+--> statement-breakpoint
+CREATE INDEX `idx_commits_is_release` ON `commits` (`is_release_commit`);
+--> statement-breakpoint
+CREATE INDEX `idx_commits_project_hash` ON `commits` (`project_hash`);

--- a/packages/core/migrations/drizzle-tasks/20260516000000_t9506-add-commits-table/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260516000000_t9506-add-commits-table/revert.sql
@@ -1,0 +1,6 @@
+-- Revert T9506 migration 1/4: drop commits table and its indexes.
+-- Indexes are dropped implicitly by SQLite when the table is dropped.
+--
+-- @task T9506
+
+DROP TABLE IF EXISTS `commits`;

--- a/packages/core/migrations/drizzle-tasks/20260516000001_t9506-add-task-commits-table/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260516000001_t9506-add-task-commits-table/migration.sql
@@ -1,0 +1,34 @@
+-- T9506 (2/4): Add `task_commits` table for provenance graph (ADR-073 / SPEC-T9345 §3.2).
+--
+-- M:N junction between tasks and commits. Each row records one typed linkage edge:
+--   task_id    → the CLEO task that a commit relates to
+--   commit_sha → the git commit SHA (FK → commits.sha)
+--   link_kind  → semantic classification (implements/fixes/refactors/tests/docs/reverts)
+--   link_source → how the link was discovered (commit-trailer/commit-subject/pr-title/
+--                 pr-body/branch-name/manual)
+--
+-- Composite PK (task_id, commit_sha, link_kind) permits a single commit to be linked
+-- to a single task via multiple relationship types (e.g., both 'implements' and 'tests').
+--
+-- FK task_id uses ON DELETE SET NULL (not CASCADE) to preserve commit linkage history
+-- even if the task is deleted — provenance graph must not lose edges on task purge.
+-- FK commit_sha uses ON DELETE CASCADE — if a commit is purged, its junction rows go too.
+--
+-- @task T9506
+-- @epic T9491
+
+CREATE TABLE `task_commits` (
+  `task_id`    TEXT REFERENCES `tasks`(`id`) ON DELETE SET NULL,
+  `commit_sha` TEXT NOT NULL REFERENCES `commits`(`sha`) ON DELETE CASCADE,
+  `link_kind`  TEXT NOT NULL,
+  `link_source` TEXT NOT NULL,
+  `created_at` TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (`task_id`, `commit_sha`, `link_kind`)
+);
+--> statement-breakpoint
+
+CREATE INDEX `idx_task_commits_task_id` ON `task_commits` (`task_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_task_commits_commit_sha` ON `task_commits` (`commit_sha`);
+--> statement-breakpoint
+CREATE INDEX `idx_task_commits_link_kind` ON `task_commits` (`link_kind`);

--- a/packages/core/migrations/drizzle-tasks/20260516000001_t9506-add-task-commits-table/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260516000001_t9506-add-task-commits-table/revert.sql
@@ -1,0 +1,6 @@
+-- Revert T9506 migration 2/4: drop task_commits table and its indexes.
+-- Indexes are dropped implicitly by SQLite when the table is dropped.
+--
+-- @task T9506
+
+DROP TABLE IF EXISTS `task_commits`;

--- a/packages/core/migrations/drizzle-tasks/20260516000002_t9506-add-commit-files-table/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260516000002_t9506-add-commit-files-table/migration.sql
@@ -1,0 +1,39 @@
+-- T9506 (3/4): Add `commit_files` table for provenance graph (ADR-073 / SPEC-T9345 §3.3).
+--
+-- Per-file × SHA materialization. Every (commit_sha, path) pair has one row describing
+-- the type of change (added/modified/deleted/renamed/copied), diff stats, and whether
+-- the file is binary.
+--
+-- Enables blast-radius queries:
+--   "Which tasks last touched packages/core/src/release/engine-ops.ts?" →
+--     SELECT t.id FROM commit_files cf
+--     JOIN task_commits tc ON tc.commit_sha = cf.commit_sha
+--     JOIN tasks t ON t.id = tc.task_id
+--     WHERE cf.path = 'packages/core/src/release/engine-ops.ts'
+--
+-- change_type values mirror git status letters:
+--   A = added, M = modified, D = deleted, R = renamed, C = copied
+--
+-- old_path is non-NULL only for R (rename) and C (copy) — records the source path.
+--
+-- FK commit_sha uses ON DELETE CASCADE — if a commit is purged, its file rows go too.
+-- Composite PK (commit_sha, path) is unique per commit: one row per file per commit.
+--
+-- @task T9506
+-- @epic T9491
+
+CREATE TABLE `commit_files` (
+  `commit_sha`  TEXT NOT NULL REFERENCES `commits`(`sha`) ON DELETE CASCADE,
+  `path`        TEXT NOT NULL,
+  `old_path`    TEXT,
+  `change_type` TEXT NOT NULL,
+  `lines_added` INTEGER NOT NULL DEFAULT 0,
+  `lines_deleted` INTEGER NOT NULL DEFAULT 0,
+  `is_binary`   INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (`commit_sha`, `path`)
+);
+--> statement-breakpoint
+
+CREATE INDEX `idx_commit_files_path` ON `commit_files` (`path`);
+--> statement-breakpoint
+CREATE INDEX `idx_commit_files_change_type` ON `commit_files` (`change_type`);

--- a/packages/core/migrations/drizzle-tasks/20260516000002_t9506-add-commit-files-table/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260516000002_t9506-add-commit-files-table/revert.sql
@@ -1,0 +1,6 @@
+-- Revert T9506 migration 3/4: drop commit_files table and its indexes.
+-- Indexes are dropped implicitly by SQLite when the table is dropped.
+--
+-- @task T9506
+
+DROP TABLE IF EXISTS `commit_files`;

--- a/packages/core/src/store/__tests__/commits-schema-parity.test.ts
+++ b/packages/core/src/store/__tests__/commits-schema-parity.test.ts
@@ -1,0 +1,522 @@
+/**
+ * Schema parity guardrails for the T9506 provenance graph tables:
+ *   `commits`, `task_commits`, `commit_files`.
+ *
+ * Each test validates that:
+ *   1. The migration SQL file creates the expected table with correct column names.
+ *   2. The migration SQL defines the expected indexes.
+ *   3. The Drizzle schema enums in tasks-schema.ts are consistent with what
+ *      the migration embeds (when CHECK constraints are present).
+ *   4. All three tables apply cleanly on a fresh in-memory tasks.db via the
+ *      standard `migrateSanitized` pipeline.
+ *
+ * @task T9506
+ * @epic T9491
+ */
+
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  COMMIT_CONVENTIONAL_TYPES,
+  COMMIT_FILE_CHANGE_TYPES,
+  COMMIT_LINK_KINDS,
+  COMMIT_LINK_SOURCES,
+  commitFiles,
+  commits,
+  taskCommits,
+} from '../tasks-schema.js';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (
+    path: string,
+    opts?: { readonly?: boolean },
+  ) => import('node:sqlite').DatabaseSync;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Resolve path to the drizzle-tasks migration folder. */
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+/** Read all migration SQL files from the drizzle-tasks folder (sorted). */
+function getAllMigrationFiles(): Array<{ name: string; sql: string }> {
+  const dir = migrationsDir();
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort()
+    .map((name) => ({
+      name,
+      sql: readFileSync(join(dir, name, 'migration.sql'), 'utf-8'),
+    }));
+}
+
+/** Find the migration SQL for a given T9506 table. */
+function getMigrationSql(tableHint: string): string {
+  const files = getAllMigrationFiles();
+  const match = files.filter(({ sql }) => sql.includes(tableHint)).pop(); // use the latest migration that mentions the table
+  if (!match) throw new Error(`No migration found for table hint: ${tableHint}`);
+  return match.sql;
+}
+
+// ---------------------------------------------------------------------------
+// Section 1: Migration SQL content checks
+// ---------------------------------------------------------------------------
+
+describe('T9506 commits migration SQL', () => {
+  it('creates the commits table', () => {
+    const sql = getMigrationSql('CREATE TABLE `commits`');
+    expect(sql).toContain('CREATE TABLE `commits`');
+  });
+
+  it('has all required columns', () => {
+    const sql = getMigrationSql('CREATE TABLE `commits`');
+    const requiredCols = [
+      'sha',
+      'short_sha',
+      'author_name',
+      'author_email',
+      'authored_at',
+      'committer_name',
+      'committer_email',
+      'committed_at',
+      'message',
+      'subject',
+      'conventional_type',
+      'is_release_commit',
+      'is_merge_commit',
+      'parent_shas',
+      'signature_verified',
+      'branch_at_commit',
+      'project_hash',
+      'created_at',
+    ];
+    for (const col of requiredCols) {
+      expect(sql, `Missing column: ${col}`).toContain(`\`${col}\``);
+    }
+  });
+
+  it('defines all required indexes', () => {
+    const sql = getMigrationSql('CREATE TABLE `commits`');
+    const requiredIndexes = [
+      'idx_commits_short_sha',
+      'idx_commits_author_email',
+      'idx_commits_authored_at',
+      'idx_commits_conventional_type',
+      'idx_commits_is_release',
+      'idx_commits_project_hash',
+    ];
+    for (const idx of requiredIndexes) {
+      expect(sql, `Missing index: ${idx}`).toContain(idx);
+    }
+  });
+});
+
+describe('T9506 task_commits migration SQL', () => {
+  it('creates the task_commits table', () => {
+    const sql = getMigrationSql('CREATE TABLE `task_commits`');
+    expect(sql).toContain('CREATE TABLE `task_commits`');
+  });
+
+  it('has all required columns', () => {
+    const sql = getMigrationSql('CREATE TABLE `task_commits`');
+    const requiredCols = ['task_id', 'commit_sha', 'link_kind', 'link_source', 'created_at'];
+    for (const col of requiredCols) {
+      expect(sql, `Missing column: ${col}`).toContain(`\`${col}\``);
+    }
+  });
+
+  it('declares composite PRIMARY KEY on (task_id, commit_sha, link_kind)', () => {
+    const sql = getMigrationSql('CREATE TABLE `task_commits`');
+    expect(sql).toContain('task_id');
+    expect(sql).toContain('commit_sha');
+    expect(sql).toContain('link_kind');
+    expect(sql).toContain('PRIMARY KEY');
+  });
+
+  it('references commits table via FK on commit_sha', () => {
+    const sql = getMigrationSql('CREATE TABLE `task_commits`');
+    expect(sql).toContain('REFERENCES `commits`(`sha`)');
+  });
+
+  it('defines all required indexes', () => {
+    const sql = getMigrationSql('CREATE TABLE `task_commits`');
+    const requiredIndexes = [
+      'idx_task_commits_task_id',
+      'idx_task_commits_commit_sha',
+      'idx_task_commits_link_kind',
+    ];
+    for (const idx of requiredIndexes) {
+      expect(sql, `Missing index: ${idx}`).toContain(idx);
+    }
+  });
+});
+
+describe('T9506 commit_files migration SQL', () => {
+  it('creates the commit_files table', () => {
+    const sql = getMigrationSql('CREATE TABLE `commit_files`');
+    expect(sql).toContain('CREATE TABLE `commit_files`');
+  });
+
+  it('has all required columns', () => {
+    const sql = getMigrationSql('CREATE TABLE `commit_files`');
+    const requiredCols = [
+      'commit_sha',
+      'path',
+      'old_path',
+      'change_type',
+      'lines_added',
+      'lines_deleted',
+      'is_binary',
+    ];
+    for (const col of requiredCols) {
+      expect(sql, `Missing column: ${col}`).toContain(`\`${col}\``);
+    }
+  });
+
+  it('references commits table via FK on commit_sha', () => {
+    const sql = getMigrationSql('CREATE TABLE `commit_files`');
+    expect(sql).toContain('REFERENCES `commits`(`sha`)');
+  });
+
+  it('defines all required indexes', () => {
+    const sql = getMigrationSql('CREATE TABLE `commit_files`');
+    const requiredIndexes = ['idx_commit_files_path', 'idx_commit_files_change_type'];
+    for (const idx of requiredIndexes) {
+      expect(sql, `Missing index: ${idx}`).toContain(idx);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 2: Drizzle schema column-name parity checks
+// ---------------------------------------------------------------------------
+
+describe('T9506 Drizzle schema parity — commits', () => {
+  it('exports the commits table with the correct column set', () => {
+    const cols = Object.keys(commits);
+    // Verify key structural columns are present via Drizzle table object
+    expect(cols).toContain('sha');
+    expect(cols).toContain('shortSha');
+    expect(cols).toContain('authorName');
+    expect(cols).toContain('authorEmail');
+    expect(cols).toContain('authoredAt');
+    expect(cols).toContain('committedAt');
+    expect(cols).toContain('message');
+    expect(cols).toContain('subject');
+    expect(cols).toContain('conventionalType');
+    expect(cols).toContain('isReleaseCommit');
+    expect(cols).toContain('isMergeCommit');
+    expect(cols).toContain('parentShas');
+    expect(cols).toContain('projectHash');
+    expect(cols).toContain('createdAt');
+  });
+
+  it('COMMIT_CONVENTIONAL_TYPES has at least the canonical CC prefixes', () => {
+    const required = [
+      'feat',
+      'fix',
+      'chore',
+      'docs',
+      'refactor',
+      'test',
+      'build',
+      'ci',
+      'perf',
+      'revert',
+    ];
+    for (const t of required) {
+      expect(COMMIT_CONVENTIONAL_TYPES, `Missing CC type: ${t}`).toContain(t);
+    }
+  });
+});
+
+describe('T9506 Drizzle schema parity — task_commits', () => {
+  it('exports the taskCommits table with the correct column set', () => {
+    const cols = Object.keys(taskCommits);
+    expect(cols).toContain('taskId');
+    expect(cols).toContain('commitSha');
+    expect(cols).toContain('linkKind');
+    expect(cols).toContain('linkSource');
+    expect(cols).toContain('createdAt');
+  });
+
+  it('COMMIT_LINK_KINDS contains all required values', () => {
+    const required = ['implements', 'fixes', 'refactors', 'tests', 'docs', 'reverts'];
+    for (const k of required) {
+      expect(COMMIT_LINK_KINDS, `Missing link kind: ${k}`).toContain(k);
+    }
+  });
+
+  it('COMMIT_LINK_SOURCES contains all required values', () => {
+    const required = [
+      'commit-trailer',
+      'commit-subject',
+      'pr-title',
+      'pr-body',
+      'branch-name',
+      'manual',
+    ];
+    for (const s of required) {
+      expect(COMMIT_LINK_SOURCES, `Missing link source: ${s}`).toContain(s);
+    }
+  });
+});
+
+describe('T9506 Drizzle schema parity — commit_files', () => {
+  it('exports the commitFiles table with the correct column set', () => {
+    const cols = Object.keys(commitFiles);
+    expect(cols).toContain('commitSha');
+    expect(cols).toContain('path');
+    expect(cols).toContain('oldPath');
+    expect(cols).toContain('changeType');
+    expect(cols).toContain('linesAdded');
+    expect(cols).toContain('linesDeleted');
+    expect(cols).toContain('isBinary');
+  });
+
+  it('COMMIT_FILE_CHANGE_TYPES contains git status letter codes', () => {
+    const required = ['A', 'M', 'D', 'R', 'C'];
+    for (const c of required) {
+      expect(COMMIT_FILE_CHANGE_TYPES, `Missing change type: ${c}`).toContain(c);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 3: End-to-end migration apply on a fresh tasks.db
+// ---------------------------------------------------------------------------
+
+describe('T9506 fresh migration apply — all 3 tables created', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-t9506-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('applies all drizzle-tasks migrations cleanly and creates commits, task_commits, commit_files', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    expect(() => migrateSanitized(db, { migrationsFolder })).not.toThrow();
+
+    const tableNames = ['commits', 'task_commits', 'commit_files'];
+    for (const tableName of tableNames) {
+      const row = nativeDb
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+        .get(tableName) as { name: string } | undefined;
+      expect(row?.name, `Table '${tableName}' was not created`).toBe(tableName);
+    }
+
+    nativeDb.close();
+  });
+
+  it('commits table has the correct columns after migration', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-col-check.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const cols = nativeDb.prepare('PRAGMA table_info(commits)').all() as Array<{ name: string }>;
+    const colNames = cols.map((c) => c.name);
+
+    const expectedCols = [
+      'sha',
+      'short_sha',
+      'author_name',
+      'author_email',
+      'authored_at',
+      'committer_name',
+      'committer_email',
+      'committed_at',
+      'message',
+      'subject',
+      'conventional_type',
+      'is_release_commit',
+      'is_merge_commit',
+      'parent_shas',
+      'signature_verified',
+      'branch_at_commit',
+      'project_hash',
+      'created_at',
+    ];
+
+    for (const col of expectedCols) {
+      expect(colNames, `Column '${col}' missing from commits table`).toContain(col);
+    }
+
+    nativeDb.close();
+  });
+
+  it('task_commits table has correct columns and composite PK after migration', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-tc-check.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const cols = nativeDb.prepare('PRAGMA table_info(task_commits)').all() as Array<{
+      name: string;
+      pk: number;
+    }>;
+    const colNames = cols.map((c) => c.name);
+    const pkCols = cols.filter((c) => c.pk > 0).map((c) => c.name);
+
+    expect(colNames).toContain('task_id');
+    expect(colNames).toContain('commit_sha');
+    expect(colNames).toContain('link_kind');
+    expect(colNames).toContain('link_source');
+    expect(colNames).toContain('created_at');
+
+    // All three PK columns must be present in the primary key
+    expect(pkCols).toContain('task_id');
+    expect(pkCols).toContain('commit_sha');
+    expect(pkCols).toContain('link_kind');
+
+    nativeDb.close();
+  });
+
+  it('commit_files table has correct columns and composite PK after migration', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-cf-check.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const cols = nativeDb.prepare('PRAGMA table_info(commit_files)').all() as Array<{
+      name: string;
+      pk: number;
+    }>;
+    const colNames = cols.map((c) => c.name);
+    const pkCols = cols.filter((c) => c.pk > 0).map((c) => c.name);
+
+    expect(colNames).toContain('commit_sha');
+    expect(colNames).toContain('path');
+    expect(colNames).toContain('old_path');
+    expect(colNames).toContain('change_type');
+    expect(colNames).toContain('lines_added');
+    expect(colNames).toContain('lines_deleted');
+    expect(colNames).toContain('is_binary');
+
+    expect(pkCols).toContain('commit_sha');
+    expect(pkCols).toContain('path');
+
+    nativeDb.close();
+  });
+
+  it('all required indexes are present after migration', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-idx-check.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const indexes = nativeDb
+      .prepare("SELECT name FROM sqlite_master WHERE type='index'")
+      .all() as Array<{ name: string }>;
+    const indexNames = new Set(indexes.map((r) => r.name));
+
+    const expectedIndexes = [
+      'idx_commits_short_sha',
+      'idx_commits_author_email',
+      'idx_commits_authored_at',
+      'idx_commits_conventional_type',
+      'idx_commits_is_release',
+      'idx_commits_project_hash',
+      'idx_task_commits_task_id',
+      'idx_task_commits_commit_sha',
+      'idx_task_commits_link_kind',
+      'idx_commit_files_path',
+      'idx_commit_files_change_type',
+    ];
+
+    for (const idx of expectedIndexes) {
+      expect(indexNames, `Index '${idx}' missing after migration`).toContain(idx);
+    }
+
+    nativeDb.close();
+  });
+
+  it('legacy release_manifests table is untouched after provenance migrations', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-legacy-check.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    // release_manifests must still exist and contain its key columns
+    const row = nativeDb
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='release_manifests'")
+      .get() as { name: string } | undefined;
+    expect(row?.name).toBe('release_manifests');
+
+    const cols = nativeDb.prepare('PRAGMA table_info(release_manifests)').all() as Array<{
+      name: string;
+    }>;
+    const colNames = cols.map((c) => c.name);
+    expect(colNames).toContain('id');
+    expect(colNames).toContain('version');
+    expect(colNames).toContain('tasks_json');
+
+    nativeDb.close();
+  });
+});

--- a/packages/core/src/store/tasks-schema.ts
+++ b/packages/core/src/store/tasks-schema.ts
@@ -1195,6 +1195,266 @@ export const experiments = sqliteTable(
   (table) => [index('idx_experiments_merged').on(table.mergedAt)],
 );
 
+// === PROVENANCE GRAPH TABLES (T9506 — ADR-073 / SPEC-T9345) ===
+
+/**
+ * Canonical enum values for {@link commits.conventionalType}.
+ *
+ * Mirrors the Conventional Commits specification prefixes plus `breaking`
+ * to flag BREAKING CHANGE footers. Stored as TEXT in SQLite.
+ *
+ * @task T9506
+ */
+export const COMMIT_CONVENTIONAL_TYPES = [
+  'feat',
+  'fix',
+  'chore',
+  'docs',
+  'refactor',
+  'test',
+  'build',
+  'ci',
+  'perf',
+  'revert',
+  'breaking',
+] as const;
+
+/** Union type for {@link COMMIT_CONVENTIONAL_TYPES}. */
+export type CommitConventionalType = (typeof COMMIT_CONVENTIONAL_TYPES)[number];
+
+/**
+ * Link-kind enum for {@link taskCommits.linkKind}.
+ *
+ * Describes the semantic relationship between a task and a commit:
+ * - `implements` — the commit directly implements the task's acceptance criteria
+ * - `fixes`      — the commit fixes a bug or regression in the task's work
+ * - `refactors`  — the commit restructures code introduced by the task
+ * - `tests`      — the commit adds or updates tests for the task
+ * - `docs`       — the commit updates documentation for the task
+ * - `reverts`    — the commit reverts work introduced by the task
+ *
+ * @task T9506
+ */
+export const COMMIT_LINK_KINDS = [
+  'implements',
+  'fixes',
+  'refactors',
+  'tests',
+  'docs',
+  'reverts',
+] as const;
+
+/** Union type for {@link COMMIT_LINK_KINDS}. */
+export type CommitLinkKind = (typeof COMMIT_LINK_KINDS)[number];
+
+/**
+ * Link-source enum for {@link taskCommits.linkSource}.
+ *
+ * Describes how a task↔commit link was discovered:
+ * - `commit-trailer` — extracted from a `T####:` or `Task-Id:` git trailer
+ * - `commit-subject` — matched `T####` regex in the commit subject line
+ * - `pr-title`       — matched task ID in the PR title
+ * - `pr-body`        — matched task ID in the PR body markdown
+ * - `branch-name`    — parsed from the branch name (e.g., `feat/T9506-...`)
+ * - `manual`         — explicitly linked via `cleo provenance link`
+ *
+ * @task T9506
+ */
+export const COMMIT_LINK_SOURCES = [
+  'commit-trailer',
+  'commit-subject',
+  'pr-title',
+  'pr-body',
+  'branch-name',
+  'manual',
+] as const;
+
+/** Union type for {@link COMMIT_LINK_SOURCES}. */
+export type CommitLinkSource = (typeof COMMIT_LINK_SOURCES)[number];
+
+/**
+ * Change-type enum for {@link commitFiles.changeType}.
+ *
+ * Uses git status letter codes: A=added, M=modified, D=deleted, R=renamed, C=copied.
+ *
+ * @task T9506
+ */
+export const COMMIT_FILE_CHANGE_TYPES = ['A', 'M', 'D', 'R', 'C'] as const;
+
+/** Union type for {@link COMMIT_FILE_CHANGE_TYPES}. */
+export type CommitFileChangeType = (typeof COMMIT_FILE_CHANGE_TYPES)[number];
+
+/**
+ * `commits` — Every git commit reachable from a release tag.
+ *
+ * Captures commit identity, author attribution, Conventional Commits
+ * classification, and project correlation so that SQL queries can answer
+ * "which commits shipped in release vX.Y.Z?" without shelling out to git
+ * at query time.
+ *
+ * Enabled edges (once junction tables are populated):
+ *   commit → task     via `task_commits`
+ *   commit → release  via `release_commits` (T9507)
+ *   commit → file     via `commit_files`
+ *
+ * @task T9506
+ * @epic T9491
+ * @see SPEC-T9345 §3.1
+ */
+export const commits = sqliteTable(
+  'commits',
+  {
+    /** Full 40-char git SHA — primary key. */
+    sha: text('sha').primaryKey(),
+    /** First 7 characters of the SHA for display purposes. */
+    shortSha: text('short_sha').notNull(),
+    /** Author display name (from `git log %an`). */
+    authorName: text('author_name'),
+    /** Author email (from `git log %ae`). */
+    authorEmail: text('author_email'),
+    /** ISO-8601 author timestamp (from `git log %aI`). */
+    authoredAt: text('authored_at').notNull(),
+    /** Committer display name (from `git log %cn`). */
+    committerName: text('committer_name'),
+    /** Committer email (from `git log %ce`). */
+    committerEmail: text('committer_email'),
+    /** ISO-8601 committer timestamp (from `git log %cI`). */
+    committedAt: text('committed_at').notNull(),
+    /** Full commit message body (subject + blank line + body if present). */
+    message: text('message').notNull(),
+    /** First line of the commit message (the subject). */
+    subject: text('subject').notNull(),
+    /**
+     * Conventional Commits type parsed from the subject line.
+     * NULL when the commit does not follow Conventional Commits format.
+     * See {@link COMMIT_CONVENTIONAL_TYPES}.
+     */
+    conventionalType: text('conventional_type'),
+    /** 1 when this commit matches the `chore(release): vX.Y.Z` release pattern. */
+    isReleaseCommit: integer('is_release_commit').notNull().default(0),
+    /** 1 when the commit has more than one parent (merge commit). */
+    isMergeCommit: integer('is_merge_commit').notNull().default(0),
+    /** JSON array of parent SHA strings. Most commits have exactly one element. */
+    parentShas: text('parent_shas').notNull().default('[]'),
+    /** 0=signature absent or invalid, 1=signature verified, NULL=not checked. */
+    signatureVerified: integer('signature_verified'),
+    /** Best-effort: branch HEAD was on at commit time. NULL if unavailable. */
+    branchAtCommit: text('branch_at_commit'),
+    /**
+     * Project hash from `audit_log.project_hash` — correlates commits to a
+     * specific CLEO project in multi-repo installs.
+     */
+    projectHash: text('project_hash'),
+    /** ISO-8601 timestamp when this row was inserted into tasks.db. */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index('idx_commits_short_sha').on(table.shortSha),
+    index('idx_commits_author_email').on(table.authorEmail),
+    index('idx_commits_authored_at').on(table.authoredAt),
+    index('idx_commits_conventional_type').on(table.conventionalType),
+    index('idx_commits_is_release').on(table.isReleaseCommit),
+    index('idx_commits_project_hash').on(table.projectHash),
+  ],
+);
+
+/**
+ * `task_commits` — M:N junction between tasks and commits.
+ *
+ * Each row records one typed linkage edge (task ↔ commit × link_kind).
+ * The composite PK `(task_id, commit_sha, link_kind)` permits a single commit
+ * to be linked to a single task via multiple relationship types (e.g., both
+ * `implements` and `tests`).
+ *
+ * `task_id` uses ON DELETE SET NULL so provenance history is preserved even
+ * when a task is purged from the system.
+ * `commit_sha` uses ON DELETE CASCADE — a purged commit removes its junction rows.
+ *
+ * @task T9506
+ * @epic T9491
+ * @see SPEC-T9345 §3.2
+ */
+export const taskCommits = sqliteTable(
+  'task_commits',
+  {
+    /**
+     * FK → tasks.id. Uses ON DELETE SET NULL to preserve linkage history
+     * after task deletion. NULL = orphaned link (task was purged).
+     */
+    taskId: text('task_id').references(() => tasks.id, { onDelete: 'set null' }),
+    /** FK → commits.sha. ON DELETE CASCADE — purging a commit clears its links. */
+    commitSha: text('commit_sha')
+      .notNull()
+      .references(() => commits.sha, { onDelete: 'cascade' }),
+    /**
+     * Semantic classification of the task↔commit relationship.
+     * See {@link COMMIT_LINK_KINDS}.
+     */
+    linkKind: text('link_kind').notNull(),
+    /**
+     * How this link was discovered (commit-trailer, branch-name, manual, etc.).
+     * See {@link COMMIT_LINK_SOURCES}.
+     */
+    linkSource: text('link_source').notNull(),
+    /** ISO-8601 timestamp when this link was created. */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.taskId, table.commitSha, table.linkKind] }),
+    index('idx_task_commits_task_id').on(table.taskId),
+    index('idx_task_commits_commit_sha').on(table.commitSha),
+    index('idx_task_commits_link_kind').on(table.linkKind),
+  ],
+);
+
+/**
+ * `commit_files` — Per-file × SHA materialization (blast-radius enabler).
+ *
+ * Every `(commit_sha, path)` pair has one row describing the type of change
+ * (A/M/D/R/C), diff stats, and whether the file is binary. Enables queries
+ * such as "which tasks last modified this file path?" and diff-by-file for
+ * `cleo release diff`.
+ *
+ * `old_path` is non-NULL only for R (rename) and C (copy) change types.
+ * FK uses ON DELETE CASCADE — purging a commit removes its file rows.
+ *
+ * @task T9506
+ * @epic T9491
+ * @see SPEC-T9345 §3.3
+ */
+export const commitFiles = sqliteTable(
+  'commit_files',
+  {
+    /** FK → commits.sha. ON DELETE CASCADE. */
+    commitSha: text('commit_sha')
+      .notNull()
+      .references(() => commits.sha, { onDelete: 'cascade' }),
+    /** Canonical repo-relative file path (after rename, if any). */
+    path: text('path').notNull(),
+    /**
+     * Previous path before a rename or copy operation.
+     * NULL for A / M / D change types.
+     */
+    oldPath: text('old_path'),
+    /**
+     * Git status letter: A=added, M=modified, D=deleted, R=renamed, C=copied.
+     * See {@link COMMIT_FILE_CHANGE_TYPES}.
+     */
+    changeType: text('change_type').notNull(),
+    /** Lines added in this commit for this file (0 for deletions and binary files). */
+    linesAdded: integer('lines_added').notNull().default(0),
+    /** Lines deleted in this commit for this file (0 for additions and binary files). */
+    linesDeleted: integer('lines_deleted').notNull().default(0),
+    /** 1 if the file is binary (diff stats are 0/0). */
+    isBinary: integer('is_binary').notNull().default(0),
+  },
+  (table) => [
+    primaryKey({ columns: [table.commitSha, table.path] }),
+    index('idx_commit_files_path').on(table.path),
+    index('idx_commit_files_change_type').on(table.changeType),
+  ],
+);
+
 // === TYPE EXPORTS ===
 
 export type AttachmentRow = typeof attachments.$inferSelect;
@@ -1239,6 +1499,13 @@ export type NewExternalTaskLinkRow = typeof externalTaskLinks.$inferInsert;
 // T944 experiments side-table row types
 export type ExperimentRow = typeof experiments.$inferSelect;
 export type NewExperimentRow = typeof experiments.$inferInsert;
+// T9506 provenance graph row types
+export type CommitRow = typeof commits.$inferSelect;
+export type NewCommitRow = typeof commits.$inferInsert;
+export type TaskCommitRow = typeof taskCommits.$inferSelect;
+export type NewTaskCommitRow = typeof taskCommits.$inferInsert;
+export type CommitFileRow = typeof commitFiles.$inferSelect;
+export type NewCommitFileRow = typeof commitFiles.$inferInsert;
 
 // agent_credentials REMOVED from tasks.db — T234 clean-cut.
 // Agent data (identity, credentials, capabilities, skills) now lives


### PR DESCRIPTION
## Summary
Phase 0 / Set 1 of 4 for the release-provenance graph per ADR-073 / SPEC-T9345 / provenance-graph-design.md §3.1-3.3. Adds 3 SQLite tables to `.cleo/tasks.db` via 3 Drizzle migrations:

- `commits` — 18 cols (sha PK, author/committer, conventional_type, parent_shas JSON, project_hash, …) + 6 indexes
- `task_commits` — M:N junction with link_kind/link_source enums + composite PK + 3 indexes
- `commit_files` — per-file path × sha with change_type (A/M/D/R/C) + composite PK + 2 indexes

Legacy `release_manifests` untouched. 4 enum constants + 6 row-type exports added to tasks-schema.ts.

## Test plan
- [x] 25 new commits-schema-parity tests pass
- [x] tsc clean (main project build)
- [x] Biome clean

Closes T9506 (parent T9491 / T9345). First of 4 schema-set tasks. ADR-073 Phase 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)