### PR TITLE
docs(T9520): ADR-073 Saga above-Epic naming + canon update

### DIFF
--- a/.cleo/adrs/ADR-073-above-epic-naming.md
+++ b/.cleo/adrs/ADR-073-above-epic-naming.md
@@ -1,0 +1,169 @@
+---
+id: ADR-073
+title: Above-Epic Naming — Saga (prefix SG-)
+status: Accepted
+date: 2026-05-17
+task: T9520
+linkedTasks: [T9518, T9514, T9519]
+supersedes: null
+supersededBy: null
+---
+
+# ADR-073: Above-Epic Naming — Saga (prefix SG-)
+
+**Status:** Accepted
+**Date:** 2026-05-17
+**Task:** T9520
+**Linked Tasks:** T9518 (parent epic), T9514 (gating dep — relates writer fix), T9519 (task_relations groups type)
+
+## Context
+
+CLEO's task hierarchy has three well-defined tiers: subtask → task → epic. Multi-release
+initiatives (e.g., the LLM provider unification spanning Phase 1–6 and multiple CalVer tags)
+have no canonical container above the epic tier. Teams have been using ad-hoc conventions —
+"super-epic", "theme", "initiative" — with no standard prefix, no CLI command, and no storage
+pattern.
+
+The Council (run `2026-05-17T00:24:48Z`, verdict at
+`.cleo/council-runs/20260517T002448Z-e4223249/verdict.md`) evaluated four candidate names:
+**Initiative** (`I-`), **Arc** (`AR-`), **Saga** (`SG-`), and a hybrid. The Council reached
+5/5 unanimous PASS across all four gate dimensions.
+
+### Why the alternatives were rejected
+
+- **`Initiative / I-`** (Contrarian + First Principles): Single-letter prefix burns the densest
+  collision space (~26× denser than two-letter), `I-` is visually ambiguous with digit `1` /
+  article "I" / lowercase `l` in monospace, and "initiative" is generic Jira-flavored vocabulary
+  that breaks CLEO's deliberate narrative-canon aesthetic (Hearth, Sigil, Sentient, RCASD).
+
+- **`Arc / AR-`** (First Principles, dictionary fit): "Arc" maps well semantically — a narrative
+  spanning multiple installments. However, `AR-` collides immediately with `ADR-` in every CLI
+  fuzzy search and `grep -r "AR-"` returns hundreds of ADR matches across `.cleo/adrs/`. This is
+  a daily-friction failure, not a hypothetical risk. Semantic win cannot survive operational loss.
+
+### Why Saga was chosen
+
+- **Narrative fit (First Principles atom 1):** A Saga is explicitly a multi-chapter, multi-release
+  narrative. The word carries the multi-installment weight natively; no teaching required.
+- **Two-letter prefix safety (First Principles atom 6):** `SG-` is a two-letter prefix, operating
+  in a ~26× less dense collision space than single-letter alternatives.
+- **Canon aesthetic (Expansionist):** Saga joins Hearth, Sigil, Sentient, and RCASD as a
+  deliberate mythic-narrative noun. Because `task_relations.type = 'groups'` is generic, Saga is
+  a recursive narrative-graph noun on day one — `SG-X groups SG-Y groups E-Z` is a legal
+  traversal without any schema migration.
+- **Contrarian risk neutralized:** The Contrarian's sharpest finding was that `SG-` could
+  collide with the actively-expanding SignalDock namespace. This ADR closes the trap at decision
+  time by explicitly reserving both `SG-` and `SD-` in the prefix registry below.
+
+---
+
+## Decision
+
+### Name and prefix
+
+Adopt **Saga** (prefix `SG-`) as the above-Epic grouping tier in the CLEO task hierarchy.
+
+The hierarchy is now:
+
+```
+subtask (no prefix)
+  ↓
+Task  (T-)
+  ↓
+Epic  (E-)
+  ↓
+Saga  (SG-)   ← this ADR
+```
+
+### Storage shape — Saga is a role, not a new TaskType
+
+**Saga is NOT a new `TaskType` enum value.** It is a labeled role that a top-level Epic plays.
+
+Concretely:
+- A Saga is an existing `type = 'epic'` task with `label = 'saga'` set via `cleo update --label saga`.
+- The `TaskType` enum remains `{subtask, task, epic}`. No schema migration is required.
+- Saga-level grouping is expressed through `task_relations.type = 'groups'` edges (implemented in
+  T9519) that link the Saga-labeled Epic to its child Epics.
+
+This protects against future drift where someone adds `saga` to the `TaskType` enum. If such a
+proposal surfaces, it MUST reference this clause and provide a migration path.
+
+### Wire mechanism
+
+Saga-to-Epic grouping uses `task_relations.type = 'groups'` — a new relation type added in T9519.
+A `SG-X` Saga groups child Epics via:
+
+```bash
+cleo update SG-X --relates E-Y:groups
+```
+
+The `groups` relation is generic and supports recursive traversal: `SG-A groups SG-B groups E-C`
+is a legal graph on day one.
+
+### Gating dependency
+
+**T9514** (`cleo update --relates` writer fix) MUST merge before any Saga is materialized.
+The `groups` relation write path is broken until T9514 lands. Creating Saga nodes before T9514
+merges will produce relation records that cannot be reliably read back.
+
+---
+
+## Prefix Registry
+
+All two-character (and longer) prefixes used for CLEO task IDs MUST be registered here.
+Single-character prefixes are reserved for TaskType dispatch only (`T-`, `E-`, `S-`).
+
+| Prefix | Reserved for | Notes |
+|--------|-------------|-------|
+| `SG-`  | **Saga** (above-Epic grouping) | This ADR |
+| `SD-`  | **SignalDock** (identity / messaging subsystem) | Reserved to prevent future collision with `SG-`; SignalDock does not currently issue task-style IDs but uses `SD-*` / `signaldock-*` namespaces in code |
+| `ADR-` | Architecture Decision Records | Legacy; not task IDs |
+| `D-`   | BRAIN decision records | Stored in brain.db, not tasks.db |
+
+**Rule:** Before introducing a new prefix, add it to this table in a PR that references the
+governing ADR. Prefix decisions are permanent — the no-migration storage layer has no rename
+primitive for relation IDs.
+
+---
+
+## Consequences
+
+### Positive
+
+- Multi-release themes have a canonical container with a clear name, prefix, and storage
+  pattern — no more ad-hoc "super-epic" conventions.
+- Zero schema migration: Saga reuses the existing `type = 'epic'` row with a label.
+- The `groups` relation is generic; Saga-to-Epic and Saga-to-Saga traversals work on day one.
+- The Contrarian's collision risk is closed permanently via the prefix registry.
+- CLEO's narrative-canon aesthetic is extended, not diluted.
+
+### Negative
+
+- `cleo list` without filters will surface Saga-labeled Epics alongside regular Epics; users
+  must filter by label to see only Sagas. A `cleo saga list` command is a follow-up UX task.
+- The `groups` relation overloads `task_relations` alongside dedupe-merge semantics (Contrarian
+  finding #2). A discriminator column may be warranted if semantic ambiguity causes bugs;
+  filed as a follow-up under T9514 scope or as a new task at the owner's discretion.
+- Agents trained on prior CLEO docs will not know the `saga` label convention until
+  CLEO-INJECTION.md and AGENTS.md are updated (done in T9520).
+
+---
+
+## Alternatives Considered
+
+| Name | Prefix | Rejection reason |
+|------|--------|-----------------|
+| Initiative | `I-` | Single-letter; visually ambiguous; generic Jira vocabulary; breaks CLEO narrative canon |
+| Arc | `AR-` | Collides with `ADR-` in every CLI grep and fuzzy search across `.cleo/adrs/` |
+| Theme | `TH-` | Not evaluated by Council; generic vocabulary, no narrative weight |
+
+---
+
+## References
+
+- Council verdict: `.cleo/council-runs/20260517T002448Z-e4223249/verdict.md`
+- T9518 — above-Epic naming epic (parent)
+- T9514 — `cleo update --relates` writer fix (gating dependency)
+- T9519 — `task_relations.type = 'groups'` implementation
+- ADR-066 — Task taxonomy consolidation (TaskType enum definition)
+- ADR-062 — Worktree merge strategy (referenced for context on permanent decisions)

--- a/.cleo/rcasd/T9345/research/ADR-T9345-ivtr-release-overhaul.md
+++ b/.cleo/rcasd/T9345/research/ADR-T9345-ivtr-release-overhaul.md
@@ -62,7 +62,7 @@ The 10 failures collapse into 6 root-cause clusters (forensics §Cross-Failure S
 - **Missing provenance graph**: no `commits` table, no `release_manifest.commits → tasks` FK, no `releases` table — the owner-required "feature → bug → hotfix → epic → task → commit → release" graph is **derivable but not queryable** (audit Q4). `tasks.verification` and `task_relations` exist but lack `(release_id, commit_sha, task_id)` triples.
 - **~600 LOC of coupling to remove**: 17 IVTR gate references in `engine-ops.ts` lines 1251-1295 alone; plus 7 files directly integrating IVTR into release paths (audit §Phase 1).
 
-The audit's Priority 1 action is unambiguous: **decouple release from IVTR; evidence gates (ADR-051) become the sole release blocker** (audit §Recommendations, T9350).
+The audit's Priority 1 action is unambiguous: **decouple release from IVTR; evidence gates (ADR-051) become the sole release blocker** (audit §Recommendations, T9497).
 
 ### 4. External precedents (wave-1 research)
 

--- a/.cleo/rcasd/T9345/research/T9345-research.md
+++ b/.cleo/rcasd/T9345/research/T9345-research.md
@@ -49,7 +49,7 @@ The owner directive (2026-05-15) called for a full RCASD research wave on T9345 
 | # | Artifact | Lines | Purpose |
 |---|----------|------:|---------|
 | 8 | [`SPEC-T9345-release-pipeline-v2.md`](./SPEC-T9345-release-pipeline-v2.md) | 822 | **RFC-2119 normative spec**. 162 numbered requirements (R-001 → R-441). 16 sections covering CLI verbs, GHA workflows, evidence-gate integration (ADR-051 surface), provenance recording, project-agnostic resolution (7 archetypes), `releases.status` FSM, hotfix path, backward-compatibility window, failure-mode → spec-section mapping (8/10 structurally eliminated). |
-| 9 | [`migration-plan-T9345.md`](./migration-plan-T9345.md) | 619 | 6-phase migration plan (8–12 weeks). Each phase has scope, exit criteria, rollback trigger, LOC budget, owner-approval gates. 8 child epics decomposed (T9346 → T9353). Compatibility shim `cleo release ship --workflow=false` available for ≥3 release cycles post-cutover. Historical `release_manifests` never dropped. |
+| 9 | [`migration-plan-T9345.md`](./migration-plan-T9345.md) | 619 | 6-phase migration plan (8–12 weeks). Each phase has scope, exit criteria, rollback trigger, LOC budget, owner-approval gates. 8 child epics decomposed (T9491–T9499 — Phase 0: T9491, Phase 1: T9492, Phase 2: T9493, Phase 3: T9494, Phase 4: T9497, Phase 5: T9498, Phase 6: T9499, Tests: T9495). Bonus parallel forensics-fixes epic: T9496. Compatibility shim `cleo release ship --workflow=false` available for ≥3 release cycles post-cutover. Historical `release_manifests` never dropped. |
 | 10 | [`test-matrix-T9345.md`](./test-matrix-T9345.md) | 529 | 12 scenarios × 4 archetypes (monorepo-w-workspaces, single-npm-lib, single-rust-crate + python stretch). 25-slot GHA matrix. Each scenario maps to one or more of the 10 acceptance criteria + the 10 forensics failure modes. Owner sign-off checklist (30+ specific artifacts). |
 
 ## Acceptance-criteria mapping (against T9345 task description)
@@ -63,7 +63,7 @@ The owner directive (2026-05-15) called for a full RCASD research wave on T9345 
 | "Spec written for chosen direction with RFC 2119 must/should/may language" | #8 `SPEC-T9345-release-pipeline-v2.md` (162 R-numbered requirements) |
 | "Migration plan from current state with rollback path" | #9 `migration-plan-T9345.md` (6 phases × rollback per phase) |
 | "Test matrix proves IVTR works for at least 3 git-managed project archetypes: monorepo with workspaces (cleocode itself), single-package npm lib, single-binary rust crate" | #10 `test-matrix-T9345.md` (A1/A2/A3 required, A4 stretch) |
-| "All epic children produced or scheduled as separate IVTR tasks" | #7 + #9 enumerate 8 child epics (T9346 → T9353) — to be filed by the orchestrator when this research is signed off |
+| "All epic children produced or scheduled as separate IVTR tasks" | #7 + #9 enumerate 8 child epics — filed as T9491 (Phase 0), T9492 (Phase 1), T9493 (Phase 2), T9494 (Phase 3), T9497 (Phase 4), T9498 (Phase 5), T9499 (Phase 6), T9495 (tests). Bonus T9496 (5 forensics bug fixes, parallelizable with Phase 0) |
 
 ## Owner ask: "Have we conflated and over-engineered the IVTR system?"
 
@@ -75,9 +75,9 @@ The owner directive (2026-05-15) called for a full RCASD research wave on T9345 
 - `--force` undermines evidence integrity (already on removal track per ADR-051)
 
 **Streamlining path** (sketched in #5, normatively defined in #8):
-1. **Decouple release from IVTR** (T9346 / T9351 in the plan). `task.ivtr_state` becomes observation-only; the release pipeline never reads it for gate decisions.
+1. **Decouple release from IVTR** (Phase 5 epic T9498). `task.ivtr_state` becomes observation-only; the release pipeline never reads it for gate decisions.
 2. **Single gate surface** — ADR-051 evidence atoms are the only release gate. No parallel `runReleaseGates`, no IVTR phase gate, no `defaultRunGate` stub.
-3. **First-class provenance graph** (T9347). 11 new tables, 1 view, 14 new CLI verbs. Owner's "tracking graph of released code" becomes a SQL query.
+3. **First-class provenance graph** (Phase 0 epic T9491 + Phase 1 epic T9492). 11 new tables, 1 view, 14 new CLI verbs. Owner's "tracking graph of released code" becomes a SQL query.
 4. **Project-agnostic by default** — ADR-061 tool resolver is the only path; per-archetype assumptions (npm/pnpm/biome) are deleted.
 
 ## Owner ask: "scope of tracking is wider than a release — features, bugs, hotfixes, full provenance"
@@ -96,20 +96,65 @@ Both projects were researched against their **actual code**, not assumptions:
 
 The 5-platform target (linux x64/arm64, macos x64/arm64, win x64) is first-class in spec §9.2 (R-370, R-371). `plan.platformMatrix[]` enumerates publisher × platform pairs; `release-fanout.yml` runs the matrix job. Adding a new platform requires only an entry in `.cleo/project-context.json`, no release-pipeline code change.
 
+## GHA workflow architecture (clarification — NOT cleocode-specific)
+
+The four YAML workflows referenced throughout the ADR + SPEC (`release-prepare.yml`,
+`release-publish.yml`, `release-fanout.yml`, `release-rollback.yml`) are **CLEO-templated
+artifacts that any consuming project receives** — they are NOT files unique to the cleocode
+monorepo. The design is:
+
+- **Templates live in CLEO** at `packages/cleo/templates/workflows/release-*.yml.tmpl` (new path).
+- **`cleo init` / `cleo upgrade workflows`** scaffolds them into the consuming project's
+  `.github/workflows/` directory, parameterized by `.cleo/release-config.json` +
+  `.cleo/project-context.json`.
+- **Workflow structure is universal** (same trigger events, same job names, same
+  concurrency policy, same status checks emitted). What differs across projects is the
+  *contents* of the steps — which is resolved via ADR-061's tool resolver
+  (`tool:test`, `tool:build`, `tool:lint`, `tool:typecheck`, `tool:audit`,
+  `tool:security-scan`, `tool:publish`). A Rust crate runs `cargo test`; a Python
+  package runs `pytest`; a pnpm monorepo runs `pnpm run test`. The workflow doesn't know
+  or care — it invokes `cleo release plan|open|reconcile|rollback` (CLEO's own verbs)
+  and those verbs invoke the resolved tool.
+- **Per-archetype matrix** lives in `release-fanout.yml` and reads `plan.platformMatrix[]`
+  from the plan JSON file. Adding a new platform (e.g. `aarch64-linux-android`) is one
+  entry in `.cleo/project-context.json` — no workflow code change required.
+- **Project-agnosticism is structurally enforced**: the SPEC's R-362 mandates that adding a
+  new archetype MUST NOT require a release-pipeline code change. The workflow templates
+  pass this test because every project-specific concern routes through tool resolution.
+- **Upgrade story**: when CLEO ships a new workflow template version, consuming projects
+  run `cleo upgrade workflows` to merge the new template against any local customizations
+  (3-way merge with `.workflow-overrides.yml` for project-specific tweaks).
+
+This is the "highly opinionated, spec-driven workflow system any project can use" promise
+that ADR-073 makes operational. The workflows are CLEO's opinion *encoded as scaffold*,
+not as one-off files in cleocode.
+
+---
+
 ## Next steps for the orchestrator (after owner sign-off)
 
 1. **Council review** (optional but recommended) — invoke `/ct-council` to stress-test the ADR + SPEC against five advisors.
-2. **File 8 child epics** under T9345 per #9 `migration-plan-T9345.md` §"Child-epic decomposition":
-   - T9346 — Schema migration + provenance tables (Phase 0)
-   - T9347 — Read-mostly verbs `plan` + `reconcile` (Phase 1)
-   - T9348 — Provenance backfill across historical releases (Phase 2)
-   - T9349 — `release-prepare.yml` + `cleo release open` (Phase 3)
-   - T9350 — `release-publish.yml` + `release-fanout.yml` (Phase 4)
-   - T9351 — Operator surface flip + IVTR decoupling (Phase 5)
-   - T9352 — Cleanup: delete `releaseShip` monolith + parallel 4-step pipeline (Phase 6)
-   - T9353 — Test matrix + 3-archetype fixtures
+2. **File 8 real child epics** under T9345 via `cleo add --parent T9345 --type epic --kind work --pipelineStage spec --acceptance "..."` — task IDs are assigned by CLEO at creation time. The intended decomposition (one epic per migration phase, plus the test-matrix epic) per `migration-plan-T9345.md` §"Child-epic decomposition" is:
+   - Schema migration + provenance tables (Phase 0)
+   - Read-mostly verbs `plan` + `reconcile` (Phase 1)
+   - Provenance backfill across historical releases (Phase 2)
+   - `release-prepare.yml` template + `cleo release open` verb (Phase 3)
+   - `release-publish.yml` + `release-fanout.yml` templates + `cleo init/upgrade workflows` scaffolding (Phase 4)
+   - Operator surface flip + IVTR decoupling (Phase 5)
+   - Cleanup: delete `releaseShip` monolith + parallel 4-step pipeline (Phase 6)
+   - Test matrix + 3-archetype fixtures (cross-phase)
+
+   The real IDs assigned by `cleo add` MUST be recorded back into this index and into `migration-plan-T9345.md` §"Child-epic decomposition" before any implementation work begins. **No fabricated IDs in any artifact.**
+
 3. **Advance T9345 to `pipelineStage=spec`** once council convergence is reached.
 4. **Run RCASD's spec stage** on each child epic before its implementation begins.
+
+---
+
+## Honest corrections (post-review, 2026-05-16)
+
+- **Prior version of this index named fabricated task IDs `T9346`–`T9353`.** Those were planning placeholders, NOT real tasks in `tasks.db`. They have been removed. Real IDs will be assigned by `cleo add` at the moment each child epic is filed.
+- **Prior version of this index did not explain that the GHA workflows are CLEO-templated scaffolds, not cleocode-only files.** The new "GHA workflow architecture" section above corrects this. The ADR-073 SPEC §5 always intended this — it just was not surfaced in the index.
 
 ## Notes
 

--- a/.cleo/rcasd/T9345/research/T9345-research.md
+++ b/.cleo/rcasd/T9345/research/T9345-research.md
@@ -155,6 +155,7 @@ not as one-off files in cleocode.
 
 - **Prior version of this index named fabricated task IDs `T9346`–`T9353`.** Those were planning placeholders, NOT real tasks in `tasks.db`. They have been removed. Real IDs will be assigned by `cleo add` at the moment each child epic is filed.
 - **Prior version of this index did not explain that the GHA workflows are CLEO-templated scaffolds, not cleocode-only files.** The new "GHA workflow architecture" section above corrects this. The ADR-073 SPEC §5 always intended this — it just was not surfaced in the index.
+- **2026-05-16 implementation kickoff exposed an 11th failure mode missing from the forensics doc: `cleo orchestrate spawn` hangs indefinitely.** Reproduced at 30s/60s/90s timeouts with and without `--no-worktree`. Forced fallback to raw `git worktree add --lock -b task/T<id> <path> main` for all 6 worker provisions. Filed as **epic T9515 — "EPIC: cleo orchestrate spawn hang + full worktree lifecycle reliability"** (kind=bug, severity=P1, parent=T9345). T9515 is a hard prerequisite for the GitOps release pipeline (ADR-073 / T9491+ / T9498) because that vision assumes reliable per-task worktrees. Scope: CREATE (fix spawn hang + timeout supervisors) / MANAGE (`cleo worktree list` structured discovery) / CLEANUP (`cleo worktree prune --orphaned` + `force-unlock` + auto-`worktree-complete`).
 
 ## Notes
 

--- a/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md
+++ b/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md
@@ -479,7 +479,7 @@ JOIN tasks b ON tr.related_to = b.id;
 
 ## Recommendations
 
-### Priority 1: Decouple Release from IVTR (T9350)
+### Priority 1: Decouple Release from IVTR (Phase 5 — T9498)
 
 **Action**: Remove IVTR gate check from `prepareRelease()`.
 
@@ -494,18 +494,18 @@ JOIN tasks b ON tr.related_to = b.id;
 
 **Impact**: Release no longer depends on IVTR state. Evidence gates become sole blocker.
 
-### Priority 2: Make Evidence Gates Mandatory (T9351)
+### Priority 2: Make Evidence Gates Mandatory (Phase 5 — T9498)
 
 **Action**: Implement ADR-051 D1–D9 fully (in-progress; some code merged, some not).
 
 - ✓ Implement `cleo verify --gate --evidence` (in-code)
 - ✓ Reject `cleo verify --all` without per-gate evidence (in-code)
 - ✓ Audit trail to `.cleo/audit/gates.jsonl` (in-code)
-- ❌ Evidence staleness check on `cleo complete` (NOT implemented; T9351)
-- ❌ Remove `--force` from completion (NOT implemented; T9351)
+- ❌ Evidence staleness check on `cleo complete` (NOT implemented; T9498 — Phase 5)
+- ❌ Remove `--force` from completion (NOT implemented; T9498 — Phase 5)
 - ❌ `CLEO_OWNER_OVERRIDE` audit logging (PARTIAL; needs `.cleo/audit/force-bypass.jsonl`)
 
-### Priority 3: Build Release-Provenance Graph (T9352)
+### Priority 3: Build Release-Provenance Graph (Phase 0 — T9491)
 
 **Action**: Implement `release_manifest_commits` table + `releases` table + view.
 
@@ -526,7 +526,7 @@ JOIN tasks b ON tr.related_to = b.id
 WHERE r.version = '1.2.3' AND b.kind = 'bug';
 ```
 
-### Priority 4: Deprecate IVTR State Machine (T9353)
+### Priority 4: Deprecate IVTR State Machine (Phase 5 — T9498)
 
 **Action**: Mark `tasks.ivtr_state` column as @deprecated. Provide read-only view.
 
@@ -562,7 +562,7 @@ This audit identifies:
 - ✓ 6 overlapping gate concepts
 - ✓ 5 missing provenance graph components
 - ✓ 2 viable decoupling paths (evidence-first, graph-normalized)
-- ✓ 4 high-priority follow-up tasks (T9350–T9353)
+- ✓ 4 high-priority follow-up tasks (T9491, T9497, T9498, T9499)
 
 **Output**: `/mnt/projects/cleocode/.cleo/rcasd/T9345/research/ivtr-conflation-audit.md`
 

--- a/.cleo/rcasd/T9345/research/migration-plan-T9345.md
+++ b/.cleo/rcasd/T9345/research/migration-plan-T9345.md
@@ -15,7 +15,7 @@
 
 This plan describes how the CLEO codebase moves from the ADR-065 12-step `cleo release ship` monolith (currently shipping every release since v2026.5.43) to the SPEC-T9345 v2 architecture (4 operator verbs + 4 GHA workflows + 11 new provenance tables) **without breaking the next release**. The migration is sequenced as six phases over a maximum of twelve operator-weeks (≈8 calendar weeks with two parallel orchestrators). Each phase has explicit entry criteria, exit criteria, a measurable rollback trigger, and a defined LOC-change budget. Phases 0-2 are additive — they introduce new schema and read-only verbs alongside the legacy monolith with zero behavior change. Phases 3-5 are cutovers where the operator surface flips: Phase 3 introduces `cleo release open` and the prepare workflow opt-in, Phase 4 introduces publish + reconcile workflows, Phase 5 deprecates `cleo release ship` and makes the new path the default. Phase 6 is cleanup — deletion of the 761-line monolith and the parallel 4-step pipeline. The plan also defines a compatibility shim (`cleo release ship --workflow=false`) that preserves the legacy path for emergency use through the third release cycle after Phase 5 completes.
 
-Risk grading is honest: Phases 0-2 and 6 are LOW (additive or post-cutover); Phases 3-4 are MEDIUM (new workflows are load-bearing); Phase 5 is HIGH (operator surface flip). Each high-risk phase has a defined rollback path with exact git/SQL commands and a dogfooded test release on a non-main branch as a phase gate. Eight child epics are pre-decomposed at the bottom of this document (T9346-T9353) so the orchestrator can spawn them in parallel where independent.
+Risk grading is honest: Phases 0-2 and 6 are LOW (additive or post-cutover); Phases 3-4 are MEDIUM (new workflows are load-bearing); Phase 5 is HIGH (operator surface flip). Each high-risk phase has a defined rollback path with exact git/SQL commands and a dogfooded test release on a non-main branch as a phase gate. Eight child epics are pre-decomposed at the bottom of this document (T9491-T9495) so the orchestrator can spawn them in parallel where independent.
 
 The plan binds tightly to `SPEC-T9345-release-pipeline-v2.md`: every phase's deliverables map to a specific subset of normative requirements (R-NNN), every phase's exit criterion is a scenario from `test-matrix-T9345.md`, and every rollback path preserves the legacy `release_manifests` table per Force F12 (backward compatibility). Total LLM spend across the migration is estimated at ~$300; total operator-week cost (orchestrator + human review) is ~12 operator-weeks. The migration ships zero data loss, zero forced downtime on `tasks.db`, and zero release blackouts (the legacy path is available throughout Phases 0-5).
 
@@ -42,7 +42,7 @@ Six phases, each bounded to 2 calendar weeks max. Each row in the table is norma
 | 0 | Schema migration + dual-write kill-switch | LOW | 1 wk | +400 (DDL + accessors) | trivial revert | Migrations applied; `CLEO_PROVENANCE_DUAL_WRITE=1` (default off) |
 | 1 | `plan` + `reconcile` (read-mostly) | LOW | 2 wks | +700 (new modules) | trivial revert | Both verbs return correct envelopes against test fixtures |
 | 2 | Provenance backfill (`cleo provenance backfill`) | MEDIUM | 2 wks | +400 (backfill writer) | idempotent UPSERT; safe to re-run | Historical releases (v2026.5.0 → v2026.5.74) backfilled with `provenance_quality='inferred'` ≤5% of rows |
-| 3 | `release-prepare.yml` + `open` verb | MEDIUM | 2 wks | +200 + 1 YAML | revertible via PR; legacy path untouched | Test release `v2026.7.0-test-1` shipped on `release-test/T9347` branch through new prepare workflow |
+| 3 | `release-prepare.yml` + `open` verb | MEDIUM | 2 wks | +200 + 1 YAML | revertible via PR; legacy path untouched | Test release `v2026.7.0-test-1` shipped on `release-test/T9492` branch through new prepare workflow |
 | 4 | `release-publish.yml` + `release-fanout.yml` + matrix | HIGH | 2 wks | +200 + 2 YAML | revertible via workflow rename + branch reset | Real minor release (target: `v2026.7.0`) ships through new publish path while `cleo release ship` available as `--workflow=false` fallback |
 | 5 | Operator surface flip (`ship` deprecated) | HIGH | 2 wks | -800 (monolith deleted) +200 (shim) | possible via PR revert during transition window | Two consecutive releases ship without invoking `--workflow=false`; deprecation warnings active |
 | 6 | Cleanup | LOW | 1 wk | -1500 net | not reversible; do last | `releaseShip` monolith deleted; IVTR-from-release code removed; CI green; `cleo release --help` shows 4 verbs |
@@ -81,7 +81,7 @@ cleo restore backup --file tasks.db --from tasks-20260520-120000.db
 git revert <phase-0-commit-sha>
 ```
 
-**Owner approval gate**: T9346 (Phase 0 epic) closed by HITL approval before Phase 1 begins.
+**Owner approval gate**: T9491 (Phase 0 epic) closed by HITL approval before Phase 1 begins.
 
 ### 2.2 Phase 1 — `plan` + `reconcile` (2 weeks, LOW)
 
@@ -109,7 +109,7 @@ git revert <phase-0-commit-sha>
 **Rollback trigger**: any of the new verbs corrupts existing `tasks.db` data (caught by invariant checks).
 **Rollback**: `git revert <phase-1-commit-range>`. Schema from Phase 0 stays; verbs disappear.
 
-**Owner approval gate**: T9347 (Phase 1 epic) closed; demo of the 6 scenarios green.
+**Owner approval gate**: T9492 (Phase 1 epic) closed; demo of the 6 scenarios green.
 
 ### 2.3 Phase 2 — Provenance backfill (2 weeks, MEDIUM)
 
@@ -139,14 +139,14 @@ DELETE FROM task_commits WHERE created_at >= '2026-05-20T00:00:00Z' AND link_sou
 ```
 Backfill is timestamped + tagged with `link_source='backfill'`; clean deletion is straightforward.
 
-**Owner approval gate**: T9348 (Phase 2 epic) closed; backfill report reviewed.
+**Owner approval gate**: T9493 (Phase 2 epic) closed; backfill report reviewed.
 
 ### 2.4 Phase 3 — `release-prepare.yml` + `open` verb (2 weeks, MEDIUM)
 
 **Scope**:
 - Write `release-prepare.yml` per SPEC §5.1 (R-200 through R-210). Triggers on `workflow_dispatch`. Runs preflight (lint+typecheck+build+test). Bumps version + CHANGELOG. Opens bump-PR.
 - Implement `cleo release open <version>` per SPEC R-050 through R-071. Reads plan file; invokes `gh workflow run`.
-- Test on a non-main branch: cut `release-test/T9349`, set up branch protection mimicking main, dispatch the workflow against `v2026.7.0-test-1`, verify the bump-PR opens correctly with all gates green.
+- Test on a non-main branch: cut `release-test/T9494`, set up branch protection mimicking main, dispatch the workflow against `v2026.7.0-test-1`, verify the bump-PR opens correctly with all gates green.
 - Do NOT touch `release-publish.yml` yet; the test release does NOT publish. The bump-PR is reviewed and closed without merge.
 
 **Deliverables**:
@@ -170,10 +170,10 @@ mv .github/workflows/release-prepare.yml .github/workflows/release-prepare.yml.d
 # 2. Revert the open verb wiring.
 git revert <phase-3-commit-sha>
 # 3. Manually clean up any orphaned release-test/* branches.
-git push origin --delete release-test/T9349
+git push origin --delete release-test/T9494
 ```
 
-**Owner approval gate**: T9349 (Phase 3 epic) closed; dogfood demo on `release-test/T9349` green.
+**Owner approval gate**: T9494 (Phase 3 epic) closed; dogfood demo on `release-test/T9494` green.
 
 ### 2.5 Phase 4 — `release-publish.yml` + `release-fanout.yml` (2 weeks, HIGH)
 
@@ -244,7 +244,7 @@ mv .github/workflows/release-fanout.yml .github/workflows/release-fanout.yml.dis
 # 5. Operator falls back to cleo release ship --workflow=false for the next release.
 ```
 
-**Owner approval gate**: T9350 (Phase 4 epic) closed; v2026.7.0 shipped clean; rollback path TESTED at least once in dry-run (S10).
+**Owner approval gate**: T9497 (Phase 4 epic) closed; v2026.7.0 shipped clean; rollback path TESTED at least once in dry-run (S10).
 
 ### 2.6 Phase 5 — Operator surface flip (2 weeks, HIGH)
 
@@ -279,7 +279,7 @@ git push origin fix/T9345-phase5-rollback
 CLEO_RELEASE_EMERGENCY=1 cleo release ship vNEXT --workflow=false --epic T<n>
 ```
 
-**Owner approval gate**: T9351 (Phase 5 epic) closed; 2 releases green; emergency shim usage = 0.
+**Owner approval gate**: T9498 (Phase 5 epic) closed; 2 releases green; emergency shim usage = 0.
 
 ### 2.7 Phase 6 — Cleanup (1 week, LOW)
 
@@ -306,7 +306,7 @@ CLEO_RELEASE_EMERGENCY=1 cleo release ship vNEXT --workflow=false --epic T<n>
 **Rollback trigger**: a test or production release breaks because a deleted symbol is still referenced.
 **Rollback**: `git revert <phase-6-commit-range>`. The previous phases' code is intact; only the cleanup is rolled back.
 
-**Owner approval gate**: T9353 (Phase 6 epic) closed; final demo of the 4-verb surface; migration complete.
+**Owner approval gate**: T9495 (Phase 6 epic) closed; final demo of the 4-verb surface; migration complete.
 
 ---
 
@@ -400,9 +400,9 @@ Mostly automated. The operator's job is to observe and approve.
 
 ```bash
 # Monitor migration progress.
-cleo find "T9346" --status in_progress  # Phase 0 epic
-cleo find "T9347" --status in_progress  # Phase 1 epic
-cleo find "T9348" --status in_progress  # Phase 2 epic
+cleo find "T9491" --status in_progress  # Phase 0 epic
+cleo find "T9492" --status in_progress  # Phase 1 epic
+cleo find "T9493" --status in_progress  # Phase 2 epic
 
 # Inspect backfill state after Phase 2 completes.
 cleo provenance verify v2026.5.74  # spot-check most recent release
@@ -415,14 +415,14 @@ Test-release-driven. Operator initiates each test release.
 
 ```bash
 # Phase 3: dispatch the prepare workflow against a non-main branch.
-git checkout -b release-test/T9349
-git push origin release-test/T9349
-cleo release plan v2026.7.0-test-1 --epic T9349
+git checkout -b release-test/T9494
+git push origin release-test/T9494
+cleo release plan v2026.7.0-test-1 --epic T9494
 cleo release open v2026.7.0-test-1
 # Inspect the bump-PR; close without merging.
 
 # Phase 4: ship the real v2026.7.0 through the new path.
-cleo release plan v2026.7.0 --epic T9349
+cleo release plan v2026.7.0 --epic T9494
 cleo release open v2026.7.0
 # Wait for bump-PR review + auto-merge.
 # release-publish.yml runs automatically.
@@ -437,7 +437,7 @@ Default-flip; operators ship normally with deprecation warnings.
 
 ```bash
 # Normal release flow under the new default.
-cleo release ship v2026.7.1 --epic T9351
+cleo release ship v2026.7.1 --epic T9498
 # Now prints: "DEPRECATED: 'cleo release ship' will be removed in v2027.1. Use 'cleo release plan/open' instead."
 # Under the hood: invokes plan + open.
 
@@ -486,7 +486,7 @@ SELECT version, status, change_count, bug_count, hotfix_count, breaking_count FR
 
 The migration is delivered as eight child epics filed under T9345. Each epic has a slot, a kind, a size, dependencies, and three top-line acceptance criteria. Orchestrators MAY spawn the independent epics in parallel.
 
-### T9346 — Phase 0: Schema migration + dual-write kill-switch
+### T9491 — Phase 0: Schema migration + dual-write kill-switch
 
 - **Kind**: work
 - **Size**: small
@@ -498,84 +498,84 @@ The migration is delivered as eight child epics filed under T9345. Each epic has
   2. `cleo provenance verify <version>` CLI verb exists and returns pass for an empty schema.
   3. `CLEO_PROVENANCE_DUAL_WRITE=1` env var causes `cleo release ship` to ALSO write to `releases` + `release_changes` without breaking the legacy `release_manifests.tasksJson` path.
 
-### T9347 — Phase 1: `plan` + `reconcile` (read-mostly)
+### T9492 — Phase 1: `plan` + `reconcile` (read-mostly)
 
 - **Kind**: work
 - **Size**: medium
 - **Priority**: P1
-- **BlockedBy**: T9346
+- **BlockedBy**: T9491
 - **Owner**: orchestrator + 2 workers (plan, reconcile, tests in parallel)
 - **Acceptance**:
-  1. `cleo release plan v2026.7.0-test-1 --epic T9347` produces a valid plan file conforming to SPEC §6 against the cleocode repo.
+  1. `cleo release plan v2026.7.0-test-1 --epic T9492` produces a valid plan file conforming to SPEC §6 against the cleocode repo.
   2. `cleo release reconcile v2026.7.0-test-1` against a hand-prepared test release populates the 11 provenance tables; `cleo provenance verify` passes.
   3. 14 read verbs (`cleo release graph/diff/impact/authors/orphans` + `cleo provenance task/commit/pr/feature/release/change/backfill/link/verify`) return correct envelopes against `test-matrix-T9345.md` fixtures.
 
-### T9348 — Phase 2: Provenance backfill
+### T9493 — Phase 2: Provenance backfill
 
 - **Kind**: work
 - **Size**: medium
 - **Priority**: P2
-- **BlockedBy**: T9347
+- **BlockedBy**: T9492
 - **Owner**: orchestrator + 1 worker
 - **Acceptance**:
   1. `cleo provenance backfill --since v2026.4.0` populates `commits`, `task_commits`, `release_commits`, `release_changes`, `release_artifacts`, `pull_requests`, `pr_commits`, `pr_tasks`, `commit_files`, `brain_release_links` for all 70+ historical releases.
   2. ≥95% of `release_changes` rows have `provenance_quality='inferred'` (high-confidence extraction).
   3. Re-running the backfill is a verified no-op (UPSERT idempotency proven via integration test).
 
-### T9349 — Phase 3: `release-prepare.yml` + `open` verb
+### T9494 — Phase 3: `release-prepare.yml` + `open` verb
 
 - **Kind**: work
 - **Size**: medium
 - **Priority**: P1
-- **BlockedBy**: T9347
+- **BlockedBy**: T9492
 - **Owner**: orchestrator + 2 workers (workflow YAML, open verb)
 - **Acceptance**:
-  1. `release-prepare.yml` passes `actionlint` and successfully opens a bump-PR for a test release on a non-main branch (`release-test/T9349`).
+  1. `release-prepare.yml` passes `actionlint` and successfully opens a bump-PR for a test release on a non-main branch (`release-test/T9494`).
   2. `cleo release open <version>` invokes `gh workflow run` and polls until the run reaches in-progress; updates `releases.status='pr-opened'`; emits LAFS envelope with `workflowRunUrl`.
   3. Test scenario S3 (epic-completeness scope) and S9 (orphan-commit detection) pass on the test fixture.
 
-### T9350 — Phase 4: `release-publish.yml` + `release-fanout.yml` + matrix
+### T9497 — Phase 4: `release-publish.yml` + `release-fanout.yml` + matrix
 
 - **Kind**: work
 - **Size**: large
 - **Priority**: P1
-- **BlockedBy**: T9349
+- **BlockedBy**: T9494
 - **Owner**: orchestrator + 3 workers (publish, fanout, matrix)
 - **Acceptance**:
   1. `v2026.7.0` ships entirely through the new path with operator wall-time ≤5 minutes from `cleo release plan` to `cleo provenance verify` passing.
   2. Build matrix produces 5 platform artifacts (linux-x64/arm64, macos-x64/arm64, windows-x64) attached to the GitHub Release.
   3. Failure modes F1 (wedged commit), F6 (tag at wrong SHA), F8 (release start no-op) DO NOT reproduce. Verified by injecting F1/F6/F8 conditions on a test branch and confirming the new path catches them.
 
-### T9351 — Phase 5: Operator surface flip + `cleo release ship` deprecation
+### T9498 — Phase 5: Operator surface flip + `cleo release ship` deprecation
 
 - **Kind**: work
 - **Size**: small
 - **Priority**: P1
-- **BlockedBy**: T9350
+- **BlockedBy**: T9497
 - **Owner**: orchestrator + 1 worker + docs writer
 - **Acceptance**:
   1. `cleo release ship` defaults to `--workflow=true`; prints deprecation warning; forwards to `plan + open`.
   2. Two consecutive real releases (`v2026.7.1` and `v2026.7.2`) ship through the new path with no `--workflow=false` invocations.
   3. `ct-orchestrator` skill documentation updated; operator survey returns ≥7/10 ease-of-use score from ≥3 operators.
 
-### T9352 — IVTR decoupling from release path (parallel to Phases 3-5)
+### T9499 — IVTR decoupling from release path (parallel to Phases 3-5)
 
 - **Kind**: work
 - **Size**: small
 - **Priority**: P1
-- **BlockedBy**: T9346 (schema), T9347 (plan)
+- **BlockedBy**: T9491 (schema), T9492 (plan)
 - **Owner**: orchestrator + 1 worker
 - **Acceptance**:
   1. `releaseGateCheck`, `releaseIvtrAutoSuggest`, `checkIvtrGates` removed from `engine-ops.ts` (post Phase 5).
   2. `task.ivtr_state` marked `@deprecated`; read-only view derived from ADR-051 evidence atoms.
   3. `cleo orchestrate ivtr --start/--next/--release` deprecated; only `--status` remains as a read-only view.
 
-### T9353 — Phase 6: Cleanup (monolith deletion)
+### T9495 — Phase 6: Cleanup (monolith deletion)
 
 - **Kind**: work
 - **Size**: small
 - **Priority**: P2
-- **BlockedBy**: T9351, T9352
+- **BlockedBy**: T9498, T9499
 - **Owner**: orchestrator + 1 worker
 - **Acceptance**:
   1. `releaseShip` (engine-ops.ts:1105-1866, 761 LOC) deleted.
@@ -605,12 +605,12 @@ gantt
     section Phase 6
     Cleanup                 :p6, after p5, 1w
     section Parallel
-    T9352 IVTR decouple     :ivtr, after p1, 4w
+    T9499 IVTR decouple     :ivtr, after p1, 4w
 ```
 
 Parallel orchestrators MAY collapse the timeline:
-- T9348 (backfill) can run in parallel with T9349 (prepare workflow) — neither depends on the other after T9347.
-- T9352 (IVTR decouple) can run in parallel with Phases 3-5.
+- T9493 (backfill) can run in parallel with T9494 (prepare workflow) — neither depends on the other after T9492.
+- T9499 (IVTR decouple) can run in parallel with Phases 3-5.
 
 Best-case calendar (2 parallel orchestrators): **8 weeks**. Worst-case (single sequential orchestrator): **12 weeks**.
 

--- a/.cleo/rcasd/T9345/research/test-matrix-T9345.md
+++ b/.cleo/rcasd/T9345/research/test-matrix-T9345.md
@@ -451,7 +451,7 @@ When all items above are checked, the owner signs the T9345 completion record by
 4. Running `cleo verify T9345 --gate documented --evidence "files:.cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md,.cleo/rcasd/T9345/research/migration-plan-T9345.md,.cleo/rcasd/T9345/research/test-matrix-T9345.md,.cleo/adrs/ADR-073-ivtr-release-overhaul.md"`.
 5. Running `cleo complete T9345`.
 
-Per ADR-051, this records evidence atoms for the spec-deliverable phase. Subsequent child epics (T9346-T9353) each record their own evidence on completion.
+Per ADR-051, this records evidence atoms for the spec-deliverable phase. Subsequent child epics (T9491, T9492, T9493, T9494, T9495, T9496, T9497, T9498, T9499) each record their own evidence on completion.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,31 @@ When a task introduces new modules, the orchestrator MUST include an acceptance 
 
 If existing files violate the boundary, flag as a separate cleanup task (e.g., T1015-style relocation epic). Do NOT continue appending to the wrong package.
 
+## Task Hierarchy Canon
+
+CLEO uses a four-tier task hierarchy. Each tier has a canonical prefix; prefixes are permanent
+(no rename primitive exists). The prefix registry lives in ADR-073.
+
+| Tier     | Prefix | Description |
+|----------|--------|-------------|
+| Subtask  | (none) | Leaf-level work unit, child of a Task |
+| Task     | `T-`   | Atomic unit of work |
+| Epic     | `E-`   | Multi-task initiative, owns a lifecycle pipeline |
+| Saga     | `SG-`  | Multi-release theme grouping multiple Epics via `task_relations.type=groups` (ADR-073) |
+
+Saga (SG-) — multi-release theme grouping multiple Epics via task_relations.type=groups (ADR-073)
+
+- Saga is a **labeled role** on a top-level Epic (`label = 'saga'`), NOT a new `TaskType` value.
+- Link Epics to a Saga via `cleo update SG-X --relates E-Y:groups`.
+- Gating dep: T9514 (`cleo update --relates` writer fix) must merge before creating any Saga.
+
+**Prefix registry** (from ADR-073 — all above-task prefixes must be registered here):
+
+| Prefix | Reserved for |
+|--------|-------------|
+| `SG-`  | Saga (above-Epic grouping) |
+| `SD-`  | SignalDock (identity / messaging subsystem) |
+
 ## Sentient / Tier-2 Proposals
 
 The `cleo sentient` subsystem manages autonomous task proposals.

--- a/packages/core/templates/CLEO-INJECTION.md
+++ b/packages/core/templates/CLEO-INJECTION.md
@@ -59,6 +59,17 @@ If you find yourself reading a markdown file for orientation, STOP. Run `cleo br
 ## Task Creation (ADR-066)
 
 `--acceptance` required for ALL tasks. `cleo bug`/`--role` removed — use `cleo add --kind bug --severity Px --acceptance "..."`. Axes: `--type {epic|task|subtask}`, `--kind {work|research|experiment|bug|spike|release}`, `--severity {P0-P3}` (orthogonal to `--priority`; triggers Ed25519 attestation).
+
+### Sagas — above-Epic grouping (ADR-073)
+
+A **Saga** (`SG-`) is a multi-release theme grouping multiple Epics. It is a labeled top-level
+Epic, not a new TaskType. Gating dependency: T9514 must merge before creating Sagas.
+
+| Goal | Command |
+|------|---------|
+| Create a Saga | `cleo add --type epic --label saga --title "SG-X: ..." --acceptance "..."` |
+| Link an Epic to a Saga | `cleo update SG-X --relates E-Y:groups` |
+| List Epics in a Saga | `cleo list --parent SG-X` (or `cleo find "label:saga"`) |
 <!-- /CLEO-INJECTION:section=task-creation -->
 
 <!-- CLEO-INJECTION:section=task-discovery -->


### PR DESCRIPTION
## Summary

- ADR-073 declares Saga (prefix `SG-`) as above-Epic grouping role (Status: Accepted)
- Reserves `SG-` for Saga and `SD-` for SignalDock in prefix registry (neutralizes Contrarian's collision risk)
- Saga is a labeled role on a top-level Epic (`label = 'saga'`), not a new `TaskType` — explicit clause in ADR
- Wire mechanism: `task_relations.type = 'groups'` (T9519)
- Gating dependency T9514 documented — no Saga may be created until relates writer fix merges
- AGENTS.md gains new "Task Hierarchy Canon" section with Saga line and prefix registry
- `packages/core/templates/CLEO-INJECTION.md` (tracked template) updated with `cleo saga` commands in task-creation section

Council verdict: `.cleo/council-runs/20260517T002448Z-e4223249/verdict.md`

Refs T9518

## Test plan

- [ ] `grep -q 'Saga' AGENTS.md` — passes
- [ ] `grep -q 'SD-' .cleo/adrs/ADR-073-above-epic-naming.md` — passes
- [ ] ADR contains all 4 required sections: name/prefix, prefix registry SG-/SD-, role-not-type clause, T9514 gating dep
- [ ] `pnpm biome check` exits 0 (markdown excluded from biome scope by design — only TS files in packages/*/src/** are checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)