### PR TITLE
fix(T9514): persist --relates writes from cleo update

### DIFF
--- a/packages/contracts/src/data-accessor.ts
+++ b/packages/contracts/src/data-accessor.ts
@@ -118,6 +118,17 @@ export interface TransactionAccessor {
   setMetaValue(key: string, value: unknown): Promise<void>;
   updateTaskFields(taskId: string, fields: TaskFieldUpdates): Promise<void>;
   appendLog(entry: Record<string, unknown>): Promise<void>;
+  /** Persist a relation row to task_relations. @task T9514 */
+  addRelation(
+    taskId: string,
+    relatedTo: string,
+    relationType: string,
+    reason?: string,
+  ): Promise<void>;
+  /** Remove a relation row from task_relations. @task T9514 */
+  removeRelation(taskId: string, relatedTo: string, relationType?: string): Promise<void>;
+  /** Remove all relations for a task (both directions) — used for set-replace. @task T9514 */
+  clearRelations(taskId: string): Promise<void>;
 }
 
 /**

--- a/packages/core/src/store/sqlite-data-accessor.ts
+++ b/packages/core/src/store/sqlite-data-accessor.ts
@@ -884,6 +884,28 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
           async appendLog(entry: Record<string, unknown>): Promise<void> {
             await accessor.appendLog(entry);
           },
+          // T9514: persist relates mutations inside the transaction
+          async addRelation(
+            taskId: string,
+            relatedTo: string,
+            relationType: string,
+            reason?: string,
+          ): Promise<void> {
+            await accessor.addRelation(taskId, relatedTo, relationType, reason);
+          },
+          async removeRelation(
+            taskId: string,
+            relatedTo: string,
+            relationType?: string,
+          ): Promise<void> {
+            await accessor.removeRelation(taskId, relatedTo, relationType);
+          },
+          async clearRelations(taskId: string): Promise<void> {
+            await db
+              .delete(schema.taskRelations)
+              .where(eq(schema.taskRelations.taskId, taskId))
+              .run();
+          },
         };
 
         const result = await fn(tx);

--- a/packages/core/src/tasks/__tests__/update-relates.test.ts
+++ b/packages/core/src/tasks/__tests__/update-relates.test.ts
@@ -1,12 +1,27 @@
 /**
- * Unit tests for relates mutations in updateTask.
+ * Tests for relates mutations in updateTask.
+ *
+ * Two suites:
+ *  1. Unit tests with mock accessor — verify in-memory relates array is updated.
+ *  2. Integration tests with real SQLite — verify task_relations table is written
+ *     (regression for T9514: --relates/--add-relates were a no-op before this fix).
+ *
  * @task T9334
+ * @task T9514
  */
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { Task } from '@cleocode/contracts';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { DataAccessor } from '../../store/data-accessor.js';
+import { createSqliteDataAccessor } from '../../store/sqlite-data-accessor.js';
 import { updateTask } from '../update.js';
+
+// ---------------------------------------------------------------------------
+// Unit tests (mock accessor — validates in-memory task.relates mutations)
+// ---------------------------------------------------------------------------
 
 function makeMockAccessor(task: Task): DataAccessor {
   return {
@@ -16,6 +31,9 @@ function makeMockAccessor(task: Task): DataAccessor {
       fn({
         upsertSingleTask: async () => {},
         appendLog: async () => {},
+        addRelation: async () => {},
+        removeRelation: async () => {},
+        clearRelations: async () => {},
       } as unknown as Parameters<Parameters<DataAccessor['transaction']>[0]>[0]),
     getSubtree: async () => [],
     getAncestorChain: async () => [],
@@ -35,7 +53,7 @@ function makeTask(overrides?: Partial<Task>): Task {
   } as Task;
 }
 
-describe('updateTask relates mutations', () => {
+describe('updateTask relates mutations (unit — mock accessor)', () => {
   it('sets relates replacing existing', async () => {
     const task = makeTask({ relates: [{ taskId: 'T002', type: 'related' }] });
     const accessor = makeMockAccessor(task);
@@ -101,5 +119,136 @@ describe('updateTask relates mutations', () => {
       accessor,
     );
     expect(result.task.relates![0].reason).toBe('blocks execution');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests (real SQLite — regression for T9514)
+//
+// These tests prove that task_relations rows are actually written to the DB,
+// not just updated in memory. Pre-fix these would pass on changes[] but
+// loadSingleTask after update would return relates: [].
+// ---------------------------------------------------------------------------
+
+describe('updateTask relates persistence (integration — real SQLite, T9514)', () => {
+  let testDir: string;
+  let accessor: Awaited<ReturnType<typeof createSqliteDataAccessor>>;
+
+  const seedTask = async (id: string, title: string): Promise<void> => {
+    const t: Task = {
+      id,
+      title,
+      status: 'pending',
+      priority: 'medium',
+      type: 'task',
+      createdAt: new Date().toISOString(),
+    };
+    await accessor.upsertSingleTask(t);
+  };
+
+  beforeEach(async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'cleo-update-relates-T9514-'));
+    accessor = await createSqliteDataAccessor(testDir);
+    // Seed three tasks so relates targets are valid
+    await seedTask('T001', 'Source task');
+    await seedTask('T002', 'Target task A');
+    await seedTask('T003', 'Target task B');
+  });
+
+  afterEach(async () => {
+    await accessor.close();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('--relates persists rows to task_relations (regression T9514)', async () => {
+    // Pre-fix: this would succeed but loadSingleTask after would return relates:[]
+    await updateTask(
+      {
+        taskId: 'T001',
+        relates: [{ taskId: 'T002', type: 'blocks', reason: 'T001 blocks T002' }],
+      },
+      testDir,
+      accessor,
+    );
+
+    const reloaded = await accessor.loadSingleTask('T001');
+    expect(reloaded?.relates).toBeDefined();
+    expect(reloaded!.relates).toHaveLength(1);
+    expect(reloaded!.relates![0]).toEqual({
+      taskId: 'T002',
+      type: 'blocks',
+      reason: 'T001 blocks T002',
+    });
+  });
+
+  it('--add-relates appends without overwriting existing rows (regression T9514)', async () => {
+    // First add one relation via --relates
+    await updateTask(
+      {
+        taskId: 'T001',
+        relates: [{ taskId: 'T002', type: 'related' }],
+      },
+      testDir,
+      accessor,
+    );
+
+    // Now append a second via --add-relates
+    await updateTask(
+      {
+        taskId: 'T001',
+        addRelates: [{ taskId: 'T003', type: 'blocks' }],
+      },
+      testDir,
+      accessor,
+    );
+
+    const reloaded = await accessor.loadSingleTask('T001');
+    expect(reloaded!.relates).toHaveLength(2);
+    expect(reloaded!.relates!.map((r) => r.taskId).sort()).toEqual(['T002', 'T003']);
+  });
+
+  it('--relates replaces all existing rows (set-replace semantics)', async () => {
+    // Seed an existing relation
+    await updateTask(
+      {
+        taskId: 'T001',
+        relates: [{ taskId: 'T002', type: 'related' }],
+      },
+      testDir,
+      accessor,
+    );
+
+    // Replace with a new set — T002 should be gone
+    await updateTask(
+      {
+        taskId: 'T001',
+        relates: [{ taskId: 'T003', type: 'blocks' }],
+      },
+      testDir,
+      accessor,
+    );
+
+    const reloaded = await accessor.loadSingleTask('T001');
+    expect(reloaded!.relates).toHaveLength(1);
+    expect(reloaded!.relates![0].taskId).toBe('T003');
+  });
+
+  it('persists across accessor restart (DB survives session boundary)', async () => {
+    await updateTask(
+      {
+        taskId: 'T001',
+        relates: [{ taskId: 'T002', type: 'fixes', reason: 'fix reason' }],
+      },
+      testDir,
+      accessor,
+    );
+
+    // Close and reopen — proves the row is in the DB, not just in memory
+    await accessor.close();
+    accessor = await createSqliteDataAccessor(testDir);
+
+    const reloaded = await accessor.loadSingleTask('T001');
+    expect(reloaded!.relates).toHaveLength(1);
+    expect(reloaded!.relates![0]).toEqual({ taskId: 'T002', type: 'fixes', reason: 'fix reason' });
   });
 });

--- a/packages/core/src/tasks/update.ts
+++ b/packages/core/src/tasks/update.ts
@@ -539,9 +539,39 @@ export async function updateTask(
 
   task.updatedAt = now;
 
+  // Capture final relates state before transaction (built above from options)
+  const finalRelates = task.relates ?? [];
+  const isRelatesChange = changes.includes('relates');
+
   // Wrap writes in a transaction for TOCTOU safety (T023)
   await acc.transaction(async (tx) => {
     await tx.upsertSingleTask(task);
+
+    // T9514: persist relates mutations to task_relations table.
+    // The in-memory task.relates update is not enough — upsertSingleTask
+    // only writes the tasks row and task_dependencies; task_relations is a
+    // separate table that must be written explicitly.
+    if (isRelatesChange) {
+      if (options.relates !== undefined) {
+        // Set-replace: clear existing rows then insert the new set.
+        await tx.clearRelations(options.taskId);
+        for (const r of finalRelates) {
+          await tx.addRelation(options.taskId, r.taskId, r.type, r.reason);
+        }
+      } else {
+        if (options.addRelates?.length) {
+          for (const r of options.addRelates) {
+            await tx.addRelation(options.taskId, r.taskId, r.type, r.reason);
+          }
+        }
+        if (options.removeRelates?.length) {
+          for (const id of options.removeRelates) {
+            await tx.removeRelation(options.taskId, id.trim());
+          }
+        }
+      }
+    }
+
     await tx.appendLog({
       id: `log-${Math.floor(Date.now() / 1000)}-${(await import('node:crypto')).randomBytes(3).toString('hex')}`,
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Fixes T9514: `cleo update --relates` and `--add-relates` were no-ops — writes never reached `task_relations` table
- Root cause: `upsertSingleTask` only writes the tasks row and task_dependencies; task_relations is a separate table requiring explicit writes
- Fix adds `addRelation`, `removeRelation`, and `clearRelations` to `TransactionAccessor` so all three relates mutation modes (set-replace, append, remove) are persisted atomically inside the existing TOCTOU-safe transaction

## Test plan
- [x] 4 integration regression tests added to `update-relates.test.ts` — each explicitly reloads task from DB post-update to prove the row is in `task_relations`, not just in memory
- [x] Pre-existing 4 unit tests updated to satisfy new `TransactionAccessor` interface (mock adds new stubs)
- [x] All 8 tests pass: `vitest run src/tasks/__tests__/update-relates.test.ts` → 8 passed
- [x] Pre-existing 23 failures in core suite confirmed pre-existing (unrelated: skills/dispatch, sentient/baseline, error-hints)
- [x] Biome: GREEN (no fixes needed after auto-fix pass)
- [x] Quality gates: biome=GREEN, test=GREEN (8/8 update-relates pass)

## Files changed
- `packages/contracts/src/data-accessor.ts` — added `addRelation`, `removeRelation`, `clearRelations` to `TransactionAccessor` interface
- `packages/core/src/store/sqlite-data-accessor.ts` — implemented the three new transaction methods
- `packages/core/src/tasks/update.ts` — call the new methods inside the transaction when `relates` changes are present
- `packages/core/src/tasks/__tests__/update-relates.test.ts` — 4 new integration tests + mock updated

Closes T9514