### PR TITLE
feat(T9403+T9404): remove cleoHomeDir() — route LLM layer through @cleocode/paths

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1707,10 +1707,11 @@ export type {
   CredentialSource,
 } from './llm/credentials.js';
 // LLM — credential resolver (T1677: moved from memory/anthropic-key-resolver.ts)
+// T9403: `cleoHomeDir` removed — callers MUST use `getCleoHome` from
+// `@cleocode/paths` directly so the `CLEO_HOME` env override applies.
 export {
   authHeaders,
   clearAnthropicKeyCache,
-  cleoHomeDir,
   OAUTH_STATUS_PROVIDERS,
   resolveCredentials,
   resolveModelCredentials,

--- a/packages/core/src/llm/__tests__/credential-pool.test.ts
+++ b/packages/core/src/llm/__tests__/credential-pool.test.ts
@@ -29,7 +29,15 @@ import {
 // ---------------------------------------------------------------------------
 
 const SAVED_ENV: Record<string, string | undefined> = {};
-const ENV_KEYS = ['XDG_DATA_HOME', 'HOME', 'CLEO_DIR', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY'];
+// T9403: include CLEO_HOME so getCleoHome() resolves into per-test sandbox.
+const ENV_KEYS = [
+  'XDG_DATA_HOME',
+  'CLEO_HOME',
+  'HOME',
+  'CLEO_DIR',
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+];
 
 function saveEnv(): void {
   for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
@@ -57,6 +65,8 @@ function isolateHomes(): { xdgRoot: string; home: string } {
   mkdirSync(join(xdgRoot, 'cleo'), { recursive: true });
   mkdirSync(home, { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9403: getCleoHome() honours CLEO_HOME first; mirror the XDG layout.
+  process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;
   return { xdgRoot, home };
 }

--- a/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
+++ b/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
@@ -25,6 +25,8 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
+  'CLEO_HOME',
   'HOME',
   'CLEO_DIR',
 ];
@@ -68,10 +70,13 @@ beforeEach(() => {
   clearEnv();
   clearAnthropicKeyCache();
   // Isolate XDG so global config tier never reads developer credentials.
-  process.env['XDG_DATA_HOME'] = join(
+  const xdgRoot = join(
     tmpdir(),
     `cleo-authtype-xdg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
+  process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9403: getCleoHome() honours CLEO_HOME first; mirror XDG layout.
+  process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   // Point HOME at an empty tmpdir so tier 3 (`~/.claude/.credentials.json`)
   // cannot pick up the developer's real Claude Code OAuth token. Deleting HOME
   // is not enough — Node's `os.homedir()` falls back to /etc/passwd. Tests that

--- a/packages/core/src/llm/__tests__/credentials-store.test.ts
+++ b/packages/core/src/llm/__tests__/credentials-store.test.ts
@@ -37,6 +37,9 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9403: getCleoHome() honours CLEO_HOME first; save/restore so the
+  // global vitest setup's per-fork pin is not destroyed by these tests.
+  'CLEO_HOME',
   'HOME',
   'CLEO_DIR',
 ];
@@ -67,6 +70,9 @@ function isolateHomes(): { xdgRoot: string; home: string } {
   mkdirSync(join(xdgRoot, 'cleo'), { recursive: true });
   mkdirSync(home, { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9403: mirror XDG layout under CLEO_HOME so getCleoHome() resolves to
+  // the same per-test sandbox.
+  process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;
   return { xdgRoot, home };
 }

--- a/packages/core/src/llm/__tests__/credentials.test.ts
+++ b/packages/core/src/llm/__tests__/credentials.test.ts
@@ -46,6 +46,10 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9403: getCleoHome() honours CLEO_HOME first, so we must save/restore it.
+  // The global vitest setup pins CLEO_HOME per-fork; per-test makeTempXdg()
+  // overrides it for filesystem isolation.
+  'CLEO_HOME',
   'CLEO_DIR',
 ];
 
@@ -71,7 +75,12 @@ function clearEnv(): void {
   }
 }
 
-/** Create a fresh temp dir and set XDG_DATA_HOME to it, returning the cleo dir. */
+/**
+ * Create a fresh temp dir and set XDG_DATA_HOME + CLEO_HOME to it, returning
+ * the cleo dir. Sets both env vars so the test isolates the global CLEO home
+ * regardless of whether the resolver consults XDG_DATA_HOME (legacy) or
+ * CLEO_HOME (T9403 — getCleoHome() from @cleocode/paths takes precedence).
+ */
 function makeTempXdg(): { xdgRoot: string; cleoDir: string; configPath: string } {
   const xdgRoot = join(
     tmpdir(),
@@ -80,6 +89,7 @@ function makeTempXdg(): { xdgRoot: string; cleoDir: string; configPath: string }
   const cleoDir = join(xdgRoot, 'cleo');
   mkdirSync(cleoDir, { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  process.env['CLEO_HOME'] = cleoDir;
   return { xdgRoot, cleoDir, configPath: join(cleoDir, 'config.json') };
 }
 

--- a/packages/core/src/llm/__tests__/migration.test.ts
+++ b/packages/core/src/llm/__tests__/migration.test.ts
@@ -43,6 +43,8 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
+  'CLEO_HOME',
   'HOME',
   'CLEO_DIR',
 ];
@@ -77,6 +79,8 @@ function isolate(): { xdgRoot: string; home: string; projectRoot: string } {
   mkdirSync(home, { recursive: true });
   mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9403: mirror XDG layout under CLEO_HOME for getCleoHome().
+  process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;
   return { xdgRoot, home, projectRoot };
 }

--- a/packages/core/src/llm/__tests__/rate-limit-guard.test.ts
+++ b/packages/core/src/llm/__tests__/rate-limit-guard.test.ts
@@ -26,7 +26,8 @@ import {
 // ---------------------------------------------------------------------------
 
 const SAVED_ENV: Record<string, string | undefined> = {};
-const ENV_KEYS = ['XDG_DATA_HOME', 'HOME'];
+// T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
+const ENV_KEYS = ['XDG_DATA_HOME', 'CLEO_HOME', 'HOME'];
 
 function saveEnv(): void {
   for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
@@ -46,6 +47,8 @@ function isolateHomes(): string {
   mkdirSync(join(xdgRoot, 'cleo'), { recursive: true });
   mkdirSync(home, { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9403: mirror XDG layout under CLEO_HOME for getCleoHome().
+  process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;
   return xdgRoot;
 }

--- a/packages/core/src/llm/__tests__/role-resolver-fullstack.test.ts
+++ b/packages/core/src/llm/__tests__/role-resolver-fullstack.test.ts
@@ -45,6 +45,8 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
+  'CLEO_HOME',
   'HOME',
   'CLEO_DIR',
 ];
@@ -73,6 +75,8 @@ function isolate(): { xdgRoot: string; home: string; projectRoot: string } {
   mkdirSync(home, { recursive: true });
   mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9403: mirror XDG layout under CLEO_HOME for getCleoHome().
+  process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;
   return { xdgRoot, home, projectRoot };
 }

--- a/packages/core/src/llm/__tests__/role-resolver.test.ts
+++ b/packages/core/src/llm/__tests__/role-resolver.test.ts
@@ -35,6 +35,8 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
+  'CLEO_HOME',
   'HOME',
   'CLEO_DIR',
 ];
@@ -69,6 +71,8 @@ function isolate(): { xdgRoot: string; home: string; projectRoot: string } {
   mkdirSync(home, { recursive: true });
   mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9403: mirror XDG layout under CLEO_HOME for getCleoHome().
+  process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;
   return { xdgRoot, home, projectRoot };
 }

--- a/packages/core/src/llm/credentials-store.ts
+++ b/packages/core/src/llm/credentials-store.ts
@@ -2,7 +2,7 @@
  * Multi-credential pool storage for the CLEO LLM layer (T-LLM-CRED Phase 2).
  *
  * Persists a versioned list of provider credentials at
- * `~/.cleo/llm-credentials.json` (XDG-aware, resolved via `cleoHomeDir()` so
+ * `~/.cleo/llm-credentials.json` (XDG-aware, resolved via `getCleoHome()` so
  * the test-only `XDG_DATA_HOME` override applies identically to every CLEO
  * global file).
  *
@@ -37,15 +37,16 @@
 
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { getLogger } from '../logger.js';
-// `withLock` already calls `writeJsonFileAtomic` under the hood — we
-// piggy-back on it for atomic writes + numbered backups.
-import { withLock } from '../store/file-utils.js';
 // Note: `credentials.ts` already depends on `credentials-store.ts`
 // (`pickCredentialForProviderSync`). The reverse arrow here closes a
 // cycle, but every imported symbol is a function reference read at
 // call-time — ESM's late binding makes the cycle safe.
-import { clearAnthropicKeyCache, cleoHomeDir } from './credentials.js';
+import { getCleoHome } from '@cleocode/paths';
+import { getLogger } from '../logger.js';
+// `withLock` already calls `writeJsonFileAtomic` under the hood — we
+// piggy-back on it for atomic writes + numbered backups.
+import { withLock } from '../store/file-utils.js';
+import { clearAnthropicKeyCache } from './credentials.js';
 import type { ModelTransport } from './types-config.js';
 
 const logger = getLogger('llm-credentials-store');
@@ -207,13 +208,13 @@ export interface CredentialsStoreData {
 /**
  * Absolute path of the credential store file.
  *
- * Resolved through `cleoHomeDir()` so XDG overrides apply uniformly with
+ * Resolved through `getCleoHome()` so XDG overrides apply uniformly with
  * `credentials.ts`'s global-config tier.
  *
  * @task T9257
  */
 export function credentialsStorePath(): string {
-  return join(cleoHomeDir(), 'llm-credentials.json');
+  return join(getCleoHome(), 'llm-credentials.json');
 }
 
 /**

--- a/packages/core/src/llm/credentials.ts
+++ b/packages/core/src/llm/credentials.ts
@@ -29,6 +29,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { parseClaudeCodeCredentials } from '@cleocode/contracts';
+import { getCleoHome } from '@cleocode/paths';
 import { pickCredentialForProviderSync } from './credentials-store.js';
 import type { ModelTransport } from './types-config.js';
 
@@ -142,29 +143,14 @@ const ENV_VARS: Record<ModelTransport, string> = {
 };
 
 // ---------------------------------------------------------------------------
-// Path helpers (mirrors anthropic-key-resolver.ts logic, now centralised)
+// Path helpers — all CLEO-home resolution routes through `getCleoHome()` from
+// `@cleocode/paths` so the `CLEO_HOME` env override and platform-aware XDG
+// resolution apply uniformly across the LLM layer (T9403).
 // ---------------------------------------------------------------------------
-
-/**
- * XDG-aware global CLEO data directory.
- *
- * Resolution: `$XDG_DATA_HOME/cleo` when set, else `~/.local/share/cleo`.
- *
- * Exported so sibling modules (notably `credentials-store.ts`) can resolve
- * `~/.cleo/llm-credentials.json` against the SAME XDG-aware home that every
- * other CLEO global file uses — including this module's tier 4/4b lookups.
- *
- * @task T-LLM-CRED-CENTRALIZATION Phase 2
- * @task T9257
- */
-export function cleoHomeDir(): string {
-  const xdg = process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share');
-  return join(xdg, 'cleo');
-}
 
 /** Path to the global CLEO config file. */
 function globalConfigPath(): string {
-  return join(cleoHomeDir(), 'config.json');
+  return join(getCleoHome(), 'config.json');
 }
 
 /** Path to the project-level CLEO config file. */
@@ -207,7 +193,7 @@ function readClaudeCredsToken(): string | null {
  */
 function readFlatAnthropicKey(): string | null {
   try {
-    const keyFile = join(cleoHomeDir(), 'anthropic-key');
+    const keyFile = join(getCleoHome(), 'anthropic-key');
     if (!existsSync(keyFile)) return null;
     const stored = readFileSync(keyFile, 'utf-8').trim();
     return stored || null;
@@ -480,7 +466,7 @@ export const OAUTH_STATUS_PROVIDERS: readonly ModelTransport[] = [
  * @param apiKey - The API key to store.
  */
 export function storeAnthropicApiKey(apiKey: string): void {
-  const dir = cleoHomeDir();
+  const dir = getCleoHome();
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -91,10 +91,11 @@ export type {
   CredentialSource,
 } from './credentials.js';
 // Credential resolver (T1677 + T-LLM-CRED-CENTRALIZATION Phase 1)
+// T9403: `cleoHomeDir` removed — callers MUST use `getCleoHome` from
+// `@cleocode/paths` directly so the `CLEO_HOME` env override applies.
 export {
   authHeaders,
   clearAnthropicKeyCache,
-  cleoHomeDir,
   defaultTransportApiKey,
   OAUTH_STATUS_PROVIDERS,
   resolveCredentials,

--- a/packages/core/src/llm/rate-limit-guard.ts
+++ b/packages/core/src/llm/rate-limit-guard.ts
@@ -11,7 +11,7 @@
  * before subsequent attempts, we eliminate retry amplification across sessions.
  *
  * State is keyed on `(provider, label)` and stored at:
- *   `${cleoHomeDir()}/rate-limit-state/<provider>-<label>.json`
+ *   `${getCleoHome()}/rate-limit-state/<provider>-<label>.json`
  *
  * @module llm/rate-limit-guard
  * @task T9273
@@ -20,8 +20,8 @@
 
 import { existsSync, mkdirSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
+import { getCleoHome } from '@cleocode/paths';
 import { readJsonFile, withFileLock, writeJsonFileAtomic } from '../store/file-utils.js';
-import { cleoHomeDir } from './credentials.js';
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -71,7 +71,7 @@ function sanitize(value: string): string {
  * @task T9273
  */
 export function rateLimitStatePath(provider: string, label: string): string {
-  const dir = join(cleoHomeDir(), 'rate-limit-state');
+  const dir = join(getCleoHome(), 'rate-limit-state');
   return join(dir, `${sanitize(provider)}-${sanitize(label)}.json`);
 }
 
@@ -137,7 +137,7 @@ function parseResetFromHeaders(headers: Headers | Record<string, string>): numbe
  *
  * Parses the reset time from HTTP response headers when available, then
  * falls back to `defaultCooldownSeconds` (default 300 s).  Writes state to
- * `${cleoHomeDir()}/rate-limit-state/<provider>-<label>.json` so that ALL
+ * `${getCleoHome()}/rate-limit-state/<provider>-<label>.json` so that ALL
  * CLEO processes (sentient daemon, CLI calls, auxiliary router) see the same
  * cooldown — preventing pile-on retries from independent sessions.
  *
@@ -181,7 +181,7 @@ export async function recordRateLimit(
   }
 
   const filePath = rateLimitStatePath(provider, label);
-  const dir = join(cleoHomeDir(), 'rate-limit-state');
+  const dir = join(getCleoHome(), 'rate-limit-state');
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
@@ -259,7 +259,7 @@ export async function clearRateLimit(provider: string, label: string): Promise<v
  * @task T9273
  */
 export function ensureRateLimitStateDir(): string {
-  const dir = join(cleoHomeDir(), 'rate-limit-state');
+  const dir = join(getCleoHome(), 'rate-limit-state');
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }

--- a/packages/core/src/llm/stable-device-id.ts
+++ b/packages/core/src/llm/stable-device-id.ts
@@ -7,7 +7,7 @@
  * trigger device re-registration prompts upstream.
  *
  * Storage: `${CLEO_HOME}/device-id` — single-line UUIDv4, no metadata. Path
- * resolves through `cleoHomeDir()` so it follows XDG conventions on Linux
+ * resolves through `getCleoHome()` so it follows XDG conventions on Linux
  * and stays inside the CLEO home on Windows/macOS.
  *
  * @module llm/stable-device-id
@@ -19,9 +19,9 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
-import { cleoHomeDir } from './credentials.js';
+import { getCleoHome } from '@cleocode/paths';
 
-/** Filename within `cleoHomeDir()` storing the persisted UUID. */
+/** Filename within `getCleoHome()` storing the persisted UUID. */
 const DEVICE_ID_FILE = 'device-id';
 
 /** Process-lifetime cache so repeat callers do not re-read the disk. */
@@ -44,7 +44,7 @@ let _cachedDeviceId: string | null = null;
 export function getStableDeviceId(): string {
   if (_cachedDeviceId !== null) return _cachedDeviceId;
 
-  const path = join(cleoHomeDir(), DEVICE_ID_FILE);
+  const path = join(getCleoHome(), DEVICE_ID_FILE);
 
   if (existsSync(path)) {
     try {
@@ -75,7 +75,7 @@ export function getStableDeviceId(): string {
   } catch {
     // If we cannot persist, still return the UUID for THIS process. The
     // next process will regenerate. Callers that need true cross-process
-    // stability MUST surface a writable cleoHomeDir at install time.
+    // stability MUST surface a writable getCleoHome at install time.
   }
 
   _cachedDeviceId = fresh;

--- a/packages/core/src/memory/__tests__/anthropic-key-resolver-source.test.ts
+++ b/packages/core/src/memory/__tests__/anthropic-key-resolver-source.test.ts
@@ -20,6 +20,7 @@ import { clearAnthropicKeyCache, resolveCredentials } from '../../llm/credential
 
 const ORIG_ENV_KEY = process.env.ANTHROPIC_API_KEY;
 const ORIG_XDG = process.env.XDG_DATA_HOME;
+const ORIG_CLEO_HOME = process.env.CLEO_HOME;
 
 function setEnvKey(value: string | undefined): void {
   if (value === undefined) {
@@ -30,6 +31,7 @@ function setEnvKey(value: string | undefined): void {
 }
 
 function setXdgHome(value: string): void {
+  delete process.env['CLEO_HOME'];
   process.env['XDG_DATA_HOME'] = value;
 }
 
@@ -62,6 +64,11 @@ afterEach(() => {
     process.env['XDG_DATA_HOME'] = ORIG_XDG;
   } else {
     delete process.env['XDG_DATA_HOME'];
+  }
+  if (ORIG_CLEO_HOME !== undefined) {
+    process.env['CLEO_HOME'] = ORIG_CLEO_HOME;
+  } else {
+    delete process.env['CLEO_HOME'];
   }
   clearAnthropicKeyCache();
 });


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E1 substrate. Removes the parallel `cleoHomeDir()` helper from `packages/core/src/llm/credentials.ts` and routes all four LLM-credential modules through the canonical `getCleoHome()` resolver in `@cleocode/paths`. CLEO_HOME env override now works correctly.

**Bundles T9403 + T9404**: Removing the function definition without updating the three sibling importers (`credentials-store.ts`, `stable-device-id.ts`, `rate-limit-guard.ts`) would have left the build in a broken intermediate state. Per the plan doc §5.1 these are independent modules, so absorbing the trivial import swaps into a single atomic change is safer than landing an unbuildable T9403 first.

## Changes
- `packages/core/src/llm/credentials.ts` — removed `cleoHomeDir()`, swapped 4 call-sites to `getCleoHome()`
- `packages/core/src/llm/credentials-store.ts` — swapped import + call
- `packages/core/src/llm/stable-device-id.ts` — swapped import + call + doc comments
- `packages/core/src/llm/rate-limit-guard.ts` — swapped import + 3 call-sites + doc comments
- `packages/core/src/llm/index.ts` + `internal.ts` — removed `cleoHomeDir` from public surface
- 8 credential test files — added `CLEO_HOME` to ENV_KEYS save/restore for sandbox isolation

## Test plan
- [x] `pnpm --filter @cleocode/core run test` — 136/136 LLM credential tests pass in 2.19s
- [x] `pnpm --filter @cleocode/core run build` — clean
- [x] `pnpm biome check` — clean
- [x] Manual smoke: `CLEO_HOME=/tmp/cleo-smoke-T9403` resolves `getCleoHome()` correctly
- [x] `grep -rn cleoHomeDir packages/core/src/llm/` returns 0 hits

## Refs
- `docs/plans/E-CONFIG-AUTH-UNIFY.md` §5.1 T-E1-1 + T-E1-2
- Epic: T9399 (E-CONFIG-AUTH-UNIFY E1)
- Master: T9500