### PR TITLE
release: ship v2026.5.77 (T9518 Saga foundation / ADR-073)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [2026.5.77] (2026-05-17)
+
+### Features — Saga foundation (T9518 / ADR-073)
+
+- **Saga — above-Epic grouping tier** — New canonical tier above Epic for grouping multiple Epics into a multi-release theme. Saga is a **labeled role** on a top-level Epic (`label='saga'`), NOT a new `TaskType`. Member Epics link via `task_relations.relation_type='groups'`. Council-validated (`.cleo/council-runs/20260517T002448Z-e4223249/`) — winning name over `Initiative` (rejected: too generic, weak prefix) and `Arc` (rejected: `AR-` collides with `ADR-` in fuzzy CLI search).
+- **`cleo saga` CLI suite** — 5 subcommands: `create`, `add`, `list`, `members`, `rollup`. Thin wrappers over existing `tasks.add` + `tasks.relates.add` + queries. Operations registered as `tasks.saga.{create,add,list,members,rollup}` (T9521).
+- **`groups` relation type** — 8th value in `TASK_RELATION_TYPES` tuple; forward-only drizzle migration extends the `task_relations.relation_type` CHECK constraint. Reuses the canonical SQLite table-rebuild pattern (T9519).
+- **Prefix registry** — `SG-` reserved for Saga, `SD-` reserved for SignalDock (ADR-073). Closes Council's strongest identified risk (Contrarian finding: latent `SG-` ↔ SignalDock namespace collision).
+
+### Bug Fixes
+
+- **fix(T9514)**: `cleo update --relates` / `--add-relates` now persists writes to `task_relations` (previously a no-op — mutation envelope returned populated relates but rows never reached DB). Root cause: `upsertSingleTask` wrote to `tasks` row + `task_dependencies` only; relates writes were missing from the transaction callback. Adds `addRelation`/`removeRelation`/`clearRelations` to `TransactionAccessor` interface. 4 new integration regression tests (real SQLite).
+- **fix(T9521)**: Replace invalid `as Record<string, unknown>` casts in saga handlers with typed narrowing (caught by CI Type Check post-rebase).
+
+### Test additions
+
+- **T9522** — End-to-end saga lifecycle integration test (8-step flow: create saga → add 2 epic members → list members → rollup → mark done → re-rollup). 4 tests, ~45 assertions. Uses direct dispatch via `TasksHandler` (no CLI shelling) for cleaner integration testing. Collateral fix: added `@cleocode/worktree` alias to `packages/cleo/vitest.config.ts` (was preventing `docs-integration.test.ts` from running).
+
+### Documentation
+
+- **ADR-073** — Above-Epic naming decision. Records the Council verdict, name/prefix/storage/wire-mechanism, prefix registry (`SG-` + `SD-`), Saga-is-a-role-not-TaskType clause, T9514 gating dependency, alternatives considered (T9520).
+- **AGENTS.md** — New "Task Hierarchy Canon" section with the four-tier hierarchy table (Subtask / Task / Epic / Saga) and the prefix registry.
+- **CLEO-INJECTION.md** (`packages/core/templates/`) — Saga subsection under Task Creation with the 3 canonical commands.
+
+### Tasks shipped under T9518 (epic)
+
+T9514 (relates writer fix — gating dep), T9519 (`groups` type + migration), T9520 (ADR-073 + canon docs), T9521 (`cleo saga` CLI suite), T9522 (lifecycle integration test).
+
+---
+
 ## [2026.5.76] (2026-05-17)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "conduit-core",
  "nom",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "cant-core",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "serde",
  "serde_json",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "cant-core",
  "serde",
@@ -394,7 +394,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-llm-native"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "lafs-core",
  "serde",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-core"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "chrono",
  "conduit-core",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-payments"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-protocol"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "cant-core",
  "chrono",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-sdk"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-storage"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-transport"
-version = "2026.5.75"
+version = "2026.5.77"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.76"
+version = "2026.5.77"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.76",
+  "version": "2026.5.77",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Ship **v2026.5.77** — Saga foundation epic (T9518) end-to-end.

Implements ADR-073 "Above-Epic naming" decision: Saga is a new canonical tier above Epic, stored as a labeled top-level Epic linked via a new `task_relations.type='groups'` relation. Council-validated naming (Saga > Initiative > Arc) at `.cleo/council-runs/20260517T002448Z-e4223249/`.

## Tasks shipped under T9518

| PR | Task | Scope |
|---|---|---|
| #186 | T9520 | ADR-073 + AGENTS.md + CLEO-INJECTION.md canon update |
| #187 | T9519 | `'groups'` relation type + drizzle migration |
| #188 | T9514 | `cleo update --relates` writer fix (gating dep) |
| #189 | T9521 | `cleo saga` CLI suite (create/add/list/members/rollup) |
| #194 | T9522 | end-to-end saga lifecycle integration test |

## Test plan

- [x] All 5 child PRs CI-green on merge
- [x] Per-package CalVer bump across 21 npm packages + Rust workspace (9 crates)
- [x] CHANGELOG.md v2026.5.77 entry references all 5 tasks + ADR-073
- [x] Council verdict referenced in commit body