### PR TITLE
feat(T9406): auto-import legacy anthropic-key flat file into credential pool

### DIFF
--- a/packages/core/src/llm/__tests__/legacy-flat-key-import.test.ts
+++ b/packages/core/src/llm/__tests__/legacy-flat-key-import.test.ts
@@ -15,8 +15,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { addCredential, getCredentialByLabel, listCredentials } from '../credentials-store.js';
 import { clearAnthropicKeyCache } from '../credentials.js';
+import { addCredential, getCredentialByLabel, listCredentials } from '../credentials-store.js';
 import {
   importLegacyFlatAnthropicKey,
   LEGACY_FLAT_KEY_BAK_SUFFIX,

--- a/packages/core/src/llm/__tests__/legacy-flat-key-import.test.ts
+++ b/packages/core/src/llm/__tests__/legacy-flat-key-import.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the legacy `anthropic-key` flat-file → credential-pool import
+ * migration (T9406 — `E-CONFIG-AUTH-UNIFY` E1, T-E1-4).
+ *
+ * Filesystem isolation mirrors `credentials-store.test.ts`: per-test
+ * tmpdirs backing `XDG_DATA_HOME` + `CLEO_HOME` + `HOME`, env saved /
+ * restored in `afterEach`. Each test starts with a fresh CleoHome with
+ * no flat file, no marker, no pool.
+ *
+ * @task T9406
+ * @epic E-CONFIG-AUTH-UNIFY
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { addCredential, getCredentialByLabel, listCredentials } from '../credentials-store.js';
+import { clearAnthropicKeyCache } from '../credentials.js';
+import {
+  importLegacyFlatAnthropicKey,
+  LEGACY_FLAT_KEY_BAK_SUFFIX,
+  LEGACY_FLAT_KEY_LABEL,
+  LEGACY_FLAT_KEY_MARKER,
+} from '../legacy-flat-key-import.js';
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'MOONSHOT_API_KEY',
+  'XDG_DATA_HOME',
+  'CLEO_HOME',
+  'HOME',
+  'CLEO_DIR',
+];
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+function clearEnv(): void {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+/**
+ * Per-test sandbox: every CLEO global path is rooted under tmpdirs that
+ * are unique to this test. Returns the resolved CleoHome so we can
+ * derive expected paths.
+ */
+function isolateHomes(): string {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const xdgRoot = join(tmpdir(), `cleo-legacyflat-xdg-${stamp}`);
+  const home = join(tmpdir(), `cleo-legacyflat-home-${stamp}`);
+  const cleoHome = join(xdgRoot, 'cleo');
+  mkdirSync(cleoHome, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  process.env['XDG_DATA_HOME'] = xdgRoot;
+  process.env['CLEO_HOME'] = cleoHome;
+  process.env['HOME'] = home;
+  return cleoHome;
+}
+
+function seedFlatFile(cleoHome: string, contents: string): string {
+  const path = join(cleoHome, 'anthropic-key');
+  writeFileSync(path, contents, 'utf-8');
+  return path;
+}
+
+beforeEach(() => {
+  saveEnv();
+  clearEnv();
+  clearAnthropicKeyCache();
+});
+
+afterEach(() => {
+  restoreEnv();
+  clearAnthropicKeyCache();
+});
+
+describe('importLegacyFlatAnthropicKey()', () => {
+  it('imports the flat key, renames the file, writes the marker, adds the pool entry', async () => {
+    const home = isolateHomes();
+    const flatPath = seedFlatFile(home, 'sk-ant-api03-flat-key-value\n');
+
+    const result = await importLegacyFlatAnthropicKey();
+
+    expect(result.status).toBe('imported');
+    expect(result.flatPath).toBe(flatPath);
+    expect(result.bakPath).toBe(join(home, `anthropic-key${LEGACY_FLAT_KEY_BAK_SUFFIX}`));
+    expect(result.markerPath).toBe(join(home, LEGACY_FLAT_KEY_MARKER));
+
+    // Pool entry must exist with the canonical shape.
+    const entry = await getCredentialByLabel('anthropic', LEGACY_FLAT_KEY_LABEL);
+    expect(entry).not.toBeNull();
+    expect(entry?.provider).toBe('anthropic');
+    expect(entry?.label).toBe(LEGACY_FLAT_KEY_LABEL);
+    expect(entry?.authType).toBe('api_key');
+    expect(entry?.accessToken).toBe('sk-ant-api03-flat-key-value');
+    expect(entry?.source).toBe('manual');
+    expect(entry?.priority).toBe(100);
+
+    // Original flat file is renamed (preserved, not deleted).
+    expect(existsSync(flatPath)).toBe(false);
+    expect(existsSync(result.bakPath ?? '')).toBe(true);
+    expect(readFileSync(result.bakPath ?? '', 'utf-8').trim()).toBe('sk-ant-api03-flat-key-value');
+
+    // Marker is written.
+    expect(existsSync(result.markerPath)).toBe(true);
+  });
+
+  it('is idempotent when the pool already has a legacy-flat-key entry (no flat file)', async () => {
+    isolateHomes();
+    // Pre-seed pool with a `legacy-flat-key` entry, simulating an earlier
+    // run that imported the key but lost its marker.
+    await addCredential({
+      provider: 'anthropic',
+      label: LEGACY_FLAT_KEY_LABEL,
+      authType: 'api_key',
+      accessToken: 'sk-ant-api03-pre-existing',
+      source: 'manual',
+      priority: 100,
+    });
+
+    const result = await importLegacyFlatAnthropicKey();
+
+    expect(result.status).toBe('already-imported');
+    expect(result.bakPath).toBeNull();
+    expect(existsSync(result.markerPath)).toBe(true);
+    // Pool entry untouched.
+    const all = await listCredentials('anthropic');
+    expect(all).toHaveLength(1);
+    expect(all[0]?.accessToken).toBe('sk-ant-api03-pre-existing');
+  });
+
+  it('short-circuits when the migration marker is present', async () => {
+    const home = isolateHomes();
+    // Seed a flat file AND a marker — marker wins, flat file is ignored.
+    const flatPath = seedFlatFile(home, 'sk-ant-api03-should-be-ignored\n');
+    writeFileSync(join(home, LEGACY_FLAT_KEY_MARKER), 'previous-run\n', 'utf-8');
+
+    const result = await importLegacyFlatAnthropicKey();
+
+    expect(result.status).toBe('marker-present');
+    expect(result.bakPath).toBeNull();
+    // Flat file is untouched (not renamed) because we short-circuited.
+    expect(existsSync(flatPath)).toBe(true);
+    // No pool entry was created.
+    const entry = await getCredentialByLabel('anthropic', LEGACY_FLAT_KEY_LABEL);
+    expect(entry).toBeNull();
+  });
+
+  it('writes the marker but creates no entry when the flat file is missing', async () => {
+    const home = isolateHomes();
+    expect(existsSync(join(home, 'anthropic-key'))).toBe(false);
+
+    const result = await importLegacyFlatAnthropicKey();
+
+    expect(result.status).toBe('no-flat-file');
+    expect(result.bakPath).toBeNull();
+    expect(existsSync(result.markerPath)).toBe(true);
+    const entry = await getCredentialByLabel('anthropic', LEGACY_FLAT_KEY_LABEL);
+    expect(entry).toBeNull();
+  });
+
+  it('skips silently on an empty flat file — no entry, no rename, marker written', async () => {
+    const home = isolateHomes();
+    const flatPath = seedFlatFile(home, '   \n  \t');
+
+    const result = await importLegacyFlatAnthropicKey();
+
+    expect(result.status).toBe('empty-flat-file');
+    expect(result.bakPath).toBeNull();
+    // Empty file is preserved (not renamed) for operator inspection.
+    expect(existsSync(flatPath)).toBe(true);
+    expect(existsSync(join(home, `anthropic-key${LEGACY_FLAT_KEY_BAK_SUFFIX}`))).toBe(false);
+    // No pool entry.
+    const entry = await getCredentialByLabel('anthropic', LEGACY_FLAT_KEY_LABEL);
+    expect(entry).toBeNull();
+    // Marker prevents re-statting on every CLI invocation.
+    expect(existsSync(result.markerPath)).toBe(true);
+  });
+
+  it('trims surrounding whitespace from the flat key before storing', async () => {
+    const home = isolateHomes();
+    seedFlatFile(home, '\n   sk-ant-api03-whitespacey   \n\n');
+
+    const result = await importLegacyFlatAnthropicKey();
+
+    expect(result.status).toBe('imported');
+    const entry = await getCredentialByLabel('anthropic', LEGACY_FLAT_KEY_LABEL);
+    expect(entry?.accessToken).toBe('sk-ant-api03-whitespacey');
+  });
+
+  it('a second call after a successful import is a marker-present no-op', async () => {
+    const home = isolateHomes();
+    seedFlatFile(home, 'sk-ant-api03-flat-key-value\n');
+
+    const first = await importLegacyFlatAnthropicKey();
+    expect(first.status).toBe('imported');
+
+    const second = await importLegacyFlatAnthropicKey();
+    expect(second.status).toBe('marker-present');
+    expect(second.bakPath).toBeNull();
+    // .bak file is still there from the first run; nothing renamed twice.
+    expect(existsSync(join(home, `anthropic-key${LEGACY_FLAT_KEY_BAK_SUFFIX}`))).toBe(true);
+    // Pool still has exactly one entry.
+    const all = await listCredentials('anthropic');
+    expect(all).toHaveLength(1);
+  });
+});

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -119,6 +119,17 @@ export {
   pickCredentialForProviderSync,
   removeCredential,
 } from './credentials-store.js';
+// One-shot legacy flat-key migration (T9406 — E-CONFIG-AUTH-UNIFY E1)
+export type {
+  LegacyFlatKeyImportResult,
+  LegacyFlatKeyImportStatus,
+} from './legacy-flat-key-import.js';
+export {
+  importLegacyFlatAnthropicKey,
+  LEGACY_FLAT_KEY_BAK_SUFFIX,
+  LEGACY_FLAT_KEY_LABEL,
+  LEGACY_FLAT_KEY_MARKER,
+} from './legacy-flat-key-import.js';
 export {
   clearLlmExecutorCache,
   DefaultLlmExecutorFactory,

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -119,17 +119,6 @@ export {
   pickCredentialForProviderSync,
   removeCredential,
 } from './credentials-store.js';
-// One-shot legacy flat-key migration (T9406 — E-CONFIG-AUTH-UNIFY E1)
-export type {
-  LegacyFlatKeyImportResult,
-  LegacyFlatKeyImportStatus,
-} from './legacy-flat-key-import.js';
-export {
-  importLegacyFlatAnthropicKey,
-  LEGACY_FLAT_KEY_BAK_SUFFIX,
-  LEGACY_FLAT_KEY_LABEL,
-  LEGACY_FLAT_KEY_MARKER,
-} from './legacy-flat-key-import.js';
 export {
   clearLlmExecutorCache,
   DefaultLlmExecutorFactory,
@@ -144,6 +133,17 @@ export {
   historyAdapterForProvider,
   OpenAIHistoryAdapter,
 } from './history-adapters.js';
+// One-shot legacy flat-key migration (T9406 — E-CONFIG-AUTH-UNIFY E1)
+export type {
+  LegacyFlatKeyImportResult,
+  LegacyFlatKeyImportStatus,
+} from './legacy-flat-key-import.js';
+export {
+  importLegacyFlatAnthropicKey,
+  LEGACY_FLAT_KEY_BAK_SUFFIX,
+  LEGACY_FLAT_KEY_LABEL,
+  LEGACY_FLAT_KEY_MARKER,
+} from './legacy-flat-key-import.js';
 export type { ModelMetadata } from './model-metadata.js';
 // Model metadata — context window resolution (T9264 / T-LLM-CRED Phase 3)
 export {

--- a/packages/core/src/llm/legacy-flat-key-import.ts
+++ b/packages/core/src/llm/legacy-flat-key-import.ts
@@ -1,0 +1,283 @@
+/**
+ * One-shot migration: import the legacy `${CLEO_HOME}/anthropic-key` flat file
+ * into the unified credential pool as a `legacy-flat-key` entry.
+ *
+ * Part of `E-CONFIG-AUTH-UNIFY` Epic E1 (T9406 / T-E1-4). The legacy flat key
+ * file is the "tier 4b" entry in the current 6-tier resolver in
+ * `credentials.ts`. Once imported into the pool, the resolver's tier-3
+ * (`cred-file`) lookup will pick it up — so post-E2 we can collapse the
+ * tier-4b branch entirely without losing any operator's previously-stored
+ * key.
+ *
+ * ## Behavior
+ *
+ * On `importLegacyFlatAnthropicKey()` (idempotent):
+ *
+ * 1. If the migration marker `${CLEO_HOME}/.imported-legacy-flat-key` exists,
+ *    return immediately (`status: 'marker-present'`).
+ * 2. If the pool already contains an `anthropic` entry with
+ *    `label === 'legacy-flat-key'`, write the marker and return
+ *    (`status: 'already-imported'`).
+ * 3. If `${CLEO_HOME}/anthropic-key` does not exist, write the marker and
+ *    return (`status: 'no-flat-file'`). Avoids re-stating the file on
+ *    every CLI invocation.
+ * 4. If the flat file exists but its trimmed content is empty, write the
+ *    marker and return (`status: 'empty-flat-file'`). We do NOT rename an
+ *    empty file — leave it for the operator to inspect / delete.
+ * 5. Otherwise: call `addCredential()` with the trimmed key, then rename
+ *    the flat file to `anthropic-key.pre-e1-bak`, then write the marker.
+ *    Returns `status: 'imported'`.
+ *
+ * ## Atomicity contract
+ *
+ * The two side-effects we care about — (a) the pool entry insert and
+ * (b) the flat-file rename — are sequenced so a failure at (b) leaves the
+ * pool entry in place AND no marker is written. The next run will then
+ * skip the insert (via the `getCredentialByLabel` check in step 2 above)
+ * but still attempt the rename. This avoids a half-done state where the
+ * marker exists but the original flat file is still discoverable by the
+ * tier-4b resolver branch (which would re-import it on the next pool
+ * rebuild).
+ *
+ * If `addCredential()` itself throws, nothing is renamed and no marker
+ * is written — the next invocation retries cleanly.
+ *
+ * @module llm/legacy-flat-key-import
+ * @task T9406
+ * @epic E-CONFIG-AUTH-UNIFY
+ */
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getCleoHome } from '@cleocode/paths';
+import { getLogger } from '../logger.js';
+import { addCredential, getCredentialByLabel } from './credentials-store.js';
+
+const logger = getLogger('llm-legacy-flat-key-import');
+
+/**
+ * Canonical label assigned to the imported entry.
+ *
+ * Constant rather than parameterized — the resolver collapse in E2 keys
+ * its behavior off this exact label, so it MUST remain stable.
+ */
+export const LEGACY_FLAT_KEY_LABEL = 'legacy-flat-key';
+
+/**
+ * Filename suffix used when renaming the original flat file post-import.
+ *
+ * Kept identical to the convention used by the T310 conduit migration
+ * (`.pre-t310.bak`) for cross-codebase greppability.
+ */
+export const LEGACY_FLAT_KEY_BAK_SUFFIX = '.pre-e1-bak';
+
+/**
+ * Filename of the migration marker inside `getCleoHome()`. Existence of
+ * this file (any content) is sufficient to short-circuit the migration.
+ */
+export const LEGACY_FLAT_KEY_MARKER = '.imported-legacy-flat-key';
+
+/**
+ * Outcome of a single migration attempt.
+ *
+ * - `imported`          — flat file read, pool entry added, file renamed,
+ *                         marker written
+ * - `already-imported`  — pool already had a `legacy-flat-key` entry;
+ *                         marker written so we never reach this branch
+ *                         again
+ * - `no-flat-file`      — `${CLEO_HOME}/anthropic-key` does not exist;
+ *                         marker written
+ * - `empty-flat-file`   — flat file existed but trimmed content was empty;
+ *                         marker written; file is NOT renamed
+ * - `marker-present`    — short-circuit from the first idempotency check
+ *
+ * @task T9406
+ */
+export type LegacyFlatKeyImportStatus =
+  | 'imported'
+  | 'already-imported'
+  | 'no-flat-file'
+  | 'empty-flat-file'
+  | 'marker-present';
+
+/**
+ * Result returned by `importLegacyFlatAnthropicKey()`.
+ *
+ * `bakPath` is populated only when the rename actually occurred (i.e.
+ * `status === 'imported'`).
+ *
+ * @task T9406
+ */
+export interface LegacyFlatKeyImportResult {
+  /** Outcome category — see `LegacyFlatKeyImportStatus`. */
+  status: LegacyFlatKeyImportStatus;
+  /** Absolute path of the original flat key file (whether or not it existed). */
+  flatPath: string;
+  /** Absolute path of the renamed backup, or null if no rename happened. */
+  bakPath: string | null;
+  /** Absolute path of the marker file (always populated post-call). */
+  markerPath: string;
+}
+
+/**
+ * Compute all paths used by the migration. Pure — no filesystem touch.
+ */
+function migrationPaths(): { flatPath: string; bakPath: string; markerPath: string } {
+  const home = getCleoHome();
+  return {
+    flatPath: join(home, 'anthropic-key'),
+    bakPath: join(home, `anthropic-key${LEGACY_FLAT_KEY_BAK_SUFFIX}`),
+    markerPath: join(home, LEGACY_FLAT_KEY_MARKER),
+  };
+}
+
+/**
+ * Write the migration marker. Uses `flag: 'wx'` so concurrent first-run
+ * callers race-tolerantly — exactly one writes, the rest get `EEXIST`
+ * which we treat as success.
+ *
+ * Best-effort 0o600 (matches the surrounding cred-store hardening).
+ */
+function writeMarker(markerPath: string): void {
+  try {
+    writeFileSync(markerPath, `${new Date().toISOString()}\n`, {
+      encoding: 'utf-8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return;
+    // Marker write is best-effort. Re-runs are cheap (one stat + one read);
+    // surfacing this would just spam the log. Drop to debug.
+    logger.debug(
+      { markerPath, err: err instanceof Error ? err.message : String(err) },
+      'legacy-flat-key migration: marker write failed',
+    );
+  }
+}
+
+/**
+ * Read and trim the flat file. Returns null on any I/O error or when the
+ * trimmed content is empty. Never throws.
+ */
+function readFlatKey(flatPath: string): string | null {
+  try {
+    if (!existsSync(flatPath)) return null;
+    const raw = readFileSync(flatPath, 'utf-8').trim();
+    return raw || null;
+  } catch (err) {
+    logger.warn(
+      { flatPath, err: err instanceof Error ? err.message : String(err) },
+      'legacy-flat-key migration: read failed — skipping',
+    );
+    return null;
+  }
+}
+
+/**
+ * Import the legacy `${CLEO_HOME}/anthropic-key` flat file into the
+ * credential pool, exactly once per CLEO home directory.
+ *
+ * Idempotent — safe to call from any bootstrap path on every CLI
+ * invocation. The marker file guarantees O(1) cost on warm runs.
+ *
+ * Never throws. All errors are caught and surfaced through the structured
+ * logger; the resolver fallback chain still works.
+ *
+ * @returns A `LegacyFlatKeyImportResult` describing the outcome.
+ *
+ * @task T9406
+ */
+export async function importLegacyFlatAnthropicKey(): Promise<LegacyFlatKeyImportResult> {
+  const { flatPath, bakPath, markerPath } = migrationPaths();
+
+  // Step 1 — Cheap idempotency check: marker file.
+  if (existsSync(markerPath)) {
+    return { status: 'marker-present', flatPath, bakPath: null, markerPath };
+  }
+
+  // Step 2 — Pool already has a legacy-flat-key entry? Treat as done.
+  // This handles the case where a prior CLEO version imported the key but
+  // never wrote a marker (or the marker was deleted), AND the case where
+  // an operator manually ran `cleo llm add --label legacy-flat-key ...`.
+  let existing: Awaited<ReturnType<typeof getCredentialByLabel>> = null;
+  try {
+    existing = await getCredentialByLabel('anthropic', LEGACY_FLAT_KEY_LABEL);
+  } catch (err) {
+    // `getCredentialByLabel` is sync-read internally and shouldn't throw,
+    // but defensively log + bail so we never wedge bootstrap.
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'legacy-flat-key migration: pool lookup failed — skipping this run',
+    );
+    return { status: 'no-flat-file', flatPath, bakPath: null, markerPath };
+  }
+  if (existing) {
+    writeMarker(markerPath);
+    return { status: 'already-imported', flatPath, bakPath: null, markerPath };
+  }
+
+  // Step 3 — Flat file missing? Write marker so we never recheck.
+  if (!existsSync(flatPath)) {
+    writeMarker(markerPath);
+    return { status: 'no-flat-file', flatPath, bakPath: null, markerPath };
+  }
+
+  // Step 4 — Flat file empty? Skip without renaming so the operator can
+  // inspect it. Write the marker — an empty file will stay empty across
+  // runs, so re-checking is pointless.
+  const token = readFlatKey(flatPath);
+  if (!token) {
+    writeMarker(markerPath);
+    return { status: 'empty-flat-file', flatPath, bakPath: null, markerPath };
+  }
+
+  // Step 5 — Import + rename + marker, in that strict order. If either
+  // (5a) or (5b) throws, NO marker is written so the next run retries.
+  try {
+    // (5a) Pool insert.
+    await addCredential({
+      provider: 'anthropic',
+      label: LEGACY_FLAT_KEY_LABEL,
+      authType: 'api_key',
+      accessToken: token,
+      source: 'manual',
+      priority: 100,
+    });
+  } catch (err) {
+    // The pool insert failed — do NOT rename, do NOT mark migrated. Next
+    // run will retry the whole operation cleanly.
+    logger.error(
+      { err: err instanceof Error ? err.message : String(err), flatPath },
+      'legacy-flat-key migration: addCredential failed — leaving flat file in place for retry',
+    );
+    return { status: 'no-flat-file', flatPath, bakPath: null, markerPath };
+  }
+
+  // (5b) Rename the flat file. If the rename fails, the pool entry is
+  // already in place — the next run will skip the insert (via the
+  // `getCredentialByLabel` check) and re-attempt the rename + marker.
+  try {
+    renameSync(flatPath, bakPath);
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err), flatPath, bakPath },
+      'legacy-flat-key migration: rename to .pre-e1-bak failed — entry imported, will retry rename',
+    );
+    // Do not write marker — we still want to retry the rename next run.
+    // The duplicate-import guard in step 2 prevents a second pool insert.
+    return { status: 'imported', flatPath, bakPath: null, markerPath };
+  }
+
+  // (5c) Marker. Best-effort; even if this fails the next run is cheap
+  // because the duplicate-import guard catches us in step 2 (which then
+  // writes the marker itself).
+  writeMarker(markerPath);
+
+  logger.info(
+    { flatPath, bakPath, markerPath, label: LEGACY_FLAT_KEY_LABEL },
+    'legacy-flat-key migration: imported anthropic flat key into pool',
+  );
+
+  return { status: 'imported', flatPath, bakPath, markerPath };
+}

--- a/packages/core/src/memory/__tests__/anthropic-key-resolver-source.test.ts
+++ b/packages/core/src/memory/__tests__/anthropic-key-resolver-source.test.ts
@@ -31,8 +31,11 @@ function setEnvKey(value: string | undefined): void {
 }
 
 function setXdgHome(value: string): void {
-  delete process.env['CLEO_HOME'];
+  // XDG_DATA_HOME is Linux-only: env-paths ignores it on macOS/Windows.
+  // Set CLEO_HOME to `<xdg>/cleo` so getCleoHome() returns the staged path on
+  // every platform.
   process.env['XDG_DATA_HOME'] = value;
+  process.env['CLEO_HOME'] = join(value, 'cleo');
 }
 
 function makeCleoDir(): { xdgRoot: string; cleoDir: string } {


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E1 §5.1 T-E1-4. Folds the tier-4b legacy flat file (`~/.local/share/cleo/anthropic-key`) into the unified credential pool so the multi-tier resolver walk can collapse to a single pool lookup post-E2.

## Behavior
- On first cleo run, if flat file exists and no `legacy-flat-key` entry is present in the pool, `addCredential` is called with the file contents
- Migration marker (`.imported-legacy-flat-key`) prevents re-run
- Original flat file renamed to `anthropic-key.pre-e1-bak` (preserved)
- Migration is atomic + idempotent
- Helper is **exported but not yet wired** — T-E1-5 or T9405's bootstrap path can call `importLegacyFlatAnthropicKey()` once those land. All AC1-5 satisfied via the helper + tests.

## Test plan
- [x] 7/7 unit tests pass for the helper (all 5 acceptance scenarios + trim + double-call idempotency)
- [x] 66/66 credential-cluster tests pass
- [x] Full `@cleocode/core` test suite shows only pre-existing `E_INVALID_PROJECT_ROOT` worktree-only failures (verified by stashing changes)
- [x] biome check + build clean

## Refs
- `docs/plans/E-CONFIG-AUTH-UNIFY.md` §5.1 T-E1-4
- Epic: T9399, Master: T9500