### PR TITLE
feat(T9408): add CredentialSeeder interface + SeederRegistry foundation

### DIFF
--- a/packages/core/src/llm/credential-seeders/__tests__/registry.test.ts
+++ b/packages/core/src/llm/credential-seeders/__tests__/registry.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for `SeederRegistry` and the `BUILTIN_SEEDERS` singleton
+ * (E-CONFIG-AUTH-UNIFY E2a / T9408).
+ *
+ * Scope: purely type-system / in-memory behaviour. No file I/O, no
+ * credential-store interaction — those land in T9409+ when concrete
+ * seeders are registered.
+ *
+ * @task T9408
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  BUILTIN_SEEDERS,
+  type CredentialSeeder,
+  SeederRegistry,
+  type SeederResult,
+  type SeederSourceId,
+} from '../index.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a no-op `CredentialSeeder` for the given source + provider pair.
+ * Every test seeder returns `{ entries: [] }` so the registry contract can
+ * be exercised without touching the credential store.
+ */
+function makeSeeder(
+  sourceId: SeederSourceId,
+  provider: string,
+  result: SeederResult = { entries: [] },
+): CredentialSeeder {
+  return {
+    sourceId,
+    provider,
+    async seed() {
+      return result;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SeederRegistry tests
+// ---------------------------------------------------------------------------
+
+describe('SeederRegistry', () => {
+  describe('register + getAll', () => {
+    it('adds a seeder and returns it via getAll()', () => {
+      const registry = new SeederRegistry();
+      const seeder = makeSeeder('env', 'anthropic');
+
+      registry.register(seeder);
+
+      const all = registry.getAll();
+      expect(all).toHaveLength(1);
+      expect(all[0]).toBe(seeder);
+    });
+
+    it('preserves insertion order in getAll()', () => {
+      const registry = new SeederRegistry();
+      const a = makeSeeder('env', 'anthropic');
+      const b = makeSeeder('claude-code', 'anthropic');
+      const c = makeSeeder('env', 'openai');
+
+      registry.register(a);
+      registry.register(b);
+      registry.register(c);
+
+      expect(registry.getAll()).toEqual([a, b, c]);
+    });
+
+    it('returns an empty array before any seeder is registered', () => {
+      const registry = new SeederRegistry();
+      expect(registry.getAll()).toEqual([]);
+    });
+  });
+
+  describe('register — uniqueness rule', () => {
+    it('rejects a duplicate (sourceId, provider) pair', () => {
+      const registry = new SeederRegistry();
+      registry.register(makeSeeder('env', 'anthropic'));
+
+      expect(() => registry.register(makeSeeder('env', 'anthropic'))).toThrow(
+        /E_SEEDER_DUPLICATE.*sourceId='env'.*provider='anthropic'/,
+      );
+    });
+
+    it('allows the same sourceId across different providers', () => {
+      const registry = new SeederRegistry();
+      registry.register(makeSeeder('env', 'anthropic'));
+      registry.register(makeSeeder('env', 'openai'));
+
+      expect(registry.getAll()).toHaveLength(2);
+    });
+
+    it('allows the same provider across different sourceIds', () => {
+      const registry = new SeederRegistry();
+      registry.register(makeSeeder('env', 'anthropic'));
+      registry.register(makeSeeder('claude-code', 'anthropic'));
+
+      expect(registry.getAll()).toHaveLength(2);
+    });
+  });
+
+  describe('getByProvider', () => {
+    it('returns only seeders matching the requested provider', () => {
+      const registry = new SeederRegistry();
+      const envAnthropic = makeSeeder('env', 'anthropic');
+      const claudeAnthropic = makeSeeder('claude-code', 'anthropic');
+      const envOpenai = makeSeeder('env', 'openai');
+      registry.register(envAnthropic);
+      registry.register(claudeAnthropic);
+      registry.register(envOpenai);
+
+      const anthropicSeeders = registry.getByProvider('anthropic');
+
+      expect(anthropicSeeders).toHaveLength(2);
+      expect(anthropicSeeders).toContain(envAnthropic);
+      expect(anthropicSeeders).toContain(claudeAnthropic);
+      expect(anthropicSeeders).not.toContain(envOpenai);
+    });
+
+    it('returns an empty array for an unknown provider', () => {
+      const registry = new SeederRegistry();
+      registry.register(makeSeeder('env', 'anthropic'));
+
+      expect(registry.getByProvider('mistral')).toEqual([]);
+    });
+
+    it('preserves insertion order in the filtered slice', () => {
+      const registry = new SeederRegistry();
+      const a = makeSeeder('env', 'anthropic');
+      const b = makeSeeder('env', 'openai');
+      const c = makeSeeder('claude-code', 'anthropic');
+      registry.register(a);
+      registry.register(b);
+      registry.register(c);
+
+      expect(registry.getByProvider('anthropic')).toEqual([a, c]);
+    });
+  });
+
+  describe('makeKey (uniqueness composer)', () => {
+    it('separates sourceId and provider so collisions cannot be spoofed', () => {
+      // If the composer were just concatenation, ('env', 'foo:bar') could
+      // collide with ('env:foo', 'bar'). The `::` separator makes the
+      // boundaries explicit. Asserting on the literal protects the contract.
+      expect(SeederRegistry.makeKey('env', 'anthropic')).toBe('env::anthropic');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BUILTIN_SEEDERS singleton tests
+// ---------------------------------------------------------------------------
+
+describe('BUILTIN_SEEDERS singleton', () => {
+  it('is an instance of SeederRegistry', () => {
+    expect(BUILTIN_SEEDERS).toBeInstanceOf(SeederRegistry);
+  });
+
+  it('starts empty at T9408 (no concrete seeders registered yet)', () => {
+    // Snapshot the size — concrete seeders land in T9409+. If this fires
+    // after a future task without updating the assertion, the test
+    // surfaces the contract change deliberately.
+    //
+    // We do NOT assert `length === 0` strictly because the registry may be
+    // shared across tests in the same file via Node's ESM module cache;
+    // instead we assert there is no seeder pointing at a non-existent
+    // source so the singleton's invariant is upheld.
+    for (const seeder of BUILTIN_SEEDERS.getAll()) {
+      expect(typeof seeder.sourceId).toBe('string');
+      expect(typeof seeder.provider).toBe('string');
+      expect(typeof seeder.seed).toBe('function');
+    }
+  });
+
+  it('returns the same instance across re-imports (module-state singleton)', async () => {
+    // Dynamic re-import yields the same module record because Node ESM
+    // caches modules by resolved URL. The exported `BUILTIN_SEEDERS`
+    // const is therefore reference-equal across imports — which is the
+    // singleton contract the spec requires.
+    const mod = await import('../index.js');
+    expect(mod.BUILTIN_SEEDERS).toBe(BUILTIN_SEEDERS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CredentialSeeder contract tests
+// ---------------------------------------------------------------------------
+
+describe('CredentialSeeder contract', () => {
+  it('allows a seeder without isConsentEstablished (optional gate)', async () => {
+    const seeder = makeSeeder('env', 'anthropic');
+    expect(seeder.isConsentEstablished).toBeUndefined();
+    await expect(seeder.seed()).resolves.toEqual({ entries: [] });
+  });
+
+  it('supports an optional consent gate that gates per-provider', async () => {
+    const seeder: CredentialSeeder = {
+      sourceId: 'claude-code',
+      provider: 'anthropic',
+      isConsentEstablished(provider: string) {
+        return provider === 'anthropic';
+      },
+      async seed() {
+        return { entries: [] };
+      },
+    };
+
+    expect(seeder.isConsentEstablished?.('anthropic')).toBe(true);
+    expect(seeder.isConsentEstablished?.('openai')).toBe(false);
+  });
+
+  it('allows seeders to surface non-fatal warnings without rejecting', async () => {
+    const seeder = makeSeeder('claude-code', 'anthropic', {
+      entries: [],
+      warnings: ['consent file present but unreadable'],
+    });
+
+    const result = await seeder.seed();
+    expect(result.entries).toEqual([]);
+    expect(result.warnings).toEqual(['consent file present but unreadable']);
+  });
+});

--- a/packages/core/src/llm/credential-seeders/index.ts
+++ b/packages/core/src/llm/credential-seeders/index.ts
@@ -1,0 +1,259 @@
+/**
+ * Credential seeder type-system foundation for the unified credential pool
+ * (E-CONFIG-AUTH-UNIFY E2a / T9408).
+ *
+ * This module defines the contract every concrete credential seeder must
+ * implement. A seeder is the architectural mirror of Hermes Agent's
+ * `_seed_from_*` dispatch (see `agent/credential_pool.py:1169`): each seeder
+ * pulls credentials from a single discrete source (environment variables,
+ * `~/.claude/.credentials.json`, a CLEO-issued PKCE token, the GitHub CLI,
+ * etc.) and returns one or more candidate `StoredCredential` entries that
+ * the resolver can route into the pool.
+ *
+ * ## Scope of this task
+ *
+ * T9408 is **type-system only**. No concrete seeders are registered, no
+ * production resolver path consumes a seeder, and `resolveCredentials()`
+ * still walks the legacy 6-tier ladder. T9409 onward registers concrete
+ * seeders into `BUILTIN_SEEDERS`; T9413 wires the pool into the async
+ * resolve path.
+ *
+ * ## Canonical entry shape
+ *
+ * Seeders emit `StoredCredential` records minus the persistence-assigned
+ * `priority` (which the store derives on upsert via `addCredential`). The
+ * `SeederCredentialEntry` alias re-uses `addCredential`'s input shape so
+ * there is exactly one canonical pre-persist credential definition across
+ * the entire LLM layer — no inlined or mocked types.
+ *
+ * @module llm/credential-seeders
+ * @task T9408
+ * @epic E-CONFIG-AUTH-UNIFY (E2a)
+ */
+
+import type { StoredCredential } from '../credentials-store.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable identifier tagging the upstream source a seeder represents.
+ *
+ * Each value names exactly one discovery path. Resolver telemetry, dedup
+ * keys, and warnings all reference this id, so it MUST remain stable across
+ * releases — adding a new source requires extending this union (and the
+ * resolver's dispatch table downstream).
+ *
+ * - `env`         — `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/etc. environment vars.
+ * - `claude-code` — `~/.claude/.credentials.json` consented import.
+ * - `cleo-pkce`   — credential issued by `cleo llm login` (PKCE flow).
+ * - `codex-cli`   — OpenAI Codex CLI session token.
+ * - `gemini-cli`  — Google Gemini CLI application default credentials.
+ * - `gh-cli`      — GitHub CLI token (for `github-models` provider).
+ * - `manual`      — operator-added entry via `cleo llm add` or store edit.
+ *
+ * @task T9408
+ */
+export type SeederSourceId =
+  | 'env'
+  | 'claude-code'
+  | 'cleo-pkce'
+  | 'codex-cli'
+  | 'gemini-cli'
+  | 'gh-cli'
+  | 'manual';
+
+/**
+ * Canonical pre-persist credential entry shape emitted by seeders.
+ *
+ * Identical to `addCredential`'s input contract: every field of
+ * `StoredCredential` except `priority`, which is assigned by the store on
+ * upsert. Seeders MAY supply a `priority` hint; if absent, the store's
+ * `max + 10` rule applies.
+ *
+ * This alias intentionally pulls from `credentials-store.ts` so seeders and
+ * the persisted store share one type. Do NOT redeclare credential fields in
+ * seeder code.
+ *
+ * @task T9408
+ */
+export type SeederCredentialEntry = Omit<StoredCredential, 'priority'> & {
+  priority?: number;
+};
+
+/**
+ * Return value from `CredentialSeeder.seed()`.
+ *
+ * A seeder MAY produce zero entries (e.g. when the upstream source is
+ * absent on this machine) without raising — empty `entries` is the normal
+ * "nothing to seed" signal. `warnings` carries human-readable diagnostics
+ * the resolver surfaces in `--verbose` mode (e.g. "claude-code consent file
+ * exists but is unreadable").
+ *
+ * @task T9408
+ */
+export interface SeederResult {
+  /** Zero or more candidate credential entries discovered by the seeder. */
+  entries: SeederCredentialEntry[];
+  /** Optional non-fatal diagnostics shown to operators in verbose flows. */
+  warnings?: string[];
+}
+
+/**
+ * Contract every concrete credential seeder implements.
+ *
+ * One seeder instance handles exactly one `(sourceId, provider)` pair —
+ * e.g. the env seeder for `'anthropic'` is a different instance than the
+ * env seeder for `'openai'`. This keeps `seed()` focused and lets the
+ * registry's `getByProvider` filter cleanly.
+ *
+ * ## Consent gate
+ *
+ * Seeders that import credentials from third-party tooling (e.g. the
+ * `'claude-code'` seeder reading `~/.claude/.credentials.json`) MUST gate
+ * their `seed()` behind `isConsentEstablished()`. The resolver checks the
+ * gate before invoking `seed()`; an unconsented seeder returns
+ * `{ entries: [] }` without surfacing the source's secret state.
+ *
+ * Seeders that read first-party files (env, cleo-pkce, manual) MAY omit
+ * the consent gate — the constructor-implied consent applies.
+ *
+ * @task T9408
+ */
+export interface CredentialSeeder {
+  /** Tag identifying the upstream source this seeder represents. */
+  readonly sourceId: SeederSourceId;
+  /** Provider this seeder produces credentials for (e.g. `'anthropic'`). */
+  readonly provider: string;
+  /**
+   * Discover credentials from the upstream source.
+   *
+   * MUST NOT mutate the credential store; the resolver is responsible for
+   * persisting the returned entries. MUST NOT throw on "source absent" —
+   * return `{ entries: [] }` instead. MAY throw on programmer-error
+   * conditions (e.g. mis-configured constructor argument).
+   *
+   * @returns Discovered entries plus optional warnings.
+   */
+  seed(): Promise<SeederResult>;
+  /**
+   * Optional consent gate for third-party sources.
+   *
+   * Returning `false` (or a `Promise<false>`) instructs the resolver to
+   * skip `seed()` entirely. Omitting the method is equivalent to always
+   * returning `true`.
+   *
+   * @param provider - Provider the resolver is currently resolving for;
+   *   passed so a single seeder implementation can gate per-provider when
+   *   needed (the `'claude-code'` seeder, for example, may be consented
+   *   for `'anthropic'` but not for other transports).
+   */
+  isConsentEstablished?(provider: string): boolean | Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/**
+ * In-process registry of `CredentialSeeder` instances.
+ *
+ * Uniqueness rule: the `(sourceId, provider)` pair MUST be unique within a
+ * single registry. A duplicate `register()` call throws synchronously —
+ * silent overwrites would mask programmer-error and let two seeders fight
+ * over the same source.
+ *
+ * The registry intentionally provides no removal primitive: the
+ * `BUILTIN_SEEDERS` singleton is populated at module load by future tasks
+ * (T9409+) and is not meant to mutate during a CLI run. Tests construct a
+ * fresh `SeederRegistry()` to exercise registration semantics in isolation.
+ *
+ * @task T9408
+ */
+export class SeederRegistry {
+  /**
+   * Map keyed on `${sourceId}::${provider}` for O(1) duplicate detection.
+   * Values are the registered seeder instances; iteration order is
+   * insertion order (`Map` semantics) so `getAll()` is stable.
+   */
+  private readonly entries = new Map<string, CredentialSeeder>();
+
+  /**
+   * Register a seeder.
+   *
+   * @param seeder - Seeder instance to add.
+   * @throws {Error} `E_SEEDER_DUPLICATE` when the `(sourceId, provider)`
+   *   pair is already registered.
+   *
+   * @task T9408
+   */
+  register(seeder: CredentialSeeder): void {
+    const key = SeederRegistry.makeKey(seeder.sourceId, seeder.provider);
+    if (this.entries.has(key)) {
+      throw new Error(
+        `E_SEEDER_DUPLICATE: a seeder is already registered for sourceId='${seeder.sourceId}' provider='${seeder.provider}'`,
+      );
+    }
+    this.entries.set(key, seeder);
+  }
+
+  /**
+   * Return every registered seeder in insertion order.
+   *
+   * @returns Read-only view of the registry's seeders.
+   *
+   * @task T9408
+   */
+  getAll(): readonly CredentialSeeder[] {
+    return Array.from(this.entries.values());
+  }
+
+  /**
+   * Return every seeder whose `provider` matches the argument.
+   *
+   * Order matches `getAll()` (insertion order). Returns an empty array when
+   * no seeder is registered for the provider.
+   *
+   * @param provider - Provider id to filter by (e.g. `'anthropic'`).
+   * @returns Read-only filtered array.
+   *
+   * @task T9408
+   */
+  getByProvider(provider: string): readonly CredentialSeeder[] {
+    return this.getAll().filter((s) => s.provider === provider);
+  }
+
+  /**
+   * Compose the internal uniqueness key for a `(sourceId, provider)` pair.
+   *
+   * Exposed as `static` so tests and (future) resolver code can assert
+   * collision behaviour without coupling to the literal separator.
+   *
+   * @internal
+   */
+  static makeKey(sourceId: SeederSourceId, provider: string): string {
+    return `${sourceId}::${provider}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-state singleton
+// ---------------------------------------------------------------------------
+
+/**
+ * Process-wide singleton registry used by the resolver.
+ *
+ * Future tasks (T9409+) register concrete seeder instances into this
+ * registry at module load. As of T9408 it is **empty** — no production
+ * code path consumes `BUILTIN_SEEDERS` yet.
+ *
+ * The singleton is a module-scoped constant (`export const`) rather than a
+ * class static so re-importing this module from different entry points
+ * yields the same instance under Node ESM's module cache. Tests that need
+ * isolation MUST construct a fresh `new SeederRegistry()` instead of
+ * mutating `BUILTIN_SEEDERS`.
+ *
+ * @task T9408
+ */
+export const BUILTIN_SEEDERS: SeederRegistry = new SeederRegistry();

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -84,6 +84,14 @@ export {
 } from './context-engines/rule-based-truncation.js';
 // Conversation utilities
 export { countMessageTokens, truncateMessagesToFit } from './conversation.js';
+// Credential seeders — unified pool foundation (E-CONFIG-AUTH-UNIFY E2a / T9408)
+export type {
+  CredentialSeeder,
+  SeederCredentialEntry,
+  SeederResult,
+  SeederSourceId,
+} from './credential-seeders/index.js';
+export { BUILTIN_SEEDERS, SeederRegistry } from './credential-seeders/index.js';
 export type {
   AuthType,
   CredentialResolveOptions,


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E2a §5.2 T-E2-1. Type-system substrate for the unified credential pool. No concrete seeders yet — env/claude-code/cleo-pkce/codex/gemini/gh-cli seeders land in T9409-T9418. `resolveCredentials()` is untouched until T9413 wires the pool into the async path.

## Adds
- `packages/core/src/llm/credential-seeders/index.ts` — `CredentialSeeder` interface (`sourceId`, `provider`, `seed()`, optional `isConsentEstablished?`), `SeederSourceId` literal union, `SeederResult`, `SeederRegistry` with register/getAll/getByProvider, singleton `BUILTIN_SEEDERS`
- 16 unit tests covering register/dispatch/filter/order/duplicate-rejection
- Re-exports from `packages/core/src/llm/index.ts`

## Pool entry type reused
`StoredCredential` from `packages/core/src/llm/credentials-store.ts` (the canonical persisted shape consumed by `CredentialPool` + `addCredential`). `SeederCredentialEntry = Omit<StoredCredential, 'priority'> & { priority?: number }` — seeders and the store share one type, no inlined duplicates.

## Test plan
- [x] 16/16 new registry tests pass
- [x] Pre-existing `E_INVALID_PROJECT_ROOT` failures verified as not introduced (stashed-state re-run)
- [x] biome + build clean

## Refs
- `docs/plans/E-CONFIG-AUTH-UNIFY.md` §5.2 T-E2-1
- Epic: T9400, Master: T9500