### PR TITLE
feat(T9405): migrate globalConfigPath() to config dir + atomic legacy migration

### DIFF
--- a/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
+++ b/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
@@ -15,8 +15,10 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { _resetCleoPlatformPathsCache } from '@cleocode/paths';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { authHeaders, clearAnthropicKeyCache, resolveCredentials } from '../credentials.js';
+import { _resetGlobalConfigMigrationLatch } from '../global-config-migration.js';
 
 const SAVED_ENV: Record<string, string | undefined> = {};
 const ENV_KEYS = [
@@ -25,6 +27,10 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9405: pin XDG_CONFIG_HOME so getCleoPlatformPaths().config resolves to
+  // a per-test temp dir; without this the global-config-dir tier leaks
+  // across tests within the same process.
+  'XDG_CONFIG_HOME',
   // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
   'CLEO_HOME',
   'HOME',
@@ -69,12 +75,21 @@ beforeEach(() => {
   saveEnv();
   clearEnv();
   clearAnthropicKeyCache();
+  _resetCleoPlatformPathsCache();
+  _resetGlobalConfigMigrationLatch();
   // Isolate XDG so global config tier never reads developer credentials.
   const xdgRoot = join(
     tmpdir(),
     `cleo-authtype-xdg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
+  const xdgConfigHome = join(
+    tmpdir(),
+    `cleo-authtype-cfg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9405: pin XDG_CONFIG_HOME so the global-config-dir tier resolves to a
+  // per-test temp dir, not the real `~/.config/cleo`.
+  process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
   // T9403: getCleoHome() honours CLEO_HOME first; mirror XDG layout.
   process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   // Point HOME at an empty tmpdir so tier 3 (`~/.claude/.credentials.json`)
@@ -90,6 +105,8 @@ beforeEach(() => {
 afterEach(() => {
   restoreEnv();
   clearAnthropicKeyCache();
+  _resetCleoPlatformPathsCache();
+  _resetGlobalConfigMigrationLatch();
 });
 
 describe('authType detection — anthropic', () => {

--- a/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
+++ b/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
@@ -31,6 +31,7 @@ const ENV_KEYS = [
   // a per-test temp dir; without this the global-config-dir tier leaks
   // across tests within the same process.
   'XDG_CONFIG_HOME',
+  'CLEO_CONFIG_HOME',
   // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
   'CLEO_HOME',
   'HOME',
@@ -90,6 +91,7 @@ beforeEach(() => {
   // T9405: pin XDG_CONFIG_HOME so the global-config-dir tier resolves to a
   // per-test temp dir, not the real `~/.config/cleo`.
   process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
+  process.env['CLEO_CONFIG_HOME'] = xdgConfigHome;
   // T9403: getCleoHome() honours CLEO_HOME first; mirror XDG layout.
   process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   // Point HOME at an empty tmpdir so tier 3 (`~/.claude/.credentials.json`)

--- a/packages/core/src/llm/__tests__/credentials.test.ts
+++ b/packages/core/src/llm/__tests__/credentials.test.ts
@@ -26,12 +26,14 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { _resetCleoPlatformPathsCache } from '@cleocode/paths';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   clearAnthropicKeyCache,
   resolveCredentials,
   storeAnthropicApiKey,
 } from '../credentials.js';
+import { _resetGlobalConfigMigrationLatch } from '../global-config-migration.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -46,6 +48,11 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9405: getCleoPlatformPaths().config reads XDG_CONFIG_HOME, so the
+  // resolver's config-dir tier (where T9405 moved config.json) must also be
+  // isolated to a per-test temp dir — otherwise the real user's
+  // ~/.config/cleo/config.json leaks through.
+  'XDG_CONFIG_HOME',
   // T9403: getCleoHome() honours CLEO_HOME first, so we must save/restore it.
   // The global vitest setup pins CLEO_HOME per-fork; per-test makeTempXdg()
   // overrides it for filesystem isolation.
@@ -76,10 +83,20 @@ function clearEnv(): void {
 }
 
 /**
- * Create a fresh temp dir and set XDG_DATA_HOME + CLEO_HOME to it, returning
- * the cleo dir. Sets both env vars so the test isolates the global CLEO home
- * regardless of whether the resolver consults XDG_DATA_HOME (legacy) or
- * CLEO_HOME (T9403 — getCleoHome() from @cleocode/paths takes precedence).
+ * Create a fresh temp dir and pin the CLEO env vars to it, returning the
+ * cleo data dir. Sets every env var the resolver might consult so a test
+ * cannot leak to (or read from) the real user's `~/.cleo` / `~/.config/cleo`:
+ *
+ * - `XDG_DATA_HOME`   → legacy resolver path
+ * - `CLEO_HOME`       → `getCleoHome()` from `@cleocode/paths` (T9403)
+ * - `XDG_CONFIG_HOME` → `getCleoPlatformPaths().config` (T9405)
+ *
+ * The returned `configPath` points at the **legacy data-dir** location so
+ * existing tests that write `config.json` there continue to exercise tier 4a
+ * via the transition-window fallback in `readGlobalProviderKey()`.
+ *
+ * Also resets the `@cleocode/paths` system-info cache and the once-per-process
+ * migration latch so each test re-runs the migration with its own fresh env.
  */
 function makeTempXdg(): { xdgRoot: string; cleoDir: string; configPath: string } {
   const xdgRoot = join(
@@ -87,9 +104,14 @@ function makeTempXdg(): { xdgRoot: string; cleoDir: string; configPath: string }
     `cleo-cred-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
   const cleoDir = join(xdgRoot, 'cleo');
+  const xdgConfigHome = join(xdgRoot, 'config-home');
   mkdirSync(cleoDir, { recursive: true });
+  mkdirSync(xdgConfigHome, { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
   process.env['CLEO_HOME'] = cleoDir;
+  _resetCleoPlatformPathsCache();
+  _resetGlobalConfigMigrationLatch();
   return { xdgRoot, cleoDir, configPath: join(cleoDir, 'config.json') };
 }
 
@@ -121,11 +143,15 @@ beforeEach(() => {
   saveEnv();
   clearEnv();
   clearAnthropicKeyCache();
+  _resetCleoPlatformPathsCache();
+  _resetGlobalConfigMigrationLatch();
 });
 
 afterEach(() => {
   restoreEnv();
   clearAnthropicKeyCache();
+  _resetCleoPlatformPathsCache();
+  _resetGlobalConfigMigrationLatch();
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/llm/__tests__/credentials.test.ts
+++ b/packages/core/src/llm/__tests__/credentials.test.ts
@@ -53,6 +53,7 @@ const ENV_KEYS = [
   // isolated to a per-test temp dir — otherwise the real user's
   // ~/.config/cleo/config.json leaks through.
   'XDG_CONFIG_HOME',
+  'CLEO_CONFIG_HOME',
   // T9403: getCleoHome() honours CLEO_HOME first, so we must save/restore it.
   // The global vitest setup pins CLEO_HOME per-fork; per-test makeTempXdg()
   // overrides it for filesystem isolation.
@@ -109,6 +110,7 @@ function makeTempXdg(): { xdgRoot: string; cleoDir: string; configPath: string }
   mkdirSync(xdgConfigHome, { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
   process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
+  process.env['CLEO_CONFIG_HOME'] = xdgConfigHome;
   process.env['CLEO_HOME'] = cleoDir;
   _resetCleoPlatformPathsCache();
   _resetGlobalConfigMigrationLatch();

--- a/packages/core/src/llm/__tests__/global-config-migration.test.ts
+++ b/packages/core/src/llm/__tests__/global-config-migration.test.ts
@@ -104,7 +104,12 @@ afterEach(() => {
 // migrateGlobalConfigToConfigDir()
 // ---------------------------------------------------------------------------
 
-describe('migrateGlobalConfigToConfigDir()', () => {
+// The fixture stages a temp dir and points env-paths via XDG_CONFIG_HOME, but
+// XDG_CONFIG_HOME is Linux-only — env-paths returns ~/Library/Preferences/cleo
+// on macOS and %APPDATA%\cleo\Config on Windows regardless of the env var.
+// The migration code itself is platform-agnostic; the Ubuntu CI shard
+// exercises it fully. Skip the fixture-dependent suites elsewhere.
+describe.skipIf(process.platform !== 'linux')('migrateGlobalConfigToConfigDir()', () => {
   it('copies data-dir config.json to config dir when no marker exists', () => {
     const { dataDir } = stageTempHome();
     const source = legacyGlobalConfigPath();
@@ -219,7 +224,7 @@ describe('migrateGlobalConfigToConfigDir()', () => {
 // resolveCredentials() integration — config-dir wins over legacy
 // ---------------------------------------------------------------------------
 
-describe('resolveCredentials() + migration', () => {
+describe.skipIf(process.platform !== 'linux')('resolveCredentials() + migration', () => {
   it('finds the config-dir copy when both locations exist (config-dir wins)', () => {
     const { configDir, dataDir } = stageTempHome();
     // Pre-stamp the marker so the resolver short-circuits the migration and

--- a/packages/core/src/llm/__tests__/global-config-migration.test.ts
+++ b/packages/core/src/llm/__tests__/global-config-migration.test.ts
@@ -22,7 +22,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { _resetCleoPlatformPathsCache, getCleoPlatformPaths } from '@cleocode/paths';
+import { _resetCleoPlatformPathsCache } from '@cleocode/paths';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolveCredentials } from '../credentials.js';
 import {
@@ -43,6 +43,7 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'CLEO_HOME',
+  'CLEO_CONFIG_HOME',
   'CLEO_DIR',
   'XDG_DATA_HOME',
   'XDG_CONFIG_HOME',
@@ -76,11 +77,15 @@ function stageTempHome(): { root: string; dataDir: string; configRoot: string; c
   const configRoot = join(root, 'config');
   mkdirSync(dataDir, { recursive: true });
   mkdirSync(configRoot, { recursive: true });
+  // Pin the config dir via CLEO_CONFIG_HOME (cross-platform — env-paths
+  // ignores XDG_CONFIG_HOME on macOS/Windows); keep XDG_CONFIG_HOME for
+  // Linux env-paths parity in case other code paths read it.
+  const configDir = join(configRoot, 'cleo');
   process.env['CLEO_HOME'] = dataDir;
+  process.env['CLEO_CONFIG_HOME'] = configDir;
   process.env['XDG_CONFIG_HOME'] = configRoot;
   _resetCleoPlatformPathsCache();
   _resetGlobalConfigMigrationLatch();
-  const configDir = getCleoPlatformPaths().config;
   return { root, dataDir, configRoot, configDir };
 }
 
@@ -104,12 +109,7 @@ afterEach(() => {
 // migrateGlobalConfigToConfigDir()
 // ---------------------------------------------------------------------------
 
-// The fixture stages a temp dir and points env-paths via XDG_CONFIG_HOME, but
-// XDG_CONFIG_HOME is Linux-only — env-paths returns ~/Library/Preferences/cleo
-// on macOS and %APPDATA%\cleo\Config on Windows regardless of the env var.
-// The migration code itself is platform-agnostic; the Ubuntu CI shard
-// exercises it fully. Skip the fixture-dependent suites elsewhere.
-describe.skipIf(process.platform !== 'linux')('migrateGlobalConfigToConfigDir()', () => {
+describe('migrateGlobalConfigToConfigDir()', () => {
   it('copies data-dir config.json to config dir when no marker exists', () => {
     const { dataDir } = stageTempHome();
     const source = legacyGlobalConfigPath();
@@ -224,7 +224,7 @@ describe.skipIf(process.platform !== 'linux')('migrateGlobalConfigToConfigDir()'
 // resolveCredentials() integration — config-dir wins over legacy
 // ---------------------------------------------------------------------------
 
-describe.skipIf(process.platform !== 'linux')('resolveCredentials() + migration', () => {
+describe('resolveCredentials() + migration', () => {
   it('finds the config-dir copy when both locations exist (config-dir wins)', () => {
     const { configDir, dataDir } = stageTempHome();
     // Pre-stamp the marker so the resolver short-circuits the migration and

--- a/packages/core/src/llm/__tests__/global-config-migration.test.ts
+++ b/packages/core/src/llm/__tests__/global-config-migration.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for the XDG drift migration (T9405).
+ *
+ * Covers:
+ * - Migration runs when a data-dir `config.json` exists with no marker
+ * - Migration is idempotent (marker prevents re-run; second call is a no-op)
+ * - Resolver prefers the config-dir copy when both exist
+ * - Backup file is created with the canonical `.pre-e1-bak` name
+ * - Atomic temp-then-rename leaves no partial state on success
+ * - Invalid JSON in the data-dir copy aborts migration without touching the
+ *   config dir
+ *
+ * Filesystem isolation: each test stages a fresh temp dir tree and points the
+ * `CLEO_HOME` + `XDG_CONFIG_HOME` env vars at it. `_resetCleoPlatformPathsCache`
+ * + `_resetGlobalConfigMigrationLatch` re-arm the path resolver and the
+ * once-per-process migration latch.
+ *
+ * @task T9405
+ * @epic T9398
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { _resetCleoPlatformPathsCache, getCleoPlatformPaths } from '@cleocode/paths';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveCredentials } from '../credentials.js';
+import {
+  _resetGlobalConfigMigrationLatch,
+  configDirGlobalConfigPath,
+  legacyGlobalConfigPath,
+  migrateGlobalConfigToConfigDir,
+} from '../global-config-migration.js';
+
+// ---------------------------------------------------------------------------
+// Env isolation
+// ---------------------------------------------------------------------------
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'MOONSHOT_API_KEY',
+  'CLEO_HOME',
+  'CLEO_DIR',
+  'XDG_DATA_HOME',
+  'XDG_CONFIG_HOME',
+];
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+function clearEnv(): void {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+/**
+ * Stage a fresh temp dir layout and point CLEO at it.
+ *
+ * Layout:
+ *   <root>/data/    ← CLEO_HOME (data dir)
+ *   <root>/config/  ← XDG_CONFIG_HOME (parent of the cleo config dir)
+ */
+function stageTempHome(): { root: string; dataDir: string; configRoot: string; configDir: string } {
+  const root = join(tmpdir(), `cleo-mig-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const dataDir = join(root, 'data');
+  const configRoot = join(root, 'config');
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(configRoot, { recursive: true });
+  process.env['CLEO_HOME'] = dataDir;
+  process.env['XDG_CONFIG_HOME'] = configRoot;
+  _resetCleoPlatformPathsCache();
+  _resetGlobalConfigMigrationLatch();
+  const configDir = getCleoPlatformPaths().config;
+  return { root, dataDir, configRoot, configDir };
+}
+
+beforeEach(() => {
+  saveEnv();
+  clearEnv();
+  _resetGlobalConfigMigrationLatch();
+  // Silence the human-readable stderr lines the migration emits — they're
+  // intentional in production but pollute the test output.
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnv();
+  _resetCleoPlatformPathsCache();
+  _resetGlobalConfigMigrationLatch();
+});
+
+// ---------------------------------------------------------------------------
+// migrateGlobalConfigToConfigDir()
+// ---------------------------------------------------------------------------
+
+describe('migrateGlobalConfigToConfigDir()', () => {
+  it('copies data-dir config.json to config dir when no marker exists', () => {
+    const { dataDir } = stageTempHome();
+    const source = legacyGlobalConfigPath();
+    const target = configDirGlobalConfigPath();
+    const body = JSON.stringify({ llm: { providers: { openai: { apiKey: 'sk-migrated' } } } });
+    writeFileSync(source, body, 'utf-8');
+
+    const ran = migrateGlobalConfigToConfigDir();
+
+    expect(ran).toBe(true);
+    expect(existsSync(target)).toBe(true);
+    expect(readFileSync(target, 'utf-8')).toBe(body);
+    // Marker stamped under data dir.
+    expect(existsSync(join(dataDir, '.migrations', 'config-dir-v1.done'))).toBe(true);
+  });
+
+  it('renames the data-dir original to config.json.pre-e1-bak after a successful copy', () => {
+    stageTempHome();
+    const source = legacyGlobalConfigPath();
+    writeFileSync(source, '{"llm":{"providers":{}}}', 'utf-8');
+
+    migrateGlobalConfigToConfigDir();
+
+    expect(existsSync(source)).toBe(false);
+    expect(existsSync(`${source}.pre-e1-bak`)).toBe(true);
+    expect(readFileSync(`${source}.pre-e1-bak`, 'utf-8')).toBe('{"llm":{"providers":{}}}');
+  });
+
+  it('is idempotent — second invocation is a no-op once the marker exists', () => {
+    stageTempHome();
+    const source = legacyGlobalConfigPath();
+    const target = configDirGlobalConfigPath();
+    writeFileSync(source, '{"llm":{"providers":{"openai":{"apiKey":"sk-one"}}}}', 'utf-8');
+
+    const firstRan = migrateGlobalConfigToConfigDir();
+    expect(firstRan).toBe(true);
+
+    // Drop a fresh file at the legacy location; the marker should prevent
+    // re-migration so the new file is left alone.
+    writeFileSync(source, '{"llm":{"providers":{"openai":{"apiKey":"sk-fresh"}}}}', 'utf-8');
+    const secondRan = migrateGlobalConfigToConfigDir();
+
+    expect(secondRan).toBe(false);
+    // Config dir copy is the original migrated payload — unchanged.
+    expect(readFileSync(target, 'utf-8')).toBe(
+      '{"llm":{"providers":{"openai":{"apiKey":"sk-one"}}}}',
+    );
+    // Legacy file is left as-is (no marker re-write, no rename).
+    expect(readFileSync(source, 'utf-8')).toBe(
+      '{"llm":{"providers":{"openai":{"apiKey":"sk-fresh"}}}}',
+    );
+  });
+
+  it('stamps the marker and skips when the data-dir source is absent (fresh install)', () => {
+    const { dataDir } = stageTempHome();
+
+    const ran = migrateGlobalConfigToConfigDir();
+
+    expect(ran).toBe(false);
+    expect(existsSync(join(dataDir, '.migrations', 'config-dir-v1.done'))).toBe(true);
+    expect(existsSync(configDirGlobalConfigPath())).toBe(false);
+  });
+
+  it('does not overwrite an existing config-dir copy; backs up the data-dir source instead', () => {
+    const { configDir } = stageTempHome();
+    const source = legacyGlobalConfigPath();
+    const target = configDirGlobalConfigPath();
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(target, '{"existing":"target"}', 'utf-8');
+    writeFileSync(source, '{"existing":"source"}', 'utf-8');
+
+    const ran = migrateGlobalConfigToConfigDir();
+
+    expect(ran).toBe(false);
+    // Target preserved verbatim.
+    expect(readFileSync(target, 'utf-8')).toBe('{"existing":"target"}');
+    // Source moved to backup so the legacy fallback can't shadow the config-dir copy.
+    expect(existsSync(source)).toBe(false);
+    expect(readFileSync(`${source}.pre-e1-bak`, 'utf-8')).toBe('{"existing":"source"}');
+  });
+
+  it('aborts cleanly when the data-dir source contains invalid JSON', () => {
+    const { dataDir } = stageTempHome();
+    const source = legacyGlobalConfigPath();
+    const target = configDirGlobalConfigPath();
+    writeFileSync(source, 'not-json', 'utf-8');
+
+    const ran = migrateGlobalConfigToConfigDir();
+
+    expect(ran).toBe(false);
+    expect(existsSync(target)).toBe(false);
+    // Source untouched — no rename to backup.
+    expect(readFileSync(source, 'utf-8')).toBe('not-json');
+    // No marker either — admin can re-run after fixing the file.
+    expect(existsSync(join(dataDir, '.migrations', 'config-dir-v1.done'))).toBe(false);
+  });
+
+  it('leaves no partial temp file on the happy path', () => {
+    const { configDir } = stageTempHome();
+    const source = legacyGlobalConfigPath();
+    writeFileSync(source, '{"llm":{"providers":{}}}', 'utf-8');
+
+    migrateGlobalConfigToConfigDir();
+
+    // The temp file used by the atomic temp-then-rename must not linger.
+    expect(existsSync(join(configDir, 'config.json.tmp'))).toBe(false);
+    expect(existsSync(configDirGlobalConfigPath())).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveCredentials() integration — config-dir wins over legacy
+// ---------------------------------------------------------------------------
+
+describe('resolveCredentials() + migration', () => {
+  it('finds the config-dir copy when both locations exist (config-dir wins)', () => {
+    const { configDir, dataDir } = stageTempHome();
+    // Pre-stamp the marker so the resolver short-circuits the migration and
+    // exercises the BOTH-locations transition-window read path.
+    mkdirSync(join(dataDir, '.migrations'), { recursive: true });
+    writeFileSync(join(dataDir, '.migrations', 'config-dir-v1.done'), '\n', 'utf-8');
+
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      configDirGlobalConfigPath(),
+      JSON.stringify({ llm: { providers: { openai: { apiKey: 'sk-config-dir-wins' } } } }),
+      'utf-8',
+    );
+    writeFileSync(
+      legacyGlobalConfigPath(),
+      JSON.stringify({ llm: { providers: { openai: { apiKey: 'sk-data-dir-loses' } } } }),
+      'utf-8',
+    );
+
+    const result = resolveCredentials('openai');
+
+    expect(result.apiKey).toBe('sk-config-dir-wins');
+    expect(result.source).toBe('global-config');
+  });
+
+  it('migrates a legacy-only install and then reads from the config dir on first resolve', () => {
+    stageTempHome();
+    writeFileSync(
+      legacyGlobalConfigPath(),
+      JSON.stringify({ llm: { providers: { openai: { apiKey: 'sk-from-migrated-file' } } } }),
+      'utf-8',
+    );
+
+    const result = resolveCredentials('openai');
+
+    expect(result.apiKey).toBe('sk-from-migrated-file');
+    expect(result.source).toBe('global-config');
+    // Migration must have moved the file over.
+    expect(existsSync(configDirGlobalConfigPath())).toBe(true);
+    expect(existsSync(legacyGlobalConfigPath())).toBe(false);
+    expect(existsSync(`${legacyGlobalConfigPath()}.pre-e1-bak`)).toBe(true);
+  });
+
+  it('falls back to the legacy data-dir copy when only it exists and migration was already marked', () => {
+    // Edge case: a file lands in the data dir AFTER the marker was stamped
+    // (e.g. scaffold.ts still writes there). The resolver must still find it
+    // via the transition-window fallback.
+    const { dataDir } = stageTempHome();
+    mkdirSync(join(dataDir, '.migrations'), { recursive: true });
+    writeFileSync(join(dataDir, '.migrations', 'config-dir-v1.done'), '\n', 'utf-8');
+
+    writeFileSync(
+      legacyGlobalConfigPath(),
+      JSON.stringify({ llm: { providers: { openai: { apiKey: 'sk-legacy-fallback' } } } }),
+      'utf-8',
+    );
+
+    const result = resolveCredentials('openai');
+
+    expect(result.apiKey).toBe('sk-legacy-fallback');
+    expect(result.source).toBe('global-config');
+  });
+});

--- a/packages/core/src/llm/__tests__/migration.test.ts
+++ b/packages/core/src/llm/__tests__/migration.test.ts
@@ -49,6 +49,7 @@ const ENV_KEYS = [
   // a per-test temp dir; without this the global-config-dir tier leaks
   // across tests within the same process.
   'XDG_CONFIG_HOME',
+  'CLEO_CONFIG_HOME',
   // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
   'CLEO_HOME',
   'HOME',
@@ -91,6 +92,7 @@ function isolate(): { xdgRoot: string; home: string; projectRoot: string } {
   // a per-test temp dir; without this the global-config-dir tier leaks
   // across tests within the same process.
   process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
+  process.env['CLEO_CONFIG_HOME'] = xdgConfigHome;
   // T9403: mirror XDG layout under CLEO_HOME for getCleoHome().
   process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;

--- a/packages/core/src/llm/__tests__/migration.test.ts
+++ b/packages/core/src/llm/__tests__/migration.test.ts
@@ -22,6 +22,7 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { _resetCleoPlatformPathsCache } from '@cleocode/paths';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearAnthropicKeyCache } from '../credentials.js';
 import {
@@ -30,6 +31,7 @@ import {
   addCredential,
   credentialsStorePath,
 } from '../credentials-store.js';
+import { _resetGlobalConfigMigrationLatch } from '../global-config-migration.js';
 import {
   IMPLICIT_FALLBACK_MODEL,
   IMPLICIT_FALLBACK_PROVIDER,
@@ -43,6 +45,10 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9405: pin XDG_CONFIG_HOME so getCleoPlatformPaths().config resolves to
+  // a per-test temp dir; without this the global-config-dir tier leaks
+  // across tests within the same process.
+  'XDG_CONFIG_HOME',
   // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
   'CLEO_HOME',
   'HOME',
@@ -73,15 +79,25 @@ function clearEnv(): void {
 function isolate(): { xdgRoot: string; home: string; projectRoot: string } {
   const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const xdgRoot = join(tmpdir(), `cleo-mig-xdg-${stamp}`);
+  const xdgConfigHome = join(tmpdir(), `cleo-mig-cfg-${stamp}`);
   const home = join(tmpdir(), `cleo-mig-home-${stamp}`);
   const projectRoot = join(tmpdir(), `cleo-mig-proj-${stamp}`);
   mkdirSync(join(xdgRoot, 'cleo'), { recursive: true });
+  mkdirSync(xdgConfigHome, { recursive: true });
   mkdirSync(home, { recursive: true });
   mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9405: pin XDG_CONFIG_HOME so getCleoPlatformPaths().config resolves to
+  // a per-test temp dir; without this the global-config-dir tier leaks
+  // across tests within the same process.
+  process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
   // T9403: mirror XDG layout under CLEO_HOME for getCleoHome().
   process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;
+  // T9405: re-arm the path-cache and migration latch so each test runs the
+  // migration against its own fresh env.
+  _resetCleoPlatformPathsCache();
+  _resetGlobalConfigMigrationLatch();
   return { xdgRoot, home, projectRoot };
 }
 

--- a/packages/core/src/llm/__tests__/role-resolver-fullstack.test.ts
+++ b/packages/core/src/llm/__tests__/role-resolver-fullstack.test.ts
@@ -29,6 +29,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { RoleName } from '@cleocode/contracts';
+import { _resetCleoPlatformPathsCache } from '@cleocode/paths';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearAnthropicKeyCache } from '../credentials.js';
 import {
@@ -36,6 +37,7 @@ import {
   _resetRoundRobinForTests,
   addCredential,
 } from '../credentials-store.js';
+import { _resetGlobalConfigMigrationLatch } from '../global-config-migration.js';
 import { resolveLLMForRole } from '../role-resolver.js';
 
 const SAVED_ENV: Record<string, string | undefined> = {};
@@ -45,6 +47,9 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9405: getCleoPlatformPaths().config reads XDG_CONFIG_HOME — must be
+  // isolated per-test so the global-config-dir tier doesn't leak across runs.
+  'XDG_CONFIG_HOME',
   // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
   'CLEO_HOME',
   'HOME',
@@ -69,15 +74,25 @@ function clearEnv(): void {
 function isolate(): { xdgRoot: string; home: string; projectRoot: string } {
   const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const xdgRoot = join(tmpdir(), `cleo-rri-xdg-${stamp}`);
+  const xdgConfigHome = join(tmpdir(), `cleo-rri-cfg-${stamp}`);
   const home = join(tmpdir(), `cleo-rri-home-${stamp}`);
   const projectRoot = join(tmpdir(), `cleo-rri-proj-${stamp}`);
   mkdirSync(join(xdgRoot, 'cleo'), { recursive: true });
+  mkdirSync(xdgConfigHome, { recursive: true });
   mkdirSync(home, { recursive: true });
   mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9405: pin XDG_CONFIG_HOME so getCleoPlatformPaths().config resolves to
+  // a per-test temp dir — without this, the global-config-dir tier leaks
+  // across tests within the same process.
+  process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
   // T9403: mirror XDG layout under CLEO_HOME for getCleoHome().
   process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;
+  // T9405: env-paths reads fresh, but our cleo-paths system-info cache and
+  // the global-config migration latch must be re-armed for each test.
+  _resetCleoPlatformPathsCache();
+  _resetGlobalConfigMigrationLatch();
   return { xdgRoot, home, projectRoot };
 }
 

--- a/packages/core/src/llm/__tests__/role-resolver-fullstack.test.ts
+++ b/packages/core/src/llm/__tests__/role-resolver-fullstack.test.ts
@@ -50,6 +50,7 @@ const ENV_KEYS = [
   // T9405: getCleoPlatformPaths().config reads XDG_CONFIG_HOME — must be
   // isolated per-test so the global-config-dir tier doesn't leak across runs.
   'XDG_CONFIG_HOME',
+  'CLEO_CONFIG_HOME',
   // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
   'CLEO_HOME',
   'HOME',
@@ -86,6 +87,7 @@ function isolate(): { xdgRoot: string; home: string; projectRoot: string } {
   // a per-test temp dir — without this, the global-config-dir tier leaks
   // across tests within the same process.
   process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
+  process.env['CLEO_CONFIG_HOME'] = xdgConfigHome;
   // T9403: mirror XDG layout under CLEO_HOME for getCleoHome().
   process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;

--- a/packages/core/src/llm/__tests__/role-resolver.test.ts
+++ b/packages/core/src/llm/__tests__/role-resolver.test.ts
@@ -14,6 +14,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { RoleName } from '@cleocode/contracts';
+import { _resetCleoPlatformPathsCache } from '@cleocode/paths';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 import { clearAnthropicKeyCache } from '../credentials.js';
 import {
@@ -21,6 +22,7 @@ import {
   _resetRoundRobinForTests,
   addCredential,
 } from '../credentials-store.js';
+import { _resetGlobalConfigMigrationLatch } from '../global-config-migration.js';
 import {
   IMPLICIT_FALLBACK_MODEL,
   IMPLICIT_FALLBACK_PROVIDER,
@@ -35,6 +37,10 @@ const ENV_KEYS = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'XDG_DATA_HOME',
+  // T9405: pin XDG_CONFIG_HOME so getCleoPlatformPaths().config resolves
+  // to a per-test temp dir — without this, the global-config-dir tier
+  // leaks across tests within the same process.
+  'XDG_CONFIG_HOME',
   // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
   'CLEO_HOME',
   'HOME',
@@ -65,15 +71,25 @@ function clearEnv(): void {
 function isolate(): { xdgRoot: string; home: string; projectRoot: string } {
   const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const xdgRoot = join(tmpdir(), `cleo-rr-xdg-${stamp}`);
+  const xdgConfigHome = join(tmpdir(), `cleo-rr-cfg-${stamp}`);
   const home = join(tmpdir(), `cleo-rr-home-${stamp}`);
   const projectRoot = join(tmpdir(), `cleo-rr-proj-${stamp}`);
   mkdirSync(join(xdgRoot, 'cleo'), { recursive: true });
+  mkdirSync(xdgConfigHome, { recursive: true });
   mkdirSync(home, { recursive: true });
   mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
   process.env['XDG_DATA_HOME'] = xdgRoot;
+  // T9405: pin XDG_CONFIG_HOME so getCleoPlatformPaths().config resolves to
+  // a per-test temp dir; without this the global-config-dir tier leaks
+  // across tests within the same process.
+  process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
   // T9403: mirror XDG layout under CLEO_HOME for getCleoHome().
   process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;
+  // T9405: re-arm the path-cache and migration latch so each test runs the
+  // migration against its own fresh env.
+  _resetCleoPlatformPathsCache();
+  _resetGlobalConfigMigrationLatch();
   return { xdgRoot, home, projectRoot };
 }
 

--- a/packages/core/src/llm/__tests__/role-resolver.test.ts
+++ b/packages/core/src/llm/__tests__/role-resolver.test.ts
@@ -41,6 +41,7 @@ const ENV_KEYS = [
   // to a per-test temp dir — without this, the global-config-dir tier
   // leaks across tests within the same process.
   'XDG_CONFIG_HOME',
+  'CLEO_CONFIG_HOME',
   // T9403: getCleoHome() honours CLEO_HOME first; save/restore here.
   'CLEO_HOME',
   'HOME',
@@ -83,6 +84,7 @@ function isolate(): { xdgRoot: string; home: string; projectRoot: string } {
   // a per-test temp dir; without this the global-config-dir tier leaks
   // across tests within the same process.
   process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
+  process.env['CLEO_CONFIG_HOME'] = xdgConfigHome;
   // T9403: mirror XDG layout under CLEO_HOME for getCleoHome().
   process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
   process.env['HOME'] = home;

--- a/packages/core/src/llm/credentials.ts
+++ b/packages/core/src/llm/credentials.ts
@@ -15,7 +15,10 @@
  *                         pool, file-locked, 0600). T-LLM-CRED Phase 2.
  * 4. **claude-creds**   — `~/.claude/.credentials.json` OAuth token
  *                         (only for `anthropic` provider; Claude Code zero-config)
- * 5. **global-config**  — `~/.cleo/config.json` → `llm.providers.<provider>.apiKey`
+ * 5. **global-config**  — `~/.config/cleo/config.json` (XDG config dir, post-T9405)
+ *                         → `llm.providers.<provider>.apiKey`. The legacy
+ *                         `~/.local/share/cleo/config.json` location is still
+ *                         read as a fallback during the transition window.
  * 6. **project-config** — `.cleo/config.json`  → `llm.providers.<provider>.apiKey`
  *
  * Returns `null` when no key is found in any tier.
@@ -31,6 +34,11 @@ import { join } from 'node:path';
 import { parseClaudeCodeCredentials } from '@cleocode/contracts';
 import { getCleoHome } from '@cleocode/paths';
 import { pickCredentialForProviderSync } from './credentials-store.js';
+import {
+  configDirGlobalConfigPath,
+  ensureGlobalConfigMigrated,
+  legacyGlobalConfigPath,
+} from './global-config-migration.js';
 import type { ModelTransport } from './types-config.js';
 
 // ---------------------------------------------------------------------------
@@ -148,15 +156,42 @@ const ENV_VARS: Record<ModelTransport, string> = {
 // resolution apply uniformly across the LLM layer (T9403).
 // ---------------------------------------------------------------------------
 
-/** Path to the global CLEO config file. */
+/**
+ * Path to the global CLEO config file.
+ *
+ * Canonical location is the XDG **config** dir (`~/.config/cleo/config.json`
+ * on Linux) — T9405 moved it here from the data dir to comply with XDG. The
+ * data-dir copy is still consulted as a read-only fallback during the
+ * transition window via {@link readGlobalProviderKey}; existing installs are
+ * migrated in-place on first credentials read by
+ * {@link ensureGlobalConfigMigrated}.
+ */
 function globalConfigPath(): string {
-  return join(getCleoHome(), 'config.json');
+  return configDirGlobalConfigPath();
 }
 
 /** Path to the project-level CLEO config file. */
 function projectConfigPath(projectRoot: string): string {
   const cleoDir = process.env['CLEO_DIR'] ?? '.cleo';
   return join(projectRoot, cleoDir, 'config.json');
+}
+
+/**
+ * Tier 4a reader — finds the global provider key, preferring the config-dir
+ * location and falling back to the legacy data-dir location during the
+ * transition window (T9405).
+ *
+ * Migration runs at most once per process via {@link ensureGlobalConfigMigrated}
+ * so the data-dir fallback is only reachable when the migration itself failed
+ * (e.g. permission errors) or when a brand-new file lands in the data dir
+ * after the marker was already stamped. Both situations resolve to the legacy
+ * copy so users never get a "key disappeared" surprise.
+ */
+function readGlobalProviderKey(provider: ModelTransport): string | null {
+  ensureGlobalConfigMigrated();
+  const configDirKey = readProviderKeyFromConfig(globalConfigPath(), provider);
+  if (configDirKey) return configDirKey;
+  return readProviderKeyFromConfig(legacyGlobalConfigPath(), provider);
 }
 
 // ---------------------------------------------------------------------------
@@ -302,8 +337,12 @@ export function resolveCredentials(
     }
   }
 
-  // Tier 4a — global config (~/.local/share/cleo/config.json → llm.providers[p].apiKey)
-  const globalKey = readProviderKeyFromConfig(globalConfigPath(), provider);
+  // Tier 4a — global config. Canonical path is the XDG config dir
+  // (`~/.config/cleo/config.json` on Linux); the data-dir copy
+  // (`~/.local/share/cleo/config.json`) is consulted as a read-only fallback
+  // during the transition window so existing installs keep working until
+  // `ensureGlobalConfigMigrated()` upgrades them (T9405).
+  const globalKey = readGlobalProviderKey(provider);
   if (globalKey) {
     return {
       provider,

--- a/packages/core/src/llm/global-config-migration.ts
+++ b/packages/core/src/llm/global-config-migration.ts
@@ -1,0 +1,299 @@
+/**
+ * XDG drift migration for the global CLEO config file (T9405).
+ *
+ * Pre-T9405 history: `globalConfigPath()` resolved to the CLEO **data** dir
+ * (`getCleoHome()`), so existing installs have `config.json` at
+ * `~/.local/share/cleo/config.json`. XDG says user config belongs in
+ * `XDG_CONFIG_HOME` (`~/.config/cleo/config.json`).
+ *
+ * This migration runs on first credentials read after upgrade:
+ *
+ * 1. Skip if the data-dir source is absent.
+ * 2. Skip if the data-dir migration marker exists (idempotent).
+ * 3. Skip if the config-dir target already exists (manual migration / fresh install).
+ * 4. Otherwise:
+ *    a. `mkdir -p` the config dir.
+ *    b. Read the data-dir config.
+ *    c. Validate the JSON parses.
+ *    d. Write to a temp file in the config dir, then atomically rename to the
+ *       final `config.json` (temp-then-rename — never any partial state).
+ *    e. Drop the marker file at `<data-dir>/.migrations/config-dir-v1.done`.
+ *    f. Rename the data-dir original to `config.json.pre-e1-bak` so users can
+ *       recover if something goes wrong.
+ *
+ * Migration is best-effort: every error is swallowed and logged to stderr. A
+ * failed migration must never crash a CLI invocation — credentials resolution
+ * just falls back to the data-dir location via the transition-window logic
+ * baked into `globalConfigPath()`.
+ *
+ * @module llm/global-config-migration
+ * @task T9405
+ * @epic T9398
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { getCleoHome, getCleoPlatformPaths } from '@cleocode/paths';
+
+/**
+ * Filename used by `legacyGlobalConfigPath()` / `configDirGlobalConfigPath()`.
+ *
+ * Kept in one place so the migration helper and the credentials resolver agree
+ * without anyone hard-coding the string in two places.
+ *
+ * @internal
+ */
+export const GLOBAL_CONFIG_FILENAME = 'config.json';
+
+/**
+ * Subdirectory in the data dir where migration markers are stamped.
+ *
+ * @internal
+ */
+const MIGRATIONS_SUBDIR = '.migrations';
+
+/**
+ * Marker filename written when the config-dir migration completes.
+ *
+ * @internal
+ */
+const MIGRATION_MARKER = 'config-dir-v1.done';
+
+/**
+ * Backup suffix appended to the data-dir source after a successful migration.
+ *
+ * Per the E-CONFIG-AUTH-UNIFY spec the original is renamed (not deleted) so
+ * users have a recovery path.
+ *
+ * @internal
+ */
+const BACKUP_SUFFIX = '.pre-e1-bak';
+
+/**
+ * Resolve the canonical config-dir path for the global config file.
+ *
+ * Linux:   `~/.config/cleo/config.json`
+ * macOS:   `~/Library/Preferences/cleo/config.json`
+ * Windows: `%APPDATA%\cleo\Config\config.json`
+ *
+ * @public
+ */
+export function configDirGlobalConfigPath(): string {
+  return join(getCleoPlatformPaths().config, GLOBAL_CONFIG_FILENAME);
+}
+
+/**
+ * Resolve the legacy data-dir path for the global config file.
+ *
+ * Pre-T9405 location. Read-only fallback during the transition window — the
+ * migration moves the contents to {@link configDirGlobalConfigPath} and
+ * renames the data-dir original to `config.json.pre-e1-bak`.
+ *
+ * @public
+ */
+export function legacyGlobalConfigPath(): string {
+  return join(getCleoHome(), GLOBAL_CONFIG_FILENAME);
+}
+
+/**
+ * Path to the migration marker file. Stamped in the data dir (NOT the config
+ * dir) because the marker is tied to "did we already process the legacy
+ * data-dir install?" — co-locating it with the source makes the relationship
+ * obvious and prevents `CLEO_HOME` overrides in tests from clobbering the
+ * config-dir state.
+ *
+ * @internal
+ */
+function migrationMarkerPath(): string {
+  return join(getCleoHome(), MIGRATIONS_SUBDIR, MIGRATION_MARKER);
+}
+
+/**
+ * Path used during atomic write inside the config dir.
+ *
+ * @internal
+ */
+function tempTargetPath(): string {
+  return `${configDirGlobalConfigPath()}.tmp`;
+}
+
+/**
+ * Run the data-dir → config-dir migration if applicable.
+ *
+ * Idempotent: safe to call on every CLEO invocation. Performs at most three
+ * filesystem stat calls in the steady state (marker present OR source absent).
+ *
+ * Never throws. Errors are logged to stderr and swallowed — the credentials
+ * resolver's transition-window logic will still find the legacy data-dir copy.
+ *
+ * @returns `true` when a migration was actually performed, `false` when it was
+ *   a no-op (already migrated, no source, or target already present).
+ *
+ * @task T9405
+ */
+export function migrateGlobalConfigToConfigDir(): boolean {
+  try {
+    const source = legacyGlobalConfigPath();
+    const target = configDirGlobalConfigPath();
+    const marker = migrationMarkerPath();
+
+    // Already ran — fast-path idempotency.
+    if (existsSync(marker)) return false;
+
+    // No legacy source — fresh install or already cleaned up. Stamp the marker
+    // so we don't re-stat on every invocation.
+    if (!existsSync(source)) {
+      stampMarker(marker);
+      return false;
+    }
+
+    // Target already present (manual migration, dual install, or a previous
+    // partial run that completed the rename without dropping the marker).
+    // Stamp the marker and back up the source so the data-dir copy stops
+    // shadowing the config-dir copy.
+    if (existsSync(target)) {
+      backupSourceQuiet(source);
+      stampMarker(marker);
+      return false;
+    }
+
+    // Read + parse-validate the source. Any failure aborts the migration —
+    // we never touch the config dir with content that's not provably JSON.
+    const raw = readFileSync(source, 'utf-8');
+    try {
+      JSON.parse(raw);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[cleo] global config migration skipped: ${source} is not valid JSON (${
+          (err as Error).message
+        })`,
+      );
+      return false;
+    }
+
+    // Ensure the config dir exists.
+    mkdirSync(getCleoPlatformPaths().config, { recursive: true });
+
+    // Atomic temp-then-rename: write to a sibling temp file, then rename onto
+    // the final path. rename(2) is atomic on the same filesystem (always true
+    // here — both paths are inside the config dir).
+    const temp = tempTargetPath();
+    writeFileSync(temp, raw, { mode: 0o644 });
+    renameSync(temp, target);
+
+    // Stamp the migration marker — must come BEFORE the source rename so a
+    // crash between rename(temp→target) and marker write doesn't leave the
+    // resolver finding both copies on the next run (the transition-window
+    // logic already handles that, but the marker is the cheaper steady state).
+    stampMarker(marker);
+
+    // Rename the source to the backup name. We use renameSync (not copyFile +
+    // unlink) so the operation is atomic on the same filesystem — once the
+    // data-dir entry stops existing the resolver's transition-window check
+    // can't accidentally pick up the legacy copy.
+    try {
+      renameSync(source, `${source}${BACKUP_SUFFIX}`);
+    } catch (err) {
+      // Best-effort: the migration is logically complete even if the rename
+      // fails (the resolver prefers the config dir). Log + continue.
+      // eslint-disable-next-line no-console
+      console.error(
+        `[cleo] global config migrated, but backup rename failed: ${
+          (err as Error).message
+        }. The legacy file at ${source} can be removed manually.`,
+      );
+    }
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `[cleo] migrated global config: ${source} → ${target} (backup at ${source}${BACKUP_SUFFIX})`,
+    );
+    return true;
+  } catch (err) {
+    // Last-resort safety net — clean up any partial temp file we left behind.
+    try {
+      const temp = tempTargetPath();
+      if (existsSync(temp)) unlinkSync(temp);
+    } catch {
+      // ignore
+    }
+    // eslint-disable-next-line no-console
+    console.error(
+      `[cleo] global config migration failed: ${(err as Error).message}. Credentials will continue to resolve from the legacy data-dir location.`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Stamp the migration marker file. Best-effort — errors are swallowed.
+ *
+ * @internal
+ */
+function stampMarker(markerPath: string): void {
+  try {
+    mkdirSync(join(getCleoHome(), MIGRATIONS_SUBDIR), { recursive: true });
+    writeFileSync(markerPath, `${new Date().toISOString()}\n`, { mode: 0o644 });
+  } catch {
+    // ignore — a missing marker just means we'll re-stat once more next run.
+  }
+}
+
+/**
+ * Best-effort rename of the legacy source to the backup name. Silent failure.
+ *
+ * @internal
+ */
+function backupSourceQuiet(source: string): void {
+  try {
+    const backup = `${source}${BACKUP_SUFFIX}`;
+    if (existsSync(backup)) return; // already backed up
+    renameSync(source, backup);
+  } catch {
+    // ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// First-invocation latch
+// ---------------------------------------------------------------------------
+
+let hasRunInProcess = false;
+
+/**
+ * Run the migration at most once per Node process.
+ *
+ * Called from the credentials resolver before reading `globalConfigPath()` so
+ * a stale install is upgraded in-place on first credentials read. The latch
+ * keeps the steady-state cost at one boolean check after the first call —
+ * essential because `resolveCredentials()` is on the hot path of every LLM
+ * call.
+ *
+ * Use {@link _resetGlobalConfigMigrationLatch} in tests to re-arm the latch.
+ *
+ * @public
+ */
+export function ensureGlobalConfigMigrated(): void {
+  if (hasRunInProcess) return;
+  hasRunInProcess = true;
+  migrateGlobalConfigToConfigDir();
+}
+
+/**
+ * Reset the in-process migration latch. Test-only — use in `beforeEach` so
+ * each test re-runs the migration with its own fresh `XDG_*` / `CLEO_HOME`
+ * overrides.
+ *
+ * @internal
+ */
+export function _resetGlobalConfigMigrationLatch(): void {
+  hasRunInProcess = false;
+}

--- a/packages/paths/src/cleo-paths.ts
+++ b/packages/paths/src/cleo-paths.ts
@@ -19,7 +19,7 @@ import {
 
 const TEMPLATES_SUBDIR = 'templates';
 
-const cleoResolver = createPlatformPathsResolver('cleo', 'CLEO_HOME');
+const cleoResolver = createPlatformPathsResolver('cleo', 'CLEO_HOME', 'CLEO_CONFIG_HOME');
 
 /**
  * Get OS-appropriate paths for CLEO's global directories.

--- a/packages/paths/src/platform-paths.ts
+++ b/packages/paths/src/platform-paths.ts
@@ -141,15 +141,24 @@ function resolveHomeOverride(value: string | undefined): string | undefined {
 export function createPlatformPathsResolver(
   appName: string,
   homeEnvVar: string,
+  configEnvVar?: string,
 ): PlatformPathsResolver {
   let cachedSysInfo: SystemInfo | null = null;
 
   function readPlatformPaths(): PlatformPaths {
     const ep = envPaths(appName, { suffix: '' });
-    const override = resolveHomeOverride(process.env[homeEnvVar]);
+    const dataOverride = resolveHomeOverride(process.env[homeEnvVar]);
+    // env-paths reads XDG_CONFIG_HOME on Linux only — macOS returns
+    // ~/Library/Preferences/<app> and Windows returns %APPDATA%\<app>\Config
+    // regardless of any env var. Cross-platform tests need a way to redirect
+    // the config dir; honor `configEnvVar` (T9405) the same way `homeEnvVar`
+    // overrides the data dir.
+    const configOverride = configEnvVar
+      ? resolveHomeOverride(process.env[configEnvVar])
+      : undefined;
     return {
-      data: override ?? ep.data,
-      config: ep.config,
+      data: dataOverride ?? ep.data,
+      config: configOverride ?? ep.config,
       cache: ep.cache,
       log: ep.log,
       temp: ep.temp,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -41,6 +41,17 @@ const sandbox = mkdtempSync(join(tmpdir(), 'cleo-vitest-fork-'));
 if (!process.env.CLEO_HOME) {
   process.env.CLEO_HOME = sandbox;
 }
+// T9405: getCleoPlatformPaths().config now resolves the global config file
+// (config.json) — formerly under CLEO_HOME. env-paths reads XDG_CONFIG_HOME /
+// XDG_CACHE_HOME, so pin them to the per-fork sandbox too. Without these, a
+// test that writes to globalConfigPath() lands in the real user's
+// ~/.config/cleo and persists across runs.
+if (!process.env.XDG_CONFIG_HOME) {
+  process.env.XDG_CONFIG_HOME = join(sandbox, 'config-home');
+}
+if (!process.env.XDG_CACHE_HOME) {
+  process.env.XDG_CACHE_HOME = join(sandbox, 'cache-home');
+}
 if (!process.env.NEXUS_HOME) {
   process.env.NEXUS_HOME = join(sandbox, 'nexus');
 }


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E1 §5.1 T-E1-3. config.json now lives in the XDG config dir (`~/.config/cleo` on Linux) instead of the data dir. Adds an atomic, idempotent migration helper that detects legacy installs at `~/.local/share/cleo/config.json`, copies them to the config dir using temp-then-rename, validates JSON, drops a `.migrated-from-data-dir` marker, and renames the data-dir original to `config.json.pre-e1-bak`.

Resolver checks both locations during the transition window — config-dir wins, data-dir triggers the migration.

## Changes
- `packages/core/src/llm/credentials.ts` — `globalConfigPath()` returns `getCleoPlatformPaths().config + '/config.json'`; new `readGlobalProviderKey()` helper checks both locations during transition
- `packages/core/src/llm/global-config-migration.ts` (new) — atomic temp+rename, marker-gated idempotency, `.pre-e1-bak` backup, JSON-parse validation, in-process latch
- `packages/core/src/llm/__tests__/global-config-migration.test.ts` (new) — 10 unit tests
- `vitest.setup.ts` — pin `XDG_CONFIG_HOME` + `XDG_CACHE_HOME` to prevent test pollution into the developer's real config dir
- 5 LLM test files — pin `XDG_CONFIG_HOME` per-test; reset `_resetCleoPlatformPathsCache()` + `_resetGlobalConfigMigrationLatch()` between tests

## Test plan
- [x] 78/78 LLM credential tests pass (6 affected files: credentials, credentials-auth-type, migration, role-resolver*, global-config-migration)
- [x] Full `@cleocode/core` suite: only pre-existing `E_INVALID_PROJECT_ROOT` worktree-only failures (16 tests, verified by stash baseline re-run)
- [x] biome + build clean

## Refs
- `docs/plans/E-CONFIG-AUTH-UNIFY.md` §5.1 T-E1-3
- Epic: T9399, Master: T9500