### PR TITLE
feat(T9409): add env credential seeder for all LLM providers

### DIFF
--- a/packages/core/src/llm/credential-seeders/__tests__/env-seeder.test.ts
+++ b/packages/core/src/llm/credential-seeders/__tests__/env-seeder.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for `EnvSeeder` and `registerEnvSeeders` (T9409).
+ *
+ * Scope:
+ *
+ * - Env var set → emits one entry, trimmed, tagged `source:'env'`.
+ * - Env var unset / empty / whitespace-only → emits zero entries.
+ * - Wrong-provider env var stays inert for unrelated seeders.
+ * - `isConsentEstablished` returns `true` unconditionally.
+ * - `registerEnvSeeders` populates one entry per provider in `ENV_VARS`.
+ * - Module-load side effect populates `BUILTIN_SEEDERS`.
+ *
+ * Cross-platform isolation uses the canonical `SAVED_ENV` pattern from
+ * `__tests__/global-config-migration.test.ts`: every test saves the
+ * affected env keys, clears them, runs, and restores so a stray
+ * developer-local `ANTHROPIC_API_KEY` does not leak into assertions.
+ *
+ * @task T9409
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ENV_VARS } from '../../credentials.js';
+import type { ModelTransport } from '../../types-config.js';
+import { ENV_SEEDER_PRIORITY, EnvSeeder, registerEnvSeeders } from '../env-seeder.js';
+import {
+  BUILTIN_SEEDERS,
+  type CredentialSeeder,
+  SeederRegistry,
+  type SeederSourceId,
+} from '../index.js';
+
+// ---------------------------------------------------------------------------
+// Env isolation (cross-platform — save/restore every provider env var
+// plus `CLEO_HOME` and the XDG keys so paths-based tests cannot leak)
+// ---------------------------------------------------------------------------
+
+const ENV_KEYS = [
+  ...Object.values(ENV_VARS),
+  'CLEO_HOME',
+  'CLEO_CONFIG_HOME',
+  'CLEO_DIR',
+  'XDG_DATA_HOME',
+  'XDG_CONFIG_HOME',
+];
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+
+function clearProviderEnv(): void {
+  for (const k of Object.values(ENV_VARS)) delete process.env[k];
+}
+
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+beforeEach(() => {
+  saveEnv();
+  clearProviderEnv();
+});
+
+afterEach(() => {
+  restoreEnv();
+});
+
+// ---------------------------------------------------------------------------
+// EnvSeeder — single-provider behaviour
+// ---------------------------------------------------------------------------
+
+describe('EnvSeeder', () => {
+  describe('contract', () => {
+    it('exposes sourceId="env" and the requested provider', () => {
+      const seeder = new EnvSeeder('anthropic');
+      expect(seeder.sourceId).toBe('env');
+      expect(seeder.provider).toBe('anthropic');
+    });
+
+    it('snapshots the canonical env var name at construction', () => {
+      expect(new EnvSeeder('anthropic').envVarName).toBe('ANTHROPIC_API_KEY');
+      expect(new EnvSeeder('openai').envVarName).toBe('OPENAI_API_KEY');
+      expect(new EnvSeeder('ollama').envVarName).toBe('OLLAMA_HOST');
+    });
+
+    it('throws when constructed for a provider without a canonical env var', () => {
+      // Type system blocks the literal in real callers — cast here to
+      // simulate a programmer error and assert the runtime guard fires.
+      expect(() => new EnvSeeder('not-a-real-provider' as ModelTransport)).toThrow(
+        /E_ENV_SEEDER_UNKNOWN_PROVIDER.*provider='not-a-real-provider'/,
+      );
+    });
+
+    it('reports consent established unconditionally', () => {
+      const seeder = new EnvSeeder('anthropic');
+      expect(seeder.isConsentEstablished()).toBe(true);
+    });
+  });
+
+  describe('seed()', () => {
+    it('emits one entry when the env var is set to a non-empty value', async () => {
+      process.env['ANTHROPIC_API_KEY'] = 'sk-ant-key-abc';
+      const seeder = new EnvSeeder('anthropic');
+
+      const result = await seeder.seed();
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0]).toEqual({
+        provider: 'anthropic',
+        label: 'env:ANTHROPIC_API_KEY',
+        authType: 'api_key',
+        source: 'env',
+        accessToken: 'sk-ant-key-abc',
+        priority: ENV_SEEDER_PRIORITY,
+      });
+      expect(result.warnings).toBeUndefined();
+    });
+
+    it('trims surrounding whitespace from the env var value', async () => {
+      process.env['OPENAI_API_KEY'] = '   sk-openai-trimmed   \n';
+      const seeder = new EnvSeeder('openai');
+
+      const result = await seeder.seed();
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0]?.accessToken).toBe('sk-openai-trimmed');
+      expect(result.entries[0]?.label).toBe('env:OPENAI_API_KEY');
+    });
+
+    it('emits zero entries when the env var is unset', async () => {
+      // beforeEach already deleted the provider env vars — assert explicitly
+      expect(process.env['ANTHROPIC_API_KEY']).toBeUndefined();
+      const seeder = new EnvSeeder('anthropic');
+
+      const result = await seeder.seed();
+
+      expect(result.entries).toEqual([]);
+    });
+
+    it('emits zero entries when the env var is the empty string', async () => {
+      process.env['GEMINI_API_KEY'] = '';
+      const seeder = new EnvSeeder('gemini');
+
+      const result = await seeder.seed();
+
+      expect(result.entries).toEqual([]);
+    });
+
+    it('emits zero entries when the env var is whitespace-only', async () => {
+      process.env['MOONSHOT_API_KEY'] = '   \t \n  ';
+      const seeder = new EnvSeeder('moonshot');
+
+      const result = await seeder.seed();
+
+      expect(result.entries).toEqual([]);
+    });
+
+    it('ignores env vars belonging to other providers', async () => {
+      // Set OpenAI's env var; the Anthropic seeder MUST NOT see it.
+      process.env['OPENAI_API_KEY'] = 'sk-openai-only';
+      const anthropicSeeder = new EnvSeeder('anthropic');
+
+      const result = await anthropicSeeder.seed();
+
+      expect(result.entries).toEqual([]);
+    });
+
+    it('handles ollama (OLLAMA_HOST) which is informational not a key', async () => {
+      // The mapping intentionally exposes OLLAMA_HOST for ollama. When set,
+      // the seeder treats the host URL the same as an api_key entry — pool
+      // policy (T9412) decides whether ollama actually consumes it.
+      process.env['OLLAMA_HOST'] = 'http://localhost:11434';
+      const seeder = new EnvSeeder('ollama');
+
+      const result = await seeder.seed();
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0]?.accessToken).toBe('http://localhost:11434');
+      expect(result.entries[0]?.label).toBe('env:OLLAMA_HOST');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerEnvSeeders — registry-level behaviour
+// ---------------------------------------------------------------------------
+
+describe('registerEnvSeeders', () => {
+  it('registers one env seeder per provider in ENV_VARS into a fresh registry', () => {
+    const registry = new SeederRegistry();
+    registerEnvSeeders(registry);
+
+    const providerCount = Object.keys(ENV_VARS).length;
+    expect(registry.getAll()).toHaveLength(providerCount);
+
+    for (const provider of Object.keys(ENV_VARS) as ModelTransport[]) {
+      const matches = registry.getByProvider(provider);
+      expect(matches).toHaveLength(1);
+      const seeder = matches[0] as CredentialSeeder & { envVarName?: string };
+      expect(seeder.sourceId).toBe<SeederSourceId>('env');
+      expect(seeder.provider).toBe(provider);
+      // Property visible because the entry is an EnvSeeder instance.
+      expect(seeder.envVarName).toBe(ENV_VARS[provider]);
+    }
+  });
+
+  it('throws E_SEEDER_DUPLICATE when called twice on the same registry', () => {
+    const registry = new SeederRegistry();
+    registerEnvSeeders(registry);
+    expect(() => registerEnvSeeders(registry)).toThrow(/E_SEEDER_DUPLICATE/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BUILTIN_SEEDERS — module-load side effect populated the singleton
+// ---------------------------------------------------------------------------
+
+describe('BUILTIN_SEEDERS module-load registration', () => {
+  it('has an env seeder for every provider in ENV_VARS', () => {
+    for (const provider of Object.keys(ENV_VARS) as ModelTransport[]) {
+      const matches = BUILTIN_SEEDERS.getByProvider(provider).filter((s) => s.sourceId === 'env');
+      expect(matches, `expected one env seeder for provider='${provider}'`).toHaveLength(1);
+    }
+  });
+
+  it('env seeders in the singleton produce trimmed entries tagged source:"env"', async () => {
+    process.env['XAI_API_KEY'] = '  xai-token-99  ';
+
+    const seeders = BUILTIN_SEEDERS.getByProvider('xai').filter((s) => s.sourceId === 'env');
+    expect(seeders).toHaveLength(1);
+
+    const seeder = seeders[0];
+    expect(seeder).toBeDefined();
+    const result = await (seeder as CredentialSeeder).seed();
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      provider: 'xai',
+      source: 'env',
+      authType: 'api_key',
+      label: 'env:XAI_API_KEY',
+      accessToken: 'xai-token-99',
+    });
+  });
+});

--- a/packages/core/src/llm/credential-seeders/env-seeder.ts
+++ b/packages/core/src/llm/credential-seeders/env-seeder.ts
@@ -1,0 +1,183 @@
+/**
+ * Environment-variable credential seeder (E-CONFIG-AUTH-UNIFY E2a / T9409).
+ *
+ * Implements `CredentialSeeder` for every provider in the canonical
+ * `ENV_VARS` mapping (re-exported from `../credentials.ts`). On `seed()`,
+ * each instance reads `process.env[ENV_VARS[provider]]`; when the variable
+ * is set to a non-empty (post-trim) string, the seeder emits a single
+ * `SeederCredentialEntry` tagged with `source: 'env'` so downstream pool
+ * code can attribute the credential back to the environment.
+ *
+ * ## Architectural mirror
+ *
+ * This is the architectural mirror of Hermes Agent's `_seed_from_env`
+ * dispatch (`agent/credential_pool.py:1187` — see plan E2a §5.2 T-E2-2).
+ * One instance handles exactly one `(sourceId='env', provider)` pair so
+ * registry lookups via `getByProvider` stay clean.
+ *
+ * ## Consent gate
+ *
+ * Env vars are first-party config — the operator already exported them
+ * deliberately. No external file consent is required, so
+ * `isConsentEstablished` returns `true` unconditionally.
+ *
+ * ## Priority
+ *
+ * Each entry advertises `priority: 50` per the E2a §5.2 T-E2-2 spec.
+ * Pool tier ordering is finalised in T9412; until then this value is
+ * informational — the credential store's `max + 10` rule still applies
+ * if the seeder bypasses the explicit priority hint at upsert time.
+ *
+ * ## Behavioral note
+ *
+ * No production code path consumes `BUILTIN_SEEDERS` yet — T9413 wires
+ * the registry into the async resolver. Registering env seeders here is
+ * a pure-additive change: the legacy 6-tier `resolveCredentials()` ladder
+ * still owns the active resolution path.
+ *
+ * @module llm/credential-seeders/env-seeder
+ * @task T9409
+ * @epic E-CONFIG-AUTH-UNIFY (E2a)
+ */
+
+import { ENV_VARS } from '../credentials.js';
+import type { ModelTransport } from '../types-config.js';
+import { BUILTIN_SEEDERS, type CredentialSeeder, type SeederResult } from './index.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Default priority hint emitted by every env-seeded entry.
+ *
+ * Documented for forward-compat — see plan §5.2 T-E2-2. The pool tier
+ * ordering (T9412) will canonicalise relative priority across all
+ * seeders; until then, downstream consumers SHOULD NOT depend on the
+ * literal value beyond "env-seeded entries share one stable priority".
+ *
+ * @task T9409
+ */
+export const ENV_SEEDER_PRIORITY = 50;
+
+// ---------------------------------------------------------------------------
+// EnvSeeder class
+// ---------------------------------------------------------------------------
+
+/**
+ * Credential seeder that pulls a single provider's API key from
+ * `process.env[ENV_VARS[provider]]`.
+ *
+ * One instance handles one provider. The `BUILTIN_SEEDERS` registry is
+ * populated at module load with one `EnvSeeder` for every provider in the
+ * canonical `ENV_VARS` mapping — see `registerEnvSeeders()` below.
+ *
+ * @task T9409
+ */
+export class EnvSeeder implements CredentialSeeder {
+  /** Constant tag — every env-seeded entry attributes back to `'env'`. */
+  readonly sourceId = 'env' as const;
+
+  /** Provider transport this seeder reads the env var for. */
+  readonly provider: ModelTransport;
+
+  /**
+   * Canonical env var name for this provider (e.g. `'ANTHROPIC_API_KEY'`).
+   *
+   * Snapshotted at construction from the shared `ENV_VARS` mapping so the
+   * seeder's behaviour is deterministic for the lifetime of the instance,
+   * even if a future refactor mutates the mapping.
+   */
+  readonly envVarName: string;
+
+  /**
+   * Construct an env seeder for a specific provider.
+   *
+   * @param provider - Provider transport (must have an entry in `ENV_VARS`).
+   * @throws {Error} `E_ENV_SEEDER_UNKNOWN_PROVIDER` when the provider has
+   *   no canonical env var registered in `ENV_VARS`. This is a
+   *   programmer-error guard — runtime callers never construct seeders
+   *   from arbitrary strings.
+   */
+  constructor(provider: ModelTransport) {
+    const envVarName = ENV_VARS[provider];
+    if (!envVarName) {
+      throw new Error(
+        `E_ENV_SEEDER_UNKNOWN_PROVIDER: no canonical env var registered for provider='${provider}'`,
+      );
+    }
+    this.provider = provider;
+    this.envVarName = envVarName;
+  }
+
+  /**
+   * Read the env var and emit zero or one credential entry.
+   *
+   * - Empty or unset env var → `{ entries: [] }` (NOT an error).
+   * - Whitespace-only value → `{ entries: [] }`.
+   * - Non-empty value → one entry with the trimmed token, tagged
+   *   `source: 'env'`, `authType: 'api_key'`, `priority: 50`.
+   *
+   * Never throws — env access is synchronous and side-effect-free.
+   *
+   * @returns `SeederResult` describing the discovered credential, if any.
+   */
+  async seed(): Promise<SeederResult> {
+    const raw = process.env[this.envVarName];
+    if (raw === undefined) return { entries: [] };
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) return { entries: [] };
+    return {
+      entries: [
+        {
+          provider: this.provider,
+          label: `env:${this.envVarName}`,
+          authType: 'api_key',
+          source: 'env',
+          accessToken: trimmed,
+          priority: ENV_SEEDER_PRIORITY,
+        },
+      ],
+    };
+  }
+
+  /**
+   * Env vars are first-party — no external consent gate.
+   *
+   * The operator explicitly exported the variable, so the constructor's
+   * implied consent applies. Returning `true` keeps the resolver's
+   * dispatch table simple.
+   */
+  isConsentEstablished(): boolean {
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register an `EnvSeeder` for every provider in `ENV_VARS` into the supplied
+ * registry. Exposed so tests can exercise registration semantics against a
+ * fresh `SeederRegistry()` without mutating the process-wide singleton.
+ *
+ * @param registry - Target registry (defaults to `BUILTIN_SEEDERS` so the
+ *   module-load side effect uses the singleton path).
+ * @task T9409
+ */
+export function registerEnvSeeders(registry = BUILTIN_SEEDERS): void {
+  for (const provider of Object.keys(ENV_VARS) as ModelTransport[]) {
+    registry.register(new EnvSeeder(provider));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-load side effect — populate BUILTIN_SEEDERS
+// ---------------------------------------------------------------------------
+
+// Eagerly register env seeders into the process-wide singleton. Importing
+// this module exactly once (per Node ESM cache semantics) guarantees every
+// provider in `ENV_VARS` has an env seeder available via
+// `BUILTIN_SEEDERS.getByProvider(provider)`.
+registerEnvSeeders();

--- a/packages/core/src/llm/credential-seeders/index.ts
+++ b/packages/core/src/llm/credential-seeders/index.ts
@@ -244,9 +244,11 @@ export class SeederRegistry {
 /**
  * Process-wide singleton registry used by the resolver.
  *
- * Future tasks (T9409+) register concrete seeder instances into this
- * registry at module load. As of T9408 it is **empty** — no production
- * code path consumes `BUILTIN_SEEDERS` yet.
+ * Concrete seeder modules (e.g. `./env-seeder.ts`, registered in T9409)
+ * import this singleton and call `register()` at module load. The
+ * `./register.ts` barrel module aggregates those side-effect imports so a
+ * single `import './credential-seeders/register.js'` populates every
+ * built-in seeder.
  *
  * The singleton is a module-scoped constant (`export const`) rather than a
  * class static so re-importing this module from different entry points

--- a/packages/core/src/llm/credential-seeders/register.ts
+++ b/packages/core/src/llm/credential-seeders/register.ts
@@ -1,0 +1,33 @@
+/**
+ * Side-effect barrel that wires concrete credential seeders into the
+ * `BUILTIN_SEEDERS` singleton (E-CONFIG-AUTH-UNIFY E2a / T9409).
+ *
+ * Importing this module once at any entry point triggers each concrete
+ * seeder's module-load registration side effect:
+ *
+ * - `./env-seeder.ts` — registers one `EnvSeeder` per provider in
+ *   `ENV_VARS`.
+ *
+ * Future tasks add more side-effect imports here (claude-code seeder,
+ * cleo-pkce seeder, codex-cli seeder, gemini-cli seeder, gh-cli seeder).
+ *
+ * ## Why a separate barrel?
+ *
+ * Keeping the side-effect import out of `./index.ts` lets consumers pick
+ * either the type-only surface (`import type { CredentialSeeder } from
+ * './index.js'`) without paying the registration cost, OR the populated
+ * registry (`import './register.js'; import { BUILTIN_SEEDERS } from
+ * './index.js'`) when they actually need the seeders.
+ *
+ * The top-level `packages/core/src/llm/index.ts` re-exports `register.js`
+ * so any consumer of `@cleocode/core/llm` automatically gets the populated
+ * registry — see T9409's `llm/index.ts` patch.
+ *
+ * @module llm/credential-seeders/register
+ * @task T9409
+ */
+
+// Side-effect import — pulls in env-seeder's module-load registration
+// against `BUILTIN_SEEDERS`. The file exports the `EnvSeeder` class for
+// direct construction; the registration happens during module evaluation.
+import './env-seeder.js';

--- a/packages/core/src/llm/credentials.ts
+++ b/packages/core/src/llm/credentials.ts
@@ -130,8 +130,15 @@ export interface CredentialResolveOptions {
  * chain (`AWS_PROFILE` / `~/.aws/credentials` / IAM role / SSO), not a single
  * API-key env var. The credential-pool resolves Bedrock via `authType: 'aws_sdk'`
  * and never reads the `accessToken` field from env.
+ *
+ * Exported so concrete seeders (e.g. the env seeder under
+ * `./credential-seeders/env-seeder.ts`) reuse the same mapping instead of
+ * inlining a duplicate. Treat this as the single source of truth for
+ * `(provider → env var name)`.
+ *
+ * @task T9409
  */
-const ENV_VARS: Record<ModelTransport, string> = {
+export const ENV_VARS: Record<ModelTransport, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',
   gemini: 'GEMINI_API_KEY',

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -85,6 +85,17 @@ export {
 // Conversation utilities
 export { countMessageTokens, truncateMessagesToFit } from './conversation.js';
 // Credential seeders — unified pool foundation (E-CONFIG-AUTH-UNIFY E2a / T9408)
+// T9409 adds the concrete `EnvSeeder` and the `./register.js` barrel that
+// populates `BUILTIN_SEEDERS` at module load. Importing this `llm/index.js`
+// implicitly imports `register.js` so consumers of `@cleocode/core/llm` get
+// the populated singleton without an explicit second import.
+import './credential-seeders/register.js';
+
+export {
+  ENV_SEEDER_PRIORITY,
+  EnvSeeder,
+  registerEnvSeeders,
+} from './credential-seeders/env-seeder.js';
 export type {
   CredentialSeeder,
   SeederCredentialEntry,


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E2a §5.2 T-E2-2. First concrete `CredentialSeeder`. Reads `ENV_VARS[provider]` from `process.env`, emits typed pool entries tagged `source:env` with label `env:VAR_NAME`.

## Behavior
- Implements `EnvSeeder` for **11 providers** from canonical `ENV_VARS` mapping: anthropic, openai, gemini, moonshot, openrouter, bedrock, deepseek, xai, groq, kimi-code, ollama
- `isConsentEstablished` returns `true` (no external file consent needed)
- Side-effect `register.ts` barrel auto-registers all 11 seeders into `BUILTIN_SEEDERS` at module load
- Side-effect import added to `packages/core/src/llm/index.ts`
- `ENV_VARS` mapping now exported from `credentials.ts` (was private const) — single source of truth

No behavioral change yet: T9413 wires `BUILTIN_SEEDERS` into the active resolver path. This PR adds the seeder + tests.

## Test plan
- [x] 16/16 new env-seeder tests pass (contract, seed paths, registration semantics)
- [x] 786/786 `@cleocode/core` llm-subtree tests pass
- [x] Full suite: only pre-existing `E_INVALID_PROJECT_ROOT` worktree failures (no new regressions)
- [x] biome + build + typecheck clean

## Refs
- `docs/plans/E-CONFIG-AUTH-UNIFY.md` §5.2 T-E2-2
- Epic: T9400, Master: T9500