### PR TITLE
feat(T9415): add RemovalStep registry + per-source removal handlers

### DIFF
--- a/packages/core/src/llm/__tests__/credential-removal.test.ts
+++ b/packages/core/src/llm/__tests__/credential-removal.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Unit tests for `credential-removal.ts` (T9415 — RemovalStep registry +
+ * suppression-state persistence).
+ *
+ * Isolation strategy: each test sets `CLEO_HOME` (and `XDG_DATA_HOME`,
+ * `HOME` so `getCleoHome` fallback paths don't leak to developer data) to
+ * a unique temp directory. Mirrors the pattern used by
+ * `rate-limit-guard.test.ts`.
+ *
+ * @task T9415
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readJsonFile } from '../../store/file-utils.js';
+import {
+  addSuppression,
+  buildBuiltinRemovalRegistry,
+  CLAUDE_CODE_REMOVAL_STEP,
+  CLEO_PKCE_REMOVAL_STEP,
+  CODEX_CLI_REMOVAL_STEP,
+  ENV_REMOVAL_STEP,
+  GEMINI_CLI_REMOVAL_STEP,
+  GH_CLI_REMOVAL_STEP,
+  isSuppressed,
+  MANUAL_REMOVAL_STEP,
+  REMOVAL_REGISTRY,
+  RemovalRegistry,
+  type RemovalStep,
+  readSuppressionFile,
+  removeSuppression,
+  type SuppressionFile,
+  suppressionStatePath,
+  writeSuppressionFile,
+} from '../credential-removal.js';
+
+// ---------------------------------------------------------------------------
+// Environment isolation helpers
+// ---------------------------------------------------------------------------
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const ENV_KEYS = ['XDG_DATA_HOME', 'CLEO_HOME', 'HOME'];
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+function isolateHomes(): string {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const xdgRoot = join(tmpdir(), `cleo-rmv-xdg-${stamp}`);
+  const home = join(tmpdir(), `cleo-rmv-home-${stamp}`);
+  const cleoHome = join(xdgRoot, 'cleo');
+  mkdirSync(cleoHome, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  process.env['XDG_DATA_HOME'] = xdgRoot;
+  process.env['CLEO_HOME'] = cleoHome;
+  process.env['HOME'] = home;
+  return cleoHome;
+}
+
+beforeEach(() => {
+  saveEnv();
+});
+
+afterEach(() => {
+  restoreEnv();
+});
+
+// ---------------------------------------------------------------------------
+// RemovalRegistry — dispatch contract
+// ---------------------------------------------------------------------------
+
+describe('RemovalRegistry', () => {
+  it('register + find — round-trips a single step', () => {
+    const registry = new RemovalRegistry();
+    const step: RemovalStep = {
+      sourceId: 'env',
+      description: 'test',
+      async remove() {
+        return { cleaned: [], hints: [], suppress: true };
+      },
+    };
+
+    registry.register(step);
+    expect(registry.find('env')).toBe(step);
+  });
+
+  it('find returns undefined for an unregistered sourceId', () => {
+    const registry = new RemovalRegistry();
+    expect(registry.find('env')).toBeUndefined();
+  });
+
+  it('rejects a duplicate sourceId registration', () => {
+    const registry = new RemovalRegistry();
+    const make = (): RemovalStep => ({
+      sourceId: 'env',
+      description: 'dup',
+      async remove() {
+        return { cleaned: [], hints: [], suppress: true };
+      },
+    });
+
+    registry.register(make());
+    expect(() => registry.register(make())).toThrow(/E_REMOVAL_DUPLICATE.*sourceId='env'/);
+  });
+
+  it('getAll preserves insertion order', () => {
+    const registry = new RemovalRegistry();
+    const a: RemovalStep = {
+      sourceId: 'env',
+      description: 'a',
+      async remove() {
+        return { cleaned: [], hints: [], suppress: true };
+      },
+    };
+    const b: RemovalStep = {
+      sourceId: 'manual',
+      description: 'b',
+      async remove() {
+        return { cleaned: [], hints: [], suppress: false };
+      },
+    };
+    registry.register(a);
+    registry.register(b);
+    expect(registry.getAll()).toEqual([a, b]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Built-in registry — every SeederSourceId is covered
+// ---------------------------------------------------------------------------
+
+describe('buildBuiltinRemovalRegistry + REMOVAL_REGISTRY singleton', () => {
+  it('registers a step for every known SeederSourceId', () => {
+    const registry = buildBuiltinRemovalRegistry();
+    const sourceIds = [
+      'manual',
+      'env',
+      'claude-code',
+      'cleo-pkce',
+      'codex-cli',
+      'gemini-cli',
+      'gh-cli',
+    ] as const;
+    for (const id of sourceIds) {
+      expect(registry.find(id), `missing step for ${id}`).toBeDefined();
+    }
+    expect(registry.getAll()).toHaveLength(sourceIds.length);
+  });
+
+  it('the REMOVAL_REGISTRY singleton has all 7 steps', () => {
+    expect(REMOVAL_REGISTRY.getAll()).toHaveLength(7);
+    expect(REMOVAL_REGISTRY.find('manual')).toBe(MANUAL_REMOVAL_STEP);
+    expect(REMOVAL_REGISTRY.find('env')).toBe(ENV_REMOVAL_STEP);
+    expect(REMOVAL_REGISTRY.find('claude-code')).toBe(CLAUDE_CODE_REMOVAL_STEP);
+    expect(REMOVAL_REGISTRY.find('cleo-pkce')).toBe(CLEO_PKCE_REMOVAL_STEP);
+    expect(REMOVAL_REGISTRY.find('codex-cli')).toBe(CODEX_CLI_REMOVAL_STEP);
+    expect(REMOVAL_REGISTRY.find('gemini-cli')).toBe(GEMINI_CLI_REMOVAL_STEP);
+    expect(REMOVAL_REGISTRY.find('gh-cli')).toBe(GH_CLI_REMOVAL_STEP);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-step behaviour
+// ---------------------------------------------------------------------------
+
+describe('MANUAL_REMOVAL_STEP', () => {
+  it('returns suppress=false and an llm-credentials hint', async () => {
+    const result = await MANUAL_REMOVAL_STEP.remove({
+      provider: 'anthropic',
+      label: 'manual-1',
+    });
+    expect(result.cleaned).toEqual([]);
+    expect(result.hints).toEqual(['entry removed from llm-credentials.json']);
+    expect(result.suppress).toBe(false);
+  });
+});
+
+describe('ENV_REMOVAL_STEP', () => {
+  it('returns suppress=true with a shell-unset hint', async () => {
+    const result = await ENV_REMOVAL_STEP.remove({
+      provider: 'anthropic',
+      label: 'env',
+    });
+    expect(result.cleaned).toEqual([]);
+    expect(result.hints).toEqual(['Unset $VARNAME in your shell to prevent re-seeding']);
+    expect(result.suppress).toBe(true);
+  });
+});
+
+describe('CLAUDE_CODE_REMOVAL_STEP', () => {
+  it('warns against deleting ~/.claude/.credentials.json and suppresses', async () => {
+    const result = await CLAUDE_CODE_REMOVAL_STEP.remove({
+      provider: 'anthropic',
+      label: 'imported',
+    });
+    expect(result.cleaned).toEqual([]);
+    expect(result.hints[0]).toMatch(/Do NOT delete ~\/.claude\/.credentials\.json/);
+    expect(result.suppress).toBe(true);
+  });
+});
+
+describe('CLEO_PKCE_REMOVAL_STEP', () => {
+  it('deletes anthropic-oauth.json when present and reports it as cleaned', async () => {
+    const cleoHome = isolateHomes();
+    const oauthPath = join(cleoHome, 'anthropic-oauth.json');
+    writeFileSync(oauthPath, JSON.stringify({ token: 'tok' }), 'utf-8');
+    expect(existsSync(oauthPath)).toBe(true);
+
+    const result = await CLEO_PKCE_REMOVAL_STEP.remove({
+      provider: 'anthropic',
+      label: 'pkce',
+    });
+
+    expect(existsSync(oauthPath)).toBe(false);
+    expect(result.cleaned).toEqual([oauthPath]);
+    expect(result.suppress).toBe(true);
+  });
+
+  it('is idempotent — missing token file yields empty cleaned + no throw', async () => {
+    isolateHomes();
+    const result = await CLEO_PKCE_REMOVAL_STEP.remove({
+      provider: 'anthropic',
+      label: 'pkce',
+    });
+    expect(result.cleaned).toEqual([]);
+    expect(result.suppress).toBe(true);
+  });
+});
+
+describe('CODEX_CLI_REMOVAL_STEP', () => {
+  it('returns suppress=true + a Codex-CLI revoke hint', async () => {
+    const result = await CODEX_CLI_REMOVAL_STEP.remove({
+      provider: 'openai',
+      label: 'codex',
+    });
+    expect(result.cleaned).toEqual([]);
+    expect(result.hints[0]).toMatch(/codex logout/);
+    expect(result.suppress).toBe(true);
+  });
+});
+
+describe('GEMINI_CLI_REMOVAL_STEP', () => {
+  it('returns suppress=true + a gcloud revoke hint', async () => {
+    const result = await GEMINI_CLI_REMOVAL_STEP.remove({
+      provider: 'gemini',
+      label: 'cli',
+    });
+    expect(result.cleaned).toEqual([]);
+    expect(result.hints[0]).toMatch(/gcloud auth application-default revoke/);
+    expect(result.suppress).toBe(true);
+  });
+});
+
+describe('GH_CLI_REMOVAL_STEP', () => {
+  it('returns suppress=true + a `gh auth logout` hint', async () => {
+    const result = await GH_CLI_REMOVAL_STEP.remove({
+      provider: 'github-models',
+      label: 'gh',
+    });
+    expect(result.cleaned).toEqual([]);
+    expect(result.hints[0]).toMatch(/gh auth logout/);
+    expect(result.suppress).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suppression-state persistence — roundtrip + atomicity
+// ---------------------------------------------------------------------------
+
+describe('suppression-state file', () => {
+  it('suppressionStatePath resolves under getCleoHome()', () => {
+    const cleoHome = isolateHomes();
+    expect(suppressionStatePath()).toBe(join(cleoHome, 'auth-suppression.json'));
+  });
+
+  it('readSuppressionFile returns an empty document when the file is missing', () => {
+    isolateHomes();
+    const doc = readSuppressionFile();
+    expect(doc).toEqual({ version: 1, entries: [] });
+  });
+
+  it('writeSuppressionFile + readSuppressionFile roundtrip preserves entries', () => {
+    isolateHomes();
+    const doc: SuppressionFile = {
+      version: 1,
+      entries: [
+        { provider: 'anthropic', sourceId: 'claude-code', suppressedAt: 1700000000000 },
+        { provider: 'openai', sourceId: 'env', suppressedAt: 1700000000001 },
+      ],
+    };
+    writeSuppressionFile(doc);
+
+    const reloaded = readSuppressionFile();
+    expect(reloaded).toEqual(doc);
+  });
+
+  it('write goes through writeJsonFileAtomic (temp + rename)', () => {
+    // We verify the temp-file pattern by checking that the persisted file
+    // is exactly the rendered JSON — writeJsonFileAtomic stringifies with
+    // 2-space indent and a trailing newline. A non-atomic write would
+    // either leave a temp file lying around or produce a different format.
+    isolateHomes();
+    const doc: SuppressionFile = {
+      version: 1,
+      entries: [{ provider: 'anthropic', sourceId: 'cleo-pkce', suppressedAt: 42 }],
+    };
+    writeSuppressionFile(doc);
+
+    const persisted = readJsonFile<SuppressionFile>(suppressionStatePath());
+    expect(persisted).toEqual(doc);
+  });
+
+  it('treats a malformed file as an empty document', () => {
+    const cleoHome = isolateHomes();
+    writeFileSync(
+      join(cleoHome, 'auth-suppression.json'),
+      JSON.stringify({ version: 999, entries: 'not-an-array' }),
+      'utf-8',
+    );
+    const doc = readSuppressionFile();
+    expect(doc).toEqual({ version: 1, entries: [] });
+  });
+});
+
+describe('addSuppression / removeSuppression / isSuppressed', () => {
+  it('addSuppression appends an entry and isSuppressed returns true', () => {
+    isolateHomes();
+    expect(isSuppressed('anthropic', 'env')).toBe(false);
+    addSuppression('anthropic', 'env');
+    expect(isSuppressed('anthropic', 'env')).toBe(true);
+  });
+
+  it('addSuppression is idempotent — duplicate calls produce a single entry', () => {
+    isolateHomes();
+    addSuppression('anthropic', 'env');
+    addSuppression('anthropic', 'env');
+    addSuppression('anthropic', 'env');
+    const doc = readSuppressionFile();
+    expect(doc.entries).toHaveLength(1);
+    expect(doc.entries[0]?.provider).toBe('anthropic');
+    expect(doc.entries[0]?.sourceId).toBe('env');
+  });
+
+  it('different (provider, sourceId) pairs accumulate independently', () => {
+    isolateHomes();
+    addSuppression('anthropic', 'env');
+    addSuppression('anthropic', 'claude-code');
+    addSuppression('openai', 'env');
+
+    const doc = readSuppressionFile();
+    expect(doc.entries).toHaveLength(3);
+    expect(isSuppressed('anthropic', 'env')).toBe(true);
+    expect(isSuppressed('anthropic', 'claude-code')).toBe(true);
+    expect(isSuppressed('openai', 'env')).toBe(true);
+    expect(isSuppressed('openai', 'claude-code')).toBe(false);
+  });
+
+  it('removeSuppression returns true when an entry was removed', () => {
+    isolateHomes();
+    addSuppression('anthropic', 'env');
+    expect(removeSuppression('anthropic', 'env')).toBe(true);
+    expect(isSuppressed('anthropic', 'env')).toBe(false);
+  });
+
+  it('removeSuppression returns false when no entry matches', () => {
+    isolateHomes();
+    expect(removeSuppression('anthropic', 'env')).toBe(false);
+  });
+
+  it('removeSuppression only removes the matching pair, leaving siblings', () => {
+    isolateHomes();
+    addSuppression('anthropic', 'env');
+    addSuppression('anthropic', 'claude-code');
+    addSuppression('openai', 'env');
+
+    expect(removeSuppression('anthropic', 'env')).toBe(true);
+
+    const doc = readSuppressionFile();
+    expect(doc.entries).toHaveLength(2);
+    expect(isSuppressed('anthropic', 'env')).toBe(false);
+    expect(isSuppressed('anthropic', 'claude-code')).toBe(true);
+    expect(isSuppressed('openai', 'env')).toBe(true);
+  });
+
+  it('preserves the original suppressedAt timestamp on re-add', () => {
+    isolateHomes();
+    addSuppression('anthropic', 'env');
+    const first = readSuppressionFile().entries[0]?.suppressedAt;
+    expect(first).toBeTypeOf('number');
+
+    // Re-add must not bump the timestamp.
+    addSuppression('anthropic', 'env');
+    const second = readSuppressionFile().entries[0]?.suppressedAt;
+    expect(second).toBe(first);
+  });
+});

--- a/packages/core/src/llm/credential-removal.ts
+++ b/packages/core/src/llm/credential-removal.ts
@@ -1,0 +1,507 @@
+/**
+ * RemovalStep registry + per-source removal handlers for the unified
+ * credential pool (E-CONFIG-AUTH-UNIFY E2a / T9415).
+ *
+ * Mirrors Hermes Agent's `agent/credential_sources.py` `RemovalStep`
+ * pattern: every credential source (env var, `~/.claude/.credentials.json`,
+ * `cleo llm login` PKCE token, third-party CLIs) registers a removal step
+ * that `cleo auth remove <provider> <label>` invokes to (a) clean up
+ * filesystem state owned by CLEO, (b) surface manual hints for state CLEO
+ * does NOT own, and (c) record a suppression entry so the next pool load
+ * does not re-seed the just-removed credential.
+ *
+ * ## Scope of this task
+ *
+ * T9415 is **removal-infrastructure only**. The `cleo auth remove` CLI
+ * lands in T9416; this module exposes the registry + per-source handlers
+ * + suppression-state persistence, all consumable by the future CLI.
+ *
+ * ## Suppression state
+ *
+ * Suppression is persisted to `${getCleoHome()}/auth-suppression.json`:
+ *
+ * ```json
+ * {
+ *   "version": 1,
+ *   "entries": [
+ *     { "provider": "anthropic", "sourceId": "claude-code", "suppressedAt": 1731000000000 }
+ *   ]
+ * }
+ * ```
+ *
+ * Writes go through {@link writeJsonFileAtomic} (temp-file + rename) so
+ * mid-update crashes never corrupt the file. The mutation flow is
+ * read-full-state → mutate-in-memory → atomic-write so concurrent CLI
+ * invocations cannot interleave partial writes.
+ *
+ * @module llm/credential-removal
+ * @task T9415
+ * @epic E-CONFIG-AUTH-UNIFY (E2a)
+ */
+
+import { unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { getCleoHome } from '@cleocode/paths';
+import { readJsonFile, writeJsonFileAtomic } from '../store/file-utils.js';
+import type { SeederSourceId } from './credential-seeders/index.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Outcome of a {@link RemovalStep.remove} invocation.
+ *
+ * @task T9415
+ */
+export interface RemovalResult {
+  /**
+   * Absolute paths of filesystem entries that were actually mutated /
+   * deleted by this removal step. Empty when CLEO does not own the
+   * source's on-disk state (env vars, third-party CLI tokens, etc.).
+   */
+  cleaned: string[];
+  /**
+   * Human-readable hints surfaced to the operator after removal — what
+   * they may still need to do manually (e.g. "unset $ANTHROPIC_API_KEY",
+   * "do NOT delete ~/.claude/.credentials.json").
+   */
+  hints: string[];
+  /**
+   * Whether the unified pool should add `(provider, sourceId)` to the
+   * suppression list so the next seed pass skips this source.
+   *
+   * `false` for the `'manual'` source — entries the operator added via
+   * `cleo llm add` are removed directly from `llm-credentials.json` and
+   * there is nothing to suppress on the next seed pass.
+   */
+  suppress: boolean;
+}
+
+/**
+ * A single removal handler in the {@link RemovalRegistry}.
+ *
+ * @task T9415
+ */
+export interface RemovalStep {
+  /** Source id this step removes — pairs 1:1 with a {@link SeederSourceId}. */
+  readonly sourceId: SeederSourceId;
+  /** Short human-readable description shown in `cleo auth remove --dry-run`. */
+  readonly description: string;
+  /**
+   * Execute the removal for a `(provider, label)` pair.
+   *
+   * MUST be idempotent — re-invoking with the same args after a successful
+   * run MUST NOT raise. Filesystem cleanup absence is treated as success
+   * (the desired post-state was already in place).
+   *
+   * @param args - Provider/label being removed.
+   * @returns Cleanup summary + hints + suppression directive.
+   */
+  remove(args: { provider: string; label: string }): Promise<RemovalResult>;
+}
+
+/**
+ * One entry in the suppression list persisted to `auth-suppression.json`.
+ *
+ * @task T9415
+ */
+export interface SuppressionEntry {
+  /** Provider id (e.g. `'anthropic'`). */
+  provider: string;
+  /** Source id whose seeder should be skipped for this provider. */
+  sourceId: SeederSourceId;
+  /** Epoch milliseconds the suppression was recorded — for diagnostics. */
+  suppressedAt: number;
+}
+
+/**
+ * On-disk shape of `auth-suppression.json`.
+ *
+ * @internal — exposed for tests; CLI callers go through the helpers below.
+ */
+export interface SuppressionFile {
+  /** Schema version; bump on any breaking layout change. */
+  version: 1;
+  /** Active suppression entries. */
+  entries: SuppressionEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/**
+ * In-process registry mapping {@link SeederSourceId} → {@link RemovalStep}.
+ *
+ * Uniqueness rule: each `sourceId` MUST appear at most once. A duplicate
+ * `register()` call throws synchronously — silent overwrites would let two
+ * steps fight over the same source, which is a programmer error in test or
+ * extension code.
+ *
+ * Tests construct a fresh `RemovalRegistry()` for isolation; production
+ * code uses the {@link REMOVAL_REGISTRY} singleton populated at module load
+ * (see bottom of this file).
+ *
+ * @task T9415
+ */
+export class RemovalRegistry {
+  private readonly steps = new Map<SeederSourceId, RemovalStep>();
+
+  /**
+   * Register a removal step.
+   *
+   * @param step - Removal step instance to add.
+   * @throws {Error} `E_REMOVAL_DUPLICATE` when `step.sourceId` is already
+   *   registered.
+   */
+  register(step: RemovalStep): void {
+    if (this.steps.has(step.sourceId)) {
+      throw new Error(
+        `E_REMOVAL_DUPLICATE: a removal step is already registered for sourceId='${step.sourceId}'`,
+      );
+    }
+    this.steps.set(step.sourceId, step);
+  }
+
+  /**
+   * Look up the step for a source id.
+   *
+   * @param sourceId - Source id to dispatch on.
+   * @returns The registered step, or `undefined` if none is registered.
+   */
+  find(sourceId: SeederSourceId): RemovalStep | undefined {
+    return this.steps.get(sourceId);
+  }
+
+  /**
+   * Return every registered step (insertion order).
+   *
+   * Used by `cleo auth remove --all` and diagnostic listing.
+   */
+  getAll(): readonly RemovalStep[] {
+    return Array.from(this.steps.values());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Suppression-state persistence
+// ---------------------------------------------------------------------------
+
+/**
+ * Filename for the persisted suppression list under `getCleoHome()`.
+ *
+ * @internal
+ */
+const SUPPRESSION_FILENAME = 'auth-suppression.json';
+
+/**
+ * Absolute path to the suppression-state file.
+ *
+ * Resolved at call time (NOT cached at module load) so test harnesses can
+ * override `CLEO_HOME` between runs and see the change reflected.
+ *
+ * @returns `${getCleoHome()}/auth-suppression.json`.
+ *
+ * @task T9415
+ */
+export function suppressionStatePath(): string {
+  return join(getCleoHome(), SUPPRESSION_FILENAME);
+}
+
+/**
+ * Read the suppression file, returning a fresh empty document when the
+ * file does not yet exist.
+ *
+ * @returns Parsed suppression document.
+ *
+ * @task T9415
+ */
+export function readSuppressionFile(): SuppressionFile {
+  const data = readJsonFile<SuppressionFile>(suppressionStatePath());
+  if (data && data.version === 1 && Array.isArray(data.entries)) {
+    return data;
+  }
+  return { version: 1, entries: [] };
+}
+
+/**
+ * Atomically persist the suppression file to disk.
+ *
+ * Goes through {@link writeJsonFileAtomic} (temp + rename); the parent
+ * directory (`getCleoHome()`) is created upstream by `@cleocode/paths` so
+ * we do not need to `mkdir` here. The atomic helper itself creates the
+ * temp file inside the target's parent directory, so a missing parent
+ * surfaces as the original error rather than corrupting state.
+ *
+ * @param next - New file contents.
+ *
+ * @task T9415
+ */
+export function writeSuppressionFile(next: SuppressionFile): void {
+  writeJsonFileAtomic(suppressionStatePath(), next);
+}
+
+/**
+ * Add `(provider, sourceId)` to the suppression list.
+ *
+ * Idempotent — a `(provider, sourceId)` pair already present is left
+ * untouched (its original `suppressedAt` is preserved so diagnostics can
+ * surface the first removal). Reads full state, mutates in-memory, writes
+ * atomically — concurrent CLI invocations cannot interleave partial
+ * writes.
+ *
+ * @param provider - Provider id whose seeder should be suppressed.
+ * @param sourceId - Source id of the seeder to suppress.
+ *
+ * @task T9415
+ */
+export function addSuppression(provider: string, sourceId: SeederSourceId): void {
+  const current = readSuppressionFile();
+  const exists = current.entries.some((e) => e.provider === provider && e.sourceId === sourceId);
+  if (exists) return;
+  const next: SuppressionFile = {
+    version: 1,
+    entries: [...current.entries, { provider, sourceId, suppressedAt: Date.now() }],
+  };
+  writeSuppressionFile(next);
+}
+
+/**
+ * Remove `(provider, sourceId)` from the suppression list.
+ *
+ * Idempotent — removing an entry that does not exist is a no-op. Intended
+ * for the future `cleo auth unsuppress` CLI surface (T9416+).
+ *
+ * @param provider - Provider id to un-suppress.
+ * @param sourceId - Source id to un-suppress.
+ * @returns `true` if an entry was removed, `false` if none matched.
+ *
+ * @task T9415
+ */
+export function removeSuppression(provider: string, sourceId: SeederSourceId): boolean {
+  const current = readSuppressionFile();
+  const before = current.entries.length;
+  const filtered = current.entries.filter(
+    (e) => !(e.provider === provider && e.sourceId === sourceId),
+  );
+  if (filtered.length === before) return false;
+  writeSuppressionFile({ version: 1, entries: filtered });
+  return true;
+}
+
+/**
+ * Test whether a `(provider, sourceId)` pair is currently suppressed.
+ *
+ * @param provider - Provider id.
+ * @param sourceId - Source id.
+ * @returns `true` if suppression is active.
+ *
+ * @task T9415
+ */
+export function isSuppressed(provider: string, sourceId: SeederSourceId): boolean {
+  const current = readSuppressionFile();
+  return current.entries.some((e) => e.provider === provider && e.sourceId === sourceId);
+}
+
+// ---------------------------------------------------------------------------
+// Concrete RemovalStep implementations
+// ---------------------------------------------------------------------------
+
+/**
+ * `'manual'` — entry the operator added with `cleo llm add`.
+ *
+ * The actual `llm-credentials.json` mutation is performed by the future
+ * `cleo auth remove` CLI (T9416) which calls the credential store
+ * directly; this step does NOT touch filesystem state itself. Suppression
+ * is `false` because `'manual'` has no seeder pass to skip.
+ *
+ * @task T9415
+ */
+export const MANUAL_REMOVAL_STEP: RemovalStep = {
+  sourceId: 'manual',
+  description: 'Operator-added entry; removed directly from llm-credentials.json',
+  async remove() {
+    return {
+      cleaned: [],
+      hints: ['entry removed from llm-credentials.json'],
+      suppress: false,
+    };
+  },
+};
+
+/**
+ * `'env'` — environment-variable seed.
+ *
+ * CLEO cannot unset another shell's exported variable, so cleanup is empty
+ * and the hint instructs the operator. Suppression is `true` so the next
+ * seed pass skips the env source even if the variable is still set
+ * (otherwise the just-removed credential would silently re-appear).
+ *
+ * @task T9415
+ */
+export const ENV_REMOVAL_STEP: RemovalStep = {
+  sourceId: 'env',
+  description: 'Environment variable; cannot be unset by CLEO',
+  async remove() {
+    return {
+      cleaned: [],
+      hints: ['Unset $VARNAME in your shell to prevent re-seeding'],
+      suppress: true,
+    };
+  },
+};
+
+/**
+ * `'claude-code'` — `~/.claude/.credentials.json` consented import.
+ *
+ * Hard rule: CLEO MUST NOT delete `~/.claude/.credentials.json` — Claude
+ * Code itself depends on the file. The correct cleanup is suppression of
+ * the seeder so the next pool load does not re-import the credential.
+ *
+ * @task T9415
+ */
+export const CLAUDE_CODE_REMOVAL_STEP: RemovalStep = {
+  sourceId: 'claude-code',
+  description: 'Suppress claude-code re-seed; leave ~/.claude/.credentials.json untouched',
+  async remove() {
+    return {
+      cleaned: [],
+      hints: [
+        'Do NOT delete ~/.claude/.credentials.json — Claude Code uses it. Re-seeding is suppressed instead.',
+      ],
+      suppress: true,
+    };
+  },
+};
+
+/**
+ * `'cleo-pkce'` — credential issued by `cleo llm login` (PKCE flow).
+ *
+ * Owned end-to-end by CLEO: the token cache file at
+ * `${getCleoHome()}/anthropic-oauth.json` is deleted unconditionally
+ * (ENOENT is silently ignored — idempotency requirement). Suppression is
+ * `true` so a residual seeder pass does not re-seed a deleted token.
+ *
+ * @task T9415
+ */
+export const CLEO_PKCE_REMOVAL_STEP: RemovalStep = {
+  sourceId: 'cleo-pkce',
+  description: 'Delete CLEO-issued PKCE token at <CLEO_HOME>/anthropic-oauth.json',
+  async remove() {
+    const path = join(getCleoHome(), 'anthropic-oauth.json');
+    const cleaned: string[] = [];
+    try {
+      unlinkSync(path);
+      cleaned.push(path);
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') throw err;
+    }
+    return {
+      cleaned,
+      hints: [],
+      suppress: true,
+    };
+  },
+};
+
+/**
+ * `'codex-cli'` — OpenAI Codex CLI session token.
+ *
+ * CLEO does not own the Codex CLI's on-disk state. The hint points the
+ * operator at the Codex tooling; suppression is `true`.
+ *
+ * @task T9415
+ */
+export const CODEX_CLI_REMOVAL_STEP: RemovalStep = {
+  sourceId: 'codex-cli',
+  description: 'Suppress codex-cli re-seed; revoke via the Codex CLI itself',
+  async remove() {
+    return {
+      cleaned: [],
+      hints: [
+        'Run `codex logout` (or remove ~/.codex/auth.json) in the Codex CLI to revoke the underlying token.',
+      ],
+      suppress: true,
+    };
+  },
+};
+
+/**
+ * `'gemini-cli'` — Google Gemini CLI application default credentials.
+ *
+ * Same pattern as `'codex-cli'`: CLEO does not own the Gemini CLI's state.
+ *
+ * @task T9415
+ */
+export const GEMINI_CLI_REMOVAL_STEP: RemovalStep = {
+  sourceId: 'gemini-cli',
+  description: 'Suppress gemini-cli re-seed; revoke via the Gemini CLI itself',
+  async remove() {
+    return {
+      cleaned: [],
+      hints: [
+        'Run `gcloud auth application-default revoke` (or `gemini auth logout`) to revoke the underlying token.',
+      ],
+      suppress: true,
+    };
+  },
+};
+
+/**
+ * `'gh-cli'` — GitHub CLI token (for the `github-models` provider).
+ *
+ * Same pattern: CLEO does not own `gh`'s keyring.
+ *
+ * @task T9415
+ */
+export const GH_CLI_REMOVAL_STEP: RemovalStep = {
+  sourceId: 'gh-cli',
+  description: 'Suppress gh-cli re-seed; revoke via `gh auth logout`',
+  async remove() {
+    return {
+      cleaned: [],
+      hints: ['Run `gh auth logout` to revoke the underlying GitHub token.'],
+      suppress: true,
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Module-state singleton
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fresh registry pre-populated with every built-in step.
+ *
+ * Exposed so tests can construct an isolated registry mirroring production
+ * state without mutating the {@link REMOVAL_REGISTRY} singleton.
+ *
+ * @returns A fully populated `RemovalRegistry`.
+ *
+ * @task T9415
+ */
+export function buildBuiltinRemovalRegistry(): RemovalRegistry {
+  const registry = new RemovalRegistry();
+  registry.register(MANUAL_REMOVAL_STEP);
+  registry.register(ENV_REMOVAL_STEP);
+  registry.register(CLAUDE_CODE_REMOVAL_STEP);
+  registry.register(CLEO_PKCE_REMOVAL_STEP);
+  registry.register(CODEX_CLI_REMOVAL_STEP);
+  registry.register(GEMINI_CLI_REMOVAL_STEP);
+  registry.register(GH_CLI_REMOVAL_STEP);
+  return registry;
+}
+
+/**
+ * Process-wide singleton used by the future `cleo auth remove` CLI.
+ *
+ * Populated at module load with every built-in step. Tests requiring
+ * isolation MUST construct a fresh registry via
+ * {@link buildBuiltinRemovalRegistry} (or `new RemovalRegistry()`) instead
+ * of mutating this instance.
+ *
+ * @task T9415
+ */
+export const REMOVAL_REGISTRY: RemovalRegistry = buildBuiltinRemovalRegistry();

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -84,6 +84,32 @@ export {
 } from './context-engines/rule-based-truncation.js';
 // Conversation utilities
 export { countMessageTokens, truncateMessagesToFit } from './conversation.js';
+// Credential removal — RemovalStep registry + suppression state
+// (E-CONFIG-AUTH-UNIFY E2a / T9415)
+export type {
+  RemovalResult,
+  RemovalStep,
+  SuppressionEntry,
+  SuppressionFile,
+} from './credential-removal.js';
+export {
+  addSuppression,
+  buildBuiltinRemovalRegistry,
+  CLAUDE_CODE_REMOVAL_STEP,
+  CLEO_PKCE_REMOVAL_STEP,
+  CODEX_CLI_REMOVAL_STEP,
+  ENV_REMOVAL_STEP,
+  GEMINI_CLI_REMOVAL_STEP,
+  GH_CLI_REMOVAL_STEP,
+  isSuppressed,
+  MANUAL_REMOVAL_STEP,
+  REMOVAL_REGISTRY,
+  RemovalRegistry,
+  readSuppressionFile,
+  removeSuppression,
+  suppressionStatePath,
+  writeSuppressionFile,
+} from './credential-removal.js';
 // Credential seeders — unified pool foundation (E-CONFIG-AUTH-UNIFY E2a / T9408)
 export type {
   CredentialSeeder,


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E2a §5.2 T-E2-7. Mirrors Hermes Agent's `credential_sources.py` `RemovalStep` pattern. `cleo auth remove` CLI integration lands in T9416.

## Adds
- `packages/core/src/llm/credential-removal.ts` (507 lines):
  - `RemovalStep` / `RemovalResult` types
  - `RemovalRegistry` class + `REMOVAL_REGISTRY` singleton
  - Suppression state persistence: `auth-suppression.json` under `getCleoHome()` via atomic `writeJsonFileAtomic`
  - 7 concrete steps: `MANUAL`, `ENV`, `CLAUDE_CODE`, `CLEO_PKCE`, `CODEX_CLI`, `GEMINI_CLI`, `GH_CLI`
  - `addSuppression`/`removeSuppression`/`isSuppressed` helpers
- 26 unit tests covering registry dispatch, per-step handlers, suppression-file roundtrip, atomic-write verification

## Test plan
- [x] 26/26 new tests pass
- [x] 797/797 LLM-subtree tests pass
- [x] biome + build clean
- [x] No regressions in pre-existing worktree failures

## Refs
- `docs/plans/E-CONFIG-AUTH-UNIFY.md` §5.2 T-E2-7
- Epic: T9401, Master: T9500