### PR TITLE
feat(T9410): add claude-code OAuth seeder with consent gate

### DIFF
--- a/packages/contracts/src/config.ts
+++ b/packages/contracts/src/config.ts
@@ -588,6 +588,42 @@ export interface CleoConfig {
    * @defaultValue undefined
    */
   briefing?: BriefingConfig;
+  /**
+   * Auth-source consent gates for credential seeders.
+   *
+   * Gates third-party credential imports (e.g. Claude Code OAuth) behind
+   * explicit operator opt-in. Mirrors Hermes Agent's PR #4210 consent gate.
+   *
+   * @defaultValue undefined
+   * @task T9410
+   */
+  auth?: AuthConfig;
+}
+
+/**
+ * Auth-source consent configuration.
+ *
+ * Concrete `CredentialSeeder` implementations consult these flags before
+ * reading any third-party credential file (e.g. `~/.claude/.credentials.json`).
+ * Defaulting every flag to `false` keeps auxiliary fallback chains opt-in:
+ * aux callers cannot silently read user credentials they were never granted.
+ *
+ * @task T9410
+ */
+export interface AuthConfig {
+  /**
+   * Whether the operator has explicitly opted in to import the Claude Code
+   * OAuth token (`~/.claude/.credentials.json`) into the CLEO credential
+   * pool.
+   *
+   * When `false` (default), the `claude-code` seeder MUST NOT read the file
+   * and MUST return an empty seeder result. When `true`, the seeder reads
+   * the file and emits a single `source: 'claude-code'` entry for the
+   * `anthropic` provider.
+   *
+   * @defaultValue false
+   */
+  claudeCodeConsentGiven?: boolean;
 }
 
 /**

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -107,6 +107,12 @@ const DEFAULTS: CleoConfig = {
       maxTranscriptChars: 60000,
     },
   },
+  auth: {
+    // T9410 — Claude Code OAuth import gated behind explicit opt-in.
+    // Mirrors Hermes Agent PR #4210: aux fallback chains cannot silently
+    // read `~/.claude/.credentials.json` without the operator's consent.
+    claudeCodeConsentGiven: false,
+  },
 };
 
 /** Environment variable to config path mapping. */

--- a/packages/core/src/llm/credential-seeders/__tests__/claude-code-seeder.test.ts
+++ b/packages/core/src/llm/credential-seeders/__tests__/claude-code-seeder.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for `ClaudeCodeSeeder` (E-CONFIG-AUTH-UNIFY E2a / T9410).
+ *
+ * The seeder is exercised with constructor-injected dependency seams
+ * (`readCredentialFile`, `readConsentFlag`) so the suite stays pure —
+ * no fs writes, no env-var fiddling, no module mocks. Each test
+ * asserts one branch of the seeder's decision tree:
+ *
+ * - valid token + consent → one pool entry emitted
+ * - valid token + no consent → empty + readCredentialFile NOT called
+ * - missing file → empty
+ * - expired token → empty
+ * - malformed JSON → empty
+ * - auto-registered in BUILTIN_SEEDERS
+ *
+ * @task T9410
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { BUILTIN_SEEDERS, ClaudeCodeSeeder, SeederRegistry } from '../index.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Far-future expiry so the parser never trips on `Date.now()` drift. */
+const FUTURE_EXPIRES_AT = Date.now() + 24 * 60 * 60 * 1000; // +24 hours
+/** Far-past expiry to exercise the expired-token branch. */
+const PAST_EXPIRES_AT = Date.now() - 60 * 60 * 1000; // -1 hour
+
+/** Minimal valid Claude Code credentials JSON with a refresh token. */
+function validCredentialsJson(): string {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'sk-ant-oauth-fixture-access',
+      refreshToken: 'sk-ant-oauth-fixture-refresh',
+      expiresAt: FUTURE_EXPIRES_AT,
+    },
+  });
+}
+
+/** Credentials JSON with `expiresAt` in the past — parser drops this. */
+function expiredCredentialsJson(): string {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'sk-ant-oauth-fixture-access',
+      refreshToken: 'sk-ant-oauth-fixture-refresh',
+      expiresAt: PAST_EXPIRES_AT,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Behavioural tests
+// ---------------------------------------------------------------------------
+
+describe('ClaudeCodeSeeder', () => {
+  describe('identity', () => {
+    it('reports sourceId=claude-code and provider=anthropic', () => {
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: () => null,
+        readConsentFlag: async () => false,
+      });
+      expect(seeder.sourceId).toBe('claude-code');
+      expect(seeder.provider).toBe('anthropic');
+    });
+  });
+
+  describe('seed — happy path', () => {
+    it('emits a single anthropic entry when consent is given and file is valid', async () => {
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: () => validCredentialsJson(),
+        readConsentFlag: async () => true,
+      });
+
+      const result = await seeder.seed();
+
+      expect(result.entries).toHaveLength(1);
+      const entry = result.entries[0]!;
+      expect(entry.provider).toBe('anthropic');
+      expect(entry.label).toBe('claude-code');
+      expect(entry.source).toBe('claude-code');
+      expect(entry.authType).toBe('oauth');
+      expect(entry.accessToken).toBe('sk-ant-oauth-fixture-access');
+      expect(entry.refreshToken).toBe('sk-ant-oauth-fixture-refresh');
+      expect(entry.expiresAt).toBe(FUTURE_EXPIRES_AT);
+    });
+
+    it('omits refreshToken/expiresAt when the source file omits them', async () => {
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: () =>
+          JSON.stringify({
+            claudeAiOauth: { accessToken: 'sk-ant-no-refresh' },
+          }),
+        readConsentFlag: async () => true,
+      });
+
+      const result = await seeder.seed();
+      expect(result.entries).toHaveLength(1);
+      const entry = result.entries[0]!;
+      expect(entry.accessToken).toBe('sk-ant-no-refresh');
+      expect(entry).not.toHaveProperty('refreshToken');
+      expect(entry).not.toHaveProperty('expiresAt');
+    });
+  });
+
+  describe('seed — consent gate', () => {
+    it('returns empty when consent is not given', async () => {
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: () => validCredentialsJson(),
+        readConsentFlag: async () => false,
+      });
+
+      const result = await seeder.seed();
+      expect(result.entries).toEqual([]);
+    });
+
+    it('does NOT read the credential file when consent is not given', async () => {
+      const readSpy = vi.fn<() => string | null>(() => validCredentialsJson());
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: readSpy,
+        readConsentFlag: async () => false,
+      });
+
+      const result = await seeder.seed();
+
+      expect(result.entries).toEqual([]);
+      // The whole point of the consent gate (Hermes Agent PR #4210):
+      // an unconsented seeder MUST NOT touch the credential file.
+      expect(readSpy).not.toHaveBeenCalled();
+    });
+
+    it('treats consent-flag resolution errors as no-consent (fail closed)', async () => {
+      const readSpy = vi.fn<() => string | null>(() => validCredentialsJson());
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: readSpy,
+        readConsentFlag: async () => {
+          throw new Error('config read failed');
+        },
+      });
+
+      const result = await seeder.seed();
+
+      expect(result.entries).toEqual([]);
+      expect(readSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('seed — degraded source paths', () => {
+    it('returns empty when the credentials file is missing (null)', async () => {
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: () => null,
+        readConsentFlag: async () => true,
+      });
+
+      const result = await seeder.seed();
+      expect(result.entries).toEqual([]);
+    });
+
+    it('returns empty when the credentials JSON is malformed', async () => {
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: () => '{ this is not valid JSON',
+        readConsentFlag: async () => true,
+      });
+
+      const result = await seeder.seed();
+      expect(result.entries).toEqual([]);
+    });
+
+    it('returns empty when the token is expired', async () => {
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: () => expiredCredentialsJson(),
+        readConsentFlag: async () => true,
+      });
+
+      const result = await seeder.seed();
+      expect(result.entries).toEqual([]);
+    });
+
+    it('returns empty when the claudeAiOauth block is absent', async () => {
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: () => JSON.stringify({ someOtherKey: 'value' }),
+        readConsentFlag: async () => true,
+      });
+
+      const result = await seeder.seed();
+      expect(result.entries).toEqual([]);
+    });
+  });
+
+  describe('isConsentEstablished', () => {
+    it('returns the resolved consent boolean', async () => {
+      const yes = new ClaudeCodeSeeder({
+        readCredentialFile: () => null,
+        readConsentFlag: async () => true,
+      });
+      const no = new ClaudeCodeSeeder({
+        readCredentialFile: () => null,
+        readConsentFlag: async () => false,
+      });
+
+      await expect(yes.isConsentEstablished('anthropic')).resolves.toBe(true);
+      await expect(no.isConsentEstablished('anthropic')).resolves.toBe(false);
+    });
+
+    it('returns false when the flag resolver throws', async () => {
+      const seeder = new ClaudeCodeSeeder({
+        readCredentialFile: () => null,
+        readConsentFlag: async () => {
+          throw new Error('boom');
+        },
+      });
+
+      await expect(seeder.isConsentEstablished('anthropic')).resolves.toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry integration
+// ---------------------------------------------------------------------------
+
+describe('BUILTIN_SEEDERS auto-registration', () => {
+  it('contains exactly one (claude-code, anthropic) seeder', () => {
+    const matches = BUILTIN_SEEDERS.getAll().filter(
+      (s) => s.sourceId === 'claude-code' && s.provider === 'anthropic',
+    );
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toBeInstanceOf(ClaudeCodeSeeder);
+  });
+
+  it('exposes the seeder via getByProvider("anthropic")', () => {
+    const anthropicSeeders = BUILTIN_SEEDERS.getByProvider('anthropic');
+    const claudeCode = anthropicSeeders.find((s) => s.sourceId === 'claude-code');
+
+    expect(claudeCode).toBeDefined();
+    expect(claudeCode).toBeInstanceOf(ClaudeCodeSeeder);
+  });
+
+  it('does NOT auto-register the seeder under any other provider', () => {
+    for (const seeder of BUILTIN_SEEDERS.getAll()) {
+      if (seeder instanceof ClaudeCodeSeeder) {
+        expect(seeder.provider).toBe('anthropic');
+      }
+    }
+  });
+
+  it('uses the canonical SeederRegistry key encoding', () => {
+    // Sanity check — the registry's collision detector relies on the
+    // `<sourceId>::<provider>` encoding. If a future task changes the
+    // separator, the auto-registration call would still succeed but the
+    // duplicate-detection contract documented on `SeederRegistry` would
+    // silently weaken. Tests assert the literal encoding here as a guard.
+    expect(SeederRegistry.makeKey('claude-code', 'anthropic')).toBe('claude-code::anthropic');
+  });
+});

--- a/packages/core/src/llm/credential-seeders/claude-code-seeder.ts
+++ b/packages/core/src/llm/credential-seeders/claude-code-seeder.ts
@@ -1,0 +1,217 @@
+/**
+ * `claude-code` credential seeder — imports the Claude Code OAuth token
+ * (`~/.claude/.credentials.json`) into the unified credential pool as an
+ * `anthropic` entry.
+ *
+ * E-CONFIG-AUTH-UNIFY E2a §5.2 T-E2-3. Architectural mirror of Hermes
+ * Agent's `_seed_from_singletons` dispatch (`agent/credential_pool.py`).
+ *
+ * ## Consent gate
+ *
+ * Reading the Claude Code credential file requires the operator to have
+ * explicitly opted in via `auth.claudeCodeConsentGiven = true` in the
+ * global config. This mirrors Hermes Agent's PR #4210 fix: without the
+ * gate, auxiliary fallback chains could silently route requests through
+ * a user's Claude Code OAuth token without consent. The default value is
+ * `false`, so the seeder is a no-op on fresh installs.
+ *
+ * The gate is checked BEFORE any filesystem access: an unconsented seeder
+ * never calls `readFileSync` on the credentials path. `isConsentEstablished`
+ * reads the global config through `getConfigValue('auth.claudeCodeConsentGiven')`
+ * so CLI/env overrides on the consent flag are respected uniformly.
+ *
+ * ## What the seeder emits
+ *
+ * One `SeederCredentialEntry` per call (or zero) with:
+ *
+ * - `provider: 'anthropic'`
+ * - `label: 'claude-code'`
+ * - `authType: 'oauth'`
+ * - `source: 'claude-code'`
+ * - `accessToken`, `refreshToken`, `expiresAt` extracted from
+ *   `claudeAiOauth` via {@link parseClaudeCodeCredentials}.
+ *
+ * Zero-result paths (consent off, file missing, file unreadable, JSON
+ * malformed, token expired) all return `{ entries: [] }` without
+ * throwing. Parsing is delegated to `parseClaudeCodeCredentials` in
+ * `@cleocode/contracts` so the JSON shape lives in exactly one place.
+ *
+ * @module llm/credential-seeders/claude-code-seeder
+ * @task T9410
+ * @epic E-CONFIG-AUTH-UNIFY (E2a)
+ */
+
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { parseClaudeCodeCredentials } from '@cleocode/contracts';
+import { getConfigValue } from '../../config.js';
+import type {
+  CredentialSeeder,
+  SeederCredentialEntry,
+  SeederResult,
+  SeederSourceId,
+} from './index.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Stable label written into the pool entry's `label` field. */
+const SEEDER_LABEL = 'claude-code';
+
+/** `(sourceId, provider)` pair this seeder owns inside the registry. */
+const SOURCE_ID: SeederSourceId = 'claude-code';
+const PROVIDER = 'anthropic';
+
+/** Config key consulted by {@link isConsentEstablished}. */
+const CONSENT_CONFIG_KEY = 'auth.claudeCodeConsentGiven';
+
+// ---------------------------------------------------------------------------
+// Seeder implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Concrete `CredentialSeeder` for the `claude-code` source.
+ *
+ * Constructor-injectable filesystem hooks (`readCredentialFile`) keep tests
+ * pure — they exercise the consent gate, expiry filter, and missing-file
+ * path without touching the real `~/.claude/.credentials.json` and without
+ * fs mocks at the module level. The default `readCredentialFile`
+ * implementation calls `readFileSync` on `~/.claude/.credentials.json`.
+ *
+ * @task T9410
+ */
+export class ClaudeCodeSeeder implements CredentialSeeder {
+  /** @inheritdoc */
+  readonly sourceId: SeederSourceId = SOURCE_ID;
+  /** @inheritdoc */
+  readonly provider = PROVIDER;
+
+  private readonly readCredentialFile: () => string | null;
+  private readonly readConsentFlag: () => Promise<boolean>;
+
+  /**
+   * Construct a seeder.
+   *
+   * @param opts - Optional dependency-injection seams. `readCredentialFile`
+   *   MUST return `null` when the file is missing or unreadable (it MUST
+   *   NOT throw). `readConsentFlag` returns the resolved consent boolean
+   *   from the config cascade.
+   */
+  constructor(opts?: {
+    readCredentialFile?: () => string | null;
+    readConsentFlag?: () => Promise<boolean>;
+  }) {
+    this.readCredentialFile = opts?.readCredentialFile ?? defaultReadCredentialFile;
+    this.readConsentFlag = opts?.readConsentFlag ?? defaultReadConsentFlag;
+  }
+
+  /**
+   * Resolve the consent flag from the canonical config cascade.
+   *
+   * Returns `true` only when `auth.claudeCodeConsentGiven` is explicitly
+   * the boolean `true`. Any other value — `undefined`, `null`, `false`,
+   * or a stray string — yields `false` so the gate fails closed.
+   *
+   * @param _provider - Provider id (ignored — this seeder is anthropic-only;
+   *   the parameter is accepted to satisfy the `CredentialSeeder` contract).
+   */
+  async isConsentEstablished(_provider: string): Promise<boolean> {
+    try {
+      return await this.readConsentFlag();
+    } catch {
+      // Defensive: any failure resolving the flag → no consent.
+      return false;
+    }
+  }
+
+  /**
+   * Read `~/.claude/.credentials.json` and emit a single pool entry.
+   *
+   * Short-circuits to `{ entries: [] }` when the consent gate is closed,
+   * the file is absent, the JSON is malformed, the `claudeAiOauth` block
+   * is missing, or the token has expired (per `parseClaudeCodeCredentials`).
+   */
+  async seed(): Promise<SeederResult> {
+    // Consent gate — checked BEFORE any filesystem access so the absence
+    // of consent is indistinguishable from the absence of the file from
+    // the perspective of an observer.
+    const consented = await this.isConsentEstablished(this.provider);
+    if (!consented) {
+      return { entries: [] };
+    }
+
+    const raw = this.readCredentialFile();
+    if (raw === null) {
+      return { entries: [] };
+    }
+
+    const parsed = parseClaudeCodeCredentials(raw);
+    if (parsed === null) {
+      // Malformed JSON, missing oauth block, or expired token.
+      return { entries: [] };
+    }
+
+    const entry: SeederCredentialEntry = {
+      provider: 'anthropic',
+      label: SEEDER_LABEL,
+      authType: 'oauth',
+      accessToken: parsed.accessToken,
+      source: SEEDER_LABEL,
+      ...(parsed.expiresAt !== undefined ? { expiresAt: parsed.expiresAt } : {}),
+      ...(parsed.refreshToken !== undefined ? { refreshToken: parsed.refreshToken } : {}),
+    };
+
+    return { entries: [entry] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default dependency-injection implementations
+// ---------------------------------------------------------------------------
+
+/**
+ * Default `readCredentialFile` implementation.
+ *
+ * Returns the UTF-8 contents of `~/.claude/.credentials.json`, or `null`
+ * when the file is absent or unreadable. NEVER throws — every error path
+ * collapses to `null` so the seeder's "source absent" contract holds.
+ *
+ * @internal
+ */
+function defaultReadCredentialFile(): string | null {
+  try {
+    return readFileSync(join(homedir(), '.claude', '.credentials.json'), 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default `readConsentFlag` implementation.
+ *
+ * Reads the consent boolean from the canonical config cascade (env >
+ * project > global > defaults). The default value at the defaults tier
+ * is `false`, so a fresh install with no overrides resolves to `false`.
+ *
+ * @internal
+ */
+async function defaultReadConsentFlag(): Promise<boolean> {
+  const resolved = await getConfigValue<boolean | undefined>(CONSENT_CONFIG_KEY);
+  return resolved.value === true;
+}
+
+/**
+ * Factory for the singleton `ClaudeCodeSeeder` registered into
+ * `BUILTIN_SEEDERS` from `index.ts`.
+ *
+ * Kept as a factory (not a module-level `const`) so the registry-side
+ * import remains acyclic and tests can construct fresh instances with
+ * injected dependencies.
+ *
+ * @task T9410
+ */
+export function createClaudeCodeSeeder(): ClaudeCodeSeeder {
+  return new ClaudeCodeSeeder();
+}

--- a/packages/core/src/llm/credential-seeders/index.ts
+++ b/packages/core/src/llm/credential-seeders/index.ts
@@ -32,6 +32,7 @@
  */
 
 import type { StoredCredential } from '../credentials-store.js';
+import { createClaudeCodeSeeder } from './claude-code-seeder.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -244,9 +245,11 @@ export class SeederRegistry {
 /**
  * Process-wide singleton registry used by the resolver.
  *
- * Future tasks (T9409+) register concrete seeder instances into this
- * registry at module load. As of T9408 it is **empty** — no production
- * code path consumes `BUILTIN_SEEDERS` yet.
+ * Concrete seeder instances are auto-registered into this registry at
+ * module load — see the registration block below. As of T9410 the
+ * registry contains:
+ *
+ * - `claude-code` × `anthropic` (T9410)
  *
  * The singleton is a module-scoped constant (`export const`) rather than a
  * class static so re-importing this module from different entry points
@@ -255,5 +258,23 @@ export class SeederRegistry {
  * mutating `BUILTIN_SEEDERS`.
  *
  * @task T9408
+ * @task T9410
  */
 export const BUILTIN_SEEDERS: SeederRegistry = new SeederRegistry();
+
+// ---------------------------------------------------------------------------
+// Auto-registration of concrete seeders (T9410+)
+// ---------------------------------------------------------------------------
+//
+// Concrete seeders import `CredentialSeeder` as a TYPE only from this
+// module, so the value-level import here does not create a runtime cycle.
+// Registration happens AFTER `BUILTIN_SEEDERS` is declared above so the
+// registry is fully initialized when `register()` is called.
+//
+// To disable a built-in seeder during tests, do NOT mutate this list —
+// construct a fresh `new SeederRegistry()` instead (the contract documented
+// on `BUILTIN_SEEDERS`).
+
+export { ClaudeCodeSeeder, createClaudeCodeSeeder } from './claude-code-seeder.js';
+
+BUILTIN_SEEDERS.register(createClaudeCodeSeeder());


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E2a §5.2 T-E2-3. Mirrors Hermes Agent's `_seed_from_singletons` pattern with the PR #4210 consent gate. The seeder reads `~/.claude/.credentials.json` and emits a pool entry tagged `source:claude-code` with `authType:oauth` — **only** when the user has explicitly opted in via `auth.claudeCodeConsentGiven = true`. Prevents aux fallback chains from silently reading Claude Code credentials.

## Adds
- `AuthConfig` interface in `@cleocode/contracts` with `claudeCodeConsentGiven?: boolean`
- `DEFAULTS.auth = { claudeCodeConsentGiven: false }` (fails closed)
- `ClaudeCodeSeeder` + `createClaudeCodeSeeder` with dependency-injectable filesystem/consent hooks (testable without fs/env mocks)
- Auto-registration into `BUILTIN_SEEDERS`
- 19 unit tests across all 5 required paths (valid+consent, valid+no-consent, missing, expired, malformed)

## Test plan
- [x] 39/39 seeder+config tests pass
- [x] 191/191 `@cleocode/contracts` tests pass
- [x] biome + build + typecheck clean
- [x] Consent gate fails closed (verified `readSpy.not.toHaveBeenCalled()` when consent denied)

## Refs
- `docs/plans/E-CONFIG-AUTH-UNIFY.md` §5.2 T-E2-3
- Epic: T9400, Master: T9500