### PR TITLE
docs(T9559): teach Saga to ct-* skills + fix CLEO-INJECTION commands

### DIFF
--- a/packages/core/templates/CLEO-INJECTION.md
+++ b/packages/core/templates/CLEO-INJECTION.md
@@ -63,13 +63,21 @@ If you find yourself reading a markdown file for orientation, STOP. Run `cleo br
 ### Sagas — above-Epic grouping (ADR-073)
 
 A **Saga** (`SG-`) is a multi-release theme grouping multiple Epics. It is a labeled top-level
-Epic, not a new TaskType. Gating dependency: T9514 must merge before creating Sagas.
+Epic (`label='saga'`), NOT a new TaskType. Members are linked via `task_relations.relation_type='groups'` —
+Sagas do NOT use parent edges, so `cleo list --parent` will not surface members.
+
+Available since v2026.5.77 (T9518 epic; T9514 relates-writer fix as gating dep).
 
 | Goal | Command |
 |------|---------|
-| Create a Saga | `cleo add --type epic --label saga --title "SG-X: ..." --acceptance "..."` |
-| Link an Epic to a Saga | `cleo update SG-X --relates E-Y:groups` |
-| List Epics in a Saga | `cleo list --parent SG-X` (or `cleo find "label:saga"`) |
+| Create a Saga | `cleo saga create --title "..." --description "..." --acceptance "ac1\|ac2\|ac3\|ac4\|ac5"` |
+| Link an Epic to a Saga | `cleo saga add <sagaId> <epicId>` |
+| List all Sagas | `cleo saga list` |
+| List member Epics of a Saga | `cleo saga members <sagaId>` |
+| Aggregate status across members | `cleo saga rollup <sagaId>` |
+
+Sagas hold N Epics at zero nesting-budget cost — the Epic→Task→Subtask depth ladder (maxDepth=3) stays
+untouched under each member Epic. Use Sagas for release themes that span multiple shippable Epics.
 <!-- /CLEO-INJECTION:section=task-creation -->
 
 <!-- CLEO-INJECTION:section=task-discovery -->

--- a/packages/skills/skills/ct-cleo/SKILL.md
+++ b/packages/skills/skills/ct-cleo/SKILL.md
@@ -24,8 +24,19 @@ Supported sections: `session-start` · `work-loop` · `triggers` · `task-creati
 | Complete task | `cleo verify T### --gate ... --evidence "..."` → `cleo complete T###` |
 | Save memory | `cleo memory observe "..." --title "..."` |
 | Spawn subagent | `cleo orchestrate spawn <taskId> --tier 2` |
+| Create a Saga (above-Epic group, ADR-073) | `cleo saga create --title "..." --acceptance "..."` |
+| Link Epic to Saga | `cleo saga add <sagaId> <epicId>` |
+| List Saga members | `cleo saga members <sagaId>` |
 
 ## Skill-Specific Extensions
 
-(No extensions beyond CLEO-INJECTION.md canonical content as of T9148.)
+### Saga tier (since v2026.5.77 · ADR-073)
+
+A **Saga** (`SG-` conceptual prefix; stored as a labeled top-level Epic) groups multiple Epics
+into a multi-release theme. Members link via `task_relations.relation_type='groups'`, not parent
+edges. `cleo list --parent <sagaId>` will NOT surface members — use `cleo saga members <id>`.
+
+Full command surface lives in CLEO-INJECTION.md `task-creation` section. Emit with
+`cleo briefing inject --section task-creation`.
+
 For full decision trees and operation reference tables, emit sections above.

--- a/packages/skills/skills/ct-epic-architect/SKILL.md
+++ b/packages/skills/skills/ct-epic-architect/SKILL.md
@@ -90,6 +90,21 @@ Epic (type: epic, size: large)
 | Task | medium | 3-7 files, single feature |
 | Subtask | small | 1-2 files, single function |
 
+### Above-Epic: Sagas (ADR-073, v2026.5.77+)
+
+A **Saga** groups multiple Epics into a multi-release theme. Use a Saga when the work spans
+more than one shippable Epic and you want a stable handle for rollup/reporting. A Saga is a
+labeled top-level Epic (`label='saga'`) — NOT a new TaskType — so the parent ladder (maxDepth=3)
+under each member Epic is unaffected.
+
+```bash
+cleo saga create --title "Auth Modernization" --description "..." --acceptance "ac1|ac2|ac3|ac4|ac5"
+# returns SG-id (stored as T#### with label=saga)
+cleo saga add <sagaId> <epicId>          # links member Epic via task_relations.type='groups'
+cleo saga members <sagaId>               # returns member list (NOT cleo list --parent)
+cleo saga rollup <sagaId>                # aggregates child statuses + completionPct
+```
+
 ---
 
 ## Epic Creation

--- a/packages/skills/skills/ct-orchestrator/SKILL.md
+++ b/packages/skills/skills/ct-orchestrator/SKILL.md
@@ -199,6 +199,8 @@ When operating without continuous HITL oversight, additional constraints apply: 
 | `cleo orchestrate ready --epic T1575` | Parallel-safe tasks in current wave |
 | `cleo orchestrate spawn T1586 --json` | Generate resolved spawn prompt |
 | `cleo orchestrate next --epic T1575` | Suggest next task |
+| `cleo saga rollup <sagaId>` | Cross-Epic status aggregation when orchestrating a multi-Epic Saga (ADR-073) |
+| `cleo saga members <sagaId>` | Member Epics of a Saga (NOT `cleo list --parent` — Sagas use `task_relations.type=groups`) |
 | `cleo pipeline stage.status --epic T1575` | Current pipeline stage |
 | `cleo pipeline stage.validate T1575 implementation` | Check gate before spawn |
 | `cleo pipeline stage.gate.pass T1575 research` | Advance pipeline stage |


### PR DESCRIPTION
## Summary

Post-v2026.5.77 follow-up. The Saga foundation shipped under T9518/T9520 added a Sagas subsection to CLEO-INJECTION.md, but the commands listed were incorrect (used the raw `cleo update --relates E-Y:groups` workaround + an impossible `cleo list --parent SG-X` — Sagas don't have parent edges). Additionally, ZERO of the SSoT skills (ct-cleo, ct-orchestrator, ct-epic-architect, ct-task-executor, ct-lead, ct-release-orchestrator) mentioned Saga.

## Changes

- **`packages/core/templates/CLEO-INJECTION.md`** — Saga section now references the actual `cleo saga create/add/list/members/rollup` CLI surface shipped in v2026.5.77.
- **`packages/skills/skills/ct-cleo/SKILL.md`** — 3 Saga rows added to the Quick Reference + a new "Saga tier" subsection in Skill-Specific Extensions.
- **`packages/skills/skills/ct-orchestrator/SKILL.md`** — saga rollup/members rows added to the operation reference, with explicit warning that `cleo list --parent` does NOT surface Saga members.
- **`packages/skills/skills/ct-epic-architect/SKILL.md`** — new "Above-Epic: Sagas" subsection under Size Guidelines explaining when to introduce a Saga vs. another Epic.

## Validation

End-to-end Saga lifecycle against installed `@cleocode/cleo@2026.5.77`:

```
cleo saga create -> T9556 (label=saga)
cleo saga add T9556 T9557 -> {added:true}
cleo saga add T9556 T9558 -> {added:true}
cleo saga members T9556 -> total:2 (both type='groups')
cleo saga rollup T9556 -> {total:2, pending:2, completionPct:0}
```

Refs T9518 (Saga foundation epic) / ADR-073