### PR TITLE
feat(T9411): add cleo-pkce seeder + cooperative write-back to claude code creds

### DIFF
--- a/packages/contracts/src/config.ts
+++ b/packages/contracts/src/config.ts
@@ -624,6 +624,25 @@ export interface AuthConfig {
    * @defaultValue false
    */
   claudeCodeConsentGiven?: boolean;
+  /**
+   * Whether CLEO writes refreshed Anthropic OAuth tokens back to Claude
+   * Code's credential file (`~/.claude/.credentials.json`) in addition to
+   * CLEO's own canonical token file (`${getCleoHome()}/anthropic-oauth.json`).
+   *
+   * CLEO ALWAYS writes its own file on every refresh. The cooperative write
+   * to Claude Code's file is gated by this flag AND by either
+   * (a) the Claude Code file already existing on disk, or
+   * (b) `claudeCodeConsentGiven` being `true`.
+   *
+   * This mirrors the OQ-1 decision in `docs/plans/E-CONFIG-AUTH-UNIFY.md`:
+   * cooperative write-back is enabled by default so two CLIs sharing one
+   * machine stay token-coherent, but CLEO never creates Claude Code's file
+   * unless the operator has explicitly opted in.
+   *
+   * @defaultValue true
+   * @task T9411
+   */
+  cooperativeWriteBack?: boolean;
 }
 
 /**

--- a/packages/contracts/src/credentials.ts
+++ b/packages/contracts/src/credentials.ts
@@ -32,6 +32,16 @@ export interface ClaudeCodeOAuthBlock {
   expiresAt?: number;
   /** Refresh token for obtaining new access tokens. Optional. */
   refreshToken?: string;
+  /**
+   * OAuth scopes granted to the token, e.g. `['user:inference']`.
+   *
+   * Claude Code >= 2.1.81 requires the `user:inference` scope on its OAuth
+   * tokens; cooperative write-back (T9411) preserves whatever scopes are
+   * already on disk so we never strip the field on refresh.
+   *
+   * @task T9411
+   */
+  scopes?: string[];
 }
 
 /**
@@ -47,6 +57,16 @@ export interface ParsedClaudeCodeCredential {
   expiresAt?: number;
   /** Refresh token, if present in the credentials file. */
   refreshToken?: string;
+  /**
+   * OAuth scopes granted to the token, if present in the credentials file.
+   *
+   * Preserved verbatim by the parser — `parseClaudeCodeCredentials` does not
+   * filter or normalize the array. Cooperative write-back (T9411) relies on
+   * this to keep Claude Code's `user:inference` scope intact across refreshes.
+   *
+   * @task T9411
+   */
+  scopes?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -103,10 +123,19 @@ export function parseClaudeCodeCredentials(
         ? block['refreshToken']
         : undefined;
 
+    // T9411 — preserve `scopes` verbatim so cooperative write-back keeps
+    // Claude Code's `user:inference` grant intact across refreshes.
+    const rawScopes = block['scopes'];
+    const scopes =
+      Array.isArray(rawScopes) && rawScopes.every((s) => typeof s === 'string')
+        ? (rawScopes as string[])
+        : undefined;
+
     return {
       accessToken: accessToken.trim(),
       ...(expiresAt !== undefined ? { expiresAt } : {}),
       ...(refreshToken !== undefined ? { refreshToken } : {}),
+      ...(scopes !== undefined ? { scopes } : {}),
     };
   } catch {
     return null;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -112,6 +112,11 @@ const DEFAULTS: CleoConfig = {
     // Mirrors Hermes Agent PR #4210: aux fallback chains cannot silently
     // read `~/.claude/.credentials.json` without the operator's consent.
     claudeCodeConsentGiven: false,
+    // T9411 — Cooperative write-back to ~/.claude/.credentials.json is ON
+    // by default per OQ-1 in docs/plans/E-CONFIG-AUTH-UNIFY.md. CLEO still
+    // never creates Claude Code's file unless the operator has consented;
+    // this default only governs whether an existing file gets co-written.
+    cooperativeWriteBack: true,
   },
 };
 

--- a/packages/core/src/llm/__tests__/credential-writeback.test.ts
+++ b/packages/core/src/llm/__tests__/credential-writeback.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Unit tests for `credential-writeback.ts` (E-CONFIG-AUTH-UNIFY E2a / T9411).
+ *
+ * Each test isolates the filesystem by setting `CLEO_HOME`, `XDG_DATA_HOME`,
+ * and `HOME` to per-test temp directories before invoking the writeback.
+ * This is the same pattern used by `credential-removal.test.ts`.
+ *
+ * The test surface covers:
+ *
+ * - default (cooperativeWriteBack=true): both files written
+ * - Claude Code file absent + no consent: only CLEO file written
+ * - Claude Code file absent + consent given: both files written
+ * - cooperativeWriteBack=false: only CLEO file written
+ * - scopes preservation: existing on-disk scopes carried forward
+ * - scopes override: refresh-supplied scopes win over disk
+ * - file permissions: 0o600 on both
+ * - atomic write: no orphaned `.tmp` files left behind
+ *
+ * @task T9411
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { writeBackAnthropicTokens } from '../credential-writeback.js';
+
+// ---------------------------------------------------------------------------
+// Environment isolation helpers
+// ---------------------------------------------------------------------------
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const ENV_KEYS = ['XDG_DATA_HOME', 'CLEO_HOME', 'HOME', 'USERPROFILE'];
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+interface IsolatedHomes {
+  cleoHome: string;
+  home: string;
+  claudeDir: string;
+  claudePath: string;
+  cleoPath: string;
+}
+
+function isolateHomes(): IsolatedHomes {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const xdgRoot = join(tmpdir(), `cleo-wb-xdg-${stamp}`);
+  const home = join(tmpdir(), `cleo-wb-home-${stamp}`);
+  const cleoHome = join(xdgRoot, 'cleo');
+  const claudeDir = join(home, '.claude');
+  mkdirSync(cleoHome, { recursive: true });
+  mkdirSync(claudeDir, { recursive: true });
+  process.env['XDG_DATA_HOME'] = xdgRoot;
+  process.env['CLEO_HOME'] = cleoHome;
+  process.env['HOME'] = home;
+  // Windows fallback used by `os.homedir()` in some envs.
+  process.env['USERPROFILE'] = home;
+  return {
+    cleoHome,
+    home,
+    claudeDir,
+    claudePath: join(claudeDir, '.credentials.json'),
+    cleoPath: join(cleoHome, 'anthropic-oauth.json'),
+  };
+}
+
+/** Write a global config with the given auth block to `<cleoHome>/config.json`. */
+function writeGlobalConfig(cleoHome: string, auth: Record<string, unknown>): void {
+  const cfg = { auth };
+  writeFileSync(join(cleoHome, 'config.json'), `${JSON.stringify(cfg, null, 2)}\n`, 'utf-8');
+}
+
+/** Seed a Claude Code credential file with given scopes. */
+function seedClaudeCodeFile(path: string, scopes?: string[]): void {
+  const envelope = {
+    claudeAiOauth: {
+      accessToken: 'sk-ant-oat-old-claude-code',
+      refreshToken: 'sk-ant-ort-old-claude-code',
+      expiresAt: Date.now() + 60_000,
+      ...(scopes !== undefined ? { scopes } : {}),
+    },
+  };
+  writeFileSync(path, `${JSON.stringify(envelope, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
+}
+
+beforeEach(() => {
+  saveEnv();
+});
+
+afterEach(() => {
+  restoreEnv();
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function refreshedTokens(): {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+} {
+  return {
+    accessToken: 'sk-ant-oat-NEW-tokens-from-refresh',
+    refreshToken: 'sk-ant-ort-NEW-tokens-from-refresh',
+    expiresAt: Date.now() + 3_600_000,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Always-write-CLEO behavior
+// ---------------------------------------------------------------------------
+
+describe('writeBackAnthropicTokens — CLEO file (always written)', () => {
+  it('writes refreshed tokens to <CLEO_HOME>/anthropic-oauth.json', async () => {
+    const { cleoPath, cleoHome } = isolateHomes();
+    // Default: no explicit config — DEFAULTS govern. cooperativeWriteBack=true.
+    // claudeCodeConsentGiven=false, Claude Code file absent → only CLEO file.
+    writeGlobalConfig(cleoHome, {});
+
+    const result = await writeBackAnthropicTokens(refreshedTokens());
+
+    expect(result.written).toContain(cleoPath);
+    expect(existsSync(cleoPath)).toBe(true);
+    const written = JSON.parse(readFileSync(cleoPath, 'utf-8')) as {
+      claudeAiOauth: Record<string, unknown>;
+    };
+    expect(written.claudeAiOauth.accessToken).toBe('sk-ant-oat-NEW-tokens-from-refresh');
+    expect(written.claudeAiOauth.refreshToken).toBe('sk-ant-ort-NEW-tokens-from-refresh');
+    expect(typeof written.claudeAiOauth.expiresAt).toBe('number');
+  });
+
+  it('persists CLEO file with mode 0o600', async () => {
+    const { cleoPath, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, {});
+
+    await writeBackAnthropicTokens(refreshedTokens());
+
+    const mode = statSync(cleoPath).mode & 0o777;
+    // POSIX: must be exactly 0o600. Windows: chmod is best-effort, so we
+    // accept 0o600 OR 0o666 (typical Windows file mode echoed back by
+    // statSync). Either way we MUST NOT see group/other bits leaking.
+    if (process.platform === 'win32') {
+      expect(mode & 0o077).toBe(0); // no group/other bits
+    } else {
+      expect(mode).toBe(0o600);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cooperative write-back — Claude Code file
+// ---------------------------------------------------------------------------
+
+describe('writeBackAnthropicTokens — Claude Code file (cooperative)', () => {
+  it('writes BOTH files by default (cooperativeWriteBack=true) when claude file exists', async () => {
+    const { cleoPath, claudePath, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, {});
+    seedClaudeCodeFile(claudePath, ['user:inference']);
+
+    const result = await writeBackAnthropicTokens(refreshedTokens());
+
+    expect(result.written).toContain(cleoPath);
+    expect(result.written).toContain(claudePath);
+    expect(result.skipped).toEqual([]);
+
+    const claudeWritten = JSON.parse(readFileSync(claudePath, 'utf-8')) as {
+      claudeAiOauth: { accessToken: string; scopes?: string[] };
+    };
+    expect(claudeWritten.claudeAiOauth.accessToken).toBe('sk-ant-oat-NEW-tokens-from-refresh');
+  });
+
+  it('skips claude file when cooperativeWriteBack=false', async () => {
+    const { cleoPath, claudePath, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, { cooperativeWriteBack: false });
+    seedClaudeCodeFile(claudePath, ['user:inference']);
+
+    const claudeBefore = readFileSync(claudePath, 'utf-8');
+    const result = await writeBackAnthropicTokens(refreshedTokens());
+
+    expect(result.written).toEqual([cleoPath]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.path).toBe(claudePath);
+    expect(result.skipped[0]?.reason).toContain('cooperativeWriteBack=false');
+    // Original claude file MUST be untouched.
+    expect(readFileSync(claudePath, 'utf-8')).toBe(claudeBefore);
+  });
+
+  it('skips claude file when absent AND no consent (does NOT create it)', async () => {
+    const { cleoPath, claudePath, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, { cooperativeWriteBack: true });
+    // Note: no seedClaudeCodeFile — file absent. consent default = false.
+    expect(existsSync(claudePath)).toBe(false);
+
+    const result = await writeBackAnthropicTokens(refreshedTokens());
+
+    expect(result.written).toEqual([cleoPath]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.path).toBe(claudePath);
+    expect(result.skipped[0]?.reason).toContain('claude-code file absent');
+    expect(existsSync(claudePath)).toBe(false);
+  });
+
+  it('creates claude file when absent BUT consent has been given', async () => {
+    const { cleoPath, claudePath, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, {
+      cooperativeWriteBack: true,
+      claudeCodeConsentGiven: true,
+    });
+    expect(existsSync(claudePath)).toBe(false);
+
+    const result = await writeBackAnthropicTokens(refreshedTokens());
+
+    expect(result.written).toContain(cleoPath);
+    expect(result.written).toContain(claudePath);
+    expect(result.skipped).toEqual([]);
+    expect(existsSync(claudePath)).toBe(true);
+  });
+
+  it('persists claude file with mode 0o600', async () => {
+    const { claudePath, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, {});
+    seedClaudeCodeFile(claudePath, ['user:inference']);
+
+    await writeBackAnthropicTokens(refreshedTokens());
+
+    const mode = statSync(claudePath).mode & 0o777;
+    if (process.platform === 'win32') {
+      expect(mode & 0o077).toBe(0);
+    } else {
+      expect(mode).toBe(0o600);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scopes preservation — critical for Claude Code >= 2.1.81
+// ---------------------------------------------------------------------------
+
+describe('writeBackAnthropicTokens — scopes preservation', () => {
+  it('preserves existing claudeAiOauth.scopes when refresh omits scopes', async () => {
+    const { claudePath, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, {});
+    seedClaudeCodeFile(claudePath, ['user:inference']);
+
+    await writeBackAnthropicTokens(refreshedTokens());
+
+    const written = JSON.parse(readFileSync(claudePath, 'utf-8')) as {
+      claudeAiOauth: { scopes?: string[] };
+    };
+    expect(written.claudeAiOauth.scopes).toEqual(['user:inference']);
+  });
+
+  it('overrides on-disk scopes with refresh-supplied scopes', async () => {
+    const { claudePath, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, {});
+    seedClaudeCodeFile(claudePath, ['user:inference']);
+
+    await writeBackAnthropicTokens({
+      ...refreshedTokens(),
+      scopes: ['user:inference', 'user:profile'],
+    });
+
+    const written = JSON.parse(readFileSync(claudePath, 'utf-8')) as {
+      claudeAiOauth: { scopes?: string[] };
+    };
+    expect(written.claudeAiOauth.scopes).toEqual(['user:inference', 'user:profile']);
+  });
+
+  it('omits scopes when neither disk nor refresh provide them', async () => {
+    const { cleoPath, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, {});
+    // No claude file, no scopes on refresh, no prior cleo file.
+
+    await writeBackAnthropicTokens(refreshedTokens());
+
+    const written = JSON.parse(readFileSync(cleoPath, 'utf-8')) as {
+      claudeAiOauth: Record<string, unknown>;
+    };
+    expect(written.claudeAiOauth).not.toHaveProperty('scopes');
+  });
+
+  it('preserves on-disk scopes even when the existing token is expired', async () => {
+    const { claudePath, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, {});
+    // Write an expired Claude Code file with scopes attached.
+    const expiredEnvelope = {
+      claudeAiOauth: {
+        accessToken: 'sk-ant-oat-expired',
+        refreshToken: 'sk-ant-ort-expired',
+        expiresAt: Date.now() - 60_000,
+        scopes: ['user:inference'],
+      },
+    };
+    writeFileSync(claudePath, `${JSON.stringify(expiredEnvelope, null, 2)}\n`, {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+
+    await writeBackAnthropicTokens(refreshedTokens());
+
+    const written = JSON.parse(readFileSync(claudePath, 'utf-8')) as {
+      claudeAiOauth: { scopes?: string[] };
+    };
+    expect(written.claudeAiOauth.scopes).toEqual(['user:inference']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Atomicity — no orphaned temp files left behind
+// ---------------------------------------------------------------------------
+
+describe('writeBackAnthropicTokens — atomicity', () => {
+  it('leaves no .tmp files behind after successful writes', async () => {
+    const { claudeDir, cleoHome } = isolateHomes();
+    writeGlobalConfig(cleoHome, {});
+    seedClaudeCodeFile(join(claudeDir, '.credentials.json'), ['user:inference']);
+
+    await writeBackAnthropicTokens(refreshedTokens());
+
+    const cleoEntries = readdirSync(cleoHome).filter((n) => n.endsWith('.tmp'));
+    const claudeEntries = readdirSync(claudeDir).filter((n) => n.endsWith('.tmp'));
+    expect(cleoEntries).toEqual([]);
+    expect(claudeEntries).toEqual([]);
+  });
+});

--- a/packages/core/src/llm/credential-seeders/__tests__/cleo-pkce-seeder.test.ts
+++ b/packages/core/src/llm/credential-seeders/__tests__/cleo-pkce-seeder.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for `CleoPkceSeeder` (E-CONFIG-AUTH-UNIFY E2a / T9411).
+ *
+ * Like the `claude-code` seeder tests, the suite uses constructor-injected
+ * dependency seams so it stays pure — no fs writes, no env-var fiddling,
+ * no module mocks. Each test asserts one branch of the seeder's decision
+ * tree:
+ *
+ * - valid token → one pool entry emitted, with scopes-aware fields
+ * - missing file → empty (no throw)
+ * - malformed JSON → empty (no throw)
+ * - expired token → empty (parser drops it)
+ * - auto-registered in BUILTIN_SEEDERS
+ *
+ * Unlike `claude-code`, this seeder reads a first-party file so there is
+ * NO consent gate to test — the `isConsentEstablished` hook is omitted on
+ * the class entirely (treated as "always consented" per the contract).
+ *
+ * @task T9411
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_SEEDERS, CleoPkceSeeder, SeederRegistry } from '../index.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const FUTURE_EXPIRES_AT = Date.now() + 24 * 60 * 60 * 1000; // +24 hours
+const PAST_EXPIRES_AT = Date.now() - 60 * 60 * 1000; // -1 hour
+
+function validPkceJson(): string {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'sk-ant-oat-cleo-pkce-fixture',
+      refreshToken: 'sk-ant-ort-cleo-pkce-fixture',
+      expiresAt: FUTURE_EXPIRES_AT,
+      scopes: ['user:inference'],
+    },
+  });
+}
+
+function expiredPkceJson(): string {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'sk-ant-oat-cleo-pkce-fixture',
+      refreshToken: 'sk-ant-ort-cleo-pkce-fixture',
+      expiresAt: PAST_EXPIRES_AT,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Behavioural tests
+// ---------------------------------------------------------------------------
+
+describe('CleoPkceSeeder', () => {
+  describe('identity', () => {
+    it('reports sourceId=cleo-pkce and provider=anthropic', () => {
+      const seeder = new CleoPkceSeeder({ readCredentialFile: () => null });
+      expect(seeder.sourceId).toBe('cleo-pkce');
+      expect(seeder.provider).toBe('anthropic');
+    });
+
+    it('does NOT declare an isConsentEstablished hook (first-party source)', () => {
+      const seeder = new CleoPkceSeeder({ readCredentialFile: () => null });
+      // The PKCE file is CLEO-owned; consent is implicit by running `cleo
+      // llm login`. Declaring the hook would route the seeder through the
+      // consent gate path in the resolver, which is wrong.
+      expect(seeder.isConsentEstablished).toBeUndefined();
+    });
+  });
+
+  describe('seed — happy path', () => {
+    it('emits one anthropic entry when the PKCE file is present + valid', async () => {
+      const seeder = new CleoPkceSeeder({
+        readCredentialFile: () => validPkceJson(),
+      });
+
+      const result = await seeder.seed();
+
+      expect(result.entries).toHaveLength(1);
+      const entry = result.entries[0]!;
+      expect(entry.provider).toBe('anthropic');
+      expect(entry.label).toBe('cleo-pkce');
+      expect(entry.source).toBe('cleo-pkce');
+      expect(entry.authType).toBe('oauth');
+      expect(entry.accessToken).toBe('sk-ant-oat-cleo-pkce-fixture');
+      expect(entry.refreshToken).toBe('sk-ant-ort-cleo-pkce-fixture');
+      expect(entry.expiresAt).toBe(FUTURE_EXPIRES_AT);
+    });
+
+    it('omits refreshToken/expiresAt when the source file omits them', async () => {
+      const seeder = new CleoPkceSeeder({
+        readCredentialFile: () =>
+          JSON.stringify({
+            claudeAiOauth: { accessToken: 'sk-ant-oat-no-extras' },
+          }),
+      });
+
+      const result = await seeder.seed();
+      expect(result.entries).toHaveLength(1);
+      const entry = result.entries[0]!;
+      expect(entry.accessToken).toBe('sk-ant-oat-no-extras');
+      expect(entry).not.toHaveProperty('refreshToken');
+      expect(entry).not.toHaveProperty('expiresAt');
+    });
+  });
+
+  describe('seed — degraded source paths', () => {
+    it('returns empty when the PKCE file is missing (null)', async () => {
+      const seeder = new CleoPkceSeeder({
+        readCredentialFile: () => null,
+      });
+      const result = await seeder.seed();
+      expect(result.entries).toEqual([]);
+    });
+
+    it('returns empty when the JSON is malformed', async () => {
+      const seeder = new CleoPkceSeeder({
+        readCredentialFile: () => '{ not valid json',
+      });
+      const result = await seeder.seed();
+      expect(result.entries).toEqual([]);
+    });
+
+    it('returns empty when the token is expired', async () => {
+      const seeder = new CleoPkceSeeder({
+        readCredentialFile: () => expiredPkceJson(),
+      });
+      const result = await seeder.seed();
+      expect(result.entries).toEqual([]);
+    });
+
+    it('returns empty when the claudeAiOauth block is absent', async () => {
+      const seeder = new CleoPkceSeeder({
+        readCredentialFile: () => JSON.stringify({ someOtherKey: 'value' }),
+      });
+      const result = await seeder.seed();
+      expect(result.entries).toEqual([]);
+    });
+
+    it('does NOT throw on filesystem errors — collapses to empty', async () => {
+      const seeder = new CleoPkceSeeder({
+        // Simulates the default `readCredentialFile`'s contract: every
+        // error path (ENOENT, EACCES, etc.) collapses to `null`.
+        readCredentialFile: () => null,
+      });
+      await expect(seeder.seed()).resolves.toEqual({ entries: [] });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry integration
+// ---------------------------------------------------------------------------
+
+describe('BUILTIN_SEEDERS auto-registration (cleo-pkce)', () => {
+  it('contains exactly one (cleo-pkce, anthropic) seeder', () => {
+    const matches = BUILTIN_SEEDERS.getAll().filter(
+      (s) => s.sourceId === 'cleo-pkce' && s.provider === 'anthropic',
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toBeInstanceOf(CleoPkceSeeder);
+  });
+
+  it('exposes the seeder via getByProvider("anthropic")', () => {
+    const anthropicSeeders = BUILTIN_SEEDERS.getByProvider('anthropic');
+    const pkce = anthropicSeeders.find((s) => s.sourceId === 'cleo-pkce');
+    expect(pkce).toBeDefined();
+    expect(pkce).toBeInstanceOf(CleoPkceSeeder);
+  });
+
+  it('uses the canonical SeederRegistry key encoding', () => {
+    expect(SeederRegistry.makeKey('cleo-pkce', 'anthropic')).toBe('cleo-pkce::anthropic');
+  });
+});

--- a/packages/core/src/llm/credential-seeders/cleo-pkce-seeder.ts
+++ b/packages/core/src/llm/credential-seeders/cleo-pkce-seeder.ts
@@ -1,0 +1,182 @@
+/**
+ * `cleo-pkce` credential seeder — reads CLEO's own PKCE-issued Anthropic
+ * OAuth token at `${getCleoHome()}/anthropic-oauth.json` and emits it as a
+ * single `anthropic` entry in the unified credential pool.
+ *
+ * E-CONFIG-AUTH-UNIFY E2a §5.2 T-E2-4. Architectural mirror of Hermes
+ * Agent's `_seed_from_cleo_pkce` dispatch.
+ *
+ * ## File shape
+ *
+ * The CLEO-owned PKCE file uses Claude Code's `claudeAiOauth` envelope
+ * shape so the two CLIs can cooperatively share credentials via the
+ * write-back handler (`credential-writeback.ts`):
+ *
+ * ```json
+ * {
+ *   "claudeAiOauth": {
+ *     "accessToken": "sk-ant-oat-...",
+ *     "refreshToken": "sk-ant-ort-...",
+ *     "expiresAt": 1700000000000,
+ *     "scopes": ["user:inference"]
+ *   }
+ * }
+ * ```
+ *
+ * Parsing is delegated to `parseClaudeCodeCredentials()` in
+ * `@cleocode/contracts` so the on-disk format lives in exactly one place.
+ *
+ * ## Consent gate
+ *
+ * Unlike the `claude-code` seeder, the PKCE seeder reads a CLEO-owned
+ * file: the operator implicitly consented by running `cleo llm login`,
+ * so no consent flag is consulted. `isConsentEstablished` is therefore
+ * omitted (`undefined` is treated as "always consented" by the contract).
+ *
+ * ## Zero-result paths
+ *
+ * Missing file, malformed JSON, missing `claudeAiOauth` block, and
+ * expired token all collapse to `{ entries: [] }` without throwing —
+ * the seeder contract MUST NOT signal "source absent" via exceptions.
+ *
+ * @module llm/credential-seeders/cleo-pkce-seeder
+ * @task T9411
+ * @epic E-CONFIG-AUTH-UNIFY (E2a)
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseClaudeCodeCredentials } from '@cleocode/contracts';
+import { getCleoHome } from '../../paths.js';
+import type {
+  CredentialSeeder,
+  SeederCredentialEntry,
+  SeederResult,
+  SeederSourceId,
+} from './index.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Stable label written into the pool entry's `label` field. */
+const SEEDER_LABEL = 'cleo-pkce';
+
+/** `(sourceId, provider)` pair this seeder owns inside the registry. */
+const SOURCE_ID: SeederSourceId = 'cleo-pkce';
+const PROVIDER = 'anthropic';
+
+/**
+ * Default on-disk path for CLEO's PKCE token cache.
+ *
+ * Computed at call-time (not module-load) so test runners that swap
+ * `CLEO_DATA_DIR` between cases observe the change.
+ */
+function defaultCleoPkcePath(): string {
+  return join(getCleoHome(), 'anthropic-oauth.json');
+}
+
+// ---------------------------------------------------------------------------
+// Seeder implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Concrete `CredentialSeeder` for the `cleo-pkce` source.
+ *
+ * Constructor-injectable filesystem hook (`readCredentialFile`) keeps tests
+ * pure — they exercise the expiry, missing-file, and malformed-JSON paths
+ * without touching the real CLEO data directory and without module-level
+ * fs mocks. The default `readCredentialFile` implementation calls
+ * `readFileSync` on `${getCleoHome()}/anthropic-oauth.json`.
+ *
+ * @task T9411
+ */
+export class CleoPkceSeeder implements CredentialSeeder {
+  /** @inheritdoc */
+  readonly sourceId: SeederSourceId = SOURCE_ID;
+  /** @inheritdoc */
+  readonly provider = PROVIDER;
+
+  private readonly readCredentialFile: () => string | null;
+
+  /**
+   * Construct a seeder.
+   *
+   * @param opts - Optional dependency-injection seams. `readCredentialFile`
+   *   MUST return `null` when the file is missing or unreadable (it MUST
+   *   NOT throw). The default implementation reads
+   *   `${getCleoHome()}/anthropic-oauth.json` and collapses every error
+   *   path to `null`.
+   */
+  constructor(opts?: { readCredentialFile?: () => string | null }) {
+    this.readCredentialFile = opts?.readCredentialFile ?? defaultReadCredentialFile;
+  }
+
+  /**
+   * Read the CLEO PKCE OAuth file and emit a single anthropic pool entry.
+   *
+   * Short-circuits to `{ entries: [] }` when the file is absent, the JSON
+   * is malformed, the `claudeAiOauth` block is missing, or the token has
+   * expired (per `parseClaudeCodeCredentials`). Never throws.
+   */
+  async seed(): Promise<SeederResult> {
+    const raw = this.readCredentialFile();
+    if (raw === null) {
+      return { entries: [] };
+    }
+
+    const parsed = parseClaudeCodeCredentials(raw);
+    if (parsed === null) {
+      // Malformed JSON, missing oauth block, or expired token.
+      return { entries: [] };
+    }
+
+    const entry: SeederCredentialEntry = {
+      provider: 'anthropic',
+      label: SEEDER_LABEL,
+      authType: 'oauth',
+      accessToken: parsed.accessToken,
+      source: SEEDER_LABEL,
+      ...(parsed.expiresAt !== undefined ? { expiresAt: parsed.expiresAt } : {}),
+      ...(parsed.refreshToken !== undefined ? { refreshToken: parsed.refreshToken } : {}),
+    };
+
+    return { entries: [entry] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default dependency-injection implementations
+// ---------------------------------------------------------------------------
+
+/**
+ * Default `readCredentialFile` implementation.
+ *
+ * Returns the UTF-8 contents of `${getCleoHome()}/anthropic-oauth.json`,
+ * or `null` when the file is absent or unreadable. NEVER throws — every
+ * error path collapses to `null` so the seeder's "source absent" contract
+ * holds.
+ *
+ * @internal
+ */
+function defaultReadCredentialFile(): string | null {
+  try {
+    return readFileSync(defaultCleoPkcePath(), 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Factory for the singleton `CleoPkceSeeder` registered into
+ * `BUILTIN_SEEDERS` from `index.ts`.
+ *
+ * Kept as a factory (not a module-level `const`) so the registry-side
+ * import remains acyclic and tests can construct fresh instances with
+ * injected dependencies.
+ *
+ * @task T9411
+ */
+export function createCleoPkceSeeder(): CleoPkceSeeder {
+  return new CleoPkceSeeder();
+}

--- a/packages/core/src/llm/credential-seeders/index.ts
+++ b/packages/core/src/llm/credential-seeders/index.ts
@@ -33,6 +33,7 @@
 
 import type { StoredCredential } from '../credentials-store.js';
 import { createClaudeCodeSeeder } from './claude-code-seeder.js';
+import { createCleoPkceSeeder } from './cleo-pkce-seeder.js';
 import { codexCliSeeder } from './codex-cli-seeder.js';
 import { geminiCliSeeder } from './gemini-cli-seeder.js';
 import { ghCliSeeder } from './gh-cli-seeder.js';
@@ -255,6 +256,7 @@ export class SeederRegistry {
  *
  * - env seeders for every provider in ENV_VARS (T9409)
  * - `claude-code` × `anthropic` (T9410)
+ * - `cleo-pkce` × `anthropic` (T9411)
  * - `codex-cli`, `gemini-cli`, `gh-cli` external seeders (T9418)
  *
  * The singleton is a module-scoped constant (`export const`) rather than a
@@ -265,6 +267,7 @@ export class SeederRegistry {
  *
  * @task T9408 (foundation)
  * @task T9410 (claude-code seeder)
+ * @task T9411 (cleo-pkce seeder)
  * @task T9418 (codex-cli, gemini-cli, gh-cli)
  */
 export const BUILTIN_SEEDERS: SeederRegistry = new SeederRegistry();
@@ -283,11 +286,13 @@ export const BUILTIN_SEEDERS: SeederRegistry = new SeederRegistry();
 // on `BUILTIN_SEEDERS`).
 
 export { ClaudeCodeSeeder, createClaudeCodeSeeder } from './claude-code-seeder.js';
+export { CleoPkceSeeder, createCleoPkceSeeder } from './cleo-pkce-seeder.js';
 export { codexCliSeeder } from './codex-cli-seeder.js';
 export { geminiCliSeeder } from './gemini-cli-seeder.js';
 export { ghCliSeeder } from './gh-cli-seeder.js';
 
 BUILTIN_SEEDERS.register(createClaudeCodeSeeder());
+BUILTIN_SEEDERS.register(createCleoPkceSeeder());
 BUILTIN_SEEDERS.register(codexCliSeeder);
 BUILTIN_SEEDERS.register(geminiCliSeeder);
 BUILTIN_SEEDERS.register(ghCliSeeder);

--- a/packages/core/src/llm/credential-writeback.ts
+++ b/packages/core/src/llm/credential-writeback.ts
@@ -1,0 +1,368 @@
+/**
+ * Anthropic OAuth token write-back — the canonical refresh-time persistence
+ * path for the unified credential pool (E-CONFIG-AUTH-UNIFY E2a / T9411).
+ *
+ * On every successful OAuth refresh, CLEO ALWAYS writes the new tokens
+ * to its own canonical file at `${getCleoHome()}/anthropic-oauth.json`.
+ * When the operator has enabled cooperative write-back (default per OQ-1)
+ * AND Claude Code's credential file either already exists OR the operator
+ * has consented to Claude Code import, CLEO ALSO mirrors the refreshed
+ * tokens into `~/.claude/.credentials.json`.
+ *
+ * ## Why cooperate
+ *
+ * Operators routinely run both CLEO and Claude Code from the same machine
+ * against the same Anthropic account. Without cooperative write-back, the
+ * first CLI to refresh wins and the other rejects subsequent requests with
+ * `401 invalid_token` until the operator manually re-logs. The OQ-1
+ * decision in `docs/plans/E-CONFIG-AUTH-UNIFY.md` resolves this by making
+ * write-back ON by default — both CLIs see the freshest token at all
+ * times — but never auto-creating Claude Code's file (consent-respecting).
+ *
+ * ## Atomicity + permissions
+ *
+ * Both writes use a temp-file-then-rename strategy with `mode: 0o600` set
+ * at temp-file creation time so:
+ *
+ * 1. The post-rename file is born with the strict permission — there is
+ *    no instant at which a 0o644 default file holds secrets on disk.
+ * 2. A crash mid-write never leaves the live file truncated.
+ *
+ * After the rename succeeds, a defensive `chmod 0o600` is applied to the
+ * live file. This is redundant on POSIX (the rename preserves the temp's
+ * mode) but guards against Windows behavior where the open-mode flag on
+ * `writeFileSync` is silently ignored.
+ *
+ * ## Scope preservation
+ *
+ * Claude Code >= 2.1.81 requires the `user:inference` scope on its OAuth
+ * tokens; refreshes from the Anthropic API do NOT necessarily return the
+ * scopes string, so this module MUST read the existing Claude Code file
+ * (when present) and carry the scopes array forward verbatim. CLEO's own
+ * file behaves the same way — if a `scopes` array is present we preserve
+ * it; if the refresh provided new scopes those override.
+ *
+ * @module llm/credential-writeback
+ * @task T9411
+ * @epic E-CONFIG-AUTH-UNIFY (E2a)
+ */
+
+import { randomBytes } from 'node:crypto';
+import {
+  chmodSync,
+  existsSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { parseClaudeCodeCredentials } from '@cleocode/contracts';
+import { getConfigValue } from '../config.js';
+import { getCleoHome } from '../paths.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Strict file mode for OAuth credential files (owner read/write only). */
+const SECRET_FILE_MODE = 0o600;
+
+/** Config flag controlling cooperative write-back to Claude Code's file. */
+const COOPERATIVE_FLAG_KEY = 'auth.cooperativeWriteBack';
+
+/** Config flag attesting that the operator consented to Claude Code import. */
+const CONSENT_FLAG_KEY = 'auth.claudeCodeConsentGiven';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Refreshed OAuth token bundle handed to {@link writeBackAnthropicTokens}.
+ *
+ * `scopes` is optional — the Anthropic refresh endpoint does not always
+ * return it. When omitted, the write-back handler reads the existing
+ * on-disk file (CLEO's own and Claude Code's) and carries the previous
+ * scopes forward so Claude Code's `user:inference` requirement is honored.
+ */
+export interface RefreshedAnthropicTokens {
+  /** New short-lived bearer token returned by the refresh exchange. */
+  accessToken: string;
+  /** New refresh token to use for the next refresh. */
+  refreshToken: string;
+  /** Unix-millisecond expiry timestamp of the new access token. */
+  expiresAt: number;
+  /**
+   * Optional scopes string array returned by the refresh exchange.
+   *
+   * When omitted, the write-back preserves whatever scopes were on disk.
+   */
+  scopes?: string[];
+}
+
+/**
+ * Result of {@link writeBackAnthropicTokens}.
+ *
+ * `written` lists the absolute paths that were successfully written.
+ * `skipped` lists paths that were intentionally NOT written, paired with
+ * a human-readable reason (e.g. `"cooperativeWriteBack=false"`). Failed
+ * writes throw — they never appear in either list.
+ */
+export interface WriteBackResult {
+  /** Absolute paths of files that were written. */
+  written: string[];
+  /** Absolute paths NOT written, paired with a `reason`. */
+  skipped: Array<{ path: string; reason: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Persist refreshed Anthropic OAuth tokens to disk.
+ *
+ * Always writes to `${getCleoHome()}/anthropic-oauth.json`. Additionally
+ * writes to `~/.claude/.credentials.json` IFF:
+ *
+ * 1. The config flag `auth.cooperativeWriteBack` is `true` (default), AND
+ * 2. The Claude Code file already exists on disk OR the operator has set
+ *    `auth.claudeCodeConsentGiven = true`.
+ *
+ * Both writes are atomic (temp file + rename) and mode 0o600. The
+ * `claudeAiOauth.scopes` field is preserved verbatim across writes so
+ * Claude Code >= 2.1.81 continues to accept the token.
+ *
+ * @param refreshed - Token bundle returned by the Anthropic refresh exchange.
+ * @returns Lists of written + skipped paths with reasons.
+ * @throws If a write fails after the gating checks pass — callers can
+ *   surface the error to the operator (refresh succeeded but persistence
+ *   failed; the in-memory tokens are still usable until process exit).
+ *
+ * @task T9411
+ */
+export async function writeBackAnthropicTokens(
+  refreshed: RefreshedAnthropicTokens,
+): Promise<WriteBackResult> {
+  const written: string[] = [];
+  const skipped: Array<{ path: string; reason: string }> = [];
+
+  // ---- 1. CLEO's own file (always written) -------------------------------
+  const cleoPath = cleoPkceFilePath();
+  const cleoPrev = readExistingClaudeAiOauth(cleoPath);
+  const cleoScopes = pickScopes(refreshed.scopes, cleoPrev?.scopes);
+  writeClaudeAiOauthFile(cleoPath, refreshed, cleoScopes);
+  written.push(cleoPath);
+
+  // ---- 2. Cooperative write to Claude Code's file (gated) ----------------
+  const claudeCodePath = claudeCodeCredentialsPath();
+  const cooperative = await resolveBooleanFlag(COOPERATIVE_FLAG_KEY);
+  if (!cooperative) {
+    skipped.push({
+      path: claudeCodePath,
+      reason: `${COOPERATIVE_FLAG_KEY}=false`,
+    });
+    return { written, skipped };
+  }
+
+  const claudeCodeExists = existsSync(claudeCodePath);
+  if (!claudeCodeExists) {
+    // Even with cooperative write-back ON, we never CREATE the Claude Code
+    // file unless the operator explicitly consented (mirrors T9410's
+    // consent gate semantics — fail closed).
+    const consented = await resolveBooleanFlag(CONSENT_FLAG_KEY);
+    if (!consented) {
+      skipped.push({
+        path: claudeCodePath,
+        reason: `claude-code file absent and ${CONSENT_FLAG_KEY}=false`,
+      });
+      return { written, skipped };
+    }
+  }
+
+  const claudeCodePrev = claudeCodeExists ? readExistingClaudeAiOauth(claudeCodePath) : null;
+  const claudeScopes = pickScopes(refreshed.scopes, claudeCodePrev?.scopes);
+  writeClaudeAiOauthFile(claudeCodePath, refreshed, claudeScopes);
+  written.push(claudeCodePath);
+
+  return { written, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+/** CLEO's canonical PKCE token file path. */
+function cleoPkceFilePath(): string {
+  return join(getCleoHome(), 'anthropic-oauth.json');
+}
+
+/** Claude Code's credential file path under the operator's home dir. */
+function claudeCodeCredentialsPath(): string {
+  return join(homedir(), '.claude', '.credentials.json');
+}
+
+// ---------------------------------------------------------------------------
+// Read-side helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the `claudeAiOauth` block from an existing credential file.
+ *
+ * Returns `null` when the file is absent, malformed, or missing the
+ * `claudeAiOauth` block — callers treat any null as "no previous state".
+ * Unlike `parseClaudeCodeCredentials`, this helper does NOT filter on
+ * expiry: we want the scopes from the existing file even if its token
+ * is stale (the whole point of write-back is to refresh that token).
+ *
+ * @internal
+ */
+function readExistingClaudeAiOauth(
+  path: string,
+): { accessToken?: string; scopes?: string[] } | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch {
+    return null;
+  }
+  // First pass — try `parseClaudeCodeCredentials` (preserves scopes when
+  // the token is not expired).
+  const parsed = parseClaudeCodeCredentials(raw);
+  if (parsed) {
+    return { accessToken: parsed.accessToken, scopes: parsed.scopes };
+  }
+  // Second pass — token may be expired but we still want the scopes.
+  try {
+    const json = JSON.parse(raw) as Record<string, unknown>;
+    const block = json['claudeAiOauth'];
+    if (block && typeof block === 'object') {
+      const rec = block as Record<string, unknown>;
+      const scopes = rec['scopes'];
+      if (Array.isArray(scopes) && scopes.every((s) => typeof s === 'string')) {
+        return { scopes: scopes as string[] };
+      }
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+/**
+ * Decide which scopes array to persist for this write.
+ *
+ * Priority order:
+ *
+ * 1. Scopes explicitly returned by the refresh exchange (`refreshed.scopes`).
+ * 2. Scopes already on disk (preserve Claude Code's `user:inference`).
+ * 3. `undefined` — omit the field entirely.
+ *
+ * @internal
+ */
+function pickScopes(
+  refreshedScopes: string[] | undefined,
+  diskScopes: string[] | undefined,
+): string[] | undefined {
+  if (refreshedScopes && refreshedScopes.length > 0) return refreshedScopes;
+  if (diskScopes && diskScopes.length > 0) return diskScopes;
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Write-side primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomically write the `claudeAiOauth` envelope to `path`.
+ *
+ * Strategy:
+ *
+ * 1. Build the envelope object.
+ * 2. Write to a sibling temp file (`.basename.<hex>.tmp`) created at mode
+ *    `0o600` so the bytes never sit on disk under a looser permission.
+ * 3. `rename` the temp into place — atomic on POSIX, near-atomic on
+ *    Windows. After rename, `chmod 0o600` to belt-and-suspenders against
+ *    Windows ignoring the temp's mode.
+ * 4. On any error during steps 2-3, unlink the temp file (best-effort).
+ *
+ * Does NOT create the parent directory — for `~/.claude/.credentials.json`
+ * we only co-write when the directory already exists (Claude Code created
+ * it); for CLEO's own file the caller ensures `getCleoHome()` exists via
+ * `bootstrap.ts`.
+ *
+ * @internal
+ */
+function writeClaudeAiOauthFile(
+  path: string,
+  refreshed: RefreshedAnthropicTokens,
+  scopes: string[] | undefined,
+): void {
+  const envelope = {
+    claudeAiOauth: {
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      expiresAt: refreshed.expiresAt,
+      ...(scopes !== undefined ? { scopes } : {}),
+    },
+  };
+  const content = `${JSON.stringify(envelope, null, 2)}\n`;
+
+  const dir = dirname(path);
+  const tempPath = join(dir, `.${basename(path)}.${randomBytes(6).toString('hex')}.tmp`);
+
+  try {
+    writeFileSync(tempPath, content, { encoding: 'utf-8', mode: SECRET_FILE_MODE });
+  } catch (err) {
+    // Cleanup any partially-written temp before re-throwing.
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      /* non-fatal */
+    }
+    throw err;
+  }
+
+  try {
+    renameSync(tempPath, path);
+  } catch (err) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      /* non-fatal */
+    }
+    throw err;
+  }
+
+  // Defensive — POSIX rename preserves mode but Windows may have ignored
+  // the temp's mode flag. chmod is cheap and idempotent.
+  try {
+    chmodSync(path, SECRET_FILE_MODE);
+  } catch {
+    /* non-fatal (e.g. Windows ACLs, NFS without chmod) */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config flag resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a `boolean | undefined` config flag through the cascade.
+ *
+ * Treats anything other than the boolean `true` as `false` — defensive
+ * against stray strings or null values that may have crept into older
+ * config files.
+ *
+ * @internal
+ */
+async function resolveBooleanFlag(key: string): Promise<boolean> {
+  try {
+    const resolved = await getConfigValue<boolean | undefined>(key);
+    return resolved.value === true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E2a §5.2 T-E2-4 + OQ-1 decision (cooperative write-back ON by default).

## Adds
- `CleoPkceSeeder`: reads `${getCleoHome()}/anthropic-oauth.json`; emits one `(anthropic, cleo-pkce, oauth)` entry. No consent gate (first-party).
- `writeBackAnthropicTokens(refreshed)`: always writes CLEO's own file (atomic temp+rename, 0600). ALSO writes `~/.claude/.credentials.json` iff `auth.cooperativeWriteBack === true` (default true per OQ-1) AND (file exists OR `claudeCodeConsentGiven === true`). Preserves `claudeAiOauth.scopes` verbatim — Claude Code >= 2.1.81 requires `user:inference`.
- `AuthConfig.cooperativeWriteBack?: boolean` in contracts
- `DEFAULTS.auth.cooperativeWriteBack: true`
- `scopes?: string[]` on `ClaudeCodeOAuthBlock` + `ParsedClaudeCodeCredential` (parser preserves)
- 12 cleo-pkce-seeder tests + 12 credential-writeback tests

## Test plan
- [x] 24/24 new tests pass
- [x] 110/110 seeder + 191/191 contracts tests pass
- [x] Full core suite: only pre-existing failures (verified by stashed-baseline comparison)
- [x] biome + build clean

## Refs
- `docs/plans/E-CONFIG-AUTH-UNIFY.md` §5.2 T-E2-4
- Epic: T9400, Master: T9500