### PR TITLE
feat(T9412): implement CredentialPool with seed/pick/list + 60s cache

### DIFF
--- a/packages/core/src/llm/__tests__/credential-pool-unified.test.ts
+++ b/packages/core/src/llm/__tests__/credential-pool-unified.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Unit tests for `UnifiedCredentialPool` + `getCredentialPool` singleton
+ * (E-CONFIG-AUTH-UNIFY E2a / T9412).
+ *
+ * Isolation strategy mirrors `credential-pool.test.ts` — every test points
+ * `XDG_DATA_HOME`, `HOME`, and `CLEO_HOME` at fresh tmpdirs so the on-disk
+ * credentials store, suppression file, and home-dir reads never collide
+ * with developer state or between parallel workers.
+ *
+ * Scope:
+ *
+ * - `seed()` invokes every registered seeder and upserts the entries.
+ * - Consent gate blocks `seed()` from running (status: `'skipped-consent'`).
+ * - Suppression list blocks `seed()` (status: `'skipped-suppressed'`).
+ * - Per-seeder failures are isolated; the sweep keeps going.
+ * - 60 s cache TTL short-circuits non-`force` calls.
+ * - `force: true` bypasses the cache.
+ * - `pick()` lazy-seeds on first call.
+ * - `list()` reads the store without seeding.
+ * - `getCredentialPool()` returns a stable singleton across imports.
+ * - `getSeederStatus()` snapshots per-seeder outcomes.
+ *
+ * @task T9412
+ */
+
+import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _resetCredentialPoolSingletonForTests,
+  getCredentialPool,
+  POOL_SEED_CACHE_TTL_MS,
+  UnifiedCredentialPool,
+} from '../credential-pool.js';
+import { addSuppression } from '../credential-removal.js';
+import {
+  type CredentialSeeder,
+  SeederRegistry,
+  type SeederResult,
+  type SeederSourceId,
+} from '../credential-seeders/index.js';
+import { clearAnthropicKeyCache } from '../credentials.js';
+import { _resetPermsWarningForTests, listCredentials } from '../credentials-store.js';
+
+// ---------------------------------------------------------------------------
+// Environment isolation
+// ---------------------------------------------------------------------------
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  'XDG_DATA_HOME',
+  'XDG_CONFIG_HOME',
+  'CLEO_HOME',
+  'CLEO_CONFIG_HOME',
+  'CLEO_DIR',
+  'HOME',
+];
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+function clearEnv(): void {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+/** Point CLEO + XDG envs at fresh tmpdirs so state cannot leak. */
+function isolateHomes(): void {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const xdgRoot = join(tmpdir(), `cleo-unifiedpool-xdg-${stamp}`);
+  const home = join(tmpdir(), `cleo-unifiedpool-home-${stamp}`);
+  const cleoHome = join(xdgRoot, 'cleo');
+  mkdirSync(cleoHome, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  process.env['XDG_DATA_HOME'] = xdgRoot;
+  process.env['CLEO_HOME'] = cleoHome;
+  process.env['HOME'] = home;
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Build a seeder that returns a single canned entry. */
+function makeSeeder(opts: {
+  sourceId: SeederSourceId;
+  provider: string;
+  token?: string;
+  label?: string;
+  consent?: boolean | (() => boolean | Promise<boolean>);
+  throwOnSeed?: Error;
+  result?: SeederResult;
+}): CredentialSeeder {
+  const label = opts.label ?? `${opts.sourceId}:${opts.provider}`;
+  const result: SeederResult = opts.result ?? {
+    entries: [
+      {
+        provider: opts.provider as never,
+        label,
+        authType: 'api_key',
+        source: opts.sourceId,
+        accessToken: opts.token ?? `tok-${label}`,
+      },
+    ],
+  };
+  const seeder: CredentialSeeder = {
+    sourceId: opts.sourceId,
+    provider: opts.provider,
+    async seed() {
+      if (opts.throwOnSeed) throw opts.throwOnSeed;
+      return result;
+    },
+  };
+  if (opts.consent !== undefined) {
+    seeder.isConsentEstablished = async (): Promise<boolean> => {
+      return typeof opts.consent === 'function' ? await opts.consent() : opts.consent === true;
+    };
+  }
+  return seeder;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle hooks
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  saveEnv();
+  clearEnv();
+  clearAnthropicKeyCache();
+  _resetPermsWarningForTests();
+  _resetCredentialPoolSingletonForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  restoreEnv();
+  clearAnthropicKeyCache();
+  _resetPermsWarningForTests();
+  _resetCredentialPoolSingletonForTests();
+});
+
+// ---------------------------------------------------------------------------
+// seed() — happy path
+// ---------------------------------------------------------------------------
+
+describe('UnifiedCredentialPool.seed', () => {
+  it('invokes every seeder in the registry and upserts the entries', async () => {
+    isolateHomes();
+    const registry = new SeederRegistry();
+    registry.register(makeSeeder({ sourceId: 'env', provider: 'anthropic' }));
+    registry.register(makeSeeder({ sourceId: 'env', provider: 'openai' }));
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    const result = await pool.seed();
+
+    expect(result.added).toBe(2);
+    expect(result.failed).toBe(0);
+
+    const stored = await listCredentials();
+    expect(stored.map((c) => c.label).sort()).toEqual(['env:anthropic', 'env:openai']);
+    expect(stored.every((c) => c.source === 'env')).toBe(true);
+  });
+
+  it('records a per-seeder status snapshot for every invocation', async () => {
+    isolateHomes();
+    const registry = new SeederRegistry();
+    registry.register(makeSeeder({ sourceId: 'env', provider: 'anthropic' }));
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    await pool.seed();
+
+    const status = pool.getSeederStatus();
+    expect(status).toHaveLength(1);
+    expect(status[0]?.sourceId).toBe('env');
+    expect(status[0]?.provider).toBe('anthropic');
+    expect(status[0]?.lastResult).toBe('ok');
+    expect(status[0]?.entriesProduced).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seed() — consent + suppression gating
+// ---------------------------------------------------------------------------
+
+describe('UnifiedCredentialPool.seed — gating', () => {
+  it('skips seeders whose isConsentEstablished returns false', async () => {
+    isolateHomes();
+    const registry = new SeederRegistry();
+    registry.register(
+      makeSeeder({ sourceId: 'claude-code', provider: 'anthropic', consent: false }),
+    );
+    registry.register(makeSeeder({ sourceId: 'env', provider: 'openai' }));
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    const result = await pool.seed();
+
+    expect(result.added).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.failed).toBe(0);
+
+    const labels = (await listCredentials()).map((c) => c.label);
+    expect(labels).toContain('env:openai');
+    expect(labels).not.toContain('claude-code:anthropic');
+
+    const status = pool.getSeederStatus();
+    const claude = status.find((s) => s.sourceId === 'claude-code');
+    expect(claude?.lastResult).toBe('skipped-consent');
+  });
+
+  it('skips seeders that are suppressed via the suppression file', async () => {
+    isolateHomes();
+    addSuppression('anthropic', 'claude-code');
+
+    const registry = new SeederRegistry();
+    registry.register(makeSeeder({ sourceId: 'claude-code', provider: 'anthropic' }));
+    registry.register(makeSeeder({ sourceId: 'env', provider: 'anthropic' }));
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    const result = await pool.seed();
+
+    expect(result.added).toBe(1);
+    expect(result.skipped).toBe(1);
+
+    const status = pool.getSeederStatus();
+    const claude = status.find((s) => s.sourceId === 'claude-code');
+    expect(claude?.lastResult).toBe('skipped-suppressed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seed() — failure isolation
+// ---------------------------------------------------------------------------
+
+describe('UnifiedCredentialPool.seed — failure isolation', () => {
+  it('a seeder that throws does not prevent other seeders from running', async () => {
+    isolateHomes();
+    const registry = new SeederRegistry();
+    registry.register(
+      makeSeeder({
+        sourceId: 'env',
+        provider: 'anthropic',
+        throwOnSeed: new Error('boom'),
+      }),
+    );
+    registry.register(makeSeeder({ sourceId: 'env', provider: 'openai' }));
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    const result = await pool.seed();
+
+    expect(result.failed).toBe(1);
+    expect(result.added).toBe(1);
+
+    const labels = (await listCredentials()).map((c) => c.label);
+    expect(labels).toEqual(['env:openai']);
+
+    const status = pool.getSeederStatus();
+    const failing = status.find((s) => s.provider === 'anthropic');
+    expect(failing?.lastResult).toBe('failed');
+    expect(failing?.error).toContain('boom');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seed() — 60s cache TTL
+// ---------------------------------------------------------------------------
+
+describe('UnifiedCredentialPool.seed — cache TTL', () => {
+  it('skips the sweep entirely when the last seed was less than 60s ago', async () => {
+    isolateHomes();
+    let seedCalls = 0;
+    const registry = new SeederRegistry();
+    const counter: CredentialSeeder = {
+      sourceId: 'env',
+      provider: 'anthropic',
+      async seed() {
+        seedCalls++;
+        return { entries: [] };
+      },
+    };
+    registry.register(counter);
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    await pool.seed();
+    await pool.seed();
+    await pool.seed();
+
+    expect(seedCalls).toBe(1);
+  });
+
+  it('force:true bypasses the cache', async () => {
+    isolateHomes();
+    let seedCalls = 0;
+    const registry = new SeederRegistry();
+    registry.register({
+      sourceId: 'env',
+      provider: 'anthropic',
+      async seed() {
+        seedCalls++;
+        return { entries: [] };
+      },
+    });
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    await pool.seed();
+    await pool.seed({ force: true });
+    await pool.seed({ force: true });
+
+    expect(seedCalls).toBe(3);
+  });
+
+  it('re-seeds after the cache TTL elapses (fake timers)', async () => {
+    isolateHomes();
+    vi.useFakeTimers();
+    let seedCalls = 0;
+    const registry = new SeederRegistry();
+    registry.register({
+      sourceId: 'env',
+      provider: 'anthropic',
+      async seed() {
+        seedCalls++;
+        return { entries: [] };
+      },
+    });
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    await pool.seed();
+    expect(seedCalls).toBe(1);
+
+    // Advance past the cache TTL.
+    vi.setSystemTime(Date.now() + POOL_SEED_CACHE_TTL_MS + 1);
+    await pool.seed();
+    expect(seedCalls).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pick() / list()
+// ---------------------------------------------------------------------------
+
+describe('UnifiedCredentialPool.pick + list', () => {
+  it('pick() lazy-seeds on the first call', async () => {
+    isolateHomes();
+    let seedCalls = 0;
+    const registry = new SeederRegistry();
+    registry.register({
+      sourceId: 'env',
+      provider: 'anthropic',
+      async seed() {
+        seedCalls++;
+        return {
+          entries: [
+            {
+              provider: 'anthropic' as never,
+              label: 'env:ANTHROPIC_API_KEY',
+              authType: 'api_key',
+              source: 'env',
+              accessToken: 'sk-test',
+            },
+          ],
+        };
+      },
+    });
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    expect(seedCalls).toBe(0);
+
+    const entry = await pool.pick('anthropic');
+    expect(seedCalls).toBe(1);
+    expect(entry?.label).toBe('env:ANTHROPIC_API_KEY');
+    expect(entry?.accessToken).toBe('sk-test');
+  });
+
+  it('pick() returns null when no entry exists for the provider', async () => {
+    isolateHomes();
+    const registry = new SeederRegistry();
+    registry.register(makeSeeder({ sourceId: 'env', provider: 'openai' }));
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    const entry = await pool.pick('anthropic');
+    expect(entry).toBeNull();
+  });
+
+  it('list() reads the store without invoking seeders', async () => {
+    isolateHomes();
+    let seedCalls = 0;
+    const registry = new SeederRegistry();
+    registry.register({
+      sourceId: 'env',
+      provider: 'anthropic',
+      async seed() {
+        seedCalls++;
+        return { entries: [] };
+      },
+    });
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    const entries = await pool.list();
+    expect(entries).toEqual([]);
+    expect(seedCalls).toBe(0);
+  });
+
+  it('list() shows entries from every source after a seed sweep', async () => {
+    isolateHomes();
+    const registry = new SeederRegistry();
+    registry.register(makeSeeder({ sourceId: 'env', provider: 'anthropic' }));
+    registry.register(
+      makeSeeder({ sourceId: 'claude-code', provider: 'anthropic', label: 'claude-code:default' }),
+    );
+    registry.register(makeSeeder({ sourceId: 'env', provider: 'openai' }));
+
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    await pool.seed();
+
+    const all = await pool.list();
+    expect(all.map((c) => `${c.source}:${c.label}`).sort()).toEqual(
+      ['claude-code:claude-code:default', 'env:env:anthropic', 'env:env:openai'].sort(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Singleton accessor
+// ---------------------------------------------------------------------------
+
+describe('getCredentialPool — singleton', () => {
+  it('returns the same instance across multiple calls', () => {
+    isolateHomes();
+    const a = getCredentialPool();
+    const b = getCredentialPool();
+    expect(a).toBe(b);
+  });
+
+  it('returns a new instance after _resetCredentialPoolSingletonForTests()', () => {
+    isolateHomes();
+    const a = getCredentialPool();
+    _resetCredentialPoolSingletonForTests();
+    const b = getCredentialPool();
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/core/src/llm/credential-pool.ts
+++ b/packages/core/src/llm/credential-pool.ts
@@ -33,8 +33,19 @@
  * @epic T-LLM-CRED-CENTRALIZATION
  */
 
-import type { StoredCredential } from './credentials-store.js';
-import { addCredential, getCredentialByLabel, listCredentials } from './credentials-store.js';
+import { isSuppressed } from './credential-removal.js';
+import {
+  BUILTIN_SEEDERS,
+  type CredentialSeeder,
+  type SeederCredentialEntry,
+} from './credential-seeders/index.js';
+import type { CredentialsStoreStrategy, StoredCredential } from './credentials-store.js';
+import {
+  addCredential,
+  getCredentialByLabel,
+  listCredentials,
+  pickCredentialForProviderSync,
+} from './credentials-store.js';
 import { getKimiCodeDeviceCodeConfig } from './oauth/device-code.js';
 import { refreshPkceToken } from './oauth/pkce.js';
 import { getProviderProfile } from './provider-registry/index.js';
@@ -629,4 +640,448 @@ export class CredentialPool {
       return b.priority - a.priority;
     })[0];
   }
+}
+
+// ===========================================================================
+// UnifiedCredentialPool — seed/pick/list over all registered seeders (T9412)
+// ===========================================================================
+//
+// `UnifiedCredentialPool` is the unified credential pool described in
+// E-CONFIG-AUTH-UNIFY E2a §5.2 T-E2-5. Where the per-provider `CredentialPool`
+// above manages rotation/cooldown for an already-populated pool, the unified
+// pool is the *seeding* layer: it walks `BUILTIN_SEEDERS`, applies consent +
+// suppression gating, and upserts the discovered entries into the credential
+// store via `addCredential` so a downstream resolver (T9413) can pick from a
+// populated pool.
+//
+// The pool exposes:
+//   - `seed({ force? })` — iterate every registered seeder, gate on consent
+//     and suppression, swallow per-seeder errors (so one bad source can never
+//     break the whole bootstrap), and upsert the returned entries.
+//   - `pick(provider, opts)` — lazy-seed on first call, then read the store
+//     synchronously via `pickCredentialForProviderSync`.
+//   - `list()` — return every entry currently in the store without seeding.
+//   - `getSeederStatus()` — snapshot of the last-result of every registered
+//     seeder, suitable for `cleo status` / `cleo auth list` diagnostics.
+//
+// The pool is exposed as a process-wide singleton via `getCredentialPool()`.
+// Tests requiring isolation MUST construct a fresh `new UnifiedCredentialPool()`
+// (the registry argument allows pointing at an isolated `SeederRegistry`).
+
+/**
+ * Seed-attempt cache TTL — 60 seconds per E2a §5.2 T-E2-5 acceptance criterion.
+ *
+ * After a successful (non-`force`) seed pass, repeat calls to `seed()` are
+ * short-circuited until this TTL elapses. `force: true` always bypasses the
+ * cache. `lazy-seed` from `pick()` also honours the cache.
+ *
+ * @task T9412
+ */
+export const POOL_SEED_CACHE_TTL_MS = 60 * 1_000;
+
+/**
+ * Outcome of a single seeder's most-recent invocation.
+ *
+ * Returned in {@link UnifiedCredentialPool.getSeederStatus} for diagnostic
+ * surfaces (`cleo status`, `cleo auth list --verbose`).
+ *
+ * @task T9412
+ */
+export interface SeederStatus {
+  /** Source id (e.g. `'env'`, `'claude-code'`). */
+  sourceId: string;
+  /** Provider this seeder produces credentials for. */
+  provider: string;
+  /** Epoch ms of the most recent invocation; `undefined` if never invoked. */
+  lastSeededAt?: number;
+  /** Outcome of the most recent invocation. */
+  lastResult: 'ok' | 'failed' | 'skipped-consent' | 'skipped-suppressed';
+  /** Number of entries the seeder produced on `lastSeededAt`. */
+  entriesProduced?: number;
+  /** Error message when `lastResult === 'failed'`. */
+  error?: string;
+}
+
+/**
+ * Aggregate counts returned by {@link UnifiedCredentialPool.seed}.
+ *
+ * @task T9412
+ */
+export interface PoolSeedResult {
+  /** Number of seeders whose entries were successfully upserted. */
+  added: number;
+  /** Number of seeders that threw or whose upsert failed. */
+  failed: number;
+  /** Number of seeders skipped due to consent / suppression / cache. */
+  skipped: number;
+}
+
+/**
+ * Options accepted by {@link UnifiedCredentialPool.pick}.
+ *
+ * Forwarded to `pickCredentialForProviderSync` so callers can request a
+ * specific strategy or label; the pool itself only handles the lazy-seed
+ * hook before delegating.
+ *
+ * @task T9412
+ */
+export interface UnifiedPoolPickOptions {
+  /** Override the store's default strategy. */
+  strategy?: CredentialsStoreStrategy;
+  /** Prefer a specific label (collapses to that entry if present). */
+  preferLabel?: string;
+  /** Skip the lazy-seed step (e.g. for diagnostic reads). Default `false`. */
+  noSeed?: boolean;
+}
+
+/**
+ * Process-wide debug log channel — kept minimal so the pool does not pull in
+ * the broader `cleo log` plumbing. Mirrors the pattern used by the per-provider
+ * pool above.
+ *
+ * Reads `process.env.CLEO_DEBUG` at call time so tests can toggle without
+ * module reload. Output goes to `console.debug` so it shows under `--verbose`
+ * but stays out of clean CLI output by default.
+ *
+ * @internal
+ */
+function debugLog(msg: string, ...rest: unknown[]): void {
+  if (process.env['CLEO_DEBUG']) {
+    console.debug(`[cleo:credential-pool] ${msg}`, ...rest);
+  }
+}
+
+/**
+ * Unified credential pool — drives every registered seeder, upserts the
+ * discovered entries, and exposes `pick`/`list` over the populated store.
+ *
+ * Lifecycle:
+ *
+ *   1. First `pick()` (or explicit `seed()`) walks `BUILTIN_SEEDERS`.
+ *   2. For each seeder: consent gate → suppression gate → `seed()` →
+ *      upsert each returned entry via `addCredential` (preserves the
+ *      seeder's `priority` hint when provided, otherwise the store's
+ *      `max + 10` rule applies).
+ *   3. A successful sweep stamps the cache; subsequent calls within
+ *      {@link POOL_SEED_CACHE_TTL_MS} short-circuit unless `force: true`.
+ *   4. `list()` reads the store directly — never triggers seeding so
+ *      diagnostic surfaces (`cleo auth list`) are pure-read.
+ *
+ * Error isolation: a single seeder that throws does NOT short-circuit the
+ * sweep. The failure is counted, the error stashed in `getSeederStatus`,
+ * and the next seeder runs.
+ *
+ * @example
+ * ```ts
+ * const pool = getCredentialPool();
+ * const entry = await pool.pick('anthropic');
+ * if (entry) {
+ *   // use entry.accessToken
+ * }
+ * ```
+ *
+ * @task T9412
+ */
+export class UnifiedCredentialPool {
+  /** Epoch ms of last successful seed pass (`0` = never seeded). */
+  private lastSeededAt = 0;
+
+  /** Per-seeder diagnostics keyed on `${sourceId}::${provider}`. */
+  private readonly seederStatus = new Map<string, SeederStatus>();
+
+  /**
+   * Construct a pool wired to a specific seeder registry.
+   *
+   * Production code uses the {@link getCredentialPool} singleton which wires
+   * to `BUILTIN_SEEDERS`. Tests pass a fresh `SeederRegistry` to isolate
+   * registration semantics from the process-wide singleton.
+   *
+   * @param registryGetter - Getter that returns the active list of seeders.
+   *   Defaults to `BUILTIN_SEEDERS.getAll()`. A getter (not the array
+   *   directly) is used so the pool stays in sync with seeders registered
+   *   after construction.
+   */
+  constructor(
+    private readonly registryGetter: () => readonly CredentialSeeder[] = () =>
+      BUILTIN_SEEDERS.getAll(),
+  ) {}
+
+  /**
+   * Walk every registered seeder, gate on consent + suppression, and upsert
+   * the returned entries into the store.
+   *
+   * Cache rules:
+   * - If `force !== true` and the last successful seed pass was less than
+   *   {@link POOL_SEED_CACHE_TTL_MS} ago, the sweep is skipped entirely
+   *   and `{ added: 0, failed: 0, skipped: <total-seeders> }` is returned.
+   * - `force: true` always re-runs every seeder.
+   *
+   * Per-seeder rules:
+   * - `isConsentEstablished?` returning `false` → skip (status:
+   *   `'skipped-consent'`).
+   * - `isSuppressed(provider, sourceId)` returning `true` → skip (status:
+   *   `'skipped-suppressed'`).
+   * - `seed()` throwing → counted as `failed`; the error is logged
+   *   and stashed in `getSeederStatus`; the next seeder still runs.
+   * - Each returned entry is upserted via `addCredential`; an upsert
+   *   failure counts the seeder as `failed`.
+   *
+   * @param options - `{ force }` — bypass the 60s cache when `true`.
+   * @returns Aggregate counts across every seeder.
+   * @task T9412
+   */
+  async seed(options: { force?: boolean } = {}): Promise<PoolSeedResult> {
+    const seeders = this.registryGetter();
+    const now = Date.now();
+
+    // ----- Cache short-circuit ------------------------------------------------
+    if (
+      !options.force &&
+      this.lastSeededAt > 0 &&
+      now - this.lastSeededAt < POOL_SEED_CACHE_TTL_MS
+    ) {
+      debugLog('seed: cache hit, skipping sweep', {
+        ageMs: now - this.lastSeededAt,
+        ttlMs: POOL_SEED_CACHE_TTL_MS,
+      });
+      return { added: 0, failed: 0, skipped: seeders.length };
+    }
+
+    let added = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const seeder of seeders) {
+      const key = `${seeder.sourceId}::${seeder.provider}`;
+      const stampedAt = Date.now();
+
+      // -- Consent gate -------------------------------------------------------
+      if (typeof seeder.isConsentEstablished === 'function') {
+        let consented: boolean;
+        try {
+          consented = await seeder.isConsentEstablished(seeder.provider);
+        } catch (err) {
+          // Treat a consent-gate exception as a failure rather than a skip:
+          // the operator should know that a gate is broken.
+          failed++;
+          this.seederStatus.set(key, {
+            sourceId: seeder.sourceId,
+            provider: seeder.provider,
+            lastSeededAt: stampedAt,
+            lastResult: 'failed',
+            error: `consent gate threw: ${err instanceof Error ? err.message : String(err)}`,
+          });
+          debugLog('seed: consent gate threw', { seeder: key, err });
+          continue;
+        }
+        if (!consented) {
+          skipped++;
+          this.seederStatus.set(key, {
+            sourceId: seeder.sourceId,
+            provider: seeder.provider,
+            lastSeededAt: stampedAt,
+            lastResult: 'skipped-consent',
+          });
+          continue;
+        }
+      }
+
+      // -- Suppression gate ---------------------------------------------------
+      // The suppression list is keyed on `(provider, SeederSourceId)`; since
+      // `SeederSourceId` is the union the seeder's `sourceId` is constrained
+      // to, the cast is sound.
+      let suppressed: boolean;
+      try {
+        suppressed = isSuppressed(seeder.provider, seeder.sourceId);
+      } catch (err) {
+        // A broken suppression-file read should not block seeding — treat as
+        // un-suppressed but log the failure for diagnostics.
+        debugLog('seed: isSuppressed threw — treating as un-suppressed', {
+          seeder: key,
+          err,
+        });
+        suppressed = false;
+      }
+      if (suppressed) {
+        skipped++;
+        this.seederStatus.set(key, {
+          sourceId: seeder.sourceId,
+          provider: seeder.provider,
+          lastSeededAt: stampedAt,
+          lastResult: 'skipped-suppressed',
+        });
+        continue;
+      }
+
+      // -- Invoke seeder ------------------------------------------------------
+      let entries: SeederCredentialEntry[];
+      try {
+        const result = await seeder.seed();
+        entries = result.entries;
+      } catch (err) {
+        failed++;
+        this.seederStatus.set(key, {
+          sourceId: seeder.sourceId,
+          provider: seeder.provider,
+          lastSeededAt: stampedAt,
+          lastResult: 'failed',
+          error: err instanceof Error ? err.message : String(err),
+        });
+        debugLog('seed: seeder threw', { seeder: key, err });
+        continue;
+      }
+
+      // -- Upsert entries -----------------------------------------------------
+      let upsertFailed = false;
+      for (const entry of entries) {
+        try {
+          await addCredential(entry);
+        } catch (err) {
+          upsertFailed = true;
+          debugLog('seed: addCredential threw', { seeder: key, label: entry.label, err });
+          // Stash the first upsert error so getSeederStatus surfaces something.
+          this.seederStatus.set(key, {
+            sourceId: seeder.sourceId,
+            provider: seeder.provider,
+            lastSeededAt: stampedAt,
+            lastResult: 'failed',
+            entriesProduced: entries.length,
+            error: `addCredential threw for '${entry.label}': ${err instanceof Error ? err.message : String(err)}`,
+          });
+          break;
+        }
+      }
+      if (upsertFailed) {
+        failed++;
+        continue;
+      }
+
+      added++;
+      this.seederStatus.set(key, {
+        sourceId: seeder.sourceId,
+        provider: seeder.provider,
+        lastSeededAt: stampedAt,
+        lastResult: 'ok',
+        entriesProduced: entries.length,
+      });
+    }
+
+    // Only stamp the cache on a complete sweep — caller may still force-rerun.
+    this.lastSeededAt = Date.now();
+
+    return { added, failed, skipped };
+  }
+
+  /**
+   * Pick a credential for the given provider, lazy-seeding on first call.
+   *
+   * Behaviour:
+   * - First call (or after `resetForTests()`) triggers a `seed()` pass.
+   * - Subsequent calls within {@link POOL_SEED_CACHE_TTL_MS} skip seeding.
+   * - The actual pick delegates to `pickCredentialForProviderSync` so the
+   *   strategy + label-preference semantics match the rest of the store.
+   *
+   * @param provider - LLM transport to pick for.
+   * @param options - Optional strategy / label / no-seed flag.
+   * @returns The selected `StoredCredential`, or `null` when the pool is
+   *   empty (or every entry has expired / been disabled).
+   * @task T9412
+   */
+  async pick(
+    provider: ModelTransport,
+    options: UnifiedPoolPickOptions = {},
+  ): Promise<StoredCredential | null> {
+    if (!options.noSeed) {
+      await this.seed();
+    }
+    return pickCredentialForProviderSync(provider, {
+      ...(options.strategy != null && { strategy: options.strategy }),
+      ...(options.preferLabel != null && { preferLabel: options.preferLabel }),
+    });
+  }
+
+  /**
+   * List every entry currently in the credential store.
+   *
+   * Pure read — never triggers seeding. Intended for diagnostic surfaces
+   * (`cleo auth list`, `cleo status`) where calling `seed()` would be
+   * surprising side-effect.
+   *
+   * @returns Read-only snapshot sorted by file order (insertion).
+   * @task T9412
+   */
+  async list(): Promise<readonly StoredCredential[]> {
+    return listCredentials();
+  }
+
+  /**
+   * Snapshot of the last-known outcome of every registered seeder.
+   *
+   * Seeders that have never been invoked do not appear in the snapshot.
+   *
+   * @returns Read-only array of {@link SeederStatus} entries.
+   * @task T9412
+   */
+  getSeederStatus(): readonly SeederStatus[] {
+    return Array.from(this.seederStatus.values());
+  }
+
+  /**
+   * Test-only: invalidate the seed cache and clear status snapshots.
+   *
+   * Production code MUST NOT call this — it bypasses the 60s rate-limit
+   * that exists specifically to prevent runaway seeding under tight retry
+   * loops. The export is prefixed `_` to match the convention used by
+   * `credentials-store.ts` for analogous helpers (`_resetRoundRobinForTests`).
+   *
+   * @internal
+   */
+  _resetForTests(): void {
+    this.lastSeededAt = 0;
+    this.seederStatus.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton accessor
+// ---------------------------------------------------------------------------
+
+/**
+ * Module-state singleton — `null` until the first {@link getCredentialPool}
+ * call constructs the instance. Lazy construction keeps test runners that
+ * import the module without ever calling `getCredentialPool` from paying the
+ * seeder-registration cost.
+ *
+ * @internal
+ */
+let _singleton: UnifiedCredentialPool | null = null;
+
+/**
+ * Return the process-wide {@link UnifiedCredentialPool} singleton.
+ *
+ * Re-imports of this module yield the same instance under Node ESM's module
+ * cache. Tests that need an isolated pool MUST construct one directly
+ * (`new UnifiedCredentialPool(...)`) rather than mutating this singleton.
+ *
+ * @returns The shared pool instance.
+ * @task T9412
+ */
+export function getCredentialPool(): UnifiedCredentialPool {
+  if (_singleton === null) {
+    _singleton = new UnifiedCredentialPool();
+  }
+  return _singleton;
+}
+
+/**
+ * Test-only: drop the singleton so the next {@link getCredentialPool} call
+ * constructs a fresh instance.
+ *
+ * Production callers MUST NOT use this — recreating the pool drops the seed
+ * cache and forces a re-sweep on the next `pick()`.
+ *
+ * @internal
+ */
+export function _resetCredentialPoolSingletonForTests(): void {
+  _singleton = null;
 }

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -117,6 +117,18 @@ export {
 // the populated singleton without an explicit second import.
 import './credential-seeders/register.js';
 
+// Unified credential pool — seed/pick/list singleton (E-CONFIG-AUTH-UNIFY E2a / T9412)
+export type {
+  PoolSeedResult,
+  SeederStatus,
+  UnifiedPoolPickOptions,
+} from './credential-pool.js';
+export {
+  _resetCredentialPoolSingletonForTests,
+  getCredentialPool,
+  POOL_SEED_CACHE_TTL_MS,
+  UnifiedCredentialPool,
+} from './credential-pool.js';
 export {
   ENV_SEEDER_PRIORITY,
   EnvSeeder,


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E2a §5.2 T-E2-5. Core unified credential pool. 

## Naming note
The existing `CredentialPool` class is the per-provider rotation pool (T9265). To avoid breaking 23 existing tests + 3 consumers (`concrete-session.ts`, `auxiliary-fallback.ts`), the new unified pool class is named **`UnifiedCredentialPool`** in the same file. The singleton accessor `getCredentialPool()` matches spec — downstream tasks call by accessor, not class name. If T9413 expects to import `CredentialPool` literally, a follow-up rename can swap names.

## Adds
- `UnifiedCredentialPool` with `seed/pick/list/getSeederStatus` + 60s cache + force bypass
- `getCredentialPool(): UnifiedCredentialPool` singleton
- Iterates `BUILTIN_SEEDERS`, respects consent gates + `RemovalRegistry` suppression
- Seeder failures isolated (caught, counted, debug-logged)
- 14 unit tests covering all 14 acceptance scenarios

## Test plan
- [x] 14/14 new tests pass
- [x] 23/23 existing pool tests still pass (no regression to rotation pool)
- [x] 808/808 llm + seeder tests pass
- [x] Full core: 8182 pass / 15 fail (vs baseline 7998 pass / 17 fail — +184 pass, -2 fail)
- [x] biome + build clean

## Refs
- `docs/plans/E-CONFIG-AUTH-UNIFY.md` §5.2 T-E2-5
- Epic: T9400, Master: T9500