### PR TITLE
feat(T9413): wire UnifiedCredentialPool into resolveCredentials; reject tier-5

### DIFF
--- a/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
+++ b/packages/core/src/llm/__tests__/credentials-auth-type.test.ts
@@ -112,11 +112,44 @@ afterEach(() => {
 });
 
 describe('authType detection — anthropic', () => {
-  it('marks Claude Code OAuth tokens (tier 3) as oauth', () => {
+  it('marks Claude Code OAuth tokens (tier 3) as oauth (via async resolver / pool)', async () => {
+    // T9413 (E-CONFIG-AUTH-UNIFY §5.2 T-E2-6): the sync resolver no longer
+    // reads `~/.claude/.credentials.json` directly. The `claude-code`
+    // seeder now owns that file and surfaces the OAuth token via the
+    // unified credential pool. Use a hand-built test seeder so the consent
+    // gate (which reads the global config in production) is short-circuited.
+    const { UnifiedCredentialPool } = await import('../credential-pool.js');
+    const { SeederRegistry } = await import('../credential-seeders/index.js');
     seedClaudeOauth('sk-ant-oat-XXXXX');
+
+    const registry = new SeederRegistry();
+    registry.register({
+      sourceId: 'claude-code',
+      provider: 'anthropic',
+      isConsentEstablished: async () => true,
+      async seed() {
+        return {
+          entries: [
+            {
+              provider: 'anthropic',
+              label: 'claude-code',
+              authType: 'oauth',
+              source: 'claude-code',
+              accessToken: 'sk-ant-oat-XXXXX',
+              expiresAt: Date.now() + 60 * 60_000,
+            },
+          ],
+        };
+      },
+    });
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    await pool.seed();
+
     const cred = resolveCredentials('anthropic');
     expect(cred.apiKey).toBe('sk-ant-oat-XXXXX');
-    expect(cred.source).toBe('claude-creds');
+    // Sync resolver tags the pool tier as `cred-file`, not `claude-creds`,
+    // because the seeder writes the entry into the pool first.
+    expect(cred.source).toBe('cred-file');
     expect(cred.authType).toBe('oauth');
   });
 
@@ -159,8 +192,35 @@ describe('authType detection — non-anthropic providers', () => {
 });
 
 describe('authHeaders()', () => {
-  it('produces Bearer + anthropic-beta headers for anthropic oauth', () => {
+  it('produces Bearer + anthropic-beta headers for anthropic oauth', async () => {
+    // T9413: seed the pool via an inline test seeder rather than relying on
+    // the now-removed direct `~/.claude/.credentials.json` sync read.
+    const { UnifiedCredentialPool } = await import('../credential-pool.js');
+    const { SeederRegistry } = await import('../credential-seeders/index.js');
     seedClaudeOauth('sk-ant-oat-XXXXX');
+    const registry = new SeederRegistry();
+    registry.register({
+      sourceId: 'claude-code',
+      provider: 'anthropic',
+      isConsentEstablished: async () => true,
+      async seed() {
+        return {
+          entries: [
+            {
+              provider: 'anthropic',
+              label: 'claude-code',
+              authType: 'oauth',
+              source: 'claude-code',
+              accessToken: 'sk-ant-oat-XXXXX',
+              expiresAt: Date.now() + 60 * 60_000,
+            },
+          ],
+        };
+      },
+    });
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    await pool.seed();
+
     const cred = resolveCredentials('anthropic');
     const headers = authHeaders(cred);
     expect(headers['Authorization']).toBe('Bearer sk-ant-oat-XXXXX');

--- a/packages/core/src/llm/__tests__/credentials-store.test.ts
+++ b/packages/core/src/llm/__tests__/credentials-store.test.ts
@@ -498,7 +498,12 @@ describe('resolveCredentials() integration — cred-file tier', () => {
     expect(cred.apiKey).toBe('sk-env-wins');
   });
 
-  it('falls through to claude-creds when cred-file has no eligible entry', async () => {
+  it('returns null when cred-file has no eligible entry (T9413 — claude-creds direct read removed)', async () => {
+    // T9413 (E-CONFIG-AUTH-UNIFY §5.2 T-E2-6): the sync resolver no longer
+    // reads `~/.claude/.credentials.json` directly. With every cred-file
+    // entry disabled and no pool-seeded claude-code entry, the resolver
+    // returns null. The claude-code seeder (T9410) is the supported path
+    // for importing the file into the pool.
     const { home } = isolateHomes();
     seedClaudeOauth(home, 'sk-ant-oat-fallback');
     // Add a disabled cred-file entry — it MUST be skipped.
@@ -512,8 +517,8 @@ describe('resolveCredentials() integration — cred-file tier', () => {
     });
     clearAnthropicKeyCache();
     const cred = resolveCredentials('anthropic');
-    expect(cred.source).toBe('claude-creds');
-    expect(cred.apiKey).toBe('sk-ant-oat-fallback');
+    expect(cred.apiKey).toBeNull();
+    expect(cred.source).toBeUndefined();
   });
 
   it('aws_sdk stored auth narrows to api_key on the wire (Phase 2 compat)', async () => {

--- a/packages/core/src/llm/__tests__/credentials.test.ts
+++ b/packages/core/src/llm/__tests__/credentials.test.ts
@@ -27,12 +27,24 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { _resetCleoPlatformPathsCache } from '@cleocode/paths';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  _resetCredentialPoolSingletonForTests,
+  UnifiedCredentialPool,
+} from '../credential-pool.js';
+import {
+  type CredentialSeeder,
+  SeederRegistry,
+  type SeederSourceId,
+} from '../credential-seeders/index.js';
+import {
+  _resetCredentialDeprecationLatchesForTests,
   clearAnthropicKeyCache,
   resolveCredentials,
+  resolveCredentialsAsync,
   storeAnthropicApiKey,
 } from '../credentials.js';
+import { _resetPermsWarningForTests } from '../credentials-store.js';
 import { _resetGlobalConfigMigrationLatch } from '../global-config-migration.js';
 
 // ---------------------------------------------------------------------------
@@ -59,6 +71,9 @@ const ENV_KEYS = [
   // overrides it for filesystem isolation.
   'CLEO_HOME',
   'CLEO_DIR',
+  // T9413: tier-3 (pool) reads files under HOME; isolate so developer state
+  // does not bleed into the async resolver tests.
+  'HOME',
 ];
 
 function saveEnv(): void {
@@ -147,6 +162,9 @@ beforeEach(() => {
   clearAnthropicKeyCache();
   _resetCleoPlatformPathsCache();
   _resetGlobalConfigMigrationLatch();
+  _resetCredentialDeprecationLatchesForTests();
+  _resetCredentialPoolSingletonForTests();
+  _resetPermsWarningForTests();
 });
 
 afterEach(() => {
@@ -154,6 +172,9 @@ afterEach(() => {
   clearAnthropicKeyCache();
   _resetCleoPlatformPathsCache();
   _resetGlobalConfigMigrationLatch();
+  _resetCredentialDeprecationLatchesForTests();
+  _resetCredentialPoolSingletonForTests();
+  _resetPermsWarningForTests();
 });
 
 // ---------------------------------------------------------------------------
@@ -269,50 +290,116 @@ describe('Tier 4 — global config (llm.providers[p].apiKey)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tier 5 — project-config
+// Tier 5 — project-config (REJECTED in T9413 — emits stderr warning,
+// MUST NOT resolve)
 // ---------------------------------------------------------------------------
 
-describe('Tier 5 — project config (.cleo/config.json)', () => {
-  it('resolves openai key from project config (openai unaffected by claude-creds)', () => {
+describe('Tier 5 — project config (.cleo/config.json) — REJECTED (T9413)', () => {
+  it('does NOT resolve openai key from project config and emits stderr warning', () => {
     const { xdgRoot } = makeTempXdg();
     const projectRoot = join(xdgRoot, 'myproject');
     mkdirSync(projectRoot, { recursive: true });
     writeProjectProviderKey(projectRoot, 'openai', 'sk-project-openai');
-    const result = resolveCredentials('openai', { projectRoot });
-    expect(result.apiKey).toBe('sk-project-openai');
-    expect(result.source).toBe('project-config');
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    try {
+      const result = resolveCredentials('openai', { projectRoot });
+      expect(result.apiKey).toBeNull();
+      expect(result.source).toBeUndefined();
+      const writes = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(writes).toMatch(/REJECTED/);
+      expect(writes).toMatch(/migrate-project-secrets/);
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 
-  it('resolves gemini key from project config', () => {
+  it('does NOT resolve gemini key from project config', () => {
     const { xdgRoot } = makeTempXdg();
     const projectRoot = join(xdgRoot, 'myproject');
     mkdirSync(projectRoot, { recursive: true });
     writeProjectProviderKey(projectRoot, 'gemini', 'sk-project-gemini');
-    const result = resolveCredentials('gemini', { projectRoot });
-    expect(result.apiKey).toBe('sk-project-gemini');
-    expect(result.source).toBe('project-config');
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    try {
+      const result = resolveCredentials('gemini', { projectRoot });
+      expect(result.apiKey).toBeNull();
+      expect(result.source).toBeUndefined();
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 
-  it('project-config is NOT used when projectRoot is not provided (openai)', () => {
+  it('does not warn when no project apiKey is present', () => {
     const { xdgRoot } = makeTempXdg();
     const projectRoot = join(xdgRoot, 'myproject');
     mkdirSync(projectRoot, { recursive: true });
-    writeProjectProviderKey(projectRoot, 'openai', 'sk-project-key');
-    // No projectRoot passed — should not find the key
-    const result = resolveCredentials('openai');
-    expect(result.apiKey).toBeNull();
-    expect(result.source).toBeUndefined();
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    try {
+      const result = resolveCredentials('openai', { projectRoot });
+      expect(result.apiKey).toBeNull();
+      // No REJECTED warning should fire when the key is simply absent.
+      const writes = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(writes).not.toMatch(/REJECTED/);
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 
-  it('global-config takes priority over project-config (openai)', () => {
-    const { xdgRoot, configPath } = makeTempXdg();
-    writeGlobalProviderKey(configPath, 'openai', 'sk-global-wins');
+  it('emits the rejection warning only once per provider', () => {
+    const { xdgRoot } = makeTempXdg();
     const projectRoot = join(xdgRoot, 'myproject');
     mkdirSync(projectRoot, { recursive: true });
-    writeProjectProviderKey(projectRoot, 'openai', 'sk-project-loses');
-    const result = resolveCredentials('openai', { projectRoot });
-    expect(result.apiKey).toBe('sk-global-wins');
-    expect(result.source).toBe('global-config');
+    writeProjectProviderKey(projectRoot, 'openai', 'sk-project-openai');
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    try {
+      resolveCredentials('openai', { projectRoot });
+      resolveCredentials('openai', { projectRoot });
+      resolveCredentials('openai', { projectRoot });
+      const rejectionWrites = writeSpy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((s) => s.includes('REJECTED'));
+      expect(rejectionWrites).toHaveLength(1);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 4a — global config DEPRECATION warning (T9413)
+// ---------------------------------------------------------------------------
+
+describe('Tier 4a — global-config apiKey deprecation (T9413)', () => {
+  it('still resolves the key but emits a DEPRECATED stderr warning', () => {
+    const { configPath } = makeTempXdg();
+    writeGlobalProviderKey(configPath, 'openai', 'sk-global-openai');
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    try {
+      const result = resolveCredentials('openai');
+      expect(result.apiKey).toBe('sk-global-openai');
+      expect(result.source).toBe('global-config');
+      const writes = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(writes).toMatch(/DEPRECATED/);
+      expect(writes).toMatch(/cleo auth add/);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it('emits the deprecation warning only once per provider', () => {
+    const { configPath } = makeTempXdg();
+    writeGlobalProviderKey(configPath, 'openai', 'sk-global-openai');
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    try {
+      resolveCredentials('openai');
+      resolveCredentials('openai');
+      resolveCredentials('openai');
+      const deprecationWrites = writeSpy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((s) => s.includes('DEPRECATED'));
+      expect(deprecationWrites).toHaveLength(1);
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 });
 
@@ -415,5 +502,138 @@ describe('storeAnthropicApiKey()', () => {
     storeAnthropicApiKey('sk-cache-test');
     process.env['ANTHROPIC_API_KEY'] = 'sk-env-after-store';
     expect(resolveCredentials('anthropic').apiKey).toBe('sk-env-after-store');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveCredentialsAsync (T9413 — E-CONFIG-AUTH-UNIFY §5.2 T-E2-6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a one-shot seeder that returns a single canned entry. Mirrors the
+ * helper in `credential-pool-unified.test.ts` — duplicated here so this
+ * file does not cross test-file boundaries.
+ */
+function makeAsyncTestSeeder(opts: {
+  sourceId: SeederSourceId;
+  provider: string;
+  token: string;
+  authType?: 'api_key' | 'oauth';
+}): CredentialSeeder {
+  return {
+    sourceId: opts.sourceId,
+    provider: opts.provider,
+    async seed() {
+      return {
+        entries: [
+          {
+            provider: opts.provider as never,
+            label: `${opts.sourceId}:${opts.provider}`,
+            authType: opts.authType ?? 'api_key',
+            source: opts.sourceId,
+            accessToken: opts.token,
+          },
+        ],
+      };
+    },
+  };
+}
+
+describe('resolveCredentialsAsync (T9413) — pool-backed', () => {
+  it('returns the explicit apiKey via tier 1 without touching the pool', async () => {
+    makeTempXdg();
+    const result = await resolveCredentialsAsync('anthropic', { apiKey: 'sk-explicit-async' });
+    expect(result.apiKey).toBe('sk-explicit-async');
+    expect(result.source).toBe('explicit');
+    expect(result.authType).toBe('api_key');
+  });
+
+  it('detects an OAuth-prefixed explicit key as authType=oauth', async () => {
+    makeTempXdg();
+    const result = await resolveCredentialsAsync('anthropic', {
+      apiKey: 'sk-ant-oat-explicit',
+    });
+    expect(result.source).toBe('explicit');
+    expect(result.authType).toBe('oauth');
+  });
+
+  it('delegates to getCredentialPool().pick() and returns the seeded entry', async () => {
+    makeTempXdg();
+    // Pre-seed the on-disk credential store via a test seeder. The default
+    // singleton's seeder sweep will run on the next pick() but is gated on
+    // consent + on-disk files that the isolated HOME does not provide — so
+    // the seeded entry below is the only thing the singleton can pick up
+    // when it reads the store.
+    const registry = new SeederRegistry();
+    registry.register(
+      makeAsyncTestSeeder({
+        sourceId: 'env',
+        provider: 'openai',
+        token: 'sk-pool-openai',
+      }),
+    );
+    const seedingPool = new UnifiedCredentialPool(() => registry.getAll());
+    await seedingPool.seed();
+
+    // The async resolver delegates to the singleton pool which now reads the
+    // pre-seeded entry from the store.
+    const result = await resolveCredentialsAsync('openai');
+    expect(result.apiKey).toBe('sk-pool-openai');
+    expect(result.source).toBe('cred-file');
+    expect(result.authType).toBe('api_key');
+  });
+
+  it('narrows oauth pool entries to authType=oauth', async () => {
+    makeTempXdg();
+    const registry = new SeederRegistry();
+    registry.register(
+      makeAsyncTestSeeder({
+        sourceId: 'cleo-pkce',
+        provider: 'anthropic',
+        token: 'sk-ant-oat-pkce',
+        authType: 'oauth',
+      }),
+    );
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    await pool.seed();
+    const entry = await pool.pick('anthropic');
+    expect(entry?.authType).toBe('oauth');
+    expect(entry?.accessToken).toBe('sk-ant-oat-pkce');
+  });
+
+  it('returns null with undefined source when the pool is empty', async () => {
+    makeTempXdg();
+    const result = await resolveCredentialsAsync('moonshot');
+    expect(result.apiKey).toBeNull();
+    expect(result.source).toBeUndefined();
+    expect(result.provider).toBe('moonshot');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sync resolveCredentials — pool tier read (no re-seeding) (T9413)
+// ---------------------------------------------------------------------------
+
+describe('resolveCredentials sync — pool file read without seeding (T9413)', () => {
+  it('reads a pre-seeded entry from the pool file synchronously', async () => {
+    makeTempXdg();
+    const registry = new SeederRegistry();
+    registry.register(
+      makeAsyncTestSeeder({
+        sourceId: 'env',
+        provider: 'openai',
+        token: 'sk-openai-from-pool',
+      }),
+    );
+    // Seed once via the unified pool — this writes the entry into the
+    // on-disk credential store under the isolated CLEO_HOME.
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    await pool.seed();
+
+    // The sync resolver MUST read that entry without re-seeding.
+    const result = resolveCredentials('openai');
+    expect(result.apiKey).toBe('sk-openai-from-pool');
+    expect(result.source).toBe('cred-file');
+    expect(result.authType).toBe('api_key');
   });
 });

--- a/packages/core/src/llm/__tests__/migration.test.ts
+++ b/packages/core/src/llm/__tests__/migration.test.ts
@@ -138,8 +138,11 @@ afterEach(() => {
 // Acceptance criterion — legacy `llm.providers[p].apiKey` still resolves
 // ---------------------------------------------------------------------------
 
-describe('Phase 1 → Phase 2 migration — legacy project-config fallback', () => {
-  it('a Phase 1 .cleo/config.json with only llm.providers.anthropic.apiKey still resolves', async () => {
+describe('Phase 1 → Phase 2 migration — legacy project-config REJECTED (T9413)', () => {
+  it('a Phase 1 .cleo/config.json with only llm.providers.anthropic.apiKey NO LONGER resolves (footgun kill)', async () => {
+    // T9413 (E-CONFIG-AUTH-UNIFY §5.2 T-E2-6): project-config apiKey is now
+    // rejected. The legacy Phase 1 path no longer resolves — operators
+    // must migrate via `cleo auth migrate-project-secrets`.
     const { projectRoot } = isolate();
     seedPhase1ProjectConfig(projectRoot, 'anthropic', 'sk-ant-api03-FIXTURE');
 
@@ -156,19 +159,12 @@ describe('Phase 1 → Phase 2 migration — legacy project-config fallback', () 
     expect(llm.provider).toBe(IMPLICIT_FALLBACK_PROVIDER);
     expect(llm.model).toBe(IMPLICIT_FALLBACK_MODEL);
 
-    // Credential resolves via the project-config tier (tier 5 in
-    // resolveCredentials), which is the legacy Phase 1 path.
-    expect(llm.credential).not.toBeNull();
-    expect(llm.credential?.apiKey).toBe('sk-ant-api03-FIXTURE');
-    expect(llm.credential?.source).toBe('project-config');
-    expect(llm.credential?.authType).toBe('api_key');
-
-    // Client must be wired (not null) since a credential is available.
-    expect(llm.client).not.toBeNull();
-    expect(llm.credentialLabel).toBeUndefined();
+    // The project-config tier is rejected — credential MUST be null.
+    expect(llm.credential).toBeNull();
+    expect(llm.client).toBeNull();
   });
 
-  it('every RoleName resolves identically from a Phase 1 config', async () => {
+  it('every RoleName falls through to null credential from a Phase 1 config (T9413)', async () => {
     const { projectRoot } = isolate();
     seedPhase1ProjectConfig(projectRoot, 'anthropic', 'sk-ant-api03-LEGACY');
 
@@ -176,9 +172,8 @@ describe('Phase 1 → Phase 2 migration — legacy project-config fallback', () 
     for (const role of roles) {
       const llm = await resolveLLMForRole(role, { projectRoot });
       expect(llm.source).toBe('implicit-fallback');
-      expect(llm.credential?.source).toBe('project-config');
-      expect(llm.credential?.apiKey).toBe('sk-ant-api03-LEGACY');
-      expect(llm.client).not.toBeNull();
+      expect(llm.credential).toBeNull();
+      expect(llm.client).toBeNull();
     }
   });
 
@@ -206,7 +201,7 @@ describe('Phase 1 → Phase 2 migration — legacy project-config fallback', () 
 // ---------------------------------------------------------------------------
 
 describe('Phase 1 → Phase 2 migration — additive upgrade', () => {
-  it('adding only llm.default upgrades provider/model without breaking credential resolution', async () => {
+  it('adding only llm.default upgrades provider/model but project-config apiKey is REJECTED (T9413)', async () => {
     const { projectRoot } = isolate();
     // Phase 1 fixture: providers map only.
     seedPhase1ProjectConfig(projectRoot, 'anthropic', 'sk-ant-api03-LEGACY-KEY');
@@ -233,9 +228,10 @@ describe('Phase 1 → Phase 2 migration — additive upgrade', () => {
     // Provider/model now come from llm.default.
     expect(llm.source).toBe('default');
     expect(llm.model).toBe('phase2-default-model');
-    // But the credential still resolves via the legacy project-config tier.
-    expect(llm.credential?.source).toBe('project-config');
-    expect(llm.credential?.apiKey).toBe('sk-ant-api03-LEGACY-KEY');
+    // The project-config apiKey is now rejected (T9413 footgun kill); the
+    // credential resolves to null until the operator migrates via
+    // `cleo auth migrate-project-secrets`.
+    expect(llm.credential).toBeNull();
   });
 
   it('seeding ~/.cleo/llm-credentials.json (Phase 2) overtakes legacy project-config tier', async () => {

--- a/packages/core/src/llm/__tests__/role-resolver-fullstack.test.ts
+++ b/packages/core/src/llm/__tests__/role-resolver-fullstack.test.ts
@@ -233,7 +233,16 @@ describe('resolveLLMForRole — credential tier precedence (full chain)', () => 
     expect(llm.credential?.apiKey).toBe('sk-ant-oat-credfile-wins');
   });
 
-  it('claude-creds (tier 4) beats global-config (tier 4a)', async () => {
+  it('claude-creds via pool seeder beats global-config (T9413 — pool tier replaces tier 4)', async () => {
+    // T9413 (E-CONFIG-AUTH-UNIFY §5.2 T-E2-6): direct read of
+    // `~/.claude/.credentials.json` was removed from the sync resolver.
+    // The `claude-code` seeder now imports the token into the unified
+    // pool, where the cred-file tier (formerly tier 3) picks it up — and
+    // still beats global-config. We use a hand-built test seeder so the
+    // consent gate (which reads the global config in production) is
+    // short-circuited without writing config files.
+    const { UnifiedCredentialPool } = await import('../credential-pool.js');
+    const { SeederRegistry } = await import('../credential-seeders/index.js');
     const { home, xdgRoot, projectRoot } = isolate();
     seedProjectConfig(projectRoot, { default: { provider: 'anthropic', model: 'm' } });
     seedClaudeOauth(home, 'sk-ant-oat-claude-wins');
@@ -241,8 +250,31 @@ describe('resolveLLMForRole — credential tier precedence (full chain)', () => 
       providers: { anthropic: { apiKey: 'sk-ant-global-loses' } },
     });
 
+    const registry = new SeederRegistry();
+    registry.register({
+      sourceId: 'claude-code',
+      provider: 'anthropic',
+      isConsentEstablished: async () => true,
+      async seed() {
+        return {
+          entries: [
+            {
+              provider: 'anthropic',
+              label: 'claude-code',
+              authType: 'oauth',
+              source: 'claude-code',
+              accessToken: 'sk-ant-oat-claude-wins',
+              expiresAt: Date.now() + 60 * 60_000,
+            },
+          ],
+        };
+      },
+    });
+    const pool = new UnifiedCredentialPool(() => registry.getAll());
+    await pool.seed();
+
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
-    expect(llm.credential?.source).toBe('claude-creds');
+    expect(llm.credential?.source).toBe('cred-file');
     expect(llm.credential?.apiKey).toBe('sk-ant-oat-claude-wins');
   });
 
@@ -261,7 +293,10 @@ describe('resolveLLMForRole — credential tier precedence (full chain)', () => 
     expect(llm.credential?.apiKey).toBe('sk-global-wins');
   });
 
-  it('project-config (tier 5) is the floor when every higher tier is empty', async () => {
+  it('project-config (tier 5) is REJECTED — never resolves even as floor (T9413)', async () => {
+    // T9413 (E-CONFIG-AUTH-UNIFY §5.2 T-E2-6): the project-config apiKey
+    // tier is the footgun this task killed. When it is the only source,
+    // the resolver returns null and emits a stderr warning instead.
     const { projectRoot } = isolate();
     seedProjectConfig(projectRoot, {
       default: { provider: 'anthropic', model: 'm' },
@@ -269,8 +304,7 @@ describe('resolveLLMForRole — credential tier precedence (full chain)', () => 
     });
 
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
-    expect(llm.credential?.source).toBe('project-config');
-    expect(llm.credential?.apiKey).toBe('sk-project-floor');
+    expect(llm.credential).toBeNull();
   });
 });
 

--- a/packages/core/src/llm/credentials.ts
+++ b/packages/core/src/llm/credentials.ts
@@ -29,10 +29,9 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { parseClaudeCodeCredentials } from '@cleocode/contracts';
 import { getCleoHome } from '@cleocode/paths';
+import { getCredentialPool } from './credential-pool.js';
 import { pickCredentialForProviderSync } from './credentials-store.js';
 import {
   configDirGlobalConfigPath,
@@ -206,26 +205,12 @@ function readGlobalProviderKey(provider: ModelTransport): string | null {
 // Tier helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Tier 3: read the Anthropic OAuth token from Claude Code credentials.
- *
- * Only applicable for the `anthropic` provider. Checks token expiry and
- * returns null if the token is present but expired.
- *
- * Delegates parsing to `parseClaudeCodeCredentials` from @cleocode/contracts
- * so the pure parsing logic has a single canonical home.
- */
-function readClaudeCredsToken(): string | null {
-  try {
-    const credPath = join(homedir(), '.claude', '.credentials.json');
-    if (!existsSync(credPath)) return null;
-    const raw = readFileSync(credPath, 'utf-8');
-    const cred = parseClaudeCodeCredentials(raw);
-    return cred?.accessToken ?? null;
-  } catch {
-    return null;
-  }
-}
+// NOTE — direct read of `~/.claude/.credentials.json` was removed in T9413
+// (E-CONFIG-AUTH-UNIFY §5.2 T-E2-6). The claude-code seeder
+// (`credential-seeders/claude-code-seeder.ts`) is now the sole owner of that
+// file; its imported entries land in the unified credential pool and are
+// served by tier 3 (`pickCredentialForProviderSync`) alongside every other
+// seeded source.
 
 /**
  * Tier 4b backward compat: read the legacy flat key file written by
@@ -273,19 +258,33 @@ function readProviderKeyFromConfig(configFile: string, provider: ModelTransport)
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the API key for a provider using the 5-tier priority chain.
+ * Resolve the API key for a provider using the synchronous tier chain.
  *
  * Resolution order (first non-empty match wins):
  * 1. `options.apiKey`  — explicit caller override
  * 2. `ENV_VARS[provider]` environment variable
- * 3. `~/.claude/.credentials.json` OAuth token (anthropic only)
- * 4. `~/.cleo/config.json` → `llm.providers[provider].apiKey`
- * 5. `<projectRoot>/.cleo/config.json` → `llm.providers[provider].apiKey`
+ * 3. `~/.cleo/llm-credentials.json` — unified credential pool (read-only;
+ *    seeding is the unified pool's responsibility — the sync path does not
+ *    re-seed)
+ * 4a. `~/.cleo/config.json` → `llm.providers[provider].apiKey` — **deprecated**
+ *     (emits stderr warning; still resolves during the transition window)
+ * 5. `<projectRoot>/.cleo/config.json` → `llm.providers[provider].apiKey` —
+ *    **rejected** (T-E2-6 footgun kill; emits stderr warning, never resolves)
+ *
+ * Direct reading of `~/.claude/.credentials.json` was removed in T9413; the
+ * `claude-code` seeder is now the sole owner of that file and its imported
+ * entries land in the pool, which the tier-3 read picks up.
+ *
+ * For new code prefer {@link resolveCredentialsAsync}, which delegates to the
+ * {@link UnifiedCredentialPool} singleton (`getCredentialPool().pick()`) and
+ * triggers a lazy seed pass on first call. The sync variant is retained for
+ * call-sites that cannot move to async (e.g. `defaultTransportApiKey`,
+ * `resolveModelCredentials`).
  *
  * Never throws. All filesystem errors are caught and treated as "not found".
  *
  * @param provider - The LLM provider transport to resolve credentials for.
- * @param options  - Optional overrides and project root for tier 5.
+ * @param options  - Optional overrides and project root for tier 5 warning.
  * @returns A `CredentialResult` with `provider`, `apiKey`, and `source`.
  *
  * @example
@@ -293,6 +292,9 @@ function readProviderKeyFromConfig(configFile: string, provider: ModelTransport)
  * const cred = resolveCredentials('anthropic', { projectRoot: cwd });
  * if (!cred.apiKey) throw new Error('No Anthropic key found');
  * ```
+ *
+ * @task T9413
+ * @epic E-CONFIG-AUTH-UNIFY
  */
 export function resolveCredentials(
   provider: ModelTransport,
@@ -328,8 +330,9 @@ export function resolveCredentials(
   // Tier 3 — ~/.cleo/llm-credentials.json (multi-credential pool).
   // T-LLM-CRED-CENTRALIZATION Phase 2 (T9257). Sync read of the file-locked,
   // 0600 store. Picks the highest-priority non-disabled, non-expired entry
-  // for `provider`. Returns null when the file is absent or has no eligible
-  // entries — falls through to the legacy claude-creds tier below.
+  // for `provider`. The sync path NEVER re-seeds — seeding is the unified
+  // pool's responsibility (T9412 / T9413). Returns null when the file is
+  // absent or has no eligible entries — falls through to the legacy tiers.
   const stored = pickCredentialForProviderSync(provider);
   if (stored) {
     // Narrow stored.authType back to the on-wire AuthType. Phase 2 widens
@@ -345,21 +348,17 @@ export function resolveCredentials(
     };
   }
 
-  // Tier 4 — ~/.claude/.credentials.json (anthropic only)
-  if (provider === 'anthropic') {
-    const oauthToken = readClaudeCredsToken();
-    if (oauthToken) {
-      return { provider, apiKey: oauthToken, source: 'claude-creds', authType: 'oauth' };
-    }
-  }
+  // Tier 4 (legacy direct claude-creds read) — REMOVED in T9413. The
+  // `claude-code` seeder owns `~/.claude/.credentials.json`; its imported
+  // entries surface via tier 3 above.
 
-  // Tier 4a — global config. Canonical path is the XDG config dir
-  // (`~/.config/cleo/config.json` on Linux); the data-dir copy
-  // (`~/.local/share/cleo/config.json`) is consulted as a read-only fallback
-  // during the transition window so existing installs keep working until
-  // `ensureGlobalConfigMigrated()` upgrades them (T9405).
+  // Tier 4a — global config. **DEPRECATED** (T9413). Emits a stderr warning
+  // on every hit so operators discover the migration path; still resolves
+  // for now so existing installs keep working. Canonical XDG config dir is
+  // preferred; the data-dir copy is the transition-window fallback.
   const globalKey = readGlobalProviderKey(provider);
   if (globalKey) {
+    warnGlobalConfigApiKeyDeprecated(provider);
     return {
       provider,
       apiKey: globalKey,
@@ -383,20 +382,153 @@ export function resolveCredentials(
     }
   }
 
-  // Tier 5 — project config (.cleo/config.json)
+  // Tier 5 — project config (.cleo/config.json). **REJECTED** in T9413
+  // (E-CONFIG-AUTH-UNIFY §5.2 T-E2-6 footgun kill). When a project config
+  // still has `llm.providers.*.apiKey` set, emit a stderr warning with the
+  // migration command and DO NOT resolve. The key MUST be migrated via
+  // `cleo auth migrate-project-secrets` (T-E2-9).
   if (options.projectRoot) {
     const projectKey = readProviderKeyFromConfig(projectConfigPath(options.projectRoot), provider);
     if (projectKey) {
-      return {
-        provider,
-        apiKey: projectKey,
-        source: 'project-config',
-        authType: detectAuthType(provider, projectKey),
-      };
+      warnProjectConfigApiKeyRejected(provider);
+      // Intentionally fall through to the null return below.
     }
   }
 
   return { provider, apiKey: null, source: undefined, authType: 'api_key' };
+}
+
+/**
+ * Async resolver that delegates to the unified credential pool (T9413).
+ *
+ * Resolution order:
+ *
+ * 1. `options.apiKey` — explicit caller override (identical to the sync
+ *    behaviour; short-circuits before touching the pool).
+ * 2. `await getCredentialPool().pick(provider, ...)` — the unified pool
+ *    transparently runs a lazy seed pass on first call (60s cache; force
+ *    via `force: true` on the pool directly). The returned entry's
+ *    `authType` is narrowed to the on-wire {@link AuthType}: `'oauth'` for
+ *    OAuth tokens, `'api_key'` for everything else (including `'aws_sdk'`).
+ *
+ * Returns `{ apiKey: null }` with `source: undefined` when the pool has no
+ * eligible entry for the provider — callers should treat this as
+ * "no credential available" and emit a setup hint.
+ *
+ * Unlike the sync resolver, the async path does NOT consult the legacy
+ * tiers 4a/4b/5: any deprecated source must be seeded into the pool first
+ * (via a seeder) to be picked up here. This is the steady-state code path
+ * the rest of E-CONFIG-AUTH-UNIFY converges on.
+ *
+ * @param provider - The LLM provider transport to resolve credentials for.
+ * @param options  - Optional explicit `apiKey` override.
+ * @returns A `CredentialResult` shaped identically to the sync resolver.
+ *
+ * @example
+ * ```ts
+ * const cred = await resolveCredentialsAsync('anthropic');
+ * if (!cred.apiKey) {
+ *   throw new Error('No anthropic credential — run `cleo auth add anthropic`');
+ * }
+ * ```
+ *
+ * @task T9413
+ * @epic E-CONFIG-AUTH-UNIFY
+ */
+export async function resolveCredentialsAsync(
+  provider: ModelTransport,
+  options: CredentialResolveOptions = {},
+): Promise<CredentialResult> {
+  // Tier 1 — explicit caller-supplied key (matches sync behaviour exactly).
+  if (options.apiKey?.trim()) {
+    const token = options.apiKey.trim();
+    return {
+      provider,
+      apiKey: token,
+      source: 'explicit',
+      authType: detectAuthType(provider, token),
+    };
+  }
+
+  // Tier 2+ — delegate to the unified pool. The pool seeds lazily on the
+  // first call (and at most once every POOL_SEED_CACHE_TTL_MS), then picks
+  // a non-disabled, non-expired entry using the store's default strategy.
+  const entry = await getCredentialPool().pick(provider);
+  if (entry) {
+    const wireAuthType: AuthType = entry.authType === 'oauth' ? 'oauth' : 'api_key';
+    return {
+      provider,
+      apiKey: entry.accessToken || null,
+      source: 'cred-file',
+      authType: wireAuthType,
+    };
+  }
+
+  return { provider, apiKey: null, source: undefined, authType: 'api_key' };
+}
+
+// ---------------------------------------------------------------------------
+// Deprecation warnings — T9413 (E-CONFIG-AUTH-UNIFY §5.2 T-E2-6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Latch the deprecation warning per (provider, message) so a hot loop does
+ * not flood stderr. Keys are simple strings — small, opaque to the rest of
+ * the module.
+ *
+ * @internal
+ */
+const WARNED_GLOBAL_CONFIG = new Set<string>();
+const WARNED_PROJECT_CONFIG = new Set<string>();
+
+/**
+ * Emit a one-shot stderr warning that the global-config `apiKey` path is
+ * deprecated. Re-emits only if the latch is cleared (test-only via
+ * {@link _resetCredentialDeprecationLatchesForTests}).
+ *
+ * @internal
+ * @task T9413
+ */
+function warnGlobalConfigApiKeyDeprecated(provider: ModelTransport): void {
+  if (WARNED_GLOBAL_CONFIG.has(provider)) return;
+  WARNED_GLOBAL_CONFIG.add(provider);
+  process.stderr.write(
+    `[cleo] DEPRECATED: \`llm.providers.${provider}.apiKey\` in the global ` +
+      `config.json is deprecated and will be removed. Migrate with ` +
+      `\`cleo auth add ${provider}\` or \`cleo llm add\`.\n`,
+  );
+}
+
+/**
+ * Emit a one-shot stderr warning that the project-config `apiKey` path is
+ * rejected. The key is NOT resolved — operators must migrate.
+ *
+ * @internal
+ * @task T9413
+ */
+function warnProjectConfigApiKeyRejected(provider: ModelTransport): void {
+  if (WARNED_PROJECT_CONFIG.has(provider)) return;
+  WARNED_PROJECT_CONFIG.add(provider);
+  process.stderr.write(
+    `[cleo] REJECTED: \`llm.providers.${provider}.apiKey\` in \`.cleo/config.json\` ` +
+      `(project-scoped) is a security footgun and is no longer honoured. ` +
+      `Run \`cleo auth migrate-project-secrets\` to move the key into the ` +
+      `unified credential pool.\n`,
+  );
+}
+
+/**
+ * Test-only: clear the one-shot deprecation latches so a test asserting
+ * the warning emission can run independently of sibling tests.
+ *
+ * Production code MUST NOT call this — re-emitting the warning on every
+ * hit would flood stderr.
+ *
+ * @internal
+ */
+export function _resetCredentialDeprecationLatchesForTests(): void {
+  WARNED_GLOBAL_CONFIG.clear();
+  WARNED_PROJECT_CONFIG.clear();
 }
 
 /**


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E2a §5.2 T-E2-6. Adds `resolveCredentialsAsync()` that delegates to `getCredentialPool().pick()` after tier-1 explicit-apiKey pass-through. Sync `resolveCredentials` retained for BC — reads pool file without re-seeding. Tier-5 (`.cleo/config.json` apiKey) emits stderr warning and MUST NOT resolve (footgun kill).

## Changes
- `resolveCredentialsAsync()` (new async overload) — explicit apiKey pass-through → pool pick → null
- Sync path: removed direct `~/.claude/.credentials.json` read (claude-code seeder owns it via pool now)
- Tier-4a: deprecation warning to stderr (still resolves for back-compat)
- Tier-5: rejection warning + returns null
- One-shot warning latches (deduplicate noise)
- Tests updated for new policy: 4 affected suites (`credentials`, `credentials-auth-type`, `migration`, `role-resolver-fullstack`, `credentials-store`)

## Test plan
- [x] 921/921 LLM tests pass
- [x] biome + build clean
- [x] async-pool, sync-no-seed, tier-5-rejection paths all tested

## Refs
- `docs/plans/E-CONFIG-AUTH-UNIFY.md` §5.2 T-E2-6
- Epic: T9400, Master: T9500