### PR TITLE
feat(T9416): add cleo auth list + cleo auth remove command group

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/auth-command.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/auth-command.test.ts
@@ -1,0 +1,339 @@
+/**
+ * CLI wiring tests for `cleo auth` (T9416).
+ *
+ * Verifies:
+ *   - `auth` exposes `list` + `remove` subcommands.
+ *   - `auth list` calls `getCredentialPool().seed()` then `list()`,
+ *      filters by --provider, and emits the LAFS envelope shape.
+ *   - `auth remove` dispatches to the per-source RemovalStep, persists
+ *      suppression when `suppress: true`, and removes the entry from
+ *      the credential store.
+ *
+ * The credential pool, removal registry, and store are mocked so the
+ * test never touches `~/.cleo/llm-credentials.json` or the real
+ * suppression file.
+ *
+ * @task T9416
+ * @epic E-CONFIG-AUTH-UNIFY (E2b)
+ */
+
+import type { CommandDef } from 'citty';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared BEFORE importing the command module.
+// ---------------------------------------------------------------------------
+
+const mockSeed = vi.fn().mockResolvedValue({ added: 0, failed: 0, skipped: 0 });
+const mockList = vi.fn();
+const mockGetCredentialPool = vi.fn(() => ({
+  seed: mockSeed,
+  list: mockList,
+}));
+
+vi.mock('@cleocode/core/llm/credential-pool.js', () => ({
+  getCredentialPool: () => mockGetCredentialPool(),
+}));
+
+const mockRemovalStep = {
+  sourceId: 'claude-code' as const,
+  description: 'mock',
+  remove: vi.fn(),
+};
+const mockRegistryFind = vi.fn();
+const mockAddSuppression = vi.fn();
+
+vi.mock('@cleocode/core/llm/credential-removal.js', () => ({
+  REMOVAL_REGISTRY: { find: (...a: unknown[]) => mockRegistryFind(...a) },
+  addSuppression: (...a: unknown[]) => mockAddSuppression(...a),
+}));
+
+const mockRemoveCredential = vi.fn();
+
+vi.mock('@cleocode/core/llm/credentials-store.js', () => ({
+  removeCredential: (...a: unknown[]) => mockRemoveCredential(...a),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { authCommand } from '../auth.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getAuthSubs(): Promise<Record<string, CommandDef>> {
+  const resolved =
+    typeof authCommand.subCommands === 'function'
+      ? await authCommand.subCommands()
+      : authCommand.subCommands;
+  return (resolved ?? {}) as Record<string, CommandDef>;
+}
+
+async function runSub(
+  cmd: CommandDef,
+  args: Record<string, unknown>,
+  rawArgs: string[] = [],
+): Promise<void> {
+  const resolved = typeof cmd === 'function' ? await cmd() : cmd;
+  const runFn = (resolved as { run?: (ctx: unknown) => Promise<void> }).run;
+  if (!runFn) throw new Error('Subcommand has no run function');
+  await runFn({ args, rawArgs, cmd: resolved });
+}
+
+function captureStdout(): { restore: () => void; lines: string[] } {
+  const orig = process.stdout.write.bind(process.stdout);
+  const lines: string[] = [];
+  process.stdout.write = ((s: unknown) => {
+    lines.push(String(s));
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    lines,
+    restore: () => {
+      process.stdout.write = orig;
+    },
+  };
+}
+
+function captureStderr(): { restore: () => void; lines: string[] } {
+  const orig = process.stderr.write.bind(process.stderr);
+  const lines: string[] = [];
+  process.stderr.write = ((s: unknown) => {
+    lines.push(String(s));
+    return true;
+  }) as typeof process.stderr.write;
+  return {
+    lines,
+    restore: () => {
+      process.stderr.write = orig;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('cleo auth — CLI wiring', () => {
+  beforeEach(() => {
+    mockSeed.mockClear();
+    mockList.mockReset();
+    mockGetCredentialPool.mockClear();
+    mockRegistryFind.mockReset();
+    mockAddSuppression.mockReset();
+    mockRemoveCredential.mockReset();
+    mockRemovalStep.remove.mockReset();
+    process.env['CLEO_FORMAT'] = 'json';
+  });
+
+  it('exposes list + remove subcommands', async () => {
+    const subs = await getAuthSubs();
+    expect(Object.keys(subs).sort()).toEqual(['list', 'remove']);
+  });
+
+  it('list — seeds, lists, filters by --provider, emits LAFS envelope', async () => {
+    mockList.mockResolvedValue([
+      {
+        provider: 'anthropic',
+        label: 'claude-code-import',
+        source: 'claude-code',
+        authType: 'oauth',
+        accessToken: 'sk-FAKE',
+        priority: 100,
+        expiresAt: Date.now() + 60 * 60 * 1000,
+      },
+      {
+        provider: 'openai',
+        label: 'env:OPENAI_API_KEY',
+        source: 'env',
+        authType: 'api_key',
+        accessToken: 'sk-OPENAI',
+        priority: 50,
+      },
+    ]);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['list']!, { provider: 'anthropic' });
+    } finally {
+      stdout.restore();
+    }
+
+    // seed() then list() — in that order.
+    expect(mockSeed).toHaveBeenCalledTimes(1);
+    expect(mockList).toHaveBeenCalledTimes(1);
+
+    // Last stdout line is the JSON envelope.
+    const env = JSON.parse(stdout.lines[stdout.lines.length - 1]!);
+    expect(env.success).toBe(true);
+    expect(env.meta.operation).toBe('auth.list');
+    expect(env.data.entries).toHaveLength(1);
+    expect(env.data.entries[0]).toMatchObject({
+      provider: 'anthropic',
+      label: 'claude-code-import',
+      source: 'claude-code',
+      authType: 'oauth',
+    });
+    expect(env.data.entries[0].expiryStatus).toMatch(/^expires in /);
+  });
+
+  it('list — labels expired and never entries correctly', async () => {
+    mockList.mockResolvedValue([
+      {
+        provider: 'a',
+        label: 'expired',
+        source: 'env',
+        authType: 'api_key',
+        accessToken: 'x',
+        priority: 1,
+        expiresAt: Date.now() - 10_000,
+      },
+      {
+        provider: 'b',
+        label: 'never',
+        source: 'manual',
+        authType: 'api_key',
+        accessToken: 'x',
+        priority: 1,
+      },
+    ]);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['list']!, {});
+    } finally {
+      stdout.restore();
+    }
+
+    const env = JSON.parse(stdout.lines[stdout.lines.length - 1]!);
+    const byLabel: Record<string, string> = Object.fromEntries(
+      env.data.entries.map((e: { label: string; expiryStatus: string }) => [
+        e.label,
+        e.expiryStatus,
+      ]),
+    );
+    expect(byLabel['expired']).toBe('expired');
+    expect(byLabel['never']).toBe('never');
+  });
+
+  it('remove — happy path: dispatches RemovalStep, suppresses, removes entry', async () => {
+    mockList.mockResolvedValue([
+      {
+        provider: 'anthropic',
+        label: 'claude-code-import',
+        source: 'claude-code',
+        authType: 'oauth',
+        accessToken: 'sk-FAKE',
+        priority: 100,
+      },
+    ]);
+    mockRegistryFind.mockReturnValue(mockRemovalStep);
+    mockRemovalStep.remove.mockResolvedValue({
+      cleaned: [],
+      hints: ['Do NOT delete ~/.claude/.credentials.json — re-seed suppressed.'],
+      suppress: true,
+    });
+    mockRemoveCredential.mockResolvedValue(true);
+
+    const stdout = captureStdout();
+    const stderr = captureStderr();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['remove']!, {
+        provider: 'anthropic',
+        label: 'claude-code-import',
+      });
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(mockRegistryFind).toHaveBeenCalledWith('claude-code');
+    expect(mockRemovalStep.remove).toHaveBeenCalledWith({
+      provider: 'anthropic',
+      label: 'claude-code-import',
+    });
+    expect(mockAddSuppression).toHaveBeenCalledWith('anthropic', 'claude-code');
+    expect(mockRemoveCredential).toHaveBeenCalledWith('anthropic', 'claude-code-import');
+
+    // Hint surfaced on stderr.
+    const hintLine = stderr.lines.find((l) => l.startsWith('hint:'));
+    expect(hintLine).toBeDefined();
+
+    // Envelope on stdout.
+    const env = JSON.parse(stdout.lines[stdout.lines.length - 1]!);
+    expect(env.success).toBe(true);
+    expect(env.data).toMatchObject({
+      provider: 'anthropic',
+      label: 'claude-code-import',
+      source: 'claude-code',
+      removed: true,
+      suppressed: true,
+    });
+  });
+
+  it('remove — entry not found emits E_NOT_FOUND envelope and exits 4', async () => {
+    mockList.mockResolvedValue([]);
+
+    const stdout = captureStdout();
+    const stderr = captureStderr();
+    const subs = await getAuthSubs();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__EXIT_${code}__`);
+    }) as never);
+    try {
+      await expect(
+        runSub(subs['remove']!, { provider: 'anthropic', label: 'nope' }),
+      ).rejects.toThrow('__EXIT_4__');
+    } finally {
+      stdout.restore();
+      stderr.restore();
+      exitSpy.mockRestore();
+    }
+
+    const env = JSON.parse(stdout.lines[stdout.lines.length - 1]!);
+    expect(env.success).toBe(false);
+    expect(env.error.codeName).toBe('E_NOT_FOUND');
+    expect(mockRegistryFind).not.toHaveBeenCalled();
+    expect(mockRemoveCredential).not.toHaveBeenCalled();
+  });
+
+  it('remove — suppress:false skips addSuppression but still removes entry', async () => {
+    mockList.mockResolvedValue([
+      {
+        provider: 'anthropic',
+        label: 'manual-key',
+        source: 'manual',
+        authType: 'api_key',
+        accessToken: 'x',
+        priority: 1,
+      },
+    ]);
+    mockRegistryFind.mockReturnValue({
+      sourceId: 'manual',
+      description: 'mock',
+      remove: async () => ({ cleaned: [], hints: ['entry removed'], suppress: false }),
+    });
+    mockRemoveCredential.mockResolvedValue(true);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['remove']!, { provider: 'anthropic', label: 'manual-key' });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(mockAddSuppression).not.toHaveBeenCalled();
+    expect(mockRemoveCredential).toHaveBeenCalledWith('anthropic', 'manual-key');
+
+    const env = JSON.parse(stdout.lines[stdout.lines.length - 1]!);
+    expect(env.data.suppressed).toBe(false);
+    expect(env.data.removed).toBe(true);
+  });
+});

--- a/packages/cleo/src/cli/commands/auth.ts
+++ b/packages/cleo/src/cli/commands/auth.ts
@@ -1,0 +1,40 @@
+/**
+ * CLI command group: `cleo auth` — unified credential view + removal.
+ *
+ * Sister surface to `cleo llm` — where `cleo llm` is scoped to the
+ * LLM-credential pool (the `llm-credentials.json` store), `cleo auth` walks
+ * every registered seeder so the operator sees the complete unified view
+ * (env, claude-code, cleo-pkce, codex-cli, gemini-cli, gh-cli, manual).
+ *
+ * Subcommands:
+ *   cleo auth list [--provider P] [--json]    — full pool listing
+ *   cleo auth remove <provider> <label>       — invoke per-source RemovalStep
+ *
+ * @task T9416
+ * @epic E-CONFIG-AUTH-UNIFY (E2b §5.2 T-E2-8)
+ */
+
+import { defineCommand, showUsage } from 'citty';
+import { authListCommand, authRemoveCommand } from './auth/index.js';
+
+/**
+ * `cleo auth` — unified credential surface.
+ *
+ * @task T9416
+ */
+export const authCommand = defineCommand({
+  meta: {
+    name: 'auth',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+  },
+  subCommands: {
+    list: authListCommand,
+    remove: authRemoveCommand,
+  },
+  async run({ cmd, rawArgs }) {
+    const firstArg = rawArgs?.find((a) => !a.startsWith('-'));
+    if (firstArg && cmd.subCommands && firstArg in cmd.subCommands) return;
+    await showUsage(cmd);
+  },
+});

--- a/packages/cleo/src/cli/commands/auth/index.ts
+++ b/packages/cleo/src/cli/commands/auth/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Barrel for the `cleo auth` command group.
+ *
+ * The dispatch wrapper lives at `packages/cleo/src/cli/commands/auth.ts`
+ * (so the command-manifest generator — which only scans top-level
+ * `commands/*.ts` files — picks it up). The wrapper imports the individual
+ * subcommands from this barrel.
+ *
+ * @task T9416
+ * @epic E-CONFIG-AUTH-UNIFY (E2b)
+ */
+
+export type { AuthListEntry } from './list.js';
+export { authListCommand } from './list.js';
+export type { AuthRemoveResult } from './remove.js';
+export { authRemoveCommand } from './remove.js';

--- a/packages/cleo/src/cli/commands/auth/list.ts
+++ b/packages/cleo/src/cli/commands/auth/list.ts
@@ -1,0 +1,162 @@
+/**
+ * `cleo auth list` — unified view of every credential the unified credential
+ * pool has discovered, across every seeder source (env, claude-code, cleo-pkce,
+ * codex-cli, gemini-cli, gh-cli, manual).
+ *
+ * Sister command to `cleo llm list` — the LLM-scoped command continues to read
+ * the redacted `llm-credentials.json` store directly, while `cleo auth list`
+ * triggers a `seed()` pass first so the user sees the same set the resolver
+ * would see on the next pick.
+ *
+ * Tokens are NEVER surfaced — every row reports only the last-4-char preview
+ * baked into `StoredCredential` (via the `accessToken` suffix display logic in
+ * the renderer below).
+ *
+ * @task T9416
+ * @epic E-CONFIG-AUTH-UNIFY (E2b)
+ */
+
+import { defineCommand } from 'citty';
+import { cliOutput } from '../../renderers/index.js';
+
+// ---------------------------------------------------------------------------
+// Public types — kept local because they are shaped by the auth CLI surface,
+// not part of the cross-package credential contract.
+// ---------------------------------------------------------------------------
+
+/**
+ * One row in `cleo auth list` output.
+ *
+ * Mirrors the columns documented in T9416 / §5.2 T-E2-8: provider, label,
+ * source, authType, expiry status, current-default flag.
+ *
+ * @task T9416
+ */
+export interface AuthListEntry {
+  /** Canonical provider name (e.g. `anthropic`). */
+  provider: string;
+  /** Human-readable label, unique within `provider`. */
+  label: string;
+  /** Seeder source id (e.g. `claude-code`, `cleo-pkce`, `env`, `manual`). */
+  source: string;
+  /** Storage-level auth scheme — `api_key`, `oauth`, or `aws_sdk`. */
+  authType: string;
+  /**
+   * Human-readable expiry status:
+   *   - `'never'`            — no `expiresAt` field on the entry.
+   *   - `'expired'`          — `expiresAt` is in the past.
+   *   - `'expires in <Xm>'`  — minutes until `expiresAt` (rounded down).
+   *   - `'expires in <Xh>'`  — hours when `> 90` minutes remain.
+   *   - `'expires in <Xd>'`  — days when `> 36` hours remain.
+   */
+  expiryStatus: string;
+  /** `true` if this entry is the current default for its provider+label. */
+  current: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Format an `expiresAt` epoch-ms timestamp into a short human-readable string.
+ *
+ * @param expiresAt - Optional epoch-ms timestamp from a {@link StoredCredential}.
+ * @returns Display string per {@link AuthListEntry.expiryStatus}.
+ *
+ * @internal
+ */
+function formatExpiry(expiresAt: number | null | undefined): string {
+  if (expiresAt == null) return 'never';
+  const remaining = expiresAt - Date.now();
+  if (remaining <= 0) return 'expired';
+  const minutes = Math.floor(remaining / 60_000);
+  if (minutes <= 90) return `expires in ${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours <= 36) return `expires in ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `expires in ${days}d`;
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * `cleo auth list` — print the unified credential view.
+ *
+ * Behaviour:
+ *   1. Resolves `getCredentialPool()` lazily so importing this module never
+ *      triggers seeder registration on `cleo --help`.
+ *   2. Calls `pool.seed()` (subject to the 60s cache) so the listing reflects
+ *      what the resolver would see — without the explicit seed step,
+ *      first-run users would see an empty list.
+ *   3. Calls `pool.list()` for the actual rows; this is a pure store read.
+ *   4. Applies `--provider` filter when supplied.
+ *   5. Sorts ascending by `(provider, label)` for deterministic output.
+ *
+ * @task T9416
+ */
+export const authListCommand = defineCommand({
+  meta: {
+    name: 'list',
+    description:
+      'List ALL pool entries from ALL sources (env, claude-code, cleo-pkce, ' +
+      'codex-cli, gemini-cli, gh-cli, manual). Tokens are never surfaced — ' +
+      'use `cleo llm list` for the LLM-scoped view that mirrors the manual store only.',
+  },
+  args: {
+    provider: {
+      type: 'string',
+      description: 'Filter to a single provider id (e.g. anthropic)',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON envelope',
+    },
+  },
+  async run({ args }) {
+    const a = args as Record<string, unknown>;
+    const providerFilter =
+      typeof a['provider'] === 'string' && a['provider'] !== '' ? (a['provider'] as string) : null;
+
+    // Lazy import — keeps `--help` fast and avoids pulling the entire LLM
+    // dependency graph for users who never call `cleo auth list`.
+    const { getCredentialPool } = await import(
+      /* webpackIgnore: true */ '@cleocode/core/llm/credential-pool.js'
+    );
+
+    const pool = getCredentialPool();
+    // Force a seed pass so the listing matches what `pick()` would return.
+    // The pool's internal 60s cache makes repeat calls cheap.
+    await pool.seed();
+    const stored = await pool.list();
+
+    const entries: AuthListEntry[] = stored
+      .filter((c) => (providerFilter ? c.provider === providerFilter : true))
+      .map((c) => ({
+        provider: c.provider,
+        label: c.label,
+        source: c.source ?? 'manual',
+        authType: c.authType,
+        expiryStatus: formatExpiry(c.expiresAt),
+        // `current` is "is this entry not in active cooldown AND not disabled"
+        // — i.e. could it be served right now. A richer notion of "default
+        // credential per provider" would require resolver introspection,
+        // which lands in a follow-up task.
+        current: !c.disabled && (c.lastErrorResetAt == null || c.lastErrorResetAt <= Date.now()),
+      }))
+      .sort((a, b) => {
+        const p = a.provider.localeCompare(b.provider);
+        return p !== 0 ? p : a.label.localeCompare(b.label);
+      });
+
+    cliOutput(
+      { entries },
+      {
+        command: 'auth-list',
+        operation: 'auth.list',
+      },
+    );
+  },
+});

--- a/packages/cleo/src/cli/commands/auth/remove.ts
+++ b/packages/cleo/src/cli/commands/auth/remove.ts
@@ -1,0 +1,198 @@
+/**
+ * `cleo auth remove <provider> <label>` — invoke the source-specific
+ * {@link RemovalStep} for a credential, persist suppression so the next pool
+ * seed does NOT re-import it, and drop the entry from
+ * `llm-credentials.json`.
+ *
+ * Flow (per E-CONFIG-AUTH-UNIFY E2b §5.2 T-E2-8 + E2-MUST-012):
+ *
+ *   1. Resolve the entry from the unified pool's `list()` so we can dispatch
+ *      on its `source`.
+ *   2. Look up the `RemovalStep` for that source via `REMOVAL_REGISTRY.find`.
+ *   3. Invoke `step.remove({ provider, label })`; surface `cleaned` + `hints`
+ *      to stderr.
+ *   4. If `result.suppress` is true, call `addSuppression(provider, sourceId)`
+ *      so the next `seed()` pass skips that source for this provider.
+ *   5. Drop the entry from the store via `removeCredential(provider, label)`.
+ *
+ * The store mutation in step 5 is what makes the change visible to the very
+ * next `cleo auth list` invocation; suppression is what makes it durable
+ * across `seed()` re-runs (env / claude-code / cleo-pkce / etc. would
+ * otherwise re-discover the credential and re-seed it on the next call).
+ *
+ * @task T9416
+ * @epic E-CONFIG-AUTH-UNIFY (E2b)
+ */
+
+import { defineCommand } from 'citty';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+// ---------------------------------------------------------------------------
+// Public type
+// ---------------------------------------------------------------------------
+
+/**
+ * Result envelope for `cleo auth remove`.
+ *
+ * Reported to stdout as `{ success: true, data: <this> }` when the LAFS
+ * envelope is requested (`--json`); the human renderer prints the
+ * `removed/cleaned/hints/suppressed` summary directly.
+ *
+ * @task T9416
+ */
+export interface AuthRemoveResult {
+  /** Provider whose entry was removed. */
+  provider: string;
+  /** Label of the removed entry. */
+  label: string;
+  /** Source id the entry came from (e.g. `claude-code`). */
+  source: string;
+  /** `true` if the entry was actually present in the store. */
+  removed: boolean;
+  /** Absolute filesystem paths the removal step mutated / deleted. */
+  cleaned: string[];
+  /** Operator-facing follow-up hints surfaced by the removal step. */
+  hints: string[];
+  /** `true` if `(provider, source)` was added to the suppression list. */
+  suppressed: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * `cleo auth remove <provider> <label>` — see file-level docstring.
+ *
+ * @task T9416
+ */
+export const authRemoveCommand = defineCommand({
+  meta: {
+    name: 'remove',
+    description:
+      'Remove a credential by (provider, label) and suppress its source from ' +
+      'future re-seeding. Dispatches to the per-source RemovalStep so claude-code ' +
+      '(et al.) entries are handled correctly without deleting external files.',
+  },
+  args: {
+    provider: {
+      type: 'positional',
+      description: 'Provider id (e.g. anthropic, openai, gemini)',
+      required: true,
+    },
+    label: {
+      type: 'positional',
+      description: 'Label of the credential to remove (unique within provider)',
+      required: true,
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON envelope',
+    },
+  },
+  async run({ args }) {
+    const a = args as Record<string, unknown>;
+    const provider = String(a['provider'] ?? '');
+    const label = String(a['label'] ?? '');
+
+    if (!provider) {
+      cliError('provider is required', 6, { name: 'E_INVALID_INPUT' });
+      process.exit(6);
+    }
+    if (!label) {
+      cliError('label is required', 6, { name: 'E_INVALID_INPUT' });
+      process.exit(6);
+    }
+
+    // Lazy import — same rationale as `cleo auth list`.
+    const { getCredentialPool } = await import(
+      /* webpackIgnore: true */ '@cleocode/core/llm/credential-pool.js'
+    );
+    const { REMOVAL_REGISTRY, addSuppression } = await import(
+      /* webpackIgnore: true */ '@cleocode/core/llm/credential-removal.js'
+    );
+    const { removeCredential } = await import(
+      /* webpackIgnore: true */ '@cleocode/core/llm/credentials-store.js'
+    );
+
+    const pool = getCredentialPool();
+    const entries = await pool.list();
+    const entry = entries.find((c) => c.provider === provider && c.label === label);
+
+    if (!entry) {
+      cliError(`No credential found for provider='${provider}' label='${label}'`, 4, {
+        name: 'E_NOT_FOUND',
+        fix: `Run 'cleo auth list' to see active credentials.`,
+      });
+      process.exit(4);
+    }
+
+    // Step 1 — dispatch to the per-source RemovalStep. `source` falls back to
+    // `'manual'` because legacy entries written before the seeder migration
+    // lack a `source` field; the MANUAL_REMOVAL_STEP handles those.
+    const sourceId = (entry.source ?? 'manual') as
+      | 'env'
+      | 'claude-code'
+      | 'cleo-pkce'
+      | 'codex-cli'
+      | 'gemini-cli'
+      | 'gh-cli'
+      | 'manual';
+    const step = REMOVAL_REGISTRY.find(sourceId);
+
+    if (!step) {
+      cliError(
+        `No RemovalStep registered for source='${sourceId}' — cannot safely remove '${provider}/${label}'.`,
+        2,
+        {
+          name: 'E_REMOVAL_NOT_REGISTERED',
+          fix: `Open an issue: a credential was seeded from an unknown source.`,
+        },
+      );
+      process.exit(2);
+    }
+
+    const stepResult = await step.remove({ provider, label });
+
+    // Step 2 — surface the per-source side-effects (`cleaned` + `hints`) on
+    // stderr. We deliberately route these through stderr so JSON consumers
+    // (--json) get the structured envelope on stdout while still seeing the
+    // human-facing guidance interleaved with their tool's output.
+    for (const path of stepResult.cleaned) {
+      process.stderr.write(`cleaned: ${path}\n`);
+    }
+    for (const hint of stepResult.hints) {
+      process.stderr.write(`hint: ${hint}\n`);
+    }
+
+    // Step 3 — persist suppression if the removal step asked for it.
+    let suppressed = false;
+    if (stepResult.suppress) {
+      addSuppression(provider, sourceId);
+      suppressed = true;
+    }
+
+    // Step 4 — drop the entry from `llm-credentials.json`. This is what makes
+    // the very next `cleo auth list` reflect the change without waiting for
+    // the 60s seed cache to expire.
+    const removed = await removeCredential(
+      entry.provider, // ModelTransport
+      label,
+    );
+
+    const result: AuthRemoveResult = {
+      provider,
+      label,
+      source: sourceId,
+      removed,
+      cleaned: stepResult.cleaned,
+      hints: stepResult.hints,
+      suppressed,
+    };
+
+    cliOutput(result, {
+      command: 'auth-remove',
+      operation: 'auth.remove',
+    });
+  },
+});

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -99,6 +99,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     load: async () => (await import('../commands/audit.js')).auditCommand as CommandDef,
   },
   {
+    exportName: 'authCommand',
+    name: 'auth',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
+  },
+  {
     exportName: 'backfillCommand',
     name: 'backfill',
     description:

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -156,6 +156,15 @@ export default defineConfig({
         '../../packages/core/src/llm/credentials-store.ts',
         import.meta.url,
       ).pathname,
+      // T9416: llm subpath imports used by `cleo auth list` / `cleo auth remove`
+      '@cleocode/core/llm/credential-pool.js': new URL(
+        '../../packages/core/src/llm/credential-pool.ts',
+        import.meta.url,
+      ).pathname,
+      '@cleocode/core/llm/credential-removal.js': new URL(
+        '../../packages/core/src/llm/credential-removal.ts',
+        import.meta.url,
+      ).pathname,
       '@cleocode/core/llm/oauth/device-code.js': new URL(
         '../../packages/core/src/llm/oauth/device-code.ts',
         import.meta.url,


### PR DESCRIPTION
## Summary

E-CONFIG-AUTH-UNIFY E2b §5.2 T-E2-8. Unified credential view across all seeded sources.

## Adds
- `cleo auth list [--provider P] [--json]` — seeds unified pool, lists all entries (provider | label | source | authType | expiry-status | current), filters + JSON envelope
- `cleo auth remove <provider> <label>` — dispatches `REMOVAL_REGISTRY` step, persists suppression, removes from store
- `cleo llm list` maintained separately (LLM-scoped, untouched)
- 6 new unit tests
- Command manifest regenerated

## Test plan
- [x] 6/6 auth-command tests pass
- [x] biome + build clean
- [x] `cleo auth --help` / `cleo auth list --help` render correctly

## Refs
- Spec: §5.2 T-E2-8
- Epic: T9401, Master: T9500