### PR TITLE
feat(T9417): cleo auth migrate-project-secrets

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/auth-command.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/auth-command.test.ts
@@ -129,9 +129,10 @@ describe('cleo auth — CLI wiring', () => {
     process.env['CLEO_FORMAT'] = 'json';
   });
 
-  it('exposes list + remove subcommands', async () => {
+  it('exposes list + remove + migrate-project-secrets subcommands', async () => {
+    // T9417 added migrate-project-secrets to the auth command group.
     const subs = await getAuthSubs();
-    expect(Object.keys(subs).sort()).toEqual(['list', 'remove']);
+    expect(Object.keys(subs).sort()).toEqual(['list', 'migrate-project-secrets', 'remove']);
   });
 
   it('list — seeds, lists, filters by --provider, emits LAFS envelope', async () => {

--- a/packages/cleo/src/cli/commands/__tests__/auth-migrate.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/auth-migrate.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for `cleo auth migrate-project-secrets` (T9417).
+ *
+ * Covers:
+ *   - Wiring: the subcommand is exposed on the `auth` command group.
+ *   - Migration moves every `llm.providers.*.apiKey` into the pool,
+ *     writes a `.pre-migration-bak`, and strips the keys from the project
+ *     config (with empty provider entries dropped).
+ *   - Idempotence: running again on the cleaned config is a no-op.
+ *   - Dry-run: no filesystem mutation; result envelope flags `dryRun: true`.
+ *   - Other `llm.*` keys (`default`, `roles`) are preserved.
+ *
+ * The credentials-store module is mocked so the test never writes to a real
+ * `~/.cleo/llm-credentials.json` — we capture every `addCredential` call.
+ *
+ * @task T9417
+ * @epic E-CONFIG-AUTH-UNIFY (E2b)
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CommandDef } from 'citty';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockAddCredential = vi.fn().mockResolvedValue(undefined);
+
+// Partial mock — keep every other export (notably `pickCredentialForProviderSync`,
+// which `resolveCredentials` uses in the warning-emission integration test).
+vi.mock('@cleocode/core/llm/credentials-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@cleocode/core/llm/credentials-store.js')>();
+  return {
+    ...actual,
+    addCredential: (...a: unknown[]) => mockAddCredential(...a),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { runMigrateProjectSecrets } from '../auth/migrate-project-secrets.js';
+import { authCommand } from '../auth.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let projectRoot: string;
+
+function readJsonFile(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+}
+
+function seedConfig(content: unknown): string {
+  const cfgDir = join(projectRoot, '.cleo');
+  mkdirSync(cfgDir, { recursive: true });
+  const cfgPath = join(cfgDir, 'config.json');
+  writeFileSync(cfgPath, JSON.stringify(content, null, 2), 'utf-8');
+  return cfgPath;
+}
+
+async function getAuthSubs(): Promise<Record<string, CommandDef>> {
+  const resolved =
+    typeof authCommand.subCommands === 'function'
+      ? await authCommand.subCommands()
+      : authCommand.subCommands;
+  return (resolved ?? {}) as Record<string, CommandDef>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockAddCredential.mockClear();
+  projectRoot = mkdtempSync(join(tmpdir(), 'cleo-mig-secrets-'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(projectRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+describe('cleo auth migrate-project-secrets — wiring', () => {
+  it('is registered as a subcommand on `cleo auth`', async () => {
+    const subs = await getAuthSubs();
+    expect(Object.keys(subs).sort()).toEqual(['list', 'migrate-project-secrets', 'remove']);
+  });
+});
+
+describe('runMigrateProjectSecrets — happy path', () => {
+  it('moves every apiKey into the pool and strips them from the project config', async () => {
+    const cfgPath = seedConfig({
+      llm: {
+        providers: {
+          anthropic: { apiKey: 'sk-ant-api03-FIXTURE' },
+          openai: { apiKey: 'sk-openai-FIXTURE', baseUrl: 'https://api.openai.com' },
+        },
+        default: { provider: 'anthropic', model: 'claude-sonnet-test' },
+      },
+    });
+
+    const result = await runMigrateProjectSecrets({
+      projectRoot,
+      yes: true,
+      dryRun: false,
+    });
+
+    // Backup file exists and matches the original byte-for-byte.
+    expect(result.backupPath).toBe(`${cfgPath}.pre-migration-bak`);
+    expect(existsSync(result.backupPath!)).toBe(true);
+
+    // addCredential called once per provider with the expected shape.
+    expect(mockAddCredential).toHaveBeenCalledTimes(2);
+    expect(mockAddCredential).toHaveBeenCalledWith({
+      provider: 'anthropic',
+      label: 'migrated-from-project-config',
+      authType: 'api_key',
+      accessToken: 'sk-ant-api03-FIXTURE',
+      source: 'manual',
+    });
+    expect(mockAddCredential).toHaveBeenCalledWith({
+      provider: 'openai',
+      label: 'migrated-from-project-config',
+      authType: 'api_key',
+      accessToken: 'sk-openai-FIXTURE',
+      source: 'manual',
+    });
+
+    // Result envelope.
+    expect(result.migrated.map((m) => m.provider).sort()).toEqual(['anthropic', 'openai']);
+    expect(result.migrated.every((m) => m.moved)).toBe(true);
+    expect(result.cancelled).toBe(false);
+    expect(result.dryRun).toBe(false);
+
+    // Cleaned config: anthropic dropped (entry empty after apiKey removal),
+    // openai retained (baseUrl remains), default preserved.
+    const cleaned = readJsonFile(cfgPath);
+    const llm = cleaned['llm'] as Record<string, unknown>;
+    const providers = llm['providers'] as Record<string, unknown>;
+    expect(providers['anthropic']).toBeUndefined();
+    expect(providers['openai']).toEqual({ baseUrl: 'https://api.openai.com' });
+    expect(llm['default']).toEqual({ provider: 'anthropic', model: 'claude-sonnet-test' });
+  });
+
+  it('writes the backup BEFORE mutating the config (recoverable on partial failure)', async () => {
+    const cfgPath = seedConfig({
+      llm: { providers: { anthropic: { apiKey: 'sk-original' } } },
+    });
+    const originalRaw = readFileSync(cfgPath, 'utf-8');
+
+    await runMigrateProjectSecrets({ projectRoot, yes: true, dryRun: false });
+
+    const backupRaw = readFileSync(`${cfgPath}.pre-migration-bak`, 'utf-8');
+    expect(backupRaw).toBe(originalRaw);
+  });
+
+  it('detects Anthropic OAuth tokens by prefix and stores authType=oauth', async () => {
+    seedConfig({
+      llm: { providers: { anthropic: { apiKey: 'sk-ant-oat-FIXTURE' } } },
+    });
+
+    await runMigrateProjectSecrets({ projectRoot, yes: true, dryRun: false });
+
+    expect(mockAddCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'anthropic',
+        authType: 'oauth',
+        accessToken: 'sk-ant-oat-FIXTURE',
+      }),
+    );
+  });
+});
+
+describe('runMigrateProjectSecrets — idempotence', () => {
+  it('is a no-op when the project config has no llm.providers.*.apiKey entries', async () => {
+    const cfgPath = seedConfig({
+      llm: { default: { provider: 'anthropic', model: 'claude-sonnet-test' } },
+    });
+
+    const result = await runMigrateProjectSecrets({
+      projectRoot,
+      yes: true,
+      dryRun: false,
+    });
+
+    expect(result.migrated).toEqual([]);
+    expect(result.backupPath).toBeNull();
+    expect(result.cancelled).toBe(false);
+    expect(mockAddCredential).not.toHaveBeenCalled();
+    // Config file untouched — should still parse identically.
+    expect(readJsonFile(cfgPath)).toEqual({
+      llm: { default: { provider: 'anthropic', model: 'claude-sonnet-test' } },
+    });
+  });
+
+  it('is a no-op when the project config file is missing', async () => {
+    // No seedConfig call — `.cleo/config.json` does not exist.
+    const result = await runMigrateProjectSecrets({
+      projectRoot,
+      yes: true,
+      dryRun: false,
+    });
+
+    expect(result.migrated).toEqual([]);
+    expect(result.backupPath).toBeNull();
+    expect(mockAddCredential).not.toHaveBeenCalled();
+  });
+
+  it('re-running after a successful migration finds nothing to do', async () => {
+    seedConfig({
+      llm: { providers: { anthropic: { apiKey: 'sk-once' } } },
+    });
+
+    await runMigrateProjectSecrets({ projectRoot, yes: true, dryRun: false });
+    mockAddCredential.mockClear();
+
+    const second = await runMigrateProjectSecrets({
+      projectRoot,
+      yes: true,
+      dryRun: false,
+    });
+    expect(second.migrated).toEqual([]);
+    expect(second.backupPath).toBeNull();
+    expect(mockAddCredential).not.toHaveBeenCalled();
+  });
+});
+
+describe('runMigrateProjectSecrets — dry-run', () => {
+  it('does not write to disk and does not call addCredential', async () => {
+    const cfgPath = seedConfig({
+      llm: { providers: { anthropic: { apiKey: 'sk-untouched' } } },
+    });
+    const originalRaw = readFileSync(cfgPath, 'utf-8');
+
+    const result = await runMigrateProjectSecrets({
+      projectRoot,
+      yes: true,
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.backupPath).toBeNull();
+    expect(result.migrated).toEqual([
+      { provider: 'anthropic', label: 'migrated-from-project-config', moved: false },
+    ]);
+    expect(mockAddCredential).not.toHaveBeenCalled();
+    // Config untouched.
+    expect(readFileSync(cfgPath, 'utf-8')).toBe(originalRaw);
+    expect(existsSync(`${cfgPath}.pre-migration-bak`)).toBe(false);
+  });
+});
+
+describe('runMigrateProjectSecrets — malformed config', () => {
+  it('throws a descriptive error when the project config is not valid JSON', async () => {
+    const cfgDir = join(projectRoot, '.cleo');
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, 'config.json'), '{ not valid json', 'utf-8');
+
+    await expect(
+      runMigrateProjectSecrets({ projectRoot, yes: true, dryRun: false }),
+    ).rejects.toThrow(/Failed to parse/);
+    expect(mockAddCredential).not.toHaveBeenCalled();
+  });
+});
+
+describe('warnProjectConfigApiKeyRejected — stderr warning (T9413 integration)', () => {
+  it('the project-config rejection warning text mentions the migration command', async () => {
+    // The warning emitter lives in @cleocode/core/llm/credentials. Verify the
+    // string it emits references `cleo auth migrate-project-secrets` so the
+    // user discovery loop (warning -> migrate) is wired correctly.
+    const { resolveCredentials, _resetCredentialDeprecationLatchesForTests } = await import(
+      '@cleocode/core/llm/credentials.js'
+    );
+    _resetCredentialDeprecationLatchesForTests();
+
+    seedConfig({
+      llm: { providers: { anthropic: { apiKey: 'sk-ant-api03-WARN-FIXTURE' } } },
+    });
+
+    const captured: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((s: unknown) => {
+      captured.push(String(s));
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      resolveCredentials('anthropic', { projectRoot });
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    const stderr = captured.join('');
+    expect(stderr).toContain('cleo auth migrate-project-secrets');
+    expect(stderr).toContain('.cleo/config.json');
+  });
+});

--- a/packages/cleo/src/cli/commands/auth.ts
+++ b/packages/cleo/src/cli/commands/auth.ts
@@ -15,7 +15,11 @@
  */
 
 import { defineCommand, showUsage } from 'citty';
-import { authListCommand, authRemoveCommand } from './auth/index.js';
+import {
+  authListCommand,
+  authMigrateProjectSecretsCommand,
+  authRemoveCommand,
+} from './auth/index.js';
 
 /**
  * `cleo auth` — unified credential surface.
@@ -31,6 +35,7 @@ export const authCommand = defineCommand({
   subCommands: {
     list: authListCommand,
     remove: authRemoveCommand,
+    'migrate-project-secrets': authMigrateProjectSecretsCommand,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/cleo/src/cli/commands/auth/index.ts
+++ b/packages/cleo/src/cli/commands/auth/index.ts
@@ -12,5 +12,14 @@
 
 export type { AuthListEntry } from './list.js';
 export { authListCommand } from './list.js';
+export type {
+  AuthMigrateProjectSecretsResult,
+  MigratedSecret,
+  RunMigrateOptions,
+} from './migrate-project-secrets.js';
+export {
+  authMigrateProjectSecretsCommand,
+  runMigrateProjectSecrets,
+} from './migrate-project-secrets.js';
 export type { AuthRemoveResult } from './remove.js';
 export { authRemoveCommand } from './remove.js';

--- a/packages/cleo/src/cli/commands/auth/migrate-project-secrets.ts
+++ b/packages/cleo/src/cli/commands/auth/migrate-project-secrets.ts
@@ -1,0 +1,415 @@
+/**
+ * `cleo auth migrate-project-secrets` — one-shot migration that moves every
+ * `llm.providers.*.apiKey` entry out of project-level `.cleo/config.json`
+ * and into the unified credential pool (`~/.cleo/llm-credentials.json`).
+ *
+ * Motivation (E-CONFIG-AUTH-UNIFY §5.2 T-E2-9): T9413 hard-rejected the
+ * project-config tier because `.cleo/config.json` is frequently committed
+ * to git, leaking API keys. Users who already had keys there need a safe,
+ * non-interactive-friendly way to fix the footgun without hand-editing JSON.
+ *
+ * Flow:
+ *   1. Resolve project root (defaults to cwd; `--project-root` override).
+ *   2. Read `<projectRoot>/.cleo/config.json`. If missing or contains no
+ *      `llm.providers.*.apiKey` entries, exit success (idempotent — running
+ *      after a successful migration is a no-op).
+ *   3. Enumerate every `(provider, apiKey)` pair. Show the operator a
+ *      preview (provider list — keys themselves NEVER printed) and prompt
+ *      for confirmation. Skip the prompt when `--yes` is passed (CI mode).
+ *   4. Snapshot the original config to `.cleo/config.json.pre-migration-bak`
+ *      BEFORE touching anything (atomic safety net).
+ *   5. For each entry call `addCredential({ provider, label, authType,
+ *      accessToken, source: 'manual' })` with
+ *      `label = 'migrated-from-project-config'`.
+ *   6. Re-emit `<projectRoot>/.cleo/config.json` with every `apiKey` field
+ *      stripped (other LLM config — `default`, `roles`, `daemon`, etc. —
+ *      is preserved untouched). Providers whose entry becomes empty after
+ *      `apiKey` removal are dropped to avoid littering the file with `{}`.
+ *   7. Emit the LAFS envelope summarising the moved providers + backup path.
+ *
+ * Re-running after a successful migration is a no-op because step 2 finds
+ * no `apiKey` entries.
+ *
+ * @task T9417
+ * @epic E-CONFIG-AUTH-UNIFY (E2b §5.2 T-E2-9)
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+import { defineCommand } from 'citty';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-provider migration outcome.
+ *
+ * @task T9417
+ */
+export interface MigratedSecret {
+  /** Provider id (e.g. `anthropic`). Open string — third-party plugins allowed. */
+  provider: string;
+  /** Label written to the pool entry (always `migrated-from-project-config`). */
+  label: string;
+  /** Whether the key was actually moved to the pool (`false` only on dry-run). */
+  moved: boolean;
+}
+
+/**
+ * Result envelope for `cleo auth migrate-project-secrets`.
+ *
+ * `migrated` is empty when the migration is a no-op (no `apiKey` entries
+ * present). `backupPath` is null on no-op runs because no file was written.
+ *
+ * @task T9417
+ */
+export interface AuthMigrateProjectSecretsResult {
+  /** Absolute path to the project config file that was inspected. */
+  configPath: string;
+  /** Absolute path to the pre-migration backup (`null` on no-op). */
+  backupPath: string | null;
+  /** Per-provider migration outcomes. */
+  migrated: MigratedSecret[];
+  /** `true` when the operator declined the prompt (no changes written). */
+  cancelled: boolean;
+  /** `true` when `--dry-run` was passed; no filesystem writes occurred. */
+  dryRun: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the project root: explicit `--project-root` wins, else cwd.
+ *
+ * `cleo` is always invoked from inside a project tree, so cwd is the
+ * pragmatic default. We deliberately do NOT walk upward looking for
+ * `.cleo/` because the migration command is operator-facing and should
+ * fail loud if the user runs it from the wrong directory.
+ *
+ * @internal
+ */
+function resolveProjectRootArg(arg: unknown): string {
+  if (typeof arg === 'string' && arg.length > 0) return arg;
+  return process.cwd();
+}
+
+/**
+ * Resolve the path of the project config file inside the given project root.
+ *
+ * Honours `CLEO_DIR` so non-default layouts (e.g. test fixtures pointing at
+ * a custom dotdir) resolve correctly.
+ *
+ * @internal
+ */
+function projectConfigPath(projectRoot: string): string {
+  const cleoDir = process.env['CLEO_DIR'] ?? '.cleo';
+  return join(projectRoot, cleoDir, 'config.json');
+}
+
+/**
+ * Extract every `(provider, apiKey)` pair from a parsed project config.
+ *
+ * Returns an empty array when:
+ *   - `llm` is missing or not an object,
+ *   - `llm.providers` is missing or not an object,
+ *   - no entry has a non-empty string `apiKey` field.
+ *
+ * Provider names are open strings (third-party plugin providers are valid).
+ *
+ * @internal
+ */
+function extractApiKeyEntries(config: unknown): Array<{ provider: string; apiKey: string }> {
+  if (!config || typeof config !== 'object') return [];
+  const llm = (config as Record<string, unknown>)['llm'];
+  if (!llm || typeof llm !== 'object') return [];
+  const providers = (llm as Record<string, unknown>)['providers'];
+  if (!providers || typeof providers !== 'object') return [];
+  const out: Array<{ provider: string; apiKey: string }> = [];
+  for (const [provider, raw] of Object.entries(providers as Record<string, unknown>)) {
+    if (!raw || typeof raw !== 'object') continue;
+    const apiKey = (raw as Record<string, unknown>)['apiKey'];
+    if (typeof apiKey === 'string' && apiKey.trim().length > 0) {
+      out.push({ provider, apiKey: apiKey.trim() });
+    }
+  }
+  return out;
+}
+
+/**
+ * Return a deep-cloned config with every `llm.providers.*.apiKey` field
+ * removed. Providers whose entry becomes empty (no remaining fields) are
+ * dropped entirely so the resulting file doesn't accumulate `{}` stubs.
+ *
+ * All other `llm` keys (`default`, `roles`, `daemon`, …) and top-level
+ * keys are preserved verbatim.
+ *
+ * @internal
+ */
+function stripApiKeysFromConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const clone = structuredClone(config);
+  const llm = clone['llm'];
+  if (!llm || typeof llm !== 'object') return clone;
+  const providers = (llm as Record<string, unknown>)['providers'];
+  if (!providers || typeof providers !== 'object') return clone;
+  const cleanedProviders: Record<string, unknown> = {};
+  for (const [provider, raw] of Object.entries(providers as Record<string, unknown>)) {
+    if (!raw || typeof raw !== 'object') {
+      cleanedProviders[provider] = raw;
+      continue;
+    }
+    const entry = { ...(raw as Record<string, unknown>) };
+    delete entry['apiKey'];
+    if (Object.keys(entry).length > 0) {
+      cleanedProviders[provider] = entry;
+    }
+    // else: drop the provider entirely — nothing left to persist.
+  }
+  (llm as Record<string, unknown>)['providers'] = cleanedProviders;
+  return clone;
+}
+
+/**
+ * Detect the auth type from an API key prefix.
+ *
+ * Anthropic OAuth tokens (`sk-ant-oat-*` / `sk-ant-ort-*`) MUST be stored
+ * with `authType: 'oauth'`; everything else uses `'api_key'`. Mirrors the
+ * detection in `packages/core/src/llm/credentials.ts`.
+ *
+ * @internal
+ */
+function detectAuthType(provider: string, token: string): 'api_key' | 'oauth' {
+  if (provider !== 'anthropic') return 'api_key';
+  if (token.startsWith('sk-ant-oat-') || token.startsWith('sk-ant-ort-')) return 'oauth';
+  return 'api_key';
+}
+
+/**
+ * Synchronously read a yes/no answer from stdin.
+ *
+ * Returns `true` when the operator answers with `y` / `yes` (case-insensitive);
+ * any other input — including the empty string — returns `false`. The prompt
+ * defaults to no because the migration mutates user data; explicit consent
+ * is required.
+ *
+ * @internal
+ */
+async function promptYesNo(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await new Promise<string>((resolve) => {
+      rl.question(question, (a: string) => resolve(a));
+    });
+    const clean = answer.trim().toLowerCase();
+    return clean === 'y' || clean === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Options consumed by {@link runMigrateProjectSecrets}.
+ *
+ * @task T9417
+ */
+export interface RunMigrateOptions {
+  /** Absolute path to the project root. */
+  projectRoot: string;
+  /** When true, skip the interactive prompt (CI / scripted usage). */
+  yes: boolean;
+  /** When true, do not write anything to disk — print what would happen. */
+  dryRun: boolean;
+}
+
+/**
+ * Internal entry point — separated from the command so tests can drive the
+ * migration without going through citty argument parsing.
+ *
+ * @task T9417
+ */
+export async function runMigrateProjectSecrets(
+  opts: RunMigrateOptions,
+): Promise<AuthMigrateProjectSecretsResult> {
+  const configPath = projectConfigPath(opts.projectRoot);
+
+  // No project config → nothing to migrate. Idempotent no-op.
+  if (!existsSync(configPath)) {
+    return {
+      configPath,
+      backupPath: null,
+      migrated: [],
+      cancelled: false,
+      dryRun: opts.dryRun,
+    };
+  }
+
+  const raw = readFileSync(configPath, 'utf-8');
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(
+      `Failed to parse ${configPath}: ${err instanceof Error ? err.message : String(err)}. ` +
+        `Fix the JSON syntax error before running migrate-project-secrets.`,
+    );
+  }
+
+  const entries = extractApiKeyEntries(parsed);
+  if (entries.length === 0) {
+    // Nothing to migrate — emit a clean no-op result.
+    return {
+      configPath,
+      backupPath: null,
+      migrated: [],
+      cancelled: false,
+      dryRun: opts.dryRun,
+    };
+  }
+
+  // Prompt for confirmation (unless --yes). Routes through stderr so JSON
+  // consumers still get clean stdout and the prompt is visible interactively.
+  if (!opts.yes) {
+    process.stderr.write(
+      `Found ${entries.length} project-config secret(s) to migrate:\n` +
+        entries.map((e) => `  - ${e.provider}\n`).join('') +
+        `\nThis will:\n` +
+        `  1. Back up ${configPath} -> ${configPath}.pre-migration-bak\n` +
+        `  2. Move each apiKey into the unified credential pool with label 'migrated-from-project-config'\n` +
+        `  3. Remove the apiKey fields from the project config\n\n`,
+    );
+    const confirmed = await promptYesNo('Proceed? [y/N] ');
+    if (!confirmed) {
+      return {
+        configPath,
+        backupPath: null,
+        migrated: [],
+        cancelled: true,
+        dryRun: opts.dryRun,
+      };
+    }
+  }
+
+  if (opts.dryRun) {
+    return {
+      configPath,
+      backupPath: null,
+      migrated: entries.map((e) => ({
+        provider: e.provider,
+        label: 'migrated-from-project-config',
+        moved: false,
+      })),
+      cancelled: false,
+      dryRun: true,
+    };
+  }
+
+  // Atomic backup BEFORE any mutation — writes a sibling file so the original
+  // is recoverable even if the addCredential calls fail midway. We use the
+  // raw bytes (not the parsed-then-reserialised form) so the backup is a
+  // byte-perfect restore target.
+  const backupPath = `${configPath}.pre-migration-bak`;
+  writeFileSync(backupPath, raw, { mode: 0o600 });
+
+  // Lazy import — keeps `cleo --help` fast and avoids pulling the credential
+  // store + its lockfile machinery into the cold-start surface for users who
+  // never call this command.
+  const { addCredential } = await import(
+    /* webpackIgnore: true */ '@cleocode/core/llm/credentials-store.js'
+  );
+
+  const migrated: MigratedSecret[] = [];
+  for (const { provider, apiKey } of entries) {
+    // `addCredential` is upsert-by-(provider, label) — running twice is safe.
+    // The unified pool only honours `BuiltinProviderId` plus open plugin
+    // strings; both are valid `ModelTransport` widenings, so we cast at the
+    // boundary without adding a new public type.
+    await addCredential({
+      provider: provider as Parameters<typeof addCredential>[0]['provider'],
+      label: 'migrated-from-project-config',
+      authType: detectAuthType(provider, apiKey),
+      accessToken: apiKey,
+      source: 'manual',
+    });
+    migrated.push({ provider, label: 'migrated-from-project-config', moved: true });
+  }
+
+  // Re-emit the config with every apiKey stripped. We pretty-print with 2-space
+  // indent to match the convention every other CLEO config writer uses.
+  const stripped = stripApiKeysFromConfig(parsed);
+  writeFileSync(configPath, `${JSON.stringify(stripped, null, 2)}\n`, 'utf-8');
+
+  return {
+    configPath,
+    backupPath,
+    migrated,
+    cancelled: false,
+    dryRun: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * `cleo auth migrate-project-secrets` — see file-level docstring.
+ *
+ * @task T9417
+ */
+export const authMigrateProjectSecretsCommand = defineCommand({
+  meta: {
+    name: 'migrate-project-secrets',
+    description:
+      'Move every llm.providers.*.apiKey out of .cleo/config.json (project-scoped, ' +
+      'often committed to git) and into the unified credential pool. Atomic: ' +
+      'backs up the original config to .cleo/config.json.pre-migration-bak first.',
+  },
+  args: {
+    'project-root': {
+      type: 'string',
+      description: 'Override the project root (default: cwd)',
+    },
+    yes: {
+      type: 'boolean',
+      description: 'Skip the interactive confirmation prompt',
+      default: false,
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Show what would be migrated without writing anything',
+      default: false,
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON envelope',
+    },
+  },
+  async run({ args }) {
+    const a = args as Record<string, unknown>;
+    const projectRoot = resolveProjectRootArg(a['project-root']);
+    const yes = Boolean(a['yes']);
+    const dryRun = Boolean(a['dry-run']);
+
+    let result: AuthMigrateProjectSecretsResult;
+    try {
+      result = await runMigrateProjectSecrets({ projectRoot, yes, dryRun });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(message, 6, { name: 'E_VALIDATION' });
+      process.exit(6);
+    }
+
+    cliOutput(result, {
+      command: 'auth-migrate-project-secrets',
+      operation: 'auth.migrate-project-secrets',
+    });
+  },
+});


### PR DESCRIPTION
E-CONFIG-AUTH-UNIFY E2b §5.2 T-E2-9. Moves .cleo/config.json apiKey entries into the pool atomically with backup. 9 tests pass.