### PR TITLE
feat(T9424): cleo status CLI over getCleoStatus()

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -52,6 +52,7 @@ const SUBPATH_DIRS = [
   'memory',
   'tasks',
   'sessions',
+  'status',
   'nexus',
   'lifecycle',
   'conduit',

--- a/packages/cleo/src/cli/commands/__tests__/status-command.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/status-command.test.ts
@@ -1,0 +1,302 @@
+/**
+ * CLI wiring tests for `cleo status` (T9424).
+ *
+ * Verifies the thin CLI wrapper over `getCleoStatus()`:
+ *
+ *   - JSON mode emits the full {@link CleoStatus} envelope via the LAFS
+ *     `cliOutput` path with `meta.operation === 'status.show'`.
+ *   - Human mode emits all six sections (Identity, Credentials, Config,
+ *     Session, Harness, Daemon) on stdout.
+ *   - `[INVALID]` and `[EXPIRED]` badges appear when credentials report
+ *     `lastStatus === 'invalid'` or `isExpired === true`.
+ *   - `hasSecretsInProjectConfig: true` raises a `WARNING:` banner at the
+ *     top of human output.
+ *   - Exit code is non-zero when any credential is `lastStatus === 'invalid'`
+ *     and zero otherwise.
+ *
+ * `@cleocode/core/status/index.js` is mocked so the test runs without
+ * touching the real credential pool, session store, or daemon-status API.
+ *
+ * @task T9424
+ * @epic E-CONFIG-AUTH-UNIFY (E3 §5.3 T-E3-5)
+ */
+
+import type { CommandDef } from 'citty';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared BEFORE importing the command module.
+// ---------------------------------------------------------------------------
+
+const mockGetCleoStatus = vi.fn();
+
+vi.mock('@cleocode/core/status', () => ({
+  getCleoStatus: () => mockGetCleoStatus(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { setFormatContext } from '../../format-context.js';
+import { statusCommand } from '../status.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function runStatus(args: Record<string, unknown>): Promise<void> {
+  const resolved = (
+    typeof statusCommand === 'function'
+      ? await (statusCommand as () => Promise<CommandDef>)()
+      : statusCommand
+  ) as CommandDef;
+  const runFn = (resolved as { run?: (ctx: unknown) => Promise<void> }).run;
+  if (!runFn) throw new Error('status command has no run function');
+  await runFn({ args, rawArgs: [], cmd: resolved });
+}
+
+function captureStdout(): { restore: () => void; lines: string[] } {
+  const orig = process.stdout.write.bind(process.stdout);
+  const lines: string[] = [];
+  process.stdout.write = ((s: unknown) => {
+    lines.push(String(s));
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    lines,
+    restore: () => {
+      process.stdout.write = orig;
+    },
+  };
+}
+
+/**
+ * Build a default healthy snapshot. Tests override individual fields by
+ * spreading on top of this object.
+ */
+function healthyStatus(): Record<string, unknown> {
+  return {
+    identity: {
+      agentId: 'agt-test-001',
+      loggedIn: true,
+      identityFile: '/tmp/.cleo/identity.json',
+    },
+    credentials: [
+      {
+        provider: 'anthropic',
+        source: 'claude-code',
+        hasCredential: true,
+        authType: 'oauth',
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        isExpired: false,
+        lastStatus: 'ok',
+        label: 'claude-code-import',
+      },
+    ],
+    config: {
+      globalConfigPath: '/home/test/.cleo/config.json',
+      projectConfigPath: '/tmp/project/.cleo/config.json',
+      activeConfigPath: '/tmp/project/.cleo/config.json',
+      hasSecretsInProjectConfig: false,
+      secretsWarnings: [],
+    },
+    session: {
+      active: true,
+      sessionId: 'sess-001',
+      focusedTask: 'T9424',
+    },
+    harness: {
+      active: 'claude-code',
+      healthy: true,
+      issues: [],
+    },
+    daemon: {
+      running: true,
+      pid: 12345,
+      lastTickAt: Date.now() - 5000,
+      killSwitchActive: false,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('cleo status — CLI wiring (T9424)', () => {
+  beforeEach(() => {
+    mockGetCleoStatus.mockReset();
+    process.env['NO_COLOR'] = '1';
+    // Reset the format singleton to the documented default (json/agent-first)
+    // so individual tests can opt into human mode via setFormatContext below.
+    setFormatContext({ format: 'json', source: 'default', quiet: false });
+  });
+
+  it('--json mode emits the CleoStatus envelope with meta.operation=status.show', async () => {
+    mockGetCleoStatus.mockResolvedValue(healthyStatus());
+    setFormatContext({ format: 'json', source: 'default', quiet: false });
+
+    const stdout = captureStdout();
+    try {
+      await runStatus({ json: true });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(mockGetCleoStatus).toHaveBeenCalledTimes(1);
+    const env = JSON.parse(stdout.lines[stdout.lines.length - 1]!);
+    expect(env.success).toBe(true);
+    expect(env.meta.operation).toBe('status.show');
+    expect(env.data).toMatchObject({
+      identity: { agentId: 'agt-test-001', loggedIn: true },
+      credentials: [{ provider: 'anthropic', lastStatus: 'ok' }],
+      harness: { active: 'claude-code' },
+      daemon: { running: true, pid: 12345 },
+    });
+  });
+
+  it('human mode renders all six sections', async () => {
+    mockGetCleoStatus.mockResolvedValue(healthyStatus());
+    setFormatContext({ format: 'human', source: 'default', quiet: false });
+
+    const stdout = captureStdout();
+    try {
+      await runStatus({});
+    } finally {
+      stdout.restore();
+    }
+
+    const text = stdout.lines.join('');
+    expect(text).toContain('Identity');
+    expect(text).toContain('Credentials');
+    expect(text).toContain('Config');
+    expect(text).toContain('Session');
+    expect(text).toContain('Harness');
+    expect(text).toContain('Daemon');
+    // Identity fields surfaced.
+    expect(text).toContain('agt-test-001');
+    expect(text).toContain('/tmp/.cleo/identity.json');
+    // No invalid badge on healthy credentials.
+    expect(text).not.toContain('[INVALID]');
+    expect(text).not.toContain('[EXPIRED]');
+    // No WARNING banner when project config is clean.
+    expect(text).not.toContain('WARNING:');
+  });
+
+  it('human mode shows [EXPIRED] for credentials with isExpired:true', async () => {
+    const snapshot = healthyStatus();
+    (snapshot['credentials'] as Array<Record<string, unknown>>)[0]!['isExpired'] = true;
+    mockGetCleoStatus.mockResolvedValue(snapshot);
+    setFormatContext({ format: 'human', source: 'default', quiet: false });
+
+    const stdout = captureStdout();
+    try {
+      await runStatus({});
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.lines.join('')).toContain('[EXPIRED]');
+  });
+
+  it('human mode shows [INVALID] when lastStatus=invalid and exits 1', async () => {
+    const snapshot = healthyStatus();
+    (snapshot['credentials'] as Array<Record<string, unknown>>)[0]!['lastStatus'] = 'invalid';
+    mockGetCleoStatus.mockResolvedValue(snapshot);
+    setFormatContext({ format: 'human', source: 'default', quiet: false });
+
+    const stdout = captureStdout();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__EXIT_${code}__`);
+    }) as never);
+    try {
+      await expect(runStatus({})).rejects.toThrow('__EXIT_1__');
+    } finally {
+      stdout.restore();
+      exitSpy.mockRestore();
+    }
+
+    expect(stdout.lines.join('')).toContain('[INVALID]');
+  });
+
+  it('JSON mode also exits 1 when a credential is invalid', async () => {
+    const snapshot = healthyStatus();
+    (snapshot['credentials'] as Array<Record<string, unknown>>)[0]!['lastStatus'] = 'invalid';
+    mockGetCleoStatus.mockResolvedValue(snapshot);
+    setFormatContext({ format: 'json', source: 'default', quiet: false });
+
+    const stdout = captureStdout();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__EXIT_${code}__`);
+    }) as never);
+    try {
+      await expect(runStatus({ json: true })).rejects.toThrow('__EXIT_1__');
+    } finally {
+      stdout.restore();
+      exitSpy.mockRestore();
+    }
+
+    const env = JSON.parse(stdout.lines[stdout.lines.length - 1]!);
+    expect(env.success).toBe(true);
+    expect(env.data.credentials[0].lastStatus).toBe('invalid');
+  });
+
+  it('human mode surfaces hasSecretsInProjectConfig warning prominently', async () => {
+    const snapshot = healthyStatus();
+    (snapshot['config'] as Record<string, unknown>)['hasSecretsInProjectConfig'] = true;
+    (snapshot['config'] as Record<string, unknown>)['secretsWarnings'] = [
+      'llm.providers.anthropic.apiKey is set in project config',
+    ];
+    mockGetCleoStatus.mockResolvedValue(snapshot);
+    setFormatContext({ format: 'human', source: 'default', quiet: false });
+
+    const stdout = captureStdout();
+    try {
+      await runStatus({});
+    } finally {
+      stdout.restore();
+    }
+
+    const text = stdout.lines.join('');
+    // Banner is at the very top — verify it appears before the Identity section.
+    expect(text.indexOf('WARNING:')).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf('WARNING:')).toBeLessThan(text.indexOf('Identity'));
+    expect(text).toContain('llm.providers.anthropic.apiKey');
+  });
+
+  it('exit 0 by default when all credentials are healthy', async () => {
+    mockGetCleoStatus.mockResolvedValue(healthyStatus());
+    setFormatContext({ format: 'json', source: 'default', quiet: false });
+
+    const stdout = captureStdout();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__EXIT_${code}__`);
+    }) as never);
+    try {
+      // Should NOT throw — exit 0 path does not call process.exit.
+      await runStatus({ json: true });
+    } finally {
+      stdout.restore();
+      exitSpy.mockRestore();
+    }
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('human mode shows "(no credentials)" placeholder when pool is empty', async () => {
+    const snapshot = healthyStatus();
+    snapshot['credentials'] = [];
+    mockGetCleoStatus.mockResolvedValue(snapshot);
+    setFormatContext({ format: 'human', source: 'default', quiet: false });
+
+    const stdout = captureStdout();
+    try {
+      await runStatus({});
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.lines.join('')).toContain('(no credentials');
+  });
+});

--- a/packages/cleo/src/cli/commands/status.ts
+++ b/packages/cleo/src/cli/commands/status.ts
@@ -1,0 +1,295 @@
+/**
+ * `cleo status` — thin CLI wrapper over {@link getCleoStatus} (T9423).
+ *
+ * The CLI surface for the unified `CleoStatus` snapshot. Today CLEO has
+ * `cleo dash` (tasks-only) and `cleo llm whoami` (LLM roles). Neither
+ * answers "what is my full config state?" — that gap is what this command
+ * fills. Output covers six sections:
+ *
+ *   Identity     — `agentId`, `identityFile`, `loggedIn`
+ *   Credentials  — every entry from the unified credential pool
+ *   Config       — global + project config paths, secrets-in-project warning
+ *   Session      — active session id + focused task
+ *   Harness      — detected harness + health
+ *   Daemon       — sentient daemon pid + last tick + kill-switch
+ *
+ * Modes:
+ *   `cleo status`         — human-readable, section-by-section formatted output
+ *   `cleo status --json`  — full `CleoStatus` JSON via the standard LAFS envelope
+ *
+ * Exit codes:
+ *   0  — all credentials healthy
+ *   1  — at least one credential has `lastStatus === 'invalid'`
+ *
+ * Highlights in human mode:
+ *   - `hasSecretsInProjectConfig: true` → bold red warning banner at the top.
+ *   - Credentials with `lastStatus === 'invalid'` → red `[INVALID]`.
+ *   - Credentials with `isExpired: true` → yellow `[EXPIRED]`.
+ *
+ * @task T9424
+ * @epic E-CONFIG-AUTH-UNIFY (E3 §5.3 T-E3-5)
+ */
+
+import { getCleoStatus } from '@cleocode/core/status';
+import { defineCommand } from 'citty';
+import { isJsonFormat } from '../format-context.js';
+import { BOLD, CYAN, DIM, GREEN, NC, RED, YELLOW } from '../renderers/colors.js';
+import { cliOutput } from '../renderers/index.js';
+
+// ---------------------------------------------------------------------------
+// Human renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Local minimal shape of the {@link CleoStatus} envelope. Mirrors the public
+ * interface in `@cleocode/core/status` but kept inline as `Record`-style
+ * indexing here so the human renderer doesn't pull the full type graph into
+ * the CLI cold-start path.
+ *
+ * @internal
+ */
+interface StatusShape {
+  identity: {
+    agentId: string | null;
+    loggedIn: boolean;
+    identityFile: string | null;
+  };
+  credentials: Array<{
+    provider: string;
+    source: string;
+    hasCredential: boolean;
+    authType?: string;
+    expiresAt?: number | null;
+    isExpired?: boolean;
+    lastStatus?: 'ok' | 'exhausted' | 'invalid';
+    label?: string;
+  }>;
+  config: {
+    globalConfigPath: string;
+    projectConfigPath: string | null;
+    activeConfigPath: string;
+    hasSecretsInProjectConfig: boolean;
+    secretsWarnings: string[];
+  };
+  session: {
+    active: boolean;
+    sessionId: string | null;
+    focusedTask: string | null;
+  };
+  harness: {
+    active: 'pi' | 'claude-code' | 'unknown';
+    healthy: boolean;
+    issues: string[];
+  };
+  daemon: {
+    running: boolean;
+    pid: number | null;
+    lastTickAt: number | null;
+    killSwitchActive: boolean;
+  };
+}
+
+/**
+ * Format an epoch-ms timestamp as a short ISO date (UTC). Empty string when
+ * the input is `null`/`undefined`. Used by both the credentials and daemon
+ * blocks so expiry and last-tick render consistently.
+ *
+ * @internal
+ */
+function formatEpoch(epoch: number | null | undefined): string {
+  if (epoch == null) return '';
+  const d = new Date(epoch);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toISOString().replace('T', ' ').slice(0, 19) + 'Z';
+}
+
+/**
+ * Build a one-line credential summary. Highlights:
+ *
+ *   `[INVALID]` → red, when `lastStatus === 'invalid'`.
+ *   `[EXPIRED]` → yellow, when `isExpired === true`.
+ *
+ * Both badges may appear together for a credential that is both expired AND
+ * has been observed as invalid in a later request.
+ *
+ * @internal
+ */
+function renderCredentialLine(c: StatusShape['credentials'][number]): string {
+  const badges: string[] = [];
+  if (c.lastStatus === 'invalid') badges.push(`${RED}${BOLD}[INVALID]${NC}`);
+  if (c.isExpired === true) badges.push(`${YELLOW}${BOLD}[EXPIRED]${NC}`);
+  const label = c.label ?? '(no label)';
+  const head = `${BOLD}${c.provider}${NC} ${DIM}${label}${NC}`;
+  const meta: string[] = [];
+  meta.push(`source=${c.source}`);
+  if (c.authType !== undefined) meta.push(`authType=${c.authType}`);
+  if (c.lastStatus !== undefined) meta.push(`lastStatus=${c.lastStatus}`);
+  if (c.expiresAt != null) meta.push(`expiresAt=${formatEpoch(c.expiresAt)}`);
+  const metaLine = `${DIM}${meta.join(' · ')}${NC}`;
+  const badgeStr = badges.length > 0 ? ` ${badges.join(' ')}` : '';
+  return `    ${head}${badgeStr}\n      ${metaLine}`;
+}
+
+/**
+ * Render the full {@link CleoStatus} envelope as a human-readable summary.
+ *
+ * Output is rendered as six labeled sections (Identity, Credentials, Config,
+ * Session, Harness, Daemon). When `hasSecretsInProjectConfig` is `true`, a
+ * bold red banner is emitted at the very top so the operator sees the
+ * footgun even if their terminal scrolls the rest off-screen.
+ *
+ * @internal
+ */
+function renderStatusHuman(status: StatusShape): string {
+  const lines: string[] = [];
+
+  // Prominent secrets-in-project-config warning at the very top.
+  if (status.config.hasSecretsInProjectConfig) {
+    lines.push(`${RED}${BOLD}WARNING: Secrets detected in project config${NC}`);
+    for (const w of status.config.secretsWarnings) {
+      lines.push(`  ${RED}${w}${NC}`);
+    }
+    lines.push('');
+  }
+
+  // Identity
+  lines.push(`${BOLD}Identity${NC}`);
+  lines.push(`  ${DIM}agentId:${NC}      ${status.identity.agentId ?? '(none)'}`);
+  lines.push(`  ${DIM}identityFile:${NC} ${status.identity.identityFile ?? '(none)'}`);
+  const loggedInBadge = status.identity.loggedIn
+    ? `${GREEN}yes${NC}`
+    : `${YELLOW}no — run \`cleo setup\`${NC}`;
+  lines.push(`  ${DIM}loggedIn:${NC}     ${loggedInBadge}`);
+  lines.push('');
+
+  // Credentials
+  lines.push(`${BOLD}Credentials${NC} ${DIM}(${status.credentials.length} entries)${NC}`);
+  if (status.credentials.length === 0) {
+    lines.push(`  ${DIM}(no credentials — run \`cleo auth list\` after \`cleo setup\`)${NC}`);
+  } else {
+    for (const c of status.credentials) {
+      lines.push(renderCredentialLine(c));
+    }
+  }
+  lines.push('');
+
+  // Config
+  lines.push(`${BOLD}Config${NC}`);
+  lines.push(`  ${DIM}globalConfigPath:${NC}  ${status.config.globalConfigPath}`);
+  lines.push(`  ${DIM}projectConfigPath:${NC} ${status.config.projectConfigPath ?? '(none)'}`);
+  lines.push(`  ${DIM}activeConfigPath:${NC}  ${status.config.activeConfigPath}`);
+  lines.push('');
+
+  // Session
+  lines.push(`${BOLD}Session${NC}`);
+  const sessionState = status.session.active ? `${GREEN}active${NC}` : `${DIM}inactive${NC}`;
+  lines.push(`  ${DIM}state:${NC}       ${sessionState}`);
+  lines.push(`  ${DIM}sessionId:${NC}   ${status.session.sessionId ?? '(none)'}`);
+  lines.push(`  ${DIM}focusedTask:${NC} ${status.session.focusedTask ?? '(none)'}`);
+  lines.push('');
+
+  // Harness
+  lines.push(`${BOLD}Harness${NC}`);
+  lines.push(`  ${DIM}active:${NC}  ${CYAN}${status.harness.active}${NC}`);
+  lines.push(
+    `  ${DIM}healthy:${NC} ${status.harness.healthy ? `${GREEN}yes${NC}` : `${RED}no${NC}`}`,
+  );
+  if (status.harness.issues.length > 0) {
+    for (const issue of status.harness.issues) {
+      lines.push(`    ${YELLOW}- ${issue}${NC}`);
+    }
+  }
+  lines.push('');
+
+  // Daemon
+  lines.push(`${BOLD}Daemon${NC}`);
+  const daemonState = status.daemon.running ? `${GREEN}running${NC}` : `${DIM}stopped${NC}`;
+  lines.push(`  ${DIM}state:${NC}            ${daemonState}`);
+  lines.push(`  ${DIM}pid:${NC}              ${status.daemon.pid ?? '(none)'}`);
+  lines.push(
+    `  ${DIM}lastTickAt:${NC}       ${
+      status.daemon.lastTickAt != null ? formatEpoch(status.daemon.lastTickAt) : '(never)'
+    }`,
+  );
+  const killSwitchBadge = status.daemon.killSwitchActive
+    ? `${RED}${BOLD}ACTIVE${NC}`
+    : `${DIM}inactive${NC}`;
+  lines.push(`  ${DIM}killSwitchActive:${NC} ${killSwitchBadge}`);
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Exit-code policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the exit code from a status snapshot.
+ *
+ * Returns 1 when any credential's `lastStatus === 'invalid'` so CI/scripts
+ * can pick up auth-state regressions without parsing JSON. Expiry alone is
+ * NOT a hard failure (refresh may still succeed) — only confirmed invalid
+ * state escalates to exit 1.
+ *
+ * @internal
+ */
+function computeExitCode(status: StatusShape): number {
+  const hasInvalid = status.credentials.some((c) => c.lastStatus === 'invalid');
+  return hasInvalid ? 1 : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * `cleo status` — print the unified config snapshot.
+ *
+ * Imports `@cleocode/core/status` statically. The status surface is the
+ * one command users explicitly type to inspect their config — there is no
+ * cold-start saving to be had from lazy-loading the snapshot aggregator
+ * when running it. Static import keeps vitest workspace-alias resolution
+ * straightforward (dynamic-import alias rewrites are flaky under v4.x).
+ *
+ * @task T9424
+ */
+export const statusCommand = defineCommand({
+  meta: {
+    name: 'status',
+    description:
+      'Unified config + credential + session + harness + daemon snapshot. ' +
+      'Use --json for the full LAFS envelope (CleoStatus interface). ' +
+      'Exits non-zero when any credential is in invalid state.',
+  },
+  args: {
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON envelope (CleoStatus interface)',
+    },
+  },
+  async run({ args }) {
+    const a = args as Record<string, unknown>;
+    // --json on this command is an explicit override on top of the global
+    // --format resolution: the command-level flag wins for users who want
+    // JSON without exporting CLEO_FORMAT.
+    const forceJson = a['json'] === true;
+
+    const status = (await getCleoStatus()) as StatusShape;
+
+    // In human mode, emit the section-by-section renderer directly via
+    // process.stdout so the renderer is bypass-safe for tests and respects
+    // ANSI/NO_COLOR via the shared color helpers. JSON mode goes through
+    // cliOutput for the LAFS envelope.
+    if (forceJson || isJsonFormat()) {
+      cliOutput(status, {
+        command: 'status',
+        operation: 'status.show',
+      });
+    } else {
+      process.stdout.write(`${renderStatusHuman(status)}\n`);
+    }
+
+    const exitCode = computeExitCode(status);
+    if (exitCode !== 0) process.exit(exitCode);
+  },
+});

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -762,6 +762,12 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     load: async () => (await import('../commands/stats.js')).statsCommand as CommandDef,
   },
   {
+    exportName: 'statusCommand',
+    name: 'status',
+    description: 'Unified config + credential + session + harness + daemon snapshot. ',
+    load: async () => (await import('../commands/status.js')).statusCommand as CommandDef,
+  },
+  {
     exportName: 'stickyCommand',
     name: 'sticky',
     description: 'Manage sticky notes - quick project-wide ephemeral captures',

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -141,6 +141,11 @@ export default defineConfig({
         '../../packages/core/src/nexus/index.ts',
         import.meta.url,
       ).pathname,
+      // T9424: status subpath export used by `cleo status` CLI thin wrapper
+      '@cleocode/core/status': new URL(
+        '../../packages/core/src/status/index.ts',
+        import.meta.url,
+      ).pathname,
       // T9274: llm/usage-pricing subpath — cost tracking helpers (not in package exports map)
       '@cleocode/core/llm/usage-pricing': new URL(
         '../../packages/core/src/llm/usage-pricing.ts',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,11 @@
       "import": "./dist/sessions/index.js",
       "require": "./dist/sessions/index.js"
     },
+    "./status": {
+      "types": "./dist/status/index.d.ts",
+      "import": "./dist/status/index.js",
+      "require": "./dist/status/index.js"
+    },
     "./nexus": {
       "types": "./dist/nexus/index.d.ts",
       "import": "./dist/nexus/index.js",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -210,6 +210,11 @@ export default defineConfig({
         './packages/core/src/nexus/index.ts',
         import.meta.url,
       ).pathname,
+      // T9424: status subpath export used by `cleo status` CLI thin wrapper
+      '@cleocode/core/status': new URL(
+        './packages/core/src/status/index.ts',
+        import.meta.url,
+      ).pathname,
       '@cleocode/core': new URL('./packages/core/src/index.ts', import.meta.url).pathname,
       '@cleocode/adapters': new URL('./packages/adapters/src/index.ts', import.meta.url).pathname,
       '@cleocode/lafs': new URL('./packages/lafs/src/index.ts', import.meta.url).pathname,


### PR DESCRIPTION
E-CONFIG-AUTH-UNIFY E3 §5.3 T-E3-5. Six-section status render + --json. Added 'status' subpath export to packages/core. 8 tests pass.