### PR TITLE
feat(T9546): cleo worktree list command

### DIFF
--- a/packages/cleo/src/cli/commands/worktree.ts
+++ b/packages/cleo/src/cli/commands/worktree.ts
@@ -1,0 +1,106 @@
+/**
+ * CLI worktree command group — structured worktree enumeration (T9546).
+ *
+ * Thin CLI wrapper delegating to the worktree dispatch domain. Implements the
+ * 2-of-5 step of the T9515 worktree-lifecycle bug fix epic: every CLEO-managed
+ * worktree is enumerated with a single mutually-exclusive `statusCategory`
+ * (`active|stale|merged|orphan|locked`) plus orphan-detection heuristics.
+ *
+ * Commands:
+ *   cleo worktree list [--status <category>] [--json] [--days <n>]
+ *     — list every worktree attached to the current project with status
+ *       classification.
+ *
+ * Dispatch equivalent:
+ *   query({ domain: 'worktree', operation: 'list', params: { statusFilter?, staleDays? } })
+ *
+ * @task T9546
+ * @epic T9515
+ */
+
+import { defineCommand, showUsage } from 'citty';
+import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
+
+/** Recognised `--status` filter values. */
+const VALID_STATUS_VALUES = ['active', 'stale', 'merged', 'orphan', 'locked'] as const;
+
+/**
+ * `cleo worktree list` — emit a structured listing of every worktree.
+ *
+ * Output:
+ *  - `--json` (or `--format json` from the global flag): LAFS envelope with
+ *    `data.worktrees: WorktreeInfo[]`.
+ *  - default (human): a compact table rendered by the generic renderer.
+ *
+ * Filter `--status` accepts a single category or a comma-separated list
+ * (e.g. `--status stale,orphan`). Unknown categories are silently dropped
+ * by the dispatch layer to keep the surface forward-compatible.
+ *
+ * @example
+ * ```sh
+ * cleo worktree list
+ * cleo worktree list --status stale,orphan
+ * cleo worktree list --json
+ * cleo worktree list --days 14 --status stale
+ * ```
+ */
+const listCommand = defineCommand({
+  meta: {
+    name: 'list',
+    description:
+      'List worktrees attached to this project with status classification ' +
+      '(active|stale|merged|orphan|locked).',
+  },
+  args: {
+    status: {
+      type: 'string',
+      description:
+        'Filter by status category (single value or comma-separated list of ' +
+        `${VALID_STATUS_VALUES.join('|')}).`,
+    },
+    days: {
+      type: 'string',
+      description: 'Staleness threshold in days for the isStale classifier (default: 7).',
+    },
+  },
+  async run({ args }) {
+    const statusFilter =
+      typeof args['status'] === 'string' && args['status'].length > 0 ? args['status'] : undefined;
+    const staleDaysRaw = typeof args['days'] === 'string' ? args['days'] : undefined;
+    const staleDays = staleDaysRaw !== undefined ? Number.parseInt(staleDaysRaw, 10) : undefined;
+
+    await dispatchFromCli(
+      'query',
+      'worktree',
+      'list',
+      {
+        ...(statusFilter !== undefined ? { statusFilter } : {}),
+        ...(staleDays !== undefined && !Number.isNaN(staleDays) ? { staleDays } : {}),
+      },
+      { command: 'worktree-list', operation: 'worktree.list' },
+    );
+  },
+});
+
+/**
+ * Root `cleo worktree` command group.
+ *
+ * Today only the read-only `list` subcommand is wired — prune and force-unlock
+ * mutations are tracked under T9547 (worktree-lifecycle 3/5).
+ *
+ * @task T9546
+ */
+export const worktreeCommand = defineCommand({
+  meta: {
+    name: 'worktree',
+    description:
+      'Inspect CLEO-managed git worktrees attached to this project. ' +
+      'See `cleo worktree list --help` for status classification details.',
+  },
+  subCommands: {
+    list: listCommand,
+  },
+  async run() {
+    await showUsage(worktreeCommand as Parameters<typeof showUsage>[0]);
+  },
+});

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -63,8 +62,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +83,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,20 +101,23 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -135,7 +140,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -238,7 +244,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'currentCommand',
@@ -255,14 +262,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -286,7 +295,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -297,7 +307,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -310,7 +321,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -346,7 +358,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -370,7 +383,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'generateChangelogCommand',
     name: 'generate-changelog',
     description: 'Generate platform-specific changelog from CHANGELOG.md',
-    load: async () => (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
   },
   {
     exportName: 'gradeCommand',
@@ -394,7 +408,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -417,14 +432,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -453,7 +471,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -495,14 +514,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -531,7 +553,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -543,13 +566,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -586,7 +611,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -645,7 +671,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -657,7 +684,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -705,13 +733,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all sections (llm, identity, sentient, project-conventions) in canonical order. Use --section <name> for a single section or --non-interactive with --provider/--api-key to configure LLM without prompts.',
+    description:
+      'Interactive setup wizard — runs all sections (llm, identity, sentient, project-conventions) in canonical order. Use --section <name> for a single section or --non-interactive with --provider/--api-key to configure LLM without prompts.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description:
+      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -777,7 +807,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -795,7 +826,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -62,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -83,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -101,23 +99,20 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -140,8 +135,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -244,8 +238,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'currentCommand',
@@ -262,16 +255,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -295,8 +286,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -307,8 +297,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -321,8 +310,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -358,8 +346,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -383,8 +370,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'generateChangelogCommand',
     name: 'generate-changelog',
     description: 'Generate platform-specific changelog from CHANGELOG.md',
-    load: async () =>
-      (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
+    load: async () => (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
   },
   {
     exportName: 'gradeCommand',
@@ -408,8 +394,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -432,17 +417,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -471,8 +453,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -514,17 +495,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -553,8 +531,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -566,15 +543,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -611,8 +586,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -671,8 +645,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -684,8 +657,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -733,15 +705,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all sections (llm, identity, sentient, project-conventions) in canonical order. Use --section <name> for a single section or --non-interactive with --provider/--api-key to configure LLM without prompts.',
+    description: 'Interactive setup wizard — runs all sections (llm, identity, sentient, project-conventions) in canonical order. Use --section <name> for a single section or --non-interactive with --provider/--api-key to configure LLM without prompts.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -807,8 +777,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -826,8 +795,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {
@@ -841,5 +809,11 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'web',
     description: 'Manage CLEO Web UI server',
     load: async () => (await import('../commands/web.js')).webCommand as CommandDef,
+  },
+  {
+    exportName: 'worktreeCommand',
+    name: 'worktree',
+    description: 'Inspect CLEO-managed git worktrees attached to this project. ',
+    load: async () => (await import('../commands/worktree.js')).worktreeCommand as CommandDef,
   },
 ] as const;

--- a/packages/cleo/src/dispatch/domains/index.ts
+++ b/packages/cleo/src/dispatch/domains/index.ts
@@ -27,6 +27,7 @@ import { SessionHandler } from './session.js';
 import { StickyHandler } from './sticky.js';
 import { TasksHandler } from './tasks.js';
 import { ToolsHandler } from './tools.js';
+import { WorktreeHandler } from './worktree.js';
 
 export {
   AdminHandler,
@@ -47,6 +48,7 @@ export {
   StickyHandler,
   TasksHandler,
   ToolsHandler,
+  WorktreeHandler,
 };
 
 /**
@@ -80,5 +82,8 @@ export function createDomainHandlers(): Map<string, DomainHandler> {
   handlers.set('release', new ReleaseHandler());
   // T9258: `cleo llm` CLI surface — credential pool + role-aware resolver + config writer.
   handlers.set('llm', new LlmHandler());
+  // T9546: `cleo worktree` CLI surface — structured worktree enumeration with status classification
+  // (T9515 worktree-lifecycle bug fix epic, 2 of 5).
+  handlers.set('worktree', new WorktreeHandler());
   return handlers;
 }

--- a/packages/cleo/src/dispatch/domains/worktree.ts
+++ b/packages/cleo/src/dispatch/domains/worktree.ts
@@ -1,0 +1,135 @@
+/**
+ * Worktree Domain Handler (Dispatch Layer)
+ *
+ * Handles `cleo worktree <operation>` dispatch operations:
+ *
+ * QUERY operations:
+ *   list — structured enumeration of every git worktree attached to the
+ *          project with status classification (active|stale|merged|orphan|locked).
+ *
+ * MUTATE operations:
+ *   (none yet — pending T9547 prune + force-unlock work)
+ *
+ * The `list` operation wraps the SDK primitive {@link listWorktrees} so the
+ * canonical EngineResult shape (LAFS envelope) is preserved on both the CLI
+ * and the typed SDK surface.
+ *
+ * @task T9546
+ * @epic T9515 — worktree-lifecycle bug-fix epic (2 of 5)
+ */
+
+import type {
+  ListWorktreesOpts,
+  ListWorktreesResult,
+  WorktreeStatusCategory,
+} from '@cleocode/contracts';
+import { getLogger, getProjectRoot, listWorktrees } from '@cleocode/core/internal';
+import type { DispatchResponse, DomainHandler } from '../types.js';
+import { handleErrorResult, unsupportedOp, wrapResult } from './_base.js';
+
+const log = getLogger('domain:worktree');
+
+const ALL_CATEGORIES: readonly WorktreeStatusCategory[] = [
+  'active',
+  'stale',
+  'merged',
+  'orphan',
+  'locked',
+];
+
+/**
+ * Narrow a raw dispatch `params.statusFilter` value into a typed list of
+ * {@link WorktreeStatusCategory} values. Accepts either a single string or
+ * a string array; unknown categories are silently dropped to keep the
+ * dispatch surface forward-compatible.
+ *
+ * @internal
+ */
+function coerceStatusFilter(value: unknown): WorktreeStatusCategory[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  const raw: string[] = Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === 'string')
+    : typeof value === 'string'
+      ? value.split(',').map((s) => s.trim())
+      : [];
+  const out = raw.filter((s): s is WorktreeStatusCategory =>
+    (ALL_CATEGORIES as readonly string[]).includes(s),
+  );
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Dispatch domain handler for read-only worktree operations.
+ *
+ * Registered under the `worktree` domain key in {@link createDomainHandlers}.
+ *
+ * @task T9546
+ */
+export class WorktreeHandler implements DomainHandler {
+  /**
+   * Handle read-only worktree queries.
+   *
+   * Supported operations:
+   *  - `list` — return a structured listing of every worktree with status
+   *             classification. Params: `{ statusFilter?, staleDays? }`.
+   */
+  async query(operation: string, params?: Record<string, unknown>): Promise<DispatchResponse> {
+    const startTime = Date.now();
+    try {
+      switch (operation) {
+        case 'list': {
+          const opts: ListWorktreesOpts = {
+            projectRoot: getProjectRoot(),
+            statusFilter: coerceStatusFilter(params?.['statusFilter']),
+            staleDays:
+              typeof params?.['staleDays'] === 'number'
+                ? (params['staleDays'] as number)
+                : undefined,
+          };
+          const result = await listWorktrees(opts);
+          return wrapResult(
+            result as Parameters<typeof wrapResult>[0],
+            'query',
+            'worktree',
+            operation,
+            startTime,
+          );
+        }
+        default:
+          return unsupportedOp('query', 'worktree', operation, startTime);
+      }
+    } catch (err) {
+      log.error({ err, operation }, 'WorktreeHandler query error');
+      return handleErrorResult('query', 'worktree', operation, err, startTime);
+    }
+  }
+
+  /**
+   * Worktree mutations (prune / unlock) are reserved for T9547 — this handler
+   * accepts no mutate operations today.
+   *
+   * @param operation - Operation name (always returns unsupported).
+   * @returns DispatchResponse with E_INVALID_OPERATION.
+   */
+  async mutate(operation: string, _params?: Record<string, unknown>): Promise<DispatchResponse> {
+    const startTime = Date.now();
+    return unsupportedOp('mutate', 'worktree', operation, startTime);
+  }
+
+  /**
+   * Declare the operations this domain supports — feeds dispatch introspection
+   * and the `cleo --help` rendering pipeline.
+   *
+   * @returns Query/mutate operation lists.
+   */
+  getSupportedOperations(): { query: string[]; mutate: string[] } {
+    return {
+      query: ['list'],
+      mutate: [],
+    };
+  }
+}
+
+// Re-export the listing result type so dispatch callers that import the
+// handler don't also have to reach into @cleocode/contracts.
+export type { ListWorktreesResult };

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1145,12 +1145,16 @@ export type {
   DestroyWorktreeOptions,
   DestroyWorktreeResult,
   ListWorktreesOptions,
+  ListWorktreesOpts,
+  ListWorktreesResult,
   PruneWorktreesOptions,
   PruneWorktreesResult,
   WorktreeHook,
   WorktreeHookResult,
   WorktreeIncludePattern,
+  WorktreeInfo,
   WorktreeListEntry,
+  WorktreeStatusCategory,
 } from './operations/worktree.js';
 // === Orchestration Roll-up Types (T9082, ADR-070) ===
 export type {

--- a/packages/contracts/src/operations/worktree.ts
+++ b/packages/contracts/src/operations/worktree.ts
@@ -349,3 +349,91 @@ export interface PruneWorktreesResult {
   /** Whether `git worktree prune` was run. */
   gitPruneRan: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Structured listing (T9546 — worktree-lifecycle 2/5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutually-exclusive worktree status category assigned by orphan-detection
+ * heuristics in {@link WorktreeInfo}.
+ *
+ * Resolution precedence (first match wins):
+ *  1. `locked` — git porcelain reports the worktree is locked.
+ *  2. `orphan` — owning task is cancelled OR the branch has been deleted.
+ *  3. `merged` — the branch is reachable from `main` (already integrated).
+ *  4. `stale`  — no commits in N days AND (task=done OR no live owner).
+ *  5. `active` — everything else (default).
+ *
+ * @task T9546
+ */
+export type WorktreeStatusCategory = 'active' | 'stale' | 'merged' | 'orphan' | 'locked';
+
+/**
+ * A single structured worktree entry with full status classification.
+ *
+ * Returned by `cleo worktree list` and the `worktree.list` dispatch operation.
+ * Each entry combines filesystem state, git state, and owning-task state into
+ * a single JSON envelope payload that downstream consumers (prune, dashboard,
+ * sentient daemon) can act on without re-querying git.
+ *
+ * @task T9546
+ */
+export interface WorktreeInfo {
+  /** Absolute path to the worktree directory. */
+  path: string;
+  /** Branch checked out in this worktree. */
+  branch: string;
+  /** Task ID derived from the branch name (`task/T####`), or null. */
+  taskId: string | null;
+  /** Agent identifier that owns this worktree (from audit log / metadata), or null. */
+  owningAgent: string | null;
+  /** ISO-8601 timestamp of last activity (newest commit OR mtime of working tree). */
+  lastActivity: string;
+  /** Whether `git worktree list --porcelain` reports the worktree as locked. */
+  isLocked: boolean;
+  /** Whether the worktree is stale: no activity > N days AND (task done/cancelled OR branch merged). */
+  isStale: boolean;
+  /** Whether the branch is reachable from `main` (already integrated). */
+  isMerged: boolean;
+  /** Status of the owning task (if {@link taskId} is present and resolvable), or null. */
+  owningTaskStatus: string | null;
+  /** Mutually-exclusive status category — see {@link WorktreeStatusCategory}. */
+  statusCategory: WorktreeStatusCategory;
+}
+
+/**
+ * Options for the structured worktree listing operation.
+ *
+ * @task T9546
+ */
+export interface ListWorktreesOpts {
+  /**
+   * Absolute path to the project root (used to compute the project hash
+   * and resolve the canonical worktrees directory).
+   */
+  projectRoot?: string;
+  /**
+   * Filter results to entries with one of these status categories.
+   * When omitted, all entries are returned.
+   */
+  statusFilter?: WorktreeStatusCategory[];
+  /**
+   * Staleness threshold in days. An entry is marked stale when its last
+   * activity is older than this AND either the owning task is done/cancelled
+   * or no owning task can be resolved while the branch is merged.
+   *
+   * @default 7
+   */
+  staleDays?: number;
+}
+
+/**
+ * Result of the structured worktree listing operation.
+ *
+ * @task T9546
+ */
+export interface ListWorktreesResult {
+  /** All matched worktree entries (post-filter). */
+  worktrees: WorktreeInfo[];
+}

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1999,6 +1999,8 @@ export {
 } from './tools/engine-ops.js';
 // Verification gates — enums/classes
 export { GateStatus, VerificationGate } from './validation/operation-verification-gates.js';
+// Worktree listing — structured enumeration with status classification (T9546 / T9515)
+export { listWorktrees } from './worktree/list.js';
 
 // ---------------------------------------------------------------------------
 // Test helpers (used by cleo test files)

--- a/packages/core/src/worktree/__tests__/list.test.ts
+++ b/packages/core/src/worktree/__tests__/list.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Unit tests for the structured worktree-list primitive (T9546).
+ *
+ * Covers:
+ *  - Happy path: porcelain output → classified WorktreeInfo entries
+ *  - Each statusCategory (`active|stale|merged|orphan|locked`) is reachable
+ *  - --status filter narrows results
+ *  - taskIdFromBranch convention
+ *  - classifyStatus precedence (locked > orphan > merged > stale > active)
+ *  - 50-worktree performance budget (<500ms with mocked git/db calls)
+ *
+ * @task T9546
+ * @epic T9515
+ */
+
+import { execFileSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock node:child_process for porcelain + log + merge-base invocations.
+// All git calls in list.ts route through execFileSync — the mock lets us
+// drive every code-path deterministically without spawning real git.
+// ---------------------------------------------------------------------------
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock openCleoDb chokepoint — returns a stub DatabaseSync that yields the
+// tasks-by-id rows the current test configured via `MOCK_TASK_ROWS`.
+// ---------------------------------------------------------------------------
+const MOCK_TASK_ROWS = new Map<string, string>();
+vi.mock('../../store/open-cleo-db.js', () => ({
+  openCleoDb: vi.fn(async () => ({
+    db: {
+      prepare: (_sql: string) => ({
+        all: (...ids: string[]) =>
+          ids
+            .filter((id) => MOCK_TASK_ROWS.has(id))
+            .map((id) => ({ id, status: MOCK_TASK_ROWS.get(id) })),
+      }),
+    },
+    role: 'tasks',
+    close: async () => {},
+  })),
+}));
+
+const mockExec = vi.mocked(execFileSync);
+
+import {
+  branchIsMergedToMain,
+  classifyStatus,
+  enumerateWorktrees,
+  listWorktrees,
+  taskIdFromBranch,
+} from '../list.js';
+
+/**
+ * Build a stub porcelain payload for `git worktree list --porcelain`.
+ * Each entry produces a record matching the documented git porcelain grammar.
+ */
+function porcelain(
+  entries: Array<{ path: string; branch: string; locked?: boolean; detached?: boolean }>,
+): string {
+  const blocks = entries.map((e) => {
+    const lines: string[] = [`worktree ${e.path}`, 'HEAD abc123'];
+    if (e.detached) {
+      lines.push('detached');
+    } else {
+      lines.push(`branch refs/heads/${e.branch}`);
+    }
+    if (e.locked) lines.push('locked');
+    return lines.join('\n');
+  });
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/**
+ * Build a per-call execFileSync mock implementation that knows how to respond
+ * to: `worktree list --porcelain`, `log -1 --format=%cI`, `merge-base --is-ancestor`,
+ * `rev-parse --verify refs/heads/main`.
+ */
+function installGitMock(opts: {
+  porcelainOutput: string;
+  /** Per-branch ISO timestamp returned by `git log -1 --format=%cI`. */
+  branchTimestamps?: Record<string, string>;
+  /** Branches reported as merged into main (via `merge-base --is-ancestor`). */
+  mergedBranches?: Set<string>;
+  /** Whether `refs/heads/main` resolves locally. */
+  mainExists?: boolean;
+}): void {
+  const merged = opts.mergedBranches ?? new Set<string>();
+  const timestamps = opts.branchTimestamps ?? {};
+  const mainExists = opts.mainExists !== false;
+
+  mockExec.mockImplementation((_cmd: string, args?: readonly string[]) => {
+    const argv = (args ?? []) as readonly string[];
+    if (argv[0] === 'worktree' && argv[1] === 'list') {
+      return opts.porcelainOutput as never;
+    }
+    if (argv[0] === 'log' && argv[1] === '-1') {
+      const branch = argv[3];
+      if (branch && timestamps[branch]) return `${timestamps[branch]}\n` as never;
+      throw new Error('no log for branch');
+    }
+    if (argv[0] === 'merge-base' && argv[1] === '--is-ancestor') {
+      const branch = argv[2];
+      if (branch && merged.has(branch)) return '' as never;
+      const err = new Error('not an ancestor');
+      throw err;
+    }
+    if (argv[0] === 'rev-parse' && argv[1] === '--verify') {
+      if (mainExists) return '' as never;
+      throw new Error('no main');
+    }
+    throw new Error(`unexpected git call: ${argv.join(' ')}`);
+  });
+}
+
+beforeEach(() => {
+  MOCK_TASK_ROWS.clear();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('taskIdFromBranch', () => {
+  it('extracts task ID from canonical branch names', () => {
+    expect(taskIdFromBranch('task/T9546')).toBe('T9546');
+    expect(taskIdFromBranch('task/T1')).toBe('T1');
+  });
+
+  it('returns null for non-task branches', () => {
+    expect(taskIdFromBranch('main')).toBeNull();
+    expect(taskIdFromBranch('feat/foo')).toBeNull();
+    expect(taskIdFromBranch('release/v2026.5.78')).toBeNull();
+    expect(taskIdFromBranch('task/foo')).toBeNull();
+  });
+});
+
+describe('classifyStatus precedence', () => {
+  it('locked beats every other flag', () => {
+    expect(classifyStatus({ isLocked: true, isOrphan: true, isMerged: true, isStale: true })).toBe(
+      'locked',
+    );
+  });
+
+  it('orphan beats merged and stale', () => {
+    expect(classifyStatus({ isLocked: false, isOrphan: true, isMerged: true, isStale: true })).toBe(
+      'orphan',
+    );
+  });
+
+  it('merged beats stale', () => {
+    expect(
+      classifyStatus({ isLocked: false, isOrphan: false, isMerged: true, isStale: true }),
+    ).toBe('merged');
+  });
+
+  it('stale wins over active when isolated', () => {
+    expect(
+      classifyStatus({ isLocked: false, isOrphan: false, isMerged: false, isStale: true }),
+    ).toBe('stale');
+  });
+
+  it('returns active by default', () => {
+    expect(
+      classifyStatus({ isLocked: false, isOrphan: false, isMerged: false, isStale: false }),
+    ).toBe('active');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Porcelain parsing
+// ---------------------------------------------------------------------------
+
+describe('enumerateWorktrees', () => {
+  it('parses a single worktree entry', () => {
+    mockExec.mockReturnValue(porcelain([{ path: '/tmp/wt/T1', branch: 'task/T1' }]) as never);
+    const out = enumerateWorktrees('/tmp/project');
+    expect(out).toEqual([{ path: '/tmp/wt/T1', branch: 'task/T1', locked: false }]);
+  });
+
+  it('parses multiple worktree entries separated by blank lines', () => {
+    mockExec.mockReturnValue(
+      porcelain([
+        { path: '/tmp/wt/T1', branch: 'task/T1' },
+        { path: '/tmp/wt/T2', branch: 'task/T2', locked: true },
+      ]) as never,
+    );
+    const out = enumerateWorktrees('/tmp/project');
+    expect(out).toHaveLength(2);
+    expect(out[1]?.locked).toBe(true);
+  });
+
+  it('handles detached HEAD entries gracefully', () => {
+    mockExec.mockReturnValue(
+      porcelain([{ path: '/tmp/wt/detached', branch: '', detached: true }]) as never,
+    );
+    const out = enumerateWorktrees('/tmp/project');
+    expect(out[0]?.branch).toBe('HEAD');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// branchIsMergedToMain
+// ---------------------------------------------------------------------------
+
+describe('branchIsMergedToMain', () => {
+  it('returns true when merge-base exits 0', () => {
+    mockExec.mockReturnValue('' as never);
+    expect(branchIsMergedToMain('task/T9546', '/tmp', 'main')).toBe(true);
+  });
+
+  it('returns false when merge-base throws', () => {
+    mockExec.mockImplementation(() => {
+      throw new Error('not an ancestor');
+    });
+    expect(branchIsMergedToMain('task/T9546', '/tmp', 'main')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listWorktrees — integration of all classifiers
+// ---------------------------------------------------------------------------
+
+describe('listWorktrees — status classification', () => {
+  const nowIso = (offsetDays = 0): string =>
+    new Date(Date.now() - offsetDays * 24 * 60 * 60 * 1000).toISOString();
+
+  it('happy path: classifies an active worktree with a live task', async () => {
+    MOCK_TASK_ROWS.set('T9546', 'active');
+    installGitMock({
+      porcelainOutput: porcelain([{ path: '/tmp/wt/T9546', branch: 'task/T9546' }]),
+      branchTimestamps: { 'task/T9546': nowIso(0) },
+      mergedBranches: new Set(),
+    });
+
+    const result = await listWorktrees({ projectRoot: '/tmp/project' });
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('expected success');
+    expect(result.data.worktrees).toHaveLength(1);
+    const wt = result.data.worktrees[0];
+    expect(wt?.statusCategory).toBe('active');
+    expect(wt?.taskId).toBe('T9546');
+    expect(wt?.owningTaskStatus).toBe('active');
+    expect(wt?.isMerged).toBe(false);
+    expect(wt?.isStale).toBe(false);
+    expect(wt?.isLocked).toBe(false);
+  });
+
+  it('stale detection: idle > 7 days AND task done → status=stale', async () => {
+    MOCK_TASK_ROWS.set('T100', 'done');
+    installGitMock({
+      porcelainOutput: porcelain([{ path: '/tmp/wt/T100', branch: 'task/T100' }]),
+      branchTimestamps: { 'task/T100': nowIso(30) },
+      mergedBranches: new Set(),
+    });
+
+    const result = await listWorktrees({ projectRoot: '/tmp/project' });
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('expected success');
+    expect(result.data.worktrees[0]?.statusCategory).toBe('stale');
+    expect(result.data.worktrees[0]?.isStale).toBe(true);
+  });
+
+  it('merged detection: branch reachable from main → status=merged', async () => {
+    MOCK_TASK_ROWS.set('T200', 'active');
+    installGitMock({
+      porcelainOutput: porcelain([{ path: '/tmp/wt/T200', branch: 'task/T200' }]),
+      branchTimestamps: { 'task/T200': nowIso(0) },
+      mergedBranches: new Set(['task/T200']),
+    });
+
+    const result = await listWorktrees({ projectRoot: '/tmp/project' });
+    if (!result.success) throw new Error('expected success');
+    const wt = result.data.worktrees[0];
+    expect(wt?.isMerged).toBe(true);
+    expect(wt?.statusCategory).toBe('merged');
+  });
+
+  it('locked detection: porcelain reports locked → status=locked', async () => {
+    MOCK_TASK_ROWS.set('T300', 'active');
+    installGitMock({
+      porcelainOutput: porcelain([{ path: '/tmp/wt/T300', branch: 'task/T300', locked: true }]),
+      branchTimestamps: { 'task/T300': nowIso(0) },
+      mergedBranches: new Set(),
+    });
+
+    const result = await listWorktrees({ projectRoot: '/tmp/project' });
+    if (!result.success) throw new Error('expected success');
+    expect(result.data.worktrees[0]?.statusCategory).toBe('locked');
+    expect(result.data.worktrees[0]?.isLocked).toBe(true);
+  });
+
+  it('orphan detection: owning task cancelled → status=orphan', async () => {
+    MOCK_TASK_ROWS.set('T400', 'cancelled');
+    installGitMock({
+      porcelainOutput: porcelain([{ path: '/tmp/wt/T400', branch: 'task/T400' }]),
+      branchTimestamps: { 'task/T400': nowIso(0) },
+      mergedBranches: new Set(),
+    });
+
+    const result = await listWorktrees({ projectRoot: '/tmp/project' });
+    if (!result.success) throw new Error('expected success');
+    expect(result.data.worktrees[0]?.statusCategory).toBe('orphan');
+    expect(result.data.worktrees[0]?.owningTaskStatus).toBe('cancelled');
+  });
+
+  it('orphan detection: task row missing → status=orphan', async () => {
+    // T500 is NOT in MOCK_TASK_ROWS — simulating a deleted task / dangling branch.
+    installGitMock({
+      porcelainOutput: porcelain([{ path: '/tmp/wt/T500', branch: 'task/T500' }]),
+      branchTimestamps: { 'task/T500': nowIso(0) },
+      mergedBranches: new Set(),
+    });
+
+    const result = await listWorktrees({ projectRoot: '/tmp/project' });
+    if (!result.success) throw new Error('expected success');
+    expect(result.data.worktrees[0]?.statusCategory).toBe('orphan');
+    expect(result.data.worktrees[0]?.owningTaskStatus).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+describe('listWorktrees — --status filter', () => {
+  it('returns subset matching the requested category', async () => {
+    MOCK_TASK_ROWS.set('T1', 'active');
+    MOCK_TASK_ROWS.set('T2', 'cancelled');
+    MOCK_TASK_ROWS.set('T3', 'done');
+    installGitMock({
+      porcelainOutput: porcelain([
+        { path: '/wt/T1', branch: 'task/T1' },
+        { path: '/wt/T2', branch: 'task/T2' },
+        { path: '/wt/T3', branch: 'task/T3' },
+      ]),
+      branchTimestamps: {
+        'task/T1': new Date().toISOString(),
+        'task/T2': new Date().toISOString(),
+        'task/T3': new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+      mergedBranches: new Set(['task/T3']),
+    });
+
+    const result = await listWorktrees({
+      projectRoot: '/tmp/project',
+      statusFilter: ['orphan', 'merged'],
+    });
+    if (!result.success) throw new Error('expected success');
+    const categories = result.data.worktrees.map((w) => w.statusCategory).sort();
+    expect(categories).toEqual(['merged', 'orphan']);
+  });
+
+  it('returns ALL entries when statusFilter is omitted', async () => {
+    MOCK_TASK_ROWS.set('T1', 'active');
+    MOCK_TASK_ROWS.set('T2', 'cancelled');
+    installGitMock({
+      porcelainOutput: porcelain([
+        { path: '/wt/T1', branch: 'task/T1' },
+        { path: '/wt/T2', branch: 'task/T2' },
+      ]),
+      branchTimestamps: {
+        'task/T1': new Date().toISOString(),
+        'task/T2': new Date().toISOString(),
+      },
+      mergedBranches: new Set(),
+    });
+
+    const result = await listWorktrees({ projectRoot: '/tmp/project' });
+    if (!result.success) throw new Error('expected success');
+    expect(result.data.worktrees).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Performance budget
+// ---------------------------------------------------------------------------
+
+describe('listWorktrees — performance budget', () => {
+  it('returns 50 mock worktrees in < 500ms', async () => {
+    const entries = Array.from({ length: 50 }, (_, i) => ({
+      path: `/tmp/wt/T${i + 1000}`,
+      branch: `task/T${i + 1000}`,
+    }));
+    for (const entry of entries) {
+      const taskId = entry.branch.slice('task/'.length);
+      MOCK_TASK_ROWS.set(taskId, 'active');
+    }
+    const timestamps: Record<string, string> = {};
+    for (const e of entries) timestamps[e.branch] = new Date().toISOString();
+    installGitMock({
+      porcelainOutput: porcelain(entries),
+      branchTimestamps: timestamps,
+      mergedBranches: new Set(),
+    });
+
+    const t0 = performance.now();
+    const result = await listWorktrees({ projectRoot: '/tmp/project' });
+    const elapsedMs = performance.now() - t0;
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('expected success');
+    expect(result.data.worktrees).toHaveLength(50);
+    expect(elapsedMs).toBeLessThan(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error surface
+// ---------------------------------------------------------------------------
+
+describe('listWorktrees — error surface', () => {
+  it('returns engineError when git worktree list fails', async () => {
+    mockExec.mockImplementation(() => {
+      throw new Error('fatal: not a git repository');
+    });
+
+    const result = await listWorktrees({ projectRoot: '/tmp/not-a-repo' });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected failure');
+    expect(result.error.code).toBe('E_GIT_FAILED');
+    expect(result.error.message).toContain('fatal: not a git repository');
+  });
+});

--- a/packages/core/src/worktree/list.ts
+++ b/packages/core/src/worktree/list.ts
@@ -1,0 +1,423 @@
+/**
+ * Structured worktree enumeration with status classification (T9546).
+ *
+ * Exposes {@link listWorktrees} — the SDK primitive behind the
+ * `cleo worktree list` CLI command and the `worktree.list` dispatch operation.
+ *
+ * For each worktree returned by `git worktree list --porcelain`, the function
+ * resolves:
+ *  - `taskId` (regex match against the branch name `task/T####`).
+ *  - `owningTaskStatus` (read from the tasks SSoT via {@link openCleoDb}).
+ *  - `lastActivity` (newest commit on the branch, falling back to dir mtime).
+ *  - `isLocked` (porcelain `locked` line).
+ *  - `isMerged` (`git merge-base --is-ancestor <branch> main`, exit-0 ⇒ merged).
+ *  - `isStale`  (no commits in >N days AND (task done/cancelled OR merged)).
+ *  - `owningAgent` (best-effort from `.git/worktree.json` if present).
+ *  - `statusCategory` — one of `locked|orphan|merged|stale|active`, resolved
+ *    by precedence in {@link classifyStatus}.
+ *
+ * All git invocations are bounded by an explicit 60-second supervisor
+ * timeout, matching the {@link runGitWithLockRetry} discipline used elsewhere
+ * in `packages/core/src/release/engine-ops.ts`. We intentionally do NOT use
+ * `runGitWithLockRetry` directly here — these read-only queries never touch
+ * `.git/index.lock`, so the retry/backoff dance would be pure overhead.
+ *
+ * @task T9546
+ * @adr ADR-068 — DB chokepoint (openCleoDb)
+ * @adr ADR-062 — git merge-no-ff integration semantics
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import {
+  type EngineResult,
+  engineError,
+  engineSuccess,
+  type ListWorktreesOpts,
+  type ListWorktreesResult,
+  type WorktreeInfo,
+  type WorktreeStatusCategory,
+} from '@cleocode/contracts';
+import { openCleoDb } from '../store/open-cleo-db.js';
+
+/** Default staleness threshold — branches/worktrees idle longer than this are stale candidates. */
+const DEFAULT_STALE_DAYS = 7;
+
+/** Default supervisor timeout for every git invocation (matches engine-ops.ts). */
+const GIT_TIMEOUT_MS = 60_000;
+
+/** Default upstream branch name used for `merge-base --is-ancestor` checks. */
+const DEFAULT_MAIN_BRANCH = 'main';
+
+/**
+ * One row of porcelain output from `git worktree list --porcelain`.
+ *
+ * @internal
+ */
+interface PorcelainEntry {
+  path: string;
+  branch: string;
+  locked: boolean;
+}
+
+/**
+ * List all worktrees attached to the given project root, classify each one
+ * by activity / merge / lock / orphan state, and return a structured envelope.
+ *
+ * @param opts - Listing options including project root, filter, and stale-days threshold.
+ * @returns EngineResult containing a {@link ListWorktreesResult} on success.
+ *
+ * @example
+ * ```ts
+ * const result = await listWorktrees({ projectRoot: process.cwd() });
+ * if (result.success) {
+ *   for (const wt of result.data.worktrees) {
+ *     console.log(wt.path, wt.statusCategory);
+ *   }
+ * }
+ * ```
+ */
+export async function listWorktrees(
+  opts: ListWorktreesOpts = {},
+): Promise<EngineResult<ListWorktreesResult>> {
+  const projectRoot = opts.projectRoot ?? process.cwd();
+  const staleDays = opts.staleDays ?? DEFAULT_STALE_DAYS;
+  const staleThresholdMs = staleDays * 24 * 60 * 60 * 1000;
+  const nowMs = Date.now();
+
+  let porcelainEntries: PorcelainEntry[];
+  try {
+    porcelainEntries = enumerateWorktrees(projectRoot);
+  } catch (err) {
+    return engineError<ListWorktreesResult>(
+      'E_GIT_FAILED',
+      `Failed to enumerate worktrees: ${err instanceof Error ? err.message : String(err)}`,
+      { fix: 'Run `git worktree list --porcelain` manually to diagnose.' },
+    );
+  }
+
+  // Resolve unique task IDs once, then batch-load their statuses through the
+  // ADR-068 chokepoint. We open the tasks DB read-only via openCleoDb so the
+  // command picks up the SSoT pragma set (T9189) — never via raw DatabaseSync.
+  const branchToTaskId = new Map<string, string | null>();
+  for (const entry of porcelainEntries) {
+    branchToTaskId.set(entry.branch, taskIdFromBranch(entry.branch));
+  }
+  const taskIds = Array.from(branchToTaskId.values()).filter((id): id is string => id !== null);
+  const taskStatusByid = await loadOwningTaskStatuses(taskIds, projectRoot);
+
+  // Pre-resolve the default upstream branch presence — if `main` is absent,
+  // `branchIsMergedToMain` would otherwise spuriously throw for every entry.
+  const mainBranch = resolveMainBranch(projectRoot);
+
+  const worktrees: WorktreeInfo[] = porcelainEntries.map((entry) => {
+    const taskId = branchToTaskId.get(entry.branch) ?? null;
+    const lastActivityMs =
+      getLastCommitTimestampMs(entry.branch, projectRoot) ?? mtimeMs(entry.path);
+    const lastActivity = new Date(lastActivityMs).toISOString();
+    const isMerged = mainBranch
+      ? branchIsMergedToMain(entry.branch, projectRoot, mainBranch)
+      : false;
+    const owningTaskStatus = taskId ? (taskStatusByid.get(taskId) ?? null) : null;
+    const owningAgent = readOwningAgent(entry.path);
+
+    const idleMs = nowMs - lastActivityMs;
+    const idleOlderThanThreshold = idleMs > staleThresholdMs;
+    const ownerTerminal = owningTaskStatus === 'done' || owningTaskStatus === 'cancelled';
+    const isOrphan =
+      owningTaskStatus === 'cancelled' || (taskId !== null && owningTaskStatus === null);
+    // Stale = idle longer than threshold AND (owner is terminal OR branch already integrated).
+    const isStale = idleOlderThanThreshold && (ownerTerminal || isMerged);
+
+    const statusCategory = classifyStatus({
+      isLocked: entry.locked,
+      isOrphan,
+      isMerged,
+      isStale,
+    });
+
+    return {
+      path: entry.path,
+      branch: entry.branch,
+      taskId,
+      owningAgent,
+      lastActivity,
+      isLocked: entry.locked,
+      isStale,
+      isMerged,
+      owningTaskStatus,
+      statusCategory,
+    };
+  });
+
+  const filtered =
+    opts.statusFilter && opts.statusFilter.length > 0
+      ? worktrees.filter((w) => opts.statusFilter?.includes(w.statusCategory))
+      : worktrees;
+
+  return engineSuccess<ListWorktreesResult>({ worktrees: filtered });
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers — exported for tests only.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `git worktree list --porcelain` into structured rows.
+ *
+ * The porcelain grammar is documented at
+ * https://git-scm.com/docs/git-worktree#_porcelain_format — each record is
+ * separated by a blank line and may contain `worktree <path>`, `HEAD <sha>`,
+ * `branch refs/heads/<name>` and `locked [<reason>]` lines.
+ *
+ * @param projectRoot - Absolute path to the project root.
+ * @returns Parsed porcelain rows, one per worktree.
+ * @internal Exported for tests only.
+ */
+export function enumerateWorktrees(projectRoot: string): PorcelainEntry[] {
+  const stdout = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+    cwd: projectRoot,
+    encoding: 'utf-8',
+    timeout: GIT_TIMEOUT_MS,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const entries: PorcelainEntry[] = [];
+  let current: Partial<PorcelainEntry> & { locked?: boolean } = {};
+
+  const flush = (): void => {
+    if (current.path && current.branch) {
+      entries.push({
+        path: current.path,
+        branch: current.branch,
+        locked: current.locked === true,
+      });
+    }
+    current = {};
+  };
+
+  for (const rawLine of stdout.split('\n')) {
+    const line = rawLine.trimEnd();
+    if (line === '') {
+      flush();
+      continue;
+    }
+    if (line.startsWith('worktree ')) {
+      // New record begins — flush any in-progress entry first.
+      if (current.path) flush();
+      current.path = line.slice('worktree '.length);
+      continue;
+    }
+    if (line.startsWith('branch ')) {
+      const ref = line.slice('branch '.length);
+      current.branch = ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+      continue;
+    }
+    if (line === 'detached') {
+      // Detached HEAD has no branch — represent as 'HEAD' so downstream
+      // filters still see something deterministic. Tests assert that
+      // detached worktrees yield taskId=null.
+      current.branch = current.branch ?? 'HEAD';
+      continue;
+    }
+    if (line === 'locked' || line.startsWith('locked ')) {
+      current.locked = true;
+    }
+  }
+  flush();
+
+  return entries;
+}
+
+/**
+ * Extract a task ID from a branch name following the `task/T####` convention.
+ *
+ * @param branch - Git branch name.
+ * @returns The task ID string, or null if the branch does not match the convention.
+ * @internal Exported for tests only.
+ */
+export function taskIdFromBranch(branch: string): string | null {
+  const match = branch.match(/^task\/(T\d+)$/);
+  return match ? (match[1] ?? null) : null;
+}
+
+/**
+ * Get the timestamp (ms since epoch) of the newest commit on the given branch.
+ *
+ * Uses `git log -1 --format=%cI` and returns null if the branch resolution or
+ * the log invocation fails — callers fall back to the worktree directory mtime.
+ *
+ * @param branch - Branch name.
+ * @param projectRoot - Project root for the git invocation.
+ * @returns ms since epoch, or null on failure.
+ * @internal Exported for tests only.
+ */
+export function getLastCommitTimestampMs(branch: string, projectRoot: string): number | null {
+  try {
+    const iso = execFileSync('git', ['log', '-1', '--format=%cI', branch], {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      timeout: GIT_TIMEOUT_MS,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (!iso) return null;
+    const ms = Date.parse(iso);
+    return Number.isNaN(ms) ? null : ms;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Test whether the given branch is reachable from the canonical upstream branch.
+ *
+ * Implementation: `git merge-base --is-ancestor <branch> <main>` exits 0 if
+ * <branch> is an ancestor of <main> (i.e. has been merged or fast-forwarded
+ * into it). Any other exit code is interpreted as "not merged".
+ *
+ * @param branch - Branch name to test.
+ * @param projectRoot - Project root.
+ * @param mainBranch - Upstream branch to test reachability against.
+ * @returns true iff branch is reachable from main.
+ * @internal Exported for tests only.
+ */
+export function branchIsMergedToMain(
+  branch: string,
+  projectRoot: string,
+  mainBranch: string = DEFAULT_MAIN_BRANCH,
+): boolean {
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', branch, mainBranch], {
+      cwd: projectRoot,
+      timeout: GIT_TIMEOUT_MS,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Apply orphan/merged/stale/locked precedence to produce the single
+ * mutually-exclusive `statusCategory` field. See the {@link WorktreeStatusCategory}
+ * docstring for the resolution order.
+ *
+ * @param flags - The set of pre-computed boolean classifiers.
+ * @returns The resolved status category.
+ * @internal Exported for tests only.
+ */
+export function classifyStatus(flags: {
+  isLocked: boolean;
+  isOrphan: boolean;
+  isMerged: boolean;
+  isStale: boolean;
+}): WorktreeStatusCategory {
+  if (flags.isLocked) return 'locked';
+  if (flags.isOrphan) return 'orphan';
+  if (flags.isMerged) return 'merged';
+  if (flags.isStale) return 'stale';
+  return 'active';
+}
+
+/**
+ * Load the `status` column for each of the given task IDs through the
+ * ADR-068 DB chokepoint.
+ *
+ * Returns a map (taskId → status) for IDs that resolved; missing IDs are
+ * absent from the map (callers treat absent as `null` for downstream
+ * orphan detection).
+ *
+ * @param taskIds - Task IDs to look up.
+ * @param projectRoot - Project root for DB resolution.
+ * @returns Map of taskId → status.
+ * @internal Exported for tests only.
+ */
+export async function loadOwningTaskStatuses(
+  taskIds: string[],
+  projectRoot: string,
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (taskIds.length === 0) return out;
+
+  // openCleoDb returns CleoDbHandle whose `.db` field is `unknown` — we narrow
+  // here to the node:sqlite DatabaseSync surface we actually use. The cast is
+  // localised and the alternative (changing the chokepoint signature) would
+  // ripple across every store-using package.
+  const handle = await openCleoDb('tasks', projectRoot);
+  try {
+    const db = handle.db as DatabaseSync;
+    const placeholders = taskIds.map(() => '?').join(', ');
+    const sql = `SELECT id, status FROM tasks WHERE id IN (${placeholders})`;
+    const rows = db.prepare(sql).all(...taskIds) as Array<{ id: string; status: string }>;
+    for (const row of rows) {
+      out.set(row.id, row.status);
+    }
+  } finally {
+    await handle.close();
+  }
+  return out;
+}
+
+/**
+ * Best-effort read of the owning agent identifier from a per-worktree metadata
+ * file (`<path>/.git/worktree.json`). Returns null if the file is absent or
+ * malformed.
+ *
+ * @param worktreePath - Absolute path to the worktree directory.
+ * @returns The owningAgent string, or null.
+ * @internal Exported for tests only.
+ */
+export function readOwningAgent(worktreePath: string): string | null {
+  const candidate = join(worktreePath, '.git', 'worktree.json');
+  if (!existsSync(candidate)) return null;
+  try {
+    const raw = readFileSync(candidate, 'utf-8');
+    const parsed = JSON.parse(raw) as { owningAgent?: unknown };
+    return typeof parsed.owningAgent === 'string' ? parsed.owningAgent : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the mtime (ms) of the worktree directory, or current time if the
+ * directory has been removed since enumeration.
+ *
+ * @param path - Absolute path to the worktree directory.
+ * @returns ms since epoch.
+ * @internal
+ */
+function mtimeMs(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return Date.now();
+  }
+}
+
+/**
+ * Resolve the canonical upstream branch name for merge-base checks.
+ *
+ * Currently hard-coded to {@link DEFAULT_MAIN_BRANCH} — falls back to null
+ * if the branch does not exist locally, in which case callers skip the
+ * merge check entirely (no spurious "not merged" classifications).
+ *
+ * @param projectRoot - Project root.
+ * @returns The main branch name if it resolves, else null.
+ * @internal
+ */
+function resolveMainBranch(projectRoot: string): string | null {
+  try {
+    execFileSync('git', ['rev-parse', '--verify', `refs/heads/${DEFAULT_MAIN_BRANCH}`], {
+      cwd: projectRoot,
+      timeout: GIT_TIMEOUT_MS,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return DEFAULT_MAIN_BRANCH;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Adds `cleo worktree list` — structured worktree enumeration with status classification (active|stale|merged|orphan|locked). Part of T9515 worktree-lifecycle bug fix (2 of 5).

## Changes
- `packages/core/src/worktree/list.ts` — SDK implementation
- `packages/core/src/worktree/__tests__/list.test.ts` — unit tests (22 cases)
- `packages/cleo/src/cli/commands/worktree.ts` — CLI command tree
- `packages/cleo/src/dispatch/domains/worktree.ts` — `worktree.list` op handler
- `packages/contracts/src/operations/worktree.ts` — `WorktreeInfo`, `WorktreeStatusCategory`, `ListWorktreesOpts`, `ListWorktreesResult`
- `packages/core/src/internal.ts` — re-export `listWorktrees`
- `packages/cleo/src/dispatch/domains/index.ts` — register `WorktreeHandler`
- `packages/cleo/src/cli/generated/command-manifest.ts` — regenerated

## Test plan
- [x] Lists git worktrees + classifies all 5 status categories
- [x] `--status` filter narrows result set
- [x] Stale detection (>7d + done/cancelled OR merged)
- [x] Locked detection from porcelain
- [x] Orphan detection (task cancelled / row missing)
- [x] Merged detection via `git merge-base --is-ancestor`
- [x] 50 worktrees < 500ms (performance budget)
- [x] biome + tsc + vitest clean (22/22 tests pass, 194 release tests pass, 248 contracts tests pass)
- [x] All git invocations carry 60s `execFileSync timeout`

Closes T9546. Unblocks T9547 (prune + force-unlock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)