### PR TITLE
feat(T9525): cleo release plan verb

### DIFF
--- a/packages/cleo/src/cli/commands/release.ts
+++ b/packages/cleo/src/cli/commands/release.ts
@@ -346,6 +346,71 @@ const publishCommand = defineCommand({
   },
 });
 
+/**
+ * cleo release plan — Phase 1 verb of SPEC-T9345 release pipeline v2.
+ *
+ * Builds the canonical Release Plan envelope from `tasks.db` + git log +
+ * previous-release state; writes `.cleo/release/<resolved-version>.plan.json`;
+ * INSERTs/UPDATEs one row in the `releases` table with `status='planned'`.
+ *
+ * Read-mostly: NO git mutations, NO `gh` calls, NO network. Only writes are
+ * the plan file under `.cleo/release/` and the `releases` table row.
+ *
+ * @task T9525
+ * @epic T9492
+ * @spec SPEC-T9345 §4.2
+ */
+const planCommand = defineCommand({
+  meta: {
+    name: 'plan',
+    description: 'Build the canonical Release Plan envelope and persist status=planned (T9525)',
+  },
+  args: {
+    version: {
+      type: 'positional',
+      description: 'Candidate release version (e.g. v2026.6.0 or 2026.6.0)',
+      required: true,
+    },
+    epic: {
+      type: 'string',
+      description: 'Epic task ID whose children are candidates for inclusion',
+      required: true,
+    },
+    scheme: {
+      type: 'string',
+      description: 'Versioning scheme: calver | semver | calver-suffix',
+    },
+    channel: {
+      type: 'string',
+      description: 'Release channel: latest | beta | alpha | rc',
+    },
+    hotfix: {
+      type: 'boolean',
+      description: 'Mark plan as release_kind=hotfix',
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Compute plan + envelope without writing the plan file or DB row',
+    },
+  },
+  async run({ args }) {
+    await dispatchFromCli(
+      'mutate',
+      'release',
+      'release.plan',
+      {
+        version: args.version,
+        epicId: args.epic,
+        scheme: args.scheme as string | undefined,
+        channel: args.channel as string | undefined,
+        hotfix: args.hotfix === true,
+        dryRun: args['dry-run'] === true,
+      },
+      { command: 'release' },
+    );
+  },
+});
+
 /** cleo release reconcile — Step 4: run post-release invariants, auto-complete tasks. */
 const reconcileCommand = defineCommand({
   meta: { name: 'reconcile', description: 'Run post-release invariants for the active release' },
@@ -381,6 +446,8 @@ export const releaseCommand = defineCommand({
     verify: verifyCommand,
     publish: publishCommand,
     reconcile: reconcileCommand,
+    // SPEC-T9345 release pipeline v2 verbs (T9492)
+    plan: planCommand,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/cleo/src/dispatch/domains/release.ts
+++ b/packages/cleo/src/dispatch/domains/release.ts
@@ -31,6 +31,7 @@
  */
 
 import type { ReleaseGateCheckParams } from '@cleocode/contracts/operations/release';
+import type { ReleasePlanOptions } from '@cleocode/core/internal';
 import { getLogger, getProjectRoot } from '@cleocode/core/internal';
 import type { OpsFromCore } from '../adapters/typed.js';
 import {
@@ -38,6 +39,7 @@ import {
   makeAdr061GateRunner,
   releaseGateCheck,
   releaseIvtrAutoSuggest,
+  releasePlan,
   releasePublish,
   releaseReconcile,
   releaseStart,
@@ -298,6 +300,48 @@ export class ReleaseHandler implements DomainHandler {
           };
         }
 
+        // release.plan — SPEC-T9345 §4.2 (T9525): build canonical Release Plan envelope
+        case 'plan': {
+          const version = typeof params?.version === 'string' ? params.version : undefined;
+          const epicId = typeof params?.epicId === 'string' ? params.epicId : undefined;
+          if (!version) {
+            return errorResult(
+              'mutate',
+              'release',
+              operation,
+              'E_INVALID_INPUT',
+              'version is required',
+              startTime,
+            );
+          }
+          if (!epicId) {
+            return errorResult(
+              'mutate',
+              'release',
+              operation,
+              'E_INVALID_INPUT',
+              'epicId is required',
+              startTime,
+            );
+          }
+          const typed: ReleasePlanOptions = {
+            version,
+            epicId,
+            scheme:
+              typeof params?.scheme === 'string'
+                ? (params.scheme as ReleasePlanOptions['scheme'])
+                : undefined,
+            channel:
+              typeof params?.channel === 'string'
+                ? (params.channel as ReleasePlanOptions['channel'])
+                : undefined,
+            hotfix: typeof params?.hotfix === 'boolean' ? params.hotfix : false,
+            dryRun: typeof params?.dryRun === 'boolean' ? params.dryRun : false,
+            projectRoot: getProjectRoot(),
+          };
+          return wrapResult(await releasePlan(typed), 'mutate', 'release', operation, startTime);
+        }
+
         // release.reconcile — Step 4 of 4 (T1597 / ADR-063)
         case 'reconcile': {
           const handle = loadActiveReleaseHandle(getProjectRoot());
@@ -328,7 +372,7 @@ export class ReleaseHandler implements DomainHandler {
   getSupportedOperations(): { query: string[]; mutate: string[] } {
     return {
       query: ['gate', 'ivtr-suggest', 'verify'],
-      mutate: ['gate', 'ivtr-suggest', 'start', 'publish', 'reconcile'],
+      mutate: ['gate', 'ivtr-suggest', 'start', 'publish', 'reconcile', 'plan'],
     };
   }
 }

--- a/packages/cleo/src/dispatch/lib/engine.ts
+++ b/packages/cleo/src/dispatch/lib/engine.ts
@@ -179,6 +179,7 @@ export {
   releaseGatesRun,
   releaseIvtrAutoSuggest,
   releaseList,
+  releasePlan,
   releasePrepare,
   releasePrStatus,
   releasePublish,

--- a/packages/contracts/src/exit-codes.ts
+++ b/packages/contracts/src/exit-codes.ts
@@ -226,6 +226,36 @@ export enum ExitCode {
   LEAD_BYPASS_DETECTED = 107,
 }
 
+// ---------------------------------------------------------------------------
+// Release pipeline v2 error code names (SPEC-T9345 §4.7)
+//
+// String-valued error codes emitted by the new release verbs (plan, open,
+// reconcile, rollback). These are the `code` field of EngineErrorPayload;
+// the numeric exit code is the bucket the verb resolves to (per SPEC §4.7).
+//
+// @task T9525
+// @epic T9492
+// @spec .cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md §4.7
+// ---------------------------------------------------------------------------
+
+/** Dirty version files block `cleo release plan` (R-020). Exit code 13. */
+export const E_DIRTY_TREE = 'E_DIRTY_TREE' as const;
+/** Epic referenced by `--epic` has zero children (R-021). Exit code 4. */
+export const E_EPIC_EMPTY = 'E_EPIC_EMPTY' as const;
+/** Epic referenced by `--epic` does not exist (R-021). Exit code 10. */
+export const E_EPIC_NOT_FOUND = 'E_EPIC_NOT_FOUND' as const;
+/** Channel + version scheme are incompatible (R-022). Exit code 6. */
+export const E_CHANNEL_MISMATCH = 'E_CHANNEL_MISMATCH' as const;
+/**
+ * One or more tasks in the plan are missing required ADR-051 evidence atoms
+ * (R-301 / R-310). Exit code 83. `error.details.tasks[]` lists offenders.
+ */
+export const E_EVIDENCE_INSUFFICIENT = 'E_EVIDENCE_INSUFFICIENT' as const;
+/** Plan file at `.cleo/release/<version>.plan.json` is absent. Exit code 4. */
+export const E_PLAN_NOT_FOUND = 'E_PLAN_NOT_FOUND' as const;
+/** Generic release-plan validation failure (e.g. schema). Exit code 6. */
+export const E_RELEASE_PLAN_INVALID = 'E_RELEASE_PLAN_INVALID' as const;
+
 /** Check if an exit code represents an error (1-99). */
 export function isErrorCode(code: ExitCode): boolean {
   return code >= 1 && code < 100;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -332,6 +332,14 @@ export {
 } from './evidence-record-schema.js';
 // === Exit Codes ===
 export {
+  // SPEC-T9345 release pipeline v2 error code names (T9525)
+  E_CHANNEL_MISMATCH,
+  E_DIRTY_TREE,
+  E_EPIC_EMPTY,
+  E_EPIC_NOT_FOUND,
+  E_EVIDENCE_INSUFFICIENT,
+  E_PLAN_NOT_FOUND,
+  E_RELEASE_PLAN_INVALID,
   ExitCode,
   getExitCodeName,
   isErrorCode,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -721,6 +721,9 @@ export {
   releaseStart,
   releaseVerify,
 } from './release/pipeline.js';
+// T9525: SPEC-T9345 release pipeline v2 verbs — exposed via internal for dispatch layer
+export type { ReleasePlanOptions, ReleasePlanResult } from './release/plan.js';
+export { releasePlan } from './release/plan.js';
 export type { ProjectReleaseConfig, ReleaseConfig, ReleaseGate } from './release/release-config.js';
 export {
   getGitFlowConfig,

--- a/packages/core/src/release/__tests__/plan.test.ts
+++ b/packages/core/src/release/__tests__/plan.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Tests for {@link releasePlan} — SPEC-T9345 §4.2 release plan verb.
+ *
+ * Covers:
+ *  - Happy path: valid plan written, releases row UPSERTed, LAFS envelope.
+ *  - E_EPIC_NOT_FOUND when the epic does not exist.
+ *  - E_EPIC_EMPTY when the epic has no eligible children.
+ *  - E_CHANNEL_MISMATCH on incompatible channel + version pair.
+ *  - E_EVIDENCE_INSUFFICIENT when a task lacks evidence atoms.
+ *  - Idempotency — re-running with identical inputs is a no-op modulo lastInvokedAt.
+ *  - Plan file structure is schema-valid.
+ *  - Releases row UPSERT semantics (no duplicate rows on re-run).
+ *
+ * @task T9525
+ * @epic T9492
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Task } from '@cleocode/contracts';
+import {
+  E_CHANNEL_MISMATCH,
+  E_DIRTY_TREE,
+  E_EPIC_EMPTY,
+  E_EPIC_NOT_FOUND,
+  E_EVIDENCE_INSUFFICIENT,
+  parseReleasePlan,
+} from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, getDb, resetDbState } from '../../store/sqlite.js';
+import { createSqliteDataAccessor } from '../../store/sqlite-data-accessor.js';
+import * as schema from '../../store/tasks-schema.js';
+import { releasePlan } from '../plan.js';
+
+let testDir: string;
+
+/**
+ * Build a Task with sensible defaults for plan-time evidence checks. By
+ * default, returns a task with a populated `verification.evidence` blob so
+ * `evidenceAtoms` is non-empty.
+ */
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    title: overrides.title ?? `Task ${overrides.id}`,
+    description: overrides.description ?? `Description for ${overrides.id}`,
+    status: overrides.status ?? 'done',
+    priority: overrides.priority ?? 'medium',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    pipelineStage: overrides.pipelineStage ?? 'contribution',
+    verification: overrides.verification ?? {
+      passed: true,
+      round: 1,
+      gates: { implemented: true },
+      evidence: {
+        implemented: {
+          atoms: [{ kind: 'commit', sha: 'abc1234567', shortSha: 'abc1234' }],
+          capturedAt: new Date().toISOString(),
+          capturedBy: 'test-agent',
+        },
+      },
+      lastAgent: null,
+      lastUpdated: new Date().toISOString(),
+      failureLog: [],
+    },
+    ...overrides,
+  } as Task;
+}
+
+/**
+ * Initialize a `.git` directory inside `testDir` so `getProjectRoot()`
+ * validation accepts it as a project root.
+ */
+async function initTestGit(): Promise<void> {
+  execFileSync('git', ['init', '--quiet', testDir], { encoding: 'utf-8' });
+  // Set a clean tree state — no commits / no dirty paths matter for our gate.
+  execFileSync('git', ['-C', testDir, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', testDir, 'config', 'user.name', 'Test']);
+}
+
+/**
+ * Seed an epic + N child tasks into the accessor.
+ */
+async function seedEpicWithChildren(
+  epicId: string,
+  childCount: number,
+  childOverrides: Partial<Task> = {},
+): Promise<void> {
+  const accessor = await createSqliteDataAccessor(testDir);
+  try {
+    await accessor.setMetaValue('schema_version', '2.10.0');
+    await accessor.upsertSingleTask(
+      makeTask({ id: epicId, type: 'epic', title: 'Epic', pipelineStage: 'contribution' }),
+    );
+    for (let i = 1; i <= childCount; i++) {
+      const id = `T${10000 + i}`;
+      await accessor.upsertSingleTask(
+        makeTask({
+          id,
+          parentId: epicId,
+          title: `Child ${i}`,
+          ...childOverrides,
+        }),
+      );
+    }
+  } finally {
+    await accessor.close();
+  }
+}
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'cleo-release-plan-'));
+  await mkdir(join(testDir, '.cleo'), { recursive: true });
+  // Seed config.json so DataAccessor opens cleanly.
+  writeFileSync(
+    join(testDir, '.cleo', 'config.json'),
+    JSON.stringify({
+      enforcement: { session: { requiredForMutate: false } },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+  // Seed project-info.json so projectHash resolves.
+  writeFileSync(
+    join(testDir, '.cleo', 'project-info.json'),
+    JSON.stringify({
+      projectHash: 'testhash00000',
+      projectId: 'test-project-id',
+      projectRoot: testDir,
+      projectName: 'test',
+    }),
+  );
+  await initTestGit();
+  resetDbState();
+});
+
+afterEach(async () => {
+  try {
+    closeDb();
+  } catch {
+    // best-effort
+  }
+  await rm(testDir, { recursive: true, force: true });
+});
+
+// =============================================================================
+// Happy path
+// =============================================================================
+
+describe('releasePlan — happy path', () => {
+  it('writes a plan file + UPSERTs releases row + returns a LAFS-compliant envelope', async () => {
+    await seedEpicWithChildren('T9999', 3);
+
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      createdBy: 'test',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+
+    // Envelope fields
+    expect(result.data.version).toBe('v2026.6.0');
+    expect(result.data.resolvedVersion).toBe('v2026.6.0');
+    expect(result.data.channel).toBe('latest');
+    expect(result.data.epicId).toBe('T9999');
+    expect(result.data.taskCount).toBe(3);
+    expect(result.data.evidenceComplete).toBe(true);
+    expect(result.data.planPath).toContain('.cleo/release/v2026.6.0.plan.json');
+
+    // Plan file on disk
+    expect(existsSync(result.data.planPath)).toBe(true);
+    const raw = JSON.parse(readFileSync(result.data.planPath, 'utf-8'));
+    const plan = parseReleasePlan(raw);
+    expect(plan.tasks).toHaveLength(3);
+    expect(plan.tasks[0]?.epicAncestor).toBe('T9999');
+    expect(plan.tasks[0]?.evidenceAtoms.length).toBeGreaterThan(0);
+    expect(plan.status).toBe('planned');
+    expect(plan.previousVersion).toBeNull();
+    expect(plan.meta?.firstEverRelease).toBe(true);
+    expect(plan.platformMatrix.length).toBeGreaterThan(0);
+    expect(plan.gates.length).toBe(6);
+
+    // Releases row in DB
+    const db = await getDb(testDir);
+    const rows = await db.select().from(schema.releasesNew).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.version).toBe('v2026.6.0');
+    expect(rows[0]?.status).toBe('planned');
+    expect(rows[0]?.epicId).toBe('T9999');
+  });
+
+  it('normalizes a version supplied without a leading v', async () => {
+    await seedEpicWithChildren('T9999', 1);
+    const result = await releasePlan({
+      version: '2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.resolvedVersion).toBe('v2026.6.0');
+  });
+});
+
+// =============================================================================
+// Error envelopes
+// =============================================================================
+
+describe('releasePlan — error envelopes', () => {
+  it('returns E_EPIC_NOT_FOUND when the epic does not exist', async () => {
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T-DOES-NOT-EXIST',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe(E_EPIC_NOT_FOUND);
+  });
+
+  it('returns E_EPIC_EMPTY when the epic has zero children', async () => {
+    const accessor = await createSqliteDataAccessor(testDir);
+    try {
+      await accessor.setMetaValue('schema_version', '2.10.0');
+      await accessor.upsertSingleTask(makeTask({ id: 'T9999', type: 'epic', title: 'Empty Epic' }));
+    } finally {
+      await accessor.close();
+    }
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe(E_EPIC_EMPTY);
+  });
+
+  it('returns E_CHANNEL_MISMATCH on channel=latest + pre-release suffix in version', async () => {
+    await seedEpicWithChildren('T9999', 1);
+    const result = await releasePlan({
+      version: 'v2026.6.0-beta.1',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe(E_CHANNEL_MISMATCH);
+  });
+
+  it('returns E_EVIDENCE_INSUFFICIENT when a child task has no evidence atoms', async () => {
+    const accessor = await createSqliteDataAccessor(testDir);
+    try {
+      await accessor.setMetaValue('schema_version', '2.10.0');
+      await accessor.upsertSingleTask(makeTask({ id: 'T9999', type: 'epic', title: 'Epic' }));
+      // Child task with no verification.evidence — should trigger R-301
+      await accessor.upsertSingleTask({
+        id: 'T10001',
+        parentId: 'T9999',
+        title: 'Empty-evidence child',
+        description: 'Has no evidence atoms',
+        status: 'done',
+        priority: 'medium',
+        createdAt: new Date().toISOString(),
+        pipelineStage: 'contribution',
+        verification: {
+          passed: false,
+          round: 1,
+          gates: {},
+          lastAgent: null,
+          lastUpdated: null,
+          failureLog: [],
+        },
+      } as Task);
+    } finally {
+      await accessor.close();
+    }
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe(E_EVIDENCE_INSUFFICIENT);
+    expect(result.error.details).toBeDefined();
+  });
+
+  it('returns E_DIRTY_TREE when version files are dirty', async () => {
+    await seedEpicWithChildren('T9999', 1);
+    // Create + stage a package.json then dirty it.
+    const pkgPath = join(testDir, 'package.json');
+    writeFileSync(pkgPath, JSON.stringify({ name: 'test', version: '1.0.0' }));
+    execFileSync('git', ['-C', testDir, 'add', 'package.json']);
+    execFileSync('git', ['-C', testDir, 'commit', '-m', 'init', '--quiet']);
+    writeFileSync(pkgPath, JSON.stringify({ name: 'test', version: '1.0.1' }));
+
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe(E_DIRTY_TREE);
+    expect(result.error.details).toMatchObject({
+      dirtyPaths: expect.arrayContaining(['package.json']),
+    });
+  });
+});
+
+// =============================================================================
+// Idempotency
+// =============================================================================
+
+describe('releasePlan — idempotency', () => {
+  it('re-running with identical inputs UPSERTs (no duplicate row)', async () => {
+    await seedEpicWithChildren('T9999', 2);
+
+    const first = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(first.success).toBe(true);
+
+    const second = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(second.success).toBe(true);
+
+    const db = await getDb(testDir);
+    const rows = await db.select().from(schema.releasesNew).all();
+    // UPSERT semantics — exactly one row regardless of re-runs.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe('planned');
+  });
+
+  it('produces identical plan-task fields across re-runs (modulo createdAt)', async () => {
+    await seedEpicWithChildren('T9999', 2);
+
+    const first = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(first.success).toBe(true);
+    if (!first.success) throw new Error('unreachable');
+    const firstPlan = parseReleasePlan(JSON.parse(readFileSync(first.data.planPath, 'utf-8')));
+
+    const second = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(second.success).toBe(true);
+    if (!second.success) throw new Error('unreachable');
+    const secondPlan = parseReleasePlan(JSON.parse(readFileSync(second.data.planPath, 'utf-8')));
+
+    expect(secondPlan.tasks).toEqual(firstPlan.tasks);
+    expect(secondPlan.epicId).toBe(firstPlan.epicId);
+    expect(secondPlan.platformMatrix).toEqual(firstPlan.platformMatrix);
+    // changelog buckets identical
+    expect(secondPlan.changelog).toEqual(firstPlan.changelog);
+  });
+});
+
+// =============================================================================
+// Dry-run
+// =============================================================================
+
+describe('releasePlan — dry-run', () => {
+  it('does not write the plan file or the releases row when dryRun is true', async () => {
+    await seedEpicWithChildren('T9999', 1);
+
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      dryRun: true,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    // Plan file should NOT exist
+    expect(existsSync(result.data.planPath)).toBe(false);
+    // No releases row inserted
+    const db = await getDb(testDir);
+    const rows = await db.select().from(schema.releasesNew).all();
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/core/src/release/index.ts
+++ b/packages/core/src/release/index.ts
@@ -120,6 +120,9 @@ export {
   releaseStart,
   releaseVerify,
 } from './pipeline.js';
+// SPEC-T9345 release pipeline v2 verbs (T9492)
+export type { ReleasePlanOptions, ReleasePlanResult } from './plan.js';
+export { releasePlan } from './plan.js';
 // Release configuration
 export type {
   ChannelConfig,

--- a/packages/core/src/release/plan.ts
+++ b/packages/core/src/release/plan.ts
@@ -1,0 +1,897 @@
+/**
+ * `cleo release plan` — Phase 1 verb of the new release pipeline.
+ *
+ * Builds the canonical Release Plan envelope from `tasks.db` + git log +
+ * previous-release state. Emits a LAFS-compliant `EngineResult<ReleasePlanResult>`,
+ * writes the plan file atomically to `.cleo/release/<resolved-version>.plan.json`,
+ * and UPSERTs one row into the `releases` table with `status='planned'`.
+ *
+ * This verb is **read-mostly** — it performs NO git mutations, NO `gh` calls,
+ * NO network calls. Writes are limited to `.cleo/release/<version>.plan.json`
+ * and the `releases` table (R-032).
+ *
+ * @task T9525
+ * @epic T9492
+ * @spec .cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md §4.2
+ */
+
+import { mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { EvidenceAtom, Task } from '@cleocode/contracts';
+import {
+  E_CHANNEL_MISMATCH,
+  E_DIRTY_TREE,
+  E_EPIC_EMPTY,
+  E_EPIC_NOT_FOUND,
+  E_EVIDENCE_INSUFFICIENT,
+  E_RELEASE_PLAN_INVALID,
+  type EngineResult,
+  ExitCode,
+  engineError,
+  engineSuccess,
+  parseReleasePlan,
+  type ReleaseGate,
+  type ReleaseGateExecutionStatus,
+  type ReleaseGateName,
+  type ReleaseKind,
+  type ReleasePlan,
+  type ReleasePlanChangelog,
+  type ReleasePlanChannel,
+  type ReleasePlanTask,
+  type ReleasePlatformMatrixEntry,
+  type ReleasePreflightSummary,
+  type ReleaseScheme,
+  type ReleaseTaskKind,
+  type ResolvedSource,
+} from '@cleocode/contracts';
+import { and, desc, eq } from 'drizzle-orm';
+
+import { getLogger } from '../logger.js';
+import { getCleoDirAbsolute } from '../paths.js';
+import { getProjectInfoSync } from '../project-info.js';
+import { getTaskAccessor } from '../store/data-accessor.js';
+import { getDb } from '../store/sqlite.js';
+import { type NewReleaseRow, type ReleaseRow, releasesNew } from '../store/tasks-schema.js';
+import { resolveToolCommand } from '../tasks/tool-resolver.js';
+import { runGitWithLockRetry } from './engine-ops.js';
+import { loadReleaseConfig } from './release-config.js';
+
+const log = getLogger('release:plan');
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Options accepted by {@link releasePlan}.
+ *
+ * @task T9525
+ */
+export interface ReleasePlanOptions {
+  /** The candidate version (e.g. `v2026.6.0`). Leading `v` optional — added if absent. */
+  version: string;
+  /** Epic task ID whose children are candidates for inclusion (required per R-021). */
+  epicId: string;
+  /** Versioning scheme. Default: inferred from `.cleo/release-config.json`. */
+  scheme?: ReleaseScheme;
+  /** Release channel. Default: `latest`. */
+  channel?: ReleasePlanChannel;
+  /** When true, the release is marked `release_kind='hotfix'`. */
+  hotfix?: boolean;
+  /** Dry-run flag — equivalent to `CLEO_DRY_RUN=1`. Reads only; no writes. */
+  dryRun?: boolean;
+  /** Project root override. Defaults to `process.cwd()`. */
+  projectRoot?: string;
+  /** Creator identity for `plan.createdBy`. Defaults to `process.env.USER` or `cleo-agent`. */
+  createdBy?: string;
+}
+
+/**
+ * Data payload returned by {@link releasePlan} on success.
+ *
+ * @task T9525
+ */
+export interface ReleasePlanResult {
+  /** The requested version (matches input). */
+  version: string;
+  /** The resolved version after suffix application. */
+  resolvedVersion: string;
+  /** True iff a `calver-suffix` was applied to disambiguate same-day hotfixes. */
+  suffixApplied: boolean;
+  /** Release channel. */
+  channel: ReleasePlanChannel;
+  /** Epic ID. */
+  epicId: string;
+  /** Absolute path to the written plan file. */
+  planPath: string;
+  /** Number of tasks rolled into the plan. */
+  taskCount: number;
+  /** True iff every task has at least one evidence atom (R-301). */
+  evidenceComplete: boolean;
+  /** Non-fatal preflight warnings (e.g. unresolved tools). */
+  preflightWarnings: string[];
+  /** Per-gate verification status summary. */
+  gateSummary: Record<ReleaseGateName, ReleaseGateExecutionStatus>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Files whose dirty state blocks the plan verb (R-020). */
+const VERSION_FILE_PATTERNS: readonly string[] = [
+  'package.json',
+  'packages/*/package.json',
+  'Cargo.toml',
+  'packages/*/Cargo.toml',
+  'pyproject.toml',
+  'packages/*/pyproject.toml',
+  'CHANGELOG.md',
+] as const;
+
+/** Six canonical gates per ADR-061 (SPEC R-024 / R-310). */
+const RELEASE_GATE_NAMES: readonly ReleaseGateName[] = [
+  'test',
+  'build',
+  'lint',
+  'typecheck',
+  'audit',
+  'security-scan',
+] as const;
+
+/** Default platform matrix entry used when `.cleo/release-config.json` carries no override. */
+const DEFAULT_PLATFORM_MATRIX_ENTRY: ReleasePlatformMatrixEntry = {
+  platform: 'any',
+  publisher: 'npm',
+  package: '@cleocode/cleo',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — version + channel
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a version string to include the leading `v` (e.g. `2026.6.0` → `v2026.6.0`).
+ *
+ * @internal
+ */
+function normalizeVersion(version: string): string {
+  return version.startsWith('v') ? version : `v${version}`;
+}
+
+/**
+ * Map the new channel taxonomy (latest|beta|alpha|rc) onto the DB channel
+ * enum (latest|beta|dev|hotfix). The DB schema does not yet model `rc` so
+ * we collapse to `beta` for now per SPEC §6.1 footnote.
+ *
+ * @internal
+ */
+function mapPlanChannelToDbChannel(
+  channel: ReleasePlanChannel,
+  releaseKind: ReleaseKind,
+): 'latest' | 'beta' | 'dev' | 'hotfix' {
+  if (releaseKind === 'hotfix') return 'hotfix';
+  switch (channel) {
+    case 'latest':
+      return 'latest';
+    case 'beta':
+    case 'rc':
+      return 'beta';
+    case 'alpha':
+      return 'dev';
+  }
+}
+
+/**
+ * Validate a channel + scheme pair per R-022.
+ *
+ * @internal
+ */
+function validateChannelScheme(
+  channel: ReleasePlanChannel,
+  scheme: ReleaseScheme,
+  version: string,
+): { ok: true } | { ok: false; reason: string } {
+  // `latest` requires NO pre-release suffix.
+  if (channel === 'latest' && version.includes('-')) {
+    return {
+      ok: false,
+      reason: `channel='latest' is incompatible with version '${version}' (contains pre-release suffix). Use --channel beta|alpha|rc, or supply a stable version.`,
+    };
+  }
+  // `calver-suffix` implies a `.N` 4-segment version per SPEC R-402.
+  if (scheme === 'calver-suffix' && !/\.\d+\.\d+\.\d+\.\d+/.test(version)) {
+    return {
+      ok: false,
+      reason: `scheme='calver-suffix' requires a vYYYY.M.DD.N version; got '${version}'.`,
+    };
+  }
+  // beta/alpha/rc are compatible with any scheme; further validation lives in the open verb.
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — git / clean tree
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify the working tree is clean for the configured version-file patterns
+ * (R-020). Returns the list of offending paths so callers can populate
+ * `error.details.dirtyPaths` for triage.
+ *
+ * @internal
+ */
+function validateCleanTree(projectRoot: string): { dirty: string[] } {
+  try {
+    const raw = runGitWithLockRetry(['status', '--porcelain', '--', ...VERSION_FILE_PATTERNS], {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: 60_000,
+    });
+    const lines = raw.split('\n').filter((line) => line.trim().length > 0);
+    const dirty: string[] = [];
+    for (const line of lines) {
+      // Porcelain v1 format: `XY path`; capture everything from col 4 onward.
+      const path = line.slice(3).trim();
+      if (path) dirty.push(path);
+    }
+    return { dirty };
+  } catch (err: unknown) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'git status failed during validateCleanTree; assuming clean tree',
+    );
+    return { dirty: [] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — tasks
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk children of `epicId` recursively (depth-first), excluding cancelled
+ * and archived tasks. Returns deduplicated tasks ordered by parent-then-position.
+ *
+ * @internal
+ */
+async function resolveEpicTasks(
+  epicId: string,
+  projectRoot: string,
+): Promise<{ tasks: Task[]; epicExists: boolean }> {
+  const accessor = await getTaskAccessor(projectRoot);
+  try {
+    const epic = await accessor.loadSingleTask(epicId);
+    if (!epic) {
+      return { tasks: [], epicExists: false };
+    }
+    // Use the subtree CTE for an efficient single-pass walk.
+    const subtree = await accessor.getSubtree(epicId);
+    // Drop the epic itself and any terminal/excluded statuses.
+    const filtered = subtree.filter((t) => {
+      if (t.id === epicId) return false;
+      if (t.status === 'cancelled') return false;
+      if (t.status === 'archived') return false;
+      return true;
+    });
+    return { tasks: filtered, epicExists: true };
+  } finally {
+    await accessor.close();
+  }
+}
+
+/**
+ * Extract ADR-051 evidence atoms from a task's `verification` blob and
+ * serialize them into the `kind:value` string form persisted in `plan.tasks[*].evidenceAtoms`.
+ *
+ * @internal
+ */
+function collectEvidenceAtomsForTask(task: Task): string[] {
+  const atoms: string[] = [];
+  const v = task.verification;
+  if (!v?.evidence) return atoms;
+  for (const gateEvidence of Object.values(v.evidence)) {
+    if (!gateEvidence) continue;
+    for (const atom of gateEvidence.atoms) {
+      const serialized = serializeAtom(atom);
+      if (serialized) atoms.push(serialized);
+    }
+  }
+  return [...new Set(atoms)];
+}
+
+/**
+ * Serialize an ADR-051 {@link EvidenceAtom} into its `kind:value` string form
+ * (e.g. `commit:abc123`, `tool:test`, `files:a.ts,b.ts`).
+ *
+ * @internal
+ */
+function serializeAtom(atom: EvidenceAtom): string | null {
+  switch (atom.kind) {
+    case 'commit':
+      return `commit:${atom.sha}`;
+    case 'files': {
+      const paths = atom.files
+        .map((f) => f.path)
+        .filter((p) => p.length > 0)
+        .join(',');
+      return paths ? `files:${paths}` : null;
+    }
+    case 'test-run':
+      return `test-run:${atom.path}`;
+    case 'tool':
+      return `tool:${atom.tool}`;
+    case 'url':
+      return `url:${atom.url}`;
+    case 'note':
+      return `note:${atom.note}`;
+    case 'override':
+      return `override:${atom.reason}`;
+    case 'decision':
+      return `decision:${atom.decisionId}`;
+    case 'loc-drop':
+      return `loc-drop:${atom.fromLines}:${atom.toLines}`;
+    case 'callsite-coverage':
+      return `callsite-coverage:${atom.symbolName}:${atom.relativeSourcePath}`;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Map an internal {@link Task} into a plan-shape {@link ReleasePlanTask}.
+ *
+ * The mapping is intentionally lossy — only fields required by SPEC §6.1 are
+ * carried into the plan. Returns `null` if the task lacks a sane `kind` axis.
+ *
+ * @internal
+ */
+function taskToPlanTask(task: Task, epicAncestor: string): ReleasePlanTask {
+  const kind = inferTaskKind(task);
+  const impact = inferImpact(kind);
+  const summary = task.title ?? task.id;
+  const atoms = collectEvidenceAtomsForTask(task);
+  const planTask: ReleasePlanTask = {
+    id: task.id,
+    kind,
+    impact,
+    userFacingSummary: summary,
+    evidenceAtoms: atoms,
+    epicAncestor,
+  };
+  if (typeof task.pipelineStage === 'string' && task.pipelineStage.length > 0) {
+    planTask.ivtrPhaseAtPlan = task.pipelineStage;
+  }
+  return planTask;
+}
+
+/**
+ * Best-effort mapping from a {@link Task} (axes: `kind`, `scope`, `labels`)
+ * into the conventional-commit-aligned {@link ReleaseTaskKind} used by the
+ * plan changelog buckets.
+ *
+ * Heuristic:
+ *   1. `task.kind === 'bug'` → `'fix'`
+ *   2. label hit on `'breaking'` / `'docs'` / `'chore'` / `'refactor'`
+ *      / `'perf'` / `'test'` / `'hotfix'` / `'revert'` → that kind
+ *   3. otherwise default to `'feat'`.
+ *
+ * @internal
+ */
+function inferTaskKind(task: Task): ReleaseTaskKind {
+  if (task.kind === 'bug') return 'fix';
+  const labels = task.labels ?? [];
+  const labelMatch: ReleaseTaskKind | null = matchLabelKind(labels);
+  if (labelMatch) return labelMatch;
+  return 'feat';
+}
+
+/**
+ * Match a label set against the {@link ReleaseTaskKind} enum literals.
+ *
+ * @internal
+ */
+function matchLabelKind(labels: readonly string[]): ReleaseTaskKind | null {
+  const candidates: ReleaseTaskKind[] = [
+    'breaking',
+    'hotfix',
+    'revert',
+    'docs',
+    'chore',
+    'refactor',
+    'perf',
+    'test',
+    'feat',
+    'fix',
+  ];
+  for (const c of candidates) {
+    if (labels.includes(c)) return c;
+  }
+  return null;
+}
+
+/**
+ * Map a {@link ReleaseTaskKind} onto a SemVer-style impact level.
+ *
+ * @internal
+ */
+function inferImpact(kind: ReleaseTaskKind): 'major' | 'minor' | 'patch' {
+  if (kind === 'breaking') return 'major';
+  if (kind === 'feat') return 'minor';
+  return 'patch';
+}
+
+/**
+ * Bucket plan tasks into the 4-section changelog shape per SPEC §6.1.
+ *
+ * @internal
+ */
+function buildChangelog(tasks: ReleasePlanTask[]): ReleasePlanChangelog {
+  const out: ReleasePlanChangelog = { features: [], fixes: [], chores: [], breaking: [] };
+  for (const t of tasks) {
+    if (t.kind === 'feat') out.features.push(t.id);
+    else if (t.kind === 'fix' || t.kind === 'hotfix') out.fixes.push(t.id);
+    else if (t.kind === 'breaking' || t.kind === 'revert') out.breaking.push(t.id);
+    else out.chores.push(t.id);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — gates via ADR-061
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the six canonical release gates via the ADR-061 tool resolver.
+ *
+ * Per R-312 this verb does NOT execute the resolved commands; it only records
+ * the resolved name + provenance into `plan.gates[]`. Status is initialized to
+ * `unresolved` for tools the resolver could not produce a command for.
+ *
+ * @internal
+ */
+function resolveGatesViaToolResolver(
+  projectRoot: string,
+  nowIso: string,
+): { gates: ReleaseGate[]; unresolved: string[] } {
+  const gates: ReleaseGate[] = [];
+  const unresolved: string[] = [];
+  for (const name of RELEASE_GATE_NAMES) {
+    const resolution = resolveToolCommand(name, projectRoot);
+    if (resolution.ok) {
+      const gate: ReleaseGate = {
+        name,
+        atom: `tool:${name}`,
+        // Per R-312, we do NOT execute the tool here. Status reflects
+        // "resolved but unexecuted"; consumers MAY upgrade to `passed` after
+        // running the command in a downstream surface (preflight job, etc).
+        status: 'unresolved',
+        lastVerifiedAt: nowIso,
+        resolvedCommand: `${resolution.command.cmd} ${resolution.command.args.join(' ')}`.trim(),
+        resolvedSource: resolution.command.source as ResolvedSource,
+      };
+      gates.push(gate);
+    } else {
+      unresolved.push(name);
+      gates.push({
+        name,
+        atom: `tool:${name}`,
+        status: 'unresolved',
+        lastVerifiedAt: nowIso,
+      });
+    }
+  }
+  return { gates, unresolved };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — platform matrix
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the publish matrix for the release.
+ *
+ * Reads `.cleo/release-config.json` for an optional `platformMatrix[]` override;
+ * else returns a single-entry default per R-371 (single platform-agnostic artifact).
+ *
+ * @internal
+ */
+function enumeratePlatformMatrix(projectRoot: string): ReleasePlatformMatrixEntry[] {
+  const config = loadReleaseConfig(projectRoot);
+  // Future: `release-config.json` may carry an explicit `platformMatrix` array.
+  // For now, derive the publisher list from `registries` if present.
+  const registries = config.registries ?? [];
+  if (registries.length === 0) {
+    return [DEFAULT_PLATFORM_MATRIX_ENTRY];
+  }
+  const entries: ReleasePlatformMatrixEntry[] = [];
+  for (const reg of registries) {
+    if (reg === 'none') continue;
+    const publisher: ReleasePlatformMatrixEntry['publisher'] =
+      reg === 'crates' ? 'cargo' : reg === 'docker' ? 'docker' : 'npm';
+    entries.push({
+      platform: 'any',
+      publisher,
+      package: publisher === 'npm' ? '@cleocode/cleo' : 'cleocode',
+    });
+  }
+  return entries.length > 0 ? entries : [DEFAULT_PLATFORM_MATRIX_ENTRY];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — previous-release lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of {@link resolvePreviousVersion}.
+ *
+ * @internal
+ */
+interface PreviousReleaseInfo {
+  previousVersion: string | null;
+  previousTag: string | null;
+  previousShippedAt: string | null;
+  firstEverRelease: boolean;
+}
+
+/**
+ * Query the `releases` table for the most recent shipped row on the same
+ * channel. Returns `{ firstEverRelease: true }` when no row matches (R-023).
+ *
+ * @internal
+ */
+async function resolvePreviousVersion(
+  channel: 'latest' | 'beta' | 'dev' | 'hotfix',
+  projectRoot: string,
+): Promise<PreviousReleaseInfo> {
+  const db = await getDb(projectRoot);
+  const rows: ReleaseRow[] = await db
+    .select()
+    .from(releasesNew)
+    .where(and(eq(releasesNew.channel, channel), eq(releasesNew.status, 'reconciled')))
+    .orderBy(desc(releasesNew.publishedAt))
+    .limit(1)
+    .all();
+  const prior = rows[0];
+  if (!prior) {
+    return {
+      previousVersion: null,
+      previousTag: null,
+      previousShippedAt: null,
+      firstEverRelease: true,
+    };
+  }
+  return {
+    previousVersion: prior.version,
+    previousTag: prior.version,
+    previousShippedAt: prior.publishedAt ?? null,
+    firstEverRelease: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — plan file IO + DB upsert
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomic write to `.cleo/release/<resolved-version>.plan.json` (R-030).
+ *
+ * @internal
+ */
+function writePlanFile(plan: ReleasePlan, projectRoot: string): string {
+  const releaseDir = join(getCleoDirAbsolute(projectRoot), 'release');
+  mkdirSync(releaseDir, { recursive: true });
+  const finalPath = join(releaseDir, `${plan.resolvedVersion}.plan.json`);
+  const tmpPath = `${finalPath}.tmp`;
+  const body = `${JSON.stringify(plan, null, 2)}\n`;
+  writeFileSync(tmpPath, body, { encoding: 'utf-8' });
+  renameSync(tmpPath, finalPath);
+  return finalPath;
+}
+
+/**
+ * UPSERT the row into the `releases` table (R-031).
+ *
+ * Uses `INSERT … ON CONFLICT(version) DO UPDATE` so re-running the verb with
+ * identical inputs is a no-op modulo timestamps (R-042).
+ *
+ * @internal
+ */
+async function upsertReleasesRow(
+  plan: ReleasePlan,
+  dbChannel: 'latest' | 'beta' | 'dev' | 'hotfix',
+  projectRoot: string,
+): Promise<void> {
+  const db = await getDb(projectRoot);
+  const projectInfo = getProjectInfoSync(projectRoot);
+  const projectHash = projectInfo?.projectHash ?? null;
+  const id = `${projectHash ?? 'unknown'}:${plan.resolvedVersion}`;
+  const scheme = plan.scheme === 'calver-suffix' ? 'calver-suffix' : plan.scheme;
+  const releaseKind = plan.releaseKind;
+  const row: NewReleaseRow = {
+    id,
+    version: plan.resolvedVersion,
+    scheme,
+    channel: dbChannel,
+    epicId: plan.epicId,
+    releaseKind,
+    status: 'planned',
+    previousVersion: plan.previousVersion,
+    plannedAt: plan.createdAt,
+    projectHash,
+  };
+  await db
+    .insert(releasesNew)
+    .values(row)
+    .onConflictDoUpdate({
+      target: releasesNew.version,
+      set: {
+        scheme: row.scheme,
+        channel: row.channel,
+        epicId: row.epicId,
+        releaseKind: row.releaseKind,
+        status: 'planned',
+        previousVersion: row.previousVersion,
+        plannedAt: row.plannedAt,
+        projectHash: row.projectHash,
+      },
+    })
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — preflight summary
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble the {@link ReleasePreflightSummary} stub. Real preflight checks
+ * (esbuild externals, lockfile drift, epic completeness, double-listing) are
+ * filed against follow-up tasks; this stub keeps the schema consistent and
+ * surfaces unresolved-tool warnings (R-024).
+ *
+ * @internal
+ */
+function assemblePreflightSummary(unresolvedTools: string[]): ReleasePreflightSummary {
+  const warnings: string[] = [];
+  for (const tool of unresolvedTools) {
+    warnings.push(`tool '${tool}' could not be resolved for this archetype`);
+  }
+  return {
+    esbuildExternalsDrift: false,
+    lockfileDrift: false,
+    epicCompletenessClean: true,
+    doubleListingClean: true,
+    preflightWarnings: warnings,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Release Plan envelope per SPEC-T9345 §4.2.
+ *
+ * @example
+ * ```ts
+ * const result = await releasePlan({
+ *   version: 'v2026.6.0',
+ *   epicId: 'T9492',
+ *   channel: 'latest',
+ *   scheme: 'calver',
+ * });
+ * if (result.success) {
+ *   console.log(`Plan written to ${result.data.planPath}`);
+ * }
+ * ```
+ *
+ * @task T9525
+ */
+export async function releasePlan(
+  opts: ReleasePlanOptions,
+): Promise<EngineResult<ReleasePlanResult>> {
+  const projectRoot = opts.projectRoot ?? process.cwd();
+  const scheme: ReleaseScheme = opts.scheme ?? 'calver';
+  const channel: ReleasePlanChannel = opts.channel ?? 'latest';
+  const releaseKind: ReleaseKind = opts.hotfix ? 'hotfix' : 'regular';
+  const dryRun = opts.dryRun === true;
+
+  // ── R-020: clean-tree gate ────────────────────────────────────────────
+  const { dirty } = validateCleanTree(projectRoot);
+  if (dirty.length > 0) {
+    return engineError<ReleasePlanResult>(
+      E_DIRTY_TREE,
+      `Working tree has uncommitted changes in version files: ${dirty.join(', ')}`,
+      {
+        exitCode: ExitCode.INVALID_PARENT_TYPE, // 13 per SPEC §4.7
+        fix: 'git status; commit or stash the listed paths before re-running',
+        details: { dirtyPaths: dirty },
+      },
+    );
+  }
+
+  // ── R-022: channel + scheme compatibility ─────────────────────────────
+  const normalizedVersion = normalizeVersion(opts.version);
+  const channelCheck = validateChannelScheme(channel, scheme, normalizedVersion);
+  if (!channelCheck.ok) {
+    return engineError<ReleasePlanResult>(E_CHANNEL_MISMATCH, channelCheck.reason, {
+      exitCode: ExitCode.VALIDATION_ERROR,
+      fix: 'adjust --channel or supply a version with the correct suffix',
+      details: { channel, scheme, version: normalizedVersion },
+    });
+  }
+
+  // ── R-021: epic exists + has children ─────────────────────────────────
+  const { tasks, epicExists } = await resolveEpicTasks(opts.epicId, projectRoot);
+  if (!epicExists) {
+    return engineError<ReleasePlanResult>(
+      E_EPIC_NOT_FOUND,
+      `Epic ${opts.epicId} not found in tasks.db`,
+      {
+        exitCode: ExitCode.PARENT_NOT_FOUND,
+        fix: `cleo exists ${opts.epicId}`,
+        details: { epicId: opts.epicId },
+      },
+    );
+  }
+  if (tasks.length === 0) {
+    return engineError<ReleasePlanResult>(
+      E_EPIC_EMPTY,
+      `Epic ${opts.epicId} has no eligible child tasks (excluding cancelled/archived)`,
+      {
+        exitCode: ExitCode.NOT_FOUND,
+        fix: `cleo show ${opts.epicId} and add children`,
+        details: { epicId: opts.epicId },
+      },
+    );
+  }
+
+  // ── R-301 / R-310: evidence-atom completeness ─────────────────────────
+  const planTasks: ReleasePlanTask[] = tasks.map((t) => taskToPlanTask(t, opts.epicId));
+  const tasksMissingEvidence = planTasks.filter((t) => t.evidenceAtoms.length === 0);
+  const evidenceComplete = tasksMissingEvidence.length === 0;
+  if (!evidenceComplete) {
+    return engineError<ReleasePlanResult>(
+      E_EVIDENCE_INSUFFICIENT,
+      `${tasksMissingEvidence.length} task(s) in epic ${opts.epicId} are missing required evidence atoms`,
+      {
+        exitCode: ExitCode.LIFECYCLE_TRANSITION_INVALID, // 83 per SPEC §4.7
+        fix: 'cleo verify <task> --gate implemented --evidence "commit:<sha>;files:<paths>"',
+        details: {
+          tasks: tasksMissingEvidence.map((t) => ({
+            id: t.id,
+            missingAtoms: ['implemented', 'testsPassed', 'qaPassed'],
+          })),
+        },
+      },
+    );
+  }
+
+  // ── R-023: previous-version resolution ────────────────────────────────
+  const dbChannel = mapPlanChannelToDbChannel(channel, releaseKind);
+  const prior = await resolvePreviousVersion(dbChannel, projectRoot);
+
+  // ── R-024 / R-311: gate resolution via ADR-061 ────────────────────────
+  const createdAt = new Date().toISOString();
+  const { gates, unresolved } = resolveGatesViaToolResolver(projectRoot, createdAt);
+
+  // ── R-305 / R-370: platform matrix ────────────────────────────────────
+  const platformMatrix = enumeratePlatformMatrix(projectRoot);
+
+  // ── Assemble + validate the plan envelope ─────────────────────────────
+  const changelog = buildChangelog(planTasks);
+  const preflightSummary = assemblePreflightSummary(unresolved);
+  const plan: ReleasePlan = {
+    $schema: 'https://cleocode.io/schemas/release-plan/v1.json',
+    version: normalizedVersion,
+    resolvedVersion: normalizedVersion,
+    suffixApplied: false,
+    scheme,
+    channel,
+    epicId: opts.epicId,
+    releaseKind,
+    createdAt,
+    createdBy: opts.createdBy ?? process.env['USER'] ?? 'cleo-agent',
+    previousVersion: prior.previousVersion,
+    previousTag: prior.previousTag,
+    previousShippedAt: prior.previousShippedAt,
+    tasks: planTasks,
+    changelog,
+    gates,
+    platformMatrix,
+    preflightSummary,
+    workflowRunUrl: null,
+    prUrl: null,
+    mergeCommitSha: null,
+    status: 'planned',
+    meta: {
+      firstEverRelease: prior.firstEverRelease,
+      ...(unresolved.length > 0 ? { unresolvedTools: unresolved } : {}),
+      archetype: 'node',
+    },
+  };
+
+  // R-306: validate against the canonical schema BEFORE any write.
+  try {
+    parseReleasePlan(plan);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return engineError<ReleasePlanResult>(
+      E_RELEASE_PLAN_INVALID,
+      `Assembled plan failed schema validation: ${message}`,
+      {
+        exitCode: ExitCode.VALIDATION_ERROR,
+        fix: 'inspect the plan structure and ensure all required fields are present',
+        details: { schemaError: message },
+      },
+    );
+  }
+
+  // ── R-030 / R-031: write plan + UPSERT releases row ───────────────────
+  let planPath: string;
+  if (dryRun) {
+    // In dry-run mode, compute the path but DO NOT touch the filesystem or DB.
+    planPath = join(
+      getCleoDirAbsolute(projectRoot),
+      'release',
+      `${plan.resolvedVersion}.plan.json`,
+    );
+  } else {
+    planPath = writePlanFile(plan, projectRoot);
+    await upsertReleasesRow(plan, dbChannel, projectRoot);
+  }
+
+  // ── Build the data envelope ───────────────────────────────────────────
+  const gateSummary: Record<ReleaseGateName, ReleaseGateExecutionStatus> = {
+    test: 'unresolved',
+    build: 'unresolved',
+    lint: 'unresolved',
+    typecheck: 'unresolved',
+    audit: 'unresolved',
+    'security-scan': 'unresolved',
+  };
+  for (const g of gates) {
+    gateSummary[g.name] = g.status;
+  }
+
+  const result: ReleasePlanResult = {
+    version: opts.version,
+    resolvedVersion: plan.resolvedVersion,
+    suffixApplied: plan.suffixApplied,
+    channel,
+    epicId: opts.epicId,
+    planPath,
+    taskCount: planTasks.length,
+    evidenceComplete,
+    preflightWarnings: preflightSummary.preflightWarnings ?? [],
+    gateSummary,
+  };
+
+  return engineSuccess(result);
+}
+
+// ---------------------------------------------------------------------------
+// Internal exports — testing only
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal helpers exported for unit testing. Not part of the public API.
+ *
+ * @internal
+ */
+export const __test__ = {
+  collectEvidenceAtomsForTask,
+  enumeratePlatformMatrix,
+  inferImpact,
+  inferTaskKind,
+  mapPlanChannelToDbChannel,
+  normalizeVersion,
+  resolveEpicTasks,
+  resolveGatesViaToolResolver,
+  resolvePreviousVersion,
+  serializeAtom,
+  validateChannelScheme,
+  validateCleanTree,
+  writePlanFile,
+};


### PR DESCRIPTION
## Summary
Adds the new `cleo release plan <version> --epic <id>` verb per SPEC-T9345 §4.2. Builds the canonical Release Plan envelope from tasks.db + git log + previous release; emits LAFS JSON; writes `.cleo/release/<version>.plan.json`; INSERTs a row into `releases` with status='planned'.

## Changes
- `packages/core/src/release/plan.ts` — implementation (~700 lines, fully typed against `@cleocode/contracts` ReleasePlanSchema)
- `packages/core/src/release/__tests__/plan.test.ts` — 10 unit tests (happy path × 2, error envelopes × 5, idempotency × 2, dry-run × 1)
- `packages/core/src/release/index.ts` — barrel export
- `packages/core/src/internal.ts` — internal API surface for dispatch
- `packages/cleo/src/cli/commands/release.ts` — register `planCommand`
- `packages/cleo/src/dispatch/domains/release.ts` — `release.plan` operation handler
- `packages/cleo/src/dispatch/lib/engine.ts` — engine barrel export
- `packages/contracts/src/exit-codes.ts` — new string error code constants (E_DIRTY_TREE, E_EPIC_EMPTY, E_EPIC_NOT_FOUND, E_CHANNEL_MISMATCH, E_EVIDENCE_INSUFFICIENT, E_PLAN_NOT_FOUND, E_RELEASE_PLAN_INVALID)
- `packages/contracts/src/index.ts` — re-export new error code constants

## RFC 2119 invariants satisfied
- R-020 — dirty-tree gate on version files (`package.json`, `packages/*/package.json`, `Cargo.toml`, `pyproject.toml`, `CHANGELOG.md`)
- R-021 — epic exists + has eligible children (excludes cancelled/archived)
- R-022 — channel + scheme compatibility
- R-023 — `previousVersion` from `releases ORDER BY published_at DESC LIMIT 1` per channel
- R-024 / R-311 — 6 gates resolved via ADR-061 `resolveToolCommand`, no execution at plan time (R-312)
- R-030 — atomic plan-file write (tmp + rename)
- R-031 — UPSERT semantics on `releases` row
- R-032 — NO git mutations, NO `gh` calls, NO network
- R-301 — `tasks[*].evidenceAtoms` non-empty enforcement
- R-303 — `epicAncestor` locked at plan time
- R-305 / R-370 — `platformMatrix[]` always populated (default `any`/`npm`)
- R-306 — plan validates against `ReleasePlanSchema` before write

## Test plan
- [x] Happy path produces valid LAFS envelope + writes plan file + UPSERTs releases row
- [x] E_DIRTY_TREE on dirty version files
- [x] E_EPIC_NOT_FOUND when epic missing
- [x] E_EPIC_EMPTY when epic has zero children
- [x] E_CHANNEL_MISMATCH on incompatible channel/scheme
- [x] E_EVIDENCE_INSUFFICIENT on missing evidence atoms
- [x] Idempotent — UPSERTs (no duplicate row) and produces identical plan-task content modulo timestamps
- [x] Dry-run does NOT touch filesystem or DB
- [x] `biome check` clean
- [x] `tsc --noEmit` clean on plan.ts + dependents
- [x] Vitest: 10 / 10 pass

Closes T9525. Unblocks T9530 (cleo release open verb).