### PR TITLE
feat(T9533): release-publish.yml.tmpl GHA template

### DIFF
--- a/packages/cleo/templates/workflows/README.md
+++ b/packages/cleo/templates/workflows/README.md
@@ -12,7 +12,7 @@ local `.cleo/project-context.json` and the ADR-061 tool resolver.
 | Template                          | SPEC section | Purpose                                                |
 |-----------------------------------|--------------|--------------------------------------------------------|
 | `release-prepare.yml.tmpl`        | §5.1         | Cut release branch, bump version, open bump-PR.        |
-| `release-publish.yml.tmpl`        | §5.2 *(T9533, future)* | Publish + tag once the bump-PR is merged.    |
+| `release-publish.yml.tmpl`        | §5.2         | Publish + tag once the bump-PR is merged.              |
 | `release-fanout.yml.tmpl`         | §5.3 *(T9534, future)* | Best-effort post-publish fanout (docs, docker, etc.). |
 | `release-reconcile.yml.tmpl`      | §5.4 *(T9535, future)* | Provenance reconciliation across systems.    |
 
@@ -35,16 +35,18 @@ local `.cleo/project-context.json` and the ADR-061 tool resolver.
 All four templates draw from the same placeholder vocabulary. Unused
 placeholders for a given template are silently ignored by the scaffolder.
 
-| Placeholder         | Source                                                 | Default                              | Example                              |
-|---------------------|--------------------------------------------------------|--------------------------------------|--------------------------------------|
-| `{{NODE_VERSION}}`  | `.cleo/project-context.json` `node.version`            | `22.x`                               | `"22.x"`                             |
-| `{{INSTALL_CMD}}`   | ADR-061 archetype defaults (`primaryType`-specific)    | `pnpm install --frozen-lockfile`     | `pnpm install --frozen-lockfile`     |
-| `{{LINT_CMD}}`      | ADR-061 `tool:lint` resolution                         | `pnpm run lint`                      | `pnpm biome ci .`                    |
-| `{{TYPECHECK_CMD}}` | ADR-061 `tool:typecheck` resolution                    | `pnpm run typecheck`                 | `pnpm run typecheck`                 |
-| `{{TEST_CMD}}`      | ADR-061 `tool:test` resolution                         | `pnpm run test`                      | `pnpm run test`                      |
-| `{{BUILD_CMD}}`     | ADR-061 `tool:build` resolution                        | `pnpm run build`                     | `pnpm run build`                     |
-| `{{BRANCH_PREFIX}}` | `release.branchPrefix` in `.cleo/config.json`          | `release`                            | `release`                            |
-| `{{PR_LABEL}}`      | `release.prLabel` in `.cleo/config.json`               | `release`                            | `release`                            |
+| Placeholder           | Source                                                 | Default                              | Example                              |
+|-----------------------|--------------------------------------------------------|--------------------------------------|--------------------------------------|
+| `{{NODE_VERSION}}`    | `.cleo/project-context.json` `node.version`            | `22.x`                               | `"22.x"`                             |
+| `{{INSTALL_CMD}}`     | ADR-061 archetype defaults (`primaryType`-specific)    | `pnpm install --frozen-lockfile`     | `pnpm install --frozen-lockfile`     |
+| `{{LINT_CMD}}`        | ADR-061 `tool:lint` resolution                         | `pnpm run lint`                      | `pnpm biome ci .`                    |
+| `{{TYPECHECK_CMD}}`   | ADR-061 `tool:typecheck` resolution                    | `pnpm run typecheck`                 | `pnpm run typecheck`                 |
+| `{{TEST_CMD}}`        | ADR-061 `tool:test` resolution                         | `pnpm run test`                      | `pnpm run test`                      |
+| `{{BUILD_CMD}}`       | ADR-061 `tool:build` resolution                        | `pnpm run build`                     | `pnpm run build`                     |
+| `{{BRANCH_PREFIX}}`   | `release.branchPrefix` in `.cleo/config.json`          | `release`                            | `release`                            |
+| `{{PR_LABEL}}`        | `release.prLabel` in `.cleo/config.json`               | `release`                            | `release`                            |
+| `{{NPM_PUBLISH_CMD}}` | `release.npmPublishCmd` in `.cleo/config.json`         | `pnpm publish --access public --tag latest` | `pnpm publish -r --access public --tag latest` |
+| `{{PUBLISHERS}}`      | `release.publishers` in `.cleo/config.json`            | `npm`                                | `npm cargo`                          |
 
 Source precedence (highest first):
 
@@ -115,11 +117,13 @@ declared permissions.
 ## Cross-references
 
 - SPEC: `.cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md`
-  - §5.1 → `release-prepare.yml.tmpl`
-  - §5.2 → `release-publish.yml.tmpl` *(T9533)*
+  - §5.1 → `release-prepare.yml.tmpl` *(T9532, landed)*
+  - §5.2 → `release-publish.yml.tmpl` *(T9533, current)*
   - §5.3 → `release-fanout.yml.tmpl` *(T9534)*
   - §5.4 → `release-reconcile.yml.tmpl` *(T9535)*
 - ADR-061 (tool resolver): governs `tool:*` placeholder resolution.
 - ADR-073 (release pipeline v2): umbrella architectural decision.
 - T9531: `cleo init --workflows` scaffold command (consumes these templates).
-- T9532: this template + README + snapshot test (current task).
+- T9532: `release-prepare.yml.tmpl` + README skeleton + snapshot test.
+- T9533: `release-publish.yml.tmpl` + README placeholders + snapshot test
+  (current task — eliminates F6 tag-on-pre-merge-SHA race by construction).

--- a/packages/cleo/templates/workflows/release-publish.yml.tmpl
+++ b/packages/cleo/templates/workflows/release-publish.yml.tmpl
@@ -1,0 +1,388 @@
+# CLEO release pipeline — Publish + tag workflow.
+#
+# Generated from packages/cleo/templates/workflows/release-publish.yml.tmpl by
+# `cleo init --workflows` (T9531). DO NOT EDIT the rendered file directly —
+# extend via `.workflow-overrides.yml` per SPEC-T9345 R-260.
+#
+# Implements SPEC-T9345-release-pipeline-v2.md §5.2 (R-220 — R-235, R-260 —
+# R-263). Triggers on push to main when the commit subject matches the
+# canonical `release: prepare v<version>` prefix produced by
+# release-prepare.yml. Tags ONLY after `gh pr view` confirms state=MERGED
+# AND mergeCommit.oid == $GITHUB_SHA — this eliminates the F6 race
+# (tag-on-pre-merge-SHA) by construction.
+#
+# Placeholders (replaced at scaffold time — see workflows/README.md):
+#   <NODE_VERSION>      Node.js version    (e.g. "22.x")
+#   <INSTALL_CMD>       Install command    (e.g. "pnpm install --frozen-lockfile")
+#   <LINT_CMD>          tool:lint          (ADR-061 resolved)
+#   <TYPECHECK_CMD>     tool:typecheck     (ADR-061 resolved)
+#   <TEST_CMD>          tool:test          (ADR-061 resolved)
+#   <BUILD_CMD>         tool:build         (ADR-061 resolved)
+#   <NPM_PUBLISH_CMD>   Publish command    (e.g. "pnpm publish --access public --tag latest")
+#   <PUBLISHERS>        Space-separated publisher list (e.g. "npm cargo")
+# (Angle-brackets in this doc comment are intentional — they avoid being
+#  substituted by the {{...}} regex pass. The placeholders below use {{...}}.)
+
+name: Release Publish
+
+# R-220: push to main filtered to version-file paths only — bypasses unrelated
+# main commits without spinning up the full matrix.
+# R-221: workflow_dispatch with `version` input for manual re-runs and
+# idempotency tests.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+      - 'packages/*/package.json'
+      - 'Cargo.toml'
+      - 'packages/*/Cargo.toml'
+      - 'pyproject.toml'
+      - 'packages/*/pyproject.toml'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. v2026.6.0)'
+        type: string
+        required: true
+
+# R-222: workflow-level grants the minimum read+tag scopes. `packages: write`
+# is granted PER-JOB on publish-and-tag only — fanout/reconcile jobs MUST
+# NOT inherit publish scope.
+permissions:
+  contents: write
+  id-token: write
+
+# R-230: concurrent publishes against the same version queue rather than
+# collide. cancel-in-progress=false preserves in-flight publishes.
+concurrency:
+  group: release-publish-${{ github.sha }}
+  cancel-in-progress: false
+
+# R-262: bash everywhere — no cross-platform shell drift across the matrix.
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # R-223 (1/4) + R-224: classify the triggering commit. If the subject
+  # doesn't match `release: prepare v<version>`, ALL downstream jobs skip
+  # (`should_publish=false`). Manual workflow_dispatch always publishes.
+  detect:
+    name: Detect release commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      should_publish: ${{ steps.classify.outputs.should_publish }}
+      version: ${{ steps.classify.outputs.version }}
+    steps:
+      # R-263: third-party Actions pinned to major+minor.
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+        timeout-minutes: 5
+
+      - name: Classify triggering commit
+        id: classify
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.version }}" ]; then
+            # Manual dispatch — trust the input.
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BEFORE="${{ github.event.before }}"
+          SHA="${{ github.sha }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="$SHA^"
+          fi
+          if subject=$(git log --format=%s "$BEFORE..$SHA" 2>/dev/null | grep -E '^release: prepare v' | head -1); then
+            VERSION=$(echo "$subject" | sed -E 's/^release: prepare (v[^ ]+).*/\1/')
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+          fi
+        timeout-minutes: 2
+
+  # R-223 (2/4) + R-225: matrix expansion across the five T1737 platform
+  # tuples. fail-fast=true so a single platform failure prevents the
+  # publish-and-tag job from running (R-228).
+  build-matrix:
+    name: Build & test (${{ matrix.platform }})
+    needs: detect
+    if: needs.detect.outputs.should_publish == 'true'
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux-x64
+            runner: ubuntu-latest
+          - platform: linux-arm64
+            runner: ubuntu-22.04-arm
+          - platform: macos-x64
+            runner: macos-15-intel
+          - platform: macos-arm64
+            runner: macos-14
+          - platform: windows-x64
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+        timeout-minutes: 5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '{{NODE_VERSION}}'
+        timeout-minutes: 3
+
+      - name: Install dependencies
+        run: {{INSTALL_CMD}}
+        timeout-minutes: 10
+
+      - name: Lint
+        run: {{LINT_CMD}}
+        timeout-minutes: 5
+
+      - name: Typecheck
+        run: {{TYPECHECK_CMD}}
+        timeout-minutes: 5
+
+      - name: Test
+        run: {{TEST_CMD}}
+        timeout-minutes: 15
+
+      - name: Build
+        run: {{BUILD_CMD}}
+        timeout-minutes: 10
+
+      # R-225: integration smoke — `cleo --version` and `cleo briefing --json
+      # | jq .ok`. ANTHROPIC_API_KEY is scoped to the environment so an
+      # unmerged PR can't smoke-test against production credentials.
+      - name: Integration smoke
+        run: |
+          set -euo pipefail
+          ./bin/cleo --version
+          ./bin/cleo briefing --json | jq '.ok'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        timeout-minutes: 5
+
+      # R-232: on failure the matrix slot artifacts are uploaded for
+      # 30-day retention so operators can triage cross-platform regressions.
+      - name: Upload build artifact
+        if: always()
+        uses: actions/upload-artifact@v4.3
+        with:
+          name: cleo-${{ needs.detect.outputs.version }}-${{ matrix.platform }}
+          path: |
+            dist/
+            packages/*/dist/
+          if-no-files-found: warn
+          retention-days: 30
+        timeout-minutes: 5
+
+  # R-223 (3/4) + R-226: publish + tag. Gated by `environment: cleo-publish`
+  # (Letta §3.4 step 7) for reviewer-policy enforcement. R-228 enforces
+  # that any matrix slot failure blocks this job via the `needs` edge.
+  publish-and-tag:
+    name: Publish & tag
+    needs:
+      - detect
+      - build-matrix
+    if: needs.detect.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: cleo-publish
+    timeout-minutes: 25
+    # R-222: packages:write scoped to THIS job only.
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    env:
+      VERSION: ${{ needs.detect.outputs.version }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # `{{PUBLISHERS}}` is a render-time placeholder. Hoisting it into env
+      # turns the downstream `contains(env.PUBLISHERS, 'npm')` into a
+      # dynamic expression so actionlint doesn't flag it as a constant `if:`.
+      PUBLISHERS: '{{PUBLISHERS}}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 5
+
+      - name: Configure git identity
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+        timeout-minutes: 1
+
+      # R-229 (CRITICAL — F6 race elimination): poll `gh pr view` and assert
+      # state=MERGED AND mergeCommit.oid == $GITHUB_SHA BEFORE issuing any
+      # `git tag`. Mismatch fails with E_TAG_MISMATCH and never pushes.
+      - name: Confirm PR merge state (R-229)
+        id: confirm
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(gh pr list \
+            --search "${{ github.sha }}" \
+            --state merged \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::E_TAG_MISMATCH no merged PR found for SHA ${{ github.sha }}"
+            exit 1
+          fi
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json state,mergeCommit)
+          STATE=$(echo "$PR_JSON" | jq -r '.state')
+          MERGE_OID=$(echo "$PR_JSON" | jq -r '.mergeCommit.oid // ""')
+          if [ "$STATE" != "MERGED" ]; then
+            echo "::error::E_TAG_MISMATCH PR #$PR_NUMBER state=$STATE (expected MERGED)"
+            exit 1
+          fi
+          if [ -z "$MERGE_OID" ] || [ "$MERGE_OID" != "${{ github.sha }}" ]; then
+            echo "::error::E_TAG_MISMATCH PR #$PR_NUMBER merge_oid=$MERGE_OID expected=${{ github.sha }}"
+            exit 1
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "merge_oid=$MERGE_OID" >> "$GITHUB_OUTPUT"
+        timeout-minutes: 5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '{{NODE_VERSION}}'
+          registry-url: 'https://registry.npmjs.org'
+        timeout-minutes: 3
+
+      - name: Install dependencies
+        run: {{INSTALL_CMD}}
+        timeout-minutes: 10
+
+      - name: Build
+        run: {{BUILD_CMD}}
+        timeout-minutes: 10
+
+      # R-226(b): npm publish — gated on PUBLISHERS env containing "npm".
+      - name: Publish npm packages
+        if: contains(env.PUBLISHERS, 'npm')
+        run: {{NPM_PUBLISH_CMD}}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        timeout-minutes: 10
+
+      # R-226(c): cargo publish — gated on PUBLISHERS env containing "cargo".
+      - name: Publish cargo crates
+        if: contains(env.PUBLISHERS, 'cargo')
+        run: cargo publish --token "${{ secrets.CARGO_TOKEN }}"
+        timeout-minutes: 10
+
+      # R-226(d): tag the merge commit (NOT $GITHUB_SHA directly — they're
+      # equivalent here but using the confirm step's output makes the
+      # F6-eliminating proof explicit).
+      - name: Tag release
+        run: |
+          set -euo pipefail
+          git tag "$VERSION" "${{ steps.confirm.outputs.merge_oid }}"
+          git push origin "$VERSION"
+        timeout-minutes: 5
+
+      # R-226(e): GitHub Release with auto-generated notes, matrix
+      # artifacts attached. fail_on_unmatched_files=true asserts artifacts
+      # actually exist.
+      - name: Download matrix artifacts
+        uses: actions/download-artifact@v4.1
+        with:
+          path: release-artifacts/
+          merge-multiple: false
+        timeout-minutes: 5
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2.0
+        with:
+          tag_name: ${{ env.VERSION }}
+          target_commitish: ${{ steps.confirm.outputs.merge_oid }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            release-artifacts/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # R-233: partial-publish failure handler — emits a critical issue when
+      # one registry succeeded but a later step failed.
+      - name: Emit partial-publish incident on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          gh issue create \
+            --label release-incident \
+            --title "Partial publish failure: ${VERSION}" \
+            --body "release-publish.yml failed AFTER one or more registries had succeeded. Manual reconciliation required: re-run reconcile or run \`cleo release reconcile ${VERSION}\` from a local checkout. Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 5
+
+  # R-223 (4/4) + R-227: provenance reconciliation. NON-BLOCKING —
+  # continue-on-error: true at the job level so reconcile failure cannot
+  # roll back the tag/publish. Failure opens a backfill issue.
+  reconcile:
+    name: Reconcile provenance
+    needs:
+      - detect
+      - publish-and-tag
+    if: needs.detect.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    env:
+      VERSION: ${{ needs.detect.outputs.version }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+        timeout-minutes: 5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '{{NODE_VERSION}}'
+          registry-url: 'https://registry.npmjs.org'
+        timeout-minutes: 3
+
+      - name: Install cleo (freshly published version)
+        run: npm install -g "@cleocode/cleo@${VERSION#v}"
+        timeout-minutes: 5
+
+      - name: Reconcile release provenance
+        id: rec
+        continue-on-error: true
+        run: cleo release reconcile "$VERSION" --from-workflow --json
+        timeout-minutes: 5
+
+      # R-227: reconcile failure opens a backfill issue but MUST NOT roll
+      # back the tag or the publish.
+      - name: Open provenance-backfill issue on failure
+        if: steps.rec.outcome == 'failure'
+        run: |
+          gh issue create \
+            --label release-incident \
+            --title "Provenance backfill needed for ${VERSION}" \
+            --body "release-publish.yml reconcile job failed for ${VERSION}. Tag and publish completed successfully; only the provenance graph is incomplete. To recover, run \`cleo release reconcile ${VERSION} --backfill\` from a local checkout. Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 5

--- a/packages/cleo/test/templates/__snapshots__/release-publish.yml.snap
+++ b/packages/cleo/test/templates/__snapshots__/release-publish.yml.snap
@@ -1,0 +1,388 @@
+# CLEO release pipeline — Publish + tag workflow.
+#
+# Generated from packages/cleo/templates/workflows/release-publish.yml.tmpl by
+# `cleo init --workflows` (T9531). DO NOT EDIT the rendered file directly —
+# extend via `.workflow-overrides.yml` per SPEC-T9345 R-260.
+#
+# Implements SPEC-T9345-release-pipeline-v2.md §5.2 (R-220 — R-235, R-260 —
+# R-263). Triggers on push to main when the commit subject matches the
+# canonical `release: prepare v<version>` prefix produced by
+# release-prepare.yml. Tags ONLY after `gh pr view` confirms state=MERGED
+# AND mergeCommit.oid == $GITHUB_SHA — this eliminates the F6 race
+# (tag-on-pre-merge-SHA) by construction.
+#
+# Placeholders (replaced at scaffold time — see workflows/README.md):
+#   <NODE_VERSION>      Node.js version    (e.g. "22.x")
+#   <INSTALL_CMD>       Install command    (e.g. "pnpm install --frozen-lockfile")
+#   <LINT_CMD>          tool:lint          (ADR-061 resolved)
+#   <TYPECHECK_CMD>     tool:typecheck     (ADR-061 resolved)
+#   <TEST_CMD>          tool:test          (ADR-061 resolved)
+#   <BUILD_CMD>         tool:build         (ADR-061 resolved)
+#   <NPM_PUBLISH_CMD>   Publish command    (e.g. "pnpm publish --access public --tag latest")
+#   <PUBLISHERS>        Space-separated publisher list (e.g. "npm cargo")
+# (Angle-brackets in this doc comment are intentional — they avoid being
+#  substituted by the {{...}} regex pass. The placeholders below use {{...}}.)
+
+name: Release Publish
+
+# R-220: push to main filtered to version-file paths only — bypasses unrelated
+# main commits without spinning up the full matrix.
+# R-221: workflow_dispatch with `version` input for manual re-runs and
+# idempotency tests.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+      - 'packages/*/package.json'
+      - 'Cargo.toml'
+      - 'packages/*/Cargo.toml'
+      - 'pyproject.toml'
+      - 'packages/*/pyproject.toml'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. v2026.6.0)'
+        type: string
+        required: true
+
+# R-222: workflow-level grants the minimum read+tag scopes. `packages: write`
+# is granted PER-JOB on publish-and-tag only — fanout/reconcile jobs MUST
+# NOT inherit publish scope.
+permissions:
+  contents: write
+  id-token: write
+
+# R-230: concurrent publishes against the same version queue rather than
+# collide. cancel-in-progress=false preserves in-flight publishes.
+concurrency:
+  group: release-publish-${{ github.sha }}
+  cancel-in-progress: false
+
+# R-262: bash everywhere — no cross-platform shell drift across the matrix.
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # R-223 (1/4) + R-224: classify the triggering commit. If the subject
+  # doesn't match `release: prepare v<version>`, ALL downstream jobs skip
+  # (`should_publish=false`). Manual workflow_dispatch always publishes.
+  detect:
+    name: Detect release commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      should_publish: ${{ steps.classify.outputs.should_publish }}
+      version: ${{ steps.classify.outputs.version }}
+    steps:
+      # R-263: third-party Actions pinned to major+minor.
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+        timeout-minutes: 5
+
+      - name: Classify triggering commit
+        id: classify
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.version }}" ]; then
+            # Manual dispatch — trust the input.
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BEFORE="${{ github.event.before }}"
+          SHA="${{ github.sha }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="$SHA^"
+          fi
+          if subject=$(git log --format=%s "$BEFORE..$SHA" 2>/dev/null | grep -E '^release: prepare v' | head -1); then
+            VERSION=$(echo "$subject" | sed -E 's/^release: prepare (v[^ ]+).*/\1/')
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+          fi
+        timeout-minutes: 2
+
+  # R-223 (2/4) + R-225: matrix expansion across the five T1737 platform
+  # tuples. fail-fast=true so a single platform failure prevents the
+  # publish-and-tag job from running (R-228).
+  build-matrix:
+    name: Build & test (${{ matrix.platform }})
+    needs: detect
+    if: needs.detect.outputs.should_publish == 'true'
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux-x64
+            runner: ubuntu-latest
+          - platform: linux-arm64
+            runner: ubuntu-22.04-arm
+          - platform: macos-x64
+            runner: macos-15-intel
+          - platform: macos-arm64
+            runner: macos-14
+          - platform: windows-x64
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+        timeout-minutes: 5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '22.x'
+        timeout-minutes: 3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        timeout-minutes: 10
+
+      - name: Lint
+        run: pnpm biome ci .
+        timeout-minutes: 5
+
+      - name: Typecheck
+        run: pnpm run typecheck
+        timeout-minutes: 5
+
+      - name: Test
+        run: pnpm run test
+        timeout-minutes: 15
+
+      - name: Build
+        run: pnpm run build
+        timeout-minutes: 10
+
+      # R-225: integration smoke — `cleo --version` and `cleo briefing --json
+      # | jq .ok`. ANTHROPIC_API_KEY is scoped to the environment so an
+      # unmerged PR can't smoke-test against production credentials.
+      - name: Integration smoke
+        run: |
+          set -euo pipefail
+          ./bin/cleo --version
+          ./bin/cleo briefing --json | jq '.ok'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        timeout-minutes: 5
+
+      # R-232: on failure the matrix slot artifacts are uploaded for
+      # 30-day retention so operators can triage cross-platform regressions.
+      - name: Upload build artifact
+        if: always()
+        uses: actions/upload-artifact@v4.3
+        with:
+          name: cleo-${{ needs.detect.outputs.version }}-${{ matrix.platform }}
+          path: |
+            dist/
+            packages/*/dist/
+          if-no-files-found: warn
+          retention-days: 30
+        timeout-minutes: 5
+
+  # R-223 (3/4) + R-226: publish + tag. Gated by `environment: cleo-publish`
+  # (Letta §3.4 step 7) for reviewer-policy enforcement. R-228 enforces
+  # that any matrix slot failure blocks this job via the `needs` edge.
+  publish-and-tag:
+    name: Publish & tag
+    needs:
+      - detect
+      - build-matrix
+    if: needs.detect.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: cleo-publish
+    timeout-minutes: 25
+    # R-222: packages:write scoped to THIS job only.
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    env:
+      VERSION: ${{ needs.detect.outputs.version }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # `npm cargo` is a render-time placeholder. Hoisting it into env
+      # turns the downstream `contains(env.PUBLISHERS, 'npm')` into a
+      # dynamic expression so actionlint doesn't flag it as a constant `if:`.
+      PUBLISHERS: 'npm cargo'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 5
+
+      - name: Configure git identity
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+        timeout-minutes: 1
+
+      # R-229 (CRITICAL — F6 race elimination): poll `gh pr view` and assert
+      # state=MERGED AND mergeCommit.oid == $GITHUB_SHA BEFORE issuing any
+      # `git tag`. Mismatch fails with E_TAG_MISMATCH and never pushes.
+      - name: Confirm PR merge state (R-229)
+        id: confirm
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(gh pr list \
+            --search "${{ github.sha }}" \
+            --state merged \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::E_TAG_MISMATCH no merged PR found for SHA ${{ github.sha }}"
+            exit 1
+          fi
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json state,mergeCommit)
+          STATE=$(echo "$PR_JSON" | jq -r '.state')
+          MERGE_OID=$(echo "$PR_JSON" | jq -r '.mergeCommit.oid // ""')
+          if [ "$STATE" != "MERGED" ]; then
+            echo "::error::E_TAG_MISMATCH PR #$PR_NUMBER state=$STATE (expected MERGED)"
+            exit 1
+          fi
+          if [ -z "$MERGE_OID" ] || [ "$MERGE_OID" != "${{ github.sha }}" ]; then
+            echo "::error::E_TAG_MISMATCH PR #$PR_NUMBER merge_oid=$MERGE_OID expected=${{ github.sha }}"
+            exit 1
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "merge_oid=$MERGE_OID" >> "$GITHUB_OUTPUT"
+        timeout-minutes: 5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+        timeout-minutes: 3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        timeout-minutes: 10
+
+      - name: Build
+        run: pnpm run build
+        timeout-minutes: 10
+
+      # R-226(b): npm publish — gated on PUBLISHERS env containing "npm".
+      - name: Publish npm packages
+        if: contains(env.PUBLISHERS, 'npm')
+        run: pnpm publish -r --access public --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        timeout-minutes: 10
+
+      # R-226(c): cargo publish — gated on PUBLISHERS env containing "cargo".
+      - name: Publish cargo crates
+        if: contains(env.PUBLISHERS, 'cargo')
+        run: cargo publish --token "${{ secrets.CARGO_TOKEN }}"
+        timeout-minutes: 10
+
+      # R-226(d): tag the merge commit (NOT $GITHUB_SHA directly — they're
+      # equivalent here but using the confirm step's output makes the
+      # F6-eliminating proof explicit).
+      - name: Tag release
+        run: |
+          set -euo pipefail
+          git tag "$VERSION" "${{ steps.confirm.outputs.merge_oid }}"
+          git push origin "$VERSION"
+        timeout-minutes: 5
+
+      # R-226(e): GitHub Release with auto-generated notes, matrix
+      # artifacts attached. fail_on_unmatched_files=true asserts artifacts
+      # actually exist.
+      - name: Download matrix artifacts
+        uses: actions/download-artifact@v4.1
+        with:
+          path: release-artifacts/
+          merge-multiple: false
+        timeout-minutes: 5
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2.0
+        with:
+          tag_name: ${{ env.VERSION }}
+          target_commitish: ${{ steps.confirm.outputs.merge_oid }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            release-artifacts/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # R-233: partial-publish failure handler — emits a critical issue when
+      # one registry succeeded but a later step failed.
+      - name: Emit partial-publish incident on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          gh issue create \
+            --label release-incident \
+            --title "Partial publish failure: ${VERSION}" \
+            --body "release-publish.yml failed AFTER one or more registries had succeeded. Manual reconciliation required: re-run reconcile or run \`cleo release reconcile ${VERSION}\` from a local checkout. Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 5
+
+  # R-223 (4/4) + R-227: provenance reconciliation. NON-BLOCKING —
+  # continue-on-error: true at the job level so reconcile failure cannot
+  # roll back the tag/publish. Failure opens a backfill issue.
+  reconcile:
+    name: Reconcile provenance
+    needs:
+      - detect
+      - publish-and-tag
+    if: needs.detect.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    env:
+      VERSION: ${{ needs.detect.outputs.version }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+        timeout-minutes: 5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+        timeout-minutes: 3
+
+      - name: Install cleo (freshly published version)
+        run: npm install -g "@cleocode/cleo@${VERSION#v}"
+        timeout-minutes: 5
+
+      - name: Reconcile release provenance
+        id: rec
+        continue-on-error: true
+        run: cleo release reconcile "$VERSION" --from-workflow --json
+        timeout-minutes: 5
+
+      # R-227: reconcile failure opens a backfill issue but MUST NOT roll
+      # back the tag or the publish.
+      - name: Open provenance-backfill issue on failure
+        if: steps.rec.outcome == 'failure'
+        run: |
+          gh issue create \
+            --label release-incident \
+            --title "Provenance backfill needed for ${VERSION}" \
+            --body "release-publish.yml reconcile job failed for ${VERSION}. Tag and publish completed successfully; only the provenance graph is incomplete. To recover, run \`cleo release reconcile ${VERSION} --backfill\` from a local checkout. Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 5

--- a/packages/cleo/test/templates/release-publish-render.test.ts
+++ b/packages/cleo/test/templates/release-publish-render.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Snapshot test for the release-publish.yml.tmpl workflow template (T9533).
+ *
+ * Renders the template with a sample placeholder set and compares against a
+ * checked-in snapshot at __snapshots__/release-publish.yml.snap. If
+ * `actionlint` is available on PATH, the rendered output is also fed through
+ * actionlint to catch syntax errors that snapshot diffing alone misses.
+ *
+ * @task T9533
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'templates',
+  'workflows',
+  'release-publish.yml.tmpl',
+);
+
+/**
+ * Minimal template renderer for `{{UPPER_SNAKE_CASE}}` placeholders.
+ *
+ * Performs a single deterministic regex substitution pass. Mirrors what the
+ * T9531 `cleo init --workflows` scaffolder is required to do — see
+ * workflows/README.md "Template contract".
+ *
+ * @param template Raw template source.
+ * @param values   Map from placeholder name (without braces) to substitution.
+ * @returns Rendered string with all placeholders replaced.
+ */
+function renderTemplate(template: string, values: Record<string, string>): string {
+  return template.replace(/{{([A-Z_]+)}}/g, (_match, name: string) => {
+    if (!(name in values)) {
+      throw new Error(`renderTemplate: missing value for {{${name}}}`);
+    }
+    return values[name]!;
+  });
+}
+
+/**
+ * Sample placeholder set used to render the snapshot. Mirrors what the
+ * scaffolder would derive from a typical pnpm/Node monorepo via ADR-061.
+ */
+const SAMPLE_VALUES: Record<string, string> = {
+  NODE_VERSION: '22.x',
+  INSTALL_CMD: 'pnpm install --frozen-lockfile',
+  LINT_CMD: 'pnpm biome ci .',
+  TYPECHECK_CMD: 'pnpm run typecheck',
+  TEST_CMD: 'pnpm run test',
+  BUILD_CMD: 'pnpm run build',
+  NPM_PUBLISH_CMD: 'pnpm publish -r --access public --tag latest',
+  PUBLISHERS: 'npm cargo',
+};
+
+describe('release-publish.yml.tmpl', () => {
+  const raw = readFileSync(TEMPLATE_PATH, 'utf8');
+
+  // Strip comment lines (anything starting with #) to assert against the live
+  // YAML body — doc-comments mentioning RFC2119 invariants don't trip
+  // negative matches.
+  const nonComment = raw
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('#'))
+    .join('\n');
+
+  it('contains every required placeholder', () => {
+    const found = new Set<string>();
+    for (const m of raw.matchAll(/{{([A-Z_]+)}}/g)) {
+      found.add(m[1]!);
+    }
+    for (const key of Object.keys(SAMPLE_VALUES)) {
+      expect(found, `expected placeholder {{${key}}} in template`).toContain(key);
+    }
+  });
+
+  it('declares the trigger surface from SPEC §5.2 (R-220, R-221)', () => {
+    // R-220: push: main with version-file paths filter.
+    expect(nonComment).toMatch(/push:\s*\n\s*branches:\s*\n\s*-\s*main/);
+    expect(nonComment).toMatch(/paths:/);
+    expect(nonComment).toMatch(/'package\.json'/);
+    expect(nonComment).toMatch(/'packages\/\*\/package\.json'/);
+    expect(nonComment).toMatch(/'Cargo\.toml'/);
+    expect(nonComment).toMatch(/'pyproject\.toml'/);
+
+    // R-221: workflow_dispatch with `version` input.
+    expect(nonComment).toMatch(/workflow_dispatch:/);
+    expect(nonComment).toMatch(/version:\s*\n\s*description:/);
+  });
+
+  it('declares the permission surface from SPEC §5.2 (R-222)', () => {
+    // R-222: workflow-level contents:write + id-token:write. No packages:write
+    // at the top level — it is per-job on publish-and-tag only.
+    const workflowPermsMatch = nonComment.match(
+      /^permissions:\s*\n((?:\s{2,}.+\n?)+)/m,
+    );
+    expect(workflowPermsMatch, 'workflow-level permissions block').not.toBeNull();
+    const workflowPerms = workflowPermsMatch?.[1] ?? '';
+    expect(workflowPerms).toMatch(/contents:\s*write/);
+    expect(workflowPerms).toMatch(/id-token:\s*write/);
+    expect(workflowPerms).not.toMatch(/packages:\s*write/);
+
+    // Per-job packages:write granted in publish-and-tag.
+    const publishJobStart = nonComment.indexOf('publish-and-tag:');
+    expect(publishJobStart).toBeGreaterThan(-1);
+    const publishJobBody = nonComment.slice(publishJobStart);
+    expect(publishJobBody).toMatch(/packages:\s*write/);
+  });
+
+  it('declares 4 jobs in the order detect → build-matrix → publish-and-tag → reconcile (R-223)', () => {
+    const detectIdx = nonComment.indexOf('detect:');
+    const buildMatrixIdx = nonComment.indexOf('build-matrix:');
+    const publishIdx = nonComment.indexOf('publish-and-tag:');
+    const reconcileIdx = nonComment.indexOf('reconcile:');
+    expect(detectIdx).toBeGreaterThan(-1);
+    expect(buildMatrixIdx).toBeGreaterThan(detectIdx);
+    expect(publishIdx).toBeGreaterThan(buildMatrixIdx);
+    expect(reconcileIdx).toBeGreaterThan(publishIdx);
+
+    // Dependency edges enforce the order at runtime.
+    expect(raw).toMatch(/needs:\s*detect/);
+    // publish-and-tag needs detect + build-matrix
+    expect(raw).toMatch(/needs:\s*\n\s*-\s*detect\s*\n\s*-\s*build-matrix/);
+    // reconcile needs detect + publish-and-tag
+    expect(raw).toMatch(/needs:\s*\n\s*-\s*detect\s*\n\s*-\s*publish-and-tag/);
+  });
+
+  it('classifies release commits via the canonical grep regex (R-224)', () => {
+    // R-224: grep -E '^release: prepare v' against the commit-range subject.
+    expect(raw).toMatch(/grep -E '\^release: prepare v'/);
+    expect(raw).toMatch(/should_publish=true/);
+    expect(raw).toMatch(/should_publish=false/);
+    expect(raw).toMatch(/should_publish:\s*\$\{\{\s*steps\.classify\.outputs\.should_publish\s*\}\}/);
+    expect(raw).toMatch(/version:\s*\$\{\{\s*steps\.classify\.outputs\.version\s*\}\}/);
+  });
+
+  it('expands build-matrix across all 5 T1737 platform tuples (R-225)', () => {
+    expect(nonComment).toMatch(/platform:\s*linux-x64/);
+    expect(nonComment).toMatch(/platform:\s*linux-arm64/);
+    expect(nonComment).toMatch(/platform:\s*macos-x64/);
+    expect(nonComment).toMatch(/platform:\s*macos-arm64/);
+    expect(nonComment).toMatch(/platform:\s*windows-x64/);
+
+    // R-225: integration smoke uses ./bin/cleo --version + briefing --json | jq .ok.
+    expect(raw).toMatch(/\.\/bin\/cleo --version/);
+    expect(raw).toMatch(/\.\/bin\/cleo briefing --json/);
+    expect(raw).toMatch(/ANTHROPIC_API_KEY:/);
+  });
+
+  it('gates publish-and-tag behind environment: cleo-publish (R-226, R-235)', () => {
+    expect(raw).toMatch(/environment:\s*cleo-publish/);
+    // softprops/action-gh-release@v2 per R-226(e)
+    expect(raw).toMatch(/softprops\/action-gh-release@v2\.\d+/);
+    expect(raw).toMatch(/generate_release_notes:\s*true/);
+    expect(raw).toMatch(/fail_on_unmatched_files:\s*true/);
+  });
+
+  it('enforces the F6-eliminating confirm-PR step BEFORE git tag (R-229)', () => {
+    // R-229: confirm step polls gh pr view --json state,mergeCommit.
+    expect(raw).toMatch(/gh pr view "?\$?PR_NUMBER"?\s+--json state,mergeCommit/);
+    // Asserts state=MERGED.
+    expect(raw).toMatch(/STATE.*!=.*"?MERGED"?/);
+    // Asserts mergeCommit.oid == $GITHUB_SHA.
+    expect(raw).toMatch(/MERGE_OID.*!=.*github\.sha/);
+    // Failure mode is E_TAG_MISMATCH.
+    expect(raw).toMatch(/E_TAG_MISMATCH/);
+
+    // CRITICAL ordering: the confirm step MUST appear before the tag step.
+    const confirmIdx = raw.indexOf('Confirm PR merge state');
+    const tagStepMatch = raw.match(/-\s*name:\s*Tag release/);
+    expect(confirmIdx).toBeGreaterThan(-1);
+    expect(tagStepMatch).not.toBeNull();
+    const tagIdx = raw.indexOf(tagStepMatch?.[0] ?? '');
+    expect(tagIdx).toBeGreaterThan(confirmIdx);
+  });
+
+  it('makes reconcile non-blocking (R-227)', () => {
+    // reconcile job has continue-on-error: true at the job level.
+    const reconcileStart = nonComment.indexOf('reconcile:');
+    expect(reconcileStart).toBeGreaterThan(-1);
+    // Scope to reconcile job body (until end-of-file in this template).
+    const reconcileBody = nonComment.slice(reconcileStart);
+    expect(reconcileBody).toMatch(/continue-on-error:\s*true/);
+
+    // Opens a provenance-backfill issue on failure.
+    expect(raw).toMatch(/gh issue create/);
+    expect(raw).toMatch(/Provenance backfill needed/);
+    expect(raw).toMatch(/release-incident/);
+
+    // Uses `cleo release reconcile <version> --from-workflow --json`.
+    expect(raw).toMatch(/cleo release reconcile.*--from-workflow.*--json/);
+  });
+
+  it('enforces concurrency group + cancel-in-progress=false (R-230)', () => {
+    expect(raw).toMatch(/group:\s*release-publish-\$\{\{\s*github\.sha\s*\}\}/);
+    expect(raw).toMatch(/cancel-in-progress:\s*false/);
+  });
+
+  it('declares the secret surface from SPEC §5.2 (R-234)', () => {
+    // R-234: GITHUB_TOKEN, NPM_TOKEN, ANTHROPIC_API_KEY required.
+    expect(raw).toMatch(/secrets\.GITHUB_TOKEN/);
+    expect(raw).toMatch(/secrets\.NPM_TOKEN/);
+    expect(raw).toMatch(/secrets\.ANTHROPIC_API_KEY/);
+    // Optional: CARGO_TOKEN.
+    expect(raw).toMatch(/secrets\.CARGO_TOKEN/);
+  });
+
+  it('sets defaults.run.shell: bash (R-262)', () => {
+    expect(raw).toMatch(/defaults:\s*\n\s*run:\s*\n\s*shell:\s*bash/);
+  });
+
+  it('pins third-party Actions to major+minor (R-263)', () => {
+    // Capture every `uses:` ref and assert no `@main`, `@master`, `@latest`,
+    // or bare-major (`@v4` without a minor) reference slips in.
+    const usesRefs = [...raw.matchAll(/uses:\s*([^\s\n]+)/g)].map((m) => m[1]!);
+    expect(usesRefs.length).toBeGreaterThan(0);
+    for (const ref of usesRefs) {
+      expect(ref, `pinned third-party Action: ${ref}`).not.toMatch(/@(main|master|latest)$/);
+      // Must be major+minor: `name@vX.Y` (e.g. `actions/checkout@v4.1`).
+      expect(ref, `${ref} must pin to major+minor`).toMatch(/@v\d+\.\d+$/);
+    }
+  });
+
+  it('renders deterministically and matches the checked-in snapshot', async () => {
+    const rendered = renderTemplate(raw, SAMPLE_VALUES);
+
+    // No unsubstituted placeholders left.
+    expect(rendered).not.toMatch(/{{[A-Z_]+}}/);
+
+    // Rendered output has the sample values inlined where expected.
+    expect(rendered).toContain("node-version: '22.x'");
+    expect(rendered).toContain('pnpm install --frozen-lockfile');
+    expect(rendered).toContain('pnpm publish -r --access public --tag latest');
+    // PUBLISHERS is hoisted into env so the `if:` becomes dynamic for
+    // actionlint (constant-expression-in-condition warning otherwise).
+    expect(rendered).toContain("PUBLISHERS: 'npm cargo'");
+    expect(rendered).toContain("contains(env.PUBLISHERS, 'npm')");
+    expect(rendered).toContain("contains(env.PUBLISHERS, 'cargo')");
+
+    await expect(rendered).toMatchFileSnapshot(
+      './__snapshots__/release-publish.yml.snap',
+    );
+  });
+
+  it('throws on missing placeholder values', () => {
+    expect(() =>
+      renderTemplate('hello {{UNKNOWN_KEY}}', { OTHER: 'x' }),
+    ).toThrow(/UNKNOWN_KEY/);
+  });
+});
+
+/**
+ * Optional actionlint gate (R-260). Skipped when `actionlint` is not on
+ * PATH so the test suite remains runnable in environments without it (e.g.
+ * sparse worker pods). CI is responsible for installing actionlint and
+ * exercising this code path — see SPEC AC-8.
+ */
+function hasActionlint(): boolean {
+  try {
+    execSync('command -v actionlint', { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const ACTIONLINT_DESCRIBE = hasActionlint() ? describe : describe.skip;
+
+ACTIONLINT_DESCRIBE('release-publish.yml.tmpl actionlint gate', () => {
+  it('passes actionlint on the rendered output', () => {
+    const raw = readFileSync(TEMPLATE_PATH, 'utf8');
+    const rendered = renderTemplate(raw, SAMPLE_VALUES);
+    // `actionlint -` reads from stdin.
+    expect(() =>
+      execSync('actionlint -', {
+        input: rendered,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Second of four CLEO-templated GHA workflows per SPEC-T9345 §5.2. Eliminates the F6 tag-on-pre-merge-SHA race **by construction**: the publish-and-tag job's confirm-PR step polls `gh pr view --json state,mergeCommit` and asserts `state=MERGED AND mergeCommit.oid==github.sha` **before** `git tag` runs. Any mismatch fails with `E_TAG_MISMATCH` and never pushes the tag.

## RFC 2119 invariants covered

| Invariant | Implementation |
|-----------|----------------|
| R-220 | `push: main` filtered to version-file paths (`package.json`, `Cargo.toml`, `pyproject.toml`, monorepo variants) |
| R-221 | `workflow_dispatch` with `version` input for manual re-runs |
| R-222 | Workflow-level: `contents:write` + `id-token:write`; per-job `packages:write` on publish-and-tag only |
| R-223 | 4 jobs in order: `detect` -> `build-matrix` -> `publish-and-tag` -> `reconcile` (enforced via `needs:` edges) |
| R-224 | `detect` grep regex `^release: prepare v` against commit-range subjects; outputs `should_publish` + `version` |
| R-225 | 5 platform tuples: linux-x64 (ubuntu-latest), linux-arm64 (ubuntu-22.04-arm), macos-x64 (macos-15-intel), macos-arm64 (macos-14), windows-x64 (windows-latest); install + lint + typecheck + test + build + integration smoke (`./bin/cleo --version` + `briefing --json | jq .ok`) |
| R-226 | `environment: cleo-publish` + reviewer policy; `softprops/action-gh-release@v2.0` with `generate_release_notes: true` + `fail_on_unmatched_files: true` |
| R-227 | `reconcile` job `continue-on-error: true`; opens provenance-backfill issue on failure |
| R-228 | `publish-and-tag` blocked by `needs: build-matrix` + `fail-fast: true` |
| **R-229** | **Confirm-PR step asserts state=MERGED AND mergeCommit.oid==github.sha BEFORE git tag (eliminates F6 race by construction)** |
| R-230 | `concurrency: { group: release-publish-<sha>, cancel-in-progress: false }` |
| R-232 | Matrix artifacts uploaded with 30-day retention |
| R-233 | Partial-publish failure opens `release-incident` issue |
| R-234 | Required: `GITHUB_TOKEN`, `NPM_TOKEN`, `ANTHROPIC_API_KEY`; optional: `CARGO_TOKEN` |
| R-235 | Secrets scoped to `environment: cleo-publish` |
| R-262 | `defaults.run.shell: bash` |
| R-263 | All third-party Actions pinned to major+minor (`@v4.1`, `@v4.3`, `@v2.0`) |

## Implementation notes

- `{{PUBLISHERS}}` is **hoisted into env** at the publish-and-tag job level so the downstream `contains(env.PUBLISHERS, 'npm')` / `contains(env.PUBLISHERS, 'cargo')` expressions are **dynamic** for actionlint (otherwise it flags constant-expression-in-condition).
- macos-x64 uses `macos-15-intel` (the canonical Intel runner; `macos-13` is retired).
- All 16 snapshot-test invariants pass under actionlint.

## Changes
- `packages/cleo/templates/workflows/release-publish.yml.tmpl` — new workflow template (388 lines)
- `packages/cleo/templates/workflows/README.md` — adds 2 new placeholders (`NPM_PUBLISH_CMD`, `PUBLISHERS`), marks §5.2 as landed
- `packages/cleo/test/templates/release-publish-render.test.ts` — 16 invariant + snapshot tests
- `packages/cleo/test/templates/__snapshots__/release-publish.yml.snap` — checked-in snapshot

## Test plan
- [x] All R-220 through R-235 invariants satisfied (12 dedicated assertions)
- [x] Snapshot renders deterministically (16/16 tests pass)
- [x] actionlint validates the rendered output (locally verified with actionlint 1.7.12)
- [x] No biome regressions in `packages/cleo/src/`
- [x] T9532 (prepare) snapshot test still passes (no shared-state regressions)

Closes T9533. Unblocks T9534 (fanout) and T9535 (reconcile).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>