### PR TITLE
feat(T9534): release-fanout.yml.tmpl GHA template

### DIFF
--- a/packages/cleo/templates/workflows/README.md
+++ b/packages/cleo/templates/workflows/README.md
@@ -13,8 +13,8 @@ local `.cleo/project-context.json` and the ADR-061 tool resolver.
 |-----------------------------------|--------------|--------------------------------------------------------|
 | `release-prepare.yml.tmpl`        | §5.1         | Cut release branch, bump version, open bump-PR.        |
 | `release-publish.yml.tmpl`        | §5.2         | Publish + tag once the bump-PR is merged.              |
-| `release-fanout.yml.tmpl`         | §5.3 *(T9534, future)* | Best-effort post-publish fanout (docs, docker, etc.). |
-| `release-reconcile.yml.tmpl`      | §5.4 *(T9535, future)* | Provenance reconciliation across systems.    |
+| `release-fanout.yml.tmpl`         | §5.3         | Best-effort post-publish fanout (docs, docker, etc.).  |
+| `release-rollback.yml.tmpl`       | §5.4 *(T9535, future)* | Rollback workflow (revert PR + npm deprecate). |
 
 ## Template contract
 
@@ -47,6 +47,16 @@ placeholders for a given template are silently ignored by the scaffolder.
 | `{{PR_LABEL}}`        | `release.prLabel` in `.cleo/config.json`               | `release`                            | `release`                            |
 | `{{NPM_PUBLISH_CMD}}` | `release.npmPublishCmd` in `.cleo/config.json`         | `pnpm publish --access public --tag latest` | `pnpm publish -r --access public --tag latest` |
 | `{{PUBLISHERS}}`      | `release.publishers` in `.cleo/config.json`            | `npm`                                | `npm cargo`                          |
+| `{{DOCS_BUILD_CMD}}`  | `release.fanout.docsBuildCmd` in `.cleo/config.json`   | `pnpm run docs:build`                | `pnpm --filter @cleocode/docs run build` |
+| `{{ENABLE_DOCS_DEPLOY}}`     | `release.fanout.docsDeploy` in `.cleo/config.json`     | `false`                  | `true`                               |
+| `{{ENABLE_DOCKER_RETAG}}`    | `release.fanout.dockerRetag` in `.cleo/config.json`    | `false`                  | `true`                               |
+| `{{ENABLE_SENTINEL_NOTIFY}}` | `release.fanout.sentinelNotify` in `.cleo/config.json` | `false`                  | `true`                               |
+| `{{ENABLE_STUDIO_DEPLOY}}`   | `release.fanout.studioDeploy` in `.cleo/config.json`   | `false`                  | `true`                               |
+| `{{ENABLE_NIGHTLY_TRIGGER}}` | `release.fanout.nightlyTrigger` in `.cleo/config.json` | `false`                  | `true`                               |
+| `{{DOCKER_IMAGE}}`    | `release.fanout.dockerImage` in `.cleo/config.json`    | *(none — required if `dockerRetag=true`)* | `cleocode/cleo`                |
+| `{{DOCKER_HUB_USER}}` | `release.fanout.dockerHubUser` in `.cleo/config.json`  | *(none — required if `dockerRetag=true`)* | `cleocode`                     |
+| `{{SENTINEL_WEBHOOK_URL}}` | `release.fanout.sentinelWebhookUrl` in `.cleo/config.json` | *(none — required if `sentinelNotify=true`)* | `https://sentinel.example.com/hooks/release` |
+| `{{STUDIO_DEPLOY_HOOK}}` | `release.fanout.studioDeployHook` in `.cleo/config.json` | *(none — required if `studioDeploy=true`)*   | `https://studio.example.com/deploy`        |
 
 Source precedence (highest first):
 
@@ -61,8 +71,8 @@ Source precedence (highest first):
 |------------------------------|-----------------|------------------|----------------------|--------------------|------------------|
 | `release-prepare.yml.tmpl`   | `write`         | `write`          | `write` (signed tags) | (MUST NOT request) | —                |
 | `release-publish.yml.tmpl`   | `write` (tag)   | `read`           | `write` (OIDC)        | `write` (publish job only) | —        |
-| `release-fanout.yml.tmpl`    | `read`          | —                | —                     | —                  | `pages: write`*  |
-| `release-reconcile.yml.tmpl` | `read`          | `write`          | —                     | —                  | `issues: write`* |
+| `release-fanout.yml.tmpl`    | `read`          | —                | `write` (Pages, docs job only)* | —        | `pages: write`*  |
+| `release-rollback.yml.tmpl`  | `write` (revert + tag delete) | `write`          | —                     | `write` (npm deprecate) | —          |
 
 *Per-job — only granted to the job that needs it.
 
@@ -72,6 +82,7 @@ Source precedence (highest first):
 |------------------------------|-------------------------|---------------------------------------------------|
 | `release-prepare.yml.tmpl`   | `GITHUB_TOKEN` (auto)   | *(none)* — MUST NOT require `NPM_TOKEN` (R-210)   |
 | `release-publish.yml.tmpl`   | `GITHUB_TOKEN`, `NPM_TOKEN`, `ANTHROPIC_API_KEY` | `CARGO_TOKEN`, `PYPI_TOKEN`, `DOCKER_HUB_TOKEN` |
+| `release-fanout.yml.tmpl`    | `GITHUB_TOKEN` (auto)   | `DOCKER_HUB_TOKEN` (if `dockerRetag=true`), `SENTINEL_TOKEN` (if `sentinelNotify=true`), `STUDIO_DEPLOY_TOKEN` (if `studioDeploy=true`) |
 
 ## Scaffolding workflow
 
@@ -118,12 +129,17 @@ declared permissions.
 
 - SPEC: `.cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md`
   - §5.1 → `release-prepare.yml.tmpl` *(T9532, landed)*
-  - §5.2 → `release-publish.yml.tmpl` *(T9533, current)*
-  - §5.3 → `release-fanout.yml.tmpl` *(T9534)*
-  - §5.4 → `release-reconcile.yml.tmpl` *(T9535)*
+  - §5.2 → `release-publish.yml.tmpl` *(T9533, landed)*
+  - §5.3 → `release-fanout.yml.tmpl` *(T9534, current)*
+  - §5.4 → `release-rollback.yml.tmpl` *(T9535)*
 - ADR-061 (tool resolver): governs `tool:*` placeholder resolution.
 - ADR-073 (release pipeline v2): umbrella architectural decision.
 - T9531: `cleo init --workflows` scaffold command (consumes these templates).
 - T9532: `release-prepare.yml.tmpl` + README skeleton + snapshot test.
 - T9533: `release-publish.yml.tmpl` + README placeholders + snapshot test
-  (current task — eliminates F6 tag-on-pre-merge-SHA race by construction).
+  (eliminates F6 tag-on-pre-merge-SHA race by construction).
+- T9534: `release-fanout.yml.tmpl` + 11 fanout placeholders + snapshot test
+  (current task — five independent best-effort jobs gated on env toggles,
+  every job carries `continue-on-error: true` so fanout failures cannot
+  mark the release as failed; fanout jobs MUST NOT be required status
+  checks per R-244).

--- a/packages/cleo/templates/workflows/release-fanout.yml.tmpl
+++ b/packages/cleo/templates/workflows/release-fanout.yml.tmpl
@@ -1,0 +1,214 @@
+# CLEO release pipeline — Best-effort fanout workflow.
+#
+# Generated from packages/cleo/templates/workflows/release-fanout.yml.tmpl by
+# `cleo init --workflows` (T9531). DO NOT EDIT the rendered file directly —
+# extend via `.workflow-overrides.yml` per SPEC-T9345 R-260.
+#
+# Implements SPEC-T9345-release-pipeline-v2.md §5.3 (R-240 — R-244, R-260 —
+# R-263). Triggers on `release: published` (the GitHub Release event, NOT
+# `release: created` which fires on drafts). Each downstream job is an
+# independent best-effort fanout — every job carries `continue-on-error:
+# true` so a failed docs deploy, docker retag, sentinel notify, studio
+# rebuild, or nightly trigger CANNOT mark the release itself as failed.
+# These jobs MUST NOT be configured as required status checks (R-244).
+#
+# Placeholders (replaced at scaffold time — see workflows/README.md):
+#   <NODE_VERSION>             Node.js version            (e.g. "22.x")
+#   <INSTALL_CMD>              Install command            (e.g. "pnpm install --frozen-lockfile")
+#   <DOCS_BUILD_CMD>           Docs build command         (e.g. "pnpm --filter @cleocode/docs run build")
+#   <ENABLE_DOCS_DEPLOY>       Toggle docs-deploy job     ("true" | "false")
+#   <ENABLE_DOCKER_RETAG>      Toggle docker-retag job    ("true" | "false")
+#   <ENABLE_SENTINEL_NOTIFY>   Toggle sentinel-notify job ("true" | "false")
+#   <ENABLE_STUDIO_DEPLOY>     Toggle studio-deploy job   ("true" | "false")
+#   <ENABLE_NIGHTLY_TRIGGER>   Toggle nightly-trigger job ("true" | "false")
+#   <DOCKER_IMAGE>             Docker image name          (e.g. "cleocode/cleo")
+#   <DOCKER_HUB_USER>          Docker Hub login user      (e.g. "cleocode")
+#   <SENTINEL_WEBHOOK_URL>     Sentinel webhook URL       (HTTPS)
+#   <STUDIO_DEPLOY_HOOK>       Studio deploy hook URL     (HTTPS)
+# (Angle-brackets in this doc comment are intentional — they avoid being
+#  substituted by the {{...}} regex pass. The placeholders below use {{...}}.)
+
+name: Release Fanout
+
+# R-240: trigger on `release: published` ONLY. Draft releases (which fire
+# `release: created`) MUST NOT trigger the fanout — operators expect this
+# to run AFTER the publish + tag workflow has shipped the artifacts.
+on:
+  release:
+    types: [published]
+
+# R-241: workflow-level grants the minimum read scope. Per-job permissions
+# escalate ONLY for the jobs that need them (e.g. `pages: write` for docs
+# deploy). No top-level write scope — fanout is intentionally read-only at
+# the workflow level.
+permissions:
+  contents: read
+
+# R-243: serialize fanouts against the same release tag. cancel-in-progress
+# is FALSE so an in-flight fanout completes rather than losing partial
+# work (e.g. a half-pushed docker tag).
+concurrency:
+  group: fanout-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+# R-262: bash everywhere — no cross-platform shell drift across the fanout
+# jobs (they all run on ubuntu-latest but the contract is explicit).
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # R-242 (1/5): deploy generated documentation site to GitHub Pages.
+  # continue-on-error: true so a docs-build regression cannot fail the
+  # release. Disabled by default — flip {{ENABLE_DOCS_DEPLOY}} to "true"
+  # at scaffold time. The flag is hoisted into env so the `if:` becomes a
+  # dynamic expression (avoids actionlint constant-expression warning).
+  docs-deploy:
+    name: Deploy docs to GitHub Pages
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+    env:
+      ENABLE_DOCS_DEPLOY: '{{ENABLE_DOCS_DEPLOY}}'
+    if: ${{ env.ENABLE_DOCS_DEPLOY == 'true' }}
+    # R-241 (per-job): pages: write + id-token: write granted ONLY for the
+    # docs-deploy job — other fanout jobs MUST NOT inherit GitHub Pages
+    # write scope.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      # R-263: third-party Actions pinned to major+minor.
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 1
+        timeout-minutes: 5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '{{NODE_VERSION}}'
+        timeout-minutes: 3
+
+      - name: Install dependencies
+        run: {{INSTALL_CMD}}
+        timeout-minutes: 5
+
+      - name: Build docs
+        run: {{DOCS_BUILD_CMD}}
+        timeout-minutes: 10
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5.0
+        timeout-minutes: 2
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3.0
+        with:
+          path: docs/dist
+        timeout-minutes: 5
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4.0
+        timeout-minutes: 5
+
+  # R-242 (2/5): retag the published docker image to `latest`. Failure here
+  # does NOT roll back the release — operators can re-run manually.
+  docker-retag:
+    name: Retag docker image to latest
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 10
+    env:
+      ENABLE_DOCKER_RETAG: '{{ENABLE_DOCKER_RETAG}}'
+      DOCKER_IMAGE: '{{DOCKER_IMAGE}}'
+      DOCKER_HUB_USER: '{{DOCKER_HUB_USER}}'
+      VERSION: ${{ github.event.release.tag_name }}
+    if: ${{ env.ENABLE_DOCKER_RETAG == 'true' }}
+    steps:
+      - name: Log in to Docker Hub
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.DOCKER_HUB_TOKEN }}" | \
+            docker login -u "$DOCKER_HUB_USER" --password-stdin
+        timeout-minutes: 3
+
+      - name: Pull, retag, push
+        run: |
+          set -euo pipefail
+          docker pull "${DOCKER_IMAGE}:${VERSION}"
+          docker tag "${DOCKER_IMAGE}:${VERSION}" "${DOCKER_IMAGE}:latest"
+          docker push "${DOCKER_IMAGE}:latest"
+        timeout-minutes: 5
+
+  # R-242 (3/5): POST a `release.published` event to the Sentinel webhook
+  # so downstream monitoring can pick the release up. Best-effort — a
+  # webhook outage MUST NOT mark the release as failed.
+  sentinel-notify:
+    name: Notify Sentinel of release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 5
+    env:
+      ENABLE_SENTINEL_NOTIFY: '{{ENABLE_SENTINEL_NOTIFY}}'
+      SENTINEL_WEBHOOK_URL: '{{SENTINEL_WEBHOOK_URL}}'
+      SENTINEL_TOKEN: ${{ secrets.SENTINEL_TOKEN }}
+      VERSION: ${{ github.event.release.tag_name }}
+      RELEASE_URL: ${{ github.event.release.html_url }}
+    if: ${{ env.ENABLE_SENTINEL_NOTIFY == 'true' }}
+    steps:
+      - name: POST release.published to Sentinel
+        run: |
+          set -euo pipefail
+          curl -fSL -X POST "$SENTINEL_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer ${SENTINEL_TOKEN}" \
+            -d "{\"event\":\"release.published\",\"version\":\"${VERSION}\",\"url\":\"${RELEASE_URL}\"}"
+        timeout-minutes: 3
+
+  # R-242 (4/5): trigger a Studio rebuild via deploy hook. Studio runs
+  # outside this repo, so this job is a fire-and-forget POST.
+  studio-deploy:
+    name: Trigger Studio rebuild
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 20
+    env:
+      ENABLE_STUDIO_DEPLOY: '{{ENABLE_STUDIO_DEPLOY}}'
+      STUDIO_DEPLOY_HOOK: '{{STUDIO_DEPLOY_HOOK}}'
+      STUDIO_DEPLOY_TOKEN: ${{ secrets.STUDIO_DEPLOY_TOKEN }}
+      VERSION: ${{ github.event.release.tag_name }}
+    if: ${{ env.ENABLE_STUDIO_DEPLOY == 'true' }}
+    steps:
+      - name: POST to Studio deploy hook
+        run: |
+          set -euo pipefail
+          curl -fSL -X POST "$STUDIO_DEPLOY_HOOK" \
+            -H "Authorization: Bearer ${STUDIO_DEPLOY_TOKEN}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"version\":\"${VERSION}\"}"
+        timeout-minutes: 10
+
+  # R-242 (5/5): dispatch the nightly e2e workflow against the freshly
+  # published release version. Decoupled from the release path — a failed
+  # dispatch is logged but does NOT fail the release.
+  nightly-trigger:
+    name: Dispatch nightly e2e for release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 3
+    env:
+      ENABLE_NIGHTLY_TRIGGER: '{{ENABLE_NIGHTLY_TRIGGER}}'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ github.event.release.tag_name }}
+    if: ${{ env.ENABLE_NIGHTLY_TRIGGER == 'true' }}
+    steps:
+      - name: Dispatch nightly e2e
+        run: |
+          set -euo pipefail
+          gh workflow run nightly-e2e.yml \
+            --repo "${{ github.repository }}" \
+            -f release_version="$VERSION"
+        timeout-minutes: 2

--- a/packages/cleo/test/templates/__snapshots__/release-fanout.yml.snap
+++ b/packages/cleo/test/templates/__snapshots__/release-fanout.yml.snap
@@ -1,0 +1,214 @@
+# CLEO release pipeline — Best-effort fanout workflow.
+#
+# Generated from packages/cleo/templates/workflows/release-fanout.yml.tmpl by
+# `cleo init --workflows` (T9531). DO NOT EDIT the rendered file directly —
+# extend via `.workflow-overrides.yml` per SPEC-T9345 R-260.
+#
+# Implements SPEC-T9345-release-pipeline-v2.md §5.3 (R-240 — R-244, R-260 —
+# R-263). Triggers on `release: published` (the GitHub Release event, NOT
+# `release: created` which fires on drafts). Each downstream job is an
+# independent best-effort fanout — every job carries `continue-on-error:
+# true` so a failed docs deploy, docker retag, sentinel notify, studio
+# rebuild, or nightly trigger CANNOT mark the release itself as failed.
+# These jobs MUST NOT be configured as required status checks (R-244).
+#
+# Placeholders (replaced at scaffold time — see workflows/README.md):
+#   <NODE_VERSION>             Node.js version            (e.g. "22.x")
+#   <INSTALL_CMD>              Install command            (e.g. "pnpm install --frozen-lockfile")
+#   <DOCS_BUILD_CMD>           Docs build command         (e.g. "pnpm --filter @cleocode/docs run build")
+#   <ENABLE_DOCS_DEPLOY>       Toggle docs-deploy job     ("true" | "false")
+#   <ENABLE_DOCKER_RETAG>      Toggle docker-retag job    ("true" | "false")
+#   <ENABLE_SENTINEL_NOTIFY>   Toggle sentinel-notify job ("true" | "false")
+#   <ENABLE_STUDIO_DEPLOY>     Toggle studio-deploy job   ("true" | "false")
+#   <ENABLE_NIGHTLY_TRIGGER>   Toggle nightly-trigger job ("true" | "false")
+#   <DOCKER_IMAGE>             Docker image name          (e.g. "cleocode/cleo")
+#   <DOCKER_HUB_USER>          Docker Hub login user      (e.g. "cleocode")
+#   <SENTINEL_WEBHOOK_URL>     Sentinel webhook URL       (HTTPS)
+#   <STUDIO_DEPLOY_HOOK>       Studio deploy hook URL     (HTTPS)
+# (Angle-brackets in this doc comment are intentional — they avoid being
+#  substituted by the {{...}} regex pass. The placeholders below use {{...}}.)
+
+name: Release Fanout
+
+# R-240: trigger on `release: published` ONLY. Draft releases (which fire
+# `release: created`) MUST NOT trigger the fanout — operators expect this
+# to run AFTER the publish + tag workflow has shipped the artifacts.
+on:
+  release:
+    types: [published]
+
+# R-241: workflow-level grants the minimum read scope. Per-job permissions
+# escalate ONLY for the jobs that need them (e.g. `pages: write` for docs
+# deploy). No top-level write scope — fanout is intentionally read-only at
+# the workflow level.
+permissions:
+  contents: read
+
+# R-243: serialize fanouts against the same release tag. cancel-in-progress
+# is FALSE so an in-flight fanout completes rather than losing partial
+# work (e.g. a half-pushed docker tag).
+concurrency:
+  group: fanout-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+# R-262: bash everywhere — no cross-platform shell drift across the fanout
+# jobs (they all run on ubuntu-latest but the contract is explicit).
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # R-242 (1/5): deploy generated documentation site to GitHub Pages.
+  # continue-on-error: true so a docs-build regression cannot fail the
+  # release. Disabled by default — flip true to "true"
+  # at scaffold time. The flag is hoisted into env so the `if:` becomes a
+  # dynamic expression (avoids actionlint constant-expression warning).
+  docs-deploy:
+    name: Deploy docs to GitHub Pages
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+    env:
+      ENABLE_DOCS_DEPLOY: 'true'
+    if: ${{ env.ENABLE_DOCS_DEPLOY == 'true' }}
+    # R-241 (per-job): pages: write + id-token: write granted ONLY for the
+    # docs-deploy job — other fanout jobs MUST NOT inherit GitHub Pages
+    # write scope.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      # R-263: third-party Actions pinned to major+minor.
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 1
+        timeout-minutes: 5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '22.x'
+        timeout-minutes: 3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        timeout-minutes: 5
+
+      - name: Build docs
+        run: pnpm --filter @cleocode/docs run build
+        timeout-minutes: 10
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5.0
+        timeout-minutes: 2
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3.0
+        with:
+          path: docs/dist
+        timeout-minutes: 5
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4.0
+        timeout-minutes: 5
+
+  # R-242 (2/5): retag the published docker image to `latest`. Failure here
+  # does NOT roll back the release — operators can re-run manually.
+  docker-retag:
+    name: Retag docker image to latest
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 10
+    env:
+      ENABLE_DOCKER_RETAG: 'true'
+      DOCKER_IMAGE: 'cleocode/cleo'
+      DOCKER_HUB_USER: 'cleocode'
+      VERSION: ${{ github.event.release.tag_name }}
+    if: ${{ env.ENABLE_DOCKER_RETAG == 'true' }}
+    steps:
+      - name: Log in to Docker Hub
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.DOCKER_HUB_TOKEN }}" | \
+            docker login -u "$DOCKER_HUB_USER" --password-stdin
+        timeout-minutes: 3
+
+      - name: Pull, retag, push
+        run: |
+          set -euo pipefail
+          docker pull "${DOCKER_IMAGE}:${VERSION}"
+          docker tag "${DOCKER_IMAGE}:${VERSION}" "${DOCKER_IMAGE}:latest"
+          docker push "${DOCKER_IMAGE}:latest"
+        timeout-minutes: 5
+
+  # R-242 (3/5): POST a `release.published` event to the Sentinel webhook
+  # so downstream monitoring can pick the release up. Best-effort — a
+  # webhook outage MUST NOT mark the release as failed.
+  sentinel-notify:
+    name: Notify Sentinel of release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 5
+    env:
+      ENABLE_SENTINEL_NOTIFY: 'true'
+      SENTINEL_WEBHOOK_URL: 'https://sentinel.example.com/hooks/release'
+      SENTINEL_TOKEN: ${{ secrets.SENTINEL_TOKEN }}
+      VERSION: ${{ github.event.release.tag_name }}
+      RELEASE_URL: ${{ github.event.release.html_url }}
+    if: ${{ env.ENABLE_SENTINEL_NOTIFY == 'true' }}
+    steps:
+      - name: POST release.published to Sentinel
+        run: |
+          set -euo pipefail
+          curl -fSL -X POST "$SENTINEL_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer ${SENTINEL_TOKEN}" \
+            -d "{\"event\":\"release.published\",\"version\":\"${VERSION}\",\"url\":\"${RELEASE_URL}\"}"
+        timeout-minutes: 3
+
+  # R-242 (4/5): trigger a Studio rebuild via deploy hook. Studio runs
+  # outside this repo, so this job is a fire-and-forget POST.
+  studio-deploy:
+    name: Trigger Studio rebuild
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 20
+    env:
+      ENABLE_STUDIO_DEPLOY: 'true'
+      STUDIO_DEPLOY_HOOK: 'https://studio.example.com/deploy'
+      STUDIO_DEPLOY_TOKEN: ${{ secrets.STUDIO_DEPLOY_TOKEN }}
+      VERSION: ${{ github.event.release.tag_name }}
+    if: ${{ env.ENABLE_STUDIO_DEPLOY == 'true' }}
+    steps:
+      - name: POST to Studio deploy hook
+        run: |
+          set -euo pipefail
+          curl -fSL -X POST "$STUDIO_DEPLOY_HOOK" \
+            -H "Authorization: Bearer ${STUDIO_DEPLOY_TOKEN}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"version\":\"${VERSION}\"}"
+        timeout-minutes: 10
+
+  # R-242 (5/5): dispatch the nightly e2e workflow against the freshly
+  # published release version. Decoupled from the release path — a failed
+  # dispatch is logged but does NOT fail the release.
+  nightly-trigger:
+    name: Dispatch nightly e2e for release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 3
+    env:
+      ENABLE_NIGHTLY_TRIGGER: 'true'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ github.event.release.tag_name }}
+    if: ${{ env.ENABLE_NIGHTLY_TRIGGER == 'true' }}
+    steps:
+      - name: Dispatch nightly e2e
+        run: |
+          set -euo pipefail
+          gh workflow run nightly-e2e.yml \
+            --repo "${{ github.repository }}" \
+            -f release_version="$VERSION"
+        timeout-minutes: 2

--- a/packages/cleo/test/templates/release-fanout-render.test.ts
+++ b/packages/cleo/test/templates/release-fanout-render.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Snapshot test for the release-fanout.yml.tmpl workflow template (T9534).
+ *
+ * Renders the template with a sample placeholder set and compares against a
+ * checked-in snapshot at __snapshots__/release-fanout.yml.snap. If
+ * `actionlint` is available on PATH, the rendered output is also fed through
+ * actionlint to catch syntax errors that snapshot diffing alone misses.
+ *
+ * Asserts every SPEC-T9345-release-pipeline-v2.md §5.3 invariant:
+ *   - R-240 trigger on `release: published` only (NOT `release: created`).
+ *   - R-241 contents:read + per-job pages:write only.
+ *   - R-242 five independent best-effort jobs each `continue-on-error: true`.
+ *   - R-243 concurrency group fanout-<tag>, cancel-in-progress=false.
+ *   - R-244 fanout jobs are advisory (verified by absence of any
+ *           required-checks marker — checked via per-job continue-on-error).
+ *   - R-260 actionlint clean.
+ *   - R-262 defaults.run.shell: bash.
+ *   - R-263 third-party Actions pinned to major+minor.
+ *
+ * @task T9534
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'templates',
+  'workflows',
+  'release-fanout.yml.tmpl',
+);
+
+/**
+ * Minimal template renderer for `{{UPPER_SNAKE_CASE}}` placeholders.
+ *
+ * Performs a single deterministic regex substitution pass. Mirrors what the
+ * T9531 `cleo init --workflows` scaffolder is required to do — see
+ * workflows/README.md "Template contract".
+ *
+ * @param template Raw template source.
+ * @param values   Map from placeholder name (without braces) to substitution.
+ * @returns Rendered string with all placeholders replaced.
+ */
+function renderTemplate(template: string, values: Record<string, string>): string {
+  return template.replace(/{{([A-Z_]+)}}/g, (_match, name: string) => {
+    if (!(name in values)) {
+      throw new Error(`renderTemplate: missing value for {{${name}}}`);
+    }
+    return values[name]!;
+  });
+}
+
+/**
+ * Sample placeholder set used to render the snapshot. Mirrors what the
+ * scaffolder would derive from a typical pnpm/Node monorepo via ADR-061 +
+ * `.cleo/config.json` `release.fanout` overrides.
+ */
+const SAMPLE_VALUES: Record<string, string> = {
+  NODE_VERSION: '22.x',
+  INSTALL_CMD: 'pnpm install --frozen-lockfile',
+  DOCS_BUILD_CMD: 'pnpm --filter @cleocode/docs run build',
+  ENABLE_DOCS_DEPLOY: 'true',
+  ENABLE_DOCKER_RETAG: 'true',
+  ENABLE_SENTINEL_NOTIFY: 'true',
+  ENABLE_STUDIO_DEPLOY: 'true',
+  ENABLE_NIGHTLY_TRIGGER: 'true',
+  DOCKER_IMAGE: 'cleocode/cleo',
+  DOCKER_HUB_USER: 'cleocode',
+  SENTINEL_WEBHOOK_URL: 'https://sentinel.example.com/hooks/release',
+  STUDIO_DEPLOY_HOOK: 'https://studio.example.com/deploy',
+};
+
+const FANOUT_JOB_NAMES = [
+  'docs-deploy',
+  'docker-retag',
+  'sentinel-notify',
+  'studio-deploy',
+  'nightly-trigger',
+] as const;
+
+describe('release-fanout.yml.tmpl', () => {
+  const raw = readFileSync(TEMPLATE_PATH, 'utf8');
+
+  // Strip comment lines (anything starting with #) to assert against the live
+  // YAML body — doc-comments mentioning RFC2119 invariants don't trip
+  // negative matches.
+  const nonComment = raw
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('#'))
+    .join('\n');
+
+  it('contains every required placeholder', () => {
+    const found = new Set<string>();
+    for (const m of raw.matchAll(/{{([A-Z_]+)}}/g)) {
+      found.add(m[1]!);
+    }
+    for (const key of Object.keys(SAMPLE_VALUES)) {
+      expect(found, `expected placeholder {{${key}}} in template`).toContain(key);
+    }
+  });
+
+  it('triggers on release: published ONLY, not release: created (R-240)', () => {
+    // R-240: trigger is exactly `release: { types: [published] }`.
+    expect(nonComment).toMatch(/on:\s*\n\s*release:\s*\n\s*types:\s*\[\s*published\s*\]/);
+    // Negative: MUST NOT include `created` in the trigger types list.
+    const triggerMatch = nonComment.match(/on:\s*\n\s*release:\s*\n\s*types:\s*\[([^\]]+)\]/);
+    expect(triggerMatch, 'release trigger block present').not.toBeNull();
+    const triggerTypes = triggerMatch?.[1] ?? '';
+    expect(triggerTypes).not.toMatch(/\bcreated\b/);
+    expect(triggerTypes).not.toMatch(/\bedited\b/);
+    expect(triggerTypes).not.toMatch(/\bprereleased\b/);
+  });
+
+  it('declares the permission surface from SPEC §5.3 (R-241)', () => {
+    // R-241: workflow-level permissions block contains contents:read ONLY.
+    const workflowPermsMatch = nonComment.match(
+      /^permissions:\s*\n((?:\s{2,}.+\n?)+)/m,
+    );
+    expect(workflowPermsMatch, 'workflow-level permissions block').not.toBeNull();
+    const workflowPerms = workflowPermsMatch?.[1] ?? '';
+    expect(workflowPerms).toMatch(/contents:\s*read/);
+    // Negative: no top-level write scope of any kind.
+    expect(workflowPerms).not.toMatch(/contents:\s*write/);
+    expect(workflowPerms).not.toMatch(/packages:\s*write/);
+    expect(workflowPerms).not.toMatch(/pages:\s*write/);
+
+    // Per-job pages:write granted in docs-deploy ONLY.
+    const docsDeployStart = nonComment.indexOf('docs-deploy:');
+    const dockerRetagStart = nonComment.indexOf('docker-retag:');
+    expect(docsDeployStart).toBeGreaterThan(-1);
+    expect(dockerRetagStart).toBeGreaterThan(docsDeployStart);
+    const docsDeployBody = nonComment.slice(docsDeployStart, dockerRetagStart);
+    expect(docsDeployBody).toMatch(/pages:\s*write/);
+    expect(docsDeployBody).toMatch(/id-token:\s*write/);
+  });
+
+  it('declares 5 best-effort fanout jobs (R-242)', () => {
+    // R-242: jobs `docs-deploy`, `docker-retag`, `sentinel-notify`,
+    // `studio-deploy`, `nightly-trigger`.
+    for (const jobName of FANOUT_JOB_NAMES) {
+      expect(nonComment, `expected job ${jobName} in template`).toMatch(
+        new RegExp(`\\b${jobName}:\\s*\\n`),
+      );
+    }
+  });
+
+  it('marks EVERY fanout job continue-on-error: true (R-242)', () => {
+    // Slice the template into per-job bodies and assert each carries
+    // continue-on-error: true at the JOB level (not just step level).
+    for (let i = 0; i < FANOUT_JOB_NAMES.length; i++) {
+      const jobName = FANOUT_JOB_NAMES[i]!;
+      const start = nonComment.indexOf(`${jobName}:`);
+      expect(start, `${jobName} job declared`).toBeGreaterThan(-1);
+      const nextName = FANOUT_JOB_NAMES[i + 1];
+      const end = nextName ? nonComment.indexOf(`${nextName}:`) : nonComment.length;
+      const body = nonComment.slice(start, end);
+      expect(body, `${jobName} declares continue-on-error: true at job level`).toMatch(
+        /continue-on-error:\s*true/,
+      );
+    }
+  });
+
+  it('declares timeout-minutes on every fanout job', () => {
+    // Every job MUST have a job-level timeout-minutes to bound stalls.
+    for (let i = 0; i < FANOUT_JOB_NAMES.length; i++) {
+      const jobName = FANOUT_JOB_NAMES[i]!;
+      const start = nonComment.indexOf(`${jobName}:`);
+      const nextName = FANOUT_JOB_NAMES[i + 1];
+      const end = nextName ? nonComment.indexOf(`${nextName}:`) : nonComment.length;
+      const body = nonComment.slice(start, end);
+      expect(body, `${jobName} declares job-level timeout-minutes`).toMatch(
+        /^\s{2,4}timeout-minutes:\s*\d+/m,
+      );
+    }
+  });
+
+  it('gates every fanout job behind its ENABLE_* env toggle (R-242)', () => {
+    // Each job hoists ENABLE_<JOB> into env and gates `if:` on
+    // `env.ENABLE_<JOB> == 'true'`. The hoist matters for actionlint —
+    // hard-coded `'true' == 'true'` is a constant-expression warning.
+    const toggleByJob: Record<(typeof FANOUT_JOB_NAMES)[number], string> = {
+      'docs-deploy': 'ENABLE_DOCS_DEPLOY',
+      'docker-retag': 'ENABLE_DOCKER_RETAG',
+      'sentinel-notify': 'ENABLE_SENTINEL_NOTIFY',
+      'studio-deploy': 'ENABLE_STUDIO_DEPLOY',
+      'nightly-trigger': 'ENABLE_NIGHTLY_TRIGGER',
+    };
+    for (let i = 0; i < FANOUT_JOB_NAMES.length; i++) {
+      const jobName = FANOUT_JOB_NAMES[i]!;
+      const toggle = toggleByJob[jobName];
+      const start = nonComment.indexOf(`${jobName}:`);
+      const nextName = FANOUT_JOB_NAMES[i + 1];
+      const end = nextName ? nonComment.indexOf(`${nextName}:`) : nonComment.length;
+      const body = nonComment.slice(start, end);
+      // Hoisted into env.
+      expect(body, `${jobName} hoists ${toggle} into env`).toMatch(
+        new RegExp(`${toggle}:\\s*'\\{\\{${toggle}\\}\\}'`),
+      );
+      // if: env.ENABLE_* == 'true'
+      expect(body, `${jobName} gates if: on env.${toggle}`).toMatch(
+        new RegExp(`if:\\s*\\$\\{\\{\\s*env\\.${toggle}\\s*==\\s*'true'\\s*\\}\\}`),
+      );
+    }
+  });
+
+  it('enforces concurrency group fanout-<tag> + cancel-in-progress=false (R-243)', () => {
+    expect(raw).toMatch(
+      /group:\s*fanout-\$\{\{\s*github\.event\.release\.tag_name\s*\}\}/,
+    );
+    expect(raw).toMatch(/cancel-in-progress:\s*false/);
+  });
+
+  it('keeps fanout jobs advisory — no required-checks marker (R-244)', () => {
+    // R-244 is enforced at the BRANCH PROTECTION layer, not the workflow YAML.
+    // The workflow-side signal that a job is advisory is the combination of:
+    //   - continue-on-error: true on the job
+    //   - no `needs:` edge from a downstream gate
+    // We verify both:
+    //   (a) every fanout job has continue-on-error: true (covered above)
+    //   (b) no fanout job is referenced by `needs:` of any other job.
+    for (const jobName of FANOUT_JOB_NAMES) {
+      const needsPattern = new RegExp(
+        `needs:\\s*(?:${jobName}|\\[\\s*[^\\]]*\\b${jobName}\\b[^\\]]*\\]|(?:-\\s*\\S+\\s*\\n)*\\s*-\\s*${jobName}\\b)`,
+      );
+      expect(raw, `${jobName} MUST NOT be in any needs: edge (R-244)`).not.toMatch(
+        needsPattern,
+      );
+    }
+  });
+
+  it('sets defaults.run.shell: bash (R-262)', () => {
+    expect(raw).toMatch(/defaults:\s*\n\s*run:\s*\n\s*shell:\s*bash/);
+  });
+
+  it('pins third-party Actions to major+minor (R-263)', () => {
+    // Capture every `uses:` ref and assert no `@main`, `@master`, `@latest`,
+    // or bare-major (`@v4` without a minor) reference slips in.
+    const usesRefs = [...raw.matchAll(/uses:\s*([^\s\n]+)/g)].map((m) => m[1]!);
+    expect(usesRefs.length).toBeGreaterThan(0);
+    for (const ref of usesRefs) {
+      expect(ref, `pinned third-party Action: ${ref}`).not.toMatch(/@(main|master|latest)$/);
+      // Must be major+minor: `name@vX.Y` (e.g. `actions/checkout@v4.1`).
+      expect(ref, `${ref} must pin to major+minor`).toMatch(/@v\d+\.\d+$/);
+    }
+  });
+
+  it('renders deterministically and matches the checked-in snapshot', async () => {
+    const rendered = renderTemplate(raw, SAMPLE_VALUES);
+
+    // No unsubstituted placeholders left.
+    expect(rendered).not.toMatch(/{{[A-Z_]+}}/);
+
+    // Rendered output has the sample values inlined where expected.
+    expect(rendered).toContain("node-version: '22.x'");
+    expect(rendered).toContain('pnpm install --frozen-lockfile');
+    expect(rendered).toContain('pnpm --filter @cleocode/docs run build');
+    expect(rendered).toContain("ENABLE_DOCS_DEPLOY: 'true'");
+    expect(rendered).toContain("DOCKER_IMAGE: 'cleocode/cleo'");
+    expect(rendered).toContain("DOCKER_HUB_USER: 'cleocode'");
+    expect(rendered).toContain("SENTINEL_WEBHOOK_URL: 'https://sentinel.example.com/hooks/release'");
+    expect(rendered).toContain("STUDIO_DEPLOY_HOOK: 'https://studio.example.com/deploy'");
+
+    await expect(rendered).toMatchFileSnapshot(
+      './__snapshots__/release-fanout.yml.snap',
+    );
+  });
+
+  it('throws on missing placeholder values', () => {
+    expect(() =>
+      renderTemplate('hello {{UNKNOWN_KEY}}', { OTHER: 'x' }),
+    ).toThrow(/UNKNOWN_KEY/);
+  });
+});
+
+/**
+ * Optional actionlint gate (R-260). Skipped when `actionlint` is not on
+ * PATH so the test suite remains runnable in environments without it (e.g.
+ * sparse worker pods). CI is responsible for installing actionlint and
+ * exercising this code path — see SPEC AC-8.
+ */
+function hasActionlint(): boolean {
+  try {
+    execSync('command -v actionlint', { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const ACTIONLINT_DESCRIBE = hasActionlint() ? describe : describe.skip;
+
+ACTIONLINT_DESCRIBE('release-fanout.yml.tmpl actionlint gate', () => {
+  it('passes actionlint on the rendered output', () => {
+    const raw = readFileSync(TEMPLATE_PATH, 'utf8');
+    const rendered = renderTemplate(raw, SAMPLE_VALUES);
+    // `actionlint -` reads from stdin.
+    expect(() =>
+      execSync('actionlint -', {
+        input: rendered,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Third of four CLEO-templated GitHub Actions workflows per SPEC-T9345 §5.3. Fanout jobs are advisory + best-effort — a failed docs deploy, docker retag, sentinel notify, studio rebuild, or nightly dispatch does NOT mark the release as failed.

- Trigger: `release: published` ONLY (NOT `release: created`) — R-240
- 5 jobs, each gated by `{{ENABLE_*}}` env toggle + `continue-on-error: true` at the job level — R-242
- `concurrency: fanout-<tag>`, `cancel-in-progress: false` — R-243
- Fanout jobs MUST NOT be required status checks at the branch-protection layer — R-244
- All third-party Actions pinned to major+minor — R-263

## Changes
- `packages/cleo/templates/workflows/release-fanout.yml.tmpl` — workflow template
- `packages/cleo/templates/workflows/README.md` — fanout row in templates + permissions + secrets tables; 11 new fanout placeholders documented; §5.4 corrected from "reconcile" (a job inside publish) to "rollback" (the actual §5.4 workflow per SPEC R-250 — R-257)
- `packages/cleo/test/templates/release-fanout-render.test.ts` — 13 specs covering every R-240 through R-244 + R-262/R-263 invariant, plus actionlint gate (skipped when actionlint not on PATH)
- `packages/cleo/test/templates/__snapshots__/release-fanout.yml.snap` — checked-in deterministic snapshot

## Test plan
- [x] All R-240 (trigger), R-241 (perms), R-242 (jobs + continue-on-error), R-243 (concurrency), R-244 (advisory) invariants asserted
- [x] R-262 (bash) + R-263 (pinned Actions) asserted
- [x] Snapshot deterministic on second run
- [x] All 3 template snapshot test files pass: `33 passed | 3 skipped` (actionlint-gate specs skipped — not installed locally; CI runs them)

Closes T9534. Unblocks T9535 (rollback) + T9536 (init).

🤖 Generated with [Claude Code](https://claude.com/claude-code)