### PR TITLE
feat(T9535): release-rollback.yml.tmpl GHA template

### DIFF
--- a/packages/cleo/templates/workflows/README.md
+++ b/packages/cleo/templates/workflows/README.md
@@ -14,7 +14,7 @@ local `.cleo/project-context.json` and the ADR-061 tool resolver.
 | `release-prepare.yml.tmpl`        | §5.1         | Cut release branch, bump version, open bump-PR.        |
 | `release-publish.yml.tmpl`        | §5.2         | Publish + tag once the bump-PR is merged.              |
 | `release-fanout.yml.tmpl`         | §5.3         | Best-effort post-publish fanout (docs, docker, etc.).  |
-| `release-rollback.yml.tmpl`       | §5.4 *(T9535, future)* | Rollback workflow (revert PR + npm deprecate). |
+| `release-rollback.yml.tmpl`       | §5.4         | Rollback workflow (revert PR + npm deprecate + reconcile). |
 
 ## Template contract
 
@@ -57,6 +57,8 @@ placeholders for a given template are silently ignored by the scaffolder.
 | `{{DOCKER_HUB_USER}}` | `release.fanout.dockerHubUser` in `.cleo/config.json`  | *(none — required if `dockerRetag=true`)* | `cleocode`                     |
 | `{{SENTINEL_WEBHOOK_URL}}` | `release.fanout.sentinelWebhookUrl` in `.cleo/config.json` | *(none — required if `sentinelNotify=true`)* | `https://sentinel.example.com/hooks/release` |
 | `{{STUDIO_DEPLOY_HOOK}}` | `release.fanout.studioDeployHook` in `.cleo/config.json` | *(none — required if `studioDeploy=true`)*   | `https://studio.example.com/deploy`        |
+| `{{NPM_PACKAGES}}`    | `release.rollback.npmPackages` in `.cleo/config.json`  | *(none — required if `PUBLISHERS` contains `npm`)*   | `@cleocode/cleo @cleocode/core`            |
+| `{{CARGO_CRATES}}`    | `release.rollback.cargoCrates` in `.cleo/config.json`  | *(none — required if `PUBLISHERS` contains `cargo`)* | `cleo-core cleo-cli`                       |
 
 Source precedence (highest first):
 
@@ -83,6 +85,7 @@ Source precedence (highest first):
 | `release-prepare.yml.tmpl`   | `GITHUB_TOKEN` (auto)   | *(none)* — MUST NOT require `NPM_TOKEN` (R-210)   |
 | `release-publish.yml.tmpl`   | `GITHUB_TOKEN`, `NPM_TOKEN`, `ANTHROPIC_API_KEY` | `CARGO_TOKEN`, `PYPI_TOKEN`, `DOCKER_HUB_TOKEN` |
 | `release-fanout.yml.tmpl`    | `GITHUB_TOKEN` (auto)   | `DOCKER_HUB_TOKEN` (if `dockerRetag=true`), `SENTINEL_TOKEN` (if `sentinelNotify=true`), `STUDIO_DEPLOY_TOKEN` (if `studioDeploy=true`) |
+| `release-rollback.yml.tmpl`  | `GITHUB_TOKEN` (auto), `NPM_TOKEN` (if `PUBLISHERS` contains `npm`) | `CARGO_TOKEN` (if `PUBLISHERS` contains `cargo`) |
 
 ## Scaffolding workflow
 
@@ -130,8 +133,8 @@ declared permissions.
 - SPEC: `.cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md`
   - §5.1 → `release-prepare.yml.tmpl` *(T9532, landed)*
   - §5.2 → `release-publish.yml.tmpl` *(T9533, landed)*
-  - §5.3 → `release-fanout.yml.tmpl` *(T9534, current)*
-  - §5.4 → `release-rollback.yml.tmpl` *(T9535)*
+  - §5.3 → `release-fanout.yml.tmpl` *(T9534, landed)*
+  - §5.4 → `release-rollback.yml.tmpl` *(T9535, current)*
 - ADR-061 (tool resolver): governs `tool:*` placeholder resolution.
 - ADR-073 (release pipeline v2): umbrella architectural decision.
 - T9531: `cleo init --workflows` scaffold command (consumes these templates).
@@ -139,7 +142,16 @@ declared permissions.
 - T9533: `release-publish.yml.tmpl` + README placeholders + snapshot test
   (eliminates F6 tag-on-pre-merge-SHA race by construction).
 - T9534: `release-fanout.yml.tmpl` + 11 fanout placeholders + snapshot test
-  (current task — five independent best-effort jobs gated on env toggles,
-  every job carries `continue-on-error: true` so fanout failures cannot
-  mark the release as failed; fanout jobs MUST NOT be required status
-  checks per R-244).
+  (five independent best-effort jobs gated on env toggles, every job
+  carries `continue-on-error: true` so fanout failures cannot mark the
+  release as failed; fanout jobs MUST NOT be required status checks per
+  R-244).
+- T9535: `release-rollback.yml.tmpl` + rollback placeholders (`NPM_PACKAGES`,
+  `CARGO_CRATES`) + snapshot test (current task — `workflow_dispatch`-only
+  rollback with 4 jobs `validate` → `revert` → `deprecate` →
+  `reconcile-rollback`. The `revert` job opens a revert PR against `main`
+  via `gh pr create --label rollback` — NEVER pushes directly to `main`
+  per ADR-065. The `deprecate` job is best-effort
+  (`continue-on-error: true`); reconcile runs whenever validate succeeded
+  so the provenance graph records the operator's intent even if a
+  downstream side-effect failed).

--- a/packages/cleo/templates/workflows/release-rollback.yml.tmpl
+++ b/packages/cleo/templates/workflows/release-rollback.yml.tmpl
@@ -1,0 +1,322 @@
+# CLEO release pipeline — Rollback workflow.
+#
+# Generated from packages/cleo/templates/workflows/release-rollback.yml.tmpl by
+# `cleo init --workflows` (T9531). DO NOT EDIT the rendered file directly —
+# extend via `.workflow-overrides.yml` per SPEC-T9345 R-260.
+#
+# Implements SPEC-T9345-release-pipeline-v2.md §5.4 (R-250 — R-257, R-260 —
+# R-263). Triggers ONLY on `workflow_dispatch` with `version`, `mode`
+# (`metadata-only|full`), and `reason` inputs. For `mode=full`, opens a
+# revert PR against `main` (NEVER pushes directly to `main` per ADR-065),
+# then runs `npm deprecate` (best-effort) and finally records the rollback
+# in the provenance graph via `cleo release reconcile --rollback`.
+#
+# Placeholders (replaced at scaffold time — see workflows/README.md):
+#   <NODE_VERSION>     Node.js version           (e.g. "22.x")
+#   <PUBLISHERS>       Space-separated publisher list (e.g. "npm cargo")
+#   <NPM_PACKAGES>     Space-separated npm package names to deprecate
+#                      (e.g. "@cleocode/cleo @cleocode/core")
+#   <CARGO_CRATES>     Space-separated cargo crate names to yank
+#                      (e.g. "cleo-core cleo-cli")
+# (Angle-brackets in this doc comment are intentional — they avoid being
+#  substituted by the {{...}} regex pass. The placeholders below use {{...}}.)
+
+name: Release Rollback
+
+# R-250: workflow_dispatch only — rollback is an explicit operator action,
+# never an automatic response to push/release events.
+# R-251: required inputs `version`, `mode` (choice), `reason` (free text).
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to roll back (e.g. v2026.6.0)'
+        type: string
+        required: true
+      mode:
+        description: 'Rollback mode — metadata-only deprecates packages; full also opens a revert PR'
+        type: choice
+        required: true
+        options:
+          - metadata-only
+          - full
+      reason:
+        description: 'Human-readable reason recorded with the rollback'
+        type: string
+        required: true
+
+# R-252: workflow-level grants minimum read scope. The `revert` and
+# `deprecate` jobs escalate per-job. `pull-requests: write` and
+# `packages: write` MUST NOT be inherited workflow-wide so reconcile
+# CANNOT silently widen its blast radius.
+permissions:
+  contents: read
+
+# R-257: serialize rollbacks against the same version. cancel-in-progress
+# is FALSE so an in-flight rollback completes rather than leaving the
+# revert PR / npm deprecate state half-applied.
+concurrency:
+  group: rollback-${{ inputs.version }}
+  cancel-in-progress: false
+
+# R-262: bash everywhere — no cross-platform shell drift.
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # R-253 (1/4): validate the rollback request. Confirms the tag exists
+  # and resolves the release commit SHA so the `revert` job has a fixed
+  # target. A missing tag MUST fail fast — no downstream side effects.
+  validate:
+    name: Validate rollback request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      release_sha: ${{ steps.find.outputs.release_sha }}
+    steps:
+      # R-263: third-party Actions pinned to major+minor.
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+        timeout-minutes: 5
+
+      - name: Resolve release commit SHA
+        id: find
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          if ! git rev-parse --verify "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION does not exist — cannot roll back a release that was never tagged."
+            exit 1
+          fi
+          # The release commit is the commit the tag points to (peeled).
+          RELEASE_SHA=$(git rev-list -n 1 "$VERSION")
+          if [ -z "$RELEASE_SHA" ]; then
+            echo "::error::Could not resolve commit SHA for tag $VERSION"
+            exit 1
+          fi
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved $VERSION -> $RELEASE_SHA"
+        timeout-minutes: 2
+
+  # R-253 (2/4) + R-254: open a revert PR for `mode=full`. NEVER pushes
+  # directly to `main` (ADR-065). The PR title MUST be
+  # `Revert release <version>: <reason>` and MUST carry the `rollback`
+  # label so branch-protection / triage automation can route it.
+  revert:
+    name: Open revert PR
+    needs: validate
+    if: inputs.mode == 'full'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # R-252: per-job escalation — `contents: write` for the revert
+    # branch commit; `pull-requests: write` for `gh pr create`. NO
+    # `packages: write` here — that belongs to the `deprecate` job only.
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ inputs.version }}
+      REASON: ${{ inputs.reason }}
+      RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 5
+
+      - name: Configure git identity
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+        timeout-minutes: 1
+
+      # R-254: cut `revert/<version>` branch, run `git revert -n` against
+      # the resolved release commit, commit with the canonical subject.
+      # Branch is cut from the action's checked-out main HEAD so the
+      # revert applies on top of current main.
+      - name: Create revert branch and commit
+        run: |
+          set -euo pipefail
+          BRANCH="revert/${VERSION}"
+          git checkout -b "$BRANCH"
+          # `-n` (no-commit) lets us craft the subject line ourselves.
+          # `-m 1` selects the first parent when the release commit is a
+          # merge (the bump-PR merge into main), which is the canonical
+          # release-commit shape for ADR-065 PR-gated releases.
+          if git rev-parse --verify "${RELEASE_SHA}^2" >/dev/null 2>&1; then
+            git revert -n -m 1 "$RELEASE_SHA"
+          else
+            git revert -n "$RELEASE_SHA"
+          fi
+          git commit -m "Revert release ${VERSION}: ${REASON}"
+        timeout-minutes: 5
+
+      # R-254 (continued): push the revert branch — NEVER `git push origin
+      # main`. Branch protection on main is the second line of defence,
+      # but the workflow MUST NOT rely on it.
+      - name: Push revert branch
+        run: git push -u origin "revert/${VERSION}"
+        timeout-minutes: 5
+
+      # R-254 (continued): open the revert PR with the canonical title
+      # and the `rollback` label. The PR body links back to this
+      # workflow run so reviewers can audit the rollback context.
+      - name: Open revert PR
+        run: |
+          set -euo pipefail
+          gh pr create \
+            --base main \
+            --head "revert/${VERSION}" \
+            --title "Revert release ${VERSION}: ${REASON}" \
+            --label rollback \
+            --body "Automated rollback PR for release **${VERSION}**.
+
+**Reason**: ${REASON}
+
+This PR reverts commit \`${RELEASE_SHA}\` (the merge commit the
+release tag points to). It was opened by the \`release-rollback.yml\`
+workflow — see the workflow run for full context:
+${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+After this PR merges, the package registries have already been marked
+as deprecated by the \`deprecate\` job, and the provenance graph has
+been updated by the \`reconcile-rollback\` job."
+        timeout-minutes: 5
+
+  # R-253 (3/4) + R-255: deprecate published artifacts. Best-effort —
+  # `continue-on-error: true` so a transient registry hiccup CANNOT
+  # block the reconcile-rollback step. Runs for BOTH `metadata-only`
+  # and `full` modes since deprecation is the core rollback signal.
+  deprecate:
+    name: Deprecate published artifacts
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    # R-252: per-job `packages: write` for npm deprecate. NO
+    # `contents: write` — this job MUST NOT touch git refs.
+    permissions:
+      contents: read
+      packages: write
+    env:
+      VERSION: ${{ inputs.version }}
+      REASON: ${{ inputs.reason }}
+      # Hoisted into env so downstream `contains(env.PUBLISHERS, ...)`
+      # is a dynamic expression (avoids actionlint constant-expression
+      # warnings — same pattern as release-publish.yml.tmpl).
+      PUBLISHERS: '{{PUBLISHERS}}'
+      NPM_PACKAGES: '{{NPM_PACKAGES}}'
+      CARGO_CRATES: '{{CARGO_CRATES}}'
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '{{NODE_VERSION}}'
+          registry-url: 'https://registry.npmjs.org'
+        timeout-minutes: 3
+
+      # R-255: `npm deprecate <pkg>@<version> "Rolled back: <reason>"`
+      # per published artifact. Failure is NON-FATAL — each iteration
+      # is wrapped so one package's failure cannot stop the others.
+      - name: Deprecate npm packages
+        if: contains(env.PUBLISHERS, 'npm')
+        run: |
+          set -uo pipefail
+          STRIPPED="${VERSION#v}"
+          for pkg in ${NPM_PACKAGES}; do
+            if npm deprecate "$pkg@$STRIPPED" "Rolled back: ${REASON}"; then
+              echo "Deprecated $pkg@$STRIPPED"
+            else
+              echo "::warning::Failed to deprecate $pkg@$STRIPPED — continuing"
+            fi
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        timeout-minutes: 10
+
+      # R-255 (extension for cargo): `cargo yank` is the cargo analogue
+      # of `npm deprecate`. Also best-effort — a missing crate or a
+      # rate-limit response MUST NOT block reconcile.
+      - name: Yank cargo crates
+        if: contains(env.PUBLISHERS, 'cargo')
+        run: |
+          set -uo pipefail
+          STRIPPED="${VERSION#v}"
+          for crate in ${CARGO_CRATES}; do
+            if cargo yank --version "$STRIPPED" "$crate"; then
+              echo "Yanked $crate@$STRIPPED"
+            else
+              echo "::warning::Failed to yank $crate@$STRIPPED — continuing"
+            fi
+          done
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        timeout-minutes: 10
+
+  # R-253 (4/4) + R-256: record the rollback in the provenance graph via
+  # `cleo release reconcile <version> --rollback --reason "<reason>"`.
+  # This writes `releases.rolled_back_at` and inserts a
+  # `release_changes` row with `change_type='revert'`. Runs after
+  # `validate` regardless of `revert` / `deprecate` outcome — provenance
+  # must record the operator's intent even if individual side-effects
+  # failed.
+  reconcile-rollback:
+    name: Record rollback in provenance graph
+    needs:
+      - validate
+    if: always() && needs.validate.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      VERSION: ${{ inputs.version }}
+      REASON: ${{ inputs.reason }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+        timeout-minutes: 5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '{{NODE_VERSION}}'
+          registry-url: 'https://registry.npmjs.org'
+        timeout-minutes: 3
+
+      - name: Install cleo
+        run: npm install -g @cleocode/cleo
+        timeout-minutes: 5
+
+      # R-256: reconcile MUST write rollback marker into `releases` +
+      # `release_changes`. The CLI is the canonical writer — workflow
+      # YAML never touches the DB directly.
+      - name: Record rollback
+        run: cleo release reconcile "${VERSION}" --rollback --reason "${REASON}"
+        timeout-minutes: 5
+
+      # Recovery hint in the job summary so an operator who sees a
+      # half-applied rollback can finish the job from a local checkout.
+      - name: Emit recovery hint
+        if: always()
+        run: |
+          {
+            echo "## Release Rollback — ${VERSION}"
+            echo ""
+            echo "**Mode**: \`${{ inputs.mode }}\`"
+            echo "**Reason**: ${REASON}"
+            echo ""
+            echo "**Recovery commands** (if anything went wrong):"
+            echo ""
+            echo "\`\`\`"
+            echo "cleo release reconcile ${VERSION} --rollback --reason \"${REASON}\""
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+        timeout-minutes: 1

--- a/packages/cleo/test/templates/__snapshots__/release-rollback.yml.snap
+++ b/packages/cleo/test/templates/__snapshots__/release-rollback.yml.snap
@@ -1,0 +1,322 @@
+# CLEO release pipeline — Rollback workflow.
+#
+# Generated from packages/cleo/templates/workflows/release-rollback.yml.tmpl by
+# `cleo init --workflows` (T9531). DO NOT EDIT the rendered file directly —
+# extend via `.workflow-overrides.yml` per SPEC-T9345 R-260.
+#
+# Implements SPEC-T9345-release-pipeline-v2.md §5.4 (R-250 — R-257, R-260 —
+# R-263). Triggers ONLY on `workflow_dispatch` with `version`, `mode`
+# (`metadata-only|full`), and `reason` inputs. For `mode=full`, opens a
+# revert PR against `main` (NEVER pushes directly to `main` per ADR-065),
+# then runs `npm deprecate` (best-effort) and finally records the rollback
+# in the provenance graph via `cleo release reconcile --rollback`.
+#
+# Placeholders (replaced at scaffold time — see workflows/README.md):
+#   <NODE_VERSION>     Node.js version           (e.g. "22.x")
+#   <PUBLISHERS>       Space-separated publisher list (e.g. "npm cargo")
+#   <NPM_PACKAGES>     Space-separated npm package names to deprecate
+#                      (e.g. "@cleocode/cleo @cleocode/core")
+#   <CARGO_CRATES>     Space-separated cargo crate names to yank
+#                      (e.g. "cleo-core cleo-cli")
+# (Angle-brackets in this doc comment are intentional — they avoid being
+#  substituted by the {{...}} regex pass. The placeholders below use {{...}}.)
+
+name: Release Rollback
+
+# R-250: workflow_dispatch only — rollback is an explicit operator action,
+# never an automatic response to push/release events.
+# R-251: required inputs `version`, `mode` (choice), `reason` (free text).
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to roll back (e.g. v2026.6.0)'
+        type: string
+        required: true
+      mode:
+        description: 'Rollback mode — metadata-only deprecates packages; full also opens a revert PR'
+        type: choice
+        required: true
+        options:
+          - metadata-only
+          - full
+      reason:
+        description: 'Human-readable reason recorded with the rollback'
+        type: string
+        required: true
+
+# R-252: workflow-level grants minimum read scope. The `revert` and
+# `deprecate` jobs escalate per-job. `pull-requests: write` and
+# `packages: write` MUST NOT be inherited workflow-wide so reconcile
+# CANNOT silently widen its blast radius.
+permissions:
+  contents: read
+
+# R-257: serialize rollbacks against the same version. cancel-in-progress
+# is FALSE so an in-flight rollback completes rather than leaving the
+# revert PR / npm deprecate state half-applied.
+concurrency:
+  group: rollback-${{ inputs.version }}
+  cancel-in-progress: false
+
+# R-262: bash everywhere — no cross-platform shell drift.
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # R-253 (1/4): validate the rollback request. Confirms the tag exists
+  # and resolves the release commit SHA so the `revert` job has a fixed
+  # target. A missing tag MUST fail fast — no downstream side effects.
+  validate:
+    name: Validate rollback request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      release_sha: ${{ steps.find.outputs.release_sha }}
+    steps:
+      # R-263: third-party Actions pinned to major+minor.
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+        timeout-minutes: 5
+
+      - name: Resolve release commit SHA
+        id: find
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          if ! git rev-parse --verify "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION does not exist — cannot roll back a release that was never tagged."
+            exit 1
+          fi
+          # The release commit is the commit the tag points to (peeled).
+          RELEASE_SHA=$(git rev-list -n 1 "$VERSION")
+          if [ -z "$RELEASE_SHA" ]; then
+            echo "::error::Could not resolve commit SHA for tag $VERSION"
+            exit 1
+          fi
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved $VERSION -> $RELEASE_SHA"
+        timeout-minutes: 2
+
+  # R-253 (2/4) + R-254: open a revert PR for `mode=full`. NEVER pushes
+  # directly to `main` (ADR-065). The PR title MUST be
+  # `Revert release <version>: <reason>` and MUST carry the `rollback`
+  # label so branch-protection / triage automation can route it.
+  revert:
+    name: Open revert PR
+    needs: validate
+    if: inputs.mode == 'full'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # R-252: per-job escalation — `contents: write` for the revert
+    # branch commit; `pull-requests: write` for `gh pr create`. NO
+    # `packages: write` here — that belongs to the `deprecate` job only.
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ inputs.version }}
+      REASON: ${{ inputs.reason }}
+      RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 5
+
+      - name: Configure git identity
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+        timeout-minutes: 1
+
+      # R-254: cut `revert/<version>` branch, run `git revert -n` against
+      # the resolved release commit, commit with the canonical subject.
+      # Branch is cut from the action's checked-out main HEAD so the
+      # revert applies on top of current main.
+      - name: Create revert branch and commit
+        run: |
+          set -euo pipefail
+          BRANCH="revert/${VERSION}"
+          git checkout -b "$BRANCH"
+          # `-n` (no-commit) lets us craft the subject line ourselves.
+          # `-m 1` selects the first parent when the release commit is a
+          # merge (the bump-PR merge into main), which is the canonical
+          # release-commit shape for ADR-065 PR-gated releases.
+          if git rev-parse --verify "${RELEASE_SHA}^2" >/dev/null 2>&1; then
+            git revert -n -m 1 "$RELEASE_SHA"
+          else
+            git revert -n "$RELEASE_SHA"
+          fi
+          git commit -m "Revert release ${VERSION}: ${REASON}"
+        timeout-minutes: 5
+
+      # R-254 (continued): push the revert branch — NEVER `git push origin
+      # main`. Branch protection on main is the second line of defence,
+      # but the workflow MUST NOT rely on it.
+      - name: Push revert branch
+        run: git push -u origin "revert/${VERSION}"
+        timeout-minutes: 5
+
+      # R-254 (continued): open the revert PR with the canonical title
+      # and the `rollback` label. The PR body links back to this
+      # workflow run so reviewers can audit the rollback context.
+      - name: Open revert PR
+        run: |
+          set -euo pipefail
+          gh pr create \
+            --base main \
+            --head "revert/${VERSION}" \
+            --title "Revert release ${VERSION}: ${REASON}" \
+            --label rollback \
+            --body "Automated rollback PR for release **${VERSION}**.
+
+**Reason**: ${REASON}
+
+This PR reverts commit \`${RELEASE_SHA}\` (the merge commit the
+release tag points to). It was opened by the \`release-rollback.yml\`
+workflow — see the workflow run for full context:
+${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+After this PR merges, the package registries have already been marked
+as deprecated by the \`deprecate\` job, and the provenance graph has
+been updated by the \`reconcile-rollback\` job."
+        timeout-minutes: 5
+
+  # R-253 (3/4) + R-255: deprecate published artifacts. Best-effort —
+  # `continue-on-error: true` so a transient registry hiccup CANNOT
+  # block the reconcile-rollback step. Runs for BOTH `metadata-only`
+  # and `full` modes since deprecation is the core rollback signal.
+  deprecate:
+    name: Deprecate published artifacts
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    # R-252: per-job `packages: write` for npm deprecate. NO
+    # `contents: write` — this job MUST NOT touch git refs.
+    permissions:
+      contents: read
+      packages: write
+    env:
+      VERSION: ${{ inputs.version }}
+      REASON: ${{ inputs.reason }}
+      # Hoisted into env so downstream `contains(env.PUBLISHERS, ...)`
+      # is a dynamic expression (avoids actionlint constant-expression
+      # warnings — same pattern as release-publish.yml.tmpl).
+      PUBLISHERS: 'npm cargo'
+      NPM_PACKAGES: '@cleocode/cleo @cleocode/core'
+      CARGO_CRATES: 'cleo-core cleo-cli'
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+        timeout-minutes: 3
+
+      # R-255: `npm deprecate <pkg>@<version> "Rolled back: <reason>"`
+      # per published artifact. Failure is NON-FATAL — each iteration
+      # is wrapped so one package's failure cannot stop the others.
+      - name: Deprecate npm packages
+        if: contains(env.PUBLISHERS, 'npm')
+        run: |
+          set -uo pipefail
+          STRIPPED="${VERSION#v}"
+          for pkg in ${NPM_PACKAGES}; do
+            if npm deprecate "$pkg@$STRIPPED" "Rolled back: ${REASON}"; then
+              echo "Deprecated $pkg@$STRIPPED"
+            else
+              echo "::warning::Failed to deprecate $pkg@$STRIPPED — continuing"
+            fi
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        timeout-minutes: 10
+
+      # R-255 (extension for cargo): `cargo yank` is the cargo analogue
+      # of `npm deprecate`. Also best-effort — a missing crate or a
+      # rate-limit response MUST NOT block reconcile.
+      - name: Yank cargo crates
+        if: contains(env.PUBLISHERS, 'cargo')
+        run: |
+          set -uo pipefail
+          STRIPPED="${VERSION#v}"
+          for crate in ${CARGO_CRATES}; do
+            if cargo yank --version "$STRIPPED" "$crate"; then
+              echo "Yanked $crate@$STRIPPED"
+            else
+              echo "::warning::Failed to yank $crate@$STRIPPED — continuing"
+            fi
+          done
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        timeout-minutes: 10
+
+  # R-253 (4/4) + R-256: record the rollback in the provenance graph via
+  # `cleo release reconcile <version> --rollback --reason "<reason>"`.
+  # This writes `releases.rolled_back_at` and inserts a
+  # `release_changes` row with `change_type='revert'`. Runs after
+  # `validate` regardless of `revert` / `deprecate` outcome — provenance
+  # must record the operator's intent even if individual side-effects
+  # failed.
+  reconcile-rollback:
+    name: Record rollback in provenance graph
+    needs:
+      - validate
+    if: always() && needs.validate.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      VERSION: ${{ inputs.version }}
+      REASON: ${{ inputs.reason }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1
+        with:
+          fetch-depth: 0
+        timeout-minutes: 5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+        timeout-minutes: 3
+
+      - name: Install cleo
+        run: npm install -g @cleocode/cleo
+        timeout-minutes: 5
+
+      # R-256: reconcile MUST write rollback marker into `releases` +
+      # `release_changes`. The CLI is the canonical writer — workflow
+      # YAML never touches the DB directly.
+      - name: Record rollback
+        run: cleo release reconcile "${VERSION}" --rollback --reason "${REASON}"
+        timeout-minutes: 5
+
+      # Recovery hint in the job summary so an operator who sees a
+      # half-applied rollback can finish the job from a local checkout.
+      - name: Emit recovery hint
+        if: always()
+        run: |
+          {
+            echo "## Release Rollback — ${VERSION}"
+            echo ""
+            echo "**Mode**: \`${{ inputs.mode }}\`"
+            echo "**Reason**: ${REASON}"
+            echo ""
+            echo "**Recovery commands** (if anything went wrong):"
+            echo ""
+            echo "\`\`\`"
+            echo "cleo release reconcile ${VERSION} --rollback --reason \"${REASON}\""
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+        timeout-minutes: 1

--- a/packages/cleo/test/templates/release-rollback-render.test.ts
+++ b/packages/cleo/test/templates/release-rollback-render.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Snapshot test for the release-rollback.yml.tmpl workflow template (T9535).
+ *
+ * Renders the template with a sample placeholder set and compares against a
+ * checked-in snapshot at __snapshots__/release-rollback.yml.snap. If
+ * `actionlint` is available on PATH, the rendered output is also fed through
+ * actionlint to catch syntax errors that snapshot diffing alone misses.
+ *
+ * Asserts every SPEC-T9345-release-pipeline-v2.md §5.4 invariant:
+ *   - R-250 trigger on `workflow_dispatch` only.
+ *   - R-251 inputs `version` (string, required), `mode` (choice
+ *           `metadata-only|full`, required), `reason` (string, required).
+ *   - R-252 for `mode=full` the workflow surfaces `contents: write`,
+ *           `pull-requests: write`, `packages: write` (per-job, not
+ *           workflow-level).
+ *   - R-253 four jobs in order: validate → revert → deprecate →
+ *           reconcile-rollback.
+ *   - R-254 revert job opens a revert PR via `gh pr create --label rollback`
+ *           — MUST NOT push directly to `main` (ADR-065).
+ *   - R-255 deprecate job runs `npm deprecate ...` per artifact and is
+ *           `continue-on-error: true` (failure non-fatal).
+ *   - R-256 reconcile-rollback invokes
+ *           `cleo release reconcile <version> --rollback --reason "<reason>"`.
+ *   - R-257 concurrency group rollback-<version>, cancel-in-progress=false.
+ *   - R-260 actionlint clean.
+ *   - R-262 defaults.run.shell: bash.
+ *   - R-263 third-party Actions pinned to major+minor.
+ *
+ * @task T9535
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'templates',
+  'workflows',
+  'release-rollback.yml.tmpl',
+);
+
+/**
+ * Minimal template renderer for `{{UPPER_SNAKE_CASE}}` placeholders.
+ *
+ * Performs a single deterministic regex substitution pass. Mirrors what the
+ * T9531 `cleo init --workflows` scaffolder is required to do — see
+ * workflows/README.md "Template contract".
+ *
+ * @param template Raw template source.
+ * @param values   Map from placeholder name (without braces) to substitution.
+ * @returns Rendered string with all placeholders replaced.
+ */
+function renderTemplate(template: string, values: Record<string, string>): string {
+  return template.replace(/{{([A-Z_]+)}}/g, (_match, name: string) => {
+    if (!(name in values)) {
+      throw new Error(`renderTemplate: missing value for {{${name}}}`);
+    }
+    return values[name]!;
+  });
+}
+
+/**
+ * Sample placeholder set used to render the snapshot. Mirrors what the
+ * scaffolder would derive from a typical pnpm/Node monorepo via ADR-061 +
+ * `.cleo/config.json` `release.rollback` overrides.
+ */
+const SAMPLE_VALUES: Record<string, string> = {
+  NODE_VERSION: '22.x',
+  PUBLISHERS: 'npm cargo',
+  NPM_PACKAGES: '@cleocode/cleo @cleocode/core',
+  CARGO_CRATES: 'cleo-core cleo-cli',
+};
+
+const JOB_NAMES = [
+  'validate',
+  'revert',
+  'deprecate',
+  'reconcile-rollback',
+] as const;
+
+describe('release-rollback.yml.tmpl', () => {
+  const raw = readFileSync(TEMPLATE_PATH, 'utf8');
+
+  // Strip comment lines (anything starting with #) to assert against the live
+  // YAML body — doc-comments mentioning RFC2119 invariants don't trip
+  // negative matches.
+  const nonComment = raw
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('#'))
+    .join('\n');
+
+  it('contains every required placeholder', () => {
+    const found = new Set<string>();
+    for (const m of raw.matchAll(/{{([A-Z_]+)}}/g)) {
+      found.add(m[1]!);
+    }
+    for (const key of Object.keys(SAMPLE_VALUES)) {
+      expect(found, `expected placeholder {{${key}}} in template`).toContain(key);
+    }
+  });
+
+  it('triggers on workflow_dispatch ONLY (R-250)', () => {
+    // R-250: trigger is exactly `on: workflow_dispatch: ...` — no push,
+    // release, pull_request, schedule, or repository_dispatch.
+    expect(nonComment).toMatch(/on:\s*\n\s*workflow_dispatch:/);
+    expect(nonComment).not.toMatch(/^\s*push:\s*$/m);
+    expect(nonComment).not.toMatch(/^\s*pull_request:\s*$/m);
+    expect(nonComment).not.toMatch(/^\s*release:\s*$/m);
+    expect(nonComment).not.toMatch(/^\s*schedule:\s*$/m);
+    expect(nonComment).not.toMatch(/^\s*repository_dispatch:\s*$/m);
+  });
+
+  it('declares required inputs version + mode (choice) + reason (R-251)', () => {
+    // Slice the dispatch input block out of the trigger declaration.
+    const dispatchMatch = nonComment.match(
+      /on:\s*\n\s*workflow_dispatch:\s*\n\s*inputs:\s*\n([\s\S]+?)(?=\npermissions:|\nconcurrency:|\ndefaults:|\njobs:|\Z)/,
+    );
+    expect(dispatchMatch, 'workflow_dispatch.inputs block present').not.toBeNull();
+    const inputs = dispatchMatch?.[1] ?? '';
+
+    // R-251 input `version` (string, required).
+    expect(inputs).toMatch(/\bversion:\s*\n[\s\S]+?type:\s*string[\s\S]+?required:\s*true/);
+
+    // R-251 input `mode` (choice with metadata-only|full, required).
+    expect(inputs).toMatch(/\bmode:\s*\n[\s\S]+?type:\s*choice/);
+    expect(inputs).toMatch(/metadata-only/);
+    expect(inputs).toMatch(/-\s*full\b/);
+    expect(inputs).toMatch(/\bmode:\s*\n[\s\S]+?required:\s*true/);
+
+    // R-251 input `reason` (string, required).
+    expect(inputs).toMatch(/\breason:\s*\n[\s\S]+?type:\s*string[\s\S]+?required:\s*true/);
+  });
+
+  it('declares the permission surface from SPEC §5.4 (R-252)', () => {
+    // Workflow-level permissions block contains contents:read ONLY.
+    const workflowPermsMatch = nonComment.match(
+      /^permissions:\s*\n((?:\s{2,}.+\n?)+)/m,
+    );
+    expect(workflowPermsMatch, 'workflow-level permissions block').not.toBeNull();
+    const workflowPerms = workflowPermsMatch?.[1] ?? '';
+    expect(workflowPerms).toMatch(/contents:\s*read/);
+    // Negative: no top-level write scope of any kind.
+    expect(workflowPerms).not.toMatch(/contents:\s*write/);
+    expect(workflowPerms).not.toMatch(/packages:\s*write/);
+    expect(workflowPerms).not.toMatch(/pull-requests:\s*write/);
+
+    // Per-job: `revert` MUST have contents: write + pull-requests: write.
+    const revertStart = nonComment.indexOf('revert:');
+    const deprecateStart = nonComment.indexOf('deprecate:');
+    expect(revertStart).toBeGreaterThan(-1);
+    expect(deprecateStart).toBeGreaterThan(revertStart);
+    const revertBody = nonComment.slice(revertStart, deprecateStart);
+    expect(revertBody, 'revert job grants contents: write').toMatch(/contents:\s*write/);
+    expect(revertBody, 'revert job grants pull-requests: write').toMatch(
+      /pull-requests:\s*write/,
+    );
+
+    // Per-job: `deprecate` MUST have packages: write.
+    const reconcileStart = nonComment.indexOf('reconcile-rollback:');
+    expect(reconcileStart).toBeGreaterThan(deprecateStart);
+    const deprecateBody = nonComment.slice(deprecateStart, reconcileStart);
+    expect(deprecateBody, 'deprecate job grants packages: write').toMatch(
+      /packages:\s*write/,
+    );
+  });
+
+  it('declares 4 jobs in order: validate → revert → deprecate → reconcile-rollback (R-253)', () => {
+    const indices = JOB_NAMES.map((name) => ({
+      name,
+      idx: nonComment.indexOf(`${name}:`),
+    }));
+    for (const { name, idx } of indices) {
+      expect(idx, `expected job ${name} in template`).toBeGreaterThan(-1);
+    }
+    // Ordering: indices MUST be strictly ascending.
+    for (let i = 1; i < indices.length; i++) {
+      expect(
+        indices[i]!.idx,
+        `job ${indices[i]!.name} must appear after ${indices[i - 1]!.name}`,
+      ).toBeGreaterThan(indices[i - 1]!.idx);
+    }
+  });
+
+  it('threads needs: edges in the canonical order (R-253)', () => {
+    // revert needs validate. deprecate needs validate. reconcile-rollback
+    // needs at least validate (it MAY also `needs: revert` but the SPEC
+    // pins the dependency on validate as the canonical edge).
+    const revertStart = nonComment.indexOf('revert:');
+    const deprecateStart = nonComment.indexOf('deprecate:');
+    const reconcileStart = nonComment.indexOf('reconcile-rollback:');
+    const revertBody = nonComment.slice(revertStart, deprecateStart);
+    const deprecateBody = nonComment.slice(deprecateStart, reconcileStart);
+    const reconcileBody = nonComment.slice(reconcileStart);
+
+    expect(revertBody, 'revert needs validate').toMatch(/needs:\s*validate/);
+    expect(deprecateBody, 'deprecate needs validate').toMatch(/needs:\s*validate/);
+    expect(reconcileBody, 'reconcile-rollback needs validate').toMatch(
+      /needs:\s*(?:validate|\n\s*-\s*validate\b|\[\s*[^\]]*\bvalidate\b)/,
+    );
+  });
+
+  it('gates revert job on mode == full (R-254)', () => {
+    const revertStart = nonComment.indexOf('revert:');
+    const deprecateStart = nonComment.indexOf('deprecate:');
+    const revertBody = nonComment.slice(revertStart, deprecateStart);
+    expect(revertBody, "revert gates on inputs.mode == 'full'").toMatch(
+      /if:\s*inputs\.mode\s*==\s*'full'/,
+    );
+  });
+
+  it('revert job opens a revert PR via gh pr create — NEVER pushes to main (R-254 + ADR-065)', () => {
+    const revertStart = nonComment.indexOf('revert:');
+    const deprecateStart = nonComment.indexOf('deprecate:');
+    const revertBody = nonComment.slice(revertStart, deprecateStart);
+
+    // Creates a revert/<version> branch. The template assigns
+    // BRANCH="revert/${VERSION}" then `git checkout -b "$BRANCH"`, so we
+    // assert the BRANCH binding pattern AND the checkout invocation.
+    expect(revertBody, 'binds BRANCH to revert/<version>').toMatch(
+      /revert\/\$\{[A-Z_]*VERSION\}|revert\/\$\{\{\s*inputs\.version\s*\}\}/,
+    );
+    expect(revertBody, 'runs git checkout -b on the revert branch').toMatch(
+      /git\s+checkout\s+-b\s+["']?(?:\$\{?BRANCH\}?|revert\/)/,
+    );
+
+    // Uses git revert (NOT git reset).
+    expect(revertBody, 'uses git revert').toMatch(/git\s+revert/);
+    expect(revertBody).not.toMatch(/git\s+reset\s+--hard/);
+
+    // Pushes the revert branch (NOT origin main).
+    expect(revertBody, 'pushes revert branch').toMatch(
+      /git\s+push\s+(?:-u\s+)?origin\s+["']?(?:\$\{?BRANCH\}?|revert\/)/,
+    );
+
+    // Opens the PR with the rollback label.
+    expect(revertBody, 'gh pr create with rollback label').toMatch(
+      /gh\s+pr\s+create[\s\S]+?--label\s+rollback/,
+    );
+
+    // PR title MUST match `Revert release <version>: <reason>`. Allows
+    // either env-style `${VERSION}` or shell-positional `${{ inputs.version }}`.
+    expect(revertBody, 'PR title format').toMatch(
+      /--title\s+["']Revert release \$\{[^}]+\}:\s*\$\{[^}]+\}["']/,
+    );
+
+    // Negative: ABSOLUTELY no `git push origin main` (ADR-065 hard rule).
+    expect(revertBody, 'MUST NOT push to main directly (ADR-065)').not.toMatch(
+      /git\s+push\s+origin\s+main\b/,
+    );
+    expect(revertBody, 'MUST NOT force-push to main (ADR-065)').not.toMatch(
+      /git\s+push\s+--force[^\n]*\bmain\b/,
+    );
+  });
+
+  it('deprecate job runs npm deprecate per artifact and is non-fatal (R-255)', () => {
+    const deprecateStart = nonComment.indexOf('deprecate:');
+    const reconcileStart = nonComment.indexOf('reconcile-rollback:');
+    const deprecateBody = nonComment.slice(deprecateStart, reconcileStart);
+
+    // Job-level continue-on-error: true.
+    expect(deprecateBody, 'deprecate continue-on-error: true').toMatch(
+      /continue-on-error:\s*true/,
+    );
+
+    // npm deprecate <pkg>@<version> "Rolled back: <reason>"
+    expect(deprecateBody, 'runs npm deprecate with rollback message').toMatch(
+      /npm\s+deprecate\s+["']\$[^"']+["']\s+["']Rolled back:\s*\$\{[^}]*REASON[^}]*\}["']/,
+    );
+
+    // Iterates over NPM_PACKAGES list.
+    expect(deprecateBody, 'iterates NPM_PACKAGES env list').toMatch(
+      /for\s+\w+\s+in\s+\$\{\s*NPM_PACKAGES\s*\}/,
+    );
+  });
+
+  it('reconcile-rollback invokes cleo release reconcile --rollback --reason (R-256)', () => {
+    const reconcileStart = nonComment.indexOf('reconcile-rollback:');
+    const reconcileBody = nonComment.slice(reconcileStart);
+
+    // The exact CLI invocation per R-256.
+    expect(reconcileBody, 'invokes cleo release reconcile --rollback').toMatch(
+      /cleo\s+release\s+reconcile\s+["']\$\{[^}]*VERSION\}["']\s+--rollback\s+--reason\s+["']\$\{[^}]*REASON\}["']/,
+    );
+  });
+
+  it('enforces concurrency group rollback-<version> + cancel-in-progress=false (R-257)', () => {
+    expect(raw).toMatch(/group:\s*rollback-\$\{\{\s*inputs\.version\s*\}\}/);
+    expect(raw).toMatch(/cancel-in-progress:\s*false/);
+  });
+
+  it('sets defaults.run.shell: bash (R-262)', () => {
+    expect(raw).toMatch(/defaults:\s*\n\s*run:\s*\n\s*shell:\s*bash/);
+  });
+
+  it('pins third-party Actions to major+minor (R-263)', () => {
+    // Capture every `uses:` ref and assert no `@main`, `@master`, `@latest`,
+    // or bare-major (`@v4` without a minor) reference slips in.
+    const usesRefs = [...raw.matchAll(/uses:\s*([^\s\n]+)/g)].map((m) => m[1]!);
+    expect(usesRefs.length).toBeGreaterThan(0);
+    for (const ref of usesRefs) {
+      expect(ref, `pinned third-party Action: ${ref}`).not.toMatch(/@(main|master|latest)$/);
+      // Must be major+minor: `name@vX.Y` (e.g. `actions/checkout@v4.1`).
+      expect(ref, `${ref} must pin to major+minor`).toMatch(/@v\d+\.\d+$/);
+    }
+  });
+
+  it('declares timeout-minutes on every job', () => {
+    // Every job MUST have a job-level timeout-minutes to bound stalls.
+    for (let i = 0; i < JOB_NAMES.length; i++) {
+      const jobName = JOB_NAMES[i]!;
+      const start = nonComment.indexOf(`${jobName}:`);
+      const nextName = JOB_NAMES[i + 1];
+      const end = nextName ? nonComment.indexOf(`${nextName}:`) : nonComment.length;
+      const body = nonComment.slice(start, end);
+      expect(body, `${jobName} declares job-level timeout-minutes`).toMatch(
+        /^\s{2,4}timeout-minutes:\s*\d+/m,
+      );
+    }
+  });
+
+  it('renders deterministically and matches the checked-in snapshot', async () => {
+    const rendered = renderTemplate(raw, SAMPLE_VALUES);
+
+    // No unsubstituted placeholders left.
+    expect(rendered).not.toMatch(/{{[A-Z_]+}}/);
+
+    // Rendered output has the sample values inlined where expected.
+    expect(rendered).toContain("node-version: '22.x'");
+    expect(rendered).toContain("PUBLISHERS: 'npm cargo'");
+    expect(rendered).toContain("NPM_PACKAGES: '@cleocode/cleo @cleocode/core'");
+    expect(rendered).toContain("CARGO_CRATES: 'cleo-core cleo-cli'");
+
+    await expect(rendered).toMatchFileSnapshot(
+      './__snapshots__/release-rollback.yml.snap',
+    );
+  });
+
+  it('throws on missing placeholder values', () => {
+    expect(() =>
+      renderTemplate('hello {{UNKNOWN_KEY}}', { OTHER: 'x' }),
+    ).toThrow(/UNKNOWN_KEY/);
+  });
+});
+
+/**
+ * Optional actionlint gate (R-260). Skipped when `actionlint` is not on
+ * PATH so the test suite remains runnable in environments without it (e.g.
+ * sparse worker pods). CI is responsible for installing actionlint and
+ * exercising this code path — see SPEC AC-8.
+ */
+function hasActionlint(): boolean {
+  try {
+    execSync('command -v actionlint', { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const ACTIONLINT_DESCRIBE = hasActionlint() ? describe : describe.skip;
+
+ACTIONLINT_DESCRIBE('release-rollback.yml.tmpl actionlint gate', () => {
+  it('passes actionlint on the rendered output', () => {
+    const raw = readFileSync(TEMPLATE_PATH, 'utf8');
+    const rendered = renderTemplate(raw, SAMPLE_VALUES);
+    // `actionlint -` reads from stdin.
+    expect(() =>
+      execSync('actionlint -', {
+        input: rendered,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Fourth and final CLEO-templated GHA workflow per SPEC-T9345 §5.4. Opens a revert PR (never direct main push per ADR-065).

## RFC 2119 invariants covered
- **R-250** Trigger on `workflow_dispatch` ONLY
- **R-251** Required inputs: `version` (string), `mode` (choice `metadata-only|full`), `reason` (string)
- **R-252** Per-job permission escalation (revert: contents+pull-requests; deprecate: packages)
- **R-253** 4 jobs in order: `validate` → `revert` → `deprecate` → `reconcile-rollback`
- **R-254** `revert` opens PR via `gh pr create --label rollback` — NEVER direct main push (ADR-065)
- **R-255** `deprecate` runs `npm deprecate` (+ optional `cargo yank`); `continue-on-error: true`
- **R-256** `reconcile-rollback` invokes `cleo release reconcile <v> --rollback --reason "<r>"`
- **R-257** Concurrency `rollback-<version>`, `cancel-in-progress: false`
- **R-262** `defaults.run.shell: bash`
- **R-263** All third-party Actions pinned to major+minor

## Changes
- `packages/cleo/templates/workflows/release-rollback.yml.tmpl` — new template
- `packages/cleo/templates/workflows/README.md` — rollback row in Template files table, 2 new placeholders (`NPM_PACKAGES`, `CARGO_CRATES`), rollback secrets row, T9535 cross-reference
- `packages/cleo/test/templates/release-rollback-render.test.ts` — snapshot + invariant test (16 passing, 1 actionlint gate skipped locally — CI runs it)
- `packages/cleo/test/templates/__snapshots__/release-rollback.yml.snap` — checked-in snapshot

## Test plan
- [x] 16/16 invariant tests pass (1 actionlint gate skipped — CI exercises it per SPEC AC-8)
- [x] All 4 template suites pass together (49 passed | 4 skipped)
- [x] Snapshot renders deterministically with sample placeholder values
- [x] Negative regression: revert job MUST NOT push to main directly (asserted)
- [x] No modifications to `packages/cleo/src/` (template-only task)

Closes T9535. Unblocks T9536 (init/upgrade scaffold integration).

Generated with [Claude Code](https://claude.com/claude-code)