### PR TITLE
feat(T9529): cleo provenance verify verb

### DIFF
--- a/packages/cleo/src/cli/commands/provenance.ts
+++ b/packages/cleo/src/cli/commands/provenance.ts
@@ -8,14 +8,22 @@
  *     pr_commits, pr_tasks, releases, release_commits, release_changes,
  *     release_artifacts, brain_release_links) for every release in the range.
  *
- * Dispatches via `provenance.backfill` operation to the provenance domain
- * handler. UPSERT semantics, idempotent, restartable via checkpoint file at
- * `.cleo/release/backfill-state.json`.
+ *   cleo provenance verify [version]             — Phase 2 of T9493 (T9529).
+ *     READ-ONLY audit of the 11 provenance tables for a release. Checks FK
+ *     integrity, orphan rows, and ADR-051 evidence-atom staleness. Returns
+ *     LAFS envelope with detailed pass/fail per category. Exit code 0 on
+ *     pass, non-zero on any fail. `--all [--limit N]` verifies the
+ *     most-recent N releases (default 5).
+ *
+ * Dispatches via `provenance.backfill` / `provenance.verify` operations to
+ * the provenance domain handler. UPSERT semantics, idempotent, restartable
+ * via checkpoint file at `.cleo/release/backfill-state.json`.
  *
  * @task T9528
+ * @task T9529
  * @epic T9493
  * @adr  ADR-T9345 (IVTR-release-overhaul)
- * @spec .cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md §8.3
+ * @spec .cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md §4.6, §8.3
  */
 
 import { defineCommand, showUsage } from 'citty';
@@ -80,6 +88,61 @@ const backfillCommand = defineCommand({
 });
 
 /**
+ * cleo provenance verify — audit the 11 provenance tables for one or more
+ * releases.
+ *
+ * Two modes:
+ *   - Single-version: `cleo provenance verify <version>` — verifies one tag.
+ *   - --all: `cleo provenance verify --all [--limit N]` — verifies the
+ *     most-recent N releases (default 5).
+ *
+ * READ-ONLY: never writes to the DB. Returns a LAFS envelope with
+ * `data.passed`, `data.categories`, and `data.releases[]`. Exit code 0 on
+ * pass, non-zero on any category fail.
+ */
+const verifyCommand = defineCommand({
+  meta: {
+    name: 'verify',
+    description:
+      'Audit the 11 provenance tables for a release (FK integrity, orphans, evidence staleness)',
+  },
+  args: {
+    version: {
+      type: 'positional',
+      description: 'Release version to verify (e.g. v2026.6.0). Optional when --all is set.',
+      required: false,
+    },
+    all: {
+      type: 'boolean',
+      description: 'Verify the most-recent N releases instead of a single version',
+    },
+    limit: {
+      type: 'string',
+      description: 'How many releases to verify in --all mode (default 5)',
+    },
+    json: { type: 'boolean', description: 'Emit LAFS envelope' },
+  },
+  async run({ args }) {
+    const version = typeof args.version === 'string' ? args.version : undefined;
+    const all = args.all === true;
+    const limitArg = typeof args.limit === 'string' ? args.limit : undefined;
+    const limit = limitArg ? Number.parseInt(limitArg, 10) : undefined;
+
+    await dispatchFromCli(
+      'query',
+      'provenance',
+      'provenance.verify',
+      {
+        ...(version ? { version } : {}),
+        all,
+        ...(limit && Number.isFinite(limit) ? { limit } : {}),
+      },
+      { command: 'provenance' },
+    );
+  },
+});
+
+/**
  * Root provenance command group — provenance-graph maintenance.
  *
  * Houses every verb that operates on the 11-table provenance graph WITHOUT
@@ -93,6 +156,7 @@ export const provenanceCommand = defineCommand({
   },
   subCommands: {
     backfill: backfillCommand,
+    verify: verifyCommand,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/cleo/src/dispatch/domains/provenance.ts
+++ b/packages/cleo/src/dispatch/domains/provenance.ts
@@ -3,6 +3,11 @@
  *
  * Handles `cleo provenance <operation>` dispatch operations:
  *
+ * QUERY operations:
+ *   verify    — Phase 2 of T9493 (T9529). READ-ONLY audit of the 11
+ *               provenance tables for a release. Checks FK integrity,
+ *               orphan rows, and ADR-051 evidence-atom staleness.
+ *
  * MUTATE operations:
  *   backfill  — Phase 2 of T9493 (T9528). Walks historical git tags from
  *               `since` forward and populates the 11 provenance tables
@@ -13,17 +18,22 @@
  *               restartable via checkpoint at
  *               `.cleo/release/backfill-state.json`.
  *
- * Future verbs (T9529+) will live here too:
- *   verify    — diff DB rows against re-parsed git log per release tag.
+ * Future verbs:
  *   repair    — re-reconcile a single tag in place.
  *
  * @task T9528
+ * @task T9529
  * @epic T9493
  * @adr  ADR-T9345 (IVTR-release-overhaul)
- * @spec .cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md §8.3
+ * @spec .cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md §4.6, §8.3
  */
 
-import { getLogger, getProjectRoot, provenanceBackfill } from '@cleocode/core/internal';
+import {
+  getLogger,
+  getProjectRoot,
+  provenanceBackfill,
+  verifyProvenance,
+} from '@cleocode/core/internal';
 import type { DispatchResponse, DomainHandler } from '../types.js';
 import { errorResult, handleErrorResult, unsupportedOp, wrapResult } from './_base.js';
 
@@ -40,18 +50,55 @@ const log = getLogger('domain:provenance');
  */
 export class ProvenanceHandler implements DomainHandler {
   // -----------------------------------------------------------------------
-  // Query — no query operations defined yet (verify lands in T9529)
+  // Query
   // -----------------------------------------------------------------------
 
   /**
-   * Provenance query operations.
+   * Provenance query operations. Currently only `verify` is implemented.
    *
-   * No query ops are registered in T9528. Returns `E_UNSUPPORTED_OP` for any
-   * incoming operation. The `verify` query op will land in T9529.
+   * @param operation - The provenance query op name (`verify`).
+   * @param params    - The dispatch params object: `version`, `all`, `limit`.
    */
-  async query(operation: string, _params?: Record<string, unknown>): Promise<DispatchResponse> {
+  async query(operation: string, params?: Record<string, unknown>): Promise<DispatchResponse> {
     const startTime = Date.now();
-    return unsupportedOp('query', 'provenance', operation, startTime);
+
+    try {
+      switch (operation) {
+        // ------------------------------------------------------------------
+        // provenance.verify — T9529 / SPEC-T9345 §4.6
+        // ------------------------------------------------------------------
+        case 'verify': {
+          const version = typeof params?.['version'] === 'string' ? params['version'] : undefined;
+          const all = typeof params?.['all'] === 'boolean' ? params['all'] : false;
+          const limit = typeof params?.['limit'] === 'number' ? params['limit'] : undefined;
+
+          if (!version && !all) {
+            return errorResult(
+              'query',
+              'provenance',
+              operation,
+              'E_INVALID_INPUT',
+              'verify requires either <version> or --all',
+              startTime,
+            );
+          }
+
+          const result = await verifyProvenance({
+            ...(version ? { version } : {}),
+            all,
+            ...(limit !== undefined ? { limit } : {}),
+            projectRoot: getProjectRoot(),
+          });
+          return wrapResult(result, 'query', 'provenance', operation, startTime);
+        }
+
+        default:
+          return unsupportedOp('query', 'provenance', operation, startTime);
+      }
+    } catch (err) {
+      log.error({ err, operation }, 'ProvenanceHandler query error');
+      return handleErrorResult('query', 'provenance', operation, err, startTime);
+    }
   }
 
   // -----------------------------------------------------------------------
@@ -118,7 +165,7 @@ export class ProvenanceHandler implements DomainHandler {
   /** Return declared operations for introspection and registry validation. */
   getSupportedOperations(): { query: string[]; mutate: string[] } {
     return {
-      query: [],
+      query: ['verify'],
       mutate: ['backfill'],
     };
   }

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -7196,6 +7196,39 @@ export const OPERATIONS: OperationDef[] = [
     ] satisfies ParamDef[],
   },
 
+  // provenance query: verify (T9529 / SPEC-T9345 §4.6)
+  {
+    gateway: 'query',
+    domain: 'provenance',
+    operation: 'verify',
+    description:
+      'provenance.verify (query) — READ-ONLY audit of the 11 provenance tables for a release. Checks FK integrity (release_commits, task_commits, pr_commits, pr_tasks, release_changes, release_artifacts), orphan rows, and ADR-051 evidence-atom staleness. Exit code 0 on pass, non-zero on any fail (T9529 / SPEC-T9345 §4.6).',
+    tier: 1,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: [],
+    params: [
+      {
+        name: 'version',
+        type: 'string',
+        required: false,
+        description: 'Release version to verify (e.g. v2026.6.0). Required unless --all is set.',
+      },
+      {
+        name: 'all',
+        type: 'boolean',
+        required: false,
+        description: 'Verify the most-recent N releases instead of a single version',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'How many releases to verify in --all mode (default 5)',
+      },
+    ] satisfies ParamDef[],
+  },
+
   // ---------------------------------------------------------------------------
   // LLM domain — `cleo llm` CLI surface (T9258 · T-LLM-CRED Phase 2)
   // ---------------------------------------------------------------------------

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -758,6 +758,16 @@ export {
   runReleaseGates,
   showManifestRelease,
 } from './release/release-manifest.js';
+// T9529: provenance verify verb (Phase 2 of T9493) — READ-ONLY audit of the
+// 11 provenance tables for a release tag.
+export type {
+  StaleEvidenceAtom as ProvenanceStaleEvidenceAtom,
+  VerifyProvenanceCategories,
+  VerifyProvenanceOptions,
+  VerifyProvenanceReleaseResult,
+  VerifyProvenanceResult,
+} from './release/verify-provenance.js';
+export { verifyProvenance } from './release/verify-provenance.js';
 export {
   bumpVersionFromConfig,
   discoverWorkspacePackageJsonFiles,

--- a/packages/core/src/release/__tests__/verify-provenance.test.ts
+++ b/packages/core/src/release/__tests__/verify-provenance.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Unit tests for {@link verifyProvenance} (T9529 / Phase 2 of T9493).
+ *
+ * Coverage:
+ *   - Happy path: provenance graph populated → all 8 categories pass.
+ *   - Missing release row → releaseExists fails, overall fail.
+ *   - Orphan release_commits row → commitFkIntegrity fails.
+ *   - Orphan task_commits row → taskCommitFkIntegrity fails.
+ *   - Orphan release_changes row → releaseChangesIntegrity fails.
+ *   - Evidence staleness: unreachable commit:<sha> atom → evidenceStaleness fails.
+ *   - --all mode iterates the most-recent N releases.
+ *   - --all mode with no releases returns E_PROVENANCE_INCOMPLETE.
+ *
+ * @task T9529
+ * @epic T9493
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { sql } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { provenanceBackfill } from '../backfill.js';
+import { verifyProvenance } from '../verify-provenance.js';
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (
+    path: string,
+    opts?: { readonly?: boolean },
+  ) => import('node:sqlite').DatabaseSync;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Resolve path to the drizzle-tasks migrations folder. */
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+/** Set up a fully-migrated tasks.db + git repo in a temp project root. */
+async function setupProject(): Promise<{
+  projectRoot: string;
+  cleanup: () => void;
+}> {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'cleo-vp-'));
+  const cleoDir = join(projectRoot, '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+  mkdirSync(join(projectRoot, '.cleo', 'release'), { recursive: true });
+
+  writeFileSync(
+    join(cleoDir, 'config.json'),
+    JSON.stringify({
+      enforcement: {
+        session: { requiredForMutate: false },
+        acceptance: { mode: 'off' },
+      },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+
+  const dbPath = join(cleoDir, 'tasks.db');
+  const nativeDb = new DatabaseSync(dbPath);
+  const { drizzle } = await import('drizzle-orm/node-sqlite');
+  const { reconcileJournal, migrateSanitized } = await import('../../store/migration-manager.js');
+  const db = drizzle({ client: nativeDb });
+  reconcileJournal(nativeDb, migrationsDir(), 'tasks', 'tasks');
+  migrateSanitized(db, { migrationsFolder: migrationsDir() });
+  nativeDb.close();
+
+  execFileSync('git', ['init', '-q'], { cwd: projectRoot });
+  execFileSync('git', ['config', 'user.email', 'test@cleo.dev'], { cwd: projectRoot });
+  execFileSync('git', ['config', 'user.name', 'Cleo Test'], { cwd: projectRoot });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: projectRoot });
+
+  return {
+    projectRoot,
+    cleanup: () => rmSync(projectRoot, { recursive: true, force: true }),
+  };
+}
+
+async function insertTasks(projectRoot: string, taskIds: string[]): Promise<void> {
+  const { getDb } = await import('../../store/sqlite.js');
+  const db = await getDb(projectRoot);
+  for (const id of taskIds) {
+    await db.run(
+      sql`INSERT OR IGNORE INTO tasks (id, title, status, priority, role, scope)
+          VALUES (${id}, ${`Task ${id}`}, 'pending', 'medium', 'work', 'feature')`,
+    );
+  }
+}
+
+function gitCommit(projectRoot: string, file: string, content: string, subject: string): string {
+  writeFileSync(join(projectRoot, file), content);
+  execFileSync('git', ['add', file], { cwd: projectRoot });
+  execFileSync('git', ['commit', '-q', '-m', subject], { cwd: projectRoot });
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: projectRoot,
+    encoding: 'utf-8',
+  }).trim();
+}
+
+function gitTag(projectRoot: string, version: string): void {
+  execFileSync('git', ['tag', '-a', version, '-m', `Release ${version}`], { cwd: projectRoot });
+}
+
+/** Seed a single populated release for the happy-path test. */
+async function seedOneRelease(projectRoot: string, taskId: string, tag: string): Promise<void> {
+  await insertTasks(projectRoot, [taskId]);
+  gitCommit(projectRoot, `${tag}-a.txt`, `${tag}-a`, `feat(${taskId}): ship ${taskId} for ${tag}`);
+  gitCommit(projectRoot, `${tag}-b.txt`, `${tag}-b`, `chore: bump version to ${tag}`);
+  gitTag(projectRoot, tag);
+  const res = await provenanceBackfill({ since: '', projectRoot });
+  if (!res.success) {
+    throw new Error(`backfill failed: ${res.error.message}`);
+  }
+}
+
+afterEach(async () => {
+  const { resetDbState } = await import('../../store/sqlite.js');
+  resetDbState();
+  vi.restoreAllMocks();
+});
+
+describe('verifyProvenance — Phase 2 (T9529)', () => {
+  let projectRoot: string;
+  let cleanup: () => void;
+
+  beforeEach(async () => {
+    const env = await setupProject();
+    projectRoot = env.projectRoot;
+    cleanup = env.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // 1. Input validation — missing version + missing --all
+  // ──────────────────────────────────────────────────────────────────────
+  it('rejects calls with neither version nor --all', async () => {
+    const result = await verifyProvenance({ projectRoot });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('E_INVALID_INPUT');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // 2. --all on empty graph returns E_PROVENANCE_INCOMPLETE
+  // ──────────────────────────────────────────────────────────────────────
+  it('--all on empty graph returns E_PROVENANCE_INCOMPLETE', async () => {
+    const result = await verifyProvenance({ all: true, projectRoot });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('E_PROVENANCE_INCOMPLETE');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // 3. Missing release row → releaseExists fails
+  // ──────────────────────────────────────────────────────────────────────
+  it('returns E_PROVENANCE_INCOMPLETE when the release row is missing', async () => {
+    const result = await verifyProvenance({ version: 'v0.0.0', projectRoot });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('E_PROVENANCE_INCOMPLETE');
+    // The full envelope is preserved in error.details.data per the spec.
+    const details = result.error.details as {
+      data: { categories: { releaseExists: { passed: boolean; count: number } } };
+    };
+    expect(details.data.categories.releaseExists.passed).toBe(false);
+    expect(details.data.categories.releaseExists.count).toBe(0);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // 4. Happy path — populated graph → every category passes
+  // ──────────────────────────────────────────────────────────────────────
+  it('happy path: all 8 categories pass for a freshly-reconciled release', async () => {
+    await seedOneRelease(projectRoot, 'T2001', 'v2.0.0');
+
+    const result = await verifyProvenance({ version: 'v2.0.0', projectRoot });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const c = result.data.categories;
+    expect(c.releaseExists.passed).toBe(true);
+    expect(c.releaseExists.count).toBe(1);
+    expect(c.commitFkIntegrity.passed).toBe(true);
+    expect(c.commitFkIntegrity.orphanCount).toBe(0);
+    expect(c.taskCommitFkIntegrity.passed).toBe(true);
+    expect(c.prCommitFkIntegrity.passed).toBe(true);
+    expect(c.prTaskFkIntegrity.passed).toBe(true);
+    expect(c.releaseChangesIntegrity.passed).toBe(true);
+    expect(c.releaseArtifactsIntegrity.passed).toBe(true);
+    expect(c.evidenceStaleness.passed).toBe(true);
+    expect(result.data.passed).toBe(true);
+    expect(result.data.releases).toHaveLength(1);
+    expect(result.data.releases[0]?.version).toBe('v2.0.0');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // 5. Orphan release_commits — directly insert a row with a fake SHA
+  // ──────────────────────────────────────────────────────────────────────
+  it('detects orphan release_commits (FK to commits broken)', async () => {
+    await seedOneRelease(projectRoot, 'T2002', 'v2.1.0');
+
+    // Hand-insert a bad row that bypasses the FK by disabling PRAGMA briefly.
+    const { getDb, getNativeDb } = await import('../../store/sqlite.js');
+    const db = await getDb(projectRoot);
+    const releaseRow = await db.all<{ id: string }>(
+      sql`SELECT id FROM releases WHERE version = 'v2.1.0'`,
+    );
+    expect(releaseRow[0]).toBeDefined();
+    const releaseId = releaseRow[0]?.id ?? '';
+
+    const native = getNativeDb();
+    if (!native) throw new Error('native db not initialized');
+    native.exec('PRAGMA foreign_keys = OFF');
+    native.exec(
+      `INSERT INTO release_commits (release_id, commit_sha, position, is_first, is_last, is_release_chore)
+       VALUES ('${releaseId.replace(/'/g, "''")}', '0000000000000000000000000000000000000000', 99, 0, 0, 0)`,
+    );
+    native.exec('PRAGMA foreign_keys = ON');
+
+    const result = await verifyProvenance({ version: 'v2.1.0', projectRoot });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('E_PROVENANCE_INCOMPLETE');
+    const details = result.error.details as {
+      data: {
+        categories: {
+          commitFkIntegrity: { passed: boolean; orphanCount: number; orphans: string[] };
+        };
+      };
+    };
+    expect(details.data.categories.commitFkIntegrity.passed).toBe(false);
+    expect(details.data.categories.commitFkIntegrity.orphanCount).toBe(1);
+    expect(details.data.categories.commitFkIntegrity.orphans).toContain(
+      '0000000000000000000000000000000000000000',
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // 6. Orphan task_commits — task_id references missing task
+  // ──────────────────────────────────────────────────────────────────────
+  it('detects orphan task_commits (task_id missing in tasks table)', async () => {
+    await seedOneRelease(projectRoot, 'T2003', 'v2.2.0');
+
+    const { getDb, getNativeDb } = await import('../../store/sqlite.js');
+    const db = await getDb(projectRoot);
+    const commitRow = await db.all<{ sha: string }>(
+      sql`SELECT commit_sha AS sha FROM release_commits LIMIT 1`,
+    );
+    expect(commitRow[0]).toBeDefined();
+    const commitSha = commitRow[0]?.sha ?? '';
+
+    const native = getNativeDb();
+    if (!native) throw new Error('native db not initialized');
+    native.exec('PRAGMA foreign_keys = OFF');
+    native.exec(
+      `INSERT INTO task_commits (task_id, commit_sha, link_kind, link_source)
+       VALUES ('T-DOES-NOT-EXIST', '${commitSha.replace(/'/g, "''")}', 'implements', 'commit-message')`,
+    );
+    native.exec('PRAGMA foreign_keys = ON');
+
+    const result = await verifyProvenance({ version: 'v2.2.0', projectRoot });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const details = result.error.details as {
+      data: {
+        categories: {
+          taskCommitFkIntegrity: { passed: boolean; orphanCount: number; orphans: string[] };
+        };
+      };
+    };
+    expect(details.data.categories.taskCommitFkIntegrity.passed).toBe(false);
+    expect(details.data.categories.taskCommitFkIntegrity.orphans).toContain('T-DOES-NOT-EXIST');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // 7. Orphan release_changes — task_id references missing task
+  // ──────────────────────────────────────────────────────────────────────
+  it('detects orphan release_changes (non-null task_id pointing at missing task)', async () => {
+    await seedOneRelease(projectRoot, 'T2004', 'v2.3.0');
+
+    const { getDb, getNativeDb } = await import('../../store/sqlite.js');
+    const db = await getDb(projectRoot);
+    const releaseRow = await db.all<{ id: string }>(
+      sql`SELECT id FROM releases WHERE version = 'v2.3.0'`,
+    );
+    expect(releaseRow[0]).toBeDefined();
+    const releaseId = releaseRow[0]?.id ?? '';
+
+    const native = getNativeDb();
+    if (!native) throw new Error('native db not initialized');
+    native.exec('PRAGMA foreign_keys = OFF');
+    native.exec(
+      `INSERT INTO release_changes (id, release_id, task_id, change_type, summary, impact, classified_by, classified_at)
+       VALUES ('orphan-rc-1', '${releaseId.replace(/'/g, "''")}', 'T-NOT-A-REAL-TASK', 'feat', 'orphan row', 'patch', 'auto', datetime('now'))`,
+    );
+    native.exec('PRAGMA foreign_keys = ON');
+
+    const result = await verifyProvenance({ version: 'v2.3.0', projectRoot });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const details = result.error.details as {
+      data: { categories: { releaseChangesIntegrity: { passed: boolean; orphanCount: number } } };
+    };
+    expect(details.data.categories.releaseChangesIntegrity.passed).toBe(false);
+    expect(details.data.categories.releaseChangesIntegrity.orphanCount).toBeGreaterThanOrEqual(1);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // 8. Evidence staleness — plan with unreachable commit:<sha> atom
+  // ──────────────────────────────────────────────────────────────────────
+  it('detects evidence staleness when a commit atom is not reachable from the tag', async () => {
+    await insertTasks(projectRoot, ['T2005']);
+    gitCommit(projectRoot, 'v2.4.0-a.txt', 'a', `feat(T2005): ship for v2.4.0`);
+    gitTag(projectRoot, 'v2.4.0');
+    const backfill = await provenanceBackfill({ since: '', projectRoot });
+    expect(backfill.success).toBe(true);
+
+    // Overwrite the plan with a deliberately unreachable commit SHA atom. The
+    // backfill writes the plan into .cleo/release/<tag>.plan.json — we mutate
+    // it in place. Re-archive of the plan happens inside reconcile, so we
+    // write to BOTH the live dir and the archive dir for safety.
+    const plan = {
+      $schema: 'https://cleocode.io/schemas/release-plan/v1.json',
+      version: 'v2.4.0',
+      resolvedVersion: 'v2.4.0',
+      suffixApplied: false,
+      scheme: 'calver',
+      channel: 'latest',
+      epicId: 'T2005',
+      releaseKind: 'regular',
+      createdAt: new Date().toISOString(),
+      createdBy: 'test',
+      previousVersion: null,
+      previousTag: null,
+      previousShippedAt: null,
+      tasks: [
+        {
+          id: 'T2005',
+          kind: 'feat',
+          impact: 'patch',
+          userFacingSummary: 'T2005 — synthetic',
+          evidenceAtoms: ['commit:deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'],
+          epicAncestor: 'T2005',
+        },
+      ],
+      changelog: { features: ['T2005'], fixes: [], chores: [], breaking: [] },
+      gates: [],
+      platformMatrix: [
+        { platform: 'any', publisher: 'npm', package: '@cleocode/cleo', smoke: false },
+      ],
+      preflightSummary: {
+        esbuildExternalsDrift: false,
+        lockfileDrift: false,
+        epicCompletenessClean: true,
+        doubleListingClean: true,
+        preflightWarnings: ['synth'],
+      },
+      workflowRunUrl: null,
+      prUrl: null,
+      mergeCommitSha: null,
+      status: 'published',
+      meta: { firstEverRelease: true },
+    };
+    const planJson = JSON.stringify(plan, null, 2);
+    mkdirSync(join(projectRoot, '.cleo', 'release'), { recursive: true });
+    mkdirSync(join(projectRoot, '.cleo', 'release', 'archive'), { recursive: true });
+    writeFileSync(join(projectRoot, '.cleo', 'release', 'v2.4.0.plan.json'), planJson);
+    writeFileSync(join(projectRoot, '.cleo', 'release', 'archive', 'v2.4.0.plan.json'), planJson);
+
+    const result = await verifyProvenance({ version: 'v2.4.0', projectRoot });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const details = result.error.details as {
+      data: {
+        categories: {
+          evidenceStaleness: {
+            passed: boolean;
+            staleAtoms: Array<{ taskId: string; atom: string; reason: string }>;
+          };
+        };
+      };
+    };
+    expect(details.data.categories.evidenceStaleness.passed).toBe(false);
+    expect(details.data.categories.evidenceStaleness.staleAtoms.length).toBeGreaterThanOrEqual(1);
+    expect(details.data.categories.evidenceStaleness.staleAtoms[0]?.taskId).toBe('T2005');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // 9. --all mode iterates the most-recent N releases
+  // ──────────────────────────────────────────────────────────────────────
+  it('--all mode verifies the most-recent N releases', async () => {
+    await insertTasks(projectRoot, ['T3001', 'T3002', 'T3003']);
+    for (const tag of ['v3.0.0', 'v3.1.0', 'v3.2.0']) {
+      gitCommit(projectRoot, `${tag}-a.txt`, `${tag}-a`, `feat(T3001): ship for ${tag}`);
+      gitCommit(projectRoot, `${tag}-b.txt`, `${tag}-b`, `chore: bump to ${tag}`);
+      gitTag(projectRoot, tag);
+    }
+    const backfill = await provenanceBackfill({ since: '', projectRoot });
+    expect(backfill.success).toBe(true);
+
+    const result = await verifyProvenance({ all: true, limit: 2, projectRoot });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.releases.length).toBe(2);
+    expect(result.data.passed).toBe(true);
+  });
+});

--- a/packages/core/src/release/index.ts
+++ b/packages/core/src/release/index.ts
@@ -185,6 +185,16 @@ export {
   showManifestRelease,
   tagRelease,
 } from './release-manifest.js';
+// T9529 — provenance verify verb (Phase 2 of T9493). READ-ONLY audit of the
+// 11 provenance tables for a release (or N most-recent releases).
+export type {
+  StaleEvidenceAtom,
+  VerifyProvenanceCategories,
+  VerifyProvenanceOptions,
+  VerifyProvenanceReleaseResult,
+  VerifyProvenanceResult,
+} from './verify-provenance.js';
+export { verifyProvenance } from './verify-provenance.js';
 // Version bumping
 export type { BumpResult, BumpType, VersionBumpTarget } from './version-bump.js';
 export {

--- a/packages/core/src/release/verify-provenance.ts
+++ b/packages/core/src/release/verify-provenance.ts
@@ -1,0 +1,546 @@
+/**
+ * `cleo provenance verify <version>` — Phase 2 of T9493 (T9529).
+ *
+ * Audits the 11 provenance tables for a given release tag. Every junction-table
+ * row MUST resolve to a real parent row (FK integrity), no orphan rows MAY
+ * exist for the release, and ADR-051 evidence atoms recorded at plan time MUST
+ * still be reachable from the tag.
+ *
+ * Design (read-only):
+ *
+ *   - Loads the release row by `version` from `releasesNew`.
+ *   - For each junction table associated with the release (`release_commits`,
+ *     `task_commits` for that release's commits, `pr_commits`, `pr_tasks`,
+ *     `release_changes`, `release_artifacts`), runs a LEFT JOIN query and
+ *     collects rows whose parent is missing.
+ *   - For each `evidence_atom` in `<version>.plan.json` of kind `commit:<sha>`,
+ *     runs `git merge-base --is-ancestor <sha> <tag>` and records non-zero
+ *     exits as "stale".
+ *   - Aggregates 8 categories into the `data.categories` envelope, sets
+ *     `data.passed = false` iff ANY category failed, and propagates to the
+ *     outer LAFS `success` flag.
+ *
+ * @task T9529
+ * @epic T9493
+ * @adr  ADR-T9345 (IVTR-release-overhaul)
+ * @spec .cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md §4.6
+ * @spec .cleo/rcasd/T9345/research/provenance-graph-design.md §11
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { sql } from 'drizzle-orm';
+import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
+import { getLogger } from '../logger.js';
+import { resolveProjectRoot } from '../store/file-utils.js';
+import { getDb } from '../store/sqlite.js';
+
+const log = getLogger('release:verify-provenance');
+
+/** Default subprocess timeout for git invocations (60s per task rules). */
+const SUBPROCESS_TIMEOUT_MS = 60_000;
+
+/** Plan-file dir relative to project root. */
+const PLAN_DIR_REL = '.cleo/release';
+
+/** Plan-archive dir relative to project root. */
+const PLAN_ARCHIVE_DIR_REL = '.cleo/release/archive';
+
+/** Default N for `--all` mode when no explicit count is supplied. */
+const DEFAULT_ALL_LIMIT = 5;
+
+// ─── Public types ───────────────────────────────────────────────────────────
+
+/**
+ * Options for {@link verifyProvenance}.
+ *
+ * Either `version` MUST be supplied (single-release mode) or `all: true`
+ * (most-recent-N mode). When both are supplied, `version` wins.
+ */
+export interface VerifyProvenanceOptions {
+  /** Specific release version string (e.g. `v2026.6.0`). */
+  version?: string;
+  /** When true, verifies the most-recent `limit` releases. */
+  all?: boolean;
+  /** Number of releases to verify in `--all` mode (default 5). */
+  limit?: number;
+  /** Project root override (defaults to CLEO_ROOT or cwd). */
+  projectRoot?: string;
+}
+
+/** One stale evidence atom — surfaced verbatim to the caller. */
+export interface StaleEvidenceAtom {
+  /** Task ID whose evidence atom failed reachability. */
+  taskId: string;
+  /** The atom string as it appeared in `plan.tasks[].evidenceAtoms`. */
+  atom: string;
+  /** Human-readable explanation (e.g. "commit X not reachable from tag Y"). */
+  reason: string;
+}
+
+/** Result envelope for ONE release version. */
+export interface VerifyProvenanceCategories {
+  /** Existence of the `releases` row for `<version>`. */
+  releaseExists: { passed: boolean; count: number };
+  /** Every `release_commits.commit_sha` resolves to a real `commits.sha`. */
+  commitFkIntegrity: { passed: boolean; orphanCount: number; orphans: string[] };
+  /** Every `task_commits.task_id` (for this release's commits) resolves. */
+  taskCommitFkIntegrity: { passed: boolean; orphanCount: number; orphans: string[] };
+  /** Every `pr_commits.commit_sha` (for PRs touching this release) resolves. */
+  prCommitFkIntegrity: { passed: boolean; orphanCount: number; orphans: string[] };
+  /** Every `pr_tasks.task_id` (for PRs touching this release) resolves. */
+  prTaskFkIntegrity: { passed: boolean; orphanCount: number; orphans: string[] };
+  /** Every `release_changes` row resolves to a real task OR to NULL. */
+  releaseChangesIntegrity: { passed: boolean; orphanCount: number };
+  /** Every `release_artifacts` row resolves to a real release. */
+  releaseArtifactsIntegrity: { passed: boolean; orphanCount: number };
+  /** ADR-051 evidence atoms still reachable from the tag. */
+  evidenceStaleness: { passed: boolean; staleAtoms: StaleEvidenceAtom[] };
+}
+
+/** Per-release verification verdict. */
+export interface VerifyProvenanceReleaseResult {
+  /** Release version string. */
+  version: string;
+  /** True iff every category passed. */
+  passed: boolean;
+  /** Per-category diagnostic detail. */
+  categories: VerifyProvenanceCategories;
+}
+
+/** Result envelope for {@link verifyProvenance}. */
+export interface VerifyProvenanceResult {
+  /** Releases verified (length 1 in single-version mode, N in --all mode). */
+  releases: VerifyProvenanceReleaseResult[];
+  /** Convenience alias for `releases[0].version` in single-mode. */
+  version: string;
+  /** True iff EVERY release verified passed every category. */
+  passed: boolean;
+  /** Aggregated categories for the FIRST release in `releases[]` (single-mode). */
+  categories: VerifyProvenanceCategories;
+  /** Total wall-clock duration in ms. */
+  durationMs?: number;
+}
+
+// ─── Internal helpers ──────────────────────────────────────────────────────
+
+/**
+ * Locate the plan JSON for `version`. Checks the live plan dir first, falls
+ * back to the archive dir. Returns null when not found.
+ */
+function findPlanFile(version: string, projectRoot: string): string | null {
+  const livePath = join(projectRoot, PLAN_DIR_REL, `${version}.plan.json`);
+  if (existsSync(livePath)) return livePath;
+  const archivePath = join(projectRoot, PLAN_ARCHIVE_DIR_REL, `${version}.plan.json`);
+  if (existsSync(archivePath)) return archivePath;
+  return null;
+}
+
+/** Minimal shape we need from a plan JSON — only `tasks[].evidenceAtoms`. */
+interface PlanShape {
+  tasks?: ReadonlyArray<{ id?: string; evidenceAtoms?: ReadonlyArray<string> }>;
+}
+
+/**
+ * Parse the plan JSON for `version` and return the task/evidence shape. Returns
+ * null when missing or malformed — caller treats absence as zero atoms to check.
+ */
+function loadPlanShape(version: string, projectRoot: string): PlanShape | null {
+  const path = findPlanFile(version, projectRoot);
+  if (!path) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as PlanShape;
+  } catch (err) {
+    log.warn(
+      { path, err: err instanceof Error ? err.message : String(err) },
+      'plan JSON unparseable — evidence staleness check skipped',
+    );
+    return null;
+  }
+}
+
+/**
+ * Check ADR-051 evidence staleness for one release. For every `commit:<sha>`
+ * atom in the plan, run `git merge-base --is-ancestor <sha> <tag>` and record
+ * non-zero exits as stale. Other atom kinds (note, decision, files, tool,
+ * test-run) are skipped here — those are the reconcile-time staleness gate's
+ * concern; verify only re-validates the reachability sub-condition.
+ */
+function checkEvidenceStaleness(
+  version: string,
+  projectRoot: string,
+): VerifyProvenanceCategories['evidenceStaleness'] {
+  const plan = loadPlanShape(version, projectRoot);
+  if (!plan || !Array.isArray(plan.tasks) || plan.tasks.length === 0) {
+    return { passed: true, staleAtoms: [] };
+  }
+  const stale: StaleEvidenceAtom[] = [];
+  for (const task of plan.tasks) {
+    const taskId = typeof task.id === 'string' ? task.id : '';
+    if (!taskId || !Array.isArray(task.evidenceAtoms)) continue;
+    for (const atom of task.evidenceAtoms) {
+      if (typeof atom !== 'string') continue;
+      const colonIdx = atom.indexOf(':');
+      if (colonIdx <= 0) continue;
+      const kind = atom.slice(0, colonIdx);
+      const value = atom.slice(colonIdx + 1);
+
+      if (kind === 'commit') {
+        try {
+          execFileSync('git', ['merge-base', '--is-ancestor', value, version], {
+            cwd: projectRoot,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            timeout: SUBPROCESS_TIMEOUT_MS,
+          });
+        } catch {
+          stale.push({
+            taskId,
+            atom,
+            reason: `commit ${value} is not reachable from tag ${version}`,
+          });
+        }
+      } else if (kind === 'files') {
+        const paths = value
+          .split(',')
+          .map((p) => p.trim())
+          .filter(Boolean);
+        for (const relPath of paths) {
+          const abs = resolve(projectRoot, relPath);
+          if (!existsSync(abs)) {
+            stale.push({
+              taskId,
+              atom,
+              reason: `file ${relPath} missing post-publish`,
+            });
+          }
+        }
+      } else if (kind === 'test-run') {
+        const abs = resolve(projectRoot, value);
+        if (!existsSync(abs)) {
+          stale.push({
+            taskId,
+            atom,
+            reason: `test-run file ${value} missing post-publish`,
+          });
+        }
+      }
+      // note:, decision:, tool: are not staleness-sensitive.
+    }
+  }
+  return { passed: stale.length === 0, staleAtoms: stale };
+}
+
+/**
+ * Row shape for the orphan-detection LEFT JOIN result.
+ *
+ * Each query in {@link verifyOneRelease} projects exactly one TEXT column —
+ * the orphan key — so a single typed row interface covers every query.
+ */
+interface OrphanRow {
+  v: string;
+}
+
+/**
+ * Run a single orphan-detection query and return the orphan key list. Wraps
+ * the drizzle `db.all` call so each category emits a strongly-typed row.
+ */
+async function fetchOrphans(
+  db: Awaited<ReturnType<typeof getDb>>,
+  query: ReturnType<typeof sql>,
+): Promise<string[]> {
+  const rows = await db.all<OrphanRow>(query);
+  const out: string[] = [];
+  for (const r of rows) {
+    if (r && typeof r.v === 'string') out.push(r.v);
+  }
+  return out;
+}
+
+/**
+ * Run all 8 verification categories for a single release version. Returns a
+ * fully-populated {@link VerifyProvenanceReleaseResult}.
+ */
+async function verifyOneRelease(
+  version: string,
+  projectRoot: string,
+  db: Awaited<ReturnType<typeof getDb>>,
+): Promise<VerifyProvenanceReleaseResult> {
+  // 1. releaseExists — count rows in releases where version=<version>.
+  const releaseCountRows = await db.all<{ cnt: number }>(
+    sql`SELECT COUNT(*) AS cnt FROM releases WHERE version = ${version}`,
+  );
+  const releaseCount = releaseCountRows[0]?.cnt ?? 0;
+  const releaseExists = { passed: releaseCount > 0, count: releaseCount };
+
+  // Look up the release id once — most downstream queries scope to it.
+  const releaseIdRows = await db.all<{ id: string }>(
+    sql`SELECT id FROM releases WHERE version = ${version} LIMIT 1`,
+  );
+  const releaseId = releaseIdRows[0]?.id ?? null;
+
+  // When the release row is missing, every junction-table check is vacuously
+  // "passed" (no rows to inspect) but we still mark the overall release as
+  // failed because `releaseExists.passed === false`.
+  if (releaseId === null) {
+    return {
+      version,
+      passed: false,
+      categories: {
+        releaseExists,
+        commitFkIntegrity: { passed: true, orphanCount: 0, orphans: [] },
+        taskCommitFkIntegrity: { passed: true, orphanCount: 0, orphans: [] },
+        prCommitFkIntegrity: { passed: true, orphanCount: 0, orphans: [] },
+        prTaskFkIntegrity: { passed: true, orphanCount: 0, orphans: [] },
+        releaseChangesIntegrity: { passed: true, orphanCount: 0 },
+        releaseArtifactsIntegrity: { passed: true, orphanCount: 0 },
+        evidenceStaleness: checkEvidenceStaleness(version, projectRoot),
+      },
+    };
+  }
+
+  // 2. commitFkIntegrity — release_commits.commit_sha → commits.sha
+  const commitOrphans = await fetchOrphans(
+    db,
+    sql`SELECT rc.commit_sha AS v
+        FROM release_commits rc
+        LEFT JOIN commits c ON c.sha = rc.commit_sha
+        WHERE rc.release_id = ${releaseId}
+          AND c.sha IS NULL`,
+  );
+
+  // 3. taskCommitFkIntegrity — task_commits.task_id → tasks.id, scoped to
+  //    THIS release's commit set.
+  const taskCommitOrphans = await fetchOrphans(
+    db,
+    sql`SELECT tc.task_id AS v
+        FROM task_commits tc
+        LEFT JOIN tasks t ON t.id = tc.task_id
+        WHERE tc.commit_sha IN (
+          SELECT commit_sha FROM release_commits WHERE release_id = ${releaseId}
+        )
+          AND t.id IS NULL`,
+  );
+
+  // 4. prCommitFkIntegrity — pr_commits.commit_sha → commits.sha, scoped to
+  //    PRs that intersect this release's commit set.
+  const prCommitOrphans = await fetchOrphans(
+    db,
+    sql`SELECT pc.commit_sha AS v
+        FROM pr_commits pc
+        LEFT JOIN commits c ON c.sha = pc.commit_sha
+        WHERE pc.pr_id IN (
+          SELECT DISTINCT pc2.pr_id
+          FROM pr_commits pc2
+          WHERE pc2.commit_sha IN (
+            SELECT commit_sha FROM release_commits WHERE release_id = ${releaseId}
+          )
+        )
+          AND c.sha IS NULL`,
+  );
+
+  // 5. prTaskFkIntegrity — pr_tasks.task_id → tasks.id, scoped to PRs that
+  //    intersect this release's commit set.
+  const prTaskOrphans = await fetchOrphans(
+    db,
+    sql`SELECT pt.task_id AS v
+        FROM pr_tasks pt
+        LEFT JOIN tasks t ON t.id = pt.task_id
+        WHERE pt.pr_id IN (
+          SELECT DISTINCT pc2.pr_id
+          FROM pr_commits pc2
+          WHERE pc2.commit_sha IN (
+            SELECT commit_sha FROM release_commits WHERE release_id = ${releaseId}
+          )
+        )
+          AND t.id IS NULL`,
+  );
+
+  // 6. releaseChangesIntegrity — every release_changes row must point at our
+  //    release row (no dangling release_changes for this version). A row with
+  //    task_id NULL is permitted (per schema comment — orphan task_id is
+  //    deliberate when classifying a non-task commit) but a row with a
+  //    NON-null task_id pointing at a missing tasks.id IS an orphan.
+  const releaseChangesOrphans = await fetchOrphans(
+    db,
+    sql`SELECT rc.id AS v
+        FROM release_changes rc
+        LEFT JOIN tasks t ON t.id = rc.task_id
+        WHERE rc.release_id = ${releaseId}
+          AND rc.task_id IS NOT NULL
+          AND t.id IS NULL`,
+  );
+
+  // 7. releaseArtifactsIntegrity — release_artifacts.release_id → releases.id
+  //    Since FK is ON DELETE CASCADE this should never produce rows; we still
+  //    audit defensively in case a row was inserted bypassing the FK (e.g.
+  //    direct sqlite3 write).
+  const releaseArtifactsOrphans = await fetchOrphans(
+    db,
+    sql`SELECT ra.identifier AS v
+        FROM release_artifacts ra
+        LEFT JOIN releases r ON r.id = ra.release_id
+        WHERE ra.release_id = ${releaseId}
+          AND r.id IS NULL`,
+  );
+
+  // 8. evidenceStaleness — re-validate plan evidence atoms.
+  const evidenceStaleness = checkEvidenceStaleness(version, projectRoot);
+
+  const categories: VerifyProvenanceCategories = {
+    releaseExists,
+    commitFkIntegrity: {
+      passed: commitOrphans.length === 0,
+      orphanCount: commitOrphans.length,
+      orphans: commitOrphans,
+    },
+    taskCommitFkIntegrity: {
+      passed: taskCommitOrphans.length === 0,
+      orphanCount: taskCommitOrphans.length,
+      orphans: taskCommitOrphans,
+    },
+    prCommitFkIntegrity: {
+      passed: prCommitOrphans.length === 0,
+      orphanCount: prCommitOrphans.length,
+      orphans: prCommitOrphans,
+    },
+    prTaskFkIntegrity: {
+      passed: prTaskOrphans.length === 0,
+      orphanCount: prTaskOrphans.length,
+      orphans: prTaskOrphans,
+    },
+    releaseChangesIntegrity: {
+      passed: releaseChangesOrphans.length === 0,
+      orphanCount: releaseChangesOrphans.length,
+    },
+    releaseArtifactsIntegrity: {
+      passed: releaseArtifactsOrphans.length === 0,
+      orphanCount: releaseArtifactsOrphans.length,
+    },
+    evidenceStaleness,
+  };
+
+  const passed =
+    categories.releaseExists.passed &&
+    categories.commitFkIntegrity.passed &&
+    categories.taskCommitFkIntegrity.passed &&
+    categories.prCommitFkIntegrity.passed &&
+    categories.prTaskFkIntegrity.passed &&
+    categories.releaseChangesIntegrity.passed &&
+    categories.releaseArtifactsIntegrity.passed &&
+    categories.evidenceStaleness.passed;
+
+  return { version, passed, categories };
+}
+
+/**
+ * Resolve the list of release versions to verify based on
+ * {@link VerifyProvenanceOptions}. Returns the most-recent `limit` versions
+ * when `all` is set; otherwise returns `[version]` as a single-element array.
+ *
+ * Sort order in `--all` mode: published_at DESC, falling back to created_at
+ * DESC for unpublished rows (which can happen during a partial reconcile).
+ */
+async function resolveVersions(
+  opts: VerifyProvenanceOptions,
+  db: Awaited<ReturnType<typeof getDb>>,
+): Promise<EngineResult<string[]>> {
+  if (opts.version) return engineSuccess([opts.version]);
+  if (opts.all !== true) {
+    return engineError(
+      'E_INVALID_INPUT',
+      'verifyProvenance requires either `version` or `all: true`',
+      { details: { received: opts } },
+    );
+  }
+  const limit =
+    typeof opts.limit === 'number' && opts.limit > 0 ? Math.floor(opts.limit) : DEFAULT_ALL_LIMIT;
+  const rows = await db.all<{ version: string }>(
+    sql`SELECT version FROM releases
+        ORDER BY COALESCE(published_at, reconciled_at, created_at) DESC
+        LIMIT ${limit}`,
+  );
+  const versions: string[] = [];
+  for (const r of rows) {
+    if (r && typeof r.version === 'string') versions.push(r.version);
+  }
+  if (versions.length === 0) {
+    return engineError(
+      'E_PROVENANCE_INCOMPLETE',
+      'No releases found in the provenance graph to verify',
+      { details: { all: true, limit } },
+    );
+  }
+  return engineSuccess(versions);
+}
+
+// ─── Main entrypoint ───────────────────────────────────────────────────────
+
+/**
+ * Audit the 11 provenance tables for a given release (or the N most-recent
+ * releases when `opts.all` is set). READ-ONLY — does not mutate the DB.
+ *
+ * Returns `engineSuccess(VerifyProvenanceResult)` with `data.passed === true`
+ * when every category passes for every release in scope. Returns
+ * `engineError('E_PROVENANCE_INCOMPLETE', ...)` with the same envelope
+ * payload available under `error.details.data` when any category fails — the
+ * CLI surfaces this via a non-zero exit code per the SPEC.
+ *
+ * @param opts — See {@link VerifyProvenanceOptions}.
+ * @returns EngineResult envelope.
+ */
+export async function verifyProvenance(
+  opts: VerifyProvenanceOptions,
+): Promise<EngineResult<VerifyProvenanceResult>> {
+  const startedAt = Date.now();
+  const projectRoot = opts.projectRoot ?? resolveProjectRoot();
+
+  // Sanity-check input — without `version` we require `all: true`.
+  if (!opts.version && opts.all !== true) {
+    return engineError(
+      'E_INVALID_INPUT',
+      'verifyProvenance requires either `version` or `all: true`',
+      { details: { received: opts } },
+    );
+  }
+
+  const db = await getDb(projectRoot);
+
+  const versionsRes = await resolveVersions(opts, db);
+  if (!versionsRes.success) return versionsRes;
+  const versions = versionsRes.data;
+
+  const releases: VerifyProvenanceReleaseResult[] = [];
+  for (const v of versions) {
+    releases.push(await verifyOneRelease(v, projectRoot, db));
+  }
+
+  const passed = releases.every((r) => r.passed);
+  const first = releases[0];
+  if (!first) {
+    return engineError('E_PROVENANCE_INCOMPLETE', 'No releases were verified', {
+      details: { versions, opts },
+    });
+  }
+
+  const result: VerifyProvenanceResult = {
+    releases,
+    version: first.version,
+    passed,
+    categories: first.categories,
+    durationMs: Date.now() - startedAt,
+  };
+
+  if (!passed) {
+    return engineError(
+      'E_PROVENANCE_INCOMPLETE',
+      `Provenance verification failed for ${releases.filter((r) => !r.passed).length}/${releases.length} release(s)`,
+      {
+        fix: 'Inspect categories[*] for the failing release(s) and re-run `cleo provenance backfill --since <prev>` or `cleo release reconcile <version>` to repair.',
+        details: { data: result },
+      },
+    );
+  }
+
+  return engineSuccess(result);
+}


### PR DESCRIPTION
## Summary
Implements `cleo provenance verify <version>` — audits 11 provenance tables for FK integrity, orphan rows, and evidence-atom staleness. Phase 2 / 2 of 2 of T9493.

## Changes
- `packages/core/src/release/verify-provenance.ts` — `verifyProvenance(opts)` SDK primitive (READ-ONLY)
- `packages/core/src/release/__tests__/verify-provenance.test.ts` — 9 unit tests (happy + each failure mode)
- `packages/cleo/src/cli/commands/provenance.ts` — `verifyCommand` subcommand
- `packages/cleo/src/dispatch/domains/provenance.ts` — `provenance.verify` query handler
- `packages/cleo/src/dispatch/registry.ts` — `provenance.verify` op entry
- Internal + release index exports

## 8 verification categories
- `releaseExists` — `releases` row present for version
- `commitFkIntegrity` — `release_commits.commit_sha` → `commits.sha`
- `taskCommitFkIntegrity` — `task_commits.task_id` → `tasks.id` (scoped to release)
- `prCommitFkIntegrity` — `pr_commits.commit_sha` → `commits.sha` (scoped to release PRs)
- `prTaskFkIntegrity` — `pr_tasks.task_id` → `tasks.id` (scoped to release PRs)
- `releaseChangesIntegrity` — `release_changes.task_id` → `tasks.id` (NULL allowed)
- `releaseArtifactsIntegrity` — `release_artifacts.release_id` → `releases.id`
- `evidenceStaleness` — `commit:<sha>` atoms reachable from tag (ADR-051)

## Test plan
- [x] Happy path: all 8 categories pass for a freshly-reconciled release
- [x] Detects FK orphans (release_commits, task_commits, release_changes)
- [x] Detects evidence staleness via unreachable commit:<sha> atoms
- [x] `--all` flag iterates the most-recent N releases (default 5)
- [x] Empty input or missing release → `E_PROVENANCE_INCOMPLETE` with envelope in `error.details.data`
- [x] biome clean, tsc clean (on files touched), 9/9 vitest pass

Closes T9529. Closes T9493 epic. Unblocks T9530 + T9531.