### PR TITLE
feat(T9530): cleo release open verb

### DIFF
--- a/packages/cleo/src/cli/commands/release.ts
+++ b/packages/cleo/src/cli/commands/release.ts
@@ -412,6 +412,57 @@ const planCommand = defineCommand({
 });
 
 /**
+ * cleo release open <version> — Phase 3 of the new release pipeline (T9530).
+ *
+ * Consumes `.cleo/release/<version>.plan.json`, dispatches the
+ * `release-prepare.yml` workflow via `gh workflow run`, and UPDATEs the
+ * `releases` row's status to `pr-opened`. Implements SPEC-T9345 §4.3.
+ *
+ * @task T9530
+ * @epic T9494
+ * @spec SPEC-T9345 §4.3
+ */
+const openCommand = defineCommand({
+  meta: {
+    name: 'open',
+    description: 'Dispatch release-prepare workflow + transition releases.status to pr-opened',
+  },
+  args: {
+    version: {
+      type: 'positional',
+      description: 'Release version (e.g. v2026.6.0)',
+      required: true,
+    },
+    workflow: {
+      type: 'string',
+      description: 'Workflow file to dispatch (default: release-prepare.yml)',
+    },
+    watch: {
+      type: 'boolean',
+      description: 'Poll gh run watch until the run reaches a terminal state',
+    },
+    'commit-plan': {
+      type: 'boolean',
+      description: 'Commit the plan file to the active branch before dispatching',
+    },
+  },
+  async run({ args }) {
+    await dispatchFromCli(
+      'mutate',
+      'release',
+      'release.open',
+      {
+        version: args.version,
+        workflow: args.workflow as string | undefined,
+        watch: args.watch === true,
+        commitPlan: args['commit-plan'] === true,
+      },
+      { command: 'release' },
+    );
+  },
+});
+
+/**
  * cleo release reconcile <version> — v2 reconcile verb (T9526 / SPEC-T9345 §4.4).
  *
  * Post-publish: backfills the 11 provenance tables (commits, task_commits,
@@ -478,6 +529,8 @@ export const releaseCommand = defineCommand({
     reconcile: reconcileCommand,
     // SPEC-T9345 release pipeline v2 verbs (T9492)
     plan: planCommand,
+    // SPEC-T9345 release pipeline v2 (T9494 Phase 3 / T9530)
+    open: openCommand,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/cleo/src/dispatch/domains/release.ts
+++ b/packages/cleo/src/dispatch/domains/release.ts
@@ -31,7 +31,7 @@
  */
 
 import type { ReleaseGateCheckParams } from '@cleocode/contracts/operations/release';
-import type { ReleasePlanOptions } from '@cleocode/core/internal';
+import type { ReleaseOpenOptions, ReleasePlanOptions } from '@cleocode/core/internal';
 import { getLogger, getProjectRoot } from '@cleocode/core/internal';
 import type { OpsFromCore } from '../adapters/typed.js';
 import {
@@ -39,6 +39,7 @@ import {
   makeAdr061GateRunner,
   releaseGateCheck,
   releaseIvtrAutoSuggest,
+  releaseOpen,
   releasePlan,
   releasePublish,
   releaseReconcileV2,
@@ -342,6 +343,29 @@ export class ReleaseHandler implements DomainHandler {
           return wrapResult(await releasePlan(typed), 'mutate', 'release', operation, startTime);
         }
 
+        // release.open — SPEC-T9345 §4.3 (T9530): dispatch release-prepare workflow
+        case 'open': {
+          const version = typeof params?.version === 'string' ? params.version : undefined;
+          if (!version) {
+            return errorResult(
+              'mutate',
+              'release',
+              operation,
+              'E_INVALID_INPUT',
+              'version is required',
+              startTime,
+            );
+          }
+          const typed: ReleaseOpenOptions = {
+            version,
+            workflow: typeof params?.workflow === 'string' ? params.workflow : undefined,
+            watch: typeof params?.watch === 'boolean' ? params.watch : false,
+            commitPlan: typeof params?.commitPlan === 'boolean' ? params.commitPlan : false,
+            projectRoot: getProjectRoot(),
+          };
+          return wrapResult(await releaseOpen(typed), 'mutate', 'release', operation, startTime);
+        }
+
         // release.reconcile — v2 reconcile verb (T9526 / SPEC-T9345 §4.4)
         case 'reconcile': {
           const version = typeof params?.version === 'string' ? params.version : undefined;
@@ -379,7 +403,7 @@ export class ReleaseHandler implements DomainHandler {
   getSupportedOperations(): { query: string[]; mutate: string[] } {
     return {
       query: ['gate', 'ivtr-suggest', 'verify'],
-      mutate: ['gate', 'ivtr-suggest', 'start', 'publish', 'reconcile', 'plan'],
+      mutate: ['gate', 'ivtr-suggest', 'start', 'publish', 'reconcile', 'plan', 'open'],
     };
   }
 }

--- a/packages/cleo/src/dispatch/lib/engine.ts
+++ b/packages/cleo/src/dispatch/lib/engine.ts
@@ -179,6 +179,7 @@ export {
   releaseGatesRun,
   releaseIvtrAutoSuggest,
   releaseList,
+  releaseOpen,
   releasePlan,
   releasePrepare,
   releasePrStatus,

--- a/packages/contracts/src/exit-codes.ts
+++ b/packages/contracts/src/exit-codes.ts
@@ -255,6 +255,30 @@ export const E_EVIDENCE_INSUFFICIENT = 'E_EVIDENCE_INSUFFICIENT' as const;
 export const E_PLAN_NOT_FOUND = 'E_PLAN_NOT_FOUND' as const;
 /** Generic release-plan validation failure (e.g. schema). Exit code 6. */
 export const E_RELEASE_PLAN_INVALID = 'E_RELEASE_PLAN_INVALID' as const;
+/**
+ * Release row exists but is not in the status FSM state required by the
+ * caller (R-051 — `cleo release open` requires status='planned'). Exit code 6.
+ * `error.details.currentStatus` MUST report the actual status; `error.details.expectedStatus`
+ * SHOULD list the accepted state(s).
+ *
+ * @task T9530
+ */
+export const E_INVALID_STATE = 'E_INVALID_STATE' as const;
+/**
+ * `gh auth status` exited non-zero (R-052). The GitHub CLI is either not
+ * installed or not authenticated for the active hostname. Exit code 5.
+ *
+ * @task T9530
+ */
+export const E_GH_NOT_AUTHENTICATED = 'E_GH_NOT_AUTHENTICATED' as const;
+/**
+ * The expected GitHub Actions workflow file is missing under `.github/workflows/`
+ * (R-053). Without it, `gh workflow run` would fail with a non-recoverable error.
+ * Exit code 4.
+ *
+ * @task T9530
+ */
+export const E_WORKFLOW_NOT_FOUND = 'E_WORKFLOW_NOT_FOUND' as const;
 
 /** Check if an exit code represents an error (1-99). */
 export function isErrorCode(code: ExitCode): boolean {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -338,8 +338,12 @@ export {
   E_EPIC_EMPTY,
   E_EPIC_NOT_FOUND,
   E_EVIDENCE_INSUFFICIENT,
+  // SPEC-T9345 release pipeline v2 error code names (T9530)
+  E_GH_NOT_AUTHENTICATED,
+  E_INVALID_STATE,
   E_PLAN_NOT_FOUND,
   E_RELEASE_PLAN_INVALID,
+  E_WORKFLOW_NOT_FOUND,
   ExitCode,
   getExitCodeName,
   isErrorCode,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -724,6 +724,13 @@ export { channelToDistTag, describeChannel, resolveChannelFromBranch } from './r
 export type { PRResult } from './release/github-pr.js';
 export { buildPRBody, createPullRequest, isGhCliAvailable } from './release/github-pr.js';
 export { checkDoubleListing, checkEpicCompleteness } from './release/guards.js';
+// T9530: release open verb (Phase 3 of T9494) — exposed via internal for dispatch layer
+export type {
+  ReleaseOpenOptions,
+  ReleaseOpenResult,
+  ReleaseOpenRunner,
+} from './release/open.js';
+export { DEFAULT_OPEN_WORKFLOW, releaseOpen } from './release/open.js';
 // T1726: canonical 4-step release pipeline (ADR-063 / T1597) — exposed via internal for dispatch layer
 export {
   loadActiveReleaseHandle,

--- a/packages/core/src/release/__tests__/open.test.ts
+++ b/packages/core/src/release/__tests__/open.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Tests for {@link releaseOpen} — SPEC-T9345 §4.3 release open verb.
+ *
+ * Covers:
+ *  - Happy path: workflow dispatched, releases row UPDATEd to `pr-opened`,
+ *    `workflow_run_url` persisted, LAFS envelope returned.
+ *  - `E_PLAN_NOT_FOUND` when `.cleo/release/<version>.plan.json` is absent (R-050).
+ *  - `E_INVALID_STATE` when the releases row status is not `planned` (R-051).
+ *  - `E_GH_NOT_AUTHENTICATED` when `gh auth status` exits non-zero (R-052).
+ *  - `E_WORKFLOW_NOT_FOUND` when `.github/workflows/release-prepare.yml` is missing (R-053).
+ *  - Idempotency — re-running on a row already at `pr-opened` is a no-op.
+ *
+ * @task T9530
+ * @epic T9494
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  E_GH_NOT_AUTHENTICATED,
+  E_INVALID_STATE,
+  E_PLAN_NOT_FOUND,
+  E_WORKFLOW_NOT_FOUND,
+  type ReleasePlan,
+} from '@cleocode/contracts';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, getDb, resetDbState } from '../../store/sqlite.js';
+import * as schema from '../../store/tasks-schema.js';
+import { DEFAULT_OPEN_WORKFLOW, type ReleaseOpenRunner, releaseOpen } from '../open.js';
+
+let testDir: string;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct a minimum-valid {@link ReleasePlan} for a given version. All
+ * required fields per the canonical schema are populated; downstream verbs
+ * never need to touch the structural details of the plan.
+ */
+function makePlan(version: string, epicId = 'T9999'): ReleasePlan {
+  const nowIso = new Date().toISOString();
+  return {
+    $schema: 'https://cleocode.io/schemas/release-plan/v1.json',
+    version,
+    resolvedVersion: version,
+    suffixApplied: false,
+    scheme: 'calver',
+    channel: 'latest',
+    epicId,
+    releaseKind: 'regular',
+    createdAt: nowIso,
+    createdBy: 'test',
+    previousVersion: null,
+    previousTag: null,
+    previousShippedAt: null,
+    tasks: [
+      {
+        id: 'T10001',
+        kind: 'feat',
+        impact: 'minor',
+        userFacingSummary: 'Test feature',
+        evidenceAtoms: ['commit:abc1234567'],
+        epicAncestor: epicId,
+      },
+    ],
+    changelog: { features: ['T10001'], fixes: [], chores: [], breaking: [] },
+    gates: [
+      { name: 'test', atom: 'tool:test', status: 'passed', lastVerifiedAt: nowIso },
+      { name: 'build', atom: 'tool:build', status: 'passed', lastVerifiedAt: nowIso },
+      { name: 'lint', atom: 'tool:lint', status: 'passed', lastVerifiedAt: nowIso },
+      { name: 'typecheck', atom: 'tool:typecheck', status: 'passed', lastVerifiedAt: nowIso },
+      { name: 'audit', atom: 'tool:audit', status: 'skipped', lastVerifiedAt: nowIso },
+      {
+        name: 'security-scan',
+        atom: 'tool:security-scan',
+        status: 'skipped',
+        lastVerifiedAt: nowIso,
+      },
+    ],
+    platformMatrix: [{ platform: 'any', publisher: 'npm', package: '@cleocode/cleo' }],
+    preflightSummary: {
+      esbuildExternalsDrift: false,
+      lockfileDrift: false,
+      epicCompletenessClean: true,
+      doubleListingClean: true,
+      preflightWarnings: [],
+    },
+    workflowRunUrl: null,
+    prUrl: null,
+    mergeCommitSha: null,
+    status: 'planned',
+    meta: { firstEverRelease: true, archetype: 'node' },
+  };
+}
+
+/** Write `.cleo/release/<version>.plan.json` with the given plan body. */
+function writePlanFile(version: string, plan: ReleasePlan): string {
+  const releaseDir = join(testDir, '.cleo', 'release');
+  mkdirSync(releaseDir, { recursive: true });
+  const planPath = join(releaseDir, `${version}.plan.json`);
+  writeFileSync(planPath, `${JSON.stringify(plan, null, 2)}\n`, { encoding: 'utf-8' });
+  return planPath;
+}
+
+/** Stage a placeholder `release-prepare.yml` workflow file. */
+function writeWorkflowFile(name: string = DEFAULT_OPEN_WORKFLOW): string {
+  const workflowDir = join(testDir, '.github', 'workflows');
+  mkdirSync(workflowDir, { recursive: true });
+  const path = join(workflowDir, name);
+  writeFileSync(path, 'name: release-prepare\non: workflow_dispatch\njobs: {}\n', {
+    encoding: 'utf-8',
+  });
+  return path;
+}
+
+/** Seed a `releases` row at the given status. */
+async function seedReleaseRow(version: string, status: schema.ReleaseStatus): Promise<void> {
+  const db = await getDb(testDir);
+  await db
+    .insert(schema.releasesNew)
+    .values({
+      id: `testhash:${version}`,
+      version,
+      scheme: 'calver',
+      channel: 'latest',
+      epicId: null,
+      releaseKind: 'regular',
+      status,
+      plannedAt: new Date().toISOString(),
+      projectHash: 'testhash',
+    })
+    .run();
+}
+
+/** Construct a {@link ReleaseOpenRunner} that records calls. */
+function makeStubRunner(opts?: {
+  authOk?: boolean;
+  runListResponse?: string;
+  workflowRunThrows?: Error;
+}): ReleaseOpenRunner & {
+  calls: Array<{ cmd: string; args: readonly string[] }>;
+} {
+  const calls: Array<{ cmd: string; args: readonly string[] }> = [];
+  const authOk = opts?.authOk !== false;
+  return {
+    calls,
+    checkGhAuth: () => {
+      calls.push({ cmd: 'gh', args: ['auth', 'status'] });
+      return authOk;
+    },
+    runGh: (args) => {
+      calls.push({ cmd: 'gh', args });
+      if (args[0] === 'workflow' && args[1] === 'run') {
+        if (opts?.workflowRunThrows) throw opts.workflowRunThrows;
+        return '';
+      }
+      if (args[0] === 'run' && args[1] === 'list') {
+        return (
+          opts?.runListResponse ??
+          JSON.stringify([
+            {
+              url: 'https://github.com/cleocode/cleo/actions/runs/12345',
+              databaseId: 12345,
+              status: 'in_progress',
+            },
+          ])
+        );
+      }
+      if (args[0] === 'run' && args[1] === 'watch') {
+        return '';
+      }
+      return '';
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'cleo-release-open-'));
+  await mkdir(join(testDir, '.cleo'), { recursive: true });
+  writeFileSync(
+    join(testDir, '.cleo', 'config.json'),
+    JSON.stringify({
+      enforcement: { session: { requiredForMutate: false } },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+  writeFileSync(
+    join(testDir, '.cleo', 'project-info.json'),
+    JSON.stringify({
+      projectHash: 'testhash',
+      projectId: 'test-project-id',
+      projectRoot: testDir,
+      projectName: 'test',
+    }),
+  );
+  execFileSync('git', ['init', '--quiet', testDir], { encoding: 'utf-8' });
+  execFileSync('git', ['-C', testDir, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', testDir, 'config', 'user.name', 'Test']);
+  execFileSync('git', ['-C', testDir, 'config', 'commit.gpgsign', 'false']);
+  resetDbState();
+});
+
+afterEach(async () => {
+  try {
+    closeDb();
+  } catch {
+    // best-effort
+  }
+  await rm(testDir, { recursive: true, force: true });
+});
+
+// =============================================================================
+// Happy path
+// =============================================================================
+
+describe('releaseOpen — happy path', () => {
+  it('dispatches the workflow, UPDATEs releases.status to pr-opened, and persists workflow_run_url', async () => {
+    const version = 'v2026.6.0';
+    writePlanFile(version, makePlan(version));
+    writeWorkflowFile();
+    await seedReleaseRow(version, 'planned');
+
+    const runner = makeStubRunner();
+
+    const result = await releaseOpen({ version, projectRoot: testDir }, runner);
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.version).toBe(version);
+    expect(result.data.workflowRunUrl).toContain('actions/runs/');
+    expect(result.data.watching).toBe(false);
+    expect(result.data.planBlobSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.data.idempotent).toBeUndefined();
+
+    // gh workflow run was invoked with the expected fields
+    const dispatched = runner.calls.find((c) => c.args[0] === 'workflow' && c.args[1] === 'run');
+    expect(dispatched).toBeDefined();
+    expect(dispatched?.args).toContain(`version=${version}`);
+    expect(dispatched?.args.some((a) => a.startsWith('plan-blob-sha256='))).toBe(true);
+
+    // releases row updated
+    const db = await getDb(testDir);
+    const rows = await db
+      .select()
+      .from(schema.releasesNew)
+      .where(eq(schema.releasesNew.version, version))
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe('pr-opened');
+    expect(rows[0]?.workflowRunUrl).toMatch(/^https:\/\/github.com\//);
+    expect(rows[0]?.prOpenedAt).toBeTruthy();
+  });
+});
+
+// =============================================================================
+// Error envelopes (R-050 .. R-053)
+// =============================================================================
+
+describe('releaseOpen — error envelopes', () => {
+  it('returns E_PLAN_NOT_FOUND when the plan file is missing (R-050)', async () => {
+    // No plan file; releases row seeded so we pass R-051 even if it ran.
+    writeWorkflowFile();
+    await seedReleaseRow('v2026.6.0', 'planned');
+
+    const result = await releaseOpen(
+      { version: 'v2026.6.0', projectRoot: testDir },
+      makeStubRunner(),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe(E_PLAN_NOT_FOUND);
+    expect(result.error.fix).toContain('cleo release plan');
+  });
+
+  it('returns E_INVALID_STATE when the releases row is at a non-planned status (R-051)', async () => {
+    const version = 'v2026.6.0';
+    writePlanFile(version, makePlan(version));
+    writeWorkflowFile();
+    await seedReleaseRow(version, 'pr-merged');
+
+    const result = await releaseOpen({ version, projectRoot: testDir }, makeStubRunner());
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe(E_INVALID_STATE);
+    expect(result.error.details).toMatchObject({
+      currentStatus: 'pr-merged',
+      expectedStatus: ['planned'],
+    });
+  });
+
+  it('returns E_INVALID_STATE when no releases row exists (R-051)', async () => {
+    const version = 'v2026.6.0';
+    writePlanFile(version, makePlan(version));
+    writeWorkflowFile();
+    // intentionally NO seedReleaseRow
+
+    const result = await releaseOpen({ version, projectRoot: testDir }, makeStubRunner());
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe(E_INVALID_STATE);
+    expect(result.error.fix).toContain('cleo release plan');
+  });
+
+  it('returns E_GH_NOT_AUTHENTICATED when gh auth status exits non-zero (R-052)', async () => {
+    const version = 'v2026.6.0';
+    writePlanFile(version, makePlan(version));
+    writeWorkflowFile();
+    await seedReleaseRow(version, 'planned');
+
+    const result = await releaseOpen(
+      { version, projectRoot: testDir },
+      makeStubRunner({ authOk: false }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe(E_GH_NOT_AUTHENTICATED);
+    expect(result.error.fix).toContain('gh auth login');
+  });
+
+  it('returns E_WORKFLOW_NOT_FOUND when the workflow yml is missing (R-053)', async () => {
+    const version = 'v2026.6.0';
+    writePlanFile(version, makePlan(version));
+    // intentionally NO writeWorkflowFile()
+    await seedReleaseRow(version, 'planned');
+
+    const result = await releaseOpen({ version, projectRoot: testDir }, makeStubRunner());
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe(E_WORKFLOW_NOT_FOUND);
+  });
+});
+
+// =============================================================================
+// Idempotency (re-run on already pr-opened row)
+// =============================================================================
+
+describe('releaseOpen — idempotency', () => {
+  it('returns idempotent=true without re-dispatching when status is already pr-opened', async () => {
+    const version = 'v2026.6.0';
+    writePlanFile(version, makePlan(version));
+    writeWorkflowFile();
+    await seedReleaseRow(version, 'planned');
+
+    const runner = makeStubRunner();
+    const first = await releaseOpen({ version, projectRoot: testDir }, runner);
+    expect(first.success).toBe(true);
+
+    const dispatchCallsAfterFirst = runner.calls.filter(
+      (c) => c.args[0] === 'workflow' && c.args[1] === 'run',
+    ).length;
+    expect(dispatchCallsAfterFirst).toBe(1);
+
+    const second = await releaseOpen({ version, projectRoot: testDir }, runner);
+    expect(second.success).toBe(true);
+    if (!second.success) throw new Error('unreachable');
+    expect(second.data.idempotent).toBe(true);
+    expect(second.data.workflowRunUrl).toBeTruthy();
+
+    // No additional `gh workflow run` invocation on the second call.
+    const dispatchCallsAfterSecond = runner.calls.filter(
+      (c) => c.args[0] === 'workflow' && c.args[1] === 'run',
+    ).length;
+    expect(dispatchCallsAfterSecond).toBe(1);
+  });
+});

--- a/packages/core/src/release/index.ts
+++ b/packages/core/src/release/index.ts
@@ -119,6 +119,9 @@ export {
   registerInvariant,
   runInvariants,
 } from './invariants/index.js';
+// T9530 — v2 release open verb (Phase 3 of T9494)
+export type { ReleaseOpenOptions, ReleaseOpenResult, ReleaseOpenRunner } from './open.js';
+export { DEFAULT_OPEN_WORKFLOW, releaseOpen } from './open.js';
 // Dispatch op registry (ADR-058 OpsFromCore inference — T1543).
 // Type-only export: ops.ts declares `releaseCoreOps` via `export declare const`
 // for `typeof` inference; there is NO runtime value. Re-exporting as `type`

--- a/packages/core/src/release/open.ts
+++ b/packages/core/src/release/open.ts
@@ -1,0 +1,609 @@
+/**
+ * `cleo release open` — Phase 3 verb of the new release pipeline.
+ *
+ * Consumes the plan file at `.cleo/release/<version>.plan.json` (written by
+ * {@link releasePlan} in T9525) and dispatches the `release-prepare.yml`
+ * GitHub Actions workflow via `gh workflow run`. UPDATEs the `releases`
+ * row's `status` to `pr-opened` and persists the resolved workflow run URL
+ * into `releases.workflow_run_url`.
+ *
+ * This verb is **side-effectful** — it shells out to `gh` and writes one
+ * row to the `releases` table. It does NOT push commits, mutate any
+ * source files, or invoke npm/cargo publish.
+ *
+ * Implements SPEC-T9345 §4.3 (R-050 through R-071):
+ *
+ *   - R-050 .. R-053 — pre-condition gates (plan exists, releases status,
+ *     gh auth, workflow file).
+ *   - R-060 .. R-062 — side effects (gh workflow run + DB update; optional
+ *     plan-commit when `--commit-plan` is supplied).
+ *   - R-070 .. R-071 — post-conditions (status='pr-opened', workflow_run_url
+ *     is a valid gh run URL).
+ *
+ * All `gh` and `git` subprocesses run with a 60s timeout per task rules.
+ *
+ * @task T9530
+ * @epic T9494
+ * @adr ADR-T9345
+ * @spec .cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md §4.3
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  E_GH_NOT_AUTHENTICATED,
+  E_INVALID_STATE,
+  E_PLAN_NOT_FOUND,
+  E_RELEASE_PLAN_INVALID,
+  E_WORKFLOW_NOT_FOUND,
+  type EngineResult,
+  ExitCode,
+  engineError,
+  engineSuccess,
+  safeParseReleasePlan,
+} from '@cleocode/contracts';
+import { eq } from 'drizzle-orm';
+
+import { getLogger } from '../logger.js';
+import { getDb } from '../store/sqlite.js';
+import { releasesNew } from '../store/tasks-schema.js';
+import { runGitWithLockRetry } from './engine-ops.js';
+
+const log = getLogger('release:open');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default subprocess timeout for git/gh calls (60s per task rules). */
+const SUBPROCESS_TIMEOUT_MS = 60_000;
+
+/** Relative location of the plan file. */
+const PLAN_DIR_REL = '.cleo/release';
+
+/** Relative location of the dispatched workflow file. */
+const WORKFLOW_DIR_REL = '.github/workflows';
+
+/** Default workflow file name dispatched by `cleo release open`. */
+export const DEFAULT_OPEN_WORKFLOW = 'release-prepare.yml' as const;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Options accepted by {@link releaseOpen}.
+ *
+ * @task T9530
+ */
+export interface ReleaseOpenOptions {
+  /** The release version, e.g. `v2026.6.0`. Required positional input. */
+  version: string;
+  /** Workflow file name to dispatch. Defaults to `release-prepare.yml`. */
+  workflow?: string;
+  /** When true, poll `gh run watch` until the run reaches a terminal state. */
+  watch?: boolean;
+  /**
+   * When true, commit the plan file to the active branch before dispatching.
+   * NOT the default — the workflow can re-derive the plan from `releases` + tasks.db.
+   */
+  commitPlan?: boolean;
+  /** Project root override. Defaults to `process.cwd()`. */
+  projectRoot?: string;
+}
+
+/**
+ * Data payload returned by {@link releaseOpen} on success.
+ *
+ * @task T9530
+ */
+export interface ReleaseOpenResult {
+  /** The version dispatched (matches input). */
+  version: string;
+  /** The GitHub Actions run URL recorded into `releases.workflow_run_url`. */
+  workflowRunUrl: string;
+  /** True iff `--watch` was supplied (caller waited for the run). */
+  watching: boolean;
+  /** True iff this invocation was a no-op because status was already `pr-opened`. */
+  idempotent?: boolean;
+  /** Plan file sha256, supplied as `plan-blob-sha256` field to the workflow dispatch. */
+  planBlobSha256: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — subprocess wrappers (mockable in tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal handle to subprocess runners. Public via {@link __test__} so unit
+ * tests can swap out the real `gh` / `git` callers without `vi.mock` plumbing.
+ *
+ * @internal
+ */
+export interface ReleaseOpenRunner {
+  /** Run `gh <args>` and return trimmed stdout. Throws on non-zero exit. */
+  runGh: (args: readonly string[], cwd: string) => string;
+  /** Test whether `gh auth status` exits 0. Returns the boolean directly. */
+  checkGhAuth: (cwd: string) => boolean;
+}
+
+/**
+ * Default runner — invokes the real `gh` binary on PATH with a 60s timeout.
+ *
+ * @internal
+ */
+function makeDefaultRunner(): ReleaseOpenRunner {
+  return {
+    runGh: (args, cwd) =>
+      execFileSync('gh', [...args], {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: SUBPROCESS_TIMEOUT_MS,
+        maxBuffer: 16 * 1024 * 1024,
+      }).trim(),
+    checkGhAuth: (cwd) => {
+      try {
+        execFileSync('gh', ['auth', 'status'], {
+          cwd,
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+          timeout: SUBPROCESS_TIMEOUT_MS,
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — pre-condition validators
+// ---------------------------------------------------------------------------
+
+/**
+ * R-050: load and validate the plan file at
+ * `.cleo/release/<version>.plan.json`.
+ *
+ * Returns the raw JSON body (for sha256 hashing) AND the parsed plan, or an
+ * `E_PLAN_NOT_FOUND` / `E_RELEASE_PLAN_INVALID` envelope on failure.
+ *
+ * @internal
+ */
+function loadPlanForOpen(
+  version: string,
+  projectRoot: string,
+): EngineResult<{ rawBody: string; planPath: string }> {
+  const planPath = join(projectRoot, PLAN_DIR_REL, `${version}.plan.json`);
+  if (!existsSync(planPath)) {
+    return engineError<{ rawBody: string; planPath: string }>(
+      E_PLAN_NOT_FOUND,
+      `Release plan not found at ${planPath}`,
+      {
+        exitCode: ExitCode.NOT_FOUND,
+        fix: `cleo release plan ${version} --epic <id>`,
+        details: { planPath, version },
+      },
+    );
+  }
+  let rawBody: string;
+  try {
+    rawBody = readFileSync(planPath, 'utf-8');
+  } catch (err) {
+    return engineError<{ rawBody: string; planPath: string }>(
+      E_RELEASE_PLAN_INVALID,
+      `Failed to read plan at ${planPath}: ${err instanceof Error ? err.message : String(err)}`,
+      {
+        exitCode: ExitCode.FILE_ERROR,
+        fix: 'Inspect the plan file permissions and re-run',
+        details: { planPath },
+      },
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch (err) {
+    return engineError<{ rawBody: string; planPath: string }>(
+      E_RELEASE_PLAN_INVALID,
+      `Plan file at ${planPath} is not valid JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      {
+        exitCode: ExitCode.VALIDATION_ERROR,
+        fix: `Re-run cleo release plan ${version} --epic <id>`,
+        details: { planPath },
+      },
+    );
+  }
+  const validation = safeParseReleasePlan(parsed);
+  if (!validation.success) {
+    return engineError<{ rawBody: string; planPath: string }>(
+      E_RELEASE_PLAN_INVALID,
+      `Plan schema validation failed for ${planPath}`,
+      {
+        exitCode: ExitCode.VALIDATION_ERROR,
+        fix: `Re-run cleo release plan ${version} --epic <id>`,
+        details: { planPath, issues: validation.error.issues },
+      },
+    );
+  }
+  return engineSuccess({ rawBody, planPath });
+}
+
+/**
+ * R-053: assert the workflow file exists under `.github/workflows/`.
+ *
+ * @internal
+ */
+function assertWorkflowFile(
+  workflow: string,
+  projectRoot: string,
+): EngineResult<{ workflowPath: string }> {
+  const workflowPath = join(projectRoot, WORKFLOW_DIR_REL, workflow);
+  if (!existsSync(workflowPath)) {
+    return engineError<{ workflowPath: string }>(
+      E_WORKFLOW_NOT_FOUND,
+      `Workflow file '${workflow}' not found at ${workflowPath}`,
+      {
+        exitCode: ExitCode.NOT_FOUND,
+        fix: `Ensure '${workflow}' is committed to ${WORKFLOW_DIR_REL}/`,
+        details: { workflow, workflowPath },
+      },
+    );
+  }
+  return engineSuccess({ workflowPath });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — workflow dispatch + run URL resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the most recent workflow run URL for the given workflow file after
+ * dispatch. Returns the URL string or `null` if `gh run list` yields nothing.
+ *
+ * Polls up to {@link maxAttempts} times because `gh workflow run` returns
+ * BEFORE the run is registered in `gh run list` (the API has a small lag).
+ *
+ * @internal
+ */
+function resolveLatestRunUrl(
+  workflow: string,
+  cwd: string,
+  runner: ReleaseOpenRunner,
+  maxAttempts = 5,
+): string | null {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const raw = runner.runGh(
+        ['run', 'list', '--workflow', workflow, '--limit', '1', '--json', 'url,databaseId,status'],
+        cwd,
+      );
+      const parsed: unknown = JSON.parse(raw);
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        const first = parsed[0];
+        if (
+          first !== null &&
+          typeof first === 'object' &&
+          'url' in first &&
+          typeof first.url === 'string' &&
+          first.url.length > 0
+        ) {
+          return first.url;
+        }
+      }
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), attempt, workflow },
+        'gh run list attempt failed; retrying',
+      );
+    }
+    // Bounded backoff — total worst case ~1.5s across all attempts.
+    if (attempt < maxAttempts - 1) {
+      const waitMs = 100 * 2 ** attempt;
+      const end = Date.now() + waitMs;
+      while (Date.now() < end) {
+        /* tight wait — synchronous to keep this function callable in non-async contexts */
+      }
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — DB UPDATE
+// ---------------------------------------------------------------------------
+
+/**
+ * UPDATE the `releases` row to `status='pr-opened'` and persist the
+ * resolved workflow run URL (R-061 + R-070 + R-071).
+ *
+ * @internal
+ */
+async function updateReleaseRow(
+  version: string,
+  workflowRunUrl: string,
+  projectRoot: string,
+): Promise<void> {
+  const db = await getDb(projectRoot);
+  await db
+    .update(releasesNew)
+    .set({
+      status: 'pr-opened',
+      workflowRunUrl,
+      prOpenedAt: new Date().toISOString(),
+    })
+    .where(eq(releasesNew.version, version))
+    .run();
+}
+
+/**
+ * Read the current status + workflow_run_url of the releases row for a version.
+ *
+ * @internal
+ */
+async function readReleaseStatus(
+  version: string,
+  projectRoot: string,
+): Promise<{ status: string; workflowRunUrl: string | null } | null> {
+  const db = await getDb(projectRoot);
+  const rows = await db
+    .select({ status: releasesNew.status, workflowRunUrl: releasesNew.workflowRunUrl })
+    .from(releasesNew)
+    .where(eq(releasesNew.version, version))
+    .all();
+  const row = rows[0];
+  if (!row) return null;
+  return { status: row.status, workflowRunUrl: row.workflowRunUrl };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — plan commit (--commit-plan)
+// ---------------------------------------------------------------------------
+
+/**
+ * R-062: commit the plan file to the active branch when `--commit-plan` is
+ * supplied. The default flow leaves the plan uncommitted; the workflow can
+ * re-derive the plan envelope from `releases` + tasks.db without it.
+ *
+ * @internal
+ */
+function commitPlanFile(planPath: string, version: string, projectRoot: string): void {
+  // Stage the plan file. Use a relative path so git accepts it inside the worktree.
+  const relPath = planPath.startsWith(projectRoot)
+    ? planPath.slice(projectRoot.length).replace(/^\/+/, '')
+    : planPath;
+  runGitWithLockRetry(['add', relPath], {
+    cwd: projectRoot,
+    encoding: 'utf-8',
+    stdio: 'pipe',
+    timeout: SUBPROCESS_TIMEOUT_MS,
+  });
+  runGitWithLockRetry(
+    ['commit', '-m', `chore(release): attach plan for ${version}`, '--', relPath],
+    {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: SUBPROCESS_TIMEOUT_MS,
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatch the `release-prepare.yml` workflow for the given version and
+ * UPDATE the `releases` row to `status='pr-opened'`.
+ *
+ * Idempotency: if the row is ALREADY at `status='pr-opened'` AND has a
+ * non-null `workflow_run_url`, the verb is a no-op modulo `meta.idempotent=true`
+ * (returns the existing URL without re-dispatching).
+ *
+ * @example
+ * ```ts
+ * const result = await releaseOpen({ version: 'v2026.6.0' });
+ * if (result.success) {
+ *   console.log(`Dispatched: ${result.data.workflowRunUrl}`);
+ * }
+ * ```
+ *
+ * @task T9530
+ */
+export async function releaseOpen(
+  opts: ReleaseOpenOptions,
+  runnerOverride?: ReleaseOpenRunner,
+): Promise<EngineResult<ReleaseOpenResult>> {
+  const projectRoot = opts.projectRoot ?? process.cwd();
+  const workflow = opts.workflow ?? DEFAULT_OPEN_WORKFLOW;
+  const watch = opts.watch === true;
+  const commitPlan = opts.commitPlan === true;
+  const runner: ReleaseOpenRunner = runnerOverride ?? makeDefaultRunner();
+
+  // ── R-050: plan file must exist + parse + schema-validate ─────────────
+  const planLoad = loadPlanForOpen(opts.version, projectRoot);
+  if (!planLoad.success) {
+    return engineError<ReleaseOpenResult>(planLoad.error.code, planLoad.error.message, {
+      exitCode: planLoad.error.exitCode,
+      fix: planLoad.error.fix,
+      details: planLoad.error.details,
+    });
+  }
+  const { rawBody, planPath } = planLoad.data;
+  const planBlobSha256 = createHash('sha256').update(rawBody).digest('hex');
+
+  // ── R-051: releases.status MUST be 'planned' (or already pr-opened ⇒ idempotent) ──
+  const current = await readReleaseStatus(opts.version, projectRoot);
+  if (!current) {
+    return engineError<ReleaseOpenResult>(
+      E_INVALID_STATE,
+      `No releases row for version '${opts.version}'; run cleo release plan first`,
+      {
+        exitCode: ExitCode.VALIDATION_ERROR,
+        fix: `cleo release plan ${opts.version} --epic <id>`,
+        details: {
+          version: opts.version,
+          currentStatus: null,
+          expectedStatus: ['planned'],
+        },
+      },
+    );
+  }
+
+  // Idempotency short-circuit: already opened.
+  if (current.status === 'pr-opened' && current.workflowRunUrl) {
+    log.info(
+      { version: opts.version, workflowRunUrl: current.workflowRunUrl },
+      'release.open: idempotent re-invocation; status already pr-opened',
+    );
+    return engineSuccess<ReleaseOpenResult>({
+      version: opts.version,
+      workflowRunUrl: current.workflowRunUrl,
+      watching: false,
+      idempotent: true,
+      planBlobSha256,
+    });
+  }
+
+  if (current.status !== 'planned') {
+    return engineError<ReleaseOpenResult>(
+      E_INVALID_STATE,
+      `releases.status for '${opts.version}' is '${current.status}'; expected 'planned'`,
+      {
+        exitCode: ExitCode.VALIDATION_ERROR,
+        fix:
+          current.status === 'pr-merged' || current.status === 'published'
+            ? `Use cleo release reconcile ${opts.version} for the post-publish flow`
+            : `Reset the release with cleo release cancel ${opts.version} OR start a fresh plan`,
+        details: {
+          version: opts.version,
+          currentStatus: current.status,
+          expectedStatus: ['planned'],
+        },
+      },
+    );
+  }
+
+  // ── R-053: workflow file must exist ───────────────────────────────────
+  const workflowCheck = assertWorkflowFile(workflow, projectRoot);
+  if (!workflowCheck.success) {
+    return engineError<ReleaseOpenResult>(workflowCheck.error.code, workflowCheck.error.message, {
+      exitCode: workflowCheck.error.exitCode,
+      fix: workflowCheck.error.fix,
+      details: workflowCheck.error.details,
+    });
+  }
+
+  // ── R-052: gh auth must succeed ───────────────────────────────────────
+  if (!runner.checkGhAuth(projectRoot)) {
+    return engineError<ReleaseOpenResult>(
+      E_GH_NOT_AUTHENTICATED,
+      'GitHub CLI is not authenticated (gh auth status exited non-zero)',
+      {
+        exitCode: ExitCode.DEPENDENCY_ERROR,
+        fix: "Run 'gh auth login' to authenticate",
+        details: { hostname: 'github.com' },
+      },
+    );
+  }
+
+  // ── R-062 (optional): commit the plan file to the active branch ───────
+  if (commitPlan) {
+    try {
+      commitPlanFile(planPath, opts.version, projectRoot);
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        'commit-plan failed; continuing without staged plan',
+      );
+    }
+  }
+
+  // ── R-060: dispatch the workflow ──────────────────────────────────────
+  try {
+    runner.runGh(
+      [
+        'workflow',
+        'run',
+        workflow,
+        '--field',
+        `version=${opts.version}`,
+        '--field',
+        `plan-blob-sha256=${planBlobSha256}`,
+      ],
+      projectRoot,
+    );
+  } catch (err) {
+    return engineError<ReleaseOpenResult>(
+      E_GH_NOT_AUTHENTICATED,
+      `gh workflow run failed: ${err instanceof Error ? err.message : String(err)}`,
+      {
+        exitCode: ExitCode.DEPENDENCY_ERROR,
+        fix: "Check 'gh workflow list' and ensure the workflow is enabled on this repo",
+        details: { workflow, version: opts.version },
+      },
+    );
+  }
+
+  // Resolve the run URL via `gh run list`. May lag for a few hundred ms.
+  const runUrl = resolveLatestRunUrl(workflow, projectRoot, runner);
+  if (!runUrl) {
+    return engineError<ReleaseOpenResult>(
+      E_GH_NOT_AUTHENTICATED,
+      'Workflow dispatched but no run URL surfaced from gh run list',
+      {
+        exitCode: ExitCode.DEPENDENCY_ERROR,
+        fix: 'Check the Actions tab on GitHub; the dispatch succeeded but URL resolution failed',
+        details: { workflow, version: opts.version },
+      },
+    );
+  }
+
+  // ── R-061 / R-070 / R-071: UPDATE releases row ────────────────────────
+  await updateReleaseRow(opts.version, runUrl, projectRoot);
+
+  // ── Optional --watch: invoke gh run watch ─────────────────────────────
+  if (watch) {
+    try {
+      // Best-effort poll — non-fatal if the run terminates before we ask.
+      runner.runGh(['run', 'watch', '--exit-status', runUrl], projectRoot);
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), runUrl },
+        'gh run watch exited non-zero; workflow may have failed',
+      );
+    }
+  }
+
+  return engineSuccess<ReleaseOpenResult>({
+    version: opts.version,
+    workflowRunUrl: runUrl,
+    watching: watch,
+    planBlobSha256,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internal exports — testing only
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal helpers exposed for unit testing. NOT part of the public API.
+ *
+ * @internal
+ */
+export const __test__ = {
+  assertWorkflowFile,
+  commitPlanFile,
+  loadPlanForOpen,
+  makeDefaultRunner,
+  readReleaseStatus,
+  resolveLatestRunUrl,
+  updateReleaseRow,
+};


### PR DESCRIPTION
## Summary
Implements `cleo release open <version>` per SPEC-T9345 §4.3 (R-050 through R-071). Phase 3 of T9494 (release pipeline v2). Consumes the plan.json written by `cleo release plan` (T9525), dispatches the `release-prepare.yml` workflow via `gh workflow run`, and UPDATEs the `releases` row status from `planned` to `pr-opened`.

## Implementation

- **New SDK primitive** — `packages/core/src/release/open.ts` (`releaseOpen(opts)`)
- **New error codes** — `E_INVALID_STATE`, `E_GH_NOT_AUTHENTICATED`, `E_WORKFLOW_NOT_FOUND` (added to `@cleocode/contracts`)
- **CLI** — `cleo release open <version> [--workflow] [--watch] [--commit-plan]` subcommand
- **Dispatch** — `release.open` mutate op registered in `ReleaseHandler`

## Acceptance Coverage

- R-050: plan file must exist (`E_PLAN_NOT_FOUND`)
- R-051: `releases.status` must be `planned` (`E_INVALID_STATE`)
- R-052: `gh auth status` must succeed (`E_GH_NOT_AUTHENTICATED`)
- R-053: workflow file must exist (`E_WORKFLOW_NOT_FOUND`)
- R-060: dispatch `gh workflow run release-prepare.yml --field version=<v> --field plan-blob-sha256=<sha>`
- R-061: UPDATE `releases.status='pr-opened'`, persist `workflow_run_url` and `pr_opened_at`
- R-062: optional `--commit-plan` commits the plan to the active branch
- R-070/R-071: post-conditions verified by tests
- LAFS envelope per §4.3.5

## Type Safety + Quality

- No `any` / `unknown` casts; runner injection via `ReleaseOpenRunner` interface
- 60s timeout on every `gh` and `git` invocation
- ESM imports with `.js` extension
- TSDoc on all exports

## Test plan
- [x] Unit tests pass (7/7) — happy + 4 error envelopes + idempotency: `packages/core/src/release/__tests__/open.test.ts`
- [x] Existing release tests still pass (plan + reconcile-v2 = 29/29 green)
- [x] Biome check clean
- [ ] CI green