### PR TITLE
feat(T9536): scaffold all 4 templates + cleo upgrade workflows

### DIFF
--- a/packages/cleo/src/cli/commands/upgrade.ts
+++ b/packages/cleo/src/cli/commands/upgrade.ts
@@ -15,6 +15,12 @@
  *   - Global `{cleoHome}` data checks (via --include-global)
  *   - Deep diagnostics via --diagnose
  *
+ * Subcommands:
+ *   - `cleo upgrade workflows` (T9536) — re-render the four shipped
+ *     `release-*.yml` workflow templates and report drift against the
+ *     project's `.github/workflows/` directory. Supports `--dry-run`,
+ *     `--check` (exit-code contract), and `--force` (overwrite drift).
+ *
  * Global output flags (--json, --human, --quiet) are declared in args so
  * citty parses them directly. This replaces the Commander.js optsWithGlobals()
  * pattern that is unavailable in native citty commands.
@@ -22,13 +28,115 @@
  * @task T4699
  * @task T5243
  * @task T131
+ * @task T9536 — `workflows` subcommand
  * @epic T4454
  */
 
-import { CleoError, diagnoseUpgrade, runUpgrade } from '@cleocode/core/internal';
+import { resolve } from 'node:path';
+import { CleoError, diagnoseUpgrade, runUpgrade, upgradeWorkflows } from '@cleocode/core/internal';
 import { defineCommand } from 'citty';
 import { createUpgradeProgress } from '../progress.js';
 import { cliError, cliOutput } from '../renderers/index.js';
+import { getWorkflowTemplatesDir } from './init.js';
+
+/**
+ * `cleo upgrade workflows` — Phase 4 / 4 of T9497.
+ *
+ * Re-renders the four shipped `*.yml.tmpl` workflow templates against
+ * the project's current `.cleo/release-config.json` + ADR-061 tool
+ * state, compares against the on-disk `.github/workflows/release-*.yml`
+ * files, and reports per-template drift.
+ *
+ * Flags:
+ *   - `--dry-run`  Print the per-template diff/status without writing.
+ *   - `--check`    Exit 0 if every file is current (`unchanged` or
+ *                  `override-kept`); exit 1 if ANY drift is detected.
+ *                  Implies `--dry-run` semantics for the on-disk state.
+ *   - `--force`    Overwrite drifted files with the rendered output.
+ *                  Files with a key in `.workflow-overrides.yml` are
+ *                  STILL preserved (operator-declared customization).
+ *                  Audit row lands in `.cleo/audit/upgrade-workflows.jsonl`.
+ *
+ * Exit codes:
+ *   - 0   every outcome was `unchanged` / `override-kept` / `updated` /
+ *         `dry-run` (i.e. no actionable drift remains).
+ *   - 1   at least one outcome reports `drift-detected` or `missing`
+ *         and `--force` was NOT supplied.
+ *
+ * @task T9536
+ */
+const workflowsSubcommand = defineCommand({
+  meta: {
+    name: 'workflows',
+    description: 'Re-render the four release-pipeline workflow templates and report drift (T9536).',
+  },
+  args: {
+    'dry-run': {
+      type: 'boolean',
+      description: 'Print the per-template diff without writing.',
+      default: false,
+    },
+    check: {
+      type: 'boolean',
+      description: 'Exit 1 if drift is detected. Implies --dry-run for write semantics.',
+      default: false,
+    },
+    force: {
+      type: 'boolean',
+      description: 'Overwrite drifted files (excluding `.workflow-overrides.yml` keys).',
+      default: false,
+    },
+    json: { type: 'boolean', description: 'Output as JSON' },
+    human: { type: 'boolean', description: 'Force human-readable output' },
+    quiet: { type: 'boolean', description: 'Suppress non-essential output' },
+  },
+  async run({ args }) {
+    try {
+      const dryRun = args['dry-run'] === true || args.check === true;
+      const force = args.force === true && !dryRun;
+
+      const result = await upgradeWorkflows({
+        projectRoot: resolve(process.cwd()),
+        templatesDir: getWorkflowTemplatesDir(),
+        dryRun,
+        force,
+      });
+
+      cliOutput(
+        {
+          outcomes: result.outcomes.map((o) => ({
+            template: o.template,
+            targetPath: o.targetPath,
+            status: o.status,
+            overrideDeclared: o.overrideDeclared,
+          })),
+          resolvedTools: result.resolvedTools,
+          hasDrift: result.hasDrift,
+          ...(dryRun
+            ? {
+                rendered: result.outcomes.map((o) => ({
+                  template: o.template,
+                  rendered: o.rendered,
+                })),
+              }
+            : {}),
+        },
+        { command: 'upgrade', operation: 'upgrade.workflows' },
+      );
+
+      // --check contract: exit 1 when drift remains.
+      if (args.check === true && result.hasDrift) {
+        process.exit(1);
+      }
+    } catch (err) {
+      if (err instanceof CleoError) {
+        cliError(err.message, err.code, { name: 'CleoError', fix: err.fix });
+        process.exit(err.code);
+      }
+      throw err;
+    }
+  },
+});
 
 /**
  * Upgrade command — unified project maintenance (storage migration, schema repair, structural fixes).
@@ -38,6 +146,9 @@ export const upgradeCommand = defineCommand({
     name: 'upgrade',
     description:
       'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+  },
+  subCommands: {
+    workflows: workflowsSubcommand,
   },
   args: {
     status: {
@@ -86,7 +197,13 @@ export const upgradeCommand = defineCommand({
       description: 'Suppress non-essential output',
     },
   },
-  async run({ args }) {
+  async run({ args, cmd, rawArgs }) {
+    // Citty subcommand routing: if the first positional argument matches a
+    // declared subcommand (e.g. `workflows`), let citty dispatch to the
+    // subcommand handler instead of running the legacy maintenance flow.
+    const firstPositional = rawArgs?.find((a: string) => !a.startsWith('-'));
+    if (firstPositional && cmd.subCommands && firstPositional in cmd.subCommands) return;
+
     const isHuman = args.human === true || (!!process.stdout.isTTY && args.json !== true);
     const progress = createUpgradeProgress(isHuman);
 

--- a/packages/cleo/src/dispatch/domains/index.ts
+++ b/packages/cleo/src/dispatch/domains/index.ts
@@ -28,6 +28,7 @@ import { SessionHandler } from './session.js';
 import { StickyHandler } from './sticky.js';
 import { TasksHandler } from './tasks.js';
 import { ToolsHandler } from './tools.js';
+import { UpgradeHandler } from './upgrade.js';
 import { WorktreeHandler } from './worktree.js';
 
 export {
@@ -50,6 +51,7 @@ export {
   StickyHandler,
   TasksHandler,
   ToolsHandler,
+  UpgradeHandler,
   WorktreeHandler,
 };
 
@@ -90,5 +92,9 @@ export function createDomainHandlers(): Map<string, DomainHandler> {
   // T9546: `cleo worktree` CLI surface — structured worktree enumeration with status classification
   // (T9515 worktree-lifecycle bug fix epic, 2 of 5).
   handlers.set('worktree', new WorktreeHandler());
+  // T9536: `cleo upgrade workflows` — re-render the four release-pipeline
+  // workflow templates and report drift with 3-way merge against
+  // .workflow-overrides.yml (Phase 4 / 4 of 4 of T9497).
+  handlers.set('upgrade', new UpgradeHandler());
   return handlers;
 }

--- a/packages/cleo/src/dispatch/domains/upgrade.ts
+++ b/packages/cleo/src/dispatch/domains/upgrade.ts
@@ -1,0 +1,186 @@
+/**
+ * Upgrade Domain Handler (Dispatch Layer)
+ *
+ * Handles `cleo upgrade <operation>` dispatch operations.
+ *
+ * For T9536 (Phase 4 of T9497) the only supported operation is
+ * `workflows` — re-renders the four shipped workflow templates against
+ * the project's current `.cleo/release-config.json` + ADR-061 tool
+ * state, compares to the on-disk `.github/workflows/release-*.yml`
+ * files, and reports per-template drift.
+ *
+ * QUERY operations:
+ *   workflows — read-only drift detection. Accepts `dryRun?: boolean`
+ *               (always true at the query gateway), `force?: boolean`
+ *               (always false at the query gateway), and a logical
+ *               `check?: boolean` discriminator the CLI uses to drive
+ *               the `--check` exit-code contract.
+ *
+ * MUTATE operations:
+ *   workflows — destructive variant that re-writes drifted files when
+ *               `force=true`. Without `force` the behaviour is identical
+ *               to the query path; with `force` the SDK primitive
+ *               atomic-writes the rendered YAML and audits the action
+ *               to `.cleo/audit/upgrade-workflows.jsonl`.
+ *
+ * @task T9536
+ * @epic T9497
+ */
+
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getLogger, getProjectRoot } from '@cleocode/core';
+import { type UpgradeWorkflowsResult, upgradeWorkflows } from '@cleocode/core/internal';
+
+import type { DispatchResponse, DomainHandler } from '../types.js';
+import { handleErrorResult, unsupportedOp } from './_base.js';
+import { dispatchMeta } from './_meta.js';
+
+const log = getLogger('domain:upgrade');
+
+/**
+ * Resolve the absolute path to the `@cleocode/cleo` package's
+ * `templates/workflows/` directory from THIS file's location. Works in
+ * both monorepo development (`packages/cleo/dist/dispatch/domains/...`)
+ * and installed npm package (`node_modules/@cleocode/cleo/dist/...`)
+ * layouts.
+ *
+ * Mirrors `getWorkflowTemplatesDir` in
+ * `packages/cleo/src/cli/commands/init.ts` — that helper is the
+ * CLI-layer source, this is the dispatch-layer source. They MUST stay
+ * in sync; see T9536 acceptance criteria.
+ *
+ * @internal
+ */
+function resolveTemplatesDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // here = packages/cleo/dist/dispatch/domains   (after esbuild emit)
+  //      = packages/cleo/src/dispatch/domains    (in dev)
+  // Either way, up 3 levels lands at packages/cleo and templates/workflows is the target.
+  return resolve(here, '..', '..', '..', 'templates', 'workflows');
+}
+
+/**
+ * Convert an {@link UpgradeWorkflowsResult} envelope into the CLI
+ * dispatch surface shape.
+ *
+ * @internal
+ */
+function toDispatchData(result: UpgradeWorkflowsResult) {
+  return {
+    outcomes: result.outcomes.map((o) => ({
+      template: o.template,
+      targetPath: o.targetPath,
+      status: o.status,
+      overrideDeclared: o.overrideDeclared,
+    })),
+    resolvedTools: result.resolvedTools,
+    hasDrift: result.hasDrift,
+  };
+}
+
+/**
+ * Dispatch handler for the `upgrade` domain (workflow upgrade ops).
+ *
+ * Registered under the `upgrade` domain key in {@link createDomainHandlers}.
+ *
+ * @task T9536
+ */
+export class UpgradeHandler implements DomainHandler {
+  /**
+   * Handle read-only upgrade queries.
+   *
+   * Supported operations:
+   *  - `workflows` — drift detection only; never writes to disk.
+   *                  Effectively forces `dryRun=true` at the query gateway.
+   */
+  async query(operation: string, params?: Record<string, unknown>): Promise<DispatchResponse> {
+    const startTime = Date.now();
+    try {
+      switch (operation) {
+        case 'workflows': {
+          const includeRendered = params?.['includeRendered'] === true;
+          const result = await upgradeWorkflows({
+            projectRoot: getProjectRoot(),
+            templatesDir: resolveTemplatesDir(),
+            dryRun: true,
+          });
+          const data = toDispatchData(result);
+          return {
+            meta: dispatchMeta('query', 'upgrade', operation, startTime),
+            success: true,
+            data: includeRendered
+              ? {
+                  ...data,
+                  rendered: result.outcomes.map((o) => ({
+                    template: o.template,
+                    rendered: o.rendered,
+                  })),
+                }
+              : data,
+          };
+        }
+        default:
+          return unsupportedOp('query', 'upgrade', operation, startTime);
+      }
+    } catch (err) {
+      log.error({ err, operation }, 'UpgradeHandler query error');
+      return handleErrorResult('query', 'upgrade', operation, err, startTime);
+    }
+  }
+
+  /**
+   * Handle upgrade mutations.
+   *
+   * Supported operations:
+   *  - `workflows` — re-render + (optionally) re-write drifted files.
+   *                  Params: `{ force?, dryRun? }`. Returns the per-template
+   *                  outcomes plus the `hasDrift` flag the CLI uses to drive
+   *                  the `--check` exit-code contract.
+   */
+  async mutate(operation: string, params?: Record<string, unknown>): Promise<DispatchResponse> {
+    const startTime = Date.now();
+    try {
+      switch (operation) {
+        case 'workflows': {
+          const force = params?.['force'] === true;
+          const dryRun = params?.['dryRun'] === true;
+          const includeRendered = params?.['includeRendered'] === true;
+          const result = await upgradeWorkflows({
+            projectRoot: getProjectRoot(),
+            templatesDir: resolveTemplatesDir(),
+            force,
+            dryRun,
+          });
+          const data = toDispatchData(result);
+          return {
+            meta: dispatchMeta('mutate', 'upgrade', operation, startTime),
+            success: true,
+            data: includeRendered
+              ? {
+                  ...data,
+                  rendered: result.outcomes.map((o) => ({
+                    template: o.template,
+                    rendered: o.rendered,
+                  })),
+                }
+              : data,
+          };
+        }
+        default:
+          return unsupportedOp('mutate', 'upgrade', operation, startTime);
+      }
+    } catch (err) {
+      log.error({ err, operation }, 'UpgradeHandler mutate error');
+      return handleErrorResult('mutate', 'upgrade', operation, err, startTime);
+    }
+  }
+
+  /** Declared operations for introspection and validation. */
+  getSupportedOperations(): { query: string[]; mutate: string[] } {
+    return {
+      query: ['workflows'],
+      mutate: ['workflows'],
+    };
+  }
+}

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -7484,6 +7484,64 @@ export const OPERATIONS: OperationDef[] = [
       },
     ] satisfies ParamDef[],
   },
+
+  // ---------------------------------------------------------------------------
+  // Upgrade domain — `cleo upgrade workflows` (T9536 · Phase 4 of T9497)
+  // ---------------------------------------------------------------------------
+
+  // upgrade query: workflows — read-only drift detection.
+  {
+    gateway: 'query',
+    domain: 'upgrade',
+    operation: 'workflows',
+    description:
+      'upgrade.workflows (query) — re-render the four release-pipeline workflow templates and report drift against .github/workflows/release-*.yml. Read-only (forces dryRun). Honours .workflow-overrides.yml for operator-declared customizations (T9536).',
+    tier: 2,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: [],
+    params: [
+      {
+        name: 'includeRendered',
+        type: 'boolean',
+        required: false,
+        description: 'Include the freshly rendered YAML in the response (for diff display)',
+      },
+    ] satisfies ParamDef[],
+  },
+
+  // upgrade mutate: workflows — re-render + optional re-write with --force.
+  {
+    gateway: 'mutate',
+    domain: 'upgrade',
+    operation: 'workflows',
+    description:
+      'upgrade.workflows (mutate) — re-render the four release-pipeline workflow templates; with force=true, overwrite drifted files and audit-log to .cleo/audit/upgrade-workflows.jsonl. .workflow-overrides.yml entries are preserved (operator-declared customization). hasDrift flag in the response drives the --check exit-code contract (T9536).',
+    tier: 2,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: [],
+    params: [
+      {
+        name: 'force',
+        type: 'boolean',
+        required: false,
+        description: 'Overwrite drifted files (excluding .workflow-overrides.yml keys)',
+      },
+      {
+        name: 'dryRun',
+        type: 'boolean',
+        required: false,
+        description: 'Print the per-template diff without writing',
+      },
+      {
+        name: 'includeRendered',
+        type: 'boolean',
+        required: false,
+        description: 'Include the freshly rendered YAML in the response (for diff display)',
+      },
+    ] satisfies ParamDef[],
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/cleo/src/dispatch/types.ts
+++ b/packages/cleo/src/dispatch/types.ts
@@ -76,6 +76,9 @@ export const CANONICAL_DOMAINS = [
   'llm',
   // T9528: provenance-graph maintenance verbs (backfill, verify, repair).
   'provenance',
+  // T9536: `cleo upgrade workflows` — re-render release-pipeline workflow
+  // templates + 3-way merge with `.workflow-overrides.yml`.
+  'upgrade',
 ] as const;
 
 export type CanonicalDomain = (typeof CANONICAL_DOMAINS)[number];

--- a/packages/core/src/init/__tests__/scaffold-workflows-all.test.ts
+++ b/packages/core/src/init/__tests__/scaffold-workflows-all.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Unit tests for T9536 — `cleo init --workflows` defaults to the full
+ * four-template set (`release-prepare`, `release-publish`,
+ * `release-fanout`, `release-rollback`).
+ *
+ * Coverage:
+ *   - default templates: omitting `templates` renders all four files.
+ *   - explicit subset:    passing a subset still works (back-compat for
+ *                         T9531 single-template behaviour).
+ *   - DEFAULT_WORKFLOW_TEMPLATES: exported constant matches the four
+ *                                 canonical names in expected order.
+ *   - real templates:    rendering the shipped `*.yml.tmpl` files leaves
+ *                        no `{{...}}` placeholders behind (smoke test —
+ *                        full actionlint integration belongs to a
+ *                        separate Phase 4 integration test).
+ *
+ * @task T9536
+ * @epic T9497
+ */
+
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_WORKFLOW_TEMPLATES,
+  scaffoldWorkflows,
+  type WorkflowName,
+} from '../scaffold-workflows.js';
+
+// ---------------------------------------------------------------------------
+// Fixture templates — minimal inline stand-ins for the four `*.yml.tmpl`
+// files. Each fixture touches the placeholders its real counterpart uses
+// (per packages/cleo/templates/workflows/README.md) so the substitution
+// pass is exercised end-to-end without depending on the byte-exact
+// contents of the shipped templates.
+// ---------------------------------------------------------------------------
+
+const FIXTURE_PREPARE_TMPL = `name: prepare
+on:
+  workflow_dispatch:
+    inputs: { version: { type: string, required: true } }
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with: { node-version: '{{NODE_VERSION}}' }
+      - run: {{INSTALL_CMD}}
+      - run: {{LINT_CMD}}
+      - run: {{TYPECHECK_CMD}}
+      - run: {{TEST_CMD}}
+      - run: {{BUILD_CMD}}
+      - run: |
+          BRANCH="{{BRANCH_PREFIX}}/\${{ inputs.version }}"
+          gh pr create --label "{{PR_LABEL}}"
+`;
+
+const FIXTURE_PUBLISH_TMPL = `name: publish
+on: { push: { branches: [main] } }
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with: { node-version: '{{NODE_VERSION}}' }
+      - run: {{INSTALL_CMD}}
+      - run: {{TEST_CMD}}
+      - run: {{BUILD_CMD}}
+      - run: {{NPM_PUBLISH_CMD}}
+      - run: echo "publishers={{PUBLISHERS}}"
+`;
+
+const FIXTURE_FANOUT_TMPL = `name: fanout
+on: { release: { types: [published] } }
+jobs:
+  docs:
+    if: \${{ {{ENABLE_DOCS_DEPLOY}} }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: {{DOCS_BUILD_CMD}}
+  docker:
+    if: \${{ {{ENABLE_DOCKER_RETAG}} }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "image={{DOCKER_IMAGE}} user={{DOCKER_HUB_USER}}"
+  sentinel:
+    if: \${{ {{ENABLE_SENTINEL_NOTIFY}} }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "url={{SENTINEL_WEBHOOK_URL}}"
+  studio:
+    if: \${{ {{ENABLE_STUDIO_DEPLOY}} }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "hook={{STUDIO_DEPLOY_HOOK}}"
+  nightly:
+    if: \${{ {{ENABLE_NIGHTLY_TRIGGER}} }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "nightly"
+`;
+
+const FIXTURE_ROLLBACK_TMPL = `name: rollback
+on:
+  workflow_dispatch:
+    inputs:
+      version: { type: string, required: true }
+      mode: { type: choice, options: [metadata-only, full], required: true }
+jobs:
+  deprecate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "publishers={{PUBLISHERS}}"
+      - run: echo "npm packages={{NPM_PACKAGES}}"
+      - run: echo "cargo crates={{CARGO_CRATES}}"
+      - run: {{NPM_PUBLISH_CMD}}
+`;
+
+interface FixturePaths {
+  projectRoot: string;
+  templatesDir: string;
+}
+
+/**
+ * Build an isolated temp directory containing all four fixture
+ * templates plus a minimal `.cleo/project-context.json`.
+ */
+async function makeFullFixture(): Promise<FixturePaths> {
+  const root = await mkdtemp(join(tmpdir(), 'cleo-scaffold-workflows-all-'));
+  const projectRoot = join(root, 'project');
+  const templatesDir = join(root, 'templates');
+  await mkdir(projectRoot, { recursive: true });
+  await mkdir(join(projectRoot, '.cleo'), { recursive: true });
+  await mkdir(templatesDir, { recursive: true });
+
+  await writeFile(join(templatesDir, 'release-prepare.yml.tmpl'), FIXTURE_PREPARE_TMPL, 'utf-8');
+  await writeFile(join(templatesDir, 'release-publish.yml.tmpl'), FIXTURE_PUBLISH_TMPL, 'utf-8');
+  await writeFile(join(templatesDir, 'release-fanout.yml.tmpl'), FIXTURE_FANOUT_TMPL, 'utf-8');
+  await writeFile(join(templatesDir, 'release-rollback.yml.tmpl'), FIXTURE_ROLLBACK_TMPL, 'utf-8');
+
+  await writeFile(
+    join(projectRoot, '.cleo', 'project-context.json'),
+    JSON.stringify({ schemaVersion: '1.0.0', primaryType: 'node' }, null, 2),
+    'utf-8',
+  );
+
+  return { projectRoot, templatesDir };
+}
+
+describe('scaffoldWorkflows defaults — full four-template set (T9536)', () => {
+  it('DEFAULT_WORKFLOW_TEMPLATES exports the four canonical names in order', () => {
+    expect(DEFAULT_WORKFLOW_TEMPLATES).toEqual([
+      'release-prepare',
+      'release-publish',
+      'release-fanout',
+      'release-rollback',
+    ]);
+  });
+
+  it('renders all four templates when `templates` is omitted', async () => {
+    const { projectRoot, templatesDir } = await makeFullFixture();
+
+    const result = await scaffoldWorkflows({ projectRoot, templatesDir });
+
+    expect(result.outcomes).toHaveLength(4);
+    const names = result.outcomes.map((o) => o.template);
+    expect(names).toEqual([
+      'release-prepare',
+      'release-publish',
+      'release-fanout',
+      'release-rollback',
+    ]);
+    // Every outcome was created on a fresh filesystem.
+    for (const o of result.outcomes) {
+      expect(o.status).toBe('created');
+    }
+
+    // Files exist with the rendered content.
+    for (const o of result.outcomes) {
+      const onDisk = await readFile(o.targetPath, 'utf-8');
+      expect(onDisk).toBe(o.rendered);
+    }
+  });
+
+  it('honours an explicit single-template subset (T9531 back-compat)', async () => {
+    const { projectRoot, templatesDir } = await makeFullFixture();
+
+    const result = await scaffoldWorkflows({
+      projectRoot,
+      templatesDir,
+      templates: ['release-prepare'],
+    });
+
+    expect(result.outcomes).toHaveLength(1);
+    expect(result.outcomes[0]?.template).toBe('release-prepare');
+  });
+
+  it('substitutes every placeholder across all four templates', async () => {
+    const { projectRoot, templatesDir } = await makeFullFixture();
+
+    const result = await scaffoldWorkflows({
+      projectRoot,
+      templatesDir,
+      dryRun: true,
+    });
+
+    expect(result.outcomes).toHaveLength(4);
+    for (const o of result.outcomes) {
+      // No raw {{NAME}} tokens should remain in the rendered output.
+      expect(o.rendered).not.toMatch(/\{\{[A-Z_]+\}\}/);
+      expect(o.rendered.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('idempotence: re-running with the same fixture returns all `unchanged`', async () => {
+    const { projectRoot, templatesDir } = await makeFullFixture();
+
+    const first = await scaffoldWorkflows({ projectRoot, templatesDir });
+    expect(first.outcomes.every((o) => o.status === 'created')).toBe(true);
+
+    const second = await scaffoldWorkflows({ projectRoot, templatesDir });
+    expect(second.outcomes).toHaveLength(4);
+    for (const o of second.outcomes) {
+      expect(o.status).toBe('unchanged');
+    }
+  });
+
+  it('dry-run: every outcome carries a non-empty rendered body without writing', async () => {
+    const { projectRoot, templatesDir } = await makeFullFixture();
+
+    const result = await scaffoldWorkflows({
+      projectRoot,
+      templatesDir,
+      dryRun: true,
+    });
+
+    expect(result.outcomes).toHaveLength(4);
+    for (const o of result.outcomes) {
+      expect(o.status).toBe('dry-run');
+      expect(o.rendered.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Smoke test against the REAL shipped templates — guards against template
+// drift that would leave a {{...}} placeholder behind in the rendered
+// output. Full `actionlint` integration is deferred to a separate Phase 4
+// integration suite (R-261).
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the absolute path to `packages/cleo/templates/workflows/` from
+ * this test file. Walks the directory tree without depending on the
+ * package layout (works in both monorepo dev + dist builds).
+ */
+function resolveRealTemplatesDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // here = packages/core/src/init/__tests__   (in source)
+  //      = packages/core/dist/init/__tests__  (after esbuild emit)
+  // From either anchor, "up" four levels lands at packages/core/, and
+  // "../cleo/templates/workflows" is the target.
+  return resolve(here, '..', '..', '..', '..', 'cleo', 'templates', 'workflows');
+}
+
+describe('scaffoldWorkflows against the real shipped templates (T9536 smoke)', () => {
+  it('renders all four real templates without leaving placeholder tokens', async () => {
+    const templatesDir = resolveRealTemplatesDir();
+
+    // Fresh project dir so no on-disk drift influences the outcome.
+    const projectRoot = await mkdtemp(join(tmpdir(), 'cleo-real-tmpl-'));
+    await mkdir(join(projectRoot, '.cleo'), { recursive: true });
+    await writeFile(
+      join(projectRoot, '.cleo', 'project-context.json'),
+      JSON.stringify({ schemaVersion: '1.0.0', primaryType: 'node' }, null, 2),
+      'utf-8',
+    );
+
+    const result = await scaffoldWorkflows({
+      projectRoot,
+      templatesDir,
+      dryRun: true,
+    });
+
+    expect(result.outcomes).toHaveLength(4);
+
+    const names: WorkflowName[] = result.outcomes.map((o) => o.template);
+    expect(new Set(names)).toEqual(
+      new Set(['release-prepare', 'release-publish', 'release-fanout', 'release-rollback']),
+    );
+
+    for (const o of result.outcomes) {
+      // No {{PLACEHOLDER}} tokens should remain.
+      expect(o.rendered, `template ${o.template} had unsubstituted placeholders`).not.toMatch(
+        /\{\{[A-Z_]+\}\}/,
+      );
+      // YAML "name:" front-matter should survive rendering.
+      expect(o.rendered).toMatch(/^name:\s+/m);
+    }
+  });
+});

--- a/packages/core/src/init/__tests__/scaffold-workflows.test.ts
+++ b/packages/core/src/init/__tests__/scaffold-workflows.test.ts
@@ -142,6 +142,7 @@ describe('scaffoldWorkflows (T9531)', () => {
     const result = await scaffoldWorkflows({
       projectRoot,
       templatesDir,
+      templates: ['release-prepare'],
       dryRun: true,
     });
 
@@ -174,6 +175,7 @@ describe('scaffoldWorkflows (T9531)', () => {
     const result = await scaffoldWorkflows({
       projectRoot,
       templatesDir,
+      templates: ['release-prepare'],
       dryRun: true,
     });
 
@@ -200,6 +202,7 @@ describe('scaffoldWorkflows (T9531)', () => {
     const result = await scaffoldWorkflows({
       projectRoot,
       templatesDir,
+      templates: ['release-prepare'],
       dryRun: true,
     });
 
@@ -217,7 +220,11 @@ describe('scaffoldWorkflows (T9531)', () => {
   it('creates .github/workflows/release-prepare.yml on first run', async () => {
     const { projectRoot, templatesDir } = await makeFixture();
 
-    const result = await scaffoldWorkflows({ projectRoot, templatesDir });
+    const result = await scaffoldWorkflows({
+      projectRoot,
+      templatesDir,
+      templates: ['release-prepare'],
+    });
 
     expect(result.outcomes).toHaveLength(1);
     expect(result.outcomes[0]?.status).toBe('created');
@@ -232,10 +239,18 @@ describe('scaffoldWorkflows (T9531)', () => {
   it('is idempotent: re-running with the same config returns unchanged', async () => {
     const { projectRoot, templatesDir } = await makeFixture();
 
-    const first = await scaffoldWorkflows({ projectRoot, templatesDir });
+    const first = await scaffoldWorkflows({
+      projectRoot,
+      templatesDir,
+      templates: ['release-prepare'],
+    });
     expect(first.outcomes[0]?.status).toBe('created');
 
-    const second = await scaffoldWorkflows({ projectRoot, templatesDir });
+    const second = await scaffoldWorkflows({
+      projectRoot,
+      templatesDir,
+      templates: ['release-prepare'],
+    });
     expect(second.outcomes[0]?.status).toBe('unchanged');
   });
 
@@ -249,7 +264,11 @@ describe('scaffoldWorkflows (T9531)', () => {
     const targetPath = join(projectRoot, '.github', 'workflows', 'release-prepare.yml');
     await writeFile(targetPath, 'name: stale handcrafted yaml\n', 'utf-8');
 
-    const result = await scaffoldWorkflows({ projectRoot, templatesDir });
+    const result = await scaffoldWorkflows({
+      projectRoot,
+      templatesDir,
+      templates: ['release-prepare'],
+    });
     expect(result.outcomes[0]?.status).toBe('skipped');
 
     // The drifted file must NOT have been overwritten.
@@ -267,6 +286,7 @@ describe('scaffoldWorkflows (T9531)', () => {
     const result = await scaffoldWorkflows({
       projectRoot,
       templatesDir,
+      templates: ['release-prepare'],
       force: true,
     });
     expect(result.outcomes[0]?.status).toBe('updated');
@@ -294,6 +314,7 @@ describe('scaffoldWorkflows (T9531)', () => {
     const result = await scaffoldWorkflows({
       projectRoot,
       templatesDir,
+      templates: ['release-prepare'],
       dryRun: true,
     });
     expect(result.outcomes[0]?.status).toBe('dry-run');
@@ -311,6 +332,7 @@ describe('scaffoldWorkflows (T9531)', () => {
     const result = await scaffoldWorkflows({
       projectRoot,
       templatesDir,
+      templates: ['release-prepare'],
       dryRun: true,
       releaseConfigOverride: {
         nodeVersion: '21.x',

--- a/packages/core/src/init/__tests__/upgrade-workflows.test.ts
+++ b/packages/core/src/init/__tests__/upgrade-workflows.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Unit tests for the `cleo upgrade workflows` SDK primitive (T9536).
+ *
+ * Coverage:
+ *   - unchanged:       re-rendering produces the same byte-equal output
+ *                      already on disk.
+ *   - missing:         the on-disk file is absent (drift, but distinct
+ *                      from `drift-detected`).
+ *   - drift-detected:  rendered output differs and no override applies.
+ *   - override-kept:   rendered output differs but `.workflow-overrides.yml`
+ *                      declares an entry for the template.
+ *   - updated + audit: `force=true` overwrites the drifted file and
+ *                      lands an audit row.
+ *   - hasDrift flag:   `--check`-style exit contract is reflected on
+ *                      the envelope.
+ *   - parseOverridesYamlBody: minimal top-level-key parser.
+ *
+ * @task T9536
+ * @epic T9497
+ */
+
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { scaffoldWorkflows, type WorkflowName } from '../scaffold-workflows.js';
+import { parseOverridesYamlBody, upgradeWorkflows } from '../upgrade-workflows.js';
+
+const FIXTURE_PREPARE_TMPL = `name: prepare
+on: { workflow_dispatch: {} }
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with: { node-version: '{{NODE_VERSION}}' }
+      - run: {{INSTALL_CMD}}
+      - run: |
+          BRANCH="{{BRANCH_PREFIX}}/x"
+          gh pr create --label "{{PR_LABEL}}"
+`;
+
+const FIXTURE_PUBLISH_TMPL = `name: publish
+on: { push: { branches: [main] } }
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with: { node-version: '{{NODE_VERSION}}' }
+      - run: {{INSTALL_CMD}}
+      - run: {{TEST_CMD}}
+      - run: {{BUILD_CMD}}
+      - run: {{NPM_PUBLISH_CMD}}
+      - run: echo "publishers={{PUBLISHERS}}"
+`;
+
+const FIXTURE_FANOUT_TMPL = `name: fanout
+on: { release: { types: [published] } }
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: {{DOCS_BUILD_CMD}}
+      - run: echo "{{ENABLE_DOCS_DEPLOY}} {{ENABLE_DOCKER_RETAG}} {{ENABLE_SENTINEL_NOTIFY}} {{ENABLE_STUDIO_DEPLOY}} {{ENABLE_NIGHTLY_TRIGGER}}"
+      - run: echo "{{DOCKER_IMAGE}} {{DOCKER_HUB_USER}} {{SENTINEL_WEBHOOK_URL}} {{STUDIO_DEPLOY_HOOK}}"
+`;
+
+const FIXTURE_ROLLBACK_TMPL = `name: rollback
+on: { workflow_dispatch: {} }
+jobs:
+  deprecate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "publishers={{PUBLISHERS}} npm={{NPM_PACKAGES}} cargo={{CARGO_CRATES}}"
+      - run: {{NPM_PUBLISH_CMD}}
+`;
+
+interface FixturePaths {
+  projectRoot: string;
+  templatesDir: string;
+}
+
+/**
+ * Build a fixture with all four template files. The project is fresh
+ * (no `.github/workflows/` files yet) — individual tests bootstrap
+ * those via `scaffoldWorkflows` if they want an "in-sync" starting
+ * state.
+ */
+async function makeUpgradeFixture(): Promise<FixturePaths> {
+  const root = await mkdtemp(join(tmpdir(), 'cleo-upgrade-workflows-'));
+  const projectRoot = join(root, 'project');
+  const templatesDir = join(root, 'templates');
+  await mkdir(projectRoot, { recursive: true });
+  await mkdir(join(projectRoot, '.cleo'), { recursive: true });
+  await mkdir(templatesDir, { recursive: true });
+
+  await writeFile(join(templatesDir, 'release-prepare.yml.tmpl'), FIXTURE_PREPARE_TMPL, 'utf-8');
+  await writeFile(join(templatesDir, 'release-publish.yml.tmpl'), FIXTURE_PUBLISH_TMPL, 'utf-8');
+  await writeFile(join(templatesDir, 'release-fanout.yml.tmpl'), FIXTURE_FANOUT_TMPL, 'utf-8');
+  await writeFile(join(templatesDir, 'release-rollback.yml.tmpl'), FIXTURE_ROLLBACK_TMPL, 'utf-8');
+
+  await writeFile(
+    join(projectRoot, '.cleo', 'project-context.json'),
+    JSON.stringify({ schemaVersion: '1.0.0', primaryType: 'node' }, null, 2),
+    'utf-8',
+  );
+
+  return { projectRoot, templatesDir };
+}
+
+describe('upgradeWorkflows (T9536)', () => {
+  it('reports `missing` for every template on a fresh project', async () => {
+    const { projectRoot, templatesDir } = await makeUpgradeFixture();
+
+    const result = await upgradeWorkflows({ projectRoot, templatesDir });
+
+    expect(result.outcomes).toHaveLength(4);
+    for (const o of result.outcomes) {
+      expect(o.status).toBe('missing');
+      expect(o.existing).toBeNull();
+    }
+    expect(result.hasDrift).toBe(true);
+  });
+
+  it('reports `unchanged` after a fresh scaffold (round-trip)', async () => {
+    const { projectRoot, templatesDir } = await makeUpgradeFixture();
+    // Bootstrap the workflows so the on-disk state matches the rendered
+    // output byte-for-byte.
+    await scaffoldWorkflows({ projectRoot, templatesDir });
+
+    const result = await upgradeWorkflows({ projectRoot, templatesDir });
+
+    expect(result.outcomes).toHaveLength(4);
+    for (const o of result.outcomes) {
+      expect(o.status).toBe('unchanged');
+      expect(o.existing).toBe(o.rendered);
+    }
+    expect(result.hasDrift).toBe(false);
+  });
+
+  it('reports `drift-detected` when the on-disk file diverges', async () => {
+    const { projectRoot, templatesDir } = await makeUpgradeFixture();
+    await scaffoldWorkflows({ projectRoot, templatesDir });
+
+    // Hand-tweak release-prepare.yml so it no longer matches the
+    // re-render.
+    const preparePath = join(projectRoot, '.github', 'workflows', 'release-prepare.yml');
+    const original = await readFile(preparePath, 'utf-8');
+    await writeFile(preparePath, `${original}\n# hand-edited tail\n`, 'utf-8');
+
+    const result = await upgradeWorkflows({ projectRoot, templatesDir });
+
+    const prepareOutcome = result.outcomes.find((o) => o.template === 'release-prepare');
+    expect(prepareOutcome).toBeDefined();
+    expect(prepareOutcome?.status).toBe('drift-detected');
+    expect(result.hasDrift).toBe(true);
+
+    // No write should have happened — the drifted content is preserved.
+    const after = await readFile(preparePath, 'utf-8');
+    expect(after).toContain('# hand-edited tail');
+  });
+
+  it('reports `override-kept` when `.workflow-overrides.yml` declares the template', async () => {
+    const { projectRoot, templatesDir } = await makeUpgradeFixture();
+    await scaffoldWorkflows({ projectRoot, templatesDir });
+
+    // Drift the file.
+    const preparePath = join(projectRoot, '.github', 'workflows', 'release-prepare.yml');
+    await writeFile(preparePath, 'name: operator-owned\n', 'utf-8');
+
+    // Declare an override.
+    await writeFile(
+      join(projectRoot, '.workflow-overrides.yml'),
+      'release-prepare:\n  jobs:\n    preflight:\n      env:\n        EXTRA: "true"\n',
+      'utf-8',
+    );
+
+    const result = await upgradeWorkflows({ projectRoot, templatesDir });
+
+    const prepareOutcome = result.outcomes.find((o) => o.template === 'release-prepare');
+    expect(prepareOutcome?.status).toBe('override-kept');
+    expect(prepareOutcome?.overrideDeclared).toBe(true);
+
+    // hasDrift must stay false — override-kept is operator-declared, not
+    // implicit drift.
+    expect(result.hasDrift).toBe(false);
+
+    // Drifted file preserved verbatim.
+    const after = await readFile(preparePath, 'utf-8');
+    expect(after).toBe('name: operator-owned\n');
+  });
+
+  it('overwrites + audit-logs when force=true and drift has no override', async () => {
+    const { projectRoot, templatesDir } = await makeUpgradeFixture();
+    await scaffoldWorkflows({ projectRoot, templatesDir });
+
+    const preparePath = join(projectRoot, '.github', 'workflows', 'release-prepare.yml');
+    await writeFile(preparePath, 'name: stale\n', 'utf-8');
+
+    const result = await upgradeWorkflows({
+      projectRoot,
+      templatesDir,
+      force: true,
+    });
+
+    const prepareOutcome = result.outcomes.find((o) => o.template === 'release-prepare');
+    expect(prepareOutcome?.status).toBe('updated');
+
+    // File was overwritten with the rendered output.
+    const after = await readFile(preparePath, 'utf-8');
+    expect(after).toBe(prepareOutcome?.rendered);
+
+    // Audit row landed.
+    const auditPath = join(projectRoot, '.cleo', 'audit', 'upgrade-workflows.jsonl');
+    const auditContents = await readFile(auditPath, 'utf-8');
+    const lines = auditContents.trim().split('\n');
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const row = JSON.parse(lines[0] as string);
+    expect(row.operation).toBe('workflow-upgrade');
+    expect(row.template).toBe('release-prepare');
+    expect(row.reason).toBe('force');
+  });
+
+  it('dry-run never writes, never flips hasDrift, and carries renders', async () => {
+    const { projectRoot, templatesDir } = await makeUpgradeFixture();
+    await scaffoldWorkflows({ projectRoot, templatesDir });
+
+    const preparePath = join(projectRoot, '.github', 'workflows', 'release-prepare.yml');
+    await writeFile(preparePath, 'name: stale\n', 'utf-8');
+
+    const result = await upgradeWorkflows({
+      projectRoot,
+      templatesDir,
+      dryRun: true,
+    });
+
+    for (const o of result.outcomes) {
+      expect(o.status).toBe('dry-run');
+      expect(o.rendered.length).toBeGreaterThan(0);
+    }
+    // hasDrift is NOT computed under dry-run — the caller is expected to
+    // run a non-dry-run pass for the exit-code contract.
+    expect(result.hasDrift).toBe(false);
+
+    // Pre-tweaked file is preserved.
+    const after = await readFile(preparePath, 'utf-8');
+    expect(after).toBe('name: stale\n');
+  });
+
+  it('honours overridesOverride without touching .workflow-overrides.yml on disk', async () => {
+    const { projectRoot, templatesDir } = await makeUpgradeFixture();
+    await scaffoldWorkflows({ projectRoot, templatesDir });
+
+    // Drift fanout.
+    const fanoutPath = join(projectRoot, '.github', 'workflows', 'release-fanout.yml');
+    await writeFile(fanoutPath, 'name: operator-fanout\n', 'utf-8');
+
+    const result = await upgradeWorkflows({
+      projectRoot,
+      templatesDir,
+      overridesOverride: { 'release-fanout': true },
+    });
+
+    const fanoutOutcome = result.outcomes.find(
+      (o: { template: WorkflowName }) => o.template === 'release-fanout',
+    );
+    expect(fanoutOutcome?.status).toBe('override-kept');
+  });
+});
+
+describe('parseOverridesYamlBody (T9536)', () => {
+  it('extracts top-level canonical template keys', () => {
+    const body = [
+      'release-prepare:',
+      '  jobs:',
+      '    preflight:',
+      '      env: { X: "1" }',
+      'release-publish:',
+      '  jobs: {}',
+      '# release-fanout: ignored — commented',
+      'release-rollback:',
+      '  jobs: {}',
+    ].join('\n');
+
+    const parsed = parseOverridesYamlBody(body);
+    expect(parsed['release-prepare']).toBe(true);
+    expect(parsed['release-publish']).toBe(true);
+    expect(parsed['release-rollback']).toBe(true);
+    expect(parsed['release-fanout']).toBeUndefined();
+  });
+
+  it('ignores nested keys with the same shape', () => {
+    const body = [
+      'release-prepare:',
+      '  release-publish: { still-nested: true }',
+      '  jobs: {}',
+    ].join('\n');
+
+    const parsed = parseOverridesYamlBody(body);
+    expect(parsed['release-prepare']).toBe(true);
+    expect(parsed['release-publish']).toBeUndefined();
+  });
+
+  it('returns an empty object on an empty body', () => {
+    expect(parseOverridesYamlBody('')).toEqual({});
+    expect(parseOverridesYamlBody('# only comments\n')).toEqual({});
+  });
+});

--- a/packages/core/src/init/index.ts
+++ b/packages/core/src/init/index.ts
@@ -26,6 +26,16 @@ export type {
   WorkflowName,
 } from './scaffold-workflows.js';
 export {
+  DEFAULT_WORKFLOW_TEMPLATES,
   listAvailableWorkflowTemplates,
   scaffoldWorkflows,
 } from './scaffold-workflows.js';
+// T9536 — workflow upgrade (`cleo upgrade workflows`).
+export type {
+  UpgradeWorkflowOutcome,
+  UpgradeWorkflowStatus,
+  UpgradeWorkflowsOptions,
+  UpgradeWorkflowsResult,
+  WorkflowOverrides,
+} from './upgrade-workflows.js';
+export { parseOverridesYamlBody, upgradeWorkflows } from './upgrade-workflows.js';

--- a/packages/core/src/init/scaffold-workflows.ts
+++ b/packages/core/src/init/scaffold-workflows.ts
@@ -14,11 +14,12 @@
  *   3. Hard-coded fallbacks — `22.x` for Node, `release` for branch/label
  *      prefixes, the conventional pnpm-flavoured commands.
  *
- * For T9531 (Phase 3 of T9494) we ship the prepare scaffold only —
+ * T9531 (Phase 3 of T9494) shipped the prepare-only scaffold —
  * `release-prepare.yml.tmpl` → `.github/workflows/release-prepare.yml`.
- * T9536 will extend this primitive to walk the full four-template set
- * (`prepare` + `publish` + `fanout` + `rollback`) without further
- * scaffolder changes.
+ * T9536 (Phase 4 of T9497) extended the default to walk the full
+ * four-template set: `release-prepare`, `release-publish`,
+ * `release-fanout`, `release-rollback`. Callers MAY still pass an
+ * explicit single-template `templates` array to scaffold a subset.
  *
  * Implementation notes:
  *
@@ -57,9 +58,10 @@ import { resolveToolCommand } from '../tasks/tool-resolver.js';
  * `<templatesDir>/<name>.yml.tmpl` and writes
  * `<projectRoot>/.github/workflows/<name>.yml`.
  *
- * For T9531 only `release-prepare` is wired. The other three names are
- * declared here so T9536 can extend the scaffolder by flipping the
- * default `templates` set without further type changes.
+ * All four canonical templates are now wired by default (T9536). Callers
+ * that need a single-template subset (legacy T9531 behaviour) MUST pass
+ * an explicit `templates` array — the default is the full four-template
+ * set so a fresh `cleo init --workflows` produces the complete pipeline.
  */
 export type WorkflowName =
   | 'release-prepare'
@@ -135,8 +137,13 @@ export interface ScaffoldWorkflowsOptions {
    */
   templatesDir: string;
   /**
-   * Which templates to render. Defaults to `['release-prepare']` for
-   * T9531 (prepare-only scaffolder). T9536 flips this to all four.
+   * Which templates to render. T9531 shipped a prepare-only default;
+   * T9536 flipped the default to ALL four canonical templates —
+   * `release-prepare`, `release-publish`, `release-fanout`,
+   * `release-rollback`. Callers MAY still pass a subset (e.g.
+   * `['release-prepare']`) to scaffold one template at a time.
+   *
+   * See {@link DEFAULT_WORKFLOW_TEMPLATES} for the default ordering.
    */
   templates?: ReadonlyArray<WorkflowName>;
   /**
@@ -194,6 +201,23 @@ export interface ScaffoldWorkflowsResult {
 // ---------------------------------------------------------------------------
 // Defaults & helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Canonical full set of release-pipeline workflow templates rendered by
+ * `cleo init --workflows` when no explicit `templates` array is provided.
+ *
+ * Ordering matters for the audit log + CLI stdout summary: prepare lands
+ * first (the entrypoint), publish second (tag-on-merge), fanout third
+ * (best-effort downstream), rollback last (workflow_dispatch only).
+ *
+ * @task T9536
+ */
+export const DEFAULT_WORKFLOW_TEMPLATES: ReadonlyArray<WorkflowName> = [
+  'release-prepare',
+  'release-publish',
+  'release-fanout',
+  'release-rollback',
+] as const;
 
 const DEFAULT_NODE_VERSION = '22.x' as const;
 const DEFAULT_BRANCH_PREFIX = 'release' as const;
@@ -397,8 +421,11 @@ async function readIfExists(path: string): Promise<string | null> {
 /**
  * Render and write the requested workflow templates.
  *
- * Default behaviour for T9531 is to render `release-prepare` only. Pass
- * `templates: ['release-prepare', 'release-publish', ...]` to extend.
+ * T9536 default behaviour: renders ALL four canonical templates
+ * (`release-prepare`, `release-publish`, `release-fanout`,
+ * `release-rollback`). Pass an explicit `templates` array to scaffold a
+ * subset (legacy T9531 prepare-only behaviour is recovered by passing
+ * `templates: ['release-prepare']`).
  *
  * @example
  * ```ts
@@ -412,6 +439,7 @@ async function readIfExists(path: string): Promise<string | null> {
  * ```
  *
  * @task T9531
+ * @task T9536 — full four-template default
  */
 export async function scaffoldWorkflows(
   opts: ScaffoldWorkflowsOptions,
@@ -420,7 +448,7 @@ export async function scaffoldWorkflows(
   const dryRun = opts.dryRun === true;
   const force = opts.force === true;
   const templates: ReadonlyArray<WorkflowName> =
-    opts.templates && opts.templates.length > 0 ? opts.templates : ['release-prepare'];
+    opts.templates && opts.templates.length > 0 ? opts.templates : DEFAULT_WORKFLOW_TEMPLATES;
 
   // 1. Inputs: release-config.json (override-aware) + ADR-061 resolved tools.
   const cfg =

--- a/packages/core/src/init/upgrade-workflows.ts
+++ b/packages/core/src/init/upgrade-workflows.ts
@@ -1,0 +1,578 @@
+/**
+ * Workflow upgrade primitive — `cleo upgrade workflows`.
+ *
+ * Phase 4 of T9497 (parent epic) and T9536. Re-renders every shipped
+ * workflow template against current `.cleo/release-config.json` +
+ * ADR-061 tool-resolver state, compares the rendered YAML against the
+ * existing `.github/workflows/release-*.yml` files, and reports a
+ * per-template `UpgradeWorkflowOutcome` envelope. An optional
+ * `.workflow-overrides.yml` file (if present at the project root)
+ * carries operator-declared customizations the upgrade MUST respect so
+ * a re-render does not silently clobber hand-tuned env vars or step
+ * additions.
+ *
+ * The first iteration of the 3-way merge is intentionally SIMPLE:
+ *
+ *   - If `rendered === existing`              ⇒ `unchanged`.
+ *   - If `existing === null`                  ⇒ `missing` (drift; the user
+ *                                                 needs to re-run
+ *                                                 `cleo init --workflows`).
+ *   - If `rendered !== existing` AND an override key matches the
+ *     template name in `.workflow-overrides.yml`        ⇒ `override-kept`
+ *                                                 (we report drift but
+ *                                                 do NOT recommend
+ *                                                 overwrite — the operator
+ *                                                 owns the file).
+ *   - If `rendered !== existing` AND no override applies ⇒ `drift-detected`
+ *                                                 (caller decides
+ *                                                 `force` or `skip`).
+ *
+ * Full deep-merge of override paths into the rendered template is
+ * deferred — the v1 contract is drift-detection plus a copy of the
+ * rendered output for diff display. The caller (`cleo upgrade
+ * workflows`) consumes this envelope to:
+ *
+ *   - Print a per-file status table.
+ *   - With `--dry-run`: emit the diff and exit 0.
+ *   - With `--check`:   exit 0 if every outcome is `unchanged` /
+ *                       `override-kept`; exit 1 otherwise.
+ *   - With `--force`:   re-write the file in-place (audit-logged).
+ *
+ * Writes are atomic via tmp-then-rename — exactly the convention
+ * {@link scaffoldWorkflows} already uses (DRY across the init/upgrade
+ * pair).
+ *
+ * @module init/upgrade-workflows
+ * @task T9536
+ * @epic T9497
+ * @adr ADR-061
+ * @adr ADR-065
+ */
+
+import { appendFile, mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import { resolveToolCommand } from '../tasks/tool-resolver.js';
+import type {
+  ResolvedToolPlaceholders,
+  ScaffoldReleaseConfig,
+  WorkflowName,
+} from './scaffold-workflows.js';
+import { DEFAULT_WORKFLOW_TEMPLATES } from './scaffold-workflows.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-template upgrade outcome status.
+ *
+ *  - `unchanged`      — rendered output matches the file already on disk.
+ *  - `missing`        — `.github/workflows/<name>.yml` is absent. The
+ *                       operator likely never ran `cleo init --workflows`
+ *                       (or deleted the file). Run init to bootstrap.
+ *  - `override-kept`  — content drift detected, BUT a key matching the
+ *                       template name exists in `.workflow-overrides.yml`.
+ *                       The drift is operator-declared; the on-disk file
+ *                       is preserved verbatim.
+ *  - `drift-detected` — content drift detected and NO override applies.
+ *                       Without `force=true`, the file is preserved
+ *                       verbatim (caller decides next step).
+ *  - `updated`        — `force=true` was passed and the file was
+ *                       overwritten with the rendered output. An audit
+ *                       row landed in `.cleo/audit/upgrade-workflows.jsonl`.
+ *  - `dry-run`        — `dryRun=true`; the rendered YAML is in the
+ *                       envelope but no write occurred.
+ */
+export type UpgradeWorkflowStatus =
+  | 'unchanged'
+  | 'missing'
+  | 'override-kept'
+  | 'drift-detected'
+  | 'updated'
+  | 'dry-run';
+
+/**
+ * Per-template upgrade outcome.
+ *
+ * `rendered` always carries the freshly rendered YAML so the CLI can
+ * surface a diff against `existing` (when present) regardless of
+ * `status`. `existing` is `null` only when `status === 'missing'`.
+ */
+export interface UpgradeWorkflowOutcome {
+  /** Which template was re-rendered. */
+  template: WorkflowName;
+  /** Absolute path to the workflow file on disk. */
+  targetPath: string;
+  /** Freshly rendered YAML (output of {@link scaffoldWorkflows}-style render). */
+  rendered: string;
+  /** The on-disk file at `targetPath`, or `null` when the file is missing. */
+  existing: string | null;
+  /** Disposition — see {@link UpgradeWorkflowStatus} for semantics. */
+  status: UpgradeWorkflowStatus;
+  /**
+   * `true` iff `.workflow-overrides.yml` carries a top-level key that
+   * matches `template`. Surfaced in the envelope so the CLI can show
+   * "operator override declared" in the status table even when
+   * `status === 'unchanged'`.
+   */
+  overrideDeclared: boolean;
+}
+
+/**
+ * Options for {@link upgradeWorkflows}.
+ */
+export interface UpgradeWorkflowsOptions {
+  /**
+   * Absolute path to the consuming project's root.
+   */
+  projectRoot: string;
+  /**
+   * Absolute path to the directory containing the `*.yml.tmpl` files —
+   * usually the `templates/workflows/` directory of an installed
+   * `@cleocode/cleo` package. Exposed as an option so tests can point at
+   * a fixture tree.
+   */
+  templatesDir: string;
+  /**
+   * Which templates to inspect. Defaults to the full four-template set
+   * declared in {@link DEFAULT_WORKFLOW_TEMPLATES}.
+   */
+  templates?: ReadonlyArray<WorkflowName>;
+  /**
+   * `true` ⇒ overwrite `.github/workflows/<name>.yml` even when content
+   * drifts. Audited to `.cleo/audit/upgrade-workflows.jsonl`. Ignored
+   * when `dryRun=true`.
+   */
+  force?: boolean;
+  /**
+   * `true` ⇒ skip the actual write. Every outcome reports `dry-run`
+   * regardless of drift; the rendered YAML stays in the envelope so the
+   * CLI can show a diff.
+   */
+  dryRun?: boolean;
+  /**
+   * Override the loaded release config — primarily for unit tests.
+   * When omitted the helper reads `<projectRoot>/.cleo/release-config.json`.
+   */
+  releaseConfigOverride?: ScaffoldReleaseConfig;
+  /**
+   * Override the parsed `.workflow-overrides.yml` body — primarily for
+   * unit tests. When omitted the helper reads
+   * `<projectRoot>/.workflow-overrides.yml` (best-effort; parse failure
+   * is treated as "no overrides declared").
+   */
+  overridesOverride?: WorkflowOverrides;
+}
+
+/**
+ * Top-level shape of `.workflow-overrides.yml`. Each top-level key
+ * names one of the four canonical templates; the value is treated as an
+ * opaque "operator-declared customization" — the v1 contract only
+ * checks for KEY presence, not value structure.
+ */
+export type WorkflowOverrides = Partial<Record<WorkflowName, unknown>>;
+
+/**
+ * Result envelope returned by {@link upgradeWorkflows}.
+ */
+export interface UpgradeWorkflowsResult {
+  /** Per-template outcomes in the order they were inspected. */
+  outcomes: UpgradeWorkflowOutcome[];
+  /** The placeholder set used by the substitution pass. */
+  resolvedTools: ResolvedToolPlaceholders;
+  /**
+   * `true` iff at least one outcome reports `drift-detected` or
+   * `missing`. Designed to drive the `--check` exit-code contract:
+   * `cleo upgrade workflows --check` exits 1 when this is `true` and
+   * 0 otherwise.
+   */
+  hasDrift: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults & helpers (DRY with scaffold-workflows.ts — same conventions)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_NODE_VERSION = '22.x' as const;
+const DEFAULT_BRANCH_PREFIX = 'release' as const;
+const DEFAULT_PR_LABEL = 'release' as const;
+const DEFAULT_INSTALL_CMD = 'pnpm install --frozen-lockfile' as const;
+const DEFAULT_LINT_CMD = 'pnpm run lint' as const;
+const DEFAULT_TYPECHECK_CMD = 'pnpm run typecheck' as const;
+const DEFAULT_TEST_CMD = 'pnpm run test' as const;
+const DEFAULT_BUILD_CMD = 'pnpm run build' as const;
+const DEFAULT_NPM_PUBLISH_CMD = 'pnpm publish --access public --tag latest' as const;
+const DEFAULT_PUBLISHERS = 'npm' as const;
+const DEFAULT_DOCS_BUILD_CMD = 'pnpm run docs:build' as const;
+
+/**
+ * Read `.cleo/release-config.json` from `<projectRoot>/.cleo/`. Returns
+ * `{}` on parse failure or missing file. Mirrors the helper in
+ * {@link scaffoldWorkflows} so the rendered output is byte-equal across
+ * the init/upgrade pair.
+ *
+ * @internal
+ */
+async function loadReleaseConfigJson(projectRoot: string): Promise<ScaffoldReleaseConfig> {
+  const configPath = join(projectRoot, '.cleo', 'release-config.json');
+  try {
+    const raw = await readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as ScaffoldReleaseConfig;
+    return parsed ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Best-effort load of `.workflow-overrides.yml`. The v1 contract only
+ * needs the top-level key set — we extract template names with a
+ * surface-level regex so this helper does NOT pull a YAML parser into
+ * `@cleocode/core` for one feature. Missing file or parse failure ⇒
+ * empty overrides object.
+ *
+ * @internal
+ */
+async function loadOverridesYaml(projectRoot: string): Promise<WorkflowOverrides> {
+  const overridesPath = join(projectRoot, '.workflow-overrides.yml');
+  try {
+    const raw = await readFile(overridesPath, 'utf-8');
+    return parseOverridesYamlBody(raw);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Parse the body of `.workflow-overrides.yml` and return a
+ * {@link WorkflowOverrides} record keyed by template name. The parser
+ * is deliberately minimal — it scans for top-level keys matching the
+ * four canonical workflow names and records `true` for each. Nested
+ * structure is ignored (the v1 contract only checks for KEY presence).
+ *
+ * Exposed for testability — callers should generally use
+ * {@link loadOverridesYaml}.
+ *
+ * @internal
+ */
+export function parseOverridesYamlBody(body: string): WorkflowOverrides {
+  const out: WorkflowOverrides = {};
+  // Top-level keys are non-indented YAML mapping keys: `^name:` on a
+  // fresh line, optionally followed by whitespace/comment. We deliberately
+  // ignore everything beneath a key.
+  const lines = body.split(/\r?\n/);
+  for (const line of lines) {
+    const match = /^([A-Za-z][A-Za-z0-9_-]*):/.exec(line);
+    if (!match) continue;
+    const key = match[1];
+    if (
+      key === 'release-prepare' ||
+      key === 'release-publish' ||
+      key === 'release-fanout' ||
+      key === 'release-rollback'
+    ) {
+      out[key] = true;
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve a canonical ADR-061 tool to a single shell-line command string
+ * suitable for substitution into a YAML `run:` step. Falls back to the
+ * supplied default when the resolver reports the tool unavailable.
+ *
+ * @internal
+ */
+function resolveToolLine(
+  canonical: 'test' | 'build' | 'lint' | 'typecheck',
+  projectRoot: string,
+  fallback: string,
+): string {
+  const result = resolveToolCommand(canonical, projectRoot);
+  if (!result.ok) return fallback;
+  const { cmd, args } = result.command;
+  return args.length > 0 ? `${cmd} ${args.join(' ')}` : cmd;
+}
+
+/**
+ * Build the resolved placeholder set used by the substitution pass.
+ *
+ * @internal
+ */
+function resolvePlaceholders(
+  projectRoot: string,
+  cfg: ScaffoldReleaseConfig,
+): ResolvedToolPlaceholders {
+  return {
+    install: cfg.installCmd ?? DEFAULT_INSTALL_CMD,
+    lint: resolveToolLine('lint', projectRoot, DEFAULT_LINT_CMD),
+    typecheck: resolveToolLine('typecheck', projectRoot, DEFAULT_TYPECHECK_CMD),
+    test: resolveToolLine('test', projectRoot, DEFAULT_TEST_CMD),
+    build: resolveToolLine('build', projectRoot, DEFAULT_BUILD_CMD),
+  };
+}
+
+/**
+ * Apply regex `s/{{NAME}}/value/g` substitutions in a single pass.
+ *
+ * @internal
+ */
+function renderTemplate(template: string, substitutions: ReadonlyMap<string, string>): string {
+  let out = template;
+  for (const [name, value] of substitutions) {
+    const pattern = new RegExp(`\\{\\{${name}\\}\\}`, 'g');
+    out = out.replace(pattern, value);
+  }
+  return out;
+}
+
+/**
+ * Construct the placeholder Map for the given template. Mirrors the
+ * implementation in `scaffold-workflows.ts` — the two surfaces MUST
+ * produce byte-equal output for the same inputs.
+ *
+ * @internal
+ */
+function buildSubstitutionMap(
+  template: WorkflowName,
+  cfg: ScaffoldReleaseConfig,
+  tools: ResolvedToolPlaceholders,
+): Map<string, string> {
+  const subs = new Map<string, string>();
+  subs.set('NODE_VERSION', cfg.nodeVersion ?? DEFAULT_NODE_VERSION);
+  subs.set('INSTALL_CMD', tools.install);
+  subs.set('LINT_CMD', tools.lint);
+  subs.set('TYPECHECK_CMD', tools.typecheck);
+  subs.set('TEST_CMD', tools.test);
+  subs.set('BUILD_CMD', tools.build);
+  subs.set('BRANCH_PREFIX', cfg.releaseBranchPrefix ?? DEFAULT_BRANCH_PREFIX);
+  subs.set('PR_LABEL', cfg.prLabel ?? DEFAULT_PR_LABEL);
+
+  if (template === 'release-publish' || template === 'release-rollback') {
+    subs.set('NPM_PUBLISH_CMD', cfg.npmPublishCmd ?? DEFAULT_NPM_PUBLISH_CMD);
+    subs.set('PUBLISHERS', cfg.publishers ?? DEFAULT_PUBLISHERS);
+  }
+  if (template === 'release-fanout') {
+    subs.set('DOCS_BUILD_CMD', cfg.fanout?.docsBuildCmd ?? DEFAULT_DOCS_BUILD_CMD);
+    subs.set('ENABLE_DOCS_DEPLOY', String(cfg.fanout?.docsDeploy ?? false));
+    subs.set('ENABLE_DOCKER_RETAG', String(cfg.fanout?.dockerRetag ?? false));
+    subs.set('ENABLE_SENTINEL_NOTIFY', String(cfg.fanout?.sentinelNotify ?? false));
+    subs.set('ENABLE_STUDIO_DEPLOY', String(cfg.fanout?.studioDeploy ?? false));
+    subs.set('ENABLE_NIGHTLY_TRIGGER', String(cfg.fanout?.nightlyTrigger ?? false));
+    subs.set('DOCKER_IMAGE', cfg.fanout?.dockerImage ?? '');
+    subs.set('DOCKER_HUB_USER', cfg.fanout?.dockerHubUser ?? '');
+    subs.set('SENTINEL_WEBHOOK_URL', cfg.fanout?.sentinelWebhookUrl ?? '');
+    subs.set('STUDIO_DEPLOY_HOOK', cfg.fanout?.studioDeployHook ?? '');
+  }
+  if (template === 'release-rollback') {
+    subs.set('NPM_PACKAGES', cfg.rollback?.npmPackages ?? '');
+    subs.set('CARGO_CRATES', cfg.rollback?.cargoCrates ?? '');
+  }
+  return subs;
+}
+
+/**
+ * Atomic file write via tmp-then-rename. Creates the parent directory
+ * if missing — same convention as `scaffold-workflows.ts`.
+ *
+ * @internal
+ */
+async function atomicWriteFile(targetPath: string, contents: string): Promise<void> {
+  const dir = dirname(targetPath);
+  await mkdir(dir, { recursive: true });
+  const tmpPath = `${targetPath}.${process.pid}.tmp`;
+  await writeFile(tmpPath, contents, 'utf-8');
+  await rename(tmpPath, targetPath);
+}
+
+/**
+ * Append an audit-log row to `.cleo/audit/upgrade-workflows.jsonl`.
+ * Best-effort — a failure to write the audit row MUST NOT prevent the
+ * upgrade itself.
+ *
+ * @internal
+ */
+async function appendAuditLog(
+  projectRoot: string,
+  row: {
+    timestamp: string;
+    operation: 'workflow-upgrade';
+    template: WorkflowName;
+    targetPath: string;
+    reason: 'force' | 'drift-detected';
+    previousStatus: UpgradeWorkflowStatus;
+  },
+): Promise<void> {
+  try {
+    const auditDir = join(projectRoot, '.cleo', 'audit');
+    await mkdir(auditDir, { recursive: true });
+    const auditPath = join(auditDir, 'upgrade-workflows.jsonl');
+    await appendFile(auditPath, `${JSON.stringify(row)}\n`, 'utf-8');
+  } catch {
+    // Best-effort.
+  }
+}
+
+/**
+ * Read a file if it exists; return `null` on `ENOENT`.
+ *
+ * @internal
+ */
+async function readIfExists(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public entrypoint
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-render every shipped workflow template and report drift against
+ * the on-disk `.github/workflows/release-*.yml` files. Honours
+ * `.workflow-overrides.yml` for operator-declared customizations.
+ *
+ * See the module docstring for the full 3-way merge contract.
+ *
+ * @example
+ * ```ts
+ * // --check semantics — exit 1 when any drift is detected.
+ * const result = await upgradeWorkflows({
+ *   projectRoot: '/path/to/my-project',
+ *   templatesDir: '/path/to/@cleocode/cleo/templates/workflows',
+ * });
+ * if (result.hasDrift) process.exit(1);
+ * ```
+ *
+ * @task T9536
+ */
+export async function upgradeWorkflows(
+  opts: UpgradeWorkflowsOptions,
+): Promise<UpgradeWorkflowsResult> {
+  const { projectRoot, templatesDir } = opts;
+  const dryRun = opts.dryRun === true;
+  const force = opts.force === true;
+  const templates: ReadonlyArray<WorkflowName> =
+    opts.templates && opts.templates.length > 0 ? opts.templates : DEFAULT_WORKFLOW_TEMPLATES;
+
+  // 1. Inputs.
+  const cfg =
+    opts.releaseConfigOverride !== undefined
+      ? opts.releaseConfigOverride
+      : await loadReleaseConfigJson(projectRoot);
+  const overrides =
+    opts.overridesOverride !== undefined
+      ? opts.overridesOverride
+      : await loadOverridesYaml(projectRoot);
+  const resolvedTools = resolvePlaceholders(projectRoot, cfg);
+
+  // 2. Sanity-check the templates dir up front.
+  await stat(templatesDir);
+
+  const outcomes: UpgradeWorkflowOutcome[] = [];
+  let hasDrift = false;
+
+  for (const name of templates) {
+    const templatePath = join(templatesDir, `${name}.yml.tmpl`);
+    const template = await readFile(templatePath, 'utf-8');
+    const subs = buildSubstitutionMap(name, cfg, resolvedTools);
+    const rendered = renderTemplate(template, subs);
+
+    const targetPath = join(projectRoot, '.github', 'workflows', `${name}.yml`);
+    const existing = await readIfExists(targetPath);
+    const overrideDeclared = Object.hasOwn(overrides, name);
+
+    // Dry-run short-circuit: never write, never compute drift bookkeeping.
+    if (dryRun) {
+      outcomes.push({
+        template: name,
+        targetPath,
+        rendered,
+        existing,
+        status: 'dry-run',
+        overrideDeclared,
+      });
+      continue;
+    }
+
+    if (existing === null) {
+      hasDrift = true;
+      outcomes.push({
+        template: name,
+        targetPath,
+        rendered,
+        existing,
+        status: 'missing',
+        overrideDeclared,
+      });
+      continue;
+    }
+
+    if (existing === rendered) {
+      outcomes.push({
+        template: name,
+        targetPath,
+        rendered,
+        existing,
+        status: 'unchanged',
+        overrideDeclared,
+      });
+      continue;
+    }
+
+    // Drift detected.
+    if (overrideDeclared) {
+      // Operator owns the file — do not flip hasDrift. The override is
+      // declared intent and the CLI should treat this as "current".
+      outcomes.push({
+        template: name,
+        targetPath,
+        rendered,
+        existing,
+        status: 'override-kept',
+        overrideDeclared,
+      });
+      continue;
+    }
+
+    if (!force) {
+      hasDrift = true;
+      outcomes.push({
+        template: name,
+        targetPath,
+        rendered,
+        existing,
+        status: 'drift-detected',
+        overrideDeclared,
+      });
+      continue;
+    }
+
+    // force=true + drift + no override ⇒ overwrite + audit.
+    await atomicWriteFile(targetPath, rendered);
+    await appendAuditLog(projectRoot, {
+      timestamp: new Date().toISOString(),
+      operation: 'workflow-upgrade',
+      template: name,
+      targetPath,
+      reason: 'force',
+      previousStatus: 'drift-detected',
+    });
+    outcomes.push({
+      template: name,
+      targetPath,
+      rendered,
+      existing,
+      status: 'updated',
+      overrideDeclared,
+    });
+  }
+
+  return { outcomes, resolvedTools, hasDrift };
+}

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -195,9 +195,21 @@ export type {
   WorkflowName,
 } from './init/scaffold-workflows.js';
 export {
+  DEFAULT_WORKFLOW_TEMPLATES,
   listAvailableWorkflowTemplates,
   scaffoldWorkflows,
 } from './init/scaffold-workflows.js';
+// Init — workflow upgrade primitive (T9536, Phase 4 of T9497). Re-renders
+// every shipped template, compares against the on-disk file, and honours
+// .workflow-overrides.yml for operator-declared customizations.
+export type {
+  UpgradeWorkflowOutcome,
+  UpgradeWorkflowStatus,
+  UpgradeWorkflowsOptions,
+  UpgradeWorkflowsResult,
+  WorkflowOverrides,
+} from './init/upgrade-workflows.js';
+export { parseOverridesYamlBody, upgradeWorkflows } from './init/upgrade-workflows.js';
 // Init (additional)
 export { isAutoInitEnabled } from './init.js';
 export type {


### PR DESCRIPTION
## Summary

Closes T9536 (Phase 4 / 4 of 4 of T9497). Closes T9497 epic.

- `cleo init --workflows` now scaffolds ALL 4 templates by default (release-prepare, release-publish, release-fanout, release-rollback) instead of prepare-only.
- New `cleo upgrade workflows` command performs drift detection with a 3-way merge against `.workflow-overrides.yml`.
- `--dry-run` shows per-template status without writing.
- `--check` exits 0 if every file is current (`unchanged` / `override-kept`), 1 if any drift detected (`drift-detected` / `missing`).
- `--force` overwrites drifted files (operator-declared overrides in `.workflow-overrides.yml` are still preserved).
- Audit log per upgrade lands in `.cleo/audit/upgrade-workflows.jsonl`.

## Files

- `packages/core/src/init/scaffold-workflows.ts` — flipped default from `['release-prepare']` to all four canonical templates; exported `DEFAULT_WORKFLOW_TEMPLATES`.
- `packages/core/src/init/upgrade-workflows.ts` (NEW) — `upgradeWorkflows` SDK primitive + `parseOverridesYamlBody` helper.
- `packages/core/src/init/__tests__/scaffold-workflows-all.test.ts` (NEW) — verifies all 4 templates render by default + smoke test against real shipped templates (no `{{...}}` left behind).
- `packages/core/src/init/__tests__/upgrade-workflows.test.ts` (NEW) — covers `unchanged` / `missing` / `drift-detected` / `override-kept` / `updated` + audit-log + dry-run paths.
- `packages/cleo/src/cli/commands/upgrade.ts` — added `workflows` subcommand with `--dry-run` / `--check` / `--force`.
- `packages/cleo/src/dispatch/domains/upgrade.ts` (NEW) — `UpgradeHandler` registered as new `upgrade` canonical domain.
- `packages/cleo/src/dispatch/registry.ts` — `upgrade.workflows` query + mutate registrations.
- `packages/cleo/src/dispatch/types.ts` — added `'upgrade'` to `CANONICAL_DOMAINS`.

## Test plan

- [x] `cd packages/core && npx vitest run src/init/__tests__/` — 26 tests pass (9 existing + 17 new).
- [x] `npx biome check` — clean across all 13 modified files.
- [ ] Wider repo test pass (deferred to CI; worktree environment lacks `node_modules` for `@a2a-js/sdk`, `express`, `@sveltejs/adapter-node` — pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)