### PR TITLE
feat(T9537): decouple IVTR from release pipeline

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1465,6 +1465,8 @@ export { getOtelStatus } from './otel/index.js';
 export { completePhase } from './phases/index.js';
 // Release engine operations (T1572 — ENG-MIG-5: migrated from dispatch layer)
 export {
+  IVTR_DECOUPLED_AUDIT_FILE,
+  IVTR_DECOUPLED_SENTINEL_FILE,
   releaseCancel,
   releaseChangelog,
   releaseChangelogSince,
@@ -1481,6 +1483,7 @@ export {
   releaseShip,
   releaseShow,
   releaseTag,
+  writeIvtrDecouplingAuditOnce,
 } from './release/engine-ops.js';
 // Release (additional)
 export { tagRelease } from './release/release-manifest.js';

--- a/packages/core/src/release/__tests__/release-ship-no-ivtr.test.ts
+++ b/packages/core/src/release/__tests__/release-ship-no-ivtr.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Regression tests for T9537 — IVTR decoupling from the release pipeline.
+ *
+ * Verifies that:
+ *   1. `releaseShip` succeeds when epic child tasks have NO `ivtr_state` row
+ *      (the legacy E_IVTR_INCOMPLETE blocker is gone — ADR-051 evidence atoms
+ *      via `runReleaseGates` are the sole gate).
+ *   2. `releaseShip` succeeds even when tasks would have been "blocked" under
+ *      the pre-T9537 IVTR gate (currentPhase !== 'released'): IVTR state is
+ *      observation-only.
+ *   3. On first invocation per project, a sentinel file
+ *      `.cleo/audit/ivtr-decoupled.flag` and a JSONL audit row are written;
+ *      subsequent invocations are no-ops.
+ *   4. The `writeIvtrDecouplingAuditOnce` helper is safe to call on a
+ *      read-only or missing directory (never throws, returns false).
+ *
+ * @task T9537 — Phase 5 / 1 of 3 of T9498
+ * @adr ADR-051 (evidence atoms are sole gate surface)
+ * @spec SPEC-T9345 §7 (R-310 through R-316)
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Task } from '@cleocode/contracts';
+import {
+  createSqliteDataAccessor,
+  IVTR_DECOUPLED_AUDIT_FILE,
+  IVTR_DECOUPLED_SENTINEL_FILE,
+  releaseShip,
+  resetDbState,
+  writeIvtrDecouplingAuditOnce,
+} from '@cleocode/core/internal';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { seedTasks } from '../../store/__tests__/test-db-helper.js';
+
+// Hoist mocks before module loads.
+vi.mock('../changelog-writer.js', () => ({
+  writeChangelogSection: vi.fn().mockResolvedValue(undefined),
+  parseChangelogBlocks: vi.fn().mockReturnValue({ customBlocks: [], strippedContent: '' }),
+}));
+
+vi.mock('../guards.js', () => ({
+  checkEpicCompleteness: vi
+    .fn()
+    .mockResolvedValue({ hasIncomplete: false, epics: [], orphanTasks: [] }),
+  checkDoubleListing: vi.fn().mockReturnValue({ hasDoubleListing: false, duplicates: [] }),
+}));
+
+vi.mock('../release-manifest.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@cleocode/core/internal')>();
+  return {
+    ...actual,
+    runReleaseGates: vi.fn(),
+    showManifestRelease: vi.fn(),
+    generateReleaseChangelog: vi.fn(),
+    listManifestReleases: vi.fn(),
+    markReleasePushed: vi.fn(),
+  };
+});
+
+let TEST_ROOT: string;
+let CLEO_DIR: string;
+
+function writeConfig(config: Record<string, unknown>): void {
+  mkdirSync(CLEO_DIR, { recursive: true });
+  writeFileSync(join(CLEO_DIR, 'config.json'), JSON.stringify(config, null, 2), 'utf-8');
+}
+
+/**
+ * Sample epic + child task fixture where the child has NO IVTR state. Under
+ * the pre-T9537 gate this would have surfaced as "unchecked" (non-blocking)
+ * but the gate also tripped on `blocked` tasks. We seed the child with
+ * `status: 'done'` so the pipeline gate-runner sees no incomplete work, then
+ * leave `ivtrState` undefined so `getIvtrState` returns null.
+ */
+const SAMPLE_TASKS: Array<Partial<Task> & { id: string }> = [
+  {
+    id: 'T-EPIC-NOIVTR',
+    type: 'epic',
+    title: 'Test epic — no IVTR state on children',
+    status: 'done',
+    priority: 'medium',
+    createdAt: '2026-01-01T00:00:00Z',
+    completedAt: '2026-02-01T00:00:00Z',
+  },
+  {
+    id: 'T-CHILD-NOIVTR-A',
+    parentId: 'T-EPIC-NOIVTR',
+    title: 'feat: child A with no IVTR row',
+    status: 'done',
+    priority: 'medium',
+    createdAt: '2026-01-01T00:00:00Z',
+    completedAt: '2026-02-01T00:00:00Z',
+  },
+  {
+    id: 'T-CHILD-NOIVTR-B',
+    parentId: 'T-EPIC-NOIVTR',
+    title: 'fix: child B with no IVTR row',
+    status: 'done',
+    priority: 'medium',
+    createdAt: '2026-01-01T00:00:00Z',
+    completedAt: '2026-02-01T00:00:00Z',
+  },
+];
+
+async function setupTestDb(): Promise<void> {
+  resetDbState();
+  const accessor = await createSqliteDataAccessor(TEST_ROOT);
+  await seedTasks(accessor, SAMPLE_TASKS);
+  await accessor.close();
+  resetDbState();
+}
+
+describe('releaseShip — IVTR decoupling (T9537)', () => {
+  beforeEach(async () => {
+    TEST_ROOT = mkdtempSync(join(tmpdir(), 'cleo-release-no-ivtr-'));
+    CLEO_DIR = join(TEST_ROOT, '.cleo');
+    await setupTestDb();
+    writeConfig({ release: { push: { enabled: true, requireCleanTree: false } } });
+    const manifest = await import('@cleocode/core/internal');
+    vi.mocked(manifest.runReleaseGates).mockResolvedValue({
+      version: '2026.5.99',
+      allPassed: true,
+      gates: [],
+      passedCount: 0,
+      failedCount: 0,
+      metadata: {
+        channel: 'latest',
+        requiresPR: false,
+        targetBranch: 'main',
+        currentBranch: 'main',
+      },
+    });
+    vi.mocked(manifest.showManifestRelease).mockResolvedValue({
+      tasks: ['T-CHILD-NOIVTR-A', 'T-CHILD-NOIVTR-B'],
+      version: 'v2026.5.99',
+    } as never);
+    vi.mocked(manifest.generateReleaseChangelog).mockResolvedValue({
+      changelog: '### Features\n- feat: child A with no IVTR row (T-CHILD-NOIVTR-A)\n',
+      taskCount: 2,
+    } as never);
+    vi.mocked(manifest.listManifestReleases).mockResolvedValue({ releases: [] } as never);
+    vi.mocked(manifest.markReleasePushed).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    resetDbState();
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it('succeeds when ALL child tasks have no ivtr_state row (was E_IVTR_INCOMPLETE pre-T9537)', async () => {
+    const result = await releaseShip(
+      { version: '2026.5.99', epicId: 'T-EPIC-NOIVTR', dryRun: true },
+      TEST_ROOT,
+    );
+
+    // Pre-T9537 this would have failed with E_LIFECYCLE_GATE_FAILED for any
+    // task whose IVTR phase wasn't 'released'. Post-T9537 the IVTR gate is
+    // gone; the only ADR-051 gate is the mocked-pass `runReleaseGates`.
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.dryRun).toBe(true);
+    expect(data.epicId).toBe('T-EPIC-NOIVTR');
+  });
+
+  it('does NOT include any "Check IVTR gate" or E_IVTR_INCOMPLETE step in the release log', async () => {
+    const result = await releaseShip(
+      { version: '2026.5.99', epicId: 'T-EPIC-NOIVTR', dryRun: true },
+      TEST_ROOT,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const steps =
+      (data.steps as string[] | undefined) ?? (data.wouldDo as string[] | undefined) ?? [];
+    for (const step of steps) {
+      expect(step).not.toMatch(/Check IVTR gate/i);
+      expect(step).not.toMatch(/IVTR gate (?:rejected|FAILED|BYPASSED)/i);
+    }
+    if (result.error) {
+      expect(result.error.code).not.toBe('E_IVTR_INCOMPLETE');
+    }
+  });
+
+  it('writes the IVTR-decoupled sentinel + JSONL audit row on first run (and only first)', async () => {
+    const sentinelPath = join(TEST_ROOT, IVTR_DECOUPLED_SENTINEL_FILE);
+    const auditPath = join(TEST_ROOT, IVTR_DECOUPLED_AUDIT_FILE);
+
+    expect(existsSync(sentinelPath)).toBe(false);
+
+    const first = await releaseShip(
+      { version: '2026.5.99', epicId: 'T-EPIC-NOIVTR', dryRun: true },
+      TEST_ROOT,
+    );
+    expect(first.success).toBe(true);
+    expect(existsSync(sentinelPath)).toBe(true);
+    expect(existsSync(auditPath)).toBe(true);
+    const auditFirst = readFileSync(auditPath, 'utf-8').trim().split('\n');
+    expect(auditFirst).toHaveLength(1);
+    const parsedFirst = JSON.parse(auditFirst[0] ?? '{}') as Record<string, unknown>;
+    expect(parsedFirst.event).toBe('ivtr-decoupled');
+    expect(parsedFirst.task).toBe('T9537');
+    expect(parsedFirst.firstEpic).toBe('T-EPIC-NOIVTR');
+
+    // Second run must not re-append.
+    const second = await releaseShip(
+      { version: '2026.5.99', epicId: 'T-EPIC-NOIVTR', dryRun: true },
+      TEST_ROOT,
+    );
+    expect(second.success).toBe(true);
+    const auditSecond = readFileSync(auditPath, 'utf-8').trim().split('\n');
+    expect(auditSecond).toHaveLength(1);
+  });
+});
+
+describe('writeIvtrDecouplingAuditOnce — unit', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'cleo-ivtr-audit-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns true on first call and false on subsequent calls (idempotent sentinel)', () => {
+    expect(writeIvtrDecouplingAuditOnce(root, 'T-EPIC-1')).toBe(true);
+    expect(writeIvtrDecouplingAuditOnce(root, 'T-EPIC-1')).toBe(false);
+    expect(writeIvtrDecouplingAuditOnce(root, 'T-EPIC-2')).toBe(false);
+  });
+
+  it('writes a JSON payload pointing to T9537 and SPEC-T9345 §7', () => {
+    expect(writeIvtrDecouplingAuditOnce(root, 'T-EPIC-X')).toBe(true);
+    const sentinelPath = join(root, IVTR_DECOUPLED_SENTINEL_FILE);
+    const payload = JSON.parse(readFileSync(sentinelPath, 'utf-8')) as Record<string, unknown>;
+    expect(payload.event).toBe('ivtr-decoupled');
+    expect(payload.task).toBe('T9537');
+    expect(typeof payload.spec).toBe('string');
+    expect(payload.firstEpic).toBe('T-EPIC-X');
+  });
+
+  it('never throws on filesystem failure — returns false', () => {
+    // Pass a path containing a NUL byte — Node refuses to operate on it and
+    // throws ERR_INVALID_ARG_VALUE deterministically on every platform. The
+    // helper must swallow this and return false rather than crashing the
+    // release.
+    expect(() => writeIvtrDecouplingAuditOnce('/tmp/cleo-bad\0path', 'T-EPIC-Z')).not.toThrow();
+    expect(writeIvtrDecouplingAuditOnce('/tmp/cleo-bad\0path', 'T-EPIC-Z')).toBe(false);
+  });
+});

--- a/packages/core/src/release/engine-ops.ts
+++ b/packages/core/src/release/engine-ops.ts
@@ -17,7 +17,8 @@
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { eq } from 'drizzle-orm';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { getIvtrState } from '../lifecycle/ivtr-loop.js';
@@ -330,6 +331,70 @@ async function checkIvtrGates(
 }
 
 /**
+ * Project-relative audit sentinel that proves the IVTR decoupling has run at
+ * least once for a project. First-run also appends a JSONL audit row so the
+ * decoupling event is traceable (matches the convention used by
+ * `force-bypass.jsonl`, `worker-mismatch.jsonl`, etc.).
+ *
+ * @task T9537
+ */
+export const IVTR_DECOUPLED_SENTINEL_FILE = '.cleo/audit/ivtr-decoupled.flag';
+
+/**
+ * Project-relative JSONL audit log for IVTR-decoupling events. Appended once
+ * on the first {@link releaseShip} invocation per project; subsequent runs are
+ * no-ops because the sentinel file already exists.
+ *
+ * @task T9537
+ */
+export const IVTR_DECOUPLED_AUDIT_FILE = '.cleo/audit/ivtr-decoupled.jsonl';
+
+/**
+ * Write a one-time audit entry confirming the IVTR gate has been decoupled
+ * from the release pipeline per T9537. The sentinel file
+ * `.cleo/audit/ivtr-decoupled.flag` prevents re-logging on subsequent runs.
+ *
+ * Best-effort: never throws — release flow must not fail because the audit
+ * directory is read-only or missing.
+ *
+ * @task T9537
+ */
+export function writeIvtrDecouplingAuditOnce(cwd: string, epicId: string): boolean {
+  try {
+    const sentinelPath = join(cwd, IVTR_DECOUPLED_SENTINEL_FILE);
+    if (existsSync(sentinelPath)) {
+      return false;
+    }
+    mkdirSync(dirname(sentinelPath), { recursive: true });
+    const payload = {
+      ts: new Date().toISOString(),
+      event: 'ivtr-decoupled',
+      task: 'T9537',
+      spec: 'SPEC-T9345 §7 / ivtr-conflation-audit.md Priority 1',
+      firstEpic: epicId,
+      message:
+        'IVTR decoupled from release per T9537 (Phase 5 of T9498). task.ivtr_state is observation-only; ADR-051 evidence atoms are the sole gate.',
+    };
+    writeFileSync(sentinelPath, `${JSON.stringify(payload)}\n`, 'utf-8');
+    const auditPath = join(cwd, IVTR_DECOUPLED_AUDIT_FILE);
+    mkdirSync(dirname(auditPath), { recursive: true });
+    appendFileSync(auditPath, `${JSON.stringify(payload)}\n`, 'utf-8');
+    log.info(
+      { audit: 'ivtr-decoupled', task: 'T9537', epicId, sentinel: IVTR_DECOUPLED_SENTINEL_FILE },
+      'IVTR decoupled from release per T9537 — sentinel written.',
+    );
+    return true;
+  } catch (err: unknown) {
+    // Audit writes are best-effort; never fail the release on filesystem errors.
+    log.debug(
+      { audit: 'ivtr-decoupled', task: 'T9537', error: (err as Error).message ?? String(err) },
+      'IVTR-decoupled audit write failed (non-blocking)',
+    );
+    return false;
+  }
+}
+
+/**
  * Build a per-task IVTR status list for the given task IDs.
  *
  * Each entry carries the task ID, current IVTR phase (or null), and whether
@@ -596,12 +661,20 @@ export async function releaseGateCheck(
  * Checks whether all sibling tasks in the parent epic are also released. If
  * so, emits a `suggestedCommand` pointing the operator toward `release ship`.
  *
+ * @deprecated As of T9537 (Phase 5 of T9498), the IVTR gate has been
+ * decoupled from the release pipeline per SPEC-T9345 §7 / ivtr-conflation-audit.md
+ * Priority 1. This function still works for telemetry and external callers,
+ * but `releaseShip` no longer reads or recommends it. ADR-051 evidence atoms
+ * (validated by `runReleaseGates`) are the sole gate execution surface.
+ * Remove in a future major version once all external integrations migrate.
+ *
  * @param taskId      - Task that just reached the `released` phase.
  * @param projectRoot - Optional working directory.
  * @returns EngineResult with IvtrAutoSuggestResult data.
  *
  * @task T820 RELEASE-07
  * @task T1416
+ * @task T9537 — deprecated marker (decoupled from releaseShip)
  */
 export async function releaseIvtrAutoSuggest(
   taskId: string,
@@ -1208,8 +1281,7 @@ export async function releasePush(
  * Sequence:
  *   0.   Bump version files (optional)
  *   0.5. Auto-prepare release record
- *   1.   Validate release gates
- *   1.5. IVTR gate check
+ *   1.   Validate release gates (ADR-051 evidence atoms — sole gate surface per T9537)
  *   2.   Check epic completeness
  *   3.   Check task double-listing
  *   4.   Generate CHANGELOG + lint check
@@ -1222,9 +1294,18 @@ export async function releasePush(
  *   11.  Cleanup release branch (local + remote)
  *   12.  Record provenance
  *
+ * IVTR decoupling (T9537 / Phase 5 of T9498): `task.ivtr_state` is no longer
+ * read by `releaseShip` for gate decisions. The legacy step 1.5 IVTR gate
+ * (E_IVTR_INCOMPLETE) was removed per SPEC-T9345 §7 (R-310 through R-316) and
+ * ivtr-conflation-audit.md Priority 1. ADR-051 evidence atoms are now the sole
+ * release gate execution surface. The schema column, the `cleo ivtr` CLI, and
+ * the `release.gate` / `release.ivtr-suggest` dispatch ops remain for telemetry
+ * and backward-compat (`releaseIvtrAutoSuggest` is `@deprecated`).
+ *
  * @task T5582
  * @task T5586
  * @task T9095 — PR-required flow
+ * @task T9537 — IVTR decoupling
  * @epic T5576
  */
 export async function releaseShip(
@@ -1234,7 +1315,12 @@ export async function releaseShip(
     remote?: string;
     dryRun?: boolean;
     bump?: boolean;
-    /** Skip IVTR gate check — requires owner confirmation (T820 RELEASE-03). */
+    /**
+     * Bypass channel/version validation — owner-level override. As of T9537,
+     * the IVTR gate is no longer part of `releaseShip` (decoupled per
+     * SPEC-T9345 §7 / ivtr-conflation-audit.md Priority 1) so `force` no
+     * longer affects IVTR state — it only bypasses the channel check below.
+     */
     force?: boolean;
   },
   projectRoot?: string,
@@ -1373,53 +1459,47 @@ export async function releaseShip(
     }
     logStep(1, 12, 'Validate release gates', true);
 
-    // Step 1.5 (T820 RELEASE-03): IVTR gate enforcement
-    if (!force) {
-      logStep(1, 12, 'Check IVTR gate for epic tasks');
-      let epicTaskIds: string[] = [];
-      try {
-        const epicAccessorForIvtr = await getTaskAccessor(cwd);
-        const epicResult = await epicAccessorForIvtr.queryTasks({ parentId: epicId });
-        epicTaskIds = ((epicResult?.tasks as Array<{ id: string; type?: string }>) ?? [])
-          .filter((t) => t.type !== 'epic')
-          .map((t) => t.id);
-      } catch {
-        // If we cannot load tasks, skip IVTR check (project may not have them)
-      }
-
+    // Step 1.5 (T9537 / Phase 5 of T9498): IVTR decoupling.
+    //
+    // The legacy E_IVTR_INCOMPLETE / E_LIFECYCLE_GATE_FAILED blocker that used
+    // to read `task.ivtr_state` for every epic child has been removed per
+    // SPEC-T9345 §7 (R-310 through R-316) and ivtr-conflation-audit.md
+    // Priority 1. ADR-051 evidence atoms validated by `runReleaseGates` (Step
+    // 1 above) are the sole release gate execution surface.
+    //
+    // `task.ivtr_state` is preserved as an observation-only column for
+    // telemetry — we still read it here to surface release-time IVTR state in
+    // the structured logs (useful for ivtr-loop dashboards) but the result
+    // NEVER blocks the pipeline. The first time a release runs after the
+    // decoupling, we write a one-time audit sentinel to
+    // `.cleo/audit/ivtr-decoupled.flag` so the change is traceable.
+    writeIvtrDecouplingAuditOnce(cwd, epicId);
+    try {
+      const epicAccessorForIvtr = await getTaskAccessor(cwd);
+      const epicResult = await epicAccessorForIvtr.queryTasks({ parentId: epicId });
+      const epicTaskIds = ((epicResult?.tasks as Array<{ id: string; type?: string }>) ?? [])
+        .filter((t) => t.type !== 'epic')
+        .map((t) => t.id);
       if (epicTaskIds.length > 0) {
         const { blocked, unchecked } = await checkIvtrGates(epicTaskIds, projectRoot);
-        if (blocked.length > 0) {
-          logStep(
-            1,
-            12,
-            'Check IVTR gate for epic tasks',
-            false,
-            `${blocked.length} task(s) not released in IVTR`,
-          );
-          return engineError(
-            'E_LIFECYCLE_GATE_FAILED',
-            `IVTR gate rejected: ${blocked.length} task(s) in epic ${epicId} have not reached IVTR 'released' phase: ${blocked.join(', ')}. ` +
-              'Run `cleo orchestrate ivtr <taskId> --release` for each blocking task, or pass --force to bypass with owner warning.',
-            {
-              fix: `cleo orchestrate ivtr ${blocked[0]} --release`,
-              details: { blocked, unchecked, epicId },
-            },
-          );
-        }
-        if (unchecked.length > 0) {
-          const w = `  ! IVTR gate: ${unchecked.length} task(s) have no IVTR state (non-blocking): ${unchecked.join(', ')}`;
-          steps.push(w);
-          log.warn({ epicId, unchecked, count: unchecked.length }, w);
-        }
-        logStep(1, 12, 'Check IVTR gate for epic tasks', true);
-      } else {
-        logStep(1, 12, 'Check IVTR gate for epic tasks', true);
+        log.info(
+          {
+            epicId,
+            ivtrTelemetry: true,
+            decoupled: true,
+            totalTasks: epicTaskIds.length,
+            blockedCount: blocked.length,
+            uncheckedCount: unchecked.length,
+          },
+          `IVTR telemetry (T9537, non-blocking): epic ${epicId} — ${epicTaskIds.length} task(s), ${blocked.length} not released, ${unchecked.length} unchecked. ADR-051 evidence atoms are the sole gate.`,
+        );
       }
-    } else {
-      const w = `  ! --force: IVTR gate check BYPASSED. Owner-level override only.`;
-      steps.push(w);
-      log.warn({ epicId, forcedBypass: true }, w);
+    } catch (err: unknown) {
+      // Telemetry is best-effort — never fail the release on IVTR read errors.
+      log.debug(
+        { epicId, ivtrTelemetry: true, error: (err as Error).message ?? String(err) },
+        'IVTR telemetry read failed (non-blocking)',
+      );
     }
 
     // Resolve release channel from the PR *target* branch — that determines

--- a/packages/core/src/release/index.ts
+++ b/packages/core/src/release/index.ts
@@ -61,6 +61,8 @@ export {
 // Engine operations — CLI-callable release operations migrated from dispatch layer (T1572)
 export type { PRCheckStatus, PRStatusResult } from './engine-ops.js';
 export {
+  IVTR_DECOUPLED_AUDIT_FILE,
+  IVTR_DECOUPLED_SENTINEL_FILE,
   releaseCancel,
   releaseChangelog,
   releaseChangelogSince,
@@ -77,6 +79,7 @@ export {
   releaseShip,
   releaseShow,
   releaseTag,
+  writeIvtrDecouplingAuditOnce,
 } from './engine-ops.js';
 // GitHub PR management
 export type {


### PR DESCRIPTION
## Summary

Closes T9537 (Phase 5 / 1 of 3 of T9498). Removes the `E_IVTR_INCOMPLETE` blocking gate from `releaseShip` per SPEC-T9345 §7 (R-310 through R-316) and `ivtr-conflation-audit.md` Priority 1. `task.ivtr_state` becomes observation-only — ADR-051 evidence atoms validated by `runReleaseGates` are the sole release gate execution surface.

## Changes

- `packages/core/src/release/engine-ops.ts`
  - Removed the IVTR-blocking step 1.5 from `releaseShip` (previously `E_LIFECYCLE_GATE_FAILED` if any child task had `ivtrState.currentPhase !== 'released'`).
  - Replaced with a telemetry-only structured log (`ivtrTelemetry: true, decoupled: true`) plus a one-time `.cleo/audit/ivtr-decoupled.flag` sentinel + JSONL audit row written by the new helper `writeIvtrDecouplingAuditOnce`.
  - Marked `releaseIvtrAutoSuggest` as `@deprecated` in TSDoc while keeping the function operational for `release.ivtr-suggest` dispatch consumers.
  - Updated the `releaseShip` JSDoc and the `force` param doc to reflect the new behavior.
- `packages/core/src/release/index.ts` + `packages/core/src/internal.ts`
  - Re-exported the new helper + sentinel constants.
- `packages/core/src/release/__tests__/release-ship-no-ivtr.test.ts` (new)
  - 6 regression tests covering: release success with no IVTR rows, absence of legacy gate-step strings, sentinel idempotency, helper unit tests.

## Preserved (no breaking change)

- `task.ivtr_state` schema column (no migration).
- `cleo ivtr` CLI commands.
- `E_IVTR_INCOMPLETE` exit code constant (used by `tasks.complete` strict enforcement + `release.gate` standalone op).
- `release.gate` and `release.ivtr-suggest` dispatch ops + their test coverage.

## Test plan

- [x] `packages/core/src/release/__tests__/release-ship-no-ivtr.test.ts` — 6/6 passing
- [x] Full `packages/core/src/release/__tests__/` suite — 25 files / 236 tests passing (2 skipped pre-existing)
- [x] `packages/cleo/src/dispatch/domains/__tests__/release.test.ts` + `pipeline.test.ts` — 29/29 passing (preserved dispatch surface untouched)
- [x] `biome check --write` clean

## Refs

- Spec: `.cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md` §7 (R-310 – R-316)
- Audit: `.cleo/rcasd/T9345/research/ivtr-conflation-audit.md` Priority 1
- ADR-051 (evidence atoms are sole gate surface)
- Parent: T9498 (Phase 5 — IVTR decoupling)