### PR TITLE
feat(T9538): cleo release ship deprecation shim

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/release-ship-deprecation.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/release-ship-deprecation.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for T9538 — `cleo release ship` deprecation shim (SPEC-T9345 §12 R-420).
+ *
+ * Verifies that the deprecated `ship` verb:
+ *   1. Emits a deprecation warning to stderr (not stdout) on every invocation.
+ *   2. Default path (workflow !== false): forwards to `release.plan` then
+ *      `release.open` via dispatch.
+ *   3. Escape-hatch path (`--workflow=false`): falls through to legacy
+ *      `pipeline.release.ship` dispatch AND appends a CRITICAL record to
+ *      `.cleo/audit/release-workflow-bypass.jsonl` (R-441).
+ *   4. Dry-run forwards plan but skips open (preview semantics).
+ *   5. The exported notice constant is a non-empty string for downstream
+ *      assertions.
+ *
+ * Strategy:
+ *   - Mock `dispatchFromCli` so we observe operation names + params without
+ *     spawning a real release.
+ *   - Mock `release.appendReleaseWorkflowBypass` to confirm the escape-hatch
+ *     path audits the bypass.
+ *   - Capture `process.stderr.write` to confirm the deprecation warning lands
+ *     on stderr (NOT stdout — JSON envelope integrity).
+ *
+ * @task T9538
+ * @epic T9498
+ * @spec SPEC-T9345 §12 R-420 / R-440 / R-441
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — registered BEFORE importing the command under test
+// ---------------------------------------------------------------------------
+
+const mockDispatchFromCli = vi.fn();
+const mockAppendBypass = vi.fn();
+
+vi.mock('../../../dispatch/adapters/cli.js', () => ({
+  dispatchFromCli: (...args: unknown[]) => mockDispatchFromCli(...args),
+}));
+
+vi.mock('@cleocode/core', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@cleocode/core')>();
+  return {
+    ...original,
+    release: {
+      ...original.release,
+      appendReleaseWorkflowBypass: (...args: unknown[]) => mockAppendBypass(...args),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import command + notice constant after mocks are registered
+// ---------------------------------------------------------------------------
+
+import { releaseCommand, SHIP_DEPRECATION_NOTICE } from '../release.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ShipArgs {
+  version: string;
+  epic: string;
+  workflow?: boolean;
+  'workflow-bypass-reason'?: string;
+  'dry-run'?: boolean;
+  push?: boolean;
+  bump?: boolean;
+  remote?: string;
+  force?: boolean;
+}
+
+/**
+ * Invoke the `ship` subcommand `run` with structured args. Looks the
+ * subcommand up by name so the test mirrors the citty dispatch path used by
+ * the real CLI.
+ */
+async function invokeShip(args: ShipArgs): Promise<void> {
+  const sub = (
+    releaseCommand as unknown as {
+      subCommands: Record<string, { run: (ctx: { args: ShipArgs }) => Promise<void> }>;
+    }
+  ).subCommands.ship;
+  if (!sub || typeof sub.run !== 'function') {
+    throw new Error('ship subcommand not found on releaseCommand');
+  }
+  await sub.run({ args });
+}
+
+/** Capture writes to process.stderr.write during a single test. */
+function captureStderr(): { writes: string[]; restore: () => void } {
+  const writes: string[] = [];
+  const original = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    writes.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    return true;
+  }) as typeof process.stderr.write;
+  return {
+    writes,
+    restore: () => {
+      process.stderr.write = original;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('cleo release ship — T9538 deprecation shim', () => {
+  beforeEach(() => {
+    mockDispatchFromCli.mockReset();
+    mockDispatchFromCli.mockResolvedValue({ success: true, data: {}, _meta: {} });
+    mockAppendBypass.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exports SHIP_DEPRECATION_NOTICE with replacement guidance and removal hint', () => {
+    expect(SHIP_DEPRECATION_NOTICE).toEqual(expect.any(String));
+    expect(SHIP_DEPRECATION_NOTICE.length).toBeGreaterThan(0);
+    // R-431: notice MUST include the replacement invocation.
+    expect(SHIP_DEPRECATION_NOTICE).toContain('cleo release plan');
+    expect(SHIP_DEPRECATION_NOTICE).toContain('cleo release open');
+    // R-431: notice MUST mention a removal milestone.
+    expect(SHIP_DEPRECATION_NOTICE.toLowerCase()).toContain('deprecated');
+  });
+
+  it('writes the deprecation warning to stderr on every invocation', async () => {
+    const cap = captureStderr();
+    try {
+      await invokeShip({ version: '2026.6.0', epic: 'T9498' });
+    } finally {
+      cap.restore();
+    }
+    const stderrOutput = cap.writes.join('');
+    expect(stderrOutput).toContain('cleo release ship');
+    expect(stderrOutput).toContain('DEPRECATED');
+    expect(stderrOutput).toContain('cleo release plan');
+  });
+
+  it('default path (no --workflow flag) forwards to release.plan then release.open', async () => {
+    const cap = captureStderr();
+    try {
+      await invokeShip({ version: '2026.6.0', epic: 'T9498' });
+    } finally {
+      cap.restore();
+    }
+
+    // Two dispatches total: plan + open.
+    expect(mockDispatchFromCli).toHaveBeenCalledTimes(2);
+
+    const [firstCall, secondCall] = mockDispatchFromCli.mock.calls;
+    // Call 1: release.plan with version + epicId.
+    expect(firstCall?.[0]).toBe('mutate');
+    expect(firstCall?.[1]).toBe('release');
+    expect(firstCall?.[2]).toBe('release.plan');
+    expect(firstCall?.[3]).toMatchObject({
+      version: '2026.6.0',
+      epicId: 'T9498',
+      dryRun: false,
+    });
+
+    // Call 2: release.open with version.
+    expect(secondCall?.[0]).toBe('mutate');
+    expect(secondCall?.[1]).toBe('release');
+    expect(secondCall?.[2]).toBe('release.open');
+    expect(secondCall?.[3]).toMatchObject({ version: '2026.6.0' });
+
+    // Escape hatch MUST NOT have been engaged.
+    expect(mockAppendBypass).not.toHaveBeenCalled();
+  });
+
+  it('dry-run forwards release.plan but skips release.open (preview semantics)', async () => {
+    const cap = captureStderr();
+    try {
+      await invokeShip({ version: '2026.6.0', epic: 'T9498', 'dry-run': true });
+    } finally {
+      cap.restore();
+    }
+
+    expect(mockDispatchFromCli).toHaveBeenCalledTimes(1);
+    const call = mockDispatchFromCli.mock.calls[0];
+    expect(call?.[2]).toBe('release.plan');
+    expect(call?.[3]).toMatchObject({ dryRun: true });
+    expect(mockAppendBypass).not.toHaveBeenCalled();
+  });
+
+  it('--workflow=false engages legacy pipeline.release.ship + audits bypass', async () => {
+    const cap = captureStderr();
+    try {
+      await invokeShip({
+        version: '2026.6.0',
+        epic: 'T9498',
+        workflow: false,
+        'workflow-bypass-reason': 'GHA outage — hotfix only',
+        push: true,
+        bump: true,
+      });
+    } finally {
+      cap.restore();
+    }
+
+    // Exactly one dispatch — and it MUST be the legacy pipeline route.
+    expect(mockDispatchFromCli).toHaveBeenCalledTimes(1);
+    const call = mockDispatchFromCli.mock.calls[0];
+    expect(call?.[1]).toBe('pipeline');
+    expect(call?.[2]).toBe('release.ship');
+    expect(call?.[3]).toMatchObject({
+      version: '2026.6.0',
+      epicId: 'T9498',
+      push: true,
+      bump: true,
+    });
+
+    // Audit log MUST have been appended exactly once (R-441).
+    expect(mockAppendBypass).toHaveBeenCalledTimes(1);
+    const auditOpts = mockAppendBypass.mock.calls[0]?.[0];
+    expect(auditOpts).toMatchObject({
+      version: '2026.6.0',
+      epicId: 'T9498',
+      reason: 'GHA outage — hotfix only',
+      source: 'cli-flag',
+    });
+  });
+
+  it('--workflow=false without reason records a sentinel rationale (audit-complete)', async () => {
+    const cap = captureStderr();
+    try {
+      await invokeShip({ version: '2026.6.0', epic: 'T9498', workflow: false });
+    } finally {
+      cap.restore();
+    }
+
+    expect(mockAppendBypass).toHaveBeenCalledTimes(1);
+    const auditOpts = mockAppendBypass.mock.calls[0]?.[0] as { reason: string };
+    expect(auditOpts.reason).toMatch(/no reason supplied/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// release command — 4-verb surface ordering (T9538 / R-420)
+// ---------------------------------------------------------------------------
+
+describe('cleo release — subcommand surface ordering (T9538)', () => {
+  it('lists the new 4-verb pipeline first in subCommands declaration order', () => {
+    const subKeys = Object.keys(
+      (releaseCommand as unknown as { subCommands: Record<string, unknown> }).subCommands,
+    );
+    // The first four entries MUST be the canonical SPEC-T9345 verbs in order.
+    expect(subKeys.slice(0, 4)).toEqual(['plan', 'open', 'reconcile', 'rollback']);
+  });
+
+  it('keeps deprecated verbs registered (compatibility window not removed yet)', () => {
+    const subs = (releaseCommand as unknown as { subCommands: Record<string, unknown> })
+      .subCommands;
+    // R-420 → R-423: each deprecated verb MUST still resolve.
+    expect(subs.ship).toBeDefined();
+    expect(subs.start).toBeDefined();
+    expect(subs.verify).toBeDefined();
+    expect(subs.publish).toBeDefined();
+  });
+
+  it('exposes a description that marks ship/start/verify/publish as deprecated', () => {
+    const description = (releaseCommand as unknown as { meta: { description: string } }).meta
+      .description;
+    expect(description.toLowerCase()).toContain('deprecated');
+    expect(description.toLowerCase()).toContain('plan');
+    expect(description.toLowerCase()).toContain('open');
+  });
+});

--- a/packages/cleo/src/cli/commands/release.ts
+++ b/packages/cleo/src/cli/commands/release.ts
@@ -1,22 +1,25 @@
 /**
  * CLI release command group — release lifecycle management.
  *
- * Commands:
- *   cleo release ship <version>         — composite release: gates → changelog → commit → tag → push
- *   cleo release list                   — list all releases
- *   cleo release show <version>         — show release details
- *   cleo release cancel <version>       — cancel a draft/prepared release
- *   cleo release changelog --since <tag> — generate CHANGELOG from git log (T820 RELEASE-02)
- *   cleo release rollback <version>     — roll back a shipped release (metadata only)
- *   cleo release rollback-full <version> — real rollback: delete tag, revert commit, remove record (T820 RELEASE-05)
- *   cleo release channel                — show current release channel
+ * Canonical 4-verb pipeline (SPEC-T9345):
+ *   cleo release plan <version> --epic <id>  — build the Release Plan envelope
+ *   cleo release open <version>              — dispatch release-prepare workflow
+ *   cleo release reconcile <version>         — post-publish provenance backfill
+ *   cleo release rollback <version>          — roll back a shipped release
  *
- * REMOVED: release add/plan commands were consolidated into release.ship as part
- * of the API rationalization (T5615). For preview/dry-run: cleo release ship <version> --epic <id> --dry-run
+ * Deprecated (kept for the migration window — see SPEC-T9345 §12):
+ *   cleo release ship    — alias that forwards to plan + open + (auto-)publish
+ *   cleo release start   — alias for plan
+ *   cleo release verify  — see `cleo verify <task> --gate X --evidence …` (ADR-051)
+ *   cleo release publish — see `cleo release open <version>`
+ *
+ * Read-only helpers:
+ *   cleo release list / show / cancel / changelog / pr-status / channel
  *
  * @task T4467
  * @task T820
- * @epic T4454
+ * @task T9538 — ship deprecation shim
+ * @epic T9498 — release v2 cutover
  */
 
 import { release } from '@cleocode/core';
@@ -25,15 +28,45 @@ import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
 import { cliOutput } from '../renderers/index.js';
 
 /**
- * cleo release ship — composite release: prepare → gates → changelog → commit → tag → push.
+ * Deprecation notice emitted to stderr by {@link shipCommand} per
+ * SPEC-T9345 §12 R-420 / R-431. The notice MUST include the replacement
+ * invocation and the target removal release per R-431.
  *
- * Requires --epic <id>. Use --dry-run to preview without writing anything.
- * Use --force to bypass IVTR gate check (T820 RELEASE-03).
+ * @task T9538
+ * @spec SPEC-T9345 §12 R-420
+ */
+export const SHIP_DEPRECATION_NOTICE =
+  '[DEPRECATED] `cleo release ship` is a deprecated alias and will be removed no earlier than the third release cycle after T9498. ' +
+  'Use `cleo release plan <version> --epic <id>` followed by `cleo release open <version>`; publish runs via GHA workflow. ' +
+  'Emergency escape hatch (audit-logged to .cleo/audit/release-workflow-bypass.jsonl): pass `--workflow=false` to run the legacy 12-step monolith locally. ' +
+  'Docs: T9345-CHILD-1.';
+
+/**
+ * cleo release ship — DEPRECATED alias per SPEC-T9345 §12 R-420.
+ *
+ * Default behavior (workflow !== false): emits {@link SHIP_DEPRECATION_NOTICE}
+ * to stderr and forwards to the new 4-verb pipeline by calling
+ * `release.plan` then `release.open` via dispatch. Publish happens through
+ * the GHA `release-prepare.yml` workflow dispatched by `release.open`, so
+ * the CLI returns once the workflow has been triggered.
+ *
+ * Emergency escape hatch (`--workflow=false`): bypasses the new flow and
+ * runs the legacy 12-step monolith via the existing `release.ship` dispatch
+ * route. Each such invocation MUST append a CRITICAL-severity record to
+ * `.cleo/audit/release-workflow-bypass.jsonl` (R-441). This flag is slated
+ * for removal in Phase 6 (T9540).
+ *
+ * The deprecation warning is written to **stderr** (NOT stdout) so JSON
+ * envelope output on stdout stays parseable for downstream tooling.
+ *
+ * @task T9538
+ * @spec SPEC-T9345 §12 R-420 / R-440 / R-441
  */
 const shipCommand = defineCommand({
   meta: {
     name: 'ship',
-    description: 'Ship a release: gates → changelog → commit → tag → push',
+    description:
+      '[DEPRECATED] Forwards to `release plan` + `release open` (use --workflow=false for legacy path)',
   },
   args: {
     version: {
@@ -43,45 +76,102 @@ const shipCommand = defineCommand({
     },
     epic: {
       type: 'string',
-      description: 'Epic task ID for commit message (e.g. T5576)',
+      description: 'Epic task ID (forwarded to release plan / release open)',
       required: true,
+    },
+    workflow: {
+      type: 'boolean',
+      description:
+        'Default true: route through new plan+open verbs. Pass --workflow=false (or --no-workflow) to run the legacy 12-step monolith (CRITICAL audit-logged)',
+      default: true,
+    },
+    'workflow-bypass-reason': {
+      type: 'string',
+      description: 'Operator-supplied rationale recorded in the workflow-bypass audit log',
     },
     'dry-run': {
       type: 'boolean',
-      description: 'Preview all actions without writing anything',
+      description: 'Preview all actions without writing anything (legacy path only)',
     },
     push: {
       type: 'boolean',
-      description: 'Push commit and tag (default: true)',
+      description: 'Push commit and tag (legacy path only — default: true)',
       default: true,
     },
     bump: {
       type: 'boolean',
-      description: 'Bump version files (default: true)',
+      description: 'Bump version files (legacy path only — default: true)',
       default: true,
     },
     remote: {
       type: 'string',
-      description: 'Git remote to push to (default: origin)',
+      description: 'Git remote to push to (legacy path only — default: origin)',
     },
     force: {
       type: 'boolean',
-      description: 'Bypass IVTR gate check with owner warning (breaks accountability chain)',
+      description: 'Bypass IVTR gate check (legacy path only — breaks accountability chain)',
     },
   },
   async run({ args }) {
+    // R-420: deprecation warning MUST go to stderr so JSON envelope on stdout
+    // stays parseable for piped tooling.
+    process.stderr.write(`${SHIP_DEPRECATION_NOTICE}\n`);
+
+    // R-440 / R-441: --workflow=false retains the legacy releaseShip monolith
+    // path and audits the bypass to `.cleo/audit/release-workflow-bypass.jsonl`.
+    if (args.workflow === false) {
+      release.appendReleaseWorkflowBypass({
+        projectRoot: process.cwd(),
+        version: args.version,
+        reason:
+          (args['workflow-bypass-reason'] as string | undefined) ??
+          '(no reason supplied — set --workflow-bypass-reason)',
+        epicId: args.epic,
+        source: 'cli-flag',
+      });
+      await dispatchFromCli(
+        'mutate',
+        'pipeline',
+        'release.ship',
+        {
+          version: args.version,
+          epicId: args.epic,
+          dryRun: args['dry-run'],
+          push: args.push !== false,
+          bump: args.bump !== false,
+          remote: args.remote as string | undefined,
+          force: args.force,
+        },
+        { command: 'release' },
+      );
+      return;
+    }
+
+    // Default: forward to the new 4-verb pipeline (R-420). Plan first, then
+    // open — publish runs in the dispatched GHA workflow.
     await dispatchFromCli(
       'mutate',
-      'pipeline',
-      'release.ship',
+      'release',
+      'release.plan',
       {
         version: args.version,
         epicId: args.epic,
-        dryRun: args['dry-run'],
-        push: args.push !== false,
-        bump: args.bump !== false,
-        remote: args.remote as string | undefined,
-        force: args.force,
+        dryRun: args['dry-run'] === true,
+      },
+      { command: 'release' },
+    );
+    if (args['dry-run'] === true) {
+      // Match the new-verb semantics: dry-run stops after plan with no side
+      // effects, so don't trip the open workflow when the operator asked
+      // for a preview.
+      return;
+    }
+    await dispatchFromCli(
+      'mutate',
+      'release',
+      'release.open',
+      {
+        version: args.version,
       },
       { command: 'release' },
     );
@@ -508,29 +598,49 @@ const reconcileCommand = defineCommand({
 /**
  * Root release command group — release lifecycle management.
  *
- * Dispatches to `pipeline.release.*` registry operations.
+ * Surfaces the SPEC-T9345 4-verb pipeline (`plan`, `open`, `reconcile`,
+ * `rollback`) as the canonical entry points. Legacy verbs (`ship`, `start`,
+ * `verify`, `publish`) remain wired for the compatibility window (R-420 →
+ * R-423) but are listed under the Deprecated section of the command
+ * description (T9538).
+ *
+ * Dispatches to `release.*` for the new verbs and to `pipeline.release.*`
+ * for the legacy compatibility shim path.
+ *
+ * @task T9538
+ * @spec SPEC-T9345 §12
  */
 export const releaseCommand = defineCommand({
-  meta: { name: 'release', description: 'Release lifecycle management' },
+  meta: {
+    name: 'release',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ' +
+      'Deprecated: ship/start/verify/publish (use the 4 verbs above; see SPEC-T9345 §12).',
+  },
   subCommands: {
-    ship: shipCommand,
+    // Canonical SPEC-T9345 4-verb pipeline — list these first so `--help`
+    // surfaces them as the documented default (T9538 / R-420).
+    plan: planCommand,
+    open: openCommand,
+    reconcile: reconcileCommand,
+    rollback: rollbackCommand,
+    // Read-only helpers — not deprecated.
     list: listCommand,
     show: showCommand,
     cancel: cancelCommand,
     changelog: changelogCommand,
-    rollback: rollbackCommand,
-    'rollback-full': rollbackFullCommand,
-    channel: channelCommand,
     'pr-status': prStatusCommand,
-    // Canonical 4-step pipeline (T1597 / ADR-063)
+    channel: channelCommand,
+    'rollback-full': rollbackFullCommand,
+    // Deprecated verbs (kept for the migration window — SPEC-T9345 §12).
+    // R-420: ship → plan + open + (auto-)publish
+    ship: shipCommand,
+    // R-421: start → plan
     start: startCommand,
+    // R-422: verify → cleo verify <task> --gate X --evidence …
     verify: verifyCommand,
+    // R-423: publish → release open
     publish: publishCommand,
-    reconcile: reconcileCommand,
-    // SPEC-T9345 release pipeline v2 verbs (T9492)
-    plan: planCommand,
-    // SPEC-T9345 release pipeline v2 (T9494 Phase 3 / T9530)
-    open: openCommand,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -748,6 +748,15 @@ export type {
 export { provenanceBackfill } from './release/backfill.js';
 // Release
 export { channelToDistTag, describeChannel, resolveChannelFromBranch } from './release/channel.js';
+// T9538: release workflow bypass audit logger (SPEC-T9345 §12.3 / R-441)
+export type {
+  AppendReleaseWorkflowBypassOptions,
+  ReleaseWorkflowBypassRecord,
+} from './release/escape-hatch.js';
+export {
+  appendReleaseWorkflowBypass,
+  RELEASE_WORKFLOW_BYPASS_FILE,
+} from './release/escape-hatch.js';
 export type { PRResult } from './release/github-pr.js';
 export { buildPRBody, createPullRequest, isGhCliAvailable } from './release/github-pr.js';
 export { checkDoubleListing, checkEpicCompleteness } from './release/guards.js';

--- a/packages/core/src/release/__tests__/escape-hatch.test.ts
+++ b/packages/core/src/release/__tests__/escape-hatch.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for {@link appendReleaseWorkflowBypass} — T9538 audit logger.
+ *
+ * Verifies SPEC-T9345 §12.3 / R-441:
+ *   1. A record is appended to `.cleo/audit/release-workflow-bypass.jsonl`.
+ *   2. The record carries severity='critical', the version, the operator, the
+ *      reason, and the timestamp.
+ *   3. Multiple invocations append multiple JSONL lines (no truncation).
+ *   4. The parent directory is created on demand (.cleo/audit/ may not exist
+ *      yet on fresh projects).
+ *   5. Filesystem errors do NOT throw (best-effort audit per R-441).
+ *
+ * @task T9538
+ * @epic T9498
+ * @spec SPEC-T9345 §12.3 / R-441
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  appendReleaseWorkflowBypass,
+  RELEASE_WORKFLOW_BYPASS_FILE,
+  type ReleaseWorkflowBypassRecord,
+} from '../escape-hatch.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+let projectRoot: string;
+
+beforeEach(() => {
+  projectRoot = join(
+    tmpdir(),
+    `cleo-escape-hatch-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(projectRoot, { recursive: true });
+});
+
+afterEach(() => {
+  if (projectRoot && existsSync(projectRoot)) {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+/** Read all JSONL lines from the audit file and parse each one. */
+function readAuditRecords(): ReleaseWorkflowBypassRecord[] {
+  const path = join(projectRoot, RELEASE_WORKFLOW_BYPASS_FILE);
+  if (!existsSync(path)) return [];
+  const body = readFileSync(path, 'utf-8');
+  return body
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as ReleaseWorkflowBypassRecord);
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('appendReleaseWorkflowBypass — T9538', () => {
+  it('creates .cleo/audit/release-workflow-bypass.jsonl and appends one record', () => {
+    appendReleaseWorkflowBypass({
+      projectRoot,
+      version: '2026.6.0',
+      reason: 'gha is down',
+      operator: 'kryptokeaton',
+      epicId: 'T9498',
+    });
+
+    const records = readAuditRecords();
+    expect(records).toHaveLength(1);
+    const record = records[0];
+    expect(record).toMatchObject({
+      version: '2026.6.0',
+      operator: 'kryptokeaton',
+      severity: 'critical',
+      reason: 'gha is down',
+      epicId: 'T9498',
+      source: 'cli-flag',
+    });
+    expect(record?.timestamp).toEqual(expect.any(String));
+    expect(new Date(record?.timestamp ?? '').toString()).not.toBe('Invalid Date');
+  });
+
+  it('appends additional records on subsequent calls (no truncation)', () => {
+    appendReleaseWorkflowBypass({
+      projectRoot,
+      version: '2026.6.0',
+      reason: 'first',
+    });
+    appendReleaseWorkflowBypass({
+      projectRoot,
+      version: '2026.6.1',
+      reason: 'second',
+    });
+    appendReleaseWorkflowBypass({
+      projectRoot,
+      version: '2026.6.2',
+      reason: 'third',
+    });
+
+    const records = readAuditRecords();
+    expect(records).toHaveLength(3);
+    expect(records.map((r) => r.reason)).toEqual(['first', 'second', 'third']);
+    expect(records.every((r) => r.severity === 'critical')).toBe(true);
+  });
+
+  it('uses process.env.USER when operator is not supplied', () => {
+    const previous = process.env.USER;
+    process.env.USER = 'env-user';
+    try {
+      appendReleaseWorkflowBypass({
+        projectRoot,
+        version: '2026.6.0',
+        reason: 'env-test',
+      });
+      const records = readAuditRecords();
+      expect(records[0]?.operator).toBe('env-user');
+    } finally {
+      if (previous === undefined) delete process.env.USER;
+      else process.env.USER = previous;
+    }
+  });
+
+  it('falls back to "unknown" when process.env.USER is absent', () => {
+    const previous = process.env.USER;
+    delete process.env.USER;
+    try {
+      appendReleaseWorkflowBypass({
+        projectRoot,
+        version: '2026.6.0',
+        reason: 'no-user',
+      });
+      const records = readAuditRecords();
+      expect(records[0]?.operator).toBe('unknown');
+    } finally {
+      if (previous !== undefined) process.env.USER = previous;
+    }
+  });
+
+  it('honours an explicit timestamp override', () => {
+    const fixed = '2026-05-18T12:00:00.000Z';
+    appendReleaseWorkflowBypass({
+      projectRoot,
+      version: '2026.6.0',
+      reason: 'fixed-ts',
+      timestamp: fixed,
+    });
+    const records = readAuditRecords();
+    expect(records[0]?.timestamp).toBe(fixed);
+  });
+
+  it('does not throw when the project root path is not writable', () => {
+    // Pointing at a clearly invalid path. The helper MUST swallow the error
+    // per R-441 (best-effort audit must never block the operation).
+    expect(() => {
+      appendReleaseWorkflowBypass({
+        projectRoot: '/nonexistent/forbidden/path/should-not-be-writable',
+        version: '2026.6.0',
+        reason: 'fs-fail',
+      });
+    }).not.toThrow();
+  });
+});

--- a/packages/core/src/release/escape-hatch.ts
+++ b/packages/core/src/release/escape-hatch.ts
@@ -1,0 +1,117 @@
+/**
+ * Release pipeline emergency escape-hatch audit logger.
+ *
+ * SPEC-T9345 §12.3 / R-440 / R-441 requires that the `cleo release ship`
+ * `--workflow=false` compatibility flag append a CRITICAL-level entry to
+ * `.cleo/audit/release-workflow-bypass.jsonl` for every invocation. This module
+ * provides the single helper used by the CLI shim so the audit shape stays
+ * stable across callsites and tests can stub the file path.
+ *
+ * The audit log is append-only JSONL — one record per line — and follows the
+ * same conventions as `contract-violations.jsonl` (see `audit.ts`).
+ *
+ * @task T9538
+ * @epic T9498
+ * @spec SPEC-T9345 §12.3
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+/**
+ * Relative path (from project root) of the release workflow bypass audit log.
+ *
+ * Exported so tests can read/inspect the file in fixtures and the dispatch
+ * layer can route observability hooks at it.
+ */
+export const RELEASE_WORKFLOW_BYPASS_FILE = '.cleo/audit/release-workflow-bypass.jsonl';
+
+/**
+ * One audit record persisted to {@link RELEASE_WORKFLOW_BYPASS_FILE}.
+ *
+ * Designed for forward-compatible JSONL parsing: required fields cover the
+ * minimum forensic context (when, what, who, why) and optional fields capture
+ * the originating epic for cross-reference against the `releases` table.
+ *
+ * @task T9538
+ */
+export interface ReleaseWorkflowBypassRecord {
+  /** ISO 8601 UTC timestamp of the bypass invocation. */
+  timestamp: string;
+  /** Release version the operator attempted to ship via the legacy path. */
+  version: string;
+  /** Operator identity (process.env.USER or override). */
+  operator: string;
+  /**
+   * Severity tier — always `'critical'` per R-441 so log aggregators can
+   * surface these events without extra parsing.
+   */
+  severity: 'critical';
+  /** Free-form rationale supplied by the operator. */
+  reason: string;
+  /** Epic task ID the release is shipping (when supplied via --epic). */
+  epicId?: string;
+  /** Reason category — `'env-flag'` covers the CLI shim path. */
+  source: 'env-flag' | 'cli-flag';
+}
+
+/**
+ * Options accepted by {@link appendReleaseWorkflowBypass}.
+ *
+ * @task T9538
+ */
+export interface AppendReleaseWorkflowBypassOptions {
+  /** Project root used to resolve `.cleo/audit/`. */
+  projectRoot: string;
+  /** Release version that was bypassed. */
+  version: string;
+  /** Operator-supplied reason for using the escape hatch. */
+  reason: string;
+  /** Operator identity override (defaults to `process.env.USER` or `unknown`). */
+  operator?: string;
+  /** Epic ID for cross-reference. */
+  epicId?: string;
+  /** Originating callsite — `cli-flag` for `--workflow=false` shim. */
+  source?: ReleaseWorkflowBypassRecord['source'];
+  /** Timestamp override — defaults to `new Date().toISOString()`. */
+  timestamp?: string;
+}
+
+/**
+ * Append a CRITICAL-severity record to the release workflow bypass audit log.
+ *
+ * Per SPEC-T9345 R-441 every `--workflow=false` invocation MUST land a record
+ * here. The write is best-effort: errors are swallowed so the legacy release
+ * path is never blocked by a permissions or filesystem fault on the audit log.
+ *
+ * @example
+ * ```ts
+ * appendReleaseWorkflowBypass({
+ *   projectRoot: process.cwd(),
+ *   version: '2026.6.0',
+ *   reason: 'GHA workflow is down — hotfix needed',
+ *   epicId: 'T9498',
+ * });
+ * ```
+ *
+ * @task T9538
+ */
+export function appendReleaseWorkflowBypass(opts: AppendReleaseWorkflowBypassOptions): void {
+  try {
+    const filePath = join(opts.projectRoot, RELEASE_WORKFLOW_BYPASS_FILE);
+    mkdirSync(dirname(filePath), { recursive: true });
+    const record: ReleaseWorkflowBypassRecord = {
+      timestamp: opts.timestamp ?? new Date().toISOString(),
+      version: opts.version,
+      operator: opts.operator ?? process.env.USER ?? 'unknown',
+      severity: 'critical',
+      reason: opts.reason,
+      epicId: opts.epicId,
+      source: opts.source ?? 'cli-flag',
+    };
+    appendFileSync(filePath, `${JSON.stringify(record)}\n`, { encoding: 'utf-8' });
+  } catch {
+    // non-fatal — audit writes must never block the operation (matches the
+    // pattern in audit.appendContractViolation).
+  }
+}

--- a/packages/core/src/release/index.ts
+++ b/packages/core/src/release/index.ts
@@ -81,6 +81,15 @@ export {
   releaseTag,
   writeIvtrDecouplingAuditOnce,
 } from './engine-ops.js';
+// T9538 — release workflow bypass audit logger (SPEC-T9345 §12.3 / R-441)
+export type {
+  AppendReleaseWorkflowBypassOptions,
+  ReleaseWorkflowBypassRecord,
+} from './escape-hatch.js';
+export {
+  appendReleaseWorkflowBypass,
+  RELEASE_WORKFLOW_BYPASS_FILE,
+} from './escape-hatch.js';
 // GitHub PR management
 export type {
   BranchProtectionResult,


### PR DESCRIPTION
## Summary

Makes `cleo release ship` a deprecated alias per SPEC-T9345 §12 R-420.
Default behavior forwards to the new 4-verb pipeline (`plan + open + auto-publish via GHA workflow`). Preserves the legacy `releaseShip` monolith behind a `--workflow=false` emergency escape hatch with CRITICAL audit logging.

## Changes

- `packages/cleo/src/cli/commands/release.ts`
  - `shipCommand.run` emits `SHIP_DEPRECATION_NOTICE` to **stderr** (NOT stdout — JSON envelope on stdout stays parseable)
  - Default path: dispatches `release.plan` then `release.open` (publish runs in the dispatched GHA workflow, CLI returns)
  - `--workflow=false`: legacy `pipeline.release.ship` path, audited to `.cleo/audit/release-workflow-bypass.jsonl` (R-441)
  - `--dry-run`: forwards `release.plan` with `dryRun:true` and short-circuits before `open` (preview semantics)
  - `releaseCommand.subCommands` reordered so the canonical 4 verbs (plan/open/reconcile/rollback) come first; deprecated verbs (ship/start/verify/publish) listed below
  - Root command description updated to call out the deprecated section
- `packages/core/src/release/escape-hatch.ts` (new) — `appendReleaseWorkflowBypass` helper writes CRITICAL JSONL records (R-441)
- `packages/core/src/release/index.ts` + `packages/core/src/internal.ts` — re-export the new helper
- `packages/cleo/src/cli/commands/__tests__/release-ship-deprecation.test.ts` (new) — 8 unit tests
- `packages/core/src/release/__tests__/escape-hatch.test.ts` (new) — 6 unit tests

## Acceptance Criteria

- [x] Deprecation warning emitted to **stderr** (envelope-safe)
- [x] Default path forwards to `release.plan` + `release.open` (verified by mocked dispatch)
- [x] `--workflow=false` retains legacy `pipeline.release.ship` route AND audits to `.cleo/audit/release-workflow-bypass.jsonl`
- [x] `cleo release --help` surfaces the new 4 verbs first; deprecated verbs documented
- [x] Exit codes propagate from underlying dispatches (no shim-introduced regressions)
- [x] Legacy `releaseShip` core function preserved untouched in `engine-ops.ts` (T9540 deletes in Phase 6)
- [x] No `any` / `unknown` shortcut casts beyond pre-existing citty patterns
- [x] Unit tests + helper tests verify forward + warning + escape-hatch + audit paths

## Spec Mapping

| Spec ref | Implementation |
|---|---|
| R-420 (ship → plan + open + publish) | `shipCommand.run` default branch (lines 152-177) |
| R-431 (warning includes replacement + removal) | `SHIP_DEPRECATION_NOTICE` constant (lines 38-42) |
| R-440 (`--workflow=false` escape hatch) | `args.workflow === false` branch (lines 122-148) |
| R-441 (CRITICAL audit log) | `appendReleaseWorkflowBypass` + `.cleo/audit/release-workflow-bypass.jsonl` |

## Test plan

- [x] `packages/core` — 202/202 release tests pass (no regressions); 6 new escape-hatch tests pass
- [ ] CI green on full vitest matrix
- [ ] `cleo release ship 2026.X.Y --epic T### --dry-run` smoke-tests `release.plan` forward (post-merge)
- [ ] `cleo release ship 2026.X.Y --epic T### --workflow=false --workflow-bypass-reason "..."` smoke-tests legacy path + audit row (post-merge)

Closes T9538 (Phase 5 / 2 of 3 of T9498). Unblocks T9539 (ship 2 real releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)