### PR TITLE
release: ship v2026.6.0 — T9345 IVTR Release System overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## [2026.6.0] (2026-05-18) — T9345 IVTR Release System overhaul
+
+Major release: complete overhaul of the CLEO release pipeline per SPEC-T9345 / ADR-073. Replaces the 761-line releaseShip monolith with four operator verbs (`plan`, `open`, `reconcile`, `rollback`) backed by four GHA workflow templates. Eliminates 10 production failure modes catalogued in `failure-forensics-10-modes.md` (8 by structural prevention, 2 by race-window narrowing). IVTR is decoupled from the release blocking path — ADR-051 evidence atoms become the sole gate execution surface.
+
+### Added
+
+#### Provenance graph (T9491 — Phase 0)
+- 11 new SQLite tables: `commits`, `task_commits`, `commit_files`, `pull_requests`, `pr_commits`, `pr_tasks`, `releases`, `release_commits`, `release_changes`, `release_artifacts`, `brain_release_links` (T9506/T9507/T9508/T9509/T9510)
+- `releases_view` materialized view for joined query consumers (T9510)
+- `CLEO_PROVENANCE_DUAL_WRITE` env var gates dual-write to legacy + new tables (T9510)
+
+#### CLI verbs (T9492 / T9493)
+- `cleo release plan <version> --epic <id>` — builds Release Plan envelope, writes `.cleo/release/<version>.plan.json`, INSERTs releases row with status=planned (T9525)
+- `cleo release reconcile <version>` — backfills 11 provenance tables from git log + gh api, single SQLite TX, UPSERT-everywhere (T9526)
+- `cleo release open <version>` — dispatches `release-prepare.yml` workflow, UPDATEs releases.status=pr-opened (T9530)
+- `cleo provenance backfill --since <version>` — walks historical tags forward, populates 11 tables, restartable via checkpoint (T9528)
+- `cleo provenance verify <version>` — audits FK integrity + orphan rows + evidence staleness across 8 categories (T9529)
+
+#### GHA workflow templates (T9494 / T9497)
+- `release-prepare.yml.tmpl` — bump-PR creation per SPEC §5.1 (T9532)
+- `release-publish.yml.tmpl` — push-to-main → tag-on-merge-SHA per SPEC §5.2; eliminates F6 race by construction via gh pr view --json state,mergeCommit polling (T9533)
+- `release-fanout.yml.tmpl` — release:published trigger with 5 best-effort jobs per SPEC §5.3 (T9534)
+- `release-rollback.yml.tmpl` — workflow_dispatch revert-PR (NOT direct main push per ADR-065) per SPEC §5.4 (T9535)
+- `cleo init --workflows` + `cleo upgrade workflows` scaffolders (T9531, T9536)
+
+#### Test infrastructure (T9495)
+- 3 archetype fixtures: monorepo / single-npm-lib / single-rust-crate (T9542)
+- 12 release-pipeline scenarios as Vitest integration tests (T9543)
+- GHA matrix workflow runs 32 scenario × archetype combinations on PR labeled release-pipeline (T9544)
+
+#### Worktree lifecycle (T9515)
+- 60s timeout supervisor + AbortController budget on `cleo orchestrate spawn` (T9545)
+- `cleo worktree list` with 5 status categories (active|stale|merged|orphan|locked) (T9546)
+- `cleo worktree prune --orphaned` + `cleo worktree force-unlock <taskId>` (T9547)
+- Auto-invoke worktree-complete post-success (T9548)
+- `docs/spec/worktree-lifecycle.md` canonical spec (T9549)
+
+#### Schema contract
+- `@cleocode/contracts/release/plan` — ReleasePlanSchema (Zod) + `parseReleasePlan` helper (T9527)
+
+### Changed
+
+- `cleo release ship` is now a deprecated alias forwarding to plan + open + auto-publish flow (T9538). `--workflow=false` emergency escape hatch preserves legacy path with audit-log entry.
+- `cleo release --help` lists new 4-verb surface (plan/open/reconcile/rollback) prominently; deprecated verbs (ship/start/verify/publish) shown below in Deprecated section.
+
+### Fixed (T9496 — Forensics 5-bug bundle)
+
+- F1: 60s supervisor timeout on every git invocation in release pipeline (T9501)
+- F2: epic-completeness scope confined to declared `--epic` argument (T9502)
+- F3/F4: gate runners actually execute via ADR-061 tool resolver (no more theater) (T9503)
+- F6: tag lands on `mergeCommit.oid` after gh pr view confirms state=MERGED (T9504)
+- F5: CLEO_OWNER_OVERRIDE counter resets per session (T9505)
+- F3b: makeAdr061GateRunner cwd-vs-projectRoot contract clarified (T9550)
+- Migration timestamp collision: T9506 renumbered 20260516000000-000002 → 20260517000000-000002 to avoid colliding with T9519 (T9551)
+
+### Removed
+
+- E_IVTR_INCOMPLETE blocking gate from release path (T9537). `task.ivtr_state` becomes observation-only; ADR-051 evidence atoms are the sole gate execution surface for release per SPEC R-310 through R-316.
+
 ## [2026.5.78] (2026-05-17) — E-CONFIG-AUTH-UNIFY
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.78"
+version = "2026.6.0"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.78",
+  "version": "2026.6.0",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Release v2026.6.0 — T9345 IVTR Release System overhaul

Closes Epic **T9345**. Ships the complete overhaul of the CLEO release pipeline per SPEC-T9345 / ADR-073 across 8 phases and 25+ subtasks.

## Summary

Replaces the 761-line `releaseShip` monolith with four operator verbs (`plan`, `open`, `reconcile`, `rollback`) backed by four GHA workflow templates. Eliminates the 10 production failure modes catalogued in `failure-forensics-10-modes.md` — 8 by structural prevention, 2 by race-window narrowing. IVTR is decoupled from the release blocking path; ADR-051 evidence atoms become the sole gate execution surface.

## Phases shipped

| Phase | Tasks | What |
|---|---|---|
| Phase 0 (T9491) | T9506-T9510, T9551 | 11 provenance tables + dual-write + view |
| Phase 1 (T9492) | T9525, T9526, T9527 | plan + reconcile verbs + Plan schema |
| Phase 2 (T9493) | T9528, T9529 | backfill + verify verbs |
| Phase 3 (T9494) | T9530, T9531, T9532 | open verb + init scaffolder + prepare.yml.tmpl |
| Phase 4 (T9497) | T9533, T9534, T9535, T9536 | publish + fanout + rollback templates + 4-template scaffolder |
| Phase 5 (T9498) | T9537, T9538, T9539 | IVTR decouple + deprecation shim + ship |
| Tests (T9495) | T9542, T9543, T9544 | 3 fixtures + 12 scenarios + GHA matrix |
| Worktree (T9515) | T9545-T9549 | timeout + list + prune + auto-complete + docs |
| Forensics (T9496) | T9501-T9505, T9550, T9551 | 5 production failure modes fixed |

## Test plan
- [x] All 25+ subtask PRs merged green with CI
- [x] biome + typecheck + vitest clean
- [x] CHANGELOG.md reflects full scope
- [x] All package.json + Cargo.toml bumped to 2026.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)