### PR TITLE
feat(T9541): retire CLEO_PROVENANCE_DUAL_WRITE env var

### DIFF
--- a/packages/core/src/release/__tests__/dual-write-regression.test.ts
+++ b/packages/core/src/release/__tests__/dual-write-regression.test.ts
@@ -1,20 +1,24 @@
 /**
- * Regression tests for CLEO_PROVENANCE_DUAL_WRITE env var.
+ * Regression tests for retired CLEO_PROVENANCE_DUAL_WRITE env var.
  *
- * Validates that `markReleaseShipped`:
- *   1. With CLEO_PROVENANCE_DUAL_WRITE='1' (default ON): inserts `task_commits`
- *      rows for every task in the release manifest, using the provided commit SHA.
- *   2. With CLEO_PROVENANCE_DUAL_WRITE='0' (OFF): writes nothing to `task_commits`.
- *   3. `release_manifests.tasksJson` is identical in both modes (F12 — ADR-073).
+ * After T9541, the env var is gone — `markReleaseShipped` writes to
+ * `task_commits` unconditionally. These tests validate the new behavior:
+ *
+ *   1. New-table writes happen unconditionally (no env var required).
+ *   2. The env var being present (set to either value) has no effect.
+ *   3. `release_manifests.tasksJson` is preserved (F12 — ADR-073).
+ *   4. The retirement audit sentinel is written on first invocation.
  *
  * Each test runs in a fully isolated tmp directory with a real SQLite database
  * and all migrations applied.
  *
  * @task T9510
+ * @task T9541
  * @epic T9491
+ * @epic T9499
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -131,7 +135,7 @@ async function readTasksJson(projectRoot: string, version: string): Promise<stri
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
-describe('CLEO_PROVENANCE_DUAL_WRITE — dual-write regression', () => {
+describe('CLEO_PROVENANCE_DUAL_WRITE — retired (T9541)', () => {
   let projectRoot: string;
   let cleanup: () => void;
   const COMMIT_SHA = 'aaaa1111bbbb2222cccc3333dddd4444eeee5555';
@@ -144,22 +148,19 @@ describe('CLEO_PROVENANCE_DUAL_WRITE — dual-write regression', () => {
     cleanup = env.cleanup;
     // Insert synthetic release manifest with 3 tasks.
     await insertManifest(projectRoot, VERSION, TASK_IDS);
+    // Defensive: if a stale env var is set from another test, remove it.
+    delete process.env['CLEO_PROVENANCE_DUAL_WRITE'];
   });
 
   afterEach(async () => {
     const { resetDbState } = await import('../../store/sqlite.js');
     resetDbState();
     cleanup();
-    // Reset the per-process warn flag between tests.
-    const mod = await import('../release-manifest.js');
-    // Force reset of the module-level warn flag via environment toggle.
-    process.env['CLEO_PROVENANCE_DUAL_WRITE'] = '1';
     delete process.env['CLEO_PROVENANCE_DUAL_WRITE'];
   });
 
-  it('Test 1: DUAL_WRITE=1 inserts task_commits rows for all 3 tasks', async () => {
-    process.env['CLEO_PROVENANCE_DUAL_WRITE'] = '1';
-
+  it('Test 1: writes task_commits rows for all tasks unconditionally', async () => {
+    // Env var unset — writes must still happen.
     const { markReleaseShipped } = await import('../release-manifest.js');
     const result = await markReleaseShipped(VERSION, new Date().toISOString(), projectRoot, {
       commitSha: COMMIT_SHA,
@@ -170,10 +171,10 @@ describe('CLEO_PROVENANCE_DUAL_WRITE — dual-write regression', () => {
     expect(count).toBe(TASK_IDS.length);
   });
 
-  it('Test 2: DUAL_WRITE=0 inserts NO task_commits rows', async () => {
+  it('Test 2: env var present (legacy "0") is ignored — writes still happen', async () => {
+    // Even with the retired var set to its old disable-value, writes proceed.
     process.env['CLEO_PROVENANCE_DUAL_WRITE'] = '0';
 
-    // Use a different version/commit to avoid collision with test 1.
     const version2 = 'v2026.99.2';
     const commit2 = 'ffff0000aaaa1111bbbb2222cccc3333dddd4444';
     await insertManifest(projectRoot, version2, TASK_IDS);
@@ -183,37 +184,63 @@ describe('CLEO_PROVENANCE_DUAL_WRITE — dual-write regression', () => {
       commitSha: commit2,
     });
 
-    expect(result.taskCommitsInserted).toBe(0);
+    expect(result.taskCommitsInserted).toBe(TASK_IDS.length);
     const count = await countTaskCommits(projectRoot, commit2);
-    expect(count).toBe(0);
+    expect(count).toBe(TASK_IDS.length);
   });
 
-  it('Test 3: release_manifests.tasksJson is identical regardless of DUAL_WRITE mode', async () => {
-    // Test with dual-write ON.
-    process.env['CLEO_PROVENANCE_DUAL_WRITE'] = '1';
-    const vON = 'v2026.99.3';
-    const commitON = '1111aaaa2222bbbb3333cccc4444dddd5555eeee';
-    await insertManifest(projectRoot, vON, TASK_IDS);
+  it('Test 3: release_manifests.tasksJson is preserved (F12 backward-compat)', async () => {
+    const vA = 'v2026.99.3';
+    const commitA = '1111aaaa2222bbbb3333cccc4444dddd5555eeee';
+    await insertManifest(projectRoot, vA, TASK_IDS);
     const { markReleaseShipped } = await import('../release-manifest.js');
-    await markReleaseShipped(vON, new Date().toISOString(), projectRoot, {
-      commitSha: commitON,
+    await markReleaseShipped(vA, new Date().toISOString(), projectRoot, {
+      commitSha: commitA,
     });
-    const tasksJsonON = await readTasksJson(projectRoot, vON);
+    const tasksJsonA = await readTasksJson(projectRoot, vA);
 
-    // Test with dual-write OFF.
-    process.env['CLEO_PROVENANCE_DUAL_WRITE'] = '0';
-    const vOFF = 'v2026.99.4';
-    const commitOFF = '9999aaaa8888bbbb7777cccc6666dddd5555eeee';
-    await insertManifest(projectRoot, vOFF, TASK_IDS);
-    await markReleaseShipped(vOFF, new Date().toISOString(), projectRoot, {
-      commitSha: commitOFF,
+    const vB = 'v2026.99.4';
+    const commitB = '9999aaaa8888bbbb7777cccc6666dddd5555eeee';
+    await insertManifest(projectRoot, vB, TASK_IDS);
+    await markReleaseShipped(vB, new Date().toISOString(), projectRoot, {
+      commitSha: commitB,
     });
-    const tasksJsonOFF = await readTasksJson(projectRoot, vOFF);
+    const tasksJsonB = await readTasksJson(projectRoot, vB);
 
-    // Both runs should preserve the same task list in release_manifests.
-    const parsedON = JSON.parse(tasksJsonON) as string[];
-    const parsedOFF = JSON.parse(tasksJsonOFF) as string[];
-    expect(parsedON.sort()).toEqual(parsedOFF.sort());
-    expect(parsedON.sort()).toEqual([...TASK_IDS].sort());
+    // The legacy release_manifests table preserves the task list verbatim.
+    const parsedA = JSON.parse(tasksJsonA) as string[];
+    const parsedB = JSON.parse(tasksJsonB) as string[];
+    expect(parsedA.sort()).toEqual([...TASK_IDS].sort());
+    expect(parsedB.sort()).toEqual([...TASK_IDS].sort());
+  });
+
+  it('Test 4: writes retirement audit sentinel + JSONL entry on first run', async () => {
+    const { markReleaseShipped } = await import('../release-manifest.js');
+    await markReleaseShipped(VERSION, new Date().toISOString(), projectRoot, {
+      commitSha: COMMIT_SHA,
+    });
+
+    const flagPath = join(projectRoot, '.cleo', 'audit', 'dual-write-retired.flag');
+    const logPath = join(projectRoot, '.cleo', 'audit', 'dual-write-retired.jsonl');
+    expect(existsSync(flagPath)).toBe(true);
+    expect(existsSync(logPath)).toBe(true);
+
+    const flagContents = JSON.parse(readFileSync(flagPath, 'utf-8')) as {
+      task: string;
+      retiredAt: string;
+    };
+    expect(flagContents.task).toBe('T9541');
+    expect(typeof flagContents.retiredAt).toBe('string');
+
+    const logLines = readFileSync(logPath, 'utf-8').trim().split('\n');
+    expect(logLines.length).toBeGreaterThanOrEqual(1);
+    const firstEntry = JSON.parse(logLines[0]!) as {
+      event: string;
+      task: string;
+      version: string;
+    };
+    expect(firstEntry.event).toBe('dual-write-retired');
+    expect(firstEntry.task).toBe('T9541');
+    expect(firstEntry.version).toBe(VERSION);
   });
 });

--- a/packages/core/src/release/release-manifest.ts
+++ b/packages/core/src/release/release-manifest.ts
@@ -9,9 +9,9 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, renameSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { and, count, desc, eq, sql } from 'drizzle-orm';
 import { createPage } from '../pagination.js';
 import { getCleoDirAbsolute, getProjectRoot } from '../paths.js';
@@ -30,15 +30,80 @@ import {
 } from './release-config.js';
 import { resolveVersionBumpTargets } from './version-bump.js';
 
-// ── Dual-write state ─────────────────────────────────────────────────────────
+// ── Provenance dual-write retirement (T9541) ─────────────────────────────────
 
 /**
- * Whether the CLEO_PROVENANCE_DUAL_WRITE advisory warning has already been
- * emitted for this process lifetime. Resets on module load (per-process).
+ * Sentinel file recording that the CLEO_PROVENANCE_DUAL_WRITE env var has been
+ * retired. Written once per project on the first shipped release after the
+ * upgrade — its presence is the audit signal that retirement has occurred.
  *
- * @task T9510
+ * @task T9541
+ * @see SPEC-T9345 §12.2
  */
-let _dualWriteOffWarnEmitted = false;
+const DUAL_WRITE_RETIRED_FLAG = '.cleo/audit/dual-write-retired.flag';
+
+/**
+ * Append-only JSONL log of dual-write retirement events. Each entry records a
+ * single observation that `markReleaseShipped` ran post-retirement (env var
+ * gone, new-table writes unconditional). Errors are swallowed so audit writes
+ * never block release operations.
+ *
+ * @task T9541
+ */
+const DUAL_WRITE_RETIRED_LOG = '.cleo/audit/dual-write-retired.jsonl';
+
+/**
+ * Record the first post-retirement run for a project (idempotent).
+ *
+ * Writes a sentinel flag file plus a single JSONL entry the first time
+ * {@link markReleaseShipped} executes after the env var is removed. Subsequent
+ * runs are no-ops (sentinel already exists).
+ *
+ * Audit writes are best-effort — filesystem errors never propagate.
+ *
+ * @param projectRoot - Absolute path to the CLEO project root.
+ * @param version     - Release version being shipped.
+ *
+ * @task T9541
+ */
+function recordDualWriteRetirementOnce(projectRoot: string, version: string): void {
+  try {
+    const flagPath = join(projectRoot, DUAL_WRITE_RETIRED_FLAG);
+    if (existsSync(flagPath)) {
+      return;
+    }
+    mkdirSync(dirname(flagPath), { recursive: true });
+    const timestamp = new Date().toISOString();
+    writeFileSync(
+      flagPath,
+      JSON.stringify(
+        {
+          retiredAt: timestamp,
+          task: 'T9541',
+          phase: 'Phase 6 / 2 of 2 of T9499',
+          note: 'CLEO_PROVENANCE_DUAL_WRITE env var retired; new-table writes are unconditional.',
+        },
+        null,
+        2,
+      ),
+      { encoding: 'utf-8' },
+    );
+    const logPath = join(projectRoot, DUAL_WRITE_RETIRED_LOG);
+    appendFileSync(
+      logPath,
+      `${JSON.stringify({
+        timestamp,
+        task: 'T9541',
+        event: 'dual-write-retired',
+        version,
+        note: 'First post-retirement markReleaseShipped invocation observed.',
+      })}\n`,
+      { encoding: 'utf-8' },
+    );
+  } catch {
+    // non-fatal — audit writes must never block release operations
+  }
+}
 
 async function getDb(cwd?: string): ReturnType<typeof import('../store/sqlite.js')['getDb']> {
   const { getDb: _getDb } = await import('../store/sqlite.js');
@@ -1304,21 +1369,18 @@ export async function markReleasePushed(
 }
 
 /**
- * Mark a release as shipped (pushed) and optionally dual-write task→commit
- * provenance rows into `task_commits`.
+ * Mark a release as shipped (pushed) and write task→commit provenance rows
+ * into `task_commits` unconditionally.
  *
- * Dual-write semantics (SPEC-T9345 §8.3):
- *   - Controlled by the `CLEO_PROVENANCE_DUAL_WRITE` environment variable.
- *   - Default is `'1'` (ON). Set to `'0'` to disable.
- *   - When ON: every task ID in `release_manifests.tasksJson` gets a
- *     corresponding row in `task_commits` using the provided `commitSha` and
- *     `link_kind='implements'` / `link_source='manual'`.
- *   - When OFF: legacy path only; `task_commits` is not touched.
- *   - A `console.warn` is emitted once per process on the first write when
- *     dual-write is disabled, so operators know provenance is not accumulating.
- *
- * The underlying `release_manifests.tasksJson` write is identical in both
- * modes (F12 — the legacy table is untouched per ADR-073).
+ * Post-retirement semantics (SPEC-T9345 §12.2 · T9541):
+ *   - The `CLEO_PROVENANCE_DUAL_WRITE` env var is retired — new-table writes
+ *     are now unconditional. The legacy `release_manifests` row is preserved
+ *     (F12 backward-compat per ADR-073).
+ *   - Every task ID in `release_manifests.tasksJson` gets a corresponding row
+ *     in `task_commits` using the provided `commitSha`,
+ *     `link_kind='implements'` and `link_source='manual'`.
+ *   - On the first invocation per project after the upgrade, a sentinel flag
+ *     and audit log entry are written to record retirement (best-effort).
  *
  * @param version     - Release version string (e.g. `v2026.6.0`).
  * @param pushedAt    - ISO-8601 timestamp of the push event.
@@ -1327,7 +1389,9 @@ export async function markReleasePushed(
  * @returns           Promise resolving to the number of `task_commits` rows inserted.
  *
  * @task T9510
+ * @task T9541
  * @see SPEC-T9345 §8.3
+ * @see SPEC-T9345 §12.2
  */
 export async function markReleaseShipped(
   version: string,
@@ -1335,26 +1399,13 @@ export async function markReleaseShipped(
   cwd?: string,
   provenance?: { commitSha?: string; gitTag?: string },
 ): Promise<{ taskCommitsInserted: number }> {
-  const dualWrite = (process.env['CLEO_PROVENANCE_DUAL_WRITE'] ?? '1') === '1';
-
-  if (!dualWrite && !_dualWriteOffWarnEmitted) {
-    _dualWriteOffWarnEmitted = true;
-    // Advisory only — operators may intentionally disable dual-write.
-    // biome-ignore lint/suspicious/noConsole: advisory advisory for operators
-    console.warn(
-      '[cleo] CLEO_PROVENANCE_DUAL_WRITE=0: provenance task_commits rows will NOT be written. ' +
-        'Set CLEO_PROVENANCE_DUAL_WRITE=1 to enable (default on).',
-    );
-  }
+  // Record retirement audit signal on first post-upgrade run (idempotent).
+  recordDualWriteRetirementOnce(cwd ?? getProjectRoot(), version);
 
   // Step 1: legacy write (F12 — release_manifests is never removed).
   await markReleasePushed(version, pushedAt, cwd, provenance);
 
-  if (!dualWrite) {
-    return { taskCommitsInserted: 0 };
-  }
-
-  // Step 2: dual-write — infer task→commit links from tasksJson.
+  // Step 2: provenance write — infer task→commit links from tasksJson.
   const commitSha = provenance?.commitSha;
   if (!commitSha) {
     // Without a concrete commit SHA we cannot write valid FK rows.


### PR DESCRIPTION
## Summary

Closes T9541 (Phase 6 / 2 of 2 of T9499). After v2026.6.0 shipped with the new release pipeline fully operational, the `CLEO_PROVENANCE_DUAL_WRITE` env var becomes vestigial. New-table writes are now unconditional; the env var is removed from all code paths.

## Changes

- Removed all `CLEO_PROVENANCE_DUAL_WRITE` env var reads from `release-manifest.ts`
- Conditional dual-write branches collapsed to unconditional writes
- Legacy `release_manifests` table preserved (NOT dropped per F12 backward-compat)
- One-time audit log entry on first run:
  - `.cleo/audit/dual-write-retired.flag` (sentinel)
  - `.cleo/audit/dual-write-retired.jsonl` (append-only event log)
- Regression tests rewritten to verify:
  - Unconditional new-table writes (env var unset)
  - Env-var-ignored behavior (legacy `'0'` value no longer disables writes)
  - `release_manifests.tasksJson` preserved (F12)
  - Audit sentinel + JSONL entry emitted on first invocation

## Test plan

- [x] `pnpm biome check` clean on touched files
- [x] All 4 dual-write regression tests pass (Tests: 4/4)
- [x] Full release suite green (Tests: 243 passed, 2 skipped in 26 files)

## References

- SPEC: `.cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md` §12.2 (Removal timeline)
- Predecessor: T9510 (introduced the env var as a kill switch)
- Epic: T9499 (cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)