### PR TITLE
fix: revert v2026.6.x → v2026.5.79 CalVer correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,8 @@
 # Changelog
 
-## [2026.6.1] (2026-05-18) — T9499 Phase 6 cleanup
+## [2026.5.79] (2026-05-18) — T9345 IVTR Release System overhaul + T9499 cleanup
 
-Cleanup release following v2026.6.0. Completes the IVTR release system overhaul (T9345) by deleting the legacy `releaseShip` monolith and retiring the `CLEO_PROVENANCE_DUAL_WRITE` env var now that the new 4-verb pipeline is the unconditional default.
-
-### Removed
-
-- `packages/core/src/release/pipeline.ts` (T9540) — 4-step legacy pipeline (releaseStart/releaseVerify/releasePublish/releaseReconcile) — superseded by SPEC-T9345 §4 verbs
-- `releaseShip` function (~841 LOC) from `packages/core/src/release/engine-ops.ts` (T9540) — superseded by `cleo release plan` + `cleo release open` + GHA publish workflow
-- `cleo release ship --workflow=false` escape-hatch flag (T9540) — shim always forwards to new flow now
-- `cleo release start` / `cleo release verify` / `cleo release publish` CLI subcommands (T9540) — superseded by 4-verb surface
-- `CLEO_PROVENANCE_DUAL_WRITE` env var reads (T9541) — new-table writes are now unconditional
-
-Net code delta: **−3178 LOC**. See PR #251 + #250.
-
-### Preserved (F12 backward-compat)
-
-- `release_manifests` SQLite table (NOT dropped — still readable for historical queries)
-- `task.ivtr_state` schema column (still written for telemetry; just no longer blocks release per T9537)
-- `cleo release reconcile` (now routes to v2 via T9526)
-- `cleo release rollback` + `cleo release rollback-full` + `cleo release cancel` + `cleo release changelog` + `cleo release pr-status` + `cleo release channel` + `cleo release list` + `cleo release show`
-
-## [2026.6.0] (2026-05-18) — T9345 IVTR Release System overhaul
-
-Major release: complete overhaul of the CLEO release pipeline per SPEC-T9345 / ADR-073. Replaces the 761-line releaseShip monolith with four operator verbs (`plan`, `open`, `reconcile`, `rollback`) backed by four GHA workflow templates. Eliminates 10 production failure modes catalogued in `failure-forensics-10-modes.md` (8 by structural prevention, 2 by race-window narrowing). IVTR is decoupled from the release blocking path — ADR-051 evidence atoms become the sole gate execution surface.
+Major release: complete overhaul of the CLEO release pipeline per SPEC-T9345 / ADR-073. Replaces the 761-line releaseShip monolith with four operator verbs (`plan`, `open`, `reconcile`, `rollback`) backed by four GHA workflow templates. Eliminates 10 production failure modes catalogued in `failure-forensics-10-modes.md` (8 by structural prevention, 2 by race-window narrowing). IVTR is decoupled from the release blocking path — ADR-051 evidence atoms become the sole gate execution surface. Bundles the Phase 6 cleanup (T9499) that removes the now-superseded legacy code.
 
 ### Added
 
@@ -79,6 +58,20 @@ Major release: complete overhaul of the CLEO release pipeline per SPEC-T9345 / A
 ### Removed
 
 - E_IVTR_INCOMPLETE blocking gate from release path (T9537). `task.ivtr_state` becomes observation-only; ADR-051 evidence atoms are the sole gate execution surface for release per SPEC R-310 through R-316.
+- `packages/core/src/release/pipeline.ts` (T9540) — 4-step legacy pipeline (releaseStart/releaseVerify/releasePublish/releaseReconcile) — superseded by SPEC-T9345 §4 verbs.
+- `releaseShip` function (~841 LOC) from `packages/core/src/release/engine-ops.ts` (T9540) — superseded by `cleo release plan` + `cleo release open` + GHA publish workflow.
+- `cleo release ship --workflow=false` escape-hatch flag (T9540) — shim always forwards to new flow now.
+- `cleo release start` / `cleo release verify` / `cleo release publish` CLI subcommands (T9540) — superseded by 4-verb surface.
+- `CLEO_PROVENANCE_DUAL_WRITE` env var reads (T9541) — new-table writes are now unconditional.
+
+Net code delta from cleanup: **−3178 LOC**. See PRs #251, #250.
+
+### Preserved (F12 backward-compat)
+
+- `release_manifests` SQLite table (NOT dropped — still readable for historical queries)
+- `task.ivtr_state` schema column (still written for telemetry; just no longer blocks release per T9537)
+- `cleo release reconcile` (now routes to v2 via T9526)
+- `cleo release rollback` + `cleo release rollback-full` + `cleo release cancel` + `cleo release changelog` + `cleo release pr-status` + `cleo release channel` + `cleo release list` + `cleo release show`
 
 ## [2026.5.78] (2026-05-17) — E-CONFIG-AUTH-UNIFY
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.6.1"
+version = "2026.5.79"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.6.1",
+  "version": "2026.5.79",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Recover from accidental month-bump

The two prior release commits (v2026.6.0 + v2026.6.1) shipped with the wrong month — May 2026 → 2026.5.X per CalVer, not 2026.6.X. The release workflow's CalVer validator correctly rejected both:

```
ERROR: 2026.6.1 does not match current CalVer 2026.5
ERROR: 2026.6.0 does not match current CalVer 2026.5
```

Neither version published to npm (CI gate caught it before any side effect).

## Changes
- Tags v2026.6.0 + v2026.6.1 deleted (local + remote)
- GitHub releases for both deleted
- All package.json + Cargo.toml bumped: 2026.6.1 → 2026.5.79
- CHANGELOG consolidated: two superseded sections collapsed into one [2026.5.79] entry that bundles **T9345 IVTR Release System overhaul + T9499 Phase 6 cleanup**

## Test plan
- [x] CalVer validator should now accept (current month = 5)
- [x] CHANGELOG accurate
- [x] No code changes — version bump only

🤖 Generated with [Claude Code](https://claude.com/claude-code)