### PR TITLE
fix(T9596): preserve cli-input/manual source in cleo status output

### DIFF
--- a/packages/core/src/llm/credential-seeders/index.ts
+++ b/packages/core/src/llm/credential-seeders/index.ts
@@ -57,8 +57,11 @@ import { ghCliSeeder } from './gh-cli-seeder.js';
  * - `gemini-cli`  — Google Gemini CLI application default credentials.
  * - `gh-cli`      — GitHub CLI token (for `github-models` provider).
  * - `manual`      — operator-added entry via `cleo llm add` or store edit.
+ * - `cli-input`   — credential supplied directly via `cleo auth add` /
+ *                   `cleo setup --api-key` (interactive or flag-driven CLI).
  *
  * @task T9408
+ * @task T9596
  */
 export type SeederSourceId =
   | 'env'
@@ -67,7 +70,8 @@ export type SeederSourceId =
   | 'codex-cli'
   | 'gemini-cli'
   | 'gh-cli'
-  | 'manual';
+  | 'manual'
+  | 'cli-input';
 
 /**
  * Canonical pre-persist credential entry shape emitted by seeders.

--- a/packages/core/src/status/__tests__/status.test.ts
+++ b/packages/core/src/status/__tests__/status.test.ts
@@ -221,6 +221,107 @@ describe('getCleoStatus.credentials', () => {
     const status = await getCleoStatus();
     expect(status.credentials).toEqual([]);
   });
+
+  it('preserves cli-input source — credentials added via cleo auth add / cleo setup --api-key (T9596 BUG-3)', async () => {
+    // This is the regression case from T9573 BUG-3: cli-input was not in
+    // KNOWN_SEEDER_SOURCES so getCleoStatus downgraded it to 'none'.
+    vi.mocked(getCredentialPool).mockReturnValue({
+      list: async () => [
+        {
+          provider: 'anthropic',
+          label: 'cli-input',
+          authType: 'api_key',
+          accessToken: 'sk-manual',
+          priority: 0,
+          source: 'cli-input',
+        },
+      ],
+    } as unknown as ReturnType<typeof getCredentialPool>);
+
+    const status = await getCleoStatus();
+    expect(status.credentials).toHaveLength(1);
+    expect(status.credentials[0].source).toBe('cli-input');
+  });
+
+  it('preserves manual source — credentials added via cleo llm add or store edit (T9596)', async () => {
+    vi.mocked(getCredentialPool).mockReturnValue({
+      list: async () => [
+        {
+          provider: 'openai',
+          label: 'operator-added',
+          authType: 'api_key',
+          accessToken: 'sk-manual',
+          priority: 0,
+          source: 'manual',
+        },
+      ],
+    } as unknown as ReturnType<typeof getCredentialPool>);
+
+    const status = await getCleoStatus();
+    expect(status.credentials).toHaveLength(1);
+    expect(status.credentials[0].source).toBe('manual');
+  });
+
+  it('preserves all known seeder sources without downgrading to none (T9596)', async () => {
+    const knownSources = [
+      'env',
+      'claude-code',
+      'cleo-pkce',
+      'codex-cli',
+      'gemini-cli',
+      'gh-cli',
+      'manual',
+      'cli-input',
+    ] as const;
+
+    vi.mocked(getCredentialPool).mockReturnValue({
+      list: async () =>
+        knownSources.map((source, i) => ({
+          provider: 'anthropic',
+          label: `entry-${i}`,
+          authType: 'api_key' as const,
+          accessToken: `sk-${i}`,
+          priority: i,
+          source,
+        })),
+    } as unknown as ReturnType<typeof getCredentialPool>);
+
+    const status = await getCleoStatus();
+    expect(status.credentials).toHaveLength(knownSources.length);
+    for (let i = 0; i < knownSources.length; i++) {
+      expect(status.credentials[i].source).toBe(knownSources[i]);
+    }
+  });
+
+  it('downgrades only truly unknown/empty source strings to none (T9596)', async () => {
+    vi.mocked(getCredentialPool).mockReturnValue({
+      list: async () => [
+        {
+          provider: 'anthropic',
+          label: 'mystery',
+          authType: 'api_key',
+          accessToken: 'sk-x',
+          priority: 0,
+          source: 'some-future-unknown-seeder',
+        },
+        {
+          provider: 'openai',
+          label: 'legacy',
+          authType: 'api_key',
+          accessToken: 'sk-y',
+          priority: 1,
+          source: undefined,
+        },
+      ],
+    } as unknown as ReturnType<typeof getCredentialPool>);
+
+    const status = await getCleoStatus();
+    expect(status.credentials).toHaveLength(2);
+    // Unrecognised source strings → 'none'
+    expect(status.credentials[0].source).toBe('none');
+    // Missing/undefined source → 'none'
+    expect(status.credentials[1].source).toBe('none');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/status/index.ts
+++ b/packages/core/src/status/index.ts
@@ -124,6 +124,7 @@ const KNOWN_SEEDER_SOURCES: readonly SeederSourceId[] = [
   'gemini-cli',
   'gh-cli',
   'manual',
+  'cli-input',
 ];
 
 function narrowSeederSource(raw: string | undefined): SeederSourceId | 'none' {


### PR DESCRIPTION
## Summary

- `cleo status credentials[].source` was downgraded to `'none'` for credentials added via `cleo auth add` or `cleo setup --api-key` because `cli-input` was not in `KNOWN_SEEDER_SOURCES`.
- Added `cli-input` to `SeederSourceId` union in `credential-seeders/index.ts` (it was already used as a literal string in `cli-ops.ts` and `setup/sections/llm.ts` but not typed).
- Added `cli-input` to `KNOWN_SEEDER_SOURCES` whitelist in `status/index.ts`.
- `manual` was already in the union but added regression test to confirm it stays.
- Added 4 regression tests: `cli-input` passthrough, `manual` passthrough, all-known-sources passthrough, and downgrades-only-truly-unknown path.

Closes T9596. Refs T9573 audit BUG-3.

## Test plan

- [ ] `pnpm --filter @cleocode/core test src/status/` — 23 tests pass (4 new)
- [ ] `pnpm biome check packages/core/src/status/ packages/core/src/llm/credential-seeders/index.ts` — no issues
- [ ] `cleo auth add` / `cleo setup --api-key` followed by `cleo status` shows `source: cli-input` not `source: none`

🤖 Generated with [Claude Code](https://claude.com/claude-code)