### PR TITLE
fix(T9594): remove gh-cli seeder from BUILTIN_SEEDERS (GitHub PAT cannot auth OpenAI)

### DIFF
--- a/packages/cleo/src/cli/commands/auth/list.ts
+++ b/packages/cleo/src/cli/commands/auth/list.ts
@@ -130,7 +130,34 @@ export const authListCommand = defineCommand({
     // Force a seed pass so the listing matches what `pick()` would return.
     // The pool's internal 60s cache makes repeat calls cheap.
     await pool.seed();
-    const stored = await pool.list();
+
+    // T9594 one-shot migration: purge any stale source=gh-cli entries that
+    // were persisted before the gh-cli seeder was removed from BUILTIN_SEEDERS.
+    // `gh auth token` returns a GitHub PAT (ghp_*/gho_*) which cannot
+    // authenticate against api.openai.com — these entries are unusable.
+    // Uses pool.list() (pure store read; already called below) so no extra import.
+    const allStored = await pool.list();
+    const ghCliEntries = allStored.filter((c) => c.source === 'gh-cli');
+    if (ghCliEntries.length > 0) {
+      const { removeCredential } = await import(
+        /* webpackIgnore: true */ '@cleocode/core/llm/credentials-store.js'
+      );
+      const { addSuppression } = await import(
+        /* webpackIgnore: true */ '@cleocode/core/llm/credential-removal.js'
+      );
+      for (const entry of ghCliEntries) {
+        // removeCredential is typed to require a ModelTransport for provider;
+        // cast is safe because we are removing an entry that already exists.
+        await removeCredential(
+          entry.provider as Parameters<typeof removeCredential>[0],
+          entry.label,
+        );
+      }
+      // Suppress re-seeding; provider was 'openai' when these entries were created.
+      addSuppression('openai', 'gh-cli');
+    }
+
+    const stored = allStored.filter((c) => c.source !== 'gh-cli');
 
     const entries: AuthListEntry[] = stored
       .filter((c) => (providerFilter ? c.provider === providerFilter : true))

--- a/packages/core/src/llm/credential-seeders/__tests__/gh-cli-seeder.test.ts
+++ b/packages/core/src/llm/credential-seeders/__tests__/gh-cli-seeder.test.ts
@@ -1,10 +1,16 @@
 /**
- * Unit tests for the GitHub CLI credential seeder (T9418).
+ * Unit tests for the GitHub CLI credential seeder (T9418 / T9594).
+ *
+ * The seeder is intentionally NOT registered in BUILTIN_SEEDERS (T9594):
+ * `gh auth token` returns a GitHub PAT that cannot authenticate against
+ * api.openai.com.  The file (and these tests) are kept in tree so the
+ * implementation is available for the future github-models provider.
  *
  * `node:child_process` is mocked so no real `gh` is invoked. ENOENT and
  * non-zero exit paths are exercised separately.
  *
  * @task T9418
+ * @task T9594
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/packages/core/src/llm/credential-seeders/__tests__/registry.test.ts
+++ b/packages/core/src/llm/credential-seeders/__tests__/registry.test.ts
@@ -173,14 +173,18 @@ describe('BUILTIN_SEEDERS singleton', () => {
     }
   });
 
-  it('contains the T9418 external-CLI seeders (codex-cli, gemini-cli, gh-cli)', () => {
+  it('contains the T9418 external-CLI seeders (codex-cli, gemini-cli) but NOT gh-cli (T9594)', () => {
     // Deliberately explicit: if a future task adds another seeder, extend
     // this list. If a future task removes one, this test fires to flag
     // the contract change.
+    //
+    // gh-cli is intentionally absent: `gh auth token` returns a GitHub PAT
+    // that cannot authenticate against api.openai.com (T9594).  It will be
+    // re-added once a real github-models provider exists.
     const ids = BUILTIN_SEEDERS.getAll().map((s) => `${s.sourceId}::${s.provider}`);
     expect(ids).toContain('codex-cli::openai');
     expect(ids).toContain('gemini-cli::gemini');
-    expect(ids).toContain('gh-cli::openai');
+    expect(ids).not.toContain('gh-cli::openai');
   });
 
   it('returns the same instance across re-imports (module-state singleton)', async () => {

--- a/packages/core/src/llm/credential-seeders/gh-cli-seeder.ts
+++ b/packages/core/src/llm/credential-seeders/gh-cli-seeder.ts
@@ -2,10 +2,23 @@
  * Credential seeder for the GitHub CLI (`gh`)
  * (E-CONFIG-AUTH-UNIFY E2a / T9418).
  *
- * Shells out to `gh auth token` and returns the captured token as an
- * `openai` credential — GitHub Copilot's API is OpenAI-compatible and
- * routes through OpenAI's transport in CLEO, so the credential's
- * `provider` is `'openai'` even though the upstream auth source is GitHub.
+ * ## DISABLED — T9594
+ *
+ * This seeder is intentionally NOT registered in `BUILTIN_SEEDERS` until a
+ * real `github-models` provider exists in CLEO.  The token returned by
+ * `gh auth token` is a GitHub Personal Access Token (`ghp_*` / `gho_*`) that
+ * **cannot authenticate against `api.openai.com`**.  Tagging the entry as
+ * `provider:'openai'` created unusable pool entries.
+ *
+ * Re-enable by:
+ *   1. Implementing a `github-models` transport in `packages/core/src/llm/`.
+ *   2. Changing `readonly provider = 'openai'` below to `'github-models'` (or
+ *      whichever id the transport registers under).
+ *   3. Adding `BUILTIN_SEEDERS.register(ghCliSeeder)` back to `./index.ts`.
+ *
+ * The file is kept in tree so the `readGhAuthToken` helper and the
+ * `GhCliSeeder` class are available for the future provider without a
+ * `git revert`.
  *
  * ## Security note
  *
@@ -27,6 +40,7 @@
  *
  * @module llm/credential-seeders/gh-cli-seeder
  * @task T9418
+ * @task T9594 (disabled — see note above)
  * @epic E-CONFIG-AUTH-UNIFY (E2a)
  */
 

--- a/packages/core/src/llm/credential-seeders/index.ts
+++ b/packages/core/src/llm/credential-seeders/index.ts
@@ -36,7 +36,8 @@ import { createClaudeCodeSeeder } from './claude-code-seeder.js';
 import { createCleoPkceSeeder } from './cleo-pkce-seeder.js';
 import { codexCliSeeder } from './codex-cli-seeder.js';
 import { geminiCliSeeder } from './gemini-cli-seeder.js';
-import { ghCliSeeder } from './gh-cli-seeder.js';
+// ghCliSeeder is NOT imported here for registration (T9594 — removed from BUILTIN_SEEDERS);
+// it is still re-exported below for consumers that want to construct it directly.
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -257,7 +258,8 @@ export class SeederRegistry {
  * - env seeders for every provider in ENV_VARS (T9409)
  * - `claude-code` × `anthropic` (T9410)
  * - `cleo-pkce` × `anthropic` (T9411)
- * - `codex-cli`, `gemini-cli`, `gh-cli` external seeders (T9418)
+ * - `codex-cli`, `gemini-cli` external seeders (T9418)
+ * - `gh-cli` seeder is present but NOT registered (T9594 — GitHub PAT cannot auth OpenAI)
  *
  * The singleton is a module-scoped constant (`export const`) rather than a
  * class static so re-importing this module from different entry points
@@ -295,4 +297,8 @@ BUILTIN_SEEDERS.register(createClaudeCodeSeeder());
 BUILTIN_SEEDERS.register(createCleoPkceSeeder());
 BUILTIN_SEEDERS.register(codexCliSeeder);
 BUILTIN_SEEDERS.register(geminiCliSeeder);
-BUILTIN_SEEDERS.register(ghCliSeeder);
+// gh-cli seeder is intentionally NOT registered here (T9594).
+// `gh auth token` returns a GitHub PAT (ghp_*/gho_*) that cannot authenticate
+// against api.openai.com.  The seeder is kept in tree for the future
+// github-models provider — re-enable once that transport exists.
+// See: packages/core/src/llm/credential-seeders/gh-cli-seeder.ts


### PR DESCRIPTION
## Summary

- Removes `ghCliSeeder` from `BUILTIN_SEEDERS.register(...)` in `credential-seeders/index.ts` — `gh auth token` returns a GitHub PAT (`ghp_*`/`gho_*`) that **cannot authenticate against `api.openai.com`**. The seeder was creating unusable pool entries tagged as `provider:'openai'` (T9573 audit bug #11).
- Keeps `gh-cli-seeder.ts` in tree with updated JSDoc marking it disabled until a `github-models` provider exists.
- Adds a one-shot migration in `cleo auth list`: on first run after upgrade, any existing `source=gh-cli` entries are purged from the credential store and the source is suppressed via `addSuppression('openai', 'gh-cli')`.
- Updates `registry.test.ts` to assert `gh-cli::openai` is NOT present in `BUILTIN_SEEDERS`.

## Test plan

- [x] `pnpm biome check` clean on all changed files
- [x] 55 tests pass: `gh-cli-seeder.test.ts` (11), `registry.test.ts` (17), `codex-cli-seeder.test.ts`, `gemini-cli-seeder.test.ts`
- [x] `cleo auth list --json` smoke: no `source=gh-cli` entries in pool

Closes T9594. Refs T9573 audit bug #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)