### PR TITLE
fix(T9593): Studio Vite SSR external @cleocode/cant — unblock /keys + /setup

### DIFF
--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -70,6 +70,10 @@ export default defineConfig({
     // T1693: noExternal ensures Vite bundles @cleocode/* packages by default.
     // The explicit excludes below override that for WASM-dependent packages.
     noExternal: [/^@cleocode\//],
-    external: ['loro-crdt', 'llmtxt'],
+    // T9593: @cleocode/cant ships as CommonJS (no "type":"module"). Vite ESM
+    // SSR runner cannot inline CJS when noExternal forces bundling — every route
+    // crashes via +layout.server.ts → @cleocode/core → @cleocode/caamp →
+    // @cleocode/cant. Mark it external so Node.js resolves it natively.
+    external: ['loro-crdt', 'llmtxt', '@cleocode/cant'],
   },
 });


### PR DESCRIPTION
## Bug

Studio dev server returned HTTP 500 on every route. @cleocode/cant ships as CommonJS (no \`\"type\":\"module\"\` in package.json) but \`noExternal: [/^@cleocode\\//]\` in vite.config.ts forced Vite ESM SSR runner to inline it, crashing the propagation chain: \`+layout.server.ts\` → \`@cleocode/core\` → \`@cleocode/caamp\` → \`@cleocode/cant\`.

## Fix

Added \`'@cleocode/cant'\` to \`ssr.external\` in \`packages/studio/vite.config.ts\` so Node.js resolves it natively rather than Vite trying to inline the CJS module as ESM.

## Test plan

- [x] curl /, /keys, /setup all return HTTP 200 (verified: `/: HTTP 200`, `/keys: HTTP 200`, `/setup: HTTP 200`)
- [x] biome check — vite.config.ts excluded from biome scope per biome.json `includes` (expected)
- [x] pnpm --filter @cleocode/studio test — 48 test files, 662 tests passed

Closes T9593. Refs T9573 audit rollup.