### PR TITLE
fix(T9599): cleo setup LAFS stdout discipline + EOF envelope

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/setup-command.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/setup-command.test.ts
@@ -1,5 +1,5 @@
 /**
- * CLI wiring tests for `cleo setup` (T9421).
+ * CLI wiring tests for `cleo setup` (T9421 + T9599).
  *
  * The core {@link WizardRunner} is exercised in
  * `packages/core/src/setup/__tests__/wizard.test.ts`. These tests only
@@ -12,11 +12,13 @@
  *     threads the right `WizardOptions` through to the wizard runner.
  *   - `buildWizardOptions()` maps every documented CLI flag onto the
  *     `WizardOptions` bag the runner expects.
+ *   - T9599: `StdinClosedError` propagates cleanly out of `runSetup`.
  *
  * We mock `createDefaultWizardRunner` so the test never touches the
  * credential pool, the sentient daemon config, or `SOUL.md`.
  *
  * @task T9421
+ * @task T9599
  * @epic E-CONFIG-AUTH-UNIFY (E3 §5.3 T-E3-2)
  */
 
@@ -103,6 +105,7 @@ vi.mock('@cleocode/core/setup', async () => {
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
+import { StdinClosedError } from '../../lib/readline-wizard-io.js';
 import { buildWizardOptions, runSetup, setupCommand } from '../setup.js';
 
 // ---------------------------------------------------------------------------
@@ -266,5 +269,41 @@ describe('cleo setup — CLI wiring', () => {
       expect(opts.apiKey).toBeUndefined();
       expect(opts.label).toBeUndefined();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T9599 — StdinClosedError propagation from runSetup
+// ---------------------------------------------------------------------------
+
+describe('T9599 — StdinClosedError propagates out of runSetup', () => {
+  it('runSetup re-throws StdinClosedError so the command handler can emit a LAFS envelope', async () => {
+    // A WizardIO that throws StdinClosedError on every prompt — simulates
+    // the ReadlineWizardIO behaviour when stdin closes mid-section.
+    const eofIo: WizardIO = {
+      prompt: () => Promise.reject(new StdinClosedError()),
+      confirm: () => Promise.reject(new StdinClosedError()),
+      select: () => Promise.reject(new StdinClosedError()),
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    };
+
+    // runSetup should let StdinClosedError propagate (not swallow it).
+    await expect(runSetup({}, eofIo)).rejects.toThrow(StdinClosedError);
+  });
+
+  it('StdinClosedError.is() type-guard identifies instances correctly', () => {
+    const err = new StdinClosedError();
+    expect(StdinClosedError.is(err)).toBe(true);
+    expect(StdinClosedError.is(new Error('other'))).toBe(false);
+    expect(StdinClosedError.is(null)).toBe(false);
+    expect(StdinClosedError.is('string')).toBe(false);
+  });
+
+  it('StdinClosedError carries the canonical codeName', () => {
+    const err = new StdinClosedError();
+    expect(err.codeName).toBe('E_SETUP_STDIN_CLOSED');
+    expect(err.message).toBe('stdin closed before section completed');
   });
 });

--- a/packages/cleo/src/cli/commands/setup.ts
+++ b/packages/cleo/src/cli/commands/setup.ts
@@ -38,8 +38,8 @@ import type {
 } from '@cleocode/core/setup';
 import { createDefaultWizardRunner } from '@cleocode/core/setup';
 import { defineCommand } from 'citty';
-import { ReadlineWizardIO } from '../lib/readline-wizard-io.js';
-import { cliOutput } from '../renderers/index.js';
+import { ReadlineWizardIO, StdinClosedError } from '../lib/readline-wizard-io.js';
+import { cliError, cliOutput } from '../renderers/index.js';
 
 // ---------------------------------------------------------------------------
 // Public types — exported so the Studio `/setup` route (T-E3-8) can reuse
@@ -244,6 +244,21 @@ export const setupCommand = defineCommand({
     let result: CleoSetupResult;
     try {
       result = await runSetup(args as Record<string, unknown>, io);
+    } catch (err) {
+      // close() is idempotent — safe to call here even though the finally
+      // block will call it again; ensures readline releases stdin before exit.
+      io.close();
+      // Bug #10 (T9599): stdin closed before the wizard finished — emit a
+      // LAFS error envelope and exit 1 instead of silently exiting 0 with
+      // no JSON output.
+      if (StdinClosedError.is(err)) {
+        cliError(err.message, 1, {
+          name: err.codeName,
+          fix: 'Run cleo setup interactively (with a TTY) or use --non-interactive flags.',
+        });
+        process.exit(1);
+      }
+      throw err;
     } finally {
       io.close();
     }

--- a/packages/cleo/src/cli/lib/__tests__/readline-wizard-io.test.ts
+++ b/packages/cleo/src/cli/lib/__tests__/readline-wizard-io.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for {@link ReadlineWizardIO} (T9599).
+ *
+ * Verifies:
+ *   - info/warn/error all write to stderr, never stdout (bug #1).
+ *   - prompt/confirm/select propagate {@link StdinClosedError} when stdin
+ *     closes before a response is received (bug #10).
+ *
+ * @task T9599
+ */
+
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReadlineWizardIO, StdinClosedError } from '../readline-wizard-io.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a ReadlineWizardIO backed by in-memory streams.
+ *
+ * @param inputLines - Lines (without newline) to push into stdin in order.
+ *   Pass `null` as a sentinel to push EOF immediately after the lines.
+ * @param eofImmediate - If true, end the input stream immediately (before
+ *   any readline question can get an answer).
+ */
+function makeIO(inputLines: string[] = [], eofImmediate = false): ReadlineWizardIO {
+  const input = new PassThrough();
+  const output = new PassThrough(); // discard readline echo
+  const io = new ReadlineWizardIO(input, output);
+  if (eofImmediate) {
+    // Close stdin immediately — the readline close event fires and aborts.
+    setImmediate(() => input.end());
+  } else {
+    for (const line of inputLines) {
+      input.write(`${line}\n`);
+    }
+    input.end();
+  }
+  return io;
+}
+
+// ---------------------------------------------------------------------------
+// Stdout discipline (T9599 bug #1)
+// ---------------------------------------------------------------------------
+
+describe('stdout discipline — info/warn/error route to stderr, never stdout', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('info() writes to stderr only', () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const io = new ReadlineWizardIO(input, output);
+    io.info('hello from info');
+    io.close();
+    input.end();
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('hello from info'));
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('hello from info'));
+  });
+
+  it('warn() writes to stderr only', () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const io = new ReadlineWizardIO(input, output);
+    io.warn('warning message');
+    io.close();
+    input.end();
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('warning message'));
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('warning message'));
+  });
+
+  it('error() writes to stderr only', () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const io = new ReadlineWizardIO(input, output);
+    io.error('error message');
+    io.close();
+    input.end();
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('error message'));
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('error message'));
+  });
+
+  it('select() menu items write to stderr, never stdout', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const io = new ReadlineWizardIO(input, output);
+    // Feed the answer through the input stream
+    setImmediate(() => {
+      input.write('1\n');
+      input.end();
+    });
+    await io.select('Pick one', ['alpha', 'beta'] as const);
+    io.close();
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Pick one'));
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('Pick one'));
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('alpha'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EOF handling (T9599 bug #10)
+// ---------------------------------------------------------------------------
+
+describe('EOF handling — StdinClosedError on stdin close', () => {
+  it('prompt() throws StdinClosedError when stdin closes immediately', async () => {
+    const io = makeIO([], true);
+    await expect(io.prompt('Your name?')).rejects.toThrow(StdinClosedError);
+    io.close();
+  });
+
+  it('confirm() throws StdinClosedError when stdin closes immediately', async () => {
+    const io = makeIO([], true);
+    await expect(io.confirm('Are you sure?', false)).rejects.toThrow(StdinClosedError);
+    io.close();
+  });
+
+  it('select() throws StdinClosedError when stdin closes immediately', async () => {
+    const io = makeIO([], true);
+    await expect(io.select('Pick one', ['a', 'b'] as const)).rejects.toThrow(StdinClosedError);
+    io.close();
+  });
+
+  it('StdinClosedError has the correct codeName', async () => {
+    const io = makeIO([], true);
+    let caughtError: unknown;
+    try {
+      await io.prompt('Name?');
+    } catch (err) {
+      caughtError = err;
+    } finally {
+      io.close();
+    }
+    expect(StdinClosedError.is(caughtError)).toBe(true);
+    expect((caughtError as StdinClosedError).codeName).toBe('E_SETUP_STDIN_CLOSED');
+  });
+
+  it('normal prompt() resolves when stdin provides an answer', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const io = new ReadlineWizardIO(input, output);
+    setImmediate(() => {
+      input.write('Atlas\n');
+      input.end();
+    });
+    const answer = await io.prompt('Name?');
+    io.close();
+    expect(answer).toBe('Atlas');
+  });
+});

--- a/packages/cleo/src/cli/lib/readline-wizard-io.ts
+++ b/packages/cleo/src/cli/lib/readline-wizard-io.ts
@@ -9,13 +9,77 @@
  * command-manifest generator — which scans top-level `commands/*.ts` for
  * `defineCommand` blocks — never tries to register this as a command.
  *
+ * ## Stdout discipline (T9599 — bugs #1 + #10)
+ *
+ * `info`, `warn` and `error` all write to **stderr** so JSON consumers
+ * reading stdout never see informational chatter mixed into the structured
+ * LAFS envelope.  The ONLY bytes that reach stdout are the final LAFS JSON
+ * envelope emitted by the CLI command after the wizard completes.
+ *
+ * ## EOF handling (T9599 — bug #10)
+ *
+ * When stdin closes before a section finishes, `node:readline/promises`'s
+ * `rl.question()` silently abandons its internal callback — the promise
+ * never settles and the process exits 0 with no JSON output.  To surface
+ * this as a real error the implementation uses an {@link AbortController}
+ * whose signal is wired to every `rl.question()` call.  The readline
+ * `'close'` event aborts the controller so in-flight `question()` calls
+ * throw an `AbortError`, which propagates out of the wizard as a typed
+ * {@link StdinClosedError} that `setup.ts` converts to a LAFS error
+ * envelope with `codeName: "E_SETUP_STDIN_CLOSED"`.
+ *
  * @task T9421
+ * @task T9599
  * @epic E-CONFIG-AUTH-UNIFY (E3 §5.3 T-E3-2)
  */
 
 import { stdin as input, stdout as output } from 'node:process';
 import * as readline from 'node:readline/promises';
 import type { WizardIO } from '@cleocode/core/setup';
+
+// ---------------------------------------------------------------------------
+// EOF sentinel
+// ---------------------------------------------------------------------------
+
+/**
+ * Error codeName emitted when stdin closes before a wizard section completes.
+ *
+ * Referenced by both {@link ReadlineWizardIO} and `setup.ts` so the two
+ * sides share the exact string without a runtime dependency on each other.
+ *
+ * @task T9599
+ */
+export const SETUP_STDIN_CLOSED_CODE = 'E_SETUP_STDIN_CLOSED' as const;
+
+/**
+ * Thrown by {@link ReadlineWizardIO} when stdin closes mid-prompt.
+ *
+ * `setup.ts` catches this and converts it to a LAFS error envelope with
+ * `codeName: "E_SETUP_STDIN_CLOSED"` before calling `process.exit(1)`.
+ *
+ * @task T9599
+ */
+export class StdinClosedError extends Error {
+  readonly codeName = SETUP_STDIN_CLOSED_CODE;
+
+  constructor() {
+    super('stdin closed before section completed');
+    this.name = 'StdinClosedError';
+  }
+
+  /**
+   * Type-guard so callers can identify this error without `instanceof`.
+   *
+   * @param err - Value caught from a `catch` block.
+   */
+  static is(err: unknown): err is StdinClosedError {
+    return err instanceof StdinClosedError;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ReadlineWizardIO
+// ---------------------------------------------------------------------------
 
 /**
  * `WizardIO` backed by `node:readline/promises` and the parent process's
@@ -25,14 +89,18 @@ import type { WizardIO } from '@cleocode/core/setup';
  * sequential prompts do not race for control of the TTY. {@link close}
  * MUST be called when the wizard finishes so the process can exit cleanly.
  *
- * `info` writes to stdout (the human channel), `warn` and `error` write
- * to stderr so JSON consumers reading stdout never see informational
- * chatter mixed into their structured envelope.
+ * `info`, `warn` and `error` all write to stderr so JSON consumers reading
+ * stdout never see informational chatter mixed into their structured envelope.
+ * The ONLY bytes that reach stdout are the final LAFS JSON envelope emitted by
+ * the CLI command after the wizard completes.
  *
  * @task T9421
+ * @task T9599
  */
 export class ReadlineWizardIO implements WizardIO {
   private readonly rl: readline.Interface;
+  /** AbortController aborted when stdin closes — surfaced as {@link StdinClosedError}. */
+  private readonly eofController: AbortController;
 
   /**
    * Construct a readline interface bound to the supplied streams.
@@ -41,10 +109,19 @@ export class ReadlineWizardIO implements WizardIO {
    * production use; tests inject in-memory streams.
    *
    * @param inStream - Input stream; defaults to `process.stdin`.
-   * @param outStream - Output stream; defaults to `process.stdout`.
+   * @param outStream - Output stream passed to readline for terminal-echo
+   *   purposes only; informational output goes to stderr.
    */
   constructor(inStream: NodeJS.ReadableStream = input, outStream: NodeJS.WritableStream = output) {
+    this.eofController = new AbortController();
     this.rl = readline.createInterface({ input: inStream, output: outStream });
+    // When stdin closes, abort the controller so all pending question()
+    // calls throw an AbortError that we wrap into StdinClosedError.
+    this.rl.on('close', () => {
+      if (!this.eofController.signal.aborted) {
+        this.eofController.abort(new StdinClosedError());
+      }
+    });
   }
 
   /**
@@ -57,14 +134,48 @@ export class ReadlineWizardIO implements WizardIO {
     this.rl.close();
   }
 
+  /**
+   * Wrap an AbortError thrown by `rl.question()` into a {@link StdinClosedError}.
+   *
+   * `rl.question({ signal })` throws an `AbortError` when the signal fires.
+   * Re-throw it as a typed `StdinClosedError` so setup.ts can detect EOF
+   * without pattern-matching on error names.
+   *
+   * @internal
+   */
+  private rethrowEof(err: unknown): never {
+    // AbortError thrown by readline when our eofController fires.
+    if (
+      err instanceof Error &&
+      (err.name === 'AbortError' || err.name === 'AbortSignal') &&
+      this.eofController.signal.aborted
+    ) {
+      throw new StdinClosedError();
+    }
+    throw err;
+  }
+
   async prompt(question: string): Promise<string> {
-    const answer = await this.rl.question(`${question} `);
-    return answer.trim();
+    try {
+      const answer = await this.rl.question(`${question} `, {
+        signal: this.eofController.signal,
+      });
+      return answer.trim();
+    } catch (err) {
+      this.rethrowEof(err);
+    }
   }
 
   async confirm(question: string, defaultValue?: boolean): Promise<boolean> {
     const hint = defaultValue === undefined ? '[y/n]' : defaultValue ? '[Y/n]' : '[y/N]';
-    const raw = (await this.rl.question(`${question} ${hint} `)).trim().toLowerCase();
+    let raw: string;
+    try {
+      raw = (await this.rl.question(`${question} ${hint} `, { signal: this.eofController.signal }))
+        .trim()
+        .toLowerCase();
+    } catch (err) {
+      this.rethrowEof(err);
+    }
     if (raw === '') {
       if (defaultValue === undefined) {
         // No default provided and operator hit enter — re-prompt once.
@@ -83,37 +194,48 @@ export class ReadlineWizardIO implements WizardIO {
       throw new Error(`ReadlineWizardIO.select: option list is empty for '${question}'`);
     }
     // Print the menu once, then loop until a valid choice arrives. The loop
-    // is bounded by a hard retry cap so a stuck pipe / EOF cannot spin
-    // indefinitely — and by EOF from readline (which surfaces as a
-    // rejected promise) in the interactive case.
-    process.stdout.write(`${question}\n`);
+    // is bounded by a hard retry cap so a stuck pipe cannot spin indefinitely.
+    // All output goes to stderr so it never corrupts the stdout LAFS envelope.
+    process.stderr.write(`${question}\n`);
     options.forEach((opt, idx) => {
-      process.stdout.write(`  ${idx + 1}) ${opt}\n`);
+      process.stderr.write(`  ${idx + 1}) ${opt}\n`);
     });
     const MAX_RETRIES = 10;
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      const raw = (await this.rl.question(`Choose [1-${options.length}]: `)).trim();
+      let raw: string;
+      try {
+        raw = (
+          await this.rl.question(`Choose [1-${options.length}]: `, {
+            signal: this.eofController.signal,
+          })
+        ).trim();
+      } catch (err) {
+        this.rethrowEof(err);
+      }
       // Allow both numeric index and verbatim option name.
       if (/^\d+$/.test(raw)) {
         const idx = Number.parseInt(raw, 10) - 1;
         if (idx >= 0 && idx < options.length) return options[idx] as T;
       }
       if (options.includes(raw as T)) return raw as T;
-      process.stdout.write(`Invalid choice '${raw}'. Try again.\n`);
+      process.stderr.write(`Invalid choice '${raw}'. Try again.\n`);
     }
     throw new Error(
       `ReadlineWizardIO.select: gave up after ${MAX_RETRIES} invalid responses for '${question}'`,
     );
   }
 
+  /** Informational message — goes to stderr, never stdout. */
   info(message: string): void {
-    process.stdout.write(`${message}\n`);
+    process.stderr.write(`${message}\n`);
   }
 
+  /** Non-fatal warning — goes to stderr. */
   warn(message: string): void {
     process.stderr.write(`${message}\n`);
   }
 
+  /** Error message — goes to stderr. */
   error(message: string): void {
     process.stderr.write(`${message}\n`);
   }

--- a/packages/core/src/setup/wizard.ts
+++ b/packages/core/src/setup/wizard.ts
@@ -148,7 +148,7 @@ export interface WizardIO {
   confirm(question: string, defaultValue?: boolean): Promise<boolean>;
   /** Single-choice selection across a finite option list. */
   select<T extends string>(question: string, options: readonly T[]): Promise<T>;
-  /** Informational message (goes to stdout in the CLI). */
+  /** Informational message (goes to stderr in the CLI — never to stdout). */
   info(message: string): void;
   /** Non-fatal warning (goes to stderr in the CLI). */
   warn(message: string): void;


### PR DESCRIPTION
## Summary

- Routes all `io.info()` and `select()` menu output to stderr (was stdout), fixing JSON parse errors when piping `cleo setup | jq`
- Adds `AbortController`-based EOF detection to `ReadlineWizardIO` so stdin close emits a typed `StdinClosedError` instead of hanging silently
- `setup.ts` catches `StdinClosedError` and emits a valid LAFS error envelope with `codeName: E_SETUP_STDIN_CLOSED` then exits 1

Closes T9599. Refs T9573 audit bugs #1 + #10.

## Changed files

- `packages/cleo/src/cli/lib/readline-wizard-io.ts` — stdout → stderr for info/select, AbortController EOF wiring, new `StdinClosedError` class
- `packages/cleo/src/cli/commands/setup.ts` — catch `StdinClosedError`, emit LAFS error envelope
- `packages/core/src/setup/wizard.ts` — doc comment fix (info goes to stderr)
- `packages/cleo/src/cli/lib/__tests__/readline-wizard-io.test.ts` — **new** (9 tests: stdout discipline + EOF)
- `packages/cleo/src/cli/commands/__tests__/setup-command.test.ts` — 3 new T9599 tests for `StdinClosedError` propagation

## Test plan

- [ ] `cleo setup --section identity --non-interactive --agent-name X | jq .success` returns `true` cleanly (no non-JSON prefix)
- [ ] `echo "" | cleo setup --section identity 2>/dev/null | jq -c .error.codeName` prints `"E_SETUP_STDIN_CLOSED"`
- [ ] All 9 `readline-wizard-io.test.ts` tests pass
- [ ] All pre-existing `setup-command.test.ts` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)