### PR TITLE
fix(T9580): 3 CLI dispatch bugs caught in v2026.5.79 real-test

### DIFF
--- a/packages/cleo/src/cli/commands/provenance.ts
+++ b/packages/cleo/src/cli/commands/provenance.ts
@@ -75,7 +75,7 @@ const backfillCommand = defineCommand({
     await dispatchFromCli(
       'mutate',
       'provenance',
-      'provenance.backfill',
+      'backfill',
       {
         since: args.since,
         forceOverwrite: args['force-overwrite'] === true,
@@ -131,7 +131,7 @@ const verifyCommand = defineCommand({
     await dispatchFromCli(
       'query',
       'provenance',
-      'provenance.verify',
+      'verify',
       {
         ...(version ? { version } : {}),
         all,

--- a/packages/cleo/src/cli/commands/release.ts
+++ b/packages/cleo/src/cli/commands/release.ts
@@ -99,7 +99,7 @@ const shipCommand = defineCommand({
     await dispatchFromCli(
       'mutate',
       'release',
-      'release.plan',
+      'plan',
       {
         version: args.version,
         epicId: args.epic,
@@ -116,7 +116,7 @@ const shipCommand = defineCommand({
     await dispatchFromCli(
       'mutate',
       'release',
-      'release.open',
+      'open',
       {
         version: args.version,
       },
@@ -387,7 +387,7 @@ const planCommand = defineCommand({
     await dispatchFromCli(
       'mutate',
       'release',
-      'release.plan',
+      'plan',
       {
         version: args.version,
         epicId: args.epic,
@@ -440,7 +440,7 @@ const openCommand = defineCommand({
     await dispatchFromCli(
       'mutate',
       'release',
-      'release.open',
+      'open',
       {
         version: args.version,
         workflow: args.workflow as string | undefined,

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -7054,12 +7054,42 @@ export const OPERATIONS: OperationDef[] = [
     sessionRequired: false,
     requiredParams: ['version', 'epicId'],
     params: [
-      { name: 'version', type: 'string', required: true, description: 'Candidate version (e.g. v2026.5.80)' },
-      { name: 'epicId', type: 'string', required: true, description: 'Epic task ID whose children scope the release (R-303)' },
-      { name: 'scheme', type: 'string', required: false, description: 'Versioning scheme: calver | semver | calver-suffix' },
-      { name: 'channel', type: 'string', required: false, description: 'Release channel: latest | beta | alpha | rc' },
-      { name: 'hotfix', type: 'boolean', required: false, description: 'Mark plan as release_kind=hotfix' },
-      { name: 'dryRun', type: 'boolean', required: false, description: 'Compute the plan without writing file or DB row' },
+      {
+        name: 'version',
+        type: 'string',
+        required: true,
+        description: 'Candidate version (e.g. v2026.5.80)',
+      },
+      {
+        name: 'epicId',
+        type: 'string',
+        required: true,
+        description: 'Epic task ID whose children scope the release (R-303)',
+      },
+      {
+        name: 'scheme',
+        type: 'string',
+        required: false,
+        description: 'Versioning scheme: calver | semver | calver-suffix',
+      },
+      {
+        name: 'channel',
+        type: 'string',
+        required: false,
+        description: 'Release channel: latest | beta | alpha | rc',
+      },
+      {
+        name: 'hotfix',
+        type: 'boolean',
+        required: false,
+        description: 'Mark plan as release_kind=hotfix',
+      },
+      {
+        name: 'dryRun',
+        type: 'boolean',
+        required: false,
+        description: 'Compute the plan without writing file or DB row',
+      },
     ] satisfies ParamDef[],
   },
 
@@ -7075,10 +7105,30 @@ export const OPERATIONS: OperationDef[] = [
     sessionRequired: false,
     requiredParams: ['version'],
     params: [
-      { name: 'version', type: 'string', required: true, description: 'Release version whose plan file lives at .cleo/release/<version>.plan.json' },
-      { name: 'workflow', type: 'string', required: false, description: 'Workflow file name (default: release-prepare.yml)' },
-      { name: 'watch', type: 'boolean', required: false, description: 'Poll gh run watch until terminal state' },
-      { name: 'commitPlan', type: 'boolean', required: false, description: 'Commit plan file before dispatching' },
+      {
+        name: 'version',
+        type: 'string',
+        required: true,
+        description: 'Release version whose plan file lives at .cleo/release/<version>.plan.json',
+      },
+      {
+        name: 'workflow',
+        type: 'string',
+        required: false,
+        description: 'Workflow file name (default: release-prepare.yml)',
+      },
+      {
+        name: 'watch',
+        type: 'boolean',
+        required: false,
+        description: 'Poll gh run watch until terminal state',
+      },
+      {
+        name: 'commitPlan',
+        type: 'boolean',
+        required: false,
+        description: 'Commit plan file before dispatching',
+      },
     ] satisfies ParamDef[],
   },
 
@@ -7513,8 +7563,18 @@ export const OPERATIONS: OperationDef[] = [
     sessionRequired: false,
     requiredParams: [],
     params: [
-      { name: 'statusFilter', type: 'string', required: false, description: 'Filter to one or more status categories (comma-separated)' },
-      { name: 'staleDays', type: 'number', required: false, description: 'Days of inactivity before flagging stale (default 7)' },
+      {
+        name: 'statusFilter',
+        type: 'string',
+        required: false,
+        description: 'Filter to one or more status categories (comma-separated)',
+      },
+      {
+        name: 'staleDays',
+        type: 'number',
+        required: false,
+        description: 'Days of inactivity before flagging stale (default 7)',
+      },
     ] satisfies ParamDef[],
   },
   {
@@ -7528,8 +7588,18 @@ export const OPERATIONS: OperationDef[] = [
     sessionRequired: false,
     requiredParams: [],
     params: [
-      { name: 'paths', type: 'array', required: false, description: 'Pre-confirmed paths to remove' },
-      { name: 'dryRun', type: 'boolean', required: false, description: 'Enumerate orphans without acting' },
+      {
+        name: 'paths',
+        type: 'array',
+        required: false,
+        description: 'Pre-confirmed paths to remove',
+      },
+      {
+        name: 'dryRun',
+        type: 'boolean',
+        required: false,
+        description: 'Enumerate orphans without acting',
+      },
     ] satisfies ParamDef[],
   },
   {
@@ -7543,7 +7613,12 @@ export const OPERATIONS: OperationDef[] = [
     sessionRequired: false,
     requiredParams: ['taskId'],
     params: [
-      { name: 'taskId', type: 'string', required: true, description: 'Task ID whose worktree (branch task/T<id>) to unlock' },
+      {
+        name: 'taskId',
+        type: 'string',
+        required: true,
+        description: 'Task ID whose worktree (branch task/T<id>) to unlock',
+      },
     ] satisfies ParamDef[],
   },
 ];

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -7042,6 +7042,46 @@ export const OPERATIONS: OperationDef[] = [
   // `release.reconcile`, plus `cleo verify <task> --gate X --evidence …`
   // for per-task gate verification (R-422 / ADR-051).
 
+  // release mutate: plan (T9525 / SPEC-T9345 §4.2 — Phase 1 plan verb)
+  {
+    gateway: 'mutate',
+    domain: 'release',
+    operation: 'plan',
+    description:
+      'release.plan (mutate) — build canonical Release Plan envelope, write .cleo/release/<version>.plan.json, INSERT/UPDATE releases row status=planned (T9525 / SPEC-T9345 §4.2).',
+    tier: 1,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: ['version', 'epicId'],
+    params: [
+      { name: 'version', type: 'string', required: true, description: 'Candidate version (e.g. v2026.5.80)' },
+      { name: 'epicId', type: 'string', required: true, description: 'Epic task ID whose children scope the release (R-303)' },
+      { name: 'scheme', type: 'string', required: false, description: 'Versioning scheme: calver | semver | calver-suffix' },
+      { name: 'channel', type: 'string', required: false, description: 'Release channel: latest | beta | alpha | rc' },
+      { name: 'hotfix', type: 'boolean', required: false, description: 'Mark plan as release_kind=hotfix' },
+      { name: 'dryRun', type: 'boolean', required: false, description: 'Compute the plan without writing file or DB row' },
+    ] satisfies ParamDef[],
+  },
+
+  // release mutate: open (T9530 / SPEC-T9345 §4.3 — Phase 3 open verb)
+  {
+    gateway: 'mutate',
+    domain: 'release',
+    operation: 'open',
+    description:
+      'release.open (mutate) — dispatch release-prepare.yml via gh workflow run, UPDATE releases.status to pr-opened (T9530 / SPEC-T9345 §4.3).',
+    tier: 1,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: ['version'],
+    params: [
+      { name: 'version', type: 'string', required: true, description: 'Release version whose plan file lives at .cleo/release/<version>.plan.json' },
+      { name: 'workflow', type: 'string', required: false, description: 'Workflow file name (default: release-prepare.yml)' },
+      { name: 'watch', type: 'boolean', required: false, description: 'Poll gh run watch until terminal state' },
+      { name: 'commitPlan', type: 'boolean', required: false, description: 'Commit plan file before dispatching' },
+    ] satisfies ParamDef[],
+  },
+
   // release mutate: reconcile (T9526 / SPEC-T9345 §4.4 — v2 reconcile verb)
   {
     gateway: 'mutate',
@@ -7456,6 +7496,54 @@ export const OPERATIONS: OperationDef[] = [
         required: false,
         description: 'Include the freshly rendered YAML in the response (for diff display)',
       },
+    ] satisfies ParamDef[],
+  },
+
+  // ---------------------------------------------------------------------------
+  // Worktree domain — `cleo worktree list/prune/force-unlock` (T9546/T9547)
+  // ---------------------------------------------------------------------------
+  {
+    gateway: 'query',
+    domain: 'worktree',
+    operation: 'list',
+    description:
+      'worktree.list (query) — enumerate git worktrees with 5 status categories (active|stale|merged|orphan|locked). Reads tasks.db for owning-task status. 60s git timeout (T9546).',
+    tier: 1,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: [],
+    params: [
+      { name: 'statusFilter', type: 'string', required: false, description: 'Filter to one or more status categories (comma-separated)' },
+      { name: 'staleDays', type: 'number', required: false, description: 'Days of inactivity before flagging stale (default 7)' },
+    ] satisfies ParamDef[],
+  },
+  {
+    gateway: 'mutate',
+    domain: 'worktree',
+    operation: 'prune',
+    description:
+      'worktree.prune (mutate) — remove orphaned worktrees with per-orphan confirmation. Audit-logs to .cleo/audit/worktree-lifecycle.jsonl (T9547).',
+    tier: 1,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: [],
+    params: [
+      { name: 'paths', type: 'array', required: false, description: 'Pre-confirmed paths to remove' },
+      { name: 'dryRun', type: 'boolean', required: false, description: 'Enumerate orphans without acting' },
+    ] satisfies ParamDef[],
+  },
+  {
+    gateway: 'mutate',
+    domain: 'worktree',
+    operation: 'forceUnlock',
+    description:
+      'worktree.forceUnlock (mutate) — remove .git/index.lock and run git worktree unlock for a task. Warns on uncommitted changes (T9547).',
+    tier: 1,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: ['taskId'],
+    params: [
+      { name: 'taskId', type: 'string', required: true, description: 'Task ID whose worktree (branch task/T<id>) to unlock' },
     ] satisfies ParamDef[],
   },
 ];

--- a/packages/cleo/src/dispatch/types.ts
+++ b/packages/cleo/src/dispatch/types.ts
@@ -79,6 +79,8 @@ export const CANONICAL_DOMAINS = [
   // T9536: `cleo upgrade workflows` — re-render release-pipeline workflow
   // templates + 3-way merge with `.workflow-overrides.yml`.
   'upgrade',
+  // T9546/T9547: 'cleo worktree list/prune/force-unlock' — worktree lifecycle.
+  'worktree',
 ] as const;
 
 export type CanonicalDomain = (typeof CANONICAL_DOMAINS)[number];


### PR DESCRIPTION
## Real-test audit of v2026.5.79 found 3 systemic dispatch bugs

The user requested REAL end-to-end testing of the just-shipped IVTR system (T9580 audit). Smoke test of all 6 new CLI verbs showed **5 of 6 returning E_INVALID_OPERATION**:

| Command | Error |
|---|---|
| `cleo release plan` | `mutate:release.release.plan` (double-prefix) |
| `cleo release open` | `mutate:release.release.open` (double-prefix) |
| `cleo provenance backfill` | `mutate:provenance.provenance.backfill` (double-prefix) |
| `cleo provenance verify` | `query:provenance.provenance.verify` (double-prefix) |
| `cleo worktree list` | `query:worktree.list` (domain missing from CANONICAL_DOMAINS) |
| `cleo release reconcile` | ✅ worked |

## Root causes
1. CLI handlers passed full dotted name `'release.plan'` as the operation arg to `dispatchFromCli`, while domain is a separate arg
2. Registry never declared `release.plan`/`release.open` operations (only `release.reconcile` was registered in T9526)
3. `'worktree'` missing from `CANONICAL_DOMAINS` in types.ts despite `WorktreeHandler` being registered

## Fix
- release.ts: pass bare `'plan'` / `'open'` (4 call sites)
- provenance.ts: pass bare `'backfill'` / `'verify'` (2 call sites)
- types.ts: add `'worktree'` to CANONICAL_DOMAINS
- registry.ts: add `release.plan`, `release.open`, `worktree.{list,prune,forceUnlock}` entries

## Verified locally (all 5 verbs return real LAFS envelopes)

```
cleo release plan v2026.5.80 --epic T9580 --dry-run
  → E_EVIDENCE_INSUFFICIENT (T9581-T9584 missing evidence atoms)
cleo release open v2026.5.80
  → E_PLAN_NOT_FOUND (needs plan first)
cleo worktree list --json
  → Returns 60+ worktrees with active|stale|merged|orphan|locked
cleo provenance verify v2026.5.79
  → E_PROVENANCE_INCOMPLETE (release row not reconciled — expected)
cleo release reconcile v2026.5.79
  → E_PLAN_NOT_FOUND (needs plan first)
```

Closes the dispatch surface of T9580 audit. The deeper project-root resolution work (T9581-T9584) remains pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)