### PR TITLE
fix(T9598): cleo auth consent — enable/disable + revoke purges pool

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/auth-command.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/auth-command.test.ts
@@ -129,10 +129,15 @@ describe('cleo auth — CLI wiring', () => {
     process.env['CLEO_FORMAT'] = 'json';
   });
 
-  it('exposes list + remove + migrate-project-secrets subcommands', async () => {
-    // T9417 added migrate-project-secrets to the auth command group.
+  it('exposes consent + list + remove + migrate-project-secrets subcommands', async () => {
+    // T9417 added migrate-project-secrets; T9598 added consent.
     const subs = await getAuthSubs();
-    expect(Object.keys(subs).sort()).toEqual(['list', 'migrate-project-secrets', 'remove']);
+    expect(Object.keys(subs).sort()).toEqual([
+      'consent',
+      'list',
+      'migrate-project-secrets',
+      'remove',
+    ]);
   });
 
   it('list — seeds, lists, filters by --provider, emits LAFS envelope', async () => {

--- a/packages/cleo/src/cli/commands/__tests__/auth-consent.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/auth-consent.test.ts
@@ -1,0 +1,530 @@
+/**
+ * Unit tests for `cleo auth consent` (T9598).
+ *
+ * Verifies:
+ *   - `auth` exposes `consent` as a subcommand.
+ *   - `--status` reads the consent flag and suppression state.
+ *   - `--enable-claude-code` writes true to global config and removes suppression.
+ *   - `--disable-claude-code` writes false to global config, adds suppression,
+ *     and purges all source:claude-code pool entries (bug #6 fix).
+ *   - No-flag invocation exits with E_INVALID_INPUT.
+ *   - Mutually-exclusive flags exit with E_INVALID_INPUT.
+ *   - `auth list` emits a hint when ~/.claude/.credentials.json exists but
+ *     no claude-code entries are present in the pool.
+ *
+ * All external dependencies (config, credential-removal, credentials-store)
+ * are mocked so no real files are read or written.
+ *
+ * @task T9598
+ * @epic T9587
+ */
+
+import type { CommandDef } from 'citty';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared BEFORE importing the command modules.
+// ---------------------------------------------------------------------------
+
+const mockGetConfigValue = vi.fn();
+const mockSetConfigValue = vi.fn().mockResolvedValue({ key: '', value: false, scope: 'global' });
+
+vi.mock('@cleocode/core/config.js', () => ({
+  getConfigValue: (...a: unknown[]) => mockGetConfigValue(...a),
+  setConfigValue: (...a: unknown[]) => mockSetConfigValue(...a),
+}));
+
+const mockIsSuppressed = vi.fn().mockReturnValue(false);
+const mockAddSuppression = vi.fn();
+const mockRemoveSuppression = vi.fn().mockReturnValue(false);
+
+vi.mock('@cleocode/core/llm/credential-removal.js', () => ({
+  REMOVAL_REGISTRY: { find: vi.fn() },
+  addSuppression: (...a: unknown[]) => mockAddSuppression(...a),
+  removeSuppression: (...a: unknown[]) => mockRemoveSuppression(...a),
+  isSuppressed: (...a: unknown[]) => mockIsSuppressed(...a),
+}));
+
+const mockListCredentials = vi.fn().mockResolvedValue([]);
+const mockRemoveCredential = vi.fn().mockResolvedValue(false);
+
+vi.mock('@cleocode/core/llm/credentials-store.js', () => ({
+  listCredentials: (...a: unknown[]) => mockListCredentials(...a),
+  removeCredential: (...a: unknown[]) => mockRemoveCredential(...a),
+}));
+
+const mockSeed = vi.fn().mockResolvedValue({ added: 0, failed: 0, skipped: 0 });
+const mockPoolList = vi.fn().mockResolvedValue([]);
+
+vi.mock('@cleocode/core/llm/credential-pool.js', () => ({
+  getCredentialPool: () => ({ seed: mockSeed, list: mockPoolList }),
+}));
+
+// Selective existsSync mock for the list hint tests.
+// The mock routes calls for `~/.claude/.credentials.json` to a controllable
+// flag (mockClaudeCredsExists) while passing every other path through to the
+// real implementation so CLEO internals (session files, config paths, etc.)
+// are unaffected.
+let mockClaudeCredsExists = false;
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn((p: unknown) => {
+      if (typeof p === 'string' && p.endsWith('.claude/.credentials.json')) {
+        return mockClaudeCredsExists;
+      }
+      return actual.existsSync(p as Parameters<typeof actual.existsSync>[0]);
+    }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { authCommand } from '../auth.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getAuthSubs(): Promise<Record<string, CommandDef>> {
+  const resolved =
+    typeof authCommand.subCommands === 'function'
+      ? await authCommand.subCommands()
+      : authCommand.subCommands;
+  return (resolved ?? {}) as Record<string, CommandDef>;
+}
+
+async function runSub(
+  cmd: CommandDef,
+  args: Record<string, unknown>,
+  rawArgs: string[] = [],
+): Promise<void> {
+  const resolved = typeof cmd === 'function' ? await cmd() : cmd;
+  const runFn = (resolved as { run?: (ctx: unknown) => Promise<void> }).run;
+  if (!runFn) throw new Error('Subcommand has no run function');
+  await runFn({ args, rawArgs, cmd: resolved });
+}
+
+function captureStdout(): { restore: () => void; lines: string[] } {
+  const orig = process.stdout.write.bind(process.stdout);
+  const lines: string[] = [];
+  process.stdout.write = ((s: unknown) => {
+    lines.push(String(s));
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    lines,
+    restore: () => {
+      process.stdout.write = orig;
+    },
+  };
+}
+
+function lastEnvelope(lines: string[]): Record<string, unknown> {
+  return JSON.parse(lines[lines.length - 1]!);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('cleo auth consent — subcommand registration', () => {
+  it('auth command exposes consent subcommand', async () => {
+    const subs = await getAuthSubs();
+    expect(Object.keys(subs)).toContain('consent');
+  });
+});
+
+describe('cleo auth consent --status', () => {
+  beforeEach(() => {
+    process.env['CLEO_FORMAT'] = 'json';
+    mockGetConfigValue.mockReset();
+    mockIsSuppressed.mockReset().mockReturnValue(false);
+  });
+
+  it('reports consent enabled=true and suppressed=false', async () => {
+    mockGetConfigValue.mockResolvedValue({ value: true });
+    mockIsSuppressed.mockReturnValue(false);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['consent']!, { status: true });
+    } finally {
+      stdout.restore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    expect(env.success).toBe(true);
+    expect(env.meta.operation).toBe('auth.consent.status');
+    const gates = (
+      env.data as { gates: Array<{ gate: string; enabled: boolean; suppressed: boolean }> }
+    ).gates;
+    expect(gates).toHaveLength(1);
+    expect(gates[0]).toMatchObject({
+      gate: 'claudeCode',
+      configKey: 'auth.claudeCodeConsentGiven',
+      enabled: true,
+      suppressed: false,
+    });
+  });
+
+  it('reports consent enabled=false and suppressed=true', async () => {
+    mockGetConfigValue.mockResolvedValue({ value: false });
+    mockIsSuppressed.mockReturnValue(true);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['consent']!, { status: true });
+    } finally {
+      stdout.restore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    const gates = (env.data as { gates: Array<{ enabled: boolean; suppressed: boolean }> }).gates;
+    expect(gates[0]).toMatchObject({ enabled: false, suppressed: true });
+  });
+
+  it('treats undefined config value as enabled=false', async () => {
+    mockGetConfigValue.mockResolvedValue({ value: undefined });
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['consent']!, { status: true });
+    } finally {
+      stdout.restore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    const gates = (env.data as { gates: Array<{ enabled: boolean }> }).gates;
+    expect(gates[0]!.enabled).toBe(false);
+  });
+});
+
+describe('cleo auth consent --enable-claude-code', () => {
+  beforeEach(() => {
+    process.env['CLEO_FORMAT'] = 'json';
+    mockSetConfigValue.mockReset().mockResolvedValue({ key: '', value: true, scope: 'global' });
+    mockRemoveSuppression.mockReset().mockReturnValue(false);
+  });
+
+  it('writes true to global config and removes suppression', async () => {
+    mockRemoveSuppression.mockReturnValue(true); // was suppressed
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['consent']!, { 'enable-claude-code': true });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(mockSetConfigValue).toHaveBeenCalledWith(
+      'auth.claudeCodeConsentGiven',
+      true,
+      undefined,
+      { global: true },
+    );
+    expect(mockRemoveSuppression).toHaveBeenCalledWith('anthropic', 'claude-code');
+
+    const env = lastEnvelope(stdout.lines);
+    expect(env.success).toBe(true);
+    expect(env.meta.operation).toBe('auth.consent.enable');
+    const data = env.data as {
+      action: string;
+      value: boolean;
+      suppressionChanged: boolean;
+      purgedCount: number;
+    };
+    expect(data.action).toBe('enabled');
+    expect(data.value).toBe(true);
+    expect(data.suppressionChanged).toBe(true);
+    expect(data.purgedCount).toBe(0);
+  });
+
+  it('suppressionChanged=false when there was no suppression to remove', async () => {
+    mockRemoveSuppression.mockReturnValue(false);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['consent']!, { 'enable-claude-code': true });
+    } finally {
+      stdout.restore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    const data = env.data as { suppressionChanged: boolean };
+    expect(data.suppressionChanged).toBe(false);
+  });
+
+  it('does NOT purge pool entries on enable', async () => {
+    mockListCredentials.mockResolvedValue([
+      {
+        provider: 'anthropic',
+        label: 'claude-code',
+        source: 'claude-code',
+        authType: 'oauth',
+        accessToken: 'token',
+        priority: 100,
+      },
+    ]);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['consent']!, { 'enable-claude-code': true });
+    } finally {
+      stdout.restore();
+    }
+
+    // removeCredential must NOT be called on enable.
+    expect(mockRemoveCredential).not.toHaveBeenCalled();
+  });
+});
+
+describe('cleo auth consent --disable-claude-code', () => {
+  beforeEach(() => {
+    process.env['CLEO_FORMAT'] = 'json';
+    mockSetConfigValue.mockReset().mockResolvedValue({ key: '', value: false, scope: 'global' });
+    mockAddSuppression.mockReset();
+    mockIsSuppressed.mockReset().mockReturnValue(false);
+    mockListCredentials.mockReset().mockResolvedValue([]);
+    mockRemoveCredential.mockReset().mockResolvedValue(true);
+  });
+
+  it('writes false to global config and adds suppression', async () => {
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['consent']!, { 'disable-claude-code': true });
+    } finally {
+      stdout.restore();
+    }
+
+    expect(mockSetConfigValue).toHaveBeenCalledWith(
+      'auth.claudeCodeConsentGiven',
+      false,
+      undefined,
+      { global: true },
+    );
+    expect(mockAddSuppression).toHaveBeenCalledWith('anthropic', 'claude-code');
+
+    const env = lastEnvelope(stdout.lines);
+    expect(env.success).toBe(true);
+    expect(env.meta.operation).toBe('auth.consent.disable');
+    const data = env.data as { action: string; value: boolean };
+    expect(data.action).toBe('disabled');
+    expect(data.value).toBe(false);
+  });
+
+  it('purges all source:claude-code pool entries on disable (bug #6 fix)', async () => {
+    mockListCredentials.mockResolvedValue([
+      {
+        provider: 'anthropic',
+        label: 'claude-code',
+        source: 'claude-code',
+        authType: 'oauth',
+        accessToken: 'tok1',
+        priority: 100,
+      },
+      {
+        provider: 'anthropic',
+        label: 'claude-code-alt',
+        source: 'claude-code',
+        authType: 'oauth',
+        accessToken: 'tok2',
+        priority: 90,
+      },
+      {
+        provider: 'openai',
+        label: 'manual-key',
+        source: 'manual',
+        authType: 'api_key',
+        accessToken: 'key',
+        priority: 50,
+      },
+    ]);
+    mockRemoveCredential.mockResolvedValue(true);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['consent']!, { 'disable-claude-code': true });
+    } finally {
+      stdout.restore();
+    }
+
+    // Only the two claude-code entries are purged, not the manual one.
+    expect(mockRemoveCredential).toHaveBeenCalledTimes(2);
+    expect(mockRemoveCredential).toHaveBeenCalledWith('anthropic', 'claude-code');
+    expect(mockRemoveCredential).toHaveBeenCalledWith('anthropic', 'claude-code-alt');
+    expect(mockRemoveCredential).not.toHaveBeenCalledWith('openai', 'manual-key');
+
+    const env = lastEnvelope(stdout.lines);
+    const data = env.data as { purgedCount: number };
+    expect(data.purgedCount).toBe(2);
+  });
+
+  it('purgedCount=0 when no claude-code entries exist in pool', async () => {
+    mockListCredentials.mockResolvedValue([]);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['consent']!, { 'disable-claude-code': true });
+    } finally {
+      stdout.restore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    const data = env.data as { purgedCount: number };
+    expect(data.purgedCount).toBe(0);
+  });
+
+  it('suppressionChanged=false when already suppressed before disable', async () => {
+    mockIsSuppressed.mockReturnValue(true); // already suppressed
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['consent']!, { 'disable-claude-code': true });
+    } finally {
+      stdout.restore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    const data = env.data as { suppressionChanged: boolean };
+    expect(data.suppressionChanged).toBe(false);
+  });
+});
+
+describe('cleo auth consent — invalid invocations', () => {
+  beforeEach(() => {
+    process.env['CLEO_FORMAT'] = 'json';
+  });
+
+  it('exits 6 with E_INVALID_INPUT when no flag supplied', async () => {
+    const stdout = captureStdout();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__EXIT_${code}__`);
+    }) as never);
+    const subs = await getAuthSubs();
+    try {
+      await expect(runSub(subs['consent']!, {})).rejects.toThrow('__EXIT_6__');
+    } finally {
+      stdout.restore();
+      exitSpy.mockRestore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    expect(env.success).toBe(false);
+    expect((env.error as { codeName?: string }).codeName).toBe('E_INVALID_INPUT');
+  });
+
+  it('exits 6 with E_INVALID_INPUT when both enable and disable flags supplied', async () => {
+    const stdout = captureStdout();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__EXIT_${code}__`);
+    }) as never);
+    const subs = await getAuthSubs();
+    try {
+      await expect(
+        runSub(subs['consent']!, { 'enable-claude-code': true, 'disable-claude-code': true }),
+      ).rejects.toThrow('__EXIT_6__');
+    } finally {
+      stdout.restore();
+      exitSpy.mockRestore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    expect(env.success).toBe(false);
+    expect((env.error as { codeName?: string }).codeName).toBe('E_INVALID_INPUT');
+  });
+});
+
+describe('cleo auth list — consent hint', () => {
+  beforeEach(() => {
+    process.env['CLEO_FORMAT'] = 'json';
+    mockSeed.mockClear();
+    mockPoolList.mockReset();
+    mockClaudeCredsExists = false;
+  });
+
+  it('emits hint when ~/.claude/.credentials.json exists and no claude-code entry in pool', async () => {
+    mockClaudeCredsExists = true;
+    mockPoolList.mockResolvedValue([
+      {
+        provider: 'anthropic',
+        label: 'manual-key',
+        source: 'manual',
+        authType: 'api_key',
+        accessToken: 'key',
+        priority: 50,
+      },
+    ]);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['list']!, {});
+    } finally {
+      stdout.restore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    expect(env.success).toBe(true);
+    const data = env.data as { hint?: string };
+    expect(data.hint).toBeDefined();
+    expect(data.hint).toContain('cleo auth consent --enable-claude-code');
+  });
+
+  it('does not emit hint when claude-code entry is already in pool', async () => {
+    mockClaudeCredsExists = true;
+    mockPoolList.mockResolvedValue([
+      {
+        provider: 'anthropic',
+        label: 'claude-code',
+        source: 'claude-code',
+        authType: 'oauth',
+        accessToken: 'token',
+        priority: 100,
+      },
+    ]);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['list']!, {});
+    } finally {
+      stdout.restore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    const data = env.data as { hint?: string };
+    expect(data.hint).toBeUndefined();
+  });
+
+  it('does not emit hint when ~/.claude/.credentials.json does not exist', async () => {
+    mockClaudeCredsExists = false;
+    mockPoolList.mockResolvedValue([]);
+
+    const stdout = captureStdout();
+    const subs = await getAuthSubs();
+    try {
+      await runSub(subs['list']!, {});
+    } finally {
+      stdout.restore();
+    }
+
+    const env = lastEnvelope(stdout.lines);
+    const data = env.data as { hint?: string };
+    expect(data.hint).toBeUndefined();
+  });
+});

--- a/packages/cleo/src/cli/commands/auth.ts
+++ b/packages/cleo/src/cli/commands/auth.ts
@@ -16,6 +16,7 @@
 
 import { defineCommand, showUsage } from 'citty';
 import {
+  authConsentCommand,
   authListCommand,
   authMigrateProjectSecretsCommand,
   authRemoveCommand,
@@ -25,6 +26,7 @@ import {
  * `cleo auth` — unified credential surface.
  *
  * @task T9416
+ * @task T9598
  */
 export const authCommand = defineCommand({
   meta: {
@@ -33,6 +35,7 @@ export const authCommand = defineCommand({
       'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
   },
   subCommands: {
+    consent: authConsentCommand,
     list: authListCommand,
     remove: authRemoveCommand,
     'migrate-project-secrets': authMigrateProjectSecretsCommand,

--- a/packages/cleo/src/cli/commands/auth/consent.ts
+++ b/packages/cleo/src/cli/commands/auth/consent.ts
@@ -1,0 +1,260 @@
+/**
+ * `cleo auth consent` — manage consent gates for external credential sources.
+ *
+ * Implements T9573 audit bug #5 + #6:
+ *   - Bug #5: `auth.claudeCodeConsentGiven` had no CLI surface to flip it.
+ *   - Bug #6: revoking consent did not purge already-persisted tokens from the pool.
+ *
+ * Subcommand flags:
+ *   --enable-claude-code   Set `auth.claudeCodeConsentGiven=true` in global config
+ *                          and remove any `claude-code` suppression entry so the
+ *                          seeder runs on the next pool seed.
+ *   --disable-claude-code  Set `auth.claudeCodeConsentGiven=false` in global config,
+ *                          add `claude-code` suppression, and purge every
+ *                          `source:claude-code` entry from the pool.
+ *   --status               Print current consent flag values as a JSON envelope.
+ *
+ * ## Purge-on-revoke (bug #6 fix)
+ *
+ * When `--disable-claude-code` is issued the command enumerates every entry
+ * in the pool whose `source === 'claude-code'` and calls `removeCredential`
+ * for each. This prevents a stale token from being served until the
+ * suppression's 60-second seed cache expires.
+ *
+ * @module cleo/commands/auth/consent
+ * @task T9598
+ * @epic T9587
+ */
+
+import type {
+  getConfigValue as GetConfigValueFn,
+  setConfigValue as SetConfigValueFn,
+} from '@cleocode/core';
+import { defineCommand } from 'citty';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result envelope for `cleo auth consent --status`.
+ *
+ * One gate entry per supported consent flag; additional gates will be added
+ * as new external-credential sources are introduced.
+ *
+ * @task T9598
+ */
+export interface ConsentStatusResult {
+  /** All known consent gate states. */
+  gates: ConsentGate[];
+}
+
+/**
+ * State of a single consent gate.
+ *
+ * @task T9598
+ */
+export interface ConsentGate {
+  /** Stable identifier for this gate (e.g. `'claudeCode'`). */
+  gate: string;
+  /** Config key consulted for this flag. */
+  configKey: string;
+  /** Whether consent is currently granted. */
+  enabled: boolean;
+  /** Whether the source seeder is suppressed (independent of the consent flag). */
+  suppressed: boolean;
+}
+
+/**
+ * Result envelope for `cleo auth consent --enable-claude-code` /
+ * `--disable-claude-code`.
+ *
+ * @task T9598
+ */
+export interface ConsentToggleResult {
+  /** Which action was performed. */
+  action: 'enabled' | 'disabled';
+  /** Gate identifier (e.g. `'claudeCode'`). */
+  gate: string;
+  /** Config key that was written. */
+  configKey: string;
+  /** Value written to the config. */
+  value: boolean;
+  /** Whether the suppression entry was added or removed. */
+  suppressionChanged: boolean;
+  /** Number of pool entries purged (only non-zero on disable). */
+  purgedCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * `cleo auth consent` — toggle and inspect Claude Code (and future) consent
+ * gates.
+ *
+ * @task T9598
+ */
+export const authConsentCommand = defineCommand({
+  meta: {
+    name: 'consent',
+    description:
+      'Manage consent gates for external credential sources (e.g. Claude Code OAuth). ' +
+      'Use --enable-claude-code / --disable-claude-code to toggle, --status to inspect.',
+  },
+  args: {
+    'enable-claude-code': {
+      type: 'boolean',
+      description:
+        'Grant consent for the claude-code seeder: sets auth.claudeCodeConsentGiven=true ' +
+        'in the global config and removes any suppression entry.',
+    },
+    'disable-claude-code': {
+      type: 'boolean',
+      description:
+        'Revoke consent for the claude-code seeder: sets auth.claudeCodeConsentGiven=false, ' +
+        'adds a suppression entry, and purges all source:claude-code entries from the pool.',
+    },
+    status: {
+      type: 'boolean',
+      description: 'Print the current state of all consent gates.',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON envelope',
+    },
+  },
+  async run({ args }) {
+    const a = args as Record<string, unknown>;
+    const enableClaudeCode = a['enable-claude-code'] === true;
+    const disableClaudeCode = a['disable-claude-code'] === true;
+    const showStatus = a['status'] === true;
+
+    // Must specify exactly one action.
+    if (!enableClaudeCode && !disableClaudeCode && !showStatus) {
+      cliError('Specify one of --enable-claude-code, --disable-claude-code, or --status.', 6, {
+        name: 'E_INVALID_INPUT',
+        fix: 'Run `cleo auth consent --status` to see current consent state.',
+      });
+      process.exit(6);
+    }
+
+    if (enableClaudeCode && disableClaudeCode) {
+      cliError('--enable-claude-code and --disable-claude-code are mutually exclusive.', 6, {
+        name: 'E_INVALID_INPUT',
+      });
+      process.exit(6);
+    }
+
+    // Lazy imports — keeps `--help` fast and avoids pulling the entire LLM
+    // dependency graph for users who never call `cleo auth consent`.
+    // Type-only aliases are imported at the top of this file so TypeScript
+    // can check the call sites; the dynamic import provides the runtime value.
+    const configMod = (await import(
+      /* webpackIgnore: true */ '@cleocode/core/config.js' as string
+    )) as { getConfigValue: typeof GetConfigValueFn; setConfigValue: typeof SetConfigValueFn };
+    const getConfigValue = configMod.getConfigValue;
+    const setConfigValue = configMod.setConfigValue;
+    const { addSuppression, removeSuppression, isSuppressed } = await import(
+      /* webpackIgnore: true */ '@cleocode/core/llm/credential-removal.js'
+    );
+
+    const CONSENT_KEY = 'auth.claudeCodeConsentGiven';
+    const SOURCE_ID = 'claude-code' as const;
+    const PROVIDER = 'anthropic';
+
+    // -------------------------------------------------------------------------
+    // --status
+    // -------------------------------------------------------------------------
+    if (showStatus) {
+      const resolved = await getConfigValue<boolean | undefined>(CONSENT_KEY);
+      const consentEnabled = resolved.value === true;
+      const suppressed = isSuppressed(PROVIDER, SOURCE_ID);
+
+      const result: ConsentStatusResult = {
+        gates: [
+          {
+            gate: 'claudeCode',
+            configKey: CONSENT_KEY,
+            enabled: consentEnabled,
+            suppressed,
+          },
+        ],
+      };
+
+      cliOutput(result, {
+        command: 'auth-consent-status',
+        operation: 'auth.consent.status',
+      });
+      return;
+    }
+
+    // -------------------------------------------------------------------------
+    // --enable-claude-code
+    // -------------------------------------------------------------------------
+    if (enableClaudeCode) {
+      await setConfigValue(CONSENT_KEY, true, undefined, { global: true });
+
+      // Remove any existing suppression so the seeder runs on next seed pass.
+      const suppressionChanged = removeSuppression(PROVIDER, SOURCE_ID);
+
+      const result: ConsentToggleResult = {
+        action: 'enabled',
+        gate: 'claudeCode',
+        configKey: CONSENT_KEY,
+        value: true,
+        suppressionChanged,
+        purgedCount: 0,
+      };
+
+      cliOutput(result, {
+        command: 'auth-consent-enable',
+        operation: 'auth.consent.enable',
+      });
+      return;
+    }
+
+    // -------------------------------------------------------------------------
+    // --disable-claude-code
+    // -------------------------------------------------------------------------
+    // Set the config flag first so any concurrent seed() call that happens to
+    // start before the suppression write also fails the consent check.
+    await setConfigValue(CONSENT_KEY, false, undefined, { global: true });
+
+    // Add suppression so future seed() passes never re-import the token.
+    const wasAlreadySuppressed = isSuppressed(PROVIDER, SOURCE_ID);
+    addSuppression(PROVIDER, SOURCE_ID);
+    const suppressionChanged = !wasAlreadySuppressed;
+
+    // Purge all source:claude-code entries that are already in the pool
+    // (bug #6 fix — revoke must take effect immediately, not just on next seed).
+    const { listCredentials, removeCredential } = await import(
+      /* webpackIgnore: true */ '@cleocode/core/llm/credentials-store.js'
+    );
+
+    const allEntries = await listCredentials();
+    const claudeCodeEntries = allEntries.filter((c) => c.source === SOURCE_ID);
+
+    let purgedCount = 0;
+    for (const entry of claudeCodeEntries) {
+      const removed = await removeCredential(entry.provider, entry.label);
+      if (removed) purgedCount++;
+    }
+
+    const result: ConsentToggleResult = {
+      action: 'disabled',
+      gate: 'claudeCode',
+      configKey: CONSENT_KEY,
+      value: false,
+      suppressionChanged,
+      purgedCount,
+    };
+
+    cliOutput(result, {
+      command: 'auth-consent-disable',
+      operation: 'auth.consent.disable',
+    });
+  },
+});

--- a/packages/cleo/src/cli/commands/auth/index.ts
+++ b/packages/cleo/src/cli/commands/auth/index.ts
@@ -10,6 +10,8 @@
  * @epic E-CONFIG-AUTH-UNIFY (E2b)
  */
 
+export type { ConsentGate, ConsentStatusResult, ConsentToggleResult } from './consent.js';
+export { authConsentCommand } from './consent.js';
 export type { AuthListEntry } from './list.js';
 export { authListCommand } from './list.js';
 export type {

--- a/packages/cleo/src/cli/commands/auth/list.ts
+++ b/packages/cleo/src/cli/commands/auth/list.ts
@@ -16,6 +16,9 @@
  * @epic E-CONFIG-AUTH-UNIFY (E2b)
  */
 
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { defineCommand } from 'citty';
 import { cliOutput } from '../../renderers/index.js';
 
@@ -151,8 +154,17 @@ export const authListCommand = defineCommand({
         return p !== 0 ? p : a.label.localeCompare(b.label);
       });
 
+    // T9598: emit a hint when ~/.claude/.credentials.json exists but the
+    // claudeCodeConsentGiven flag is false — so operators know they can opt in.
+    const claudeCredsPath = join(homedir(), '.claude', '.credentials.json');
+    const hint =
+      existsSync(claudeCredsPath) && entries.every((e) => e.source !== 'claude-code')
+        ? 'Hint: Claude Code OAuth detected at ~/.claude/.credentials.json but consent is off. ' +
+          'Run `cleo auth consent --enable-claude-code` to seed it into the pool.'
+        : null;
+
     cliOutput(
-      { entries },
+      { entries, ...(hint !== null ? { hint } : {}) },
       {
         command: 'auth-list',
         operation: 'auth.list',

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -62,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -83,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -101,23 +99,20 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -140,8 +135,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -244,8 +238,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'currentCommand',
@@ -262,16 +255,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -295,8 +286,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -307,8 +297,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -321,8 +310,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -358,8 +346,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -383,8 +370,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'generateChangelogCommand',
     name: 'generate-changelog',
     description: 'Generate platform-specific changelog from CHANGELOG.md',
-    load: async () =>
-      (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
+    load: async () => (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
   },
   {
     exportName: 'gradeCommand',
@@ -408,8 +394,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -432,17 +417,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -471,8 +453,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -514,17 +495,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -553,8 +531,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -566,15 +543,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -617,8 +592,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -629,7 +603,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -677,8 +651,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -690,8 +663,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -739,15 +711,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all sections (llm, identity, sentient, project-conventions) in canonical order. Use --section <name> for a single section or --non-interactive with --provider/--api-key to configure LLM without prompts.',
+    description: 'Interactive setup wizard — runs all sections (llm, identity, sentient, project-conventions) in canonical order. Use --section <name> for a single section or --non-interactive with --provider/--api-key to configure LLM without prompts.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -813,8 +783,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -832,8 +801,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {
@@ -851,7 +819,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'worktreeCommand',
     name: 'worktree',
-    description: 'Inspect CLEO-managed git worktrees attached to this project. ',
+    description: 'Inspect and manage CLEO-attached git worktrees. ',
     load: async () => (await import('../commands/worktree.js')).worktreeCommand as CommandDef,
   },
 ] as const;

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -63,8 +62,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +83,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,20 +101,23 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -135,7 +140,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -238,7 +244,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'currentCommand',
@@ -255,14 +262,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -286,7 +295,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -297,7 +307,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -310,7 +321,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -346,7 +358,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -370,7 +383,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'generateChangelogCommand',
     name: 'generate-changelog',
     description: 'Generate platform-specific changelog from CHANGELOG.md',
-    load: async () => (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
   },
   {
     exportName: 'gradeCommand',
@@ -394,7 +408,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -417,14 +432,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -453,7 +471,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -495,14 +514,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -531,7 +553,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -543,13 +566,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -592,7 +617,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -603,7 +629,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -651,7 +678,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -663,7 +691,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -711,13 +740,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all sections (llm, identity, sentient, project-conventions) in canonical order. Use --section <name> for a single section or --non-interactive with --provider/--api-key to configure LLM without prompts.',
+    description:
+      'Interactive setup wizard — runs all sections (llm, identity, sentient, project-conventions) in canonical order. Use --section <name> for a single section or --non-interactive with --provider/--api-key to configure LLM without prompts.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description:
+      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -783,7 +814,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -801,7 +833,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -173,6 +173,11 @@ export default defineConfig({
         '../../packages/core/src/llm/credentials-store.ts',
         import.meta.url,
       ).pathname,
+      // T9598: config subpath import used by `cleo auth consent`
+      '@cleocode/core/config.js': new URL(
+        '../../packages/core/src/config.ts',
+        import.meta.url,
+      ).pathname,
       // T9416: llm subpath imports used by `cleo auth list` / `cleo auth remove`
       '@cleocode/core/llm/credential-pool.js': new URL(
         '../../packages/core/src/llm/credential-pool.ts',


### PR DESCRIPTION
Closes T9598. Refs T9573 audit bugs #5 + #6.

## Changes
- New `packages/cleo/src/cli/commands/auth/consent.ts` — consent subcommand group
- New tests at `packages/cleo/src/cli/commands/__tests__/auth-consent.test.ts`
- Updated auth command dispatcher to wire consent subcommand
- cleo auth list emits hint when consent off + ~/.claude/.credentials.json exists