### PR TITLE
feat(T9600): getEffectiveHead primitive for worktree-aware verify

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2079,9 +2079,9 @@ export {
   resolveWorktreeAuditActor,
   WORKTREE_LIFECYCLE_AUDIT_FILE,
 } from './worktree/audit.js';
-export { forceUnlockWorktree } from './worktree/force-unlock.js';
 // Worktree effective HEAD — branch-aware ref resolution for evidence validation (T9600 / T-WT-1)
 export { getEffectiveHead } from './worktree/effective-head.js';
+export { forceUnlockWorktree } from './worktree/force-unlock.js';
 // Worktree listing — structured enumeration with status classification (T9546 / T9515)
 export { listWorktrees } from './worktree/list.js';
 export { pruneOrphanedWorktreesByStatus } from './worktree/prune.js';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2080,6 +2080,8 @@ export {
   WORKTREE_LIFECYCLE_AUDIT_FILE,
 } from './worktree/audit.js';
 export { forceUnlockWorktree } from './worktree/force-unlock.js';
+// Worktree effective HEAD — branch-aware ref resolution for evidence validation (T9600 / T-WT-1)
+export { getEffectiveHead } from './worktree/effective-head.js';
 // Worktree listing — structured enumeration with status classification (T9546 / T9515)
 export { listWorktrees } from './worktree/list.js';
 export { pruneOrphanedWorktreesByStatus } from './worktree/prune.js';

--- a/packages/core/src/worktree/__tests__/effective-head.test.ts
+++ b/packages/core/src/worktree/__tests__/effective-head.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for `getEffectiveHead` (T9600 / T-WT-1).
+ *
+ * Covers:
+ *  - No taskId → returns "HEAD"
+ *  - Branch exists → returns "task/<taskId>"
+ *  - Branch absent (git rev-parse exits non-zero) → returns "HEAD"
+ *  - git binary fails entirely → returns "HEAD"
+ *
+ * @task T9600
+ * @task T-WT-1
+ * @epic T9586
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { getEffectiveHead } from '../effective-head.js';
+
+// ---------------------------------------------------------------------------
+// Mock child_process so tests never invoke a real git binary
+// ---------------------------------------------------------------------------
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from 'node:child_process';
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+describe('getEffectiveHead', () => {
+  const PROJECT_ROOT = '/fake/project';
+
+  it('returns "HEAD" when no taskId is provided', async () => {
+    const result = await getEffectiveHead(PROJECT_ROOT);
+    expect(result).toBe('HEAD');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('returns "HEAD" when taskId is undefined', async () => {
+    const result = await getEffectiveHead(PROJECT_ROOT, undefined);
+    expect(result).toBe('HEAD');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('returns "task/<taskId>" when the branch exists', async () => {
+    mockExecFileSync.mockReturnValueOnce(Buffer.from(''));
+    const result = await getEffectiveHead(PROJECT_ROOT, 'T123');
+    expect(result).toBe('task/T123');
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['rev-parse', '--verify', 'refs/heads/task/T123'],
+      { cwd: PROJECT_ROOT, stdio: 'ignore' },
+    );
+  });
+
+  it('returns "HEAD" when the branch does not exist (rev-parse exits non-zero)', async () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      const err = new Error('fatal: ambiguous argument');
+      Object.assign(err, { status: 128 });
+      throw err;
+    });
+    const result = await getEffectiveHead(PROJECT_ROOT, 'T999');
+    expect(result).toBe('HEAD');
+  });
+
+  it('returns "HEAD" when git binary fails entirely', async () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error('ENOENT: git not found');
+    });
+    const result = await getEffectiveHead(PROJECT_ROOT, 'T456');
+    expect(result).toBe('HEAD');
+  });
+});

--- a/packages/core/src/worktree/effective-head.ts
+++ b/packages/core/src/worktree/effective-head.ts
@@ -1,0 +1,25 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Resolve the effective HEAD ref for evidence validation in a worktree context.
+ *
+ * When a task branch exists, returns `"task/<taskId>"`. Otherwise falls back to `"HEAD"`.
+ * Used by validateCommit's `--is-ancestor` check so commits on a worktree's task
+ * branch are correctly recognized as reachable.
+ *
+ * @task T-WT-1
+ * @task T9600
+ * @epic T9586
+ */
+export async function getEffectiveHead(projectRoot: string, taskId?: string): Promise<string> {
+  if (!taskId) return 'HEAD';
+  try {
+    execFileSync('git', ['rev-parse', '--verify', `refs/heads/task/${taskId}`], {
+      cwd: projectRoot,
+      stdio: 'ignore',
+    });
+    return `task/${taskId}`;
+  } catch {
+    return 'HEAD';
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `packages/core/src/worktree/effective-head.ts` with `getEffectiveHead(projectRoot, taskId?)`.
- Returns `"task/<taskId>"` when the local branch exists, otherwise falls back to `"HEAD"`.
- Re-exported from `packages/core/src/internal.ts` alongside other worktree primitives.
- 5 unit tests covering: no taskId, undefined taskId, branch present, branch absent (rev-parse non-zero exit), git binary failure — all mocked via vitest.

Closes T9600 (T-WT-1). Refs spec `docs/plans/E-WORKTREE-IVTR.md`.

## Test plan

- [x] `pnpm biome check --write` on new files — passes
- [x] `pnpm --filter @cleocode/core test src/worktree/` — 5 files, 78 tests, all pass
- [x] Build: pre-existing `prune.ts` TS7006 errors on `origin/main` are unrelated to this PR (verified by diff — `prune.ts` is not modified)

Generated with [Claude Code](https://claude.com/claude-code)