### PR TITLE
fix(T9599b): WizardFatalError + stdin-EOF propagation through WizardRunner

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/setup-command.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/setup-command.test.ts
@@ -289,6 +289,14 @@ describe('T9599 — StdinClosedError propagates out of runSetup', () => {
       error: () => undefined,
     };
 
+    // Wire the llm section mock to actually call io.prompt() so StdinClosedError
+    // propagates — the FakeRunner calls section.run(io, options), and if the
+    // section calls io.prompt() it will throw.
+    sections.llm.run.mockImplementationOnce(async (io: WizardIO) => {
+      await io.prompt('This triggers StdinClosedError');
+      return { changed: false, summary: 'unreachable' };
+    });
+
     // runSetup should let StdinClosedError propagate (not swallow it).
     await expect(runSetup({}, eofIo)).rejects.toThrow(StdinClosedError);
   });

--- a/packages/cleo/src/cli/lib/readline-wizard-io.ts
+++ b/packages/cleo/src/cli/lib/readline-wizard-io.ts
@@ -36,6 +36,7 @@
 import { stdin as input, stdout as output } from 'node:process';
 import * as readline from 'node:readline/promises';
 import type { WizardIO } from '@cleocode/core/setup';
+import { WizardFatalError } from '@cleocode/core/setup';
 
 // ---------------------------------------------------------------------------
 // EOF sentinel
@@ -54,12 +55,14 @@ export const SETUP_STDIN_CLOSED_CODE = 'E_SETUP_STDIN_CLOSED' as const;
 /**
  * Thrown by {@link ReadlineWizardIO} when stdin closes mid-prompt.
  *
- * `setup.ts` catches this and converts it to a LAFS error envelope with
+ * Extends {@link WizardFatalError} so `WizardRunner.invokeSection` re-throws
+ * it instead of swallowing it into a failed summary — the CLI `setup.ts`
+ * then catches this and converts it to a LAFS error envelope with
  * `codeName: "E_SETUP_STDIN_CLOSED"` before calling `process.exit(1)`.
  *
  * @task T9599
  */
-export class StdinClosedError extends Error {
+export class StdinClosedError extends WizardFatalError {
   readonly codeName = SETUP_STDIN_CLOSED_CODE;
 
   constructor() {

--- a/packages/core/src/setup/__tests__/wizard.test.ts
+++ b/packages/core/src/setup/__tests__/wizard.test.ts
@@ -29,6 +29,7 @@ import {
   createProjectConventionsSection,
   createSentientSection,
   StubWizardIO,
+  WizardFatalError,
   WizardRunner,
   type WizardSectionRunner,
 } from '../index.js';
@@ -176,6 +177,51 @@ describe('WizardRunner — registration + dispatch', () => {
     const result = await runner.run(io);
     expect(result.summary[0]).toMatch(/^llm: failed: boom/);
     expect(io.errors[0]).toMatch(/section 'llm' failed: boom/);
+  });
+
+  it('run() re-throws WizardFatalError (T9599 — stdin EOF must not be swallowed)', async () => {
+    // WizardFatalError subclasses represent conditions (stdin closed, broken pipe)
+    // where continuing the wizard is impossible. invokeSection re-throws them.
+    class TestFatalError extends WizardFatalError {
+      constructor() {
+        super('fatal signal');
+        this.name = 'TestFatalError';
+      }
+    }
+    const fataler: WizardSectionRunner = {
+      section: 'llm',
+      title: 'fatal',
+      optional: false,
+      async run() {
+        throw new TestFatalError();
+      },
+    };
+    const runner = new WizardRunner([fataler]);
+    const io = new StubWizardIO();
+    await expect(runner.run(io)).rejects.toThrow(TestFatalError);
+    // io.errors must NOT have been called for this throw (it bypasses the
+    // normal "section failed" path).
+    expect(io.errors).toHaveLength(0);
+  });
+
+  it('runSection() re-throws WizardFatalError', async () => {
+    class TestFatalError extends WizardFatalError {
+      constructor() {
+        super('fatal');
+        this.name = 'TestFatalError';
+      }
+    }
+    const fataler: WizardSectionRunner = {
+      section: 'identity',
+      title: 'fatal',
+      optional: false,
+      async run() {
+        throw new TestFatalError();
+      },
+    };
+    const runner = new WizardRunner([fataler]);
+    const io = new StubWizardIO();
+    await expect(runner.runSection('identity', io)).rejects.toThrow(TestFatalError);
   });
 });
 

--- a/packages/core/src/setup/index.ts
+++ b/packages/core/src/setup/index.ts
@@ -26,6 +26,7 @@ export { createProjectConventionsSection } from './sections/project-conventions.
 export { createSentientSection } from './sections/sentient.js';
 export {
   StubWizardIO,
+  WizardFatalError,
   type WizardIO,
   type WizardOptions,
   WizardRunner,

--- a/packages/core/src/setup/wizard.ts
+++ b/packages/core/src/setup/wizard.ts
@@ -42,6 +42,36 @@
  */
 
 /**
+ * Base class for errors that are fatal to the entire wizard run.
+ *
+ * `WizardRunner.invokeSection` catches and swallows section-level errors so
+ * a single failing section does not abort the rest of the wizard. But some
+ * error conditions (e.g. stdin closed) make further prompting impossible and
+ * must propagate all the way out so the CLI can emit a proper LAFS error
+ * envelope instead of silently continuing with dead prompts.
+ *
+ * CLI-layer error classes (e.g. `StdinClosedError` in
+ * `packages/cleo/src/cli/lib/readline-wizard-io.ts`) extend this class so
+ * the runner recognises them without importing CLI types.
+ *
+ * @task T9599
+ */
+export class WizardFatalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WizardFatalError';
+  }
+
+  /**
+   * Type-guard so `invokeSection` can detect subclasses without `instanceof`
+   * across package boundaries.
+   */
+  static is(err: unknown): err is WizardFatalError {
+    return err instanceof WizardFatalError;
+  }
+}
+
+/**
  * Canonical identifier for every built-in wizard section.
  *
  * Surface order matters: `cleo setup` runs sections in declaration order
@@ -303,6 +333,11 @@ export class WizardRunner {
    * than uncaught throws so an `cleo setup` invocation always completes
    * with a non-fatal report instead of a stack trace.
    *
+   * **Exception**: {@link WizardFatalError} subclasses (e.g. `StdinClosedError`)
+   * are re-thrown immediately — they signal conditions (stdin EOF, broken pipe)
+   * where further prompting is impossible and the CLI must emit a LAFS error
+   * envelope rather than continuing with a dead I/O surface.
+   *
    * @internal
    */
   private async invokeSection(
@@ -313,6 +348,11 @@ export class WizardRunner {
     try {
       return await runner.run(io, options);
     } catch (err) {
+      // Re-throw fatal errors — they propagate to the CLI for LAFS envelope
+      // emission (T9599 bug #10: stdin EOF must not be silently swallowed).
+      if (WizardFatalError.is(err)) {
+        throw err;
+      }
       const message = err instanceof Error ? err.message : String(err);
       io.error(`section '${runner.section}' failed: ${message}`);
       return { changed: false, summary: `failed: ${message}` };


### PR DESCRIPTION
## Summary

Follow-up to #262 (already merged). Adds `WizardFatalError` base class so that fatal I/O errors like stdin-EOF propagate through `WizardRunner.invokeSection` instead of being silently swallowed into a failed summary line.

- `WizardFatalError` class in core/setup/wizard.ts — `invokeSection` re-throws subclasses
- `WizardFatalError` exported from core/setup/index.ts
- `StdinClosedError` extends `WizardFatalError` (was `Error`)
- 2 new `WizardRunner` tests covering the re-throw behavior
- Fixed `runSetup re-throws StdinClosedError` test (mock section now calls `io.prompt()`)

Refs T9599, T9573 audit bug #10.

## Test plan

- [ ] `WizardRunner.run()` propagates `WizardFatalError` subclass (new test)
- [ ] `WizardRunner.runSection()` propagates `WizardFatalError` subclass (new test)
- [ ] `runSetup` with stdin-EOF io correctly re-throws `StdinClosedError` (fixed test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)