### PR TITLE
fix(T9581): normalize project-root resolution in doctor/lifecycle/compliance

### DIFF
--- a/packages/core/src/compliance/__tests__/sync.test.ts
+++ b/packages/core/src/compliance/__tests__/sync.test.ts
@@ -14,6 +14,10 @@ function makeTmpDir(): string {
     `cleo-compliance-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
   mkdirSync(join(dir, '.cleo', 'metrics'), { recursive: true });
+  // T9581: getProjectRoot() now validates project roots via validateProjectRoot().
+  // The legacy-fallback path requires a sibling `.git/` directory. Without this,
+  // getProjectRoot() walks up from `tmpDir` and throws E_INVALID_PROJECT_ROOT.
+  mkdirSync(join(dir, '.git'), { recursive: true });
   return dir;
 }
 

--- a/packages/core/src/compliance/index.ts
+++ b/packages/core/src/compliance/index.ts
@@ -6,7 +6,7 @@
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
-import { getManifestPath as getManifestPathFromPaths } from '../paths.js';
+import { getManifestPath as getManifestPathFromPaths, getProjectRoot } from '../paths.js';
 import { atomicWriteJson } from '../store/atomic.js';
 import { getComplianceJsonlPath, readComplianceJsonl } from './store.js';
 // CleoError and ExitCode available if needed for future error cases
@@ -17,7 +17,7 @@ export async function getComplianceSummary(opts: {
   agent?: string;
   cwd?: string;
 }): Promise<Record<string, unknown>> {
-  let entries = readComplianceJsonl(opts.cwd ?? process.cwd());
+  let entries = readComplianceJsonl(getProjectRoot(opts.cwd));
 
   if (opts.since) {
     entries = entries.filter((e) => (e.timestamp as string) >= opts.since!);
@@ -58,7 +58,7 @@ export async function listComplianceViolations(opts: {
   agent?: string;
   cwd?: string;
 }): Promise<Record<string, unknown>> {
-  let entries = readComplianceJsonl(opts.cwd ?? process.cwd());
+  let entries = readComplianceJsonl(getProjectRoot(opts.cwd));
 
   entries = entries.filter((e) => {
     const c = (e.compliance ?? {}) as Record<string, unknown>;
@@ -99,7 +99,7 @@ export async function getComplianceTrend(
   days: number = 7,
   cwd?: string,
 ): Promise<Record<string, unknown>> {
-  const entries = readComplianceJsonl(cwd ?? process.cwd());
+  const entries = readComplianceJsonl(getProjectRoot(cwd));
   const cutoff = new Date(Date.now() - days * 86400000).toISOString();
 
   const filtered = entries.filter((e) => (e.timestamp as string) >= cutoff);
@@ -144,7 +144,7 @@ export async function auditEpicCompliance(
   epicId: string,
   opts: { since?: string; cwd?: string },
 ): Promise<Record<string, unknown>> {
-  const entries = readComplianceJsonl(opts.cwd ?? process.cwd());
+  const entries = readComplianceJsonl(getProjectRoot(opts.cwd));
 
   const epicEntries = entries.filter((e) => {
     const ctx = (e._context ?? {}) as Record<string, unknown>;
@@ -181,7 +181,7 @@ export async function syncComplianceMetrics(opts: {
   force?: boolean;
   cwd?: string;
 }): Promise<Record<string, unknown>> {
-  const cwd = opts.cwd ?? process.cwd();
+  const cwd = getProjectRoot(opts.cwd);
   const force = opts.force ?? false;
   const jsonlPath = getComplianceJsonlPath(cwd);
   const summaryPath = join(cwd, '.cleo', 'metrics', 'compliance-summary.json');
@@ -274,7 +274,7 @@ export async function getSkillReliability(opts: {
   global?: boolean;
   cwd?: string;
 }): Promise<Record<string, unknown>> {
-  const entries = readComplianceJsonl(opts.cwd ?? process.cwd());
+  const entries = readComplianceJsonl(getProjectRoot(opts.cwd));
 
   const byAgent: Record<string, { count: number; passRateSum: number; violations: number }> = {};
   for (const e of entries) {
@@ -319,7 +319,7 @@ export async function getValueMetrics(
   let violationsCaught = 0;
   let realValidations = 0;
 
-  const entries = readComplianceJsonl(cwd ?? process.cwd());
+  const entries = readComplianceJsonl(getProjectRoot(cwd));
   totalValidations = entries.length;
   violationsCaught = entries.filter((e) => {
     const c = (e.compliance ?? {}) as Record<string, unknown>;

--- a/packages/core/src/lifecycle/engine-ops.ts
+++ b/packages/core/src/lifecycle/engine-ops.ts
@@ -26,6 +26,7 @@ import type {
   LifecycleSkipParams,
 } from '@cleocode/contracts';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
+import { getProjectRoot } from '../paths.js';
 import { getActiveSession } from '../store/session-store.js';
 import { getForceBypassPath } from '../tasks/gate-audit.js';
 import { getPipelineStageOrder, isPipelineTransitionForward } from '../tasks/pipeline-stage.js';
@@ -159,7 +160,7 @@ export async function enforceScopeForLifecycleMutation(
     const reason = (process.env['CLEO_OWNER_OVERRIDE_REASON'] ?? '').trim() || 'unspecified';
     const scopeStr = scope.epicId ? `epic:${scope.epicId}` : scope.type;
     try {
-      const root = projectRoot ?? process.cwd();
+      const root = getProjectRoot(projectRoot);
       await appendLifecycleScopeBypassLine(root, epicId, scopeStr, reason);
     } catch {
       // Audit write failure must not block the operation.
@@ -204,7 +205,7 @@ export async function enforceScopeForLifecycleMutation(
  * @param projectRoot - Absolute project root path.
  */
 export async function listRcsdEpics(projectRoot?: string): Promise<string[]> {
-  return listEpicsWithLifecycle(projectRoot ?? process.cwd());
+  return listEpicsWithLifecycle(getProjectRoot(projectRoot));
 }
 
 /**
@@ -220,7 +221,7 @@ export async function lifecycleStatus(epicId: string, projectRoot?: string): Pro
     return engineError('E_INVALID_INPUT', 'epicId is required');
   }
   try {
-    const data = await getLifecycleStatus(projectRoot ?? process.cwd(), { epicId });
+    const data = await getLifecycleStatus(getProjectRoot(projectRoot), { epicId });
     return engineSuccess(data);
   } catch (err) {
     if (err instanceof Error) {
@@ -243,7 +244,7 @@ export async function lifecycleHistory(
   projectRoot?: string,
 ): Promise<EngineResult> {
   try {
-    const data = await getLifecycleHistory(projectRoot ?? process.cwd(), { taskId });
+    const data = await getLifecycleHistory(getProjectRoot(projectRoot), { taskId });
     return engineSuccess(data);
   } catch (err) {
     if (err instanceof Error) {
@@ -263,7 +264,7 @@ export async function lifecycleHistory(
  */
 export async function lifecycleGates(taskId: string, projectRoot?: string): Promise<EngineResult> {
   try {
-    const data = await getLifecycleGates(projectRoot ?? process.cwd(), { taskId });
+    const data = await getLifecycleGates(getProjectRoot(projectRoot), { taskId });
     return engineSuccess(data);
   } catch (err) {
     if (err instanceof Error) {
@@ -317,7 +318,7 @@ export async function lifecycleCheck(
     return engineError('E_INVALID_INPUT', 'epicId and targetStage are required');
   }
   try {
-    const data = await checkStagePrerequisites(projectRoot ?? process.cwd(), {
+    const data = await checkStagePrerequisites(getProjectRoot(projectRoot), {
       epicId,
       targetStage: targetStage as LifecycleCheckParams['targetStage'],
     });
@@ -369,7 +370,7 @@ export async function lifecycleProgress(
   try {
     // Enforce forward-only stage progression
     if (status === 'in_progress' || status === 'completed') {
-      const current = await getLifecycleStatus(projectRoot ?? process.cwd(), { taskId });
+      const current = await getLifecycleStatus(getProjectRoot(projectRoot), { taskId });
       if (current.currentStage) {
         if (!isPipelineTransitionForward(current.currentStage, stage)) {
           const currentOrder = getPipelineStageOrder(current.currentStage);
@@ -388,7 +389,7 @@ export async function lifecycleProgress(
       }
     }
 
-    const data = await recordStageProgress(projectRoot ?? process.cwd(), {
+    const data = await recordStageProgress(getProjectRoot(projectRoot), {
       taskId,
       stage: stage as LifecycleProgressParams['stage'],
       status: status as LifecycleProgressParams['status'],
@@ -433,7 +434,7 @@ export async function lifecycleSkip(
   if (scopeDenied) return scopeDenied;
 
   try {
-    const data = await skipStageWithReason(projectRoot ?? process.cwd(), {
+    const data = await skipStageWithReason(getProjectRoot(projectRoot), {
       taskId,
       stage: stage as LifecycleSkipParams['stage'],
       reason,
@@ -477,7 +478,7 @@ export async function lifecycleReset(
   if (scopeDenied) return scopeDenied;
 
   try {
-    const data = await resetStage(projectRoot ?? process.cwd(), {
+    const data = await resetStage(getProjectRoot(projectRoot), {
       taskId,
       stage: stage as LifecycleResetParams['stage'],
       reason,
@@ -513,7 +514,7 @@ export async function lifecycleGatePass(
     return engineError('E_INVALID_INPUT', 'taskId and gateName are required');
   }
   try {
-    const data = await passGate(projectRoot ?? process.cwd(), {
+    const data = await passGate(getProjectRoot(projectRoot), {
       taskId,
       gateName,
       agent: agent ?? 'system',
@@ -548,7 +549,7 @@ export async function lifecycleGateFail(
     return engineError('E_INVALID_INPUT', 'taskId and gateName are required');
   }
   try {
-    const data = await failGate(projectRoot ?? process.cwd(), {
+    const data = await failGate(getProjectRoot(projectRoot), {
       taskId,
       gateName,
       reason: reason ?? '',

--- a/packages/core/src/validation/__tests__/doctor-gitignore.test.ts
+++ b/packages/core/src/validation/__tests__/doctor-gitignore.test.ts
@@ -22,6 +22,9 @@ function makeTempDir(): string {
     `cleo-doctor-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
   mkdirSync(dir, { recursive: true });
+  // T9581: getProjectRoot() validates project roots — legacy-fallback path
+  // requires a sibling `.git/` directory.
+  mkdirSync(join(dir, '.git'), { recursive: true });
   return dir;
 }
 

--- a/packages/core/src/validation/__tests__/doctor-injection.test.ts
+++ b/packages/core/src/validation/__tests__/doctor-injection.test.ts
@@ -26,6 +26,9 @@ function makeTempDir(): string {
     `cleo-injection-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
   mkdirSync(dir, { recursive: true });
+  // T9581: getProjectRoot() validates project roots — legacy-fallback path
+  // requires a sibling `.git/` directory.
+  mkdirSync(join(dir, '.git'), { recursive: true });
   return dir;
 }
 

--- a/packages/core/src/validation/doctor/__tests__/subdir-isolation.test.ts
+++ b/packages/core/src/validation/doctor/__tests__/subdir-isolation.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Subdir-isolation tests for the T9581 project-root resolution fix.
+ *
+ * Verifies that callable surfaces in:
+ *   - validation/doctor/checks.ts   (doctor health checks)
+ *   - lifecycle/engine-ops.ts       (lifecycle pipeline ops)
+ *   - compliance/index.ts           (compliance metrics)
+ *
+ * resolve their effective project root through `getProjectRoot()` rather
+ * than raw `process.cwd()`. The regression scenario is invocation from a
+ * monorepo subdirectory (`<root>/packages/<X>`) — without normalization,
+ * each call previously created or wrote to `<root>/packages/<X>/.cleo/`
+ * instead of the canonical `<root>/.cleo/`, silently corrupting state.
+ *
+ * The tests exercise both invocation styles documented in T9580:
+ *   (a) `process.chdir(subdir)` — caller's cwd is a subdir, fn invoked
+ *       with no explicit `cwd`/`projectRoot` argument.
+ *   (b) explicit subdir arg — caller passes `cwd: <subdir>` directly.
+ * Both MUST resolve to the canonical project root.
+ *
+ * @task T9581
+ * @epic T9580
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { syncComplianceMetrics } from '../../../compliance/index.js';
+import { lifecycleStatus } from '../../../lifecycle/engine-ops.js';
+import {
+  checkAgentsMdHub,
+  checkCleoGitignore,
+  checkLegacyAgentOutputs,
+  checkRootGitignore,
+} from '../checks.js';
+
+// ---------------------------------------------------------------------------
+// Test fixture: a synthetic project root with a deeply nested subdir
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  /** Canonical project root: `<tmp>/proj-<rand>` with `.cleo/` + `.git/`. */
+  rootDir: string;
+  /** Monorepo subdir below the root: `<rootDir>/packages/core`. */
+  subDir: string;
+}
+
+function makeFixture(): Fixture {
+  const rootDir = mkdtempSync(join(tmpdir(), 'cleo-subdir-iso-'));
+  // T9581: validateProjectRoot() requires `.cleo/` AND (`.git/` directory
+  // OR `.cleo/project-info.json`). Use the legacy-fallback path (`.git/`)
+  // to match how most real projects look during early CLEO bootstrap.
+  mkdirSync(join(rootDir, '.cleo', 'metrics'), { recursive: true });
+  mkdirSync(join(rootDir, '.git'), { recursive: true });
+  // Add project-info.json so getProjectRoot() takes the primary (non-warning)
+  // path through validateProjectRoot() — avoids stderr noise in test output.
+  writeFileSync(
+    join(rootDir, '.cleo', 'project-info.json'),
+    JSON.stringify({ projectId: 'subdir-iso-test' }),
+  );
+  // Create a monorepo-style subdir; this is the path callers invoke from
+  // when the regression surfaces.
+  const subDir = join(rootDir, 'packages', 'core');
+  mkdirSync(subDir, { recursive: true });
+  return { rootDir, subDir };
+}
+
+/**
+ * Snapshot and clear all CLEO_* env vars so the test sees a clean
+ * env-var resolution path (no operator's CLEO_ROOT bleeding in).
+ */
+function useCleanEnv(): { restore: () => void } {
+  const saved: Record<string, string | undefined> = {
+    CLEO_ROOT: process.env['CLEO_ROOT'],
+    CLEO_PROJECT_ROOT: process.env['CLEO_PROJECT_ROOT'],
+    CLEO_DIR: process.env['CLEO_DIR'],
+  };
+  delete process.env['CLEO_ROOT'];
+  delete process.env['CLEO_PROJECT_ROOT'];
+  delete process.env['CLEO_DIR'];
+  return {
+    restore() {
+      for (const [key, val] of Object.entries(saved)) {
+        if (val !== undefined) {
+          process.env[key] = val;
+        } else {
+          delete process.env[key];
+        }
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite: doctor/checks.ts — subdir isolation
+// ---------------------------------------------------------------------------
+
+describe('T9581 — doctor/checks.ts: project-root resolution from subdir', () => {
+  let fixture: Fixture;
+  let origCwd: string;
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    origCwd = process.cwd();
+    const env = useCleanEnv();
+    restoreEnv = env.restore;
+    fixture = makeFixture();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } catch {
+      /* ignore */
+    }
+    restoreEnv();
+    try {
+      rmSync(fixture.rootDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('checkAgentsMdHub: resolves to rootDir/.cleo when called with explicit subdir cwd', () => {
+    // Sanity: the subdir has no .cleo/ of its own.
+    expect(existsSync(join(fixture.subDir, '.cleo'))).toBe(false);
+
+    // Invocation style (b): explicit subdir cwd argument.
+    const result = checkAgentsMdHub(fixture.subDir);
+
+    // The check reads AGENTS.md from the resolved project root. Without
+    // T9581's getProjectRoot() normalization, the path would point at
+    // `<subdir>/AGENTS.md` (does not exist). With normalization, it points
+    // at `<rootDir>/AGENTS.md` (also doesn't exist, but the resolved path
+    // proves which root the check chose).
+    const detailPath = String((result.details as Record<string, unknown>)['path'] ?? '');
+    expect(detailPath).toBe(join(fixture.rootDir, 'AGENTS.md'));
+    // No stray `.cleo/` was created under the subdir.
+    expect(existsSync(join(fixture.subDir, '.cleo'))).toBe(false);
+  });
+
+  it('checkAgentsMdHub: resolves to rootDir/.cleo when invoked from subdir cwd (chdir)', () => {
+    // Invocation style (a): no arg, but process.cwd() is the subdir.
+    process.chdir(fixture.subDir);
+    const result = checkAgentsMdHub();
+    const detailPath = String((result.details as Record<string, unknown>)['path'] ?? '');
+    expect(detailPath).toBe(join(fixture.rootDir, 'AGENTS.md'));
+  });
+
+  it('checkRootGitignore: reads <rootDir>/.gitignore, not <subdir>/.gitignore', () => {
+    // Plant a `.gitignore` with a `.cleo/` entry at the root — the check
+    // looks for ignored `.cleo/` to surface a warning.
+    writeFileSync(join(fixture.rootDir, '.gitignore'), '.cleo/\nnode_modules/\n');
+
+    const result = checkRootGitignore(fixture.subDir);
+    const detailPath = String((result.details as Record<string, unknown>)['path'] ?? '');
+    expect(detailPath).toBe(join(fixture.rootDir, '.gitignore'));
+    // The check should have detected the `.cleo/` blocking line at rootDir,
+    // not failed to find a .gitignore in the subdir.
+    expect(result.status).toBe('warning');
+  });
+
+  it('checkCleoGitignore: reads <rootDir>/.cleo/.gitignore, not <subdir>/.cleo/.gitignore', () => {
+    writeFileSync(join(fixture.rootDir, '.cleo', '.gitignore'), '# placeholder\n');
+
+    const result = checkCleoGitignore(fixture.subDir);
+    const detailPath = String((result.details as Record<string, unknown>)['path'] ?? '');
+    expect(detailPath).toBe(join(fixture.rootDir, '.cleo', '.gitignore'));
+  });
+
+  it('checkLegacyAgentOutputs: scans <rootDir>/.cleo, not <subdir>/.cleo', () => {
+    // No legacy outputs at root → status passed.
+    const result = checkLegacyAgentOutputs(fixture.subDir);
+    expect(result.status).toBe('passed');
+    // No stray `.cleo/` should appear in the subdir.
+    expect(existsSync(join(fixture.subDir, '.cleo'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: lifecycle/engine-ops.ts — subdir isolation
+// ---------------------------------------------------------------------------
+
+describe('T9581 — lifecycle/engine-ops.ts: project-root resolution from subdir', () => {
+  let fixture: Fixture;
+  let origCwd: string;
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    origCwd = process.cwd();
+    const env = useCleanEnv();
+    restoreEnv = env.restore;
+    fixture = makeFixture();
+  });
+
+  afterEach(async () => {
+    try {
+      process.chdir(origCwd);
+    } catch {
+      /* ignore */
+    }
+    restoreEnv();
+    // Best-effort close any DB handles before cleanup (mirror lifecycle test pattern)
+    try {
+      const { closeDb } = await import('../../../store/sqlite.js');
+      closeDb();
+    } catch {
+      /* ignore — closeDb may not be available in all build modes */
+    }
+    try {
+      rmSync(fixture.rootDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('lifecycleStatus: opens DB under <rootDir>/.cleo, not <subdir>/.cleo (explicit cwd)', async () => {
+    // Invocation style (b): explicit subdir as projectRoot argument.
+    const result = await lifecycleStatus('T-test-9581', fixture.subDir);
+    // Function returns success because uninitialized status is a valid response.
+    expect(result.success).toBe(true);
+
+    // CRITICAL: no `.cleo/` directory should have been created under the
+    // subdir. Before T9581, the lifecycle DB layer would create
+    // `<subdir>/.cleo/tasks.db` on first access.
+    expect(existsSync(join(fixture.subDir, '.cleo'))).toBe(false);
+    // If a DB was created, it must be under the canonical root.
+    // (lifecycleStatus is read-only on uninitialized state, so the DB
+    // file may or may not exist — but if it does, it is under rootDir.)
+    const subCleoPath = join(fixture.subDir, '.cleo');
+    expect(existsSync(subCleoPath)).toBe(false);
+  });
+
+  it('lifecycleStatus: opens DB under <rootDir>/.cleo when invoked from subdir cwd (chdir)', async () => {
+    process.chdir(fixture.subDir);
+    // Invocation style (a): no projectRoot arg; resolution falls through
+    // to getProjectRoot() which now correctly walks up from the subdir.
+    const result = await lifecycleStatus('T-test-9581');
+    expect(result.success).toBe(true);
+    expect(existsSync(join(fixture.subDir, '.cleo'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: compliance/index.ts — subdir isolation
+// ---------------------------------------------------------------------------
+
+describe('T9581 — compliance/index.ts: project-root resolution from subdir', () => {
+  let fixture: Fixture;
+  let origCwd: string;
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    origCwd = process.cwd();
+    const env = useCleanEnv();
+    restoreEnv = env.restore;
+    fixture = makeFixture();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } catch {
+      /* ignore */
+    }
+    restoreEnv();
+    try {
+      rmSync(fixture.rootDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('syncComplianceMetrics: writes summary under <rootDir>/.cleo (explicit subdir cwd)', async () => {
+    // Plant a JSONL file at the canonical root so sync has data to process.
+    const jsonlPath = join(fixture.rootDir, '.cleo', 'metrics', 'COMPLIANCE.jsonl');
+    writeFileSync(
+      jsonlPath,
+      JSON.stringify({
+        timestamp: '2026-05-18T10:00:00Z',
+        source_id: 'agent-1',
+        source_type: 'subagent',
+        compliance: {
+          compliance_pass_rate: 1.0,
+          rule_adherence_score: 0.9,
+          violation_count: 0,
+        },
+      }) + '\n',
+      'utf-8',
+    );
+
+    // Invocation style (b): explicit subdir cwd.
+    const result = await syncComplianceMetrics({ cwd: fixture.subDir });
+    expect(result.synced).toBe(1);
+
+    // Summary MUST land at <rootDir>/.cleo/metrics/, not <subdir>/.cleo/...
+    const canonicalSummary = join(fixture.rootDir, '.cleo', 'metrics', 'compliance-summary.json');
+    const subdirSummary = join(fixture.subDir, '.cleo', 'metrics', 'compliance-summary.json');
+    expect(existsSync(canonicalSummary)).toBe(true);
+    expect(existsSync(subdirSummary)).toBe(false);
+    // No stray .cleo/ tree under the subdir.
+    expect(existsSync(join(fixture.subDir, '.cleo'))).toBe(false);
+  });
+
+  it('syncComplianceMetrics: writes summary under <rootDir>/.cleo when invoked from subdir cwd (chdir)', async () => {
+    const jsonlPath = join(fixture.rootDir, '.cleo', 'metrics', 'COMPLIANCE.jsonl');
+    writeFileSync(
+      jsonlPath,
+      JSON.stringify({
+        timestamp: '2026-05-18T10:00:00Z',
+        source_id: 'agent-1',
+        source_type: 'subagent',
+        compliance: {
+          compliance_pass_rate: 1.0,
+          rule_adherence_score: 0.9,
+          violation_count: 0,
+        },
+      }) + '\n',
+      'utf-8',
+    );
+
+    // Invocation style (a): chdir to subdir, no explicit cwd.
+    process.chdir(fixture.subDir);
+    const result = await syncComplianceMetrics({});
+    expect(result.synced).toBe(1);
+
+    const canonicalSummary = join(fixture.rootDir, '.cleo', 'metrics', 'compliance-summary.json');
+    const subdirSummary = join(fixture.subDir, '.cleo', 'metrics', 'compliance-summary.json');
+    expect(existsSync(canonicalSummary)).toBe(true);
+    expect(existsSync(subdirSummary)).toBe(false);
+    expect(existsSync(join(fixture.subDir, '.cleo'))).toBe(false);
+  });
+});

--- a/packages/core/src/validation/doctor/checks.ts
+++ b/packages/core/src/validation/doctor/checks.ts
@@ -14,7 +14,12 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { CORE_PROTECTED_FILES } from '../../constants.js';
 import { detectLegacyAgentOutputs } from '../../migration/agent-outputs.js';
-import { getCleoHome, getCleoTemplatesDir, getCleoTemplatesTildePath } from '../../paths.js';
+import {
+  getCleoHome,
+  getCleoTemplatesDir,
+  getCleoTemplatesTildePath,
+  getProjectRoot,
+} from '../../paths.js';
 import {
   getNodeUpgradeInstructions,
   getNodeVersionInfo,
@@ -201,7 +206,7 @@ export function checkAtReferenceResolution(): CheckResult {
  * indicating it serves as the injection hub for CLEO protocol content.
  */
 export function checkAgentsMdHub(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const agentsMdPath = join(root, 'AGENTS.md');
 
   if (!existsSync(agentsMdPath)) {
@@ -261,7 +266,7 @@ export function checkAgentsMdHub(projectRoot?: string): CheckResult {
  * @epic T4637
  */
 export function checkRootGitignore(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const gitignorePath = join(root, '.gitignore');
 
   if (!existsSync(gitignorePath)) {
@@ -326,7 +331,7 @@ export function checkRootGitignore(projectRoot?: string): CheckResult {
  * @task T4700
  */
 export function checkCleoGitignore(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const gitignorePath = join(root, '.cleo', '.gitignore');
 
   if (!existsSync(gitignorePath)) {
@@ -444,7 +449,7 @@ function detectStorageEngine(projectRoot: string): string {
  * @task T4700
  */
 export function checkVitalFilesTracked(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const gitDir = join(root, '.git');
 
   if (!existsSync(gitDir)) {
@@ -510,7 +515,7 @@ export function checkVitalFilesTracked(projectRoot?: string): CheckResult {
  * Returns critical status if any protected file is gitignored.
  */
 export function checkCoreFilesNotIgnored(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const gitDir = join(root, '.git');
 
   if (!existsSync(gitDir)) {
@@ -577,7 +582,7 @@ export function checkCoreFilesNotIgnored(projectRoot?: string): CheckResult {
  * @task T5160
  */
 export function checkSqliteNotTracked(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const gitDir = join(root, '.git');
 
   if (!existsSync(gitDir)) {
@@ -642,7 +647,7 @@ export function checkSqliteNotTracked(projectRoot?: string): CheckResult {
  * @task T4700
  */
 export function checkLegacyAgentOutputs(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const cleoDir = join(root, '.cleo');
   const detection = detectLegacyAgentOutputs(root, cleoDir);
 
@@ -678,7 +683,7 @@ export function checkLegacyAgentOutputs(projectRoot?: string): CheckResult {
  * @task T708 (scaffolding path drift validator)
  */
 export function checkCanonicalRcasdPaths(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const cleoDir = join(root, '.cleo');
   const failures: string[] = [];
 
@@ -781,7 +786,7 @@ export function checkCanonicalRcasdPaths(projectRoot?: string): CheckResult {
  * @task T5153
  */
 export function checkCaampMarkerIntegrity(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const files = ['CLAUDE.md', 'AGENTS.md'];
   const issues: string[] = [];
 
@@ -837,7 +842,7 @@ export function checkCaampMarkerIntegrity(projectRoot?: string): CheckResult {
  * @task T5153
  */
 export function checkAtReferenceTargetExists(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const agentsPath = join(root, 'AGENTS.md');
 
   if (!existsSync(agentsPath)) {
@@ -925,7 +930,7 @@ export function checkAtReferenceTargetExists(projectRoot?: string): CheckResult 
  * @task T5153
  */
 export function checkTemplateFreshness(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const sourcePath = join(root, 'templates', 'CLEO-INJECTION.md');
   const deployedPath = join(getCleoTemplatesDir(), 'CLEO-INJECTION.md');
   const deployedTildePath = `${getCleoTemplatesTildePath()}/CLEO-INJECTION.md`;
@@ -1150,7 +1155,7 @@ export function checkGlobalSchemaHealth(_projectRoot?: string): CheckResult {
  * Schemas should live in ~/.cleo/schemas/ (global), not in project directories.
  */
 export function checkNoLocalSchemas(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = getProjectRoot(projectRoot);
   const localSchemasDir = join(root, '.cleo', 'schemas');
 
   if (!existsSync(localSchemasDir)) {


### PR DESCRIPTION
## Summary

Batch 2 CRITICAL fixes per T9580 audit (`.cleo/rcasd/T9580/research/`). 3 files contained 31 vulnerable sites where `process.cwd()` calls would silently corrupt state when commands ran from a monorepo subdir.

- `validation/doctor/checks.ts` — 12 `process.cwd()` sites normalized via `getProjectRoot()`
- `lifecycle/engine-ops.ts` — 12 forwards normalized
- `compliance/index.ts` — 7 sites normalized

## Fix Pattern

```diff
- const root = projectRoot ?? process.cwd();
+ const root = getProjectRoot(projectRoot);
```

`getProjectRoot(cwd?: string)` (from `packages/core/src/paths.ts:481`) walks up from the given cwd through the 5-tier resolution priority (ALS scope → env vars → walk-up to `.cleo/project-info.json` with `.git` sibling validation).

## Test plan

- Added `packages/core/src/validation/doctor/__tests__/subdir-isolation.test.ts` with 9 test cases that:
  - Create a synthetic project root with `.cleo/` + `.git/` + `project-info.json`
  - Spawn a `<root>/packages/core/` subdir
  - Call the modified functions with both invocation styles:
    - (a) `process.chdir(subdir)` + no arg (relies on `process.cwd()` walk-up)
    - (b) explicit `cwd: <subdir>` argument
  - Assert resolved paths point at `<rootDir>/.cleo`, not `<subdir>/.cleo`
  - Assert no stray `.cleo/` is created in the subdir
- Updated `sync.test.ts`, `doctor-gitignore.test.ts`, `doctor-injection.test.ts` to add `.git/` siblings to their tempDirs (legacy-fallback path through `validateProjectRoot()`).
- Verified `pnpm vitest run src/compliance/__tests__/sync.test.ts --pool=threads` passes 6/6 in the worktree (rolldown native binding broken in the worktree blocks bulk vitest runs; CI runner will validate).

## Acceptance Criteria

- [x] All 12 `process.cwd()` in `doctor/checks.ts` normalized
- [x] All 12 `process.cwd()` in `lifecycle/engine-ops.ts` normalized
- [x] All 7 sites in `compliance/index.ts` normalized
- [x] `getProjectRoot` imported from relative `../paths.js` (no cross-package import)
- [x] No `any` or `unknown` casts introduced
- [x] ESM `.js` extensions on all imports
- [x] New subdir-isolation test asserts canonical-root writes, not just function calls

Closes T9581 (Batch 2 of T9580). Unblocks T9582 + T9583.