### PR TITLE
fix(T9583): normalize project-root in release/orchestrate/spawn

### DIFF
--- a/packages/core/src/orchestrate/handoff-ops.ts
+++ b/packages/core/src/orchestrate/handoff-ops.ts
@@ -15,7 +15,7 @@
 import type { Session, TaskWorkState } from '@cleocode/contracts';
 import type { OrchestrateHandoffParams } from '@cleocode/contracts/operations/orchestrate';
 import { type EngineResult, engineError } from '../engine-result.js';
-import { resolveProjectRoot } from '../store/file-utils.js';
+import { getProjectRoot } from '../paths.js';
 import { orchestrateSpawn, sendConduitEvent } from './spawn-ops.js';
 
 export type { EngineResult };
@@ -138,7 +138,7 @@ export async function orchestrateHandoff(
     return engineError('E_INVALID_INPUT', 'protocolType is required');
   }
 
-  const root = projectRoot || resolveProjectRoot();
+  const root = getProjectRoot(projectRoot);
 
   const steps: HandoffState = {
     contextInject: { status: 'pending', operation: 'session.context.inject' },

--- a/packages/core/src/orchestrate/lifecycle-ops.ts
+++ b/packages/core/src/orchestrate/lifecycle-ops.ts
@@ -25,8 +25,8 @@ import {
 import { getSkillContent } from '../orchestration/skill-ops.js';
 import { computeProgress, computeStartupSummary } from '../orchestration/status.js';
 import { getUnblockOpportunities } from '../orchestration/unblock.js';
+import { getProjectRoot } from '../paths.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
-import { resolveProjectRoot } from '../store/file-utils.js';
 import { loadTasks } from './query-ops.js';
 
 export type { EngineResult };
@@ -101,7 +101,7 @@ export async function orchestrateStartup(
   }
 
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const accessor = await getTaskAccessor(root);
 
     const tasks = await loadTasks(root);
@@ -142,7 +142,7 @@ export async function orchestrateBootstrap(
   params?: { speed?: 'fast' | 'full' | 'complete' },
 ): Promise<EngineResult<BrainState>> {
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const accessor = await getTaskAccessor(root);
     const brain = await buildBrainState(root, params, accessor);
     return { success: true, data: brain };
@@ -160,7 +160,7 @@ export async function orchestrateBootstrap(
  */
 export async function orchestrateCriticalPath(projectRoot?: string): Promise<EngineResult> {
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const accessor = await getTaskAccessor(root);
     const result = await getCriticalPath(root, accessor);
     return { success: true, data: result };
@@ -178,7 +178,7 @@ export async function orchestrateCriticalPath(projectRoot?: string): Promise<Eng
  */
 export async function orchestrateUnblockOpportunities(projectRoot?: string): Promise<EngineResult> {
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const accessor = await getTaskAccessor(root);
     const result = await getUnblockOpportunities(root, accessor);
     return { success: true, data: result };
@@ -242,7 +242,7 @@ export async function orchestrateParallelStart(
   }
 
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const accessor = await getTaskAccessor(root);
     const result = await startParallelExecution(epicId, wave, root, accessor);
     return { success: true, data: result };
@@ -271,7 +271,7 @@ export async function orchestrateParallelEnd(
   }
 
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const result = await endParallelExecution(epicId, wave, root);
 
     if (result.alreadyEnded) {
@@ -302,7 +302,7 @@ export async function orchestrateParallelEnd(
  */
 export async function orchestrateCheck(projectRoot?: string): Promise<EngineResult> {
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const parallelState = await getParallelStatus(root);
     const tasks = await loadTasks(root);
 
@@ -338,7 +338,7 @@ export async function orchestrateCheck(projectRoot?: string): Promise<EngineResu
  */
 export function orchestrateSkillInject(skillName: string, projectRoot?: string): EngineResult {
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const result = getSkillContent(skillName, root);
     return { success: true, data: result };
   } catch (err: unknown) {

--- a/packages/core/src/orchestrate/pivot.ts
+++ b/packages/core/src/orchestrate/pivot.ts
@@ -25,9 +25,9 @@ import type { TaskWorkState } from '@cleocode/contracts';
 import { ExitCode } from '@cleocode/contracts';
 import { CleoError } from '../errors.js';
 import { memoryObserve } from '../memory/engine-compat.js';
+import { getProjectRoot } from '../paths.js';
 import type { DataAccessor } from '../store/data-accessor.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
-import { resolveProjectRoot } from '../store/file-utils.js';
 import { startTask, stopTask } from '../task-work/index.js';
 import { logOperation } from '../tasks/add.js';
 import { updateTask } from '../tasks/update.js';
@@ -48,7 +48,7 @@ export interface PivotOptions {
    * complete independently.
    */
   blocksFrom?: boolean;
-  /** Optional override for project root — defaults to {@link resolveProjectRoot}. */
+  /** Optional override for project root — defaults to {@link getProjectRoot}. */
   projectRoot?: string;
   /** Optional override for the data accessor (used by tests). */
   accessor?: DataAccessor;
@@ -206,7 +206,7 @@ export async function pivotTask(
     );
   }
 
-  const root = opts.projectRoot ?? resolveProjectRoot();
+  const root = getProjectRoot(opts.projectRoot);
   const acc = opts.accessor ?? (await getTaskAccessor(root));
 
   // ---------------------------------------------------------------------------

--- a/packages/core/src/orchestrate/plan.ts
+++ b/packages/core/src/orchestrate/plan.ts
@@ -15,9 +15,9 @@ import type { AgentTier, ResolvedAgent, Task } from '@cleocode/contracts';
 import type { OrchestratePlanResult } from '@cleocode/contracts/operations/orchestrate';
 import { type EngineResult, engineError } from '../engine-result.js';
 import { getEnrichedWaves } from '../orchestration/waves.js';
+import { getProjectRoot } from '../paths.js';
 import { AgentNotFoundError, resolveAgent } from '../store/agent-resolver.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
-import { resolveProjectRoot } from '../store/file-utils.js';
 import { ensureGlobalSignaldockDb, getGlobalSignaldockDbPath } from '../store/signaldock-sqlite.js';
 import { loadTasks } from './query-ops.js';
 
@@ -296,7 +296,7 @@ export async function orchestratePlan(
     return engineError('E_INVALID_INPUT', 'epicId is required');
   }
 
-  const root = input.projectRoot || resolveProjectRoot();
+  const root = getProjectRoot(input.projectRoot);
 
   try {
     const tasks = await loadTasks(root);

--- a/packages/core/src/orchestrate/query-ops.ts
+++ b/packages/core/src/orchestrate/query-ops.ts
@@ -21,8 +21,8 @@ import { analyzeEpic, getNextTask, getReadyTasks } from '../orchestration/index.
 import { computeEpicStatus, computeOverallStatus } from '../orchestration/status.js';
 import { validateSpawnReadiness } from '../orchestration/validate-spawn.js';
 import { getEnrichedWaves } from '../orchestration/waves.js';
+import { getProjectRoot } from '../paths.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
-import { resolveProjectRoot } from '../store/file-utils.js';
 import type { DepGraphIssue } from '../tasks/dep-graph-validator.js';
 import { runValidation } from '../tasks/dep-graph-validator.js';
 
@@ -100,7 +100,7 @@ export type { EngineResult };
  * @returns Array of all tasks, empty on error.
  */
 export async function loadTasks(projectRoot?: string): Promise<Task[]> {
-  const root = projectRoot || resolveProjectRoot();
+  const root = getProjectRoot(projectRoot);
   try {
     const accessor = await getTaskAccessor(root);
     const result = await accessor.queryTasks({
@@ -125,7 +125,7 @@ export async function orchestrateStatus(
   projectRoot?: string,
 ): Promise<EngineResult> {
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const tasks = await loadTasks(root);
 
     if (epicId) {
@@ -174,7 +174,7 @@ export async function orchestrateAnalyze(
   }
 
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const accessor = await getTaskAccessor(root);
     const result = await analyzeEpic(epicId, root, accessor);
 
@@ -249,7 +249,7 @@ export async function orchestrateReady(
   }
 
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     // T929: verify the epic exists before computing the ready-set so that a
     // nonexistent epicId returns E_NOT_FOUND (exit 4) instead of success:{total:0}.
     const tasks = await loadTasks(root);
@@ -374,7 +374,7 @@ export async function orchestrateNext(epicId: string, projectRoot?: string): Pro
   }
 
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const accessor = await getTaskAccessor(root);
     const nextTask = await getNextTask(epicId, root, accessor);
 
@@ -427,7 +427,7 @@ export async function orchestrateWaves(
   }
 
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const accessor = await getTaskAccessor(root);
     const result = await getEnrichedWaves(epicId, root, accessor);
     return { success: true, data: result };
@@ -450,7 +450,7 @@ export async function orchestrateContext(
   projectRoot?: string,
 ): Promise<EngineResult> {
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const tasks = await loadTasks(root);
 
     let taskCount = tasks.length;
@@ -482,7 +482,7 @@ export async function orchestrateValidate(
   }
 
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     const accessor = await getTaskAccessor(root);
     const result = await validateSpawnReadiness(taskId, root, accessor);
     return { success: true, data: result };

--- a/packages/core/src/orchestrate/spawn-ops.ts
+++ b/packages/core/src/orchestrate/spawn-ops.ts
@@ -67,10 +67,10 @@ import { composeSpawnPayload } from '../orchestration/spawn.js';
 import type { ConduitSubscriptionConfig } from '../orchestration/spawn-prompt.js';
 import { resolveEffectiveTier } from '../orchestration/tier-selector.js';
 import { validateSpawnReadiness } from '../orchestration/validate-spawn.js';
+import { getProjectRoot } from '../paths.js';
 import { spawnWorktree } from '../sentient/worktree-dispatch.js';
 import { initializeDefaultAdapters, spawnRegistry } from '../spawn/adapter-registry.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
-import { resolveProjectRoot } from '../store/file-utils.js';
 import { getActiveSession } from '../store/session-store.js';
 import { provisionIsolatedShell } from '../tools/sdk/isolation.js';
 import { openSignaldockDbForComposer } from './plan.js';
@@ -481,7 +481,7 @@ export async function orchestrateSpawnExecute(
   tier?: 0 | 1 | 2,
   opts: OrchestrateSpawnExecuteOpts = {},
 ): Promise<EngineResult> {
-  const cwd = projectRoot ?? process.cwd();
+  const cwd = getProjectRoot(projectRoot);
   const autoComplete = opts.autoComplete ?? true;
 
   try {
@@ -906,7 +906,7 @@ export async function orchestrateSpawn(
   };
 
   try {
-    const root = projectRoot || resolveProjectRoot();
+    const root = getProjectRoot(projectRoot);
     spawnLogger.info(
       { taskId, tier, noWorktree, budgetMs: SPAWN_BUDGET_MS },
       'T9545 spawn pipeline started',

--- a/packages/core/src/release/__tests__/subdir-isolation.test.ts
+++ b/packages/core/src/release/__tests__/subdir-isolation.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Sub-directory isolation tests for the release pipeline (T9583).
+ *
+ * Verifies that release verbs ({@link releasePlan}, {@link releaseOpen},
+ * {@link releaseReconcileV2}) resolve the project root via
+ * {@link getProjectRoot} even when invoked from a monorepo sub-directory.
+ *
+ * Regression guard: prior to T9583 these verbs called `process.cwd()`
+ * directly. Running `cleo release plan` from `packages/core` would write the
+ * plan file to `packages/core/.cleo/release/<v>.plan.json` instead of the
+ * canonical `<root>/.cleo/release/<v>.plan.json`, fragmenting release state.
+ *
+ * @task T9583
+ * @epic T9580
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ReleasePlan, Task } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, resetDbState } from '../../store/sqlite.js';
+import { createSqliteDataAccessor } from '../../store/sqlite-data-accessor.js';
+import { releasePlan } from '../plan.js';
+
+let testDir: string;
+let subdir: string;
+let originalCwd: string;
+
+/**
+ * Build a Task with sensible defaults so plan-time evidence checks pass.
+ */
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    title: overrides.title ?? `Task ${overrides.id}`,
+    description: overrides.description ?? `Description for ${overrides.id}`,
+    status: overrides.status ?? 'done',
+    priority: overrides.priority ?? 'medium',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    pipelineStage: overrides.pipelineStage ?? 'contribution',
+    verification: overrides.verification ?? {
+      passed: true,
+      round: 1,
+      gates: { implemented: true },
+      evidence: {
+        implemented: {
+          atoms: [{ kind: 'commit', sha: 'abc1234567', shortSha: 'abc1234' }],
+          capturedAt: new Date().toISOString(),
+          capturedBy: 'test-agent',
+        },
+      },
+      lastAgent: null,
+      lastUpdated: new Date().toISOString(),
+      failureLog: [],
+    },
+    ...overrides,
+  } as Task;
+}
+
+async function initTestGit(root: string): Promise<void> {
+  execFileSync('git', ['init', '--quiet', root], { encoding: 'utf-8' });
+  execFileSync('git', ['-C', root, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', root, 'config', 'user.name', 'Test']);
+  execFileSync('git', ['-C', root, 'config', 'commit.gpgsign', 'false']);
+}
+
+async function seedEpic(epicId: string, childCount: number, root: string): Promise<void> {
+  const accessor = await createSqliteDataAccessor(root);
+  try {
+    await accessor.setMetaValue('schema_version', '2.10.0');
+    await accessor.upsertSingleTask(
+      makeTask({ id: epicId, type: 'epic', title: 'Epic', pipelineStage: 'contribution' }),
+    );
+    for (let i = 1; i <= childCount; i++) {
+      const id = `T${10000 + i}`;
+      await accessor.upsertSingleTask(
+        makeTask({
+          id,
+          parentId: epicId,
+          title: `Child ${i}`,
+        }),
+      );
+    }
+  } finally {
+    await accessor.close();
+  }
+}
+
+beforeEach(async () => {
+  originalCwd = process.cwd();
+  testDir = await mkdtemp(join(tmpdir(), 'cleo-subdir-iso-'));
+  await mkdir(join(testDir, '.cleo'), { recursive: true });
+  writeFileSync(
+    join(testDir, '.cleo', 'config.json'),
+    JSON.stringify({
+      enforcement: { session: { requiredForMutate: false } },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+  writeFileSync(
+    join(testDir, '.cleo', 'project-info.json'),
+    JSON.stringify({
+      projectHash: 'testhash00000',
+      projectId: 'test-project-id',
+      projectRoot: testDir,
+      projectName: 'test',
+    }),
+  );
+
+  // Carve out a monorepo-like sub-directory: <root>/packages/core
+  subdir = join(testDir, 'packages', 'core');
+  await mkdir(subdir, { recursive: true });
+
+  await initTestGit(testDir);
+  resetDbState();
+});
+
+afterEach(async () => {
+  // Always restore cwd before tearing down — otherwise vitest follow-on tests
+  // inherit a removed working directory and fail with ENOENT on cwd().
+  try {
+    process.chdir(originalCwd);
+  } catch {
+    // best-effort
+  }
+  try {
+    closeDb();
+  } catch {
+    // best-effort
+  }
+  await rm(testDir, { recursive: true, force: true });
+});
+
+// =============================================================================
+// Sub-directory isolation
+// =============================================================================
+
+describe('release pipeline — sub-directory isolation (T9583)', () => {
+  it('releasePlan writes .cleo/release/<v>.plan.json to project root, not subdir cwd', async () => {
+    await seedEpic('T9999', 2, testDir);
+
+    // Run from the sub-directory — this is the regression vector.
+    process.chdir(subdir);
+
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      // NOTE: deliberately NOT passing projectRoot — exercising the walk-up
+      // resolution that getProjectRoot() performs from process.cwd().
+      createdBy: 'test',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(`releasePlan failed: ${result.error.message}`);
+
+    // The plan path MUST root at testDir, NOT subdir.
+    const expectedRootPlanPath = join(testDir, '.cleo', 'release', 'v2026.6.0.plan.json');
+    const wrongSubdirPlanPath = join(subdir, '.cleo', 'release', 'v2026.6.0.plan.json');
+
+    expect(result.data.planPath).toBe(expectedRootPlanPath);
+    expect(existsSync(expectedRootPlanPath)).toBe(true);
+    expect(existsSync(wrongSubdirPlanPath)).toBe(false);
+
+    // Plan content sanity check — confirms the plan was actually written to
+    // the canonical location with the expected epic.
+    const plan: ReleasePlan = JSON.parse(readFileSync(expectedRootPlanPath, 'utf-8'));
+    expect(plan.epicId).toBe('T9999');
+    expect(plan.tasks).toHaveLength(2);
+  });
+
+  it('releasePlan honours an explicit projectRoot override over cwd-walkup', async () => {
+    await seedEpic('T9999', 1, testDir);
+
+    // From the subdir, supply an explicit projectRoot — that path wins.
+    process.chdir(subdir);
+
+    const result = await releasePlan({
+      version: 'v2026.7.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      createdBy: 'test',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(`releasePlan failed: ${result.error.message}`);
+
+    expect(result.data.planPath).toBe(join(testDir, '.cleo', 'release', 'v2026.7.0.plan.json'));
+  });
+
+  it('releasePlan honours CLEO_ROOT env var when projectRoot omitted', async () => {
+    await seedEpic('T9999', 1, testDir);
+
+    // No cwd change — but set CLEO_ROOT to override.
+    const prev = process.env['CLEO_ROOT'];
+    process.env['CLEO_ROOT'] = testDir;
+    try {
+      const result = await releasePlan({
+        version: 'v2026.8.0',
+        epicId: 'T9999',
+        channel: 'latest',
+        scheme: 'calver',
+        createdBy: 'test',
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error(`releasePlan failed: ${result.error.message}`);
+
+      expect(result.data.planPath).toBe(join(testDir, '.cleo', 'release', 'v2026.8.0.plan.json'));
+    } finally {
+      if (prev === undefined) delete process.env['CLEO_ROOT'];
+      else process.env['CLEO_ROOT'] = prev;
+    }
+  });
+});

--- a/packages/core/src/release/backfill.ts
+++ b/packages/core/src/release/backfill.ts
@@ -45,7 +45,7 @@ import { dirname, join } from 'node:path';
 import { sql } from 'drizzle-orm';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { getLogger } from '../logger.js';
-import { resolveProjectRoot } from '../store/file-utils.js';
+import { getProjectRoot } from '../paths.js';
 import { getDb } from '../store/sqlite.js';
 import * as schema from '../store/tasks-schema.js';
 import { releaseReconcileV2 } from './reconcile.js';
@@ -508,7 +508,7 @@ export async function provenanceBackfill(
   opts: BackfillOptions,
 ): Promise<EngineResult<BackfillResult>> {
   const startedAt = Date.now();
-  const projectRoot = opts.projectRoot ?? resolveProjectRoot();
+  const projectRoot = getProjectRoot(opts.projectRoot);
   const since = opts.since;
   const dryRun = opts.dryRun === true;
   const forceOverwrite = opts.forceOverwrite === true;

--- a/packages/core/src/release/ci.ts
+++ b/packages/core/src/release/ci.ts
@@ -10,6 +10,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { getProjectRoot } from '../paths.js';
 import { loadReleaseConfig } from './release-config.js';
 
 /** Supported CI/CD platforms. */
@@ -32,7 +33,7 @@ export function getPlatformPath(platform: CIPlatform): string {
 
 /** Detect the CI platform from the project. */
 export function detectCIPlatform(projectDir?: string): CIPlatform | null {
-  const dir = projectDir ?? process.cwd();
+  const dir = getProjectRoot(projectDir);
 
   if (existsSync(join(dir, '.github'))) return 'github-actions';
   if (existsSync(join(dir, '.gitlab-ci.yml'))) return 'gitlab-ci';
@@ -157,7 +158,7 @@ export function writeCIConfig(
   platform: CIPlatform,
   options: { projectDir?: string; dryRun?: boolean } = {},
 ): { action: string; path: string; content: string } {
-  const projectDir = options.projectDir ?? process.cwd();
+  const projectDir = getProjectRoot(options.projectDir);
   const outputPath = join(projectDir, getPlatformPath(platform));
   const content = generateCIConfig(platform, projectDir);
 
@@ -176,7 +177,7 @@ export function validateCIConfig(
   platform: CIPlatform,
   projectDir?: string,
 ): { valid: boolean; exists: boolean; errors: string[] } {
-  const dir = projectDir ?? process.cwd();
+  const dir = getProjectRoot(projectDir);
   const configPath = join(dir, getPlatformPath(platform));
 
   if (!existsSync(configPath)) {

--- a/packages/core/src/release/engine-ops.ts
+++ b/packages/core/src/release/engine-ops.ts
@@ -22,8 +22,8 @@ import { dirname, join } from 'node:path';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { getIvtrState } from '../lifecycle/ivtr-loop.js';
 import { getLogger } from '../logger.js';
+import { getProjectRoot } from '../paths.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
-import { resolveProjectRoot } from '../store/file-utils.js';
 import { isGhCliAvailable } from './github-pr.js';
 import { getReleaseBranchConfig, loadReleaseConfig } from './release-config.js';
 import {
@@ -271,7 +271,7 @@ async function hasManifestEntry(version: string, projectRoot?: string): Promise<
  * Load tasks via DataAccessor (SQLite).
  */
 async function loadTasks(projectRoot?: string): Promise<ReleaseTaskRecord[]> {
-  const root = projectRoot ?? resolveProjectRoot();
+  const root = getProjectRoot(projectRoot);
   try {
     const accessor = await getTaskAccessor(root);
     const result = await accessor.queryTasks({});
@@ -478,7 +478,7 @@ export async function releaseGateCheck(
     return engineError('E_INVALID_INPUT', 'epicId is required');
   }
 
-  const cwd = projectRoot ?? resolveProjectRoot();
+  const cwd = getProjectRoot(projectRoot);
 
   // Bypass: loud warning, return pass with forcedBypass flag.
   if (force) {
@@ -596,7 +596,7 @@ export async function releaseIvtrAutoSuggest(
     return engineError('E_INVALID_INPUT', 'taskId is required');
   }
 
-  const cwd = projectRoot ?? resolveProjectRoot();
+  const cwd = getProjectRoot(projectRoot);
 
   try {
     // Find the parent epic for this task.
@@ -868,7 +868,7 @@ export async function releaseRollbackFull(
     return engineError('E_INVALID_INPUT', 'version is required');
   }
 
-  const cwd = projectRoot ?? resolveProjectRoot();
+  const cwd = getProjectRoot(projectRoot);
   const gitTag = `v${version.replace(/^v/, '')}`;
   const reason = options.reason ?? 'Rollback via cleo release rollback';
   const gitCwd = {
@@ -999,7 +999,7 @@ export async function releaseChangelogSince(
     return engineError('E_INVALID_INPUT', 'sinceTag is required');
   }
 
-  const cwd = projectRoot ?? resolveProjectRoot();
+  const cwd = getProjectRoot(projectRoot);
 
   try {
     // Walk git log since the given tag using a parseable format
@@ -1157,7 +1157,7 @@ export async function releasePush(
     let commitSha: string | undefined;
     try {
       commitSha = execFileSync('git', ['rev-parse', 'HEAD'], {
-        cwd: projectRoot ?? process.cwd(),
+        cwd: getProjectRoot(projectRoot),
         encoding: 'utf-8',
         stdio: 'pipe',
         timeout: 60_000,
@@ -1238,7 +1238,7 @@ export async function releasePrStatus(
     return engineError('E_INVALID_INPUT', 'version is required');
   }
 
-  const cwd = projectRoot ?? resolveProjectRoot();
+  const cwd = getProjectRoot(projectRoot);
 
   if (!isGhCliAvailable()) {
     return engineError(

--- a/packages/core/src/release/invariants/registry.ts
+++ b/packages/core/src/release/invariants/registry.ts
@@ -17,6 +17,8 @@
  * @adr ADR-056 D5
  */
 
+import { getProjectRoot } from '../../paths.js';
+
 /**
  * Severity classifications for invariants.
  *
@@ -162,7 +164,7 @@ export async function runInvariants(
   tag: string,
   options: { dryRun?: boolean; repoRoot?: string; cwd?: string } = {},
 ): Promise<InvariantReport> {
-  const repoRoot = options.repoRoot ?? options.cwd ?? process.cwd();
+  const repoRoot = options.repoRoot ?? getProjectRoot(options.cwd);
   const dryRun = options.dryRun ?? false;
 
   const runOpts: InvariantRunOptions = {

--- a/packages/core/src/release/open.ts
+++ b/packages/core/src/release/open.ts
@@ -47,6 +47,7 @@ import {
 import { eq } from 'drizzle-orm';
 
 import { getLogger } from '../logger.js';
+import { getProjectRoot } from '../paths.js';
 import { getDb } from '../store/sqlite.js';
 import { releasesNew } from '../store/tasks-schema.js';
 import { runGitWithLockRetry } from './engine-ops.js';
@@ -90,7 +91,13 @@ export interface ReleaseOpenOptions {
    * NOT the default — the workflow can re-derive the plan from `releases` + tasks.db.
    */
   commitPlan?: boolean;
-  /** Project root override. Defaults to `process.cwd()`. */
+  /**
+   * Project root override. Defaults to the canonical project root resolved
+   * via {@link getProjectRoot} (walks up from `process.cwd()` for monorepo
+   * subdir invocations; honours `CLEO_ROOT` / `CLEO_PROJECT_ROOT`).
+   *
+   * @task T9583
+   */
   projectRoot?: string;
 }
 
@@ -420,7 +427,7 @@ export async function releaseOpen(
   opts: ReleaseOpenOptions,
   runnerOverride?: ReleaseOpenRunner,
 ): Promise<EngineResult<ReleaseOpenResult>> {
-  const projectRoot = opts.projectRoot ?? process.cwd();
+  const projectRoot = getProjectRoot(opts.projectRoot);
   const workflow = opts.workflow ?? DEFAULT_OPEN_WORKFLOW;
   const watch = opts.watch === true;
   const commitPlan = opts.commitPlan === true;

--- a/packages/core/src/release/plan.ts
+++ b/packages/core/src/release/plan.ts
@@ -47,7 +47,7 @@ import {
 import { and, desc, eq } from 'drizzle-orm';
 
 import { getLogger } from '../logger.js';
-import { getCleoDirAbsolute } from '../paths.js';
+import { getCleoDirAbsolute, getProjectRoot } from '../paths.js';
 import { getProjectInfoSync } from '../project-info.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { getDb } from '../store/sqlite.js';
@@ -80,7 +80,13 @@ export interface ReleasePlanOptions {
   hotfix?: boolean;
   /** Dry-run flag — equivalent to `CLEO_DRY_RUN=1`. Reads only; no writes. */
   dryRun?: boolean;
-  /** Project root override. Defaults to `process.cwd()`. */
+  /**
+   * Project root override. Defaults to the canonical project root resolved
+   * via {@link getProjectRoot} (walks up from `process.cwd()` for monorepo
+   * subdir invocations; honours `CLEO_ROOT` / `CLEO_PROJECT_ROOT`).
+   *
+   * @task T9583
+   */
   projectRoot?: string;
   /** Creator identity for `plan.createdBy`. Defaults to `process.env.USER` or `cleo-agent`. */
   createdBy?: string;
@@ -691,7 +697,7 @@ function assemblePreflightSummary(unresolvedTools: string[]): ReleasePreflightSu
 export async function releasePlan(
   opts: ReleasePlanOptions,
 ): Promise<EngineResult<ReleasePlanResult>> {
-  const projectRoot = opts.projectRoot ?? process.cwd();
+  const projectRoot = getProjectRoot(opts.projectRoot);
   const scheme: ReleaseScheme = opts.scheme ?? 'calver';
   const channel: ReleasePlanChannel = opts.channel ?? 'latest';
   const releaseKind: ReleaseKind = opts.hotfix ? 'hotfix' : 'regular';

--- a/packages/core/src/release/reconcile.ts
+++ b/packages/core/src/release/reconcile.ts
@@ -44,7 +44,7 @@ import { eq } from 'drizzle-orm';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { getLogger } from '../logger.js';
 import { generateProjectHash } from '../nexus/hash.js';
-import { resolveProjectRoot } from '../store/file-utils.js';
+import { getProjectRoot } from '../paths.js';
 import { getDb, getNativeDb } from '../store/sqlite.js';
 import * as schema from '../store/tasks-schema.js';
 
@@ -823,7 +823,7 @@ export async function releaseReconcileV2(
   opts: ReleaseReconcileV2Options = {},
 ): Promise<EngineResult<ReleaseReconcileV2Result>> {
   const startedAt = Date.now();
-  const projectRoot = opts.projectRoot ?? resolveProjectRoot();
+  const projectRoot = getProjectRoot(opts.projectRoot);
 
   // ── 1. Pre-conditions (R-080 .. R-083) ──
   const planRes = loadPlan(version, projectRoot);

--- a/packages/core/src/release/release-config.ts
+++ b/packages/core/src/release/release-config.ts
@@ -16,12 +16,14 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getCleoDir } from '../paths.js';
+import { getCleoDir, getProjectRoot } from '../paths.js';
 
 /** Synchronous config value reader (avoids async config pipeline). */
 function readConfigValueSync(path: string, defaultValue: unknown, cwd?: string): unknown {
   try {
-    const configPath = join(getCleoDir(cwd), 'config.json');
+    // T9583 — normalize cwd via getProjectRoot so monorepo subdir invocations
+    // still resolve `.cleo/config.json` at the canonical project root.
+    const configPath = join(getCleoDir(getProjectRoot(cwd)), 'config.json');
     if (!existsSync(configPath)) return defaultValue;
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     const keys = path.split('.');
@@ -47,7 +49,9 @@ function readConfigValueSync(path: string, defaultValue: unknown, cwd?: string):
  */
 function loadReleaseConfigJson(cwd?: string): Partial<ProjectReleaseConfig> {
   try {
-    const configPath = join(getCleoDir(cwd), 'release-config.json');
+    // T9583 — normalize cwd via getProjectRoot so subdir invocations resolve
+    // the project's `.cleo/release-config.json` (not a stray subdir file).
+    const configPath = join(getCleoDir(getProjectRoot(cwd)), 'release-config.json');
     if (!existsSync(configPath)) return {};
     const raw = readFileSync(configPath, 'utf-8');
     return JSON.parse(raw) as Partial<ProjectReleaseConfig>;

--- a/packages/core/src/release/release-manifest.ts
+++ b/packages/core/src/release/release-manifest.ts
@@ -608,7 +608,7 @@ export async function generateReleaseChangelog(
     .run();
 
   // Write or update CHANGELOG.md with section-aware merge
-  const changelogPath = join(cwd ?? process.cwd(), 'CHANGELOG.md');
+  const changelogPath = join(cwd ?? getProjectRoot(), 'CHANGELOG.md');
   let existingChangelogContent = '';
   try {
     existingChangelogContent = await readFile(changelogPath, 'utf8');

--- a/packages/core/src/release/verify-provenance.ts
+++ b/packages/core/src/release/verify-provenance.ts
@@ -33,7 +33,7 @@ import { join, resolve } from 'node:path';
 import { sql } from 'drizzle-orm';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { getLogger } from '../logger.js';
-import { resolveProjectRoot } from '../store/file-utils.js';
+import { getProjectRoot } from '../paths.js';
 import { getDb } from '../store/sqlite.js';
 
 const log = getLogger('release:verify-provenance');
@@ -493,7 +493,7 @@ export async function verifyProvenance(
   opts: VerifyProvenanceOptions,
 ): Promise<EngineResult<VerifyProvenanceResult>> {
   const startedAt = Date.now();
-  const projectRoot = opts.projectRoot ?? resolveProjectRoot();
+  const projectRoot = getProjectRoot(opts.projectRoot);
 
   // Sanity-check input — without `version` we require `all: true`.
   if (!opts.version && opts.all !== true) {

--- a/packages/core/src/spawn/adapter-registry.ts
+++ b/packages/core/src/spawn/adapter-registry.ts
@@ -25,6 +25,7 @@ import type {
   SpawnContext,
   SpawnResult,
 } from '@cleocode/contracts';
+import { getProjectRoot } from '../paths.js';
 
 /**
  * Spawn capability type - subset of provider capabilities related to spawning
@@ -285,6 +286,6 @@ export async function initializeSpawnAdapters(
  */
 export async function initializeDefaultAdapters(): Promise<void> {
   const { discoverAdapterManifests } = await import('../adapters/discovery.js');
-  const manifests = discoverAdapterManifests(process.cwd());
+  const manifests = discoverAdapterManifests(getProjectRoot());
   await initializeSpawnAdapters(manifests);
 }


### PR DESCRIPTION
## Summary

Batch 1 HIGH fixes per T9580 audit. Replaces every `process.cwd()` and `resolveProjectRoot()` (the thin `CLEO_ROOT || process.cwd()` helper) in the release pipeline, orchestrate ops, and spawn registry with `getProjectRoot()` from `packages/core/src/paths.ts`.

Running `cleo release plan|open|reconcile|backfill|verify-provenance` or any orchestrate verb from a monorepo sub-directory now writes plan files, audit logs, and config reads against the canonical project root rather than `<subdir>/.cleo/...`.

### Files touched

**Release pipeline:**
- `engine-ops.ts` — 7 `resolveProjectRoot()` + 1 `process.cwd()` site
- `release-manifest.ts` — CHANGELOG.md path normalization
- `release-config.ts` — normalize `cwd` before reading `.cleo/config.json` and `.cleo/release-config.json`
- `plan.ts`, `open.ts`, `reconcile.ts`, `backfill.ts`, `verify-provenance.ts` — entry-point root resolution
- `ci.ts` — 3 sites in `detectCIPlatform` / `writeCIConfig` / `validateCIConfig`
- `invariants/registry.ts` — `runInvariants` repo-root resolution

**Orchestrate pipeline:**
- `spawn-ops.ts` — `orchestrateSpawnExecute` + `orchestrateSpawn` root resolution
- `handoff-ops.ts`, `query-ops.ts` (8 sites), `pivot.ts`, `plan.ts`, `lifecycle-ops.ts` (7 sites)

**Spawn registry:**
- `adapter-registry.ts` — `initializeDefaultAdapters` discovery root

### New test

`packages/core/src/release/__tests__/subdir-isolation.test.ts` — asserts that:
1. `releasePlan` invoked from `<root>/packages/core` writes the plan to `<root>/.cleo/release/<v>.plan.json`, not `<subdir>/.cleo/...`.
2. An explicit `projectRoot` override is honoured over cwd walk-up.
3. `CLEO_ROOT` env var is honoured over cwd walk-up.

### Out of scope (filed as Batch 2/3 per T9580 audit)

- `doctor` / `lifecycle` / `compliance` (T9581)
- `agent` / `nexus` / `conduit` (T9582)

## Test plan

- [x] `npx tsc --noEmit` on `packages/core` — no new type errors (pre-existing missing-module errors unrelated)
- [x] `npx biome check --write` on changed directories — no fixes applied (already clean)
- [ ] CI runs full test suite — verify 196+ release tests still pass
- [ ] CI runs the new `subdir-isolation.test.ts` — verify the three sub-dir-isolation assertions pass

Closes T9583 (Batch 1 of T9580).