### PR TITLE
fix(T9601): normalize resolveCanonicalProjectRoot path via realpathSync (macOS)

### DIFF
--- a/packages/core/src/tasks/__tests__/evidence-content-intersect.test.ts
+++ b/packages/core/src/tasks/__tests__/evidence-content-intersect.test.ts
@@ -27,7 +27,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, realpathSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Task } from '@cleocode/contracts';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -427,8 +427,9 @@ describe('T-WT-2 — resolveCanonicalProjectRoot', () => {
     });
 
     // Verify resolveCanonicalProjectRoot maps the real worktree back to the main repo.
+    // Use realpathSync for both sides to handle macOS /var → /private/var symlink.
     const resolved = resolveCanonicalProjectRoot(worktreeDir);
-    expect(resolved).toBe(env.tempDir);
+    expect(resolved).toBe(realpathSync(env.tempDir));
 
     // validateAtom with projectRoot = MAIN repo (simulating step 2.5 resolution)
     // should accept the commit since its diff intersects the declared AC file.

--- a/packages/core/src/tasks/evidence.ts
+++ b/packages/core/src/tasks/evidence.ts
@@ -22,7 +22,7 @@
 
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { readFile, stat } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve as resolvePath } from 'node:path';
 
@@ -671,7 +671,15 @@ export function resolveCanonicalProjectRoot(projectRoot: string): string {
       // gitdirPath ends with /.git/worktrees/<name>; main repo is 3 levels up
       const worktreesDir = dirname(gitdirPath); // .../.git/worktrees
       const dotGit = dirname(worktreesDir); // .../.git
-      return dirname(dotGit); // main repo root
+      const mainRepo = dirname(dotGit); // main repo root
+      // Resolve symlinks (needed on macOS where /var → /private/var) so that
+      // the returned path compares equal to realpathSync(env.tempDir) in tests
+      // and matches what getTaskAccessor() uses for DB-path construction.
+      try {
+        return realpathSync(mainRepo);
+      } catch {
+        return mainRepo;
+      }
     }
   } catch {
     /* fall through — not a valid git repo or stat failed */


### PR DESCRIPTION
## Summary

- PR #270 merged `resolveCanonicalProjectRoot` with a test that failed on macOS-latest because `/var/folders/...` symlinks resolve to `/private/var/folders/...` on macOS.
- This PR adds `realpathSync` normalization to the result path so the comparison succeeds on both Linux and macOS.
- Also updates the test assertion to use `realpathSync(env.tempDir)` for cross-platform correctness.

## Test plan

- [ ] `Unit Tests (macos-latest)` should now pass
- [ ] `Unit Tests (ubuntu-latest)` continues to pass (no regression)
- [ ] `evidence-content-intersect.test.ts` — all 22 tests pass

Refs T9601 / T-WT-2 from `docs/plans/E-WORKTREE-IVTR.md`.