### PR TITLE
feat(T9608): integrations wizard section (T-SETUP-V2-2)

### DIFF
--- a/packages/core/src/setup/index.ts
+++ b/packages/core/src/setup/index.ts
@@ -6,9 +6,11 @@
  * and the Studio `/setup` route (T-E3-8) consume this surface.
  *
  * V2 additions (T9607): re-exports {@link WizardInterruptError}.
+ * V2 additions (T9608): re-exports {@link createIntegrationsSection}.
  *
  * @task T9420
  * @task T9607
+ * @task T9608
  * @epic T9402
  * @epic T9591
  */
@@ -16,6 +18,7 @@
 import { createBrainSection } from './sections/brain.js';
 import { createHarnessSection } from './sections/harness.js';
 import { createIdentitySection } from './sections/identity.js';
+import { createIntegrationsSection } from './sections/integrations.js';
 import { createLlmSection } from './sections/llm.js';
 import { createProjectConventionsSection } from './sections/project-conventions.js';
 import { createSentientSection } from './sections/sentient.js';
@@ -25,7 +28,7 @@ import { WizardRunner, type WizardSectionRunner } from './wizard.js';
 export { createBrainSection } from './sections/brain.js';
 export { createHarnessSection } from './sections/harness.js';
 export { createIdentitySection } from './sections/identity.js';
-
+export { createIntegrationsSection } from './sections/integrations.js';
 export { createLlmSection } from './sections/llm.js';
 export { createProjectConventionsSection } from './sections/project-conventions.js';
 export { createSentientSection } from './sections/sentient.js';
@@ -57,12 +60,14 @@ export {
  *   4. `project-conventions` — strictness preset before harness/brain layering
  *   5. `harness`             — operator selects Pi vs Claude Code (T9425)
  *   6. `brain`               — BRAIN memory bridge mode (T9425)
- *   7. `verification`        — read-only health checks (T9594)
+ *   7. `integrations`        — SignalDock + Studio + Conduit (T9608)
+ *   8. `verification`        — read-only health checks (T9594)
  *
  * @returns Fresh array of section runner instances.
  * @task T9420
  * @task T9425
  * @task T9594
+ * @task T9608
  */
 export function createBuiltinSections(): WizardSectionRunner[] {
   return [
@@ -72,6 +77,7 @@ export function createBuiltinSections(): WizardSectionRunner[] {
     createProjectConventionsSection(),
     createHarnessSection(),
     createBrainSection(),
+    createIntegrationsSection(),
     createVerificationSection(),
   ];
 }

--- a/packages/core/src/setup/sections/__tests__/integrations.test.ts
+++ b/packages/core/src/setup/sections/__tests__/integrations.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Unit tests for `createIntegrationsSection()` (T9608 / E-CLEO-SETUP-V2).
+ *
+ * All filesystem I/O is sandboxed to a temp directory via env-var pinning.
+ * No network calls are made — the section does not perform any.
+ *
+ * Test cases:
+ *   1. Non-interactive: all four flags applied and persisted correctly.
+ *   2. Non-interactive: no flags → short-circuits silently.
+ *   3. Non-interactive: invalid SignalDock endpoint URL → throws.
+ *   4. Non-interactive: conduitPath not absolute → throws.
+ *   5. Interactive: SignalDock enabled + custom endpoint + Studio + no Conduit path.
+ *   6. Interactive: SignalDock disabled + Studio disabled + blank Conduit path.
+ *   7. `isConfigured()`: returns false when signaldock.enabled not set.
+ *   8. `isConfigured()`: returns true when signaldock.enabled is set to false.
+ *   9. `isConfigured()`: returns true when signaldock.enabled is set to true.
+ *  10. `createBuiltinSections()` includes 'integrations' at position 7.
+ *
+ * @task T9608
+ */
+
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { _resetCleoPlatformPathsCache } from '@cleocode/paths';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { _resetCredentialPoolSingletonForTests } from '../../../llm/credential-pool.js';
+import {
+  createBuiltinSections,
+  createIntegrationsSection,
+  StubWizardIO,
+  WizardRunner,
+} from '../../index.js';
+
+const ENV_KEYS = [
+  'XDG_DATA_HOME',
+  'XDG_CONFIG_HOME',
+  'CLEO_HOME',
+  'CLEO_DIR',
+  'CLEO_CONFIG_HOME',
+  'HOME',
+];
+const SAVED_ENV: Record<string, string | undefined> = {};
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+/** Provision a sandboxed temp root for each test. */
+function makeTempRoot(): { root: string; projectRoot: string } {
+  const root = join(
+    tmpdir(),
+    `cleo-intg-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  const projectRoot = join(root, 'project');
+  mkdirSync(join(root, 'data'), { recursive: true });
+  mkdirSync(join(root, 'config'), { recursive: true });
+  mkdirSync(join(root, 'cleo-home'), { recursive: true });
+  mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+
+  process.env['XDG_DATA_HOME'] = join(root, 'data');
+  process.env['XDG_CONFIG_HOME'] = join(root, 'config');
+  process.env['CLEO_HOME'] = join(root, 'cleo-home');
+  process.env['HOME'] = root;
+  delete process.env['CLEO_DIR'];
+  delete process.env['CLEO_CONFIG_HOME'];
+
+  _resetCleoPlatformPathsCache();
+  _resetCredentialPoolSingletonForTests();
+  return { root, projectRoot };
+}
+
+beforeEach(() => {
+  saveEnv();
+});
+afterEach(() => {
+  _resetCleoPlatformPathsCache();
+  _resetCredentialPoolSingletonForTests();
+  restoreEnv();
+});
+
+// ---------------------------------------------------------------------------
+// Non-interactive path
+// ---------------------------------------------------------------------------
+
+describe('integrations section — non-interactive', () => {
+  it('applies all four flags and persists to correct config scopes', async () => {
+    const { root, projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    const io = new StubWizardIO();
+
+    const result = await runner.runSection('integrations', io, {
+      nonInteractive: true,
+      signaldockEnabled: true,
+      signaldockEndpoint: 'https://signaldock.example.com',
+      studioEnabled: true,
+      conduitPath: '/var/cleo/conduit.db',
+      projectRoot,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.summary).toContain('signaldock.enabled=true');
+    expect(result.summary).toContain('signaldock.endpoint=https://signaldock.example.com');
+    expect(result.summary).toContain('studio.enabled=true');
+    expect(result.summary).toContain('conduit.dbPath=/var/cleo/conduit.db');
+
+    // Verify global config for SignalDock + Studio.
+    const globalCfgPath = join(root, 'cleo-home', 'config.json');
+    expect(existsSync(globalCfgPath)).toBe(true);
+    const globalCfg = JSON.parse(readFileSync(globalCfgPath, 'utf-8')) as {
+      signaldock?: { enabled?: boolean; endpoint?: string };
+      studio?: { enabled?: boolean };
+    };
+    expect(globalCfg.signaldock?.enabled).toBe(true);
+    expect(globalCfg.signaldock?.endpoint).toBe('https://signaldock.example.com');
+    expect(globalCfg.studio?.enabled).toBe(true);
+
+    // Verify project config for Conduit.
+    const projectCfgPath = join(projectRoot, '.cleo', 'config.json');
+    expect(existsSync(projectCfgPath)).toBe(true);
+    const projectCfg = JSON.parse(readFileSync(projectCfgPath, 'utf-8')) as {
+      conduit?: { dbPath?: string };
+    };
+    expect(projectCfg.conduit?.dbPath).toBe('/var/cleo/conduit.db');
+  });
+
+  it('short-circuits silently when no flags are supplied', async () => {
+    makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    const io = new StubWizardIO();
+
+    const result = await runner.runSection('integrations', io, {
+      nonInteractive: true,
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.summary).toMatch(/^skipped/);
+  });
+
+  it('applies only the flags that are present (partial non-interactive)', async () => {
+    const { root, projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    const io = new StubWizardIO();
+
+    const result = await runner.runSection('integrations', io, {
+      nonInteractive: true,
+      signaldockEnabled: false,
+      projectRoot,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.summary).toContain('signaldock.enabled=false');
+
+    const globalCfg = JSON.parse(readFileSync(join(root, 'cleo-home', 'config.json'), 'utf-8')) as {
+      signaldock?: { enabled?: boolean };
+    };
+    expect(globalCfg.signaldock?.enabled).toBe(false);
+  });
+
+  it('throws E_SETUP_INVALID_VALUE for an invalid signaldockEndpoint URL', async () => {
+    const { projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    const io = new StubWizardIO();
+
+    // invokeSection wraps the throw in a failed: summary.
+    const result = await runner.runSection('integrations', io, {
+      nonInteractive: true,
+      signaldockEndpoint: 'not-a-url',
+      projectRoot,
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.summary).toMatch(/E_SETUP_INVALID_VALUE/);
+    expect(result.summary).toMatch(/not-a-url/);
+  });
+
+  it('throws E_SETUP_INVALID_VALUE for a relative conduitPath', async () => {
+    const { projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    const io = new StubWizardIO();
+
+    const result = await runner.runSection('integrations', io, {
+      nonInteractive: true,
+      conduitPath: 'relative/path/conduit.db',
+      projectRoot,
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.summary).toMatch(/E_SETUP_INVALID_VALUE/);
+    expect(result.summary).toMatch(/absolute path/);
+  });
+
+  it('emits Studio start hint when studioEnabled is true', async () => {
+    const { projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    const io = new StubWizardIO();
+
+    await runner.runSection('integrations', io, {
+      nonInteractive: true,
+      studioEnabled: true,
+      projectRoot,
+    });
+
+    expect(io.infos.some((m) => m.includes('cleo studio start'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interactive path
+// ---------------------------------------------------------------------------
+
+describe('integrations section — interactive', () => {
+  it('enables SignalDock with custom endpoint + Studio + no Conduit path', async () => {
+    const { root, projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    // confirms: SignalDock=yes, Studio=yes
+    // prompts: endpoint, conduit path (blank → default)
+    const io = new StubWizardIO({
+      confirms: [true, true],
+      prompts: ['https://sd.example.com:8080', ''],
+    });
+
+    const result = await runner.runSection('integrations', io, { projectRoot });
+
+    expect(result.changed).toBe(true);
+    expect(result.summary).toContain('signaldock.enabled=true');
+    expect(result.summary).toContain('signaldock.endpoint=https://sd.example.com:8080');
+    expect(result.summary).toContain('studio.enabled=true');
+    expect(result.summary).toContain('conduit.dbPath=default');
+
+    const globalCfg = JSON.parse(readFileSync(join(root, 'cleo-home', 'config.json'), 'utf-8')) as {
+      signaldock?: { enabled?: boolean; endpoint?: string };
+      studio?: { enabled?: boolean };
+    };
+    expect(globalCfg.signaldock?.enabled).toBe(true);
+    expect(globalCfg.signaldock?.endpoint).toBe('https://sd.example.com:8080');
+    expect(globalCfg.studio?.enabled).toBe(true);
+  });
+
+  it('disables SignalDock + Studio; blank Conduit path leaves project config untouched', async () => {
+    const { root, projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    // confirms: SignalDock=no, Studio=no
+    // prompts: conduit path (blank)
+    const io = new StubWizardIO({
+      confirms: [false, false],
+      prompts: [''],
+    });
+
+    const result = await runner.runSection('integrations', io, { projectRoot });
+
+    expect(result.changed).toBe(true);
+    expect(result.summary).toContain('signaldock.enabled=false');
+    expect(result.summary).toContain('studio.enabled=false');
+
+    const globalCfg = JSON.parse(readFileSync(join(root, 'cleo-home', 'config.json'), 'utf-8')) as {
+      signaldock?: { enabled?: boolean };
+      studio?: { enabled?: boolean };
+    };
+    expect(globalCfg.signaldock?.enabled).toBe(false);
+    expect(globalCfg.studio?.enabled).toBe(false);
+
+    // Project config not written (blank conduit path).
+    const projectCfgPath = join(projectRoot, '.cleo', 'config.json');
+    if (existsSync(projectCfgPath)) {
+      const projectCfg = JSON.parse(readFileSync(projectCfgPath, 'utf-8')) as {
+        conduit?: { dbPath?: string };
+      };
+      expect(projectCfg.conduit?.dbPath).toBeUndefined();
+    }
+  });
+
+  it('uses default endpoint when blank is entered for SignalDock endpoint', async () => {
+    const { root, projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    // confirms: SignalDock=yes, Studio=no
+    // prompts: endpoint (blank → default), conduit (blank)
+    const io = new StubWizardIO({
+      confirms: [true, false],
+      prompts: ['', ''],
+    });
+
+    await runner.runSection('integrations', io, { projectRoot });
+
+    const globalCfg = JSON.parse(readFileSync(join(root, 'cleo-home', 'config.json'), 'utf-8')) as {
+      signaldock?: { endpoint?: string };
+    };
+    expect(globalCfg.signaldock?.endpoint).toBe('http://localhost:4000');
+  });
+
+  it('emits Studio start hint when Studio is enabled interactively', async () => {
+    const { projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    // confirms: SignalDock=no, Studio=yes
+    // prompts: conduit path (blank)
+    const io = new StubWizardIO({
+      confirms: [false, true],
+      prompts: [''],
+    });
+
+    await runner.runSection('integrations', io, { projectRoot });
+
+    expect(io.infos.some((m) => m.includes('cleo studio start'))).toBe(true);
+  });
+
+  it('emits current state before prompting', async () => {
+    const { projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    const io = new StubWizardIO({
+      confirms: [false, false],
+      prompts: [''],
+    });
+
+    await runner.runSection('integrations', io, { projectRoot });
+
+    // First info message must describe current state.
+    const stateInfo = io.infos.find((m) => m.includes('Current integrations state'));
+    expect(stateInfo).toBeDefined();
+    expect(stateInfo).toContain('signaldock.enabled');
+    expect(stateInfo).toContain('studio.enabled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isConfigured()
+// ---------------------------------------------------------------------------
+
+describe('integrations section — isConfigured()', () => {
+  it('returns false when signaldock.enabled has never been written', async () => {
+    const { projectRoot } = makeTempRoot();
+    const section = createIntegrationsSection();
+    // isConfigured is optional — guard against missing implementation.
+    expect(section.isConfigured).toBeDefined();
+    const configured = await section.isConfigured!({ projectRoot });
+    expect(configured).toBe(false);
+  });
+
+  it('returns true when signaldock.enabled is explicitly set to false', async () => {
+    const { projectRoot } = makeTempRoot();
+    // Write explicitly via non-interactive run.
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    const io = new StubWizardIO();
+    await runner.runSection('integrations', io, {
+      nonInteractive: true,
+      signaldockEnabled: false,
+      projectRoot,
+    });
+
+    // Re-create section for a clean isConfigured check.
+    const section = createIntegrationsSection();
+    const configured = await section.isConfigured!({ projectRoot });
+    expect(configured).toBe(true);
+  });
+
+  it('returns true when signaldock.enabled is explicitly set to true', async () => {
+    const { projectRoot } = makeTempRoot();
+    const runner = new WizardRunner([createIntegrationsSection()]);
+    const io = new StubWizardIO();
+    await runner.runSection('integrations', io, {
+      nonInteractive: true,
+      signaldockEnabled: true,
+      projectRoot,
+    });
+
+    const section = createIntegrationsSection();
+    const configured = await section.isConfigured!({ projectRoot });
+    expect(configured).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createBuiltinSections() registration
+// ---------------------------------------------------------------------------
+
+describe('createBuiltinSections() — integrations at position 7', () => {
+  it('includes integrations as the 7th section (index 6)', () => {
+    const sections = createBuiltinSections();
+    expect(sections[6]?.section).toBe('integrations');
+  });
+
+  it('has 8 built-in sections after T9608 (integrations + verification)', () => {
+    const sections = createBuiltinSections();
+    expect(sections).toHaveLength(8);
+  });
+
+  it('section ids are in the expected canonical order', () => {
+    const sections = createBuiltinSections();
+    expect(sections.map((s) => s.section)).toEqual([
+      'llm',
+      'identity',
+      'sentient',
+      'project-conventions',
+      'harness',
+      'brain',
+      'integrations',
+      'verification',
+    ]);
+  });
+});

--- a/packages/core/src/setup/sections/integrations.ts
+++ b/packages/core/src/setup/sections/integrations.ts
@@ -1,0 +1,261 @@
+/**
+ * `integrations` setup wizard section (E-CLEO-SETUP-V2 / T9608).
+ *
+ * Captures operator intent for three integration subsystems:
+ *
+ *   1. **SignalDock** — the cloud messaging transport.
+ *      - `signaldock.enabled` (global config, boolean)
+ *      - `signaldock.endpoint` (global config, string — defaults to
+ *        `http://localhost:4000` when not supplied)
+ *
+ *   2. **Studio** — the local web UI.
+ *      - `studio.enabled` (global config, boolean)
+ *      - After enabling, the section emits: "Start Studio with `cleo studio start`."
+ *
+ *   3. **Conduit** — the local message-bus DB.
+ *      - `conduit.dbPath` (project config, string — must be an absolute path)
+ *      - Blank input ⇒ the built-in default is used; nothing is persisted.
+ *
+ * The section emits the current state of all three subsystems before
+ * prompting so operators can confirm idempotently.
+ *
+ * No network calls are made inside this section — connectivity validation
+ * is delegated to the `verification` section (T9594).
+ *
+ * Non-interactive contract (INTG-5):
+ *   - `options.nonInteractive === true` → apply each of
+ *     `signaldockEnabled`, `signaldockEndpoint`, `studioEnabled`, and
+ *     `conduitPath` when present; fields not supplied are left untouched.
+ *   - All four absent under non-interactive → short-circuit silently.
+ *
+ * `isConfigured()` (INTG-6):
+ *   - Returns `true` when `signaldock.enabled` is **explicitly set** in
+ *     the global config (even when the stored value is `false`), because
+ *     an explicit `false` means the operator intentionally disabled it.
+ *
+ * @task T9608
+ * @epic T9591
+ * @see docs/plans/E-CLEO-SETUP-V2.md §4.8, §5.2 T9593
+ */
+
+import { getConfigValue, setConfigValue } from '../../config.js';
+import type {
+  WizardIO,
+  WizardOptions,
+  WizardSectionResult,
+  WizardSectionRunner,
+} from '../wizard.js';
+
+/** Default SignalDock endpoint shown to the operator. */
+const DEFAULT_SIGNALDOCK_ENDPOINT = 'http://localhost:4000';
+
+/**
+ * Validate that `url` is an HTTP or HTTPS URL.
+ *
+ * Used to guard the SignalDock endpoint prompt — the section MUST NOT
+ * make network calls (INTG-7), so only syntactic validation is performed.
+ *
+ * @param url - Raw user input to validate.
+ * @returns `true` when `url` is a valid HTTP(S) URL.
+ * @internal
+ */
+function isValidHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate that `path` is an absolute filesystem path.
+ *
+ * @param p - Raw user input to validate.
+ * @returns `true` when `p` starts with `/` (Unix absolute path).
+ * @internal
+ */
+function isAbsolutePath(p: string): boolean {
+  return p.startsWith('/');
+}
+
+/**
+ * Build the `integrations` section runner.
+ *
+ * @returns A {@link WizardSectionRunner} for the integrations section.
+ * @task T9608
+ */
+export function createIntegrationsSection(): WizardSectionRunner {
+  return {
+    section: 'integrations',
+    title: 'Integrations (SignalDock + Studio + Conduit)',
+    optional: true,
+
+    /**
+     * Return `true` when `signaldock.enabled` is explicitly set in global
+     * config (INTG-6). An explicit `false` still counts as "configured" —
+     * it means the operator intentionally opted out.
+     */
+    async isConfigured(options: WizardOptions): Promise<boolean> {
+      const resolved = await getConfigValue<boolean>('signaldock.enabled', options.projectRoot);
+      // `resolved.source === 'default'` means the key has never been written;
+      // any other source (global, project, env) means it was set explicitly.
+      return resolved.source !== 'default' && resolved.value !== undefined;
+    },
+
+    async run(io: WizardIO, options: WizardOptions): Promise<WizardSectionResult> {
+      // ── Emit current state (INTG-1) ──────────────────────────────────────
+      const [sdEnabled, sdEndpoint, stEnabled] = await Promise.all([
+        getConfigValue<boolean>('signaldock.enabled', options.projectRoot),
+        getConfigValue<string>('signaldock.endpoint', options.projectRoot),
+        getConfigValue<boolean>('studio.enabled', options.projectRoot),
+      ]);
+
+      const sdEnabledLabel = sdEnabled.value === undefined ? 'not set' : String(sdEnabled.value);
+      const sdEndpointLabel = sdEndpoint.value ?? '(default)';
+      const stEnabledLabel = stEnabled.value === undefined ? 'not set' : String(stEnabled.value);
+
+      io.info(
+        `Current integrations state:\n` +
+          `  signaldock.enabled  = ${sdEnabledLabel} (source: ${sdEnabled.source})\n` +
+          `  signaldock.endpoint = ${sdEndpointLabel} (source: ${sdEndpoint.source})\n` +
+          `  studio.enabled      = ${stEnabledLabel} (source: ${stEnabled.source})`,
+      );
+
+      const fragments: string[] = [];
+
+      if (options.nonInteractive === true) {
+        // ── Non-interactive path (INTG-5) ──────────────────────────────────
+        const { signaldockEnabled, signaldockEndpoint, studioEnabled, conduitPath } = options;
+
+        if (
+          signaldockEnabled === undefined &&
+          signaldockEndpoint === undefined &&
+          studioEnabled === undefined &&
+          conduitPath === undefined
+        ) {
+          return {
+            changed: false,
+            summary: 'skipped (non-interactive: no integrations flags supplied)',
+          };
+        }
+
+        if (signaldockEnabled !== undefined) {
+          await setConfigValue('signaldock.enabled', signaldockEnabled, options.projectRoot, {
+            global: true,
+          });
+          fragments.push(`signaldock.enabled=${signaldockEnabled}`);
+        }
+
+        if (signaldockEndpoint !== undefined) {
+          if (!isValidHttpUrl(signaldockEndpoint)) {
+            throw new Error(
+              `E_SETUP_INVALID_VALUE: signaldockEndpoint '${signaldockEndpoint}' is not a valid HTTP(S) URL`,
+            );
+          }
+          await setConfigValue('signaldock.endpoint', signaldockEndpoint, options.projectRoot, {
+            global: true,
+          });
+          fragments.push(`signaldock.endpoint=${signaldockEndpoint}`);
+        }
+
+        if (studioEnabled !== undefined) {
+          await setConfigValue('studio.enabled', studioEnabled, options.projectRoot, {
+            global: true,
+          });
+          fragments.push(`studio.enabled=${studioEnabled}`);
+          if (studioEnabled) {
+            io.info('Start Studio with `cleo studio start`.');
+          }
+        }
+
+        if (conduitPath !== undefined) {
+          if (!isAbsolutePath(conduitPath)) {
+            throw new Error(
+              `E_SETUP_INVALID_VALUE: conduitPath '${conduitPath}' must be an absolute path`,
+            );
+          }
+          await setConfigValue('conduit.dbPath', conduitPath, options.projectRoot, {
+            global: false,
+          });
+          fragments.push(`conduit.dbPath=${conduitPath}`);
+        }
+
+        return {
+          changed: fragments.length > 0,
+          summary: fragments.length > 0 ? fragments.join(' + ') : 'no changes',
+        };
+      }
+
+      // ── Interactive path (INTG-2, INTG-3, INTG-4) ────────────────────────
+
+      // 1. SignalDock enable (INTG-2)
+      const wantsSignalDock = await io.confirm('Enable SignalDock transport?', false);
+      await setConfigValue('signaldock.enabled', wantsSignalDock, options.projectRoot, {
+        global: true,
+      });
+      fragments.push(`signaldock.enabled=${wantsSignalDock}`);
+
+      if (wantsSignalDock) {
+        // Prompt for endpoint URL; keep re-prompting until a valid URL is entered.
+        let endpoint = '';
+        while (true) {
+          const raw = (
+            await io.prompt(`SignalDock endpoint URL [${DEFAULT_SIGNALDOCK_ENDPOINT}]:`)
+          ).trim();
+          endpoint = raw === '' ? DEFAULT_SIGNALDOCK_ENDPOINT : raw;
+          if (isValidHttpUrl(endpoint)) break;
+          io.warn(`'${endpoint}' is not a valid HTTP(S) URL — please try again.`);
+        }
+        await setConfigValue('signaldock.endpoint', endpoint, options.projectRoot, {
+          global: true,
+        });
+        fragments.push(`signaldock.endpoint=${endpoint}`);
+      }
+
+      // 2. Studio enable (INTG-3)
+      const wantsStudio = await io.confirm('Enable Studio web UI?', false);
+      await setConfigValue('studio.enabled', wantsStudio, options.projectRoot, {
+        global: true,
+      });
+      fragments.push(`studio.enabled=${wantsStudio}`);
+      if (wantsStudio) {
+        io.info('Start Studio with `cleo studio start`.');
+      }
+
+      // 3. Conduit DB path (INTG-4)
+      let conduitWritten = false;
+      while (true) {
+        const raw = (
+          await io.prompt('Custom Conduit DB path? [leave blank to use default]')
+        ).trim();
+
+        if (raw === '') {
+          // Blank ⇒ use default; nothing persisted.
+          break;
+        }
+
+        if (!isAbsolutePath(raw)) {
+          io.warn(
+            `'${raw}' is not an absolute path — please supply an absolute path or leave blank.`,
+          );
+          continue;
+        }
+
+        await setConfigValue('conduit.dbPath', raw, options.projectRoot, { global: false });
+        fragments.push(`conduit.dbPath=${raw}`);
+        conduitWritten = true;
+        break;
+      }
+
+      if (!conduitWritten) {
+        fragments.push('conduit.dbPath=default');
+      }
+
+      return {
+        changed: true,
+        summary: fragments.join(' + '),
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Implements `createIntegrationsSection()` factory in `packages/core/src/setup/sections/integrations.ts`
- Interactive flow: SignalDock enable + endpoint, Studio enable, Conduit DB path
- Non-interactive flow: all 4 options applied from `WizardOptions` when present (INTG-5)
- `isConfigured()` returns `true` when `signaldock.enabled` is explicitly set in global config (INTG-6)
- Emits current state of all 3 subsystems before prompting (INTG-1)
- No network calls inside the section (INTG-7)
- Registered as section #7 in `createBuiltinSections()`; `verification` moves to #8

## Test plan

- [ ] 14 unit tests covering non-interactive + interactive paths + `isConfigured()` + registration
- [ ] `biome check --write` passes with no changes
- [ ] CI green

Closes T9608. Refs docs/plans/E-CLEO-SETUP-V2.md §4.8, §5.2 T9593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)