### PR TITLE
feat(T9618): Studio /api/search uses getNexusDb CORE accessor

### DIFF
--- a/packages/studio/src/routes/api/search/+server.ts
+++ b/packages/studio/src/routes/api/search/+server.ts
@@ -16,21 +16,10 @@
  * @task T622
  */
 
-import { existsSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { join } from 'node:path';
-import type { DatabaseSync as _DatabaseSyncType } from 'node:sqlite';
-import { applyPerfPragmas } from '@cleocode/core';
 import { json } from '@sveltejs/kit';
-import { getCleoHome } from '$lib/server/cleo-home.js';
+import { getNexusDb } from '$lib/server/db/connections.js';
 import { getActiveProjectId, listRegisteredProjects } from '$lib/server/project-context.js';
 import type { RequestHandler } from './$types';
-
-const _require = createRequire(import.meta.url);
-type _DatabaseSync = _DatabaseSyncType;
-const { DatabaseSync } = _require('node:sqlite') as {
-  DatabaseSync: new (...args: ConstructorParameters<typeof _DatabaseSyncType>) => _DatabaseSync;
-};
 
 interface SymbolHit {
   projectId: string;
@@ -68,8 +57,8 @@ export const GET: RequestHandler = ({ url, cookies }) => {
   }
 
   try {
-    const nexusPath = join(getCleoHome(), 'nexus.db');
-    if (!existsSync(nexusPath)) {
+    const db = getNexusDb();
+    if (!db) {
       return json({
         success: true,
         data: { query: q, scope, results: [], totalHits: 0 },
@@ -93,65 +82,18 @@ export const GET: RequestHandler = ({ url, cookies }) => {
     const allProjects = listRegisteredProjects();
     const projectNameById = new Map(allProjects.map((p) => [p.projectId, p.name]));
 
-    const db = new DatabaseSync(nexusPath, { open: true });
-    applyPerfPragmas(db); // T9045
     const hits: SymbolHit[] = [];
+    const term = `%${q.toLowerCase()}%`;
 
-    try {
-      const term = `%${q.toLowerCase()}%`;
-
-      if (projectFilter) {
-        // Scoped to specific project(s)
-        for (const projectId of projectFilter) {
-          const rows = db
-            .prepare(
-              `SELECT id, project_id, name, kind, file_path, start_line, language, doc_summary, is_exported
-               FROM nexus_nodes
-               WHERE project_id = ?
-                 AND lower(name) LIKE ?
-                 AND kind NOT IN ('community', 'process', 'file', 'folder')
-               ORDER BY
-                 CASE kind
-                   WHEN 'function' THEN 0 WHEN 'method' THEN 1 WHEN 'class' THEN 2
-                   WHEN 'interface' THEN 3 WHEN 'type_alias' THEN 4 ELSE 5
-                 END, name
-               LIMIT ?`,
-            )
-            .all(projectId, term, limit) as Array<{
-            id: string;
-            project_id: string;
-            name: string | null;
-            kind: string;
-            file_path: string | null;
-            start_line: number | null;
-            language: string | null;
-            doc_summary: string | null;
-            is_exported: number;
-          }>;
-
-          for (const row of rows) {
-            if (!row.name) continue;
-            hits.push({
-              projectId: row.project_id,
-              projectName: projectNameById.get(row.project_id) ?? row.project_id,
-              nodeId: row.id,
-              name: row.name,
-              kind: row.kind,
-              filePath: row.file_path ?? null,
-              startLine: row.start_line ?? null,
-              language: row.language ?? null,
-              docSummary: row.doc_summary ?? null,
-              isExported: row.is_exported === 1,
-            });
-          }
-        }
-      } else {
-        // Search all projects
+    if (projectFilter) {
+      // Scoped to specific project(s)
+      for (const projectId of projectFilter) {
         const rows = db
           .prepare(
             `SELECT id, project_id, name, kind, file_path, start_line, language, doc_summary, is_exported
              FROM nexus_nodes
-             WHERE lower(name) LIKE ?
+             WHERE project_id = ?
+               AND lower(name) LIKE ?
                AND kind NOT IN ('community', 'process', 'file', 'folder')
              ORDER BY
                CASE kind
@@ -160,7 +102,7 @@ export const GET: RequestHandler = ({ url, cookies }) => {
                END, name
              LIMIT ?`,
           )
-          .all(term, limit * Math.max(allProjects.length, 1)) as Array<{
+          .all(projectId, term, limit) as Array<{
           id: string;
           project_id: string;
           name: string | null;
@@ -188,8 +130,48 @@ export const GET: RequestHandler = ({ url, cookies }) => {
           });
         }
       }
-    } finally {
-      db.close();
+    } else {
+      // Search all projects
+      const rows = db
+        .prepare(
+          `SELECT id, project_id, name, kind, file_path, start_line, language, doc_summary, is_exported
+           FROM nexus_nodes
+           WHERE lower(name) LIKE ?
+             AND kind NOT IN ('community', 'process', 'file', 'folder')
+           ORDER BY
+             CASE kind
+               WHEN 'function' THEN 0 WHEN 'method' THEN 1 WHEN 'class' THEN 2
+               WHEN 'interface' THEN 3 WHEN 'type_alias' THEN 4 ELSE 5
+             END, name
+           LIMIT ?`,
+        )
+        .all(term, limit * Math.max(allProjects.length, 1)) as Array<{
+        id: string;
+        project_id: string;
+        name: string | null;
+        kind: string;
+        file_path: string | null;
+        start_line: number | null;
+        language: string | null;
+        doc_summary: string | null;
+        is_exported: number;
+      }>;
+
+      for (const row of rows) {
+        if (!row.name) continue;
+        hits.push({
+          projectId: row.project_id,
+          projectName: projectNameById.get(row.project_id) ?? row.project_id,
+          nodeId: row.id,
+          name: row.name,
+          kind: row.kind,
+          filePath: row.file_path ?? null,
+          startLine: row.start_line ?? null,
+          language: row.language ?? null,
+          docSummary: row.doc_summary ?? null,
+          isExported: row.is_exported === 1,
+        });
+      }
     }
 
     return json({


### PR DESCRIPTION
## Summary

- Replaces `new DatabaseSync(nexusPath)` + manual `applyPerfPragmas` + `db.close()` in `/api/search` with `getNexusDb()` from `$lib/server/db/connections` — the same singleton accessor already used by all `/api/nexus/*` routes
- Removes 5 now-unused imports: `existsSync`, `createRequire`, `join`, `DatabaseSync` type, `applyPerfPragmas`, `getCleoHome`
- Removes the manual `DatabaseSync` polyfill block (was needed to work around ESM/CJS interop)
- The `null` check on `getNexusDb()` replaces the `existsSync(nexusPath)` guard
- Removes `db.close()` in the `finally` block — the singleton must not be closed between requests
- All `/api/nexus/*` routes were already using `getNexusDb()` correctly; only `/api/search` needed migration

## Audit

- `/api/nexus/+server.ts` — already clean (uses `getNexusDb`)
- `/api/nexus/search/+server.ts` — already clean (uses `getNexusDb`)
- `/api/nexus/symbol/[name]/+server.ts` — already clean (uses `getNexusDb`)
- `/api/nexus/community/[id]/+server.ts` — already clean (uses `getNexusDb`)
- `/api/search/+server.ts` — **migrated** (was using `new DatabaseSync` directly)

## Test plan

- [ ] Biome check passes: `pnpm biome check --write packages/studio/` — no fixes applied
- [ ] No new TypeScript errors introduced (pre-existing env errors due to missing `@sveltejs` packages are unrelated)
- [ ] Studio `/api/search` endpoint behavior unchanged — same SQL queries, same response shape

Closes T9618. Refs docs/plans/E-CORE-FIRST-ARCH.md Task 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)