### PR TITLE
feat(T9621): brain+sentient+doctor+backup+restore → CORE (T-CLI-MISC-DISPATCH)

### DIFF
--- a/packages/cleo/src/cli/commands/backup.ts
+++ b/packages/cleo/src/cli/commands/backup.ts
@@ -144,7 +144,7 @@ const listCommand = defineCommand({
 /**
  * `cleo backup export <name>` — export project + global state to a portable archive.
  *
- * Delegates to `packBundle` from `@cleocode/core/internal`. When `--encrypt`
+ * Delegates to `packBundle` from `@cleocode/core/store/backup-pack.js`. When `--encrypt`
  * is requested, the passphrase is read from the `CLEO_BACKUP_PASSPHRASE`
  * environment variable (agent-friendly) or prompted interactively on a TTY.
  *
@@ -179,7 +179,8 @@ const exportCommand = defineCommand({
   async run({ args }): Promise<void> {
     const scope = args.scope as 'project' | 'global' | 'all';
 
-    const { packBundle, getProjectRoot } = await import('@cleocode/core/internal');
+    const { packBundle } = await import('@cleocode/core/store/backup-pack.js');
+    const { getProjectRoot } = await import('@cleocode/core');
 
     const includesProject = scope === 'project' || scope === 'all';
     const projectRoot = includesProject ? getProjectRoot() : undefined;
@@ -278,15 +279,24 @@ const importCommand = defineCommand({
   },
   async run({ args }): Promise<void> {
     const bundlePath = args.bundle;
-    const core = await import('@cleocode/core/internal');
+    const { getProjectRoot, getCleoHome, getCleoVersion } = await import('@cleocode/core');
+    const { BundleError, cleanupStaging, unpackBundle } = await import(
+      '@cleocode/core/store/backup-unpack.js'
+    );
+    const { regenerateConfigJson, regenerateProjectContextJson, regenerateProjectInfoJson } =
+      await import('@cleocode/core/store/regenerators.js');
+    const { regenerateAndCompare } = await import('@cleocode/core/store/restore-json-merge.js');
+    const { buildConflictReport, writeConflictReport } = await import(
+      '@cleocode/core/store/restore-conflict-report.js'
+    );
 
-    const projectRoot = core.getProjectRoot();
+    const projectRoot = getProjectRoot();
 
     // -----------------------------------------------------------------------
     // Step 1: Pre-check existing data (skip when --force)
     // -----------------------------------------------------------------------
     if (args.force !== true) {
-      const existing = checkForExistingData(projectRoot, core.getCleoHome());
+      const existing = checkForExistingData(projectRoot, getCleoHome());
       if (existing.length > 0) {
         process.stderr.write(
           JSON.stringify({
@@ -326,11 +336,11 @@ const importCommand = defineCommand({
     // -----------------------------------------------------------------------
     // Step 3: Unpack + verify (layers 1–6 delegated to unpackBundle)
     // -----------------------------------------------------------------------
-    let result: Awaited<ReturnType<typeof core.unpackBundle>>;
+    let result: Awaited<ReturnType<typeof unpackBundle>>;
     try {
-      result = await core.unpackBundle({ bundlePath, passphrase });
+      result = await unpackBundle({ bundlePath, passphrase });
     } catch (err) {
-      if (err instanceof core.BundleError) {
+      if (err instanceof BundleError) {
         process.stderr.write(
           JSON.stringify({
             success: false,
@@ -355,7 +365,7 @@ const importCommand = defineCommand({
       for (const dbEntry of manifest.databases) {
         const src = path.join(stagingDir, dbEntry.filename);
         if (!fs.existsSync(src)) continue;
-        const dst = resolveDbTarget(projectRoot, dbEntry.name, core.getCleoHome());
+        const dst = resolveDbTarget(projectRoot, dbEntry.name, getCleoHome());
         fs.mkdirSync(path.dirname(dst), { recursive: true });
 
         // Atomic: write to tmp then rename
@@ -378,7 +388,7 @@ const importCommand = defineCommand({
       // -----------------------------------------------------------------------
       // Step 5: A/B regenerate-and-compare for JSON files
       // -----------------------------------------------------------------------
-      const jsonReports: Array<ReturnType<typeof core.regenerateAndCompare>> = [];
+      const jsonReports: Array<ReturnType<typeof regenerateAndCompare>> = [];
 
       for (const jsonEntry of manifest.json) {
         const importedPath = path.join(stagingDir, jsonEntry.filename);
@@ -395,14 +405,14 @@ const importCommand = defineCommand({
 
         let localGenerated: unknown;
         if (basename === CONFIG_JSON) {
-          localGenerated = core.regenerateConfigJson(projectRoot).content;
+          localGenerated = regenerateConfigJson(projectRoot).content;
         } else if (basename === PROJECT_INFO_JSON) {
-          localGenerated = core.regenerateProjectInfoJson(projectRoot).content;
+          localGenerated = regenerateProjectInfoJson(projectRoot).content;
         } else {
-          localGenerated = core.regenerateProjectContextJson(projectRoot).content;
+          localGenerated = regenerateProjectContextJson(projectRoot).content;
         }
 
-        const report = core.regenerateAndCompare({
+        const report = regenerateAndCompare({
           filename: basename,
           imported,
           localGenerated,
@@ -418,12 +428,12 @@ const importCommand = defineCommand({
       // -----------------------------------------------------------------------
       // Step 6: Write .cleo/restore-conflicts.md
       // -----------------------------------------------------------------------
-      const cleoVersion = core.getCleoVersion();
-      const conflictMd = core.buildConflictReport({
+      const cleoVersion = getCleoVersion();
+      const conflictMd = buildConflictReport({
         reports: jsonReports,
         bundlePath,
         sourceMachineFingerprint: manifest.backup.machineFingerprint,
-        targetMachineFingerprint: sha256OfMachineKey(core.getCleoHome()),
+        targetMachineFingerprint: sha256OfMachineKey(getCleoHome()),
         cleoVersion,
         schemaWarnings: warnings.map((w) => ({
           db: w.db,
@@ -432,7 +442,7 @@ const importCommand = defineCommand({
           severity: w.severity,
         })),
       });
-      core.writeConflictReport(projectRoot, conflictMd);
+      writeConflictReport(projectRoot, conflictMd);
 
       // -----------------------------------------------------------------------
       // Step 7: Move raw imported JSON files to .cleo/restore-imported/
@@ -489,7 +499,7 @@ const importCommand = defineCommand({
       process.exitCode = 79;
     } finally {
       // Always clean up staging dir regardless of success or failure
-      core.cleanupStaging(stagingDir);
+      cleanupStaging(stagingDir);
     }
   },
 });

--- a/packages/cleo/src/cli/commands/brain.ts
+++ b/packages/cleo/src/cli/commands/brain.ts
@@ -17,16 +17,16 @@
  * @what Parent command group with subcommands and progress reporting
  */
 
+import { getProjectRoot } from '@cleocode/core';
 import {
   backfillBrainGraph,
   exportBrainAsGexf,
   exportBrainAsJson,
   getMemoryQualityReport,
   getPlasticityStats,
-  getProjectRoot,
   purgeBrainNoise,
   runBrainMaintenance,
-} from '@cleocode/core/internal';
+} from '@cleocode/core/memory';
 import { defineCommand, showUsage } from 'citty';
 import { cliError, cliOutput, humanInfo, humanProgress } from '../renderers/index.js';
 

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -16,8 +16,12 @@
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import type { HookMatrixResult } from '@cleocode/core/internal';
-import { getProjectRoot, quarantineRogueCleoDir, scanRogueCleoDirs } from '@cleocode/core/internal';
+import type { HookMatrixResult } from '@cleocode/core';
+import { getProjectRoot } from '@cleocode/core';
+import {
+  quarantineRogueCleoDir,
+  scanRogueCleoDirs,
+} from '@cleocode/core/system/rogue-cleo-detector.js';
 import { defineCommand } from 'citty';
 import { dispatchFromCli, dispatchRaw } from '../../dispatch/adapters/cli.js';
 import { createDoctorProgress } from '../progress.js';
@@ -55,7 +59,7 @@ const FIXTURE_TITLE_KEYWORDS = [
  */
 async function scanTestFixturesInProd(projectRoot: string): Promise<FixtureMatch[]> {
   type NativeDb = { prepare: (sql: string) => { all: (arg?: string) => unknown[] } };
-  const { getDb, getNativeDb } = await import('@cleocode/core/internal');
+  const { getDb, getNativeDb } = await import('@cleocode/core/store/sqlite.js');
   await getDb(projectRoot);
   const nativeDb = getNativeDb() as NativeDb | null;
   if (!nativeDb) return [];
@@ -120,7 +124,7 @@ async function quarantineTestFixtures(
   );
 
   type NativeDbRun = { prepare: (sql: string) => { run: (arg: string) => void } };
-  const { getNativeDb } = await import('@cleocode/core/internal');
+  const { getNativeDb } = await import('@cleocode/core/store/sqlite.js');
   const nativeDb = getNativeDb() as NativeDbRun | null;
   if (nativeDb) {
     for (const m of matches) {
@@ -312,7 +316,9 @@ export const doctorCommand = defineCommand({
     try {
       // T1908 / BBTT-W2-4: brain health dashboard
       if (args.brain) {
-        const { computeBrainHealthDashboard } = await import('@cleocode/core/internal');
+        const { computeBrainHealthDashboard } = await import(
+          '@cleocode/core/memory/brain-health-dashboard.js'
+        );
         const projectRoot = getProjectRoot();
         const dashboard = await computeBrainHealthDashboard(projectRoot);
 
@@ -488,9 +494,9 @@ export const doctorCommand = defineCommand({
       } else if (args['scan-stray-nexus-dbs']) {
         progress.step(0, 'Scanning for stray nexus.db files');
         const { detectAndRemoveLegacyGlobalFiles, detectAndRemoveStrayProjectNexus } = await import(
-          '@cleocode/core/internal'
+          '@cleocode/core/store/cleanup-legacy.js'
         );
-        const { getCleoHome } = await import('@cleocode/core/internal');
+        const { getCleoHome } = await import('@cleocode/core');
         const cleoHome = getCleoHome();
         const projectRoot = getProjectRoot();
 
@@ -519,7 +525,7 @@ export const doctorCommand = defineCommand({
         cliOutput(report, { command: 'doctor', operation: 'doctor.scan-stray-nexus-dbs' });
       } else if (args['audit-worktrees']) {
         progress.step(0, 'Auditing orphaned agent worktrees');
-        const { auditOrphanWorktrees } = await import('@cleocode/core/internal');
+        const { auditOrphanWorktrees } = await import('@cleocode/core/gc/index.js');
         const checkResult = auditOrphanWorktrees();
         progress.complete(`Worktree audit complete — ${checkResult.status}`);
 
@@ -533,7 +539,7 @@ export const doctorCommand = defineCommand({
         }
       } else if (args['audit-temp']) {
         progress.step(0, 'Auditing orphaned CLEO temp directories');
-        const { auditOrphanTempDirs } = await import('@cleocode/core/internal');
+        const { auditOrphanTempDirs } = await import('@cleocode/core/gc/index.js');
         const checkResult = await auditOrphanTempDirs();
         progress.complete(`Temp audit complete — ${checkResult.status}`);
 

--- a/packages/cleo/src/cli/commands/restore.ts
+++ b/packages/cleo/src/cli/commands/restore.ts
@@ -17,8 +17,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { ExitCode } from '@cleocode/contracts';
-import { CleoError, getTaskAccessor } from '@cleocode/core';
-import { getProjectRoot } from '@cleocode/core/internal';
+import { CleoError, getProjectRoot, getTaskAccessor } from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchRaw } from '../../dispatch/adapters/cli.js';
 import {

--- a/packages/cleo/src/cli/commands/sentient.ts
+++ b/packages/cleo/src/cli/commands/sentient.ts
@@ -343,7 +343,7 @@ const proposeAcceptSub = defineCommand({
     const id = args.id as string;
 
     try {
-      const { getDb } = await import('@cleocode/core/internal');
+      const { getDb } = await import('@cleocode/core/store/sqlite.js');
       const { tasks } = await import('@cleocode/core/store/tasks-schema');
       const { and, eq, like } = await import('drizzle-orm');
 
@@ -412,7 +412,7 @@ const proposeRejectSub = defineCommand({
     const reason = (args.reason as string | undefined) ?? 'rejected by owner';
 
     try {
-      const { getDb } = await import('@cleocode/core/internal');
+      const { getDb } = await import('@cleocode/core/store/sqlite.js');
       const { tasks } = await import('@cleocode/core/store/tasks-schema');
       const { and, eq, like } = await import('drizzle-orm');
 

--- a/packages/core/src/gc/index.ts
+++ b/packages/core/src/gc/index.ts
@@ -8,6 +8,12 @@
  * @package @cleocode/core
  */
 
+// T9621 — auditOrphans promoted to @cleocode/core/gc for doctor.ts CORE-first migration.
+// Read-only audit counterparts to pruneOrphanWorktrees / pruneOrphanTempDirs.
+export {
+  auditOrphanTempDirs,
+  auditOrphanWorktrees,
+} from '../validation/doctor/checks.js';
 export * from './daemon.js';
 export * from './runner.js';
 export * from './state.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -393,6 +393,8 @@ export {
   resolveGitDir,
   resolveHooksDir,
 } from './git/hooks-install.js';
+// T9621 — HookMatrixResult promoted to public API for doctor.ts CORE-first migration
+export type { HookMatrixResult } from './hooks/engine-ops.js';
 // Hooks
 export { HookRegistry, hooks } from './hooks/registry.js';
 // Lifecycle

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -1195,15 +1195,26 @@ export async function validateManifestEntries(
 // getBrainDb + getBrainNativeDb allow CLI commands that need the raw DB
 // handle (dedup-scan, tier ops) to avoid @cleocode/core/internal.
 export { getBrainDb, getBrainNativeDb } from '../store/memory-sqlite.js';
+// === T9621 — CLI CORE-first promotion (brain.ts misc commands) ===
+// Exposes backfillBrainGraph, exportBrainAsGexf/Json, getPlasticityStats,
+// purgeBrainNoise, runBrainMaintenance, and computeBrainHealthDashboard as
+// stable @cleocode/core/memory surface so CLI commands no longer need
+// @cleocode/core/internal.
+export { backfillBrainGraph } from './brain-backfill.js';
 // === T549 Wave 3: Consolidator (contradiction detection) ===
 export * from './brain-consolidator.js';
+export { exportBrainAsGexf, exportBrainAsJson } from './brain-export.js';
+export { computeBrainHealthDashboard } from './brain-health-dashboard.js';
 // === BRAIN Lifecycle (temporal decay, consolidation, tier promotion) ===
 export * from './brain-lifecycle.js';
 export * from './brain-links.js';
+export { runBrainMaintenance } from './brain-maintenance.js';
 export * from './brain-migration.js';
+export { purgeBrainNoise } from './brain-purge.js';
 // === BRAIN Retrieval functions (3-layer pattern + budget-aware) ===
 export * from './brain-retrieval.js';
 export * from './brain-search.js';
+export { getPlasticityStats } from './brain-stdp.js';
 // === BRAIN Memory modules (brain.db backed) ===
 export * from './decisions.js';
 // === T1087 PSYCHE Wave 3: Dialectic Evaluator + Session Narrative ===


### PR DESCRIPTION
## Summary

- Replaces all `@cleocode/core/internal` imports in `brain.ts`, `sentient.ts`, `doctor.ts`, `backup.ts`, `restore.ts` with public CORE barrels
- Promotes 8 brain operations to `@cleocode/core/memory` barrel (backfillBrainGraph, exportBrainAs{Gexf,Json}, computeBrainHealthDashboard, runBrainMaintenance, purgeBrainNoise, getPlasticityStats)
- Adds `HookMatrixResult` type to the public `@cleocode/core` root barrel
- Adds `auditOrphanWorktrees` + `auditOrphanTempDirs` to `@cleocode/core/gc` barrel

## Test plan

- [ ] Biome lint: 0 errors (verified locally — 5 files auto-fixed, no issues)
- [ ] Zero `/internal` imports remain in any of the 5 target files
- [ ] Pre-existing build/test failures in worktree match main branch (module resolution errors are worktree-symlink artifacts)
- [ ] All barrel promotions use stable public export paths from `packages/core/package.json`

Closes T9621. Refs docs/plans/E-CORE-FIRST-ARCH.md Task 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)