### PR TITLE
release: ship v2026.5.80 — T9580 CLI dispatch fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2026.5.80] (2026-05-18) — T9580 CLI dispatch fixes
+
+Real-test audit of v2026.5.79 (T9580) caught 3 systemic dispatch bugs that left 5 of 6 new IVTR verbs returning `E_INVALID_OPERATION`. This patch wires them correctly so the IVTR pipeline becomes usable from the CLI as documented.
+
+### Fixed
+
+- `cleo release plan` / `cleo release open` — CLI now passes bare op name `'plan'` / `'open'` instead of double-prefixed `'release.plan'` / `'release.open'`; registry now declares both ops (only `release.reconcile` was registered before this patch).
+- `cleo provenance backfill` / `cleo provenance verify` — same double-prefix fix.
+- `cleo worktree list` / `cleo worktree prune` / `cleo worktree force-unlock` — `worktree` domain added to `CANONICAL_DOMAINS`; ops registered in the dispatch registry.
+
+### Verified locally
+
+```
+cleo release plan v2026.5.80 --epic T9580 --dry-run → E_EVIDENCE_INSUFFICIENT (real domain error)
+cleo release open v2026.5.80 → E_PLAN_NOT_FOUND (real domain error)
+cleo worktree list --json → Returns 60+ worktrees classified
+cleo provenance backfill --since v2026.5.78 --dry-run → enumerates 122 historical tags
+cleo provenance verify v2026.5.79 → E_PROVENANCE_INCOMPLETE (release not reconciled)
+cleo release reconcile v2026.5.79 → E_PLAN_NOT_FOUND (needs plan first)
+```
+
+### Known in-flight (T9580 audit)
+
+The deeper `process.cwd()` → `getProjectRoot()` normalization across `~120 vulnerable sites` (T9581-T9584) is partially in PRs (#273 T9581, #274 T9583) with test fixture regressions to repair. These PRs do not block v2026.5.80 — they are tracked separately and will land in a future release.
+
 ## [2026.5.79] (2026-05-18) — T9345 IVTR Release System overhaul + T9499 cleanup
 
 Major release: complete overhaul of the CLEO release pipeline per SPEC-T9345 / ADR-073. Replaces the 761-line releaseShip monolith with four operator verbs (`plan`, `open`, `reconcile`, `rollback`) backed by four GHA workflow templates. Eliminates 10 production failure modes catalogued in `failure-forensics-10-modes.md` (8 by structural prevention, 2 by race-window narrowing). IVTR is decoupled from the release blocking path — ADR-051 evidence atoms become the sole gate execution surface. Bundles the Phase 6 cleanup (T9499) that removes the now-superseded legacy code.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.79"
+version = "2026.5.80"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.79",
+  "version": "2026.5.80",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## v2026.5.80 — T9580 CLI dispatch fixes

Patch release. The T9580 real-test audit of v2026.5.79 caught 3 systemic dispatch bugs that left 5 of 6 new IVTR verbs returning `E_INVALID_OPERATION`. This patch wires them correctly.

## Includes
- PR #264 (already merged to main): `fix(T9580): 3 CLI dispatch bugs caught in v2026.5.79 real-test`

## Verified locally (all 6 verbs return real LAFS envelopes)

```
cleo release plan v2026.5.80 --epic T9580 --dry-run → E_EVIDENCE_INSUFFICIENT (real domain error)
cleo release open v2026.5.80 → E_PLAN_NOT_FOUND (real domain error)
cleo worktree list --json → 60+ worktrees classified
cleo provenance backfill --since v2026.5.78 --dry-run → enumerates 122 historical tags
cleo provenance verify v2026.5.79 → E_PROVENANCE_INCOMPLETE
cleo release reconcile v2026.5.79 → E_PLAN_NOT_FOUND
```

## Known in-flight

The deeper `process.cwd()` → `getProjectRoot()` normalization (~120 sites per T9580 audit) is partially in PRs:
- PR #273 (T9581) — doctor/lifecycle/compliance — test fixtures need fix
- PR #274 (T9583) — release/orchestrate/spawn — test fixtures need fix
- T9582 — agent/nexus/conduit — in flight
- T9584 — DRY helpers + CI guard — pending

These do NOT block v2026.5.80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)