### PR TITLE
fix(T9582): normalize project-root in agent/nexus/conduit dispatch

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/agent-subdir-isolation.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/agent-subdir-isolation.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Subdir-isolation tests for the T9582 project-root resolution fix.
+ *
+ * Verifies that the `cleo agent <verb>` CLI handlers in
+ * `packages/cleo/src/cli/commands/agent.ts` resolve the effective project
+ * root through `getProjectRoot()` rather than raw `process.cwd()`. The
+ * regression scenario is invocation from a monorepo subdirectory
+ * (`<root>/packages/<X>`) — without normalization, each call previously
+ * wrote to `<root>/packages/<X>/.cleo/...` instead of the canonical
+ * `<root>/.cleo/...`, silently corrupting state.
+ *
+ * The tests use the dynamic-import seam in agent.ts: each `cleo agent`
+ * subcommand imports `@cleocode/core/internal` inside its `run` handler,
+ * so we mock that module and capture the `projectRoot` argument passed
+ * to the registry accessor / lookup / list helpers. Then we cross-check
+ * that capture against the canonical project root returned by
+ * `getProjectRoot()` (resolved by walking up from the temp fixture).
+ *
+ * The regression scenario is exercised via `process.chdir(subDir)` — the
+ * subcommand handler is invoked with cwd inside the synthetic subdir,
+ * and we assert the captured projectRoot equals the canonical fixture
+ * root, NOT the subdir.
+ *
+ * @task T9582
+ * @epic T9580
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { agentCommand } from '../agent.js';
+
+// ---------------------------------------------------------------------------
+// Captured projectRoot arguments — reset in beforeEach()
+// ---------------------------------------------------------------------------
+
+const captured = {
+  /** projectRoot passed to `new AgentRegistryAccessor(projectRoot)`. */
+  accessorRoot: undefined as string | undefined,
+  /** projectRoot passed to `listAgentsForProject(projectRoot, opts)`. */
+  listRoot: undefined as string | undefined,
+  /** projectRoot passed to `lookupAgent(projectRoot, agentId, opts)`. */
+  lookupRoot: undefined as string | undefined,
+  /** projectRoot passed to `attachAgentToProject(projectRoot, ...)`. */
+  attachRoot: undefined as string | undefined,
+  /** projectRoot passed to `detachAgentFromProject(projectRoot, ...)`. */
+  detachRoot: undefined as string | undefined,
+  /** projectRoot passed to `getProjectAgentRef(projectRoot, ...)`. */
+  getRefRoot: undefined as string | undefined,
+};
+
+function resetCaptured(): void {
+  captured.accessorRoot = undefined;
+  captured.listRoot = undefined;
+  captured.lookupRoot = undefined;
+  captured.attachRoot = undefined;
+  captured.detachRoot = undefined;
+  captured.getRefRoot = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Mock @cleocode/core/internal — record projectRoot captures, stub
+// downstream operations so handlers exit through the success path.
+// ---------------------------------------------------------------------------
+
+vi.mock('@cleocode/core/internal', async () => {
+  // Resolve the REAL getProjectRoot so the test exercises the canonical
+  // path walk (worktree + git-link + walk-up). All other exports are stubbed.
+  const realPaths = await vi.importActual<typeof import('../../../../../core/src/paths.js')>(
+    '../../../../../core/src/paths.js',
+  );
+  return {
+    getProjectRoot: realPaths.getProjectRoot,
+    getDb: vi.fn().mockResolvedValue(undefined),
+    AgentRegistryAccessor: class AgentRegistryAccessor {
+      constructor(projectRoot: string) {
+        captured.accessorRoot = projectRoot;
+      }
+      async register(): Promise<{ agentId: string; displayName: string }> {
+        return { agentId: 'agent-test', displayName: 'Test Agent' };
+      }
+      async get(): Promise<null> {
+        return null;
+      }
+      async getActive(): Promise<null> {
+        return null;
+      }
+    },
+    listAgentsForProject: (projectRoot: string) => {
+      captured.listRoot = projectRoot;
+      return [];
+    },
+    lookupAgent: (projectRoot: string) => {
+      captured.lookupRoot = projectRoot;
+      return null;
+    },
+    attachAgentToProject: (projectRoot: string) => {
+      captured.attachRoot = projectRoot;
+    },
+    detachAgentFromProject: (projectRoot: string) => {
+      captured.detachRoot = projectRoot;
+    },
+    getProjectAgentRef: (projectRoot: string) => {
+      captured.getRefRoot = projectRoot;
+      return null;
+    },
+    checkAgentHealth: vi.fn(),
+    detectCrashedAgents: vi.fn(),
+    detectStaleAgents: vi.fn(),
+    getHealthReport: vi.fn(),
+    STALE_THRESHOLD_MS: 60_000,
+  };
+});
+
+// Mock cliOutput / cliError so the assertions stay clean.
+vi.mock('../../renderers/index.js', () => ({
+  cliOutput: vi.fn(),
+  cliError: vi.fn(),
+  humanLine: vi.fn(),
+  humanWarn: vi.fn(),
+  humanInfo: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Test fixture: a synthetic project root with a deeply nested subdir.
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  /** Canonical project root: `<tmp>/proj-<rand>` with `.cleo/` + `.git/`. */
+  rootDir: string;
+  /** Monorepo subdir below the root: `<rootDir>/packages/core`. */
+  subDir: string;
+}
+
+function makeFixture(): Fixture {
+  const rootDir = mkdtempSync(join(tmpdir(), 'cleo-agent-subdir-iso-'));
+  // getProjectRoot()'s validateProjectRoot() requires `.cleo/` AND
+  // (`.git/` directory OR `.cleo/project-info.json`). Provide both.
+  mkdirSync(join(rootDir, '.cleo'), { recursive: true });
+  mkdirSync(join(rootDir, '.git'), { recursive: true });
+  writeFileSync(
+    join(rootDir, '.cleo', 'project-info.json'),
+    JSON.stringify({ projectId: 'agent-subdir-iso-test' }),
+  );
+  const subDir = join(rootDir, 'packages', 'core');
+  mkdirSync(subDir, { recursive: true });
+  return { rootDir, subDir };
+}
+
+/**
+ * Snapshot and clear all CLEO_* env vars so the resolution path walks
+ * the filesystem from cwd rather than honoring an operator-set override.
+ */
+function useCleanEnv(): { restore: () => void } {
+  const saved: Record<string, string | undefined> = {
+    CLEO_ROOT: process.env['CLEO_ROOT'],
+    CLEO_PROJECT_ROOT: process.env['CLEO_PROJECT_ROOT'],
+    CLEO_DIR: process.env['CLEO_DIR'],
+  };
+  delete process.env['CLEO_ROOT'];
+  delete process.env['CLEO_PROJECT_ROOT'];
+  delete process.env['CLEO_DIR'];
+  return {
+    restore() {
+      for (const [key, val] of Object.entries(saved)) {
+        if (val !== undefined) {
+          process.env[key] = val;
+        } else {
+          delete process.env[key];
+        }
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Run-handler extraction helper
+// ---------------------------------------------------------------------------
+
+type RunContext = { args: Record<string, unknown>; rawArgs: string[] };
+type RunFn = (ctx: RunContext) => Promise<void>;
+
+function getAgentSubRun(subName: string): RunFn {
+  const subs = agentCommand.subCommands as Record<string, { run?: RunFn }>;
+  const sub = subs[subName];
+  if (!sub?.run) {
+    throw new Error(`agent ${subName} subcommand has no run function`);
+  }
+  return sub.run;
+}
+
+// ---------------------------------------------------------------------------
+// Suite: agent CLI handlers resolve canonical project root from subdir
+// ---------------------------------------------------------------------------
+
+describe('T9582 — cleo agent: project-root resolution from monorepo subdir', () => {
+  let fixture: Fixture;
+  let origCwd: string;
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    origCwd = process.cwd();
+    const env = useCleanEnv();
+    restoreEnv = env.restore;
+    fixture = makeFixture();
+    resetCaptured();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } catch {
+      /* ignore */
+    }
+    restoreEnv();
+    try {
+      rmSync(fixture.rootDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('cleo agent list reads registry against the canonical project root, not the subdir', async () => {
+    process.chdir(fixture.subDir);
+
+    const run = getAgentSubRun('list');
+    await run({ args: {}, rawArgs: [] });
+
+    expect(captured.listRoot).toBe(fixture.rootDir);
+    expect(captured.listRoot).not.toBe(fixture.subDir);
+  });
+
+  it('cleo agent get looks up the agent against the canonical project root, not the subdir', async () => {
+    process.chdir(fixture.subDir);
+
+    const run = getAgentSubRun('get');
+    await run({ args: { agentId: 'agent-test' }, rawArgs: [] });
+
+    expect(captured.lookupRoot).toBe(fixture.rootDir);
+    expect(captured.lookupRoot).not.toBe(fixture.subDir);
+  });
+
+  it('cleo agent attach uses the canonical project root for both accessor + attach', async () => {
+    process.chdir(fixture.subDir);
+
+    // Make lookupAgent return a "found" record so the attach handler proceeds
+    // past its E_NOT_FOUND guard.
+    const internal = await import('@cleocode/core/internal');
+    const lookupSpy = vi
+      .spyOn(internal, 'lookupAgent')
+      .mockImplementation((projectRoot: string) => {
+        captured.lookupRoot = projectRoot;
+        return {
+          agentId: 'agent-test',
+          displayName: 'Test Agent',
+        } as unknown as ReturnType<typeof internal.lookupAgent>;
+      });
+
+    try {
+      const run = getAgentSubRun('attach');
+      await run({ args: { agentId: 'agent-test' }, rawArgs: [] });
+    } finally {
+      lookupSpy.mockRestore();
+    }
+
+    expect(captured.accessorRoot).toBe(fixture.rootDir);
+    expect(captured.lookupRoot).toBe(fixture.rootDir);
+    expect(captured.attachRoot).toBe(fixture.rootDir);
+  });
+
+  it('cleo agent detach uses the canonical project root for the ref lookup', async () => {
+    process.chdir(fixture.subDir);
+
+    // Make getProjectAgentRef return a "found" ref so detach proceeds.
+    const internal = await import('@cleocode/core/internal');
+    const refSpy = vi
+      .spyOn(internal, 'getProjectAgentRef')
+      .mockImplementation((projectRoot: string) => {
+        captured.getRefRoot = projectRoot;
+        return { agentId: 'agent-test', enabled: 1 } as unknown as ReturnType<
+          typeof internal.getProjectAgentRef
+        >;
+      });
+
+    try {
+      const run = getAgentSubRun('detach');
+      await run({ args: { agentId: 'agent-test' }, rawArgs: [] });
+    } finally {
+      refSpy.mockRestore();
+    }
+
+    expect(captured.accessorRoot).toBe(fixture.rootDir);
+    expect(captured.getRefRoot).toBe(fixture.rootDir);
+    expect(captured.detachRoot).toBe(fixture.rootDir);
+  });
+
+  it('CLEO_ROOT env var overrides cwd-derived resolution (sanity check)', async () => {
+    // When CLEO_ROOT is set, getProjectRoot honors it even from a subdir.
+    // Use a *different* canonical root to prove the env-var wins.
+    const overrideRoot = mkdtempSync(join(tmpdir(), 'cleo-agent-override-'));
+    mkdirSync(join(overrideRoot, '.cleo'), { recursive: true });
+    mkdirSync(join(overrideRoot, '.git'), { recursive: true });
+    writeFileSync(
+      join(overrideRoot, '.cleo', 'project-info.json'),
+      JSON.stringify({ projectId: 'override' }),
+    );
+    process.env['CLEO_ROOT'] = overrideRoot;
+    process.chdir(fixture.subDir);
+
+    try {
+      const run = getAgentSubRun('list');
+      await run({ args: {}, rawArgs: [] });
+
+      expect(captured.listRoot).toBe(overrideRoot);
+      expect(captured.listRoot).not.toBe(fixture.rootDir);
+      expect(captured.listRoot).not.toBe(fixture.subDir);
+    } finally {
+      delete process.env['CLEO_ROOT'];
+      try {
+        rmSync(overrideRoot, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+});

--- a/packages/cleo/src/cli/commands/agent.ts
+++ b/packages/cleo/src/cli/commands/agent.ts
@@ -40,6 +40,7 @@ import {
   detectCrashedAgents,
   detectStaleAgents,
   getHealthReport,
+  getProjectRoot,
   STALE_THRESHOLD_MS,
 } from '@cleocode/core/internal';
 import { defineCommand, showUsage } from 'citty';
@@ -88,7 +89,7 @@ const registerCommand = defineCommand({
     try {
       const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const agentId = args.id;
       const displayName = args.name;
@@ -213,7 +214,7 @@ const signinCommand = defineCommand({
     try {
       const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       // Look up the credential
       const credential = await registry.get(args.agentId);
@@ -332,7 +333,7 @@ const startCommand = defineCommand({
       const { join } = await import('node:path');
 
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       // 1. Look up credential
       const credential = await registry.get(args.agentId);
@@ -485,7 +486,7 @@ const stopCommand = defineCommand({
     try {
       const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const credential = await registry.get(args.agentId);
       if (!credential) {
@@ -550,7 +551,7 @@ const statusCommand = defineCommand({
     try {
       const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       if (args.agentId) {
         const credential = await registry.get(args.agentId);
@@ -630,7 +631,7 @@ const assignCommand = defineCommand({
         '@cleocode/core/internal'
       );
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const active = await registry.getActive();
       if (!active) {
@@ -691,7 +692,7 @@ const wakeCommand = defineCommand({
         '@cleocode/core/internal'
       );
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const active = await registry.getActive();
       if (!active) {
@@ -759,7 +760,7 @@ const spawnCommand = defineCommand({
     try {
       const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const role = args.role;
       const taskId = args.task as string | undefined;
@@ -831,7 +832,7 @@ const reassignCommand = defineCommand({
         '@cleocode/core/internal'
       );
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
       const active = await registry.getActive();
       if (!active) {
         cliOutput(
@@ -874,7 +875,7 @@ const stopAllCommand = defineCommand({
     try {
       const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
       const agents = await registry.list({ active: true });
       let stopped = 0;
       for (const a of agents) {
@@ -956,7 +957,7 @@ const workCommand = defineCommand({
       const { promisify } = await import('node:util');
       const execFileAsync = promisify(execFile);
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
       const credential = await registry.get(args.agentId);
       if (!credential) {
         cliOutput(
@@ -1151,7 +1152,7 @@ const listCommand = defineCommand({
       const includeGlobal = args.global === true;
       const includeDisabled = args['include-disabled'] === true;
 
-      const agents = listAgentsForProject(process.cwd(), {
+      const agents = listAgentsForProject(getProjectRoot(), {
         includeGlobal,
         includeDisabled,
       });
@@ -1219,7 +1220,7 @@ const getCommand = defineCommand({
       await getDb();
 
       const includeGlobal = args.global === true;
-      const agent = lookupAgent(process.cwd(), args.agentId, { includeGlobal });
+      const agent = lookupAgent(getProjectRoot(), args.agentId, { includeGlobal });
 
       if (!agent) {
         cliOutput(
@@ -1301,7 +1302,7 @@ const attachCommand = defineCommand({
         '@cleocode/core/internal'
       );
       await getDb();
-      const projectRoot = process.cwd();
+      const projectRoot = getProjectRoot();
 
       // Ensure both DBs initialised before any cross-DB operation
       const _registry = new AgentRegistryAccessor(projectRoot);
@@ -1372,7 +1373,7 @@ const detachCommand = defineCommand({
       const { AgentRegistryAccessor, detachAgentFromProject, getProjectAgentRef, getDb } =
         await import('@cleocode/core/internal');
       await getDb();
-      const projectRoot = process.cwd();
+      const projectRoot = getProjectRoot();
 
       // Ensure both DBs initialised
       const _registry = new AgentRegistryAccessor(projectRoot);
@@ -1449,7 +1450,7 @@ const removeCommand = defineCommand({
       const { AgentRegistryAccessor, detachAgentFromProject, getProjectAgentRef, getDb } =
         await import('@cleocode/core/internal');
       await getDb();
-      const projectRoot = process.cwd();
+      const projectRoot = getProjectRoot();
 
       if (!args.global) {
         // Project-scoped detach (default post-T310) — mirrors `cleo agent detach`
@@ -1552,7 +1553,7 @@ const rotateKeyCommand = defineCommand({
     try {
       const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const result = await registry.rotateKey(args.agentId);
       cliOutput(
@@ -1593,7 +1594,7 @@ const claimCodeCommand = defineCommand({
     try {
       const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const credential = await registry.get(args.agentId);
       if (!credential) {
@@ -1676,7 +1677,7 @@ const watchCommand = defineCommand({
       const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
       const { createRuntime } = await import('@cleocode/runtime');
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const groupIds = args.group ? args.group.split(',').map((s) => s.trim()) : undefined;
 
@@ -1769,7 +1770,7 @@ const pollCommand = defineCommand({
         '@cleocode/core/internal'
       );
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const agentId = args.agent as string | undefined;
       const conduit = await createConduit(registry, agentId);
@@ -1827,7 +1828,7 @@ const sendCommand = defineCommand({
         '@cleocode/core/internal'
       );
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const agentId = args.agent as string | undefined;
       const to = args.to as string | undefined;
@@ -2168,7 +2169,7 @@ const installCommand = defineCommand({
 
       const isGlobal = args.global === true;
       const targetTier: 'global' | 'project' = isGlobal ? 'global' : 'project';
-      const projectRoot = process.cwd();
+      const projectRoot = getProjectRoot();
 
       try {
         // `--resync`: drop+reinstall the registry row but preserve the
@@ -2527,7 +2528,7 @@ const createCommand = defineCommand({
         const xdgData = process.env['XDG_DATA_HOME'] ?? join(home, '.local', 'share');
         targetRoot = join(xdgData, 'cleo', 'cant', 'agents');
       } else {
-        targetRoot = join(process.cwd(), CLEO_DIR_NAME, CANT_AGENTS_SUBDIR);
+        targetRoot = join(getProjectRoot(), CLEO_DIR_NAME, CANT_AGENTS_SUBDIR);
       }
 
       const agentDir = join(targetRoot, name);
@@ -2619,7 +2620,7 @@ const createCommand = defineCommand({
       try {
         const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
         await getDb();
-        const registry = new AgentRegistryAccessor(process.cwd());
+        const registry = new AgentRegistryAccessor(getProjectRoot());
         const existing = await registry.get(name);
 
         if (!existing) {
@@ -2733,7 +2734,7 @@ const mintCommand = defineCommand({
       }
 
       const specContent = readFileSync(specPath, 'utf-8');
-      const projectRoot = process.cwd();
+      const projectRoot = getProjectRoot();
       const outputDir = args['output-dir']
         ? resolve(args['output-dir'])
         : join(projectRoot, '.cleo', 'cant', 'agents');
@@ -2881,7 +2882,7 @@ const doctorCommand = defineCommand({
       const db = _sdDb3 as import('node:sqlite').DatabaseSync;
 
       try {
-        const report = await buildDoctorReport(db, { projectRoot: process.cwd() });
+        const report = await buildDoctorReport(db, { projectRoot: getProjectRoot() });
         const repairFlag = args.repair === true;
 
         let reconciled: Awaited<ReturnType<typeof reconcileDoctor>> | undefined;

--- a/packages/cleo/src/cli/commands/nexus.ts
+++ b/packages/cleo/src/cli/commands/nexus.ts
@@ -17,6 +17,7 @@
 import { appendFile, mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
+import { getProjectRoot } from '@cleocode/core/internal';
 import { generateGexf, getSymbolImpact } from '@cleocode/core/nexus';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli, dispatchRaw } from '../../dispatch/adapters/cli.js';
@@ -153,7 +154,7 @@ const statusCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const startTime = Date.now();
 
     try {
@@ -742,7 +743,7 @@ const clustersCommand = defineCommand({
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('query', 'nexus', 'clusters', { projectId, repoPath });
     const durationMs = Date.now() - startTime;
@@ -788,7 +789,7 @@ const flowsCommand = defineCommand({
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('query', 'nexus', 'flows', { projectId, repoPath });
     const durationMs = Date.now() - startTime;
@@ -835,7 +836,7 @@ const contextCommand = defineCommand({
     void appendDeprecationTelemetry('nexus.context', 'cleo graph context');
     const startTime = Date.now();
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = process.cwd();
+    const repoPath = getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const limit = parseInt(args.limit as string, 10);
     const symbolName = args.symbol as string;
@@ -901,7 +902,7 @@ const impactCommand = defineCommand({
     const startTime = Date.now();
     const whyFlag = !!args.why;
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = process.cwd();
+    const repoPath = getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const maxDepth = Math.min(parseInt(args.depth as string, 10), 5);
     const symbolName = args.symbol as string;
@@ -981,7 +982,7 @@ const analyzeCommand = defineCommand({
     const ctx = getFormatContext();
 
     // Resolve target path
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
 
     humanInfo(`[nexus] Analyzing: ${repoPath}${isIncremental ? ' (incremental)' : ''}`);
 
@@ -1183,7 +1184,7 @@ const projectsRegisterCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const name = args.name as string | undefined;
 
     const response = await dispatchRaw('mutate', 'nexus', 'projects.register', {
@@ -1573,7 +1574,7 @@ const refreshBridgeCommand = defineCommand({
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
 
     const response = await dispatchRaw('mutate', 'nexus', 'refresh-bridge', {
@@ -1762,7 +1763,7 @@ const diffCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectIdOverride = args['project-id'] as string | undefined;
     const beforeRef = (args.before as string | undefined) ?? 'HEAD~1';
     const afterRef = (args.after as string | undefined) ?? 'HEAD';
@@ -1907,7 +1908,7 @@ const routeMapCommand = defineCommand({
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('query', 'nexus', 'route-map', { projectId });
     const durationMs = Date.now() - startTime;
@@ -1967,7 +1968,7 @@ const shapeCheckCommand = defineCommand({
     const startTime = Date.now();
     const routeSymbol = args.routeSymbol as string;
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('query', 'nexus', 'shape-check', { routeSymbol, projectId });
     const durationMs = Date.now() - startTime;
@@ -2441,7 +2442,7 @@ const contractsSyncCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectIdOverride = args['project-id'] as string | undefined;
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('mutate', 'nexus', 'contracts-sync', {
@@ -2549,7 +2550,7 @@ const contractsLinkTasksCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('mutate', 'nexus', 'contracts-link-tasks', {
       projectId,
@@ -2633,7 +2634,7 @@ const wikiCommand = defineCommand({
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
     const outputDir =
-      (args.output as string | undefined) ?? path.join(process.cwd(), '.cleo', 'wiki');
+      (args.output as string | undefined) ?? path.join(getProjectRoot(), '.cleo', 'wiki');
     const communityFilter = (args.community as string | undefined) ?? undefined;
     const isIncremental = !!(args.incremental as boolean | undefined);
 
@@ -2680,11 +2681,11 @@ const wikiCommand = defineCommand({
       const { generateNexusWikiIndex } = await import(
         '@cleocode/core/nexus/wiki-index.js' as string
       );
-      const result = await generateNexusWikiIndex(outputDir, process.cwd(), {
+      const result = await generateNexusWikiIndex(outputDir, getProjectRoot(), {
         communityFilter,
         incremental: isIncremental,
         loomProvider,
-        projectRoot: process.cwd(),
+        projectRoot: getProjectRoot(),
       });
       const durationMs = Date.now() - startTime;
 

--- a/packages/cleo/src/dispatch/domains/conduit.ts
+++ b/packages/cleo/src/dispatch/domains/conduit.ts
@@ -25,6 +25,7 @@
  */
 
 import type { conduit } from '@cleocode/core';
+import { getProjectRoot } from '@cleocode/core/internal';
 import {
   defineTypedHandler,
   type OpsFromCore,
@@ -219,7 +220,7 @@ export class ConduitHandler implements DomainHandler {
 async function _resolveCredential(agentId?: string) {
   const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
   await getDb(); // Ensure DB initialized before registry access
-  const registry = new AgentRegistryAccessor(process.cwd());
+  const registry = new AgentRegistryAccessor(getProjectRoot());
   const credential = agentId ? await registry.get(agentId) : await registry.getActive();
   if (!credential) {
     throw new Error(
@@ -236,7 +237,7 @@ async function getStatusImpl(agentId?: string) {
 
   // Check local conduit.db unread count when available
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (LocalTransport.isAvailable(process.cwd())) {
+  if (LocalTransport.isAvailable(getProjectRoot())) {
     const transport = new LocalTransport();
     await transport.connect({
       agentId: credential.agentId,
@@ -305,7 +306,7 @@ async function peekImpl(agentId?: string, limit?: number) {
 
   // Prefer LocalTransport when conduit.db is present — no network round-trip needed.
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (LocalTransport.isAvailable(process.cwd())) {
+  if (LocalTransport.isAvailable(getProjectRoot())) {
     const transport = new LocalTransport();
     await transport.connect({
       agentId: credential.agentId,
@@ -404,7 +405,7 @@ async function startPollingImpl(
   let transport: import('@cleocode/contracts').Transport | undefined;
   let transportName = 'http';
 
-  if (LocalTransport.isAvailable(process.cwd())) {
+  if (LocalTransport.isAvailable(getProjectRoot())) {
     const local = new LocalTransport();
     await local.connect({
       agentId: credential.agentId,
@@ -487,7 +488,7 @@ async function subscribeTopicImpl(
   }
   const credential = await _resolveCredential(agentId);
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (!LocalTransport.isAvailable(process.cwd())) {
+  if (!LocalTransport.isAvailable(getProjectRoot())) {
     return {
       success: false,
       error: { code: 'E_CONDUIT', message: 'conduit.db not found — run: cleo init' },
@@ -547,7 +548,7 @@ async function publishToTopicImpl(
   }
   const credential = await _resolveCredential(agentId);
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (!LocalTransport.isAvailable(process.cwd())) {
+  if (!LocalTransport.isAvailable(getProjectRoot())) {
     return {
       success: false,
       error: { code: 'E_CONDUIT', message: 'conduit.db not found — run: cleo init' },
@@ -603,7 +604,7 @@ async function listenTopicImpl(
   const startMs = Date.now();
   const credential = await _resolveCredential(agentId);
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (!LocalTransport.isAvailable(process.cwd())) {
+  if (!LocalTransport.isAvailable(getProjectRoot())) {
     return {
       success: false,
       error: { code: 'E_CONDUIT', message: 'conduit.db not found — run: cleo init' },
@@ -660,7 +661,7 @@ async function sendMessageImpl(
   // Prefer LocalTransport when conduit.db is present — message written directly
   // to the SQLite store without network, available for immediate local polling.
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (LocalTransport.isAvailable(process.cwd())) {
+  if (LocalTransport.isAvailable(getProjectRoot())) {
     const transport = new LocalTransport();
     await transport.connect({
       agentId: credential.agentId,

--- a/packages/cleo/src/dispatch/domains/nexus.ts
+++ b/packages/cleo/src/dispatch/domains/nexus.ts
@@ -527,7 +527,7 @@ const _nexusTypedHandler = defineTypedHandler<NexusOps>('nexus', {
   },
 
   reconcile: async (params) =>
-    wrapCoreResult(await nexusReconcileProject(params.projectRoot ?? process.cwd()), 'reconcile'),
+    wrapCoreResult(await nexusReconcileProject(getProjectRoot(params.projectRoot)), 'reconcile'),
 
   'share.snapshot.export': async (params) => {
     const projectRoot = getProjectRoot();
@@ -1251,7 +1251,8 @@ async function handleImpact(
     5,
   );
   const projectIdParam = params?.projectId as string | undefined;
-  const projectId = projectIdParam ?? Buffer.from(process.cwd()).toString('base64url').slice(0, 32);
+  const projectId =
+    projectIdParam ?? Buffer.from(getProjectRoot()).toString('base64url').slice(0, 32);
 
   try {
     const { getNexusDb } = await import('@cleocode/core/store/nexus-sqlite' as string);

--- a/packages/core/src/agents/invoke-meta-agent.ts
+++ b/packages/core/src/agents/invoke-meta-agent.ts
@@ -24,6 +24,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { getProjectRoot } from '../paths.js';
 import { resolveMetaAgentsDir } from './resolveAgentTemplates.js';
 
 // ---------------------------------------------------------------------------
@@ -204,7 +205,13 @@ async function readUserProfile(nexusDb: any): Promise<string | null> {
  * @task T1273 — user_profile + project-context threading
  */
 export async function invokeMetaAgent(options: InvokeMetaAgentOptions): Promise<MetaAgentResult> {
-  const { agentName, projectRoot = process.cwd(), tokens = {}, nexusDb, dryRun = false } = options;
+  const {
+    agentName,
+    projectRoot = getProjectRoot(),
+    tokens = {},
+    nexusDb,
+    dryRun = false,
+  } = options;
 
   if (dryRun) {
     return { invoked: false, reason: 'dry-run requested' };

--- a/packages/core/src/conduit/local-transport.ts
+++ b/packages/core/src/conduit/local-transport.ts
@@ -26,6 +26,7 @@ import type {
   Transport,
   TransportConnectConfig,
 } from '@cleocode/contracts';
+import { getProjectRoot } from '../paths.js';
 import { getConduitDbPath, openFreshConduitDb } from '../store/conduit-sqlite.js';
 
 /**
@@ -87,14 +88,15 @@ export class LocalTransport implements Transport {
    * @epic T310
    */
   async connect(config: TransportConnectConfig): Promise<void> {
-    const dbPath = getConduitDbPath(process.cwd());
+    const projectRoot = getProjectRoot();
+    const dbPath = getConduitDbPath(projectRoot);
 
     if (!existsSync(dbPath)) {
       throw new Error(`LocalTransport: conduit.db not found at ${dbPath}. Run: cleo init`);
     }
 
     // Open fresh (non-singleton) conduit connection with pragmas applied (T9189)
-    const db = openFreshConduitDb(process.cwd());
+    const db = openFreshConduitDb(projectRoot);
 
     // Verify the messages table exists
     const hasMessages = db
@@ -520,11 +522,11 @@ export class LocalTransport implements Transport {
    *
    * @task T356
    * @epic T310
-   * @param cwd - Optional working directory override (defaults to process.cwd()).
+   * @param cwd - Optional working directory override (defaults to canonical project root).
    * @returns `true` if conduit.db exists at the expected path.
    */
   static isAvailable(cwd?: string): boolean {
-    const dbPath = getConduitDbPath(cwd ?? process.cwd());
+    const dbPath = getConduitDbPath(getProjectRoot(cwd));
     return existsSync(dbPath);
   }
 

--- a/packages/core/src/nexus/query.ts
+++ b/packages/core/src/nexus/query.ts
@@ -17,6 +17,7 @@ import type { Task } from '@cleocode/contracts';
 import { ExitCode, type NexusResolveParams } from '@cleocode/contracts';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { CleoError } from '../errors.js';
+import { getProjectRoot } from '../paths.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { getBrainNativeDb } from '../store/memory-sqlite.js';
 import { getNexusNativeDb } from '../store/nexus-sqlite.js';
@@ -96,7 +97,7 @@ export function getCurrentProject(): string {
 
   // Try to read from .cleo/project-info.json (matches bash behavior)
   try {
-    const infoPath = join(process.cwd(), '.cleo', 'project-info.json');
+    const infoPath = join(getProjectRoot(), '.cleo', 'project-info.json');
     if (existsSync(infoPath)) {
       const data = JSON.parse(readFileSync(infoPath, 'utf-8')) as Record<string, unknown>;
       if (typeof data.name === 'string' && data.name.length > 0) {
@@ -107,8 +108,8 @@ export function getCurrentProject(): string {
     // Fall through to directory name
   }
 
-  // Fallback to cwd directory name
-  return basename(process.cwd());
+  // Fallback to project-root directory name
+  return basename(getProjectRoot());
 }
 
 /**
@@ -122,9 +123,10 @@ export async function resolveProjectPath(projectName: string): Promise<string> {
 
   if (projectName === '.') {
     try {
-      const accessor = await getTaskAccessor(process.cwd());
+      const projectRoot = getProjectRoot();
+      const accessor = await getTaskAccessor(projectRoot);
       const count = await accessor.countTasks();
-      if (count >= 0) return process.cwd();
+      if (count >= 0) return projectRoot;
       throw new Error('No task data');
     } catch {
       throw new CleoError(

--- a/packages/core/src/nexus/wiki-index.ts
+++ b/packages/core/src/nexus/wiki-index.ts
@@ -32,6 +32,7 @@ import type {
   WikiSymbolRow,
 } from '@cleocode/contracts';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
+import { getProjectRoot } from '../paths.js';
 import { getNexusDbPath, getNexusNativeDb } from '../store/nexus-sqlite.js';
 
 const execFileAsync = promisify(execFileNode);
@@ -258,7 +259,7 @@ export async function generateNexusWikiIndex(
   projectRoot?: string,
   options?: GenerateNexusWikiOptions,
 ): Promise<NexusWikiResult> {
-  const resolvedProjectRoot = projectRoot ?? process.cwd();
+  const resolvedProjectRoot = getProjectRoot(projectRoot);
   const communityFilter = options?.communityFilter ?? null;
   const isIncremental = options?.incremental ?? false;
   const loomProvider = options?.loomProvider ?? null;


### PR DESCRIPTION
## Summary

Batch 3 HIGH fixes per T9580 audit. Replaces `process.cwd()` direct calls in
agent CLI, nexus dispatch handlers, and conduit dispatch handlers with
`getProjectRoot()` from `packages/core/src/paths.ts`. Running `cleo agent
register/get/list`, `cleo nexus *`, `cleo conduit *` from a monorepo
subdir now reads/writes to the canonical project root instead of subdir.

`getProjectRoot()` performs the canonical 5-tier resolution:
worktreeScope > CLEO_ROOT/CLEO_PROJECT_ROOT > CLEO_DIR (abs) >
git-worktree gitlink walk-up > ancestor `.cleo`/`.git` walk-up. This
preserves all existing override paths while fixing the silent
state-corruption bug exercised from a monorepo subdir.

## Files touched

- `packages/cleo/src/cli/commands/agent.ts` — 26 sites normalized
- `packages/cleo/src/cli/commands/nexus.ts` — 16 sites normalized
- `packages/cleo/src/dispatch/domains/nexus.ts` — 2 sites normalized
- `packages/cleo/src/dispatch/domains/conduit.ts` — 8 sites normalized
- `packages/core/src/agents/invoke-meta-agent.ts` — 1 site normalized
- `packages/core/src/nexus/query.ts` — 4 sites normalized
- `packages/core/src/nexus/wiki-index.ts` — 1 site normalized
- `packages/core/src/conduit/local-transport.ts` — 4 sites normalized

## Test plan

- [x] Added subdir-isolation test `packages/cleo/src/cli/commands/__tests__/agent-subdir-isolation.test.ts`
- [x] Mock `@cleocode/core/internal`, capture `projectRoot` arg passed to
      `AgentRegistryAccessor` / `listAgentsForProject` / `lookupAgent` /
      `attachAgentToProject` / `detachAgentFromProject` / `getProjectAgentRef`
- [x] `process.chdir(subDir)` regression scenario asserts captured root
      equals canonical fixture root, NOT subdir
- [x] `CLEO_ROOT` env override sanity check
- [x] Quality gates: `biome check --write` (passes), `pnpm run build` (exit 0),
      `tsc --noEmit` on both core + cleo (exit 0)

Closes T9582 (Batch 3 of T9580). Unblocks T9584 cleanup.