### PR TITLE
fix: remove duplicate WizardInterruptError import in setup.ts

### DIFF
--- a/packages/cleo/src/cli/commands/setup.ts
+++ b/packages/cleo/src/cli/commands/setup.ts
@@ -45,7 +45,6 @@ import type {
   WizardSectionResult,
 } from '@cleocode/core/setup';
 import { createDefaultWizardRunner, WizardInterruptError } from '@cleocode/core/setup';
-import { WizardInterruptError, createDefaultWizardRunner } from '@cleocode/core/setup';
 import { defineCommand } from 'citty';
 import { ReadlineWizardIO, StdinClosedError } from '../lib/readline-wizard-io.js';
 import { cliError, cliOutput } from '../renderers/index.js';


### PR DESCRIPTION
Concurrent PR landed a duplicate import block on main, blocking the v2026.5.80 release workflow's biome ci gate (npm publish failed). Drops the duplicate line; keeps the first occurrence. Unblocks the v2026.5.80 npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)