### PR TITLE
feat(T9620): CLI agent.ts → CORE dispatch (T-CLI-AGENT-DISPATCH)

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/agent-attach.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/agent-attach.test.ts
@@ -12,7 +12,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { agentCommand } from '../agent.js';
 
 // ---------------------------------------------------------------------------
-// Mock @cleocode/core/internal (dynamic import inside run handlers)
+// Mock @cleocode/core/agents (T9620: agent.ts now imports from public barrel)
+// and @cleocode/core/internal for infrastructure symbols (getDb)
 // ---------------------------------------------------------------------------
 
 const mockAttachAgentToProject = vi.fn();
@@ -21,18 +22,27 @@ const mockGetProjectAgentRef = vi.fn();
 const mockLookupAgent = vi.fn();
 const mockGetDb = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('@cleocode/core/internal', () => ({
+// T9620: agent.ts imports agent-specific symbols from @cleocode/core/agents
+vi.mock('@cleocode/core/agents', () => ({
   attachAgentToProject: (...args: unknown[]) => mockAttachAgentToProject(...args),
   detachAgentFromProject: (...args: unknown[]) => mockDetachAgentFromProject(...args),
   getProjectAgentRef: (...args: unknown[]) => mockGetProjectAgentRef(...args),
   lookupAgent: (...args: unknown[]) => mockLookupAgent(...args),
-  getDb: (...args: unknown[]) => mockGetDb(...args),
   AgentRegistryAccessor: function AgentRegistryAccessor() {},
   checkAgentHealth: vi.fn(),
   detectCrashedAgents: vi.fn(),
   detectStaleAgents: vi.fn(),
   getHealthReport: vi.fn(),
   STALE_THRESHOLD_MS: 60_000,
+  createConduit: vi.fn(),
+  buildDoctorReport: vi.fn(),
+  reconcileDoctor: vi.fn(),
+  installAgentFromCant: vi.fn(),
+}));
+
+// @cleocode/core/internal is still used for getDb (core-first-allowed infrastructure)
+vi.mock('@cleocode/core/internal', () => ({
+  getDb: (...args: unknown[]) => mockGetDb(...args),
 }));
 
 // Mock cliOutput so tests can inspect calls without a full renderer stack.
@@ -40,6 +50,8 @@ const mockCliOutput = vi.fn();
 vi.mock('../../renderers/index.js', () => ({
   cliOutput: (...args: unknown[]) => mockCliOutput(...args),
   cliError: vi.fn(),
+  humanWarn: vi.fn(),
+  humanLine: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------

--- a/packages/cleo/src/cli/commands/__tests__/agent-list-global.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/agent-list-global.test.ts
@@ -30,10 +30,10 @@ const { mockListAgentsForProject, mockLookupAgent, mockGetDb, mockCliOutput } = 
   mockCliOutput: vi.fn(),
 }));
 
-vi.mock('@cleocode/core/internal', () => ({
+// T9620: agent.ts imports agent-specific symbols from @cleocode/core/agents
+vi.mock('@cleocode/core/agents', () => ({
   listAgentsForProject: mockListAgentsForProject,
   lookupAgent: mockLookupAgent,
-  getDb: mockGetDb,
   AgentRegistryAccessor: vi.fn(),
   checkAgentHealth: vi.fn(),
   detectCrashedAgents: vi.fn(),
@@ -41,11 +41,24 @@ vi.mock('@cleocode/core/internal', () => ({
   getHealthReport: vi.fn(),
   STALE_THRESHOLD_MS: 180000,
   createConduit: vi.fn(),
+  attachAgentToProject: vi.fn(),
+  detachAgentFromProject: vi.fn(),
+  getProjectAgentRef: vi.fn(),
+  installAgentFromCant: vi.fn(),
+  buildDoctorReport: vi.fn(),
+  reconcileDoctor: vi.fn(),
+}));
+
+// @cleocode/core/internal is still used for getDb (core-first-allowed infrastructure)
+vi.mock('@cleocode/core/internal', () => ({
+  getDb: mockGetDb,
 }));
 
 vi.mock('../../renderers/index.js', () => ({
   cliOutput: (...args: unknown[]) => mockCliOutput(...args),
   cliError: vi.fn(),
+  humanWarn: vi.fn(),
+  humanLine: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------

--- a/packages/cleo/src/cli/commands/__tests__/agent-remove-global.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/agent-remove-global.test.ts
@@ -18,7 +18,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { agentCommand } from '../agent.js';
 
 // ---------------------------------------------------------------------------
-// Mock @cleocode/core/internal
+// Mock @cleocode/core/agents (T9620: agent.ts now imports from public barrel)
+// and @cleocode/core/internal for infrastructure symbols (getDb)
 // ---------------------------------------------------------------------------
 
 const mockDetachAgentFromProject = vi.fn();
@@ -26,10 +27,10 @@ const mockGetProjectAgentRef = vi.fn();
 const mockRemoveGlobal = vi.fn().mockResolvedValue(undefined);
 const mockGetDb = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('@cleocode/core/internal', () => ({
+// T9620: agent.ts imports agent-specific symbols from @cleocode/core/agents
+vi.mock('@cleocode/core/agents', () => ({
   detachAgentFromProject: (...args: unknown[]) => mockDetachAgentFromProject(...args),
   getProjectAgentRef: (...args: unknown[]) => mockGetProjectAgentRef(...args),
-  getDb: (...args: unknown[]) => mockGetDb(...args),
   // AgentRegistryAccessor — provide an inline constructor to avoid hoisting issues
   // (arrow functions cannot be used as constructors).
   AgentRegistryAccessor: function AgentRegistryAccessor(this: {
@@ -45,13 +46,25 @@ vi.mock('@cleocode/core/internal', () => ({
   detectStaleAgents: vi.fn(),
   getHealthReport: vi.fn(),
   STALE_THRESHOLD_MS: 60_000,
+  createConduit: vi.fn(),
+  buildDoctorReport: vi.fn(),
+  reconcileDoctor: vi.fn(),
+  installAgentFromCant: vi.fn(),
+}));
+
+// @cleocode/core/internal is still used for getDb (core-first-allowed infrastructure)
+vi.mock('@cleocode/core/internal', () => ({
+  getDb: (...args: unknown[]) => mockGetDb(...args),
 }));
 
 // Mock cliOutput so tests can inspect calls without a full renderer stack.
 const mockCliOutput = vi.fn();
+const mockHumanWarn = vi.fn();
 vi.mock('../../renderers/index.js', () => ({
   cliOutput: (...args: unknown[]) => mockCliOutput(...args),
   cliError: vi.fn(),
+  humanWarn: (...args: unknown[]) => mockHumanWarn(...args),
+  humanLine: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------

--- a/packages/cleo/src/cli/commands/agent.ts
+++ b/packages/cleo/src/cli/commands/agent.ts
@@ -41,7 +41,7 @@ import {
   detectStaleAgents,
   getHealthReport,
   STALE_THRESHOLD_MS,
-} from '@cleocode/core/internal';
+} from '@cleocode/core/agents';
 import { defineCommand, showUsage } from 'citty';
 import { AGENTS_SUBDIR, CANT_AGENTS_SUBDIR, CLEO_DIR_NAME } from '../paths.js';
 import { cliError, cliOutput, humanLine, humanWarn } from '../renderers/index.js';
@@ -86,7 +86,8 @@ const registerCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -211,7 +212,8 @@ const signinCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -326,7 +328,8 @@ const startCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       const { createRuntime } = await import('@cleocode/runtime');
       const { existsSync, readFileSync } = await import('node:fs');
       const { join } = await import('node:path');
@@ -483,7 +486,8 @@ const stopCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -548,7 +552,8 @@ const statusCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -626,9 +631,8 @@ const assignCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb, createConduit } = await import(
-        '@cleocode/core/internal'
-      );
+      const { AgentRegistryAccessor, createConduit } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -687,9 +691,8 @@ const wakeCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb, createConduit } = await import(
-        '@cleocode/core/internal'
-      );
+      const { AgentRegistryAccessor, createConduit } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -757,7 +760,8 @@ const spawnCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -827,9 +831,8 @@ const reassignCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb, createConduit } = await import(
-        '@cleocode/core/internal'
-      );
+      const { AgentRegistryAccessor, createConduit } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
       const active = await registry.getActive();
@@ -872,7 +875,8 @@ const stopAllCommand = defineCommand({
   },
   async run() {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
       const agents = await registry.list({ active: true });
@@ -948,7 +952,8 @@ const workCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       const { createRuntime } = await import('@cleocode/runtime');
       const { existsSync } = await import('node:fs');
       const { join } = await import('node:path');
@@ -1145,7 +1150,8 @@ const listCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { listAgentsForProject, getDb } = await import('@cleocode/core/internal');
+      const { listAgentsForProject } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
 
       const includeGlobal = args.global === true;
@@ -1215,7 +1221,8 @@ const getCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { lookupAgent, getDb } = await import('@cleocode/core/internal');
+      const { lookupAgent } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
 
       const includeGlobal = args.global === true;
@@ -1297,9 +1304,10 @@ const attachCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, attachAgentToProject, lookupAgent, getDb } = await import(
-        '@cleocode/core/internal'
+      const { AgentRegistryAccessor, attachAgentToProject, lookupAgent } = await import(
+        '@cleocode/core/agents'
       );
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const projectRoot = process.cwd();
 
@@ -1369,8 +1377,10 @@ const detachCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, detachAgentFromProject, getProjectAgentRef, getDb } =
-        await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor, detachAgentFromProject, getProjectAgentRef } = await import(
+        '@cleocode/core/agents'
+      );
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const projectRoot = process.cwd();
 
@@ -1446,8 +1456,10 @@ const removeCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, detachAgentFromProject, getProjectAgentRef, getDb } =
-        await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor, detachAgentFromProject, getProjectAgentRef } = await import(
+        '@cleocode/core/agents'
+      );
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const projectRoot = process.cwd();
 
@@ -1550,7 +1562,8 @@ const rotateKeyCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -1591,7 +1604,8 @@ const claimCodeCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -1673,7 +1687,8 @@ const watchCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+      const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       const { createRuntime } = await import('@cleocode/runtime');
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
@@ -1765,9 +1780,8 @@ const pollCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, createConduit, getDb } = await import(
-        '@cleocode/core/internal'
-      );
+      const { AgentRegistryAccessor, createConduit } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -1823,9 +1837,8 @@ const sendCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { AgentRegistryAccessor, createConduit, getDb } = await import(
-        '@cleocode/core/internal'
-      );
+      const { AgentRegistryAccessor, createConduit } = await import('@cleocode/core/agents');
+      const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
       const registry = new AgentRegistryAccessor(process.cwd());
 
@@ -2157,9 +2170,7 @@ const installCommand = defineCommand({
       }
 
       // Lazy-import the core facade so test mocks can intercept these symbols.
-      const { installAgentFromCant, attachAgentToProject } = await import(
-        '@cleocode/core/internal'
-      );
+      const { installAgentFromCant, attachAgentToProject } = await import('@cleocode/core/agents');
       const { openCleoDb } = await import('@cleocode/core/store/open-cleo-db');
 
       // Open via chokepoint — applies pragma SSoT (T9047, T9189)
@@ -2617,7 +2628,8 @@ const createCommand = defineCommand({
       // Best-effort agent registration in signaldock.db
       let registered = false;
       try {
-        const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
+        const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
+        const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
         await getDb();
         const registry = new AgentRegistryAccessor(process.cwd());
         const existing = await registry.get(name);
@@ -2801,7 +2813,7 @@ const pruneOrphansCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { buildDoctorReport, reconcileDoctor } = await import('@cleocode/core/internal');
+      const { buildDoctorReport, reconcileDoctor } = await import('@cleocode/core/agents');
       const { openCleoDb } = await import('@cleocode/core/store/open-cleo-db');
       // Open via chokepoint — applies pragma SSoT (T9047, T9189)
       const { db: _sdDb2 } = await openCleoDb('signaldock');
@@ -2874,7 +2886,7 @@ const doctorCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { buildDoctorReport, reconcileDoctor } = await import('@cleocode/core/internal');
+      const { buildDoctorReport, reconcileDoctor } = await import('@cleocode/core/agents');
       const { openCleoDb } = await import('@cleocode/core/store/open-cleo-db');
       // Open via chokepoint — applies pragma SSoT (T9047, T9189)
       const { db: _sdDb3 } = await openCleoDb('signaldock');

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -153,6 +153,11 @@ export default defineConfig({
         '../../packages/core/src/nexus/index.ts',
         import.meta.url,
       ).pathname,
+      // T9620: agents public API subpath — CLI agent commands use @cleocode/core/agents
+      '@cleocode/core/agents': new URL(
+        '../../packages/core/src/agents/index.ts',
+        import.meta.url,
+      ).pathname,
       // T9424: status subpath export used by `cleo status` CLI thin wrapper
       '@cleocode/core/status': new URL(
         '../../packages/core/src/status/index.ts',

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -11,6 +11,33 @@
  * @module agents
  */
 
+// Conduit factory — creates a messaging Conduit from an agent registry.
+export { createConduit } from '../conduit/factory.js';
+// Agent doctor — orphan-row detection and reconciliation.
+export {
+  type BuildDoctorReportOptions,
+  buildDoctorReport,
+  type ReconcileDoctorOptions,
+  type ReconcileDoctorResult,
+  reconcileDoctor,
+} from '../store/agent-doctor.js';
+// Agent installer — .cant/.cantz archive → registry row pipeline.
+export {
+  type InstallAgentFromCantInput,
+  type InstallAgentFromCantResult,
+  installAgentFromCant,
+} from '../store/agent-install.js';
+// === Agent store layer (T9620 — CORE-first promotion from @cleocode/core/internal) ===
+// Agent registry accessor — cross-DB CRUD (global signaldock.db + project conduit.db).
+// CLI agent commands (`packages/cleo`) consume these via @cleocode/core/agents.
+export {
+  AgentRegistryAccessor,
+  attachAgentToProject,
+  detachAgentFromProject,
+  getProjectAgentRef,
+  listAgentsForProject,
+  lookupAgent,
+} from '../store/agent-registry-accessor.js';
 // Load-balancing registry: task-count capacity, specializations, performance recording
 export {
   type AgentCapacity,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -210,6 +210,11 @@ export default defineConfig({
         './packages/core/src/nexus/index.ts',
         import.meta.url,
       ).pathname,
+      // T9620: agents public API subpath — CLI agent commands use @cleocode/core/agents
+      '@cleocode/core/agents': new URL(
+        './packages/core/src/agents/index.ts',
+        import.meta.url,
+      ).pathname,
       // T9424: status subpath export used by `cleo status` CLI thin wrapper
       '@cleocode/core/status': new URL(
         './packages/core/src/status/index.ts',


### PR DESCRIPTION
## Summary

- Replaces all `@cleocode/core/internal` imports in `packages/cleo/src/cli/commands/agent.ts` with `@cleocode/core/agents` public barrel
- Promotes 10 symbols to `packages/core/src/agents/index.ts`: `AgentRegistryAccessor`, `listAgentsForProject`, `lookupAgent`, `attachAgentToProject`, `detachAgentFromProject`, `getProjectAgentRef`, `buildDoctorReport`, `reconcileDoctor`, `installAgentFromCant`, `createConduit`
- 22 remaining `@cleocode/core/internal` references are all `getDb` (infrastructure, annotated `// core-first-allowed` with TODO T9621)
- Adds `@cleocode/core/agents` vitest alias to root and cleo package vitest configs
- Updates 3 mock-based test files to mock `@cleocode/core/agents` instead of `@cleocode/core/internal`

Closes T9620. Refs docs/plans/E-CORE-FIRST-ARCH.md Task 6.