### PR TITLE
fix(T9610): update wizard section order test for 8-section builtin list

### DIFF
--- a/packages/core/src/setup/__tests__/wizard.test.ts
+++ b/packages/core/src/setup/__tests__/wizard.test.ts
@@ -117,6 +117,7 @@ describe('WizardRunner — registration + dispatch', () => {
       'project-conventions',
       'harness',
       'brain',
+      'integrations',
       'verification',
     ]);
   });


### PR DESCRIPTION
## Summary

- Fixes the `list() returns sections in declaration order` test that was failing because `createBuiltinSections()` now includes the `integrations` section (added in T9593/T9608 via parallel PR), making the canonical section count 8 instead of 7

## Test plan

- [x] Single-line change to expected array in `wizard.test.ts` - adds `'integrations'` at position 7 before `'verification'`
- [x] Biome check passes on the modified file

Closes: CI test failure in wizard.test.ts shard 2 from PR #286 merge.
Refs T9610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)