### PR TITLE
release: ship v2026.5.81 — T9580 closeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [2026.5.81] (2026-05-18) — T9580 closeout + post-ship cleanup
+
+Closure release wrapping the v2026.5.80 ship: gathers the test, doc, and dispatch refactors that landed after `v2026.5.80` was tagged. No new product features in this version — it stabilises the docs hierarchy, completes the CLI agent dispatch refactor, and ships the wizard section + worktree IVTR test additions queued behind the v2026.5.80 cutoff.
+
+### Fixed
+
+- **PR #292 / #293** — duplicate `WizardInterruptError` import in `packages/cleo/src/cli/commands/setup.ts` that caused `Lint & Format` to fail on main after v2026.5.80 was tagged. Two parallel fixes landed (T9613 + a follow-up hotfix); main lint is green again.
+- **PR #295 (T9610 follow-up)** — wizard section order test updated to include the new integrations section (8 sections total, was 7).
+
+### Added
+
+- **PR #289 (T9603) — worktree IVTR regression tests** (T-WT-4): regression test suite for worktree IVTR flow.
+- **PR #297 (T9604) — spawn-verify E2E test** (T-WT-5).
+- **PR #294 (T9620) — CLI agent.ts uses `@cleocode/core/agents` public API** (T-CLI-AGENT-DISPATCH): replaces all `/internal` imports in `packages/cleo/src/cli/commands/agent.ts` with the promoted public barrel (`AgentRegistryAccessor`, `listAgentsForProject`, `lookupAgent`, `attachAgentToProject`, `detachAgentFromProject`, `getProjectAgentRef`, `buildDoctorReport`, `reconcileDoctor`, `installAgentFromCant`, `createConduit`). 22 remaining `/internal` references are all `getDb` infrastructure (annotated `core-first-allowed` with TODO T9621). Closes E-CORE-FIRST-ARCH Task 6.
+
+### Documentation
+
+- **PR #291 (T9624) — ADR-073 Task Hierarchy Charter as canonical SSoT**: locks the Saga (`SG-`) / Epic (`E-`) / Task (`T-`) / Subtask (none) prefix registry as charter, plus auxiliary registered prefixes (`SD-`).
+- **PR #296 (T9606) — E-WORKTREE-IVTR closeout** (T-WT-7): docs + status rollup; quality gates green; all E1 PRs merged.
+
+### Closed without merging
+
+- **PR #290 (T9582)** — `fix: normalize project-root in agent/nexus/conduit dispatch`. Superseded by PR #294 (T9620), which refactored `agent.ts` to use the public `@cleocode/core/agents` barrel — making T9582's diff (adding `getProjectRoot` to an `/internal` import block) stale beyond clean rebase. Project-root normalization in agent / nexus / conduit dispatch can be reopened post-T9620 if still needed.
+
+### Known issues carried forward (T9580 audit)
+
+- **~75 unit-test regressions on main** caused by the `getProjectRoot(projectRoot)` re-resolution introduced by T9581 (#273) and T9583 (#274) in v2026.5.80. Production behaviour is correct (callers pass real absolute roots from `getProjectRoot()`), but tests passing mock path strings (`/mock/project`, etc.) now hit the walk-up + throw path. Affected suites: `orchestrate-engine`, `orchestrate-plan`, `orchestrate-ready-display`, `orchestrate-engine-composer`, `release-engine`, `project-agnostic-release`, `release-pr-flow`, `lifecycle-scope-guard`, `doctor-injection`, `doctor-gitignore`, `subdir-isolation`, `evidence-content-intersect`, `health`, `wizard`, `worktree-ivtr`, `write-endpoints`. Fix requires either: (a) revert the `getProjectRoot(projectRoot)` re-resolution and rely on caller-provided absolute root (~70 source sites), or (b) update all affected test fixtures with `.git/` + `.cleo/` siblings in temp dirs (~75 tests across 13+ files). Tracked as a follow-up task.
+
 ## [2026.5.80] (2026-05-18) — T9580 CLI dispatch fixes
 
 Real-test audit of v2026.5.79 (T9580) caught 3 systemic dispatch bugs that left 5 of 6 new IVTR verbs returning `E_INVALID_OPERATION`. This patch wires them correctly so the IVTR pipeline becomes usable from the CLI as documented.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.80"
+version = "2026.5.81"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.80",
+  "version": "2026.5.81",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Closure release for the T9580 sweep — gathers test, doc, and dispatch refactors that landed after v2026.5.80 was tagged.

### Included PRs

- #292 / #293 (hotfix) — duplicate `WizardInterruptError` import fix in `setup.ts`
- #289 (T9603) — worktree IVTR regression tests (T-WT-4)
- #294 (T9620) — CLI `agent.ts` uses `@cleocode/core/agents` public API (T-CLI-AGENT-DISPATCH)
- #291 (T9624) — ADR-073 Task Hierarchy Charter as canonical SSoT
- #295 (T9610 follow-up) — wizard section order test updated to include integrations (8 sections)
- #296 (T9606) — E-WORKTREE-IVTR closeout (T-WT-7)
- #297 (T9604) — spawn-verify E2E test (T-WT-5) — included if green at merge time

### Closed without merging

- #290 (T9582) — `fix: normalize project-root in agent/nexus/conduit dispatch`. Superseded by #294 (T9620) which refactored `agent.ts` to use the public barrel.

### Known issues carried forward

~75 unit-test regressions on main from T9581 (#273) and T9583 (#274) introduced before v2026.5.80 — production behaviour correct, tests pass mock path strings that now hit the `getProjectRoot` walk-up + throw path. **Fix is out-of-scope for this closeout** and tracked as a follow-up task. See CHANGELOG.md for the full list of affected suites and proposed fix paths.

## Test plan

- [ ] CI lint / typecheck green
- [ ] Tag `v2026.5.81` from merge SHA after merge
- [ ] GitHub release created from merge SHA