### PR TITLE
fix(T9582): normalize project-root in agent/nexus/conduit dispatch

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/project-root-guard.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/project-root-guard.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression guard for T9582 — project-root normalization in the CLI
+ * + dispatch surfaces for `agent`, `nexus`, and `conduit`.
+ *
+ * The original T9580 audit identified 52 raw `process.cwd()` call sites
+ * across four files that forwarded an un-normalized working directory to
+ * downstream functions in `@cleocode/core`. When a `cleo` command is
+ * invoked from a monorepo subdirectory, every one of those sites would
+ * silently create or read state under `<subdir>/.cleo/` instead of the
+ * canonical `<projectRoot>/.cleo/`.
+ *
+ * This test does not exercise the CLI commands end-to-end — those have
+ * full handler tests under `__tests__/` already. Instead, it asserts the
+ * structural property that closes the regression: each file (a) imports
+ * `getProjectRoot`, and (b) contains zero raw `process.cwd()` references
+ * at the source level. If a future PR re-introduces `process.cwd()` in
+ * any of these files, this test fails before the change reaches main.
+ *
+ * @task T9582
+ * @epic T9580
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..', '..', '..');
+
+const GUARDED_FILES = [
+  'packages/cleo/src/cli/commands/agent.ts',
+  'packages/cleo/src/cli/commands/nexus.ts',
+  'packages/cleo/src/dispatch/domains/conduit.ts',
+  'packages/cleo/src/dispatch/domains/nexus.ts',
+] as const;
+
+describe('T9582 — project-root normalization guard', () => {
+  for (const relPath of GUARDED_FILES) {
+    describe(relPath, () => {
+      const abs = join(REPO_ROOT, relPath);
+      const source = readFileSync(abs, 'utf8');
+
+      it('imports getProjectRoot from @cleocode/core', () => {
+        // Match `import { ... getProjectRoot ... } from '@cleocode/core(/internal)?'`
+        // across single-line and multi-line bracket forms. Using [\s\S] (DOTALL
+        // shim) handles imports that span many lines (e.g. dispatch/nexus.ts
+        // pulls 50+ symbols from @cleocode/core/internal in a multi-line block).
+        const pattern =
+          /import\s*\{[\s\S]*?getProjectRoot[\s\S]*?\}\s*from\s*['"]@cleocode\/core(\/internal)?['"]/;
+        expect(
+          pattern.test(source),
+          `expected a multi-line import of getProjectRoot from @cleocode/core(/internal)? in ${relPath}`,
+        ).toBe(true);
+      });
+
+      it('contains zero raw process.cwd() references', () => {
+        // Strip comments to avoid false positives from doc references.
+        const stripped = source
+          .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+          .replace(/^\s*\/\/.*$/gm, ''); // line comments
+        const matches = stripped.match(/process\.cwd\(\)/g) ?? [];
+        expect(
+          matches.length,
+          `expected zero process.cwd() call sites in ${relPath}, found ${matches.length}`,
+        ).toBe(0);
+      });
+    });
+  }
+});

--- a/packages/cleo/src/cli/commands/agent.ts
+++ b/packages/cleo/src/cli/commands/agent.ts
@@ -35,6 +35,7 @@
  */
 
 import type { AgentDoctorFinding } from '@cleocode/contracts';
+import { getProjectRoot } from '@cleocode/core';
 import {
   checkAgentHealth,
   detectCrashedAgents,
@@ -89,7 +90,7 @@ const registerCommand = defineCommand({
       const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const agentId = args.id;
       const displayName = args.name;
@@ -215,7 +216,7 @@ const signinCommand = defineCommand({
       const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       // Look up the credential
       const credential = await registry.get(args.agentId);
@@ -335,7 +336,7 @@ const startCommand = defineCommand({
       const { join } = await import('node:path');
 
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       // 1. Look up credential
       const credential = await registry.get(args.agentId);
@@ -489,7 +490,7 @@ const stopCommand = defineCommand({
       const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const credential = await registry.get(args.agentId);
       if (!credential) {
@@ -555,7 +556,7 @@ const statusCommand = defineCommand({
       const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       if (args.agentId) {
         const credential = await registry.get(args.agentId);
@@ -634,7 +635,7 @@ const assignCommand = defineCommand({
       const { AgentRegistryAccessor, createConduit } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const active = await registry.getActive();
       if (!active) {
@@ -694,7 +695,7 @@ const wakeCommand = defineCommand({
       const { AgentRegistryAccessor, createConduit } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const active = await registry.getActive();
       if (!active) {
@@ -763,7 +764,7 @@ const spawnCommand = defineCommand({
       const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const role = args.role;
       const taskId = args.task as string | undefined;
@@ -834,7 +835,7 @@ const reassignCommand = defineCommand({
       const { AgentRegistryAccessor, createConduit } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
       const active = await registry.getActive();
       if (!active) {
         cliOutput(
@@ -878,7 +879,7 @@ const stopAllCommand = defineCommand({
       const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
       const agents = await registry.list({ active: true });
       let stopped = 0;
       for (const a of agents) {
@@ -961,7 +962,7 @@ const workCommand = defineCommand({
       const { promisify } = await import('node:util');
       const execFileAsync = promisify(execFile);
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
       const credential = await registry.get(args.agentId);
       if (!credential) {
         cliOutput(
@@ -1157,7 +1158,7 @@ const listCommand = defineCommand({
       const includeGlobal = args.global === true;
       const includeDisabled = args['include-disabled'] === true;
 
-      const agents = listAgentsForProject(process.cwd(), {
+      const agents = listAgentsForProject(getProjectRoot(), {
         includeGlobal,
         includeDisabled,
       });
@@ -1226,7 +1227,7 @@ const getCommand = defineCommand({
       await getDb();
 
       const includeGlobal = args.global === true;
-      const agent = lookupAgent(process.cwd(), args.agentId, { includeGlobal });
+      const agent = lookupAgent(getProjectRoot(), args.agentId, { includeGlobal });
 
       if (!agent) {
         cliOutput(
@@ -1309,7 +1310,7 @@ const attachCommand = defineCommand({
       );
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const projectRoot = process.cwd();
+      const projectRoot = getProjectRoot();
 
       // Ensure both DBs initialised before any cross-DB operation
       const _registry = new AgentRegistryAccessor(projectRoot);
@@ -1382,7 +1383,7 @@ const detachCommand = defineCommand({
       );
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const projectRoot = process.cwd();
+      const projectRoot = getProjectRoot();
 
       // Ensure both DBs initialised
       const _registry = new AgentRegistryAccessor(projectRoot);
@@ -1461,7 +1462,7 @@ const removeCommand = defineCommand({
       );
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const projectRoot = process.cwd();
+      const projectRoot = getProjectRoot();
 
       if (!args.global) {
         // Project-scoped detach (default post-T310) — mirrors `cleo agent detach`
@@ -1565,7 +1566,7 @@ const rotateKeyCommand = defineCommand({
       const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const result = await registry.rotateKey(args.agentId);
       cliOutput(
@@ -1607,7 +1608,7 @@ const claimCodeCommand = defineCommand({
       const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const credential = await registry.get(args.agentId);
       if (!credential) {
@@ -1691,7 +1692,7 @@ const watchCommand = defineCommand({
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       const { createRuntime } = await import('@cleocode/runtime');
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const groupIds = args.group ? args.group.split(',').map((s) => s.trim()) : undefined;
 
@@ -1783,7 +1784,7 @@ const pollCommand = defineCommand({
       const { AgentRegistryAccessor, createConduit } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const agentId = args.agent as string | undefined;
       const conduit = await createConduit(registry, agentId);
@@ -1840,7 +1841,7 @@ const sendCommand = defineCommand({
       const { AgentRegistryAccessor, createConduit } = await import('@cleocode/core/agents');
       const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
       await getDb();
-      const registry = new AgentRegistryAccessor(process.cwd());
+      const registry = new AgentRegistryAccessor(getProjectRoot());
 
       const agentId = args.agent as string | undefined;
       const to = args.to as string | undefined;
@@ -2179,7 +2180,7 @@ const installCommand = defineCommand({
 
       const isGlobal = args.global === true;
       const targetTier: 'global' | 'project' = isGlobal ? 'global' : 'project';
-      const projectRoot = process.cwd();
+      const projectRoot = getProjectRoot();
 
       try {
         // `--resync`: drop+reinstall the registry row but preserve the
@@ -2538,7 +2539,7 @@ const createCommand = defineCommand({
         const xdgData = process.env['XDG_DATA_HOME'] ?? join(home, '.local', 'share');
         targetRoot = join(xdgData, 'cleo', 'cant', 'agents');
       } else {
-        targetRoot = join(process.cwd(), CLEO_DIR_NAME, CANT_AGENTS_SUBDIR);
+        targetRoot = join(getProjectRoot(), CLEO_DIR_NAME, CANT_AGENTS_SUBDIR);
       }
 
       const agentDir = join(targetRoot, name);
@@ -2631,7 +2632,7 @@ const createCommand = defineCommand({
         const { AgentRegistryAccessor } = await import('@cleocode/core/agents');
         const { getDb } = await import('@cleocode/core/internal'); // core-first-allowed: infrastructure — TODO T9621 promote getDb
         await getDb();
-        const registry = new AgentRegistryAccessor(process.cwd());
+        const registry = new AgentRegistryAccessor(getProjectRoot());
         const existing = await registry.get(name);
 
         if (!existing) {
@@ -2745,7 +2746,7 @@ const mintCommand = defineCommand({
       }
 
       const specContent = readFileSync(specPath, 'utf-8');
-      const projectRoot = process.cwd();
+      const projectRoot = getProjectRoot();
       const outputDir = args['output-dir']
         ? resolve(args['output-dir'])
         : join(projectRoot, '.cleo', 'cant', 'agents');
@@ -2893,7 +2894,7 @@ const doctorCommand = defineCommand({
       const db = _sdDb3 as import('node:sqlite').DatabaseSync;
 
       try {
-        const report = await buildDoctorReport(db, { projectRoot: process.cwd() });
+        const report = await buildDoctorReport(db, { projectRoot: getProjectRoot() });
         const repairFlag = args.repair === true;
 
         let reconciled: Awaited<ReturnType<typeof reconcileDoctor>> | undefined;

--- a/packages/cleo/src/cli/commands/nexus.ts
+++ b/packages/cleo/src/cli/commands/nexus.ts
@@ -17,6 +17,7 @@
 import { appendFile, mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
+import { getProjectRoot } from '@cleocode/core';
 import { generateGexf, getSymbolImpact } from '@cleocode/core/nexus';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli, dispatchRaw } from '../../dispatch/adapters/cli.js';
@@ -153,7 +154,7 @@ const statusCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const startTime = Date.now();
 
     try {
@@ -742,7 +743,7 @@ const clustersCommand = defineCommand({
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('query', 'nexus', 'clusters', { projectId, repoPath });
     const durationMs = Date.now() - startTime;
@@ -788,7 +789,7 @@ const flowsCommand = defineCommand({
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('query', 'nexus', 'flows', { projectId, repoPath });
     const durationMs = Date.now() - startTime;
@@ -835,7 +836,7 @@ const contextCommand = defineCommand({
     void appendDeprecationTelemetry('nexus.context', 'cleo graph context');
     const startTime = Date.now();
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = process.cwd();
+    const repoPath = getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const limit = parseInt(args.limit as string, 10);
     const symbolName = args.symbol as string;
@@ -901,7 +902,7 @@ const impactCommand = defineCommand({
     const startTime = Date.now();
     const whyFlag = !!args.why;
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = process.cwd();
+    const repoPath = getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const maxDepth = Math.min(parseInt(args.depth as string, 10), 5);
     const symbolName = args.symbol as string;
@@ -981,7 +982,7 @@ const analyzeCommand = defineCommand({
     const ctx = getFormatContext();
 
     // Resolve target path
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
 
     humanInfo(`[nexus] Analyzing: ${repoPath}${isIncremental ? ' (incremental)' : ''}`);
 
@@ -991,13 +992,11 @@ const analyzeCommand = defineCommand({
       // can expose this without introducing CLI rendering concerns into the dispatch
       // layer. The full analyze pipeline is fundamentally CLI-side-orchestrated.
       // Lazy imports to avoid loading heavy dependencies until needed
-      const [{ getNexusDb, nexusSchema }, { runPipeline }, { getProjectRoot }, { eq }] =
-        await Promise.all([
-          import('@cleocode/core/store/nexus-sqlite' as string),
-          import('@cleocode/nexus/pipeline' as string),
-          import('@cleocode/core/internal' as string),
-          import('drizzle-orm' as string),
-        ]);
+      const [{ getNexusDb, nexusSchema }, { runPipeline }, { eq }] = await Promise.all([
+        import('@cleocode/core/store/nexus-sqlite' as string),
+        import('@cleocode/nexus/pipeline' as string),
+        import('drizzle-orm' as string),
+      ]);
 
       // Determine project ID — use override or derive from path
       const projectId =
@@ -1105,8 +1104,6 @@ const analyzeCommand = defineCommand({
           extensions: { duration_ms: durationMs },
         },
       );
-
-      void getProjectRoot; // referenced to satisfy import
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       cliError(
@@ -1183,7 +1180,7 @@ const projectsRegisterCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const name = args.name as string | undefined;
 
     const response = await dispatchRaw('mutate', 'nexus', 'projects.register', {
@@ -1573,7 +1570,7 @@ const refreshBridgeCommand = defineCommand({
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
 
     const response = await dispatchRaw('mutate', 'nexus', 'refresh-bridge', {
@@ -1762,7 +1759,7 @@ const diffCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectIdOverride = args['project-id'] as string | undefined;
     const beforeRef = (args.before as string | undefined) ?? 'HEAD~1';
     const afterRef = (args.after as string | undefined) ?? 'HEAD';
@@ -1907,7 +1904,7 @@ const routeMapCommand = defineCommand({
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('query', 'nexus', 'route-map', { projectId });
     const durationMs = Date.now() - startTime;
@@ -1967,7 +1964,7 @@ const shapeCheckCommand = defineCommand({
     const startTime = Date.now();
     const routeSymbol = args.routeSymbol as string;
     const projectIdOverride = args['project-id'] as string | undefined;
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('query', 'nexus', 'shape-check', { routeSymbol, projectId });
     const durationMs = Date.now() - startTime;
@@ -2441,7 +2438,7 @@ const contractsSyncCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectIdOverride = args['project-id'] as string | undefined;
     const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('mutate', 'nexus', 'contracts-sync', {
@@ -2549,7 +2546,7 @@ const contractsLinkTasksCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
-    const repoPath = args.path ? path.resolve(args.path as string) : process.cwd();
+    const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
     const projectId = Buffer.from(repoPath).toString('base64url').slice(0, 32);
     const response = await dispatchRaw('mutate', 'nexus', 'contracts-link-tasks', {
       projectId,
@@ -2633,7 +2630,7 @@ const wikiCommand = defineCommand({
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
     const outputDir =
-      (args.output as string | undefined) ?? path.join(process.cwd(), '.cleo', 'wiki');
+      (args.output as string | undefined) ?? path.join(getProjectRoot(), '.cleo', 'wiki');
     const communityFilter = (args.community as string | undefined) ?? undefined;
     const isIncremental = !!(args.incremental as boolean | undefined);
 
@@ -2680,11 +2677,11 @@ const wikiCommand = defineCommand({
       const { generateNexusWikiIndex } = await import(
         '@cleocode/core/nexus/wiki-index.js' as string
       );
-      const result = await generateNexusWikiIndex(outputDir, process.cwd(), {
+      const result = await generateNexusWikiIndex(outputDir, getProjectRoot(), {
         communityFilter,
         incremental: isIncremental,
         loomProvider,
-        projectRoot: process.cwd(),
+        projectRoot: getProjectRoot(),
       });
       const durationMs = Date.now() - startTime;
 

--- a/packages/cleo/src/dispatch/domains/__tests__/nexus.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/nexus.test.ts
@@ -77,6 +77,7 @@ vi.mock('@cleocode/core/internal', () => ({
 }));
 
 import {
+  getProjectRoot,
   nexusBlockers,
   nexusCriticalPath,
   nexusDepsQuery,
@@ -757,7 +758,9 @@ describe('NexusHandler', () => {
   // -----------------------------------------------------------------------
 
   describe('mutate: reconcile', () => {
-    it('reconciles using process.cwd() when projectRoot is omitted', async () => {
+    it('reconciles using resolved project root when projectRoot is omitted', async () => {
+      // T9582: dispatch handler normalizes via getProjectRoot() (not raw
+      // process.cwd()) so subdir invocations resolve to the canonical root.
       vi.mocked(nexusReconcileProject).mockResolvedValue({
         success: true,
         data: { status: 'ok' },
@@ -766,7 +769,7 @@ describe('NexusHandler', () => {
       const result = await handler.mutate('reconcile', {});
 
       expect(result.success).toBe(true);
-      expect(nexusReconcileProject).toHaveBeenCalledWith(process.cwd());
+      expect(nexusReconcileProject).toHaveBeenCalledWith(getProjectRoot());
     });
 
     it('reconciles using explicit projectRoot when provided', async () => {

--- a/packages/cleo/src/dispatch/domains/conduit.ts
+++ b/packages/cleo/src/dispatch/domains/conduit.ts
@@ -24,7 +24,7 @@
  * @task T1439 — OpsFromCore inference (T1435 Wave 1)
  */
 
-import type { conduit } from '@cleocode/core';
+import { type conduit, getProjectRoot } from '@cleocode/core';
 import {
   defineTypedHandler,
   type OpsFromCore,
@@ -219,7 +219,7 @@ export class ConduitHandler implements DomainHandler {
 async function _resolveCredential(agentId?: string) {
   const { AgentRegistryAccessor, getDb } = await import('@cleocode/core/internal');
   await getDb(); // Ensure DB initialized before registry access
-  const registry = new AgentRegistryAccessor(process.cwd());
+  const registry = new AgentRegistryAccessor(getProjectRoot());
   const credential = agentId ? await registry.get(agentId) : await registry.getActive();
   if (!credential) {
     throw new Error(
@@ -236,7 +236,7 @@ async function getStatusImpl(agentId?: string) {
 
   // Check local conduit.db unread count when available
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (LocalTransport.isAvailable(process.cwd())) {
+  if (LocalTransport.isAvailable(getProjectRoot())) {
     const transport = new LocalTransport();
     await transport.connect({
       agentId: credential.agentId,
@@ -305,7 +305,7 @@ async function peekImpl(agentId?: string, limit?: number) {
 
   // Prefer LocalTransport when conduit.db is present — no network round-trip needed.
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (LocalTransport.isAvailable(process.cwd())) {
+  if (LocalTransport.isAvailable(getProjectRoot())) {
     const transport = new LocalTransport();
     await transport.connect({
       agentId: credential.agentId,
@@ -404,7 +404,7 @@ async function startPollingImpl(
   let transport: import('@cleocode/contracts').Transport | undefined;
   let transportName = 'http';
 
-  if (LocalTransport.isAvailable(process.cwd())) {
+  if (LocalTransport.isAvailable(getProjectRoot())) {
     const local = new LocalTransport();
     await local.connect({
       agentId: credential.agentId,
@@ -487,7 +487,7 @@ async function subscribeTopicImpl(
   }
   const credential = await _resolveCredential(agentId);
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (!LocalTransport.isAvailable(process.cwd())) {
+  if (!LocalTransport.isAvailable(getProjectRoot())) {
     return {
       success: false,
       error: { code: 'E_CONDUIT', message: 'conduit.db not found — run: cleo init' },
@@ -547,7 +547,7 @@ async function publishToTopicImpl(
   }
   const credential = await _resolveCredential(agentId);
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (!LocalTransport.isAvailable(process.cwd())) {
+  if (!LocalTransport.isAvailable(getProjectRoot())) {
     return {
       success: false,
       error: { code: 'E_CONDUIT', message: 'conduit.db not found — run: cleo init' },
@@ -603,7 +603,7 @@ async function listenTopicImpl(
   const startMs = Date.now();
   const credential = await _resolveCredential(agentId);
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (!LocalTransport.isAvailable(process.cwd())) {
+  if (!LocalTransport.isAvailable(getProjectRoot())) {
     return {
       success: false,
       error: { code: 'E_CONDUIT', message: 'conduit.db not found — run: cleo init' },
@@ -660,7 +660,7 @@ async function sendMessageImpl(
   // Prefer LocalTransport when conduit.db is present — message written directly
   // to the SQLite store without network, available for immediate local polling.
   const { LocalTransport } = await import('@cleocode/core/conduit');
-  if (LocalTransport.isAvailable(process.cwd())) {
+  if (LocalTransport.isAvailable(getProjectRoot())) {
     const transport = new LocalTransport();
     await transport.connect({
       agentId: credential.agentId,

--- a/packages/cleo/src/dispatch/domains/nexus.ts
+++ b/packages/cleo/src/dispatch/domains/nexus.ts
@@ -527,7 +527,10 @@ const _nexusTypedHandler = defineTypedHandler<NexusOps>('nexus', {
   },
 
   reconcile: async (params) =>
-    wrapCoreResult(await nexusReconcileProject(params.projectRoot ?? process.cwd()), 'reconcile'),
+    wrapCoreResult(
+      await nexusReconcileProject(params.projectRoot ?? getProjectRoot()),
+      'reconcile',
+    ),
 
   'share.snapshot.export': async (params) => {
     const projectRoot = getProjectRoot();
@@ -1251,7 +1254,8 @@ async function handleImpact(
     5,
   );
   const projectIdParam = params?.projectId as string | undefined;
-  const projectId = projectIdParam ?? Buffer.from(process.cwd()).toString('base64url').slice(0, 32);
+  const projectId =
+    projectIdParam ?? Buffer.from(getProjectRoot()).toString('base64url').slice(0, 32);
 
   try {
     const { getNexusDb } = await import('@cleocode/core/store/nexus-sqlite' as string);


### PR DESCRIPTION
## Summary

- Replace 52 raw `process.cwd()` call sites across `agent.ts` (26), `cli/nexus.ts` (16), `dispatch/conduit.ts` (8), and `dispatch/nexus.ts` (2) with `getProjectRoot()` so CLI commands invoked from a monorepo subdirectory resolve to the canonical project root.
- Add a static regression-guard test that asserts each of the four files imports `getProjectRoot` and contains zero raw `process.cwd()` at the source level.
- Update one dispatch/nexus.test.ts mock assertion that previously pinned to `process.cwd()` to assert the resolved root.

## Why this PR exists (T9582 redo)

PR #290 (T9582) was closed when T9620 refactored `agent.ts` to use the `@cleocode/core/agents` public-API barrel. The closeout assumed T9620 "obsoleted" T9582's diff, but T9620 only changed the **import surface** — it did NOT normalize project-root. Confirmed by re-audit against `origin/main` HEAD (5608f75cd): 52 unsafe sites remained, exactly matching the T9580 audit. Downstream callees (`AgentRegistryAccessor`, `LocalTransport.isAvailable`, `getConduitDbPath`) do not normalize internally — they trust the caller to supply a canonical root.

## Test plan

- [x] `pnpm biome check --write` on all 6 changed files — clean
- [x] New `project-root-guard.test.ts` — 8/8 pass
- [x] All `dispatch/domains/__tests__/` tests — 981/989 pass; 8 failures are pre-existing on `origin/main` (animations dep-resolution, orchestrate worktree.complete, tasks getSupportedOperations) and unrelated to this change
- [x] Fixed 1 baseline failure: `nexus.test.ts > reconciles using resolved project root` (was expecting raw `process.cwd()` — updated to assert `getProjectRoot()`)
- [x] `conduit.test.ts` — 36/36 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)