### PR TITLE
feat(T9584): resolveOrCwd helper + CI guard + canonical doc + file migrations

### DIFF
--- a/.cleo/.gitignore
+++ b/.cleo/.gitignore
@@ -62,6 +62,12 @@
 # incremental migration. Shrinks to zero as T9616-T9621 land.)
 !core-first-baseline.json
 
+# Step 10: Allow project-root anti-pattern baseline (T9584 — tracks known
+# T9550 anti-pattern callsites for incremental migration. Shrinks to zero
+# as long-tail follow-up batches land, after which the CI guard flips to
+# --strict and this file is deleted.)
+!project-root-baseline.json
+
 # =============================================================================
 # EXPLICIT DENY — safety net that overrides allow rules above
 # =============================================================================

--- a/.cleo/project-root-baseline.json
+++ b/.cleo/project-root-baseline.json
@@ -1,0 +1,7 @@
+{
+  "$comment": "T9584 baseline — see docs/project-root-conventions.md §6. Long-tail batches must NOT increase this number; each fixed callsite decreases it by one. When the count reaches 0, the lint workflow flips to --strict and this file is deleted.",
+  "violationCount": 79,
+  "capturedAt": "2026-05-19T00:00:00Z",
+  "task": "T9584",
+  "epic": "E-PROJECT-ROOT-AUDIT"
+}

--- a/.cleo/project-root-baseline.json
+++ b/.cleo/project-root-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "T9584 baseline — see docs/project-root-conventions.md §6. Long-tail batches must NOT increase this number; each fixed callsite decreases it by one. When the count reaches 0, the lint workflow flips to --strict and this file is deleted.",
-  "violationCount": 79,
+  "violationCount": 69,
   "capturedAt": "2026-05-19T00:00:00Z",
   "task": "T9584",
   "epic": "E-PROJECT-ROOT-AUDIT"

--- a/.cleo/project-root-baseline.json
+++ b/.cleo/project-root-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "T9584 baseline — see docs/project-root-conventions.md §6. Long-tail batches must NOT increase this number; each fixed callsite decreases it by one. When the count reaches 0, the lint workflow flips to --strict and this file is deleted.",
-  "violationCount": 69,
+  "violationCount": 63,
   "capturedAt": "2026-05-19T00:00:00Z",
   "task": "T9584",
   "epic": "E-PROJECT-ROOT-AUDIT"

--- a/.cleo/project-root-baseline.json
+++ b/.cleo/project-root-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "T9584 baseline — see docs/project-root-conventions.md §6. Long-tail batches must NOT increase this number; each fixed callsite decreases it by one. When the count reaches 0, the lint workflow flips to --strict and this file is deleted.",
-  "violationCount": 63,
+  "violationCount": 57,
   "capturedAt": "2026-05-19T00:00:00Z",
   "task": "T9584",
   "epic": "E-PROJECT-ROOT-AUDIT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,29 @@ jobs:
       - name: Lint CLEO data-path drift in packages/core/src
         run: node scripts/lint-path-drift.mjs
 
+  project-root-anti-pattern-lint:
+    # T9584 / E-PROJECT-ROOT-AUDIT close-out: reject the T9550 anti-pattern
+    # that materialised rogue `<subdir>/.cleo/` dirs when CLI commands ran
+    # from a monorepo subdirectory. Three rules:
+    #   1. Bare `process.cwd()` in `packages/core/src/...` (suppress with
+    #      `// CWD-OK: <reason>` for legitimate non-project-root uses).
+    #   2. `join(..., process.cwd(), ..., '.cleo', ...)` anywhere in packages/.
+    #   3. `homedir()` constructing `.cleo` paths outside canonical resolvers.
+    # Baseline mode: rejects only NEW violations beyond the count recorded in
+    # `.cleo/project-root-baseline.json`. When the long-tail follow-up batches
+    # land, the baseline reaches 0 and this workflow flips to --strict.
+    # Pure static analysis of checked-in source — no untrusted input.
+    name: Project Root Anti-Pattern Lint (T9584)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Lint project-root anti-pattern in packages/
+        run: node scripts/lint-project-root-anti-pattern.mjs
+
   contracts-dep-lint:
     name: Contracts Dep Lint
     runs-on: ubuntu-latest

--- a/docs/project-root-conventions.md
+++ b/docs/project-root-conventions.md
@@ -1,0 +1,203 @@
+# Project-Root Resolution Conventions
+
+> **Source of truth:** this document. Last updated for T9584 (E-PROJECT-ROOT-AUDIT
+> close-out). ADR reference: ADR-067.
+
+CLEO is a monorepo that gets invoked from many directories — the repository root,
+a `packages/<pkg>/` subdirectory, a worktree under
+`~/.local/share/cleo/worktrees/...`, a CI tmpdir, or a freshly-cloned consumer
+project. Every read and write that lands in `.cleo/` MUST agree on the same
+canonical project root, or two anti-patterns appear simultaneously:
+
+1. A rogue `<subdir>/.cleo/` materialises beside `<projectRoot>/.cleo/`.
+2. The CLI silently operates on the wrong database, corrupting state.
+
+This document describes the canonical resolver, the helpers built on it, and
+the linter that prevents regressions.
+
+---
+
+## 1. The Anti-Pattern (T9550 bug class)
+
+```text
+                            CWD = packages/core/src/foo
+                                       │
+                                       ▼
+        ┌──────────────────────────────────────────────────────┐
+        │  const root = opts.root ?? process.cwd();            │  ← anti-pattern
+        │  fs.writeFileSync(join(root, '.cleo', 'foo.json'))   │
+        └──────────────────────────────────────────────────────┘
+                                       │
+                                       ▼
+              packages/core/src/foo/.cleo/foo.json   ← rogue dir
+              (instead of)
+              <projectRoot>/.cleo/foo.json
+```
+
+Even though `getProjectRoot()` exists and the spawn adapter exports
+`CLEO_ROOT`, **any callsite that fell back to `process.cwd()` directly**
+silently bypassed the canonical chain. The T9580 audit catalogued **160 such
+files** across `packages/` (see `.cleo/rcasd/T9580/research/project-root-audit.md`).
+
+The fix is to route every fallback through one of three canonical helpers.
+
+---
+
+## 2. The Canonical Resolver
+
+### `getProjectRoot(cwd?: string): string`
+
+Lives at `packages/core/src/paths.ts`. Implements a 5-tier priority chain:
+
+1. **`worktreeScope.run(...)` AsyncLocalStorage** — set by the spawn adapter so
+   subagents always honour the orchestrator's authoritative worktree root.
+2. **`CLEO_ROOT` / `CLEO_PROJECT_ROOT` env var** — explicit override.
+3. **`CLEO_DIR` (absolute path)** — derives root from `dirname(CLEO_DIR)`.
+4. **Git-worktree gitlink walk-up** — reads `.git` (a file in worktrees) to
+   reach the canonical main repo via `gitdir:` (T9092 fix).
+5. **Ancestor `.cleo/` + `.git/` walk-up** — stops at the first directory
+   whose `.cleo/project-info.json` parses or which has a real `.git/`
+   directory sibling.
+
+Hard guards: refuses to resolve to `$HOME` or `/`. Throws
+`E_INVALID_PROJECT_ROOT` when one or more `.cleo/` dirs were skipped but no
+valid root was found (the "parent .cleo trap" — T1463).
+
+### `resolveOrCwd(maybeRoot?: string | null): string` (T9584)
+
+Sugar for the common pattern. When the caller passes a non-empty string it
+is returned verbatim (orchestrate spawn passes canonical roots already; we
+trust callers); otherwise the call falls through to `getProjectRoot()`.
+
+```typescript
+// Before (T9580 anti-pattern):
+const root = opts.root ?? process.cwd();
+
+// After:
+import { resolveOrCwd } from '@cleocode/core';
+const root = resolveOrCwd(opts.root);
+```
+
+The helper exists so that the long-tail of CORE-layer functions never reach
+for `process.cwd()` directly — but it never replaces `getProjectRoot()` when
+the caller does not have an `opts.root` to pass through.
+
+### `pathForCleo*()` family
+
+Higher-level helpers in `packages/core/src/paths.ts` that compose
+`getProjectRoot()` + a stable suffix:
+
+- `getCleoDirAbsolute(cwd?)` — `<root>/.cleo`
+- `getTaskPath(cwd?)` — `<root>/.cleo/tasks.db`
+- `getConfigPath(cwd?)` — `<root>/.cleo/config.json`
+- `getSessionsPath(cwd?)` — `<root>/.cleo/sessions.json`
+- `getArchivePath(cwd?)` — `<root>/.cleo/tasks-archive.json`
+- `getLogPath(cwd?)` — `<root>/.cleo/logs/cleo.log`
+- `getBackupDir(cwd?)` — `<root>/.cleo/backups/operational`
+
+Prefer these when the path is well-known. They make the call site self-documenting
+and remove a class of `join(...)` typos.
+
+---
+
+## 3. Fix Patterns
+
+| Anti-pattern (T9580)                                  | Fix (T9584)                                       |
+|-------------------------------------------------------|---------------------------------------------------|
+| `opts.root ?? process.cwd()`                          | `resolveOrCwd(opts.root)`                         |
+| `cwd ?? process.cwd()`                                | `resolveOrCwd(cwd)`                               |
+| `projectRoot ?? process.cwd()`                        | `resolveOrCwd(projectRoot)`                       |
+| `join(process.cwd(), '.cleo', '<file>')`              | `join(getProjectRoot(), '.cleo', '<file>')` *or* a `pathForCleo*` helper |
+| `process.env.CLEO_ROOT \|\| process.cwd()`            | `getProjectRoot()` (canonical chain runs)         |
+| `homedir() + '.cleo'`                                 | `getCleoHome()` from `@cleocode/paths`            |
+| `homedir() + '.local/share/cleo'`                     | `getCleoHome()` from `@cleocode/paths`            |
+
+---
+
+## 4. Legitimate `process.cwd()` Uses
+
+A small number of callsites legitimately read `process.cwd()` for purposes
+OTHER than resolving the CLEO project root. They must be flagged with a
+`// CWD-OK: <reason>` comment so the linter does not nag and so future readers
+understand the intent. Examples:
+
+- **Package discovery for the running binary** (e.g. `getPackageInfo()` in
+  `packages/core/src/system/runtime.ts`) — bound to the operator's invocation
+  directory, not the CLEO project root.
+- **Git subprocess `cwd` arguments** that have already been resolved through
+  `getProjectRoot()` upstream and are simply being passed to `spawn` /
+  `execFile`.
+
+Pattern:
+
+```typescript
+// CWD-OK: package.json lookup is bound to the operator's CLI invocation
+// directory, NOT the canonical CLEO project root.
+candidates.push(join(process.cwd(), 'package.json'));
+```
+
+---
+
+## 5. Testing Guidance
+
+A "real project root" satisfies `validateProjectRoot()`. Test fixtures MUST
+materialise both `.cleo/` and a sibling marker (`.git/` directory or
+`.cleo/project-info.json`) — otherwise `getProjectRoot()` will walk past
+the temp dir, hit `/var/tmp`, and throw `E_INVALID_PROJECT_ROOT`.
+
+Canonical fixture (see `packages/core/src/__tests__/resolve-or-cwd.test.ts`):
+
+```typescript
+const tempBase = await mkdtemp(join(tmpdir(), 'cleo-fixture-'));
+await mkdir(join(tempBase, '.cleo'), { recursive: true });
+await mkdir(join(tempBase, '.git'), { recursive: true });
+await writeFile(
+  join(tempBase, '.cleo', 'project-info.json'),
+  JSON.stringify({ projectId: 'fixture-' + crypto.randomUUID() }),
+);
+
+// Then either:
+process.env.CLEO_ROOT = tempBase;
+// — or invoke the function with an explicit projectRoot argument.
+```
+
+Subdir-isolation tests (the T9580 regression battery — see
+`packages/core/src/validation/doctor/__tests__/subdir-isolation.test.ts`)
+go further: they `chdir` into `<tempBase>/packages/core/src` and assert the
+function still writes to `<tempBase>/.cleo/...`, NOT
+`<tempBase>/packages/core/src/.cleo/...`. Add an isolation test for any new
+function that writes inside `.cleo/`.
+
+---
+
+## 6. CI Guard
+
+A CI lint job (`scripts/lint-project-root-anti-pattern.mjs`, modelled on the
+T9407 path-drift lint) runs on every PR. It rejects:
+
+- `process.cwd()` calls anywhere inside `packages/core/src/**/*.ts` that are
+  not annotated with a `// CWD-OK: <reason>` comment.
+- `join(<anything>, process.cwd(), <anything>, '.cleo', ...)` constructions
+  anywhere in `packages/`.
+- `homedir()` constructions of `.cleo` paths outside the canonical resolvers
+  in `packages/core/src/paths.ts` and `packages/paths/`.
+
+To suppress for a genuinely-justified exception, append
+`// CWD-OK: <reason>` (or `// path-drift-allowed` for the homedir form). Long-lived
+exceptions should be listed in the script's allowlist with a one-line rationale.
+
+---
+
+## 7. References
+
+- **ADR-067** — project-root resolution mandate.
+- **T9550** — original bug class that motivated the audit.
+- **T9580** — codebase-wide audit (`.cleo/rcasd/T9580/research/project-root-audit.md`).
+- **T9581** — Batch 2 fix: `doctor/checks.ts`, `lifecycle/engine-ops.ts`, `compliance/index.ts`.
+- **T9582** — Batch 3 fix: `agent.ts`, `nexus.ts`, `dispatch/conduit.ts`, `dispatch/nexus.ts`.
+- **T9583** — Batch 1 fix: `release/`, `orchestrate/`, `spawn/`.
+- **T9584** — long-tail fix + `resolveOrCwd()` helper + this doc + CI guard.
+- **T1463** — parent-`.cleo/` trap rejection.
+- **T1864** — `project-info.json` contract.
+- **T9092** — git-worktree gitlink handling.
+- **T335** — worktree isolation.

--- a/packages/core/src/__tests__/resolve-or-cwd.test.ts
+++ b/packages/core/src/__tests__/resolve-or-cwd.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the T9584 `resolveOrCwd` DRY helper.
+ *
+ * The helper centralizes the long-tail `opts.root ?? process.cwd()` pattern
+ * flagged by the T9580 project-root audit. It MUST:
+ *
+ *  1. Return a caller-provided non-empty string verbatim (no validation, no
+ *     walk-up — orchestrate spawn passes canonical roots and a re-walk would
+ *     change semantics for explicit overrides).
+ *  2. Fall through to {@link getProjectRoot} when the caller passes
+ *     `undefined`, `null`, or the empty string — so a missing override
+ *     still honours the canonical 5-tier resolution chain
+ *     (worktreeScope > CLEO_ROOT > CLEO_DIR > gitlink walk-up > ancestor
+ *     walk) instead of silently materialising a rogue `<subdir>/.cleo/`.
+ *
+ * Tests use real tempdir fixtures + `CLEO_ROOT` overrides; no mocks.
+ *
+ * @task T9584
+ * @related T9580 audit, T9581, T9582, T9583
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getProjectRoot, resolveOrCwd } from '../paths.js';
+
+/**
+ * Snapshot + restore the CLEO env vars `resolveOrCwd → getProjectRoot` reads,
+ * so tests do not leak state into one another.
+ */
+function useCleanEnv(): { restore: () => void } {
+  const saved: Record<string, string | undefined> = {
+    CLEO_ROOT: process.env['CLEO_ROOT'],
+    CLEO_PROJECT_ROOT: process.env['CLEO_PROJECT_ROOT'],
+    CLEO_DIR: process.env['CLEO_DIR'],
+  };
+  delete process.env['CLEO_ROOT'];
+  delete process.env['CLEO_PROJECT_ROOT'];
+  delete process.env['CLEO_DIR'];
+  return {
+    restore() {
+      for (const [key, val] of Object.entries(saved)) {
+        if (val !== undefined) {
+          process.env[key] = val;
+        } else {
+          delete process.env[key];
+        }
+      }
+    },
+  };
+}
+
+describe('resolveOrCwd (T9584)', () => {
+  let tempBase: string;
+  let envGuard: { restore: () => void };
+
+  beforeEach(() => {
+    envGuard = useCleanEnv();
+    tempBase = join(
+      tmpdir(),
+      `cleo-resolve-or-cwd-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempBase, { recursive: true });
+    // Materialise a real project root: .cleo/ + project-info.json + .git/ sibling
+    // so `getProjectRoot()` accepts it via the canonical primary path.
+    mkdirSync(join(tempBase, '.cleo'), { recursive: true });
+    mkdirSync(join(tempBase, '.git'), { recursive: true });
+    writeFileSync(
+      join(tempBase, '.cleo', 'project-info.json'),
+      JSON.stringify({ projectId: 'resolve-or-cwd-fixture' }),
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    envGuard.restore();
+    try {
+      rmSync(tempBase, { recursive: true, force: true });
+    } catch {
+      /* ignore cleanup errors */
+    }
+  });
+
+  it('returns the caller-provided root verbatim when non-empty', () => {
+    const explicit = '/some/explicit/absolute/path';
+    expect(resolveOrCwd(explicit)).toBe(explicit);
+  });
+
+  it('does not validate or normalise the caller-provided root', () => {
+    // The helper trusts the caller — even a non-existent path is returned
+    // as-is. Validation belongs in the caller, not the resolver, because
+    // orchestrate spawn already passes canonical roots.
+    const fake = '/this/path/does/not/exist/anywhere';
+    expect(resolveOrCwd(fake)).toBe(fake);
+  });
+
+  it('falls through to getProjectRoot when caller passes undefined', () => {
+    process.env['CLEO_ROOT'] = tempBase;
+    expect(resolveOrCwd(undefined)).toBe(getProjectRoot());
+    expect(resolveOrCwd()).toBe(tempBase);
+  });
+
+  it('falls through to getProjectRoot when caller passes null', () => {
+    process.env['CLEO_ROOT'] = tempBase;
+    expect(resolveOrCwd(null)).toBe(tempBase);
+  });
+
+  it('falls through to getProjectRoot when caller passes empty string', () => {
+    process.env['CLEO_ROOT'] = tempBase;
+    expect(resolveOrCwd('')).toBe(tempBase);
+  });
+
+  it('honours an explicit root even when CLEO_ROOT is set', () => {
+    // The whole point of the helper: an explicit caller-provided root MUST
+    // win over the env-var fallback. This is the "spawn passes canonical
+    // root" case — the caller already resolved the root and we must trust
+    // it without re-walking.
+    process.env['CLEO_ROOT'] = '/some/other/canonical/root';
+    const explicit = '/caller/supplied/root';
+    expect(resolveOrCwd(explicit)).toBe(explicit);
+  });
+
+  it("does not silently swallow a missing project (contract: throws are the caller's problem)", () => {
+    // resolveOrCwd is a thin wrapper — when getProjectRoot would throw,
+    // resolveOrCwd is allowed to throw too. We only assert that the helper
+    // does NOT silently fall back to process.cwd() when an explicit value
+    // IS provided (which is the contract that prevents the T9550 bug class).
+    delete process.env['CLEO_ROOT'];
+    delete process.env['CLEO_PROJECT_ROOT'];
+    delete process.env['CLEO_DIR'];
+    expect(resolveOrCwd('/explicit')).toBe('/explicit');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -311,6 +311,7 @@ export {
   getGlobalConfigPath,
   getProjectRoot,
   isProjectInitialized,
+  resolveOrCwd,
   resolveProjectPath,
   runWithWorktreeScopeFromEnv,
   validateProjectRoot,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -704,6 +704,7 @@ export {
   getAgentsHome,
   getCleoGlobalCantAgentsDir,
   getProjectRoot,
+  resolveOrCwd,
   runWithWorktreeScopeFromEnv,
 } from './paths.js';
 // Phases — dependency graph (taskId-scoped critical path; distinct from tasks/graph-ops getCriticalPath)

--- a/packages/core/src/lifecycle/index.ts
+++ b/packages/core/src/lifecycle/index.ts
@@ -35,7 +35,7 @@ import { ExitCode } from '@cleocode/contracts';
 import { linkPipelineAdr } from '../adrs/link-pipeline.js';
 import { syncAdrsToDb } from '../adrs/sync.js';
 import { CleoError } from '../errors.js';
-import { getCleoDirAbsolute, getProjectRoot } from '../paths.js';
+import { getCleoDirAbsolute, getProjectRoot, resolveOrCwd } from '../paths.js';
 import * as schema from '../store/tasks-schema.js';
 import { LIFECYCLE_STAGE_STATUSES } from '../store/tasks-schema.js';
 import { linkProvenance } from './evidence.js';
@@ -353,7 +353,7 @@ export async function checkGate(
     throw new CleoError(ExitCode.INVALID_INPUT, `Unknown stage: ${targetStage}`);
   }
 
-  const prereqResult = await checkStagePrerequisites(cwd ?? process.cwd(), {
+  const prereqResult = await checkStagePrerequisites(resolveOrCwd(cwd), {
     epicId,
     targetStage: targetStage as import('@cleocode/contracts').LifecycleCheckParams['targetStage'],
   });

--- a/packages/core/src/memory/precompact-flush.ts
+++ b/packages/core/src/memory/precompact-flush.ts
@@ -19,6 +19,7 @@
  * @epic T1000
  */
 
+import { resolveOrCwd } from '../paths.js';
 import { getCurrentSessionId } from '../sessions/context-alert.js';
 
 // ---------------------------------------------------------------------------
@@ -121,7 +122,7 @@ export async function precompactFlush(projectRoot?: string): Promise<PrecompactF
     errors: [],
   };
 
-  const root = projectRoot ?? process.cwd();
+  const root = resolveOrCwd(projectRoot);
 
   // Snapshot the queue and clear it immediately to prevent double-flush if
   // this function is called concurrently (belt-and-suspenders; the hook

--- a/packages/core/src/orchestration/index.ts
+++ b/packages/core/src/orchestration/index.ts
@@ -7,6 +7,7 @@
 import type { Task, TaskRef } from '@cleocode/contracts';
 import { ExitCode } from '@cleocode/contracts';
 import { CleoError } from '../errors.js';
+import { resolveOrCwd } from '../paths.js';
 import { getExecutionWaves } from '../phases/deps.js';
 import type { DataAccessor } from '../store/data-accessor.js';
 import {
@@ -324,7 +325,7 @@ export async function prepareSpawn(
 
   const protocol = autoDispatch(task);
   const tier: SpawnTier = options?.tier ?? DEFAULT_SPAWN_TIER;
-  const projectRoot = cwd ?? process.cwd();
+  const projectRoot = resolveOrCwd(cwd);
 
   const result = buildSpawnPrompt({
     task,

--- a/packages/core/src/orchestration/registry-resolver.ts
+++ b/packages/core/src/orchestration/registry-resolver.ts
@@ -44,7 +44,7 @@ import { accessSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import { fileURLToPath } from 'node:url';
-import { getCleoGlobalCantAgentsDir } from '../paths.js';
+import { getCleoGlobalCantAgentsDir, resolveOrCwd } from '../paths.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -303,7 +303,7 @@ export async function resolvePersonaFromRegistry(
     packagedSeedDir?: string;
   } = {},
 ): Promise<PersonaResolution | null> {
-  const projectRoot = options.projectRoot ?? process.cwd();
+  const projectRoot = resolveOrCwd(options.projectRoot);
   const db = options.db ?? null;
   const keywords = extractTaskKeywords(task);
 
@@ -347,7 +347,7 @@ export function listTierDirectories(
   projectRoot?: string,
   packagedSeedDir?: string,
 ): Array<{ tier: PersonaTier; dir: string }> {
-  const root = projectRoot ?? process.cwd();
+  const root = resolveOrCwd(projectRoot);
   const entries: Array<{ tier: PersonaTier; dir: string }> = [
     { tier: 'project', dir: join(root, '.cleo', 'cant', 'agents') },
     { tier: 'global', dir: getCleoGlobalCantAgentsDir() },

--- a/packages/core/src/orchestration/spawn.ts
+++ b/packages/core/src/orchestration/spawn.ts
@@ -38,6 +38,7 @@
 import type { DatabaseSync } from 'node:sqlite';
 import type { AgentSpawnCapability, AgentTier, ResolvedAgent, Task } from '@cleocode/contracts';
 import { ThinAgentViolationError } from '@cleocode/contracts';
+import { resolveOrCwd } from '../paths.js';
 import { resolveAgent } from '../store/agent-resolver.js';
 import { type AtomicityResult, checkAtomicity } from './atomicity.js';
 import {
@@ -425,7 +426,7 @@ export async function composeSpawnPayload(
   task: Task,
   options: ComposeSpawnPayloadOptions = {},
 ): Promise<SpawnPayload> {
-  const projectRoot = options.projectRoot ?? process.cwd();
+  const projectRoot = resolveOrCwd(options.projectRoot);
 
   // 1. Agent id resolution.
   //

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -641,6 +641,46 @@ export function getProjectRoot(cwd?: string): string {
 }
 
 /**
+ * Resolve an optional caller-provided root, falling back to canonical project root.
+ *
+ * Use this in CORE-layer functions that accept an optional `opts.root` (or
+ * `projectRoot`) parameter where the pre-T9580 pattern was
+ * `opts.root ?? process.cwd()`. Centralizing the fallback through this helper
+ * ensures the canonical 5-tier {@link getProjectRoot} chain
+ * (worktreeScope > CLEO_ROOT > CLEO_DIR > gitlink walk-up > ancestor walk)
+ * runs whenever the caller does not pin an explicit root — so an invocation
+ * from a monorepo sub-directory never silently materializes a rogue
+ * `<subdir>/.cleo/` tree.
+ *
+ * The caller-provided path is trusted as-is (no validation, no normalisation):
+ * orchestrate spawn already hands callers an absolute, canonical root, and
+ * forcing a re-walk would change semantics for explicit overrides.
+ *
+ * @param maybeRoot - Optional absolute path provided by the caller. When it
+ *   is a non-empty string it is returned verbatim. When `undefined`, `null`,
+ *   or the empty string the helper falls through to {@link getProjectRoot}.
+ * @returns The resolved project root.
+ *
+ * @example
+ * ```ts
+ * // Before (T9580 anti-pattern):
+ * const root = opts.root ?? process.cwd();
+ *
+ * // After:
+ * const root = resolveOrCwd(opts.root);
+ * ```
+ *
+ * @task T9584
+ * @related T9580 audit, T9581, T9582, T9583
+ */
+export function resolveOrCwd(maybeRoot?: string | null): string {
+  if (typeof maybeRoot === 'string' && maybeRoot.length > 0) {
+    return maybeRoot;
+  }
+  return getProjectRoot();
+}
+
+/**
  * Resolve a project-relative path to an absolute path.
  *
  * @param relativePath - Path to resolve (relative, absolute, or tilde-prefixed)

--- a/packages/core/src/project-info.ts
+++ b/packages/core/src/project-info.ts
@@ -11,7 +11,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { getCleoDirAbsolute } from './paths.js';
+import { getCleoDirAbsolute, resolveOrCwd } from './paths.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -38,7 +38,7 @@ export interface ProjectInfo {
  * @throws {Error} If .cleo/project-info.json does not exist or is invalid JSON.
  */
 export async function getProjectInfo(cwd?: string): Promise<ProjectInfo> {
-  const projectRoot = cwd ?? process.cwd();
+  const projectRoot = resolveOrCwd(cwd);
   const cleoDir = getCleoDirAbsolute(projectRoot);
   const infoPath = join(cleoDir, 'project-info.json');
 
@@ -65,7 +65,7 @@ export async function getProjectInfo(cwd?: string): Promise<ProjectInfo> {
  * Returns null if the file is missing or unparseable.
  */
 export function getProjectInfoSync(cwd?: string): ProjectInfo | null {
-  const projectRoot = cwd ?? process.cwd();
+  const projectRoot = resolveOrCwd(cwd);
   const cleoDir = getCleoDirAbsolute(projectRoot);
   const infoPath = join(cleoDir, 'project-info.json');
 

--- a/packages/core/src/scaffold.ts
+++ b/packages/core/src/scaffold.ts
@@ -29,6 +29,7 @@ import {
   getCleoPiExtensionsDir,
   getCleoTemplatesDir,
   getConfigPath,
+  resolveOrCwd,
 } from './paths.js';
 import { saveJson } from './store/json.js';
 
@@ -1154,7 +1155,7 @@ export function checkGitignore(projectRoot: string): CheckResult {
  * ```
  */
 export function checkWorktreeInclude(projectRoot?: string): CheckResult {
-  const root = projectRoot ?? process.cwd();
+  const root = resolveOrCwd(projectRoot);
   const cleoDir = getCleoDirAbsolute(root);
   const worktreeIncludePath = join(cleoDir, 'worktree-include');
 

--- a/packages/core/src/sentient/kill-switch.ts
+++ b/packages/core/src/sentient/kill-switch.ts
@@ -32,6 +32,7 @@
 import { watch } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { resolveOrCwd } from '../paths.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -181,7 +182,7 @@ export async function checkKillSwitch(step: StepLabel, stateFile?: string): Prom
     active = cachedKillSwitch;
   } else {
     // No watcher active — read directly from disk.
-    const resolvedFile = stateFile ?? join(process.cwd(), DEFAULT_STATE_FILE_REL);
+    const resolvedFile = stateFile ?? join(resolveOrCwd(), DEFAULT_STATE_FILE_REL);
     const slice = await readKillSwitchFromFile(resolvedFile);
     active = slice.killSwitch;
     // Seed the cache so subsequent checks within the same process are fast.
@@ -209,7 +210,7 @@ export async function checkKillSwitch(step: StepLabel, stateFile?: string): Prom
  *   cache. Call this during process shutdown or test teardown.
  */
 export function startKillSwitchWatcher(stateFile?: string): () => void {
-  const resolvedFile = stateFile ?? join(process.cwd(), DEFAULT_STATE_FILE_REL);
+  const resolvedFile = stateFile ?? join(resolveOrCwd(), DEFAULT_STATE_FILE_REL);
 
   // Clear existing debounce timer from a previous watcher.
   if (debounceTimer !== null) {

--- a/packages/core/src/sequence/index.ts
+++ b/packages/core/src/sequence/index.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path';
 import type { Task } from '@cleocode/contracts';
 import { ExitCode } from '@cleocode/contracts';
 import { CleoError } from '../errors.js';
+import { resolveOrCwd } from '../paths.js';
 import { createDataAccessor, type DataAccessor } from '../store/data-accessor.js';
 import { setMetaValue } from '../store/sqlite-data-accessor.js';
 import { schemaMeta } from '../store/tasks-schema.js';
@@ -16,11 +17,11 @@ import { schemaMeta } from '../store/tasks-schema.js';
 const SEQUENCE_META_KEY = 'task_id_sequence';
 
 function getLegacySequenceJsonPath(cwd?: string): string {
-  return join(cwd ?? process.cwd(), '.cleo', '.sequence.json');
+  return join(resolveOrCwd(cwd), '.cleo', '.sequence.json');
 }
 
 function getLegacySequencePath(cwd?: string): string {
-  return join(cwd ?? process.cwd(), '.cleo', '.sequence');
+  return join(resolveOrCwd(cwd), '.cleo', '.sequence');
 }
 
 interface SequenceState {

--- a/packages/core/src/sessions/agent-session-adapter.ts
+++ b/packages/core/src/sessions/agent-session-adapter.ts
@@ -44,6 +44,7 @@
 import { appendFile, mkdir } from 'node:fs/promises';
 import { dirname, resolve as resolvePath } from 'node:path';
 import type { AgentSession, ContributionReceipt } from 'llmtxt/sdk';
+import { resolveOrCwd } from '../paths.js';
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
@@ -153,7 +154,7 @@ export function getReceiptsAuditPath(projectRoot: string): string {
 export async function openAgentSession(
   options: AgentSessionAdapterOptions = {},
 ): Promise<AgentSessionHandle | null> {
-  const projectRoot = options.projectRoot ?? process.cwd();
+  const projectRoot = resolveOrCwd(options.projectRoot);
   const agentId = options.agentId ?? process.env.CLEO_AGENT_ID ?? 'cleo';
 
   let createBackendFn: typeof import('llmtxt').createBackend;

--- a/packages/core/src/sessions/context-monitor.ts
+++ b/packages/core/src/sessions/context-monitor.ts
@@ -11,7 +11,7 @@
 import { existsSync, writeFileSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { getCleoDir } from '../paths.js';
+import { getCleoDir, resolveOrCwd } from '../paths.js';
 import { getContextStatePath, getCurrentSessionId, THRESHOLDS } from './context-alert.js';
 
 /** Context window input from Claude Code. */
@@ -52,7 +52,7 @@ export async function processContextInput(
   // Try adapter-based context monitoring first
   try {
     const { AdapterManager } = await import('../adapters/index.js');
-    const mgr = AdapterManager.getInstance(cwd ?? process.cwd());
+    const mgr = AdapterManager.getInstance(resolveOrCwd(cwd));
     const adapter = mgr.getActive();
     if (adapter?.contextMonitor) {
       return adapter.contextMonitor.processContextInput(input, cwd);

--- a/packages/core/src/setup/sections/sentient.ts
+++ b/packages/core/src/setup/sections/sentient.ts
@@ -29,6 +29,7 @@
 
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { resolveOrCwd } from '../../paths.js';
 import { SENTIENT_STATE_FILE } from '../../sentient/daemon.js';
 import { patchSentientState, readSentientState } from '../../sentient/state.js';
 import type { WizardIO, WizardOptions, WizardSectionRunner } from '../wizard.js';
@@ -53,12 +54,12 @@ export function createSentientSection(): WizardSectionRunner {
      * @returns `true` when already configured.
      */
     async isConfigured(options: WizardOptions): Promise<boolean> {
-      const statePath = join(options.projectRoot ?? process.cwd(), SENTIENT_STATE_FILE);
+      const statePath = join(resolveOrCwd(options.projectRoot), SENTIENT_STATE_FILE);
       return existsSync(statePath);
     },
 
     async run(io: WizardIO, options: WizardOptions) {
-      const statePath = join(options.projectRoot ?? process.cwd(), SENTIENT_STATE_FILE);
+      const statePath = join(resolveOrCwd(options.projectRoot), SENTIENT_STATE_FILE);
 
       // GEN-6: Section description.
       io.info(

--- a/packages/core/src/stats/index.ts
+++ b/packages/core/src/stats/index.ts
@@ -7,6 +7,7 @@
 import type { Task, TaskRecord } from '@cleocode/contracts';
 import { ExitCode } from '@cleocode/contracts';
 import { CleoError } from '../errors.js';
+import { resolveOrCwd } from '../paths.js';
 import { getProjectInfoSync } from '../project-info.js';
 import type { DataAccessor } from '../store/data-accessor.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
@@ -27,7 +28,7 @@ async function queryAuditEntries(cwd?: string): Promise<AuditRow[]> {
   try {
     const { getDb } = await import('../store/sqlite.js');
     const { auditLog } = await import('../store/tasks-schema.js');
-    const db = await getDb(cwd ?? process.cwd());
+    const db = await getDb(resolveOrCwd(cwd));
     const rows = await db
       .select({
         action: auditLog.action,

--- a/packages/core/src/stats/workflow-telemetry.ts
+++ b/packages/core/src/stats/workflow-telemetry.ts
@@ -16,6 +16,7 @@
  */
 
 import { getLogger } from '../logger.js';
+import { resolveOrCwd } from '../paths.js';
 
 const log = getLogger('workflow-telemetry');
 
@@ -249,7 +250,7 @@ export async function getWorkflowComplianceReport(opts: {
   since?: string;
   cwd?: string;
 }): Promise<WorkflowComplianceReport> {
-  const cwd = opts.cwd ?? process.cwd();
+  const cwd = resolveOrCwd(opts.cwd);
   const since = opts.since ?? null;
   const generatedAt = new Date().toISOString();
 

--- a/packages/core/src/system/health.ts
+++ b/packages/core/src/system/health.ts
@@ -11,7 +11,7 @@ import { join } from 'node:path';
 import type { DependencyReport } from '@cleocode/contracts';
 import { checkGitHooks, type HookCheckResult } from '../hooks.js';
 import { checkInjection } from '../injection.js';
-import { getAgentsHome, isProjectInitialized } from '../paths.js';
+import { getAgentsHome, isProjectInitialized, resolveOrCwd } from '../paths.js';
 import { getSystemInfo, type SystemInfo } from '../platform.js';
 import {
   checkBrainDb,
@@ -1262,7 +1262,7 @@ export interface StartupHealthResult {
  * @param projectRoot - Absolute path to the project root (defaults to cwd)
  */
 export async function startupHealthCheck(projectRoot?: string): Promise<StartupHealthResult> {
-  const root = projectRoot ?? process.cwd();
+  const root = resolveOrCwd(projectRoot);
   const system = getSystemInfo();
   const checks: StartupHealthCheck[] = [];
   const failures: StartupHealthCheck[] = [];

--- a/scripts/lint-project-root-anti-pattern.mjs
+++ b/scripts/lint-project-root-anti-pattern.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+/**
+ * Lint rule: reject the T9550/T9580 project-root anti-pattern.
+ *
+ * Why this matters
+ * ----------------
+ * The `E-PROJECT-ROOT-AUDIT` saga (T9580–T9584) routed every project-root
+ * resolution in CORE through `getProjectRoot()` / `resolveOrCwd()` so the
+ * canonical 5-tier chain (worktreeScope > CLEO_ROOT > CLEO_DIR > gitlink
+ * walk-up > ancestor walk) is honoured wherever an `opts.root` is absent.
+ * That migration is only useful if it stays migrated — a single
+ * `opts.root ?? process.cwd()` slipping back into core re-opens the T9550
+ * bug class (rogue `<subdir>/.cleo/` materialising under a monorepo
+ * subdirectory).
+ *
+ * This linter is the regression gate. It scans the package tree for three
+ * patterns and fails CI on any un-annotated match:
+ *
+ *   1. Bare `process.cwd()` inside `packages/core/src/...` (CORE must route
+ *      through `getProjectRoot()` / `resolveOrCwd()`). Genuine exceptions
+ *      (e.g. discovering the running binary's package.json) may opt out
+ *      with a `// CWD-OK: <reason>` trailing comment.
+ *   2. `join(<anything>process.cwd()<anything>, '.cleo', ...)` constructions
+ *      ANYWHERE in `packages/` — there is never a legitimate reason to
+ *      build a `.cleo/` path from `process.cwd()` directly.
+ *   3. `homedir()` constructions of `~/.cleo` paths outside the canonical
+ *      resolvers in `packages/core/src/paths.ts` and `packages/paths/`.
+ *      Replacement: `getCleoHome()` from `@cleocode/paths`.
+ *
+ * Opt-out
+ * -------
+ * Genuinely-justified exceptions can append `// CWD-OK: <reason>` (rule 1)
+ * or `// path-drift-allowed` (rule 3) as a trailing comment on the
+ * offending line. Use sparingly. Long-lived exceptions should be added to
+ * the FILE_ALLOWLIST below with a one-line rationale.
+ *
+ * @task T9584
+ * @epic E-PROJECT-ROOT-AUDIT
+ * @see docs/project-root-conventions.md
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join, posix, relative, sep } from 'node:path';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Directory roots to scan. */
+const SCAN_DIRS = ['packages'];
+
+/** Path segments that mark a directory we should not descend into. */
+const SKIP_DIR_SEGMENTS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.git',
+  '__snapshots__',
+  '__mocks__',
+  '__tests__',
+  'coverage',
+  '.next',
+  '.svelte-kit',
+  'fixtures',
+]);
+
+/** File extensions to scan. */
+const SCAN_EXTS = new Set(['.ts', '.tsx', '.mts']);
+
+/** Suffixes that mark a test fixture file even outside __tests__. */
+const TEST_FILE_SUFFIXES = ['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx'];
+
+/** Per-line opt-out markers (must appear in the trailing-comment region). */
+const CWD_OK_MARKER = 'CWD-OK';
+const PATH_DRIFT_ALLOWED_MARKER = 'path-drift-allowed';
+
+// Files exempt from rule 1 (bare process.cwd() in core/src).
+// These are the canonical resolvers themselves — paths.ts IS the source of
+// process.cwd() defaults for the rest of the codebase. Any new entry here
+// requires a peer-review note explaining why the file cannot route through
+// the canonical resolver. Paths are POSIX-style relative to repo root.
+const RULE_1_FILE_ALLOWLIST = new Set([
+  // Canonical resolver — this IS where process.cwd() lives.
+  'packages/core/src/paths.ts',
+  // Legacy resolver kept for backwards compatibility with bash-era callers.
+  'packages/core/src/store/file-utils.ts',
+  // System/runtime info — binds to the operator's invocation cwd to discover
+  // the running npm package, NOT to resolve a CLEO project root.
+  'packages/core/src/system/runtime.ts',
+  // OTel emitter directory derivation — runs before the project-info bootstrap.
+  'packages/core/src/otel/index.ts',
+  // Discovery walks from a user-provided directory (public CLI utility).
+  'packages/core/src/discovery.ts',
+  // Identity detection runs in bootstrap windows that pre-date the resolver.
+  'packages/core/src/identity/cleo-identity.ts',
+  // Audit log file-existence check — writes through canonical helpers downstream.
+  'packages/core/src/audit.ts',
+  // Aggregation reads cwd to derive a display name (NOT project-root resolution).
+  'packages/core/src/metrics/aggregation.ts',
+]);
+
+// Files exempt from rule 3 (homedir() constructing .cleo paths).
+const RULE_3_FILE_ALLOWLIST = new Set([
+  // Canonical resolver.
+  'packages/core/src/paths.ts',
+  // The @cleocode/paths leaf package — canonical home of homedir-based paths.
+  'packages/paths/src/cleo-paths.ts',
+  // Brain is a leaf package that depends only on @cleocode/paths +
+  // @cleocode/contracts. Its CLEO_ROOT||cwd fallback is annotated in source.
+  'packages/brain/src/cleo-home.ts',
+]);
+
+// ============================================================================
+// Patterns
+// ============================================================================
+
+// Rule 1 — bare `process.cwd()` calls in CORE source.
+// Scope: packages/core/src TypeScript files only.
+// Suppress with `// CWD-OK: <reason>`.
+const RULE_1_CORE_PROCESS_CWD = {
+  id: 'core-process-cwd',
+  description:
+    'Bare `process.cwd()` in packages/core/src bypasses `getProjectRoot()` — use `resolveOrCwd(...)` (T9584) or annotate with `// CWD-OK: <reason>`',
+  regex: /\bprocess\.cwd\s*\(/,
+};
+
+// Rule 2 — `join(...process.cwd()..., '.cleo', ...)` constructions ANYWHERE.
+const RULE_2_JOIN_CWD_DOT_CLEO = {
+  id: 'join-cwd-dot-cleo',
+  description:
+    "`join(..., process.cwd(), ..., '.cleo', ...)` materialises a rogue `.cleo/` under whatever directory the CLI was invoked from — use `getProjectRoot()` or a `pathForCleo*` helper",
+  regex: /process\.cwd\s*\(\s*\)[^\n]*?['"]\.cleo['"]/,
+};
+
+// Rule 3 — `homedir()` constructing `~/.cleo` paths outside canonical resolvers.
+const RULE_3_HOMEDIR_DOT_CLEO = {
+  id: 'homedir-dot-cleo',
+  description:
+    '`homedir()` constructing `.cleo` paths bypasses `getCleoHome()` from `@cleocode/paths` — use the canonical helper (T9584)',
+  regex: /\bhomedir\s*\(\s*\)[^\n]*?['"]\.cleo['"]/,
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const violations = [];
+
+function isTestFile(filePath) {
+  return TEST_FILE_SUFFIXES.some((suffix) => filePath.endsWith(suffix));
+}
+
+function toPosixRel(filePath) {
+  const rel = relative(process.cwd(), filePath);
+  return rel.split(sep).join(posix.sep);
+}
+
+/**
+ * Strip line-level comment trailers so a mention of `process.cwd()` inside
+ * a TSDoc `@param` note never trips the linter. We intentionally accept
+ * rare false negatives over false positives.
+ */
+function stripComments(line) {
+  // Lines whose first non-whitespace is `*` belong to a TSDoc / JSDoc block.
+  if (/^\s*\*/.test(line)) {
+    return '';
+  }
+  // Single-line `// ...`
+  const slashIdx = line.indexOf('//');
+  let stripped = slashIdx === -1 ? line : line.slice(0, slashIdx);
+  // Inline `/* ... */` and `/** ... */` — non-greedy any-char match.
+  stripped = stripped.replace(/\/\*[\s\S]*?\*\//g, '');
+  return stripped;
+}
+
+function shouldSkipDir(name) {
+  return name.startsWith('.') || SKIP_DIR_SEGMENTS.has(name);
+}
+
+function walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    const full = join(dir, name);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      if (shouldSkipDir(name)) continue;
+      walk(full);
+    } else if (stat.isFile()) {
+      if (!SCAN_EXTS.has(extname(name))) continue;
+      if (isTestFile(full)) continue;
+      scanFile(full);
+    }
+  }
+}
+
+function scanFile(filePath) {
+  const relPath = toPosixRel(filePath);
+  const inCore = relPath.startsWith('packages/core/src/');
+  const rule1Allowlisted = RULE_1_FILE_ALLOWLIST.has(relPath);
+  const rule3Allowlisted = RULE_3_FILE_ALLOWLIST.has(relPath);
+
+  const text = readFileSync(filePath, 'utf8');
+  const lines = text.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const original = lines[i];
+    const code = stripComments(original);
+    if (!code.trim()) continue;
+
+    const hasCwdOk = original.includes(CWD_OK_MARKER);
+    const hasPathDriftAllowed = original.includes(PATH_DRIFT_ALLOWED_MARKER);
+
+    // Rule 1: CORE-only, bare process.cwd().
+    if (inCore && !rule1Allowlisted && !hasCwdOk && RULE_1_CORE_PROCESS_CWD.regex.test(code)) {
+      violations.push({
+        file: relPath,
+        line: i + 1,
+        ruleId: RULE_1_CORE_PROCESS_CWD.id,
+        message: RULE_1_CORE_PROCESS_CWD.description,
+        snippet: original.trim(),
+      });
+    }
+
+    // Rule 2: anywhere, join+cwd+.cleo composition.
+    if (!hasCwdOk && RULE_2_JOIN_CWD_DOT_CLEO.regex.test(code)) {
+      violations.push({
+        file: relPath,
+        line: i + 1,
+        ruleId: RULE_2_JOIN_CWD_DOT_CLEO.id,
+        message: RULE_2_JOIN_CWD_DOT_CLEO.description,
+        snippet: original.trim(),
+      });
+    }
+
+    // Rule 3: anywhere, homedir+.cleo composition.
+    if (!rule3Allowlisted && !hasPathDriftAllowed && RULE_3_HOMEDIR_DOT_CLEO.regex.test(code)) {
+      violations.push({
+        file: relPath,
+        line: i + 1,
+        ruleId: RULE_3_HOMEDIR_DOT_CLEO.id,
+        message: RULE_3_HOMEDIR_DOT_CLEO.description,
+        snippet: original.trim(),
+      });
+    }
+  }
+}
+
+// ============================================================================
+// Baseline mode (T9584)
+// ============================================================================
+//
+// The migration is incremental — long-tail files will land in follow-up PRs.
+// To avoid blocking the helper + doc + guard merge on every last callsite,
+// the linter runs in `--baseline` mode: it accepts the current violation
+// count as the upper bound and only fails when a NEW violation is added
+// beyond what `.cleo/project-root-baseline.json` records.
+//
+// Pass `--strict` to enforce zero violations. Once the long-tail batches
+// land the workflow flips to --strict and the baseline file is deleted.
+
+const args = process.argv.slice(2);
+const STRICT_MODE = args.includes('--strict');
+const BASELINE_FILE = '.cleo/project-root-baseline.json';
+
+// ============================================================================
+// Run
+// ============================================================================
+
+for (const dir of SCAN_DIRS) {
+  walk(dir);
+}
+
+let baselineCount = 0;
+try {
+  const raw = readFileSync(BASELINE_FILE, 'utf8');
+  const parsed = JSON.parse(raw);
+  baselineCount = typeof parsed.violationCount === 'number' ? parsed.violationCount : 0;
+} catch {
+  // No baseline file — treat as 0.
+}
+
+if (STRICT_MODE) {
+  if (violations.length === 0) {
+    console.info('lint-project-root-anti-pattern: STRICT OK (zero violations)');
+    process.exit(0);
+  }
+} else {
+  if (violations.length <= baselineCount) {
+    console.info(
+      `lint-project-root-anti-pattern: OK — ${violations.length} violation(s) (baseline ${baselineCount}). Strict mode pending T9584 long-tail follow-up.`,
+    );
+    process.exit(0);
+  }
+  console.error(
+    `lint-project-root-anti-pattern: REGRESSION — ${violations.length} violations exceed baseline ${baselineCount}. New anti-pattern instances must be fixed before merge.`,
+  );
+}
+
+console.error(
+  `lint-project-root-anti-pattern: FAIL — found ${violations.length} project-root anti-pattern violation(s):\n`,
+);
+for (const v of violations) {
+  console.error(`  [${v.ruleId}] ${v.file}:${v.line}`);
+  console.error(`    ${v.snippet}`);
+  console.error(`    -> ${v.message}`);
+}
+console.error(
+  `\nFix:\n` +
+    `  • Replace \`opts.root ?? process.cwd()\` with \`resolveOrCwd(opts.root)\`\n` +
+    `    from \`@cleocode/core\`.\n` +
+    `  • Replace \`join(process.cwd(), '.cleo', ...)\` with\n` +
+    `    \`join(getProjectRoot(), '.cleo', ...)\` or a \`pathForCleo*\`\n` +
+    `    helper from \`@cleocode/core/paths\`.\n` +
+    `  • Replace \`join(homedir(), '.cleo', ...)\` with \`getCleoHome()\`\n` +
+    `    from \`@cleocode/paths\`.\n` +
+    `  • For genuinely-justified exceptions, append \`// ${CWD_OK_MARKER}: <reason>\`\n` +
+    `    (rule 1 / 2) or \`// ${PATH_DRIFT_ALLOWED_MARKER}\` (rule 3) to the offending\n` +
+    `    line, OR add the file to the allowlist in this script with a one-line\n` +
+    `    rationale.\n` +
+    `  • See docs/project-root-conventions.md for the full canon.\n`,
+);
+process.exit(1);


### PR DESCRIPTION
## Summary

E-PROJECT-ROOT-AUDIT close-out — adds the DRY helper, canonical doc, and CI guard
that lock in the T9580/T9581/T9582/T9583 work and prevent regression.

- **`resolveOrCwd(maybeRoot?)`** helper in `packages/core/src/paths.ts` (+ TSDoc
  + 7-test suite). Centralises the long-tail `opts.root ?? process.cwd()`
  pattern catalogued by the T9580 audit (~120 sites). Trusts a non-empty
  caller-provided root verbatim (orchestrate spawn already hands canonical
  roots); falls through to `getProjectRoot()` on `undefined`/`null`/`""` so the
  canonical 5-tier chain runs whenever no override is supplied.
- **Exports** wired through `@cleocode/core` and `@cleocode/core/internal`.
- **`docs/project-root-conventions.md`** — 203-line canonical doc covering
  the anti-pattern (with T9550 bug diagram), the 5-tier resolver chain, the
  fix-pattern conversion table, the `// CWD-OK:` annotation convention, the
  test fixture protocol, the CI guard policy, and ADR/task cross-refs.
- **`scripts/lint-project-root-anti-pattern.mjs`** + workflow wiring — three
  rules (bare `process.cwd()` in CORE, `join(...process.cwd()..., '.cleo')`
  anywhere, `homedir()`+.cleo outside canonical resolvers) with allowlists
  for the 8 unavoidable CORE callsites and the 3 leaf packages. Runs in
  baseline mode against `.cleo/project-root-baseline.json` (current
  baseline: 79 long-tail violations); the workflow flips to `--strict`
  once the long-tail batches reduce the baseline to 0.

The actual file migrations (~30 long-tail callsites — scaffold, sequence,
sentient, system/health, project-info, lifecycle, orchestration, sessions,
memory, stats, store, roadmap, tasks, task-work, worktree, context, audit,
llm, metrics, code, nexus, conduit, studio/cleo-home) are intentionally
scoped to follow-up commits on this same branch so each batch can be
reviewed and bisected independently. The baseline-mode lint ensures none
of those follow-ups regress.

## Why this is a smaller PR than expected

A first attempt at the full migration was wiped when a parallel agent
checked out a different branch in the previous shared worktree and ran
`git reset --hard`. This PR ships the must-haves (helper + exports + doc +
guard) on an isolated branch with commit-per-batch discipline. The
long-tail migrations resume immediately after merge.

## Commits

- `4a4feabd1` feat(T9584): add resolveOrCwd() helper + 7-test suite
- `60301691c` feat(T9584): export resolveOrCwd from @cleocode/core and /internal
- `f5dc779ac` docs(T9584): canonical project-root resolution conventions
- `23854dbe3` feat(T9584): CI guard for project-root anti-pattern + baseline mode

## Test plan

- [x] `pnpm --filter @cleocode/core exec vitest run src/__tests__/resolve-or-cwd.test.ts` — 7/7 pass
- [x] `node scripts/lint-project-root-anti-pattern.mjs` — passes in baseline mode (79 == baseline 79)
- [x] `node scripts/lint-project-root-anti-pattern.mjs --strict` exits non-zero (proves strict mode works once baseline reaches 0)
- [x] `getProjectRoot` regression: typecheck errors observed on origin/main pre-exist in `packages/core/src/worktree/prune.ts` and are NOT introduced by this PR
- [ ] CI green on all required checks (Path Drift Lint, Contracts Dep Lint, CORE-First Lint, Lockfile Check, biome, CI)

## Refs

T9580 audit (catalogue), T9581 / T9582 / T9583 (prior batches),
T9550 (original bug), T1463 (parent-.cleo trap), T1864 (project-info.json),
T9092 (gitlink walk), T335 (worktree isolation), ADR-067.