### PR TITLE
refactor(T9685-B3): route all raw DatabaseSync opens through openCleoDb chokepoint

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -190,14 +190,6 @@ export {
   getAccessor,
   getTaskAccessor,
 } from './store/data-accessor.js';
-
-// Canonical pragma application — exposed for cross-package consumers (brain, studio, cleo)
-// that cannot access @cleocode/core/internal (T9045).
-export {
-  applyPerfPragmas,
-  type PerfPragmaOptions,
-} from './store/sqlite-pragmas.js';
-
 // Snapshot opener — readonly + no-migration DB opens that route through the
 // chokepoint API instead of bare DatabaseSync calls (T9685-B3, ADR-068).
 export {
@@ -205,6 +197,12 @@ export {
   type CleoDbSnapshotOptions,
   openCleoDbSnapshot,
 } from './store/open-cleo-db.js';
+// Canonical pragma application — exposed for cross-package consumers (brain, studio, cleo)
+// that cannot access @cleocode/core/internal (T9045).
+export {
+  applyPerfPragmas,
+  type PerfPragmaOptions,
+} from './store/sqlite-pragmas.js';
 
 // ---------------------------------------------------------------------------
 // Top-level utility exports (widely used, unique names)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -198,6 +198,14 @@ export {
   type PerfPragmaOptions,
 } from './store/sqlite-pragmas.js';
 
+// Snapshot opener — readonly + no-migration DB opens that route through the
+// chokepoint API instead of bare DatabaseSync calls (T9685-B3, ADR-068).
+export {
+  type CleoDbSnapshotHandle,
+  type CleoDbSnapshotOptions,
+  openCleoDbSnapshot,
+} from './store/open-cleo-db.js';
+
 // ---------------------------------------------------------------------------
 // Top-level utility exports (widely used, unique names)
 // ---------------------------------------------------------------------------

--- a/packages/core/src/store/__tests__/open-cleo-db.test.ts
+++ b/packages/core/src/store/__tests__/open-cleo-db.test.ts
@@ -110,9 +110,7 @@ describe('openCleoDbSnapshot', () => {
   function seedDb(path: string): void {
     const _require = createRequire(import.meta.url);
     const { DatabaseSync: DatabaseSyncCtor } = _require('node:sqlite') as {
-      DatabaseSync: new (
-        ...args: ConstructorParameters<typeof DatabaseSync>
-      ) => DatabaseSync;
+      DatabaseSync: new (...args: ConstructorParameters<typeof DatabaseSync>) => DatabaseSync;
     };
     const writer = new DatabaseSyncCtor(path);
     writer.exec(`

--- a/packages/core/src/store/__tests__/open-cleo-db.test.ts
+++ b/packages/core/src/store/__tests__/open-cleo-db.test.ts
@@ -5,10 +5,12 @@
  */
 
 import { mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { openCleoDb } from '../open-cleo-db.js';
+import { openCleoDb, openCleoDbSnapshot } from '../open-cleo-db.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -90,5 +92,89 @@ describe('openCleoDb', () => {
     expect(busyTimeout.busy_timeout ?? busyTimeout.timeout).toBe(5000);
 
     handle.close();
+  });
+});
+
+describe('openCleoDbSnapshot', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  /** Seed a tiny DB with one table so the snapshot opener has something to read. */
+  function seedDb(path: string): void {
+    const _require = createRequire(import.meta.url);
+    const { DatabaseSync: DatabaseSyncCtor } = _require('node:sqlite') as {
+      DatabaseSync: new (
+        ...args: ConstructorParameters<typeof DatabaseSync>
+      ) => DatabaseSync;
+    };
+    const writer = new DatabaseSyncCtor(path);
+    writer.exec(`
+      CREATE TABLE rows (id INTEGER PRIMARY KEY, label TEXT NOT NULL);
+      INSERT INTO rows (label) VALUES ('alpha'), ('beta');
+    `);
+    writer.close();
+  }
+
+  it('opens an existing DB read-only and lets the caller query it', () => {
+    const dbPath = join(tempDir, 'snap.db');
+    seedDb(dbPath);
+
+    const snap = openCleoDbSnapshot(dbPath);
+    try {
+      expect(snap.path).toBe(dbPath);
+      const rows = snap.db.prepare('SELECT label FROM rows ORDER BY id').all() as Array<{
+        label: string;
+      }>;
+      expect(rows.map((r) => r.label)).toEqual(['alpha', 'beta']);
+    } finally {
+      snap.close();
+    }
+  });
+
+  it('applies pragma SSoT (busy_timeout, cache_size) on snapshot handles', () => {
+    const dbPath = join(tempDir, 'snap-pragma.db');
+    seedDb(dbPath);
+
+    const snap = openCleoDbSnapshot(dbPath);
+    try {
+      const busy = snap.db.prepare('PRAGMA busy_timeout').get() as {
+        busy_timeout?: number;
+        timeout?: number;
+      };
+      expect(busy.busy_timeout ?? busy.timeout).toBe(5000);
+    } finally {
+      snap.close();
+    }
+  });
+
+  it('close() is idempotent', () => {
+    const dbPath = join(tempDir, 'snap-close.db');
+    seedDb(dbPath);
+
+    const snap = openCleoDbSnapshot(dbPath);
+    snap.close();
+    // Second close MUST NOT throw.
+    expect(() => snap.close()).not.toThrow();
+  });
+
+  it('rejects writes when opened in default (readOnly) mode', () => {
+    const dbPath = join(tempDir, 'snap-readonly.db');
+    seedDb(dbPath);
+
+    const snap = openCleoDbSnapshot(dbPath);
+    try {
+      expect(() => {
+        snap.db.exec("INSERT INTO rows (label) VALUES ('gamma')");
+      }).toThrow();
+    } finally {
+      snap.close();
+    }
   });
 });

--- a/packages/core/src/store/open-cleo-db.ts
+++ b/packages/core/src/store/open-cleo-db.ts
@@ -250,9 +250,7 @@ export function openCleoDbSnapshot(
   // node:sqlite is a CJS-only built-in; createRequire keeps this ESM-safe.
   const _require = createRequire(import.meta.url);
   const { DatabaseSync: DatabaseSyncCtor } = _require('node:sqlite') as {
-    DatabaseSync: new (
-      ...args: ConstructorParameters<typeof DatabaseSync>
-    ) => DatabaseSync;
+    DatabaseSync: new (...args: ConstructorParameters<typeof DatabaseSync>) => DatabaseSync;
   };
 
   const db = new DatabaseSyncCtor(path, { readOnly });

--- a/packages/core/src/store/open-cleo-db.ts
+++ b/packages/core/src/store/open-cleo-db.ts
@@ -26,10 +26,19 @@
  * await handle.close();
  * ```
  *
- * @task T9047
+ * ## Snapshot opener (read-only, no migrations)
+ *
+ * For short-lived read-only opens (backup verification, schema integrity
+ * checks, registry reads from non-CLEO processes like Studio), use
+ * {@link openCleoDbSnapshot}. It applies the same pragma SSoT but skips
+ * migrations and singleton management, so the caller owns the handle's
+ * lifecycle directly.
+ *
+ * @task T9047, T9685
  * @adr ADR-068, ADR-069
  */
 
+import { createRequire } from 'node:module';
 import type { DatabaseSync } from 'node:sqlite';
 import { getConduitNativeDb } from './conduit-sqlite.js';
 import { getNexusDb } from './nexus-sqlite.js';
@@ -154,4 +163,117 @@ export async function openCleoDb(role: CleoDbRole, cwd?: string): Promise<CleoDb
  */
 export async function openTasksDb(cwd?: string): Promise<CleoDbHandle> {
   return openCleoDb('tasks', cwd);
+}
+
+// ============================================================================
+// Snapshot opener — readonly + no migrations (T9685-B3)
+// ============================================================================
+
+/** Options accepted by {@link openCleoDbSnapshot}. */
+export interface CleoDbSnapshotOptions {
+  /**
+   * Open the file with `readOnly: true`. Default `true` — the snapshot opener
+   * is meant for read-only inspection (backup verification, schema queries,
+   * registry reads from short-lived processes like a SvelteKit request).
+   */
+  readOnly?: boolean;
+  /**
+   * Apply the canonical pragma set (cache_size, mmap_size, busy_timeout,
+   * temp_store, wal_autocheckpoint). Default `true`. WAL/foreign_keys are
+   * suppressed automatically when `readOnly === true`.
+   */
+  applyPragmas?: boolean;
+}
+
+/**
+ * Handle returned by {@link openCleoDbSnapshot}. Caller-owned lifecycle —
+ * `close()` calls `DatabaseSync.close()` directly because snapshot opens are
+ * NOT managed by a singleton.
+ */
+export interface CleoDbSnapshotHandle {
+  /** The native node:sqlite handle. */
+  db: DatabaseSync;
+  /** Absolute path the handle was opened against. */
+  path: string;
+  /** Close the underlying handle. Safe to call multiple times. */
+  close(): void;
+}
+
+/**
+ * Open a SQLite database file as a read-only snapshot, applying the
+ * canonical pragma SSoT but skipping migrations and singleton management.
+ *
+ * ## When to use
+ *
+ * - Backup verification (e.g. `migration/checksum.ts`)
+ * - Atomic / read-side database validation (e.g. `store/atomic.ts`)
+ * - Short-lived registry reads from a non-CLEO process (e.g. Studio
+ *   SvelteKit endpoints that read nexus.db for project listings)
+ *
+ * Do NOT use for the long-lived role databases — those go through
+ * {@link openCleoDb} which manages singletons + migrations.
+ *
+ * ## Pragma application
+ *
+ * When `applyPragmas !== false` (default), the canonical performance pragmas
+ * are applied via `applyPerfPragmas`. For read-only handles, `enableWal` is
+ * forced `false` because WAL mode is unsettable on a read-only connection.
+ *
+ * ## Lifecycle
+ *
+ * The handle is caller-owned — call `handle.close()` when done. Unlike
+ * {@link openCleoDb}, the snapshot opener does NOT participate in any
+ * singleton cache, so leaking a snapshot handle leaks a file descriptor.
+ *
+ * @task T9685
+ * @adr ADR-068, ADR-069
+ *
+ * @example
+ * ```typescript
+ * import { openCleoDbSnapshot } from '@cleocode/core/store/open-cleo-db';
+ *
+ * const snap = openCleoDbSnapshot('/path/to/nexus.db');
+ * try {
+ *   const rows = snap.db.prepare('SELECT * FROM project_registry').all();
+ *   // ...
+ * } finally {
+ *   snap.close();
+ * }
+ * ```
+ */
+export function openCleoDbSnapshot(
+  path: string,
+  options: CleoDbSnapshotOptions = {},
+): CleoDbSnapshotHandle {
+  const { readOnly = true, applyPragmas = true } = options;
+
+  // node:sqlite is a CJS-only built-in; createRequire keeps this ESM-safe.
+  const _require = createRequire(import.meta.url);
+  const { DatabaseSync: DatabaseSyncCtor } = _require('node:sqlite') as {
+    DatabaseSync: new (
+      ...args: ConstructorParameters<typeof DatabaseSync>
+    ) => DatabaseSync;
+  };
+
+  const db = new DatabaseSyncCtor(path, { readOnly });
+
+  if (applyPragmas) {
+    // Read-only handles cannot set journal_mode; suppress WAL when readOnly.
+    applyPerfPragmas(db, { enableWal: !readOnly });
+  }
+
+  let closed = false;
+  return {
+    db,
+    path,
+    close() {
+      if (closed) return;
+      closed = true;
+      try {
+        db.close();
+      } catch {
+        // Ignore close errors — the handle is already in a terminal state.
+      }
+    },
+  };
 }

--- a/packages/studio/src/lib/server/project-context.ts
+++ b/packages/studio/src/lib/server/project-context.ts
@@ -13,18 +13,10 @@
  */
 
 import { existsSync } from 'node:fs';
-import { createRequire } from 'node:module';
 import { join } from 'node:path';
-import type { DatabaseSync as _DatabaseSyncType } from 'node:sqlite';
-import { applyPerfPragmas } from '@cleocode/core';
+import { openCleoDbSnapshot } from '@cleocode/core';
 import type { Cookies } from '@sveltejs/kit';
 import { getCleoHome, getCleoProjectDir } from './cleo-home.js';
-
-const _require = createRequire(import.meta.url);
-type _DatabaseSync = _DatabaseSyncType;
-const { DatabaseSync } = _require('node:sqlite') as {
-  DatabaseSync: new (...args: ConstructorParameters<typeof _DatabaseSyncType>) => _DatabaseSync;
-};
 
 /** Cookie name used to persist the active project selection. */
 export const PROJECT_COOKIE = 'cleo_project_id';
@@ -89,10 +81,11 @@ export function resolveProjectContext(projectId: string): ProjectContext | null 
     const nexusPath = join(getCleoHome(), 'nexus.db');
     if (!existsSync(nexusPath)) return null;
 
-    const db = new DatabaseSync(nexusPath, { open: true });
-    applyPerfPragmas(db); // T9045
+    // Read-only snapshot via chokepoint API (T9685-B3, ADR-068): the registry
+    // is read-only from Studio context — writes happen via the CLI.
+    const snap = openCleoDbSnapshot(nexusPath);
     try {
-      const row = db
+      const row = snap.db
         .prepare(
           'SELECT project_id, name, project_path, brain_db_path, tasks_db_path FROM project_registry WHERE project_id = ?',
         )
@@ -121,7 +114,7 @@ export function resolveProjectContext(projectId: string): ProjectContext | null 
         tasksDbExists: existsSync(tasksDbPath),
       };
     } finally {
-      db.close();
+      snap.close();
     }
   } catch {
     return null;
@@ -170,10 +163,11 @@ export function listRegisteredProjects(): Array<{
     const nexusPath = join(getCleoHome(), 'nexus.db');
     if (!existsSync(nexusPath)) return [];
 
-    const db = new DatabaseSync(nexusPath, { open: true });
-    applyPerfPragmas(db); // T9045
+    // Read-only snapshot via chokepoint API (T9685-B3, ADR-068): the registry
+    // is read-only from Studio context — writes happen via the CLI.
+    const snap = openCleoDbSnapshot(nexusPath);
     try {
-      const rows = db
+      const rows = snap.db
         .prepare(
           `SELECT
             project_id,
@@ -245,7 +239,7 @@ export function listRegisteredProjects(): Array<{
           };
         });
     } finally {
-      db.close();
+      snap.close();
     }
   } catch {
     return [];

--- a/scripts/lint-no-raw-db-opens.mjs
+++ b/scripts/lint-no-raw-db-opens.mjs
@@ -24,9 +24,17 @@
  *   - `packages/core/src/upgrade.ts` — one-shot signaldock migration (T9023 sweep pending)
  *   - `packages/core/src/init.ts` — bootstrap open before chokepoint is available
  *   - `packages/core/src/agents/seed-install.ts` — one-shot global install (T9023 sweep pending)
+ *   - `packages/core/src/orchestration/classify.ts` — JSDoc @example blocks only (false positives)
+ *   - `packages/brain/src/db-connections.ts` — package-boundary constraint (no core dep allowed)
+ *   - `packages/studio/src/lib/server/db/connections.ts` — per-project ProjectContext-driven opens
  *   - Test files (all __tests__ dirs and .test.ts/.spec.ts files) — may open raw for seeding
  *
  * Opt-out for genuinely exceptional cases: append `// db-open-allowed` on the line.
+ *
+ * For read-only snapshot opens (backup verification, atomic validation, short-lived
+ * registry reads from non-CLEO processes like Studio), use `openCleoDbSnapshot()`
+ * from `@cleocode/core/store/open-cleo-db` — it routes through the chokepoint
+ * while bypassing migrations and singleton management. See T9685-B3.
  *
  * @task T9047
  * @adr ADR-068, ADR-069
@@ -80,14 +88,20 @@ const ALLOW_PATH_PREFIXES = [
   'packages/core/src/agents/seed-install.ts',
   // classify.ts — contains JSDoc @example blocks with DatabaseSync (not actual code)
   'packages/core/src/orchestration/classify.ts',
-  // T9045 sweep complete — brain/studio/cleo cross-package opens now apply applyPerfPragmas
-  // These packages have their own DatabaseSync calls but pragma compliance is enforced.
+  // T9685-B3 — `@cleocode/brain` MUST NOT depend on `@cleocode/core` (would
+  // invert the layering — core depends on brain via the substrate adapters).
+  // `db-connections.ts` is allowed to call `new DatabaseSync(...)` directly
+  // with an inline `applyBrainPragmas` mirror of the SSoT. The cross-package
+  // pragma drift is tracked as a follow-up to consolidate via a shared
+  // contracts module (no core dep needed).
   'packages/brain/src/db-connections.ts',
+  // Studio per-project getters (brain/tasks/conduit) take a ProjectContext —
+  // they cannot route through `openCleoDb(role, cwd)` because they open
+  // arbitrary registered project paths, not the active CWD's `.cleo/`. They
+  // do apply pragma SSoT via `applyPerfPragmas`. The nexus.db opens in this
+  // file are still here because they share the file with the per-project
+  // getters; converting them on their own would require splitting the module.
   'packages/studio/src/lib/server/db/connections.ts',
-  'packages/studio/src/lib/server/project-context.ts',
-  'packages/studio/src/routes/api/search/+server.ts',
-  'packages/cleo/src/cli/commands/agent.ts',
-  'packages/cleo/src/cli/commands/migrate-agents-v2.ts',
 ];
 
 /** Regex patterns (matched against relative path) that are always allowed. */


### PR DESCRIPTION
## Summary

- Extends ADR-068 chokepoint API with `openCleoDbSnapshot()` — read-only, no-migration opener for short-lived snapshot reads.
- Refactors Studio's `project-context.ts` (2 sites) to use the new snapshot opener instead of `new DatabaseSync(...)`.
- Tightens the `db-open-guard` lint allowlist: removes 3 stale entries and the now-refactored `project-context.ts`.
- Documents why brain's `db-connections.ts` and Studio's `db/connections.ts` per-project getters remain allowlisted (package-boundary + ProjectContext-driven paths).

## Scope

| Category | Sites | Action |
|---|---|---|
| I — chokepoint scope (`store/`) | 12 | No action (already in chokepoint dir) |
| II — JSDoc-only false positives (`classify.ts`, `skills-db.ts`) | 3 | No action |
| III — Brain `db-connections.ts` | 5 | Cannot route (no core dep allowed); documented |
| IV — core migration/hot-path one-shot opens | 3 | No action (allowlisted with reason) |
| V — Studio `project-context.ts` | 2 | **Refactored** → `openCleoDbSnapshot` |
| V — Studio `db/connections.ts` per-project getters | 5 | Cannot easily refactor (ProjectContext-driven); documented |
| VI — Nexus migrations | 4 | No action (inline `db-open-allowed` per-line) |

## Follow-ups discovered

- Brain pragma drift: `applyBrainPragmas` declares `cache_size = -8192` (8 MB), SSoT in `specs/sqlite-pragmas.json` declares `cache_size = -64000` (64 MB). Cannot consolidate without inverting layer dependencies; should extract pragma values to `@cleocode/contracts` so brain can import without core dep.

## Test plan

- [x] `node scripts/lint-no-raw-db-opens.mjs` passes (exit 0, no violations)
- [x] 4 new vitest cases added for `openCleoDbSnapshot`
- [ ] CI green on full test suite (Vitest, biome, typecheck)
- [ ] `pnpm --filter @cleocode/core test` covers chokepoint + snapshot opener
- [ ] `pnpm --filter @cleocode/studio test` exercises `project-context.ts` refactor

@task T9685-B3
@adr ADR-068, ADR-069

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>