### PR TITLE
feat(T9653): cleo skills migrate — legacy → ~/.cleo/skills/ with reversible backup

### DIFF
--- a/packages/caamp/src/commands/skills/doctor-migrate.ts
+++ b/packages/caamp/src/commands/skills/doctor-migrate.ts
@@ -1,0 +1,222 @@
+/**
+ * `skills migrate` subcommand — legacy XDG store → `~/.cleo/skills/` SSoT.
+ *
+ * @remarks
+ * Implements the CLI surface for T9653. Wraps the pure helpers in
+ * `../../core/skills/migration.ts` with LAFS envelope emission, format
+ * resolution, and the `--dry-run` / `--rollback` flag set required by
+ * acceptance criteria 3 + 4 of T9653.
+ *
+ * Registered as `caamp skills migrate` (also surfaced through `cleo skills
+ * migrate` once the cleo dispatch wiring lands). We register a flat
+ * subcommand rather than nesting under `doctor` so the file stays orthogonal
+ * to T9652 (which is in flight against `doctor.ts`) — the task spec
+ * explicitly authorises this fallback.
+ *
+ * @task T9653
+ * @epic T9571
+ * @saga T9560
+ * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §1
+ */
+
+import type { Command } from 'commander';
+import pc from 'picocolors';
+import {
+  ErrorCategories,
+  ErrorCodes,
+  emitJsonError,
+  outputSuccess,
+  resolveFormat,
+} from '../../core/lafs.js';
+import { isHuman } from '../../core/logger.js';
+import {
+  defaultMigrationOptions,
+  type MigrationOptions,
+  type MigrationOutcome,
+  planMigration,
+  runMigration,
+  runRollback,
+} from '../../core/skills/migration.js';
+
+/**
+ * Options the migrate CLI accepts.
+ *
+ * @remarks
+ * `dryRun` and `rollback` are mutually exclusive — selecting both surfaces a
+ * `VALIDATION` error. `manifestNames` is a hidden test seam so unit tests
+ * can drive the planner against a synthetic manifest.
+ */
+export interface MigrateCliOpts {
+  dryRun?: boolean;
+  rollback?: boolean;
+  json?: boolean;
+  human?: boolean;
+  /** Hidden test seam — overrides the default options bag entirely. */
+  __optionsOverride?: MigrationOptions;
+  /** Hidden test seam — supplies the canonical manifest names. */
+  __manifestNamesOverride?: string[];
+}
+
+/**
+ * Build the migration options bag for a given invocation.
+ *
+ * @remarks
+ * When `__optionsOverride` is set (tests) it wins outright. Otherwise we
+ * compose the production defaults around the supplied manifest names.
+ *
+ * @param opts - Parsed CLI options (incl. hidden test seams).
+ * @returns A fully-populated migration options bag.
+ */
+function buildOptions(opts: MigrateCliOpts): MigrationOptions {
+  if (opts.__optionsOverride) return opts.__optionsOverride;
+  const manifestNames = opts.__manifestNamesOverride ?? [];
+  return defaultMigrationOptions(manifestNames);
+}
+
+/**
+ * Render a successful migration outcome to a human-readable string.
+ *
+ * @remarks
+ * The JSON path always wins by default; this helper is only invoked when the
+ * resolved format is `'human'`. Keeps colour use minimal so the output is
+ * grep-able from shell scripts.
+ *
+ * @param outcome - The outcome returned by the migration helper.
+ * @returns Multi-line string ready for `console.log`.
+ */
+function renderHuman(outcome: MigrationOutcome): string {
+  const lines: string[] = [];
+  lines.push(pc.bold(`\nskills ${outcome.action}`));
+  lines.push(pc.dim(`  legacy:    ${outcome.legacyRoot}`));
+  lines.push(pc.dim(`  canonical: ${outcome.canonicalRoot}`));
+  if (outcome.backupPath) {
+    lines.push(pc.dim(`  backup:    ${outcome.backupPath}`));
+  }
+  lines.push(pc.dim(`  duration:  ${outcome.durationMs}ms`));
+  if (outcome.migrated.length > 0) {
+    lines.push(pc.green(`\nMigrated (${outcome.migrated.length}):`));
+    for (const m of outcome.migrated) {
+      lines.push(`  + ${pc.bold(m.name)} ${pc.dim(`[${m.sourceType}]`)}`);
+    }
+  }
+  if (outcome.skipped.length > 0) {
+    lines.push(pc.yellow(`\nSkipped (${outcome.skipped.length}):`));
+    for (const s of outcome.skipped) {
+      lines.push(`  ! ${pc.bold(s.name)} ${pc.dim(`(${s.reason})`)}`);
+    }
+  }
+  if (outcome.action === 'no-op') {
+    lines.push(pc.dim('\nLegacy store is already migrated (sentinel present).'));
+  }
+  if (outcome.action === 'dry-run') {
+    lines.push(pc.dim('\n(dry run — no filesystem changes were made)'));
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Register the `skills migrate` subcommand on a Commander parent.
+ *
+ * @remarks
+ * Wires up the `--dry-run` / `--rollback` / `--json` / `--human` flags and
+ * dispatches into the pure migration helpers. Emits a LAFS envelope on
+ * stdout for the JSON path and a coloured summary for the human path.
+ *
+ * @param parent - The `skills` Commander instance to attach to.
+ *
+ * @example
+ * ```bash
+ * # Preview without writing
+ * caamp skills migrate --dry-run
+ *
+ * # Perform the migration (default action)
+ * caamp skills migrate
+ *
+ * # Roll back to the most recent backup
+ * caamp skills migrate --rollback
+ * ```
+ *
+ * @public
+ */
+export function registerSkillsDoctorMigrate(parent: Command): void {
+  parent
+    .command('migrate')
+    .description('Migrate legacy skills (~/.local/share/agents/skills) into ~/.cleo/skills')
+    .option('--dry-run', 'Preview the plan without writing anything', false)
+    .option('--rollback', 'Restore from the most recent backup tarball', false)
+    .option('--json', 'Output as JSON (default)')
+    .option('--human', 'Output in human-readable format')
+    .action(async (opts: MigrateCliOpts) => {
+      const operation = 'skills.migrate';
+      const mvi: import('../../core/lafs.js').MVILevel = 'standard';
+
+      let format: 'json' | 'human';
+      try {
+        format = resolveFormat({
+          jsonFlag: opts.json ?? false,
+          humanFlag: (opts.human ?? false) || isHuman(),
+          projectDefault: 'json',
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        emitJsonError(
+          operation,
+          mvi,
+          ErrorCodes.FORMAT_CONFLICT,
+          message,
+          ErrorCategories.VALIDATION,
+        );
+        process.exit(1);
+      }
+
+      if (opts.dryRun && opts.rollback) {
+        const message = 'Cannot combine --dry-run with --rollback';
+        if (format === 'json') {
+          emitJsonError(
+            operation,
+            mvi,
+            ErrorCodes.INVALID_INPUT,
+            message,
+            ErrorCategories.VALIDATION,
+          );
+        } else {
+          console.error(pc.red(message));
+        }
+        process.exit(1);
+      }
+
+      const options = buildOptions(opts);
+
+      try {
+        let outcome: MigrationOutcome;
+        if (opts.rollback) {
+          outcome = await runRollback(options);
+        } else if (opts.dryRun) {
+          outcome = planMigration(options);
+        } else {
+          outcome = await runMigration(options);
+        }
+
+        if (format === 'json') {
+          outputSuccess(operation, mvi, outcome);
+        } else {
+          console.log(renderHuman(outcome));
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (format === 'json') {
+          emitJsonError(
+            operation,
+            mvi,
+            ErrorCodes.INTERNAL_ERROR,
+            message,
+            ErrorCategories.MIGRATION,
+            { legacyRoot: options.legacyRoot, canonicalRoot: options.canonicalRoot },
+          );
+        } else {
+          console.error(pc.red(`migration failed: ${message}`));
+        }
+        process.exit(1);
+      }
+    });
+}

--- a/packages/caamp/src/commands/skills/index.ts
+++ b/packages/caamp/src/commands/skills/index.ts
@@ -8,6 +8,7 @@
 import type { Command } from 'commander';
 import { registerSkillsAudit } from './audit.js';
 import { registerSkillsCheck } from './check.js';
+import { registerSkillsDoctorMigrate } from './doctor-migrate.js';
 import { registerSkillsFind } from './find.js';
 import { registerSkillsInit } from './init.js';
 import { registerSkillsInstall } from './install.js';
@@ -46,4 +47,5 @@ export function registerSkillsCommands(program: Command): void {
   registerSkillsInit(skills);
   registerSkillsAudit(skills);
   registerSkillsValidate(skills);
+  registerSkillsDoctorMigrate(skills);
 }

--- a/packages/caamp/src/core/skills/migration.ts
+++ b/packages/caamp/src/core/skills/migration.ts
@@ -1,0 +1,522 @@
+/**
+ * Skills migration helpers — legacy XDG store → `~/.cleo/skills/` (SSoT).
+ *
+ * @remarks
+ * Implements the filesystem half of `cleo skills doctor migrate` (T9653).
+ * Pure functions only — every side effect is parameterised so the CLI handler
+ * and tests can drive identical code paths against tmpdirs.
+ *
+ * Migration shape (per architecture-v3.md §1):
+ *
+ * 1. **Detect** legacy install at `~/.local/share/agents/skills/`.
+ * 2. **Plan** the set of skill directories to copy into `~/.cleo/skills/`
+ *    (skipping any name already present at the new root — first-wins).
+ * 3. **Backup** the entire legacy tree to a timestamped tgz under
+ *    `~/.cleo/backups/skills/skills-pre-migrate-<ts>.tgz` BEFORE any write.
+ * 4. **Copy** (recursively) each planned entry from legacy → canonical.
+ * 5. **Marker** writes a `.MIGRATED-TO-CLEO` sentinel into the legacy root so
+ *    re-runs detect the already-migrated state and become a no-op. The legacy
+ *    tree itself is left intact for one release cycle as a safety net.
+ *
+ * Rollback (`--rollback`) restores from the most recent backup tarball by
+ * extracting it back over `~/.local/share/agents/skills/` and removing the
+ * sentinel.
+ *
+ * Side-effect injection: `now` (timestamp) and `tarExec` (child-process
+ * wrapper) are parameters so tests can deterministically drive the planner +
+ * runner. The default `tarExec` shells out to the system `tar` binary; tests
+ * supply an in-memory fake.
+ *
+ * @task T9653
+ * @epic T9571
+ * @saga T9560
+ * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §1
+ */
+
+import { execFile } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Filename of the legacy-root sentinel written after a successful migration.
+ *
+ * @remarks
+ * The presence of this file in the legacy skills directory short-circuits
+ * subsequent migrate runs to a no-op. It is also removed by `--rollback`.
+ *
+ * @public
+ */
+export const LEGACY_MIGRATED_MARKER = '.MIGRATED-TO-CLEO';
+
+/**
+ * Provenance row that the migrator emits per migrated skill directory.
+ *
+ * @remarks
+ * The CLI handler funnels these into a callback (`recordRow`) so that the
+ * skills.db upsert lives in the dispatch layer (`packages/cleo/`), keeping
+ * caamp free of a circular `@cleocode/core` import. See architecture-v3.md
+ * §4 for the matching `skills` table schema.
+ *
+ * @public
+ */
+export interface MigratedSkillRecord {
+  /** Skill folder basename (matches `skills.name` column). */
+  name: string;
+  /** Resolved destination path under `~/.cleo/skills/`. */
+  installPath: string;
+  /** Resolved source path under the legacy XDG store. */
+  legacyPath: string;
+  /** `canonical` when the basename matches the bundled manifest, else `user`. */
+  sourceType: 'canonical' | 'user' | 'community';
+}
+
+/**
+ * Provenance row for skills that were SKIPPED during planning.
+ *
+ * @remarks
+ * The most common skip reason is `'already-present'` — the same directory
+ * name already exists under `~/.cleo/skills/`. We never overwrite a
+ * pre-existing target because the canonical store may have been touched by
+ * a newer install path. Returned to callers so they can present the user
+ * with an actionable summary (and optionally remove dupes by hand).
+ *
+ * @public
+ */
+export interface SkippedSkillRecord {
+  /** Skill folder basename. */
+  name: string;
+  /** Reason for skipping. */
+  reason: 'already-present' | 'not-a-directory';
+  /** Resolved legacy path that triggered the skip. */
+  legacyPath: string;
+}
+
+/**
+ * Aggregated outcome of a planning or migration pass.
+ *
+ * @remarks
+ * `backupPath` is `null` when running in dry-run mode (no archive is
+ * produced) or when there are no entries to migrate. `durationMs` is wall
+ * clock from the start of {@link runMigration} until the marker write.
+ *
+ * @public
+ */
+export interface MigrationOutcome {
+  /** Action that was performed — `'migrate'`, `'dry-run'`, `'rollback'`, `'no-op'`. */
+  action: 'migrate' | 'dry-run' | 'rollback' | 'no-op';
+  /** Entries that were (or would be) copied across. */
+  migrated: MigratedSkillRecord[];
+  /** Entries that were SKIPPED with reasons. */
+  skipped: SkippedSkillRecord[];
+  /** Path to the produced backup archive, or `null` on dry-run / no-op. */
+  backupPath: string | null;
+  /** Resolved legacy root the migrator was driven against. */
+  legacyRoot: string;
+  /** Resolved destination root the migrator was driven against. */
+  canonicalRoot: string;
+  /** Wall-clock duration in milliseconds. */
+  durationMs: number;
+}
+
+/**
+ * Inputs every migration helper accepts.
+ *
+ * @remarks
+ * All filesystem roots and side effects are parameterised so tests can wire
+ * tmpdirs + fakes without monkey-patching `os.homedir()`. Production callers
+ * use {@link defaultMigrationOptions} to fill the defaults.
+ *
+ * @public
+ */
+export interface MigrationOptions {
+  /** Legacy skills directory (default: `~/.local/share/agents/skills`). */
+  legacyRoot: string;
+  /** Destination canonical skills directory (default: `~/.cleo/skills`). */
+  canonicalRoot: string;
+  /** Backup directory (default: `~/.cleo/backups/skills`). */
+  backupDir: string;
+  /** Names of canonical skills from the bundled manifest (sphere-A discriminator). */
+  manifestNames: string[];
+  /** Wall-clock injection for testability. Defaults to `() => new Date()`. */
+  now?: () => Date;
+  /**
+   * `tar` wrapper for testability. Default implementation shells out to the
+   * system `tar` binary; tests pass an in-memory fake.
+   */
+  tarExec?: TarExec;
+  /**
+   * Per-row sink invoked after each successful copy. The CLI handler in
+   * `packages/cleo/` plugs `upsertSkillRow` here without caamp needing a
+   * `@cleocode/core` dep. Defaults to a no-op.
+   */
+  recordRow?: (row: MigratedSkillRecord) => Promise<void> | void;
+}
+
+/**
+ * Shape of the optional tar wrapper used by {@link MigrationOptions}.
+ *
+ * @remarks
+ * Tests can swap the default `execFile`-backed implementation for a pure
+ * in-memory fake. The functions return on success and throw on failure
+ * (mirroring `execFileAsync` semantics).
+ *
+ * @public
+ */
+export interface TarExec {
+  /** Create a tgz at `archivePath` containing the contents of `sourceRoot`. */
+  create(args: { archivePath: string; sourceRoot: string }): Promise<void>;
+  /** Extract a tgz from `archivePath` back into `destinationRoot`. */
+  extract(args: { archivePath: string; destinationRoot: string }): Promise<void>;
+}
+
+/**
+ * Build a {@link MigrationOptions} bag populated with production defaults.
+ *
+ * @remarks
+ * Reads `$HOME` via {@link homedir} and wires the canonical paths described
+ * in architecture-v3.md §1. Callers that want to override only some fields
+ * spread the result, e.g. `{ ...defaultMigrationOptions(names), recordRow }`.
+ *
+ * @param manifestNames - Canonical-skill names parsed from the bundled
+ *   manifest (`packages/skills/manifest.json`). Used to discriminate
+ *   `source_type` for the {@link MigratedSkillRecord} payload.
+ * @returns A complete options bag for the migration helpers.
+ *
+ * @public
+ */
+export function defaultMigrationOptions(manifestNames: string[]): MigrationOptions {
+  const home = homedir();
+  return {
+    legacyRoot: join(home, '.local', 'share', 'agents', 'skills'),
+    canonicalRoot: join(home, '.cleo', 'skills'),
+    backupDir: join(home, '.cleo', 'backups', 'skills'),
+    manifestNames,
+    now: () => new Date(),
+    tarExec: systemTarExec,
+    recordRow: () => undefined,
+  };
+}
+
+/**
+ * Default {@link TarExec} that shells out to the system `tar` binary.
+ *
+ * @remarks
+ * Uses `-czf` for create and `-xzf` for extract — the same flags the rest of
+ * the CLEO backup pipeline (e.g. `cleo backup add`) relies on. Surfaces
+ * stderr in thrown errors so callers can debug missing dependencies.
+ *
+ * @public
+ */
+export const systemTarExec: TarExec = {
+  async create({ archivePath, sourceRoot }) {
+    // -C parent + basename keeps the archive root scoped (no absolute paths).
+    const parent = join(sourceRoot, '..');
+    const base = sourceRoot.slice(parent.length + 1);
+    await execFileAsync('tar', ['-czf', archivePath, '-C', parent, base]);
+  },
+  async extract({ archivePath, destinationRoot }) {
+    mkdirSync(destinationRoot, { recursive: true });
+    // -C destination/.. so the archive's top-level dir lands at destination.
+    const parent = join(destinationRoot, '..');
+    await execFileAsync('tar', ['-xzf', archivePath, '-C', parent]);
+  },
+};
+
+/**
+ * Detect whether the legacy XDG store has already been migrated.
+ *
+ * @remarks
+ * Returns `true` when the legacy root either does not exist OR contains the
+ * {@link LEGACY_MIGRATED_MARKER} sentinel. The CLI handler uses this to
+ * short-circuit to a `'no-op'` outcome on idempotent re-runs.
+ *
+ * @param legacyRoot - Absolute path to the legacy skills directory.
+ * @returns `true` when no migration work is needed.
+ *
+ * @public
+ */
+export function isAlreadyMigrated(legacyRoot: string): boolean {
+  if (!existsSync(legacyRoot)) return true;
+  return existsSync(join(legacyRoot, LEGACY_MIGRATED_MARKER));
+}
+
+/**
+ * Enumerate the top-level skill directories under a given root.
+ *
+ * @remarks
+ * Filters out the migration sentinel and any non-directory entries (the
+ * legacy tree historically also contained stray lock files). Returned in
+ * stable lexicographic order so plans are reproducible across runs.
+ *
+ * @param root - Directory to scan; if missing, returns an empty array.
+ * @returns Skill folder basenames in lexicographic order.
+ *
+ * @public
+ */
+export function listSkillDirs(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const entries = readdirSync(root, { withFileTypes: true });
+  return entries
+    .filter((d) => d.isDirectory() && d.name !== LEGACY_MIGRATED_MARKER)
+    .map((d) => d.name)
+    .sort();
+}
+
+/**
+ * Plan a migration without performing any writes.
+ *
+ * @remarks
+ * Used both as the engine for `--dry-run` and as the first step of a real
+ * migration. Resolves which entries will be copied vs skipped based on
+ * presence-at-destination. The returned outcome carries `action: 'dry-run'`
+ * and `durationMs` reflecting the planning cost only.
+ *
+ * @param options - Resolved migration options (see {@link MigrationOptions}).
+ * @returns Outcome describing the planned migration.
+ *
+ * @public
+ */
+export function planMigration(options: MigrationOptions): MigrationOutcome {
+  const start = Date.now();
+  const migrated: MigratedSkillRecord[] = [];
+  const skipped: SkippedSkillRecord[] = [];
+
+  if (isAlreadyMigrated(options.legacyRoot)) {
+    return {
+      action: 'no-op',
+      migrated,
+      skipped,
+      backupPath: null,
+      legacyRoot: options.legacyRoot,
+      canonicalRoot: options.canonicalRoot,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  const names = listSkillDirs(options.legacyRoot);
+  for (const name of names) {
+    const legacyPath = join(options.legacyRoot, name);
+    if (!statSync(legacyPath).isDirectory()) {
+      skipped.push({ name, reason: 'not-a-directory', legacyPath });
+      continue;
+    }
+    const destPath = join(options.canonicalRoot, name);
+    if (existsSync(destPath)) {
+      skipped.push({ name, reason: 'already-present', legacyPath });
+      continue;
+    }
+    migrated.push({
+      name,
+      installPath: destPath,
+      legacyPath,
+      sourceType: options.manifestNames.includes(name) ? 'canonical' : 'user',
+    });
+  }
+
+  return {
+    action: 'dry-run',
+    migrated,
+    skipped,
+    backupPath: null,
+    legacyRoot: options.legacyRoot,
+    canonicalRoot: options.canonicalRoot,
+    durationMs: Date.now() - start,
+  };
+}
+
+/**
+ * Format a UTC timestamp suitable for backup filenames.
+ *
+ * @remarks
+ * Produces `YYYYMMDD-HHmmss` in UTC so the lexicographic order matches
+ * chronological order. Exposed publicly so tests and downstream callers can
+ * generate matching filenames without re-implementing the format.
+ *
+ * @param now - The `Date` to format.
+ * @returns A filename-safe timestamp string.
+ *
+ * @public
+ */
+export function formatBackupTimestamp(now: Date): string {
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+  return (
+    `${now.getUTCFullYear()}` +
+    `${pad(now.getUTCMonth() + 1)}` +
+    `${pad(now.getUTCDate())}` +
+    `-${pad(now.getUTCHours())}` +
+    `${pad(now.getUTCMinutes())}` +
+    `${pad(now.getUTCSeconds())}`
+  );
+}
+
+/**
+ * List backup tarballs in chronological order (newest first).
+ *
+ * @remarks
+ * Used by `--rollback` to pick the most recent archive. Returns absolute
+ * paths so callers do not need to know the backup directory layout.
+ *
+ * @param backupDir - Directory that holds `skills-pre-migrate-*.tgz`.
+ * @returns Absolute paths, newest first; empty when the directory is empty.
+ *
+ * @public
+ */
+export function listBackups(backupDir: string): string[] {
+  if (!existsSync(backupDir)) return [];
+  const files = readdirSync(backupDir).filter(
+    (f) => f.startsWith('skills-pre-migrate-') && f.endsWith('.tgz'),
+  );
+  // Filename embeds an UTC timestamp, so reverse lex sort = newest first.
+  files.sort().reverse();
+  return files.map((f) => join(backupDir, f));
+}
+
+/**
+ * Perform a real migration from legacy → canonical, leaving a sentinel
+ * behind in the legacy root so subsequent runs are no-ops.
+ *
+ * @remarks
+ * Steps performed (in order):
+ *
+ * 1. Short-circuit to `{action:'no-op'}` if the sentinel already exists.
+ * 2. Compute the plan via {@link planMigration} (read-only).
+ * 3. Create `~/.cleo/skills/` and the backup dir.
+ * 4. Tar+gzip the entire legacy tree into the timestamped backup path.
+ * 5. `cp -a` each planned entry (recursive, preserves symlinks + mtime).
+ * 6. Invoke `recordRow` for each migrated entry (db side-effect hook).
+ * 7. Write the sentinel into the legacy root.
+ *
+ * On error before step 7 the partial state is left in place — re-running
+ * after fixing the error will pick up any entries that weren't copied
+ * (idempotent at the directory level: existing destinations are skipped).
+ *
+ * @param options - Resolved migration options.
+ * @returns Outcome describing the work performed.
+ *
+ * @public
+ */
+export async function runMigration(options: MigrationOptions): Promise<MigrationOutcome> {
+  const start = Date.now();
+  const now = (options.now ?? (() => new Date()))();
+  const tar = options.tarExec ?? systemTarExec;
+  const sink = options.recordRow ?? (() => undefined);
+
+  if (isAlreadyMigrated(options.legacyRoot)) {
+    return {
+      action: 'no-op',
+      migrated: [],
+      skipped: [],
+      backupPath: null,
+      legacyRoot: options.legacyRoot,
+      canonicalRoot: options.canonicalRoot,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  const plan = planMigration(options);
+
+  // Ensure destination + backup directories exist before any write.
+  mkdirSync(options.canonicalRoot, { recursive: true });
+  mkdirSync(options.backupDir, { recursive: true });
+
+  // Step 1: backup BEFORE any destructive op.
+  const backupName = `skills-pre-migrate-${formatBackupTimestamp(now)}.tgz`;
+  const backupPath = join(options.backupDir, backupName);
+  await tar.create({ archivePath: backupPath, sourceRoot: options.legacyRoot });
+
+  // Step 2: copy each planned entry.
+  for (const entry of plan.migrated) {
+    cpSync(entry.legacyPath, entry.installPath, { recursive: true, dereference: false });
+    await sink(entry);
+  }
+
+  // Step 3: drop the sentinel so subsequent runs become no-ops.
+  writeFileSync(
+    join(options.legacyRoot, LEGACY_MIGRATED_MARKER),
+    JSON.stringify(
+      {
+        migratedAt: now.toISOString(),
+        backupPath,
+        canonicalRoot: options.canonicalRoot,
+        entries: plan.migrated.length,
+      },
+      null,
+      2,
+    ),
+    'utf-8',
+  );
+
+  return {
+    action: 'migrate',
+    migrated: plan.migrated,
+    skipped: plan.skipped,
+    backupPath,
+    legacyRoot: options.legacyRoot,
+    canonicalRoot: options.canonicalRoot,
+    durationMs: Date.now() - start,
+  };
+}
+
+/**
+ * Restore the legacy skills tree from the most recent backup tarball.
+ *
+ * @remarks
+ * Steps performed (in order):
+ *
+ * 1. Locate the newest tarball via {@link listBackups}; error if none.
+ * 2. Delete the existing legacy root (including the sentinel) so the
+ *    extract lands in a clean directory.
+ * 3. Extract the tarball back over the legacy root.
+ *
+ * Rollback is intentionally non-destructive toward the new `~/.cleo/skills/`
+ * directory: copies that were already made remain in place. The next migrate
+ * call will short-circuit any names that already exist at the destination
+ * (idempotent overlap handling).
+ *
+ * @param options - Resolved migration options.
+ * @returns Outcome describing the rollback.
+ * @throws If no backup tarballs are available under `options.backupDir`.
+ *
+ * @public
+ */
+export async function runRollback(options: MigrationOptions): Promise<MigrationOutcome> {
+  const start = Date.now();
+  const tar = options.tarExec ?? systemTarExec;
+
+  const backups = listBackups(options.backupDir);
+  const newest = backups[0];
+  if (!newest) {
+    throw new Error(
+      `No backup tarballs found under ${options.backupDir}. ` +
+        `Run "cleo skills migrate" (without --rollback) first.`,
+    );
+  }
+
+  // Wipe the legacy root (including any sentinel) before extracting.
+  if (existsSync(options.legacyRoot)) {
+    rmSync(options.legacyRoot, { recursive: true, force: true });
+  }
+  await tar.extract({ archivePath: newest, destinationRoot: options.legacyRoot });
+
+  return {
+    action: 'rollback',
+    migrated: [],
+    skipped: [],
+    backupPath: newest,
+    legacyRoot: options.legacyRoot,
+    canonicalRoot: options.canonicalRoot,
+    durationMs: Date.now() - start,
+  };
+}

--- a/packages/caamp/tests/unit/doctor-migrate.test.ts
+++ b/packages/caamp/tests/unit/doctor-migrate.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Unit tests for `cleo skills migrate` (T9653).
+ *
+ * Drives the migration helpers in `src/core/skills/migration.ts` against a
+ * `mkdtemp`-backed tmpfs with an in-memory `tar` fake so no shell-out, no
+ * real `$HOME` mutation, and full determinism.
+ *
+ * Coverage:
+ *   1. `--dry-run` — produces a plan, writes nothing.
+ *   2. real migration — copies dirs, writes backup tarball, writes sentinel.
+ *   3. idempotent re-run — second migrate call yields `{action:'no-op'}`.
+ *   4. `--rollback` — restores legacy tree from the most recent backup.
+ *   5. partial-failure resumability — left-over dirs at canonical root are
+ *      skipped on the next migrate pass.
+ *
+ * @task T9653
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  formatBackupTimestamp,
+  isAlreadyMigrated,
+  LEGACY_MIGRATED_MARKER,
+  listBackups,
+  listSkillDirs,
+  type MigratedSkillRecord,
+  type MigrationOptions,
+  planMigration,
+  runMigration,
+  runRollback,
+  type TarExec,
+} from '../../src/core/skills/migration.js';
+
+// ---------------------------------------------------------------------------
+// Test scaffolding — tmpdir + fake tar
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  root: string;
+  legacyRoot: string;
+  canonicalRoot: string;
+  backupDir: string;
+}
+
+function makeFixture(): Fixture {
+  const root = join(tmpdir(), `caamp-migrate-${randomUUID()}`);
+  mkdirSync(root, { recursive: true });
+  return {
+    root,
+    legacyRoot: join(root, '.local', 'share', 'agents', 'skills'),
+    canonicalRoot: join(root, '.cleo', 'skills'),
+    backupDir: join(root, '.cleo', 'backups', 'skills'),
+  };
+}
+
+function seedSkill(legacyRoot: string, name: string): string {
+  const dir = join(legacyRoot, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: seed ${name}\n---\n# ${name}\n`,
+    'utf-8',
+  );
+  return dir;
+}
+
+/**
+ * In-memory `tar` fake: snapshots the source tree to disk in a sidecar
+ * directory (so we can detect a "backup was written") and restores it on
+ * extract. Behaves identically across create + extract for round-trip tests.
+ */
+function makeFakeTar(): TarExec & { archives: Map<string, string> } {
+  const archives = new Map<string, string>(); // archivePath → snapshotDir
+
+  return {
+    archives,
+    async create({ archivePath, sourceRoot }) {
+      const snapshotDir = `${archivePath}.snapshot`;
+      if (existsSync(snapshotDir)) {
+        rmSync(snapshotDir, { recursive: true, force: true });
+      }
+      mkdirSync(snapshotDir, { recursive: true });
+      if (existsSync(sourceRoot)) {
+        cpSync(sourceRoot, join(snapshotDir, 'root'), { recursive: true });
+      }
+      // Touch the archive path so consumers can verify file existence.
+      writeFileSync(archivePath, JSON.stringify({ sourceRoot }), 'utf-8');
+      archives.set(archivePath, snapshotDir);
+    },
+    async extract({ archivePath, destinationRoot }) {
+      const snapshotDir = archives.get(archivePath);
+      if (!snapshotDir) {
+        throw new Error(`fake-tar: no snapshot recorded for ${archivePath}`);
+      }
+      mkdirSync(destinationRoot, { recursive: true });
+      const snapshotRoot = join(snapshotDir, 'root');
+      if (existsSync(snapshotRoot)) {
+        // cpSync overwrites by default when target exists, but the migrate
+        // flow rms the legacy root before extract — so a plain recursive
+        // copy is sufficient here.
+        cpSync(snapshotRoot, destinationRoot, { recursive: true });
+      }
+    },
+  };
+}
+
+function buildOptions(fx: Fixture, manifestNames: string[] = []): MigrationOptions {
+  return {
+    legacyRoot: fx.legacyRoot,
+    canonicalRoot: fx.canonicalRoot,
+    backupDir: fx.backupDir,
+    manifestNames,
+    now: () => new Date('2026-05-19T12:00:00Z'),
+    tarExec: makeFakeTar(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let fx: Fixture;
+
+beforeEach(() => {
+  fx = makeFixture();
+});
+
+afterEach(() => {
+  rmSync(fx.root, { recursive: true, force: true });
+});
+
+describe('formatBackupTimestamp', () => {
+  it('produces YYYYMMDD-HHmmss in UTC', () => {
+    const ts = formatBackupTimestamp(new Date('2026-05-19T08:09:07Z'));
+    expect(ts).toBe('20260519-080907');
+  });
+});
+
+describe('listSkillDirs', () => {
+  it('returns empty when root is missing', () => {
+    expect(listSkillDirs(join(fx.root, 'nope'))).toEqual([]);
+  });
+
+  it('lists top-level dirs in sorted order, skipping the sentinel', () => {
+    seedSkill(fx.legacyRoot, 'ct-zeta');
+    seedSkill(fx.legacyRoot, 'ct-alpha');
+    seedSkill(fx.legacyRoot, 'user-skill');
+    writeFileSync(join(fx.legacyRoot, LEGACY_MIGRATED_MARKER), '{}', 'utf-8');
+    expect(listSkillDirs(fx.legacyRoot)).toEqual(['ct-alpha', 'ct-zeta', 'user-skill']);
+  });
+});
+
+describe('isAlreadyMigrated', () => {
+  it('returns true when legacy root does not exist', () => {
+    expect(isAlreadyMigrated(join(fx.root, 'missing'))).toBe(true);
+  });
+
+  it('returns true when the sentinel is present', () => {
+    seedSkill(fx.legacyRoot, 'foo');
+    writeFileSync(join(fx.legacyRoot, LEGACY_MIGRATED_MARKER), '{}', 'utf-8');
+    expect(isAlreadyMigrated(fx.legacyRoot)).toBe(true);
+  });
+
+  it('returns false when legacy exists with no sentinel', () => {
+    seedSkill(fx.legacyRoot, 'foo');
+    expect(isAlreadyMigrated(fx.legacyRoot)).toBe(false);
+  });
+});
+
+describe('planMigration (dry-run engine)', () => {
+  it('returns no-op when nothing to migrate', () => {
+    const outcome = planMigration(buildOptions(fx));
+    expect(outcome.action).toBe('no-op');
+    expect(outcome.migrated).toEqual([]);
+    expect(outcome.backupPath).toBeNull();
+  });
+
+  it('flags canonical skills via manifest membership', () => {
+    seedSkill(fx.legacyRoot, 'ct-orchestrator');
+    seedSkill(fx.legacyRoot, 'my-user-skill');
+    const outcome = planMigration(buildOptions(fx, ['ct-orchestrator', 'ct-lead']));
+    expect(outcome.action).toBe('dry-run');
+    expect(outcome.migrated).toHaveLength(2);
+    const byName = new Map(outcome.migrated.map((m) => [m.name, m]));
+    expect(byName.get('ct-orchestrator')?.sourceType).toBe('canonical');
+    expect(byName.get('my-user-skill')?.sourceType).toBe('user');
+  });
+
+  it('skips entries already present at the destination', () => {
+    seedSkill(fx.legacyRoot, 'shared');
+    mkdirSync(join(fx.canonicalRoot, 'shared'), { recursive: true });
+    const outcome = planMigration(buildOptions(fx));
+    expect(outcome.migrated).toHaveLength(0);
+    expect(outcome.skipped).toHaveLength(1);
+    expect(outcome.skipped[0]).toMatchObject({
+      name: 'shared',
+      reason: 'already-present',
+    });
+  });
+
+  it('does not write to the filesystem', () => {
+    seedSkill(fx.legacyRoot, 'foo');
+    planMigration(buildOptions(fx));
+    expect(existsSync(fx.canonicalRoot)).toBe(false);
+    expect(existsSync(fx.backupDir)).toBe(false);
+    expect(existsSync(join(fx.legacyRoot, LEGACY_MIGRATED_MARKER))).toBe(false);
+  });
+});
+
+describe('runMigration', () => {
+  it('copies entries and writes backup + sentinel', async () => {
+    seedSkill(fx.legacyRoot, 'ct-orchestrator');
+    seedSkill(fx.legacyRoot, 'user-skill');
+    const recorded: MigratedSkillRecord[] = [];
+    const options: MigrationOptions = {
+      ...buildOptions(fx, ['ct-orchestrator']),
+      recordRow: (row) => {
+        recorded.push(row);
+      },
+    };
+
+    const outcome = await runMigration(options);
+
+    expect(outcome.action).toBe('migrate');
+    expect(outcome.migrated).toHaveLength(2);
+    expect(outcome.backupPath).toContain('skills-pre-migrate-20260519-120000.tgz');
+
+    // Files actually landed at the destination.
+    expect(existsSync(join(fx.canonicalRoot, 'ct-orchestrator', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(fx.canonicalRoot, 'user-skill', 'SKILL.md'))).toBe(true);
+
+    // Sentinel written.
+    const sentinel = JSON.parse(
+      readFileSync(join(fx.legacyRoot, LEGACY_MIGRATED_MARKER), 'utf-8'),
+    );
+    expect(sentinel.entries).toBe(2);
+    expect(sentinel.canonicalRoot).toBe(fx.canonicalRoot);
+
+    // recordRow invoked per migrated entry.
+    expect(recorded.map((r) => r.name).sort()).toEqual(['ct-orchestrator', 'user-skill']);
+  });
+
+  it('is idempotent: second run is a no-op', async () => {
+    seedSkill(fx.legacyRoot, 'alpha');
+    const opts = buildOptions(fx);
+    await runMigration(opts);
+    const second = await runMigration(opts);
+    expect(second.action).toBe('no-op');
+    expect(second.migrated).toEqual([]);
+    expect(second.backupPath).toBeNull();
+  });
+
+  it('skips a partial-state entry that already exists at the destination', async () => {
+    // Simulate a previous run that copied "alpha" but crashed before the
+    // sentinel was written.
+    seedSkill(fx.legacyRoot, 'alpha');
+    seedSkill(fx.legacyRoot, 'beta');
+    mkdirSync(join(fx.canonicalRoot, 'alpha'), { recursive: true });
+    writeFileSync(join(fx.canonicalRoot, 'alpha', 'SKILL.md'), 'pre-existing', 'utf-8');
+
+    const outcome = await runMigration(buildOptions(fx));
+    expect(outcome.action).toBe('migrate');
+    expect(outcome.migrated.map((m) => m.name)).toEqual(['beta']);
+    expect(outcome.skipped.map((s) => s.name)).toEqual(['alpha']);
+    expect(readFileSync(join(fx.canonicalRoot, 'alpha', 'SKILL.md'), 'utf-8')).toBe('pre-existing');
+  });
+});
+
+describe('runRollback', () => {
+  it('restores legacy tree from the most recent backup', async () => {
+    seedSkill(fx.legacyRoot, 'gamma');
+    const opts = buildOptions(fx);
+    await runMigration(opts);
+
+    // Verify the sentinel + canonical copy exist before rollback.
+    expect(existsSync(join(fx.legacyRoot, LEGACY_MIGRATED_MARKER))).toBe(true);
+
+    const outcome = await runRollback(opts);
+    expect(outcome.action).toBe('rollback');
+    expect(outcome.backupPath).not.toBeNull();
+    // Legacy tree was extracted back (without sentinel).
+    expect(existsSync(join(fx.legacyRoot, 'gamma', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(fx.legacyRoot, LEGACY_MIGRATED_MARKER))).toBe(false);
+  });
+
+  it('throws when no backup tarballs exist', async () => {
+    await expect(runRollback(buildOptions(fx))).rejects.toThrow(/No backup tarballs/);
+  });
+});
+
+describe('listBackups', () => {
+  it('returns absolute paths, newest first', () => {
+    mkdirSync(fx.backupDir, { recursive: true });
+    writeFileSync(join(fx.backupDir, 'skills-pre-migrate-20260101-000000.tgz'), '', 'utf-8');
+    writeFileSync(join(fx.backupDir, 'skills-pre-migrate-20260601-000000.tgz'), '', 'utf-8');
+    writeFileSync(join(fx.backupDir, 'unrelated.txt'), '', 'utf-8');
+    const sorted = listBackups(fx.backupDir);
+    expect(sorted).toHaveLength(2);
+    expect(sorted[0]).toContain('20260601');
+    expect(sorted[1]).toContain('20260101');
+  });
+
+  it('returns empty when backup dir does not exist', () => {
+    expect(listBackups(join(fx.root, 'nope'))).toEqual([]);
+  });
+});
+
+describe('end-to-end: dry-run → migrate → re-run → rollback', () => {
+  it('walks the full lifecycle without leaving stale state', async () => {
+    seedSkill(fx.legacyRoot, 'ct-lead');
+    seedSkill(fx.legacyRoot, 'user-skill');
+    const opts = buildOptions(fx, ['ct-lead']);
+
+    // 1. Dry-run — plan only, no writes.
+    const dry = planMigration(opts);
+    expect(dry.action).toBe('dry-run');
+    expect(dry.migrated).toHaveLength(2);
+    expect(existsSync(fx.canonicalRoot)).toBe(false);
+
+    // 2. Real migrate.
+    const migrated = await runMigration(opts);
+    expect(migrated.action).toBe('migrate');
+    expect(readdirSync(fx.canonicalRoot).sort()).toEqual(['ct-lead', 'user-skill']);
+
+    // 3. Re-run is a no-op.
+    const again = await runMigration(opts);
+    expect(again.action).toBe('no-op');
+
+    // 4. Rollback restores legacy.
+    const restored = await runRollback(opts);
+    expect(restored.action).toBe('rollback');
+    expect(existsSync(join(fx.legacyRoot, 'ct-lead', 'SKILL.md'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `cleo skills migrate` subcommand under epic T9571 / saga T9560 (SG-CLEO-SKILLS architecture-v3 §1)
- Migrates skills from legacy `~/.local/share/agents/skills/` (XDG canonical) into the new SSoT at `~/.cleo/skills/`, with timestamped backup tarball at `~/.cleo/backups/skills/skills-pre-migrate-<UTC-ts>.tgz`
- Supports `--dry-run` (preview, no writes) and `--rollback` (extracts the most recent backup over the legacy root and removes the sentinel)
- Idempotent: drops a `.MIGRATED-TO-CLEO` sentinel in the legacy root so subsequent runs short-circuit to `{action:'no-op'}`
- Skips entries that already exist at the destination (partial-failure resumability)

## Implementation Notes

- Pure migration helpers live in `packages/caamp/src/core/skills/migration.ts` with side effects (timestamp, `tar` execution, db sink) fully injected so the CLI and tests share the same code paths
- `recordRow` callback is the seam where the `packages/cleo/` dispatch layer plugs `upsertSkillRow` (T9651) — keeping caamp free of any `@cleocode/core` import (which would create a cycle, since core already depends on caamp)
- Default tar implementation shells out to system `tar -czf` / `-xzf` (same flags as `cleo backup add`); tests inject an in-memory fake
- Backup runs BEFORE any destructive op; legacy tree is left intact for one release cycle as a safety net
- Registered as `skills migrate` (flat) rather than `skills doctor migrate` to avoid edit conflict with T9652 (`skills doctor`) running in parallel — explicitly authorised by the task spec

## Acceptance Criteria

- [x] AC1: CLI subcommand handler in `packages/caamp/src/commands/skills/doctor-migrate.ts`
- [x] AC2: Migration flow with tgz backup + cp-a + db row population hook + read-only legacy fallback
- [x] AC3: `--dry-run` flag prints planned actions without executing
- [x] AC4: `--rollback` restores from most recent backup tarball
- [x] AC5: Idempotent — sentinel-aware re-runs are no-ops
- [x] AC6: LAFS envelope emitted with `{migrated, skipped, backupPath, durationMs}` payload
- [x] AC7: Unit tests cover dry-run, real run, idempotent re-run, rollback, partial-failure resumability
- [x] AC8: Code placed in `packages/caamp/` per Package-Boundary Check

## Test plan

- [x] `pnpm --filter @cleocode/caamp run test tests/unit/doctor-migrate.test.ts` — 18/18 passed
- [x] `pnpm --filter @cleocode/caamp run test` (full caamp suite) — 1364 passed / 6 skipped, no new failures
- [x] `pnpm --filter @cleocode/caamp run typecheck` — clean
- [x] `npx biome check` on new + modified files — clean
- [x] Live dry-run on this machine: detected 23 `ct-*` skills under `~/.local/share/agents/skills/`, emitted LAFS envelope, zero filesystem mutations
- [x] Conflict-flag rejection verified (`--dry-run --rollback` → `E_INVALID_INPUT`)
- [x] No-backup error path verified (`--rollback` with empty backup dir → `E_INTERNAL_ERROR` + `MIGRATION` category)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>