### PR TITLE
refactor(T9685-B2): consolidate homedir/cleo-dir resolution into resolveLegacyCleoDir helper

### DIFF
--- a/packages/adapters/src/providers/claude-code/context-monitor.ts
+++ b/packages/adapters/src/providers/claude-code/context-monitor.ts
@@ -12,6 +12,7 @@ import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { AdapterContextMonitorProvider } from '@cleocode/contracts';
+import { resolveLegacyCleoDir } from '@cleocode/paths';
 import { ClaudeCodePathProvider } from './paths.js';
 
 /** Context window input from Claude Code. */
@@ -165,7 +166,7 @@ export class ClaudeCodeContextMonitorProvider implements AdapterContextMonitorPr
     return {
       statusLine: {
         type: 'command',
-        command: join(homedir(), '.cleo', 'lib', 'session', 'context-monitor.sh'),
+        command: join(resolveLegacyCleoDir(), 'lib', 'session', 'context-monitor.sh'),
       },
     };
   }

--- a/packages/adapters/src/providers/cursor/install.ts
+++ b/packages/adapters/src/providers/cursor/install.ts
@@ -91,11 +91,16 @@ export class CursorInstallProvider implements AdapterInstallProvider {
    * Checks for .cursor/rules/cleo.mdc or .cursorrules with CLEO references.
    */
   async isInstalled(): Promise<boolean> {
+    // CWD-OK: `.cursor/` is a Cursor-IDE convention rooted at the project the
+    // user is *invoking* CLEO from, not a CLEO project root — Cursor itself
+    // walks from cwd for its rules discovery, so we mirror that semantic.
     const mdcPath = join(process.cwd(), '.cursor', 'rules', 'cleo.mdc');
     if (existsSync(mdcPath)) {
       return true;
     }
 
+    // CWD-OK: `.cursorrules` is the legacy Cursor-IDE rules file, same
+    // cwd-rooted semantic as `.cursor/rules/` above.
     const rulesPath = join(process.cwd(), '.cursorrules');
     if (existsSync(rulesPath)) {
       try {

--- a/packages/cleo/src/cli/commands/briefing.ts
+++ b/packages/cleo/src/cli/commands/briefing.ts
@@ -16,8 +16,8 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { resolveLegacyCleoDir } from '@cleocode/paths';
 import { defineCommand } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
 import { isSubCommandDispatch } from '../lib/subcommand-guard.js';
@@ -57,7 +57,7 @@ type AdapterFormat = (typeof ADAPTER_FORMATS)[number];
  * without XDG_CONFIG_HOME set.
  */
 function resolveInjectionTemplatePath(): string {
-  const xdgConfig = process.env['XDG_CONFIG_HOME'] ?? join(homedir(), '.cleo');
+  const xdgConfig = resolveLegacyCleoDir(process.env['XDG_CONFIG_HOME']);
   return join(xdgConfig, 'templates', 'CLEO-INJECTION.md');
 }
 

--- a/packages/cleo/src/cli/commands/daemon.ts
+++ b/packages/cleo/src/cli/commands/daemon.ts
@@ -31,7 +31,6 @@
  */
 
 import { existsSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getGCDaemonStatus, spawnGCDaemon, stopGCDaemon } from '@cleocode/core/gc/daemon.js';
@@ -39,6 +38,7 @@ import {
   bootstrapDaemon as bootstrapSentientDaemon,
   getSentientDaemonStatus,
 } from '@cleocode/core/sentient';
+import { resolveLegacyCleoDir } from '@cleocode/paths';
 import { defineCommand } from 'citty';
 import { isSubCommandDispatch } from '../lib/subcommand-guard.js';
 import { cliError, cliOutput } from '../renderers/index.js';
@@ -186,7 +186,7 @@ const startCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cleoDir = (args['cleo-dir'] as string | undefined) ?? join(homedir(), '.cleo');
+    const cleoDir = resolveLegacyCleoDir(args['cleo-dir'] as string | undefined);
     const foreground = (args.foreground as boolean | undefined) ?? false;
 
     // --foreground: run the sentient daemon bootstrap in-process so that
@@ -268,7 +268,7 @@ const stopCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cleoDir = (args['cleo-dir'] as string | undefined) ?? join(homedir(), '.cleo');
+    const cleoDir = resolveLegacyCleoDir(args['cleo-dir'] as string | undefined);
 
     try {
       const stopResult = await stopGCDaemon(cleoDir);
@@ -312,7 +312,7 @@ const statusCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cleoDir = (args['cleo-dir'] as string | undefined) ?? join(homedir(), '.cleo');
+    const cleoDir = resolveLegacyCleoDir(args['cleo-dir'] as string | undefined);
     await showDaemonStatus(cleoDir, process.cwd());
   },
 });
@@ -451,7 +451,7 @@ export const daemonCommand = defineCommand({
     // Parent run() fires after subcommand per citty@0.2.x — skip default
     // status print so `cleo daemon start` doesn't also run status. T1187-followup.
     if (isSubCommandDispatch(rawArgs, cmd.subCommands)) return;
-    const cleoDir = (args['cleo-dir'] as string | undefined) ?? join(homedir(), '.cleo');
+    const cleoDir = resolveLegacyCleoDir(args['cleo-dir'] as string | undefined);
     await showDaemonStatus(cleoDir, process.cwd());
   },
 });

--- a/packages/cleo/src/cli/commands/gc.ts
+++ b/packages/cleo/src/cli/commands/gc.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path';
 import { pruneOrphanTempDirs, pruneOrphanWorktrees } from '@cleocode/core/gc/cleanup.js';
 import { runGC } from '@cleocode/core/gc/runner.js';
 import { readGCState } from '@cleocode/core/gc/state.js';
+import { resolveLegacyCleoDir } from '@cleocode/paths';
 import { defineCommand, showUsage } from 'citty';
 import { cliError, cliOutput } from '../renderers/index.js';
 
@@ -66,7 +67,7 @@ const runCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cleoDir = (args['cleo-dir'] as string | undefined) ?? join(homedir(), '.cleo');
+    const cleoDir = resolveLegacyCleoDir(args['cleo-dir'] as string | undefined);
     const dryRun = args['dry-run'];
 
     try {
@@ -117,7 +118,7 @@ const statusCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cleoDir = (args['cleo-dir'] as string | undefined) ?? join(homedir(), '.cleo');
+    const cleoDir = resolveLegacyCleoDir(args['cleo-dir'] as string | undefined);
     const statePath = join(cleoDir, 'gc-state.json');
 
     try {

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -15,6 +15,7 @@ import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
 import { copyFile, mkdir, readFile, readlink, rename, symlink, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, normalize } from 'node:path';
+import { resolveLegacyCleoDir } from '@cleocode/paths';
 import {
   getAgentsHome,
   getCanonicalTemplatesTildePath,
@@ -140,7 +141,7 @@ export async function bootstrapGlobalCleo(options?: BootstrapOptions): Promise<B
 export async function ensureCleoSymlink(ctx: BootstrapContext): Promise<void> {
   if (ctx.isDryRun) return;
 
-  const legacyPath = join(homedir(), '.cleo');
+  const legacyPath = resolveLegacyCleoDir();
   const canonicalTarget = getCleoHome();
   const linkType: 'dir' | 'junction' = process.platform === 'win32' ? 'junction' : 'dir';
 
@@ -759,7 +760,7 @@ async function verifyBootstrapHealth(ctx: BootstrapContext): Promise<void> {
 
     // Check 2: ~/.cleo symlink integrity. On fresh installs Step 0.5 created
     // the link; here we verify it stayed intact (user didn't replace it).
-    const legacyPath = join(homedir(), '.cleo');
+    const legacyPath = resolveLegacyCleoDir();
     const canonicalTarget = getCleoHome();
     if (existsSync(legacyPath)) {
       const stat = lstatSync(legacyPath);

--- a/packages/core/src/gc/daemon-entry.ts
+++ b/packages/core/src/gc/daemon-entry.ts
@@ -12,11 +12,10 @@
  * @epic T726
  */
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { resolveLegacyCleoDir } from '@cleocode/paths';
 import { bootstrapDaemon } from './daemon.js';
 
-const cleoDir = process.argv[2] ?? join(homedir(), '.cleo');
+const cleoDir = resolveLegacyCleoDir(process.argv[2]);
 
 bootstrapDaemon(cleoDir).catch((err: unknown) => {
   const message = err instanceof Error ? err.message : String(err);

--- a/packages/paths/src/__tests__/cleo-paths.test.ts
+++ b/packages/paths/src/__tests__/cleo-paths.test.ts
@@ -9,6 +9,7 @@ import {
   getCleoPlatformPaths,
   getCleoSystemInfo,
   getCleoTemplatesTildePath,
+  resolveLegacyCleoDir,
 } from '../cleo-paths.js';
 
 describe('cleo-paths', () => {
@@ -103,6 +104,36 @@ describe('cleo-paths', () => {
     it('produces the correct @-reference for CLEO-INJECTION.md', () => {
       const ref = `@${getCanonicalTemplatesTildePath()}/CLEO-INJECTION.md`;
       expect(ref).toBe('@~/.cleo/templates/CLEO-INJECTION.md');
+    });
+  });
+
+  // ── resolveLegacyCleoDir (T9685-B2) ───────────────────────────────────────
+
+  describe('resolveLegacyCleoDir()', () => {
+    it('returns the override when provided', () => {
+      expect(resolveLegacyCleoDir('/custom/cleo-dir')).toBe('/custom/cleo-dir');
+    });
+
+    it('returns ~/.cleo when no override is provided', () => {
+      expect(resolveLegacyCleoDir()).toBe(join(homedir(), '.cleo'));
+    });
+
+    it('returns ~/.cleo when override is undefined', () => {
+      expect(resolveLegacyCleoDir(undefined)).toBe(join(homedir(), '.cleo'));
+    });
+
+    it('treats empty string override as falsy and falls back to ~/.cleo', () => {
+      // Empty string is falsy — falls through to default. Documented behaviour:
+      // CLI handlers that pass `args['cleo-dir'] as string | undefined` will never
+      // pass '', but we guard against it explicitly so the contract is clear.
+      expect(resolveLegacyCleoDir('')).toBe(join(homedir(), '.cleo'));
+    });
+
+    it('is immune to CLEO_HOME — always resolves the legacy ~/.cleo path', () => {
+      process.env['CLEO_HOME'] = '/opt/custom-cleo';
+      _resetCleoPlatformPathsCache();
+      // Even with CLEO_HOME set, the legacy resolver returns ~/.cleo
+      expect(resolveLegacyCleoDir()).toBe(join(homedir(), '.cleo'));
     });
   });
 });

--- a/packages/paths/src/cleo-paths.ts
+++ b/packages/paths/src/cleo-paths.ts
@@ -128,6 +128,38 @@ export function getCanonicalTemplatesTildePath(): string {
 }
 
 /**
+ * Resolve the legacy `~/.cleo` directory, with optional explicit override.
+ *
+ * On a fully-bootstrapped install `~/.cleo` is a symlink to {@link getCleoHome}
+ * (see `ensureCleoSymlink` in `@cleocode/core/bootstrap`), so writes through
+ * this path land in the canonical OS-appropriate location. The override
+ * argument takes precedence and is the standard wiring for CLI commands that
+ * accept a `--cleo-dir` flag (`cleo daemon`, `cleo gc`, …).
+ *
+ * This helper centralizes the `args['--cleo-dir'] ?? join(homedir(), '.cleo')`
+ * pattern that was previously duplicated across the CLI surface. Prefer
+ * {@link getCleoHome} when you need the canonical (post-XDG) data directory
+ * and there is no legacy-path or `--cleo-dir` override semantic.
+ *
+ * @param override - Explicit override (typically the `--cleo-dir` CLI arg)
+ * @returns Absolute path to the resolved `.cleo` directory
+ *
+ * @example
+ * ```typescript
+ * // CLI handler
+ * const cleoDir = resolveLegacyCleoDir(args['cleo-dir'] as string | undefined);
+ * // Bootstrap migration probe
+ * const legacyPath = resolveLegacyCleoDir();
+ * ```
+ *
+ * @public
+ */
+export function resolveLegacyCleoDir(override?: string): string {
+  if (override) return override;
+  return join(homedir(), '.cleo');
+}
+
+/**
  * Invalidate the cached CLEO system info snapshot. Use in tests after
  * mutating `CLEO_HOME` or related env vars.
  *

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -27,6 +27,7 @@ export {
   getCleoPlatformPaths,
   getCleoSystemInfo,
   getCleoTemplatesTildePath,
+  resolveLegacyCleoDir,
 } from './cleo-paths.js';
 export {
   createPlatformPathsResolver,


### PR DESCRIPTION
## Summary

B2 lane of E-PROJECT-ROOT-AUDIT (T9685) — consolidates the 13 ad-hoc `homedir() + '.cleo'` and `--cleo-dir` resolution sites across the CLI/adapter surface into a single SSoT helper, `resolveLegacyCleoDir(override?)`, in `@cleocode/paths`.

### Changes

- **New SSoT helper** — `packages/paths/src/cleo-paths.ts::resolveLegacyCleoDir(override?)`
  - Accepts optional override (the standard wiring for `--cleo-dir` CLI args)
  - Falls back to `join(homedir(), '.cleo')`, which on a bootstrapped install resolves through the canonical symlink created by `ensureCleoSymlink()`
  - 5 new unit tests in `packages/paths/src/__tests__/cleo-paths.test.ts`

- **Refactored 11 sites** to use the helper:
  - `packages/cleo/src/cli/commands/daemon.ts` (4 sites — start/stop/status/sentient)
  - `packages/cleo/src/cli/commands/gc.ts` (2 sites — run/config)
  - `packages/cleo/src/cli/commands/briefing.ts` (1 site — XDG_CONFIG_HOME fallback)
  - `packages/adapters/src/providers/claude-code/context-monitor.ts` (1 site — statusline script path)
  - `packages/core/src/bootstrap.ts` (2 sites — `ensureCleoSymlink` + `verifyBootstrapHealth` legacy-path migration probes)
  - `packages/core/src/gc/daemon-entry.ts` (1 site — argv[2] fallback)

- **Annotated** `packages/adapters/src/providers/cursor/install.ts` — added `CWD-OK` comments documenting the Cursor-IDE cwd-rooted `.cursor/rules/` convention.

### Result

- **Baseline**: 57 → 46 violations (11 sites eliminated)
- **Tests**: 37 paths tests pass (5 new for `resolveLegacyCleoDir`)
- **Build**: full root build green (`pnpm run build`)

### Out of scope (intentional)

- `packages/core/src/skills/skill-root.ts:112` — documented intentional use of `~/.cleo` (immune to `CLEO_HOME` test overrides via the symlink). Not a violation.
- `packages/core/src/bootstrap.ts:129` — TSDoc comment mention, not a code site.

## Test plan

- [x] `pnpm --filter @cleocode/paths run test` → 37/37 pass
- [x] `pnpm run build` (root) → green across all packages
- [x] `node scripts/lint-project-root-anti-pattern.mjs` → 46 violations (down from 57)
- [ ] CI green

Refs T9685-B2, E-PROJECT-ROOT-AUDIT, T9580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)