### PR TITLE
feat(T9655): cleo skills doctor bridge — single bridge symlink + per-skill cleanup

### DIFF
--- a/packages/caamp/src/commands/skills/doctor-bridge.ts
+++ b/packages/caamp/src/commands/skills/doctor-bridge.ts
@@ -1,0 +1,573 @@
+/**
+ * `cleo skills doctor bridge` — single bridge symlink + per-skill symlink removal.
+ *
+ * @remarks
+ * Implements the canonical discovery topology described in
+ * `docs/architecture/SG-CLEO-SKILLS-architecture-v3.md` §1:
+ *
+ * - `~/.cleo/skills/<name>/` is the per-user install root (Sphere A + B).
+ * - `~/.claude/skills/agents-shared/<name>` is a symlink INTO `~/.cleo/skills/`
+ *   for each installed skill — Claude Code's hardcoded discovery mount.
+ * - `~/.agents/skills` is the SINGLE bridge symlink → `~/.claude/skills/agents-shared`
+ *   used by every non-Claude harness (Cursor, Aider, Codeium, etc.).
+ *
+ * The bridge command takes a host machine from any pre-v3 state and:
+ *
+ * 1. Ensures `~/.claude/skills/agents-shared/` exists (mkdir -p).
+ * 2. Creates a symlink under `agents-shared/` for every skill currently in
+ *    `~/.cleo/skills/` whose target is missing or wrong.
+ * 3. Atomically replaces `~/.agents/skills` with a symlink to
+ *    `~/.claude/skills/agents-shared`. If the existing `~/.agents/skills` is a
+ *    REAL directory with contents, the command refuses without `--force` and
+ *    backs up to `~/.cleo/backups/agents-skills-pre-bridge-YYYYMMDD-HHmmss/`
+ *    when `--force` is supplied.
+ * 4. Rips per-skill symlinks under `~/.claude/skills/*` that point OUTSIDE
+ *    `agents-shared/` (orphans from the old per-skill fan-out model).
+ *
+ * The handler is pure-functional with a dependency-injected `homeDir` so it
+ * can be exercised against tmpfs fixtures in unit tests without touching the
+ * real user environment.
+ *
+ * @see {@link docs/architecture/SG-CLEO-SKILLS-architecture-v3.md} §1
+ * @task T9655
+ * @epic T9571
+ * @public
+ */
+
+import { existsSync, lstatSync, readdirSync, readlinkSync, realpathSync } from 'node:fs';
+import { cp, mkdir, readdir, rm, symlink, unlink } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+import type { Command } from 'commander';
+import pc from 'picocolors';
+import {
+  ErrorCategories,
+  ErrorCodes,
+  emitJsonError,
+  outputSuccess,
+  resolveFormat,
+} from '../../core/lafs.js';
+
+/**
+ * One symlink that was created (or would be created in `--dry-run`).
+ *
+ * @public
+ */
+export interface BridgeSymlinkRecord {
+  /** Skill basename, e.g. `ct-orchestrator`. */
+  name: string;
+  /** Absolute path of the symlink under `~/.claude/skills/agents-shared/`. */
+  linkPath: string;
+  /** Absolute path of the symlink target inside `~/.cleo/skills/`. */
+  target: string;
+}
+
+/**
+ * One per-skill symlink that was removed (or would be removed in `--dry-run`).
+ *
+ * @public
+ */
+export interface PerSkillSymlinkRemoval {
+  /** Absolute path of the symlink that was removed. */
+  linkPath: string;
+  /** Resolved target the symlink pointed at, or `null` when unreadable. */
+  previousTarget: string | null;
+}
+
+/**
+ * LAFS-shaped result payload emitted by {@link runDoctorBridge}.
+ *
+ * @public
+ */
+export interface DoctorBridgeResult {
+  /** Whether this run materially changed disk state. `false` on idempotent re-runs. */
+  bridgeCreated: boolean;
+  /**
+   * Whether `~/.agents/skills` is now a symlink to `~/.claude/skills/agents-shared`.
+   *
+   * @remarks
+   * Always `true` after a successful run. `false` only when `--dry-run` was
+   * requested and the bridge had to be created.
+   */
+  bridgeSymlinkActive: boolean;
+  /** Symlinks created under `~/.claude/skills/agents-shared/` (or planned in dry-run). */
+  perSkillSymlinksCreated: BridgeSymlinkRecord[];
+  /** Per-skill symlinks under `~/.claude/skills/*` that were removed (or planned). */
+  perSkillSymlinksRemoved: PerSkillSymlinkRemoval[];
+  /**
+   * Absolute backup path when the existing `~/.agents/skills` real dir was
+   * relocated to make room for the bridge symlink. `null` when no backup was
+   * needed.
+   */
+  backupPath: string | null;
+  /** `true` when `--dry-run` was passed and no disk state was mutated. */
+  dryRun: boolean;
+  /** Resolved skills root, e.g. `~/.cleo/skills`. */
+  skillsRoot: string;
+  /** Resolved bridge target, e.g. `~/.claude/skills/agents-shared`. */
+  bridgeTarget: string;
+  /** Resolved bridge symlink path, e.g. `~/.agents/skills`. */
+  bridgePath: string;
+}
+
+/**
+ * Dependency-injected options accepted by {@link runDoctorBridge}.
+ *
+ * @public
+ */
+export interface DoctorBridgeOptions {
+  /**
+   * Override the home directory. Defaults to {@link homedir}.
+   *
+   * @remarks
+   * Tests pass a tmpfs root so the bridge logic can be exercised end-to-end
+   * without touching the real user environment.
+   */
+  homeDir?: string;
+  /**
+   * Allow the command to clobber an existing real `~/.agents/skills` directory.
+   *
+   * @remarks
+   * When `false` (the default) and `~/.agents/skills` is a non-empty real
+   * directory, the command refuses with `E_AGENTS_SKILLS_REAL_DIR` to preserve
+   * user data. When `true`, the directory is moved to
+   * `~/.cleo/backups/agents-skills-pre-bridge-<ts>/` before the bridge symlink
+   * is created.
+   *
+   * @defaultValue `false`
+   */
+  force?: boolean;
+  /**
+   * Plan-only mode. When `true`, no disk state is mutated; the result still
+   * lists what WOULD happen.
+   *
+   * @defaultValue `false`
+   */
+  dryRun?: boolean;
+}
+
+/**
+ * Error thrown when {@link runDoctorBridge} refuses to clobber a real
+ * `~/.agents/skills` directory and `--force` was not passed.
+ *
+ * @public
+ */
+export class AgentsSkillsRealDirError extends Error {
+  /** LAFS error code surfaced by the CLI. */
+  public readonly code = 'E_AGENTS_SKILLS_REAL_DIR' as const;
+  /** Resolved path of the offending real directory. */
+  public readonly agentsSkillsPath: string;
+  /** Number of immediate entries in the offending directory. */
+  public readonly entryCount: number;
+
+  /**
+   * Construct an `AgentsSkillsRealDirError`.
+   *
+   * @param agentsSkillsPath - Path to the real `~/.agents/skills` directory.
+   * @param entryCount - Number of entries inside the directory.
+   */
+  constructor(agentsSkillsPath: string, entryCount: number) {
+    super(
+      `Refusing to replace real directory at ${agentsSkillsPath} (${entryCount} entries). Pass --force to back up and bridge.`,
+    );
+    this.name = 'AgentsSkillsRealDirError';
+    this.agentsSkillsPath = agentsSkillsPath;
+    this.entryCount = entryCount;
+  }
+}
+
+/**
+ * Generate a deterministic backup-suffix timestamp `YYYYMMDD-HHmmss` (UTC).
+ *
+ * @remarks
+ * Pulled out as a helper so callers (and tests) can deterministically compute
+ * the expected backup path without re-implementing the format. The string is
+ * UTC so backups taken on different machines round-trip identically.
+ *
+ * @returns Timestamp suffix string for backup directory naming.
+ */
+export function buildBackupTimestamp(): string {
+  const d = new Date();
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+  return (
+    `${d.getUTCFullYear()}` +
+    `${pad(d.getUTCMonth() + 1)}` +
+    `${pad(d.getUTCDate())}` +
+    `-${pad(d.getUTCHours())}` +
+    `${pad(d.getUTCMinutes())}` +
+    `${pad(d.getUTCSeconds())}`
+  );
+}
+
+/**
+ * Resolve the canonical bridge-related paths against a home directory.
+ *
+ * @param homeRoot - Absolute home directory (usually {@link homedir}).
+ * @returns The four absolute paths involved in the bridge topology.
+ */
+function resolveBridgePaths(homeRoot: string): {
+  skillsRoot: string;
+  bridgeTarget: string;
+  bridgePath: string;
+  backupsRoot: string;
+  claudeSkillsRoot: string;
+} {
+  return {
+    skillsRoot: path.join(homeRoot, '.cleo', 'skills'),
+    bridgeTarget: path.join(homeRoot, '.claude', 'skills', 'agents-shared'),
+    bridgePath: path.join(homeRoot, '.agents', 'skills'),
+    backupsRoot: path.join(homeRoot, '.cleo', 'backups'),
+    claudeSkillsRoot: path.join(homeRoot, '.claude', 'skills'),
+  };
+}
+
+/**
+ * Read the immediate subdirectory entries of `~/.cleo/skills/` (skills root).
+ *
+ * @param skillsRoot - Absolute path to `~/.cleo/skills/`.
+ * @returns Array of skill basenames sorted lexicographically; empty when the
+ *   root does not exist.
+ */
+function listSkillDirs(skillsRoot: string): string[] {
+  if (!existsSync(skillsRoot)) return [];
+  const entries = readdirSync(skillsRoot, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory() || e.isSymbolicLink())
+    .map((e) => e.name)
+    .filter((n) => !n.startsWith('.'))
+    .sort();
+}
+
+/**
+ * Determine whether `linkPath` is a symlink that already points at `target`.
+ *
+ * @remarks
+ * Used to make {@link runDoctorBridge} idempotent — re-running on an
+ * already-bridged tree must NOT recreate identical symlinks.
+ *
+ * @param linkPath - Filesystem path to inspect.
+ * @param target - Absolute target the symlink would point at.
+ * @returns `true` when `linkPath` is a symlink resolving to `target`.
+ */
+function symlinkPointsAt(linkPath: string, target: string): boolean {
+  try {
+    const stat = lstatSync(linkPath);
+    if (!stat.isSymbolicLink()) return false;
+    const current = readlinkSync(linkPath);
+    const resolved = path.isAbsolute(current)
+      ? current
+      : path.resolve(path.dirname(linkPath), current);
+    return path.resolve(resolved) === path.resolve(target);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create (or re-create) a symlink so it points at `target`.
+ *
+ * @param linkPath - Path of the symlink to create.
+ * @param target - Absolute path the symlink should point at.
+ * @param dryRun - When `true`, no disk mutation occurs.
+ */
+async function ensureSymlink(linkPath: string, target: string, dryRun: boolean): Promise<void> {
+  if (dryRun) return;
+  await mkdir(path.dirname(linkPath), { recursive: true });
+  if (existsSync(linkPath)) {
+    try {
+      await unlink(linkPath);
+    } catch {
+      // Fall through — symlink() will surface a clearer error if removal failed.
+    }
+  }
+  await symlink(target, linkPath, 'dir');
+}
+
+/**
+ * Count immediate entries in a directory, returning `0` for a missing path.
+ *
+ * @param dir - Directory to inspect.
+ * @returns Entry count, or `0` when the path does not exist.
+ */
+async function countEntries(dir: string): Promise<number> {
+  try {
+    const entries = await readdir(dir);
+    return entries.length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Execute the bridge flow described in the module docblock.
+ *
+ * @remarks
+ * Order of operations:
+ *
+ * 1. Ensure `~/.claude/skills/agents-shared/` exists.
+ * 2. For each skill in `~/.cleo/skills/`, ensure
+ *    `~/.claude/skills/agents-shared/<name>` → `~/.cleo/skills/<name>` exists.
+ * 3. Rip every per-skill entry under `~/.claude/skills/` that is a symlink
+ *    pointing OUTSIDE `agents-shared/` — those are orphans from the old
+ *    per-skill fan-out model and must be deleted.
+ * 4. Replace `~/.agents/skills` with a symlink to `~/.claude/skills/agents-shared`.
+ *    If it is currently a real directory, refuse unless `options.force` is
+ *    `true`, in which case back up to
+ *    `~/.cleo/backups/agents-skills-pre-bridge-<ts>/` first.
+ *
+ * Idempotency invariant: re-running on a fully-bridged tree returns
+ * `{ bridgeCreated: false, bridgeSymlinkActive: true, perSkillSymlinksCreated: [], perSkillSymlinksRemoved: [], backupPath: null }`.
+ *
+ * @param options - Dependency-injected options (homeDir / force / dry-run).
+ * @returns Materialized {@link DoctorBridgeResult} reflecting the run.
+ * @throws AgentsSkillsRealDirError when `~/.agents/skills` is a non-empty real
+ *   directory and `options.force` is not set.
+ *
+ * @example
+ * ```typescript
+ * import { runDoctorBridge } from '@cleocode/caamp';
+ *
+ * const result = await runDoctorBridge({ homeDir: '/tmp/test-home' });
+ * console.log(result.perSkillSymlinksCreated.length); // # of new bridge symlinks
+ * ```
+ *
+ * @public
+ */
+export async function runDoctorBridge(
+  options: DoctorBridgeOptions = {},
+): Promise<DoctorBridgeResult> {
+  const homeRoot = options.homeDir ?? homedir();
+  const force = options.force ?? false;
+  const dryRun = options.dryRun ?? false;
+  const { skillsRoot, bridgeTarget, bridgePath, backupsRoot, claudeSkillsRoot } =
+    resolveBridgePaths(homeRoot);
+
+  // 1. Ensure bridge target dir exists.
+  if (!dryRun) {
+    await mkdir(bridgeTarget, { recursive: true });
+  }
+
+  // 2. Populate agents-shared/ with per-skill symlinks into ~/.cleo/skills/.
+  const skillNames = listSkillDirs(skillsRoot);
+  const created: BridgeSymlinkRecord[] = [];
+  for (const name of skillNames) {
+    const linkPath = path.join(bridgeTarget, name);
+    const target = path.join(skillsRoot, name);
+    if (symlinkPointsAt(linkPath, target)) continue;
+    await ensureSymlink(linkPath, target, dryRun);
+    created.push({ name, linkPath, target });
+  }
+
+  // 3. Rip per-skill symlinks under ~/.claude/skills/<name> that point outside agents-shared/.
+  const removed: PerSkillSymlinkRemoval[] = [];
+  if (existsSync(claudeSkillsRoot)) {
+    const entries = readdirSync(claudeSkillsRoot, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'agents-shared') continue;
+      const entryPath = path.join(claudeSkillsRoot, entry.name);
+      let stat: ReturnType<typeof lstatSync>;
+      try {
+        stat = lstatSync(entryPath);
+      } catch {
+        continue;
+      }
+      if (!stat.isSymbolicLink()) continue;
+      let resolvedTarget: string | null = null;
+      try {
+        const raw = readlinkSync(entryPath);
+        resolvedTarget = path.isAbsolute(raw) ? raw : path.resolve(path.dirname(entryPath), raw);
+      } catch {
+        resolvedTarget = null;
+      }
+      // Keep symlinks that already point inside agents-shared/.
+      if (resolvedTarget !== null) {
+        const realResolved = (() => {
+          try {
+            return realpathSync(resolvedTarget);
+          } catch {
+            return resolvedTarget;
+          }
+        })();
+        if (
+          realResolved === bridgeTarget ||
+          realResolved.startsWith(`${bridgeTarget}${path.sep}`)
+        ) {
+          continue;
+        }
+      }
+      if (!dryRun) {
+        await unlink(entryPath);
+      }
+      removed.push({ linkPath: entryPath, previousTarget: resolvedTarget });
+    }
+  }
+
+  // 4. Establish the single bridge symlink at ~/.agents/skills.
+  let backupPath: string | null = null;
+  const bridgeAlreadyCorrect = symlinkPointsAt(bridgePath, bridgeTarget);
+  let bridgeSymlinkActive = bridgeAlreadyCorrect;
+
+  if (!bridgeAlreadyCorrect) {
+    if (existsSync(bridgePath)) {
+      const lstat = lstatSync(bridgePath);
+      if (lstat.isSymbolicLink()) {
+        // Wrong-target symlink — safe to replace.
+        if (!dryRun) await unlink(bridgePath);
+      } else if (lstat.isDirectory()) {
+        const entryCount = await countEntries(bridgePath);
+        if (entryCount > 0 && !force) {
+          throw new AgentsSkillsRealDirError(bridgePath, entryCount);
+        }
+        // Backup before replacing (only when force OR empty dir; the empty-dir
+        // case also benefits from a copyless rename to keep the audit trail).
+        if (entryCount > 0) {
+          backupPath = path.join(backupsRoot, `agents-skills-pre-bridge-${buildBackupTimestamp()}`);
+          if (!dryRun) {
+            await mkdir(backupsRoot, { recursive: true });
+            await cp(bridgePath, backupPath, { recursive: true, dereference: false });
+            await rm(bridgePath, { recursive: true, force: true });
+          }
+        } else if (!dryRun) {
+          await rm(bridgePath, { recursive: true, force: true });
+        }
+      } else if (!dryRun) {
+        // Regular file at ~/.agents/skills — refuse silently? Better: unlink.
+        await unlink(bridgePath);
+      }
+    }
+    if (!dryRun) {
+      await mkdir(path.dirname(bridgePath), { recursive: true });
+      await symlink(bridgeTarget, bridgePath, 'dir');
+      bridgeSymlinkActive = true;
+    }
+  }
+
+  return {
+    bridgeCreated: !bridgeAlreadyCorrect,
+    bridgeSymlinkActive,
+    perSkillSymlinksCreated: created,
+    perSkillSymlinksRemoved: removed,
+    backupPath,
+    dryRun,
+    skillsRoot,
+    bridgeTarget,
+    bridgePath,
+  };
+}
+
+/**
+ * Print a human-friendly summary of the bridge run to stdout.
+ *
+ * @param result - Result of {@link runDoctorBridge}.
+ */
+function printHumanSummary(result: DoctorBridgeResult): void {
+  if (result.dryRun) {
+    console.log(pc.dim('(dry-run — no disk state mutated)'));
+  }
+  if (!result.bridgeCreated && result.perSkillSymlinksCreated.length === 0) {
+    console.log(pc.green('Bridge already correct — nothing to do.'));
+  } else {
+    console.log(pc.green('Bridge configured.'));
+  }
+  console.log(`  ${pc.dim('bridge:')} ${result.bridgePath} -> ${result.bridgeTarget}`);
+  console.log(
+    `  ${pc.dim('per-skill symlinks created:')} ${result.perSkillSymlinksCreated.length}`,
+  );
+  console.log(
+    `  ${pc.dim('per-skill symlinks removed:')} ${result.perSkillSymlinksRemoved.length}`,
+  );
+  if (result.backupPath) {
+    console.log(`  ${pc.yellow('backup:')} ${result.backupPath}`);
+  }
+}
+
+/**
+ * Register the `skills doctor bridge` subcommand on a parent `doctor` group.
+ *
+ * @remarks
+ * Wires the LAFS-compliant CLI surface around {@link runDoctorBridge}. The
+ * handler is split out so the implementation can be reused by the citty-based
+ * `cleo skills doctor bridge` wrapper in `packages/cleo`.
+ *
+ * @param parent - Parent Commander command (the `doctor` subgroup).
+ *
+ * @example
+ * ```bash
+ * caamp skills doctor bridge            # refuses if ~/.agents/skills is a real dir
+ * caamp skills doctor bridge --force    # backs up + bridges
+ * caamp skills doctor bridge --dry-run  # plan-only
+ * ```
+ *
+ * @public
+ */
+export function registerDoctorBridge(parent: Command): void {
+  parent
+    .command('bridge')
+    .description('Create the single ~/.agents/skills bridge symlink and rip per-skill symlinks')
+    .option('--force', 'Back up and replace a real ~/.agents/skills directory if present')
+    .option('--dry-run', 'Print planned actions without mutating disk state')
+    .option('--json', 'Output as JSON (default)')
+    .option('--human', 'Output in human-readable format')
+    .action(
+      async (opts: { force?: boolean; dryRun?: boolean; json?: boolean; human?: boolean }) => {
+        const operation = 'skills.doctor.bridge';
+        const mvi: import('../../core/lafs.js').MVILevel = 'standard';
+
+        let format: 'json' | 'human';
+        try {
+          format = resolveFormat({
+            jsonFlag: opts.json ?? false,
+            humanFlag: opts.human ?? false,
+            projectDefault: 'json',
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          emitJsonError(
+            operation,
+            mvi,
+            ErrorCodes.FORMAT_CONFLICT,
+            message,
+            ErrorCategories.VALIDATION,
+          );
+          process.exit(1);
+        }
+
+        try {
+          const result = await runDoctorBridge({
+            force: opts.force ?? false,
+            dryRun: opts.dryRun ?? false,
+          });
+          if (format === 'json') {
+            outputSuccess(operation, mvi, result);
+          } else {
+            printHumanSummary(result);
+          }
+        } catch (error) {
+          if (error instanceof AgentsSkillsRealDirError) {
+            if (format === 'json') {
+              emitJsonError(operation, mvi, error.code, error.message, ErrorCategories.CONFLICT, {
+                agentsSkillsPath: error.agentsSkillsPath,
+                entryCount: error.entryCount,
+              });
+            } else {
+              console.error(pc.red(error.message));
+            }
+            process.exit(1);
+          }
+          const message = error instanceof Error ? error.message : String(error);
+          if (format === 'json') {
+            emitJsonError(
+              operation,
+              mvi,
+              ErrorCodes.INTERNAL_ERROR,
+              message,
+              ErrorCategories.INTERNAL,
+            );
+          } else {
+            console.error(pc.red(message));
+          }
+          process.exit(1);
+        }
+      },
+    );
+}

--- a/packages/caamp/src/commands/skills/doctor.ts
+++ b/packages/caamp/src/commands/skills/doctor.ts
@@ -1,0 +1,41 @@
+/**
+ * `cleo skills doctor` — diagnostic and remediation subcommands for the skill
+ * storage topology.
+ *
+ * @remarks
+ * This module hosts the `doctor` Commander group. Individual subcommands
+ * (`diagnose`, `migrate`, `bridge`, `adopt-orphans`) are owned by separate
+ * modules and attached here so the group can be re-used by both the
+ * standalone `caamp` CLI and the `cleo` citty CLI in `packages/cleo`.
+ *
+ * @see {@link docs/architecture/SG-CLEO-SKILLS-architecture-v3.md} §1
+ * @task T9655
+ * @epic T9571
+ */
+
+import type { Command } from 'commander';
+import { registerDoctorBridge } from './doctor-bridge.js';
+
+/**
+ * Register the `doctor` subcommand group on the parent `skills` command.
+ *
+ * @remarks
+ * Wires every `skills doctor <verb>` subcommand. New verbs (`diagnose`,
+ * `migrate`, `adopt-orphans`, …) should attach themselves here so the
+ * surface remains discoverable via `caamp skills doctor --help`.
+ *
+ * @param parent - The parent `skills` Commander group.
+ *
+ * @example
+ * ```bash
+ * caamp skills doctor bridge
+ * ```
+ *
+ * @public
+ */
+export function registerSkillsDoctor(parent: Command): void {
+  const doctor = parent
+    .command('doctor')
+    .description('Diagnose and repair the skill storage topology');
+  registerDoctorBridge(doctor);
+}

--- a/packages/caamp/src/commands/skills/index.ts
+++ b/packages/caamp/src/commands/skills/index.ts
@@ -8,6 +8,7 @@
 import type { Command } from 'commander';
 import { registerSkillsAudit } from './audit.js';
 import { registerSkillsCheck } from './check.js';
+import { registerSkillsDoctor } from './doctor.js';
 import { registerSkillsDoctorMigrate } from './doctor-migrate.js';
 import { registerSkillsFind } from './find.js';
 import { registerSkillsInit } from './init.js';
@@ -48,4 +49,5 @@ export function registerSkillsCommands(program: Command): void {
   registerSkillsAudit(skills);
   registerSkillsValidate(skills);
   registerSkillsDoctorMigrate(skills);
+  registerSkillsDoctor(skills);
 }

--- a/packages/caamp/src/index.ts
+++ b/packages/caamp/src/index.ts
@@ -7,6 +7,18 @@
  */
 
 export type {
+  BridgeSymlinkRecord,
+  DoctorBridgeOptions,
+  DoctorBridgeResult,
+  PerSkillSymlinkRemoval,
+} from './commands/skills/doctor-bridge.js';
+// Skills doctor — bridge subcommand (T9655)
+export {
+  AgentsSkillsRealDirError,
+  buildBackupTimestamp,
+  runDoctorBridge,
+} from './commands/skills/doctor-bridge.js';
+export type {
   BatchInstallOptions,
   BatchInstallResult,
   InstructionUpdateSummary,

--- a/packages/caamp/tests/unit/doctor-bridge.test.ts
+++ b/packages/caamp/tests/unit/doctor-bridge.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for `cleo skills doctor bridge` — single bridge symlink topology.
+ *
+ * @task T9655
+ * @epic T9571
+ */
+
+import { existsSync, lstatSync, readdirSync, readlinkSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  AgentsSkillsRealDirError,
+  buildBackupTimestamp,
+  runDoctorBridge,
+} from '../../src/commands/skills/doctor-bridge.js';
+
+let homeDir: string;
+
+/**
+ * Build a minimal `~/.cleo/skills/<name>/SKILL.md` fixture inside `homeDir`.
+ */
+async function seedSkill(name: string, content = `---\nname: ${name}\n---\n`): Promise<string> {
+  const dir = join(homeDir, '.cleo', 'skills', name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'SKILL.md'), content);
+  return dir;
+}
+
+beforeEach(async () => {
+  homeDir = await mkdtemp(join(tmpdir(), 'doctor-bridge-'));
+});
+
+afterEach(async () => {
+  await rm(homeDir, { recursive: true, force: true }).catch(() => undefined);
+});
+
+describe('buildBackupTimestamp', () => {
+  it('produces a UTC YYYYMMDD-HHmmss string', () => {
+    const ts = buildBackupTimestamp();
+    expect(ts).toMatch(/^\d{8}-\d{6}$/);
+  });
+});
+
+describe('runDoctorBridge — fresh install', () => {
+  it('creates the bridge symlink and populates agents-shared/ with per-skill symlinks', async () => {
+    await seedSkill('ct-orchestrator');
+    await seedSkill('ct-lead');
+
+    const result = await runDoctorBridge({ homeDir });
+
+    expect(result.bridgeCreated).toBe(true);
+    expect(result.bridgeSymlinkActive).toBe(true);
+    expect(result.dryRun).toBe(false);
+    expect(result.backupPath).toBeNull();
+    expect(result.perSkillSymlinksCreated.map((r) => r.name).sort()).toEqual([
+      'ct-lead',
+      'ct-orchestrator',
+    ]);
+
+    const bridgePath = join(homeDir, '.agents', 'skills');
+    const bridgeTarget = join(homeDir, '.claude', 'skills', 'agents-shared');
+    expect(lstatSync(bridgePath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(bridgePath)).toBe(bridgeTarget);
+
+    expect(existsSync(join(bridgeTarget, 'ct-orchestrator', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(bridgeTarget, 'ct-lead', 'SKILL.md'))).toBe(true);
+  });
+
+  it('handles empty skills root without error', async () => {
+    const result = await runDoctorBridge({ homeDir });
+    expect(result.bridgeCreated).toBe(true);
+    expect(result.perSkillSymlinksCreated).toEqual([]);
+  });
+});
+
+describe('runDoctorBridge — idempotency', () => {
+  it('re-runs are a no-op on an already-bridged tree', async () => {
+    await seedSkill('ct-foo');
+    await runDoctorBridge({ homeDir });
+    const second = await runDoctorBridge({ homeDir });
+
+    expect(second.bridgeCreated).toBe(false);
+    expect(second.bridgeSymlinkActive).toBe(true);
+    expect(second.perSkillSymlinksCreated).toEqual([]);
+    expect(second.perSkillSymlinksRemoved).toEqual([]);
+    expect(second.backupPath).toBeNull();
+  });
+});
+
+describe('runDoctorBridge — per-skill symlink reap', () => {
+  it('rips per-skill symlinks under ~/.claude/skills/* that point outside agents-shared/', async () => {
+    await seedSkill('ct-foo');
+    // Plant an orphan per-skill symlink at ~/.claude/skills/ct-orphan -> some other dir.
+    const elsewhere = join(homeDir, 'somewhere', 'ct-orphan');
+    await mkdir(elsewhere, { recursive: true });
+    await mkdir(join(homeDir, '.claude', 'skills'), { recursive: true });
+    await symlink(elsewhere, join(homeDir, '.claude', 'skills', 'ct-orphan'), 'dir');
+
+    const result = await runDoctorBridge({ homeDir });
+
+    expect(result.perSkillSymlinksRemoved).toHaveLength(1);
+    expect(result.perSkillSymlinksRemoved[0]?.linkPath).toBe(
+      join(homeDir, '.claude', 'skills', 'ct-orphan'),
+    );
+    expect(existsSync(join(homeDir, '.claude', 'skills', 'ct-orphan'))).toBe(false);
+    // The actual target dir still exists — we only remove the symlink.
+    expect(existsSync(elsewhere)).toBe(true);
+  });
+
+  it('keeps per-skill symlinks that already point inside agents-shared/', async () => {
+    await seedSkill('ct-foo');
+    // Pre-create a valid per-skill symlink under .claude/skills/ that points into agents-shared.
+    const bridgeTarget = join(homeDir, '.claude', 'skills', 'agents-shared');
+    await mkdir(bridgeTarget, { recursive: true });
+    await mkdir(join(homeDir, '.claude', 'skills'), { recursive: true });
+    // No additional symlink — runDoctorBridge will create the agents-shared symlinks itself.
+    // Add a non-symlink dir as a control — it should be preserved.
+    await mkdir(join(homeDir, '.claude', 'skills', 'real-dir'), { recursive: true });
+
+    const result = await runDoctorBridge({ homeDir });
+
+    expect(result.perSkillSymlinksRemoved).toEqual([]);
+    // Real directory is left alone (we only rip symlinks).
+    expect(existsSync(join(homeDir, '.claude', 'skills', 'real-dir'))).toBe(true);
+  });
+});
+
+describe('runDoctorBridge — refuses to clobber a real ~/.agents/skills', () => {
+  it('throws AgentsSkillsRealDirError when ~/.agents/skills is a real dir with content', async () => {
+    await seedSkill('ct-foo');
+    const realDir = join(homeDir, '.agents', 'skills');
+    await mkdir(realDir, { recursive: true });
+    await writeFile(join(realDir, 'user-precious.md'), 'do not delete');
+
+    await expect(runDoctorBridge({ homeDir })).rejects.toBeInstanceOf(AgentsSkillsRealDirError);
+    // User content preserved.
+    expect(existsSync(join(realDir, 'user-precious.md'))).toBe(true);
+  });
+
+  it('with --force, backs up real ~/.agents/skills then bridges', async () => {
+    await seedSkill('ct-foo');
+    const realDir = join(homeDir, '.agents', 'skills');
+    await mkdir(realDir, { recursive: true });
+    await writeFile(join(realDir, 'user-precious.md'), 'do not delete');
+
+    const result = await runDoctorBridge({ homeDir, force: true });
+
+    expect(result.bridgeCreated).toBe(true);
+    expect(result.bridgeSymlinkActive).toBe(true);
+    expect(result.backupPath).not.toBeNull();
+    if (result.backupPath !== null) {
+      expect(result.backupPath).toMatch(/agents-skills-pre-bridge-/);
+      expect(existsSync(join(result.backupPath, 'user-precious.md'))).toBe(true);
+    }
+    // Bridge symlink is in place.
+    expect(lstatSync(realDir).isSymbolicLink()).toBe(true);
+  });
+
+  it('treats an empty real ~/.agents/skills dir as safe to replace without --force', async () => {
+    await seedSkill('ct-foo');
+    const realDir = join(homeDir, '.agents', 'skills');
+    await mkdir(realDir, { recursive: true });
+
+    const result = await runDoctorBridge({ homeDir });
+    expect(result.backupPath).toBeNull();
+    expect(lstatSync(realDir).isSymbolicLink()).toBe(true);
+  });
+});
+
+describe('runDoctorBridge — repairs wrong-target bridge symlink', () => {
+  it('replaces an existing symlink that points at the wrong target', async () => {
+    await seedSkill('ct-foo');
+    const bridgePath = join(homeDir, '.agents', 'skills');
+    const wrongTarget = join(homeDir, 'wrong');
+    await mkdir(wrongTarget, { recursive: true });
+    await mkdir(join(homeDir, '.agents'), { recursive: true });
+    await symlink(wrongTarget, bridgePath, 'dir');
+
+    const result = await runDoctorBridge({ homeDir });
+
+    expect(result.bridgeCreated).toBe(true);
+    expect(readlinkSync(bridgePath)).toBe(join(homeDir, '.claude', 'skills', 'agents-shared'));
+  });
+});
+
+describe('runDoctorBridge — dry-run', () => {
+  it('mutates nothing on disk and still reports planned actions', async () => {
+    await seedSkill('ct-foo');
+    const result = await runDoctorBridge({ homeDir, dryRun: true });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.bridgeCreated).toBe(true);
+    expect(result.perSkillSymlinksCreated).toHaveLength(1);
+    expect(existsSync(join(homeDir, '.agents', 'skills'))).toBe(false);
+    expect(existsSync(join(homeDir, '.claude', 'skills', 'agents-shared', 'ct-foo'))).toBe(false);
+  });
+});
+
+describe('runDoctorBridge — output shape', () => {
+  it('returns a fully populated DoctorBridgeResult', async () => {
+    await seedSkill('ct-foo');
+    const result = await runDoctorBridge({ homeDir });
+
+    expect(result).toMatchObject({
+      bridgeCreated: true,
+      bridgeSymlinkActive: true,
+      perSkillSymlinksCreated: expect.any(Array),
+      perSkillSymlinksRemoved: expect.any(Array),
+      backupPath: null,
+      dryRun: false,
+      skillsRoot: join(homeDir, '.cleo', 'skills'),
+      bridgeTarget: join(homeDir, '.claude', 'skills', 'agents-shared'),
+      bridgePath: join(homeDir, '.agents', 'skills'),
+    });
+  });
+});
+
+describe('runDoctorBridge — sanity on existing agents-shared/', () => {
+  it('does not touch a non-symlink directory like agents-shared itself', async () => {
+    await seedSkill('ct-foo');
+    // agents-shared is created as a real dir by step 1; step 3 must skip it.
+    const result = await runDoctorBridge({ homeDir });
+    const bridgeTarget = join(homeDir, '.claude', 'skills', 'agents-shared');
+    expect(existsSync(bridgeTarget)).toBe(true);
+    // Sanity: agents-shared not removed; it is a real dir (not a symlink).
+    expect(lstatSync(bridgeTarget).isDirectory()).toBe(true);
+    expect(result.perSkillSymlinksRemoved.map((r) => r.linkPath)).not.toContain(bridgeTarget);
+  });
+
+  it('lists skill entries lexicographically', async () => {
+    await seedSkill('ct-z');
+    await seedSkill('ct-a');
+    await seedSkill('ct-m');
+    const result = await runDoctorBridge({ homeDir });
+    expect(result.perSkillSymlinksCreated.map((r) => r.name)).toEqual(['ct-a', 'ct-m', 'ct-z']);
+  });
+
+  it('ignores dotfiles in skills root', async () => {
+    await seedSkill('ct-foo');
+    await mkdir(join(homeDir, '.cleo', 'skills', '.hidden'), { recursive: true });
+    const result = await runDoctorBridge({ homeDir });
+    expect(result.perSkillSymlinksCreated.map((r) => r.name)).toEqual(['ct-foo']);
+    expect(
+      readdirSync(join(homeDir, '.claude', 'skills', 'agents-shared')).sort(),
+    ).toEqual(['ct-foo']);
+  });
+});

--- a/packages/cleo/src/cli/commands/skills.ts
+++ b/packages/cleo/src/cli/commands/skills.ts
@@ -22,6 +22,7 @@
  * @epic T4545
  */
 
+import { AgentsSkillsRealDirError, runDoctorBridge } from '@cleocode/caamp';
 import { defineCommand } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
 import { isSubCommandDispatch } from '../lib/subcommand-guard.js';
@@ -346,6 +347,81 @@ const depsCommand = defineCommand({
   },
 });
 
+/**
+ * cleo skills doctor bridge — single bridge symlink + per-skill symlink removal (T9655).
+ */
+const doctorBridgeCommand = defineCommand({
+  meta: {
+    name: 'bridge',
+    description:
+      'Create the single ~/.agents/skills bridge symlink + remove orphan per-skill symlinks',
+  },
+  args: {
+    force: {
+      type: 'boolean',
+      description: 'Back up and replace a real ~/.agents/skills directory if present',
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Print planned actions without mutating disk state',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON (default)',
+    },
+    human: {
+      type: 'boolean',
+      description: 'Output in human-readable format',
+    },
+  },
+  async run({ args }) {
+    const { cliError, cliOutput } = await import('../renderers/index.js');
+    try {
+      const result = await runDoctorBridge({
+        force: args.force === true,
+        dryRun: args['dry-run'] === true,
+      });
+      cliOutput(
+        { success: true, data: result },
+        { command: 'skills doctor bridge', operation: 'skills.doctor.bridge' },
+      );
+    } catch (error) {
+      if (error instanceof AgentsSkillsRealDirError) {
+        cliError(
+          error.message,
+          error.code,
+          {
+            details: {
+              agentsSkillsPath: error.agentsSkillsPath,
+              entryCount: error.entryCount,
+            },
+          },
+          { operation: 'skills.doctor.bridge' },
+        );
+        process.exit(1);
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      cliError(message, 'E_INTERNAL_ERROR', undefined, {
+        operation: 'skills.doctor.bridge',
+      });
+      process.exit(1);
+    }
+  },
+});
+
+/**
+ * cleo skills doctor — diagnose and repair skill storage topology (parent group, T9655).
+ */
+const doctorCommand = defineCommand({
+  meta: {
+    name: 'doctor',
+    description: 'Diagnose and repair the skill storage topology',
+  },
+  subCommands: {
+    bridge: doctorBridgeCommand,
+  },
+});
+
 /** cleo skills spawn-providers — list providers capable of spawning subagents */
 const spawnProvidersCommand = defineCommand({
   meta: { name: 'spawn-providers', description: 'List providers capable of spawning subagents' },
@@ -390,6 +466,7 @@ export const skillsCommand = defineCommand({
     precedence: precedenceCommand,
     deps: depsCommand,
     'spawn-providers': spawnProvidersCommand,
+    doctor: doctorCommand,
   },
   async run({ cmd, rawArgs }) {
     // Parent run() fires after subcommand per citty@0.2.x — skip default


### PR DESCRIPTION
## Summary

Implements **T9655** (T-STORE-5) under epic **T9571** / saga **T9560**: `cleo skills doctor bridge` establishes the canonical discovery topology described in `docs/architecture/SG-CLEO-SKILLS-architecture-v3.md` §1.

### Bridge flow
1. Ensures `~/.claude/skills/agents-shared/` exists.
2. Creates per-skill symlinks under `agents-shared/<name>` → `~/.cleo/skills/<name>` for every skill in the user-machine install root.
3. Rips orphan per-skill symlinks under `~/.claude/skills/*` that point OUTSIDE `agents-shared/` (legacy per-skill fan-out cleanup).
4. Replaces `~/.agents/skills` with a single symlink → `~/.claude/skills/agents-shared` (the bridge for non-Claude harnesses).

### Safety guarantees
- **Refuses by default** when `~/.agents/skills` is a real directory with contents (owner machine has 88+ entries — data preservation).
- **`--force`** backs up the existing dir to `~/.cleo/backups/agents-skills-pre-bridge-YYYYMMDD-HHmmss/` before clobbering.
- **`--dry-run`** plans without mutating disk.
- **Idempotent** — re-running on an already-bridged tree returns `{bridgeCreated: false, perSkillSymlinksCreated: [], perSkillSymlinksRemoved: []}`.
- **LAFS envelope** on all JSON output.
- New CLI surface: `caamp skills doctor bridge` AND `cleo skills doctor bridge`.

### State-before / state-after

**Before:**
```
~/.cleo/skills/ct-foo/
~/.cleo/skills/ct-bar/
~/.agents/skills/                  (REAL DIR — 88 entries)
~/.claude/skills/ct-foo  → /elsewhere/ct-foo
~/.claude/skills/ct-orphan → /elsewhere/ct-orphan
```

**After (`--force`):**
```
~/.cleo/skills/ct-foo/
~/.cleo/skills/ct-bar/
~/.agents/skills                   → ~/.claude/skills/agents-shared (SYMLINK — single bridge)
~/.claude/skills/agents-shared/
~/.claude/skills/agents-shared/ct-foo → ~/.cleo/skills/ct-foo
~/.claude/skills/agents-shared/ct-bar → ~/.cleo/skills/ct-bar
~/.cleo/backups/agents-skills-pre-bridge-20260519-170646/  (88 entries preserved)
```

## Files

- `packages/caamp/src/commands/skills/doctor-bridge.ts` — handler + `runDoctorBridge()` reusable export
- `packages/caamp/src/commands/skills/doctor.ts` — `doctor` Commander group (first subcommand)
- `packages/caamp/src/commands/skills/index.ts` — registers the group
- `packages/caamp/src/index.ts` — public exports of `runDoctorBridge`, `AgentsSkillsRealDirError`, types
- `packages/caamp/tests/unit/doctor-bridge.test.ts` — 15 tests (fresh install, idempotency, per-skill rip, refuses real dir, --force backup, wrong-target repair, dry-run, sorting, dotfile filter)
- `packages/cleo/src/cli/commands/skills.ts` — citty wire-up for `cleo skills doctor bridge`

## Test plan

- [x] `pnpm exec vitest run tests/unit/doctor-bridge.test.ts` — **15/15 passing**
- [x] `pnpm --filter @cleocode/caamp run typecheck` — clean
- [x] `pnpm --filter @cleocode/caamp run build` — green
- [x] Real CLI smoke test against tmpdir HOME — emits valid LAFS envelope
- [x] Existing skills tests (`tests/integration/skills-commands.test.ts`, `tests/unit/skills-installer.test.ts`) — 70/74 passing (4 pre-existing skipped, no regressions)
- [x] Biome `check --write` on changed files

## Notes

- Handler is dependency-injected via `homeDir` option so tests exercise the full flow against tmpfs without touching real `$HOME`.
- `is_canonical()`-style write-guard is NOT needed in this command (it's a pure topology repair, not a skill mutation).
- T9651 (skills.db) is not yet implemented; the bridge therefore enumerates `~/.cleo/skills/` directly via filesystem rather than via db rows. A follow-up tightening is easy once T9651 lands (just swap the `listSkillDirs()` source).