### PR TITLE
feat(T9657): cleo skills doctor adopt-orphans — interactive orphan audit

### DIFF
--- a/packages/caamp/src/commands/skills/doctor-adopt.ts
+++ b/packages/caamp/src/commands/skills/doctor-adopt.ts
@@ -1,0 +1,977 @@
+/**
+ * `skills doctor adopt-orphans` — interactive orphan audit + adoption.
+ *
+ * @remarks
+ * An "orphan" is a skill directory that exists under any tracked path
+ * (`~/.cleo/skills/`, legacy `~/.local/share/agents/skills/`,
+ * `~/.agents/skills/` as a real dir) but has NO row in the per-user
+ * `skills.db` registry described in
+ * `docs/architecture/SG-CLEO-SKILLS-architecture-v3.md` §4.
+ *
+ * The handler offers four per-orphan dispositions:
+ *
+ *   - **canonical-adopt** — REFUSED on a user machine. Canonical writes
+ *     must flow via PR to `packages/skills/skills/` (architecture-v3 §6
+ *     invariant). The handler emits a refusal explaining the PR flow.
+ *   - **user-adopt** — inserts a row into `skills.db` with
+ *     `source_type='user'`, `lifecycle_state='active'`, `installedAt=now`.
+ *   - **delete** — archives the directory to
+ *     `~/.cleo/skills/.archive/<name>-<ts>/` before unlinking from the
+ *     original location.
+ *   - **skip** — no action; the orphan is logged but otherwise ignored.
+ *
+ * All decisions are recorded to a structured JSON audit log at
+ * `~/.cleo/skills/.audit-log/adopt-<ISO-ts>.json` regardless of mode.
+ *
+ * ## Chokepoint compliance (ADR-068)
+ *
+ * This module emits PURE DATA. The skills.db reads and writes are deferred
+ * to caller-supplied callbacks (`loadRegisteredNames`, `recordRow`). The
+ * `cleo` dispatch layer in `packages/cleo/src/cli/commands/skills.ts` plugs
+ * the canonical `openCleoDb('skills')`/`upsertSkillRow` helpers from
+ * `@cleocode/core/store/skills-db`. caamp cannot depend on `@cleocode/core`
+ * directly (would invert the dep direction: core dynamically imports caamp).
+ *
+ * Three execution modes:
+ *
+ *   - default (TTY) — interactive prompt per orphan.
+ *   - `--non-interactive` — list orphans and exit without action
+ *     (read-only audit).
+ *   - `--auto-user-adopt` — bulk user-adopt all orphans without prompting
+ *     (safe default for `cleo-init`-style scripts).
+ *
+ * @task T9657
+ * @epic T9571
+ * @saga T9560
+ * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §1, §6
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import type { Command } from 'commander';
+import pc from 'picocolors';
+
+import {
+  ErrorCategories,
+  ErrorCodes,
+  emitJsonError,
+  handleFormatError,
+  outputSuccess,
+  resolveFormat,
+} from '../../core/lafs.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * One orphan disposition decision.
+ *
+ * @public
+ */
+export type OrphanDecision = 'canonical-adopt' | 'user-adopt' | 'delete' | 'skip';
+
+/**
+ * Reason an action was refused (canonical-adopt on user machine, etc.).
+ *
+ * @public
+ */
+export interface OrphanRefusal {
+  /** Stable code for programmatic handling. */
+  code: 'E_CANONICAL_ADOPT_REFUSED';
+  /** Human-readable explanation. */
+  message: string;
+  /** Suggested next step (e.g. PR flow). */
+  remediation: string;
+}
+
+/**
+ * A single orphan skill directory discovered on disk.
+ *
+ * @public
+ */
+export interface OrphanRecord {
+  /** Skill name (basename of the orphan directory). */
+  name: string;
+  /** Absolute path to the orphan directory on disk. */
+  path: string;
+  /** Which tracked root this orphan was discovered under. */
+  discoveredVia: 'cleo' | 'legacy-agents' | 'home-agents';
+  /** Whether a `SKILL.md` sentinel exists at the root. */
+  hasSkillMd: boolean;
+  /** Size of the directory in bytes (best-effort; 0 on stat failure). */
+  sizeBytes: number;
+}
+
+/**
+ * Outcome of acting on a single orphan.
+ *
+ * @public
+ */
+export interface OrphanActionResult {
+  /** The orphan that was acted upon. */
+  orphan: OrphanRecord;
+  /** Decision the user (or flag) made. */
+  decision: OrphanDecision;
+  /** Whether the action completed successfully. */
+  applied: boolean;
+  /** Refusal payload when `applied=false` due to a policy block. */
+  refusal: OrphanRefusal | null;
+  /** Where the directory was archived to (delete only). */
+  archivedTo: string | null;
+  /** ISO-8601 timestamp when the action was taken. */
+  decidedAt: string;
+}
+
+/**
+ * Top-level result returned in the LAFS envelope.
+ *
+ * @public
+ */
+export interface DoctorAdoptResult {
+  /** Total orphans discovered. */
+  totalOrphans: number;
+  /** Per-orphan action results. */
+  results: OrphanActionResult[];
+  /** Audit log file path (always written). */
+  auditLogPath: string;
+  /** Execution mode used. */
+  mode: 'interactive' | 'non-interactive' | 'auto-user-adopt';
+}
+
+/**
+ * Pure-data payload emitted when a `user-adopt` decision is applied.
+ *
+ * @remarks
+ * The dispatch layer translates this into an `upsertSkillRow` call via the
+ * `openCleoDb('skills')` chokepoint. Keeping it as pure data means caamp
+ * never has to touch sqlite directly.
+ *
+ * @public
+ */
+export interface AdoptedSkillRowData {
+  /** Skill name (PK in skills.db). */
+  name: string;
+  /** Absolute install path on disk. */
+  installPath: string;
+  /** Wall-clock timestamp the adoption occurred. */
+  installedAt: string;
+  /** Always `'user'` for the adopt-orphans flow (canonical is refused). */
+  sourceType: 'user';
+  /** Always `'active'` post-adoption. */
+  lifecycleState: 'active';
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the preferred user-machine skills root at `~/.cleo/skills/`.
+ *
+ * @remarks
+ * Mirrors `resolveSkillsRoot()` from `@cleocode/core/skills/skill-root` but
+ * stays self-contained inside CAAMP so doctor-adopt does not introduce a
+ * static dependency on `@cleocode/core` (which would create a cycle since
+ * core dynamically imports caamp).
+ *
+ * @returns Absolute path to `~/.cleo/skills/`.
+ *
+ * @internal
+ */
+function cleoSkillsRoot(): string {
+  return join(homedir(), '.cleo', 'skills'); // path-drift-allowed: ~/.cleo symlink is the canonical bootstrap target — mirrors core/src/skills/skill-root.ts newSkillsPath()
+}
+
+/**
+ * Compute the legacy XDG canonical skills directory.
+ *
+ * @returns Absolute path to `~/.local/share/agents/skills/`.
+ *
+ * @internal
+ */
+function legacyAgentsSkillsRoot(): string {
+  return join(homedir(), '.local', 'share', 'agents', 'skills');
+}
+
+/**
+ * Compute the user-level `~/.agents/skills/` directory.
+ *
+ * @remarks
+ * In architecture-v3 §1, this path SHOULD be a single symlink that points
+ * at `~/.claude/skills/agents-shared/`. Some user machines still have it
+ * as a real directory with 88+ entries (per architecture-v3 §1 LEGACY
+ * note), in which case its contents are also orphan candidates.
+ *
+ * @returns Absolute path to `~/.agents/skills/`.
+ *
+ * @internal
+ */
+function homeAgentsSkillsRoot(): string {
+  return join(homedir(), '.agents', 'skills');
+}
+
+/**
+ * Compute the archive directory for soft-deleted orphans.
+ *
+ * @returns Absolute path to `~/.cleo/skills/.archive/`.
+ *
+ * @internal
+ */
+function archiveRoot(): string {
+  return join(cleoSkillsRoot(), '.archive');
+}
+
+/**
+ * Compute the audit-log directory.
+ *
+ * @returns Absolute path to `~/.cleo/skills/.audit-log/`.
+ *
+ * @internal
+ */
+function auditLogRoot(): string {
+  return join(cleoSkillsRoot(), '.audit-log');
+}
+
+// ---------------------------------------------------------------------------
+// Orphan detection
+// ---------------------------------------------------------------------------
+
+/**
+ * List candidate skill directory entries under a given root.
+ *
+ * @remarks
+ * "Candidates" are immediate-children entries that are either real
+ * directories OR symlinks resolving to a directory. Hidden entries
+ * (leading dot) and known sentinel folders (`.archive`, `.audit-log`,
+ * `.git`) are skipped so the doctor does not consider its own bookkeeping
+ * as orphans.
+ *
+ * @param root - Absolute path of the tracked skills root to scan.
+ * @returns Array of `{name, path}` pairs; empty when `root` is absent or
+ *   unreadable.
+ *
+ * @internal
+ */
+function listCandidates(root: string): Array<{ name: string; path: string }> {
+  if (!existsSync(root)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return [];
+  }
+  const out: Array<{ name: string; path: string }> = [];
+  for (const name of entries) {
+    if (name.startsWith('.')) continue; // .archive, .audit-log, .git, .DS_Store
+    const full = join(root, name);
+    let isDirLike = false;
+    try {
+      const stat = lstatSync(full);
+      if (stat.isDirectory()) {
+        isDirLike = true;
+      } else if (stat.isSymbolicLink()) {
+        try {
+          const real = statSync(full);
+          isDirLike = real.isDirectory();
+        } catch {
+          // dangling symlink — not a skill, skip
+          isDirLike = false;
+        }
+      }
+    } catch {
+      isDirLike = false;
+    }
+    if (isDirLike) {
+      out.push({ name, path: full });
+    }
+  }
+  return out;
+}
+
+/**
+ * Compute a best-effort byte size for a directory.
+ *
+ * @remarks
+ * Sums file sizes via a non-recursive single-pass `readdirSync`. This is
+ * intentionally shallow — orphan adoption only needs a rough sense of
+ * footprint, not a precise du(1) figure. Returns `0` on any stat failure
+ * so the audit log never blocks on permission errors.
+ *
+ * @param dir - Absolute path of the directory to size.
+ * @returns Approximate byte count, always finite.
+ *
+ * @internal
+ */
+function approxDirSize(dir: string): number {
+  let total = 0;
+  try {
+    const entries = readdirSync(dir);
+    for (const entry of entries) {
+      try {
+        const stat = statSync(join(dir, entry));
+        if (stat.isFile()) total += stat.size;
+      } catch {
+        // skip unreadable entries
+      }
+    }
+  } catch {
+    return 0;
+  }
+  return total;
+}
+
+/**
+ * Discover orphan skills across all tracked roots.
+ *
+ * @remarks
+ * Visits the three tracked roots in priority order and de-duplicates by
+ * basename — the first occurrence of `<name>` wins (so a `~/.cleo/skills/`
+ * entry shadows the same-named legacy entry). Symlinks under
+ * `~/.agents/skills/` that resolve back into `~/.cleo/skills/` are dropped
+ * because those are the bridge symlinks, not real orphans.
+ *
+ * Read-side IO (the set of names already known to `skills.db`) is supplied
+ * via the `registeredNames` callback so this module never opens sqlite
+ * directly — see ADR-068 chokepoint compliance in the file header.
+ *
+ * @param registeredNames - Pre-computed set of skill names known to the
+ *   registry. Callers in production wire this through `openCleoDb('skills')`;
+ *   tests wire it through a sandboxed `DatabaseSync` open.
+ * @returns Sorted-by-name list of `OrphanRecord`s.
+ *
+ * @public
+ */
+export function discoverOrphans(registeredNames: ReadonlySet<string>): OrphanRecord[] {
+  const cleoRoot = cleoSkillsRoot();
+  const legacyRoot = legacyAgentsSkillsRoot();
+  const homeRoot = homeAgentsSkillsRoot();
+
+  const seen = new Map<string, OrphanRecord>();
+
+  const visit = (
+    root: string,
+    via: OrphanRecord['discoveredVia'],
+    filter?: (path: string) => boolean,
+  ): void => {
+    for (const candidate of listCandidates(root)) {
+      if (seen.has(candidate.name)) continue;
+      if (registeredNames.has(candidate.name)) continue;
+      if (filter && !filter(candidate.path)) continue;
+      seen.set(candidate.name, {
+        name: candidate.name,
+        path: candidate.path,
+        discoveredVia: via,
+        hasSkillMd: existsSync(join(candidate.path, 'SKILL.md')),
+        sizeBytes: approxDirSize(candidate.path),
+      });
+    }
+  };
+
+  visit(cleoRoot, 'cleo');
+  visit(legacyRoot, 'legacy-agents');
+  // Skip ~/.agents/skills/ entries whose realpath resolves back into
+  // ~/.cleo/skills/ — those are bridge symlinks, not orphans.
+  visit(homeRoot, 'home-agents', (path) => {
+    try {
+      const real = realpathSync(path);
+      return !real.startsWith(`${cleoRoot}/`);
+    } catch {
+      return true;
+    }
+  });
+
+  return Array.from(seen.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the canonical-adopt refusal payload.
+ *
+ * @returns Static `OrphanRefusal` explaining the PR-flow requirement.
+ *
+ * @internal
+ */
+function canonicalAdoptRefusal(): OrphanRefusal {
+  return {
+    code: 'E_CANONICAL_ADOPT_REFUSED',
+    message:
+      'Canonical adoption is refused on user machines. Canonical skills are owned by ' +
+      'the CLEO core team and ONLY the owner-CI workflow may write them ' +
+      '(architecture-v3 §6 invariant).',
+    remediation:
+      'To contribute this skill to canonical: clone https://github.com/kryptobaseddev/cleo, ' +
+      'place the skill under packages/skills/skills/<name>/, and open a PR. ' +
+      'Local user-machine canonical writes are blocked by design.',
+  };
+}
+
+/**
+ * Build the per-row payload for a successful user-adopt action.
+ *
+ * @remarks
+ * Pure-data helper — never touches the filesystem or sqlite. Centralised so
+ * the shape stays consistent across {@link applyDecision} and any future
+ * batch adopter.
+ *
+ * @param orphan - Orphan record being adopted.
+ * @param now - ISO-8601 timestamp to stamp on the row.
+ * @returns The {@link AdoptedSkillRowData} payload.
+ *
+ * @internal
+ */
+function buildAdoptedRow(orphan: OrphanRecord, now: string): AdoptedSkillRowData {
+  return {
+    name: orphan.name,
+    installPath: orphan.path,
+    installedAt: now,
+    sourceType: 'user',
+    lifecycleState: 'active',
+  };
+}
+
+/**
+ * Archive an orphan directory then unlink it from its original location.
+ *
+ * @remarks
+ * The archive path is `~/.cleo/skills/.archive/<name>-<ts>/` where `<ts>`
+ * is an ISO-8601 wall-clock timestamp with `:` replaced by `-` for
+ * filesystem-safety. The original directory is removed only AFTER the
+ * archive copy completes; on any failure the original is left in place so
+ * the operation is recoverable.
+ *
+ * @param orphan - The orphan to archive + delete.
+ * @param now - ISO-8601 timestamp to use in the archive directory name.
+ * @returns Absolute path the directory was archived to.
+ *
+ * @internal
+ */
+function archiveAndDelete(orphan: OrphanRecord, now: string): string {
+  const tsToken = now.replace(/[:.]/g, '-');
+  const archiveDir = join(archiveRoot(), `${orphan.name}-${tsToken}`);
+  mkdirSync(archiveRoot(), { recursive: true });
+  // Recursive copy via node:fs.cpSync (Node 20+) — preserves the directory
+  // tree byte-for-byte so the original is reproducible.
+  cpSync(orphan.path, archiveDir, { recursive: true, dereference: false });
+  rmSync(orphan.path, { recursive: true, force: true });
+  return archiveDir;
+}
+
+/**
+ * Callback signature for persisting a `user-adopt` decision.
+ *
+ * @remarks
+ * Production wiring lives in `packages/cleo/src/cli/commands/skills.ts` and
+ * funnels into `upsertSkillRow` from `@cleocode/core/store/skills-db`,
+ * which routes through the canonical `openCleoDb('skills')` chokepoint.
+ * Test code passes a sandboxed sqlite write. May be synchronous or async.
+ *
+ * @public
+ */
+export type RecordRowFn = (data: AdoptedSkillRowData) => void | Promise<void>;
+
+/**
+ * Apply a single decision to an orphan, returning a structured outcome.
+ *
+ * @remarks
+ * This is the policy chokepoint — `canonical-adopt` is unconditionally
+ * refused, `user-adopt` invokes `recordRow` with the canonical
+ * {@link AdoptedSkillRowData} payload, `delete` archives-then-rms, and
+ * `skip` records the intent without side effects. Errors during
+ * `user-adopt` or `delete` produce an `applied=false` result with a
+ * synthesised refusal payload rather than throwing, so the bulk loop can
+ * proceed across all orphans.
+ *
+ * @param orphan - Orphan to act on.
+ * @param decision - Decision to apply.
+ * @param now - ISO-8601 timestamp to record on the result.
+ * @param recordRow - Callback invoked to persist a successful `user-adopt`.
+ *   Tests pass a sandbox write; production passes the cleo-dispatch wrapper.
+ * @returns A populated `OrphanActionResult`.
+ *
+ * @public
+ */
+export async function applyDecision(
+  orphan: OrphanRecord,
+  decision: OrphanDecision,
+  now: string,
+  recordRow: RecordRowFn,
+): Promise<OrphanActionResult> {
+  const base: Omit<OrphanActionResult, 'decision' | 'applied' | 'refusal' | 'archivedTo'> = {
+    orphan,
+    decidedAt: now,
+  };
+
+  if (decision === 'canonical-adopt') {
+    return {
+      ...base,
+      decision,
+      applied: false,
+      refusal: canonicalAdoptRefusal(),
+      archivedTo: null,
+    };
+  }
+
+  if (decision === 'skip') {
+    return { ...base, decision, applied: true, refusal: null, archivedTo: null };
+  }
+
+  if (decision === 'user-adopt') {
+    try {
+      await recordRow(buildAdoptedRow(orphan, now));
+      return { ...base, decision, applied: true, refusal: null, archivedTo: null };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ...base,
+        decision,
+        applied: false,
+        refusal: {
+          code: 'E_CANONICAL_ADOPT_REFUSED',
+          message: `user-adopt failed: ${message}`,
+          remediation: 'Initialise the registry with `cleo skills list` then re-run.',
+        },
+        archivedTo: null,
+      };
+    }
+  }
+
+  // delete
+  try {
+    const archived = archiveAndDelete(orphan, now);
+    return { ...base, decision, applied: true, refusal: null, archivedTo: archived };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ...base,
+      decision,
+      applied: false,
+      refusal: {
+        code: 'E_CANONICAL_ADOPT_REFUSED',
+        message: `delete failed: ${message}`,
+        remediation: 'Inspect filesystem permissions and rerun with --non-interactive to verify.',
+      },
+      archivedTo: null,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+/**
+ * Write the audit log to `~/.cleo/skills/.audit-log/adopt-<ts>.json`.
+ *
+ * @remarks
+ * The log is written atomically (tmp-then-rename) so a SIGINT mid-write
+ * cannot leave a half-written file. The payload is a structured object
+ * containing the run timestamp, mode, full per-orphan results, and a
+ * stable `runId` UUID for cross-referencing in other CLEO audit streams
+ * (e.g. release-ship logs).
+ *
+ * @param result - The doctor-adopt result to persist.
+ * @returns Absolute path the audit log was written to.
+ *
+ * @public
+ */
+export function writeAuditLog(result: DoctorAdoptResult): string {
+  const dir = auditLogRoot();
+  mkdirSync(dir, { recursive: true });
+  const tsToken = new Date().toISOString().replace(/[:.]/g, '-');
+  const path = join(dir, `adopt-${tsToken}.json`);
+  const tmp = `${path}.tmp`;
+  const payload = {
+    runId: randomUUID(),
+    writtenAt: new Date().toISOString(),
+    ...result,
+  };
+  writeFileSync(tmp, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  // Atomic rename — fs.renameSync is atomic within the same filesystem.
+  renameSync(tmp, path);
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// Interactive prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Readline interface shape used by {@link promptDecision}.
+ *
+ * @internal
+ */
+type ReadlineInterface = ReturnType<typeof createInterface>;
+
+/**
+ * Prompt the user for a decision on a single orphan.
+ *
+ * @remarks
+ * Accepts one-letter shortcuts (`c`/`u`/`d`/`s`) for canonical-adopt,
+ * user-adopt, delete, and skip respectively. Unknown inputs re-prompt up
+ * to 3 times before defaulting to `skip` (safest no-op disposition).
+ *
+ * @param rl - Pre-created readline interface (re-used across orphans).
+ * @param orphan - Orphan to describe in the prompt header.
+ * @returns Promise resolving to the chosen `OrphanDecision`.
+ *
+ * @internal
+ */
+async function promptDecision(
+  rl: ReadlineInterface,
+  orphan: OrphanRecord,
+): Promise<OrphanDecision> {
+  const kb = Math.round(orphan.sizeBytes / 1024);
+  process.stderr.write(
+    `\n${pc.bold(orphan.name)}\n` +
+      `  path: ${orphan.path}\n` +
+      `  via:  ${orphan.discoveredVia}\n` +
+      `  size: ~${kb} KiB\n` +
+      `  SKILL.md: ${orphan.hasSkillMd ? 'yes' : 'no'}\n`,
+  );
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const answer = (await rl.question('  [c]anonical-adopt | [u]ser-adopt | [d]elete | [s]kip: '))
+      .trim()
+      .toLowerCase();
+    if (answer === 'c' || answer === 'canonical' || answer === 'canonical-adopt') {
+      return 'canonical-adopt';
+    }
+    if (answer === 'u' || answer === 'user' || answer === 'user-adopt') {
+      return 'user-adopt';
+    }
+    if (answer === 'd' || answer === 'delete') return 'delete';
+    if (answer === 's' || answer === 'skip' || answer === '') return 'skip';
+    process.stderr.write(`  ${pc.yellow('unrecognised input — try one of c/u/d/s')}\n`);
+  }
+  return 'skip';
+}
+
+// ---------------------------------------------------------------------------
+// Top-level orchestrator (callable directly for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Options controlling a `runDoctorAdopt` invocation.
+ *
+ * @public
+ */
+export interface DoctorAdoptOptions {
+  /** Skip prompting and write nothing — list-only audit mode. */
+  nonInteractive?: boolean;
+  /** Skip prompting and bulk-adopt every orphan as `source_type='user'`. */
+  autoUserAdopt?: boolean;
+  /**
+   * Loads the set of skill names already known to the registry.
+   *
+   * Production wiring opens `skills.db` via `openCleoDb('skills')`; tests
+   * inject a sandbox-scoped reader.
+   */
+  loadRegisteredNames: () => ReadonlySet<string> | Promise<ReadonlySet<string>>;
+  /**
+   * Persists a single `user-adopt` decision to `skills.db`.
+   *
+   * Production wiring calls `upsertSkillRow` from `@cleocode/core/store`;
+   * tests inject a sandbox writer.
+   */
+  recordRow: RecordRowFn;
+  /** Test-only injection of a readline-compatible prompt. */
+  prompt?: (orphan: OrphanRecord) => Promise<OrphanDecision>;
+  /** Test-only opt-out of writing the audit log to disk. */
+  skipAuditLog?: boolean;
+  /** Test-only override for the discovery step. */
+  discoverFn?: (registeredNames: ReadonlySet<string>) => OrphanRecord[];
+}
+
+/**
+ * Execute the doctor-adopt workflow and return a structured result.
+ *
+ * @remarks
+ * Designed for both CLI invocation (from {@link registerSkillsDoctorAdopt})
+ * and direct testing — every side effect is overridable via
+ * {@link DoctorAdoptOptions}. The function never throws on per-orphan
+ * failures; instead each failure produces an `applied=false` entry with a
+ * refusal payload, so the caller gets a complete report even on partial
+ * failure.
+ *
+ * @param options - Mode flags + dependency-injected callbacks. The
+ *   `loadRegisteredNames` and `recordRow` callbacks are MANDATORY so the
+ *   caller (cleo dispatch or test harness) owns the sqlite open via the
+ *   chokepoint.
+ * @returns The populated `DoctorAdoptResult`.
+ *
+ * @public
+ */
+export async function runDoctorAdopt(options: DoctorAdoptOptions): Promise<DoctorAdoptResult> {
+  const discover = options.discoverFn ?? discoverOrphans;
+  const registeredNames = await options.loadRegisteredNames();
+  const orphans = discover(registeredNames);
+  const results: OrphanActionResult[] = [];
+
+  const mode: DoctorAdoptResult['mode'] = options.nonInteractive
+    ? 'non-interactive'
+    : options.autoUserAdopt
+      ? 'auto-user-adopt'
+      : 'interactive';
+
+  if (orphans.length === 0) {
+    const empty: DoctorAdoptResult = {
+      totalOrphans: 0,
+      results: [],
+      auditLogPath: '',
+      mode,
+    };
+    if (!options.skipAuditLog) empty.auditLogPath = writeAuditLog(empty);
+    return empty;
+  }
+
+  if (mode === 'non-interactive') {
+    // Read-only: record a `skip` for every orphan without touching disk
+    // beyond the audit log.
+    const now = new Date().toISOString();
+    for (const orphan of orphans) {
+      results.push({
+        orphan,
+        decision: 'skip',
+        applied: true,
+        refusal: null,
+        archivedTo: null,
+        decidedAt: now,
+      });
+    }
+  } else if (mode === 'auto-user-adopt') {
+    for (const orphan of orphans) {
+      results.push(
+        await applyDecision(orphan, 'user-adopt', new Date().toISOString(), options.recordRow),
+      );
+    }
+  } else {
+    // interactive
+    const promptFn =
+      options.prompt ??
+      (async (orphan: OrphanRecord): Promise<OrphanDecision> => {
+        const rl = createInterface({ input: process.stdin, output: process.stderr });
+        try {
+          return await promptDecision(rl, orphan);
+        } finally {
+          rl.close();
+        }
+      });
+    for (const orphan of orphans) {
+      const decision = await promptFn(orphan);
+      results.push(
+        await applyDecision(orphan, decision, new Date().toISOString(), options.recordRow),
+      );
+    }
+  }
+
+  const result: DoctorAdoptResult = {
+    totalOrphans: orphans.length,
+    results,
+    auditLogPath: '',
+    mode,
+  };
+  if (!options.skipAuditLog) result.auditLogPath = writeAuditLog(result);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// CLI registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Default skill-name loader bound at CLI dispatch time.
+ *
+ * @remarks
+ * Re-exported so the cleo dispatch layer can construct it once and inject
+ * the same instance into {@link runDoctorAdopt}.
+ *
+ * @public
+ */
+export type RegisteredNamesLoader = () => ReadonlySet<string> | Promise<ReadonlySet<string>>;
+
+/**
+ * Adapter callbacks the CLI registrar needs to satisfy
+ * {@link DoctorAdoptOptions}'s mandatory deps.
+ *
+ * @remarks
+ * The caamp CLI (`caamp skills doctor adopt-orphans`) supplies a no-op pair
+ * — caamp is the registry-author-tool and never touches a live skills.db.
+ * The cleo CLI overrides both with chokepoint-routed implementations.
+ *
+ * @public
+ */
+export interface DoctorAdoptCliAdapters {
+  loadRegisteredNames: RegisteredNamesLoader;
+  recordRow: RecordRowFn;
+}
+
+/**
+ * Standalone-`caamp` defaults — no DB access, every directory is an orphan.
+ *
+ * @remarks
+ * In the standalone caamp CLI, there's no skills.db (caamp is the
+ * registry-author tool, not the user-runtime). We treat every directory as
+ * an orphan and refuse all user-adopt writes by surfacing an explanatory
+ * error through `recordRow`. The cleo CLI overrides this with the real
+ * chokepoint-routed adapters.
+ *
+ * @public
+ */
+export const caampStandaloneAdapters: DoctorAdoptCliAdapters = {
+  loadRegisteredNames: () => new Set<string>(),
+  recordRow: () => {
+    throw new Error(
+      'caamp standalone CLI cannot write to skills.db. Use `cleo skills doctor adopt-orphans` instead.',
+    );
+  },
+};
+
+/**
+ * Register the `skills doctor adopt-orphans` subcommand on the parent
+ * `skills` Commander group.
+ *
+ * @remarks
+ * The handler creates the `doctor` subgroup if it doesn't already exist on
+ * the parent, so registration order is tolerant of co-registration with
+ * `registerSkillsDoctor` (T9655 bridge). Adapters default to
+ * {@link caampStandaloneAdapters} which surface a clear error — pass the
+ * cleo-chokepoint adapters when wiring under `packages/cleo/`.
+ *
+ * Default output is LAFS JSON. Pass `--human` for the colorised summary.
+ *
+ * @param parent - The parent `skills` Command from
+ *   {@link registerSkillsCommands}.
+ * @param adapters - DB read/write hooks. Defaults to
+ *   {@link caampStandaloneAdapters} so the standalone caamp CLI surfaces a
+ *   helpful error rather than silently no-op'ing.
+ *
+ * @example
+ * ```bash
+ * cleo skills doctor adopt-orphans                 # interactive
+ * cleo skills doctor adopt-orphans --non-interactive
+ * cleo skills doctor adopt-orphans --auto-user-adopt --json
+ * ```
+ *
+ * @public
+ */
+export function registerSkillsDoctorAdopt(
+  parent: Command,
+  adapters: DoctorAdoptCliAdapters = caampStandaloneAdapters,
+): void {
+  // Reuse an existing `doctor` subgroup if one is already attached (e.g. by
+  // `registerSkillsDoctor` for the `bridge` subcommand); otherwise create
+  // one. Commander tolerates `.command()` being called twice with the same
+  // name but only one will surface in `--help`, so we prefer reuse.
+  const existing = parent.commands.find((c) => c.name() === 'doctor');
+  const doctor =
+    existing ?? parent.command('doctor').description('Diagnostics + repair for the skill system');
+
+  doctor
+    .command('adopt-orphans')
+    .description(
+      'Interactive audit of on-disk skill dirs not tracked in skills.db (canonical/user/delete/skip)',
+    )
+    .option('--json', 'Output as LAFS JSON envelope (default)')
+    .option('--human', 'Output a colorised human-readable summary')
+    .option('--non-interactive', 'List orphans + exit without action')
+    .option('--auto-user-adopt', 'Bulk-mark all orphans as source_type=user without prompting')
+    .action(
+      async (opts: {
+        json?: boolean;
+        human?: boolean;
+        nonInteractive?: boolean;
+        autoUserAdopt?: boolean;
+      }) => {
+        const operation = 'skills.doctor.adopt-orphans';
+        const mvi: import('../../core/lafs.js').MVILevel = 'standard';
+
+        let format: 'json' | 'human';
+        try {
+          format = resolveFormat({
+            jsonFlag: opts.json ?? false,
+            humanFlag: opts.human ?? false,
+            projectDefault: 'json',
+          });
+        } catch (error) {
+          handleFormatError(error, operation, mvi, opts.json);
+        }
+
+        try {
+          const result = await runDoctorAdopt({
+            nonInteractive: opts.nonInteractive ?? false,
+            autoUserAdopt: opts.autoUserAdopt ?? false,
+            loadRegisteredNames: adapters.loadRegisteredNames,
+            recordRow: adapters.recordRow,
+          });
+
+          if (format === 'json') {
+            outputSuccess(operation, mvi, result);
+            return;
+          }
+
+          // Human-readable
+          const ok = result.results.filter((r) => r.applied);
+          const blocked = result.results.filter((r) => !r.applied);
+
+          console.log(pc.bold(`\nskills doctor adopt-orphans (${result.mode})\n`));
+          console.log(
+            `  ${pc.bold('Discovered')}: ${result.totalOrphans} orphan${
+              result.totalOrphans === 1 ? '' : 's'
+            }`,
+          );
+          for (const r of result.results) {
+            const icon =
+              r.decision === 'skip' ? pc.dim('·') : r.applied ? pc.green('✓') : pc.red('✗');
+            const verb = r.applied ? r.decision : `${r.decision} (refused)`;
+            console.log(`  ${icon} ${r.orphan.name.padEnd(32)} ${pc.dim(verb)}`);
+            if (r.refusal) {
+              console.log(`      ${pc.yellow(r.refusal.message)}`);
+              console.log(`      ${pc.dim(r.refusal.remediation)}`);
+            }
+            if (r.archivedTo) {
+              console.log(`      ${pc.dim(`archived → ${r.archivedTo}`)}`);
+            }
+          }
+          console.log(
+            `\n  ${pc.bold('Summary')}: ${pc.green(`${ok.length} applied`)}, ` +
+              `${pc.red(`${blocked.length} blocked`)}`,
+          );
+          if (result.auditLogPath) {
+            console.log(`  ${pc.dim(`audit log → ${result.auditLogPath}`)}`);
+          }
+          console.log();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (format === 'json') {
+            emitJsonError(
+              operation,
+              mvi,
+              ErrorCodes.INTERNAL_ERROR,
+              message,
+              ErrorCategories.INTERNAL,
+            );
+          } else {
+            console.error(pc.red(`Error: ${message}`));
+          }
+          process.exit(1);
+        }
+      },
+    );
+}

--- a/packages/caamp/src/commands/skills/index.ts
+++ b/packages/caamp/src/commands/skills/index.ts
@@ -9,6 +9,7 @@ import type { Command } from 'commander';
 import { registerSkillsAudit } from './audit.js';
 import { registerSkillsCheck } from './check.js';
 import { registerSkillsDoctor } from './doctor.js';
+import { registerSkillsDoctorAdopt } from './doctor-adopt.js';
 import { registerSkillsDoctorMigrate } from './doctor-migrate.js';
 import { registerSkillsFind } from './find.js';
 import { registerSkillsInit } from './init.js';
@@ -50,4 +51,5 @@ export function registerSkillsCommands(program: Command): void {
   registerSkillsValidate(skills);
   registerSkillsDoctorMigrate(skills);
   registerSkillsDoctor(skills);
+  registerSkillsDoctorAdopt(skills);
 }

--- a/packages/caamp/src/index.ts
+++ b/packages/caamp/src/index.ts
@@ -6,6 +6,27 @@
  * format-agnostic config read/write operations.
  */
 
+// Skills doctor — adopt-orphans subcommand (T9657)
+export type {
+  AdoptedSkillRowData,
+  DoctorAdoptCliAdapters,
+  DoctorAdoptOptions,
+  DoctorAdoptResult,
+  OrphanActionResult,
+  OrphanDecision,
+  OrphanRecord,
+  OrphanRefusal,
+  RecordRowFn,
+  RegisteredNamesLoader,
+} from './commands/skills/doctor-adopt.js';
+export {
+  applyDecision,
+  caampStandaloneAdapters,
+  discoverOrphans,
+  registerSkillsDoctorAdopt,
+  runDoctorAdopt,
+  writeAuditLog,
+} from './commands/skills/doctor-adopt.js';
 export type {
   BridgeSymlinkRecord,
   DoctorBridgeOptions,

--- a/packages/caamp/tests/unit/skills-doctor-adopt.test.ts
+++ b/packages/caamp/tests/unit/skills-doctor-adopt.test.ts
@@ -1,0 +1,548 @@
+/**
+ * Unit tests for `cleo skills doctor adopt-orphans` (T9657).
+ *
+ * Covers:
+ *  - orphan discovery (on-disk dirs not in skills.db)
+ *  - non-interactive mode → list-only, zero side effects
+ *  - --auto-user-adopt → bulk insert with source_type='user'
+ *  - canonical-adopt refused on user machine (always)
+ *  - delete → archives before remove
+ *  - idempotent re-runs (upsert path)
+ *  - audit-log JSON envelope
+ *
+ * @remarks
+ * Post-ADR-068 refactor (T9657 follow-up): the caamp module no longer opens
+ * `skills.db` itself; the test harness owns the chokepoint-compliant sqlite
+ * open via `node:sqlite` (test files are allowlisted by
+ * `scripts/lint-no-raw-db-opens.mjs`).
+ */
+
+import { execSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  type AdoptedSkillRowData,
+  applyDecision,
+  discoverOrphans,
+  type OrphanRecord,
+  type RecordRowFn,
+  runDoctorAdopt,
+  writeAuditLog,
+} from '../../src/commands/skills/doctor-adopt.js';
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+const MIGRATION_SQL = `
+CREATE TABLE IF NOT EXISTS \`skills\` (
+  \`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  \`name\` text NOT NULL,
+  \`version\` text,
+  \`source_type\` text NOT NULL,
+  \`source_url\` text,
+  \`install_path\` text NOT NULL,
+  \`canonical_path\` text,
+  \`installed_at\` text NOT NULL,
+  \`last_updated_at\` text,
+  \`lifecycle_state\` text DEFAULT 'active' NOT NULL,
+  \`pinned\` integer DEFAULT 0 NOT NULL,
+  \`is_agent_created\` integer DEFAULT 0 NOT NULL,
+  \`archived_at\` text,
+  \`archived_from_path\` text,
+  CONSTRAINT \`skills_source_type_check\` CHECK (\`source_type\` IN ('canonical','user','community','agent-created')),
+  CONSTRAINT \`skills_lifecycle_state_check\` CHECK (\`lifecycle_state\` IN ('active','stale','archived'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS \`skills_name_unique\` ON \`skills\` (\`name\`);
+`;
+
+interface Sandbox {
+  root: string;
+  fakeHome: string;
+  cleoHome: string;
+  cleoSkills: string;
+  legacySkills: string;
+  homeAgentsSkills: string;
+  dbPath: string;
+  origHome: string | undefined;
+  origCleoHome: string | undefined;
+}
+
+function makeSandbox(): Sandbox {
+  const root = mkdtempSync(join(tmpdir(), 'doctor-adopt-'));
+  const fakeHome = join(root, 'home');
+  const cleoHome = join(fakeHome, '.local', 'share', 'cleo');
+  const cleoSkills = join(fakeHome, '.cleo', 'skills');
+  const legacySkills = join(fakeHome, '.local', 'share', 'agents', 'skills');
+  const homeAgentsSkills = join(fakeHome, '.agents', 'skills');
+
+  mkdirSync(cleoHome, { recursive: true });
+  mkdirSync(cleoSkills, { recursive: true });
+  mkdirSync(legacySkills, { recursive: true });
+  mkdirSync(homeAgentsSkills, { recursive: true });
+
+  const dbPath = join(cleoHome, 'skills.db');
+  const db = new DatabaseSync(dbPath);
+  db.exec(MIGRATION_SQL);
+  db.close();
+
+  const sandbox: Sandbox = {
+    root,
+    fakeHome,
+    cleoHome,
+    cleoSkills,
+    legacySkills,
+    homeAgentsSkills,
+    dbPath,
+    origHome: process.env.HOME,
+    origCleoHome: process.env.CLEO_HOME,
+  };
+  process.env.HOME = fakeHome;
+  // Force @cleocode/paths to use our sandboxed cleo home for getCleoHome()
+  process.env.CLEO_HOME = cleoHome;
+  return sandbox;
+}
+
+function teardown(s: Sandbox): void {
+  if (s.origHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = s.origHome;
+  }
+  if (s.origCleoHome === undefined) {
+    delete process.env.CLEO_HOME;
+  } else {
+    process.env.CLEO_HOME = s.origCleoHome;
+  }
+  rmSync(s.root, { recursive: true, force: true });
+}
+
+function createSkillDir(parent: string, name: string, withSkillMd: boolean = true): string {
+  const dir = join(parent, name);
+  mkdirSync(dir, { recursive: true });
+  if (withSkillMd) {
+    writeFileSync(join(dir, 'SKILL.md'), `---\nname: ${name}\n---\n# ${name}\n`, 'utf8');
+  }
+  return dir;
+}
+
+function registerSkill(dbPath: string, name: string, installPath: string): void {
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.prepare(
+      `INSERT INTO skills (name, source_type, install_path, installed_at)
+       VALUES (?, 'user', ?, ?)`,
+    ).run(name, installPath, new Date().toISOString());
+  } finally {
+    db.close();
+  }
+}
+
+function readSkillsRows(dbPath: string): Array<{
+  name: string;
+  source_type: string;
+  install_path: string;
+  lifecycle_state: string;
+}> {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    return db
+      .prepare('SELECT name, source_type, install_path, lifecycle_state FROM skills ORDER BY name')
+      .all() as Array<{
+      name: string;
+      source_type: string;
+      install_path: string;
+      lifecycle_state: string;
+    }>;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Build a sandboxed `loadRegisteredNames` callback that reads from the given
+ * sqlite file. Mirrors the production wiring (which would route through
+ * `openCleoDb('skills')`) without taking a `@cleocode/core` dep from the
+ * caamp test suite.
+ */
+function makeLoadRegisteredNames(dbPath: string): () => ReadonlySet<string> {
+  return (): ReadonlySet<string> => {
+    if (!existsSync(dbPath)) return new Set();
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      const tableCheck = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='skills'")
+        .get();
+      if (!tableCheck) return new Set();
+      const rows = db.prepare('SELECT name FROM skills').all() as Array<{ name: string }>;
+      return new Set(rows.map((r) => r.name));
+    } finally {
+      db.close();
+    }
+  };
+}
+
+/**
+ * Build a sandboxed `recordRow` callback that writes via upsert into the
+ * given sqlite file. Mirrors the production wiring (`upsertSkillRow` from
+ * `@cleocode/core/store/skills-db`).
+ */
+function makeRecordRow(dbPath: string): RecordRowFn {
+  return (data: AdoptedSkillRowData): void => {
+    if (!existsSync(dbPath)) {
+      throw new Error(`skills.db not found at ${dbPath}`);
+    }
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.prepare(
+        `INSERT INTO skills (name, source_type, install_path, installed_at, lifecycle_state, pinned, is_agent_created)
+         VALUES (?, ?, ?, ?, ?, 0, 0)
+         ON CONFLICT(name) DO UPDATE SET
+           install_path = excluded.install_path,
+           lifecycle_state = 'active',
+           last_updated_at = excluded.installed_at`,
+      ).run(data.name, data.sourceType, data.installPath, data.installedAt, data.lifecycleState);
+    } finally {
+      db.close();
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('skills doctor adopt-orphans', () => {
+  let s: Sandbox;
+  beforeEach(() => {
+    s = makeSandbox();
+  });
+  afterEach(() => {
+    teardown(s);
+  });
+
+  describe('discoverOrphans', () => {
+    it('identifies skill dirs not present in skills.db', () => {
+      createSkillDir(s.cleoSkills, 'orphan-one');
+      createSkillDir(s.cleoSkills, 'orphan-two');
+      createSkillDir(s.cleoSkills, 'tracked-skill');
+      registerSkill(s.dbPath, 'tracked-skill', join(s.cleoSkills, 'tracked-skill'));
+
+      const registered = makeLoadRegisteredNames(s.dbPath)();
+      const orphans = discoverOrphans(registered);
+      const names = orphans.map((o) => o.name).sort();
+
+      expect(names).toEqual(['orphan-one', 'orphan-two']);
+      expect(orphans.every((o) => o.discoveredVia === 'cleo')).toBe(true);
+      expect(orphans.every((o) => o.hasSkillMd)).toBe(true);
+    });
+
+    it('discovers orphans in legacy XDG path', () => {
+      createSkillDir(s.legacySkills, 'legacy-orphan');
+      const registered = makeLoadRegisteredNames(s.dbPath)();
+      const orphans = discoverOrphans(registered);
+      expect(orphans.map((o) => o.name)).toContain('legacy-orphan');
+      expect(orphans.find((o) => o.name === 'legacy-orphan')?.discoveredVia).toBe('legacy-agents');
+    });
+
+    it('skips bridge symlinks under ~/.agents/skills/ that resolve into ~/.cleo/skills/', () => {
+      // Create a real cleo skill, then a symlink from ~/.agents/skills/ to it.
+      createSkillDir(s.cleoSkills, 'shared-skill');
+      const bridge = join(s.homeAgentsSkills, 'shared-skill');
+      // Use cpSync? No — symlink.
+      execSync(`ln -s ${join(s.cleoSkills, 'shared-skill')} ${bridge}`);
+      registerSkill(s.dbPath, 'shared-skill', join(s.cleoSkills, 'shared-skill'));
+
+      const registered = makeLoadRegisteredNames(s.dbPath)();
+      const orphans = discoverOrphans(registered);
+      expect(orphans.find((o) => o.name === 'shared-skill')).toBeUndefined();
+    });
+
+    it('reports real-dir orphans in ~/.agents/skills/', () => {
+      createSkillDir(s.homeAgentsSkills, 'real-dir-orphan');
+      const registered = makeLoadRegisteredNames(s.dbPath)();
+      const orphans = discoverOrphans(registered);
+      expect(orphans.find((o) => o.name === 'real-dir-orphan')?.discoveredVia).toBe('home-agents');
+    });
+
+    it('skips dotfile sentinel dirs (.archive, .audit-log)', () => {
+      mkdirSync(join(s.cleoSkills, '.archive'), { recursive: true });
+      mkdirSync(join(s.cleoSkills, '.audit-log'), { recursive: true });
+      createSkillDir(s.cleoSkills, 'real-orphan');
+      const registered = makeLoadRegisteredNames(s.dbPath)();
+      const orphans = discoverOrphans(registered);
+      expect(orphans.map((o) => o.name)).toEqual(['real-orphan']);
+    });
+
+    it('returns empty list when skills.db has no row for any on-disk dir AND no dirs exist', () => {
+      const registered = makeLoadRegisteredNames(s.dbPath)();
+      const orphans = discoverOrphans(registered);
+      expect(orphans).toEqual([]);
+    });
+  });
+
+  describe('applyDecision', () => {
+    function makeOrphan(name: string, parent: string = s.cleoSkills): OrphanRecord {
+      const path = createSkillDir(parent, name);
+      return {
+        name,
+        path,
+        discoveredVia: 'cleo',
+        hasSkillMd: true,
+        sizeBytes: 42,
+      };
+    }
+
+    it('refuses canonical-adopt with E_CANONICAL_ADOPT_REFUSED + PR-flow remediation', async () => {
+      const orphan = makeOrphan('would-be-canonical');
+      const result = await applyDecision(
+        orphan,
+        'canonical-adopt',
+        new Date().toISOString(),
+        makeRecordRow(s.dbPath),
+      );
+
+      expect(result.applied).toBe(false);
+      expect(result.refusal?.code).toBe('E_CANONICAL_ADOPT_REFUSED');
+      expect(result.refusal?.remediation).toMatch(/packages\/skills\/skills\//);
+      expect(result.refusal?.remediation).toMatch(/PR/);
+      // Directory MUST still exist (no destructive side-effect).
+      expect(existsSync(orphan.path)).toBe(true);
+      // No row inserted.
+      const rows = readSkillsRows(s.dbPath);
+      expect(rows.find((r) => r.name === 'would-be-canonical')).toBeUndefined();
+    });
+
+    it('user-adopt inserts a source_type=user row in skills.db', async () => {
+      const orphan = makeOrphan('my-user-skill');
+      const now = new Date().toISOString();
+      const result = await applyDecision(orphan, 'user-adopt', now, makeRecordRow(s.dbPath));
+
+      expect(result.applied).toBe(true);
+      expect(result.refusal).toBeNull();
+      const rows = readSkillsRows(s.dbPath);
+      const row = rows.find((r) => r.name === 'my-user-skill');
+      expect(row).toBeDefined();
+      expect(row?.source_type).toBe('user');
+      expect(row?.lifecycle_state).toBe('active');
+      expect(row?.install_path).toBe(orphan.path);
+    });
+
+    it('user-adopt is idempotent across repeat invocations (upsert)', async () => {
+      const orphan = makeOrphan('idempotent-skill');
+      const recordRow = makeRecordRow(s.dbPath);
+      await applyDecision(orphan, 'user-adopt', new Date().toISOString(), recordRow);
+      await applyDecision(orphan, 'user-adopt', new Date().toISOString(), recordRow);
+      const rows = readSkillsRows(s.dbPath);
+      const matches = rows.filter((r) => r.name === 'idempotent-skill');
+      expect(matches).toHaveLength(1);
+    });
+
+    it('delete archives the dir before removing the original', async () => {
+      const orphan = makeOrphan('to-be-deleted');
+      const result = await applyDecision(
+        orphan,
+        'delete',
+        new Date().toISOString(),
+        makeRecordRow(s.dbPath),
+      );
+
+      expect(result.applied).toBe(true);
+      expect(result.archivedTo).toBeTruthy();
+      expect(result.archivedTo).toMatch(/\.archive\/to-be-deleted-/);
+      if (!result.archivedTo) throw new Error('archive path missing');
+      // Archive exists with original SKILL.md content.
+      expect(existsSync(result.archivedTo)).toBe(true);
+      expect(existsSync(join(result.archivedTo, 'SKILL.md'))).toBe(true);
+      const archivedMd = readFileSync(join(result.archivedTo, 'SKILL.md'), 'utf8');
+      expect(archivedMd).toContain('to-be-deleted');
+      // Original removed.
+      expect(existsSync(orphan.path)).toBe(false);
+    });
+
+    it('skip is a true no-op', async () => {
+      const orphan = makeOrphan('untouched');
+      const result = await applyDecision(
+        orphan,
+        'skip',
+        new Date().toISOString(),
+        makeRecordRow(s.dbPath),
+      );
+      expect(result.applied).toBe(true);
+      expect(result.refusal).toBeNull();
+      expect(result.archivedTo).toBeNull();
+      expect(existsSync(orphan.path)).toBe(true);
+      const rows = readSkillsRows(s.dbPath);
+      expect(rows.find((r) => r.name === 'untouched')).toBeUndefined();
+    });
+  });
+
+  describe('runDoctorAdopt', () => {
+    it('--non-interactive lists orphans without action', async () => {
+      createSkillDir(s.cleoSkills, 'a-orphan');
+      createSkillDir(s.cleoSkills, 'b-orphan');
+
+      const result = await runDoctorAdopt({
+        nonInteractive: true,
+        loadRegisteredNames: makeLoadRegisteredNames(s.dbPath),
+        recordRow: makeRecordRow(s.dbPath),
+      });
+
+      expect(result.mode).toBe('non-interactive');
+      expect(result.totalOrphans).toBe(2);
+      expect(result.results).toHaveLength(2);
+      expect(result.results.every((r) => r.decision === 'skip')).toBe(true);
+      expect(result.results.every((r) => r.applied)).toBe(true);
+      // No rows inserted, dirs intact.
+      expect(readSkillsRows(s.dbPath)).toHaveLength(0);
+      expect(existsSync(join(s.cleoSkills, 'a-orphan'))).toBe(true);
+      expect(existsSync(join(s.cleoSkills, 'b-orphan'))).toBe(true);
+    });
+
+    it('--auto-user-adopt bulk-adopts all orphans', async () => {
+      createSkillDir(s.cleoSkills, 'auto-one');
+      createSkillDir(s.cleoSkills, 'auto-two');
+      createSkillDir(s.cleoSkills, 'auto-three');
+
+      const result = await runDoctorAdopt({
+        autoUserAdopt: true,
+        loadRegisteredNames: makeLoadRegisteredNames(s.dbPath),
+        recordRow: makeRecordRow(s.dbPath),
+      });
+
+      expect(result.mode).toBe('auto-user-adopt');
+      expect(result.totalOrphans).toBe(3);
+      expect(result.results.every((r) => r.applied)).toBe(true);
+      expect(result.results.every((r) => r.decision === 'user-adopt')).toBe(true);
+
+      const rows = readSkillsRows(s.dbPath);
+      expect(rows.map((r) => r.name).sort()).toEqual(['auto-one', 'auto-three', 'auto-two']);
+      expect(rows.every((r) => r.source_type === 'user')).toBe(true);
+    });
+
+    it('writes an audit log under ~/.cleo/skills/.audit-log/', async () => {
+      createSkillDir(s.cleoSkills, 'log-me');
+      const result = await runDoctorAdopt({
+        autoUserAdopt: true,
+        loadRegisteredNames: makeLoadRegisteredNames(s.dbPath),
+        recordRow: makeRecordRow(s.dbPath),
+      });
+
+      expect(result.auditLogPath).toBeTruthy();
+      expect(result.auditLogPath.startsWith(join(s.cleoSkills, '.audit-log'))).toBe(true);
+      expect(existsSync(result.auditLogPath)).toBe(true);
+
+      const logged = JSON.parse(readFileSync(result.auditLogPath, 'utf8')) as {
+        runId: string;
+        writtenAt: string;
+        totalOrphans: number;
+        results: Array<{ orphan: { name: string }; decision: string; applied: boolean }>;
+        mode: string;
+      };
+      expect(typeof logged.runId).toBe('string');
+      expect(typeof logged.writtenAt).toBe('string');
+      expect(logged.totalOrphans).toBe(1);
+      expect(logged.mode).toBe('auto-user-adopt');
+      expect(logged.results[0]?.orphan.name).toBe('log-me');
+      expect(logged.results[0]?.applied).toBe(true);
+    });
+
+    it('produces a zero-orphan result when nothing is on disk', async () => {
+      const result = await runDoctorAdopt({
+        nonInteractive: true,
+        loadRegisteredNames: makeLoadRegisteredNames(s.dbPath),
+        recordRow: makeRecordRow(s.dbPath),
+      });
+      expect(result.totalOrphans).toBe(0);
+      expect(result.results).toEqual([]);
+    });
+
+    it('interactive mode threads injected prompt through every orphan', async () => {
+      createSkillDir(s.cleoSkills, 'prompt-a');
+      createSkillDir(s.cleoSkills, 'prompt-b');
+      createSkillDir(s.cleoSkills, 'prompt-c');
+
+      const seen: string[] = [];
+      const result = await runDoctorAdopt({
+        loadRegisteredNames: makeLoadRegisteredNames(s.dbPath),
+        recordRow: makeRecordRow(s.dbPath),
+        prompt: async (orphan) => {
+          seen.push(orphan.name);
+          if (orphan.name === 'prompt-a') return 'user-adopt';
+          if (orphan.name === 'prompt-b') return 'canonical-adopt';
+          return 'skip';
+        },
+      });
+
+      expect(seen.sort()).toEqual(['prompt-a', 'prompt-b', 'prompt-c']);
+      expect(result.mode).toBe('interactive');
+
+      const aResult = result.results.find((r) => r.orphan.name === 'prompt-a');
+      const bResult = result.results.find((r) => r.orphan.name === 'prompt-b');
+      const cResult = result.results.find((r) => r.orphan.name === 'prompt-c');
+
+      expect(aResult?.decision).toBe('user-adopt');
+      expect(aResult?.applied).toBe(true);
+      expect(bResult?.decision).toBe('canonical-adopt');
+      expect(bResult?.applied).toBe(false);
+      expect(bResult?.refusal?.code).toBe('E_CANONICAL_ADOPT_REFUSED');
+      expect(cResult?.decision).toBe('skip');
+    });
+  });
+
+  describe('writeAuditLog', () => {
+    it('writes structured JSON with runId + writtenAt', () => {
+      const orphans: OrphanRecord[] = [
+        {
+          name: 'standalone',
+          path: '/tmp/standalone',
+          discoveredVia: 'cleo',
+          hasSkillMd: true,
+          sizeBytes: 100,
+        },
+      ];
+      const path = writeAuditLog({
+        totalOrphans: 1,
+        results: [
+          {
+            orphan: orphans[0]!,
+            decision: 'skip',
+            applied: true,
+            refusal: null,
+            archivedTo: null,
+            decidedAt: new Date().toISOString(),
+          },
+        ],
+        auditLogPath: '',
+        mode: 'non-interactive',
+      });
+
+      expect(existsSync(path)).toBe(true);
+      const parsed = JSON.parse(readFileSync(path, 'utf8')) as {
+        runId: string;
+        writtenAt: string;
+        results: unknown[];
+      };
+      expect(parsed.runId).toMatch(/[0-9a-f-]{36}/);
+      expect(typeof parsed.writtenAt).toBe('string');
+      expect(parsed.results).toHaveLength(1);
+
+      // Verify atomic write — no .tmp leftover
+      const dir = join(s.cleoSkills, '.audit-log');
+      const tmpLeft = readdirSync(dir).filter((f) => f.endsWith('.tmp'));
+      expect(tmpLeft).toHaveLength(0);
+    });
+  });
+});

--- a/packages/cleo/src/cli/commands/skills.ts
+++ b/packages/cleo/src/cli/commands/skills.ts
@@ -22,7 +22,8 @@
  * @epic T4545
  */
 
-import { AgentsSkillsRealDirError, runDoctorBridge } from '@cleocode/caamp';
+import type { AdoptedSkillRowData, DoctorAdoptCliAdapters } from '@cleocode/caamp';
+import { AgentsSkillsRealDirError, runDoctorAdopt, runDoctorBridge } from '@cleocode/caamp';
 import { defineCommand } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
 import { isSubCommandDispatch } from '../lib/subcommand-guard.js';
@@ -409,6 +410,102 @@ const doctorBridgeCommand = defineCommand({
   },
 });
 
+/**
+ * Build the cleo-side `DoctorAdoptCliAdapters` that route every skills.db
+ * access through the canonical `openCleoDb('skills')` chokepoint (ADR-068).
+ *
+ * @remarks
+ * caamp cannot import `@cleocode/core` (dep direction is core → caamp), so
+ * caamp emits pure-data callbacks and the cleo dispatch layer wires the
+ * concrete sqlite helpers. Construction is lazy to keep `@cleocode/core`
+ * out of the cold-start path for `cleo skills` invocations that never
+ * touch the registry.
+ *
+ * @returns Adapters that delegate read+write to core's `skills-db` module.
+ *
+ * @task T9657
+ */
+function buildSkillsDoctorAdoptAdapters(): DoctorAdoptCliAdapters {
+  return {
+    loadRegisteredNames: async (): Promise<ReadonlySet<string>> => {
+      const { listSkillsBySource } = await import('@cleocode/core');
+      const rows = await Promise.all([
+        listSkillsBySource('canonical'),
+        listSkillsBySource('user'),
+        listSkillsBySource('community'),
+        listSkillsBySource('agent-created'),
+      ]);
+      return new Set(rows.flat().map((r) => r.name));
+    },
+    recordRow: async (data: AdoptedSkillRowData): Promise<void> => {
+      const { upsertSkillRow } = await import('@cleocode/core');
+      await upsertSkillRow({
+        name: data.name,
+        sourceType: data.sourceType,
+        installPath: data.installPath,
+        installedAt: data.installedAt,
+        lifecycleState: data.lifecycleState,
+        pinned: false,
+        isAgentCreated: false,
+      });
+    },
+  };
+}
+
+/**
+ * cleo skills doctor adopt-orphans — interactive orphan audit + adoption (T9657).
+ *
+ * Routes skills.db reads + writes through `openCleoDb('skills')` from
+ * `@cleocode/core/store/skills-db` to satisfy the ADR-068 chokepoint guard.
+ */
+const doctorAdoptOrphansCommand = defineCommand({
+  meta: {
+    name: 'adopt-orphans',
+    description:
+      'Interactive audit of on-disk skill dirs not tracked in skills.db (canonical/user/delete/skip)',
+  },
+  args: {
+    'non-interactive': {
+      type: 'boolean',
+      description: 'List orphans + exit without action',
+    },
+    'auto-user-adopt': {
+      type: 'boolean',
+      description: 'Bulk-mark all orphans as source_type=user without prompting',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON (default)',
+    },
+    human: {
+      type: 'boolean',
+      description: 'Output in human-readable format',
+    },
+  },
+  async run({ args }) {
+    const { cliError, cliOutput } = await import('../renderers/index.js');
+    try {
+      const adapters = buildSkillsDoctorAdoptAdapters();
+      const result = await runDoctorAdopt({
+        nonInteractive: args['non-interactive'] === true,
+        autoUserAdopt: args['auto-user-adopt'] === true,
+        loadRegisteredNames: adapters.loadRegisteredNames,
+        recordRow: adapters.recordRow,
+      });
+      cliOutput(
+        { success: true, data: result },
+        { command: 'skills doctor adopt-orphans', operation: 'skills.doctor.adopt-orphans' },
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      cliError(message, 'E_INTERNAL_ERROR', undefined, {
+        operation: 'skills.doctor.adopt-orphans',
+      });
+      process.exit(1);
+    }
+  },
+});
+
 /** cleo skills spawn-providers — list providers capable of spawning subagents */
 const spawnProvidersCommand = defineCommand({
   meta: { name: 'spawn-providers', description: 'List providers capable of spawning subagents' },
@@ -459,16 +556,16 @@ const doctorDiagnoseCommand = defineCommand({
   },
 });
 
-/** cleo skills doctor — skill-store health + bridge/migrate subcommands (T9652, T9655). */
+/** cleo skills doctor — skill-store health + bridge/adopt-orphans subcommands (T9652, T9655, T9657). */
 const doctorCommand = defineCommand({
   meta: {
     name: 'doctor',
-    description:
-      'Skill-store health checks (diagnose, migrate, bridge — read-only diagnose only in T9652)',
+    description: 'Skill-store health checks (diagnose, bridge, adopt-orphans)',
   },
   subCommands: {
     diagnose: doctorDiagnoseCommand,
     bridge: doctorBridgeCommand,
+    'adopt-orphans': doctorAdoptOrphansCommand,
   },
   async run({ cmd, rawArgs }) {
     // Default to diagnose when no subcommand is given.

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -63,8 +62,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +83,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,20 +101,23 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -135,7 +140,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -238,7 +244,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'currentCommand',
@@ -255,14 +262,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -286,7 +295,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -297,7 +307,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -310,7 +321,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -346,7 +358,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -370,7 +383,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'generateChangelogCommand',
     name: 'generate-changelog',
     description: 'Generate platform-specific changelog from CHANGELOG.md',
-    load: async () => (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
   },
   {
     exportName: 'gradeCommand',
@@ -394,7 +408,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -417,14 +432,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -453,7 +471,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -495,14 +514,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -531,7 +553,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -543,13 +566,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -592,7 +617,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -603,7 +629,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -651,7 +678,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -663,7 +691,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -711,13 +740,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description:
+      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -789,7 +820,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -807,7 +839,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -197,6 +197,14 @@ export {
   type CleoDbSnapshotOptions,
   openCleoDbSnapshot,
 } from './store/open-cleo-db.js';
+export {
+  getSkillRow,
+  listSkillsBySource,
+  openSkillsDb,
+  upsertSkillRow,
+} from './store/skills-db.js';
+// Skills DB chokepoint helpers — exposed for cleo dispatch (T9657 adopt-orphans wiring)
+export type { NewSkillRow, SkillRow, SkillSourceType } from './store/skills-schema.js';
 // Canonical pragma application — exposed for cross-package consumers (brain, studio, cleo)
 // that cannot access @cleocode/core/internal (T9045).
 export {

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -62,6 +62,25 @@ export {
   SafetyDataAccessor,
   wrapWithSafety,
 } from './safety-data-accessor.js';
+// Skills DB helpers (per-user skills.db chokepoint — T9651 / T9657)
+export {
+  closeSkillsDb,
+  getDefaultSkillsDbPath,
+  getSkillRow,
+  getSkillsNativeDb,
+  listSkillsBySource,
+  openSkillsDb,
+  resetSkillsDbState,
+  resolveSkillsMigrationsFolder,
+  SKILLS_DB_FILENAME,
+  SKILLS_SCHEMA_VERSION,
+  upsertSkillRow,
+} from './skills-db.js';
+export type {
+  NewSkillRow,
+  SkillRow,
+  SkillSourceType,
+} from './skills-schema.js';
 export {
   listBrainBackups,
   listSqliteBackups,


### PR DESCRIPTION
## Summary

- New `cleo skills doctor adopt-orphans` CAAMP subcommand for the SG-CLEO-SKILLS saga (T9657 under epic T9571, saga T9560).
- Identifies skill directories that exist on disk under `~/.cleo/skills/`, legacy `~/.local/share/agents/skills/`, or `~/.agents/skills/` (real-dir entries) but have NO row in `skills.db`.
- Per-orphan disposition: `canonical-adopt` (refused on user machine — suggests PR to `packages/skills/skills/` per architecture-v3 §6 invariant), `user-adopt` (upserts `source_type='user'`), `delete` (archives to `~/.cleo/skills/.archive/<name>-<ts>/` before unlinking), `skip`.
- Three modes: interactive (default TTY), `--non-interactive` (read-only list), `--auto-user-adopt` (safe bulk).
- Structured JSON audit log written to `~/.cleo/skills/.audit-log/adopt-<iso-ts>.json` every run, including a UUID `runId` for cross-stream correlation.
- LAFS-envelope JSON output by default; `--human` for colorised summary.

## Files

- `packages/caamp/src/commands/skills/doctor-adopt.ts` — handler (orphan discovery, decision policy, archive+delete, audit-log writer, CLI registration).
- `packages/caamp/src/commands/skills/index.ts` — wire new `doctor adopt-orphans` subgroup.
- `packages/caamp/tests/unit/skills-doctor-adopt.test.ts` — 17 tests across discovery, applyDecision, runDoctorAdopt modes, audit-log atomicity.

## Test plan

- [x] `vitest run tests/unit/skills-doctor-adopt.test.ts` → 17/17 pass
- [x] End-to-end CLI smoke: `cleo skills doctor adopt-orphans --non-interactive` emits LAFS envelope + audit log
- [x] End-to-end CLI smoke: `cleo skills doctor adopt-orphans --auto-user-adopt --human` bulk-adopts + inserts `source_type='user'` rows
- [x] `npx biome check packages/caamp/src/commands/skills/` clean
- [x] Companion tests (`doctor.test.ts`, `skills-audit.test.ts`, `skills-discovery.test.ts`) — 100/100 pass (no regressions)

## Architecture notes

- `node:sqlite` + `node:readline/promises` are loaded via `createRequire` because tsup/esbuild strip the `node:` prefix on static imports, leaving the runtime asking for the (non-existent) bare `sqlite` / `readline/promises` packages.
- Canonical adoption REFUSED unconditionally on user machines per architecture-v3 §6 — the refusal payload includes a remediation pointer to the PR flow (`clone cleocode → packages/skills/skills/<name>/ → PR`).
- Archive-before-delete: directory is `cpSync`'d into `~/.cleo/skills/.archive/<name>-<ts>/` first; only on successful copy is the original removed.
- Bridge-symlink awareness: entries under `~/.agents/skills/` whose `realpath` resolves into `~/.cleo/skills/` are skipped (they're bridge symlinks, not orphans).
- Idempotent: re-running on a directory that was already adopted yields a no-op upsert (no duplicate rows).

## Followups (out of scope)

- AC4 from the original task mentions `cleo adr add` integration to also record decisions to `.cleo/adrs/`. The executing instructions specified the structured audit log at `~/.cleo/skills/.audit-log/` as the canonical sink instead — followup task can wire ADR creation once the CLI helper is exposed from `@cleocode/caamp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)