### PR TITLE
feat(T9685-B4): flip project-root CI guard to STRICT mode — baseline goes to zero

### DIFF
--- a/.cleo/project-root-baseline.json
+++ b/.cleo/project-root-baseline.json
@@ -1,7 +1,0 @@
-{
-  "$comment": "T9584 baseline — see docs/project-root-conventions.md §6. Long-tail batches must NOT increase this number; each fixed callsite decreases it by one. When the count reaches 0, the lint workflow flips to --strict and this file is deleted.",
-  "violationCount": 57,
-  "capturedAt": "2026-05-19T00:00:00Z",
-  "task": "T9584",
-  "epic": "E-PROJECT-ROOT-AUDIT"
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,16 +157,18 @@ jobs:
         run: node scripts/lint-path-drift.mjs
 
   project-root-anti-pattern-lint:
-    # T9584 / E-PROJECT-ROOT-AUDIT close-out: reject the T9550 anti-pattern
-    # that materialised rogue `<subdir>/.cleo/` dirs when CLI commands ran
-    # from a monorepo subdirectory. Three rules:
+    # T9584 / E-PROJECT-ROOT-AUDIT close-out + T9685-B4 strict-mode flip:
+    # reject the T9550 anti-pattern that materialised rogue `<subdir>/.cleo/`
+    # dirs when CLI commands ran from a monorepo subdirectory. Three rules:
     #   1. Bare `process.cwd()` in `packages/core/src/...` (suppress with
     #      `// CWD-OK: <reason>` for legitimate non-project-root uses).
     #   2. `join(..., process.cwd(), ..., '.cleo', ...)` anywhere in packages/.
-    #   3. `homedir()` constructing `.cleo` paths outside canonical resolvers.
-    # Baseline mode: rejects only NEW violations beyond the count recorded in
-    # `.cleo/project-root-baseline.json`. When the long-tail follow-up batches
-    # land, the baseline reaches 0 and this workflow flips to --strict.
+    #   3. `homedir()` constructing `.cleo` paths outside canonical resolvers
+    #      (suppress with `// path-drift-allowed: <reason>` for documented
+    #      escape hatches like the `~/.cleo` symlink bootstrap anchor).
+    # Strict mode (--strict): zero violations allowed. The T9584 baseline file
+    # was deleted after the long-tail batches (T9685-B1, B2, B3) shipped and
+    # the count dropped to zero. NEW violations now fail CI immediately.
     # Pure static analysis of checked-in source — no untrusted input.
     name: Project Root Anti-Pattern Lint (T9584)
     runs-on: ubuntu-latest
@@ -177,7 +179,7 @@ jobs:
         with:
           node-version: '24'
       - name: Lint project-root anti-pattern in packages/
-        run: node scripts/lint-project-root-anti-pattern.mjs
+        run: node scripts/lint-project-root-anti-pattern.mjs --strict
 
   contracts-dep-lint:
     name: Contracts Dep Lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## [2026.5.83] (2026-05-19) — T9685 strict-mode flip — project-root baseline → zero
+
+Long-tail follow-up to the v2026.5.82 E-PROJECT-ROOT-AUDIT closure. The
+T9584 baseline-mode CI guard (which tolerated 57 remaining violations during
+the migration) flips to strict mode: zero violations allowed. Four PRs
+(B1 + B2 + B3 + B4) drove the baseline 57 → 0 and locked the regression
+gate permanently.
+
+### Fixed
+
+- **PR #310 (T9685-B1)** — replace 52 `process.cwd()` sites in CORE with
+  `resolveOrCwd()` / `getProjectRoot()` across `pipeline/engine-ops`, code
+  helpers, store/skills/agents/sentient/release, roadmap/tasks/task-work,
+  and Pattern B/C/E/F sites. CWD-OK annotations added where binding to the
+  operator's invocation cwd is intentional (e.g. discovering the running
+  binary's package.json).
+- **PR #313 (T9685-B2)** — consolidate `homedir()` + `.cleo` resolution into
+  a single `resolveLegacyCleoDir()` helper in `@cleocode/paths`. Refactored
+  6 daemon/gc call sites plus `context-monitor.ts`, `briefing.ts`,
+  `bootstrap.ts`, and `gc/daemon-entry.ts`. `cursor/install.ts:94` annotated
+  with CWD-OK (legitimate installer-context cwd binding).
+- **PR #309 (T9685-B3)** — route all raw `new DatabaseSync()` opens through
+  the `openCleoDb()` chokepoint (ADR-068). Extended the chokepoint API with
+  `readOnly` and `role` support. Refactored Category III (brain
+  db-connections) and Category V (misc) call sites. Closes the bypass route
+  around the canonical pragma policy.
+
+### Changed
+
+- **PR #N (T9685-B4)** — `scripts/lint-project-root-anti-pattern.mjs`
+  becomes strict-by-default. CI workflow `.github/workflows/ci.yml` now
+  passes `--strict` explicitly. Baseline file `.cleo/project-root-baseline.json`
+  deleted (no longer needed; count is zero). NEW anti-pattern instances now
+  fail CI immediately on the offending PR. One documented escape hatch
+  annotated: `packages/core/src/skills/skill-root.ts:112` uses
+  `// path-drift-allowed` because the `~/.cleo` symlink is the canonical
+  bootstrap target (see TSDoc above the function).
+
+### Documentation
+
+- `docs/project-root-conventions.md` §6 updated to reflect strict mode and
+  retirement of the baseline file. New cross-references to T9685-B1/B2/B3/B4.
+
+### Regression gate
+
+The T9550 bug class (rogue `<subdir>/.cleo/` materialising under a monorepo
+subdirectory) is now regression-locked permanently. Any new `process.cwd()`,
+`homedir().cleo`, or raw `new DatabaseSync()` in disallowed locations fails
+the build on the offending PR.
+
 ## [2026.5.82] (2026-05-19) — E-PROJECT-ROOT-AUDIT closure (T9580 epic)
 
 The actual remediation release for the T9580 codebase-wide project-root audit. Closes Epic T9580 with all 4 child tasks (T9581/T9582/T9583/T9584) shipped: production code normalized, CI guard in baseline mode, canonical doc published, ~75 test regressions resolved.

--- a/docs/project-root-conventions.md
+++ b/docs/project-root-conventions.md
@@ -186,6 +186,14 @@ To suppress for a genuinely-justified exception, append
 `// CWD-OK: <reason>` (or `// path-drift-allowed` for the homedir form). Long-lived
 exceptions should be listed in the script's allowlist with a one-line rationale.
 
+**Strict mode (T9685-B4).** As of T9685-B4 the linter is strict-by-default:
+zero violations allowed. The original T9584 `.cleo/project-root-baseline.json`
+file (which tolerated 57 → 12 → 1 long-tail violations during the migration)
+was deleted once the T9685-B1/B2/B3 batches drove the count to zero. New
+anti-pattern instances now fail CI immediately on the offending PR. The CI
+workflow passes `--strict` explicitly for intent; the flag is accepted as a
+no-op for workflow stability.
+
 ---
 
 ## 7. References
@@ -197,6 +205,9 @@ exceptions should be listed in the script's allowlist with a one-line rationale.
 - **T9582** — Batch 3 fix: `agent.ts`, `nexus.ts`, `dispatch/conduit.ts`, `dispatch/nexus.ts`.
 - **T9583** — Batch 1 fix: `release/`, `orchestrate/`, `spawn/`.
 - **T9584** — long-tail fix + `resolveOrCwd()` helper + this doc + CI guard.
+- **T9685-B1/B2/B3** — drove baseline 57 → 0 (CORE `process.cwd()` migration,
+  `homedir`-`.cleo` consolidation, raw `DatabaseSync` chokepoint).
+- **T9685-B4** — flip CI guard to strict mode; delete baseline file.
 - **T1463** — parent-`.cleo/` trap rejection.
 - **T1864** — `project-info.json` contract.
 - **T9092** — git-worktree gitlink handling.

--- a/packages/core/src/skills/skill-root.ts
+++ b/packages/core/src/skills/skill-root.ts
@@ -109,7 +109,7 @@ function legacySkillsPath(): string {
  * @returns The absolute new skills path (does not check existence).
  */
 function newSkillsPath(): string {
-  return join(homedir(), '.cleo', 'skills');
+  return join(homedir(), '.cleo', 'skills'); // path-drift-allowed: ~/.cleo symlink is the canonical bootstrap target — see TSDoc above
 }
 
 /**

--- a/scripts/lint-project-root-anti-pattern.mjs
+++ b/scripts/lint-project-root-anti-pattern.mjs
@@ -34,7 +34,14 @@
  * offending line. Use sparingly. Long-lived exceptions should be added to
  * the FILE_ALLOWLIST below with a one-line rationale.
  *
- * @task T9584
+ * Strict-by-default
+ * -----------------
+ * As of T9685-B4 the linter is strict-by-default: zero violations allowed.
+ * The T9584 baseline file was deleted after T9685-B1/B2/B3 drove the count
+ * to zero. The CI workflow passes `--strict` explicitly for intent; the
+ * flag is accepted as a no-op for workflow stability.
+ *
+ * @task T9584 / T9685-B4
  * @epic E-PROJECT-ROOT-AUDIT
  * @see docs/project-root-conventions.md
  */
@@ -256,21 +263,16 @@ function scanFile(filePath) {
 }
 
 // ============================================================================
-// Baseline mode (T9584)
+// Strict mode (T9685-B4)
 // ============================================================================
 //
-// The migration is incremental — long-tail files will land in follow-up PRs.
-// To avoid blocking the helper + doc + guard merge on every last callsite,
-// the linter runs in `--baseline` mode: it accepts the current violation
-// count as the upper bound and only fails when a NEW violation is added
-// beyond what `.cleo/project-root-baseline.json` records.
-//
-// Pass `--strict` to enforce zero violations. Once the long-tail batches
-// land the workflow flips to --strict and the baseline file is deleted.
-
-const args = process.argv.slice(2);
-const STRICT_MODE = args.includes('--strict');
-const BASELINE_FILE = '.cleo/project-root-baseline.json';
+// As of T9685-B4 the linter is strict-by-default: zero violations allowed.
+// The T9584 baseline file (`.cleo/project-root-baseline.json`) was deleted
+// after the long-tail batches T9685-B1 (CORE process.cwd), T9685-B2
+// (homedir-.cleo), and T9685-B3 (raw DatabaseSync chokepoint) shipped and
+// the violation count dropped to zero. The CI workflow still passes
+// `--strict` explicitly for documentation/intent; the flag is accepted as
+// a no-op for backwards compatibility with the workflow.
 
 // ============================================================================
 // Run
@@ -280,30 +282,9 @@ for (const dir of SCAN_DIRS) {
   walk(dir);
 }
 
-let baselineCount = 0;
-try {
-  const raw = readFileSync(BASELINE_FILE, 'utf8');
-  const parsed = JSON.parse(raw);
-  baselineCount = typeof parsed.violationCount === 'number' ? parsed.violationCount : 0;
-} catch {
-  // No baseline file — treat as 0.
-}
-
-if (STRICT_MODE) {
-  if (violations.length === 0) {
-    console.info('lint-project-root-anti-pattern: STRICT OK (zero violations)');
-    process.exit(0);
-  }
-} else {
-  if (violations.length <= baselineCount) {
-    console.info(
-      `lint-project-root-anti-pattern: OK — ${violations.length} violation(s) (baseline ${baselineCount}). Strict mode pending T9584 long-tail follow-up.`,
-    );
-    process.exit(0);
-  }
-  console.error(
-    `lint-project-root-anti-pattern: REGRESSION — ${violations.length} violations exceed baseline ${baselineCount}. New anti-pattern instances must be fixed before merge.`,
-  );
+if (violations.length === 0) {
+  console.info('lint-project-root-anti-pattern: STRICT OK (zero violations)');
+  process.exit(0);
 }
 
 console.error(


### PR DESCRIPTION
## Summary

Long-tail follow-up to the v2026.5.82 E-PROJECT-ROOT-AUDIT closure. After T9685-B1 (#310), T9685-B2 (#313), and T9685-B3 (#309) drove the project-root anti-pattern count from 57 → 0, this PR locks the regression gate permanently.

- `.github/workflows/ci.yml`: pass `--strict` to the lint script; explanatory comment updated.
- `scripts/lint-project-root-anti-pattern.mjs`: strict-by-default. Baseline-mode code path removed; the `--strict` flag is now a no-op kept for workflow stability.
- `.cleo/project-root-baseline.json`: deleted (count is zero).
- `packages/core/src/skills/skill-root.ts:112`: annotate the one remaining `homedir().cleo` site with `// path-drift-allowed`. This is the documented `~/.cleo` symlink bootstrap anchor (see TSDoc above the function).
- `docs/project-root-conventions.md` §6 + References: document strict-mode flip and baseline retirement.
- `CHANGELOG.md`: v2026.5.83 entry rolling up B1 + B2 + B3 + B4.

After this PR, the T9550 bug class (rogue `<subdir>/.cleo/` materialising under a monorepo subdirectory) is regression-locked. Any new `process.cwd()` in CORE, `homedir().cleo` outside canonical resolvers, or raw `new DatabaseSync()` in disallowed locations fails CI on the offending PR.

## Test plan

- [x] Rebase B4 onto current main (6dfc7b4cd, post B1/B2/B3 merges)
- [x] `node scripts/lint-project-root-anti-pattern.mjs --strict` → `STRICT OK (zero violations)`
- [x] `node scripts/lint-project-root-anti-pattern.mjs` (no flag) → `STRICT OK (zero violations)` (strict is now default)
- [ ] CI: `Project Root Anti-Pattern Lint (T9584)` job passes with `--strict`
- [ ] CI: full pipeline green (no regression in adjacent checks)
- [ ] Manual: confirm `.cleo/project-root-baseline.json` is gone in the merge commit

## Notes

- Branch label: `T9685-B4-strict-mode`
- Epic: E-PROJECT-ROOT-AUDIT (T9580 / T9584 long-tail)
- The CI workflow continues to pass `--strict` explicitly for intent/documentation, even though the lint script defaults to strict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>