### PR TITLE
fix(T9686-DE): worktree prune main-dir protection + AGENTS.md release docs cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,45 +126,65 @@ The `cleo sentient` subsystem manages autonomous task proposals.
 Tier-2 proposals are **disabled by default**. Enable them with `cleo sentient propose enable`.
 The kill-switch (`cleo sentient kill`) is always respected regardless of Tier-2 state.
 
-## Release & Branching (ADR-065)
+## Release & Branching (ADR-065, SPEC-T9345)
 
-All releases flow through a PR-gated pipeline. Direct pushes to `main` are prohibited.
+All releases flow through a PR-gated pipeline. Direct pushes to `main` are
+prohibited. The current pipeline uses the 4-verb model — `plan` → `open` →
+`reconcile` (or `rollback`) — introduced by SPEC-T9345 and finalized when
+T9540 removed the legacy `start` / `verify` / `publish` verbs.
 
 ### Branch Conventions
 
-- **Feature work**: `feat/T####-<slug>` branches
-- **Release branches**: automatically cut by `cleo release ship` as `release/v<version>`
+- **Feature work**: `feat/T####-<slug>` or `task/T####-<slug>` branches
+- **Release branches**: cut by the `release-prepare` GitHub Actions workflow
+  (dispatched by `cleo release open`) as `release/v<version>`
 - **Main branch**: receives merges only from reviewed, CI-green PRs
 
 ### Shipping a Release
 
 ```bash
-# 1. Prepare the release handle
-cleo release start v2026.MM.N
+# 1. Plan — build the canonical Release Plan envelope.
+#    Writes `.cleo/release/v<version>.plan.json` and persists one row in
+#    `releases` with status='planned'. Read-mostly: no git mutations,
+#    no `gh` calls, no network.
+cleo release plan v2026.MM.N --epic TXXXX
 
-# 2. Run gates + epic completeness check
-cleo release verify
+# 2. Open — dispatch the release-prepare GHA workflow. The workflow cuts
+#    `release/v<version>`, commits changelog + version bump, pushes the
+#    branch, and opens the PR. `releases.status` advances to 'pr-opened'.
+#    Use `--commit-plan` to commit the plan file in the same step.
+cleo release open v2026.MM.N
 
-# 3. Ship — cuts release/vX.Y.Z, opens PR, waits for CI, merges + tags
-cleo release ship 2026.MM.N --epic TXXXX
+# 3. (Optional) Poll PR + CI status while the workflow runs.
+cleo release pr-status v2026.MM.N
 
-# 4. Poll CI status while waiting
-cleo release pr-status 2026.MM.N
+# 4. Reconcile — after the PR merges and the release-publish workflow
+#    pushes the tag, reconcile backfills the 11 provenance tables.
+#    Typically invoked by the publish workflow itself; can be run
+#    manually with --from-workflow=false.
+cleo release reconcile v2026.MM.N
 ```
 
-`cleo release ship` performs these 12 steps automatically:
-1. Prepare (validate version, changelog)
-2. Run quality gates (lint, typecheck, tests)
-3. IVTR loop check
-4. Epic completeness check
-5. Double-listing guard
-6. CHANGELOG generation (tasks filtered by `completedAt > previousVersion.pushedAt`)
-7. Biome lint pass
-8. Cut `release/v<version>` branch
-9. Commit changelog + version bump
-10. Push branch + open PR via `gh`
-11. Wait for CI green (15-minute timeout)
-12. Merge (--merge) + tag from main + cleanup
+### Per-task evidence gating
+
+Per-task quality gates are no longer batched at release time. The legacy
+`cleo release verify` verb was removed in T9540; each task's gates must be
+recorded individually via the ADR-051 evidence-based ritual BEFORE
+completion:
+
+```bash
+# Per-task — runs once per gate, with programmatic evidence.
+cleo verify T#### --gate implemented --evidence "commit:<sha>;files:..."
+cleo verify T#### --gate testsPassed --evidence "tool:test"
+cleo verify T#### --gate qaPassed --evidence "tool:lint;tool:typecheck"
+cleo verify T#### --gate documented --evidence "files:..."
+
+# Then mark the task done. CLEO re-validates every hard atom on complete.
+cleo complete T####
+```
+
+See "Pre-Complete Gate Ritual (ADR-051)" in the protocol injection for the
+full atom grammar and tool-resolution rules.
 
 ### Rules
 
@@ -172,6 +192,9 @@ cleo release pr-status 2026.MM.N
 - `gh` CLI must be authenticated (`gh auth status`)
 - Branch model is configurable: `cleo config set release.branchModel feat-to-main`
 - To check in-flight PR CI status: `cleo release pr-status <version>`
+- `cleo release ship` is **[DEPRECATED]** — it forwards to `plan` + `open`
+  but emits a deprecation warning and will be removed no earlier than the
+  third release cycle after T9498. Prefer the explicit two-verb invocation.
 
 ### Branch Protection
 

--- a/packages/contracts/src/operations/worktree.ts
+++ b/packages/contracts/src/operations/worktree.ts
@@ -359,11 +359,17 @@ export interface PruneWorktreesResult {
  * heuristics in {@link WorktreeInfo}.
  *
  * Resolution precedence (first match wins):
- *  1. `locked` — git porcelain reports the worktree is locked.
- *  2. `orphan` — owning task is cancelled OR the branch has been deleted.
- *  3. `merged` — the branch is reachable from `main` (already integrated).
- *  4. `stale`  — no commits in N days AND (task=done OR no live owner).
- *  5. `active` — everything else (default).
+ *  1. `active` — primary worktree guard: the canonical project checkout
+ *     (the directory containing `.git/`, not a `git worktree add` derivative)
+ *     is ALWAYS active, regardless of merge state. Without this guard the
+ *     `main` branch would classify as `merged` (it is trivially its own
+ *     ancestor) and `cleo worktree prune --orphaned` would offer to delete
+ *     the project root. (T9686-D)
+ *  2. `locked` — git porcelain reports the worktree is locked.
+ *  3. `orphan` — owning task is cancelled OR the branch has been deleted.
+ *  4. `merged` — the branch is reachable from `main` (already integrated).
+ *  5. `stale`  — no commits in N days AND (task=done OR no live owner).
+ *  6. `active` — everything else (default).
  *
  * @task T9546
  */

--- a/packages/core/src/worktree/__tests__/list.test.ts
+++ b/packages/core/src/worktree/__tests__/list.test.ts
@@ -55,7 +55,9 @@ import {
   branchIsMergedToMain,
   classifyStatus,
   enumerateWorktrees,
+  isPrimaryWorktree,
   listWorktrees,
+  resolvePrimaryWorktreePath,
   taskIdFromBranch,
 } from '../list.js';
 
@@ -92,6 +94,12 @@ function installGitMock(opts: {
   mergedBranches?: Set<string>;
   /** Whether `refs/heads/main` resolves locally. */
   mainExists?: boolean;
+  /**
+   * Optional absolute path to the primary worktree's `.git` directory, returned by
+   * `git rev-parse --path-format=absolute --git-common-dir` (T9686-D primary
+   * guard). When omitted, the call throws so the guard falls back gracefully.
+   */
+  gitCommonDir?: string;
 }): void {
   const merged = opts.mergedBranches ?? new Set<string>();
   const timestamps = opts.branchTimestamps ?? {};
@@ -116,6 +124,10 @@ function installGitMock(opts: {
     if (argv[0] === 'rev-parse' && argv[1] === '--verify') {
       if (mainExists) return '' as never;
       throw new Error('no main');
+    }
+    if (argv[0] === 'rev-parse' && argv.includes('--git-common-dir')) {
+      if (opts.gitCommonDir !== undefined) return `${opts.gitCommonDir}\n` as never;
+      throw new Error('git-common-dir unavailable');
     }
     throw new Error(`unexpected git call: ${argv.join(' ')}`);
   });
@@ -177,6 +189,82 @@ describe('classifyStatus precedence', () => {
     expect(
       classifyStatus({ isLocked: false, isOrphan: false, isMerged: false, isStale: false }),
     ).toBe('active');
+  });
+
+  it('primary-worktree guard: isPrimary forces active even when merged (T9686-D)', () => {
+    expect(
+      classifyStatus({
+        isPrimary: true,
+        isLocked: false,
+        isOrphan: false,
+        isMerged: true,
+        isStale: false,
+      }),
+    ).toBe('active');
+  });
+
+  it('primary-worktree guard: isPrimary forces active even when orphan+merged+stale', () => {
+    expect(
+      classifyStatus({
+        isPrimary: true,
+        isLocked: false,
+        isOrphan: true,
+        isMerged: true,
+        isStale: true,
+      }),
+    ).toBe('active');
+  });
+
+  it('primary-worktree guard: omitting isPrimary preserves legacy behavior', () => {
+    expect(
+      classifyStatus({ isLocked: false, isOrphan: false, isMerged: true, isStale: false }),
+    ).toBe('merged');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Primary-worktree detection (T9686-D)
+// ---------------------------------------------------------------------------
+
+describe('resolvePrimaryWorktreePath', () => {
+  it('strips trailing .git from the git-common-dir output', () => {
+    mockExec.mockReturnValueOnce('/repo/.git\n' as never);
+    expect(resolvePrimaryWorktreePath('/repo')).toBe('/repo');
+  });
+
+  it('strips trailing .git/ with slash', () => {
+    mockExec.mockReturnValueOnce('/repo/.git/\n' as never);
+    expect(resolvePrimaryWorktreePath('/repo')).toBe('/repo');
+  });
+
+  it('returns null when git fails', () => {
+    mockExec.mockImplementationOnce(() => {
+      throw new Error('not a git repo');
+    });
+    expect(resolvePrimaryWorktreePath('/elsewhere')).toBeNull();
+  });
+
+  it('returns null when stdout is empty', () => {
+    mockExec.mockReturnValueOnce('\n' as never);
+    expect(resolvePrimaryWorktreePath('/repo')).toBeNull();
+  });
+});
+
+describe('isPrimaryWorktree', () => {
+  it('returns true when worktree path equals primary path', () => {
+    expect(isPrimaryWorktree('/repo', '/repo')).toBe(true);
+  });
+
+  it('returns true after path normalization', () => {
+    expect(isPrimaryWorktree('/repo/./foo/..', '/repo')).toBe(true);
+  });
+
+  it('returns false for a different path', () => {
+    expect(isPrimaryWorktree('/repo/wt/T1', '/repo')).toBe(false);
+  });
+
+  it('returns false when primaryPath is null', () => {
+    expect(isPrimaryWorktree('/repo', null)).toBe(false);
   });
 });
 
@@ -329,6 +417,49 @@ describe('listWorktrees — status classification', () => {
     if (!result.success) throw new Error('expected success');
     expect(result.data.worktrees[0]?.statusCategory).toBe('orphan');
     expect(result.data.worktrees[0]?.owningTaskStatus).toBeNull();
+  });
+
+  it('primary worktree on main is classified active, NOT merged (T9686-D)', async () => {
+    // Simulates the production bug: the canonical project checkout sits on
+    // `main` which is trivially its own ancestor, so without the
+    // primary-worktree guard the classifier would label it `merged` and
+    // `cleo worktree prune --orphaned` would offer to delete the project root.
+    installGitMock({
+      porcelainOutput: porcelain([{ path: '/repo', branch: 'main' }]),
+      branchTimestamps: { main: nowIso(0) },
+      mergedBranches: new Set(['main']),
+      gitCommonDir: '/repo/.git',
+    });
+
+    const result = await listWorktrees({ projectRoot: '/repo' });
+    if (!result.success) throw new Error('expected success');
+    const wt = result.data.worktrees[0];
+    expect(wt?.path).toBe('/repo');
+    expect(wt?.statusCategory).toBe('active');
+    // isMerged still reflects reality (main IS an ancestor of main) — only the
+    // category is overridden so downstream code (prune) can't act on it.
+    expect(wt?.isMerged).toBe(true);
+  });
+
+  it('primary-guard does not affect secondary worktrees (T9686-D)', async () => {
+    MOCK_TASK_ROWS.set('T9001', 'active');
+    installGitMock({
+      porcelainOutput: porcelain([
+        { path: '/repo', branch: 'main' },
+        { path: '/repo/.cleo/worktrees/T9001', branch: 'task/T9001' },
+      ]),
+      branchTimestamps: { main: nowIso(0), 'task/T9001': nowIso(0) },
+      mergedBranches: new Set(['main', 'task/T9001']),
+      gitCommonDir: '/repo/.git',
+    });
+
+    const result = await listWorktrees({ projectRoot: '/repo' });
+    if (!result.success) throw new Error('expected success');
+    const byPath = new Map(result.data.worktrees.map((w) => [w.path, w]));
+    expect(byPath.get('/repo')?.statusCategory).toBe('active');
+    // Secondary worktree: still classified as `merged` (it really is — the guard
+    // only protects the primary), so prune candidacy is unchanged for it.
+    expect(byPath.get('/repo/.cleo/worktrees/T9001')?.statusCategory).toBe('merged');
   });
 });
 

--- a/packages/core/src/worktree/__tests__/primary-guard.test.ts
+++ b/packages/core/src/worktree/__tests__/primary-guard.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration test for the T9686-D primary-worktree safety net.
+ *
+ * Unlike the heavily-mocked unit suite in `list.test.ts` and `prune.test.ts`,
+ * this spec spawns REAL git in a freshly-initialized tmp repo so we exercise
+ * the end-to-end path: `git worktree list --porcelain` → classifier →
+ * prune candidate filter. The repro the regression here matches exactly what
+ * the user reported: running `cleo worktree prune --orphaned --dry-run` on the
+ * canonical project root must NEVER mark the project root as a prune candidate.
+ *
+ * @task T9686-D
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { listWorktrees } from '../list.js';
+import { pruneOrphanedWorktreesByStatus } from '../prune.js';
+
+function run(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+let repoRoot: string;
+
+beforeEach(() => {
+  repoRoot = mkdtempSync(join(tmpdir(), 'cleo-t9686d-primary-'));
+  // Initialize a minimal repo with one commit on `main` so `merge-base
+  // --is-ancestor main main` succeeds — that's the exact condition that
+  // caused the regression.
+  run(repoRoot, ['init', '-q', '-b', 'main']);
+  run(repoRoot, ['config', 'user.email', 't9686d@example.invalid']);
+  run(repoRoot, ['config', 'user.name', 'T9686-D Test']);
+  writeFileSync(join(repoRoot, 'README.md'), 'hello\n');
+  run(repoRoot, ['add', 'README.md']);
+  run(repoRoot, ['commit', '-q', '-m', 'init']);
+});
+
+afterEach(() => {
+  try {
+    rmSync(repoRoot, { recursive: true, force: true });
+  } catch {
+    /* tmpdir cleanup best-effort */
+  }
+});
+
+describe('T9686-D primary-worktree guard (real git)', () => {
+  it('classifies a bare main checkout as `active`, NOT `merged`', async () => {
+    const result = await listWorktrees({ projectRoot: repoRoot });
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('expected success');
+
+    expect(result.data.worktrees).toHaveLength(1);
+    const primary = result.data.worktrees[0];
+    expect(primary?.branch).toBe('main');
+    // The branch IS reachable from itself — that part is reality.
+    expect(primary?.isMerged).toBe(true);
+    // The category overrides the merged status so prune candidacy is denied.
+    expect(primary?.statusCategory).toBe('active');
+  });
+
+  it('prune --dry-run never lists the primary worktree as a candidate', async () => {
+    const auditLogPath = join(repoRoot, 'audit.jsonl');
+    const result = await pruneOrphanedWorktreesByStatus({
+      projectRoot: repoRoot,
+      auditLogPath,
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('expected success');
+    const candidatePaths = result.data.outcomes.map((o) => o.path);
+    expect(candidatePaths).not.toContain(repoRoot);
+    expect(result.data.outcomes).toHaveLength(0);
+  });
+
+  it('secondary worktrees on merged branches are still pruneable', async () => {
+    // Create a fully-merged secondary worktree: branch off main, never diverge.
+    // `git worktree add` checks out a new ref pointing at the same commit, so
+    // `merge-base --is-ancestor <branch> main` returns exit 0.
+    //
+    // We use a non-`task/` branch name so the classifier doesn't treat the
+    // worktree as an orphan (taskId set, owningTaskStatus null → orphan in
+    // precedence). The intent here is to exercise the `merged` candidacy
+    // path, not orphan detection — those have separate coverage.
+    const secondaryPath = join(repoRoot, 'wt-secondary');
+    run(repoRoot, ['worktree', 'add', '-b', 'feat/already-merged', secondaryPath]);
+
+    try {
+      const list = await listWorktrees({ projectRoot: repoRoot });
+      if (!list.success) throw new Error('expected success');
+      // The primary stays active; the secondary classifies as merged.
+      const primary = list.data.worktrees.find((w) => w.path === repoRoot);
+      expect(primary?.statusCategory).toBe('active');
+      const secondary = list.data.worktrees.find((w) => w.branch === 'feat/already-merged');
+      expect(secondary?.statusCategory).toBe('merged');
+
+      // Prune dry-run should pick up the secondary but skip the primary.
+      const prune = await pruneOrphanedWorktreesByStatus({
+        projectRoot: repoRoot,
+        auditLogPath: join(repoRoot, 'audit.jsonl'),
+        dryRun: true,
+      });
+      if (!prune.success) throw new Error('expected success');
+      const paths = prune.data.outcomes.map((o) => o.path);
+      expect(paths).not.toContain(repoRoot);
+      expect(paths.some((p) => p.endsWith('/wt-secondary'))).toBe(true);
+    } finally {
+      // Clean up the secondary worktree before tmpdir nuke (otherwise git's
+      // admin entry under .git/worktrees/wt-secondary lingers across tests).
+      try {
+        run(repoRoot, ['worktree', 'remove', '--force', secondaryPath]);
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+});

--- a/packages/core/src/worktree/__tests__/prune.test.ts
+++ b/packages/core/src/worktree/__tests__/prune.test.ts
@@ -18,7 +18,7 @@
 
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve as resolvePath } from 'node:path';
 import type { WorktreeInfo } from '@cleocode/contracts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -32,6 +32,13 @@ const MOCK_LIST: { value: WorktreeInfo[]; success: boolean; errorMsg: string } =
   errorMsg: '',
 };
 
+/**
+ * Optional primary-worktree path consulted by the mocked
+ * `resolvePrimaryWorktreePath`. Tests that exercise the T9686-D safety net
+ * set this; legacy tests leave it null so `isPrimaryWorktree` is a no-op.
+ */
+let MOCK_PRIMARY_PATH: string | null = null;
+
 vi.mock('../list.js', () => ({
   listWorktrees: vi.fn(async () => {
     if (!MOCK_LIST.success) {
@@ -44,6 +51,14 @@ vi.mock('../list.js', () => ({
       success: true,
       data: { worktrees: MOCK_LIST.value },
     };
+  }),
+  // Mirror the real exports prune.ts depends on. We intentionally implement
+  // them here instead of `vi.importActual` so prune-test mocks don't bleed
+  // into the list.test.ts surface area.
+  resolvePrimaryWorktreePath: vi.fn(() => MOCK_PRIMARY_PATH),
+  isPrimaryWorktree: vi.fn((worktreePath: string, primary: string | null) => {
+    if (primary === null) return false;
+    return resolvePath(worktreePath) === resolvePath(primary);
   }),
 }));
 
@@ -108,6 +123,7 @@ beforeEach(() => {
   MOCK_LIST.value = [];
   MOCK_LIST.success = true;
   MOCK_LIST.errorMsg = '';
+  MOCK_PRIMARY_PATH = null;
   execCalls.length = 0;
   execShouldThrow.clear();
   vi.clearAllMocks();
@@ -284,6 +300,80 @@ describe('pruneOrphanedWorktreesByStatus — happy path', () => {
 // ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Primary-worktree safety net (T9686-D)
+// ---------------------------------------------------------------------------
+
+describe('pruneOrphanedWorktreesByStatus — primary worktree safety net (T9686-D)', () => {
+  it('NEVER prunes the canonical project root, even when classified merged', async () => {
+    // The mocked `resolvePrimaryWorktreePath` reads MOCK_PRIMARY_PATH — set it
+    // to the tmp projectRoot so the safety net knows which path to protect.
+    MOCK_PRIMARY_PATH = projectRoot;
+
+    MOCK_LIST.value = [
+      // Primary worktree — incorrectly classified as `merged` (simulates the
+      // pre-fix classifier slipping through, e.g. due to a future regression).
+      makeWorktreeInfo({
+        path: projectRoot,
+        branch: 'main',
+        taskId: null,
+        statusCategory: 'merged',
+        isMerged: true,
+      }),
+      // A real orphan candidate — should still be pruned normally.
+      makeWorktreeInfo({
+        path: '/wt/T100',
+        branch: 'task/T100',
+        taskId: 'T100',
+        statusCategory: 'orphan',
+        owningTaskStatus: 'cancelled',
+      }),
+    ];
+
+    const result = await pruneOrphanedWorktreesByStatus({
+      projectRoot,
+      auditLogPath,
+      actor: 'unit-test',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('expected success');
+    // Primary worktree must be excluded entirely — it should never appear in
+    // outcomes (not even as `pruned: false`), because the filter runs BEFORE
+    // candidate enumeration.
+    const paths = result.data.outcomes.map((o) => o.path);
+    expect(paths).not.toContain(projectRoot);
+    expect(paths).toContain('/wt/T100');
+    expect(result.data.prunedCount).toBe(1);
+  });
+
+  it('dry-run also excludes the primary worktree from candidate list', async () => {
+    MOCK_PRIMARY_PATH = projectRoot;
+
+    MOCK_LIST.value = [
+      makeWorktreeInfo({
+        path: projectRoot,
+        branch: 'main',
+        taskId: null,
+        statusCategory: 'merged',
+        isMerged: true,
+      }),
+    ];
+
+    const result = await pruneOrphanedWorktreesByStatus({
+      projectRoot,
+      auditLogPath,
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('expected success');
+    expect(result.data.outcomes).toHaveLength(0);
+    expect(result.data.prunedCount).toBe(0);
+    expect(result.data.skippedCount).toBe(0);
+  });
+});
 
 describe('pruneOrphanedWorktreesByStatus — edge cases', () => {
   it('returns prunedCount=0 when no orphans exist', async () => {

--- a/packages/core/src/worktree/list.ts
+++ b/packages/core/src/worktree/list.ts
@@ -28,8 +28,8 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { join, resolve as resolvePath } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import {
   type EngineResult,
@@ -113,11 +113,20 @@ export async function listWorktrees(
   // `branchIsMergedToMain` would otherwise spuriously throw for every entry.
   const mainBranch = resolveMainBranch(projectRoot);
 
+  // Pre-resolve the primary worktree path. The primary worktree is the
+  // canonical project checkout (NOT a `git worktree add` derivative) — it
+  // must never be classified as `merged`/`orphan`/`stale`, even though its
+  // branch (typically `main`) is trivially an ancestor of itself. Without
+  // this guard, `cleo worktree prune --orphaned` would offer to delete the
+  // project root.
+  const primaryWorktreePath = resolvePrimaryWorktreePath(projectRoot);
+
   const worktrees: WorktreeInfo[] = porcelainEntries.map((entry) => {
     const taskId = branchToTaskId.get(entry.branch) ?? null;
     const lastActivityMs =
       getLastCommitTimestampMs(entry.branch, projectRoot) ?? mtimeMs(entry.path);
     const lastActivity = new Date(lastActivityMs).toISOString();
+    const isPrimary = isPrimaryWorktree(entry.path, primaryWorktreePath);
     const isMerged = mainBranch
       ? branchIsMergedToMain(entry.branch, projectRoot, mainBranch)
       : false;
@@ -133,6 +142,7 @@ export async function listWorktrees(
     const isStale = idleOlderThanThreshold && (ownerTerminal || isMerged);
 
     const statusCategory = classifyStatus({
+      isPrimary,
       isLocked: entry.locked,
       isOrphan,
       isMerged,
@@ -306,16 +316,23 @@ export function branchIsMergedToMain(
  * mutually-exclusive `statusCategory` field. See the {@link WorktreeStatusCategory}
  * docstring for the resolution order.
  *
+ * Primary-worktree guard: the canonical project checkout is always classified
+ * as `active`, regardless of merge state. The primary worktree's branch is
+ * trivially an ancestor of itself (`main` is reachable from `main`), so the
+ * naive ancestry check would label it `merged` and make it a prune candidate.
+ *
  * @param flags - The set of pre-computed boolean classifiers.
  * @returns The resolved status category.
  * @internal Exported for tests only.
  */
 export function classifyStatus(flags: {
+  isPrimary?: boolean;
   isLocked: boolean;
   isOrphan: boolean;
   isMerged: boolean;
   isStale: boolean;
 }): WorktreeStatusCategory {
+  if (flags.isPrimary === true) return 'active';
   if (flags.isLocked) return 'locked';
   if (flags.isOrphan) return 'orphan';
   if (flags.isMerged) return 'merged';
@@ -420,5 +437,65 @@ function resolveMainBranch(projectRoot: string): string | null {
     return DEFAULT_MAIN_BRANCH;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Resolve the canonical primary worktree path — i.e. the directory containing
+ * the repository's `.git` directory (not a `.git` file pointing into
+ * `.git/worktrees/<name>`).
+ *
+ * Implementation: `git rev-parse --path-format=absolute --git-common-dir`
+ * returns the absolute path to `.git` regardless of which worktree the
+ * command is invoked from. The primary worktree is the parent of that path.
+ *
+ * Falls back to null on failure — callers treat missing detection as "do
+ * nothing special" (no primary guard applied). This is safe: every worktree
+ * still gets classified, just the same way the old code did.
+ *
+ * @param projectRoot - Project root for the git invocation.
+ * @returns Absolute path to the primary worktree, or null on failure.
+ * @internal Exported for tests only.
+ */
+export function resolvePrimaryWorktreePath(projectRoot: string): string | null {
+  try {
+    const commonDir = execFileSync(
+      'git',
+      ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+      {
+        cwd: projectRoot,
+        encoding: 'utf-8',
+        timeout: GIT_TIMEOUT_MS,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    ).trim();
+    if (!commonDir) return null;
+    // The primary worktree is the parent of `.git` (or `.git/`). Strip the
+    // trailing `/.git` segment to recover the worktree path itself.
+    const normalized = commonDir.replace(/\/?\.git\/?$/, '');
+    return normalized || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Test whether the given worktree path is the canonical primary worktree.
+ *
+ * Compares both raw and `realpath`-resolved variants to handle the common
+ * case where the project root is symlinked or contains symlinked ancestors.
+ *
+ * @param worktreePath - Path from `git worktree list --porcelain`.
+ * @param primaryPath - Output of {@link resolvePrimaryWorktreePath}, or null.
+ * @returns true iff the two paths resolve to the same canonical location.
+ * @internal Exported for tests only.
+ */
+export function isPrimaryWorktree(worktreePath: string, primaryPath: string | null): boolean {
+  if (primaryPath === null) return false;
+  if (resolvePath(worktreePath) === resolvePath(primaryPath)) return true;
+  try {
+    return realpathSync(worktreePath) === realpathSync(primaryPath);
+  } catch {
+    return false;
   }
 }

--- a/packages/core/src/worktree/prune.ts
+++ b/packages/core/src/worktree/prune.ts
@@ -35,7 +35,7 @@ import {
 } from '@cleocode/contracts';
 import { getLogger } from '../logger.js';
 import { appendWorktreeAuditEntry, resolveWorktreeAuditActor } from './audit.js';
-import { listWorktrees } from './list.js';
+import { isPrimaryWorktree, listWorktrees, resolvePrimaryWorktreePath } from './list.js';
 
 const log = getLogger('worktree:prune');
 
@@ -101,8 +101,17 @@ export async function pruneOrphanedWorktreesByStatus(
   // Candidates: any worktree the T9546 classifier labelled `orphan` or `merged`.
   // We deliberately keep these two categories together — both mean "no longer
   // needed for active development" and both are safe to delete-on-confirm.
+  //
+  // Primary-worktree safety net (T9686-D): even when the classifier returns
+  // `merged` for the canonical project checkout (a regression we've seen
+  // because `main` is trivially an ancestor of itself), the primary worktree
+  // is NEVER a valid prune target. Filter it out unconditionally as
+  // defense-in-depth on top of the `classifyStatus` `isPrimary` guard.
+  const primaryWorktreePath = resolvePrimaryWorktreePath(opts.projectRoot);
   const allCandidates = listResult.data.worktrees.filter(
-    (w) => w.statusCategory === 'orphan' || w.statusCategory === 'merged',
+    (w) =>
+      (w.statusCategory === 'orphan' || w.statusCategory === 'merged') &&
+      !isPrimaryWorktree(w.path, primaryWorktreePath),
   );
 
   // Optional path-filter — used by the CLI to apply per-orphan Y/N answers.


### PR DESCRIPTION
## Summary

Fixes two distinct issues filed as T9686-D and T9686-E:

### D1 — Worktree prune classifies the canonical project root as orphaned-merged

`cleo worktree prune --orphaned --dry-run` was offering to delete the main checkout. Reproduction (before fix):

```bash
$ cleo worktree prune --orphaned --dry-run | head -c 500
{"success":true,"data":{"prunedCount":0,"skippedCount":39,"outcomes":[
  {"path":"/mnt/projects/cleocode","branch":"main","taskId":null,
   "reason":"orphaned-merged","pruned":false,...
```

Root cause in `packages/core/src/worktree/list.ts`: `merge-base --is-ancestor main main` returns exit 0 (a branch is trivially its own ancestor), so the primary checkout walked the precedence to `merged` and `pruneOrphanedWorktreesByStatus` accepted it as a candidate.

Two-layer fix:
- **Classifier guard** — new `isPrimary` flag in `classifyStatus` takes top precedence and forces `active` for the canonical checkout. Detected via `git rev-parse --path-format=absolute --git-common-dir`.
- **Defense-in-depth filter** — `prune.ts` also filters out the primary path even if classification slips.

`isMerged` on `WorktreeInfo` still reflects reality; only the category is overridden so downstream consumers can't act on it.

### E1/E2 — AGENTS.md release section is stale

Two references in the "Release & Branching (ADR-065)" section were stale:
- `cleo release verify` — removed in T9540 (per `release.ts` line 332-336). Per-task gates are now recorded individually via `cleo verify <task> --gate X --evidence ...` per ADR-051.
- `cleo release ship` — now `[DEPRECATED]` per `release.ts` line 44. Canonical pipeline is `plan → open → reconcile`.

AGENTS.md now documents the SPEC-T9345 4-verb pipeline and the ADR-051 per-task gate ritual, with a note that `ship` is deprecated until at least three release cycles after T9498.

## Test plan

- [x] `pnpm vitest run packages/core/src/worktree` — 96/96 green
- [x] `pnpm biome check` on all modified files — clean
- [x] New tests:
  - `list.test.ts` — 3 new `classifyStatus` cases (isPrimary precedence) + 4 `resolvePrimaryWorktreePath` cases + 4 `isPrimaryWorktree` cases + 2 end-to-end cases (primary classifies active, secondary still classifies merged)
  - `prune.test.ts` — 2 new defense-in-depth cases (primary excluded in real + dry-run)
  - `primary-guard.test.ts` (new file) — real-git integration test that initializes a tmp repo on `main`, runs both `listWorktrees` and `pruneOrphanedWorktreesByStatus`, asserts project root is never a prune candidate
- [ ] Reviewer: verify `cleo worktree prune --orphaned --dry-run` against the canonical checkout no longer lists the project root after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)