### PR TITLE
feat(T9567): E-SKILLS-DEPTH-BACKFILL (9 tasks, 8 skills + CI gate)

### DIFF
--- a/.github/workflows/skills-depth-check.yml
+++ b/.github/workflows/skills-depth-check.yml
@@ -1,0 +1,68 @@
+name: Skills Depth Check (T9684)
+
+# Gates progressive-disclosure depth on skill definitions.
+# Runs the check_depth.py script against every skill under
+# packages/skills/skills/. Fails on stub skills (SKILL.md too short
+# AND no references/ subdir AND no manifest references[]).
+#
+# An allowlist in check_depth.py exempts pre-existing stubs at T9567;
+# each entry MUST carry a follow-up task ID. Owner approval required to
+# add new entries.
+#
+# Triggers on PRs touching packages/skills/ so author gets feedback at
+# review time, before merge.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/skills/skills/**'
+      - 'packages/skills/__tests__/**'
+      - '.github/workflows/skills-depth-check.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/skills/skills/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  depth-check:
+    name: progressive-disclosure-depth
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run depth check (all skills)
+        run: |
+          python packages/skills/skills/ct-skill-validator/scripts/check_depth.py \
+            . --all --json | tee /tmp/depth-report.json
+
+      - name: Summarize
+        if: always()
+        run: |
+          if [ -f /tmp/depth-report.json ]; then
+            python -c "
+          import json
+          with open('/tmp/depth-report.json') as f:
+              data = json.load(f)
+          summary = data['summary']
+          print(f\"Total skills: {summary['total']}\")
+          print(f\"Passed: {summary['passed']}\")
+          print(f\"Failed: {summary['failed']}\")
+          if summary['failed'] > 0:
+              print()
+              print('FAILED skills:')
+              for s in data['skills']:
+                  if not s['passed']:
+                      print(f\"  - {s['skill_name']} (body={s['body_lines']} lines, refs={s['ref_files_on_disk']} files)\")
+                      for r in s.get('remediation', []):
+                          print(f\"      * {r}\")
+          "
+          fi

--- a/packages/skills/__tests__/depth-check.test.ts
+++ b/packages/skills/__tests__/depth-check.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Integration tests for the progressive-disclosure-depth rule (T9684).
+ *
+ * Exercises `packages/skills/skills/ct-skill-validator/scripts/check_depth.py`
+ * against (a) the gold-standard ct-orchestrator skill — must pass, and
+ * (b) a synthetic stub fixture written to a tmp dir — must fail.
+ *
+ * The depth rule guards against the "stub skill" regression that
+ * E-SKILLS-DEPTH-BACKFILL (T9567) corrected. Future stub skills MUST
+ * fail this check, which the CI workflow surfaces on PRs touching
+ * `packages/skills/skills/**`.
+ *
+ * @task T9684
+ */
+
+import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const thisFile = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(thisFile), '..', '..', '..');
+const checkDepthScript = join(
+  repoRoot,
+  'packages/skills/skills/ct-skill-validator/scripts/check_depth.py',
+);
+const ctOrchestratorPath = join(repoRoot, 'packages/skills/skills/ct-orchestrator');
+
+/** Run check_depth.py and capture exit code + JSON output. */
+function runCheckDepth(args: string[]): {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  report?: unknown;
+} {
+  try {
+    const stdout = execSync(`python3 "${checkDepthScript}" ${args.join(' ')}`, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return {
+      exitCode: 0,
+      stdout,
+      stderr: '',
+      report: args.includes('--json') ? JSON.parse(stdout) : undefined,
+    };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return {
+      exitCode: e.status ?? 1,
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+      report: args.includes('--json') && e.stdout ? JSON.parse(e.stdout) : undefined,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pass case — gold-standard ct-orchestrator
+// ---------------------------------------------------------------------------
+
+describe('check_depth.py — pass case (gold standard)', () => {
+  it('ct-orchestrator passes the progressive-disclosure-depth rule', () => {
+    const result = runCheckDepth([`"${ctOrchestratorPath}"`, '--json']);
+    expect(result.exitCode).toBe(0);
+    const report = result.report as {
+      skill_name: string;
+      passed: boolean;
+      ref_files_on_disk: number;
+    };
+    expect(report.skill_name).toBe('ct-orchestrator');
+    expect(report.passed).toBe(true);
+    // Gold standard has 9 reference files
+    expect(report.ref_files_on_disk).toBeGreaterThanOrEqual(3);
+  });
+
+  it('each T9567-backfilled skill passes the rule', () => {
+    const backfilled = [
+      'ct-research-agent',
+      'ct-spec-writer',
+      'ct-task-executor',
+      'ct-validator',
+      'ct-documentor',
+      'ct-docs-lookup',
+      'ct-docs-write',
+      'ct-docs-review',
+    ];
+    for (const name of backfilled) {
+      const skillPath = join(repoRoot, 'packages/skills/skills', name);
+      const result = runCheckDepth([`"${skillPath}"`, '--json']);
+      expect(result.exitCode, `${name} should pass depth check, got: ${result.stdout}`).toBe(0);
+      const report = result.report as { passed: boolean };
+      expect(report.passed, `${name} should pass depth check`).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail case — synthetic stub fixture
+// ---------------------------------------------------------------------------
+
+describe('check_depth.py — fail case (synthetic stub)', () => {
+  let stubDir: string;
+
+  beforeAll(() => {
+    // Create a synthetic stub: minimal SKILL.md, no references/, not in
+    // any manifest. The depth rule MUST flag it.
+    stubDir = mkdtempSync(join(tmpdir(), 'cleo-depth-stub-'));
+    const stubSkillDir = join(stubDir, 'ct-synthetic-stub');
+    mkdirSync(stubSkillDir, { recursive: true });
+
+    const stubSkillMd = `---
+name: ct-synthetic-stub
+description: A deliberately minimal stub used to exercise the progressive-disclosure-depth rule in tests. Use only for the test suite.
+---
+
+# Synthetic stub
+
+This is too short.
+`;
+    writeFileSync(join(stubSkillDir, 'SKILL.md'), stubSkillMd);
+  });
+
+  afterAll(() => {
+    if (stubDir) {
+      rmSync(stubDir, { recursive: true, force: true });
+    }
+  });
+
+  it('synthetic stub fails the rule', () => {
+    const stubSkillDir = join(stubDir, 'ct-synthetic-stub');
+    const result = runCheckDepth([`"${stubSkillDir}"`, '--json']);
+    expect(result.exitCode).toBe(1);
+    const report = result.report as {
+      skill_name: string;
+      passed: boolean;
+      body_lines: number;
+      ref_files_on_disk: number;
+      remediation: string[];
+    };
+    expect(report.skill_name).toBe('ct-synthetic-stub');
+    expect(report.passed).toBe(false);
+    expect(report.body_lines).toBeLessThan(100);
+    expect(report.ref_files_on_disk).toBe(0);
+    // Remediation MUST point at the gold standard
+    const remediationText = report.remediation.join(' ');
+    expect(remediationText).toMatch(/ct-orchestrator/);
+    expect(remediationText).toMatch(/ct-skill-creator/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Repo-wide sweep
+// ---------------------------------------------------------------------------
+
+describe('check_depth.py --all (repo sweep)', () => {
+  it('every skill currently in the repo passes or is allowlisted', () => {
+    const result = runCheckDepth([`"${repoRoot}"`, '--all', '--json']);
+    expect(result.exitCode).toBe(0);
+    const report = result.report as {
+      summary: { total: number; passed: number; failed: number };
+    };
+    expect(report.summary.failed).toBe(0);
+    expect(report.summary.total).toBeGreaterThan(0);
+    expect(report.summary.passed).toBe(report.summary.total);
+  });
+});

--- a/packages/skills/skills/ct-docs-lookup/SKILL.md
+++ b/packages/skills/skills/ct-docs-lookup/SKILL.md
@@ -64,3 +64,118 @@ Incorporate the fetched documentation into your response:
 - **Be specific**: Pass the user's full question as the query for better results
 - **Version awareness**: When users mention versions ("Next.js 15", "React 19"), use version-specific library IDs if available from the resolution step
 - **Prefer official sources**: When multiple matches exist, prefer official/primary packages over community forks
+
+## Why Context7 (not training data)
+
+The user's global rule is explicit: prefer Context7 over training data for any
+library, framework, SDK, API, CLI tool, or cloud service — even well-known ones
+like React, Next.js, Prisma, Express, Tailwind, Django, or Spring Boot. This
+includes API syntax, configuration, version migration, library-specific
+debugging, setup instructions, and CLI tool usage. Use even when you think
+you know the answer; training data may not reflect recent changes.
+
+## Three-Command Budget
+
+The user rules cap a docs lookup at three CLI invocations per question. The
+budget fits the standard workflow:
+
+1. `npx ctx7@latest library "<name>" "<question>"` — one call to resolve.
+2. `npx ctx7@latest docs <id> "<question>"` — one call to fetch.
+3. (Optional) `npx ctx7@latest docs <id> "<question>" --research` — one
+   retry with sandboxed agents pulling source + web search.
+
+Going over budget is a signal: the library name is wrong, the question
+is too broad, or Context7 doesn't cover this library. In any of those
+cases, refine before retrying — don't burn more calls.
+
+## When NOT to Use This Skill
+
+The user rules explicitly exclude these from docs-lookup:
+
+- **Refactoring** — re-shaping existing code; no library lookup needed.
+- **Scripts written from scratch** — general programming, not library API.
+- **Debugging business logic** — use codebase tools (Grep, GitNexus), not
+  external docs.
+- **Code review** — quality assessment, not library reference.
+- **General programming concepts** — pure CS questions; training data is fine.
+
+Use docs-lookup ONLY for: API syntax, configuration questions, version
+migration issues, library-specific debugging, setup instructions, and CLI
+tool usage.
+
+## Authentication and Quotas
+
+The `ctx7` CLI runs anonymously with a limited free quota. When quota
+exhausts:
+
+```text
+Error: Quota exceeded.
+  Run `npx ctx7@latest login` for higher limits.
+  Or set CONTEXT7_API_KEY env var with your key.
+```
+
+Surface the error to the user (or include in `needs_followup`). NEVER
+silently fall back to training data — that violates the skill's contract.
+
+## Sensitive Data
+
+Queries to Context7 are logged on the Context7 side. Never include:
+
+- API keys, tokens, passwords
+- Internal hostnames or URLs
+- Customer-identifying data
+- Source code excerpts from private repos
+
+Use generic phrasing. If the actual API call needs a specific value,
+describe it abstractly ("how do I authenticate with an API key" instead
+of "use API key sk_live_abc123 to...").
+
+## Multi-Library Composition
+
+A single question may touch multiple libraries — common in modern stacks
+(SvelteKit + Better-Auth + Drizzle, Next.js + Prisma + Tailwind, etc.).
+Resolve each library independently with the right version pin, then
+synthesize.
+
+The three-command budget applies per-library; a question spanning
+three libraries gets nine commands. Stay focused — fetch the specific
+integration point each time, not the entire library surface.
+
+## Citing Versions in Answers
+
+Every code example produced from a version-pinned fetch MUST cite the
+version. The reader copies the code and runs it; when their version
+differs, the citation is the first thing they check.
+
+```markdown
+Use `defineRelations` (Drizzle ORM v1.0.0-beta and later):
+
+```typescript
+import { defineRelations } from "drizzle-orm";
+// ...
+```
+```
+
+Without the version note, the reader who is on Drizzle 0.x will be
+confused when the import fails.
+
+## Common Failure Modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Library not found" | Wrong name format | Use official punctuation: "Next.js" not "nextjs" |
+| Stale answer | No version pin | Detect installed version from lockfile, pin |
+| Generic answer when specifics needed | Vague query | Pass full question text, not single words |
+| Quota exceeded | Anonymous over-use | `ctx7 login` or set `CONTEXT7_API_KEY` |
+| Hallucinated API | Skipped Context7 | Always run Step 1+2 before answering library questions |
+| Wrong fork picked | Took top result blindly | Read descriptions; prefer official org |
+
+---
+
+## See references/
+
+Progressive disclosure — load on demand only:
+
+- `references/ctx7-workflow.md` — two-step loop, query formatting, research mode, budget
+- `references/library-id-resolution.md` — signals for picking the right ID; disambiguation procedure
+- `references/version-specific-docs.md` — version pinning, migrations, deprecations, drift detection

--- a/packages/skills/skills/ct-docs-lookup/references/ctx7-workflow.md
+++ b/packages/skills/skills/ct-docs-lookup/references/ctx7-workflow.md
@@ -1,0 +1,198 @@
+# ctx7 Workflow
+
+`ct-docs-lookup` is the CLEO-side wrapper around the `ctx7` CLI. The
+underlying contract is set in the user's global rules
+(`~/.claude/rules/context7.md`) and the project's `MCP_Context7.md`.
+This reference codifies the workflow with concrete examples and
+recovery procedures.
+
+## Why Context7
+
+The skill's purpose statement is direct: when the user asks about a
+library, framework, or needs code examples, fetch current documentation
+instead of relying on training data. Training data is stale — the
+project's user rules say so explicitly.
+
+This applies even when you think you know the answer. API surfaces of
+React, Next.js, Prisma, Tailwind, Drizzle, Svelte, Supabase, and friends
+move faster than any model's cutoff. Verify against current docs.
+
+## The Two-Step Loop
+
+The ctx7 CLI is shipped as `npx ctx7@latest`. The workflow is two calls.
+
+```bash
+# Step 1 — resolve the official library ID
+npx ctx7@latest library "<library-name>" "<user-question>"
+
+# Step 2 — fetch docs for the resolved ID
+npx ctx7@latest docs <libraryId> "<user-question>"
+```
+
+The output of Step 1 is a list of candidate library IDs in the form
+`/org/project`. Pick the best match (see `library-id-resolution.md` for
+the heuristics) and pass it to Step 2.
+
+## Step 1: Library Resolution
+
+Use the official library name with proper punctuation:
+
+| ❌ Wrong | ✅ Correct |
+|----------|------------|
+| `"nextjs"` | `"Next.js"` |
+| `"customerio"` | `"Customer.io"` |
+| `"threejs"` | `"Three.js"` |
+| `"reactdom"` | `"React DOM"` |
+| `"vuejs"` | `"Vue.js"` |
+| `"tailwindcss"` | `"Tailwind CSS"` |
+
+The library name matches what the project documents itself as. When
+unsure, search the project's GitHub README for the official name.
+
+Pass the user's full question as the second arg — specific queries
+return better matches than single words.
+
+```bash
+# GOOD
+npx ctx7@latest library "Drizzle ORM" "how do I define relations in v1"
+
+# BAD — too generic, ranks poorly
+npx ctx7@latest library "drizzle" "relations"
+```
+
+## Step 1 Output Interpretation
+
+The CLI returns candidates with several signals — pick by:
+
+1. **Exact name match.** "Next.js" should resolve to `/vercel/next.js`
+   over `/some-fork/next.js-clone`.
+2. **Source reputation.** Look for High or Medium source labels.
+3. **Code snippet count.** More snippets = better-indexed library.
+4. **Benchmark score.** Higher is better; reflects retrieval quality.
+
+If the top candidate doesn't match exactly what the user asked for —
+e.g., they said "Next.js 15" and the top candidate is generic — try
+again with refined terms or version-specific names.
+
+## Step 2: Docs Fetch
+
+Once you have the library ID:
+
+```bash
+npx ctx7@latest docs /vercel/next.js "how do I configure middleware to inject auth headers"
+```
+
+The output is documentation excerpts with citations. Use these directly
+in your answer — they are current, sourced, and citable.
+
+## Version-Specific Docs
+
+When the user names a version, use the version-specific form:
+
+```bash
+# General
+npx ctx7@latest docs /vercel/next.js "..."
+
+# Pinned to v14.3.0
+npx ctx7@latest docs /vercel/next.js/v14.3.0 "..."
+
+# Pinned to v15 (latest 15.x)
+npx ctx7@latest docs /vercel/next.js/v15 "..."
+```
+
+The Step 1 output enumerates available versions. Pick the version
+matching the project's actual installed version (check
+`package.json` / `Cargo.toml` / `requirements.txt`).
+
+## Research Mode (Fallback)
+
+If the default fetch doesn't satisfy the question, retry with
+`--research`:
+
+```bash
+npx ctx7@latest docs /vercel/next.js "..." --research
+```
+
+This launches sandboxed agents that git-pull the actual source repos
+plus live web search, then synthesizes a fresh answer. More costly
+(longer, more tokens), so use only when:
+
+- Default fetch returned a generic answer when specifics were needed.
+- The question references a recent change that may not be indexed yet.
+- The user explicitly asked for research-grade depth.
+
+## Auth and Quotas
+
+The `ctx7` CLI runs anonymously by default with limited quota. When
+quota is exhausted:
+
+```bash
+# Error message will be something like:
+# Error: Quota exceeded. Run `npx ctx7@latest login` or set CONTEXT7_API_KEY
+```
+
+Instruct the user (or surface in `needs_followup`) to either:
+- Run `npx ctx7@latest login` (one-time browser auth)
+- Set `CONTEXT7_API_KEY` env var with their key
+
+Do NOT silently fall back to training data — that violates the skill's
+contract. The whole point is current docs, not stale recall.
+
+## Budget Discipline
+
+The user rules cap the workflow at "no more than 3 commands per
+question". For most lookups this is plenty:
+- 1 call: library resolution
+- 1 call: docs fetch
+- 1 call (optional): retry with `--research` if needed
+
+Going over budget signals one of:
+- Wrong library name (refine and retry)
+- Question too broad (narrow the question first)
+- Genuine library mismatch (Context7 doesn't cover this library — use
+  web search via WebSearch/WebFetch as alternative)
+
+## Sensitive Data
+
+Never include API keys, passwords, credentials, or internal URLs in
+queries. The query is logged on the Context7 side.
+
+```bash
+# WRONG
+npx ctx7@latest docs /supabase/supabase "use API key sk_live_abc123 to..."
+
+# RIGHT
+npx ctx7@latest docs /supabase/supabase "how do I authenticate the client with an API key"
+```
+
+## End-to-End Example
+
+```bash
+# User asked: "How do I do streaming server actions in Next.js 15?"
+
+# Step 1 — resolve
+$ npx ctx7@latest library "Next.js" "How do I do streaming server actions in Next.js 15?"
+> /vercel/next.js/v15 (benchmark 0.87, snippets 1240, source: High)
+> /vercel/next.js     (benchmark 0.85, snippets 5230, source: High)
+> ...
+
+# Step 2 — fetch (use version-pinned ID)
+$ npx ctx7@latest docs /vercel/next.js/v15 "How do I do streaming server actions in Next.js 15?"
+> [docs excerpt with streaming example, citation]
+
+# Compose answer using the fetched docs, citing version
+```
+
+## When NOT to Use This Skill
+
+See `library-id-resolution.md` for the boundary with debugging tasks,
+and `version-specific-docs.md` for when the answer doesn't depend on
+a specific library. Quick summary:
+
+- ❌ Don't use for refactoring (no library lookup needed)
+- ❌ Don't use for scripts written from scratch
+- ❌ Don't use for debugging business logic (use codebase tools)
+- ❌ Don't use for code review
+- ❌ Don't use for general programming concepts
+- ✅ Use for API syntax, configuration, version migration, library-specific
+  debugging, setup instructions, CLI tool usage

--- a/packages/skills/skills/ct-docs-lookup/references/library-id-resolution.md
+++ b/packages/skills/skills/ct-docs-lookup/references/library-id-resolution.md
@@ -1,0 +1,217 @@
+# Library ID Resolution
+
+The Context7 library catalog uses `/org/project` IDs. Picking the right
+ID is the difference between fetching authoritative docs and fetching
+a community fork's stale README. This reference codifies the
+disambiguation heuristics with concrete examples.
+
+## ID Anatomy
+
+```
+/vercel/next.js
+└org─┘ └proj─┘
+
+/vercel/next.js/v14.3.0
+└org─┘ └proj─┘ └version┘
+```
+
+- The `org` is typically the GitHub org or the company name.
+- The `project` is the official package name.
+- The optional `version` is a tag or release branch.
+
+## Resolution Output Format
+
+A typical Step 1 (`ctx7 library`) output:
+
+```text
+Top matches for "Next.js" against query "configure middleware":
+
+1. /vercel/next.js
+   - Source: High
+   - Description: The React Framework for the Web.
+   - Code snippets: 5230
+   - Benchmark: 0.85
+
+2. /vercel/next.js/v15
+   - Source: High
+   - Description: Next.js v15 release line.
+   - Code snippets: 1240
+   - Benchmark: 0.87
+
+3. /community/next-with-foo
+   - Source: Medium
+   - Description: Next.js + Foo starter template.
+   - Code snippets: 87
+   - Benchmark: 0.42
+
+4. /old-org/nextjs-legacy
+   - Source: Low
+   - Description: Pre-app-router Next.js patterns.
+   - Code snippets: 412
+   - Benchmark: 0.39
+```
+
+Five signals to weigh.
+
+## Signal 1: Exact Name Match
+
+The user said "Next.js". Candidates 1 and 2 are exact matches; 3 is
+"next-with-foo" (a derivative); 4 is "nextjs-legacy" (suffixed).
+
+Prefer the canonical name. The derivative or suffixed projects are
+appropriate ONLY when the user explicitly named them.
+
+## Signal 2: Source Reputation
+
+`High` > `Medium` > `Low`. Source reputation reflects how authoritative
+Context7 considers the project. Official org-owned repos are High.
+Community forks are typically Medium. Abandoned or low-quality projects
+are Low.
+
+When multiple High candidates exist, look further. When the only
+High candidate is the obvious one, pick it.
+
+## Signal 3: Code Snippet Count
+
+More snippets = better-indexed library = higher chance of finding the
+exact API the user asked about. The unversioned ID usually has higher
+snippet counts than version-pinned IDs because it aggregates across
+versions.
+
+For general questions, prefer unversioned IDs. For version-specific
+questions, accept the lower snippet count of the pinned ID.
+
+## Signal 4: Benchmark Score
+
+The benchmark is a retrieval-quality measure produced by Context7 —
+higher means the candidate library has good documentation that
+indexes well. Use as a tiebreaker only.
+
+In the example above, candidate 2 has a slightly higher benchmark
+(0.87) than candidate 1 (0.85) because v15-specific queries score
+better against the pinned slice. For a v15-specific question, prefer
+candidate 2.
+
+## Signal 5: Query Alignment
+
+The user's query in Step 1 affects ranking. If the query mentioned
+"middleware", candidates whose docs cover middleware will rank higher.
+This is why passing the FULL user question (not a single word) yields
+better resolution.
+
+## Common Pitfalls
+
+### Pitfall: Picking the version-pinned ID for a general question
+
+The user asked "What does Next.js do?" — a general question.
+
+- ❌ Pick `/vercel/next.js/v15` — too narrow; misses cross-version context.
+- ✅ Pick `/vercel/next.js` — covers the whole project.
+
+### Pitfall: Picking the unversioned ID for a version-specific question
+
+The user asked "How do I migrate from Next.js 14 to 15?"
+
+- ❌ Pick `/vercel/next.js` — might return mixed-version docs.
+- ✅ Pick `/vercel/next.js/v15` — gets the migration guide for 15.
+- ✅ Better: pick `/vercel/next.js/v15` for "to" and `/vercel/next.js/v14`
+  for "from", and run two fetches.
+
+### Pitfall: Picking the community fork when the user wants the official
+
+The user asked "How do I use Tailwind utilities?"
+
+- ❌ Pick `/some-community/tailwind-with-extras` — not what they meant.
+- ✅ Pick `/tailwindlabs/tailwindcss` — the official.
+
+Community forks rank LOW on the "what user meant" axis even when they
+rank high on other signals. Default to the official.
+
+### Pitfall: Picking the highest snippet count regardless of relevance
+
+The user asked about Vue 3 composition API.
+
+- ❌ Pick `/vuejs/vue` (high snippet count, but it's the Vue 2 line).
+- ✅ Pick `/vuejs/core` or `/vuejs/vue-next` (Vue 3).
+
+Always read the description, not just the count. Old projects accumulate
+snippets because they've been around longer — they may no longer be
+current.
+
+## Disambiguation Procedure
+
+When two candidates look equally good:
+
+1. **Read the descriptions.** They usually disambiguate.
+2. **Check the org.** Official org = the project's home; community
+   org = derivative.
+3. **Check the project's GitHub URL** if Context7 includes it. The URL
+   matches what the project's README cites.
+4. **Try both.** Compare the outputs of Step 2 for each candidate. The
+   one that better answers the question is the right one.
+
+## When Resolution Fails
+
+Sometimes Step 1 returns no good match. The library may not be in
+Context7's catalog, or the name was wrong. Recovery:
+
+```bash
+# Retry with the formal name from the project's GitHub
+npx ctx7@latest library "TanStack Query" "..."   # not "react-query"
+
+# Retry with the alternative spelling
+npx ctx7@latest library "GitHub Actions" "..."   # not "gh-actions"
+
+# Retry with a more specific query
+npx ctx7@latest library "Next.js" "App Router middleware in v15"
+
+# If all retries fail, fall back to WebSearch / WebFetch
+# (but tell the user the library isn't in Context7's catalog)
+```
+
+## Version Resolution Specifics
+
+When a project has many versions, Step 1's output lists them. Pick by:
+
+1. **Match the project's installed version.** Check `package.json`,
+   `Cargo.toml`, `requirements.txt`, etc.
+2. **If the user named a version, use that.**
+3. **If neither, use the latest stable (highest version number that
+   isn't pre-release).**
+
+```bash
+# Project installed Next.js 14.3.x
+$ jq '.dependencies.next' package.json
+"14.3.0"
+
+# Use the pinned version
+npx ctx7@latest docs /vercel/next.js/v14.3.0 "..."
+```
+
+This catches the case where the user asks about behavior that differs
+between versions; using the wrong version pin gives a confidently
+wrong answer.
+
+## Caching
+
+Library IDs rarely change. If you resolved `/vercel/next.js/v15` for
+one query, you can re-use it for the next query about the same library
+without running Step 1 again. Just remember to refresh the resolution
+when:
+
+- Asking about a different major version.
+- The project's installed version changed.
+- The previous fetch didn't satisfy the question (maybe the wrong ID
+  was picked).
+
+## When NOT to Use Library Lookup
+
+The user rules are explicit: not for refactoring, scripts-from-scratch,
+business-logic debugging, code review, or general programming concepts.
+
+If the question is "how do I structure my repository?" — that is a
+general programming question. Use general knowledge plus codebase
+inspection, not Context7.
+
+If the question is "how does Next.js's app router handle parallel
+routes?" — that is a library API question. Use Context7.

--- a/packages/skills/skills/ct-docs-lookup/references/version-specific-docs.md
+++ b/packages/skills/skills/ct-docs-lookup/references/version-specific-docs.md
@@ -1,0 +1,220 @@
+# Version-Specific Docs
+
+Library APIs drift across versions — sometimes silently (default value
+changes), sometimes loudly (renames, removals). This reference covers
+how to lock the docs lookup to the version the user actually runs,
+and how to handle migrations and deprecated APIs.
+
+## Why Version Pinning Matters
+
+The cost of citing the wrong version is high.
+
+- Drizzle ORM v1.0.0-beta renamed `relations()` to `defineRelations()`.
+  A 0.x user given a v1 example will copy code that doesn't import.
+- Next.js 15 changed default `fetch` cache from `force-cache` to
+  `no-store`. A user on 14 reading a 15 doc will not see the behavior
+  they expect.
+- React 19 introduced new hooks. A React 18 user copying a React 19
+  example gets `useActionState is not defined`.
+
+In each case, the failure mode is "confidently wrong answer". The
+remedy is always: pin to the user's actual version before fetching.
+
+## Finding the User's Version
+
+The skill SHOULD detect the user's installed version before opening
+Step 2.
+
+```bash
+# Node.js projects
+jq -r '.dependencies.next, .devDependencies.next | select(.)' package.json
+
+# Cargo projects
+cargo tree -p drizzle 2>/dev/null  # if applicable
+grep -A 1 '^drizzle-orm =' Cargo.toml
+
+# Python projects
+grep '^next' requirements.txt
+pip show next 2>/dev/null | grep '^Version'
+
+# Generic — search for any lockfile entry
+grep -A 1 'next:' pnpm-lock.yaml | head -3
+```
+
+If detection fails (no lockfile, version not pinned), ask the user
+or default to the project's stated version.
+
+## Version Format Matching
+
+Context7 IDs accept several version forms:
+
+```text
+/vercel/next.js                    # all versions; unspecified
+/vercel/next.js/v15                # latest within v15.x
+/vercel/next.js/v15.0.0            # exactly v15.0.0
+/vercel/next.js/v15.0.0-canary.7   # specific canary
+```
+
+Match the granularity of the user's question:
+
+- General "how do I do X with library" → unversioned or major-pinned.
+- Migration "from N to M" → both major-pinned: `/lib/vN` and `/lib/vM`.
+- Bug investigation "in 15.0.3 specifically X happens" → exact pin.
+
+## Major-Version Migrations
+
+When the user is upgrading from major N to major N+1, run two fetches.
+
+```bash
+# From-version: what works today
+npx ctx7@latest docs /drizzle-team/drizzle-orm/v0.36 "how do I define relations"
+
+# To-version: what they will move to
+npx ctx7@latest docs /drizzle-team/drizzle-orm/v1.0.0-beta "how do I define relations"
+
+# Compose the migration story:
+# 1. Show the current API
+# 2. Show the new API
+# 3. Show the mapping
+```
+
+The migration story has THREE parts. Skipping any of them produces
+confusion:
+
+- **Current API.** What the user has now.
+- **New API.** What it becomes.
+- **Mapping.** Mechanical translation between them.
+
+Documenting only the new API leaves the user wondering "but my code
+uses X — what does that become?"
+
+## Deprecated APIs
+
+When a fetched doc mentions an API as deprecated:
+
+1. Surface the deprecation explicitly. Don't bury it.
+2. Show the recommended replacement, fetched from the same docs.
+3. Cite when deprecation began and when removal is planned (if stated).
+
+Example output:
+
+```markdown
+The `relations()` helper in Drizzle ORM 0.x is deprecated as of v1.0.0-beta.
+Use `defineRelations` instead.
+
+| Drizzle 0.x | Drizzle 1.x (beta) |
+|-------------|--------------------|
+| `relations(table, (helpers) => ({ ... }))` | `defineRelations(schema, (t) => ({ ... }))` |
+
+Deprecation announced: v1.0.0-beta (2025-Q4).
+Planned removal: TBD (the 0.x line is still supported through 2026).
+```
+
+## Version Drift Detection
+
+Run a sanity check before answering — does the user's installed
+version match what they think they're using?
+
+```bash
+# User says "I'm on Next.js 15".
+$ jq -r '.dependencies.next' package.json
+"14.3.0"
+
+# Drift! Surface it:
+# > Your package.json says Next.js 14.3.0, not 15. Are you planning
+# > to upgrade, or did you mean 14? I'll fetch docs for what's
+# > installed unless you confirm 15 is the target.
+```
+
+This catches the common case where the user's mental model is ahead
+of (or behind) their actual install.
+
+## Multi-Library Lookups
+
+A single question may span multiple libraries. Resolve each
+independently with the right version pin.
+
+```bash
+# Question: "How do I integrate Better-Auth with Drizzle ORM in a
+#  Svelte 5 SvelteKit project?"
+
+# Three libraries; resolve each with project's actual version
+npx ctx7@latest library "Better-Auth" "..."
+npx ctx7@latest library "Drizzle ORM" "..."
+npx ctx7@latest library "SvelteKit" "..."
+
+# Then three fetches:
+npx ctx7@latest docs /better-auth/better-auth        "integration with drizzle"
+npx ctx7@latest docs /drizzle-team/drizzle-orm/v1    "integration with better-auth"
+npx ctx7@latest docs /sveltejs/kit/v2                "hooks for auth middleware"
+```
+
+Compose the answer from the three. Cite each library's version
+explicitly so the user knows what works with what.
+
+## When Versioned Docs Aren't Available
+
+Context7's catalog doesn't always have per-version slices. When a
+version pin returns "no matches":
+
+1. Drop one granularity level (e.g., `/v15.0.0-canary.7` → `/v15`).
+2. Drop another (`/v15` → `/vercel/next.js` unversioned).
+3. Add a note that version-specific data may be missing — recommend
+   the user verify against the official release notes.
+
+## Reading Release Notes
+
+When the question is "what changed in version X", release notes are
+often a better source than API docs. Two routes:
+
+```bash
+# Route 1 — Context7 may have it indexed
+npx ctx7@latest docs /vercel/next.js "release notes for v15"
+
+# Route 2 — WebFetch the official release notes page
+# (use when Context7 doesn't have release notes specifically)
+WebFetch: https://nextjs.org/blog/next-15  "summarize the breaking changes"
+```
+
+Release notes are more concise than docs and explicitly call out
+deprecations and removals — exactly what migration questions need.
+
+## Citing Versions
+
+Every code example produced from a version-pinned fetch MUST cite the
+version.
+
+```markdown
+GOOD:
+Use `defineRelations` (Drizzle ORM v1.0.0-beta and later):
+
+```typescript
+import { defineRelations } from "drizzle-orm";
+// ...
+```
+
+BAD:
+Use `defineRelations`:
+
+```typescript
+import { defineRelations } from "drizzle-orm";
+// ...
+```
+(no version context — reader doesn't know if their version supports it)
+```
+
+When the user copies the code and it doesn't work, the version citation
+is the first thing they check. Give it to them up front.
+
+## Skill Boundary
+
+This reference covers version handling within docs-lookup. It does NOT
+cover:
+
+- Migration code generators (out of scope; that's task-executor work).
+- Upgrade plan authoring (out of scope; that's spec-writer work).
+- Pinning the user's project to a new version (out of scope; that's a
+  task for the human or the executor).
+
+Docs-lookup just produces the version-accurate documentation. The
+downstream skills act on it.

--- a/packages/skills/skills/ct-docs-review/SKILL.md
+++ b/packages/skills/skills/ct-docs-review/SKILL.md
@@ -173,3 +173,66 @@ This could be more conversational. Consider: "You can't..." instead of "You cann
 2. **Verify all issues are numbered sequentially** starting from Issue 1 with no gaps in numbering.
 3. Confirm the format exactly matches: `**Issue N: [Brief title]**` where N is the issue number.
 4. **In PR mode**: Verify each issue was posted as a separate GitHub comment (not output to conversation).
+
+## Issue length guidelines
+
+| Doc size | Typical issue count | Red flag |
+|----------|---------------------|----------|
+| Small (< 100 lines) | 0-3 issues | 10+ issues |
+| Medium (100-300 lines) | 0-8 issues | 20+ issues |
+| Large (300+ lines) | 0-15 issues | 30+ issues |
+
+A flood of low-value flags trains the author to ignore reviews. Apply
+the materiality filter aggressively — be selective up front; flag only
+what matters.
+
+## Workflow discipline
+
+| Step | Anti-pattern | Correct |
+|------|--------------|---------|
+| Start | Post comments immediately | Start pending review first |
+| Identify | Post issues one-by-one | Collect ALL, then post in parallel |
+| Format | Plain text bodies | `**Issue N: [Title]**` prefix |
+| Submit | `event: REQUEST_CHANGES` blocks PR | `event: COMMENT` is non-blocking |
+| Body | Long summary body on submit | Empty body — let inline comments speak |
+
+## When review should block
+
+The default event is `COMMENT` (non-blocking). Use `REQUEST_CHANGES`
+only when the PR contains issues that, if shipped, would actively harm
+readers:
+
+- Broken code examples that would fail when copy-pasted
+- Outdated security guidance
+- Links to deprecated APIs in setup instructions
+- Patronizing language to vulnerable audiences
+
+For everything else, use COMMENT. Trust the author to take feedback
+seriously without being forced.
+
+## Re-review after fix
+
+When the author addresses feedback and pushes new commits, run the
+review again on the updated diff. Don't re-flag issues already fixed;
+do flag new issues introduced in the fix.
+
+For re-reviews, start the comment with a status line:
+
+```text
+**Issue 2 (UPDATED): Vague heading**
+
+The previous fix changed "Setup" to "Setup Steps" — still vague.
+Try "Install dependencies, then run init".
+```
+
+The "(UPDATED)" tag signals iteration, not a brand-new flag.
+
+---
+
+## See references/
+
+Progressive disclosure — load on demand only:
+
+- `references/style-violations.md` — taxonomy of violations with detection patterns, issue titles, and remediation messages
+- `references/pr-review-mode.md` — pending-review workflow, comment format, gh CLI fallback, materiality filter
+- `references/inline-comment-patterns.md` — comment anatomy, single-line/multi-line/pattern fixes, anti-patterns

--- a/packages/skills/skills/ct-docs-review/references/inline-comment-patterns.md
+++ b/packages/skills/skills/ct-docs-review/references/inline-comment-patterns.md
@@ -1,0 +1,268 @@
+# Inline Comment Patterns
+
+How to construct individual review comments that are concrete,
+actionable, and respectful. Each pattern below covers a common
+review situation with a template and a worked example.
+
+## Anatomy of a Good Comment
+
+A review comment has four parts:
+
+1. **Title line.** `**Issue N: [Brief title]**` — always.
+2. **Location.** Line number or "throughout the file".
+3. **Description.** What's wrong, one sentence.
+4. **Suggestion.** Concrete fix, copy-paste-ready when possible.
+
+Skipping any part degrades the comment. Skipping the title makes
+issues unfindable; skipping location makes the fix scope unclear;
+skipping description makes the rule arbitrary; skipping suggestion
+makes the comment unactionable.
+
+## Pattern: Single-Line Fix
+
+When the fix is a one-line replacement, use the GitHub `suggestion`
+block.
+
+````text
+**Issue 1: Missing contraction**
+
+Line 15: CLEO docs use contractions. Change "cannot" to "can't".
+
+```suggestion
+You can't run this command on a dirty tree.
+```
+````
+
+The suggestion block renders as a one-click "Commit suggestion"
+button. Author applies it without leaving the PR view.
+
+## Pattern: Multi-Line Fix
+
+When the fix spans multiple lines, use a diff fence.
+
+````text
+**Issue 2: Buried lead**
+
+Lines 14-18: The action is buried in the third sentence. Lead with it.
+
+Suggested fix:
+
+```diff
+-Configuration files in CLEO support various format options including
+-JSON, YAML, and TOML. When choosing a format, consider readability,
+-merge-conflict friendliness, and editor support. Use JSON for the
+-primary config file because it's the project default.
++Use JSON for the primary CLEO config file (the project default).
++CLEO also supports YAML and TOML if your team prefers them.
+```
+````
+
+The diff fence shows before and after side-by-side. No one-click apply,
+but the structure is clear.
+
+## Pattern: Pattern Issue (Throughout File)
+
+When the same issue appears in multiple places, flag once with
+representative examples — not once per occurrence.
+
+```text
+**Issue 4: "Users" instead of "people"**
+
+The word "users" appears throughout the file (lines 8, 14, 22, 37, 51,
+68). CLEO docs say "people" or "companies".
+
+Examples to fix:
+- Line 8: "users can configure" → "people can configure"
+- Line 22: "our users expect" → "our customers expect"
+- Line 51: "user input" → "what people type"
+
+Apply the same pattern to remaining instances.
+```
+
+This compresses a 6-comment flood into a 1-comment summary. The author
+gets the message without scrolling through duplicates.
+
+## Pattern: Question (Clarification Needed)
+
+Sometimes the issue is "I don't understand the intent". Phrase as a
+question, not a demand.
+
+```text
+**Issue 5: Ambiguous step**
+
+Line 33: "Configure the cache before deployment."
+
+The step doesn't say HOW to configure the cache or WHERE to deploy.
+Is this the production cache or the dev cache? Should it reference
+the `cacheTimeout` config or the `cacheStore` setting?
+
+Suggested expansion:
+"Set `cacheTimeout` to 30000 (30s) in `cleo.config.json` before
+deploying to production."
+```
+
+Questions are respectful — they assume the author had a reason and
+you're inviting them to make it visible.
+
+## Pattern: Code-Example Failure
+
+When a code example wouldn't run, show the error.
+
+````text
+**Issue 6: Code example doesn't compile**
+
+Lines 42-46: The TypeScript example imports `defineRelations` from
+`drizzle-orm`, but the function isn't exported from the top-level
+package in v0.x — it's in `drizzle-orm/relations`.
+
+Tested:
+```bash
+$ npx tsc --noEmit example.ts
+example.ts:1:10 - error TS2305: Module '"drizzle-orm"' has no
+exported member 'defineRelations'.
+```
+
+Either:
+- Import from the subpath: `import { defineRelations } from "drizzle-orm/relations";`
+- Or cite the version that has the top-level export (v1.0.0-beta and later)
+````
+
+The error excerpt gives the author proof. Without it, the author may
+push back ("works on my machine"); with it, the issue is unambiguous.
+
+## Pattern: Style Choice with Rationale
+
+When flagging style violations, cite the rule. Don't enforce personal
+preference disguised as style.
+
+```text
+**Issue 7: Formal language**
+
+Line 27 uses "utilize" — too formal for CLEO docs. Use "use".
+
+Source: CLEO style guide §Conversational Pillar — "utilize" is on
+the avoid-list because it's just "use" wearing a suit.
+
+```suggestion
+Use the orchestrator to dispatch wave 3.
+```
+```
+
+The source line lets the author verify the rule. Without it, the
+flag feels arbitrary.
+
+## Pattern: Praise (Sometimes)
+
+When the doc does something particularly well, a short positive note
+can be valuable feedback. Keep them sparse — too much praise reads as
+performative.
+
+```text
+**Issue 8 (note, not a fix): Excellent structure**
+
+The migration table at lines 60-75 is exactly the right pattern for
+a v0.x → v1.x guide — current API, new API, mapping. Consider
+extracting this table format into a shared template for future
+migration docs.
+```
+
+Note: even praise gets a number — sequential numbering throughout.
+
+## Anti-Patterns
+
+### "This is wrong" (no fix)
+
+```text
+BAD:
+**Issue 9: Wrong**
+Line 22 is wrong.
+```
+
+No location specificity, no description, no fix. Useless.
+
+### "Maybe consider perhaps"
+
+```text
+BAD:
+**Issue 10: Possibly an issue**
+Line 33: This might be slightly suboptimal, maybe consider...
+```
+
+Hedging tells the author you don't trust your own judgment. Either
+flag it confidently or skip it.
+
+### "Bikeshedding"
+
+```text
+BAD:
+**Issue 11: Two spaces**
+Line 18 has two spaces after the period — CLEO docs use one.
+```
+
+If the rule isn't material to readers, don't flag it. Whitespace
+between sentences is invisible in rendered markdown.
+
+### "Personal preference disguised as rule"
+
+```text
+BAD:
+**Issue 12: I'd write this differently**
+Line 41 isn't how I'd phrase it — I'd say...
+```
+
+Style preference is not a rule. Either it's in the style guide (cite
+it) or it's not (skip the flag).
+
+### "Compound issue"
+
+```text
+BAD:
+**Issue 13: Multiple problems**
+Line 22 has formal tone, a vague heading, and a missing serial comma.
+Also lines 30-35 have user-construct issues.
+```
+
+Split into separate numbered issues. The author may want to fix one
+but not the others; combined flags can't be resolved partially.
+
+## Length Discipline
+
+Keep each comment short. 3-6 lines for the description; 3-10 lines
+for the suggestion block.
+
+Long comments lose the author. If the explanation needs 20 lines, you
+might be over-explaining — trust the author to understand the rule
+after the suggestion.
+
+## Tone
+
+Comments are feedback, not judgment. Aim for:
+
+- **Specific** — "line 22 uses X" not "the writing feels wrong"
+- **Concrete** — show the fix, don't describe it
+- **Respectful** — assume the author had a reason; don't assume bad faith
+- **Time-respecting** — short over long; one issue per comment
+
+## Comment Lifecycle
+
+After the author addresses feedback, the comment can be:
+
+- **Resolved** — author marks the conversation resolved when fixed
+- **Unresolved** — left as historical record if not addressed
+- **Updated** — reviewer adds follow-up after author's fix
+
+The skill doesn't need to track resolution — that's GitHub's job. But
+when re-reviewing, scan unresolved threads to see what's still pending.
+
+## Cross-Reference to Other Comments
+
+When two issues are related, reference the prior issue's number:
+
+```text
+**Issue 14: Related to Issue 3**
+
+Line 47 has the same "users" problem as Issue 3. Apply the same fix
+here too.
+```
+
+This compresses the review and shows the author the pattern.

--- a/packages/skills/skills/ct-docs-review/references/pr-review-mode.md
+++ b/packages/skills/skills/ct-docs-review/references/pr-review-mode.md
@@ -1,0 +1,270 @@
+# PR Review Mode
+
+When the GitHub MCP tools are available, ct-docs-review uses the
+pending-review workflow to post all findings as one cohesive GitHub
+review. This reference codifies the workflow, the comment format,
+and the integration with `gh` CLI for the cases where MCP tools are
+not available.
+
+## Mode Detection
+
+The mode is determined by tool availability:
+
+| Available | Mode | Output target |
+|-----------|------|---------------|
+| `mcp__github__create_pending_pull_request_review` | PR mode | GitHub PR review |
+| Not available | Local mode | Conversation / file |
+
+The skill MUST check tool availability before review starts. If a
+review is conducted in the wrong mode, the findings won't reach the
+reader.
+
+## PR Mode Workflow
+
+### Step 1: Start a Pending Review
+
+```text
+Tool: mcp__github__create_pending_pull_request_review
+Args: { owner, repo, pull_number }
+```
+
+This creates a draft review that doesn't appear on the PR until
+submitted. The draft accumulates comments without spamming the PR.
+
+### Step 2: Fetch the Diff
+
+```text
+Tool: mcp__github__get_pull_request_diff
+Args: { owner, repo, pull_number }
+```
+
+The diff tells you which file paths and line numbers to use for each
+inline comment. Comments tied to lines that don't appear in the diff
+are rejected by GitHub.
+
+### Step 3: Collect All Findings First
+
+Read through the entire diff. Identify every violation worth flagging.
+Number them sequentially: Issue 1, Issue 2, Issue 3, etc.
+
+Do NOT post comments as you find them. Collect first, post second.
+
+### Step 4: Add Comments in Parallel
+
+```text
+Tool: mcp__github__add_pull_request_review_comment_to_pending_review
+Args: { owner, repo, pull_number, path, line, body }
+```
+
+CRITICAL: Post ALL comments in a SINGLE response, in parallel tool
+calls. Posting them one-at-a-time across multiple responses creates
+visual flicker and may cause GitHub to throttle.
+
+Each comment body starts with:
+
+```text
+**Issue N: [Brief title]**
+```
+
+Followed by the description and suggested fix.
+
+### Step 5: Submit the Review
+
+```text
+Tool: mcp__github__submit_pending_pull_request_review
+Args: { owner, repo, pull_number, event: "COMMENT" }
+```
+
+Use `event: "COMMENT"` (non-blocking) — NOT `REQUEST_CHANGES`. The
+non-blocking event lets the author address comments without
+forcing a re-review.
+
+Do NOT include a `body` parameter. The pending-review workflow
+already attaches each finding inline; a summary body just clutters
+the PR.
+
+## Comment Format
+
+### Standard Comment
+
+```text
+**Issue 1: Formal tone**
+
+Line 15 uses "cannot" — CLEO docs prefer the contraction "can't" for
+conversational tone.
+
+Suggested fix:
+
+```diff
+-You cannot run this command on a dirty tree.
++You can't run this command on a dirty tree.
+```
+```
+
+### Comment with Multiple Examples
+
+```text
+**Issue 3: Vague headings**
+
+The headings "Setup" (line 8) and "Configuration" (line 47) don't
+tell the reader what each section is for.
+
+Suggested fixes:
+
+- "Setup" → "Install dependencies and run init"
+- "Configuration" → "Configure release pipeline before first ship"
+```
+
+### Comment with Diff Suggestion
+
+GitHub supports rendered diff suggestions when the comment is on a
+specific line. Use this format:
+
+````text
+**Issue 5: User-construct**
+
+Line 22 uses "users" — CLEO docs say "people".
+
+```suggestion
+people can configure the cache by setting `cacheTimeout`.
+```
+````
+
+The `suggestion` block becomes a "Commit suggestion" button for the
+author. Use sparingly — only when the fix is a one-line replacement.
+
+## Local Mode Workflow
+
+When MCP tools aren't available, output the same findings in the
+conversation using numbered markdown:
+
+```markdown
+## Issues
+
+**Issue 1: Formal tone**
+Line 15: This could be more conversational. Consider: "You can't..."
+instead of "You cannot..."
+
+**Issue 2: Vague heading**
+Line 8: The heading could be more specific. Try stating the point
+directly: "Run migrations before upgrading" vs "Upgrade process"
+
+**Issue 3: Patronizing qualifier**
+Line 23: Remove "easy" — it patronizes the reader. Let the steps
+speak for themselves.
+```
+
+### gh CLI Fallback
+
+If MCP tools aren't available but `gh` CLI is, you can still post a
+PR review via shell:
+
+```bash
+gh pr review <PR_NUMBER> --comment --body "$(cat <<'EOF'
+## Issues
+
+**Issue 1: Formal tone**
+Line 15: This could be more conversational...
+
+**Issue 2: Vague heading**
+Line 8: The heading could be more specific...
+EOF
+)"
+```
+
+The shell route uses a single overall comment rather than inline
+comments. Less precise but still useful when MCP isn't an option.
+
+## Numbering Discipline
+
+Every issue MUST be numbered sequentially starting from Issue 1.
+
+```text
+GOOD:
+Issue 1: ...
+Issue 2: ...
+Issue 3: ...
+
+BAD (skipping numbers):
+Issue 1: ...
+Issue 3: ...
+
+BAD (random labels):
+Issue A: ...
+Issue 2: ...
+Issue Important: ...
+```
+
+Sequential numbering lets the author say "fix issues 1, 3, and 5"
+unambiguously. It also lets them track which feedback they've
+addressed.
+
+## Materiality Before Numbering
+
+Before assigning Issue numbers, run the materiality filter (see
+`style-violations.md` §Materiality Filter). Issues that would not
+make a meaningful difference to the reader are SKIPPED, not numbered
+and labeled "minor".
+
+The materiality filter exists because flooding the author with low-
+value flags trains them to ignore the review. Be selective up front;
+flag only what matters.
+
+## Review Length Guidelines
+
+| Doc size | Typical issue count |
+|----------|---------------------|
+| Small (< 100 lines) | 0-3 issues |
+| Medium (100-300 lines) | 0-8 issues |
+| Large (300+ lines) | 0-15 issues |
+
+A review with 30 issues on a 200-line doc signals one of:
+
+- The doc is genuinely in bad shape (needs deep rewrite, not nits)
+- The reviewer is over-flagging low-value stuff
+
+If you find yourself at 20+ issues on a medium doc, step back and
+ask: is the materiality filter being applied? Are these the issues
+that matter?
+
+## Workflow Discipline
+
+| Step | Anti-pattern | Correct |
+|------|--------------|---------|
+| Start | Begin posting comments immediately | Start pending review first |
+| Identify | Post issues one-by-one as found | Collect ALL, then post in parallel |
+| Format | Plain text bodies | `**Issue N: [Title]**` prefix |
+| Submit | `event: REQUEST_CHANGES` blocks PR | `event: COMMENT` is non-blocking |
+| Body | Long summary body on submit | Empty body — let inline comments speak |
+
+## Re-Review After Fix
+
+When the author addresses feedback and pushes new commits, run the
+review again on the updated diff. Don't re-flag issues that are
+already fixed; do flag new issues introduced in the fix.
+
+For re-reviews, start the comment with a status line:
+
+```text
+**Issue 2 (UPDATED): Vague heading**
+
+The previous fix changed "Setup" to "Setup Steps" — still vague.
+Try "Install dependencies, then run init".
+```
+
+The "(UPDATED)" tag signals to the author that this is iteration,
+not a brand-new flag.
+
+## When Review Should Block
+
+The default event is `COMMENT` (non-blocking). Use `REQUEST_CHANGES`
+only when the PR contains issues that, if shipped, would actively
+harm readers:
+
+- Broken code examples that would fail when copy-pasted
+- Outdated security guidance
+- Links to deprecated APIs in setup instructions
+- Patronizing language to vulnerable audiences
+
+For everything else, use COMMENT. Trust the author to take feedback
+seriously without being forced.

--- a/packages/skills/skills/ct-docs-review/references/style-violations.md
+++ b/packages/skills/skills/ct-docs-review/references/style-violations.md
@@ -1,0 +1,341 @@
+# Style Violations
+
+The taxonomy of style violations that ct-docs-review catches. Each
+violation type carries a detection pattern, an issue title format,
+and a remediation message. The numbering scheme below (V-NNN) is
+informational — issues in reviews are numbered sequentially per
+review, not by global ID.
+
+## Violation Categories
+
+| Category | Examples | Severity |
+|----------|----------|----------|
+| Forbidden phrases | "easy", "simple", "just", "click here" | High |
+| Tone and voice | "we" referring to CLEO, formal language | Medium |
+| Structure | Buried lead, vague heading, no clear purpose | Medium |
+| Links | Bare-word links, link-in-heading | High |
+| Formatting | Missing language tag, full-width screenshot | Low |
+| Code examples | Don't run, out of order | High |
+| Sentence construction | Pronoun overuse, missing serial comma | Low |
+
+Severity drives prioritization but not categorical filtering — review
+flags everything worth fixing. The final filter is the materiality
+test: "would fixing this make a meaningful difference to the reader?"
+
+## Forbidden Phrases
+
+The hardest-to-shake violations. They sneak into drafts because they
+feel natural — and they're banned because they're patronizing.
+
+### "easy" / "simple" / "just"
+
+**Detection pattern.**
+
+```bash
+grep -inE '\b(easy|simple|just|easily|simply)\b' <file>
+```
+
+**Issue title.** `Patronizing qualifier: "<word>"`
+
+**Remediation message.**
+
+> Line X uses "<word>" — this assumes the reader's context. Remove it
+> and let the steps speak for themselves.
+
+**Examples.**
+
+| Before | After |
+|--------|-------|
+| Setting up SAML is easy. | Set up SAML by following these steps. |
+| Just run `cleo init`. | Run `cleo init`. |
+| The CLI makes this simple. | Use the CLI: `cleo verify`. |
+
+### "obviously" / "of course"
+
+**Detection pattern.**
+
+```bash
+grep -inE '\b(obviously|of course|clearly|naturally)\b' <file>
+```
+
+**Issue title.** `Condescending qualifier: "<word>"`
+
+**Remediation message.**
+
+> Line X uses "<word>" — patronizing the reader. If it's truly obvious,
+> the doc doesn't need to say so; if it's not, calling it obvious feels
+> condescending.
+
+### "click here" / "read more here"
+
+**Detection pattern.**
+
+```bash
+grep -inE '\[(click here|here|read more here|this|more info)\]\(' <file>
+```
+
+**Issue title.** `Non-descriptive link text: "<text>"`
+
+**Remediation message.**
+
+> Line X uses "<text>" as the link text. Link text MUST describe the
+> destination. Replace with descriptive text such as
+> "the [SAML configuration guide]".
+
+### "etc." / "and so on"
+
+**Detection pattern.**
+
+```bash
+grep -inE '\b(etc\.|and so on|and more)\b' <file>
+```
+
+**Issue title.** `Trailing list: "<phrase>"`
+
+**Remediation message.**
+
+> Line X ends a list with "<phrase>" — this signals incomplete thinking.
+> Either enumerate the items completely, or restate the sentence
+> without the trailing phrase.
+
+## Tone and Voice Violations
+
+### "we" referring to CLEO
+
+**Detection pattern.**
+
+```bash
+# Tricky — "we" + verb usually means CLEO
+grep -inE '\bwe (will|can|use|do|have|are|provide|deliver|run|build|deploy)' <file>
+```
+
+**Issue title.** `First-person plural referring to CLEO`
+
+**Remediation message.**
+
+> Line X uses "we" — when talking about CLEO features, say "CLEO" or
+> "it". "We" is for the human team; "CLEO" is for the system.
+
+### Formal language
+
+**Detection pattern.**
+
+```bash
+grep -inE '\b(utilize|leverage|reference|offerings|provisions|delineate)\b' <file>
+```
+
+**Issue title.** `Formal/corporate language: "<word>"`
+
+**Remediation message.**
+
+> Line X uses "<word>" — too formal. Use the everyday word: "<replacement>".
+
+| Formal | Everyday |
+|--------|----------|
+| utilize | use |
+| leverage | use |
+| reference (verb) | see, look at |
+| offerings | products, features |
+| provisions | settings |
+| delineate | describe, list |
+
+### Missing contractions
+
+**Detection pattern.**
+
+```bash
+grep -inE '\b(cannot|do not|will not|is not|are not|does not|did not)\b' <file>
+```
+
+**Issue title.** `Missing contraction: "<phrase>"`
+
+**Remediation message.**
+
+> Line X uses "<phrase>" — CLEO docs USE contractions. Change to
+> "<contracted form>" for the conversational tone.
+
+This is the one rule that surprises writers most often. CLEO is opposite
+to many style guides on this point.
+
+### "users" instead of "people"
+
+**Detection pattern.**
+
+```bash
+# Standalone "users" — careful not to match "end-users" or "user-agent"
+grep -inE '(?<!end-)\busers?\b(?!-)' <file>
+```
+
+**Issue title.** `User-construct instead of human: "<word>"`
+
+**Remediation message.**
+
+> Line X uses "<word>" — CLEO docs say "people" or "companies", not
+> "users". "User" is a system construct; "people" centers the human.
+
+Note: compound terms keep "user" — "end-user", "user-agent", "user-space".
+
+## Structure Violations
+
+### Buried lead
+
+**Detection pattern.** (Manual — no regex.)
+
+Read the first paragraph of each section. Does the action / definition
+appear in the first sentence? If not, the lead is buried.
+
+**Issue title.** `Buried lead in §<section>`
+
+**Remediation message.**
+
+> The action / definition is not stated until line X. Lead with it.
+> Move the explanation after.
+
+### Vague heading
+
+**Detection pattern.** (Manual — needs semantic reading.)
+
+Read each heading. Does it state the point or just the topic?
+
+| Vague | Specific |
+|-------|----------|
+| Configuration | Configure release pipeline before first ship |
+| Authentication | Authenticate with API tokens |
+| Notes | Use environment variables for secrets |
+| Setup | Install dependencies and run init |
+| Performance | Set timeout to 30s on slow networks |
+
+**Issue title.** `Vague heading: "<heading>"`
+
+**Remediation message.**
+
+> Heading "<heading>" doesn't tell the reader what the section is for.
+> State the action or claim: e.g., "<specific replacement>".
+
+### Paragraph without purpose
+
+**Detection pattern.** (Manual.)
+
+For each paragraph, ask "what does this contribute?" If the answer is
+"none — it restates the previous paragraph or sets up the next one
+without adding information", flag it.
+
+**Issue title.** `Paragraph without clear purpose at line X`
+
+**Remediation message.**
+
+> The paragraph at line X restates / sets up without adding new
+> information. Cut it or merge with adjacent content.
+
+## Link Violations
+
+### Link in heading
+
+**Detection pattern.**
+
+```bash
+grep -inE '^#+ .*\[.*\]\(' <file>
+```
+
+**Issue title.** `Link inside heading: "<heading>"`
+
+**Remediation message.**
+
+> Line X has a link inside the heading. Headings should be plain text;
+> move the link to the body. Exception: if the entire heading is the
+> link (no surrounding text), it's allowed.
+
+### Ampersands
+
+**Detection pattern.**
+
+```bash
+grep -inE ' & ' <file>
+```
+
+**Issue title.** `Ampersand instead of "and"`
+
+**Remediation message.**
+
+> Line X uses "&" — spell out "and" unless the ampersand is part of a
+> proper noun (e.g., "AT&T").
+
+## Formatting Violations
+
+### Missing language tag
+
+**Detection pattern.**
+
+```bash
+# Find fenced blocks with no language tag
+grep -inP '^```$' <file>
+```
+
+**Issue title.** `Code block without language tag`
+
+**Remediation message.**
+
+> Code block at line X has no language tag. Add `bash`, `typescript`,
+> `python`, `json`, etc., for syntax highlighting.
+
+### Abbreviated language tag
+
+**Detection pattern.**
+
+```bash
+grep -inE '^```(ts|js|py|rs|md)\s*$' <file>
+```
+
+**Issue title.** `Abbreviated language tag: "<tag>"`
+
+**Remediation message.**
+
+> Code block at line X uses "<tag>" — use the full name. Mapping:
+> ts → typescript, js → javascript, py → python, rs → rust,
+> md → markdown.
+
+## Code Example Violations
+
+### Example doesn't run
+
+**Detection pattern.** (Manual + tool.)
+
+For TypeScript/JavaScript/Python code blocks that contain runnable
+snippets, attempt to dry-run them (TS: `tsc --noEmit`; Python: `python
+-c`). For shell snippets, sanity-check the syntax.
+
+**Issue title.** `Example at line X doesn't compile / run`
+
+**Remediation message.**
+
+> The code at line X has <error>. Either fix the example to compile/run,
+> or mark it as pseudocode with a comment.
+
+### Commands out of order
+
+**Detection pattern.** (Manual.)
+
+In a sequence of shell commands, check that each command's
+prerequisites are stated before it.
+
+**Issue title.** `Commands out of dependency order at line X`
+
+**Remediation message.**
+
+> Command at line X depends on output of command at line Y, but appears
+> before it. Reorder, or split into separate code blocks with prose
+> between.
+
+## Materiality Filter
+
+After collecting all detected violations, apply the materiality filter:
+"Would fixing this make a meaningful difference to the reader?"
+
+- High-severity violations always pass the filter.
+- Medium-severity: pass if the doc is end-user-facing or the violation
+  appears in a prominent location (heading, intro, summary).
+- Low-severity: pass if there are several together (signals a quality
+  problem); otherwise SKIP.
+
+Flag only what passes the filter. A flood of low-severity flags
+overwhelms the reviewer — be selective.

--- a/packages/skills/skills/ct-docs-write/SKILL.md
+++ b/packages/skills/skills/ct-docs-write/SKILL.md
@@ -106,3 +106,99 @@ Not: "(remember to run X before Y...)" buried in a paragraph.
 | can't, don't               | cannot, do not     |
 | **Filter** button          | \`Filter\` button  |
 | Check out [the docs](link) | Click [here](link) |
+
+## The Three Pillars (Why)
+
+CLEO documentation has three principles. Every rule supports one of them.
+
+1. **Conversational.** Read aloud — does it sound like you talking? CLEO docs
+   use contractions (don't, can't) where many style guides ban them. The
+   contractions are deliberate; they make the writing feel like a colleague
+   talking, not a corporate press release.
+
+2. **Clear.** Lead with what to do; explain after. Headings state the point,
+   not just the topic. "Configure release pipeline before first ship" beats
+   "Configuration" every time.
+
+3. **User-focused.** Say "people" and "companies" — not "users". The user
+   construct is for systems; people are the readers. This change is jarring
+   the first time, then becomes second nature.
+
+## Forbidden Phrases (Most Common Failures)
+
+These ship to PR, get caught in review, and create rework. Avoid them up
+front.
+
+- "easy" / "simple" / "just" — patronizing; you don't know the reader's context
+- "obviously" / "of course" — same problem
+- "click here" / "read more here" — link text must describe the destination
+- "etc." / "and so on" — be specific, or cut the sentence
+- "we" referring to CLEO — say "CLEO" or "it"
+
+## Audience-Matching
+
+Match complexity to audience. Mismatch is the biggest style failure.
+
+| Audience | Tone | Code examples | Depth |
+|----------|------|---------------|-------|
+| End-user | Conversational, second-person | Realistic, copy-paste | Low |
+| Agent (LLM) | Dense, structured | Schemas, JSON | Medium |
+| Maintainer | Technical, third-person | Code with internals | High |
+
+Declare the audience in frontmatter — `audience: end-user | agent | maintainer`
+— so reviewers can apply the right rubric.
+
+## Output Location
+
+Documentation goes in `docs/` for end-user and maintainer content. Agent-
+facing protocol docs (skill references, agent-outputs) go in
+`packages/skills/skills/<name>/references/` or `.cleo/agent-outputs/`.
+Never mix audiences in one location.
+
+## When to Update Instead of Create
+
+The MAINTAIN, DON'T DUPLICATE rule from ct-documentor applies here too.
+Before creating any new file:
+
+1. Run `Glob: docs/**/*.md` and `Grep: <topic-keywords> path=docs/` to find
+   prior coverage.
+2. If a prior page exists, UPDATE that page. Add a section if needed.
+3. If multiple prior pages cover the topic in fragments, propose a
+   consolidation to the documentor coordinator before writing.
+4. Only create a new file when no existing location fits.
+
+The cost of duplicate documentation is paid by every future reader —
+they find one page or the other depending on search keywords, and the
+two versions inevitably drift.
+
+## Final-Pass Checklist
+
+Before declaring the draft done:
+
+- [ ] All code blocks have explicit language tags (`bash`, `typescript`, not `ts`).
+- [ ] All links have descriptive text (no "here", "this").
+- [ ] All headings state the point in sentence case.
+- [ ] All "users" replaced with "people" or "companies".
+- [ ] Contractions present (don't, can't, won't).
+- [ ] No "easy", "simple", "just", "obviously" anywhere (including code comments).
+- [ ] Frontmatter title and H1 match.
+- [ ] Audience declared in frontmatter.
+- [ ] Final newline at end of file.
+
+Run grep for the forbidden phrases before completing:
+
+```bash
+for word in easy simple just obviously "click here" "read more"; do
+  grep -in "$word" <new-file>
+done
+```
+
+---
+
+## See references/
+
+Progressive disclosure — load on demand only:
+
+- `references/cleo-style-guide.md` — the three pillars, forbidden phrases, format conventions, hidden drift
+- `references/markdown-patterns.md` — code-block / table / list / link / callout patterns with positive/negative examples
+- `references/audience-targeting.md` — end-user / agent / maintainer profiles, mixed-audience pitfalls, re-targeting

--- a/packages/skills/skills/ct-docs-write/references/audience-targeting.md
+++ b/packages/skills/skills/ct-docs-write/references/audience-targeting.md
@@ -1,0 +1,305 @@
+# Audience Targeting
+
+CLEO docs serve three audiences with very different needs. Writing
+without identifying the audience produces docs that satisfy none.
+This reference defines each audience's profile and how to tune the
+draft to fit.
+
+## Three Audiences
+
+| Audience | Profile | Reading goal |
+|----------|---------|--------------|
+| End-user | Uses CLEO to ship their own software | "Help me do this thing now" |
+| Agent | LLM consuming the doc as context | "Give me the structure I need" |
+| Maintainer | Contributes to CLEO itself | "Show me how this works internally" |
+
+Identifying the audience is the first step in any documentation task.
+The downstream choices — tone, depth, examples, structure — all flow
+from this single decision.
+
+## End-User Audience
+
+The end-user has installed CLEO and wants to use it. They are a
+developer or a tech-comfortable team lead. They are working — not
+exploring.
+
+### Tone
+
+Conversational, practical, second-person.
+
+```markdown
+You can run the release pipeline manually with `cleo release ship`.
+Just kidding — never use "just". Run it with `cleo release ship`,
+and CLEO walks through the gates one by one.
+```
+
+### Depth
+
+Show the action; show the outcome; show the recovery if it fails.
+Do not explain why unless the why directly affects behavior.
+
+```markdown
+GOOD (end-user):
+Run `cleo release ship 2026.5.82 --epic T9567`.
+
+You see:
+- The 12 release steps run in order.
+- CI status streams in real-time.
+- On success, the tag is pushed and the PR merges.
+
+If a step fails, CLEO stops and prints the failing gate. Fix the issue
+and re-run.
+
+BAD (end-user, too deep):
+The `cleo release ship` command dispatches through `dispatch.ts`,
+loading the `release` handler from the registry built at module
+init. The handler then constructs a release plan using the 12-stage
+state machine defined in `packages/cleo/src/commands/release/...`
+```
+
+### Examples
+
+Realistic. Copy-paste-able. With expected output.
+
+```markdown
+GOOD:
+```bash
+$ cleo show T9567
+T9567 — E-SKILLS-DEPTH-BACKFILL
+Status: pending
+Acceptance:
+  1. Each of 6+ stub skills gains references/ with min 3 docs each
+  ...
+```
+```
+
+### Structure
+
+How-to or tutorial template. The reader scans for steps; give them
+steps.
+
+## Agent Audience
+
+The agent is an LLM — Claude, GPT, a CLEO subagent. It consumes the
+doc as context for completing a task. Its needs are very different
+from the human's.
+
+### Tone
+
+Dense, structured, declarative. Bullet points and tables over prose.
+
+```markdown
+GOOD (agent):
+Worker contract:
+1. cd to worktree path (provided in spawn prompt)
+2. read task with `cleo show <ID>`
+3. implement; commit on task branch
+4. verify each gate with `cleo verify --gate X --evidence Y`
+5. complete with `cleo complete <ID>`
+6. observe learning with `cleo memory observe`
+
+BAD (agent, too narrative):
+When the worker starts up, it first navigates to the worktree the
+orchestrator created. This is important because all subsequent
+operations need to happen inside the worktree's boundary. After
+arrival, the worker reads the task it was assigned...
+```
+
+### Depth
+
+Maximum useful. The agent can absorb dense reference material; it
+prefers structured data to prose framing.
+
+### Examples
+
+Schemas, JSON, command sequences. Show the data shape directly.
+
+```markdown
+Manifest entry shape:
+
+```json
+{
+  "id": "<topic>-<date>",
+  "file": "<filename>",
+  "title": "<title>",
+  "status": "complete" | "partial" | "blocked",
+  "agent_type": "research" | "spec" | "implementation" | ...,
+  "topics": ["<tag>", "<tag>"],
+  "key_findings": ["<sentence>", ...],
+  "actionable": true | false,
+  "needs_followup": ["<task-id>", ...],
+  "linked_tasks": ["<epic-id>", "<task-id>"]
+}
+```
+```
+
+### Structure
+
+Reference template. Tables. Bullet lists. The agent doesn't need
+warm-up prose.
+
+## Maintainer Audience
+
+The maintainer is a CLEO contributor — they have read the codebase
+and want to understand or modify the internals. They are exploring
+or making architectural decisions.
+
+### Tone
+
+Technical, precise, third-person.
+
+```markdown
+GOOD (maintainer):
+The release pipeline is implemented as a 12-stage state machine in
+`packages/cleo/src/commands/release/`. Stages are pure functions
+that take a `ReleaseContext` and return either `{ ok: true, ctx }`
+or `{ ok: false, error }`. The dispatcher in `pipeline.ts` runs
+stages in declared order, short-circuiting on failure.
+
+BAD (maintainer, too casual):
+Releases work through this cool 12-step thing. Each step is a
+function that either works or doesn't. If a step fails, we stop.
+```
+
+### Depth
+
+Maximum. Internal symbols, file paths, design decisions. The reader
+is expected to follow links into the codebase.
+
+### Examples
+
+Code excerpts with the actual implementation. Reference to ADRs
+and prior discussions.
+
+```markdown
+The dispatcher signature is:
+
+```typescript
+// packages/cleo/src/commands/release/pipeline.ts
+export async function runPipeline(
+  stages: Stage[],
+  ctx: ReleaseContext
+): Promise<Result<ReleaseContext, ReleaseError>>;
+```
+
+See ADR-065 for the gate-ordering rationale.
+```
+
+### Structure
+
+Explanation template often. Mermaid diagrams for flows. Cross-references
+to ADRs.
+
+## Mixed-Audience Pitfalls
+
+The most common style failure is mixing audiences within a single doc.
+
+### Pitfall: End-user doc with maintainer aside
+
+```markdown
+BAD:
+Run `cleo release ship`.
+
+(Internally, this dispatches through `dispatch.ts` to the release
+handler registered via the registry pattern...)
+
+Then check that the PR opens.
+```
+
+The aside is for maintainers, not end-users. End-users don't care
+about `dispatch.ts`. Either:
+- Cut the aside.
+- Move it to a separate maintainer doc.
+- Link to it as "for more details, see [release pipeline internals]".
+
+### Pitfall: Maintainer doc with consumer hand-holding
+
+```markdown
+BAD:
+The release pipeline runs gates in order — that means each step
+happens one after another, like steps on a staircase. (You go up
+one step at a time, right?)
+```
+
+Maintainer-audience readers know what "in order" means. Patronizing
+them wastes their time.
+
+### Pitfall: Agent doc with narrative warm-up
+
+```markdown
+BAD (agent doc):
+Welcome to the worker protocol! In this guide, we'll walk through
+the steps you'll follow as a worker. We're excited to have you on
+board. Let's get started!
+
+(Then 200 lines of actual protocol.)
+```
+
+Agent readers want the protocol immediately. The warm-up is pure
+token waste.
+
+## Tagging Audience in Frontmatter
+
+Every CLEO doc SHOULD declare its audience in frontmatter:
+
+```markdown
+---
+title: How to ship a release
+audience: end-user
+type: how-to
+---
+```
+
+The audience tag lets reviewers, future maintainers, and automated
+style checks apply the right rubric. Without it, the reader has to
+infer from tone — and inference is error-prone.
+
+## Audience-Specific Conventions
+
+| Element | End-user | Agent | Maintainer |
+|---------|----------|-------|------------|
+| Pronoun | "you" | (none — declarative) | "the X", "we" rarely |
+| Verb mood | Imperative | Declarative | Descriptive |
+| Code examples | Realistic, with output | Schemas, JSON | Code excerpts with paths |
+| Internal refs | Avoid | None | Heavy |
+| ADR refs | Rarely | Rarely | Heavy |
+| Diagrams | Sometimes | Rarely | Often (Mermaid) |
+| Warm-up | One sentence | None | Context paragraph |
+
+## Re-Targeting
+
+When a doc is mis-audienced, the fix is usually structural — not
+tonal. Re-target by:
+
+1. Re-classify the audience in frontmatter.
+2. Restructure to the new audience's template.
+3. Strip content that doesn't fit (maintainer details from end-user
+   doc; warm-up from agent doc).
+4. Add content that does fit (verification steps for end-user;
+   internal links for maintainer).
+
+Re-targeting a long doc is sometimes more expensive than splitting it.
+A doc that genuinely serves two audiences should be two docs with
+cross-links — not one doc trying to do both.
+
+## Cross-Audience References
+
+When a doc primarily serves audience A but the reader from audience B
+might land on it (via search, link, etc.), add a footer pointer:
+
+```markdown
+> Are you contributing to CLEO? See the [maintainer's deep dive
+> on release internals](../internals/release-pipeline.md) instead.
+```
+
+The pointer respects B's time without polluting A's reading flow.
+
+## Self-Check
+
+Before declaring a draft done:
+
+- [ ] Frontmatter declares the audience.
+- [ ] Tone matches the audience profile.
+- [ ] Depth matches what the audience needs.
+- [ ] No content from a different audience snuck in.
+- [ ] Cross-references to other-audience docs added if relevant.

--- a/packages/skills/skills/ct-docs-write/references/cleo-style-guide.md
+++ b/packages/skills/skills/ct-docs-write/references/cleo-style-guide.md
@@ -1,0 +1,234 @@
+# CLEO Style Guide
+
+The canonical style guide lives at
+`packages/skills/skills/_shared/cleo-style-guide.md` and is consumed
+by both ct-docs-write and ct-docs-review. This reference makes the
+guide's most-violated rules concrete with positive/negative examples
+and the rationale for each.
+
+## The Three Pillars
+
+CLEO documentation is **conversational, clear, and user-focused**.
+Every other rule supports one of these three. When in doubt, ask:
+"would I say this to a colleague in a chat?"
+
+### Pillar 1: Conversational
+
+Write the way you talk to a colleague — not the way a corporate press
+release would. The contraction rule is the most distinctive marker.
+
+CLEO USES contractions. Many style guides ban them; CLEO does the
+opposite. "Don't" reads more like a colleague than "do not".
+
+| Avoid | Prefer | Why |
+|-------|--------|-----|
+| utilize | use | "utilize" is just "use" wearing a suit |
+| reference (verb) | see, look at | "reference" makes things sound bureaucratic |
+| offerings | products, features | "offerings" sounds like a press release |
+| we will use HTTPS | use HTTPS | imperative > first-person future |
+| cannot, do not | can't, don't | contractions read more conversationally |
+| it is recommended that | use | passive recommendation = no recommendation |
+
+### Pillar 2: Clear
+
+Lead with what to do. Explain after. Bury nothing.
+
+Headings state the point. Vague headings make the reader scan the body
+to learn whether to read it.
+
+| Vague heading | Clear heading |
+|---------------|---------------|
+| Configuration | Configure release pipeline before first ship |
+| Authentication | Authenticate with API tokens |
+| Performance | Set timeout to 30s on slow networks |
+| Common issues | Solve E_VALIDATION errors |
+| Setup | Install dependencies and run init |
+| Notes | Use environment variables for secrets |
+
+The pattern: action verb + object + (qualifier). Vague nouns alone
+fail the test.
+
+### Pillar 3: User-Focused
+
+CLEO docs say "people" and "companies", not "users". This is jarring
+the first time you switch; once you do, the writing reads more
+concrete.
+
+| Avoid | Prefer |
+|-------|--------|
+| users can | people can |
+| our users | our customers, or "the companies using CLEO" |
+| user input | what people type |
+| user experience | what people see |
+| end-user | (the same — only when "user" is part of a compound) |
+
+The exception: when "user" is part of a compound technical term
+("end-user", "user-agent", "user-space"), it stays. Only the standalone
+"user" gets replaced.
+
+## Forbidden Phrases
+
+These never appear in CLEO docs. The review skill rejects them on sight.
+
+### "easy" / "simple" / "just"
+
+These words assume you know the reader's context — and you don't. What
+is easy for you may be intimidating for them. Removing these words
+costs nothing and makes the doc respectful.
+
+| Bad | Good |
+|-----|------|
+| Setting up SAML is easy. Just follow these steps. | Set up SAML with these steps. |
+| It's simple to configure the cache. | Configure the cache by setting `cacheTimeout`. |
+| You can just import the helper. | Import the helper from `@cleocode/contracts`. |
+
+### "obviously" / "of course"
+
+Same problem as "easy" — they patronize the reader. If something is
+obvious, it doesn't need to be said. If it's not, calling it obvious
+makes the reader feel stupid.
+
+### "click here" / "read more here"
+
+Link text must describe the destination. The naked words "here" or
+"this" tell the reader nothing about where the link goes.
+
+| Bad | Good |
+|-----|------|
+| Click [here](url) to learn about SAML. | See the [SAML configuration guide](url). |
+| For more info, [read this](url). | Read the [release pipeline ADR](url). |
+| You can [download it here](url). | Download [the CLEO CLI binary](url). |
+
+### "etc." / "and so on"
+
+Be specific or cut the sentence. Trailing-off phrases signal you
+didn't finish thinking.
+
+| Bad | Good |
+|-----|------|
+| Use environment variables, config files, etc. | Use environment variables or config files. |
+| You can run tests, lint, format, and so on. | Run lint, format, build, then tests. |
+
+### "we" (when referring to CLEO)
+
+When talking about CLEO features, say "CLEO" or "it" — not "we".
+"We" is for the human team, not the system.
+
+| Bad | Good |
+|-----|------|
+| We use a per-skill token budget. | CLEO uses a per-skill token budget. |
+| We will deprecate this in 2026-Q3. | This feature is deprecated as of 2026-Q3. |
+| Our orchestrator manages... | The orchestrator manages... |
+
+## Code Block Discipline
+
+Code blocks always have a language tag.
+
+````markdown
+GOOD:
+```bash
+pnpm run test
+```
+
+GOOD:
+```typescript
+import { foo } from "@cleocode/contracts";
+```
+
+BAD (no tag):
+```
+pnpm run test
+```
+
+BAD (abbreviated tag):
+```ts
+import { foo } from "@cleocode/contracts";
+```
+````
+
+Use full names: `bash`, `typescript`, `tsx`, `python`, `rust`, `json`,
+`yaml`, `markdown`. Avoid `js`, `ts`, `py`, `rs`.
+
+When the command depends on a working directory or other context, say
+so in a comment within the block:
+
+````markdown
+```bash
+# In the project root
+pnpm run test
+```
+
+```typescript
+// packages/cleo/src/foo.ts
+import { bar } from "@cleocode/contracts";
+```
+````
+
+## Format Conventions
+
+| Element | Convention |
+|---------|-----------|
+| **Bold** | UI element names: "Click the **Submit** button" |
+| `Code` | Code symbols, variables, commands, filenames |
+| _Italic_ | New terms (on first mention) only |
+| `[link text](url)` | Descriptive link text always |
+| Numbered list | When order matters |
+| Bulleted list | When items are peers |
+| Table | When items have parallel structure |
+| Heading | State the point, not the topic |
+
+### Spelling and Punctuation
+
+- **American spelling.** "color" not "colour", "behavior" not "behaviour".
+- **Serial commas.** "a, b, and c" with the comma before "and".
+- **One space after periods.** Not two.
+- **Em dashes.** Use `—` (em dash) for parenthetical breaks. Not `--` or
+  ` - ` with surrounding spaces.
+- **Quote marks.** Straight (`"`) in code; curly (`"`) in prose (your
+  editor handles this).
+
+## Audience-Matching
+
+Match complexity to audience. The biggest stylistic failure is mismatch.
+
+| Audience | Tone | Code examples | Conceptual depth |
+|----------|------|---------------|------------------|
+| End-user (using CLEO) | Conversational, practical | Realistic, copy-paste | Low — they want to ship |
+| Agent (LLM consuming docs) | Dense, structured | Schemas, JSON | Medium — context-economical |
+| Maintainer (contributing) | Technical, precise | Code with internals | High — internal architecture |
+
+End-user docs say "Run `cleo show T123` to see the task." Maintainer
+docs say "The `cleo show` handler dispatches via `dispatch.ts:107`
+through the LAFS envelope wrapper at `packages/cleo/src/dispatch.ts`."
+
+## Headings: One Pattern
+
+Use sentence case (only the first word and proper nouns capitalized).
+
+| Bad | Good |
+|-----|------|
+| # How To Configure The Release Pipeline | # How to configure the release pipeline |
+| ## Common Issues With Authentication | ## Common issues with authentication |
+| ### Pre-Flight Checks | ### Pre-flight checks |
+
+Exception: ADRs use title case for their title because they are formal
+documents — but their internal headings use sentence case.
+
+## Hidden Drift
+
+These violations sneak through review most often:
+
+1. "easy"/"simple" inside code comments (review may skip code blocks)
+2. "users" in alt text on images
+3. Title case headings in newly-added sections of an otherwise
+   sentence-case doc
+4. Trailing "etc." inside a longer list
+5. "we" in the description field of frontmatter
+
+Run grep before declaring done:
+
+```bash
+for word in easy simple just obviously "click here" "read more"; do
+  grep -in "$word" <new-file>
+done
+```

--- a/packages/skills/skills/ct-docs-write/references/markdown-patterns.md
+++ b/packages/skills/skills/ct-docs-write/references/markdown-patterns.md
@@ -1,0 +1,329 @@
+# Markdown Patterns
+
+Concrete patterns for the code blocks, tables, lists, and other
+markdown constructs that appear most often in CLEO docs. The right
+pattern in the right place compresses information; the wrong pattern
+makes the doc feel cluttered.
+
+## Code Block Patterns
+
+### Pattern: Instructions in Sequence
+
+When the reader runs commands in order, separate each by prose that
+states the outcome — not interjections inside the block.
+
+````markdown
+GOOD:
+Run the migration:
+
+```bash
+pnpm run migrate
+```
+
+You should see "Migration complete" with no error output.
+
+Then start the dev server:
+
+```bash
+pnpm run dev
+```
+
+It boots on port 3000 by default.
+
+BAD (interjections buried in code):
+
+```bash
+# (Remember to run migration before this)
+pnpm run dev
+```
+
+BAD (multiple commands smashed together):
+
+```bash
+pnpm run migrate
+# then
+pnpm run dev
+```
+````
+
+The good pattern lets the reader pause between steps and confirm
+each one. The bad patterns force them to read the comments to learn
+the structure.
+
+### Pattern: Annotated Output
+
+When showing what command output looks like, use a separate code block
+with the language `text` (or no language):
+
+````markdown
+Run:
+
+```bash
+cleo show T9567
+```
+
+You see:
+
+```text
+T9567 — E-SKILLS-DEPTH-BACKFILL
+Status: pending
+Acceptance:
+  1. Each of 6+ stub skills gains references/ with min 3 docs each
+  ...
+```
+````
+
+Do NOT mix command and output in one block — it confuses syntax
+highlighters and makes copy-paste error-prone.
+
+### Pattern: TypeScript with Path Comment
+
+When showing TypeScript that lives at a specific path, lead with a
+path comment:
+
+````markdown
+```typescript
+// packages/cleo/src/commands/release-plan.ts
+import { defineCommand } from "citty";
+
+export const releasePlan = defineCommand({
+  meta: { name: "plan", description: "..." },
+  // ...
+});
+```
+````
+
+The path comment gives the reader the "where" before the "what".
+
+## Table Patterns
+
+### Pattern: Comparison Table
+
+Use when the reader is choosing between options.
+
+```markdown
+| Approach | Pros | Cons | Use when |
+|----------|------|------|----------|
+| A | fast, simple | limited | quick scripts |
+| B | flexible, typed | more setup | production code |
+| C | minimal | runtime cost | very small projects |
+```
+
+The "Use when" column is the punchline — readers scan the comparison
+table to find their use case.
+
+### Pattern: Reference Table
+
+Use when listing options, flags, or enum values.
+
+```markdown
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--verbose` | false | Print full execution trace |
+| `--epic <id>` | (required) | Epic to release |
+| `--no-tag` | false | Skip the tag step |
+```
+
+Default column makes the reader's reading order clear: read row,
+notice it has a sensible default, move on. Without the default
+column, the reader has to mentally guess what happens when they
+don't specify the flag.
+
+### Pattern: Status Table
+
+Use for state machines or status codes.
+
+```markdown
+| Status | Meaning | Next states |
+|--------|---------|-------------|
+| pending | Created, not yet started | active |
+| active | In progress | done, blocked |
+| blocked | Awaiting dependency | active, cancelled |
+| done | Complete | — |
+```
+
+The "Next states" column makes the state machine readable as a table.
+
+### Anti-pattern: Too Many Columns
+
+Tables wider than 5 columns become illegible on mobile and look like
+data dumps. If you have more dimensions, split into multiple tables.
+
+```markdown
+BAD:
+| Name | Status | Date | Owner | Priority | Estimate | Description | Notes |
+
+GOOD (split):
+| Name | Status | Date | Owner |
+|------|--------|------|-------|
+| ... | ... | ... | ... |
+
+For details and estimates, see the [task tracker]...
+```
+
+## List Patterns
+
+### Pattern: Numbered for Sequence
+
+Use when order matters and the reader will follow steps.
+
+```markdown
+1. Install the CLI: `pnpm i -g @cleocode/cleo`
+2. Initialize a project: `cleo init`
+3. Open the first task: `cleo next`
+```
+
+### Pattern: Bulleted for Peers
+
+Use when items are independent.
+
+```markdown
+The release pipeline runs these gates:
+
+- Lint and format
+- Build
+- Type-check
+- Unit tests
+- Integration tests
+- Security scan
+```
+
+### Pattern: Definition List
+
+For term + definition pairs, use bold-prefixed bullets:
+
+```markdown
+- **Orchestrator** — the agent that dispatches subagents.
+- **Worker** — an agent spawned for a leaf task.
+- **Lead** — a middle-tier agent supervising one wave.
+```
+
+The em-dash separator reads cleanly. Don't use a colon (looks like
+prose); don't use a hyphen alone (too thin).
+
+## Link Patterns
+
+### Pattern: Inline Reference
+
+```markdown
+The release pipeline is defined in [ADR-065](../.cleo/adrs/ADR-065-release-pipeline.md).
+```
+
+### Pattern: Section Reference
+
+```markdown
+See [§Worktree Discipline](#worktree-discipline) below for the full constraint.
+```
+
+### Pattern: External + Citation Comment
+
+```markdown
+The default cache behavior changed in [Next.js 15](https://nextjs.org/blog/next-15)
+— retrieved 2026-05-19.
+```
+
+The retrieval date is essential when citing an external page that may
+change. Without it, the reader can't tell whether the citation is
+still accurate.
+
+## Callout Patterns
+
+CLEO docs use bold-prefixed paragraphs rather than custom admonitions
+(no special syntax).
+
+```markdown
+**Note:** This feature requires CLEO v2026.5.81 or later.
+
+**Warning:** Running this command on a dirty working tree will lose changes.
+
+**Tip:** Use `cleo find` instead of `cleo list` for browsing.
+```
+
+The three callout types: Note (informational), Warning (potential
+foot-gun), Tip (efficiency improvement). Don't invent new ones.
+
+## Image Patterns
+
+### Pattern: Scoped UI Screenshot
+
+```markdown
+![The release pipeline dashboard showing three green checks](./images/release-dashboard.png)
+```
+
+The alt text describes what the image conveys, not what it is. "Three
+green checks" is meaningful; "Dashboard screenshot" is not.
+
+### Pattern: Diagram with Mermaid
+
+```markdown
+```mermaid
+graph LR
+  A[Task created] --> B[Wave dispatched]
+  B --> C[Worker completes]
+  C --> D[Manifest appended]
+  D --> E[Task closed]
+```
+```
+
+Mermaid renders inline in GitHub and most markdown viewers. Prefer
+over PNG diagrams for anything textual — Mermaid is editable in
+source control.
+
+## Frontmatter Patterns
+
+YAML frontmatter goes at the very top, between `---` fences.
+
+```markdown
+---
+title: How to configure the release pipeline
+date: 2026-05-19
+audience: maintainer
+status: draft
+---
+
+# How to configure the release pipeline
+...
+```
+
+The first H1 in the body matches the title field. Keeping both in sync
+is the writer's job.
+
+## Footnote and Aside Patterns
+
+CLEO docs avoid markdown footnotes — they break in many renderers.
+Use inline parenthetical references instead.
+
+```markdown
+GOOD:
+The orchestrator dispatches via `cleo orchestrate spawn` (see
+`packages/cleo/src/commands/orchestrate/spawn.ts:107`).
+
+BAD:
+The orchestrator dispatches via `cleo orchestrate spawn`[^1].
+
+[^1]: See `packages/cleo/src/commands/orchestrate/spawn.ts:107`.
+```
+
+## Whitespace and Structure
+
+- One blank line between sections.
+- Two blank lines around H1 headings (rare in CLEO docs — usually
+  only one H1 per file).
+- No trailing whitespace.
+- Final newline at end of file (POSIX requirement).
+- Tables: align the `|` separators by eye in source; it makes diff
+  review easier.
+
+## Final-Pass Checklist
+
+Before declaring a doc done, run through:
+
+- [ ] All code blocks have language tags.
+- [ ] All links have descriptive text (no "here", "this").
+- [ ] All tables ≤ 5 columns.
+- [ ] All headings state the point (not just the topic).
+- [ ] All "users" replaced with "people" or "companies".
+- [ ] All contractions present (don't, can't, won't).
+- [ ] No "easy", "simple", "just", "obviously".
+- [ ] Title and frontmatter title match.
+- [ ] Final newline present.

--- a/packages/skills/skills/ct-documentor/SKILL.md
+++ b/packages/skills/skills/ct-documentor/SKILL.md
@@ -229,3 +229,14 @@ Append ONE line to `{{MANIFEST_PATH}}`:
 - [ ] Output file written with "Files NOT Created" section
 - [ ] Manifest entry appended
 - [ ] Task completed via `cleo complete`
+
+---
+
+## See references/
+
+Progressive disclosure — load on demand only:
+
+- `references/chain-orchestration.md` — when to invoke lookup/write/review, input shapes, review loop budget
+- `references/doc-types-and-templates.md` — Diátaxis grid plus CLEO-native (ADR, agent-output, skill) templates
+- `references/style-coordination.md` — tone pillars, forbidden phrases, link/code/table discipline
+- `references/anti-patterns.md` — twelve documentation coordination failure modes

--- a/packages/skills/skills/ct-documentor/references/anti-patterns.md
+++ b/packages/skills/skills/ct-documentor/references/anti-patterns.md
@@ -1,0 +1,216 @@
+# Anti-Patterns
+
+Failure modes specific to documentation coordination. Each is detectable
+during the documentor's workflow and has a concrete remediation. Several
+have been observed in past CLEO sessions and are recorded in BRAIN.
+
+## 1. The Phantom Documentation
+
+**Symptom.** Manifest reports "documentation complete" but no file
+exists at the claimed path.
+
+**Detection cue.** `cat <claimed-path>` returns "no such file". Or
+`git log --follow <claimed-path>` returns nothing.
+
+**Root cause.** The documentor described work it didn't actually
+delegate. Common when the orchestrator stuffed a doc task into a
+larger PR and the documentor coordinator didn't get triggered.
+
+**Fix.** After every chain, the documentor MUST verify the file
+exists and contains the claimed content. Use `Read` to confirm before
+appending the manifest entry.
+
+## 2. The Duplicate Page
+
+**Symptom.** Two pages cover the same topic with similar but
+non-identical content. Readers find one or the other depending on
+search keywords; updates land on one and not the other.
+
+**Detection cue.** Glob + grep during Discovery turns up a prior
+page on the same topic; documentor proceeded to create a new one
+anyway.
+
+**Root cause.** Skipped Discovery, or treated "I prefer this path
+name" as justification to duplicate.
+
+**Fix.** When prior coverage exists, UPDATE it. The MAINTAIN, DON'T
+DUPLICATE rule is in SKILL.md for this reason. Add a section to the
+existing page; do not create a sibling.
+
+## 3. The Stale Library Citation
+
+**Symptom.** A how-to or reference cites a library API that has been
+renamed, deprecated, or removed.
+
+**Detection cue.** `ct-docs-lookup` was NOT invoked for the topic.
+
+**Root cause.** Documentor coordinator skipped lookup because "I know
+the API" or assumed training data was current.
+
+**Fix.** Always invoke `ct-docs-lookup` when documenting external
+library behavior. Training data is stale by definition — Context7 is
+the current source.
+
+## 4. The Type Confusion
+
+**Symptom.** Document uses tutorial framing for what should be a
+reference, or vice versa. Reader confused.
+
+**Detection cue.** A "how-to" doc spends 5 paragraphs explaining
+concepts before any imperative step. Or a "reference" doc reads
+like a narrative.
+
+**Root cause.** Skipped Classification; documentor didn't pick a type
+up front.
+
+**Fix.** Always assign the Diátaxis type (or CLEO-native type) before
+invoking write. The type determines the template; the template
+prevents drift.
+
+## 5. The Infinite Review Loop
+
+**Symptom.** Review keeps finding issues; write keeps fixing; review
+keeps finding new issues. The loop never converges.
+
+**Detection cue.** Iteration count exceeds 3.
+
+**Root cause.** Either (a) the topic is mis-scoped (the audience is
+unclear, the type is wrong), or (b) the style guide and the writer's
+defaults conflict.
+
+**Fix.** After 3 iterations, escalate to HITL with:
+- Original input
+- Each draft
+- Each review's findings
+- The pattern across iterations (e.g., "review keeps flagging tone,
+  write keeps producing the same tone")
+
+HITL can override or re-scope. Don't burn tokens on convergence the
+loop won't reach.
+
+## 6. The Orphan Cross-Reference
+
+**Symptom.** Updated doc links to a page that no longer exists, or to
+a section that was renamed.
+
+**Detection cue.** `markdown-link-check` flags the link as broken.
+Or the index/TOC contains entries for files that have been deleted.
+
+**Root cause.** Documentor consolidated content but didn't update
+inbound references.
+
+**Fix.** When consolidating or moving content:
+1. Find all inbound links: `grep -r "<old-path>" docs/`
+2. Update each link or add a redirect
+3. Add a deprecation notice at the old path that explains the move
+4. Only delete the old path after a deprecation period
+
+## 7. The Voice Drift
+
+**Symptom.** Same doc switches between "you", "we", "the user", and
+"people" within a few paragraphs.
+
+**Detection cue.** Grep for pronouns in the new file; count occurrences
+of each voice marker.
+
+**Root cause.** Either write produced inconsistent voice, OR the doc
+was assembled from multiple sources without normalization.
+
+**Fix.** CLEO style is "you" (second person) for how-tos and tutorials;
+"CLEO" (third person) for explanations and references. Apply
+consistently. Pass the choice explicitly to ct-docs-write as input.
+
+## 8. The Forbidden Word Sneak-In
+
+**Symptom.** Doc ships with "easy", "simple", "just", "obviously",
+or other forbidden phrases.
+
+**Detection cue.** Review didn't catch it. Grep for the forbidden
+list in the new file.
+
+**Root cause.** Review's rule list drifted from the canonical style
+guide. Or the words appeared inside a code block (where review may
+skip).
+
+**Fix.** Run grep yourself before completing:
+
+```bash
+for word in easy simple just obviously "click here" "read more here"; do
+  grep -n "$word" <new-file> && echo "FAIL: $word"
+done
+```
+
+If review missed something, also file a task to sync the rule list.
+
+## 9. The Imperative Confusion
+
+**Symptom.** A tutorial uses "you can", "you might", "the user can",
+when the contract is "the reader DOES this step now".
+
+**Detection cue.** Modal verbs (can, might, would) appear in tutorial
+step bodies.
+
+**Root cause.** Writer hedged when the doc required imperatives.
+
+**Fix.** Tutorials and how-tos use imperative voice — "Run the
+command", "Open the file", "Set the value". Pass that constraint
+explicitly to ct-docs-write.
+
+## 10. The Lost Manifest
+
+**Symptom.** Documentation work shipped but the orchestrator's rollup
+shows no manifest entry. Subsequent agents redo the same work.
+
+**Detection cue.** `cleo find <topic>` returns no manifest entries
+for the documentation work. The doc file exists but the manifest
+doesn't link to it.
+
+**Root cause.** Documentor skipped the manifest append step (or one
+of the children appended in a wrong format).
+
+**Fix.** The manifest append is mandatory. The documentor — not its
+children — owns the entry. Run:
+
+```bash
+cleo manifest append <(cat <<EOF
+{"id":"docs-<topic>-<date>", "file":"<path>", "title":"...", ...}
+EOF
+)
+```
+
+After append, verify with:
+
+```bash
+cleo find "<topic>" | head -3
+```
+
+The new entry should appear.
+
+## 11. The Audience Whiplash
+
+**Symptom.** Doc switches audience mid-page — opens for end-users,
+shifts into maintainer-level detail, returns to end-user framing.
+Readers from neither group are well-served.
+
+**Detection cue.** Page mixes "people who use CLEO" framing with
+"contributors to CLEO" framing.
+
+**Root cause.** Documentor didn't pin audience in Classification.
+
+**Fix.** One audience per page. If both audiences need coverage, split
+into two pages — `guide.md` for end-users and `internals.md` for
+contributors — and cross-link.
+
+## 12. The Skipped Pre-PR Pass
+
+**Symptom.** PR opens with documentation; reviewer finds style
+violations the local review didn't catch.
+
+**Detection cue.** PR comments contain style-guide flags.
+
+**Root cause.** Documentor ran review on the draft, but not on the
+PR diff. Integration introduced drift (rebase fixups, merge prose).
+
+**Fix.** Always run `ct-docs-review --mode=pr` on the PR's diff
+before requesting merge. Catches drift that slipped through during
+integration.

--- a/packages/skills/skills/ct-documentor/references/chain-orchestration.md
+++ b/packages/skills/skills/ct-documentor/references/chain-orchestration.md
@@ -1,0 +1,194 @@
+# Chain Orchestration
+
+`ct-documentor` is a coordinator skill — it does not produce documentation
+directly. Its job is to orchestrate three child skills (`ct-docs-lookup`,
+`ct-docs-write`, `ct-docs-review`) in the right sequence with the right
+inputs. This reference defines when to invoke each child, what to pass,
+and how to handle returns.
+
+## The Three Children
+
+| Child | Purpose | Owns |
+|-------|---------|------|
+| `ct-docs-lookup` | Library/framework API lookup via Context7 | Current external docs |
+| `ct-docs-write` | Drafts content following CLEO style guide | New content |
+| `ct-docs-review` | Reviews against style guide; supports PR mode | Quality validation |
+
+A complete documentation task usually invokes write + review. Lookup is
+optional — only when the doc must cite a library's actual current API.
+
+## Decision Sequence
+
+For every documentation task, run this sequence before invoking any child.
+
+```text
+1. DISCOVERY
+   - Glob: docs/**/*.md to map the existing tree
+   - Grep: <topic-keywords> across docs/ to find prior coverage
+   - Decision: is there already a canonical location for this content?
+
+2. CLASSIFICATION
+   - Type: tutorial | how-to | reference | explanation (Diátaxis grid)
+   - Audience: end-user | agent | maintainer
+   - Lifecycle: new file | update existing | consolidate scattered
+
+3. CHAIN
+   - If type touches library APIs → ct-docs-lookup first
+   - Always → ct-docs-write
+   - Always → ct-docs-review
+
+4. REPORT
+   - Manifest entry with "Files NOT Created (Avoided Duplication)" section
+   - Cross-references updated
+```
+
+The Discovery step is mandatory. Skipping it produces duplicate
+documentation — the dominant failure mode of past documentation tasks.
+
+## Invoking ct-docs-lookup
+
+Use when the task touches a specific library, framework, or external
+API. Pass the library name, the user's actual question (full sentence,
+not a single word), and any version qualifier.
+
+**Invoke when:**
+
+- Documenting a setup or migration that depends on a specific
+  framework version.
+- Writing reference docs that cite a library's exported API.
+- Answering "how do I X with library Y" in a guide.
+
+**Do NOT invoke when:**
+
+- The doc describes CLEO's own internal architecture (use BRAIN + code
+  reading, not external lookup).
+- The user asks a conceptual question that does not name a library.
+
+**Input shape:**
+
+```json
+{
+  "library": "Next.js",
+  "version": "15",
+  "query": "how do I configure middleware to inject auth headers"
+}
+```
+
+**Return.** Documentation excerpts with citations. Do not paste blindly —
+synthesize into the doc body, citing the library version.
+
+## Invoking ct-docs-write
+
+The write child owns content production. Its frontmatter (under
+`packages/skills/skills/ct-docs-write/SKILL.md`) describes the style
+guide it enforces. Always invoke for any new or updated content.
+
+**Input shape:**
+
+```json
+{
+  "file_path": "docs/guides/auth-setup.md",
+  "content_topic": "configure SAML before adding users",
+  "audience": "end-user",
+  "type": "how-to",
+  "outline": [
+    "Why SAML must precede user addition",
+    "Step-by-step config",
+    "Common errors and fixes"
+  ]
+}
+```
+
+The outline guides the writer — without it, the draft tends to drift
+into tutorial mode when reference was needed (and vice versa).
+
+**Return.** A drafted markdown file. The documentor does not edit it
+directly — the next step is review.
+
+## Invoking ct-docs-review
+
+The review child owns quality validation. It checks against the CLEO
+style guide and is the gate before the documentation task can complete.
+
+**Input shape:**
+
+```json
+{
+  "file_path": "docs/guides/auth-setup.md",
+  "mode": "local"
+}
+```
+
+For PR-mode review (when reviewing a GitHub PR rather than a local
+file):
+
+```json
+{
+  "pr_url": "https://github.com/kryptobaseddev/cleocode/pull/315",
+  "mode": "pr"
+}
+```
+
+**Return.** A numbered list of issues with line refs and suggested
+fixes. If the issue count is 0, the doc passes. If non-zero, the
+documentor MUST loop — pass the issues back to `ct-docs-write` for
+revision, then re-review.
+
+## The Review Loop
+
+The contract is: documentation does not ship with open review issues.
+The documentor MUST loop until review returns zero issues OR escalates
+to HITL.
+
+```text
+draft = ct-docs-write(input)
+issues = ct-docs-review(draft)
+while issues != [] and iteration < 3:
+  draft = ct-docs-write(input + issues)
+  issues = ct-docs-review(draft)
+if issues != []:
+  escalate_to_HITL("3 review iterations did not converge")
+```
+
+Three iterations is the convergence budget. If review keeps finding
+issues, the task is mis-scoped (audience confusion, style guide
+conflict with content) — escalate rather than burning more tokens.
+
+## Cross-Skill Output Conventions
+
+All three children return to the documentor. The documentor aggregates
+into ONE manifest entry. Children do NOT each append their own — that
+would inflate the manifest.
+
+```json
+{
+  "id": "docs-auth-setup-2026-05-19",
+  "file": "2026-05-19_docs-auth-setup.md",
+  "title": "Documentation Update: SAML Setup Guide",
+  "status": "complete",
+  "agent_type": "documentation",
+  "topics": ["documentation", "auth", "saml"],
+  "key_findings": [
+    "Created docs/guides/auth-setup.md (how-to, end-user audience)",
+    "Cited Next.js 15 middleware API via ct-docs-lookup",
+    "Review converged in 2 iterations (8 issues → 3 → 0)",
+    "Updated docs/index.md to reference new guide"
+  ],
+  "actionable": false,
+  "needs_followup": [],
+  "linked_tasks": ["{{TASK_ID}}"]
+}
+```
+
+The `key_findings` MUST report the iteration count and the chain that
+ran. This lets the orchestrator confirm the contract was honored.
+
+## Failure Modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Doc duplicates existing content | Skipped Discovery | Always Glob + Grep before write |
+| Doc cites stale API | Skipped ct-docs-lookup | Invoke lookup for any library API claim |
+| Doc fails review repeatedly | Audience or type mismatch | Re-classify; pass corrected to write |
+| Review iteration count >3 | Mis-scoped task | Escalate to HITL with summary |
+| Manifest missing iteration data | Children appended their own entries | Children MUST return to documentor; one entry only |

--- a/packages/skills/skills/ct-documentor/references/doc-types-and-templates.md
+++ b/packages/skills/skills/ct-documentor/references/doc-types-and-templates.md
@@ -1,0 +1,301 @@
+# Doc Types and Templates
+
+CLEO documentation follows the Diátaxis grid (tutorial, how-to,
+reference, explanation) plus three CLEO-native types (ADR,
+agent-output, skill). Each type has a distinct shape — using the
+wrong template confuses the reader. This reference defines each
+type's purpose, audience, and skeleton.
+
+## Diátaxis Grid
+
+| Type | Purpose | When user is | Cognitive mode |
+|------|---------|--------------|----------------|
+| Tutorial | Learning by doing | New, exploring | Acquisition |
+| How-to | Solving a problem | Working, blocked | Application |
+| Reference | Looking up details | Working, knows what | Lookup |
+| Explanation | Understanding | Reflecting, curious | Cognition |
+
+The four types are NOT interchangeable. A how-to written as a tutorial
+is too slow for working users; a reference written as explanation
+hides the lookup data behind prose. Identify the type up front.
+
+## Tutorial Template
+
+```markdown
+# {Tutorial Title}: Build a {thing} with {tech}
+
+This tutorial walks you through building {thing} from scratch using
+{tech}. By the end, you'll have a working {thing} and understand
+{key concepts}.
+
+## What you'll build
+
+{Screenshot or output of finished thing}
+
+## Prerequisites
+
+- {Required tool / knowledge}
+- {Required tool / knowledge}
+
+## Step 1: {action verb + noun}
+
+{1-3 sentences setting up the step.}
+
+```bash
+{exact command}
+```
+
+You should see {expected output}.
+
+## Step 2: ...
+
+...
+
+## What you learned
+
+- {concept 1}
+- {concept 2}
+
+## Next steps
+
+- See [{how-to}](../how-to/...) to do {related task}.
+- See [{reference}](../reference/...) for the full {API} surface.
+```
+
+Tutorials are linear. They never branch. They never ask the reader
+to choose. Every step results in observable progress.
+
+## How-to Template
+
+```markdown
+# How to {accomplish task}
+
+When you need to {accomplish task}, follow these steps.
+
+## Prerequisites
+
+- {Required state / config}
+
+## Steps
+
+1. {Action verb + noun}.
+   ```bash
+   {exact command}
+   ```
+
+2. {Action verb + noun}.
+
+3. {Action verb + noun}.
+
+## Verify
+
+Check that {observable outcome}.
+
+```bash
+{verification command}
+```
+
+## Troubleshooting
+
+- **{Symptom}**: {Cause + fix}
+- **{Symptom}**: {Cause + fix}
+
+## Related
+
+- [{Reference page}]
+- [{Similar how-to}]
+```
+
+How-tos assume the reader knows the basics. They do not explain why —
+they instruct.
+
+## Reference Template
+
+```markdown
+# {API/command/feature} Reference
+
+{One-sentence definition.}
+
+## Synopsis
+
+```bash
+{command-syntax} [OPTIONS] <ARGS>
+```
+
+## Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `<arg1>` | string | {what it is} |
+| `<arg2>` | number | {what it is} |
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--flag` | false | {effect} |
+| `--opt <v>` | (none) | {effect} |
+
+## Output
+
+```json
+{ "schema": "..." }
+```
+
+## Errors
+
+| Exit | Code | Cause |
+|------|------|-------|
+| 0 | — | Success |
+| 1 | E_VALIDATION | Bad input |
+
+## Examples
+
+```bash
+{example 1}
+```
+
+```bash
+{example 2}
+```
+```
+
+References are dense and exhaustive. They do not include narrative.
+Tables are preferred over prose.
+
+## Explanation Template
+
+```markdown
+# {Concept or System Name}: Why {it matters}
+
+## Context
+
+{Why this exists; what problem it solves.}
+
+## Mental model
+
+{2-3 paragraphs framing the concept.}
+
+```mermaid
+{diagram if useful}
+```
+
+## How it works
+
+{Walk through the structure.}
+
+## Trade-offs
+
+- **{trade-off 1}**: {what gives, what gains}
+- **{trade-off 2}**: {what gives, what gains}
+
+## Comparisons
+
+| Alternative | Why we didn't pick it |
+|-------------|-----------------------|
+| {Alt A} | {reason} |
+| {Alt B} | {reason} |
+
+## Related
+
+- [{ADR-NNN}]: the decision record
+- [{Reference}]: the surface
+- [{How-to}]: practical recipe
+```
+
+Explanations are essays. They have a thesis. They argue.
+
+## CLEO-Native: ADR
+
+Architecture Decision Record. Lives in `.cleo/adrs/`. Strictly templated.
+
+```markdown
+# ADR-NNN: {Short title}
+
+**Status**: proposed | accepted | superseded | deprecated
+**Date**: YYYY-MM-DD
+**Decider(s)**: {names or "council vote ID"}
+**Supersedes**: {ADR-MMM} or "(none)"
+**Superseded by**: {ADR-PPP} or "(none)"
+
+## Context
+
+{Why this decision is needed now.}
+
+## Decision
+
+We will {state the decision}.
+
+## Alternatives Considered
+
+1. **{Alt A}**: {description, why rejected}
+2. **{Alt B}**: {description, why rejected}
+
+## Consequences
+
+- **Positive**: {what improves}
+- **Negative**: {what costs}
+- **Neutral**: {what changes without strong direction}
+
+## Implementation Notes
+
+{Pointers to follow-up tasks, specs, code.}
+```
+
+ADRs are immutable once accepted. Changes go in a new ADR that
+supersedes the old one.
+
+## CLEO-Native: Agent-Output
+
+Outputs of agent work, recorded in `.cleo/agent-outputs/`. Templated
+to support `cleo docs add` registration and rollup.
+
+```markdown
+---
+date: YYYY-MM-DD
+agent: <agent-id>
+task: T####
+status: complete | partial | blocked
+topics: [topic1, topic2]
+---
+
+# {Output Title}
+
+## Summary
+
+{2-3 sentences.}
+
+## Findings / Deliverables
+
+{Body.}
+
+## Manifest Entry
+
+```json
+{ ... }
+```
+```
+
+The frontmatter is mandatory. The CI lint (`agent-outputs-registration`
+job per T1617) rejects any new `.md` in this directory that lacks it
+or that wasn't registered via `cleo docs add` / `cleo memory observe`.
+
+## CLEO-Native: Skill
+
+Lives in `packages/skills/skills/<name>/SKILL.md`. The ct-skill-creator
+skill is the canonical template — see its references/.
+
+## When to Pick Which Type
+
+| Question | Type |
+|----------|------|
+| "How do I do X?" — and the reader is learning | Tutorial |
+| "How do I do X?" — and the reader is working | How-to |
+| "What does X do?" / "What's the syntax?" | Reference |
+| "Why does X work this way?" | Explanation |
+| "Why did we pick X over Y?" | ADR |
+| "What did this agent produce?" | Agent-output |
+| "Add a new agent skill" | Skill |
+
+When in doubt: pick how-to. It is the type most users want most of the
+time, and the easiest to convert to reference later.

--- a/packages/skills/skills/ct-documentor/references/style-coordination.md
+++ b/packages/skills/skills/ct-documentor/references/style-coordination.md
@@ -1,0 +1,195 @@
+# Style Coordination
+
+The CLEO documentation style guide lives at
+`packages/skills/skills/_shared/cleo-style-guide.md` and is referenced
+by both `ct-docs-write` and `ct-docs-review`. As coordinator, the
+documentor's role is to ensure the style guide is enforced consistently
+across the chain — write applies it; review verifies it. This reference
+covers the parts of the style guide most commonly violated and how the
+documentor enforces them.
+
+## Tone Pillars
+
+The CLEO style is **conversational, clear, user-focused**. Three pillars
+the documentor must enforce across the chain.
+
+### 1. Conversational
+
+Write the way you would explain to a colleague — not the way a corporate
+press release would. This shows up at the word level.
+
+| Avoid | Prefer |
+|-------|--------|
+| utilize | use |
+| reference | see / look at |
+| offerings | products / features |
+| we will / we can | CLEO does / CLEO can |
+| cannot, do not | can't, don't |
+| people are able to | people can |
+
+The contraction rule is real and unusual — CLEO docs USE contractions.
+Many style guides ban them; CLEO does the opposite.
+
+### 2. Clear
+
+Lead with the action; explain after. Headings state the point.
+
+| Vague heading | Clear heading |
+|---------------|---------------|
+| "Environment variables" | "Use environment variables for configuration" |
+| "Authentication" | "Authenticate with API tokens" |
+| "Configuration" | "Configure release pipeline before first ship" |
+| "Performance considerations" | "Set timeout to 30s on slow networks" |
+
+Vague headings force the reader to scan the body to learn the point.
+Clear headings let the reader skip the section if it's not what they
+need.
+
+### 3. User-Focused
+
+Use "people" or "companies", not "users". The first refers to humans;
+the second to a system construct. The CLEO docs are for humans.
+
+| Avoid | Prefer |
+|-------|--------|
+| users can | people can |
+| our users | our customers / the companies using CLEO |
+| user input | what people type |
+| user experience | what people see |
+
+This is jarring at first — many docs are full of "users". Once you
+switch, the writing reads more concretely.
+
+## Forbidden Phrases
+
+These never appear in CLEO docs. The review child rejects them on sight.
+
+- "easy" / "simple" / "just" — patronizing; the reader doesn't know if
+  it's easy until they try
+- "obviously" / "of course" — same problem
+- "for free" / "out of the box" — vague
+- "click here" / "read more here" — link text must be descriptive
+- "and so on" / "etc." — be specific or cut the sentence
+- "as mentioned above" — use a stable cross-reference
+
+The forbidden list is the most common reason a draft fails review.
+Pass the list to ct-docs-write as part of the input contract so it
+knows what to avoid.
+
+## Link Discipline
+
+Link text must describe the destination. Never link bare words like
+"here", "this", "read more".
+
+```markdown
+GOOD: See the [release pipeline ADR](../.cleo/adrs/ADR-065.md) for the gate set.
+
+BAD: See ADR-065 [here](../.cleo/adrs/ADR-065.md) for the gate set.
+
+BAD: For more info, [click here](../.cleo/adrs/ADR-065.md).
+```
+
+The full link text MUST make sense out of context — a reader scanning
+just the link list should understand each destination.
+
+## Code Block Discipline
+
+Code blocks include their language tag for syntax highlighting and
+their working-directory context.
+
+````markdown
+GOOD:
+```bash
+# In the project root
+pnpm run test
+```
+
+GOOD:
+```typescript
+// packages/cleo/src/foo.ts
+import { bar } from "@cleocode/contracts";
+```
+
+BAD:
+```
+pnpm run test
+```
+(no language tag)
+
+BAD:
+```ts
+import { bar } from "@cleocode/contracts";
+```
+(use `typescript`, not `ts`)
+````
+
+The full language tags are `bash`, `typescript`, `tsx`, `python`,
+`rust`, `json`, `yaml`, `markdown`. Avoid abbreviations.
+
+## Table Discipline
+
+Tables compress information that would otherwise sprawl. Use them
+liberally — they signal "look up data" mode.
+
+| Use a table when... | Don't use when... |
+|---------------------|-------------------|
+| You have parallel structured items | You have unstructured prose |
+| Each row has the same columns | Each "row" has different fields |
+| The reader will scan, not read | The reader needs narrative |
+
+Keep tables narrow — three to five columns is the sweet spot. Wider
+tables overflow on mobile and look like data dumps.
+
+## Image Discipline
+
+Images are scoped — they show one specific UI element with relevant
+context. They never show full-window screenshots.
+
+| Scope | When to use |
+|-------|-------------|
+| UI element + label | Annotating a feature |
+| Specific dialog | Showing a flow step |
+| Code in editor | Showing syntax highlighting |
+| Whole window | Almost never |
+
+Add alt text that describes what the image conveys, not what the image
+is of. "Screenshot of the release pipeline dashboard showing three
+green checks" rather than "Dashboard screenshot".
+
+## Cross-Skill Drift Detection
+
+Documentor MUST check that write's output and review's checks agree.
+If they disagree, the style guide reference is the tiebreaker.
+
+```text
+write_output = ct-docs-write(input)
+review_findings = ct-docs-review(write_output)
+
+# Possible drift case:
+# write produced "users" (it should have used "people")
+# review didn't flag it (its rule list was outdated)
+# → file a sync task; passing the style guide explicitly to write
+#   on next iteration
+
+# Possible drift case:
+# write produced "click here"
+# review flagged "click here" with high confidence
+# → no drift; write just made a mistake; iterate
+```
+
+When drift is detected, surface it in `needs_followup` so the next
+session updates the shared style guide or the child skill's rules.
+
+## Pre-PR Style Pass
+
+Before opening a PR with documentation changes, the documentor MUST
+run review one more time on the diff:
+
+```bash
+# Review the diff for style violations
+gh pr diff <PR_NUMBER> | ct-docs-review --mode=diff
+```
+
+PR-mode review uses the `mcp__github__*` tools when available;
+otherwise local mode is fine. The pre-PR pass catches drift that
+sneaked in during integration.

--- a/packages/skills/skills/ct-research-agent/SKILL.md
+++ b/packages/skills/skills/ct-research-agent/SKILL.md
@@ -239,3 +239,12 @@ This skill binds to the **research** LOOM lifecycle stage. Governing ADRs:
 - [ADR-070 — three-tier orchestration](../../../../.cleo/adrs/ADR-070-three-tier-orchestration.md) — defines the Orchestrator → Phase Lead → Worker tiers; research runs as a leaf Worker.
 
 LOOM coverage matrix: [docs/skills/loom-coverage-matrix.md](../../../../docs/skills/loom-coverage-matrix.md).
+
+## See references/
+
+Progressive disclosure — load on demand only:
+
+- `references/triggers-and-routing.md` — when to use ct-research-agent and what downstream skill consumes the output
+- `references/source-strategy.md` — codebase + Context7 + web hierarchy, query patterns, time-boxing
+- `references/citation-and-evidence.md` — evidence ladder, citation format, confidence labels
+- `references/anti-patterns.md` — ten failure modes observed in past CLEO sessions and how to avoid them

--- a/packages/skills/skills/ct-research-agent/references/anti-patterns.md
+++ b/packages/skills/skills/ct-research-agent/references/anti-patterns.md
@@ -1,0 +1,154 @@
+# Anti-Patterns
+
+Common failure modes for research tasks. Each pattern below has been
+observed in real CLEO sessions (some recorded in BRAIN as patterns
+`P-b2e59bf4`, `P-75035d53`, and others). Avoid them by following the
+detection cue and applying the remediation.
+
+## 1. The Hallucinated Citation
+
+**Symptom.** A finding cites a URL, function signature, or API that does
+not actually exist. The agent inferred its existence from naming
+conventions and a plausible domain.
+
+**Detection cue.** Citation has not been retrieved during this session.
+URL was not produced by a tool call; signature was not read from a file.
+
+**Remediation.** Every citation MUST come from a tool call output in this
+session — `WebFetch`, `WebSearch`, `Grep`, `Read`, `ctx7 docs`, or
+`gitnexus_*`. If the source cannot be re-shown by a tool call, it is
+hallucinated. Strip it and either re-fetch or downgrade the finding to
+`hypothesis`.
+
+## 2. The Stale Authority
+
+**Symptom.** A finding cites the official docs for library X — but the
+project uses version Y, and the cited page describes version Z which has
+different semantics.
+
+**Detection cue.** No version qualifier on the citation. The
+`package.json` or `Cargo.toml` for the project specifies a version that
+differs from the doc page version.
+
+**Remediation.** Always pin Context7 queries to the project's actual
+version. Use the `/org/project/version` form when available. Read the
+project's lockfile before citing version-dependent behavior.
+
+## 3. The Single-Blog Cascade
+
+**Symptom.** A blog post made an interesting claim; the research output
+cited it as fact; downstream the spec writer baked it into requirements;
+the implementation fails because the claim was wrong.
+
+**Detection cue.** A finding sourced to a single blog post or Medium
+article is labeled `verified` or `documented` in the output.
+
+**Remediation.** Blog posts are at most `reported` rung-3 evidence.
+Promote to `documented` only after corroborating with the canonical
+source (official docs, source code, or RFC). If no canonical source
+exists, label `anecdotal` and put it under `## Hypotheses`.
+
+## 4. The Boil-the-Ocean
+
+**Symptom.** The research task is "investigate JavaScript build tools".
+The agent spends 90 minutes producing a 50-page survey of every tool from
+Browserify to Bun, exhausts its token budget, and never answers the
+question the orchestrator actually had.
+
+**Detection cue.** Output exceeds 30 KB without a `## Recommendations`
+section in the first 20% of the file.
+
+**Remediation.** Before opening any source, restate the question in one
+sentence and pick the success criterion. "Boil the ocean" tasks SHOULD be
+split into multiple narrower research tasks via the orchestrator — return
+a `needs_followup` list rather than producing one giant document.
+
+## 5. The Confirmation Loop
+
+**Symptom.** The user (or the calling task) implied a preferred answer in
+the question. The agent finds that preferred answer immediately, stops
+searching, and reports it as if it had explored alternatives.
+
+**Detection cue.** The output lists fewer than 2 alternatives even when
+the task description used comparative language ("compare", "evaluate",
+"options"). All findings support a single direction.
+
+**Remediation.** For comparative tasks, mandate one paragraph per
+alternative with stated pros and cons, even if the agent expects to
+recommend one. The reader needs to see the tradeoff space.
+
+## 6. The Ungrounded Recommendation
+
+**Symptom.** The recommendations section contains imperative statements
+("use library X", "adopt pattern Y") that are not tied to any specific
+finding above.
+
+**Detection cue.** Recommendations cannot be traced back to a numbered
+finding or cited source.
+
+**Remediation.** Each recommendation MUST reference at least one finding
+by name or section heading. Use this format:
+
+```markdown
+1. Adopt `defineRelations` for the new schema work.
+   - Based on finding: "Drizzle v1 deprecates `relations()` in favor of
+     `defineRelations` (verified, 0.95)"
+   - Tradeoff: minor migration cost; offset by ergonomics + future-proof.
+```
+
+## 7. The Forgotten Codebase
+
+**Symptom.** Research output cites web sources extensively but never
+references the existing codebase, ADRs, or BRAIN memory. The
+recommendation contradicts a decision already recorded in ADR-XXX.
+
+**Detection cue.** No `.cleo/adrs/`, `packages/`, or `cleo memory find`
+references in the citations.
+
+**Remediation.** ALWAYS run a codebase + BRAIN sweep before opening the
+web. Even when the topic is "external", the project has likely already
+made related decisions that constrain the answer space. ADRs are
+canonical — overriding them requires explicit consensus, not silent
+research recommendation.
+
+## 8. The Manifest Stuffer
+
+**Symptom.** The pipeline_manifest entry's `key_findings` array contains
+20+ items, half of which are minor or duplicative. The orchestrator's
+briefing surface chokes on the noise.
+
+**Detection cue.** `key_findings` length > 7 or contains items shorter
+than 8 words.
+
+**Remediation.** `key_findings` is for the orchestrator's roll-up — 3-7
+sentence-length, action-oriented items only. Detail belongs in the
+output file. If a finding cannot be summarized in one sentence, it is
+two findings.
+
+## 9. The Premature Completion
+
+**Symptom.** Task is marked complete; the output file says "research
+complete" but the recommendations are vague ("further investigation
+needed", "more work required") with no specific followup IDs.
+
+**Detection cue.** Manifest status is `complete` but the file contains
+phrases like "TBD", "future work", or "to be determined".
+
+**Remediation.** If research cannot reach actionable recommendations,
+the manifest status MUST be `partial` or `blocked`, NOT `complete`.
+Specific gaps belong in `needs_followup` as concrete task descriptions,
+not as soft prose in the file body.
+
+## 10. The Format Drift
+
+**Symptom.** Output file does not match the template in SKILL.md.
+Sections are renamed, the manifest entry uses old field names, or the
+file location is wrong.
+
+**Detection cue.** Validator script fails or the orchestrator reports
+"could not parse manifest entry".
+
+**Remediation.** Re-read SKILL.md's "Output File Format" and "Manifest
+Entry Format" sections before writing. The downstream consumers are
+brittle by design — they trust the format and will reject anything
+unexpected.

--- a/packages/skills/skills/ct-research-agent/references/citation-and-evidence.md
+++ b/packages/skills/skills/ct-research-agent/references/citation-and-evidence.md
@@ -1,0 +1,140 @@
+# Citation and Evidence
+
+Research is only useful if it is verifiable. This reference defines the
+evidence ladder, citation format, and confidence labels that every research
+finding in CLEO MUST carry. The downstream consumers — `ct-spec-writer`,
+`ct-consensus-voter`, the orchestrator's HITL gates — rely on these signals
+to weight findings correctly.
+
+## Evidence Ladder
+
+Findings sit on a five-rung ladder. Each finding in the output file MUST be
+marked with the strongest rung that applies.
+
+| Rung | Label | Meaning | Citable? |
+|------|-------|---------|----------|
+| 5 | `verified` | Reproduced locally or confirmed in two independent canonical sources | Yes |
+| 4 | `documented` | Confirmed in one canonical source (official docs, RFC, source code) | Yes |
+| 3 | `reported` | Stated in a credible community source (named blog, conference talk, well-cited GitHub issue) | Yes, with caveat |
+| 2 | `anecdotal` | Stated in an uncredentialed source (random blog, forum post) | No — needs corroboration |
+| 1 | `hypothesis` | Inferred but not verified | Never |
+
+Findings at rung 1-2 MUST live in a separate `## Hypotheses` section, never
+mixed with verified findings. The spec writer downstream will silently treat
+all findings as verified facts unless the rung labels are explicit.
+
+## Canonical Sources by Domain
+
+| Domain | Canonical source |
+|--------|------------------|
+| HTTP/REST semantics | IETF RFCs (RFC 7230-7235, RFC 9110) |
+| TLS/crypto | RFC + IANA registries + NIST publications |
+| JavaScript language | ECMAScript spec (tc39.es) + MDN |
+| TypeScript | typescript-go source or microsoft/TypeScript |
+| Node.js APIs | nodejs.org/api/* + Node source code |
+| Library X | github.com/<owner>/<repo> README + docs + release notes |
+| CLEO architecture | `.cleo/adrs/ADR-*.md` (project-internal canon) |
+| CLEO past decisions | `cleo memory find` + `.cleo/agent-outputs/` |
+| Cloud platforms (AWS/GCP/Azure) | Vendor's "what's new" page + product docs |
+
+Blog posts and Medium articles are NOT canonical — they are interpretive
+layer that may have drifted from the source.
+
+## Citation Format Standards
+
+Every citable finding includes at minimum: source identifier, retrieval
+location, and (where relevant) retrieval date.
+
+### Web Source
+
+```markdown
+According to the [Next.js 15 caching docs](https://nextjs.org/docs/app/building-your-application/caching),
+the default fetch cache behavior changed from `force-cache` to `no-store`.
+Retrieved 2026-05-19.
+```
+
+### Official Repository
+
+```markdown
+The `defineRelations` API was introduced in
+[drizzle-team/drizzle-orm@e2b9c1a](https://github.com/drizzle-team/drizzle-orm/commit/e2b9c1a)
+and replaces the legacy `relations()` helper.
+```
+
+### Project-Internal (ADR)
+
+```markdown
+ADR-065 §3 establishes the PR-gated release pipeline — direct pushes to
+`main` are prohibited (`.cleo/adrs/ADR-065-release-pipeline.md`).
+```
+
+### Project-Internal (Code)
+
+```markdown
+The current implementation in `packages/core/src/store/openCleoDb.ts:42-78`
+routes all DB opens through a single chokepoint per Decision D003.
+```
+
+### Project-Internal (BRAIN)
+
+```markdown
+BRAIN observation `O-mpd07uma-0` records that pub1-diagnoser correctly
+refused under broken dispatcher — confirming the protocol-correct refusal
+pattern is exercising at agent-level.
+```
+
+### Context7 Fetch
+
+```markdown
+Context7 query `/vercel/next.js/v15` against the question "how do I set
+revalidation interval" returns the `revalidate` segment-config option as
+the canonical mechanism.
+```
+
+## Conflict Handling
+
+When two canonical sources disagree, the research output MUST surface the
+conflict rather than silently picking one. Recommended pattern:
+
+```markdown
+### Finding: Default cache behavior in Next.js 15
+
+- The [official caching docs](https://nextjs.org/docs/app/.../caching)
+  state the default is `no-store`.
+- The [release notes for 15.0](https://nextjs.org/blog/next-15) describe
+  the change but also mention a `staleTimes` config that softens it.
+- Resolution: the default IS `no-store`, but `staleTimes` can restore
+  per-segment caching when explicitly configured.
+```
+
+Conflict surfaces are the most valuable research output — they prevent
+downstream consumers from making decisions on partial information.
+
+## Confidence Labels
+
+In addition to the evidence rung, each `key_findings` entry in the manifest
+SHOULD carry a confidence band when the rung is below 4. The orchestrator
+uses this for HITL gating in `ct-consensus-voter`.
+
+| Confidence | Meaning |
+|------------|---------|
+| 0.9–1.0 | Verified — multiple canonical sources agree |
+| 0.7–0.9 | High — one canonical source, no conflicts |
+| 0.5–0.7 | Medium — community sources agree, no canonical |
+| 0.3–0.5 | Low — single source or conflicting evidence |
+| 0.0–0.3 | Speculation — hypothesis only, not citable |
+
+The manifest entry MUST reflect these in `key_findings`:
+
+```json
+{
+  "key_findings": [
+    "Next.js 15 default cache is no-store (verified, 0.95)",
+    "staleTimes config can restore caching (documented, 0.85)",
+    "Migration path for existing apps requires per-route audit (reported, 0.6)"
+  ]
+}
+```
+
+Downstream skills filter by confidence — `ct-spec-writer` ignores findings
+below 0.5 unless the user explicitly opts in.

--- a/packages/skills/skills/ct-research-agent/references/source-strategy.md
+++ b/packages/skills/skills/ct-research-agent/references/source-strategy.md
@@ -1,0 +1,116 @@
+# Source Strategy
+
+How to pick sources, what order to query them in, and how to bound the search
+so that the research task completes within its token budget. The skill has
+three primary source channels — web, Context7, and the local codebase — and
+each carries different reliability and currency trade-offs.
+
+## Source Hierarchy
+
+| Tier | Source | Strength | Weakness |
+|------|--------|----------|----------|
+| 1 | Local codebase | Ground truth for the project | Reflects past decisions, not future ones |
+| 2 | Context7 (`ctx7 docs`) | Current official library docs | Limited to libraries published to Context7 |
+| 3 | Web search | Breadth, recency, community wisdom | Variable signal-to-noise |
+| 4 | LLM general knowledge | Conceptual framing | Stale, hallucination-prone |
+
+Always query top-down. Codebase first — the answer may already exist as
+prior art. Context7 second when a specific library or framework is named.
+Web third when the question is open-ended. LLM general knowledge SHOULD be
+used only to frame the question, never as a citable source.
+
+## Codebase Search Patterns
+
+The skill operates in a worktree; the entire repository is reachable via
+`Grep`, `Glob`, and `Read`. Use these patterns to find prior art quickly.
+
+```bash
+# Find existing ADRs on the topic
+Grep: pattern="<keyword>" path=".cleo/adrs/" output_mode="files_with_matches"
+
+# Find prior research notes
+Grep: pattern="<keyword>" path=".cleo/agent-outputs/" output_mode="files_with_matches"
+
+# Find BRAIN decisions/patterns/observations on the topic
+cleo memory find "<keyword>"
+
+# Find related tasks
+cleo find "<keyword>"
+```
+
+When the topic touches code symbols, also use the GitNexus tools — they
+return execution flows, callers, and impact rings that grep cannot surface.
+
+```bash
+gitnexus_query({query: "<concept>"})        # process-grouped flows
+gitnexus_context({name: "<symbol>"})        # 360 view of a symbol
+gitnexus_impact({target: "<symbol>"})       # blast radius
+```
+
+## Context7 (ctx7) Workflow
+
+For any question that names a library, framework, SDK, or CLI tool, use the
+`ctx7` CLI before the open web. The workflow is two-step.
+
+```bash
+# Step 1 — resolve the library ID
+npx ctx7@latest library "<library-name>" "<user-question>"
+
+# Step 2 — fetch docs for the resolved ID
+npx ctx7@latest docs <libraryId> "<user-question>"
+
+# Optional — retry with sandboxed agents pulling source + web
+npx ctx7@latest docs <libraryId> "<user-question>" --research
+```
+
+The official library name is required — pass `"Next.js"` not `"nextjs"`.
+Version-specific docs use the `/org/project/version` form (e.g.
+`/vercel/next.js/v14.3.0`). Pass the user's full question as the query —
+specific queries return better matches than single words.
+
+## Web Search Tactics
+
+Web search is the most variable channel. Apply these filters to keep the
+signal high.
+
+- Prefer the canonical source (official docs, GitHub README, RFC) over
+  blog posts, Medium, StackOverflow.
+- Prefer recent results — append `2026`, `2025`, or the current year when
+  the topic is moving fast (LLM APIs, build tools, framework migrations).
+- Cross-check at least two sources before stating a fact. A single blog
+  post is a lead, not a finding.
+- Avoid AI-generated content farms — sites that publish hundreds of
+  thin "guides" daily are not citable.
+- Strip tracking parameters from URLs when citing — they break and they
+  leak provenance.
+
+## Time-Boxing
+
+Research is unbounded by nature; the skill MUST self-limit. Use this
+schedule when the task does not specify otherwise.
+
+| Topic complexity | Time budget | Sources to query |
+|------------------|-------------|------------------|
+| Single library/API question | 5 min | Context7 only |
+| "What is the current best practice for X" | 15 min | Web + Context7 |
+| "Compare options A, B, C for use-case Y" | 30 min | Web + Context7 + codebase |
+| "Audit current implementation against state of the art" | 60 min | All sources |
+
+When the budget is exhausted, write up what was found with `status: partial`
+and list remaining questions in `needs_followup`. Partial research is more
+useful than abandoned research.
+
+## Citation Format
+
+Every finding MUST carry a source. Acceptable formats:
+
+```markdown
+- According to [the Next.js routing docs](https://nextjs.org/docs/app), ...
+- Context7 (`/vercel/next.js/v15`) confirms that ...
+- See `.cleo/adrs/ADR-065-release-pipeline.md` §3 for prior decision on ...
+- The current implementation at `packages/cleo/src/commands/release.ts:42` ...
+- BRAIN observation `O-mpd07uma-0` records the pub1-diagnoser refusal pattern.
+```
+
+Unsourced claims SHOULD be flagged with `[unsourced]` or moved to a
+`Hypotheses` section. The reader must always be able to verify.

--- a/packages/skills/skills/ct-research-agent/references/triggers-and-routing.md
+++ b/packages/skills/skills/ct-research-agent/references/triggers-and-routing.md
@@ -1,0 +1,93 @@
+# Triggers and Routing
+
+When to load `ct-research-agent`, what tasks it owns, and how it hands off
+to neighboring skills in the RCASD-IVTR+C pipeline. The skill operates as the
+`research` protocol within the orchestrator's stage taxonomy and is the first
+skill invoked when an Epic enters its research lifecycle stage.
+
+## Primary Triggers
+
+Load this skill when the orchestrator (or the user) requests any of the
+following — the dispatch matrix in `manifest.json` enumerates the canonical
+keyword set.
+
+| Trigger phrase | Routing decision |
+|----------------|------------------|
+| "research <topic>" | Direct invocation — proceed with multi-source pull |
+| "investigate <area>" | Same as research; emphasize codebase + web blend |
+| "explore options for <decision>" | Treat as research → ct-consensus-voter |
+| "what does the literature say about X" | Web + Context7 lookup, no codebase |
+| "audit current <subsystem> implementation" | Codebase-only research; skip web |
+| "compare libraries for <use-case>" | Web + Context7 with `--research` flag |
+| "due-diligence on <vendor/tool>" | Web + reputation + license scan |
+
+The orchestrator's `cleo orchestrate spawn` prompt always carries a
+`stage: research` hint when the task's `pipelineStage` field equals
+`research`. The skill SHOULD honor that hint and SHOULD NOT advance the
+pipeline stage on its own — that is the orchestrator's responsibility once
+the research manifest entry is appended.
+
+## Anti-Triggers (Do NOT Load)
+
+The skill MUST NOT be loaded for the following requests because they belong
+to sibling skills that have narrower context budgets and stricter contracts.
+
+| Request | Correct skill |
+|---------|---------------|
+| "fix this failing test" | `ct-task-executor` |
+| "write the spec for X" | `ct-spec-writer` |
+| "validate this implementation against the spec" | `ct-validator` |
+| "decompose this epic into tasks" | `ct-epic-architect` |
+| "look up Next.js 15 middleware API" | `ct-docs-lookup` (single-library fetch) |
+| "decide between A and B" (no investigation needed) | `ct-consensus-voter` |
+| "explain this function" | (no skill — direct read suffices) |
+
+A useful heuristic: if the user already knows the answer and just wants it
+written down, route to `ct-spec-writer` or `ct-docs-write`. Research is for
+when the answer is not yet known.
+
+## Routing to Downstream Skills
+
+Research outputs typically feed one of these next stages. The manifest
+`chains_to` array enumerates the legal handoffs.
+
+1. **`ct-spec-writer`** — when findings produce testable requirements.
+   Pass the research file path and the synthesized recommendations as
+   spec input. Use this when the task description contains "spec",
+   "contract", "RFC", or "protocol".
+2. **`ct-epic-architect`** — when findings change the scope estimate of
+   an Epic. The architect re-decomposes based on the new evidence.
+3. **`ct-consensus-voter`** — when research surfaces two-or-more viable
+   options with comparable trade-offs. The voter resolves the choice
+   under HITL when confidence < 0.5.
+4. **`ct-task-executor`** — only when the research itself contains an
+   actionable next step that does not require a spec (e.g. "bump the
+   library version" or "delete deprecated path"). Rare.
+
+## Decision Tree
+
+```
+Is the answer already known and just needs documentation?
+├── YES → ct-docs-write
+└── NO → continue
+    │
+    Is this a single-library API question?
+    ├── YES → ct-docs-lookup
+    └── NO → ct-research-agent (this skill)
+        │
+        After research, do findings produce requirements?
+        ├── YES → ct-spec-writer next
+        └── NO → continue
+            │
+            Do findings produce a decision between options?
+            ├── YES → ct-consensus-voter next
+            └── NO → return manifest only, no chain
+```
+
+## Stage Hint Compliance
+
+The orchestrator's `pipeline_manifest` table tracks per-task stage
+progression. The research skill MUST append exactly one entry with
+`agent_type: "research"` and MUST NOT mutate stage fields directly. If
+findings indicate a stage advance is warranted, the skill SHOULD include
+that suggestion in `needs_followup` so the orchestrator can act on it.

--- a/packages/skills/skills/ct-skill-validator/SKILL.md
+++ b/packages/skills/skills/ct-skill-validator/SKILL.md
@@ -36,7 +36,26 @@ python ${CLAUDE_SKILL_DIR}/scripts/audit_body.py <skill-dir>
 
 # Manifest alignment check:
 python ${CLAUDE_SKILL_DIR}/scripts/check_manifest.py <skill-dir> <manifest.json>
+
+# Progressive-disclosure depth check (T9684 — CI gate):
+python ${CLAUDE_SKILL_DIR}/scripts/check_depth.py <skill-dir>
+
+# Repo-wide depth sweep:
+python ${CLAUDE_SKILL_DIR}/scripts/check_depth.py <repo-root> --all
 ```
+
+**Depth rule (T9684):** A skill PASSES when ANY of:
+
+- SKILL.md body has ≥ 100 content lines, OR
+- `references/` subdir has ≥ 3 markdown files, OR
+- `manifest.json` `references[]` array enumerates ≥ 3 files (all on disk)
+
+Pre-existing stubs are allowlisted with follow-up task IDs in
+`scripts/check_depth.py::ALLOWLIST`. Gold-standard skills:
+`ct-orchestrator` (9 refs) and `ct-skill-creator` (7 refs).
+
+The depth check runs on every PR touching `packages/skills/skills/**`
+via `.github/workflows/skills-depth-check.yml`.
 
 **Iteration rule**: If errors > 0, fix them in the skill's SKILL.md, re-run `validate.py`.
 Repeat until errors = 0. Do not proceed to Phase 2 while errors remain.

--- a/packages/skills/skills/ct-skill-validator/scripts/check_depth.py
+++ b/packages/skills/skills/ct-skill-validator/scripts/check_depth.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+CLEO Skill Depth Check — progressive-disclosure-depth rule (T9684).
+
+Fails when a skill's SKILL.md is below the depth threshold AND it has
+no references/ subdir with at least the manifest-declared reference
+files. The gold standard is ct-orchestrator (9 references) and
+ct-skill-creator (7 references); the rule is calibrated to flag
+stubs without forcing every skill to that depth.
+
+Rule logic:
+  PASS when ANY of:
+    - SKILL.md body has >= MIN_BODY_LINES content lines
+    - references/ subdir exists with >= MIN_REF_FILES files
+    - manifest.json references[] array populated with file paths that
+      all exist on disk
+
+  FAIL when:
+    - SKILL.md body < MIN_BODY_LINES lines AND
+    - references/ missing or has < MIN_REF_FILES files AND
+    - manifest.json references[] empty or files missing
+
+Error message points at the gold standard and lists expected files
+from the manifest entry (when present) so the fix is obvious.
+
+Usage:
+    check_depth.py <skill-directory>
+    check_depth.py <skill-directory> --manifest path/to/manifest.json
+    check_depth.py <skill-directory> --all                  # walk all skills under a root
+    check_depth.py <skill-directory> --json
+"""
+import sys
+import re
+import json
+import argparse
+from pathlib import Path
+
+
+# Calibration knobs — set against the post-T9567 state.
+# Adjust here, then re-run the audit to verify all 19 active skills pass.
+MIN_BODY_LINES = 100
+MIN_REF_FILES = 3
+GOLD_STANDARDS = ("ct-orchestrator", "ct-skill-creator")
+
+# Allowlist — pre-existing stub skills exempted at T9567 (E-SKILLS-DEPTH-BACKFILL).
+# Each entry MUST have a follow-up task ID. Remove the entry once that task lands
+# a depth backfill. New entries require owner approval — do not add silently.
+ALLOWLIST: dict[str, str] = {
+    "ct-codebase-mapper": "T9567-followup: pre-existing; depth-backfill deferred",
+    "ct-master-tac": "T9567-followup: pre-existing; depth-backfill deferred",
+    "ct-memory": "T9567-followup: pre-existing; depth-backfill deferred",
+    "ct-stickynote": "T9567-followup: ephemeral note skill; minimal-by-design",
+}
+
+
+def count_body_lines(skill_md_path: Path) -> int:
+    """Count content lines in the SKILL.md body (excluding frontmatter)."""
+    if not skill_md_path.exists():
+        return 0
+    raw = skill_md_path.read_text(encoding="utf-8")
+    if not raw.startswith("---"):
+        # No frontmatter — count whole file
+        return len(raw.split("\n"))
+    parts = raw.split("---", 2)
+    if len(parts) < 3:
+        return 0
+    body = parts[2].strip()
+    if not body:
+        return 0
+    return len(body.split("\n"))
+
+
+def manifest_references_for(skill_name: str, manifest_path: Path) -> list[str]:
+    """Return the references array from manifest.json for the given skill,
+    or empty list if not present."""
+    if not manifest_path.exists():
+        return []
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return []
+    for entry in data.get("skills", []):
+        if entry.get("name") == skill_name:
+            return entry.get("references", []) or []
+    return []
+
+
+def repo_root_of(skill_dir: Path) -> Path:
+    """Walk up from skill_dir to the repo root (heuristic: contains
+    `packages/skills/skills/manifest.json`)."""
+    cur = skill_dir.resolve()
+    for _ in range(10):
+        if (cur / "packages" / "skills" / "skills" / "manifest.json").exists():
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    return skill_dir  # fallback
+
+
+def check_depth(skill_path: Path, manifest_path: Path | None = None) -> tuple[bool, dict]:
+    """Run the depth check on a single skill directory.
+
+    Returns (passed, report_dict).
+    """
+    skill_dir = Path(skill_path).resolve()
+    skill_name = skill_dir.name
+    skill_md = skill_dir / "SKILL.md"
+    refs_dir = skill_dir / "references"
+
+    report: dict = {
+        "skill_name": skill_name,
+        "path": str(skill_dir),
+        "body_lines": 0,
+        "ref_files_on_disk": 0,
+        "manifest_references": [],
+        "manifest_references_missing": [],
+        "thresholds": {
+            "min_body_lines": MIN_BODY_LINES,
+            "min_ref_files": MIN_REF_FILES,
+        },
+        "passed": False,
+        "reasons": [],
+        "remediation": [],
+    }
+
+    # Threshold A: body length
+    body_lines = count_body_lines(skill_md)
+    report["body_lines"] = body_lines
+    body_passes = body_lines >= MIN_BODY_LINES
+
+    # Threshold B: references/ subdir
+    ref_files_on_disk = 0
+    if refs_dir.is_dir():
+        ref_files_on_disk = len([p for p in refs_dir.iterdir() if p.is_file() and p.suffix == ".md"])
+    report["ref_files_on_disk"] = ref_files_on_disk
+    refs_dir_passes = ref_files_on_disk >= MIN_REF_FILES
+
+    # Threshold C: manifest.json references populated and on disk
+    manifest_passes = False
+    if manifest_path is None:
+        # Auto-locate from repo root
+        root = repo_root_of(skill_dir)
+        manifest_path = root / "packages" / "skills" / "skills" / "manifest.json"
+
+    if manifest_path.exists():
+        manifest_refs = manifest_references_for(skill_name, manifest_path)
+        report["manifest_references"] = manifest_refs
+        if manifest_refs:
+            root = repo_root_of(skill_dir)
+            base = root / "packages" / "skills"
+            missing = []
+            for rel in manifest_refs:
+                ref_abs = base / rel
+                if not ref_abs.exists():
+                    # Try relative to skill_dir as fallback
+                    fallback = skill_dir / Path(rel).relative_to(Path(rel).parts[0]) \
+                        if Path(rel).parts else None
+                    if fallback is None or not fallback.exists():
+                        missing.append(rel)
+            report["manifest_references_missing"] = missing
+            manifest_passes = (len(manifest_refs) >= MIN_REF_FILES and not missing)
+
+    # Decide pass/fail — ANY threshold passes ⇒ depth check passes.
+    passed = body_passes or refs_dir_passes or manifest_passes
+    report["passed"] = passed
+
+    if body_passes:
+        report["reasons"].append(f"body_lines={body_lines} >= {MIN_BODY_LINES}")
+    if refs_dir_passes:
+        report["reasons"].append(f"references/ has {ref_files_on_disk} files >= {MIN_REF_FILES}")
+    if manifest_passes:
+        report["reasons"].append(
+            f"manifest references[] populated with {len(report['manifest_references'])} files (all on disk)"
+        )
+
+    # Allowlist override — exempted skills pass with a reason captured.
+    if not passed and skill_name in ALLOWLIST:
+        passed = True
+        report["passed"] = True
+        report["allowlisted"] = True
+        report["allowlist_reason"] = ALLOWLIST[skill_name]
+        report["reasons"].append(f"allowlisted: {ALLOWLIST[skill_name]}")
+
+    if not passed:
+        report["reasons"].append("none of the three thresholds met")
+        report["remediation"] = [
+            f"Expand SKILL.md body to >= {MIN_BODY_LINES} content lines (currently {body_lines}), OR",
+            f"Add references/ subdir with >= {MIN_REF_FILES} markdown files (currently {ref_files_on_disk}), OR",
+            "Populate manifest.json references[] array for this skill with file paths.",
+            f"Gold-standard examples: {', '.join(GOLD_STANDARDS)}.",
+        ]
+        if report["manifest_references_missing"]:
+            report["remediation"].append(
+                "Manifest references[] lists files that do not exist on disk: "
+                + ", ".join(report["manifest_references_missing"])
+            )
+
+    return passed, report
+
+
+def _print_report(report: dict) -> None:
+    """Print a single skill's depth report."""
+    name = report["skill_name"]
+    status = "PASS" if report["passed"] else "FAIL"
+    icon = "✅" if report["passed"] else "❌"
+    print(f"\n{icon} {status}  {name}")
+    print(f"     body_lines={report['body_lines']} (min {MIN_BODY_LINES})")
+    print(f"     ref_files_on_disk={report['ref_files_on_disk']} (min {MIN_REF_FILES})")
+    print(f"     manifest_references={len(report['manifest_references'])} files")
+    if report["manifest_references_missing"]:
+        print(f"     manifest_references_missing={report['manifest_references_missing']}")
+    for r in report["reasons"]:
+        print(f"     - {r}")
+    if not report["passed"]:
+        print("     remediation:")
+        for r in report["remediation"]:
+            print(f"       * {r}")
+
+
+def walk_all_skills(root: Path) -> list[Path]:
+    """Find all skill directories under packages/skills/skills/.
+    Skips manifest.json, _shared/, and any dir without SKILL.md."""
+    base = root if (root / "SKILL.md").exists() else (root / "packages" / "skills" / "skills")
+    if not base.is_dir():
+        return []
+    skills = []
+    for entry in sorted(base.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith("_") or entry.name.startswith("."):
+            continue
+        if (entry / "SKILL.md").exists():
+            skills.append(entry)
+    return skills
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="CLEO Skill Depth Check (T9684) — progressive-disclosure-depth"
+    )
+    parser.add_argument("skill_dir", help="Path to the skill directory (or repo root if --all)")
+    parser.add_argument("--manifest", help="Path to manifest.json (auto-located if omitted)")
+    parser.add_argument(
+        "--all", action="store_true",
+        help="Walk every skill under packages/skills/skills/",
+    )
+    parser.add_argument("--json", action="store_true", help="Output JSON instead of text")
+    args = parser.parse_args()
+
+    arg_path = Path(args.skill_dir).resolve()
+    manifest = Path(args.manifest).resolve() if args.manifest else None
+
+    if args.all:
+        skills = walk_all_skills(arg_path)
+        if not skills:
+            print(f"Error: no skill directories found under {arg_path}", file=sys.stderr)
+            return 1
+        all_reports = []
+        total_fail = 0
+        for s in skills:
+            passed, report = check_depth(s, manifest)
+            all_reports.append(report)
+            if not passed:
+                total_fail += 1
+        if args.json:
+            print(json.dumps({
+                "summary": {
+                    "total": len(all_reports),
+                    "passed": len(all_reports) - total_fail,
+                    "failed": total_fail,
+                    "thresholds": {
+                        "min_body_lines": MIN_BODY_LINES,
+                        "min_ref_files": MIN_REF_FILES,
+                    },
+                },
+                "skills": all_reports,
+            }, indent=2))
+        else:
+            print(f"=== CLEO Skill Depth Check (all skills under {arg_path}) ===")
+            for r in all_reports:
+                _print_report(r)
+            print(f"\n=== SUMMARY ===")
+            print(f"Total skills: {len(all_reports)}")
+            print(f"Passed: {len(all_reports) - total_fail}")
+            print(f"Failed: {total_fail}")
+        return 1 if total_fail > 0 else 0
+
+    # Single-skill mode
+    if not arg_path.is_dir():
+        print(f"Error: '{args.skill_dir}' is not a directory", file=sys.stderr)
+        return 1
+    if not (arg_path / "SKILL.md").exists():
+        print(f"Error: '{args.skill_dir}' has no SKILL.md", file=sys.stderr)
+        return 1
+
+    passed, report = check_depth(arg_path, manifest)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_report(report)
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/skills/skills/ct-spec-writer/SKILL.md
+++ b/packages/skills/skills/ct-spec-writer/SKILL.md
@@ -202,3 +202,12 @@ This skill binds to the **specification** LOOM lifecycle stage. Governing ADRs:
 - [ADR-023 — protocol validation dispatch](../../../../.cleo/adrs/ADR-023-protocol-validation-dispatch.md) — defines how specifications are validated before decomposition.
 
 LOOM coverage matrix: [docs/skills/loom-coverage-matrix.md](../../../../docs/skills/loom-coverage-matrix.md).
+
+## See references/
+
+Progressive disclosure — load on demand only:
+
+- `references/rfc2119-language.md` — keyword semantics, positive/negative examples, decision rubric
+- `references/spec-templates.md` — protocol, API, architecture, requirements scaffolds + naming + versioning
+- `references/traceability-matrix.md` — three-way trace from source to REQ to test, drift detection
+- `references/anti-patterns.md` — ten failure modes seen in past spec drafts

--- a/packages/skills/skills/ct-spec-writer/references/anti-patterns.md
+++ b/packages/skills/skills/ct-spec-writer/references/anti-patterns.md
@@ -1,0 +1,176 @@
+# Anti-Patterns
+
+Common failure modes when writing CLEO specs. Each pattern degrades the
+spec from a testable contract into prose. Detection cues and remediations
+are listed; many of these were caught in past `ct-validator` reports and
+in council reviews on previously-shipped specs.
+
+## 1. The Ambiguous MUST
+
+**Symptom.** A requirement uses MUST but the failure condition cannot be
+mechanically determined.
+
+**Example (bad)**
+
+> **REQ-005**: The system MUST handle errors gracefully.
+
+**Detection cue.** Words like "gracefully", "appropriately", "reasonably",
+"properly", "sensibly" appear in the requirement body.
+
+**Remediation.** Replace fuzzy adverbs with measurable conditions.
+
+> **REQ-005**: The system MUST return an LAFS envelope with
+> `success: false` and `error.code` matching one of the registered
+> error codes (see `packages/contracts/src/errors.ts`) on any failure
+> reaching the command dispatcher.
+
+## 2. The Tautological Requirement
+
+**Symptom.** The requirement restates the function's name.
+
+**Example (bad)**
+
+> **REQ-003**: The `validate()` function MUST validate the input.
+
+**Detection cue.** The requirement body's main verb matches the
+subject's name without adding constraint.
+
+**Remediation.** State the contract — what defines successful validation,
+what the function returns on failure, what side effects it has.
+
+> **REQ-003**: The `validate()` function MUST return `{ ok: true }` if
+> the input matches the schema, or `{ ok: false, errors: [...] }`
+> containing one entry per violation otherwise. It MUST NOT mutate
+> the input.
+
+## 3. The Compound Requirement
+
+**Symptom.** A single REQ asserts multiple independent constraints joined
+by "and" or commas.
+
+**Example (bad)**
+
+> **REQ-009**: The release pipeline MUST run lint, MUST run tests, MUST
+> generate a changelog, AND MUST push the tag.
+
+**Detection cue.** Multiple MUST/MUST NOT/SHOULD phrases in one REQ; or
+"and" connecting verb phrases.
+
+**Remediation.** Split into atomic REQs so each can be tested
+independently and traced individually.
+
+> **REQ-009**: The release pipeline MUST run lint.
+> **REQ-010**: The release pipeline MUST run tests after lint passes.
+> **REQ-011**: The release pipeline MUST generate a changelog.
+> **REQ-012**: The release pipeline MUST push the tag only after all
+> prior REQs in this sequence have passed.
+
+## 4. The Implementation Detail Spec
+
+**Symptom.** The spec dictates HOW the implementation should work, not
+WHAT it must achieve.
+
+**Example (bad)**
+
+> **REQ-014**: The cache MUST be implemented using a Map<string, Buffer>
+> with LRU eviction.
+
+**Detection cue.** Concrete data structures, library names, or algorithm
+choices appear in MUST clauses.
+
+**Remediation.** State the observable contract; let implementations
+choose the structure.
+
+> **REQ-014**: The cache MUST support O(1) lookup by string key.
+> **REQ-015**: The cache MUST evict the least-recently-used entry when
+> capacity is exceeded.
+
+## 5. The Untestable SHOULD
+
+**Symptom.** SHOULD is used to mean "MAY" or to defer the test problem.
+
+**Example (bad)**
+
+> **REQ-017**: The orchestrator SHOULD be efficient.
+
+**Detection cue.** SHOULD without a measurable cap, threshold, or
+comparison.
+
+**Remediation.** Either make it testable, or downgrade to MAY.
+
+> **REQ-017**: The orchestrator SHOULD complete a 5-task wave dispatch
+> within 2 seconds on the reference hardware (T9396).
+> [— OR —]
+> **REQ-017**: The orchestrator MAY parallelize wave dispatch.
+
+## 6. The Forgotten Edge Case
+
+**Symptom.** The happy-path requirement is stated, but failure modes
+(timeouts, partial completion, concurrent invocation) are unspecified.
+
+**Detection cue.** No requirement mentions error codes, retries,
+timeouts, or concurrent semantics — yet the implementation will face
+all of these.
+
+**Remediation.** For every operation, add at minimum:
+
+- Timeout behavior (REQ: "after N seconds without progress, MUST return
+  E_TIMEOUT")
+- Concurrent invocation (REQ: "MUST serialize concurrent calls per
+  resource ID")
+- Partial state (REQ: "on failure mid-operation, MUST roll back to
+  pre-call state OR persist a recovery record")
+
+## 7. The Spec Without Conformance
+
+**Symptom.** The spec has 20 REQs but no `## Compliance` section.
+
+**Detection cue.** Last section heading is not `## Compliance`.
+
+**Remediation.** Add the section. Without it, `ct-validator` cannot
+produce pass/fail reports, and implementations cannot self-attest. A
+spec without a compliance criteria block is unfinished.
+
+## 8. The Stealth Decision
+
+**Symptom.** The spec contains a phrase like "we chose X over Y for
+reasons A, B, C" — but that decision was not recorded in any ADR.
+
+**Detection cue.** Spec body explains *why* a choice was made, instead
+of *what* the requirement is.
+
+**Remediation.** Pull the decision into a proper ADR. Reference the ADR
+from the REQ's source column. The spec body asserts the requirement
+flatly; the rationale lives in the ADR.
+
+## 9. The Drift-Prone Cross-Reference
+
+**Symptom.** A REQ cross-references another section by prose ("as
+discussed in the previous section") or by page number.
+
+**Detection cue.** No `REQ-NNN` token in cross-references.
+
+**Remediation.** Always reference by stable identifier — `REQ-001`,
+`CON-007`, `§3.2`, `ADR-065`. Prose references rot when sections
+reorder.
+
+## 10. The Version Hostage
+
+**Symptom.** The spec hard-codes the version of a dependency or the
+specific commit of an ADR that motivated it.
+
+**Example (bad)**
+
+> **REQ-021**: The pipeline MUST use drizzle-orm@1.0.0-beta.
+
+**Detection cue.** Pinned version in a requirement body.
+
+**Remediation.** Pin only the behavior; pin the version in the
+implementation's manifest. If a specific version is genuinely required,
+state the constraint as a range.
+
+> **REQ-021**: The pipeline MUST use a Drizzle ORM release that
+> supports `defineRelations` (introduced in v1.0.0-beta or later).
+
+This preserves the spec across patch upgrades that do not change
+contracts.

--- a/packages/skills/skills/ct-spec-writer/references/rfc2119-language.md
+++ b/packages/skills/skills/ct-spec-writer/references/rfc2119-language.md
@@ -1,0 +1,138 @@
+# RFC 2119 Language
+
+The skill MUST use RFC 2119 keywords correctly. This reference defines each
+keyword precisely, gives positive and negative examples, and lists the
+common misuses that downstream test writers and validators catch most
+often. A spec is only as testable as its language is unambiguous.
+
+## The Five Keywords
+
+| Keyword | Synonyms | Precise meaning |
+|---------|----------|-----------------|
+| **MUST** | REQUIRED, SHALL | Absolute requirement. Non-compliance is a defect. |
+| **MUST NOT** | SHALL NOT | Absolute prohibition. Non-compliance is a defect. |
+| **SHOULD** | RECOMMENDED | Recommended; non-compliance requires recorded rationale. |
+| **SHOULD NOT** | NOT RECOMMENDED | Discouraged; non-compliance requires recorded rationale. |
+| **MAY** | OPTIONAL | Truly optional; compliance and non-compliance are both fine. |
+
+These keywords are case-sensitive in their normative meaning. Use UPPERCASE
+when carrying RFC 2119 weight; lowercase ("must", "should") is prose and
+does not bind implementations.
+
+## The Mandatory Header
+
+Every CLEO specification MUST open with the IETF boilerplate, exactly:
+
+```markdown
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in RFC 2119.
+```
+
+If the boilerplate is missing, the document is a guide, not a spec.
+Downstream tooling — `ct-validator`, the IVT loop, the consensus voter —
+will not enforce normative weight on un-boilerplated documents.
+
+## Positive Examples
+
+**Absolute requirement (MUST)**
+
+> **REQ-007**: The release-ship command MUST cut the release branch from
+> the tip of `main` after passing all quality gates.
+
+This is testable: the test reads the branch's merge-base; if it is not
+the `main`-tip-at-cut-time, the test fails.
+
+**Conditional requirement (MUST + when-clause)**
+
+> **REQ-008**: When `release.branchModel` is `feat-to-main`, the
+> release pipeline MUST refuse direct pushes to `main`.
+
+This is testable: with the config set, attempt a direct push; assert
+rejection.
+
+**Recommendation (SHOULD)**
+
+> **REQ-012**: The orchestrator SHOULD batch parallel-safe tasks into
+> waves rather than serializing them.
+
+Compliant if waves exist; if serialization happens for a documented
+reason (e.g. a dependency the auto-detector missed) the implementation
+remains compliant — but the rationale MUST be recorded.
+
+**Truly optional (MAY)**
+
+> **REQ-019**: Implementations MAY cache the resolved skill manifest
+> for the duration of a single orchestration session.
+
+No conformance pressure either way. Caching and re-fetching are both
+valid implementations.
+
+## Negative Examples (Anti-Spec Language)
+
+These phrasings look normative but are not. Replace each before the spec
+ships.
+
+| Anti-pattern | Why it fails | Replacement |
+|--------------|--------------|-------------|
+| "The system needs to validate input" | "Needs to" is aspirational, not binding | "The system MUST validate input" |
+| "It is recommended that you encrypt at rest" | "It is recommended" is passive prose | "Implementations SHOULD encrypt at rest" |
+| "We will use HTTPS" | First-person future tense is a plan, not a requirement | "All transports MUST use HTTPS" |
+| "Should ideally be idempotent" | "Ideally" weakens SHOULD into nothing | "MUST be idempotent" or "SHOULD be idempotent" |
+| "Try to keep payloads under 1MB" | "Try to" is unmeasurable | "Payloads SHOULD NOT exceed 1MB" |
+| "Cannot exceed 100 requests/minute" | "Cannot" is descriptive, not normative | "MUST NOT exceed 100 requests/minute" |
+
+## When to Pick Which Keyword
+
+Use this decision rubric:
+
+1. **Will an implementation that violates this rule fail user expectations
+   or break interoperability?**
+   - Yes → MUST / MUST NOT
+   - Maybe → continue
+2. **Is there a legitimate operating environment where violating this rule
+   is the right call?**
+   - Yes → SHOULD / SHOULD NOT
+   - No → revisit step 1
+3. **Is the behavior genuinely a choice with no preferred direction?**
+   - Yes → MAY
+   - No → revisit steps 1-2
+
+If you cannot decide between MUST and SHOULD, the requirement is probably
+under-specified — sharpen the failure condition first, then re-evaluate.
+
+## Cross-Reference Patterns
+
+When one requirement depends on another, link them explicitly so the test
+matrix can build the dependency graph.
+
+```markdown
+**REQ-021**: The skill MUST emit a `pipeline_manifest` entry per
+**REQ-008** before completing the task.
+```
+
+Avoid prose-cross-references ("as mentioned above") — they cannot be
+machine-extracted. Use the `REQ-NNN` token.
+
+## Compliance Statements
+
+Every spec MUST close with a `## Compliance` section that enumerates the
+conditions under which an implementation is conformant.
+
+```markdown
+## Compliance
+
+An implementation is **conformant** if and only if:
+
+1. All MUST and MUST NOT requirements (REQ-001 through REQ-007) hold.
+2. Each SHOULD or SHOULD NOT requirement either holds OR is accompanied
+   by a recorded rationale in the implementation's `decisions` table.
+3. MAY requirements are reported in the implementation's capability
+   manifest if applicable.
+
+Non-conformant implementations SHOULD provide a remediation plan with
+target conformance date.
+```
+
+This section is what `ct-validator` reads when producing the validation
+report — without it, validation cannot proceed.

--- a/packages/skills/skills/ct-spec-writer/references/spec-templates.md
+++ b/packages/skills/skills/ct-spec-writer/references/spec-templates.md
@@ -1,0 +1,233 @@
+# Spec Templates
+
+Templates for the spec types that CLEO produces most frequently. Each
+template includes the canonical sections, required cross-references, and
+the conformance criteria block that `ct-validator` reads downstream.
+
+## Protocol Specification
+
+For inter-component or inter-process contracts. Examples: the
+`cleo-subagent` protocol, the `pipeline_manifest` schema, the LAFS
+envelope contract.
+
+```markdown
+# {Protocol Name} Specification v{X.Y.Z}
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in RFC 2119.
+
+**Status**: draft | proposed | accepted | deprecated
+**Supersedes**: (none) | {ADR-XXX} | {Spec-Name v{X.Y.Z-1}}
+**Related ADRs**: ADR-XXX, ADR-YYY
+
+---
+
+## Abstract
+
+{One paragraph: what this protocol governs and why it exists.}
+
+## Definitions
+
+| Term | Definition |
+|------|------------|
+| {term} | {precise definition; avoid synonyms} |
+
+## Roles
+
+- **{Role A}**: {responsibilities}
+- **{Role B}**: {responsibilities}
+
+## Message Types / Operations
+
+### {Operation 1}
+
+**REQ-001**: {what MUST happen}.
+- Inputs: {field list with types}
+- Outputs: {field list with types}
+- Errors: {error code enumeration}
+
+### {Operation 2}
+...
+
+## State Machine (if applicable)
+
+| State | Transitions | Triggers |
+|-------|-------------|----------|
+| init | → ready | start() |
+| ready | → running, → cancelled | run(), cancel() |
+| running | → done, → failed | (auto) |
+
+## Security Considerations
+
+{What can go wrong; threat model.}
+
+## Compliance
+
+An implementation is conformant if {enumerated conditions}.
+```
+
+## API Specification
+
+For HTTP, gRPC, or CLI-level interfaces.
+
+```markdown
+# {API Name} Specification v{X.Y.Z}
+
+{RFC 2119 boilerplate}
+
+## Overview
+
+{One paragraph.}
+
+## Endpoints / Commands
+
+### `{METHOD} /path` or `cleo {verb} {noun}`
+
+**REQ-001**: The endpoint MUST return 2xx on success, 4xx on client
+error, 5xx on server error.
+
+**Request schema**:
+```json
+{ "field": "type", "field2": "type" }
+```
+
+**Response schema (success)**:
+```json
+{ "result": "type" }
+```
+
+**Errors**:
+| Code | Meaning | When |
+|------|---------|------|
+| E_NOT_FOUND | Resource missing | {trigger} |
+| E_VALIDATION | Bad input | {trigger} |
+
+**REQ-002**: The endpoint SHOULD complete within {N}ms p95.
+
+## Authentication
+
+{Required headers, scopes, etc.}
+
+## Versioning
+
+{How breaking changes are communicated.}
+
+## Compliance
+
+{Conditions.}
+```
+
+## Architecture Document
+
+For high-level structural decisions that do not fit the ADR (single
+decision) shape but need normative weight. The ADR records the decision;
+the architecture document specifies the resulting structure.
+
+```markdown
+# {System Name} Architecture v{X.Y.Z}
+
+{RFC 2119 boilerplate}
+
+## Context
+
+{Why this system exists; what problem it solves.}
+
+## Constraints
+
+| ID | Constraint | Source |
+|----|------------|--------|
+| CON-001 | All DB opens go through openCleoDb() | ADR-D003 |
+| CON-002 | No raw new DatabaseSync() outside chokepoint | ADR-D003 |
+
+## Components
+
+### {Component A}
+- **Responsibility**: {one sentence}
+- **Inputs**: {what it consumes}
+- **Outputs**: {what it produces}
+- **Constraints**: CON-XXX, CON-YYY
+
+### {Component B}
+...
+
+## Dependencies
+
+```mermaid
+graph LR
+  A[Component A] --> B[Component B]
+  B --> C[Component C]
+```
+
+## Cross-cutting Concerns
+
+- **Observability**: {logging, metrics, tracing requirements}
+- **Security**: {authn, authz, secrets handling}
+- **Resilience**: {failure modes, recovery}
+
+## Compliance
+
+{Conditions.}
+```
+
+## Requirements Document (small/targeted)
+
+For a single feature where a full protocol spec is overkill but a
+testable contract is needed.
+
+```markdown
+# {Feature Name} Requirements v{X.Y.Z}
+
+{RFC 2119 boilerplate}
+
+## Scope
+
+{What's in; what's out.}
+
+## Requirements
+
+**REQ-001**: {requirement}
+- Rationale: {why}
+- Verification: {how to test}
+
+**REQ-002**: {requirement}
+- Rationale: {why}
+- Verification: {how to test}
+
+## Constraints
+
+{CON-XXX list if relevant.}
+
+## Open Questions
+
+{Anything not yet resolved — these block acceptance.}
+
+## Compliance
+
+{Conditions.}
+```
+
+## Naming Conventions
+
+| Type | Filename pattern | Location |
+|------|------------------|----------|
+| Protocol spec | `<name>-protocol-v<x>.md` | `docs/specs/protocols/` |
+| API spec | `<name>-api-v<x>.md` | `docs/specs/apis/` |
+| Architecture | `<name>-architecture-v<x>.md` | `docs/architecture/` |
+| Requirements | `<name>-requirements.md` | `docs/specs/requirements/` |
+| ADR | `ADR-NNN-<short-slug>.md` | `.cleo/adrs/` |
+
+When in doubt: protocol vs requirements — a protocol governs a contract
+between two parties; requirements govern behavior of a single party.
+
+## Versioning Rules
+
+| Bump | Trigger |
+|------|---------|
+| Patch (`X.Y.Z+1`) | Clarification, typo fix, no semantic change |
+| Minor (`X.Y+1.0`) | Added requirement (additive) |
+| Major (`X+1.0.0`) | Changed or removed requirement (breaking) |
+
+A major bump REQUIRES a corresponding deprecation period for the prior
+major version. State the period in `## Status` (e.g., "v2.x deprecated
+2026-Q3, removed 2026-Q4").

--- a/packages/skills/skills/ct-spec-writer/references/traceability-matrix.md
+++ b/packages/skills/skills/ct-spec-writer/references/traceability-matrix.md
@@ -1,0 +1,145 @@
+# Traceability Matrix
+
+Every REQ in a CLEO spec MUST be traceable to (a) the source justifying
+its existence and (b) the test that verifies its implementation. The
+traceability matrix is the table that makes those links explicit and
+machine-readable. Without it, specs decay — requirements survive
+implementations they no longer reflect.
+
+## Three-Way Trace
+
+A complete trace links three artifacts:
+
+```
+[Source]  ── justifies ──>  [Requirement]  ── verified by ──>  [Test]
+```
+
+- **Source.** The research finding, ADR, user need, or upstream spec that
+  motivates the requirement.
+- **Requirement.** The REQ-NNN entry in this spec.
+- **Test.** The test file/case that exercises the requirement.
+
+Each link MUST be a stable identifier — not prose. "REQ-007 was discussed
+in a meeting" is not a trace; "REQ-007 derives from ADR-065 §3" is.
+
+## The Matrix Block
+
+Include this block in every spec, immediately before the `## Compliance`
+section.
+
+```markdown
+## Traceability
+
+| REQ | Source | Verification |
+|-----|--------|--------------|
+| REQ-001 | ADR-065 §3 | `packages/cleo/__tests__/release-pipeline.test.ts::cuts-from-main-tip` |
+| REQ-002 | ADR-065 §3 | `packages/cleo/__tests__/release-pipeline.test.ts::refuses-direct-push` |
+| REQ-003 | T9580 acceptance | `packages/cleo/__tests__/release-ship.test.ts::epic-completeness-check` |
+| REQ-004 | RFC 7230 §3.2 | `packages/transport/__tests__/http.test.ts::header-canonicalization` |
+| REQ-005 | (TODO: assign source) | (TODO: write test) |
+```
+
+Rows with `(TODO: ...)` are acceptable in `draft` status, NOT in
+`accepted`. A spec cannot move to `accepted` while any TODO row remains.
+
+## Source Token Conventions
+
+The source column accepts these forms:
+
+| Form | Example | When to use |
+|------|---------|-------------|
+| ADR reference | `ADR-065 §3` | Decision recorded in `.cleo/adrs/` |
+| Spec reference | `Spec-foo v1.2 REQ-007` | Inherited from upstream spec |
+| Task reference | `T9580 acceptance` | Direct from task acceptance criteria |
+| Research reference | `.cleo/agent-outputs/2026-05-19_caching.md §Findings` | From research output |
+| External standard | `RFC 7230 §3.2` | IETF / W3C / ISO standard |
+| BRAIN reference | `D003` or `O-mpd07uma-0` | Stored decision or observation |
+| User mandate | `Owner directive 2026-05-19` | Direct from user/owner |
+
+The form `(meeting notes)` or `(slack thread)` is NOT acceptable — these
+are ephemeral and not citable.
+
+## Verification Token Conventions
+
+The verification column accepts these forms:
+
+| Form | Example | Meaning |
+|------|---------|---------|
+| Test ID | `pkg/__tests__/foo.test.ts::case-name` | Unit/integration test exists |
+| Eval ID | `eval-suite-x::scenario-7` | Agent eval covers this REQ |
+| Manual procedure | `docs/qa/manual-release-checklist.md §A` | Human verification step |
+| Tool gate | `pnpm run typecheck` | Toolchain enforces this REQ |
+| Linter rule | `biome.json::rules.style.X` | Linter rule covers this REQ |
+
+A REQ that cannot be verified is not a requirement — it is a wish.
+Reject any REQ that lacks a verification plan during draft review.
+
+## Bidirectional Index
+
+Large specs (more than 30 REQs) SHOULD include a reverse index from test
+back to REQ, so a failing test can be located against its requirement
+quickly.
+
+```markdown
+## Test → REQ Reverse Index
+
+- `release-pipeline.test.ts::cuts-from-main-tip` → REQ-001
+- `release-pipeline.test.ts::refuses-direct-push` → REQ-002
+- `release-ship.test.ts::epic-completeness-check` → REQ-003
+- `http.test.ts::header-canonicalization` → REQ-004
+```
+
+Generate this manually for small specs; large specs SHOULD include a
+script at `scripts/extract-trace.ts` that produces it from the forward
+matrix.
+
+## Trace Health Metrics
+
+A healthy spec has these properties — `ct-validator` reports on them.
+
+| Metric | Healthy | Warning | Failure |
+|--------|---------|---------|---------|
+| REQs without source | 0 | 1-2 | 3+ |
+| REQs without verification | 0 | 1-2 | 3+ |
+| Tests not linked from any REQ | low | 10-25% | 25%+ |
+| External standard refs | present | (n/a) | (n/a) |
+| TODO rows in accepted spec | 0 | (cannot be) | any |
+
+## Drift Detection
+
+When the implementation evolves, the matrix drifts. Detect drift with:
+
+```bash
+# List tests that exist on disk
+find packages -name "*.test.ts" -exec grep -l "REQ-" {} \;
+
+# Compare to REQs claimed in the matrix
+grep "^| REQ-" docs/specs/*.md
+
+# Diff yields:
+# - tests referencing REQs not in any matrix (orphan tests)
+# - matrix REQs whose tests have disappeared (broken trace)
+```
+
+This SHOULD run in CI on `pull_request` touching `docs/specs/**`. The
+existing CI `skills` job (or a new `spec-trace-check` job) is the right
+home — the workflow MUST fail when broken traces appear in `accepted`
+specs.
+
+## Inheritance When Specs Refactor
+
+When Spec-A is superseded by Spec-B, copy the matrix forward and add a
+`Supersedes` column for the legacy REQ ID. This preserves test trace
+across the rename.
+
+```markdown
+| REQ (new) | Supersedes | Source | Verification |
+|-----------|------------|--------|--------------|
+| REQ-001 | Spec-A REQ-007 | ADR-065 §3 | test::cuts-from-main-tip |
+| REQ-002 | Spec-A REQ-008 | ADR-065 §3 | test::refuses-direct-push |
+| REQ-003 | (new) | T9580 | test::epic-completeness-check |
+```
+
+The legacy spec MUST mark itself `deprecated` and link forward to the
+successor. Never delete the legacy spec until all tests have been
+re-attributed.

--- a/packages/skills/skills/ct-task-executor/SKILL.md
+++ b/packages/skills/skills/ct-task-executor/SKILL.md
@@ -309,3 +309,13 @@ This skill binds to the **implementation** LOOM lifecycle stage. Governing ADRs:
 - [ADR-062 — worktree merge, not cherry-pick](../../../../.cleo/adrs/ADR-062-worktree-merge-not-cherry-pick.md) — defines the integration path that preserves the executor's commit SHAs end-to-end.
 
 LOOM coverage matrix: [docs/skills/loom-coverage-matrix.md](../../../../docs/skills/loom-coverage-matrix.md).
+
+## See references/
+
+Progressive disclosure — load on demand only:
+
+- `references/implementation-patterns.md` — read-before-write, file-placement, ESM imports, quality-gate sequence
+- `references/acceptance-criteria-mapping.md` — mapping table, AC categories, verification commands
+- `references/evidence-and-gates.md` — ADR-051 atom shape, gate ritual, tool resolution + cache
+- `references/common-failures.md` — twelve observed worker failure modes with corrected approach
+- `references/anti-patterns.md` — instant-rejection patterns from AGENTS.md

--- a/packages/skills/skills/ct-task-executor/references/acceptance-criteria-mapping.md
+++ b/packages/skills/skills/ct-task-executor/references/acceptance-criteria-mapping.md
@@ -1,0 +1,163 @@
+# Acceptance Criteria Mapping
+
+Every CLEO task ships with explicit acceptance criteria (ACs) — usually
+3-6 pipe-separated entries on the task's `acceptance` field. The executor's
+job is to map each AC to a verifiable deliverable, exercise it, and report
+the mapping in the manifest. This reference defines the mapping discipline.
+
+## Read the Whole AC Set First
+
+Before touching code, run `cleo show <TASK_ID>` and copy the full `acceptance`
+array into your scratch notes. Do not start with a partial reading — ACs
+interact, and some only make sense in light of others.
+
+Example AC set (from T9660):
+
+```text
+1. packages/skills/skills/ct-research-agent/references/ created with 4 files (...)
+2. each reference doc is >=50 lines of genuine multi-source research guidance (...)
+3. SKILL.md updated to link references via standard 'See references/' resolution pattern
+4. packages/skills/skills/manifest.json references array updated to enumerate all reference files
+5. skill body >=10K bytes per gold standard; load-time token budget verified <=8000
+6. Code placed in packages/skills/ per Package-Boundary Check - verified against AGENTS.md
+```
+
+This task has six ACs — three structural (1, 4, 6), two content-quality
+(2, 5), and one cross-link (3). The implementation must touch all of them.
+
+## Build a Mapping Table
+
+For each AC, identify the deliverable and the verification mechanism.
+Write the table to your scratch first — do not start implementing until
+every AC has a row.
+
+| AC | Deliverable | Verification |
+|----|-------------|--------------|
+| AC1 | 4 .md files under references/ | `ls` + filename match |
+| AC2 | ≥50 lines each, genuine content | `wc -l` + manual review |
+| AC3 | SKILL.md footer with "See references/" | grep for footer block |
+| AC4 | manifest.json `references` array populated | `jq` extract + length |
+| AC5 | Skill body ≥10K bytes | `wc -c packages/.../SKILL.md` |
+| AC6 | Files placed in packages/skills/ | path inspection |
+
+The verification column MUST yield a yes/no answer — not "looks good".
+If an AC cannot be reduced to a mechanical check, push back to the
+orchestrator: "AC-N is not testable; please clarify the success
+condition."
+
+## AC Categories and Standard Verifications
+
+| Category | Signal phrases | Standard verification |
+|----------|----------------|----------------------|
+| Existence | "created", "added", "exists" | `ls`, `stat`, `[ -f path ]` |
+| Count | "with N files", "≥3 entries" | `find -type f | wc -l` |
+| Length/size | "≥50 lines", "≥10K bytes" | `wc -l`, `wc -c` |
+| Linkage | "linked from", "referenced in" | `grep -F` |
+| Tests pass | "all tests pass", "no regressions" | `pnpm run test` |
+| Lint clean | "biome check passes" | `pnpm biome check .` |
+| Build clean | "compiles", "type-checks" | `pnpm run build && pnpm run typecheck` |
+| Spec match | "satisfies REQ-NNN" | manual trace + test |
+| Boundary | "placed in packages/X per Package-Boundary Check" | path inspection |
+| Provenance | "commit message includes task ID" | `git log --grep=<TID>` |
+
+When an AC mentions "Package-Boundary Check", you MUST cite the AGENTS.md
+section by name in the manifest's `key_findings` — the orchestrator
+greps for that compliance phrase.
+
+## Acceptance Criteria Anti-Patterns
+
+These shapes signal that the AC needs refinement before execution.
+
+| Anti-pattern AC | Why it fails | What to ask the orchestrator |
+|-----------------|--------------|------------------------------|
+| "Implementation works as expected" | Not testable | What is the expected behavior? |
+| "User experience improved" | Subjective | Which metric should improve and by how much? |
+| "Performance is good" | No baseline | What's the target latency / throughput? |
+| "Documentation updated" | Which docs? | Specific file paths or section names? |
+| "No regressions" | Whole-suite test or focused? | Which test files must pass? |
+
+When an AC is fuzzy, push back BEFORE starting. The orchestrator can
+refine the AC; rework caused by guessing the AC is much more expensive.
+
+## Pre-Flight: AC → Test Mapping
+
+Before writing implementation code, for each AC that mentions testable
+behavior, identify or create the test that exercises it.
+
+```bash
+# AC-7: "the new release-plan verb errors with E_VALIDATION on missing --epic"
+
+# Find existing test file
+find packages/cleo -path '*/release-plan*' -name '*.test.ts'
+
+# If no test exists yet, create the skeleton
+cat > packages/cleo/__tests__/release-plan.test.ts <<'EOF'
+import { describe, it, expect } from "vitest";
+describe("release-plan", () => {
+  it("errors with E_VALIDATION on missing --epic", () => {
+    // RED — test fails until handler exists
+  });
+});
+EOF
+```
+
+Run the test now — it should fail (the implementation is not there yet).
+This confirms your mapping: the test exercises the right AC.
+
+## During Implementation
+
+Keep the mapping table open in your scratch. After each significant edit,
+re-run the verification for the AC you just touched. Do not let mappings
+drift — if you discover an AC requires a different deliverable than you
+planned, update the table BEFORE making the change.
+
+## Post-Implementation: AC Verification Walkthrough
+
+Before calling `cleo verify` or `cleo complete`, execute every verification
+in the table.
+
+```bash
+# AC1: 4 files exist
+ls packages/skills/skills/ct-research-agent/references/ | wc -l
+# expect: 4
+
+# AC2: each ≥50 lines
+wc -l packages/skills/skills/ct-research-agent/references/*.md
+# expect: each line count >= 50
+
+# AC3: SKILL.md has footer
+grep -q "## See references/" packages/skills/skills/ct-research-agent/SKILL.md
+# expect: exit 0
+
+# AC4: manifest.json references array populated
+jq '.skills[] | select(.name=="ct-research-agent") | .references | length' \
+  packages/skills/skills/manifest.json
+# expect: 4
+
+# AC5: skill body ≥10K bytes
+wc -c packages/skills/skills/ct-research-agent/SKILL.md
+# expect: byte count >= 10000
+
+# AC6: path inspection
+echo "All files under packages/skills/ — confirms Package-Boundary Check"
+```
+
+## Manifest Reporting
+
+The pipeline_manifest entry's `key_findings` MUST report AC outcomes
+concisely. Use this shape:
+
+```json
+{
+  "key_findings": [
+    "AC1-4 met: 4 reference files created (triggers, source, citation, anti-patterns)",
+    "AC2 met: line counts 116/93/140/154 (all >=50)",
+    "AC3-4 met: SKILL.md footer added; manifest references[] populated",
+    "AC5 verified: skill body 11.2KB",
+    "AC6 verified: all files under packages/skills/ per AGENTS.md"
+  ]
+}
+```
+
+If any AC failed or was partial, surface it. Silent partial completion
+breaks the orchestrator's rollup logic.

--- a/packages/skills/skills/ct-task-executor/references/anti-patterns.md
+++ b/packages/skills/skills/ct-task-executor/references/anti-patterns.md
@@ -1,0 +1,201 @@
+# Anti-Patterns
+
+The instant-rejection list for executor work — from AGENTS.md
+"Anti-Patterns (INSTANT REJECTION)" plus session-observed additions.
+Each anti-pattern is testable by the orchestrator's reviewer; do not
+ship work that contains any of these.
+
+## 1. Test Theater
+
+**Anti-pattern.** Claiming "tests pass" without actually running
+`pnpm run test`.
+
+**Detection.** Manifest reports `testsPassed: true` but no
+`tool:test` evidence atom; or evidence atom references a stale cache
+key.
+
+**Cost.** Reviewer must reject and re-spawn the work, doubling the
+token spend on the task.
+
+**Correct pattern.** Always run tests, capture the exit code, and pass
+`--evidence "tool:test"` to `cleo verify`. The cache will skip re-running
+if state is unchanged; running it is free.
+
+## 2. Workaround Over Root Cause
+
+**Anti-pattern.** Adding `// @ts-ignore`, `eslint-disable-next-line`, or
+`as unknown as X` chains to suppress an error rather than fixing it.
+
+**Detection.** Suppression comments or escape-hatch casts in the diff.
+
+**Cost.** Technical debt accumulates; the actual contract violation
+remains; the next worker encounters the same problem.
+
+**Correct pattern.** Diagnose the type/lint failure; update the
+contract in `packages/contracts/` or fix the source. Suppression is
+permitted only with an inline TODO referencing a follow-up task ID,
+e.g., `// @ts-ignore — TODO(T9999): legacy adapter pending refactor`.
+
+## 3. Skipped Lint/Format
+
+**Anti-pattern.** Committing without `pnpm biome check --write .`,
+producing a diff with unrelated whitespace or import-order churn that
+biome would normalize.
+
+**Detection.** Reviewer's `pnpm biome check .` (in CI) reports
+violations on lines the worker did not intentionally touch.
+
+**Cost.** Biome's auto-fix produces large drive-by diffs in the next
+PR; review noise drowns the actual change.
+
+**Correct pattern.** Run `pnpm biome check --write .` BEFORE every
+commit. Make biome's output part of the commit, not a follow-up cleanup.
+
+## 4. New File Where Existing Suffices
+
+**Anti-pattern.** Creating a new helper file when the existing utility
+module could be extended.
+
+**Detection.** Diff contains a new file in `src/` that exports a single
+function which logically belongs alongside existing functions in a
+sibling file.
+
+**Cost.** Code duplication; future maintainers do not find the helper
+because the search lands on the older file.
+
+**Correct pattern.** Before creating any new file, run
+`Grep "<related-keyword>" packages/<pkg>/src/` and add to the most
+related existing module. NEVER create files unless they are absolutely
+necessary.
+
+## 5. `catch (err: unknown)`
+
+**Anti-pattern.** Wrapping a function body in `try { ... } catch (err:
+unknown) { ... }` and then casting `err` to read its `.message`.
+
+**Detection.** Grep for `catch (err: unknown)` or `catch (e: unknown)`.
+
+**Cost.** Defeats type narrowing; hides real error types; AGENTS.md
+explicitly bans this.
+
+**Correct pattern.** Use the contract's typed error classes from
+`packages/contracts/src/errors.ts`. Throw and catch by class, not by
+the generic `Error` shape.
+
+```typescript
+import { TaskNotFoundError, ValidationError } from "@cleocode/contracts";
+try {
+  ...
+} catch (err) {
+  if (err instanceof TaskNotFoundError) { ... }
+  if (err instanceof ValidationError) { ... }
+  throw err; // re-throw unknown
+}
+```
+
+## 6. console.log in Production Code
+
+**Anti-pattern.** Leftover `console.log("debug:", x)` after debugging.
+
+**Detection.** `pnpm biome check .` flags it; grep for `console.log`
+in `src/` (test files may legitimately log).
+
+**Cost.** Spam in user-facing CLI output; potential PII leakage.
+
+**Correct pattern.** Remove debug logs before commit. For genuine
+operational logging, use the project's logger (LAFS envelope meta
+field, or `packages/core/src/log/` if present).
+
+## 7. Import Without Boundary Check
+
+**Anti-pattern.** Adding an import that creates a circular dependency
+or crosses a package boundary the consumer does not declare.
+
+**Detection.** `pnpm run build` fails with module-resolution error, or
+the build succeeds locally but CI's clean install fails.
+
+**Cost.** CI-only failure; PR cannot land.
+
+**Correct pattern.** Before adding an import: (a) check if the source
+package is in the consumer's `package.json` dependencies; (b) if it's
+a relative import within the same package, check for cycles by reading
+the source's imports too.
+
+## 8. Test Expectation Modification
+
+**Anti-pattern.** A test fails; instead of fixing the implementation,
+the worker modifies the test's expected value to match the actual
+output.
+
+**Detection.** Diff modifies `expect(x).toBe(...)` or `toMatchSnapshot()`
+inputs in a test file without corresponding implementation changes.
+
+**Cost.** Test no longer guards the original contract; the regression
+ships silently.
+
+**Correct pattern.** Determine which is wrong — the test or the
+implementation. If the test was wrong (spec changed, contract updated),
+update the test AND the source AND the spec. Never change the test
+alone.
+
+## 9. Worktree Boundary Violation
+
+**Anti-pattern.** Editing files outside the worktree path the spawn
+prompt assigned.
+
+**Detection.** The git shim blocks most operations; if it slips
+through, the change does not land in the PR.
+
+**Cost.** Lost work; integration confusion; potential corruption of
+sibling worker's branch.
+
+**Correct pattern.** First action is `cd <worktree-path>`. All
+subsequent paths SHOULD be absolute within the worktree. Use
+`git rev-parse --show-toplevel` to confirm cwd if uncertain.
+
+## 10. Self-Attestation Without Proof
+
+**Anti-pattern.** "I completed the task" returned to the orchestrator
+without `cleo verify` evidence atoms.
+
+**Detection.** Manifest entry lacks evidence; `cleo show <id>` shows
+gates pending; orchestrator cannot programmatically confirm completion.
+
+**Cost.** Orchestrator must re-verify manually; if the work was not
+actually done, the rollback is much more expensive.
+
+**Correct pattern.** ADR-051 ritual. Every gate gets evidence; verify
+re-validates programmatically. Self-attestation without atoms is
+rejected by the post-ADR-051 system.
+
+## 11. Skipped Memory Observation
+
+**Anti-pattern.** Non-trivial task completed; session ends; nothing
+new in BRAIN.
+
+**Detection.** `cleo memory find <task-topic>` returns no new
+observations from this session.
+
+**Cost.** The next session relearns the same lesson; institutional
+knowledge does not accumulate.
+
+**Correct pattern.** After every non-trivial complete:
+
+```bash
+cleo memory observe "<learning, 1-2 sentences>" --title "<short title>"
+```
+
+The CLEO-INJECTION.md trigger row says this explicitly. Honor it.
+
+## 12. Premature `cleo complete`
+
+**Anti-pattern.** Calling `cleo complete` before all gates have been
+verified, on the theory that the worker can verify in parallel.
+
+**Detection.** Exit code 80 (`E_LIFECYCLE_GATE_FAILED`) or
+`E_EVIDENCE_MISSING`.
+
+**Cost.** Failed complete; worker must back out, re-verify, re-complete.
+
+**Correct pattern.** Verify all six gates first; complete last. The
+verify steps are fast (cached) and idempotent. No reason to skip.

--- a/packages/skills/skills/ct-task-executor/references/common-failures.md
+++ b/packages/skills/skills/ct-task-executor/references/common-failures.md
@@ -1,0 +1,193 @@
+# Common Failures
+
+The most frequent worker-agent failure modes observed across CLEO
+sessions. Each entry includes a recognition signal, the root cause, and
+the corrected approach. Many of these are recorded in BRAIN observations
+under `O-*` IDs.
+
+## False Success Reports
+
+**Symptom.** Worker returns "Task complete. All tests pass." The
+orchestrator later finds (via `cleo show <id>` showing pending gates,
+or `git log` showing no commits, or `pnpm test` showing failures) that
+the work was not actually done.
+
+**Recognition.** Reported success without (a) a commit SHA in the
+response, (b) the test output excerpt, or (c) a `cleo verify` audit
+trail.
+
+**Root cause.** The worker conflated "I drafted code that should work"
+with "I ran the tests and they passed." Often correlates with model
+fatigue at >70% context utilization.
+
+**Fix.** The worker MUST run the full quality-gate sequence (biome →
+build → typecheck → test) and capture the exit codes / output before
+reporting completion. The spawn prompt's tier-1+ injection contains this
+ritual — re-read it if uncertain.
+
+This failure mode was first formally documented in T1450 PROOF
+(`spawn-capability-gap-2026-04-25.md` — historical context, the
+underlying gap is now resolved but the pattern recurs at the worker
+level).
+
+## Outside-Worktree Edits
+
+**Symptom.** Worker edits files outside its assigned worktree path. The
+git shim usually blocks this, but if it slips through, the change does
+not get into the PR.
+
+**Recognition.** Files appear modified in `/mnt/projects/cleocode/` but
+not in the worktree's branch.
+
+**Root cause.** Worker resolved a relative path against the wrong cwd
+(persistent shell state was not reset between tool calls), or
+deliberately followed an absolute path from a prior session's notes.
+
+**Fix.** The spawn prompt's `FIRST ACTION: cd <path>` MUST be the first
+command. All subsequent paths SHOULD be absolute within the worktree.
+If unsure, prefix with `git rev-parse --show-toplevel` first.
+
+## Cherry-Pick Instead of Merge
+
+**Symptom.** When integrating completed work to main, the worker (or
+overzealous orchestrator) used `git cherry-pick` instead of
+`git merge --no-ff`.
+
+**Recognition.** `git log --grep "<task-id>"` shows different SHAs in
+the task branch vs main. The author email is lost. `cleo find` cannot
+relate commits to the task.
+
+**Root cause.** Following a generalized "cherry-pick is safer" instinct
+without reading ADR-062. The CLEO contract is that workers commit on
+their task branch; the integrator MUST use `git merge --no-ff
+task/<id>` to preserve SHAs, author identity, and the
+`cleo find <task-id> --commits` trace.
+
+**Fix.** Always `git merge --no-ff task/<TID>` for integration. See
+`feedback_cherry_pick_worktrees.md` for the full pattern.
+
+## Hard Reset Disasters
+
+**Symptom.** Multiple worktree-spawn agents working in parallel suddenly
+find their work has vanished from main. The orchestrator's primary
+working dir's branch is on main; an agent or the orchestrator ran
+`git reset --hard origin/main`, wiping local commits that had not yet
+been pushed.
+
+**Recognition.** `git reflog` on the primary working dir shows a
+recent `HEAD@{N}: reset: moving to origin/main`.
+
+**Root cause.** The primary working dir's branch is shared across
+parallel orchestrators. A reset there wipes shared state. Caught in
+T9354 session and recovered via reflog cherry-pick — at the cost of 3
+PRs.
+
+**Fix.** NEVER `git reset --hard` on the orchestrator's primary working
+dir while any worker agents are alive. Apply fixes from inside the
+worker's worktree path, or use `git update-ref` + push to land
+corrections without resetting the local branch.
+
+## ESM Import Path Drift
+
+**Symptom.** Build fails locally with `ERR_MODULE_NOT_FOUND` or CI fails
+with `Cannot find module './foo'` even though the file exists.
+
+**Recognition.** Import line `import { foo } from "./foo";` (no
+`.js` extension).
+
+**Root cause.** The repo's TypeScript config uses pure ESM with explicit
+`.js` extensions on imports. Stripping the extension works at write
+time but fails at runtime under Node's strict ESM resolver.
+
+**Fix.** Always include `.js` in relative imports — even for `.ts`
+sources. The compiled output uses the same extension. Workspace imports
+(`@cleocode/...`) do not need the extension.
+
+## Cross-Package Reach
+
+**Symptom.** Worker imports across package boundaries without declaring
+the dependency in the consumer's `package.json`. Build succeeds locally
+(pnpm hoists) but CI fails on a clean install.
+
+**Recognition.** Import like `import { thing } from "../../core/src/foo.js"`
+inside `packages/cleo/`.
+
+**Root cause.** Took a relative-path shortcut instead of using the
+workspace import `@cleocode/core`. Also bypasses the type contract.
+
+**Fix.** Add the consumer's `package.json` dependency and use the
+workspace import:
+
+```typescript
+import { thing } from "@cleocode/core/foo";
+```
+
+If the function being imported is not exported from the consumer
+package, add an export — do not reach through internals.
+
+## Type Cast Chains
+
+**Symptom.** Code contains `as unknown as SomeType`, `any` types, or
+empty `catch (err: unknown)` blocks. AGENTS.md type-safety rules ban
+all three.
+
+**Recognition.** `pnpm biome check` warnings on `any` / `unknown` usage,
+or grep for `as unknown as`.
+
+**Root cause.** Worker hit a type mismatch and reached for the escape
+hatch instead of fixing the underlying contract.
+
+**Fix.** Inspect the actual types; update or extend the contract in
+`packages/contracts/src/` if necessary. The repo's policy is "find the
+root cause" — type casts hide the cause and accumulate as debt.
+
+## Drive-By Refactors
+
+**Symptom.** PR for T9660 includes unrelated changes to files outside
+the task's scope. Reviewer comments "scope creep" and requests a split.
+
+**Recognition.** `git diff --stat HEAD` shows files modified that do
+not appear in the task's acceptance criteria.
+
+**Root cause.** Worker noticed something to improve while reading
+adjacent code and "fixed it in passing".
+
+**Fix.** Revert unrelated changes; file a new task for them. One task =
+one purpose = one PR. The CLEO contract relies on this for traceability.
+
+## Stale Cache Confusion
+
+**Symptom.** `cleo complete` fails with `E_EVIDENCE_STALE` even though
+the worker is sure they didn't touch the file after verify.
+
+**Recognition.** Error message references a file the worker only read,
+never edited.
+
+**Root cause.** A formatter (biome auto-fix on save, or a sibling
+agent's commit) modified the file between `cleo verify` and
+`cleo complete`. The sha256 no longer matches.
+
+**Fix.** Re-run `cleo verify` for the affected gate(s) before
+`cleo complete`. Treat verify+complete as an atomic pair — minimize the
+time between them.
+
+## Forgotten Memory Observation
+
+**Symptom.** Task completed; the session ends; the next session
+re-discovers a fact that should have been retained.
+
+**Recognition.** `cleo memory find <topic>` after the task returns
+nothing, even though the worker learned something non-trivial.
+
+**Root cause.** Worker skipped the post-complete `cleo memory observe`
+step (CLEO-INJECTION.md trigger row 2: "after non-trivial task
+completion").
+
+**Fix.** After every non-trivial `cleo complete`, run:
+
+```bash
+cleo memory observe "<one-paragraph learning>" --title "<short title>"
+```
+
+Trivial tasks (typo fix, version bump) do not need observations.
+Anything that changed your mental model does.

--- a/packages/skills/skills/ct-task-executor/references/evidence-and-gates.md
+++ b/packages/skills/skills/ct-task-executor/references/evidence-and-gates.md
@@ -1,0 +1,179 @@
+# Evidence and Gates
+
+ADR-051 requires every `cleo complete <TASK_ID>` to be backed by
+programmatic evidence. The executor MUST attach evidence atoms to each
+gate before completing; the verify step re-validates them against git,
+the filesystem, and the toolchain. This reference defines atom shapes,
+canonical names, and the failure modes most often hit.
+
+## The Gate Set
+
+Every task carries six standard gates. Optional gates may be added per
+task; the standard set is non-negotiable.
+
+| Gate | Meaning | Evidence kind |
+|------|---------|---------------|
+| implemented | Code change exists | `commit:<sha>` + `files:<list>` |
+| testsPassed | Tests green | `tool:test` or `test-run:<json>` |
+| qaPassed | Lint + typecheck clean | `tool:lint` + `tool:typecheck` |
+| documented | Docs updated | `files:<docs-paths>` |
+| securityPassed | Security scan or waiver | `tool:security-scan` or `note:<rationale>` |
+| cleanupDone | Branch/cleanup summary | `note:<text>` |
+
+Decision-only tasks (no code change; the deliverable is a recorded BRAIN
+decision) use a distinct `implemented` atom shape:
+
+```bash
+cleo verify T### --gate implemented \
+  --evidence "decision:D-arch-001;files:docs/research-note.md"
+```
+
+This shape eliminates the `CLEO_OWNER_OVERRIDE` path on decision-only
+completion (per T1875).
+
+## Atom Kinds
+
+### `commit:<sha>`
+
+The git commit SHA where the work landed. Re-validated for reachability
+from HEAD at complete time. The SHA MUST be a full or short SHA that
+`git rev-parse` resolves.
+
+```bash
+cleo verify T### --gate implemented \
+  --evidence "commit:b8e723d78;files:packages/skills/.../references/triggers.md"
+```
+
+If the worktree's branch has been merged to main since the commit, the
+atom still resolves. If the commit was rebased away, validation fails
+with `E_EVIDENCE_STALE` — re-attach the new SHA.
+
+### `files:<comma-list>`
+
+Paths affected by the work. Re-validated by sha256 against the on-disk
+file at complete time. If the file's contents change between verify
+and complete (e.g. a later edit drifts the hash), validation fails with
+`E_EVIDENCE_STALE`.
+
+```bash
+--evidence "files:packages/cleo/src/commands/release-plan.ts,packages/cleo/__tests__/release-plan.test.ts"
+```
+
+Use forward slashes; absolute or repo-relative paths both work.
+
+### `tool:<name>`
+
+Canonical tool name. CLEO resolves to the project's actual command via
+`.cleo/project-context.json` (`testing.command`, `build.command`) with
+per-`primaryType` fallbacks. Canonical names:
+
+| Canonical | Resolves to (Node) | Fallback |
+|-----------|-------------------|----------|
+| `test` | `pnpm run test` | `cargo test`, `pytest`, `go test` |
+| `build` | `pnpm run build` | `cargo build`, etc. |
+| `lint` | biome / eslint | clippy, ruff |
+| `typecheck` | `tsc -b` | mypy |
+| `audit` | `pnpm audit` | `cargo audit` |
+| `security-scan` | varies | varies |
+
+Legacy aliases still work: `pnpm-test`, `tsc`, `biome`, `cargo-test`,
+`pytest` all map to canonical names.
+
+### `test-run:<json-path>`
+
+Path to a vitest JSON output file. Re-validated by hash. Preferred for
+sharing test evidence across sibling tasks in the same wave.
+
+```bash
+pnpm vitest run --reporter=json --outputFile=/tmp/vitest-out.json
+cleo verify T### --gate testsPassed --evidence "test-run:/tmp/vitest-out.json"
+```
+
+### `decision:<decision-id>`
+
+A BRAIN decision ID (e.g., `D-arch-001`) or an `AGT-*` provenance ID.
+Validated by lookup against the brain.db; status MUST be `proposed` or
+`accepted`. Used for decision-only tasks where the deliverable is the
+decision itself, not code.
+
+### `note:<text>`
+
+Free-form rationale. Always permitted; used when no programmatic atom
+applies. Notes appear in the audit log but do not gate validation —
+they document, they do not prove. Reserve for `cleanupDone`,
+`securityPassed` waivers, and rare edge cases.
+
+## The Ritual
+
+The full per-task ritual, in order:
+
+```bash
+# 1. Implement and verify locally
+pnpm biome check --write .
+pnpm run build && pnpm run typecheck
+pnpm run test
+git add -p && git commit -m "feat(T###): <slug>"
+
+# 2. Capture evidence for each gate (commit SHA from step 1)
+SHA=$(git rev-parse HEAD)
+FILES=$(git diff-tree --no-commit-id --name-only -r HEAD | paste -sd,)
+
+cleo verify T### --gate implemented --evidence "commit:$SHA;files:$FILES"
+cleo verify T### --gate testsPassed --evidence "tool:test"
+cleo verify T### --gate qaPassed --evidence "tool:lint;tool:typecheck"
+cleo verify T### --gate documented --evidence "files:docs/path/to/note.md"
+cleo verify T### --gate securityPassed --evidence "note:no network surface"
+cleo verify T### --gate cleanupDone --evidence "note:branch task/T### ready for merge"
+
+# 3. Complete (CLEO re-validates everything)
+cleo complete T###
+
+# 4. Record learning
+cleo memory observe "..." --title "..."
+```
+
+## Common Failure Modes
+
+| Exit | Code | Cause | Fix |
+|------|------|-------|-----|
+| — | `E_EVIDENCE_MISSING` | Ran `verify --all` without `--evidence` | Re-run per-gate with atoms |
+| — | `E_EVIDENCE_INSUFFICIENT` | Gate atom kind doesn't match required | See gate-atom table above |
+| — | `E_EVIDENCE_TESTS_FAILED` | `tool:test` exit non-zero | Fix failing tests first |
+| — | `E_EVIDENCE_TOOL_FAILED` | Lint/typecheck/etc exit non-zero | Fix source and re-run |
+| — | `E_EVIDENCE_STALE` | Files or commit changed after verify | Re-verify before complete |
+| — | `E_EVIDENCE_INVALID_DECISION` | Decision ID not found in BRAIN | Use `cleo memory decision-find` |
+| — | `E_FLAG_REMOVED` | Tried `cleo complete --force` | `--force` removed per ADR-051 |
+
+## Cache Behavior
+
+Tool-evidence results are cached under `.cleo/cache/evidence/<key>.json`,
+keyed on (canonical, cmd, args, HEAD, dirty-tree fingerprint). Parallel
+verifies against identical state coalesce to one execution via a per-key
+lock. Cross-worktree parallelism is bounded by a machine-wide per-tool
+semaphore at `~/.local/share/cleo/locks/tool-<canonical>/`.
+
+Tune with `CLEO_TOOL_CONCURRENCY_<TOOL>=<n>` (`0` disables). For most
+worker agents this is set-and-forget; the orchestrator handles tuning.
+
+## The Emergency Override
+
+In rare incident-response scenarios, the override exists:
+
+```bash
+CLEO_OWNER_OVERRIDE=1 \
+CLEO_OWNER_OVERRIDE_REASON="incident 1234 hotfix" \
+  cleo verify T### --all --evidence "note:owner-approved"
+```
+
+The override appends to `.cleo/audit/force-bypass.jsonl`. Use only when
+the owner has explicitly authorized — never as a routine shortcut to
+skip gates.
+
+## What NOT to Do
+
+- ❌ Run `cleo complete` without verifying tests actually ran
+- ❌ Run `cleo verify --all` without `--evidence` (REJECTED post-ADR-051)
+- ❌ Use `cleo complete --force` (REMOVED post-ADR-051)
+- ❌ Skip `cleo memory observe` on non-trivial tasks
+- ❌ Self-attest without programmatic proof
+- ❌ Modify files between `verify` and `complete` (caught by staleness check)

--- a/packages/skills/skills/ct-task-executor/references/implementation-patterns.md
+++ b/packages/skills/skills/ct-task-executor/references/implementation-patterns.md
@@ -1,0 +1,160 @@
+# Implementation Patterns
+
+Canonical patterns for executing CLEO tasks. The executor sits at the
+leaf of the orchestrator's pipeline — its job is to take a fully-resolved
+task spec and produce concrete deliverables that pass acceptance criteria.
+This reference codifies the patterns that succeed most consistently.
+
+## Read-Before-Write (Mandatory)
+
+The repository CLAUDE.md and AGENTS.md make this non-negotiable for CLEO:
+"Read first — understand existing code, patterns, and contracts before
+writing." For the executor, this means a concrete sequence.
+
+1. `cleo show <TASK_ID>` — full task body, including hidden acceptance
+   criteria, gate config, and prior manifest summaries.
+2. `cleo memory find "<topic-keyword>"` — prior decisions on the same
+   surface area. The BRAIN may already have answers.
+3. `Grep` for the symbol or feature name in the target package. Most
+   "new" features have a related ancestor that should be extended, not
+   rewritten.
+4. `gitnexus_impact({target: "<symbol>"})` — blast radius before any
+   edit. HIGH/CRITICAL warnings MUST be reported to the orchestrator
+   before proceeding.
+
+Skipping any of these steps produces churn the reviewer will flag.
+
+## Smallest-Change Principle
+
+Match the existing pattern even when you could "improve" it in passing.
+The contract on the executor is to ship the acceptance criteria — not
+to refactor adjacent code. If the existing pattern is genuinely broken,
+file a separate task; do not entangle a fix with the requested feature.
+
+```text
+GOOD: feat(T1234): add wave-rollup verb
+  packages/cleo/src/commands/orchestrate/wave-rollup.ts  (new file)
+
+BAD:  feat(T1234): add wave-rollup verb + clean up unrelated handler
+  packages/cleo/src/commands/orchestrate/wave-rollup.ts  (new file)
+  packages/cleo/src/commands/orchestrate/spawn.ts        (drive-by refactor)
+  packages/cleo/src/dispatch.ts                          (rename in pass)
+```
+
+The drive-by changes belong in their own task with their own acceptance
+criteria. Reviewers cannot meaningfully approve a mixed-purpose diff.
+
+## File-Placement Patterns
+
+Package boundaries are enforced — see AGENTS.md "Package-Boundary Check".
+Use this table when introducing new modules.
+
+| Concern | Package | Why |
+|---------|---------|-----|
+| Runtime primitive, domain logic, store, memory | `packages/core/` | SDK; provider-neutral |
+| CLI command handler, dispatch wiring | `packages/cleo/` | CLI surface only |
+| Shared type, envelope, operation, error | `packages/contracts/` | Cross-package contract |
+| Harness adapter, Pi runtime, claude-code adapter | `packages/cleo-os/` | Harness layer |
+| Studio frontend (SvelteKit) | `packages/studio/` | UI |
+| LAFS envelope spec or validator | `packages/lafs/` | Envelope ground truth |
+| .cant DSL or parser | `packages/cant/` | DSL |
+| Agent manifest packaging | `packages/caamp/` | Packaging |
+
+When in doubt: state runtime concerns go in `core`; CLI handlers stay
+thin and call into `core`. The repo has previously had to do T1015-style
+relocation epics — avoid creating the next one.
+
+## ESM Import Patterns
+
+The repository uses ESM with `.js` extensions on import paths (TypeScript
+strict, kebab-case files). The lint will fail any drift.
+
+```typescript
+// CORRECT
+import { openCleoDb } from "../store/open-cleo-db.js";
+import type { TaskEnvelope } from "@cleocode/contracts";
+
+// WRONG — no .js suffix
+import { openCleoDb } from "../store/open-cleo-db";
+
+// WRONG — CommonJS
+const { openCleoDb } = require("../store/open-cleo-db");
+
+// WRONG — no relative-path crossing of package boundary
+import { something } from "../../../other-package/src/foo.js";
+// (use a workspace import: import { something } from "@cleocode/other-package")
+```
+
+## Test-First When Possible
+
+For new behavior in `packages/core/` or `packages/contracts/`, write the
+test before the implementation. The test file lives alongside the source
+under `__tests__/`.
+
+```text
+packages/core/src/store/open-cleo-db.ts
+packages/core/src/store/__tests__/open-cleo-db.test.ts
+```
+
+For CLI changes where the behavior is integration-heavy (touches the
+dispatcher, the worktree, the store), prefer an end-to-end test in
+`packages/cleo/__tests__/<verb>.test.ts` that exercises the verb via
+`runMain()` rather than a unit test of an internal helper.
+
+## Error Handling Pattern
+
+The repository contracts an LAFS envelope `{ success, data?, error?, meta }`
+for every command output. Internal helpers throw typed errors; the
+dispatcher converts to envelope at the boundary.
+
+```typescript
+// Internal: throw typed error
+import { TaskNotFoundError } from "@cleocode/contracts";
+if (!task) throw new TaskNotFoundError(taskId);
+
+// Boundary: catch and wrap
+try {
+  const data = await handler(input);
+  return { success: true, data, meta: makeMeta() };
+} catch (err) {
+  return formatError(err, makeMeta());
+}
+```
+
+Do not introduce `catch (err: unknown)` — the AGENTS.md type-safety rules
+ban it. Use the contract's error types and let TypeScript narrow.
+
+## Quality Gate Sequence
+
+Run these IN ORDER before completing. The contract is in AGENTS.md;
+shortening this sequence has caused two patch-release hotfixes (v2026.4.67,
+v2026.4.69) in past sessions.
+
+```bash
+pnpm biome check --write .   # 1. format + lint
+pnpm run build               # 2. build (includes typecheck via tsc -b)
+pnpm run typecheck           # 3. typecheck — strict TS project refs
+pnpm run test                # 4. test (zero new failures)
+git diff --stat HEAD         # 5. verify scope matches intent
+```
+
+Note: `pnpm run build` (esbuild) does NOT run the strict TS project-reference
+typecheck. Always run `pnpm run typecheck` separately before tagging or
+marking complete. This was learned the hard way via L-3 in
+`feedback_typecheck_vs_build.md`.
+
+## Worktree Discipline
+
+All executor work happens inside the worktree at the path provided in the
+spawn prompt's `## Worktree Setup` section. Operations to AVOID:
+
+- `git checkout <other-branch>` — the worktree's branch is sticky.
+- `git reset --hard origin/main` — destroys in-flight commits from other
+  worktree-spawn agents (caught in T9354 session: cost 3 PRs of recovery
+  via reflog cherry-pick).
+- Editing files outside the worktree path — the git shim will block
+  most forbidden operations but the policy boundary is the worktree.
+
+When done, the orchestrator integrates via `git merge --no-ff task/<id>`
+per ADR-062 — preserving commit SHAs and task↔commit traceability. The
+executor never touches `main` directly.

--- a/packages/skills/skills/ct-validator/SKILL.md
+++ b/packages/skills/skills/ct-validator/SKILL.md
@@ -249,3 +249,12 @@ This skill binds to the **validation** LOOM lifecycle stage. Governing ADRs:
 - [ADR-023 — protocol validation dispatch](../../../../.cleo/adrs/ADR-023-protocol-validation-dispatch.md) — defines the protocol-validation routing layer that dispatches to this skill.
 
 LOOM coverage matrix: [docs/skills/loom-coverage-matrix.md](../../../../docs/skills/loom-coverage-matrix.md).
+
+## See references/
+
+Progressive disclosure — load on demand only:
+
+- `references/validation-modes.md` — schema/code/document/protocol modes, selection rubric, composition
+- `references/schema-checking.md` — engine selection, draft selection, pitfalls, bulk validation
+- `references/compliance-reports.md` — canonical scaffold, status calculus, severity, ct-ivt-looper integration
+- `references/anti-patterns.md` — twelve validation failure modes with detection and remediation

--- a/packages/skills/skills/ct-validator/references/anti-patterns.md
+++ b/packages/skills/skills/ct-validator/references/anti-patterns.md
@@ -1,0 +1,194 @@
+# Anti-Patterns
+
+Common failure modes when running validation tasks. These degrade the
+report's usefulness, break downstream consumers, or mask defects. Avoid
+them by following the detection cue and the remediation.
+
+## 1. The Short-Circuit Validator
+
+**Symptom.** Validator stops on the first failure and reports only that
+one. The report claims "FAIL" but lists only one issue when there are
+several.
+
+**Detection cue.** Issue count is exactly 1 but the underlying tool
+(biome, tsc, jsonschema) has multi-issue output.
+
+**Root cause.** Engine was run without `--all-errors` (AJV),
+`--exhaustive`, or equivalent. Or a try/catch wrapped the validation
+and bailed on first throw.
+
+**Fix.** Always pass the all-errors flag. For Zod, use `safeParse` and
+collect every issue from `result.error.issues`. For TypeScript, use
+`tsc -b --pretty false` and capture every line.
+
+## 2. The Soft Pass
+
+**Symptom.** Report status is `PASS` but the target has known
+unaddressed warnings.
+
+**Detection cue.** Findings table contains entries; status is PASS.
+
+**Root cause.** Status calculus violation — PASS requires zero
+critical AND ≤2 warnings (per `compliance-reports.md`). Warnings
+above threshold demote to PARTIAL.
+
+**Fix.** Apply the status calculus mechanically. PASS only when the
+table is empty (or warnings ≤2). When in doubt, demote.
+
+## 3. The Unreproducible Report
+
+**Symptom.** Six weeks later, someone tries to re-validate the same
+target. The report's claims cannot be verified.
+
+**Detection cue.** Report has no `## Trace` section or the Trace lists
+no reproducer command.
+
+**Root cause.** Reporter forgot to record the command sequence and
+tool versions used.
+
+**Fix.** Always include the reproducer. The Trace section is mandatory
+per the canonical scaffold.
+
+```markdown
+## Trace
+
+- Target: packages/cleo/src/release.ts (at 5608f75cd)
+- Tooling: biome@2.4.11, tsc@5.6.0, pnpm@9.x
+- Reproducer:
+  pnpm biome check packages/cleo/src/release.ts && \
+  pnpm exec tsc -b packages/cleo --pretty false
+```
+
+## 4. The Mode Confusion
+
+**Symptom.** A Document-mode report applies Code-mode rules, or
+vice-versa.
+
+**Detection cue.** Findings about TypeScript strictness in a spec
+review; findings about RFC 2119 in a code lint.
+
+**Root cause.** Mode was not made explicit at the start; the validator
+defaulted to its strongest familiarity.
+
+**Fix.** Declare mode in the report header. The spawn prompt or task
+body MUST set it; if absent, ask the orchestrator to clarify before
+proceeding.
+
+## 5. The Missing Severity
+
+**Symptom.** Findings listed but consumer cannot prioritize.
+
+**Detection cue.** Findings without `Critical | Warning | Suggestion`
+classification.
+
+**Root cause.** Reporter treated all findings as equal.
+
+**Fix.** Every finding MUST carry severity. When unclear, apply the
+"blocks ship?" test: yes → Critical; no → Warning; "nice to have" →
+Suggestion.
+
+## 6. The Vague Remediation
+
+**Symptom.** Issue says "fix this". Reader does not know how.
+
+**Detection cue.** `Fix:` line is missing or contains only "see above"
+/ "obvious from context" / "fix the issue".
+
+**Root cause.** Reporter ran out of energy by the time they got to
+the fix column.
+
+**Fix.** Every finding has a concrete fix step. If the fix requires
+discussion (architectural change), state that — but specifically:
+"file a task to redesign the credential rotation flow; reference
+ADR-XX-NEW once it lands".
+
+## 7. The Phantom Test
+
+**Symptom.** Protocol mode report claims REQ-NNN is verified by
+`test/foo.test.ts::case-name`. The test does not exist.
+
+**Detection cue.** Reproducer command fails with "no such test".
+
+**Root cause.** Reporter copied the spec's traceability matrix without
+re-checking that the named tests still exist (or ever existed).
+
+**Fix.** Re-run each verification command from the traceability
+matrix during validation. Flag REQs whose verification fails to
+resolve as Critical findings — the spec drifted from the implementation.
+
+## 8. The Single-File Tunnel
+
+**Symptom.** Code-mode validation runs only on the file that was
+explicitly named. Misses related files that share the violation.
+
+**Detection cue.** Report has findings in `release.ts` only; the
+same issue exists in 5 sibling files that were not checked.
+
+**Root cause.** Reporter took the task literally instead of the
+useful scope.
+
+**Fix.** Apply the validation to all related files when feasible —
+"the diff" usually means "all files touched by the task branch", not
+"only the one file the orchestrator mentioned".
+
+## 9. The Stale Schema
+
+**Symptom.** Schema-mode validation passes but downstream consumers
+still reject the data.
+
+**Detection cue.** Schema version pinned in the report does not match
+the producer's contract.
+
+**Root cause.** Schema was updated upstream; validator used a cached
+or pinned older version.
+
+**Fix.** Always resolve the schema fresh from the contract source
+(`@cleocode/contracts`). Pin the consumer/producer relationship in
+the schema's `$id` and `version` fields and check both.
+
+## 10. The Disposable Sidecar
+
+**Symptom.** JSON sidecar emitted, but it has different findings than
+the markdown report.
+
+**Detection cue.** `diff <(md-extract-findings report.md)
+<(jq '.findings' report.json)` shows mismatched data.
+
+**Root cause.** Reporter wrote the markdown manually and the JSON
+separately; they drifted.
+
+**Fix.** Generate one from the other. Write the structured data first
+(JSON), then render the markdown from it. A `--render-md` flag on the
+report generator enforces this.
+
+## 11. The Unsourced Rule
+
+**Symptom.** A finding cites a rule that does not exist in any visible
+standard.
+
+**Detection cue.** Rule reference is prose ("naming should be
+consistent") rather than a stable identifier ("AGENTS.md §Package
+Boundary").
+
+**Root cause.** Reporter applied a personal preference and labeled
+it as a rule.
+
+**Fix.** Every rule citation MUST link to a stable source:
+`AGENTS.md §X`, `ADR-NNN`, `biome.json#rules.style.Y`. If the
+preference is real but unwritten, the report SHOULD propose adding
+it to the standard (file a task) rather than enforcing it silently.
+
+## 12. The Pre-Empty Report
+
+**Symptom.** Validator runs against an empty or absent target, reports
+`PASS`.
+
+**Detection cue.** Target file is empty or does not exist; report says
+"100% compliance".
+
+**Root cause.** Engine returned zero violations because there was
+nothing to violate.
+
+**Fix.** Always sanity-check the target exists and has content before
+running validation. Empty/missing target is itself a Critical finding —
+not a clean pass.

--- a/packages/skills/skills/ct-validator/references/compliance-reports.md
+++ b/packages/skills/skills/ct-validator/references/compliance-reports.md
@@ -1,0 +1,199 @@
+# Compliance Reports
+
+The shape, severity calculus, and downstream consumption of the
+validation report. The report is the validator's product — its format
+is rigid because `ct-ivt-looper`, `ct-release-orchestrator`, and HITL
+gates all parse it.
+
+## Canonical Report Scaffold
+
+Every report MUST use this structure. Sections are mandatory; their
+content varies by mode.
+
+```markdown
+# Validation Report: {{VALIDATION_TARGET}}
+
+**Mode**: schema | code | document | protocol
+**Date**: {{DATE}}
+**Validator**: ct-validator v2.0.0
+
+---
+
+## Summary
+
+- **Status**: PASS | PARTIAL | FAIL
+- **Compliance**: {X}%
+- **Critical Issues**: {N}
+- **Warnings**: {N}
+- **Suggestions**: {N}
+
+## Checklist Results
+
+| Check | Status | Details |
+|-------|--------|---------|
+| {CHECK_1} | PASS/FAIL | {Details} |
+| {CHECK_2} | PASS/FAIL | {Details} |
+
+## Issues Found
+
+### Critical
+{List or "None"}
+
+### Warnings
+{List or "None"}
+
+### Suggestions
+{List or "None"}
+
+## Remediation
+
+{Required fixes if FAIL/PARTIAL, or "No remediation required" if PASS}
+
+## Trace
+
+- Target: {file/spec/diff path}
+- Tooling: {versions of tools run}
+- Reproducer: {one command that re-runs this report}
+```
+
+The Trace section is essential — without a reproducer, the report
+cannot be re-run later to confirm a remediation worked.
+
+## Status Calculus
+
+| Mode | PASS | PARTIAL | FAIL |
+|------|------|---------|------|
+| Schema | 0 violations | (n/a) | ≥1 violation |
+| Code | 0 critical, ≤2 warnings | 0 critical, 3+ warnings | ≥1 critical |
+| Document | All required sections present, 0 broken links | 1-2 missing sections | 3+ missing sections OR broken refs |
+| Protocol | 100% REQ compliance | 70-99% compliance | <70% compliance |
+
+The status is not a vote — it is a computed function of the findings.
+Two validators running on the same target MUST produce the same
+status.
+
+PARTIAL is reserved for cases where the target is shippable WITH
+recorded remediation; FAIL means the target cannot ship as-is.
+
+## Severity Definitions
+
+| Severity | Meaning | Examples |
+|----------|---------|----------|
+| Critical | Blocks ship; data corruption, security, AGENTS.md rejection | `any` type, missing required field, broken link in spec |
+| Warning | Should fix soon; degrades quality but does not block | Long body, unused import, missing optional section |
+| Suggestion | Improvement opportunity; no obligation | Extract helper, rename for clarity |
+
+Each finding MUST carry a severity. Findings without severity are
+unactionable — the consumer cannot prioritize.
+
+## Per-Finding Format
+
+```markdown
+### Critical
+
+**C-001**: `packages/cleo/src/dispatch.ts:42` uses `any` type.
+- Rule: AGENTS.md Type Safety §1 — "NEVER use `any` type"
+- Fix: Import the relevant type from `@cleocode/contracts` or
+  define a narrower union.
+- Verification: `pnpm biome check packages/cleo/src/dispatch.ts`
+
+**C-002**: `packages/cleo/src/release.ts:107` catches `err: unknown`.
+- Rule: AGENTS.md Type Safety §5 — "NEVER use `catch (err: unknown)`"
+- Fix: Throw and catch by class from `@cleocode/contracts/errors`.
+- Verification: Replace with `catch (err)` and pattern-match by
+  `instanceof`.
+
+### Warnings
+
+**W-001**: `packages/cleo/src/dispatch.ts` is 487 lines (warn at 400).
+- Rule: ct-skill-validator audit_body §body-length
+- Fix: Extract sub-handlers into sibling files.
+- Verification: re-run audit_body.py.
+
+### Suggestions
+
+**S-001**: `packages/cleo/src/dispatch.ts:120` has a TODO with no task ID.
+- Rule: Internal — TODOs should reference task IDs.
+- Fix: File a task, attach the ID: `// TODO(T9999): ...`.
+```
+
+Each finding gets a stable ID (`C-NNN`, `W-NNN`, `S-NNN`) so subsequent
+reports can reference whether the same issue persists.
+
+## Compliance Percentage
+
+For modes that report a percentage:
+
+```text
+compliance = (passed_checks / total_checks) × 100
+```
+
+Round to one decimal. For Protocol mode (REQ compliance), checks are
+the REQs in the spec's traceability matrix. For Schema mode, "checks"
+is the count of constraints evaluated.
+
+When the denominator is zero (e.g., a spec with no REQs), the
+percentage is undefined — emit `N/A` and report a Critical finding for
+the empty spec.
+
+## Integration with ct-ivt-looper
+
+The IVT loop reads the validator's `status` and `compliance` fields
+to decide whether to continue iterating. The contract:
+
+- `status: PASS` → IVT loop converges; release-orchestrator may proceed.
+- `status: PARTIAL` → IVT loop loops once more with the remediation as
+  input; if still PARTIAL on iteration 3, escalates to HITL.
+- `status: FAIL` → IVT loop blocks; release-orchestrator MUST not
+  proceed; HITL escalation immediate.
+
+This contract is the reason status calculus is rigid — fuzzy statuses
+break the loop's termination conditions.
+
+## Integration with Release
+
+`ct-release-orchestrator` reads the most recent validation report
+for the epic before allowing ship. The release pipeline (ADR-065)
+contains a gate that asserts `status: PASS` on the implementation
+against the spec. PARTIAL reports trigger a recorded remediation
+plan; FAIL reports block.
+
+## Machine-Readable Sidecar
+
+Always emit a JSON sidecar next to the markdown report:
+
+```json
+{
+  "target": "packages/cleo/src/release.ts",
+  "mode": "code",
+  "status": "FAIL",
+  "compliance": 88.5,
+  "findings": {
+    "critical": [
+      {"id": "C-001", "file": "...", "line": 42, "rule": "...", "fix": "..."},
+      {"id": "C-002", "file": "...", "line": 107, "rule": "...", "fix": "..."}
+    ],
+    "warnings": [...],
+    "suggestions": [...]
+  },
+  "trace": {
+    "tooling": ["biome@2.4.11", "tsc@5.6.0"],
+    "reproducer": "pnpm biome check . && pnpm exec tsc -b",
+    "timestamp": "2026-05-19T19:35:00Z"
+  }
+}
+```
+
+The orchestrator parses this when programmatic decisions are needed;
+the human report (.md) is for review.
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails |
+|--------------|--------------|
+| Vague finding ("file looks weird") | Cannot remediate |
+| Missing severity | Consumer cannot prioritize |
+| No reproducer in trace | Cannot re-validate after fix |
+| PARTIAL with no remediation plan | Status calculus violation |
+| Findings without rule reference | Disputable, not actionable |
+| Markdown only, no JSON sidecar | Breaks orchestrator integration |

--- a/packages/skills/skills/ct-validator/references/schema-checking.md
+++ b/packages/skills/skills/ct-validator/references/schema-checking.md
@@ -1,0 +1,191 @@
+# Schema Checking
+
+Deeper guidance for Schema Validation mode (Mode 1 from
+`validation-modes.md`). Schema checking is the most mechanical of the
+four modes — but only if the inputs are correctly configured. This
+reference covers the configuration pitfalls and tool-selection rules.
+
+## Pick the Right Engine
+
+| Engine | Strength | When to use |
+|--------|----------|-------------|
+| AJV (`ajv-cli`) | Fast; draft-07 / 2019-09 / 2020-12 | Generic JSON Schema validation |
+| Zod | Type-safe; integrates with TypeScript | Project-internal data validation |
+| drizzle-orm/zod | Schema → Zod auto-generation | Drizzle ORM consumers |
+| jsonschema (Python) | Cross-language; same draft support | Python-side validation |
+| `cargo schema` / serde | Type-safe; Rust-side | Rust crates |
+
+The CLEO repo's primary engine is Zod (via `@cleocode/contracts`) — most
+internal schemas are exported as Zod schemas with optional drizzle
+codegen. Use Zod's `safeParse` to get structured errors.
+
+For external contracts (LAFS envelope spec, JSON-RPC requests from
+non-CLEO clients), use AJV or jsonschema for cross-language portability.
+
+## Draft Selection
+
+Always state the draft explicitly. Draft-07 and draft-2020-12 have
+incompatible semantics around `$ref`, `if/then/else`, and tuple arrays.
+
+| Draft | Best for | Caveats |
+|-------|----------|---------|
+| draft-04 | Legacy | `id` not `$id`; many engines deprecated this |
+| draft-07 | Industry standard | Most engines support fully |
+| draft-2019-09 | New work, conservative | `$defs` replaces `definitions` |
+| draft-2020-12 | New work, full | Some engines lag |
+
+CLEO contracts target draft-07 unless the schema needs 2020-12-only
+features (typically `prefixItems` for tuple arrays). Add the explicit
+`"$schema"` field on every published schema:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TaskEnvelope",
+  "type": "object",
+  "required": ["success", "meta"],
+  ...
+}
+```
+
+## The Standard Validation Loop
+
+```bash
+# 1. Choose engine; choose draft
+ENGINE=ajv
+DRAFT=draft-07
+
+# 2. Resolve schema file (must include $schema or pass --spec)
+SCHEMA=packages/contracts/schemas/envelope.json
+
+# 3. Iterate over data files
+for DATA in path/to/*.json; do
+  echo "=== $DATA ==="
+  npx ajv validate -s "$SCHEMA" -d "$DATA" --spec=$DRAFT --all-errors
+done
+
+# 4. Aggregate by file in the report
+```
+
+The `--all-errors` flag (AJV) or `--exhaustive` (Zod's `safeParse` does
+this by default) is essential — the spec ground rule is "report every
+violation", not "stop at the first one".
+
+## Pitfalls
+
+### 1. $ref Resolution Failure
+
+**Symptom.** Validator complains "could not resolve $ref" or "unknown
+keyword $ref".
+
+**Cause.** Schema references another file by relative path; the engine
+does not know the base directory.
+
+**Fix.** Pass `--ref` (AJV) pointing at the referenced files, or inline
+the references with `$defs`. For multi-file schemas, use AJV's
+`addSchema()` API or a bundler step that flattens before validation.
+
+### 2. Implicit Type Coercion
+
+**Symptom.** A string `"123"` validates against `{"type": "number"}`.
+
+**Cause.** Engine has coercion enabled (`coerceTypes: true` in AJV).
+
+**Fix.** Disable coercion for strict validation:
+
+```javascript
+new Ajv({ coerceTypes: false, strict: true, allErrors: true })
+```
+
+CLEO contracts are strict by default — incoming data must already be
+typed correctly.
+
+### 3. Missing required not flagged
+
+**Symptom.** A required field is missing; schema says it's required;
+validator passes.
+
+**Cause.** The schema's `required` is at the wrong level (nested vs
+top), or the validator is in non-strict mode.
+
+**Fix.** Re-check the schema structure. `required` must be a peer of
+`properties` at the same nesting level.
+
+### 4. Additional Properties Silently Allowed
+
+**Symptom.** Data has extra fields not in the schema; validator passes.
+
+**Cause.** Schema does not specify `additionalProperties: false`.
+
+**Fix.** CLEO contracts default to `additionalProperties: false` — extra
+fields indicate either drift in the producer or a malicious payload.
+Override only with an inline justification.
+
+## Reporting Schema Violations
+
+Each violation goes in the report as:
+
+```markdown
+### Violations
+
+| Path | Keyword | Actual | Expected | File |
+|------|---------|--------|----------|------|
+| `/data/items/3/id` | required | (absent) | string | manifest-instance.json |
+| `/data/version` | type | "1.2.3" (string) | number | manifest-instance.json |
+| `/meta/timestamp` | format | "today" | date-time | manifest-instance.json |
+| `/error.code` | enum | "E_WUT" | one of [E_NOT_FOUND, E_VALIDATION, ...] | response.json |
+```
+
+The Path column uses JSON Pointer (RFC 6901). The Keyword column names
+the schema constraint violated. Actual + Expected gives the diff
+needed to fix.
+
+## Bulk Schema Validation
+
+When validating many instances (e.g., every manifest file in
+`.cleo/agent-outputs/`), produce a summary table first, then drill
+into failures.
+
+```markdown
+## Summary
+
+- **Files validated**: 47
+- **Pass**: 42
+- **Fail**: 5
+- **Compliance**: 89.4%
+
+## Failed Files
+
+| File | Violations |
+|------|-----------|
+| `.cleo/agent-outputs/2026-05-19_old.md` | 3 |
+| `.cleo/agent-outputs/2026-05-19_draft.md` | 1 |
+| ... | ... |
+
+## Detail (per-file)
+
+### `.cleo/agent-outputs/2026-05-19_old.md`
+
+| Path | Keyword | Actual | Expected |
+|------|---------|--------|----------|
+| ... | ... | ... | ... |
+```
+
+Bulk reports SHOULD be machine-readable. Emit a sibling JSON report
+under the same name when the consumer is automation.
+
+## Self-Test the Schema
+
+Before trusting any schema for validation, verify it accepts known-good
+instances and rejects known-bad instances. Maintain a `fixtures/`
+directory next to the schema:
+
+```text
+packages/contracts/schemas/envelope.json
+packages/contracts/schemas/fixtures/envelope-valid.json
+packages/contracts/schemas/fixtures/envelope-missing-success.json
+packages/contracts/schemas/fixtures/envelope-wrong-type.json
+```
+
+A test that exercises all three confirms the schema does what it
+claims. Without fixtures, schema drift goes undetected.

--- a/packages/skills/skills/ct-validator/references/validation-modes.md
+++ b/packages/skills/skills/ct-validator/references/validation-modes.md
@@ -1,0 +1,185 @@
+# Validation Modes
+
+`ct-validator` operates in four distinct modes. Each has different inputs,
+different verification mechanics, and different report shape. The mode is
+determined by the target type — the spawn prompt or task body MUST make
+the mode explicit.
+
+## Mode 1: Schema Validation
+
+**Target.** A data instance (JSON, YAML, TOML, etc.) checked against a
+schema (JSON Schema, Zod, drizzle/zod, ajv, JSON-LD).
+
+**Inputs.**
+- One or more data files (or stdin)
+- A schema (file path or inline)
+- Optional: schema dialect (draft-07, draft-2020-12, etc.)
+
+**Mechanics.** Run the schema engine; collect every violation; classify
+by JSON Path. Do not short-circuit on first failure — exhaustive
+reporting is the whole value-add.
+
+**Tool examples.**
+
+```bash
+# AJV (Node)
+npx ajv validate -s schema.json -d data.json --spec=draft7
+
+# Zod (Node, via project's contracts)
+node -e "
+  import { Schema } from '@cleocode/contracts';
+  const result = Schema.safeParse(JSON.parse(input));
+  if (!result.success) console.log(JSON.stringify(result.error.format()));
+"
+
+# jsonschema (Python)
+python -m jsonschema -i data.json schema.json
+```
+
+**Report shape.** Each violation gets file + JSON Path + violated keyword
++ actual value + expected. Group by file when validating many instances.
+
+## Mode 2: Code Compliance
+
+**Target.** A code change (PR, diff, or working-tree state) checked
+against project standards — lint rules, style guide, naming conventions,
+import boundaries, type discipline.
+
+**Inputs.**
+- A diff (or branch comparison)
+- The project's lint/format configs (biome.json, .eslintrc, clippy.toml)
+- The relevant AGENTS.md / ADR rules
+
+**Mechanics.** Run each tool; collect findings; classify by severity.
+Aggregate the toolchain (biome + tsc + project-specific rules) into a
+single report.
+
+**Tool examples.**
+
+```bash
+# Biome (lint + format in one)
+pnpm biome check . --reporter=json
+
+# TypeScript strict
+pnpm exec tsc -b --pretty false
+
+# Custom AGENTS.md rule checks
+grep -rn "catch (err: unknown)" packages/ --include='*.ts'
+grep -rn ": any\b" packages/ --include='*.ts'
+
+# Package-boundary check
+find packages -name "*.ts" -exec grep -l "../../../" {} \;
+```
+
+**Report shape.** Each finding gets file + line + rule + severity + fix
+suggestion. The AGENTS.md "INSTANT REJECTION" anti-patterns get
+`critical` severity; biome warnings get `warning` severity.
+
+## Mode 3: Document Validation
+
+**Target.** A markdown document (spec, ADR, agent-output, skill) checked
+against a structural standard — required sections, frontmatter, link
+validity, style guide.
+
+**Inputs.**
+- The document(s) under validation
+- The structural standard (e.g., "every spec MUST have RFC 2119
+  boilerplate, REQ-NNN numbered requirements, and a Compliance section")
+- The CLEO style guide (`packages/skills/skills/_shared/cleo-style-guide.md`)
+
+**Mechanics.** Parse the document; check section presence; validate
+links; scan for placeholder text; verify formatting.
+
+**Tool examples.**
+
+```bash
+# Use the ct-skill-validator scripts as a model
+python packages/skills/skills/ct-skill-validator/scripts/validate.py <skill-dir>
+python packages/skills/skills/ct-skill-validator/scripts/audit_body.py <skill-dir>
+
+# Generic markdown link check
+markdown-link-check docs/specs/*.md
+
+# Section presence check (ad-hoc)
+for f in docs/specs/*.md; do
+  grep -q "^## Compliance" "$f" || echo "FAIL: $f missing Compliance"
+  grep -q "RFC 2119" "$f" || echo "FAIL: $f missing RFC 2119 boilerplate"
+done
+```
+
+**Report shape.** Each finding gets file + section/line + violated rule
++ fix suggestion. Document-mode reports are the most useful when paired
+with traceability — see Mode 4.
+
+## Mode 4: Protocol Compliance
+
+**Target.** An implementation checked against its specification — the
+spec defines REQ-NNN, the implementation MUST satisfy each.
+
+**Inputs.**
+- The specification document (with traceability matrix)
+- The implementation source
+- The test suite (each REQ should have a verifying test)
+
+**Mechanics.** For each REQ in the matrix, run the verifying test;
+record pass/fail; record any REQs that lack a verifying test. Compute
+compliance percentage.
+
+**Tool examples.**
+
+```bash
+# Run the specific test for each REQ
+pnpm vitest run --testNamePattern="REQ-001|REQ-002|REQ-003"
+
+# Extract REQ→test map from the spec's traceability matrix
+grep -E "^\| REQ-" docs/specs/foo-spec.md | awk -F'|' '{print $2, "->", $4}'
+
+# Detect REQs without verification
+grep -E "^\| REQ-.*\| \(TODO" docs/specs/foo-spec.md
+```
+
+**Report shape.** Compliance percentage + per-REQ pass/fail + list of
+unverified REQs. This is the input to release-gate decisions.
+
+## Mode Selection Cheat Sheet
+
+| Signal in task description | Mode |
+|----------------------------|------|
+| "validate this JSON against schema X" | Schema |
+| "check the PR for style violations" | Code |
+| "review this spec for completeness" | Document |
+| "verify the implementation satisfies the spec" | Protocol |
+| "audit the release pipeline against ADR-065" | Protocol |
+| "lint the changes" | Code |
+| "validate the LAFS envelope" | Schema |
+| "review the agent-output for style guide compliance" | Document |
+
+## Mode Composition
+
+A single task may chain modes. Example: "validate the new release-plan
+implementation."
+
+1. Mode 3 (Document) — does `docs/specs/release-plan-spec.md` have
+   RFC 2119 boilerplate, numbered REQs, traceability matrix, compliance
+   section?
+2. Mode 4 (Protocol) — does the implementation pass each REQ's test?
+3. Mode 2 (Code) — does the implementation's diff pass lint + typecheck?
+4. Mode 1 (Schema) — do the LAFS envelopes the new code emits validate
+   against the contract schema?
+
+When composing, run the modes in this order — document → protocol →
+code → schema. Each later mode assumes the earlier modes have passed,
+so they bail early on irrelevant failures.
+
+## Output Per Mode
+
+| Mode | Status fields | Key metric |
+|------|---------------|------------|
+| Schema | `status: PASS|FAIL`, `violations: [...]` | violation count |
+| Code | `status: PASS|FAIL`, `findings: [...]` | finding count by severity |
+| Document | `status: PASS|FAIL`, `sections_missing: [...]` | missing-section count |
+| Protocol | `status: PASS|PARTIAL|FAIL`, `compliance: X%`, `unverified: [...]` | compliance percentage |
+
+All modes share the canonical report scaffold in SKILL.md — `## Summary`,
+`## Checklist Results`, `## Issues Found`, `## Remediation`. Only the
+content differs.

--- a/packages/skills/skills/manifest.json
+++ b/packages/skills/skills/manifest.json
@@ -391,7 +391,11 @@
       "status": "active",
       "tier": 2,
       "token_budget": 6000,
-      "references": [],
+      "references": [
+        "skills/ct-docs-write/references/cleo-style-guide.md",
+        "skills/ct-docs-write/references/markdown-patterns.md",
+        "skills/ct-docs-write/references/audience-targeting.md"
+      ],
       "capabilities": {
         "inputs": ["file_path", "content_topic", "audience"],
         "outputs": ["documentation-file", "markdown-content"],

--- a/packages/skills/skills/manifest.json
+++ b/packages/skills/skills/manifest.json
@@ -326,7 +326,12 @@
       "status": "active",
       "tier": 2,
       "token_budget": 8000,
-      "references": [],
+      "references": [
+        "skills/ct-documentor/references/chain-orchestration.md",
+        "skills/ct-documentor/references/doc-types-and-templates.md",
+        "skills/ct-documentor/references/style-coordination.md",
+        "skills/ct-documentor/references/anti-patterns.md"
+      ],
       "capabilities": {
         "inputs": ["TASK_ID", "documentation_topic"],
         "outputs": ["documentation-file", "manifest-entry", "review-report"],

--- a/packages/skills/skills/manifest.json
+++ b/packages/skills/skills/manifest.json
@@ -359,7 +359,11 @@
       "status": "active",
       "tier": 2,
       "token_budget": 6000,
-      "references": [],
+      "references": [
+        "skills/ct-docs-lookup/references/ctx7-workflow.md",
+        "skills/ct-docs-lookup/references/library-id-resolution.md",
+        "skills/ct-docs-lookup/references/version-specific-docs.md"
+      ],
       "capabilities": {
         "inputs": ["library_name", "query", "version"],
         "outputs": ["documentation-content", "code-examples"],

--- a/packages/skills/skills/manifest.json
+++ b/packages/skills/skills/manifest.json
@@ -423,7 +423,11 @@
       "status": "active",
       "tier": 2,
       "token_budget": 6000,
-      "references": [],
+      "references": [
+        "skills/ct-docs-review/references/style-violations.md",
+        "skills/ct-docs-review/references/pr-review-mode.md",
+        "skills/ct-docs-review/references/inline-comment-patterns.md"
+      ],
       "capabilities": {
         "inputs": ["file_path", "pr_url", "diff_content"],
         "outputs": ["review-comments", "style-violations"],

--- a/packages/skills/skills/manifest.json
+++ b/packages/skills/skills/manifest.json
@@ -223,7 +223,12 @@
       "protocol": "specification",
       "loomStage": "specification",
       "adrRefs": ["ADR-014", "ADR-023"],
-      "references": [],
+      "references": [
+        "skills/ct-spec-writer/references/rfc2119-language.md",
+        "skills/ct-spec-writer/references/spec-templates.md",
+        "skills/ct-spec-writer/references/traceability-matrix.md",
+        "skills/ct-spec-writer/references/anti-patterns.md"
+      ],
       "capabilities": {
         "inputs": ["TASK_ID", "SPEC_NAME", "spec_topic"],
         "outputs": ["specification-file", "manifest-entry"],

--- a/packages/skills/skills/manifest.json
+++ b/packages/skills/skills/manifest.json
@@ -125,7 +125,13 @@
       "protocol": "implementation",
       "loomStage": "implementation",
       "adrRefs": ["ADR-070", "ADR-062"],
-      "references": [],
+      "references": [
+        "skills/ct-task-executor/references/implementation-patterns.md",
+        "skills/ct-task-executor/references/acceptance-criteria-mapping.md",
+        "skills/ct-task-executor/references/evidence-and-gates.md",
+        "skills/ct-task-executor/references/common-failures.md",
+        "skills/ct-task-executor/references/anti-patterns.md"
+      ],
       "capabilities": {
         "inputs": ["TASK_ID", "TASK_NAME", "TASK_INSTRUCTIONS", "DELIVERABLES_LIST", "ACCEPTANCE_CRITERIA"],
         "outputs": ["deliverables", "manifest-entry"],

--- a/packages/skills/skills/manifest.json
+++ b/packages/skills/skills/manifest.json
@@ -265,7 +265,12 @@
       "protocol": "validation",
       "loomStage": "validation",
       "adrRefs": ["ADR-051", "ADR-023"],
-      "references": [],
+      "references": [
+        "skills/ct-validator/references/validation-modes.md",
+        "skills/ct-validator/references/schema-checking.md",
+        "skills/ct-validator/references/compliance-reports.md",
+        "skills/ct-validator/references/anti-patterns.md"
+      ],
       "capabilities": {
         "inputs": ["TASK_ID", "VALIDATION_TARGET", "VALIDATION_CRITERIA"],
         "outputs": ["validation-report", "manifest-entry"],

--- a/packages/skills/skills/manifest.json
+++ b/packages/skills/skills/manifest.json
@@ -187,7 +187,12 @@
       "protocol": "research",
       "loomStage": "research",
       "adrRefs": ["ADR-023", "ADR-070"],
-      "references": [],
+      "references": [
+        "skills/ct-research-agent/references/triggers-and-routing.md",
+        "skills/ct-research-agent/references/source-strategy.md",
+        "skills/ct-research-agent/references/citation-and-evidence.md",
+        "skills/ct-research-agent/references/anti-patterns.md"
+      ],
       "capabilities": {
         "inputs": ["TASK_ID", "TOPIC", "RESEARCH_QUESTIONS"],
         "outputs": ["research-file", "manifest-entry"],

--- a/packages/skills/vitest.config.ts
+++ b/packages/skills/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     include: [
       'skills/**/__tests__/*.test.ts',
       'skills/**/*.test.ts',
+      '__tests__/*.test.ts',
     ],
     exclude: ['node_modules', 'dist', '**/node_modules/**', '**/e2e/**', '**/*.integration.test.ts', '**/*-integration.test.ts'],
   },


### PR DESCRIPTION
## Summary

Backfills progressive-disclosure depth on 8 stub skills and adds a CI gate
to prevent future stubs. Closes epic **T9567** (E-SKILLS-DEPTH-BACKFILL,
saga T9560). Each child task is one commit; the PR ships as one unit.

## Children closed

| Task | Skill | Refs added | Commit |
|------|-------|-----------:|--------|
| T9660 | ct-research-agent | 4 | b8e723d78 |
| T9663 | ct-spec-writer | 4 | 036409ac1 |
| T9668 | ct-task-executor | 5 | c42294d82 |
| T9669 | ct-validator | 4 | 1fd047fe9 |
| T9671 | ct-documentor | 4 | 0debf2b54 |
| T9676 | ct-docs-lookup | 3 | 524e437a8 |
| T9680 | ct-docs-write | 3 | 77b584721 |
| T9681 | ct-docs-review | 3 | 981e94ea1 |
| T9684 | ct-skill-validator (CI gate) | — | fb5011575 |

Total: **30 new reference files**, plus the depth-check script,
integration tests, and CI workflow.

## What each skill gained

Every backfilled skill now has:
- A `references/` subdirectory with 3-5 markdown files of genuine,
  topic-specific guidance (no filler).
- A "See references/" footer in `SKILL.md` linking each reference.
- The `references[]` array populated in
  `packages/skills/skills/manifest.json`.

Reference topics were drawn from each skill's actual purpose — triggers,
methodology, evidence, anti-patterns, integration, etc.

## CI gate (T9684)

- `scripts/check_depth.py`: new `progressive-disclosure-depth` rule
  with three pass criteria (body length, references/ files, manifest
  references[]) and an allowlist for 4 pre-existing stubs (each carries
  a follow-up reason).
- `packages/skills/__tests__/depth-check.test.ts`: 4 tests covering
  pass case (gold-standard ct-orchestrator + each T9567-backfilled
  skill), fail case (synthetic stub), and repo-wide sweep.
- `.github/workflows/skills-depth-check.yml`: PR-triggered gate on
  `packages/skills/skills/**`.

## Verification

- `python3 packages/skills/skills/ct-skill-validator/scripts/check_depth.py . --all` → 29 passed, 0 failed.
- `pnpm exec vitest run` in `packages/skills` → 4 test files, 59 tests pass.
- `packages/skills/` is biome-ignored — no lint regressions possible.

## Test plan

- [x] Each backfilled skill passes the new depth rule
- [x] Synthetic stub fails the rule with gold-standard remediation
- [x] Repo-wide sweep shows zero stubs (excluding allowlisted)
- [x] No test regressions in packages/skills/
- [x] Manifest JSON validates
- [ ] CI workflow runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)