### PR TITLE
fix(T9686-B): releaseShow + releaseList read from releases_view SSoT (eliminates dual-table split)

### DIFF
--- a/packages/core/migrations/drizzle-tasks/20260519000000_t9686b-extend-releases-view-union-legacy/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260519000000_t9686b-extend-releases-view-union-legacy/migration.sql
@@ -1,0 +1,203 @@
+-- T9686-B: Extend `releases_view` to UNION the legacy `release_manifests` rows.
+--
+-- Background: prior to this migration `releases_view` was `FROM releases r`
+-- only. Pre-T9492 releases (cut via the old `release prepare`/`ship` pipeline)
+-- live in `release_manifests` and were invisible to the view, so
+-- `cleo release show <legacy-version>` and `cleo release list` had to read
+-- the legacy table directly. That created a dual-source-of-truth: the new
+-- `plan` op wrote `releases`, but consumers read `release_manifests`, so
+-- `plan v2026.5.99 → show v2026.5.99` failed with E_NOT_FOUND even though
+-- the row was correctly upserted.
+--
+-- This migration rebuilds the view as a UNION ALL of:
+--   1. NEW rows from `releases` (T9508 provenance graph) — full provenance.
+--   2. LEGACY rows from `release_manifests` (T5580) — flattened into the
+--      same columns with NULLs where not applicable.
+--
+-- A new `source` column ('new' | 'legacy') lets callers distinguish provenance
+-- when needed. The legacy rows expose empty JSON arrays for the relational
+-- columns (`commits_json`, `changes_json`, `artifacts_json`, `brain_links_json`,
+-- `pr_metadata`) so the row shape is identical.
+--
+-- The view is recreated via DROP+CREATE because SQLite does not support
+-- CREATE OR REPLACE VIEW. Views hold no data, so this is safe.
+--
+-- @task T9686
+-- @epic T9499
+-- @see SPEC-T9345 §3.12
+
+DROP VIEW IF EXISTS `releases_view`;
+--> statement-breakpoint
+CREATE VIEW `releases_view` AS
+-- ── Branch 1: NEW pipeline rows from `releases` ─────────────────────────────
+SELECT
+  r.id                  AS release_id,
+  r.version,
+  r.scheme,
+  r.channel,
+  r.epic_id,
+  r.release_kind,
+  r.status,
+  r.previous_version,
+  r.merge_commit_sha,
+  r.pr_id,
+  r.workflow_run_url,
+  r.created_at,
+  r.planned_at,
+  r.pr_opened_at,
+  r.pr_merged_at,
+  r.published_at,
+  r.reconciled_at,
+  r.rolled_back_at,
+  r.failed_at,
+  r.cancelled_at,
+  r.failure_reason,
+  r.rolled_back_by,
+  r.project_hash,
+  'new'                 AS source,
+
+  -- PR metadata (single PR per release, joined via releases.pr_id).
+  -- Returns a json_object when a PR exists, NULL when pr_id is NULL.
+  CASE
+    WHEN pr.id IS NOT NULL THEN json_object(
+      'id',              pr.id,
+      'pr_number',       pr.pr_number,
+      'title',           pr.title,
+      'state',           pr.state,
+      'base_ref',        pr.base_ref,
+      'head_ref',        pr.head_ref,
+      'author_login',    pr.author_login,
+      'opened_at',       pr.opened_at,
+      'merged_at',       pr.merged_at
+    )
+    ELSE NULL
+  END                   AS pr_metadata,
+
+  -- Commits in this release range (one json_object per release_commits row).
+  (
+    SELECT json_group_array(
+      json_object(
+        'sha',     c.sha,
+        'subject', c.subject,
+        'position', rc.position,
+        'is_first', rc.is_first,
+        'is_last',  rc.is_last
+      )
+    )
+    FROM release_commits rc
+    LEFT JOIN commits c ON c.sha = rc.commit_sha
+    WHERE rc.release_id = r.id
+  )                     AS commits_json,
+
+  -- Release changes (CHANGELOG entries) with linked task info.
+  (
+    SELECT json_group_array(
+      json_object(
+        'id',          rch.id,
+        'task_id',     rch.task_id,
+        'change_type', rch.change_type,
+        'summary',     rch.summary,
+        'impact',      rch.impact,
+        'classified_by', rch.classified_by
+      )
+    )
+    FROM release_changes rch
+    WHERE rch.release_id = r.id
+  )                     AS changes_json,
+
+  -- Artifacts published for this release (npm, cargo, docker, etc.).
+  (
+    SELECT json_group_array(
+      json_object(
+        'artifact_type', ra.artifact_type,
+        'identifier',    ra.identifier,
+        'version',       ra.version,
+        'url',           ra.url,
+        'published_at',  ra.published_at
+      )
+    )
+    FROM release_artifacts ra
+    WHERE ra.release_id = r.id
+  )                     AS artifacts_json,
+
+  -- BRAIN links closing the BRAIN↔release loop.
+  (
+    SELECT json_group_array(
+      json_object(
+        'brain_entry_id', brl.brain_entry_id,
+        'link_type',      brl.link_type,
+        'created_by',     brl.created_by,
+        'created_at',     brl.created_at
+      )
+    )
+    FROM brain_release_links brl
+    WHERE brl.release_id = r.id
+  )                     AS brain_links_json,
+
+  -- Legacy-only columns (NULL for new pipeline rows).
+  NULL                  AS tasks_json,
+  NULL                  AS notes,
+  NULL                  AS changelog,
+  NULL                  AS git_tag,
+  NULL                  AS npm_dist_tag,
+  NULL                  AS prepared_at,
+  NULL                  AS committed_at,
+  NULL                  AS tagged_at,
+  NULL                  AS pushed_at
+
+FROM releases r
+LEFT JOIN pull_requests pr ON pr.id = r.pr_id
+
+UNION ALL
+
+-- ── Branch 2: LEGACY rows from `release_manifests` ──────────────────────────
+-- Only include legacy rows whose version is NOT already present in `releases`.
+-- This prevents duplicate rows when a release was dual-written during the
+-- T9510 dual-write window (CLEO_PROVENANCE_DUAL_WRITE).
+SELECT
+  'legacy:' || rm.id    AS release_id,
+  rm.version,
+  'calver'              AS scheme,
+  -- Map legacy `npm_dist_tag` to channel; fall back to 'latest'.
+  COALESCE(
+    CASE WHEN rm.npm_dist_tag IN ('latest','beta','dev','hotfix') THEN rm.npm_dist_tag END,
+    'latest'
+  )                     AS channel,
+  rm.epic_id,
+  'regular'             AS release_kind,
+  rm.status,
+  rm.previous_version,
+  rm.commit_sha         AS merge_commit_sha,
+  NULL                  AS pr_id,
+  NULL                  AS workflow_run_url,
+  rm.created_at,
+  NULL                  AS planned_at,
+  NULL                  AS pr_opened_at,
+  NULL                  AS pr_merged_at,
+  rm.pushed_at          AS published_at,
+  NULL                  AS reconciled_at,
+  NULL                  AS rolled_back_at,
+  NULL                  AS failed_at,
+  NULL                  AS cancelled_at,
+  NULL                  AS failure_reason,
+  NULL                  AS rolled_back_by,
+  NULL                  AS project_hash,
+  'legacy'              AS source,
+  NULL                  AS pr_metadata,
+  '[]'                  AS commits_json,
+  '[]'                  AS changes_json,
+  '[]'                  AS artifacts_json,
+  '[]'                  AS brain_links_json,
+  rm.tasks_json,
+  rm.notes,
+  rm.changelog,
+  rm.git_tag,
+  rm.npm_dist_tag,
+  rm.prepared_at,
+  rm.committed_at,
+  rm.tagged_at,
+  rm.pushed_at
+FROM release_manifests rm
+WHERE NOT EXISTS (
+  SELECT 1 FROM releases r2 WHERE r2.version = rm.version
+);

--- a/packages/core/migrations/drizzle-tasks/20260519000000_t9686b-extend-releases-view-union-legacy/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260519000000_t9686b-extend-releases-view-union-legacy/revert.sql
@@ -1,0 +1,102 @@
+-- Revert T9686-B view extension. Restore the original new-pipeline-only view.
+-- Views hold no data — recreating the prior shape has no data-loss risk.
+--
+-- @task T9686
+
+DROP VIEW IF EXISTS `releases_view`;
+--> statement-breakpoint
+CREATE VIEW IF NOT EXISTS `releases_view` AS
+SELECT
+  r.id                  AS release_id,
+  r.version,
+  r.scheme,
+  r.channel,
+  r.epic_id,
+  r.release_kind,
+  r.status,
+  r.previous_version,
+  r.merge_commit_sha,
+  r.pr_id,
+  r.workflow_run_url,
+  r.created_at,
+  r.planned_at,
+  r.pr_opened_at,
+  r.pr_merged_at,
+  r.published_at,
+  r.reconciled_at,
+  r.rolled_back_at,
+  r.failed_at,
+  r.cancelled_at,
+  r.failure_reason,
+  r.rolled_back_by,
+  r.project_hash,
+  CASE
+    WHEN pr.id IS NOT NULL THEN json_object(
+      'id',              pr.id,
+      'pr_number',       pr.pr_number,
+      'title',           pr.title,
+      'state',           pr.state,
+      'base_ref',        pr.base_ref,
+      'head_ref',        pr.head_ref,
+      'author_login',    pr.author_login,
+      'opened_at',       pr.opened_at,
+      'merged_at',       pr.merged_at
+    )
+    ELSE NULL
+  END AS pr_metadata,
+  (
+    SELECT json_group_array(
+      json_object(
+        'sha',     c.sha,
+        'subject', c.subject,
+        'position', rc.position,
+        'is_first', rc.is_first,
+        'is_last',  rc.is_last
+      )
+    )
+    FROM release_commits rc
+    LEFT JOIN commits c ON c.sha = rc.commit_sha
+    WHERE rc.release_id = r.id
+  ) AS commits_json,
+  (
+    SELECT json_group_array(
+      json_object(
+        'id',          rch.id,
+        'task_id',     rch.task_id,
+        'change_type', rch.change_type,
+        'summary',     rch.summary,
+        'impact',      rch.impact,
+        'classified_by', rch.classified_by
+      )
+    )
+    FROM release_changes rch
+    WHERE rch.release_id = r.id
+  ) AS changes_json,
+  (
+    SELECT json_group_array(
+      json_object(
+        'artifact_type', ra.artifact_type,
+        'identifier',    ra.identifier,
+        'version',       ra.version,
+        'url',           ra.url,
+        'published_at',  ra.published_at
+      )
+    )
+    FROM release_artifacts ra
+    WHERE ra.release_id = r.id
+  ) AS artifacts_json,
+  (
+    SELECT json_group_array(
+      json_object(
+        'brain_entry_id', brl.brain_entry_id,
+        'link_type',      brl.link_type,
+        'created_by',     brl.created_by,
+        'created_at',     brl.created_at
+      )
+    )
+    FROM brain_release_links brl
+    WHERE brl.release_id = r.id
+  ) AS brain_links_json
+FROM releases r
+LEFT JOIN pull_requests pr ON pr.id = r.pr_id
+GROUP BY r.id;

--- a/packages/core/src/release/__tests__/plan-show-roundtrip.test.ts
+++ b/packages/core/src/release/__tests__/plan-show-roundtrip.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Round-trip regression test for T9686: `cleo release plan v<X>` must make
+ * `cleo release show v<X>` succeed.
+ *
+ * Prior to T9686, `releaseShow` / `releaseList` read from the legacy
+ * `release_manifests` table while `releasePlan` wrote to the new `releases`
+ * table. The dual-source-of-truth caused `show` to return E_NOT_FOUND for
+ * any release that had gone through the new pipeline but never through the
+ * legacy one. This test locks the fix in place: read + write now share
+ * `releases_view` as the single SSoT.
+ *
+ * @task T9686
+ * @epic T9499
+ * @see SPEC-T9345 §3.12
+ */
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Task } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, resetDbState } from '../../store/sqlite.js';
+import { createSqliteDataAccessor } from '../../store/sqlite-data-accessor.js';
+import { releasePlan } from '../plan.js';
+import { listManifestReleases, showManifestRelease } from '../release-manifest.js';
+
+let testDir: string;
+
+/** Build a Task with sensible defaults for plan-time evidence checks. */
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    title: overrides.title ?? `Task ${overrides.id}`,
+    description: overrides.description ?? `Description for ${overrides.id}`,
+    status: overrides.status ?? 'done',
+    priority: overrides.priority ?? 'medium',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    pipelineStage: overrides.pipelineStage ?? 'contribution',
+    verification: overrides.verification ?? {
+      passed: true,
+      round: 1,
+      gates: { implemented: true },
+      evidence: {
+        implemented: {
+          atoms: [{ kind: 'commit', sha: 'abc1234567', shortSha: 'abc1234' }],
+          capturedAt: new Date().toISOString(),
+          capturedBy: 'test-agent',
+        },
+      },
+      lastAgent: null,
+      lastUpdated: new Date().toISOString(),
+      failureLog: [],
+    },
+    ...overrides,
+  } as Task;
+}
+
+async function initTestGit(): Promise<void> {
+  execFileSync('git', ['init', '--quiet', testDir], { encoding: 'utf-8' });
+  execFileSync('git', ['-C', testDir, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', testDir, 'config', 'user.name', 'Test']);
+}
+
+async function seedEpicWithChildren(epicId: string, childCount: number): Promise<void> {
+  const accessor = await createSqliteDataAccessor(testDir);
+  try {
+    await accessor.setMetaValue('schema_version', '2.10.0');
+    await accessor.upsertSingleTask(
+      makeTask({ id: epicId, type: 'epic', title: 'Epic', pipelineStage: 'contribution' }),
+    );
+    for (let i = 1; i <= childCount; i++) {
+      const id = `T${20000 + i}`;
+      await accessor.upsertSingleTask(makeTask({ id, parentId: epicId, title: `Child ${i}` }));
+    }
+  } finally {
+    await accessor.close();
+  }
+}
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'cleo-release-roundtrip-'));
+  await mkdir(join(testDir, '.cleo'), { recursive: true });
+  writeFileSync(
+    join(testDir, '.cleo', 'config.json'),
+    JSON.stringify({
+      enforcement: { session: { requiredForMutate: false } },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+  writeFileSync(
+    join(testDir, '.cleo', 'project-info.json'),
+    JSON.stringify({
+      projectHash: 'testhash00000',
+      projectId: 'test-project-id',
+      projectRoot: testDir,
+      projectName: 'test',
+    }),
+  );
+  await initTestGit();
+  resetDbState();
+});
+
+afterEach(async () => {
+  try {
+    closeDb();
+  } catch {
+    // best-effort
+  }
+  await rm(testDir, { recursive: true, force: true });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T9686 regression lock — plan → show round-trip
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('T9686 — release plan → show round-trip (SSoT regression lock)', () => {
+  it('`cleo release plan v<X>` then `cleo release show v<X>` succeeds without E_NOT_FOUND', async () => {
+    await seedEpicWithChildren('T20000', 2);
+
+    const planResult = await releasePlan({
+      version: 'v2026.7.0',
+      epicId: 'T20000',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      createdBy: 'roundtrip-test',
+    });
+
+    expect(planResult.success).toBe(true);
+    if (!planResult.success) throw new Error('plan failed');
+    expect(planResult.data.resolvedVersion).toBe('v2026.7.0');
+
+    // show MUST find the release the plan just wrote. Pre-T9686 this threw
+    // 'Release v2026.7.0 not found' because show read the legacy table.
+    const manifest = await showManifestRelease('v2026.7.0', testDir);
+    expect(manifest.version).toBe('v2026.7.0');
+    expect(manifest.status).toBe('planned');
+    expect(manifest.source).toBe('new');
+    // Task list is projected from `release_changes.task_id` for new-pipeline
+    // rows. Plan does not populate release_changes yet (that's reconcile's
+    // job), so for a freshly-planned release the tasks array MAY be empty.
+    // Just assert it is well-formed.
+    expect(Array.isArray(manifest.tasks)).toBe(true);
+  });
+
+  it('`cleo release list` shows new-pipeline rows alongside any legacy rows', async () => {
+    await seedEpicWithChildren('T20000', 1);
+
+    await releasePlan({
+      version: 'v2026.7.1',
+      epicId: 'T20000',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      createdBy: 'roundtrip-test',
+    });
+
+    const list = await listManifestReleases(undefined, testDir);
+    expect(list.total).toBe(1);
+    expect(list.filtered).toBe(1);
+    const found = list.releases.find((r) => r.version === 'v2026.7.1');
+    expect(found).toBeDefined();
+    expect(found?.status).toBe('planned');
+    expect(found?.source).toBe('new');
+  });
+
+  it('idempotent plan re-run does not duplicate the row in the SSoT view', async () => {
+    await seedEpicWithChildren('T20000', 1);
+
+    // First plan
+    const first = await releasePlan({
+      version: 'v2026.7.2',
+      epicId: 'T20000',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      createdBy: 'roundtrip-test',
+    });
+    expect(first.success).toBe(true);
+
+    // Second plan with the same args — UPSERT no-op modulo timestamps.
+    const second = await releasePlan({
+      version: 'v2026.7.2',
+      epicId: 'T20000',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      createdBy: 'roundtrip-test',
+    });
+    expect(second.success).toBe(true);
+
+    const list = await listManifestReleases(undefined, testDir);
+    const matches = list.releases.filter((r) => r.version === 'v2026.7.2');
+    expect(matches).toHaveLength(1);
+  });
+
+  it('show throws when the version is absent from BOTH the new and legacy tables', async () => {
+    await expect(showManifestRelease('v9999.999.999', testDir)).rejects.toThrow(
+      /v9999\.999\.999 not found/,
+    );
+  });
+});

--- a/packages/core/src/release/release-manifest.ts
+++ b/packages/core/src/release/release-manifest.ts
@@ -12,9 +12,15 @@ import { execFileSync } from 'node:child_process';
 import { appendFileSync, existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { and, count, desc, eq, sql } from 'drizzle-orm';
+import { desc, eq, sql } from 'drizzle-orm';
 import { createPage } from '../pagination.js';
 import { getCleoDirAbsolute, getProjectRoot } from '../paths.js';
+import {
+  countReleasesView,
+  findReleaseViewByVersion,
+  queryReleasesView,
+  type ReleasesViewRow,
+} from '../store/releases-view.js';
 import * as schema from '../store/tasks-schema.js';
 import { parseChangelogBlocks, writeChangelogSection } from './changelog-writer.js';
 import type { ReleaseChannel } from './channel.js';
@@ -112,10 +118,38 @@ async function getDb(cwd?: string): ReturnType<typeof import('../store/sqlite.js
 
 // ── Types ────────────────────────────────────────────────────────────
 
+/**
+ * Status values exposed through the `releases_view` SSoT.
+ *
+ * Legacy pipeline (T5580 / `release_manifests`): `draft | prepared | committed
+ * | tagged | pushed | rolled_back`. New pipeline (T9508 / `releases`): `planned
+ * | pr-opened | pr-merged | published | reconciled | rolled_back | failed |
+ * cancelled`. Consumers MUST handle both — the field is widened intentionally
+ * so the show/list surface can render rows from either branch of the view.
+ *
+ * @task T9686
+ */
+export type ReleaseManifestStatus =
+  // legacy statuses
+  | 'draft'
+  | 'prepared'
+  | 'committed'
+  | 'tagged'
+  | 'pushed'
+  | 'rolled_back'
+  // new pipeline statuses
+  | 'planned'
+  | 'pr-opened'
+  | 'pr-merged'
+  | 'published'
+  | 'reconciled'
+  | 'failed'
+  | 'cancelled';
+
 /** Release manifest structure. */
 export interface ReleaseManifest {
   version: string;
-  status: 'draft' | 'prepared' | 'committed' | 'tagged' | 'pushed' | 'rolled_back';
+  status: ReleaseManifestStatus;
   createdAt: string;
   preparedAt?: string;
   committedAt?: string;
@@ -127,6 +161,18 @@ export interface ReleaseManifest {
   previousVersion?: string;
   commitSha?: string;
   gitTag?: string;
+  /**
+   * Provenance discriminator added by T9686.
+   *
+   * - `'new'` — row came from the `releases` table (new pipeline).
+   * - `'legacy'` — row came from the `release_manifests` table (pre-T9492).
+   *
+   * Callers that only care about the legacy shape can ignore this field; it is
+   * always populated by reads through `releases_view`.
+   *
+   * @task T9686
+   */
+  source?: 'new' | 'legacy';
 }
 
 export interface ReleaseListOptions {
@@ -219,22 +265,65 @@ function normalizeVersion(version: string): string {
   return version.startsWith('v') ? version : `v${version}`;
 }
 
-function rowToManifest(row: schema.ReleaseManifestRow): ReleaseManifest {
-  return {
+/**
+ * Project a {@link ReleasesViewRow} (unified SSoT row from `releases_view`)
+ * down to a {@link ReleaseManifest} shape. Used by `releaseShow` /
+ * `releaseList` so CLI consumers see a single shape regardless of whether
+ * the row originated from the new `releases` table or the legacy
+ * `release_manifests` table (T9686).
+ *
+ * Field-mapping notes:
+ * - `tasks` — parsed from `tasksJson` for legacy rows; for new-pipeline rows
+ *   the corresponding data lives in `release_changes` and is exposed via
+ *   `row.changes[*].task_id`. We project that to a deduplicated id list so
+ *   the `taskCount` reported by list endpoints stays meaningful.
+ * - `commitSha` — comes from `merge_commit_sha` in the view (new pipeline)
+ *   or from the legacy `commit_sha` column (legacy pipeline). The view
+ *   normalizes both into `mergeCommitSha`.
+ * - `pushedAt` — for legacy rows, projected from `pushed_at`; for new-pipeline
+ *   rows we fall back to `publishedAt` so list endpoints can still sort by
+ *   ship time.
+ *
+ * @task T9686
+ * @internal
+ */
+function viewRowToManifest(row: ReleasesViewRow): ReleaseManifest {
+  const isLegacy = row.source === 'legacy';
+  const tasks: string[] = (() => {
+    if (isLegacy && row.tasksJson) {
+      try {
+        const parsed = JSON.parse(row.tasksJson) as unknown;
+        return Array.isArray(parsed) ? (parsed as string[]) : [];
+      } catch {
+        return [];
+      }
+    }
+    const ids = row.changes
+      .map((c) => c.task_id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    return [...new Set(ids)];
+  })();
+
+  const manifest: ReleaseManifest = {
     version: row.version,
-    status: row.status as ReleaseManifest['status'],
+    status: row.status as ReleaseManifestStatus,
     createdAt: row.createdAt,
-    preparedAt: row.preparedAt ?? undefined,
-    committedAt: row.committedAt ?? undefined,
-    taggedAt: row.taggedAt ?? undefined,
-    pushedAt: row.pushedAt ?? undefined,
-    tasks: JSON.parse(row.tasksJson) as string[],
-    notes: row.notes ?? undefined,
-    changelog: row.changelog ?? undefined,
-    previousVersion: row.previousVersion ?? undefined,
-    commitSha: row.commitSha ?? undefined,
-    gitTag: row.gitTag ?? undefined,
+    tasks,
+    source: row.source,
   };
+  if (row.preparedAt) manifest.preparedAt = row.preparedAt;
+  if (row.committedAt) manifest.committedAt = row.committedAt;
+  if (row.taggedAt) manifest.taggedAt = row.taggedAt;
+  // For new-pipeline rows, expose publishedAt as pushedAt so callers that
+  // sort by "ship time" don't have to special-case the row source.
+  const effectivePushedAt = row.pushedAt ?? row.publishedAt;
+  if (effectivePushedAt) manifest.pushedAt = effectivePushedAt;
+  if (row.notes) manifest.notes = row.notes;
+  if (row.changelog) manifest.changelog = row.changelog;
+  if (row.previousVersion) manifest.previousVersion = row.previousVersion;
+  if (row.mergeCommitSha) manifest.commitSha = row.mergeCommitSha;
+  if (row.gitTag) manifest.gitTag = row.gitTag;
+  return manifest;
 }
 
 interface LatestPushedVersion {
@@ -642,14 +731,28 @@ export async function generateReleaseChangelog(
 }
 
 /**
- * List all releases.
+ * List all releases via the SSoT `releases_view` (T9686).
+ *
+ * Reads from the unified view that UNIONs `releases` (new pipeline) and
+ * `release_manifests` (legacy), so a release planned via `cleo release plan`
+ * is immediately visible alongside historical pre-T9492 releases. The
+ * previous implementation read only `release_manifests` and silently dropped
+ * any release that had only been written through the new pipeline.
+ *
  * @task T4788
+ * @task T9686
  */
 export async function listManifestReleases(
   optionsOrCwd?: ReleaseListOptions | string,
   cwd?: string,
 ): Promise<{
-  releases: Array<{ version: string; status: string; createdAt: string; taskCount: number }>;
+  releases: Array<{
+    version: string;
+    status: string;
+    createdAt: string;
+    taskCount: number;
+    source?: 'new' | 'legacy';
+  }>;
   total: number;
   filtered: number;
   latest?: string;
@@ -663,43 +766,30 @@ export async function listManifestReleases(
   const pageLimit = effectivePageLimit(limit, offset);
 
   const db = await getDb(effectiveCwd);
-  const totalRow = await db.select({ count: count() }).from(schema.releaseManifests).get();
-  const total = totalRow?.count ?? 0;
 
-  const conditions = options.status ? [eq(schema.releaseManifests.status, options.status)] : [];
-  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+  const total = countReleasesView(db);
+  const filtered = countReleasesView(db, options.status ? { status: options.status } : {});
 
-  const filteredRow = await db
-    .select({ count: count() })
-    .from(schema.releaseManifests)
-    .where(whereClause)
-    .get();
-  const filtered = filteredRow?.count ?? 0;
+  const queryOptions: Parameters<typeof queryReleasesView>[1] = {};
+  if (options.status !== undefined) queryOptions.status = options.status;
+  if (pageLimit !== undefined) queryOptions.limit = pageLimit;
+  if (offset !== undefined) queryOptions.offset = offset;
 
-  let query = db
-    .select()
-    .from(schema.releaseManifests)
-    .where(whereClause)
-    .orderBy(desc(schema.releaseManifests.createdAt));
-
-  if (pageLimit !== undefined) {
-    query = query.limit(pageLimit) as typeof query;
-  }
-  if (offset !== undefined) {
-    query = query.offset(offset) as typeof query;
-  }
-
-  const rows = await query.all();
+  const viewRows = await queryReleasesView(db, queryOptions);
 
   const latest = await findLatestPushedVersion(effectiveCwd);
 
   return {
-    releases: rows.map((r) => ({
-      version: r.version,
-      status: r.status,
-      createdAt: r.createdAt,
-      taskCount: (JSON.parse(r.tasksJson) as string[]).length,
-    })),
+    releases: viewRows.map((row) => {
+      const manifest = viewRowToManifest(row);
+      return {
+        version: manifest.version,
+        status: manifest.status,
+        createdAt: manifest.createdAt,
+        taskCount: manifest.tasks.length,
+        source: row.source,
+      };
+    }),
     total,
     filtered,
     latest: latest?.version,
@@ -708,8 +798,15 @@ export async function listManifestReleases(
 }
 
 /**
- * Show release details.
+ * Show release details via the SSoT `releases_view` (T9686).
+ *
+ * Reads from the unified view so a release planned via `cleo release plan`
+ * is immediately visible (round-trip: `plan v<X> → show v<X>` succeeds).
+ * Falls through both pipeline branches; throws when the version is absent
+ * from BOTH `releases` and `release_manifests`.
+ *
  * @task T4788
+ * @task T9686
  */
 export async function showManifestRelease(version: string, cwd?: string): Promise<ReleaseManifest> {
   if (!version) {
@@ -718,18 +815,13 @@ export async function showManifestRelease(version: string, cwd?: string): Promis
 
   const normalizedVersion = normalizeVersion(version);
   const db = await getDb(cwd);
-  const rows = await db
-    .select()
-    .from(schema.releaseManifests)
-    .where(eq(schema.releaseManifests.version, normalizedVersion))
-    .limit(1)
-    .all();
+  const row = await findReleaseViewByVersion(db, normalizedVersion);
 
-  if (rows.length === 0) {
+  if (row === null) {
     throw new Error(`Release ${normalizedVersion} not found`);
   }
 
-  return rowToManifest(rows[0]!);
+  return viewRowToManifest(row);
 }
 
 /**

--- a/packages/core/src/store/releases-view.ts
+++ b/packages/core/src/store/releases-view.ts
@@ -125,11 +125,23 @@ interface ReleasesViewRawRow {
   failure_reason: string | null;
   rolled_back_by: string | null;
   project_hash: string | null;
+  /** Provenance discriminator — 'new' (from `releases`) or 'legacy' (from `release_manifests`). */
+  source: 'new' | 'legacy';
   pr_metadata: string | null;
   commits_json: string | null;
   changes_json: string | null;
   artifacts_json: string | null;
   brain_links_json: string | null;
+  // Legacy-only columns surfaced by the T9686-B view union. NULL on `new` rows.
+  tasks_json: string | null;
+  notes: string | null;
+  changelog: string | null;
+  git_tag: string | null;
+  npm_dist_tag: string | null;
+  prepared_at: string | null;
+  committed_at: string | null;
+  tagged_at: string | null;
+  pushed_at: string | null;
 }
 
 // ── Public output type ─────────────────────────────────────────────────────────
@@ -189,6 +201,20 @@ export interface ReleasesViewRow {
   rolledBackBy: string | null;
   /** Project hash for multi-repo installs. */
   projectHash: string | null;
+  /**
+   * Provenance discriminator for the row.
+   *
+   * - `'new'` — row originates from the `releases` table (T9508 provenance graph).
+   * - `'legacy'` — row originates from the `release_manifests` table (T5580 / pre-T9492).
+   *
+   * Callers that need full provenance arrays (`commits`, `changes`, `artifacts`,
+   * `brainLinks`) should check `source === 'new'`; legacy rows return empty
+   * arrays for those columns because the relational tables don't exist for
+   * pre-T9492 releases.
+   *
+   * @task T9686
+   */
+  source: 'new' | 'legacy';
   /** PR metadata. Null when no PR is associated. */
   pr: ReleasesViewPr | null;
   /** Commits included in this release range. Empty array when none are linked. */
@@ -199,6 +225,30 @@ export interface ReleasesViewRow {
   artifacts: ReleasesViewArtifact[];
   /** BRAIN knowledge links. Empty array when none are recorded. */
   brainLinks: ReleasesViewBrainLink[];
+  /**
+   * Legacy task ID list from `release_manifests.tasks_json`. Null on `new` rows.
+   * Parsed lazily by consumers — kept as JSON string here so callers that don't
+   * need it pay no parsing cost.
+   *
+   * @task T9686
+   */
+  tasksJson: string | null;
+  /** Free-form notes (legacy `release_manifests.notes`). Null on `new` rows. */
+  notes: string | null;
+  /** CHANGELOG body (legacy `release_manifests.changelog`). Null on `new` rows. */
+  changelog: string | null;
+  /** Git tag string (legacy `release_manifests.git_tag`). Null on `new` rows. */
+  gitTag: string | null;
+  /** npm dist-tag (legacy `release_manifests.npm_dist_tag`). Null on `new` rows. */
+  npmDistTag: string | null;
+  /** Legacy `prepared_at` timestamp (status='prepared'). Null on `new` rows. */
+  preparedAt: string | null;
+  /** Legacy `committed_at` timestamp (status='committed'). Null on `new` rows. */
+  committedAt: string | null;
+  /** Legacy `tagged_at` timestamp (status='tagged'). Null on `new` rows. */
+  taggedAt: string | null;
+  /** Legacy `pushed_at` timestamp (status='pushed'). Null on `new` rows. */
+  pushedAt: string | null;
 }
 
 // ── JSON parse helpers ─────────────────────────────────────────────────────────
@@ -256,11 +306,21 @@ function mapRawRow(raw: ReleasesViewRawRow): ReleasesViewRow {
     failureReason: raw.failure_reason,
     rolledBackBy: raw.rolled_back_by,
     projectHash: raw.project_hash,
+    source: raw.source,
     pr: parsePrMetadata(raw.pr_metadata),
     commits: parseJsonArray<ReleasesViewCommit>(raw.commits_json),
     changes: parseJsonArray<ReleasesViewChange>(raw.changes_json),
     artifacts: parseJsonArray<ReleasesViewArtifact>(raw.artifacts_json),
     brainLinks: parseJsonArray<ReleasesViewBrainLink>(raw.brain_links_json),
+    tasksJson: raw.tasks_json,
+    notes: raw.notes,
+    changelog: raw.changelog,
+    gitTag: raw.git_tag,
+    npmDistTag: raw.npm_dist_tag,
+    preparedAt: raw.prepared_at,
+    committedAt: raw.committed_at,
+    taggedAt: raw.tagged_at,
+    pushedAt: raw.pushed_at,
   };
 }
 
@@ -315,7 +375,7 @@ export interface ReleasesViewOptions {
  * @task T9510
  */
 export async function queryReleasesView(
-  db: NodeSQLiteDatabase,
+  db: NodeSQLiteDatabase<Record<string, unknown>>,
   options: ReleasesViewOptions = {},
 ): Promise<ReleasesViewRow[]> {
   const { status, channel, limit, offset } = options;
@@ -339,4 +399,60 @@ export async function queryReleasesView(
 
   const rawRows = db.all(sql.raw(query)) as ReleasesViewRawRow[];
   return rawRows.map(mapRawRow);
+}
+
+/**
+ * Look up a single release row by version string. Returns `null` when the
+ * version is not present in either branch of `releases_view`.
+ *
+ * Used by `cleo release show <version>` as the SSoT lookup that bridges
+ * both the new `releases` table (T9508) and the legacy `release_manifests`
+ * table (T5580). Eliminates the dual-table split that caused E_NOT_FOUND
+ * after `cleo release plan` (T9686).
+ *
+ * @example
+ * ```ts
+ * const row = await findReleaseViewByVersion(db, 'v2026.5.99');
+ * if (row === null) {
+ *   throw new Error('release not found');
+ * }
+ * ```
+ *
+ * @task T9686
+ */
+export async function findReleaseViewByVersion(
+  db: NodeSQLiteDatabase<Record<string, unknown>>,
+  version: string,
+): Promise<ReleasesViewRow | null> {
+  const escaped = version.replace(/'/g, "''");
+  const query = `SELECT * FROM releases_view WHERE version = '${escaped}' LIMIT 1`;
+  const rawRows = db.all(sql.raw(query)) as ReleasesViewRawRow[];
+  const first = rawRows[0];
+  if (first === undefined) return null;
+  return mapRawRow(first);
+}
+
+/**
+ * Count rows in `releases_view`, optionally filtered by status / channel.
+ * Mirrors the predicate shape of {@link queryReleasesView} so list endpoints
+ * can render an accurate `total` alongside a paginated slice.
+ *
+ * @task T9686
+ */
+export function countReleasesView(
+  db: NodeSQLiteDatabase<Record<string, unknown>>,
+  filter: { status?: string; channel?: string } = {},
+): number {
+  const conditions: string[] = [];
+  if (filter.status !== undefined) {
+    conditions.push(`status = '${filter.status.replace(/'/g, "''")}'`);
+  }
+  if (filter.channel !== undefined) {
+    conditions.push(`channel = '${filter.channel.replace(/'/g, "''")}'`);
+  }
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  const row = db.get(sql.raw(`SELECT COUNT(*) AS n FROM releases_view ${whereClause}`)) as
+    | { n: number }
+    | undefined;
+  return row?.n ?? 0;
 }


### PR DESCRIPTION
## Summary

- **Bug**: `cleo release plan v<X>` correctly upserts into the new `releases` table, but `cleo release show v<X>` and `cleo release list` read from the legacy `release_manifests` table — a dual-source-of-truth that returned `E_NOT_FOUND` for any release that had gone through the new pipeline but never through the legacy one.
- **Fix**: Both reads now route through `releases_view`. The view (originally added by T9510 for new-pipeline rows only) is extended via a new migration to UNION ALL the legacy `release_manifests`, exposing a stable column set with a `source: 'new' | 'legacy'` discriminator.
- **Regression lock**: `plan-show-roundtrip.test.ts` (4 tests, all green) makes `plan v<X> → show v<X>` an explicit invariant.

## Investigation note

The original brief asked me to "make `cleo release plan` insert into the `releases` table" — but plan.ts already did that correctly (verified by code read + live repro + existing test at `plan.test.ts:154`). The actual root cause was that the consumers (`show`/`list`) read from the wrong table. Team lead approved scope expansion to Option C (use `releases_view`) after I reported the misdiagnosis.

## Test plan

- [x] `plan-show-roundtrip.test.ts` (4 tests) pass
- [x] `plan.test.ts` (12 tests) pass — existing release.plan tests unaffected
- [x] `releases-view.test.ts` (existing) pass — view contract preserved
- [x] Wider `pnpm --filter @cleocode/core test src/release/` — 212 passed, 4 failures are pre-existing flake in `dual-write-regression.test.ts` (vitest 60s hook timeout + TDZ on `_nativeDb`, both unrelated to this change — verified by direct migration timing test showing my migration runs in <2s and the view is created correctly)
- [x] Typecheck — only 2 pre-existing errors remain (`plan.ts:178`, `req.ts:352`), both predate this branch (commit 2146f8b42)
- [x] Biome check — clean after auto-fix on imports ordering

## Out of scope

- Backfilling pre-T9492 tagged releases (v5.82, v5.83) into either table — handled by the provenance-backfill agent (Group C).
- Refactoring the other consumers of `release_manifests` (e.g. `releaseCommit`, `releaseTag`) to also route through the view — those write the legacy state machine and don't share `show`/`list`'s read pattern.

## Files

- `packages/core/migrations/drizzle-tasks/20260519000000_t9686b-extend-releases-view-union-legacy/migration.sql` — extends view
- `packages/core/migrations/drizzle-tasks/20260519000000_t9686b-extend-releases-view-union-legacy/revert.sql` — restores prior view
- `packages/core/src/store/releases-view.ts` — adds `findReleaseViewByVersion`, `countReleasesView`, widens row type with `source` + 9 legacy columns
- `packages/core/src/release/release-manifest.ts` — `showManifestRelease` + `listManifestReleases` now use the view via `viewRowToManifest`; `ReleaseManifest.status` widened to cover both enums
- `packages/core/src/release/__tests__/plan-show-roundtrip.test.ts` — new regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)