### PR TITLE
fix(T9686-A): IVTR dispatch + envelope bugs (pr-status, changelog, reconcile wrap, worktree help text)

### DIFF
--- a/packages/cleo/src/cli/commands/release.ts
+++ b/packages/cleo/src/cli/commands/release.ts
@@ -516,8 +516,26 @@ const reconcileCommand = defineCommand({
       fromWorkflow: args['from-workflow'] === true,
       rollback: args.rollback === true,
     });
-    cliOutput(result, { command: 'release', operation: 'release.reconcile' });
-    if (!result.success) process.exit(1);
+    // releaseReconcileV2 returns an EngineResult discriminated union
+    // ({success:true,data} | {success:false,error}). Passing the union
+    // directly to cliOutput would double-wrap into {success:true,
+    // data:{success:false,error}}. Unwrap to surface the inner result
+    // as the canonical CLI envelope (T9686-A bug A3).
+    if (result.success) {
+      cliOutput(result.data, { command: 'release', operation: 'release.reconcile' });
+      return;
+    }
+    cliError(
+      result.error.message,
+      result.error.code,
+      {
+        name: result.error.code,
+        ...(result.error.details ? { details: result.error.details } : {}),
+        ...(result.error.fix ? { fix: result.error.fix } : {}),
+      },
+      { operation: 'release.reconcile' },
+    );
+    process.exit(1);
   },
 });
 

--- a/packages/cleo/src/cli/commands/release.ts
+++ b/packages/cleo/src/cli/commands/release.ts
@@ -28,7 +28,7 @@
 import { release } from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
-import { cliOutput } from '../renderers/index.js';
+import { cliError, cliOutput } from '../renderers/index.js';
 
 /**
  * Deprecation notice emitted to stderr by {@link shipCommand} per
@@ -192,18 +192,44 @@ const changelogCommand = defineCommand({
     description: 'Generate CHANGELOG from git log since a given tag, with task/epic grouping',
   },
   args: {
+    sinceTag: {
+      type: 'positional',
+      description: 'Git tag or ref to generate changelog from (e.g. v2026.4.75)',
+      required: false,
+    },
     since: {
       type: 'string',
-      description: 'Git tag or ref to generate changelog from (e.g. v2026.4.75)',
-      required: true,
+      description:
+        'Git tag or ref to generate changelog from (e.g. v2026.4.75). Alias for the positional argument.',
+      required: false,
     },
   },
   async run({ args }) {
+    // Accept either `cleo release changelog v2026.5.81` (positional, matches
+    // pr-status / show / cancel) or the legacy `--since v...` flag. Emit a
+    // LAFS envelope on missing input rather than letting citty dump help
+    // text to stderr (T9686-A bug A2).
+    const sinceTag =
+      typeof args['sinceTag'] === 'string' && args['sinceTag'].length > 0
+        ? args['sinceTag']
+        : typeof args['since'] === 'string' && args['since'].length > 0
+          ? args['since']
+          : undefined;
+    if (sinceTag === undefined) {
+      cliError(
+        'Missing required argument: <sinceTag> (or --since)',
+        2,
+        { name: 'E_MISSING_ARGUMENT', fix: 'Run: cleo release changelog <tag>' },
+        { operation: 'release.changelog.since' },
+      );
+      process.exit(2);
+      return;
+    }
     await dispatchFromCli(
       'query',
       'pipeline',
       'release.changelog.since',
-      { sinceTag: args.since },
+      { sinceTag },
       { command: 'release' },
     );
   },

--- a/packages/cleo/src/cli/commands/worktree.ts
+++ b/packages/cleo/src/cli/commands/worktree.ts
@@ -355,7 +355,13 @@ export const worktreeCommand = defineCommand({
     prune: pruneCommand,
     'force-unlock': forceUnlockCommand,
   },
-  async run() {
-    await showUsage(worktreeCommand as Parameters<typeof showUsage>[0]);
+  // Early-return when a subcommand was matched; citty still invokes the
+  // parent run() after the subcommand finishes which would otherwise
+  // append the help text to the subcommand's JSON envelope output
+  // (T9686-A bug A4).
+  async run({ cmd, rawArgs }) {
+    const firstArg = rawArgs?.find((a) => !a.startsWith('-'));
+    if (firstArg && cmd.subCommands && firstArg in cmd.subCommands) return;
+    await showUsage(cmd as Parameters<typeof showUsage>[0]);
   },
 });

--- a/packages/cleo/src/dispatch/domains/__tests__/registry-parity.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/registry-parity.test.ts
@@ -207,6 +207,10 @@ vi.mock('../../lib/engine.js', () => {
     releaseRollback: mockFn(),
     releaseCancel: mockFn(),
     releasePush: mockFn(),
+    // T9686-A bug A1 — pr-status engine function (was already in the engine
+    // barrel but missing from the parity-test mock — the missing registry
+    // entry hid this gap).
+    releasePrStatus: mockFn(),
     // releaseShip removed in T9540 (Phase 6 of T9499)
     // Template parser
     parseIssueTemplates: mockFn(),
@@ -632,6 +636,8 @@ const MINIMAL_PARAMS: Record<string, Record<string, Record<string, unknown>>> = 
     'release.show': { version: '1.0.0' },
     'release.rollback': { version: '1.0.0' },
     'release.cancel': { version: '1.0.0' },
+    // T9686-A — bug A1: queryOps + registry entry must both list this op.
+    'release.pr-status': { version: '1.0.0' },
     'manifest.show': { entryId: 'e1' },
     'manifest.find': { query: 'test' },
     'manifest.append': { entry: { id: 'e1', type: 'finding', content: 'x' } },

--- a/packages/cleo/src/dispatch/domains/pipeline.ts
+++ b/packages/cleo/src/dispatch/domains/pipeline.ts
@@ -889,6 +889,7 @@ export class PipelineHandler implements DomainHandler {
       'release.show',
       'release.channel.show',
       'release.changelog.since',
+      'release.pr-status',
       'phase.show',
       'phase.list',
       'chain.show',

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -3641,6 +3641,26 @@ export const OPERATIONS: OperationDef[] = [
       },
     ] satisfies ParamDef[],
   },
+  {
+    gateway: 'query',
+    domain: 'pipeline',
+    operation: 'release.pr-status',
+    description:
+      'Poll GitHub CI check statuses for the open release PR matching release/v<version> (T9095)',
+    tier: 1,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: ['version'],
+    params: [
+      {
+        name: 'version',
+        type: 'string',
+        required: true,
+        description: 'Release version (e.g. 2026.5.43 or v2026.5.43)',
+        cli: { positional: true },
+      },
+    ] satisfies ParamDef[],
+  },
   // release.prepare/changelog/commit/tag/push/gates.run removed — merged into release.ship via step param (T5615)
   {
     gateway: 'mutate',


### PR DESCRIPTION
## Summary

Four independent dispatch/envelope bugs in the v5.83 IVTR release surface, each fixed in its own commit:

- **A1 — `cleo release pr-status`** returned `E_INVALID_OPERATION` for `query:pipeline.release.pr-status`. Missing registry entry AND missing entry in `PipelineHandler.query()` `queryOps` allow-list. Added both, plus parity-test wiring.
- **A2 — `cleo release changelog v...`** emitted citty help text to stderr with no JSON envelope when given a bare positional argument. `since` was `required:true`, so citty bailed before our `run()` could emit. Now accepts the tag as a positional (matches sibling `release show v...`, `release pr-status v...`), keeps `--since` as a backwards-compat alias, and emits a canonical LAFS error envelope on missing input.
- **A3 — `cleo release reconcile v...`** double-wrapped: `{success:true, data:{success:false, error:{...}}}`. The handler passed the raw `EngineResult` discriminated union into `cliOutput()`, which already wraps its arg as `data`. Unwrapped — success branch passes `result.data`, failure branch routes through `cliError()` forwarding `code`/`details`/`fix` faithfully.
- **A4 — `cleo worktree list / prune`** appended ANSI-colored citty help text to stdout AFTER the subcommand's JSON envelope, breaking JSON consumers. `worktreeCommand.run()` unconditionally called `showUsage()`. Mirrored the early-return pattern already used by `releaseCommand.run()`: if `rawArgs` names a registered subcommand, return without printing usage.

## Test plan

- [x] A1 — `cleo release pr-status v2026.5.82` returns a single-layer LAFS envelope (`meta.operation = "pipeline.release.pr-status"`).
- [x] A2 — `cleo release changelog` (no arg) emits `{success:false, error.code:"E_MISSING_ARGUMENT", meta.operation:"release.changelog.since"}`. `cleo release changelog v2026.5.81` returns the generated changelog in `data.changelog`.
- [x] A3 — `cleo release reconcile v2026.5.82` returns a single-layer envelope (no `data.success` field on failure; the inner failure IS the outer failure).
- [x] A4 — `cleo worktree prune --orphaned --dry-run` stdout is parseable JSON end-to-end; no trailing help text after the envelope.
- [x] `pnpm --filter @cleocode/cleo run build` (tsc) passes.
- [x] `pnpm biome check` passes for all touched files.
- [ ] CI green on registry-parity test (now also covers `release.pr-status`).

## Files touched

- `packages/cleo/src/dispatch/registry.ts` — add `pipeline.release.pr-status` query op (A1).
- `packages/cleo/src/dispatch/domains/pipeline.ts` — add `release.pr-status` to the `queryOps` allow-list (A1).
- `packages/cleo/src/dispatch/domains/__tests__/registry-parity.test.ts` — wire `release.pr-status` into MINIMAL_PARAMS + mock the engine fn (A1).
- `packages/cleo/src/cli/commands/release.ts` — add positional + `cliError` for `changelog` (A2); unwrap EngineResult for `reconcile` (A3).
- `packages/cleo/src/cli/commands/worktree.ts` — early-return parent `run()` when subcommand matched (A4).