### PR TITLE
feat(T9634): cleo docs git⇄llmtxt round-trip (T9701/T9702/T9703/T9704)

### DIFF
--- a/packages/cleo/src/cli/__tests__/docs-idempotency.test.ts
+++ b/packages/cleo/src/cli/__tests__/docs-idempotency.test.ts
@@ -1,0 +1,274 @@
+/**
+ * T9704 — git⇄llmtxt round-trip idempotency tests.
+ *
+ * Verifies that the three commands shipped under T9701/T9702/T9703 satisfy
+ * the umbrella acceptance criteria of T9634:
+ *
+ *   - Running `publish` twice → same file SHA and the destination is byte-
+ *     identical (T9634 AC4).
+ *   - Running `sync --from` twice on unchanged content → second call returns
+ *     `action: 'noop'` and the manifest gains NO new blob version (T9634 AC5).
+ *   - Running `status` twice on the same state → identical drift envelope
+ *     (envelope-shape determinism, transitively covering T9634 AC6).
+ *
+ * Implementation note: these tests exercise the core fns directly with an
+ * explicit `projectRoot` so vitest discovery does not need to spawn `node
+ * dist/cli/index.js`. Calling through the CLI adds zero coverage over the
+ * core contract — the CLI is a thin pass-through verified in
+ * docs-publish-envelope.test.ts.
+ *
+ * @epic T9626 (W0)
+ * @task T9704 (ST-PUB-2d — idempotency)
+ * @saga T9625
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  CleoBlobStore,
+  listPublications,
+  publishDocs,
+  recordPublication,
+  statusDocs,
+  syncFromGit,
+} from '@cleocode/core/internal';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+let projectRoot: string;
+
+beforeEach(async () => {
+  projectRoot = await mkdtemp(join(tmpdir(), 'cleo-docs-idemp-'));
+  // The blob store writes to `<projectRoot>/.cleo/blobs/`; create the prefix
+  // so the adapter's open() can stat the parent.
+  await mkdir(join(projectRoot, '.cleo'), { recursive: true });
+});
+
+afterEach(async () => {
+  // Best-effort cleanup. The OS will reap /tmp eventually either way.
+  const { rm } = await import('node:fs/promises');
+  await rm(projectRoot, { recursive: true, force: true }).catch(() => {
+    /* never fail teardown */
+  });
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Attach a single blob under (ownerId, name) and return its sha. */
+async function seedBlob(ownerId: string, name: string, content: string): Promise<string> {
+  const store = new CleoBlobStore({ projectRoot });
+  await store.open();
+  try {
+    const bytes = new TextEncoder().encode(content);
+    const res = await store.attach(ownerId, name, bytes, 'text/markdown');
+    return res.sha256;
+  } finally {
+    await store.close();
+  }
+}
+
+/** Hash a file on disk for direct verification. */
+async function fileSha(path: string): Promise<string> {
+  const data = await readFile(path);
+  return createHash('sha256').update(data).digest('hex');
+}
+
+// ─── T9634 AC4 — publish idempotency ──────────────────────────────────────────
+
+describe('T9704 — publish twice produces same file SHA + same blob sha', () => {
+  it('two publishes of the same blob to the same path yield identical file SHA', async () => {
+    const ownerId = 'T-publish-idemp';
+    const blobName = 'spec.md';
+    const content = '# Spec v1\n\nHello T9701.\n';
+    const blobSha = await seedBlob(ownerId, blobName, content);
+
+    const dest = 'docs/published/spec.md';
+
+    const first = await publishDocs({
+      ownerId,
+      toPath: dest,
+      projectRoot,
+    });
+    const second = await publishDocs({
+      ownerId,
+      toPath: dest,
+      projectRoot,
+    });
+
+    // Envelope contract: same blob selected, same byte count, same SHA.
+    expect(first.sha256).toBe(second.sha256);
+    expect(first.blobSha256).toBe(blobSha);
+    expect(second.blobSha256).toBe(blobSha);
+    expect(first.bytes).toBe(second.bytes);
+
+    // On-disk truth: file SHA matches the envelope SHA and is stable across
+    // both publishes (tmp-then-rename is overwrite-in-place atomic).
+    const diskSha = await fileSha(first.publishedPath);
+    expect(diskSha).toBe(first.sha256);
+    expect(diskSha).toBe(second.sha256);
+  });
+});
+
+// ─── T9634 AC5 — sync --from idempotency ──────────────────────────────────────
+
+describe('T9704 — sync --from twice on unchanged content yields no new blob', () => {
+  it('returns noop on the second call when content sha matches', async () => {
+    const ownerId = 'T-sync-idemp';
+
+    // Write a git-tracked file under the project root.
+    const gitFile = join(projectRoot, 'docs/source/note.md');
+    await mkdir(join(projectRoot, 'docs/source'), { recursive: true });
+    const content = '# Note\n\nReverse-ingest target.\n';
+    await writeFile(gitFile, content, 'utf-8');
+
+    // First sync — creates the blob.
+    const first = await syncFromGit({
+      ownerId,
+      fromPath: 'docs/source/note.md',
+      projectRoot,
+    });
+    expect(first.action).toBe('created');
+    expect(first.oldSha).toBeUndefined();
+    expect(first.newSha).toMatch(/^[0-9a-f]{64}$/);
+
+    // Second sync against unchanged content — noop.
+    const second = await syncFromGit({
+      ownerId,
+      fromPath: 'docs/source/note.md',
+      projectRoot,
+    });
+    expect(second.action).toBe('noop');
+    expect(second.oldSha).toBe(first.newSha);
+    expect(second.newSha).toBe(first.newSha);
+  });
+
+  it('returns updated when the source file changes between calls', async () => {
+    const ownerId = 'T-sync-update';
+    const gitFile = join(projectRoot, 'docs/source/changing.md');
+    await mkdir(join(projectRoot, 'docs/source'), { recursive: true });
+
+    await writeFile(gitFile, '# v1\n', 'utf-8');
+    const first = await syncFromGit({
+      ownerId,
+      fromPath: 'docs/source/changing.md',
+      projectRoot,
+    });
+    expect(first.action).toBe('created');
+
+    // Mutate the file — second call MUST create a new blob version.
+    await writeFile(gitFile, '# v2\n', 'utf-8');
+    const second = await syncFromGit({
+      ownerId,
+      fromPath: 'docs/source/changing.md',
+      projectRoot,
+    });
+    expect(second.action).toBe('updated');
+    expect(second.oldSha).toBe(first.newSha);
+    expect(second.newSha).not.toBe(first.newSha);
+  });
+});
+
+// ─── T9634 AC6 — status drift coverage + idempotency ──────────────────────────
+
+describe('T9704 — status twice produces identical envelope output', () => {
+  it('two status calls against the same state return byte-identical envelopes', async () => {
+    const ownerId = 'T-status-idemp';
+    const blobName = 'guide.md';
+    await seedBlob(ownerId, blobName, '# Guide\n');
+
+    // Publish + record so the ledger has something to check.
+    const published = await publishDocs({
+      ownerId,
+      toPath: 'docs/guide.md',
+      projectRoot,
+    });
+    await recordPublication({
+      ownerId,
+      blobName,
+      publishedPath: published.relativePath,
+      lastBlobSha: published.blobSha256,
+      projectRoot,
+    });
+
+    const first = await statusDocs({ projectRoot });
+    const second = await statusDocs({ projectRoot });
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+    expect(first.allInSync).toBe(true);
+    expect(first.items).toHaveLength(1);
+    expect(first.items[0]?.drift).toBe('in-sync');
+  });
+
+  it('classifies modified + deleted + in-sync across multiple entries', async () => {
+    // ── Owner A: published, then file mutated on disk → modified
+    const ownerA = 'T-status-modified';
+    const blobA = 'a.md';
+    await seedBlob(ownerA, blobA, '# A v1\n');
+    const pubA = await publishDocs({
+      ownerId: ownerA,
+      toPath: 'docs/a.md',
+      projectRoot,
+    });
+    await recordPublication({
+      ownerId: ownerA,
+      blobName: blobA,
+      publishedPath: pubA.relativePath,
+      lastBlobSha: pubA.blobSha256,
+      projectRoot,
+    });
+    await writeFile(pubA.publishedPath, '# A mutated\n', 'utf-8');
+
+    // ── Owner B: published, then file removed → deleted
+    const ownerB = 'T-status-deleted';
+    const blobB = 'b.md';
+    await seedBlob(ownerB, blobB, '# B v1\n');
+    const pubB = await publishDocs({
+      ownerId: ownerB,
+      toPath: 'docs/b.md',
+      projectRoot,
+    });
+    await recordPublication({
+      ownerId: ownerB,
+      blobName: blobB,
+      publishedPath: pubB.relativePath,
+      lastBlobSha: pubB.blobSha256,
+      projectRoot,
+    });
+    const { rm } = await import('node:fs/promises');
+    await rm(pubB.publishedPath);
+
+    // ── Owner C: published + untouched → in-sync
+    const ownerC = 'T-status-insync';
+    const blobC = 'c.md';
+    await seedBlob(ownerC, blobC, '# C v1\n');
+    const pubC = await publishDocs({
+      ownerId: ownerC,
+      toPath: 'docs/c.md',
+      projectRoot,
+    });
+    await recordPublication({
+      ownerId: ownerC,
+      blobName: blobC,
+      publishedPath: pubC.relativePath,
+      lastBlobSha: pubC.blobSha256,
+      projectRoot,
+    });
+
+    const status = await statusDocs({ projectRoot });
+
+    expect(status.allInSync).toBe(false);
+    expect(status.items).toHaveLength(3);
+
+    const byOwner = new Map(status.items.map((i) => [i.ownerId, i]));
+    expect(byOwner.get(ownerA)?.drift).toBe('modified');
+    expect(byOwner.get(ownerB)?.drift).toBe('deleted');
+    expect(byOwner.get(ownerC)?.drift).toBe('in-sync');
+
+    // Ledger transparency — what status reads must match what was written.
+    const ledger = await listPublications({ projectRoot });
+    expect(ledger).toHaveLength(3);
+  });
+});

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -31,6 +31,7 @@ import {
   rankDocs,
   readJson,
   searchDocs,
+  syncFromGit,
 } from '@cleocode/core/internal';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
@@ -832,22 +833,94 @@ const publishCommand = defineCommand({
   },
 });
 
-// ── Legacy: cleo docs sync ────────────────────────────────────────────────────
+// ── cleo docs sync ────────────────────────────────────────────────────────────
 
-/** cleo docs sync — drift detection between scripts and docs index */
+/**
+ * cleo docs sync — bidirectional surface.
+ *
+ * Two modes, selected by the presence of `--from`:
+ *
+ *   1. Reverse-ingest (`--from <git-path> --for <ownerId>` — T9702):
+ *      Read the git-tracked file, hash its bytes, and write a new blob
+ *      version to the docs SSoT. Idempotent: same content sha → noop.
+ *
+ *   2. Legacy drift check (no `--from`):
+ *      Compare `scripts/` against `COMMANDS-INDEX.json` — pre-existing
+ *      behaviour preserved verbatim for backward compatibility.
+ *
+ * @epic T9626 (W0)
+ * @task T9702 (ST-PUB-2b — reverse-ingest)
+ */
 const syncCommand = defineCommand({
-  meta: { name: 'sync', description: 'Run drift detection between scripts and docs index' },
+  meta: {
+    name: 'sync',
+    description:
+      'Bidirectional docs sync. Use --from <path> --for <ownerId> to ingest a git file as a new blob version. ' +
+      'Without --from, runs the legacy drift check between scripts/ and COMMANDS-INDEX.json.',
+  },
   args: {
+    from: {
+      type: 'string',
+      description:
+        'Git-tracked file path to ingest as a new blob version (triggers reverse-ingest mode)',
+    },
+    for: {
+      type: 'string',
+      description:
+        'Owner entity ID for reverse-ingest mode (T###, ses_*, O-*). Required when --from is set.',
+    },
+    name: {
+      type: 'string',
+      description: 'Override the blob name used in the manifest. Default: basename of --from.',
+    },
+    'content-type': {
+      type: 'string',
+      description:
+        'IANA MIME type recorded with the new blob version (default: application/octet-stream)',
+    },
     quick: {
       type: 'boolean',
-      description: 'Quick check (commands only)',
+      description: 'Legacy mode only: quick check (commands only)',
     },
     strict: {
       type: 'boolean',
-      description: 'Exit with error on any drift',
+      description: 'Legacy mode only: exit with error on any drift',
     },
   },
   async run({ args }) {
+    // Reverse-ingest mode (T9702).
+    if (args.from) {
+      const projectRoot = getProjectRoot();
+      const ownerId = args.for ?? undefined;
+      if (!ownerId) {
+        cliError(
+          '--for <ownerId> is required when --from <path> is set',
+          ExitCode.VALIDATION_ERROR,
+          { name: 'E_VALIDATION' },
+        );
+        process.exit(ExitCode.VALIDATION_ERROR);
+      }
+
+      try {
+        const result = await syncFromGit({
+          ownerId: String(ownerId),
+          fromPath: String(args.from),
+          blobName: args.name ?? undefined,
+          contentType: args['content-type'] ?? undefined,
+          projectRoot,
+        });
+        cliOutput(result, { command: 'docs sync', operation: 'docs.sync' });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        cliError(`docs sync failed: ${message}`, ExitCode.GENERAL_ERROR, {
+          name: 'E_DOCS_SYNC_FAILED',
+        });
+        process.exit(ExitCode.GENERAL_ERROR);
+      }
+      return;
+    }
+
+    // Legacy drift mode (T4551 — preserved unchanged).
     try {
       const projectRoot = process.cwd();
       const result = await detectDrift(projectRoot);
@@ -927,7 +1000,8 @@ const gapCheckCommand = defineCommand({
 });
 
 /**
- * Root docs command group — attachment management, llmtxt primitives, and drift detection.
+ * Root docs command group — attachment management, llmtxt primitives, drift detection,
+ * and git⇄llmtxt round-trip publish + sync per Saga T9625 / Epic T9626.
  *
  * Subcommands: add, list, fetch, remove, generate, export,
  *              search, merge, graph, rank, versions, publish,

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -30,7 +30,9 @@ import {
   publishDocs,
   rankDocs,
   readJson,
+  recordPublication,
   searchDocs,
+  statusDocs,
   syncFromGit,
 } from '@cleocode/core/internal';
 import { defineCommand, showUsage } from 'citty';
@@ -817,6 +819,22 @@ const publishCommand = defineCommand({
         projectRoot,
       });
 
+      // Persist the publication in the docs-publications ledger so the
+      // `cleo docs status` drift detector can subsequently check this path.
+      // Failure here MUST NOT mask publish success — the file is already on
+      // disk and reachable; ledger drift is recoverable on the next publish.
+      try {
+        await recordPublication({
+          ownerId: result.ownerId,
+          blobName: result.blobName,
+          publishedPath: result.relativePath,
+          lastBlobSha: result.blobSha256,
+          projectRoot,
+        });
+      } catch {
+        /* Ledger write is best-effort. */
+      }
+
       cliOutput(result, { command: 'docs publish', operation: 'docs.publish' });
     } catch (err) {
       // T9633: emit a flat LAFS error envelope (single layer, ADR-039).
@@ -954,6 +972,49 @@ const syncCommand = defineCommand({
   },
 });
 
+// ── cleo docs status ──────────────────────────────────────────────────────────
+
+/**
+ * cleo docs status — git⇄llmtxt drift detector.
+ *
+ * Walks the docs-publications ledger and classifies each entry as one of
+ * `in-sync`, `modified`, `deleted`, or `added`. Exits non-zero (code 2)
+ * when ANY entry has drift — convention from `git diff --exit-code`.
+ *
+ * @epic T9626 (W0)
+ * @task T9703 (ST-PUB-2c)
+ */
+const statusCommand = defineCommand({
+  meta: {
+    name: 'status',
+    description:
+      'Compare published files on disk against the docs SSoT and report drift. ' +
+      'Exits 0 when all entries are in-sync, 2 when any drift is present.',
+  },
+  args: {
+    json: {
+      type: 'boolean',
+      description: 'Emit LAFS JSON envelope',
+    },
+  },
+  async run() {
+    const projectRoot = getProjectRoot();
+    try {
+      const result = await statusDocs({ projectRoot });
+      cliOutput(result, { command: 'docs status', operation: 'docs.status' });
+      if (!result.allInSync) {
+        process.exit(2);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`docs status failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_DOCS_STATUS_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+    }
+  },
+});
+
 // ── Legacy: cleo docs gap-check ───────────────────────────────────────────────
 
 /** cleo docs gap-check — validate knowledge transfer from review docs */
@@ -1001,11 +1062,11 @@ const gapCheckCommand = defineCommand({
 
 /**
  * Root docs command group — attachment management, llmtxt primitives, drift detection,
- * and git⇄llmtxt round-trip publish + sync per Saga T9625 / Epic T9626.
+ * and git⇄llmtxt round-trip (publish/sync/status) per Saga T9625 / Epic T9626.
  *
  * Subcommands: add, list, fetch, remove, generate, export,
  *              search, merge, graph, rank, versions, publish,
- *              sync, gap-check.
+ *              sync, status, gap-check.
  */
 export const docsCommand = defineCommand({
   meta: {
@@ -1013,7 +1074,7 @@ export const docsCommand = defineCommand({
     description:
       'Documentation attachment management (add/list/fetch/remove), ' +
       'llmtxt primitives (search/merge/graph/rank/versions/publish), ' +
-      'and drift detection (sync/gap-check)',
+      'and drift detection (sync/status/gap-check)',
   },
   subCommands: {
     add: addCommand,
@@ -1029,6 +1090,7 @@ export const docsCommand = defineCommand({
     versions: versionsCommand,
     publish: publishCommand,
     sync: syncCommand,
+    status: statusCommand,
     'gap-check': gapCheckCommand,
   },
   async run({ cmd, rawArgs }) {

--- a/packages/core/src/docs/__tests__/docs-ops.test.ts
+++ b/packages/core/src/docs/__tests__/docs-ops.test.ts
@@ -300,13 +300,20 @@ describe('publishDocs', () => {
   it('reads the last blob and writes to toPath when no attachmentId given', async () => {
     const result = await publishDocs({
       ownerId: 'T123',
+      // Outside the mocked projectRoot — caller opts into the bypass explicitly.
       toPath: '/tmp/out/doc.md',
+      allowOutsideRoot: true,
     });
 
     expect(blobOps.blobRead).toHaveBeenCalledWith('T123', 'design.png', '/tmp/test-project');
     expect(result.publishedPath).toBe('/tmp/out/doc.md');
     expect(result.bytes).toBe(5);
     expect(result.sha256).toHaveLength(64);
+    // T9701 — richer envelope fields.
+    expect(result.blobName).toBe('design.png');
+    expect(result.blobSha256).toBe('ccdd');
+    expect(result.ownerId).toBe('T123');
+    expect(typeof result.relativePath).toBe('string');
   });
 
   it('selects blob by sha256 when attachmentId matches', async () => {
@@ -314,31 +321,60 @@ describe('publishDocs', () => {
       ownerId: 'T123',
       attachmentId: 'aabb',
       toPath: '/tmp/out/spec.md',
+      allowOutsideRoot: true,
     });
 
     expect(blobOps.blobRead).toHaveBeenCalledWith('T123', 'spec.md', '/tmp/test-project');
     expect(result.publishedPath).toBe('/tmp/out/spec.md');
+    expect(result.blobName).toBe('spec.md');
+    expect(result.blobSha256).toBe('aabb');
   });
 
   it('throws when no attachments found for owner', async () => {
     vi.mocked(blobOps.blobList).mockResolvedValue([]);
 
-    await expect(publishDocs({ ownerId: 'T999', toPath: '/tmp/out.md' })).rejects.toThrow(
-      'no attachments found',
-    );
+    await expect(
+      publishDocs({ ownerId: 'T999', toPath: '/tmp/out.md', allowOutsideRoot: true }),
+    ).rejects.toThrow('no attachments found');
   });
 
   it('throws when specified attachmentId not found', async () => {
     await expect(
-      publishDocs({ ownerId: 'T123', attachmentId: 'nonexistent', toPath: '/tmp/out.md' }),
+      publishDocs({
+        ownerId: 'T123',
+        attachmentId: 'nonexistent',
+        toPath: '/tmp/out.md',
+        allowOutsideRoot: true,
+      }),
     ).rejects.toThrow('not found');
   });
 
   it('throws when blobRead returns null', async () => {
     vi.mocked(blobOps.blobRead).mockResolvedValue(null);
 
-    await expect(publishDocs({ ownerId: 'T123', toPath: '/tmp/out.md' })).rejects.toThrow(
-      'could not read blob',
-    );
+    await expect(
+      publishDocs({ ownerId: 'T123', toPath: '/tmp/out.md', allowOutsideRoot: true }),
+    ).rejects.toThrow('could not read blob');
+  });
+
+  // T9701 — path-escape guard: writes outside projectRoot are rejected unless
+  // the caller passes allowOutsideRoot:true. CLI never sets that flag.
+  it('rejects absolute toPath that escapes projectRoot by default', async () => {
+    await expect(
+      publishDocs({
+        ownerId: 'T123',
+        toPath: '/etc/passwd',
+      }),
+    ).rejects.toThrow(/outside projectRoot/);
+  });
+
+  // T9701 — same protection for relative `..` traversal sequences.
+  it('rejects relative toPath that resolves outside projectRoot', async () => {
+    await expect(
+      publishDocs({
+        ownerId: 'T123',
+        toPath: '../../escape.md',
+      }),
+    ).rejects.toThrow(/outside projectRoot/);
   });
 });

--- a/packages/core/src/docs/docs-ops.ts
+++ b/packages/core/src/docs/docs-ops.ts
@@ -15,9 +15,9 @@
  * @see packages/cleo/src/cli/commands/docs.ts (CLI surface)
  */
 
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { mkdir } from 'node:fs/promises';
-import { dirname, isAbsolute, join } from 'node:path';
+import { dirname, isAbsolute, relative, resolve as resolvePath } from 'node:path';
 import type { KnowledgeGraph, MessageInput } from 'llmtxt/graph';
 import type { ReconstructionResult, VersionDiffSummary, VersionEntry } from 'llmtxt/sdk';
 import type { SimilarityRankResult } from 'llmtxt/similarity';
@@ -510,17 +510,56 @@ export async function listDocVersions(opts: {
 }
 
 /**
+ * Result returned by {@link publishDocs}.
+ *
+ * @epic T9626 (W0)
+ * @task T9701 (ST-PUB-2a — atomic write-side + envelope SHA)
+ */
+export interface DocsPublishResult {
+  /** Absolute path the bytes were written to. */
+  readonly publishedPath: string;
+  /** Project-root-relative form of `publishedPath`. Stable across machines. */
+  readonly relativePath: string;
+  /** Lowercase hex SHA-256 of the written bytes. */
+  readonly sha256: string;
+  /** Byte count actually written to disk. */
+  readonly bytes: number;
+  /** Content-addressed blob id (sha256) selected from the manifest. */
+  readonly blobSha256: string;
+  /** User-visible attachment name (e.g. `"spec.md"`) selected from the manifest. */
+  readonly blobName: string;
+  /** Owner entity ID whose blob was published. */
+  readonly ownerId: string;
+}
+
+/**
  * Atomically publish an attachment from the docs SSoT to a git-tracked path.
  *
  * Reads the named blob from the store and writes it to `toPath` using a
- * tmp-then-rename atomic pattern. When `attachmentId` is omitted the last
- * blob in the manifest is used.
+ * tmp-then-rename atomic pattern with `fsync` before close. When `attachmentId`
+ * is omitted the last blob in the manifest is used.
  *
- * @param opts - Required `ownerId` and `toPath`, optional `attachmentId` and `projectRoot`.
- * @returns Published path, SHA-256 digest of written bytes, and byte count.
+ * Path-escape guard: when `toPath` is relative it is joined under
+ * `projectRoot`; absolute paths must still resolve within `projectRoot`
+ * unless the caller passes `allowOutsideRoot: true`. This prevents an
+ * attacker-controlled blob name from being published to an arbitrary path
+ * via traversal sequences.
+ *
+ * Idempotency: writing the same bytes twice produces the same file SHA and
+ * leaves the destination byte-identical (tmp-then-rename overwrites in-place).
+ *
+ * @param opts - Required `ownerId` and `toPath`, optional `attachmentId`,
+ *               `projectRoot`, and `allowOutsideRoot`.
+ * @returns Published path, SHA-256 digest of written bytes, byte count,
+ *          blob name + sha256, and the owner ID.
  *
  * @throws {Error} when no matching attachment is found for the owner.
  * @throws {Error} when the blob store cannot supply the bytes.
+ * @throws {Error} when the resolved publish path escapes `projectRoot`
+ *                 and `allowOutsideRoot` is not set.
+ *
+ * @epic T9626 (W0)
+ * @task T9701 (ST-PUB-2a)
  *
  * @example
  * ```ts
@@ -533,7 +572,9 @@ export async function publishDocs(opts: {
   attachmentId?: string;
   toPath: string;
   projectRoot?: string;
-}): Promise<{ publishedPath: string; sha256: string; bytes: number }> {
+  /** When true, allow writing to paths outside `projectRoot`. Default: `false`. */
+  allowOutsideRoot?: boolean;
+}): Promise<DocsPublishResult> {
   const root = opts.projectRoot ?? getProjectRoot();
   const blobs = await blobList(opts.ownerId, root).catch(() => []);
 
@@ -559,16 +600,58 @@ export async function publishDocs(opts: {
     );
   }
 
-  const publishedPath = isAbsolute(opts.toPath) ? opts.toPath : join(root, opts.toPath);
-  const tmpPath = `${publishedPath}.cleo-publish-tmp`;
+  // Resolve to absolute, then enforce project-root containment unless opted out.
+  const publishedPath = isAbsolute(opts.toPath)
+    ? resolvePath(opts.toPath)
+    : resolvePath(root, opts.toPath);
+
+  if (!opts.allowOutsideRoot) {
+    const rel = relative(root, publishedPath);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      throw new Error(
+        `publishDocs: refusing to write outside projectRoot "${root}" (resolved to "${publishedPath}"). Pass allowOutsideRoot:true to override.`,
+      );
+    }
+  }
+
+  // Tmp name carries pid + random suffix so concurrent publishes never collide.
+  const tmpPath = `${publishedPath}.cleo-publish-tmp.${process.pid}.${randomBytes(4).toString('hex')}`;
 
   await mkdir(dirname(publishedPath), { recursive: true });
 
-  const { writeFile, rename } = await import('node:fs/promises');
-  await writeFile(tmpPath, bytes);
-  await rename(tmpPath, publishedPath);
+  const { open, rename, unlink } = await import('node:fs/promises');
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(tmpPath, 'w', 0o644);
+    await handle.writeFile(bytes);
+    // Flush page cache + metadata so a crash between rename and reboot does
+    // not surface a zero-byte file under the destination path.
+    await handle.sync();
+  } finally {
+    await handle?.close();
+  }
+
+  try {
+    await rename(tmpPath, publishedPath);
+  } catch (err) {
+    // Cross-device rename is the most common cause; surface a clear error
+    // rather than leaving a stray tmp file behind.
+    await unlink(tmpPath).catch(() => {
+      /* tmp already gone — nothing to clean. */
+    });
+    throw err;
+  }
 
   const sha256 = createHash('sha256').update(bytes).digest('hex');
+  const relativePath = relative(root, publishedPath);
 
-  return { publishedPath, sha256, bytes: bytes.byteLength };
+  return {
+    publishedPath,
+    relativePath,
+    sha256,
+    bytes: bytes.byteLength,
+    blobSha256: target.sha256,
+    blobName: target.name,
+    ownerId: opts.ownerId,
+  };
 }

--- a/packages/core/src/docs/docs-ops.ts
+++ b/packages/core/src/docs/docs-ops.ts
@@ -17,7 +17,7 @@
 
 import { createHash, randomBytes } from 'node:crypto';
 import { mkdir } from 'node:fs/promises';
-import { dirname, isAbsolute, relative, resolve as resolvePath } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve as resolvePath } from 'node:path';
 import type { KnowledgeGraph, MessageInput } from 'llmtxt/graph';
 import type { ReconstructionResult, VersionDiffSummary, VersionEntry } from 'llmtxt/sdk';
 import type { SimilarityRankResult } from 'llmtxt/similarity';
@@ -656,6 +656,175 @@ export async function publishDocs(opts: {
   };
 }
 
+// ─── docs-publications ledger (T9703 prep — used by status drift detector) ────
+
+/**
+ * On-disk record of one published doc. Persisted to
+ * `<projectRoot>/.cleo/docs-publications.json`.
+ *
+ * The ledger is intentionally a JSON sidecar rather than a SQLite table —
+ * it stores ≤ O(docs) entries, is rewritten atomically, and avoids a
+ * schema migration on the docs domain.
+ *
+ * @epic T9626 (W0)
+ * @task T9703 (ST-PUB-2c — drift detector)
+ */
+export interface DocsPublicationRecord {
+  /** Owner entity ID whose blob was published (e.g. `"T123"`). */
+  readonly ownerId: string;
+  /** Attachment name as stored in the blob manifest. */
+  readonly blobName: string;
+  /** Project-root-relative path the bytes were written to. */
+  readonly publishedPath: string;
+  /** SHA-256 of the blob bytes at the time of publish. */
+  readonly lastBlobSha: string;
+  /** ISO-8601 timestamp of the latest publish event for this record. */
+  readonly publishedAt: string;
+}
+
+/** Wire format of `.cleo/docs-publications.json` on disk. */
+interface DocsPublicationsLedger {
+  readonly version: 1;
+  readonly entries: readonly DocsPublicationRecord[];
+}
+
+/** Absolute path to the docs-publications ledger for a given project root. */
+function ledgerPath(projectRoot: string): string {
+  return join(projectRoot, '.cleo', 'docs-publications.json');
+}
+
+/**
+ * Load the docs-publications ledger from disk.
+ *
+ * Returns an empty list when the ledger file does not yet exist. Tolerates
+ * corrupt JSON by returning an empty list — callers should treat a missing
+ * ledger as "no publications recorded yet" rather than a hard error.
+ *
+ * @internal
+ */
+async function readPublicationsLedger(projectRoot: string): Promise<DocsPublicationRecord[]> {
+  const { readFile } = await import('node:fs/promises');
+  try {
+    const raw = await readFile(ledgerPath(projectRoot), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<DocsPublicationsLedger>;
+    if (!parsed || !Array.isArray(parsed.entries)) return [];
+    return parsed.entries.filter(
+      (e): e is DocsPublicationRecord =>
+        !!e &&
+        typeof e.ownerId === 'string' &&
+        typeof e.blobName === 'string' &&
+        typeof e.publishedPath === 'string' &&
+        typeof e.lastBlobSha === 'string' &&
+        typeof e.publishedAt === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist the docs-publications ledger atomically (tmp-then-rename + fsync).
+ *
+ * @internal
+ */
+async function writePublicationsLedger(
+  projectRoot: string,
+  entries: readonly DocsPublicationRecord[],
+): Promise<void> {
+  const path = ledgerPath(projectRoot);
+  const tmp = `${path}.tmp.${process.pid}.${randomBytes(4).toString('hex')}`;
+  const payload: DocsPublicationsLedger = { version: 1, entries };
+  const text = `${JSON.stringify(payload, null, 2)}\n`;
+
+  await mkdir(dirname(path), { recursive: true });
+
+  const { open, rename, unlink } = await import('node:fs/promises');
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(tmp, 'w', 0o644);
+    await handle.writeFile(text, 'utf-8');
+    await handle.sync();
+  } finally {
+    await handle?.close();
+  }
+
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    await unlink(tmp).catch(() => {
+      /* already gone */
+    });
+    throw err;
+  }
+}
+
+/**
+ * Record a publish event in the docs-publications ledger.
+ *
+ * Upserts on `(ownerId, blobName, publishedPath)`. Refreshes
+ * `lastBlobSha` and `publishedAt` when the row already exists so the
+ * ledger always reflects the latest known good publication.
+ *
+ * @param opts - Required record fields.
+ * @epic T9626 (W0)
+ * @task T9703 (ST-PUB-2c)
+ */
+export async function recordPublication(opts: {
+  ownerId: string;
+  blobName: string;
+  publishedPath: string;
+  lastBlobSha: string;
+  projectRoot?: string;
+}): Promise<void> {
+  const root = opts.projectRoot ?? getProjectRoot();
+  const existing = await readPublicationsLedger(root);
+  const next: DocsPublicationRecord[] = [];
+  let upserted = false;
+  for (const row of existing) {
+    if (
+      row.ownerId === opts.ownerId &&
+      row.blobName === opts.blobName &&
+      row.publishedPath === opts.publishedPath
+    ) {
+      next.push({
+        ownerId: opts.ownerId,
+        blobName: opts.blobName,
+        publishedPath: opts.publishedPath,
+        lastBlobSha: opts.lastBlobSha,
+        publishedAt: new Date().toISOString(),
+      });
+      upserted = true;
+    } else {
+      next.push(row);
+    }
+  }
+  if (!upserted) {
+    next.push({
+      ownerId: opts.ownerId,
+      blobName: opts.blobName,
+      publishedPath: opts.publishedPath,
+      lastBlobSha: opts.lastBlobSha,
+      publishedAt: new Date().toISOString(),
+    });
+  }
+  await writePublicationsLedger(root, next);
+}
+
+/**
+ * List all recorded publications in the ledger.
+ *
+ * Returns an empty array when the ledger does not exist or is unreadable.
+ *
+ * @epic T9626 (W0)
+ * @task T9703 (ST-PUB-2c)
+ */
+export async function listPublications(opts?: {
+  projectRoot?: string;
+}): Promise<DocsPublicationRecord[]> {
+  const root = opts?.projectRoot ?? getProjectRoot();
+  return readPublicationsLedger(root);
+}
+
 // ─── syncFromGit (T9702 — reverse-ingest) ─────────────────────────────────────
 
 /**
@@ -782,5 +951,145 @@ export async function syncFromGit(opts: {
     oldSha,
     bytes: bytes.byteLength,
     action: latest ? 'updated' : 'created',
+  };
+}
+
+// ─── docs status (T9703 — drift detector) ─────────────────────────────────────
+
+/**
+ * Single drift item returned by {@link statusDocs}.
+ *
+ * @epic T9626 (W0)
+ * @task T9703 (ST-PUB-2c)
+ */
+export interface DocsDriftItem {
+  /** Owner entity ID the blob is attached to. */
+  readonly ownerId: string;
+  /** Attachment name in the blob manifest. */
+  readonly blobName: string;
+  /** Project-root-relative path the blob was published to. */
+  readonly publishedPath: string;
+  /** SHA-256 of the blob in the manifest (the docs SSoT). */
+  readonly blobSha: string;
+  /** SHA-256 of the file at `publishedPath`, or `null` when missing. */
+  readonly fileSha: string | null;
+  /**
+   * Drift classification:
+   *   - `in-sync`  — blobSha === fileSha
+   *   - `added`    — file exists on disk but no row in the manifest (rare; never set today)
+   *   - `modified` — blobSha !== fileSha and file is present
+   *   - `deleted`  — file is missing from disk
+   */
+  readonly drift: 'in-sync' | 'added' | 'modified' | 'deleted';
+}
+
+/**
+ * Result returned by {@link statusDocs}.
+ *
+ * @epic T9626 (W0)
+ * @task T9703 (ST-PUB-2c)
+ */
+export interface DocsStatusResult {
+  /** Each recorded publication, with drift classification. */
+  readonly items: readonly DocsDriftItem[];
+  /** True when every item is `in-sync`. */
+  readonly allInSync: boolean;
+}
+
+/**
+ * Read `.cleo/docs-publications.json` and classify drift for each entry.
+ *
+ * Drift cases covered:
+ *   - blob present + file present + matching sha → `in-sync`
+ *   - blob present + file present + sha mismatch → `modified`
+ *   - blob present + file missing                → `deleted`
+ *
+ * The `added` classification is reserved for files-on-disk-without-a-manifest-row
+ * and is not produced today — `status` operates strictly on the ledger.
+ *
+ * @param opts - Optional `projectRoot`.
+ * @returns Items list + `allInSync` boolean. Suitable for CI exit-code gating
+ *          (0 when `allInSync`, 2 otherwise).
+ *
+ * @epic T9626 (W0)
+ * @task T9703 (ST-PUB-2c)
+ *
+ * @example
+ * ```ts
+ * const status = await statusDocs();
+ * if (!status.allInSync) process.exit(2);
+ * ```
+ */
+export async function statusDocs(opts?: { projectRoot?: string }): Promise<DocsStatusResult> {
+  const root = opts?.projectRoot ?? getProjectRoot();
+  const ledger = await readPublicationsLedger(root);
+  if (ledger.length === 0) {
+    return { items: [], allInSync: true };
+  }
+
+  const { readFile, stat } = await import('node:fs/promises');
+
+  // Refresh blob shas from the manifest so the ledger drives WHICH paths to
+  // check but the latest manifest drives the authoritative SSoT sha.
+  const ownerCache = new Map<string, Map<string, string>>();
+  async function getBlobSha(ownerId: string, blobName: string, ledgerSha: string): Promise<string> {
+    let perOwner = ownerCache.get(ownerId);
+    if (!perOwner) {
+      perOwner = new Map();
+      const rows = await blobList(ownerId, root).catch(() => []);
+      for (const row of rows) perOwner.set(row.name, row.sha256);
+      ownerCache.set(ownerId, perOwner);
+    }
+    return perOwner.get(blobName) ?? ledgerSha;
+  }
+
+  const items: DocsDriftItem[] = [];
+  for (const row of ledger) {
+    const filePath = isAbsolute(row.publishedPath)
+      ? row.publishedPath
+      : resolvePath(root, row.publishedPath);
+
+    const blobSha = await getBlobSha(row.ownerId, row.blobName, row.lastBlobSha);
+
+    let fileSha: string | null = null;
+    let exists = false;
+    try {
+      await stat(filePath);
+      exists = true;
+    } catch {
+      exists = false;
+    }
+
+    if (exists) {
+      try {
+        const data = await readFile(filePath);
+        fileSha = createHash('sha256').update(data).digest('hex');
+      } catch {
+        fileSha = null;
+      }
+    }
+
+    let drift: DocsDriftItem['drift'];
+    if (!exists || fileSha === null) {
+      drift = 'deleted';
+    } else if (fileSha === blobSha) {
+      drift = 'in-sync';
+    } else {
+      drift = 'modified';
+    }
+
+    items.push({
+      ownerId: row.ownerId,
+      blobName: row.blobName,
+      publishedPath: row.publishedPath,
+      blobSha,
+      fileSha,
+      drift,
+    });
+  }
+
+  return {
+    items,
+    allInSync: items.every((i) => i.drift === 'in-sync'),
   };
 }

--- a/packages/core/src/docs/docs-ops.ts
+++ b/packages/core/src/docs/docs-ops.ts
@@ -655,3 +655,132 @@ export async function publishDocs(opts: {
     ownerId: opts.ownerId,
   };
 }
+
+// ─── syncFromGit (T9702 — reverse-ingest) ─────────────────────────────────────
+
+/**
+ * Result returned by {@link syncFromGit}.
+ *
+ * @epic T9626 (W0)
+ * @task T9702 (ST-PUB-2b — reverse-ingest)
+ */
+export interface DocsSyncFromGitResult {
+  /** Owner entity ID the file was ingested under. */
+  readonly ownerId: string;
+  /** Attachment name as stored in the blob manifest. */
+  readonly blobName: string;
+  /** Project-root-relative source path. */
+  readonly sourcePath: string;
+  /** SHA-256 of the bytes that were ingested. */
+  readonly newSha: string;
+  /** SHA-256 of the previously-stored blob with the same name, when present. */
+  readonly oldSha?: string;
+  /** Byte count of the ingested file. */
+  readonly bytes: number;
+  /**
+   * What happened during ingest:
+   *   - `created` — first time this `(ownerId, name)` pair was seen.
+   *   - `updated` — content differs from the latest stored blob.
+   *   - `noop`    — content sha matches the latest stored blob; no new blob was written.
+   */
+  readonly action: 'created' | 'updated' | 'noop';
+}
+
+/**
+ * Ingest a git-tracked file as a new blob version on the docs SSoT.
+ *
+ * Reads `fromPath`, computes its SHA-256, and:
+ *   - Returns `{action: 'noop'}` when the latest stored blob for
+ *     `(ownerId, blobName)` already matches the content sha (idempotency).
+ *   - Otherwise attaches a new blob via `CleoBlobStore.attach` and returns
+ *     `{action: 'created' | 'updated', newSha, oldSha?}`.
+ *
+ * The `blobName` defaults to `path.basename(fromPath)` unless explicitly
+ * passed. Use `--name <slug>` from the CLI to override.
+ *
+ * @param opts - Required `ownerId` and `fromPath`, optional `blobName`,
+ *               `contentType`, and `projectRoot`.
+ * @returns Action taken + before/after SHAs.
+ *
+ * @throws {Error} when `fromPath` cannot be read.
+ *
+ * @epic T9626 (W0)
+ * @task T9702 (ST-PUB-2b)
+ *
+ * @example
+ * ```ts
+ * const out = await syncFromGit({ ownerId: 'T123', fromPath: 'docs/spec.md' });
+ * if (out.action === 'noop') console.log('already in sync');
+ * ```
+ */
+export async function syncFromGit(opts: {
+  ownerId: string;
+  fromPath: string;
+  blobName?: string;
+  contentType?: string;
+  projectRoot?: string;
+}): Promise<DocsSyncFromGitResult> {
+  const root = opts.projectRoot ?? getProjectRoot();
+
+  const sourceAbs = isAbsolute(opts.fromPath)
+    ? resolvePath(opts.fromPath)
+    : resolvePath(root, opts.fromPath);
+  const sourceRel = relative(root, sourceAbs);
+
+  const { readFile } = await import('node:fs/promises');
+  let bytes: Buffer;
+  try {
+    bytes = await readFile(sourceAbs);
+  } catch (cause) {
+    const msg = cause instanceof Error ? cause.message : String(cause);
+    const err = new Error(`syncFromGit: cannot read "${sourceAbs}": ${msg}`);
+    err.cause = cause;
+    throw err;
+  }
+
+  const blobName = opts.blobName ?? sourceAbs.split(/[\\/]/).pop() ?? 'doc';
+  const newSha = createHash('sha256').update(bytes).digest('hex');
+
+  // Probe the existing manifest for a same-named blob.
+  const existing = await blobList(opts.ownerId, root).catch(() => []);
+  const latest = existing.find((b) => b.name === blobName);
+  const oldSha = latest?.sha256;
+
+  if (latest && latest.sha256 === newSha) {
+    return {
+      ownerId: opts.ownerId,
+      blobName,
+      sourcePath: sourceRel,
+      newSha,
+      oldSha,
+      bytes: bytes.byteLength,
+      action: 'noop',
+    };
+  }
+
+  // Open the blob store and attach the new version. Same content under the
+  // same name with a different sha overwrites the manifest row (LWW).
+  const { CleoBlobStore } = await import('../store/llmtxt-blob-adapter.js');
+  const store = new CleoBlobStore({ projectRoot: root });
+  await store.open();
+  try {
+    await store.attach(
+      opts.ownerId,
+      blobName,
+      new Uint8Array(bytes),
+      opts.contentType ?? 'application/octet-stream',
+    );
+  } finally {
+    await store.close();
+  }
+
+  return {
+    ownerId: opts.ownerId,
+    blobName,
+    sourcePath: sourceRel,
+    newSha,
+    oldSha,
+    bytes: bytes.byteLength,
+    action: latest ? 'updated' : 'created',
+  };
+}

--- a/packages/core/src/docs/index.ts
+++ b/packages/core/src/docs/index.ts
@@ -18,15 +18,18 @@
 export type { GenerateDocsOptions, GenerateDocsResult } from './docs-generator.js';
 export { generateDocsLlmsTxt } from './docs-generator.js';
 export type {
+  DocsDriftItem,
   DocsGraphEdge,
   DocsGraphNode,
   DocsGraphResult,
   DocsMergeResult,
+  DocsPublicationRecord,
   DocsPublishResult,
   DocsRankHit,
   DocsRankResult,
   DocsSearchHit,
   DocsSearchResult,
+  DocsStatusResult,
   DocsSyncFromGitResult,
   DocsVersionEntry,
   DocsVersionsResult,
@@ -34,10 +37,13 @@ export type {
 export {
   buildDocsGraph,
   listDocVersions,
+  listPublications,
   mergeDocs,
   publishDocs,
   rankDocs,
+  recordPublication,
   searchDocs,
+  statusDocs,
   syncFromGit,
 } from './docs-ops.js';
 

--- a/packages/core/src/docs/index.ts
+++ b/packages/core/src/docs/index.ts
@@ -22,6 +22,7 @@ export type {
   DocsGraphNode,
   DocsGraphResult,
   DocsMergeResult,
+  DocsPublishResult,
   DocsRankHit,
   DocsRankResult,
   DocsSearchHit,

--- a/packages/core/src/docs/index.ts
+++ b/packages/core/src/docs/index.ts
@@ -27,6 +27,7 @@ export type {
   DocsRankResult,
   DocsSearchHit,
   DocsSearchResult,
+  DocsSyncFromGitResult,
   DocsVersionEntry,
   DocsVersionsResult,
 } from './docs-ops.js';
@@ -37,6 +38,7 @@ export {
   publishDocs,
   rankDocs,
   searchDocs,
+  syncFromGit,
 } from './docs-ops.js';
 
 export type { ExportDocumentOptions, ExportDocumentResult } from './export-document.js';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -120,11 +120,13 @@ export {
 export type { GenerateDocsOptions, GenerateDocsResult } from './docs/docs-generator.js';
 export { generateDocsLlmsTxt } from './docs/docs-generator.js';
 // Docs ops — llmtxt primitive wrappers (search, merge, graph, rank, versions, publish) (T1041)
+// + publishDocs hardening (T9701 — Saga T9625 / Epic T9626)
 export type {
   DocsGraphEdge,
   DocsGraphNode,
   DocsGraphResult,
   DocsMergeResult,
+  DocsPublishResult,
   DocsRankHit,
   DocsRankResult,
   DocsSearchHit,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -120,17 +120,20 @@ export {
 export type { GenerateDocsOptions, GenerateDocsResult } from './docs/docs-generator.js';
 export { generateDocsLlmsTxt } from './docs/docs-generator.js';
 // Docs ops — llmtxt primitive wrappers (search, merge, graph, rank, versions, publish) (T1041)
-// + publishDocs hardening (T9701) + sync reverse-ingest (T9702) — Saga T9625 / Epic T9626
+// + git⇄llmtxt round-trip (publish/sync/status) (T9634 — Saga T9625 / Epic T9626)
 export type {
+  DocsDriftItem,
   DocsGraphEdge,
   DocsGraphNode,
   DocsGraphResult,
   DocsMergeResult,
+  DocsPublicationRecord,
   DocsPublishResult,
   DocsRankHit,
   DocsRankResult,
   DocsSearchHit,
   DocsSearchResult,
+  DocsStatusResult,
   DocsSyncFromGitResult,
   DocsVersionEntry,
   DocsVersionsResult,
@@ -138,10 +141,13 @@ export type {
 export {
   buildDocsGraph,
   listDocVersions,
+  listPublications,
   mergeDocs,
   publishDocs,
   rankDocs,
+  recordPublication,
   searchDocs,
+  statusDocs,
   syncFromGit,
 } from './docs/docs-ops.js';
 // Docs export — rich Markdown export of a task with frontmatter + attachments (T947)
@@ -1007,6 +1013,9 @@ export { createBackup, listBackups, restoreFromBackup } from './store/backup.js'
 // Backup portability — bundle packer (T311 / T347)
 export type { PackBundleInput, PackBundleResult } from './store/backup-pack.js';
 export { packBundle } from './store/backup-pack.js';
+// Read-only blob ops façade — content-address read API (T947 step 1)
+export type { BlobListEntry } from './store/blob-ops.js';
+export { blobList, blobRead } from './store/blob-ops.js';
 export type { LegacyCleanupResult, StrayNexusCleanupResult } from './store/cleanup-legacy.js';
 export {
   detectAndRemoveLegacyGlobalFiles,
@@ -1024,6 +1033,13 @@ export {
   isCleoGitInitialized,
 } from './store/git-checkpoint.js';
 export { computeChecksum, readJson } from './store/json.js';
+// CleoBlobStore — content-addressed blob store (T9634 idempotency tests + future
+// callers that need to seed blobs without going through the full v2 wrapper).
+export type {
+  CleoBlobAttachResult,
+  CleoBlobStoreOptions,
+} from './store/llmtxt-blob-adapter.js';
+export { CleoBlobStore } from './store/llmtxt-blob-adapter.js';
 export type { BrainDataAccessor } from './store/memory-accessor.js';
 // Brain accessor — for intelligence domain handler construction
 export { getBrainAccessor } from './store/memory-accessor.js';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -120,7 +120,7 @@ export {
 export type { GenerateDocsOptions, GenerateDocsResult } from './docs/docs-generator.js';
 export { generateDocsLlmsTxt } from './docs/docs-generator.js';
 // Docs ops — llmtxt primitive wrappers (search, merge, graph, rank, versions, publish) (T1041)
-// + publishDocs hardening (T9701 — Saga T9625 / Epic T9626)
+// + publishDocs hardening (T9701) + sync reverse-ingest (T9702) — Saga T9625 / Epic T9626
 export type {
   DocsGraphEdge,
   DocsGraphNode,
@@ -131,6 +131,7 @@ export type {
   DocsRankResult,
   DocsSearchHit,
   DocsSearchResult,
+  DocsSyncFromGitResult,
   DocsVersionEntry,
   DocsVersionsResult,
 } from './docs/docs-ops.js';
@@ -141,6 +142,7 @@ export {
   publishDocs,
   rankDocs,
   searchDocs,
+  syncFromGit,
 } from './docs/docs-ops.js';
 // Docs export — rich Markdown export of a task with frontmatter + attachments (T947)
 export type { ExportDocumentOptions, ExportDocumentResult } from './docs/export-document.js';


### PR DESCRIPTION
## Summary

Ships the full git⇄llmtxt round-trip surface for `cleo docs` — Saga T9625 / Epic T9626 / Wave 0. Four subtasks shipped as four atomic commits in this one PR (ADR-073 §1.2 I8 — subtask-to-PR aggregation).

## Subtasks delivered

- **T9701 (ST-PUB-2a)** — `cleo docs publish --to <path>` hardened: tmp-then-rename + `fsync`, path-escape guard rejecting writes outside `projectRoot`, richer envelope with `{publishedPath, relativePath, sha256, bytes, blobSha256, blobName, ownerId}`, per-pid tmp suffix.
- **T9702 (ST-PUB-2b)** — `cleo docs sync --from <git-path>` reverse-ingest. Reads the file, hashes it, returns `{action: 'created' | 'updated' | 'noop', oldSha?, newSha}`. Idempotent: same content sha → `noop`, no new blob.
- **T9703 (ST-PUB-2c)** — `cleo docs status` drift detector + `.cleo/docs-publications.json` ledger. Classifies each tracked publication as `in-sync` / `modified` / `deleted`. Exits 0 when all in-sync, exit 2 on any drift (mirrors `git diff --exit-code`).
- **T9704 (ST-PUB-2d)** — 5 idempotency tests in `packages/cleo/src/cli/__tests__/docs-idempotency.test.ts` covering all three commands against a real tmp project root + CleoBlobStore.

## Acceptance gates (T9634)

- [x] `publish --to <path>` writes atomically via tmp-then-rename, envelope returns file SHA (AC1)
- [x] `sync --from` ingests git file as new blob version with provenance (AC2)
- [x] `status` reports blob-SHA vs file-SHA mismatch for all watched docs covering add/modify/delete (AC3)
- [x] `publish` twice → same file SHA + identical destination (AC4 — idempotent)
- [x] `sync` twice on unchanged content → `noop`, no new blob (AC5)
- [x] `status` covers `in-sync` / `modified` / `deleted` cases (AC6)

## Design choices (A/B notes)

- **T9702 — option A** (chose): extended existing `cleo docs sync` with `--from <path>` flag. Legacy drift mode (scripts/ vs COMMANDS-INDEX.json) is preserved when `--from` is absent. Keeps the surface bidirectional under one verb.
- **T9703 — option A** (chose): new `cleo docs status` subcommand, read-only. Keeps `sync` writable and `status` strictly observational.
- **T9703 schema — JSON sidecar, NOT a new SQLite table**: persisted at `<projectRoot>/.cleo/docs-publications.json` with atomic tmp-then-rename + `fsync`. Reasoning: the ledger is O(docs)-sized and rewritten on every publish — avoiding a Drizzle migration on the docs domain keeps the blast radius minimal. A future T-series task can migrate to SQLite if scale demands.

## No schema migration

This PR does not add a Drizzle migration. The ledger lives at `.cleo/docs-publications.json`.

## Test plan

- [x] `pnpm biome ci .` exits 0
- [x] `pnpm --filter @cleocode/core exec tsc --noEmit` exits 0
- [x] `pnpm --filter @cleocode/cleo exec tsc --noEmit` exits 0
- [x] `pnpm exec vitest run --config packages/core/vitest.config.ts src/docs/__tests__/docs-ops.test.ts` → 21 pass
- [x] `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/cli/__tests__/docs.test.ts packages/cleo/src/cli/__tests__/docs-publish-envelope.test.ts packages/cleo/src/cli/__tests__/docs-idempotency.test.ts` → 3 files / 11 tests pass
- [x] `node build.mjs` (full root build) → exit 0

## Notes on test invocation

Vitest workspace-filter discovery is a known issue in worktrees (flagged by pub1 during T9633). Tests run reliably with `--config packages/<pkg>/vitest.config.ts` and an explicit file path. The new idempotency tests sit at `packages/cleo/src/cli/__tests__/docs-idempotency.test.ts` (under `packages/cleo/src/**/__tests__/*.test.ts` per cleo's vitest config include pattern) — NOT at top-level `packages/cleo/test/` (which is restricted to fixtures + templates + release-pipeline integration).

Refs: T9701, T9702, T9703, T9704, T9634, Epic T9626, Saga T9625