### PR TITLE
release: v2026.5.84 — SG-CLEO-SKILLS Sphere A close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## [2026.5.84] (2026-05-19) — SG-CLEO-SKILLS Sphere A close (T9560)
+
+Sphere A close of the SG-CLEO-SKILLS saga (T9560). Bundles the canonical
+skills-storage foundations (resolveSkillsRoot + is_canonical, skills.db
+Drizzle schema), the first batch of `cleo skills doctor` health verbs
+(`migrate`, `bridge`), the saga-aware `cleo list --parent` router, the
+ct-skill registry curation (ct-council added, ct-grade-v2-1 removed),
+CAAMP installer canonical-path writes, and the T9568 LOOM coverage matrix.
+
+### Added (E-SKILLS-STORAGE-CLEANUP / T9571)
+
+- **PR #301 (T9650)** — `resolveSkillsRoot()` + `is_canonical()` SSoT path
+  helpers in `packages/core/src/skills/skill-root.ts`. Canonical path
+  resolution for `~/.cleo/skills/` (XDG-backed via
+  `~/.local/share/cleo/skills/`) with `is_canonical(path)` walking
+  symlinks AND checking manifest membership.
+- **PR #304 (T9651)** — `skills.db` Drizzle schema + per-user registry
+  init. New tables: `installed_skills`, `skill_profiles`,
+  `skill_audit_log`. Migration `20260519051821_t9651-initial`. New
+  `packages/core/src/store/skills-db.ts` accessor + 371-line test suite.
+  Routed through `openCleoDb()` chokepoint (ADR-068).
+- **PR #312 (T9653)** — `cleo skills doctor migrate` verb in
+  `packages/caamp/src/commands/skills/doctor-migrate.ts`. Legacy
+  `.claude/skills/` → canonical `~/.cleo/skills/` with reversible backup.
+  522-line migration engine in `packages/caamp/src/core/skills/migration.ts`.
+- **PR #314 (T9655)** — `cleo skills doctor bridge` verb in
+  `packages/caamp/src/commands/skills/doctor-bridge.ts`. Creates the
+  single bridge symlink `~/.agents/skills -> ~/.claude/skills/agents-shared`,
+  removes per-skill symlinks pointing elsewhere, validates Claude Code
+  skill discovery picks them up.
+- **PR #326 (T9659)** — CAAMP installer writes to canonical
+  `~/.cleo/skills/` and records install rows in `skills.db`. Refactored
+  `packages/caamp/src/core/skills/installer.ts` + canonical-path helpers
+  in `packages/caamp/src/core/paths/standard.ts`.
+
+### Added (T9568 LOOM coverage)
+
+- **PR #321 (T9568 batch)** — 6 tasks shipped: T9661 LOOM coverage matrix
+  doc (10 stages × skill × ADR), T9664 enforce `loomStage` frontmatter on
+  canonical LOOM skills, T9665 link ADR refs on LOOM-stage skill SKILL.md,
+  T9670 bind `ct-contribution` to contribution LOOM stage, T9672 reconcile
+  `architecture_decision` vs `architecture-decision` naming, T9675 clarify
+  `ct-validator` vs `ct-ivt-looper` boundary.
+
+### Changed
+
+- **PR #311 (T9658)** — saga-aware `cleo list --parent` routes `SG-X`
+  via `task_relations.groups`. Sagas with `label='saga'` resolve their
+  members through the relations table rather than the parent_id column,
+  preserving Epic→Task→Subtask depth-budget invariants (I8).
+- **PR #302 (T9654)** — add `ct-council` to recommended + full skill
+  profiles. The 5-advisor stress-test workflow is now part of the
+  default agent toolkit.
+- **PR #303 (T9656)** — remove deprecated `ct-grade-v2-1` skill.
+  Superseded by `ct-grade` (the canonical session-grading skill).
+
+### Fixed
+
+- **PR #318 (T9633)** — `cleo docs publish` silent failure. Citty
+  `runMain` was swallowing CLIError envelopes; the publish verb now
+  emits a proper LAFS error envelope on failure.
+
+### Saga progress (SG-CLEO-SKILLS / T9560)
+
+This release closes Sphere A of the SG-CLEO-SKILLS saga (storage
+foundations + first doctor verbs + curated skill registry + LOOM
+coverage). Remaining saga work (T9657 `cleo skills doctor
+adopt-orphans`, T9652 `cleo skills doctor diagnose`, and curator state
+machine T9677) is held over to a future sphere — T9657 is in PR #315
+pending CI fixes.
+
 ## [2026.5.83] (2026-05-19) — T9685 strict-mode flip — project-root baseline → zero
 
 Long-tail follow-up to the v2026.5.82 E-PROJECT-ROOT-AUDIT closure. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "conduit-core",
  "nom",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "cant-core",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "serde",
  "serde_json",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "cant-core",
  "serde",
@@ -394,7 +394,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-llm-native"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "lafs-core",
  "serde",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-core"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "chrono",
  "conduit-core",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-payments"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-protocol"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "cant-core",
  "chrono",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-sdk"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-storage"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-transport"
-version = "2026.5.78"
+version = "2026.5.84"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.83"
+version = "2026.5.84"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.83",
+  "version": "2026.5.84",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Sphere A close of the SG-CLEO-SKILLS saga (T9560). Bundles the canonical skills-storage foundations (`resolveSkillsRoot` + `is_canonical`, `skills.db` Drizzle schema), first batch of `cleo skills doctor` health verbs (`migrate`, `bridge`), saga-aware `cleo list --parent` router, ct-skill registry curation, CAAMP installer canonical-path writes, and the T9568 LOOM coverage matrix.

## PRs bundled

| PR    | Task          | Description                                                            |
|-------|---------------|------------------------------------------------------------------------|
| #301  | T9650         | `resolveSkillsRoot()` + `is_canonical()` SSoT path helpers             |
| #304  | T9651         | `skills.db` Drizzle schema + per-user registry init                    |
| #312  | T9653         | `cleo skills doctor migrate` — legacy -> canonical with backup         |
| #314  | T9655         | `cleo skills doctor bridge` — single bridge symlink + cleanup          |
| #326  | T9659         | CAAMP installer writes to canonical `~/.cleo/skills/` + records to db  |
| #321  | T9568 (batch) | LOOM coverage (T9661, T9664, T9665, T9670, T9672, T9675)               |
| #311  | T9658         | Saga-aware `cleo list --parent` routes SG-X via task_relations.groups  |
| #302  | T9654         | Add `ct-council` to recommended + full skill profiles                  |
| #303  | T9656         | Remove deprecated `ct-grade-v2-1` skill (superseded by `ct-grade`)     |
| #318  | T9633         | Fix `cleo docs publish` silent failure — emit proper LAFS envelope     |

## Saga progress

This release closes **Sphere A** of SG-CLEO-SKILLS (storage foundations + first doctor verbs + curated skill registry + LOOM coverage). Remaining saga work held over to a future sphere:

- T9657 (`cleo skills doctor adopt-orphans`) — in PR #315 pending CI fixes
- T9652 (`cleo skills doctor diagnose`) — staged
- T9677 (curator state machine) — depends on T9650 + T9651 (now merged)

## Release path

Attempted canonical `cleo release plan v2026.5.84 --epic T9571` first; blocked by `E_EVIDENCE_INSUFFICIENT` because T9657 (PR #315) is not yet on main — epic evidence sweep cannot complete. Fell back to manual path per AGENTS.md "Release & Branching" section.

## Version bumps

- 21 package.json files (root + all `packages/*` workspaces) — `2026.5.83` -> `2026.5.84`
- `Cargo.toml` workspace.package version -> `2026.5.84`
- `Cargo.lock` regenerated to match

## Test plan

- [x] Version bumps applied across all 21 npm workspace `package.json` files
- [x] `Cargo.toml` + `Cargo.lock` updated (workspace.package version)
- [x] CHANGELOG.md v2026.5.84 section added at top with all 10 PRs documented
- [x] Branch `release/v2026.5.84-ship` cut from current `origin/main`
- [x] Commit message follows release convention with task/PR traceability
- [ ] CI green on this PR (waiting)
- [ ] Merge via `gh pr merge --merge` (NOT squash — preserves provenance per ADR-062)
- [ ] Tag `v2026.5.84` from main after merge (owner runs)
- [ ] npm publish via trusted-publisher OIDC on tag push (OWNER HITL)

## Notes

- ferrous-forge safety bypass was active for the release commit (audit-logged, 24h, reason recorded). All other repo gates (lockfile drift, migration linter, ADR-057 SSoT, biome) passed.
- Pre-commit hook normally runs cargo-tarpaulin + clippy --all-features which takes 40+ minutes; bypass is the documented sanctioned mechanism for release commits.
- Owner must run tag + push after merge (NOT executed by this PR).