### PR TITLE
feat(T9627): docs slugs + types + project listing (T9636/T9637/T9638)

### DIFF
--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -241,13 +241,13 @@ const addCommand = defineCommand({
 
 // ── cleo docs list ───────────────────────────────────────────────────────────
 
-/** cleo docs list [--task T###] [--session ses_*] [--observation O###] [--type TYPE] — list attachments. */
+/** cleo docs list [--task T###] [--session ses_*] [--observation O###] [--project] [--type TYPE] — list attachments. */
 const listCommand = defineCommand({
   meta: {
     name: 'list',
     description:
-      'List attachments for a CLEO entity. Provide exactly one of --task, --session, or --observation. ' +
-      '--type filters across any scope (T9637).',
+      'List attachments. Provide exactly one of --task, --session, --observation, or --project. ' +
+      '--type filters across any scope (T9637/T9638).',
   },
   args: {
     task: {
@@ -262,6 +262,11 @@ const listCommand = defineCommand({
       type: 'string',
       description: 'Filter by observation ID (e.g. O-abc123)',
     },
+    project: {
+      type: 'boolean',
+      description:
+        'List ALL attachments in the project (T9638). Mutually exclusive with --task/--session/--observation.',
+    },
     type: {
       type: 'string',
       description: 'Filter by classification: spec|adr|research|handoff|note|llm-readme (T9637)',
@@ -271,10 +276,18 @@ const listCommand = defineCommand({
     const task = args.task ?? undefined;
     const session = args.session ?? undefined;
     const observation = args.observation ?? undefined;
+    const project = args.project === true;
     const type = args.type ?? undefined;
 
-    if (!task && !session && !observation) {
-      cliError('provide one of --task <id>, --session <id>, or --observation <id>', 6, {
+    const scopeCount = [task, session, observation].filter(Boolean).length + (project ? 1 : 0);
+    if (scopeCount === 0) {
+      cliError('provide one of --task <id>, --session <id>, --observation <id>, or --project', 6, {
+        name: 'E_VALIDATION',
+      });
+      process.exit(6);
+    }
+    if (scopeCount > 1) {
+      cliError('--task, --session, --observation, and --project are mutually exclusive', 6, {
         name: 'E_VALIDATION',
       });
       process.exit(6);
@@ -288,6 +301,7 @@ const listCommand = defineCommand({
         ...(task ? { task } : {}),
         ...(session ? { session } : {}),
         ...(observation ? { observation } : {}),
+        ...(project ? { project: true } : {}),
         ...(type ? { type } : {}),
       },
       { command: 'docs list' },

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -202,6 +202,10 @@ const addCommand = defineCommand({
         'Human-friendly kebab-case alias for the attachment, unique per project (T9636). ' +
         'Collision returns E_SLUG_TAKEN with 3 alternative suggestions.',
     },
+    type: {
+      type: 'string',
+      description: 'Taxonomy classification: spec|adr|research|handoff|note|llm-readme (T9637)',
+    },
   },
   async run({ args }) {
     const ownerId = args['owner-id'];
@@ -228,6 +232,7 @@ const addCommand = defineCommand({
         ...(args.labels ? { labels: args.labels } : {}),
         ...(args['attached-by'] ? { attachedBy: args['attached-by'] } : {}),
         ...(args.slug ? { slug: args.slug } : {}),
+        ...(args.type ? { type: args.type } : {}),
       },
       { command: 'docs add' },
     );
@@ -236,12 +241,13 @@ const addCommand = defineCommand({
 
 // ── cleo docs list ───────────────────────────────────────────────────────────
 
-/** cleo docs list [--task T###] [--session ses_*] [--observation O###] — list attachments. */
+/** cleo docs list [--task T###] [--session ses_*] [--observation O###] [--type TYPE] — list attachments. */
 const listCommand = defineCommand({
   meta: {
     name: 'list',
     description:
-      'List attachments for a CLEO entity. Provide exactly one of --task, --session, or --observation.',
+      'List attachments for a CLEO entity. Provide exactly one of --task, --session, or --observation. ' +
+      '--type filters across any scope (T9637).',
   },
   args: {
     task: {
@@ -256,11 +262,16 @@ const listCommand = defineCommand({
       type: 'string',
       description: 'Filter by observation ID (e.g. O-abc123)',
     },
+    type: {
+      type: 'string',
+      description: 'Filter by classification: spec|adr|research|handoff|note|llm-readme (T9637)',
+    },
   },
   async run({ args }) {
     const task = args.task ?? undefined;
     const session = args.session ?? undefined;
     const observation = args.observation ?? undefined;
+    const type = args.type ?? undefined;
 
     if (!task && !session && !observation) {
       cliError('provide one of --task <id>, --session <id>, or --observation <id>', 6, {
@@ -277,6 +288,7 @@ const listCommand = defineCommand({
         ...(task ? { task } : {}),
         ...(session ? { session } : {}),
         ...(observation ? { observation } : {}),
+        ...(type ? { type } : {}),
       },
       { command: 'docs list' },
     );

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -166,7 +166,8 @@ const addCommand = defineCommand({
     name: 'add',
     description:
       'Attach a local file or remote URL to a CLEO entity (task, session, observation). ' +
-      'Owner type is inferred from the ID prefix: T### → task, ses_* → session, O-* → observation.',
+      'Owner type is inferred from the ID prefix: T### → task, ses_* → session, O-* → observation. ' +
+      'Use --slug to set a human-friendly alias (unique per project) (T9636).',
   },
   args: {
     'owner-id': {
@@ -195,6 +196,12 @@ const addCommand = defineCommand({
       type: 'string',
       description: 'Agent identity that created the attachment (default: "human")',
     },
+    slug: {
+      type: 'string',
+      description:
+        'Human-friendly kebab-case alias for the attachment, unique per project (T9636). ' +
+        'Collision returns E_SLUG_TAKEN with 3 alternative suggestions.',
+    },
   },
   async run({ args }) {
     const ownerId = args['owner-id'];
@@ -220,6 +227,7 @@ const addCommand = defineCommand({
         ...(args.desc ? { desc: args.desc } : {}),
         ...(args.labels ? { labels: args.labels } : {}),
         ...(args['attached-by'] ? { attachedBy: args['attached-by'] } : {}),
+        ...(args.slug ? { slug: args.slug } : {}),
       },
       { command: 'docs add' },
     );

--- a/packages/cleo/src/dispatch/domains/__tests__/docs-slug-type-project.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/docs-slug-type-project.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Integration tests for the slug + type + project-scope features on the
+ * `cleo docs` dispatch surface.
+ *
+ * Covers:
+ *   - T9636: add --slug, slug collision → E_SLUG_TAKEN with suggestions,
+ *            invalid slug → E_INVALID_SLUG, fetch by slug.
+ *   - T9637: add --type, invalid type → E_INVALID_TYPE, list --type filter.
+ *   - T9638: list --project, scope mutual-exclusivity at dispatch level.
+ *   - Backward compat: att_*-id fetch + full sha256 fetch + sha256 prefix
+ *     fetch all keep working.
+ *
+ * @task T9636 / T9637 / T9638
+ * @epic T9627
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DocsHandler } from '../docs.js';
+
+let tempDir: string;
+let fixtureA: string;
+let fixtureB: string;
+let fixtureC: string;
+
+describe('docs dispatch — slug/type/project (T9636/T9637/T9638)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-docs-slug-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+
+    fixtureA = join(tempDir, 'a.md');
+    fixtureB = join(tempDir, 'b.md');
+    fixtureC = join(tempDir, 'c.md');
+    await writeFile(fixtureA, '# A\n\nfirst fixture', 'utf-8');
+    await writeFile(fixtureB, '# B\n\nsecond fixture (different)', 'utf-8');
+    await writeFile(fixtureC, '# C\n\nthird fixture entirely', 'utf-8');
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('@cleocode/core/internal');
+    closeDb();
+    delete process.env['CLEO_DIR'];
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // T9636 — slug
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('docs.add --slug stores the slug and surfaces it on the result', async () => {
+    const handler = new DocsHandler();
+
+    const resp = await handler.mutate('add', {
+      ownerId: 'T100',
+      file: fixtureA,
+      slug: 'my-spec',
+    });
+
+    expect(resp.success).toBe(true);
+    const data = resp.data as { attachmentId: string; slug?: string };
+    expect(data.slug).toBe('my-spec');
+    expect(data.attachmentId).toBeTruthy();
+  });
+
+  it('docs.add --slug collision returns E_SLUG_TAKEN with 3 suggestions', async () => {
+    const handler = new DocsHandler();
+
+    const first = await handler.mutate('add', {
+      ownerId: 'T100',
+      file: fixtureA,
+      slug: 'shared-slug',
+    });
+    expect(first.success).toBe(true);
+
+    const second = await handler.mutate('add', {
+      ownerId: 'T101',
+      file: fixtureB,
+      slug: 'shared-slug',
+    });
+
+    expect(second.success).toBe(false);
+    expect(second.error?.code).toBe('E_SLUG_TAKEN');
+    const details = second.error?.details as { suggestions: string[] } | undefined;
+    expect(details).toBeDefined();
+    expect(details?.suggestions).toHaveLength(3);
+    for (const s of details?.suggestions ?? []) {
+      expect(typeof s).toBe('string');
+      expect(s.length).toBeGreaterThan(0);
+    }
+    expect(new Set(details?.suggestions).size).toBe(3);
+  });
+
+  it('docs.add --slug with invalid shape returns E_INVALID_SLUG', async () => {
+    const handler = new DocsHandler();
+
+    const resp = await handler.mutate('add', {
+      ownerId: 'T100',
+      file: fixtureA,
+      slug: 'NotKebabCase!', // uppercase + bang — fails SLUG_PATTERN
+    });
+
+    expect(resp.success).toBe(false);
+    expect(resp.error?.code).toBe('E_INVALID_SLUG');
+  });
+
+  it('docs.fetch by slug resolves the attachment', async () => {
+    const handler = new DocsHandler();
+
+    const add = await handler.mutate('add', {
+      ownerId: 'T200',
+      file: fixtureA,
+      slug: 'fetchable',
+    });
+    expect(add.success).toBe(true);
+    const addData = add.data as { attachmentId: string };
+
+    const fetched = await handler.query('fetch', { attachmentRef: 'fetchable' });
+    expect(fetched.success).toBe(true);
+    const data = fetched.data as { metadata: { id: string; slug?: string } };
+    expect(data.metadata.id).toBe(addData.attachmentId);
+    expect(data.metadata.slug).toBe('fetchable');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // T9637 — type
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('docs.add --type stores the classification', async () => {
+    const handler = new DocsHandler();
+
+    const resp = await handler.mutate('add', {
+      ownerId: 'T300',
+      file: fixtureA,
+      type: 'adr',
+    });
+
+    expect(resp.success).toBe(true);
+    const data = resp.data as { type?: string };
+    expect(data.type).toBe('adr');
+  });
+
+  it('docs.add --type invalid value returns E_INVALID_TYPE', async () => {
+    const handler = new DocsHandler();
+
+    const resp = await handler.mutate('add', {
+      ownerId: 'T300',
+      file: fixtureA,
+      // Not in DOCS_TYPE_VALUES.
+      type: 'wishlist',
+    });
+
+    expect(resp.success).toBe(false);
+    expect(resp.error?.code).toBe('E_INVALID_TYPE');
+  });
+
+  it('docs.list --type filters owner-scoped attachments', async () => {
+    const handler = new DocsHandler();
+
+    await handler.mutate('add', { ownerId: 'T400', file: fixtureA, type: 'spec' });
+    await handler.mutate('add', { ownerId: 'T400', file: fixtureB, type: 'adr' });
+    await handler.mutate('add', { ownerId: 'T400', file: fixtureC, type: 'spec' });
+
+    const specs = await handler.query('list', { task: 'T400', type: 'spec' });
+    expect(specs.success).toBe(true);
+    const data = specs.data as {
+      count: number;
+      type?: string;
+      attachments: Array<{ type?: string }>;
+    };
+    expect(data.count).toBe(2);
+    expect(data.type).toBe('spec');
+    for (const a of data.attachments) expect(a.type).toBe('spec');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // T9638 — project scope
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('docs.list --project lists attachments across every owner', async () => {
+    const handler = new DocsHandler();
+
+    await handler.mutate('add', { ownerId: 'T500', file: fixtureA, slug: 'proj-a' });
+    await handler.mutate('add', { ownerId: 'T501', file: fixtureB, slug: 'proj-b' });
+    await handler.mutate('add', { ownerId: 'ses_xyz', file: fixtureC, slug: 'proj-c' });
+
+    const resp = await handler.query('list', { project: true });
+    expect(resp.success).toBe(true);
+    const data = resp.data as {
+      ownerId: string;
+      project?: boolean;
+      count: number;
+      attachments: Array<{ slug?: string; ownerId?: string; ownerType?: string }>;
+    };
+    expect(data.project).toBe(true);
+    expect(data.ownerId).toBe('');
+    expect(data.count).toBeGreaterThanOrEqual(3);
+
+    const slugs = data.attachments.map((a) => a.slug).filter(Boolean);
+    expect(slugs).toContain('proj-a');
+    expect(slugs).toContain('proj-b');
+    expect(slugs).toContain('proj-c');
+
+    const ownerTypes = new Set(
+      data.attachments.map((a) => a.ownerType).filter((t): t is string => Boolean(t)),
+    );
+    expect(ownerTypes.has('task')).toBe(true);
+    expect(ownerTypes.has('session')).toBe(true);
+  });
+
+  it('docs.list --project --type combines project scope + type filter', async () => {
+    const handler = new DocsHandler();
+
+    await handler.mutate('add', { ownerId: 'T600', file: fixtureA, type: 'spec' });
+    await handler.mutate('add', { ownerId: 'T601', file: fixtureB, type: 'adr' });
+    await handler.mutate('add', { ownerId: 'T602', file: fixtureC, type: 'spec' });
+
+    const resp = await handler.query('list', { project: true, type: 'spec' });
+    expect(resp.success).toBe(true);
+    const data = resp.data as {
+      count: number;
+      attachments: Array<{ type?: string }>;
+    };
+    expect(data.count).toBe(2);
+    for (const a of data.attachments) expect(a.type).toBe('spec');
+  });
+
+  it('docs.list with no scope returns E_INVALID_INPUT', async () => {
+    const handler = new DocsHandler();
+
+    const resp = await handler.query('list', {});
+    expect(resp.success).toBe(false);
+    expect(resp.error?.code).toBe('E_INVALID_INPUT');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Backward compat — existing resolution paths still work
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('docs.fetch by attachment ID still resolves (backward compat)', async () => {
+    const handler = new DocsHandler();
+
+    const add = await handler.mutate('add', { ownerId: 'T700', file: fixtureA });
+    expect(add.success).toBe(true);
+    const addData = add.data as { attachmentId: string };
+
+    const fetched = await handler.query('fetch', { attachmentRef: addData.attachmentId });
+    expect(fetched.success).toBe(true);
+    const data = fetched.data as { metadata: { id: string } };
+    expect(data.metadata.id).toBe(addData.attachmentId);
+  });
+
+  it('docs.fetch by full sha256 still resolves (backward compat)', async () => {
+    const handler = new DocsHandler();
+
+    const add = await handler.mutate('add', { ownerId: 'T800', file: fixtureA });
+    expect(add.success).toBe(true);
+    const addData = add.data as { sha256: string };
+
+    const fetched = await handler.query('fetch', { attachmentRef: addData.sha256 });
+    expect(fetched.success).toBe(true);
+    const data = fetched.data as { metadata: { sha256: string } };
+    // The stored sha256 is full 64hex; the wire row truncates it for list
+    // but fetch returns the full digest in its top-level field as well.
+    expect(addData.sha256).toMatch(/^[0-9a-f]{64}$/);
+    // Truncated form on the row is acceptable; the request used the full hash
+    // so resolution succeeded — that's the assertion that matters.
+    expect(data.metadata).toBeDefined();
+  });
+
+  it('docs.fetch by sha256 prefix (>=6 hex) resolves uniquely', async () => {
+    const handler = new DocsHandler();
+
+    const add = await handler.mutate('add', { ownerId: 'T801', file: fixtureA });
+    expect(add.success).toBe(true);
+    const addData = add.data as { sha256: string };
+
+    const prefix = addData.sha256.slice(0, 10);
+    const fetched = await handler.query('fetch', { attachmentRef: prefix });
+    expect(fetched.success).toBe(true);
+  });
+});

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -43,7 +43,6 @@ import type {
   DocsRemoveResult,
   DocsType,
 } from '@cleocode/contracts/operations/docs';
-import { DOCS_TYPE_VALUES } from '@cleocode/contracts/operations/docs';
 import type {
   AttachmentRef,
   LlmsTxtAttachment,
@@ -65,6 +64,26 @@ import { defineTypedHandler, lafsError, lafsSuccess, typedDispatch } from '../ad
 import type { DispatchResponse, DomainHandler } from '../types.js';
 import { handleErrorResult, unsupportedOp } from './_base.js';
 import { dispatchMeta } from './_meta.js';
+
+/**
+ * Local copy of the closed taxonomy values for runtime validation.
+ *
+ * Kept in lock-step with `DOCS_TYPE_VALUES` exported from
+ * `@cleocode/contracts/operations/docs` — the contracts module is the
+ * authoritative SSoT; this constant exists only because the test runner's
+ * alias map doesn't resolve subpath runtime imports for `@cleocode/contracts`,
+ * forcing the dispatch layer to keep a local mirror.
+ *
+ * @task T9637
+ */
+const DOCS_TYPE_VALUES = [
+  'spec',
+  'adr',
+  'research',
+  'handoff',
+  'note',
+  'llm-readme',
+] as const satisfies readonly DocsType[];
 
 // ─── DocsTypedOps ─────────────────────────────────────────────────────────────
 
@@ -869,7 +888,7 @@ function docsEnvelopeToResponse(
   envelope: {
     success: boolean;
     data?: unknown;
-    error?: { code: string | number; message: string };
+    error?: { code: string | number; message: string; details?: Record<string, unknown> };
   },
   gateway: string,
   operation: string,
@@ -882,6 +901,9 @@ function docsEnvelopeToResponse(
       error: {
         code: String(envelope.error?.code ?? 'E_INTERNAL'),
         message: envelope.error?.message ?? 'Unknown error',
+        // T9636 — preserve structured details (e.g. slug suggestions) so the
+        // CLI can render alternative slugs without a separate API call.
+        ...(envelope.error?.details !== undefined ? { details: envelope.error.details } : {}),
       },
     };
   }

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -57,6 +57,7 @@ import {
   getCleoDirAbsolute,
   getProjectRoot,
   resolveAttachmentBackend,
+  SlugCollisionError,
 } from '@cleocode/core/internal';
 import { defineTypedHandler, lafsError, lafsSuccess, typedDispatch } from '../adapters/typed.js';
 import type { DispatchResponse, DomainHandler } from '../types.js';
@@ -146,6 +147,41 @@ function mimeFromPath(filePath: string): string {
   if (lower.endsWith('.js')) return 'text/javascript';
   if (lower.endsWith('.css')) return 'text/css';
   return 'application/octet-stream';
+}
+
+// ─── Slug helpers (T9636) ────────────────────────────────────────────────────
+
+/**
+ * Slug validation: lowercase, kebab-case, 1–80 chars, no leading/trailing dash.
+ *
+ * @task T9636
+ */
+const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const SLUG_MAX_LEN = 80;
+
+/**
+ * Validate a slug string against {@link SLUG_PATTERN}.
+ *
+ * @returns `{ valid: true }` when the slug matches; `{ valid: false, reason }`
+ *   carrying a human-readable error otherwise.
+ */
+function validateSlug(raw: unknown): { valid: false; reason: string } | { valid: true } {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return { valid: false, reason: 'slug must be a non-empty string' };
+  }
+  if (raw.length > SLUG_MAX_LEN) {
+    return { valid: false, reason: `slug exceeds ${SLUG_MAX_LEN} characters` };
+  }
+  if (!SLUG_PATTERN.test(raw)) {
+    return {
+      valid: false,
+      reason:
+        "slug must be lowercase kebab-case (matches /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/) — got '" +
+        raw +
+        "'",
+    };
+  }
+  return { valid: true };
 }
 
 // ─── Typed inner handler ──────────────────────────────────────────────────────
@@ -284,10 +320,23 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
 
     const store = createAttachmentStore();
 
-    // Try by attachment ID first, then by SHA-256.
+    // Resolution order (T9636 acceptance #5/#7):
+    //   1. Full SHA-256 hex (64 chars, case-insensitive)
+    //   2. Attachment ID (att_* / UUID)
+    //   3. Slug (kebab-case match)
+    //   4. SHA-256 prefix (>= 6 hex chars, unique match)
+    //
+    // The order keeps backward-compat: pre-T9636 callers pass att_id or full
+    // sha256; new callers can pass slug. The slug check comes BEFORE prefix
+    // resolution because slugs have a stricter pattern (lowercase letters
+    // mixed with hyphens) than a hex prefix, so the discriminator is exact.
     const isSha256 = /^[0-9a-f]{64}$/i.test(ref);
+    const looksLikeAttId = /^(att_|[0-9a-f]{8}-)/i.test(ref);
+    const looksLikeSlug = SLUG_PATTERN.test(ref) && !/^[0-9a-f]+$/i.test(ref);
+    const isHexPrefix = /^[0-9a-f]{6,63}$/i.test(ref);
+
     let fetchResult: Awaited<ReturnType<typeof store.get>> | null = null;
-    let metadata = await store.getMetadata(ref);
+    let metadata = isSha256 ? null : looksLikeAttId ? await store.getMetadata(ref) : null;
 
     if (metadata) {
       // Resolved by ID — get bytes via sha256
@@ -296,6 +345,50 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       fetchResult = await store.get(ref);
       if (fetchResult) {
         metadata = fetchResult.metadata;
+      }
+    }
+
+    // Slug fallback
+    if (!metadata && looksLikeSlug) {
+      const bySlug = await store.findBySlug(ref);
+      if (bySlug) {
+        metadata = bySlug.metadata;
+        fetchResult = await store.get(metadata.sha256);
+      }
+    }
+
+    // SHA-256 prefix fallback (>=6 chars). We scan attachment_refs distinct
+    // ids and find the unique row whose sha256 startsWith ref. Ambiguous
+    // prefixes return E_AMBIGUOUS to avoid silently picking the wrong blob.
+    if (!metadata && isHexPrefix) {
+      const projectList = await store.listAllInProject();
+      const seen = new Map<string, (typeof projectList)[number]>();
+      for (const row of projectList) {
+        if (row.metadata.sha256.toLowerCase().startsWith(ref.toLowerCase())) {
+          seen.set(row.metadata.id, row);
+        }
+      }
+      if (seen.size > 1) {
+        return lafsError(
+          'E_AMBIGUOUS',
+          `sha256 prefix '${ref}' matches ${seen.size} attachments — provide more hex digits`,
+          'fetch',
+        );
+      }
+      const hit = seen.values().next().value;
+      if (hit) {
+        metadata = hit.metadata;
+        fetchResult = await store.get(metadata.sha256);
+      }
+    }
+
+    // Fallback: try plain getMetadata even if it didn't look like an att-id —
+    // some pre-T9636 callers used arbitrary IDs.
+    if (!metadata && !looksLikeAttId) {
+      const direct = await store.getMetadata(ref);
+      if (direct) {
+        metadata = direct;
+        fetchResult = await store.get(direct.sha256);
       }
     }
 
@@ -332,6 +425,9 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
 
     const backend: AttachmentBackend = await resolveAttachmentBackend();
 
+    // Re-read slug so the wire envelope mirrors what's in the DB (T9636).
+    const extras = await store.getExtras(metadata.id);
+
     return lafsSuccess<DocsFetchResult>(
       {
         // Project the domain AttachmentMetadata (nested `attachment` object) into the
@@ -352,6 +448,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           labels: metadata.attachment.labels,
           createdAt: metadata.createdAt,
           refCount: metadata.refCount,
+          ...(extras?.slug ? { slug: extras.slug } : {}),
         },
         path: storagePath,
         sizeBytes: fetchResult.bytes.length,
@@ -374,6 +471,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       desc: description,
       labels: rawLabels,
       attachedBy: rawAttachedBy,
+      slug: rawSlug,
     } = params;
     if (!ownerId) {
       return lafsError('E_INVALID_INPUT', 'ownerId is required', 'add');
@@ -386,6 +484,19 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
         'add',
       );
     }
+
+    // T9636 — validate slug (shape only; uniqueness is checked by the store).
+    let slug: string | undefined;
+    if (rawSlug !== undefined) {
+      const check = validateSlug(rawSlug);
+      if (!check.valid) {
+        return lafsError('E_INVALID_SLUG', check.reason, 'add');
+      }
+      slug = rawSlug as string;
+    }
+
+    const extras: { slug?: string; type?: string } = {};
+    if (slug !== undefined) extras.slug = slug;
 
     const labels = parseLabels(rawLabels);
     const attachedBy = rawAttachedBy ?? 'human';
@@ -412,7 +523,33 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
         ...(labels ? { labels } : {}),
       };
 
-      const meta = await store.put(bytes, attachment, ownerType, ownerId, attachedBy);
+      let meta: Awaited<ReturnType<typeof store.put>>;
+      try {
+        meta = await store.put(
+          bytes,
+          attachment,
+          ownerType,
+          ownerId,
+          attachedBy,
+          undefined,
+          extras,
+        );
+      } catch (err) {
+        if (err instanceof SlugCollisionError) {
+          // Construct the envelope directly so we can attach `suggestions` to
+          // the error.details payload — `lafsError()` does not accept extra
+          // fields beyond `code/message/fix`.
+          return {
+            success: false,
+            error: {
+              code: 'E_SLUG_TAKEN',
+              message: `slug '${err.slug}' is already in use in this project`,
+              details: { suggestions: err.suggestions },
+            },
+          };
+        }
+        throw err;
+      }
 
       // T947 Wave B — also mirror the write through the unified v2 store
       // so llmtxt-backed manifests learn about the attachment. The v2
@@ -458,6 +595,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           ownerType,
           // Cast: core returns 'llmtxt'|'legacy'; contracts uses 'legacy'|'llmstxt-v2' (T1529)
           attachmentBackend: backend as DocsAddResult['attachmentBackend'],
+          ...(slug !== undefined ? { slug } : {}),
         },
         'add',
       );
@@ -474,7 +612,30 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
 
       // For URL-only attachments, use the URL as content so we have a sha256
       const urlBytes = Buffer.from(url, 'utf-8');
-      const meta = await store.put(urlBytes, attachment, ownerType, ownerId, attachedBy);
+      let meta: Awaited<ReturnType<typeof store.put>>;
+      try {
+        meta = await store.put(
+          urlBytes,
+          attachment,
+          ownerType,
+          ownerId,
+          attachedBy,
+          undefined,
+          extras,
+        );
+      } catch (err) {
+        if (err instanceof SlugCollisionError) {
+          return {
+            success: false,
+            error: {
+              code: 'E_SLUG_TAKEN',
+              message: `slug '${err.slug}' is already in use in this project`,
+              details: { suggestions: err.suggestions },
+            },
+          };
+        }
+        throw err;
+      }
 
       // T945 Stage A — mint `llmtxt:<sha256>` node + `embeds` edge for the
       // URL attachment (the URL itself is the content-addressable identity).
@@ -500,6 +661,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           ownerType,
           // Cast: core returns 'llmtxt'|'legacy'; contracts uses 'legacy'|'llmstxt-v2' (T1529)
           attachmentBackend: backend as DocsAddResult['attachmentBackend'],
+          ...(slug !== undefined ? { slug } : {}),
         },
         'add',
       );

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -41,7 +41,9 @@ import type {
   DocsListResult,
   DocsRemoveParams,
   DocsRemoveResult,
+  DocsType,
 } from '@cleocode/contracts/operations/docs';
+import { DOCS_TYPE_VALUES } from '@cleocode/contracts/operations/docs';
 import type {
   AttachmentRef,
   LlmsTxtAttachment,
@@ -184,6 +186,15 @@ function validateSlug(raw: unknown): { valid: false; reason: string } | { valid:
   return { valid: true };
 }
 
+/**
+ * Validate a type value against the closed {@link DOCS_TYPE_VALUES} set.
+ *
+ * @task T9637
+ */
+function validateDocsType(raw: unknown): raw is DocsType {
+  return typeof raw === 'string' && (DOCS_TYPE_VALUES as readonly string[]).includes(raw as string);
+}
+
 // ─── Typed inner handler ──────────────────────────────────────────────────────
 
 /**
@@ -212,21 +223,50 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       );
     }
 
+    // Validate `--type` filter if provided (T9637).
+    let typeFilter: DocsType | undefined;
+    if (params.type !== undefined) {
+      if (!validateDocsType(params.type)) {
+        return lafsError(
+          'E_INVALID_TYPE',
+          `type must be one of: ${DOCS_TYPE_VALUES.join('|')} — got '${String(params.type)}'`,
+          'list',
+        );
+      }
+      typeFilter = params.type;
+    }
+
     const ownerType = inferOwnerType(ownerId);
     // Legacy store still drives the envelope because it tracks URL and
     // llms-txt kinds the v2 interface does not expose. `backend` metadata
     // reports the path that FUTURE writes would take, so operators can
     // observe llmtxt adoption without changing the data contract.
     const store = createAttachmentStore();
-    const attachments = await store.listByOwner(ownerType, ownerId);
+    const ownerAttachments = await store.listByOwner(ownerType, ownerId);
     const backend: AttachmentBackend = await resolveAttachmentBackend();
+
+    // T9637 — apply the type filter post-list. listByOwner returns
+    // AttachmentMetadata (no slug/type), so we re-hydrate via getExtras().
+    const enriched: Array<{
+      meta: (typeof ownerAttachments)[number];
+      slug: string | null;
+      type: string | null;
+    }> = [];
+    for (const m of ownerAttachments) {
+      const extras = await store.getExtras(m.id);
+      const slug = extras?.slug ?? null;
+      const type = extras?.type ?? null;
+      if (typeFilter !== undefined && type !== typeFilter) continue;
+      enriched.push({ meta: m, slug, type });
+    }
 
     return lafsSuccess<DocsListResult>(
       {
         ownerId,
         ownerType,
-        count: attachments.length,
-        attachments: attachments.map((m) => ({
+        ...(typeFilter !== undefined ? { type: typeFilter } : {}),
+        count: enriched.length,
+        attachments: enriched.map(({ meta: m, slug, type }) => ({
           id: m.id,
           sha256: `${m.sha256.slice(0, 8)}…`,
           kind: m.attachment.kind,
@@ -242,6 +282,8 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           labels: m.attachment.labels,
           createdAt: m.createdAt,
           refCount: m.refCount,
+          ...(slug ? { slug } : {}),
+          ...(type ? { type: type as DocsType } : {}),
         })),
         // Cast: core returns 'llmtxt'|'legacy'; contracts uses 'legacy'|'llmstxt-v2' (drift T1529)
         attachmentBackend: backend as DocsListResult['attachmentBackend'],
@@ -449,6 +491,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           createdAt: metadata.createdAt,
           refCount: metadata.refCount,
           ...(extras?.slug ? { slug: extras.slug } : {}),
+          ...(extras?.type ? { type: extras.type as DocsType } : {}),
         },
         path: storagePath,
         sizeBytes: fetchResult.bytes.length,
@@ -472,6 +515,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       labels: rawLabels,
       attachedBy: rawAttachedBy,
       slug: rawSlug,
+      type: rawType,
     } = params;
     if (!ownerId) {
       return lafsError('E_INVALID_INPUT', 'ownerId is required', 'add');
@@ -495,8 +539,22 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       slug = rawSlug as string;
     }
 
+    // T9637 — validate type against the closed taxonomy set.
+    let type: DocsType | undefined;
+    if (rawType !== undefined) {
+      if (!validateDocsType(rawType)) {
+        return lafsError(
+          'E_INVALID_TYPE',
+          `type must be one of: ${DOCS_TYPE_VALUES.join('|')} — got '${String(rawType)}'`,
+          'add',
+        );
+      }
+      type = rawType;
+    }
+
     const extras: { slug?: string; type?: string } = {};
     if (slug !== undefined) extras.slug = slug;
+    if (type !== undefined) extras.type = type;
 
     const labels = parseLabels(rawLabels);
     const attachedBy = rawAttachedBy ?? 'human';
@@ -596,6 +654,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           // Cast: core returns 'llmtxt'|'legacy'; contracts uses 'legacy'|'llmstxt-v2' (T1529)
           attachmentBackend: backend as DocsAddResult['attachmentBackend'],
           ...(slug !== undefined ? { slug } : {}),
+          ...(type !== undefined ? { type } : {}),
         },
         'add',
       );
@@ -662,6 +721,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           // Cast: core returns 'llmtxt'|'legacy'; contracts uses 'legacy'|'llmstxt-v2' (T1529)
           attachmentBackend: backend as DocsAddResult['attachmentBackend'],
           ...(slug !== undefined ? { slug } : {}),
+          ...(type !== undefined ? { type } : {}),
         },
         'add',
       );

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -215,10 +215,12 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
     // SSoT-EXEMPT:dispatch-normalize — docs.list accepts three aliased owner params;
     // normalization to ownerId is a docs-domain concern, not a Core concern.
     const ownerId = params.task ?? params.session ?? params.observation;
-    if (!ownerId) {
+    const isProjectScope = params.project === true;
+
+    if (!ownerId && !isProjectScope) {
       return lafsError(
         'E_INVALID_INPUT',
-        'Provide one of --task, --session, or --observation to scope the list.',
+        'Provide one of --task, --session, --observation, or --project to scope the list.',
         'list',
       );
     }
@@ -236,14 +238,61 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       typeFilter = params.type;
     }
 
-    const ownerType = inferOwnerType(ownerId);
+    const store = createAttachmentStore();
+    const backend: AttachmentBackend = await resolveAttachmentBackend();
+
+    if (isProjectScope) {
+      // T9638 — project-scoped listing: union all attachment_refs into a flat
+      // row list. The shape stays compatible with DocsAttachmentRow by
+      // populating `ownerId` / `ownerType` per row instead of at the envelope.
+      const rows = await store.listAllInProject(
+        undefined,
+        typeFilter !== undefined ? { type: typeFilter } : undefined,
+      );
+
+      return lafsSuccess<DocsListResult>(
+        {
+          ownerId: '',
+          ownerType: 'task',
+          project: true,
+          ...(typeFilter !== undefined ? { type: typeFilter } : {}),
+          count: rows.length,
+          attachments: rows.map(({ metadata: m, slug, type, ownerId: oid, ownerType: ot }) => ({
+            id: m.id,
+            sha256: `${m.sha256.slice(0, 8)}…`,
+            kind: m.attachment.kind,
+            mime:
+              m.attachment.kind === 'local-file' || m.attachment.kind === 'blob'
+                ? m.attachment.mime
+                : ((m.attachment as UrlAttachment).mime ?? '—'),
+            size:
+              m.attachment.kind === 'local-file' || m.attachment.kind === 'blob'
+                ? m.attachment.size
+                : undefined,
+            description: m.attachment.description,
+            labels: m.attachment.labels,
+            createdAt: m.createdAt,
+            refCount: m.refCount,
+            ...(slug ? { slug } : {}),
+            ...(type ? { type: type as DocsType } : {}),
+            ownerId: oid,
+            ownerType: ot,
+          })),
+          attachmentBackend: backend as DocsListResult['attachmentBackend'],
+        },
+        'list',
+      );
+    }
+
+    // Owner-scoped listing (existing behaviour) — narrow to non-null after
+    // the project-scope branch.
+    const scopedOwner = ownerId as string;
+    const ownerType = inferOwnerType(scopedOwner);
     // Legacy store still drives the envelope because it tracks URL and
     // llms-txt kinds the v2 interface does not expose. `backend` metadata
     // reports the path that FUTURE writes would take, so operators can
     // observe llmtxt adoption without changing the data contract.
-    const store = createAttachmentStore();
-    const ownerAttachments = await store.listByOwner(ownerType, ownerId);
-    const backend: AttachmentBackend = await resolveAttachmentBackend();
+    const ownerAttachments = await store.listByOwner(ownerType, scopedOwner);
 
     // T9637 — apply the type filter post-list. listByOwner returns
     // AttachmentMetadata (no slug/type), so we re-hydrate via getExtras().
@@ -262,7 +311,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
 
     return lafsSuccess<DocsListResult>(
       {
-        ownerId,
+        ownerId: scopedOwner,
         ownerType,
         ...(typeFilter !== undefined ? { type: typeFilter } : {}),
         count: enriched.length,

--- a/packages/contracts/src/operations/docs.ts
+++ b/packages/contracts/src/operations/docs.ts
@@ -123,6 +123,16 @@ export interface DocsAttachmentRow {
    * @task T9637 (T-DOCS-SLUG-2)
    */
   type?: DocsType;
+  /**
+   * When the attachment is project-scoped (no specific entity owner), this
+   * row's owner ID / type still reflect how the attachment was registered.
+   * The `--project` list view simply unions all owner-types.
+   *
+   * @task T9638 (T-DOCS-SLUG-3)
+   */
+  ownerId?: string;
+  /** Owner type (only populated by `docs list --project`). */
+  ownerType?: AttachmentOwnerType;
 }
 
 /**
@@ -162,10 +172,13 @@ export interface AttachmentRecord {
 /**
  * Parameters for `docs.list`.
  *
- * Exactly one of `task`, `session`, or `observation` must be provided.
- * `type` is an optional filter that matches the {@link DocsType} taxonomy.
+ * Exactly one of `task`, `session`, `observation`, or `project` must be
+ * provided. `project=true` lists ALL attachments in the project DB
+ * regardless of owner. `type` is an optional filter applicable to every
+ * mode and matches the {@link DocsType} taxonomy exactly.
  *
  * @task T9637 (T-DOCS-SLUG-2 — `type` filter)
+ * @task T9638 (T-DOCS-SLUG-3 — `project` scope)
  */
 export interface DocsListParams {
   /** Task identifier to list attachments for. */
@@ -174,6 +187,12 @@ export interface DocsListParams {
   session?: string;
   /** Observation identifier to list attachments for. */
   observation?: string;
+  /**
+   * When true, list ALL attachments in the project (across every owner).
+   *
+   * @task T9638
+   */
+  project?: boolean;
   /**
    * Filter results to attachments whose `type` column equals this value.
    *
@@ -184,12 +203,19 @@ export interface DocsListParams {
 
 /**
  * Result of `docs.list`.
+ *
+ * When the caller passed `project: true`, `ownerId` is the empty string and
+ * `ownerType` is `"task"` (a stable placeholder so consumers don't have to
+ * widen their types); per-row owner information is carried on the
+ * {@link DocsAttachmentRow.ownerId} / `ownerType` fields instead.
  */
 export interface DocsListResult {
-  /** Owner entity ID. */
+  /** Owner entity ID (empty when `project: true`). */
   ownerId: string;
-  /** Inferred owner type. */
+  /** Inferred owner type (placeholder when `project: true`). */
   ownerType: AttachmentOwnerType;
+  /** True when the result represents the whole-project scope (T9638). */
+  project?: boolean;
   /** Type taxonomy filter, echoed back from the request when provided. */
   type?: DocsType;
   /** Count of attachments for this owner. */

--- a/packages/contracts/src/operations/docs.ts
+++ b/packages/contracts/src/operations/docs.ts
@@ -52,6 +52,32 @@ export type AttachmentOwnerType =
 export type { AttachmentKind } from '../attachment.js';
 
 /**
+ * Allowed values for the `--type` taxonomy on `cleo docs add`.
+ *
+ * The set is closed at the CLI surface; new values require a coordinated
+ * update to (1) {@link DOCS_TYPE_VALUES}, (2) the dispatch-layer guard, and
+ * (3) the citty CLI flag description. The DB column itself is open (no CHECK)
+ * so older clients reading a forward-compatible value gracefully degrade.
+ *
+ * @task T9637 (T-DOCS-SLUG-2)
+ */
+export const DOCS_TYPE_VALUES = [
+  'spec',
+  'adr',
+  'research',
+  'handoff',
+  'note',
+  'llm-readme',
+] as const;
+
+/**
+ * Closed-set type alias for {@link DOCS_TYPE_VALUES}.
+ *
+ * @task T9637
+ */
+export type DocsType = (typeof DOCS_TYPE_VALUES)[number];
+
+/**
  * Flattened wire-format attachment row returned by docs query operations.
  *
  * This is the **API response shape** — a denormalised projection of the domain
@@ -91,6 +117,12 @@ export interface DocsAttachmentRow {
    * @task T9636 (T-DOCS-SLUG-1)
    */
   slug?: string;
+  /**
+   * Optional taxonomy classification.
+   *
+   * @task T9637 (T-DOCS-SLUG-2)
+   */
+  type?: DocsType;
 }
 
 /**
@@ -131,6 +163,9 @@ export interface AttachmentRecord {
  * Parameters for `docs.list`.
  *
  * Exactly one of `task`, `session`, or `observation` must be provided.
+ * `type` is an optional filter that matches the {@link DocsType} taxonomy.
+ *
+ * @task T9637 (T-DOCS-SLUG-2 — `type` filter)
  */
 export interface DocsListParams {
   /** Task identifier to list attachments for. */
@@ -139,6 +174,12 @@ export interface DocsListParams {
   session?: string;
   /** Observation identifier to list attachments for. */
   observation?: string;
+  /**
+   * Filter results to attachments whose `type` column equals this value.
+   *
+   * @task T9637
+   */
+  type?: DocsType;
 }
 
 /**
@@ -149,6 +190,8 @@ export interface DocsListResult {
   ownerId: string;
   /** Inferred owner type. */
   ownerType: AttachmentOwnerType;
+  /** Type taxonomy filter, echoed back from the request when provided. */
+  type?: DocsType;
   /** Count of attachments for this owner. */
   count: number;
   /** Attachment metadata array. */
@@ -255,6 +298,13 @@ export interface DocsAddParams {
    * @task T9636 (T-DOCS-SLUG-1)
    */
   slug?: string;
+  /**
+   * Optional taxonomy classification. Must match one of
+   * {@link DOCS_TYPE_VALUES}; an invalid value returns `E_INVALID_TYPE`.
+   *
+   * @task T9637 (T-DOCS-SLUG-2)
+   */
+  type?: DocsType;
 }
 
 /**
@@ -279,6 +329,8 @@ export interface DocsAddResult {
   attachmentBackend?: AttachmentBackend;
   /** Slug recorded for this attachment, when provided (T9636). */
   slug?: string;
+  /** Type classification recorded for this attachment, when provided (T9637). */
+  type?: DocsType;
 }
 
 // --------------------------------------------------------------------------

--- a/packages/contracts/src/operations/docs.ts
+++ b/packages/contracts/src/operations/docs.ts
@@ -85,6 +85,12 @@ export interface DocsAttachmentRow {
   createdAt: string;
   /** Current reference count across all owners. */
   refCount: number;
+  /**
+   * Optional human-friendly slug for the attachment, unique per project.
+   *
+   * @task T9636 (T-DOCS-SLUG-1)
+   */
+  slug?: string;
 }
 
 /**
@@ -241,6 +247,14 @@ export interface DocsAddParams {
   labels?: string;
   /** Agent or service that attached this file (default: 'human'). */
   attachedBy?: string;
+  /**
+   * Optional human-friendly slug, unique per project. Pattern: kebab-case,
+   * `[a-z0-9][a-z0-9-]*[a-z0-9]?` (≥1 char, ≤80 chars). Collision returns
+   * `E_SLUG_TAKEN` with 3 alternative suggestions.
+   *
+   * @task T9636 (T-DOCS-SLUG-1)
+   */
+  slug?: string;
 }
 
 /**
@@ -263,6 +277,8 @@ export interface DocsAddResult {
   url?: string;
   /** Current attachment backend in use. */
   attachmentBackend?: AttachmentBackend;
+  /** Slug recorded for this attachment, when provided (T9636). */
+  slug?: string;
 }
 
 // --------------------------------------------------------------------------

--- a/packages/core/migrations/drizzle-tasks/20260519000001_t9636-t9637-add-slug-type-to-attachments/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260519000001_t9636-t9637-add-slug-type-to-attachments/migration.sql
@@ -1,0 +1,34 @@
+-- T9636 / T9637 — Add `slug` and `type` columns to `attachments` table.
+--
+-- Background: prior to this migration, attachments could only be addressed by
+-- their generated `att_<base62>` ID or by full / prefix SHA-256. Operators
+-- writing docs at the command line want short, human-friendly aliases — and
+-- a coarse classification axis to filter by intent (spec / adr / research /
+-- handoff / note / llm-readme).
+--
+-- Schema decision (Option B, per Epic T9627 design guidance): the legacy
+-- `attachments` table has no `projectId` column because tasks.db is itself
+-- per-project. Slug uniqueness is therefore enforced via a PARTIAL UNIQUE
+-- INDEX on (slug) WHERE slug IS NOT NULL. Rows without a slug remain
+-- non-unique (multiple attachments without a slug are allowed).
+--
+-- Backward compatibility:
+--   - Both columns are nullable. Existing rows pass-through with NULL slug
+--     and NULL type, so `cleo docs fetch <att_id>` and SHA-256-prefix lookup
+--     paths continue to work unchanged.
+--   - The `type` column does NOT carry a CHECK constraint: validation happens
+--     at the dispatch layer so future taxonomy additions don't require a
+--     schema migration.
+--
+-- @task T9636 (T-DOCS-SLUG-1 — slug column + uniqueness + collision suggestions)
+-- @task T9637 (T-DOCS-SLUG-2 — type taxonomy column)
+-- @epic T9627 (E-DOCS-SLUG-CLASSIFY)
+-- @saga T9625
+
+ALTER TABLE `attachments` ADD COLUMN `slug` text;
+--> statement-breakpoint
+ALTER TABLE `attachments` ADD COLUMN `type` text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uniq_attachments_slug` ON `attachments` (`slug`) WHERE `slug` IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_attachments_type` ON `attachments` (`type`) WHERE `type` IS NOT NULL;

--- a/packages/core/migrations/drizzle-tasks/20260519000001_t9636-t9637-add-slug-type-to-attachments/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260519000001_t9636-t9637-add-slug-type-to-attachments/revert.sql
@@ -1,0 +1,13 @@
+-- Revert T9636 / T9637 — drop the slug and type columns + indexes.
+--
+-- SQLite supports ALTER TABLE DROP COLUMN since v3.35 (2021), so this is a
+-- straightforward reversal. The unique partial index on slug is implicitly
+-- dropped when the slug column is dropped — listed explicitly for clarity.
+
+DROP INDEX IF EXISTS `uniq_attachments_slug`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_attachments_type`;
+--> statement-breakpoint
+ALTER TABLE `attachments` DROP COLUMN `slug`;
+--> statement-breakpoint
+ALTER TABLE `attachments` DROP COLUMN `type`;

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1054,9 +1054,13 @@ export type {
   StickyConvertTaskParams,
 } from './sticky/ops.js';
 export type { CreateStickyParams, ListStickiesParams, StickyNote } from './sticky/types.js';
-export type { DerefResult } from './store/attachment-store.js';
+export type { DerefResult, PutAttachmentExtras } from './store/attachment-store.js';
 // Attachment store (T760 docs domain)
-export { AttachmentIntegrityError, createAttachmentStore } from './store/attachment-store.js';
+export {
+  AttachmentIntegrityError,
+  createAttachmentStore,
+  SlugCollisionError,
+} from './store/attachment-store.js';
 // Attachment store v2 — unified llmtxt/legacy wrapper (T947 Wave B)
 export type {
   AttachmentBackend,

--- a/packages/core/src/store/__tests__/attachment-slug-type.test.ts
+++ b/packages/core/src/store/__tests__/attachment-slug-type.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for slug + type + project-scope listing on the attachment store.
+ *
+ * Each test uses an isolated temporary `.cleo/` so the tasks.db singleton is
+ * reset between runs (same pattern as attachment-store.test.ts).
+ *
+ * @task T9636 (slug + collision)
+ * @task T9637 (type taxonomy)
+ * @task T9638 (project-scoped listing)
+ * @epic T9627
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let tempDir: string;
+
+describe('AttachmentStore slug + type + project-scope', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-att-slug-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+    delete process.env['CLEO_DIR'];
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // T9636 — slug column + uniqueness + collision suggestions
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('put with --slug stores the slug and findBySlug resolves it', async () => {
+    const { createAttachmentStore } = await import('../attachment-store.js');
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStore();
+    const bytes = Buffer.from('hello world', 'utf-8');
+
+    const meta = await store.put(
+      bytes,
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: bytes.length },
+      'task',
+      'T001',
+      'test',
+      undefined,
+      { slug: 'my-doc' },
+    );
+
+    expect(meta.id).toBeTruthy();
+
+    const bySlug = await store.findBySlug('my-doc');
+    expect(bySlug).not.toBeNull();
+    expect(bySlug?.slug).toBe('my-doc');
+    expect(bySlug?.metadata.id).toBe(meta.id);
+
+    const extras = await store.getExtras(meta.id);
+    expect(extras?.slug).toBe('my-doc');
+    expect(extras?.type).toBeNull();
+  });
+
+  it('put with duplicate slug throws SlugCollisionError carrying 3 suggestions', async () => {
+    const { createAttachmentStore, SlugCollisionError } = await import('../attachment-store.js');
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStore();
+
+    await store.put(
+      Buffer.from('first', 'utf-8'),
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: 5 },
+      'task',
+      'T001',
+      'test',
+      undefined,
+      { slug: 'shared' },
+    );
+
+    // Different content (different sha256) trying to claim the same slug.
+    await expect(
+      store.put(
+        Buffer.from('second', 'utf-8'),
+        { kind: 'blob', storageKey: '', mime: 'text/plain', size: 6 },
+        'task',
+        'T002',
+        'test',
+        undefined,
+        { slug: 'shared' },
+      ),
+    ).rejects.toBeInstanceOf(SlugCollisionError);
+
+    try {
+      await store.put(
+        Buffer.from('third', 'utf-8'),
+        { kind: 'blob', storageKey: '', mime: 'text/plain', size: 5 },
+        'task',
+        'T003',
+        'test',
+        undefined,
+        { slug: 'shared' },
+      );
+      throw new Error('expected SlugCollisionError to be thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SlugCollisionError);
+      const sce = err as InstanceType<typeof SlugCollisionError>;
+      expect(sce.slug).toBe('shared');
+      expect(sce.suggestions).toHaveLength(3);
+      // Suggestions must be strings, non-empty, and distinct.
+      const unique = new Set(sce.suggestions);
+      expect(unique.size).toBe(3);
+      for (const s of sce.suggestions) {
+        expect(typeof s).toBe('string');
+        expect(s.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('put with the same slug on the same blob is a no-op (idempotent)', async () => {
+    const { createAttachmentStore } = await import('../attachment-store.js');
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStore();
+    const bytes = Buffer.from('same content', 'utf-8');
+
+    const first = await store.put(
+      bytes,
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: bytes.length },
+      'task',
+      'T001',
+      'test',
+      undefined,
+      { slug: 'doc' },
+    );
+
+    // Same bytes + same slug from a different owner — should NOT throw.
+    const second = await store.put(
+      bytes,
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: bytes.length },
+      'task',
+      'T002',
+      'test',
+      undefined,
+      { slug: 'doc' },
+    );
+
+    expect(second.id).toBe(first.id);
+    expect(second.sha256).toBe(first.sha256);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // T9637 — type taxonomy column
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('put with --type stores the type and getExtras retrieves it', async () => {
+    const { createAttachmentStore } = await import('../attachment-store.js');
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStore();
+    const bytes = Buffer.from('adr-content', 'utf-8');
+
+    const meta = await store.put(
+      bytes,
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: bytes.length },
+      'task',
+      'T001',
+      'test',
+      undefined,
+      { type: 'adr' },
+    );
+
+    const extras = await store.getExtras(meta.id);
+    expect(extras?.type).toBe('adr');
+    expect(extras?.slug).toBeNull();
+  });
+
+  it('put with both --slug and --type stores both columns', async () => {
+    const { createAttachmentStore } = await import('../attachment-store.js');
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStore();
+    const bytes = Buffer.from('spec', 'utf-8');
+
+    const meta = await store.put(
+      bytes,
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: bytes.length },
+      'task',
+      'T001',
+      'test',
+      undefined,
+      { slug: 'my-spec', type: 'spec' },
+    );
+
+    const extras = await store.getExtras(meta.id);
+    expect(extras?.slug).toBe('my-spec');
+    expect(extras?.type).toBe('spec');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // T9638 — listAllInProject + type filter
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('listAllInProject unions every owner ref with slug + type + ownerType', async () => {
+    const { createAttachmentStore } = await import('../attachment-store.js');
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStore();
+
+    await store.put(
+      Buffer.from('a', 'utf-8'),
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: 1 },
+      'task',
+      'T001',
+      'test',
+      undefined,
+      { slug: 'doc-a', type: 'spec' },
+    );
+    await store.put(
+      Buffer.from('b', 'utf-8'),
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: 1 },
+      'session',
+      'ses_xyz',
+      'test',
+      undefined,
+      { slug: 'doc-b', type: 'adr' },
+    );
+    await store.put(
+      Buffer.from('c', 'utf-8'),
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: 1 },
+      'task',
+      'T002',
+      'test',
+      undefined,
+      { type: 'note' },
+    );
+
+    const all = await store.listAllInProject();
+    expect(all.length).toBeGreaterThanOrEqual(3);
+
+    const slugs = all.map((r) => r.slug).filter((s): s is string => Boolean(s));
+    expect(slugs).toContain('doc-a');
+    expect(slugs).toContain('doc-b');
+
+    const types = all.map((r) => r.type).filter((t): t is string => Boolean(t));
+    expect(types).toContain('spec');
+    expect(types).toContain('adr');
+    expect(types).toContain('note');
+
+    const ownerTypes = new Set(all.map((r) => r.ownerType));
+    expect(ownerTypes.has('task')).toBe(true);
+    expect(ownerTypes.has('session')).toBe(true);
+  });
+
+  it('listAllInProject filters by type', async () => {
+    const { createAttachmentStore } = await import('../attachment-store.js');
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStore();
+
+    await store.put(
+      Buffer.from('1', 'utf-8'),
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: 1 },
+      'task',
+      'T001',
+      'test',
+      undefined,
+      { type: 'spec' },
+    );
+    await store.put(
+      Buffer.from('2', 'utf-8'),
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: 1 },
+      'task',
+      'T002',
+      'test',
+      undefined,
+      { type: 'adr' },
+    );
+    await store.put(
+      Buffer.from('3', 'utf-8'),
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: 1 },
+      'task',
+      'T003',
+      'test',
+      undefined,
+      { type: 'spec' },
+    );
+
+    const specs = await store.listAllInProject(undefined, { type: 'spec' });
+    expect(specs.length).toBe(2);
+    for (const row of specs) {
+      expect(row.type).toBe('spec');
+    }
+
+    const adrs = await store.listAllInProject(undefined, { type: 'adr' });
+    expect(adrs.length).toBe(1);
+    expect(adrs[0]?.type).toBe('adr');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Backward compat — existing rows without slug/type continue to work
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('put without slug/type leaves both columns NULL', async () => {
+    const { createAttachmentStore } = await import('../attachment-store.js');
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStore();
+    const bytes = Buffer.from('legacy', 'utf-8');
+
+    const meta = await store.put(
+      bytes,
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: bytes.length },
+      'task',
+      'T001',
+    );
+
+    const extras = await store.getExtras(meta.id);
+    expect(extras?.slug).toBeNull();
+    expect(extras?.type).toBeNull();
+
+    // Existing att_id fetch path unchanged.
+    const fetched = await store.getMetadata(meta.id);
+    expect(fetched?.id).toBe(meta.id);
+  });
+});

--- a/packages/core/src/store/attachment-store.ts
+++ b/packages/core/src/store/attachment-store.ts
@@ -60,6 +60,39 @@ export type DerefResult =
   | { status: 'derefd'; refCountAfter: number }
   | { status: 'removed' };
 
+/**
+ * Error thrown by {@link AttachmentStore.put} when an attempt is made to
+ * assign a slug that is already in use elsewhere in the project DB.
+ *
+ * Carries `suggestions` so callers (CLI dispatch) can surface alternative
+ * slugs without re-deriving them. The list is always exactly 3 candidates.
+ *
+ * @task T9636
+ */
+export class SlugCollisionError extends Error {
+  constructor(
+    public readonly slug: string,
+    public readonly suggestions: readonly string[],
+  ) {
+    super(`Slug '${slug}' is already in use in this project`);
+    this.name = 'SlugCollisionError';
+  }
+}
+
+/**
+ * Side-table extension for {@link AttachmentStore.put} carrying optional
+ * project-scoped metadata (slug, type) that lives directly on the
+ * `attachments` row rather than inside the discriminated-union JSON blob.
+ *
+ * @task T9636 (slug) / T9637 (type)
+ */
+export interface PutAttachmentExtras {
+  /** Optional kebab-case slug; uniqueness is enforced at the DB layer. */
+  slug?: string;
+  /** Optional taxonomy classification; validated upstream. */
+  type?: string;
+}
+
 // ─── MIME → extension map ──────────────────────────────────────────────────────
 
 /**
@@ -183,12 +216,18 @@ export interface AttachmentStore {
    * `attachment_refs` row is created for each call so that the caller's owning
    * entity receives its own ref even when the blob is shared.
    *
+   * When `extras.slug` is provided it is assigned to the underlying row;
+   * collision with another row's slug throws {@link SlugCollisionError} after
+   * rolling back. When the same SHA-256 is re-put with a slug, the slug is
+   * applied to the existing row (no-op if equal, collision-checked otherwise).
+   *
    * @param bytes      - Content to store (Buffer or UTF-8 string)
    * @param attachment - Attachment descriptor **without** `sha256` pre-filled
    * @param ownerType  - Entity type for the initial ref (e.g., `"task"`)
    * @param ownerId    - Entity ID for the initial ref (e.g., `"T766"`)
    * @param attachedBy - Optional agent identity that created the ref
    * @param cwd        - Optional working directory for path resolution
+   * @param extras     - Optional per-row metadata (slug, type) — T9636/T9637
    * @returns Resolved {@link AttachmentMetadata} (with `sha256` and `id` set)
    */
   put(
@@ -198,6 +237,7 @@ export interface AttachmentStore {
     ownerId: string,
     attachedBy?: string,
     cwd?: string,
+    extras?: PutAttachmentExtras,
   ): Promise<AttachmentMetadata>;
 
   /**
@@ -220,6 +260,52 @@ export interface AttachmentStore {
    * @returns {@link AttachmentMetadata} or `null` if not found
    */
   getMetadata(attachmentId: string, cwd?: string): Promise<AttachmentMetadata | null>;
+
+  /**
+   * Retrieve attachment metadata + slug + type by slug.
+   *
+   * Returns `null` if no attachment in this project carries the slug.
+   *
+   * @task T9636
+   */
+  findBySlug(
+    slug: string,
+    cwd?: string,
+  ): Promise<{ metadata: AttachmentMetadata; slug: string; type: string | null } | null>;
+
+  /**
+   * List ALL attachments in the project DB, optionally filtered by `type`.
+   *
+   * Returns one row per `attachment_refs` entry so callers see how the
+   * attachment was bound to its owner. Use this for `cleo docs list --project`.
+   *
+   * @task T9638
+   */
+  listAllInProject(
+    cwd?: string,
+    filter?: { type?: string },
+  ): Promise<
+    Array<{
+      metadata: AttachmentMetadata;
+      slug: string | null;
+      type: string | null;
+      ownerType: AttachmentRef['ownerType'];
+      ownerId: string;
+    }>
+  >;
+
+  /**
+   * Read the slug + type columns for an attachment ID.
+   *
+   * Returns `null` when the row doesn't exist; otherwise returns the raw
+   * column values (each independently nullable).
+   *
+   * @task T9636 / T9637
+   */
+  getExtras(
+    attachmentId: string,
+    cwd?: string,
+  ): Promise<{ slug: string | null; type: string | null } | null>;
 
   /**
    * List all attachments associated with a given owner entity.
@@ -327,6 +413,67 @@ function rowToMetadata(row: {
 }
 
 /**
+ * Drizzle DB type used internally — matches the singleton returned by getDb().
+ * Declared loosely (`Awaited<ReturnType<typeof getDb>>`) so the helper stays
+ * forward-compatible if the schema-strictness option changes upstream.
+ */
+type DrizzleDb = Awaited<ReturnType<typeof getDb>>;
+
+/**
+ * Derive 3 alternative slug candidates that are NOT currently in use.
+ *
+ * Strategy (per Epic T9627 design guidance):
+ *   1. `<slug>-N` where N is the count-of-existing-rows + 1
+ *   2. `<slug>-v2`
+ *   3. `<slug>-new` (or `-alt` if `-new` is also taken)
+ *
+ * If a primary candidate is also taken, walk forward until a free one is
+ * found. The lookup is bounded by a maximum of 32 probes per candidate so
+ * a pathological dataset can never block the request.
+ *
+ * @task T9636
+ */
+async function deriveSlugSuggestions(db: DrizzleDb, base: string): Promise<string[]> {
+  const taken = new Set<string>();
+  const probes: string[] = [];
+  const startCount = await db.$count(attachments);
+  probes.push(`${base}-${startCount + 1}`);
+  probes.push(`${base}-v2`);
+  probes.push(`${base}-new`);
+
+  const out: string[] = [];
+  for (let idx = 0; idx < probes.length; idx++) {
+    let candidate = probes[idx] as string;
+    let walk = 0;
+    while (walk < 32) {
+      if (taken.has(candidate)) {
+        walk++;
+        candidate = `${candidate}-x`;
+        continue;
+      }
+      const conflict = await db
+        .select()
+        .from(attachments)
+        .where(eq(attachments.slug, candidate))
+        .get();
+      if (!conflict) {
+        out.push(candidate);
+        taken.add(candidate);
+        break;
+      }
+      taken.add(candidate);
+      walk++;
+      candidate = idx === 2 ? `${base}-alt-${walk}` : `${candidate}-x`;
+    }
+    if (out.length === idx + 1) continue;
+    // Failed to derive — keep a fallback so caller always sees 3 entries.
+    out.push(`${base}-${startCount + idx + 100}`);
+  }
+
+  return out.slice(0, 3);
+}
+
+/**
  * Validate and coerce ownerType to the allowed enum.
  *
  * Throws if the value is not one of the six supported entity types.
@@ -366,17 +513,35 @@ function assertOwnerType(ownerType: string): AttachmentRef['ownerType'] {
  */
 export function createAttachmentStore(): AttachmentStore {
   return {
-    async put(bytes, attachment, ownerType, ownerId, attachedBy, cwd) {
+    async put(bytes, attachment, ownerType, ownerId, attachedBy, cwd, extras) {
       const buf = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes, 'utf-8');
       const hash = sha256Of(buf);
       const mime = mimeFromAttachment({ sha256: hash, ...attachment } as Attachment);
       const filePath = blobPath(hash, mime, cwd);
       const fullAttachment: Attachment = { sha256: hash, ...attachment } as Attachment;
+      const slug = extras?.slug;
+      const type = extras?.type;
 
       return withWriteLock(async () => {
         const db = await getDb(cwd);
         const nativeDb = getNativeTasksDb();
         if (!nativeDb) throw new Error('Database not initialized');
+
+        // Pre-check slug collision OUTSIDE the BEGIN IMMEDIATE window so the
+        // caller receives SlugCollisionError without leaving a half-written
+        // transaction. The partial UNIQUE INDEX on the slug column is the
+        // hard backstop; this check provides a friendly error + suggestions.
+        if (slug !== undefined) {
+          const conflict = await db
+            .select()
+            .from(attachments)
+            .where(eq(attachments.slug, slug))
+            .get();
+          if (conflict && conflict.sha256 !== hash) {
+            const suggestions = await deriveSlugSuggestions(db, slug);
+            throw new SlugCollisionError(slug, suggestions);
+          }
+        }
 
         // Transaction: check for existing blob, insert if needed, create ref, increment refCount.
         let wasNew = false;
@@ -410,8 +575,22 @@ export function createAttachmentStore(): AttachmentStore {
                 attachmentJson: JSON.stringify(fullAttachment),
                 createdAt,
                 refCount: 0,
+                ...(slug !== undefined ? { slug } : {}),
+                ...(type !== undefined ? { type } : {}),
               })
               .run();
+          }
+
+          // For an already-existing row, apply slug/type if requested. The
+          // pre-check above guarantees no cross-row collision; same-row
+          // re-assignment of the same slug is a no-op via the partial UNIQUE
+          // INDEX semantics. Use raw SQL via drizzle update to avoid clobbering
+          // existing values when extras is undefined.
+          if (existing && (slug !== undefined || type !== undefined)) {
+            const updates: Record<string, string> = {};
+            if (slug !== undefined) updates.slug = slug;
+            if (type !== undefined) updates.type = type;
+            await db.update(attachments).set(updates).where(eq(attachments.id, attachmentId)).run();
           }
 
           // Insert ref.
@@ -491,6 +670,66 @@ export function createAttachmentStore(): AttachmentStore {
       const db = await getDb(cwd);
       const row = await db.select().from(attachments).where(eq(attachments.id, attachmentId)).get();
       return row ? rowToMetadata(row) : null;
+    },
+
+    async findBySlug(slug, cwd) {
+      const db = await getDb(cwd);
+      const row = await db.select().from(attachments).where(eq(attachments.slug, slug)).get();
+      if (!row) return null;
+      return {
+        metadata: rowToMetadata(row),
+        slug: row.slug ?? slug,
+        type: row.type ?? null,
+      };
+    },
+
+    async getExtras(attachmentId, cwd) {
+      const db = await getDb(cwd);
+      const row = await db.select().from(attachments).where(eq(attachments.id, attachmentId)).get();
+      if (!row) return null;
+      return { slug: row.slug ?? null, type: row.type ?? null };
+    },
+
+    async listAllInProject(cwd, filter) {
+      const db = await getDb(cwd);
+      // One row per attachment_refs binding, joined to attachments. We
+      // intentionally surface duplicates when one blob is referenced by
+      // multiple owners — callers wanting deduplication can collapse by id.
+      const rows = await db
+        .select({
+          attachmentId: attachmentRefs.attachmentId,
+          ownerType: attachmentRefs.ownerType,
+          ownerId: attachmentRefs.ownerId,
+        })
+        .from(attachmentRefs)
+        .all();
+
+      if (rows.length === 0) return [];
+
+      const out: Array<{
+        metadata: AttachmentMetadata;
+        slug: string | null;
+        type: string | null;
+        ownerType: AttachmentRef['ownerType'];
+        ownerId: string;
+      }> = [];
+      for (const refRow of rows) {
+        const row = await db
+          .select()
+          .from(attachments)
+          .where(eq(attachments.id, refRow.attachmentId))
+          .get();
+        if (!row) continue;
+        if (filter?.type !== undefined && row.type !== filter.type) continue;
+        out.push({
+          metadata: rowToMetadata(row),
+          slug: row.slug ?? null,
+          type: row.type ?? null,
+          ownerType: refRow.ownerType,
+          ownerId: refRow.ownerId,
+        });
+      }
+      return out;
     },
 
     async listByOwner(ownerType, ownerId, cwd) {

--- a/packages/core/src/store/tasks-schema.ts
+++ b/packages/core/src/store/tasks-schema.ts
@@ -1112,6 +1112,35 @@ export const attachments = sqliteTable(
      * Blobs are NEVER auto-deleted — use `cleo docs attachments gc`.
      */
     refCount: integer('ref_count').notNull().default(0),
+    /**
+     * Optional human-friendly slug for the attachment, unique per project
+     * (the DB is per-project, so uniqueness is enforced via a partial UNIQUE
+     * INDEX `WHERE slug IS NOT NULL`).
+     *
+     * `cleo docs fetch <slug>` resolves an attachment by slug as a friendlier
+     * alternative to `att_<base62>` IDs or SHA-256 prefixes.
+     *
+     * @task T9636 (Epic T9627 / Saga T9625)
+     */
+    slug: text('slug'),
+    /**
+     * Optional taxonomy classification for the attachment.
+     *
+     * Allowed values:
+     *   - `spec`        — formal specification documents
+     *   - `adr`         — architecture decision records
+     *   - `research`    — research notes and exploration artefacts
+     *   - `handoff`     — session/agent handoff notes
+     *   - `note`        — general notes
+     *   - `llm-readme`  — llms.txt / READMEs intended for LLM consumption
+     *
+     * Enforced at the dispatch layer (not as a DB CHECK constraint) so that
+     * forward-compatible additions don't require a schema migration. The
+     * absence of a value means "unclassified" for backward compatibility.
+     *
+     * @task T9637 (Epic T9627 / Saga T9625)
+     */
+    type: text('type'),
   },
   (table) => [index('idx_attachments_sha256').on(table.sha256)],
 );


### PR DESCRIPTION
## Summary

Closes Epic **T9627** (E-DOCS-SLUG-CLASSIFY) of Saga T9625 W1. Adds three
features to `cleo docs` so attachments can be addressed by human-friendly
aliases, classified by intent, and listed across the whole project:

- **T9636** — `cleo docs add --slug <kebab-case>` with per-project uniqueness
  enforced by a partial UNIQUE index. Collisions return `E_SLUG_TAKEN` with
  3 alternative suggestions (suffix-based: `-N`, `-v2`, `-new/-alt`). Fetch
  resolves slug as a first-class lookup path alongside att-id / sha256 /
  sha256-prefix (ambiguous prefix → `E_AMBIGUOUS`).
- **T9637** — `cleo docs add --type {spec|adr|research|handoff|note|llm-readme}`
  taxonomy classification, validated against `DOCS_TYPE_VALUES` (closed set
  exported from `@cleocode/contracts/operations/docs`). `cleo docs list --type
  <t>` filters across owner-scope and project-scope.
- **T9638** — `cleo docs list --project` unions all attachment refs across
  every owner (mutually exclusive with `--task/--session/--observation`).
  Combinable with `--type` for cross-cutting queries.

This PR is a **pickup of work started by slug1-classifier** — their session
ended before commits were created. The uncommitted dispatch + store + contracts
implementation in the worktree covered all 7 acceptance criteria; I audited
it, split into 3 ADR-073-I8-compliant feature commits + 1 test commit, fixed
the envelope-details stripping bug surfaced by tests, and added 20 + 13 unit
+ integration tests.

## Acceptance coverage

| AC | Behavior | Coverage |
|----|----------|----------|
| 1  | `cleo docs add --slug` writes slug, uniqueness enforced per project | core test + dispatch test |
| 2  | `cleo docs add --type {spec\|adr\|research\|handoff\|note\|llm-readme}` writes type | core test + dispatch test |
| 3  | `cleo docs list --type` filters | dispatch test |
| 4  | `cleo docs list --project` lists project-scoped docs | dispatch test |
| 5  | `cleo docs fetch` accepts slug OR att_id OR sha256 prefix | dispatch test (slug + sha256-prefix + att_id) |
| 6  | Slug collision returns `E_SLUG_TAKEN` envelope with 3 suggestions | core test + dispatch test |
| 7  | Backward compat: existing att_*-id docs fetch by ID | dispatch test |

## Migration

`20260519000001_t9636-t9637-add-slug-type-to-attachments` adds:
- `slug TEXT` column + partial `UNIQUE INDEX … WHERE slug IS NOT NULL`
- `type TEXT` column + partial `INDEX … WHERE type IS NOT NULL`
- Open CHECK semantics (validation lives in dispatch) so future taxonomy
  additions don't require a schema migration

Revert script drops both columns + indexes.

## Test plan

- [x] `pnpm biome ci .` — exit 0
- [x] `pnpm --filter @cleocode/contracts exec tsc --noEmit` — exit 0
- [x] `pnpm --filter @cleocode/core exec tsc --noEmit` — exit 0
- [x] `pnpm --filter @cleocode/cleo exec tsc --noEmit` — exit 0 (after rebuilding caamp+core)
- [x] Core: `pnpm exec vitest run packages/core/src/store/__tests__/attachment-slug-type.test.ts` — 8/8 pass
- [x] Dispatch: `pnpm exec vitest run packages/cleo/src/dispatch/domains/__tests__/docs-slug-type-project.test.ts` — 13/13 pass
- [x] Regression: existing `docs.test.ts` — 23/23 pass
- [x] Rebased on origin/main (36 commits ahead, clean rebase)

## Audit findings (pickup from slug1-classifier)

slug1's uncommitted work covered all 7 acceptance criteria functionally —
schema, migration, store helpers, dispatch validation, CLI flags, fetch
resolution. **Zero tests existed.** Additions in this PR:

- 8 core unit tests (`attachment-slug-type.test.ts`) — slug round-trip,
  collision behavior + 3 suggestions, idempotent re-put, listAllInProject
  union + filter, NULL-column backward compat
- 13 dispatch integration tests (`docs-slug-type-project.test.ts`) — all
  7 acceptance criteria + 6 edge cases (invalid slug, invalid type, no-scope,
  sha256-prefix, att_id fetch backward compat, full-sha256 fetch)
- **Bug fix**: `docsEnvelopeToResponse` was stripping `error.details` →
  `E_SLUG_TAKEN` reached the CLI without the `suggestions` payload.
  Preserved details when present.
- **Test infrastructure**: vitest aliases don't resolve runtime subpath
  imports for `@cleocode/contracts`. Mirrored `DOCS_TYPE_VALUES` locally in
  `dispatch/docs.ts` (with a comment noting the SSoT-by-convention lock-step
  with `@cleocode/contracts/operations/docs`).

## Commit structure (4 commits, ADR-073 I8)

1. `feat(T9636)`: slug + collision + suggestions + fetch resolution chain
2. `feat(T9637)`: type taxonomy + DOCS_TYPE_VALUES + --type filter
3. `feat(T9638)`: --project listing + listAllInProject scope branch
4. `test(T9627)`: 21 new tests + envelope-details preservation fix

Each commit independently typechecks + builds.

Refs: T9636, T9637, T9638, Epic T9627, Saga T9625.