### PR TITLE
feat(T9561): E-SKILLS-TELEMETRY (5 impl tasks)

### DIFF
--- a/packages/cleo/src/cli/commands/skills.ts
+++ b/packages/cleo/src/cli/commands/skills.ts
@@ -557,6 +557,65 @@ const doctorAdoptOrphansCommand = defineCommand({
   },
 });
 
+/**
+ * `cleo skills stats` — Sphere B telemetry rollup (T9690).
+ *
+ * Surfaces the typed `SkillsStore` adapter behind a single command. Flags:
+ *
+ *   --top N            Top-N usage rollup (default 10)
+ *   --since DAYS       Restrict the rollup to the last N days
+ *   --by-source        Include source-type breakdown facet
+ *   --by-lifecycle     Include lifecycle-state breakdown facet
+ *   --agent-created    Include agent-created skill list facet
+ *   --json             LAFS envelope (default) vs human renderer
+ */
+const statsCommand = defineCommand({
+  meta: {
+    name: 'stats',
+    description:
+      'Show skill telemetry stats: top-N usage, lifecycle / source-type breakdowns, agent-created skills',
+  },
+  args: {
+    top: {
+      type: 'string',
+      description: 'Top-N usage rollup limit (default 10)',
+    },
+    since: {
+      type: 'string',
+      description: 'Restrict the top-N rollup to the last N days (default: all-time)',
+    },
+    'by-source': {
+      type: 'boolean',
+      description: 'Include source-type breakdown facet',
+    },
+    'by-lifecycle': {
+      type: 'boolean',
+      description: 'Include lifecycle-state breakdown facet',
+    },
+    'agent-created': {
+      type: 'boolean',
+      description: 'Include agent-created skill list facet',
+    },
+  },
+  async run({ args }) {
+    const top = args.top ? Number(args.top) : undefined;
+    const sinceDays = args.since ? Number(args.since) : undefined;
+    await dispatchFromCli(
+      'query',
+      'tools',
+      'skill.stats',
+      {
+        top,
+        sinceDays,
+        bySource: args['by-source'] === true,
+        byLifecycle: args['by-lifecycle'] === true,
+        agentCreated: args['agent-created'] === true,
+      },
+      { command: 'skills', operation: 'tools.skill.stats' },
+    );
+  },
+});
+
 /** cleo skills spawn-providers — list providers capable of spawning subagents */
 const spawnProvidersCommand = defineCommand({
   meta: { name: 'spawn-providers', description: 'List providers capable of spawning subagents' },
@@ -855,6 +914,7 @@ export const skillsCommand = defineCommand({
     'spawn-providers': spawnProvidersCommand,
     doctor: doctorCommand,
     'propose-patch': proposePatchCommand,
+    stats: statsCommand,
   },
   async run({ cmd, rawArgs }) {
     // Parent run() fires after subcommand per citty@0.2.x — skip default

--- a/packages/cleo/src/cli/commands/skills.ts
+++ b/packages/cleo/src/cli/commands/skills.ts
@@ -654,6 +654,49 @@ const importHermesCommand = defineCommand({
   },
 });
 
+/**
+ * `cleo skills prune-telemetry` — Sphere B retention sweep (T9693).
+ *
+ * Deletes `skill_usage` rows older than `--older-than DAYS` (default 180,
+ * mirrors Hermes `archive_after_days`). Optional `--vacuum` reclaims disk
+ * space after the delete. Use `--dry-run` to preview without writes.
+ */
+const pruneTelemetryCommand = defineCommand({
+  meta: {
+    name: 'prune-telemetry',
+    description:
+      'Delete skill_usage rows older than --older-than DAYS (default 180); optional --vacuum reclaims disk space',
+  },
+  args: {
+    'older-than': {
+      type: 'string',
+      description: 'Age threshold in days (default 180)',
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Print planned deletes without touching the DB',
+    },
+    vacuum: {
+      type: 'boolean',
+      description: 'Run VACUUM after the delete to reclaim disk space',
+    },
+  },
+  async run({ args }) {
+    const olderThanDays = args['older-than'] ? Number(args['older-than']) : undefined;
+    await dispatchFromCli(
+      'mutate',
+      'tools',
+      'skill.prune.telemetry',
+      {
+        olderThanDays,
+        dryRun: args['dry-run'] === true,
+        vacuum: args.vacuum === true,
+      },
+      { command: 'skills', operation: 'tools.skill.prune.telemetry' },
+    );
+  },
+});
+
 /** cleo skills spawn-providers — list providers capable of spawning subagents */
 const spawnProvidersCommand = defineCommand({
   meta: { name: 'spawn-providers', description: 'List providers capable of spawning subagents' },
@@ -954,6 +997,7 @@ export const skillsCommand = defineCommand({
     'propose-patch': proposePatchCommand,
     stats: statsCommand,
     'import-hermes': importHermesCommand,
+    'prune-telemetry': pruneTelemetryCommand,
   },
   async run({ cmd, rawArgs }) {
     // Parent run() fires after subcommand per citty@0.2.x — skip default

--- a/packages/cleo/src/cli/commands/skills.ts
+++ b/packages/cleo/src/cli/commands/skills.ts
@@ -616,6 +616,44 @@ const statsCommand = defineCommand({
   },
 });
 
+/**
+ * `cleo skills import-hermes` — Hermes sidecar migration (T9691).
+ *
+ * Reads `~/.hermes/skills/.usage.json` + `.bundled_manifest` and inserts
+ * equivalent rows into the CLEO `skills.db`. Idempotent — re-running the
+ * verb upserts by `name` and re-synthesizes the counter rows. Use
+ * `--dry-run` to preview without mutating disk state.
+ */
+const importHermesCommand = defineCommand({
+  meta: {
+    name: 'import-hermes',
+    description:
+      'Migrate Hermes ~/.hermes/skills/.usage.json sidecars into the CLEO skills.db registry',
+  },
+  args: {
+    'hermes-home': {
+      type: 'string',
+      description: 'Override Hermes home directory (default: $HERMES_HOME or ~/.hermes)',
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Print planned writes without mutating skills.db',
+    },
+  },
+  async run({ args }) {
+    await dispatchFromCli(
+      'mutate',
+      'tools',
+      'skill.import.hermes',
+      {
+        hermesHome: args['hermes-home'] as string | undefined,
+        dryRun: args['dry-run'] === true,
+      },
+      { command: 'skills', operation: 'tools.skill.import.hermes' },
+    );
+  },
+});
+
 /** cleo skills spawn-providers — list providers capable of spawning subagents */
 const spawnProvidersCommand = defineCommand({
   meta: { name: 'spawn-providers', description: 'List providers capable of spawning subagents' },
@@ -915,6 +953,7 @@ export const skillsCommand = defineCommand({
     doctor: doctorCommand,
     'propose-patch': proposePatchCommand,
     stats: statsCommand,
+    'import-hermes': importHermesCommand,
   },
   async run({ cmd, rawArgs }) {
     // Parent run() fires after subcommand per citty@0.2.x — skip default

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -62,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -83,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -101,23 +99,20 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -140,8 +135,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -244,8 +238,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -268,16 +261,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -301,8 +292,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -313,8 +303,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -327,8 +316,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -364,8 +352,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -395,8 +382,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'generateChangelogCommand',
     name: 'generate-changelog',
     description: 'Generate platform-specific changelog from CHANGELOG.md',
-    load: async () =>
-      (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
+    load: async () => (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
   },
   {
     exportName: 'gradeCommand',
@@ -420,8 +406,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -444,17 +429,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -483,8 +465,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -526,17 +507,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -565,8 +543,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -578,15 +555,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -629,8 +604,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -641,8 +615,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description:
-      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -690,8 +663,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -703,8 +675,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -752,15 +723,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -838,8 +807,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -857,8 +825,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/dispatch/domains/tools.ts
+++ b/packages/cleo/src/dispatch/domains/tools.ts
@@ -48,6 +48,7 @@ import {
   toolsSkillList,
   toolsSkillPrecedenceResolve,
   toolsSkillPrecedenceShow,
+  toolsSkillPruneTelemetry,
   toolsSkillRefresh,
   toolsSkillShow,
   toolsSkillSpawnProviders,
@@ -502,6 +503,18 @@ export class ToolsHandler implements DomainHandler {
         const dryRun = params?.dryRun === true;
         const result = await toolsSkillImportHermes({ hermesHome, dryRun });
         return wrapResult(result, 'mutate', 'tools', 'skill.import.hermes', startTime);
+      }
+
+      // T9693 — skill.prune.telemetry: retention sweep on skill_usage
+      case 'prune.telemetry': {
+        const olderThanDays =
+          typeof params?.olderThanDays === 'number' ? (params.olderThanDays as number) : undefined;
+        const result = await toolsSkillPruneTelemetry({
+          olderThanDays,
+          dryRun: params?.dryRun === true,
+          vacuum: params?.vacuum === true,
+        });
+        return wrapResult(result, 'mutate', 'tools', 'skill.prune.telemetry', startTime);
       }
 
       default:

--- a/packages/cleo/src/dispatch/domains/tools.ts
+++ b/packages/cleo/src/dispatch/domains/tools.ts
@@ -43,6 +43,7 @@ import {
   toolsSkillDoctorDiagnose,
   toolsSkillFederatedFind,
   toolsSkillFind,
+  toolsSkillImportHermes,
   toolsSkillInstall,
   toolsSkillList,
   toolsSkillPrecedenceResolve,
@@ -178,6 +179,8 @@ export class ToolsHandler implements DomainHandler {
         'skill.install',
         'skill.uninstall',
         'skill.refresh',
+        'skill.import.hermes',
+        'skill.prune.telemetry',
         // provider
         'provider.inject',
         // adapter
@@ -491,6 +494,14 @@ export class ToolsHandler implements DomainHandler {
       case 'refresh': {
         const result = await toolsSkillRefresh(this.projectRoot);
         return wrapResult(result, 'mutate', 'tools', 'skill.refresh', startTime);
+      }
+
+      // T9691 — skill.import.hermes: migrate Hermes .usage.json into skills.db
+      case 'import.hermes': {
+        const hermesHome = params?.hermesHome as string | undefined;
+        const dryRun = params?.dryRun === true;
+        const result = await toolsSkillImportHermes({ hermesHome, dryRun });
+        return wrapResult(result, 'mutate', 'tools', 'skill.import.hermes', startTime);
       }
 
       default:

--- a/packages/cleo/src/dispatch/domains/tools.ts
+++ b/packages/cleo/src/dispatch/domains/tools.ts
@@ -50,6 +50,7 @@ import {
   toolsSkillRefresh,
   toolsSkillShow,
   toolsSkillSpawnProviders,
+  toolsSkillStats,
   toolsSkillUninstall,
   toolsSkillVerify,
 } from '@cleocode/core/internal';
@@ -159,6 +160,7 @@ export class ToolsHandler implements DomainHandler {
         'skill.catalog',
         'skill.precedence',
         'skill.doctor.diagnose',
+        'skill.stats',
         // provider
         'provider.list',
         'provider.detect',
@@ -421,6 +423,21 @@ export class ToolsHandler implements DomainHandler {
         const verbose = params?.verbose === true;
         const result = await toolsSkillDoctorDiagnose({ verbose });
         return wrapResult(result, 'query', 'tools', 'skill.doctor.diagnose', startTime);
+      }
+
+      // T9690 — skill.stats: Sphere B telemetry rollup
+      case 'stats': {
+        const top = typeof params?.top === 'number' ? (params.top as number) : undefined;
+        const sinceDays =
+          typeof params?.sinceDays === 'number' ? (params.sinceDays as number) : undefined;
+        const result = await toolsSkillStats({
+          top,
+          sinceDays,
+          bySource: params?.bySource === true,
+          byLifecycle: params?.byLifecycle === true,
+          agentCreated: params?.agentCreated === true,
+        });
+        return wrapResult(result, 'query', 'tools', 'skill.stats', startTime);
       }
 
       default:

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -1789,6 +1789,50 @@ export const OPERATIONS: OperationDef[] = [
       },
     ],
   },
+  // T9690 — skill.stats: Sphere B telemetry rollup
+  {
+    gateway: 'query',
+    domain: 'tools',
+    operation: 'skill.stats',
+    description:
+      'tools.skill.stats (query) — Sphere B telemetry rollup; top-N usage, lifecycle / source-type breakdowns, agent-created list',
+    tier: 1,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: [],
+    params: [
+      {
+        name: 'top',
+        type: 'number',
+        required: false,
+        description: 'Top-N usage rollup limit (default 10)',
+      },
+      {
+        name: 'sinceDays',
+        type: 'number',
+        required: false,
+        description: 'Restrict top-N rollup to the last N days (default: all-time)',
+      },
+      {
+        name: 'bySource',
+        type: 'boolean',
+        required: false,
+        description: 'Include source-type breakdown facet',
+      },
+      {
+        name: 'byLifecycle',
+        type: 'boolean',
+        required: false,
+        description: 'Include lifecycle-state breakdown facet',
+      },
+      {
+        name: 'agentCreated',
+        type: 'boolean',
+        required: false,
+        description: 'Include agent-created skill list facet',
+      },
+    ],
+  },
   {
     gateway: 'query',
     domain: 'tools',

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -1789,6 +1789,38 @@ export const OPERATIONS: OperationDef[] = [
       },
     ],
   },
+  // T9693 — skill.prune.telemetry: skill_usage retention sweep
+  {
+    gateway: 'mutate',
+    domain: 'tools',
+    operation: 'skill.prune.telemetry',
+    description:
+      'tools.skill.prune.telemetry (mutate) — delete skill_usage rows older than --older-than DAYS (default 180)',
+    tier: 2,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: [],
+    params: [
+      {
+        name: 'olderThanDays',
+        type: 'number',
+        required: false,
+        description: 'Age threshold in days (default 180)',
+      },
+      {
+        name: 'dryRun',
+        type: 'boolean',
+        required: false,
+        description: 'Return the plan without touching the DB',
+      },
+      {
+        name: 'vacuum',
+        type: 'boolean',
+        required: false,
+        description: 'Run VACUUM after the delete to reclaim disk space',
+      },
+    ],
+  },
   // T9691 — skill.import.hermes: Hermes sidecar migration
   {
     gateway: 'mutate',

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -1789,6 +1789,32 @@ export const OPERATIONS: OperationDef[] = [
       },
     ],
   },
+  // T9691 — skill.import.hermes: Hermes sidecar migration
+  {
+    gateway: 'mutate',
+    domain: 'tools',
+    operation: 'skill.import.hermes',
+    description:
+      'tools.skill.import.hermes (mutate) — migrate ~/.hermes/skills/.usage.json sidecars into CLEO skills.db',
+    tier: 2,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: [],
+    params: [
+      {
+        name: 'hermesHome',
+        type: 'string',
+        required: false,
+        description: 'Override Hermes home directory (default: $HERMES_HOME or ~/.hermes)',
+      },
+      {
+        name: 'dryRun',
+        type: 'boolean',
+        required: false,
+        description: 'Print planned writes without mutating skills.db',
+      },
+    ],
+  },
   // T9690 — skill.stats: Sphere B telemetry rollup
   {
     gateway: 'query',

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1377,6 +1377,17 @@ export {
   sessionJournalDoctorSummarySchema,
   sessionJournalEntrySchema,
 } from './session-journal.js';
+// === Skills Stats (T9690 — SG-CLEO-SKILLS Sphere B) ===
+export type {
+  SkillStatsAgentCreatedRow,
+  SkillStatsByLifecycleRow,
+  SkillStatsBySourceRow,
+  SkillStatsRequest,
+  SkillStatsResponse,
+  SkillStatsTopRow,
+  StatsSkillLifecycleState,
+  StatsSkillSourceType,
+} from './skills/stats.js';
 export type { AdapterSpawnProvider, SpawnContext, SpawnResult } from './spawn.js';
 // === CLEO Spawn Types (distinct from adapter spawn) ===
 export type {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1377,6 +1377,12 @@ export {
   sessionJournalDoctorSummarySchema,
   sessionJournalEntrySchema,
 } from './session-journal.js';
+// === Skills Hermes Import (T9691 — SG-CLEO-SKILLS Sphere B) ===
+export type {
+  SkillImportHermesRequest,
+  SkillImportHermesResponse,
+  SkillImportHermesRow,
+} from './skills/import-hermes.js';
 // === Skills Stats (T9690 — SG-CLEO-SKILLS Sphere B) ===
 export type {
   SkillStatsAgentCreatedRow,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1383,6 +1383,11 @@ export type {
   SkillImportHermesResponse,
   SkillImportHermesRow,
 } from './skills/import-hermes.js';
+// === Skills Prune Telemetry (T9693 — SG-CLEO-SKILLS Sphere B retention) ===
+export type {
+  SkillPruneTelemetryRequest,
+  SkillPruneTelemetryResponse,
+} from './skills/prune.js';
 // === Skills Stats (T9690 — SG-CLEO-SKILLS Sphere B) ===
 export type {
   SkillStatsAgentCreatedRow,

--- a/packages/contracts/src/skills/import-hermes.ts
+++ b/packages/contracts/src/skills/import-hermes.ts
@@ -1,0 +1,69 @@
+/**
+ * Contract types for `cleo skill import-hermes` — Hermes sidecar migration.
+ *
+ * Reads `~/.hermes/skills/.usage.json` plus `~/.hermes/skills/.bundled_manifest`
+ * and inserts equivalent rows into CLEO's `skills.db`. Counters from the
+ * Hermes sidecar (use_count / view_count / patch_count) are preserved as
+ * synthesized `skill_usage` rows so the CLEO `cleo skills stats` rollup
+ * surfaces day-zero usage data right after migration.
+ *
+ * @task T9691
+ * @epic T9561
+ * @saga T9560
+ */
+
+/**
+ * Input parameters for the `cleo skill import-hermes` verb.
+ */
+export interface SkillImportHermesRequest {
+  /** Override default `~/.hermes` lookup. */
+  readonly hermesHome?: string;
+  /** When true, print planned writes without mutating skills.db. */
+  readonly dryRun?: boolean;
+}
+
+/**
+ * Per-skill outcome row in the import response.
+ */
+export interface SkillImportHermesRow {
+  /** Skill identifier. */
+  readonly name: string;
+  /**
+   * Disposition of the row:
+   * - `imported` — skills row was inserted / upserted.
+   * - `skipped`  — skills row already exists with matching content; no write.
+   * - `failed`   — validation error or DB error; see `error`.
+   */
+  readonly disposition: 'imported' | 'skipped' | 'failed';
+  /** Resolved CLEO source-type mapping for the row (or null when failed). */
+  readonly sourceType: 'canonical' | 'user' | 'community' | 'agent-created' | null;
+  /** Number of synthesized `skill_usage` rows from counters. */
+  readonly synthesizedUsageRows: number;
+  /** Error message if `disposition='failed'`. */
+  readonly error: string | null;
+}
+
+/**
+ * Result envelope for `cleo skill import-hermes`.
+ *
+ * Wrapped in the standard LAFS `{success, data, meta}` envelope at the
+ * dispatch boundary; this interface describes the `data` payload only.
+ */
+export interface SkillImportHermesResponse {
+  /** Resolved Hermes home used for this run. */
+  readonly hermesHome: string;
+  /** Whether this was a dry-run (no DB writes). */
+  readonly dryRun: boolean;
+  /** Total skills rows seen in the Hermes sidecar. */
+  readonly seen: number;
+  /** Count of `disposition='imported'` rows. */
+  readonly imported: number;
+  /** Count of `disposition='skipped'` rows. */
+  readonly skipped: number;
+  /** Count of `disposition='failed'` rows. */
+  readonly failed: number;
+  /** Per-skill outcome rows. */
+  readonly rows: readonly SkillImportHermesRow[];
+  /** Total `skill_usage` rows synthesized from counters (sum across rows). */
+  readonly totalSynthesizedUsage: number;
+}

--- a/packages/contracts/src/skills/prune.ts
+++ b/packages/contracts/src/skills/prune.ts
@@ -1,0 +1,53 @@
+/**
+ * Contract types for `cleo skills prune-telemetry` — Sphere B retention policy.
+ *
+ * Deletes `skill_usage` rows older than a configurable window so the
+ * SQLite file doesn't grow unbounded over long-lived installs.
+ *
+ * @task T9693
+ * @epic T9561
+ * @saga T9560
+ */
+
+/**
+ * Input parameters for the `cleo skills prune-telemetry` verb.
+ */
+export interface SkillPruneTelemetryRequest {
+  /**
+   * Age threshold in days. Rows with `observed_at` strictly older than
+   * `NOW() - olderThanDays * 86_400_000` are deleted. Defaults to 180
+   * days at the CLI layer (mirrors Hermes `archive_after_days`).
+   */
+  readonly olderThanDays?: number;
+  /** When true, returns the plan without touching the DB. */
+  readonly dryRun?: boolean;
+  /** When true, runs `VACUUM` after the delete to reclaim disk space. */
+  readonly vacuum?: boolean;
+}
+
+/**
+ * Result envelope for `cleo skills prune-telemetry`.
+ *
+ * Wrapped in the standard LAFS `{success, data, meta}` envelope at the
+ * dispatch boundary; this interface describes the `data` payload only.
+ */
+export interface SkillPruneTelemetryResponse {
+  /** Number of `skill_usage` rows deleted (or projected for dry-run). */
+  readonly deletedRows: number;
+  /** Effective `olderThanDays` value used. */
+  readonly olderThanDays: number;
+  /** ISO-8601 cutoff timestamp the prune was computed against. */
+  readonly cutoffIso: string;
+  /** Whether this was a dry-run (no DB writes). */
+  readonly dryRun: boolean;
+  /** Whether VACUUM ran after the prune. */
+  readonly vacuumed: boolean;
+  /** Bytes on disk for skills.db BEFORE the prune (best-effort). */
+  readonly dbSizeBefore: number;
+  /** Bytes on disk for skills.db AFTER the prune. */
+  readonly dbSizeAfter: number;
+  /** Oldest `observed_at` still in the table (`null` if empty). */
+  readonly oldestRemaining: string | null;
+  /** Newest `observed_at` still in the table (`null` if empty). */
+  readonly newestRemaining: string | null;
+}

--- a/packages/contracts/src/skills/stats.ts
+++ b/packages/contracts/src/skills/stats.ts
@@ -1,0 +1,131 @@
+/**
+ * Contract types for `cleo skills stats` — Sphere B telemetry rollup CLI.
+ *
+ * The stats verb queries the typed Drizzle adapter (`skills-store.ts`) and
+ * returns a multi-faceted view of recent usage: top-N by event count,
+ * lifecycle distribution, source-type breakdown, and agent-created counts.
+ * Designed to mirror Hermes' `agent_created_report()` output shape but
+ * sourced from `skills.db` instead of `~/.hermes/skills/.usage.json`.
+ *
+ * @task T9690
+ * @epic T9561
+ * @saga T9560
+ * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §5
+ */
+
+// ---------------------------------------------------------------------------
+// Enum mirrors (kept in sync with packages/core/src/store/skills-schema.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Provenance of a skill row, mirrored from
+ * `packages/core/src/store/skills-schema.ts` so contracts consumers don't
+ * need a runtime dependency on @cleocode/core.
+ */
+export type StatsSkillSourceType = 'canonical' | 'user' | 'community' | 'agent-created';
+
+/**
+ * Lifecycle state of a skill row, mirrored from
+ * `packages/core/src/store/skills-schema.ts`.
+ */
+export type StatsSkillLifecycleState = 'active' | 'stale' | 'archived';
+
+// ---------------------------------------------------------------------------
+// Request
+// ---------------------------------------------------------------------------
+
+/**
+ * Input parameters for the `cleo skills stats` verb.
+ *
+ * All flags are optional. When no facet flag is set, the verb returns the
+ * full multi-facet report.
+ */
+export interface SkillStatsRequest {
+  /** Cap on entries returned by the top-N facet (default 10). */
+  readonly top?: number;
+  /** Restrict the top-N rollup to the last N days (default: all-time). */
+  readonly sinceDays?: number;
+  /** When true, include the source-type breakdown facet. */
+  readonly bySource?: boolean;
+  /** When true, include the lifecycle-state breakdown facet. */
+  readonly byLifecycle?: boolean;
+  /** When true, include the agent-created skill list facet. */
+  readonly agentCreated?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Response
+// ---------------------------------------------------------------------------
+
+/**
+ * Single row in the {@link SkillStatsResponse.top} rollup.
+ *
+ * Mirrors the `SkillUsageRollup` interface exposed by the core
+ * `skills-store.ts` module.
+ */
+export interface SkillStatsTopRow {
+  /** Skill identifier (matches `skills.name`). */
+  readonly skillName: string;
+  /** Number of `skill_usage` rows referencing this skill in the window. */
+  readonly count: number;
+}
+
+/**
+ * Source-type breakdown row.
+ *
+ * Reports the count of skills in each {@link StatsSkillSourceType} bucket.
+ * Skills whose `lifecycle_state` is `archived` are excluded by default.
+ */
+export interface SkillStatsBySourceRow {
+  /** Source-type bucket. */
+  readonly sourceType: StatsSkillSourceType;
+  /** Number of active skills in this bucket. */
+  readonly count: number;
+}
+
+/**
+ * Lifecycle-state breakdown row.
+ */
+export interface SkillStatsByLifecycleRow {
+  /** Lifecycle bucket. */
+  readonly state: StatsSkillLifecycleState;
+  /** Number of skills in this bucket. */
+  readonly count: number;
+}
+
+/**
+ * Lightweight summary of a single agent-created skill row, ordered by
+ * `installed_at` descending.
+ */
+export interface SkillStatsAgentCreatedRow {
+  /** Skill identifier. */
+  readonly name: string;
+  /** Semver from frontmatter, if present. */
+  readonly version: string | null;
+  /** ISO-8601 install timestamp. */
+  readonly installedAt: string;
+  /** Lifecycle state at query time. */
+  readonly lifecycleState: StatsSkillLifecycleState;
+}
+
+/**
+ * Result envelope for `cleo skills stats`.
+ *
+ * Facet fields are nullable so consumers can detect "facet was not requested"
+ * vs. "facet returned zero rows" — both result in `[]` would be ambiguous.
+ *
+ * Wrapped in the standard LAFS `{success, data, meta}` envelope at the
+ * dispatch boundary; this interface describes the `data` payload only.
+ */
+export interface SkillStatsResponse {
+  /** Top-N rollup (always present). */
+  readonly top: readonly SkillStatsTopRow[];
+  /** Source-type breakdown — `null` when `bySource` was not requested. */
+  readonly bySource: readonly SkillStatsBySourceRow[] | null;
+  /** Lifecycle breakdown — `null` when `byLifecycle` was not requested. */
+  readonly byLifecycle: readonly SkillStatsByLifecycleRow[] | null;
+  /** Agent-created skill list — `null` when `agentCreated` was not requested. */
+  readonly agentCreated: readonly SkillStatsAgentCreatedRow[] | null;
+  /** Effective `sinceDays` value applied to the top-N rollup, if any. */
+  readonly sinceDays: number | null;
+}

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2156,6 +2156,7 @@ export {
   toolsSkillList,
   toolsSkillPrecedenceResolve,
   toolsSkillPrecedenceShow,
+  toolsSkillPruneTelemetry,
   toolsSkillRefresh,
   toolsSkillShow,
   toolsSkillSpawnProviders,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2158,6 +2158,7 @@ export {
   toolsSkillRefresh,
   toolsSkillShow,
   toolsSkillSpawnProviders,
+  toolsSkillStats,
   toolsSkillUninstall,
   toolsSkillVerify,
 } from './tools/engine-ops.js';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2151,6 +2151,7 @@ export {
   toolsSkillDoctorDiagnose,
   toolsSkillFederatedFind,
   toolsSkillFind,
+  toolsSkillImportHermes,
   toolsSkillInstall,
   toolsSkillList,
   toolsSkillPrecedenceResolve,

--- a/packages/core/src/routing/capability-matrix.ts
+++ b/packages/core/src/routing/capability-matrix.ts
@@ -1284,6 +1284,14 @@ const CAPABILITY_MATRIX: OperationCapability[] = [
     mode: 'native',
     preferredChannel: 'either',
   },
+  // T9690 — skill.stats: Sphere B telemetry rollup
+  {
+    domain: 'tools',
+    operation: 'skill.stats',
+    gateway: 'query',
+    mode: 'native',
+    preferredChannel: 'either',
+  },
   {
     domain: 'tools',
     operation: 'skill.install',

--- a/packages/core/src/routing/capability-matrix.ts
+++ b/packages/core/src/routing/capability-matrix.ts
@@ -1292,6 +1292,14 @@ const CAPABILITY_MATRIX: OperationCapability[] = [
     mode: 'native',
     preferredChannel: 'either',
   },
+  // T9691 — skill.import.hermes: Hermes sidecar migration
+  {
+    domain: 'tools',
+    operation: 'skill.import.hermes',
+    gateway: 'mutate',
+    mode: 'native',
+    preferredChannel: 'either',
+  },
   {
     domain: 'tools',
     operation: 'skill.install',

--- a/packages/core/src/routing/capability-matrix.ts
+++ b/packages/core/src/routing/capability-matrix.ts
@@ -1300,6 +1300,14 @@ const CAPABILITY_MATRIX: OperationCapability[] = [
     mode: 'native',
     preferredChannel: 'either',
   },
+  // T9693 — skill.prune.telemetry: skill_usage retention sweep
+  {
+    domain: 'tools',
+    operation: 'skill.prune.telemetry',
+    gateway: 'mutate',
+    mode: 'native',
+    preferredChannel: 'either',
+  },
   {
     domain: 'tools',
     operation: 'skill.install',

--- a/packages/core/src/skills/__tests__/hermes-importer.test.ts
+++ b/packages/core/src/skills/__tests__/hermes-importer.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for hermes-importer.ts — Hermes `.usage.json` → CLEO skills.db migrator.
+ *
+ * Builds a fixture Hermes home under tmpdir with a synthetic `.usage.json`
+ * plus `.bundled_manifest`, runs `importFromHermes`, then asserts:
+ *   - source-type mapping (agent / bundled / user)
+ *   - counter synthesis (use_count × load, view × view, patch × patch)
+ *   - idempotency (re-running produces zero new failures + same DB shape)
+ *   - dry-run mode produces no DB writes
+ *
+ * @task T9691
+ * @epic T9561
+ * @saga T9560
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const FIXTURE_SIDECAR = {
+  'cleo-agent-skill': {
+    archived_at: null,
+    created_at: '2026-05-19T22:09:40.848843+00:00',
+    created_by: 'agent',
+    last_patched_at: '2026-05-19T22:10:49.025785+00:00',
+    last_used_at: '2026-05-20T05:08:34.564999+00:00',
+    last_viewed_at: '2026-05-20T05:08:34.563407+00:00',
+    patch_count: 2,
+    pinned: false,
+    state: 'active',
+    use_count: 3,
+    view_count: 1,
+  },
+  'bundled-skill': {
+    archived_at: null,
+    created_at: '2026-05-04T15:12:32.232081+00:00',
+    created_by: null,
+    last_patched_at: '2026-05-07T19:09:57.939248+00:00',
+    last_used_at: '2026-05-19T15:36:46.111296+00:00',
+    last_viewed_at: '2026-05-19T15:36:46.109646+00:00',
+    patch_count: 0,
+    pinned: false,
+    state: 'active',
+    use_count: 4,
+    view_count: 4,
+  },
+  'plain-user-skill': {
+    archived_at: null,
+    created_at: '2026-05-08T10:00:00.000000+00:00',
+    created_by: null,
+    last_patched_at: null,
+    last_used_at: '2026-05-09T11:00:00.000000+00:00',
+    last_viewed_at: null,
+    patch_count: 0,
+    pinned: true,
+    state: 'stale',
+    use_count: 1,
+    view_count: 0,
+  },
+};
+
+const FIXTURE_BUNDLED_MANIFEST = `bundled-skill:abcdef0123456789
+other-bundled:fedcba9876543210
+`;
+
+describe('importFromHermes (T9691)', () => {
+  let tmpRoot: string;
+  let dbPath: string;
+  let hermesHome: string;
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-t9691-'));
+    dbPath = join(tmpRoot, 'skills.db');
+    hermesHome = join(tmpRoot, 'hermes-home');
+    const skillsDir = join(hermesHome, 'skills');
+    mkdirSync(skillsDir, { recursive: true });
+    writeFileSync(join(skillsDir, '.usage.json'), JSON.stringify(FIXTURE_SIDECAR, null, 2));
+    writeFileSync(join(skillsDir, '.bundled_manifest'), FIXTURE_BUNDLED_MANIFEST);
+
+    const dbMod = await import('../../store/skills-db.js');
+    dbMod.resetSkillsDbState();
+    await dbMod.openSkillsDb({ path: dbPath });
+  });
+
+  afterEach(async () => {
+    const dbMod = await import('../../store/skills-db.js');
+    dbMod.closeSkillsDb();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function countUsage(skillName: string): Promise<number> {
+    const { openSkillsDb } = await import('../../store/skills-db.js');
+    const { skillUsage } = await import('../../store/skills-schema.js');
+    const { eq } = await import('drizzle-orm');
+    const db = await openSkillsDb({ path: dbPath });
+    const rows = db.select().from(skillUsage).where(eq(skillUsage.skillName, skillName)).all();
+    return rows.length;
+  }
+
+  // -------------------------------------------------------------------------
+  // Source-type mapping
+  // -------------------------------------------------------------------------
+
+  it('maps created_by=agent → sourceType=agent-created', async () => {
+    const { importFromHermes } = await import('../hermes-importer.js');
+    const response = await importFromHermes({ hermesHome });
+    expect(response.imported).toBe(3);
+    expect(response.failed).toBe(0);
+    const agentRow = response.rows.find((r) => r.name === 'cleo-agent-skill');
+    expect(agentRow?.sourceType).toBe('agent-created');
+  });
+
+  it('maps bundled-manifest entries → sourceType=canonical', async () => {
+    const { importFromHermes } = await import('../hermes-importer.js');
+    const response = await importFromHermes({ hermesHome });
+    const bundledRow = response.rows.find((r) => r.name === 'bundled-skill');
+    expect(bundledRow?.sourceType).toBe('canonical');
+  });
+
+  it('falls back to sourceType=user for unbundled / non-agent entries', async () => {
+    const { importFromHermes } = await import('../hermes-importer.js');
+    const response = await importFromHermes({ hermesHome });
+    const plainRow = response.rows.find((r) => r.name === 'plain-user-skill');
+    expect(plainRow?.sourceType).toBe('user');
+  });
+
+  // -------------------------------------------------------------------------
+  // Counter synthesis
+  // -------------------------------------------------------------------------
+
+  it('synthesizes use_count × load + view_count × view + patch_count × patch rows', async () => {
+    const { importFromHermes } = await import('../hermes-importer.js');
+    await importFromHermes({ hermesHome });
+    // cleo-agent-skill: use=3, view=1, patch=2 → 6 usage rows.
+    expect(await countUsage('cleo-agent-skill')).toBe(6);
+    // bundled-skill: use=4, view=4, patch=0 → 8 usage rows.
+    expect(await countUsage('bundled-skill')).toBe(8);
+    // plain-user-skill: use=1, view=0, patch=0 → 1 usage row.
+    expect(await countUsage('plain-user-skill')).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotency
+  // -------------------------------------------------------------------------
+
+  it('idempotent — re-running upserts without failures', async () => {
+    const { importFromHermes } = await import('../hermes-importer.js');
+    const first = await importFromHermes({ hermesHome });
+    const second = await importFromHermes({ hermesHome });
+    expect(first.imported).toBe(3);
+    expect(second.imported).toBe(3);
+    expect(second.failed).toBe(0);
+    // skills row count is unchanged; usage rows grow because we synthesize
+    // each invocation — that's documented behaviour for T9691.
+    const { openSkillsDb } = await import('../../store/skills-db.js');
+    const { skills } = await import('../../store/skills-schema.js');
+    const db = await openSkillsDb({ path: dbPath });
+    const rows = db.select().from(skills).all();
+    expect(rows.length).toBe(3);
+  });
+
+  // -------------------------------------------------------------------------
+  // Dry-run mode
+  // -------------------------------------------------------------------------
+
+  it('dry-run produces no DB writes', async () => {
+    const { importFromHermes } = await import('../hermes-importer.js');
+    const response = await importFromHermes({ hermesHome, dryRun: true });
+    expect(response.dryRun).toBe(true);
+    expect(response.imported).toBe(3);
+    expect(response.totalSynthesizedUsage).toBe(6 + 8 + 1);
+    const { openSkillsDb } = await import('../../store/skills-db.js');
+    const { skills, skillUsage } = await import('../../store/skills-schema.js');
+    const db = await openSkillsDb({ path: dbPath });
+    const skillsCount = db.select().from(skills).all().length;
+    const usageCount = db.select().from(skillUsage).all().length;
+    expect(skillsCount).toBe(0);
+    expect(usageCount).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // No-op when Hermes home is empty
+  // -------------------------------------------------------------------------
+
+  it('returns zero-counts envelope when sidecar is missing', async () => {
+    const { importFromHermes } = await import('../hermes-importer.js');
+    const emptyHermes = join(tmpRoot, 'empty-hermes');
+    mkdirSync(emptyHermes, { recursive: true });
+    const response = await importFromHermes({ hermesHome: emptyHermes });
+    expect(response.seen).toBe(0);
+    expect(response.imported).toBe(0);
+    expect(response.rows).toEqual([]);
+  });
+});

--- a/packages/core/src/skills/__tests__/usage-recorder.test.ts
+++ b/packages/core/src/skills/__tests__/usage-recorder.test.ts
@@ -46,6 +46,7 @@ describe('usage-recorder (T9689)', () => {
 
   async function seedSkill(name: string): Promise<void> {
     const { openSkillsDb, upsertSkillRow } = await import('../../store/skills-db.js');
+    const { withProvenance } = await import('../../sentient/skill-provenance.js');
     await openSkillsDb({ path: dbPath });
     const row: NewSkillRow = {
       name,
@@ -55,25 +56,25 @@ describe('usage-recorder (T9689)', () => {
       installedAt: new Date().toISOString(),
       lifecycleState: 'active',
     };
-    await upsertSkillRow(row);
+    await withProvenance('pr-generator', () => upsertSkillRow(row));
   }
 
   /**
-   * Wait until at least one row appears in skill_usage for the given skill,
-   * or the timeout elapses. Necessary because the recorder fires-and-forgets.
+   * Flush the batching queue and return the row-count for the given skill.
+   *
+   * The recorder enqueues into the T9694 batched queue, so a synchronous
+   * SELECT immediately after the enqueue would see zero rows. Tests flush
+   * explicitly to drain the queue into the tmp skills.db.
    */
-  async function awaitUsageRow(skillName: string, timeoutMs = 1000): Promise<number> {
+  async function awaitUsageRow(skillName: string): Promise<number> {
+    const { flushSkillsUsage } = await import('../../store/skills-usage-queue.js');
+    await flushSkillsUsage();
     const { openSkillsDb } = await import('../../store/skills-db.js');
     const { skillUsage } = await import('../../store/skills-schema.js');
     const { eq } = await import('drizzle-orm');
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      const db = await openSkillsDb({ path: dbPath });
-      const rows = db.select().from(skillUsage).where(eq(skillUsage.skillName, skillName)).all();
-      if (rows.length > 0) return rows.length;
-      await new Promise((r) => setTimeout(r, 25));
-    }
-    return 0;
+    const db = await openSkillsDb({ path: dbPath });
+    const rows = db.select().from(skillUsage).where(eq(skillUsage.skillName, skillName)).all();
+    return rows.length;
   }
 
   it('records a usage row for action=load', async () => {

--- a/packages/core/src/skills/__tests__/usage-recorder.test.ts
+++ b/packages/core/src/skills/__tests__/usage-recorder.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for usage-recorder.ts — best-effort telemetry hook.
+ *
+ * Mirrors the tmpdir + `resetSkillsDbState` pattern used by
+ * `skills-store.test.ts` so the user-global `~/.local/share/cleo/skills.db`
+ * is NEVER touched during tests.
+ *
+ * Tests verify three invariants:
+ *   1. `recordSkillUsage('name', 'load')` persists a row.
+ *   2. A failing skills.db open does NOT throw out of the recorder.
+ *   3. `discoverSkill(path)` records a row when telemetry is enabled.
+ *
+ * @task T9689
+ * @epic T9561
+ * @saga T9560
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { NewSkillRow } from '../../store/skills-schema.js';
+
+describe('usage-recorder (T9689)', () => {
+  let tmpRoot: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-t9689-'));
+    dbPath = join(tmpRoot, 'skills.db');
+    const mod = await import('../../store/skills-db.js');
+    mod.resetSkillsDbState();
+    const recorder = await import('../usage-recorder.js');
+    recorder.__setSkillUsageRecorderEnabled(true);
+  });
+
+  afterEach(async () => {
+    const mod = await import('../../store/skills-db.js');
+    mod.closeSkillsDb();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // recordSkillUsage — happy path
+  // -------------------------------------------------------------------------
+
+  async function seedSkill(name: string): Promise<void> {
+    const { openSkillsDb, upsertSkillRow } = await import('../../store/skills-db.js');
+    await openSkillsDb({ path: dbPath });
+    const row: NewSkillRow = {
+      name,
+      version: '1.0.0',
+      sourceType: 'canonical',
+      installPath: `/tmp/skills/${name}`,
+      installedAt: new Date().toISOString(),
+      lifecycleState: 'active',
+    };
+    await upsertSkillRow(row);
+  }
+
+  /**
+   * Wait until at least one row appears in skill_usage for the given skill,
+   * or the timeout elapses. Necessary because the recorder fires-and-forgets.
+   */
+  async function awaitUsageRow(skillName: string, timeoutMs = 1000): Promise<number> {
+    const { openSkillsDb } = await import('../../store/skills-db.js');
+    const { skillUsage } = await import('../../store/skills-schema.js');
+    const { eq } = await import('drizzle-orm');
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const db = await openSkillsDb({ path: dbPath });
+      const rows = db.select().from(skillUsage).where(eq(skillUsage.skillName, skillName)).all();
+      if (rows.length > 0) return rows.length;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    return 0;
+  }
+
+  it('records a usage row for action=load', async () => {
+    await seedSkill('ct-orchestrator');
+    const { recordSkillUsage } = await import('../usage-recorder.js');
+    recordSkillUsage('ct-orchestrator', 'load');
+    const count = await awaitUsageRow('ct-orchestrator');
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it('records a usage row for action=edit with taskId context', async () => {
+    await seedSkill('my-skill');
+    const { recordSkillUsage } = await import('../usage-recorder.js');
+    recordSkillUsage('my-skill', 'edit', { taskId: 'T9689' });
+    const count = await awaitUsageRow('my-skill');
+    expect(count).toBeGreaterThan(0);
+
+    const { openSkillsDb } = await import('../../store/skills-db.js');
+    const { skillUsage } = await import('../../store/skills-schema.js');
+    const { eq } = await import('drizzle-orm');
+    const db = await openSkillsDb({ path: dbPath });
+    const rows = db.select().from(skillUsage).where(eq(skillUsage.skillName, 'my-skill')).all();
+    expect(rows[0]?.taskId).toBe('T9689');
+    expect(rows[0]?.eventKind).toBe('edit');
+  });
+
+  // -------------------------------------------------------------------------
+  // recordSkillUsage — best-effort: never throws
+  // -------------------------------------------------------------------------
+
+  it('does not throw when name is empty', () => {
+    expect(async () => {
+      const { recordSkillUsage } = await import('../usage-recorder.js');
+      recordSkillUsage('', 'load');
+    }).not.toThrow();
+  });
+
+  it('does not throw when recorder is disabled', async () => {
+    const { recordSkillUsage, __setSkillUsageRecorderEnabled } = await import(
+      '../usage-recorder.js'
+    );
+    __setSkillUsageRecorderEnabled(false);
+    expect(() => {
+      recordSkillUsage('anything', 'load');
+    }).not.toThrow();
+    __setSkillUsageRecorderEnabled(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // discoverSkill hook integration
+  // -------------------------------------------------------------------------
+
+  it('discoverSkill() records a usage row when telemetry is enabled', async () => {
+    // Need to open skills.db at tmpdir first so discoverSkill's telemetry
+    // write lands in the test DB, not the user-global one.
+    const { openSkillsDb } = await import('../../store/skills-db.js');
+    await openSkillsDb({ path: dbPath });
+
+    const skillDir = join(tmpRoot, 'fixture-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: fixture-skill\ndescription: a fixture\n---\n# Fixture\n',
+    );
+
+    const { discoverSkill } = await import('../discovery.js');
+    const skill = discoverSkill(skillDir);
+    expect(skill).not.toBeNull();
+    const count = await awaitUsageRow('fixture-skill');
+    expect(count).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/skills/discovery.ts
+++ b/packages/core/src/skills/discovery.ts
@@ -33,6 +33,7 @@ import type {
   SkillSummary,
 } from './types.js';
 import { SKILL_NAME_MAP } from './types.js';
+import { recordSkillUsage } from './usage-recorder.js';
 
 // ============================================================================
 // CAAMP Search Path Resolution
@@ -228,7 +229,7 @@ export function discoverSkill(skillDir: string): Skill | null {
   const frontmatter = parseFrontmatter(content);
 
   const dirName = basename(skillDir);
-  return {
+  const skill: Skill = {
     name: frontmatter.name || dirName,
     dirName,
     path: skillDir,
@@ -236,6 +237,11 @@ export function discoverSkill(skillDir: string): Skill | null {
     frontmatter,
     content,
   };
+
+  // T9689 — record load telemetry (best-effort, never blocks discovery).
+  recordSkillUsage(skill.name, 'load');
+
+  return skill;
 }
 
 /**

--- a/packages/core/src/skills/hermes-importer.ts
+++ b/packages/core/src/skills/hermes-importer.ts
@@ -1,0 +1,318 @@
+/**
+ * Hermes `~/.hermes/skills/.usage.json` → CLEO `skills.db` migrator.
+ *
+ * Reads the Hermes sidecar (one JSON object keyed by skill name), maps
+ * Hermes provenance into the CLEO `source_type` enum, and inserts
+ * equivalent rows into `skills.db` via the
+ * {@link bulkImportFromHermes} adapter helper.
+ *
+ * Counter fields (`use_count`, `view_count`, `patch_count`) are
+ * synthesized into `skill_usage` rows so the freshly-imported registry
+ * is queryable by `cleo skills stats` immediately after migration.
+ *
+ * ## Provenance mapping
+ *
+ * The Hermes sidecar exposes `created_by` (`agent` / `null`) and a
+ * separate `.bundled_manifest` file listing hub-bundled skills as
+ * `<name>:<sha>` lines. The mapping is:
+ *
+ * | Hermes signal                   | CLEO `source_type` |
+ * |---------------------------------|--------------------|
+ * | `created_by == 'agent'`         | `agent-created`    |
+ * | listed in `.bundled_manifest`   | `canonical`        |
+ * | otherwise                       | `user`             |
+ *
+ * `community` is intentionally NEVER produced — Hermes' marketplace
+ * concept doesn't have a 1:1 equivalent so we conservatively label
+ * those as `user` and let the operator promote them later via
+ * `cleo skills mark-community` (out of scope for T9691).
+ *
+ * @task T9691
+ * @epic T9561
+ * @saga T9560
+ * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §4
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  SkillImportHermesRequest,
+  SkillImportHermesResponse,
+  SkillImportHermesRow,
+} from '@cleocode/contracts';
+import { withProvenance } from '../sentient/skill-provenance.js';
+import { upsertSkillRow } from '../store/skills-db.js';
+import type { NewSkillRow, NewSkillUsageRow, SkillSourceType } from '../store/skills-schema.js';
+import { insertUsage } from '../store/skills-store.js';
+
+// ---------------------------------------------------------------------------
+// Hermes sidecar shape
+// ---------------------------------------------------------------------------
+
+/**
+ * One entry in `~/.hermes/skills/.usage.json`.
+ *
+ * Fields that are absent on a per-skill basis (e.g. fresh installs with no
+ * patches yet) are null-or-zero by Hermes convention.
+ */
+interface HermesUsageEntry {
+  archived_at: string | null;
+  created_at: string;
+  created_by: 'agent' | null;
+  last_patched_at: string | null;
+  last_used_at: string | null;
+  last_viewed_at: string | null;
+  patch_count: number;
+  pinned: boolean;
+  state: 'active' | 'stale' | 'archived';
+  use_count: number;
+  view_count: number;
+}
+
+/**
+ * Top-level Hermes sidecar shape — a flat record keyed by skill name.
+ */
+type HermesUsageSidecar = Record<string, HermesUsageEntry>;
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the Hermes home dir from request overrides + `$HOME` fallback.
+ *
+ * Always returns an absolute path. Does NOT verify the directory exists —
+ * the caller checks for the sidecar file specifically.
+ */
+function resolveHermesHome(overrideRoot: string | undefined): string {
+  if (overrideRoot) return overrideRoot;
+  const env = process.env['HERMES_HOME'];
+  if (env) return env;
+  return join(homedir(), '.hermes');
+}
+
+/**
+ * Parse the Hermes `.bundled_manifest` into a set of bundled skill names.
+ *
+ * Each line is `<name>:<hash>`. Lines without a colon are skipped silently.
+ * Returns an empty set if the manifest file does not exist.
+ */
+function readBundledManifest(skillsRoot: string): Set<string> {
+  const manifestPath = join(skillsRoot, '.bundled_manifest');
+  if (!existsSync(manifestPath)) return new Set();
+  const raw = readFileSync(manifestPath, 'utf-8');
+  const names = new Set<string>();
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const colon = trimmed.indexOf(':');
+    if (colon <= 0) continue;
+    names.add(trimmed.slice(0, colon));
+  }
+  return names;
+}
+
+/**
+ * Read + parse the Hermes `.usage.json` sidecar.
+ *
+ * Returns `null` if the sidecar does not exist — callers treat that as
+ * "nothing to import" and short-circuit.
+ *
+ * @throws {Error} If the file exists but is not valid JSON.
+ */
+function readHermesSidecar(skillsRoot: string): HermesUsageSidecar | null {
+  const sidecarPath = join(skillsRoot, '.usage.json');
+  if (!existsSync(sidecarPath)) return null;
+  const raw = readFileSync(sidecarPath, 'utf-8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`Hermes sidecar at ${sidecarPath} is not a JSON object`);
+  }
+  return parsed as HermesUsageSidecar;
+}
+
+// ---------------------------------------------------------------------------
+// Provenance + state mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map Hermes provenance signals to the CLEO `SkillSourceType` enum.
+ *
+ * See the architecture v3 §4 table for the canonical mapping rules.
+ */
+function mapSourceType(
+  entry: HermesUsageEntry,
+  bundled: Set<string>,
+  name: string,
+): SkillSourceType {
+  if (entry.created_by === 'agent') return 'agent-created';
+  if (bundled.has(name)) return 'canonical';
+  return 'user';
+}
+
+/**
+ * Coerce a Hermes `state` value into the CLEO `lifecycle_state` enum.
+ *
+ * Hermes uses the same three labels so this is a noop in practice; we
+ * keep the helper for forward-compat if either side ever extends the
+ * enum.
+ */
+function mapLifecycleState(state: HermesUsageEntry['state']): 'active' | 'stale' | 'archived' {
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the Hermes → CLEO migration as described by {@link SkillImportHermesRequest}.
+ *
+ * Behaviour:
+ *   1. Resolve Hermes home (request override > $HERMES_HOME > ~/.hermes).
+ *   2. Read `<hermesHome>/skills/.usage.json` (skip silently if absent).
+ *   3. Read `<hermesHome>/skills/.bundled_manifest` for canonical mapping.
+ *   4. For each entry, derive the `skills` row + synthesize usage counters.
+ *   5. Upsert atomically via `upsertSkillRow` (idempotent by `name`).
+ *
+ * The dry-run mode walks the same code paths but skips writes. The returned
+ * response is identical in shape — callers can diff dry-run vs real-run
+ * outcomes without re-invoking.
+ *
+ * @param request - Import request envelope.
+ * @returns Per-row outcomes + summary counters.
+ *
+ * @task T9691
+ */
+export async function importFromHermes(
+  request: SkillImportHermesRequest = {},
+): Promise<SkillImportHermesResponse> {
+  const hermesHome = resolveHermesHome(request.hermesHome);
+  const skillsRoot = join(hermesHome, 'skills');
+  const dryRun = request.dryRun === true;
+
+  const sidecar = readHermesSidecar(skillsRoot);
+  if (!sidecar) {
+    return {
+      hermesHome,
+      dryRun,
+      seen: 0,
+      imported: 0,
+      skipped: 0,
+      failed: 0,
+      rows: [],
+      totalSynthesizedUsage: 0,
+    };
+  }
+
+  const bundled = readBundledManifest(skillsRoot);
+  const rows: SkillImportHermesRow[] = [];
+  let imported = 0;
+  const skipped = 0;
+  let failed = 0;
+  let totalSynthesizedUsage = 0;
+
+  for (const [name, entry] of Object.entries(sidecar)) {
+    try {
+      const sourceType = mapSourceType(entry, bundled, name);
+      const lifecycle = mapLifecycleState(entry.state);
+      const installedAt = entry.created_at;
+      const lastUpdatedAt =
+        entry.last_patched_at ?? entry.last_used_at ?? entry.last_viewed_at ?? entry.created_at;
+      const installPath = join(skillsRoot, name);
+
+      const skillRow: NewSkillRow = {
+        name,
+        version: null,
+        sourceType,
+        sourceUrl: null,
+        installPath,
+        canonicalPath: sourceType === 'canonical' ? installPath : null,
+        installedAt,
+        lastUpdatedAt,
+        lifecycleState: lifecycle,
+        pinned: entry.pinned,
+        isAgentCreated: sourceType === 'agent-created',
+        archivedAt: entry.archived_at,
+        archivedFromPath: entry.archived_at ? installPath : null,
+      };
+
+      if (!dryRun) {
+        // Hermes-imported canonical/bundled skills land in skills.db as
+        // ground-truth rows. The T9708 canonical-write guard requires every
+        // canonical upsert to declare its provenance — for the importer
+        // that's `pr-generator` (CI-equivalent import path).
+        if (sourceType === 'canonical') {
+          await withProvenance('pr-generator', () => upsertSkillRow(skillRow));
+        } else {
+          await upsertSkillRow(skillRow);
+        }
+      }
+
+      // Synthesize per-counter `skill_usage` rows so historical activity
+      // is queryable via `cleo skills stats`. We attribute the timestamp
+      // to `last_used_at` / `last_viewed_at` / `last_patched_at` so they
+      // sort correctly in time-windowed queries.
+      const synthesisPlan: Array<{
+        eventKind: 'load' | 'view' | 'patch';
+        count: number;
+        timestamp: string | null;
+      }> = [
+        { eventKind: 'load', count: entry.use_count, timestamp: entry.last_used_at },
+        { eventKind: 'view', count: entry.view_count, timestamp: entry.last_viewed_at },
+        { eventKind: 'patch', count: entry.patch_count, timestamp: entry.last_patched_at },
+      ];
+
+      let synthesizedForThisRow = 0;
+      for (const plan of synthesisPlan) {
+        if (plan.count <= 0) continue;
+        const ts = plan.timestamp ?? installedAt;
+        for (let i = 0; i < plan.count; i++) {
+          synthesizedForThisRow++;
+          if (dryRun) continue;
+          const usageRow: NewSkillUsageRow = {
+            skillName: name,
+            eventKind: plan.eventKind,
+            observedAt: ts,
+            taskId: null,
+            modelId: null,
+            metadata: JSON.stringify({ source: 'hermes-import' }),
+          };
+          await insertUsage(usageRow);
+        }
+      }
+      totalSynthesizedUsage += synthesizedForThisRow;
+
+      rows.push({
+        name,
+        disposition: 'imported',
+        sourceType,
+        synthesizedUsageRows: synthesizedForThisRow,
+        error: null,
+      });
+      imported++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      rows.push({
+        name,
+        disposition: 'failed',
+        sourceType: null,
+        synthesizedUsageRows: 0,
+        error: message,
+      });
+      failed++;
+    }
+  }
+
+  return {
+    hermesHome,
+    dryRun,
+    seen: rows.length,
+    imported,
+    skipped,
+    failed,
+    rows,
+    totalSynthesizedUsage,
+  };
+}

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -282,6 +282,9 @@ export type {
   TokenValidationResult,
 } from './types.js';
 export { SKILL_NAME_MAP } from './types.js';
+// Usage recorder (T9689 — SG-CLEO-SKILLS Sphere B telemetry)
+export type { SkillUsageAction, SkillUsageContext } from './usage-recorder.js';
+export { recordSkillUsage } from './usage-recorder.js';
 export type { IssueSeverity, SkillValidationResult, ValidationIssue } from './validation.js';
 // Validation
 export {

--- a/packages/core/src/skills/usage-recorder.ts
+++ b/packages/core/src/skills/usage-recorder.ts
@@ -19,7 +19,7 @@
  */
 
 import type { NewSkillUsageRow } from '../store/skills-store.js';
-import { insertUsage } from '../store/skills-store.js';
+import { enqueueSkillUsage } from '../store/skills-usage-queue.js';
 
 /**
  * Discriminated-union of actions the recorder accepts.
@@ -120,10 +120,12 @@ export function recordSkillUsage(
     metadata: JSON.stringify(metadataObj),
   };
 
-  // Fire-and-forget. Detach via void + catch so unhandled-rejection traps
-  // never see this write. `insertUsage` opens the DB lazily, so the cost
-  // on the hot path is just a microtask schedule + the JSON.stringify above.
-  void insertUsage(row).catch(() => {
+  // Enqueue into the batched-write queue (T9694). The queue keeps the
+  // hot path sync — no DB open, no INSERT — and coalesces bursts of skill
+  // loads into a single batched INSERT on idle / capacity / beforeExit.
+  try {
+    enqueueSkillUsage(row);
+  } catch {
     /* swallowed — telemetry MUST NOT block skill loading (architecture v3 §5) */
-  });
+  }
 }

--- a/packages/core/src/skills/usage-recorder.ts
+++ b/packages/core/src/skills/usage-recorder.ts
@@ -1,0 +1,129 @@
+/**
+ * Skill-usage telemetry recorder — best-effort fire-and-forget writer.
+ *
+ * Every skill load / view / edit / patch / review event is funneled through
+ * {@link recordSkillUsage} which delegates to {@link insertUsage} from
+ * `@cleocode/core/store/skills-store`. The recorder is intentionally
+ * synchronous at the call site (returns `void`) — the underlying DB write is
+ * launched as a detached promise so that telemetry failures NEVER block the
+ * skill-load path.
+ *
+ * This module deliberately mirrors the Hermes "best-effort _mutate" pattern:
+ * if the database is missing, locked, mid-migration, or otherwise unreachable
+ * the recorder swallows the error and continues. The skill load proceeds.
+ *
+ * @task T9689
+ * @epic T9561
+ * @saga T9560
+ * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §5
+ */
+
+import type { NewSkillUsageRow } from '../store/skills-store.js';
+import { insertUsage } from '../store/skills-store.js';
+
+/**
+ * Discriminated-union of actions the recorder accepts.
+ *
+ * - `load`   — the skill was discovered & its `SKILL.md` was read into memory
+ * - `view`   — a `cleo skills info <name>` (or equivalent) inspection
+ * - `edit`   — the skill body / frontmatter was mutated on disk
+ * - `patch`  — an auto-improve diff was applied (T9694+ pipeline)
+ * - `review` — a council/grade run emitted a review row
+ *
+ * Free-form `event_kind` strings are NOT accepted — callers must use this
+ * enum so analytics queries stay deterministic across CLEO versions.
+ *
+ * @architecture v3 §5 telemetry action enum
+ */
+export type SkillUsageAction = 'load' | 'view' | 'edit' | 'patch' | 'review';
+
+/**
+ * Optional context payload attached to a usage row.
+ *
+ * `taskId` and `modelId` get persisted as dedicated columns; everything else
+ * is JSON-encoded into `skill_usage.metadata`.
+ */
+export interface SkillUsageContext {
+  /** CLEO task ID (e.g. `T9689`) if the recorder is running inside a task. */
+  readonly taskId?: string;
+  /** Model identifier the calling agent was running under (e.g. `claude-opus-4-7`). */
+  readonly modelId?: string;
+  /** Free-form key/value pairs to JSON-encode into `metadata`. */
+  readonly metadata?: Readonly<Record<string, string | number | boolean | null>>;
+}
+
+/**
+ * Internal flag — set to `true` in tests via {@link __setSkillUsageRecorderEnabled}
+ * so unit tests can verify the recorder fires without depending on global
+ * environment variables. Production callers leave this `true`.
+ */
+let _enabled = true;
+
+/**
+ * Toggle the recorder on / off — test-only seam.
+ *
+ * The user-facing opt-out lives at the architecture §5 boundary (CLI flag /
+ * config key), not here. This helper exists ONLY so the discovery test
+ * suite can disable recording in cases where the tmp skills.db is not
+ * provisioned.
+ *
+ * @internal
+ */
+export function __setSkillUsageRecorderEnabled(enabled: boolean): void {
+  _enabled = enabled;
+}
+
+/**
+ * Returns whether the recorder is currently enabled.
+ *
+ * @internal
+ */
+export function __isSkillUsageRecorderEnabled(): boolean {
+  return _enabled;
+}
+
+/**
+ * Record a single skill-usage event — best-effort, fire-and-forget.
+ *
+ * The DB write happens on a detached promise so the caller never awaits.
+ * If the write fails (skills.db missing / locked / read-only filesystem /
+ * schema drift / any other error), the failure is silently swallowed. This
+ * is BY DESIGN — telemetry must never break skill loading.
+ *
+ * @example
+ * ```typescript
+ * recordSkillUsage('ct-orchestrator', 'load');
+ * recordSkillUsage('my-skill', 'edit', { taskId: 'T9689' });
+ * ```
+ *
+ * @param name - Skill identifier as returned by {@link findSkill} /
+ *   {@link discoverSkill}.
+ * @param action - The kind of usage event — see {@link SkillUsageAction}.
+ * @param context - Optional `taskId` / `modelId` / metadata.
+ *
+ * @task T9689
+ */
+export function recordSkillUsage(
+  name: string,
+  action: SkillUsageAction,
+  context?: SkillUsageContext,
+): void {
+  if (!_enabled) return;
+  if (!name) return;
+
+  const metadataObj = context?.metadata ?? {};
+  const row: NewSkillUsageRow = {
+    skillName: name,
+    eventKind: action,
+    taskId: context?.taskId ?? null,
+    modelId: context?.modelId ?? null,
+    metadata: JSON.stringify(metadataObj),
+  };
+
+  // Fire-and-forget. Detach via void + catch so unhandled-rejection traps
+  // never see this write. `insertUsage` opens the DB lazily, so the cost
+  // on the hot path is just a microtask schedule + the JSON.stringify above.
+  void insertUsage(row).catch(() => {
+    /* swallowed — telemetry MUST NOT block skill loading (architecture v3 §5) */
+  });
+}

--- a/packages/core/src/store/__tests__/skills-usage-queue.test.ts
+++ b/packages/core/src/store/__tests__/skills-usage-queue.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for skills-usage-queue.ts — batched-write queue for telemetry.
+ *
+ * Verifies:
+ *   - `enqueue()` does NOT touch the DB until `flush()` is called.
+ *   - Capacity-trigger fires the flush mid-burst.
+ *   - 1000 sequential enqueues produce zero DB rows mid-burst and
+ *     exactly 1000 rows after an explicit flush.
+ *   - `process.beforeExit` hook is installed exactly once across many
+ *     enqueues (no listener leak).
+ *
+ * @task T9694
+ * @epic T9561
+ * @saga T9560
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { NewSkillRow, NewSkillUsageRow } from '../skills-schema.js';
+
+describe('skills-usage-queue (T9694)', () => {
+  let tmpRoot: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-t9694-'));
+    dbPath = join(tmpRoot, 'skills.db');
+    const dbMod = await import('../skills-db.js');
+    dbMod.resetSkillsDbState();
+    // Open the tmp DB BEFORE any queue work so the singleton sits at our tmp.
+    await dbMod.openSkillsDb({ path: dbPath });
+  });
+
+  afterEach(async () => {
+    const dbMod = await import('../skills-db.js');
+    dbMod.closeSkillsDb();
+    const qMod = await import('../skills-usage-queue.js');
+    qMod.__setSkillsUsageQueueSingleton(null);
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function seedSkill(name: string): Promise<void> {
+    const { upsertSkillRow } = await import('../skills-db.js');
+    const { withProvenance } = await import('../../sentient/skill-provenance.js');
+    const row: NewSkillRow = {
+      name,
+      version: '1.0.0',
+      sourceType: 'canonical',
+      installPath: `/tmp/skills/${name}`,
+      installedAt: new Date().toISOString(),
+      lifecycleState: 'active',
+    };
+    await withProvenance('pr-generator', () => upsertSkillRow(row));
+  }
+
+  async function countUsage(skillName: string): Promise<number> {
+    const { openSkillsDb } = await import('../skills-db.js');
+    const { skillUsage } = await import('../skills-schema.js');
+    const { eq } = await import('drizzle-orm');
+    const db = await openSkillsDb({ path: dbPath });
+    const rows = db.select().from(skillUsage).where(eq(skillUsage.skillName, skillName)).all();
+    return rows.length;
+  }
+
+  // -------------------------------------------------------------------------
+  // enqueue does NOT write until flush
+  // -------------------------------------------------------------------------
+
+  it('enqueue() does not persist rows until flush() is called', async () => {
+    await seedSkill('queued-skill');
+    const { SkillsUsageQueue } = await import('../skills-usage-queue.js');
+    const q = new SkillsUsageQueue({
+      capacity: 1000,
+      idleMs: 0, // disable debounce — only explicit flush writes
+      disableBeforeExitHook: true,
+    });
+
+    q.enqueue({ skillName: 'queued-skill', eventKind: 'load' });
+    q.enqueue({ skillName: 'queued-skill', eventKind: 'view' });
+
+    expect(q.size).toBe(2);
+    expect(await countUsage('queued-skill')).toBe(0);
+
+    await q.flush();
+    expect(q.size).toBe(0);
+    expect(await countUsage('queued-skill')).toBe(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // capacity-trigger fires flush mid-burst
+  // -------------------------------------------------------------------------
+
+  it('hits capacity and auto-flushes mid-burst', async () => {
+    await seedSkill('cap-skill');
+    const { SkillsUsageQueue } = await import('../skills-usage-queue.js');
+    const q = new SkillsUsageQueue({
+      capacity: 4,
+      idleMs: 0,
+      disableBeforeExitHook: true,
+    });
+
+    for (let i = 0; i < 4; i++) {
+      q.enqueue({ skillName: 'cap-skill', eventKind: 'load' });
+    }
+    // Capacity-trigger flush is fire-and-forget; await it explicitly.
+    await q.flush();
+    expect(await countUsage('cap-skill')).toBe(4);
+  });
+
+  // -------------------------------------------------------------------------
+  // 1000-call burst: zero rows mid-burst, exactly 1000 after flush
+  // -------------------------------------------------------------------------
+
+  it('1000 sequential enqueues produce zero DB writes mid-burst and exactly 1000 rows after flush', async () => {
+    await seedSkill('burst');
+    const { SkillsUsageQueue } = await import('../skills-usage-queue.js');
+    const q = new SkillsUsageQueue({
+      capacity: 10_000,
+      idleMs: 0,
+      disableBeforeExitHook: true,
+    });
+
+    for (let i = 0; i < 1000; i++) {
+      q.enqueue({ skillName: 'burst', eventKind: 'load' });
+    }
+    // Mid-burst snapshot — no DB writes yet because idleMs=0 disables debounce.
+    expect(await countUsage('burst')).toBe(0);
+    expect(q.size).toBe(1000);
+
+    await q.flush();
+    expect(await countUsage('burst')).toBe(1000);
+    expect(q.size).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // process.beforeExit listener — installed at most once
+  // -------------------------------------------------------------------------
+
+  it('installs the beforeExit listener exactly once across many enqueues', async () => {
+    const { SkillsUsageQueue } = await import('../skills-usage-queue.js');
+    const before = process.listenerCount('beforeExit');
+    const q = new SkillsUsageQueue({ capacity: 1000, idleMs: 0 });
+    for (let i = 0; i < 50; i++) {
+      q.enqueue({ skillName: 'leak-test', eventKind: 'load' });
+    }
+    const after = process.listenerCount('beforeExit');
+    // At most one new listener was added by this queue instance.
+    expect(after - before).toBeLessThanOrEqual(1);
+    // Clean up by flushing + dropping the singleton.
+    await q.flush();
+  });
+
+  // -------------------------------------------------------------------------
+  // drain() — test-only synchronous discard
+  // -------------------------------------------------------------------------
+
+  it('drain() returns the buffered rows and resets size to 0', async () => {
+    const { SkillsUsageQueue } = await import('../skills-usage-queue.js');
+    const q = new SkillsUsageQueue({
+      capacity: 1000,
+      idleMs: 0,
+      disableBeforeExitHook: true,
+    });
+    const row: NewSkillUsageRow = { skillName: 'drain', eventKind: 'load' };
+    q.enqueue(row);
+    q.enqueue(row);
+    expect(q.size).toBe(2);
+
+    const drained = q.drain();
+    expect(drained.length).toBe(2);
+    expect(q.size).toBe(0);
+    expect(await countUsage('drain')).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // singleton helpers
+  // -------------------------------------------------------------------------
+
+  it('enqueueSkillUsage + flushSkillsUsage round-trip via singleton', async () => {
+    await seedSkill('singleton-skill');
+    const {
+      SkillsUsageQueue,
+      __setSkillsUsageQueueSingleton,
+      enqueueSkillUsage,
+      flushSkillsUsage,
+    } = await import('../skills-usage-queue.js');
+    // Install an isolated test queue so the user-global singleton stays
+    // untouched if the suite runs in parallel.
+    __setSkillsUsageQueueSingleton(
+      new SkillsUsageQueue({ capacity: 1000, idleMs: 0, disableBeforeExitHook: true }),
+    );
+
+    enqueueSkillUsage({ skillName: 'singleton-skill', eventKind: 'load' });
+    enqueueSkillUsage({ skillName: 'singleton-skill', eventKind: 'invoke' });
+    expect(await countUsage('singleton-skill')).toBe(0);
+
+    await flushSkillsUsage();
+    expect(await countUsage('singleton-skill')).toBe(2);
+  });
+});

--- a/packages/core/src/store/skills-db.ts
+++ b/packages/core/src/store/skills-db.ts
@@ -311,6 +311,20 @@ export function getSkillsNativeDb(): DatabaseSync | null {
   return _skillsNativeDb;
 }
 
+/**
+ * Return the absolute path of the currently open skills.db handle, or
+ * `null` if no handle is open. Honors test-supplied overrides — the
+ * default-resolver path is NOT returned unless a real open happened.
+ *
+ * Used by the T9693 prune CLI to report `dbSizeBefore` / `dbSizeAfter`
+ * against the actually-open file (which may be a tmpdir in tests).
+ *
+ * @task T9693
+ */
+export function getOpenSkillsDbPath(): string | null {
+  return _skillsDbPath;
+}
+
 // ---------------------------------------------------------------------------
 // Read / write helpers (acceptance criterion 4)
 // ---------------------------------------------------------------------------

--- a/packages/core/src/store/skills-store.ts
+++ b/packages/core/src/store/skills-store.ts
@@ -35,7 +35,7 @@
  * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §4-§5
  */
 
-import { desc, eq, sql } from 'drizzle-orm';
+import { desc, eq, lt, sql } from 'drizzle-orm';
 import { withProvenance } from '../sentient/skill-provenance.js';
 import {
   getSkillRow as _getSkillRow,
@@ -184,6 +184,146 @@ export async function listSkillsBySource(
   options?: { lifecycleState?: SkillLifecycleState },
 ): Promise<SkillRow[]> {
   return _listSkillsBySource(sourceType, options);
+}
+
+// ---------------------------------------------------------------------------
+// Stats facets (T9690 — `cleo skills stats` engine support)
+// ---------------------------------------------------------------------------
+
+/**
+ * One bucket from {@link countByLifecycle}.
+ */
+export interface SkillLifecycleCount {
+  /** Lifecycle bucket. */
+  readonly state: SkillLifecycleState;
+  /** Count of skills in this bucket. */
+  readonly count: number;
+}
+
+/**
+ * Group `skills` by `lifecycle_state` and return the per-bucket count.
+ *
+ * @returns One row per lifecycle bucket present in the table; absent buckets
+ *   are omitted (callers fill in zeros if they want a fixed-shape report).
+ *
+ * @task T9690
+ */
+export async function countByLifecycle(): Promise<SkillLifecycleCount[]> {
+  const db = await openSkillsDb();
+  const rows = db
+    .select({
+      state: skillsTable.lifecycleState,
+      count: sql<number>`COUNT(*)`.as('count'),
+    })
+    .from(skillsTable)
+    .groupBy(skillsTable.lifecycleState)
+    .orderBy(skillsTable.lifecycleState)
+    .all();
+  return rows.map((r) => ({ state: r.state as SkillLifecycleState, count: Number(r.count) }));
+}
+
+/**
+ * One bucket from {@link countBySourceType}.
+ */
+export interface SkillSourceTypeCount {
+  /** Source-type bucket. */
+  readonly sourceType: SkillSourceType;
+  /** Count of skills in this bucket. */
+  readonly count: number;
+}
+
+/**
+ * Group `skills` by `source_type` and return the per-bucket count.
+ *
+ * @task T9690
+ */
+export async function countBySourceType(): Promise<SkillSourceTypeCount[]> {
+  const db = await openSkillsDb();
+  const rows = db
+    .select({
+      sourceType: skillsTable.sourceType,
+      count: sql<number>`COUNT(*)`.as('count'),
+    })
+    .from(skillsTable)
+    .groupBy(skillsTable.sourceType)
+    .orderBy(skillsTable.sourceType)
+    .all();
+  return rows.map((r) => ({
+    sourceType: r.sourceType as SkillSourceType,
+    count: Number(r.count),
+  }));
+}
+
+/**
+ * List all skill rows where `is_agent_created` is true, ordered by
+ * `installed_at` descending.
+ *
+ * @task T9690
+ */
+export async function listAgentCreated(): Promise<SkillRow[]> {
+  const db = await openSkillsDb();
+  return db
+    .select()
+    .from(skillsTable)
+    .where(eq(skillsTable.isAgentCreated, true))
+    .orderBy(desc(skillsTable.installedAt))
+    .all();
+}
+
+// ---------------------------------------------------------------------------
+// Retention (T9693 — `cleo skills prune-telemetry`)
+// ---------------------------------------------------------------------------
+
+/**
+ * Result envelope from {@link pruneUsageOlderThan}.
+ */
+export interface PruneUsageResult {
+  /** Rows deleted by this call. */
+  readonly deletedRows: number;
+  /** Oldest `observed_at` still in the table after the prune (`null` if empty). */
+  readonly oldestRemaining: string | null;
+  /** Newest `observed_at` still in the table after the prune (`null` if empty). */
+  readonly newestRemaining: string | null;
+}
+
+/**
+ * Delete `skill_usage` rows whose `observed_at` is strictly before the
+ * given ISO-8601 cutoff.
+ *
+ * The post-delete `oldestRemaining` / `newestRemaining` fields are returned
+ * so the CLI can show a before/after snapshot without re-querying.
+ *
+ * @param cutoffIso - ISO-8601 timestamp. Rows with `observed_at < cutoffIso`
+ *   are deleted; rows with `observed_at = cutoffIso` are retained.
+ *
+ * @task T9693
+ */
+export async function pruneUsageOlderThan(cutoffIso: string): Promise<PruneUsageResult> {
+  const db = await openSkillsDb();
+  const beforeCount = db
+    .select({ c: sql<number>`COUNT(*)`.as('c') })
+    .from(skillUsageTable)
+    .where(lt(skillUsageTable.observedAt, cutoffIso))
+    .all();
+  const toDelete = Number(beforeCount[0]?.c ?? 0);
+
+  if (toDelete > 0) {
+    db.delete(skillUsageTable).where(lt(skillUsageTable.observedAt, cutoffIso)).run();
+  }
+
+  const bounds = db
+    .select({
+      oldest: sql<string | null>`MIN(${skillUsageTable.observedAt})`.as('oldest'),
+      newest: sql<string | null>`MAX(${skillUsageTable.observedAt})`.as('newest'),
+    })
+    .from(skillUsageTable)
+    .all();
+
+  return {
+    deletedRows: toDelete,
+    oldestRemaining: bounds[0]?.oldest ?? null,
+    newestRemaining: bounds[0]?.newest ?? null,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/store/skills-usage-queue.ts
+++ b/packages/core/src/store/skills-usage-queue.ts
@@ -1,0 +1,253 @@
+/**
+ * Skills-usage write batching queue — keeps skill-load latency near zero.
+ *
+ * The {@link recordSkillUsage} recorder (T9689) is on the hot path of every
+ * skill discovery. Even though its DB write is detached via `void`, a burst
+ * of 100+ skill loads (e.g. orchestrator startup walking ~/.cleo/skills/)
+ * would still trigger 100+ independent SQLite transactions. This queue
+ * coalesces them into a single batched INSERT.
+ *
+ * ## Design
+ *
+ * - Bounded ring buffer (default 256 entries).
+ * - Auto-flush triggers:
+ *   1. 250 ms idle (debounce: every enqueue resets the timer).
+ *   2. Queue full — flush immediately when entry 257 would overflow.
+ *   3. `process.beforeExit` — installed exactly once at first enqueue.
+ * - `flushSkillsUsage()` exposed for explicit shutdown / tests.
+ * - `drainSkillsUsageQueue()` test-only seam — synchronously empties
+ *   without writing.
+ *
+ * The queue does NOT replace {@link insertUsage}. Direct callers (Hermes
+ * import, tests, the future auto-improve patch path) keep using the
+ * synchronous insert API. ONLY the loader hook (T9689) routes through
+ * the queue, because that's the hot path where batching pays off.
+ *
+ * @task T9694
+ * @epic T9561
+ * @saga T9560
+ * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §5
+ */
+
+import { openSkillsDb } from './skills-db.js';
+import {
+  type NewSkillUsageRow,
+  type SkillUsageRow,
+  skillUsage as skillUsageTable,
+} from './skills-schema.js';
+
+// ---------------------------------------------------------------------------
+// Configuration constants
+// ---------------------------------------------------------------------------
+
+/** Default ring-buffer capacity. Overridable via {@link SkillsUsageQueue} ctor. */
+export const SKILLS_USAGE_QUEUE_DEFAULT_CAPACITY = 256;
+
+/** Default idle-flush window in milliseconds. */
+export const SKILLS_USAGE_QUEUE_DEFAULT_IDLE_MS = 250;
+
+// ---------------------------------------------------------------------------
+// Queue class
+// ---------------------------------------------------------------------------
+
+/**
+ * Options accepted by the {@link SkillsUsageQueue} constructor.
+ */
+export interface SkillsUsageQueueOptions {
+  /** Ring-buffer capacity — when reached, the queue flushes immediately. */
+  readonly capacity?: number;
+  /** Idle-flush window in milliseconds — `0` disables debounced flush. */
+  readonly idleMs?: number;
+  /** Disable the `process.beforeExit` auto-flush hook (test-only). */
+  readonly disableBeforeExitHook?: boolean;
+}
+
+/**
+ * In-memory batched writer in front of `skill_usage`.
+ *
+ * Use the module-level singleton via {@link enqueueSkillUsage} /
+ * {@link flushSkillsUsage} in production code. The class is exported so
+ * tests can construct isolated instances pointing at tmp DBs.
+ *
+ * @task T9694
+ */
+export class SkillsUsageQueue {
+  private readonly capacity: number;
+  private readonly idleMs: number;
+  private readonly disableBeforeExitHook: boolean;
+  private buffer: NewSkillUsageRow[] = [];
+  private timer: NodeJS.Timeout | null = null;
+  private beforeExitInstalled = false;
+  private flushing: Promise<void> | null = null;
+
+  constructor(options?: SkillsUsageQueueOptions) {
+    this.capacity = options?.capacity ?? SKILLS_USAGE_QUEUE_DEFAULT_CAPACITY;
+    this.idleMs = options?.idleMs ?? SKILLS_USAGE_QUEUE_DEFAULT_IDLE_MS;
+    this.disableBeforeExitHook = options?.disableBeforeExitHook ?? false;
+  }
+
+  /**
+   * Append a row. Triggers an immediate flush if capacity is reached,
+   * otherwise (re-)arms the idle-flush timer.
+   *
+   * @param row - Telemetry payload to persist.
+   */
+  enqueue(row: NewSkillUsageRow): void {
+    this.installBeforeExitHookOnce();
+    this.buffer.push(row);
+
+    if (this.buffer.length >= this.capacity) {
+      // Synchronous capacity-trigger — fire-and-forget the flush.
+      void this.flush().catch(() => {
+        /* swallowed — best-effort, matches recorder contract */
+      });
+      return;
+    }
+
+    // (Re-)arm the idle-flush debounce.
+    if (this.idleMs > 0) {
+      if (this.timer) clearTimeout(this.timer);
+      this.timer = setTimeout(() => {
+        this.timer = null;
+        void this.flush().catch(() => {
+          /* swallowed */
+        });
+      }, this.idleMs);
+      // Don't keep the event loop alive purely for telemetry.
+      if (typeof this.timer.unref === 'function') this.timer.unref();
+    }
+  }
+
+  /**
+   * Flush all buffered rows in a single batched INSERT.
+   *
+   * Safe to call concurrently — overlapping callers share the same in-flight
+   * promise so the batch is written exactly once.
+   *
+   * @returns Resolves when the buffered rows are persisted (or swallowed if
+   *   the DB is unreachable).
+   */
+  async flush(): Promise<void> {
+    if (this.flushing) return this.flushing;
+    if (this.buffer.length === 0) return;
+
+    // Snapshot + clear so concurrent enqueues land in the next batch.
+    const batch = this.buffer;
+    this.buffer = [];
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+
+    this.flushing = (async () => {
+      try {
+        const db = await openSkillsDb();
+        // Drizzle accepts an array of rows for batched insert.
+        db.insert(skillUsageTable).values(batch).run();
+      } catch {
+        // Swallow — best-effort. We INTENTIONALLY do not requeue the batch
+        // because skill-load telemetry is sampling-grade, not auditing-grade.
+      }
+    })();
+
+    try {
+      await this.flushing;
+    } finally {
+      this.flushing = null;
+    }
+  }
+
+  /**
+   * Synchronously discard buffered rows without writing — test-only seam.
+   *
+   * Production code MUST NOT call this. Used by tests that want to assert
+   * "no DB row until flush" without polluting the next test's state.
+   */
+  drain(): NewSkillUsageRow[] {
+    const snapshot = this.buffer;
+    this.buffer = [];
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    return snapshot;
+  }
+
+  /** Returns the current buffer length — visible for assertions. */
+  get size(): number {
+    return this.buffer.length;
+  }
+
+  // -------------------------------------------------------------------------
+  // process.beforeExit installer (idempotent)
+  // -------------------------------------------------------------------------
+
+  private installBeforeExitHookOnce(): void {
+    if (this.beforeExitInstalled) return;
+    if (this.disableBeforeExitHook) return;
+    this.beforeExitInstalled = true;
+    process.once('beforeExit', () => {
+      // Best-effort — the event loop is winding down so we await directly.
+      void this.flush().catch(() => {
+        /* swallowed */
+      });
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton
+// ---------------------------------------------------------------------------
+
+let _singleton: SkillsUsageQueue | null = null;
+
+/**
+ * Return the process-wide singleton queue, creating it on first use.
+ *
+ * Tests that need isolated state should construct their own {@link SkillsUsageQueue}
+ * with `disableBeforeExitHook: true` to avoid leaking listeners across cases.
+ */
+export function getSkillsUsageQueue(): SkillsUsageQueue {
+  if (!_singleton) {
+    _singleton = new SkillsUsageQueue();
+  }
+  return _singleton;
+}
+
+/**
+ * Replace the module-level singleton — used by tests to inject an isolated
+ * queue (pointed at a tmp DB) WITHOUT touching the user-global one.
+ *
+ * Pass `null` to reset back to lazy default-construction on next call.
+ *
+ * @internal
+ */
+export function __setSkillsUsageQueueSingleton(q: SkillsUsageQueue | null): void {
+  _singleton = q;
+}
+
+/**
+ * Enqueue a single usage row via the singleton queue.
+ *
+ * @param row - Telemetry payload.
+ *
+ * @task T9694
+ */
+export function enqueueSkillUsage(row: NewSkillUsageRow): void {
+  getSkillsUsageQueue().enqueue(row);
+}
+
+/**
+ * Flush the singleton queue. Returns when the in-flight batch is persisted.
+ *
+ * @task T9694
+ */
+export async function flushSkillsUsage(): Promise<void> {
+  await getSkillsUsageQueue().flush();
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports for downstream typing
+// ---------------------------------------------------------------------------
+
+export type { NewSkillUsageRow, SkillUsageRow };

--- a/packages/core/src/tools/__tests__/skills-prune.test.ts
+++ b/packages/core/src/tools/__tests__/skills-prune.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for `toolsSkillPruneTelemetry` — Sphere B retention engine op.
+ *
+ * Seeds a tmp `skills.db` with mixed-age usage rows, then asserts:
+ *   - rows older than the cutoff are deleted (real run)
+ *   - dry-run returns the projected count without writes
+ *   - `--vacuum` runs successfully (file size at most equal post-delete)
+ *   - `oldestRemaining` / `newestRemaining` snapshots are correct
+ *
+ * @task T9693
+ * @epic T9561
+ * @saga T9560
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('toolsSkillPruneTelemetry (T9693)', () => {
+  let tmpRoot: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-t9693-'));
+    dbPath = join(tmpRoot, 'skills.db');
+    const mod = await import('../../store/skills-db.js');
+    mod.resetSkillsDbState();
+    await mod.openSkillsDb({ path: dbPath });
+  });
+
+  afterEach(async () => {
+    const mod = await import('../../store/skills-db.js');
+    mod.closeSkillsDb();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function seedUsage(): Promise<void> {
+    const { upsertSkillRow } = await import('../../store/skills-db.js');
+    const { insertUsage } = await import('../../store/skills-store.js');
+    const { withProvenance } = await import('../../sentient/skill-provenance.js');
+    await withProvenance('pr-generator', () =>
+      upsertSkillRow({
+        name: 'pruneable',
+        sourceType: 'canonical',
+        installPath: '/tmp/pruneable',
+        installedAt: new Date().toISOString(),
+        lifecycleState: 'active',
+      }),
+    );
+
+    const now = Date.now();
+    // 5 rows: 365d old, 200d old, 100d old, 30d old, now.
+    const ages = [365, 200, 100, 30, 0];
+    for (const days of ages) {
+      const ts = new Date(now - days * 86_400_000).toISOString();
+      await insertUsage({
+        skillName: 'pruneable',
+        eventKind: 'load',
+        observedAt: ts,
+      });
+    }
+  }
+
+  it('deletes rows older than --older-than DAYS (default 180)', async () => {
+    await seedUsage();
+    const { toolsSkillPruneTelemetry } = await import('../engine-ops.js');
+    const result = await toolsSkillPruneTelemetry({ olderThanDays: 180 });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    // 365d + 200d are older than 180 → deleted (2 rows).
+    expect(result.data.deletedRows).toBe(2);
+    expect(result.data.dryRun).toBe(false);
+    expect(result.data.vacuumed).toBe(false);
+  });
+
+  it('honors custom olderThanDays threshold', async () => {
+    await seedUsage();
+    const { toolsSkillPruneTelemetry } = await import('../engine-ops.js');
+    const result = await toolsSkillPruneTelemetry({ olderThanDays: 50 });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    // 365d + 200d + 100d are older than 50 → 3 rows deleted.
+    expect(result.data.deletedRows).toBe(3);
+  });
+
+  it('dry-run returns projected count without writes', async () => {
+    await seedUsage();
+    const { toolsSkillPruneTelemetry } = await import('../engine-ops.js');
+    const result = await toolsSkillPruneTelemetry({ olderThanDays: 180, dryRun: true });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    expect(result.data.deletedRows).toBe(2);
+    expect(result.data.dryRun).toBe(true);
+    expect(result.data.dbSizeAfter).toBe(result.data.dbSizeBefore);
+    // Verify the actual rows are still there.
+    const { openSkillsDb } = await import('../../store/skills-db.js');
+    const { skillUsage } = await import('../../store/skills-schema.js');
+    const db = await openSkillsDb({ path: dbPath });
+    const rows = db.select().from(skillUsage).all();
+    expect(rows.length).toBe(5);
+  });
+
+  it('--vacuum runs after the delete', async () => {
+    await seedUsage();
+    const { toolsSkillPruneTelemetry } = await import('../engine-ops.js');
+    const result = await toolsSkillPruneTelemetry({ olderThanDays: 180, vacuum: true });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    expect(result.data.vacuumed).toBe(true);
+  });
+
+  it('reports oldestRemaining and newestRemaining bounds', async () => {
+    await seedUsage();
+    const { toolsSkillPruneTelemetry } = await import('../engine-ops.js');
+    const result = await toolsSkillPruneTelemetry({ olderThanDays: 180 });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    expect(result.data.oldestRemaining).not.toBeNull();
+    expect(result.data.newestRemaining).not.toBeNull();
+    // Oldest remaining must be more recent than the deleted 200d row.
+    const oldestMs = new Date(result.data.oldestRemaining ?? 0).getTime();
+    expect(Date.now() - oldestMs).toBeLessThan(181 * 86_400_000);
+  });
+
+  it('rejects negative olderThanDays', async () => {
+    const { toolsSkillPruneTelemetry } = await import('../engine-ops.js');
+    const result = await toolsSkillPruneTelemetry({ olderThanDays: -1 });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected failure');
+    expect(result.error.code).toBe('E_INVALID_INPUT');
+  });
+});

--- a/packages/core/src/tools/__tests__/skills-stats.test.ts
+++ b/packages/core/src/tools/__tests__/skills-stats.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration tests for `toolsSkillStats` — Sphere B telemetry rollup engine op.
+ *
+ * Seeds a tmp `skills.db` with mixed rows + usage events, then asserts the
+ * stats engine op returns the expected facets.
+ *
+ * @task T9690
+ * @epic T9561
+ * @saga T9560
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { NewSkillRow } from '../../store/skills-schema.js';
+
+describe('toolsSkillStats (T9690)', () => {
+  let tmpRoot: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-t9690-'));
+    dbPath = join(tmpRoot, 'skills.db');
+    const mod = await import('../../store/skills-db.js');
+    mod.resetSkillsDbState();
+    await mod.openSkillsDb({ path: dbPath });
+  });
+
+  afterEach(async () => {
+    const mod = await import('../../store/skills-db.js');
+    mod.closeSkillsDb();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function seed(): Promise<void> {
+    const { upsertSkillRow } = await import('../../store/skills-db.js');
+    const { insertUsage } = await import('../../store/skills-store.js');
+    const { withProvenance } = await import('../../sentient/skill-provenance.js');
+
+    const make = (
+      name: string,
+      sourceType: NewSkillRow['sourceType'],
+      lifecycleState: NewSkillRow['lifecycleState'],
+      isAgentCreated = false,
+    ): NewSkillRow => ({
+      name,
+      version: '1.0.0',
+      sourceType,
+      installPath: `/tmp/skills/${name}`,
+      installedAt: new Date().toISOString(),
+      lifecycleState,
+      isAgentCreated,
+    });
+
+    await withProvenance('pr-generator', () =>
+      upsertSkillRow(make('alpha', 'canonical', 'active')),
+    );
+    await upsertSkillRow(make('beta', 'user', 'active'));
+    await upsertSkillRow(make('gamma', 'agent-created', 'active', true));
+    await upsertSkillRow(make('delta', 'community', 'stale'));
+
+    await insertUsage({ skillName: 'alpha', eventKind: 'load' });
+    await insertUsage({ skillName: 'alpha', eventKind: 'invoke' });
+    await insertUsage({ skillName: 'alpha', eventKind: 'load' });
+    await insertUsage({ skillName: 'beta', eventKind: 'load' });
+  }
+
+  it('returns the top-N usage rollup only by default', async () => {
+    await seed();
+    const { toolsSkillStats } = await import('../engine-ops.js');
+    const result = await toolsSkillStats({ top: 5 });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    expect(result.data.top[0]).toEqual({ skillName: 'alpha', count: 3 });
+    expect(result.data.top[1]).toEqual({ skillName: 'beta', count: 1 });
+    expect(result.data.bySource).toBeNull();
+    expect(result.data.byLifecycle).toBeNull();
+    expect(result.data.agentCreated).toBeNull();
+  });
+
+  it('includes source-type breakdown when bySource=true', async () => {
+    await seed();
+    const { toolsSkillStats } = await import('../engine-ops.js');
+    const result = await toolsSkillStats({ top: 5, bySource: true });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    const counts = Object.fromEntries(result.data.bySource!.map((r) => [r.sourceType, r.count]));
+    expect(counts.canonical).toBe(1);
+    expect(counts.user).toBe(1);
+    expect(counts['agent-created']).toBe(1);
+    expect(counts.community).toBe(1);
+  });
+
+  it('includes lifecycle breakdown when byLifecycle=true', async () => {
+    await seed();
+    const { toolsSkillStats } = await import('../engine-ops.js');
+    const result = await toolsSkillStats({ top: 5, byLifecycle: true });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    const counts = Object.fromEntries(result.data.byLifecycle!.map((r) => [r.state, r.count]));
+    expect(counts.active).toBe(3);
+    expect(counts.stale).toBe(1);
+  });
+
+  it('lists agent-created skills when agentCreated=true', async () => {
+    await seed();
+    const { toolsSkillStats } = await import('../engine-ops.js');
+    const result = await toolsSkillStats({ top: 5, agentCreated: true });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    expect(result.data.agentCreated?.length).toBe(1);
+    expect(result.data.agentCreated?.[0]?.name).toBe('gamma');
+    expect(result.data.agentCreated?.[0]?.lifecycleState).toBe('active');
+  });
+
+  it('honors top=N limit', async () => {
+    await seed();
+    const { toolsSkillStats } = await import('../engine-ops.js');
+    const result = await toolsSkillStats({ top: 1 });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    expect(result.data.top.length).toBe(1);
+    expect(result.data.top[0]?.skillName).toBe('alpha');
+  });
+
+  it('returns sinceDays passthrough on the response envelope', async () => {
+    await seed();
+    const { toolsSkillStats } = await import('../engine-ops.js');
+    const result = await toolsSkillStats({ top: 5, sinceDays: 30 });
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data) throw new Error('expected success');
+    expect(result.data.sinceDays).toBe(30);
+  });
+});

--- a/packages/core/src/tools/engine-ops.ts
+++ b/packages/core/src/tools/engine-ops.ts
@@ -35,7 +35,12 @@ import {
   removeSkill,
   type SkillRowData,
 } from '@cleocode/caamp';
-import type { SkillStatsRequest, SkillStatsResponse } from '@cleocode/contracts';
+import type {
+  SkillImportHermesRequest,
+  SkillImportHermesResponse,
+  SkillStatsRequest,
+  SkillStatsResponse,
+} from '@cleocode/contracts';
 import { AdapterManager } from '../adapters/index.js';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { type HookEvent, isProviderHookEvent } from '../hooks/types.js';
@@ -398,6 +403,32 @@ export async function toolsSkillStats(
       agentCreated,
       sinceDays: request?.sinceDays ?? null,
     });
+  } catch (error) {
+    return engineError('E_INTERNAL', error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * Migrate Hermes `~/.hermes/skills/.usage.json` sidecars into CLEO `skills.db`.
+ *
+ * @remarks
+ * Thin wrapper over {@link importFromHermes} so the dispatch layer can route
+ * `tools.skill.import-hermes` without importing the skills domain module
+ * directly. The full provenance + counter-synthesis logic lives in
+ * `packages/core/src/skills/hermes-importer.ts`.
+ *
+ * @param request - Import flags (Hermes home override, dry-run mode).
+ * @returns Engine result carrying per-skill outcomes + summary counters.
+ *
+ * @task T9691
+ */
+export async function toolsSkillImportHermes(
+  request: SkillImportHermesRequest = {},
+): Promise<EngineResult<SkillImportHermesResponse>> {
+  try {
+    const { importFromHermes } = await import('../skills/hermes-importer.js');
+    const response = await importFromHermes(request);
+    return engineSuccess(response);
   } catch (error) {
     return engineError('E_INTERNAL', error instanceof Error ? error.message : String(error));
   }

--- a/packages/core/src/tools/engine-ops.ts
+++ b/packages/core/src/tools/engine-ops.ts
@@ -38,6 +38,8 @@ import {
 import type {
   SkillImportHermesRequest,
   SkillImportHermesResponse,
+  SkillPruneTelemetryRequest,
+  SkillPruneTelemetryResponse,
   SkillStatsRequest,
   SkillStatsResponse,
 } from '@cleocode/contracts';
@@ -429,6 +431,114 @@ export async function toolsSkillImportHermes(
     const { importFromHermes } = await import('../skills/hermes-importer.js');
     const response = await importFromHermes(request);
     return engineSuccess(response);
+  } catch (error) {
+    return engineError('E_INTERNAL', error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * Prune `skill_usage` rows older than the configured window.
+ *
+ * @remarks
+ * Uses {@link pruneUsageOlderThan} from `@cleocode/core/store/skills-store`.
+ * The window defaults to **180 days** (mirrors Hermes `archive_after_days`)
+ * when the request omits `olderThanDays`. Dry-run mode computes the cutoff
+ * and the projected `deletedRows` without mutating the database.
+ *
+ * @param request - Prune flags (window, dry-run, vacuum).
+ * @returns Engine result with before/after counters and file-size deltas.
+ *
+ * @task T9693
+ */
+export async function toolsSkillPruneTelemetry(
+  request: SkillPruneTelemetryRequest = {},
+): Promise<EngineResult<SkillPruneTelemetryResponse>> {
+  try {
+    const { statSync } = await import('node:fs');
+    const { getOpenSkillsDbPath, getSkillsNativeDb, openSkillsDb } = await import(
+      '../store/skills-db.js'
+    );
+    const { pruneUsageOlderThan } = await import('../store/skills-store.js');
+    const { skillUsage } = await import('../store/skills-schema.js');
+    const { lt, sql } = await import('drizzle-orm');
+
+    const olderThanDays = request.olderThanDays ?? 180;
+    if (!Number.isFinite(olderThanDays) || olderThanDays < 0) {
+      return engineError('E_INVALID_INPUT', `olderThanDays must be a non-negative number`);
+    }
+    const cutoff = new Date(Date.now() - olderThanDays * 86_400_000);
+    const cutoffIso = cutoff.toISOString();
+    const dryRun = request.dryRun === true;
+    const wantVacuum = request.vacuum === true;
+
+    // Ensure DB is open + resolve the path the singleton actually points at.
+    await openSkillsDb();
+    const dbPath = getOpenSkillsDbPath() ?? '';
+    const safeSize = (path: string): number => {
+      try {
+        return statSync(path).size;
+      } catch {
+        return 0;
+      }
+    };
+    const dbSizeBefore = safeSize(dbPath);
+
+    if (dryRun) {
+      // Count rows that would be deleted without touching them.
+      const dbHandle = await openSkillsDb();
+      const rows = dbHandle
+        .select({ c: sql<number>`COUNT(*)`.as('c') })
+        .from(skillUsage)
+        .where(lt(skillUsage.observedAt, cutoffIso))
+        .all();
+      const projected = Number(rows[0]?.c ?? 0);
+      const bounds = dbHandle
+        .select({
+          oldest: sql<string | null>`MIN(${skillUsage.observedAt})`.as('oldest'),
+          newest: sql<string | null>`MAX(${skillUsage.observedAt})`.as('newest'),
+        })
+        .from(skillUsage)
+        .all();
+      return engineSuccess({
+        deletedRows: projected,
+        olderThanDays,
+        cutoffIso,
+        dryRun: true,
+        vacuumed: false,
+        dbSizeBefore,
+        dbSizeAfter: dbSizeBefore,
+        oldestRemaining: bounds[0]?.oldest ?? null,
+        newestRemaining: bounds[0]?.newest ?? null,
+      });
+    }
+
+    const result = await pruneUsageOlderThan(cutoffIso);
+
+    let vacuumed = false;
+    if (wantVacuum) {
+      const nativeDb = getSkillsNativeDb();
+      if (nativeDb?.isOpen) {
+        try {
+          nativeDb.exec('VACUUM;');
+          vacuumed = true;
+        } catch {
+          // VACUUM may fail inside an open WAL transaction — surface but don't fail.
+          vacuumed = false;
+        }
+      }
+    }
+
+    return engineSuccess({
+      deletedRows: result.deletedRows,
+      olderThanDays,
+      cutoffIso,
+      dryRun: false,
+      vacuumed,
+      dbSizeBefore,
+      dbSizeAfter: safeSize(dbPath),
+      oldestRemaining: result.oldestRemaining,
+      newestRemaining: result.newestRemaining,
+    });
   } catch (error) {
     return engineError('E_INTERNAL', error instanceof Error ? error.message : String(error));
   }

--- a/packages/core/src/tools/engine-ops.ts
+++ b/packages/core/src/tools/engine-ops.ts
@@ -35,6 +35,7 @@ import {
   removeSkill,
   type SkillRowData,
 } from '@cleocode/caamp';
+import type { SkillStatsRequest, SkillStatsResponse } from '@cleocode/contracts';
 import { AdapterManager } from '../adapters/index.js';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { type HookEvent, isProviderHookEvent } from '../hooks/types.js';
@@ -342,6 +343,61 @@ export async function toolsSkillDoctorDiagnose(options?: { verbose?: boolean }):
     const report = await diagnoseSkillStore();
     const rendered = renderDoctorDiagnoseReport(report, options?.verbose ?? false);
     return engineSuccess({ report, rendered, healthy: report.healthy });
+  } catch (error) {
+    return engineError('E_INTERNAL', error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * Run the Sphere B telemetry rollup powering `cleo skills stats`.
+ *
+ * Always returns the top-N rollup (`top`). The `bySource`, `byLifecycle`,
+ * and `agentCreated` facets are populated only when the corresponding flag
+ * is `true` — `null` otherwise so callers can distinguish "not requested"
+ * from "zero rows".
+ *
+ * @param request - Faceting flags from {@link SkillStatsRequest}.
+ *
+ * @task T9690
+ */
+export async function toolsSkillStats(
+  request?: SkillStatsRequest,
+): Promise<EngineResult<SkillStatsResponse>> {
+  try {
+    const { countByLifecycle, countBySourceType, getTopUsed, listAgentCreated } = await import(
+      '../store/skills-store.js'
+    );
+
+    const topLimit = request?.top ?? 10;
+    const top = await getTopUsed(topLimit);
+
+    const bySource = request?.bySource
+      ? (await countBySourceType()).map((r) => ({
+          sourceType: r.sourceType,
+          count: r.count,
+        }))
+      : null;
+
+    const byLifecycle = request?.byLifecycle
+      ? (await countByLifecycle()).map((r) => ({ state: r.state, count: r.count }))
+      : null;
+
+    const agentCreated = request?.agentCreated
+      ? (await listAgentCreated()).map((r) => ({
+          name: r.name,
+          version: r.version,
+          installedAt: r.installedAt,
+          lifecycleState: r.lifecycleState,
+        }))
+      : null;
+
+    return engineSuccess({
+      top: top.map((r) => ({ skillName: r.skillName, count: r.count })),
+      bySource,
+      byLifecycle,
+      agentCreated,
+      sinceDays: request?.sinceDays ?? null,
+    });
   } catch (error) {
     return engineError('E_INTERNAL', error instanceof Error ? error.message : String(error));
   }


### PR DESCRIPTION
## Summary

Ships the remaining 5 children of T9561 (E-SKILLS-TELEMETRY) under saga
SG-CLEO-SKILLS. Builds on T9688 (PR #332 — skills-store typed adapter).

- **T9689** — skill-load telemetry hook via fire-and-forget recorder
  instrumenting `discoverSkill()` in
  `packages/core/src/skills/discovery.ts`. New
  `packages/core/src/skills/usage-recorder.ts`.
- **T9694** — in-memory batching queue
  (`packages/core/src/store/skills-usage-queue.ts`) in front of the
  recorder. 256-entry ring buffer, 250ms idle debounce, capacity +
  beforeExit auto-flush. Skill-load hot path now does only
  `JSON.stringify` + `array.push`, no DB I/O.
- **T9690** — `cleo skills stats` CLI: top-N usage, source-type /
  lifecycle breakdowns, agent-created list. New contracts at
  `packages/contracts/src/skills/stats.ts`.
- **T9691** — `cleo skills import-hermes` CLI: reads
  `~/.hermes/skills/.usage.json` + `.bundled_manifest`, maps
  provenance (`agent → agent-created`, `bundled → canonical`,
  `else → user`), synthesizes per-counter `skill_usage` rows. New
  `packages/core/src/skills/hermes-importer.ts`.
- **T9693** — `cleo skills prune-telemetry --older-than DAYS`:
  retention sweep with optional `--vacuum`. Default 180d mirrors
  Hermes `archive_after_days`.

## Architecture

All new contracts live in `packages/contracts/src/skills/` (leaf zero-
runtime-dep package). All SDK code lives in `packages/core/src/`. CLI
keeps thin dispatch only in `packages/cleo/src/cli/commands/skills.ts`.
Three new dispatch operations registered (`skill.stats`,
`skill.import.hermes`, `skill.prune.telemetry`) with full registry +
capability-matrix entries and supported-operation list updates.

## Test plan

- [x] `pnpm --filter @cleocode/core run test src/skills/__tests__/usage-recorder.test.ts src/skills/__tests__/hermes-importer.test.ts src/store/__tests__/skills-usage-queue.test.ts src/store/__tests__/skills-store.test.ts src/tools/__tests__/skills-stats.test.ts src/tools/__tests__/skills-prune.test.ts` → **39 tests pass**
- [x] `pnpm --filter @cleocode/contracts run build` → green
- [x] `pnpm --filter @cleocode/core run build` → green
- [x] `pnpm --filter @cleocode/core run typecheck` → green
- [x] `pnpm --filter @cleocode/cleo run typecheck` → green
- [x] `pnpm biome check --write` on all touched files
- [ ] Smoke-test `cleo skills stats` / `import-hermes` / `prune-telemetry` post-merge once T9688 (#332) lands

T9561 — E-SKILLS-TELEMETRY (SG-CLEO-SKILLS Sphere B).