### PR TITLE
release: v2026.5.85 — SG-CLEO-SKILLS Sphere B close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,92 @@
 # Changelog
 
+## [2026.5.85] (2026-05-20) — SG-CLEO-SKILLS Sphere B close (T9560)
+
+Sphere B close of the SG-CLEO-SKILLS saga (T9560). Bundles the Sphere B
+foundations (typed skills.db adapter, curator config schema, write-origin
+AsyncLocalStorage, skill-review prompt builder, federation index storage),
+the four impl epics (E-SKILLS-TELEMETRY, E-SKILLS-CURATOR,
+E-SKILLS-AUTO-IMPROVE, E-SKILLS-FEDERATION-SECURITY), plus Sphere A
+follow-ups (T9652 diagnose, T9567 depth backfill, T9572 owner-CI, T9657
+adopt-orphans) and unrelated infra (T9686-C provenance backfill, T9627
+docs slugs/types, T9639 docs import, T9633 docs publish, T9634 docs
+git round-trip).
+
+### Added (T9560 Sphere B W0 foundations)
+
+- **PR #332 (T9683, T9688, T9705, T9706, T9729)** — 5 Sphere B
+  foundations: typed Drizzle adapter for `skills.db`, curator daemon
+  config schema with cross-field validation, `AsyncLocalStorage`
+  write-origin tracker for skills, skill-review prompt builder (Hermes
+  `run_agent.py:3981` port), federation index storage + `cleo
+  federation` CLI.
+
+### Added (T9561 telemetry — PR #337)
+
+- **T9689** — skill-load telemetry hook via fire-and-forget recorder.
+- **T9690** — `cleo skills stats` CLI + telemetry rollup engine op.
+- **T9691** — `cleo skills import-hermes` — Hermes sidecar migration.
+- **T9693** — `cleo skills prune-telemetry` — `skill_usage` retention sweep.
+- **T9694** — in-memory batching queue for skill-usage telemetry writes.
+
+### Added (T9562 curator — PR #334)
+
+- **T9677** — curator state machine — triple guard, archive-only
+  transitions.
+- **T9682, T9683** — wire curator tick into sentient daemon + config
+  defaults.
+- **T9685, T9686** — `cleo curator run` / `status` CLI.
+- **T9687** — `cleo skill restore <name>` CLI.
+
+### Added (T9563 auto-improve — PR #335)
+
+- **T9707** — background-review fork wired to skill-provenance frame.
+- **T9708** — canonical-row write-guard via skill-provenance ALS.
+- **T9714** — `cleo skills propose-patch` PR-cut for canonical skills.
+- **T9715** — local patch applier for Sphere B skills.
+- **T9727** — `cleo sentient review-status` group — auto-improve
+  dispatch.
+
+### Added (T9564 federation — PR #338)
+
+- **T9730** — skills-guard 120-pattern TS port + trust gate.
+- **T9731** — `cleo skills find --federated` multi-source query.
+- **T9732** — federation install gate — first-install prompt + sha256
+  checksum.
+- **T9733** — `hermes-import` classifier + ADR-075 trust-ladder.
+- **T9734** — `hermes-to-cleo` migration + skills federation guides.
+
+### Added (Sphere A follow-ups)
+
+- **PR #319 (T9652)** — `cleo skills doctor diagnose` read-only health
+  report.
+- **PR #322 (T9567)** — E-SKILLS-DEPTH-BACKFILL (9 tasks): 8
+  `references/` skills backfills for `ct-research-agent`,
+  `ct-spec-writer`, `ct-task-executor`, `ct-validator`, `ct-documentor`,
+  `ct-docs-lookup`, `ct-docs-write`, `ct-docs-review`, plus the
+  progressive-disclosure-depth CI gate (T9684).
+- **PR #331 (T9572)** — E-SKILLS-OWNER-CI (7 tasks) — operator privacy
+  doc + owner-CI pipeline for skills.
+- **PR #315 (T9657)** — `cleo skills doctor adopt-orphans` —
+  interactive orphan audit.
+
+### Added (docs infrastructure)
+
+- **PR #336 (T9627)** — docs slugs + types + project listing: T9636
+  `--slug` flag + collision detection + `E_SLUG_TAKEN` suggestions,
+  T9637 `--type` taxonomy + `docs list --type` filter, T9638 `docs
+  list --project` for project-scoped listing.
+- **PR #333 (T9639)** — `cleo docs import` — 5 subtasks for legacy
+  `.md` migration: T9710 recursive `.md` scanner with type classifier,
+  T9712 slug generator with collision suffix, T9711 SHA-based dedup
+  gate, T9713 `--dry-run` mode + audit manifest writer, T9709 counter
+  integrity check + `cleo docs import` wiring.
+
+### Fixed
+
+- **PR #325 (T9686-C)** — provenance backfill: tag enumeration,
+  `--since` empty handling, FK order.
+
 ## [2026.5.84] (2026-05-19) — SG-CLEO-SKILLS Sphere A close (T9560)
 
 Sphere A close of the SG-CLEO-SKILLS saga (T9560). Bundles the canonical

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "conduit-core",
  "nom",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "cant-core",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "serde",
  "serde_json",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "cant-core",
  "serde",
@@ -394,7 +394,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-llm-native"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "lafs-core",
  "serde",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-core"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "chrono",
  "conduit-core",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-payments"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-protocol"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "cant-core",
  "chrono",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-sdk"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-storage"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-transport"
-version = "2026.5.84"
+version = "2026.5.85"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.84"
+version = "2026.5.85"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.84",
+  "version": "2026.5.85",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Ship release **v2026.5.85** — Sphere B close of the SG-CLEO-SKILLS saga (T9560).

This release bundles the four Sphere B implementation epics, the W0 Sphere B foundations, plus Sphere A follow-ups that landed after v2026.5.84, plus unrelated docs/infra work.

### Sphere B (T9560)
- **W0 foundations (PR #332)** — T9683, T9688, T9705, T9706, T9729
- **T9561 telemetry (PR #337)** — T9689, T9690, T9691, T9693, T9694
- **T9562 curator (PR #334)** — T9677, T9682, T9685, T9686, T9687
- **T9563 auto-improve (PR #335)** — T9707, T9708, T9714, T9715, T9727
- **T9564 federation (PR #338)** — T9730, T9731, T9732, T9733, T9734

### Sphere A follow-ups
- **PR #319 (T9652)** — `cleo skills doctor diagnose`
- **PR #322 (T9567)** — E-SKILLS-DEPTH-BACKFILL (9 tasks)
- **PR #331 (T9572)** — E-SKILLS-OWNER-CI (7 tasks)
- **PR #315 (T9657)** — `cleo skills doctor adopt-orphans`

### Unrelated infra
- **PR #325 (T9686-C)** — provenance backfill fixes
- **PR #333 (T9639)** — `cleo docs import` (5 subtasks)
- **PR #336 (T9627)** — docs slugs/types/project listing

### Mechanical changes
- 21 npm `package.json` versions bumped 2026.5.84 → 2026.5.85
- Cargo `workspace.package.version` bumped 2026.5.84 → 2026.5.85
- `Cargo.lock` regenerated via `cargo update --workspace` (17 workspace crates)
- CHANGELOG.md entry added grouped by Added/Fixed with PR refs

## Test plan

- [ ] CI green (build + typecheck + test + biome + lockfile-check + contracts-dep-lint)
- [ ] Owner squash-merges to main
- [ ] Owner tags `v2026.5.85` from main; trusted-publisher OIDC fires npm publish
- [ ] `cleo --version` reflects 2026.5.85 after global install

🤖 Generated with [Claude Code](https://claude.com/claude-code)