### PR TITLE
docs(T9640): validate cleo docs import against full cleocode repo + migration guide

### DIFF
--- a/docs/migration/legacy-to-docs.md
+++ b/docs/migration/legacy-to-docs.md
@@ -1,0 +1,159 @@
+# Migrating Legacy `.cleo/` Markdown to the Docs SSoT
+
+CLEO projects accumulate hundreds (sometimes thousands) of free-floating
+markdown files under `.cleo/research/`, `.cleo/adrs/`, and
+`.cleo/agent-outputs/` over their lifetime. Until Saga T9625 these files
+were only addressable by filesystem path — they could not be fetched by
+slug, searched semantically, or linked to tasks.
+
+`cleo docs import` (Epic T9628) walks one of these legacy trees and
+streams every `.md` it finds into the docs SSoT (`.cleo/blobs/`). The
+import is content-addressed and idempotent: re-running on the same
+corpus rewrites the manifest entries but never duplicates blob bytes.
+
+> **TL;DR**: `cleo docs import .cleo --json --audit-manifest .cleo/docs-import.json`
+
+## What gets migrated
+
+The scanner walks the directory you point it at and classifies each
+markdown file by its source-dir prefix:
+
+| Source-dir prefix                       | CLI import type | `DocKind` written              |
+|-----------------------------------------|-----------------|--------------------------------|
+| `.cleo/adrs/*.md`                       | `adr`           | `adr` (manifest.db)            |
+| `.cleo/research/*.md`                   | `research`      | `agent-output` (manifest.db)   |
+| `.cleo/agent-outputs/*.md`              | `note`          | `agent-output` (manifest.db)   |
+| `docs/specs/*.md` and `docs/**/*.md`    | `spec`          | `agent-output` (manifest.db)   |
+| anything else                           | `note`          | `agent-output` (manifest.db)   |
+
+The CLI-level `importType` is preserved on `meta.importType` so future
+queries can recover the original classification without rescanning.
+
+Each imported blob is keyed by SHA-256 of its UTF-8 bytes. The original
+file at its legacy path is **not modified** — the migration is purely
+additive. See the deprecation policy below.
+
+## Running a migration
+
+```bash
+# Dry-run first to preview what would be imported. Writes no blobs and
+# no audit manifest. Counters still report scan/import/noop/error split.
+cleo docs import .cleo --dry-run --json
+
+# Real import. Writes blobs to .cleo/blobs/blobs/<sha> and an audit
+# manifest to <project-root>/docs-import-<ts>.json by default. Override
+# the manifest path with --audit-manifest.
+cleo docs import .cleo --json --audit-manifest .cleo/docs-import.json
+```
+
+For a fresh clone with no existing docs SSoT, this is the only command
+you need — `cleo` provisions `.cleo/blobs/manifest.db` on first write.
+
+### Useful flags
+
+- `--dry-run` — preview only, never write
+- `--force` — bypass SHA-dedup. Logged to
+  `.cleo/audit/import-force-bypass.jsonl` for traceability
+- `--audit-manifest <path>` — override the audit-manifest output path
+- `--json` — emit the LAFS JSON envelope (default for agent callers)
+
+## Counter-integrity invariant (T9709)
+
+Every import enforces:
+
+```
+scanCount === importCount + noopCount + errorCount
+```
+
+If the sum diverges from the scan count the CLI exits non-zero with
+`E_COUNTER_MISMATCH` and the audit manifest is not written. This catches
+silent skips (e.g. a `continue` that forgets to bump a counter) before
+they corrupt downstream provenance work.
+
+## Validation against the cleocode repo
+
+The migration was validated end-to-end against this repo on 2026-05-19:
+
+| Metric                          | Value      |
+|---------------------------------|------------|
+| `find ... -name '*.md'` count   | 1272       |
+| `scanCount`                     | 1272       |
+| `importCount`                   | 1268       |
+| `noopCount`                     | 2          |
+| `errorCount`                    | 2          |
+| Counter-integrity sum           | 1272 (✓)   |
+| 10-file round-trip byte-equality| 10/10 PASS |
+
+The four non-imports break down as:
+
+- **Two `noop` rows** — both files happened to have the same SHA-256 as
+  an earlier file in the same scan (the in-run dedup set catches this).
+- **Two `error` rows** — both files are named `import.md` and the slug
+  generator refuses to emit reserved slugs (`import`, `export`, etc.) to
+  avoid colliding with reserved subcommands once the SSoT is exposed
+  over CLI.
+
+All four cases are legitimate; rerunning with `--force` is not
+recommended because it would mint blob duplicates without resolving the
+underlying slug conflict.
+
+## Deprecation policy for legacy files
+
+The import is **additive**. After running it the pre-existing markdown
+files remain in place under `.cleo/research/`, `.cleo/adrs/`, and
+`.cleo/agent-outputs/`. We deliberately do not rewrite, move, or delete
+them because:
+
+1. Many of those files are referenced by hard-coded paths in older agent
+   outputs and ADR cross-links. Renaming them would break the
+   historical record.
+2. The docs SSoT can serve them by slug or SHA-256 once imported, so
+   nothing is *gained* by deleting the originals.
+3. Audit and forensics workflows benefit from the original filesystem
+   layout staying intact.
+
+If you want to encourage callers to migrate to slug-based fetch, add a
+short frontmatter banner to the legacy files:
+
+```markdown
+> **Deprecated path** — fetch via `cleo docs fetch <slug-or-sha>` instead.
+```
+
+The banner is **not** rewritten automatically by `cleo docs import`;
+adding it is a one-time editorial choice per project. The CLI's
+deprecation policy is "leave bytes alone, audit the import".
+
+## CI smoke test
+
+A minimal smoke script lives at `scripts/docs-import-smoke.mjs`. It
+copies a tiny corpus into a tmp project root, runs the import, and
+asserts the counter-integrity invariant. Run it ad-hoc with:
+
+```bash
+node scripts/docs-import-smoke.mjs
+```
+
+## Troubleshooting
+
+- **`E_COUNTER_MISMATCH`** — the scanner found more files than the
+  counters add up to. Re-run with `--dry-run` and inspect
+  `entries[].action` to find the missing classifications. File an issue
+  with the audit manifest attached.
+- **`slug "<x>" is reserved`** — the file's name collides with the
+  slug-generator's reserved list (e.g. `import`, `export`). Rename the
+  source file or accept the `error` row.
+- **High `noopCount` on first run** — multiple source files genuinely
+  contain identical bytes. Confirm with `sha256sum` on the source paths;
+  the dedup is by content, not by name.
+- **`docs fetch` returns `E_NOT_FOUND`** — the `cleo docs fetch`
+  subcommand currently reads from the legacy attachment store, not the
+  new docs SSoT. Round-trip verification today goes through the
+  content-addressed blob at `.cleo/blobs/blobs/<sha>`. Full read-side
+  parity is tracked under the T9064 follow-up.
+
+## See also
+
+- `packages/core/src/docs/import/` — implementation (scanner, slug,
+  dedup, audit, orchestrator).
+- ADR-068 — DB Charter (manifest.db write-ownership table).
+- Saga T9625 — full migration roll-up.

--- a/scripts/docs-import-smoke.mjs
+++ b/scripts/docs-import-smoke.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * scripts/docs-import-smoke.mjs
+ *
+ * CI smoke test for `cleo docs import` (T9640 / Saga T9625 / Epic T9628).
+ *
+ * Builds a tiny synthetic markdown corpus inside a tmp project root,
+ * invokes the import via the built CLI, and asserts:
+ *
+ *   1. The command exits 0.
+ *   2. Counter-integrity holds: scanCount === importCount + noopCount + errorCount.
+ *   3. scanCount matches the local find -name '*.md' count.
+ *   4. Every `created` row's blob exists at .cleo/blobs/blobs/<sha> AND
+ *      sha256(blob) === manifest entry sha === sha256(source file).
+ *
+ * Designed to run in CI without network. Cleans its tmp root on exit.
+ *
+ * Usage:
+ *   node scripts/docs-import-smoke.mjs
+ *
+ * Exit codes:
+ *   0 — all assertions pass
+ *   1 — any assertion fails
+ *
+ * @task T9640
+ * @epic T9628 (Saga T9625)
+ */
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..');
+const cliEntry = resolve(repoRoot, 'packages/cleo/dist/cli/index.js');
+
+let exitCode = 0;
+const fail = (msg) => {
+  console.error(`FAIL ${msg}`);
+  exitCode = 1;
+};
+const pass = (msg) => console.log(`PASS ${msg}`);
+
+const sandbox = mkdtempSync(join(tmpdir(), 'cleo-docs-import-smoke-'));
+const projectRoot = join(sandbox, 'project');
+mkdirSync(join(projectRoot, '.cleo/adrs'), { recursive: true });
+mkdirSync(join(projectRoot, '.cleo/research'), { recursive: true });
+mkdirSync(join(projectRoot, '.cleo/agent-outputs/nested'), { recursive: true });
+mkdirSync(join(projectRoot, 'docs/specs'), { recursive: true });
+
+const fixtures = [
+  { path: '.cleo/adrs/ADR-001-example.md', body: '# ADR 001\n\nExample architectural decision.\n' },
+  { path: '.cleo/adrs/ADR-002-other.md', body: '# ADR 002\n\nAnother decision.\n' },
+  {
+    path: '.cleo/research/study-a.md',
+    body: '# Research A\n\nFindings on a topic that informs ADR-001.\n',
+  },
+  {
+    path: '.cleo/agent-outputs/T0001-handoff.md',
+    body: '# Handoff for T0001\n\nNotes from agent.\n',
+  },
+  {
+    path: '.cleo/agent-outputs/nested/inner-note.md',
+    body: '# Inner note\n\nNested agent-output to exercise the walker.\n',
+  },
+  { path: 'docs/specs/SPEC-LAYOUT.md', body: '# Spec layout\n\nA spec.\n' },
+];
+
+const findCount = fixtures.length;
+for (const { path, body } of fixtures) {
+  writeFileSync(join(projectRoot, path), body, 'utf-8');
+}
+
+const manifestPath = join(projectRoot, 'docs-import-smoke.json');
+const result = spawnSync(
+  process.execPath,
+  [cliEntry, 'docs', 'import', projectRoot, '--json', '--audit-manifest', manifestPath],
+  {
+    encoding: 'utf-8',
+    env: { ...process.env, CLEO_PROJECT_ROOT: projectRoot, NO_COLOR: '1' },
+    maxBuffer: 64 * 1024 * 1024,
+  },
+);
+
+try {
+  if (result.status !== 0) {
+    fail(
+      `cleo docs import exited ${result.status}. stderr:\n${result.stderr}\nstdout (head):\n${(result.stdout ?? '').slice(0, 800)}`,
+    );
+    throw new Error('import failed');
+  }
+  pass('cleo docs import exited 0');
+
+  const envelopeMatch = (result.stdout ?? '').match(/\{"success":true[\s\S]*\}/);
+  if (!envelopeMatch) {
+    fail('could not locate LAFS JSON envelope in stdout');
+    throw new Error('no envelope');
+  }
+  const envelope = JSON.parse(envelopeMatch[0]);
+  const { counters, entries } = envelope.data;
+  if (!counters) {
+    fail('envelope missing counters');
+    throw new Error('no counters');
+  }
+
+  const sum = counters.importCount + counters.noopCount + counters.errorCount;
+  if (sum !== counters.scanCount) {
+    fail(
+      `counter-integrity broken: importCount(${counters.importCount}) + noopCount(${counters.noopCount}) + errorCount(${counters.errorCount}) = ${sum} != scanCount(${counters.scanCount})`,
+    );
+  } else {
+    pass(`counter-integrity holds (${sum} === ${counters.scanCount})`);
+  }
+
+  // Locally count .md files to cross-check the scanner.
+  const localCount = await countMarkdownFiles(projectRoot);
+  if (localCount !== counters.scanCount) {
+    fail(`find-count(${localCount}) !== scanCount(${counters.scanCount})`);
+  } else {
+    pass(`scanCount(${counters.scanCount}) matches local find -name '*.md' count (${localCount})`);
+  }
+
+  if (localCount !== findCount) {
+    fail(`unexpected local-count ${localCount} (expected ${findCount}) — fixture corruption?`);
+  } else {
+    pass(`fixture corpus count matches expected (${findCount})`);
+  }
+
+  // Round-trip: for every `created` entry, blob must exist and bytes must match source.
+  const blobsDir = join(projectRoot, '.cleo/blobs/blobs');
+  let rtPass = 0;
+  let rtFail = 0;
+  for (const entry of entries) {
+    if (entry.action !== 'created') continue;
+    const blobPath = join(blobsDir, entry.sha);
+    let blobBytes;
+    try {
+      blobBytes = readFileSync(blobPath);
+    } catch (err) {
+      fail(`blob missing on disk for ${entry.file}: ${blobPath} (${err.message})`);
+      rtFail++;
+      continue;
+    }
+    const blobSha = createHash('sha256').update(blobBytes).digest('hex');
+    const sourceBytes = readFileSync(join(projectRoot, entry.file));
+    const sourceSha = createHash('sha256').update(sourceBytes).digest('hex');
+    if (blobSha === entry.sha && sourceSha === entry.sha) {
+      rtPass++;
+    } else {
+      fail(
+        `round-trip mismatch for ${entry.file}: source=${sourceSha} blob=${blobSha} manifest=${entry.sha}`,
+      );
+      rtFail++;
+    }
+  }
+  if (rtFail === 0 && rtPass > 0) {
+    pass(`round-trip byte-equality verified for ${rtPass}/${rtPass} created blobs`);
+  }
+} finally {
+  rmSync(sandbox, { recursive: true, force: true });
+}
+
+if (exitCode === 0) {
+  console.log('\nOK: docs-import smoke passed.');
+}
+process.exit(exitCode);
+
+/**
+ * @param {string} root
+ */
+async function countMarkdownFiles(root) {
+  let count = 0;
+  /** @param {string} dir */
+  async function walk(dir) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const abs = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (['node_modules', '.git', 'dist', 'coverage', 'build', '_archived'].includes(entry.name))
+          continue;
+        await walk(abs);
+        continue;
+      }
+      if (entry.isFile() && entry.name.endsWith('.md')) count++;
+    }
+  }
+  await walk(root);
+  void relative; // touch the import so future maintainers see it's intentional
+  return count;
+}


### PR DESCRIPTION
## Summary

Closes Task T9640 (W1 closeout for Epic T9628 / Saga T9625). Validates the T9639 `cleo docs import` command works on the full cleocode markdown corpus and ships the migration guide.

## Validation results

Sandboxed real-copy of `/mnt/projects/cleocode/.cleo/{research,adrs,agent-outputs}` into a tmp project root, then invoked the built CLI:

| Metric                                | Value      |
|---------------------------------------|------------|
| `find ... -name '*.md'` (source)      | 1272       |
| Sandbox `.md` count                   | 1272       |
| `scanCount`                           | 1272       |
| `importCount`                         | 1268       |
| `noopCount`                           | 2          |
| `errorCount`                          | 2          |
| Counter-integrity sum                 | 1272 (PASS)|
| 10-file random sample round-trip      | 10/10 PASS |

Error rows (legitimate, reserved-slug):
- `.cleo/agent-outputs/T-POMODORO-BENCH-2026-04-16/gsd/.claude/commands/gsd/import.md`
- `.cleo/agent-outputs/T-POMODORO-BENCH-2026-04-16/gsd/.claude/get-shit-done/workflows/import.md`

Noop rows (legitimate, in-run SHA dedup):
- `.cleo/agent-outputs/NEXT-SESSION-HANDOFF.md`
- `.cleo/agent-outputs/T-POMODORO-BENCH-2026-04-16/cleo/GEMINI.md`

Round-trip byte-equality verified by hashing source file, the `.cleo/blobs/blobs/<sha>` blob, and the manifest entry's `sha` — all three matched for every sampled file.

## Migration doc

`docs/migration/legacy-to-docs.md` covers:
- Source-dir classification rules (`.cleo/adrs/` → `adr`, etc.)
- How to run the import (dry-run + real)
- Counter-integrity invariant (`E_COUNTER_MISMATCH`)
- Deprecation policy (additive — leave legacy `.md` in place)
- Troubleshooting (reserved slugs, noop semantics, `docs fetch` separation)

## Smoke test

`scripts/docs-import-smoke.mjs` — self-contained CI script:

```bash
node scripts/docs-import-smoke.mjs
# PASS cleo docs import exited 0
# PASS counter-integrity holds (6 === 6)
# PASS scanCount(6) matches local find -name '*.md' count (6)
# PASS fixture corpus count matches expected (6)
# PASS round-trip byte-equality verified for 6/6 created blobs
```

Builds a 6-file synthetic corpus in a tmp project root, runs the import, and asserts exit-code 0 + counter-integrity + scan-count parity + per-blob round-trip. Cleans up on exit.

## Acceptance gates

- [x] Full import completes without error (exit 0)
- [x] Imported count + noops + errors == scan count == find count (1268 + 2 + 2 = 1272)
- [x] 10-file random sample round-trip byte-identical
- [x] Migration documented at `docs/migration/legacy-to-docs.md`
- [x] Deprecation policy documented (additive — files stay in place)

## Quality gates

- `pnpm biome ci .` → exit 0 (2 pre-existing warnings in `packages/core/src/skills/hermes-import-classifier.ts`, not touched by this PR)
- `pnpm run build` → success (built locally before validation)

## Notes on idempotency

The current implementation's `DocsAccessor.listDocs()` reads from an in-memory `blobIndex` Map that isn't rehydrated from `manifest.db` on a fresh process. As a result, a second `cleo docs import` against the same dir reports the same `importCount=1268` rather than `noopCount=1268`. The underlying `CleoBlobStore.attach` is content-addressed (no byte duplication), but counter accounting treats them as new imports. This does not violate any T9640 AC — first-run validation, counter integrity, and round-trip equality all hold. Full read-side parity is the T9064 follow-up.

Refs: T9640, Epic T9628, Saga T9625