### PR TITLE
feat(T9646): cleo docs serve local viewer (T9723/T9720/T9722/T9721)

### DIFF
--- a/packages/cleo/assets/viewer/index.html
+++ b/packages/cleo/assets/viewer/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CLEO Docs Viewer</title>
+  <link rel="stylesheet" href="/viewer/styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <h1>CLEO Docs</h1>
+    <input id="filter" type="search" placeholder="Filter by slug, title, type..." autocomplete="off" />
+  </header>
+  <main class="layout">
+    <aside id="sidebar">
+      <div id="doc-list" aria-live="polite">Loading docs...</div>
+    </aside>
+    <section id="content">
+      <article id="doc-render">
+        <p class="hint">Select a document from the sidebar, or open a direct link like <code>/docs/&lt;slug&gt;</code>.</p>
+      </article>
+    </section>
+  </main>
+  <script src="/viewer/viewer.js" type="module"></script>
+</body>
+</html>

--- a/packages/cleo/assets/viewer/styles.css
+++ b/packages/cleo/assets/viewer/styles.css
@@ -1,0 +1,132 @@
+:root {
+  --bg: #0f1115;
+  --surface: #161a22;
+  --surface-2: #1f2632;
+  --border: #2a3140;
+  --text: #d6dbe3;
+  --text-muted: #8a93a3;
+  --accent: #6aa7ff;
+  --accent-hover: #88baff;
+  --code-bg: #0b0d12;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  height: 100%;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+}
+
+#filter {
+  flex: 1;
+  max-width: 480px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 0.45rem 0.75rem;
+  border-radius: 6px;
+  font: inherit;
+}
+
+#filter:focus { outline: 2px solid var(--accent); outline-offset: 0; }
+
+.layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: calc(100vh - 56px);
+}
+
+#sidebar {
+  border-right: 1px solid var(--border);
+  background: var(--surface);
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  max-height: calc(100vh - 56px);
+  position: sticky;
+  top: 56px;
+}
+
+#doc-list a {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: var(--text);
+  text-decoration: none;
+  border-left: 3px solid transparent;
+  font-size: 0.9rem;
+  line-height: 1.3;
+}
+
+#doc-list a small {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  margin-top: 2px;
+}
+
+#doc-list a:hover { background: var(--surface-2); }
+#doc-list a.active {
+  background: var(--surface-2);
+  border-left-color: var(--accent);
+}
+
+#content { padding: 2rem 2.5rem; max-width: 60rem; }
+
+#doc-render { line-height: 1.55; }
+#doc-render h1 { border-bottom: 1px solid var(--border); padding-bottom: 0.35rem; }
+#doc-render h1, #doc-render h2, #doc-render h3 { color: #fff; }
+#doc-render a { color: var(--accent); }
+#doc-render a:hover { color: var(--accent-hover); }
+#doc-render code {
+  background: var(--code-bg);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.9em;
+}
+#doc-render pre {
+  background: var(--code-bg);
+  padding: 0.85rem 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+}
+#doc-render pre code { background: transparent; padding: 0; }
+#doc-render blockquote {
+  margin: 0;
+  padding: 0.4rem 1rem;
+  border-left: 3px solid var(--accent);
+  color: var(--text-muted);
+  background: var(--surface);
+}
+#doc-render table { border-collapse: collapse; margin: 1rem 0; }
+#doc-render th, #doc-render td {
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.75rem;
+}
+#doc-render th { background: var(--surface-2); }
+
+.hint { color: var(--text-muted); }
+.error { color: #ff7f7f; }

--- a/packages/cleo/assets/viewer/viewer.js
+++ b/packages/cleo/assets/viewer/viewer.js
@@ -1,0 +1,300 @@
+// CLEO Docs Viewer SPA — minimal, zero-dep client for /api/docs + /api/docs/:slug.
+// Renders markdown via a tiny inline renderer (sufficient for headings, code,
+// lists, links, blockquotes, inline-code, bold, italic, tables, hr). For
+// anything richer we recommend wiring a real markdown lib later.
+
+const $list = document.getElementById('doc-list');
+const $render = document.getElementById('doc-render');
+const $filter = document.getElementById('filter');
+
+const state = {
+  docs: [],
+  activeSlug: null,
+};
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Tiny markdown -> HTML renderer. Not CommonMark-complete; covers the basics.
+function renderMarkdown(md) {
+  if (typeof md !== 'string') return '';
+  const lines = md.split('\n');
+  const out = [];
+  let inCode = false;
+  let codeBuf = [];
+  let codeLang = '';
+  let listType = null;
+  let listBuf = [];
+  let paraBuf = [];
+  let inTable = false;
+  let tableBuf = [];
+
+  const flushPara = () => {
+    if (paraBuf.length === 0) return;
+    out.push('<p>' + inlineMd(paraBuf.join(' ')) + '</p>');
+    paraBuf = [];
+  };
+  const flushList = () => {
+    if (listType === null || listBuf.length === 0) return;
+    const tag = listType === 'ol' ? 'ol' : 'ul';
+    out.push(`<${tag}>` + listBuf.map((i) => `<li>${inlineMd(i)}</li>`).join('') + `</${tag}>`);
+    listBuf = [];
+    listType = null;
+  };
+  const flushTable = () => {
+    if (!inTable || tableBuf.length === 0) return;
+    const rows = tableBuf.map((r) =>
+      r
+        .replace(/^\||\|$/g, '')
+        .split('|')
+        .map((c) => c.trim()),
+    );
+    const head = rows[0];
+    const body = rows.slice(2);
+    let html = '<table><thead><tr>';
+    for (const c of head) html += `<th>${inlineMd(c)}</th>`;
+    html += '</tr></thead><tbody>';
+    for (const row of body) {
+      html += '<tr>';
+      for (const c of row) html += `<td>${inlineMd(c)}</td>`;
+      html += '</tr>';
+    }
+    html += '</tbody></table>';
+    out.push(html);
+    tableBuf = [];
+    inTable = false;
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const fence = line.match(/^```(\w*)\s*$/);
+    if (fence) {
+      flushPara();
+      flushList();
+      flushTable();
+      if (inCode) {
+        out.push(
+          `<pre><code class="lang-${escapeHtml(codeLang)}">` +
+            escapeHtml(codeBuf.join('\n')) +
+            '</code></pre>',
+        );
+        codeBuf = [];
+        codeLang = '';
+        inCode = false;
+      } else {
+        inCode = true;
+        codeLang = fence[1] || '';
+      }
+      continue;
+    }
+    if (inCode) {
+      codeBuf.push(line);
+      continue;
+    }
+
+    // Blank line → flush block buffers
+    if (/^\s*$/.test(line)) {
+      flushPara();
+      flushList();
+      flushTable();
+      continue;
+    }
+
+    // Tables (very basic — | a | b | with separator row)
+    if (/^\s*\|.*\|\s*$/.test(line)) {
+      if (!inTable) {
+        flushPara();
+        flushList();
+        inTable = true;
+      }
+      tableBuf.push(line.trim());
+      continue;
+    } else if (inTable) {
+      flushTable();
+    }
+
+    // Headings
+    const h = line.match(/^(#{1,6})\s+(.*)$/);
+    if (h) {
+      flushPara();
+      flushList();
+      const level = h[1].length;
+      out.push(`<h${level}>${inlineMd(h[2])}</h${level}>`);
+      continue;
+    }
+
+    // HR
+    if (/^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/.test(line)) {
+      flushPara();
+      flushList();
+      out.push('<hr/>');
+      continue;
+    }
+
+    // Blockquote
+    const bq = line.match(/^>\s?(.*)$/);
+    if (bq) {
+      flushPara();
+      flushList();
+      out.push(`<blockquote>${inlineMd(bq[1])}</blockquote>`);
+      continue;
+    }
+
+    // Ordered / unordered list items
+    const ol = line.match(/^\s*(\d+)\.\s+(.*)$/);
+    const ul = line.match(/^\s*[-*+]\s+(.*)$/);
+    if (ol) {
+      flushPara();
+      if (listType !== 'ol') flushList();
+      listType = 'ol';
+      listBuf.push(ol[2]);
+      continue;
+    }
+    if (ul) {
+      flushPara();
+      if (listType !== 'ul') flushList();
+      listType = 'ul';
+      listBuf.push(ul[1]);
+      continue;
+    }
+
+    // Default — accumulate paragraph
+    flushList();
+    paraBuf.push(line);
+  }
+
+  if (inCode) {
+    out.push('<pre><code>' + escapeHtml(codeBuf.join('\n')) + '</code></pre>');
+  }
+  flushPara();
+  flushList();
+  flushTable();
+
+  return out.join('\n');
+}
+
+// Inline markdown — code spans, bold, italic, links.
+function inlineMd(s) {
+  let str = escapeHtml(s);
+  // Inline code
+  str = str.replace(/`([^`]+)`/g, (_, c) => `<code>${c}</code>`);
+  // Bold + italic combined
+  str = str.replace(/\*\*\*([^*]+)\*\*\*/g, '<strong><em>$1</em></strong>');
+  // Bold
+  str = str.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  // Italic
+  str = str.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '<em>$1</em>');
+  // Links [text](href)
+  str = str.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, href) => {
+    const safe = String(href).replace(/"/g, '%22');
+    return `<a href="${safe}" target="_blank" rel="noopener">${text}</a>`;
+  });
+  return str;
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url, { headers: { Accept: 'application/json' } });
+  const body = await res.json().catch(() => null);
+  if (!res.ok || !body) {
+    const code = body?.error?.code ?? 'E_HTTP';
+    const msg = body?.error?.message ?? res.statusText;
+    throw new Error(`${code}: ${msg}`);
+  }
+  if (body && body.success === false) {
+    throw new Error(`${body.error?.code ?? 'E_UNKNOWN'}: ${body.error?.message ?? 'unknown'}`);
+  }
+  return body.data;
+}
+
+function renderDocList(docs) {
+  if (docs.length === 0) {
+    $list.innerHTML = '<p class="hint">No published docs in this project. Run <code>cleo docs publish</code> first.</p>';
+    return;
+  }
+  const html = docs
+    .map((d) => {
+      const slug = escapeHtml(d.slug || d.id);
+      const title = escapeHtml(d.title || d.slug || d.id);
+      const type = d.type ? `<small>${escapeHtml(d.type)}</small>` : '';
+      const isActive = d.slug === state.activeSlug ? ' class="active"' : '';
+      return `<a href="/docs/${slug}" data-slug="${slug}"${isActive}>${title}${type}</a>`;
+    })
+    .join('');
+  $list.innerHTML = html;
+  $list.querySelectorAll('a').forEach((a) => {
+    a.addEventListener('click', (e) => {
+      e.preventDefault();
+      const slug = a.getAttribute('data-slug');
+      navigate(slug);
+    });
+  });
+}
+
+function applyFilter(q) {
+  const lower = q.toLowerCase().trim();
+  if (!lower) return renderDocList(state.docs);
+  const filtered = state.docs.filter((d) => {
+    return (
+      (d.slug || '').toLowerCase().includes(lower) ||
+      (d.title || '').toLowerCase().includes(lower) ||
+      (d.type || '').toLowerCase().includes(lower)
+    );
+  });
+  renderDocList(filtered);
+}
+
+async function loadDoc(slug) {
+  if (!slug) {
+    $render.innerHTML = '<p class="hint">Select a document from the sidebar.</p>';
+    return;
+  }
+  state.activeSlug = slug;
+  $render.innerHTML = '<p class="hint">Loading...</p>';
+  try {
+    const data = await fetchJson(`/api/docs/${encodeURIComponent(slug)}`);
+    const md = data.content ?? '';
+    $render.innerHTML = renderMarkdown(md);
+    document.title = `${data.title || slug} — CLEO Docs`;
+    // Highlight active in sidebar
+    $list.querySelectorAll('a').forEach((a) => {
+      a.classList.toggle('active', a.getAttribute('data-slug') === slug);
+    });
+  } catch (err) {
+    $render.innerHTML = `<p class="error">${escapeHtml(String(err.message || err))}</p>`;
+  }
+}
+
+function navigate(slug) {
+  history.pushState({ slug }, '', `/docs/${slug}`);
+  loadDoc(slug);
+}
+
+window.addEventListener('popstate', (e) => {
+  const slug = e.state?.slug || slugFromPath(location.pathname);
+  if (slug) loadDoc(slug);
+});
+
+function slugFromPath(pathname) {
+  const m = pathname.match(/^\/docs\/([^/?#]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+$filter.addEventListener('input', (e) => applyFilter(e.target.value));
+
+(async function init() {
+  try {
+    const data = await fetchJson('/api/docs');
+    state.docs = data.docs || [];
+    renderDocList(state.docs);
+    const initialSlug = slugFromPath(location.pathname);
+    if (initialSlug) loadDoc(initialSlug);
+  } catch (err) {
+    $list.innerHTML = `<p class="error">${escapeHtml(String(err.message || err))}</p>`;
+  }
+})();

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -70,7 +70,8 @@
     "completions",
     "bin",
     "scripts",
-    "templates"
+    "templates",
+    "assets"
   ],
   "devDependencies": {
     "@types/node-cron": "^3.0.11",

--- a/packages/cleo/src/cli/__tests__/docs-viewer.test.ts
+++ b/packages/cleo/src/cli/__tests__/docs-viewer.test.ts
@@ -12,10 +12,12 @@
  */
 
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { type AddressInfo, createServer, type Server } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createAttachmentStore } from '@cleocode/core/internal';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { tryListen } from '../../viewer/port-allocator.js';
 import { startViewer } from '../../viewer/server.js';
 
 let tmpProjectRoot: string;
@@ -227,6 +229,77 @@ describe('T9720 + T9723 — round-trip: published doc is reachable by slug', () 
       expect(oneRes.body?.data?.mime).toBe('text/markdown');
     } finally {
       handle.server.close();
+    }
+  });
+});
+
+describe('T9722 — graceful port allocation', () => {
+  let blockingServer: Server;
+  let blockedPort: number;
+
+  beforeEach(async () => {
+    blockingServer = createServer();
+    await new Promise<void>((res) => blockingServer.listen(0, '127.0.0.1', res));
+    blockedPort = (blockingServer.address() as AddressInfo).port;
+  });
+
+  afterEach(() => {
+    blockingServer.close();
+  });
+
+  it('auto-increments past a busy port', async () => {
+    const handle = await tryListen(() => {}, {
+      startPort: blockedPort,
+      endPort: blockedPort + 20,
+      host: '127.0.0.1',
+      autoIncrement: true,
+    });
+    try {
+      expect(handle.port).toBeGreaterThan(blockedPort);
+      expect(handle.port).toBeLessThanOrEqual(blockedPort + 20);
+    } finally {
+      handle.server.close();
+    }
+  });
+
+  it('throws EADDRINUSE when --no-auto-port is set and start port is busy', async () => {
+    await expect(
+      tryListen(() => {}, {
+        startPort: blockedPort,
+        endPort: blockedPort,
+        host: '127.0.0.1',
+        autoIncrement: false,
+      }),
+    ).rejects.toMatchObject({ code: 'EADDRINUSE' });
+  });
+
+  it('throws E_NO_PORT when the whole range is busy', async () => {
+    // Block a contiguous range of N ports, then attempt to bind across that
+    // same range — every attempt should EADDRINUSE → E_NO_PORT.
+    const blockers: Server[] = [];
+    const ports: number[] = [];
+    try {
+      for (let i = 0; i < 4; i++) {
+        const s = createServer();
+        await new Promise<void>((res) => s.listen(0, '127.0.0.1', res));
+        blockers.push(s);
+        ports.push((s.address() as AddressInfo).port);
+      }
+      const min = Math.min(...ports);
+      const max = Math.max(...ports);
+      const contiguous = max - min + 1 === ports.length;
+      const startPort = min;
+      const endPort = contiguous ? max : min;
+      await expect(
+        tryListen(() => {}, {
+          startPort,
+          endPort,
+          host: '127.0.0.1',
+          autoIncrement: true,
+        }),
+      ).rejects.toMatchObject({ code: 'E_NO_PORT' });
+    } finally {
+      for (const s of blockers) s.close();
     }
   });
 });

--- a/packages/cleo/src/cli/__tests__/docs-viewer.test.ts
+++ b/packages/cleo/src/cli/__tests__/docs-viewer.test.ts
@@ -11,12 +11,18 @@
  * @epic T9631
  */
 
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { type AddressInfo, createServer, type Server } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createAttachmentStore } from '@cleocode/core/internal';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  isProcessAlive,
+  readViewerPidFile,
+  removeViewerPidFile,
+  writeViewerPidFile,
+} from '../../viewer/pidfile.js';
 import { tryListen } from '../../viewer/port-allocator.js';
 import { startViewer } from '../../viewer/server.js';
 
@@ -319,5 +325,46 @@ describe('T9723 — viewer SPA assets are bundled', () => {
     } finally {
       handle.server.close();
     }
+  });
+});
+
+describe('T9721 — pidfile lifecycle', () => {
+  it('writeViewerPidFile + readViewerPidFile roundtrip', async () => {
+    await removeViewerPidFile();
+    const record = {
+      pid: 99999, // implausibly large pid that won't collide with real procs
+      port: 7777,
+      host: '127.0.0.1',
+      projectRoot: tmpProjectRoot,
+      startedAt: Date.now(),
+    };
+    const path = await writeViewerPidFile(record);
+    expect(path).toContain('viewer.pid');
+    const read = await readViewerPidFile();
+    expect(read).toEqual(record);
+    await removeViewerPidFile();
+    expect(await readViewerPidFile()).toBeNull();
+  });
+
+  it('readViewerPidFile returns null on malformed JSON', async () => {
+    await removeViewerPidFile();
+    const path = `${process.env.CLEO_HOME}/viewer.pid`;
+    const cleoHome = process.env.CLEO_HOME;
+    if (!cleoHome) throw new Error('CLEO_HOME unset in test setup');
+    await mkdir(cleoHome, { recursive: true });
+    await writeFile(path, 'not json', 'utf8');
+    const read = await readViewerPidFile();
+    expect(read).toBeNull();
+    await removeViewerPidFile();
+  });
+
+  it('isProcessAlive(process.pid) is true; isProcessAlive(impossible pid) is false', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+    // Pids are 16-bit on POSIX by default, 22-bit on Linux. A pid like
+    // 9_999_999 essentially never exists.
+    expect(isProcessAlive(9_999_999)).toBe(false);
+    expect(isProcessAlive(0)).toBe(false);
+    expect(isProcessAlive(-1)).toBe(false);
+    expect(isProcessAlive(Number.NaN)).toBe(false);
   });
 });

--- a/packages/cleo/src/cli/__tests__/docs-viewer.test.ts
+++ b/packages/cleo/src/cli/__tests__/docs-viewer.test.ts
@@ -1,0 +1,250 @@
+/**
+ * T9646 — `cleo docs serve` local viewer tests (route + bundle coverage).
+ *
+ * Exercises the HTTP server and the bundled SPA in-process (no CLI
+ * subprocess) so the suite runs cheaply in CI. Port-collision and pidfile
+ * tests live in follow-up commits.
+ *
+ * @task T9646
+ * @task T9720 — HTTP server with slug-based routing
+ * @task T9723 — viewer SPA bundle
+ * @epic T9631
+ */
+
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createAttachmentStore } from '@cleocode/core/internal';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { startViewer } from '../../viewer/server.js';
+
+let tmpProjectRoot: string;
+let prevCleoHome: string | undefined;
+let prevCwd: string;
+
+/**
+ * Allocate a temp dir for both:
+ *   1. CLEO_HOME — so pidfile tests don't clobber the dev/user pidfile.
+ *   2. Project root — set as cwd so getProjectRoot() picks it up.
+ */
+beforeEach(async () => {
+  tmpProjectRoot = await mkdtemp(join(tmpdir(), 'cleo-viewer-test-'));
+  prevCleoHome = process.env.CLEO_HOME;
+  process.env.CLEO_HOME = join(tmpProjectRoot, 'cleo-home');
+  prevCwd = process.cwd();
+  // getProjectRoot() requires a `.cleo` dir with a SIBLING `.git` dir.
+  await mkdir(join(tmpProjectRoot, '.cleo'), { recursive: true });
+  await mkdir(join(tmpProjectRoot, '.git'), { recursive: true });
+  process.chdir(tmpProjectRoot);
+});
+
+afterEach(async () => {
+  process.chdir(prevCwd);
+  if (prevCleoHome === undefined) delete process.env.CLEO_HOME;
+  else process.env.CLEO_HOME = prevCleoHome;
+  await rm(tmpProjectRoot, { recursive: true, force: true });
+});
+
+/** Fetch `path` from the running viewer and parse as JSON. */
+async function fetchJson(host: string, port: number, path: string) {
+  const res = await fetch(`http://${host}:${port}${path}`, {
+    headers: { Accept: 'application/json' },
+  });
+  const body = await res.json().catch(() => null);
+  return { status: res.status, body, contentType: res.headers.get('content-type') };
+}
+
+/** Fetch `path` and return text + status. */
+async function fetchText(host: string, port: number, path: string) {
+  const res = await fetch(`http://${host}:${port}${path}`, { redirect: 'manual' });
+  const text = await res.text();
+  return { status: res.status, text, location: res.headers.get('location') };
+}
+
+describe('T9720 — HTTP server with slug-based routing', () => {
+  it('serves the SPA index.html from /viewer/index.html and redirects /', async () => {
+    const handle = await startViewer({ startPort: 0, endPort: 0, autoIncrement: false });
+    try {
+      const redirect = await fetchText(handle.host, handle.port, '/');
+      expect(redirect.status).toBe(302);
+      expect(redirect.location).toBe('/viewer/index.html');
+
+      const index = await fetchText(handle.host, handle.port, '/viewer/index.html');
+      expect(index.status).toBe(200);
+      expect(index.text).toContain('CLEO Docs');
+      expect(index.text).toContain('/viewer/viewer.js');
+
+      const css = await fetchText(handle.host, handle.port, '/viewer/styles.css');
+      expect(css.status).toBe(200);
+      expect(css.text).toContain('--bg');
+
+      const js = await fetchText(handle.host, handle.port, '/viewer/viewer.js');
+      expect(js.status).toBe(200);
+      expect(js.text).toContain('renderMarkdown');
+    } finally {
+      handle.server.close();
+    }
+  });
+
+  it('/api/health returns a LAFS success envelope', async () => {
+    const handle = await startViewer({ startPort: 0, endPort: 0, autoIncrement: false });
+    try {
+      const { status, body, contentType } = await fetchJson(
+        handle.host,
+        handle.port,
+        '/api/health',
+      );
+      expect(status).toBe(200);
+      expect(contentType).toContain('application/json');
+      expect(body).toEqual({ success: true, data: { status: 'ok' } });
+    } finally {
+      handle.server.close();
+    }
+  });
+
+  it('/api/docs returns LAFS success envelope with empty docs array on a fresh project', async () => {
+    const handle = await startViewer({ startPort: 0, endPort: 0, autoIncrement: false });
+    try {
+      const { status, body } = await fetchJson(handle.host, handle.port, '/api/docs');
+      expect(status).toBe(200);
+      expect(body?.success).toBe(true);
+      expect(body?.data?.docs).toEqual([]);
+    } finally {
+      handle.server.close();
+    }
+  });
+
+  it('/api/docs/:slug returns LAFS error envelope for unknown slug', async () => {
+    const handle = await startViewer({ startPort: 0, endPort: 0, autoIncrement: false });
+    try {
+      const { status, body, contentType } = await fetchJson(
+        handle.host,
+        handle.port,
+        '/api/docs/does-not-exist',
+      );
+      expect(status).toBe(404);
+      expect(contentType).toContain('application/json');
+      expect(body?.success).toBe(false);
+      expect(body?.error?.code).toBe('E_NOT_FOUND');
+      expect(body?.error?.message).toContain('does-not-exist');
+    } finally {
+      handle.server.close();
+    }
+  });
+
+  it('/docs/:slug renders the SPA shell so the client can route by pathname', async () => {
+    const handle = await startViewer({ startPort: 0, endPort: 0, autoIncrement: false });
+    try {
+      const { status, text } = await fetchText(handle.host, handle.port, '/docs/some-slug');
+      expect(status).toBe(200);
+      expect(text).toContain('CLEO Docs');
+      expect(text).toContain('/viewer/viewer.js');
+    } finally {
+      handle.server.close();
+    }
+  });
+
+  it('unknown route returns LAFS error envelope (404 JSON)', async () => {
+    const handle = await startViewer({ startPort: 0, endPort: 0, autoIncrement: false });
+    try {
+      const { status, body, contentType } = await fetchJson(
+        handle.host,
+        handle.port,
+        '/no/such/route',
+      );
+      expect(status).toBe(404);
+      expect(contentType).toContain('application/json');
+      expect(body?.success).toBe(false);
+      expect(body?.error?.code).toBe('E_NOT_FOUND');
+    } finally {
+      handle.server.close();
+    }
+  });
+
+  it('rejects POST /api/docs with E_METHOD_NOT_ALLOWED', async () => {
+    const handle = await startViewer({ startPort: 0, endPort: 0, autoIncrement: false });
+    try {
+      const res = await fetch(`http://${handle.host}:${handle.port}/api/docs`, {
+        method: 'POST',
+        body: '{}',
+      });
+      expect(res.status).toBe(405);
+      const body = (await res.json()) as { success: boolean; error: { code: string } };
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('E_METHOD_NOT_ALLOWED');
+    } finally {
+      handle.server.close();
+    }
+  });
+
+  it('static asset path-traversal is blocked', async () => {
+    const handle = await startViewer({ startPort: 0, endPort: 0, autoIncrement: false });
+    try {
+      const res = await fetch(`http://${handle.host}:${handle.port}/viewer/..%2f..%2fpackage.json`);
+      const body = await res.text();
+      expect(body.includes('"name"') && body.includes('@cleocode/cleo')).toBe(false);
+    } finally {
+      handle.server.close();
+    }
+  });
+});
+
+describe('T9720 + T9723 — round-trip: published doc is reachable by slug', () => {
+  it('puts a markdown blob with a slug, then fetches it via /api/docs + /api/docs/:slug', async () => {
+    const store = createAttachmentStore();
+    const markdown = '# Hello Viewer\n\nThis is a **test** doc.\n\n- item one\n- item two';
+    const buf = Buffer.from(markdown, 'utf8');
+    const slug = 'hello-viewer';
+    await store.put(
+      buf,
+      { kind: 'blob', mime: 'text/markdown' } as Parameters<typeof store.put>[1],
+      'task',
+      'T9646',
+      'docs-viewer-test',
+      tmpProjectRoot,
+      { slug, type: 'note' },
+    );
+
+    const handle = await startViewer({
+      startPort: 0,
+      endPort: 0,
+      autoIncrement: false,
+      projectRoot: tmpProjectRoot,
+    });
+    try {
+      const listRes = await fetchJson(handle.host, handle.port, '/api/docs');
+      expect(listRes.status).toBe(200);
+      const docs = listRes.body?.data?.docs as Array<{ slug: string; title: string }>;
+      expect(docs).toHaveLength(1);
+      expect(docs[0]?.slug).toBe(slug);
+
+      const oneRes = await fetchJson(handle.host, handle.port, `/api/docs/${slug}`);
+      expect(oneRes.status).toBe(200);
+      expect(oneRes.body?.success).toBe(true);
+      expect(oneRes.body?.data?.slug).toBe(slug);
+      expect(oneRes.body?.data?.title).toBe('Hello Viewer');
+      expect(oneRes.body?.data?.content).toBe(markdown);
+      expect(oneRes.body?.data?.mime).toBe('text/markdown');
+    } finally {
+      handle.server.close();
+    }
+  });
+});
+
+describe('T9723 — viewer SPA assets are bundled', () => {
+  it('index.html, viewer.js, styles.css are reachable via the server', async () => {
+    const handle = await startViewer({ startPort: 0, endPort: 0, autoIncrement: false });
+    try {
+      const idx = await fetchText(handle.host, handle.port, '/viewer/index.html');
+      const js = await fetchText(handle.host, handle.port, '/viewer/viewer.js');
+      const css = await fetchText(handle.host, handle.port, '/viewer/styles.css');
+      expect(idx.status).toBe(200);
+      expect(js.status).toBe(200);
+      expect(css.status).toBe(200);
+      expect(js.text).toContain('renderMarkdown');
+      expect(js.text).toContain('/docs/');
+    } finally {
+      handle.server.close();
+    }
+  });
+});

--- a/packages/cleo/src/cli/commands/docs-viewer.ts
+++ b/packages/cleo/src/cli/commands/docs-viewer.ts
@@ -1,0 +1,576 @@
+/**
+ * CLI: `cleo docs serve | open | stop | viewer-status`.
+ *
+ * Wires the {@link startViewer} server + pidfile helpers behind the four
+ * subcommands required by T9646. Subcommands are registered into the existing
+ * `cleo docs` command surface in `commands/docs.ts`.
+ *
+ * @epic T9631
+ * @task T9646 — `cleo docs serve` local viewer
+ * @task T9720 — HTTP server with slug-based routing
+ * @task T9721 — `cleo docs open` + `cleo docs stop` + `cleo docs viewer-status`
+ * @task T9722 — port allocation 7777 → 7800
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process';
+import { open as fsOpen } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ExitCode } from '@cleocode/contracts';
+import { getCleoHome, getProjectRoot } from '@cleocode/core/internal';
+import { defineCommand } from 'citty';
+import {
+  isProcessAlive,
+  readViewerPidFile,
+  removeViewerPidFile,
+  type ViewerPidRecord,
+  viewerPidFilePath,
+  writeViewerPidFile,
+} from '../../viewer/pidfile.js';
+import { startViewer } from '../../viewer/server.js';
+import { cliError, cliOutput, humanInfo } from '../renderers/index.js';
+
+/**
+ * Sentinel env var set on the detached child so the foreground `serve` code
+ * path knows to skip re-detaching and stay in the foreground forever.
+ */
+const DETACHED_CHILD_ENV = 'CLEO_VIEWER_DETACHED_CHILD';
+
+/**
+ * Resolve the path to the `cleo` bin shim that this process was launched
+ * from. Used to re-spawn ourselves as a detached child for `--detach`.
+ */
+function getCleoBinPath(): string {
+  // The compiled CLI lives at packages/cleo/dist/cli/index.js. The bin shim at
+  // packages/cleo/bin/cleo.js wraps it. We re-spawn the dist entry directly
+  // (no need for the wrapper's extra `execFileSync` hop).
+  const thisFile = fileURLToPath(import.meta.url);
+  // dist/cli/commands/docs-viewer.js → ../../cli/index.js
+  return join(thisFile, '..', '..', 'index.js');
+}
+
+/** Wait up to `timeoutMs` for `pid` to exit. Returns true if it exited. */
+async function waitForExit(pid: number, timeoutMs: number, intervalMs = 100): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return !isProcessAlive(pid);
+}
+
+/** Open the system default browser at `url`. Best-effort, never throws. */
+function openInBrowser(url: string): void {
+  try {
+    let cmd: string;
+    let args: string[];
+    if (process.platform === 'darwin') {
+      cmd = 'open';
+      args = [url];
+    } else if (process.platform === 'win32') {
+      cmd = 'cmd';
+      args = ['/c', 'start', '', url];
+    } else {
+      cmd = 'xdg-open';
+      args = [url];
+    }
+    spawn(cmd, args, { detached: true, stdio: 'ignore' }).unref();
+  } catch {
+    /* swallow — caller has already printed the URL */
+  }
+}
+
+/**
+ * Spawn a backgrounded copy of `cleo docs serve` and return the child handle.
+ * The detached child re-enters `serveCommand.run` and (because the env-sentinel
+ * is set) skips the re-detach branch.
+ */
+async function spawnDetachedServer(opts: {
+  startPort: number;
+  endPort: number;
+  host: string;
+  noAutoPort: boolean;
+}): Promise<ChildProcess> {
+  const logFile = join(getCleoHome(), 'viewer.log');
+  const handle = await fsOpen(logFile, 'a').catch(() => null);
+  const stdio: ('ignore' | number)[] = handle
+    ? ['ignore', handle.fd, handle.fd]
+    : ['ignore', 'ignore', 'ignore'];
+
+  const args = [
+    getCleoBinPath(),
+    'docs',
+    'serve',
+    '--port',
+    String(opts.startPort),
+    '--end-port',
+    String(opts.endPort),
+    '--host',
+    opts.host,
+  ];
+  if (opts.noAutoPort) args.push('--no-auto-port');
+
+  const child = spawn(process.execPath, args, {
+    detached: true,
+    stdio,
+    env: { ...process.env, [DETACHED_CHILD_ENV]: '1' },
+    cwd: getProjectRoot(),
+  });
+  child.unref();
+  if (handle) await handle.close();
+  return child;
+}
+
+/**
+ * `cleo docs serve` — start the viewer HTTP server.
+ *
+ * In foreground mode the process blocks until SIGINT/SIGTERM.
+ * In `--detach` mode the parent spawns a detached child, waits for the
+ * child to bind (via health-probe), persists the pidfile, and exits.
+ */
+const serveCommand = defineCommand({
+  meta: {
+    name: 'serve',
+    description: 'Run a local web viewer for published docs',
+  },
+  args: {
+    port: {
+      type: 'string',
+      description: 'Starting port (default 7777)',
+      default: '7777',
+    },
+    'end-port': {
+      type: 'string',
+      description: 'Last port to try when auto-incrementing (default 7800)',
+      default: '7800',
+    },
+    host: {
+      type: 'string',
+      description: 'Bind host (default 127.0.0.1)',
+      default: '127.0.0.1',
+    },
+    'no-auto-port': {
+      type: 'boolean',
+      description: 'Disable auto-increment when start port is busy',
+      default: false,
+    },
+    detach: {
+      type: 'boolean',
+      description: 'Run in background; write pid to viewer.pid; exit immediately',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const startPort = Number.parseInt(String(args.port), 10);
+    const endPort = Number.parseInt(String(args['end-port']), 10);
+    const host = String(args.host);
+    const noAutoPort = Boolean(args['no-auto-port']);
+    const detach = Boolean(args.detach);
+    const isDetachedChild = process.env[DETACHED_CHILD_ENV] === '1';
+
+    if (!Number.isFinite(startPort) || startPort < 1 || startPort > 65535) {
+      cliError(`invalid --port: ${args.port}`, ExitCode.VALIDATION_ERROR, { name: 'E_VALIDATION' });
+      return;
+    }
+    if (!Number.isFinite(endPort) || endPort < startPort) {
+      cliError(`invalid --end-port: ${args['end-port']}`, ExitCode.VALIDATION_ERROR, {
+        name: 'E_VALIDATION',
+      });
+      return;
+    }
+
+    if (detach && !isDetachedChild) {
+      // Parent path: spawn child, wait for health, write pidfile.
+      const existing = await readViewerPidFile();
+      if (existing && isProcessAlive(existing.pid)) {
+        cliOutput(
+          {
+            running: true,
+            pid: existing.pid,
+            port: existing.port,
+            host: existing.host,
+            url: `http://${existing.host}:${existing.port}`,
+            pidFile: viewerPidFilePath(),
+          },
+          {
+            command: 'docs serve',
+            operation: 'docs.serve',
+            message: `viewer already running on http://${existing.host}:${existing.port}`,
+          },
+        );
+        return;
+      }
+
+      const child = await spawnDetachedServer({ startPort, endPort, host, noAutoPort });
+      if (!child.pid) {
+        cliError('failed to spawn detached viewer process', ExitCode.GENERAL_ERROR, {
+          name: 'E_SPAWN_FAILED',
+        });
+        return;
+      }
+
+      // Poll for the child's bound port by reading the pidfile it writes once
+      // it has called listen(). Grace period: 10s.
+      let record: ViewerPidRecord | null = null;
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 150));
+        record = await readViewerPidFile();
+        if (record && record.pid === child.pid) break;
+        if (!isProcessAlive(child.pid)) {
+          cliError(
+            'detached viewer exited before binding (check ~/.local/share/cleo/viewer.log)',
+            ExitCode.GENERAL_ERROR,
+            { name: 'E_VIEWER_EXITED' },
+          );
+          return;
+        }
+      }
+      if (!record || record.pid !== child.pid) {
+        cliError('timed out waiting for detached viewer to bind', ExitCode.GENERAL_ERROR, {
+          name: 'E_VIEWER_TIMEOUT',
+        });
+        return;
+      }
+      cliOutput(
+        {
+          running: true,
+          pid: record.pid,
+          port: record.port,
+          host: record.host,
+          url: `http://${record.host}:${record.port}`,
+          pidFile: viewerPidFilePath(),
+        },
+        {
+          command: 'docs serve',
+          operation: 'docs.serve',
+          message: `viewer started on http://${record.host}:${record.port}`,
+        },
+      );
+      return;
+    }
+
+    // Foreground path: bind, optionally write pidfile (always when detached
+    // child, optional otherwise), block until SIGINT/SIGTERM.
+    let handle: Awaited<ReturnType<typeof startViewer>>;
+    try {
+      handle = await startViewer({
+        startPort,
+        endPort,
+        host,
+        autoIncrement: !noAutoPort,
+      });
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code === 'E_NO_PORT' || e.code === 'EADDRINUSE') {
+        cliError(e.message ?? `port ${startPort} unavailable`, ExitCode.GENERAL_ERROR, {
+          name: e.code === 'E_NO_PORT' ? 'E_NO_PORT' : 'EADDRINUSE',
+        });
+        return;
+      }
+      throw err;
+    }
+
+    const record: ViewerPidRecord = {
+      pid: process.pid,
+      port: handle.port,
+      host: handle.host,
+      projectRoot: getProjectRoot(),
+      startedAt: Date.now(),
+    };
+    await writeViewerPidFile(record);
+
+    const url = `http://${handle.host}:${handle.port}`;
+    if (isDetachedChild) {
+      // Detached child: stay quiet on stdout (parent already printed) — log
+      // file captures the rest. Just keep the loop alive.
+    } else {
+      humanInfo(`viewer listening on ${url} (Ctrl+C to stop)`);
+      cliOutput(
+        {
+          running: true,
+          pid: record.pid,
+          port: record.port,
+          host: record.host,
+          url,
+          pidFile: viewerPidFilePath(),
+        },
+        {
+          command: 'docs serve',
+          operation: 'docs.serve',
+          message: `viewer running on ${url}`,
+        },
+      );
+    }
+
+    const shutdown = async (signal: NodeJS.Signals) => {
+      handle.server.close();
+      await removeViewerPidFile();
+      process.exit(signal === 'SIGINT' ? 130 : 143);
+    };
+    process.on('SIGINT', () => void shutdown('SIGINT'));
+    process.on('SIGTERM', () => void shutdown('SIGTERM'));
+
+    // Foreground mode (incl. detached child) — keep node running. server.close
+    // events resolve the promise below so we still exit cleanly if the kernel
+    // forcibly closes the listener.
+    await new Promise<void>((res) => handle.server.on('close', res));
+    await removeViewerPidFile();
+  },
+});
+
+/**
+ * `cleo docs open <slug>` — open the browser to a doc URL, auto-starting the
+ * viewer in detached mode when no instance is running.
+ */
+const openCommand = defineCommand({
+  meta: {
+    name: 'open',
+    description: 'Open the docs viewer in the browser (auto-starts server if needed)',
+  },
+  args: {
+    slug: {
+      type: 'positional',
+      description: 'Doc slug to open (omit to open the viewer home page)',
+      required: false,
+    },
+    port: {
+      type: 'string',
+      description: 'Starting port for the viewer (default 7777)',
+      default: '7777',
+    },
+    'end-port': {
+      type: 'string',
+      description: 'Last port to try (default 7800)',
+      default: '7800',
+    },
+    host: {
+      type: 'string',
+      description: 'Bind host (default 127.0.0.1)',
+      default: '127.0.0.1',
+    },
+    'no-launch': {
+      type: 'boolean',
+      description: 'Skip browser launch; just print the URL',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const slug = args.slug ? String(args.slug) : undefined;
+    let record = await readViewerPidFile();
+    if (record && !isProcessAlive(record.pid)) {
+      await removeViewerPidFile();
+      record = null;
+    }
+    if (!record) {
+      const startPort = Number.parseInt(String(args.port), 10);
+      const endPort = Number.parseInt(String(args['end-port']), 10);
+      const host = String(args.host);
+      const child = await spawnDetachedServer({
+        startPort,
+        endPort,
+        host,
+        noAutoPort: false,
+      });
+      if (!child.pid) {
+        cliError('failed to spawn detached viewer process', ExitCode.GENERAL_ERROR, {
+          name: 'E_SPAWN_FAILED',
+        });
+        return;
+      }
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 150));
+        record = await readViewerPidFile();
+        if (record && record.pid === child.pid) break;
+        if (!isProcessAlive(child.pid)) {
+          cliError(
+            'detached viewer exited before binding (check ~/.local/share/cleo/viewer.log)',
+            ExitCode.GENERAL_ERROR,
+            { name: 'E_VIEWER_EXITED' },
+          );
+          return;
+        }
+      }
+      if (!record) {
+        cliError('timed out waiting for viewer to bind', ExitCode.GENERAL_ERROR, {
+          name: 'E_VIEWER_TIMEOUT',
+        });
+        return;
+      }
+    }
+
+    const url = slug
+      ? `http://${record.host}:${record.port}/docs/${encodeURIComponent(slug)}`
+      : `http://${record.host}:${record.port}/`;
+
+    if (!args['no-launch']) {
+      openInBrowser(url);
+    }
+
+    cliOutput(
+      {
+        opened: true,
+        slug: slug ?? null,
+        pid: record.pid,
+        port: record.port,
+        host: record.host,
+        url,
+      },
+      {
+        command: 'docs open',
+        operation: 'docs.open',
+        message: `opened ${url}`,
+      },
+    );
+  },
+});
+
+/** `cleo docs stop` — SIGTERM the viewer pid and clean up the pidfile. */
+const stopCommand = defineCommand({
+  meta: {
+    name: 'stop',
+    description: 'Stop the running docs viewer (SIGTERM + cleanup pidfile)',
+  },
+  args: {
+    timeout: {
+      type: 'string',
+      description: 'Grace period in seconds before SIGKILL (default 10)',
+      default: '10',
+    },
+  },
+  async run({ args }) {
+    const record = await readViewerPidFile();
+    if (!record) {
+      cliOutput(
+        { stopped: false, reason: 'no pidfile' },
+        {
+          command: 'docs stop',
+          operation: 'docs.stop',
+          message: 'viewer not running (no pidfile)',
+        },
+      );
+      return;
+    }
+    if (!isProcessAlive(record.pid)) {
+      await removeViewerPidFile();
+      cliOutput(
+        { stopped: false, reason: 'stale pidfile', pid: record.pid },
+        {
+          command: 'docs stop',
+          operation: 'docs.stop',
+          message: `stale pidfile removed (pid ${record.pid} not alive)`,
+        },
+      );
+      return;
+    }
+
+    try {
+      process.kill(record.pid, 'SIGTERM');
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code !== 'ESRCH') {
+        cliError(
+          `failed to signal viewer pid ${record.pid}: ${e.message ?? e.code}`,
+          ExitCode.GENERAL_ERROR,
+          { name: 'E_SIGNAL_FAILED' },
+        );
+        return;
+      }
+    }
+
+    const timeoutSec = Math.max(1, Number.parseInt(String(args.timeout), 10) || 10);
+    const exited = await waitForExit(record.pid, timeoutSec * 1000);
+    if (!exited) {
+      try {
+        process.kill(record.pid, 'SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    }
+    await removeViewerPidFile();
+
+    cliOutput(
+      {
+        stopped: true,
+        pid: record.pid,
+        graceful: exited,
+      },
+      {
+        command: 'docs stop',
+        operation: 'docs.stop',
+        message: exited
+          ? `viewer (pid ${record.pid}) stopped gracefully`
+          : `viewer (pid ${record.pid}) force-killed after ${timeoutSec}s`,
+      },
+    );
+  },
+});
+
+/**
+ * `cleo docs viewer-status` — report whether the viewer is running and its
+ * pid/port/url.
+ */
+const viewerStatusCommand = defineCommand({
+  meta: {
+    name: 'viewer-status',
+    description: 'Report viewer running state (pid, port, url)',
+  },
+  async run() {
+    const record = await readViewerPidFile();
+    if (!record) {
+      cliOutput(
+        { running: false, pidFile: viewerPidFilePath() },
+        {
+          command: 'docs viewer-status',
+          operation: 'docs.viewer-status',
+          message: 'viewer not running',
+        },
+      );
+      return;
+    }
+    const alive = isProcessAlive(record.pid);
+    if (!alive) {
+      await removeViewerPidFile();
+      cliOutput(
+        {
+          running: false,
+          reason: 'stale pidfile',
+          pid: record.pid,
+          pidFile: viewerPidFilePath(),
+        },
+        {
+          command: 'docs viewer-status',
+          operation: 'docs.viewer-status',
+          message: `stale pidfile removed (pid ${record.pid} not alive)`,
+        },
+      );
+      return;
+    }
+    cliOutput(
+      {
+        running: true,
+        pid: record.pid,
+        port: record.port,
+        host: record.host,
+        projectRoot: record.projectRoot,
+        startedAt: record.startedAt,
+        uptimeMs: Date.now() - record.startedAt,
+        url: `http://${record.host}:${record.port}`,
+        pidFile: viewerPidFilePath(),
+      },
+      {
+        command: 'docs viewer-status',
+        operation: 'docs.viewer-status',
+        message: `viewer running (pid ${record.pid})`,
+      },
+    );
+  },
+});
+
+export const docsViewerSubcommands = {
+  serve: serveCommand,
+  open: openCommand,
+  stop: stopCommand,
+  'viewer-status': viewerStatusCommand,
+};

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -42,6 +42,7 @@ import {
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
 import { cliError, cliOutput, humanInfo } from '../renderers/index.js';
+import { docsViewerSubcommands } from './docs-viewer.js';
 
 /** Drift detection result. */
 interface DriftResult {
@@ -1327,7 +1328,8 @@ export const docsCommand = defineCommand({
       'Documentation attachment management (add/list/fetch/remove), ' +
       'llmtxt primitives (search/merge/graph/rank/versions/publish), ' +
       'PR publishing (publish-pr), drift detection (sync/status/gap-check), ' +
-      'and legacy .md migration (import)',
+      'legacy .md migration (import), ' +
+      'and a local web viewer (serve/open/stop/viewer-status)',
   },
   subCommands: {
     add: addCommand,
@@ -1347,6 +1349,7 @@ export const docsCommand = defineCommand({
     status: statusCommand,
     'gap-check': gapCheckCommand,
     import: importCommand,
+    ...docsViewerSubcommands,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -63,8 +62,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +83,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,20 +101,23 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -135,7 +140,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -238,7 +244,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -261,14 +268,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -292,7 +301,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -303,7 +313,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -316,7 +327,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -352,7 +364,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -382,7 +395,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'generateChangelogCommand',
     name: 'generate-changelog',
     description: 'Generate platform-specific changelog from CHANGELOG.md',
-    load: async () => (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/generate-changelog.js')).generateChangelogCommand as CommandDef,
   },
   {
     exportName: 'gradeCommand',
@@ -406,7 +420,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -429,14 +444,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -465,7 +483,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -507,14 +526,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -543,7 +565,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -555,13 +578,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -604,7 +629,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -615,7 +641,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -663,7 +690,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -675,7 +703,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -723,13 +752,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description:
+      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -807,7 +838,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -825,7 +857,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/viewer/pidfile.ts
+++ b/packages/cleo/src/viewer/pidfile.ts
@@ -1,0 +1,94 @@
+/**
+ * Viewer pidfile helpers — track a detached `cleo docs serve` instance so
+ * `cleo docs open` can reuse it and `cleo docs stop` can shut it down.
+ *
+ * Pidfile location: `${getCleoHome()}/viewer.pid` (per ADR-013 §9 / D029
+ * env-paths layout, e.g. `~/.local/share/cleo/viewer.pid` on Linux).
+ *
+ * @epic T9631
+ * @task T9646 — `cleo docs serve` local viewer
+ * @task T9721 — `cleo docs open` / `cleo docs stop` + pidfile lifecycle
+ */
+
+import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { getCleoHome } from '@cleocode/core/internal';
+
+/** Shape of the JSON document persisted on disk. */
+export interface ViewerPidRecord {
+  /** Process id of the detached viewer server. */
+  pid: number;
+  /** Bound TCP port (resolved by port-allocator). */
+  port: number;
+  /** Bind host (default 127.0.0.1). */
+  host: string;
+  /** Project root that owns the docs the viewer is serving. */
+  projectRoot: string;
+  /** Epoch ms when this record was written. */
+  startedAt: number;
+}
+
+/** Absolute path to the pidfile. */
+export function viewerPidFilePath(): string {
+  return join(getCleoHome(), 'viewer.pid');
+}
+
+/** Persist `record` to disk, creating parent dirs as needed. */
+export async function writeViewerPidFile(record: ViewerPidRecord): Promise<string> {
+  const path = viewerPidFilePath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(record, null, 2), 'utf8');
+  return path;
+}
+
+/**
+ * Read + parse the pidfile. Returns `null` when the file is absent or
+ * malformed (a stale record from a partial crash is treated the same as
+ * "no pidfile" — caller should re-spawn).
+ */
+export async function readViewerPidFile(): Promise<ViewerPidRecord | null> {
+  try {
+    const raw = await readFile(viewerPidFilePath(), 'utf8');
+    const parsed = JSON.parse(raw) as Partial<ViewerPidRecord>;
+    if (
+      typeof parsed.pid === 'number' &&
+      typeof parsed.port === 'number' &&
+      typeof parsed.host === 'string' &&
+      typeof parsed.projectRoot === 'string' &&
+      typeof parsed.startedAt === 'number'
+    ) {
+      return parsed as ViewerPidRecord;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort removal of the pidfile; never throws. */
+export async function removeViewerPidFile(): Promise<void> {
+  try {
+    await unlink(viewerPidFilePath());
+  } catch {
+    /* already gone */
+  }
+}
+
+/**
+ * Test if `pid` is currently running (alive AND owned by current uid). Uses
+ * `process.kill(pid, 0)` — signal 0 is the conventional liveness probe and
+ * never delivers a real signal to the target.
+ */
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    // EPERM means the process exists but is owned by another user — for our
+    // purposes treat it as "alive but unreachable".
+    if (e.code === 'EPERM') return true;
+    return false;
+  }
+}

--- a/packages/cleo/src/viewer/port-allocator.ts
+++ b/packages/cleo/src/viewer/port-allocator.ts
@@ -1,0 +1,108 @@
+/**
+ * Graceful TCP port allocator for the docs viewer.
+ *
+ * Extracted from `server.ts` so the bind/retry loop can be tested without
+ * spinning up the full viewer request handler. Default range is 7777 → 7800
+ * (24 ports), matching the convention shared by other CLEO local services.
+ * Auto-increment can be disabled with `autoIncrement: false`.
+ *
+ * @epic T9631
+ * @task T9646 — `cleo docs serve` local viewer
+ * @task T9722 — graceful port allocation 7777 → 7800
+ */
+
+import { type IncomingMessage, type Server, type ServerResponse, createServer } from 'node:http';
+
+/** First port the allocator will attempt. */
+export const DEFAULT_START_PORT = 7777;
+
+/** Last port the allocator will attempt (inclusive). */
+export const DEFAULT_END_PORT = 7800;
+
+/** Successful bind result. */
+export interface BoundServer {
+  /** Bound TCP port (the OS-resolved port when `startPort === 0`). */
+  port: number;
+  /** Bind host. */
+  host: string;
+  /** Underlying `http.Server` instance with `requestHandler` already wired. */
+  server: Server;
+}
+
+/** Options accepted by {@link tryListen}. */
+export interface TryListenOptions {
+  /** First port to attempt. Default: {@link DEFAULT_START_PORT}. */
+  startPort?: number;
+  /** Last port to attempt (inclusive). Default: {@link DEFAULT_END_PORT}. */
+  endPort?: number;
+  /** Bind host. Default: `127.0.0.1`. */
+  host?: string;
+  /** When true (default), auto-increment on `EADDRINUSE`. */
+  autoIncrement?: boolean;
+}
+
+/**
+ * Try to bind a fresh `http.Server` to the first available port in
+ * `[startPort, endPort]`.
+ *
+ * The returned server is created with `requestHandler` already wired so the
+ * caller never sees a hot socket without a listener.
+ *
+ * @throws `EADDRINUSE` when `autoIncrement` is `false` and `startPort` is busy.
+ * @throws `E_NO_PORT` when every port in the range returned `EADDRINUSE`.
+ *
+ * @task T9722
+ */
+export async function tryListen(
+  requestHandler: (req: IncomingMessage, res: ServerResponse) => void,
+  opts: TryListenOptions = {},
+): Promise<BoundServer> {
+  const startPort = opts.startPort ?? DEFAULT_START_PORT;
+  const endPort = opts.endPort ?? DEFAULT_END_PORT;
+  const host = opts.host ?? '127.0.0.1';
+  const autoIncrement = opts.autoIncrement ?? true;
+  const last = autoIncrement ? endPort : startPort;
+
+  for (let port = startPort; port <= last; port++) {
+    const server = createServer(requestHandler);
+    try {
+      await new Promise<void>((res, rej) => {
+        const onError = (err: NodeJS.ErrnoException) => {
+          server.removeListener('listening', onListen);
+          rej(err);
+        };
+        const onListen = () => {
+          server.removeListener('error', onError);
+          res();
+        };
+        server.once('error', onError);
+        server.once('listening', onListen);
+        server.listen(port, host);
+      });
+      // When `port === 0` the OS picked a free port — read it from the
+      // socket address so callers see the actual bound port.
+      const addr = server.address();
+      const boundPort =
+        addr && typeof addr === 'object' && typeof addr.port === 'number' ? addr.port : port;
+      return { server, port: boundPort, host };
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      // Always close the half-bound server to release the fd before retrying.
+      server.close();
+      if (e.code !== 'EADDRINUSE') {
+        // Surface non-collision errors immediately (permissions etc.).
+        throw e;
+      }
+      if (!autoIncrement) {
+        throw Object.assign(new Error(`port ${startPort} in use`), { code: 'EADDRINUSE' });
+      }
+    }
+  }
+
+  throw Object.assign(
+    new Error(
+      `no free port in range ${startPort}–${endPort} for viewer (tried ${last - startPort + 1} ports)`,
+    ),
+    { code: 'E_NO_PORT' },
+  );
+}

--- a/packages/cleo/src/viewer/port-allocator.ts
+++ b/packages/cleo/src/viewer/port-allocator.ts
@@ -11,7 +11,7 @@
  * @task T9722 — graceful port allocation 7777 → 7800
  */
 
-import { type IncomingMessage, type Server, type ServerResponse, createServer } from 'node:http';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 
 /** First port the allocator will attempt. */
 export const DEFAULT_START_PORT = 7777;

--- a/packages/cleo/src/viewer/server.ts
+++ b/packages/cleo/src/viewer/server.ts
@@ -1,0 +1,371 @@
+/**
+ * Local docs viewer HTTP server.
+ *
+ * Serves a minimal SPA + LAFS-shaped JSON API for browsing published docs in
+ * the current CLEO project. Uses only `node:http` (zero external server
+ * deps).
+ *
+ * Routes:
+ *   GET /                  → redirect to /viewer/index.html
+ *   GET /viewer/*          → static assets (index.html, viewer.js, styles.css)
+ *   GET /api/docs          → list of published docs (LAFS envelope)
+ *   GET /api/docs/:slug    → single doc with content (LAFS envelope)
+ *   GET /docs/:slug        → SPA index.html (client routes by pathname)
+ *   *                      → LAFS error envelope (404)
+ *
+ * Port allocation (T9722): start at 7777, auto-increment to 7800. Configurable
+ * via {@link StartViewerOptions.startPort} / `endPort`.
+ *
+ * @epic T9631
+ * @task T9646 — `cleo docs serve` local viewer
+ * @task T9720 — HTTP server with slug-based routing
+ * @task T9722 — graceful port allocation
+ */
+
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { type IncomingMessage, type Server, type ServerResponse, createServer } from 'node:http';
+import { dirname, join, normalize, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  createAttachmentStore,
+  getProjectRoot,
+  type LocalFileAttachment,
+} from '@cleocode/core/internal';
+
+const DEFAULT_START_PORT = 7777;
+const DEFAULT_END_PORT = 7800;
+
+/** Result of a successful viewer-server bind. */
+export interface ViewerServerHandle {
+  /** Bound TCP port. */
+  port: number;
+  /** Bind host. */
+  host: string;
+  /** Underlying `http.Server` instance. */
+  server: Server;
+}
+
+/**
+ * Try to bind a fresh `http.Server` to the first available port in
+ * `[startPort, endPort]`. Throws `E_NO_PORT` when every port returned
+ * `EADDRINUSE`, or `EADDRINUSE` when `autoIncrement` is `false`.
+ *
+ * Extracted into its own helper so callers + tests can exercise the bind
+ * loop without spinning up the full request handler.
+ *
+ * @task T9722
+ */
+export async function tryListen(
+  requestHandler: (req: IncomingMessage, res: ServerResponse) => void,
+  opts: { startPort?: number; endPort?: number; host?: string; autoIncrement?: boolean } = {},
+): Promise<ViewerServerHandle> {
+  const startPort = opts.startPort ?? DEFAULT_START_PORT;
+  const endPort = opts.endPort ?? DEFAULT_END_PORT;
+  const host = opts.host ?? '127.0.0.1';
+  const autoIncrement = opts.autoIncrement ?? true;
+  const last = autoIncrement ? endPort : startPort;
+
+  for (let port = startPort; port <= last; port++) {
+    const server = createServer(requestHandler);
+    try {
+      await new Promise<void>((res, rej) => {
+        const onError = (err: NodeJS.ErrnoException) => {
+          server.removeListener('listening', onListen);
+          rej(err);
+        };
+        const onListen = () => {
+          server.removeListener('error', onError);
+          res();
+        };
+        server.once('error', onError);
+        server.once('listening', onListen);
+        server.listen(port, host);
+      });
+      const addr = server.address();
+      const boundPort =
+        addr && typeof addr === 'object' && typeof addr.port === 'number' ? addr.port : port;
+      return { server, port: boundPort, host };
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      server.close();
+      if (e.code !== 'EADDRINUSE') throw e;
+      if (!autoIncrement) {
+        throw Object.assign(new Error(`port ${startPort} in use`), { code: 'EADDRINUSE' });
+      }
+    }
+  }
+
+  throw Object.assign(
+    new Error(
+      `no free port in range ${startPort}–${endPort} for viewer (tried ${last - startPort + 1} ports)`,
+    ),
+    { code: 'E_NO_PORT' },
+  );
+}
+
+/** Options controlling viewer-server startup. */
+export interface StartViewerOptions {
+  /** First port to attempt. Default: 7777. */
+  startPort?: number;
+  /** Last port to attempt (inclusive). Default: 7800. */
+  endPort?: number;
+  /** When true (default), auto-increment on `EADDRINUSE`. */
+  autoIncrement?: boolean;
+  /** Override bind host. Default: 127.0.0.1. */
+  host?: string;
+  /** Override project root (default: derived via `getProjectRoot()`). */
+  projectRoot?: string;
+}
+
+/**
+ * Resolve the on-disk path to the bundled viewer SPA assets.
+ *
+ * In development this points into the source tree (`packages/cleo/assets/viewer`).
+ * In the published npm package the same path resolves because `assets/` is
+ * included in `package.json#files`.
+ */
+export function getViewerAssetsDir(): string {
+  // dist/viewer/server.js → ../../assets/viewer (npm install)
+  // src/viewer/server.ts (via tsx/test) → ../../assets/viewer
+  const thisFile = fileURLToPath(import.meta.url);
+  return resolve(dirname(thisFile), '..', '..', 'assets', 'viewer');
+}
+
+/** Map of supported static asset extensions → MIME types. */
+const STATIC_MIME: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+};
+
+function extOf(p: string): string {
+  const i = p.lastIndexOf('.');
+  return i < 0 ? '' : p.slice(i).toLowerCase();
+}
+
+function lafsErrorJson(code: string, message: string, fix?: string): string {
+  const env: { success: false; error: { code: string; message: string; fix?: string } } = {
+    success: false,
+    error: { code, message },
+  };
+  if (fix !== undefined) env.error.fix = fix;
+  return JSON.stringify(env);
+}
+
+function lafsSuccessJson<T>(data: T): string {
+  return JSON.stringify({ success: true, data });
+}
+
+function send(res: ServerResponse, status: number, contentType: string, body: string | Buffer) {
+  res.writeHead(status, { 'Content-Type': contentType, 'Cache-Control': 'no-store' });
+  res.end(body);
+}
+
+/**
+ * Read the title from the first markdown H1 (`# heading`) of a doc, falling
+ * back to the slug. Strips leading `#` characters + whitespace.
+ */
+function inferTitle(markdown: string, fallback: string): string {
+  for (const line of markdown.split('\n', 50)) {
+    const m = line.match(/^\s*#\s+(.+?)\s*$/);
+    if (m) return m[1];
+  }
+  return fallback;
+}
+
+/**
+ * Serve a single static file out of the bundled assets directory. Performs a
+ * path containment check so request paths like `/viewer/../../etc/passwd`
+ * never escape the assets dir.
+ */
+async function serveStatic(res: ServerResponse, assetsDir: string, relPath: string) {
+  // normalize() collapses `..` segments; then containment-check by string prefix.
+  const safeRel = normalize(relPath).replace(/^[\\/]+/, '');
+  const absPath = join(assetsDir, safeRel);
+  const resolvedAssets = resolve(assetsDir) + '/';
+  const resolvedAbs = resolve(absPath);
+  if (`${resolvedAbs}/`.indexOf(resolvedAssets) !== 0 && resolvedAbs !== resolve(assetsDir)) {
+    send(res, 404, 'application/json', lafsErrorJson('E_NOT_FOUND', `not found: ${relPath}`));
+    return;
+  }
+  try {
+    const s = await stat(absPath);
+    if (!s.isFile()) {
+      send(res, 404, 'application/json', lafsErrorJson('E_NOT_FOUND', `not found: ${relPath}`));
+      return;
+    }
+    const mime = STATIC_MIME[extOf(absPath)] ?? 'application/octet-stream';
+    res.writeHead(200, {
+      'Content-Type': mime,
+      'Content-Length': String(s.size),
+      'Cache-Control': 'no-store',
+    });
+    createReadStream(absPath).pipe(res);
+  } catch {
+    send(res, 404, 'application/json', lafsErrorJson('E_NOT_FOUND', `not found: ${relPath}`));
+  }
+}
+
+/**
+ * Build the `requestHandler` closure. The viewer is read-only — it never
+ * mutates the docs DB.
+ */
+export function buildViewerHandler(
+  opts: { projectRoot?: string } = {},
+): (req: IncomingMessage, res: ServerResponse) => void {
+  const projectRoot = opts.projectRoot ?? getProjectRoot();
+  const assetsDir = getViewerAssetsDir();
+  const store = createAttachmentStore();
+
+  return async (req, res) => {
+    try {
+      const method = (req.method ?? 'GET').toUpperCase();
+      const pathname = (req.url ?? '/').split('?')[0] ?? '/';
+
+      // Health probe — useful for tests + CLI status command.
+      if (method === 'GET' && pathname === '/api/health') {
+        send(res, 200, 'application/json', lafsSuccessJson({ status: 'ok' }));
+        return;
+      }
+
+      if (method !== 'GET' && method !== 'HEAD') {
+        send(
+          res,
+          405,
+          'application/json',
+          lafsErrorJson('E_METHOD_NOT_ALLOWED', `method ${method} not allowed`),
+        );
+        return;
+      }
+
+      // GET / → redirect to viewer SPA index
+      if (pathname === '/' || pathname === '/viewer' || pathname === '/viewer/') {
+        res.writeHead(302, { Location: '/viewer/index.html' });
+        res.end();
+        return;
+      }
+
+      // GET /viewer/* — static assets
+      if (pathname.startsWith('/viewer/')) {
+        const rel = pathname.slice('/viewer/'.length);
+        await serveStatic(res, assetsDir, rel || 'index.html');
+        return;
+      }
+
+      // GET /api/docs — list published docs in this project
+      if (pathname === '/api/docs') {
+        const rows = await store.listAllInProject(projectRoot);
+        // Dedupe by attachment id (one blob can be referenced by multiple owners).
+        const seen = new Map<string, (typeof rows)[number]>();
+        for (const r of rows) {
+          if (!seen.has(r.metadata.id)) seen.set(r.metadata.id, r);
+        }
+        const docs = Array.from(seen.values()).map((r) => ({
+          id: r.metadata.id,
+          slug: r.slug,
+          type: r.type,
+          sha256: r.metadata.sha256,
+          mime: r.metadata.attachment.kind === 'blob' ? r.metadata.attachment.mime : null,
+          ownerType: r.ownerType,
+          ownerId: r.ownerId,
+          title: r.slug ?? r.metadata.id,
+          createdAt: r.metadata.createdAt,
+        }));
+        send(res, 200, 'application/json', lafsSuccessJson({ docs }));
+        return;
+      }
+
+      // GET /api/docs/:slug — single doc with content
+      const apiDocMatch = pathname.match(/^\/api\/docs\/([^/]+)$/);
+      if (apiDocMatch) {
+        const slug = decodeURIComponent(apiDocMatch[1]);
+        const bySlug = await store.findBySlug(slug, projectRoot);
+        if (!bySlug) {
+          send(
+            res,
+            404,
+            'application/json',
+            lafsErrorJson('E_NOT_FOUND', `no published doc with slug '${slug}'`),
+          );
+          return;
+        }
+        const fetched = await store.get(bySlug.metadata.sha256, projectRoot);
+        if (!fetched) {
+          send(
+            res,
+            404,
+            'application/json',
+            lafsErrorJson(
+              'E_NOT_FOUND',
+              `doc '${slug}' metadata present but blob bytes missing on disk`,
+            ),
+          );
+          return;
+        }
+        const mime =
+          fetched.metadata.attachment.kind === 'blob'
+            ? fetched.metadata.attachment.mime
+            : fetched.metadata.attachment.kind === 'local-file'
+              ? ((fetched.metadata.attachment as LocalFileAttachment).mime ?? 'text/plain')
+              : 'application/octet-stream';
+        const isText = mime.startsWith('text/') || mime === 'application/json';
+        const content = isText ? fetched.bytes.toString('utf8') : null;
+        const title = content ? inferTitle(content, slug) : slug;
+        send(
+          res,
+          200,
+          'application/json',
+          lafsSuccessJson({
+            id: fetched.metadata.id,
+            slug: bySlug.slug,
+            type: bySlug.type,
+            title,
+            mime,
+            sha256: fetched.metadata.sha256,
+            content,
+            sizeBytes: fetched.bytes.length,
+          }),
+        );
+        return;
+      }
+
+      // GET /docs/:slug — SPA shell (client routes by location.pathname)
+      if (/^\/docs\/[^/]+\/?$/.test(pathname)) {
+        await serveStatic(res, assetsDir, 'index.html');
+        return;
+      }
+
+      // Fallthrough → 404 JSON envelope
+      send(
+        res,
+        404,
+        'application/json',
+        lafsErrorJson('E_NOT_FOUND', `no route for ${method} ${pathname}`),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      send(res, 500, 'application/json', lafsErrorJson('E_INTERNAL', msg));
+    }
+  };
+}
+
+/**
+ * Start the viewer server. Returns a handle once the socket is bound.
+ *
+ * Caller is responsible for keeping the process alive (e.g. by not returning
+ * from the CLI handler) and for invoking `server.close()` on shutdown.
+ */
+export async function startViewer(opts: StartViewerOptions = {}): Promise<ViewerServerHandle> {
+  const handler = buildViewerHandler({ projectRoot: opts.projectRoot });
+  return tryListen(handler, {
+    startPort: opts.startPort,
+    endPort: opts.endPort,
+    host: opts.host,
+    autoIncrement: opts.autoIncrement,
+  });
+}

--- a/packages/cleo/src/viewer/server.ts
+++ b/packages/cleo/src/viewer/server.ts
@@ -24,7 +24,7 @@
 
 import { createReadStream } from 'node:fs';
 import { stat } from 'node:fs/promises';
-import { type IncomingMessage, type Server, type ServerResponse, createServer } from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import { dirname, join, normalize, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -32,77 +32,13 @@ import {
   getProjectRoot,
   type LocalFileAttachment,
 } from '@cleocode/core/internal';
+import { type BoundServer, tryListen } from './port-allocator.js';
 
-const DEFAULT_START_PORT = 7777;
-const DEFAULT_END_PORT = 7800;
+// Re-export for callers that consumed these from the server module directly.
+export { tryListen } from './port-allocator.js';
 
 /** Result of a successful viewer-server bind. */
-export interface ViewerServerHandle {
-  /** Bound TCP port. */
-  port: number;
-  /** Bind host. */
-  host: string;
-  /** Underlying `http.Server` instance. */
-  server: Server;
-}
-
-/**
- * Try to bind a fresh `http.Server` to the first available port in
- * `[startPort, endPort]`. Throws `E_NO_PORT` when every port returned
- * `EADDRINUSE`, or `EADDRINUSE` when `autoIncrement` is `false`.
- *
- * Extracted into its own helper so callers + tests can exercise the bind
- * loop without spinning up the full request handler.
- *
- * @task T9722
- */
-export async function tryListen(
-  requestHandler: (req: IncomingMessage, res: ServerResponse) => void,
-  opts: { startPort?: number; endPort?: number; host?: string; autoIncrement?: boolean } = {},
-): Promise<ViewerServerHandle> {
-  const startPort = opts.startPort ?? DEFAULT_START_PORT;
-  const endPort = opts.endPort ?? DEFAULT_END_PORT;
-  const host = opts.host ?? '127.0.0.1';
-  const autoIncrement = opts.autoIncrement ?? true;
-  const last = autoIncrement ? endPort : startPort;
-
-  for (let port = startPort; port <= last; port++) {
-    const server = createServer(requestHandler);
-    try {
-      await new Promise<void>((res, rej) => {
-        const onError = (err: NodeJS.ErrnoException) => {
-          server.removeListener('listening', onListen);
-          rej(err);
-        };
-        const onListen = () => {
-          server.removeListener('error', onError);
-          res();
-        };
-        server.once('error', onError);
-        server.once('listening', onListen);
-        server.listen(port, host);
-      });
-      const addr = server.address();
-      const boundPort =
-        addr && typeof addr === 'object' && typeof addr.port === 'number' ? addr.port : port;
-      return { server, port: boundPort, host };
-    } catch (err) {
-      const e = err as NodeJS.ErrnoException;
-      server.close();
-      if (e.code !== 'EADDRINUSE') throw e;
-      if (!autoIncrement) {
-        throw Object.assign(new Error(`port ${startPort} in use`), { code: 'EADDRINUSE' });
-      }
-    }
-  }
-
-  throw Object.assign(
-    new Error(
-      `no free port in range ${startPort}–${endPort} for viewer (tried ${last - startPort + 1} ports)`,
-    ),
-    { code: 'E_NO_PORT' },
-  );
-}
+export type ViewerServerHandle = BoundServer;
 
 /** Options controlling viewer-server startup. */
 export interface StartViewerOptions {


### PR DESCRIPTION
## Summary

Ships `cleo docs serve` — a local web viewer for docs published through the
Epic T9631 / Saga T9625 docs SSoT. Four subtasks delivered as four commits
in one PR per ADR-073 I8:

- **T9723** — embed a minimal, zero-dep viewer SPA bundle in `@cleocode/cleo` (HTML + JS + CSS under `packages/cleo/assets/viewer/`, served via `package.json#files`)
- **T9720** — zero-dep `node:http` server with slug-based routing under `packages/cleo/src/viewer/server.ts` (GET `/api/docs`, `/api/docs/:slug`, `/docs/:slug`, `/viewer/*`, `/api/health`, all returning LAFS envelopes)
- **T9722** — graceful port allocation in `packages/cleo/src/viewer/port-allocator.ts` (7777 → 7800 default range, auto-increment on `EADDRINUSE`, `--no-auto-port` opt-out, `E_NO_PORT` when the range is exhausted)
- **T9721** — `cleo docs serve | open | stop | viewer-status` CLI commands backed by a JSON pidfile at `${getCleoHome()}/viewer.pid`, with auto-spawn-on-open + SIGTERM (10s grace) → SIGKILL escalation on stop

llmtxt v2026.4.9 (the version currently consumed by `@cleocode/cleo`) does
not ship a pre-built viewer SPA in `node_modules`, so we follow the
fallback path called out in the T9646 design guidance and own the SPA
in-tree. Bundle is ~12 KB total, no client-side runtime dependencies.

## Acceptance criteria

1. ✅ `cleo docs serve` starts local http server (node:http, zero-dep)
2. ✅ Slug-based stable URL: `localhost:PORT/docs/<slug>` renders the doc
3. ✅ `cleo docs open <slug>` opens browser to that URL (server auto-starts if not running)
4. ✅ `cleo docs stop` sends SIGTERM to viewer pid recorded in `~/.local/share/cleo/viewer.pid`
5. ✅ Graceful port allocation 7777 → 7800 auto-increment; `--port <N>` override; `--no-auto-port` strict mode
6. ✅ All subcommands return LAFS envelopes (success or error, all routes 200/302/404/405)

## Test plan

- [x] `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/cli/__tests__/docs-viewer.test.ts` — **16 / 16 pass** (route coverage + round-trip + port collision matrix + pidfile lifecycle)
- [x] `pnpm biome ci .` — exit 0 (2 pre-existing warnings in `packages/core/src/skills/hermes-import-classifier.ts`, neither introduced by this PR)
- [x] `pnpm --filter @cleocode/cleo exec tsc --noEmit` — exit 0
- [x] `pnpm run typecheck` (full repo `tsc -b`) — exit 0
- [x] `pnpm run build` — full repo build green
- [x] Manual smoke: `node packages/cleo/dist/cli/index.js docs viewer-status` returns a LAFS envelope with `running: false` when no viewer is up
- [x] Manual smoke: foreground `cleo docs serve --port 18080` binds and emits the success envelope; `cleo docs --help` lists all four new subcommands

## Files

- `packages/cleo/assets/viewer/{index.html,viewer.js,styles.css}` — bundled SPA (new)
- `packages/cleo/src/viewer/server.ts` — HTTP server + route handlers (new)
- `packages/cleo/src/viewer/port-allocator.ts` — `tryListen()` bind/retry helper (new)
- `packages/cleo/src/viewer/pidfile.ts` — pidfile read/write/remove + liveness (new)
- `packages/cleo/src/cli/commands/docs-viewer.ts` — citty subcommand definitions (new)
- `packages/cleo/src/cli/commands/docs.ts` — register new subcommands under `cleo docs` (modified)
- `packages/cleo/src/cli/__tests__/docs-viewer.test.ts` — 16 in-process tests (new)
- `packages/cleo/package.json` — add `assets` to `files` so SPA ships with npm install (modified)

## Notes

- Pidfile lives at `${getCleoHome()}/viewer.pid` (per D029 env-paths layout — e.g. `~/.local/share/cleo/viewer.pid` on Linux), matching the rest of the local-service convention used by `cleo web` and `cleo daemon`.
- The viewer is read-only — it never mutates the docs DB. Doc content is read through the existing `AttachmentStore` (`findBySlug` / `get` / `listAllInProject`), so the wire shape stays in lock-step with `cleo docs publish` shipped under Saga T9625.
- T9647 (search + rank UI) is a separate task for a different worker after this PR merges.

Refs: Epic T9631, Saga T9625