### PR TITLE
feat(T9645): docs PR-merge re-ingest + drift gating + release-verify integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,70 @@ jobs:
       - name: Run canon drift gate
         run: node packages/cleo/dist/cli/index.js check canon
 
+  docs-drift:
+    # T9645: gate published docs SSoT vs the on-disk git files.
+    # `cleo docs status` exits 2 when any publication has drifted, 0 when
+    # all are in-sync, and is a no-op when no `.cleo/docs-publications.json`
+    # exists yet. This job IS the release-verify drift gate.
+    name: Docs SSoT Drift Gate (T9645)
+    needs: [biome]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.30.0'
+          run_install: false
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Skip when no docs ledger exists
+        id: ledger-check
+        run: |
+          if [[ -f .cleo/docs-publications.json ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No docs-publications.json — gate is a no-op."
+          fi
+      - run: pnpm install --frozen-lockfile
+        if: steps.ledger-check.outputs.exists == 'true'
+      - name: Build monorepo (cleo + workspace deps)
+        if: steps.ledger-check.outputs.exists == 'true'
+        run: pnpm run build
+      - name: Run docs drift gate
+        if: steps.ledger-check.outputs.exists == 'true'
+        run: |
+          # `cleo docs status` exits:
+          #   0 — every publication in-sync
+          #   2 — at least one publication drifted (modified/deleted)
+          # Any other non-zero exit is a tool failure and must fail the gate.
+          set +e
+          node packages/cleo/dist/cli/index.js docs status
+          rc=$?
+          set -e
+          if [ $rc -eq 0 ]; then
+            echo "docs-drift: clean."
+            exit 0
+          fi
+          if [ $rc -eq 2 ]; then
+            echo "::error::docs SSoT drift detected — published files have diverged from the blob store."
+            echo "::error::Run \`cleo docs sync --from <path> --for <ownerId> --name <blobName>\` for each drifted entry, or wait for the docs-reingest workflow after merge."
+            exit 2
+          fi
+          echo "::error::cleo docs status failed with exit $rc"
+          exit $rc
+
   migration-integrity:
     # Guards against the gitignore-silent-block bug that caused the CI
     # regression fixed in c6ae85a3. Before that, a too-broad "migrations/"

--- a/.github/workflows/docs-reingest.yml
+++ b/.github/workflows/docs-reingest.yml
@@ -1,0 +1,219 @@
+name: Docs Re-ingest (PR merge)
+
+# Re-ingest CLEO docs SSoT blobs whenever a PR that touches a published
+# Markdown file is merged into the default branch.
+#
+# Trigger
+# -------
+# `pull_request` `closed` event with `merged == true`. We deliberately do
+# NOT use `pull_request_target` — checkout always points at the merge SHA
+# in `github.event.pull_request.merge_commit_sha`, which is already on
+# `main`, so the privileges available to `pull_request: closed` are
+# sufficient (and safer — no risk of running fork code with secrets).
+#
+# Flow
+# ----
+# 1. Checkout the merge commit on main.
+# 2. Install pnpm + build the CLEO CLI.
+# 3. Run `cleo docs status --json` to find drifted publications.
+# 4. For each item with `drift = "modified" | "deleted"`, run
+#    `cleo docs sync --from <publishedPath> --for <ownerId> --name <blobName>`
+#    so a new blob version is recorded under the SSoT.
+# 5. Re-run `cleo docs status` and commit the updated ledger back to main
+#    when the working tree has changes (atomic post-merge sync).
+#
+# Idempotency
+# -----------
+# `cleo docs sync` returns `action=noop` when content already matches, so
+# repeated invocations are safe. The workflow's `commit-on-change` step
+# only fires when `git status --porcelain` reports actual diffs.
+#
+# References
+#   - T9645 (this task)
+#   - T9702 (`docs sync --from`) — packages/core/src/docs/docs-ops.ts
+#   - T9703 (`docs status`)       — packages/core/src/docs/docs-ops.ts
+#   - Epic T9630 / Saga T9625
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: docs-reingest-${{ github.event.pull_request.base.ref || 'main' }}
+  cancel-in-progress: false
+
+jobs:
+  reingest:
+    name: Re-ingest published docs
+    # Only run when the PR actually merged (closed-without-merge is a no-op).
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          # Pin to the merge commit so the working tree exactly mirrors
+          # the state that landed on the base branch.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          # We push a follow-up commit when the ledger drifts.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Skip when no docs ledger exists
+        id: ledger-check
+        run: |
+          if [[ -f .cleo/docs-publications.json ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No docs-publications.json — skipping re-ingest." >&2
+          fi
+
+      - name: Setup pnpm
+        if: steps.ledger-check.outputs.exists == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: '10.30.0'
+          run_install: false
+
+      - name: Setup Node.js
+        if: steps.ledger-check.outputs.exists == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        if: steps.ledger-check.outputs.exists == 'true'
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        if: steps.ledger-check.outputs.exists == 'true'
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        if: steps.ledger-check.outputs.exists == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build CLEO CLI
+        if: steps.ledger-check.outputs.exists == 'true'
+        run: pnpm run build
+
+      - name: Compute initial drift snapshot
+        if: steps.ledger-check.outputs.exists == 'true'
+        id: status
+        run: |
+          set +e
+          node packages/cleo/dist/cli/index.js docs status > /tmp/docs-status.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          cat /tmp/docs-status.json
+
+      - name: Re-ingest drifted docs
+        if: steps.ledger-check.outputs.exists == 'true' && steps.status.outputs.exit_code != '0'
+        run: |
+          # Read the status envelope, iterate each drifted item, and call
+          # `cleo docs sync --from <path>` so a new blob version lands in
+          # the SSoT. `deleted` entries are reported but NOT auto-synced —
+          # a removed file on disk likely means the publication was retired
+          # and should be cleared via `cleo docs remove`, not re-ingested.
+          node --input-type=module <<'NODE'
+          import { spawnSync } from 'node:child_process';
+          import { readFileSync } from 'node:fs';
+
+          const raw = readFileSync('/tmp/docs-status.json', 'utf-8');
+          // Envelope is single-line JSON; tolerate trailing chrome lines.
+          let env;
+          for (const line of raw.split('\n')) {
+            if (!line.trim().startsWith('{')) continue;
+            try { env = JSON.parse(line); break; } catch { /* keep scanning */ }
+          }
+          if (!env || !env.data || !Array.isArray(env.data.items)) {
+            console.error('docs-reingest: malformed status envelope; aborting.');
+            process.exit(1);
+          }
+
+          const failures = [];
+          let synced = 0;
+          let skipped = 0;
+          for (const item of env.data.items) {
+            if (item.drift === 'in-sync') continue;
+            if (item.drift === 'deleted') {
+              console.error(`docs-reingest: skipping deleted ${item.publishedPath} — `
+                + 'use `cleo docs remove` to retire this publication.');
+              skipped++;
+              continue;
+            }
+            if (item.drift !== 'modified') {
+              console.error(`docs-reingest: unknown drift "${item.drift}" on ${item.publishedPath} — skipped.`);
+              skipped++;
+              continue;
+            }
+
+            const args = [
+              'packages/cleo/dist/cli/index.js',
+              'docs', 'sync',
+              '--from', item.publishedPath,
+              '--for',  item.ownerId,
+              '--name', item.blobName,
+            ];
+            const r = spawnSync('node', args, { stdio: 'inherit' });
+            if (r.status !== 0) {
+              failures.push({ path: item.publishedPath, code: r.status });
+            } else {
+              synced++;
+            }
+          }
+          console.log(`docs-reingest: synced=${synced} skipped=${skipped} failures=${failures.length}`);
+          if (failures.length > 0) {
+            console.error(JSON.stringify(failures, null, 2));
+            process.exit(1);
+          }
+          NODE
+
+      - name: Verify post-ingest drift cleared
+        if: steps.ledger-check.outputs.exists == 'true' && steps.status.outputs.exit_code != '0'
+        run: |
+          set +e
+          node packages/cleo/dist/cli/index.js docs status
+          rc=$?
+          if [ $rc -eq 0 ]; then
+            echo "docs-reingest: post-ingest status clean."
+          else
+            echo "::warning::docs status still reports drift after re-ingest (exit $rc). Likely a `deleted` entry that needs `cleo docs remove`."
+          fi
+          # Always exit 0 — non-blocking. The workflow's job is to attempt
+          # re-ingest, not to fail on irrecoverable ledger states.
+          exit 0
+
+      - name: Commit ledger updates (when changed)
+        if: steps.ledger-check.outputs.exists == 'true'
+        run: |
+          if git diff --quiet -- .cleo/docs-publications.json; then
+            echo "docs-reingest: ledger unchanged — nothing to commit."
+            exit 0
+          fi
+          git config user.name  "cleo-docs-reingest[bot]"
+          git config user.email "cleo-docs-reingest@users.noreply.github.com"
+          git add .cleo/docs-publications.json
+          git commit -m "chore(docs): re-ingest SSoT blobs after PR #${{ github.event.pull_request.number }} (T9645)" \
+                     -m "Refs: T9645, Epic T9630, Saga T9625"
+          # Push back to the base branch (typically `main`). The workflow's
+          # GITHUB_TOKEN scope is `contents: write` which is sufficient for
+          # repositories with no branch-protection require-PR policy. When
+          # branch protection is enabled this step will hard-fail — switch
+          # to a dedicated PAT or peter-evans/create-pull-request action.
+          git push origin HEAD:${{ github.event.pull_request.base.ref }}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "hooks:install": "simple-git-hooks"
   },
   "simple-git-hooks": {
-    "commit-msg": "node scripts/hooks/commit-msg-release-lint.mjs \"$1\""
+    "commit-msg": "node scripts/hooks/commit-msg-release-lint.mjs \"$1\"",
+    "pre-commit": "node scripts/hooks/pre-commit-docs-drift.mjs"
   },
   "pnpm": {
     "supportedArchitectures": {

--- a/packages/cleo/src/cli/__tests__/docs-roundtrip-pr-merge.test.ts
+++ b/packages/cleo/src/cli/__tests__/docs-roundtrip-pr-merge.test.ts
@@ -1,0 +1,326 @@
+/**
+ * T9645 — End-to-end round-trip test for the post-merge docs re-ingest flow.
+ *
+ * This test simulates the exact sequence the
+ * `.github/workflows/docs-reingest.yml` workflow performs after a PR merges:
+ *
+ *   1. Seed a blob and `cleo docs publish` it to a git-tracked path (RT-A).
+ *   2. Edit the on-disk file (simulates a PR that touched the published doc).
+ *   3. Run `cleo docs status` against the post-merge state → drift=modified.
+ *   4. Iterate the drifted items and call
+ *      `cleo docs sync --from <publishedPath> --for <ownerId> --name <blobName>`
+ *      exactly as the workflow does.
+ *   5. Re-run `cleo docs status` → drift cleared (all in-sync, exit 0).
+ *   6. AC4 invariants:
+ *      - The new SSoT blob SHA matches the on-disk file SHA after re-ingest.
+ *      - The OLD blob SHA is preserved as `oldSha` on the sync envelope
+ *        so blob-version history is reconstructable.
+ *      - The publications ledger row reflects the new SHA.
+ *
+ * Whereas `docs-roundtrip.test.ts` exercises the per-command surfaces in
+ * isolation, this file validates that the WORKFLOW LOGIC (status → for each
+ * drifted item: sync → status) is consistent end-to-end and idempotent on
+ * a second pass.
+ *
+ * @task T9645 (T-DOCS-GH-2 — Re-ingest on PR merge + drift gating)
+ * @epic T9630
+ * @saga T9625
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Absolute path to `packages/cleo/` root. */
+const PKG_ROOT = resolve(__dirname, '..', '..', '..');
+
+/** Path to the compiled CLI entry point. */
+const CLI_DIST = resolve(PKG_ROOT, 'dist', 'cli', 'index.js');
+
+/** True when the compiled CLI dist bundle exists and can be spawned. */
+const CLI_DIST_AVAILABLE = existsSync(CLI_DIST);
+
+interface CliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number | null;
+}
+
+/**
+ * Run `node dist/cli/index.js <args>` against an isolated tmp project root.
+ */
+function runCli(args: readonly string[], projectRoot: string): CliResult {
+  const env = {
+    ...process.env,
+    CLEO_PROJECT_ROOT: projectRoot,
+    CLEO_ROOT: projectRoot,
+    CLEO_DIR: join(projectRoot, '.cleo'),
+    CLEO_OUTPUT_FORMAT: 'json',
+  };
+  const result = spawnSync('node', [CLI_DIST, ...args], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+    timeout: 30_000,
+    cwd: projectRoot,
+    env,
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status,
+  };
+}
+
+interface LafsEnvelope<TData = unknown> {
+  readonly success: boolean;
+  readonly data?: TData;
+  readonly error?: {
+    readonly code?: number | string;
+    readonly codeName?: string;
+    readonly message?: string;
+  };
+}
+
+function parseEnvelope<T = unknown>(stdout: string): LafsEnvelope<T> {
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+  for (const line of lines) {
+    if (!line.trim().startsWith('{')) continue;
+    try {
+      return JSON.parse(line) as LafsEnvelope<T>;
+    } catch {
+      /* keep scanning */
+    }
+  }
+  throw new Error(`parseEnvelope: no JSON envelope on stdout. Got:\n${stdout.slice(0, 2000)}`);
+}
+
+async function fileSha(path: string): Promise<string> {
+  const data = await readFile(path);
+  return createHash('sha256').update(data).digest('hex');
+}
+
+interface DocsStatusItem {
+  readonly ownerId: string;
+  readonly blobName: string;
+  readonly publishedPath: string;
+  readonly blobSha: string;
+  readonly fileSha: string | null;
+  readonly drift: 'in-sync' | 'added' | 'modified' | 'deleted';
+}
+
+/**
+ * Simulates the re-ingest loop the GitHub Actions workflow performs.
+ * Returns the list of `cleo docs sync` envelopes (one per drifted entry).
+ */
+function reingestDriftedDocs(
+  status: { items: readonly DocsStatusItem[] },
+  projectRoot: string,
+): Array<{
+  publishedPath: string;
+  envelope: LafsEnvelope<{
+    action: 'created' | 'updated' | 'noop';
+    newSha: string;
+    oldSha?: string;
+  }>;
+  exitCode: number | null;
+}> {
+  const out: Array<{
+    publishedPath: string;
+    envelope: LafsEnvelope<{
+      action: 'created' | 'updated' | 'noop';
+      newSha: string;
+      oldSha?: string;
+    }>;
+    exitCode: number | null;
+  }> = [];
+  for (const item of status.items) {
+    if (item.drift === 'in-sync' || item.drift === 'deleted') continue;
+    const args = [
+      'docs',
+      'sync',
+      '--from',
+      item.publishedPath,
+      '--for',
+      item.ownerId,
+      '--name',
+      item.blobName,
+    ];
+    const res = runCli(args, projectRoot);
+    out.push({
+      publishedPath: item.publishedPath,
+      envelope: parseEnvelope(res.stdout),
+      exitCode: res.status,
+    });
+  }
+  return out;
+}
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+let projectRoot: string;
+
+beforeEach(async () => {
+  projectRoot = await mkdtemp(join(tmpdir(), 'cleo-T9645-'));
+  await mkdir(join(projectRoot, '.cleo'), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(projectRoot, { recursive: true, force: true }).catch(() => {
+    /* never fail teardown */
+  });
+});
+
+async function seedBlobViaCli(ownerId: string, filename: string, content: string): Promise<string> {
+  const seedDir = join(projectRoot, '__seeds', ownerId);
+  await mkdir(seedDir, { recursive: true });
+  const fixturePath = join(seedDir, filename);
+  await writeFile(fixturePath, content, 'utf-8');
+  const res = runCli(['docs', 'add', ownerId, fixturePath], projectRoot);
+  if (res.status !== 0) {
+    throw new Error(
+      `seedBlobViaCli failed (exit ${res.status}). stdout=${res.stdout} stderr=${res.stderr}`,
+    );
+  }
+  const env = parseEnvelope<{ sha256: string }>(res.stdout);
+  expect(env.success, `docs add envelope: ${JSON.stringify(env)}`).toBe(true);
+  return env.data?.sha256 ?? '';
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe.skipIf(!CLI_DIST_AVAILABLE)('T9645 — post-merge docs re-ingest round-trip', () => {
+  it('AC4: edit → status drift → reingest → status clean → blob SHA matches file SHA', async () => {
+    const ownerId = 'T9645-ac4';
+    const original = '# Original doc\n\nv1 content.\n';
+    const originalSha = createHash('sha256').update(original).digest('hex');
+    await seedBlobViaCli(ownerId, 'doc.md', original);
+
+    // Step 1 — publish to a git-tracked path (simulates merge into main).
+    const dest = 'docs/published/ac4-doc.md';
+    const pubRes = runCli(['docs', 'publish', '--for', ownerId, '--to', dest], projectRoot);
+    expect(pubRes.status, `publish stderr: ${pubRes.stderr}`).toBe(0);
+    const pubEnv = parseEnvelope<{ blobSha256: string; publishedPath: string }>(pubRes.stdout);
+    expect(pubEnv.success).toBe(true);
+    expect(pubEnv.data?.blobSha256).toBe(originalSha);
+
+    // Step 2 — simulate a PR editing the on-disk file before merging.
+    const absDest = join(projectRoot, dest);
+    const edited = '# Original doc\n\nv2 content — edited in the PR that just merged.\n';
+    const editedSha = createHash('sha256').update(edited).digest('hex');
+    await writeFile(absDest, edited, 'utf-8');
+    expect(await fileSha(absDest)).toBe(editedSha);
+
+    // Step 3 — `cleo docs status` MUST exit 2 (drift) and classify modified.
+    const driftRes = runCli(['docs', 'status'], projectRoot);
+    expect(driftRes.status).toBe(2);
+    const driftEnv = parseEnvelope<{
+      items: DocsStatusItem[];
+      allInSync: boolean;
+    }>(driftRes.stdout);
+    expect(driftEnv.success).toBe(true);
+    expect(driftEnv.data?.allInSync).toBe(false);
+    const driftedItems = driftEnv.data?.items ?? [];
+    expect(driftedItems).toHaveLength(1);
+    expect(driftedItems[0]?.drift).toBe('modified');
+    expect(driftedItems[0]?.fileSha).toBe(editedSha);
+    expect(driftedItems[0]?.blobSha).toBe(originalSha);
+
+    // Step 4 — run the workflow's re-ingest loop on the drifted items.
+    const syncResults = reingestDriftedDocs({ items: driftedItems }, projectRoot);
+    expect(syncResults).toHaveLength(1);
+    const [{ envelope, exitCode }] = syncResults;
+    expect(exitCode).toBe(0);
+    expect(envelope.success).toBe(true);
+    expect(envelope.data?.action).toBe('updated');
+    // AC4 invariant: new SHA == on-disk edited SHA.
+    expect(envelope.data?.newSha).toBe(editedSha);
+    // AC4 invariant: oldSha references the previous published version.
+    expect(envelope.data?.oldSha).toBe(originalSha);
+
+    // Step 5 — status MUST now be clean and exit 0.
+    const finalRes = runCli(['docs', 'status'], projectRoot);
+    expect(finalRes.status, `final stderr: ${finalRes.stderr}`).toBe(0);
+    const finalEnv = parseEnvelope<{
+      items: DocsStatusItem[];
+      allInSync: boolean;
+    }>(finalRes.stdout);
+    expect(finalEnv.success).toBe(true);
+    expect(finalEnv.data?.allInSync).toBe(true);
+    expect(finalEnv.data?.items).toHaveLength(1);
+    expect(finalEnv.data?.items[0]?.drift).toBe('in-sync');
+    expect(finalEnv.data?.items[0]?.blobSha).toBe(editedSha);
+    expect(finalEnv.data?.items[0]?.fileSha).toBe(editedSha);
+  });
+
+  it('AC4-idempotent: replaying the re-ingest loop on a clean tree is a no-op (action=noop)', async () => {
+    const ownerId = 'T9645-ac4-idem';
+    const content = '# Idempotent\n';
+    await seedBlobViaCli(ownerId, 'idem.md', content);
+    const dest = 'docs/idem.md';
+    expect(runCli(['docs', 'publish', '--for', ownerId, '--to', dest], projectRoot).status).toBe(0);
+
+    // Edit + reingest once.
+    const edited = '# Edited once\n';
+    await writeFile(join(projectRoot, dest), edited, 'utf-8');
+    const status1 = parseEnvelope<{ items: DocsStatusItem[]; allInSync: boolean }>(
+      runCli(['docs', 'status'], projectRoot).stdout,
+    );
+    const first = reingestDriftedDocs({ items: status1.data?.items ?? [] }, projectRoot);
+    expect(first).toHaveLength(1);
+    expect(first[0]?.envelope.data?.action).toBe('updated');
+
+    // Second pass — file unchanged on disk, ledger row already in-sync.
+    // The workflow re-runs `status` and finds nothing to sync, so the
+    // re-ingest loop returns an empty result set.
+    const status2 = parseEnvelope<{ items: DocsStatusItem[]; allInSync: boolean }>(
+      runCli(['docs', 'status'], projectRoot).stdout,
+    );
+    expect(status2.data?.allInSync).toBe(true);
+    const second = reingestDriftedDocs({ items: status2.data?.items ?? [] }, projectRoot);
+    expect(second).toHaveLength(0);
+
+    // Belt-and-braces: even if the workflow naively re-syncs every item
+    // (no status filter), the sync MUST return `noop` because content
+    // matches the latest stored blob.
+    const directSync = runCli(
+      ['docs', 'sync', '--from', dest, '--for', ownerId, '--name', 'idem.md'],
+      projectRoot,
+    );
+    expect(directSync.status).toBe(0);
+    const directEnv = parseEnvelope<{ action: string; newSha: string; oldSha: string }>(
+      directSync.stdout,
+    );
+    expect(directEnv.data?.action).toBe('noop');
+    expect(directEnv.data?.newSha).toBe(directEnv.data?.oldSha);
+  });
+
+  it('AC4-deleted: status reports drift=deleted; workflow logic skips it (does not auto-sync)', async () => {
+    const ownerId = 'T9645-ac4-del';
+    await seedBlobViaCli(ownerId, 'gone.md', '# To be deleted\n');
+    const dest = 'docs/gone.md';
+    expect(runCli(['docs', 'publish', '--for', ownerId, '--to', dest], projectRoot).status).toBe(0);
+
+    // Remove the published file on disk (simulates a retire-PR merge).
+    const absDest = isAbsolute(dest) ? dest : resolve(projectRoot, dest);
+    await rm(absDest);
+
+    const status = parseEnvelope<{ items: DocsStatusItem[]; allInSync: boolean }>(
+      runCli(['docs', 'status'], projectRoot).stdout,
+    );
+    expect(status.data?.allInSync).toBe(false);
+    expect(status.data?.items[0]?.drift).toBe('deleted');
+
+    const ingest = reingestDriftedDocs({ items: status.data?.items ?? [] }, projectRoot);
+    // Workflow logic explicitly does NOT re-ingest deleted entries —
+    // they require `cleo docs remove` to retire the publication.
+    expect(ingest).toHaveLength(0);
+  });
+});

--- a/scripts/hooks/pre-commit-docs-drift.mjs
+++ b/scripts/hooks/pre-commit-docs-drift.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * pre-commit-docs-drift — advisory hook that warns when a staged Markdown
+ * file is registered in the docs-publications ledger but its on-disk content
+ * has drifted from the SSoT blob recorded under `.cleo/docs-publications.json`.
+ *
+ * Triggered by `simple-git-hooks` on every `pre-commit` event. Designed for
+ * sub-200ms execution on the staged-file fast-path (zero work when no
+ * staged file is in the ledger).
+ *
+ * Behaviour
+ * ---------
+ * 1. Read the staged `.md` paths via `git diff --cached --name-only --diff-filter=ACMR`.
+ * 2. Load `.cleo/docs-publications.json` (ledger). No ledger → exit 0 (no-op).
+ * 3. For each staged path that matches a `publishedPath` in the ledger:
+ *      - Hash the on-disk bytes.
+ *      - Compare against `lastBlobSha`.
+ *      - Mismatch → emit an ADVISORY hint with the exact `cleo docs sync`
+ *        invocation needed to update the SSoT blob.
+ * 4. Exit 0 by default — this hook NEVER blocks a commit.
+ *
+ * Strict mode
+ * -----------
+ * When `CLEO_STRICT_DOCS_DRIFT=1` is set in the environment, the hook exits
+ * with code 1 on any drift — useful for release-prep branches where
+ * unsynced docs should be a blocker before tagging.
+ *
+ * Bypass
+ * ------
+ * `CLEO_OWNER_OVERRIDE=1` + `CLEO_OWNER_OVERRIDE_REASON="<reason>"` bypasses
+ * the strict gate AND appends an audit row to `.cleo/audit/force-bypass.jsonl`.
+ * In advisory mode the bypass is a no-op (nothing to bypass).
+ *
+ * Exit codes
+ * ----------
+ *   0 — no drift, OR drift detected in advisory mode (default)
+ *   1 — drift detected with CLEO_STRICT_DOCS_DRIFT=1 set
+ *
+ * @task T9645
+ * @epic T9630
+ * @saga T9625
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { appendFileSync, mkdirSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute, join, resolve } from 'node:path';
+
+const STRICT = process.env.CLEO_STRICT_DOCS_DRIFT === '1';
+const OWNER_OVERRIDE = process.env.CLEO_OWNER_OVERRIDE === '1';
+const OWNER_OVERRIDE_REASON = process.env.CLEO_OWNER_OVERRIDE_REASON ?? '';
+
+function projectRoot() {
+  // Repo root is git's top-level when invoked from any subdir.
+  const r = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (r.status !== 0) process.exit(0);
+  return r.stdout.trim();
+}
+
+function stagedMarkdownPaths(root) {
+  // ACMR — Added, Copied, Modified, Renamed (skip Deleted; nothing to sync).
+  const r = spawnSync('git', ['diff', '--cached', '--name-only', '--diff-filter=ACMR'], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+    cwd: root,
+  });
+  if (r.status !== 0) return [];
+  return r.stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && s.toLowerCase().endsWith('.md'));
+}
+
+function loadLedger(root) {
+  const path = join(root, '.cleo', 'docs-publications.json');
+  try {
+    const data = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(data);
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed && typeof parsed === 'object' && Array.isArray(parsed.rows)) {
+      return parsed.rows;
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function sha256(path) {
+  try {
+    const data = readFileSync(path);
+    return createHash('sha256').update(data).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+function appendBypassAudit(root, payload) {
+  try {
+    const dir = join(root, '.cleo', 'audit');
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(join(dir, 'force-bypass.jsonl'), `${JSON.stringify(payload)}\n`, 'utf-8');
+  } catch {
+    /* audit failures must NEVER block a commit */
+  }
+}
+
+function main() {
+  const root = projectRoot();
+  const staged = stagedMarkdownPaths(root);
+  if (staged.length === 0) process.exit(0);
+
+  const ledger = loadLedger(root);
+  if (ledger.length === 0) process.exit(0);
+
+  // Index ledger by publishedPath for O(1) lookup.
+  const byPath = new Map();
+  for (const row of ledger) {
+    if (row && typeof row.publishedPath === 'string') {
+      byPath.set(row.publishedPath, row);
+    }
+  }
+  if (byPath.size === 0) process.exit(0);
+
+  const drifts = [];
+  for (const rel of staged) {
+    const row = byPath.get(rel);
+    if (!row) continue;
+    const abs = isAbsolute(rel) ? rel : resolve(root, rel);
+    try {
+      statSync(abs);
+    } catch {
+      continue;
+    }
+    const fileSha = sha256(abs);
+    if (fileSha === null) continue;
+    if (fileSha !== row.lastBlobSha) {
+      drifts.push({
+        publishedPath: rel,
+        ownerId: row.ownerId,
+        blobName: row.blobName,
+        fileSha,
+        blobSha: row.lastBlobSha,
+      });
+    }
+  }
+
+  if (drifts.length === 0) process.exit(0);
+
+  // Emit advisory message to stderr — visible but does not block.
+  process.stderr.write('\n');
+  process.stderr.write('[docs-drift] CLEO docs SSoT drift detected on staged files:\n\n');
+  for (const d of drifts) {
+    process.stderr.write(`  - ${d.publishedPath}\n`);
+    process.stderr.write(`      owner    : ${d.ownerId}\n`);
+    process.stderr.write(`      blobSha  : ${d.blobSha?.slice(0, 12) ?? '(none)'}\n`);
+    process.stderr.write(`      fileSha  : ${d.fileSha.slice(0, 12)}\n`);
+    process.stderr.write(
+      `      sync     : cleo docs sync --from ${d.publishedPath} --for ${d.ownerId} --name ${d.blobName}\n\n`,
+    );
+  }
+  process.stderr.write(
+    '[docs-drift] Tip: run `cleo docs sync --from <path> --for <ownerId> --name <blobName>` to update the SSoT blob before committing.\n',
+  );
+
+  if (!STRICT) {
+    process.stderr.write(
+      '[docs-drift] Advisory only — commit allowed (set CLEO_STRICT_DOCS_DRIFT=1 to enforce).\n\n',
+    );
+    process.exit(0);
+  }
+
+  // STRICT mode — block unless owner override.
+  if (OWNER_OVERRIDE) {
+    if (!OWNER_OVERRIDE_REASON || OWNER_OVERRIDE_REASON.trim().length === 0) {
+      process.stderr.write(
+        '[docs-drift] CLEO_OWNER_OVERRIDE=1 set but CLEO_OWNER_OVERRIDE_REASON is empty — blocking.\n',
+      );
+      process.exit(1);
+    }
+    appendBypassAudit(root, {
+      ts: new Date().toISOString(),
+      hook: 'pre-commit-docs-drift',
+      reason: OWNER_OVERRIDE_REASON,
+      drifts: drifts.map((d) => d.publishedPath),
+    });
+    process.stderr.write(
+      `[docs-drift] Owner override accepted — bypass logged (reason: "${OWNER_OVERRIDE_REASON}").\n\n`,
+    );
+    process.exit(0);
+  }
+
+  process.stderr.write('[docs-drift] CLEO_STRICT_DOCS_DRIFT=1 set — refusing to commit.\n\n');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Closes Epic **T9630** (W2 close-out under Saga T9625). Wires the
post-merge docs SSoT lifecycle end-to-end:

1. **Pre-commit hook** (`scripts/hooks/pre-commit-docs-drift.mjs`)
   advises developers when a staged Markdown file has drifted from the
   blob recorded in `.cleo/docs-publications.json`. Advisory by default;
   blocks under `CLEO_STRICT_DOCS_DRIFT=1`; owner override with audit log.
2. **GitHub Actions workflow** (`.github/workflows/docs-reingest.yml`)
   triggers on `pull_request: closed` with `merged == true`. It builds
   the CLI from the merge commit, calls `cleo docs status --json`,
   re-ingests each `modified` entry via `cleo docs sync --from`, then
   commits the updated ledger back to main.
3. **Release-verify drift gate** (`docs-drift` job in `ci.yml`) calls
   `cleo docs status` on every PR — exit 2 fails the gate. Already-shipped
   `cleo docs status` (T9703 / PR #327) provides the exit-code contract.
4. **Round-trip integration test**
   (`docs-roundtrip-pr-merge.test.ts`) drives the compiled CLI in a
   subprocess: publish → edit → status drift → workflow's reingest loop
   → status clean. Verifies blob/file SHA convergence, `oldSha`
   preservation, idempotency on replay, and the `deleted`-skip
   behaviour the workflow relies on.

## Acceptance Criteria

| AC | Delivery | Status |
|----|----------|--------|
| 1 — pre-commit hook detects modified docs + offers `docs sync` | `scripts/hooks/pre-commit-docs-drift.mjs` + `simple-git-hooks` wiring | DONE |
| 2 — PR-merge workflow re-ingests git → blob (auto-versioning) | `.github/workflows/docs-reingest.yml` | DONE |
| 3 — drift gating in release-verify | `docs-drift` job in `.github/workflows/ci.yml` | DONE |
| 4 — round-trip test: edit → publish-pr → CI green → merge → re-ingest | `packages/cleo/src/cli/__tests__/docs-roundtrip-pr-merge.test.ts` (3 specs) | DONE |

## Test plan

- [x] `pnpm biome ci .` — exit 0 (2 pre-existing warnings, no new errors)
- [x] `pnpm --filter @cleocode/cleo exec tsc --noEmit` — exit 0
- [x] `pnpm --filter @cleocode/core exec tsc --noEmit` — exit 0
- [x] `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/cli/__tests__/docs-roundtrip-pr-merge.test.ts` — 3/3 pass
- [x] `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/cli/__tests__/docs-roundtrip.test.ts` — 9/9 still pass (no regression)
- [x] Pre-commit hook smoke-tested in 3 modes: advisory (exit 0), strict (exit 1), owner-override (exit 0 + audit row)
- [x] Both workflow YAMLs parse with `yaml.safe_load`

## Notes for reviewers

- `packages/cleo/src/cli/generated/command-manifest.ts` is **not** modified
  by this PR — biome flags it but the violation exists on `origin/main` and
  was reset with `git checkout HEAD --` after the local build regenerated
  it (per orchestrator brief). The same applies to the
  `hermes-import-classifier.ts` useOptionalChain warnings.
- The re-ingest workflow's `git push` will hard-fail if branch protection
  on `main` requires PRs. In that case switch to
  `peter-evans/create-pull-request` — left as a deliberate follow-up so
  the policy decision lands with the workflow's first real invocation.
- `pull_request: closed` (not `pull_request_target`) was chosen
  deliberately: the merge commit is already on the trusted base branch,
  so we avoid the well-known `pull_request_target` privilege-escalation
  vector.

Refs: T9645, Epic T9630, Saga T9625