### PR TITLE
fix(T9738): repair 3 pre-existing main CI breakages

### DIFF
--- a/packages/cleo/src/cli/commands/docs-viewer.ts
+++ b/packages/cleo/src/cli/commands/docs-viewer.ts
@@ -17,7 +17,7 @@ import { open as fsOpen } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ExitCode } from '@cleocode/contracts';
-import { getCleoHome, getProjectRoot } from '@cleocode/core/internal';
+import { getCleoHome, getProjectRoot } from '@cleocode/core';
 import { defineCommand } from 'citty';
 import {
   isProcessAlive,

--- a/packages/core/src/sentient/__tests__/curator.test.ts
+++ b/packages/core/src/sentient/__tests__/curator.test.ts
@@ -116,19 +116,24 @@ describe('sentient curator', () => {
 
   it('refuses to archive a canonical row (db source_type = canonical)', async () => {
     const { upsertSkillRow } = await import('../../store/skills-db.js');
+    const { withProvenance } = await import('../skill-provenance.js');
     const installPath = plantSkillDir(skillsRoot, 'ct-orchestrator');
     // listSkillsBySource filters by sourceType, and 'canonical' is NOT in
     // CURATABLE_SOURCE_TYPES — so the curator should never see this row at
     // all. We still seed it to prove that even if a future caller widens
-    // CURATABLE_SOURCE_TYPES, the triple guard would catch it.
-    await upsertSkillRow(
-      buildRow({
-        name: 'ct-orchestrator',
-        installPath,
-        sourceType: 'canonical',
-        installedAt: isoDaysAgo(365),
-        lastUpdatedAt: isoDaysAgo(365),
-      }),
+    // CURATABLE_SOURCE_TYPES, the triple guard would catch it. Seeding a
+    // canonical row goes through the pr-generator provenance frame because
+    // assertCanonicalWriteAllowed (T9708) rejects bare upserts.
+    await withProvenance('pr-generator', () =>
+      upsertSkillRow(
+        buildRow({
+          name: 'ct-orchestrator',
+          installPath,
+          sourceType: 'canonical',
+          installedAt: isoDaysAgo(365),
+          lastUpdatedAt: isoDaysAgo(365),
+        }),
+      ),
     );
 
     const result = await runCuratorTick({ now: NOW, skillsRoot });

--- a/packages/core/src/skills/skills-guard-audit.ts
+++ b/packages/core/src/skills/skills-guard-audit.ts
@@ -15,6 +15,7 @@
 import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+import { getProjectRoot } from '../paths.js';
 import type { ScanResult } from './skills-guard.js';
 
 /**
@@ -41,11 +42,11 @@ export interface SkillTrustBypassEntry {
 /**
  * Resolve the canonical audit-log path.
  *
- * Defaults to `<cwd>/.cleo/audit/skill-trust-bypass.jsonl`. Tests inject an
- * explicit `cleoRoot` so they never touch the user's audit log.
+ * Defaults to `<projectRoot>/.cleo/audit/skill-trust-bypass.jsonl`. Tests
+ * inject an explicit `cleoRoot` so they never touch the user's audit log.
  */
 function resolveAuditPath(cleoRoot?: string): string {
-  const root = cleoRoot ?? join(process.cwd(), '.cleo');
+  const root = cleoRoot ?? join(getProjectRoot(), '.cleo');
   return join(root, 'audit', 'skill-trust-bypass.jsonl');
 }
 


### PR DESCRIPTION
## Summary

Three blockers landed via very recent T9730 / T9721 / T9708 merges that fail strict-mode CI on every PR — including T9738 release-track PRs (#328 B2 unification, #349 changesets foundation).

## Fixes

1. **`packages/core/src/skills/skills-guard-audit.ts:48`** — replace `process.cwd()` with `getProjectRoot()` for the audit-log path (lint-project-root-anti-pattern --strict regression from T9730).
2. **`packages/cleo/src/cli/commands/docs-viewer.ts:20`** — switch the `@cleocode/core/internal` import to the public `@cleocode/core` barrel (both helpers re-exported there). CORE-First lint regression from T9721.
3. **`packages/core/src/sentient/__tests__/curator.test.ts:124`** — wrap the canonical-row seed in `withProvenance("pr-generator", ...)`. T9708 added a triple guard that correctly refuses bare `upsertSkillRow` on canonical rows; the test fixture must enter the pr-generator frame before seeding. Behaviour under test unchanged.

## Verification

- `node scripts/lint-project-root-anti-pattern.mjs --strict` → `STRICT OK (zero violations)`
- `node scripts/lint-core-first.mjs --check` → `PASS — no new violations above baseline (87 known)`
- `vitest run packages/core/src/sentient/__tests__/curator.test.ts` → `12/12 passed`
- `pnpm run build` → green (full root, 23s, 9 waves)
- `pnpm biome check --write` on 3 touched files → 0 fixes needed

## Test plan

- [x] Lint gates pass locally
- [x] Curator test passes locally
- [x] Full root build passes
- [ ] CI green