### PR TITLE
release: ship v2026.5.88 — T9738 IVTR remediation close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,56 @@
 # Changelog
 
-## [unreleased] — T9686-B2 releases-table unification
+## [2026.5.88] (2026-05-20) — T9738 IVTR functional bug remediation close
 
-Drop the legacy `release_manifests` table and the `releases_view` bridge.
-Merge all legacy columns and rows into the canonical `releases` table so
-there is one source of truth for release state. The status enum is
-widened to admit both the new T9492 pipeline FSM (planned / pr-opened /
-pr-merged / published / reconciled) AND the legacy T5580 FSM (prepared /
-committed / tagged / pushed / rolled_back) — no information loss.
+Closes Epic **T9738** (IVTR functional bug remediation, post-v5.83 real-world
+testing). Bundles the B2 releases-table unification, the CLEO-native task-
+anchored changesets foundation, and the pre-existing main-CI repair that
+unblocked them.
+
+### Added
+
+- **PR #349 (T9738 changesets foundation)** — CLEO-native task-anchored
+  changesets DSL replaces the dormant `@changesets/cli` install: zod
+  schema in `@cleocode/contracts`, parser in `@cleocode/core`, CI lint
+  script, and seed entries for the T9686-A/B/B2/C/D/E shipped work.
+  `@changesets/cli` remains a dormant devDep (separate follow-up PR).
+  The consumer side (`cleo release plan` aggregator) is a follow-up task.
+
+### Refactored
+
+- **PR #328 (T9686-B2 releases-table unification)** — drop the legacy
+  `release_manifests` table and the `releases_view` SQL bridge; merge
+  every legacy column and row into the canonical `releases` table so
+  there is one source of truth for release state. The status enum is
+  widened to admit BOTH the new T9492 pipeline FSM (`planned` /
+  `pr-opened` / `pr-merged` / `published` / `reconciled`) AND the legacy
+  T5580 FSM (`prepared` / `committed` / `tagged` / `pushed` /
+  `rolled_back`) — no information loss.
+
+### Fixed
+
+- **PR #350 (T9738 CI repair)** — three pre-existing main-CI breakages
+  that were blocking every PR including the T9738 release-track:
+  - `packages/core/src/skills/skills-guard-audit.ts:48` — switch
+    `process.cwd()` → `getProjectRoot()` so the audit log lands in
+    the canonical project root (lint-project-root-anti-pattern strict
+    regression from T9730).
+  - `packages/cleo/src/cli/commands/docs-viewer.ts:20` — switch the
+    `@cleocode/core/internal` import to the public `@cleocode/core`
+    barrel (CORE-First lint regression from T9721).
+  - `packages/core/src/sentient/__tests__/curator.test.ts:124` —
+    wrap the canonical-row seed in `withProvenance("pr-generator", ...)`
+    so the test fixture clears the T9708 canonical-write guard before
+    seeding. Behaviour under test is unchanged.
 
 ### Breaking (internal)
 
-- **`release_manifests` table dropped.** Rows migrated to `releases` with
-  PK `legacy:<version>`. Migration `20260519010000_t9686b2-unify-releases-tables`
-  runs automatically on next CLI invocation.
-- **`releases_view` SQL view dropped.** No longer needed — readers query
-  `releases` directly.
+- **`release_manifests` table dropped.** Rows migrated to `releases`
+  with PK `legacy:<version>`. Migration
+  `20260519010000_t9686b2-unify-releases-tables` runs automatically on
+  next CLI invocation.
+- **`releases_view` SQL view dropped.** No longer needed — readers
+  query `releases` directly.
 - **Drizzle binding rename.** `schema.releasesNew` → `schema.releases`.
   Any code importing `releaseManifests` from `@cleocode/core/internal`
   must switch to `releases`.
@@ -32,11 +67,29 @@ committed / tagged / pushed / rolled_back) — no information loss.
 
 ### Downgrade notes
 
-This migration is destructive on downgrade. The `revert.sql` recreates
+The B2 migration is destructive on downgrade. The `revert.sql` recreates
 an empty `release_manifests` shell and the prior `releases_view` shape,
 but cannot split `legacy:*` rows out of `releases` back into the legacy
 table without manual SQL. Operators who need pre-T9686-B2 history after
 a downgrade must restore from a pre-migration `tasks.db` backup.
+
+### Deferred follow-ups (not blocking T9738 close)
+
+- **T9738-changesets-aggregator** — `cleo release plan` reads
+  `.changeset/*.md`, aggregates into `release_changesets` table, writes
+  CHANGELOG section.
+- **T9738-changesets-cleanup-cli** — remove `@changesets/cli` from
+  `package.json` devDependencies (now dormant after Path A foundation).
+- **T9738-C-followup** — backfill `commits` table for ~12-15 legacy
+  ship SHAs, re-enable `merge_commit_sha` FK.
+- **A4 cosmetic cleanup** — amend B2 migration to use
+  `<projectHash>:<version>` instead of `legacy:<version>` for migrated
+  rows. NEW migration file.
+- **Stale `releases` rows audit** — 30 v5.x rows in `prepared` status
+  that never pushed; archive or delete after B2 unifies the table.
+- **T9736** — `primary-guard.test.ts:100` macOS shard 1 flake (per
+  v5.87 CHANGELOG); pre-existing, merged through as not-a-required-
+  check.
 
 ## [2026.5.87] (2026-05-20) — SG-CLEO-DOCS-CANON saga close (T9625)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "conduit-core",
  "nom",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "cant-core",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "serde",
  "serde_json",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "cant-core",
  "serde",
@@ -394,7 +394,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-llm-native"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "lafs-core",
  "serde",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-core"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "chrono",
  "conduit-core",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-payments"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-protocol"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "cant-core",
  "chrono",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-sdk"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-storage"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-transport"
-version = "2026.5.86"
+version = "2026.5.88"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.87"
+version = "2026.5.88"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.87",
+  "version": "2026.5.88",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Closes Epic **T9738** (IVTR functional bug remediation). Bundles three merged PRs:

- **#350** — pre-existing main-CI repair (3 fixes that unblocked everything else)
- **#328** — T9686-B2 releases-table unification (canonical \`releases\` SSoT)
- **#349** — T9738 CLEO-native task-anchored changesets foundation

Also realigns Cargo.lock — it had drifted to v5.86 because the v5.87 ship commit did not stage it.

## Test plan

- [x] All 3 sub-PRs were squash-merged with admin via the green-gate set
- [x] `pnpm install` regenerates lockfile with no changes (workspace catalog stays locked)
- [x] `cargo check --workspace` realigns Cargo.lock to v5.88
- [ ] CI green on release branch (this PR)
- [ ] Tag pushed → release-publish workflow → GitHub Release → npm publish

## Decisions captured (Q1–Q5 owner)

- Q1 hand-written SQL (no drizzle.config.ts)
- Q2 DROP pipeline_id (zero callers)
- Q3 Path A CLEO-native changesets DSL (NOT upstream @changesets/cli)
- Q4 ship \`legacy:<version>\` PK as-is; 1-line A4 follow-up filed
- Q5 EXTEND status enum (no info loss)

## Deferred follow-ups (filed in CHANGELOG)

- T9738-changesets-aggregator (consumer side)
- T9738-changesets-cleanup-cli (remove dormant @changesets/cli)
- T9738-C-followup (commits backfill, re-enable FK)
- A4 cosmetic cleanup (uniform PK shape)
- Stale \`releases\` rows audit
- T9736 macOS shard 1 flake (per v5.87 CHANGELOG; not-a-required-check)