### PR TITLE
fix(T9757): primary-guard test realpath comparison for macOS shard 1

### DIFF
--- a/packages/core/src/worktree/__tests__/primary-guard.test.ts
+++ b/packages/core/src/worktree/__tests__/primary-guard.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -27,10 +27,15 @@ function run(cwd: string, args: string[]): string {
   }).trim();
 }
 
+// `repoRoot` is realpath-resolved at fixture setup so path comparisons against
+// `git worktree list --porcelain` output match on macOS. On macOS, `tmpdir()`
+// returns `/var/folders/...` which is a symlink to `/private/var/folders/...`,
+// and git reports the realpath-resolved form — a raw string compare would fail
+// only on macOS (T9757 / T9736 / T9738-E carryforward).
 let repoRoot: string;
 
 beforeEach(() => {
-  repoRoot = mkdtempSync(join(tmpdir(), 'cleo-t9686d-primary-'));
+  repoRoot = realpathSync(mkdtempSync(join(tmpdir(), 'cleo-t9686d-primary-')));
   // Initialize a minimal repo with one commit on `main` so `merge-base
   // --is-ancestor main main` succeeds — that's the exact condition that
   // caused the regression.


### PR DESCRIPTION
## Summary

- T9738-E carryforward (documented as T9736 in v5.87 CHANGELOG). The `primary-guard.test.ts` flaked only on macOS shard 1: `mkdtempSync(tmpdir())` on macOS returns `/var/folders/...` which is a symlink to `/private/var/folders/...`, while `git worktree list --porcelain` reports the realpath-resolved form — so the raw `w.path === repoRoot` predicate always failed on macOS, producing `expected undefined to be 'active'`.
- Fix: `realpathSync(mkdtempSync(...))` at fixture setup. Production code's `isPrimaryWorktree` helper (list.ts:493) already handles this — the test was the broken party. Smallest possible diff: one-line wrap + one-line import + a comment explaining the macOS hazard.
- Repro confirmed on Linux by symlinking the tmpdir alias to the real tmpdir; got the identical failure mode (`expected undefined to be 'active'`). Without the fix the test fails; with the fix it passes.

## Test plan

- [x] `pnpm install && pnpm run build` — green
- [x] `pnpm biome check --write packages/core/src/worktree` — clean
- [x] `pnpm --filter @cleocode/core run test src/worktree/__tests__/primary-guard` — 3/3 pass
- [x] `node scripts/lint-project-root-anti-pattern.mjs --strict` — zero violations
- [x] `node scripts/lint-core-first.mjs --check` — pass (87 baseline)
- [x] Linux symlink repro: identical failure pre-fix, passes post-fix

## Refs

- Tasks: T9757
- Epic: T9752 (T9738 carryforward closure)