### PR TITLE
feat(T9753): CLEO-native changesets aggregator

### DIFF
--- a/packages/core/migrations/drizzle-tasks/20260520000000_t9753-release-changesets-table/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260520000000_t9753-release-changesets-table/migration.sql
@@ -1,0 +1,52 @@
+-- T9753: Add `release_changesets` persistence table for CLEO-native
+-- task-anchored changesets (T9738 carryforward).
+--
+-- Each row records one `.changeset/*.md` entry that was aggregated into the
+-- corresponding release. `cleo release plan` reads `.changeset/*.md`, parses
+-- them via `parseChangesetDir`, persists one row per entry here, and then
+-- aggregates them into the CHANGELOG markdown section embedded into the
+-- release plan envelope.
+--
+-- This table is the persistent audit trail of which entries shipped under
+-- which release — once a release is published, the corresponding rows here
+-- become an immutable record of the user-facing change inventory.
+--
+-- Differs from `release_changes` (T9508): release_changes is the editorial
+-- CHANGELOG bucket derived from commit-level analysis and is per-bullet
+-- granular. release_changesets is the upstream-entry source — one row per
+-- `.changeset/*.md` file, carrying the structured frontmatter as-is so
+-- downstream renderers can re-aggregate without re-reading the markdown.
+--
+-- task_ids: JSON array (one entry per CLEO task ID anchored by the changeset).
+-- prs:      JSON array of integer PR numbers, nullable.
+-- notes:    longer-form markdown body from the entry, nullable.
+-- breaking: migration note when kind='breaking', nullable.
+--
+-- FKs:
+--   release_id → releases(id) ON DELETE CASCADE
+--
+-- @task T9753
+-- @epic T9752
+
+CREATE TABLE IF NOT EXISTS `release_changesets` (
+  `id`             TEXT PRIMARY KEY NOT NULL,
+  `release_id`     TEXT NOT NULL REFERENCES `releases`(`id`) ON DELETE CASCADE,
+  `changeset_id`   TEXT NOT NULL,
+  `task_ids`       TEXT NOT NULL,
+  `kind`           TEXT NOT NULL,
+  `summary`        TEXT NOT NULL,
+  `prs`            TEXT,
+  `notes`          TEXT,
+  `breaking`       TEXT,
+  `created_at`     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `release_changesets_release_id_idx`
+  ON `release_changesets` (`release_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `release_changesets_changeset_id_idx`
+  ON `release_changesets` (`changeset_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `release_changesets_kind_idx`
+  ON `release_changesets` (`kind`);

--- a/packages/core/migrations/drizzle-tasks/20260520000000_t9753-release-changesets-table/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260520000000_t9753-release-changesets-table/revert.sql
@@ -1,0 +1,7 @@
+-- Revert T9753: drop the `release_changesets` table + its indexes.
+-- Indexes drop implicitly when the table is dropped.
+--
+-- @task T9753
+-- @epic T9752
+
+DROP TABLE IF EXISTS `release_changesets`;

--- a/packages/core/src/release/__tests__/changesets-aggregator.test.ts
+++ b/packages/core/src/release/__tests__/changesets-aggregator.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for {@link aggregateChangesetsForRelease} — CLEO-native changesets
+ * aggregator (T9753).
+ *
+ * Covers:
+ *  - Empty input → empty markdown
+ *  - Mixed kinds → grouped + ordered output
+ *  - Breaking entry floats to the top with migration note
+ *  - Task IDs rendered as `(T1234)` anchors
+ *  - PR numbers appended as `(#42)` anchors when present
+ *
+ * @task T9753
+ * @epic T9752
+ */
+
+import type { ChangesetEntry } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { aggregateChangesetsForRelease } from '../changesets-aggregator.js';
+
+/**
+ * Build a minimal ChangesetEntry for test fixtures. Overrides win.
+ */
+function entry(overrides: Partial<ChangesetEntry> & { id: string }): ChangesetEntry {
+  return {
+    id: overrides.id,
+    tasks: overrides.tasks ?? ['T1234'],
+    kind: overrides.kind ?? 'feat',
+    summary: overrides.summary ?? `Summary for ${overrides.id}`,
+    prs: overrides.prs,
+    notes: overrides.notes,
+    breaking: overrides.breaking,
+  } as ChangesetEntry;
+}
+
+describe('aggregateChangesetsForRelease', () => {
+  it('returns empty markdown + zero count for empty input', () => {
+    const result = aggregateChangesetsForRelease({
+      entries: [],
+      version: 'v2026.6.0',
+      date: '2026-05-20',
+    });
+    expect(result.markdown).toBe('');
+    expect(result.entryCount).toBe(0);
+    expect(result.kinds.size).toBe(0);
+  });
+
+  it('renders 5 mixed-kind entries with grouped section headers + task anchors', () => {
+    const entries: ChangesetEntry[] = [
+      entry({ id: 'one', kind: 'feat', tasks: ['T9001'], summary: 'New API endpoint.' }),
+      entry({ id: 'two', kind: 'fix', tasks: ['T9002'], summary: 'Stop the bleed.' }),
+      entry({ id: 'three', kind: 'docs', tasks: ['T9003'], summary: 'Update README.' }),
+      entry({ id: 'four', kind: 'refactor', tasks: ['T9004'], summary: 'Untangle.' }),
+      entry({ id: 'five', kind: 'chore', tasks: ['T9005'], summary: 'Bump deps.' }),
+    ];
+
+    const result = aggregateChangesetsForRelease({
+      entries,
+      version: 'v2026.6.0',
+      date: '2026-05-20',
+    });
+
+    expect(result.entryCount).toBe(5);
+    expect(result.kinds.size).toBe(5);
+    expect(result.markdown).toContain('## v2026.6.0 — 2026-05-20');
+    expect(result.markdown).toContain('### Features');
+    expect(result.markdown).toContain('### Fixes');
+    expect(result.markdown).toContain('### Documentation');
+    expect(result.markdown).toContain('### Refactors');
+    expect(result.markdown).toContain('### Chores');
+    // Each summary line includes the task-ID anchor.
+    expect(result.markdown).toContain('- New API endpoint. (T9001)');
+    expect(result.markdown).toContain('- Stop the bleed. (T9002)');
+    expect(result.markdown).toContain('- Update README. (T9003)');
+    expect(result.markdown).toContain('- Untangle. (T9004)');
+    expect(result.markdown).toContain('- Bump deps. (T9005)');
+  });
+
+  it('renders kind sections in canonical order: feat → fix → perf → refactor → docs → test → chore', () => {
+    const entries: ChangesetEntry[] = [
+      // Intentionally pass in reversed order to verify the renderer reorders.
+      entry({ id: 'a', kind: 'chore', tasks: ['T1'], summary: 'chore.' }),
+      entry({ id: 'b', kind: 'test', tasks: ['T2'], summary: 'test.' }),
+      entry({ id: 'c', kind: 'docs', tasks: ['T3'], summary: 'docs.' }),
+      entry({ id: 'd', kind: 'refactor', tasks: ['T4'], summary: 'refactor.' }),
+      entry({ id: 'e', kind: 'perf', tasks: ['T5'], summary: 'perf.' }),
+      entry({ id: 'f', kind: 'fix', tasks: ['T6'], summary: 'fix.' }),
+      entry({ id: 'g', kind: 'feat', tasks: ['T7'], summary: 'feat.' }),
+    ];
+
+    const result = aggregateChangesetsForRelease({
+      entries,
+      version: 'v2026.6.0',
+      date: '2026-05-20',
+    });
+
+    const sections = result.markdown
+      .split('\n')
+      .filter((line) => line.startsWith('### '))
+      .map((line) => line.replace('### ', ''));
+
+    expect(sections).toEqual([
+      'Features',
+      'Fixes',
+      'Performance',
+      'Refactors',
+      'Documentation',
+      'Tests',
+      'Chores',
+    ]);
+  });
+
+  it('floats a breaking entry to the TOP with its migration note rendered inline', () => {
+    const entries: ChangesetEntry[] = [
+      entry({ id: 'one', kind: 'feat', tasks: ['T1001'], summary: 'New feature.' }),
+      entry({
+        id: 'two',
+        kind: 'breaking',
+        tasks: ['T1002'],
+        summary: 'Remove legacy API.',
+        breaking: 'Callers must switch to the new `v2` endpoint. The old endpoint returns 410.',
+      }),
+      entry({ id: 'three', kind: 'fix', tasks: ['T1003'], summary: 'Fix race.' }),
+    ];
+
+    const result = aggregateChangesetsForRelease({
+      entries,
+      version: 'v2026.6.0',
+      date: '2026-05-20',
+    });
+
+    // BREAKING section must precede Features section in the output.
+    const breakingIdx = result.markdown.indexOf('### BREAKING CHANGES');
+    const featuresIdx = result.markdown.indexOf('### Features');
+    expect(breakingIdx).toBeGreaterThanOrEqual(0);
+    expect(featuresIdx).toBeGreaterThan(breakingIdx);
+
+    // Migration note appears indented under the breaking bullet.
+    expect(result.markdown).toContain('  Migration:');
+    expect(result.markdown).toContain(
+      '  Callers must switch to the new `v2` endpoint. The old endpoint returns 410.',
+    );
+  });
+
+  it('appends PR anchors after task IDs when present', () => {
+    const entries: ChangesetEntry[] = [
+      entry({
+        id: 'one',
+        kind: 'fix',
+        tasks: ['T9686-A', 'T9686-B'],
+        prs: [324, 325],
+        summary: 'Two tasks, two PRs.',
+      }),
+    ];
+
+    const result = aggregateChangesetsForRelease({
+      entries,
+      version: 'v2026.6.0',
+      date: '2026-05-20',
+    });
+
+    expect(result.markdown).toContain('- Two tasks, two PRs. (T9686-A) (T9686-B) (#324) (#325)');
+  });
+
+  it('appends optional release title to the section header when provided', () => {
+    const result = aggregateChangesetsForRelease({
+      entries: [entry({ id: 'one', kind: 'feat', summary: 'X.' })],
+      version: 'v2026.6.0',
+      date: '2026-05-20',
+      title: 'June Release',
+    });
+
+    expect(result.markdown).toContain('## v2026.6.0 — 2026-05-20 — June Release');
+  });
+
+  it('omits the BREAKING section when no breaking entries are present', () => {
+    const result = aggregateChangesetsForRelease({
+      entries: [entry({ id: 'one', kind: 'feat', summary: 'A feature.' })],
+      version: 'v2026.6.0',
+      date: '2026-05-20',
+    });
+    expect(result.markdown).not.toContain('BREAKING');
+  });
+
+  it('preserves input order within a kind bucket so on-disk filename ordering survives', () => {
+    const entries: ChangesetEntry[] = [
+      entry({ id: 'a', kind: 'feat', tasks: ['T1'], summary: 'first feature.' }),
+      entry({ id: 'b', kind: 'feat', tasks: ['T2'], summary: 'second feature.' }),
+      entry({ id: 'c', kind: 'feat', tasks: ['T3'], summary: 'third feature.' }),
+    ];
+
+    const result = aggregateChangesetsForRelease({
+      entries,
+      version: 'v2026.6.0',
+      date: '2026-05-20',
+    });
+
+    const firstIdx = result.markdown.indexOf('first feature.');
+    const secondIdx = result.markdown.indexOf('second feature.');
+    const thirdIdx = result.markdown.indexOf('third feature.');
+    expect(firstIdx).toBeGreaterThan(0);
+    expect(secondIdx).toBeGreaterThan(firstIdx);
+    expect(thirdIdx).toBeGreaterThan(secondIdx);
+  });
+});

--- a/packages/core/src/release/__tests__/plan-aggregator-wiring.test.ts
+++ b/packages/core/src/release/__tests__/plan-aggregator-wiring.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Integration tests for `cleo release plan` × CLEO-native changesets aggregator (T9753).
+ *
+ * Covers:
+ *  - plan reads `.changeset/*.md` and embeds the aggregated CHANGELOG markdown
+ *    into `meta.releaseNotes` on the written plan envelope.
+ *  - empty `.changeset/` directory → plan succeeds with changesetEntryCount=0.
+ *  - missing `.changeset/` directory → plan succeeds (no error) with count=0.
+ *  - `release_changesets` rows persist correctly with FK to releases.id and
+ *    structured JSON columns for `taskIds` / `prs`.
+ *  - Re-running the plan verb overwrites prior changeset rows (no accumulation).
+ *
+ * @task T9753
+ * @epic T9752
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Task } from '@cleocode/contracts';
+import { parseReleasePlan } from '@cleocode/contracts';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, getDb, resetDbState } from '../../store/sqlite.js';
+import { createSqliteDataAccessor } from '../../store/sqlite-data-accessor.js';
+import * as schema from '../../store/tasks-schema.js';
+import { releasePlan } from '../plan.js';
+
+let testDir: string;
+
+/**
+ * Build a Task with sensible defaults for plan-time evidence checks.
+ */
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    title: overrides.title ?? `Task ${overrides.id}`,
+    description: overrides.description ?? `Description for ${overrides.id}`,
+    status: overrides.status ?? 'done',
+    priority: overrides.priority ?? 'medium',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    pipelineStage: overrides.pipelineStage ?? 'contribution',
+    verification: overrides.verification ?? {
+      passed: true,
+      round: 1,
+      gates: { implemented: true },
+      evidence: {
+        implemented: {
+          atoms: [{ kind: 'commit', sha: 'abc1234567', shortSha: 'abc1234' }],
+          capturedAt: new Date().toISOString(),
+          capturedBy: 'test-agent',
+        },
+      },
+      lastAgent: null,
+      lastUpdated: new Date().toISOString(),
+      failureLog: [],
+    },
+    ...overrides,
+  } as Task;
+}
+
+/**
+ * Initialize a `.git` directory so `getProjectRoot` accepts the test path.
+ */
+async function initTestGit(): Promise<void> {
+  execFileSync('git', ['init', '--quiet', testDir], { encoding: 'utf-8' });
+  execFileSync('git', ['-C', testDir, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', testDir, 'config', 'user.name', 'Test']);
+}
+
+/**
+ * Seed an epic + N child tasks.
+ */
+async function seedEpicWithChildren(epicId: string, childCount: number): Promise<void> {
+  const accessor = await createSqliteDataAccessor(testDir);
+  try {
+    await accessor.setMetaValue('schema_version', '2.10.0');
+    await accessor.upsertSingleTask(
+      makeTask({ id: epicId, type: 'epic', title: 'Epic', pipelineStage: 'contribution' }),
+    );
+    for (let i = 1; i <= childCount; i++) {
+      const id = `T${10000 + i}`;
+      await accessor.upsertSingleTask(makeTask({ id, parentId: epicId, title: `Child ${i}` }));
+    }
+  } finally {
+    await accessor.close();
+  }
+}
+
+/**
+ * Write a single `.changeset/<slug>.md` file with the given content.
+ */
+function writeChangeset(slug: string, content: string): void {
+  const dir = join(testDir, '.changeset');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${slug}.md`), content, 'utf8');
+}
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'cleo-plan-agg-'));
+  await mkdir(join(testDir, '.cleo'), { recursive: true });
+  writeFileSync(
+    join(testDir, '.cleo', 'config.json'),
+    JSON.stringify({
+      enforcement: { session: { requiredForMutate: false } },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+  writeFileSync(
+    join(testDir, '.cleo', 'project-info.json'),
+    JSON.stringify({
+      projectHash: 'testhash00000',
+      projectId: 'test-project-id',
+      projectRoot: testDir,
+      projectName: 'test',
+    }),
+  );
+  await initTestGit();
+  resetDbState();
+});
+
+afterEach(async () => {
+  try {
+    closeDb();
+  } catch {
+    // best-effort
+  }
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe('releasePlan × changesets aggregator', () => {
+  it('reads .changeset/*.md and embeds aggregated CHANGELOG in plan.meta.releaseNotes', async () => {
+    await seedEpicWithChildren('T9999', 1);
+
+    writeChangeset(
+      'sample-fix',
+      [
+        '---',
+        'id: sample-fix',
+        'tasks: [T1234]',
+        'kind: fix',
+        'summary: A sample bug fix.',
+        '---',
+        '',
+        'Longer explanation of the fix.',
+        '',
+      ].join('\n'),
+    );
+
+    writeChangeset(
+      'sample-feat',
+      [
+        '---',
+        'id: sample-feat',
+        'tasks: [T5678]',
+        'kind: feat',
+        'prs: [99]',
+        'summary: A new capability.',
+        '---',
+        '',
+      ].join('\n'),
+    );
+
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      createdBy: 'integration-test',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.changesetEntryCount).toBe(2);
+
+    const plan = parseReleasePlan(JSON.parse(readFileSync(result.data.planPath, 'utf-8')));
+    const meta = plan.meta as Record<string, unknown> | undefined;
+    expect(meta).toBeDefined();
+    const releaseNotes = meta?.['releaseNotes'];
+    expect(typeof releaseNotes).toBe('string');
+    expect(releaseNotes).toContain('## v2026.6.0');
+    expect(releaseNotes).toContain('### Features');
+    expect(releaseNotes).toContain('### Fixes');
+    expect(releaseNotes).toContain('- A new capability. (T5678) (#99)');
+    expect(releaseNotes).toContain('- A sample bug fix. (T1234)');
+    expect(meta?.['changesetEntryCount']).toBe(2);
+  });
+
+  it('persists release_changesets rows linked to the release with structured JSON columns', async () => {
+    await seedEpicWithChildren('T9999', 1);
+
+    writeChangeset(
+      'multi-task',
+      [
+        '---',
+        'id: multi-task',
+        'tasks: [T100, T101, T102]',
+        'kind: refactor',
+        'prs: [42, 43]',
+        'summary: Split a big module.',
+        '---',
+        '',
+        'Body paragraph.',
+        '',
+      ].join('\n'),
+    );
+
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+
+    const db = await getDb(testDir);
+    const releases = await db.select().from(schema.releases).all();
+    expect(releases).toHaveLength(1);
+    const releaseId = releases[0]!.id;
+
+    const changesetRows = await db
+      .select()
+      .from(schema.releaseChangesets)
+      .where(eq(schema.releaseChangesets.releaseId, releaseId))
+      .all();
+
+    expect(changesetRows).toHaveLength(1);
+    const row = changesetRows[0]!;
+    expect(row.changesetId).toBe('multi-task');
+    expect(row.kind).toBe('refactor');
+    expect(row.summary).toBe('Split a big module.');
+    expect(JSON.parse(row.taskIds)).toEqual(['T100', 'T101', 'T102']);
+    expect(row.prs).not.toBeNull();
+    expect(JSON.parse(row.prs!)).toEqual([42, 43]);
+    expect(row.notes).toBe('Body paragraph.');
+    expect(row.breaking).toBeNull();
+  });
+
+  it('succeeds with entryCount=0 when .changeset/ directory is missing entirely', async () => {
+    await seedEpicWithChildren('T9999', 1);
+
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.changesetEntryCount).toBe(0);
+
+    const plan = parseReleasePlan(JSON.parse(readFileSync(result.data.planPath, 'utf-8')));
+    const meta = plan.meta as Record<string, unknown> | undefined;
+    expect(meta?.['releaseNotes']).toBe('');
+    expect(meta?.['changesetEntryCount']).toBe(0);
+  });
+
+  it('succeeds with entryCount=0 when .changeset/ exists but only contains README.md', async () => {
+    await seedEpicWithChildren('T9999', 1);
+    mkdirSync(join(testDir, '.changeset'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.changeset', 'README.md'),
+      '# Changesets directory\n\nDocs only.\n',
+    );
+
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.changesetEntryCount).toBe(0);
+  });
+
+  it('re-running the plan overwrites prior release_changesets rows (no accumulation)', async () => {
+    await seedEpicWithChildren('T9999', 1);
+
+    writeChangeset(
+      'first',
+      ['---', 'id: first', 'tasks: [T1]', 'kind: feat', 'summary: First entry.', '---', ''].join(
+        '\n',
+      ),
+    );
+
+    const first = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(first.success).toBe(true);
+
+    // Add a second entry and re-run.
+    writeChangeset(
+      'second',
+      ['---', 'id: second', 'tasks: [T2]', 'kind: fix', 'summary: Second entry.', '---', ''].join(
+        '\n',
+      ),
+    );
+
+    const second = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+    expect(second.success).toBe(true);
+    if (!second.success) throw new Error('unreachable');
+    expect(second.data.changesetEntryCount).toBe(2);
+
+    const db = await getDb(testDir);
+    const releases = await db.select().from(schema.releases).all();
+    const releaseId = releases[0]!.id;
+    const rows = await db
+      .select()
+      .from(schema.releaseChangesets)
+      .where(eq(schema.releaseChangesets.releaseId, releaseId))
+      .all();
+    // Exactly 2 — the prior row was wiped before re-insert.
+    expect(rows).toHaveLength(2);
+    const slugs = rows.map((r) => r.changesetId).sort();
+    expect(slugs).toEqual(['first', 'second']);
+  });
+});

--- a/packages/core/src/release/changesets-aggregator.ts
+++ b/packages/core/src/release/changesets-aggregator.ts
@@ -1,0 +1,236 @@
+/**
+ * CLEO-native changesets aggregator — rolls `.changeset/*.md` entries into a
+ * CHANGELOG markdown section embedded into the release plan envelope.
+ *
+ * Pure module: no filesystem, no database, no network. Callers are expected to
+ * read changeset files via {@link parseChangesetDir} (lives in
+ * `@cleocode/core/changesets`) and persist the entries via the data-accessor
+ * chokepoint.
+ *
+ * Output shape: one markdown section per release. Entries are grouped by
+ * {@link ChangesetKind} in a stable canonical order; breaking changes float to
+ * the top of the section with their `breaking` migration note rendered inline.
+ *
+ * @epic T9752
+ * @task T9753
+ */
+import type { ChangesetEntry, ChangesetKind } from '@cleocode/contracts';
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+/**
+ * Result of aggregating a slice of changeset entries into a release CHANGELOG
+ * section. The `markdown` field is empty string when `entries.length === 0` so
+ * callers can compose conditionally without branching on the contents.
+ */
+export interface AggregatedChangesetSection {
+  /** Rendered CHANGELOG markdown section. Empty string when no entries. */
+  readonly markdown: string;
+  /** Number of entries rolled into the section. */
+  readonly entryCount: number;
+  /** Distinct kinds represented in the rendered section. */
+  readonly kinds: ReadonlySet<ChangesetKind>;
+}
+
+/**
+ * Options accepted by {@link aggregateChangesetsForRelease}.
+ */
+export interface AggregateChangesetsOptions {
+  /** Parsed changeset entries to aggregate. */
+  readonly entries: readonly ChangesetEntry[];
+  /** Release version string (e.g. `v2026.6.0`). Used in the section header. */
+  readonly version: string;
+  /** ISO-8601 calendar date (YYYY-MM-DD). Used in the section header. */
+  readonly date: string;
+  /** Optional human-readable release title appended after the version header. */
+  readonly title?: string;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/**
+ * Canonical render order for kind groups. Breaking floats to the TOP of the
+ * section so migration-critical context lands first; everything else follows a
+ * stable engineering taxonomy aligned with conventional-commit semantics.
+ *
+ * NOTE: `breaking` is rendered FIRST in the markdown body but iterated last
+ * here — rendering wraps the order so breaking sits at the head. See
+ * {@link aggregateChangesetsForRelease} for the wrap logic.
+ *
+ * @internal
+ */
+const KIND_RENDER_ORDER: readonly ChangesetKind[] = [
+  'feat',
+  'fix',
+  'perf',
+  'refactor',
+  'docs',
+  'test',
+  'chore',
+  'breaking',
+] as const;
+
+/**
+ * Human-readable section headers per kind. Lower-case keys are intentional;
+ * we Title-Case at render time for consistency with conventional-commit
+ * vocabulary used elsewhere in CLEO's release tooling.
+ *
+ * @internal
+ */
+const KIND_HEADERS: Readonly<Record<ChangesetKind, string>> = {
+  feat: 'Features',
+  fix: 'Fixes',
+  perf: 'Performance',
+  refactor: 'Refactors',
+  docs: 'Documentation',
+  test: 'Tests',
+  chore: 'Chores',
+  breaking: 'BREAKING CHANGES',
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Group entries by {@link ChangesetKind}, preserving the input order WITHIN
+ * each bucket so deterministic on-disk ordering (alphabetical filenames per
+ * `parseChangesetDir`) translates to stable bullet order in the section.
+ *
+ * @internal
+ */
+function groupByKind(entries: readonly ChangesetEntry[]): Map<ChangesetKind, ChangesetEntry[]> {
+  const groups = new Map<ChangesetKind, ChangesetEntry[]>();
+  for (const entry of entries) {
+    const bucket = groups.get(entry.kind);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      groups.set(entry.kind, [entry]);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Render a single non-breaking entry as a bullet line.
+ *
+ * Format: `- summary (T1234, T5678) (#42, #43)` — task IDs and PR numbers are
+ * appended in parens only when present. Task IDs precede PRs because tasks are
+ * the canonical CLEO identifier; PRs are secondary metadata.
+ *
+ * @internal
+ */
+function renderEntryBullet(entry: ChangesetEntry): string {
+  const taskAnchors = entry.tasks.map((id) => `(${id})`).join(' ');
+  const prAnchors =
+    entry.prs && entry.prs.length > 0 ? ' ' + entry.prs.map((n) => `(#${n})`).join(' ') : '';
+  return `- ${entry.summary} ${taskAnchors}${prAnchors}`.trimEnd();
+}
+
+/**
+ * Render a breaking entry as a bullet plus an indented migration block.
+ *
+ * The `breaking` field is required for `kind: 'breaking'` (enforced by the
+ * Zod schema) — we still defensively coalesce to an empty migration note so a
+ * mis-tagged future entry does not crash the renderer.
+ *
+ * @internal
+ */
+function renderBreakingEntry(entry: ChangesetEntry): string {
+  const bullet = renderEntryBullet(entry);
+  const migration = (entry.breaking ?? '').trim();
+  if (migration.length === 0) return bullet;
+  // Indent each line of the migration note by two spaces so it renders as a
+  // nested block under the bullet in standard markdown renderers.
+  const indented = migration
+    .split('\n')
+    .map((line) => (line.length > 0 ? `  ${line}` : ''))
+    .join('\n');
+  return `${bullet}\n\n  Migration:\n\n${indented}`;
+}
+
+/**
+ * Render a kind group as a `### Header` block followed by bullet lines.
+ *
+ * @internal
+ */
+function renderGroup(kind: ChangesetKind, entries: readonly ChangesetEntry[]): string {
+  const header = `### ${KIND_HEADERS[kind]}`;
+  const body = entries
+    .map((e) => (kind === 'breaking' ? renderBreakingEntry(e) : renderEntryBullet(e)))
+    .join('\n');
+  return `${header}\n\n${body}`;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Aggregate a parsed set of {@link ChangesetEntry} records into a single
+ * CHANGELOG section.
+ *
+ * Section layout:
+ *
+ * ```md
+ * ## <version> — <date> [— <title>]
+ *
+ * ### BREAKING CHANGES   ← only when at least one breaking entry exists
+ *
+ * - <summary> (T####) (#PR)
+ *
+ *   Migration:
+ *
+ *   <breaking note indented>
+ *
+ * ### Features
+ *
+ * - <summary> (T####) (#PR)
+ * ```
+ *
+ * Empty input → returns `{ markdown: '', entryCount: 0, kinds: new Set() }` so
+ * the caller can skip emission without branching on string length.
+ *
+ * @example
+ * ```ts
+ * import { parseChangesetDir } from '@cleocode/core/changesets';
+ * import { aggregateChangesetsForRelease } from '@cleocode/core/release/changesets-aggregator';
+ *
+ * const entries = parseChangesetDir('.changeset');
+ * const section = aggregateChangesetsForRelease({
+ *   entries,
+ *   version: 'v2026.6.0',
+ *   date: '2026-05-20',
+ * });
+ * console.log(section.markdown);
+ * ```
+ */
+export function aggregateChangesetsForRelease(
+  opts: AggregateChangesetsOptions,
+): AggregatedChangesetSection {
+  const { entries, version, date, title } = opts;
+  if (entries.length === 0) {
+    return { markdown: '', entryCount: 0, kinds: new Set<ChangesetKind>() };
+  }
+
+  const groups = groupByKind(entries);
+  const presentKinds = new Set<ChangesetKind>(groups.keys());
+
+  // Compose a render order that floats `breaking` to the head if present and
+  // preserves the canonical engineering order for the rest.
+  const orderedKinds: ChangesetKind[] = [];
+  if (groups.has('breaking')) orderedKinds.push('breaking');
+  for (const kind of KIND_RENDER_ORDER) {
+    if (kind === 'breaking') continue;
+    if (groups.has(kind)) orderedKinds.push(kind);
+  }
+
+  const header = title ? `## ${version} — ${date} — ${title}` : `## ${version} — ${date}`;
+
+  const body = orderedKinds.map((kind) => renderGroup(kind, groups.get(kind) ?? [])).join('\n\n');
+
+  const markdown = `${header}\n\n${body}\n`;
+
+  return {
+    markdown,
+    entryCount: entries.length,
+    kinds: presentKinds,
+  };
+}

--- a/packages/core/src/release/plan.ts
+++ b/packages/core/src/release/plan.ts
@@ -15,9 +15,9 @@
  * @spec .cleo/rcasd/T9345/research/SPEC-T9345-release-pipeline-v2.md §4.2
  */
 
-import { mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import type { EvidenceAtom, Task } from '@cleocode/contracts';
+import type { ChangesetEntry, EvidenceAtom, Task } from '@cleocode/contracts';
 import {
   E_CHANNEL_MISMATCH,
   E_DIRTY_TREE,
@@ -46,13 +46,21 @@ import {
 } from '@cleocode/contracts';
 import { and, desc, eq } from 'drizzle-orm';
 
+import { parseChangesetDir } from '../changesets/index.js';
 import { getLogger } from '../logger.js';
 import { getCleoDirAbsolute, getProjectRoot } from '../paths.js';
 import { getProjectInfoSync } from '../project-info.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { getDb } from '../store/sqlite.js';
-import { type NewReleaseRow, type ReleaseRow, releases } from '../store/tasks-schema.js';
+import {
+  type NewReleaseChangesetRow,
+  type NewReleaseRow,
+  type ReleaseRow,
+  releaseChangesets,
+  releases,
+} from '../store/tasks-schema.js';
 import { resolveToolCommand } from '../tasks/tool-resolver.js';
+import { aggregateChangesetsForRelease } from './changesets-aggregator.js';
 import { runGitWithLockRetry } from './engine-ops.js';
 import { loadReleaseConfig } from './release-config.js';
 
@@ -118,6 +126,13 @@ export interface ReleasePlanResult {
   preflightWarnings: string[];
   /** Per-gate verification status summary. */
   gateSummary: Record<ReleaseGateName, ReleaseGateExecutionStatus>;
+  /**
+   * Number of CLEO-native changeset entries (`.changeset/*.md`) rolled into
+   * this release. Zero when `.changeset/` is absent or empty.
+   *
+   * @task T9753
+   */
+  changesetEntryCount: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -647,6 +662,69 @@ async function upsertReleasesRow(
 }
 
 // ---------------------------------------------------------------------------
+// Helpers — CLEO-native changesets (T9753)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read parsed changeset entries from `<projectRoot>/.changeset/`.
+ *
+ * Returns an empty array when the directory is missing, when the directory has
+ * no `.md` files apart from `README.md`, or when parsing fails — failures are
+ * logged at warn level but never propagated, because changeset entries are
+ * advisory metadata, not a blocking precondition for the plan verb.
+ *
+ * @internal
+ * @task T9753
+ */
+function readChangesetEntries(projectRoot: string): ChangesetEntry[] {
+  const changesetDir = join(projectRoot, '.changeset');
+  if (!existsSync(changesetDir)) {
+    return [];
+  }
+  try {
+    return parseChangesetDir(changesetDir);
+  } catch (err: unknown) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), dir: changesetDir },
+      'parseChangesetDir failed during release plan — treating as zero entries',
+    );
+    return [];
+  }
+}
+
+/**
+ * Persist each parsed changeset entry into the `release_changesets` table.
+ *
+ * Idempotent re-runs of `cleo release plan` clear any prior rows for the same
+ * `release_id` before re-inserting so the row set is always in sync with the
+ * `.changeset/` directory state at plan time.
+ *
+ * @internal
+ * @task T9753
+ */
+async function persistReleaseChangesets(
+  releaseId: string,
+  entries: readonly ChangesetEntry[],
+  projectRoot: string,
+): Promise<void> {
+  const db = await getDb(projectRoot);
+  // Clear prior rows so a re-run is a clean overwrite, not an append.
+  await db.delete(releaseChangesets).where(eq(releaseChangesets.releaseId, releaseId)).run();
+  if (entries.length === 0) return;
+  const rows: NewReleaseChangesetRow[] = entries.map((entry) => ({
+    releaseId,
+    changesetId: entry.id,
+    taskIds: JSON.stringify(entry.tasks),
+    kind: entry.kind,
+    summary: entry.summary,
+    prs: entry.prs && entry.prs.length > 0 ? JSON.stringify(entry.prs) : null,
+    notes: entry.notes ?? null,
+    breaking: entry.breaking ?? null,
+  }));
+  await db.insert(releaseChangesets).values(rows).run();
+}
+
+// ---------------------------------------------------------------------------
 // Helpers — preflight summary
 // ---------------------------------------------------------------------------
 
@@ -785,6 +863,17 @@ export async function releasePlan(
   // ── R-305 / R-370: platform matrix ────────────────────────────────────
   const platformMatrix = enumeratePlatformMatrix(projectRoot);
 
+  // ── T9753: CLEO-native changesets — read + aggregate ────────────────
+  // Reads `.changeset/*.md` and aggregates into a CHANGELOG markdown section
+  // embedded under `meta.releaseNotes`. Failure is non-blocking (warn-and-skip)
+  // because changesets are advisory; the plan itself is built from task data.
+  const changesetEntries = readChangesetEntries(projectRoot);
+  const aggregated = aggregateChangesetsForRelease({
+    entries: changesetEntries,
+    version: normalizedVersion,
+    date: createdAt.slice(0, 10),
+  });
+
   // ── Assemble + validate the plan envelope ─────────────────────────────
   const changelog = buildChangelog(planTasks);
   const preflightSummary = assemblePreflightSummary(unresolved);
@@ -815,6 +904,11 @@ export async function releasePlan(
       firstEverRelease: prior.firstEverRelease,
       ...(unresolved.length > 0 ? { unresolvedTools: unresolved } : {}),
       archetype: 'node',
+      // T9753: aggregated CHANGELOG markdown from `.changeset/*.md` entries.
+      // Empty string when no entries — caller (changelog writer) can branch on
+      // length to decide whether to append a section.
+      releaseNotes: aggregated.markdown,
+      changesetEntryCount: aggregated.entryCount,
     },
   };
 
@@ -846,6 +940,20 @@ export async function releasePlan(
   } else {
     planPath = writePlanFile(plan, projectRoot);
     await upsertReleasesRow(plan, dbChannel, projectRoot);
+    // T9753: persist parsed changeset entries linked to the release row.
+    // Runs AFTER the releases UPSERT so the FK is satisfied. Errors here are
+    // logged but non-fatal — the plan file itself is the canonical source of
+    // truth; release_changesets is the structured side-table.
+    const projectInfo = getProjectInfoSync(projectRoot);
+    const releaseId = `${projectInfo?.projectHash ?? 'unknown'}:${plan.resolvedVersion}`;
+    try {
+      await persistReleaseChangesets(releaseId, changesetEntries, projectRoot);
+    } catch (err: unknown) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), releaseId },
+        'persistReleaseChangesets failed — plan envelope still written',
+      );
+    }
   }
 
   // ── Build the data envelope ───────────────────────────────────────────
@@ -872,6 +980,7 @@ export async function releasePlan(
     evidenceComplete,
     preflightWarnings: preflightSummary.preflightWarnings ?? [],
     gateSummary,
+    changesetEntryCount: aggregated.entryCount,
   };
 
   return engineSuccess(result);

--- a/packages/core/src/store/tasks-schema.ts
+++ b/packages/core/src/store/tasks-schema.ts
@@ -2139,6 +2139,67 @@ export const releaseChanges = sqliteTable(
 );
 
 /**
+ * `release_changesets` — Persistence layer for CLEO-native task-anchored
+ * changesets (T9738 carryforward → T9753).
+ *
+ * Each row records one `.changeset/*.md` entry that was rolled into the
+ * corresponding release plan by `cleo release plan`. The plan verb parses
+ * `.changeset/*.md` via {@link parseChangesetDir} (in
+ * `@cleocode/core/changesets`), persists one row per entry here, and then
+ * aggregates them into the CHANGELOG markdown section embedded into the
+ * release plan envelope.
+ *
+ * Differs from {@link releaseChanges} (T9508): `releaseChanges` is the
+ * editorial CHANGELOG bucket derived from commit-level analysis — one row per
+ * rendered bullet. `releaseChangesets` is the upstream-entry source — one row
+ * per `.changeset/*.md` file, carrying the structured frontmatter as-is so
+ * downstream renderers can re-aggregate without re-reading the markdown.
+ *
+ * `taskIds` / `prs` are JSON-encoded arrays. `notes` and `breaking` are
+ * nullable longer-form bodies preserved verbatim from the source entry.
+ *
+ * FK: `release_id → releases(id) ON DELETE CASCADE` — purging a release
+ * removes its changeset rows.
+ *
+ * @task T9753
+ * @epic T9752
+ */
+export const releaseChangesets = sqliteTable(
+  'release_changesets',
+  {
+    /** UUID primary key generated at insert time. */
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    /** FK → releases.id. ON DELETE CASCADE — purging a release removes its changeset rows. */
+    releaseId: text('release_id')
+      .notNull()
+      .references(() => releases.id, { onDelete: 'cascade' }),
+    /** Filename slug of the `.changeset/<slug>.md` file (matches `ChangesetEntry.id`). */
+    changesetId: text('changeset_id').notNull(),
+    /** JSON array of CLEO task IDs anchored by this changeset entry. */
+    taskIds: text('task_ids').notNull(),
+    /** Kind discriminator — mirrors {@link CHANGESET_KINDS} from `@cleocode/contracts`. */
+    kind: text('kind').notNull(),
+    /** User-facing one-liner summary lifted verbatim from the entry's `summary` field. */
+    summary: text('summary').notNull(),
+    /** JSON array of integer PR numbers, nullable. */
+    prs: text('prs'),
+    /** Markdown body — longer-form explanation from the source entry, nullable. */
+    notes: text('notes'),
+    /** Migration note when `kind = 'breaking'`, nullable. */
+    breaking: text('breaking'),
+    /** ISO-8601 timestamp when this row was inserted. */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index('release_changesets_release_id_idx').on(table.releaseId),
+    index('release_changesets_changeset_id_idx').on(table.changesetId),
+    index('release_changesets_kind_idx').on(table.kind),
+  ],
+);
+
+/**
  * Artifact type enum for {@link releaseArtifacts.artifactType}.
  *
  * Polymorphic: a single table covers all publishing archetypes. Adding a new
@@ -2390,6 +2451,9 @@ export type ReleaseCommitRow = typeof releaseCommits.$inferSelect;
 export type NewReleaseCommitRow = typeof releaseCommits.$inferInsert;
 export type ReleaseChangeRow = typeof releaseChanges.$inferSelect;
 export type NewReleaseChangeRow = typeof releaseChanges.$inferInsert;
+// T9753 release changesets (CLEO-native changesets aggregator)
+export type ReleaseChangesetRow = typeof releaseChangesets.$inferSelect;
+export type NewReleaseChangesetRow = typeof releaseChangesets.$inferInsert;
 // T9509 provenance graph row types (release_artifacts + brain_release_links)
 export type ReleaseArtifactRow = typeof releaseArtifacts.$inferSelect;
 export type NewReleaseArtifactRow = typeof releaseArtifacts.$inferInsert;


### PR DESCRIPTION
## Summary

- Aggregator (pure fn) in `@cleocode/core/release/changesets-aggregator` — groups `.changeset/*.md` entries by kind, floats breaking changes to the top, renders task ID / PR anchors.
- New `release_changesets` table + Drizzle binding + migration `20260520000000_t9753-release-changesets-table` (FK → `releases.id` ON DELETE CASCADE).
- `cleo release plan` wired to `parseChangesetDir` → `aggregateChangesetsForRelease` → `persistReleaseChangesets` → embed markdown into `plan.meta.releaseNotes`. Failures non-fatal (warn-and-skip) because changesets are advisory.
- 13 new tests: 8 aggregator unit tests + 5 plan×aggregator wiring tests.

T9738-A carryforward consuming the foundation shipped in #349.

## Test plan

- [x] `pnpm --filter @cleocode/core run build` — clean
- [x] `pnpm --filter @cleocode/core exec vitest run src/release/__tests__/changesets-aggregator.test.ts` — 8/8 pass
- [x] `pnpm --filter @cleocode/core exec vitest run src/release/__tests__/plan-aggregator-wiring.test.ts` — 5/5 pass
- [x] `pnpm --filter @cleocode/core exec vitest run src/release/__tests__/` — 230 pass / 2 skipped (no regressions)
- [x] `pnpm biome check --write` on touched files — clean
- [x] `node scripts/lint-project-root-anti-pattern.mjs --strict` — zero violations
- [x] `node scripts/lint-core-first.mjs --check` — no new violations above baseline
- [x] `node scripts/lint-migrations.mjs` — passes

## Notes

- Integration test filename had to avoid the `*-integration.test.ts` glob (excluded from default `pnpm run test`) — named `plan-aggregator-wiring.test.ts` so it runs in standard CI.
- `meta.releaseNotes` chosen over a new top-level field because `ReleasePlanMetaSchema` already has `catchall(z.unknown())` for forward-compat — no contracts change required.