### PR TITLE
fix(T9755): backfill legacy ship commits + re-enable merge_commit_sha FK

### DIFF
--- a/packages/core/migrations/drizzle-tasks/20260520163324_t9755-backfill-legacy-ship-commits/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260520163324_t9755-backfill-legacy-ship-commits/migration.sql
@@ -1,0 +1,607 @@
+-- T9755: Backfill legacy v5.x ship commits into the `commits` table and
+-- re-enable the `merge_commit_sha` FK on `releases`.
+--
+-- Background: PR #328 (T9686-B2 unify-releases-tables) RELAXED the FK from
+-- `releases.merge_commit_sha` → `commits.sha` from a hard REFERENCES to a
+-- soft text column. The reason: the unification migration copied ~16 legacy
+-- ship SHAs out of `release_manifests.commit_sha`, but those SHAs were not
+-- present in the `commits` table (the table was added in T9506 well after
+-- those releases were cut). A hard FK at copy time would have either
+-- nullified the SHA links or failed the migration.
+--
+-- The v5.88 CHANGELOG (T9686-B2 entry) flags re-enablement as a follow-up.
+-- This migration is that follow-up.
+--
+-- WHAT THIS MIGRATION DOES
+--
+--   Step 1: INSERT one `commits` row per legacy v5.80 → v5.88 ship/merge
+--           SHA referenced by `releases.merge_commit_sha`. Idempotent via
+--           ON CONFLICT(sha) DO NOTHING so re-applying the migration on a
+--           DB whose commits table already has these rows is a no-op.
+--
+--   Step 2: REBUILD `releases` with the hard FK back in place
+--           (`merge_commit_sha TEXT REFERENCES commits(sha) ON DELETE SET NULL`)
+--           via the standard SQLite create-new-table → copy → drop → rename
+--           dance (PRAGMA foreign_keys=OFF wraps the rebuild). Indexes are
+--           recreated to match the post-rebuild table.
+--
+-- WHY 18 ENTRIES INSTEAD OF 9
+--
+-- For each v5.80 → v5.88 release there are typically two relevant SHAs:
+--   - the canonical `release: ship vX.Y.Z ...` commit (always present), and
+--   - the PR merge commit `Merge pull request #N from .../release/vX.Y.Z`
+--     (present when shipped via a PR, missing only when the ship commit was
+--     pushed directly).
+--
+-- Both can appear in `releases.merge_commit_sha` depending on whether the
+-- row was written by the new release-publish workflow (which records the PR
+-- merge SHA) or by hand (which records the ship SHA). To make the FK
+-- restoration succeed for any historical row, we backfill both.
+--
+-- v5.86 is the hotfix release with subject prefix `release(T9739): ship ...`
+-- — this matches the same Conventional Commits `release` type as the
+-- standard form `release: ship ...` so `conventional_type` is `release`
+-- across all 18 rows.
+--
+-- The PR squash-merge entry for v5.88 (#352) uses subject `release: ship
+-- v2026.5.88 — T9738 IVTR remediation close (#352)` (Keaton Hoskins / GitHub
+-- committer) and has the ship commit `ebee726e5...` as its second parent.
+-- Both are inserted: the squash-merge as the canonical row used by
+-- release-publish, and the ship commit as the row used by anything that
+-- recorded the SHA before the PR was merged.
+--
+-- WHY ALL DATA INLINE
+--
+-- This migration MUST be self-contained — no runtime `git show` or
+-- subprocess execution. Migrations run on operator machines that may not
+-- have the cleocode repo cloned, or may have a shallow clone where these
+-- SHAs are unreachable. The 18 SHA → metadata mappings below are
+-- hand-extracted from `git show --format='%H|%s|%aN|%aE|%aI|%cI|%P'` on
+-- the cleocode repo at HEAD = 23dc2cc5e (v5.88 PR squash merge).
+--
+-- @task T9755
+-- @epic T9752
+-- @see /mnt/projects/cleocode/packages/core/migrations/drizzle-tasks/20260519010000_t9686b2-unify-releases-tables/migration.sql
+-- @see CHANGELOG.md (v2026.5.88 — T9686-B2 follow-up note)
+
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+
+-- ── Step 1: Backfill legacy v5.80 → v5.88 commits ─────────────────────────
+-- One INSERT per SHA. `is_release_commit = 1` for every row (all are ship
+-- or release-merge commits). `is_merge_commit = 1` only on PR-merge rows
+-- (those whose `parent_shas` JSON has 2 entries).
+
+-- v5.80 PR merge — Merge pull request #288 from kryptobaseddev/release/v2026.5.80
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '9f1eac565d44818f7c803e3327aaed4d5d830c67',
+  '9f1eac5',
+  'Keaton Hoskins',
+  '95310582+kryptobaseddev@users.noreply.github.com',
+  '2026-05-18T20:11:47-07:00',
+  'GitHub',
+  'noreply@github.com',
+  '2026-05-18T20:11:47-07:00',
+  'Merge pull request #288 from kryptobaseddev/release/v2026.5.80',
+  'Merge pull request #288 from kryptobaseddev/release/v2026.5.80',
+  'merge',
+  1,
+  1,
+  '["c63377fe8896079539eb7a81122a01e8b109686a","1e1f2302b1ad5ed764206f573b6ca07d638cfa5b"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.80 ship commit
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '1e1f2302b1ad5ed764206f573b6ca07d638cfa5b',
+  '1e1f230',
+  'kryptobaseddev',
+  'kryptobaseddev@users.noreply.github.com',
+  '2026-05-18T20:07:47-07:00',
+  'kryptobaseddev',
+  'kryptobaseddev@users.noreply.github.com',
+  '2026-05-18T20:07:47-07:00',
+  'release: ship v2026.5.80 — T9580 CLI dispatch fixes',
+  'release: ship v2026.5.80 — T9580 CLI dispatch fixes',
+  'release',
+  1,
+  0,
+  '["b2b82fa8982f06fd0a3b343050ce39c9ef0f8b95"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.81 PR merge — Merge pull request #298
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '572630ee6a54b94a904ae6c79a7a86fc3a5054b0',
+  '572630e',
+  'Keaton Hoskins',
+  '95310582+kryptobaseddev@users.noreply.github.com',
+  '2026-05-18T21:11:08-07:00',
+  'GitHub',
+  'noreply@github.com',
+  '2026-05-18T21:11:08-07:00',
+  'Merge pull request #298 from kryptobaseddev/release/v2026.5.81',
+  'Merge pull request #298 from kryptobaseddev/release/v2026.5.81',
+  'merge',
+  1,
+  1,
+  '["e330a47d2d9af28e50142dc18ca7eca07ed474a7","f2b2466bf9f5f53c5ab6f619a30490621c27e903"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.81 ship commit
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  'f2b2466bf9f5f53c5ab6f619a30490621c27e903',
+  'f2b2466',
+  'kryptobaseddev',
+  'kryptokeaton@gmail.com',
+  '2026-05-18T20:59:47-07:00',
+  'kryptobaseddev',
+  'kryptokeaton@gmail.com',
+  '2026-05-18T20:59:47-07:00',
+  'release: ship v2026.5.81 — T9580 closeout + post-ship cleanup',
+  'release: ship v2026.5.81 — T9580 closeout + post-ship cleanup',
+  'release',
+  1,
+  0,
+  '["6e748c5811e3ec4964cfebdfc09275145c325b15"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.82 PR merge — Merge pull request #307
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '101c0eb6f637cdc92165ade04ceef58f8f4dd014',
+  '101c0eb',
+  'Keaton Hoskins',
+  '95310582+kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T01:19:21-07:00',
+  'GitHub',
+  'noreply@github.com',
+  '2026-05-19T01:19:21-07:00',
+  'Merge pull request #307 from kryptobaseddev/release/v2026.5.82',
+  'Merge pull request #307 from kryptobaseddev/release/v2026.5.82',
+  'merge',
+  1,
+  1,
+  '["338290fd571c667bfbe4f46aa1bc9c5953c4c767","1386636d32bfd58d90d900e2636c02cc939025a8"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.82 ship commit
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '1386636d32bfd58d90d900e2636c02cc939025a8',
+  '1386636',
+  'kryptobaseddev',
+  'kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T01:09:53-07:00',
+  'kryptobaseddev',
+  'kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T01:09:53-07:00',
+  'release: ship v2026.5.82 — E-PROJECT-ROOT-AUDIT closure (T9580 epic)',
+  'release: ship v2026.5.82 — E-PROJECT-ROOT-AUDIT closure (T9580 epic)',
+  'release',
+  1,
+  0,
+  '["338290fd571c667bfbe4f46aa1bc9c5953c4c767"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.83 PR merge — Merge pull request #317
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '6607fc2cd09f0bd700bf6bdbcc7d7aac75873b4d',
+  '6607fc2',
+  'Keaton Hoskins',
+  '95310582+kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T11:11:41-07:00',
+  'GitHub',
+  'noreply@github.com',
+  '2026-05-19T11:11:41-07:00',
+  'Merge pull request #317 from kryptobaseddev/release/v2026.5.83',
+  'Merge pull request #317 from kryptobaseddev/release/v2026.5.83',
+  'merge',
+  1,
+  1,
+  '["ce026501fdaad08e80017f4a83eeb084c2be50e3","5638ac5f567a9420c9c18b356ed1640f4236f526"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.83 ship commit
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '5638ac5f567a9420c9c18b356ed1640f4236f526',
+  '5638ac5',
+  'kryptobaseddev',
+  'kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T10:55:05-07:00',
+  'kryptobaseddev',
+  'kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T10:55:05-07:00',
+  'release: ship v2026.5.83 — T9685 strict-mode flip',
+  'release: ship v2026.5.83 — T9685 strict-mode flip',
+  'release',
+  1,
+  0,
+  '["ce026501fdaad08e80017f4a83eeb084c2be50e3"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.84 PR merge — Merge pull request #329
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  'bd4bba8f654722a0e4ebd491bbb8b500cf8ae4d0',
+  'bd4bba8',
+  'Keaton Hoskins',
+  '95310582+kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T15:58:17-07:00',
+  'GitHub',
+  'noreply@github.com',
+  '2026-05-19T15:58:17-07:00',
+  'Merge pull request #329 from kryptobaseddev/release/v2026.5.84-ship',
+  'Merge pull request #329 from kryptobaseddev/release/v2026.5.84-ship',
+  'merge',
+  1,
+  1,
+  '["88d6fabcc5c94c4e67631f264d4547e1c538e10f","1867e9778f7c02807d543435dd6bd29fc89abddd"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.84 ship commit
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '1867e9778f7c02807d543435dd6bd29fc89abddd',
+  '1867e97',
+  'kryptobaseddev',
+  'kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T15:55:42-07:00',
+  'kryptobaseddev',
+  'kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T15:55:42-07:00',
+  'release: ship v2026.5.84 — SG-CLEO-SKILLS Sphere A close (T9560)',
+  'release: ship v2026.5.84 — SG-CLEO-SKILLS Sphere A close (T9560)',
+  'release',
+  1,
+  0,
+  '["88d6fabcc5c94c4e67631f264d4547e1c538e10f"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.85 PR merge — Merge pull request #339
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '856353ebe45a4904e461fe00f326bd83d863ded8',
+  '856353e',
+  'Keaton Hoskins',
+  '95310582+kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T22:59:47-07:00',
+  'GitHub',
+  'noreply@github.com',
+  '2026-05-19T22:59:47-07:00',
+  'Merge pull request #339 from kryptobaseddev/release/v2026.5.85-ship',
+  'Merge pull request #339 from kryptobaseddev/release/v2026.5.85-ship',
+  'merge',
+  1,
+  1,
+  '["7633add8c02bf8e01ba69631513bc2fa50d1c33d","018b2cd7d36c0edde68234544834d9bc076c08d8"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.85 ship commit
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '018b2cd7d36c0edde68234544834d9bc076c08d8',
+  '018b2cd',
+  'kryptobaseddev',
+  'kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T22:58:40-07:00',
+  'kryptobaseddev',
+  'kryptobaseddev@users.noreply.github.com',
+  '2026-05-19T22:58:40-07:00',
+  'release: ship v2026.5.85 — SG-CLEO-SKILLS Sphere B close + Sphere A follow-ups (T9560)',
+  'release: ship v2026.5.85 — SG-CLEO-SKILLS Sphere B close + Sphere A follow-ups (T9560)',
+  'release',
+  1,
+  0,
+  '["7633add8c02bf8e01ba69631513bc2fa50d1c33d"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.86 PR merge — Merge pull request #348 (hotfix)
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '85fa011fb08eb4e49f94be4ac92071e5b7f80b6e',
+  '85fa011',
+  'Keaton Hoskins',
+  '95310582+kryptobaseddev@users.noreply.github.com',
+  '2026-05-20T00:07:57-07:00',
+  'GitHub',
+  'noreply@github.com',
+  '2026-05-20T00:07:57-07:00',
+  'Merge pull request #348 from kryptobaseddev/release/v2026.5.86-hotfix',
+  'Merge pull request #348 from kryptobaseddev/release/v2026.5.86-hotfix',
+  'merge',
+  1,
+  1,
+  '["567cd12de0d23d37d09aaf98d95968a165f2b8d1","8a0a0131a536730a0017cf9de056d18f4a86e800"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.86 ship commit (hotfix, scoped `release(T9739)`)
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '8a0a0131a536730a0017cf9de056d18f4a86e800',
+  '8a0a013',
+  'kryptobaseddev',
+  'kryptokeaton@gmail.com',
+  '2026-05-20T00:06:56-07:00',
+  'kryptobaseddev',
+  'kryptokeaton@gmail.com',
+  '2026-05-20T00:06:56-07:00',
+  'release(T9739): ship v2026.5.86 — hotfix biome lint on generated command-manifest.ts (v2026.5.85 release workflow rescue)',
+  'release(T9739): ship v2026.5.86 — hotfix biome lint on generated command-manifest.ts (v2026.5.85 release workflow rescue)',
+  'release',
+  1,
+  0,
+  '["567cd12de0d23d37d09aaf98d95968a165f2b8d1"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.87 PR merge — Merge pull request #351
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '422ff7353365f7e3ab5b2e1b7ca824e0b486ded6',
+  '422ff73',
+  'Keaton Hoskins',
+  '95310582+kryptobaseddev@users.noreply.github.com',
+  '2026-05-20T00:31:56-07:00',
+  'GitHub',
+  'noreply@github.com',
+  '2026-05-20T00:31:56-07:00',
+  'Merge pull request #351 from kryptobaseddev/release/v2026.5.87-saga-t9625',
+  'Merge pull request #351 from kryptobaseddev/release/v2026.5.87-saga-t9625',
+  'merge',
+  1,
+  1,
+  '["de6c1cd9dc17af6ca53e8e3b91ef1883a4eee016","d36146b979ed0c50b4275400074188dabce79c86"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.87 ship commit
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  'd36146b979ed0c50b4275400074188dabce79c86',
+  'd36146b',
+  'kryptobaseddev',
+  'kryptokeaton@gmail.com',
+  '2026-05-20T00:19:14-07:00',
+  'kryptobaseddev',
+  'kryptokeaton@gmail.com',
+  '2026-05-20T00:19:14-07:00',
+  'release: ship v2026.5.87 — SG-CLEO-DOCS-CANON Saga close (T9625)',
+  'release: ship v2026.5.87 — SG-CLEO-DOCS-CANON Saga close (T9625)',
+  'release',
+  1,
+  0,
+  '["89c94a75f857c70b121610292a55064b9a7fe654"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.88 PR squash merge — release: ship v2026.5.88 ... (#352)
+-- NOTE: this is the PR squash-merge commit, NOT a `Merge pull request`-style
+-- merge. It still has 2 parents (the v5.87 PR merge and the ship commit).
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  '23dc2cc5e10176697f14f172c4ee5b94937fd7fc',
+  '23dc2cc',
+  'Keaton Hoskins',
+  '95310582+kryptobaseddev@users.noreply.github.com',
+  '2026-05-20T01:00:31-07:00',
+  'GitHub',
+  'noreply@github.com',
+  '2026-05-20T01:00:31-07:00',
+  'release: ship v2026.5.88 — T9738 IVTR remediation close (#352)',
+  'release: ship v2026.5.88 — T9738 IVTR remediation close (#352)',
+  'release',
+  1,
+  1,
+  '["812e380ce5fae1ec852793dd00c5683c135f416f","ebee726e5318d3cd7407310d0c44c0b53ead392b"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- v5.88 ship commit (the underlying squashed work)
+INSERT INTO `commits` (
+  `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`,
+  `committer_name`, `committer_email`, `committed_at`, `message`, `subject`,
+  `conventional_type`, `is_release_commit`, `is_merge_commit`, `parent_shas`
+) VALUES (
+  'ebee726e5318d3cd7407310d0c44c0b53ead392b',
+  'ebee726',
+  'kryptobaseddev',
+  'kryptokeaton@gmail.com',
+  '2026-05-20T00:50:34-07:00',
+  'kryptobaseddev',
+  'kryptokeaton@gmail.com',
+  '2026-05-20T00:50:34-07:00',
+  'release: ship v2026.5.88 — T9738 IVTR functional bug remediation close',
+  'release: ship v2026.5.88 — T9738 IVTR functional bug remediation close',
+  'release',
+  1,
+  0,
+  '["812e380ce5fae1ec852793dd00c5683c135f416f"]'
+)
+ON CONFLICT(`sha`) DO NOTHING;
+--> statement-breakpoint
+
+-- ── Step 2: Re-enable the `merge_commit_sha` FK via table rebuild ─────────
+-- SQLite can't ALTER a constraint in place; we rebuild the table with the
+-- hard FK and copy every row across. This mirrors the rebuild dance from
+-- T9686-B2 — same column set, same default values, same indexes — but
+-- ADDS BACK the `REFERENCES commits(sha) ON DELETE SET NULL` constraint
+-- that was dropped in Step 3 of that earlier migration.
+--
+-- All junction tables (release_commits, release_changes, release_artifacts,
+-- brain_release_links) reference `releases(id)` by name — they continue to
+-- resolve to the rebuilt table after RENAME.
+--
+-- Because PRAGMA foreign_keys=OFF wraps the entire migration, the copy
+-- succeeds even though some `merge_commit_sha` values may still be NULL or
+-- (transiently) reference commits not yet inserted on a partial backfill —
+-- when we PRAGMA foreign_keys=ON at the end, SQLite re-validates the FKs
+-- against the now-populated `commits` table.
+
+CREATE TABLE `releases_rebuilt` (
+  `id`                TEXT PRIMARY KEY NOT NULL,
+  `version`           TEXT NOT NULL UNIQUE,
+  `scheme`            TEXT NOT NULL DEFAULT 'calver',
+  `channel`           TEXT NOT NULL DEFAULT 'latest',
+  `epic_id`           TEXT REFERENCES `tasks`(`id`) ON DELETE SET NULL,
+  `release_kind`      TEXT NOT NULL DEFAULT 'regular',
+  `status`            TEXT NOT NULL DEFAULT 'planned',
+  `previous_version`  TEXT,
+  `merge_commit_sha`  TEXT REFERENCES `commits`(`sha`) ON DELETE SET NULL,  -- HARD FK restored (T9755)
+  `pr_id`             TEXT REFERENCES `pull_requests`(`id`) ON DELETE SET NULL,
+  `workflow_run_url`  TEXT,
+  `created_at`        TEXT NOT NULL DEFAULT (datetime('now')),
+  `planned_at`        TEXT,
+  `pr_opened_at`      TEXT,
+  `pr_merged_at`      TEXT,
+  `published_at`      TEXT,
+  `reconciled_at`     TEXT,
+  `rolled_back_at`    TEXT,
+  `failed_at`         TEXT,
+  `cancelled_at`      TEXT,
+  `failure_reason`    TEXT,
+  `rolled_back_by`    TEXT,
+  `project_hash`      TEXT,
+  -- Legacy columns merged in by T9686-B2 (preserved):
+  `tasks_json`        TEXT,
+  `changelog`         TEXT,
+  `notes`             TEXT,
+  `git_tag`           TEXT,
+  `prepared_at`       TEXT,
+  `committed_at`      TEXT,
+  `tagged_at`         TEXT,
+  `pushed_at`         TEXT
+);
+--> statement-breakpoint
+
+INSERT INTO `releases_rebuilt` (
+  `id`, `version`, `scheme`, `channel`, `epic_id`, `release_kind`, `status`,
+  `previous_version`, `merge_commit_sha`, `pr_id`, `workflow_run_url`,
+  `created_at`, `planned_at`, `pr_opened_at`, `pr_merged_at`, `published_at`,
+  `reconciled_at`, `rolled_back_at`, `failed_at`, `cancelled_at`,
+  `failure_reason`, `rolled_back_by`, `project_hash`,
+  `tasks_json`, `changelog`, `notes`, `git_tag`,
+  `prepared_at`, `committed_at`, `tagged_at`, `pushed_at`
+)
+SELECT
+  `id`, `version`, `scheme`, `channel`, `epic_id`, `release_kind`, `status`,
+  `previous_version`, `merge_commit_sha`, `pr_id`, `workflow_run_url`,
+  `created_at`, `planned_at`, `pr_opened_at`, `pr_merged_at`, `published_at`,
+  `reconciled_at`, `rolled_back_at`, `failed_at`, `cancelled_at`,
+  `failure_reason`, `rolled_back_by`, `project_hash`,
+  `tasks_json`, `changelog`, `notes`, `git_tag`,
+  `prepared_at`, `committed_at`, `tagged_at`, `pushed_at`
+FROM `releases`;
+--> statement-breakpoint
+
+DROP TABLE `releases`;
+--> statement-breakpoint
+
+ALTER TABLE `releases_rebuilt` RENAME TO `releases`;
+--> statement-breakpoint
+
+-- ── Step 3: Recreate indexes on the rebuilt table ─────────────────────────
+-- Same set as T9686-B2 Step 4 — drizzle's schema layer expects these by name.
+CREATE INDEX `idx_releases_version` ON `releases` (`version`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_status` ON `releases` (`status`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_channel` ON `releases` (`channel`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_epic_id` ON `releases` (`epic_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_merge_commit_sha` ON `releases` (`merge_commit_sha`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_project_hash` ON `releases` (`project_hash`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_published_at` ON `releases` (`published_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_pushed_at` ON `releases` (`pushed_at`);
+--> statement-breakpoint
+
+PRAGMA foreign_keys=ON;

--- a/packages/core/migrations/drizzle-tasks/20260520163324_t9755-backfill-legacy-ship-commits/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260520163324_t9755-backfill-legacy-ship-commits/revert.sql
@@ -1,0 +1,141 @@
+-- Revert T9755 — drop the `merge_commit_sha` FK on `releases` and DELETE
+-- the 18 backfilled commit rows.
+--
+-- This restores the post-T9686-B2 / pre-T9755 state:
+--   - `releases.merge_commit_sha` is a soft TEXT column with no FK
+--   - the 18 legacy v5.x ship/merge commits are absent from `commits`
+--
+-- Operators who downgrade past this point and then re-apply the migration
+-- will repopulate the same 18 rows (idempotent via ON CONFLICT DO NOTHING).
+--
+-- Backfilled SHAs (for auditability — these are the rows DELETEd below):
+--   v5.80 PR merge:  9f1eac565d44818f7c803e3327aaed4d5d830c67
+--   v5.80 ship:      1e1f2302b1ad5ed764206f573b6ca07d638cfa5b
+--   v5.81 PR merge:  572630ee6a54b94a904ae6c79a7a86fc3a5054b0
+--   v5.81 ship:      f2b2466bf9f5f53c5ab6f619a30490621c27e903
+--   v5.82 PR merge:  101c0eb6f637cdc92165ade04ceef58f8f4dd014
+--   v5.82 ship:      1386636d32bfd58d90d900e2636c02cc939025a8
+--   v5.83 PR merge:  6607fc2cd09f0bd700bf6bdbcc7d7aac75873b4d
+--   v5.83 ship:      5638ac5f567a9420c9c18b356ed1640f4236f526
+--   v5.84 PR merge:  bd4bba8f654722a0e4ebd491bbb8b500cf8ae4d0
+--   v5.84 ship:      1867e9778f7c02807d543435dd6bd29fc89abddd
+--   v5.85 PR merge:  856353ebe45a4904e461fe00f326bd83d863ded8
+--   v5.85 ship:      018b2cd7d36c0edde68234544834d9bc076c08d8
+--   v5.86 PR merge:  85fa011fb08eb4e49f94be4ac92071e5b7f80b6e
+--   v5.86 ship:      8a0a0131a536730a0017cf9de056d18f4a86e800
+--   v5.87 PR merge:  422ff7353365f7e3ab5b2e1b7ca824e0b486ded6
+--   v5.87 ship:      d36146b979ed0c50b4275400074188dabce79c86
+--   v5.88 PR squash: 23dc2cc5e10176697f14f172c4ee5b94937fd7fc
+--   v5.88 ship:      ebee726e5318d3cd7407310d0c44c0b53ead392b
+--
+-- @task T9755
+
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+
+-- ── Step 1: Re-drop the FK via table rebuild ──────────────────────────────
+-- This is the inverse of migration.sql Step 2 — recreate the table WITHOUT
+-- the merge_commit_sha REFERENCES clause, then copy + drop + rename.
+CREATE TABLE `releases_rebuilt` (
+  `id`                TEXT PRIMARY KEY NOT NULL,
+  `version`           TEXT NOT NULL UNIQUE,
+  `scheme`            TEXT NOT NULL DEFAULT 'calver',
+  `channel`           TEXT NOT NULL DEFAULT 'latest',
+  `epic_id`           TEXT REFERENCES `tasks`(`id`) ON DELETE SET NULL,
+  `release_kind`      TEXT NOT NULL DEFAULT 'regular',
+  `status`            TEXT NOT NULL DEFAULT 'planned',
+  `previous_version`  TEXT,
+  `merge_commit_sha`  TEXT,                       -- soft FK restored (revert of T9755)
+  `pr_id`             TEXT REFERENCES `pull_requests`(`id`) ON DELETE SET NULL,
+  `workflow_run_url`  TEXT,
+  `created_at`        TEXT NOT NULL DEFAULT (datetime('now')),
+  `planned_at`        TEXT,
+  `pr_opened_at`      TEXT,
+  `pr_merged_at`      TEXT,
+  `published_at`      TEXT,
+  `reconciled_at`     TEXT,
+  `rolled_back_at`    TEXT,
+  `failed_at`         TEXT,
+  `cancelled_at`      TEXT,
+  `failure_reason`    TEXT,
+  `rolled_back_by`    TEXT,
+  `project_hash`      TEXT,
+  `tasks_json`        TEXT,
+  `changelog`         TEXT,
+  `notes`             TEXT,
+  `git_tag`           TEXT,
+  `prepared_at`       TEXT,
+  `committed_at`      TEXT,
+  `tagged_at`         TEXT,
+  `pushed_at`         TEXT
+);
+--> statement-breakpoint
+
+INSERT INTO `releases_rebuilt` (
+  `id`, `version`, `scheme`, `channel`, `epic_id`, `release_kind`, `status`,
+  `previous_version`, `merge_commit_sha`, `pr_id`, `workflow_run_url`,
+  `created_at`, `planned_at`, `pr_opened_at`, `pr_merged_at`, `published_at`,
+  `reconciled_at`, `rolled_back_at`, `failed_at`, `cancelled_at`,
+  `failure_reason`, `rolled_back_by`, `project_hash`,
+  `tasks_json`, `changelog`, `notes`, `git_tag`,
+  `prepared_at`, `committed_at`, `tagged_at`, `pushed_at`
+)
+SELECT
+  `id`, `version`, `scheme`, `channel`, `epic_id`, `release_kind`, `status`,
+  `previous_version`, `merge_commit_sha`, `pr_id`, `workflow_run_url`,
+  `created_at`, `planned_at`, `pr_opened_at`, `pr_merged_at`, `published_at`,
+  `reconciled_at`, `rolled_back_at`, `failed_at`, `cancelled_at`,
+  `failure_reason`, `rolled_back_by`, `project_hash`,
+  `tasks_json`, `changelog`, `notes`, `git_tag`,
+  `prepared_at`, `committed_at`, `tagged_at`, `pushed_at`
+FROM `releases`;
+--> statement-breakpoint
+
+DROP TABLE `releases`;
+--> statement-breakpoint
+
+ALTER TABLE `releases_rebuilt` RENAME TO `releases`;
+--> statement-breakpoint
+
+-- Recreate the same indexes the migration set up.
+CREATE INDEX `idx_releases_version` ON `releases` (`version`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_status` ON `releases` (`status`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_channel` ON `releases` (`channel`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_epic_id` ON `releases` (`epic_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_merge_commit_sha` ON `releases` (`merge_commit_sha`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_project_hash` ON `releases` (`project_hash`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_published_at` ON `releases` (`published_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_releases_pushed_at` ON `releases` (`pushed_at`);
+--> statement-breakpoint
+
+-- ── Step 2: DELETE the 18 backfilled commit rows ──────────────────────────
+DELETE FROM `commits` WHERE `sha` IN (
+  '9f1eac565d44818f7c803e3327aaed4d5d830c67',
+  '1e1f2302b1ad5ed764206f573b6ca07d638cfa5b',
+  '572630ee6a54b94a904ae6c79a7a86fc3a5054b0',
+  'f2b2466bf9f5f53c5ab6f619a30490621c27e903',
+  '101c0eb6f637cdc92165ade04ceef58f8f4dd014',
+  '1386636d32bfd58d90d900e2636c02cc939025a8',
+  '6607fc2cd09f0bd700bf6bdbcc7d7aac75873b4d',
+  '5638ac5f567a9420c9c18b356ed1640f4236f526',
+  'bd4bba8f654722a0e4ebd491bbb8b500cf8ae4d0',
+  '1867e9778f7c02807d543435dd6bd29fc89abddd',
+  '856353ebe45a4904e461fe00f326bd83d863ded8',
+  '018b2cd7d36c0edde68234544834d9bc076c08d8',
+  '85fa011fb08eb4e49f94be4ac92071e5b7f80b6e',
+  '8a0a0131a536730a0017cf9de056d18f4a86e800',
+  '422ff7353365f7e3ab5b2e1b7ca824e0b486ded6',
+  'd36146b979ed0c50b4275400074188dabce79c86',
+  '23dc2cc5e10176697f14f172c4ee5b94937fd7fc',
+  'ebee726e5318d3cd7407310d0c44c0b53ead392b'
+);
+--> statement-breakpoint
+
+PRAGMA foreign_keys=ON;

--- a/packages/core/src/release/__tests__/backfill.test.ts
+++ b/packages/core/src/release/__tests__/backfill.test.ts
@@ -41,6 +41,14 @@ const { DatabaseSync } = _require('node:sqlite') as {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+/**
+ * Number of legacy v5.x ship/merge commits backfilled by the T9755 migration
+ * (`20260520163324_t9755-backfill-legacy-ship-commits`). Every fresh tasks.db
+ * starts with these rows already in the `commits` table, so tests that assert
+ * absolute counts must shift by this baseline.
+ */
+const LEGACY_BACKFILL_COMMIT_COUNT = 18;
+
 /** Resolve path to the drizzle-tasks migrations folder. */
 function migrationsDir(): string {
   return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
@@ -370,7 +378,10 @@ describe('provenanceBackfill — Phase 2 (T9528)', () => {
 
     // Zero releases written.
     expect(await countRows(projectRoot, 'releases')).toBe(0);
-    expect(await countRows(projectRoot, 'commits')).toBe(0);
+    // The T9755 migration backfills LEGACY_BACKFILL_COMMIT_COUNT legacy ship
+    // commits on every fresh DB; the dry-run walks tags but writes no new
+    // commits, so the count stays at exactly the baked-in baseline.
+    expect(await countRows(projectRoot, 'commits')).toBe(LEGACY_BACKFILL_COMMIT_COUNT);
   });
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/release/__tests__/commits-backfill.test.ts
+++ b/packages/core/src/release/__tests__/commits-backfill.test.ts
@@ -1,0 +1,383 @@
+/**
+ * T9755 backfill migration — regression lock.
+ *
+ * Locks the invariants of the
+ * `20260520163324_t9755-backfill-legacy-ship-commits` migration:
+ *
+ *   1. Applying the migration on an empty `tasks.db` inserts all 18
+ *      backfill rows into `commits`.
+ *   2. The migration is idempotent — re-running it via raw INSERTs is a
+ *      no-op (ON CONFLICT(sha) DO NOTHING) and never duplicates rows.
+ *   3. After the migration the `merge_commit_sha` FK is hard again:
+ *      inserting a `releases` row whose `merge_commit_sha` does NOT
+ *      exist in `commits` fails with a SQLite FK constraint error.
+ *   4. Inserting a `releases` row whose `merge_commit_sha` references one
+ *      of the backfilled SHAs succeeds.
+ *   5. Idempotent re-apply of the FULL migration (commits inserts + table
+ *      rebuild) does not duplicate `commits` rows.
+ *
+ * The migration is loaded from disk and split on
+ * `--> statement-breakpoint` exactly the way drizzle's runner does in
+ * production (mirrored from `unify-migration.test.ts`).
+ *
+ * @task T9755
+ * @epic T9752
+ */
+
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (path: string) => import('node:sqlite').DatabaseSync;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Resolve the drizzle-tasks migrations folder.
+ *
+ * @internal
+ */
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+/**
+ * The 18 SHAs the T9755 migration backfills. Used by the "all rows present"
+ * and "idempotent" assertions.
+ *
+ * @internal
+ */
+const BACKFILLED_SHAS: ReadonlyArray<string> = [
+  '9f1eac565d44818f7c803e3327aaed4d5d830c67',
+  '1e1f2302b1ad5ed764206f573b6ca07d638cfa5b',
+  '572630ee6a54b94a904ae6c79a7a86fc3a5054b0',
+  'f2b2466bf9f5f53c5ab6f619a30490621c27e903',
+  '101c0eb6f637cdc92165ade04ceef58f8f4dd014',
+  '1386636d32bfd58d90d900e2636c02cc939025a8',
+  '6607fc2cd09f0bd700bf6bdbcc7d7aac75873b4d',
+  '5638ac5f567a9420c9c18b356ed1640f4236f526',
+  'bd4bba8f654722a0e4ebd491bbb8b500cf8ae4d0',
+  '1867e9778f7c02807d543435dd6bd29fc89abddd',
+  '856353ebe45a4904e461fe00f326bd83d863ded8',
+  '018b2cd7d36c0edde68234544834d9bc076c08d8',
+  '85fa011fb08eb4e49f94be4ac92071e5b7f80b6e',
+  '8a0a0131a536730a0017cf9de056d18f4a86e800',
+  '422ff7353365f7e3ab5b2e1b7ca824e0b486ded6',
+  'd36146b979ed0c50b4275400074188dabce79c86',
+  '23dc2cc5e10176697f14f172c4ee5b94937fd7fc',
+  'ebee726e5318d3cd7407310d0c44c0b53ead392b',
+] as const;
+
+/**
+ * Apply the pre-T9755 schema for `commits` + `releases` + their
+ * dependencies. This matches the production state at HEAD of `main` AFTER
+ * T9686-B2 ran but BEFORE T9755 ran — i.e. `commits` exists (empty),
+ * `releases` exists with the soft `merge_commit_sha` text column (no FK).
+ *
+ * Mirrors the snapshot approach used by `unify-migration.test.ts` to keep
+ * the test stable against unrelated DDL drift in the 50+ unrelated
+ * migrations.
+ *
+ * @internal
+ */
+function applySchemaBeforeBackfill(dbPath: string): import('node:sqlite').DatabaseSync {
+  const nativeDb = new DatabaseSync(dbPath);
+  const preBackfillDdl = `
+    PRAGMA foreign_keys=ON;
+
+    CREATE TABLE tasks (id TEXT PRIMARY KEY);
+    CREATE TABLE pull_requests (id TEXT PRIMARY KEY);
+
+    -- Post-T9506 \`commits\` shape (matches migration
+    -- 20260517000000_t9506-add-commits-table/migration.sql verbatim).
+    CREATE TABLE commits (
+      sha                TEXT PRIMARY KEY NOT NULL,
+      short_sha          TEXT NOT NULL,
+      author_name        TEXT,
+      author_email       TEXT,
+      authored_at        TEXT NOT NULL,
+      committer_name     TEXT,
+      committer_email    TEXT,
+      committed_at       TEXT NOT NULL,
+      message            TEXT NOT NULL,
+      subject            TEXT NOT NULL,
+      conventional_type  TEXT,
+      is_release_commit  INTEGER NOT NULL DEFAULT 0,
+      is_merge_commit    INTEGER NOT NULL DEFAULT 0,
+      parent_shas        TEXT NOT NULL DEFAULT '[]',
+      signature_verified INTEGER,
+      branch_at_commit   TEXT,
+      project_hash       TEXT,
+      created_at         TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    -- Post-T9686-B2 \`releases\` shape: merge_commit_sha is a soft TEXT
+    -- column with NO foreign key — exactly what T9755 must replace.
+    CREATE TABLE releases (
+      id                TEXT PRIMARY KEY NOT NULL,
+      version           TEXT NOT NULL UNIQUE,
+      scheme            TEXT NOT NULL DEFAULT 'calver',
+      channel           TEXT NOT NULL DEFAULT 'latest',
+      epic_id           TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+      release_kind      TEXT NOT NULL DEFAULT 'regular',
+      status            TEXT NOT NULL DEFAULT 'planned',
+      previous_version  TEXT,
+      merge_commit_sha  TEXT,
+      pr_id             TEXT REFERENCES pull_requests(id) ON DELETE SET NULL,
+      workflow_run_url  TEXT,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      planned_at        TEXT,
+      pr_opened_at      TEXT,
+      pr_merged_at      TEXT,
+      published_at      TEXT,
+      reconciled_at     TEXT,
+      rolled_back_at    TEXT,
+      failed_at         TEXT,
+      cancelled_at      TEXT,
+      failure_reason    TEXT,
+      rolled_back_by    TEXT,
+      project_hash      TEXT,
+      tasks_json        TEXT,
+      changelog         TEXT,
+      notes             TEXT,
+      git_tag           TEXT,
+      prepared_at       TEXT,
+      committed_at      TEXT,
+      tagged_at         TEXT,
+      pushed_at         TEXT
+    );
+
+    CREATE INDEX idx_releases_version ON releases (version);
+    CREATE INDEX idx_releases_status ON releases (status);
+    CREATE INDEX idx_releases_channel ON releases (channel);
+    CREATE INDEX idx_releases_epic_id ON releases (epic_id);
+    CREATE INDEX idx_releases_merge_commit_sha ON releases (merge_commit_sha);
+    CREATE INDEX idx_releases_project_hash ON releases (project_hash);
+    CREATE INDEX idx_releases_published_at ON releases (published_at);
+    CREATE INDEX idx_releases_pushed_at ON releases (pushed_at);
+  `;
+  nativeDb.exec(preBackfillDdl);
+  return nativeDb;
+}
+
+/**
+ * Apply the T9755 backfill migration to the supplied DB by splitting the
+ * SQL on `--> statement-breakpoint` and exec'ing each chunk. Mirrors the
+ * production runner's behaviour exactly (see drizzle-orm/migrator).
+ *
+ * @internal
+ */
+function applyBackfillMigration(nativeDb: import('node:sqlite').DatabaseSync): void {
+  const sqlPath = join(
+    migrationsDir(),
+    '20260520163324_t9755-backfill-legacy-ship-commits',
+    'migration.sql',
+  );
+  const sql = execSync(`cat ${sqlPath}`, { encoding: 'utf-8' });
+  const statements = sql.split('--> statement-breakpoint');
+  for (const stmt of statements) {
+    const trimmed = stmt.trim();
+    if (!trimmed) continue;
+    nativeDb.exec(trimmed);
+  }
+}
+
+describe('T9755 backfill-legacy-ship-commits migration', () => {
+  let tempDir: string;
+  let nativeDb: import('node:sqlite').DatabaseSync;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-t9755-mig-'));
+    nativeDb = applySchemaBeforeBackfill(join(tempDir, 'tasks.db'));
+  });
+
+  afterEach(() => {
+    try {
+      nativeDb.close();
+    } catch {
+      // already closed
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('inserts all 18 backfill rows into `commits` on first apply', () => {
+    applyBackfillMigration(nativeDb);
+
+    const count = (nativeDb.prepare('SELECT COUNT(*) AS n FROM commits').get() as { n: number }).n;
+    expect(count).toBe(BACKFILLED_SHAS.length);
+
+    const shas = (
+      nativeDb.prepare('SELECT sha FROM commits ORDER BY sha').all() as Array<{ sha: string }>
+    ).map((r) => r.sha);
+    expect(shas.sort()).toEqual([...BACKFILLED_SHAS].sort());
+  });
+
+  it('flags every backfilled row as a release commit', () => {
+    applyBackfillMigration(nativeDb);
+
+    const nonRelease = (
+      nativeDb.prepare('SELECT COUNT(*) AS n FROM commits WHERE is_release_commit = 0').get() as {
+        n: number;
+      }
+    ).n;
+    expect(nonRelease).toBe(0);
+  });
+
+  it('marks the 9 PR-merge / squash-merge rows as merge commits', () => {
+    applyBackfillMigration(nativeDb);
+
+    // PR merge commits and the v5.88 squash-merge — every row whose
+    // parent_shas JSON array has 2 entries (and conventional_type=merge OR
+    // is_merge_commit=1).
+    const mergeCount = (
+      nativeDb.prepare('SELECT COUNT(*) AS n FROM commits WHERE is_merge_commit = 1').get() as {
+        n: number;
+      }
+    ).n;
+    expect(mergeCount).toBe(9);
+  });
+
+  it('is idempotent — replaying ONLY the INSERT statements is a no-op', () => {
+    applyBackfillMigration(nativeDb);
+    const firstCount = (
+      nativeDb.prepare('SELECT COUNT(*) AS n FROM commits').get() as { n: number }
+    ).n;
+
+    // Re-run just the INSERT block (ON CONFLICT DO NOTHING is the
+    // idempotency guarantee). We splice out the table-rebuild block
+    // because dropping + recreating the table is not idempotent on its
+    // own — only Drizzle's journal makes the whole migration idempotent
+    // at the runner level. We're testing the INSERT idempotency only.
+    const sqlPath = join(
+      migrationsDir(),
+      '20260520163324_t9755-backfill-legacy-ship-commits',
+      'migration.sql',
+    );
+    const sql = execSync(`cat ${sqlPath}`, { encoding: 'utf-8' });
+    const statements = sql.split('--> statement-breakpoint');
+    for (const stmt of statements) {
+      const trimmed = stmt.trim();
+      if (!trimmed) continue;
+      // Only re-run the INSERT INTO commits statements.
+      if (trimmed.startsWith('INSERT INTO `commits`')) {
+        nativeDb.exec(trimmed);
+      }
+    }
+
+    const secondCount = (
+      nativeDb.prepare('SELECT COUNT(*) AS n FROM commits').get() as { n: number }
+    ).n;
+    expect(secondCount).toBe(firstCount);
+    expect(secondCount).toBe(BACKFILLED_SHAS.length);
+  });
+
+  it('re-enables the merge_commit_sha FK (insert with unknown SHA fails)', () => {
+    applyBackfillMigration(nativeDb);
+
+    // After the migration, FKs are re-enabled (final PRAGMA in migration.sql).
+    // Inserting a `releases` row whose merge_commit_sha doesn't exist in
+    // `commits` MUST fail.
+    expect(() => {
+      nativeDb.exec(`
+        INSERT INTO releases (id, version, status, merge_commit_sha, created_at)
+        VALUES ('test:v0.0.1', 'v0.0.1', 'planned', 'deadbeef0000000000000000000000000000beef', '2026-05-20T00:00:00Z');
+      `);
+    }).toThrow(/foreign key/i);
+  });
+
+  it('accepts a releases row whose merge_commit_sha matches a backfilled commit', () => {
+    applyBackfillMigration(nativeDb);
+
+    // v5.88 PR squash-merge SHA — should be present in `commits` post-migration.
+    nativeDb.exec(`
+      INSERT INTO releases (id, version, status, merge_commit_sha, created_at)
+      VALUES (
+        'hash1:v2026.5.88',
+        'v2026.5.88',
+        'reconciled',
+        '23dc2cc5e10176697f14f172c4ee5b94937fd7fc',
+        '2026-05-20T01:00:31Z'
+      );
+    `);
+
+    const row = nativeDb
+      .prepare("SELECT id, merge_commit_sha FROM releases WHERE version = 'v2026.5.88'")
+      .get() as { id: string; merge_commit_sha: string };
+    expect(row).toMatchObject({
+      id: 'hash1:v2026.5.88',
+      merge_commit_sha: '23dc2cc5e10176697f14f172c4ee5b94937fd7fc',
+    });
+  });
+
+  it('preserves pre-existing releases rows across the table rebuild', () => {
+    // Seed a legacy `legacy:vX` row whose merge_commit_sha points at one of
+    // the SHAs that this migration will backfill. The rebuild must copy
+    // it across without changing its values (and without an FK violation
+    // because the migration inserts commits BEFORE rebuilding the table).
+    nativeDb.exec(`
+      INSERT INTO releases (id, version, scheme, channel, status, merge_commit_sha, tasks_json, created_at)
+      VALUES (
+        'legacy:v2026.5.80',
+        'v2026.5.80',
+        'calver',
+        'latest',
+        'pushed',
+        '1e1f2302b1ad5ed764206f573b6ca07d638cfa5b',
+        '["T9580"]',
+        '2026-05-18T20:07:47Z'
+      );
+    `);
+
+    applyBackfillMigration(nativeDb);
+
+    const row = nativeDb
+      .prepare(
+        "SELECT id, status, merge_commit_sha, tasks_json FROM releases WHERE version = 'v2026.5.80'",
+      )
+      .get() as { id: string; status: string; merge_commit_sha: string; tasks_json: string };
+    expect(row).toMatchObject({
+      id: 'legacy:v2026.5.80',
+      status: 'pushed',
+      merge_commit_sha: '1e1f2302b1ad5ed764206f573b6ca07d638cfa5b',
+      tasks_json: '["T9580"]',
+    });
+  });
+
+  it('preserves pre-existing releases rows whose merge_commit_sha is NULL', () => {
+    // Releases that never recorded a merge_commit_sha (e.g. cancelled
+    // planning rows) must survive the rebuild — the FK is ON DELETE SET NULL
+    // and the column is nullable.
+    nativeDb.exec(`
+      INSERT INTO releases (id, version, status, created_at)
+      VALUES ('hash1:v2026.6.99', 'v2026.6.99', 'cancelled', '2026-06-01T00:00:00Z');
+    `);
+
+    applyBackfillMigration(nativeDb);
+
+    const row = nativeDb
+      .prepare("SELECT id, status, merge_commit_sha FROM releases WHERE version = 'v2026.6.99'")
+      .get() as { id: string; status: string; merge_commit_sha: string | null };
+    expect(row).toMatchObject({
+      id: 'hash1:v2026.6.99',
+      status: 'cancelled',
+      merge_commit_sha: null,
+    });
+  });
+});

--- a/packages/core/src/release/__tests__/reconcile-v2.test.ts
+++ b/packages/core/src/release/__tests__/reconcile-v2.test.ts
@@ -45,6 +45,14 @@ const { DatabaseSync } = _require('node:sqlite') as {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+/**
+ * Number of legacy v5.x ship/merge commits backfilled by the T9755 migration
+ * (`20260520163324_t9755-backfill-legacy-ship-commits`). Every fresh tasks.db
+ * starts with these rows already in the `commits` table, so tests that assert
+ * absolute counts must shift by this baseline.
+ */
+const LEGACY_BACKFILL_COMMIT_COUNT = 18;
+
 /** Resolve path to the drizzle-tasks migrations folder. */
 function migrationsDir(): string {
   return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
@@ -315,8 +323,13 @@ describe('releaseReconcileV2 — Phase 1 (T9526)', () => {
     expect(result.data.artifactCount).toBe(1);
     expect(result.data.orphanCommits).toHaveLength(0);
 
-    // Verify table populations
-    expect(await countRows(projectRoot, 'commits')).toBe(2);
+    // Verify table populations. The T9755 migration backfills
+    // LEGACY_BACKFILL_COMMIT_COUNT legacy ship commits into the `commits`
+    // table on init; the 2 commits written by this reconcile sit on top of
+    // that baseline. `task_commits` is NOT touched by the backfill — none
+    // of the legacy SHAs carry T#### tokens that would seed task_commits —
+    // so its count remains a clean 2.
+    expect(await countRows(projectRoot, 'commits')).toBe(LEGACY_BACKFILL_COMMIT_COUNT + 2);
     expect(await countRows(projectRoot, 'commit_files')).toBeGreaterThanOrEqual(2);
     expect(await countRows(projectRoot, 'task_commits')).toBe(2);
     expect(await countRows(projectRoot, 'releases')).toBe(1);

--- a/packages/core/src/store/tasks-schema.ts
+++ b/packages/core/src/store/tasks-schema.ts
@@ -1924,12 +1924,17 @@ export const releases = sqliteTable(
      * at pr-merged time). For legacy-migrated rows this is the ship commit
      * from the legacy `release_manifests.commit_sha` column.
      *
-     * SOFT FK only (T9686-B2): the prior hard FK to `commits(sha)` was dropped
-     * because legacy ship SHAs are not present in the `commits` table. A
-     * follow-up task may backfill `commits` rows for legacy ship SHAs and
-     * re-add the FK.
+     * HARD FK to `commits(sha)` ON DELETE SET NULL (T9755): T9686-B2 had
+     * dropped this FK because legacy ship SHAs were not present in the
+     * `commits` table; T9755 backfilled rows for every v5.80–v5.88 ship
+     * and PR-merge commit referenced by `releases`, then rebuilt this
+     * table with the FK restored. New ship rows continue to satisfy the
+     * FK because release-publish writes `commits` rows during the
+     * provenance reconcile step before inserting the `releases` row.
      */
-    mergeCommitSha: text('merge_commit_sha'),
+    mergeCommitSha: text('merge_commit_sha').references(() => commits.sha, {
+      onDelete: 'set null',
+    }),
     /**
      * FK → pull_requests.id (ON DELETE SET NULL). The bump-PR opened by `cleo release open`.
      * Always NULL on legacy migrated rows (legacy pipeline pre-dated `pull_requests`).


### PR DESCRIPTION
## Summary

T9738-C carryforward closure. PR #328 (T9686-B2 unify-releases-tables) relaxed the FK from `releases.merge_commit_sha` → `commits.sha` because legacy ship SHAs were not tracked in the `commits` table. The v5.88 CHANGELOG flagged re-enablement as a follow-up — this PR is that follow-up.

- **Backfills 18 legacy v5.x ship/PR-merge commit rows** into `commits` for v5.80 → v5.88 (9 ship commits + 8 PR-merge commits + 1 PR squash-merge), idempotent via `ON CONFLICT(sha) DO NOTHING`.
- **Re-enables the hard `merge_commit_sha` FK** via SQLite create-new-table → copy → drop → rename rebuild (mirrors the T9686-B2 rebuild pattern).
- **Updates the drizzle schema** so `releases.mergeCommitSha` re-declares `.references(() => commits.sha, { onDelete: 'set null' })`.

All 16 SHA values are inline in the migration (extracted from `git show --format='%H|%s|%aN|%aE|%aI|%cI|%P'` at HEAD = 23dc2cc5e). No runtime git calls — migration is deterministic and reproducible on any operator machine.

## Test plan

- [x] `pnpm install` + `pnpm --filter @cleocode/contracts run build` + `pnpm --filter @cleocode/core run build` — pass
- [x] `pnpm biome check --write packages/core/src/release packages/core/src/store packages/core/migrations` — pass
- [x] `pnpm --filter @cleocode/core run test src/release/__tests__/commits-backfill` — 8/8 pass
- [x] `pnpm --filter @cleocode/core run test src/release/__tests__/unify-migration src/store/__tests__/commits-schema-parity` — 31/31 pass (no regression in related migration tests)
- [x] `pnpm --filter @cleocode/core run test src/store/__tests__/migration-smoke` — 19/19 pass (full migration chain still applies cleanly)
- [x] `node scripts/lint-project-root-anti-pattern.mjs --strict` — STRICT OK
- [x] `node scripts/lint-core-first.mjs --check` — PASS (baseline 87)

## Files

- `packages/core/migrations/drizzle-tasks/20260520163324_t9755-backfill-legacy-ship-commits/migration.sql` (new)
- `packages/core/migrations/drizzle-tasks/20260520163324_t9755-backfill-legacy-ship-commits/revert.sql` (new)
- `packages/core/src/release/__tests__/commits-backfill.test.ts` (new, 8 cases)
- `packages/core/src/store/tasks-schema.ts` (FK re-declared on `mergeCommitSha`)

Refs: Epic T9752 (T9738 carryforward closure)