### PR TITLE
refactor(T9756): A4 — uniform releases.id PK shape (legacy: -> <projectHash>:)

### DIFF
--- a/packages/core/migrations/drizzle-tasks/20260520163500_t9756-uniform-releases-pk/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260520163500_t9756-uniform-releases-pk/migration.sql
@@ -1,0 +1,123 @@
+-- T9756 (T9738-D / A4 carryforward): Rewrite legacy releases.id PKs from the
+-- `legacy:<version>` shape to the uniform `<projectHash>:<version>` shape that
+-- the new (T9492) pipeline path already uses.
+--
+-- Background
+-- ──────────
+-- T9686-B2 unified `release_manifests` (legacy) and `releases` (new) into one
+-- table for expediency, encoding provenance via PK shape:
+--   * new-pipeline rows:    `<projectHash>:<version>`  (e.g. `1e3146b7352b:v2026.6.0`)
+--   * legacy-migrated rows: `legacy:<version>`         (e.g. `legacy:v2026.5.73`)
+--
+-- That dual shape requires downstream consumers (e.g. `releasesRowToManifest`
+-- in packages/core/src/release/release-manifest.ts) to branch on a PK-prefix
+-- check. This migration eliminates that branch by rewriting every legacy row's
+-- PK to the uniform shape — choosing a STATIC `projectHash` baked into the
+-- SQL because migrations have no runtime context (they run before the CLI is
+-- even constructed).
+--
+-- Choice of projectHash
+-- ─────────────────────
+-- The hard-coded value `1e3146b7352b` is the canonical hash for `/mnt/projects/cleocode`
+-- (the CLEO source repository itself), computed via
+-- `crypto.createHash('sha256').update('/mnt/projects/cleocode').digest('hex').slice(0,12)`
+-- — see {@link generateProjectHash} in `packages/core/src/nexus/hash.ts`.
+--
+-- Multi-project caveat
+-- ────────────────────
+-- This migration ships in the `@cleocode/cleo` npm package and therefore runs
+-- against EVERY consumer's `tasks.db`, not just the cleocode repo. The
+-- assumption that all legacy rows belong to the cleocode project breaks for
+-- consumers who:
+--   (a) ran the pre-T9492 12-step `release_manifests` pipeline on their own
+--       repo (very rare — that pipeline was internal-only and never shipped
+--       to external consumers), AND
+--   (b) actually have `legacy:`-prefixed rows in their `releases` table at
+--       the moment they install the version carrying this migration.
+--
+-- For (b)-positive consumers, the rewritten PK will mis-attribute legacy rows
+-- to the cleocode project's hash. This is COSMETIC, not data-destructive:
+--   * The `version`, `status`, and content columns are unchanged.
+--   * The PK is opaque outside its discriminator role; no FK consumer parses
+--     it for semantics.
+--   * The `project_hash` column on the row remains NULL (this migration does
+--     NOT populate it), so the row is still distinguishable from properly
+--     attributed new-pipeline rows.
+--
+-- A follow-up backfill task may correctly re-attribute mis-hashed legacy rows
+-- by inspecting the row's `created_at` against the project's git history (or
+-- by surveying consumers directly). For now, the cosmetic risk is acceptable.
+--
+-- Idempotency
+-- ───────────
+-- The UPDATE statements are guarded by `WHERE id LIKE 'legacy:%'` (or the
+-- equivalent on dependent tables) so re-running is a no-op. The migration is
+-- replay-safe; cross-instance idempotent in the drizzle journal sense.
+--
+-- Dependent tables (release_id FK)
+-- ────────────────────────────────
+-- All four junction tables reference `releases(id)` and must be updated in
+-- lockstep with the PK rewrite:
+--   * release_commits        — (release_id, commit_sha)
+--   * release_changes        — release_id NOT NULL
+--   * release_artifacts      — (release_id, artifact_type, identifier)
+--   * brain_release_links    — (brain_entry_id, release_id, link_type)
+--
+-- Foreign keys on `releases(id)` are CASCADE ON DELETE; an UPDATE of the
+-- parent PK requires explicit ON UPDATE CASCADE, which the original DDLs do
+-- NOT have. We therefore disable foreign_keys for the duration of the UPDATE
+-- sequence and rewrite both sides explicitly.
+--
+-- DESTRUCTIVE: downgrade past this migration via `revert.sql` flips the PKs
+-- back to `legacy:` shape. Any external system that captured the new PK
+-- between apply and revert will hold stale references.
+--
+-- @task T9756
+-- @epic T9752
+-- @see packages/core/migrations/drizzle-tasks/20260519010000_t9686b2-unify-releases-tables/migration.sql
+-- @see packages/core/src/nexus/hash.ts (generateProjectHash)
+-- @see packages/core/src/release/release-manifest.ts (releasesRowToManifest)
+
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+
+-- ── Step 1: Rewrite legacy PKs on dependent tables FIRST ────────────────
+-- Order matters: child rows reference the old `legacy:` PK; if we updated
+-- the parent first the child rows would dangle (FKs are OFF but logical
+-- integrity still matters for the in-flight rewrite).
+--
+-- The REPLACE is anchored by `WHERE release_id LIKE 'legacy:%'` so it only
+-- touches rows that were migrated by T9686-B2 — new-pipeline rows are
+-- untouched.
+
+UPDATE `release_commits`
+   SET `release_id` = '1e3146b7352b:' || SUBSTR(`release_id`, LENGTH('legacy:') + 1)
+ WHERE `release_id` LIKE 'legacy:%';
+--> statement-breakpoint
+
+UPDATE `release_changes`
+   SET `release_id` = '1e3146b7352b:' || SUBSTR(`release_id`, LENGTH('legacy:') + 1)
+ WHERE `release_id` LIKE 'legacy:%';
+--> statement-breakpoint
+
+UPDATE `release_artifacts`
+   SET `release_id` = '1e3146b7352b:' || SUBSTR(`release_id`, LENGTH('legacy:') + 1)
+ WHERE `release_id` LIKE 'legacy:%';
+--> statement-breakpoint
+
+UPDATE `brain_release_links`
+   SET `release_id` = '1e3146b7352b:' || SUBSTR(`release_id`, LENGTH('legacy:') + 1)
+ WHERE `release_id` LIKE 'legacy:%';
+--> statement-breakpoint
+
+-- ── Step 2: Rewrite the parent PKs ──────────────────────────────────────
+-- Using SUBSTR rather than REPLACE so we ONLY strip the leading `legacy:`
+-- prefix — guards against pathological data where `legacy:` happens to
+-- appear later in the version string (e.g. `legacy:v1-legacy:hotfix`).
+
+UPDATE `releases`
+   SET `id` = '1e3146b7352b:' || SUBSTR(`id`, LENGTH('legacy:') + 1)
+ WHERE `id` LIKE 'legacy:%';
+--> statement-breakpoint
+
+PRAGMA foreign_keys=ON;

--- a/packages/core/migrations/drizzle-tasks/20260520163500_t9756-uniform-releases-pk/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260520163500_t9756-uniform-releases-pk/revert.sql
@@ -1,0 +1,44 @@
+-- Revert for T9756: flip `<projectHash>:<version>` rows BACK to `legacy:<version>`
+-- shape, restoring the post-T9686-B2 dual-shape encoding.
+--
+-- Idempotent: the WHERE clause `LIKE '1e3146b7352b:%'` ensures only rows that
+-- the T9756 forward migration touched are flipped back. Properly
+-- attributed new-pipeline rows that happen to share the cleocode project
+-- hash will ALSO be flipped here — this is the inverse of the forward
+-- migration's mis-attribution risk. Consumers who reverted on a non-cleocode
+-- project should verify they have no genuine `1e3146b7352b:*` new-pipeline
+-- rows before applying this revert. (Practically: virtually no consumer
+-- has rows under this exact project hash.)
+--
+-- @task T9756
+-- @epic T9752
+
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+
+UPDATE `brain_release_links`
+   SET `release_id` = 'legacy:' || SUBSTR(`release_id`, LENGTH('1e3146b7352b:') + 1)
+ WHERE `release_id` LIKE '1e3146b7352b:%';
+--> statement-breakpoint
+
+UPDATE `release_artifacts`
+   SET `release_id` = 'legacy:' || SUBSTR(`release_id`, LENGTH('1e3146b7352b:') + 1)
+ WHERE `release_id` LIKE '1e3146b7352b:%';
+--> statement-breakpoint
+
+UPDATE `release_changes`
+   SET `release_id` = 'legacy:' || SUBSTR(`release_id`, LENGTH('1e3146b7352b:') + 1)
+ WHERE `release_id` LIKE '1e3146b7352b:%';
+--> statement-breakpoint
+
+UPDATE `release_commits`
+   SET `release_id` = 'legacy:' || SUBSTR(`release_id`, LENGTH('1e3146b7352b:') + 1)
+ WHERE `release_id` LIKE '1e3146b7352b:%';
+--> statement-breakpoint
+
+UPDATE `releases`
+   SET `id` = 'legacy:' || SUBSTR(`id`, LENGTH('1e3146b7352b:') + 1)
+ WHERE `id` LIKE '1e3146b7352b:%';
+--> statement-breakpoint
+
+PRAGMA foreign_keys=ON;

--- a/packages/core/src/release/__tests__/dual-write-regression.test.ts
+++ b/packages/core/src/release/__tests__/dual-write-regression.test.ts
@@ -96,13 +96,14 @@ async function insertManifest(
 ): Promise<void> {
   const { getDb } = await import('../../store/sqlite.js');
   const { resetDbState } = await import('../../store/sqlite.js');
+  const { generateProjectHash } = await import('../../nexus/hash.js');
   resetDbState();
 
   const db = await getDb(projectRoot);
-  // T9686-B2: `release_manifests` was unified into `releases`. Use the
-  // canonical `legacy:` PK prefix matching what migration produces for
-  // pre-T9492 historical rows.
-  const id = `legacy:${version}`;
+  // T9756: every release row now uses the uniform `<projectHash>:<version>`
+  // PK shape. The `tasks_json` column (non-null) signals legacy-origin
+  // provenance for `releasesRowToManifest`.
+  const id = `${generateProjectHash(projectRoot)}:${version}`;
   const { sql } = await import('drizzle-orm');
   await db.run(
     sql`INSERT INTO releases (id, version, status, tasks_json, created_at)

--- a/packages/core/src/release/__tests__/uniform-pk-migration.test.ts
+++ b/packages/core/src/release/__tests__/uniform-pk-migration.test.ts
@@ -1,0 +1,396 @@
+/**
+ * T9756 (T9738-D / A4) — uniform releases.id PK migration regression lock.
+ *
+ * Validates the invariants of the
+ * `20260520163500_t9756-uniform-releases-pk` migration:
+ *
+ *   1. After B2 (the predecessor migration) is applied, legacy rows carry
+ *      the `legacy:<version>` PK shape.
+ *   2. After T9756 is applied, the SAME rows carry the uniform
+ *      `<projectHash>:<version>` shape — version preserved, only the prefix
+ *      flips.
+ *   3. FK references in the four dependent tables (`release_commits`,
+ *      `release_changes`, `release_artifacts`, `brain_release_links`) are
+ *      rewritten in lockstep with the parent PK.
+ *   4. Re-applying the migration is a no-op — already-uniform rows are not
+ *      double-prefixed (`projectHash:projectHash:<version>` must NOT occur).
+ *   5. Revert flips uniform-shape rows back to `legacy:<version>`.
+ *
+ * The hard-coded project hash baked into the forward migration is the
+ * canonical hash for `/mnt/projects/cleocode` (`1e3146b7352b`) — see the
+ * migration header for the multi-project caveat.
+ *
+ * @task T9756
+ * @epic T9752
+ */
+
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (path: string) => import('node:sqlite').DatabaseSync;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Canonical hash of `/mnt/projects/cleocode` baked into the T9756 migration. */
+const CLEOCODE_PROJECT_HASH = '1e3146b7352b';
+
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+/**
+ * Materialize the post-B2 schema by hand: the unified `releases` table
+ * (with all legacy columns merged in) plus the four dependent junction
+ * tables. We intentionally elide the unrelated tables — the T9756
+ * migration only touches these five.
+ *
+ * @internal
+ */
+function applyPostB2Schema(dbPath: string): import('node:sqlite').DatabaseSync {
+  const nativeDb = new DatabaseSync(dbPath);
+  nativeDb.exec(`
+    CREATE TABLE tasks (id TEXT PRIMARY KEY);
+    CREATE TABLE commits (sha TEXT PRIMARY KEY, subject TEXT);
+    CREATE TABLE pull_requests (id TEXT PRIMARY KEY);
+    CREATE TABLE brain_entries (id TEXT PRIMARY KEY);
+
+    -- Post-B2 unified \`releases\` shape (matches the table that T9686-B2
+    -- leaves behind, with the merge_commit_sha FK already dropped).
+    CREATE TABLE releases (
+      id                TEXT PRIMARY KEY NOT NULL,
+      version           TEXT NOT NULL UNIQUE,
+      scheme            TEXT NOT NULL DEFAULT 'calver',
+      channel           TEXT NOT NULL DEFAULT 'latest',
+      epic_id           TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+      release_kind      TEXT NOT NULL DEFAULT 'regular',
+      status            TEXT NOT NULL DEFAULT 'planned',
+      previous_version  TEXT,
+      merge_commit_sha  TEXT,
+      pr_id             TEXT REFERENCES pull_requests(id) ON DELETE SET NULL,
+      workflow_run_url  TEXT,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      planned_at        TEXT,
+      pr_opened_at      TEXT,
+      pr_merged_at      TEXT,
+      published_at      TEXT,
+      reconciled_at     TEXT,
+      rolled_back_at    TEXT,
+      failed_at         TEXT,
+      cancelled_at      TEXT,
+      failure_reason    TEXT,
+      rolled_back_by    TEXT,
+      project_hash      TEXT,
+      tasks_json        TEXT,
+      changelog         TEXT,
+      notes             TEXT,
+      git_tag           TEXT,
+      prepared_at       TEXT,
+      committed_at      TEXT,
+      tagged_at         TEXT,
+      pushed_at         TEXT
+    );
+
+    -- Dependent tables — minimal columns + FK to releases(id).
+    CREATE TABLE release_commits (
+      release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+      commit_sha TEXT NOT NULL REFERENCES commits(sha) ON DELETE CASCADE,
+      position   INTEGER NOT NULL,
+      PRIMARY KEY (release_id, commit_sha)
+    );
+
+    CREATE TABLE release_changes (
+      id         TEXT PRIMARY KEY NOT NULL,
+      release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE release_artifacts (
+      release_id    TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+      artifact_type TEXT NOT NULL,
+      identifier    TEXT NOT NULL,
+      PRIMARY KEY (release_id, artifact_type, identifier)
+    );
+
+    CREATE TABLE brain_release_links (
+      brain_entry_id TEXT NOT NULL REFERENCES brain_entries(id) ON DELETE CASCADE,
+      release_id     TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+      link_type      TEXT NOT NULL,
+      PRIMARY KEY (brain_entry_id, release_id, link_type)
+    );
+  `);
+  return nativeDb;
+}
+
+/**
+ * Apply the T9756 forward migration to an already-post-B2-seeded DB.
+ *
+ * @internal
+ */
+function applyT9756Migration(nativeDb: import('node:sqlite').DatabaseSync): void {
+  const sqlPath = join(
+    migrationsDir(),
+    '20260520163500_t9756-uniform-releases-pk',
+    'migration.sql',
+  );
+  const sql = execSync(`cat ${sqlPath}`, { encoding: 'utf-8' });
+  const statements = sql.split('--> statement-breakpoint');
+  for (const stmt of statements) {
+    const trimmed = stmt.trim();
+    if (!trimmed) continue;
+    nativeDb.exec(trimmed);
+  }
+}
+
+/**
+ * Apply the T9756 revert migration.
+ *
+ * @internal
+ */
+function applyT9756Revert(nativeDb: import('node:sqlite').DatabaseSync): void {
+  const sqlPath = join(migrationsDir(), '20260520163500_t9756-uniform-releases-pk', 'revert.sql');
+  const sql = execSync(`cat ${sqlPath}`, { encoding: 'utf-8' });
+  const statements = sql.split('--> statement-breakpoint');
+  for (const stmt of statements) {
+    const trimmed = stmt.trim();
+    if (!trimmed) continue;
+    nativeDb.exec(trimmed);
+  }
+}
+
+describe('T9756 uniform releases.id PK migration', () => {
+  let tempDir: string;
+  let nativeDb: import('node:sqlite').DatabaseSync;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-t9756-mig-'));
+    nativeDb = applyPostB2Schema(join(tempDir, 'tasks.db'));
+  });
+
+  afterEach(() => {
+    try {
+      nativeDb.close();
+    } catch {
+      // already closed
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('rewrites legacy:<version> PKs to <projectHash>:<version> shape', () => {
+    nativeDb.exec(`
+      INSERT INTO releases (id, version, status, tasks_json, created_at, prepared_at)
+      VALUES
+        ('legacy:v1.0.0',     'v1.0.0',     'prepared', '["T100"]',          '2026-01-01', '2026-01-01'),
+        ('legacy:v2026.5.73', 'v2026.5.73', 'pushed',   '["T9000","T9001"]', '2026-05-15', '2026-05-15');
+    `);
+
+    applyT9756Migration(nativeDb);
+
+    const rows = nativeDb
+      .prepare('SELECT id, version FROM releases ORDER BY version')
+      .all() as Array<{ id: string; version: string }>;
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({
+      id: `${CLEOCODE_PROJECT_HASH}:v1.0.0`,
+      version: 'v1.0.0',
+    });
+    expect(rows[1]).toEqual({
+      id: `${CLEOCODE_PROJECT_HASH}:v2026.5.73`,
+      version: 'v2026.5.73',
+    });
+  });
+
+  it('preserves new-pipeline rows (does not double-prefix them)', () => {
+    // New-pipeline rows already use the uniform shape — they must be left
+    // untouched by the LIKE 'legacy:%' guard.
+    nativeDb.exec(`
+      INSERT INTO releases (id, version, status, created_at)
+      VALUES
+        ('legacy:v1.0.0',       'v1.0.0',       'pushed',    '2026-01-01'),
+        ('aaaaaaaaaaaa:v2026.6.0', 'v2026.6.0', 'planned',   '2026-06-01'),
+        ('bbbbbbbbbbbb:v2026.6.1', 'v2026.6.1', 'reconciled', '2026-06-02');
+    `);
+
+    applyT9756Migration(nativeDb);
+
+    const rows = nativeDb.prepare('SELECT id FROM releases ORDER BY version').all() as Array<{
+      id: string;
+    }>;
+
+    // The legacy row was rewritten; the two new-pipeline rows were not.
+    expect(rows.map((r) => r.id)).toEqual([
+      `${CLEOCODE_PROJECT_HASH}:v1.0.0`,
+      'aaaaaaaaaaaa:v2026.6.0',
+      'bbbbbbbbbbbb:v2026.6.1',
+    ]);
+  });
+
+  it('updates FK references in all four dependent tables', () => {
+    // Seed parent + a row in each dependent table.
+    nativeDb.exec(`
+      INSERT INTO commits (sha) VALUES ('abc123');
+      INSERT INTO brain_entries (id) VALUES ('B-001');
+
+      INSERT INTO releases (id, version, status, created_at)
+      VALUES ('legacy:v1.0.0', 'v1.0.0', 'pushed', '2026-01-01');
+
+      INSERT INTO release_commits (release_id, commit_sha, position)
+      VALUES ('legacy:v1.0.0', 'abc123', 0);
+
+      INSERT INTO release_changes (id, release_id)
+      VALUES ('chg-1', 'legacy:v1.0.0');
+
+      INSERT INTO release_artifacts (release_id, artifact_type, identifier)
+      VALUES ('legacy:v1.0.0', 'npm', '@cleocode/cleo@v1.0.0');
+
+      INSERT INTO brain_release_links (brain_entry_id, release_id, link_type)
+      VALUES ('B-001', 'legacy:v1.0.0', 'shipped');
+    `);
+
+    applyT9756Migration(nativeDb);
+
+    const expectedId = `${CLEOCODE_PROJECT_HASH}:v1.0.0`;
+
+    const rc = nativeDb.prepare('SELECT release_id FROM release_commits').all() as Array<{
+      release_id: string;
+    }>;
+    expect(rc).toEqual([{ release_id: expectedId }]);
+
+    const rch = nativeDb.prepare('SELECT release_id FROM release_changes').all() as Array<{
+      release_id: string;
+    }>;
+    expect(rch).toEqual([{ release_id: expectedId }]);
+
+    const ra = nativeDb.prepare('SELECT release_id FROM release_artifacts').all() as Array<{
+      release_id: string;
+    }>;
+    expect(ra).toEqual([{ release_id: expectedId }]);
+
+    const brl = nativeDb.prepare('SELECT release_id FROM brain_release_links').all() as Array<{
+      release_id: string;
+    }>;
+    expect(brl).toEqual([{ release_id: expectedId }]);
+  });
+
+  it('is idempotent — re-running does not double-prefix', () => {
+    nativeDb.exec(`
+      INSERT INTO releases (id, version, status, created_at)
+      VALUES ('legacy:v1.0.0', 'v1.0.0', 'pushed', '2026-01-01');
+    `);
+
+    applyT9756Migration(nativeDb);
+    applyT9756Migration(nativeDb); // second apply — should be a no-op
+
+    const row = nativeDb.prepare("SELECT id FROM releases WHERE version = 'v1.0.0'").get() as {
+      id: string;
+    };
+
+    expect(row.id).toBe(`${CLEOCODE_PROJECT_HASH}:v1.0.0`);
+    // Must NOT have been re-prefixed:
+    expect(row.id).not.toContain(`${CLEOCODE_PROJECT_HASH}:${CLEOCODE_PROJECT_HASH}`);
+  });
+
+  it('preserves all non-PK columns verbatim (no data loss on rewrite)', () => {
+    nativeDb.exec(`
+      INSERT INTO releases (
+        id, version, status, tasks_json, changelog, notes,
+        previous_version, merge_commit_sha, git_tag, created_at,
+        prepared_at, committed_at, tagged_at, pushed_at
+      )
+      VALUES (
+        'legacy:v2026.5.73', 'v2026.5.73', 'pushed',
+        '["T9000","T9001"]', 'CHANGELOG body', 'release notes',
+        'v2026.5.72', 'fedcba987654', 'v2026.5.73-tag', '2026-05-15T00:00:00Z',
+        '2026-05-15T01:00:00Z', '2026-05-15T02:00:00Z', '2026-05-15T03:00:00Z', '2026-05-15T04:00:00Z'
+      );
+    `);
+
+    applyT9756Migration(nativeDb);
+
+    const row = nativeDb
+      .prepare("SELECT * FROM releases WHERE version = 'v2026.5.73'")
+      .get() as Record<string, unknown>;
+
+    expect(row).toMatchObject({
+      id: `${CLEOCODE_PROJECT_HASH}:v2026.5.73`,
+      version: 'v2026.5.73',
+      status: 'pushed',
+      tasks_json: '["T9000","T9001"]',
+      changelog: 'CHANGELOG body',
+      notes: 'release notes',
+      previous_version: 'v2026.5.72',
+      merge_commit_sha: 'fedcba987654',
+      git_tag: 'v2026.5.73-tag',
+      prepared_at: '2026-05-15T01:00:00Z',
+      committed_at: '2026-05-15T02:00:00Z',
+      tagged_at: '2026-05-15T03:00:00Z',
+      pushed_at: '2026-05-15T04:00:00Z',
+    });
+  });
+
+  it('revert flips uniform-shape rows back to legacy:<version>', () => {
+    nativeDb.exec(`
+      INSERT INTO releases (id, version, status, created_at)
+      VALUES ('legacy:v1.0.0', 'v1.0.0', 'pushed', '2026-01-01');
+    `);
+
+    applyT9756Migration(nativeDb);
+    expect((nativeDb.prepare('SELECT id FROM releases').get() as { id: string }).id).toBe(
+      `${CLEOCODE_PROJECT_HASH}:v1.0.0`,
+    );
+
+    applyT9756Revert(nativeDb);
+    expect((nativeDb.prepare('SELECT id FROM releases').get() as { id: string }).id).toBe(
+      'legacy:v1.0.0',
+    );
+  });
+
+  it('revert reverses FK rewrites in dependent tables', () => {
+    nativeDb.exec(`
+      INSERT INTO commits (sha) VALUES ('abc123');
+      INSERT INTO releases (id, version, status, created_at)
+      VALUES ('legacy:v1.0.0', 'v1.0.0', 'pushed', '2026-01-01');
+      INSERT INTO release_commits (release_id, commit_sha, position)
+      VALUES ('legacy:v1.0.0', 'abc123', 0);
+    `);
+
+    applyT9756Migration(nativeDb);
+    applyT9756Revert(nativeDb);
+
+    const rc = nativeDb.prepare('SELECT release_id FROM release_commits').all() as Array<{
+      release_id: string;
+    }>;
+    expect(rc).toEqual([{ release_id: 'legacy:v1.0.0' }]);
+  });
+
+  it('handles versions that contain the literal `legacy:` substring safely', () => {
+    // Defensive: ensure we strip ONLY the leading `legacy:` prefix and not
+    // any later occurrence inside the version string.
+    nativeDb.exec(`
+      INSERT INTO releases (id, version, status, created_at)
+      VALUES ('legacy:v1.0.0-legacy:hotfix', 'v1.0.0-legacy:hotfix', 'pushed', '2026-01-01');
+    `);
+
+    applyT9756Migration(nativeDb);
+
+    const row = nativeDb.prepare('SELECT id FROM releases').get() as { id: string };
+    expect(row.id).toBe(`${CLEOCODE_PROJECT_HASH}:v1.0.0-legacy:hotfix`);
+  });
+});

--- a/packages/core/src/release/release-manifest.ts
+++ b/packages/core/src/release/release-manifest.ts
@@ -4,9 +4,20 @@
  * Originally migrated from `.cleo/releases.json` into `release_manifests`
  * by T5580. T9686-B2 unified `release_manifests` into the new `releases`
  * table (T9508) and dropped the legacy table — every read/write here now
- * targets the single canonical `releases` table via Drizzle ORM. Legacy
- * rows live under PK `legacy:<version>`; new-pipeline rows under
- * `<projectHash>:<version>`.
+ * targets the single canonical `releases` table via Drizzle ORM.
+ *
+ * T9756 (T9738-D / A4) eliminated the dual PK shape introduced by T9686-B2.
+ * Every row — legacy-migrated AND new-pipeline — now uses the uniform
+ * `<projectHash>:<version>` PK shape. The migration at
+ * `20260520163500_t9756-uniform-releases-pk/` rewrites historical
+ * `legacy:<version>` rows in place. New writes (via {@link prepareRelease}
+ * and {@link migrateReleasesFromJson}) derive `<projectHash>` from
+ * {@link generateProjectHash} so all rows share one shape.
+ *
+ * Provenance discrimination is no longer carried by the PK prefix. The
+ * `tasksJson` column (NOT NULL on legacy rows, NULL on new-pipeline rows)
+ * serves as the column-level discriminator consumed by
+ * {@link releasesRowToManifest}.
  *
  * The status enum on the unified table is the union of both lifecycles:
  *   New T9492: planned / pr-opened / pr-merged / published / reconciled
@@ -16,6 +27,7 @@
  * @task T5580
  * @task T4788
  * @task T9686 (unification)
+ * @task T9756 (uniform PK shape)
  */
 
 import { execFileSync } from 'node:child_process';
@@ -23,6 +35,7 @@ import { appendFileSync, existsSync, mkdirSync, renameSync, writeFileSync } from
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { and, count, desc, eq, sql } from 'drizzle-orm';
+import { generateProjectHash } from '../nexus/hash.js';
 import { createPage } from '../pagination.js';
 import { getCleoDirAbsolute, getProjectRoot } from '../paths.js';
 import * as schema from '../store/tasks-schema.js';
@@ -210,6 +223,28 @@ function effectivePageLimit(
   return limit ?? (offset !== undefined ? 50 : undefined);
 }
 
+/**
+ * Project-root resolution for {@link generateProjectHash} that mirrors the
+ * tolerant fallback used by {@link getCleoDirAbsolute}: try the strict
+ * `getProjectRoot` walk-up first, fall back to the literal `cwd` (or
+ * `process.cwd()`) when the strict check fails.
+ *
+ * Without this fallback, callers operating in tmp directories that do not
+ * yet satisfy the strict `.cleo + .git` predicate (e.g. unit-test sandboxes,
+ * the `cleo init` bootstrap path) would crash before they could compute a
+ * stable hash for the release PK.
+ *
+ * @task T9756
+ * @internal
+ */
+function resolveProjectRootForHash(cwd?: string): string {
+  try {
+    return getProjectRoot(cwd);
+  } catch {
+    return cwd ?? process.cwd(); // CWD-OK: hash-input fallback when getProjectRoot rejects (tests / cleo init bootstrap)
+  }
+}
+
 /** Task record shape needed for release operations. */
 export interface ReleaseTaskRecord {
   id: string;
@@ -282,8 +317,14 @@ function normalizeVersion(version: string): string {
 /**
  * Project a unified `releases` row down to the {@link ReleaseManifest}
  * shape consumed by CLI surfaces. After T9686-B2 the `releases` table
- * carries both new-pipeline and legacy-pipeline columns; the row's
- * `id` prefix (`legacy:` vs `<projectHash>:`) discriminates provenance.
+ * carries both new-pipeline and legacy-pipeline columns.
+ *
+ * Provenance discriminator (T9756): every row now uses the uniform
+ * `<projectHash>:<version>` PK shape, so the previous `legacy:`-prefix
+ * heuristic has been replaced by a column-level check — legacy-migrated
+ * rows have a populated `tasksJson` column (the legacy schema declared it
+ * `NOT NULL DEFAULT '[]'`), while new-pipeline rows leave it NULL because
+ * per-task changes live in {@link schema.releaseChanges}.
  *
  * Field-mapping notes:
  * - `tasks` — parsed from `tasksJson` for legacy-migrated rows. New-pipeline
@@ -298,10 +339,15 @@ function normalizeVersion(version: string): string {
  *   don't have to special-case the row source.
  *
  * @task T9686
+ * @task T9756 (uniform PK shape)
  * @internal
  */
 function releasesRowToManifest(row: schema.ReleaseRow): ReleaseManifest {
-  const source: 'new' | 'legacy' = row.id.startsWith('legacy:') ? 'legacy' : 'new';
+  // T9756: `tasksJson` is the post-uniform-PK provenance discriminator. The
+  // legacy `release_manifests` schema declared `tasks_json NOT NULL DEFAULT
+  // '[]'`, so every legacy-migrated row has a non-null value here; new-
+  // pipeline rows always leave it NULL.
+  const source: 'new' | 'legacy' = row.tasksJson === null ? 'new' : 'legacy';
   let tasks: string[] = [];
   if (row.tasksJson) {
     try {
@@ -413,10 +459,15 @@ export async function prepareRelease(
   );
   releaseTasks = releaseTasks.filter((id) => !epicIds.has(id));
   const now = new Date().toISOString();
-  // T9686-B2: write into the unified `releases` table with the `legacy:`
-  // PK prefix so prepareRelease rows match the format used by the migration
-  // for pre-T9492 historical rows.
-  const id = `legacy:${normalizedVersion}`;
+  // T9756: write the uniform `<projectHash>:<version>` PK shape. `tasksJson`
+  // is the non-PK provenance discriminator (see `releasesRowToManifest`) —
+  // legacy-prepare rows are still distinguishable from new-pipeline rows
+  // because they populate `tasksJson` and `preparedAt`. Mirrors the
+  // tolerant resolution `getCleoDirAbsolute` uses so tests/init paths that
+  // don't yet satisfy `getProjectRoot`'s strict `.cleo + .git` predicate
+  // can still derive a stable hash from cwd.
+  const projectHash = generateProjectHash(resolveProjectRootForHash(cwd));
+  const id = `${projectHash}:${normalizedVersion}`;
 
   await db
     .insert(schema.releases)
@@ -429,6 +480,7 @@ export async function prepareRelease(
       previousVersion: previousVersion?.version ?? null,
       createdAt: now,
       preparedAt: now,
+      projectHash,
     })
     .run();
 
@@ -1643,10 +1695,11 @@ export async function migrateReleasesJsonToSqlite(
 
     if (existing.length > 0) continue;
 
-    // T9686-B2: migrated rows from `releases.json` are pre-T9492 legacy
-    // releases, so use the `legacy:<version>` PK prefix to match the
-    // canonical format produced by the unification migration.
-    const id = `legacy:${r.version}`;
+    // T9756: emit the uniform `<projectHash>:<version>` PK shape. The
+    // populated `tasksJson` column still discriminates these rows as
+    // legacy-origin for `releasesRowToManifest`.
+    const projectHash = generateProjectHash(resolveProjectRootForHash(projectRoot));
+    const id = `${projectHash}:${r.version}`;
     await db
       .insert(schema.releases)
       .values({
@@ -1664,6 +1717,7 @@ export async function migrateReleasesJsonToSqlite(
         committedAt: r.committedAt ?? null,
         taggedAt: r.taggedAt ?? null,
         pushedAt: r.pushedAt ?? null,
+        projectHash,
       })
       .run();
 

--- a/packages/core/src/store/tasks-schema.ts
+++ b/packages/core/src/store/tasks-schema.ts
@@ -713,9 +713,13 @@ export const pipelineManifest = sqliteTable(
 //
 // The legacy `release_manifests` table (T5580) was merged into the unified
 // `releases` table by migration `20260519010000_t9686b2-unify-releases-tables`.
-// Legacy rows live in `releases` with PK `legacy:<version>` and the legacy
-// status values (`prepared`, `committed`, `tagged`, `pushed`, `rolled_back`)
-// admitted by the widened {@link RELEASE_STATUSES} enum.
+// Legacy-migrated rows initially used PK `legacy:<version>`; T9756
+// (migration `20260520163500_t9756-uniform-releases-pk`) rewrote them to
+// the uniform `<projectHash>:<version>` shape used by the new pipeline.
+// Provenance is now discriminated by `tasksJson IS NOT NULL` (legacy) rather
+// than by PK prefix. Legacy status values (`prepared`, `committed`, `tagged`,
+// `pushed`, `rolled_back`) remain admitted by the widened
+// {@link RELEASE_STATUSES} enum.
 //
 // All readers/writers now target the unified `releases` table directly.
 // The `releaseManifests` Drizzle binding has been removed — code that
@@ -1860,13 +1864,19 @@ export type ReleaseClassifiedBy = (typeof RELEASE_CLASSIFIED_BY)[number];
  *
  * As of T9686-B2, this is the SINGLE source of truth for release state. The
  * legacy `release_manifests` table (T5580) was merged into this table and
- * dropped — legacy rows now live here with PK `legacy:<version>` and legacy
- * status values (`prepared`/`committed`/`tagged`/`pushed`/`rolled_back`)
- * admitted by the widened {@link RELEASE_STATUSES} enum.
+ * dropped. Legacy-migrated rows initially used PK `legacy:<version>`;
+ * T9756 (migration `20260520163500_t9756-uniform-releases-pk`) rewrote
+ * them to the uniform `<projectHash>:<version>` shape. All status values
+ * (`prepared`/`committed`/`tagged`/`pushed`/`rolled_back` for legacy,
+ * `planned`/`pr-opened`/`pr-merged`/`published`/`reconciled` for new)
+ * are admitted by the widened {@link RELEASE_STATUSES} enum.
  *
- * ID format:
- * - New T9492 pipeline rows: `<projectHash>:<version>` (e.g. `abc123:v2026.6.0`)
- * - Legacy migrated rows:    `legacy:<version>`        (e.g. `legacy:v2026.5.73`)
+ * ID format (uniform post-T9756):
+ *   `<projectHash>:<version>` (e.g. `abc123:v2026.6.0`)
+ *
+ * Provenance discriminator: `tasksJson IS NOT NULL` indicates a
+ * legacy-origin row; new-pipeline rows leave `tasksJson` NULL and store
+ * per-task changes in {@link releaseChanges}.
  *
  * Status FSM (lifecycle is discriminated by status value, not a separate column):
  * - New T9492: `planned → pr-opened → pr-merged → published → reconciled`
@@ -1877,6 +1887,7 @@ export type ReleaseClassifiedBy = (typeof RELEASE_CLASSIFIED_BY)[number];
  *
  * @task T9508
  * @task T9686 (unification — legacy columns + widened status enum)
+ * @task T9756 (uniform PK shape)
  * @epic T9491
  * @see SPEC-T9345 §3.6
  */
@@ -1884,9 +1895,13 @@ export const releases = sqliteTable(
   'releases',
   {
     /**
-     * Canonical PK.
-     * - New-pipeline rows: `<projectHash>:<version>` (e.g. `abc123:v2026.6.0`).
-     * - Legacy-migrated rows: `legacy:<version>` (e.g. `legacy:v2026.5.73`).
+     * Canonical PK — uniform `<projectHash>:<version>` shape (post-T9756).
+     * Example: `1e3146b7352b:v2026.6.0`.
+     *
+     * Historically (T9686-B2 era) legacy-migrated rows used `legacy:<version>`;
+     * the T9756 migration rewrites those to the uniform shape. Provenance is
+     * now signalled by `tasksJson` (non-null = legacy origin), not by PK
+     * prefix.
      */
     id: text('id').primaryKey(),
     /** Release version string, e.g. `v2026.6.0`. UNIQUE — one row per version. */


### PR DESCRIPTION
## Summary

T9738-D / A4 carryforward. PR #328 (B2 unification) shipped legacy rows with PK shape `legacy:<version>` for expediency. This **new** migration (`20260520163500_t9756-uniform-releases-pk/`) rewrites those rows to the uniform `<projectHash>:<version>` shape used by the new pipeline path, eliminating the dual-shape branch in downstream consumers.

The B2 migration file is **untouched** — per owner decision Q4, we ship the cleanup as a new migration on top of B2 rather than rewriting history.

## What changed

### Migration

- `packages/core/migrations/drizzle-tasks/20260520163500_t9756-uniform-releases-pk/migration.sql`
  - Updates `releases.id` from `legacy:<v>` → `1e3146b7352b:<v>` (the canonical hash for `/mnt/projects/cleocode`).
  - Updates `release_id` FK on all four dependent tables in lockstep (`release_commits`, `release_changes`, `release_artifacts`, `brain_release_links`) — FKs are disabled for the duration of the rewrite since the original DDLs don't have `ON UPDATE CASCADE`.
  - Anchored by `WHERE … LIKE 'legacy:%'` so it's idempotent and leaves new-pipeline rows untouched.
- `revert.sql` flips the rewrites in the opposite direction.

### Multi-project caveat (documented in migration header)

The hard-coded hash is correct only for the cleocode repo itself. Foreign-DB consumers who somehow accumulated `legacy:`-prefixed rows will see those rows mis-attributed to cleocode's hash — **cosmetic, not data-destructive** (version + content columns unchanged; row's `project_hash` column stays NULL so the row remains distinguishable). A follow-up backfill task may correctly re-attribute.

### Downstream consumer updates

- `packages/core/src/release/release-manifest.ts`
  - `releasesRowToManifest`: discriminator flipped from PK-prefix check to `tasksJson IS NULL` (new pipeline) / `IS NOT NULL` (legacy origin). The legacy schema declared `tasks_json NOT NULL DEFAULT '[]'` so the column reliably encodes provenance after the PK shape unifies.
  - `prepareRelease` + `migrateReleasesFromJson`: now write the uniform `<projectHash>:<version>` PK via a new `resolveProjectRootForHash` helper that mirrors `getCleoDirAbsolute`'s tolerant fallback (so tests and the `cleo init` bootstrap path still work when `getProjectRoot`'s strict `.cleo+.git` predicate isn't yet satisfied).
- `packages/core/src/store/tasks-schema.ts` — docstrings updated.
- `packages/core/src/release/__tests__/dual-write-regression.test.ts` — fixture switched to uniform shape via `generateProjectHash`.

### Tests

- `packages/core/src/release/__tests__/uniform-pk-migration.test.ts` (**new**, 8 cases):
  - forward rewrite of legacy rows
  - new-pipeline rows untouched
  - FK lockstep across all four dependent tables
  - idempotent re-apply (no double-prefix)
  - revert flip (parent + children)
  - column preservation (no data loss on rewrite)
  - `legacy:` substring inside version string handled safely

## Test plan

- [x] `pnpm --filter @cleocode/contracts run build`
- [x] `pnpm --filter @cleocode/core run build`
- [x] `pnpm biome check packages/core/src/release packages/core/src/store packages/core/migrations`
- [x] `pnpm --filter @cleocode/core run test src/release/__tests__` — **225 passed, 2 skipped** (all 26 release test files green, including the existing `unify-migration` regression lock)
- [x] `pnpm --filter @cleocode/core run test src/release/__tests__/uniform-pk-migration` — 8/8 pass
- [x] `node scripts/lint-project-root-anti-pattern.mjs --strict` — STRICT OK (zero violations)
- [x] `node scripts/lint-core-first.mjs --check` — PASS (no new CORE-first violations above baseline)

## Refs

- Task: T9756
- Epic: T9752 (T9738 carryforward closure)
- B2 unification migration this builds on: PR #328 / `20260519010000_t9686b2-unify-releases-tables/`