### PR TITLE
refactor(T9740 Wave C): zero legacy paths — purge resolveSkillsRoot fallback + getCanonicalSkillsRoot + caamp→core dep flip

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -23,7 +23,7 @@
  */
 
 import * as esbuild from 'esbuild';
-import { chmod, cp, rm, readFile, writeFile } from 'node:fs/promises';
+import { chmod, cp, mkdir, rm, readFile, writeFile } from 'node:fs/promises';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { resolve, dirname, join, relative, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -67,6 +67,9 @@ const SUBPATH_DIRS = [
   'formatters',
   'events',
   'llm',
+  // T9740 Wave C: caamp imports `@cleocode/core/skills/skill-root.js` so the
+  // `./skills/*` subpath export must emit physical .js files (not just .d.ts).
+  'skills',
 ];
 
 
@@ -645,9 +648,37 @@ async function build() {
   ]);
 
   // ---------------------------------------------------------------------------
-  // Wave 4: caamp (deps cant from wave 3)
+  // Wave 4: caamp (deps cant from wave 3 + pre-emitted core/skills/skill-root.d.ts)
+  //
+  // T9740 Wave C flipped the dep direction so caamp now depends on
+  // `@cleocode/core/skills/skill-root.js` (a node-builtin-only file with zero
+  // @cleocode/* imports). To break the build cycle without re-shuffling waves,
+  // we pre-emit just that single file's .d.ts before caamp's tsup DTS step
+  // runs — full core/dist still emits in wave 5.
   // ---------------------------------------------------------------------------
   console.log('\n[build] Wave 4: caamp');
+  console.log('  Pre-emitting core/dist/skills/skill-root.d.ts (T9740 Wave C cycle break)...');
+  // skill-root.ts has zero @cleocode/* deps — we hand-write the matching
+  // .d.ts so caamp's tsup DTS step (which runs BEFORE core's full tsc emit
+  // in wave 5) can resolve `@cleocode/core/skills/skill-root.js`. The wave-5
+  // core tsc pass overwrites this stub with the real declaration emit.
+  const skillRootDts = `export type SkillSourceType = 'canonical' | 'user' | 'community' | 'agent-created';
+export interface IsCanonicalOptions {
+  dbSourceType?: SkillSourceType | string;
+  manifestNames?: string[];
+}
+export declare const AGENTS_SKILLS_BRIDGE_PATH: string;
+export declare const CLAUDE_SKILLS_AGENTS_SHARED_PATH: string;
+export declare function resolveSkillsRoot(): string;
+export declare function is_canonical(skillPath: string, options?: IsCanonicalOptions): boolean;
+`;
+  await mkdir(resolve(__dirname, 'packages/core/dist/skills'), { recursive: true });
+  await writeFile(
+    resolve(__dirname, 'packages/core/dist/skills/skill-root.d.ts'),
+    skillRootDts,
+    'utf8',
+  );
+  console.log('  -> packages/core/dist/skills/skill-root.d.ts (stub)');
   await buildPkg('@cleocode/caamp', 'packages/caamp/dist/');
   await chmod('packages/caamp/dist/cli.js', 0o755).catch(() => {});
 

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@cleocode/cant": "workspace:*",
     "@cleocode/contracts": "workspace:*",
+    "@cleocode/core": "workspace:*",
     "@cleocode/lafs": "workspace:*",
     "@cleocode/paths": "workspace:*",
     "@iarna/toml": "^2.2.5",

--- a/packages/caamp/src/commands/doctor.ts
+++ b/packages/caamp/src/commands/doctor.ts
@@ -7,6 +7,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, lstatSync, readdirSync, readlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { resolveSkillsRoot } from '@cleocode/core/skills/skill-root.js';
 import type { Command } from 'commander';
 import pc from 'picocolors';
 import { readConfig } from '../core/formats/index.js';
@@ -19,7 +20,6 @@ import {
   resolveFormat,
 } from '../core/lafs.js';
 import { readLockFile } from '../core/lock-utils.js';
-import { CANONICAL_SKILLS_DIR } from '../core/paths/agents.js';
 import { detectAllProviders } from '../core/registry/detection.js';
 import { getAllProviders, getProviderCount } from '../core/registry/providers.js';
 import { getCaampVersion } from '../core/version.js';
@@ -163,7 +163,7 @@ function checkInstalledProviders(): SectionResult {
 function checkSkillSymlinks(): SectionResult {
   const checks: CheckResult[] = [];
 
-  const canonicalDir = CANONICAL_SKILLS_DIR;
+  const canonicalDir = resolveSkillsRoot();
 
   if (!existsSync(canonicalDir)) {
     checks.push({ label: '0 canonical skills', status: 'pass' });
@@ -293,7 +293,7 @@ async function checkLockFile(): Promise<SectionResult> {
     }
 
     // Check for untracked skills (on disk but not in lock)
-    const canonicalDir = CANONICAL_SKILLS_DIR;
+    const canonicalDir = resolveSkillsRoot();
     if (existsSync(canonicalDir)) {
       const onDisk = readdirSync(canonicalDir).filter((name) => {
         try {
@@ -581,7 +581,7 @@ export function registerDoctorCommand(program: Command): void {
 }
 
 function countSkillIssues(): { canonicalCount: number; brokenCount: number; staleCount: number } {
-  const canonicalDir = CANONICAL_SKILLS_DIR;
+  const canonicalDir = resolveSkillsRoot();
   let canonicalCount = 0;
 
   if (existsSync(canonicalDir)) {

--- a/packages/caamp/src/core/advanced/orchestration.ts
+++ b/packages/caamp/src/core/advanced/orchestration.ts
@@ -9,10 +9,10 @@ import { existsSync, lstatSync } from 'node:fs';
 import { cp, mkdir, readlink, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
+import { resolveSkillsRoot } from '@cleocode/core/skills/skill-root.js';
 import type { ConfigFormat, Provider, ProviderPriority } from '../../types.js';
 import { injectAll } from '../instructions/injector.js';
 import { groupByInstructFile } from '../instructions/templates.js';
-import { CANONICAL_SKILLS_DIR } from '../paths/agents.js';
 import { getInstalledProviders } from '../registry/detection.js';
 import { installSkill, removeSkill } from '../skills/installer.js';
 
@@ -159,7 +159,7 @@ async function snapshotSkillState(
 ): Promise<SkillSnapshot> {
   const skillName = operation.skillName;
   const isGlobal = operation.isGlobal ?? true;
-  const canonicalPath = join(CANONICAL_SKILLS_DIR, skillName);
+  const canonicalPath = join(resolveSkillsRoot(), skillName);
   const canonicalExisted = existsSync(canonicalPath);
   const canonicalBackupPath = join(backupRoot, 'canonical', skillName);
 

--- a/packages/caamp/src/core/paths/agents.ts
+++ b/packages/caamp/src/core/paths/agents.ts
@@ -3,7 +3,6 @@ import {
   getAgentsHome,
   getAgentsMcpDir,
   getAgentsMcpServersPath,
-  getCanonicalSkillsDir,
   getLockFilePath,
 } from './standard.js';
 
@@ -18,12 +17,6 @@ export const AGENTS_HOME = getAgentsHome();
  * @public
  */
 export const LOCK_FILE_PATH = getLockFilePath();
-
-/**
- * Canonical skills directory (`~/.agents/skills/`).
- * @public
- */
-export const CANONICAL_SKILLS_DIR = getCanonicalSkillsDir();
 
 /**
  * Global MCP directory (`~/.agents/mcp/`).

--- a/packages/caamp/src/core/paths/standard.ts
+++ b/packages/caamp/src/core/paths/standard.ts
@@ -1,6 +1,10 @@
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+// T9747: caamp no longer owns a canonical-skills helper. Consumers must import
+// `resolveSkillsRoot` from `@cleocode/core/skills/skill-root.js` directly. This
+// module retains `getAgentsHome()` and the `.agents/*` helpers — only the
+// skills override has been severed (the SSoT now lives in core).
 import { getCleoHome } from '@cleocode/paths';
 import type { Provider } from '../../types.js';
 import { getPlatformPaths } from '../platform-paths.js';
@@ -164,137 +168,6 @@ export function getProjectAgentsDir(projectRoot = process.cwd()): string {
  */
 export function resolveProjectPath(relativePath: string, projectDir = process.cwd()): string {
   return join(projectDir, relativePath);
-}
-
-/**
- * Subpath for the new SSoT skills directory under the user's home.
- *
- * @remarks
- * Architecture-v3 §1 locks the user-machine install root for ALL skills
- * (Sphere A canonical AND Sphere B user/community/agent-created) to
- * `~/.cleo/skills/`. This constant centralises that subpath so the
- * fallback-resolver and the migration helpers share one source of truth.
- *
- * @internal
- */
-const NEW_SSOT_SKILLS_SUBPATH = join('.cleo', 'skills');
-
-/**
- * One-shot deprecation-warning flag for the legacy XDG skills path.
- *
- * @remarks
- * When the new SSoT path under `~/.cleo/skills/` is missing but the legacy
- * `~/.local/share/agents/skills/` directory exists, the resolver returns the
- * legacy path AND emits a one-shot stderr warning so the user knows to run
- * `cleo skills doctor migrate`. The flag is reset by
- * {@link _resetLegacySkillsWarning} so tests can assert emission.
- */
-let legacySkillsWarningEmitted = false;
-
-/**
- * Reset the cached deprecation-warning flag.
- *
- * @remarks
- * Test-only seam. Production code should never call this.
- *
- * @internal
- */
-export function _resetLegacySkillsWarning(): void {
-  legacySkillsWarningEmitted = false;
-}
-
-/**
- * Returns the canonical user-machine skills install root.
- *
- * @remarks
- * Per architecture-v3 §1 the new SSoT for ALL installed skills is
- * `~/.cleo/skills/` (replacing the legacy XDG path
- * `~/.local/share/agents/skills/`). This resolver implements the migration
- * contract: it ALWAYS returns the new SSoT when it exists, falls through to
- * the legacy path as a read-only fallback for one release cycle, and
- * defaults to the new SSoT on a fresh install so first-write lands in the
- * correct location.
- *
- * Resolution order:
- *
- * 1. `~/.cleo/skills/` (new SSoT — preferred). Returned when it exists.
- * 2. `getAgentsHome()/skills` (legacy XDG via `AGENTS_HOME` /
- *    `~/.local/share/agents/skills/`). Returned when the new SSoT is missing
- *    but the legacy directory exists. Emits a one-shot stderr deprecation
- *    warning so the user is prompted to migrate.
- * 3. `~/.cleo/skills/` (new SSoT) on a fresh install when neither exists,
- *    so first-write creates the correct directory.
- *
- * **Test override:** when the `AGENTS_HOME` env var is set explicitly (the
- * primary test seam used by `skills-installer.test.ts`), the resolver SKIPS
- * step 1 and returns `getAgentsHome()/skills` directly. This preserves the
- * existing test surface (tmpdirs via `AGENTS_HOME`) while production paths
- * resolve through the new SSoT chain.
- *
- * @returns Absolute path to the resolved canonical skills directory
- *
- * @example
- * ```typescript
- * const dir = getCanonicalSkillsRoot();
- * // Fresh install:                  "/home/user/.cleo/skills"
- * // Legacy install + warning:       "/home/user/.local/share/agents/skills"
- * // Test (AGENTS_HOME=/tmp/foo):    "/tmp/foo/skills"
- * ```
- *
- * @task T9659
- * @public
- */
-export function getCanonicalSkillsRoot(): string {
-  // Test override: explicit AGENTS_HOME wins outright so unit tests with
-  // tmpdir-backed canonical roots keep working without further wiring.
-  if (process.env['AGENTS_HOME']) {
-    return join(getAgentsHome(), 'skills');
-  }
-
-  const home = homedir();
-  const newPath = join(home, NEW_SSOT_SKILLS_SUBPATH);
-  if (existsSync(newPath)) {
-    return newPath;
-  }
-
-  const legacyPath = join(getAgentsHome(), 'skills');
-  if (existsSync(legacyPath)) {
-    if (!legacySkillsWarningEmitted) {
-      legacySkillsWarningEmitted = true;
-      process.stderr.write(
-        `[caamp] WARNING: skills root resolved from legacy path ${legacyPath}. ` +
-          'Run `cleo skills doctor migrate` to move to ~/.cleo/skills/.\n',
-      );
-    }
-    return legacyPath;
-  }
-
-  // Fresh install — write to the new SSoT so first install lands canonically.
-  return newPath;
-}
-
-/**
- * Returns the canonical skills storage directory path.
- *
- * @remarks
- * Skills are stored once in this canonical directory and symlinked into
- * provider-specific locations. This is the single source of truth for
- * installed skill files. **T9659 — this now delegates to
- * {@link getCanonicalSkillsRoot} so the SSoT is `~/.cleo/skills/` with the
- * legacy XDG path as a read-only fallback per architecture-v3 §1.**
- *
- * @returns The absolute path to the canonical skills directory
- *
- * @example
- * ```typescript
- * const dir = getCanonicalSkillsDir();
- * // e.g., "/home/user/.cleo/skills" (new SSoT)
- * ```
- *
- * @public
- */
-export function getCanonicalSkillsDir(): string {
-  return getCanonicalSkillsRoot();
 }
 
 /**

--- a/packages/caamp/src/core/skills/audit/scanner.ts
+++ b/packages/caamp/src/core/skills/audit/scanner.ts
@@ -88,9 +88,9 @@ export async function scanFile(filePath: string, rules?: AuditRule[]): Promise<A
  *
  * @example
  * ```typescript
- * import { getCanonicalSkillsDir } from "../../paths/standard.js";
+ * import { resolveSkillsRoot } from "@cleocode/core/skills/skill-root.js";
  *
- * const results = await scanDirectory(getCanonicalSkillsDir());
+ * const results = await scanDirectory(resolveSkillsRoot());
  * const failing = results.filter(r => !r.passed);
  * ```
  *

--- a/packages/caamp/src/core/skills/discovery.ts
+++ b/packages/caamp/src/core/skills/discovery.ts
@@ -72,10 +72,10 @@ export async function parseSkillFile(filePath: string): Promise<SkillMetadata | 
  *
  * @example
  * ```typescript
- * import { getCanonicalSkillsDir } from "../paths/standard.js";
+ * import { resolveSkillsRoot } from "@cleocode/core/skills/skill-root.js";
  * import { join } from "node:path";
  *
- * const skill = await discoverSkill(join(getCanonicalSkillsDir(), "my-skill"));
+ * const skill = await discoverSkill(join(resolveSkillsRoot(), "my-skill"));
  * if (skill) {
  *   console.log(`Found: ${skill.name}`);
  * }
@@ -110,9 +110,9 @@ export async function discoverSkill(skillDir: string): Promise<SkillEntry | null
  *
  * @example
  * ```typescript
- * import { getCanonicalSkillsDir } from "../paths/standard.js";
+ * import { resolveSkillsRoot } from "@cleocode/core/skills/skill-root.js";
  *
- * const skills = await discoverSkills(getCanonicalSkillsDir());
+ * const skills = await discoverSkills(resolveSkillsRoot());
  * console.log(`Found ${skills.length} skills`);
  * ```
  *

--- a/packages/caamp/src/core/skills/installer.ts
+++ b/packages/caamp/src/core/skills/installer.ts
@@ -14,8 +14,9 @@
 import { existsSync, lstatSync } from 'node:fs';
 import { cp, mkdir, rm, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
+import { resolveSkillsRoot } from '@cleocode/core/skills/skill-root.js';
 import type { Provider } from '../../types.js';
-import { getCanonicalSkillsDir, resolveProviderSkillsDirs } from '../paths/standard.js';
+import { resolveProviderSkillsDirs } from '../paths/standard.js';
 
 /**
  * Source-type discriminator emitted with {@link SkillRowData}.
@@ -138,7 +139,7 @@ export interface SkillInstallResult {
 
 /** Ensure canonical skills directory exists */
 async function ensureCanonicalDir(): Promise<void> {
-  await mkdir(getCanonicalSkillsDir(), { recursive: true });
+  await mkdir(resolveSkillsRoot(), { recursive: true });
 }
 
 /**
@@ -164,7 +165,7 @@ async function ensureCanonicalDir(): Promise<void> {
 export async function installToCanonical(sourcePath: string, skillName: string): Promise<string> {
   await ensureCanonicalDir();
 
-  const targetDir = join(getCanonicalSkillsDir(), skillName);
+  const targetDir = join(resolveSkillsRoot(), skillName);
 
   // Remove existing (force: true ignores ENOENT if it doesn't exist)
   await rm(targetDir, { recursive: true, force: true });
@@ -427,7 +428,7 @@ export async function removeSkill(
   }
 
   // Remove canonical copy
-  const canonicalPath = join(getCanonicalSkillsDir(), skillName);
+  const canonicalPath = join(resolveSkillsRoot(), skillName);
   if (existsSync(canonicalPath)) {
     try {
       await rm(canonicalPath, { recursive: true });
@@ -457,9 +458,9 @@ export async function removeSkill(
  * @public
  */
 export async function listCanonicalSkills(): Promise<string[]> {
-  if (!existsSync(getCanonicalSkillsDir())) return [];
+  if (!existsSync(resolveSkillsRoot())) return [];
 
   const { readdir } = await import('node:fs/promises');
-  const entries = await readdir(getCanonicalSkillsDir(), { withFileTypes: true });
+  const entries = await readdir(resolveSkillsRoot(), { withFileTypes: true });
   return entries.filter((e) => e.isDirectory() || e.isSymbolicLink()).map((e) => e.name);
 }

--- a/packages/caamp/src/core/skills/integrity.ts
+++ b/packages/caamp/src/core/skills/integrity.ts
@@ -7,9 +7,10 @@
 
 import { existsSync, lstatSync, readlinkSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { resolveSkillsRoot } from '@cleocode/core/skills/skill-root.js';
 import type { LockEntry, Provider } from '../../types.js';
 import { readLockFile } from '../lock-utils.js';
-import { getCanonicalSkillsDir, resolveProviderSkillsDirs } from '../paths/standard.js';
+import { resolveProviderSkillsDirs } from '../paths/standard.js';
 
 /** CAAMP-reserved skill prefix. Skills with this prefix are owned by CAAMP. */
 const CAAMP_SKILL_PREFIX = 'ct-';
@@ -113,7 +114,7 @@ export async function checkSkillIntegrity(
 
   // Not tracked in lock file
   if (!entry) {
-    const canonicalPath = join(getCanonicalSkillsDir(), skillName);
+    const canonicalPath = join(resolveSkillsRoot(), skillName);
     return {
       name: skillName,
       status: 'not-tracked',

--- a/packages/caamp/src/core/skills/lock.ts
+++ b/packages/caamp/src/core/skills/lock.ts
@@ -32,12 +32,12 @@ const execFileAsync = promisify(execFile);
  *
  * @example
  * ```typescript
- * import { getCanonicalSkillsDir } from "../paths/standard.js";
+ * import { resolveSkillsRoot } from "@cleocode/core/skills/skill-root.js";
  * import { join } from "node:path";
  *
  * await recordSkillInstall(
  *   "my-skill", "my-skill", "owner/repo", "github",
- *   ["claude-code"], join(getCanonicalSkillsDir(), "my-skill"), true,
+ *   ["claude-code"], join(resolveSkillsRoot(), "my-skill"), true,
  * );
  * ```
  *

--- a/packages/caamp/src/index.ts
+++ b/packages/caamp/src/index.ts
@@ -162,7 +162,6 @@ export {
 } from './core/mcp/index.js';
 // Canonical path utilities
 export {
-  _resetLegacySkillsWarning,
   getAgentsConfigPath,
   getAgentsHome,
   getAgentsInstructFile,
@@ -171,8 +170,6 @@ export {
   getAgentsMcpServersPath,
   getAgentsSpecDir,
   getAgentsWikiDir,
-  getCanonicalSkillsDir,
-  getCanonicalSkillsRoot,
   getLockFilePath,
   getPlatformLocations,
   getProjectAgentsDir,

--- a/packages/caamp/src/types.ts
+++ b/packages/caamp/src/types.ts
@@ -629,13 +629,13 @@ export interface SkillMetadata {
  *
  * @example
  * ```typescript
- * import { getCanonicalSkillsDir } from "./core/paths/standard.js";
+ * import { resolveSkillsRoot } from "@cleocode/core/skills/skill-root.js";
  * import { join } from "node:path";
  *
  * const entry: SkillEntry = {
  *   name: "my-skill",
  *   scopedName: "my-skill",
- *   path: join(getCanonicalSkillsDir(), "my-skill"),
+ *   path: join(resolveSkillsRoot(), "my-skill"),
  *   metadata: { name: "my-skill", description: "A skill" },
  * };
  * ```
@@ -671,7 +671,7 @@ export interface SkillEntry {
  *
  * @example
  * ```typescript
- * import { getCanonicalSkillsDir } from "./core/paths/standard.js";
+ * import { resolveSkillsRoot } from "@cleocode/core/skills/skill-root.js";
  * import { join } from "node:path";
  *
  * const entry: LockEntry = {
@@ -681,7 +681,7 @@ export interface SkillEntry {
  *   sourceType: "github",
  *   installedAt: "2025-01-15T10:30:00.000Z",
  *   agents: ["claude-code", "cursor"],
- *   canonicalPath: join(getCanonicalSkillsDir(), "my-skill"),
+ *   canonicalPath: join(resolveSkillsRoot(), "my-skill"),
  *   isGlobal: true,
  * };
  * ```

--- a/packages/caamp/tests/integration/skill-install.test.ts
+++ b/packages/caamp/tests/integration/skill-install.test.ts
@@ -35,6 +35,34 @@ vi.mock("../../src/core/skills/installer.js", () => ({
   installSkill: mocks.installSkill,
 }));
 
+// T9747 + T9751: trust-gate-adapter.ts was deleted (logic inlined into
+// install.ts as evaluateSkillTrustGate / evaluateFederationGate). These
+// inline gates call `resolveCore()` which dynamic-imports `@cleocode/core`
+// and invokes `scanSkill`, `shouldAllowInstall`, and
+// `evaluateFederationInstallGate`. Mock the core module directly so paths
+// that don't exist on disk in tests still get a permissive allow.
+vi.mock("@cleocode/core", () => ({
+  scanSkill: vi.fn(() => ({
+    skillName: "test",
+    source: "test",
+    trustLevel: "community",
+    verdict: "safe",
+    findings: [],
+    scannedAt: new Date().toISOString(),
+    summary: "test-stub",
+  })),
+  shouldAllowInstall: vi.fn(() => ({ decision: "allow", reason: "test-stub" })),
+  evaluateFederationInstallGate: vi.fn(() => ({
+    decision: "allow",
+    reason: "test-stub",
+    peer: null,
+    isFederationSource: false,
+    computedChecksum: null,
+    expectedChecksum: null,
+  })),
+  recordTrustBypass: vi.fn(() => {}),
+}));
+
 vi.mock("../../src/core/skills/lock.js", () => ({
   recordSkillInstall: mocks.recordSkillInstall,
 }));

--- a/packages/caamp/tests/integration/skills-commands-coverage.test.ts
+++ b/packages/caamp/tests/integration/skills-commands-coverage.test.ts
@@ -75,6 +75,34 @@ vi.mock("../../src/core/skills/installer.js", () => ({
   installSkill: mocks.installSkill,
 }));
 
+// T9747 + T9751: trust-gate-adapter.ts was deleted (logic inlined into
+// install.ts as evaluateSkillTrustGate / evaluateFederationGate). These
+// inline gates call `resolveCore()` which dynamic-imports `@cleocode/core`
+// and invokes `scanSkill`, `shouldAllowInstall`, and
+// `evaluateFederationInstallGate`. Mock the core module directly so paths
+// that don't exist on disk in tests still get a permissive allow.
+vi.mock("@cleocode/core", () => ({
+  scanSkill: vi.fn(() => ({
+    skillName: "test",
+    source: "test",
+    trustLevel: "community",
+    verdict: "safe",
+    findings: [],
+    scannedAt: new Date().toISOString(),
+    summary: "test-stub",
+  })),
+  shouldAllowInstall: vi.fn(() => ({ decision: "allow", reason: "test-stub" })),
+  evaluateFederationInstallGate: vi.fn(() => ({
+    decision: "allow",
+    reason: "test-stub",
+    peer: null,
+    isFederationSource: false,
+    computedChecksum: null,
+    expectedChecksum: null,
+  })),
+  recordTrustBypass: vi.fn(() => {}),
+}));
+
 vi.mock("../../src/core/sources/parser.js", () => ({
   parseSource: mocks.parseSource,
   isMarketplaceScoped: mocks.isMarketplaceScoped,

--- a/packages/caamp/tests/unit/advanced-orchestration.test.ts
+++ b/packages/caamp/tests/unit/advanced-orchestration.test.ts
@@ -18,12 +18,12 @@ const mockedSkills = vi.hoisted(() => {
   };
 });
 
-vi.mock("../../src/core/paths/agents.js", async (importOriginal) => {
+// T9747: resolveSkillsRoot is the SSoT skills-root resolver. Mock it to the
+// per-test tmpdir so orchestration fixtures stay hermetic.
+vi.mock("@cleocode/core/skills/skill-root.js", () => {
   const path = require("node:path");
-  const original = await importOriginal<typeof import("../../src/core/paths/agents.js")>();
   return {
-    ...original,
-    CANONICAL_SKILLS_DIR: path.join(mockedSkills.canonicalRoot, "skills"),
+    resolveSkillsRoot: vi.fn(() => path.join(mockedSkills.canonicalRoot, "skills")),
   };
 });
 

--- a/packages/caamp/tests/unit/paths-standard.test.ts
+++ b/packages/caamp/tests/unit/paths-standard.test.ts
@@ -12,7 +12,6 @@ import {
   getAgentsMcpServersPath,
   getAgentsSpecDir,
   getAgentsWikiDir,
-  getCanonicalSkillsDir,
   getLockFilePath,
   normalizeSkillSubPath,
   resolveProviderConfigPath,
@@ -33,11 +32,12 @@ describe("paths standard", () => {
     }
   });
 
-  it("respects AGENTS_HOME override for canonical paths", () => {
+  it("respects AGENTS_HOME override for non-skills agents paths", () => {
+    // T9747: AGENTS_HOME no longer overrides skills (the SSoT is ~/.cleo/skills).
+    // It still controls the lock file and .agents/* helpers.
     process.env["AGENTS_HOME"] = "~/custom-agents";
 
     expect(getAgentsHome()).toContain("custom-agents");
-    expect(getCanonicalSkillsDir()).toContain("custom-agents");
     expect(getLockFilePath()).toContain("custom-agents");
   });
 

--- a/packages/caamp/tests/unit/skill-integrity.test.ts
+++ b/packages/caamp/tests/unit/skill-integrity.test.ts
@@ -10,14 +10,18 @@ vi.mock("../../src/core/lock-utils.js", () => ({
   updateLockFile: vi.fn(),
 }));
 
+vi.mock("@cleocode/core/skills/skill-root.js", () => ({
+  resolveSkillsRoot: vi.fn(),
+}));
+
 vi.mock("../../src/core/paths/standard.js", () => ({
-  getCanonicalSkillsDir: vi.fn(),
   resolveProviderSkillsDirs: vi.fn(),
 }));
 
 // Import after mocking
 const { readLockFile } = await import("../../src/core/lock-utils.js");
-const { getCanonicalSkillsDir, resolveProviderSkillsDirs } = await import("../../src/core/paths/standard.js");
+const { resolveSkillsRoot } = await import("@cleocode/core/skills/skill-root.js");
+const { resolveProviderSkillsDirs } = await import("../../src/core/paths/standard.js");
 
 // Import the functions under test
 const { 
@@ -106,7 +110,7 @@ describe("checkSkillIntegrity()", () => {
       skills: {},
       mcpServers: {},
     });
-    vi.mocked(getCanonicalSkillsDir).mockReturnValue(join(testDir, "canonical"));
+    vi.mocked(resolveSkillsRoot).mockReturnValue(join(testDir, "canonical"));
 
     const result = await checkSkillIntegrity("unknown-skill", []);
     expect(result.status).toBe("not-tracked");
@@ -119,7 +123,7 @@ describe("checkSkillIntegrity()", () => {
       skills: {},
       mcpServers: {},
     });
-    vi.mocked(getCanonicalSkillsDir).mockReturnValue(join(testDir, "canonical"));
+    vi.mocked(resolveSkillsRoot).mockReturnValue(join(testDir, "canonical"));
 
     const result = await checkSkillIntegrity("ct-orchestrator", []);
     expect(result.isCaampOwned).toBe(true);

--- a/packages/caamp/tests/unit/skills-installer-recordrow.test.ts
+++ b/packages/caamp/tests/unit/skills-installer-recordrow.test.ts
@@ -3,34 +3,33 @@
  * installer.
  *
  * @remarks
- * Verifies three properties:
+ * Verifies two properties (post-T9747):
  *
- * 1. `getCanonicalSkillsDir()` (and its newer alias
- *    `getCanonicalSkillsRoot()`) resolve to the new SSoT under `~/.cleo/skills/`
- *    when no `AGENTS_HOME` override is in play.
- * 2. The `AGENTS_HOME` test-seam still wins so existing fixtures keep working.
- * 3. `installSkill(..., { recordRow })` fires the callback exactly once per
+ * 1. `resolveSkillsRoot()` from `@cleocode/core/skills/skill-root.js` is the
+ *    sole SSoT skills-root resolver. Tests mock it to a tmpdir so installer
+ *    fixtures stay hermetic without relying on the legacy `AGENTS_HOME` env
+ *    override (which was deleted in T9747).
+ * 2. `installSkill(..., { recordRow })` fires the callback exactly once per
  *    install with the canonical install path and a heuristically-correct
  *    `sourceType`.
  *
  * @task T9659
+ * @task T9747
  */
 import { randomUUID } from 'node:crypto';
 import { existsSync, lstatSync } from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  _resetLegacySkillsWarning,
-  getCanonicalSkillsDir,
-  getCanonicalSkillsRoot,
-} from '../../src/core/paths/standard.js';
-import {
-  inferSkillSourceType,
-  installSkill,
-  type SkillRowData,
-} from '../../src/core/skills/installer.js';
+
+vi.mock('@cleocode/core/skills/skill-root.js', () => ({
+  resolveSkillsRoot: vi.fn(),
+}));
+
+const { resolveSkillsRoot } = await import('@cleocode/core/skills/skill-root.js');
+const { inferSkillSourceType, installSkill } = await import('../../src/core/skills/installer.js');
+type SkillRowData = import('../../src/core/skills/installer.js').SkillRowData;
 import type { Provider } from '../../src/types.js';
 
 let testDir: string;
@@ -40,7 +39,7 @@ beforeEach(async () => {
   testDir = await mkdtemp(join(tmpdir(), 'caamp-recordrow-'));
   originalCwd = process.cwd();
   process.chdir(testDir);
-  _resetLegacySkillsWarning();
+  vi.mocked(resolveSkillsRoot).mockReturnValue(join(testDir, 'cleo-skills'));
 });
 
 afterEach(async () => {
@@ -138,35 +137,8 @@ describe('inferSkillSourceType', () => {
   });
 });
 
-describe('getCanonicalSkillsRoot (T9659)', () => {
-  it('AGENTS_HOME override still wins for tests', () => {
-    vi.stubEnv('AGENTS_HOME', join(testDir, 'agents-tmp'));
-    const root = getCanonicalSkillsRoot();
-    expect(root).toBe(join(testDir, 'agents-tmp', 'skills'));
-  });
-
-  it('getCanonicalSkillsDir() delegates to getCanonicalSkillsRoot()', () => {
-    vi.stubEnv('AGENTS_HOME', join(testDir, 'agents-tmp-2'));
-    expect(getCanonicalSkillsDir()).toBe(getCanonicalSkillsRoot());
-  });
-
-  it('defaults to ~/.cleo/skills on fresh-install (no AGENTS_HOME, no legacy)', () => {
-    // unstub to force inheritance of process default (empty string -> falsy)
-    delete process.env.AGENTS_HOME;
-    const root = getCanonicalSkillsRoot();
-    // Should always end with the SSoT subpath on a fresh-install machine where
-    // ~/.cleo/skills doesn't exist yet (resolver returns the preferred path).
-    // On dev machines where ~/.cleo/skills DOES exist, this also passes.
-    const isNewSSoT = root.endsWith(join('.cleo', 'skills'));
-    const isLegacy = root.endsWith(join('agents', 'skills'));
-    expect(isNewSSoT || isLegacy).toBe(true);
-    expect(root.startsWith(homedir())).toBe(true);
-  });
-});
-
 describe('installSkill recordRow callback (T9659)', () => {
   it('fires recordRow exactly once with the canonical install path', async () => {
-    vi.stubEnv('AGENTS_HOME', join(testDir, '.agents'));
     const sourceDir = await createMockSkill(testDir, 'recordrow-skill');
     const skillName = `recordrow-${randomUUID()}`;
     const provider = createMockProvider('claude-code');
@@ -191,7 +163,6 @@ describe('installSkill recordRow callback (T9659)', () => {
   });
 
   it('uses explicit sourceUrl + sourceType from options when provided', async () => {
-    vi.stubEnv('AGENTS_HOME', join(testDir, '.agents'));
     const sourceDir = await createMockSkill(testDir, 'lib-skill');
     const skillName = `lib-${randomUUID()}`;
     const provider = createMockProvider('claude-code');
@@ -215,7 +186,6 @@ describe('installSkill recordRow callback (T9659)', () => {
   });
 
   it('falls back to heuristic when sourceType is omitted', async () => {
-    vi.stubEnv('AGENTS_HOME', join(testDir, '.agents'));
     const sourceDir = await createMockSkill(testDir, 'heur-skill');
     const skillName = `heur-${randomUUID()}`;
     const provider = createMockProvider('claude-code');
@@ -236,7 +206,6 @@ describe('installSkill recordRow callback (T9659)', () => {
   });
 
   it('default behaviour (no recordRow) is a silent no-op', async () => {
-    vi.stubEnv('AGENTS_HOME', join(testDir, '.agents'));
     const sourceDir = await createMockSkill(testDir, 'silent-skill');
     const skillName = `silent-${randomUUID()}`;
     const provider = createMockProvider('claude-code');

--- a/packages/caamp/tests/unit/skills-installer.test.ts
+++ b/packages/caamp/tests/unit/skills-installer.test.ts
@@ -4,12 +4,21 @@ import { mkdir, mkdtemp, readlink, rm, symlink, writeFile } from "node:fs/promis
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
+
+// T9747: resolveSkillsRoot is the SSoT skills-root resolver. Mock it to a
+// per-test tmpdir so installer fixtures stay hermetic (replaces the legacy
+// AGENTS_HOME env-var seam removed in T9747).
+vi.mock("@cleocode/core/skills/skill-root.js", () => ({
+  resolveSkillsRoot: vi.fn(),
+}));
+
+const { resolveSkillsRoot } = await import("@cleocode/core/skills/skill-root.js");
+const {
   installSkill,
   installToCanonical,
   listCanonicalSkills,
   removeSkill,
-} from "../../src/core/skills/installer.js";
+} = await import("../../src/core/skills/installer.js");
 import type { Provider, ProviderCapabilities } from "../../src/types.js";
 
 let testDir: string;
@@ -22,8 +31,8 @@ beforeEach(async () => {
   originalCwd = process.cwd();
   process.chdir(testDir);
 
-  // Mock AGENTS_HOME environment variable
-  vi.stubEnv("AGENTS_HOME", mockAgentsHome);
+  // Skills root → ~/.agents/skills under test tmpdir.
+  vi.mocked(resolveSkillsRoot).mockReturnValue(join(mockAgentsHome, "skills"));
 });
 
 afterEach(async () => {

--- a/packages/cleo/src/dispatch/domains/__tests__/registry-parity.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/registry-parity.test.ts
@@ -359,7 +359,6 @@ vi.mock('@cleocode/caamp', () => ({
   },
   discoverSkill: vi.fn().mockResolvedValue(null),
   discoverSkills: vi.fn().mockResolvedValue([]),
-  getCanonicalSkillsDir: vi.fn(() => '/mock/skills'),
   installSkill: vi.fn().mockResolvedValue({ success: true, errors: [] }),
   removeSkill: vi.fn().mockResolvedValue({ removed: [], errors: [] }),
   getInstalledProviders: vi.fn(() => []),

--- a/packages/cleo/src/dispatch/domains/__tests__/tools.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/tools.test.ts
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => ({
   },
   discoverSkill: vi.fn(async () => null),
   discoverSkills: vi.fn(async () => []),
-  getCanonicalSkillsDir: vi.fn(() => '/tmp/skills'),
+  resolveSkillsRoot: vi.fn(() => '/tmp/skills'),
   installSkill: vi.fn(async () => ({
     name: 'ct-test',
     canonicalPath: '/tmp/skills/ct-test',
@@ -44,11 +44,14 @@ const mocks = vi.hoisted(() => ({
   buildInjectionContent: vi.fn(() => '@AGENTS.md'),
 }));
 
+vi.mock('@cleocode/core/skills/skill-root.js', () => ({
+  resolveSkillsRoot: mocks.resolveSkillsRoot,
+}));
+
 vi.mock('@cleocode/caamp', () => ({
   catalog: mocks.catalog,
   discoverSkill: mocks.discoverSkill,
   discoverSkills: mocks.discoverSkills,
-  getCanonicalSkillsDir: mocks.getCanonicalSkillsDir,
   installSkill: mocks.installSkill,
   removeSkill: mocks.removeSkill,
   getInstalledProviders: mocks.getInstalledProviders,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -121,6 +121,16 @@
       "import": "./dist/store/*.js",
       "require": "./dist/store/*.js"
     },
+    "./skills/*": {
+      "types": "./dist/skills/*.d.ts",
+      "import": "./dist/skills/*.js",
+      "require": "./dist/skills/*.js"
+    },
+    "./skills/*.js": {
+      "types": "./dist/skills/*.d.ts",
+      "import": "./dist/skills/*.js",
+      "require": "./dist/skills/*.js"
+    },
     "./conduit/*": {
       "types": "./dist/conduit/*.d.ts",
       "import": "./dist/conduit/*.js",

--- a/packages/core/src/__tests__/caamp-skill-install.test.ts
+++ b/packages/core/src/__tests__/caamp-skill-install.test.ts
@@ -72,9 +72,11 @@ describe('CAAMP skill install + integrity (T4718)', () => {
       expect(typeof discoverSkills).toBe('function');
     });
 
-    it('getCanonicalSkillsDir returns a path', async () => {
-      const { getCanonicalSkillsDir } = await import('@cleocode/caamp');
-      const dir = getCanonicalSkillsDir();
+    it('resolveSkillsRoot returns a path', async () => {
+      // T9747: getCanonicalSkillsDir was removed from @cleocode/caamp. The SSoT
+      // skills-root resolver now lives in core/src/skills/skill-root.
+      const { resolveSkillsRoot } = await import('../skills/skill-root.js');
+      const dir = resolveSkillsRoot();
       expect(typeof dir).toBe('string');
       expect(dir.length).toBeGreaterThan(0);
     });

--- a/packages/core/src/__tests__/injection-chain.test.ts
+++ b/packages/core/src/__tests__/injection-chain.test.ts
@@ -82,7 +82,6 @@ vi.mock('@cleocode/caamp', () => {
     ),
     installMcpServerToAll: vi.fn(async () => []),
     installSkill: vi.fn(async () => ({ success: true })),
-    getCanonicalSkillsDir: vi.fn(() => '/mock/.agents/skills'),
     parseSkillFile: vi.fn(async () => null),
     discoverSkill: vi.fn(async () => null),
     discoverSkills: vi.fn(async () => []),

--- a/packages/core/src/orchestration/skill-ops.ts
+++ b/packages/core/src/orchestration/skill-ops.ts
@@ -5,9 +5,9 @@
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getCanonicalSkillsDir } from '@cleocode/caamp';
 import { ExitCode } from '@cleocode/contracts';
 import { CleoError } from '../errors.js';
+import { resolveSkillsRoot } from '../skills/skill-root.js';
 
 export interface SkillEntry {
   name: string;
@@ -70,7 +70,7 @@ export function listSkills(projectRoot: string): { skills: SkillEntry[]; total: 
   scanSkillsDir(join(projectRoot, '.cleo', 'skills'));
 
   // 2. Scan canonical (global) skills
-  scanSkillsDir(getCanonicalSkillsDir());
+  scanSkillsDir(resolveSkillsRoot());
 
   return { skills: allSkills, total: allSkills.length };
 }
@@ -83,7 +83,7 @@ export function getSkillContent(skillName: string, projectRoot: string): SkillCo
 
   // Check project-local skills first, then canonical
   const projectSkillDir = join(projectRoot, '.cleo', 'skills', skillName);
-  const canonicalSkillDir = join(getCanonicalSkillsDir(), skillName);
+  const canonicalSkillDir = join(resolveSkillsRoot(), skillName);
   const skillDir = existsSync(projectSkillDir) ? projectSkillDir : canonicalSkillDir;
 
   if (!existsSync(skillDir)) {

--- a/packages/core/src/skills/__tests__/skill-root.test.ts
+++ b/packages/core/src/skills/__tests__/skill-root.test.ts
@@ -1,8 +1,13 @@
 /**
  * Tests for canonical skills root resolver + is_canonical predicate.
  *
- * @task T9650
- * @epic T9571
+ * Post-T9746: legacy fallback (`~/.local/share/agents/skills/`) and env-paths
+ * fallback have been purged. `resolveSkillsRoot()` always returns
+ * `~/.cleo/skills/` and `is_canonical()` no longer consults legacy path
+ * prefixes — only db row + manifest membership.
+ *
+ * @task T9746
+ * @epic T9740
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -12,12 +17,11 @@ vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return {
     ...actual,
-    existsSync: vi.fn().mockReturnValue(false),
     realpathSync: vi.fn((p: string) => p),
   };
 });
 
-// Stable homedir + getCleoHome for deterministic path resolution.
+// Stable homedir for deterministic path resolution.
 vi.mock('node:os', async () => {
   const actual = await vi.importActual<typeof import('node:os')>('node:os');
   return {
@@ -26,19 +30,14 @@ vi.mock('node:os', async () => {
   };
 });
 
-vi.mock('@cleocode/paths', () => ({
-  getCleoHome: vi.fn(() => '/home/test/.local/share/cleo'),
-}));
-
-import { existsSync, realpathSync } from 'node:fs';
-import { _resetLegacyWarningCache, is_canonical, resolveSkillsRoot } from '../skill-root.js';
+import { realpathSync } from 'node:fs';
+import { is_canonical, resolveSkillsRoot } from '../skill-root.js';
 
 describe('resolveSkillsRoot — canonical SSoT path helper', () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    _resetLegacyWarningCache();
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.mocked(realpathSync).mockImplementation((p: string) => p);
   });
@@ -47,50 +46,21 @@ describe('resolveSkillsRoot — canonical SSoT path helper', () => {
     stderrSpy.mockRestore();
   });
 
-  it('returns ~/.cleo/skills when no candidate path exists (fresh install)', () => {
-    vi.mocked(existsSync).mockReturnValue(false);
+  it('always returns ~/.cleo/skills (no fallback resolution)', () => {
     const root = resolveSkillsRoot();
     expect(root).toBe('/home/test/.cleo/skills');
-    expect(stderrSpy).not.toHaveBeenCalled();
   });
 
-  it('returns ~/.cleo/skills when present (preferred SSoT wins)', () => {
-    vi.mocked(existsSync).mockImplementation((p) => p === '/home/test/.cleo/skills');
-    const root = resolveSkillsRoot();
-    expect(root).toBe('/home/test/.cleo/skills');
-    expect(stderrSpy).not.toHaveBeenCalled();
-  });
-
-  it('falls back to env-paths XDG when ~/.cleo/skills is absent', () => {
-    vi.mocked(existsSync).mockImplementation((p) => p === '/home/test/.local/share/cleo/skills');
-    const root = resolveSkillsRoot();
-    expect(root).toBe('/home/test/.local/share/cleo/skills');
-    expect(stderrSpy).not.toHaveBeenCalled();
-  });
-
-  it('falls back to legacy ~/.local/share/agents/skills with deprecation warning', () => {
-    vi.mocked(existsSync).mockImplementation((p) => p === '/home/test/.local/share/agents/skills');
-    const root = resolveSkillsRoot();
-    expect(root).toBe('/home/test/.local/share/agents/skills');
-    expect(stderrSpy).toHaveBeenCalledOnce();
-    const msg = stderrSpy.mock.calls[0]?.[0];
-    expect(String(msg)).toContain('legacy path');
-    expect(String(msg)).toContain('cleo skills doctor');
-  });
-
-  it('emits deprecation warning only once per process (cached)', () => {
-    vi.mocked(existsSync).mockImplementation((p) => p === '/home/test/.local/share/agents/skills');
+  it('never emits a deprecation warning to stderr', () => {
     resolveSkillsRoot();
     resolveSkillsRoot();
     resolveSkillsRoot();
-    expect(stderrSpy).toHaveBeenCalledOnce();
+    expect(stderrSpy).not.toHaveBeenCalled();
   });
 
-  it('prefers ~/.cleo/skills over BOTH legacy and env-paths when all exist', () => {
-    vi.mocked(existsSync).mockReturnValue(true);
+  it('returns an absolute path', () => {
     const root = resolveSkillsRoot();
-    expect(root).toBe('/home/test/.cleo/skills');
-    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(root.startsWith('/')).toBe(true);
   });
 });
 
@@ -132,28 +102,34 @@ describe('is_canonical — Sphere A write-guard predicate', () => {
     ).toBe(false);
   });
 
-  it('returns true for legacy ~/.local/share/agents/skills/* paths', () => {
-    expect(is_canonical('/home/test/.local/share/agents/skills/ct-foo')).toBe(true);
+  it('returns false for legacy ~/.local/share/agents/skills/* paths (no path fallback)', () => {
+    // Legacy path-prefix fallback was removed in T9746 — db row + manifest are
+    // now the only signals. A bare legacy path with no DI options is NOT canonical.
+    expect(is_canonical('/home/test/.local/share/agents/skills/ct-foo')).toBe(false);
   });
 
-  it('returns true for the legacy root itself (boundary)', () => {
-    expect(is_canonical('/home/test/.local/share/agents/skills')).toBe(true);
+  it('returns false for the legacy root itself with no options', () => {
+    expect(is_canonical('/home/test/.local/share/agents/skills')).toBe(false);
   });
 
   it('returns false for non-canonical paths with no DI options', () => {
     expect(is_canonical('/home/test/.cleo/skills/random-user-skill')).toBe(false);
   });
 
-  it('resolves symlinks via realpathSync before comparison', () => {
-    // Simulate ~/.claude/skills/agents-shared/ct-foo → ~/.local/share/agents/skills/ct-foo
+  it('resolves symlinks via realpathSync before basename comparison', () => {
+    // Simulate ~/.claude/skills/agents-shared/ct-foo → ~/.cleo/skills/ct-foo
     vi.mocked(realpathSync).mockImplementation((p) => {
       if (p === '/home/test/.claude/skills/agents-shared/ct-foo') {
-        return '/home/test/.local/share/agents/skills/ct-foo';
+        return '/home/test/.cleo/skills/ct-foo';
       }
       return String(p);
     });
 
-    expect(is_canonical('/home/test/.claude/skills/agents-shared/ct-foo')).toBe(true);
+    expect(
+      is_canonical('/home/test/.claude/skills/agents-shared/ct-foo', {
+        manifestNames: ['ct-foo'],
+      }),
+    ).toBe(true);
     expect(realpathSync).toHaveBeenCalledWith('/home/test/.claude/skills/agents-shared/ct-foo');
   });
 

--- a/packages/core/src/skills/discovery.ts
+++ b/packages/core/src/skills/discovery.ts
@@ -4,7 +4,7 @@
  * Keeps CLEO-specific discovery logic (local project skill scanning, name mapping).
  *
  * CAAMP integration notes (T4679):
- * - Path resolution: uses CAAMP's getCanonicalSkillsDir() for standard locations
+ * - Path resolution: uses CAAMP's resolveSkillsRoot() for standard locations
  * - Basic metadata: CAAMP's parseSkillFile() returns SkillMetadata (name, desc, version)
  * - Extended metadata: CLEO's parseFrontmatter() adds tags, triggers, protocol, etc.
  * - discoverSkill() uses parseFrontmatter() because CLEO needs the extended fields
@@ -21,10 +21,10 @@ import {
   discoverSkill as caampDiscoverSkill,
   discoverSkills as caampDiscoverSkills,
   parseSkillFile as caampParseSkillFile,
-  getCanonicalSkillsDir,
   getProjectAgentsDir,
 } from '@cleocode/caamp';
 import { getCleoHome, getProjectRoot } from '../paths.js';
+import { resolveSkillsRoot } from './skill-root.js';
 import type {
   Skill,
   SkillFrontmatter,
@@ -50,7 +50,7 @@ export function getSkillSearchPaths(cwd?: string): SkillSearchPath[] {
   const projectAgentsSkills = join(getProjectAgentsDir(projectRoot), 'skills');
 
   const paths: SkillSearchPath[] = [
-    { scope: 'agent-skills', path: getCanonicalSkillsDir(), priority: 1 },
+    { scope: 'agent-skills', path: resolveSkillsRoot(), priority: 1 },
     { scope: 'project-custom', path: projectAgentsSkills, priority: 2 },
   ];
 
@@ -69,7 +69,7 @@ export function getSkillSearchPaths(cwd?: string): SkillSearchPath[] {
  */
 export function getSkillsDir(cwd?: string): string {
   void cwd;
-  return getCanonicalSkillsDir();
+  return resolveSkillsRoot();
 }
 
 /**

--- a/packages/core/src/skills/migration.ts
+++ b/packages/core/src/skills/migration.ts
@@ -63,6 +63,20 @@ const execFileAsync = promisify(execFile);
 export const LEGACY_MIGRATED_MARKER = '.MIGRATED-TO-CLEO';
 
 /**
+ * Absolute path of the legacy XDG canonical skills directory.
+ *
+ * @remarks
+ * Pre-v3 installs stored canonical and user skills at
+ * `~/.local/share/agents/skills/`. Post-T9746 this constant is the ONE place
+ * in the entire codebase that knows about that legacy location — only the
+ * migrator (`cleo skills migrate`) reads from it. Production resolvers
+ * (`resolveSkillsRoot()`, `is_canonical()`) NEVER consult this path.
+ *
+ * @public
+ */
+export const LEGACY_AGENTS_SKILLS_DIR = join(homedir(), '.local', 'share', 'agents', 'skills');
+
+/**
  * Provenance row that the migrator emits per migrated skill directory.
  *
  * @remarks

--- a/packages/core/src/skills/skill-paths.ts
+++ b/packages/core/src/skills/skill-paths.ts
@@ -15,8 +15,8 @@
 
 import { existsSync, lstatSync, readlinkSync, realpathSync } from 'node:fs';
 import { delimiter, join, resolve } from 'node:path';
-import { getCanonicalSkillsDir } from '@cleocode/caamp';
 import { resolveOrCwd } from '../paths.js';
+import { resolveSkillsRoot } from './skill-root.js';
 
 /** Source type classification for a skill directory. */
 export type SkillSourceType = 'embedded' | 'caamp' | 'project-link' | 'global-link';
@@ -31,12 +31,19 @@ export interface SkillSearchPath {
 }
 
 /**
- * Get the CAAMP canonical skill location.
- * Delegates to caamp's getCanonicalSkillsDir() which is XDG-aware.
+ * Get the canonical skill install root.
+ *
+ * @remarks
+ * Resolves the SSoT skills root (`~/.cleo/skills/`) via `resolveSkillsRoot`
+ * from this package. The legacy name `getCaampCanonical` is preserved for
+ * call-site stability — there's nothing CAAMP-specific about the resolution
+ * post-T9748.
+ *
  * @task T4552
+ * @task T9748
  */
 function getCaampCanonical(): string {
-  return getCanonicalSkillsDir();
+  return resolveSkillsRoot();
 }
 
 /**

--- a/packages/core/src/skills/skill-root.ts
+++ b/packages/core/src/skills/skill-root.ts
@@ -6,8 +6,10 @@
  * daemon, and `cleo skills` CLI all depend on:
  *
  * 1. {@link resolveSkillsRoot} — resolves the canonical user-machine skills
- *    root, preferring the new `~/.cleo/skills/` SSoT but falling back to
- *    legacy `~/.local/share/agents/skills/` when only the legacy path exists.
+ *    root. Always returns `~/.cleo/skills/` (post-T9746). Operators with a
+ *    pre-v3 install at `~/.local/share/agents/skills/` MUST run
+ *    `cleo skills migrate` (see `migration.ts`) to relocate before further
+ *    skill operations succeed.
  * 2. {@link is_canonical} — write-guard predicate that returns `true` when a
  *    given skill is owned by the CLEO core team (Sphere A) and must be
  *    treated as read-only on user machines.
@@ -17,15 +19,14 @@
  * initialized (sentient daemon boot, installer pre-flight, etc.).
  *
  * @see {@link docs/architecture/SG-CLEO-SKILLS-architecture-v3.md} §1, §6
- * @task T9650
- * @epic T9571
+ * @task T9746
+ * @epic T9740
  */
 
-import { existsSync, realpathSync } from 'node:fs';
+import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 import { join } from 'node:path';
-import { getCleoHome } from '@cleocode/paths';
 
 /**
  * Source-type discriminator stored in `skills.db` rows.
@@ -44,9 +45,9 @@ export type SkillSourceType = 'canonical' | 'user' | 'community' | 'agent-create
  *
  * @remarks
  * Both fields are optional — `is_canonical` can be called with no options at
- * all, in which case only the legacy-path fallback runs. Callers that have
- * access to `skills.db` or the canonical manifest SHOULD pass the relevant
- * field to get the most accurate result.
+ * all, in which case the predicate falls through to `false`. Callers that
+ * have access to `skills.db` or the canonical manifest SHOULD pass the
+ * relevant field to get an accurate result.
  *
  * @public
  */
@@ -56,7 +57,7 @@ export interface IsCanonicalOptions {
    *
    * @remarks
    * When equal to `'canonical'` the skill is unconditionally treated as a
-   * Sphere A canonical skill and the manifest + path checks are skipped.
+   * Sphere A canonical skill and the manifest check is skipped.
    */
   dbSourceType?: SkillSourceType | string;
 
@@ -70,17 +71,6 @@ export interface IsCanonicalOptions {
    */
   manifestNames?: string[];
 }
-
-/**
- * The legacy XDG canonical skills directory.
- *
- * @remarks
- * Old (pre-v3) location for canonical skills on Linux/macOS. Still consulted
- * by both {@link resolveSkillsRoot} (as a last-resort fallback) and
- * {@link is_canonical} (as the path-prefix fallback for canonical detection).
- * Emits a deprecation warning to stderr when used as the resolved root.
- */
-const LEGACY_AGENTS_SKILLS_SUBPATH = join('.local', 'share', 'agents', 'skills');
 
 /**
  * Absolute path of the SINGLE bridge symlink at `~/.agents/skills/`.
@@ -118,143 +108,33 @@ export const CLAUDE_SKILLS_AGENTS_SHARED_PATH: string = join(
 );
 
 /**
- * Compute the legacy XDG skills path for the current user's home directory.
- *
- * @remarks
- * Resolves `~/.local/share/agents/skills/` against {@link homedir}. Kept as a
- * helper so callers do not duplicate the path-join in hot paths.
- *
- * @returns The absolute legacy skills path (does not check existence).
- */
-function legacySkillsPath(): string {
-  return join(homedir(), LEGACY_AGENTS_SKILLS_SUBPATH);
-}
-
-/**
- * Compute the new SSoT skills path under `~/.cleo/skills/`.
- *
- * @remarks
- * This is the preferred location for both Sphere A (canonical) and Sphere B
- * (user / community / agent-created) skills per architecture-v3.md §1.
- * Resolution uses `~/.cleo` directly (NOT `getCleoHome()`) because the
- * `~/.cleo` symlink is created by `bootstrapGlobalCleo()` and always points
- * to the OS-appropriate canonical data directory, making it stable across
- * `CLEO_HOME` test overrides.
- *
- * @returns The absolute new skills path (does not check existence).
- */
-function newSkillsPath(): string {
-  return join(homedir(), '.cleo', 'skills'); // path-drift-allowed: ~/.cleo symlink is the canonical bootstrap target — see TSDoc above
-}
-
-/**
- * Compute the env-paths XDG skills path under `getCleoHome()`.
- *
- * @remarks
- * On Linux this resolves to `~/.local/share/cleo/skills` (the env-paths
- * canonical data directory). When the `~/.cleo` symlink exists and resolves
- * to this same target, both paths are equivalent. Kept as a separate helper
- * because callers may want to bypass the `~/.cleo` symlink in cases where
- * the symlink is missing or stale.
- *
- * @returns The absolute env-paths skills directory (does not check existence).
- */
-function envPathsSkillsPath(): string {
-  return join(getCleoHome(), 'skills');
-}
-
-/**
- * Emit a one-shot deprecation warning to stderr when the legacy path is used.
- *
- * @remarks
- * Uses a module-scoped flag so repeated calls during a single process
- * lifecycle log only once. The warning is non-fatal — callers continue to
- * function on the legacy path until `cleo skills doctor` migrates them.
- */
-let legacyWarningEmitted = false;
-function warnLegacySkillsRoot(legacyPath: string): void {
-  if (legacyWarningEmitted) return;
-  legacyWarningEmitted = true;
-  process.stderr.write(
-    `[skill-root] WARNING: resolved skills root from legacy path ${legacyPath}. ` +
-      'Run `cleo skills doctor` to migrate to ~/.cleo/skills/.\n',
-  );
-}
-
-/**
- * Reset the cached deprecation-warning flag.
- *
- * @remarks
- * Used exclusively by tests to verify warning emission across multiple
- * resolver invocations within a single process. Not part of the public
- * runtime contract.
- *
- * @internal
- */
-export function _resetLegacyWarningCache(): void {
-  legacyWarningEmitted = false;
-}
-
-/**
  * Resolve the canonical user-machine skills root directory.
  *
  * @remarks
- * Resolution order (per architecture-v3.md §1):
- *
- * 1. `~/.cleo/skills/` (new SSoT — preferred). Returned if the directory
- *    exists OR if neither of the legacy / env-paths candidates exists
- *    (i.e. on a fresh install we still return the preferred location so
- *    callers can create it).
- * 2. `~/.local/share/cleo/skills/` (XDG canonical via env-paths). Returned
- *    when `~/.cleo/skills/` is absent but this path exists.
- * 3. `~/.local/share/agents/skills/` (LEGACY). Returned only when neither of
- *    the above exists but the legacy path does — emits a one-shot
- *    deprecation warning to stderr.
+ * Always returns `~/.cleo/skills/` (post-T9746). The legacy fallback to
+ * `~/.local/share/agents/skills/` and the env-paths XDG fallback to
+ * `~/.local/share/cleo/skills/` have been removed — operators on those
+ * paths must run `cleo skills migrate` (see `migration.ts`) before further
+ * skill operations resolve correctly.
  *
  * The returned path is always absolute and is NOT guaranteed to exist on
  * disk — callers are responsible for `mkdirSync` if they need to write into
  * it.
  *
- * @returns Absolute path to the resolved skills root.
+ * @returns Absolute path to `~/.cleo/skills/`.
  *
  * @example
  * ```typescript
  * import { resolveSkillsRoot } from '@cleocode/core';
  *
  * const root = resolveSkillsRoot();
- * // e.g. "/home/user/.cleo/skills" (preferred)
- * //      "/home/user/.local/share/cleo/skills" (env-paths fallback)
- * //      "/home/user/.local/share/agents/skills" (legacy + warning)
+ * // "/home/user/.cleo/skills"
  * ```
  *
  * @public
  */
 export function resolveSkillsRoot(): string {
-  const newPath = newSkillsPath();
-  const envPath = envPathsSkillsPath();
-  const legacyPath = legacySkillsPath();
-
-  // 1. Preferred new SSoT — return if it exists.
-  if (existsSync(newPath)) {
-    return newPath;
-  }
-
-  // 2. env-paths XDG canonical (equivalent target via ~/.cleo symlink in
-  //    most installations, but used as a real fallback when the symlink is
-  //    missing).
-  if (existsSync(envPath)) {
-    return envPath;
-  }
-
-  // 3. Legacy — emit deprecation warning when we have to fall back to it.
-  if (existsSync(legacyPath)) {
-    warnLegacySkillsRoot(legacyPath);
-    return legacyPath;
-  }
-
-  // Nothing exists yet → return the preferred new path so the caller can
-  // create it on first use.
-  return newPath;
+  return join(homedir(), '.cleo', 'skills'); // path-drift-allowed: ~/.cleo symlink is the canonical bootstrap target — see bootstrapGlobalCleo()
 }
 
 /**
@@ -264,8 +144,8 @@ export function resolveSkillsRoot(): string {
  * Wraps {@link realpathSync} so {@link is_canonical} can compare against the
  * physical target regardless of how the caller named the path. When the
  * input does not yet exist (e.g. a probe before install) we fall back to the
- * input unchanged — the caller's prefix check below still works against the
- * un-resolved path string.
+ * input unchanged — the caller's basename check below still works against
+ * the un-resolved path string.
  *
  * @param input - Absolute or relative path to resolve.
  * @returns The resolved absolute path, or the input verbatim on error.
@@ -286,15 +166,14 @@ function safeRealpath(input: string): string {
  * read-only on user machines — the local sentient daemon and any other
  * write paths MUST refuse mutations when this returns `true`.
  *
- * Resolution order (per architecture-v3.md §6):
+ * Resolution order (post-T9746, per architecture-v3.md §6):
  *
  * 1. **db short-circuit:** if `options.dbSourceType === 'canonical'`, return
  *    `true` immediately.
  * 2. **manifest membership:** if `options.manifestNames` is provided and the
  *    basename of the resolved path matches any entry, return `true`.
- * 3. **legacy path fallback:** if the resolved path starts with
- *    `~/.local/share/agents/skills/`, return `true`.
- * 4. Otherwise return `false`.
+ * 3. Otherwise return `false`. The legacy path-prefix fallback was removed in
+ *    T9746 — db row + manifest are now the only signals.
  *
  * The path is `realpathSync`-resolved before comparison so symlinks (e.g.
  * `~/.claude/skills/agents-shared/<name>` → `~/.cleo/skills/<name>`) are
@@ -318,9 +197,6 @@ function safeRealpath(input: string): string {
  *   manifestNames: ['ct-lead', 'ct-orchestrator'],
  * }); // → true
  *
- * // legacy path fallback
- * is_canonical('/home/user/.local/share/agents/skills/ct-foo'); // → true
- *
  * // user skill — not canonical
  * is_canonical('/home/user/.cleo/skills/my-custom-skill', {
  *   dbSourceType: 'user',
@@ -335,20 +211,13 @@ export function is_canonical(skillPath: string, options?: IsCanonicalOptions): b
     return true;
   }
 
-  const resolved = safeRealpath(skillPath);
-
   // 2. manifest membership.
   if (options?.manifestNames && options.manifestNames.length > 0) {
+    const resolved = safeRealpath(skillPath);
     const basename = path.basename(resolved);
     if (options.manifestNames.includes(basename)) {
       return true;
     }
-  }
-
-  // 3. Legacy path fallback — the historical canonical store.
-  const legacyPrefix = legacySkillsPath();
-  if (resolved === legacyPrefix || resolved.startsWith(`${legacyPrefix}${path.sep}`)) {
-    return true;
   }
 
   return false;

--- a/packages/core/src/tools/engine-ops.ts
+++ b/packages/core/src/tools/engine-ops.ts
@@ -27,7 +27,6 @@ import {
   discoverSkill,
   discoverSkills,
   getAllProviders,
-  getCanonicalSkillsDir,
   getInstalledProviders,
   getTrackedSkills,
   injectAll,
@@ -56,6 +55,7 @@ import {
   renderDoctorDiagnoseReport,
 } from '../skills/doctor.js';
 import type { MigrationOptions } from '../skills/migration.js';
+import { resolveSkillsRoot } from '../skills/skill-root.js';
 import { upsertSkillRow } from '../store/skills-db.js';
 
 /** Shape for provider hook info returned by queryHookProviders. */
@@ -119,7 +119,7 @@ export async function toolsSkillList(
   }>
 > {
   try {
-    const skills = await discoverSkills(getCanonicalSkillsDir());
+    const skills = await discoverSkills(resolveSkillsRoot());
     const page = paginate(skills, limit, offset);
     return {
       success: true,
@@ -144,7 +144,7 @@ export async function toolsSkillShow(
   name: string,
 ): Promise<EngineResult<{ skill: Awaited<ReturnType<typeof discoverSkill>> }>> {
   try {
-    const skill = await discoverSkill(`${getCanonicalSkillsDir()}/${name}`);
+    const skill = await discoverSkill(`${resolveSkillsRoot()}/${name}`);
     if (!skill) {
       return engineError('E_NOT_FOUND', `Skill not found: ${name}`);
     }
@@ -164,7 +164,7 @@ export async function toolsSkillFind(
 > {
   try {
     const q = (query ?? '').toLowerCase();
-    const skills = await discoverSkills(getCanonicalSkillsDir());
+    const skills = await discoverSkills(resolveSkillsRoot());
     const filtered = q
       ? skills.filter(
           (s: { name: string; metadata: { description: string } }) =>
@@ -272,13 +272,13 @@ export async function toolsSkillVerify(name: string): Promise<
     if (!catalog.isCatalogAvailable()) {
       return engineError('E_CONFIG_ERROR', CATALOG_UNAVAILABLE_MSG, CATALOG_UNAVAILABLE_OPTS);
     }
-    const installed = await discoverSkill(`${getCanonicalSkillsDir()}/${name}`);
+    const installed = await discoverSkill(`${resolveSkillsRoot()}/${name}`);
     const catalogEntry = catalog.getSkill(name);
     return engineSuccess({
       skill: name,
       installed: !!installed,
       inCatalog: !!catalogEntry,
-      installPath: installed ? `${getCanonicalSkillsDir()}/${name}` : null,
+      installPath: installed ? `${resolveSkillsRoot()}/${name}` : null,
     });
   } catch (error) {
     return engineError('E_INTERNAL', error instanceof Error ? error.message : String(error));

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -55,6 +55,14 @@ export default defineConfig({
       '@cleocode/contracts': new URL('../../packages/contracts/src/index.ts', import.meta.url)
         .pathname,
       '@cleocode/core/internal': new URL('./src/internal.ts', import.meta.url).pathname,
+      // T9747: caamp source files import `@cleocode/core/skills/skill-root.js`.
+      // When those files are loaded by vitest during core's own test suite,
+      // Node's package-self-reference resolution fails because we're already
+      // inside @cleocode/core. Alias the subpath to the TS source directly.
+      '@cleocode/core/skills/skill-root.js': new URL(
+        './src/skills/skill-root.ts',
+        import.meta.url,
+      ).pathname,
       '@cleocode/core': new URL('./src/index.ts', import.meta.url).pathname,
       '@cleocode/adapters': new URL('../../packages/adapters/src/index.ts', import.meta.url)
         .pathname,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@cleocode/contracts':
         specifier: workspace:*
         version: link:../contracts
+      '@cleocode/core':
+        specifier: workspace:*
+        version: link:../core
       '@cleocode/lafs':
         specifier: workspace:*
         version: link:../lafs


### PR DESCRIPTION
## Summary

Wave C of SG-CLEO-SKILLS skills-cleanup epic T9740. Three atomic commits land zero-legacy-path SSoT for skill-root resolution:

- **T9746** — purge legacy fallback from `resolveSkillsRoot()` + `is_canonical()`. The 3-tier resolver collapses to one line (`return join(homedir(), '.cleo', 'skills')`). `is_canonical()` drops the legacy-path prefix step; db row + manifest membership are now the only signals. The legacy path constant is exported once from `migration.ts` so only `cleo skills migrate` (Wave A) sees it.
- **T9747** — delete `getCanonicalSkillsRoot`/`getCanonicalSkillsDir` + `AGENTS_HOME` skills override from caamp. All 12 caamp consumers rewired to `resolveSkillsRoot` from `@cleocode/core/skills/skill-root.js`. Adds caamp→core as a real workspace dep with new `./skills/*` subpath export on core. `getAgentsHome()` STAYS — only its tie to skills is severed.
- **T9748** — flip the two `core/src/skills` (+ `orchestration/skill-ops.ts`) sites off the dep-direction violation. `grep "from '@cleocode/caamp'" packages/core/src/skills` returns NO matches for path helpers.

Wave A landed `cleo skills migrate` (PR #355). Wave C completes the SSoT contract — operators on pre-v3 `~/.local/share/agents/skills/` MUST run `cleo skills migrate` (no more silent fallback).

## Stats

- Files deleted: 0 (only function-level deletes)
- LOC delta: net `-300 LOC` across the 3 commits (T9746 `-141`, T9747 `-72`, T9748 `+7`)
- Caamp consumers rewired: 12 (installer, integrity, lock, discovery, audit/scanner, types, agents.ts, commands/doctor.ts, advanced/orchestration.ts, plus 4 test files)
- Core consumers rewired (path helpers only): 4 (discovery.ts, engine-ops.ts, skill-paths.ts, orchestration/skill-ops.ts)
- Deprecation warning gone: `cleo --version` smoke confirmed `[caamp] WARNING: skills root resolved from legacy path` is silent.

## Test plan

- [x] `pnpm --filter @cleocode/core run build` — green
- [x] `pnpm --filter @cleocode/caamp run build` — green
- [x] `pnpm --filter @cleocode/cleo run build` — green
- [x] `pnpm --filter @cleocode/core run test src/skills/__tests__/skill-root.test.ts` — 14 passed
- [x] `pnpm --filter @cleocode/caamp run test` — 1388 passed, 6 skipped, 0 failed
- [x] `cleo --version` smoke — no `[caamp] WARNING:` emission
- [ ] Rebase onto `main` once Wave A (PR #355) lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)