### PR TITLE
release: ship v2026.5.89 — T9738 carryforward closure (Epic T9752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## [2026.5.89] (2026-05-20) — T9738 carryforward closure (Epic T9752)
+
+Closes Epic **T9752** — the 5 deferred T9738 carryforwards from the
+v2026.5.88 IVTR remediation. Lands all 5 in a single release alongside
+SOLID/DRY refactor groundwork (pure aggregator + DB chokepoint
+discipline + realpath-aware test helpers).
+
+### Added (T9753 — changesets aggregator)
+
+- **PR #357 (T9753)** — `cleo release plan` now reads `.changeset/*.md`,
+  aggregates entries via a pure `aggregateChangesetsForRelease(...)`
+  helper, persists rows into the new `release_changesets` table, and
+  embeds the rendered CHANGELOG section into `plan.meta.releaseNotes`.
+  Re-run is idempotent (delete-then-insert keyed on `release_id`). All
+  writes route through the existing `getDb()` chokepoint — no raw SQL
+  outside the store layer. 13 new tests (8 aggregator + 5 wiring); 225
+  release tests pass with no regressions.
+
+### Refactored (T9756 — A4 uniform PK shape)
+
+- **PR #359 (T9756)** — new migration
+  `20260520163500_t9756-uniform-releases-pk` rewrites legacy
+  `releases.id` from `legacy:<version>` → `<projectHash>:<version>` so
+  every row uses the canonical PK shape. FK references in 4 dependent
+  tables (`release_commits`, `release_changes`, `release_artifacts`,
+  `brain_release_links`) update in lockstep under `PRAGMA
+  foreign_keys=OFF`. Idempotent re-apply; full revert restores
+  `legacy:` form. The discriminator in `releasesRowToManifest` switched
+  from a PK-prefix check to `tasks_json IS NULL/NOT NULL`, which is the
+  correct semantic boundary anyway.
+
+### Fixed (T9755 — commits backfill + FK)
+
+- **PR #358 (T9755)** — backfills 18 legacy v5.80 → v5.88 ship and
+  PR-merge SHAs into the `commits` table (9 ship + 8 PR-merge + 1
+  squash-merge), then re-adds the `releases.merge_commit_sha` →
+  `commits.sha` FK that PR #328 (B2) relaxed for expediency. Migration
+  is idempotent (`ON CONFLICT (sha) DO NOTHING`), wrapped in `PRAGMA
+  foreign_keys=OFF` for the table rebuild, and ships a
+  `LEGACY_BACKFILL_COMMIT_COUNT = 18` constant in affected fixtures so
+  count-based test assertions stay readable.
+
+- **PR #354 (T9757)** — `primary-guard.test.ts` is now realpath-aware.
+  Root cause: macOS `mkdtempSync` returns `/var/folders/...` (a symlink
+  to `/private/var/folders/...`) while `git worktree list --porcelain`
+  reports the realpath form, so the raw `w.path === repoRoot` predicate
+  silently failed on macOS only. Confirmed via Linux symlink repro (same
+  failure mode); 3 path-comparison sites in the test file are now
+  routed through the existing `isPrimaryWorktree(...)` helper. This
+  closes T9736 — the documented "merged-through-as-not-required" flake.
+
+### Removed (T9754 — cleanup)
+
+- **PR #353 (T9754)** — drops `@changesets/cli@^2.30.0` from root
+  devDependencies. PR #349 replaced upstream changesets with the
+  CLEO-native task-anchored DSL on 2026-05-20; the upstream package
+  has been dead weight since. 482 lockfile lines pruned. The stale
+  "Replaces the upstream `@changesets/cli` format" comment in
+  `packages/contracts/src/changesets.ts` is also corrected.
+
 ## [2026.5.88] (2026-05-20) — T9738 IVTR functional bug remediation close
 
 Closes Epic **T9738** (IVTR functional bug remediation, post-v5.83 real-world

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "conduit-core",
  "nom",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "cant-core",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "serde",
  "serde_json",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "cant-core",
  "serde",
@@ -394,7 +394,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-llm-native"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "lafs-core",
  "serde",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-core"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "chrono",
  "conduit-core",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-payments"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-protocol"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "cant-core",
  "chrono",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-sdk"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-storage"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-transport"
-version = "2026.5.88"
+version = "2026.5.89"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.88"
+version = "2026.5.89"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.88",
+  "version": "2026.5.89",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Closes Epic **T9752** — the 5 deferred T9738 carryforwards. All 5 PRs merged today:

- **#353 (T9754)** — remove dormant @changesets/cli devDep
- **#354 (T9757)** — primary-guard realpath comparison (closes T9736 macOS flake)
- **#357 (T9753)** — CLEO-native changesets aggregator (consumer side)
- **#358 (T9755)** — backfill 18 legacy ship commits + re-enable FK
- **#359 (T9756)** — A4 uniform releases.id PK shape

Cargo.lock realigned to v2026.5.89 in lockstep with workspace.

## SOLID/DRY groundwork shipped

- **Pure aggregator** — `aggregateChangesetsForRelease(...)` is fs/db-free; wiring at the plan.ts edge.
- **DB chokepoint discipline** — `persistReleaseChangesets` routes through `getDb()` + Drizzle, no raw SQL outside the store layer.
- **Realpath-aware test helpers** — `isPrimaryWorktree` already handled macOS symlinks; tests now consistently use it.
- **Schema discriminator correctness** — `releasesRowToManifest` switched from PK-prefix branch to `tasks_json IS NULL` semantic boundary.

## Test plan

- [x] All 5 sub-PRs merged green via admin (single macOS flake on #357/#359 was the pre-existing T9736, now fixed by #354)
- [x] `pnpm install` + `cargo check --workspace` regenerate lockfiles cleanly
- [ ] CI green on release branch (this PR)
- [ ] Tag pushed → release-publish workflow → GitHub Release → npm publish
- [ ] Install verify + IVTR smoke test on shipped v5.89