### PR TITLE
release: v2026.5.90 — SG-SKILLS-CLEANUP close (T9740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog
 
+## [2026.5.90] (2026-05-20) — SG-SKILLS-CLEANUP close (T9740)
+
+Closes Saga **SG-SKILLS-CLEANUP** (Epic **T9740**) — the four-sphere
+cleanup pass on the skills/CAAMP subsystem that converged on a single
+canonical `cleo skills migrate` command, collapsed three duplicated
+path resolvers into one SSoT line in `resolveSkillsRoot()`, and
+flipped the inverted caamp→core dependency direction so CORE no
+longer reaches into a leaf package for path helpers. Net: **-489
+LOC** across the four waves.
+
+### Changed (T9740 Wave A — single `cleo skills migrate`)
+
+- **PR #355 (T9741+T9742+T9743)** — collapses the historical
+  `cleo skills migrate` (Commander) and `cleo doctor migrate` (citty,
+  partial) into a single canonical citty surface. Migration helpers
+  move from `@cleocode/caamp` to
+  `@cleocode/core/skills/migration`; the dead Commander registrar
+  and `doctor migrate` alias are deleted. Resolves long-standing
+  "which migrate do I run?" confusion documented in the T9740
+  research note.
+
+### Changed (T9740 Wave B — doctor helpers to CORE)
+
+- **PR #360 (T9744+T9745)** — `runDoctorBridge` and `runDoctorAdopt`
+  move from the CLI handler into `@cleocode/core`, eliminating
+  business logic in the dispatch layer. Three duplicated path
+  resolvers (caamp + cleo-os + cleo) consolidate behind new SSoT
+  constants `AGENTS_SKILLS_BRIDGE_PATH` and friends. No behavioral
+  change — only the import paths shift.
+
+### Changed (T9740 Wave C — ZERO legacy paths)
+
+- **PR #361 (T9746+T9747+T9748)** — `resolveSkillsRoot()` is now a
+  single line: `return join(homedir(), '.cleo', 'skills')`. The
+  legacy `$AGENTS_HOME/skills` fallback, the
+  `[caamp] WARNING: skills root resolved from legacy path`
+  deprecation log, and the `getCanonicalSkillsRoot/Dir` helpers in
+  `@cleocode/caamp` are all deleted. The caamp→core dependency
+  direction is flipped — CORE no longer imports from caamp for
+  skills-path resolution, restoring the canonical layering. ~300
+  LOC net removal.
+
+### Changed (T9740 Wave D — CLI polish)
+
+- **PR #356 (T9749+T9750+T9751)** — `proposeCanonicalPatch()` moves
+  from the CLI into `@cleocode/core`; four inline `openSkillsDb`
+  queries in `sentient.ts` move into CORE adapters; the orphan
+  `trust-gate-adapter.ts` shim is deleted (-189 LOC). Pure refactor
+  with no surface change.
+
+### Removed
+
+- `[caamp] WARNING: skills root resolved from legacy path`
+  deprecation warning (verified silent on `cleo --version` once
+  Wave C lands).
+- `getCanonicalSkillsRoot` and `getCanonicalSkillsDir` from
+  `@cleocode/caamp` — replaced by the SSoT helper in
+  `@cleocode/core`.
+- `trust-gate-adapter.ts` (Wave D) — superseded by inline CORE
+  resolver in `install.ts`.
+
+### Internal
+
+- Net **-489 LOC** across Spheres A/B/C/D combined.
+- Three duplicated path resolvers collapsed to one SSoT.
+- caamp no longer a transitive dep of CORE for skills paths.
+
 ## [2026.5.89] (2026-05-20) — T9738 carryforward closure (Epic T9752)
 
 Closes Epic **T9752** — the 5 deferred T9738 carryforwards from the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "conduit-core",
  "nom",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "cant-core",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "serde",
  "serde_json",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "cant-core",
  "serde",
@@ -394,7 +394,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-llm-native"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "lafs-core",
  "serde",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-core"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "chrono",
  "conduit-core",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-payments"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-protocol"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "cant-core",
  "chrono",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-sdk"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-storage"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-transport"
-version = "2026.5.89"
+version = "2026.5.90"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.89"
+version = "2026.5.90"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.89",
+  "version": "2026.5.90",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Closes Saga **SG-SKILLS-CLEANUP** (Epic **T9740**) — the four-sphere
cleanup pass on the skills/CAAMP subsystem.

**Why now?** The four T9740 PRs (#355, #356, #360, #361) merged
between v2026.5.89's CHANGELOG and tag, so their CHANGELOG entries
were never written. v2026.5.89's release notes describe the T9738
carryforwards (T9752 epic) — this release groups the four T9740
waves under their own version.

## What ships

| Wave | PRs | Highlight |
|------|-----|-----------|
| **A** (T9741+T9742+T9743) | #355 | Single canonical `cleo skills migrate` — no more `doctor migrate` confusion; helpers move to `@cleocode/core/skills/migration`; dead Commander registrar deleted |
| **B** (T9744+T9745) | #360 | `runDoctorBridge` + `runDoctorAdopt` move to CORE; 3 duplicated path resolvers collapsed; new `AGENTS_SKILLS_BRIDGE_PATH` SSoT consts |
| **C** (T9746+T9747+T9748) | #361 | **ZERO legacy paths** — `resolveSkillsRoot()` collapsed to one line (`return join(homedir(), '.cleo', 'skills')`); `getCanonicalSkillsRoot/Dir` deleted from caamp; caamp→core dep direction flipped (-300 LOC) |
| **D** (T9749+T9750+T9751) | #356 | Extract `proposeCanonicalPatch` to CORE; 4 inline `openSkillsDb` queries move to CORE adapters; delete `trust-gate-adapter.ts` (-189 LOC) |

**Net: -489 LOC** across the saga.

## Mechanical bumps

- 21 npm `package.json` files: 2026.5.89 → 2026.5.90
- `Cargo.toml` `workspace.package.version`: 2026.5.89 → 2026.5.90
- `Cargo.lock`: 17 workspace crates re-stamped via `cargo update --workspace`
- `CHANGELOG.md`: new `## [2026.5.90]` section above the existing v2026.5.89 entry

## Test plan

- [ ] CI green on PR (Lint, Build, Test, Lockfile Check, Contracts Dep Lint)
- [ ] After merge: trusted-publisher OIDC fires on `v2026.5.90` tag push
- [ ] After publish: `npm install -g @cleocode/cleo@2026.5.90` then `cleo --version` reports `2026.5.90`
- [ ] After install: `cleo skills migrate --help` shows the canonical citty surface (no deprecation log)
- [ ] After install: `cleo doctor --help` no longer lists `migrate` subcommand