### PR TITLE
refactor(T9766): centralize logger + memory types in @cleocode/contracts

### DIFF
--- a/packages/cleo/src/cli/logger-bootstrap.ts
+++ b/packages/cleo/src/cli/logger-bootstrap.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
-import type { LoggerConfig } from '@cleocode/core';
+// T9766 — `LoggerConfig` is now centralized in `@cleocode/contracts`.
+import type { LoggerConfig } from '@cleocode/contracts';
 import { getProjectInfoSync, initLogger } from '@cleocode/core';
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -499,6 +499,8 @@ export type {
 } from './llm/provider-profile.js';
 // === Phase 4 Unified Architecture (T9281 / ADR-072) — Resolved credential ===
 export type { ResolvedCredential } from './llm/resolved-credential.js';
+// === Logger contract (T9766 — centralized from @cleocode/core) ===
+export type { LoggerConfig } from './logger.js';
 // === ContextEngine contract (canonical home — T9304) ===
 export type { CompressedContext, ContextEngine } from './memory/context-engine.js';
 export type {
@@ -507,8 +509,14 @@ export type {
   BridgeObservation,
   BridgePattern,
   DispatchTrace,
+  // T9766 — BRAIN public-API records (centralized from @cleocode/core)
+  LearningRecord,
   MemoryBridgeConfig,
   MemoryBridgeContent,
+  MemoryDecisionRecord,
+  MemoryGraphStats,
+  MemorySearchHit,
+  PatternRecord,
   SessionSummary,
 } from './memory.js';
 export type {

--- a/packages/contracts/src/logger.ts
+++ b/packages/contracts/src/logger.ts
@@ -1,0 +1,42 @@
+/**
+ * Logger configuration contract for the CLEO ecosystem.
+ *
+ * Lives in `@cleocode/contracts` so CLI bootstrap, harness adapters, and other
+ * consumer packages can wire pino without reaching into `@cleocode/core` for a
+ * type definition. The implementation (`initLogger`, `getLogger`, etc.) remains
+ * in `@cleocode/core/logger`.
+ *
+ * @task T9766
+ * @epic T9752
+ * @saga T9758
+ */
+
+/**
+ * Configuration for the centralized pino logger.
+ *
+ * @remarks
+ * Consumed by `@cleocode/core`'s `initLogger` factory. The CLI bootstrap reads
+ * the corresponding `logging` section of `CleoConfig` and forwards it verbatim.
+ *
+ * @example
+ * ```typescript
+ * import type { LoggerConfig } from '@cleocode/contracts';
+ *
+ * const config: LoggerConfig = {
+ *   level: 'info',
+ *   filePath: 'logs/cleo.log',
+ *   maxFileSize: 10 * 1024 * 1024,
+ *   maxFiles: 5,
+ * };
+ * ```
+ */
+export interface LoggerConfig {
+  /** Pino log level (`trace` | `debug` | `info` | `warn` | `error` | `fatal`). */
+  level: string;
+  /** Path to the primary log file, relative to the `.cleo` directory. */
+  filePath: string;
+  /** Maximum bytes per log file before pino-roll rotates to a new file. */
+  maxFileSize: number;
+  /** Maximum number of rotated log files to retain before pino-roll deletes oldest. */
+  maxFiles: number;
+}

--- a/packages/contracts/src/memory.ts
+++ b/packages/contracts/src/memory.ts
@@ -1,8 +1,28 @@
 /**
- * Memory bridge types for CLEO provider adapters.
- * Defines the shape of .cleo/memory-bridge.md content for cross-provider memory sharing.
+ * Memory bridge types for CLEO provider adapters and BRAIN public-API records.
+ *
+ * Two sets of types live in this file:
+ *
+ * 1. **Memory bridge types** (`MemoryBridgeContent`, `BridgeLearning`, …) — define
+ *    the shape of `.cleo/memory-bridge.md` content for cross-provider memory
+ *    sharing. Original home; added under T5240.
+ * 2. **BRAIN public-API records** (`MemorySearchHit`, `MemoryGraphStats`,
+ *    `MemoryDecisionRecord`, `PatternRecord`, `LearningRecord`) — typed result
+ *    shapes returned by `@cleocode/core`'s memory public API
+ *    (`findMemoryEntries`, `getDecisions`, `getPatterns`, `getLearnings`,
+ *    `getMemoryGraph`). Centralized here under T9766 so Studio + CLI consumers
+ *    can depend on them without reaching into `@cleocode/core`.
+ *
+ * @remarks
+ * `MemoryDecisionRecord` deliberately differs in name from the session-ops
+ * `DecisionRecord` exported by `./operations/session.ts` to avoid a barrel-level
+ * name collision. The two shapes are NOT interchangeable: session-ops captures
+ * an audit-log entry (`sessionId`, `taskId`, `alternatives`, `timestamp`),
+ * whereas `MemoryDecisionRecord` captures a BRAIN graph node
+ * (`outcome`, `memoryTier`, `verified`, `createdAt`).
  *
  * @task T5240
+ * @task T9766
  */
 
 // ============================================================================
@@ -179,4 +199,136 @@ export interface BridgeObservation {
   date: string;
   /** Truncated summary of the observation content. */
   summary: string;
+}
+
+// ============================================================================
+// BRAIN public-API records (T9766 — centralized from @cleocode/core)
+// ============================================================================
+
+/**
+ * A single cross-table memory search hit returned by `findMemoryEntries`.
+ *
+ * @remarks
+ * Spans all four BRAIN tables (observations, decisions, patterns, learnings) and
+ * is what the `memory.find` dispatch operation surfaces to the CLI and Studio.
+ *
+ * @task T9766
+ */
+export interface MemorySearchHit {
+  /** Entry identifier. */
+  id: string;
+  /** Source brain table. */
+  table: 'observations' | 'decisions' | 'patterns' | 'learnings';
+  /** Display title. */
+  title: string;
+  /** Short preview string (first ~160 chars of narrative/rationale/context). */
+  preview: string;
+  /** ISO 8601 creation timestamp. */
+  createdAt: string;
+  /** Quality score in [0..1] or null if not computed. */
+  quality: number | null;
+  /** Memory tier (`'short'` | `'medium'` | `'long'`). */
+  tier: string | null;
+  /** Whether the entry has been owner-verified (1 = true, 0 = false). */
+  verified: number;
+  /** Number of times this entry has been retrieved. */
+  citations: number;
+}
+
+/**
+ * Aggregate statistics for the BRAIN memory graph returned by `getMemoryGraph`.
+ *
+ * @remarks
+ * Used by the `memory.graph` dispatch op and Studio's `/api/memory/graph` route.
+ *
+ * @task T9766
+ */
+export interface MemoryGraphStats {
+  /** Total node count. */
+  nodeCount: number;
+  /** Total edge count. */
+  edgeCount: number;
+  /** Edge type distribution. */
+  edgeTypeDistribution: Record<string, number>;
+  /** Average edges per node. */
+  averageEdgesPerNode: number;
+}
+
+/**
+ * A single decision record returned by `getDecisions`.
+ *
+ * @remarks
+ * **Intentionally named `MemoryDecisionRecord`** to avoid a barrel-level
+ * collision with the session-ops `DecisionRecord` exported by
+ * `./operations/session.ts`. The session-ops shape is an audit-log entry
+ * (`sessionId`, `taskId`, `alternatives`, `timestamp`); this shape is a BRAIN
+ * graph node (`outcome`, `memoryTier`, `verified`, `createdAt`).
+ *
+ * `@cleocode/core` continues to re-export this type under the legacy name
+ * `DecisionRecord` from its main barrel for back-compat — see
+ * `packages/core/src/memory/public-api.ts`.
+ *
+ * @task T9766
+ */
+export interface MemoryDecisionRecord {
+  /** Decision identifier (e.g. `D-arch-001`). */
+  id: string;
+  /** Decision statement. */
+  decision: string;
+  /** Justification / rationale. */
+  rationale: string | null;
+  /** Outcome: `proposed` | `accepted` | `rejected` | `superseded`. */
+  outcome: string | null;
+  /** ISO creation timestamp. */
+  createdAt: string;
+  /** Memory tier. */
+  memoryTier: string | null;
+  /** Owner-verified flag. */
+  verified: number;
+}
+
+/**
+ * A single pattern record returned by `getPatterns`.
+ *
+ * @task T9766
+ */
+export interface PatternRecord {
+  /** Pattern identifier. */
+  id: string;
+  /** Pattern description. */
+  pattern: string;
+  /** Contextual description where the pattern applies. */
+  context: string | null;
+  /** Pattern type tag. */
+  patternType: string | null;
+  /** Impact level (`'low'` | `'medium'` | `'high'`). */
+  impact: string | null;
+  /** Extraction timestamp. */
+  extractedAt: string;
+  /** Memory tier. */
+  memoryTier: string | null;
+  /** Retrieval count. */
+  citationCount: number;
+}
+
+/**
+ * A single learning record returned by `getLearnings`.
+ *
+ * @task T9766
+ */
+export interface LearningRecord {
+  /** Learning identifier. */
+  id: string;
+  /** Core insight. */
+  insight: string;
+  /** Source context where the learning was extracted from. */
+  source: string | null;
+  /** Learning type tag. */
+  learningType: string | null;
+  /** Creation timestamp. */
+  createdAt: string;
+  /** Memory tier. */
+  memoryTier: string | null;
+  /** Retrieval count. */
+  citationCount: number;
 }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -11,7 +11,14 @@
 
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import type { LoggerConfig } from '@cleocode/contracts';
 import pino from 'pino';
+
+// T9766 — `LoggerConfig` lives in `@cleocode/contracts`. Re-export here so
+// existing `import { LoggerConfig } from '@cleocode/core'` continues to work
+// without churn. New consumers should import from `@cleocode/contracts`
+// directly.
+export type { LoggerConfig };
 
 /**
  * Minimal shape of the pino-roll transport return value. `pino.transport()`
@@ -27,13 +34,6 @@ interface TransportStream {
 let rootLogger: pino.Logger | null = null;
 let currentLogDir: string | null = null;
 let currentTransport: TransportStream | null = null;
-
-export interface LoggerConfig {
-  level: string;
-  filePath: string;
-  maxFileSize: number;
-  maxFiles: number;
-}
 
 /**
  * Convert bytes to a human-readable size string for pino-roll.

--- a/packages/core/src/memory/public-api.ts
+++ b/packages/core/src/memory/public-api.ts
@@ -14,6 +14,16 @@
  * @epic T9592
  */
 
+import type {
+  // T9766 — `MemoryDecisionRecord` is the canonical name in @cleocode/contracts;
+  // we import it under the legacy alias `DecisionRecord` so existing call sites
+  // (Studio + dispatch engine) keep working without churn.
+  MemoryDecisionRecord as DecisionRecord,
+  LearningRecord,
+  MemoryGraphStats,
+  MemorySearchHit,
+  PatternRecord,
+} from '@cleocode/contracts';
 import { getProjectRoot } from '../paths.js';
 import { getBrainNativeDb } from '../store/memory-sqlite.js';
 import { listDecisions, searchDecisions } from './decisions.js';
@@ -22,30 +32,28 @@ import { searchLearnings } from './learnings.js';
 import { type PatternType, searchPatterns } from './patterns.js';
 
 // ---------------------------------------------------------------------------
-// findMemoryEntries
+// Type re-exports (T9766 — centralized in @cleocode/contracts)
 // ---------------------------------------------------------------------------
+//
+// `MemorySearchHit`, `MemoryGraphStats`, `MemoryDecisionRecord`, `PatternRecord`,
+// and `LearningRecord` all live in `@cleocode/contracts/memory` so cross-package
+// consumers (Studio, CLI, etc.) can depend on them without reaching into Core.
+//
+// The legacy name `DecisionRecord` is re-aliased to `MemoryDecisionRecord` for
+// back-compat — Studio's `+server.ts` files and `@cleocode/cleo`'s dispatch
+// engine already import `DecisionRecord` from `@cleocode/core`.
 
-/** A single cross-table memory search hit. */
-export interface MemorySearchHit {
-  /** Entry identifier. */
-  id: string;
-  /** Source brain table. */
-  table: 'observations' | 'decisions' | 'patterns' | 'learnings';
-  /** Display title. */
-  title: string;
-  /** Short preview string (first ~160 chars of narrative/rationale/context). */
-  preview: string;
-  /** ISO 8601 creation timestamp. */
-  createdAt: string;
-  /** Quality score in [0..1] or null if not computed. */
-  quality: number | null;
-  /** Memory tier ('short' | 'medium' | 'long'). */
-  tier: string | null;
-  /** Whether the entry has been owner-verified (1 = true, 0 = false). */
-  verified: number;
-  /** Number of times this entry has been retrieved. */
-  citations: number;
-}
+export type {
+  // Back-compat alias: legacy `DecisionRecord` continues to mean the memory v2
+  // shape from `@cleocode/contracts` (canonical name: `MemoryDecisionRecord`).
+  // The session-ops `DecisionRecord` is a distinct type living in
+  // `@cleocode/contracts/operations/session`.
+  DecisionRecord,
+  LearningRecord,
+  MemoryGraphStats,
+  MemorySearchHit,
+  PatternRecord,
+};
 
 /** Options for {@link findMemoryEntries}. */
 export interface FindMemoryEntriesOptions {
@@ -462,24 +470,6 @@ export interface GetDecisionsOptions {
   limit?: number;
 }
 
-/** A single decision record returned by {@link getDecisions}. */
-export interface DecisionRecord {
-  /** Decision identifier (e.g. D-arch-001). */
-  id: string;
-  /** Decision statement. */
-  decision: string;
-  /** Justification / rationale. */
-  rationale: string | null;
-  /** Outcome: proposed | accepted | rejected | superseded. */
-  outcome: string | null;
-  /** ISO creation timestamp. */
-  createdAt: string;
-  /** Memory tier. */
-  memoryTier: string | null;
-  /** Owner-verified flag. */
-  verified: number;
-}
-
 /**
  * Retrieve decision records from brain.db, optionally filtered by text query.
  *
@@ -544,26 +534,6 @@ export interface GetPatternsOptions {
   limit?: number;
 }
 
-/** A single pattern record returned by {@link getPatterns}. */
-export interface PatternRecord {
-  /** Pattern identifier. */
-  id: string;
-  /** Pattern description. */
-  pattern: string;
-  /** Contextual description where the pattern applies. */
-  context: string | null;
-  /** Pattern type tag. */
-  patternType: string | null;
-  /** Impact level ('low' | 'medium' | 'high'). */
-  impact: string | null;
-  /** Extraction timestamp. */
-  extractedAt: string;
-  /** Memory tier. */
-  memoryTier: string | null;
-  /** Retrieval count. */
-  citationCount: number;
-}
-
 /**
  * Retrieve pattern records from brain.db, optionally filtered by text query.
  *
@@ -620,24 +590,6 @@ export interface GetLearningsOptions {
   limit?: number;
 }
 
-/** A single learning record returned by {@link getLearnings}. */
-export interface LearningRecord {
-  /** Learning identifier. */
-  id: string;
-  /** Core insight. */
-  insight: string;
-  /** Source context where the learning was extracted from. */
-  source: string | null;
-  /** Learning type tag. */
-  learningType: string | null;
-  /** Creation timestamp. */
-  createdAt: string;
-  /** Memory tier. */
-  memoryTier: string | null;
-  /** Retrieval count. */
-  citationCount: number;
-}
-
 /**
  * Retrieve learning records from brain.db, optionally filtered by text query.
  *
@@ -683,18 +635,6 @@ export async function getLearnings(
 export interface GetMemoryGraphOptions {
   /** Project root path; defaults to resolved root. */
   projectPath?: string;
-}
-
-/** Aggregate graph statistics returned by {@link getMemoryGraph}. */
-export interface MemoryGraphStats {
-  /** Total node count. */
-  nodeCount: number;
-  /** Total edge count. */
-  edgeCount: number;
-  /** Edge type distribution. */
-  edgeTypeDistribution: Record<string, number>;
-  /** Average edges per node. */
-  averageEdgesPerNode: number;
 }
 
 /**

--- a/packages/studio/src/routes/api/memory/decisions/+server.ts
+++ b/packages/studio/src/routes/api/memory/decisions/+server.ts
@@ -6,7 +6,13 @@
  * Zero raw SQL in this handler.
  */
 
-import { type DecisionRecord, getDecisions } from '@cleocode/core';
+// T9766 — `MemoryDecisionRecord` is the canonical name in `@cleocode/contracts`
+// (the contracts barrel also re-exports a session-ops `DecisionRecord` of a
+// DIFFERENT shape — we deliberately import the memory variant by its full
+// name and re-export it under the legacy `DecisionRecord` name so the API
+// response shape stays stable for existing callers).
+import type { MemoryDecisionRecord as DecisionRecord } from '@cleocode/contracts';
+import { getDecisions } from '@cleocode/core';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 

--- a/packages/studio/src/routes/api/memory/find/+server.ts
+++ b/packages/studio/src/routes/api/memory/find/+server.ts
@@ -10,7 +10,11 @@
  * search page can group by table without knowing the underlying schema.
  */
 
-import { findMemoryEntries, type MemorySearchHit } from '@cleocode/core';
+// T9766 — `MemorySearchHit` is now centralized in `@cleocode/contracts`.
+// Studio depends on the type contract directly; `findMemoryEntries` remains
+// the runtime entry point from `@cleocode/core`.
+import type { MemorySearchHit } from '@cleocode/contracts';
+import { findMemoryEntries } from '@cleocode/core';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 

--- a/packages/studio/src/routes/api/memory/graph/+server.ts
+++ b/packages/studio/src/routes/api/memory/graph/+server.ts
@@ -12,7 +12,9 @@
  * use the search or observations endpoints instead.
  */
 
-import { getMemoryGraph, type MemoryGraphStats } from '@cleocode/core';
+// T9766 — `MemoryGraphStats` is now centralized in `@cleocode/contracts`.
+import type { MemoryGraphStats } from '@cleocode/contracts';
+import { getMemoryGraph } from '@cleocode/core';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 

--- a/packages/studio/src/routes/api/memory/learnings/+server.ts
+++ b/packages/studio/src/routes/api/memory/learnings/+server.ts
@@ -16,7 +16,9 @@
  * be applied until CORE exposes these options.
  */
 
-import { getLearnings, type LearningRecord } from '@cleocode/core';
+// T9766 — `LearningRecord` is now centralized in `@cleocode/contracts`.
+import type { LearningRecord } from '@cleocode/contracts';
+import { getLearnings } from '@cleocode/core';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 

--- a/packages/studio/src/routes/api/memory/patterns/+server.ts
+++ b/packages/studio/src/routes/api/memory/patterns/+server.ts
@@ -17,7 +17,9 @@
  * exposes these options.
  */
 
-import { getPatterns, type PatternRecord } from '@cleocode/core';
+// T9766 — `PatternRecord` is now centralized in `@cleocode/contracts`.
+import type { PatternRecord } from '@cleocode/contracts';
+import { getPatterns } from '@cleocode/core';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 


### PR DESCRIPTION
## Summary

Wave 1 of the contracts-centralization initiative ([Saga T9758](https://github.com/kryptobaseddev/cleo/issues?q=T9758), Epic T9752). Moves 5 public-API types out of `@cleocode/core` and into `@cleocode/contracts` so cross-package callers (Studio, CLI, CAAMP) can depend on the type surface without reaching into Core.

## Moved types

| Type | New location |
|------|--------------|
| `LoggerConfig` | `packages/contracts/src/logger.ts` (new) |
| `MemorySearchHit` | `packages/contracts/src/memory.ts` |
| `MemoryGraphStats` | `packages/contracts/src/memory.ts` |
| `MemoryDecisionRecord` (was `DecisionRecord` in `memory/public-api.ts`) | `packages/contracts/src/memory.ts` |
| `PatternRecord` | `packages/contracts/src/memory.ts` |
| `LearningRecord` | `packages/contracts/src/memory.ts` |

## Name collision resolved

`packages/contracts/src/operations/session.ts` already exports a `DecisionRecord` of a **different** shape (session-ops audit-log entry with `sessionId`, `taskId`, `alternatives`, `timestamp`). The memory v2 record (with `outcome`, `memoryTier`, `verified`, `createdAt`) was renamed to `MemoryDecisionRecord` to avoid a barrel-level collision.

`@cleocode/core/memory/public-api.ts` continues to re-export the memory v2 type under the legacy name `DecisionRecord` (`export type { MemoryDecisionRecord as DecisionRecord }`), so every existing `import { DecisionRecord } from '@cleocode/core'` call site continues to work unchanged.

## Consumer updates

Studio + CLI now import the type contract directly from `@cleocode/contracts` for the 5 moved types — the runtime functions (`getDecisions`, `findMemoryEntries`, etc.) still come from `@cleocode/core`.

- `packages/cleo/src/cli/logger-bootstrap.ts`
- `packages/studio/src/routes/api/memory/find/+server.ts`
- `packages/studio/src/routes/api/memory/graph/+server.ts`
- `packages/studio/src/routes/api/memory/learnings/+server.ts`
- `packages/studio/src/routes/api/memory/patterns/+server.ts`
- `packages/studio/src/routes/api/memory/decisions/+server.ts`

## Test plan

- [x] `pnpm --filter @cleocode/contracts run build` — green
- [x] `pnpm --filter @cleocode/core run build` — green
- [x] `pnpm --filter @cleocode/cleo run build` — green
- [x] `pnpm biome check --write` on all touched files — clean
- [x] `pnpm --filter @cleocode/core run test src/memory` — 4 pre-existing failures (verified identical on `main` via stash + retest); zero new regressions
- [x] `node scripts/lint-project-root-anti-pattern.mjs --strict` — STRICT OK
- [x] `node scripts/lint-core-first.mjs --check` — PASS
- [x] `node scripts/lint-contracts-core-ssot.mjs` — no SSoT violations
- [x] Repo-wide grep confirms zero hard declarations of moved types in `packages/core/src/`

Refs: Saga T9758, Epic T9752