### PR TITLE
feat(T9763 W0): WarningCollector foundation — extend Warning type + ALS carrier + renderer drain

### DIFF
--- a/packages/cleo/src/cli/index.ts
+++ b/packages/cleo/src/cli/index.ts
@@ -313,31 +313,46 @@ async function runMainWithLafsEnvelope(
     process.exit(0);
   }
 
-  try {
-    await runCommand(cmd, { rawArgs });
-  } catch (err) {
-    const { cliError } = await import('./renderers/index.js');
-    // Citty's CLIError extends Error with a string `code` (e.g. 'EARG') and
-    // sets `name === 'CLIError'`. Narrow without lying to the type system.
-    const cittyCliError = asCittyCliError(err);
+  // T9769 — bind a fresh WarningCollector for this request via AsyncLocalStorage.
+  // Producers anywhere in the call chain (CORE bridges, dispatch middleware,
+  // CAAMP commands) can call `pushWarning(...)` from `@cleocode/lafs` and the
+  // CLI renderer (formatSuccess / formatError → createCliMeta) automatically
+  // drains the collector into `meta.warnings[]`. Outside this scope, the same
+  // `pushWarning` call is a silent no-op — keeping the API safe for SDK
+  // consumers that have not yet adopted the carrier.
+  //
+  // The dynamic import keeps the lafs symbol off the help / version fast-path
+  // (already short-circuited above).
+  const { WarningCollector, withWarningCollector } = await import('@cleocode/lafs');
+  const collector = new WarningCollector();
 
-    if (cittyCliError) {
-      // Do NOT render citty's usage block here — `createCustomShowUsage` uses
-      // `console.log` (stdout), which would corrupt the JSON envelope below.
-      // The envelope's `fix` field tells humans how to recover; agents key
-      // off `codeName`. Help is one `cleo <cmd> --help` away.
-      cliError(cittyCliError.message, 1, {
-        name: cittyCliError.code === 'EARG' ? 'E_VALIDATION' : `E_${cittyCliError.code}`,
-        fix: `Run 'cleo <command> --help' to see required arguments.`,
-      });
+  await withWarningCollector(collector, async () => {
+    try {
+      await runCommand(cmd, { rawArgs });
+    } catch (err) {
+      const { cliError } = await import('./renderers/index.js');
+      // Citty's CLIError extends Error with a string `code` (e.g. 'EARG') and
+      // sets `name === 'CLIError'`. Narrow without lying to the type system.
+      const cittyCliError = asCittyCliError(err);
+
+      if (cittyCliError) {
+        // Do NOT render citty's usage block here — `createCustomShowUsage` uses
+        // `console.log` (stdout), which would corrupt the JSON envelope below.
+        // The envelope's `fix` field tells humans how to recover; agents key
+        // off `codeName`. Help is one `cleo <cmd> --help` away.
+        cliError(cittyCliError.message, 1, {
+          name: cittyCliError.code === 'EARG' ? 'E_VALIDATION' : `E_${cittyCliError.code}`,
+          fix: `Run 'cleo <command> --help' to see required arguments.`,
+        });
+        process.exit(1);
+      }
+
+      // Non-citty error path — still must emit an envelope.
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(message, 1, { name: 'E_CLI_UNCAUGHT' });
       process.exit(1);
     }
-
-    // Non-citty error path — still must emit an envelope.
-    const message = err instanceof Error ? err.message : String(err);
-    cliError(message, 1, { name: 'E_CLI_UNCAUGHT' });
-    process.exit(1);
-  }
+  });
 }
 
 /**

--- a/packages/cleo/src/cli/renderers/__tests__/cli-error-signature.test.ts
+++ b/packages/cleo/src/cli/renderers/__tests__/cli-error-signature.test.ts
@@ -27,9 +27,15 @@ vi.mock('../../format-context.js', () => ({
 // chain from trying to load @a2a-js/sdk (not installed in this worktree).
 // These modules are not exercised by cliError tests — cliError only calls
 // getFormatContext() and console.log/error.
+//
+// T9769: cliError now drains `getCurrentWarningCollector()` into
+// `meta.warnings[]`; mock it as a no-op (returns undefined, matching the
+// "no active scope" path) so these signature tests continue to exercise
+// only the call-pattern surface they care about.
 vi.mock('@cleocode/lafs', () => ({
   applyFieldFilter: vi.fn(),
   extractFieldFromResult: vi.fn(),
+  getCurrentWarningCollector: vi.fn(() => undefined),
 }));
 vi.mock('@cleocode/core', () => ({
   formatSuccess: vi.fn(() => '{}'),

--- a/packages/cleo/src/cli/renderers/__tests__/warnings-drain.test.ts
+++ b/packages/cleo/src/cli/renderers/__tests__/warnings-drain.test.ts
@@ -1,0 +1,177 @@
+/**
+ * T9769 renderer integration test — CLI envelope must surface warnings
+ * pushed via `pushWarning` (from `@cleocode/lafs`) inside an active
+ * `withWarningCollector` scope, with zero stderr writes.
+ *
+ * This guards the Wave 0 contract for the JSON stream hygiene epic
+ * (T9763): handlers attach non-fatal notices via the ALS carrier; the
+ * renderer drains them into `meta.warnings[]`. Subsequent waves migrate
+ * existing `process.stderr.write` / `console.warn` producers onto this
+ * channel so JSON consumers see clean stdout.
+ *
+ * @epic T9763
+ * @task T9769
+ */
+
+import {
+  pushWarning as lafsPushWarning,
+  WarningCollector,
+  withWarningCollector,
+} from '@cleocode/lafs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setFormatContext } from '../../format-context.js';
+import { cliError, cliOutput } from '../index.js';
+
+beforeEach(() => {
+  setFormatContext({ format: 'json', source: 'flag', quiet: false });
+});
+
+afterEach(() => {
+  setFormatContext({ format: 'json', source: 'default', quiet: false });
+  vi.restoreAllMocks();
+});
+
+interface CapturedStreams {
+  stdout: string;
+  stderr: string;
+}
+
+function captureStreams(run: () => void): CapturedStreams {
+  let stdout = '';
+  let stderr = '';
+  const outSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: string | Uint8Array): boolean => {
+      stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+      return true;
+    });
+  const errSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: string | Uint8Array): boolean => {
+      stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+      return true;
+    });
+  try {
+    run();
+  } finally {
+    outSpy.mockRestore();
+    errSpy.mockRestore();
+  }
+  return { stdout, stderr };
+}
+
+interface CliEnvelopeShape {
+  success: boolean;
+  data?: Record<string, unknown>;
+  error?: { code: number | string; message: string };
+  meta: {
+    operation: string;
+    requestId: string;
+    duration_ms: number;
+    timestamp: string;
+    warnings?: Array<{
+      code: string;
+      message: string;
+      severity?: string;
+      context?: Record<string, unknown>;
+    }>;
+  };
+}
+
+function parseFirstEnvelope(stdout: string): CliEnvelopeShape {
+  const firstLine = stdout.split('\n').find((l) => l.trim().length > 0);
+  expect(firstLine, 'no stdout output captured').toBeDefined();
+  return JSON.parse(firstLine ?? '{}') as CliEnvelopeShape;
+}
+
+describe('renderer drains ALS warnings into meta.warnings', () => {
+  it('cliOutput surfaces a single pushWarning call in the success envelope', () => {
+    const collector = new WarningCollector();
+    const captured = captureStreams(() => {
+      withWarningCollector(collector, () => {
+        lafsPushWarning({
+          code: 'W_BRIDGE_WRITE_FAILED',
+          message: 'memory bridge unavailable',
+          severity: 'warn',
+          context: { file: 'memory-bridge.md' },
+        });
+        cliOutput({ ok: true }, { command: 'generic', operation: 'test.warning' });
+      });
+    });
+
+    const envelope = parseFirstEnvelope(captured.stdout);
+    expect(envelope.success).toBe(true);
+    expect(envelope.meta.warnings).toBeDefined();
+    expect(envelope.meta.warnings).toHaveLength(1);
+    expect(envelope.meta.warnings?.[0]).toMatchObject({
+      code: 'W_BRIDGE_WRITE_FAILED',
+      message: 'memory bridge unavailable',
+      severity: 'warn',
+      context: { file: 'memory-bridge.md' },
+    });
+
+    // T9763 core invariant: producer wrote via pushWarning ONLY — no stderr.
+    expect(captured.stderr).toBe('');
+  });
+
+  it('multiple pushWarning calls accumulate in envelope order', () => {
+    const collector = new WarningCollector();
+    const captured = captureStreams(() => {
+      withWarningCollector(collector, () => {
+        lafsPushWarning({ code: 'W_ONE', message: 'first' });
+        lafsPushWarning({ code: 'W_TWO', message: 'second' });
+        cliOutput({ ok: true }, { command: 'generic', operation: 'test.multi' });
+      });
+    });
+
+    const envelope = parseFirstEnvelope(captured.stdout);
+    expect(envelope.meta.warnings?.map((w) => w.code)).toEqual(['W_ONE', 'W_TWO']);
+    expect(captured.stderr).toBe('');
+  });
+
+  it('cliError surfaces warnings in the error envelope meta', () => {
+    const collector = new WarningCollector();
+    const captured = captureStreams(() => {
+      withWarningCollector(collector, () => {
+        lafsPushWarning({ code: 'W_DEPRECATED_COMMAND', message: 'use new verb' });
+        cliError('something broke', 99, { name: 'E_TEST' });
+      });
+    });
+
+    const envelope = parseFirstEnvelope(captured.stdout);
+    expect(envelope.success).toBe(false);
+    expect(envelope.error?.code).toBe(99);
+    expect(envelope.meta.warnings).toBeDefined();
+    expect(envelope.meta.warnings?.[0]).toMatchObject({
+      code: 'W_DEPRECATED_COMMAND',
+      message: 'use new verb',
+    });
+    expect(captured.stderr).toBe('');
+  });
+
+  it('omits meta.warnings when no warnings are pushed', () => {
+    const collector = new WarningCollector();
+    const captured = captureStreams(() => {
+      withWarningCollector(collector, () => {
+        cliOutput({ ok: true }, { command: 'generic', operation: 'test.empty' });
+      });
+    });
+
+    const envelope = parseFirstEnvelope(captured.stdout);
+    expect(envelope.success).toBe(true);
+    expect(envelope.meta.warnings).toBeUndefined();
+    expect(captured.stderr).toBe('');
+  });
+
+  it('pushWarning outside an active collector is a no-op and yields no warnings field', () => {
+    const captured = captureStreams(() => {
+      // No withWarningCollector wrapper — should silently drop.
+      lafsPushWarning({ code: 'W_LOST', message: 'no collector bound' });
+      cliOutput({ ok: true }, { command: 'generic', operation: 'test.nocoll' });
+    });
+
+    const envelope = parseFirstEnvelope(captured.stdout);
+    expect(envelope.meta.warnings).toBeUndefined();
+    expect(captured.stderr).toBe('');
+  });
+});

--- a/packages/cleo/src/cli/renderers/index.ts
+++ b/packages/cleo/src/cli/renderers/index.ts
@@ -28,7 +28,11 @@ function generateRequestId(): string {
 
 import { type FormatOptions, formatSuccess } from '@cleocode/core';
 import type { CliEnvelope, CliMeta } from '@cleocode/lafs';
-import { applyFieldFilter, extractFieldFromResult } from '@cleocode/lafs';
+import {
+  applyFieldFilter,
+  extractFieldFromResult,
+  getCurrentWarningCollector,
+} from '@cleocode/lafs';
 import { getFieldContext } from '../field-context.js';
 import { getFormatContext } from '../format-context.js';
 import { metaFooter, pagerFooter } from './format-helpers.js';
@@ -599,6 +603,19 @@ export function cliError(
     timestamp: meta?.timestamp ?? new Date().toISOString(),
     ...meta,
   };
+
+  // T9769 — drain any non-fatal warnings pushed via `pushWarning` (lafs ALS
+  // carrier) into `meta.warnings[]`. `formatError` in core already does this
+  // for the formatError path, but `cliError` builds the envelope inline so
+  // we mirror the drain here. Outside an active `withWarningCollector`
+  // scope `drained` is `undefined` and the field is omitted entirely.
+  const drained = getCurrentWarningCollector()?.drain();
+  if (drained && drained.length > 0) {
+    // Preserve any explicitly-set caller warnings — drained collector entries
+    // append after them, matching the JSON-emitter intent: explicit > implicit.
+    const existing = (errorMeta as { warnings?: unknown }).warnings;
+    errorMeta.warnings = Array.isArray(existing) ? [...existing, ...drained] : drained;
+  }
 
   const envelope: CliEnvelope<never> = {
     success: false,

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -158,6 +158,18 @@ export default defineConfig({
         '../../packages/core/src/agents/index.ts',
         import.meta.url,
       ).pathname,
+      // T9769 (T9763 W0): caamp/src/core/advanced/orchestration.ts imports the
+      // subpath at runtime — vitest's alias rewrites for `@cleocode/core` only
+      // cover the root entry point, leaving this subpath to fall through to
+      // node resolution, which fails because root node_modules does not
+      // symlink `@cleocode/core`. Map directly to source so transitive caamp
+      // imports load under vitest. Resolves the import error that surfaced
+      // after T9747's skill-root refactor for every renderer test that pulls
+      // in `@cleocode/core` through `formatSuccess`.
+      '@cleocode/core/skills/skill-root.js': new URL(
+        '../../packages/core/src/skills/skill-root.ts',
+        import.meta.url,
+      ).pathname,
       // T9424: status subpath export used by `cleo status` CLI thin wrapper
       '@cleocode/core/status': new URL(
         '../../packages/core/src/status/index.ts',

--- a/packages/core/src/output.ts
+++ b/packages/core/src/output.ts
@@ -22,6 +22,7 @@
 import { randomUUID } from 'node:crypto';
 import type { LafsEnvelope, LafsError, LafsSuccess } from '@cleocode/contracts';
 import type { CliEnvelope, CliEnvelopeError, CliMeta, LAFSPage, Warning } from '@cleocode/lafs';
+import { getCurrentWarningCollector } from '@cleocode/lafs';
 import { CleoError } from './errors.js';
 import { getCurrentSessionId } from './sessions/context-alert.js';
 
@@ -48,16 +49,36 @@ export function pushWarning(warning: Warning): void {
 }
 
 /**
- * Drain all pending warnings (returns and clears the queue).
+ * Drain all pending warnings — both the legacy module-global queue (CORE
+ * pushWarning) and any active ALS-bound WarningCollector (LAFS pushWarning).
+ *
+ * @returns Combined warning list, or `undefined` when neither source produced
+ *   any entries.
+ *
+ * @remarks
+ * Two carriers must be merged transitionally because:
+ * - The legacy `pendingWarnings` array is module-global and race-prone, but
+ *   is still used by several deprecation paths (T4669 et al.).
+ * - The new {@link import('@cleocode/lafs').WarningCollector} is bound per
+ *   request via {@link import('@cleocode/lafs').withWarningCollector} from
+ *   the CLI entrypoint (T9769), so it correctly isolates concurrent commands.
+ *
+ * Subsequent waves of T9763 migrate every legacy producer to the ALS carrier;
+ * the legacy queue can be removed once that sweep is complete. Until then,
+ * this function is the single source of truth for what lands in
+ * `meta.warnings[]`.
  *
  * @task T4669
- * @epic T4663
+ * @task T9769
+ * @epic T9763
  */
 function drainWarnings(): Warning[] | undefined {
-  if (pendingWarnings.length === 0) return undefined;
-  const drained = [...pendingWarnings];
-  pendingWarnings.length = 0;
-  return drained;
+  const legacy = pendingWarnings.length > 0 ? pendingWarnings.splice(0) : [];
+  const collector = getCurrentWarningCollector();
+  const als = collector?.drain() ?? [];
+
+  if (legacy.length === 0 && als.length === 0) return undefined;
+  return [...legacy, ...als];
 }
 
 /**

--- a/packages/lafs/src/__tests__/warnings.test.ts
+++ b/packages/lafs/src/__tests__/warnings.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the WarningCollector + AsyncLocalStorage carrier (T9768 / T9763 W0).
+ *
+ * Covers:
+ *   - push / drain basics
+ *   - drain returns `undefined` when no warnings pushed
+ *   - pushIfMissing deduplicates by code, leaves push untouched
+ *   - withWarningCollector binds via AsyncLocalStorage
+ *   - pushWarning no-ops outside a withWarningCollector scope
+ *   - Concurrent withWarningCollector contexts remain isolated
+ *
+ * @epic T9763
+ * @task T9768
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  getCurrentWarningCollector,
+  pushWarning,
+  WarningCollector,
+  withWarningCollector,
+} from '../envelope.js';
+import type { Warning } from '../types.js';
+
+describe('WarningCollector', () => {
+  it('push appends warnings in insertion order', () => {
+    const collector = new WarningCollector();
+    const a: Warning = { code: 'W_FIRST', message: 'first' };
+    const b: Warning = { code: 'W_SECOND', message: 'second' };
+
+    collector.push(a);
+    collector.push(b);
+
+    expect(collector.size()).toBe(2);
+    expect(collector.drain()).toEqual([a, b]);
+  });
+
+  it('drain returns undefined when no warnings have been pushed', () => {
+    const collector = new WarningCollector();
+    expect(collector.size()).toBe(0);
+    expect(collector.drain()).toBeUndefined();
+  });
+
+  it('drain returns a fresh snapshot — mutating the returned array does not affect the collector', () => {
+    const collector = new WarningCollector();
+    collector.push({ code: 'W_X', message: 'x' });
+
+    const snapshot = collector.drain();
+    expect(snapshot).toBeDefined();
+    snapshot?.push({ code: 'W_Y', message: 'y' });
+
+    expect(collector.size()).toBe(1);
+  });
+
+  it('drain is idempotent — calling twice returns the same warnings', () => {
+    const collector = new WarningCollector();
+    collector.push({ code: 'W_KEEP', message: 'keep' });
+
+    const first = collector.drain();
+    const second = collector.drain();
+
+    expect(first).toEqual(second);
+    expect(collector.size()).toBe(1);
+  });
+
+  it('pushIfMissing adds the first time and deduplicates by code thereafter', () => {
+    const collector = new WarningCollector();
+    let factoryCalls = 0;
+    const factory = (): Warning => {
+      factoryCalls++;
+      return { code: 'W_DEDUP', message: `call ${factoryCalls}` };
+    };
+
+    expect(collector.pushIfMissing('W_DEDUP', factory)).toBe(true);
+    expect(collector.pushIfMissing('W_DEDUP', factory)).toBe(false);
+    expect(collector.pushIfMissing('W_DEDUP', factory)).toBe(false);
+
+    expect(factoryCalls).toBe(1);
+    expect(collector.drain()).toEqual([{ code: 'W_DEDUP', message: 'call 1' }]);
+  });
+
+  it('pushIfMissing dedup state is independent of push', () => {
+    // push() does not consume a "seen" slot — pushIfMissing with the same code
+    // should still fire once after a regular push.
+    const collector = new WarningCollector();
+    collector.push({ code: 'W_SHARED', message: 'from push' });
+
+    const fired = collector.pushIfMissing('W_SHARED', () => ({
+      code: 'W_SHARED',
+      message: 'from pushIfMissing',
+    }));
+
+    expect(fired).toBe(true);
+    expect(collector.drain()).toEqual([
+      { code: 'W_SHARED', message: 'from push' },
+      { code: 'W_SHARED', message: 'from pushIfMissing' },
+    ]);
+  });
+});
+
+describe('pushWarning (ALS carrier)', () => {
+  it('pushWarning routes to the active collector', () => {
+    const collector = new WarningCollector();
+    withWarningCollector(collector, () => {
+      pushWarning({ code: 'W_INSIDE', message: 'inside scope' });
+    });
+
+    expect(collector.drain()).toEqual([{ code: 'W_INSIDE', message: 'inside scope' }]);
+  });
+
+  it('pushWarning is a silent no-op outside any withWarningCollector scope', () => {
+    // Sanity: no ALS context bound, no collector available.
+    expect(getCurrentWarningCollector()).toBeUndefined();
+    // Should not throw, should not record anywhere observable.
+    expect(() => pushWarning({ code: 'W_LOST', message: 'no scope' })).not.toThrow();
+  });
+
+  it('getCurrentWarningCollector returns the active collector inside scope', () => {
+    const collector = new WarningCollector();
+    let observed: WarningCollector | undefined;
+    withWarningCollector(collector, () => {
+      observed = getCurrentWarningCollector();
+    });
+    expect(observed).toBe(collector);
+    // And is unbound again afterwards.
+    expect(getCurrentWarningCollector()).toBeUndefined();
+  });
+
+  it('async work inside withWarningCollector continues to see the collector', async () => {
+    const collector = new WarningCollector();
+    await withWarningCollector(collector, async () => {
+      // Defer past a microtask boundary to make sure ALS survives `await`.
+      await Promise.resolve();
+      pushWarning({ code: 'W_ASYNC', message: 'after await' });
+    });
+
+    expect(collector.drain()).toEqual([{ code: 'W_ASYNC', message: 'after await' }]);
+  });
+
+  it('concurrent withWarningCollector scopes remain isolated', async () => {
+    const collectorA = new WarningCollector();
+    const collectorB = new WarningCollector();
+
+    async function workA(): Promise<void> {
+      await withWarningCollector(collectorA, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        pushWarning({ code: 'W_A', message: 'from A' });
+      });
+    }
+
+    async function workB(): Promise<void> {
+      await withWarningCollector(collectorB, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        pushWarning({ code: 'W_B', message: 'from B' });
+      });
+    }
+
+    await Promise.all([workA(), workB()]);
+
+    expect(collectorA.drain()).toEqual([{ code: 'W_A', message: 'from A' }]);
+    expect(collectorB.drain()).toEqual([{ code: 'W_B', message: 'from B' }]);
+  });
+
+  it('warnings carry severity and context when supplied', () => {
+    const collector = new WarningCollector();
+    withWarningCollector(collector, () => {
+      pushWarning({
+        code: 'W_BRIDGE_WRITE_FAILED',
+        message: 'memory bridge unavailable',
+        severity: 'warn',
+        context: { file: 'memory-bridge.md', retry: 2 },
+      });
+    });
+
+    expect(collector.drain()).toEqual([
+      {
+        code: 'W_BRIDGE_WRITE_FAILED',
+        message: 'memory bridge unavailable',
+        severity: 'warn',
+        context: { file: 'memory-bridge.md', retry: 2 },
+      },
+    ]);
+  });
+});

--- a/packages/lafs/src/envelope.ts
+++ b/packages/lafs/src/envelope.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   getAgentAction,
   getDocUrl,
@@ -12,6 +13,7 @@ import type {
   LAFSMeta,
   LAFSTransport,
   MVILevel,
+  Warning,
 } from './types.js';
 import { assertEnvelope } from './validateEnvelope.js';
 
@@ -499,6 +501,214 @@ export function parseLafsResponse<T = unknown>(
   }
 
   throw new LafsError(error);
+}
+
+// ---------------------------------------------------------------------------
+// WarningCollector — async-local carrier for non-fatal warnings (T9768)
+//
+// Producer code anywhere in the call chain (CORE bridges, CAAMP commands,
+// dispatch middleware) calls `pushWarning(w)` to attach a non-fatal notice
+// to the current operation. The CLI renderer (or any other adapter that
+// runs handlers inside `withWarningCollector`) drains the collector at
+// envelope-construction time and merges the result into `meta.warnings[]`.
+//
+// When `pushWarning` is called OUTSIDE an active `withWarningCollector`
+// scope, it silently no-ops — preserving the current behaviour for any
+// caller that has not yet adopted the new carrier.
+// ---------------------------------------------------------------------------
+
+/**
+ * Async-local collector for non-fatal {@link Warning} entries.
+ *
+ * @remarks
+ * Producers anywhere in the synchronous OR asynchronous call chain can
+ * push warnings into the active collector via {@link pushWarning} without
+ * knowing which adapter (CLI, HTTP, etc.) is going to drain them. The
+ * collector is intentionally lightweight: it owns a plain array and a
+ * `Set` of seen codes for `pushIfMissing` deduplication. Instances are
+ * cheap to construct — adapters typically allocate one per request.
+ *
+ * @example
+ * ```ts
+ * import { WarningCollector, withWarningCollector, pushWarning } from '@cleocode/lafs';
+ *
+ * const collector = new WarningCollector();
+ * await withWarningCollector(collector, async () => {
+ *   pushWarning({ code: 'W_BRIDGE_WRITE_FAILED', message: 'memory bridge unavailable' });
+ * });
+ * const warnings = collector.drain(); // → [Warning] or undefined
+ * ```
+ *
+ * @public
+ */
+export class WarningCollector {
+  /** Backing store of pushed warnings, in insertion order. */
+  private readonly warnings: Warning[] = [];
+  /** Set of codes seen via {@link pushIfMissing}, for dedup tracking. */
+  private readonly seenCodes: Set<string> = new Set();
+
+  /**
+   * Append a warning to the collector.
+   *
+   * @param warning - The {@link Warning} to attach. The collector does not
+   *   normalise or copy the input — callers retain ownership of mutable
+   *   `context` objects.
+   *
+   * @remarks
+   * No deduplication is performed. Pass the same code twice and you get two
+   * entries. For dedup-by-code semantics use {@link pushIfMissing} instead.
+   */
+  push(warning: Warning): void {
+    this.warnings.push(warning);
+  }
+
+  /**
+   * Append a warning only when no entry for {@link code} has been added via
+   * `pushIfMissing` yet on this collector.
+   *
+   * @param code - Warning code to dedupe on.
+   * @param factory - Lazy constructor invoked only when the code is unseen.
+   * @returns `true` when the warning was added, `false` when skipped.
+   *
+   * @remarks
+   * Dedup state is tracked separately from {@link push} so a `push` call with
+   * the same code does NOT prevent a later `pushIfMissing` from firing —
+   * the two paths intentionally have independent dedup semantics. Use
+   * `pushIfMissing` for warnings that are likely to be emitted from a hot
+   * loop (e.g. per-iteration bridge failure during a sweep).
+   */
+  pushIfMissing(code: string, factory: () => Warning): boolean {
+    if (this.seenCodes.has(code)) return false;
+    this.seenCodes.add(code);
+    this.warnings.push(factory());
+    return true;
+  }
+
+  /**
+   * Return a copy of every warning pushed so far, or `undefined` when empty.
+   *
+   * @returns A fresh array of warnings, or `undefined` if none were pushed.
+   *
+   * @remarks
+   * The collector is NOT cleared by `drain()` — calling drain twice returns
+   * the same set of warnings. This matches the renderer's "snapshot then
+   * emit" pattern: a single envelope construction reads the collector once.
+   * The `undefined` return (rather than an empty array) lets callers cheaply
+   * omit the field via `...(drained ? { warnings: drained } : {})`.
+   */
+  drain(): Warning[] | undefined {
+    return this.warnings.length > 0 ? [...this.warnings] : undefined;
+  }
+
+  /**
+   * Read-only count of warnings currently held by the collector.
+   *
+   * @returns The number of warnings pushed since construction.
+   *
+   * @remarks
+   * Useful for fast "did anything happen?" checks without allocating the
+   * `drain()` snapshot array.
+   */
+  size(): number {
+    return this.warnings.length;
+  }
+}
+
+/**
+ * AsyncLocalStorage carrier holding the active {@link WarningCollector}, if any.
+ *
+ * @remarks
+ * Exported so adapters that need to inspect (or temporarily replace) the
+ * active collector can do so without instantiating their own ALS. Most
+ * producers should use {@link pushWarning} and most adapters should use
+ * {@link withWarningCollector} instead of touching this directly.
+ *
+ * @public
+ */
+export const currentWarningCollector = new AsyncLocalStorage<WarningCollector>();
+
+/**
+ * Run {@link fn} with {@link collector} bound as the active warning collector.
+ *
+ * @typeParam T - Return type of the wrapped function.
+ * @param collector - The collector that should receive `pushWarning` calls
+ *   originating from within `fn` (synchronous or asynchronous descendants).
+ * @param fn - Function to execute inside the bound scope.
+ * @returns Whatever `fn` returns. If `fn` returns a Promise, the binding is
+ *   preserved for the entire async chain via AsyncLocalStorage semantics.
+ *
+ * @remarks
+ * Adapters (CLI, HTTP middleware, etc.) call this once per request, drain
+ * the collector when constructing the response envelope, and discard it.
+ * Nested calls are supported — the innermost collector wins for any
+ * `pushWarning` originating inside the nested scope.
+ *
+ * @example
+ * ```ts
+ * import { WarningCollector, withWarningCollector } from '@cleocode/lafs';
+ *
+ * const collector = new WarningCollector();
+ * const result = await withWarningCollector(collector, () => runHandler(req));
+ * const warnings = collector.drain();
+ * ```
+ *
+ * @public
+ */
+export function withWarningCollector<T>(collector: WarningCollector, fn: () => T): T {
+  return currentWarningCollector.run(collector, fn);
+}
+
+/**
+ * Return the currently-active {@link WarningCollector}, or `undefined` when
+ * no `withWarningCollector` scope is bound.
+ *
+ * @returns The active collector, or `undefined`.
+ *
+ * @remarks
+ * Use this from adapter code that needs to read state but not push (e.g.
+ * a logger that wants to mirror warnings to a structured sink). Producers
+ * should prefer {@link pushWarning}, which handles the missing-scope case
+ * silently.
+ *
+ * @public
+ */
+export function getCurrentWarningCollector(): WarningCollector | undefined {
+  return currentWarningCollector.getStore();
+}
+
+/**
+ * Attach a non-fatal warning to the active operation's envelope.
+ *
+ * @param warning - The {@link Warning} to attach.
+ *
+ * @remarks
+ * No-op when there is no active {@link WarningCollector} bound via
+ * {@link withWarningCollector}. This means CORE / library code can call
+ * `pushWarning` unconditionally without checking whether it is running
+ * under a CLI adapter, a test harness, or an SDK consumer that has not yet
+ * adopted the carrier.
+ *
+ * @example
+ * ```ts
+ * import { pushWarning } from '@cleocode/lafs';
+ *
+ * try {
+ *   await writeBridge(...);
+ * } catch (err) {
+ *   pushWarning({
+ *     code: 'W_BRIDGE_WRITE_FAILED',
+ *     message: 'memory bridge write failed',
+ *     severity: 'warn',
+ *     context: { error: err instanceof Error ? err.message : String(err) },
+ *   });
+ * }
+ * ```
+ *
+ * @public
+ */
+export function pushWarning(warning: Warning): void {
+  const collector = currentWarningCollector.getStore();
+  if (collector) collector.push(warning);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lafs/src/types.ts
+++ b/packages/lafs/src/types.ts
@@ -29,18 +29,55 @@ export type LAFSErrorCategory =
   | 'MIGRATION';
 
 /**
+ * Severity classification for a non-fatal {@link Warning}.
+ *
+ * @remarks
+ * Severity is purely informational — it never converts a warning into an error.
+ * Agents and CLIs MAY use this to colourise output or filter low-priority
+ * notices, but the operation itself still succeeds when warnings are present.
+ *
+ * - `info` - Purely informational notice (e.g. cache miss, fallback path).
+ * - `warn` - Default. Operation succeeded but consumer should inspect.
+ * - `error` - Soft policy violation; future versions may upgrade to a hard error.
+ *
+ * @public
+ */
+export type WarningSeverity = 'info' | 'warn' | 'error';
+
+/**
  * A non-fatal warning attached to a LAFS envelope's `_meta.warnings` array.
  *
  * @remarks
  * Warnings inform the consuming agent about deprecations, upcoming removals,
- * or soft policy violations without failing the request. Agents SHOULD log
- * warnings and surface them during development but MUST NOT treat them as errors.
+ * soft policy violations, or degraded side-effects (e.g. bridge write
+ * failures) without failing the request. Agents SHOULD log warnings and
+ * surface them during development but MUST NOT treat them as errors.
+ *
+ * The shape is intentionally extensible: `severity` and `context` were added
+ * post-1.0 so commands can attach structured data (e.g. file path, retry
+ * count) without inventing one-off vendor fields. All new fields are
+ * optional — pre-existing producers that only set `code` + `message` remain
+ * fully forward-compatible.
  */
 export interface Warning {
   /** Machine-readable warning code (e.g. `"W_DEPRECATED_FIELD"`). */
   code: string;
   /** Human-readable description of the warning. */
   message: string;
+  /**
+   * Severity classification. Defaults to `"warn"` when omitted by the producer.
+   *
+   * @defaultValue "warn"
+   */
+  severity?: WarningSeverity;
+  /**
+   * Structured context the producer wants to surface alongside the message
+   * (e.g. `{ file: "skills.json", retry: 2 }`). Keys are arbitrary; values
+   * MUST be JSON-serialisable.
+   *
+   * @defaultValue undefined
+   */
+  context?: Record<string, unknown>;
   /**
    * Name of the deprecated field, parameter, or feature.
    *


### PR DESCRIPTION
## Summary

Wave 0 of the JSON stream hygiene epic (T9763) — the foundation that
subsequent waves build on to migrate production stderr / `console.warn`
emissions out of JSON-emitting command paths.

- **T9768** (commit 1) extends the LAFS `Warning` type with optional
  `severity` + `context` fields, adds a dependency-free `WarningCollector`
  class with `push` / `pushIfMissing` (code-dedup) / `drain` (snapshot,
  `undefined` when empty) / `size`, and exposes an `AsyncLocalStorage`-based
  carrier (`withWarningCollector`, `pushWarning`, `getCurrentWarningCollector`)
  so producers anywhere in the call chain can attach non-fatal notices
  without coupling to the CLI adapter. `pushWarning` is a silent no-op
  outside any active scope.

- **T9769** (commit 2) binds a fresh `WarningCollector` per CLI request
  inside `runMainWithLafsEnvelope`, drains it into `meta.warnings[]` from
  both the success path (via `createCliMeta` in `@cleocode/core/output`
  alongside the existing legacy queue) and the error path (via `cliError`
  in `@cleocode/cleo/cli/renderers`). Caller-supplied `meta.warnings`
  always win over drained entries; an empty collector yields no
  `meta.warnings` field. Includes a Vitest config alias fix unblocking
  every renderer test that pulls in `formatSuccess` from `@cleocode/core`
  (regression introduced by T9747's skill-root refactor).

Per Part F + G of `.cleo/research/JSON-STREAM-HYGIENE-AUDIT.md`. Subsequent
waves (T-JH-3 onwards) migrate caamp, memory/nexus bridges, sentient
ingesters, etc. onto this carrier.

## Test plan

- [x] `pnpm exec vitest run packages/lafs/src/__tests__/warnings.test.ts` —
      12/12 unit tests green (push order, drain idempotency / snapshot
      isolation, `pushIfMissing` dedup, ALS sync + async scoping, concurrent
      scope isolation, severity / context propagation).
- [x] `vitest run packages/cleo/src/cli/renderers/__tests__/warnings-drain.test.ts`
      under `packages/cleo/vitest.config.ts` — 5/5 integration tests green
      (success envelope drain, multi-push order, error envelope drain,
      empty-collector field omission, no-op outside scope). Every test
      asserts `process.stderr` is empty.
- [x] `vitest run packages/cleo/src/cli/renderers/__tests__/` — 9/9 renderer
      test files, 206/206 tests pass (including the previously-broken
      `cli-output-response-meta` and `cli-error-signature` suites).
- [x] `pnpm --filter @cleocode/lafs run test` — 21/21 test files, 425/425
      tests green.
- [x] `pnpm --filter @cleocode/lafs --filter @cleocode/core --filter @cleocode/cleo run build`
      — TypeScript clean across all three packages.
- [x] `pnpm biome check --write` on touched files — no fixes applied.

## Backwards compatibility

- The two new `Warning` fields (`severity`, `context`) are optional;
  pre-existing producers compile unchanged.
- `pushWarning` is a silent no-op outside `withWarningCollector` — SDK
  consumers that have not yet adopted the carrier see no behavioural change.
- `meta.warnings` is omitted from envelopes when no warnings are pushed,
  matching current shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)