### PR TITLE
refactor(T9773): sentient propose-tick + ingester warnings -> meta.warnings

### DIFF
--- a/packages/core/src/sentient/ingesters/brain-ingester.ts
+++ b/packages/core/src/sentient/ingesters/brain-ingester.ts
@@ -8,7 +8,8 @@
  * - NO LLM calls. All data comes from structured SQL queries.
  * - Title is template-generated: `[T2-BRAIN] Recurring issue: {title}`.
  *   This is the prompt-injection defence from T1008 §3.6.
- * - Failures are swallowed: returns empty array + logs warning.
+ * - Failures are swallowed: returns empty array + pushes a non-fatal warning
+ *   (`W_SENTIENT_INGESTER_DEGRADED`) into the active LAFS envelope (T9773).
  *   Brain.db absence must never crash the propose tick.
  *
  * @task T1008
@@ -17,6 +18,7 @@
 
 import type { DatabaseSync } from 'node:sqlite';
 import type { ProposalCandidate } from '@cleocode/contracts';
+import { pushWarning } from '@cleocode/lafs';
 
 // ---------------------------------------------------------------------------
 // Brain observation row (raw SQL result)
@@ -114,9 +116,15 @@ export function runBrainIngester(nativeDb: DatabaseSync | null): ProposalCandida
 
     return candidates;
   } catch (err) {
-    // Best-effort: log warning but never throw from an ingester.
+    // Best-effort: surface degraded-ingester signal in the envelope but never
+    // throw from an ingester. Migrated from process.stderr.write per T9773.
     const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[sentient/brain-ingester] WARNING: ${message}\n`);
+    pushWarning({
+      code: 'W_SENTIENT_INGESTER_DEGRADED',
+      severity: 'warn',
+      message: `[sentient/brain-ingester] ${message}`,
+      context: { ingester: 'brain', error: message },
+    });
     return [];
   }
 }

--- a/packages/core/src/sentient/ingesters/nexus-ingester.ts
+++ b/packages/core/src/sentient/ingesters/nexus-ingester.ts
@@ -23,7 +23,8 @@
  * Design principles:
  * - NO LLM calls. All data comes from structured SQL queries.
  * - Title is template-generated: `[T2-NEXUS] ...`. Prompt-injection defence.
- * - Failures are swallowed: returns empty array + logs warning.
+ * - Failures are swallowed: returns empty array + pushes a non-fatal warning
+ *   (`W_SENTIENT_INGESTER_DEGRADED`) into the active LAFS envelope (T9773).
  *   Nexus.db absence must never crash the propose tick.
  * - Community snapshots stored in nexus_schema_meta (k/v) with key
  *   `community_snapshot_json`. First analyze run has no baseline.
@@ -35,6 +36,7 @@
 
 import type { DatabaseSync } from 'node:sqlite';
 import type { ProposalCandidate } from '@cleocode/contracts';
+import { pushWarning } from '@cleocode/lafs';
 
 // ---------------------------------------------------------------------------
 // Raw row types
@@ -147,8 +149,15 @@ function logAuditEvent(
       details_json: JSON.stringify(detailsJson),
     });
   } catch (err) {
+    // Best-effort: surface degraded-ingester signal in the envelope but never
+    // throw from the audit logger. Migrated from process.stderr.write per T9773.
     const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[sentient/nexus-ingester] WARNING audit log: ${message}\n`);
+    pushWarning({
+      code: 'W_SENTIENT_INGESTER_DEGRADED',
+      severity: 'warn',
+      message: `[sentient/nexus-ingester] audit log: ${message}`,
+      context: { ingester: 'nexus', phase: 'audit-log', action, error: message },
+    });
   }
 }
 
@@ -194,8 +203,15 @@ function saveCommunitySnapshot(nativeDb: DatabaseSync, snapshot: Record<string, 
       value: JSON.stringify(snapshot),
     });
   } catch (err) {
+    // Best-effort: surface degraded-ingester signal in the envelope but never
+    // throw from snapshot persistence. Migrated from process.stderr.write per T9773.
     const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[sentient/nexus-ingester] WARNING snapshot save: ${message}\n`);
+    pushWarning({
+      code: 'W_SENTIENT_INGESTER_DEGRADED',
+      severity: 'warn',
+      message: `[sentient/nexus-ingester] snapshot save: ${message}`,
+      context: { ingester: 'nexus', phase: 'snapshot-save', error: message },
+    });
   }
 }
 
@@ -263,8 +279,15 @@ export function runNexusIngester(nativeDb: DatabaseSync | null): ProposalCandida
       });
     }
   } catch (err) {
+    // Best-effort: surface degraded-ingester signal in the envelope but never
+    // throw from a query branch. Migrated from process.stderr.write per T9773.
     const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[sentient/nexus-ingester] WARNING query A: ${message}\n`);
+    pushWarning({
+      code: 'W_SENTIENT_INGESTER_DEGRADED',
+      severity: 'warn',
+      message: `[sentient/nexus-ingester] query A: ${message}`,
+      context: { ingester: 'nexus', query: 'A', error: message },
+    });
   }
 
   try {
@@ -297,8 +320,15 @@ export function runNexusIngester(nativeDb: DatabaseSync | null): ProposalCandida
       });
     }
   } catch (err) {
+    // Best-effort: surface degraded-ingester signal in the envelope but never
+    // throw from a query branch. Migrated from process.stderr.write per T9773.
     const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[sentient/nexus-ingester] WARNING query B: ${message}\n`);
+    pushWarning({
+      code: 'W_SENTIENT_INGESTER_DEGRADED',
+      severity: 'warn',
+      message: `[sentient/nexus-ingester] query B: ${message}`,
+      context: { ingester: 'nexus', query: 'B', error: message },
+    });
   }
 
   try {
@@ -351,8 +381,15 @@ export function runNexusIngester(nativeDb: DatabaseSync | null): ProposalCandida
     // Save new snapshot for next run.
     saveCommunitySnapshot(nativeDb, newSnapshot);
   } catch (err) {
+    // Best-effort: surface degraded-ingester signal in the envelope but never
+    // throw from a query branch. Migrated from process.stderr.write per T9773.
     const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[sentient/nexus-ingester] WARNING query C: ${message}\n`);
+    pushWarning({
+      code: 'W_SENTIENT_INGESTER_DEGRADED',
+      severity: 'warn',
+      message: `[sentient/nexus-ingester] query C: ${message}`,
+      context: { ingester: 'nexus', query: 'C', error: message },
+    });
   }
 
   try {
@@ -396,8 +433,15 @@ export function runNexusIngester(nativeDb: DatabaseSync | null): ProposalCandida
       });
     }
   } catch (err) {
+    // Best-effort: surface degraded-ingester signal in the envelope but never
+    // throw from a query branch. Migrated from process.stderr.write per T9773.
     const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[sentient/nexus-ingester] WARNING query D: ${message}\n`);
+    pushWarning({
+      code: 'W_SENTIENT_INGESTER_DEGRADED',
+      severity: 'warn',
+      message: `[sentient/nexus-ingester] query D: ${message}`,
+      context: { ingester: 'nexus', query: 'D', error: message },
+    });
   }
 
   try {
@@ -483,8 +527,15 @@ export function runNexusIngester(nativeDb: DatabaseSync | null): ProposalCandida
       }
     }
   } catch (err) {
+    // Best-effort: surface degraded-ingester signal in the envelope but never
+    // throw from a query branch. Migrated from process.stderr.write per T9773.
     const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[sentient/nexus-ingester] WARNING query E: ${message}\n`);
+    pushWarning({
+      code: 'W_SENTIENT_INGESTER_DEGRADED',
+      severity: 'warn',
+      message: `[sentient/nexus-ingester] query E: ${message}`,
+      context: { ingester: 'nexus', query: 'E', error: message },
+    });
   }
 
   return candidates;

--- a/packages/core/src/sentient/ingesters/test-ingester.ts
+++ b/packages/core/src/sentient/ingesters/test-ingester.ts
@@ -15,7 +15,8 @@
  * Design principles:
  * - NO LLM calls. All data comes from structured file reads.
  * - Title is template-generated. Prompt-injection defence (T1008 §3.6).
- * - Failures are swallowed: returns empty array + logs warning.
+ * - Failures are swallowed: returns empty array + pushes a non-fatal warning
+ *   (`W_SENTIENT_INGESTER_DEGRADED`) into the active LAFS envelope (T9773).
  *
  * @task T1008
  * @see ADR-054 — Sentient Loop Tier-2
@@ -24,6 +25,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { ProposalCandidate } from '@cleocode/contracts';
+import { pushWarning } from '@cleocode/lafs';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -198,8 +200,15 @@ export function runTestIngester(projectRoot: string): ProposalCandidate[] {
 
     return merged;
   } catch (err) {
+    // Best-effort: surface degraded-ingester signal in the envelope but never
+    // throw from an ingester. Migrated from process.stderr.write per T9773.
     const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[sentient/test-ingester] WARNING: ${message}\n`);
+    pushWarning({
+      code: 'W_SENTIENT_INGESTER_DEGRADED',
+      severity: 'warn',
+      message: `[sentient/test-ingester] ${message}`,
+      context: { ingester: 'test', error: message },
+    });
     return [];
   }
 }

--- a/packages/core/src/sentient/propose-tick.ts
+++ b/packages/core/src/sentient/propose-tick.ts
@@ -27,6 +27,7 @@
  */
 
 import type { ProposalCandidate } from '@cleocode/contracts';
+import { pushWarning } from '@cleocode/lafs';
 import { runBrainIngester } from './ingesters/brain-ingester.js';
 import { runNexusIngester } from './ingesters/nexus-ingester.js';
 import { runTestIngester } from './ingesters/test-ingester.js';
@@ -284,9 +285,18 @@ export async function runProposeTick(options: ProposeTickOptions): Promise<Propo
   for (const candidate of [...brainCandidates, ...nexusCandidates, ...testCandidates]) {
     // Validate title format — reject candidates with non-template titles
     if (!PROPOSAL_TITLE_PATTERN.test(candidate.title)) {
-      process.stderr.write(
-        `[sentient/propose-tick] Rejected candidate with invalid title format: "${candidate.title}"\n`,
-      );
+      // Surface via envelope warnings instead of stderr (T9773).
+      pushWarning({
+        code: 'W_PROPOSE_AUDIT_FAILED',
+        severity: 'warn',
+        message: `[sentient/propose-tick] Rejected candidate with invalid title format: "${candidate.title}"`,
+        context: {
+          phase: 'title-validation',
+          source: candidate.source,
+          sourceId: candidate.sourceId,
+          title: candidate.title,
+        },
+      });
       continue;
     }
 
@@ -335,7 +345,13 @@ export async function runProposeTick(options: ProposeTickOptions): Promise<Propo
 
   for (const candidate of toWrite) {
     if (!tasksNativeDb) {
-      process.stderr.write('[sentient/propose-tick] tasks DB not available; skipping write\n');
+      // Surface via envelope warnings instead of stderr (T9773).
+      pushWarning({
+        code: 'W_PROPOSE_AUDIT_FAILED',
+        severity: 'warn',
+        message: '[sentient/propose-tick] tasks DB not available; skipping write',
+        context: { phase: 'pre-write', reason: 'tasks-db-unavailable' },
+      });
       break;
     }
 
@@ -365,8 +381,19 @@ export async function runProposeTick(options: ProposeTickOptions): Promise<Propo
           existingTaskId: dedupCheck.existingTaskId,
         });
       } catch (auditErr) {
+        // Surface via envelope warnings instead of stderr (T9773).
         const message = auditErr instanceof Error ? auditErr.message : String(auditErr);
-        process.stderr.write(`[sentient/propose-tick] audit append failed: ${message}\n`);
+        pushWarning({
+          code: 'W_PROPOSE_AUDIT_FAILED',
+          severity: 'warn',
+          message: `[sentient/propose-tick] audit append failed: ${message}`,
+          context: {
+            phase: 'dedup-audit-append',
+            source: candidate.source,
+            sourceId: candidate.sourceId,
+            error: message,
+          },
+        });
       }
       continue;
     }
@@ -446,8 +473,14 @@ export async function runProposeTick(options: ProposeTickOptions): Promise<Propo
       }
       // If 'busy', skip this one and continue.
     } catch (err) {
+      // Surface via envelope warnings instead of stderr (T9773).
       const message = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[sentient/propose-tick] INSERT failed for ${taskId}: ${message}\n`);
+      pushWarning({
+        code: 'W_PROPOSE_AUDIT_FAILED',
+        severity: 'warn',
+        message: `[sentient/propose-tick] INSERT failed for ${taskId}: ${message}`,
+        context: { phase: 'transactional-insert', taskId, error: message },
+      });
     }
   }
 

--- a/packages/core/src/sentient/stage-drift-tick.ts
+++ b/packages/core/src/sentient/stage-drift-tick.ts
@@ -31,6 +31,7 @@
  */
 
 import type { DatabaseSync } from 'node:sqlite';
+import { pushWarning } from '@cleocode/lafs';
 import {
   computeEffectiveStage,
   EFFECTIVE_STAGE_INDEX,
@@ -445,10 +446,21 @@ export async function runStageDriftScan(options: StageDriftOptions): Promise<Sta
         break;
       }
     } catch (err) {
+      // Surface via envelope warnings instead of stderr (T9773).
       const message = err instanceof Error ? err.message : String(err);
-      process.stderr.write(
-        `[sentient/stage-drift] INSERT failed for ${taskId} (${drift.epicId}): ${message}\n`,
-      );
+      pushWarning({
+        code: 'W_STAGE_DRIFT_FAILED',
+        severity: 'warn',
+        message: `[sentient/stage-drift] INSERT failed for ${taskId} (${drift.epicId}): ${message}`,
+        context: {
+          phase: 'transactional-insert',
+          taskId,
+          epicId: drift.epicId,
+          storedStage: drift.storedStage,
+          effectiveStage: drift.effectiveStage,
+          error: message,
+        },
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

T-JH-6 (parent T9763 — JSON stream hygiene). Migrate 14 non-fatal `process.stderr.write` sites in the sentient subsystem onto the LAFS `WarningCollector` carrier introduced by T9768. After this change, `cleo sentient propose run --json` emits zero stderr noise from the propose pipeline (the only remaining line is Node's unavoidable `ExperimentalWarning` for `node:sqlite`, outside the sentient surface).

## Files touched (5)

- `packages/core/src/sentient/propose-tick.ts` — 4 sites → `W_PROPOSE_AUDIT_FAILED`
- `packages/core/src/sentient/ingesters/brain-ingester.ts` — 1 site → `W_SENTIENT_INGESTER_DEGRADED`
- `packages/core/src/sentient/ingesters/test-ingester.ts` — 1 site → `W_SENTIENT_INGESTER_DEGRADED`
- `packages/core/src/sentient/ingesters/nexus-ingester.ts` — 7 sites (audit log + snapshot + queries A-E) → `W_SENTIENT_INGESTER_DEGRADED`
- `packages/core/src/sentient/stage-drift-tick.ts` — 1 site → `W_STAGE_DRIFT_FAILED`

Total: **14 sites migrated** (task spec said 13; one extra found in nexus snapshot-save).

## Pattern

Each `pushWarning` call (from `@cleocode/lafs`) carries:

- `code` — canonical name from the `W_*` namespace
- `severity: 'warn'`
- `message` — same prose as the old stderr write
- `context` — typed `Record<string, unknown>` (`ingester` id, `query` branch, `taskId`, `epicId`, `error` string) so downstream callers can inspect the failure mode programmatically

## Test plan

- [x] `pnpm run build` — all 9 waves green
- [x] `pnpm --filter @cleocode/core run test src/sentient` — 431 passed, 1 todo
- [x] 2 `baseline.test.ts` failures are **pre-existing on `origin/main`** (verified by stashing + re-running against clean main)
- [x] Targeted suites: `brain-ingester` + `test-ingester` + `nexus-ingester` + `propose-tick` + `stage-drift` — 56 passed
- [x] `pnpm biome check` on touched files — clean
- [x] Smoke: `cleo sentient propose enable && cleo sentient propose run --json && cleo sentient propose disable` — stdout pure JSON, stderr clean (only node:sqlite ExperimentalWarning)

## Constraints honoured

- No `any` / `unknown` introduced (`Warning.context` is typed via the public `Warning` interface from `@cleocode/lafs`)
- All TSDoc preserved + design-principle comments updated in ingester headers to document the new warning channel
- Worktree under `/mnt/projects/T9763-W1-sentient`, single commit