### PR TITLE
fix(T9770): caamp install warnings → meta.warnings

### DIFF
--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -72,6 +72,14 @@
     "picocolors": "^1.1.1",
     "simple-git": "3.33.0"
   },
+  "peerDependencies": {
+    "@cleocode/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@cleocode/core": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@biomejs/biome": "2.4.11",
     "@forge-ts/cli": "0.23.0",

--- a/packages/caamp/src/commands/skills/install.ts
+++ b/packages/caamp/src/commands/skills/install.ts
@@ -3,6 +3,8 @@
  */
 
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { pushWarning } from '@cleocode/lafs';
 import type { Command } from 'commander';
 import pc from 'picocolors';
 import {
@@ -130,23 +132,63 @@ interface CoreSkillsGuardShape {
 let cachedCore: CoreSkillsGuardShape | null | undefined;
 
 /**
+ * Pluggable resolver for `@cleocode/core`. Production code uses the default
+ * which combines `createRequire(import.meta.url).resolve()` (existence check)
+ * with `import('@cleocode/core' as string)` (dynamic load). Tests override
+ * via {@link __testing.setCoreResolver} to simulate resolution failure
+ * without touching the real module graph.
+ *
+ * @internal
+ */
+type CoreResolver = () => Promise<CoreSkillsGuardShape>;
+
+const defaultCoreResolver: CoreResolver = async () => {
+  const require = createRequire(import.meta.url);
+  require.resolve('@cleocode/core');
+  // The `as string` cast keeps the dependency out of the static module graph;
+  // tsc treats this as a fully opaque dynamic import.
+  return (await import('@cleocode/core' as string)) as CoreSkillsGuardShape;
+};
+
+let coreResolver: CoreResolver = defaultCoreResolver;
+
+/**
  * Lazily resolve `@cleocode/core`. Returns `null` when caamp runs outside
  * the cleo monorepo and core is unavailable — callers MUST degrade to
  * `allow` rather than fail-closed (refusing legitimate standalone caamp
  * installs purely because core is missing would break the package).
+ *
+ * @remarks
+ * Resolution strategy (T9770):
+ * 1. `createRequire(import.meta.url).resolve('@cleocode/core')` to check
+ *    whether the module is reachable from caamp's runtime location. This
+ *    uses Node's standard resolution rules so symlinked workspaces, pnpm
+ *    global installs, and direct installs all resolve correctly when core
+ *    IS listed as a `dependency` / `peerDependency`.
+ * 2. If `resolve()` succeeds, dynamically `import()` the module. The string
+ *    is still cast to `string` so tsc doesn't lift `@cleocode/core` into the
+ *    static module graph (avoids the core ↔ caamp circular dep at build
+ *    time — core depends on caamp, not the other way around).
+ * 3. On any failure the function returns `null` and routes a structured
+ *    warning into the active LAFS {@link WarningCollector} via
+ *    {@link pushWarning}. NO stderr writes — JSON-emitting commands stay
+ *    parser-clean.
  */
 async function resolveCore(): Promise<CoreSkillsGuardShape | null> {
   if (cachedCore !== undefined) return cachedCore;
   try {
-    // The string is intentionally not statically analysable so module-graph
-    // tools (and tsc itself) don't treat this as a static dependency.
-    const mod = (await import('@cleocode/core' as string)) as CoreSkillsGuardShape;
-    cachedCore = mod;
-  } catch {
+    cachedCore = await coreResolver();
+  } catch (err) {
     cachedCore = null;
-    process.stderr.write(
-      '[caamp] WARNING: @cleocode/core unavailable — skipping trust gate (skill installs not security-checked)\n',
-    );
+    pushWarning({
+      code: 'W_CORE_UNAVAILABLE',
+      severity: 'warn',
+      message:
+        'caamp running without @cleocode/core — trust gate skipped (skill installs not security-checked)',
+      context: {
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
   }
   return cachedCore;
 }
@@ -217,8 +259,10 @@ async function evaluateFederationGate(
 
 /**
  * Append a bypass entry to `.cleo/audit/skill-trust-bypass.jsonl`. No-op
- * when core is unavailable. Failures during writing are swallowed and
- * logged to stderr so an audit-log failure never breaks a real install.
+ * when core is unavailable. Failures during writing are routed to the
+ * active LAFS {@link WarningCollector} as `W_AUDIT_LOG_FAILED` so an
+ * audit-log failure never breaks a real install AND never pollutes stderr
+ * with `[caamp] WARNING:` lines that mangle JSON parsers (T9770).
  */
 async function recordSkillTrustBypass(
   scan: AdapterScanResult,
@@ -229,11 +273,42 @@ async function recordSkillTrustBypass(
   try {
     core.recordTrustBypass(scan, reason);
   } catch (err) {
-    process.stderr.write(
-      `[caamp] WARNING: failed to record trust-bypass audit row: ${err instanceof Error ? err.message : String(err)}\n`,
-    );
+    const msg = err instanceof Error ? err.message : String(err);
+    pushWarning({
+      code: 'W_AUDIT_LOG_FAILED',
+      severity: 'warn',
+      message: 'trust-bypass audit record failed',
+      context: { error: msg },
+    });
   }
 }
+
+/**
+ * Test-only exports — exposes the warning-emitting internals so tests can
+ * verify they route into the active LAFS {@link WarningCollector} without
+ * polluting stderr.
+ *
+ * @internal
+ */
+export const __testing = {
+  /** Resets the module-scoped core cache so each test gets a clean slate. */
+  resetCoreCache(): void {
+    cachedCore = undefined;
+  },
+  /** Overrides the core cache with a test fixture (or `null` to simulate "unavailable"). */
+  setCoreCache(value: CoreSkillsGuardShape | null): void {
+    cachedCore = value;
+  },
+  /**
+   * Replaces the resolver. Pass `null` to restore the production resolver.
+   * Tests use this to simulate `@cleocode/core` being absent at runtime.
+   */
+  setCoreResolver(resolver: CoreResolver | null): void {
+    coreResolver = resolver ?? defaultCoreResolver;
+  },
+  resolveCore,
+  recordSkillTrustBypass,
+};
 
 /**
  * Registers the `skills install` subcommand for installing skills from various sources.

--- a/packages/caamp/tests/unit/install-warnings.test.ts
+++ b/packages/caamp/tests/unit/install-warnings.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for T9770 — caamp `skills install` warning routing.
+ *
+ * @remarks
+ * Verifies the `[caamp] WARNING:` stderr pollution reported by the user is
+ * eliminated by routing graceful-degradation notices into the active LAFS
+ * {@link WarningCollector} instead of `process.stderr.write`.
+ *
+ * Two scenarios are covered:
+ * 1. `resolveCore()` fails (e.g. `@cleocode/core` unavailable in a standalone
+ *    caamp install) — collector MUST capture exactly one
+ *    `W_CORE_UNAVAILABLE` warning and stderr MUST stay silent.
+ * 2. `recordTrustBypass()` throws (audit log write fails) — collector MUST
+ *    capture `W_AUDIT_LOG_FAILED` and stderr MUST stay silent.
+ *
+ * @task T9770
+ * @epic T9763
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WarningCollector, withWarningCollector } from '@cleocode/lafs';
+import { __testing } from '../../src/commands/skills/install.js';
+
+interface AdapterScanResultFixture {
+  readonly skillName: string;
+  readonly source: string;
+  readonly trustLevel: 'community';
+  readonly verdict: 'safe';
+  readonly findings: readonly never[];
+  readonly scannedAt: string;
+  readonly summary: string;
+}
+
+function makeScanFixture(): AdapterScanResultFixture {
+  return {
+    skillName: 'test-skill',
+    source: 'local:/tmp/test-skill',
+    trustLevel: 'community',
+    verdict: 'safe',
+    findings: [],
+    scannedAt: new Date().toISOString(),
+    summary: 'fixture',
+  };
+}
+
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  __testing.resetCoreCache();
+  __testing.setCoreResolver(null);
+  // Sentinel: any stderr write during the test counts as pollution.
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  __testing.resetCoreCache();
+  __testing.setCoreResolver(null);
+});
+
+describe('caamp skills install — warning routing (T9770)', () => {
+  it('routes W_CORE_UNAVAILABLE into the active WarningCollector when core resolution fails', async () => {
+    const collector = new WarningCollector();
+    // Simulate `@cleocode/core` being absent.
+    __testing.setCoreResolver(() => Promise.reject(new Error('MODULE_NOT_FOUND')));
+
+    const result = await withWarningCollector(collector, async () => __testing.resolveCore());
+
+    expect(result).toBeNull();
+
+    const drained = collector.drain();
+    expect(drained).toBeDefined();
+    expect(drained).toHaveLength(1);
+    const [warning] = drained!;
+    expect(warning.code).toBe('W_CORE_UNAVAILABLE');
+    expect(warning.severity).toBe('warn');
+    expect(warning.message).toMatch(/@cleocode\/core/);
+    expect(warning.context).toMatchObject({ error: 'MODULE_NOT_FOUND' });
+
+    // Stderr stays silent — no `[caamp] WARNING:` line should be emitted.
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('routes W_AUDIT_LOG_FAILED into the active WarningCollector when recordTrustBypass throws', async () => {
+    const collector = new WarningCollector();
+    // Provide a stub core whose `recordTrustBypass` always throws.
+    __testing.setCoreResolver(() =>
+      Promise.resolve({
+        scanSkill: () => makeScanFixture(),
+        shouldAllowInstall: () => ({ decision: 'allow' as const, reason: 'fixture' }),
+        recordTrustBypass: () => {
+          throw new Error('disk full');
+        },
+        evaluateFederationInstallGate: () => ({
+          decision: 'allow' as const,
+          reason: 'fixture',
+          peer: null,
+          isFederationSource: false,
+          computedChecksum: null,
+          expectedChecksum: null,
+        }),
+      }),
+    );
+
+    await withWarningCollector(collector, async () =>
+      __testing.recordSkillTrustBypass(makeScanFixture(), 'unit test'),
+    );
+
+    const drained = collector.drain();
+    expect(drained).toBeDefined();
+    expect(drained).toHaveLength(1);
+    const [warning] = drained!;
+    expect(warning.code).toBe('W_AUDIT_LOG_FAILED');
+    expect(warning.severity).toBe('warn');
+    expect(warning.message).toBe('trust-bypass audit record failed');
+    expect(warning.context).toMatchObject({ error: 'disk full' });
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('is silent (no warnings, no stderr) when there is no active collector and core is available', async () => {
+    __testing.setCoreResolver(() =>
+      Promise.resolve({
+        scanSkill: () => makeScanFixture(),
+        shouldAllowInstall: () => ({ decision: 'allow' as const, reason: 'fixture' }),
+        recordTrustBypass: () => undefined,
+        evaluateFederationInstallGate: () => ({
+          decision: 'allow' as const,
+          reason: 'fixture',
+          peer: null,
+          isFederationSource: false,
+          computedChecksum: null,
+          expectedChecksum: null,
+        }),
+      }),
+    );
+
+    const core = await __testing.resolveCore();
+    expect(core).not.toBeNull();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('pushWarning is a no-op when no collector is active (resolver failure case)', async () => {
+    // Outside any withWarningCollector scope — pushWarning falls through silently.
+    __testing.setCoreResolver(() => Promise.reject(new Error('boom')));
+    const result = await __testing.resolveCore();
+    expect(result).toBeNull();
+    // Critically: stderr stays silent even with NO collector — the warning is
+    // simply dropped rather than being routed back to legacy stderr writes.
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the user-reported `[caamp] WARNING:` stderr pollution emitted by `cleo skills install`. Both stderr write sites in `packages/caamp/src/commands/skills/install.ts` (lines 148 and 233 per the Wave 0 audit) are removed and replaced with `pushWarning(...)` from `@cleocode/lafs` (T9768 foundation, T9769 CLI drain).

- `resolveCore()` now combines `createRequire(import.meta.url).resolve('@cleocode/core')` with the existing `import('@cleocode/core' as string)` dodge — `resolve()` uses Node's standard pnpm/workspace symlink-aware resolution so the cleo dispatch path no longer falsely trips the "core unavailable" warning when core IS reachable.
- On genuine resolution failure (standalone caamp install without core): `pushWarning({code: 'W_CORE_UNAVAILABLE', severity: 'warn', context: {error}})`. Stderr stays silent.
- On `recordTrustBypass` write failure: `pushWarning({code: 'W_AUDIT_LOG_FAILED', severity: 'warn', context: {error}})`. Stderr stays silent.
- `@cleocode/core` declared as an optional `peerDependency` (kept as `dependency` too — caamp still imports it dynamically).
- Resolver is pluggable for tests via `__testing.setCoreResolver()`.

## Test plan

- [x] New unit suite `packages/caamp/tests/unit/install-warnings.test.ts` (4 tests):
  - [x] `W_CORE_UNAVAILABLE` lands in the active `WarningCollector` when resolution fails; `process.stderr.write` is never invoked.
  - [x] `W_AUDIT_LOG_FAILED` lands when `recordTrustBypass` throws; stderr silent.
  - [x] Silent success path when core resolves cleanly.
  - [x] No-op when no collector is bound (no stderr fallback).
- [x] `pnpm --filter @cleocode/caamp run build` — DTS + ESM green.
- [x] `pnpm biome check packages/caamp/` — clean.
- [x] Full caamp suite — only pre-existing flaky `coverage-*` tests fail; isolation reruns prove they pass standalone. Not a regression of this change (verified by running same tests on origin/main HEAD).
- [x] Smoke: `node packages/cleo/bin/cleo.js skills install <name> 2>/tmp/stderr` — stderr file is empty; stdout has a clean LAFS envelope.

Epic: T9763 (JSON stream hygiene) · Task: T9770

🤖 Generated with [Claude Code](https://claude.com/claude-code)