### PR TITLE
refactor(T9771): bridge warnings → meta.warnings

### DIFF
--- a/packages/core/src/memory/__tests__/memory-bridge-warnings.test.ts
+++ b/packages/core/src/memory/__tests__/memory-bridge-warnings.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for T9771 — memory bridge stderr → LAFS meta.warnings migration.
+ *
+ * Verifies that bridge failures inside an active `withWarningCollector`
+ * scope land in the collector as `W_BRIDGE_WRITE_FAILED` /
+ * `W_BRIDGE_REFRESH_FAILED` warnings, and that NO output is emitted to
+ * stdout or stderr.
+ *
+ * @task T9771
+ * @epic T9763 (JSON-stream hygiene)
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WarningCollector, withWarningCollector } from '@cleocode/lafs';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+let tempDir: string;
+
+/**
+ * Extract calls from a stderr spy that originate from CLEO bridge code,
+ * filtering out unrelated Node-level chatter (e.g. the SQLite
+ * `ExperimentalWarning` that Node emits unconditionally on first import).
+ */
+function bridgeStderrCalls(spy: MockInstance<typeof process.stderr.write>): unknown[][] {
+  return spy.mock.calls.filter((call) => {
+    const first = call[0];
+    const text = typeof first === 'string' ? first : '';
+    if (text.includes('ExperimentalWarning')) return false;
+    if (text.includes('Use `node --trace-warnings')) return false;
+    return true;
+  });
+}
+
+/** Set up a project root with `.cleo/config.json` for mode=file, with the
+ *  bridge file path BLOCKED by a directory so writeFileSync throws EISDIR. */
+function setupBlockedProject(): { projectRoot: string; cleoDir: string } {
+  const projectRoot = tempDir;
+  const cleoDir = join(projectRoot, '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+  writeFileSync(
+    join(cleoDir, 'config.json'),
+    JSON.stringify({ brain: { memoryBridge: { mode: 'file' } } }),
+    'utf-8',
+  );
+  // Block: place a directory where the bridge file should be written.
+  mkdirSync(join(cleoDir, 'memory-bridge.md'));
+  return { projectRoot, cleoDir };
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'cleo-bridge-warn-'));
+});
+
+afterEach(async () => {
+  try {
+    const { closeBrainDb } = await import('../../store/memory-sqlite.js');
+    closeBrainDb();
+  } catch {
+    /* may not be loaded */
+  }
+  vi.restoreAllMocks();
+  await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+});
+
+describe('T9771 — memory-bridge warnings → meta.warnings', () => {
+  it('writeMemoryBridge: write failure pushes W_BRIDGE_WRITE_FAILED with zero stderr', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { projectRoot } = setupBlockedProject();
+
+    const collector = new WarningCollector();
+    const { writeMemoryBridge } = await import('../memory-bridge.js');
+
+    const result = await withWarningCollector(collector, async () =>
+      writeMemoryBridge(projectRoot),
+    );
+
+    expect(result.written).toBe(false);
+
+    const drained = collector.drain();
+    expect(drained).toBeDefined();
+    const warning = drained!.find((w) => w.code === 'W_BRIDGE_WRITE_FAILED');
+    expect(warning).toBeDefined();
+    expect(warning!.severity).toBe('warn');
+    expect(warning!.context?.['bridge']).toBe('memory');
+    expect(typeof warning!.context?.['error']).toBe('string');
+
+    // Filter Node's own ExperimentalWarning chatter (SQLite preview) — it is
+    // environmental and unrelated to bridge stderr discipline.
+    expect(bridgeStderrCalls(stderrSpy)).toEqual([]);
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('refreshMemoryBridge: success path emits NO warnings (mode=cli)', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // No .cleo/config.json — default mode is 'cli' which short-circuits the
+    // write and the refresh succeeds with no work.
+    const collector = new WarningCollector();
+    const { refreshMemoryBridge } = await import('../memory-bridge.js');
+
+    await withWarningCollector(collector, async () => {
+      await refreshMemoryBridge(tempDir);
+    });
+
+    const drained = collector.drain();
+    // No warnings expected — drain returns undefined.
+    expect(drained).toBeUndefined();
+    expect(bridgeStderrCalls(stderrSpy)).toEqual([]);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('refreshMemoryBridge: write failure (mode=file, blocked path) does NOT touch stderr', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { projectRoot } = setupBlockedProject();
+
+    const collector = new WarningCollector();
+    const { refreshMemoryBridge } = await import('../memory-bridge.js');
+
+    await withWarningCollector(collector, async () => {
+      await refreshMemoryBridge(projectRoot);
+    });
+
+    // The inner writeMemoryBridge will fail and emit W_BRIDGE_WRITE_FAILED.
+    // refreshMemoryBridge itself does NOT catch (writeMemoryBridge already
+    // swallows the throw) — but the key property is: zero stderr writes.
+    const drained = collector.drain();
+    expect(drained).toBeDefined();
+    expect(drained!.some((w) => w.code === 'W_BRIDGE_WRITE_FAILED')).toBe(true);
+
+    expect(bridgeStderrCalls(stderrSpy)).toEqual([]);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('pushWarning outside a withWarningCollector scope is a silent no-op', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { projectRoot } = setupBlockedProject();
+    const { writeMemoryBridge } = await import('../memory-bridge.js');
+
+    // No withWarningCollector wrapper — the catch path should still run but
+    // produce nothing on any sink (pushWarning silently no-ops when the ALS
+    // store is empty).
+    const result = await writeMemoryBridge(projectRoot);
+    expect(result.written).toBe(false);
+
+    expect(bridgeStderrCalls(stderrSpy)).toEqual([]);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/memory/memory-bridge.ts
+++ b/packages/core/src/memory/memory-bridge.ts
@@ -25,6 +25,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
+import { pushWarning } from '@cleocode/lafs';
 import { getLastHandoff } from '../sessions/handoff.js';
 import { resolveBridgeMode } from '../system/bridge-mode.js';
 
@@ -261,10 +262,18 @@ export async function writeMemoryBridge(
     writeFileSync(bridgePath, content, 'utf-8');
     return { path: bridgePath, written: true };
   } catch (err) {
-    console.error(
-      '[CLEO] Failed to write memory bridge:',
-      err instanceof Error ? err.message : String(err),
-    );
+    // T9771: route bridge-write failure to LAFS meta.warnings — stderr noise
+    // was breaking JSON-only consumers of `cleo memory observe` and friends.
+    pushWarning({
+      code: 'W_BRIDGE_WRITE_FAILED',
+      message: 'Failed to write memory bridge',
+      severity: 'warn',
+      context: {
+        bridge: 'memory',
+        path: bridgePath,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
     return { path: bridgePath, written: false };
   }
 }
@@ -292,10 +301,16 @@ export async function refreshMemoryBridge(
       await writeMemoryBridge(projectRoot);
     }
   } catch (err) {
-    console.error(
-      '[CLEO] Memory bridge refresh failed:',
-      err instanceof Error ? err.message : String(err),
-    );
+    // T9771: route bridge-refresh failure to LAFS meta.warnings.
+    pushWarning({
+      code: 'W_BRIDGE_REFRESH_FAILED',
+      message: 'Memory bridge refresh failed',
+      severity: 'warn',
+      context: {
+        bridge: 'memory',
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
   }
 }
 

--- a/packages/core/src/nexus/__tests__/nexus-bridge-warnings.test.ts
+++ b/packages/core/src/nexus/__tests__/nexus-bridge-warnings.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for T9771 — nexus bridge stderr → LAFS meta.warnings migration.
+ *
+ * Verifies that nexus bridge write failures inside an active
+ * `withWarningCollector` scope land in the collector as
+ * `W_NEXUS_BRIDGE_FAILED`, with zero stdout/stderr noise.
+ *
+ * @task T9771
+ * @epic T9763 (JSON-stream hygiene)
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WarningCollector, withWarningCollector } from '@cleocode/lafs';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+let tempDir: string;
+
+/**
+ * Extract calls from a stderr spy that originate from CLEO bridge code,
+ * filtering out unrelated Node-level chatter (e.g. the SQLite
+ * `ExperimentalWarning` that Node emits unconditionally on first import).
+ */
+function bridgeStderrCalls(spy: MockInstance<typeof process.stderr.write>): unknown[][] {
+  return spy.mock.calls.filter((call) => {
+    const first = call[0];
+    const text = typeof first === 'string' ? first : '';
+    if (text.includes('ExperimentalWarning')) return false;
+    if (text.includes('Use `node --trace-warnings')) return false;
+    return true;
+  });
+}
+
+/** Set up a project root with mode=file config and a directory blocking the
+ *  bridge file path so writeFileSync throws EISDIR. */
+function setupBlockedProject(): string {
+  const projectRoot = tempDir;
+  const cleoDir = join(projectRoot, '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+  writeFileSync(
+    join(cleoDir, 'config.json'),
+    JSON.stringify({ brain: { memoryBridge: { mode: 'file' } } }),
+    'utf-8',
+  );
+  // Block: place a directory where the bridge file should be written.
+  mkdirSync(join(cleoDir, 'nexus-bridge.md'));
+  return projectRoot;
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'cleo-nexus-bridge-warn-'));
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+});
+
+describe('T9771 — nexus-bridge warnings → meta.warnings', () => {
+  it('writeNexusBridge: failure pushes W_NEXUS_BRIDGE_FAILED with zero stderr', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const projectRoot = setupBlockedProject();
+
+    const collector = new WarningCollector();
+    const { writeNexusBridge } = await import('../nexus-bridge.js');
+
+    const result = await withWarningCollector(collector, async () => writeNexusBridge(projectRoot));
+
+    expect(result.written).toBe(false);
+
+    const drained = collector.drain();
+    expect(drained).toBeDefined();
+    const warning = drained!.find((w) => w.code === 'W_NEXUS_BRIDGE_FAILED');
+    expect(warning).toBeDefined();
+    expect(warning!.severity).toBe('warn');
+    expect(warning!.context?.['bridge']).toBe('nexus');
+    expect(typeof warning!.context?.['error']).toBe('string');
+
+    expect(bridgeStderrCalls(stderrSpy)).toEqual([]);
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('refreshNexusBridge: success path emits NO warnings (mode=cli)', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // No config → mode=cli → write short-circuits.
+    const collector = new WarningCollector();
+    const { refreshNexusBridge } = await import('../nexus-bridge.js');
+
+    await withWarningCollector(collector, async () => {
+      await refreshNexusBridge(tempDir);
+    });
+
+    const drained = collector.drain();
+    expect(drained).toBeUndefined();
+    expect(bridgeStderrCalls(stderrSpy)).toEqual([]);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('pushWarning outside withWarningCollector remains silent (no stderr)', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const projectRoot = setupBlockedProject();
+    const { writeNexusBridge } = await import('../nexus-bridge.js');
+
+    const result = await writeNexusBridge(projectRoot);
+    expect(result.written).toBe(false);
+
+    expect(bridgeStderrCalls(stderrSpy)).toEqual([]);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/nexus/__tests__/task-sweeper-wired.test.ts
+++ b/packages/core/src/nexus/__tests__/task-sweeper-wired.test.ts
@@ -20,6 +20,7 @@ import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { WarningCollector, withWarningCollector } from '@cleocode/lafs';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EDGE_TYPES } from '../../memory/edge-types.js';
 import { closeBrainDb, getBrainDb, getBrainNativeDb } from '../../store/memory-sqlite.js';
@@ -254,7 +255,7 @@ describe('task-sweeper post-analyze wiring', { sequential: true }, () => {
     expect(edgeCount).toBe(result1.linked);
   }, 30_000);
 
-  it('handles a non-git directory gracefully — no error thrown, warn logged', async () => {
+  it('handles a non-git directory gracefully — no error thrown, warning routed to envelope', async () => {
     // Arrange: plain directory, not a git repo
     const plainDir = join(tmpDir, 'plain-dir');
     mkdirSync(plainDir);
@@ -263,11 +264,13 @@ describe('task-sweeper post-analyze wiring', { sequential: true }, () => {
     await getBrainDb(plainDir);
     await getNexusDb();
 
-    // Spy on console.warn to verify the warning is emitted
+    // T9771: warnings now flow through LAFS `WarningCollector` rather than
+    // console.warn. Capture them via an explicit collector bound through
+    // `withWarningCollector` and verify the envelope-shaped Warning.
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const collector = new WarningCollector();
 
-    // Act: sweeper should NOT throw
-    const result = await runGitLogTaskLinker(plainDir);
+    const result = await withWarningCollector(collector, async () => runGitLogTaskLinker(plainDir));
 
     // Assert: graceful empty result
     expect(result.linked).toBe(0);
@@ -275,8 +278,16 @@ describe('task-sweeper post-analyze wiring', { sequential: true }, () => {
     expect(result.tasksFound).toBe(0);
     expect(result.lastCommitHash).toBeNull();
 
-    // Assert: warning was logged
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('runGitLogTaskLinker'));
+    // Assert: warning routed to envelope, not stderr
+    const drained = collector.drain();
+    expect(drained).toBeDefined();
+    const w = drained!.find((entry) => entry.code === 'W_TASKS_BRIDGE_FAILED');
+    expect(w).toBeDefined();
+    expect(w!.message).toContain('runGitLogTaskLinker');
+    expect(w!.context?.['operation']).toBe('runGitLogTaskLinker');
+
+    // Assert: NO console.warn fallback (post-T9771 hygiene)
+    expect(warnSpy).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
   }, 10_000);

--- a/packages/core/src/nexus/__tests__/tasks-bridge-warnings.test.ts
+++ b/packages/core/src/nexus/__tests__/tasks-bridge-warnings.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for T9771 — tasks-bridge stderr → LAFS meta.warnings migration.
+ *
+ * Verifies that task-symbol bridge failures surface as
+ * `W_TASKS_BRIDGE_FAILED` warnings in the active `WarningCollector` and
+ * never touch stdout/stderr.
+ *
+ * @task T9771
+ * @epic T9763 (JSON-stream hygiene)
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WarningCollector, withWarningCollector } from '@cleocode/lafs';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+let tempDir: string;
+
+/**
+ * Extract calls from a stderr spy that originate from CLEO bridge code,
+ * filtering out unrelated Node-level chatter (e.g. the SQLite
+ * `ExperimentalWarning` that Node emits unconditionally on first import).
+ */
+function bridgeStderrCalls(spy: MockInstance<typeof process.stderr.write>): unknown[][] {
+  return spy.mock.calls.filter((call) => {
+    const first = call[0];
+    const text = typeof first === 'string' ? first : '';
+    if (text.includes('ExperimentalWarning')) return false;
+    if (text.includes('Use `node --trace-warnings')) return false;
+    return true;
+  });
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'cleo-tasks-bridge-warn-'));
+  // Isolate brain/nexus state in this temp dir so other tests don't leak.
+  process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+});
+
+afterEach(async () => {
+  try {
+    const { closeBrainDb } = await import('../../store/memory-sqlite.js');
+    closeBrainDb();
+  } catch {
+    /* may not be loaded */
+  }
+  try {
+    const { closeNexusDb } = await import('../../store/nexus-sqlite.js');
+    closeNexusDb();
+  } catch {
+    /* may not be loaded */
+  }
+  delete process.env['CLEO_DIR'];
+  vi.restoreAllMocks();
+  await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+});
+
+describe('T9771 — tasks-bridge warnings → meta.warnings', () => {
+  it('runGitLogTaskLinker on a non-git directory pushes W_TASKS_BRIDGE_FAILED with zero stderr', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const collector = new WarningCollector();
+    const { runGitLogTaskLinker } = await import('../tasks-bridge.js');
+
+    // tempDir is NOT a git repo → git log fails inside the inner try-catch.
+    const result = await withWarningCollector(collector, async () => runGitLogTaskLinker(tempDir));
+
+    // Result is the empty linker payload.
+    expect(result.linked).toBe(0);
+    expect(result.tasksFound).toBe(0);
+
+    const drained = collector.drain();
+    expect(drained).toBeDefined();
+    const warning = drained!.find((w) => w.code === 'W_TASKS_BRIDGE_FAILED');
+    expect(warning).toBeDefined();
+    expect(warning!.severity).toBe('warn');
+    expect(warning!.context?.['bridge']).toBe('tasks');
+    expect(warning!.context?.['operation']).toBe('runGitLogTaskLinker');
+
+    // Zero noise on every sink (filtering out Node's SQLite experimental
+    // banner that lands once-per-process on first DB import).
+    expect(bridgeStderrCalls(stderrSpy)).toEqual([]);
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('linkTaskToSymbols with malformed filesJson returns empty result without warnings', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const collector = new WarningCollector();
+    const { linkTaskToSymbols } = await import('../tasks-bridge.js');
+
+    // Malformed JSON → files=[] → early return with linked=0 — no warning path.
+    const result = await withWarningCollector(collector, async () =>
+      linkTaskToSymbols('T0001', '{not-json', tempDir),
+    );
+
+    expect(result.linked).toBe(0);
+    expect(result.taskId).toBe('T0001');
+    // Empty files → no warning fired.
+    expect(collector.drain()).toBeUndefined();
+
+    expect(bridgeStderrCalls(stderrSpy)).toEqual([]);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('runGitLogTaskLinker outside withWarningCollector stays silent on git failure', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { runGitLogTaskLinker } = await import('../tasks-bridge.js');
+
+    // No collector binding — pushWarning is a no-op, but ZERO stderr must be
+    // observed regardless.
+    const result = await runGitLogTaskLinker(tempDir);
+    expect(result.linked).toBe(0);
+
+    expect(bridgeStderrCalls(stderrSpy)).toEqual([]);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/nexus/nexus-bridge.ts
+++ b/packages/core/src/nexus/nexus-bridge.ts
@@ -24,6 +24,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
+import { pushWarning } from '@cleocode/lafs';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { resolveBridgeMode } from '../system/bridge-mode.js';
 
@@ -406,10 +407,17 @@ export async function writeNexusBridge(
     writeFileSync(bridgePath, content, 'utf-8');
     return { path: bridgePath, written: true };
   } catch (err) {
-    console.error(
-      '[CLEO] Failed to write nexus bridge:',
-      err instanceof Error ? err.message : String(err),
-    );
+    // T9771: route nexus-bridge write failure to LAFS meta.warnings.
+    pushWarning({
+      code: 'W_NEXUS_BRIDGE_FAILED',
+      message: 'Failed to write nexus bridge',
+      severity: 'warn',
+      context: {
+        bridge: 'nexus',
+        path: bridgePath,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
     return { path: bridgePath, written: false };
   }
 }
@@ -425,10 +433,16 @@ export async function refreshNexusBridge(projectRoot: string, projectId?: string
   try {
     await writeNexusBridge(projectRoot, projectId);
   } catch (err) {
-    console.error(
-      '[CLEO] Nexus bridge refresh failed:',
-      err instanceof Error ? err.message : String(err),
-    );
+    // T9771: route nexus bridge-refresh failure to LAFS meta.warnings.
+    pushWarning({
+      code: 'W_NEXUS_BRIDGE_FAILED',
+      message: 'Nexus bridge refresh failed',
+      severity: 'warn',
+      context: {
+        bridge: 'nexus',
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
   }
 }
 

--- a/packages/core/src/nexus/tasks-bridge.ts
+++ b/packages/core/src/nexus/tasks-bridge.ts
@@ -22,6 +22,7 @@ import type {
   SymbolReference,
   TaskReference,
 } from '@cleocode/contracts';
+import { pushWarning } from '@cleocode/lafs';
 import { EDGE_TYPES } from '../memory/edge-types.js';
 import { getBrainDb, getBrainNativeDb } from '../store/memory-sqlite.js';
 import { getNexusDb, getNexusNativeDb } from '../store/nexus-sqlite.js';
@@ -163,10 +164,18 @@ export async function linkTaskToSymbols(
       symbolsFound,
     };
   } catch (err) {
-    console.error(
-      `[CLEO] linkTaskToSymbols failed for ${taskId}:`,
-      err instanceof Error ? err.message : String(err),
-    );
+    // T9771: route task-symbol-link failure to LAFS meta.warnings.
+    pushWarning({
+      code: 'W_TASKS_BRIDGE_FAILED',
+      message: `linkTaskToSymbols failed for ${taskId}`,
+      severity: 'warn',
+      context: {
+        bridge: 'tasks',
+        operation: 'linkTaskToSymbols',
+        taskId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
     return {
       linked: 0,
       taskId,
@@ -217,10 +226,18 @@ export async function getTasksForSymbol(
       matchStrategy: 'git-log-file-match',
     }));
   } catch (err) {
-    console.error(
-      `[CLEO] getTasksForSymbol failed for ${symbolId}:`,
-      err instanceof Error ? err.message : String(err),
-    );
+    // T9771: route task-symbol-lookup failure to LAFS meta.warnings.
+    pushWarning({
+      code: 'W_TASKS_BRIDGE_FAILED',
+      message: `getTasksForSymbol failed for ${symbolId}`,
+      severity: 'warn',
+      context: {
+        bridge: 'tasks',
+        operation: 'getTasksForSymbol',
+        symbolId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
     return [];
   }
 }
@@ -286,10 +303,18 @@ export async function getSymbolsForTask(
 
     return results;
   } catch (err) {
-    console.error(
-      `[CLEO] getSymbolsForTask failed for ${taskId}:`,
-      err instanceof Error ? err.message : String(err),
-    );
+    // T9771: route task-symbol-lookup failure to LAFS meta.warnings.
+    pushWarning({
+      code: 'W_TASKS_BRIDGE_FAILED',
+      message: `getSymbolsForTask failed for ${taskId}`,
+      severity: 'warn',
+      context: {
+        bridge: 'tasks',
+        operation: 'getSymbolsForTask',
+        taskId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
     return [];
   }
 }
@@ -360,12 +385,27 @@ export async function runGitLogTaskLinker(
       gitLogOutput = execFileSync('git', args, {
         cwd: projectRoot,
         encoding: 'utf-8',
+        // T9771: capture stderr (pipe) so git's own diagnostics do NOT leak
+        // to the parent's stderr when running under JSON-emitting handlers.
+        // Without this, "fatal: not a git repository" from git would land in
+        // the user's terminal even though we route the failure through
+        // pushWarning() for envelope-only delivery.
+        stdio: ['ignore', 'pipe', 'pipe'],
       });
     } catch {
-      // git command failed — likely not a git repo; warn and return empty result
-      console.warn(
-        `[CLEO] runGitLogTaskLinker: git log failed in "${projectRoot}" — directory may not be a git repository. Skipping task-symbol linking.`,
-      );
+      // T9771: git command failed — likely not a git repo; surface as
+      // envelope warning instead of stderr so JSON consumers stay clean.
+      pushWarning({
+        code: 'W_TASKS_BRIDGE_FAILED',
+        message:
+          'runGitLogTaskLinker: git log failed — directory may not be a git repository. Skipping task-symbol linking.',
+        severity: 'warn',
+        context: {
+          bridge: 'tasks',
+          operation: 'runGitLogTaskLinker',
+          projectRoot,
+        },
+      });
       return {
         linked: 0,
         commitsProcessed: 0,
@@ -445,10 +485,17 @@ export async function runGitLogTaskLinker(
       lastCommitHash: lastCommit,
     };
   } catch (err) {
-    console.error(
-      '[CLEO] runGitLogTaskLinker failed:',
-      err instanceof Error ? err.message : String(err),
-    );
+    // T9771: route git-log linker failure to LAFS meta.warnings.
+    pushWarning({
+      code: 'W_TASKS_BRIDGE_FAILED',
+      message: 'runGitLogTaskLinker failed',
+      severity: 'warn',
+      context: {
+        bridge: 'tasks',
+        operation: 'runGitLogTaskLinker',
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
     return {
       linked: 0,
       commitsProcessed: 0,

--- a/packages/core/src/sentient/tick.ts
+++ b/packages/core/src/sentient/tick.ts
@@ -24,6 +24,7 @@
 
 import { spawn } from 'node:child_process';
 import type { Task } from '@cleocode/contracts';
+import { pushWarning } from '@cleocode/lafs';
 import {
   type ReVerifyOptions,
   reVerifyWorkerReport,
@@ -516,10 +517,30 @@ async function maybeTriggerDream(
       volumeThreshold: volumeThreshold > 0 ? volumeThreshold : undefined,
       inline: false,
     }).catch((err: unknown) => {
-      console.warn('[sentient/tick] dream trigger error:', err);
+      // T9771: route dream-trigger failure to LAFS meta.warnings.
+      pushWarning({
+        code: 'W_DREAM_TRIGGER_FAILED',
+        message: 'sentient/tick: dream trigger error',
+        severity: 'warn',
+        context: {
+          source: 'sentient/tick',
+          phase: 'dreamer.catch',
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
     });
   } catch (err) {
-    console.warn('[sentient/tick] dream trigger threw:', err);
+    // T9771: route dream-trigger throw to LAFS meta.warnings.
+    pushWarning({
+      code: 'W_DREAM_TRIGGER_FAILED',
+      message: 'sentient/tick: dream trigger threw',
+      severity: 'warn',
+      context: {
+        source: 'sentient/tick',
+        phase: 'dreamer.throw',
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

T-JH-4 of the JSON-stream hygiene epic (T9763). Migrate the 9 production `console.warn` / `console.error` sites in the bridge layer so non-fatal bridge failures surface through the LAFS `WarningCollector` (T9768) instead of leaking onto the parent process's stderr.

This was breaking `cleo memory observe`, `cleo nexus impact`, `cleo nexus context`, and any other JSON-emitting command that triggered a memory/nexus/tasks bridge refresh as a side-effect.

## Migrated sites (9 total)

| File                       | Sites | Warning code               |
|----------------------------|-------|----------------------------|
| `memory/memory-bridge.ts`  | 2     | `W_BRIDGE_WRITE_FAILED`, `W_BRIDGE_REFRESH_FAILED` |
| `nexus/nexus-bridge.ts`    | 2     | `W_NEXUS_BRIDGE_FAILED`    |
| `nexus/tasks-bridge.ts`    | 5     | `W_TASKS_BRIDGE_FAILED`    |
| `sentient/tick.ts`         | 2     | `W_DREAM_TRIGGER_FAILED`   |

Every warning carries `severity: 'warn'` plus a structured `context` (bridge name, operation, path / taskId / symbolId where applicable, underlying error message). When no `withWarningCollector` scope is bound, `pushWarning` is a silent no-op — matching the SDK-consumer contract from T9768/T9769.

## Secondary fix

`runGitLogTaskLinker` now passes `stdio: ['ignore', 'pipe', 'pipe']` to `execFileSync('git', ...)` so git's own `"fatal: not a git repository"` diagnostics are captured by the child process rather than inherited onto the parent's stderr.

## Test plan

- [x] New `memory/__tests__/memory-bridge-warnings.test.ts` — 4 cases (write failure, refresh success, refresh failure, no-collector silent no-op)
- [x] New `nexus/__tests__/nexus-bridge-warnings.test.ts` — 3 cases
- [x] New `nexus/__tests__/tasks-bridge-warnings.test.ts` — 3 cases
- [x] Updated `task-sweeper-wired.test.ts` "non-git directory graceful" test to assert envelope warning rather than the now-removed `console.warn` fallback
- [x] Targeted run: 47 bridge tests pass (memory-bridge + memory-bridge-warnings + nexus-bridge-mode-gate + nexus-bridge-warnings + tasks-bridge + tasks-bridge-warnings + task-sweeper-wired)
- [x] `pnpm --filter @cleocode/core run build` clean
- [x] `pnpm biome ci` clean on all 8 touched files
- [x] Smoke test (`/tmp/T9771-smoke.mjs`): bridge write failure inside `withWarningCollector` produces `W_BRIDGE_WRITE_FAILED` with **zero** writes to stderr or stdout

## Notes for reviewer

- `pushWarning` is imported from `@cleocode/lafs` (per the foundation merged via T9763 wave-0). `@cleocode/core` already lists `@cleocode/lafs` as a workspace dependency.
- The pre-existing 10 broader test failures in `src/memory src/nexus src/sentient` (precompact-flush, query/getCurrentProject, wiki-index, baseline, daemon picker, hygiene-scan timeouts, etc.) are unrelated to this change — they fail on `origin/main` as well (E_INVALID_PROJECT_ROOT and timeouts in the worktree environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)