### PR TITLE
fix(T9765): cleo release <verb> --help now shows verb-specific help

### DIFF
--- a/packages/cleo/src/cli/__tests__/release-help.test.ts
+++ b/packages/cleo/src/cli/__tests__/release-help.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit test — `resolveSubCommandForHelp` walks nested subcommand trees so
+ * `cleo release <verb> --help` (and every other `<group> <verb> --help`)
+ * renders verb-specific help instead of the top-level command listing (T9765).
+ *
+ * Pre-fix bug: `runMainWithLafsEnvelope` (packages/cleo/src/cli/index.ts)
+ * detected `--help` anywhere in `rawArgs` and called `showUsage(rootCmd)`
+ * directly. That dumped the grouped top-level help for EVERY subcommand
+ * invocation — `cleo release plan --help`, `cleo session start --help`, `cleo
+ * nexus impact --help` all collapsed to the same screen. This regression
+ * made `--help` useless as a discovery tool for option flags on nested verbs.
+ *
+ * Fix: walk the subcommand tree via `resolveSubCommandForHelp` (a local port
+ * of citty 0.2.1's unexported `resolveSubCommand`, lifted into its own module
+ * to avoid index.ts's top-level `void startCli()` side effect) before calling
+ * showUsage, so we hand the leaf command + its parent to the renderer.
+ *
+ * This file exercises the resolver directly with mock CommandDefs — pure
+ * tree-walk semantics, no process spawn, no global IO, fast enough to run
+ * under heavy CI load. We assert the resolver:
+ *
+ *   1. Walks down to the leaf for `release plan --help`.
+ *   2. Stops at the group for `release --help`.
+ *   3. Stops at root for bare `--help` / `-h`.
+ *   4. Handles `lazyCommand`-style thunks for `subCommands`.
+ *   5. Ignores leading flags before the subcommand token (the original bug).
+ *
+ * @task T9765
+ * @epic T9758 (Saga: release system becomes a product)
+ */
+
+import type { CommandDef } from 'citty';
+import { defineCommand } from 'citty';
+import { describe, expect, it } from 'vitest';
+import { resolveSubCommandForHelp } from '../resolve-subcommand.js';
+
+// ---------------------------------------------------------------------------
+// Fixture: a 3-level command tree mirroring the real cleo > release > <verb>
+// shape. Each verb has its own `args` block (the help renderer reads these),
+// so an assertion against `args` proves we walked to the correct level.
+// ---------------------------------------------------------------------------
+
+const planCmd: CommandDef = defineCommand({
+  meta: { name: 'plan', description: 'Build the release plan.' },
+  args: {
+    version: { type: 'positional', description: 'Release version', required: true },
+    epic: { type: 'string', description: 'Epic ID', required: true },
+  },
+  run() {
+    // intentionally empty — fixture
+  },
+});
+
+const openCmd: CommandDef = defineCommand({
+  meta: { name: 'open', description: 'Open the release PR.' },
+  args: {
+    version: { type: 'positional', description: 'Release version', required: true },
+    workflow: { type: 'string', description: 'Workflow file' },
+  },
+  run() {
+    // intentionally empty — fixture
+  },
+});
+
+const releaseCmd: CommandDef = defineCommand({
+  meta: { name: 'release', description: 'Release lifecycle group.' },
+  subCommands: { plan: planCmd, open: openCmd },
+  run() {
+    // intentionally empty — fixture
+  },
+});
+
+const rootCmd: CommandDef = defineCommand({
+  meta: { name: 'cleo', description: 'CLEO root.' },
+  subCommands: { release: releaseCmd },
+  run() {
+    // intentionally empty — fixture
+  },
+});
+
+// Lazy-command variant — mirrors what `lazyCommand` produces: `subCommands`
+// is a function thunk that returns the resolved map. The resolver MUST
+// transparently await it.
+const lazyRootCmd: CommandDef = {
+  meta: { name: 'cleo', description: 'CLEO root (lazy).' },
+  subCommands: (async () => ({ release: releaseCmd })) as unknown as CommandDef['subCommands'],
+};
+
+describe('T9765 — resolveSubCommandForHelp', () => {
+  it('walks down to the leaf for `release plan --help`', async () => {
+    const [leaf, parent] = await resolveSubCommandForHelp(rootCmd, ['release', 'plan', '--help']);
+    expect(leaf).toBe(planCmd);
+    expect(parent).toBe(releaseCmd);
+    // Sanity: the leaf has the plan-specific `--epic` arg.
+    expect(leaf.args).toMatchObject({ epic: { type: 'string', required: true } });
+  });
+
+  it('walks down to the leaf for `release open --help`', async () => {
+    const [leaf, parent] = await resolveSubCommandForHelp(rootCmd, ['release', 'open', '--help']);
+    expect(leaf).toBe(openCmd);
+    expect(parent).toBe(releaseCmd);
+    expect(leaf.args).toMatchObject({ workflow: { type: 'string' } });
+  });
+
+  it('stops at the group for `release --help`', async () => {
+    const [leaf, parent] = await resolveSubCommandForHelp(rootCmd, ['release', '--help']);
+    expect(leaf).toBe(releaseCmd);
+    expect(parent).toBe(rootCmd);
+  });
+
+  it('stops at root for bare `--help`', async () => {
+    const [leaf, parent] = await resolveSubCommandForHelp(rootCmd, ['--help']);
+    expect(leaf).toBe(rootCmd);
+    expect(parent).toBeUndefined();
+  });
+
+  it('stops at root for bare `-h`', async () => {
+    const [leaf, parent] = await resolveSubCommandForHelp(rootCmd, ['-h']);
+    expect(leaf).toBe(rootCmd);
+    expect(parent).toBeUndefined();
+  });
+
+  it('stops at root for empty rawArgs', async () => {
+    const [leaf, parent] = await resolveSubCommandForHelp(rootCmd, []);
+    expect(leaf).toBe(rootCmd);
+    expect(parent).toBeUndefined();
+  });
+
+  it('stops at the unknown subcommand boundary', async () => {
+    const [leaf, parent] = await resolveSubCommandForHelp(rootCmd, [
+      'release',
+      'nonexistent-verb',
+      '--help',
+    ]);
+    expect(leaf).toBe(releaseCmd);
+    expect(parent).toBe(rootCmd);
+  });
+
+  it('skips leading flags before the subcommand token', async () => {
+    // Pre-fix: `--json release plan --help` would still trigger the buggy
+    // help fast-path. Resolver must ignore leading flags and find the first
+    // non-flag token.
+    const [leaf, parent] = await resolveSubCommandForHelp(rootCmd, [
+      '--json',
+      'release',
+      'plan',
+      '--help',
+    ]);
+    expect(leaf).toBe(planCmd);
+    expect(parent).toBe(releaseCmd);
+  });
+
+  it('handles lazy-command thunks for subCommands', async () => {
+    const [leaf, parent] = await resolveSubCommandForHelp(lazyRootCmd, [
+      'release',
+      'plan',
+      '--help',
+    ]);
+    expect(leaf).toBe(planCmd);
+    expect(parent).toBe(releaseCmd);
+  });
+
+  it('returns root when leaf has no subCommands and rawArgs has further tokens', async () => {
+    // E.g. `release plan extra-token --help` — plan is a leaf, we stop there.
+    const [leaf, parent] = await resolveSubCommandForHelp(rootCmd, [
+      'release',
+      'plan',
+      'extra-token',
+      '--help',
+    ]);
+    expect(leaf).toBe(planCmd);
+    expect(parent).toBe(releaseCmd);
+  });
+});

--- a/packages/cleo/src/cli/index.ts
+++ b/packages/cleo/src/cli/index.ts
@@ -57,6 +57,7 @@ import { lazyCommand } from './lazy-command.js';
 import { didYouMean } from './lib/did-you-mean.js';
 import { maybePromptFirstRun } from './lib/first-run-detection.js';
 import { resolveFormat } from './middleware/output-format.js';
+import { resolveSubCommandForHelp } from './resolve-subcommand.js';
 
 function getPackageVersion(): string {
   const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '../../package.json');
@@ -289,10 +290,18 @@ async function runMainWithLafsEnvelope(
   const helpFlags = ['--help', '-h'];
   const versionFlags = ['--version', '-V'];
 
-  // Help fast-path — preserve citty's behaviour by calling the caller-supplied
-  // showUsage (which routes through createCustomShowUsage for grouped output).
+  // Help fast-path — walk DOWN the subcommand tree before rendering usage so
+  // `cleo release plan --help` shows plan-specific help, not the root listing.
+  //
+  // BUG FIX (T9765): the previous implementation passed the ROOT `cmd` directly
+  // to `showUsage`, so every `cleo <group> <verb> --help` invocation dumped the
+  // top-level command list. Citty's own `runMain` resolves the leaf subcommand
+  // via an unexported `resolveSubCommand` helper before calling showUsage; we
+  // mirror that here with `resolveSubCommandForHelp` because citty 0.2.1 does
+  // not re-export the resolver.
   if (rawArgs.some((a) => helpFlags.includes(a))) {
-    await showUsage(cmd);
+    const [leafCmd, parentCmd] = await resolveSubCommandForHelp(cmd, rawArgs);
+    await showUsage(leafCmd, parentCmd);
     process.exit(0);
   }
 

--- a/packages/cleo/src/cli/resolve-subcommand.ts
+++ b/packages/cleo/src/cli/resolve-subcommand.ts
@@ -1,0 +1,84 @@
+/**
+ * Subcommand resolution helper for `--help` rendering (T9765).
+ *
+ * Citty 0.2.1's `runMain` walks the subcommand tree before calling
+ * `showUsage` so `cleo <group> <verb> --help` renders the verb-specific help
+ * — but our LAFS-wrapped `runMainWithLafsEnvelope` (packages/cleo/src/cli/index.ts)
+ * needs the same behaviour. Citty exports neither `resolveSubCommand` nor
+ * `resolveValue`, so we mirror them here.
+ *
+ * Lives in its own module so the unit test (`__tests__/resolve-subcommand.test.ts`)
+ * can import the helper without triggering `index.ts`'s top-level
+ * `void startCli()` invocation.
+ *
+ * @packageDocumentation
+ */
+
+import type { CommandDef } from 'citty';
+
+/**
+ * Resolve a lazily-defined value (function, promise, or plain) — mirrors
+ * citty's internal `resolveValue` helper. Used by {@link resolveSubCommandForHelp}
+ * to read `cmd.subCommands` which may be a function thunk or promise
+ * (see `lazyCommand`).
+ *
+ * @internal
+ */
+async function resolveLazyValue<T>(input: T | (() => T | Promise<T>) | Promise<T>): Promise<T> {
+  if (typeof input === 'function') {
+    return resolveLazyValue((input as () => T | Promise<T>)());
+  }
+  return Promise.resolve(input as T | Promise<T>);
+}
+
+/**
+ * Walk the subcommand tree to locate the leaf command referenced by `rawArgs`,
+ * returning `[leafCmd, parentCmd]` for citty's `showUsage`.
+ *
+ * Mirrors citty 0.2.1's internal `resolveSubCommand` (which is NOT re-exported)
+ * so we can render verb-specific `--help` for nested groups like
+ * `cleo release plan --help`. Each step:
+ *
+ *   1. Resolve `cmd.subCommands` (possibly lazy via `lazyCommand`).
+ *   2. Find the first non-flag token in `rawArgs` — that names the subcommand.
+ *   3. If it matches a known subcommand, recurse one level deeper with the
+ *      remainder of `rawArgs` (slice past the matched token).
+ *   4. Stop when no further subcommand matches, returning the current node.
+ *
+ * Bare `--help` (e.g. `cleo --help`) resolves to `[rootCmd, undefined]`
+ * unchanged. Unknown subcommand names also stop the walk — citty's runCommand
+ * surfaces the "Unknown command" error elsewhere.
+ *
+ * @param cmd     - The root command definition.
+ * @param rawArgs - Argument vector to inspect (typically `process.argv.slice(2)`).
+ * @returns Tuple of `[matched-command, its-immediate-parent | undefined]`.
+ *          The parent is `undefined` when the match is the root itself.
+ */
+export async function resolveSubCommandForHelp(
+  cmd: CommandDef,
+  rawArgs: string[],
+): Promise<[CommandDef, CommandDef | undefined]> {
+  let current: CommandDef = cmd;
+  let parent: CommandDef | undefined;
+  let remaining: string[] = [...rawArgs];
+
+  while (true) {
+    const subCommands = (await resolveLazyValue(current.subCommands)) as
+      | Record<string, CommandDef>
+      | undefined;
+    if (!subCommands || Object.keys(subCommands).length === 0) return [current, parent];
+
+    const subIndex = remaining.findIndex((arg) => !arg.startsWith('-'));
+    if (subIndex < 0) return [current, parent];
+
+    const subName = remaining[subIndex];
+    if (subName === undefined || !(subName in subCommands)) return [current, parent];
+
+    const next = (await resolveLazyValue(subCommands[subName])) as CommandDef | undefined;
+    if (!next) return [current, parent];
+
+    parent = current;
+    current = next;
+    remaining = remaining.slice(subIndex + 1);
+  }
+}


### PR DESCRIPTION
## Summary

- `cleo release plan --help` (and every nested `<group> <verb> --help`) used to dump the top-level cleo command listing instead of the verb's own option list.
- **Root cause**: `runMainWithLafsEnvelope` in `packages/cleo/src/cli/index.ts` called `showUsage(rootCmd)` directly when `--help` was anywhere in `rawArgs`, never walking the subcommand tree.
- **Fix**: extract a `resolveSubCommandForHelp` helper (port of citty 0.2.1's unexported `resolveSubCommand`) into its own module and walk down to the leaf verb before rendering. Handles `lazyCommand` thunks transparently.

The bug affected ALL nested subcommands across cleo — not just release. After the fix, `cleo release plan --help`, `cleo session start --help`, `cleo nexus impact --help`, `cleo memory find --help`, etc. all surface their own help. Root `cleo --help` and group-level `cleo release --help` still render correctly.

## Test plan

- [x] `cleo release plan --help` shows plan-specific USAGE + `--epic` / `--hotfix` options
- [x] `cleo release open --help` shows `--workflow` / `--commit-plan`
- [x] `cleo release reconcile --help` shows reconcile-specific options
- [x] `cleo release changelog --help` shows `[SINCETAG]` positional
- [x] All 11 release verbs (plan/open/reconcile/rollback/list/show/cancel/changelog/pr-status/channel/rollback-full) verified to render verb-specific USAGE
- [x] `cleo release --help` still renders the group listing (regression guard)
- [x] `cleo --help` still renders the top-level grouped help (regression guard)
- [x] Unit test suite (10 cases) covers tree-walk semantics, lazy thunks, leading-flag skip, unknown-subcommand boundary
- [x] `pnpm biome check` clean on modified files
- [x] `lint-project-root-anti-pattern.mjs --strict` passes
- [x] `lint-core-first.mjs --check` passes