### PR TITLE
refactor(T9772): pre-envelope validation errors → LAFS envelope; deprecation → meta.warnings

### DIFF
--- a/packages/cleo/src/cli/__tests__/llm-command.test.ts
+++ b/packages/cleo/src/cli/__tests__/llm-command.test.ts
@@ -22,10 +22,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // ---------------------------------------------------------------------------
 
 const mockDispatchFromCli = vi.fn().mockResolvedValue(undefined);
+const mockPushWarning = vi.fn();
 
 vi.mock('../../dispatch/adapters/cli.js', () => ({
   dispatchFromCli: (...args: unknown[]) => mockDispatchFromCli(...args),
 }));
+
+vi.mock('@cleocode/core', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@cleocode/core')>();
+  return {
+    ...original,
+    pushWarning: (...args: unknown[]) => mockPushWarning(...args),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
@@ -64,6 +73,7 @@ async function runSub(
 describe('cleo llm — CLI wiring', () => {
   beforeEach(() => {
     mockDispatchFromCli.mockClear();
+    mockPushWarning.mockClear();
   });
 
   it('exposes every documented subcommand', async () => {
@@ -89,11 +99,11 @@ describe('cleo llm — CLI wiring', () => {
   // S-11 — secret-on-argv mitigation
   // ---------------------------------------------------------------------
 
-  it('add (S-11) — --api-key=<value> emits the verbatim deprecation warning on stderr', async () => {
+  it('add (S-11) — --api-key=<value> queues the verbatim deprecation warning via pushWarning (T9772)', async () => {
     const subs = await getLlmSubs();
-    // Capture by replacing process.stderr.write directly; vi.spyOn doesn't
-    // intercept the `write` symbol once the citty `run` closure has bound
-    // it earlier in the module-load chain.
+    // T9772: the deprecation now surfaces through pushWarning() so it appears
+    // in `meta.warnings[]` on the LAFS envelope instead of polluting stderr.
+    // Capture stderr too — it MUST stay empty for this path.
     const origWrite = process.stderr.write.bind(process.stderr);
     const captured: string[] = [];
     process.stderr.write = ((s: unknown) => {
@@ -109,12 +119,21 @@ describe('cleo llm — CLI wiring', () => {
     } finally {
       process.stderr.write = origWrite;
     }
-    const warned = captured.find((s) =>
-      s.includes(
-        "[warning] --api-key exposes the secret to 'ps' listings and shell history. Prefer --api-key-stdin or --api-key-env=NAME for production use.",
-      ),
+    expect(captured.join(''), 'no raw stderr writes on --api-key deprecation path').toBe('');
+    expect(mockPushWarning).toHaveBeenCalledTimes(1);
+    const warn = mockPushWarning.mock.calls[0]?.[0] as {
+      code: string;
+      message: string;
+      deprecated?: string;
+      replacement?: string;
+    };
+    expect(warn.code).toBe('W_DEPRECATED_FLAG');
+    expect(warn.message).toContain(
+      "--api-key exposes the secret to 'ps' listings and shell history.",
     );
-    expect(warned, 'verbatim S-11 deprecation warning must be emitted').toBeDefined();
+    expect(warn.deprecated).toBe('--api-key=<value>');
+    expect(warn.replacement).toContain('--api-key-stdin');
+    expect(warn.replacement).toContain('--api-key-env=NAME');
     expect(mockDispatchFromCli).toHaveBeenCalledTimes(1);
     const call = mockDispatchFromCli.mock.calls[0]!;
     expect(call[3]).toMatchObject({

--- a/packages/cleo/src/cli/commands/__tests__/release-ship-deprecation.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/release-ship-deprecation.test.ts
@@ -1,26 +1,36 @@
 /**
  * Tests for T9538 — `cleo release ship` deprecation shim (SPEC-T9345 §12 R-420).
  *
+ * Updated by T9772 (JSON stream hygiene): the deprecation notice now ships
+ * through `meta.warnings[]` via `pushWarning(...)` instead of raw stderr, so
+ * JSON consumers parsing stdout see the deprecation without losing parseability
+ * of the dispatch envelope. The exported `SHIP_DEPRECATION_NOTICE` string is
+ * still asserted in full (constant contents unchanged).
+ *
  * Verifies that the deprecated `ship` verb:
- *   1. Emits a deprecation warning to stderr (not stdout) on every invocation.
- *   2. Default path (workflow !== false): forwards to `release.plan` then
- *      `release.open` via dispatch.
- *   3. Escape-hatch path (`--workflow=false`): falls through to legacy
- *      `pipeline.release.ship` dispatch AND appends a CRITICAL record to
- *      `.cleo/audit/release-workflow-bypass.jsonl` (R-441).
- *   4. Dry-run forwards plan but skips open (preview semantics).
- *   5. The exported notice constant is a non-empty string for downstream
+ *   1. Pushes a `W_DEPRECATED_COMMAND` warning carrying SHIP_DEPRECATION_NOTICE
+ *      into the LAFS envelope (not stderr) on every invocation.
+ *   2. Default path: forwards to `release.plan` then `release.open` via
+ *      dispatch.
+ *   3. Dry-run forwards plan but skips open (preview semantics).
+ *   4. The exported notice constant is a non-empty string for downstream
  *      assertions.
+ *
+ * Note: the `--workflow=false` escape hatch was removed in T9540 (Phase 6 of
+ * T9499) along with the legacy `releaseShip` monolith. Tests covering that
+ * escape hatch were dropped here when the flag itself was deleted.
  *
  * Strategy:
  *   - Mock `dispatchFromCli` so we observe operation names + params without
  *     spawning a real release.
- *   - Mock `release.appendReleaseWorkflowBypass` to confirm the escape-hatch
- *     path audits the bypass.
- *   - Capture `process.stderr.write` to confirm the deprecation warning lands
- *     on stderr (NOT stdout — JSON envelope integrity).
+ *   - Mock `pushWarning` so we can assert the deprecation warning is queued
+ *     for the next envelope.
+ *   - Capture `process.stderr.write` to confirm NO stderr writes occur on
+ *     the ship path (T9772 hygiene guarantee).
  *
  * @task T9538
+ * @task T9540 — removed `--workflow=false` + audit hook
+ * @task T9772 — deprecation now goes through `pushWarning`, not stderr
  * @epic T9498
  * @spec SPEC-T9345 §12 R-420 / R-440 / R-441
  */
@@ -33,6 +43,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockDispatchFromCli = vi.fn();
 const mockAppendBypass = vi.fn();
+const mockPushWarning = vi.fn();
 
 vi.mock('../../../dispatch/adapters/cli.js', () => ({
   dispatchFromCli: (...args: unknown[]) => mockDispatchFromCli(...args),
@@ -42,6 +53,7 @@ vi.mock('@cleocode/core', async (importOriginal) => {
   const original = await importOriginal<typeof import('@cleocode/core')>();
   return {
     ...original,
+    pushWarning: (...args: unknown[]) => mockPushWarning(...args),
     release: {
       ...original.release,
       appendReleaseWorkflowBypass: (...args: unknown[]) => mockAppendBypass(...args),
@@ -62,13 +74,7 @@ import { releaseCommand, SHIP_DEPRECATION_NOTICE } from '../release.js';
 interface ShipArgs {
   version: string;
   epic: string;
-  workflow?: boolean;
-  'workflow-bypass-reason'?: string;
   'dry-run'?: boolean;
-  push?: boolean;
-  bump?: boolean;
-  remote?: string;
-  force?: boolean;
 }
 
 /**
@@ -113,6 +119,7 @@ describe('cleo release ship — T9538 deprecation shim', () => {
     mockDispatchFromCli.mockReset();
     mockDispatchFromCli.mockResolvedValue({ success: true, data: {}, _meta: {} });
     mockAppendBypass.mockReset();
+    mockPushWarning.mockReset();
   });
 
   afterEach(() => {
@@ -129,20 +136,30 @@ describe('cleo release ship — T9538 deprecation shim', () => {
     expect(SHIP_DEPRECATION_NOTICE.toLowerCase()).toContain('deprecated');
   });
 
-  it('writes the deprecation warning to stderr on every invocation', async () => {
+  it('queues the deprecation warning via pushWarning (envelope, not stderr) on every invocation', async () => {
     const cap = captureStderr();
     try {
       await invokeShip({ version: '2026.6.0', epic: 'T9498' });
     } finally {
       cap.restore();
     }
-    const stderrOutput = cap.writes.join('');
-    expect(stderrOutput).toContain('cleo release ship');
-    expect(stderrOutput).toContain('DEPRECATED');
-    expect(stderrOutput).toContain('cleo release plan');
+    // T9772: notice MUST surface through the LAFS envelope, NOT stderr.
+    expect(cap.writes.join('')).toBe('');
+    expect(mockPushWarning).toHaveBeenCalledTimes(1);
+    const warn = mockPushWarning.mock.calls[0]?.[0] as {
+      code: string;
+      message: string;
+      deprecated?: string;
+      replacement?: string;
+    };
+    expect(warn.code).toBe('W_DEPRECATED_COMMAND');
+    expect(warn.message).toBe(SHIP_DEPRECATION_NOTICE);
+    expect(warn.deprecated).toBe('cleo release ship');
+    expect(warn.replacement).toContain('cleo release plan');
+    expect(warn.replacement).toContain('cleo release open');
   });
 
-  it('default path (no --workflow flag) forwards to release.plan then release.open', async () => {
+  it('default path forwards to release.plan then release.open', async () => {
     const cap = captureStderr();
     try {
       await invokeShip({ version: '2026.6.0', epic: 'T9498' });
@@ -157,7 +174,7 @@ describe('cleo release ship — T9538 deprecation shim', () => {
     // Call 1: release.plan with version + epicId.
     expect(firstCall?.[0]).toBe('mutate');
     expect(firstCall?.[1]).toBe('release');
-    expect(firstCall?.[2]).toBe('release.plan');
+    expect(firstCall?.[2]).toBe('plan');
     expect(firstCall?.[3]).toMatchObject({
       version: '2026.6.0',
       epicId: 'T9498',
@@ -167,10 +184,10 @@ describe('cleo release ship — T9538 deprecation shim', () => {
     // Call 2: release.open with version.
     expect(secondCall?.[0]).toBe('mutate');
     expect(secondCall?.[1]).toBe('release');
-    expect(secondCall?.[2]).toBe('release.open');
+    expect(secondCall?.[2]).toBe('open');
     expect(secondCall?.[3]).toMatchObject({ version: '2026.6.0' });
 
-    // Escape hatch MUST NOT have been engaged.
+    // T9540: bypass audit hook removed — legacy `--workflow=false` no longer exists.
     expect(mockAppendBypass).not.toHaveBeenCalled();
   });
 
@@ -184,60 +201,9 @@ describe('cleo release ship — T9538 deprecation shim', () => {
 
     expect(mockDispatchFromCli).toHaveBeenCalledTimes(1);
     const call = mockDispatchFromCli.mock.calls[0];
-    expect(call?.[2]).toBe('release.plan');
+    expect(call?.[2]).toBe('plan');
     expect(call?.[3]).toMatchObject({ dryRun: true });
     expect(mockAppendBypass).not.toHaveBeenCalled();
-  });
-
-  it('--workflow=false engages legacy pipeline.release.ship + audits bypass', async () => {
-    const cap = captureStderr();
-    try {
-      await invokeShip({
-        version: '2026.6.0',
-        epic: 'T9498',
-        workflow: false,
-        'workflow-bypass-reason': 'GHA outage — hotfix only',
-        push: true,
-        bump: true,
-      });
-    } finally {
-      cap.restore();
-    }
-
-    // Exactly one dispatch — and it MUST be the legacy pipeline route.
-    expect(mockDispatchFromCli).toHaveBeenCalledTimes(1);
-    const call = mockDispatchFromCli.mock.calls[0];
-    expect(call?.[1]).toBe('pipeline');
-    expect(call?.[2]).toBe('release.ship');
-    expect(call?.[3]).toMatchObject({
-      version: '2026.6.0',
-      epicId: 'T9498',
-      push: true,
-      bump: true,
-    });
-
-    // Audit log MUST have been appended exactly once (R-441).
-    expect(mockAppendBypass).toHaveBeenCalledTimes(1);
-    const auditOpts = mockAppendBypass.mock.calls[0]?.[0];
-    expect(auditOpts).toMatchObject({
-      version: '2026.6.0',
-      epicId: 'T9498',
-      reason: 'GHA outage — hotfix only',
-      source: 'cli-flag',
-    });
-  });
-
-  it('--workflow=false without reason records a sentinel rationale (audit-complete)', async () => {
-    const cap = captureStderr();
-    try {
-      await invokeShip({ version: '2026.6.0', epic: 'T9498', workflow: false });
-    } finally {
-      cap.restore();
-    }
-
-    expect(mockAppendBypass).toHaveBeenCalledTimes(1);
-    const auditOpts = mockAppendBypass.mock.calls[0]?.[0] as { reason: string };
-    expect(auditOpts.reason).toMatch(/no reason supplied/i);
   });
 });
 

--- a/packages/cleo/src/cli/commands/briefing.ts
+++ b/packages/cleo/src/cli/commands/briefing.ts
@@ -17,10 +17,12 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { pushWarning } from '@cleocode/core';
 import { resolveLegacyCleoDir } from '@cleocode/paths';
 import { defineCommand } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
 import { isSubCommandDispatch } from '../lib/subcommand-guard.js';
+import { cliError } from '../renderers/index.js';
 
 /** Canonical section names supported by `cleo briefing inject`. */
 const INJECTION_SECTION_NAMES = [
@@ -120,7 +122,21 @@ function renderForAdapter(sectionName: string, content: string, format: AdapterF
 async function runBriefingInject(sectionName: string, formatStr: string): Promise<void> {
   const templatePath = resolveInjectionTemplatePath();
   if (!existsSync(templatePath)) {
-    process.stderr.write(`[briefing inject] CLEO-INJECTION.md not found at ${templatePath}\n`);
+    // T9772: template-not-found is a non-fatal inject failure — surface as
+    // a `W_TEMPLATE_INJECT_FAILED` warning attached to the LAFS error envelope.
+    pushWarning({
+      code: 'W_TEMPLATE_INJECT_FAILED',
+      message: `CLEO-INJECTION.md not found at ${templatePath}`,
+    });
+    cliError(
+      `CLEO-INJECTION.md not found at ${templatePath}`,
+      1,
+      {
+        name: 'E_TEMPLATE_NOT_FOUND',
+        fix: 'Re-run `cleo init` or restore the templates directory.',
+      },
+      { operation: 'briefing.inject' },
+    );
     process.exitCode = 1;
     return;
   }
@@ -130,9 +146,19 @@ async function runBriefingInject(sectionName: string, formatStr: string): Promis
 
   if (section === null) {
     const available = INJECTION_SECTION_NAMES.join(', ');
-    process.stderr.write(
-      `[briefing inject] Section "${sectionName}" not found in CLEO-INJECTION.md.\n` +
-        `Available sections: ${available}\n`,
+    // T9772: unknown section is a validation failure — emit envelope with warning.
+    pushWarning({
+      code: 'W_TEMPLATE_INJECT_FAILED',
+      message: `Section "${sectionName}" not found in CLEO-INJECTION.md.`,
+    });
+    cliError(
+      `Section "${sectionName}" not found in CLEO-INJECTION.md. Available sections: ${available}`,
+      1,
+      {
+        name: 'E_VALIDATION',
+        fix: `Pass one of: ${available}`,
+      },
+      { operation: 'briefing.inject' },
     );
     process.exitCode = 1;
     return;
@@ -142,9 +168,20 @@ async function runBriefingInject(sectionName: string, formatStr: string): Promis
   if (formatStr.startsWith('adapter:')) {
     const adapterName = formatStr.slice('adapter:'.length) as AdapterFormat;
     if (!(ADAPTER_FORMATS as readonly string[]).includes(adapterName)) {
-      process.stderr.write(
-        `[briefing inject] Unknown adapter format "${adapterName}". ` +
-          `Supported: ${ADAPTER_FORMATS.join(', ')}\n`,
+      // T9772: unknown adapter is a validation failure — emit envelope with warning.
+      const supported = ADAPTER_FORMATS.join(', ');
+      pushWarning({
+        code: 'W_TEMPLATE_INJECT_FAILED',
+        message: `Unknown adapter format "${adapterName}".`,
+      });
+      cliError(
+        `Unknown adapter format "${adapterName}". Supported: ${supported}`,
+        1,
+        {
+          name: 'E_VALIDATION',
+          fix: `Pass one of: ${supported}`,
+        },
+        { operation: 'briefing.inject' },
       );
       process.exitCode = 1;
       return;

--- a/packages/cleo/src/cli/commands/llm-stream.ts
+++ b/packages/cleo/src/cli/commands/llm-stream.ts
@@ -23,6 +23,7 @@ import type { NormalizedDelta, SendOptions } from '@cleocode/contracts/llm/inter
 import type { TransportMessage } from '@cleocode/contracts/llm/normalized-response.js';
 import type { ModelTransport } from '@cleocode/contracts/operations/llm.js';
 import { defineCommand } from 'citty';
+import { cliError } from '../renderers/index.js';
 
 // ---------------------------------------------------------------------------
 // Lazy imports — keeps startup fast and avoids circular-dep issues at module
@@ -279,11 +280,23 @@ export const streamCommand = defineCommand({
     const prompt = String(a['prompt'] ?? '').trim();
 
     if (!provider) {
-      process.stderr.write('[error] cleo llm stream: <provider> is required.\n');
+      // T9772: validation error → LAFS envelope (no raw stderr).
+      cliError(
+        'cleo llm stream: <provider> is required.',
+        2,
+        { name: 'E_VALIDATION', fix: 'Pass a provider as the first positional argument.' },
+        { operation: 'llm.stream' },
+      );
       process.exit(2);
     }
     if (!prompt) {
-      process.stderr.write('[error] cleo llm stream: <prompt> is required.\n');
+      // T9772: validation error → LAFS envelope (no raw stderr).
+      cliError(
+        'cleo llm stream: <prompt> is required.',
+        2,
+        { name: 'E_VALIDATION', fix: 'Pass a prompt as the second positional argument.' },
+        { operation: 'llm.stream' },
+      );
       process.exit(2);
     }
 
@@ -308,7 +321,13 @@ export const streamCommand = defineCommand({
       await runLlmStream({ provider, prompt, model, maxTokens, temperature, showThink, system });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[error] cleo llm stream: ${msg}\n`);
+      // T9772: stream failure → LAFS envelope (no raw stderr).
+      cliError(
+        `cleo llm stream: ${msg}`,
+        1,
+        { name: 'E_LLM_STREAM_FAILED' },
+        { operation: 'llm.stream' },
+      );
       process.exit(1);
     }
   },

--- a/packages/cleo/src/cli/commands/llm.ts
+++ b/packages/cleo/src/cli/commands/llm.ts
@@ -37,9 +37,10 @@
  * @epic T-LLM-CRED-CENTRALIZATION
  */
 
+import { pushWarning } from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
-import { cliOutput } from '../renderers/index.js';
+import { cliError, cliOutput } from '../renderers/index.js';
 import { costCommand } from './llm-cost.js';
 import { runLlmLogin } from './llm-login.js';
 import { runLlmRefreshCatalog } from './llm-refresh-catalog.js';
@@ -240,8 +241,12 @@ const addCommand = defineCommand({
       apiKey = await readApiKeyFromStdin();
       source = 'stdin';
       if (!apiKey) {
-        process.stderr.write(
-          '[error] --api-key-stdin set but stdin is empty or a TTY. Pipe the secret in, e.g. `echo "$KEY" | cleo llm add ...`.\n',
+        // T9772: validation error → LAFS envelope (no raw stderr).
+        cliError(
+          '--api-key-stdin set but stdin is empty or a TTY. Pipe the secret in, e.g. `echo "$KEY" | cleo llm add ...`.',
+          2,
+          { name: 'E_VALIDATION', fix: 'Pipe the secret to stdin or use --api-key-env=NAME.' },
+          { operation: 'llm.add' },
         );
         process.exit(2);
       }
@@ -249,19 +254,41 @@ const addCommand = defineCommand({
       const envName = a['api-key-env'] as string;
       const envValue = process.env[envName];
       if (!envValue) {
-        process.stderr.write(`[error] --api-key-env=${envName} is not set in the environment.\n`);
+        // T9772: validation error → LAFS envelope (no raw stderr).
+        cliError(
+          `--api-key-env=${envName} is not set in the environment.`,
+          2,
+          {
+            name: 'E_VALIDATION',
+            fix: `Export ${envName} before running, or use --api-key-stdin.`,
+          },
+          { operation: 'llm.add' },
+        );
         process.exit(2);
       }
       apiKey = envValue;
       source = 'env';
     } else if (typeof a['api-key'] === 'string' && a['api-key']) {
-      // Deprecated path — accept but warn on stderr (CI-compat).
-      process.stderr.write(`${API_KEY_FLAG_DEPRECATION}\n`);
+      // Deprecated path — accept but surface deprecation warning through the
+      // LAFS envelope (`meta.warnings[]`) instead of polluting stderr. T9772.
+      pushWarning({
+        code: 'W_DEPRECATED_FLAG',
+        message: API_KEY_FLAG_DEPRECATION,
+        deprecated: '--api-key=<value>',
+        replacement: '--api-key-stdin or --api-key-env=NAME',
+      });
       apiKey = a['api-key'] as string;
       source = 'flag';
     } else {
-      process.stderr.write(
-        '[error] cleo llm add requires one of --api-key-stdin (recommended), --api-key-env=NAME, or --api-key=<value> (deprecated).\n',
+      // T9772: validation error → LAFS envelope (no raw stderr).
+      cliError(
+        'cleo llm add requires one of --api-key-stdin (recommended), --api-key-env=NAME, or --api-key=<value> (deprecated).',
+        2,
+        {
+          name: 'E_VALIDATION',
+          fix: 'Provide the credential via --api-key-stdin, --api-key-env=NAME, or --api-key=<value>.',
+        },
+        { operation: 'llm.add' },
       );
       process.exit(2);
     }
@@ -633,7 +660,13 @@ const loginCommand = defineCommand({
           '\n',
       );
     } else if (result.error) {
-      process.stderr.write(`[error] ${result.error.message}\n`);
+      // T9772: surface login failure through LAFS envelope (no raw stderr).
+      cliError(
+        result.error.message,
+        result.error.code || 1,
+        { name: result.error.codeName },
+        { operation: 'llm.login' },
+      );
       process.exit(1);
     }
   },
@@ -681,7 +714,13 @@ const refreshCatalogCommand = defineCommand({
         `Catalog refreshed: ${d.providers} providers, ${d.models} models written to ${d.filePath}\n`,
       );
     } else if (!result.success) {
-      process.stderr.write(`[error] ${result.error?.message ?? 'refresh failed'}\n`);
+      // T9772: surface refresh failure through LAFS envelope (no raw stderr).
+      cliError(
+        result.error?.message ?? 'refresh failed',
+        result.error?.code ?? 1,
+        { name: 'E_REFRESH_FAILED' },
+        { operation: 'llm.refreshCatalog' },
+      );
       process.exit(1);
     }
   },

--- a/packages/cleo/src/cli/commands/release.ts
+++ b/packages/cleo/src/cli/commands/release.ts
@@ -25,7 +25,7 @@
  * @epic T9499 — Phase 6 cleanup epic
  */
 
-import { release } from '@cleocode/core';
+import { pushWarning, release } from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
 import { cliError, cliOutput } from '../renderers/index.js';
@@ -88,9 +88,15 @@ const shipCommand = defineCommand({
     },
   },
   async run({ args }) {
-    // R-420: deprecation warning MUST go to stderr so JSON envelope on stdout
-    // stays parseable for piped tooling.
-    process.stderr.write(`${SHIP_DEPRECATION_NOTICE}\n`);
+    // R-420 (T9772): deprecation now surfaces through `meta.warnings[]` in the
+    // LAFS envelope instead of polluting stderr — keeps stdout parseable AND
+    // makes the deprecation discoverable to JSON-only consumers.
+    pushWarning({
+      code: 'W_DEPRECATED_COMMAND',
+      message: SHIP_DEPRECATION_NOTICE,
+      deprecated: 'cleo release ship',
+      replacement: 'cleo release plan <version> --epic <id> && cleo release open <version>',
+    });
 
     // T9540: --workflow=false escape hatch and the legacy releaseShip
     // monolith were removed. Ship ALWAYS forwards to the new 4-verb

--- a/packages/cleo/src/cli/renderers/index.ts
+++ b/packages/cleo/src/cli/renderers/index.ts
@@ -26,13 +26,9 @@ function generateRequestId(): string {
  * @epic T4663
  */
 
-import { type FormatOptions, formatSuccess } from '@cleocode/core';
-import type { CliEnvelope, CliMeta } from '@cleocode/lafs';
-import {
-  applyFieldFilter,
-  extractFieldFromResult,
-  getCurrentWarningCollector,
-} from '@cleocode/lafs';
+import { drainWarnings, type FormatOptions, formatSuccess } from '@cleocode/core';
+import type { CliEnvelope, CliMeta, Warning } from '@cleocode/lafs';
+import { applyFieldFilter, extractFieldFromResult } from '@cleocode/lafs';
 import type { DispatchResponseMeta } from '../../dispatch/types.js';
 import { getFieldContext } from '../field-context.js';
 import { getFormatContext } from '../format-context.js';
@@ -605,15 +601,17 @@ export function cliError(
     ...meta,
   };
 
-  // T9769 — drain any non-fatal warnings pushed via `pushWarning` (lafs ALS
-  // carrier) into `meta.warnings[]`. `formatError` in core already does this
-  // for the formatError path, but `cliError` builds the envelope inline so
-  // we mirror the drain here. Outside an active `withWarningCollector`
-  // scope `drained` is `undefined` and the field is omitted entirely.
-  const drained = getCurrentWarningCollector()?.drain();
+  // T9769 + T9772 — drain non-fatal warnings pushed via `pushWarning` (both
+  // the legacy core `pendingWarnings` queue used by deprecation paths AND the
+  // ALS-bound `WarningCollector` carrier from T9769) into `meta.warnings[]`.
+  // `formatError` in core already does this on its path, but `cliError` builds
+  // the envelope inline so we mirror the unified drain here. Outside an active
+  // `withWarningCollector` scope and with an empty legacy queue, the result is
+  // `undefined` and the field is omitted entirely.
+  const drained: Warning[] | undefined = drainWarnings();
   if (drained && drained.length > 0) {
-    // Preserve any explicitly-set caller warnings — drained collector entries
-    // append after them, matching the JSON-emitter intent: explicit > implicit.
+    // Preserve any explicitly-set caller warnings — drained entries append
+    // after them, matching the JSON-emitter intent: explicit > implicit.
     const existing = (errorMeta as { warnings?: unknown }).warnings;
     errorMeta.warnings = Array.isArray(existing) ? [...existing, ...drained] : drained;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -318,7 +318,7 @@ export type { LoggerConfig } from './logger.js';
 export { closeLogger, getLogDir, getLogger, initLogger } from './logger.js';
 export type { FormatOptions } from './output.js';
 // Output formatting (LAFS envelope)
-export { formatError, formatOutput, formatSuccess, pushWarning } from './output.js';
+export { drainWarnings, formatError, formatOutput, formatSuccess, pushWarning } from './output.js';
 // Pagination
 export { createPage, paginate } from './pagination.js';
 // Paths

--- a/packages/core/src/output.ts
+++ b/packages/core/src/output.ts
@@ -68,11 +68,17 @@ export function pushWarning(warning: Warning): void {
  * this function is the single source of truth for what lands in
  * `meta.warnings[]`.
  *
+ * Exported (T9772) so renderers in `@cleocode/cleo` that build their own
+ * envelopes via `cliOutput` / `cliError` (instead of going through
+ * `formatSuccess` / `formatError`) can attach queued warnings to `meta.warnings[]`
+ * without duplicating the pending-queue state.
+ *
  * @task T4669
  * @task T9769
+ * @task T9772
  * @epic T9763
  */
-function drainWarnings(): Warning[] | undefined {
+export function drainWarnings(): Warning[] | undefined {
   const legacy = pendingWarnings.length > 0 ? pendingWarnings.splice(0) : [];
   const collector = getCurrentWarningCollector();
   const als = collector?.drain() ?? [];


### PR DESCRIPTION
## Summary

Migrates 13 pre-envelope `process.stderr.write` sites in `cleo llm`, `cleo llm stream`, `cleo briefing inject`, and `cleo release ship` to canonical LAFS envelopes. JSON consumers parsing stdout will no longer see interleaved `[error] ...`, `[briefing inject] ...`, or `SHIP_DEPRECATION_NOTICE` lines.

This is **T-JH-5 / T9772** from the JSON Stream Hygiene Audit (Parts B+D).

### Sites migrated

- `packages/cleo/src/cli/commands/llm.ts` (6 sites)
  - empty-stdin, missing-env, missing-flag, login error, refresh-catalog error → `cliError(...)` envelope
  - deprecated `--api-key=<value>` flag → `pushWarning(W_DEPRECATED_FLAG)`
- `packages/cleo/src/cli/commands/llm-stream.ts` (3 sites)
  - missing provider, missing prompt, stream failure → `cliError(...)` envelope
- `packages/cleo/src/cli/commands/briefing.ts` (3 sites)
  - template-not-found, unknown-section, unknown-adapter → `cliError(...)` plus `pushWarning(W_TEMPLATE_INJECT_FAILED)`
- `packages/cleo/src/cli/commands/release.ts` (1 site)
  - `cleo release ship` deprecation notice → `pushWarning(W_DEPRECATED_COMMAND)` carrying `deprecated`/`replacement` fields

### Foundation (small, focused)

- Exports `drainWarnings()` from `@cleocode/core/output` so renderers bypassing `formatSuccess`/`formatError` can attach queued warnings.
- `cliError()` (in `packages/cleo/src/cli/renderers/index.ts`) now drains `pendingWarnings` into `envelope.meta.warnings[]` so warnings queued via `pushWarning()` surface even on the error exit path.

## Test plan

- [x] Per-site smoke verified against built CLI (`packages/cleo/dist/cli/index.js`):
  - `cleo llm add` (no args) → `success:false`, `E_VALIDATION`, **no stderr**
  - `cleo llm stream` (no args) → `success:false`, `E_VALIDATION`, **no stderr**
  - `cleo briefing inject --section nonexistent` → `success:false` with `meta.warnings:[{code:'W_TEMPLATE_INJECT_FAILED',…}]`
  - `cleo release ship 2026.6.0 --epic T9498 --dry-run` → envelope carries `meta.warnings:[{code:'W_DEPRECATED_COMMAND',deprecated:'cleo release ship',replacement:'cleo release plan … && cleo release open …'}]`
- [x] `pnpm run typecheck` (tsc -b) clean.
- [x] `pnpm biome check` clean on all modified files.
- [x] `pnpm run build` (esbuild) clean.
- [x] Updated tests:
  - `release-ship-deprecation.test.ts`: asserts `pushWarning` queues `W_DEPRECATED_COMMAND` with full envelope shape; stderr stays empty.
  - `llm-command.test.ts`: asserts `--api-key=<value>` queues `W_DEPRECATED_FLAG` via `pushWarning` and writes zero stderr.

## Constraints honoured

- Worktree under `/mnt/projects/T9763-W1-pre-env`.
- Exit codes preserved (2 for validation errors, 1 for runtime errors).
- LAFS envelopes everywhere — no raw stderr for validation / deprecation.
- No `any` / `unknown` shortcuts.
- TSDoc preserved + augmented where behaviour changed.

@task T9772
@audit .cleo/research/JSON-STREAM-HYGIENE-AUDIT.md Parts B+D