### PR TITLE
refactor(T9774): long-tail stderr/console.warn sweep → meta.warnings + CLEO_DEBUG gating

### DIFF
--- a/packages/cleo/src/cli/renderers/lafs-validator.ts
+++ b/packages/cleo/src/cli/renderers/lafs-validator.ts
@@ -212,6 +212,11 @@ export function emitLafsViolation(err: LafsViolationError): void {
       timestamp: new Date().toISOString(),
     },
   };
-  process.stderr.write(`${JSON.stringify(envelope)}\n`);
+  // T9774: gate stderr emission under CLEO_DEBUG. The LAFS-violation exit code is
+  // still set so callers can detect the failure programmatically; we just don't
+  // pollute stderr with a JSON dump unless an operator opted in.
+  if (process.env['CLEO_DEBUG']) {
+    process.stderr.write(`${JSON.stringify(envelope)}\n`);
+  }
   process.exitCode = ExitCode.LAFS_VIOLATION;
 }

--- a/packages/core/src/agents/resolveAgentTemplates.ts
+++ b/packages/core/src/agents/resolveAgentTemplates.ts
@@ -33,6 +33,7 @@ import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { pushWarning } from '../output.js';
 
 // ---------------------------------------------------------------------------
 // Meta-agents directory helper
@@ -155,10 +156,15 @@ export function resolveAgentTemplates(): string | null {
 export function resolveStarterBundle(): string | null {
   if (!_starterBundleWarnFired) {
     _starterBundleWarnFired = true;
-    console.warn(
-      '[cleo][deprecated] resolveStarterBundle() is deprecated and will be removed in v2027.x. ' +
+    pushWarning({
+      code: 'W_DEPRECATED_AGENT_PATH',
+      message:
+        'resolveStarterBundle() is deprecated and will be removed in v2027.x. ' +
         'Use resolveAgentTemplates() instead (ADR-068 / T1929).',
-    );
+      deprecated: 'resolveStarterBundle',
+      replacement: 'resolveAgentTemplates',
+      removeBy: 'v2027.x',
+    });
   }
   return resolveAgentTemplates();
 }

--- a/packages/core/src/agents/variable-substitution.ts
+++ b/packages/core/src/agents/variable-substitution.ts
@@ -38,6 +38,7 @@ import type {
   SubstitutionSource,
   VariableResolver,
 } from '@cleocode/contracts';
+import { pushWarning } from '../output.js';
 import { getCleoDirAbsolute } from '../paths.js';
 
 /**
@@ -195,8 +196,10 @@ export class DefaultVariableResolver implements VariableResolver {
         perVariable.set(varName, null);
         if (!missing.includes(varName)) missing.push(varName);
         if (warnMissing) {
-          // eslint-disable-next-line no-console
-          console.warn(`[variable-substitution] "${varName}" not in allowedVars whitelist`);
+          pushWarning({
+            code: 'W_VAR_SUB_UNRESOLVED',
+            message: `"${varName}" not in allowedVars whitelist`,
+          });
         }
         continue;
       }
@@ -223,8 +226,10 @@ export class DefaultVariableResolver implements VariableResolver {
       perVariable.set(varName, null);
       if (!missing.includes(varName)) missing.push(varName);
       if (warnMissing) {
-        // eslint-disable-next-line no-console
-        console.warn(`[variable-substitution] "${varName}" unresolved`);
+        pushWarning({
+          code: 'W_VAR_SUB_UNRESOLVED',
+          message: `"${varName}" unresolved`,
+        });
       }
     }
 

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -42,6 +42,7 @@ import { ensureGitHooks } from './hooks.js';
 import { ensureInjection } from './injection.js';
 import { writeMemoryBridge } from './memory/memory-bridge.js';
 import { migrateAgentOutputs } from './migration/agent-outputs.js';
+import { pushWarning } from './output.js';
 import { getAgentsHome, getCleoDirAbsolute, getProjectRoot } from './paths.js';
 // Shared utility imports
 import {
@@ -1141,11 +1142,14 @@ export async function initProject(opts: InitOptions = {}): Promise<InitResult> {
   // All 5 worker templates are auto-registered above on every plain `cleo init`.
   // The flag is preserved for one minor release to avoid breaking existing scripts.
   if (opts.installSeedAgents) {
-    console.warn(
-      '[cleo][deprecated] --install-seed-agents is no longer required. ' +
+    pushWarning({
+      code: 'W_DEPRECATED_AGENT_PATH',
+      message:
+        '--install-seed-agents is no longer required. ' +
         'All worker templates are now auto-registered on plain `cleo init` (T1934 / ADR-068). ' +
         'This flag will be removed in a future release.',
-    );
+      deprecated: '--install-seed-agents',
+    });
   }
 
   // ────────────────────────────────────────────────────────────────────

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -410,10 +410,15 @@ export function validateProjectRoot(candidate: string): boolean {
     }
     if (!_legacyFallbackWarned) {
       _legacyFallbackWarned = true;
-      process.stderr.write(
-        `[cleo] WARNING: ${candidate}/.cleo/ lacks project-info.json. ` +
-          `Run \`cleo init\` to upgrade project metadata (T1864 legacy-fallback).\n`,
-      );
+      // T9774: debug-only — surfaced via CLEO_DEBUG to keep stderr clean by default.
+      // Cannot use pushWarning here because paths.ts is in the import chain of
+      // output.ts (output → sessions/context-alert → paths) — circular dep.
+      if (process.env['CLEO_DEBUG']) {
+        process.stderr.write(
+          `[cleo][debug] W_PATH_RESOLUTION: ${candidate}/.cleo/ lacks project-info.json. ` +
+            `Run \`cleo init\` to upgrade project metadata (T1864 legacy-fallback).\n`,
+        );
+      }
     }
     return true;
   }

--- a/packages/core/src/scaffold.ts
+++ b/packages/core/src/scaffold.ts
@@ -20,6 +20,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { generateProjectHash } from './nexus/hash.js';
+import { pushWarning } from './output.js';
 import {
   getCleoCantWorkflowsDir,
   getCleoDirAbsolute,
@@ -793,8 +794,10 @@ export async function ensureProjectContext(
       addFormats(ajv);
       const valid = ajv.validate(schema, context);
       if (!valid) {
-        // eslint-disable-next-line no-console
-        console.warn('[CLEO] project-context.json schema validation warnings:', ajv.errors);
+        pushWarning({
+          code: 'W_SCAFFOLD_PARTIAL',
+          message: `project-context.json schema validation warnings: ${JSON.stringify(ajv.errors)}`,
+        });
       }
     }
   } catch {
@@ -1795,13 +1798,15 @@ export async function ensureGlobalHome(): Promise<ScaffoldResult> {
       if (existsSync(stalePath)) {
         try {
           await rm(stalePath, { recursive: true, force: true });
-          // eslint-disable-next-line no-console
-          console.warn(`[CLEO] Removed stale global entry: ${stalePath}`);
+          pushWarning({
+            code: 'W_SCAFFOLD_PARTIAL',
+            message: `Removed stale global entry: ${stalePath}`,
+          });
         } catch (err) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `[CLEO] Could not remove stale global entry ${stalePath}: ${err instanceof Error ? err.message : String(err)}`,
-          );
+          pushWarning({
+            code: 'W_SCAFFOLD_PARTIAL',
+            message: `Could not remove stale global entry ${stalePath}: ${err instanceof Error ? err.message : String(err)}`,
+          });
         }
       }
     }
@@ -1957,10 +1962,10 @@ async function copyTemplateTree(
   try {
     entries = await readdir(srcDir, { withFileTypes: true });
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[CLEO] Could not read template dir ${srcDir}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    pushWarning({
+      code: 'W_SCAFFOLD_PARTIAL',
+      message: `Could not read template dir ${srcDir}: ${err instanceof Error ? err.message : String(err)}`,
+    });
     return { copied: 0, kept: 0 };
   }
 
@@ -1989,10 +1994,10 @@ async function copyTemplateTree(
       await copyFile(srcPath, dstPath);
       copied += 1;
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `[CLEO] Could not copy template file ${srcPath} -> ${dstPath}: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      pushWarning({
+        code: 'W_SCAFFOLD_PARTIAL',
+        message: `Could not copy template file ${srcPath} -> ${dstPath}: ${err instanceof Error ? err.message : String(err)}`,
+      });
     }
   }
 

--- a/packages/core/src/security/shared-evidence-tracker.ts
+++ b/packages/core/src/security/shared-evidence-tracker.ts
@@ -24,6 +24,7 @@ import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { BRANCH_LOCK_ERROR_CODES } from '@cleocode/contracts';
+import { pushWarning } from '../output.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -336,10 +337,12 @@ export function enforceSharedEvidence(
   }
 
   // Non-strict: warn and allow.
-  process.stderr.write(
-    `[CLEO WARN] Shared evidence atom(s) [${atomList}] applied to >3 tasks in this session. ` +
-      `Pass --shared-evidence to suppress this warning. In CI (CLEO_STRICT_EVIDENCE=1) this will become a hard reject.\n`,
-  );
+  pushWarning({
+    code: 'W_EVIDENCE_AUDIT_MISS',
+    message:
+      `Shared evidence atom(s) [${atomList}] applied to >3 tasks in this session. ` +
+      `Pass --shared-evidence to suppress this warning. In CI (CLEO_STRICT_EVIDENCE=1) this will become a hard reject.`,
+  });
 
   return { allowed: true, warned: true };
 }

--- a/packages/core/src/sentient/allowlist.ts
+++ b/packages/core/src/sentient/allowlist.ts
@@ -24,6 +24,7 @@
 import crypto from 'node:crypto';
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { pushWarning } from '../output.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -105,9 +106,10 @@ export async function getOwnerPubkeys(
     config = JSON.parse(raw) as OwnerAllowlistConfig;
   } catch {
     // Malformed config → empty allowlist (fail open, log warning).
-    process.stderr.write(
-      `[allowlist] Warning: failed to parse ${configPath} — treating ownerPubkeys as empty\n`,
-    );
+    pushWarning({
+      code: 'W_ALLOWLIST_SIGNER',
+      message: `failed to parse ${configPath} — treating ownerPubkeys as empty`,
+    });
     cache = { pubkeys: [], expiresAt: now + CACHE_TTL_MS };
     return [];
   }
@@ -159,10 +161,12 @@ export async function isOwnerSigner(projectRoot: string, pubkey: Uint8Array): Pr
       return false;
     }
     // Bootstrapping mode: emit a warning but allow.
-    process.stderr.write(
-      '[allowlist] Warning: ownerPubkeys is empty — accepting all signers. ' +
-        'Run `cleo sentient allowlist add <base64>` to populate the allowlist.\n',
-    );
+    pushWarning({
+      code: 'W_ALLOWLIST_SIGNER',
+      message:
+        'ownerPubkeys is empty — accepting all signers. ' +
+        'Run `cleo sentient allowlist add <base64>` to populate the allowlist.',
+    });
     return true;
   }
 

--- a/packages/core/src/sentient/tsa-anchor.ts
+++ b/packages/core/src/sentient/tsa-anchor.ts
@@ -54,6 +54,7 @@ import { readFile } from 'node:fs/promises';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import { join } from 'node:path';
+import { pushWarning } from '../output.js';
 import type { TsaAnchorEvent } from './events.js';
 import { appendSentientEvent, querySentientEvents, SENTIENT_EVENTS_FILE } from './events.js';
 import { loadSigningIdentity } from './kms.js';
@@ -182,7 +183,10 @@ export async function anchorChainDaily(
     tsTokenBase64 = responseBytes.toString('base64');
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[tsa-anchor] TSA request to ${tsaUrl} failed: ${message}. Skipping anchor.`);
+    pushWarning({
+      code: 'W_TSA_ANCHOR_FAILED',
+      message: `TSA request to ${tsaUrl} failed: ${message}. Skipping anchor.`,
+    });
     return null;
   }
 


### PR DESCRIPTION
## Summary

T9774 (T-JH-7) — Migrates the remaining long-tail production `console.warn` / `process.stderr.write` sites onto the canonical `pushWarning` → `meta.warnings` envelope channel (ADR-039), and gates two debug-only diagnostics under `CLEO_DEBUG=1` so they stay silent by default.

- **13 sites** migrated to `pushWarning({code, message, ...})` — schema warnings, stale-entry cleanup, deprecated flags, evidence audit, allowlist signer, agent-path deprecation, variable-substitution misses, TSA-anchor failures.
- **2 sites** gated under `CLEO_DEBUG=1` — `paths.ts` legacy-fallback warn (can't use `pushWarning` — circular dep on `output.ts`), and `lafs-validator.ts` violation JSON dump (`exitCode` is still set; only the stderr emission is gated).

Reserved warning codes used (per task description):
`W_SCAFFOLD_PARTIAL` · `W_EVIDENCE_AUDIT_MISS` · `W_ALLOWLIST_SIGNER` · `W_DEPRECATED_AGENT_PATH` · `W_VAR_SUB_UNRESOLVED` · `W_TSA_ANCHOR_FAILED`

## Files touched (9)

- `packages/cleo/src/cli/renderers/lafs-validator.ts` — gated under `CLEO_DEBUG`
- `packages/core/src/agents/resolveAgentTemplates.ts` — `W_DEPRECATED_AGENT_PATH`
- `packages/core/src/agents/variable-substitution.ts` — `W_VAR_SUB_UNRESOLVED` (×2)
- `packages/core/src/init.ts` — `W_DEPRECATED_AGENT_PATH`
- `packages/core/src/paths.ts` — gated under `CLEO_DEBUG`
- `packages/core/src/scaffold.ts` — `W_SCAFFOLD_PARTIAL` (×5)
- `packages/core/src/security/shared-evidence-tracker.ts` — `W_EVIDENCE_AUDIT_MISS`
- `packages/core/src/sentient/allowlist.ts` — `W_ALLOWLIST_SIGNER` (×2)
- `packages/core/src/sentient/tsa-anchor.ts` — `W_TSA_ANCHOR_FAILED`

## Test plan

- [x] `pnpm run build` — green
- [x] `pnpm run typecheck` — clean
- [x] `pnpm biome ci` over the 9 touched files — clean
- [x] Smoke: `cleo init` in a fresh tmpdir → zero CLEO stderr noise (only platform-emitted `node:sqlite ExperimentalWarning`)
- [x] Smoke: `cleo memory observe ... --title ...` → zero CLEO stderr noise; canonical LAFS envelope on stdout
- [x] Targeted vitest re-run of 3 timeout-flake files (daemon / hygiene-scan / performance-safety) → 83/83 pass in isolation; the 12 timeouts in the full-suite run are unrelated parallel-load flakes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)