### PR TITLE
release: v2026.5.91 — JSON stream hygiene close (T9763)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## [2026.5.91] (2026-05-20) — SG-JSON-STREAM-HYGIENE close (T9763)
+
+Closes Saga **SG-JSON-STREAM-HYGIENE** (Epic **T9763**) — the
+five-wave migration of legacy `console.warn` / direct `stderr.write`
+call sites onto the LAFS envelope's structured `meta.warnings[]`
+channel. Driven by a user-reported bug where `cleo skills install`
+emitted a raw `[caamp] WARNING:` line that polluted stdout-parsed
+JSON streams in agent harnesses. Net: **43 sites migrated**, one new
+CI lint gate locking the clean state in place.
+
+### Fixed (USER-REPORTED)
+
+- **PR #369 (T9770)** — `cleo skills install` no longer emits
+  `[caamp] WARNING:` to stderr. Two long-standing raw writes in
+  `packages/caamp/src/install.ts` (CORE_UNAVAILABLE and
+  AUDIT_LOG_FAILED) now push into the LAFS warning collector and
+  surface inside the response envelope's `meta.warnings[]` array.
+  This was breaking JSON parsers in agent harnesses that wrap CLEO
+  CLI calls.
+
+### Added (T9763 Wave 0 — WarningCollector foundation)
+
+- **PR #366 (T9768+T9769)** — introduces a process-wide
+  `WarningCollector` in `@cleocode/lafs` backed by an
+  `AsyncLocalStorage` carrier so warnings raised anywhere inside a
+  CLI invocation are gathered into the active request scope and
+  drained into the response envelope's `meta.warnings[]` by the LAFS
+  CLI renderer. Includes a typed warning code registry so every
+  warning carries a stable `W_*` identifier.
+
+### Changed (T9763 Wave 1 — 43 sites migrated)
+
+- **PR #370 (T9771)** — 9 bridge sites across `memory`, `nexus`,
+  `tasks`, and `sentient-tick` migrated from `console.warn` to
+  `pushWarning(W_BRIDGE_*)`. Removes raw stderr noise from the
+  memory/nexus/tasks read-paths and the sentient daemon's tick
+  loop.
+- **PR #368 (T9773)** — 14 `sentient propose-tick` and ingester
+  sites migrated to `pushWarning(W_SENTIENT_*)`. Sentient proposals
+  no longer emit progress chatter to stderr.
+- **PR #372 (T9772)** — pre-envelope validation errors in `llm`,
+  `llm-stream`, and `briefing` now return proper
+  `envelope { success:false, error }` instead of writing raw lines
+  to stderr before the CLI dispatcher's catch frame. `cleo release
+  ship`'s deprecation notice now surfaces in `meta.warnings[]`
+  (`W_DEPRECATED_COMMAND`) instead of stderr. `cliError` drains the
+  active warning collector so it is preserved even when a command
+  exits via the error path.
+- **PR #373 (T9774)** — 13 long-tail sites across `scaffold`,
+  `init`, `security`, `allowlist`, `agents`, `sentient`, and `tsa`
+  migrated to `pushWarning` with codes such as
+  `W_TEMPLATE_INJECT_FAILED`, `W_SCAFFOLD_PARTIAL`, and
+  `W_ALLOWLIST_SIGNER`. Two especially noisy debug-only sites moved
+  behind a `CLEO_DEBUG` gate.
+
+### Internal (T9763 Wave 2 — CI lint gate)
+
+- **PR #374 (T9775)** — adds
+  `scripts/lint-json-stream-hygiene.mjs` plus a baseline file
+  capturing the residual allow-listed sites. New PRs that add raw
+  `process.stderr.write` or `console.warn` calls to JSON-stream
+  command paths fail CI. The baseline currently contains **0 new
+  violations** on top of pre-existing intentional escape hatches.
+
 ## [2026.5.90] (2026-05-20) — SG-SKILLS-CLEANUP close (T9740)
 
 Closes Saga **SG-SKILLS-CLEANUP** (Epic **T9740**) — the four-sphere

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "conduit-core",
  "nom",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "cant-core",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "serde",
  "serde_json",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "cant-core",
  "serde",
@@ -394,7 +394,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-llm-native"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "lafs-core",
  "serde",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-core"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "chrono",
  "conduit-core",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-payments"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-protocol"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "cant-core",
  "chrono",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-sdk"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-storage"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-transport"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.90"
+version = "2026.5.91"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Release v2026.5.91 — SG-JSON-STREAM-HYGIENE close (T9763)

Closes Saga **SG-JSON-STREAM-HYGIENE** (Epic **T9763**). Five waves migrated 43 raw `console.warn` / `stderr.write` sites onto the LAFS envelope's structured `meta.warnings[]` channel, plus a CI lint gate to keep the surface clean.

### User-reported bug fixed

- **PR #369 (T9770)** — `cleo skills install` no longer emits `[caamp] WARNING:` to stderr. Two long-standing raw writes in `packages/caamp/src/install.ts` (CORE_UNAVAILABLE, AUDIT_LOG_FAILED) now push into the LAFS warning collector and surface in `meta.warnings[]`. This was breaking JSON parsers in agent harnesses that wrap CLEO CLI calls.

### Waves merged since v2026.5.90

- **PR #366 (Wave 0 — T9768+T9769)** — `WarningCollector` + AsyncLocalStorage carrier in `@cleocode/lafs`; renderer drains into `meta.warnings[]`.
- **PR #369 (Wave 1a — T9770)** — caamp install.ts → `pushWarning(W_CORE_UNAVAILABLE / W_AUDIT_LOG_FAILED)`.
- **PR #370 (Wave 1b — T9771)** — 9 bridge sites (memory / nexus / tasks / sentient-tick) → `pushWarning(W_BRIDGE_*)`.
- **PR #368 (Wave 1c — T9773)** — 14 `sentient propose-tick` + ingester sites → `pushWarning(W_SENTIENT_*)`.
- **PR #372 (Wave 1d — T9772)** — pre-envelope llm / llm-stream / briefing validation now returns `{success:false}` envelope; `release ship` deprecation now in `meta.warnings(W_DEPRECATED_COMMAND)`; `cliError` drains warnings.
- **PR #373 (Wave 1e — T9774)** — 13 long-tail stderr / console.warn sites (scaffold / init / security / allowlist / agents / sentient / tsa) → `pushWarning` (2 sites gated behind `CLEO_DEBUG`).
- **PR #374 (Wave 2 — T9775)** — CI lint `scripts/lint-json-stream-hygiene.mjs` + allowlist baseline (0 new violations).

### Release metadata

- **Version:** 2026.5.90 → 2026.5.91 (CalVer YYYY.MM.patch)
- **Files bumped:** 21 npm `package.json` + `Cargo.toml` workspace.package.version + `Cargo.lock` (17 workspace crates)
- **Tag:** `v2026.5.91` (available, verified before branch cut)
- **CHANGELOG:** new section at top under `## [2026.5.91]`

### Post-merge

Tag `v2026.5.91` to be pushed by the release-publish workflow once this PR merges. npm publish remains owner HITL.