### PR TITLE
release: ship v2026.5.91 — T9758 Wave 1 + T9752 carryforward closure

### DIFF
--- a/.changeset/t9764-pr-evidence-atom.md
+++ b/.changeset/t9764-pr-evidence-atom.md
@@ -1,0 +1,18 @@
+---
+id: t9764-pr-evidence-atom
+tasks: [T9764]
+kind: feat
+prs: [365]
+summary: "New `pr:<num>` evidence atom — retroactively verify shipped tasks against their PR's CI rollup."
+---
+
+Closes the release-verb dogfood gap. Previously, after a PR shipped via admin-merge, there was no zero-friction way to record `testsPassed` and `qaPassed` evidence — `tool:test` ran the full repo suite (overkill for one-line tasks) and `note:` was rejected for hard gates.
+
+The new atom is resolved via `gh pr view <num> --json statusCheckRollup`. If the PR is merged and every required check is SUCCESS, the atom satisfies both `testsPassed` and `qaPassed` gates. Cached under `.cleo/cache/evidence/pr-<num>.json` keyed on `(prNumber, mergedAt)` so re-verifies are zero-cost.
+
+Closes the gap that previously forced the orchestrator into manual `sed`-based release ships (per Saga T9758 / Epic T9762 dogfood directive). The atom shape ships in `@cleocode/contracts` to keep types centralized; the resolver lives in `@cleocode/core/release/pr-evidence.ts`.
+
+```bash
+cleo verify T#### --gate testsPassed --evidence "pr:357"
+cleo verify T#### --gate qaPassed   --evidence "pr:357"
+```

--- a/.changeset/t9765-release-verb-help.md
+++ b/.changeset/t9765-release-verb-help.md
@@ -1,0 +1,11 @@
+---
+id: t9765-release-verb-help
+tasks: [T9765]
+kind: fix
+prs: [371]
+summary: "`cleo release <verb> --help` now shows verb-specific help instead of the top-level command listing."
+---
+
+Pre-fix bug: `runMainWithLafsEnvelope` detected `--help` anywhere in `rawArgs` and called `showUsage(rootCmd)` directly. That dumped the grouped top-level help for every nested subcommand — `cleo release plan --help`, `cleo session start --help`, `cleo nexus impact --help` all collapsed to the same screen. Made `--help` useless as a discovery tool for option flags on nested verbs.
+
+Fix: walk the subcommand tree via a new `resolveSubCommandForHelp` (a local port of citty 0.2.1's unexported `resolveSubCommand`) before calling `showUsage`, so the renderer receives the leaf command + its parent. The resolver is its own module so unit tests don't trigger `index.ts`'s top-level `void startCli()` side effect. Scope of fix covers ALL 11 release verbs plus every other group/verb pair (session, nexus, brain, …).

--- a/.changeset/t9766-contracts-wave1.md
+++ b/.changeset/t9766-contracts-wave1.md
@@ -1,0 +1,18 @@
+---
+id: t9766-contracts-wave1
+tasks: [T9766]
+kind: refactor
+prs: [364]
+summary: Centralize logger + memory studio-API types in @cleocode/contracts (Wave 1 of inline-types-in-core cleanup).
+---
+
+Wave 1 of moving cross-package types out of `@cleocode/core` and into `@cleocode/contracts` per the AGENTS.md SSoT rule — types that are imported across package boundaries (studio, cleo, caamp) live in contracts.
+
+Moved (5 types, 2 new files in contracts):
+
+- `LoggerConfig` → `@cleocode/contracts/src/logger.ts`
+- `MemorySearchHit`, `MemoryGraphStats`, `MemoryDecisionRecord`, `PatternRecord`, `LearningRecord` → `@cleocode/contracts/src/memory.ts`
+
+`@cleocode/core` re-exports the same names for back-compat — no breaking imports. Studio + cleo + caamp can now import from `@cleocode/contracts` directly, which is verified by 6 consumer-side import rewrites in this PR.
+
+Resolved a name collision: `DecisionRecord` already existed in `@cleocode/contracts/operations/session.ts` as a session-ops audit-log shape (different fields). The memory-domain v2 type is therefore exported as `MemoryDecisionRecord`; `@cleocode/core/memory/public-api.ts` re-exports it under the legacy `DecisionRecord` name so existing callers stay green.

--- a/.changeset/t9767-bandaid-wave1.md
+++ b/.changeset/t9767-bandaid-wave1.md
@@ -1,0 +1,20 @@
+---
+id: t9767-bandaid-wave1
+tasks: [T9767]
+kind: refactor
+prs: [367]
+summary: "Remove all 56 `as unknown as` cast chains in the 4 worst-offender files (Wave 1 zero-tolerance type cleanup)."
+---
+
+Wave 1 of the AGENTS.md zero-tolerance bandaid sweep — no more `as unknown as X` chained casts in the worst-offender files.
+
+Removed 56 sites across:
+
+- `packages/cleo/src/cli/commands/nexus.ts` — 28 → 0 (defined `DispatchResponseMeta` once, all consumer sites now typed)
+- `packages/core/src/memory/graph-queries.ts` — 10 → 0 (typed row helper)
+- `packages/nexus/src/pipeline/index.ts` — 9 → 0 (tightened `NexusTables.nexusNodes` generic from `unknown` to `DrizzleTableRef`)
+- `packages/core/src/llm/transports/openai.ts` — 9 → 0 (adapter type alignment: `OpenAIRequestBag`, `OpenAIChatRequest`, `ExtendedChatMessage`, `ExtendedUsage`, `ExtendedChatCompletionChunk`, plus a `hasProp()` type-guard helper that correctly accepts function-shaped class constructors)
+
+8 named declarations introduced (all in contracts where shared, in-file where local). One stray `@ts-ignore` in `packages/skills/scripts/validate-operations.ts:33` also resolved (now `@ts-expect-error T9767-followup:` with a one-line rationale).
+
+125 remaining `as unknown as` sites across the monorepo are tracked as Wave 2 (separate task — not in this PR).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [2026.5.91] (2026-05-20) — T9758 release-as-product Wave 1 + T9752 carryforward closure
+
+### BREAKING CHANGES
+
+- Unify releases tables — drop release_manifests + releases_view, hard-rename to canonical "releases". (T9686-B2) (#328)
+
+  Migration:
+
+  `release_manifests` is dropped and `releases_view` is removed. Readers that
+  previously queried either name must switch to the canonical `releases`
+  table. The migration handles the data move in-place; consumers that touch
+  the SQLite schema directly (e.g. raw queries outside the DataAccessor) need
+  to update their statements.
+
+### Features
+
+- Agent unification + Conduit architecture — unified cleo agent CLI, AgentRegistry with encrypted credentials, Conduit transport layer. (T170)
+- WASM bindings for the CANT ecosystem — cant-core, lafs-core, conduit-core, signaldock-core compile to WASM with TypeScript SDK integration. (T9738)
+- New `pr:<num>` evidence atom — retroactively verify shipped tasks against their PR's CI rollup. (T9764) (#365)
+
+### Fixes
+
+- Four dispatch/envelope bugs in the release pipeline — worktree help text, pr-status routing, reconcile double-wrap, changelog envelope. (T9686-A) (#324)
+- releaseShow + releaseList read from releases_view SSoT — eliminates dual-table split between releases and release_manifests. (T9686-B) (#323)
+- Provenance backfill — tag enumeration, --since empty handling, foreign-key insertion order. (T9686-C) (#325)
+- `cleo release <verb> --help` now shows verb-specific help instead of the top-level command listing. (T9765) (#371)
+
+### Refactors
+
+- Centralize logger + memory studio-API types in @cleocode/contracts (Wave 1 of inline-types-in-core cleanup). (T9766) (#364)
+- Remove all 56 `as unknown as` cast chains in the 4 worst-offender files (Wave 1 zero-tolerance type cleanup). (T9767) (#367)
+
+### Documentation
+
+- Worktree prune main-dir protection + AGENTS.md release docs aligned to SPEC-T9345 4-verb pipeline. (T9686-D) (T9686-E) (#320)
+
+
 ## [2026.5.90] (2026-05-20) — SG-SKILLS-CLEANUP close (T9740)
 
 Closes Saga **SG-SKILLS-CLEANUP** (Epic **T9740**) — the four-sphere

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "conduit-core",
  "nom",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "cant-core",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "serde",
  "serde_json",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "cant-core",
  "serde",
@@ -394,7 +394,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-llm-native"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "lafs-core",
  "serde",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-core"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "chrono",
  "conduit-core",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-payments"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-protocol"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "cant-core",
  "chrono",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-sdk"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-storage"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-transport"
-version = "2026.5.90"
+version = "2026.5.91"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.90"
+version = "2026.5.91"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.90",
+  "version": "2026.5.91",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

**First release shipped via `cleo release plan` end-to-end** per Saga T9758 directive. The CHANGELOG was composed automatically by the task-anchored changesets aggregator (PR #357) — no hand-edits.

## Bundled PRs (9)

#320 (T9686-D/E), #323 (T9686-B), #324 (T9686-A), #325 (T9686-C), #328 (T9686-B2), #364 (T9766), #365 (T9764), #367 (T9767), #371 (T9765).

## Dogfood gaps surfaced (filed)

- **T9780** — parseChangesetDir drops ALL on one bad YAML
- **T9781** — release-prepare.yml workflow missing in cleocode
- **T9776** — Type Check job pre-existing breakage on main

## Test plan

- [x] `cleo release plan v2026.5.91 --epic T9752` succeeded: evidenceComplete=true, changesetEntryCount=11
- [x] Lockfiles realigned cleanly
- [ ] CI green; tag → release-publish → npm publish; install verify; IVTR smoke