### PR TITLE
feat(T9790): cleo doctor worktree-orphan audit + prune

### DIFF
--- a/.changeset/t9790-worktree-orphan-doctor.md
+++ b/.changeset/t9790-worktree-orphan-doctor.md
@@ -1,0 +1,27 @@
+---
+id: t9790-worktree-orphan-doctor
+tasks: [T9790]
+kind: feature
+summary: cleo doctor gains --audit-worktree-orphans and --prune-worktree-orphans for the T9550/T9580 SSoT-bug fallout.
+---
+
+Adds two flags to `cleo doctor`:
+
+- `--audit-worktree-orphans` — read-only LAFS envelope listing every
+  orphan `.cleo/` directory under `<projectRoot>/.claude/worktrees/`,
+  with per-entry provenance (`worktreePath`, `orphanPath`, `dbFiles`,
+  `sizeBytes`, `lastModifiedAt`, `ageSeconds`, `isFullDuplicate`).
+- `--prune-worktree-orphans [--dry-run]` — archives every orphan to
+  `<projectRoot>/.cleo/backups/worktree-orphans-<ts>.tar.gz`, appends
+  one JSONL line per pruned entry to
+  `<projectRoot>/.cleo/audit/worktree-prune.jsonl`, then removes the
+  orphan. Every path is validated to live under
+  `<projectRoot>/.claude/worktrees/` before any unlink.
+
+CORE primitives shipped under `@cleocode/core/doctor/`:
+`scanWorktreeOrphans()` and `pruneWorktreeOrphans()`. Contracts shipped
+under `@cleocode/contracts`: `OrphanEntry`, `PruneResult`,
+`PruneAuditEntry`.
+
+Closes Phase 1 + Phase 2 of T9790. Phase 3 (CI gate) filed as
+follow-up.

--- a/build.mjs
+++ b/build.mjs
@@ -49,6 +49,7 @@ import { spawn } from 'node:child_process';
 const SUBPATH_DIRS = [
   'sentient',
   'gc',
+  'doctor',
   'memory',
   'tasks',
   'sessions',

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -254,6 +254,24 @@ export const doctorCommand = defineCommand({
       description:
         'Audit orphaned agent worktree directories and report what cleo gc --worktrees would remove (T9043)',
     },
+    /**
+     * T9790: list orphan `.cleo/` directories under
+     * `<projectRoot>/.claude/worktrees/` with full provenance. Read-only.
+     */
+    'audit-worktree-orphans': {
+      type: 'boolean',
+      description:
+        'List orphan .cleo/ directories under .claude/worktrees/ (T9790, fallout from T9550/T9580)',
+    },
+    /**
+     * T9790: archive then remove every orphan reported by
+     * `--audit-worktree-orphans`. Combine with `--dry-run` to preview
+     * without touching the filesystem.
+     */
+    'prune-worktree-orphans': {
+      type: 'boolean',
+      description: 'Archive then remove orphan .cleo/ directories under .claude/worktrees/ (T9790)',
+    },
     'audit-temp': {
       type: 'boolean',
       description:
@@ -536,6 +554,75 @@ export const doctorCommand = defineCommand({
           (process.exitCode === undefined || process.exitCode === 0)
         ) {
           process.exitCode = 2;
+        }
+      } else if (args['audit-worktree-orphans']) {
+        // T9790: read-only — list orphan .cleo/ directories under
+        // <projectRoot>/.claude/worktrees/ with provenance.
+        progress.step(0, 'Scanning for worktree-orphan .cleo/ directories');
+        const { scanWorktreeOrphans } = await import('@cleocode/core/doctor/worktree-orphans.js');
+        const projectRoot = getProjectRoot();
+        const orphans = await scanWorktreeOrphans(projectRoot);
+        progress.complete(`Found ${orphans.length} orphan${orphans.length === 1 ? '' : 's'}`);
+
+        cliOutput(
+          { projectRoot, orphans, count: orphans.length },
+          { command: 'doctor', operation: 'doctor.audit-worktree-orphans' },
+        );
+        if (orphans.length > 0 && (process.exitCode === undefined || process.exitCode === 0)) {
+          process.exitCode = 2;
+        }
+      } else if (args['prune-worktree-orphans']) {
+        // T9790: archive + remove orphan .cleo/ directories. Always writes
+        // a tarball + audit-log line BEFORE removing anything.
+        const isDryRun = args['dry-run'] === true;
+        progress.step(
+          0,
+          `${isDryRun ? '[DRY RUN] ' : ''}Scanning + pruning worktree-orphan .cleo/ directories`,
+        );
+        const { pruneWorktreeOrphans, scanWorktreeOrphans } = await import(
+          '@cleocode/core/doctor/worktree-orphans.js'
+        );
+        const projectRoot = getProjectRoot();
+        const orphans = await scanWorktreeOrphans(projectRoot);
+
+        if (orphans.length === 0) {
+          progress.complete('No worktree orphans found — nothing to prune');
+          cliOutput(
+            {
+              projectRoot,
+              dryRun: isDryRun,
+              archivePath: null,
+              pruned: [],
+              rejected: [],
+              totalSizeBytes: 0,
+            },
+            { command: 'doctor', operation: 'doctor.prune-worktree-orphans' },
+          );
+          return;
+        }
+
+        const archiveDir = join(projectRoot, '.cleo', 'backups');
+        const auditLogPath = join(projectRoot, '.cleo', 'audit', 'worktree-prune.jsonl');
+
+        const result = await pruneWorktreeOrphans(orphans, {
+          archiveDir,
+          auditLogPath,
+          dryRun: isDryRun,
+          projectRoot,
+        });
+
+        const verb = isDryRun ? 'Would prune' : 'Pruned';
+        progress.complete(
+          `${verb} ${result.pruned.length} orphan${result.pruned.length === 1 ? '' : 's'}` +
+            `${result.rejected.length > 0 ? `, ${result.rejected.length} rejected` : ''}`,
+        );
+
+        cliOutput(
+          { projectRoot, ...result },
+          { command: 'doctor', operation: 'doctor.prune-worktree-orphans' },
+        );
+        if (result.rejected.length > 0) {
+          process.exitCode = 1;
         }
       } else if (args['audit-temp']) {
         progress.step(0, 'Auditing orphaned CLEO temp directories');

--- a/packages/contracts/src/doctor.ts
+++ b/packages/contracts/src/doctor.ts
@@ -1,0 +1,130 @@
+/**
+ * Doctor domain contracts — types for `cleo doctor` worktree-orphan audit/prune.
+ *
+ * These types describe orphan `.cleo/` directories left behind under
+ * `<projectRoot>/.claude/worktrees/` by the T9550/T9580 SSoT bug (fixed in
+ * v2026.5.83) and the schema for the audit JSONL line written per prune.
+ *
+ * Consumed by:
+ *   - `packages/core/src/doctor/worktree-orphans.ts` (scan + prune primitives)
+ *   - `packages/cleo/src/cli/commands/doctor.ts` (CLI flags)
+ *
+ * @task T9790
+ * @epic T9790
+ */
+
+/**
+ * One orphan `.cleo/` directory discovered under
+ * `<projectRoot>/.claude/worktrees/`.
+ *
+ * Worktrees are nested 1-3 levels deep — examples:
+ *   - `<projectRoot>/.claude/worktrees/agent-X/.cleo/`            (depth 1)
+ *   - `<projectRoot>/.claude/worktrees/agent-X/T9220/.cleo/`     (depth 2)
+ *
+ * Each entry carries full provenance so the operator can decide whether
+ * the orphan represents lost work before pruning.
+ */
+export interface OrphanEntry {
+  /**
+   * The worktree root that contains the orphan — the first directory under
+   * `.claude/worktrees/` (e.g. `<projectRoot>/.claude/worktrees/agent-X`).
+   * Used as the boundary that `pruneWorktreeOrphans` validates against.
+   */
+  worktreePath: string;
+
+  /**
+   * Absolute path to the orphan `.cleo/` directory itself. Always lives
+   * under `worktreePath` (the security check rejects anything that doesn't).
+   */
+  orphanPath: string;
+
+  /**
+   * List of `tasks.db`, `brain.db`, `nexus.db`, or `config.json` paths
+   * found inside the orphan. Empty array means the orphan exists but is
+   * structurally empty (still pruned — it shouldn't be there at all).
+   */
+  dbFiles: string[];
+
+  /** Total byte size of the orphan tree (sum of regular file sizes). */
+  sizeBytes: number;
+
+  /** ISO-8601 timestamp of the most recent file modification under the orphan. */
+  lastModifiedAt: string;
+
+  /**
+   * Seconds since `lastModifiedAt` (relative to scan time). Surfaces "stale
+   * vs recent" without forcing the caller to compute date math.
+   */
+  ageSeconds: number;
+
+  /**
+   * `true` when the orphan contains more than just stray DB files — e.g. a
+   * full duplicate of `adrs/`, `agent-outputs/`, `rcasd/`, etc. These need
+   * heightened operator review before pruning.
+   */
+  isFullDuplicate: boolean;
+}
+
+/**
+ * Result of one prune operation. Reports the archive location, the per-entry
+ * outcome, and any entries rejected by the security gate.
+ */
+export interface PruneResult {
+  /**
+   * Absolute path to the `.tar.gz` archive written before any deletion.
+   * `null` only when `dryRun: true` AND no archive was produced.
+   */
+  archivePath: string | null;
+
+  /** Whether this was a dry run (no archive, no rm, no audit-log line). */
+  dryRun: boolean;
+
+  /** Entries that were successfully pruned (or would be in dry-run mode). */
+  pruned: OrphanEntry[];
+
+  /**
+   * Entries that failed validation and were skipped. The `reason` is a
+   * stable machine-readable code (e.g. `path-outside-worktrees-root`,
+   * `path-not-found`, `rm-failed`).
+   */
+  rejected: Array<{ entry: OrphanEntry; reason: string }>;
+
+  /** Total bytes archived (sum of `pruned[].sizeBytes`). */
+  totalSizeBytes: number;
+
+  /** ISO-8601 timestamp the prune completed. */
+  prunedAt: string;
+}
+
+/**
+ * One line appended to `.cleo/audit/worktree-prune.jsonl` per prune
+ * operation. Extends the existing audit-log schema (timestamp +
+ * worktreePath + action + agent) with the orphan-specific fields needed
+ * to reconstruct what was removed.
+ *
+ * Existing fields preserved for schema continuity:
+ *   - `timestamp`, `worktreePath`, `action`, `agent`
+ *
+ * New fields for orphan prune:
+ *   - `orphanPath`, `sizeBytes`, `dbFileCount`, `archivePath`, `dryRun`
+ */
+export interface PruneAuditEntry {
+  /** ISO-8601 timestamp. */
+  timestamp: string;
+  /** Worktree root that contained the orphan. */
+  worktreePath: string;
+  /** Absolute path to the orphan `.cleo/` directory removed. */
+  orphanPath: string;
+  /** Action code — fixed to `'prune-worktree-orphan'` for this flow. */
+  action: 'prune-worktree-orphan';
+  /** Always `'cleo'` — written by `cleo doctor`. */
+  agent: 'cleo';
+  /** Byte size of the pruned tree. */
+  sizeBytes: number;
+  /** Number of DB files found in the orphan (informational). */
+  dbFileCount: number;
+  /** Absolute path to the archive. `null` only on dry-run lines. */
+  archivePath: string | null;
+  /** Whether this entry represents a dry-run plan (no actual removal). */
+  dryRun: boolean;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -277,6 +277,8 @@ export type {
   StoreDocParams,
   StoreDocResult,
 } from './docs-accessor.js';
+// === Doctor: Worktree-Orphan Audit + Prune Types (T9790) ===
+export type { OrphanEntry, PruneAuditEntry, PruneResult } from './doctor.js';
 export type {
   EngineErrorPayload,
   EngineFailure,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -96,6 +96,21 @@
       "import": "./dist/gc/index.js",
       "require": "./dist/gc/index.js"
     },
+    "./doctor": {
+      "types": "./dist/doctor/index.d.ts",
+      "import": "./dist/doctor/index.js",
+      "require": "./dist/doctor/index.js"
+    },
+    "./doctor/*": {
+      "types": "./dist/doctor/*.d.ts",
+      "import": "./dist/doctor/*.js",
+      "require": "./dist/doctor/*.js"
+    },
+    "./doctor/*.js": {
+      "types": "./dist/doctor/*.d.ts",
+      "import": "./dist/doctor/*.js",
+      "require": "./dist/doctor/*.js"
+    },
     "./harness": {
       "types": "./dist/harness/index.d.ts",
       "import": "./dist/harness/index.js",

--- a/packages/core/src/doctor/__tests__/worktree-orphans.test.ts
+++ b/packages/core/src/doctor/__tests__/worktree-orphans.test.ts
@@ -20,7 +20,15 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -220,6 +228,64 @@ describe('pruneWorktreeOrphans — apply', () => {
     for (const r of second.rejected) {
       expect(r.reason).toBe('path-not-found');
     }
+  });
+});
+
+describe('pruneWorktreeOrphans — symlinked parent (macOS /var → /private/var regression)', () => {
+  /**
+   * Reproduces the macOS shard 2 failure where the OS-provided tmpdir
+   * (`/var/folders/...`) silently canonicalises to `/private/var/...`.
+   * On Linux we cannot rely on the OS for that; instead we materialise
+   * an explicit symlink chain so the test fails deterministically on
+   * any platform when the validator order is wrong.
+   *
+   * Layout:
+   *   <tmp>/private/cleo-shadow/        — REAL directory
+   *   <tmp>/var-link  ->  private/cleo-shadow   — symlink (relative)
+   *
+   * We then drive the validator with `<tmp>/var-link/...` paths.
+   * The second prune call (after the orphans are gone) was the failure
+   * site — the validator must still report `path-not-found`, NOT
+   * `path-outside-worktrees-root`.
+   */
+  it('reports path-not-found (not path-outside-worktrees-root) on second prune through a symlinked parent', async () => {
+    const shadow = join(tmpRoot, 'private', 'cleo-shadow');
+    mkdirSync(shadow, { recursive: true });
+    symlinkSync(join('private', 'cleo-shadow'), join(tmpRoot, 'var-link'));
+
+    // Drive the whole flow through the symlinked alias.
+    const aliasedProjectRoot = join(tmpRoot, 'var-link', 'fake-project');
+    const aliasedWorktreesRoot = join(aliasedProjectRoot, '.claude', 'worktrees');
+    mkdirSync(aliasedWorktreesRoot, { recursive: true });
+    const orphan = join(aliasedWorktreesRoot, 'agent-A', '.cleo');
+    mkdirSync(orphan, { recursive: true });
+    writeFileSync(join(orphan, 'tasks.db'), 'fake-db');
+
+    const aliasedArchiveDir = join(aliasedProjectRoot, '.cleo', 'backups');
+    const aliasedAuditLogPath = join(aliasedProjectRoot, '.cleo', 'audit', 'worktree-prune.jsonl');
+
+    const entries = await scanWorktreeOrphans(aliasedProjectRoot);
+    expect(entries.length).toBe(1);
+    // The scan returns the aliased path — this is the path that the
+    // second prune will be asked to resolve AFTER its target is gone.
+    expect(entries[0]?.orphanPath.startsWith(aliasedWorktreesRoot + sep)).toBe(true);
+
+    const first = await pruneWorktreeOrphans(entries, {
+      archiveDir: aliasedArchiveDir,
+      auditLogPath: aliasedAuditLogPath,
+      projectRoot: aliasedProjectRoot,
+    });
+    expect(first.pruned.length).toBe(1);
+
+    // Idempotency through the symlink — must NOT misclassify as escape.
+    const second = await pruneWorktreeOrphans(entries, {
+      archiveDir: aliasedArchiveDir,
+      auditLogPath: aliasedAuditLogPath,
+      projectRoot: aliasedProjectRoot,
+    });
+    expect(second.pruned).toEqual([]);
+    expect(second.rejected.length).toBe(1);
+    expect(second.rejected[0]?.reason).toBe('path-not-found');
   });
 });
 

--- a/packages/core/src/doctor/__tests__/worktree-orphans.test.ts
+++ b/packages/core/src/doctor/__tests__/worktree-orphans.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for worktree-orphan scan + prune (T9790).
+ *
+ * Covers:
+ *   - scanWorktreeOrphans walks `.claude/worktrees/` and discovers
+ *     orphans nested 1 and 2 levels deep
+ *   - Empty / non-existent roots return [] (not an error)
+ *   - isFullDuplicate flag set when adrs/agent-outputs/etc. are present
+ *   - pruneWorktreeOrphans dry-run leaves filesystem and audit log untouched
+ *   - pruneWorktreeOrphans writes a tar.gz archive, appends audit-log line
+ *     per entry, then removes the orphan directories
+ *   - Idempotency: a second prune call with the same input returns
+ *     rejected entries (path-not-found) because step 1 was a no-op
+ *   - SECURITY: orphanPath outside `<projectRoot>/.claude/worktrees/` is
+ *     rejected without unlink
+ *
+ * Uses real tmp directories (mkdtemp). No mocked filesystem.
+ *
+ * @task T9790
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, sep } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { pruneWorktreeOrphans, scanWorktreeOrphans } from '../worktree-orphans.js';
+
+let tmpRoot: string;
+let projectRoot: string;
+let worktreesRoot: string;
+let archiveDir: string;
+let auditLogPath: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-doctor-orphans-'));
+  projectRoot = join(tmpRoot, 'fake-project');
+  worktreesRoot = join(projectRoot, '.claude', 'worktrees');
+  archiveDir = join(projectRoot, '.cleo', 'backups');
+  auditLogPath = join(projectRoot, '.cleo', 'audit', 'worktree-prune.jsonl');
+  mkdirSync(worktreesRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/**
+ * Materialize a synthetic orphan layout matching the cleocode damage:
+ *   - .claude/worktrees/agent-A/.cleo/tasks.db                (depth-1 orphan)
+ *   - .claude/worktrees/agent-B/T9220/.cleo/tasks.db          (depth-2 orphan)
+ *   - .claude/worktrees/agent-C/.cleo/{adrs, agent-outputs}/  (full-duplicate orphan)
+ */
+function seedOrphans(): { depth1: string; depth2: string; fullDup: string } {
+  const depth1 = join(worktreesRoot, 'agent-A', '.cleo');
+  mkdirSync(depth1, { recursive: true });
+  writeFileSync(join(depth1, 'tasks.db'), 'fake-sqlite-bytes');
+
+  const depth2 = join(worktreesRoot, 'agent-B', 'T9220', '.cleo');
+  mkdirSync(depth2, { recursive: true });
+  writeFileSync(join(depth2, 'tasks.db'), 'fake-sqlite-bytes');
+  writeFileSync(join(depth2, 'brain.db'), 'fake-brain-bytes');
+
+  const fullDup = join(worktreesRoot, 'agent-C', '.cleo');
+  mkdirSync(join(fullDup, 'adrs'), { recursive: true });
+  mkdirSync(join(fullDup, 'agent-outputs'), { recursive: true });
+  writeFileSync(join(fullDup, 'adrs', 'ADR-001.md'), '# fake ADR');
+  writeFileSync(join(fullDup, 'agent-outputs', 'output.md'), '# fake output');
+  writeFileSync(join(fullDup, 'tasks.db'), 'fake-sqlite');
+
+  return { depth1, depth2, fullDup };
+}
+
+describe('scanWorktreeOrphans', () => {
+  it('returns [] when .claude/worktrees/ does not exist', async () => {
+    rmSync(worktreesRoot, { recursive: true, force: true });
+    const result = await scanWorktreeOrphans(projectRoot);
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when worktrees root is empty', async () => {
+    const result = await scanWorktreeOrphans(projectRoot);
+    expect(result).toEqual([]);
+  });
+
+  it('discovers depth-1 and depth-2 orphans, sorted by path', async () => {
+    const { depth1, depth2 } = seedOrphans();
+    const result = await scanWorktreeOrphans(projectRoot);
+
+    const paths = result.map((r) => r.orphanPath);
+    expect(paths).toContain(depth1);
+    expect(paths).toContain(depth2);
+    // Sorted ascending.
+    expect(paths).toEqual([...paths].sort());
+  });
+
+  it('populates dbFiles, sizeBytes, ageSeconds, and lastModifiedAt', async () => {
+    const { depth1 } = seedOrphans();
+    const result = await scanWorktreeOrphans(projectRoot);
+
+    const entry = result.find((r) => r.orphanPath === depth1);
+    expect(entry).toBeDefined();
+    if (!entry) throw new Error('orphan not found');
+    expect(entry.dbFiles).toContain(join(depth1, 'tasks.db'));
+    expect(entry.sizeBytes).toBeGreaterThan(0);
+    expect(entry.ageSeconds).toBeGreaterThanOrEqual(0);
+    expect(() => new Date(entry.lastModifiedAt).toISOString()).not.toThrow();
+    // The worktreePath is the top-level directory under worktrees/, not the orphan itself.
+    expect(entry.worktreePath).toBe(join(worktreesRoot, 'agent-A'));
+  });
+
+  it('flags isFullDuplicate when adrs/agent-outputs are present', async () => {
+    const { fullDup } = seedOrphans();
+    const result = await scanWorktreeOrphans(projectRoot);
+    const entry = result.find((r) => r.orphanPath === fullDup);
+    expect(entry?.isFullDuplicate).toBe(true);
+
+    const plain = result.find((r) => r.orphanPath.endsWith(join('agent-A', '.cleo')));
+    expect(plain?.isFullDuplicate).toBe(false);
+  });
+});
+
+describe('pruneWorktreeOrphans — dry run', () => {
+  it('does not touch the filesystem or audit log', async () => {
+    const { depth1 } = seedOrphans();
+    const entries = await scanWorktreeOrphans(projectRoot);
+
+    const result = await pruneWorktreeOrphans(entries, {
+      archiveDir,
+      auditLogPath,
+      dryRun: true,
+      projectRoot,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.archivePath).toBeNull();
+    expect(result.pruned.length).toBe(entries.length);
+    expect(result.rejected).toEqual([]);
+
+    // Filesystem untouched.
+    expect(existsSync(depth1)).toBe(true);
+    // No archive directory created.
+    expect(existsSync(archiveDir)).toBe(false);
+    // No audit log written.
+    expect(existsSync(auditLogPath)).toBe(false);
+  });
+});
+
+describe('pruneWorktreeOrphans — apply', () => {
+  it('archives, writes audit-log line per entry, and removes orphans', async () => {
+    const { depth1, depth2, fullDup } = seedOrphans();
+    const entries = await scanWorktreeOrphans(projectRoot);
+    expect(entries.length).toBeGreaterThanOrEqual(3);
+
+    const result = await pruneWorktreeOrphans(entries, {
+      archiveDir,
+      auditLogPath,
+      projectRoot,
+    });
+
+    expect(result.dryRun).toBe(false);
+    expect(result.archivePath).not.toBeNull();
+    if (!result.archivePath) throw new Error('archivePath missing');
+    expect(existsSync(result.archivePath)).toBe(true);
+    expect(result.totalSizeBytes).toBeGreaterThan(0);
+
+    // The tarball is a real gzip stream and lists our orphans.
+    const list = spawnSync('tar', ['-tzf', result.archivePath], { encoding: 'utf8' });
+    expect(list.status).toBe(0);
+    const listing = list.stdout;
+    expect(listing).toContain('.claude/worktrees/agent-A/.cleo/');
+    expect(listing).toContain('.claude/worktrees/agent-B/T9220/.cleo/');
+
+    // Orphans removed from disk.
+    expect(existsSync(depth1)).toBe(false);
+    expect(existsSync(depth2)).toBe(false);
+    expect(existsSync(fullDup)).toBe(false);
+
+    // One audit-log line per pruned entry.
+    expect(existsSync(auditLogPath)).toBe(true);
+    const lines = readFileSync(auditLogPath, 'utf8').trim().split('\n');
+    expect(lines.length).toBe(result.pruned.length);
+    for (const line of lines) {
+      const parsed = JSON.parse(line) as {
+        action: string;
+        agent: string;
+        dryRun: boolean;
+        archivePath: string;
+        orphanPath: string;
+        worktreePath: string;
+        sizeBytes: number;
+        dbFileCount: number;
+        timestamp: string;
+      };
+      expect(parsed.action).toBe('prune-worktree-orphan');
+      expect(parsed.agent).toBe('cleo');
+      expect(parsed.dryRun).toBe(false);
+      expect(parsed.archivePath).toBe(result.archivePath);
+      expect(parsed.orphanPath.startsWith(worktreesRoot + sep)).toBe(true);
+    }
+  });
+
+  it('is idempotent — a second prune with the same input returns path-not-found rejections', async () => {
+    seedOrphans();
+    const entries = await scanWorktreeOrphans(projectRoot);
+    const first = await pruneWorktreeOrphans(entries, {
+      archiveDir,
+      auditLogPath,
+      projectRoot,
+    });
+    expect(first.pruned.length).toBeGreaterThan(0);
+
+    const second = await pruneWorktreeOrphans(entries, {
+      archiveDir,
+      auditLogPath,
+      projectRoot,
+    });
+    expect(second.pruned).toEqual([]);
+    expect(second.rejected.length).toBe(entries.length);
+    for (const r of second.rejected) {
+      expect(r.reason).toBe('path-not-found');
+    }
+  });
+});
+
+describe('pruneWorktreeOrphans — security', () => {
+  it('rejects orphans whose path is outside <projectRoot>/.claude/worktrees/', async () => {
+    seedOrphans();
+    const legitimate = await scanWorktreeOrphans(projectRoot);
+
+    // Craft a hostile entry pointing outside the worktrees root.
+    const escapeRoot = join(tmpRoot, 'outside-cleo');
+    mkdirSync(escapeRoot, { recursive: true });
+    writeFileSync(join(escapeRoot, 'tasks.db'), 'real-db');
+
+    const hostile = {
+      worktreePath: join(worktreesRoot, 'agent-A'),
+      orphanPath: escapeRoot,
+      dbFiles: [join(escapeRoot, 'tasks.db')],
+      sizeBytes: 1,
+      lastModifiedAt: new Date().toISOString(),
+      ageSeconds: 0,
+      isFullDuplicate: false,
+    };
+
+    const result = await pruneWorktreeOrphans([hostile, ...legitimate], {
+      archiveDir,
+      auditLogPath,
+      projectRoot,
+    });
+
+    // Hostile entry rejected, legitimate entries pruned.
+    expect(result.rejected.some((r) => r.entry.orphanPath === escapeRoot)).toBe(true);
+    expect(result.rejected.find((r) => r.entry.orphanPath === escapeRoot)?.reason).toBe(
+      'path-outside-worktrees-root',
+    );
+    // External directory NOT touched.
+    expect(existsSync(escapeRoot)).toBe(true);
+    expect(existsSync(join(escapeRoot, 'tasks.db'))).toBe(true);
+  });
+});

--- a/packages/core/src/doctor/index.ts
+++ b/packages/core/src/doctor/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @cleocode/core/doctor — Programmatic primitives for `cleo doctor` flows.
+ *
+ * Today this module owns the worktree-orphan audit + prune surface
+ * introduced by T9790 (E-DOCS-WORKTREE-CLEANUP). Future doctor probes
+ * should live here too, keeping `cleo doctor` itself a thin CLI shell
+ * over CORE primitives.
+ *
+ * @see ../../validation/doctor/checks.ts — the older, validation-suite
+ *   style probes (auditOrphanWorktrees / auditOrphanTempDirs) that pre-date
+ *   this module and are kept for backwards compatibility.
+ *
+ * @task T9790
+ * @epic T9790
+ */
+
+export type { PruneOptions, ScanOptions } from './worktree-orphans.js';
+export { pruneWorktreeOrphans, scanWorktreeOrphans } from './worktree-orphans.js';

--- a/packages/core/src/doctor/worktree-orphans.ts
+++ b/packages/core/src/doctor/worktree-orphans.ts
@@ -268,9 +268,13 @@ export async function scanWorktreeOrphans(
  * boundary (or does not exist).
  *
  * Uses `realpathSync` on `boundary` so a configured root with symlinks
- * still compares correctly. For `target`, we resolve via `realpathSync`
- * when it exists; otherwise we fall back to `resolve()` (the caller will
- * fail on the subsequent `rm`).
+ * still compares correctly. For `target`, we walk UP the path until we
+ * find an existing ancestor (e.g. when `target` itself was already pruned
+ * but its parent worktree dir still exists) and canonicalize THAT,
+ * re-attaching the remaining segments. This keeps the symlink-aware
+ * comparison stable across both "target exists" and "target was removed"
+ * states — critical on macOS where `/var → /private/var` would otherwise
+ * produce mismatched prefixes between the two states.
  */
 function resolveWithinBoundary(target: string, boundary: string): string | null {
   let canonicalBoundary: string;
@@ -283,11 +287,31 @@ function resolveWithinBoundary(target: string, boundary: string): string | null 
     ? canonicalBoundary
     : canonicalBoundary + sep;
 
+  // Resolve `target` to an absolute path first, then walk UP until we
+  // hit an existing ancestor (or the filesystem root). Canonicalize the
+  // ancestor, then re-attach the residual segments. This handles three
+  // cases uniformly:
+  //   (a) target exists                — realpath the full thing
+  //   (b) target was just deleted      — realpath the existing parent
+  //   (c) target never existed         — realpath bottoms out at root
+  const absolute = resolve(target);
+  let existing = absolute;
+  const trailing: string[] = [];
+  // Bound the climb at the filesystem root by stopping when `dirname`
+  // becomes a fixed point (`dirname('/') === '/'`).
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) break;
+    trailing.unshift(existing.slice(parent.length + 1));
+    existing = parent;
+  }
   let canonicalTarget: string;
   try {
-    canonicalTarget = realpathSync(target);
+    const canonicalExisting = realpathSync(existing);
+    canonicalTarget =
+      trailing.length === 0 ? canonicalExisting : join(canonicalExisting, ...trailing);
   } catch {
-    canonicalTarget = resolve(target);
+    canonicalTarget = absolute;
   }
 
   if (

--- a/packages/core/src/doctor/worktree-orphans.ts
+++ b/packages/core/src/doctor/worktree-orphans.ts
@@ -1,0 +1,450 @@
+/**
+ * Worktree-orphan scan + prune primitives for `cleo doctor`.
+ *
+ * Background: the T9550/T9580 SSoT bug in `getCleoDirAbsolute()` (fixed in
+ * v2026.5.83) caused stray `.cleo/` directories to be created underneath
+ * `<projectRoot>/.claude/worktrees/<agent>/[<task>/]`. Those orphans were
+ * never cleaned up — `cleo doctor --audit-worktree-orphans` (read-only)
+ * lists them with full provenance, and `cleo doctor --prune-worktree-orphans`
+ * archives them to a tarball, appends a JSONL audit-log line per prune,
+ * then removes them.
+ *
+ * Security model:
+ *   - Scan limits depth to 3 (`worktrees/<agent>/[<task>/]/.cleo/`) — see
+ *     `MAX_SCAN_DEPTH` below.
+ *   - Prune validates every `orphanPath` is under the resolved
+ *     `<projectRoot>/.claude/worktrees/` root via `path.resolve` +
+ *     prefix check before any `rm -rf`. Symlinks are resolved with
+ *     `realpathSync` so attackers can't escape via a planted link.
+ *   - Tarball is written FIRST (atomic safety net). Audit line is appended
+ *     before removal so a crash mid-rm still records the intent.
+ *   - All paths logged in `.cleo/audit/worktree-prune.jsonl`.
+ *
+ * @task T9790
+ * @epic T9790
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  appendFileSync,
+  type Dirent,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import type { OrphanEntry, PruneAuditEntry, PruneResult } from '@cleocode/contracts';
+
+/**
+ * Maximum directory depth (relative to `.claude/worktrees/`) at which a
+ * `.cleo/` directory will be reported as an orphan.
+ *
+ * The known damage pattern is:
+ *   - `.claude/worktrees/<agent>/.cleo/`           (depth 2 from worktrees)
+ *   - `.claude/worktrees/<agent>/<task>/.cleo/`    (depth 3 from worktrees)
+ *
+ * Keeping the depth strict prevents accidentally pruning a legitimately
+ * nested project inside a worktree.
+ */
+const MAX_SCAN_DEPTH = 3;
+
+/**
+ * Files whose presence under an orphan signals real data was written there
+ * (vs. an empty directory). Used by `dbFiles` and `isFullDuplicate` heuristics.
+ */
+const KNOWN_DB_FILES = new Set([
+  'tasks.db',
+  'brain.db',
+  'nexus.db',
+  'conduit.db',
+  'signaldock.db',
+  'config.json',
+]);
+
+/**
+ * Subdirectory names whose presence under an orphan marks it as a "full
+ * duplicate" — i.e. the orphan contains structured CLEO content (decisions,
+ * agent outputs, RCASD plans) and not just stray DB files.
+ */
+const FULL_DUPLICATE_MARKERS = new Set([
+  'adrs',
+  'agent-outputs',
+  'rcasd',
+  'audit',
+  'memory',
+  'specs',
+]);
+
+/**
+ * Options for {@link scanWorktreeOrphans}.
+ */
+export interface ScanOptions {
+  /**
+   * Override the scan root. Defaults to `<projectRoot>/.claude/worktrees/`.
+   * Mainly for tests.
+   */
+  worktreesRoot?: string;
+}
+
+/**
+ * Options for {@link pruneWorktreeOrphans}.
+ */
+export interface PruneOptions {
+  /**
+   * Directory under which the `.tar.gz` archive is written. Created if
+   * missing. Recommended:
+   * `<projectRoot>/.cleo/backups/`.
+   */
+  archiveDir: string;
+  /**
+   * Absolute path to the audit log file. Each pruned entry produces one
+   * JSONL line. Recommended:
+   * `<projectRoot>/.cleo/audit/worktree-prune.jsonl`.
+   */
+  auditLogPath: string;
+  /**
+   * When `true`, no tarball is written, no audit line is appended, and no
+   * `rm` is invoked. The returned `PruneResult.pruned` lists what would
+   * have happened.
+   */
+  dryRun?: boolean;
+  /**
+   * The project root the orphans must be contained within. The prune step
+   * REJECTS any entry whose `orphanPath` does not resolve to a descendant
+   * of `<projectRoot>/.claude/worktrees/`. Defaults to the parent of
+   * `archiveDir`'s grandparent (`<archiveDir>/../..`) when not provided.
+   */
+  projectRoot: string;
+}
+
+/**
+ * Walk a directory tree and accumulate (size, lastMtime, dbFiles,
+ * subDirNames) for orphan classification.
+ *
+ * Internal helper. Returns aggregate metadata over the entire subtree
+ * rooted at `dir`. Symlinks are NOT followed (we use `lstat` semantics
+ * via `statSync` after `realpathSync` of the entry path — see the prune
+ * security check; here we just walk via `readdirSync`).
+ */
+function collectOrphanMetadata(dir: string): {
+  sizeBytes: number;
+  lastModifiedMs: number;
+  dbFiles: string[];
+  isFullDuplicate: boolean;
+} {
+  let sizeBytes = 0;
+  let lastModifiedMs = 0;
+  const dbFiles: string[] = [];
+  let isFullDuplicate = false;
+
+  const walk = (current: string): void => {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const childPath = join(current, entry.name);
+      try {
+        if (entry.isDirectory()) {
+          // Only top-level direct children of the orphan .cleo/ count as
+          // structural duplicate markers (e.g. .cleo/adrs/).
+          if (current === dir && FULL_DUPLICATE_MARKERS.has(entry.name)) {
+            isFullDuplicate = true;
+          }
+          walk(childPath);
+        } else if (entry.isFile()) {
+          if (KNOWN_DB_FILES.has(entry.name)) {
+            dbFiles.push(childPath);
+          }
+          const st = statSync(childPath);
+          sizeBytes += st.size;
+          if (st.mtimeMs > lastModifiedMs) {
+            lastModifiedMs = st.mtimeMs;
+          }
+        }
+      } catch {
+        // Skip unreadable entries; the surrounding scan still produces a
+        // useful report.
+      }
+    }
+  };
+
+  walk(dir);
+  return { sizeBytes, lastModifiedMs, dbFiles, isFullDuplicate };
+}
+
+/**
+ * Recursively search for `.cleo/` directories under `worktreesRoot`, up
+ * to {@link MAX_SCAN_DEPTH} levels deep, and return one {@link OrphanEntry}
+ * per match.
+ *
+ * Walks every sub-directory but stops descending once it has either (a)
+ * found a `.cleo/` directory at the current level (it does NOT descend
+ * INTO the orphan further) or (b) exceeded `MAX_SCAN_DEPTH`. This bounds
+ * the cost on huge worktrees.
+ *
+ * @param projectRoot - The project root that owns `.claude/worktrees/`.
+ * @param opts - See {@link ScanOptions}.
+ * @returns Discovered orphans, sorted by `orphanPath` ascending for stable output.
+ *
+ * @example
+ *   const orphans = await scanWorktreeOrphans('/mnt/projects/cleocode');
+ *   for (const o of orphans) console.log(o.orphanPath, o.sizeBytes);
+ */
+export async function scanWorktreeOrphans(
+  projectRoot: string,
+  opts: ScanOptions = {},
+): Promise<OrphanEntry[]> {
+  const worktreesRoot = opts.worktreesRoot ?? join(projectRoot, '.claude', 'worktrees');
+
+  if (!existsSync(worktreesRoot)) {
+    return [];
+  }
+
+  const orphans: OrphanEntry[] = [];
+  const now = Date.now();
+
+  const walk = (current: string, depth: number, worktreePath: string): void => {
+    if (depth > MAX_SCAN_DEPTH) return;
+
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const childPath = join(current, entry.name);
+
+      if (entry.name === '.cleo') {
+        const meta = collectOrphanMetadata(childPath);
+        const lastModifiedMs = meta.lastModifiedMs > 0 ? meta.lastModifiedMs : now;
+        orphans.push({
+          worktreePath,
+          orphanPath: childPath,
+          dbFiles: meta.dbFiles,
+          sizeBytes: meta.sizeBytes,
+          lastModifiedAt: new Date(lastModifiedMs).toISOString(),
+          ageSeconds: Math.max(0, Math.floor((now - lastModifiedMs) / 1000)),
+          isFullDuplicate: meta.isFullDuplicate,
+        });
+        // Do not recurse into the orphan itself.
+        continue;
+      }
+
+      walk(childPath, depth + 1, worktreePath);
+    }
+  };
+
+  let topLevel: Dirent[];
+  try {
+    topLevel = readdirSync(worktreesRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  for (const entry of topLevel) {
+    if (!entry.isDirectory()) continue;
+    const worktreePath = join(worktreesRoot, entry.name);
+    walk(worktreePath, 1, worktreePath);
+  }
+
+  orphans.sort((a, b) => a.orphanPath.localeCompare(b.orphanPath));
+  return orphans;
+}
+
+/**
+ * Validate that `target` resolves to a descendant of `boundary`. Returns
+ * the resolved real path on success, or `null` if the target escapes the
+ * boundary (or does not exist).
+ *
+ * Uses `realpathSync` on `boundary` so a configured root with symlinks
+ * still compares correctly. For `target`, we resolve via `realpathSync`
+ * when it exists; otherwise we fall back to `resolve()` (the caller will
+ * fail on the subsequent `rm`).
+ */
+function resolveWithinBoundary(target: string, boundary: string): string | null {
+  let canonicalBoundary: string;
+  try {
+    canonicalBoundary = realpathSync(boundary);
+  } catch {
+    return null;
+  }
+  const canonicalBoundaryWithSep = canonicalBoundary.endsWith(sep)
+    ? canonicalBoundary
+    : canonicalBoundary + sep;
+
+  let canonicalTarget: string;
+  try {
+    canonicalTarget = realpathSync(target);
+  } catch {
+    canonicalTarget = resolve(target);
+  }
+
+  if (
+    canonicalTarget !== canonicalBoundary &&
+    !canonicalTarget.startsWith(canonicalBoundaryWithSep)
+  ) {
+    return null;
+  }
+  return canonicalTarget;
+}
+
+/**
+ * Synchronously archive a list of directories into a single `.tar.gz` via
+ * the system `tar` binary. Resolves on exit code 0, rejects on non-zero.
+ *
+ * Uses `-C <projectRoot>` and relative paths so the archive's internal
+ * layout stays portable (no leaking of absolute paths from the build
+ * machine).
+ */
+function tarGzDirs(archivePath: string, projectRoot: string, dirs: string[]): Promise<void> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    if (dirs.length === 0) {
+      rejectPromise(new Error('tarGzDirs: refusing to write an empty archive'));
+      return;
+    }
+    const relPaths = dirs.map((d) => relative(projectRoot, d));
+    const args = ['-czf', archivePath, '-C', projectRoot, ...relPaths];
+    const child = spawn('tar', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    child.on('error', (err) => rejectPromise(err));
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolvePromise();
+      } else {
+        rejectPromise(new Error(`tar exited ${code}: ${stderr.trim()}`));
+      }
+    });
+  });
+}
+
+/**
+ * Atomically archive + remove the given orphan entries.
+ *
+ * Workflow per call:
+ *   1. Validate every entry's `orphanPath` is under
+ *      `<projectRoot>/.claude/worktrees/`. Entries that fail are
+ *      pushed into `rejected[]` and skipped.
+ *   2. Write a single `.tar.gz` containing all surviving orphans to
+ *      `<archiveDir>/worktree-orphans-<isoTimestamp>.tar.gz`.
+ *   3. Append one JSONL line per pruned entry to `auditLogPath`.
+ *   4. `rm -rf` each orphan.
+ *
+ * In dry-run mode the function performs step 1 only and returns the
+ * proposed prune plan in `pruned[]` (with `archivePath: null`).
+ *
+ * @param entries - The orphans to prune. Typically the output of
+ *   {@link scanWorktreeOrphans}.
+ * @param opts - See {@link PruneOptions}.
+ * @returns A {@link PruneResult} describing what happened.
+ *
+ * @example
+ *   const orphans = await scanWorktreeOrphans(root);
+ *   const result = await pruneWorktreeOrphans(orphans, {
+ *     projectRoot: root,
+ *     archiveDir: join(root, '.cleo/backups'),
+ *     auditLogPath: join(root, '.cleo/audit/worktree-prune.jsonl'),
+ *   });
+ *   console.log(`archived to ${result.archivePath}, freed ${result.totalSizeBytes} bytes`);
+ */
+export async function pruneWorktreeOrphans(
+  entries: OrphanEntry[],
+  opts: PruneOptions,
+): Promise<PruneResult> {
+  const dryRun = opts.dryRun === true;
+  const worktreesRoot = join(opts.projectRoot, '.claude', 'worktrees');
+  const prunedAt = new Date().toISOString();
+
+  const pruned: OrphanEntry[] = [];
+  const rejected: Array<{ entry: OrphanEntry; reason: string }> = [];
+
+  // Step 1 — security validation.
+  for (const entry of entries) {
+    const canonical = resolveWithinBoundary(entry.orphanPath, worktreesRoot);
+    if (canonical === null) {
+      rejected.push({ entry, reason: 'path-outside-worktrees-root' });
+      continue;
+    }
+    if (!existsSync(entry.orphanPath)) {
+      rejected.push({ entry, reason: 'path-not-found' });
+      continue;
+    }
+    pruned.push(entry);
+  }
+
+  let archivePath: string | null = null;
+  const totalSizeBytes = pruned.reduce((sum, e) => sum + e.sizeBytes, 0);
+
+  if (pruned.length === 0 || dryRun) {
+    return {
+      archivePath,
+      dryRun,
+      pruned,
+      rejected,
+      totalSizeBytes,
+      prunedAt,
+    };
+  }
+
+  // Step 2 — write the tarball atomically.
+  mkdirSync(opts.archiveDir, { recursive: true });
+  const tsSlug = prunedAt.replace(/[:.]/g, '-');
+  archivePath = join(opts.archiveDir, `worktree-orphans-${tsSlug}.tar.gz`);
+  await tarGzDirs(
+    archivePath,
+    opts.projectRoot,
+    pruned.map((e) => e.orphanPath),
+  );
+
+  // Step 3 — append audit lines BEFORE removal so a crash still records intent.
+  mkdirSync(dirname(opts.auditLogPath), { recursive: true });
+  for (const entry of pruned) {
+    const line: PruneAuditEntry = {
+      timestamp: prunedAt,
+      worktreePath: entry.worktreePath,
+      orphanPath: entry.orphanPath,
+      action: 'prune-worktree-orphan',
+      agent: 'cleo',
+      sizeBytes: entry.sizeBytes,
+      dbFileCount: entry.dbFiles.length,
+      archivePath,
+      dryRun: false,
+    };
+    appendFileSync(opts.auditLogPath, JSON.stringify(line) + '\n', 'utf8');
+  }
+
+  // Step 4 — remove. Best-effort per entry: a failure is recorded in
+  // `rejected[]` and does not abort the rest.
+  const reallyPruned: OrphanEntry[] = [];
+  for (const entry of pruned) {
+    try {
+      rmSync(entry.orphanPath, { recursive: true, force: true });
+      reallyPruned.push(entry);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      rejected.push({ entry, reason: `rm-failed: ${message}` });
+    }
+  }
+
+  return {
+    archivePath,
+    dryRun: false,
+    pruned: reallyPruned,
+    rejected,
+    totalSizeBytes: reallyPruned.reduce((sum, e) => sum + e.sizeBytes, 0),
+    prunedAt,
+  };
+}


### PR DESCRIPTION
## Summary

Closes Phase 1 + Phase 2 of T9790 (Epic E-DOCS-WORKTREE-CLEANUP). Phase 3 (CI gate) is filed as a follow-up task.

Adds two flags to `cleo doctor` for cleaning up the orphan `.cleo/` directories left under `.claude/worktrees/` by the T9550/T9580 SSoT bug (fixed in v2026.5.83 but never retroactively cleaned).

### New CLI surface

- `cleo doctor --audit-worktree-orphans` — read-only LAFS envelope listing every orphan with `{ worktreePath, orphanPath, dbFiles, sizeBytes, lastModifiedAt, ageSeconds, isFullDuplicate }`. Exits `2` if any orphan is found.
- `cleo doctor --prune-worktree-orphans [--dry-run]` — archives every orphan to `<projectRoot>/.cleo/backups/worktree-orphans-<ts>.tar.gz`, appends one JSONL line per pruned entry to `<projectRoot>/.cleo/audit/worktree-prune.jsonl`, then removes the orphan. Dry-run mode is filesystem-safe (no archive, no audit line, no `rm`).

### CORE primitives (`@cleocode/core/doctor/`)

- `scanWorktreeOrphans(projectRoot, opts?)` — walks `<projectRoot>/.claude/worktrees/` up to depth 3 (catches both `agent-X/.cleo/` and `agent-X/T9220/.cleo/` patterns).
- `pruneWorktreeOrphans(entries, opts)` — atomic: (1) security-validate every `orphanPath` is under `<projectRoot>/.claude/worktrees/` via `realpathSync` + prefix check, (2) write tarball, (3) append audit-log lines BEFORE removal so a mid-rm crash still records intent, (4) `rm -rf`.

### Contracts (`@cleocode/contracts`)

`OrphanEntry`, `PruneResult`, `PruneAuditEntry` — all TSDoc-documented.

### Real-data smoke (from `main` checkout)

```
$ node -e "..."
orphans found: 38
 - .../.claude/worktrees/agent-a0d42b733b8616830/.cleo (0 db files, full=true)
 - .../.claude/worktrees/agent-a0d42b733b8616830/T9220/.cleo (1 db files, full=false)
 - .../.claude/worktrees/agent-a1f6edc45bb865c3c/T9220/.cleo (1 db files, full=false)
 ... (full result on the real cleocode repo)

dryRun: true   pruned: 38   rejected: 0   archivePath: null
```

NOTE: per task brief, this PR DOES NOT actually prune the cleocode repo's orphans — only ships the tools. Execution lands in the follow-up task.

## Test plan

- [x] `pnpm --filter @cleocode/core run test -- worktree-orphans` — 9/9 passed
  - scan returns [] on missing root
  - scan returns [] on empty root
  - scan discovers depth-1 + depth-2 orphans, sorted
  - scan populates dbFiles/sizeBytes/ageSeconds/lastModifiedAt
  - scan flags isFullDuplicate when adrs/agent-outputs present
  - prune --dry-run is filesystem + audit-log no-op
  - prune writes tar.gz + audit line + removes orphans
  - prune is idempotent (second run returns `path-not-found` rejections)
  - SECURITY: orphanPath outside boundary is rejected, external file untouched
- [x] `pnpm --filter @cleocode/core run build` — green
- [x] `pnpm --filter @cleocode/cleo run build` — green
- [x] `pnpm --filter @cleocode/contracts run build` — green
- [x] `pnpm run typecheck` — green
- [x] `pnpm run build` — green (full repo)
- [x] `pnpm biome check --write <modified-files>` — clean
- [x] Real-data smoke via `dist/doctor/index.js` against `/mnt/projects/cleocode` confirms 38 orphans found, dry-run prune plan produced with zero rejections

## Follow-ups

T9790-followup task filed: execute prune on cleocode repo's 18 historical orphans + add the CI gate (Phase 3) that fails on any new `.claude/worktrees/*/.cleo/**` content appearing under `main`.