### PR TITLE
feat(T9788): DocKindRegistry foundation in @cleocode/contracts

### DIFF
--- a/packages/cleo/src/cli/__tests__/docs-publish-pr.test.ts
+++ b/packages/cleo/src/cli/__tests__/docs-publish-pr.test.ts
@@ -209,10 +209,18 @@ describe('T9716 — branch naming docs/<slug> + temp worktree handling', () => {
     expect(branchForSlug('a')).toBe('docs/a');
   });
 
-  it('publishDirForType maps known types to docs/<type> and falls back to note', () => {
+  it('publishDirForType maps known types via the canonical registry and falls back to note', () => {
+    // T9788 — publishDirs now flow from `BUILTIN_DOC_KINDS` in
+    // @cleocode/contracts so the legacy fixed `docs/<type>` convention holds
+    // for kinds whose metadata declares it (spec, adr), but kinds with
+    // bespoke directories (llm-readme → '.', changeset → '.changeset')
+    // return what the registry says rather than the legacy synthesised path.
     expect(publishDirForType('spec')).toBe('docs/spec');
     expect(publishDirForType('adr')).toBe('docs/adr');
-    expect(publishDirForType('llm-readme')).toBe('docs/llm-readme');
+    expect(publishDirForType('llm-readme')).toBe('.');
+    expect(publishDirForType('changeset')).toBe('.changeset');
+    expect(publishDirForType('release-note')).toBe('docs/release');
+    expect(publishDirForType('rcasd')).toBe('.cleo/rcasd');
     expect(publishDirForType(undefined)).toBe('docs/note');
     expect(publishDirForType('weird-unknown')).toBe('docs/note');
     expect(publishDirForType(null)).toBe('docs/note');

--- a/packages/cleo/src/cli/__tests__/docs-schema.test.ts
+++ b/packages/cleo/src/cli/__tests__/docs-schema.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the `cleo docs schema` and `cleo docs list-types` CLI surfaces
+ * introduced by T9788.
+ *
+ * Coverage:
+ *  - subcommand registration on the root `docs` command (both verbs)
+ *  - meta description mentions the registry / taxonomy
+ *  - existing subcommand surface (add/list/fetch/remove/publish-pr) still wired
+ *
+ * Envelope-shape behaviour is exercised against the {@link DocKindRegistry}
+ * by the contracts + core test suites — this file deliberately stays at the
+ * registration layer to match the pattern in `docs.test.ts`.
+ *
+ * @epic T9787
+ * @task T9788
+ */
+
+import { describe, expect, it } from 'vitest';
+import { docsCommand } from '../commands/docs.js';
+
+describe('docsCommand — T9788 taxonomy discovery subcommands', () => {
+  it('exposes `schema` as a subcommand', () => {
+    const subs = docsCommand.subCommands as Record<string, unknown> | undefined;
+    expect(subs).toBeDefined();
+    expect(subs?.['schema']).toBeDefined();
+  });
+
+  it('exposes `list-types` as a subcommand', () => {
+    const subs = docsCommand.subCommands as Record<string, unknown> | undefined;
+    expect(subs).toBeDefined();
+    expect(subs?.['list-types']).toBeDefined();
+  });
+
+  it('`schema` subcommand carries a meaningful description', () => {
+    const subs = docsCommand.subCommands as Record<string, { meta?: unknown } | undefined>;
+    const schema = subs?.['schema'];
+    expect(schema).toBeDefined();
+    const meta =
+      schema && typeof schema.meta === 'function'
+        ? (schema.meta as () => { description: string })()
+        : (schema?.meta as { description: string } | undefined);
+    expect(meta?.description).toMatch(/registry|taxonomy/i);
+  });
+
+  it('`list-types` subcommand carries a meaningful description', () => {
+    const subs = docsCommand.subCommands as Record<string, { meta?: unknown } | undefined>;
+    const listTypes = subs?.['list-types'];
+    expect(listTypes).toBeDefined();
+    const meta =
+      listTypes && typeof listTypes.meta === 'function'
+        ? (listTypes.meta as () => { description: string })()
+        : (listTypes?.meta as { description: string } | undefined);
+    expect(meta?.description).toMatch(/kind|publish|slug/i);
+  });
+
+  it('keeps the legacy attachment subcommands wired alongside the new ones', () => {
+    const subs = docsCommand.subCommands as Record<string, unknown> | undefined;
+    expect(subs?.['add']).toBeDefined();
+    expect(subs?.['list']).toBeDefined();
+    expect(subs?.['fetch']).toBeDefined();
+    expect(subs?.['remove']).toBeDefined();
+    expect(subs?.['publish-pr']).toBeDefined();
+  });
+});

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -17,7 +17,12 @@
 
 import { appendFile, mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
-import { ExitCode } from '@cleocode/contracts';
+import {
+  DocKindConfigError,
+  type DocKindMetadata,
+  DocKindRegistry,
+  ExitCode,
+} from '@cleocode/contracts';
 import {
   buildDocsGraph,
   CleoError,
@@ -207,7 +212,8 @@ const addCommand = defineCommand({
     },
     type: {
       type: 'string',
-      description: 'Taxonomy classification: spec|adr|research|handoff|note|llm-readme (T9637)',
+      description:
+        'Taxonomy classification — run `cleo docs list-types` to enumerate registered kinds (T9637 / T9788)',
     },
   },
   async run({ args }) {
@@ -1327,13 +1333,211 @@ const importCommand = defineCommand({
   },
 });
 
+// ── cleo docs schema ─────────────────────────────────────────────────────────
+
+/**
+ * Serializable wire shape for the doc-kind registry envelope.
+ *
+ * Regex patterns are serialized to their `.source` string so JSON
+ * consumers (and downstream agents) can re-compile them deterministically.
+ *
+ * @task T9788
+ */
+interface DocKindMetadataWire {
+  readonly kind: string;
+  readonly label: string;
+  readonly description: string;
+  readonly defaultOwnerKind: 'task' | 'session' | 'observation' | 'project';
+  readonly publishDir: string;
+  readonly requiresEntityId: boolean;
+  readonly entityIdPattern?: string;
+  readonly isExtension: boolean;
+}
+
+/**
+ * Convert a {@link DocKindMetadata} entry to its wire-format twin.
+ *
+ * @internal
+ * @task T9788
+ */
+function toWireKind(meta: DocKindMetadata): DocKindMetadataWire {
+  return {
+    kind: meta.kind,
+    label: meta.label,
+    description: meta.description,
+    defaultOwnerKind: meta.defaultOwnerKind,
+    publishDir: meta.publishDir,
+    requiresEntityId: meta.requiresEntityId,
+    ...(meta.entityIdPattern ? { entityIdPattern: meta.entityIdPattern.source } : {}),
+    isExtension: meta.isExtension === true,
+  };
+}
+
+/**
+ * Load the canonical registry, mapping config errors into a CLI-friendly
+ * envelope. Returns the built-in-only fallback on failure so commands stay
+ * usable even when `.cleo/docs-config.json` is broken.
+ *
+ * @internal
+ * @task T9788
+ */
+function loadCliRegistry(projectRoot: string): {
+  registry: DocKindRegistry;
+  configError?: { source: string; message: string };
+} {
+  try {
+    return { registry: DocKindRegistry.load(projectRoot) };
+  } catch (err) {
+    if (err instanceof DocKindConfigError) {
+      return {
+        registry: DocKindRegistry.builtinOnly(),
+        configError: { source: err.source, message: err.message },
+      };
+    }
+    throw err;
+  }
+}
+
+/**
+ * `cleo docs schema` — emit the full doc-kind registry as a LAFS envelope.
+ *
+ * Built-in kinds appear first (declaration order), then any extensions
+ * loaded from `.cleo/docs-config.json`. The envelope includes
+ * `extensionsCount` so consumers can quickly tell whether project-level
+ * extensions are in play.
+ *
+ * @task T9788
+ */
+const schemaCommand = defineCommand({
+  meta: {
+    name: 'schema',
+    description:
+      'Emit the canonical doc-kind taxonomy registry (built-ins + project extensions) ' +
+      'as a LAFS envelope. The schema is the single source of truth for the ' +
+      '--type values accepted by `cleo docs add` and the publish-dir layout used by ' +
+      '`cleo docs publish-pr`. See `cleo docs list-types` for the human-readable form (T9788).',
+  },
+  args: {
+    'include-counts': {
+      type: 'boolean',
+      description: 'Include per-kind attachment counts from the project SSoT',
+    },
+  },
+  async run({ args }) {
+    const projectRoot = getProjectRoot();
+    const { registry, configError } = loadCliRegistry(projectRoot);
+    const kinds = registry.list().map(toWireKind);
+    const extensionsCount = kinds.filter((k) => k.isExtension).length;
+
+    let counts: Record<string, number> | undefined;
+    if (args['include-counts']) {
+      counts = {};
+      const { createAttachmentStore } = await import('@cleocode/core/internal');
+      const store = createAttachmentStore();
+      for (const k of kinds) counts[k.kind] = 0;
+      try {
+        const rows = await store.listAllInProject(projectRoot);
+        for (const row of rows) {
+          const key = row.type;
+          if (key && key in counts) counts[key] = (counts[key] ?? 0) + 1;
+        }
+      } catch {
+        // SSoT not initialised — leave the zero-filled counts in place.
+      }
+    }
+
+    cliOutput(
+      {
+        version: 1,
+        builtinsCount: kinds.length - extensionsCount,
+        extensionsCount,
+        kinds,
+        ...(counts ? { counts } : {}),
+        ...(configError ? { configError } : {}),
+      },
+      { command: 'docs schema', operation: 'docs.schema' },
+    );
+  },
+});
+
+// ── cleo docs list-types ─────────────────────────────────────────────────────
+
+/**
+ * `cleo docs list-types` — human-readable table of every registered kind.
+ *
+ * Columns: kind, label, count (when `--counts`), requiresEntityId, publishDir.
+ * In JSON mode emits a LAFS envelope mirroring the table's rows.
+ *
+ * @task T9788
+ */
+const listTypesCommand = defineCommand({
+  meta: {
+    name: 'list-types',
+    description:
+      'List every registered doc kind with its label, publish directory, and ' +
+      'slug-pattern requirement. Use --counts to include per-kind attachment counts ' +
+      'from the project SSoT (T9788).',
+  },
+  args: {
+    counts: {
+      type: 'boolean',
+      description: 'Include per-kind attachment counts from the project SSoT',
+    },
+  },
+  async run({ args }) {
+    const projectRoot = getProjectRoot();
+    const { registry, configError } = loadCliRegistry(projectRoot);
+    const kinds = registry.list().map(toWireKind);
+
+    let counts: Record<string, number> | undefined;
+    if (args.counts) {
+      counts = {};
+      const { createAttachmentStore } = await import('@cleocode/core/internal');
+      const store = createAttachmentStore();
+      for (const k of kinds) counts[k.kind] = 0;
+      try {
+        const rows = await store.listAllInProject(projectRoot);
+        for (const row of rows) {
+          const key = row.type;
+          if (key && key in counts) counts[key] = (counts[key] ?? 0) + 1;
+        }
+      } catch {
+        // SSoT not initialised — leave the zero-filled counts in place.
+      }
+    }
+
+    const rows = kinds.map((k) => ({
+      kind: k.kind,
+      label: k.label,
+      ...(counts ? { count: counts[k.kind] ?? 0 } : {}),
+      requiresEntityId: k.requiresEntityId,
+      publishDir: k.publishDir,
+      isExtension: k.isExtension,
+    }));
+
+    cliOutput(
+      {
+        version: 1,
+        total: rows.length,
+        rows,
+        ...(configError ? { configError } : {}),
+      },
+      {
+        command: 'docs list-types',
+        operation: 'docs.list-types',
+        message: configError ? `loaded built-ins only — ${configError.message}` : undefined,
+      },
+    );
+  },
+});
+
 /**
  * Root docs command group — attachment management, llmtxt primitives, drift detection,
  * and git⇄llmtxt round-trip (publish/sync/status) per Saga T9625 / Epic T9626.
  *
  * Subcommands: add, list, fetch, remove, generate, export,
  *              search, merge, graph, rank, versions, publish,
- *              sync, status, gap-check, import.
+ *              sync, status, gap-check, import, schema, list-types.
  */
 export const docsCommand = defineCommand({
   meta: {
@@ -1363,6 +1567,9 @@ export const docsCommand = defineCommand({
     status: statusCommand,
     'gap-check': gapCheckCommand,
     import: importCommand,
+    // T9788 — canonical doc-kind taxonomy discovery surface.
+    schema: schemaCommand,
+    'list-types': listTypesCommand,
     ...docsViewerSubcommands,
   },
   async run({ cmd, rawArgs }) {

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -30,6 +30,7 @@
 
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { DocKindRegistry } from '@cleocode/contracts';
 import type {
   DocsAddParams,
   DocsAddResult,
@@ -66,24 +67,48 @@ import { handleErrorResult, unsupportedOp } from './_base.js';
 import { dispatchMeta } from './_meta.js';
 
 /**
- * Local copy of the closed taxonomy values for runtime validation.
+ * Canonical doc-kind registry — single source of truth for the user-facing
+ * taxonomy (built-ins + `.cleo/docs-config.json` extensions).
  *
- * Kept in lock-step with `DOCS_TYPE_VALUES` exported from
- * `@cleocode/contracts/operations/docs` — the contracts module is the
- * authoritative SSoT; this constant exists only because the test runner's
- * alias map doesn't resolve subpath runtime imports for `@cleocode/contracts`,
- * forcing the dispatch layer to keep a local mirror.
+ * Loaded lazily so we pick up extensions on every CLI invocation without
+ * paying the cost up-front during module init. Resolution caches the
+ * registry per `projectRoot` so repeated calls within one CLI run are free.
  *
- * @task T9637
+ * @task T9788 (E-DOCS-TAXONOMY-V2)
  */
-const DOCS_TYPE_VALUES = [
-  'spec',
-  'adr',
-  'research',
-  'handoff',
-  'note',
-  'llm-readme',
-] as const satisfies readonly DocsType[];
+const _registryCache = new Map<string, DocKindRegistry>();
+
+function getDocKindRegistry(): DocKindRegistry {
+  const root = getProjectRoot();
+  const cached = _registryCache.get(root);
+  if (cached) return cached;
+  try {
+    const registry = DocKindRegistry.load(root);
+    _registryCache.set(root, registry);
+    return registry;
+  } catch {
+    // Malformed config falls back to built-ins so a single bad file
+    // never breaks `cleo docs *` entirely. The schema CLI surfaces
+    // the parse error separately so operators can fix it.
+    const fallback = DocKindRegistry.builtinOnly();
+    _registryCache.set(root, fallback);
+    return fallback;
+  }
+}
+
+/**
+ * Snapshot of registered kind names for runtime validation.
+ *
+ * Includes both built-ins and project-level extensions. Recomputed once
+ * per registry load (cache invalidates with the registry itself).
+ *
+ * @task T9788
+ */
+function registeredKindValues(): readonly string[] {
+  return getDocKindRegistry()
+    .list()
+    .map((d) => d.kind);
+}
 
 // ─── DocsTypedOps ─────────────────────────────────────────────────────────────
 
@@ -206,12 +231,32 @@ function validateSlug(raw: unknown): { valid: false; reason: string } | { valid:
 }
 
 /**
- * Validate a type value against the closed {@link DOCS_TYPE_VALUES} set.
+ * Validate a type value against the canonical {@link DocKindRegistry}.
+ *
+ * As of T9788 accepts every registered kind — built-in OR project-level
+ * extension — so a custom kind declared in `.cleo/docs-config.json`
+ * (e.g. `incident`) works seamlessly with `cleo docs add --type incident`.
+ *
+ * The type guard still narrows to {@link DocsType} (the built-in union)
+ * because extensions cannot widen a compile-time union; runtime callers
+ * that hit an extension kind get the runtime acceptance plus a stored
+ * string field that downstream consumers read as a plain string.
  *
  * @task T9637
+ * @task T9788
  */
 function validateDocsType(raw: unknown): raw is DocsType {
-  return typeof raw === 'string' && (DOCS_TYPE_VALUES as readonly string[]).includes(raw as string);
+  if (typeof raw !== 'string') return false;
+  return getDocKindRegistry().has(raw);
+}
+
+/**
+ * Build the human-readable list of registered kinds for error messages.
+ *
+ * @task T9788
+ */
+function registeredKindList(): string {
+  return registeredKindValues().join('|');
 }
 
 // ─── Typed inner handler ──────────────────────────────────────────────────────
@@ -250,7 +295,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       if (!validateDocsType(params.type)) {
         return lafsError(
           'E_INVALID_TYPE',
-          `type must be one of: ${DOCS_TYPE_VALUES.join('|')} — got '${String(params.type)}'`,
+          `type must be one of: ${registeredKindList()} — got '${String(params.type)}'`,
           'list',
         );
       }
@@ -613,11 +658,24 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       if (!validateDocsType(rawType)) {
         return lafsError(
           'E_INVALID_TYPE',
-          `type must be one of: ${DOCS_TYPE_VALUES.join('|')} — got '${String(rawType)}'`,
+          `type must be one of: ${registeredKindList()} — got '${String(rawType)}'`,
           'add',
         );
       }
       type = rawType;
+    }
+
+    // T9788 — when the registered kind requires an entityId, enforce the
+    // kind's slug pattern on top of the shape check above. We accept a
+    // missing slug (the store will assign one) but reject mismatches
+    // with `E_SLUG_PATTERN_MISMATCH` + an example so the operator can fix
+    // the input on retry.
+    if (type !== undefined && slug !== undefined) {
+      const patternCheck = getDocKindRegistry().validateSlug(type, slug);
+      if (!patternCheck.ok) {
+        const exampleHint = patternCheck.example ? ` (example: ${patternCheck.example})` : '';
+        return lafsError('E_SLUG_PATTERN_MISMATCH', `${patternCheck.error}${exampleHint}`, 'add');
+      }
     }
 
     const extras: { slug?: string; type?: string } = {};

--- a/packages/contracts/src/__tests__/docs-taxonomy.test.ts
+++ b/packages/contracts/src/__tests__/docs-taxonomy.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Tests for the canonical doc-kind taxonomy registry (T9788).
+ *
+ * Covers:
+ *  - Built-in registry shape (every kind has the required metadata)
+ *  - Backward-compatible enumeration (the 6 prior kinds still resolve)
+ *  - Extension load — happy-path
+ *  - Extension load — every invalid-config branch
+ *  - validateSlug pass/fail for each `requiresEntityId` kind
+ *  - validateSlug semantics for kinds without an entityIdPattern
+ *
+ * @epic T9787
+ * @task T9788
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  BUILTIN_DOC_KIND_VALUES,
+  BUILTIN_DOC_KINDS,
+  DocKindConfigError,
+  DocKindRegistry,
+} from '../docs-taxonomy.js';
+
+/** Build a throwaway project root with a `.cleo/` dir for config-file tests. */
+function newProjectRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'docs-taxonomy-test-'));
+  mkdirSync(join(root, '.cleo'), { recursive: true });
+  return root;
+}
+
+/** Convenience — write a `.cleo/docs-config.json` to a project root. */
+function writeConfig(root: string, body: unknown): void {
+  writeFileSync(join(root, '.cleo', 'docs-config.json'), JSON.stringify(body), 'utf-8');
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// BUILTIN_DOC_KINDS shape
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('BUILTIN_DOC_KINDS — registry shape', () => {
+  it('declares every built-in kind once with kebab-case ids', () => {
+    const seen = new Set<string>();
+    for (const meta of BUILTIN_DOC_KINDS) {
+      expect(meta.kind).toMatch(/^[a-z][a-z0-9-]*$/);
+      expect(seen.has(meta.kind)).toBe(false);
+      seen.add(meta.kind);
+    }
+    expect(seen.size).toBe(BUILTIN_DOC_KINDS.length);
+  });
+
+  it('attaches an entityIdPattern to every requiresEntityId entry', () => {
+    for (const meta of BUILTIN_DOC_KINDS) {
+      if (meta.requiresEntityId) {
+        expect(meta.entityIdPattern).toBeInstanceOf(RegExp);
+      }
+    }
+  });
+
+  it('exposes every label, description, publishDir, and defaultOwnerKind', () => {
+    for (const meta of BUILTIN_DOC_KINDS) {
+      expect(meta.label.length).toBeGreaterThan(0);
+      expect(meta.description.length).toBeGreaterThan(0);
+      expect(meta.publishDir.length).toBeGreaterThan(0);
+      expect(['task', 'session', 'observation', 'project']).toContain(meta.defaultOwnerKind);
+    }
+  });
+
+  it('preserves backward compatibility with the prior 6-kind DOCS_TYPE_VALUES', () => {
+    // The original closed set of kinds must remain registered so existing
+    // CLI flags and stored attachments keep working.
+    const legacyKinds = ['adr', 'spec', 'research', 'handoff', 'note', 'llm-readme'];
+    for (const kind of legacyKinds) {
+      expect(BUILTIN_DOC_KIND_VALUES).toContain(kind);
+    }
+  });
+
+  it('introduces the four new kinds defined by the T9788 spec', () => {
+    for (const kind of ['changeset', 'release-note', 'plan', 'rcasd']) {
+      expect(BUILTIN_DOC_KIND_VALUES).toContain(kind);
+    }
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// DocKindRegistry.load — built-ins only (no config file)
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('DocKindRegistry.load — built-ins only', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = newProjectRoot();
+  });
+
+  it('returns every built-in kind when no config file exists', () => {
+    const registry = DocKindRegistry.load(root);
+    const kinds = registry.list().map((d) => d.kind);
+    expect(kinds).toEqual(BUILTIN_DOC_KIND_VALUES);
+  });
+
+  it('reports has() correctly for built-ins and rejects unknowns', () => {
+    const registry = DocKindRegistry.load(root);
+    expect(registry.has('adr')).toBe(true);
+    expect(registry.has('rcasd')).toBe(true);
+    expect(registry.has('wishlist')).toBe(false);
+    expect(registry.has('')).toBe(false);
+  });
+
+  it('publishDirFor returns the registry-declared dir for every built-in', () => {
+    const registry = DocKindRegistry.load(root);
+    expect(registry.publishDirFor('adr')).toBe('docs/adr');
+    expect(registry.publishDirFor('changeset')).toBe('.changeset');
+    expect(registry.publishDirFor('rcasd')).toBe('.cleo/rcasd');
+    expect(registry.publishDirFor('llm-readme')).toBe('.');
+  });
+
+  it('publishDirFor returns undefined for unknown kinds', () => {
+    const registry = DocKindRegistry.load(root);
+    expect(registry.publishDirFor('wishlist')).toBeUndefined();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// DocKindRegistry.load — with extensions
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('DocKindRegistry.load — with valid extensions', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = newProjectRoot();
+  });
+
+  it('appends extension kinds after the built-ins', () => {
+    writeConfig(root, {
+      extensions: [
+        {
+          kind: 'incident',
+          label: 'Incident',
+          description: 'Post-mortem record',
+          defaultOwnerKind: 'task',
+          publishDir: 'docs/incident',
+          requiresEntityId: true,
+          entityIdPattern: '^inc-\\d{4}-\\d{2}-\\d{2}-[a-z0-9-]+$',
+        },
+      ],
+    });
+
+    const registry = DocKindRegistry.load(root);
+    const kinds = registry.list();
+    expect(kinds.length).toBe(BUILTIN_DOC_KINDS.length + 1);
+    expect(kinds[kinds.length - 1].kind).toBe('incident');
+    expect(kinds[kinds.length - 1].isExtension).toBe(true);
+    expect(kinds[kinds.length - 1].entityIdPattern).toBeInstanceOf(RegExp);
+  });
+
+  it('marks extensions with isExtension=true and leaves built-ins untouched', () => {
+    writeConfig(root, {
+      extensions: [
+        {
+          kind: 'retro',
+          label: 'Retro',
+          description: 'Retrospective note',
+          defaultOwnerKind: 'session',
+          publishDir: 'docs/retro',
+          requiresEntityId: false,
+        },
+      ],
+    });
+
+    const registry = DocKindRegistry.load(root);
+    const builtin = registry.get('adr');
+    const ext = registry.get('retro');
+    expect(builtin?.isExtension).toBeUndefined();
+    expect(ext?.isExtension).toBe(true);
+  });
+
+  it('rejects an extension that shadows a built-in kind', () => {
+    writeConfig(root, {
+      extensions: [
+        {
+          kind: 'adr',
+          label: 'CUSTOM ADR',
+          description: 'shadow attempt',
+          defaultOwnerKind: 'task',
+          publishDir: 'docs/custom-adr',
+          requiresEntityId: false,
+        },
+      ],
+    });
+
+    expect(() => DocKindRegistry.load(root)).toThrow(DocKindConfigError);
+  });
+
+  it('supports an empty extensions array', () => {
+    writeConfig(root, { extensions: [] });
+    const registry = DocKindRegistry.load(root);
+    expect(registry.list().length).toBe(BUILTIN_DOC_KINDS.length);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// DocKindRegistry.load — invalid configs
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('DocKindRegistry.load — invalid configs', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = newProjectRoot();
+  });
+
+  it('throws DocKindConfigError on invalid JSON', () => {
+    writeFileSync(join(root, '.cleo', 'docs-config.json'), '{ not json', 'utf-8');
+    expect(() => DocKindRegistry.load(root)).toThrow(DocKindConfigError);
+  });
+
+  it('throws when the top-level value is an array', () => {
+    writeFileSync(join(root, '.cleo', 'docs-config.json'), '[]', 'utf-8');
+    expect(() => DocKindRegistry.load(root)).toThrow(/must be an object/);
+  });
+
+  it('throws when extensions is not an array', () => {
+    writeConfig(root, { extensions: { kind: 'x' } });
+    expect(() => DocKindRegistry.load(root)).toThrow(/'extensions' must be an array/);
+  });
+
+  it('throws when an extension entry is missing required fields', () => {
+    writeConfig(root, {
+      extensions: [{ kind: 'incident', label: 'I' /* missing description, etc. */ }],
+    });
+    expect(() => DocKindRegistry.load(root)).toThrow(DocKindConfigError);
+  });
+
+  it('throws when kind is not kebab-case', () => {
+    writeConfig(root, {
+      extensions: [
+        {
+          kind: 'BadKind',
+          label: 'X',
+          description: 'Y',
+          defaultOwnerKind: 'task',
+          publishDir: 'docs/x',
+          requiresEntityId: false,
+        },
+      ],
+    });
+    expect(() => DocKindRegistry.load(root)).toThrow(/lowercase kebab-case/);
+  });
+
+  it('throws when defaultOwnerKind is unsupported', () => {
+    writeConfig(root, {
+      extensions: [
+        {
+          kind: 'incident',
+          label: 'I',
+          description: 'd',
+          defaultOwnerKind: 'mystery',
+          publishDir: 'docs/incident',
+          requiresEntityId: false,
+        },
+      ],
+    });
+    expect(() => DocKindRegistry.load(root)).toThrow(/defaultOwnerKind/);
+  });
+
+  it('throws when requiresEntityId=true but entityIdPattern is missing', () => {
+    writeConfig(root, {
+      extensions: [
+        {
+          kind: 'incident',
+          label: 'I',
+          description: 'd',
+          defaultOwnerKind: 'task',
+          publishDir: 'docs/i',
+          requiresEntityId: true,
+        },
+      ],
+    });
+    expect(() => DocKindRegistry.load(root)).toThrow(/entityIdPattern.*required/);
+  });
+
+  it('throws when entityIdPattern is malformed regex', () => {
+    writeConfig(root, {
+      extensions: [
+        {
+          kind: 'incident',
+          label: 'I',
+          description: 'd',
+          defaultOwnerKind: 'task',
+          publishDir: 'docs/i',
+          requiresEntityId: true,
+          entityIdPattern: '[oops',
+        },
+      ],
+    });
+    expect(() => DocKindRegistry.load(root)).toThrow(/invalid regex/);
+  });
+
+  it('throws when entityIdPattern exceeds the safe length limit', () => {
+    const huge = 'a'.repeat(DocKindRegistry.SAFE_REGEX_LENGTH_LIMIT + 1);
+    writeConfig(root, {
+      extensions: [
+        {
+          kind: 'incident',
+          label: 'I',
+          description: 'd',
+          defaultOwnerKind: 'task',
+          publishDir: 'docs/i',
+          requiresEntityId: true,
+          entityIdPattern: huge,
+        },
+      ],
+    });
+    expect(() => DocKindRegistry.load(root)).toThrow(/exceeds/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// DocKindRegistry.builtinOnly + fromConfig
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('DocKindRegistry.builtinOnly / fromConfig', () => {
+  it('builtinOnly returns exactly the built-ins regardless of disk state', () => {
+    const registry = DocKindRegistry.builtinOnly();
+    expect(registry.list().length).toBe(BUILTIN_DOC_KINDS.length);
+    expect(registry.list().every((d) => d.isExtension !== true)).toBe(true);
+  });
+
+  it('fromConfig(undefined) is equivalent to builtinOnly', () => {
+    const a = DocKindRegistry.fromConfig(undefined);
+    const b = DocKindRegistry.builtinOnly();
+    expect(a.list().map((d) => d.kind)).toEqual(b.list().map((d) => d.kind));
+  });
+
+  it('fromConfig merges extensions like load() does', () => {
+    const registry = DocKindRegistry.fromConfig({
+      extensions: [
+        {
+          kind: 'incident',
+          label: 'Incident',
+          description: 'Post-mortem',
+          defaultOwnerKind: 'task',
+          publishDir: 'docs/incident',
+          requiresEntityId: false,
+        },
+      ],
+    });
+    expect(registry.has('incident')).toBe(true);
+    expect(registry.get('incident')?.isExtension).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// DocKindRegistry.validateSlug
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('DocKindRegistry.validateSlug', () => {
+  const registry = DocKindRegistry.builtinOnly();
+
+  it('returns ok=true for kinds without requiresEntityId', () => {
+    expect(registry.validateSlug('spec', 'anything-here').ok).toBe(true);
+    expect(registry.validateSlug('note', 'free-form-1').ok).toBe(true);
+    expect(registry.validateSlug('plan', '').ok).toBe(true);
+  });
+
+  it('accepts conforming slugs for ADR (adr-NNN-<rest>)', () => {
+    expect(registry.validateSlug('adr', 'adr-001-intro').ok).toBe(true);
+    expect(registry.validateSlug('adr', 'adr-9999-complex-rationale').ok).toBe(true);
+  });
+
+  it('rejects non-conforming ADR slugs with an example hint', () => {
+    const result = registry.validateSlug('adr', 'random-name');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('does not match');
+      expect(result.example).toBe('adr-001-intro');
+    }
+  });
+
+  it('accepts conforming changeset slugs (t####-<rest>)', () => {
+    expect(registry.validateSlug('changeset', 't9788-docs-taxonomy').ok).toBe(true);
+    expect(registry.validateSlug('changeset', 't1-x').ok).toBe(true);
+  });
+
+  it('rejects malformed changeset slugs', () => {
+    expect(registry.validateSlug('changeset', 'release-notes').ok).toBe(false);
+    expect(registry.validateSlug('changeset', 'T9788-UPPERCASE').ok).toBe(false);
+  });
+
+  it('accepts conforming release-note slugs (v####.MM.N)', () => {
+    expect(registry.validateSlug('release-note', 'v2026.5.93').ok).toBe(true);
+    expect(registry.validateSlug('release-note', 'v2026.12.99-rc1').ok).toBe(true);
+  });
+
+  it('rejects malformed release-note slugs', () => {
+    expect(registry.validateSlug('release-note', '2026.5.93').ok).toBe(false);
+    expect(registry.validateSlug('release-note', 'v1.2').ok).toBe(false);
+  });
+
+  it('accepts conforming rcasd slugs (t#### or t####-<rest>)', () => {
+    expect(registry.validateSlug('rcasd', 't9788').ok).toBe(true);
+    expect(registry.validateSlug('rcasd', 't9788-investigation').ok).toBe(true);
+  });
+
+  it('reports unknown kinds with a useful error', () => {
+    const result = registry.validateSlug('wishlist', 'anything');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("unknown kind 'wishlist'");
+    }
+  });
+
+  it('reports the defensive branch when entityIdPattern is missing on a require-entity entry', () => {
+    // Construct a hand-crafted registry that bypasses the load-time guard.
+    const broken = new DocKindRegistry([
+      {
+        kind: 'broken',
+        label: 'Broken',
+        description: 'pattern intentionally omitted',
+        defaultOwnerKind: 'task',
+        publishDir: 'docs/broken',
+        requiresEntityId: true,
+        // entityIdPattern intentionally omitted to exercise the defensive
+        // branch in validateSlug.
+      },
+    ]);
+    const result = broken.validateSlug('broken', 'anything');
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// DocKindRegistry.get / has — extension precedence
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('DocKindRegistry — built-ins beat extensions on collision', () => {
+  it('first-write-wins semantics keep built-ins authoritative', () => {
+    // The constructor uses first-write-wins; load() always passes builtins
+    // first. This test exercises the constructor directly so any future
+    // refactor can't regress the invariant silently.
+    const registry = new DocKindRegistry([
+      ...BUILTIN_DOC_KINDS,
+      {
+        kind: 'adr',
+        label: 'shadow attempt',
+        description: 'should never win',
+        defaultOwnerKind: 'project',
+        publishDir: 'docs/SHADOW',
+        requiresEntityId: false,
+        isExtension: true,
+      },
+    ]);
+    const meta = registry.get('adr');
+    expect(meta?.label).toBe('ADR');
+    expect(meta?.publishDir).toBe('docs/adr');
+  });
+});
+
+// keep one afterEach stub so vitest reports the suite cleanly even when
+// tests share root state under the OS temp dir.
+afterEach(() => {});

--- a/packages/contracts/src/docs-taxonomy.ts
+++ b/packages/contracts/src/docs-taxonomy.ts
@@ -1,0 +1,682 @@
+/**
+ * Canonical Doc-Kind Taxonomy Registry (T9788).
+ *
+ * Single source of truth for the user-facing document-kind taxonomy consumed
+ * by `cleo docs` (add / list / publish-pr / list-types / schema). Prior to
+ * this module the taxonomy was duplicated across three files:
+ *
+ * - `packages/contracts/src/operations/docs.ts` — `DOCS_TYPE_VALUES` (6 kinds)
+ * - `packages/core/src/docs/publish-pr.ts` — `KNOWN_DOC_TYPES` (6 kinds)
+ * - `packages/cleo/src/dispatch/domains/docs.ts` — local mirror (6 kinds)
+ *
+ * The three copies drifted independently. T9788 consolidates them behind
+ * {@link DocKindRegistry} so a new kind requires editing exactly one place
+ * (or one config file for project-level extensions).
+ *
+ * IMPORTANT — relationship to {@link import('./docs-accessor.js').DocKind}:
+ * `DocKind` in `docs-accessor.ts` is the STORAGE-LAYER discriminator (which
+ * backing store holds the bytes — llmtxt.db vs manifest.db). The taxonomy
+ * here is the USER-FACING DOCUMENT CLASSIFICATION (what kind of document
+ * the human / agent authored). The two are intentionally distinct:
+ *
+ * - `docs-accessor.DocKind` answers "where is it stored?"
+ * - `docs-taxonomy.DocKindMetadata.kind` answers "what is it about?"
+ *
+ * Most user-facing docs are stored under `docs-accessor.DocKind = 'adr'` or
+ * `'agent-output'`; their taxonomy `kind` (this file) carries the semantic
+ * classification.
+ *
+ * Backward compatibility (T9788 AC8):
+ * - Every prior `DOCS_TYPE_VALUES` value remains in {@link BUILTIN_DOC_KINDS}.
+ * - Tests using literal strings `'spec'`, `'adr'`, etc. continue to pass.
+ * - The stored `type` column shape is unchanged (still a string).
+ *
+ * @epic T9787 (E-DOCS-TAXONOMY-V2)
+ * @task T9788
+ * @see ADR-073 §1 — Task Hierarchy Charter (sibling registry pattern)
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Core taxonomy metadata interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Metadata for a single document kind in the canonical registry.
+ *
+ * Built-in kinds are declared in {@link BUILTIN_DOC_KINDS}; project-level
+ * extensions are loaded from `.cleo/docs-config.json` via
+ * {@link DocKindRegistry.load}.
+ *
+ * @see {@link DocKindRegistry} — runtime accessor and validator
+ */
+export interface DocKindMetadata {
+  /** Canonical kind id, lowercase kebab-case. */
+  readonly kind: string;
+  /** Human label for display in CLI output and UIs. */
+  readonly label: string;
+  /** One-line description shown by `cleo docs list-types`. */
+  readonly description: string;
+  /**
+   * Default owner kind prefix when no explicit owner is provided.
+   *
+   * - `task` — `T###`
+   * - `session` — `ses_*`
+   * - `observation` — `O-*`
+   * - `project` — repo-root project doc (no entity owner)
+   */
+  readonly defaultOwnerKind: 'task' | 'session' | 'observation' | 'project';
+  /**
+   * Publish-dir under the repo root for `cleo docs publish-pr`.
+   *
+   * Examples: `docs/adr`, `docs/spec`, `.changeset`, `docs/release`.
+   */
+  readonly publishDir: string;
+  /**
+   * When `true`, every doc of this kind MUST carry a slug matching
+   * {@link entityIdPattern}.
+   *
+   * Used by `cleo docs add --type X --slug Y` to enforce naming
+   * conventions for kinds whose downstream consumers parse the slug
+   * (e.g. ADRs expect `adr-NNN-<rest>`).
+   */
+  readonly requiresEntityId: boolean;
+  /**
+   * Regex slug pattern. Validated when {@link requiresEntityId} is `true`.
+   *
+   * Stored as a {@link RegExp} so the validator can run without a
+   * compile step. Extensions loaded from `.cleo/docs-config.json` parse
+   * their string pattern into a `RegExp` at load time.
+   */
+  readonly entityIdPattern?: RegExp;
+  /**
+   * Marks an entry that was loaded from `.cleo/docs-config.json` rather
+   * than the built-in {@link BUILTIN_DOC_KINDS} array.
+   *
+   * Built-in kinds leave this unset; extensions set it to `true`.
+   */
+  readonly isExtension?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Built-in registry (10 canonical kinds)
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical list of built-in document kinds.
+ *
+ * Adding a kind requires:
+ *   1. Append an entry here (preserving existing kinds for back-compat).
+ *   2. Run the contracts build — every consumer picks the new kind up.
+ *
+ * Order is preserved by {@link DocKindRegistry.list}. Built-in kinds
+ * always sort before extensions.
+ *
+ * @see {@link DocKindMetadata} — entry shape
+ */
+export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
+  {
+    kind: 'adr',
+    label: 'ADR',
+    description: 'Architectural decision record',
+    defaultOwnerKind: 'task',
+    publishDir: 'docs/adr',
+    requiresEntityId: true,
+    entityIdPattern: /^adr-\d{3,4}-[a-z0-9-]+$/,
+  },
+  {
+    kind: 'spec',
+    label: 'Spec',
+    description: 'Technical specification',
+    defaultOwnerKind: 'task',
+    publishDir: 'docs/spec',
+    requiresEntityId: false,
+  },
+  {
+    kind: 'research',
+    label: 'Research',
+    description: 'Investigation / research note',
+    defaultOwnerKind: 'task',
+    publishDir: 'docs/research',
+    requiresEntityId: false,
+  },
+  {
+    kind: 'handoff',
+    label: 'Handoff',
+    description: 'Session / agent handoff',
+    defaultOwnerKind: 'session',
+    publishDir: 'docs/handoff',
+    requiresEntityId: false,
+  },
+  {
+    kind: 'note',
+    label: 'Note',
+    description: 'Agent observation / informal note',
+    defaultOwnerKind: 'observation',
+    publishDir: 'docs/note',
+    requiresEntityId: false,
+  },
+  {
+    kind: 'llm-readme',
+    label: 'LLM README',
+    description: 'Machine-readable README (llms.txt)',
+    defaultOwnerKind: 'project',
+    publishDir: '.',
+    requiresEntityId: false,
+  },
+  {
+    kind: 'changeset',
+    label: 'Changeset',
+    description: 'Atomic change entry (release-note input)',
+    defaultOwnerKind: 'task',
+    publishDir: '.changeset',
+    requiresEntityId: true,
+    entityIdPattern: /^t\d+-[a-z0-9-]+$/,
+  },
+  {
+    kind: 'release-note',
+    label: 'Release Note',
+    description: 'Composed release notes',
+    defaultOwnerKind: 'project',
+    publishDir: 'docs/release',
+    requiresEntityId: true,
+    entityIdPattern: /^v\d{4}\.\d+\.\d+(-[a-z0-9-]+)?$/,
+  },
+  {
+    kind: 'plan',
+    label: 'Plan',
+    description: 'Epic / saga decomposition plan',
+    defaultOwnerKind: 'task',
+    publishDir: 'docs/plan',
+    requiresEntityId: false,
+  },
+  {
+    kind: 'rcasd',
+    label: 'RCASD',
+    description: 'Root-cause analysis + scoped delivery',
+    defaultOwnerKind: 'task',
+    publishDir: '.cleo/rcasd',
+    requiresEntityId: true,
+    entityIdPattern: /^t\d+(-.+)?$/,
+  },
+];
+
+/**
+ * Tuple of every built-in kind id (lowercase kebab-case).
+ *
+ * Useful for `satisfies` checks and union derivation in downstream
+ * contracts (e.g. `operations/docs.ts`). Kept frozen.
+ */
+export const BUILTIN_DOC_KIND_VALUES: ReadonlyArray<string> = Object.freeze(
+  BUILTIN_DOC_KINDS.map((d) => d.kind),
+);
+
+/**
+ * Union of every built-in kind id.
+ *
+ * Extensions loaded at runtime widen the runtime registry but NOT this
+ * compile-time type — that is intentional: extensions are opt-in and
+ * code that only handles the built-in surface stays type-safe.
+ */
+export type BuiltinDocKind = (typeof BUILTIN_DOC_KINDS)[number]['kind'];
+
+// ---------------------------------------------------------------------------
+// Extension config schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire shape of an extension entry in `.cleo/docs-config.json`.
+ *
+ * `entityIdPattern` is a string here (not a {@link RegExp}) because JSON
+ * cannot carry compiled regexes. {@link DocKindRegistry.load} compiles it
+ * to a `RegExp` while validating the config.
+ */
+export interface DocKindExtensionConfig {
+  /** Canonical kind id, lowercase kebab-case. */
+  readonly kind: string;
+  /** Human label for display. */
+  readonly label: string;
+  /** One-line description for `cleo docs list-types`. */
+  readonly description: string;
+  /** Default owner kind prefix. */
+  readonly defaultOwnerKind: 'task' | 'session' | 'observation' | 'project';
+  /** Publish-dir under repo root. */
+  readonly publishDir: string;
+  /** When `true`, slug MUST match {@link entityIdPattern}. */
+  readonly requiresEntityId: boolean;
+  /**
+   * Regex source string (no flags). Compiled to a `RegExp` at load time.
+   *
+   * Validated against {@link DocKindRegistry.SAFE_REGEX_LENGTH_LIMIT} so
+   * a malformed config can't trigger pathological backtracking.
+   */
+  readonly entityIdPattern?: string;
+}
+
+/**
+ * Top-level shape of `.cleo/docs-config.json`.
+ *
+ * Future fields stay backward compatible by being optional.
+ */
+export interface DocKindConfigFile {
+  /** Project-level extension registry. */
+  readonly extensions?: ReadonlyArray<DocKindExtensionConfig>;
+}
+
+// ---------------------------------------------------------------------------
+// Slug validation result type
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of {@link DocKindRegistry.validateSlug}.
+ *
+ * - `ok: true` — slug is valid for the given kind.
+ * - `ok: false` — slug fails validation; `error` carries a human-readable
+ *   reason and `example` shows a passing slug.
+ */
+export type SlugValidationResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error: string; readonly example?: string };
+
+// ---------------------------------------------------------------------------
+// Registry class
+// ---------------------------------------------------------------------------
+
+/**
+ * Runtime accessor for the canonical doc-kind registry.
+ *
+ * Combines {@link BUILTIN_DOC_KINDS} with project-level extensions loaded
+ * from `.cleo/docs-config.json`. Built-in entries always win on collision
+ * — extensions cannot override a built-in kind.
+ *
+ * Usage:
+ * ```ts
+ * const registry = DocKindRegistry.load(projectRoot);
+ * const adr = registry.get('adr');
+ * const check = registry.validateSlug('adr', 'adr-001-intro');
+ * ```
+ *
+ * @task T9788
+ */
+export class DocKindRegistry {
+  /**
+   * Maximum allowed length of an `entityIdPattern` source string.
+   *
+   * Caps the input surface so a malformed extension config cannot trigger
+   * pathological regex backtracking. 256 chars is far more than any
+   * realistic slug pattern (typical: 30–60 chars).
+   */
+  static readonly SAFE_REGEX_LENGTH_LIMIT = 256;
+
+  private readonly byKind: ReadonlyMap<string, DocKindMetadata>;
+  private readonly orderedEntries: ReadonlyArray<DocKindMetadata>;
+
+  /**
+   * Construct a registry from an explicit array of entries.
+   *
+   * Most callers should use {@link DocKindRegistry.load} instead; this
+   * constructor is exposed for tests that want to bypass filesystem I/O.
+   *
+   * @param entries - Pre-validated doc-kind metadata (built-in + extensions).
+   */
+  constructor(entries: ReadonlyArray<DocKindMetadata>) {
+    this.orderedEntries = entries;
+    const map = new Map<string, DocKindMetadata>();
+    for (const entry of entries) {
+      // First write wins; built-ins are passed first by `load`, so this
+      // automatically gives built-ins precedence over extensions.
+      if (!map.has(entry.kind)) map.set(entry.kind, entry);
+    }
+    this.byKind = map;
+  }
+
+  /**
+   * Load the canonical registry, merging built-ins with extensions from
+   * `<projectRoot>/.cleo/docs-config.json`.
+   *
+   * Missing or unreadable config file → returns the built-in-only registry.
+   * Malformed config (bad JSON, invalid entry, regex too long, etc.) →
+   * throws {@link DocKindConfigError} so the caller can surface a clear
+   * envelope rather than silently dropping extensions.
+   *
+   * @param projectRoot - Absolute path to the repo root.
+   * @throws DocKindConfigError when the config exists but is invalid.
+   */
+  static load(projectRoot: string): DocKindRegistry {
+    const configPath = join(projectRoot, '.cleo', 'docs-config.json');
+
+    let raw: string;
+    try {
+      raw = readFileSync(configPath, 'utf-8');
+    } catch {
+      // No config file → built-ins only.
+      return new DocKindRegistry(BUILTIN_DOC_KINDS);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new DocKindConfigError(
+        `${configPath}: invalid JSON — ${(err as Error).message}`,
+        configPath,
+      );
+    }
+
+    const config = validateDocKindConfig(parsed, configPath);
+    const extensions = (config.extensions ?? []).map((ext) => compileExtension(ext, configPath));
+
+    return new DocKindRegistry([...BUILTIN_DOC_KINDS, ...extensions]);
+  }
+
+  /**
+   * Build a registry from already-parsed config — bypasses filesystem I/O.
+   *
+   * Used by tests and HTTP-dispatch callers that hand-construct a config
+   * object instead of reading from disk.
+   *
+   * @param config - Parsed config object (or `undefined` for built-ins only).
+   * @param sourceLabel - Optional label used in error messages.
+   * @throws DocKindConfigError when the config object is invalid.
+   */
+  static fromConfig(
+    config: DocKindConfigFile | undefined,
+    sourceLabel = '<inline-config>',
+  ): DocKindRegistry {
+    if (!config) return new DocKindRegistry(BUILTIN_DOC_KINDS);
+    const validated = validateDocKindConfig(config, sourceLabel);
+    const extensions = (validated.extensions ?? []).map((ext) =>
+      compileExtension(ext, sourceLabel),
+    );
+    return new DocKindRegistry([...BUILTIN_DOC_KINDS, ...extensions]);
+  }
+
+  /**
+   * Default registry — built-in kinds only, no extensions.
+   *
+   * Suitable for code paths that never need project-level extensions
+   * (e.g. unit tests, library-mode consumers).
+   */
+  static builtinOnly(): DocKindRegistry {
+    return new DocKindRegistry(BUILTIN_DOC_KINDS);
+  }
+
+  /** True when `kind` is registered (built-in OR extension). */
+  has(kind: string): boolean {
+    return this.byKind.has(kind);
+  }
+
+  /** Look up metadata for a registered kind. Returns `undefined` on miss. */
+  get(kind: string): DocKindMetadata | undefined {
+    return this.byKind.get(kind);
+  }
+
+  /**
+   * List every registered kind, built-ins first then extensions in
+   * declaration order.
+   *
+   * Used by `cleo docs schema` and `cleo docs list-types`.
+   */
+  list(): ReadonlyArray<DocKindMetadata> {
+    return this.orderedEntries;
+  }
+
+  /**
+   * Validate a slug against the registered pattern for `kind`.
+   *
+   * Behaviour:
+   * - Unknown kind → `{ ok: false, error: "unknown kind '<kind>'" }`.
+   * - Known kind with `requiresEntityId === false` → always `{ ok: true }`.
+   * - Known kind with `requiresEntityId === true` and no pattern → defensive
+   *   `{ ok: false }` since the registry entry is internally inconsistent.
+   * - Known kind with pattern → tests `slug` against the pattern.
+   *
+   * @param kind - Registered kind id.
+   * @param slug - Slug to validate.
+   * @returns Pass/fail result with a human-readable error on failure.
+   */
+  validateSlug(kind: string, slug: string): SlugValidationResult {
+    const meta = this.byKind.get(kind);
+    if (!meta) {
+      return { ok: false, error: `unknown kind '${kind}'` };
+    }
+    if (!meta.requiresEntityId) {
+      return { ok: true };
+    }
+    if (!meta.entityIdPattern) {
+      // Defensive: registry entry marked requiresEntityId but lacks the
+      // pattern. Built-in entries always carry one; an extension that
+      // omits it is rejected at load time, so this branch is reachable
+      // only via the public constructor with a hand-crafted array.
+      return {
+        ok: false,
+        error: `kind '${kind}' requires an entityIdPattern but the registry entry omits one`,
+      };
+    }
+    if (!meta.entityIdPattern.test(slug)) {
+      return {
+        ok: false,
+        error: `slug '${slug}' does not match pattern ${meta.entityIdPattern.source} for kind '${kind}'`,
+        example: buildSlugExample(meta),
+      };
+    }
+    return { ok: true };
+  }
+
+  /**
+   * Map a kind to its `publishDir` (e.g. `'adr'` → `'docs/adr'`).
+   *
+   * Returns `undefined` for unknown kinds — callers decide whether to
+   * fall back to a default (e.g. `'docs/note'`) or surface an error.
+   */
+  publishDirFor(kind: string): string | undefined {
+    return this.byKind.get(kind)?.publishDir;
+  }
+}
+
+/**
+ * Error thrown by {@link DocKindRegistry.load} and
+ * {@link DocKindRegistry.fromConfig} when the supplied config is invalid.
+ *
+ * Carries the offending source path / label so the CLI surface can render
+ * a `details` payload pointing the user at the right file.
+ */
+export class DocKindConfigError extends Error {
+  /** Source identifier — file path on disk, or `<inline-config>` for tests. */
+  readonly source: string;
+
+  constructor(message: string, source: string) {
+    super(message);
+    this.name = 'DocKindConfigError';
+    this.source = source;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config validation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow an arbitrary parsed-JSON value to {@link DocKindConfigFile}.
+ *
+ * Performs structural validation only — regex compilation happens in
+ * {@link compileExtension}.
+ *
+ * @internal
+ */
+function validateDocKindConfig(raw: unknown, source: string): DocKindConfigFile {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new DocKindConfigError(`${source}: top-level value must be an object`, source);
+  }
+  const obj = raw as Record<string, unknown>;
+  if (obj.extensions === undefined) {
+    return {};
+  }
+  if (!Array.isArray(obj.extensions)) {
+    throw new DocKindConfigError(`${source}: 'extensions' must be an array`, source);
+  }
+  const extensions: DocKindExtensionConfig[] = [];
+  for (let i = 0; i < obj.extensions.length; i++) {
+    const item = obj.extensions[i];
+    extensions.push(validateExtensionEntry(item, source, i));
+  }
+  return { extensions };
+}
+
+/**
+ * Narrow one extension entry from the parsed `extensions[]` array.
+ *
+ * @internal
+ */
+function validateExtensionEntry(
+  raw: unknown,
+  source: string,
+  index: number,
+): DocKindExtensionConfig {
+  const where = `${source} extensions[${index}]`;
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new DocKindConfigError(`${where}: must be an object`, source);
+  }
+  const obj = raw as Record<string, unknown>;
+
+  const kind = requireString(obj, 'kind', where, source);
+  if (!/^[a-z][a-z0-9-]*$/.test(kind)) {
+    throw new DocKindConfigError(
+      `${where}: 'kind' must be lowercase kebab-case (got '${kind}')`,
+      source,
+    );
+  }
+  const builtinNames = new Set(BUILTIN_DOC_KIND_VALUES);
+  if (builtinNames.has(kind)) {
+    throw new DocKindConfigError(
+      `${where}: kind '${kind}' shadows a built-in — built-ins cannot be overridden`,
+      source,
+    );
+  }
+  const label = requireString(obj, 'label', where, source);
+  const description = requireString(obj, 'description', where, source);
+  const defaultOwnerKind = requireString(obj, 'defaultOwnerKind', where, source);
+  if (
+    defaultOwnerKind !== 'task' &&
+    defaultOwnerKind !== 'session' &&
+    defaultOwnerKind !== 'observation' &&
+    defaultOwnerKind !== 'project'
+  ) {
+    throw new DocKindConfigError(
+      `${where}: 'defaultOwnerKind' must be task|session|observation|project (got '${defaultOwnerKind}')`,
+      source,
+    );
+  }
+  const publishDir = requireString(obj, 'publishDir', where, source);
+  const requiresEntityId = obj.requiresEntityId;
+  if (typeof requiresEntityId !== 'boolean') {
+    throw new DocKindConfigError(`${where}: 'requiresEntityId' must be a boolean`, source);
+  }
+
+  let entityIdPattern: string | undefined;
+  if (obj.entityIdPattern !== undefined) {
+    if (typeof obj.entityIdPattern !== 'string') {
+      throw new DocKindConfigError(`${where}: 'entityIdPattern' must be a string`, source);
+    }
+    if (obj.entityIdPattern.length > DocKindRegistry.SAFE_REGEX_LENGTH_LIMIT) {
+      throw new DocKindConfigError(
+        `${where}: 'entityIdPattern' exceeds ${DocKindRegistry.SAFE_REGEX_LENGTH_LIMIT} chars`,
+        source,
+      );
+    }
+    entityIdPattern = obj.entityIdPattern;
+  }
+
+  if (requiresEntityId && entityIdPattern === undefined) {
+    throw new DocKindConfigError(
+      `${where}: 'entityIdPattern' is required when 'requiresEntityId' is true`,
+      source,
+    );
+  }
+
+  return {
+    kind,
+    label,
+    description,
+    defaultOwnerKind,
+    publishDir,
+    requiresEntityId,
+    ...(entityIdPattern !== undefined ? { entityIdPattern } : {}),
+  };
+}
+
+/**
+ * Compile an extension config into a `DocKindMetadata` (regex compiled,
+ * `isExtension` set).
+ *
+ * @internal
+ */
+function compileExtension(ext: DocKindExtensionConfig, source: string): DocKindMetadata {
+  let entityIdPattern: RegExp | undefined;
+  if (ext.entityIdPattern !== undefined) {
+    try {
+      entityIdPattern = new RegExp(ext.entityIdPattern);
+    } catch (err) {
+      throw new DocKindConfigError(
+        `${source}: invalid regex for kind '${ext.kind}': ${(err as Error).message}`,
+        source,
+      );
+    }
+  }
+  return {
+    kind: ext.kind,
+    label: ext.label,
+    description: ext.description,
+    defaultOwnerKind: ext.defaultOwnerKind,
+    publishDir: ext.publishDir,
+    requiresEntityId: ext.requiresEntityId,
+    ...(entityIdPattern !== undefined ? { entityIdPattern } : {}),
+    isExtension: true,
+  };
+}
+
+/**
+ * Extract a required string field from a parsed JSON object.
+ *
+ * @internal
+ */
+function requireString(
+  obj: Record<string, unknown>,
+  field: string,
+  where: string,
+  source: string,
+): string {
+  const value = obj[field];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new DocKindConfigError(`${where}: '${field}' must be a non-empty string`, source);
+  }
+  return value;
+}
+
+/**
+ * Build a best-effort example slug from a metadata entry's pattern.
+ *
+ * Used by {@link DocKindRegistry.validateSlug} to give the caller a
+ * concrete sample slug that would pass. Built-in patterns ship with
+ * hard-coded samples; extensions fall back to the pattern source.
+ *
+ * @internal
+ */
+function buildSlugExample(meta: DocKindMetadata): string | undefined {
+  // Hard-coded samples for built-in kinds keep the error message friendly.
+  // Extensions get the raw pattern as a fallback.
+  switch (meta.kind) {
+    case 'adr':
+      return 'adr-001-intro';
+    case 'changeset':
+      return 't9788-docs-taxonomy';
+    case 'release-note':
+      return 'v2026.5.93';
+    case 'rcasd':
+      return 't9788-investigation';
+    default:
+      return meta.entityIdPattern?.source;
+  }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -277,6 +277,20 @@ export type {
   StoreDocParams,
   StoreDocResult,
 } from './docs-accessor.js';
+// === Canonical Doc-Kind Taxonomy Registry (T9788) ===
+export type {
+  BuiltinDocKind,
+  DocKindConfigFile,
+  DocKindExtensionConfig,
+  DocKindMetadata,
+  SlugValidationResult,
+} from './docs-taxonomy.js';
+export {
+  BUILTIN_DOC_KIND_VALUES,
+  BUILTIN_DOC_KINDS,
+  DocKindConfigError,
+  DocKindRegistry,
+} from './docs-taxonomy.js';
 export type {
   EngineErrorPayload,
   EngineFailure,

--- a/packages/contracts/src/operations/docs.ts
+++ b/packages/contracts/src/operations/docs.ts
@@ -29,6 +29,7 @@
  */
 
 import type { AttachmentKind } from '../attachment.js';
+import { BUILTIN_DOC_KIND_VALUES, type BuiltinDocKind } from '../docs-taxonomy.js';
 
 // ============================================================================
 // Shared Attachment Types (API wire format)
@@ -54,28 +55,32 @@ export type { AttachmentKind } from '../attachment.js';
 /**
  * Allowed values for the `--type` taxonomy on `cleo docs add`.
  *
- * The set is closed at the CLI surface; new values require a coordinated
- * update to (1) {@link DOCS_TYPE_VALUES}, (2) the dispatch-layer guard, and
- * (3) the citty CLI flag description. The DB column itself is open (no CHECK)
- * so older clients reading a forward-compatible value gracefully degrade.
+ * As of T9788 this is derived from the canonical {@link BUILTIN_DOC_KIND_VALUES}
+ * in `docs-taxonomy.ts` — adding a kind there automatically widens this set
+ * without a duplicate edit here.
+ *
+ * Project-level extensions registered through `.cleo/docs-config.json` are
+ * NOT included in this constant (they are runtime-only, since the
+ * compile-time union must stay closed). Use {@link DocKindRegistry.list}
+ * to enumerate built-ins plus extensions at runtime.
  *
  * @task T9637 (T-DOCS-SLUG-2)
+ * @task T9788 (E-DOCS-TAXONOMY-V2 — registry consolidation)
  */
-export const DOCS_TYPE_VALUES = [
-  'spec',
-  'adr',
-  'research',
-  'handoff',
-  'note',
-  'llm-readme',
-] as const;
+export const DOCS_TYPE_VALUES: ReadonlyArray<BuiltinDocKind> =
+  BUILTIN_DOC_KIND_VALUES as ReadonlyArray<BuiltinDocKind>;
 
 /**
  * Closed-set type alias for {@link DOCS_TYPE_VALUES}.
  *
+ * As of T9788 this aliases {@link BuiltinDocKind} from the canonical
+ * registry — the union widens automatically when a new built-in kind
+ * is added to {@link BUILTIN_DOC_KINDS}.
+ *
  * @task T9637
+ * @task T9788
  */
-export type DocsType = (typeof DOCS_TYPE_VALUES)[number];
+export type DocsType = BuiltinDocKind;
 
 /**
  * Flattened wire-format attachment row returned by docs query operations.

--- a/packages/core/src/docs/__tests__/publish-pr-registry.test.ts
+++ b/packages/core/src/docs/__tests__/publish-pr-registry.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the publish-pr taxonomy bridge added by T9788.
+ *
+ * `publishDirForType` used to hard-code `docs/<type>` and back its lookup
+ * against an inlined `KNOWN_DOC_TYPES` set. After T9788 both derive from
+ * the canonical {@link DocKindRegistry} — these tests assert the bridge
+ * behaviour without booting the full publish-pr flow.
+ *
+ * Coverage:
+ *  - publishDirForType maps every built-in kind to the registry-declared dir
+ *  - publishDirForType falls back to docs/note for unknown / nullish input
+ *  - knownDocTypesForProject merges built-ins + project extensions
+ *  - knownDocTypesForProject falls back to built-ins when the config is invalid
+ *  - KNOWN_DOC_TYPES (legacy export) still contains every built-in kind id
+ *
+ * @epic T9787
+ * @task T9788
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { BUILTIN_DOC_KINDS } from '@cleocode/contracts';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { KNOWN_DOC_TYPES, knownDocTypesForProject, publishDirForType } from '../publish-pr.js';
+
+/** Build a throwaway project root with a `.cleo/` dir for config-file tests. */
+function newProjectRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'publish-pr-registry-test-'));
+  mkdirSync(join(root, '.cleo'), { recursive: true });
+  return root;
+}
+
+describe('publishDirForType — registry-backed lookup (T9788)', () => {
+  it('maps every built-in kind to the registry-declared dir', () => {
+    for (const meta of BUILTIN_DOC_KINDS) {
+      expect(publishDirForType(meta.kind)).toBe(meta.publishDir);
+    }
+  });
+
+  it('falls back to docs/note for unknown kinds', () => {
+    expect(publishDirForType('wishlist')).toBe('docs/note');
+    expect(publishDirForType('totally-fake-kind-xyz')).toBe('docs/note');
+  });
+
+  it('falls back to docs/note for nullish input', () => {
+    expect(publishDirForType(undefined)).toBe('docs/note');
+    expect(publishDirForType(null)).toBe('docs/note');
+    expect(publishDirForType('')).toBe('docs/note');
+  });
+
+  it('reports the bespoke publish-dir for the four new T9788 kinds', () => {
+    expect(publishDirForType('changeset')).toBe('.changeset');
+    expect(publishDirForType('release-note')).toBe('docs/release');
+    expect(publishDirForType('rcasd')).toBe('.cleo/rcasd');
+    expect(publishDirForType('plan')).toBe('docs/plan');
+  });
+
+  it('picks up project extensions when projectRoot is supplied', () => {
+    const root = newProjectRoot();
+    writeFileSync(
+      join(root, '.cleo', 'docs-config.json'),
+      JSON.stringify({
+        extensions: [
+          {
+            kind: 'incident',
+            label: 'Incident',
+            description: 'Post-mortem',
+            defaultOwnerKind: 'task',
+            publishDir: 'docs/incident',
+            requiresEntityId: false,
+          },
+        ],
+      }),
+      'utf-8',
+    );
+
+    expect(publishDirForType('incident', root)).toBe('docs/incident');
+    // Without projectRoot the same kind falls back since the extension
+    // is invisible to the built-in-only registry.
+    expect(publishDirForType('incident')).toBe('docs/note');
+  });
+
+  it('handles a malformed config without throwing', () => {
+    const root = newProjectRoot();
+    writeFileSync(join(root, '.cleo', 'docs-config.json'), '{ not-json', 'utf-8');
+    // Even with a broken config, every built-in kind continues to resolve.
+    expect(publishDirForType('adr', root)).toBe('docs/adr');
+  });
+});
+
+describe('knownDocTypesForProject — merge built-ins with extensions (T9788)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = newProjectRoot();
+  });
+
+  it('returns every built-in kind when no config file exists', () => {
+    const types = knownDocTypesForProject(root);
+    for (const meta of BUILTIN_DOC_KINDS) {
+      expect(types.has(meta.kind)).toBe(true);
+    }
+  });
+
+  it('merges extensions into the resulting set', () => {
+    writeFileSync(
+      join(root, '.cleo', 'docs-config.json'),
+      JSON.stringify({
+        extensions: [
+          {
+            kind: 'incident',
+            label: 'Incident',
+            description: 'Post-mortem',
+            defaultOwnerKind: 'task',
+            publishDir: 'docs/incident',
+            requiresEntityId: false,
+          },
+        ],
+      }),
+      'utf-8',
+    );
+    const types = knownDocTypesForProject(root);
+    expect(types.has('incident')).toBe(true);
+    expect(types.has('adr')).toBe(true);
+  });
+
+  it('falls back to built-ins-only on malformed config', () => {
+    writeFileSync(join(root, '.cleo', 'docs-config.json'), '{ broken', 'utf-8');
+    const types = knownDocTypesForProject(root);
+    for (const meta of BUILTIN_DOC_KINDS) {
+      expect(types.has(meta.kind)).toBe(true);
+    }
+  });
+});
+
+describe('KNOWN_DOC_TYPES — legacy export still contains every built-in (T9788)', () => {
+  it('contains the prior 6-kind closed set', () => {
+    for (const kind of ['adr', 'spec', 'research', 'handoff', 'note', 'llm-readme']) {
+      expect(KNOWN_DOC_TYPES.has(kind)).toBe(true);
+    }
+  });
+
+  it('also contains the four new T9788 kinds', () => {
+    for (const kind of ['changeset', 'release-note', 'plan', 'rcasd']) {
+      expect(KNOWN_DOC_TYPES.has(kind)).toBe(true);
+    }
+  });
+
+  it('does not contain unknown kinds', () => {
+    expect(KNOWN_DOC_TYPES.has('wishlist')).toBe(false);
+  });
+});

--- a/packages/core/src/docs/index.ts
+++ b/packages/core/src/docs/index.ts
@@ -109,6 +109,7 @@ export {
   defaultRun,
   execMsg,
   KNOWN_DOC_TYPES,
+  knownDocTypesForProject,
   parseGhPrUrl,
   pickRunner,
   provisionPublishPrWorktree,

--- a/packages/core/src/docs/publish-pr.ts
+++ b/packages/core/src/docs/publish-pr.ts
@@ -24,6 +24,7 @@ import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
+import { BUILTIN_DOC_KIND_VALUES, DocKindRegistry } from '@cleocode/contracts';
 
 const execFileAsync = promisify(execFile);
 
@@ -36,18 +37,51 @@ const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 const SLUG_MAX_LEN = 80;
 
 /**
- * Closed taxonomy of doc types — mirrors `DOCS_TYPE_VALUES` in
- * `packages/cleo/src/dispatch/domains/docs.ts`. Used to pick the publish
- * subdir under `docs/<type>/`.
+ * Snapshot of every built-in doc-kind name from the canonical
+ * {@link DocKindRegistry} (T9788).
+ *
+ * Built-in-only — project-level extensions registered through
+ * `.cleo/docs-config.json` are NOT included here. Use
+ * {@link knownDocTypesForProject} when extensions matter (e.g. inside
+ * the publish-pr flow where the project root is known).
+ *
+ * Kept as a {@link Set} for O(1) `has()` checks.
  */
-export const KNOWN_DOC_TYPES = new Set<string>([
-  'spec',
-  'adr',
-  'research',
-  'handoff',
-  'note',
-  'llm-readme',
-]);
+export const KNOWN_DOC_TYPES: ReadonlySet<string> = new Set<string>(BUILTIN_DOC_KIND_VALUES);
+
+/**
+ * Project-aware variant of {@link KNOWN_DOC_TYPES}.
+ *
+ * Loads the per-project registry (built-ins + `.cleo/docs-config.json`
+ * extensions) and returns the union as a {@link Set}. Used by the
+ * publish-pr flow so project-defined kinds (e.g. `incident`) land in the
+ * correct `publishDir` rather than the `docs/note` fallback.
+ *
+ * Safe against malformed configs — falls back to built-ins on load failure.
+ *
+ * @param projectRoot - Absolute repo-root path.
+ * @task T9788
+ */
+export function knownDocTypesForProject(projectRoot: string): ReadonlySet<string> {
+  const registry = loadRegistrySafely(projectRoot);
+  return new Set(registry.list().map((d) => d.kind));
+}
+
+/**
+ * Load the canonical registry, swallowing config errors and falling back
+ * to built-ins so a single malformed `.cleo/docs-config.json` cannot
+ * derail the publish-pr flow.
+ *
+ * @internal
+ * @task T9788
+ */
+function loadRegistrySafely(projectRoot: string): DocKindRegistry {
+  try {
+    return DocKindRegistry.load(projectRoot);
+  } catch {
+    return DocKindRegistry.builtinOnly();
+  }
+}
 
 /**
  * Validate a slug string against {@link SLUG_PATTERN}.
@@ -75,10 +109,27 @@ export function validatePublishSlug(
   return { ok: true, slug: raw };
 }
 
-/** Map a doc type to its publish subdir (defaults to `note` when unknown). */
-export function publishDirForType(type: string | null | undefined): string {
-  if (typeof type === 'string' && KNOWN_DOC_TYPES.has(type)) return `docs/${type}`;
-  return 'docs/note';
+/**
+ * Map a doc type to its publish subdir.
+ *
+ * As of T9788 the lookup is delegated to {@link DocKindRegistry} so the
+ * subdir follows whatever each kind declares (e.g. `changeset → .changeset`,
+ * `release-note → docs/release`, `llm-readme → .`). Unknown types fall back
+ * to `docs/note`, preserving prior behavior.
+ *
+ * When `projectRoot` is provided the lookup includes project-level
+ * extensions registered through `.cleo/docs-config.json`; otherwise it
+ * uses the built-in-only registry.
+ *
+ * @param type - Doc kind id (`adr`, `spec`, `changeset`, …).
+ * @param projectRoot - Optional repo-root path for project-level extensions.
+ * @task T9788
+ */
+export function publishDirForType(type: string | null | undefined, projectRoot?: string): string {
+  if (typeof type !== 'string' || type.length === 0) return 'docs/note';
+  const registry = projectRoot ? loadRegistrySafely(projectRoot) : DocKindRegistry.builtinOnly();
+  const meta = registry.get(type);
+  return meta?.publishDir ?? 'docs/note';
 }
 
 /** Compute the canonical branch name for a slug. */
@@ -598,13 +649,17 @@ export async function publishDocsAsPr(opts: PublishPrOptions): Promise<PublishPr
   const slug = slugCheck.slug;
 
   // 3. Resolve the publish type/dir.
+  // T9788 — use the project-aware known-types set so project extensions
+  // declared in `.cleo/docs-config.json` (e.g. `incident`) participate in
+  // type resolution rather than falling through to `note`.
+  const projectKnownTypes = knownDocTypesForProject(projectRoot);
   const type =
-    opts.type && KNOWN_DOC_TYPES.has(opts.type)
+    opts.type && projectKnownTypes.has(opts.type)
       ? opts.type
-      : resolved.type && KNOWN_DOC_TYPES.has(resolved.type)
+      : resolved.type && projectKnownTypes.has(resolved.type)
         ? resolved.type
         : 'note';
-  const publishDir = publishDirForType(type);
+  const publishDir = publishDirForType(type, projectRoot);
   const branch = branchForSlug(slug);
 
   // 4. Pre-flight gh auth so we fail early before any side effects.

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -216,6 +216,7 @@ export {
   defaultRun,
   execMsg,
   KNOWN_DOC_TYPES,
+  knownDocTypesForProject,
   parseGhPrUrl,
   pickRunner,
   provisionPublishPrWorktree,


### PR DESCRIPTION
## Summary

Consolidates three disconnected doc-kind taxonomies into a single canonical `DocKindRegistry` shipped from `@cleocode/contracts`. Foundational Epic for Saga **T9787** — other epics consume the registry shipped here.

- New `packages/contracts/src/docs-taxonomy.ts` defines `BUILTIN_DOC_KINDS` (10 kinds: adr, spec, research, handoff, note, llm-readme, changeset, release-note, plan, rcasd) + `DocKindRegistry` runtime accessor.
- Migrates the three legacy enums to derive from the registry:
  - `packages/contracts/src/operations/docs.ts` — `DOCS_TYPE_VALUES` / `DocsType` now alias `BUILTIN_DOC_KIND_VALUES` / `BuiltinDocKind`.
  - `packages/core/src/docs/publish-pr.ts` — `KNOWN_DOC_TYPES` set + project-aware `knownDocTypesForProject()`; `publishDirForType()` delegates to the registry.
  - `packages/cleo/src/dispatch/domains/docs.ts` — runtime `validateDocsType()` queries the registry (built-ins + extensions).
- Project-level extensibility via `.cleo/docs-config.json` with structural validation (`DocKindConfigError`), regex-length cap, and built-in-shadowing rejection.
- New `cleo docs schema` + `cleo docs list-types` CLI surfaces emit LAFS envelopes with builtinsCount / extensionsCount / per-kind metadata.
- `cleo docs add --type X --slug Y` now enforces `entityIdPattern` for kinds with `requiresEntityId`, returning `E_SLUG_PATTERN_MISMATCH` plus an example slug.

## Backward Compatibility

- All six prior `DOCS_TYPE_VALUES` remain registered — every existing test/literal-string call site continues to pass.
- `KNOWN_DOC_TYPES` export retained (now derived from the registry).
- One assertion in `docs-publish-pr.test.ts` updated to match the new registry-declared `publishDir` for `llm-readme` (`.` not `docs/llm-readme`) — the change reflects the registry's intentional design for project-root publishing of llms.txt.
- `DocKind` in `docs-accessor.ts` (storage-layer kinds) is intentionally untouched — orthogonal to the user-facing taxonomy added here.

## Test plan

- [x] 36 new tests in `packages/contracts/src/__tests__/docs-taxonomy.test.ts` cover registry shape, extension load (happy-path + every invalid-config branch), slug validation per kind, and built-ins-beat-extensions precedence.
- [x] 12 new tests in `packages/core/src/docs/__tests__/publish-pr-registry.test.ts` cover `publishDirForType` registry routing, `knownDocTypesForProject` extension merging, malformed-config fallback, and `KNOWN_DOC_TYPES` legacy export coverage.
- [x] CLI subcommand registration covered by `packages/cleo/src/cli/__tests__/docs-schema.test.ts`.
- [x] Full contracts suite (284 tests) and core/docs suite (99 tests) pass with zero regressions.
- [x] Biome check + format clean on every modified file.
- [x] Contracts build (`tsc -b --force`) produces `dist/docs-taxonomy.js` + emits the new exports from `index.js`.
- [x] No new TypeScript errors introduced in `packages/cleo` (pre-existing errors in playbook.ts/conduit.ts/etc. unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)