### PR TITLE
fix(T9789): eliminate docs.ts formatError double-wrap (8 sites + lint rule)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,25 @@ jobs:
         # No untrusted input used — pure static analysis of checked-in source files.
         run: node scripts/lint-contracts-dep.mjs
 
+  format-error-misuse-lint:
+    # T9789 / E-DOCS-FORMATERR-FIX — guard against
+    # `cliOutput(formatError(...))` and `cliError(formatError(...))`
+    # double-wrap patterns. `formatError` already produces a serialised
+    # LAFS envelope; nesting it inside `cliOutput`/`cliError` either
+    # fakes success (cliOutput) or replaces the human-readable message
+    # with a JSON blob (cliError). Pure static analysis of checked-in
+    # source — no untrusted input.
+    name: Format-Error Misuse Lint (T9789)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Reject cliOutput(formatError) / cliError(formatError) double-wraps
+        run: node scripts/lint-format-error-misuse.mjs
+
   pragma-drift:
     name: SQLite Pragma Drift Guard (T9025 / T9190)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:changesets": "node scripts/lint-changesets.mjs",
     "lint:cleo-errors": "node scripts/lint-cleo-errors.mjs",
     "lint:contracts-dep": "node scripts/lint-contracts-dep.mjs",
+    "lint:format-error": "node scripts/lint-format-error-misuse.mjs",
     "lint:json-stream": "node scripts/lint-json-stream-hygiene.mjs",
     "lint:raw-cr": "node scripts/lint-no-raw-cr-writes.mjs",
     "bench:nexus": "BENCH_FIXTURE_PATH=packages/nexus/src/__tests__/fixtures node scripts/bench/nexus-vs-gitnexus.mjs",

--- a/packages/cleo/src/cli/__tests__/docs-error-envelopes.test.ts
+++ b/packages/cleo/src/cli/__tests__/docs-error-envelopes.test.ts
@@ -1,0 +1,188 @@
+/**
+ * T9789 — `cleo docs <verb>` LAFS error envelope contract.
+ *
+ * Reproduces the pre-fix double-wrap class: six sibling commands
+ * (export, search, merge, graph, rank, versions) all called
+ * `cliOutput(formatError(...))` in their `catch` blocks. Because
+ * `formatError` already serialises a `{success:false, error, meta}`
+ * envelope to JSON, feeding that string into `cliOutput` produced
+ * `{success:true, data:"<json>"}` — a FAKE-success envelope that
+ * masked failures from agents and pipelines.
+ *
+ * After the T9789 fix, every verb's failure path emits a top-level
+ * `{success:false, error:{...}, meta:{...}}` envelope on stdout while
+ * still exiting non-zero (ADR-039). This suite verifies the contract
+ * on every verb that has a reliable failure-trigger from the CLI
+ * surface; the corresponding lint rule
+ * (`scripts/lint-format-error-misuse.mjs`) guards every other site
+ * (and any future re-introduction) at the source level.
+ *
+ * Uses the `it.skipIf(!CLI_DIST_AVAILABLE)` pattern from
+ * docs-publish-envelope.test.ts so the suite is harmless on a cold
+ * monorepo where `dist/` does not yet exist.
+ *
+ * @task T9789
+ * @epic E-DOCS-FORMATERR-FIX (T9789)
+ * @saga T9787
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Absolute path to `packages/cleo/` root. */
+const PKG_ROOT = resolve(__dirname, '..', '..', '..');
+
+/** Path to compiled CLI entry point. */
+const CLI_DIST = resolve(PKG_ROOT, 'dist', 'cli', 'index.js');
+
+/** True when the compiled CLI dist bundle exists and can be spawned. */
+const CLI_DIST_AVAILABLE = existsSync(CLI_DIST);
+
+/** Shape of a parsed LAFS envelope as observed on stdout. */
+interface LafsEnvelope {
+  success: boolean;
+  data?: unknown;
+  error?: { code?: number | string; message?: string; codeName?: string };
+  meta?: { operation?: string; requestId?: string; timestamp?: string };
+}
+
+/** Run `node dist/cli/index.js <args>` with a short timeout. */
+function runCli(args: string[]): { stdout: string; stderr: string; status: number | null } {
+  const result = spawnSync('node', [CLI_DIST, ...args], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+    timeout: 20000,
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status,
+  };
+}
+
+/**
+ * Locate the first JSON-envelope line on stdout, parse it, and return.
+ * `cliError` writes the LAFS envelope to stdout; any other lines (citty
+ * usage etc.) go to stderr.
+ */
+function parseEnvelopeFromStdout(stdout: string): LafsEnvelope {
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+  const envelopeLine = lines.find((l) => l.trim().startsWith('{'));
+  expect(envelopeLine, 'expected a JSON envelope line on stdout').toBeDefined();
+  return JSON.parse(envelopeLine as string) as LafsEnvelope;
+}
+
+/**
+ * Shared contract assertions: an envelope on stdout — whether
+ * success or failure — MUST NOT be a double-wrapped success envelope
+ * carrying a serialised `{success:false,...}` blob inside `data`.
+ * That fingerprint is the smoking gun of the pre-T9789 bug.
+ */
+function assertNotDoubleWrapped(envelope: LafsEnvelope): void {
+  // ADR-039: meta MUST always be present.
+  expect(envelope.meta).toBeDefined();
+
+  // The double-wrap bug fingerprint: a success envelope carrying a
+  // stringified error envelope inside `data`. Refuse to ship this.
+  if (envelope.success === true && typeof envelope.data === 'string') {
+    const dataStr = envelope.data as string;
+    if (dataStr.startsWith('{')) {
+      let inner: { success?: boolean } | null = null;
+      try {
+        inner = JSON.parse(dataStr) as { success?: boolean };
+      } catch {
+        /* not JSON — fine */
+      }
+      expect(inner?.success, 'double-wrapped error envelope inside data').not.toBe(false);
+    }
+  }
+}
+
+describe('T9789 — cleo docs <verb> emits flat LAFS error envelopes (no double-wrap)', () => {
+  it.skipIf(!CLI_DIST_AVAILABLE)(
+    'cleo docs export — unknown task ID emits flat E_DOCS_EXPORT_FAILED envelope',
+    () => {
+      // exportDocument reliably throws on an unknown task ID, exercising
+      // the catch block that previously double-wrapped via
+      // `cliOutput(formatError(...))`.
+      const { stdout, status } = runCli(['docs', 'export', '--task', 'T-DOES-NOT-EXIST-9789']);
+
+      expect(stdout.length).toBeGreaterThan(0);
+      const envelope = parseEnvelopeFromStdout(stdout);
+
+      assertNotDoubleWrapped(envelope);
+      expect(envelope.success).toBe(false);
+      expect(envelope.error).toBeDefined();
+      expect(envelope.error?.codeName).toBe('E_DOCS_EXPORT_FAILED');
+      expect(envelope.error?.message).toMatch(/export/i);
+      expect(envelope.meta?.operation).toBeDefined();
+      expect(status).not.toBe(0);
+      expect(status).not.toBeNull();
+    },
+  );
+
+  it.skipIf(!CLI_DIST_AVAILABLE)(
+    'cleo docs merge — invalid attachment refs emit flat E_DOCS_MERGE_FAILED envelope',
+    () => {
+      // mergeDocs reliably throws when passed two attachment identifiers
+      // that cannot be resolved to blobs. Exercises the merge catch block.
+      const { stdout, status } = runCli([
+        'docs',
+        'merge',
+        '/nonexistent/cleo-T9789-A.md',
+        '/nonexistent/cleo-T9789-B.md',
+      ]);
+
+      expect(stdout.length).toBeGreaterThan(0);
+      const envelope = parseEnvelopeFromStdout(stdout);
+
+      assertNotDoubleWrapped(envelope);
+      // Either the catch fires (success=false) — preferred — or core
+      // succeeds with empty data. The double-wrap is what we forbid.
+      if (envelope.success === false) {
+        expect(envelope.error?.codeName).toBe('E_DOCS_MERGE_FAILED');
+        expect(envelope.error?.message).toMatch(/merge/i);
+        expect(status).not.toBe(0);
+      }
+    },
+  );
+
+  /**
+   * Static envelope-shape contract: for every sibling verb the renderer
+   * MUST emit a flat envelope on stdout when the catch block fires.
+   *
+   * This test uses `--help` rather than a failure trigger so it works
+   * reliably across environments — the goal is to confirm the CLI
+   * BINARY is invokable for each verb without crashing into an
+   * unrecoverable double-wrap on the happy path. Failure-path coverage
+   * for these verbs is enforced structurally by the lint rule
+   * (`scripts/lint-format-error-misuse.mjs`), which fails CI if
+   * `cliOutput(formatError(...))` or `cliError(formatError(...))` is
+   * ever re-introduced.
+   */
+  const SMOKE_VERBS = [
+    { label: 'search', argv: ['docs', 'search', '--help'] },
+    { label: 'graph', argv: ['docs', 'graph', '--help'] },
+    { label: 'rank', argv: ['docs', 'rank', '--help'] },
+    { label: 'versions', argv: ['docs', 'versions', '--help'] },
+  ];
+
+  for (const verb of SMOKE_VERBS) {
+    it.skipIf(!CLI_DIST_AVAILABLE)(
+      `cleo docs ${verb.label} — --help responds without crashing (CLI surface alive)`,
+      () => {
+        const { status } = runCli(verb.argv);
+        // citty exits 0 on --help. The point of this case is just to
+        // confirm the verb is reachable; failure-path lint coverage
+        // is enforced statically.
+        expect(status).toBe(0);
+      },
+    );
+  }
+});

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -24,7 +24,6 @@ import {
   CounterMismatchError,
   createDocsAccessor,
   exportDocument,
-  formatError,
   getAgentOutputsAbsolute,
   getProjectRoot,
   listDocVersions,
@@ -501,11 +500,14 @@ const exportCommand = defineCommand({
         }
       }
     } catch (err) {
+      // T9789: emit a flat LAFS error envelope (single layer, ADR-039).
+      // `cliOutput(formatError(...))` double-wraps — `formatError` already
+      // serialises a `{success:false, error, meta}` envelope to JSON, and
+      // feeding that string to `cliOutput` produces `{success:true, data:"<json>"}`.
       const message = err instanceof Error ? err.message : String(err);
-      cliOutput(
-        formatError(new CleoError(ExitCode.GENERAL_ERROR, `docs export failed: ${message}`)),
-        { command: 'docs export', operation: 'docs.export' },
-      );
+      cliError(`docs export failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_DOCS_EXPORT_FAILED',
+      });
       process.exit(ExitCode.GENERAL_ERROR);
     }
   },
@@ -566,11 +568,11 @@ const searchCommand = defineCommand({
 
       cliOutput(result, { command: 'docs search', operation: 'docs.search' });
     } catch (err) {
+      // T9789: flat LAFS error envelope (ADR-039) — no double-wrap.
       const message = err instanceof Error ? err.message : String(err);
-      cliOutput(
-        formatError(new CleoError(ExitCode.GENERAL_ERROR, `docs search failed: ${message}`)),
-        { command: 'docs search', operation: 'docs.search' },
-      );
+      cliError(`docs search failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_DOCS_SEARCH_FAILED',
+      });
       process.exit(ExitCode.GENERAL_ERROR);
     }
   },
@@ -637,11 +639,11 @@ const mergeCommand = defineCommand({
 
       cliOutput(result, { command: 'docs merge', operation: 'docs.merge' });
     } catch (err) {
+      // T9789: flat LAFS error envelope (ADR-039) — no double-wrap.
       const message = err instanceof Error ? err.message : String(err);
-      cliOutput(
-        formatError(new CleoError(ExitCode.GENERAL_ERROR, `docs merge failed: ${message}`)),
-        { command: 'docs merge', operation: 'docs.merge' },
-      );
+      cliError(`docs merge failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_DOCS_MERGE_FAILED',
+      });
       process.exit(ExitCode.GENERAL_ERROR);
     }
   },
@@ -724,11 +726,11 @@ const graphCommand = defineCommand({
         { command: 'docs graph', operation: 'docs.graph' },
       );
     } catch (err) {
+      // T9789: flat LAFS error envelope (ADR-039) — no double-wrap.
       const message = err instanceof Error ? err.message : String(err);
-      cliOutput(
-        formatError(new CleoError(ExitCode.GENERAL_ERROR, `docs graph failed: ${message}`)),
-        { command: 'docs graph', operation: 'docs.graph' },
-      );
+      cliError(`docs graph failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_DOCS_GRAPH_FAILED',
+      });
       process.exit(ExitCode.GENERAL_ERROR);
     }
   },
@@ -772,11 +774,11 @@ const rankCommand = defineCommand({
 
       cliOutput(result, { command: 'docs rank', operation: 'docs.rank' });
     } catch (err) {
+      // T9789: flat LAFS error envelope (ADR-039) — no double-wrap.
       const message = err instanceof Error ? err.message : String(err);
-      cliOutput(
-        formatError(new CleoError(ExitCode.GENERAL_ERROR, `docs rank failed: ${message}`)),
-        { command: 'docs rank', operation: 'docs.rank' },
-      );
+      cliError(`docs rank failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_DOCS_RANK_FAILED',
+      });
       process.exit(ExitCode.GENERAL_ERROR);
     }
   },
@@ -820,11 +822,11 @@ const versionsCommand = defineCommand({
 
       cliOutput(result, { command: 'docs versions', operation: 'docs.versions' });
     } catch (err) {
+      // T9789: flat LAFS error envelope (ADR-039) — no double-wrap.
       const message = err instanceof Error ? err.message : String(err);
-      cliOutput(
-        formatError(new CleoError(ExitCode.GENERAL_ERROR, `docs versions failed: ${message}`)),
-        { command: 'docs versions', operation: 'docs.versions' },
-      );
+      cliError(`docs versions failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_DOCS_VERSIONS_FAILED',
+      });
       process.exit(ExitCode.GENERAL_ERROR);
     }
   },
@@ -1108,7 +1110,10 @@ const syncCommand = defineCommand({
       }
     } catch (err) {
       if (err instanceof CleoError) {
-        cliError(formatError(err), err.code, { name: 'E_DOCS_FAILED' });
+        // T9789: flat LAFS error envelope (ADR-039). Passing `formatError(err)`
+        // (a JSON envelope string) as the message overrode the human-readable
+        // text with a stringified blob — use the raw `err.message` instead.
+        cliError(err.message, err.code, { name: 'E_DOCS_SYNC_FAILED' });
         process.exit(err.code);
       }
       throw err;
@@ -1196,7 +1201,8 @@ const gapCheckCommand = defineCommand({
       }
     } catch (err) {
       if (err instanceof CleoError) {
-        cliError(formatError(err), err.code, { name: 'E_DOCS_FAILED' });
+        // T9789: flat LAFS error envelope (ADR-039) — same fix class as syncCommand.
+        cliError(err.message, err.code, { name: 'E_DOCS_GAP_CHECK_FAILED' });
         process.exit(err.code);
       }
       throw err;

--- a/scripts/lint-format-error-misuse.mjs
+++ b/scripts/lint-format-error-misuse.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+/**
+ * Lint rule: reject `cliOutput(formatError(...))` and `cliError(formatError(...))`
+ * double-wrap calls in CLI command handlers.
+ *
+ * Why this matters
+ * ----------------
+ * `formatError` already serialises a `{success:false, error, meta}` LAFS
+ * envelope to a JSON string (ADR-039). Feeding that string into:
+ *
+ *   - `cliOutput(...)` produces `{success:true, data:"<json-string>"}`
+ *     — a FAKE-success envelope that masks failures from agents and
+ *     pipelines.
+ *
+ *   - `cliError(formatError(err), ...)` overrides the human-readable
+ *     `message` field with a stringified JSON blob — unreadable noise
+ *     instead of a clean error.
+ *
+ * The correct pattern is:
+ *
+ *   ```ts
+ *   } catch (err) {
+ *     const message = err instanceof Error ? err.message : String(err);
+ *     cliError(`<verb> failed: ${message}`, ExitCode.GENERAL_ERROR, {
+ *       name: 'E_<VERB>_FAILED',
+ *     });
+ *     process.exit(ExitCode.GENERAL_ERROR);
+ *   }
+ *   ```
+ *
+ * Opt-out
+ * -------
+ * Trailing comment `// format-error-allowed` on the same line suppresses
+ * the check. Use sparingly — there is no legitimate use of this pattern
+ * in a CLI command handler today.
+ *
+ * @task T9789
+ * @epic E-DOCS-FORMATERR-FIX (T9789)
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join } from 'node:path';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Directory roots to scan. Every package's `src/` is in scope. */
+const SCAN_DIRS = ['packages'];
+
+/** Path segments that mark a directory we should not descend into. */
+const SKIP_DIR_SEGMENTS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.git',
+  '__snapshots__',
+  '__mocks__',
+  '__tests__',
+  'coverage',
+  'fixtures',
+]);
+
+/** File extensions to scan. */
+const SCAN_EXTS = new Set(['.ts', '.tsx', '.mjs', '.mts', '.js', '.cjs']);
+
+/** Skip test/spec files — they may legitimately reference the bad pattern in fixtures. */
+const SKIP_FILE_PATTERNS = [/\.test\.(ts|tsx|js|mjs)$/, /\.spec\.(ts|tsx|js|mjs)$/];
+
+/**
+ * Pattern matches `cliOutput(formatError(` or `cliError(formatError(`.
+ * Whitespace permitted between identifier and paren, and between paren
+ * and inner identifier. Matches occurrences anywhere on a line.
+ */
+const DOUBLE_WRAP_REGEX = /\b(cliOutput|cliError)\s*\(\s*formatError\s*\(/;
+
+/** Comment marker that suppresses the check for one line. */
+const OPT_OUT_MARKER = 'format-error-allowed';
+
+/**
+ * Baseline allowlist — pre-existing sites that ship before T9789's fix
+ * was authored. These are scoped follow-up work (filed under Saga T9787)
+ * and must NOT cause new merges to fail. Any NEW site outside this list
+ * is a hard fail.
+ *
+ * Format: `<repo-relative path>:<line>` keyed at the time the baseline
+ * was captured. When fixing one of these, remove the matching entry —
+ * the lint will then guard the file going forward.
+ *
+ * The baseline is intentionally narrow: each entry is path+line, so a
+ * fix that changes line numbers will (correctly) re-trigger the lint
+ * and force the entry to be removed.
+ */
+const BASELINE_ALLOWLIST = new Set([
+  'packages/cleo/src/cli/commands/checkpoint.ts:129',
+  'packages/cleo/src/cli/commands/config.ts:127',
+  'packages/cleo/src/cli/commands/generate-changelog.ts:309',
+  'packages/cleo/src/cli/commands/init.ts:192',
+  'packages/cleo/src/cli/commands/otel.ts:43',
+  'packages/cleo/src/cli/commands/otel.ts:60',
+  'packages/cleo/src/cli/commands/otel.ts:90',
+  'packages/cleo/src/cli/commands/otel.ts:120',
+  'packages/cleo/src/cli/commands/otel.ts:150',
+  'packages/cleo/src/cli/commands/otel.ts:167',
+]);
+
+/**
+ * Normalise an absolute path to a repo-relative key for allowlist lookup.
+ * The lint is invoked from the repo root, so cwd-anchored relative paths
+ * match the keys above byte-for-byte.
+ *
+ * @param {string} filePath
+ * @returns {string}
+ */
+function normaliseKey(filePath) {
+  // readdirSync returns names relative to the dir we passed (e.g. "packages"),
+  // so join'd paths are already relative to cwd. Strip a leading "./" if any.
+  return filePath.startsWith('./') ? filePath.slice(2) : filePath;
+}
+
+// ============================================================================
+// Walker
+// ============================================================================
+
+const violations = [];
+
+/**
+ * Determine whether a directory entry name should be skipped.
+ *
+ * @param {string} name - directory entry name
+ * @returns {boolean}
+ */
+function shouldSkipDir(name) {
+  return name.startsWith('.') || SKIP_DIR_SEGMENTS.has(name);
+}
+
+/**
+ * Determine whether a file path should be skipped (test files, etc.).
+ *
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function shouldSkipFile(filePath) {
+  return SKIP_FILE_PATTERNS.some((re) => re.test(filePath));
+}
+
+/**
+ * Recursively walk a directory, scanning each eligible file.
+ *
+ * @param {string} dir
+ */
+function walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    const full = join(dir, name);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      if (shouldSkipDir(name)) continue;
+      walk(full);
+    } else if (stat.isFile()) {
+      if (!SCAN_EXTS.has(extname(name))) continue;
+      if (shouldSkipFile(full)) continue;
+      scanFile(full);
+    }
+  }
+}
+
+/**
+ * Scan a single file for the double-wrap pattern.
+ *
+ * @param {string} filePath
+ */
+function scanFile(filePath) {
+  const text = readFileSync(filePath, 'utf8');
+  if (!text.includes('formatError')) return;
+  const lines = text.split('\n');
+  const key = normaliseKey(filePath);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!DOUBLE_WRAP_REGEX.test(line)) continue;
+    if (line.includes(OPT_OUT_MARKER)) continue;
+    // Ignore lines that are pure comments (// or *) explaining the rule.
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
+    const allowlistKey = `${key}:${i + 1}`;
+    if (BASELINE_ALLOWLIST.has(allowlistKey)) {
+      // Pinned legacy site — recorded for follow-up under Saga T9787.
+      continue;
+    }
+    violations.push({ file: filePath, line: i + 1, snippet: line.trim() });
+  }
+}
+
+// ============================================================================
+// Run
+// ============================================================================
+
+for (const dir of SCAN_DIRS) {
+  walk(dir);
+}
+
+if (violations.length === 0) {
+  console.info(
+    'lint-format-error-misuse: OK (no cliOutput(formatError) / cliError(formatError) double-wraps).',
+  );
+  process.exit(0);
+}
+
+console.error(`lint-format-error-misuse: FAIL — found ${violations.length} double-wrap call(s):\n`);
+for (const v of violations) {
+  console.error(`  ${v.file}:${v.line}`);
+  console.error(`    ${v.snippet}`);
+}
+console.error(
+  `\nFix: replace the wrapper with the canonical pattern:\n\n` +
+    `  } catch (err) {\n` +
+    `    const message = err instanceof Error ? err.message : String(err);\n` +
+    `    cliError(\`<verb> failed: \${message}\`, ExitCode.GENERAL_ERROR, {\n` +
+    `      name: 'E_<VERB>_FAILED',\n` +
+    `    });\n` +
+    `    process.exit(ExitCode.GENERAL_ERROR);\n` +
+    `  }\n\n` +
+    `If genuinely necessary (e.g. a fixture), append a trailing "// ${OPT_OUT_MARKER}" comment.\n`,
+);
+process.exit(1);


### PR DESCRIPTION
## Summary

Eliminates the `cliOutput(formatError(...))` and `cliError(formatError(...))` double-wrap class bug across `packages/cleo/src/cli/commands/docs.ts` and adds a CI-enforced lint rule so the pattern cannot regress.

`formatError` already serialises a `{success:false, error, meta}` LAFS envelope to JSON. Feeding that string into:

- `cliOutput(...)` produced `{success:true, data:"<json>"}` — a FAKE-success envelope that masked failures from agents and pipelines.
- `cliError(formatError(err), ...)` overrode the human-readable message with a stringified JSON blob.

### Changes

- **8 broken sites fixed** in `docs.ts`: export (505), search (570), merge (641), graph (728), rank (776), versions (824), syncCommand legacy drift branch (1111), gapCheckCommand (1199). Each gets a verb-specific `E_DOCS_<VERB>_FAILED` codeName matching the `publishCommand` pattern (T9633).
- **Lint rule** `scripts/lint-format-error-misuse.mjs` scans `packages/*/src/` for the double-wrap pattern. Includes a baseline allowlist pinning 10 pre-existing sites under Saga T9787 (checkpoint, config, generate-changelog, init, otel × 6) so existing CI stays green while preventing new violations.
- **CI integration**: wired into `package.json` (`lint:format-error`) and `.github/workflows/ci.yml` as a new `format-error-misuse-lint` job (2-minute timeout).
- **Tests**: `packages/cleo/src/cli/__tests__/docs-error-envelopes.test.ts` spawns the compiled CLI and asserts flat envelope shape, mirroring the `docs-publish-envelope.test.ts` pattern with `it.skipIf(!CLI_DIST_AVAILABLE)`.
- Drops the now-unused `formatError` import from `docs.ts`.

## Test plan

- [x] `pnpm biome check` — clean
- [x] `pnpm run typecheck` — full project passes
- [x] `pnpm run build` — full monorepo builds
- [x] `node scripts/lint-format-error-misuse.mjs` — exits 0 with allowlist
- [x] Manual: `grep -cE "^\s*(cliOutput|cliError)\(formatError" packages/cleo/src/cli/commands/docs.ts` → 0 active sites
- [ ] CI: new `format-error-misuse-lint` job passes on this PR
- [ ] CI: existing tests + lints stay green

Closes T9789. Part of Saga T9787 (change-tracking consolidation umbrella).