### PR TITLE
feat(T9794): ct-documentor + protocol injection enforce docs SSoT

### DIFF
--- a/packages/core/templates/CLEO-INJECTION.md
+++ b/packages/core/templates/CLEO-INJECTION.md
@@ -53,6 +53,8 @@ If you find yourself reading a markdown file for orientation, STOP. Run `cleo br
 | Session token budget ≈ 80% consumed | Run `cleo session end --note "..."` and hand off |
 | Multiple related tasks ready in parallel | Run `cleo orchestrate ready --epic <id>` for the wave set |
 | About to call `cleo complete` | First: check gates via `cleo show <id>` → run tests → then complete |
+| Writing a canonical doc (spec/adr/research/handoff/note/llm-readme) | Use `cleo docs add --type <kind> --slug <kebab-handle>` — NEVER raw fs write to `.cleo/adrs/`, `.cleo/research/`, `.cleo/agent-outputs/`, or `docs/` |
+| Reading an ADR/spec/research note/handoff | `cleo docs fetch <slug>` — never grep the filesystem for canonical docs |
 <!-- /CLEO-INJECTION:section=triggers -->
 
 <!-- CLEO-INJECTION:section=task-creation -->

--- a/packages/skills/__tests__/skill-ssot-coverage.test.ts
+++ b/packages/skills/__tests__/skill-ssot-coverage.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Skill SSoT coverage — every doc-related skill MUST teach the docs SSoT contract.
+ *
+ * Pins the closure of Saga T9787 / Epic T9794. The four doc-related skills
+ * — ct-documentor (coordinator), ct-docs-write, ct-docs-review,
+ * ct-spec-writer, ct-adr-recorder — each MUST reference `cleo docs *`
+ * commands at least three times so future agents cannot regress to raw
+ * filesystem writes for canonical documentation types.
+ *
+ * ct-documentor additionally MUST coordinate every other doc-owning skill
+ * (ct-docs-write, ct-docs-review, ct-spec-writer, ct-adr-recorder) and
+ * declare the SSoT routing rule.
+ *
+ * @task T9794
+ * @saga T9787
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const thisFile = fileURLToPath(import.meta.url);
+const skillsRoot = resolve(dirname(thisFile), '..', 'skills');
+
+/** Read SKILL.md for a given skill name (e.g. "ct-documentor"). */
+function readSkill(name: string): string {
+  return readFileSync(join(skillsRoot, name, 'SKILL.md'), 'utf-8');
+}
+
+/** Count distinct `cleo docs <verb>` references in a skill body. */
+function countDocsRefs(content: string): number {
+  const matches = content.match(/cleo docs\s+\w+/g);
+  return matches?.length ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Every doc-related skill teaches the SSoT
+// ---------------------------------------------------------------------------
+
+describe('SSoT coverage — every doc-related skill references `cleo docs *`', () => {
+  const docSkills = [
+    'ct-documentor',
+    'ct-docs-write',
+    'ct-docs-review',
+    'ct-spec-writer',
+    'ct-adr-recorder',
+  ] as const;
+
+  for (const skill of docSkills) {
+    it(`${skill}/SKILL.md references \`cleo docs *\` at least 3 times`, () => {
+      const content = readSkill(skill);
+      const count = countDocsRefs(content);
+      expect(count, `${skill} has only ${count} \`cleo docs *\` references`).toBeGreaterThanOrEqual(
+        3,
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// ct-documentor is the coordinator: MUST route through the other skills
+// ---------------------------------------------------------------------------
+
+describe('ct-documentor — coordinator contract (T9794)', () => {
+  const content = readSkill('ct-documentor');
+
+  it('teaches `cleo docs add` as the canonical write entry point', () => {
+    expect(content).toContain('cleo docs add');
+  });
+
+  it('teaches `cleo docs publish` for git-tracked publication', () => {
+    expect(content).toContain('cleo docs publish');
+  });
+
+  it('teaches `cleo docs fetch` for slug-based retrieval', () => {
+    expect(content).toContain('cleo docs fetch');
+  });
+
+  it('declares the SSoT routing rule (canonical types via cleo docs add)', () => {
+    // Either "SSoT" or "docs SSoT" must appear in the routing context.
+    expect(content).toMatch(/SSoT/);
+    // And the closed-set --type taxonomy must be present.
+    expect(content).toMatch(
+      /spec\s*\|\s*adr\s*\|\s*research\s*\|\s*handoff\s*\|\s*note\s*\|\s*llm-readme/,
+    );
+  });
+
+  it('coordinates ct-docs-write for note/llm-readme content', () => {
+    expect(content).toContain('ct-docs-write');
+  });
+
+  it('coordinates ct-docs-review for quality validation', () => {
+    expect(content).toContain('ct-docs-review');
+  });
+
+  it('coordinates ct-spec-writer for REQ-XXX specifications', () => {
+    expect(content).toContain('ct-spec-writer');
+  });
+
+  it('coordinates ct-adr-recorder for architecture decisions', () => {
+    expect(content).toContain('ct-adr-recorder');
+  });
+
+  it('lists every coordinated skill in the dependencies frontmatter', () => {
+    // Match the `dependencies:` YAML block at the top of the file.
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    expect(frontmatterMatch, 'frontmatter missing').toBeTruthy();
+    const frontmatter = frontmatterMatch?.[1] ?? '';
+    expect(frontmatter).toMatch(/dependencies:[\s\S]*?- ct-docs-lookup/);
+    expect(frontmatter).toMatch(/dependencies:[\s\S]*?- ct-docs-write/);
+    expect(frontmatter).toMatch(/dependencies:[\s\S]*?- ct-docs-review/);
+    expect(frontmatter).toMatch(/dependencies:[\s\S]*?- ct-spec-writer/);
+    expect(frontmatter).toMatch(/dependencies:[\s\S]*?- ct-adr-recorder/);
+  });
+
+  it('marks the legacy direct-filesystem path as deprecated', () => {
+    expect(content).toContain('Deprecated');
+  });
+});

--- a/packages/skills/skills/ct-documentor/SKILL.md
+++ b/packages/skills/skills/ct-documentor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ct-documentor
-description: Documentation creation, editing, and review with CLEO style guide compliance. Coordinates specialized skills for lookup, writing, and review. Use when creating or updating documentation files, consolidating scattered documentation, or validating documentation against style standards. Triggers on documentation tasks, doc update requests, or style guide compliance checks.
-version: 3.0.0
+description: Documentation coordinator with CLEO style guide compliance. Routes every canonical-doc write (spec, adr, research, handoff, note, llm-readme) through the docs SSoT via `cleo docs add` / `cleo docs publish` / `cleo docs fetch` — never raw filesystem writes. Coordinates ct-docs-lookup, ct-docs-write, ct-docs-review, ct-spec-writer, and ct-adr-recorder. Use when creating or updating documentation files, consolidating scattered documentation, or validating documentation against style standards. Triggers on documentation tasks, doc update requests, or style guide compliance checks.
+version: 3.1.0
 tier: 3
 core: false
 category: specialist
@@ -10,6 +10,8 @@ dependencies:
   - ct-docs-lookup
   - ct-docs-write
   - ct-docs-review
+  - ct-spec-writer
+  - ct-adr-recorder
 sharedResources:
   - subagent-protocol-base
   - task-system-integration
@@ -39,9 +41,100 @@ Context injection for documentation tasks spawned via cleo-subagent. Orchestrate
 
 | Skill | Purpose | Invoke When |
 |-------|---------|-------------|
-| `ct-docs-lookup` | Query existing docs, find references | Discovery phase, checking what exists |
-| `ct-docs-write` | Create/edit docs with CLEO style | Writing or updating content |
-| `ct-docs-review` | Check compliance with style guide | Quality validation before completion |
+| `ct-docs-lookup` | Query existing docs, find references via `cleo docs fetch`/`list` | Discovery phase, checking what exists |
+| `ct-docs-write` | Create/edit docs via `cleo docs add` with CLEO style | Writing or updating content |
+| `ct-docs-review` | Check compliance with style guide, read through `cleo docs fetch` | Quality validation before completion |
+| `ct-spec-writer` | Author specs (REQ-XXX requirements) via `cleo docs add --type spec` | Formal specification work |
+| `ct-adr-recorder` | Author ADRs via `cleo docs add --type adr --slug adr-NNN-...` | Architecture decisions promoted from consensus |
+
+The coordinator never writes content itself — it routes the work to the
+specialist skill that owns the doc type, and every specialist routes its
+filesystem write through the docs SSoT (see "Coordinator Pattern" below).
+
+---
+
+## Coordinator Pattern: SSoT-First Routing
+
+ct-documentor is a router. It dispatches each doc-type to its owning skill,
+and every owner writes through `cleo docs add` — not raw filesystem writes.
+
+| Doc Type | Owner Skill | SSoT Command |
+|----------|-------------|--------------|
+| `spec` (REQ-XXX requirements) | `ct-spec-writer` | `cleo docs add <ownerId> <path> --type spec --slug spec-<feature>` |
+| `adr` (architecture decisions) | `ct-adr-recorder` | `cleo docs add <ownerId> <path> --type adr --slug adr-<NNN>-<rest>` |
+| `research` (multi-source investigation) | `ct-research-agent` | `cleo docs add <ownerId> <path> --type research --slug research-<topic>` |
+| `handoff` (session/agent transition) | `ct-documentor` (this skill) | `cleo docs add <ownerId> <path> --type handoff --slug handoff-<context>` |
+| `note` (conversational prose) | `ct-docs-write` | `cleo docs add <ownerId> <path> --type note --slug <kebab-topic>` |
+| `llm-readme` (agent-facing) | `ct-docs-write` | `cleo docs add <ownerId> <path> --type llm-readme --slug <kebab-topic>` |
+
+Hard rule: EVERY canonical-type write goes through the SSoT. The coordinator
+rejects any subagent return that wrote raw markdown into `.cleo/adrs/`,
+`.cleo/research/`, `.cleo/agent-outputs/`, or `docs/` without first
+materializing through `cleo docs add` + (optionally) `cleo docs publish`.
+
+---
+
+## Through SDK (preferred)
+
+Documentation work flows through the docs SSoT in three steps —
+add, publish, fetch. Use the slug-based contract so downstream consumers
+can retrieve docs without grepping the filesystem.
+
+### Add a doc attached to a task
+
+```bash
+cleo docs add T1234 docs/drafts/feature-x.md \
+  --type note \
+  --slug feature-x-overview \
+  --desc "Conversational overview — pre-review"
+```
+
+- `--type` MUST be one of `spec | adr | research | handoff | note | llm-readme`.
+  Pick the type by the document's purpose, not its filename.
+- `--slug` is the human-friendly retrieval handle (kebab-case). If taken the
+  CLI returns `E_SLUG_TAKEN` with 3 alternatives — pick one, do not overwrite.
+- The owner ID (`T1234` above) auto-classifies the attachment by prefix:
+  `T###` → task, `ses_*` → session, `O-*` → observation.
+
+### Publish to a git-tracked path (when the doc must live on disk)
+
+```bash
+cleo docs publish --for T1234 --to docs/feature-x.md
+```
+
+Atomic tmp-then-rename. The published file ships in the next commit; the
+SSoT blob remains canonical and continues to track future versions.
+
+### Fetch the doc back by slug
+
+```bash
+cleo docs fetch feature-x-overview         # latest version
+cleo docs versions --for T1234             # list every SHA version
+```
+
+Slug-based fetch is the contract used by reviewers, downstream skills, and
+the docs graph — never grep the filesystem for the file you just wrote.
+
+### List + sync
+
+```bash
+cleo docs list --type spec --project       # every spec in this project
+cleo docs list --task T1234                # everything attached to a task
+cleo docs sync --from docs/legacy.md --for T1234 --type note --slug legacy-doc
+```
+
+`cleo docs sync` back-fills an existing on-disk file into the SSoT.
+
+---
+
+## Deprecated: Direct filesystem
+
+The legacy "write straight to `.cleo/adrs/`, `.cleo/research/`,
+`.cleo/agent-outputs/`, or `docs/` and commit" pattern is deprecated.
+The drift between the working file and the docs SSoT is real: published
+files go stale, types are inferred ad-hoc from path, and slug-based
+retrieval becomes impossible. Migrate every doc-type write to
+`cleo docs add --type X --slug Y`.
 
 ---
 
@@ -61,16 +154,19 @@ BEFORE creating ANY new file, you MUST:
 
 ### Phase 1: Discovery (MANDATORY)
 
-Before writing anything, discover what exists:
+Before writing anything, discover what exists. Prefer the SSoT over `Glob`/`Grep`
+when scanning canonical docs — `cleo docs list` returns slug + owner + type
+without forcing a filesystem walk.
 
 ```bash
-# List documentation structure
+# SSoT-first discovery (preferred)
+cleo docs list --project                       # all docs for this project
+cleo docs list --type {TYPE} --project         # docs filtered by canonical type
+cleo docs fetch {SUSPECTED_SLUG}               # check if a slug exists
+
+# Filesystem fallback (only for un-migrated content)
 Glob: pattern="docs/**/*.md"
-
-# Search for existing content on topic
 Grep: pattern="{TOPIC_KEYWORDS}" path="docs/"
-
-# Check for related files
 Grep: pattern="{RELATED_TERMS}" path="docs/" output_mode="files_with_matches"
 ```
 
@@ -131,12 +227,14 @@ Checklist:
 
 Before completing, verify:
 
-- [ ] Searched for existing docs on this topic
+- [ ] Searched for existing docs on this topic via `cleo docs list` first
 - [ ] Did NOT create a file that duplicates existing content
 - [ ] Updated existing file if one existed
 - [ ] Added deprecation notice if consolidating
 - [ ] Cross-references are updated
 - [ ] No orphaned documentation created
+- [ ] Every canonical-type write went through `cleo docs add --type X --slug Y`
+- [ ] Slug retrieval verified via `cleo docs fetch <slug>` before declaring done
 
 ---
 
@@ -221,9 +319,13 @@ Append ONE line to `{{MANIFEST_PATH}}`:
 
 ## Completion Requirements
 
-- [ ] Discovery phase completed (searched existing docs)
+- [ ] Discovery phase completed (searched existing docs via `cleo docs list`)
 - [ ] Core principle followed (maintain, don't duplicate)
-- [ ] `/ct-docs-write` invoked for content creation
+- [ ] Coordinator pattern followed: every doc-type routed to its owning skill
+- [ ] Every canonical-type write went through `cleo docs add --type X --slug Y`
+- [ ] `/ct-docs-write` invoked for `note`/`llm-readme` content
+- [ ] `/ct-spec-writer` invoked when writing specs (REQ-XXX requirements)
+- [ ] `/ct-adr-recorder` invoked when promoting consensus → ADR
 - [ ] `/ct-docs-review` invoked for quality validation
 - [ ] Anti-duplication checklist verified
 - [ ] Output file written with "Files NOT Created" section


### PR DESCRIPTION
## Summary

- **ct-documentor SKILL.md** rewritten as an SSoT-first coordinator. Adds a "Through SDK (preferred)" section with `cleo docs add` / `publish` / `fetch` examples, a "Coordinator Pattern: SSoT-First Routing" table mapping each canonical doc type (spec, adr, research, handoff, note, llm-readme) to its owner skill via `cleo docs add --type <kind>`, and expands skill coordination to include `ct-spec-writer` + `ct-adr-recorder`. Frontmatter description and `dependencies:` list updated. **32** `cleo docs *` references now (was 0).
- **CLEO-INJECTION.md** gains two new Tier-0 protocol triggers — writing canonical docs routes through `cleo docs add`, reading routes through `cleo docs fetch`. Future spawned agents see the SSoT requirement before falling back to raw filesystem writes into `.cleo/adrs/`, `.cleo/research/`, `.cleo/agent-outputs/`, or `docs/`.
- **skill-ssot-coverage.test.ts** is a new regression at `packages/skills/__tests__/`. 15 tests pin the contract: every doc-related skill (ct-documentor, ct-docs-write, ct-docs-review, ct-spec-writer, ct-adr-recorder) MUST reference `cleo docs *` at least 3 times, and ct-documentor MUST coordinate the four owner skills with SSoT routing declared. Mirrors the per-skill regression style established by T9641 and T9642.

## ct-adr-recorder audit

Present at `packages/skills/skills/ct-adr-recorder/SKILL.md` with **11** `cleo docs *` references — already exceeds the 3-minimum from T9629 wave 1. No follow-up gap task filed.

## Reference count summary

| Skill | cleo-docs refs (before → after) |
|-------|--------------------------------:|
| ct-documentor | 0 → **32** |
| ct-docs-write | 9 (unchanged — T9641 already shipped) |
| ct-docs-review | 13 (unchanged — T9642 already shipped) |
| ct-spec-writer | 10 (unchanged — T9629 wave 1) |
| ct-adr-recorder | 11 (unchanged — T9629 wave 1) |

## Test plan

- [x] `pnpm --filter @cleocode/skills run test __tests__/skill-ssot-coverage.test.ts` → 15/15 pass
- [x] `pnpm --filter @cleocode/skills run test` → 195/195 pass (no regression in existing skill tests)
- [x] `python3 packages/skills/skills/ct-skill-validator/scripts/check_depth.py packages/skills/skills/ct-documentor --json` → passes (body=319, refs=4, manifest=4/4)
- [x] biome: markdown files are intentionally ignored; test file auto-formatted by biome via `pnpm dlx @biomejs/biome check --write`

Closes T9794. Saga T9787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)