### PR TITLE
feat(T9795): @deprecated markers + deprecations.yml registry + CI gate

### DIFF
--- a/.cleo/.gitignore
+++ b/.cleo/.gitignore
@@ -76,6 +76,12 @@
 !audit/imports/
 !audit/imports/**
 
+# Step 12: Allow deprecation registry + schema (T9795 / Saga T9787) — the
+# source-of-truth listing legacy code paths bearing TSDoc @deprecated
+# markers. Validated by scripts/lint-deprecations.mjs in CI.
+!deprecations.yml
+!deprecations.schema.json
+
 # =============================================================================
 # EXPLICIT DENY — safety net that overrides allow rules above
 # =============================================================================

--- a/.cleo/deprecations.schema.json
+++ b/.cleo/deprecations.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cleocode.io/schemas/deprecations.schema.json",
+  "title": "CLEO Deprecation Registry",
+  "description": "Source-of-truth for legacy code paths marked @deprecated. Validated by scripts/lint-deprecations.mjs. T9795 / Saga T9787.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "deprecations"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Registry schema version. Bump when the entry shape changes."
+    },
+    "deprecations": {
+      "type": "array",
+      "minItems": 0,
+      "items": { "$ref": "#/definitions/DeprecationEntry" }
+    }
+  },
+  "definitions": {
+    "DeprecationEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "since", "remove", "replacement", "note"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*[a-z0-9]$",
+          "description": "Unique kebab-case identifier."
+        },
+        "path": {
+          "type": "string",
+          "description": "Single source file bearing the @deprecated TSDoc. Either `path` or `paths` MUST be set.",
+          "minLength": 1
+        },
+        "paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Multiple source files (or globs) sharing this deprecation. Either `path` or `paths` MUST be set."
+        },
+        "since": {
+          "type": "string",
+          "pattern": "^v\\d{4}\\.\\d+\\.\\d+$",
+          "description": "CalVer release tag where deprecation landed (e.g. v2026.5.93)."
+        },
+        "remove": {
+          "type": "string",
+          "pattern": "^v\\d{4}\\.\\d+\\.\\d+$",
+          "description": "Earliest CalVer tag that MAY remove the deprecated code."
+        },
+        "replacement": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Concrete migration target (CLI command, symbol, or doc URL)."
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short prose explaining the supersession + ADR/task refs."
+        }
+      },
+      "oneOf": [
+        { "required": ["path"], "not": { "required": ["paths"] } },
+        { "required": ["paths"], "not": { "required": ["path"] } }
+      ]
+    }
+  }
+}

--- a/.cleo/deprecations.yml
+++ b/.cleo/deprecations.yml
@@ -1,0 +1,62 @@
+# CLEO Deprecation Registry
+#
+# Each entry MUST be unique by `id` and carry:
+#   - path(s) — source file(s) bearing the @deprecated TSDoc
+#   - since   — release version where deprecation landed
+#   - remove  — earliest release version that may drop the code
+#   - replacement — concrete migration command/symbol
+#   - note    — short justification + ADR/task reference
+#
+# Validated by scripts/lint-deprecations.mjs against
+# .cleo/deprecations.schema.json. The lint also asserts every TSDoc
+# `@deprecated` in the listed paths has a corresponding registry entry.
+#
+# @task T9795
+# @saga T9787
+version: 1
+deprecations:
+  - id: changelog-writer-custom-log
+    path: packages/core/src/release/changelog-writer.ts
+    since: v2026.5.93
+    remove: v2026.6.0
+    replacement: cleo changeset add
+    note: >-
+      ADR-028-era [custom-log]...[/custom-log] blocks. Superseded by the
+      CLEO-native task-anchored changesets DSL (T9793 / Saga T9787).
+
+  - id: ui-changelog-label-grouping
+    path: packages/core/src/ui/changelog.ts
+    since: v2026.5.93
+    remove: v2026.6.0
+    replacement: cleo release plan
+    note: >-
+      Label-grouped task→changelog renderer. Superseded by the LLM-driven
+      release-notes composer (T9759) consuming the Release Plan envelope.
+
+  - id: cleo-release-changelog-verb-git-log
+    path: packages/cleo/src/cli/commands/release.ts
+    since: v2026.5.93
+    remove: v2026.6.0
+    replacement: cleo release plan
+    note: >-
+      `cleo release changelog <tag>` git-log scraping path. Superseded by
+      the changeset-driven `cleo release plan` flow (T9525) — the plan
+      envelope enumerates included tasks via the releases graph.
+
+  - id: generate-changelog-renderer
+    path: packages/cleo/src/cli/commands/generate-changelog.ts
+    since: v2026.5.93
+    remove: v2026.6.0
+    replacement: cleo changeset add
+    note: >-
+      CHANGELOG.md → platform (Mintlify/Docusaurus/...) renderer chain.
+      Superseded by the task-anchored changesets DSL aggregator (T9793).
+
+  - id: agent-output-raw-md-write
+    path: packages/core/src/tools/adr-backfill-walker.ts
+    since: v2026.5.93
+    remove: v2026.6.0
+    replacement: cleo docs add --type note
+    note: >-
+      Raw `.md` writes to `.cleo/agent-outputs/` bypass the docs registry
+      SSoT. Migrate to `cleo docs add --type note` (T9788).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,38 @@ jobs:
       - name: Reject cliOutput(formatError) / cliError(formatError) double-wraps
         run: node scripts/lint-format-error-misuse.mjs
 
+  deprecations-lint:
+    # T9795 / Saga T9787 — guard the deprecation registry. Asserts every
+    # entry in `.cleo/deprecations.yml` points at a real file that
+    # actually carries a TSDoc `@deprecated` tag, and that the YAML
+    # conforms to `.cleo/deprecations.schema.json`. Catches drift the
+    # moment a legacy file is deleted or renamed without the registry
+    # being updated.
+    name: Deprecations Registry Lint (T9795)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.30.0'
+          run_install: false
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
+      - name: Validate .cleo/deprecations.yml against schema + path existence
+        run: pnpm run lint:deprecations
+
   pragma-drift:
     name: SQLite Pragma Drift Guard (T9025 / T9190)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint:changesets": "node scripts/lint-changesets.mjs",
     "lint:cleo-errors": "node scripts/lint-cleo-errors.mjs",
     "lint:contracts-dep": "node scripts/lint-contracts-dep.mjs",
+    "lint:deprecations": "node scripts/lint-deprecations.mjs",
     "lint:format-error": "node scripts/lint-format-error-misuse.mjs",
     "lint:json-stream": "node scripts/lint-json-stream-hygiene.mjs",
     "lint:raw-cr": "node scripts/lint-no-raw-cr-writes.mjs",

--- a/packages/cleo/src/cli/commands/generate-changelog.ts
+++ b/packages/cleo/src/cli/commands/generate-changelog.ts
@@ -10,7 +10,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { ExitCode } from '@cleocode/contracts';
-import { CleoError, formatError, getConfigPath, getProjectRoot, pushWarning } from '@cleocode/core';
+import { CleoError, getConfigPath, getProjectRoot, pushWarning } from '@cleocode/core';
 import { defineCommand } from 'citty';
 // CLI-only: implements local file generation from CHANGELOG.md, not a dispatch operation
 import { cliError, cliOutput } from '../renderers/index.js';
@@ -329,11 +329,21 @@ export const generateChangelogCommand = defineCommand({
         { command: 'generate-changelog' },
       );
     } catch (err) {
+      // T9789: cliError takes a plain string — passing formatError(err)
+      // here double-wraps a serialised LAFS envelope inside cliError's
+      // own envelope. Pass the message directly and let cliError build
+      // the canonical envelope itself.
       if (err instanceof CleoError) {
-        cliError(formatError(err), err.code, { name: 'E_INTERNAL' });
+        cliError(`generate-changelog failed: ${err.message}`, err.code, {
+          name: 'E_GENERATE_CHANGELOG_FAILED',
+        });
         process.exit(err.code);
       }
-      throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`generate-changelog failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_GENERATE_CHANGELOG_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
     }
   },
 });

--- a/packages/cleo/src/cli/commands/generate-changelog.ts
+++ b/packages/cleo/src/cli/commands/generate-changelog.ts
@@ -10,7 +10,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { ExitCode } from '@cleocode/contracts';
-import { CleoError, formatError, getConfigPath, getProjectRoot } from '@cleocode/core';
+import { CleoError, formatError, getConfigPath, getProjectRoot, pushWarning } from '@cleocode/core';
 import { defineCommand } from 'citty';
 // CLI-only: implements local file generation from CHANGELOG.md, not a dispatch operation
 import { cliError, cliOutput } from '../renderers/index.js';
@@ -216,6 +216,13 @@ function generateDocusaurus(source: string, limit: number): string {
  *
  * @task T4555
  * @epic T487
+ *
+ * @deprecated Since v2026.5.93 (T9795 / Saga T9787). Will be removed no
+ *   earlier than v2026.6.0. The CHANGELOG.md → platform renderer chain is
+ *   superseded by the task-anchored changesets DSL aggregator (T9793) —
+ *   `.changeset/*.md` entries feed the aggregator, and downstream
+ *   platform renderers consume the aggregator's output. See
+ *   `.cleo/deprecations.yml` id:`generate-changelog-renderer`.
  */
 export const generateChangelogCommand = defineCommand({
   meta: {
@@ -239,6 +246,23 @@ export const generateChangelogCommand = defineCommand({
   },
   async run({ args }) {
     try {
+      // T9795: deprecation warning surfaces via meta.warnings[]; the
+      // renderer drops it to stderr only when output mode is human.
+      pushWarning({
+        code: 'W_DEPRECATED_COMMAND',
+        message:
+          '`cleo generate-changelog` is deprecated. Use `cleo changeset add` (T9793) + the aggregator (T9759 composer) instead.',
+        severity: 'warn',
+        deprecated: 'cleo generate-changelog',
+        replacement: 'cleo changeset add',
+        removeBy: 'v2026.6.0',
+        context: {
+          registryId: 'generate-changelog-renderer',
+          task: 'T9795',
+          saga: 'T9787',
+        },
+      });
+
       const limit = Number(args.limit ?? 15);
       const targetPlatform = args.platform as string | undefined;
       const dryRun = args['dry-run'] === true;

--- a/packages/cleo/src/cli/commands/release.ts
+++ b/packages/cleo/src/cli/commands/release.ts
@@ -191,6 +191,14 @@ const cancelCommand = defineCommand({
  * groups by epic, and produces a structured CHANGELOG entry.
  *
  * @task T820 RELEASE-02
+ *
+ * @deprecated Since v2026.5.93 (T9795 / Saga T9787). Will be removed no
+ *   earlier than v2026.6.0. The git-log scraping path is superseded by
+ *   the changeset-driven `cleo release plan` flow (T9525) — the plan
+ *   envelope already enumerates included tasks via the
+ *   `task_relations`/`releases` graph, and the T9759 LLM composer renders
+ *   the human-readable Markdown. See `.cleo/deprecations.yml` id:
+ *   `cleo-release-changelog-verb-git-log`.
  */
 const changelogCommand = defineCommand({
   meta: {
@@ -211,6 +219,24 @@ const changelogCommand = defineCommand({
     },
   },
   async run({ args }) {
+    // T9795: emit the deprecation warning BEFORE the missing-arg check so
+    // even error envelopes carry the migration hint. JSON callers receive
+    // it in `meta.warnings[]`; human-mode renders it on stderr.
+    pushWarning({
+      code: 'W_DEPRECATED_COMMAND',
+      message:
+        '`cleo release changelog <tag>` is deprecated. Use `cleo release plan <version> --epic <id>` (T9525) plus the T9759 LLM composer.',
+      severity: 'warn',
+      deprecated: 'cleo release changelog',
+      replacement: 'cleo release plan',
+      removeBy: 'v2026.6.0',
+      context: {
+        registryId: 'cleo-release-changelog-verb-git-log',
+        task: 'T9795',
+        saga: 'T9787',
+      },
+    });
+
     // Accept either `cleo release changelog v2026.5.81` (positional, matches
     // pr-status / show / cancel) or the legacy `--since v...` flag. Emit a
     // LAFS envelope on missing input rather than letting citty dump help

--- a/packages/core/src/__tests__/deprecations-registry.test.ts
+++ b/packages/core/src/__tests__/deprecations-registry.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Deprecation registry coverage tests (T9795 / Saga T9787).
+ *
+ * Asserts:
+ *   1. `.cleo/deprecations.yml` parses + matches the JSON Schema.
+ *   2. Every listed source file actually carries a TSDoc `@deprecated` tag
+ *      (catches drift when the legacy file is removed without the
+ *      registry entry being deleted).
+ *   3. `pushWarning` fires when a deprecated function is invoked — proves
+ *      the runtime warning machinery is wired (T9795 hard rule:
+ *      "runtime warning emitted on stderr human-mode only" depends on the
+ *      warning being queued onto the LAFS envelope first).
+ *
+ * @task T9795
+ * @saga T9787
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import Ajv from 'ajv';
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+import { drainWarnings, pushWarning } from '../output.js';
+import { writeChangelogSection } from '../release/changelog-writer.js';
+import { generateChangelog } from '../ui/changelog.js';
+
+// ─── Locate registry + schema relative to the monorepo root ────────────────
+
+// vitest runs from the package root; the repo root is two levels up.
+const REPO_ROOT = resolve(__dirname, '../../../..');
+const REGISTRY_PATH = resolve(REPO_ROOT, '.cleo/deprecations.yml');
+const SCHEMA_PATH = resolve(REPO_ROOT, '.cleo/deprecations.schema.json');
+
+interface DeprecationEntry {
+  id: string;
+  path?: string;
+  paths?: string[];
+  since: string;
+  remove: string;
+  replacement: string;
+  note: string;
+}
+
+interface Registry {
+  version: number;
+  deprecations: DeprecationEntry[];
+}
+
+describe('T9795: Deprecation registry (.cleo/deprecations.yml)', () => {
+  it('registry + schema files exist', () => {
+    expect(existsSync(REGISTRY_PATH)).toBe(true);
+    expect(existsSync(SCHEMA_PATH)).toBe(true);
+  });
+
+  it('registry conforms to the JSON Schema', () => {
+    const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf-8'));
+    const registry = parseYaml(readFileSync(REGISTRY_PATH, 'utf-8')) as Registry;
+    const ajv = new (Ajv as unknown as typeof Ajv.default)({
+      allErrors: true,
+      strict: false,
+    });
+    const validate = ajv.compile(schema);
+    const valid = validate(registry);
+    if (!valid) {
+      // Surface every violation for fast triage.
+      throw new Error(
+        `Schema violations:\n${(validate.errors ?? [])
+          .map((e) => `  ${e.instancePath || '(root)'}: ${e.message}`)
+          .join('\n')}`,
+      );
+    }
+    expect(registry.version).toBe(1);
+    expect(Array.isArray(registry.deprecations)).toBe(true);
+    expect(registry.deprecations.length).toBeGreaterThan(0);
+  });
+
+  it('every registered source file carries a TSDoc @deprecated tag', () => {
+    const registry = parseYaml(readFileSync(REGISTRY_PATH, 'utf-8')) as Registry;
+    const failures: string[] = [];
+
+    for (const entry of registry.deprecations) {
+      const filesForEntry: string[] = [];
+      if (typeof entry.path === 'string') filesForEntry.push(entry.path);
+      if (Array.isArray(entry.paths)) filesForEntry.push(...entry.paths);
+
+      for (const file of filesForEntry) {
+        // Skip globs — the lint script enforces non-glob path existence.
+        if (file.includes('*')) continue;
+        const absPath = resolve(REPO_ROOT, file);
+        if (!existsSync(absPath)) {
+          failures.push(`Entry ${entry.id}: missing file ${file}`);
+          continue;
+        }
+        const contents = readFileSync(absPath, 'utf-8');
+        if (!/@deprecated\b/.test(contents)) {
+          failures.push(`Entry ${entry.id}: ${file} lacks @deprecated TSDoc`);
+        }
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(failures.join('\n'));
+    }
+  });
+
+  it('IDs are unique', () => {
+    const registry = parseYaml(readFileSync(REGISTRY_PATH, 'utf-8')) as Registry;
+    const ids = registry.deprecations.map((d) => d.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('T9795: Runtime W_DEPRECATED warning emission', () => {
+  it('pushWarning queues a structured warning that drainWarnings returns', () => {
+    // Sanity check the queue plumbing in isolation so deprecation-fire tests
+    // below can rely on it.
+    drainWarnings(); // clear any pending residue
+    pushWarning({
+      code: 'W_DEPRECATED',
+      message: 'test',
+      severity: 'warn',
+      deprecated: 'foo',
+      replacement: 'bar',
+      removeBy: 'v2026.6.0',
+    });
+    const drained = drainWarnings();
+    expect(drained?.length).toBe(1);
+    expect(drained?.[0]?.code).toBe('W_DEPRECATED');
+  });
+
+  it('writeChangelogSection emits W_DEPRECATED (changelog-writer-custom-log)', async () => {
+    drainWarnings();
+    // The function writes via atomicWrite — give it a path inside /tmp so
+    // we don't pollute the repo. We only care about the warning side-effect.
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const tmpPath = join(tmpdir(), `T9795-changelog-${Date.now()}.md`);
+    await writeChangelogSection('v0.0.0-test', '- entry', [], tmpPath);
+    const drained = drainWarnings();
+    const codes = (drained ?? []).map((w) => w.code);
+    expect(codes).toContain('W_DEPRECATED');
+    const ctx = (drained ?? []).find((w) => w.code === 'W_DEPRECATED')?.context as
+      | { registryId?: string }
+      | undefined;
+    expect(ctx?.registryId).toBe('changelog-writer-custom-log');
+  });
+
+  it('generateChangelog emits W_DEPRECATED (ui-changelog-label-grouping)', async () => {
+    drainWarnings();
+    // Pass an accessor stub that returns no tasks so the function short-
+    // circuits without touching the filesystem.
+    const stubAccessor = {
+      queryTasks: async () => ({ tasks: [] }),
+      loadArchive: async () => ({ archivedTasks: [] }),
+    } as unknown as Parameters<typeof generateChangelog>[3];
+    await generateChangelog('v0.0.0-test', {}, undefined, stubAccessor);
+    const drained = drainWarnings();
+    const dep = (drained ?? []).find((w) => w.code === 'W_DEPRECATED');
+    expect(dep).toBeDefined();
+    const ctx = dep?.context as { registryId?: string } | undefined;
+    expect(ctx?.registryId).toBe('ui-changelog-label-grouping');
+  });
+});

--- a/packages/core/src/release/changelog-writer.ts
+++ b/packages/core/src/release/changelog-writer.ts
@@ -3,10 +3,19 @@
  *
  * @task T5579
  * @epic T5576
+ *
+ * @deprecated Since v2026.5.93 (T9795 / Saga T9787). Will be removed no
+ *   earlier than v2026.6.0. ADR-028-era `[custom-log]…[/custom-log]` blocks
+ *   are superseded by the CLEO-native task-anchored changesets DSL — see
+ *   `cleo changeset add` (T9793). Migrate by emitting `.changeset/*.md`
+ *   entries and running the aggregator instead of editing CHANGELOG.md
+ *   sections directly. See `.cleo/deprecations.yml` (id:
+ *   `changelog-writer-custom-log`) for the migration table.
  */
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { pushWarning } from '../output.js';
 import { atomicWrite } from '../store/atomic.js';
 
 // ── Custom-log block parsing ──────────────────────────────────────────
@@ -15,6 +24,9 @@ import { atomicWrite } from '../store/atomic.js';
  * Parse [custom-log]...[/custom-log] blocks from a CHANGELOG section.
  * Returns the extracted block content (tags stripped) and the content
  * with tags+content removed.
+ *
+ * @deprecated Since v2026.5.93. Migrate to `cleo changeset add` (T9793 /
+ *   Saga T9787). Removal: no earlier than v2026.6.0.
  */
 export function parseChangelogBlocks(content: string): {
   customBlocks: string[];
@@ -70,6 +82,10 @@ function buildSection(version: string, generatedContent: string, customBlocks: s
  * - Custom block content (from [custom-log] blocks) is appended after
  *   generated content.
  * - Section header format: '## [VERSION] (YYYY-MM-DD)'
+ *
+ * @deprecated Since v2026.5.93. Migrate to `cleo changeset add` (T9793 /
+ *   Saga T9787). The new aggregator owns CHANGELOG.md composition.
+ *   Removal: no earlier than v2026.6.0.
  */
 export async function writeChangelogSection(
   version: string,
@@ -77,6 +93,24 @@ export async function writeChangelogSection(
   customBlocks: string[],
   changelogPath: string,
 ): Promise<void> {
+  // T9795: emit a structured deprecation warning into the active LAFS
+  // envelope (drained by formatSuccess/formatError). The CLI renderer
+  // surfaces this on stderr ONLY in human mode — JSON output remains
+  // clean. See `.cleo/deprecations.yml` id:`changelog-writer-custom-log`.
+  pushWarning({
+    code: 'W_DEPRECATED',
+    message:
+      'writeChangelogSection (ADR-028 custom-log blocks) is deprecated. Use `cleo changeset add` (T9793).',
+    severity: 'warn',
+    deprecated: 'writeChangelogSection',
+    replacement: 'cleo changeset add',
+    removeBy: 'v2026.6.0',
+    context: {
+      registryId: 'changelog-writer-custom-log',
+      task: 'T9795',
+      saga: 'T9787',
+    },
+  });
   let existing = '';
   if (existsSync(changelogPath)) {
     existing = await readFile(changelogPath, 'utf8');

--- a/packages/core/src/tools/adr-backfill-walker.ts
+++ b/packages/core/src/tools/adr-backfill-walker.ts
@@ -542,6 +542,11 @@ export async function runAdrBackfillWalker(
 
 /**
  * Write the backfill report to `.cleo/agent-outputs/T1824-5-backfill-report.md`.
+ *
+ * @deprecated Since v2026.5.93 (T9795 / Saga T9787). Raw `.md` writes to
+ *   `.cleo/agent-outputs/` bypass the docs registry SSoT — migrate to
+ *   `cleo docs add --type note` (T9788). Removal: no earlier than
+ *   v2026.6.0. See `.cleo/deprecations.yml` id:`agent-output-raw-md-write`.
  */
 async function writeReport(
   projectRoot: string,

--- a/packages/core/src/ui/changelog.ts
+++ b/packages/core/src/ui/changelog.ts
@@ -7,10 +7,18 @@
  *
  * @task T4454
  * @epic T4454
+ *
+ * @deprecated Since v2026.5.93 (T9795 / Saga T9787). Will be removed no
+ *   earlier than v2026.6.0. Label-grouped task→changelog rendering is
+ *   superseded by the LLM-driven release-notes composer (T9759) which
+ *   consumes the canonical Release Plan envelope produced by
+ *   `cleo release plan`. See `.cleo/deprecations.yml` (id:
+ *   `ui-changelog-label-grouping`) for the migration table.
  */
 
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import type { Task } from '@cleocode/contracts';
+import { pushWarning } from '../output.js';
 import type { DataAccessor } from '../store/data-accessor.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 
@@ -46,6 +54,10 @@ interface ChangelogTask {
 /**
  * Discover task IDs for a release from completed tasks.
  * Optionally filtered by date range or specific task IDs.
+ *
+ * @deprecated Since v2026.5.93. Migrate to the Release Plan envelope from
+ *   `cleo release plan` + the T9759 LLM composer. Removal: no earlier than
+ *   v2026.6.0.
  */
 export async function discoverReleaseTasks(
   options: {
@@ -205,6 +217,10 @@ export function appendToChangelog(filePath: string, newContent: string): void {
 
 /**
  * Full changelog generation: discover tasks, group, generate, write.
+ *
+ * @deprecated Since v2026.5.93. Use `cleo release plan` + the T9759 LLM
+ *   composer instead. Removal: no earlier than v2026.6.0. Tracked in
+ *   `.cleo/deprecations.yml` id:`ui-changelog-label-grouping`.
  */
 export async function generateChangelog(
   version: string,
@@ -218,6 +234,24 @@ export async function generateChangelog(
   cwd?: string,
   accessor?: DataAccessor,
 ): Promise<Record<string, unknown>> {
+  // T9795: structured deprecation warning on the LAFS envelope; surfaces
+  // on stderr only when the CLI is in human mode (renderer respects the
+  // format flag — pure JSON callers stay parseable).
+  pushWarning({
+    code: 'W_DEPRECATED',
+    message:
+      'generateChangelog (label-grouping renderer) is deprecated. Use `cleo release plan` + T9759 LLM composer.',
+    severity: 'warn',
+    deprecated: 'generateChangelog',
+    replacement: 'cleo release plan',
+    removeBy: 'v2026.6.0',
+    context: {
+      registryId: 'ui-changelog-label-grouping',
+      task: 'T9795',
+      saga: 'T9787',
+    },
+  });
+
   const date = new Date().toISOString().split('T')[0]!;
   const tasks = await discoverReleaseTasks(
     { since: options.since, until: options.until, taskIds: options.taskIds },

--- a/scripts/lint-deprecations.mjs
+++ b/scripts/lint-deprecations.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+/**
+ * Lint rule: .cleo/deprecations.yml is the source-of-truth for legacy
+ * code paths bearing TSDoc `@deprecated` markers.
+ *
+ * Verifies:
+ *   1. `.cleo/deprecations.yml` parses cleanly and conforms to
+ *      `.cleo/deprecations.schema.json`.
+ *   2. Every TSDoc `@deprecated` symbol-comment in a path/paths listed in
+ *      the registry — the file MUST contain at least one @deprecated tag.
+ *   3. Every registered path EXISTS on disk (catches stale entries after
+ *      file moves).
+ *   4. IDs are unique.
+ *
+ * Exits non-zero on any drift, printing every failure to stderr.
+ *
+ * @task T9795
+ * @saga T9787
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv from 'ajv';
+import { parse as parseYaml } from 'yaml';
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), '..');
+const REGISTRY_PATH = join(REPO_ROOT, '.cleo/deprecations.yml');
+const SCHEMA_PATH = join(REPO_ROOT, '.cleo/deprecations.schema.json');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const failures = [];
+
+/**
+ * Push a failure with a stable shape; we surface all of them at the end.
+ *
+ * @param {string} message
+ */
+function fail(message) {
+  failures.push(message);
+}
+
+// ─── Load registry + schema ───────────────────────────────────────────────────
+
+if (!existsSync(REGISTRY_PATH)) {
+  fail(`Registry missing: ${REGISTRY_PATH}`);
+  printAndExit();
+}
+if (!existsSync(SCHEMA_PATH)) {
+  fail(`Schema missing: ${SCHEMA_PATH}`);
+  printAndExit();
+}
+
+/** @type {unknown} */
+let registry;
+try {
+  registry = parseYaml(readFileSync(REGISTRY_PATH, 'utf-8'));
+} catch (err) {
+  fail(`Failed to parse YAML: ${REGISTRY_PATH} — ${/** @type {Error} */ (err).message}`);
+  printAndExit();
+}
+
+/** @type {object} */
+let schema;
+try {
+  schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf-8'));
+} catch (err) {
+  fail(`Failed to parse JSON schema: ${SCHEMA_PATH} — ${/** @type {Error} */ (err).message}`);
+  printAndExit();
+}
+
+// ─── 1. Schema validation ─────────────────────────────────────────────────────
+
+const ajv = new Ajv.default({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+const valid = validate(registry);
+if (!valid) {
+  for (const e of validate.errors ?? []) {
+    fail(
+      `Schema violation @ ${e.instancePath || '(root)'}: ${e.message} ${JSON.stringify(e.params)}`,
+    );
+  }
+}
+
+// Type-narrow after schema validation succeeds — if it failed, we still want
+// to attempt the structural checks so authors see all problems in one pass.
+const reg =
+  /** @type {{ version: number, deprecations: Array<{ id: string, path?: string, paths?: string[], since: string, remove: string, replacement: string, note: string }> }} */ (
+    registry
+  );
+
+// ─── 2. Path existence + collect all registered files ─────────────────────────
+
+/** @type {Map<string, string>} */
+const fileToEntryId = new Map();
+
+if (Array.isArray(reg?.deprecations)) {
+  /** @type {Set<string>} */
+  const seenIds = new Set();
+
+  for (const entry of reg.deprecations) {
+    if (!entry || typeof entry.id !== 'string') continue;
+
+    if (seenIds.has(entry.id)) {
+      fail(`Duplicate deprecation id: ${entry.id}`);
+    }
+    seenIds.add(entry.id);
+
+    /** @type {string[]} */
+    const filesForEntry = [];
+    if (typeof entry.path === 'string') filesForEntry.push(entry.path);
+    if (Array.isArray(entry.paths)) filesForEntry.push(...entry.paths);
+
+    if (filesForEntry.length === 0) {
+      fail(`Entry ${entry.id} has no path/paths`);
+      continue;
+    }
+
+    for (const f of filesForEntry) {
+      // We skip glob expansion — `paths` may contain wildcards used for
+      // coverage scoping but the lint asserts the LITERAL path exists OR
+      // a clearly-globbed pattern (contains '**' / '*') is left alone.
+      const isGlob = f.includes('*');
+      if (isGlob) continue;
+      const absPath = join(REPO_ROOT, f);
+      if (!existsSync(absPath)) {
+        fail(`Entry ${entry.id} → path does not exist: ${f}`);
+        continue;
+      }
+      fileToEntryId.set(f, entry.id);
+    }
+  }
+}
+
+// ─── 3. Every registered file MUST contain a @deprecated TSDoc tag ────────────
+
+for (const [file, entryId] of fileToEntryId.entries()) {
+  const absPath = join(REPO_ROOT, file);
+  let contents = '';
+  try {
+    contents = readFileSync(absPath, 'utf-8');
+  } catch {
+    fail(`Entry ${entryId} → cannot read ${file}`);
+    continue;
+  }
+  if (!/@deprecated\b/.test(contents)) {
+    fail(
+      `Entry ${entryId} → file lacks @deprecated TSDoc: ${file}\n` +
+        `  Fix: add a TSDoc /** @deprecated Since v…  */ block, or remove the registry entry.`,
+    );
+  }
+}
+
+// ─── Report ───────────────────────────────────────────────────────────────────
+
+function printAndExit() {
+  if (failures.length === 0) {
+    process.stdout.write(
+      `lint-deprecations: OK — ${reg?.deprecations?.length ?? 0} entries validated\n`,
+    );
+    process.exit(0);
+  }
+  process.stderr.write(
+    `lint-deprecations: FAILED — ${failures.length} issue(s):\n` +
+      failures.map((m) => `  ✗ ${m}`).join('\n') +
+      '\n',
+  );
+  process.exit(1);
+}
+
+printAndExit();


### PR DESCRIPTION
## Summary

- Add TSDoc `@deprecated` markers to the 4 legacy changelog systems flagged by T9782 + the raw-md write path that bypasses the docs SSoT (5 entries total)
- Wire `pushWarning({ code: 'W_DEPRECATED' })` runtime warnings into `writeChangelogSection`, `generateChangelog`, `cleo release changelog`, and `cleo generate-changelog` — warnings surface via `meta.warnings[]` in the LAFS envelope, renderer drops to stderr only in human mode (JSON callers stay parseable)
- Create `.cleo/deprecations.yml` as the source-of-truth registry, validated by `.cleo/deprecations.schema.json` + `scripts/lint-deprecations.mjs`
- Add `Deprecations Registry Lint (T9795)` CI job

Closes T9795. Saga T9787.

## Scope (per T9782 audit)

5 legacy paths marked `@deprecated`:

| ID | Path | Replacement |
|---|---|---|
| `changelog-writer-custom-log` | `packages/core/src/release/changelog-writer.ts` | `cleo changeset add` (T9793) |
| `ui-changelog-label-grouping` | `packages/core/src/ui/changelog.ts` | `cleo release plan` (T9759 LLM composer) |
| `cleo-release-changelog-verb-git-log` | `packages/cleo/src/cli/commands/release.ts` | `cleo release plan` (T9525) |
| `generate-changelog-renderer` | `packages/cleo/src/cli/commands/generate-changelog.ts` | `cleo changeset add` + aggregator (T9793) |
| `agent-output-raw-md-write` | `packages/core/src/tools/adr-backfill-walker.ts` | `cleo docs add --type note` (T9788) |

All 5 deprecations target removal **no earlier than v2026.6.0**. No code was deleted in this PR — markers + warnings only.

## Acceptance Criteria

- [x] All 4 changelog systems + agent-output raw-md path carry `@deprecated` TSDoc with removal-version + migration-command
- [x] Runtime warning emitted via `pushWarning` (queued in `meta.warnings[]`, stderr only in human mode)
- [x] `.cleo/deprecations.yml` lists each deprecation with `id`, `path`, `since`, `remove`, `replacement`, `note`
- [x] JSON Schema (`.cleo/deprecations.schema.json`) enforces structure
- [x] CI gate (`scripts/lint-deprecations.mjs`) catches drift: schema violation, missing file, missing `@deprecated` tag, duplicate IDs
- [x] Tests cover schema validity, registry coverage, ID uniqueness, and warning emission from `writeChangelogSection` + `generateChangelog`

## Test plan

- [x] `node scripts/lint-deprecations.mjs` → `OK — 5 entries validated`
- [x] `pnpm --filter @cleocode/core exec vitest run src/__tests__/deprecations-registry.test.ts` → 7/7 pass
- [x] `pnpm --filter @cleocode/core exec vitest run src/release/__tests__/` → 295/295 pass (no regressions)
- [x] `pnpm --filter @cleocode/core run build` → clean
- [x] `pnpm --filter @cleocode/cleo run build` → clean
- [x] `pnpm --filter @cleocode/core run typecheck` → clean
- [x] `pnpm biome check` on all modified files → clean

## Hard rules followed

- No deprecated code was deleted — markers + warnings only
- Runtime warnings flow through `pushWarning()` → `meta.warnings[]`; renderers respect human/JSON mode (no raw stderr writes)
- All new `@deprecated` TSDocs reference the registry ID for traceability