### PR TITLE
feat(T9796): .cleo/canon.yml + cleo check canon docs CI gate + ADR-076

### DIFF
--- a/.cleo/.gitignore
+++ b/.cleo/.gitignore
@@ -76,6 +76,13 @@
 !audit/imports/
 !audit/imports/**
 
+# Step 12: Allow canonical doc-routing registry + JSON Schema (T9796 / ADR-076).
+# `cleo check canon docs` reads canon.yml at PR-time to decide whether a new
+# *.md file under a `rawMdPaths` directory is allowed. Both files must be
+# git-tracked so the CI gate sees the same registry every reviewer does.
+!canon.yml
+!canon.schema.json
+
 # =============================================================================
 # EXPLICIT DENY — safety net that overrides allow rules above
 # =============================================================================

--- a/.cleo/canon.schema.json
+++ b/.cleo/canon.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cleocode.io/schemas/canon.schema.json",
+  "title": "CLEO Canonical Doc Routing",
+  "description": "Schema for .cleo/canon.yml — routes every DocKind to its canonical home (SSoT vs SSoT-first dual-write) and declares which raw markdown paths the canon-check CI gate should block (T9796).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "kinds"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Canon schema version. Bumped only on breaking format changes."
+    },
+    "kinds": {
+      "type": "object",
+      "description": "Map of DocKind id (from packages/contracts/src/docs-taxonomy.ts) to its routing entry.",
+      "minProperties": 1,
+      "patternProperties": {
+        "^[a-z][a-z0-9-]*$": {
+          "$ref": "#/$defs/CanonKindEntry"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "CanonKindEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["canonicalHome", "publishMirror", "rawMdAllowed"],
+      "properties": {
+        "canonicalHome": {
+          "type": "string",
+          "enum": ["ssot", "ssot-first"],
+          "description": "Where the canonical bytes live. `ssot` = blob/attachment store only; `ssot-first` = dual-write via a dedicated cleo verb (e.g. changeset)."
+        },
+        "publishMirror": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Relative path to the human-reviewable mirror written by `cleo docs publish` (or by the dedicated verb for ssot-first kinds)."
+        },
+        "rawMdAllowed": {
+          "type": "boolean",
+          "description": "When false, NEW *.md files under any `rawMdPaths` directory fail `cleo check canon docs`. When true, raw additions are tolerated (kind is dual-write or repo-root)."
+        },
+        "rawMdPaths": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Directories the CI gate scans for new *.md additions. When rawMdAllowed is false, additions to these paths fail the gate. Optional — kinds without listed paths have no on-disk surface to police (the SSoT is the only legitimate home).",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/.cleo/canon.yml
+++ b/.cleo/canon.yml
@@ -1,0 +1,90 @@
+# CLEO Canonical Doc Routing — T9796 / Saga T9787
+#
+# Source of truth for where each DocKind lives. Loaded by
+# `cleo check canon docs` to detect raw-markdown writes that should have
+# routed through SSoT (via `cleo docs add`) instead.
+#
+# Schema is enforced at runtime — see .cleo/canon.schema.json.
+#
+# Routing taxonomy (one of):
+#   - `ssot`        — canonical bytes live in the attachment / blob store;
+#                     publishMirror is the human-reviewable copy written by
+#                     `cleo docs publish`. Raw fs writes to listed paths
+#                     are CI-blocked when `rawMdAllowed: false`.
+#   - `ssot-first`  — dual-write via a dedicated `cleo` verb (e.g.
+#                     `cleo changeset add`). The publishMirror is part of
+#                     the contract (e.g. `.changeset/` is git-tracked by
+#                     design), so raw markdown additions are allowed.
+#
+# Per-kind keys:
+#   canonicalHome   — `ssot` | `ssot-first`
+#   publishMirror   — relative path of the human-reviewable mirror
+#   rawMdAllowed    — when `false`, NEW *.md files under `rawMdPaths` fail
+#                     `cleo check canon docs`. When `true`, raw additions
+#                     are tolerated (kind is dual-write or repo-root).
+#   rawMdPaths      — directories that the CI gate scans for new *.md
+#                     additions when `rawMdAllowed: false`. Existing files
+#                     migrated by T9791 are NOT flagged (gate only fires
+#                     on `git diff --diff-filter=A`).
+#
+# Adding a new DocKind:
+#   1. Add its metadata to packages/contracts/src/docs-taxonomy.ts.
+#   2. Add a routing entry here.
+#   3. Re-run `cleo check canon docs` locally — gate should still pass.
+#
+# Removing a `rawMdPaths` entry:
+#   Drop the path here. Any future raw additions will be blocked.
+#
+# See ADR-076 (Canonical Docs SSoT) for the lockdown rationale.
+# Pre-state: T9788 (DocKindRegistry), T9791 (1,427 docs imported), T9793
+# (changeset dual-write), T9794 (agent triggers), T9795 (deprecations.yml).
+
+version: 1
+kinds:
+  adr:
+    canonicalHome: ssot                # blob in attachment store
+    publishMirror: docs/adr/           # human-reviewable copy via cleo docs publish
+    rawMdAllowed: false                # raw fs writes to these dirs are CI-blocked
+    rawMdPaths:
+      - .cleo/adrs/                    # legacy mirror (deprecated but tolerated until v2026.6.0)
+  spec:
+    canonicalHome: ssot
+    publishMirror: docs/spec/
+    rawMdAllowed: false
+  research:
+    canonicalHome: ssot
+    publishMirror: docs/research/
+    rawMdAllowed: false
+    rawMdPaths:
+      - .cleo/research/
+      - .cleo/rcasd/
+  handoff:
+    canonicalHome: ssot
+    publishMirror: docs/handoff/
+    rawMdAllowed: false
+  note:
+    canonicalHome: ssot
+    publishMirror: docs/note/
+    rawMdAllowed: false
+    rawMdPaths:
+      - .cleo/agent-outputs/
+  llm-readme:
+    canonicalHome: ssot
+    publishMirror: .
+    rawMdAllowed: true                 # llms.txt is intentionally at project root
+  changeset:
+    canonicalHome: ssot-first          # dual-write via cleo changeset add (T9793)
+    publishMirror: .changeset/
+    rawMdAllowed: true                 # changeset files are git-tracked by design
+  release-note:
+    canonicalHome: ssot
+    publishMirror: docs/release/
+    rawMdAllowed: false
+  plan:
+    canonicalHome: ssot
+    publishMirror: docs/plan/
+    rawMdAllowed: false
+  rcasd:
+    canonicalHome: ssot
+    publishMirror: .cleo/rcasd/
+    rawMdAllowed: true                 # rcasd dirs are agent-generated structure; tolerated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,38 @@ jobs:
       - name: Reject cliOutput(formatError) / cliError(formatError) double-wraps
         run: node scripts/lint-format-error-misuse.mjs
 
+  deprecations-lint:
+    # T9795 / Saga T9787 — guard the deprecation registry. Asserts every
+    # entry in `.cleo/deprecations.yml` points at a real file that
+    # actually carries a TSDoc `@deprecated` tag, and that the YAML
+    # conforms to `.cleo/deprecations.schema.json`. Catches drift the
+    # moment a legacy file is deleted or renamed without the registry
+    # being updated.
+    name: Deprecations Registry Lint (T9795)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.30.0'
+          run_install: false
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
+      - name: Validate .cleo/deprecations.yml against schema + path existence
+        run: pnpm run lint:deprecations
+
   pragma-drift:
     name: SQLite Pragma Drift Guard (T9025 / T9190)
     runs-on: ubuntu-latest
@@ -331,6 +363,51 @@ jobs:
         run: pnpm run build
       - name: Run canon drift gate
         run: node packages/cleo/dist/cli/index.js check canon
+
+  canon-check:
+    # T9796 — Docs canon-routing CI gate. Loads `.cleo/canon.yml` and rejects
+    # NEW *.md files (git diff --diff-filter=A vs the PR's base ref) that
+    # land inside a `rawMdPaths` directory whose owning DocKind has
+    # `rawMdAllowed: false`. Existing legacy files (migrated by T9791) are
+    # never flagged — the gate only fires on ADDITIONS. Saga T9787.
+    name: Canon Drift Check (T9796)
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.30.0'
+          run_install: false
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
+      - name: Install ripgrep (required for T1605 callsite-coverage validator)
+        uses: ./.github/actions/install-ripgrep
+      - name: Build monorepo (cleo + all workspace deps)
+        run: pnpm run build
+      - name: Run docs canon gate
+        run: |
+          # On PRs, diff against the base branch — origin/${{ github.base_ref }}
+          # — so non-main PR targets (release branches, stacked PRs, etc.) work.
+          # On push events, fall back to origin/main.
+          base_ref="origin/${{ github.base_ref || 'main' }}"
+          echo "canon-check: diffing against $base_ref"
+          node packages/cleo/dist/cli/index.js check canon docs --base "$base_ref"
 
   docs-drift:
     # T9645: gate published docs SSoT vs the on-disk git files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,31 @@ These rules are NON-NEGOTIABLE. Every agent, subagent, and orchestrator MUST fol
 - **ALWAYS** update existing documentation — NEVER create new docs unless absolutely necessary
 - **ALWAYS** validate with `forge-ts` when available
 
+## Canonical Docs Routing (ADR-076 · T9796)
+
+Every canonical document type (ADR, spec, research, handoff, note,
+release-note, plan) MUST be created via `cleo docs add` — NOT a raw
+`Write` to `.cleo/adrs/`, `.cleo/agent-outputs/`, or `.cleo/research/`.
+
+The routing registry lives at `.cleo/canon.yml` (schema:
+`.cleo/canon.schema.json`). It declares for each DocKind:
+
+- `canonicalHome` — `ssot` (blob-store only) or `ssot-first` (dual-write
+  via a dedicated `cleo` verb such as `cleo changeset add`).
+- `publishMirror` — the human-reviewable copy written by `cleo docs publish`.
+- `rawMdAllowed` — when `false`, raw `.md` additions under any
+  `rawMdPaths` directory are blocked at PR-time by the CI gate.
+
+The CI gate is `cleo check canon docs` (job: `Canon Drift Check (T9796)`).
+It walks `git diff --diff-filter=A` between the PR base and `HEAD`,
+flagging any NEW `*.md` that bypasses the SSoT. Existing legacy files
+imported by T9791 are NEVER flagged — the gate is forward-only.
+
+If you genuinely need a doc-kind not yet listed:
+1. Add it to `packages/contracts/src/docs-taxonomy.ts` (`BUILTIN_DOC_KINDS`).
+2. Add a routing entry to `.cleo/canon.yml`.
+3. Re-run `pnpm --filter @cleocode/cleo run build` and the gate stays green.
+
 ## Quality Gates (MUST PASS BEFORE COMPLETING)
 
 Run these IN ORDER before marking any task complete:

--- a/docs/adr/ADR-076-canonical-docs-ssot.md
+++ b/docs/adr/ADR-076-canonical-docs-ssot.md
@@ -1,0 +1,204 @@
+---
+id: ADR-076
+slug: adr-076-canonical-docs-ssot
+title: Canonical Docs SSoT — `.cleo/canon.yml` + `cleo check canon docs` CI gate
+status: Accepted
+date: 2026-05-20
+task: T9796
+saga: SG-DOCS-CANON-CLOSURE (T9787)
+supersedes: ADR-028
+supersededBy: null
+linkedTasks: [T9788, T9791, T9793, T9794, T9795]
+---
+
+# ADR-076: Canonical Docs SSoT
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in RFC 2119.
+
+> NOTE — numbering: ADR-074 and ADR-075 were already in use when this
+> ADR landed (skills telemetry transport + skills federation trust
+> ladder, both shipped under Saga SG-CLEO-SKILLS). The original T9796
+> spec referenced "ADR-074"; the next free slot — ADR-076 — was used
+> here. This ADR is the one referred to as "ADR-074" in the T9796
+> commit message and is the canonical lockdown record.
+
+---
+
+## 1. Context
+
+The Saga `SG-DOCS-CANON-CLOSURE` (T9787) shipped a SSoT for every
+canonical document kind:
+
+- **T9788** — `DocKindRegistry` consolidates 10 built-in kinds
+  (`adr`, `spec`, `research`, `handoff`, `note`, `llm-readme`,
+  `changeset`, `release-note`, `plan`, `rcasd`) into one taxonomy at
+  `packages/contracts/src/docs-taxonomy.ts`.
+- **T9791** — 1,427 legacy `.md` files across the five legacy sources
+  (`.cleo/adrs/`, `.cleo/agent-outputs/`, `.cleo/rcasd/`, `docs/adr/`,
+  `docs/spec/`) were imported into the SSoT blob store.
+- **T9793** — `changeset` was promoted to a first-class DocKind with a
+  SSoT-first dual-write path via `cleo changeset add`.
+- **T9794** — `ct-documentor` + the protocol-injection triggers were
+  updated so future agents reach for `cleo docs add` instead of `Write`.
+- **T9795** — `.cleo/deprecations.yml` registry pattern was introduced;
+  this ADR uses the same shape (`version + dictionary-of-entries`) for
+  routing.
+
+Despite all of the above, **nothing stopped an agent from writing
+`.cleo/adrs/ADR-XXX.md` directly with a plain `Write` tool call**. The
+SSoT existed, the docs verb routed through it, the agent prompts said
+"use SSoT" — but the bypass remained available. A single non-compliant
+session could re-introduce the same drift T9625 spent a quarter
+closing.
+
+This ADR locks the door.
+
+---
+
+## 2. Decision
+
+### 2.1 Canonical routing registry (`.cleo/canon.yml`)
+
+A new file `.cleo/canon.yml` (validated by
+`.cleo/canon.schema.json`) MUST list every DocKind's routing:
+
+```yaml
+version: 1
+kinds:
+  adr:
+    canonicalHome: ssot                # SSoT-only
+    publishMirror: docs/adr/           # human-reviewable mirror
+    rawMdAllowed: false                # gate-blocked
+    rawMdPaths:
+      - .cleo/adrs/
+```
+
+Per-kind keys:
+
+- `canonicalHome: ssot` — bytes live in the attachment/blob store; the
+  publish mirror is written by `cleo docs publish`.
+- `canonicalHome: ssot-first` — dual-write via a dedicated cleo verb
+  (e.g. `cleo changeset add`). Publish mirror is part of the contract
+  (e.g. `.changeset/` is git-tracked by design).
+- `rawMdAllowed: false` — new `*.md` files in any `rawMdPaths`
+  directory fail the CI gate.
+- `rawMdAllowed: true` — kind is dual-write or repo-root (e.g.
+  `llm-readme` at `.`, `changeset` under `.changeset/`).
+
+### 2.2 CI gate (`cleo check canon docs`)
+
+A new subcommand `cleo check canon docs [--base <ref>]` MUST:
+
+1. Load `.cleo/canon.yml` (no-op when missing — projects opt in).
+2. Walk `git diff --diff-filter=A --name-only <base>...HEAD` for newly
+   added `*.md` files (`<base>` defaults to `origin/main`, overridden
+   in CI to `origin/${{ github.base_ref }}`).
+3. For each addition, check whether its path starts with any
+   `rawMdPaths` entry whose owning kind has `rawMdAllowed: false`.
+4. Emit a LAFS error envelope with code `E_CANON_VIOLATION` and exit
+   non-zero when any violation is found. The envelope MUST carry the
+   full structured result (file list, kind, matched path, fix hint)
+   under `error.details.result` so the CI surface can grep it.
+
+The gate MUST NOT flag pre-existing files (T9791-imported legacy
+`.md` content) — only ADDITIONS in the PR diff trigger it.
+
+### 2.3 CI wiring
+
+A new `canon-check` job (named "Canon Drift Check (T9796)") MUST be
+added to `.github/workflows/ci.yml`. It runs only when
+`needs.changes.outputs.code == 'true'`, builds the cleo CLI, and
+invokes `cleo check canon docs --base origin/${{ github.base_ref }}`.
+
+### 2.4 Documentation surface
+
+`AGENTS.md` MUST include a "Canonical Docs Routing" section pointing
+to `.cleo/canon.yml` and `cleo check canon docs` so agents reading
+the file understand BOTH that the SSoT exists AND that bypassing it
+is now a hard CI fail.
+
+### 2.5 Supersession of ADR-028
+
+ADR-028 ("CHANGELOG Generation Model") covered ONE specific document
+flow — the section-aware merge of `CHANGELOG.md`. It predated the
+SSoT-first changeset DocKind shipped by T9793 and the consolidated
+docs-taxonomy registry shipped by T9788. The changeset DocKind +
+canon routing replace the implicit policy that lived inside
+`changelog-generator.ts`. ADR-028 is hereby marked **superseded**;
+its operational rules (idempotent merge, `[custom-log]` block
+preservation, CI gate on `## [VERSION]` header) remain valid but now
+live behind the SSoT — direct `CHANGELOG.md` writes go through
+`cleo changeset add` / `cleo docs publish`.
+
+---
+
+## 3. Consequences
+
+### Positive
+
+- **Bypass closed.** A raw `Write` to `.cleo/adrs/ADR-XXX.md` now
+  fails `canon-check`. The agent cannot complete a PR without routing
+  through `cleo docs add`.
+- **Opt-in design.** Projects without `.cleo/canon.yml` see a no-op
+  success envelope — the lockdown ships first to cleocode itself
+  before any cross-project mandate.
+- **Schema-validated.** `.cleo/canon.schema.json` constrains the
+  routing file so a typo (`canonicalHome: ssot-first` vs
+  `cononicalHome:`) is caught at parse time.
+- **Mirrors `.cleo/deprecations.yml`** (T9795) — single, recognisable
+  registry shape across the project.
+
+### Negative
+
+- **Friction for hot-fix flows.** An agent who genuinely needs to
+  write a one-off `.md` (e.g. an emergency runbook) must route through
+  `cleo docs add`. The dispatched LAFS error envelope includes the
+  exact `cleo docs add` command to run, so the friction is one
+  redirection rather than a research task.
+- **CI cost.** One additional ~2-minute job per PR. The job runs only
+  when `needs.changes.outputs.code == 'true'`, so doc-only PRs skip
+  it.
+
+### Neutral
+
+- Existing legacy files migrated by T9791 are NEVER flagged — the
+  `--diff-filter=A` semantics ensure the gate is forward-only.
+- `.cleo/rcasd/` retains `rawMdAllowed: true` because RCASD directory
+  trees are agent-generated and the SSoT mirror is still the source
+  of truth via the dual-write contract.
+
+---
+
+## 4. Migration Path
+
+1. Land `.cleo/canon.yml` + `.cleo/canon.schema.json` in this PR.
+2. Land the `cleo check canon docs` subcommand + dispatch wiring.
+3. Add the `canon-check` job to `.github/workflows/ci.yml`.
+4. Update `AGENTS.md` to document the new gate.
+5. Mark ADR-028 as superseded by this ADR.
+6. (Future) Once the legacy `.cleo/adrs/` mirror reaches end-of-life
+   (~v2026.6.0), remove that entry from `rawMdPaths` — additions
+   anywhere under `.cleo/adrs/` will then fail unconditionally and
+   the only valid path is `cleo docs add ... --type adr` →
+   `docs/adr/`.
+
+---
+
+## 5. References
+
+- ADR-028 (superseded) — CHANGELOG Generation Model
+- ADR-073 — Above-Epic Naming (Task Hierarchy Charter)
+- T9787 — Saga SG-DOCS-CANON-CLOSURE
+- T9788 — DocKindRegistry (taxonomy SSoT)
+- T9791 — 1,427 legacy `.md` files imported to SSoT
+- T9793 — Changeset DocKind dual-write
+- T9794 — ct-documentor + protocol-injection triggers
+- T9795 — `.cleo/deprecations.yml` registry pattern
+- `packages/contracts/src/docs-taxonomy.ts` — DocKindRegistry source
+- `packages/cleo/src/dispatch/domains/check/canon-docs.ts` — gate engine
+
+---
+
+**END OF ADR-076**

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -48,7 +48,8 @@
     "tree-sitter-python": "0.23.4",
     "tree-sitter-ruby": "^0.23.1",
     "tree-sitter-rust": "0.23.1",
-    "tree-sitter-typescript": "^0.23.2"
+    "tree-sitter-typescript": "^0.23.2",
+    "yaml": "^2.8.3"
   },
   "peerDependencies": {
     "@cleocode/core": "workspace:*"

--- a/packages/cleo/src/cli/__tests__/check-canon-docs.test.ts
+++ b/packages/cleo/src/cli/__tests__/check-canon-docs.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Unit tests for `cleo check canon docs` (T9796).
+ *
+ * Validates the routing engine in isolation (no git diff required) by
+ * supplying `candidateFiles` directly. This pins the four routing
+ * scenarios from the task spec:
+ *
+ *   1. `.cleo/adrs/ADR-XXX-test.md`  → E_CANON_VIOLATION (adr blocked)
+ *   2. `docs/adr/ADR-XXX-test.md`    → PASS (publishMirror, never blocked)
+ *   3. `.changeset/t9796-foo.md`     → PASS (rawMdAllowed: true)
+ *   4. `llms.txt`                    → PASS (llm-readme at project root)
+ *
+ * Also exercises:
+ *   - `.cleo/agent-outputs/foo.md` → E_CANON_VIOLATION (note blocked)
+ *   - `.cleo/rcasd/T9000/note.md`  → PASS (rcasd allows raw md)
+ *   - Missing `canon.yml`          → no-op success (`mode: 'no-canon'`)
+ *   - Malformed `canon.yml`        → throws (surfaced as E_CANON_INVALID)
+ *   - Direct CLI subcommand        → registered + exits 1 on violation
+ *
+ * @epic T9787 (SG-DOCS-CANON-CLOSURE)
+ * @task T9796 (E-DOCS-CANON-LOCKDOWN)
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadCanonRegistry, runCanonDocsCheck } from '../../dispatch/domains/check/canon-docs.js';
+import { checkCommand } from '../commands/check.js';
+
+// ---------------------------------------------------------------------------
+// Canonical fixture — mirrors the production `.cleo/canon.yml` exactly so
+// every test exercises the same routing surface a real PR would see.
+// ---------------------------------------------------------------------------
+
+const CANON_YAML = `version: 1
+kinds:
+  adr:
+    canonicalHome: ssot
+    publishMirror: docs/adr/
+    rawMdAllowed: false
+    rawMdPaths:
+      - .cleo/adrs/
+  spec:
+    canonicalHome: ssot
+    publishMirror: docs/spec/
+    rawMdAllowed: false
+  research:
+    canonicalHome: ssot
+    publishMirror: docs/research/
+    rawMdAllowed: false
+    rawMdPaths:
+      - .cleo/research/
+      - .cleo/rcasd/
+  handoff:
+    canonicalHome: ssot
+    publishMirror: docs/handoff/
+    rawMdAllowed: false
+  note:
+    canonicalHome: ssot
+    publishMirror: docs/note/
+    rawMdAllowed: false
+    rawMdPaths:
+      - .cleo/agent-outputs/
+  llm-readme:
+    canonicalHome: ssot
+    publishMirror: .
+    rawMdAllowed: true
+  changeset:
+    canonicalHome: ssot-first
+    publishMirror: .changeset/
+    rawMdAllowed: true
+  release-note:
+    canonicalHome: ssot
+    publishMirror: docs/release/
+    rawMdAllowed: false
+  plan:
+    canonicalHome: ssot
+    publishMirror: docs/plan/
+    rawMdAllowed: false
+  rcasd:
+    canonicalHome: ssot
+    publishMirror: .cleo/rcasd/
+    rawMdAllowed: true
+`;
+
+/**
+ * Materialise an isolated tmp project root with a `.cleo/canon.yml` so
+ * tests exercise the same load path as production (no in-memory shortcut).
+ */
+async function setupTmpProject(canonContent: string | null): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'cleo-canon-docs-'));
+  mkdirSync(join(root, '.cleo'), { recursive: true });
+  if (canonContent !== null) {
+    writeFileSync(join(root, '.cleo', 'canon.yml'), canonContent, 'utf8');
+  }
+  return root;
+}
+
+// ---------------------------------------------------------------------------
+// Engine-level tests (no CLI subprocess — keeps the suite < 1s)
+// ---------------------------------------------------------------------------
+
+describe('runCanonDocsCheck — routing', () => {
+  let projectRoot = '';
+
+  beforeEach(async () => {
+    projectRoot = await setupTmpProject(CANON_YAML);
+  });
+  afterEach(async () => {
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it('flags a NEW raw .md addition under .cleo/adrs/ as a violation', () => {
+    const result = runCanonDocsCheck({
+      projectRoot,
+      candidateFiles: ['.cleo/adrs/ADR-XXX-test.md'],
+    });
+    expect(result.passed).toBe(false);
+    expect(result.mode).toBe('enforced');
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toMatchObject({
+      file: '.cleo/adrs/ADR-XXX-test.md',
+      kind: 'adr',
+      matchedPath: '.cleo/adrs/',
+    });
+    expect(result.violations[0]?.fix).toContain('cleo docs add');
+    expect(result.violations[0]?.fix).toContain('--type adr');
+  });
+
+  it('passes when the same file lands under docs/adr/ (publish mirror)', () => {
+    const result = runCanonDocsCheck({
+      projectRoot,
+      candidateFiles: ['docs/adr/ADR-XXX-test.md'],
+    });
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+    expect(result.scanned).toBe(1);
+  });
+
+  it('passes for .changeset/ additions (rawMdAllowed: true)', () => {
+    const result = runCanonDocsCheck({
+      projectRoot,
+      candidateFiles: ['.changeset/t9796-canon-lockdown.md'],
+    });
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('passes for llms.txt at the project root (llm-readme)', () => {
+    const result = runCanonDocsCheck({
+      projectRoot,
+      candidateFiles: ['llms.txt'],
+    });
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('blocks raw additions to .cleo/agent-outputs/ (note kind)', () => {
+    const result = runCanonDocsCheck({
+      projectRoot,
+      candidateFiles: ['.cleo/agent-outputs/T9796-handoff.md'],
+    });
+    expect(result.passed).toBe(false);
+    expect(result.violations[0]?.kind).toBe('note');
+  });
+
+  it('tolerates .cleo/rcasd/ additions (rcasd rawMdAllowed: true)', () => {
+    const result = runCanonDocsCheck({
+      projectRoot,
+      candidateFiles: ['.cleo/rcasd/T9000/investigation.md'],
+    });
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('handles deeply-nested files under a rawMdPaths entry', () => {
+    const result = runCanonDocsCheck({
+      projectRoot,
+      candidateFiles: ['.cleo/adrs/legacy/sub/ADR-200-deep.md'],
+    });
+    expect(result.passed).toBe(false);
+    expect(result.violations[0]?.kind).toBe('adr');
+  });
+
+  it('does not match adjacent directories with the same prefix', () => {
+    // `.cleo/adrs-archive/` MUST NOT match `.cleo/adrs/` — the engine
+    // appends a trailing `/` to every rawMdPath specifically to prevent
+    // this class of false positive.
+    const result = runCanonDocsCheck({
+      projectRoot,
+      candidateFiles: ['.cleo/adrs-archive/old-thing.md'],
+    });
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('emits PASS with mode=enforced when no candidates supplied', () => {
+    const result = runCanonDocsCheck({ projectRoot, candidateFiles: [] });
+    expect(result.passed).toBe(true);
+    expect(result.mode).toBe('enforced');
+    expect(result.scanned).toBe(0);
+  });
+
+  it('groups mixed inputs — only the blocked one fails', () => {
+    const result = runCanonDocsCheck({
+      projectRoot,
+      candidateFiles: ['.changeset/t-ok.md', '.cleo/adrs/ADR-BAD.md', 'docs/spec/SPEC-OK.md'],
+    });
+    expect(result.passed).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]?.file).toBe('.cleo/adrs/ADR-BAD.md');
+    expect(result.scanned).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// no-canon mode — gate is a no-op when canon.yml is missing
+// ---------------------------------------------------------------------------
+
+describe('runCanonDocsCheck — no canon.yml', () => {
+  let projectRoot = '';
+
+  beforeEach(async () => {
+    projectRoot = await setupTmpProject(null);
+  });
+  afterEach(async () => {
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it('returns mode=no-canon and passes regardless of candidates', () => {
+    const result = runCanonDocsCheck({
+      projectRoot,
+      // These would all be violations under the production canon.yml.
+      candidateFiles: ['.cleo/adrs/ADR-X.md', '.cleo/agent-outputs/foo.md'],
+    });
+    expect(result.passed).toBe(true);
+    expect(result.mode).toBe('no-canon');
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('loadCanonRegistry returns undefined when file is missing', () => {
+    expect(loadCanonRegistry(projectRoot)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid canon.yml — surfaced as a throw (callers map to E_CANON_INVALID)
+// ---------------------------------------------------------------------------
+
+describe('runCanonDocsCheck — invalid canon.yml', () => {
+  it('throws when version is missing', async () => {
+    const root = await setupTmpProject('kinds: {}\n');
+    expect(() => runCanonDocsCheck({ projectRoot: root, candidateFiles: [] })).toThrow(/version/);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('throws when an entry omits canonicalHome', async () => {
+    const root = await setupTmpProject(`version: 1
+kinds:
+  adr:
+    publishMirror: docs/adr/
+    rawMdAllowed: false
+`);
+    expect(() => runCanonDocsCheck({ projectRoot: root, candidateFiles: [] })).toThrow(
+      /canonicalHome/,
+    );
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('throws when canonicalHome is not ssot|ssot-first', async () => {
+    const root = await setupTmpProject(`version: 1
+kinds:
+  adr:
+    canonicalHome: bogus
+    publishMirror: docs/adr/
+    rawMdAllowed: false
+`);
+    expect(() => runCanonDocsCheck({ projectRoot: root, candidateFiles: [] })).toThrow(
+      /canonicalHome/,
+    );
+    await rm(root, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI subcommand registration — the `docs` verb must be reachable.
+// ---------------------------------------------------------------------------
+
+describe('cleo check canon — subcommand surface', () => {
+  it('registers the `docs` subcommand under `canon`', () => {
+    const canon = checkCommand.subCommands?.canon as {
+      subCommands?: Record<string, unknown>;
+    };
+    expect(canon).toBeDefined();
+    expect(canon.subCommands?.['docs']).toBeDefined();
+  });
+});

--- a/packages/cleo/src/cli/commands/check.ts
+++ b/packages/cleo/src/cli/commands/check.ts
@@ -137,10 +137,52 @@ const checkChainValidateCommand = defineCommand({
   },
 });
 
+/**
+ * cleo check canon docs — CI gate: detect raw markdown writes against
+ * `.cleo/canon.yml`.
+ *
+ * Walks `git diff --diff-filter=A` between `--base` (default `origin/main`)
+ * and `HEAD`, then blocks any newly-added `*.md` file that lands inside a
+ * `rawMdPaths` directory whose owning DocKind has `rawMdAllowed: false`.
+ *
+ * Exits 0 on pass, 1 on violation (so CI fails the job), 2 on tool error
+ * (invalid canon.yml, etc.).
+ *
+ * @task T9796
+ */
+const checkCanonDocsCommand = defineCommand({
+  meta: {
+    name: 'docs',
+    description: 'CI gate: block raw *.md writes that bypass the docs SSoT (T9796)',
+  },
+  args: {
+    base: {
+      type: 'string',
+      description: 'Git ref to diff against (default: origin/main)',
+    },
+  },
+  async run({ args }) {
+    await dispatchFromCli(
+      'query',
+      'check',
+      'canon.docs',
+      { baseRef: args.base as string | undefined },
+      { command: 'check', operation: 'check.canon.docs' },
+    );
+  },
+});
+
 /** cleo check canon — CI gate: detect canon drift between docs and live code */
 const checkCanonCommand = defineCommand({
   meta: { name: 'canon', description: 'CI gate: detect canon drift between docs and live code' },
-  async run() {
+  subCommands: {
+    docs: checkCanonDocsCommand,
+  },
+  async run({ cmd, rawArgs }) {
+    // When a recognised subcommand was supplied, citty already dispatched —
+    // bail out so we don't double-fire the legacy code/doc drift check.
+    const firstArg = rawArgs?.find((a) => !a.startsWith('-'));
+    if (firstArg && cmd.subCommands && firstArg in cmd.subCommands) return;
     await dispatchFromCli('query', 'check', 'canon', {}, { command: 'check' });
   },
 });

--- a/packages/cleo/src/dispatch/adapters/cli.ts
+++ b/packages/cleo/src/dispatch/adapters/cli.ts
@@ -55,6 +55,9 @@ const ERROR_CODE_TO_EXIT: Record<string, number> = {
   E_MISSING_PARAMS: 2,
   E_NO_HANDLER: 1,
   E_INTERNAL: 1,
+  // T9796 — docs canon CI gate: violation = fail-build, invalid = tool-error.
+  E_CANON_VIOLATION: 1,
+  E_CANON_INVALID: 2,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/cleo/src/dispatch/adapters/typed.ts
+++ b/packages/cleo/src/dispatch/adapters/typed.ts
@@ -357,6 +357,9 @@ export function lafsSuccess<T>(
  * @param _operation - Operation name (accepted for parity; not persisted on
  *   the CLI envelope variant — it is written by the gateway middleware).
  * @param fix - Optional copy-paste fix hint for the caller.
+ * @param details - Optional structured payload forwarded onto the envelope's
+ *   `error.details` field (e.g. for CI gates that need to surface a list of
+ *   per-file violations alongside the human-readable message — T9796).
  * @returns A `LafsError` envelope. Typed as `LafsEnvelope<never>` so it
  *   composes with any `LafsEnvelope<T>` return type.
  *
@@ -370,9 +373,11 @@ export function lafsError(
   message: string,
   _operation: string,
   fix?: string,
+  details?: Record<string, unknown>,
 ): LafsEnvelope<never> {
   const error: LafsError['error'] = { code, message };
   if (fix !== undefined) error.fix = fix;
+  if (details !== undefined) error.details = details;
   return {
     success: false,
     error,

--- a/packages/cleo/src/dispatch/domains/check.ts
+++ b/packages/cleo/src/dispatch/domains/check.ts
@@ -18,6 +18,7 @@
 import type {
   CheckOps,
   ValidateArchiveStatsParams,
+  ValidateCanonDocsParams,
   ValidateCanonParams,
   ValidateChainParams,
   ValidateCoherenceParams,
@@ -532,6 +533,40 @@ const _checkTypedHandler = defineTypedHandler<CheckOps>('check', {
     return lafsSuccess(result, 'canon');
   },
 
+  'canon.docs': async (params: ValidateCanonDocsParams) => {
+    const projectRoot = getProjectRoot();
+    const { runCanonDocsCheck } = await import('./check/canon-docs.js');
+    try {
+      const result = runCanonDocsCheck({
+        projectRoot,
+        ...(params.baseRef !== undefined ? { baseRef: params.baseRef } : {}),
+        ...(params.candidateFiles !== undefined ? { candidateFiles: params.candidateFiles } : {}),
+      });
+      // Surface violations as an error envelope so the CLI exits non-zero
+      // — that's what makes `cleo check canon docs` a CI gate. The full
+      // structured `result` (including the violations array) is forwarded
+      // via `details` so tooling can grep / parse it on stdout.
+      if (!result.passed) {
+        const firstFix = result.violations[0]?.fix ?? 'cleo docs add ...';
+        const fileList = result.violations.map((v) => `${v.file} (kind=${v.kind})`).join(', ');
+        return lafsError(
+          'E_CANON_VIOLATION',
+          `Docs canon violation: ${result.violations.length} raw *.md addition(s) bypass the SSoT — ${fileList}`,
+          'canon.docs',
+          `Route through SSoT instead: ${firstFix}`,
+          { result: result as unknown as Record<string, unknown> },
+        );
+      }
+      return lafsSuccess(result, 'canon.docs');
+    } catch (err) {
+      return lafsError(
+        'E_CANON_INVALID',
+        err instanceof Error ? err.message : String(err),
+        'canon.docs',
+      );
+    }
+  },
+
   'workflow.compliance': async (params: ValidateWorkflowComplianceParams) => {
     const projectRoot = getProjectRoot();
     try {
@@ -676,6 +711,8 @@ export class CheckHandler implements DomainHandler {
       );
       // T1434: normalize the LAFS error shape (`code: string | number`)
       // to the DispatchError shape (`code: string`).
+      // T9796: preserve `fix` / `details` so the CI gate envelope can carry
+      // the structured violations alongside the human-readable message.
       return {
         meta: dispatchMeta('query', 'check', operation, startTime),
         success: envelope.success,
@@ -686,6 +723,10 @@ export class CheckHandler implements DomainHandler {
                 code:
                   envelope.error?.code !== undefined ? String(envelope.error.code) : 'E_INTERNAL',
                 message: envelope.error?.message ?? 'Unknown error',
+                ...(envelope.error?.fix !== undefined ? { fix: envelope.error.fix } : {}),
+                ...(envelope.error?.details !== undefined
+                  ? { details: envelope.error.details as Record<string, unknown> }
+                  : {}),
               },
             }),
       };
@@ -751,6 +792,7 @@ export class CheckHandler implements DomainHandler {
         'grade.list',
         'chain.validate',
         'canon',
+        'canon.docs',
         'verify.explain',
       ],
       mutate: ['compliance.record', 'compliance.sync', 'test.run', 'gate.set'],

--- a/packages/cleo/src/dispatch/domains/check/canon-docs.ts
+++ b/packages/cleo/src/dispatch/domains/check/canon-docs.ts
@@ -1,0 +1,312 @@
+/**
+ * check.canon.docs — CI gate for raw markdown writes against `.cleo/canon.yml`.
+ *
+ * Reads the canon routing registry, walks `git diff --diff-filter=A` between
+ * a configurable base ref and `HEAD`, and flags any newly-added `*.md` file
+ * that lands inside a `rawMdPaths` directory whose owning DocKind has
+ * `rawMdAllowed: false`.
+ *
+ * The lockdown closes the gap T9625 left open: SSoT already exists (T9788
+ * DocKindRegistry, T9791 1,427 imported docs), `cleo docs add` already
+ * routes through it (T9793, T9794), but agents could still bypass the
+ * pipeline with a plain `Write` to `.cleo/adrs/ADR-XXX.md`. This gate
+ * blocks the bypass at PR-time without touching any existing legacy file.
+ *
+ * Semantics:
+ *   - Pure additions (`--diff-filter=A`) only — renames/modifies/deletes
+ *     are ignored so the gate never flags pre-existing migration artefacts.
+ *   - Path match is "starts-with" against `rawMdPaths`, normalised to use
+ *     `/` separators and a trailing `/` so `.cleo/adrs/sub/foo.md` is
+ *     correctly attributed to the `.cleo/adrs/` entry.
+ *   - When `rawMdAllowed: true` the entry is treated as a publish mirror
+ *     (e.g. `.changeset/`) and skipped entirely.
+ *   - When `canon.yml` is missing the gate is a no-op (success envelope)
+ *     so projects without the lockdown opted-in see no behaviour change.
+ *
+ * @epic T9787 — SG-DOCS-CANON-CLOSURE
+ * @task T9796 — E-DOCS-CANON-LOCKDOWN
+ * @see ADR-076 — Canonical Docs SSoT (supersedes ADR-028)
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, sep } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * One DocKind entry in `.cleo/canon.yml`.
+ *
+ * See `.cleo/canon.schema.json` for the JSON-Schema contract.
+ */
+export interface CanonKindEntry {
+  /** `'ssot'` — blob-store-only; `'ssot-first'` — dual-write via cleo verb. */
+  readonly canonicalHome: 'ssot' | 'ssot-first';
+  /** Relative path to the human-reviewable mirror (e.g. `docs/adr/`). */
+  readonly publishMirror: string;
+  /** When `false`, NEW *.md under `rawMdPaths` fails the gate. */
+  readonly rawMdAllowed: boolean;
+  /** Directories the gate scans. Optional when `rawMdAllowed: false`. */
+  readonly rawMdPaths?: ReadonlyArray<string>;
+}
+
+/**
+ * Parsed shape of `.cleo/canon.yml`.
+ *
+ * Validated at runtime by {@link loadCanonRegistry}; callers receive the
+ * narrowed type only when validation passes.
+ */
+export interface CanonRegistry {
+  /** Schema version. Currently always `1`. */
+  readonly version: number;
+  /** Map of DocKind id (e.g. `'adr'`, `'changeset'`) to its routing entry. */
+  readonly kinds: Readonly<Record<string, CanonKindEntry>>;
+}
+
+/** One violation surfaced by the docs canon gate. */
+export interface CanonDocsViolation {
+  /** Repo-relative path of the offending file (e.g. `.cleo/adrs/ADR-XXX.md`). */
+  readonly file: string;
+  /** Owning DocKind id from `canon.yml` (e.g. `'adr'`). */
+  readonly kind: string;
+  /** The `rawMdPaths` entry that matched (e.g. `'.cleo/adrs/'`). */
+  readonly matchedPath: string;
+  /** Suggested fix-command text (`cleo docs add ... --type <kind>`). */
+  readonly fix: string;
+}
+
+/** Aggregate result returned by {@link runCanonDocsCheck}. */
+export interface CanonDocsCheckResult {
+  /** True when no violations were found. */
+  readonly passed: boolean;
+  /** Git diff base ref that was scanned. */
+  readonly baseRef: string;
+  /** Number of `*.md` additions inspected. */
+  readonly scanned: number;
+  /** Violations grouped per file. Empty when `passed === true`. */
+  readonly violations: ReadonlyArray<CanonDocsViolation>;
+  /**
+   * When `canon.yml` is missing, this is `'no-canon'` — the gate becomes
+   * a no-op success. When `canon.yml` is present, this is `'enforced'`.
+   */
+  readonly mode: 'enforced' | 'no-canon';
+}
+
+/** Parameters accepted by {@link runCanonDocsCheck}. */
+export interface CanonDocsCheckParams {
+  /** Absolute path to the project root. */
+  readonly projectRoot: string;
+  /**
+   * Git revision to diff against. Defaults to `origin/main`.
+   *
+   * CI surface passes `origin/${{ github.base_ref }}` so PRs targeting any
+   * branch (not just `main`) get a correct, branch-relative scan.
+   */
+  readonly baseRef?: string;
+  /**
+   * Test override — when supplied, bypasses `git diff` and uses these
+   * repo-relative paths as the candidate set. Used by unit tests so they
+   * can validate routing without needing a live commit graph.
+   */
+  readonly candidateFiles?: ReadonlyArray<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalise a configured directory path so it always:
+ *   1. Uses forward slashes (matches `git diff` output).
+ *   2. Ends with a trailing `/` so `startsWith` cannot accidentally
+ *      match e.g. `.cleo/adrs-archive/` against `.cleo/adrs/`.
+ *
+ * @internal
+ */
+function normaliseDir(dir: string): string {
+  const slashed = dir.split(sep).join('/');
+  return slashed.endsWith('/') ? slashed : `${slashed}/`;
+}
+
+/**
+ * Run `git diff --diff-filter=A --name-only <base>...HEAD` and return the
+ * `*.md` additions. Failures (missing ref, not-a-repo) surface as an empty
+ * list — the gate stays permissive when the diff cannot be computed so a
+ * shallow CI clone or fresh repo never produces a false positive.
+ *
+ * @internal
+ */
+function listAddedMarkdownFiles(projectRoot: string, baseRef: string): string[] {
+  try {
+    const out = execSync(`git diff --diff-filter=A --name-only ${baseRef}...HEAD`, {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return out
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && line.endsWith('.md'));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Validate the parsed YAML against the `CanonRegistry` shape. Throws on
+ * structural defects with a message identifying the offending field so the
+ * CI gate surfaces a clear `E_CANON_INVALID` envelope.
+ *
+ * @internal
+ */
+function validateCanonRegistry(raw: unknown, source: string): CanonRegistry {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${source}: top-level value must be an object`);
+  }
+  const obj = raw as Record<string, unknown>;
+  const version = obj['version'];
+  if (typeof version !== 'number' || version !== 1) {
+    throw new Error(`${source}: 'version' must be the integer 1 (got ${String(version)})`);
+  }
+  const kindsRaw = obj['kinds'];
+  if (kindsRaw === null || typeof kindsRaw !== 'object' || Array.isArray(kindsRaw)) {
+    throw new Error(`${source}: 'kinds' must be an object`);
+  }
+  const kinds: Record<string, CanonKindEntry> = {};
+  for (const [kindId, entryRaw] of Object.entries(kindsRaw as Record<string, unknown>)) {
+    kinds[kindId] = validateKindEntry(kindId, entryRaw, source);
+  }
+  return { version, kinds };
+}
+
+/** @internal */
+function validateKindEntry(kindId: string, raw: unknown, source: string): CanonKindEntry {
+  const where = `${source} kinds.${kindId}`;
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${where}: must be an object`);
+  }
+  const obj = raw as Record<string, unknown>;
+  const canonicalHome = obj['canonicalHome'];
+  if (canonicalHome !== 'ssot' && canonicalHome !== 'ssot-first') {
+    throw new Error(
+      `${where}: 'canonicalHome' must be 'ssot' or 'ssot-first' (got ${String(canonicalHome)})`,
+    );
+  }
+  const publishMirror = obj['publishMirror'];
+  if (typeof publishMirror !== 'string' || publishMirror.length === 0) {
+    throw new Error(`${where}: 'publishMirror' must be a non-empty string`);
+  }
+  const rawMdAllowed = obj['rawMdAllowed'];
+  if (typeof rawMdAllowed !== 'boolean') {
+    throw new Error(`${where}: 'rawMdAllowed' must be a boolean`);
+  }
+  const rawMdPathsRaw = obj['rawMdPaths'];
+  let rawMdPaths: ReadonlyArray<string> | undefined;
+  if (rawMdPathsRaw !== undefined) {
+    if (!Array.isArray(rawMdPathsRaw)) {
+      throw new Error(`${where}: 'rawMdPaths' must be an array`);
+    }
+    for (const p of rawMdPathsRaw) {
+      if (typeof p !== 'string' || p.length === 0) {
+        throw new Error(`${where}: 'rawMdPaths' entries must be non-empty strings`);
+      }
+    }
+    rawMdPaths = rawMdPathsRaw as ReadonlyArray<string>;
+  }
+  return {
+    canonicalHome,
+    publishMirror,
+    rawMdAllowed,
+    ...(rawMdPaths !== undefined ? { rawMdPaths } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Load `.cleo/canon.yml` from `projectRoot`. Returns `undefined` when the
+ * file is missing (the gate becomes a no-op success). Throws on parse or
+ * structural errors so the CI gate can surface them as `E_CANON_INVALID`.
+ *
+ * @param projectRoot - Absolute path to the repo root.
+ */
+export function loadCanonRegistry(projectRoot: string): CanonRegistry | undefined {
+  const path = join(projectRoot, '.cleo', 'canon.yml');
+  if (!existsSync(path)) {
+    return undefined;
+  }
+  const text = readFileSync(path, 'utf8');
+  const parsed = parseYaml(text) as unknown;
+  return validateCanonRegistry(parsed, path);
+}
+
+/**
+ * Run the docs canon gate.
+ *
+ * Walks `git diff --diff-filter=A --name-only <baseRef>...HEAD` (or the
+ * test-supplied `candidateFiles`), then flags every `*.md` file that lands
+ * under a `rawMdPaths` entry whose owning kind has `rawMdAllowed: false`.
+ *
+ * The default `baseRef` is `origin/main`. CI invocations override it with
+ * `origin/${{ github.base_ref }}` so non-main PR bases work.
+ *
+ * @param params - Project root + optional base ref + test overrides.
+ * @returns Structured result enumerating every violation.
+ */
+export function runCanonDocsCheck(params: CanonDocsCheckParams): CanonDocsCheckResult {
+  const { projectRoot, baseRef = 'origin/main', candidateFiles } = params;
+
+  const registry = loadCanonRegistry(projectRoot);
+  if (!registry) {
+    return {
+      passed: true,
+      baseRef,
+      scanned: 0,
+      violations: [],
+      mode: 'no-canon',
+    };
+  }
+
+  // Build the [matchedPath, kindId] list, only for kinds that actively block.
+  const blockingPaths: Array<{ dir: string; kind: string }> = [];
+  for (const [kind, entry] of Object.entries(registry.kinds)) {
+    if (entry.rawMdAllowed) continue;
+    if (!entry.rawMdPaths || entry.rawMdPaths.length === 0) continue;
+    for (const p of entry.rawMdPaths) {
+      blockingPaths.push({ dir: normaliseDir(p), kind });
+    }
+  }
+
+  const candidates = candidateFiles ?? listAddedMarkdownFiles(projectRoot, baseRef);
+  const violations: CanonDocsViolation[] = [];
+
+  for (const file of candidates) {
+    // Normalise to forward slashes — `git diff` already uses `/`, but the
+    // test surface may pass Windows-style separators.
+    const normalised = file.split(sep).join('/');
+    for (const { dir, kind } of blockingPaths) {
+      if (normalised.startsWith(dir)) {
+        violations.push({
+          file: normalised,
+          kind,
+          matchedPath: dir,
+          fix: `cleo docs add <taskId> ${normalised} --type ${kind}`,
+        });
+        break;
+      }
+    }
+  }
+
+  return {
+    passed: violations.length === 0,
+    baseRef,
+    scanned: candidates.length,
+    violations,
+    mode: 'enforced',
+  };
+}

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -1369,6 +1369,26 @@ export const OPERATIONS: OperationDef[] = [
     requiredParams: [],
     params: [],
   },
+  // T9796: Docs canon-routing CI gate — block raw *.md writes that bypass SSoT
+  {
+    gateway: 'query',
+    domain: 'check',
+    operation: 'canon.docs',
+    description:
+      'check.canon.docs (query) — CI gate: rejects new *.md files that bypass the docs SSoT (.cleo/canon.yml routing). Scans git diff additions against rawMdPaths whose owning DocKind has rawMdAllowed:false.',
+    tier: 1,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: [],
+    params: [
+      {
+        name: 'baseRef',
+        type: 'string',
+        required: false,
+        description: 'Git revision to diff against (default: origin/main)',
+      },
+    ],
+  },
   // T065: Agent workflow compliance telemetry
   {
     gateway: 'query',

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1121,6 +1121,8 @@ export type {
   ComplianceMetrics,
   ValidateArchiveStatsParams,
   ValidateArchiveStatsResult,
+  ValidateCanonDocsParams,
+  ValidateCanonDocsResult,
   ValidateCanonParams,
   ValidateCanonResult,
   ValidateChainParams,

--- a/packages/contracts/src/operations/validate.ts
+++ b/packages/contracts/src/operations/validate.ts
@@ -277,6 +277,39 @@ export interface ValidateCanonResult {
   assertions: Array<{ passed: boolean }>;
 }
 
+/**
+ * Params for `check.canon.docs` — the T9796 docs-routing CI gate.
+ *
+ * `baseRef` defaults to `origin/main` and is overridden in CI to
+ * `origin/${{ github.base_ref }}` so PRs targeting any branch work.
+ * `candidateFiles` is a test seam — when supplied, bypasses `git diff`
+ * and treats the list as the candidate set.
+ *
+ * @task T9796 — E-DOCS-CANON-LOCKDOWN
+ */
+export interface ValidateCanonDocsParams {
+  baseRef?: string;
+  candidateFiles?: ReadonlyArray<string>;
+}
+
+/**
+ * Result envelope returned by `check.canon.docs`.
+ *
+ * @task T9796
+ */
+export interface ValidateCanonDocsResult {
+  passed: boolean;
+  baseRef: string;
+  scanned: number;
+  violations: ReadonlyArray<{
+    file: string;
+    kind: string;
+    matchedPath: string;
+    fix: string;
+  }>;
+  mode: 'enforced' | 'no-canon';
+}
+
 export interface ValidateWorkflowComplianceParams {
   since?: string;
 }
@@ -350,6 +383,7 @@ export type CheckOps = {
   readonly grade: readonly [ValidateGradeParams, ValidateGradeResult];
   readonly 'grade.list': readonly [ValidateGradeListParams, ValidateGradeListResult];
   readonly canon: readonly [ValidateCanonParams, ValidateCanonResult];
+  readonly 'canon.docs': readonly [ValidateCanonDocsParams, ValidateCanonDocsResult];
   readonly 'workflow.compliance': readonly [
     ValidateWorkflowComplianceParams,
     ValidateWorkflowComplianceResult,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       tree-sitter-typescript:
         specifier: ^0.23.2
         version: 0.23.2(tree-sitter@0.21.1)
+      yaml:
+        specifier: '>=2.8.3'
+        version: 2.8.3
     devDependencies:
       '@types/node-cron':
         specifier: ^3.0.11
@@ -802,7 +805,7 @@ importers:
         version: 4.12.12
       llmtxt:
         specifier: '*'
-        version: 2026.4.13(@cleocode/lafs@2026.5.88)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9)
+        version: 2026.4.13(@cleocode/lafs@2026.5.92)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9)
       loro-crdt:
         specifier: '*'
         version: 1.11.0
@@ -1358,8 +1361,8 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  '@cleocode/lafs@2026.5.88':
-    resolution: {integrity: sha512-WqufGjCVlGxuKZYUIPzDQ1OJnOBjnvS+HONVcj4JptAfU3/O7IRuPO94OlFyef7OWElmvASgamQEffZbWRYvQg==}
+  '@cleocode/lafs@2026.5.92':
+    resolution: {integrity: sha512-FOMc4Jl9lLBMwoWo1xQUnHIznlhoFRxw7rgB7N029fprpc72jV3Qz9KpYHxqrOYRemvZU+1LEb954qg+0j3w0Q==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -6984,7 +6987,7 @@ snapshots:
       - '@grpc/grpc-js'
       - supports-color
 
-  '@cleocode/lafs@2026.5.88':
+  '@cleocode/lafs@2026.5.92':
     dependencies:
       '@a2a-js/sdk': 0.3.13(express@5.2.1)
       ajv: 8.18.0
@@ -10013,7 +10016,7 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  llmtxt@2026.4.13(@cleocode/lafs@2026.5.88)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9):
+  llmtxt@2026.4.13(@cleocode/lafs@2026.5.92)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9):
     dependencies:
       '@noble/ed25519': 3.1.0
       '@noble/hashes': 2.2.0
@@ -10022,7 +10025,7 @@ snapshots:
       yjs: 13.6.30
       zod: 4.3.6
     optionalDependencies:
-      '@cleocode/lafs': 2026.5.88
+      '@cleocode/lafs': 2026.5.92
       better-sqlite3: 12.9.0
       drizzle-orm: 1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6)
       onnxruntime-node: 1.24.3


### PR DESCRIPTION
## Summary

Locks down "SSoT is canonical" as enforced policy. Closes the last gap in
Saga T9787 (SG-DOCS-CANON-CLOSURE) — even after T9788 (DocKindRegistry),
T9791 (1,427 docs imported), T9793 (changeset SSoT-first), T9794
(agent triggers), and T9795 (deprecations registry), nothing stopped an
agent from writing `.cleo/adrs/ADR-XXX.md` directly. This PR adds the
hard CI gate.

- **`.cleo/canon.yml`** — routes every DocKind to its canonical home
  (`ssot` blob-store-only OR `ssot-first` dual-write via cleo verb).
  Validated by `.cleo/canon.schema.json`.
- **`cleo check canon docs`** — walks `git diff --diff-filter=A` against
  the configured base ref. Returns `E_CANON_VIOLATION` with structured
  `error.details.result.violations` and exit 1 for any new `*.md` that
  lands inside a `rawMdPaths` directory whose owning kind has
  `rawMdAllowed: false`. `E_CANON_INVALID` (exit 2) for parse errors.
  No-op success when `canon.yml` is missing (opt-in by project).
- **CI wiring** — new `canon-check` job (Canon Drift Check (T9796)) under
  `.github/workflows/ci.yml`, runs on every PR with `code` changes.
- **ADR-076** — supersedes ADR-028 (CHANGELOG Generation Model). Numbered
  ADR-076 because ADR-074 and ADR-075 were already taken by SG-CLEO-SKILLS
  (skills telemetry + federation trust ladder). The ADR notes this.
- **AGENTS.md** — new "Canonical Docs Routing (ADR-076 · T9796)" section.

### Routing protected (10 kinds)

| Kind          | Mode         | Mirror           | Blocks raw .md under                  |
|---------------|--------------|------------------|---------------------------------------|
| adr           | ssot         | docs/adr/        | .cleo/adrs/                           |
| spec          | ssot         | docs/spec/       | (no on-disk surface to police)        |
| research      | ssot         | docs/research/   | .cleo/research/, .cleo/rcasd/         |
| handoff       | ssot         | docs/handoff/    | (none)                                |
| note          | ssot         | docs/note/       | .cleo/agent-outputs/                  |
| llm-readme    | ssot         | .                | — (rawMdAllowed: true)                |
| changeset     | ssot-first   | .changeset/      | — (dual-write contract; allowed)      |
| release-note  | ssot         | docs/release/    | (none)                                |
| plan          | ssot         | docs/plan/       | (none)                                |
| rcasd         | ssot         | .cleo/rcasd/     | — (rcasd dirs allowed structure)      |

### Gate self-consistency

This PR's own `.md` addition is `docs/adr/ADR-076-canonical-docs-ssot.md`
under `docs/adr/` (publish mirror). The gate was smoke-tested against
the PR's staged files and returns `passed: true, scanned: 5`. CI must
stay green.

## Test plan

- [x] Engine smoke test (7 routing scenarios) PASSES end-to-end
- [x] `pnpm run build` GREEN (all workspaces)
- [x] `pnpm run typecheck` GREEN
- [x] `pnpm biome check` GREEN (no new findings)
- [x] `node scripts/lint-format-error-misuse.mjs` GREEN
- [x] `node scripts/lint-project-root-anti-pattern.mjs --strict` GREEN
- [x] `node scripts/lint-contracts-dep.mjs` GREEN
- [x] `node scripts/lint-json-stream-hygiene.mjs` GREEN (no new violations)
- [x] CLI subcommand `cleo check canon docs --help` registered + shows
      verb-specific help (T9765 pattern)
- [x] CLI subcommand `cleo check canon docs --base main` exits 0 against
      this PR's own changes (self-consistency check)
- [ ] CI runs the new `Canon Drift Check (T9796)` job and stays green
- [ ] CI runs the new `check-canon-docs.test.ts` Vitest suite (11 cases:
      4 routing scenarios + no-canon mode + 3 invalid yaml shapes + 1
      CLI surface check + 3 edge cases)

Closes T9796. Saga T9787.