### PR TITLE
release(T9787): ship v2026.5.93 — SG-CLEO-DOCS-CANON-CLOSURE saga complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,106 @@
 # Changelog
 
+## [2026.5.93] (2026-05-21) — SG-CLEO-DOCS-CANON-CLOSURE (T9787): canonical docs SSoT shipped end-to-end
+
+Closes Saga **SG-CLEO-DOCS-CANON-CLOSURE** (T9787) — the 10-epic
+remediation of T9625's premature closure. All 10 member epics shipped
+and merged to main across Waves 0-3. T9625's original validation gate
+(`cleo docs fetch sg-cleo-docs-canon-plan`) is now CLOSED — the plan
+doc lives in the SSoT and is fetchable by slug.
+
+### Wave 0 — Foundation + critical bugs
+
+- **T9776** (#379) — pretypecheck hook preemits `skill-root.d.ts` stub
+  before `tsc -b`, unblocking the Type Check CI job that had been red
+  on main since T9740 Wave C. Also fixed the env-state-leak in
+  `allowlist.test.ts:294` by draining `pushWarning` queue (T9763
+  migration). Restored CI parity across all PRs.
+- **T9788** (#380) — Canonical **DocKindRegistry** in
+  `@cleocode/contracts/docs-taxonomy.ts`. 10 built-in DocKinds (`adr`,
+  `spec`, `research`, `handoff`, `note`, `llm-readme`, `changeset`,
+  `release-note`, `plan`, `rcasd`) with per-type metadata
+  (`entityIdPattern`, `defaultOwnerKind`, `publishDir`,
+  `requiresEntityId`). Project-level extensions via
+  `.cleo/docs-config.json`. New `cleo docs schema` + `cleo docs list-types`
+  discovery surfaces. Consolidated 3 disconnected enums.
+- **T9789** (#381) — Eliminated the `cliOutput(formatError)` /
+  `cliError(formatError)` double-wrap bug class (8 sites in `docs.ts`).
+  Added `scripts/lint-format-error-misuse.mjs` CI gate so the pattern
+  cannot regress.
+- **T9790** (#378) — `cleo doctor --audit-worktree-orphans` +
+  `--prune-worktree-orphans` (atomic archive-then-prune with audit
+  log). Audit of cleocode found **38 orphan worktree directories**;
+  cleanup execution deferred to T9798.
+
+### Wave 1 — Migration + UX
+
+- **T9791** (#384) — Executed `cleo docs import` against ALL legacy
+  source dirs: **2,388 docs scanned, 1,115 imported, 1,273 noop**.
+  ADR slug derivation now matches the registry's `entityIdPattern`
+  (`adr-NNN-<rest>`). Audit manifests committed under
+  `.cleo/audit/imports/<ts>/`. `cleo docs fetch sg-cleo-docs-canon-plan`
+  works — closing T9625's original validation gate.
+- **T9792** (#383) — `cleo docs list --type X` no longer requires
+  `--project`; project-scoped default + browse hints. New
+  `--limit` / `--orderBy newest|sha|slug` flags.
+- **T9793** (#382) — `changeset` is now a first-class DocKind via
+  SSoT-first dual-write. `cleo changeset add` writes both
+  `.changeset/<slug>.md` AND a docs SSoT blob transactionally.
+  `changesets-aggregator` reads SSoT-first with `.md` fallback;
+  `meta.source: 'ssot' | 'file'` for provenance.
+
+### Wave 2 — Surface enforcement
+
+- **T9794** (#385) — `ct-documentor` SKILL.md went from **0 → 32**
+  `cleo docs *` references. New "Coordinator Pattern: SSoT-First
+  Routing" section. `ct-adr-recorder` audited (11 refs already, no
+  gap). Two new Tier-0 trigger rows in `CLEO-INJECTION.md` enforcing
+  SSoT routing for canonical doc reads/writes.
+- **T9795** (#386) — 11 `@deprecated` TSDoc markers on 4 legacy
+  changelog systems + raw-md write paths. Runtime `W_DEPRECATED`
+  warning via `pushWarning`. `.cleo/deprecations.yml` registry +
+  JSON Schema + `scripts/lint-deprecations.mjs` CI gate.
+
+### Wave 3 — Lockdown + validation
+
+- **T9796** (#387) — `.cleo/canon.yml` registry routes every DocKind
+  to canonical home (`ssot` | `ssot-first` | `rawMdAllowed`). New
+  `cleo check canon docs [--base <ref>]` CI gate that walks the PR
+  diff and rejects raw `.md` additions in `rawMdPaths` where
+  `rawMdAllowed: false`. **ADR-076** supersedes ADR-028. New
+  "Canon Drift Check" CI job. AGENTS.md updated.
+- **T9797** (#388) — End-to-end **REAL-WORLD validation** on cleocode:
+  9-step E2E script (`scripts/saga-T9787-e2e-validation.mjs`) covers
+  fetch-by-slug, list-by-type, similarity search, doc-add, publish-pr,
+  drift detection, canon violation rejection, duplicate-slug
+  E_SLUG_TAKEN with alternatives. Plus
+  `packages/core/src/session/canon-lint.ts` + `cleo session lint`
+  agent-accountability harness (15/15 tests). Multi-agent race test
+  proves two parallel fetches against the same slug return identical
+  bytes without lock contention. Closure report at slug
+  `sg-docs-canon-closure-report`.
+
+### Saga T9787 closure metrics
+
+- 10/10 member Epics merged to main
+- 10 PRs (#378, #379, #380, #381, #382, #383, #384, #385, #386, #387, #388)
+- T9625's validation gate satisfied: `cleo docs fetch sg-cleo-docs-canon-plan` returns 5,731 bytes
+- 1,115 legacy `.md` files imported into the docs SSoT (originals retained — disposal deferred)
+- 38 worktree orphans cataloged for cleanup under T9798
+- New ADR-076 (Canonical Docs SSoT) shipped
+- DocKindRegistry + canon.yml + 4 new CI gates regression-lock the class
+- 4 legacy changelog systems carry `@deprecated` markers with removal target v2026.6.0
+
+### Known follow-ups (filed, not blocking)
+
+- **T9758** SAGA (release-as-product) — `cleo release plan/open` flow
+  has a known gap requiring child task evidence atoms; v2026.5.93
+  shipped via manual fallback per the documented hotfix exception.
+- **T9798** — execute prune on the 38 cataloged worktree orphans + add
+  CI gate for future damage prevention.
+- **T9800** SAGA (SG-WORKTREE-CANON) filed for systemic worktree
+  subsystem unification (separate ownership).
+
 ## [2026.5.92] (2026-05-20) — hotfix: biome formatting on T9775 CI lint script + import-sort fix (v2026.5.91 release workflow rescue)
 
 Hotfix release rescuing the v2026.5.91 ship cycle. The v2026.5.91 tag was

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.92",
+  "version": "2026.5.93",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Ships v2026.5.93 — closes Saga **T9787 (SG-CLEO-DOCS-CANON-CLOSURE)**.

**All 10 member Epics merged to main** across PRs #378-#388 in this session. T9625's original validation gate is satisfied: `cleo docs fetch sg-cleo-docs-canon-plan` returns 5,731 bytes.

See the [CHANGELOG entry](https://github.com/kryptobaseddev/cleo/blob/release/v2026.5.93-ship/CHANGELOG.md) for full details.

## Test plan

- [x] All 10 member epic PRs CI-green and merged to main individually
- [x] Local `pnpm run typecheck` clean
- [x] `cleo docs fetch sg-cleo-docs-canon-plan` works
- [ ] CI green on this release PR
- [ ] Tag push triggers `release-publish.yml` (npm publish via OIDC)
- [ ] Global install verified: `pnpm install -g @cleocode/cleo@2026.5.93 && cleo --version`
- [ ] Real-world smoke: `cleo docs list --type adr` shows 79 entries

## Known follow-ups

- T9758 — release-as-product saga: `cleo release plan` flow has a gap requiring release-task evidence atoms (this PR shipped via manual path per the documented hotfix exception)
- T9798 — execute prune on the 38 cataloged worktree orphans + CI gate
- T9800 — SG-WORKTREE-CANON saga (filed for systemic worktree subsystem unification)