### PR TITLE
feat(T9806): DB chokepoint refuses worktree-resident .cleo/ opens

### DIFF
--- a/.changeset/t9806-db-isolation-guards.md
+++ b/.changeset/t9806-db-isolation-guards.md
@@ -1,0 +1,41 @@
+---
+id: t9806-db-isolation-guards
+tasks: [T9806]
+kind: feat
+prs: []
+summary: DB chokepoint refuses opens when the resolved `.cleo/` resides inside a git worktree — defense-in-depth on top of T9803.
+---
+
+After T9803 closed the orphan `.cleo/` synthesis vector at the path-resolution
+layer, T9806 adds a second guard at the DB-open chokepoint:
+
+```ts
+assertDbPathIsNotWorktreeResident(role, cwd);
+```
+
+If the resolved `.cleo/`'s parent directory has `.git` as a FILE (gitlink —
+i.e. the parent is a git worktree, not a canonical project root), the open
+is refused with `E_WT_DB_ISOLATION_VIOLATION`. This catches the residual
+case where a leaked `.cleo/` already exists inside a worktree from a
+pre-T9803 install.
+
+`signaldock` and `skills` roles are skipped — they open against
+`~/.local/share/cleo/` regardless of cwd, so a worktree gitlink parent is
+irrelevant.
+
+**Kill-switch**: `CLEO_ALLOW_WORKTREE_DB_CREATE=1` bypasses the guard. The
+override is logged to stderr:
+
+```
+[T9806 WT-DB-OVERRIDE] role=<role> path=<cleoDir> reason=CLEO_ALLOW_WORKTREE_DB_CREATE=1
+```
+
+Non-`'1'` values (e.g. `'true'`, `'yes'`) do NOT bypass — the literal string
+match is intentional to require explicit opt-in.
+
+Regression suite at
+`packages/core/src/store/__tests__/open-cleo-db-worktree-guard.test.ts`
+covers AC-1 (refuses for tasks/brain/conduit/nexus), AC-2 (kill-switch
+bypass + literal-`'1'` enforcement), AC-3 (signaldock unaffected).
+
+Saga: T9800 SG-WORKTREE-CANON · Decision D009 (council verdict).

--- a/packages/core/src/store/__tests__/open-cleo-db-worktree-guard.test.ts
+++ b/packages/core/src/store/__tests__/open-cleo-db-worktree-guard.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression suite for T9806 — DB chokepoint refuses worktree-resident opens.
+ *
+ * Defense-in-depth on top of T9803. T9803 stops NEW orphan-`.cleo/` synthesis
+ * at the path-resolution layer; T9806 stops re-use of OLD leaked `.cleo/`
+ * directories that already exist inside worktrees from pre-T9803 installs.
+ *
+ * @task T9806
+ * @saga T9800
+ * @decision D009
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { openCleoDb } from '../open-cleo-db.js';
+
+function makeWorktreeFixture(label: string, gitContent: string): string {
+  const dir = join(
+    tmpdir(),
+    `cleo-t9806-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  // Write `.git` as a FILE (gitlink) — simulates a `git worktree add` checkout.
+  writeFileSync(join(dir, '.git'), gitContent);
+  // Write a `.cleo/` directory + project-info.json so the path resolution
+  // path-layer (T9803) succeeds and we exercise the T9806 guard layer.
+  mkdirSync(join(dir, '.cleo'), { recursive: true });
+  writeFileSync(
+    join(dir, '.cleo', 'project-info.json'),
+    JSON.stringify({ projectId: 'wt-fixture-leaked' }),
+  );
+  return dir;
+}
+
+function snapshotEnv(): { restore: () => void } {
+  const saved = process.env['CLEO_ALLOW_WORKTREE_DB_CREATE'];
+  return {
+    restore() {
+      if (saved === undefined) delete process.env['CLEO_ALLOW_WORKTREE_DB_CREATE'];
+      else process.env['CLEO_ALLOW_WORKTREE_DB_CREATE'] = saved;
+    },
+  };
+}
+
+describe('openCleoDb — worktree-isolation guard (T9806 / D009)', () => {
+  let tempDir: string | undefined;
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    ({ restore: restoreEnv } = snapshotEnv());
+    delete process.env['CLEO_ALLOW_WORKTREE_DB_CREATE'];
+    tempDir = undefined;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    if (tempDir) {
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  describe('AC-1: refuses open when .cleo/ parent is a worktree gitlink', () => {
+    it('throws E_WT_DB_ISOLATION_VIOLATION for role=tasks inside worktree', async () => {
+      tempDir = makeWorktreeFixture('tasks-refuse', 'gitdir: /tmp/some-main/.git/worktrees/foo\n');
+      await expect(openCleoDb('tasks', tempDir)).rejects.toThrowError(
+        /E_WT_DB_ISOLATION_VIOLATION/,
+      );
+    });
+
+    it('throws E_WT_DB_ISOLATION_VIOLATION for role=brain inside worktree', async () => {
+      tempDir = makeWorktreeFixture('brain-refuse', 'gitdir: /tmp/some-main/.git/worktrees/bar\n');
+      await expect(openCleoDb('brain', tempDir)).rejects.toThrowError(
+        /E_WT_DB_ISOLATION_VIOLATION/,
+      );
+    });
+
+    it('throws E_WT_DB_ISOLATION_VIOLATION for role=conduit inside worktree', async () => {
+      tempDir = makeWorktreeFixture(
+        'conduit-refuse',
+        'gitdir: /tmp/some-main/.git/worktrees/baz\n',
+      );
+      await expect(openCleoDb('conduit', tempDir)).rejects.toThrowError(
+        /E_WT_DB_ISOLATION_VIOLATION/,
+      );
+    });
+
+    it('throws E_WT_DB_ISOLATION_VIOLATION for role=nexus inside worktree', async () => {
+      tempDir = makeWorktreeFixture('nexus-refuse', 'gitdir: /tmp/some-main/.git/worktrees/qux\n');
+      await expect(openCleoDb('nexus', tempDir)).rejects.toThrowError(
+        /E_WT_DB_ISOLATION_VIOLATION/,
+      );
+    });
+  });
+
+  describe('AC-2: kill-switch CLEO_ALLOW_WORKTREE_DB_CREATE=1 bypasses guard', () => {
+    it('does NOT throw E_WT_DB_ISOLATION_VIOLATION when override is set', async () => {
+      tempDir = makeWorktreeFixture('override', 'gitdir: /tmp/some-main/.git/worktrees/override\n');
+      process.env['CLEO_ALLOW_WORKTREE_DB_CREATE'] = '1';
+      // Open may still fail for other reasons (DB modules not initialised in
+      // a temp dir without migrations), but it must NOT fail with the
+      // T9806-specific isolation-violation error.
+      const errorPromise = openCleoDb('tasks', tempDir)
+        .then(() => null as Error | null)
+        .catch((err: unknown) => (err instanceof Error ? err : new Error(String(err))));
+      const err = await errorPromise;
+      if (err) {
+        expect(err.message).not.toMatch(/E_WT_DB_ISOLATION_VIOLATION/);
+      }
+    });
+
+    it('non-"1" values do NOT bypass the guard', async () => {
+      tempDir = makeWorktreeFixture('override-bad', 'gitdir: /tmp/some-main/.git/worktrees/bad\n');
+      process.env['CLEO_ALLOW_WORKTREE_DB_CREATE'] = 'true'; // not literally '1'
+      await expect(openCleoDb('tasks', tempDir)).rejects.toThrowError(
+        /E_WT_DB_ISOLATION_VIOLATION/,
+      );
+    });
+  });
+
+  describe('AC-3: signaldock + skills (global-tier roles) NOT guarded', () => {
+    it('signaldock open is allowed inside a worktree (global path)', async () => {
+      tempDir = makeWorktreeFixture(
+        'signaldock-allow',
+        'gitdir: /tmp/some-main/.git/worktrees/sd\n',
+      );
+      // signaldock opens against ~/.local/share/cleo/signaldock.db regardless
+      // of cwd; the worktree guard intentionally skips it.
+      const errorPromise = openCleoDb('signaldock', tempDir)
+        .then(() => null as Error | null)
+        .catch((err: unknown) => (err instanceof Error ? err : new Error(String(err))));
+      const err = await errorPromise;
+      if (err) {
+        expect(err.message).not.toMatch(/E_WT_DB_ISOLATION_VIOLATION/);
+      }
+    });
+  });
+});

--- a/packages/core/src/store/open-cleo-db.ts
+++ b/packages/core/src/store/open-cleo-db.ts
@@ -38,9 +38,13 @@
  * @adr ADR-068, ADR-069
  */
 
+import { existsSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
-import { resolveOrCwd } from '../paths.js';
+import { ExitCode } from '@cleocode/contracts';
+import { CleoError } from '../errors.js';
+import { getCleoDirAbsolute, resolveOrCwd } from '../paths.js';
 import { getConduitNativeDb } from './conduit-sqlite.js';
 import { getNexusDb } from './nexus-sqlite.js';
 import { ensureGlobalSignaldockDb, getGlobalSignaldockNativeDb } from './signaldock-sqlite.js';
@@ -127,9 +131,69 @@ function isDatabaseSync(db: unknown): db is DatabaseSync {
 }
 
 /**
+ * Worktree-isolation guard for the DB chokepoint (T9806 / council verdict D009).
+ *
+ * Defense-in-depth on top of T9803's `getCleoDirAbsolute` THROWS-on-orphan
+ * fix. After path resolution, this verifies the resolved `.cleo/`'s parent
+ * directory is the **canonical project root** (i.e. `.git` is a real
+ * directory) rather than a **git worktree** (i.e. `.git` is a gitlink file).
+ *
+ * Refusing worktree-resident opens prevents the residual orphan path where a
+ * leaked `.cleo/` already exists inside a worktree from a pre-T9803 install:
+ * T9803 stops NEW creation, T9806 stops re-use of an OLD leak.
+ *
+ * Kill-switch: `CLEO_ALLOW_WORKTREE_DB_CREATE=1` bypasses the guard. The
+ * override is recorded to stderr (caller may pipe to audit log).
+ *
+ * @throws `CleoError('E_WT_DB_ISOLATION_VIOLATION')` when:
+ *   - The resolved `.cleo/`'s parent directory contains `.git` as a FILE
+ *     (gitlink — worktree marker), AND
+ *   - `CLEO_ALLOW_WORKTREE_DB_CREATE` is not set to `'1'`.
+ *
+ * @internal
+ */
+function assertDbPathIsNotWorktreeResident(role: CleoDbRole, cwd?: string): void {
+  let cleoDir: string;
+  try {
+    cleoDir = getCleoDirAbsolute(cwd);
+  } catch {
+    // T9803 already throws on unresolvable project root. Re-raising here
+    // would lose context; let the underlying opener surface the original
+    // error.
+    return;
+  }
+  const projectRoot = dirname(cleoDir);
+  const projectGit = join(projectRoot, '.git');
+  let isWorktreeGitlink = false;
+  try {
+    isWorktreeGitlink = existsSync(projectGit) && statSync(projectGit).isFile();
+  } catch {
+    /* If `.git` itself is missing, this isn't our concern — T9803 will fire. */
+  }
+  if (!isWorktreeGitlink) {
+    return;
+  }
+  if (process.env['CLEO_ALLOW_WORKTREE_DB_CREATE'] === '1') {
+    process.stderr.write(
+      `[T9806 WT-DB-OVERRIDE] role=${role} path=${cleoDir} reason=CLEO_ALLOW_WORKTREE_DB_CREATE=1\n`,
+    );
+    return;
+  }
+  throw new CleoError(
+    ExitCode.CONFIG_ERROR,
+    `E_WT_DB_ISOLATION_VIOLATION: refusing to open '${role}' DB at ${cleoDir} — parent ${projectRoot} is a git worktree (gitlink). DBs must open against the canonical project root.`,
+    {
+      fix: `Run from the canonical project root, OR delete the leaked .cleo/ inside the worktree, OR set CLEO_ALLOW_WORKTREE_DB_CREATE=1 (emergency override, audited).`,
+    },
+  );
+}
+
+/**
  * Open (or create) a CLEO database by canonical role.
  *
  * Single chokepoint for all DB opens. Applies pragma SSoT at open time.
+ * Enforces the worktree-isolation guard (T9806) on top of T9803's path-layer
+ * THROWS-on-orphan fix.
  */
 export async function openCleoDb(role: CleoDbRole, cwd?: string): Promise<CleoDbHandle> {
   if (role === 'llmtxt') {
@@ -139,6 +203,14 @@ export async function openCleoDb(role: CleoDbRole, cwd?: string): Promise<CleoDb
   const opener = ROLE_OPENERS[role];
   if (!opener) {
     throw new Error(`Unknown CLEO DB role: ${role}`);
+  }
+
+  // T9806/D009: defense-in-depth — refuse opens whose resolved `.cleo/`
+  // resides inside a git worktree (gitlink-file parent). Roles that read
+  // from a global path (signaldock, skills) MAY legitimately open from
+  // anywhere — they don't depend on cwd-resolved project root.
+  if (role !== 'signaldock' && role !== 'skills') {
+    assertDbPathIsNotWorktreeResident(role, cwd);
   }
 
   const openedDb = await opener(cwd);


### PR DESCRIPTION
## Summary

Defense-in-depth on top of #389 (T9803). T9803 stops NEW orphan `.cleo/` synthesis at the path layer; T9806 stops re-use of OLD leaked `.cleo/` directories that already exist inside worktrees from pre-T9803 installs.

- New `assertDbPathIsNotWorktreeResident(role, cwd)` guard in `packages/core/src/store/open-cleo-db.ts`
- Refuses opens whose resolved `.cleo/` parent has `.git` as a FILE (gitlink — worktree marker)
- Throws `E_WT_DB_ISOLATION_VIOLATION` with fix-hint
- Kill-switch `CLEO_ALLOW_WORKTREE_DB_CREATE=1` bypasses (logged to stderr)
- `signaldock` + `skills` roles skipped (global path, cwd-independent)

## Saga / Decision context

- Saga: T9800 SG-WORKTREE-CANON (epic T9806 of 9)
- Decision: D009 (council verdict — defense-in-depth post-T9803)
- Depends on (logically, not via git): #389 T9803

## Test plan

- [x] New regression suite `packages/core/src/store/__tests__/open-cleo-db-worktree-guard.test.ts` — 7 tests covering AC-1 (refuses for tasks/brain/conduit/nexus), AC-2 (kill-switch bypass + literal `'1'` enforcement), AC-3 (signaldock unaffected).
- [x] Existing `open-cleo-db.test.ts` — 10/10 pass (no regression).
- [x] `pnpm biome check` clean on touched files.
- [ ] CI to run full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)