### PR TITLE
fix(gh-402): diagnostics reads CLEO version from package.json SSoT

### DIFF
--- a/packages/core/src/issue/__tests__/diagnostics.test.ts
+++ b/packages/core/src/issue/__tests__/diagnostics.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for `collectDiagnostics` — primarily that the CLEO version is read
+ * from package.json SSoT instead of a hardcoded literal (gh-402).
+ *
+ * @task T9839 (gh-402)
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { collectDiagnostics, formatDiagnosticsTable } from '../diagnostics.js';
+
+describe('collectDiagnostics — gh-402: version SSoT', () => {
+  it('returns the CLEO version from @cleocode/cleo/package.json (not a hardcoded literal)', () => {
+    const diag = collectDiagnostics();
+
+    expect(diag.cleoVersion).toBeDefined();
+    expect(typeof diag.cleoVersion).toBe('string');
+    expect(diag.cleoVersion).not.toBe('2026.2.1');
+    expect(diag.cleoVersion).not.toBe('');
+    expect(diag.cleoVersion).not.toBe('not installed');
+  });
+
+  it('matches the version field in packages/cleo/package.json', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const cleoPkgPath = join(here, '..', '..', '..', '..', 'cleo', 'package.json');
+    const cleoPkg = JSON.parse(readFileSync(cleoPkgPath, 'utf-8')) as { version: string };
+
+    const diag = collectDiagnostics();
+    expect(diag.cleoVersion).toBe(cleoPkg.version);
+  });
+
+  it('CalVer format (YYYY.M.patch) — guards against future hardcode regression', () => {
+    const diag = collectDiagnostics();
+    expect(diag.cleoVersion).toMatch(/^\d{4}\.\d{1,2}\.\d+(?:-[a-z0-9.]+)?$/);
+  });
+
+  it('exposes nodeVersion, os, shell, cleoHome, installLocation, ghVersion fields', () => {
+    const diag = collectDiagnostics();
+    expect(diag.nodeVersion).toMatch(/^v\d+/);
+    expect(diag.os).toBeTruthy();
+    expect(diag.shell).toBeTruthy();
+    expect(diag.cleoHome).toBeTruthy();
+    expect(diag.installLocation).toBeTruthy();
+    expect(diag.ghVersion).toBeTruthy();
+  });
+});
+
+describe('formatDiagnosticsTable', () => {
+  it('renders a markdown table containing the resolved CLEO version', () => {
+    const diag = collectDiagnostics();
+    const md = formatDiagnosticsTable(diag);
+
+    expect(md).toContain('## Environment');
+    expect(md).toContain('| Component | Version |');
+    expect(md).toContain(`| CLEO | ${diag.cleoVersion} |`);
+    expect(md).not.toContain('| CLEO | 2026.2.1 |');
+  });
+});

--- a/packages/core/src/issue/diagnostics.ts
+++ b/packages/core/src/issue/diagnostics.ts
@@ -9,8 +9,45 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { getCleoHome } from '../paths.js';
+import { getCleoVersion } from '../scaffold.js';
 import { getSystemInfo } from '../system/platform-paths.js';
+
+/**
+ * Resolve the runtime CLEO CLI version that `cleo --version` reports.
+ *
+ * Reads `@cleocode/cleo/package.json` via Node module resolution so the value
+ * matches whatever copy of the CLI is currently loaded — whether installed
+ * globally under `<npm-global>/lib/node_modules/@cleocode/cleo/` or running
+ * from the monorepo source tree at `packages/cleo/`.
+ *
+ * Falls back to `getCleoVersion()` (the @cleocode/core version, which is
+ * released in lockstep with the CLI) when module resolution fails, and to
+ * `'unknown'` if even that fails. Replaces a hardcoded `'2026.2.1'` literal
+ * that drifted ~3 months stale before being caught (gh-402).
+ *
+ * @internal
+ */
+function resolveCleoVersion(): string {
+  try {
+    const req = createRequire(import.meta.url);
+    const pkgPath = req.resolve('@cleocode/cleo/package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version?: string };
+    if (typeof pkg.version === 'string' && pkg.version.length > 0) return pkg.version;
+  } catch {
+    // Not resolvable (e.g. core running without cleo on the resolution path) —
+    // fall through to the core version, which is released in lockstep.
+  }
+  try {
+    const v = getCleoVersion();
+    if (v && v !== '0.0.0') return v;
+  } catch {
+    // ignore
+  }
+  return 'unknown';
+}
 
 /**
  * Collect system diagnostics for bug reports.
@@ -32,7 +69,7 @@ export function collectDiagnostics(): Record<string, string> {
   const sysInfo = getSystemInfo();
 
   return {
-    cleoVersion: '2026.2.1',
+    cleoVersion: resolveCleoVersion(),
     nodeVersion: process.version,
     os: `${sysInfo.platform} ${sysInfo.release} ${sysInfo.arch}`,
     arch: sysInfo.arch,


### PR DESCRIPTION
## Summary
- Replaces stale `'2026.2.1'` hardcode in `collectDiagnostics()` with `resolveCleoVersion()`
- New helper does Node-module-resolution lookup against `@cleocode/cleo/package.json`
- Falls back to `getCleoVersion()` (core's package.json, released in lockstep) then `'unknown'`
- 5 new test cases regression-lock the SSoT contract

## Why
The literal `'2026.2.1'` had drifted ~3 months stale (current `cleo --version` is `2026.5.93`), so every issue filed via `cleo issue submit` carried the wrong version, undermining triage. Caught while triaging the gh-issue wave logged 2026-05-21.

## Verification
- `pnpm --filter @cleocode/core test diagnostics` — **5/5 pass**
- `pnpm --filter @cleocode/core run build` — **exit 0**
- `pnpm biome check` — clean on the two touched files

## Test plan
- [x] Diagnostics matches `packages/cleo/package.json` version
- [x] CalVer format regex guard against future hardcode regression
- [x] All other diag fields (`nodeVersion`, `os`, `shell`, `cleoHome`, `ghVersion`, `installLocation`) present
- [x] Markdown formatter still renders the CLEO row without the old literal

Fixes #402
Refs SG-GH-TRIAGE-2026-05-21 (T9839)

🤖 Generated with [Claude Code](https://claude.com/claude-code)