### PR TITLE
fix(gh-409): bracket+quote-aware acceptance tokenizer + DRY collapse

### DIFF
--- a/packages/cleo/src/cli/commands/saga.ts
+++ b/packages/cleo/src/cli/commands/saga.ts
@@ -17,6 +17,7 @@
  * @epic T9518
  */
 
+import { parseAcceptanceCriteria } from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli, dispatchRaw, handleRawError } from '../../dispatch/adapters/cli.js';
 import { cliOutput } from '../renderers/index.js';
@@ -52,7 +53,9 @@ const createCommand = defineCommand({
       {
         title: args.title,
         description: args.description,
-        acceptance: args.acceptance ? args.acceptance.split('|') : undefined,
+        // T9839/gh-409: route through bracket+quote-aware parser so criteria
+        // containing `ENUM (a|b|c)` or quoted unions aren't shredded.
+        acceptance: args.acceptance ? parseAcceptanceCriteria(args.acceptance) : undefined,
       },
       { command: 'saga', operation: 'tasks.saga.create' },
     );

--- a/packages/cleo/src/cli/commands/update.ts
+++ b/packages/cleo/src/cli/commands/update.ts
@@ -19,7 +19,7 @@
  * @epic T4454
  */
 
-import { appendSignedSeverityAttestation } from '@cleocode/core';
+import { appendSignedSeverityAttestation, parseAcceptanceCriteria } from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli, dispatchRaw } from '../../dispatch/adapters/cli.js';
 import { cliError } from '../renderers/index.js';
@@ -265,11 +265,9 @@ export const updateCommand = defineCommand({
     }
     if (args.notes !== undefined) params['notes'] = args.notes;
     if (args.note !== undefined) params['notes'] = params['notes'] ?? args.note;
-    if (args.acceptance)
-      params['acceptance'] = (args.acceptance as string)
-        .split('|')
-        .map((s) => s.trim())
-        .filter(Boolean);
+    // T9839/gh-409: route through bracket+quote-aware parser to preserve
+    // criteria containing `ENUM (a|b|c)` or quoted unions like `'a'|'b'`.
+    if (args.acceptance) params['acceptance'] = parseAcceptanceCriteria(args.acceptance as string);
     if (args.files) params['files'] = (args.files as string).split(',').map((s) => s.trim());
     if (args['add-files'])
       params['addFiles'] = (args['add-files'] as string).split(',').map((s) => s.trim());

--- a/packages/core/src/tasks/__tests__/parse-acceptance-criteria.test.ts
+++ b/packages/core/src/tasks/__tests__/parse-acceptance-criteria.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression tests for `parseAcceptanceCriteria` — the canonical acceptance
+ * criteria tokenizer used by `cleo add`, `cleo update`, and `cleo saga create`.
+ *
+ * Covers:
+ * - Basic pipe-split behaviour (trim, drop empties)
+ * - gh-409 corruption shapes (T237/T239/T240) — pipes inside parens, quoted
+ *   string-unions, escape sequences, nested brackets
+ * - JSON-array fast-path preservation
+ * - Defensive handling of malformed input (unbalanced brackets, empty/whitespace)
+ *
+ * @bug https://github.com/kryptobaseddev/cleo/issues/409
+ * @task T9839
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseAcceptanceCriteria } from '../infer-add-params.js';
+
+describe('parseAcceptanceCriteria', () => {
+  // ─── Baseline pipe-split behaviour ────────────────────────────────────────
+  it('splits a plain pipe-delimited string', () => {
+    expect(parseAcceptanceCriteria('A|B|C')).toEqual(['A', 'B', 'C']);
+  });
+
+  it('trims whitespace around each token', () => {
+    expect(parseAcceptanceCriteria('  A | B  ')).toEqual(['A', 'B']);
+  });
+
+  it('drops empty tokens between consecutive delimiters', () => {
+    expect(parseAcceptanceCriteria('A||B')).toEqual(['A', 'B']);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(parseAcceptanceCriteria('')).toEqual([]);
+  });
+
+  it('returns an empty array for whitespace-only input', () => {
+    expect(parseAcceptanceCriteria('   ')).toEqual([]);
+  });
+
+  // ─── gh-409 regression — pipes inside parens / brackets ───────────────────
+  it('gh-409 (T237): preserves ENUM (hot|cold|batch|embed) as one token', () => {
+    expect(parseAcceptanceCriteria('AC1|ENUM (hot|cold|batch|embed)|AC2')).toEqual([
+      'AC1',
+      'ENUM (hot|cold|batch|embed)',
+      'AC2',
+    ]);
+  });
+
+  it('gh-409 (T240): preserves ENUM(passed|advisory|none) with no space', () => {
+    expect(parseAcceptanceCriteria('AC1|bench_status ENUM(passed|advisory|none)|AC2')).toEqual([
+      'AC1',
+      'bench_status ENUM(passed|advisory|none)',
+      'AC2',
+    ]);
+  });
+
+  it("gh-409 (T239): preserves quoted string-union mode: 'realtime-token'|'batch'", () => {
+    expect(parseAcceptanceCriteria("AC1|mode: 'realtime-token'|'batch'|AC2")).toEqual([
+      'AC1',
+      "mode: 'realtime-token'|'batch'",
+      'AC2',
+    ]);
+  });
+
+  it('preserves nested brackets [...] (...) with embedded pipes', () => {
+    expect(parseAcceptanceCriteria('AC1|a[b|c](d|e)|AC2')).toEqual(['AC1', 'a[b|c](d|e)', 'AC2']);
+  });
+
+  it('preserves curly-brace groups with embedded pipes', () => {
+    expect(parseAcceptanceCriteria('AC1|union {x|y|z}|AC2')).toEqual([
+      'AC1',
+      'union {x|y|z}',
+      'AC2',
+    ]);
+  });
+
+  it('preserves double-quoted string-unions', () => {
+    expect(parseAcceptanceCriteria('AC1|type: "a"|"b"|AC2')).toEqual([
+      'AC1',
+      'type: "a"|"b"',
+      'AC2',
+    ]);
+  });
+
+  // ─── Escape semantics ─────────────────────────────────────────────────────
+  it('treats backslash-pipe as a literal pipe at depth 0', () => {
+    // Raw input: AC1\|literal|AC2  →  ["AC1|literal", "AC2"]
+    expect(parseAcceptanceCriteria('AC1\\|literal|AC2')).toEqual(['AC1|literal', 'AC2']);
+  });
+
+  // ─── JSON-array fast-path ─────────────────────────────────────────────────
+  it('JSON-array fast-path: preserves pipes inside string values', () => {
+    expect(parseAcceptanceCriteria('["A","B|C","D"]')).toEqual(['A', 'B|C', 'D']);
+  });
+
+  it('JSON-array fast-path: trims and drops empty entries', () => {
+    expect(parseAcceptanceCriteria('["  A  ","","B"]')).toEqual(['A', 'B']);
+  });
+
+  it('JSON-array fast-path: falls through to pipe tokenizer on malformed JSON', () => {
+    // Starts with `[` but isn't valid JSON → fall through to pipe tokenizer.
+    // The tokenizer then enters bracket-mode at the leading `[` (depth=1) and
+    // the `|` is swallowed as part of the unterminated bracket span. The
+    // entire input is emitted as a single trailing token.
+    expect(parseAcceptanceCriteria('[not-json|AC2')).toEqual(['[not-json|AC2']);
+  });
+
+  it('JSON-array fast-path: falls through when leading `[` is followed by depth-0 pipe outside bracket scope', () => {
+    // After malformed JSON parse, a pipe AFTER a balanced bracket span still
+    // splits correctly at depth 0.
+    expect(parseAcceptanceCriteria('[not-json]|AC2')).toEqual(['[not-json]', 'AC2']);
+  });
+
+  // ─── Defensive: malformed bracket inputs must NOT throw or infinite-loop ──
+  it('does not throw on unbalanced opening bracket', () => {
+    // Unbalanced `(` — once we open a bracket, the rest of the input is
+    // captured inside depth>=1 and emitted as one trailing token.
+    expect(() => parseAcceptanceCriteria('AC1|(unclosed|AC2')).not.toThrow();
+    expect(parseAcceptanceCriteria('AC1|(unclosed|AC2')).toEqual(['AC1', '(unclosed|AC2']);
+  });
+
+  it('tolerates unbalanced closing bracket (no underflow)', () => {
+    // Stray `)` at depth 0 — the Math.max(0, depth-1) guard keeps depth at 0,
+    // so the subsequent `|` still splits normally.
+    expect(() => parseAcceptanceCriteria('AC1)|AC2')).not.toThrow();
+    expect(parseAcceptanceCriteria('AC1)|AC2')).toEqual(['AC1)', 'AC2']);
+  });
+
+  it('terminates on a pathologically long input (loop bound)', () => {
+    // 10k tokens — proves the loop is bounded by input.length.
+    const input = Array.from({ length: 10_000 }, (_, n) => `AC${n}`).join('|');
+    expect(parseAcceptanceCriteria(input)).toHaveLength(10_000);
+  });
+});

--- a/packages/core/src/tasks/infer-add-params.ts
+++ b/packages/core/src/tasks/infer-add-params.ts
@@ -113,16 +113,146 @@ export function inferFilesViaGitNexus(title: string, description?: string): stri
 }
 
 /**
+ * Find the previous non-whitespace character in `s` searching backwards from
+ * the end. Returns the empty string when `s` is empty or all-whitespace.
+ *
+ * Used by `splitAcceptance` to detect the string-union continuation rule
+ * (gh-409): a `|` between a closing quote and an opening quote is NOT a split.
+ *
+ * @internal
+ */
+function lastNonWsChar(s: string): string {
+  for (let k = s.length - 1; k >= 0; k--) {
+    const c = s[k];
+    if (c !== ' ' && c !== '\t' && c !== '\n' && c !== '\r') return c;
+  }
+  return '';
+}
+
+/**
+ * Find the next non-whitespace character in `s` starting at index `start`.
+ * Returns the empty string when no non-whitespace remains.
+ *
+ * @internal
+ */
+function nextNonWsChar(s: string, start: number): string {
+  for (let k = start; k < s.length; k++) {
+    const c = s[k];
+    if (c !== ' ' && c !== '\t' && c !== '\n' && c !== '\r') return c;
+  }
+  return '';
+}
+
+/**
+ * Bracket+quote+escape-aware tokenizer for pipe-delimited acceptance criteria.
+ *
+ * Splits `input` on the top-level `delim` character ONLY — pipes inside
+ * brackets/parens/braces or inside single-/double-quoted strings are preserved
+ * as part of the current token. A backslash at depth 0 (outside any quote)
+ * immediately preceding a delimiter escapes it (treats it as a literal
+ * character in the current token).
+ *
+ * Used by `parseAcceptanceCriteria` to fix the data-corruption bug where
+ * naive `String.split('|')` shredded criteria containing `ENUM (a|b|c)` or
+ * quoted string-unions like `'realtime-token'|'batch'`.
+ *
+ * Rules:
+ * - Quotes: `"` and `'` open a quote-context; the matching close char ends it.
+ *   Inside a quote, `|`, brackets, and escape sequences are passed through
+ *   literally (the only thing that exits the quote is the matching close).
+ * - Brackets: `(`, `[`, `{` increase depth; `)`, `]`, `}` decrease (clamped
+ *   at 0 — unbalanced closing brackets are tolerated, never throw).
+ * - Escape: `\|` at depth 0 with no active quote → literal `|` in the token.
+ * - Delimiter: `|` is a split point ONLY when depth === 0 AND no active quote
+ *   AND it does NOT join two quoted spans. A `|` whose preceding non-whitespace
+ *   char in `buf` is a closing quote AND whose next non-whitespace char in
+ *   `input` is an opening quote is treated as a continuation (the entire
+ *   `'a'|'b'` or `"a"|"b"` expression stays as one token). This is the
+ *   gh-409 "string-union" rule used by T239.
+ * - Trim: each emitted token is trimmed; empty tokens (after trim) are dropped.
+ * - Defensive: unbalanced opening brackets do NOT throw; the unterminated
+ *   tail is emitted as a single trailing token (no infinite loop possible —
+ *   the loop is bounded by `input.length`).
+ *
+ * @param input - Raw delimiter-separated string
+ * @param delim - Delimiter character (single char; default `|`)
+ * @returns Array of trimmed, non-empty tokens
+ *
+ * @internal
+ * @bug https://github.com/kryptobaseddev/cleo/issues/409
+ * @task T9839
+ */
+function splitAcceptance(input: string, delim = '|'): string[] {
+  const out: string[] = [];
+  let buf = '';
+  let depth = 0;
+  let quote: string | null = null;
+  let i = 0;
+  while (i < input.length) {
+    const ch = input[i];
+    // Escape: \| at depth 0 with no active quote → literal | in the token.
+    if (ch === '\\' && input[i + 1] === delim && depth === 0 && quote === null) {
+      buf += delim;
+      i += 2;
+      continue;
+    }
+    if (quote !== null) {
+      // Inside a quote: only the matching close char exits.
+      if (ch === quote) quote = null;
+      buf += ch;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+      buf += ch;
+    } else if (ch === '(' || ch === '[' || ch === '{') {
+      depth++;
+      buf += ch;
+    } else if (ch === ')' || ch === ']' || ch === '}') {
+      depth = Math.max(0, depth - 1);
+      buf += ch;
+    } else if (ch === delim && depth === 0) {
+      // gh-409 string-union rule: `'a'|'b'` and `"a"|"b"` stay as one token.
+      // If the previous non-ws char in buf is a closing quote AND the next
+      // non-ws char in input is an opening quote, treat this `|` as part of
+      // the current token (continuation), not as a split point.
+      const prev = lastNonWsChar(buf);
+      const next = nextNonWsChar(input, i + 1);
+      const isUnionContinuation = (prev === "'" || prev === '"') && (next === "'" || next === '"');
+      if (isUnionContinuation) {
+        buf += ch;
+      } else {
+        const trimmed = buf.trim();
+        if (trimmed) out.push(trimmed);
+        buf = '';
+      }
+    } else {
+      buf += ch;
+    }
+    i++;
+  }
+  // Flush trailing buffer (also handles unbalanced opens gracefully).
+  const trimmed = buf.trim();
+  if (trimmed) out.push(trimmed);
+  return out;
+}
+
+/**
  * Parse acceptance criteria from a raw CLI string.
  *
  * Supports two formats:
- * - JSON array: `'["AC1","AC2","AC3"]'`
- * - Pipe-separated: `"AC1|AC2|AC3"`
+ * - JSON array: `'["AC1","AC2","AC3"]'` (fast-path; preserved verbatim)
+ * - Pipe-separated: `"AC1|AC2|AC3"` (tokenized via `splitAcceptance`)
+ *
+ * The pipe-separated form uses a bracket+quote+escape-aware tokenizer so
+ * criteria containing `ENUM (hot|cold|batch|embed)`, quoted string-unions
+ * like `mode: 'realtime-token'|'batch'`, or escaped literals (`\|`) are
+ * preserved as single tokens rather than being shredded.
  *
  * @param raw - Raw string from `--acceptance` flag
  * @returns Array of trimmed, non-empty acceptance criteria strings
  *
+ * @bug https://github.com/kryptobaseddev/cleo/issues/409
  * @task T1490
+ * @task T9839
  */
 export function parseAcceptanceCriteria(raw: string): string[] {
   if (raw.trimStart().startsWith('[')) {
@@ -135,10 +265,7 @@ export function parseAcceptanceCriteria(raw: string): string[] {
       // Not valid JSON — fall through to pipe-delimited parsing
     }
   }
-  return raw
-    .split('|')
-    .map((s) => s.trim())
-    .filter(Boolean);
+  return splitAcceptance(raw, '|');
 }
 
 /**


### PR DESCRIPTION
## Summary

CRITICAL data-integrity fix for `cleo add --acceptance "..."` (issue #409). The naive `String.split('|')` shredded any acceptance criterion that contained a pipe inside parentheses, brackets, or quoted string-unions. This PR replaces the naive split with a bracket+quote+escape-aware tokenizer in the canonical core helper, and collapses two duplicate inline implementations onto that helper.

Saga: SG-GH-TRIAGE-2026-05-21 (T9839)
Fixes #409

## Why — the data-corruption mechanism

Three real corrupted tasks in the live tasks.db prove the bug shipped to users:

| Task | Original AC | Corruption |
|------|-------------|-----------|
| T237 | `path ENUM (hot\|cold\|batch\|embed)` | Split into 4 fragments — task got 8 AC entries instead of ~6 |
| T239 | `mode: 'realtime-token'\|'batch'` | Quoted string-union split into two separate criteria |
| T240 | `bench_status ENUM(passed\|advisory\|none)` | Single criterion split into 3 |

Root cause: `parseAcceptanceCriteria` (and two inline duplicates in `cleo update` + `cleo saga create`) called `raw.split('|')` with no awareness of brackets, quotes, or escapes.

## Algorithm

The new tokenizer `splitAcceptance(input, delim='|')` walks the input once, tracking:

- ``depth`` — bracket nesting counter for ``(``/``[``/``{`` (clamped at 0 on close)
- ``quote`` — currently open quote character (``'`` or ``"``), or null
- Escape: ``\|`` at ``depth === 0`` with no active quote becomes a literal ``|``

A ``|`` is a split point ONLY when ALL THREE are true:

1. ``depth === 0`` (not inside any bracket span)
2. ``quote === null`` (not inside a quoted string)
3. It does NOT join two quoted spans. The ``|`` between a closing quote and an opening quote is treated as a **string-union continuation** — the entire ``'a'|'b'`` or ``"a"|"b"`` expression stays as one token. This is the gh-409 T239 rule.

Defensive guarantees:
- Unbalanced opening brackets do NOT throw and do NOT infinite-loop — the loop is bounded by ``input.length``. The unterminated tail is emitted as a single trailing token.
- Unbalanced closing brackets are tolerated via ``Math.max(0, depth - 1)``.
- The JSON-array fast-path (``'["A","B|C","D"]'``) is preserved verbatim — no behavioural change for JSON callers.

## DRY collapse (3 → 1)

Before this PR there were **three** competing pipe-split implementations:

| Site | Status |
|------|--------|
| `packages/core/src/tasks/infer-add-params.ts:127` (`parseAcceptanceCriteria`) | CANONICAL — fixed in place |
| `packages/cleo/src/cli/commands/update.ts:268-272` | DUPLICATE — now imports + calls canonical |
| `packages/cleo/src/cli/commands/saga.ts:55` | DUPLICATE — now imports + calls canonical |

After this PR there is exactly one tokenizer. Verified with `grep "split('|')" packages/cleo/src/cli/commands/` — zero hits outside generated/snapshot files.

## Test coverage

New regression suite: `packages/core/src/tasks/__tests__/parse-acceptance-criteria.test.ts` — 19 tests, all passing.

Covers:
- Plain pipe split, whitespace trim, empty-token drop, empty input, whitespace-only input
- **gh-409 T237**: ``ENUM (hot|cold|batch|embed)`` preserved
- **gh-409 T240**: ``ENUM(passed|advisory|none)`` (no space) preserved
- **gh-409 T239**: ``mode: 'realtime-token'|'batch'`` quoted-union preserved
- Nested brackets ``[...] (...)`` with embedded pipes
- Curly-brace groups ``{x|y|z}``
- Double-quoted string-unions ``"a"|"b"``
- Escape semantics: ``\|`` → literal ``|``
- JSON-array fast-path with embedded pipes
- JSON-array fast-path falls through on malformed JSON
- Defensive: unbalanced opening bracket does NOT throw, does NOT infinite-loop
- Defensive: unbalanced closing bracket tolerated (no underflow)
- Loop-bound proof: 10,000-token input terminates correctly

## Out of scope (file as follow-up)

**Data-repair for already-corrupted T237/T239/T240** in the live tasks.db is NOT addressed here. The corruption is persisted JSON in `tasks.acceptanceJson` and needs either a one-shot migration or manual ``cleo update --acceptance "..." --reason "gh-409 data-repair"`` per task. This PR fixes the tokenizer so no NEW data is corrupted going forward.

## Code-quality constraints honoured

- No ``any`` types, no ``unknown`` shortcuts, no ``as unknown as X`` casts
- Comprehensive TSDoc on the new helper with ``@bug`` link to gh-409 and ``@task T9839``
- Imports added in alphabetical/canonical position (biome enforces)
- No new package boundaries
- Generated file `packages/cleo/src/cli/generated/command-manifest.ts` was NOT touched

## CI checklist

- [x] `pnpm biome check --write` on all 4 touched files — clean
- [x] `pnpm --filter @cleocode/core test parse-acceptance-criteria` — 19/19 pass
- [x] Pre-existing build errors on `main` (in `src/routing/build-command-groups.ts` + `src/tasks/ops.ts` + `src/dispatch/domains/tasks.ts`) confirmed via stash-test — NOT introduced by this PR
- [ ] Full CI to confirm in PR

Fixes #409
Refs SG-GH-TRIAGE-2026-05-21 (T9839)