### PR TITLE
fix(T9838-C): cleo cancel survives T877 invariant; idempotent re-cancel

### DIFF
--- a/packages/cleo/src/cli/__tests__/cancel.test.ts
+++ b/packages/cleo/src/cli/__tests__/cancel.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the `cleo cancel` CLI command.
+ *
+ * Asserts:
+ *   - Command surface (name, description, taskId positional, --reason flag)
+ *   - Dispatch call routes to `mutate` / `tasks` / `cancel` with the args
+ *     supplied by the user (taskId + reason).
+ *
+ * @task T9838
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dispatchFromCli } = vi.hoisted(() => ({
+  dispatchFromCli: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../dispatch/adapters/cli.js', () => ({ dispatchFromCli }));
+
+import { cancelCommand } from '../commands/cancel.js';
+
+describe('cancelCommand (CLI surface)', () => {
+  beforeEach(() => {
+    dispatchFromCli.mockClear();
+  });
+
+  it('exports a command named "cancel"', () => {
+    expect(cancelCommand).toBeDefined();
+    const meta =
+      typeof cancelCommand.meta === 'function' ? cancelCommand.meta() : cancelCommand.meta;
+    expect((meta as { name: string }).name).toBe('cancel');
+  });
+
+  it('has a description mentioning the soft terminal state', () => {
+    const meta =
+      typeof cancelCommand.meta === 'function' ? cancelCommand.meta() : cancelCommand.meta;
+    expect((meta as { description: string }).description).toMatch(/cancel/i);
+    expect((meta as { description: string }).description).toMatch(/soft|reversible|restore/i);
+  });
+
+  it('declares a required `taskId` positional and an optional `reason` flag', () => {
+    const args = cancelCommand.args as Record<
+      string,
+      { type: string; required?: boolean; description?: string }
+    >;
+    expect(args).toBeDefined();
+    expect(args.taskId).toBeDefined();
+    expect(args.taskId.type).toBe('positional');
+    expect(args.taskId.required).toBe(true);
+    expect(args.reason).toBeDefined();
+    expect(args.reason.type).toBe('string');
+    // reason is intentionally OPTIONAL.
+    expect(args.reason.required).not.toBe(true);
+  });
+
+  it('dispatches to mutate/tasks/cancel with the supplied taskId', async () => {
+    const runner = cancelCommand.run as (ctx: {
+      args: { taskId: string; reason?: string };
+    }) => Promise<void>;
+    await runner({ args: { taskId: 'T0001' } });
+
+    expect(dispatchFromCli).toHaveBeenCalledTimes(1);
+    const call = dispatchFromCli.mock.calls[0];
+    expect(call[0]).toBe('mutate');
+    expect(call[1]).toBe('tasks');
+    expect(call[2]).toBe('cancel');
+    expect(call[3]).toEqual({ taskId: 'T0001', reason: undefined });
+  });
+
+  it('passes --reason through to the dispatcher', async () => {
+    const runner = cancelCommand.run as (ctx: {
+      args: { taskId: string; reason?: string };
+    }) => Promise<void>;
+    await runner({ args: { taskId: 'T0002', reason: 'Superseded by T0003' } });
+
+    expect(dispatchFromCli).toHaveBeenCalledTimes(1);
+    const call = dispatchFromCli.mock.calls[0];
+    expect(call[3]).toEqual({ taskId: 'T0002', reason: 'Superseded by T0003' });
+  });
+});

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -2168,7 +2168,9 @@ export const OPERATIONS: OperationDef[] = [
     description:
       'tasks.cancel (mutate) — cancel task (soft terminal state; reversible via tasks.restore)',
     tier: 1,
-    idempotent: false,
+    // T9838: re-cancel returns `alreadyCancelled: true` instead of failing,
+    // so the operation is idempotent at the registry level.
+    idempotent: true,
     sessionRequired: false,
     requiredParams: ['taskId'],
     params: [
@@ -2178,6 +2180,15 @@ export const OPERATIONS: OperationDef[] = [
         required: true,
         description: 'taskId parameter',
         cli: { positional: true },
+      },
+      {
+        // T9838: reason was implicitly accepted by the dispatch handler but
+        // missing from the registry schema, so dispatch tooling treated it
+        // as an unknown param.
+        name: 'reason',
+        type: 'string',
+        required: false,
+        description: 'Optional human-readable cancellation reason stored on the task',
       },
     ] satisfies ParamDef[],
   },

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -524,6 +524,7 @@ export interface TasksCancelParams {
  * Result of `tasks.cancel` — cancellation confirmation.
  *
  * @task T1703
+ * @task T9838 (idempotency — `alreadyCancelled` returned when re-cancelling)
  */
 export interface TasksCancelResult {
   /** The task ID that was cancelled. */
@@ -534,6 +535,14 @@ export interface TasksCancelResult {
   reason?: string;
   /** ISO 8601 timestamp of cancellation. */
   cancelledAt: string;
+  /**
+   * True when the task was already cancelled before this call — the
+   * operation is a no-op and the response reflects the pre-existing
+   * cancellation state. Idempotent re-cancellation (T9838).
+   *
+   * @defaultValue undefined
+   */
+  alreadyCancelled?: boolean;
 }
 
 // tasks.restore (with from routing: done → reopen, archived → unarchive)

--- a/packages/core/src/tasks/__tests__/cancel-ops.test.ts
+++ b/packages/core/src/tasks/__tests__/cancel-ops.test.ts
@@ -154,11 +154,40 @@ describe('cancelTask pipelineStage sync (T871)', () => {
     expect(updated[0].pipelineStage).toBe('cancelled');
   });
 
-  it('leaves already-terminal pipelineStage alone (idempotent)', () => {
+  it('forces pipelineStage to cancelled even when prior stage is contribution (T877 invariant fix)', () => {
+    // T9838: prior to this fix the carve-out left 'contribution' in place,
+    // tripping the T877 BEFORE-UPDATE trigger
+    // (`status=cancelled` MUST imply `pipeline_stage='cancelled'`).
     const tasks = [makeTask({ id: 'T001', status: 'pending', pipelineStage: 'contribution' })];
     const { tasks: updated } = cancelTask('T001', tasks);
     expect(updated[0].status).toBe('cancelled');
-    // contribution is a terminal marker; cancelTask must not overwrite it.
-    expect(updated[0].pipelineStage).toBe('contribution');
+    expect(updated[0].pipelineStage).toBe('cancelled');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// T9838 — idempotent re-cancel
+// ----------------------------------------------------------------------------
+
+describe('cancelTask idempotency (T9838)', () => {
+  it('re-cancelling a cancelled task returns success with alreadyCancelled', () => {
+    const existingCancelledAt = '2026-05-01T00:00:00.000Z';
+    const tasks = [
+      makeTask({
+        id: 'T001',
+        status: 'cancelled',
+        cancelledAt: existingCancelledAt,
+        cancellationReason: 'original reason',
+        pipelineStage: 'cancelled',
+      }),
+    ];
+    const { tasks: updated, result } = cancelTask('T001', tasks, 'ignored');
+    expect(result.success).toBe(true);
+    expect(result.alreadyCancelled).toBe(true);
+    expect(result.cancelledAt).toBe(existingCancelledAt);
+    expect(result.reason).toBe('original reason');
+    // Task state is unchanged (idempotent — no UPDATE issued).
+    expect(updated[0].cancelledAt).toBe(existingCancelledAt);
+    expect(updated[0].cancellationReason).toBe('original reason');
   });
 });

--- a/packages/core/src/tasks/__tests__/core-task-cancel.test.ts
+++ b/packages/core/src/tasks/__tests__/core-task-cancel.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Engine-level tests for `coreTaskCancel` and `taskCancel`.
+ *
+ * Exercises the live SQLite DB (with the T877 BEFORE-UPDATE trigger) to:
+ *   - Reproduce the T9838 regression: cancelling a task whose
+ *     `pipelineStage='contribution'` previously failed with
+ *     `T877_INVARIANT_VIOLATION` because the cancel handler skipped
+ *     overwriting the terminal stage.
+ *   - Verify the fix: pipeline_stage is always forced to 'cancelled'
+ *     when status='cancelled'.
+ *   - Verify idempotency: re-cancelling returns success with
+ *     `alreadyCancelled: true`.
+ *   - Verify dispatch wrapper maps errors to the correct sentinel codes
+ *     (E_NOT_FOUND for missing tasks, E_INVALID_STATE for completed tasks).
+ *
+ * @task T9838
+ */
+
+import type { Task } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import { coreTaskCancel, taskCancel } from '../task-ops.js';
+
+async function seedTask(
+  env: TestDbEnv,
+  overrides: { id: string; status?: string; pipelineStage?: string },
+): Promise<void> {
+  const now = new Date().toISOString();
+  // Cast through `unknown` rather than `any` — we provide the minimal shape
+  // sufficient for the cancel paths under test; the rest of Task is optional.
+  const seed = {
+    id: overrides.id,
+    title: `Seed ${overrides.id}`,
+    status: overrides.status ?? 'pending',
+    priority: 'medium',
+    createdAt: now,
+    updatedAt: now,
+    pipelineStage: overrides.pipelineStage ?? null,
+  } as unknown as Task;
+  await env.accessor.upsertSingleTask(seed);
+}
+
+describe('coreTaskCancel (engine, with live T877 trigger)', () => {
+  let env: TestDbEnv;
+  beforeEach(async () => {
+    env = await createTestDb();
+  });
+  afterEach(async () => {
+    await env.cleanup();
+  });
+
+  it('cancels a pending task and stamps cancelledAt + cancellationReason', async () => {
+    await seedTask(env, { id: 'T0001', status: 'pending' });
+
+    const result = await coreTaskCancel(env.tempDir, 'T0001', { reason: 'no longer needed' });
+    expect(result.cancelled).toBe(true);
+    expect(result.task).toBe('T0001');
+    expect(result.cancelledAt).toBeDefined();
+    expect(result.reason).toBe('no longer needed');
+
+    const reread = await env.accessor.loadSingleTask('T0001');
+    expect(reread?.status).toBe('cancelled');
+    expect(reread?.cancellationReason).toBe('no longer needed');
+    expect(reread?.pipelineStage).toBe('cancelled');
+  });
+
+  it('T9838 regression: cancels a task whose pipelineStage is contribution', async () => {
+    // Prior to the T9838 fix, this raised:
+    //   T877_INVARIANT_VIOLATION: status/pipeline_stage mismatch.
+    //   status=cancelled requires pipeline_stage=cancelled.
+    // The T871 carve-out left `contribution` in place; the BEFORE-UPDATE
+    // trigger then aborted the write.
+    await seedTask(env, { id: 'T0002', status: 'done', pipelineStage: 'contribution' });
+    // Move it out of `done` so canCancel allows it (canCancel rejects
+    // `done` per design). pending + contribution stage exercises the same
+    // trigger condition.
+    await seedTask(env, { id: 'T0003', status: 'pending', pipelineStage: 'contribution' });
+
+    const result = await coreTaskCancel(env.tempDir, 'T0003');
+    expect(result.cancelled).toBe(true);
+
+    const reread = await env.accessor.loadSingleTask('T0003');
+    expect(reread?.status).toBe('cancelled');
+    // Critical: stage MUST be 'cancelled' to satisfy the trigger.
+    expect(reread?.pipelineStage).toBe('cancelled');
+  });
+
+  it('is idempotent: re-cancelling returns alreadyCancelled', async () => {
+    await seedTask(env, { id: 'T0004', status: 'pending' });
+    const first = await coreTaskCancel(env.tempDir, 'T0004', { reason: 'first' });
+    expect(first.cancelled).toBe(true);
+    expect(first.alreadyCancelled).toBeUndefined();
+
+    const second = await coreTaskCancel(env.tempDir, 'T0004', { reason: 'second' });
+    expect(second.cancelled).toBe(true);
+    expect(second.alreadyCancelled).toBe(true);
+    // Echoes the ORIGINAL cancelledAt, not a new one.
+    expect(second.cancelledAt).toBe(first.cancelledAt);
+    // Echoes the original reason, not the new one — true no-op semantics.
+    expect(second.reason).toBe('first');
+  });
+});
+
+describe('taskCancel (dispatch wrapper, error mapping)', () => {
+  let env: TestDbEnv;
+  beforeEach(async () => {
+    env = await createTestDb();
+  });
+  afterEach(async () => {
+    await env.cleanup();
+  });
+
+  it('returns E_NOT_FOUND when the task does not exist', async () => {
+    const result = await taskCancel(env.tempDir, 'T9999');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe('E_NOT_FOUND');
+    }
+  });
+
+  it('returns E_INVALID_STATE for a completed task (not E_NOT_FOUND)', async () => {
+    // Seed a `done` task with the matching terminal stage so the seed
+    // itself doesn't trip the trigger.
+    await seedTask(env, { id: 'T0010', status: 'done', pipelineStage: 'contribution' });
+
+    const result = await taskCancel(env.tempDir, 'T0010');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Prior to T9838 this returned E_NOT_FOUND for ALL errors. After the
+      // fix, the dispatch wrapper distinguishes missing-task from
+      // invalid-state from internal errors.
+      expect(result.error.code).toBe('E_INVALID_STATE');
+      expect(result.error.message).toMatch(/completed/i);
+    }
+  });
+
+  it('returns success on a real cancel and again on idempotent re-cancel', async () => {
+    await seedTask(env, { id: 'T0011', status: 'pending' });
+    const first = await taskCancel(env.tempDir, 'T0011', 'first call');
+    expect(first.success).toBe(true);
+    if (first.success) {
+      expect(first.data.cancelled).toBe(true);
+      expect(first.data.alreadyCancelled).toBeUndefined();
+    }
+
+    const second = await taskCancel(env.tempDir, 'T0011', 'second call');
+    expect(second.success).toBe(true);
+    if (second.success) {
+      expect(second.data.alreadyCancelled).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/tasks/cancel-ops.ts
+++ b/packages/core/src/tasks/cancel-ops.ts
@@ -8,7 +8,6 @@
 
 import type { Task } from '@cleocode/contracts';
 import { teardownWorktree } from '../sentient/worktree-dispatch.js';
-import { isTerminalPipelineStage } from './pipeline-stage.js';
 
 /** Result of a cancel operation. */
 export interface CancelResult {
@@ -16,6 +15,13 @@ export interface CancelResult {
   taskId: string;
   reason?: string;
   cancelledAt?: string;
+  /**
+   * True when the task was already cancelled before this call. The cancel
+   * is treated as a no-op success — see T9838 idempotency contract.
+   *
+   * @defaultValue undefined
+   */
+  alreadyCancelled?: boolean;
   error?: { code: string; message: string };
 }
 
@@ -54,6 +60,22 @@ export function cancelTask(
     };
   }
 
+  // T9838: idempotent re-cancel. If the task is already cancelled, return
+  // success with `alreadyCancelled: true` and echo the existing cancelledAt
+  // rather than failing with E_CANNOT_CANCEL.
+  if (task.status === 'cancelled') {
+    return {
+      tasks,
+      result: {
+        success: true,
+        taskId,
+        reason: task.cancellationReason ?? undefined,
+        cancelledAt: task.cancelledAt ?? task.updatedAt ?? undefined,
+        alreadyCancelled: true,
+      },
+    };
+  }
+
   const check = canCancel(task);
   if (!check.allowed) {
     return {
@@ -75,11 +97,12 @@ export function cancelTask(
         cancelledAt: timestamp,
         cancellationReason: reason ?? undefined,
         updatedAt: timestamp,
-        // T871: sync pipelineStage with status. Leave an already-terminal
-        // stage alone (idempotent), otherwise route to the 'cancelled'
-        // terminal marker so Studio Pipeline groups this task under the
-        // CANCELLED column.
-        pipelineStage: isTerminalPipelineStage(t.pipelineStage) ? t.pipelineStage : 'cancelled',
+        // T877: DB invariant requires status='cancelled' ↔ pipeline_stage='cancelled'.
+        // ALWAYS overwrite the stage on cancellation — the prior T871 carve-out
+        // (`isTerminalPipelineStage ? keep : 'cancelled'`) left 'contribution' in
+        // place for cancelled tasks that had finished contribution, tripping the
+        // BEFORE-UPDATE trigger (T9838 repro).
+        pipelineStage: 'cancelled' as const,
       };
     }
     return t;

--- a/packages/core/src/tasks/deletion-strategy.ts
+++ b/packages/core/src/tasks/deletion-strategy.ts
@@ -188,6 +188,11 @@ function handleCascade(
         cancelledAt: timestamp,
         cancellationReason: 'Parent task cancelled (cascade)',
         updatedAt: timestamp,
+        // T877: DB invariant requires status='cancelled' ↔ pipeline_stage='cancelled'.
+        // Without this, descendants whose pipelineStage was 'research' (or any
+        // non-'cancelled' value) would trip the BEFORE-UPDATE trigger on persist.
+        // T9838 fix: mirror coreTaskCancel's invariant treatment.
+        pipelineStage: 'cancelled' as const,
       };
     }
     return t;

--- a/packages/core/src/tasks/task-ops.ts
+++ b/packages/core/src/tasks/task-ops.ts
@@ -44,7 +44,6 @@ import {
   validateDependencies,
 } from './dependency-check.js';
 import { depsReady } from './deps-ready.js';
-import { isTerminalPipelineStage } from './pipeline-stage.js';
 import {
   discoverRelated,
   removeRelation as relatesRemoveRelation,
@@ -1035,12 +1034,22 @@ export async function coreTaskRestore(
  * @param taskId - The task ID to cancel
  * @param params - Optional cancel options
  * @param params.reason - Human-readable cancellation reason stored on the task
- * @returns Confirmation with cancelled flag and timestamp
+ * @returns Confirmation with cancelled flag and timestamp. When the task is
+ *          already cancelled, the response includes `alreadyCancelled: true`
+ *          and echoes the existing `cancelledAt` (idempotent — T9838).
  *
  * @remarks
  * Cancellation is a soft terminal state -- the task remains in the database and
  * can be restored via {@link coreTaskRestore}. Not all statuses are cancellable;
  * the `canCancel` guard determines eligibility.
+ *
+ * The T877 DB trigger enforces an invariant: when `status='cancelled'`, the
+ * `pipeline_stage` MUST equal `'cancelled'`. This function therefore always
+ * forces `pipelineStage='cancelled'` on a successful cancel, overriding any
+ * prior terminal value such as `'contribution'`. The previous T871 carve-out
+ * (skip overwrite when stage was already terminal) caused
+ * `T877_INVARIANT_VIOLATION` for tasks that had reached the `'contribution'`
+ * terminal stage before cancellation — see T9838 repro.
  *
  * @example
  * ```typescript
@@ -1049,21 +1058,43 @@ export async function coreTaskRestore(
  * ```
  *
  * @task T4529
+ * @task T9838 (T877 invariant fix + idempotent re-cancel)
  */
 export async function coreTaskCancel(
   projectRoot: string,
   taskId: string,
   params?: { reason?: string },
-): Promise<{ task: string; cancelled: boolean; reason?: string; cancelledAt: string }> {
+): Promise<{
+  task: string;
+  cancelled: boolean;
+  reason?: string;
+  cancelledAt: string;
+  alreadyCancelled?: boolean;
+}> {
   const accessor = await getTaskAccessor(projectRoot);
   const task = await accessor.loadSingleTask(taskId);
   if (!task) {
     throw new Error(`Task ${taskId} not found`);
   }
 
+  // Idempotent: re-cancelling an already-cancelled task returns success with
+  // `alreadyCancelled: true` and echoes the existing cancelledAt. T9838.
+  if (task.status === 'cancelled') {
+    return {
+      task: taskId,
+      cancelled: true,
+      reason: task.cancellationReason ?? undefined,
+      cancelledAt: task.cancelledAt ?? task.updatedAt ?? new Date().toISOString(),
+      alreadyCancelled: true,
+    };
+  }
+
   const check = canCancel(task);
   if (!check.allowed) {
-    throw new Error(check.reason!);
+    // Reject with a sentinel that the dispatch layer (taskCancel in
+    // packages/core/src/tasks/task-ops.ts::taskCancel) maps to E_INVALID_STATE
+    // rather than the catch-all E_NOT_FOUND.
+    throw new Error(`E_INVALID_STATE: ${check.reason!}`);
   }
 
   const cancelledAt = new Date().toISOString();
@@ -1071,13 +1102,11 @@ export async function coreTaskCancel(
   task.cancelledAt = cancelledAt;
   task.cancellationReason = params?.reason ?? undefined;
   task.updatedAt = cancelledAt;
-  // T871: keep status and pipelineStage in lock-step. Cancelled tasks must
-  // leave the active RCASD-IVTR+C chain so Studio Pipeline routes them to
-  // the dedicated CANCELLED column instead of lingering in research/
-  // implementation/release.
-  if (!isTerminalPipelineStage(task.pipelineStage)) {
-    task.pipelineStage = 'cancelled';
-  }
+  // T877: DB invariant requires status='cancelled' ↔ pipeline_stage='cancelled'.
+  // ALWAYS force the stage to 'cancelled' on a successful cancel — the prior
+  // T871 carve-out (skip when already terminal) would leave 'contribution'
+  // in place and trip the BEFORE-UPDATE trigger. T9838 repro.
+  task.pipelineStage = 'cancelled';
   await accessor.upsertSingleTask(task);
 
   // Best-effort worktree cleanup when cancelling a task.
@@ -2841,14 +2870,31 @@ export async function taskCancel(
   taskId: string,
   reason?: string,
 ): Promise<
-  EngineResult<{ task: string; cancelled: boolean; reason?: string; cancelledAt: string }>
+  EngineResult<{
+    task: string;
+    cancelled: boolean;
+    reason?: string;
+    cancelledAt: string;
+    alreadyCancelled?: boolean;
+  }>
 > {
   try {
     const result = await coreTaskCancel(projectRoot, taskId, { reason });
     return engineSuccess(result);
   } catch (err: unknown) {
+    // T9838: distinguish "task missing" from "task exists but cannot be
+    // cancelled" from underlying engine/DB failures. Prior to this fix
+    // every error mapped to E_NOT_FOUND, including T877_INVARIANT_VIOLATION
+    // and E_CANNOT_CANCEL — masking real bugs as missing tasks.
     const e = err as { message?: string };
-    return engineError('E_NOT_FOUND', e?.message ?? 'Failed to cancel task');
+    const message = e?.message ?? 'Failed to cancel task';
+    if (message.startsWith('E_INVALID_STATE:')) {
+      return engineError('E_INVALID_STATE', message.replace(/^E_INVALID_STATE:\s*/, ''));
+    }
+    if (message.includes(' not found')) {
+      return engineError('E_NOT_FOUND', message);
+    }
+    return engineError('E_INTERNAL', message);
   }
 }
 


### PR DESCRIPTION
## Summary

The parent task T9838 reported that `cleo cancel T#####` was listed in `--help` but returned `E_NOT_FOUND` ("verb missing"). Investigation revealed the verb IS registered (cancelCommand → command-manifest → registry → dispatch). The real regression is at the engine layer: `cleo cancel` silently failed with `E_NOT_FOUND` for any task whose `pipelineStage` had reached the terminal `'contribution'` stage — the inner DB trigger error was being swallowed.

Concrete repro (pre-fix, against the live tasks.db):

```
$ cleo cancel T9840 --reason "smoke"
{"error":{"code":4,"codeName":"E_NOT_FOUND",
  "message":"T877_INVARIANT_VIOLATION: status/pipeline_stage mismatch.
             status=cancelled requires pipeline_stage=cancelled."}}
```

Root cause: `coreTaskCancel` deliberately preserved `'contribution'` under the T871 "terminal stage" carve-out, but the T877 BEFORE-UPDATE trigger demands `status='cancelled' ↔ pipeline_stage='cancelled'`. The trigger aborted every cancel of a contribution-stage task; `taskCancel`'s blanket `catch` then relabelled the abort as `E_NOT_FOUND`.

## Changes

- **`packages/core/src/tasks/task-ops.ts`** — `coreTaskCancel` always forces `pipelineStage='cancelled'`; idempotent re-cancel returns `alreadyCancelled: true` with the original timestamp. `taskCancel` distinguishes `E_NOT_FOUND` / `E_INVALID_STATE` / `E_INTERNAL` instead of mapping every error to `E_NOT_FOUND`.
- **`packages/core/src/tasks/cancel-ops.ts`** — Pure-array `cancelTask` mirrors the same fix + idempotency.
- **`packages/core/src/tasks/deletion-strategy.ts`** — Cascade cancel also stamps `pipeline_stage='cancelled'` on descendants (same trigger condition).
- **`packages/contracts/src/operations/tasks.ts`** — `TasksCancelResult` gains `alreadyCancelled?: boolean` per the idempotent contract (SSoT — used by CLI + core).
- **`packages/cleo/src/dispatch/registry.ts`** — `tasks.cancel` param schema now declares `reason`; `idempotent: true`.
- **New tests:**
  - `packages/cleo/src/cli/__tests__/cancel.test.ts` — 5 tests covering CLI surface + dispatch routing with `--reason`.
  - `packages/core/src/tasks/__tests__/core-task-cancel.test.ts` — 6 engine-level tests against the live SQLite trigger (regression for T9838 + idempotency + error-mapping).
- **Updated tests:** `cancel-ops.test.ts` — inverts the broken "preserves contribution" assertion (which was asserting the bug) and adds idempotency test.

## Quality gates

- `pnpm biome check .` → 0 warnings
- `pnpm --filter @cleocode/{contracts,core,cleo} run build` → green
- Tests: 30 passed across the three cancel test files; 53 passed in pipeline-stage + T877-invariants regression
- `node scripts/lint-project-root-anti-pattern.mjs --strict` → 0 violations
- `node scripts/lint-core-first.mjs --check` → no new violations above baseline (87)

## Test plan

- [x] Reproduce E_NOT_FOUND with live cleo cancel against a contribution-stage task
- [x] Cancel-ops + core-task-cancel unit tests against the live SQLite trigger
- [x] CLI cancel test mocks dispatch and verifies `--reason` passthrough
- [x] T877 invariant regression suite still green (53 tests)
- [ ] After merge: re-cancel T9840 (the orphaned smoke task from the repro) and confirm status flips to `cancelled`

## Re: op pre-existing or new

The `cancel` operation was **pre-existing** at every layer (cancelCommand, registry, dispatch, engine, contracts). This PR fixes the latent T877 invariant bug + idempotency contract gap; it does NOT introduce a new op.

Tasks: T9838
Refs: T9782 saga, T9758 release-as-product, T877, T871