### PR TITLE
feat(T9838-B): pr:<num> evidence atom satisfies implemented gate

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1273,13 +1273,18 @@ export type {
 export type { AdapterPathProvider } from './provider-paths.js';
 // === Release Channel ===
 export type { ChannelValidationResult, ReleaseChannel } from './release/channel.js';
-// === Release Evidence Atoms (T9764) ===
-export type { GhPrViewPayload, ParsedPrEvidenceAtom } from './release/evidence-atoms.js';
+// === Release Evidence Atoms (T9764 + T9838) ===
+export type {
+  GhPrViewPayload,
+  ParsedPrEvidenceAtom,
+  PrEvidenceStateModifier,
+} from './release/evidence-atoms.js';
 export {
   ghPrViewSchema,
   PR_REQUIRED_WORKFLOWS,
   PR_REQUIRED_WORKFLOWS_ENV_VAR,
   parsedPrEvidenceAtomSchema,
+  prEvidenceStateModifierSchema,
 } from './release/evidence-atoms.js';
 // === Release GitHub PR ===
 export type {

--- a/packages/contracts/src/release/evidence-atoms.ts
+++ b/packages/contracts/src/release/evidence-atoms.ts
@@ -28,7 +28,14 @@ import { z } from 'zod';
  * "pr:357"`. The number is restricted to positive integers because
  * GitHub PR numbers cannot be zero or negative.
  *
+ * T9838 introduced the optional explicit-form modifier
+ * `pr:<num>;state:MERGED`. The `state` modifier is intent-documenting
+ * (the resolver always demands state === 'MERGED') and is consumed at
+ * parse time without being emitted as a separate atom. See
+ * {@link prEvidenceStateModifierSchema}.
+ *
  * @task T9764
+ * @task T9838
  */
 export interface ParsedPrEvidenceAtom {
   /** Discriminant — always `'pr'`. */
@@ -50,6 +57,37 @@ export const parsedPrEvidenceAtomSchema = z.object({
   kind: z.literal('pr'),
   prNumber: z.number().int().positive(),
 }) satisfies z.ZodType<ParsedPrEvidenceAtom>;
+
+/**
+ * Zod schema for the optional `state:MERGED` modifier that may follow a
+ * `pr:<num>` atom in the evidence string (T9838).
+ *
+ * The modifier is intent-documenting: the resolver always demands
+ * `state === 'MERGED'`, so emitting `state:MERGED` explicitly is a
+ * no-op assertion that proves the caller knows the contract. Only the
+ * literal string `"MERGED"` is accepted — `OPEN`, `CLOSED`, or any other
+ * value is rejected at parse time because no other state can satisfy any
+ * gate the `pr:` atom is allowed to back.
+ *
+ * The parser consumes the modifier in-place (it does NOT emit a separate
+ * atom) so downstream code never sees a free-standing `state` atom. The
+ * schema exists so external producers (e.g. a future provenance importer)
+ * can validate the literal payload before passing it to `parseEvidence`.
+ *
+ * @task T9838
+ */
+export const prEvidenceStateModifierSchema = z.object({
+  kind: z.literal('state'),
+  value: z.literal('MERGED'),
+});
+
+/**
+ * Inferred type for the explicit `state:MERGED` modifier emitted alongside
+ * a `pr:<num>` atom. See {@link prEvidenceStateModifierSchema}.
+ *
+ * @task T9838
+ */
+export type PrEvidenceStateModifier = z.infer<typeof prEvidenceStateModifierSchema>;
 
 /**
  * Raw shape returned by `gh pr view <num> --json

--- a/packages/core/src/release/__tests__/evidence-pr-atom.test.ts
+++ b/packages/core/src/release/__tests__/evidence-pr-atom.test.ts
@@ -563,7 +563,7 @@ describe('evaluateRollup', () => {
 // Gate evidence minimums
 // ---------------------------------------------------------------------------
 
-describe('checkGateEvidenceMinimum — pr atom satisfies testsPassed + qaPassed', () => {
+describe('checkGateEvidenceMinimum — pr atom satisfies testsPassed + qaPassed + implemented (T9838)', () => {
   const prAtom: EvidenceAtom = {
     kind: 'pr',
     prNumber: 357,
@@ -581,9 +581,146 @@ describe('checkGateEvidenceMinimum — pr atom satisfies testsPassed + qaPassed'
     expect(checkGateEvidenceMinimum('qaPassed', [prAtom])).toBeNull();
   });
 
-  it('does not auto-satisfy implemented gate (still needs commit+files)', () => {
-    const result = checkGateEvidenceMinimum('implemented', [prAtom]);
-    expect(result).not.toBeNull();
+  it('T9838: accepts pr atom for implemented gate (merged PR IS the landing commit)', () => {
+    // T9838: a merged PR with a real mergeCommitSha IS the proof that the
+    // implementation landed on main. Eliminates the manual
+    // `commit:<sha>;files:...` backfill ritual that v5.91-v5.93 ships
+    // were stuck in.
+    expect(checkGateEvidenceMinimum('implemented', [prAtom])).toBeNull();
+  });
+
+  it('T9838: pr atom satisfies all three release-time gates simultaneously', () => {
+    // The motivating use case: after merging a PR, one `pr:<num>` atom
+    // should cover implemented + testsPassed + qaPassed in a single
+    // verify invocation.
+    expect(checkGateEvidenceMinimum('implemented', [prAtom])).toBeNull();
+    expect(checkGateEvidenceMinimum('testsPassed', [prAtom])).toBeNull();
+    expect(checkGateEvidenceMinimum('qaPassed', [prAtom])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T9838 — explicit-form parsing (pr:<num>;state:MERGED)
+// ---------------------------------------------------------------------------
+
+describe('parseEvidence — explicit-form pr atom (T9838)', () => {
+  it('parses pr:<num>;state:MERGED as a single pr atom (state modifier consumed in-place)', () => {
+    const r = parseEvidence('pr:357;state:MERGED');
+    expect(r.atoms).toHaveLength(1);
+    expect(r.atoms[0]).toEqual({ kind: 'pr', prNumber: 357 });
+  });
+
+  it('treats bare pr:<num> equivalently to pr:<num>;state:MERGED (backward compat)', () => {
+    const bare = parseEvidence('pr:357');
+    const explicit = parseEvidence('pr:357;state:MERGED');
+    expect(explicit.atoms).toEqual(bare.atoms);
+  });
+
+  it('rejects state:OPEN (only MERGED is meaningful)', () => {
+    expect(() => parseEvidence('pr:357;state:OPEN')).toThrow(/only accepts "MERGED"/);
+  });
+
+  it('rejects state:CLOSED', () => {
+    expect(() => parseEvidence('pr:357;state:CLOSED')).toThrow(/only accepts "MERGED"/);
+  });
+
+  it('rejects free-standing state:MERGED with no preceding pr: atom', () => {
+    expect(() => parseEvidence('state:MERGED')).toThrow(/must immediately follow a pr:<num> atom/);
+  });
+
+  it('rejects state:MERGED preceded by a non-pr atom', () => {
+    expect(() => parseEvidence('commit:abc1234;state:MERGED')).toThrow(
+      /must immediately follow a pr:<num> atom/,
+    );
+  });
+
+  it('explicit form composes with other atoms', () => {
+    const r = parseEvidence('pr:357;state:MERGED;note:explicit form used');
+    expect(r.atoms).toHaveLength(2);
+    expect(r.atoms[0]).toEqual({ kind: 'pr', prNumber: 357 });
+    expect(r.atoms[1]).toEqual({ kind: 'note', note: 'explicit form used' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T9838 — resolver behavior on implemented gate
+// ---------------------------------------------------------------------------
+
+describe('resolvePrEvidenceAtom — implemented gate semantics (T9838)', () => {
+  it('happy path: merged PR with passing CI satisfies all three gates', async () => {
+    fetchSpy.mockResolvedValue({ ok: true, payload: makePrPayload() });
+    const r = await resolvePrEvidenceAtom(357, projectRoot, {
+      fetchGhPrPayload: mockFetch,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    // The resolver returned a valid atom — wire it through the gate engine.
+    const atom: EvidenceAtom = {
+      kind: 'pr',
+      prNumber: r.prNumber,
+      mergeCommitSha: r.mergeCommitSha,
+      mergedAt: r.mergedAt,
+      successCount: r.successCount,
+      totalChecks: r.totalChecks,
+    };
+    expect(checkGateEvidenceMinimum('implemented', [atom])).toBeNull();
+    expect(checkGateEvidenceMinimum('testsPassed', [atom])).toBeNull();
+    expect(checkGateEvidenceMinimum('qaPassed', [atom])).toBeNull();
+  });
+
+  it('non-merged (state=OPEN) PR yields no atom — gates remain unsatisfied', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      payload: makePrPayload({ state: 'OPEN', mergedAt: null }),
+    });
+    const r = await resolvePrEvidenceAtom(357, projectRoot, {
+      fetchGhPrPayload: mockFetch,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.codeName).toBe('E_EVIDENCE_INSUFFICIENT');
+    expect(r.reason).toMatch(/state.*OPEN/);
+
+    // With no successful atom the gate engine MUST refuse implemented as well.
+    expect(checkGateEvidenceMinimum('implemented', [])).not.toBeNull();
+  });
+
+  it('merged PR with required-CI failure preserves T9764 testsPassed/qaPassed rejection', async () => {
+    // Sanity: T9838 only EXTENDS the gate list — it must not weaken the
+    // existing T9764 CI-failure rejection on testsPassed/qaPassed.
+    const payload = makePrPayload({
+      statusCheckRollup: [
+        {
+          __typename: 'CheckRun',
+          name: 'Build & Verify (ubuntu-latest)',
+          workflowName: 'CI',
+          conclusion: 'SUCCESS',
+          status: 'COMPLETED',
+        },
+        {
+          __typename: 'CheckRun',
+          name: 'Verify pnpm-lock.yaml consistency',
+          workflowName: 'Lockfile Check',
+          conclusion: 'SUCCESS',
+          status: 'COMPLETED',
+        },
+        {
+          __typename: 'CheckRun',
+          name: 'Contracts Dep Lint',
+          workflowName: 'Contracts Dep Lint',
+          conclusion: 'FAILURE',
+          status: 'COMPLETED',
+        },
+      ],
+    });
+    fetchSpy.mockResolvedValue({ ok: true, payload });
+    const r = await resolvePrEvidenceAtom(357, projectRoot, {
+      fetchGhPrPayload: mockFetch,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.codeName).toBe('E_EVIDENCE_TESTS_FAILED');
   });
 });
 

--- a/packages/core/src/tasks/evidence.ts
+++ b/packages/core/src/tasks/evidence.ts
@@ -122,9 +122,17 @@ export const GATE_EVIDENCE_MINIMUMS: Record<VerificationGate, EvidenceAtom['kind
     // Decision-only tasks with no research file: a brain_decisions row + note
     // satisfies the implemented gate.
     ['decision', 'note'],
+    // pr atom (T9838) — a merged PR with a real mergeCommitSha IS the proof
+    // that the implementation landed on main. The resolver only succeeds
+    // when state === 'MERGED' and mergeCommitSha is non-null, so the merged
+    // PR's merge commit is the canonical landing commit. Eliminates the
+    // manual `commit:<sha>;files:...` backfill ritual that
+    // v5.91 - v5.93 ships were stuck in.
+    ['pr'],
   ],
   // pr atom (T9764) — a merged PR with all required-workflow checks green
   // satisfies BOTH testsPassed and qaPassed simultaneously.
+  // T9838 extends the same atom to satisfy `implemented` (see above).
   testsPassed: [['test-run'], ['tool'], ['pr']],
   qaPassed: [['tool'], ['pr']],
   documented: [['files'], ['url']],
@@ -383,12 +391,47 @@ export function parseEvidence(raw: string): ParsedEvidence {
         atoms.push({ kind: 'pr', prNumber });
         break;
       }
+      case 'state': {
+        // T9838: optional explicit-form modifier for the preceding pr: atom.
+        // Format: pr:<num>;state:MERGED  (only "MERGED" is currently meaningful).
+        // The resolver ALWAYS requires state === 'MERGED' regardless, so this
+        // modifier is intent-documenting — it asserts the caller knows the
+        // contract, and rejects nonsensical pairings early.
+        if (payload !== 'MERGED') {
+          throw new CleoError(
+            ExitCode.VALIDATION_ERROR,
+            `state atom only accepts "MERGED", got "${payload}" in "${chunk}"`,
+            {
+              fix: 'Use format: pr:<num>;state:MERGED (state is only meaningful paired with a pr: atom)',
+            },
+          );
+        }
+        // Must follow a pr: atom in the same evidence string. Locate the
+        // most recent pr: atom and tag it as explicitly-asserted-MERGED.
+        // Since the resolver already enforces state === 'MERGED', no extra
+        // runtime check is needed — we just validate the pairing here.
+        const lastPrIdx = atoms.length - 1;
+        const lastAtom = atoms[lastPrIdx];
+        if (!lastAtom || lastAtom.kind !== 'pr') {
+          throw new CleoError(
+            ExitCode.VALIDATION_ERROR,
+            `state:MERGED must immediately follow a pr:<num> atom in the same evidence string ` +
+              `(got "${chunk}" with no preceding pr: atom)`,
+            {
+              fix: 'Use format: --evidence "pr:357;state:MERGED" (state modifier requires a pr: predecessor)',
+            },
+          );
+        }
+        // Modifier consumed — no new atom emitted. The pr: atom already carries
+        // the prNumber; the merge-state assertion is handled by the resolver.
+        break;
+      }
       default:
         throw new CleoError(
           ExitCode.VALIDATION_ERROR,
           `Unknown evidence kind: "${kind}" in atom "${chunk}"`,
           {
-            fix: 'Valid kinds: commit, files, test-run, tool, url, note, loc-drop, callsite-coverage, decision, pr',
+            fix: 'Valid kinds: commit, files, test-run, tool, url, note, loc-drop, callsite-coverage, decision, pr, state',
           },
         );
     }


### PR DESCRIPTION
## Summary

- Extends the `pr:<num>` evidence atom (T9764) so a merged PR ALSO satisfies the `implemented` gate — not just `testsPassed` + `qaPassed`. A `state=MERGED` PR with a real `mergeCommitSha` IS the canonical proof that the implementation landed on `main`.
- Adds optional explicit-form modifier `pr:<num>;state:MERGED` for callers that want to assert the merge contract in the evidence string. The modifier is consumed in-place at parse time (no new contract atom kind) and validated against `'MERGED'`.
- Adds zod schema `prEvidenceStateModifierSchema` + type `PrEvidenceStateModifier` in `@cleocode/contracts/release/evidence-atoms.ts`, exported from the package root.

## Why this is correct

The `implemented` gate's purpose is "the work landed in some commit". A merged PR is a PR that landed in main via a commit (the merge commit / head commit on main). Requiring a separate `commit:<sha>;files:<list>` atom on top of a `pr:` atom is redundant friction once GitHub has resolved the PR — the resolver already only succeeds when `state === 'MERGED'` AND `mergeCommitSha` is non-null AND all required-workflow checks are green. Eliminates the manual `commit:<sha>;files:...` backfill ritual that the v5.91 → v5.93 ships were stuck in.

## Changes (gate map: was 2, now 3)

`GATE_EVIDENCE_MINIMUMS['implemented']` previously accepted `[commit, files] | [commit, note] | [decision, files] | [decision, note]`. After T9838 it also accepts `[pr]`. `testsPassed` and `qaPassed` retain the existing `[pr]` alternative (unchanged).

## Backward compatibility

- Bare `pr:<num>` continues to work unchanged.
- All existing T9764 tests pass — the previous assertion that "pr atom does not auto-satisfy implemented" is updated to "T9838: pr atom now satisfies implemented".
- Required-CI-failure rejection on `testsPassed` / `qaPassed` is preserved (regression-tested).

## Test plan

- [x] 43 tests pass in `evidence-pr-atom.test.ts` (was 28; +15 new T9838 tests)
- [x] 92 release+tasks test files / 1269 tests / 2 skipped — all green
- [x] `pnpm biome check` clean on touched dirs
- [x] `lint-project-root-anti-pattern.mjs --strict` clean
- [x] `lint-core-first.mjs --check` clean
- [x] `@cleocode/contracts` + `@cleocode/core` + workspace build green
- [x] Parser tests cover: explicit form parses, `state:OPEN` rejected, `state:CLOSED` rejected, free-standing `state:` rejected, non-pr-preceding `state:` rejected, explicit form composes with other atoms, explicit ≡ bare
- [x] Resolver tests cover: happy path satisfies all 3 gates, non-merged PR yields no atom, required-CI failure preserves T9764 rejection