### PR TITLE
fix(T9838-D): cleo update --status cancelled works without verify-init

### DIFF
--- a/packages/core/src/tasks/__tests__/update-status-cancellation.test.ts
+++ b/packages/core/src/tasks/__tests__/update-status-cancellation.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for the cancellation path of `updateTask` (`cleo update --status cancelled`).
+ *
+ * Closes the T9838-D gap: prior to this fix, `cleo update T### --status cancelled`
+ * on a pending task threw `T877_INVARIANT_VIOLATION` because the status flipped to
+ * `cancelled` without the pipeline_stage trigger being satisfied; the
+ * `taskUpdate` engine wrapper then mis-labelled the error as `E_NOT_INITIALIZED`.
+ *
+ * Fix verifies:
+ *  - pending -> cancelled succeeds, cancelledAt stamped, pipelineStage synced.
+ *  - active -> cancelled succeeds, same.
+ *  - blocked -> cancelled succeeds, same.
+ *  - cancelled -> cancelled is rejected by transition validator (no idempotent re-cancel).
+ *  - done -> cancelled is rejected with a clear E_VALIDATION (not E_NOT_INITIALIZED).
+ *  - pending -> done still funnels through the dedicated complete flow.
+ *  - the engine-result wrapper surfaces real CleoError codes, not E_NOT_INITIALIZED.
+ *
+ * @task T9838-D
+ * @epic T9838
+ */
+
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { ExitCode } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CleoError } from '../../errors.js';
+import { createTestDb, seedTasks, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { resetDbState } from '../../store/sqlite.js';
+import { taskUpdate, updateTask } from '../update.js';
+
+describe('updateTask cancellation path (T9838-D)', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+    await writeFile(
+      join(env.cleoDir, 'config.json'),
+      JSON.stringify({
+        enforcement: {
+          session: { requiredForMutate: false },
+          acceptance: { mode: 'off' },
+        },
+        lifecycle: { mode: 'off' },
+        verification: { enabled: false },
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  it('pending -> cancelled succeeds, stamps cancelledAt, syncs pipelineStage', async () => {
+    await seedTasks(accessor, [
+      {
+        id: 'T001',
+        title: 'Pending task',
+        status: 'pending',
+        priority: 'medium',
+        pipelineStage: 'implementation',
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await updateTask({ taskId: 'T001', status: 'cancelled' }, env.tempDir, accessor);
+
+    expect(result.task.status).toBe('cancelled');
+    expect(result.task.cancelledAt).toBeTruthy();
+    expect(result.task.pipelineStage).toBe('cancelled');
+    expect(result.changes).toContain('status');
+    expect(result.changes).toContain('pipelineStage');
+  });
+
+  it('active -> cancelled succeeds, stamps cancelledAt, syncs pipelineStage', async () => {
+    await seedTasks(accessor, [
+      {
+        id: 'T002',
+        title: 'Active task',
+        status: 'active',
+        priority: 'medium',
+        pipelineStage: 'validation',
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await updateTask({ taskId: 'T002', status: 'cancelled' }, env.tempDir, accessor);
+
+    expect(result.task.status).toBe('cancelled');
+    expect(result.task.cancelledAt).toBeTruthy();
+    expect(result.task.pipelineStage).toBe('cancelled');
+  });
+
+  it('blocked -> cancelled succeeds, stamps cancelledAt, syncs pipelineStage', async () => {
+    await seedTasks(accessor, [
+      {
+        id: 'T003',
+        title: 'Blocked task',
+        status: 'blocked',
+        priority: 'medium',
+        pipelineStage: 'research',
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await updateTask({ taskId: 'T003', status: 'cancelled' }, env.tempDir, accessor);
+
+    expect(result.task.status).toBe('cancelled');
+    expect(result.task.cancelledAt).toBeTruthy();
+    expect(result.task.pipelineStage).toBe('cancelled');
+  });
+
+  it('forces pipelineStage=cancelled even when the prior stage was contribution', async () => {
+    // The T877 DB invariant (Part B) requires `status=cancelled` rows to have
+    // `pipeline_stage='cancelled'` — stricter than the in-memory cancel-ops
+    // sync which preserved any terminal stage. Cancellation routes ALL
+    // pipelineStage values to the 'cancelled' marker so the trigger accepts
+    // the write and Studio Pipeline groups the task under CANCELLED.
+    await seedTasks(accessor, [
+      {
+        id: 'T004',
+        title: 'Contribution stage task',
+        status: 'pending',
+        priority: 'medium',
+        pipelineStage: 'contribution',
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await updateTask({ taskId: 'T004', status: 'cancelled' }, env.tempDir, accessor);
+
+    expect(result.task.status).toBe('cancelled');
+    expect(result.task.cancelledAt).toBeTruthy();
+    expect(result.task.pipelineStage).toBe('cancelled');
+    expect(result.changes).toContain('pipelineStage');
+  });
+
+  it('cancelled -> cancelled rejects (transition validator blocks self-loop)', async () => {
+    await seedTasks(accessor, [
+      {
+        id: 'T005',
+        title: 'Already cancelled',
+        status: 'cancelled',
+        priority: 'medium',
+        pipelineStage: 'cancelled',
+        cancelledAt: '2026-05-20T00:00:00.000Z',
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    await expect(
+      updateTask({ taskId: 'T005', status: 'cancelled' }, env.tempDir, accessor),
+    ).rejects.toThrow(CleoError);
+  });
+
+  it('done -> cancelled is rejected with E_VALIDATION (not E_NOT_INITIALIZED)', async () => {
+    await seedTasks(accessor, [
+      {
+        id: 'T006',
+        title: 'Completed task',
+        status: 'done',
+        priority: 'medium',
+        pipelineStage: 'contribution',
+        completedAt: '2026-05-20T00:00:00.000Z',
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    await expect(
+      updateTask({ taskId: 'T006', status: 'cancelled' }, env.tempDir, accessor),
+    ).rejects.toMatchObject({
+      code: ExitCode.VALIDATION_ERROR,
+    });
+  });
+
+  it('pending -> done still routes through the dedicated complete flow', async () => {
+    await seedTasks(accessor, [
+      {
+        id: 'T007',
+        title: 'To be completed',
+        status: 'pending',
+        priority: 'medium',
+        pipelineStage: 'contribution',
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await updateTask({ taskId: 'T007', status: 'done' }, env.tempDir, accessor);
+    expect(result.task.status).toBe('done');
+    expect(result.changes).toEqual(['status']);
+  });
+
+  describe('taskUpdate engine-result wrapper (T9838-D — error surfacing)', () => {
+    it('pending -> cancelled returns success envelope (no E_NOT_INITIALIZED)', async () => {
+      await seedTasks(accessor, [
+        {
+          id: 'T010',
+          title: 'Wrapper pending',
+          status: 'pending',
+          priority: 'medium',
+          pipelineStage: 'implementation',
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+
+      const result = await taskUpdate(env.tempDir, 'T010', { status: 'cancelled' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.task.status).toBe('cancelled');
+        expect(result.data.task.cancelledAt).toBeTruthy();
+        expect(result.data.task.pipelineStage).toBe('cancelled');
+      }
+    });
+
+    it('done -> cancelled surfaces validation error (not E_NOT_INITIALIZED)', async () => {
+      await seedTasks(accessor, [
+        {
+          id: 'T011',
+          title: 'Wrapper done',
+          status: 'done',
+          priority: 'medium',
+          pipelineStage: 'contribution',
+          completedAt: '2026-05-20T00:00:00.000Z',
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+
+      const result = await taskUpdate(env.tempDir, 'T011', { status: 'cancelled' });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).not.toBe('E_NOT_INITIALIZED');
+        // CleoError.toLAFSError() emits the catalog lafsCode for VALIDATION_ERROR.
+        expect(result.error.code).toBe('E_CLEO_VALIDATION');
+        expect(result.error.message).toMatch(/Cannot transition from 'done'/);
+      }
+    });
+
+    it('not-found task surfaces NOT_FOUND code (not E_NOT_INITIALIZED)', async () => {
+      const result = await taskUpdate(env.tempDir, 'T999', { status: 'cancelled' });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).not.toBe('E_NOT_INITIALIZED');
+        // CleoError.toLAFSError() emits the catalog lafsCode for NOT_FOUND.
+        expect(result.error.code).toBe('E_CLEO_NOT_FOUND');
+      }
+    });
+  });
+});

--- a/packages/core/src/tasks/update.ts
+++ b/packages/core/src/tasks/update.ts
@@ -18,7 +18,7 @@ import type {
 // safeAppendLog replaced by tx.appendLog inside transaction (T023)
 import { ExitCode } from '@cleocode/contracts';
 import { loadConfig } from '../config.js';
-import { type EngineResult, engineSuccess } from '../engine-result.js';
+import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { CleoError } from '../errors.js';
 import { requireActiveSession } from '../sessions/session-enforcement.js';
 import type { DataAccessor } from '../store/data-accessor.js';
@@ -248,6 +248,19 @@ export async function updateTask(
     }
     if (options.status === 'cancelled' && oldStatus !== 'cancelled') {
       task.cancelledAt = now;
+      // T9838-D: keep pipelineStage in lock-step with status=cancelled to
+      // satisfy the T877 invariant trigger (`status=cancelled requires
+      // pipeline_stage=cancelled`). The DB invariant (Part B of T877) is
+      // stricter than the in-memory cancel-ops sync — it requires the
+      // pipeline_stage to be EXACTLY 'cancelled' once status flips, even
+      // if the task previously reached the 'contribution' terminal stage.
+      // Route every cancellation to the 'cancelled' marker so Studio
+      // Pipeline groups the task under CANCELLED and the DB trigger
+      // accepts the write.
+      if (task.pipelineStage !== 'cancelled') {
+        task.pipelineStage = 'cancelled';
+        if (!changes.includes('pipelineStage')) changes.push('pipelineStage');
+      }
     }
   }
 
@@ -676,10 +689,20 @@ export async function taskUpdate(
     );
     return engineSuccess({ task: taskToRecord(result.task), changes: result.changes });
   } catch (err: unknown) {
+    // T9838-D: surface real error codes instead of mis-labelling everything
+    // as `E_NOT_INITIALIZED`. CleoErrors carry their own LAFS code via
+    // `toLAFSError()`; non-CleoErrors (DB invariant triggers, unexpected
+    // runtime issues) fall through to `E_INTERNAL`.
+    if (err instanceof CleoError) {
+      const lafs = err.toLAFSError();
+      return engineError(lafs.code, err.message, {
+        exitCode: err.code,
+        ...(err.fix !== undefined ? { fix: err.fix } : {}),
+        ...(err.alternatives !== undefined ? { alternatives: err.alternatives } : {}),
+        ...(err.details !== undefined ? { details: err.details } : {}),
+      });
+    }
     const e = err as { message?: string };
-    return {
-      success: false,
-      error: { code: 'E_NOT_INITIALIZED', message: e?.message ?? 'Task database not initialized' },
-    };
+    return engineError('E_INTERNAL', e?.message ?? 'Failed to update task');
   }
 }


### PR DESCRIPTION
## Summary

- `cleo update T### --status cancelled` on a pending task previously returned `E_NOT_INITIALIZED` — the gap that T9838 was opened to close.
- Root cause was structural, not gate-related: `updateTask` flipped `status='cancelled'` without syncing `pipelineStage`, tripping the T877 DB invariant trigger (`status=cancelled requires pipeline_stage='cancelled'`), and the `taskUpdate` engine-result wrapper caught every thrown error and mis-labelled it as `E_NOT_INITIALIZED`.
- Fix syncs `pipelineStage='cancelled'` whenever status flips to cancelled (matching `coreTaskCancel`), and propagates real LAFS error codes from `CleoError.toLAFSError()` instead of the catch-all `E_NOT_INITIALIZED`.

## Changes

- `packages/core/src/tasks/update.ts`:
  - In the status-transition block, sync `pipelineStage='cancelled'` whenever the new status is `cancelled` (T877 invariant compliance). Both `cleo update --status cancelled` and `cleo cancel` (T9838-C) now produce identical DB state.
  - In `taskUpdate` engine-result wrapper, extract the real LAFS code from any `CleoError` via `toLAFSError()`. Non-CleoErrors fall through to `E_INTERNAL` rather than the misleading `E_NOT_INITIALIZED`.
- `packages/core/src/tasks/__tests__/update-status-cancellation.test.ts` (new): 10 tests covering the cancellation path and engine-wrapper error surfacing.

## Coordination with T9838-C

Both `cleo cancel` (T9838-C) and `cleo update --status cancelled` (this PR) terminate at the database with identical state — `status='cancelled'`, `cancelledAt` stamped, `pipelineStage='cancelled'`. T9838-C's `taskCancel` engine wrapper uses the same engine error pattern.

## Test plan

- [x] Unit tests pass — 10/10 in `update-status-cancellation.test.ts`
- [x] Existing tests pass — 55/55 across `update.test.ts`, `update-pipelinestage.test.ts`, `update-relates.test.ts`, `cancel-ops.test.ts`
- [x] Quality gates pass — `biome check --write`, `lint-project-root-anti-pattern.mjs --strict`, `lint-core-first.mjs --check`
- [x] Smoke verified end-to-end on a real pending task T9844:
  - `update --status cancelled` succeeds with `success:true`
  - `status='cancelled'`, `cancelledAt='2026-05-21T08:45:56.188Z'`, `pipelineStage='cancelled'`
  - `changes=['status','pipelineStage']`
  - Idempotent re-cancel surfaces `E_CLEO_VALIDATION` (not `E_NOT_INITIALIZED`), confirming the wrapper fix end-to-end

## Refs

Tasks: T9838  
Saga: T9782  
Release-as-product: T9758

🤖 Generated with [Claude Code](https://claude.com/claude-code)