### PR TITLE
feat(T9785): cleo changeset list + polish add verb + README pointing at canonical writer

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,23 +1,59 @@
-# Changesets (CLEO-native)
+# CLEO Changesets
 
-This directory holds CLEO-native task-anchored changeset entries. Each `*.md`
-file is a markdown file with YAML frontmatter that pins a change to one or
-more CLEO task IDs.
+The `.changeset/` directory holds task-anchored changeset entries that
+`cleo release plan` aggregates into structured `CHANGELOG.md` sections.
+Each `*.md` file pins one shipped change to one or more CLEO task IDs.
 
-> CLEO-native format — the upstream `@changesets/cli` devDep was removed
-> in T9754 (carryforward closure of T9738-B). PR #349 shipped the parser
-> and DSL; this directory is the resulting write-only audit trail.
+## Adding an entry
+
+ALWAYS use the canonical writer — never hand-author `*.md` files here:
+
+```bash
+cleo changeset add \
+  --slug t9785-polish-changeset \
+  --tasks T9785 \
+  --kind chore \
+  --summary "One-line user-facing description." \
+  --prs 123,456 \
+  --notes "Optional longer markdown body (becomes the file body)."
+```
+
+Required flags: `--slug`, `--tasks`, `--kind`, `--summary`.
+Optional: `--prs` (comma-separated PR numbers), `--notes` (markdown body),
+`--breaking` (REQUIRED iff `--kind breaking`), `--attached-by` (SSoT identity).
+
+The verb dual-writes — either both surfaces succeed or NEITHER persists:
+
+- `.changeset/<slug>.md` — this directory; human-reviewable PR mirror.
+- The docs SSoT blob store — canonical, content-addressed, searchable
+  (`extras.type = 'changeset'`, owner = first task in `tasks`).
+
+Slug rules: must match `/^t\d+-[a-z0-9-]+$/`
+(e.g. `t9793-changeset-ssot-integration`). `kind` is one of
+`feat | fix | perf | refactor | docs | test | chore | breaking`.
+
+## Listing entries
+
+```bash
+cleo changeset list             # LAFS JSON envelope (default — agent mode)
+cleo changeset list --human     # aligned SLUG/KIND/TASKS/PR/SUMMARY table
+```
+
+`list` parses every `*.md` under `.changeset/` via the SAME parser
+(`@cleocode/core` → `parseChangesetDir`) that the release-plan aggregator
+and `scripts/lint-changesets.mjs` consume — a successful `list` implies
+the lint gate would also pass.
 
 ## File format
 
 ```md
 ---
-id: <kebab-case-slug-matching-filename>
-tasks: [T9686-A]               # one or more T#### or E-#### IDs (required)
-kind: fix                      # feat | fix | perf | refactor | docs | test | chore | breaking
-summary: One-line description. # required, user-facing
-prs: [324]                     # optional, linked PR numbers
-breaking: |                    # required iff kind == breaking
+id: t9686-a-dispatch-envelope           # MUST match filename slug
+tasks: [T9686-A]                        # one or more T#### or E-#### IDs
+kind: fix                               # feat|fix|perf|refactor|docs|test|chore|breaking
+summary: One-line description.          # required, user-facing
+prs: [324]                              # optional, linked PR numbers
+breaking: |                             # required iff kind == breaking
   Migration note explaining what consumers must change.
 ---
 
@@ -25,20 +61,24 @@ Optional longer-form markdown body becomes the `notes` field. Use it for
 context, motivation, or migration steps.
 ```
 
-## Validation
+The Zod schema lives in `@cleocode/contracts/src/changesets.ts` and is
+parsed by `@cleocode/core/src/changesets/parser.ts`. CI runs
+`scripts/lint-changesets.mjs` on every push — malformed entries fail the
+lint gate.
 
-The schema is defined in `@cleocode/contracts/src/changesets.ts` and parsed by
-`@cleocode/core/src/changesets/parser.ts`. CI runs `scripts/lint-changesets.mjs`
-on every push — malformed entries fail the lint gate.
+## How entries become CHANGELOG sections
 
-## Aggregation (T9738 follow-up)
+`cleo release plan v<version> --epic T####` parses every entry under
+`.changeset/`, validates the YAML + body, groups by `kind`, and renders
+the markdown into:
 
-For now, entries are write-only history. The future `cleo release plan`
-aggregator will fold all entries since the previous tag into the next release
-manifest. See `.cleo/agent-outputs/T9738-IVTR-bug-remediation-research.md`
-§6.6 A3 for the full design.
+- `meta.releaseNotes` on the release plan envelope.
+- The `## [VERSION] (YYYY-MM-DD)` section in `CHANGELOG.md` (per the
+  T9838-A release-as-product pipeline).
+
+See ADR-028 (revised 2026-05-20) for the canonical pipeline spec.
 
 ## Example
 
-See `t9686-a-dispatch-envelope.md` for a minimal example pinned to a single
-task with a linked PR.
+See `t9686-a-dispatch-envelope.md` for a minimal example pinned to a
+single task with a linked PR.

--- a/.changeset/t9785-changeset-list-and-readme.md
+++ b/.changeset/t9785-changeset-list-and-readme.md
@@ -1,0 +1,14 @@
+---
+id: t9785-changeset-list-and-readme
+tasks: [T9785]
+kind: chore
+summary: cleo changeset list verb + README pointing at canonical writer
+---
+
+Saga T9782 — the T9793 dual-write writer is now the only changesets author path.
+
+Added `cleo changeset list` (LAFS envelope default, `--human` aligned SLUG/KIND/TASKS/PR/SUMMARY table) that reuses the same `parseChangesetDir` the release-plan aggregator + lint-changesets.mjs consume — no separate code path.
+
+Regenerated `.changeset/README.md` to teach contributors the canonical `cleo changeset add` flow and document `cleo changeset list`.
+
+Extended the integration test to cover the new `list` subcommand: empty-state envelope, post-add roundtrip, and `--human` table rendering.

--- a/packages/cleo/src/cli/__tests__/changeset-add.test.ts
+++ b/packages/cleo/src/cli/__tests__/changeset-add.test.ts
@@ -62,7 +62,7 @@ function runCli(args: readonly string[], projectRoot: string): CliResult {
   const result = spawnSync('node', [CLI_DIST, ...args], {
     stdio: ['pipe', 'pipe', 'pipe'],
     encoding: 'utf-8',
-    timeout: 30_000,
+    timeout: 90_000,
     cwd: projectRoot,
     env,
   });
@@ -348,5 +348,148 @@ describe.skipIf(!CLI_DIST_AVAILABLE)('cleo changeset add — subprocess', () => 
 
     const md = readFileSync(env.data.filePath, 'utf-8');
     expect(md).toContain('prs: [349, 357]');
+  });
+});
+
+// ─── cleo changeset list — registration + E2E subprocess ────────────────────
+
+describe('cleo changeset — list registration', () => {
+  it('exposes the `list` subcommand alongside `add`', () => {
+    const subs = (changesetCommand as unknown as CittyCommand).subCommands ?? {};
+    expect(subs.list).toBeDefined();
+    expect(subs.add).toBeDefined();
+  });
+
+  it('list takes no positional/required args — pure read', () => {
+    const subs = (changesetCommand as unknown as CittyCommand).subCommands ?? {};
+    const listCmd = subs.list as CittyCommand;
+    const args = listCmd.args ?? {};
+    // No required flags — list is project-rooted and parameter-free.
+    for (const [, def] of Object.entries(args)) {
+      expect(def.required).not.toBe(true);
+    }
+  });
+});
+
+interface ChangesetListData {
+  readonly entries: ReadonlyArray<{
+    readonly id: string;
+    readonly tasks: readonly string[];
+    readonly kind: string;
+    readonly summary: string;
+    readonly prs?: readonly number[];
+  }>;
+  readonly count: number;
+  readonly dir: string;
+  readonly note?: string;
+}
+
+describe.skipIf(!CLI_DIST_AVAILABLE)('cleo changeset list — subprocess', () => {
+  it('returns empty entries envelope when .changeset/ does not exist', () => {
+    // Fresh project root from the beforeEach — no .changeset/ subdir yet.
+    const res = runCli(['changeset', 'list'], projectRoot);
+    expect(res.status).toBe(0);
+    const env = parseEnvelope<ChangesetListData>(res.stdout);
+    expect(env.success).toBe(true);
+    if (!env.success || !env.data) return;
+    expect(env.data.count).toBe(0);
+    expect(env.data.entries).toEqual([]);
+    expect(env.data.note).toBeDefined();
+  });
+
+  it('lists entries after a successful add — same parser as the aggregator', () => {
+    // Seed two entries via the canonical writer so we exercise the dual-write
+    // path AND the read path in one E2E shot.
+    const addOne = runCli(
+      [
+        'changeset',
+        'add',
+        '--slug',
+        't9785-listed-alpha',
+        '--tasks',
+        'T9785',
+        '--kind',
+        'chore',
+        '--summary',
+        'Alpha entry for list E2E.',
+      ],
+      projectRoot,
+    );
+    expect(addOne.status).toBe(0);
+
+    const addTwo = runCli(
+      [
+        'changeset',
+        'add',
+        '--slug',
+        't9785-listed-beta',
+        '--tasks',
+        'T9785,T9786',
+        '--kind',
+        'feat',
+        '--summary',
+        'Beta entry — multi-task.',
+        '--prs',
+        '999',
+      ],
+      projectRoot,
+    );
+    expect(addTwo.status).toBe(0);
+
+    const list = runCli(['changeset', 'list'], projectRoot);
+    expect(list.status).toBe(0);
+    const env = parseEnvelope<ChangesetListData>(list.stdout);
+    expect(env.success).toBe(true);
+    if (!env.success || !env.data) return;
+
+    expect(env.data.count).toBe(2);
+    const slugs = env.data.entries.map((e) => e.id).sort();
+    expect(slugs).toEqual(['t9785-listed-alpha', 't9785-listed-beta']);
+
+    const beta = env.data.entries.find((e) => e.id === 't9785-listed-beta');
+    expect(beta?.kind).toBe('feat');
+    expect(beta?.tasks).toEqual(['T9785', 'T9786']);
+    expect(beta?.prs).toEqual([999]);
+  });
+
+  it('--human renders an aligned SLUG/KIND/TASKS/PR/SUMMARY table', () => {
+    runCli(
+      [
+        'changeset',
+        'add',
+        '--slug',
+        't9785-human-row',
+        '--tasks',
+        'T9785',
+        '--kind',
+        'docs',
+        '--summary',
+        'Human row.',
+      ],
+      projectRoot,
+    );
+
+    const env = {
+      ...process.env,
+      CLEO_PROJECT_ROOT: projectRoot,
+      CLEO_ROOT: projectRoot,
+      CLEO_DIR: join(projectRoot, '.cleo'),
+      CLEO_OUTPUT_FORMAT: 'human',
+    };
+    const res = spawnSync('node', [CLI_DIST, 'changeset', 'list', '--human'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      timeout: 90_000,
+      cwd: projectRoot,
+      env,
+    });
+    expect(res.status).toBe(0);
+    // dataTable writes to stdout via humanLine; header row + the slug row
+    // both have to land somewhere on stdout.
+    const out = (res.stdout ?? '') + (res.stderr ?? '');
+    expect(out).toContain('SLUG');
+    expect(out).toContain('SUMMARY');
+    expect(out).toContain('t9785-human-row');
+    expect(out).toContain('docs');
   });
 });

--- a/packages/cleo/src/cli/commands/changeset.ts
+++ b/packages/cleo/src/cli/commands/changeset.ts
@@ -1,28 +1,28 @@
 /**
- * CLI `cleo changeset` command — author task-anchored changeset entries that
- * dual-write to both `.changeset/<slug>.md` (file surface, preserved for git
- * PR review) AND the canonical docs SSoT blob store.
- *
- * Today CLEO ships 12 hand-authored `.changeset/*.md` files. This command
- * elevates the directory from "parallel system" to "first-class DocKind"
- * backed by the SSoT, while keeping the file surface for backward compat.
+ * CLI `cleo changeset` command — the canonical author + reader surface for
+ * task-anchored changeset entries. Every write goes through the dual-write
+ * pipeline so the bytes always land in BOTH `.changeset/<slug>.md` (the
+ * human-reviewable file mirror) AND the docs SSoT blob store.
  *
  * Subcommands:
- *   - `cleo changeset add` — author and dual-write a new entry
+ *   - `cleo changeset add` — author and dual-write a new entry (T9793)
+ *   - `cleo changeset list` — list entries via the same parser the aggregator
+ *     consumes; LAFS envelope on JSON, aligned table on `--human` (T9785)
  *
  * The aggregator (`changesets-aggregator.ts`) reads SSoT-first and falls back
  * to `.changeset/*.md` for slugs that have not yet been mirrored, so the
- * existing workflow (hand-author a `.md` file) continues to work unchanged.
+ * file surface remains the source of truth for review while the SSoT
+ * unlocks search, dedup, and provenance.
  *
- * Future Wave 6 (T9791) will batch-import the 12 existing files into SSoT.
- *
- * @epic T9793 (E-DOCS-CHANGESET-INTEGRATION)
- * @task T9793
+ * @epic T9785 (Saga T9782 — single canonical changesets system)
+ * @task T9785
  * @see ADR-068 — DB Charter: changeset bytes live in manifest.db blob store
  * @see packages/core/src/changesets/writer.ts — dual-write transaction
  * @see packages/core/src/release/changesets-aggregator.ts — SSoT-first reader
  */
 
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   CHANGESET_KINDS,
   type ChangesetEntry,
@@ -31,7 +31,8 @@ import {
 } from '@cleocode/contracts';
 import { changesets, getProjectRoot } from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
-import { cliError, cliOutput, humanInfo } from '../renderers/index.js';
+import { dataTable } from '../renderers/format-helpers.js';
+import { cliError, cliOutput, humanInfo, humanLine, isHumanOutput } from '../renderers/index.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -210,23 +211,121 @@ const addCommand = defineCommand({
   },
 });
 
+// ─── cleo changeset list ─────────────────────────────────────────────────────
+
+/**
+ * `cleo changeset list`
+ *
+ * Read-only verb that lists every entry under `.changeset/*.md` by routing
+ * through the SAME {@link changesets.parseChangesetDir} the release-plan
+ * aggregator uses — no duplicate parsing logic, no separate code path.
+ *
+ * Output surfaces:
+ * - JSON (default — agent mode): emits a LAFS envelope whose `data.entries`
+ *   array carries the full parsed records (`id`, `tasks`, `kind`, `summary`,
+ *   `prs`, `notes`, `breaking`).
+ * - Human (`--human`): renders an aligned `dataTable` (SLUG · KIND · TASKS ·
+ *   PR · SUMMARY) ordered by filename (alphabetical, matching the parser's
+ *   deterministic sort).
+ *
+ * The lookup is project-local: `getProjectRoot()` + `.changeset/`. When the
+ * directory is missing (fresh repo, no entries yet), the verb returns an
+ * empty `entries` array with a `note` rather than erroring — operators and
+ * agents alike can rely on it for idempotent "is there anything queued?"
+ * checks.
+ *
+ * @task T9785
+ */
+const listCommand = defineCommand({
+  meta: {
+    name: 'list',
+    description:
+      'List every changeset entry under .changeset/*.md using the same parser ' +
+      'the release-plan aggregator consumes. JSON envelope by default, ' +
+      'aligned table on --human.',
+  },
+  args: {},
+  async run() {
+    const projectRoot = getProjectRoot();
+    const dir = join(projectRoot, '.changeset');
+
+    // Empty-state path: missing directory is a perfectly valid "nothing
+    // queued" answer — return an envelope rather than erroring so scripts
+    // can poll without try/catch noise.
+    if (!existsSync(dir)) {
+      const empty = { entries: [] as ChangesetEntry[], count: 0, dir, note: 'no .changeset/ dir' };
+      if (isHumanOutput()) {
+        humanLine('No changeset entries found (.changeset/ directory absent).');
+      }
+      cliOutput(empty, { command: 'changeset list', operation: 'changeset.list' });
+      return;
+    }
+
+    // Re-use the canonical parser the aggregator/lint script share — keeps
+    // this verb and CI lockstep, so a `list` that succeeds implies the lint
+    // gate would also pass.
+    let entries: ChangesetEntry[];
+    try {
+      entries = changesets.parseChangesetDir(dir);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      cliError(`Failed to parse .changeset directory: ${msg}`, ExitCode.VALIDATION_ERROR, {
+        name: 'E_VALIDATION',
+        fix: 'run `node scripts/lint-changesets.mjs` to surface every offending entry',
+      });
+      process.exit(ExitCode.VALIDATION_ERROR);
+    }
+
+    // Human surface: aligned table. Empty list still emits a friendly line.
+    if (isHumanOutput()) {
+      if (entries.length === 0) {
+        humanLine('No changeset entries found (.changeset/ has no *.md files).');
+      } else {
+        const rendered = dataTable<ChangesetEntry>(entries, [
+          { header: 'SLUG', get: (e) => e.id, maxWidth: 40 },
+          { header: 'KIND', get: (e) => e.kind, maxWidth: 10 },
+          { header: 'TASKS', get: (e) => e.tasks.join(','), maxWidth: 22 },
+          {
+            header: 'PR',
+            get: (e) => (e.prs && e.prs.length > 0 ? `#${e.prs.join(',#')}` : '-'),
+            maxWidth: 10,
+          },
+          { header: 'SUMMARY', get: (e) => e.summary },
+        ]);
+        humanLine(rendered);
+      }
+    }
+
+    cliOutput(
+      { entries, count: entries.length, dir },
+      { command: 'changeset list', operation: 'changeset.list' },
+    );
+  },
+});
+
 // ─── Root command group ──────────────────────────────────────────────────────
 
 /**
- * Root `cleo changeset` command group.
+ * Root `cleo changeset` command group — the canonical surface for the
+ * task-anchored changesets DSL.
  *
- * Currently exposes only `add` — future subcommands (list, fetch, lint) will
- * land on top of the same dual-write foundation introduced by T9793.
+ * Subcommands:
+ *   - `add`  — author + dual-write (file + SSoT) per T9793
+ *   - `list` — read-only listing via the shared aggregator parser (T9785)
+ *
+ * Future read verbs (fetch, lint) can land on the same foundation without
+ * forking the dual-write transaction or duplicating the parser path.
  */
 export const changesetCommand = defineCommand({
   meta: {
     name: 'changeset',
     description:
-      'Author task-anchored changeset entries that dual-write to ' +
-      '.changeset/*.md AND the docs SSoT blob store (T9793).',
+      'Author + list task-anchored changeset entries — dual-writes go to ' +
+      '.changeset/*.md AND the docs SSoT blob store (Saga T9782).',
   },
   subCommands: {
     add: addCommand,
+    list: listCommand,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -62,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -83,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -101,23 +99,20 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -140,8 +135,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -171,7 +165,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'changesetCommand',
     name: 'changeset',
-    description: 'Author task-anchored changeset entries that dual-write to ',
+    description: 'Author + list task-anchored changeset entries — dual-writes go to ',
     load: async () => (await import('../commands/changeset.js')).changesetCommand as CommandDef,
   },
   {
@@ -250,8 +244,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -274,16 +267,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -307,8 +298,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -319,8 +309,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -333,8 +322,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -370,8 +358,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -419,8 +406,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -443,17 +429,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -482,8 +465,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -525,17 +507,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -564,8 +543,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -577,15 +555,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -628,8 +604,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -640,8 +615,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description:
-      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -689,8 +663,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -702,8 +675,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -751,15 +723,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -837,8 +807,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -856,8 +825,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {


### PR DESCRIPTION
## Summary

Saga T9782 — single canonical changesets system. The T9793 dual-write writer is now the only changesets author path; this commit polishes the surface so contributors reach the canonical writer first.

- **Adds `cleo changeset list`** (LAFS envelope default, `--human` aligned SLUG/KIND/TASKS/PR/SUMMARY table) — re-uses the SAME `parseChangesetDir` the release-plan aggregator + `scripts/lint-changesets.mjs` consume. No separate code path means a successful `list` implies the lint gate would also pass.
- **Regenerates `.changeset/README.md`** to teach the canonical `cleo changeset add` flow, document the new `list` verb, and point at ADR-028 (revised) for the pipeline spec.
- **Polishes the existing `add` verb** with updated module-level docs naming the Saga and the dual `add` + `list` surface.
- **Extends the integration test** with three new subprocess cases for `list`: empty-state envelope, post-add roundtrip, and `--human` table render. Bumps subprocess timeout to 90s (load-tolerant on shared CI runners).

## End-to-end verification

Built cleo locally and ran the canonical writer:

```
$ CLEO_PROJECT_ROOT=$(pwd) node packages/cleo/dist/cli/index.js \
    changeset add --slug t9785-changeset-list-and-readme --tasks T9785 \
    --kind chore --summary "..." --notes "..."
{"success":true,"data":{
  "filePath":"/mnt/projects/.../.changeset/t9785-changeset-list-and-readme.md",
  "slug":"t9785-changeset-list-and-readme",
  "attachmentId":"f99d4fe7-...",
  "sha256":"c0a827c27a3e2cbc6b9039d3be8b836df7f95727757e90fb6ac0436ed7eb2022",
  "ownerId":"T9785"
}}
```

Both surfaces persisted:
- `.changeset/t9785-changeset-list-and-readme.md` on disk (included in this PR)
- SSoT blob at `.cleo/attachments/sha256/c0/a827c2...md`

File re-parses cleanly via `changesets.parseChangesetFile` (verified directly).

## Gaps surfaced during E2E

Pre-existing data quality issue (NOT in this PR's scope, filing as follow-up): `.changeset/t9790-worktree-orphan-doctor.md` has `kind: feature` (invalid — should be `feat`). Causes `node scripts/lint-changesets.mjs` to FAIL on first encountered entry. The fix is a one-character edit; flagged here so it can land alongside or before the next release plan run.

## Test plan

- [ ] `pnpm install`
- [ ] `pnpm run build` (all 9 build waves)
- [ ] `pnpm --filter @cleocode/cleo run test` — 5 registration tests pass; subprocess tests need CI-class machine (local runs timed out on 12-load shared dev box)
- [ ] `pnpm --filter @cleocode/core run test src/changesets` — 25/25 pass
- [ ] `pnpm biome check packages/cleo/src/cli/commands/changeset.ts packages/cleo/src/cli/__tests__/changeset-add.test.ts packages/core/src/changesets/ .changeset/README.md` — clean
- [ ] `node scripts/lint-project-root-anti-pattern.mjs --strict` — STRICT OK (zero violations)
- [ ] `node scripts/lint-core-first.mjs --check` — PASS (87 known baseline)

## Refs

- Saga T9782 (single canonical changesets system)
- T9793 — dual-write writer foundation (`writeChangesetEntry`)
- T9758 — release-as-product LLM composer pipeline
- ADR-068 — DB Charter (changeset bytes live in manifest.db blob store)
- ADR-028 (revised 2026-05-20) — release-notes composer pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)