### PR TITLE
fix(gh-390): orchestrate ready/waves traverse saga 'groups' relation (+ --via flag)

### DIFF
--- a/packages/cleo/src/cli/commands/orchestrate.ts
+++ b/packages/cleo/src/cli/commands/orchestrate.ts
@@ -209,7 +209,11 @@ const analyzeCommand = defineCommand({
  * @task T1858
  */
 const readyCommand = defineCommand({
-  meta: { name: 'ready', description: 'Get parallel-safe ready tasks' },
+  meta: {
+    name: 'ready',
+    description:
+      "Get parallel-safe ready tasks. When the epic is a Saga (label='saga', ADR-073), traverses task_relations.type='groups' instead of parentId.",
+  },
   args: {
     epicId: {
       type: 'positional',
@@ -221,6 +225,11 @@ const readyCommand = defineCommand({
       description:
         'Skip dep-graph validation and proceed even if issues exist (audit-logged bypass). CLI-only — sentient mode does not support this flag.',
     },
+    via: {
+      type: 'string',
+      description:
+        "Traversal mode (gh-390/ADR-073): 'parent' walks parentId only, 'saga' walks task_relations.type='groups' only, 'both' (default) auto-detects saga-labeled epics.",
+    },
   },
   async run({ args }) {
     await dispatchFromCli(
@@ -230,6 +239,7 @@ const readyCommand = defineCommand({
       {
         epicId: args.epicId,
         ignoreDepsValidate: args['ignore-deps-validate'] === true,
+        ...(args.via !== undefined && { via: args.via }),
       },
       { command: 'orchestrate' },
     );
@@ -259,12 +269,21 @@ const nextCommand = defineCommand({
 
 /** cleo orchestrate waves — compute dependency waves for an epic */
 const wavesCommand = defineCommand({
-  meta: { name: 'waves', description: 'Compute dependency waves for an epic' },
+  meta: {
+    name: 'waves',
+    description:
+      "Compute dependency waves for an epic. When the epic is a Saga (label='saga', ADR-073), per-member wave plans are merged by index (wave N across all members → one unified wave N).",
+  },
   args: {
     epicId: {
       type: 'positional',
       description: 'Epic ID to compute waves for',
       required: true,
+    },
+    via: {
+      type: 'string',
+      description:
+        "Traversal mode (gh-390/ADR-073): 'parent' walks parentId only, 'saga' walks task_relations.type='groups' only, 'both' (default) auto-detects saga-labeled epics.",
     },
   },
   async run({ args }) {
@@ -272,7 +291,10 @@ const wavesCommand = defineCommand({
       'query',
       'orchestrate',
       'waves',
-      { epicId: args.epicId },
+      {
+        epicId: args.epicId,
+        ...(args.via !== undefined && { via: args.via }),
+      },
       { command: 'orchestrate' },
     );
   },

--- a/packages/cleo/src/dispatch/domains/orchestrate.ts
+++ b/packages/cleo/src/dispatch/domains/orchestrate.ts
@@ -82,6 +82,12 @@ interface OrchestrateReadyParams {
   epicId: string;
   /** CLI-only bypass flag. When true, skips dep-graph validation and audit-logs the bypass. */
   ignoreDepsValidate?: boolean;
+  /**
+   * Traversal mode (gh-390 / ADR-073). `'parent'` walks `parentId` only,
+   * `'saga'` walks `task_relations.type='groups'` only, `'both'` (default)
+   * auto-detects saga-labeled epics.
+   */
+  via?: 'parent' | 'saga' | 'both';
 }
 
 interface OrchestrateAnalyzeParams {
@@ -105,6 +111,10 @@ interface OrchestrateContextParams {
 
 interface OrchestrateWavesParams {
   epicId: string;
+  /**
+   * Traversal mode (gh-390 / ADR-073). See {@link OrchestrateReadyParams.via}.
+   */
+  via?: 'parent' | 'saga' | 'both';
 }
 
 interface OrchestratePlanParams {
@@ -290,6 +300,7 @@ async function orchestrateNextOp(params: OrchestrateNextParams) {
 async function orchestrateReadyOp(params: OrchestrateReadyParams) {
   return orchestrateReady(params.epicId, getProjectRoot(), {
     ignoreDepsValidate: params.ignoreDepsValidate,
+    via: params.via,
   });
 }
 
@@ -340,7 +351,7 @@ async function orchestrateContextOp(params: OrchestrateContextParams) {
 }
 
 async function orchestrateWavesOp(params: OrchestrateWavesParams) {
-  return orchestrateWaves(params.epicId, getProjectRoot());
+  return orchestrateWaves(params.epicId, getProjectRoot(), { via: params.via });
 }
 
 async function orchestratePlanOp(params: OrchestratePlanParams) {
@@ -562,9 +573,13 @@ export class OrchestrateHandler implements DomainHandler {
               'epicId is required',
               startTime,
             );
+          const viaRaw = params.via;
+          const via: OrchestrateReadyParams['via'] =
+            viaRaw === 'parent' || viaRaw === 'saga' || viaRaw === 'both' ? viaRaw : undefined;
           const p: OrchestrateReadyParams = {
             epicId: params.epicId as string,
             ignoreDepsValidate: params.ignoreDepsValidate as boolean | undefined,
+            ...(via !== undefined && { via }),
           };
           return wrapResult(await coreOps.ready(p), 'query', 'orchestrate', operation, startTime);
         }
@@ -643,7 +658,15 @@ export class OrchestrateHandler implements DomainHandler {
               'epicId is required',
               startTime,
             );
-          const p: OrchestrateWavesParams = { epicId: params.epicId as string };
+          const wavesViaRaw = params.via;
+          const wavesVia: OrchestrateWavesParams['via'] =
+            wavesViaRaw === 'parent' || wavesViaRaw === 'saga' || wavesViaRaw === 'both'
+              ? wavesViaRaw
+              : undefined;
+          const p: OrchestrateWavesParams = {
+            epicId: params.epicId as string,
+            ...(wavesVia !== undefined && { via: wavesVia }),
+          };
           return wrapResult(await coreOps.waves(p), 'query', 'orchestrate', operation, startTime);
         }
 

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1210,7 +1210,7 @@ export {
   taskDependencies,
   tasks,
 } from './store/tasks-schema.js';
-export { createTask, getTask } from './store/tasks-sqlite.js';
+export { addRelation, createTask, getTask } from './store/tasks-sqlite.js';
 export { AuditLogInsertSchema } from './store/validation-schemas.js';
 export type {
   AnalyzeArchiveOptions,

--- a/packages/core/src/orchestrate/__tests__/saga-walk.test.ts
+++ b/packages/core/src/orchestrate/__tests__/saga-walk.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Regression tests for gh-390 — `orchestrate.ready` and `orchestrate.waves`
+ * must traverse the Saga `task_relations.type='groups'` relation when the
+ * target epic carries `label='saga'` (ADR-073).
+ *
+ * Before this fix both ops walked only `parentId`, so sagas (which DO NOT
+ * use `parentId` for member linkage) returned `total: 0` with
+ * `reason: "epic has no children"`. This test seeds a saga with 3 member
+ * epics, each holding a small pending task set, and asserts the aggregated
+ * ready + merged wave plans flow through.
+ *
+ * Fixture layout:
+ *
+ *   T-S (epic, labels=['saga']) — Saga
+ *     ↳ groups → T-E1 (epic)
+ *         ↳ T-E1-A (pending, no deps)        — wave 1
+ *         ↳ T-E1-B (pending, depends T-E1-A) — wave 2
+ *     ↳ groups → T-E2 (epic)
+ *         ↳ T-E2-A (pending, no deps)        — wave 1
+ *         ↳ T-E2-B (done)                    — excluded
+ *     ↳ groups → T-E3 (epic)
+ *         ↳ T-E3-A (pending, no deps)        — wave 1
+ *
+ *   T-REGULAR (epic, no labels) — regression target
+ *     ↳ T-REG-A (pending) — child via parentId
+ *
+ * @bug gh-390
+ * @adr ADR-073
+ * @task T9839
+ */
+
+import { mkdirSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  addRelation,
+  createTask,
+  getDb,
+  orchestrateReady,
+  orchestrateWaves,
+} from '@cleocode/core/internal';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let TEST_ROOT: string;
+
+/**
+ * Seed the saga fixture described in the file header.
+ */
+async function seedSagaFixture(testRoot: string): Promise<void> {
+  const cleoDir = join(testRoot, '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+  // validateProjectRoot requires `.git/` sibling for the walk-up.
+  mkdirSync(join(testRoot, '.git'), { recursive: true });
+  await getDb(testRoot);
+
+  const ts = '2026-05-21T00:00:00Z';
+
+  const tasks = [
+    // Saga
+    {
+      id: 'T-S',
+      title: 'Saga Root',
+      description: 'Saga grouping epic',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'high' as const,
+      labels: ['saga'],
+      createdAt: ts,
+      updatedAt: null,
+    },
+    // Member epics
+    {
+      id: 'T-E1',
+      title: 'Member epic 1',
+      description: 'First saga member',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'high' as const,
+      createdAt: ts,
+      updatedAt: null,
+    },
+    {
+      id: 'T-E2',
+      title: 'Member epic 2',
+      description: 'Second saga member',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'medium' as const,
+      createdAt: ts,
+      updatedAt: null,
+    },
+    {
+      id: 'T-E3',
+      title: 'Member epic 3',
+      description: 'Third saga member',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'medium' as const,
+      createdAt: ts,
+      updatedAt: null,
+    },
+    // T-E1 children
+    {
+      id: 'T-E1-A',
+      title: 'E1 wave-1 task',
+      description: 'Pending, no deps — wave 1',
+      type: 'task' as const,
+      status: 'pending' as const,
+      priority: 'high' as const,
+      parentId: 'T-E1',
+      createdAt: ts,
+      updatedAt: null,
+    },
+    {
+      id: 'T-E1-B',
+      title: 'E1 wave-2 task',
+      description: 'Depends on E1-A — wave 2',
+      type: 'task' as const,
+      status: 'pending' as const,
+      priority: 'medium' as const,
+      parentId: 'T-E1',
+      depends: ['T-E1-A'],
+      createdAt: ts,
+      updatedAt: null,
+    },
+    // T-E2 children
+    {
+      id: 'T-E2-A',
+      title: 'E2 wave-1 task',
+      description: 'Pending, no deps',
+      type: 'task' as const,
+      status: 'pending' as const,
+      priority: 'critical' as const,
+      parentId: 'T-E2',
+      createdAt: ts,
+      updatedAt: null,
+    },
+    {
+      id: 'T-E2-B',
+      title: 'E2 completed task',
+      description: 'Already done',
+      type: 'task' as const,
+      status: 'done' as const,
+      priority: 'low' as const,
+      parentId: 'T-E2',
+      createdAt: ts,
+      updatedAt: null,
+    },
+    // T-E3 children
+    {
+      id: 'T-E3-A',
+      title: 'E3 wave-1 task',
+      description: 'Pending, no deps',
+      type: 'task' as const,
+      status: 'pending' as const,
+      priority: 'medium' as const,
+      parentId: 'T-E3',
+      createdAt: ts,
+      updatedAt: null,
+    },
+    // Regression baseline — regular epic with parentId-attached child.
+    {
+      id: 'T-REGULAR',
+      title: 'Non-saga epic',
+      description: 'Regular epic — should still walk parentId',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'medium' as const,
+      createdAt: ts,
+      updatedAt: null,
+    },
+    {
+      id: 'T-REG-A',
+      title: 'Regular child',
+      description: 'Pending child of T-REGULAR',
+      type: 'task' as const,
+      status: 'pending' as const,
+      priority: 'medium' as const,
+      parentId: 'T-REGULAR',
+      createdAt: ts,
+      updatedAt: null,
+    },
+  ];
+
+  for (const task of tasks) {
+    await createTask(task as Parameters<typeof createTask>[0], testRoot);
+  }
+
+  // Link saga members via task_relations.type='groups'.
+  await addRelation('T-S', 'T-E1', 'groups', testRoot);
+  await addRelation('T-S', 'T-E2', 'groups', testRoot);
+  await addRelation('T-S', 'T-E3', 'groups', testRoot);
+}
+
+beforeEach(async () => {
+  TEST_ROOT = await mkdtemp(join(tmpdir(), 'cleo-saga-walk-test-'));
+  await seedSagaFixture(TEST_ROOT);
+});
+
+afterEach(async () => {
+  try {
+    const { closeAllDatabases } = await import('@cleocode/core/internal');
+    await closeAllDatabases();
+  } catch {
+    // ignore cleanup errors
+  }
+  await rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// orchestrateReady — saga walk
+// ---------------------------------------------------------------------------
+
+describe('orchestrateReady — saga groups-relation walk (gh-390)', () => {
+  interface ReadyData {
+    epicId: string;
+    readyTasks: Array<{ id: string; title: string; priority: string; depends: string[] }>;
+    total: number;
+    via?: 'parent' | 'saga';
+    sagaMembers?: string[];
+    reason?: string;
+  }
+
+  it('default --via=both: aggregates ready tasks from saga member epics', async () => {
+    const result = await orchestrateReady('T-S', TEST_ROOT);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as ReadyData;
+
+    // T-E1-A (high), T-E2-A (critical), T-E3-A (medium) are the wave-1
+    // ready tasks across the 3 members. T-E1-B is blocked, T-E2-B is done.
+    expect(data.via, 'auto-detected saga traversal').toBe('saga');
+    expect(data.sagaMembers, 'all 3 member epics surfaced').toEqual(['T-E1', 'T-E2', 'T-E3']);
+    expect(data.total, 'three wave-1 tasks ready across members').toBe(3);
+
+    const ids = data.readyTasks.map((t) => t.id).sort();
+    expect(ids).toEqual(['T-E1-A', 'T-E2-A', 'T-E3-A']);
+
+    // Verify priority ordering (critical first).
+    expect(data.readyTasks[0]?.id).toBe('T-E2-A');
+    expect(data.readyTasks[0]?.priority).toBe('critical');
+  });
+
+  it('deduplicates tasks that appear under multiple members', async () => {
+    // Re-issuing the same ready query MUST not double-count.
+    const result = await orchestrateReady('T-S', TEST_ROOT);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as ReadyData;
+    const ids = data.readyTasks.map((t) => t.id);
+    expect(new Set(ids).size, 'no duplicate IDs').toBe(ids.length);
+  });
+
+  it('--via=parent on a saga returns empty (legacy behaviour preserved)', async () => {
+    const result = await orchestrateReady('T-S', TEST_ROOT, { via: 'parent' });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as ReadyData;
+    expect(data.via).toBe('parent');
+    expect(data.total).toBe(0);
+    expect(data.reason).toBe('epic has no children');
+  });
+
+  it('--via=saga walks ONLY the groups relation', async () => {
+    const result = await orchestrateReady('T-S', TEST_ROOT, { via: 'saga' });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as ReadyData;
+    expect(data.via).toBe('saga');
+    expect(data.total).toBe(3);
+    expect(data.sagaMembers).toEqual(['T-E1', 'T-E2', 'T-E3']);
+  });
+
+  it('regression: non-saga epic still walks parentId (default via=both)', async () => {
+    const result = await orchestrateReady('T-REGULAR', TEST_ROOT);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as ReadyData;
+    expect(data.via).toBe('parent');
+    expect(data.total).toBe(1);
+    expect(data.readyTasks[0]?.id).toBe('T-REG-A');
+    expect(data.sagaMembers).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orchestrateWaves — saga walk
+// ---------------------------------------------------------------------------
+
+describe('orchestrateWaves — saga groups-relation walk (gh-390)', () => {
+  interface WavesData {
+    epicId: string;
+    waves: Array<{ waveNumber: number; taskIds: string[]; tasks: Array<{ id: string }> }>;
+    totalWaves: number;
+    totalTasks: number;
+    via?: 'parent' | 'saga';
+    sagaMembers?: string[];
+  }
+
+  it('default --via=both: merges per-member wave plans by wave index', async () => {
+    const result = await orchestrateWaves('T-S', TEST_ROOT);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as WavesData;
+
+    expect(data.via).toBe('saga');
+    expect(data.sagaMembers).toEqual(['T-E1', 'T-E2', 'T-E3']);
+
+    // T-E1 has 2 waves (A then B). T-E2/T-E3 have 1 wave each (A only).
+    // Merged: wave 1 = {E1-A, E2-A, E3-A}, wave 2 = {E1-B}.
+    expect(data.totalWaves).toBe(2);
+
+    const wave1Ids = data.waves[0]?.taskIds.sort() ?? [];
+    expect(wave1Ids).toEqual(['T-E1-A', 'T-E2-A', 'T-E3-A']);
+
+    const wave2Ids = data.waves[1]?.taskIds ?? [];
+    expect(wave2Ids).toEqual(['T-E1-B']);
+
+    // taskIds mirrors tasks.map(t => t.id) per wave (waves contract).
+    for (const wave of data.waves) {
+      expect(wave.taskIds).toEqual(wave.tasks.map((t) => t.id));
+    }
+  });
+
+  it('--via=parent on a saga returns empty wave list (legacy behaviour)', async () => {
+    const result = await orchestrateWaves('T-S', TEST_ROOT, { via: 'parent' });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as WavesData;
+    expect(data.via).toBe('parent');
+    expect(data.totalWaves).toBe(0);
+    expect(data.waves.length).toBe(0);
+  });
+
+  it('--via=saga walks ONLY the groups relation', async () => {
+    const result = await orchestrateWaves('T-S', TEST_ROOT, { via: 'saga' });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as WavesData;
+    expect(data.via).toBe('saga');
+    expect(data.totalWaves).toBe(2);
+    expect(data.sagaMembers).toEqual(['T-E1', 'T-E2', 'T-E3']);
+  });
+
+  it('regression: non-saga epic still walks parentId', async () => {
+    const result = await orchestrateWaves('T-REGULAR', TEST_ROOT);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as WavesData;
+    expect(data.via).toBe('parent');
+    expect(data.totalTasks).toBe(1);
+    expect(data.totalWaves).toBe(1);
+    expect(data.waves[0]?.taskIds).toEqual(['T-REG-A']);
+    expect(data.sagaMembers).toBeUndefined();
+  });
+});

--- a/packages/core/src/orchestrate/query-ops.ts
+++ b/packages/core/src/orchestrate/query-ops.ts
@@ -20,11 +20,13 @@ import { estimateContext } from '../orchestration/context.js';
 import { analyzeEpic, getNextTask, getReadyTasks } from '../orchestration/index.js';
 import { computeEpicStatus, computeOverallStatus } from '../orchestration/status.js';
 import { validateSpawnReadiness } from '../orchestration/validate-spawn.js';
+import type { EnrichedWave } from '../orchestration/waves.js';
 import { getEnrichedWaves } from '../orchestration/waves.js';
 import { getProjectRoot } from '../paths.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import type { DepGraphIssue } from '../tasks/dep-graph-validator.js';
 import { runValidation } from '../tasks/dep-graph-validator.js';
+import { SAGA_GROUPS_RELATION, SAGA_LABEL } from '../tasks/list.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -92,6 +94,79 @@ export function appendDepsValidateBypassAudit(
 }
 
 export type { EngineResult };
+
+// ---------------------------------------------------------------------------
+// Saga traversal (gh-390 / ADR-073)
+// ---------------------------------------------------------------------------
+
+/**
+ * Traversal mode for {@link orchestrateReady} and {@link orchestrateWaves}.
+ *
+ * Sagas (Epics with `labels.includes('saga')`) hold their member Epics via
+ * `task_relations.type='groups'` edges instead of the `parentId` column
+ * (ADR-073). The query-ops historically walked only `parentId`, so sagas
+ * appeared childless.
+ *
+ * - `'parent'` — legacy behaviour: walk `parentId` only (sagas return empty).
+ * - `'saga'`   — walk `relates[type='groups']` only (regular epics return empty).
+ * - `'both'`   — auto-detect: walk groups when the target is saga-labeled,
+ *                otherwise walk `parentId`. Default for callers that don't
+ *                care which storage shape the epic uses.
+ *
+ * @bug gh-390
+ * @adr ADR-073
+ * @task T9839
+ */
+export type OrchestrateTraversal = 'parent' | 'saga' | 'both';
+
+/**
+ * Single source of truth for the saga-shaped-epic check (ADR-073).
+ *
+ * A task is a saga when its `labels` array contains `'saga'` AND its `type`
+ * is `'epic'`. Sagas are top-level grouping nodes whose members are linked
+ * via `task_relations.type='groups'` rather than `parentId`.
+ *
+ * @param task - The task to inspect. Pass either a fully-loaded {@link Task}
+ *               (with `labels` populated by `loadSingleTask` / `queryTasks`)
+ *               or `null`/`undefined` (returns `false`).
+ * @returns `true` when `task` is a saga-labeled epic.
+ *
+ * @bug gh-390
+ * @adr ADR-073
+ * @task T9839
+ */
+export function isSagaEpic(task: Pick<Task, 'type' | 'labels'> | null | undefined): boolean {
+  if (!task) return false;
+  if (task.type !== 'epic') return false;
+  return (task.labels ?? []).includes(SAGA_LABEL);
+}
+
+/**
+ * Extract member-Epic IDs from a saga's `relates` array.
+ *
+ * Walks {@link Task.relates} and returns the `taskId` of every entry whose
+ * `type === 'groups'`. Order is preserved (insertion order from the
+ * data-accessor) and duplicates are removed. Non-saga tasks return an empty
+ * array — callers MUST gate on {@link isSagaEpic} first.
+ *
+ * @param sagaTask - A saga-labeled epic with `relates` populated.
+ * @returns Deduplicated list of member Epic IDs in stable order.
+ *
+ * @bug gh-390
+ * @adr ADR-073
+ * @task T9839
+ */
+export function resolveSagaMembers(sagaTask: Pick<Task, 'relates'>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const relation of sagaTask.relates ?? []) {
+    if (relation.type !== SAGA_GROUPS_RELATION) continue;
+    if (seen.has(relation.taskId)) continue;
+    seen.add(relation.taskId);
+    out.push(relation.taskId);
+  }
+  return out;
+}
 
 /**
  * Load all tasks from task data.
@@ -217,6 +292,24 @@ export interface OrchestrateReadyOptions {
    * at the call-site closest to the source of truth.
    */
   ignoreDepsValidate?: boolean;
+
+  /**
+   * Traversal mode for resolving the epic's children (ADR-073 / gh-390).
+   *
+   * - `'parent'` — walk only the `parentId` column (legacy behaviour).
+   * - `'saga'`   — walk only `task_relations.type='groups'` edges.
+   * - `'both'`   — auto-detect saga-labeled epics and walk the groups edge,
+   *                otherwise fall back to the `parentId` walk. Default.
+   *
+   * Saga members (themselves Epics) are recursed into per-member; the result
+   * is the deduplicated union of ready tasks across all members. A guard
+   * prevents infinite recursion if a member is itself saga-labeled.
+   *
+   * @bug gh-390
+   * @adr ADR-073
+   * @task T9839
+   */
+  via?: OrchestrateTraversal;
 }
 
 /**
@@ -259,7 +352,7 @@ export async function orchestrateReady(
     }
 
     // ---------------------------------------------------------------------------
-    // T1858: dep-graph validation pre-step
+    // T1858: dep-graph validation pre-step (shared between parent + saga modes)
     // ---------------------------------------------------------------------------
     const config = await loadConfig(root);
     const lifecycleMode = config.lifecycle?.mode ?? 'strict';
@@ -320,7 +413,111 @@ export async function orchestrateReady(
     // mode === 'off': skip validation entirely
     // ---------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+    // gh-390 / ADR-073: saga-aware traversal
+    //
+    // A saga (Epic with labels='saga') holds its members via
+    // task_relations.type='groups', NOT via parentId. The legacy ready-walk
+    // only inspected getChildren(parentId), so sagas returned empty. We now
+    // detect the saga shape and aggregate ready-sets across member epics.
+    // -------------------------------------------------------------------------
+    const via: OrchestrateTraversal = opts?.via ?? 'both';
+    const sagaShaped = isSagaEpic(epic);
+    const useSagaWalk = via === 'saga' || (via === 'both' && sagaShaped);
+
     const accessor = await getTaskAccessor(root);
+
+    type ReadyTaskOut = {
+      id: string;
+      title: string;
+      priority: string;
+      depends: string[];
+    };
+
+    if (useSagaWalk) {
+      // We need the saga's `relates` populated. `tasks` from queryTasks does
+      // not include relations by default — pull the saga via loadSingleTask.
+      const sagaWithRelates = await accessor.loadSingleTask(epicId);
+      const members = sagaWithRelates ? resolveSagaMembers(sagaWithRelates) : [];
+
+      const seenIds = new Set<string>();
+      const aggregated: ReadyTaskOut[] = [];
+      let aggregatedAllCount = 0;
+      let aggregatedBlockedCount = 0;
+      const skippedNested: string[] = [];
+
+      for (const memberId of members) {
+        // Recursion safety: sagas SHOULD NOT nest (ADR-073). If a member is
+        // itself saga-labeled, skip it and surface the anomaly in meta rather
+        // than recursing — preserves O(N) aggregation.
+        const memberTask = tasks.find((t) => t.id === memberId);
+        if (memberTask && isSagaEpic(memberTask)) {
+          skippedNested.push(memberId);
+          continue;
+        }
+
+        const memberReady = await getReadyTasks(memberId, root, accessor);
+        aggregatedAllCount += memberReady.length;
+        aggregatedBlockedCount += memberReady.filter(
+          (t) => !t.ready && t.blockers.length > 0,
+        ).length;
+
+        for (const t of memberReady) {
+          if (!t.ready) continue;
+          if (seenIds.has(t.taskId)) continue;
+          seenIds.add(t.taskId);
+          aggregated.push({
+            id: t.taskId,
+            title: t.title,
+            priority: t.priority,
+            depends: t.depends,
+          });
+        }
+      }
+
+      // Preserve priority ordering (critical → high → medium → low) then ID.
+      const priorityWeight: Record<string, number> = {
+        critical: 4,
+        high: 3,
+        medium: 2,
+        low: 1,
+      };
+      aggregated.sort((a, b) => {
+        const wa = priorityWeight[a.priority] ?? 0;
+        const wb = priorityWeight[b.priority] ?? 0;
+        if (wa !== wb) return wb - wa;
+        return a.id.localeCompare(b.id);
+      });
+
+      let reason: string | undefined;
+      if (aggregated.length === 0) {
+        if (members.length === 0) {
+          reason = 'saga has no member epics';
+        } else if (aggregatedAllCount === 0) {
+          reason = 'saga members have no children';
+        } else if (aggregatedBlockedCount === aggregatedAllCount) {
+          reason = 'all saga-member tasks have unmet dependencies';
+        } else {
+          reason = 'no saga-member tasks with unmet dependencies found';
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          epicId,
+          readyTasks: aggregated,
+          total: aggregated.length,
+          via: 'saga',
+          sagaMembers: members,
+          ...(skippedNested.length > 0 && { sagaNestedSkipped: skippedNested }),
+          ...(reason !== undefined && { reason }),
+          ...(depsWarning !== undefined && { depsWarning }),
+        },
+      };
+    }
+
+    // Default / via='parent': legacy parentId-walk.
     const readyTasks = await getReadyTasks(epicId, root, accessor);
     const ready = readyTasks.filter((t) => t.ready);
 
@@ -350,6 +547,7 @@ export async function orchestrateReady(
           depends: t.depends,
         })),
         total: ready.length,
+        via: 'parent' as const,
         ...(reason !== undefined && { reason }),
         ...(depsWarning !== undefined && { depsWarning }),
       },
@@ -411,16 +609,46 @@ export async function orchestrateNext(epicId: string, projectRoot?: string): Pro
 }
 
 /**
+ * Options for {@link orchestrateWaves}.
+ *
+ * @bug gh-390
+ * @adr ADR-073
+ * @task T9839
+ */
+export interface OrchestrateWavesOptions {
+  /**
+   * Traversal mode for resolving the epic's children — see
+   * {@link OrchestrateTraversal}. Default `'both'`.
+   *
+   * @bug gh-390
+   * @adr ADR-073
+   * @task T9839
+   */
+  via?: OrchestrateTraversal;
+}
+
+/**
  * orchestrate.waves - Compute dependency waves
+ *
+ * For regular epics the wave plan is `getEnrichedWaves(epicId)`. For sagas
+ * (Epics labeled `'saga'`, ADR-073), per-member wave plans are computed and
+ * merged by wave index: wave N across all members becomes one unified wave N.
+ * Members of unequal depth contribute to the trailing waves (longest tail
+ * wins). Task IDs are deduplicated; per-wave order preserves the per-member
+ * sort.
  *
  * @param epicId - Epic to compute waves for.
  * @param projectRoot - Optional project root path.
+ * @param opts - Optional traversal flag ({@link OrchestrateWavesOptions}).
  * @returns Engine result with wave data.
  * @task T4478
+ * @bug gh-390
+ * @adr ADR-073
  */
 export async function orchestrateWaves(
   epicId: string,
   projectRoot?: string,
+  opts?: OrchestrateWavesOptions,
 ): Promise<EngineResult> {
   if (!epicId) {
     return engineError('E_INVALID_INPUT', 'epicId is required');
@@ -429,8 +657,97 @@ export async function orchestrateWaves(
   try {
     const root = getProjectRoot(projectRoot);
     const accessor = await getTaskAccessor(root);
-    const result = await getEnrichedWaves(epicId, root, accessor);
-    return { success: true, data: result };
+
+    // gh-390 / ADR-073: detect saga shape so we walk the groups relation.
+    const epic = await accessor.loadSingleTask(epicId);
+    if (!epic) {
+      return engineError('E_NOT_FOUND', `Epic ${epicId} not found`);
+    }
+
+    const via: OrchestrateTraversal = opts?.via ?? 'both';
+    const sagaShaped = isSagaEpic(epic);
+    const useSagaWalk = via === 'saga' || (via === 'both' && sagaShaped);
+
+    if (!useSagaWalk) {
+      const result = await getEnrichedWaves(epicId, root, accessor);
+      return {
+        success: true,
+        data: { ...result, via: 'parent' as const },
+      };
+    }
+
+    // Saga walk: compute per-member waves and merge by index.
+    const members = resolveSagaMembers(epic);
+    const skippedNested: string[] = [];
+    const perMemberWaves: EnrichedWave[][] = [];
+    let totalChildren = 0;
+
+    for (const memberId of members) {
+      const memberTask = await accessor.loadSingleTask(memberId);
+      if (memberTask && isSagaEpic(memberTask)) {
+        skippedNested.push(memberId);
+        continue;
+      }
+      const memberResult = await getEnrichedWaves(memberId, root, accessor);
+      perMemberWaves.push(memberResult.waves);
+      totalChildren += memberResult.totalTasks;
+    }
+
+    const maxWaves = perMemberWaves.reduce((m, w) => Math.max(m, w.length), 0);
+    const mergedWaves: EnrichedWave[] = [];
+
+    for (let i = 0; i < maxWaves; i++) {
+      const seen = new Set<string>();
+      const mergedTasks: EnrichedWave['tasks'] = [];
+      let anyInProgress = false;
+      let allCompleted = true;
+      let latestCompletedAt: string | undefined;
+
+      for (const memberWaves of perMemberWaves) {
+        const wave = memberWaves[i];
+        if (!wave) continue;
+        if (wave.status === 'in_progress') anyInProgress = true;
+        if (wave.status !== 'completed') allCompleted = false;
+        if (wave.completedAt && (!latestCompletedAt || wave.completedAt > latestCompletedAt)) {
+          latestCompletedAt = wave.completedAt;
+        }
+        for (const t of wave.tasks) {
+          if (seen.has(t.id)) continue;
+          seen.add(t.id);
+          mergedTasks.push(t);
+        }
+      }
+
+      const mergedStatus: EnrichedWave['status'] = allCompleted
+        ? 'completed'
+        : anyInProgress
+          ? 'in_progress'
+          : 'pending';
+
+      const merged: EnrichedWave = {
+        waveNumber: i + 1,
+        status: mergedStatus,
+        tasks: mergedTasks,
+        taskIds: mergedTasks.map((t) => t.id),
+      };
+      if (mergedStatus === 'completed' && latestCompletedAt) {
+        merged.completedAt = latestCompletedAt;
+      }
+      mergedWaves.push(merged);
+    }
+
+    return {
+      success: true,
+      data: {
+        epicId,
+        waves: mergedWaves,
+        totalWaves: mergedWaves.length,
+        totalTasks: totalChildren,
+        via: 'saga' as const,
+        sagaMembers: members,
+        ...(skippedNested.length > 0 && { sagaNestedSkipped: skippedNested }),
+      },
+    };
   } catch (err: unknown) {
     const code = (err as { code?: string }).code ?? 'E_GENERAL';
     return engineError(code, (err as Error).message);

--- a/packages/core/src/store/tasks-sqlite.ts
+++ b/packages/core/src/store/tasks-sqlite.ts
@@ -334,7 +334,8 @@ export async function addRelation(
     | 'absorbs'
     | 'fixes'
     | 'extends'
-    | 'supersedes' = 'related',
+    | 'supersedes'
+    | 'groups' = 'related',
   cwd?: string,
   reason?: string,
 ): Promise<void> {


### PR DESCRIPTION
## Summary

ADR-073 Sagas hold member Epics via `task_relations.relation_type='groups'`, NOT via `parentId`. `cleo orchestrate ready <sagaId>` and `cleo orchestrate waves <sagaId>` walked only `parentId`, so sagas returned `total:0, reason:"epic has no children"` even when `cleo saga members <sagaId>` correctly listed the linked epics (gh-390 repro on T119, 9 members).

This PR makes both ops saga-aware:

- **Auto-detect** (default `--via=both`): saga-shaped epics (`label='saga'` AND `type='epic'`) walk the groups relation; non-saga epics use the legacy `parentId` walk — zero behaviour change for regular epics.
- **Per-member aggregation**:
  - `orchestrate ready` — unions ready sets across all member epics, dedupes by ID, sorts critical→high→medium→low.
  - `orchestrate waves` — computes waves per member, merges by wave index (wave N across all members → unified wave N, longest tail wins).
- **Envelope additions** (in `data`): `via:'parent'|'saga'`, `sagaMembers:string[]`, optional `sagaNestedSkipped` when a member is itself saga-labeled (sagas don't nest per ADR-073).
- **New `--via <mode>` CLI flag** on both `ready` and `waves`: `'parent'` (legacy / regression escape hatch), `'saga'` (explicit groups walk), `'both'` (default auto-detect).
- **Recursion safety**: nested sagas are skipped and reported in meta — never infinite-recurse.

## Files changed

- `packages/core/src/orchestrate/query-ops.ts` — saga detection + traversal (~250 LOC). New helpers `isSagaEpic` + `resolveSagaMembers` reuse `SAGA_LABEL` / `SAGA_GROUPS_RELATION` constants already exported by `tasks/list.ts`.
- `packages/cleo/src/dispatch/domains/orchestrate.ts` — `via` field on `OrchestrateReadyParams` + `OrchestrateWavesParams` with validated narrowing (no `any` / `as unknown`).
- `packages/cleo/src/cli/commands/orchestrate.ts` — `--via` flag on both subcommands + updated help text.
- `packages/core/src/store/tasks-sqlite.ts` — `addRelation` type union extended with `'groups'` (already valid in the CHECK constraint and accessor; type signature was the only gap).
- `packages/core/src/internal.ts` — expose `addRelation` for test fixtures.
- `packages/core/src/orchestrate/__tests__/saga-walk.test.ts` — new file, 9 tests (fixture: saga T-S → groups → T-E1/T-E2/T-E3 + regression T-REGULAR).

## Test plan

- [x] `pnpm --filter @cleocode/core test saga-walk` — 9/9 pass
- [x] `pnpm vitest run src/orchestrate/__tests__/{orchestrate-waves,orchestrate-ready-display,saga-walk}.test.ts` co-run — 17/17 pass (no regression in adjacent suites)
- [x] `pnpm --filter @cleocode/core run build` — exit 0
- [x] `pnpm --filter @cleocode/cleo run build` — exit 0
- [x] `pnpm biome check --write <touched>` — clean
- [ ] Owner-action: run on a live `cleocode` checkout — `cleo saga create … && cleo saga add … && cleo orchestrate ready <sagaId>` should return the member-epic ready set with `data.via='saga'`.

Fixes #390
Refs SG-GH-TRIAGE-2026-05-21 (T9839)