### PR TITLE
docs(T9819): teach add-batch in ct-cleo SKILL.md + CLEO-INJECTION Task Creation

### DIFF
--- a/packages/core/templates/CLEO-INJECTION.md
+++ b/packages/core/templates/CLEO-INJECTION.md
@@ -62,6 +62,16 @@ If you find yourself reading a markdown file for orientation, STOP. Run `cleo br
 
 `--acceptance` required for ALL tasks. `cleo bug`/`--role` removed — use `cleo add --kind bug --severity Px --acceptance "..."`. Axes: `--type {epic|task|subtask}`, `--kind {work|research|experiment|bug|spike|release}`, `--severity {P0-P3}` (orthogonal to `--priority`; triggers Ed25519 attestation).
 
+| Goal | Command |
+|------|---------|
+| Create a single task | `cleo add --type task --parent <epicId> --title "..." --acceptance "..."` |
+| Create N tasks atomically | `cleo add-batch --file tasks.json --parent <epicId>` |
+| Preview batch before inserting | `cleo add-batch --file tasks.json --parent <epicId> --dry-run` |
+| Batch from stdin | `echo '[...]' \| cleo add-batch --file - --parent <epicId>` |
+
+`cleo add-batch` inserts all tasks in a single transaction — ANY failure rolls back ALL inserts.
+See `ct-cleo` skill section "Decomposing an epic into N tasks" for the JSON schema and rollback semantic.
+
 ### Sagas — above-Epic grouping (ADR-073)
 
 A **Saga** (`SG-`) is a multi-release theme grouping multiple Epics. It is a labeled top-level

--- a/packages/skills/skills/ct-cleo/SKILL.md
+++ b/packages/skills/skills/ct-cleo/SKILL.md
@@ -51,3 +51,68 @@ Full charter (8 invariants + lifecycle decision table + prefix registry) lives i
 CLEO-INJECTION.md `task-creation` section (`cleo briefing inject --section task-creation`).
 
 For full decision trees and operation reference tables, emit sections above.
+
+## Decomposing an epic into N tasks
+
+When you need to bulk-create child tasks under an epic, use `cleo add-batch`. It inserts all
+tasks in a single atomic transaction — if ANY task fails validation, ALL inserts are rolled back.
+This is the canonical pattern for epic decomposition; prefer it over N sequential `cleo add` calls.
+
+### Canonical command
+
+```bash
+cleo add-batch --file tasks.json --parent <epicId>
+```
+
+### Minimal JSON example
+
+Create a `tasks.json` file (array of task objects):
+
+```json
+[
+  {
+    "title": "Research: survey add-batch prior art",
+    "acceptance": "Written summary of 3+ prior approaches|Coverage of rollback semantics"
+  },
+  {
+    "title": "Implement: add-batch CORE op with atomic semantics",
+    "acceptance": "All tasks inserted or none|Returns IDs of created tasks"
+  },
+  {
+    "title": "TF: teach add-batch in ct-cleo SKILL.md + CLEO-INJECTION",
+    "acceptance": "SKILL.md contains Decomposing an epic section|INJECTION Task Creation table includes add-batch row"
+  }
+]
+```
+
+Every object in the array supports the same fields as `cleo add` (`title`, `acceptance`,
+`kind`, `priority`, `size`, `labels`, `depends`). The `--parent` flag applies to all items.
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--file <path>` | Path to JSON file (array of task objects) |
+| `-` | Read JSON array from stdin (`echo '[...]' \| cleo add-batch --file - --parent <id>`) |
+| `--parent <id>` | Parent epic/task ID. All created tasks become direct children. |
+| `--dry-run` | Validate and preview all tasks without inserting. Shows what would be created. |
+
+### Rollback semantic
+
+```
+ANY task fails → ALL inserts rolled back (zero partial state)
+```
+
+Run `--dry-run` first to catch validation errors (missing `acceptance`, title too long, etc.)
+before committing the batch.
+
+### Meta-dogfood: how T9813 itself was decomposed
+
+The Epic T9813 (`add-batch` feature saga) used this exact pattern to create its child tasks
+(T9814–T9819) in a single call. Use the task decomposition from your epic planning as the
+input JSON — `cleo show <epicId>` acceptance criteria → tasks array → `cleo add-batch`.
+
+### Related
+
+- Saga/Epic workflow: `cleo briefing inject --section task-creation`
+- Single task: `cleo add --type task --parent <id> --acceptance "..." --title "..."`


### PR DESCRIPTION
## Summary

- New 'Decomposing an epic into N tasks' section in `packages/skills/skills/ct-cleo/SKILL.md` — shows canonical `cleo add-batch` JSON pattern, `--dry-run`, stdin (`-`) flag, and rollback-on-failure semantic with a meta-dogfood T9813 example
- New Task Creation table in `packages/core/templates/CLEO-INJECTION.md` (task-creation section) with rows for single task, batch (atomic), dry-run preview, and stdin batch; cross-references the ct-cleo skill section

## Why

Closes Epic T9813 AC6 + AC7. The CORE op (T9814), CLI wrapper (T9816), and Tier 0 surface (T9817) are all in place — this PR closes the skill/protocol discoverability gap so future agents learn to use `cleo add-batch` for epic decomposition instead of N sequential `cleo add` calls.

ADR-076 routing decision: `skill` and `injection` DocKinds are NOT listed under any `rawMdAllowed: false` entry in `.cleo/canon.yml` — raw edits are allowed. Canon drift check: passed (0 violations, `scanned: 0`).

## Test plan

- [x] `grep -A 5 "Decomposing an epic"` confirms new section in SKILL.md
- [x] `cleo skills info ct-cleo` returns success (skill loader works)
- [x] `cleo check canon docs` passes with 0 violations
- [x] Biome check (via npx): 2 files checked, no fixes needed
- [x] Pre-existing ct-cleo + INJECTION content unchanged

🤖 Worker for T9819 under Epic T9813