### PR TITLE
fix(gh-401): RCA + persist severity/kind/scope on task UPDATE

### DIFF
--- a/packages/core/src/store/db-helpers.ts
+++ b/packages/core/src/store/db-helpers.ts
@@ -70,12 +70,29 @@ export async function upsertTask(
   }
 
   const values = archiveFields ? { ...row, ...archiveFields, status: 'archived' as const } : row;
+  // GH #401 / T9839: the `set` clause defines which columns are updated on
+  // ON CONFLICT (id) DO UPDATE. Any column omitted from this object is
+  // SILENTLY DROPPED on update — INSERT carries the field, but UPDATE does
+  // not. This caused a critical data-integrity bug where `severity`, `kind`,
+  // and `scope` (added by T944/T9072/T9073 but never appended to the SET
+  // clause) appeared to update in the response envelope while the underlying
+  // DB row was unchanged. Treat this list as load-bearing: any new column on
+  // the `tasks` table MUST be mirrored here.
   const set: Record<string, unknown> = {
     title: row.title,
     description: row.description,
     status: archiveFields ? 'archived' : row.status,
     priority: row.priority,
     type: row.type,
+    // T944 / GH #401: kind axis (DB col 'role') — must be in set clause
+    // so update persists changes. Undefined skips the column (preserves DB
+    // value); a concrete value overwrites it.
+    kind: row.kind,
+    // T944 / GH #401: scope axis — same persistence requirement.
+    scope: row.scope,
+    // T9073 / GH #401: severity — owner-write-only axis (nullable).
+    // Same undefined-skips-update semantics as the other axes.
+    severity: row.severity,
     parentId: row.parentId,
     phase: row.phase,
     size: row.size,

--- a/packages/core/src/tasks/__tests__/severity-update.test.ts
+++ b/packages/core/src/tasks/__tests__/severity-update.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Regression test for GH #401 / T9839 — severity P0 silent downgrade.
+ *
+ * BUG (pre-fix): `cleo update <id> --severity P0` returned `success:true`
+ * with `task.severity:"P0"` in the response envelope, but the underlying
+ * SQLite row was unchanged (still showed `P1`). The same defect affected
+ * the `kind` and `scope` orthogonal axes added by T944 / T9072.
+ *
+ * ROOT CAUSE: `upsertTask` in `store/db-helpers.ts` builds an
+ * `onConflictDoUpdate({ set })` clause that EXPLICITLY lists every column
+ * the UPDATE branch is allowed to touch. The `kind` (DB col `role`),
+ * `scope`, and `severity` columns were never appended to that list, so
+ * UPDATE silently dropped those fields. INSERT carried them via the
+ * `values` object (`taskToRow` returns them), which is why a freshly
+ * `cleo add`-ed task showed the right severity — only updates to an
+ * existing row were affected.
+ *
+ * The fix adds `kind`, `scope`, and `severity` to the `set` object. These
+ * tests guard against regression by exercising the full `updateTask` path
+ * and then re-reading the row via `loadSingleTask` to confirm the DB
+ * state matches the response envelope.
+ *
+ * @task T9839
+ * @issue gh-401
+ */
+
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, seedTasks, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { resetDbState } from '../../store/sqlite.js';
+import { updateTask } from '../update.js';
+
+describe('updateTask — orthogonal axes persistence (GH #401 / T9839)', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+    await writeFile(
+      join(env.cleoDir, 'config.json'),
+      JSON.stringify({
+        enforcement: {
+          session: { requiredForMutate: false },
+          acceptance: { mode: 'off' },
+        },
+        lifecycle: { mode: 'off' },
+        verification: { enabled: false },
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  describe('severity', () => {
+    it('persists P1 -> P0 escalation to the DB (response envelope MUST match DB state)', async () => {
+      await seedTasks(accessor, [
+        {
+          id: 'T001',
+          title: 'Task with P1 severity',
+          status: 'pending',
+          priority: 'medium',
+          severity: 'P1',
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+
+      const result = await updateTask({ taskId: 'T001', severity: 'P0' }, env.tempDir, accessor);
+
+      // Response envelope claim
+      expect(result.task.severity).toBe('P0');
+      expect(result.changes).toContain('severity');
+
+      // GH #401 invariant — DB state matches the response envelope
+      const reloaded = await accessor.loadSingleTask('T001');
+      expect(reloaded?.severity).toBe('P0');
+    });
+
+    it('persists P0 -> P1 de-escalation (no attestation required on write path)', async () => {
+      await seedTasks(accessor, [
+        {
+          id: 'T002',
+          title: 'P0 task being de-escalated',
+          status: 'pending',
+          priority: 'high',
+          severity: 'P0',
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+
+      const result = await updateTask({ taskId: 'T002', severity: 'P1' }, env.tempDir, accessor);
+
+      expect(result.task.severity).toBe('P1');
+      const reloaded = await accessor.loadSingleTask('T002');
+      expect(reloaded?.severity).toBe('P1');
+    });
+
+    it('persists severity on a task that previously had none (null -> P2)', async () => {
+      await seedTasks(accessor, [
+        {
+          id: 'T003',
+          title: 'Task with no severity',
+          status: 'pending',
+          priority: 'medium',
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+
+      // Sanity check the seed
+      const seeded = await accessor.loadSingleTask('T003');
+      expect(seeded?.severity).toBeUndefined();
+
+      const result = await updateTask({ taskId: 'T003', severity: 'P2' }, env.tempDir, accessor);
+      expect(result.task.severity).toBe('P2');
+      const reloaded = await accessor.loadSingleTask('T003');
+      expect(reloaded?.severity).toBe('P2');
+    });
+
+    it('preserves severity when updating unrelated fields (kind/scope/severity not in set clause regression-guard)', async () => {
+      await seedTasks(accessor, [
+        {
+          id: 'T004',
+          title: 'P0 task',
+          status: 'pending',
+          priority: 'high',
+          severity: 'P0',
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+
+      // Update title only — severity must remain P0
+      await updateTask({ taskId: 'T004', title: 'P0 task (renamed)' }, env.tempDir, accessor);
+      const reloaded = await accessor.loadSingleTask('T004');
+      expect(reloaded?.title).toBe('P0 task (renamed)');
+      expect(reloaded?.severity).toBe('P0');
+    });
+  });
+
+  describe('kind (T944 / DB col role) — same defect class as severity', () => {
+    it('persists kind change to the DB (work -> bug)', async () => {
+      await seedTasks(accessor, [
+        {
+          id: 'T010',
+          title: 'Work task being reclassified',
+          status: 'pending',
+          priority: 'medium',
+          kind: 'work',
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+
+      const result = await updateTask({ taskId: 'T010', kind: 'bug' }, env.tempDir, accessor);
+      expect(result.task.kind).toBe('bug');
+      expect(result.changes).toContain('kind');
+
+      const reloaded = await accessor.loadSingleTask('T010');
+      expect(reloaded?.kind).toBe('bug');
+    });
+  });
+
+  describe('scope (T944) — same defect class as severity', () => {
+    it('persists scope change to the DB (feature -> project)', async () => {
+      await seedTasks(accessor, [
+        {
+          id: 'T020',
+          title: 'Feature-scoped task',
+          status: 'pending',
+          priority: 'medium',
+          scope: 'feature',
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+
+      const result = await updateTask({ taskId: 'T020', scope: 'project' }, env.tempDir, accessor);
+      expect(result.task.scope).toBe('project');
+      expect(result.changes).toContain('scope');
+
+      const reloaded = await accessor.loadSingleTask('T020');
+      expect(reloaded?.scope).toBe('project');
+    });
+  });
+
+  describe('combined orthogonal axes — multi-field update persists every field', () => {
+    it('updates kind+scope+severity in a single call and persists all three', async () => {
+      await seedTasks(accessor, [
+        {
+          id: 'T030',
+          title: 'Triple-axis update',
+          status: 'pending',
+          priority: 'medium',
+          kind: 'work',
+          scope: 'feature',
+          severity: 'P3',
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+
+      const result = await updateTask(
+        { taskId: 'T030', kind: 'bug', scope: 'project', severity: 'P0' },
+        env.tempDir,
+        accessor,
+      );
+      expect(result.task.kind).toBe('bug');
+      expect(result.task.scope).toBe('project');
+      expect(result.task.severity).toBe('P0');
+
+      const reloaded = await accessor.loadSingleTask('T030');
+      expect(reloaded?.kind).toBe('bug');
+      expect(reloaded?.scope).toBe('project');
+      expect(reloaded?.severity).toBe('P0');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

GitHub Issue #401 reported a critical data-integrity bug: `cleo update <id> --severity P0` returned `success:true` with `task.severity:"P0"` in the response envelope, but the underlying SQLite row was unchanged. This PR fixes the bug, adds a regression test, and documents the root cause.

This is the **worst possible failure mode** — three layers of "success" signal (`success:true`, `changes:["severity"]`, `task.severity:"P0"`) followed by silent data loss.

## Root Cause Analysis

The bug is NOT in the severity-attestation gate, NOT in the read-side projection, NOT in a hidden write-side gate. It is in the upsert helper at `packages/core/src/store/db-helpers.ts:upsertTask`.

```ts
await db
  .insert(schema.tasks)
  .values(values)                            // INSERT branch — carries severity/kind/scope
  .onConflictDoUpdate({ target: ..., set })  // UPDATE branch — set object enumerates columns
  .run();
```

The `set` object explicitly lists every column the UPDATE branch is allowed to touch. The orthogonal axes added by T944 / T9072 / T9073 — `kind` (DB col `role`), `scope`, and `severity` — were **never appended to that list**. INSERT carried them, so a freshly `cleo add`-ed task showed the right severity, but every subsequent UPDATE silently dropped those three columns.

Meanwhile `updateTask` mutated `task.severity` in memory and returned the in-memory task object in the response envelope — hence the `success:true` / `task.severity:"P0"` claim. The next `cleo show` loaded from the unchanged DB row.

**Three hypotheses ruled out, one confirmed:**

| Hypothesis | Status | Evidence |
|---|---|---|
| A — Hidden write-side gate reverts severity | **CONFIRMED — but actually a missing column in set clause, not a reversion** | `db-helpers.ts:73-108` does not list `kind`, `scope`, or `severity` |
| B — Audit-trail rollback wipes severity in same TX | RULED OUT | Attestation is JSONL not SQLite, and CLI calls it AFTER the dispatch returns |
| C — Read-side filter masks P0 to P1 | RULED OUT | `rowToTask` converter returns severity verbatim |
| D — Severity derived from priority on load | RULED OUT | `tasks.severity` is a real schema column with default NULL |
| E — `ownerPubkeys` allowlist non-empty | RULED OUT | Allowlist empty in repro; would throw `E_OWNER_ONLY` and exit 72 if it triggered |

**Repro on v2026.5.93 confirms the same defect class hits `kind` and `scope`:**

```text
$ cleo update T002 --severity P0 --reason "..."
resp.severity: P0   # claim
$ cleo show T002
db.severity: P1     # reality — UPDATE silently dropped severity

$ cleo update T002 --kind bug
resp.kind: bug      # claim
$ cleo show T002
db.kind: work       # reality

$ cleo update T002 --scope project
resp.scope: project # claim
$ cleo show T002
db.scope: feature   # reality
```

## Fix

Append `kind`, `scope`, and `severity` to the `set` object in `upsertTask`. Drizzle treats `undefined` in a set clause as "do not touch this column", so unchanged tasks continue to behave correctly (the `taskToRow` converter returns `task.kind ?? undefined` etc., which is the existing convention).

Added a leading comment block documenting that the `set` list is load-bearing: any new column on the `tasks` table MUST be mirrored there, or it will silently fail to persist on UPDATE.

## Response-envelope ↔ DB-state invariant

The fix restores the contract that **the response envelope MUST match the DB state after the call**. The new regression test asserts this by re-reading via `loadSingleTask` after every mutation — including unrelated-field updates that must NOT accidentally clobber severity.

## Attestation gate (intentionally not touched)

The CLI-level severity-attestation gate (`packages/cleo/src/cli/commands/update.ts:331-351`) is a separate concern. It correctly throws `E_OWNER_ONLY` when `ownerPubkeys` is non-empty and the signer is absent. In the reporter's repro the allowlist was empty (opt-in policy) so attestation passed — the write SHOULD have succeeded and the CLI DID claim it succeeded. The upsert was simply broken. No attestation contract changes were required.

## Test plan

- [x] New file `packages/core/src/tasks/__tests__/severity-update.test.ts` — 7 tests covering P1→P0 escalation, P0→P1 de-escalation, null→P2 first-set, kind work→bug, scope feature→project, combined three-axis update, and severity-preservation when updating an unrelated field
- [x] All 7 new tests pass against the fix
- [x] Existing `update.test.ts` + `t9073-severity-cross-role.test.ts` + `t944-role-scope-wiring.test.ts` continue to pass (46/46)
- [x] Schema tests `t9073-severity-any-role-schema.test.ts` + `t944-role-scope-schema.test.ts` continue to pass (16/16)
- [x] Live repro against rebuilt CLI confirms severity, kind, scope now persist correctly

## Caveats

- Repo-wide `pnpm run build` (which runs `tsc --emitDeclarationOnly`) fails on a pre-existing main-branch issue (`packages/caamp/src/core/advanced/orchestration.ts` references `@cleocode/core/skills/skill-root.js`). This is **not introduced by this PR** — it is the T9776 carryforward already documented in cleo memory. The esbuild JS output succeeds.
- `pnpm biome check` on the touched files is clean (biome auto-reformatted the test file).
- PR #412 (gh-409 acceptance tokenizer) touches `packages/cleo/src/cli/commands/update.ts` at lines 268-271 — this PR does not modify that file at all, so no merge conflict expected.

Fixes #401
Refs SG-GH-TRIAGE-2026-05-21 (T9839)

🤖 Generated with [Claude Code](https://claude.com/claude-code)