### PR TITLE
docs(gh-392/394/399/403/405): CLI help-text hardening bundle

### DIFF
--- a/packages/cleo/src/cli/commands/add.ts
+++ b/packages/cleo/src/cli/commands/add.ts
@@ -95,7 +95,8 @@ export const addCommand = defineCommand({
     labels: {
       type: 'string',
       alias: 'l',
-      description: 'Comma-separated labels',
+      description:
+        'Comma-separated labels (lowercase alphanumeric + hyphens + periods only, e.g. "track-b,wave.1") (gh-392)',
     },
     files: {
       type: 'string',

--- a/packages/cleo/src/cli/commands/req.ts
+++ b/packages/cleo/src/cli/commands/req.ts
@@ -129,7 +129,11 @@ const migrateCommand = defineCommand({
  * ```
  */
 export const reqCommand = defineCommand({
-  meta: { name: 'req', description: 'Manage REQ-ID-addressable acceptance gates on tasks' },
+  meta: {
+    name: 'req',
+    description:
+      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use `cleo update <id> --add-depends <ids>` or `cleo update <id> --add-relates <id>:blocks` (gh-394).',
+  },
   subCommands: {
     add: addCommand,
     list: listCommand,

--- a/packages/cleo/src/cli/commands/update.ts
+++ b/packages/cleo/src/cli/commands/update.ts
@@ -70,12 +70,14 @@ export const updateCommand = defineCommand({
     },
     labels: {
       type: 'string',
-      description: 'Set labels (comma-separated)',
+      description:
+        'Set labels (comma-separated; lowercase alphanumeric + hyphens + periods only, e.g. "track-b,wave.1") (gh-392)',
       alias: 'l',
     },
     'add-labels': {
       type: 'string',
-      description: 'Add labels (comma-separated)',
+      description:
+        'Add labels (comma-separated; lowercase alphanumeric + hyphens + periods only, e.g. "track-b,wave.1") (gh-392)',
     },
     'remove-labels': {
       type: 'string',
@@ -203,21 +205,32 @@ export const updateCommand = defineCommand({
     'depends-waiver': {
       type: 'string',
       description:
-        'Justification for promoting a task to critical priority without --depends (T1856). Records waiver in task metadata.',
+        'Justification (string) to waive the "--depends required for critical priority" check. Only consulted when the task is being promoted to --priority critical AND no existing or new --depends are declared. Stored verbatim in task metadata as audit trail; ignored for non-critical updates. (gh-405 / T1856)',
     },
     /**
      * Related tasks — semantic relationships (non-dependency).
-     * Comma-separated task IDs with optional type suffix (e.g. "T001:blocks,T002").
-     * Default type is 'related'. Replaces existing relates list.
+     *
+     * Direction convention (gh-403):
+     *   `cleo update <fromId> --add-relates <toId>:<type>`
+     * creates a directed edge FROM `<fromId>` TO `<toId>` with the given type.
+     * Example: `cleo update T127 --add-relates T123:blocks` means
+     * "T127 blocks T123" (the task being updated is the source).
+     *
+     * For dependency edges (T127 must complete before T128 can start), prefer
+     * `--add-depends T128` on T127 — `depends` is the canonical dep primitive
+     * and is what `cleo orchestrate ready`/`waves` walks. `--add-relates` is for
+     * semantic relationships (blocks/supersedes/groups/related) that don't
+     * affect wave-order scheduling.
      */
     relates: {
       type: 'string',
-      description: 'Set related tasks (comma-separated, optional type suffix: "T001:blocks,T002")',
+      description:
+        'Set related tasks (comma-separated, optional type suffix: "T001:blocks,T002"). Direction: <current task> → <relate>. For dep edges, prefer --add-depends. (gh-403)',
     },
     'add-relates': {
       type: 'string',
       description:
-        'Add related tasks without overwriting existing (comma-separated, optional type suffix)',
+        'Add related tasks without overwriting (comma-separated, optional type suffix: "T001:blocks"). Direction: <current task> → <relate>. For dep edges, prefer --add-depends. (gh-403)',
     },
     'remove-relates': {
       type: 'string',

--- a/packages/core/src/tasks/__tests__/task-ops-depends.test.ts
+++ b/packages/core/src/tasks/__tests__/task-ops-depends.test.ts
@@ -86,7 +86,7 @@ describe('coreTaskDepends transitive hints', () => {
 
     const withHint = await coreTaskDepends('/mock', 'T003');
     expect(withHint.hint).toBeDefined();
-    expect(withHint.hint).toContain('ct deps show');
+    expect(withHint.hint).toContain('cleo deps show');
 
     // All deps resolved
     const resolvedTasks = [

--- a/packages/core/src/tasks/task-ops.ts
+++ b/packages/core/src/tasks/task-ops.ts
@@ -1811,7 +1811,7 @@ export async function coreTaskDepends(
   const allDepsReady = unresolvedChain === 0;
   const hint =
     unresolvedChain > 0
-      ? `Run 'ct deps show ${taskId} --tree' for full dependency graph`
+      ? `Run 'cleo deps show ${taskId} --tree' for full dependency graph (gh-399)`
       : undefined;
 
   // Optional upstream tree


### PR DESCRIPTION
## Summary
Five small operator-papercut fixes batched into one PR — each is a help-string edit with no behavioural change.

| Issue | Fix |
|-------|-----|
| #392 | \`--labels\`/\`--add-labels\` on \`cleo add\` + \`cleo update\` now document the label-format constraint (lowercase alphanumeric + hyphens + periods only) inline with a copyable example |
| #394 | \`cleo req\` meta cross-links to \`cleo update --add-depends\`/\`--add-relates :blocks\` — disambiguates the in-task gate vs. cross-task edge confusion |
| #399 | \`cleo deps show <id>\` trailing hint no longer references the non-existent \`ct\` shim — uses \`cleo deps show <id> --tree\` |
| #403 | \`--add-relates\` direction made explicit: edge FROM \`<currentId>\` TO \`<relateId>\`. Prefer \`--add-depends\` for dep edges since \`relates\` doesn't affect orchestration scheduling |
| #405 | \`--depends-waiver\` semantics: applies ONLY when promoting to \`--priority critical\` with no \`--depends\`; stored verbatim in task metadata for audit |

## Files
- \`packages/cleo/src/cli/commands/update.ts\` — \`--labels\`/\`--add-labels\`/\`--depends-waiver\`/\`--relates\`/\`--add-relates\` descriptions
- \`packages/cleo/src/cli/commands/add.ts\` — \`--labels\` description
- \`packages/cleo/src/cli/commands/req.ts\` — \`cleo req\` meta cross-link
- \`packages/core/src/tasks/task-ops.ts\` — \`ct deps\` → \`cleo deps\`
- \`packages/core/src/tasks/__tests__/task-ops-depends.test.ts\` — assertion updated

## Verification
- \`pnpm biome check\` clean on all 5 files
- \`pnpm --filter @cleocode/core test task-ops-depends\` — **6/6 pass**

## Test plan
- [x] Help text rendered via \`cleo update --help\` shows the new label-format note
- [x] \`cleo req --help\` includes the cross-link
- [x] \`cleo deps show <id>\` trailing hint shows \`cleo deps\` not \`ct deps\`
- [x] task-ops-depends test assertion still passes

Fixes #392
Fixes #394
Fixes #399
Fixes #403
Fixes #405

Refs SG-GH-TRIAGE-2026-05-21 (T9839)

🤖 Generated with [Claude Code](https://claude.com/claude-code)