### PR TITLE
chore(T9852): backfill 7 changesets for gh-triage Saga (shipped in v2026.5.94)

### DIFF
--- a/.changeset/t9852-gh-390-saga-walk.md
+++ b/.changeset/t9852-gh-390-saga-walk.md
@@ -1,0 +1,9 @@
+---
+id: t9852-gh-390-saga-walk
+tasks: [T9852, T9839]
+kind: fix
+summary: orchestrate ready/waves traverse saga 'groups' relation (+ --via flag)
+prs: [422]
+---
+
+Closes #390. ADR-073 sagas hold members via task_relations.relation_type='groups' not parentId — orchestrateReady/Waves now detects label='saga' and walks the groups relation. New --via flag (parent|saga|both, default both). Envelope adds via + sagaMembers + sagaNestedSkipped diagnostics.

--- a/.changeset/t9852-gh-391-sqlite-busy-retry.md
+++ b/.changeset/t9852-gh-391-sqlite-busy-retry.md
@@ -1,0 +1,9 @@
+---
+id: t9852-gh-391-sqlite-busy-retry
+tasks: [T9852, T9839]
+kind: fix
+summary: SQLITE_BUSY retry on parallel task writes (CORE SDK with-retry primitive)
+prs: [413]
+---
+
+Closes #391. Extracts isSqliteBusy + new withWriteRetry helper into shared core/store/with-retry.ts. Wraps 8 BEGIN IMMEDIATE call sites in sqlite-data-accessor.ts (saveArchive, upsertSingleTask, addRelation, removeRelation, archiveSingleTask, removeSingleTask, updateTaskFields, appendLog) with 4-attempt 100/200/400/800ms +/- 50ms jitter backoff. New E_WRITE_CONTENTION exit code distinct from E_VALIDATION.

--- a/.changeset/t9852-gh-401-severity-rca.md
+++ b/.changeset/t9852-gh-401-severity-rca.md
@@ -1,0 +1,9 @@
+---
+id: t9852-gh-401-severity-rca
+tasks: [T9852, T9839]
+kind: fix
+summary: RCA + persist severity/kind/scope on task UPDATE
+prs: [425]
+---
+
+Closes #401. RCA: bug was write-side defect in upsertTask onConflictDoUpdate({set}) — kind/scope/severity columns were enumerated for INSERT but not UPDATE, so cleo add --severity P0 worked but cleo update silently dropped them. Three layers of success signal with no DB write. Fix: added the 3 columns to the set object in db-helpers.ts + load-bearing comment for future additions.

--- a/.changeset/t9852-gh-402-diagnostics-version.md
+++ b/.changeset/t9852-gh-402-diagnostics-version.md
@@ -1,0 +1,9 @@
+---
+id: t9852-gh-402-diagnostics-version
+tasks: [T9852, T9839]
+kind: fix
+summary: cleo issue diagnostics reads CLEO version from package.json SSoT
+prs: [411]
+---
+
+Closes #402. Replaces stale '2026.2.1' hardcode (drifted 3 months) with resolveCleoVersion() reading @cleocode/cleo/package.json via Node module resolution, falling back to getCleoVersion() (core) then 'unknown'.

--- a/.changeset/t9852-gh-409-acceptance-tokenizer.md
+++ b/.changeset/t9852-gh-409-acceptance-tokenizer.md
@@ -1,0 +1,9 @@
+---
+id: t9852-gh-409-acceptance-tokenizer
+tasks: [T9852, T9839]
+kind: fix
+summary: Bracket+quote-aware acceptance tokenizer + DRY collapse of 3 duplicate split impls
+prs: [412]
+---
+
+Closes #409. Replaces naive String.split('|') in parseAcceptanceCriteria with a tokenizer that tracks balanced brackets ((), [], {}) and single/double quotes, so | inside ENUM (hot|cold|batch|embed) or 'realtime-token'|'batch' is preserved as a literal character. Adds \| escape syntax at depth 0. Collapses 3 inline split sites in update.ts + saga.ts onto the canonical core helper — SOLID+DRY consolidation per AGENTS.md.

--- a/.changeset/t9852-gh-docs-bundle.md
+++ b/.changeset/t9852-gh-docs-bundle.md
@@ -1,0 +1,9 @@
+---
+id: t9852-gh-docs-bundle
+tasks: [T9852, T9839]
+kind: docs
+summary: CLI help-text hardening bundle (gh-392 #394 #399 #403 #405)
+prs: [426]
+---
+
+Five operator-papercut fixes batched into one PR — help-string edits, zero behavioural change. (a) #392 --labels constraint inline. (b) #394 cleo req cross-link to deps/relates. (c) #399 ct deps → cleo deps. (d) #403 --add-relates direction made explicit. (e) #405 --depends-waiver semantics expanded.

--- a/.changeset/t9852-lint-hotfix.md
+++ b/.changeset/t9852-lint-hotfix.md
@@ -1,0 +1,9 @@
+---
+id: t9852-lint-hotfix
+tasks: [T9852, T9839]
+kind: chore
+summary: biome lint hotfixes — unblock CI after T9797 saga-T9787 file landed
+prs: [427]
+---
+
+Three pre-existing lint failures surfacing on main: noUselessLoneBlockStatements in saga-T9787-e2e-validation.mjs:321; useOptionalChain in hermes-import-classifier.ts:143/150; noTemplateCurlyInString in lint-json-stream-hygiene.mjs:394. Also formatted command-manifest.ts to satisfy biome ci (generator drift, T9246 follow-up).


### PR DESCRIPTION
## Summary
Adds 7 canonical changeset entries (\`cleo changeset add\`, T9785/T9793 DSL) for the gh-issue triage Saga T9839. The 7 PRs (#411-#427) merged into main before the v2026.5.94 ship commit but were authored without changeset entries — so the auto-CHANGELOG generator didn't credit them. **Code IS in v5.94; narrative is not.** This PR fixes the narrative for the next release.

## What landed in v2026.5.94 unattributed
| Changeset | Fix | PR | Closes |
|-----------|-----|----|----|
| t9852-gh-409-acceptance-tokenizer | Bracket+quote-aware acceptance tokenizer + DRY collapse of 3 dup impls | #412 | #409 |
| t9852-gh-391-sqlite-busy-retry | SQLITE_BUSY retry on parallel writes (CORE SDK with-retry primitive) | #413 | #391 |
| t9852-gh-390-saga-walk | orchestrate ready/waves traverse saga 'groups' relation (+ \`--via\` flag) | #422 | #390 |
| t9852-gh-401-severity-rca | RCA + persist severity/kind/scope on task UPDATE (upsertTask defect) | #425 | #401 |
| t9852-gh-402-diagnostics-version | cleo issue diagnostics reads CLEO version from package.json SSoT | #411 | #402 |
| t9852-gh-docs-bundle | CLI help-text hardening bundle | #426 | #392 #394 #399 #403 #405 |
| t9852-lint-hotfix | biome lint hotfixes (noUselessLoneBlock, useOptionalChain, noTemplateCurlyInString, command-manifest format) | #427 | — |

## Verification
- All 7 \`.md\` files written by \`cleo changeset add\` (dual-write to .changeset/ + SSoT blob store)
- Schema-conformant per the changeset DSL: \`/^t\\d+-[a-z0-9-]+$/\` slug, valid \`kind\`, tasks anchored

## Test plan
- [x] All 7 files present in \`.changeset/\`
- [x] Slug format matches the changeset DSL regex
- [x] Each entry references the PR number that landed the fix
- [x] Next release's auto-CHANGELOG will pick these up via the existing aggregator

Refs SG-GH-TRIAGE-2026-05-21 (T9839)
Refs T9852

🤖 Generated with [Claude Code](https://claude.com/claude-code)