### PR TITLE
fix(T9853): repair typo in plan-saga-leaf-changelog test (line 617)

### DIFF
--- a/packages/core/src/release/__tests__/plan-saga-leaf-changelog.test.ts
+++ b/packages/core/src/release/__tests__/plan-saga-leaf-changelog.test.ts
@@ -614,7 +614,7 @@ describe('releasePlan writes CHANGELOG.md (T9838 Fix 3)', () => {
     const preExisting = [
       '# Changelog',
       '',
-      ## [2025.1.0] (2025-01-15)',
+      '## [2025.1.0] (2025-01-15)',
       '',
       '- Older release notes left intact.',
       '',


### PR DESCRIPTION
Follow-up to #431. The v-prefix-stripping sed broke a string literal: `'## [2025.1.0]` lost its opening quote. Repair.