### PR TITLE
fix(T9854): ensureArray preserves object array items — unblocks cleo add-batch

### DIFF
--- a/packages/cleo/src/dispatch/lib/__tests__/security.test.ts
+++ b/packages/cleo/src/dispatch/lib/__tests__/security.test.ts
@@ -83,6 +83,40 @@ describe('ensureArray', () => {
   it('supports a custom separator', () => {
     expect(ensureArray('a|b|c', '|')).toEqual(['a', 'b', 'c']);
   });
+
+  // T9854 regression: object arrays must NOT be String()-coerced to "[object Object]"
+  it('passes through an array of objects unmodified (T9854)', () => {
+    const tasks = [
+      { title: 'Task A', acceptance: ['a'] },
+      { title: 'Task B', parent: 'T100', acceptance: ['b'] },
+    ];
+    const result = ensureArray(tasks);
+    expect(result).toHaveLength(2);
+    expect(result?.[0]).toStrictEqual({ title: 'Task A', acceptance: ['a'] });
+    expect(result?.[1]).toStrictEqual({ title: 'Task B', parent: 'T100', acceptance: ['b'] });
+  });
+
+  it('does NOT produce "[object Object]" strings for object array items (T9854)', () => {
+    const result = ensureArray([{ title: 'Smoke' }, { title: 'Test' }]);
+    // Items must be objects, not the string literal "[object Object]" (the original bug)
+    expect(result?.every((item) => typeof item !== 'string')).toBe(true);
+    // Verify items are NOT stored as the string "[object Object]" — the pre-fix behaviour
+    expect(result?.some((item) => item === '[object Object]')).toBe(false);
+  });
+
+  it('passes through a mixed array of objects and strings unmodified (T9854)', () => {
+    const mixed = [{ title: 'Task' }, 'raw-string-label'];
+    const result = ensureArray(mixed);
+    expect(result?.[0]).toStrictEqual({ title: 'Task' });
+    expect(result?.[1]).toBe('raw-string-label');
+  });
+
+  it('trims strings within an array but does not touch non-string items (T9854)', () => {
+    const result = ensureArray(['  label-a  ', { key: 'val' }, '  label-b  ']);
+    expect(result?.[0]).toBe('label-a');
+    expect(result?.[1]).toStrictEqual({ key: 'val' });
+    expect(result?.[2]).toBe('label-b');
+  });
 });
 
 describe('sanitizeParams array normalization', () => {
@@ -104,6 +138,38 @@ describe('sanitizeParams array normalization', () => {
   it('normalizes comma-separated depends string to array', () => {
     const result = sanitizeParams({ depends: 'T001,T002' });
     expect(result?.['depends']).toEqual(['T001', 'T002']);
+  });
+
+  // T9854 regression: `tasks` param with array of objects must survive sanitizer intact
+  it('preserves tasks array-of-objects through sanitizeParams (T9854)', () => {
+    const taskSpecs = [
+      { title: 'Smoke A', acceptance: ['x'] },
+      { title: 'Smoke B', parent: 'T100', acceptance: ['y'] },
+    ];
+    const result = sanitizeParams({ tasks: taskSpecs });
+    const sanitizedTasks = result?.['tasks'];
+    expect(Array.isArray(sanitizedTasks)).toBe(true);
+    const arr = sanitizedTasks as unknown[];
+    expect(arr).toHaveLength(2);
+    expect(arr[0]).toStrictEqual({ title: 'Smoke A', acceptance: ['x'] });
+    expect(arr[1]).toStrictEqual({ title: 'Smoke B', parent: 'T100', acceptance: ['y'] });
+  });
+
+  it('does NOT convert task objects to "[object Object]" strings (T9854)', () => {
+    const result = sanitizeParams({
+      tasks: [
+        { title: 'Task A', acceptance: ['a'] },
+        { title: 'Task B', acceptance: ['b'] },
+      ],
+    });
+    const arr = result?.['tasks'] as unknown[];
+    expect(arr.every((item) => item !== '[object Object]')).toBe(true);
+    expect(arr.every((item) => typeof item === 'object' && item !== null)).toBe(true);
+  });
+
+  it('still normalizes string-array params like labels (T9854 non-regression)', () => {
+    const result = sanitizeParams({ labels: 'bug,feature,p1' });
+    expect(result?.['labels']).toEqual(['bug', 'feature', 'p1']);
   });
 });
 

--- a/packages/core/src/security/input-sanitization.ts
+++ b/packages/core/src/security/input-sanitization.ts
@@ -317,17 +317,32 @@ const ARRAY_PARAMS = new Set([
 ]);
 
 /**
- * Normalize a value to an array of strings.
- * Handles external clients sending comma-separated strings where arrays are expected.
+ * Normalize a value to an array, preserving item types.
+ *
+ * - `undefined` / `null` → `undefined`
+ * - Array input → returned as-is (items are NOT coerced; objects, numbers, etc. survive)
+ * - String input → split on `separator`, trimmed, empty segments dropped (CSV expansion)
+ * - Any other scalar → wrapped in a single-element array as a string (e.g. a bare number)
+ *
+ * String-array CSV expansion (e.g. `--labels foo,bar` → `["foo","bar"]`) is preserved.
+ * Object-array params (e.g. `tasks.add-batch` `tasks: [{title,...}, ...]`) are NOT
+ * String()-coerced — the previous behaviour corrupted objects to `"[object Object]"`.
+ * Downstream typed validators (CORE) own per-param type enforcement.
+ *
+ * @task T9854
  */
-export function ensureArray(value: unknown, separator = ','): string[] | undefined {
+export function ensureArray(value: unknown, separator = ','): unknown[] | undefined {
   if (value === undefined || value === null) return undefined;
-  if (Array.isArray(value)) return value.map((v) => (typeof v === 'string' ? v.trim() : String(v)));
+  if (Array.isArray(value)) {
+    // Preserve item types — callers' typed validators enforce string[] vs object[] constraints
+    return value.map((v) => (typeof v === 'string' ? v.trim() : v));
+  }
   if (typeof value === 'string')
     return value
       .split(separator)
       .map((s) => s.trim())
       .filter(Boolean);
+  // Scalar non-string (e.g. bare number from CLI arg) → wrap as string for backward compat
   return [String(value)];
 }
 


### PR DESCRIPTION
## Summary
- `ensureArray()` in `input-sanitization.ts` no longer `String(v)`-coerces array items — objects, arrays, and non-string primitives pass through unchanged
- Restores end-to-end CLI atomicity for `cleo add-batch` which passes `tasks: [{title,...}, ...]` through the sanitizer middleware before reaching CORE
- 7 regression tests added covering object arrays, mixed arrays, CSV expansion non-regression, and full `sanitizeParams` round-trip

## Root cause
`ARRAY_PARAMS` set includes `'tasks'` — so every call through `sanitizeParams` ran `ensureArray()` on the `tasks` param. `ensureArray` called `String(v)` on each array item, turning `{title: "Smoke A", acceptance: [...]}` into the literal string `"[object Object]"`. CORE atomicity (T9814) is correct when called directly; the break was exclusively in the CLI→sanitizer wire.

## Fix path chosen
**Wider type-preservation fix** (not narrower "remove tasks from ARRAY_PARAMS"). Rationale: `ensureArray`'s documented purpose is "make sure this is an array" — not "stringify everything". String coercion was never correct for object-array params. The wider fix prevents this bug class for any future object-array param (e.g. anything like `tasks`), not just this one instance.

Return type: `string[] | undefined` → `unknown[] | undefined`. Downstream typed validators (CORE) own per-param type enforcement. The sanitizer's job is shape normalization only.

CSV string expansion (`--labels foo,bar` → `["foo","bar"]`) is preserved unchanged.

## Test plan
- [x] `ensureArray([{a:1},{b:2}])` returns `[{a:1},{b:2}]` (deep-equal, no `"[object Object]"`)
- [x] `ensureArray(['a','b'])` → `['a','b']` (string array unchanged)
- [x] `ensureArray('a,b,c')` → `['a','b','c']` (CSV expansion preserved)
- [x] `ensureArray(null/undefined)` → `undefined`
- [x] Mixed array `[{title:'Task'}, 'raw-string']` passes through correctly
- [x] `sanitizeParams({ tasks: [{title,...}, ...] })` preserves all task object structure
- [x] `sanitizeParams({ labels: 'bug,feature,p1' })` still produces `['bug','feature','p1']` (non-regression)
- [x] All 38 security.test.ts tests green
- [x] All 11 add-batch.test.ts tests green
- [x] Pre-existing full-suite failures in cleo domain tests (saga ops list, T9854-unrelated) confirmed pre-existing on base commit — not introduced by this PR

Closes T9854. Unblocks Epic T9813.

🤖 Worker for T9854