### PR TITLE
release(T9800): ship v2026.5.96 — Saga SG-WORKTREE-CANON (9 epics, 8 PRs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,83 @@
 # Changelog
 
+## [2026.5.96] (2026-05-21)
+
+Ships Saga **T9800 SG-WORKTREE-CANON** end-to-end — 9 epics + 1 council sub-task,
+8 PRs merged, council verdict **D009** (hybrid XDG-external + in-project
+`.cleo/worktrees.json` sentinel index) executed.
+
+### Features
+
+- **Council D009 hybrid**: keep XDG-external worktree checkout location
+  (`~/.local/share/cleo/worktrees/<projectHash>/<taskId>/`); add in-project
+  `<repo>/.cleo/worktrees.json` SENTINEL INDEX (FILE not directory) for
+  discoverability. Verdict 4/5 consensus (Christensen/Drucker/Porter/Taleb/Meadows). (T9812)
+- **`cleo worktree adopt`**: register externally-created worktrees
+  (e.g. Claude Code Agent `isolation:worktree`) in the CLEO SSoT via the
+  sentinel index. `cleo worktree list` is now a multi-source union of
+  `git worktree list --porcelain` + sentinel entries with `source` field
+  (`cleo-spawn` / `claude-agent` / `manual` / `adopted`). (T9804) (#440)
+- **`cleo worktree destroy --pr <num>`** subcommand + `cleo worktree prune
+  --idle-days <N>` flag + `.cleo/audit/worktree-lifecycle.jsonl` audit log
+  + `.github/workflows/worktree-cleanup.yml` GHA workflow that triggers on
+  PR merge events. (T9805) (#437)
+- **`cleo doctor --audit-worktree-orphans`** comprehensive scan: detects
+  `.cleo/` directories inside any worktree path, worktrees outside
+  canonical XDG location, rogue `<repo>/.cleo/worktrees/` directories
+  (council D009 forbids — only `.json` sentinel allowed). (T9808) (#441)
+- **`packages/paths` SSoT**: new `resolveWorktreeIndexPath()` helper
+  returning the canonical sentinel path. `scripts/lint-paths-ssot.mjs`
+  CI gate prevents new env-paths / `process.cwd() + .cleo` /
+  hand-rolled-worktree-path drift via baseline allowlist. (T9802) (#436)
+- **`cleo orchestrate spawn --scope <path>`** flag enables sparse-checkout
+  cone mode — agents check out only the requested subtree (97% disk
+  reduction in the T9807 benchmark for `--scope packages/cleo`). (T9807)
+  (#438)
+
+### Fixes (root-cause)
+
+- **`getCleoDirAbsolute` throws instead of silent orphan synthesis**
+  (Meadows leverage point per council D009). Pre-fix, line 305 of
+  `packages/core/src/paths.ts` caught `getProjectRoot` failures and
+  silently fell back to `<cwd>/.cleo` — synthesizing orphan `.cleo/`
+  directories inside worktrees that any downstream `mkdirSync` would
+  materialize. Surgical refinement (post CI feedback): throws ONLY when
+  cwd has a worktree gitlink ancestor (`.git` as FILE), allowing
+  fallback for clean-slate test fixtures. Closes the 25+ leaked
+  `.cleo/` orphan bug class catalogued in the T9801 forensic audit.
+  (T9803) (#389)
+- **DB chokepoint refuses worktree-resident `.cleo/` opens**:
+  defense-in-depth in `openCleoDb()` — after path resolution, asserts
+  the resolved `.cleo/`'s parent has `.git` as a real DIRECTORY (not a
+  gitlink FILE). Throws `E_WT_DB_ISOLATION_VIOLATION` unless
+  `CLEO_ALLOW_WORKTREE_DB_CREATE=1` is set (audited to stderr).
+  Catches the residual case where a pre-T9803 leaked `.cleo/` already
+  exists inside a worktree. (T9806) (#406)
+- **BAN worktrees outside canonical XDG location**:
+  `assertCanonicalWorktreeLocation()` in `packages/worktree/worktree-create.ts`
+  throws `E_WT_LOCATION_FORBIDDEN` for any path outside
+  `<cleoHome>/worktrees/`. No escape hatch — not even `CLEO_FORCE_LOCATION`
+  env var. `scripts/lint-worktree-location.mjs` CI gate fails on rogue
+  trees at project root, sibling `/mnt/projects/*`, or nested inside
+  another worktree. `scripts/migrate-rogue-worktrees.mjs` dry-runnable +
+  idempotent migration tool with `.cleo/backups/rogue-worktrees-<ts>.tar.gz`
+  archive-before-move. (T9809) (#435)
+- **Bound the include-pattern apply loop** in
+  `packages/worktree/src/worktree-include.ts` — fixes the 60s `cleo
+  orchestrate spawn` `E_TIMEOUT` regression catalogued in the T9801
+  audit appendix B (root cause: unbounded retry on
+  `.vscode/settings.json` symlink failure). (T9807) (#438)
+
+### Audit + closure
+
+- T9801 forensic audit (SSoT slug `sg-t9800-worktree-forensic-audit`):
+  40 worktrees inventoried, 5 creation sites identified, 3 helper drift
+  cases catalogued, GSD-2 reference compared. (T9801)
+- T9808 saga closure report (SSoT slug `sg-worktree-canon-closure-report`):
+  per-epic shipped/deferred matrix, before/after metrics. (T9808) (#441)
+- `scripts/lint-agent-worktree-isolation.mjs` non-blocking warning gate
+  flags `EnterWorktree` invocations in agent transcripts. (T9808) (#441)
+
 ## [2026.5.95] (2026-05-21)
 
 ### BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.95",
+  "version": "2026.5.96",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Summary

Ships **Saga T9800 SG-WORKTREE-CANON** end-to-end — 9 epics, 8 PRs merged today, council verdict **D009** (hybrid XDG-external + `<repo>/.cleo/worktrees.json` sentinel index) fully delivered.

## Member PRs (all merged to main)

| PR | Epic | Title |
|----|------|-------|
| #389 | T9803 | `paths.ts:305` throw instead of orphan `.cleo/` synthesis (Meadows leverage) |
| #406 | T9806 | DB chokepoint refuses worktree-resident `.cleo/` (E_WT_DB_ISOLATION_VIOLATION) |
| #435 | T9809 | BAN rogue locations + migration tool (no escape hatch) |
| #436 | T9802 | paths SSoT lint + `resolveWorktreeIndexPath` sentinel helper |
| #437 | T9805 | Worktree lifecycle audit log + auto-cleanup GHA workflow |
| #438 | T9807 | Bound include-pattern loop (fix 60s timeout) + `--scope` sparse-checkout |
| #440 | T9804 | `cleo worktree adopt` + multi-source list (Claude isolation bridge) |
| #441 | T9808 | `cleo doctor --audit-worktree-orphans` + isolation lint + saga closure report |

## Closes bug class

The T9550/T9580 orphan-`.cleo/` bug class catalogued in the T9801 forensic audit is now structurally impossible:
- T9803 closes the synthesis vector at the path-resolution layer.
- T9806 adds defense-in-depth at the DB-open chokepoint.
- T9809 bans rogue worktree locations.
- T9805 auto-cleans worktrees + branches on PR merge.

## Audit + closure docs

- Forensic audit (SSoT): `cleo docs fetch sg-t9800-worktree-forensic-audit`
- Closure report (SSoT): `cleo docs fetch sg-worktree-canon-closure-report`
- Council verdict: BRAIN decision **D009**

## Test plan

- [x] All 8 member PRs CI green individually (passed `pr:<num>` evidence atom verification).
- [x] Saga T9800 verified: `cleo verify T9800 --gate {implemented,testsPassed,qaPassed} --evidence "pr:441;..."` all passed.
- [x] Release plan written: `.cleo/release/v2026.5.96.plan.json`.
- [ ] CI on this PR to confirm version-bump cascade.
- [ ] Post-merge: `git push origin v2026.5.96` triggers `release.yml` auto-publish to npm via OIDC.
- [ ] Post-install dogfood: 194 orphan `.cleo/` dirs in `.claude/worktrees/` cleaned via `cleo doctor --audit-worktree-orphans` + `cleo worktree migrate-rogue --dry-run` then execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)