### PR TITLE
feat(T9973): cleo focus macro — single-envelope orientation (8→1)

### DIFF
--- a/packages/cleo/src/cli/__tests__/focus.test.ts
+++ b/packages/cleo/src/cli/__tests__/focus.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for `cleo focus` — single-envelope task orientation.
+ *
+ * Covers three scope types:
+ *   1. Task scope  — focus on a task (T####)
+ *   2. Epic scope  — focus on an Epic
+ *   3. Saga scope  — focus on a Saga (with members)
+ *
+ * Registry and CLI-shape tests are pure (no DB). Handler unit-tests use
+ * `vi.mock` at the module level (hoisted by Vitest) so they do not touch
+ * any real database.
+ *
+ * @task T9973
+ * @epic T9964 E-ORIENT-V2
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module-level mocks (hoisted by Vitest before any import is resolved)
+// ---------------------------------------------------------------------------
+
+// Mock @cleocode/animations (not built in test env — imported by animation-bridge.ts
+// which is transitively pulled in by dispatch/adapters/cli.ts → focusCommand).
+vi.mock('@cleocode/animations', () => ({
+  createAnimateContext: vi.fn().mockReturnValue({ start: vi.fn(), stop: vi.fn() }),
+  spinnerFrames: {},
+}));
+
+// Mock @cleocode/core so CLI imports do not blow up in a non-project context.
+vi.mock('@cleocode/core', () => ({
+  getProjectRoot: vi.fn().mockReturnValue('/tmp/test-project'),
+  pushWarning: vi.fn(),
+  getLogger: vi
+    .fn()
+    .mockReturnValue({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+// Provide overrides for @cleocode/core/internal — spread importOriginal so
+// every other export (llmList, llmTest, etc.) keeps its real binding.
+vi.mock('@cleocode/core/internal', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@cleocode/core/internal')>();
+  return {
+    ...actual,
+    taskShow: vi.fn(),
+    taskRelates: vi.fn(),
+    orchestrateReady: vi.fn(),
+    createAttachmentStore: vi.fn(),
+    memoryFind: vi.fn(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Lazy imports (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import {
+  createAttachmentStore,
+  memoryFind,
+  orchestrateReady,
+  taskRelates,
+  taskShow,
+} from '@cleocode/core/internal';
+import { FocusHandler } from '../../dispatch/domains/focus.js';
+import { resolve, validateRequiredParams } from '../../dispatch/registry.js';
+import { focusCommand } from '../commands/focus.js';
+
+// ---------------------------------------------------------------------------
+// Shared mock store (used by all handler tests)
+// ---------------------------------------------------------------------------
+
+const mockStore = {
+  listByOwner: vi.fn().mockResolvedValue([]),
+  getExtras: vi.fn().mockResolvedValue(null),
+};
+vi.mocked(createAttachmentStore).mockReturnValue(
+  mockStore as ReturnType<typeof createAttachmentStore>,
+);
+
+const emptyMemory = { success: true, data: { results: [], total: 0, tokensEstimated: 0 } };
+vi.mocked(memoryFind).mockResolvedValue(emptyMemory);
+
+const emptyReady = { success: true, data: { epicId: 'T9964', readyTasks: [], total: 0 } };
+vi.mocked(orchestrateReady).mockResolvedValue(emptyReady);
+
+const emptyRelates = { success: true, data: { taskId: 'T9831', relations: [], count: 0 } };
+vi.mocked(taskRelates).mockResolvedValue(emptyRelates);
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal task record
+// ---------------------------------------------------------------------------
+
+function makeTask(
+  overrides: Partial<{
+    id: string;
+    title: string;
+    type: string;
+    status: string;
+    parentId: string | null;
+    labels: string[];
+    depends: string[];
+    blockedBy: string[];
+  }> = {},
+) {
+  return {
+    id: overrides.id ?? 'T9973',
+    title: overrides.title ?? 'Test task',
+    type: overrides.type ?? 'task',
+    status: overrides.status ?? 'active',
+    parentId: overrides.parentId ?? null,
+    labels: overrides.labels ?? [],
+    depends: overrides.depends ?? [],
+    blockedBy: overrides.blockedBy ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Registry wiring
+// ---------------------------------------------------------------------------
+
+describe('focus.show — dispatch registry wiring (T9973)', () => {
+  it('focus.show resolves through the dispatch registry', () => {
+    const result = resolve('query', 'focus', 'show');
+    expect(result, 'focus.show must be registered as a query operation').toBeDefined();
+    expect(result!.domain).toBe('focus');
+    expect(result!.operation).toBe('show');
+  });
+
+  it('focus.show is a tier-0 idempotent query (no session required)', () => {
+    const result = resolve('query', 'focus', 'show');
+    expect(result).toBeDefined();
+    expect(result!.def.gateway).toBe('query');
+    expect(result!.def.tier).toBe(0);
+    expect(result!.def.idempotent).toBe(true);
+    expect(result!.def.sessionRequired).toBe(false);
+  });
+
+  it('focus.show requires the id param', () => {
+    const result = resolve('query', 'focus', 'show');
+    expect(result).toBeDefined();
+    const missing = validateRequiredParams(result!.def, {});
+    expect(missing).toContain('id');
+  });
+
+  it('id param satisfies required params check', () => {
+    const result = resolve('query', 'focus', 'show');
+    expect(result).toBeDefined();
+    const missing = validateRequiredParams(result!.def, { id: 'T9973' });
+    expect(missing).toEqual([]);
+  });
+
+  it('focus.show does NOT resolve as a mutate', () => {
+    const mutate = resolve('mutate', 'focus', 'show');
+    expect(mutate).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. CLI command shape
+// ---------------------------------------------------------------------------
+
+describe('focusCommand — CLI command shape (T9973)', () => {
+  it('exports focusCommand as a defined command', () => {
+    expect(focusCommand).toBeDefined();
+  });
+
+  it('has meta.name === "focus"', () => {
+    const meta = typeof focusCommand.meta === 'function' ? focusCommand.meta() : focusCommand.meta;
+    expect((meta as { name: string }).name).toBe('focus');
+  });
+
+  it('description mentions "single-envelope" or "orientation"', () => {
+    const meta = typeof focusCommand.meta === 'function' ? focusCommand.meta() : focusCommand.meta;
+    const desc = (meta as { description?: string }).description ?? '';
+    expect(desc.toLowerCase()).toMatch(/orientation|single-envelope/);
+  });
+
+  it('has a required positional arg "id"', () => {
+    const args = focusCommand.args as
+      | Record<string, { type?: string; required?: boolean }>
+      | undefined;
+    expect(args).toBeDefined();
+    expect(args!['id']).toBeDefined();
+    expect(args!['id'].type).toBe('positional');
+    expect(args!['id'].required).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. FocusHandler — missing id
+// ---------------------------------------------------------------------------
+
+describe('FocusHandler — missing id (T9973)', () => {
+  it('returns E_INVALID_INPUT when id is missing', async () => {
+    const handler = new FocusHandler();
+    const response = await handler.query('show', {});
+    expect(response.success).toBe(false);
+    expect(response.error?.code).toBe('E_INVALID_INPUT');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. FocusHandler — task scope
+// ---------------------------------------------------------------------------
+
+describe('FocusHandler — task scope (T9973)', () => {
+  it('returns a complete focus envelope for a valid task', async () => {
+    vi.mocked(taskShow).mockResolvedValue({
+      success: true,
+      data: {
+        task: makeTask({ id: 'T9973', type: 'task', parentId: 'T9964' }),
+        view: null,
+      },
+    });
+    vi.mocked(orchestrateReady).mockResolvedValue({
+      success: true,
+      data: {
+        epicId: 'T9964',
+        readyTasks: [{ id: 'T9973', title: 'focus macro', priority: 'high', depends: [] }],
+        total: 1,
+      },
+    });
+
+    const handler = new FocusHandler();
+    const response = await handler.query('show', { id: 'T9973' });
+    expect(response.success).toBe(true);
+
+    const data = response.data as {
+      identity: { id: string; type: string };
+      scope: { taskId?: string; epicId?: string };
+      blockers: unknown[];
+      tokensEstimated: number;
+      readyWave?: unknown[];
+    };
+
+    expect(data.identity.id).toBe('T9973');
+    expect(data.identity.type).toBe('task');
+    expect(data.scope.taskId).toBe('T9973');
+    expect(data.scope.epicId).toBe('T9964');
+    expect(Array.isArray(data.blockers)).toBe(true);
+    expect(typeof data.tokensEstimated).toBe('number');
+    expect(data.tokensEstimated).toBeGreaterThan(0);
+    expect(Array.isArray(data.readyWave)).toBe(true);
+  });
+
+  it('returns E_NOT_FOUND for an unknown task ID', async () => {
+    vi.mocked(taskShow).mockResolvedValue({
+      success: false,
+      error: { code: 'E_NOT_FOUND', message: 'Task not found: T0001' },
+    });
+
+    const handler = new FocusHandler();
+    const response = await handler.query('show', { id: 'T0001' });
+    expect(response.success).toBe(false);
+    expect(response.error?.code).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. FocusHandler — epic scope
+// ---------------------------------------------------------------------------
+
+describe('FocusHandler — epic scope (T9973)', () => {
+  it('resolves scope.epicId when focused on an Epic directly', async () => {
+    vi.mocked(taskShow).mockResolvedValue({
+      success: true,
+      data: {
+        task: makeTask({ id: 'T9964', title: 'E-ORIENT-V2', type: 'epic', parentId: null }),
+        view: null,
+      },
+    });
+    vi.mocked(orchestrateReady).mockResolvedValue({
+      success: true,
+      data: { epicId: 'T9964', readyTasks: [], total: 0 },
+    });
+
+    const handler = new FocusHandler();
+    const response = await handler.query('show', { id: 'T9964' });
+    expect(response.success).toBe(true);
+
+    const data = response.data as {
+      identity: { type: string };
+      scope: { epicId?: string; taskId?: string };
+    };
+    expect(data.identity.type).toBe('epic');
+    expect(data.scope.epicId).toBe('T9964');
+    expect(data.scope.taskId).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. FocusHandler — saga scope
+// ---------------------------------------------------------------------------
+
+describe('FocusHandler — saga scope (T9973)', () => {
+  const SAGA_ID = 'T9831';
+  const MEMBER_EPIC_ID = 'T9832';
+
+  it('resolves scope.sagaId and populates members when focused on a Saga', async () => {
+    // First call = saga itself; second call = member epic
+    vi.mocked(taskShow)
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          task: makeTask({
+            id: SAGA_ID,
+            title: 'SG-ARCH-SOLID',
+            type: 'epic',
+            parentId: null,
+            labels: ['saga'],
+          }),
+          view: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          task: makeTask({
+            id: MEMBER_EPIC_ID,
+            title: 'E-CONTRACTS-FOUNDATION',
+            type: 'epic',
+            status: 'done',
+            parentId: SAGA_ID,
+          }),
+          view: null,
+        },
+      });
+
+    vi.mocked(taskRelates).mockResolvedValue({
+      success: true,
+      data: {
+        taskId: SAGA_ID,
+        relations: [{ taskId: MEMBER_EPIC_ID, type: 'groups' }],
+        count: 1,
+      },
+    });
+
+    vi.mocked(orchestrateReady).mockResolvedValue({
+      success: true,
+      data: { epicId: SAGA_ID, readyTasks: [], total: 0 },
+    });
+
+    const handler = new FocusHandler();
+    const response = await handler.query('show', { id: SAGA_ID });
+    expect(response.success).toBe(true);
+
+    const data = response.data as {
+      identity: { type: string };
+      scope: { sagaId?: string };
+      members?: Array<{ epicId: string; status: string }>;
+    };
+
+    expect(data.identity.type).toBe('saga');
+    expect(data.scope.sagaId).toBe(SAGA_ID);
+    expect(Array.isArray(data.members)).toBe(true);
+    expect(data.members!.some((m) => m.epicId === MEMBER_EPIC_ID)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. FocusHandler — unsupported operations
+// ---------------------------------------------------------------------------
+
+describe('FocusHandler — unsupported operations (T9973)', () => {
+  it('returns unsupported error for mutate operations', async () => {
+    const handler = new FocusHandler();
+    const response = await handler.mutate('show', { id: 'T9973' });
+    expect(response.success).toBe(false);
+    expect(response.error?.code).toBeDefined();
+  });
+
+  it('getSupportedOperations returns only query:show', () => {
+    const handler = new FocusHandler();
+    const ops = handler.getSupportedOperations();
+    expect(ops.query).toContain('show');
+    expect(ops.mutate).toEqual([]);
+  });
+});

--- a/packages/cleo/src/cli/commands/focus.ts
+++ b/packages/cleo/src/cli/commands/focus.ts
@@ -1,0 +1,57 @@
+/**
+ * CLI focus command — single-envelope task orientation.
+ *
+ * Replaces the 8-call pattern (show + list + memory find + docs list +
+ * git log + gh pr list + nexus context etc.) with one envelope containing:
+ *   - identity + scope
+ *   - members (saga only)
+ *   - blockers
+ *   - ready wave (next parallel-safe tasks from parent epic)
+ *   - attached docs
+ *   - recent git activity (last 5 commits mentioning the task ID)
+ *   - brain context (≤ 3 entries per category, scope-filtered)
+ *
+ * Token budget: ≤ 1 500 tokens for typical task orientation.
+ *
+ * Usage: cleo focus <id>
+ *
+ * @task T9973
+ * @epic T9964 E-ORIENT-V2
+ */
+
+import { defineCommand } from 'citty';
+import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
+
+/**
+ * `cleo focus <id>` — single-envelope task orientation.
+ *
+ * Orient on a task, epic, or saga with one call instead of eight.
+ * Aggregates identity, scope, members, blockers, ready wave, attached docs,
+ * recent git activity, and brain context into a single LAFS envelope.
+ *
+ * @task T9973
+ * @epic T9964
+ */
+export const focusCommand = defineCommand({
+  meta: {
+    name: 'focus',
+    description:
+      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+  },
+  args: {
+    id: {
+      type: 'positional',
+      description: 'Task, Epic, or Saga ID to orient on (e.g. T9973, T9831)',
+      required: true,
+    },
+  },
+  async run({ args }) {
+    await dispatchFromCli(
+      'query',
+      'focus',
+      'show',
+      { id: args['id'] as string },
+      { command: 'focus' },
+    );
+  },
+});

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -45,7 +44,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description:
+      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,8 +63,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +84,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,20 +102,23 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -135,7 +141,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -244,7 +251,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -267,14 +275,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -298,7 +308,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -309,7 +320,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -322,7 +334,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -358,7 +371,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -381,7 +395,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description:
+      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -412,7 +427,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -435,14 +451,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -471,7 +490,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -513,14 +533,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -549,7 +572,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -561,13 +585,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -610,7 +636,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -621,7 +648,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -657,7 +685,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description:
+      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -669,7 +698,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -681,7 +711,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -729,13 +760,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description:
+      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -813,7 +846,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -825,13 +859,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description:
+      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -44,8 +45,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description:
-      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -84,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -102,23 +99,20 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -141,8 +135,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -251,8 +244,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -275,16 +267,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -308,8 +298,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -320,8 +309,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -334,8 +322,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -371,8 +358,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -391,6 +377,12 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'find',
     description: 'Fuzzy search tasks by title/description',
     load: async () => (await import('../commands/find.js')).findCommand as CommandDef,
+  },
+  {
+    exportName: 'focusCommand',
+    name: 'focus',
+    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
     exportName: 'gcCommand',
@@ -420,8 +412,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -444,17 +435,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -483,8 +471,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -526,17 +513,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -565,8 +549,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -578,15 +561,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -629,8 +610,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -641,8 +621,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description:
-      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -678,8 +657,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description:
-      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -691,8 +669,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -704,8 +681,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -753,15 +729,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -839,8 +813,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -852,15 +825,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description:
-      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/dispatch/domains/focus.ts
+++ b/packages/cleo/src/dispatch/domains/focus.ts
@@ -1,0 +1,463 @@
+/**
+ * Focus Domain Handler (Dispatch Layer)
+ *
+ * Implements `cleo focus <id>` — a single-envelope orientation call that
+ * replaces the 8-call pattern:
+ *   1. tasks.show              → identity + scope + blockers
+ *   2. tasks.saga.members/rollup → members (saga only), via taskRelates
+ *   3. orchestrate.ready       → readyWave (epic / task with parent epic)
+ *   4. docs store              → attachedDocs
+ *   5. memory.find             → brainContext (scope-filtered, ≤ 3 each)
+ *   6. git log --grep          → recentActivity (last 5 commits)
+ *
+ * All sub-calls run in parallel where possible via `Promise.allSettled`.
+ * Failures are silently swallowed so a missing store never blocks `cleo focus`.
+ *
+ * Token budget: ≤ 1 500 tokens for typical task orientation.
+ *
+ * @task T9973
+ * @epic T9964 E-ORIENT-V2
+ */
+
+import { execSync } from 'node:child_process';
+import type {
+  FocusAttachedDoc,
+  FocusBlocker,
+  FocusBrainContext,
+  FocusIdentity,
+  FocusReadyTask,
+  FocusRecentCommit,
+  FocusSagaMember,
+  FocusShowResult,
+} from '@cleocode/contracts/operations/focus';
+import type { MemoryCompactHit } from '@cleocode/contracts/operations/memory';
+import { getProjectRoot } from '@cleocode/core';
+import {
+  createAttachmentStore,
+  memoryFind,
+  orchestrateReady,
+  taskRelates,
+  taskShow,
+} from '@cleocode/core/internal';
+import { lafsSuccess } from '../adapters/typed.js';
+import type { DispatchResponse, DomainHandler } from '../types.js';
+import { handleErrorResult, unsupportedOp } from './_base.js';
+import { dispatchMeta } from './_meta.js';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate the token weight of a value using the ~4 chars-per-token heuristic.
+ *
+ * @param value - Any serialisable value.
+ *
+ * @internal
+ */
+function roughTokenCount(value: unknown): number {
+  try {
+    return Math.ceil(JSON.stringify(value).length / 4);
+  } catch {
+    return 0;
+  }
+}
+
+/** Pattern for a valid CLEO task ID (`T####`). */
+const TASK_ID_RE = /^T\d+$/i;
+
+/**
+ * Fetch up to 5 recent git commits mentioning `taskId` via `git log --grep`.
+ *
+ * Returns an empty array on any git failure so the envelope is never blocked.
+ *
+ * @param taskId      - Task ID to grep for in commit messages.
+ * @param projectRoot - Absolute project root (must be a git repo root).
+ *
+ * @internal
+ */
+function fetchRecentActivity(taskId: string, projectRoot: string): FocusRecentCommit[] {
+  try {
+    const raw = execSync(`git log --grep="${taskId}" --pretty=format:"%H\t%s\t%aI" -n 5`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: projectRoot,
+    });
+    return raw
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const parts = line.split('\t');
+        return {
+          commitSha: parts[0] ?? '',
+          message: parts[1] ?? '',
+          date: parts[2] ?? '',
+        };
+      })
+      .filter((c) => c.commitSha !== '');
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Collect task-scoped attachment entries from the docs store.
+ *
+ * Always resolves — returns `[]` on any failure.
+ *
+ * @param projectRoot - Absolute project root.
+ * @param taskId      - Owner task ID.
+ *
+ * @internal
+ */
+async function fetchAttachedDocs(projectRoot: string, taskId: string): Promise<FocusAttachedDoc[]> {
+  try {
+    const store = createAttachmentStore();
+    const metas = await store.listByOwner('task', taskId, projectRoot);
+    const entries: FocusAttachedDoc[] = [];
+    for (const meta of metas) {
+      const extras = await store.getExtras(meta.id, projectRoot);
+      entries.push({
+        attachmentId: meta.id,
+        kind: meta.attachment.kind,
+        ...(extras?.slug != null ? { slug: extras.slug } : {}),
+        ...(extras?.type != null ? { type: extras.type } : {}),
+      });
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Fetch scope-filtered brain context — up to 3 entries per category.
+ *
+ * Queries observations, decisions, and learnings in parallel, each scoped
+ * to the task ID query. Returns `undefined` on complete failure so the
+ * envelope field is omitted cleanly.
+ *
+ * @param taskId - Task ID to use as the search query.
+ *
+ * @internal
+ */
+async function fetchBrainContext(taskId: string): Promise<FocusBrainContext | undefined> {
+  try {
+    const [obsResult, decResult, lrnResult] = await Promise.allSettled([
+      memoryFind({ query: taskId, limit: 3, tables: ['observations'] }),
+      memoryFind({ query: taskId, limit: 3, tables: ['decisions'] }),
+      memoryFind({ query: taskId, limit: 3, tables: ['learnings'] }),
+    ]);
+
+    const toHits = (
+      r: PromiseSettledResult<Awaited<ReturnType<typeof memoryFind>>>,
+    ): MemoryCompactHit[] => {
+      if (r.status !== 'fulfilled' || !r.value.success) return [];
+      const data = r.value.data as { results?: MemoryCompactHit[] } | undefined;
+      return (data?.results ?? []).slice(0, 3);
+    };
+
+    return {
+      observations: toHits(obsResult),
+      learnings: toHits(lrnResult),
+      decisions: toHits(decResult),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve Saga member Epics with titles and statuses using `taskRelates`.
+ *
+ * @param projectRoot - Absolute project root.
+ * @param sagaId      - Saga identifier.
+ *
+ * @internal
+ */
+async function fetchSagaMembersWithTitles(
+  projectRoot: string,
+  sagaId: string,
+): Promise<FocusSagaMember[]> {
+  try {
+    const relResult = await taskRelates(projectRoot, sagaId);
+    if (!relResult.success) return [];
+
+    const memberIds = (relResult.data?.relations ?? [])
+      .filter((r) => r.type === 'groups')
+      .map((r) => r.taskId);
+
+    if (memberIds.length === 0) return [];
+
+    const showResults = await Promise.allSettled(
+      memberIds.map((epicId) => taskShow(projectRoot, epicId)),
+    );
+
+    return showResults
+      .map((r, i) => {
+        const epicId = memberIds[i] ?? '';
+        if (r.status !== 'fulfilled' || !r.value.success) {
+          return { epicId, title: epicId, status: 'unknown' };
+        }
+        const t = r.value.data!.task;
+        return { epicId: t.id, title: t.title, status: t.status };
+      })
+      .filter((m) => m.epicId !== '');
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core aggregator
+// ---------------------------------------------------------------------------
+
+/** Opaque error shape returned when the target entity cannot be loaded. */
+interface FocusError {
+  error: { code: string; message: string };
+}
+
+/**
+ * Build the focus envelope for a given task, epic, or saga ID.
+ *
+ * @param id          - Task / Epic / Saga identifier.
+ * @param projectRoot - Absolute project root.
+ *
+ * @internal
+ */
+async function buildFocusEnvelope(
+  id: string,
+  projectRoot: string,
+): Promise<FocusShowResult | FocusError> {
+  // ── 1. Core task record ───────────────────────────────────────────────────
+  const showResult = await taskShow(projectRoot, id);
+  if (!showResult.success) {
+    return {
+      error: {
+        code: showResult.error?.code?.toString() ?? 'E_NOT_FOUND',
+        message: showResult.error?.message ?? `Task not found: ${id}`,
+      },
+    };
+  }
+
+  const task = showResult.data!.task;
+
+  // ── 2. Determine entity tier ──────────────────────────────────────────────
+  const labels = Array.isArray(task.labels) ? (task.labels as string[]) : [];
+  const isSaga = labels.includes('saga');
+  const isEpic = task.type === 'epic' && !isSaga;
+  const entityType = isSaga ? 'saga' : isEpic ? 'epic' : 'task';
+
+  // ── 3. Identity ───────────────────────────────────────────────────────────
+  const identity: FocusIdentity = {
+    id: task.id,
+    title: task.title,
+    type: entityType,
+    status: task.status,
+    ...(task.parentId != null ? { parentId: task.parentId } : {}),
+  };
+
+  // ── 4. Scope ──────────────────────────────────────────────────────────────
+  const scope: { sagaId?: string; epicId?: string; taskId?: string } = {};
+  if (entityType === 'task') {
+    scope.taskId = task.id;
+    if (task.parentId) scope.epicId = task.parentId;
+  } else if (entityType === 'epic') {
+    scope.epicId = task.id;
+  } else {
+    scope.sagaId = task.id;
+  }
+
+  // ── 5. Blockers (sequential — N is typically small) ───────────────────────
+  const blockers: FocusBlocker[] = [];
+
+  // Honour explicit `blockedBy` first
+  const explicitBlockers: string[] = Array.isArray(task.blockedBy)
+    ? (task.blockedBy as string[])
+    : [];
+
+  // Fall back to unresolved `depends` entries
+  const unresolvedDepends: string[] = [];
+  if (explicitBlockers.length === 0 && Array.isArray(task.depends)) {
+    for (const depId of task.depends as string[]) {
+      const dRes = await taskShow(projectRoot, depId).catch(() => null);
+      if (dRes?.success && dRes.data) {
+        const s = dRes.data.task.status;
+        if (s !== 'done' && s !== 'cancelled') {
+          unresolvedDepends.push(depId);
+          blockers.push({
+            id: depId,
+            title: dRes.data.task.title,
+            reason: `dependency not resolved (status: ${s})`,
+          });
+        }
+      }
+    }
+  }
+
+  if (explicitBlockers.length > 0) {
+    await Promise.allSettled(
+      explicitBlockers.map(async (bid) => {
+        const bRes = await taskShow(projectRoot, bid).catch(() => null);
+        blockers.push({
+          id: bid,
+          title: bRes?.success ? (bRes.data?.task.title ?? bid) : bid,
+          reason: bRes?.success ? (bRes.data?.task.status ?? 'unknown') : 'unknown',
+        });
+      }),
+    );
+  }
+
+  // ── 6. Parent epic for ready wave ─────────────────────────────────────────
+  const epicIdForReady =
+    entityType === 'epic'
+      ? task.id
+      : entityType === 'task' && task.parentId
+        ? task.parentId
+        : undefined;
+
+  // ── 7. Parallel sub-calls ─────────────────────────────────────────────────
+  const [sagaMembersResult, readyResult, docsResult, brainResult] = await Promise.allSettled([
+    isSaga
+      ? fetchSagaMembersWithTitles(projectRoot, id)
+      : Promise.resolve(undefined as FocusSagaMember[] | undefined),
+
+    epicIdForReady && TASK_ID_RE.test(epicIdForReady)
+      ? orchestrateReady(epicIdForReady, projectRoot)
+      : Promise.resolve(null),
+
+    fetchAttachedDocs(projectRoot, id),
+
+    fetchBrainContext(id),
+  ]);
+
+  // ── 8. Recent git activity (sync, cheap) ──────────────────────────────────
+  const recentActivity = fetchRecentActivity(id, projectRoot);
+
+  // ── 9. Assemble result ────────────────────────────────────────────────────
+
+  const members: FocusSagaMember[] | undefined =
+    sagaMembersResult.status === 'fulfilled' && sagaMembersResult.value != null
+      ? sagaMembersResult.value
+      : undefined;
+
+  let readyWave: FocusReadyTask[] | undefined;
+  if (readyResult.status === 'fulfilled' && readyResult.value?.success) {
+    const rData = readyResult.value.data as
+      | { readyTasks?: Array<{ id: string; title: string; priority: string; depends: string[] }> }
+      | undefined;
+    const rTasks = rData?.readyTasks ?? [];
+    if (rTasks.length > 0) {
+      readyWave = rTasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        priority: t.priority,
+        depends: t.depends,
+      }));
+    }
+  }
+
+  const attachedDocs: FocusAttachedDoc[] | undefined =
+    docsResult.status === 'fulfilled' && docsResult.value.length > 0 ? docsResult.value : undefined;
+
+  const brainContext: FocusBrainContext | undefined =
+    brainResult.status === 'fulfilled' ? brainResult.value : undefined;
+
+  const envelope: FocusShowResult = {
+    identity,
+    scope,
+    ...(members != null ? { members } : {}),
+    blockers,
+    ...(readyWave != null ? { readyWave } : {}),
+    ...(attachedDocs != null ? { attachedDocs } : {}),
+    ...(recentActivity.length > 0 ? { recentActivity } : {}),
+    ...(brainContext != null ? { brainContext } : {}),
+    tokensEstimated: 0,
+  };
+
+  envelope.tokensEstimated = roughTokenCount(envelope);
+  return envelope;
+}
+
+// ---------------------------------------------------------------------------
+// Domain handler
+// ---------------------------------------------------------------------------
+
+const QUERY_OPS = new Set<string>(['show']);
+
+/**
+ * Domain handler for `cleo focus` — single-envelope task orientation.
+ *
+ * Aggregates identity, scope, members, blockers, readyWave, attachedDocs,
+ * recentActivity, and brainContext into one LAFS response, replacing 8
+ * sequential CLI calls with a single parallel dispatch.
+ *
+ * There are no mutate operations in this domain.
+ *
+ * @task T9973
+ * @epic T9964
+ */
+export class FocusHandler implements DomainHandler {
+  /**
+   * Execute a read-only focus query operation.
+   *
+   * @param operation - Operation name (`'show'`).
+   * @param params    - Raw params (must contain `id: string`).
+   */
+  async query(operation: string, params?: Record<string, unknown>): Promise<DispatchResponse> {
+    const startTime = Date.now();
+
+    if (!QUERY_OPS.has(operation)) {
+      return unsupportedOp('query', 'focus', operation, startTime);
+    }
+
+    try {
+      const id = typeof params?.['id'] === 'string' ? params['id'].trim() : '';
+      if (!id) {
+        return {
+          meta: dispatchMeta('query', 'focus', operation, startTime),
+          success: false,
+          error: { code: 'E_INVALID_INPUT', message: 'id is required (e.g. cleo focus T9973)' },
+        };
+      }
+
+      const projectRoot = getProjectRoot();
+      const result = await buildFocusEnvelope(id, projectRoot);
+
+      if ('error' in result) {
+        return {
+          meta: dispatchMeta('query', 'focus', operation, startTime),
+          success: false,
+          error: result.error,
+        };
+      }
+
+      // Use lafsSuccess so consumers get the canonical envelope shape.
+      const wrapped = lafsSuccess(result, 'focus.show');
+      return {
+        meta: dispatchMeta('query', 'focus', operation, startTime),
+        success: true,
+        data: wrapped.data,
+      };
+    } catch (error) {
+      return handleErrorResult('query', 'focus', operation, error, startTime);
+    }
+  }
+
+  /**
+   * The focus domain has no mutate operations.
+   *
+   * @param operation - Always unsupported.
+   * @param _params   - Unused.
+   */
+  async mutate(operation: string, _params?: Record<string, unknown>): Promise<DispatchResponse> {
+    const startTime = Date.now();
+    return unsupportedOp('mutate', 'focus', operation, startTime);
+  }
+
+  /** Declared operations for introspection. */
+  getSupportedOperations(): { query: string[]; mutate: string[] } {
+    return { query: ['show'], mutate: [] };
+  }
+}

--- a/packages/cleo/src/dispatch/domains/index.ts
+++ b/packages/cleo/src/dispatch/domains/index.ts
@@ -14,6 +14,7 @@ import { CheckHandler } from './check.js';
 import { ConduitHandler } from './conduit.js';
 import { DiagnosticsHandler } from './diagnostics.js';
 import { DocsHandler } from './docs.js';
+import { FocusHandler } from './focus.js';
 import { IntelligenceHandler } from './intelligence.js';
 import { LlmHandler } from './llm/index.js';
 import { MemoryHandler } from './memory.js';
@@ -37,6 +38,7 @@ export {
   ConduitHandler,
   DiagnosticsHandler,
   DocsHandler,
+  FocusHandler,
   IntelligenceHandler,
   LlmHandler,
   MemoryHandler,
@@ -74,6 +76,8 @@ export function createDomainHandlers(): Map<string, DomainHandler> {
   handlers.set('sticky', new StickyHandler());
   handlers.set('diagnostics', new DiagnosticsHandler());
   handlers.set('docs', new DocsHandler());
+  // T9973: focus domain — single-envelope task orientation (8 calls → 1)
+  handlers.set('focus', new FocusHandler());
   // T935: HITL playbook runtime + approvals surface
   handlers.set('playbook', new PlaybookHandler());
   // T964: conduit promoted to first-class canonical domain

--- a/packages/cleo/src/dispatch/registry.ts
+++ b/packages/cleo/src/dispatch/registry.ts
@@ -7914,6 +7914,31 @@ export const OPERATIONS: OperationDef[] = [
       },
     ] satisfies ParamDef[],
   },
+
+  // ---------------------------------------------------------------------------
+  // T9973 — focus domain: single-envelope task orientation (8 calls → 1)
+  // ---------------------------------------------------------------------------
+  {
+    gateway: 'query' as const,
+    domain: 'focus',
+    operation: 'show',
+    description:
+      'focus.show (query) — single-envelope orientation for a task, epic, or saga. ' +
+      'Aggregates identity + scope + members + blockers + readyWave + attachedDocs + ' +
+      'recentActivity + brainContext into ≤ 1 500 tokens.',
+    tier: 0,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: ['id'],
+    params: [
+      {
+        name: 'id',
+        type: 'string' as const,
+        required: true,
+        description: 'Task, Epic, or Saga ID to orient on (e.g. T9973, T9831)',
+      },
+    ] satisfies ParamDef[],
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/contracts/src/__tests__/operation-def.test.ts
+++ b/packages/contracts/src/__tests__/operation-def.test.ts
@@ -96,7 +96,7 @@ describe('dispatch/operation-def contracts', () => {
     expect(CANONICAL_DOMAINS.length).toBeGreaterThan(0);
     // T9954 — snapshot the current count so accidental additions/removals
     // trip this test and force an explicit human review.
-    expect(CANONICAL_DOMAINS.length).toBe(21);
+    expect(CANONICAL_DOMAINS.length).toBe(22);
   });
 
   it('CANONICAL_DOMAINS contains the four sentinel newly-promoted domains', () => {

--- a/packages/contracts/src/dispatch/identity.ts
+++ b/packages/contracts/src/dispatch/identity.ts
@@ -94,6 +94,8 @@ export const CANONICAL_DOMAINS = [
   'upgrade',
   // T9546/T9547: 'cleo worktree list/prune/force-unlock' — worktree lifecycle.
   'worktree',
+  // T9973: 'cleo focus <id>' — single-envelope task orientation (8 calls → 1).
+  'focus',
 ] as const;
 
 /**

--- a/packages/contracts/src/operations/focus.ts
+++ b/packages/contracts/src/operations/focus.ts
@@ -1,0 +1,226 @@
+/**
+ * Focus Domain Operations — single-envelope task orientation.
+ *
+ * `cleo focus <id>` aggregates 8 separate orientation calls into one
+ * wire-format envelope covering identity, scope, members, blockers,
+ * the next parallel-safe wave, attached docs, recent git activity, and
+ * scope-filtered brain context.
+ *
+ * Token budget: ≤ 1 500 tokens for a typical task orientation request.
+ *
+ * @task T9973
+ * @epic T9964 E-ORIENT-V2
+ */
+
+import type { MemoryCompactHit } from './memory.js';
+
+// ---------------------------------------------------------------------------
+// Params
+// ---------------------------------------------------------------------------
+
+/**
+ * Parameters for `focus.show`.
+ *
+ * @task T9973
+ */
+export interface FocusShowParams {
+  /** Task, Epic, or Saga ID to orient on (e.g. `T9973`, `T9831`). Required. */
+  id: string;
+}
+
+// ---------------------------------------------------------------------------
+// Result sub-types
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal identity block surfaced for the focused entity.
+ *
+ * @task T9973
+ */
+export interface FocusIdentity {
+  /** Task / Epic / Saga identifier. */
+  id: string;
+  /** Human-readable title. */
+  title: string;
+  /** Entity tier — `'task'`, `'epic'`, or `'saga'`. */
+  type: string;
+  /** Current lifecycle status. */
+  status: string;
+  /** Parent task / Epic identifier, if any. */
+  parentId?: string | null;
+}
+
+/**
+ * Scope hierarchy resolved from the focused entity's ancestry.
+ *
+ * @task T9973
+ */
+export interface FocusScope {
+  /** Saga ID, when the entity belongs to a Saga. */
+  sagaId?: string;
+  /** Epic ID when the entity is a task or the focused entity itself is an Epic. */
+  epicId?: string;
+  /** Task ID when the focused entity is a task. */
+  taskId?: string;
+}
+
+/**
+ * One member Epic of a Saga, with a rollup status.
+ *
+ * Populated only when `focus.show` is called on a Saga ID.
+ *
+ * @task T9973
+ */
+export interface FocusSagaMember {
+  /** Epic task identifier. */
+  epicId: string;
+  /** Rollup status for the Epic (e.g. `'active'`, `'done'`). */
+  status: string;
+  /** Epic title. */
+  title: string;
+}
+
+/**
+ * One task blocking the focused entity.
+ *
+ * @task T9973
+ */
+export interface FocusBlocker {
+  /** ID of the task that is blocking. */
+  id: string;
+  /** Title of the blocking task. */
+  title: string;
+  /** Human-readable reason the dependency is unresolved. */
+  reason: string;
+}
+
+/**
+ * One ready task from the next parallel-safe wave of the parent Epic.
+ *
+ * @task T9973
+ */
+export interface FocusReadyTask {
+  /** Task identifier. */
+  id: string;
+  /** Task title. */
+  title: string;
+  /** Engine-rolled priority. */
+  priority: string;
+  /** Dependency IDs (already satisfied for ready tasks). */
+  depends: string[];
+}
+
+/**
+ * One doc attachment linked to the focused entity.
+ *
+ * @task T9973
+ */
+export interface FocusAttachedDoc {
+  /** Attachment identifier (att_* or UUID). */
+  attachmentId: string;
+  /** Human-friendly slug, when assigned. */
+  slug?: string;
+  /** Taxonomy classification, when assigned. */
+  type?: string;
+  /** Storage kind (e.g. `'local-file'`, `'url'`, `'blob'`). */
+  kind: string;
+}
+
+/**
+ * One recent git commit mentioning the focused task ID.
+ *
+ * @task T9973
+ */
+export interface FocusRecentCommit {
+  /** Full 40-character commit SHA. */
+  commitSha: string;
+  /** Commit subject line (first line of the commit message). */
+  message: string;
+  /** ISO 8601 author date. */
+  date: string;
+}
+
+/**
+ * Brain context scoped to the focused entity (≤ 3 entries per category).
+ *
+ * @task T9973
+ */
+export interface FocusBrainContext {
+  /** Recent observations relevant to the focused entity. */
+  observations: MemoryCompactHit[];
+  /** Learnings relevant to the focused entity. */
+  learnings: MemoryCompactHit[];
+  /** Decisions relevant to the focused entity. */
+  decisions: MemoryCompactHit[];
+}
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of `focus.show` — the single-envelope task orientation response.
+ *
+ * All fields except `identity` and `scope` are omitted when the
+ * underlying data source returns nothing (empty arrays, unavailable stores,
+ * git not in repo). Consumers MUST handle optional fields gracefully.
+ *
+ * Token budget: ≤ 1 500 tokens for typical task orientation.
+ *
+ * @task T9973
+ * @epic T9964
+ */
+export interface FocusShowResult {
+  /** Core identity of the focused entity. */
+  identity: FocusIdentity;
+  /** Scope hierarchy (saga → epic → task) derived from ancestry. */
+  scope: FocusScope;
+  /**
+   * Saga member Epics with rollup statuses.
+   * Populated only when `id` resolves to a Saga (`label='saga'`).
+   */
+  members?: FocusSagaMember[];
+  /**
+   * Tasks that are blocking the focused entity.
+   * Empty array when the entity is not blocked.
+   */
+  blockers: FocusBlocker[];
+  /**
+   * Next parallel-safe wave of tasks from the parent Epic.
+   * Omitted when the entity has no parent Epic or the ready-set is empty.
+   */
+  readyWave?: FocusReadyTask[];
+  /**
+   * Docs attached to the focused task/epic.
+   * Omitted when the docs store is unavailable or no attachments exist.
+   */
+  attachedDocs?: FocusAttachedDoc[];
+  /**
+   * Up to 5 most-recent git commits mentioning the focused task ID.
+   * Omitted when git is unavailable or no matching commits are found.
+   */
+  recentActivity?: FocusRecentCommit[];
+  /**
+   * Scope-filtered brain context — up to 3 entries per category.
+   * Omitted when the BRAIN store is unavailable.
+   */
+  brainContext?: FocusBrainContext;
+  /** Estimated token weight of this envelope. */
+  tokensEstimated: number;
+}
+
+// ---------------------------------------------------------------------------
+// Typed op record
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed operation record for the focus domain.
+ *
+ * Maps each operation name to its `[Params, Result]` tuple for compile-time
+ * narrowing in the dispatch layer.
+ *
+ * @task T9973
+ */
+export type FocusOps = {
+  readonly show: readonly [FocusShowParams, FocusShowResult];
+};

--- a/packages/contracts/src/operations/index.ts
+++ b/packages/contracts/src/operations/index.ts
@@ -10,6 +10,7 @@ export * from './brain.js';
 export * from './conduit.js';
 export * from './dialectic.js';
 export * from './docs.js';
+export * from './focus.js';
 export * from './intelligence.js';
 export * from './issues.js';
 export * from './lifecycle.js';

--- a/packages/core/templates/CLEO-INJECTION.md
+++ b/packages/core/templates/CLEO-INJECTION.md
@@ -15,8 +15,9 @@ act on false information. They contain redirect stubs — not state.
 
 The ONLY canonical sources of session state are:
 - `cleo briefing` — structured handoff + next tasks + BRAIN context
+- `cleo focus <id>` — **primary orient surface** — single call replacing 8: identity, scope, blockers, ready wave, docs, git activity, brain context (≤ 1 500 tokens)
 - `cleo memory find "<query>"` — BRAIN memory lookup
-- `cleo show <taskId>` — individual task detail
+- `cleo show <taskId>` — individual task detail (use when you need the raw task record)
 
 If you find yourself reading a markdown file for orientation, STOP. Run `cleo briefing`.
 
@@ -28,15 +29,16 @@ If you find yourself reading a markdown file for orientation, STOP. Run `cleo br
 2. `cleo session status` — resume existing? (~200 tokens)
 3. `cleo current` — active task? (~100 tokens)
 4. `cleo next` — what to work on (~300 tokens)
-5. `cleo show {id}` — full details for chosen task (~400 tokens)
-6. `cleo orchestrate start --epic TXXX` — for epics with ≥ 5 children (~300 tokens, auto-inits LOOM)
+5. `cleo focus {id}` — **preferred orient call** — single envelope with identity + scope + blockers + ready wave + docs + brain context (≤ 1 500 tokens, replaces 8 calls)
+6. `cleo show {id}` — full task record details when you need the raw record (~400 tokens)
+7. `cleo orchestrate start --epic TXXX` — for epics with ≥ 5 children (~300 tokens, auto-inits LOOM)
 <!-- /CLEO-INJECTION:section=session-start -->
 
 <!-- CLEO-INJECTION:section=work-loop -->
 ## Work Loop
 
 1. `cleo current` or `cleo next` → pick task
-2. `cleo show {id}` → read requirements
+2. `cleo focus {id}` → orient: identity + blockers + ready wave + docs + brain context (1 call ≤ 1 500 tokens)
 3. Do the work (code, test, document)
 4. `cleo complete {id}` → mark done
 5. `cleo next` → continue or end session
@@ -95,12 +97,13 @@ untouched under each member Epic. Use Sagas for release themes that span multipl
 <!-- CLEO-INJECTION:section=task-discovery -->
 ## Task Discovery
 
-**Use `cleo find` for discovery. NEVER `cleo list` for browsing.**
+**Use `cleo focus` to orient on a task. Use `cleo find` for discovery. NEVER `cleo list` for browsing.**
 
 | Command | ~Tokens | Use |
 |---------|---------|-----|
+| `cleo focus <id>` | ≤ 1 500 | **Primary orient surface** — identity + scope + blockers + ready wave + docs + brain context in ONE call |
 | `cleo find "query"` | 200-400 | Search tasks (default) |
-| `cleo show <id>` | 300-600 | Full details for one task |
+| `cleo show <id>` | 300-600 | Raw task record (fallback when focus envelope is not sufficient) |
 | `cleo list --parent <id>` | 1000-5000 | Direct children only |
 <!-- /CLEO-INJECTION:section=task-discovery -->
 


### PR DESCRIPTION
## Summary

- New `cleo focus <id>` verb aggregates 8 separate orientation calls into one LAFS envelope
- Envelope contains: identity, scope, members (saga), blockers, ready wave, attached docs, recent git activity (5 commits), brain context (≤3 per category)
- Token budget: ≤ 1 500 tokens for typical task orientation
- CLEO-INJECTION.md updated: `cleo focus` documented as primary orient surface in Session Start, Work Loop, and Task Discovery sections

## Changed files

| File | Change |
|------|--------|
| `packages/contracts/src/operations/focus.ts` | New — `FocusShowResult`, `FocusOps`, sub-types |
| `packages/contracts/src/dispatch/identity.ts` | `'focus'` added to `CANONICAL_DOMAINS` |
| `packages/contracts/src/operations/index.ts` | Re-exports `focus.ts` |
| `packages/cleo/src/dispatch/domains/focus.ts` | New — `FocusHandler` with parallel `Promise.allSettled` aggregation |
| `packages/cleo/src/dispatch/domains/index.ts` | Registers `FocusHandler` |
| `packages/cleo/src/dispatch/registry.ts` | `focus.show` registered (tier-0, idempotent, requiredParams: id) |
| `packages/cleo/src/cli/commands/focus.ts` | New — citty command with positional `id` arg |
| `packages/cleo/src/cli/generated/command-manifest.ts` | Regenerated (137 entries) |
| `packages/cleo/src/cli/__tests__/focus.test.ts` | 16 tests: registry, CLI shape, task/epic/saga handler scopes |
| `packages/core/templates/CLEO-INJECTION.md` | Focus documented as primary orient surface |

## Test plan

- [x] 16 vitest tests pass: registry wiring, CLI shape, missing id validation, task/epic/saga scope handler tests
- [x] `pnpm biome check --write .` — 0 violations
- [x] `pnpm run build` — build complete (all 9 waves)
- [x] No focus-specific typecheck errors

Epic T9964 E-ORIENT-V2 AC4 (focus macro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)