### PR TITLE
chore(T9964): fix 8 legacy changesets + add T9964 changeset

### DIFF
--- a/.changeset/t9790-worktree-orphan-doctor.md
+++ b/.changeset/t9790-worktree-orphan-doctor.md
@@ -1,7 +1,7 @@
 ---
 id: t9790-worktree-orphan-doctor
 tasks: [T9790]
-kind: feature
+kind: feat
 summary: cleo doctor gains --audit-worktree-orphans and --prune-worktree-orphans for the T9550/T9580 SSoT-bug fallout.
 ---
 

--- a/.changeset/t9791-docs-migrate-execute.md
+++ b/.changeset/t9791-docs-migrate-execute.md
@@ -1,7 +1,7 @@
 ---
 id: t9791-docs-migrate-execute
 tasks: [T9791]
-kind: feature
+kind: feat
 summary: Execute cleo docs import across all 5 legacy doc sources (2388 files) — closes T9625 validation gate.
 ---
 

--- a/.changeset/t9792-docs-list-ux.md
+++ b/.changeset/t9792-docs-list-ux.md
@@ -1,7 +1,7 @@
 ---
 id: t9792-docs-list-ux
 tasks: [T9792]
-kind: feature
+kind: feat
 summary: cleo docs list defaults to project scope, supports --limit + --orderBy, and surfaces a narrowing hint.
 ---
 

--- a/.changeset/t9803-paths-rootcause-chokepoint.md
+++ b/.changeset/t9803-paths-rootcause-chokepoint.md
@@ -3,7 +3,7 @@ id: t9803-paths-rootcause-chokepoint
 tasks: [T9803]
 kind: fix
 prs: []
-summary: Root-cause fix for orphan-`.cleo/` synthesis — `getCleoDirAbsolute` now THROWS when `getProjectRoot` fails unless caller passes `{ bootstrap: true }`.
+summary: "Root-cause fix for orphan-`.cleo/` synthesis — `getCleoDirAbsolute` now THROWS when `getProjectRoot` fails unless caller passes `{ bootstrap: true }`."
 ---
 
 The chokepoint at `packages/core/src/paths.ts:305` previously caught the

--- a/.changeset/t9804-claude-isolation-bridge.md
+++ b/.changeset/t9804-claude-isolation-bridge.md
@@ -1,7 +1,9 @@
 ---
-"@cleocode/contracts": minor
-"@cleocode/core": minor
-"@cleocode/cleo": minor
+id: t9804-claude-isolation-bridge
+tasks: [T9804]
+kind: feat
+prs: []
+summary: "cleo worktree adopt + multi-source list (Claude Code Agent isolation bridge)"
 ---
 
 feat(T9804): cleo worktree adopt + multi-source list (Claude Code Agent isolation bridge)

--- a/.changeset/t9805-lifecycle-hooks.md
+++ b/.changeset/t9805-lifecycle-hooks.md
@@ -1,7 +1,9 @@
 ---
-"@cleocode/worktree": minor
-"@cleocode/contracts": minor
-"@cleocode/cleo": minor
+id: t9805-lifecycle-hooks
+tasks: [T9805]
+kind: feat
+prs: []
+summary: "worktree lifecycle audit log + auto-cleanup GHA workflow"
 ---
 
 feat(T9805): worktree lifecycle audit log + auto-cleanup GHA workflow

--- a/.changeset/t9807-provisioning-perf.md
+++ b/.changeset/t9807-provisioning-perf.md
@@ -1,8 +1,9 @@
 ---
-'@cleocode/worktree': patch
-'@cleocode/contracts': patch
-'@cleocode/core': patch
-'@cleocode/cleo': patch
+id: t9807-provisioning-perf
+tasks: [T9807]
+kind: fix
+prs: []
+summary: "bound worktree include-pattern apply loop + optional sparse-checkout scope"
 ---
 
 fix(T9807): bound worktree include-pattern apply loop + optional sparse-checkout scope

--- a/.changeset/t9808-validation-closure.md
+++ b/.changeset/t9808-validation-closure.md
@@ -1,7 +1,9 @@
 ---
-'@cleocode/cleo': minor
-'@cleocode/core': minor
-'@cleocode/contracts': minor
+id: t9808-validation-closure
+tasks: [T9808]
+kind: feat
+prs: []
+summary: "cleo doctor --audit-worktree-orphans comprehensive scan + isolation lint + saga closure report"
 ---
 
 feat(T9808): cleo doctor --audit-worktree-orphans comprehensive scan + isolation lint + saga closure report

--- a/.changeset/t9964-orient-v2.md
+++ b/.changeset/t9964-orient-v2.md
@@ -1,0 +1,6 @@
+---
+id: t9964-orient-v2
+tasks: [T9965, T9966, T9967, T9968, T9973, T9974, T9975, T9976]
+kind: feat
+summary: "E-ORIENT-V2: multi-agent orientation surface — docs fetch/show fixes, briefing diet + scope, focus macro, per-agent sessions, worktree destroy dispatch, auto-emit memory observation"
+---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## [2026.5.97] (2026-05-22)
+
+### BREAKING CHANGES
+
+- Unify releases tables — drop release_manifests + releases_view, hard-rename to canonical "releases". (T9686-B2) (#328)
+
+  Migration:
+
+  `release_manifests` is dropped and `releases_view` is removed. Readers that
+  previously queried either name must switch to the canonical `releases`
+  table. The migration handles the data move in-place; consumers that touch
+  the SQLite schema directly (e.g. raw queries outside the DataAccessor) need
+  to update their statements.
+
+### Features
+
+- Agent unification + Conduit architecture — unified cleo agent CLI, AgentRegistry with encrypted credentials, Conduit transport layer. (T170)
+- WASM bindings for the CANT ecosystem — cant-core, lafs-core, conduit-core, signaldock-core compile to WASM with TypeScript SDK integration. (T9738)
+- cleo doctor gains --audit-worktree-orphans and --prune-worktree-orphans for the T9550/T9580 SSoT-bug fallout. (T9790)
+- Execute cleo docs import across all 5 legacy doc sources (2388 files) — closes T9625 validation gate. (T9791)
+- cleo docs list defaults to project scope, supports --limit + --orderBy, and surfaces a narrowing hint. (T9792)
+- Saga T9787 closing Epic — 9-step E2E real-world validation + agent-accountability harness (canon-lint). (T9797)
+- Paths SSoT CI gate (lint-paths-ssot.mjs) + resolveWorktreeIndexPath helper (D009 sentinel) (T9802)
+- cleo worktree adopt + multi-source list (Claude Code Agent isolation bridge) (T9804)
+- worktree lifecycle audit log + auto-cleanup GHA workflow (T9805)
+- DB chokepoint refuses opens when the resolved `.cleo/` resides inside a git worktree — defense-in-depth on top of T9803. (T9806)
+- cleo doctor --audit-worktree-orphans comprehensive scan + isolation lint + saga closure report (T9808)
+- Ban worktrees outside canonical XDG location + CI lint gate + migration tool. (T9809)
+- E-ORIENT-V2: multi-agent orientation surface — docs fetch/show fixes, briefing diet + scope, focus macro, per-agent sessions, worktree destroy dispatch, auto-emit memory observation (T9965) (T9966) (T9967) (T9968) (T9973) (T9974) (T9975) (T9976)
+
+### Fixes
+
+- Four dispatch/envelope bugs in the release pipeline — worktree help text, pr-status routing, reconcile double-wrap, changelog envelope. (T9686-A) (#324)
+- releaseShow + releaseList read from releases_view SSoT — eliminates dual-table split between releases and release_manifests. (T9686-B) (#323)
+- Provenance backfill — tag enumeration, --since empty handling, foreign-key insertion order. (T9686-C) (#325)
+- Root-cause fix for orphan-`.cleo/` synthesis — `getCleoDirAbsolute` now THROWS when `getProjectRoot` fails unless caller passes `{ bootstrap: true }`. (T9803)
+- bound worktree include-pattern apply loop + optional sparse-checkout scope (T9807)
+- orchestrate ready/waves traverse saga 'groups' relation (+ --via flag) (T9852) (T9839) (#422)
+- SQLITE_BUSY retry on parallel task writes (CORE SDK with-retry primitive) (T9852) (T9839) (#413)
+- RCA + persist severity/kind/scope on task UPDATE (T9852) (T9839) (#425)
+- cleo issue diagnostics reads CLEO version from package.json SSoT (T9852) (T9839) (#411)
+- Bracket+quote-aware acceptance tokenizer + DRY collapse of 3 duplicate split impls (T9852) (T9839) (#412)
+
+### Refactors
+
+- Promote 17 provenance/job unions + 6 task-axis enum constants from core/store/tasks-schema.ts to @cleocode/contracts (Phase 0c · T9832). (T9955)
+- Promote 15 BRAIN memory wire-shapes from `@cleocode/core` to `@cleocode/contracts/memory` (Phase 0e of SG-ARCH-SOLID). (T9956)
+
+### Documentation
+
+- Worktree prune main-dir protection + AGENTS.md release docs aligned to SPEC-T9345 4-verb pipeline. (T9686-D) (T9686-E) (#320)
+- CLI help-text hardening bundle (gh-392 (T9852) (T9839) (#426)
+
+### Chores
+
+- cleo changeset list verb + README pointing at canonical writer (T9785)
+- biome lint hotfixes — unblock CI after T9797 saga-T9787 file landed (T9852) (T9839) (#427)
+
 ## [2026.5.96] (2026-05-21)
 
 Ships Saga **T9800 SG-WORKTREE-CANON** end-to-end — 9 epics + 1 council sub-task,


### PR DESCRIPTION
## Summary
Release prep for v2026.5.97 (Epic T9964 E-ORIENT-V2). Eight pre-existing changesets had schema/format errors that prevented \`cleo release plan\` from aggregating the changelog (T9780 known bug — first bad file aborts entire parse batch).

Fixes:
- t9790, t9791, t9792: \`kind: feature\` → \`kind: feat\` (enum mismatch)
- t9803: unquoted summary containing colons (YAML nested-mapping error)
- t9804, t9805, t9807, t9808: legacy @changesets-cli format → CLEO id/tasks/kind/summary format

Plus: new \`.changeset/t9964-orient-v2.md\` aggregating the 8 PRs of Epic T9964.

After merge, \`cleo release plan v2026.5.97\` reports \`changesetEntryCount=30\` (was 0) and writes the CHANGELOG.

## Test plan
- [x] \`cleo release plan v2026.5.97 --epic T9964\` returns success with 30 entries
- [x] CHANGELOG.md updated with this and 29 prior entries from already-shipped epics

🤖 Generated with [Claude Code](https://claude.com/claude-code)