### PR TITLE
fix(T9962): width-budget + timeout for doctor worktree-orphan audit

### DIFF
--- a/.changeset/t9962-doctor-audit-budget.md
+++ b/.changeset/t9962-doctor-audit-budget.md
@@ -1,0 +1,15 @@
+---
+id: t9962-doctor-audit-budget
+tasks: [T9962]
+kind: fix
+summary: Add width-budget + timeout to doctor worktree-orphan audit to prevent 60s+ hang on large corpora
+---
+
+`cleo doctor --audit-worktree-orphans` hung indefinitely on a 194-orphan corpus because depth was already bounded (MAX_SCAN_DEPTH=3) but per-entry IO at width was unbounded.
+
+Two tactical fixes (strategic Rust rewrite deferred to T9977/T9986):
+
+- Width budget: soft-warn at 100 entries per level, hard-stop at 500 with `isPartial: true, partialReason: 'overflow'` on the result envelope.
+- Timeout: `--timeout <seconds>` flag (default 30s) on `cleo doctor --audit-worktree-orphans` and `--prune-worktree-orphans`; on expiry scan returns `isPartial: true, partialReason: 'timeout'`.
+
+New `scanWorktreeOrphansBudgeted()` function wraps the existing bare-array scanner and surfaces the `OrphanScanResult` envelope. Existing `scanWorktreeOrphans` callers are unaffected.

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -264,6 +264,27 @@ export const doctorCommand = defineCommand({
         'List orphan .cleo/ directories under .claude/worktrees/ (T9790, fallout from T9550/T9580)',
     },
     /**
+     * T9962: timeout in seconds for --audit-worktree-orphans and
+     * --prune-worktree-orphans. On expiry the scan returns a partial result.
+     * Default: 30 seconds.
+     */
+    timeout: {
+      type: 'string',
+      description:
+        'Timeout in seconds for worktree-orphan audit/prune scan (default: 30). ' +
+        'Partial results are returned on expiry.',
+    },
+    /**
+     * T9962: per-level fan-out cap for --audit-worktree-orphans.
+     * Default: 500.
+     */
+    'max-entries-per-level': {
+      type: 'string',
+      description:
+        'Per-level entry hard-stop for worktree-orphan scan (default: 500). ' +
+        'Scan aborts with partial result when exceeded.',
+    },
+    /**
      * T9790: archive then remove every orphan reported by
      * `--audit-worktree-orphans`. Combine with `--dry-run` to preview
      * without touching the filesystem.
@@ -561,22 +582,56 @@ export const doctorCommand = defineCommand({
         //   2. worktrees outside the canonical XDG location
         //   3. rogue .cleo/worktrees/ DIRECTORY (council D009)
         // Also runs the legacy .claude/worktrees/ orphan scan for full coverage.
+        // T9962: budgeted scan with configurable timeout + per-level fan-out cap.
         progress.step(0, 'Comprehensive worktree anomaly audit (T9808 / council D009)');
-        const { auditWorktreeOrphansComprehensive, scanWorktreeOrphans } = await import(
+        const { auditWorktreeOrphansComprehensive, scanWorktreeOrphansBudgeted } = await import(
           '@cleocode/core/doctor/worktree-orphans.js'
         );
         const projectRoot = getProjectRoot();
 
+        // Parse optional budget overrides from CLI flags (T9962).
+        const timeoutSecs =
+          args['timeout'] !== undefined ? Number.parseInt(String(args['timeout']), 10) : 30;
+        const timeoutMs =
+          Number.isFinite(timeoutSecs) && timeoutSecs > 0 ? timeoutSecs * 1000 : 30_000;
+        const maxEntriesPerLevel =
+          args['max-entries-per-level'] !== undefined
+            ? Number.parseInt(String(args['max-entries-per-level']), 10)
+            : 500;
+
         // Run both scans in parallel.
-        const [comprehensive, legacyOrphans] = await Promise.all([
+        const [comprehensive, legacyScanResult] = await Promise.all([
           auditWorktreeOrphansComprehensive(projectRoot),
-          scanWorktreeOrphans(projectRoot),
+          scanWorktreeOrphansBudgeted(projectRoot, {
+            timeoutMs,
+            maxEntriesPerLevel: Number.isFinite(maxEntriesPerLevel) ? maxEntriesPerLevel : 500,
+          }),
         ]);
 
+        const legacyOrphans = legacyScanResult.orphans;
         const totalAnomalies = comprehensive.count;
+
+        // Emit soft-warn message to stderr if triggered.
+        if (legacyScanResult.softWarnMessage) {
+          process.stderr.write(`[cleo doctor] ${legacyScanResult.softWarnMessage}\n`);
+        }
+
+        // Emit partial-result warning to stderr if the scan was aborted.
+        if (legacyScanResult.isPartial) {
+          const reason =
+            legacyScanResult.partialReason === 'timeout'
+              ? `timed out after ${timeoutSecs}s (use --timeout <seconds> to adjust)`
+              : `per-level entry cap of ${maxEntriesPerLevel} exceeded (use --max-entries-per-level <n> to adjust)`;
+          process.stderr.write(
+            `[cleo doctor] WARNING: legacy orphan scan is PARTIAL — ${reason}. ` +
+              `Results may be incomplete.\n`,
+          );
+        }
+
         progress.complete(
           `Found ${totalAnomalies} anomal${totalAnomalies === 1 ? 'y' : 'ies'}` +
-            (legacyOrphans.length > 0 ? ` (${legacyOrphans.length} legacy orphan(s))` : ''),
+            (legacyOrphans.length > 0 ? ` (${legacyOrphans.length} legacy orphan(s))` : '') +
+            (legacyScanResult.isPartial ? ' [PARTIAL]' : ''),
         );
 
         cliOutput(
@@ -584,6 +639,8 @@ export const doctorCommand = defineCommand({
             projectRoot,
             comprehensive,
             legacyOrphans,
+            legacyScanPartial: legacyScanResult.isPartial,
+            legacyScanPartialReason: legacyScanResult.partialReason,
             count: totalAnomalies,
           },
           { command: 'doctor', operation: 'doctor.audit-worktree-orphans' },
@@ -594,19 +651,53 @@ export const doctorCommand = defineCommand({
       } else if (args['prune-worktree-orphans']) {
         // T9790: archive + remove orphan .cleo/ directories. Always writes
         // a tarball + audit-log line BEFORE removing anything.
+        // T9962: budgeted scan with configurable timeout + per-level fan-out cap.
         const isDryRun = args['dry-run'] === true;
         progress.step(
           0,
           `${isDryRun ? '[DRY RUN] ' : ''}Scanning + pruning worktree-orphan .cleo/ directories`,
         );
-        const { pruneWorktreeOrphans, scanWorktreeOrphans } = await import(
+        const { pruneWorktreeOrphans, scanWorktreeOrphansBudgeted } = await import(
           '@cleocode/core/doctor/worktree-orphans.js'
         );
         const projectRoot = getProjectRoot();
-        const orphans = await scanWorktreeOrphans(projectRoot);
+
+        // Parse optional budget overrides from CLI flags (T9962).
+        const timeoutSecs =
+          args['timeout'] !== undefined ? Number.parseInt(String(args['timeout']), 10) : 30;
+        const timeoutMs =
+          Number.isFinite(timeoutSecs) && timeoutSecs > 0 ? timeoutSecs * 1000 : 30_000;
+        const maxEntriesPerLevel =
+          args['max-entries-per-level'] !== undefined
+            ? Number.parseInt(String(args['max-entries-per-level']), 10)
+            : 500;
+
+        const scanResult = await scanWorktreeOrphansBudgeted(projectRoot, {
+          timeoutMs,
+          maxEntriesPerLevel: Number.isFinite(maxEntriesPerLevel) ? maxEntriesPerLevel : 500,
+        });
+
+        // Emit partial-result warning to stderr if the scan was aborted.
+        if (scanResult.softWarnMessage) {
+          process.stderr.write(`[cleo doctor] ${scanResult.softWarnMessage}\n`);
+        }
+        if (scanResult.isPartial) {
+          const reason =
+            scanResult.partialReason === 'timeout'
+              ? `timed out after ${timeoutSecs}s (use --timeout <seconds> to adjust)`
+              : `per-level entry cap of ${maxEntriesPerLevel} exceeded (use --max-entries-per-level <n> to adjust)`;
+          process.stderr.write(
+            `[cleo doctor] WARNING: orphan scan is PARTIAL — ${reason}. ` +
+              `Only orphans found before abort will be pruned.\n`,
+          );
+        }
+
+        const orphans = scanResult.orphans;
 
         if (orphans.length === 0) {
-          progress.complete('No worktree orphans found — nothing to prune');
+          progress.complete(
+            `No worktree orphans found — nothing to prune${scanResult.isPartial ? ' [PARTIAL SCAN]' : ''}`,
+          );
           cliOutput(
             {
               projectRoot,
@@ -615,6 +706,8 @@ export const doctorCommand = defineCommand({
               pruned: [],
               rejected: [],
               totalSizeBytes: 0,
+              scanPartial: scanResult.isPartial,
+              scanPartialReason: scanResult.partialReason,
             },
             { command: 'doctor', operation: 'doctor.prune-worktree-orphans' },
           );
@@ -634,11 +727,17 @@ export const doctorCommand = defineCommand({
         const verb = isDryRun ? 'Would prune' : 'Pruned';
         progress.complete(
           `${verb} ${result.pruned.length} orphan${result.pruned.length === 1 ? '' : 's'}` +
-            `${result.rejected.length > 0 ? `, ${result.rejected.length} rejected` : ''}`,
+            `${result.rejected.length > 0 ? `, ${result.rejected.length} rejected` : ''}` +
+            `${scanResult.isPartial ? ' [PARTIAL SCAN]' : ''}`,
         );
 
         cliOutput(
-          { projectRoot, ...result },
+          {
+            projectRoot,
+            ...result,
+            scanPartial: scanResult.isPartial,
+            scanPartialReason: scanResult.partialReason,
+          },
           { command: 'doctor', operation: 'doctor.prune-worktree-orphans' },
         );
         if (result.rejected.length > 0) {

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -616,7 +616,7 @@ export const doctorCommand = defineCommand({
           pushWarning({
             code: 'W_DOCTOR_SCAN_SOFT_WARN',
             message: legacyScanResult.softWarnMessage,
-            severity: 'warning',
+            severity: 'warn',
           });
         }
 
@@ -629,8 +629,8 @@ export const doctorCommand = defineCommand({
           pushWarning({
             code: 'W_DOCTOR_SCAN_PARTIAL',
             message: `legacy orphan scan is PARTIAL — ${reason}. Results may be incomplete.`,
-            severity: 'warning',
-            meta: {
+            severity: 'warn',
+            context: {
               partialReason: legacyScanResult.partialReason,
               timeoutSecs,
               maxEntriesPerLevel,
@@ -692,7 +692,7 @@ export const doctorCommand = defineCommand({
           pushWarning({
             code: 'W_DOCTOR_SCAN_SOFT_WARN',
             message: scanResult.softWarnMessage,
-            severity: 'warning',
+            severity: 'warn',
           });
         }
         if (scanResult.isPartial) {
@@ -703,8 +703,8 @@ export const doctorCommand = defineCommand({
           pushWarning({
             code: 'W_DOCTOR_SCAN_PARTIAL',
             message: `orphan scan is PARTIAL — ${reason}. Only orphans found before abort will be pruned.`,
-            severity: 'warning',
-            meta: {
+            severity: 'warn',
+            context: {
               partialReason: scanResult.partialReason,
               timeoutSecs,
               maxEntriesPerLevel,

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -17,7 +17,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { HookMatrixResult } from '@cleocode/core';
-import { getProjectRoot } from '@cleocode/core';
+import { getProjectRoot, pushWarning } from '@cleocode/core';
 import {
   quarantineRogueCleoDir,
   scanRogueCleoDirs,
@@ -611,21 +611,31 @@ export const doctorCommand = defineCommand({
         const legacyOrphans = legacyScanResult.orphans;
         const totalAnomalies = comprehensive.count;
 
-        // Emit soft-warn message to stderr if triggered.
+        // Queue soft-warn through pushWarning so it lands in envelope.meta.warnings (T9763/T9772).
         if (legacyScanResult.softWarnMessage) {
-          process.stderr.write(`[cleo doctor] ${legacyScanResult.softWarnMessage}\n`);
+          pushWarning({
+            code: 'W_DOCTOR_SCAN_SOFT_WARN',
+            message: legacyScanResult.softWarnMessage,
+            severity: 'warning',
+          });
         }
 
-        // Emit partial-result warning to stderr if the scan was aborted.
+        // Queue partial-result warning if the scan was aborted.
         if (legacyScanResult.isPartial) {
           const reason =
             legacyScanResult.partialReason === 'timeout'
               ? `timed out after ${timeoutSecs}s (use --timeout <seconds> to adjust)`
               : `per-level entry cap of ${maxEntriesPerLevel} exceeded (use --max-entries-per-level <n> to adjust)`;
-          process.stderr.write(
-            `[cleo doctor] WARNING: legacy orphan scan is PARTIAL — ${reason}. ` +
-              `Results may be incomplete.\n`,
-          );
+          pushWarning({
+            code: 'W_DOCTOR_SCAN_PARTIAL',
+            message: `legacy orphan scan is PARTIAL — ${reason}. Results may be incomplete.`,
+            severity: 'warning',
+            meta: {
+              partialReason: legacyScanResult.partialReason,
+              timeoutSecs,
+              maxEntriesPerLevel,
+            },
+          });
         }
 
         progress.complete(
@@ -677,19 +687,29 @@ export const doctorCommand = defineCommand({
           maxEntriesPerLevel: Number.isFinite(maxEntriesPerLevel) ? maxEntriesPerLevel : 500,
         });
 
-        // Emit partial-result warning to stderr if the scan was aborted.
+        // Queue partial-result warning through pushWarning if the scan was aborted.
         if (scanResult.softWarnMessage) {
-          process.stderr.write(`[cleo doctor] ${scanResult.softWarnMessage}\n`);
+          pushWarning({
+            code: 'W_DOCTOR_SCAN_SOFT_WARN',
+            message: scanResult.softWarnMessage,
+            severity: 'warning',
+          });
         }
         if (scanResult.isPartial) {
           const reason =
             scanResult.partialReason === 'timeout'
               ? `timed out after ${timeoutSecs}s (use --timeout <seconds> to adjust)`
               : `per-level entry cap of ${maxEntriesPerLevel} exceeded (use --max-entries-per-level <n> to adjust)`;
-          process.stderr.write(
-            `[cleo doctor] WARNING: orphan scan is PARTIAL — ${reason}. ` +
-              `Only orphans found before abort will be pruned.\n`,
-          );
+          pushWarning({
+            code: 'W_DOCTOR_SCAN_PARTIAL',
+            message: `orphan scan is PARTIAL — ${reason}. Only orphans found before abort will be pruned.`,
+            severity: 'warning',
+            meta: {
+              partialReason: scanResult.partialReason,
+              timeoutSecs,
+              maxEntriesPerLevel,
+            },
+          });
         }
 
         const orphans = scanResult.orphans;

--- a/packages/contracts/src/doctor.ts
+++ b/packages/contracts/src/doctor.ts
@@ -156,6 +156,50 @@ export interface ComprehensiveAuditResult {
   anomalies: WorktreeAnomaly[];
   /** Total anomaly count. Non-zero triggers exit code 2. */
   count: number;
+  /**
+   * `true` when the audit was aborted early due to a width budget overflow
+   * or a timeout. The `anomalies` list reflects only the entries scanned
+   * before the abort — results may be incomplete.
+   */
+  isPartial?: boolean;
+  /**
+   * Machine-readable reason the scan was cut short.
+   * - `'timeout'`: the configured `timeoutMs` was exceeded.
+   * - `'overflow'`: a per-level entry count exceeded `maxEntriesPerLevel`.
+   */
+  partialReason?: 'timeout' | 'overflow';
+}
+
+/**
+ * Result shape returned by the budgeted orphan scanner
+ * ({@link scanWorktreeOrphansBudgeted}).
+ *
+ * Wraps the bare `OrphanEntry[]` from `scanWorktreeOrphans` with optional
+ * partial-result metadata so callers can surface incomplete scans to the
+ * operator without changing the existing `OrphanEntry[]` return type.
+ */
+export interface OrphanScanResult {
+  /** Discovered orphan entries (may be incomplete when `isPartial` is `true`). */
+  orphans: OrphanEntry[];
+  /**
+   * `true` when the scan was aborted before completion due to a budget
+   * overflow or timeout. The `orphans` list reflects only entries found
+   * before the abort.
+   */
+  isPartial: boolean;
+  /**
+   * Machine-readable reason the scan was cut short.
+   * - `'timeout'`: the configured `timeoutMs` was exceeded.
+   * - `'overflow'`: a per-level entry count exceeded `maxEntriesPerLevel`.
+   * `undefined` when `isPartial` is `false`.
+   */
+  partialReason?: 'timeout' | 'overflow';
+  /**
+   * Human-readable warning message produced when the soft-warn threshold
+   * was crossed (entries per level exceeded `softWarnEntriesPerLevel` but
+   * stayed under the hard stop). `undefined` when no warning was triggered.
+   */
+  softWarnMessage?: string;
 }
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -299,10 +299,11 @@ export {
   DocKindConfigError,
   DocKindRegistry,
 } from './docs-taxonomy.js';
-// === Doctor: Worktree-Orphan Audit + Prune Types (T9790, T9808) ===
+// === Doctor: Worktree-Orphan Audit + Prune Types (T9790, T9808, T9962) ===
 export type {
   ComprehensiveAuditResult,
   OrphanEntry,
+  OrphanScanResult,
   PruneAuditEntry,
   PruneResult,
   WorktreeAnomaly,

--- a/packages/core/src/doctor/__tests__/worktree-orphans.test.ts
+++ b/packages/core/src/doctor/__tests__/worktree-orphans.test.ts
@@ -32,7 +32,11 @@ import {
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { pruneWorktreeOrphans, scanWorktreeOrphans } from '../worktree-orphans.js';
+import {
+  pruneWorktreeOrphans,
+  scanWorktreeOrphans,
+  scanWorktreeOrphansBudgeted,
+} from '../worktree-orphans.js';
 
 let tmpRoot: string;
 let projectRoot: string;
@@ -286,6 +290,121 @@ describe('pruneWorktreeOrphans — symlinked parent (macOS /var → /private/var
     expect(second.pruned).toEqual([]);
     expect(second.rejected.length).toBe(1);
     expect(second.rejected[0]?.reason).toBe('path-not-found');
+  });
+});
+
+// ============================================================================
+// T9962: Width budget tests
+// ============================================================================
+
+describe('scanWorktreeOrphansBudgeted — width budget', () => {
+  /**
+   * Hard-stop: 501 subdirs under worktreesRoot exceeds the default 500 cap.
+   * Expect isPartial=true, partialReason='overflow'.
+   */
+  it('returns isPartial+overflow when top-level entries exceed maxEntriesPerLevel', async () => {
+    // Create 501 subdirectories under worktreesRoot.
+    for (let i = 0; i < 501; i++) {
+      mkdirSync(join(worktreesRoot, `agent-overflow-${i}`), { recursive: true });
+    }
+
+    const result = await scanWorktreeOrphansBudgeted(projectRoot, {
+      maxEntriesPerLevel: 500,
+    });
+
+    expect(result.isPartial).toBe(true);
+    expect(result.partialReason).toBe('overflow');
+  });
+
+  /**
+   * Soft-warn: 101 subdirs crosses the default 100 soft-warn threshold but
+   * stays under 500. The scan should complete (isPartial=false) and
+   * softWarnMessage should be set.
+   */
+  it('completes with softWarnMessage when entries exceed softWarnEntriesPerLevel but stay under hard stop', async () => {
+    // Create 101 subdirectories (crosses soft-warn default of 100).
+    for (let i = 0; i < 101; i++) {
+      mkdirSync(join(worktreesRoot, `agent-soft-${i}`), { recursive: true });
+    }
+
+    const result = await scanWorktreeOrphansBudgeted(projectRoot, {
+      maxEntriesPerLevel: 500,
+      softWarnEntriesPerLevel: 100,
+    });
+
+    // Scan should complete fully.
+    expect(result.isPartial).toBe(false);
+    // But a soft warning should be present.
+    expect(result.softWarnMessage).toBeDefined();
+    expect(typeof result.softWarnMessage).toBe('string');
+    expect(result.softWarnMessage!.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * Normal operation: small corpus returns results with isPartial=false.
+   */
+  it('returns isPartial=false for a normal small corpus', async () => {
+    seedOrphans();
+
+    const result = await scanWorktreeOrphansBudgeted(projectRoot);
+
+    expect(result.isPartial).toBe(false);
+    expect(result.partialReason).toBeUndefined();
+    expect(result.orphans.length).toBeGreaterThanOrEqual(3);
+  });
+
+  /**
+   * Empty root: returns isPartial=false with empty orphan list.
+   */
+  it('returns isPartial=false with empty orphans when worktreesRoot does not exist', async () => {
+    rmSync(worktreesRoot, { recursive: true, force: true });
+
+    const result = await scanWorktreeOrphansBudgeted(projectRoot);
+
+    expect(result.isPartial).toBe(false);
+    expect(result.orphans).toEqual([]);
+  });
+});
+
+// ============================================================================
+// T9962: Timeout tests
+// ============================================================================
+
+describe('scanWorktreeOrphansBudgeted — timeout', () => {
+  /**
+   * Timeout: use a negative timeoutMs (-1) so that
+   * `Date.now() - startTime > timeoutMs` evaluates to `true` immediately
+   * (since `Date.now() - startTime` is always >= 0, and 0 > -1 is always
+   * true). This avoids the flakiness of relying on wall-clock elapsed time
+   * on fast CI machines where 1ms might elapse before the first check.
+   */
+  it('returns isPartial+timeout when timeoutMs is exceeded', async () => {
+    // Seed at least one directory so the walker actually enters the loop.
+    const dir = join(worktreesRoot, 'agent-timeout-0');
+    mkdirSync(join(dir, '.cleo'), { recursive: true });
+    writeFileSync(join(dir, '.cleo', 'tasks.db'), 'fake');
+
+    const result = await scanWorktreeOrphansBudgeted(projectRoot, {
+      timeoutMs: -1, // Always expired: Date.now() - start (>=0) > -1 is always true
+    });
+
+    // Must be partial due to timeout.
+    expect(result.isPartial).toBe(true);
+    expect(result.partialReason).toBe('timeout');
+  });
+
+  /**
+   * Adequate timeout: generous budget should not trigger partial.
+   */
+  it('completes without partial when timeout is generous', async () => {
+    seedOrphans();
+
+    const result = await scanWorktreeOrphansBudgeted(projectRoot, {
+      timeoutMs: 30_000, // 30s — plenty of time for 3 orphans
+    });
+
+    expect(result.isPartial).toBe(false);
+    expect(result.orphans.length).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/packages/core/src/doctor/worktree-orphans.ts
+++ b/packages/core/src/doctor/worktree-orphans.ts
@@ -50,6 +50,7 @@ import { dirname, join, relative, resolve, sep } from 'node:path';
 import type {
   ComprehensiveAuditResult,
   OrphanEntry,
+  OrphanScanResult,
   PruneAuditEntry,
   PruneResult,
   WorktreeAnomaly,
@@ -97,7 +98,21 @@ const FULL_DUPLICATE_MARKERS = new Set([
 ]);
 
 /**
- * Options for {@link scanWorktreeOrphans}.
+ * Default soft-warn threshold: emit a warning when a single directory
+ * level contains more than this many entries (but scan continues).
+ */
+const DEFAULT_SOFT_WARN_ENTRIES = 100;
+
+/**
+ * Default hard-stop threshold: abort the scan with `isPartial: true` /
+ * `partialReason: 'overflow'` when a single level has more entries than
+ * this. Prevents the 194-orphan / 60s+ hang class (T9962).
+ */
+const DEFAULT_MAX_ENTRIES_PER_LEVEL = 500;
+
+/**
+ * Options for {@link scanWorktreeOrphans} and
+ * {@link scanWorktreeOrphansBudgeted}.
  */
 export interface ScanOptions {
   /**
@@ -105,6 +120,33 @@ export interface ScanOptions {
    * Mainly for tests.
    */
   worktreesRoot?: string;
+  /**
+   * Per-level fan-out hard-stop. When the number of entries in a single
+   * directory level reaches this limit the scan aborts and returns with
+   * `isPartial: true, partialReason: 'overflow'`.
+   *
+   * Default: 500. Set to `Infinity` to disable.
+   * Only honoured by {@link scanWorktreeOrphansBudgeted}.
+   */
+  maxEntriesPerLevel?: number;
+  /**
+   * Per-level soft-warn threshold. When entries in a level exceed this value
+   * a warning message is added to the result but the scan continues (up to
+   * `maxEntriesPerLevel`).
+   *
+   * Default: 100. Set to `Infinity` to disable.
+   * Only honoured by {@link scanWorktreeOrphansBudgeted}.
+   */
+  softWarnEntriesPerLevel?: number;
+  /**
+   * Maximum wall-clock milliseconds for the entire scan. When exceeded the
+   * scan aborts and returns with `isPartial: true, partialReason: 'timeout'`.
+   *
+   * Default: `undefined` (no timeout). Typically set to `30_000` (30 s) by
+   * the CLI.
+   * Only honoured by {@link scanWorktreeOrphansBudgeted}.
+   */
+  timeoutMs?: number;
 }
 
 /**
@@ -278,6 +320,157 @@ export async function scanWorktreeOrphans(
 
   orphans.sort((a, b) => a.orphanPath.localeCompare(b.orphanPath));
   return orphans;
+}
+
+/**
+ * Width-budgeted wrapper around {@link scanWorktreeOrphans}.
+ *
+ * Adds three safety valves (T9962):
+ *   - **Hard stop** at `maxEntriesPerLevel` entries per directory level
+ *     (default 500). Aborts immediately and returns
+ *     `isPartial: true, partialReason: 'overflow'`.
+ *   - **Soft warn** at `softWarnEntriesPerLevel` (default 100). Scan
+ *     continues but `softWarnMessage` is set in the result.
+ *   - **Timeout** at `timeoutMs` milliseconds. Aborts and returns
+ *     `isPartial: true, partialReason: 'timeout'`.
+ *
+ * Existing callers of `scanWorktreeOrphans` keep their original behaviour
+ * unchanged. New code (e.g. the CLI) should call this function instead.
+ *
+ * NOTE: This code is scheduled for replacement by the Rust worktrunk-core
+ * rewrite in T9977/T9986. Do NOT over-engineer.
+ *
+ * @param projectRoot - The project root that owns `.claude/worktrees/`.
+ * @param opts - See {@link ScanOptions}.
+ * @returns {@link OrphanScanResult} wrapping the discovered orphans.
+ *
+ * @task T9962
+ */
+export async function scanWorktreeOrphansBudgeted(
+  projectRoot: string,
+  opts: ScanOptions = {},
+): Promise<OrphanScanResult> {
+  const maxEntriesPerLevel = opts.maxEntriesPerLevel ?? DEFAULT_MAX_ENTRIES_PER_LEVEL;
+  const softWarnEntriesPerLevel = opts.softWarnEntriesPerLevel ?? DEFAULT_SOFT_WARN_ENTRIES;
+  const worktreesRoot = opts.worktreesRoot ?? join(projectRoot, '.claude', 'worktrees');
+
+  if (!existsSync(worktreesRoot)) {
+    return { orphans: [], isPartial: false };
+  }
+
+  const startTime = Date.now();
+  const { timeoutMs } = opts;
+
+  const orphans: OrphanEntry[] = [];
+  const now = startTime;
+  let isPartial = false;
+  let partialReason: 'timeout' | 'overflow' | undefined;
+  let softWarnMessage: string | undefined;
+
+  const checkTimeout = (): boolean => {
+    if (timeoutMs !== undefined && Date.now() - startTime > timeoutMs) {
+      isPartial = true;
+      partialReason = 'timeout';
+      return true;
+    }
+    return false;
+  };
+
+  /**
+   * Recursive walker — mirrors the one in `scanWorktreeOrphans` but checks
+   * per-level entry counts and the wall-clock budget on each iteration.
+   */
+  const walk = (current: string, depth: number, worktreePath: string): boolean => {
+    if (depth > MAX_SCAN_DEPTH) return false;
+    if (checkTimeout()) return true;
+
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+
+    const dirEntries = entries.filter((e) => e.isDirectory());
+
+    // Soft-warn check (only emitted once, on the first level that crosses).
+    if (softWarnMessage === undefined && dirEntries.length > softWarnEntriesPerLevel) {
+      softWarnMessage =
+        `Warning: ${dirEntries.length} entries found at depth ${depth} under ${current} ` +
+        `(soft-warn threshold: ${softWarnEntriesPerLevel}). ` +
+        `Scan continues but may be slow. Run \`cleo doctor --prune-worktree-orphans\` ` +
+        `or reduce orphan count to avoid this warning.`;
+    }
+
+    // Hard-stop overflow check.
+    if (dirEntries.length > maxEntriesPerLevel) {
+      isPartial = true;
+      partialReason = 'overflow';
+      return true;
+    }
+
+    for (const entry of dirEntries) {
+      if (checkTimeout()) return true;
+
+      const childPath = join(current, entry.name);
+
+      if (entry.name === '.cleo') {
+        const meta = collectOrphanMetadata(childPath);
+        const lastModifiedMs = meta.lastModifiedMs > 0 ? meta.lastModifiedMs : now;
+        orphans.push({
+          worktreePath,
+          orphanPath: childPath,
+          dbFiles: meta.dbFiles,
+          sizeBytes: meta.sizeBytes,
+          lastModifiedAt: new Date(lastModifiedMs).toISOString(),
+          ageSeconds: Math.max(0, Math.floor((now - lastModifiedMs) / 1000)),
+          isFullDuplicate: meta.isFullDuplicate,
+        });
+        continue;
+      }
+
+      if (walk(childPath, depth + 1, worktreePath)) return true;
+    }
+    return false;
+  };
+
+  let topLevel: Dirent[];
+  try {
+    topLevel = readdirSync(worktreesRoot, { withFileTypes: true });
+  } catch {
+    return { orphans: [], isPartial: false };
+  }
+
+  // Check the top-level width budget first.
+  const topLevelDirs = topLevel.filter((e) => e.isDirectory());
+
+  if (topLevelDirs.length > maxEntriesPerLevel) {
+    isPartial = true;
+    partialReason = 'overflow';
+    return { orphans, isPartial, partialReason, softWarnMessage };
+  }
+
+  if (softWarnMessage === undefined && topLevelDirs.length > softWarnEntriesPerLevel) {
+    softWarnMessage =
+      `Warning: ${topLevelDirs.length} entries found at the top-level under ${worktreesRoot} ` +
+      `(soft-warn threshold: ${softWarnEntriesPerLevel}). ` +
+      `Scan continues but may be slow. Run \`cleo doctor --prune-worktree-orphans\` ` +
+      `or reduce orphan count to avoid this warning.`;
+  }
+
+  for (const entry of topLevelDirs) {
+    if (checkTimeout()) break;
+    const worktreePath = join(worktreesRoot, entry.name);
+    if (walk(worktreePath, 1, worktreePath)) break;
+  }
+
+  orphans.sort((a, b) => a.orphanPath.localeCompare(b.orphanPath));
+
+  if (!isPartial) {
+    return { orphans, isPartial: false, softWarnMessage };
+  }
+
+  return { orphans, isPartial, partialReason, softWarnMessage };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Width budget: soft-warn 100 / hard-stop 500 per level with `isPartial: true, partialReason: 'overflow'`
- Timeout: `--timeout <seconds>` flag (default 30s) on `cleo doctor --audit-worktree-orphans` and `--prune-worktree-orphans`
- Partial flag: `isPartial` + `partialReason` on result envelope (`OrphanScanResult`, `ComprehensiveAuditResult`)
- New `scanWorktreeOrphansBudgeted()` wraps existing bare-array scanner; existing callers unaffected

## Why
194-orphan corpus took 60s+ — depth was already bounded (MAX_SCAN_DEPTH=3), real cost is width × per-entry IO. Strategic fix is T9977's Rust rewrite; this is the tactical patch.

## Test plan
- [x] `pnpm --filter @cleocode/core run test -- worktree-orphans` — 16 tests pass
- [x] Width-budget test: 501 top-level subdirs → `isPartial=true, partialReason='overflow'`
- [x] Soft-warn test: 101 entries → scan completes, `softWarnMessage` set
- [x] Timeout test: `timeoutMs=-1` → `isPartial=true, partialReason='timeout'` (deterministic)
- [x] biome check clean (0 violations)
- [x] All 16 existing + new tests pass

Closes T9962.