### PR TITLE
chore(T9964): v5.98 follow-ups — real briefing diet + ferrous-forge fix + release-prepare.yml

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,260 @@
+name: Release Prepare
+
+# Triggered by `cleo release open <version>` via:
+#   gh workflow run release-prepare.yml -f version=v2026.MM.N
+#
+# Responsibilities:
+#   1. Validate the version matches CalVer pattern
+#   2. Cut release/<version>-ship branch from main
+#   3. Bump versions in root package.json, all packages/*/package.json,
+#      and Cargo.toml workspace version
+#   4. Commit and push the release branch
+#   5. Open a PR from release/<version>-ship -> main
+#
+# After this workflow runs, the owner reviews the PR. On merge, the tag-push
+# triggers .github/workflows/release.yml which handles npm publish.
+#
+# See AGENTS.md "Release & Branching (ADR-065)" for full context.
+#
+# @task T9781
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'CalVer release version with v-prefix (e.g. v2026.5.99)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Prepare Release Branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate version format
+        id: version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          VERSION="$INPUT_VERSION"
+
+          # Must start with 'v'
+          if [[ "$VERSION" != v* ]]; then
+            echo "ERROR: version must start with 'v' (got: $VERSION)"
+            exit 1
+          fi
+
+          # Validate CalVer pattern: vYYYY.M.PATCH or vYYYY.M.PATCH-suffix
+          if ! echo "$VERSION" | grep -qE '^v[0-9]{4}\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'; then
+            echo "ERROR: version does not match CalVer pattern vYYYY.MM.PATCH (got: $VERSION)"
+            exit 1
+          fi
+
+          # Strip leading 'v' for use in package.json / Cargo.toml
+          VERSION_BARE="${VERSION#v}"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_bare=$VERSION_BARE" >> "$GITHUB_OUTPUT"
+          echo "branch=release/${VERSION}-ship" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION | bare: $VERSION_BARE | branch: release/${VERSION}-ship"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Cut release branch from main
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
+        run: |
+          git checkout -b "$BRANCH"
+          echo "Branch $BRANCH created from main"
+
+      - name: Bump root package.json version
+        env:
+          VERSION_BARE: ${{ steps.version.outputs.version_bare }}
+        run: |
+          if [[ -f "package.json" ]]; then
+            jq --arg v "$VERSION_BARE" '.version = $v' package.json > package.tmp \
+              && mv package.tmp package.json
+            echo "ROOT package.json -> $VERSION_BARE"
+          fi
+
+      - name: Bump workspace package.json versions
+        env:
+          VERSION_BARE: ${{ steps.version.outputs.version_bare }}
+        run: |
+          # All publishable workspace packages -- keep in sync with release.yml
+          PACKAGES=(
+            adapters agents animations brain caamp cant
+            cleo cleo-os contracts core git-shim lafs
+            mcp-adapter nexus paths playbooks runtime
+            skills studio worktree
+          )
+          for pkg in "${PACKAGES[@]}"; do
+            PKG_JSON="packages/$pkg/package.json"
+            if [[ -f "$PKG_JSON" ]]; then
+              jq --arg v "$VERSION_BARE" '.version = $v' "$PKG_JSON" > "$PKG_JSON.tmp" \
+                && mv "$PKG_JSON.tmp" "$PKG_JSON"
+              echo "packages/$pkg/package.json -> $VERSION_BARE"
+            fi
+          done
+
+      - name: Bump workspace @cleocode/* dependency refs
+        env:
+          VERSION_BARE: ${{ steps.version.outputs.version_bare }}
+        run: |
+          # Update any @cleocode/* dep pinned to a specific numeric version
+          # (not workspace:* -- those are handled by pnpm at publish time).
+          for PKG_JSON in packages/*/package.json; do
+            updated=$(jq --arg v "$VERSION_BARE" '
+              def bump_if_numeric:
+                if . and (test("^[0-9]")) then $v else . end;
+              (.dependencies // {}) |= with_entries(.value |= bump_if_numeric) |
+              (.devDependencies // {}) |= with_entries(.value |= bump_if_numeric) |
+              (.peerDependencies // {}) |= with_entries(.value |= bump_if_numeric)
+            ' "$PKG_JSON")
+            echo "$updated" > "$PKG_JSON"
+          done
+          echo "Workspace @cleocode/* numeric dep refs updated"
+
+      - name: Bump Cargo.toml workspace version
+        env:
+          VERSION_BARE: ${{ steps.version.outputs.version_bare }}
+        run: |
+          if [[ -f "Cargo.toml" ]]; then
+            # Replace the version field in the [package] section.
+            # The workspace Cargo.toml contains: version = "YYYY.M.patch"
+            # sed targets the first occurrence (workspace package table).
+            # Using perl for portable in-place regex with back-references.
+            perl -i -pe 's{^(version\s*=\s*")[^"]+(")}{"${1}'"$VERSION_BARE"'${2}"}e if 1..1' Cargo.toml
+            echo "Cargo.toml [package].version -> $VERSION_BARE"
+          fi
+
+      - name: Resolve release title from plan (if available)
+        id: plan
+        env:
+          VERSION_BARE: ${{ steps.version.outputs.version_bare }}
+        run: |
+          PLAN_FILE=".cleo/release/${VERSION_BARE}.plan.json"
+          if [[ -f "$PLAN_FILE" ]]; then
+            EPIC_TITLE=$(jq -r '.epicTitle // .title // empty' "$PLAN_FILE" 2>/dev/null || true)
+            if [[ -n "$EPIC_TITLE" ]]; then
+              echo "title=${EPIC_TITLE}" >> "$GITHUB_OUTPUT"
+              echo "Plan title: $EPIC_TITLE"
+            else
+              echo "title=" >> "$GITHUB_OUTPUT"
+              echo "No epicTitle in plan -- using generic message"
+            fi
+          else
+            echo "title=" >> "$GITHUB_OUTPUT"
+            echo "No plan file at $PLAN_FILE -- using generic commit message"
+          fi
+
+      - name: Commit version bump
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          EPIC_TITLE: ${{ steps.plan.outputs.title }}
+        run: |
+          git add \
+            package.json \
+            packages/*/package.json \
+            Cargo.toml || true
+
+          if [[ -n "$EPIC_TITLE" ]]; then
+            COMMIT_MSG="release: ship ${VERSION} -- ${EPIC_TITLE}"
+          else
+            COMMIT_MSG="release: ship ${VERSION}"
+          fi
+
+          # Only commit if there are staged changes
+          if ! git diff --cached --quiet; then
+            git commit -m "$COMMIT_MSG"
+            echo "Committed: $COMMIT_MSG"
+          else
+            echo "No version changes to commit (versions may already be correct)"
+          fi
+
+      - name: Push release branch
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
+        run: |
+          git push -u origin "$BRANCH"
+          echo "Pushed branch: $BRANCH"
+
+      - name: Open pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          VERSION_BARE: ${{ steps.version.outputs.version_bare }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          EPIC_TITLE: ${{ steps.plan.outputs.title }}
+        run: |
+          if [[ -n "$EPIC_TITLE" ]]; then
+            PR_TITLE="release: ship ${VERSION} -- ${EPIC_TITLE}"
+          else
+            PR_TITLE="release: ship ${VERSION}"
+          fi
+
+          PR_BODY="## Release ${VERSION}
+
+          This PR was opened automatically by the \`release-prepare\` workflow
+          (triggered via \`cleo release open ${VERSION}\`).
+
+          ### What this PR does
+          - Bumps all \`packages/*/package.json\` versions to \`${VERSION_BARE}\`
+          - Bumps root \`package.json\` and \`Cargo.toml\` workspace version
+          - Provides a clean merge point for review before the tag is pushed
+
+          ### Next steps
+          1. Review the version bump diff
+          2. Merge this PR (admin merge OK -- no approver required per branch protection)
+          3. Push the release tag: \`git tag ${VERSION} && git push origin ${VERSION}\`
+          4. The \`release.yml\` workflow fires on tag push and handles npm publish
+
+          > Workflow: \`release-prepare.yml\` | Task: T9781"
+
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY")
+
+          echo "PR URL: $PR_URL"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        run: |
+          echo "### Release Prepare Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Version | \`$VERSION\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Branch | \`$BRANCH\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| PR | $PR_URL |" >> "$GITHUB_STEP_SUMMARY"

--- a/packages/cleo/src/cli/commands/briefing.ts
+++ b/packages/cleo/src/cli/commands/briefing.ts
@@ -267,6 +267,18 @@ export const briefingCommand = defineCommand({
       description: 'Include user profile traits in the bundle (suppressed by default)',
       default: false,
     },
+    /**
+     * T9964: restore full text fields on peerLearnings and decisions.
+     * By default these are truncated to 80-char previews with a `_next.fetch`
+     * hint. Pass --memory-detail to restore the full `insight` and `decision`
+     * body fields (equivalent to pre-T9964 output for those fields).
+     */
+    'memory-detail': {
+      type: 'boolean',
+      description:
+        'Restore full peerLearnings/decisions body text (suppressed by default for token budget)',
+      default: false,
+    },
   },
   async run({ args, cmd, rawArgs }) {
     // Citty does not route to subcommands within lazy-loaded top-level commands.
@@ -300,6 +312,7 @@ export const briefingCommand = defineCommand({
         maxEpics: parseInt(args['max-epics'], 10),
         debug: args.debug as boolean | undefined,
         withProfile: args['with-profile'] as boolean | undefined,
+        memoryDetail: args['memory-detail'] as boolean | undefined,
       },
       { command: 'briefing' },
     );

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -45,7 +44,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description:
+      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,8 +63,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +84,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,20 +102,23 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -135,7 +141,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -244,7 +251,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -267,14 +275,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -298,7 +308,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -309,7 +320,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -322,7 +334,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -358,7 +371,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -381,7 +395,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description:
+      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -412,7 +427,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -435,14 +451,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -471,7 +490,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -513,14 +533,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -549,7 +572,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -561,13 +585,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -610,7 +636,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -621,7 +648,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -657,7 +685,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description:
+      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -669,7 +698,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -681,7 +711,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -729,13 +760,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description:
+      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -813,7 +846,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -825,13 +859,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description:
+      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -44,8 +45,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description:
-      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -84,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -102,23 +99,20 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -141,8 +135,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -251,8 +244,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -275,16 +267,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -308,8 +298,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -320,8 +309,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -334,8 +322,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -371,8 +358,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -395,8 +381,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description:
-      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -427,8 +412,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -451,17 +435,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -490,8 +471,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -533,17 +513,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -572,8 +549,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -585,15 +561,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -636,8 +610,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -648,8 +621,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description:
-      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -685,8 +657,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description:
-      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -698,8 +669,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -711,8 +681,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -760,15 +729,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -846,8 +813,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -859,15 +825,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description:
-      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/test/fixtures/release-test-rust-crate/Cargo.toml
+++ b/packages/cleo/test/fixtures/release-test-rust-crate/Cargo.toml
@@ -5,4 +5,30 @@ resolver = "2"
 [package]
 name = "release-test-rust-crate"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
+rust-version = "1.88"
+
+[lints.rust]
+missing_docs = "warn"
+unsafe_code = "deny"
+
+[lints.rustdoc]
+broken_intra_doc_links = "deny"
+invalid_html_tags = "deny"
+missing_crate_level_docs = "warn"
+bare_urls = "warn"
+redundant_explicit_links = "warn"
+unescaped_backticks = "warn"
+private_intra_doc_links = "warn"
+
+[lints.clippy]
+missing_safety_doc = "deny"
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+empty_docs = "warn"
+doc_markdown = "warn"
+needless_doctest_main = "warn"
+suspicious_doc_comments = "warn"
+too_long_first_doc_paragraph = "warn"
+unwrap_used = "deny"
+expect_used = "deny"

--- a/packages/contracts/src/operations/session.ts
+++ b/packages/contracts/src/operations/session.ts
@@ -321,6 +321,17 @@ export interface SessionBriefingShowParams {
    * @task T9974
    */
   withProfile?: boolean;
+  /**
+   * When true, restore full text fields on peerLearnings and decisions
+   * (the `insight` and `decision` body fields respectively). By default
+   * these are stripped and only `{id, title, createdAt, _next}` is emitted
+   * to reduce token consumption (T9964 Part 1 follow-up).
+   *
+   * Alias: `--memory-detail` on the CLI.
+   *
+   * @task T9964
+   */
+  memoryDetail?: boolean;
 }
 
 /** Compact task entry in a session briefing's next-tasks list. */

--- a/packages/core/src/sessions/__tests__/briefing-diet.test.ts
+++ b/packages/core/src/sessions/__tests__/briefing-diet.test.ts
@@ -34,9 +34,14 @@ vi.mock('../../lifecycle/pipeline.js', () => ({
 
 // Mock attachment store
 const mockListByOwner = vi.fn().mockResolvedValue([]);
+// T9964: getExtras returns a slug by default so entries survive the slug-filter
+// in applyDocsFilter. Tests that need to exercise slug-less behaviour can
+// override this mock in the individual test.
+const mockGetExtras = vi.fn().mockResolvedValue({ slug: 'test-slug', type: null });
 vi.mock('../../store/attachment-store.js', () => ({
   createAttachmentStore: vi.fn(() => ({
     listByOwner: mockListByOwner,
+    getExtras: mockGetExtras,
     put: vi.fn(),
     get: vi.fn(),
     getMetadata: vi.fn(),
@@ -201,6 +206,8 @@ describe('briefing diet (T9974)', () => {
     vi.clearAllMocks();
     mockBuildRetrievalBundle.mockResolvedValue(makeMockBundle());
     mockListByOwner.mockResolvedValue([]);
+    // Default: getExtras returns a slug so docs survive the slug-filter
+    mockGetExtras.mockResolvedValue({ slug: 'test-slug', type: null });
   });
 
   // ── AC1 / AC2: peerPatterns suppressed by default, present with --debug ──
@@ -519,5 +526,165 @@ describe('briefing diet (T9974)', () => {
         "nextTasksUpTo5": true,
       }
     `);
+  });
+
+  // ── T9964 Part 1: REAL briefing diet additional assertions ──────────────────
+
+  // assert default tokenCounts.total ≤ 1000 for a project with ≥10 peerLearnings + ≥10 decisions
+  it('T9964: default token count ≤ 1000 with 10 peerLearnings + 10 decisions', async () => {
+    setupMockAccessor();
+
+    // Build a bundle with 10 full-prose learnings and 10 full-prose decisions
+    const heavyBundle = {
+      cold: {
+        userProfile: [],
+        peerInstructions: '',
+        sigilCard: null,
+      },
+      warm: {
+        peerLearnings: Array.from({ length: 10 }, (_, i) => ({
+          id: `L${i}`,
+          insight: `This is a very detailed learning insight with lots of prose text that would normally consume many tokens in a briefing response. Learning #${i} explains an architectural decision about the distributed system components and how they interact with each other in complex ways.`,
+          createdAt: '2026-05-01T00:00:00Z',
+        })),
+        peerPatterns: [],
+        decisions: Array.from({ length: 10 }, (_, i) => ({
+          id: `D${i}`,
+          decision: `This is a very detailed decision record with lots of prose text that would normally consume many tokens in a briefing response. Decision #${i} covers the architectural choice about distributed system components and the trade-offs considered.`,
+          createdAt: '2026-05-01T00:00:00Z',
+        })),
+      },
+      hot: {
+        sessionNarrative: '',
+        recentObservations: [],
+        activeTasks: [],
+      },
+      tokenCounts: { cold: 0, warm: 5000, hot: 0, total: 5000 },
+    };
+    mockBuildRetrievalBundle.mockResolvedValue(heavyBundle);
+
+    const briefing = await computeBriefing('/fake/project', {});
+
+    const total = briefing.bundle?.tokenCounts.total ?? 0;
+    expect(total).toBeLessThanOrEqual(1000);
+    // Confirm we have diet-capped entries (≤3 learnings, ≤3 decisions)
+    expect(briefing.bundle?.warm.peerLearnings.length).toBeLessThanOrEqual(3);
+    expect(briefing.bundle?.warm.decisions.length).toBeLessThanOrEqual(3);
+  });
+
+  // assert --memory-detail preserves full text fields
+  it('T9964: --memory-detail preserves full peerLearnings insight text', async () => {
+    setupMockAccessor();
+
+    const fullInsight =
+      'Full detailed insight text that should not be truncated when memoryDetail=true — this text is definitely longer than 80 characters.';
+    const bundle = {
+      ...makeMockBundle(),
+      warm: {
+        ...makeMockBundle().warm,
+        peerLearnings: [{ id: 'L1', insight: fullInsight, createdAt: '2026-05-01T00:00:00Z' }],
+        decisions: [{ id: 'D1', decision: fullInsight, createdAt: '2026-05-01T00:00:00Z' }],
+      },
+    };
+    mockBuildRetrievalBundle.mockResolvedValue(bundle);
+
+    const briefing = await computeBriefing('/fake/project', { memoryDetail: true });
+
+    expect(briefing.bundle?.warm.peerLearnings[0]?.insight).toBe(fullInsight);
+    expect(briefing.bundle?.warm.decisions[0]?.decision).toBe(fullInsight);
+  });
+
+  // assert default mode truncates peerLearnings insight to 80 chars
+  it('T9964: default mode truncates peerLearnings insight to 80 chars', async () => {
+    setupMockAccessor();
+
+    const fullInsight = 'A'.repeat(200); // 200-char insight that should be truncated
+    const bundle = {
+      ...makeMockBundle(),
+      warm: {
+        ...makeMockBundle().warm,
+        peerLearnings: [{ id: 'L1', insight: fullInsight, createdAt: '2026-05-01T00:00:00Z' }],
+        decisions: [],
+      },
+    };
+    mockBuildRetrievalBundle.mockResolvedValue(bundle);
+
+    const briefing = await computeBriefing('/fake/project', {});
+
+    const insight = briefing.bundle?.warm.peerLearnings[0]?.insight ?? '';
+    expect(insight.length).toBeLessThanOrEqual(80);
+  });
+
+  // assert peerLearnings[i].insight is undefined on diet (no _next field in base type,
+  // but insight should be truncated, not absent)
+  it('T9964: diet mode adds _next.fetch hint to peerLearnings entries', async () => {
+    setupMockAccessor();
+
+    const bundle = {
+      ...makeMockBundle(),
+      warm: {
+        ...makeMockBundle().warm,
+        peerLearnings: [{ id: 'L42', insight: 'Some insight', createdAt: '2026-05-01T00:00:00Z' }],
+        decisions: [],
+      },
+    };
+    mockBuildRetrievalBundle.mockResolvedValue(bundle);
+
+    const briefing = await computeBriefing('/fake/project', {});
+
+    const learning = briefing.bundle?.warm.peerLearnings[0] as Record<string, unknown> | undefined;
+    expect(learning).toBeDefined();
+    // _next hint is attached at runtime (not in the static type but present in JSON)
+    expect((learning as Record<string, unknown>)?.['_next']).toEqual({
+      fetch: 'cleo memory fetch L42',
+    });
+  });
+
+  // assert relatedDocs entries without slug are dropped
+  it('T9964: relatedDocs entries without slug are dropped from diet output', async () => {
+    const tasks = makeTasks();
+    vi.mocked(getTaskAccessor).mockResolvedValue({
+      loadSessions: vi.fn().mockResolvedValue([]),
+      getActiveSession: vi.fn().mockResolvedValue({ id: 'sess-001', activePeerId: 'global' }),
+      queryTasks: vi.fn().mockResolvedValue({ tasks, total: tasks.length }),
+      getMetaValue: vi.fn().mockImplementation((key: string) => {
+        if (key === 'focus_state')
+          return Promise.resolve({ currentTask: 'T11', currentPhase: null });
+        return Promise.resolve(null);
+      }),
+      setMetaValue: vi.fn().mockResolvedValue(undefined),
+      loadArchive: vi.fn().mockResolvedValue(null),
+      saveArchive: vi.fn().mockResolvedValue(undefined),
+      appendLog: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      engine: 'sqlite' as const,
+    });
+
+    const now = new Date().toISOString();
+    mockListByOwner.mockImplementation(async (_ownerType: string, taskId: string) => {
+      if (taskId === 'T11') return [];
+      if (taskId === 'T12') return [makeAttachmentMeta('doc-with-slug', now)];
+      if (taskId === 'T13') return [makeAttachmentMeta('doc-without-slug', now)];
+      return [];
+    });
+
+    // T12 gets a slug, T13 does not
+    mockGetExtras.mockImplementation(async (id: string) => {
+      if (id === 'doc-with-slug') return { slug: 'my-doc-slug', type: 'adr' };
+      return { slug: null, type: null }; // no slug — should be dropped
+    });
+
+    const briefing = await computeBriefing('/fake/project', {});
+
+    const relatedIds = briefing.docsContext?.relatedDocs.map((d) => d.attachmentId) ?? [];
+    // Only the entry with a slug should survive
+    expect(relatedIds).toContain('doc-with-slug');
+    expect(relatedIds).not.toContain('doc-without-slug');
+    // The slug and type should be populated
+    const docWithSlug = briefing.docsContext?.relatedDocs.find(
+      (d) => d.attachmentId === 'doc-with-slug',
+    );
+    expect(docWithSlug?.slug).toBe('my-doc-slug');
+    expect(docWithSlug?.type).toBe('adr');
   });
 });

--- a/packages/core/src/sessions/__tests__/briefing-docs.test.ts
+++ b/packages/core/src/sessions/__tests__/briefing-docs.test.ts
@@ -31,9 +31,13 @@ vi.mock('../../lifecycle/pipeline.js', () => ({
 
 // Mock attachment store — the docs pillar uses createAttachmentStore
 const mockListByOwner = vi.fn().mockResolvedValue([]);
+// T9964: getExtras returns a slug by default so docs survive the slug-filter
+// in applyDocsFilter (entries without a slug are dropped in diet mode).
+const mockGetExtras = vi.fn().mockResolvedValue({ slug: 'test-slug', type: null });
 vi.mock('../../store/attachment-store.js', () => ({
   createAttachmentStore: vi.fn(() => ({
     listByOwner: mockListByOwner,
+    getExtras: mockGetExtras,
     put: vi.fn(),
     get: vi.fn(),
     getMetadata: vi.fn(),

--- a/packages/core/src/sessions/__tests__/briefing-scope-handoff.test.ts
+++ b/packages/core/src/sessions/__tests__/briefing-scope-handoff.test.ts
@@ -31,10 +31,14 @@ vi.mock('../../lifecycle/pipeline.js', () => ({
 // Mock attachment store
 const mockListByOwner = vi.fn().mockResolvedValue([]);
 const mockListAllInProject = vi.fn().mockResolvedValue([]);
+// T9964: getExtras returns a slug by default so docs survive the slug-filter
+// in applyDocsFilter (entries without a slug are dropped in diet mode).
+const mockGetExtras = vi.fn().mockResolvedValue({ slug: 'test-slug', type: null });
 vi.mock('../../store/attachment-store.js', () => ({
   createAttachmentStore: vi.fn(() => ({
     listByOwner: mockListByOwner,
     listAllInProject: mockListAllInProject,
+    getExtras: mockGetExtras,
     put: vi.fn(),
     get: vi.fn(),
     getMetadata: vi.fn(),

--- a/packages/core/src/sessions/briefing.ts
+++ b/packages/core/src/sessions/briefing.ts
@@ -99,6 +99,21 @@ export interface BriefingDocRef {
   labels?: string[];
   /** ISO 8601 creation timestamp. */
   createdAt: string;
+  /**
+   * Human-readable kebab-case slug for this attachment (when set).
+   * Only entries with a slug are surfaced in the default briefing diet;
+   * entries without a slug are dropped as they cannot be fetched by name.
+   *
+   * @task T9964
+   */
+  slug?: string;
+  /**
+   * Document type classification (e.g. "adr", "spec", "handoff", "research").
+   * Set when the attachment was created with an explicit type annotation.
+   *
+   * @task T9964
+   */
+  type?: string;
 }
 
 /**
@@ -247,17 +262,19 @@ export async function computeBriefing(
     scopeTaskIds,
   });
 
-  // 5. Blocked tasks
+  // 5. Blocked tasks — default diet cap of 3 (T9964)
   const blockedTasks = computeBlockedTasks(tasks, taskMap, {
-    maxBlocked: params.maxBlocked ?? 10,
+    maxBlocked: params.maxBlocked ?? MAX_BLOCKED_TASKS_DIET,
     scopeTaskIds,
+    truncateTitles: true,
   });
 
-  // 6. Active epics — deduped against nextTasks (T9974)
+  // 6. Active epics — deduped against nextTasks (T9974), diet cap of 3 (T9964)
   const nextTaskIdSet = new Set(nextTasks.map((t) => t.id));
   const rawActiveEpics = computeActiveEpics(tasks, taskMap, {
-    maxEpics: params.maxEpics ?? 5,
+    maxEpics: params.maxEpics ?? MAX_ACTIVE_EPICS_DIET,
     scopeTaskIds,
+    truncateTitles: true,
   });
   // Remove epics already surfaced in nextTasks to avoid duplicate signal
   const activeEpics = rawActiveEpics.filter((e) => !nextTaskIdSet.has(e.id));
@@ -266,10 +283,26 @@ export async function computeBriefing(
   const pipelineStage = await computePipelineStage(focus);
 
   // 8. Brain memory context (optional, best-effort)
+  // T9964: truncate title fields to MAX_MEMORY_TITLE_LEN_DIET in default mode.
   let memoryContext: SessionMemoryContext | undefined;
   try {
     const { getSessionMemoryContext } = await import('../memory/session-memory.js');
-    memoryContext = await getSessionMemoryContext(projectRoot, scopeFilter);
+    const rawMemoryContext = await getSessionMemoryContext(projectRoot, scopeFilter);
+    if (!params.memoryDetail) {
+      // Truncate title fields to 80 chars to reduce token count.
+      // BrainCompactHit has a `title` string field — we map over arrays.
+      const truncHits = <T extends { title: string }>(hits: T[]): T[] =>
+        hits.map((h) => ({ ...h, title: truncate(h.title, MAX_MEMORY_TITLE_LEN_DIET) }));
+      memoryContext = {
+        ...rawMemoryContext,
+        recentLearnings: truncHits(rawMemoryContext.recentLearnings),
+        recentObservations: truncHits(rawMemoryContext.recentObservations),
+        relevantPatterns: truncHits(rawMemoryContext.relevantPatterns),
+        recentDecisions: truncHits(rawMemoryContext.recentDecisions),
+      };
+    } else {
+      memoryContext = rawMemoryContext;
+    }
   } catch {
     // Brain memory not available -- proceed without
   }
@@ -315,6 +348,7 @@ export async function computeBriefing(
       bundle = applyBriefingDiet(rawBundle, {
         debug: params.debug ?? false,
         withProfile: params.withProfile ?? false,
+        memoryDetail: params.memoryDetail ?? false,
       });
     }
   } catch {
@@ -340,6 +374,16 @@ export async function computeBriefing(
     // Docs context not available -- proceed without
   }
 
+  // T9964: Strip empty arrays from lastSession.handoff to reduce token noise.
+  // Empty `tasksCompleted`, `tasksCreated`, `nextSuggested`, `openBlockers`,
+  // `openBugs` add JSON weight without actionable content.
+  const cleanedLastSession: LastSessionInfo | null = lastSession
+    ? {
+        ...lastSession,
+        handoff: cleanHandoff(lastSession.handoff),
+      }
+    : null;
+
   // Compute warnings
   const warnings: string[] = [];
   if (currentTaskInfo?.blockedBy?.length) {
@@ -350,7 +394,7 @@ export async function computeBriefing(
 
   // Build partial briefing for contract assertion
   const partialBriefing: SessionBriefing = {
-    lastSession,
+    lastSession: cleanedLastSession,
     currentTask: currentTaskInfo,
     nextTasks,
     openBugs,
@@ -758,7 +802,7 @@ function computeOpenBugs(
 function computeBlockedTasks(
   tasks: unknown[],
   taskMap: Map<string, unknown>,
-  options: { maxBlocked: number; scopeTaskIds?: Set<string> },
+  options: { maxBlocked: number; scopeTaskIds?: Set<string>; truncateTitles?: boolean },
 ): BriefingBlockedTask[] {
   const blocked: BriefingBlockedTask[] = [];
 
@@ -795,7 +839,7 @@ function computeBlockedTasks(
     if (blockedBy.length > 0) {
       blocked.push({
         id: t.id,
-        title: t.title,
+        title: options.truncateTitles ? truncate(t.title, MAX_TITLE_LEN_DIET) : t.title,
         blockedBy,
       });
     }
@@ -836,7 +880,7 @@ function isTestFixtureEpic(id: string, title: string): boolean {
 function computeActiveEpics(
   tasks: unknown[],
   taskMap: Map<string, unknown>,
-  options: { maxEpics: number; scopeTaskIds?: Set<string> },
+  options: { maxEpics: number; scopeTaskIds?: Set<string>; truncateTitles?: boolean },
 ): BriefingEpic[] {
   const epics: BriefingEpic[] = [];
 
@@ -868,7 +912,7 @@ function computeActiveEpics(
     const completionPercent = calculateEpicCompletion(t.id, taskMap);
     epics.push({
       id: t.id,
-      title: t.title,
+      title: options.truncateTitles ? truncate(t.title, MAX_TITLE_LEN_DIET) : t.title,
       completionPercent,
     });
   }
@@ -929,7 +973,7 @@ async function computePipelineStage(
 }
 
 // ---------------------------------------------------------------------------
-// T9974: Briefing diet helpers — noise suppression for default mode
+// T9974 / T9964: Briefing diet helpers — noise suppression for default mode
 // ---------------------------------------------------------------------------
 
 /** Maximum relatedDocs entries in the default (diet) briefing output. */
@@ -937,15 +981,76 @@ const MAX_RELATED_DOCS_DIET = 5;
 /** Recency window (ms) for relatedDocs in diet mode — 7 days. */
 const RELATED_DOCS_RECENCY_MS = 7 * 24 * 60 * 60 * 1000;
 
+/** Maximum peerLearnings entries in the default (diet) briefing output. */
+const MAX_PEER_LEARNINGS_DIET = 3;
+/** Maximum decisions entries in the default (diet) briefing output. */
+const MAX_DECISIONS_DIET = 3;
+/** Maximum blockedTasks entries in the default (diet) briefing output. */
+const MAX_BLOCKED_TASKS_DIET = 3;
+/** Maximum activeEpics entries in the default (diet) briefing output. */
+const MAX_ACTIVE_EPICS_DIET = 3;
+/** Maximum title length (chars) for blockedTasks/activeEpics entries in diet mode. */
+const MAX_TITLE_LEN_DIET = 60;
+/** Maximum memoryContext title length (chars) in diet mode. */
+const MAX_MEMORY_TITLE_LEN_DIET = 80;
+
+/**
+ * Truncate a string to the given max length, appending `…` when truncated.
+ */
+function truncate(str: string, maxLen: number): string {
+  return str.length > maxLen ? `${str.slice(0, maxLen - 1)}…` : str;
+}
+
+/**
+ * Strip empty arrays from a handoff data object.
+ *
+ * Empty `tasksCompleted`, `tasksCreated`, `nextSuggested`, `openBlockers`,
+ * and `openBugs` arrays add JSON weight without actionable content for a new
+ * orchestrator session. This function removes only the zero-length arrays;
+ * non-empty ones are preserved as-is.
+ *
+ * @param handoff - Raw handoff data from the last session.
+ * @returns Handoff with empty array fields omitted.
+ *
+ * @task T9964
+ */
+function cleanHandoff(handoff: HandoffData): HandoffData {
+  // Build a mutable copy. We cast to a plain record to permit `delete` on
+  // optional array fields — `HandoffData` keys are all declared non-optional
+  // but the runtime intent is to drop zero-length arrays before serialisation.
+  const cleaned = { ...handoff } as unknown as Record<string, unknown>;
+  const arrayKeys: ReadonlyArray<keyof HandoffData> = [
+    'tasksCompleted',
+    'tasksCreated',
+    'nextSuggested',
+    'openBlockers',
+    'openBugs',
+  ];
+  for (const key of arrayKeys) {
+    const val = cleaned[key];
+    if (Array.isArray(val) && val.length === 0) {
+      delete cleaned[key];
+    }
+  }
+  return cleaned as unknown as HandoffData;
+}
+
 /**
  * Post-process a `RetrievalBundle` to suppress noisy fields in default mode.
  *
- * Rules applied:
+ * Rules applied (T9974 / T9964):
  * - `warm.peerPatterns`: stripped unless `debug` is true
  * - `cold.userProfile`: stripped unless `withProfile` is true
+ * - `warm.peerLearnings`: stripped to `{id, insight_title, createdAt, _next}`
+ *   unless `memoryDetail` is true. Capped at {@link MAX_PEER_LEARNINGS_DIET}.
+ *   The `insight` body field is renamed to `insight_title` and is a truncated
+ *   preview (first 80 chars) for orientation. Full text via `--memory-detail`.
+ * - `warm.decisions`: stripped to `{id, decision_title, createdAt, _next}`
+ *   unless `memoryDetail` is true. Capped at {@link MAX_DECISIONS_DIET}.
  * - `hot.sessionNarrative`: the key is retained in the type but callers
- *   building the final envelope should omit it when empty (handled in
- *   {@link computeBriefing} via the spread pattern)
+ *   building the final envelope should omit it when empty.
+ * - Token counts are recomputed from the diet output so consumers see the
+ *   actual post-diet token estimate.
  *
  * This keeps `buildRetrievalBundle` unchanged (backward-compat) and applies
  * the diet at the briefing layer only.
@@ -955,21 +1060,61 @@ const RELATED_DOCS_RECENCY_MS = 7 * 24 * 60 * 60 * 1000;
  * @returns A new bundle with noise fields suppressed.
  *
  * @task T9974
+ * @task T9964
  */
 function applyBriefingDiet(
   bundle: RetrievalBundle,
-  opts: { debug: boolean; withProfile: boolean },
+  opts: { debug: boolean; withProfile: boolean; memoryDetail: boolean },
 ): RetrievalBundle {
-  return {
+  // peerLearnings: in diet mode emit {id, insight (80-char preview), createdAt}
+  // with a _next hint for fetching full text. Full insight is preserved when memoryDetail=true.
+  // RetrievalLearning does not declare _next — cast to include the extension field.
+  type DietLearning = import('@cleocode/contracts').RetrievalLearning & {
+    _next?: Record<string, string>;
+  };
+  const peerLearnings: DietLearning[] = opts.memoryDetail
+    ? bundle.warm.peerLearnings
+    : bundle.warm.peerLearnings.slice(0, MAX_PEER_LEARNINGS_DIET).map(
+        (l): DietLearning => ({
+          id: l.id,
+          insight: truncate(l.insight, MAX_MEMORY_TITLE_LEN_DIET),
+          createdAt: l.createdAt,
+          ...(l.provenanceClass !== undefined ? { provenanceClass: l.provenanceClass } : {}),
+          _next: { fetch: `cleo memory fetch ${l.id}` },
+        }),
+      );
+
+  // decisions: in diet mode emit {id, decision (80-char preview), createdAt}
+  // with a _next hint for fetching full text. Full body preserved when memoryDetail=true.
+  // RetrievalDecision does not declare _next — cast to include the extension field.
+  type DietDecision = import('@cleocode/contracts').RetrievalDecision & {
+    _next?: Record<string, string>;
+  };
+  const decisions: DietDecision[] = opts.memoryDetail
+    ? bundle.warm.decisions
+    : bundle.warm.decisions.slice(0, MAX_DECISIONS_DIET).map(
+        (d): DietDecision => ({
+          id: d.id,
+          decision: truncate(d.decision, MAX_MEMORY_TITLE_LEN_DIET),
+          createdAt: d.createdAt,
+          ...(d.provenanceClass !== undefined ? { provenanceClass: d.provenanceClass } : {}),
+          _next: { fetch: `cleo memory fetch ${d.id}` },
+        }),
+      );
+
+  // RetrievalBundle.warm expects the base types; DietLearning/DietDecision are
+  // structural supertypes so the cast is safe — the extra `_next` field is
+  // present at runtime and surfaced in JSON serialisation.
+  const dietBundle: RetrievalBundle = {
     cold: {
       userProfile: opts.withProfile ? bundle.cold.userProfile : [],
       peerInstructions: bundle.cold.peerInstructions,
       sigilCard: bundle.cold.sigilCard,
     },
     warm: {
-      peerLearnings: bundle.warm.peerLearnings,
+      peerLearnings: peerLearnings as import('@cleocode/contracts').RetrievalLearning[],
       peerPatterns: opts.debug ? bundle.warm.peerPatterns : [],
-      decisions: bundle.warm.decisions,
+      decisions: decisions as import('@cleocode/contracts').RetrievalDecision[],
     },
     hot: {
       // Drop sessionNarrative entirely when it is an empty string — keeps the
@@ -980,10 +1125,36 @@ function applyBriefingDiet(
     },
     tokenCounts: bundle.tokenCounts,
   };
+
+  // Recompute token estimates after diet so consumers see post-diet cost.
+  // Simple heuristic: 1 token ≈ 4 chars (conservative, consistent with
+  // the estimateTokens() function in brain-retrieval.ts).
+  const estimate = (s: string): number => Math.ceil(s.length / 4);
+  let warmTokens = 0;
+  for (const l of dietBundle.warm.peerLearnings) warmTokens += estimate(l.insight);
+  for (const p of dietBundle.warm.peerPatterns) warmTokens += estimate(p.pattern);
+  for (const d of dietBundle.warm.decisions) warmTokens += estimate(d.decision);
+  let coldTokens = 0;
+  for (const t of dietBundle.cold.userProfile)
+    coldTokens += estimate(`${t.traitKey}:${t.traitValue}`);
+  coldTokens += estimate(dietBundle.cold.peerInstructions);
+  let hotTokens = estimate(dietBundle.hot.sessionNarrative);
+  for (const o of dietBundle.hot.recentObservations) hotTokens += estimate(o.narrative || o.title);
+  for (const t of dietBundle.hot.activeTasks) hotTokens += estimate(`${t.id} ${t.title}`);
+
+  dietBundle.tokenCounts = {
+    cold: coldTokens,
+    warm: warmTokens,
+    hot: hotTokens,
+    total: coldTokens + warmTokens + hotTokens,
+  };
+
+  return dietBundle;
 }
 
 /**
  * Apply the diet filter to `BriefingDocsContext`:
+ * - drop `relatedDocs` entries that have no `slug` (cannot be fetched by name)
  * - cap `relatedDocs` at {@link MAX_RELATED_DOCS_DIET}
  * - filter out `relatedDocs` entries older than {@link RELATED_DOCS_RECENCY_MS}
  *   when a scope is active (no-scope = no recency filter, avoids over-trimming
@@ -996,12 +1167,15 @@ function applyBriefingDiet(
  * @returns Filtered docs context.
  *
  * @task T9974
+ * @task T9964
  */
 function applyDocsFilter(ctx: BriefingDocsContext, scope: string | undefined): BriefingDocsContext {
   const now = Date.now();
   const applyRecency = scope !== undefined && scope !== 'global';
 
-  let filtered = ctx.relatedDocs;
+  // T9964: drop entries without a slug — useless to a fresh agent that cannot
+  // fetch the doc by name (only attachmentId would remain, which is opaque).
+  let filtered = ctx.relatedDocs.filter((doc) => Boolean(doc.slug));
 
   if (applyRecency) {
     filtered = filtered.filter((doc) => {
@@ -1068,10 +1242,15 @@ async function computeDocsContext(
 
   /**
    * Convert one AttachmentMetadata record into a BriefingDocRef.
+   *
+   * T9964: Also fetches slug + type from the extras column so consumers can
+   * identify documents by name (not just opaque attachmentId). Entries without
+   * a slug are returned with slug=undefined so callers can drop them when the
+   * identifier is required for a `cleo docs fetch` operation.
    */
-  function toDocRef(taskId: string, meta: AttachmentMetadata): BriefingDocRef {
+  async function toDocRef(taskId: string, meta: AttachmentMetadata): Promise<BriefingDocRef> {
     const att = meta.attachment;
-    return {
+    const base: BriefingDocRef = {
       taskId,
       attachmentId: meta.id,
       kind: att.kind,
@@ -1079,6 +1258,15 @@ async function computeDocsContext(
       ...(att.labels?.length ? { labels: att.labels } : {}),
       createdAt: meta.createdAt,
     };
+    // Best-effort: fetch slug + type extras; failure is non-fatal.
+    try {
+      const extras = await store.getExtras(meta.id, projectRoot);
+      if (extras?.slug) base.slug = extras.slug;
+      if (extras?.type) base.type = extras.type;
+    } catch {
+      // extras unavailable — proceed without slug/type
+    }
+    return base;
   }
 
   // 1. Fetch attachments for the currently focused task.
@@ -1087,7 +1275,7 @@ async function computeDocsContext(
     try {
       const metas = await store.listByOwner('task', currentTaskId, projectRoot);
       for (const meta of metas.slice(0, MAX_DOCS_PER_TASK)) {
-        currentTaskDocs.push(toDocRef(currentTaskId, meta));
+        currentTaskDocs.push(await toDocRef(currentTaskId, meta));
       }
     } catch {
       // Attachment store unavailable for this task — proceed without
@@ -1119,7 +1307,7 @@ async function computeDocsContext(
       const metas = await store.listByOwner('task', task.id, projectRoot);
       for (const meta of metas.slice(0, MAX_DOCS_PER_TASK)) {
         if (relatedDocs.length >= MAX_RELATED_DOCS) break;
-        relatedDocs.push(toDocRef(task.id, meta));
+        relatedDocs.push(await toDocRef(task.id, meta));
       }
     } catch {
       // Attachment store unavailable for this task — proceed without


### PR DESCRIPTION
## Summary

Three honest follow-ups from T9964 E-ORIENT-V2 v5.97 ship validation:

### Part 1: REAL briefing diet (T9974 AC1 was missed — 2367 tokens, target ≤1000)
- `peerLearnings`/`decisions` stripped to `{id, insight/decision preview, createdAt, _next.fetch}` in default mode; capped at 3 entries each
- `memoryContext.recent*` title fields truncated to 80 chars
- `relatedDocs` now fetches `slug`+`type` via `getExtras()`; entries without a slug are dropped (useless to a fresh agent)
- `blockedTasks`/`activeEpics` capped at 3 with 60-char title truncation
- `lastSession.handoff` strips empty arrays
- Token counts recomputed post-diet (not pre-diet estimate)
- New `--memory-detail` CLI flag / `memoryDetail` param restores full text fields
- 5 new T9964 tests + 3 existing test mocks updated to include `getExtras`
- `SessionBriefingShowParams.memoryDetail` added to contracts

### Part 2: ferrous-forge pre-commit no longer blocks releases (Option A)
- `packages/cleo/test/fixtures/release-test-rust-crate/Cargo.toml`: edition 2021→2024, rust-version 1.88 added, `[lints.*]` sections added
- Eliminates MISSINGDOCCONFIG + WRONGEDITION violations — pre-commit now passes without `--no-verify`
- All fixture tests unaffected (they check release-config.json, not edition/lints)

### Part 3: `.github/workflows/release-prepare.yml` added (closes T9781)
- `workflow_dispatch` with `version` input (e.g. `v2026.5.99`)
- Validates CalVer pattern; cuts `release/<version>-ship` branch from main
- Bumps root + 20 workspace `package.json` files + `Cargo.toml` workspace version
- Updates `@cleocode/*` numeric dep refs in workspace packages
- Reads `.cleo/release/<version>.plan.json` for epic title (if present)
- Commits, pushes branch, opens PR ready for review + admin merge
- Future releases: `cleo release open v2026.5.99` works end-to-end

## Test plan
- [x] 20 briefing-diet tests pass (15 existing + 5 new T9964)
- [x] 39 briefing-related tests pass (diet + docs + scope-handoff)
- [x] 72 briefing test files pass total (all 8 briefing test files)
- [x] Pre-commit hook passes WITHOUT `--no-verify` (ferrous-forge fix validated)
- [x] `release-prepare.yml` YAML syntax validated with python3 yaml parser
- [x] biome check clean on all changed files
- [x] Commit SHA: 269463cde

🤖 Generated with [Claude Code](https://claude.com/claude-code)