### PR TITLE
feat(T10068): TaskTools SDK surface (T9835a — Saga T9831)

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1719,6 +1719,24 @@ export type {
   TesseraTemplate,
   TesseraVariable,
 } from './tessera.js';
+// === Task SDK Tool Contracts (T10068 / T9835) ===
+export type {
+  BuildTaskTreeInput,
+  BuildTaskTreeOptions,
+  BuildTaskTreeResult,
+} from './tools/build-task-tree.js';
+export type {
+  CriticalPathEdge,
+  CriticalPathNode,
+  CriticalPathResult,
+} from './tools/compute-critical-path.js';
+export type { RenderTaskTreeInput } from './tools/render-task-tree.js';
+export type {
+  ScoreFactor,
+  ScoreTaskContext,
+  ScoreTaskInput,
+  ScoreTaskResult,
+} from './tools/score-task-priority.js';
 // === Transport (low-level wire protocol) ===
 export type {
   AdapterTransportProvider,

--- a/packages/contracts/src/tools/build-task-tree.ts
+++ b/packages/contracts/src/tools/build-task-tree.ts
@@ -1,0 +1,48 @@
+/**
+ * Contract types for the buildTaskTree SDK tool.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, pure-functional
+ * @task T10068
+ * @epic T9835
+ */
+
+import type { TaskPriority } from '../task.js';
+import type { TaskTreeNode } from '../tasks.js';
+
+export type { TaskTreeNode };
+
+/** Minimal task shape required by buildTaskTree. */
+export interface BuildTaskTreeInput {
+  /** Unique task identifier. */
+  id: string;
+  /** Human-readable task title. */
+  title: string;
+  /** Current task status. */
+  status: string;
+  /** Task type classification. */
+  type?: string;
+  /** Task priority level. */
+  priority: TaskPriority;
+  /** ID of the parent task (null for root). */
+  parentId?: string | null;
+  /** Sort position within sibling scope. */
+  position?: number | null;
+  /** Dependency IDs. */
+  depends?: string[];
+  /** Additional labels. */
+  labels?: string[];
+}
+
+/** Options for buildTaskTree. */
+export interface BuildTaskTreeOptions {
+  /** When true, annotate each node with transitive blocker chains. */
+  withBlockers?: boolean;
+}
+
+/** Result of buildTaskTree. */
+export interface BuildTaskTreeResult {
+  /** Root-level tree nodes. */
+  tree: TaskTreeNode[];
+  /** Total number of nodes across all levels. */
+  totalNodes: number;
+}

--- a/packages/contracts/src/tools/compute-critical-path.ts
+++ b/packages/contracts/src/tools/compute-critical-path.ts
@@ -1,0 +1,35 @@
+/**
+ * Contract types for the computeCriticalPath SDK tool.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, pure-functional
+ * @task T10068
+ * @epic T9835
+ */
+
+/** A node in the dependency DAG. */
+export interface CriticalPathNode {
+  /** Unique task identifier. */
+  id: string;
+  /** Human-readable task title. */
+  title: string;
+  /** Current task status. */
+  status: string;
+  /** Dependency IDs (scoped to the same set of nodes). */
+  depends: string[];
+}
+
+/** A directed edge in the dependency DAG (dependency → dependent). */
+export interface CriticalPathEdge {
+  /** Source node ID (the dependency). */
+  from: string;
+  /** Target node ID (the dependent). */
+  to: string;
+}
+
+/** Result of computeCriticalPath. */
+export interface CriticalPathResult {
+  /** Ordered task IDs from path start to end (empty when graph has cycles). */
+  path: string[];
+  /** Length of the critical path. */
+  length: number;
+}

--- a/packages/contracts/src/tools/index.ts
+++ b/packages/contracts/src/tools/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Task SDK tool contract types.
+ *
+ * @arch Contracts barrel for Category B SDK Tools in packages/core/src/tools/task-tools/
+ * @task T10068
+ * @epic T9835
+ */
+
+export type {
+  BuildTaskTreeInput,
+  BuildTaskTreeOptions,
+  BuildTaskTreeResult,
+} from './build-task-tree.js';
+export type {
+  CriticalPathEdge,
+  CriticalPathNode,
+  CriticalPathResult,
+} from './compute-critical-path.js';
+export type { RenderTaskTreeInput } from './render-task-tree.js';
+export type {
+  ScoreFactor,
+  ScoreTaskContext,
+  ScoreTaskInput,
+  ScoreTaskResult,
+} from './score-task-priority.js';

--- a/packages/contracts/src/tools/render-task-tree.ts
+++ b/packages/contracts/src/tools/render-task-tree.ts
@@ -1,0 +1,19 @@
+/**
+ * Contract types for the renderTaskTree SDK tools.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, pure-functional
+ * @task T10068
+ * @epic T9835
+ */
+
+import type { CriticalPathEdge, CriticalPathNode } from './compute-critical-path.js';
+
+/** Input to both text and Mermaid renderers. */
+export interface RenderTaskTreeInput {
+  /** Task nodes to render. */
+  nodes: CriticalPathNode[];
+  /** Directed edges between nodes. */
+  edges: CriticalPathEdge[];
+  /** Task IDs on the critical path (highlighted in output). */
+  criticalPath: string[];
+}

--- a/packages/contracts/src/tools/score-task-priority.ts
+++ b/packages/contracts/src/tools/score-task-priority.ts
@@ -1,0 +1,59 @@
+/**
+ * Contract types for the scoreTask SDK tool.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, pure-functional
+ * @task T10068
+ * @epic T9835
+ */
+
+import type { TaskPriority } from '../task.js';
+
+/** Minimal task shape required by scoreTask. */
+export interface ScoreTaskInput {
+  /** Unique task identifier. */
+  id: string;
+  /** Human-readable task title. */
+  title: string;
+  /** Task priority level. */
+  priority: TaskPriority;
+  /** Phase slug this task belongs to. */
+  phase?: string;
+  /** Dependency IDs. */
+  depends?: string[];
+  /** ISO timestamp of task creation. */
+  createdAt?: string;
+  /** Labels for pattern matching. */
+  labels?: string[];
+}
+
+/** Context provided to scoreTask to enable phase-aware and dependency-aware scoring. */
+export interface ScoreTaskContext {
+  /** Current project phase slug (used for phase alignment bonus). */
+  currentPhase?: string | null;
+  /** Map of all task IDs to their statuses (used for dep readiness check). */
+  taskStatuses?: Map<string, string>;
+  /** Current timestamp (ms since epoch) — defaults to Date.now() when omitted. */
+  nowMs?: number;
+  /** Matched success patterns from BRAIN (optional bonus scoring). */
+  successPatterns?: Array<{ pattern: string }>;
+  /** Matched failure patterns from BRAIN (optional penalty scoring). */
+  failurePatterns?: Array<{ pattern: string }>;
+}
+
+/** A scoring factor contributing to the final score. */
+export interface ScoreFactor {
+  /** Factor name (e.g. "priority", "phaseAlignment"). */
+  name: string;
+  /** Numeric contribution (positive = bonus, negative = penalty). */
+  delta: number;
+  /** Human-readable explanation. */
+  detail: string;
+}
+
+/** Result of scoreTask. */
+export interface ScoreTaskResult {
+  /** Final computed score. */
+  score: number;
+  /** Individual scoring factors. */
+  factors: ScoreFactor[];
+}

--- a/packages/core/src/tools/__tests__/task-tools/build-task-tree.test.ts
+++ b/packages/core/src/tools/__tests__/task-tools/build-task-tree.test.ts
@@ -1,0 +1,104 @@
+import type { BuildTaskTreeInput } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { buildTaskTree } from '../../task-tools/build-task-tree.js';
+
+const BASE_TASKS: BuildTaskTreeInput[] = [
+  {
+    id: 'E1',
+    title: 'Epic',
+    status: 'active',
+    priority: 'high',
+    parentId: null,
+  },
+  {
+    id: 'T1',
+    title: 'Task A',
+    status: 'done',
+    priority: 'medium',
+    parentId: 'E1',
+    position: 1,
+    depends: [],
+  },
+  {
+    id: 'T2',
+    title: 'Task B',
+    status: 'pending',
+    priority: 'high',
+    parentId: 'E1',
+    position: 2,
+    depends: ['T1'],
+  },
+  {
+    id: 'T3',
+    title: 'Subtask B1',
+    status: 'pending',
+    priority: 'low',
+    parentId: 'T2',
+    position: 1,
+    depends: [],
+  },
+];
+
+describe('buildTaskTree', () => {
+  it('builds a full tree from flat tasks with correct parent-child relationships', () => {
+    const { tree, totalNodes } = buildTaskTree(BASE_TASKS);
+
+    expect(tree).toHaveLength(1); // E1 is the only root
+    const epic = tree[0];
+    expect(epic.id).toBe('E1');
+    expect(epic.children).toHaveLength(2); // T1 and T2
+    expect(epic.children[0].id).toBe('T1');
+    expect(epic.children[1].id).toBe('T2');
+    expect(epic.children[1].children[0].id).toBe('T3');
+    expect(totalNodes).toBe(4);
+  });
+
+  it('computes blockedBy and ready fields correctly', () => {
+    const { tree } = buildTaskTree(BASE_TASKS);
+    const epic = tree[0];
+    const t1 = epic.children[0]; // done — not blocked
+    const t2 = epic.children[1]; // pending, depends on done T1 — should be ready
+
+    expect(t1.blockedBy).toEqual([]);
+    expect(t1.ready).toBe(false); // status is 'done', not actionable
+
+    expect(t2.depends).toEqual(['T1']);
+    expect(t2.blockedBy).toEqual([]); // T1 is done
+    expect(t2.ready).toBe(true);
+  });
+
+  it('scopes to a subtree when rootId is provided', () => {
+    const { tree, totalNodes } = buildTaskTree(BASE_TASKS, 'T2');
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe('T2');
+    expect(tree[0].children).toHaveLength(1);
+    expect(totalNodes).toBe(2); // T2 + T3
+  });
+
+  it('annotates nodes with blockerChain when withBlockers=true', () => {
+    const tasks: BuildTaskTreeInput[] = [
+      { id: 'A', title: 'A', status: 'pending', priority: 'medium', depends: ['B'] },
+      { id: 'B', title: 'B', status: 'pending', priority: 'medium', depends: [] },
+    ];
+    const { tree } = buildTaskTree(tasks, undefined, { withBlockers: true });
+    const nodeA = tree.find((n) => n.id === 'A')!;
+
+    expect(nodeA.blockerChain).toBeDefined();
+    expect(nodeA.blockerChain).toContain('B');
+    expect(nodeA.leafBlockers).toBeDefined();
+    expect(nodeA.leafBlockers).toContain('B');
+  });
+
+  it('sorts children by position ascending', () => {
+    const tasks: BuildTaskTreeInput[] = [
+      { id: 'P', title: 'Parent', status: 'active', priority: 'high' },
+      { id: 'C3', title: 'C3', status: 'pending', priority: 'low', parentId: 'P', position: 3 },
+      { id: 'C1', title: 'C1', status: 'pending', priority: 'low', parentId: 'P', position: 1 },
+      { id: 'C2', title: 'C2', status: 'pending', priority: 'low', parentId: 'P', position: 2 },
+    ];
+    const { tree } = buildTaskTree(tasks);
+    const childIds = tree[0].children.map((c) => c.id);
+    expect(childIds).toEqual(['C1', 'C2', 'C3']);
+  });
+});

--- a/packages/core/src/tools/__tests__/task-tools/compute-critical-path.test.ts
+++ b/packages/core/src/tools/__tests__/task-tools/compute-critical-path.test.ts
@@ -1,0 +1,78 @@
+import type { CriticalPathEdge, CriticalPathNode } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { computeCriticalPath } from '../../task-tools/compute-critical-path.js';
+
+describe('computeCriticalPath', () => {
+  it('finds the longest path in a linear chain', () => {
+    const nodes: CriticalPathNode[] = [
+      { id: 'T1', title: 'Step 1', status: 'done', depends: [] },
+      { id: 'T2', title: 'Step 2', status: 'pending', depends: ['T1'] },
+      { id: 'T3', title: 'Step 3', status: 'pending', depends: ['T2'] },
+    ];
+    const edges: CriticalPathEdge[] = [
+      { from: 'T1', to: 'T2' },
+      { from: 'T2', to: 'T3' },
+    ];
+
+    const { path, length } = computeCriticalPath(nodes, edges, 'E1');
+    expect(path).toEqual(['T1', 'T2', 'T3']);
+    expect(length).toBe(3);
+  });
+
+  it('selects the longer branch in a forked graph', () => {
+    // T1 → T2 (short branch)
+    // T1 → T3 → T4 (long branch)
+    const nodes: CriticalPathNode[] = [
+      { id: 'T1', title: 'Root', status: 'done', depends: [] },
+      { id: 'T2', title: 'Short', status: 'pending', depends: ['T1'] },
+      { id: 'T3', title: 'Mid', status: 'pending', depends: ['T1'] },
+      { id: 'T4', title: 'Long End', status: 'pending', depends: ['T3'] },
+    ];
+    const edges: CriticalPathEdge[] = [
+      { from: 'T1', to: 'T2' },
+      { from: 'T1', to: 'T3' },
+      { from: 'T3', to: 'T4' },
+    ];
+
+    const { path, length } = computeCriticalPath(nodes, edges, 'E1');
+    expect(path).toEqual(['T1', 'T3', 'T4']);
+    expect(length).toBe(3);
+  });
+
+  it('returns empty path for a graph with a cycle', () => {
+    // T1 → T2 → T1 (cycle)
+    const nodes: CriticalPathNode[] = [
+      { id: 'T1', title: 'A', status: 'pending', depends: ['T2'] },
+      { id: 'T2', title: 'B', status: 'pending', depends: ['T1'] },
+    ];
+    const edges: CriticalPathEdge[] = [
+      { from: 'T1', to: 'T2' },
+      { from: 'T2', to: 'T1' },
+    ];
+
+    const { path, length } = computeCriticalPath(nodes, edges, 'E1');
+    expect(path).toEqual([]);
+    expect(length).toBe(0);
+  });
+
+  it('never selects epicId as the end-node — path always terminates at a leaf task', () => {
+    // Linear chain E1 → T1 → T2 (scoped set)
+    // Without exclusion, E1 has longest=1 — but T2 has longest=3.
+    // With epicId exclusion, end node is T2. E1 may appear as the path start.
+    const nodes: CriticalPathNode[] = [
+      { id: 'E1', title: 'Epic', status: 'active', depends: [] },
+      { id: 'T1', title: 'Task 1', status: 'pending', depends: ['E1'] },
+      { id: 'T2', title: 'Task 2', status: 'pending', depends: ['T1'] },
+    ];
+    const edges: CriticalPathEdge[] = [
+      { from: 'E1', to: 'T1' },
+      { from: 'T1', to: 'T2' },
+    ];
+
+    const { path, length } = computeCriticalPath(nodes, edges, 'E1');
+    // Path ends at T2, not E1
+    expect(path[path.length - 1]).toBe('T2');
+    // Full chain is traced: E1 → T1 → T2
+    expect(length).toBe(3);
+  });
+});

--- a/packages/core/src/tools/__tests__/task-tools/render-task-tree.test.ts
+++ b/packages/core/src/tools/__tests__/task-tools/render-task-tree.test.ts
@@ -1,0 +1,85 @@
+import type { CriticalPathEdge, CriticalPathNode, RenderTaskTreeInput } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { renderTaskTreeMermaid, renderTaskTreeText } from '../../task-tools/render-task-tree.js';
+
+const NODES: CriticalPathNode[] = [
+  { id: 'T1', title: 'Setup', status: 'done', depends: [] },
+  { id: 'T2', title: 'Build', status: 'pending', depends: ['T1'] },
+  { id: 'T3', title: 'Test "suite"', status: 'active', depends: ['T2'] },
+];
+const EDGES: CriticalPathEdge[] = [
+  { from: 'T1', to: 'T2' },
+  { from: 'T2', to: 'T3' },
+];
+const CRITICAL_PATH = ['T1', 'T2', 'T3'];
+
+const INPUT: RenderTaskTreeInput = { nodes: NODES, edges: EDGES, criticalPath: CRITICAL_PATH };
+
+describe('renderTaskTreeText', () => {
+  it('produces output starting with "Dep tree:" and includes all task IDs', () => {
+    const output = renderTaskTreeText(INPUT);
+
+    expect(output).toMatch(/^Dep tree:/);
+    expect(output).toContain('T1');
+    expect(output).toContain('T2');
+    expect(output).toContain('T3');
+  });
+
+  it('marks critical path nodes with **', () => {
+    const output = renderTaskTreeText(INPUT);
+
+    // All three nodes are on the critical path
+    expect(output).toContain('T1: Setup **');
+    expect(output).toContain('Critical path (** marked): T1 -> T2 -> T3');
+  });
+
+  it('uses correct status symbols', () => {
+    const output = renderTaskTreeText(INPUT);
+
+    expect(output).toContain('[x]'); // done
+    expect(output).toContain('[ ]'); // pending
+    expect(output).toContain('[>]'); // active
+  });
+
+  it('omits critical path summary line when path is empty', () => {
+    const output = renderTaskTreeText({ nodes: NODES, edges: EDGES, criticalPath: [] });
+    expect(output).not.toContain('Critical path');
+  });
+});
+
+describe('renderTaskTreeMermaid', () => {
+  it('produces a valid graph TD block with node definitions', () => {
+    const output = renderTaskTreeMermaid(INPUT);
+
+    expect(output).toMatch(/^graph TD/);
+    expect(output).toContain('T1[');
+    expect(output).toContain('T2[');
+    expect(output).toContain('T3[');
+  });
+
+  it('includes directed edges between nodes', () => {
+    const output = renderTaskTreeMermaid(INPUT);
+
+    expect(output).toContain('T1 --> T2');
+    expect(output).toContain('T2 --> T3');
+  });
+
+  it('applies critical path classDef styling', () => {
+    const output = renderTaskTreeMermaid(INPUT);
+
+    expect(output).toContain('classDef critical fill:#f96,stroke:#c00;');
+    expect(output).toContain('class T1 critical;');
+  });
+
+  it('escapes double-quotes in task titles', () => {
+    const output = renderTaskTreeMermaid(INPUT);
+    // T3 title has double-quotes — must be escaped to single quotes
+    expect(output).toContain("Test 'suite'");
+    expect(output).not.toContain('Test "suite"');
+  });
+
+  it('omits classDef when critical path is empty', () => {
+    const output = renderTaskTreeMermaid({ nodes: NODES, edges: EDGES, criticalPath: [] });
+    expect(output).not.toContain('classDef');
+  });
+});

--- a/packages/core/src/tools/__tests__/task-tools/score-task-priority.test.ts
+++ b/packages/core/src/tools/__tests__/task-tools/score-task-priority.test.ts
@@ -1,0 +1,102 @@
+import type { ScoreTaskInput } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { scoreTask } from '../../task-tools/score-task-priority.js';
+
+// Task with a dependency so depsReady bonus only applies when statuses provided
+const HIGH_TASK: ScoreTaskInput = {
+  id: 'T1',
+  title: 'High priority auth task',
+  priority: 'high',
+  phase: 'v2',
+  depends: ['T0'],
+  createdAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(), // 10 days ago
+};
+
+// Task with a dependency so no accidental depsReady bonus
+const LOW_TASK: ScoreTaskInput = {
+  id: 'T2',
+  title: 'Low priority cleanup',
+  priority: 'low',
+  phase: 'v3',
+  depends: ['T0'],
+  createdAt: new Date().toISOString(), // just created
+};
+
+describe('scoreTask', () => {
+  it('assigns higher score to a high-priority task vs a low-priority task', () => {
+    // Pass taskStatuses without T0 resolved — both get 0 depsReady bonus
+    const ctx = { taskStatuses: new Map([['T0', 'pending']]) };
+    const highResult = scoreTask(HIGH_TASK, ctx);
+    const lowResult = scoreTask(LOW_TASK, ctx);
+
+    expect(highResult.score).toBeGreaterThan(lowResult.score);
+    // High priority baseline is 75, low is 25 (both get age bonus check separately)
+    expect(highResult.score).toBeGreaterThanOrEqual(75);
+    expect(lowResult.score).toBe(25); // priority only — no other bonuses apply
+  });
+
+  it('adds phase alignment bonus when task phase matches currentPhase', () => {
+    const withoutPhase = scoreTask(HIGH_TASK, {});
+    const withPhase = scoreTask(HIGH_TASK, { currentPhase: 'v2' });
+
+    expect(withPhase.score).toBe(withoutPhase.score + 20);
+    const phaseFactors = withPhase.factors.filter((f) => f.name === 'phaseAlignment');
+    expect(phaseFactors).toHaveLength(1);
+    expect(phaseFactors[0].delta).toBe(20);
+  });
+
+  it('adds deps readiness bonus when all deps are done/cancelled', () => {
+    const taskStatuses = new Map([['T0', 'done']]);
+    const withDeps = scoreTask(HIGH_TASK, { taskStatuses });
+    const withoutDeps = scoreTask(HIGH_TASK, {});
+
+    expect(withDeps.score).toBe(withoutDeps.score + 10);
+    expect(withDeps.factors.some((f) => f.name === 'depsReady')).toBe(true);
+  });
+
+  it('adds age bonus for tasks older than 7 days', () => {
+    const nowMs = Date.now();
+    const result = scoreTask(HIGH_TASK, { nowMs });
+
+    // 10 days old → floor(10/7) = 1 week → +1 age bonus
+    const ageFactors = result.factors.filter((f) => f.name === 'age');
+    expect(ageFactors).toHaveLength(1);
+    expect(ageFactors[0].delta).toBeGreaterThanOrEqual(1);
+  });
+
+  it('applies brain success pattern bonus and failure pattern penalty', () => {
+    // Task with explicit depends so no accidental depsReady bonus
+    const task: ScoreTaskInput = {
+      id: 'T3',
+      title: 'database migration',
+      priority: 'medium',
+      depends: ['T0'],
+    };
+    const noDepCtx = { taskStatuses: new Map([['T0', 'pending']]) };
+
+    const withSuccess = scoreTask(task, {
+      ...noDepCtx,
+      successPatterns: [{ pattern: 'database' }],
+    });
+    const withFailure = scoreTask(task, {
+      ...noDepCtx,
+      failurePatterns: [{ pattern: 'migration' }],
+    });
+
+    expect(withSuccess.score).toBe(50 + 10); // medium + success bonus
+    expect(withFailure.score).toBe(50 - 5); // medium - failure penalty
+  });
+
+  it('returns all factor names in result', () => {
+    const result = scoreTask(HIGH_TASK, {
+      currentPhase: 'v2',
+      taskStatuses: new Map([['T0', 'done']]),
+      nowMs: Date.now(),
+    });
+
+    const names = result.factors.map((f) => f.name);
+    expect(names).toContain('priority');
+    expect(names).toContain('phaseAlignment');
+    expect(names).toContain('depsReady');
+  });
+});

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -48,3 +48,5 @@ export {
 } from './engine-ops.js';
 // SDK Tools (Category B) — harness-agnostic infrastructure (T1768 / ADR-064)
 export * from './sdk/index.js';
+// TaskTools (Category B) — pure-functional task graph SDK tools (T10068 / T9835)
+export * from './task-tools/index.js';

--- a/packages/core/src/tools/task-tools/build-task-tree.ts
+++ b/packages/core/src/tools/task-tools/build-task-tree.ts
@@ -1,0 +1,155 @@
+/**
+ * buildTaskTree — pure-functional task hierarchy builder.
+ *
+ * Accepts a flat array of tasks and constructs a tree of {@link TaskTreeNode}
+ * objects. No I/O, no DB access — all input supplied by the caller.
+ *
+ * @arch SDK Tool (Category B) — pure, no side effects, contracts-typed
+ * @task T10068
+ * @epic T9835
+ */
+
+import type {
+  BuildTaskTreeInput,
+  BuildTaskTreeOptions,
+  BuildTaskTreeResult,
+  TaskTreeNode,
+} from '@cleocode/contracts';
+
+const SATISFIED_STATUSES = new Set<string>(['done', 'cancelled']);
+const ACTIONABLE_STATUSES = new Set<string>(['pending', 'active']);
+
+function getTransitiveBlockers(
+  taskId: string,
+  taskMap: Map<string, BuildTaskTreeInput>,
+  visited: Set<string> = new Set(),
+): string[] {
+  if (visited.has(taskId)) return [];
+  visited.add(taskId);
+
+  const task = taskMap.get(taskId);
+  if (!task?.depends?.length) return [];
+
+  const blockers: string[] = [];
+  for (const depId of task.depends) {
+    const dep = taskMap.get(depId);
+    if (!dep) continue;
+    if (!SATISFIED_STATUSES.has(dep.status)) {
+      blockers.push(depId);
+    }
+    blockers.push(...getTransitiveBlockers(depId, taskMap, visited));
+  }
+  return [...new Set(blockers)];
+}
+
+function getLeafBlockers(taskId: string, taskMap: Map<string, BuildTaskTreeInput>): string[] {
+  const chain = getTransitiveBlockers(taskId, taskMap);
+  return chain.filter((id) => {
+    const t = taskMap.get(id);
+    if (!t) return false;
+    const deps = t.depends ?? [];
+    return deps.every((depId) => {
+      const dep = taskMap.get(depId);
+      return !dep || SATISFIED_STATUSES.has(dep.status);
+    });
+  });
+}
+
+function buildNode(
+  task: BuildTaskTreeInput,
+  childrenMap: Map<string, BuildTaskTreeInput[]>,
+  taskMap: Map<string, BuildTaskTreeInput>,
+  withBlockers: boolean,
+): TaskTreeNode {
+  const rawChildren = childrenMap.get(task.id) ?? [];
+  const sortedChildren = [...rawChildren].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+  const children = sortedChildren.map((c) => buildNode(c, childrenMap, taskMap, withBlockers));
+
+  const depends = task.depends ?? [];
+  const blockedBy = depends.filter((depId) => {
+    const dep = taskMap.get(depId);
+    return dep !== undefined && !SATISFIED_STATUSES.has(dep.status);
+  });
+  const ready = blockedBy.length === 0 && ACTIONABLE_STATUSES.has(task.status);
+
+  const node: TaskTreeNode = {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    type: task.type,
+    priority: task.priority,
+    depends,
+    blockedBy,
+    ready,
+    children,
+  };
+
+  if (withBlockers) {
+    node.blockerChain = getTransitiveBlockers(task.id, taskMap);
+    node.leafBlockers = getLeafBlockers(task.id, taskMap);
+  }
+
+  return node;
+}
+
+function countNodes(nodes: TaskTreeNode[]): number {
+  let count = nodes.length;
+  for (const n of nodes) {
+    count += countNodes(n.children);
+  }
+  return count;
+}
+
+/**
+ * Build a task hierarchy tree from a flat array of tasks.
+ *
+ * Pure functional — no I/O. The caller is responsible for loading tasks and
+ * passing them in. When `rootId` is provided, only the subtree rooted at that
+ * task is returned. When `opts.withBlockers` is true, each node is annotated
+ * with `blockerChain` and `leafBlockers`.
+ *
+ * @param tasks - Flat array of all tasks (or a pre-filtered subset)
+ * @param rootId - Optional root task ID; returns full tree when omitted
+ * @param opts - Tree-build options
+ * @returns Tree nodes and total node count
+ *
+ * @example
+ * ```typescript
+ * const { tree, totalNodes } = buildTaskTree(allTasks, 'T042');
+ * console.log(`${totalNodes} nodes in subtree`);
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const { tree } = buildTaskTree(allTasks, undefined, { withBlockers: true });
+ * console.log(tree[0].blockerChain);
+ * ```
+ */
+export function buildTaskTree(
+  tasks: BuildTaskTreeInput[],
+  rootId?: string,
+  opts?: BuildTaskTreeOptions,
+): BuildTaskTreeResult {
+  const taskMap = new Map<string, BuildTaskTreeInput>(tasks.map((t) => [t.id, t]));
+  const childrenMap = new Map<string, BuildTaskTreeInput[]>();
+
+  for (const task of tasks) {
+    const key = task.parentId ?? '__root__';
+    if (!childrenMap.has(key)) childrenMap.set(key, []);
+    childrenMap.get(key)!.push(task);
+  }
+
+  let roots: BuildTaskTreeInput[];
+  if (rootId) {
+    const root = taskMap.get(rootId);
+    if (!root) throw new Error(`Task '${rootId}' not found`);
+    roots = [root];
+  } else {
+    roots = childrenMap.get('__root__') ?? [];
+  }
+
+  const withBlockers = opts?.withBlockers ?? false;
+  const tree = roots.map((r) => buildNode(r, childrenMap, taskMap, withBlockers));
+
+  return { tree, totalNodes: countNodes(tree) };
+}

--- a/packages/core/src/tools/task-tools/compute-critical-path.ts
+++ b/packages/core/src/tools/task-tools/compute-critical-path.ts
@@ -1,0 +1,111 @@
+/**
+ * computeCriticalPath — pure-functional longest-path finder for a dependency DAG.
+ *
+ * Uses Kahn's topological sort + dynamic programming to find the longest path.
+ * Returns an empty array when the graph contains a cycle.
+ *
+ * @arch SDK Tool (Category B) — pure, no side effects, contracts-typed
+ * @task T10068
+ * @epic T9835
+ */
+
+import type { CriticalPathEdge, CriticalPathNode, CriticalPathResult } from '@cleocode/contracts';
+
+/**
+ * Compute the critical (longest) path through a dependency DAG.
+ *
+ * The `epicId` node is excluded from end-node selection so the path represents
+ * the deepest leaf work, not the epic container itself. Returns task IDs from
+ * path start to end; returns an empty path when the graph has cycles.
+ *
+ * @param nodes - All task nodes in the scoped graph
+ * @param edges - Directed edges (dependency → dependent)
+ * @param epicId - Epic container ID to exclude from end-node selection
+ * @returns Critical path result with ordered IDs and length
+ *
+ * @example
+ * ```typescript
+ * const nodes = [
+ *   { id: 'T1', title: 'Setup', status: 'done', depends: [] },
+ *   { id: 'T2', title: 'Build', status: 'pending', depends: ['T1'] },
+ *   { id: 'T3', title: 'Test',  status: 'pending', depends: ['T2'] },
+ * ];
+ * const edges = [{ from: 'T1', to: 'T2' }, { from: 'T2', to: 'T3' }];
+ * const { path } = computeCriticalPath(nodes, edges, 'E1');
+ * // path === ['T1', 'T2', 'T3']
+ * ```
+ */
+export function computeCriticalPath(
+  nodes: CriticalPathNode[],
+  edges: CriticalPathEdge[],
+  epicId: string,
+): CriticalPathResult {
+  const forward = new Map<string, string[]>();
+  const backward = new Map<string, string[]>();
+  for (const n of nodes) {
+    if (!forward.has(n.id)) forward.set(n.id, []);
+    if (!backward.has(n.id)) backward.set(n.id, []);
+  }
+  for (const e of edges) {
+    (forward.get(e.from) ?? []).push(e.to);
+    (backward.get(e.to) ?? []).push(e.from);
+  }
+
+  // Kahn's topological sort
+  const inDegree = new Map<string, number>();
+  for (const n of nodes) inDegree.set(n.id, (backward.get(n.id) ?? []).length);
+
+  const longest = new Map<string, number>();
+  const prev = new Map<string, string | null>();
+  for (const n of nodes) {
+    longest.set(n.id, 1);
+    prev.set(n.id, null);
+  }
+
+  const topo: string[] = [];
+  const remaining = new Map(inDegree);
+  const queue: string[] = [];
+  for (const [id, deg] of inDegree) {
+    if (deg === 0) queue.push(id);
+  }
+
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    topo.push(cur);
+    for (const next of forward.get(cur) ?? []) {
+      const curLen = (longest.get(cur) ?? 1) + 1;
+      if (curLen > (longest.get(next) ?? 1)) {
+        longest.set(next, curLen);
+        prev.set(next, cur);
+      }
+      const deg = (remaining.get(next) ?? 1) - 1;
+      remaining.set(next, deg);
+      if (deg === 0) queue.push(next);
+    }
+  }
+
+  if (topo.length === 0) return { path: [], length: 0 };
+
+  // Find end node with maximum longest-path value (excluding epicId)
+  let maxLen = 0;
+  let endNode = '';
+  for (const [id, len] of longest) {
+    if (id === epicId) continue;
+    if (len > maxLen) {
+      maxLen = len;
+      endNode = id;
+    }
+  }
+
+  if (!endNode) return { path: [], length: 0 };
+
+  // Trace back from endNode
+  const path: string[] = [];
+  let cur: string | null = endNode;
+  while (cur) {
+    path.unshift(cur);
+    cur = prev.get(cur) ?? null;
+  }
+
+  return { path, length: path.length };
+}

--- a/packages/core/src/tools/task-tools/index.ts
+++ b/packages/core/src/tools/task-tools/index.ts
@@ -1,0 +1,24 @@
+/**
+ * TaskTools barrel — pure-functional SDK tools for task graph operations.
+ *
+ * All tools are Category B SDK Tools (harness-agnostic, pure-functional, no I/O).
+ * Input/output types are defined in `@cleocode/contracts` — never inline.
+ *
+ * Exposed tools:
+ *   buildTaskTree        — flat array → hierarchical TaskTreeNode tree
+ *   computeCriticalPath  — DAG longest-path via topological DP
+ *   scoreTask            — priority score with per-factor breakdown
+ *   renderTaskTreeText   — ASCII dep tree renderer
+ *   renderTaskTreeMermaid — Mermaid graph TD renderer
+ *   defineSdkTool        — schema-annotated tool registration factory
+ *
+ * @arch SDK Tools (Category B) — T10068 / Epic T9835 / Saga T9831
+ * @task T10068
+ */
+
+export { buildTaskTree } from './build-task-tree.js';
+export { computeCriticalPath } from './compute-critical-path.js';
+export { renderTaskTreeMermaid, renderTaskTreeText } from './render-task-tree.js';
+export { scoreTask } from './score-task-priority.js';
+export type { JsonSchema, RegisteredSdkTool, SdkToolSpec } from './sdk-tool.js';
+export { defineSdkTool } from './sdk-tool.js';

--- a/packages/core/src/tools/task-tools/render-task-tree.ts
+++ b/packages/core/src/tools/task-tools/render-task-tree.ts
@@ -1,0 +1,111 @@
+/**
+ * renderTaskTreeText / renderTaskTreeMermaid — pure-functional tree renderers.
+ *
+ * Convert a scoped dependency graph into a human-readable ASCII tree or a
+ * Mermaid graph TD block. Both renderers are stateless and produce a string.
+ *
+ * @arch SDK Tool (Category B) — pure, no side effects, contracts-typed
+ * @task T10068
+ * @epic T9835
+ */
+
+import type { RenderTaskTreeInput } from '@cleocode/contracts';
+
+function statusSymbol(status: string): string {
+  switch (status) {
+    case 'done':
+      return '[x]';
+    case 'cancelled':
+      return '[-]';
+    case 'active':
+      return '[>]';
+    default:
+      return '[ ]';
+  }
+}
+
+/**
+ * Render a simple ASCII dependency tree.
+ *
+ * Root tasks (no dependencies within the scoped set) are listed first.
+ * Tasks on the critical path are marked with `**`.
+ *
+ * @param input - Nodes, edges, and critical path
+ * @returns ASCII text block
+ *
+ * @example
+ * ```typescript
+ * const text = renderTaskTreeText({ nodes, edges, criticalPath: ['T1', 'T2'] });
+ * // "Dep tree:\n  [ ] T1: Setup **\n  [ ] T2: Build **\n  ..."
+ * ```
+ */
+export function renderTaskTreeText(input: RenderTaskTreeInput): string {
+  const { nodes, edges: _edges, criticalPath } = input;
+  const cpSet = new Set(criticalPath);
+  const lines: string[] = [];
+
+  const roots = nodes.filter((n) => n.depends.length === 0);
+  const nonRoots = nodes.filter((n) => n.depends.length > 0);
+
+  lines.push('Dep tree:');
+  for (const n of roots) {
+    const cp = cpSet.has(n.id) ? ' **' : '';
+    lines.push(`  ${statusSymbol(n.status)} ${n.id}: ${n.title}${cp}`);
+  }
+
+  if (nonRoots.length > 0) {
+    lines.push('  Dependencies:');
+    for (const n of nonRoots) {
+      const cp = cpSet.has(n.id) ? ' **' : '';
+      lines.push(`  ${statusSymbol(n.status)} ${n.id}: ${n.title}${cp}`);
+      for (const depId of n.depends) {
+        lines.push(`    <- ${depId}`);
+      }
+    }
+  }
+
+  if (criticalPath.length > 0) {
+    lines.push(`\nCritical path (** marked): ${criticalPath.join(' -> ')}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Render a Mermaid `graph TD` block.
+ *
+ * Escapes double-quotes and brackets in task titles to prevent parse errors.
+ * Tasks on the critical path are styled with an orange-red highlight.
+ *
+ * @param input - Nodes, edges, and critical path
+ * @returns Mermaid graph TD string
+ *
+ * @example
+ * ```typescript
+ * const mermaid = renderTaskTreeMermaid({ nodes, edges, criticalPath: ['T1'] });
+ * // "graph TD\n  T1[\"T1: Setup (pending)\"]\n  ..."
+ * ```
+ */
+export function renderTaskTreeMermaid(input: RenderTaskTreeInput): string {
+  const { nodes, edges, criticalPath } = input;
+  const cpSet = new Set(criticalPath);
+  const lines: string[] = ['graph TD'];
+
+  for (const n of nodes) {
+    const safeTitle = n.title.replace(/"/g, "'").replace(/[[\]]/g, '');
+    lines.push(`  ${n.id}["${n.id}: ${safeTitle} (${n.status})"]`);
+  }
+
+  for (const e of edges) {
+    lines.push(`  ${e.from} --> ${e.to}`);
+  }
+
+  if (cpSet.size > 0) {
+    lines.push('  classDef critical fill:#f96,stroke:#c00;');
+    for (const id of cpSet) {
+      lines.push(`  class ${id} critical;`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/packages/core/src/tools/task-tools/score-task-priority.ts
+++ b/packages/core/src/tools/task-tools/score-task-priority.ts
@@ -1,0 +1,137 @@
+/**
+ * scoreTask — pure-functional task priority scorer.
+ *
+ * Computes a numeric score for a task given its attributes and project context.
+ * Pure functional — no I/O, no DB access, no async.
+ *
+ * @arch SDK Tool (Category B) — pure, no side effects, contracts-typed
+ * @task T10068
+ * @epic T9835
+ */
+
+import type {
+  ScoreFactor,
+  ScoreTaskContext,
+  ScoreTaskInput,
+  ScoreTaskResult,
+} from '@cleocode/contracts';
+
+const PRIORITY_SCORE: Record<string, number> = {
+  critical: 100,
+  high: 75,
+  medium: 50,
+  low: 25,
+};
+
+const SATISFIED_STATUSES = new Set<string>(['done', 'cancelled']);
+
+function areDepsReady(
+  depends: string[] | undefined,
+  taskStatuses: Map<string, string> | undefined,
+): boolean {
+  if (!depends?.length) return true;
+  if (!taskStatuses) return false;
+  return depends.every((depId) => {
+    const status = taskStatuses.get(depId);
+    return status !== undefined && SATISFIED_STATUSES.has(status);
+  });
+}
+
+/**
+ * Compute a priority score for a single task.
+ *
+ * Scoring formula:
+ * - **Priority** (+25/+50/+75/+100 depending on level)
+ * - **Phase alignment** (+20 when task phase matches `ctx.currentPhase`)
+ * - **Dependency readiness** (+10 when all deps are done/cancelled)
+ * - **Age bonus** (+1 per week over 7 days, capped at +15)
+ * - **Brain success pattern** (+10 for first matching success pattern)
+ * - **Brain failure pattern** (-5 for first matching failure pattern)
+ *
+ * @param task - Task to score
+ * @param ctx - Scoring context (phase, dep statuses, patterns)
+ * @returns Score and individual factors
+ *
+ * @example
+ * ```typescript
+ * const result = scoreTask(
+ *   { id: 'T1', title: 'Auth', priority: 'high', phase: 'v2', depends: ['T0'] },
+ *   { currentPhase: 'v2', taskStatuses: new Map([['T0', 'done']]) },
+ * );
+ * // result.score === 75 (priority) + 20 (phase) + 10 (deps) = 105
+ * ```
+ */
+export function scoreTask(task: ScoreTaskInput, ctx: ScoreTaskContext): ScoreTaskResult {
+  const factors: ScoreFactor[] = [];
+  let score = 0;
+
+  // Priority
+  const priorityDelta = PRIORITY_SCORE[task.priority] ?? 50;
+  score += priorityDelta;
+  factors.push({ name: 'priority', delta: priorityDelta, detail: `${task.priority}` });
+
+  // Phase alignment
+  if (ctx.currentPhase && task.phase === ctx.currentPhase) {
+    score += 20;
+    factors.push({
+      name: 'phaseAlignment',
+      delta: 20,
+      detail: `matches current phase "${ctx.currentPhase}"`,
+    });
+  }
+
+  // Dependency readiness
+  if (areDepsReady(task.depends, ctx.taskStatuses)) {
+    score += 10;
+    factors.push({ name: 'depsReady', delta: 10, detail: 'all dependencies satisfied' });
+  }
+
+  // Age bonus
+  if (task.createdAt) {
+    const nowMs = ctx.nowMs ?? Date.now();
+    const ageMs = nowMs - new Date(task.createdAt).getTime();
+    const ageDays = ageMs / (1000 * 60 * 60 * 24);
+    if (ageDays > 7) {
+      const ageBonus = Math.min(15, Math.floor(ageDays / 7));
+      score += ageBonus;
+      factors.push({
+        name: 'age',
+        delta: ageBonus,
+        detail: `${Math.floor(ageDays)} days old`,
+      });
+    }
+  }
+
+  // Brain pattern scoring
+  if (ctx.successPatterns?.length || ctx.failurePatterns?.length) {
+    const titleLower = task.title.toLowerCase();
+    const labels = (task.labels ?? []).map((l) => l.toLowerCase());
+    const matchText = [titleLower, ...labels].join(' ');
+
+    for (const sp of ctx.successPatterns ?? []) {
+      if (matchText.includes(sp.pattern.toLowerCase())) {
+        score += 10;
+        factors.push({
+          name: 'brainSuccess',
+          delta: 10,
+          detail: `success pattern "${sp.pattern}"`,
+        });
+        break;
+      }
+    }
+
+    for (const fp of ctx.failurePatterns ?? []) {
+      if (matchText.includes(fp.pattern.toLowerCase())) {
+        score -= 5;
+        factors.push({
+          name: 'brainFailure',
+          delta: -5,
+          detail: `failure pattern "${fp.pattern}"`,
+        });
+        break;
+      }
+    }
+  }
+
+  return { score, factors };
+}

--- a/packages/core/src/tools/task-tools/sdk-tool.ts
+++ b/packages/core/src/tools/task-tools/sdk-tool.ts
@@ -1,0 +1,78 @@
+/**
+ * defineSdkTool — factory for schema-annotated SDK tool registration.
+ *
+ * Wraps a tool function with identity metadata and JSON Schema annotations so
+ * external consumers (Studio, MCP adapter, agent registries) can discover and
+ * invoke the tool programmatically.
+ *
+ * @arch SDK Tool (Category B) infrastructure helper
+ * @task T10068
+ * @epic T9835
+ */
+
+import type { SdkToolIdentity } from '@cleocode/contracts';
+
+/** JSON Schema (draft-07 subset) for input/output type annotation. */
+export interface JsonSchema {
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  items?: JsonSchema;
+  description?: string;
+  [key: string]: unknown;
+}
+
+/** Full specification for a schema-annotated SDK tool. */
+export interface SdkToolSpec<TInput, TOutput> {
+  /** Stable identity metadata. */
+  identity: SdkToolIdentity;
+  /** JSON Schema describing the input shape. */
+  inputSchema: JsonSchema;
+  /** JSON Schema describing the output shape. */
+  outputSchema: JsonSchema;
+  /** The tool implementation — MUST be pure functional (no I/O). */
+  fn: (input: TInput) => TOutput;
+}
+
+/** A fully registered SDK tool ready for discovery and invocation. */
+export interface RegisteredSdkTool<TInput, TOutput> {
+  /** Stable identity metadata (name, description, version). */
+  readonly identity: SdkToolIdentity;
+  /** JSON Schema for the tool's input. */
+  readonly inputSchema: JsonSchema;
+  /** JSON Schema for the tool's output. */
+  readonly outputSchema: JsonSchema;
+  /** Invoke the tool with the given input. */
+  readonly invoke: (input: TInput) => TOutput;
+}
+
+/**
+ * Wrap a pure tool function with schema annotations for external discovery.
+ *
+ * The returned object satisfies the SDK Tool (Category B) contract and can be
+ * registered in any agent tool registry or MCP adapter without modification.
+ *
+ * @param spec - Tool identity, schemas, and implementation
+ * @returns Annotated, immutable tool descriptor
+ *
+ * @example
+ * ```typescript
+ * const myTool = defineSdkTool({
+ *   identity: { name: 'my-tool', description: 'Does X', version: '1.0.0' },
+ *   inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+ *   outputSchema: { type: 'object', properties: { result: { type: 'string' } } },
+ *   fn: ({ id }) => ({ result: `processed-${id}` }),
+ * });
+ * const out = myTool.invoke({ id: 'T1' });
+ * ```
+ */
+export function defineSdkTool<TInput, TOutput>(
+  spec: SdkToolSpec<TInput, TOutput>,
+): RegisteredSdkTool<TInput, TOutput> {
+  return Object.freeze({
+    identity: spec.identity,
+    inputSchema: spec.inputSchema,
+    outputSchema: spec.outputSchema,
+    invoke: spec.fn,
+  });
+}


### PR DESCRIPTION
## Summary

- Creates `packages/contracts/src/tools/` with 4 TaskTool contract types (no inline types — all defined in contracts)
- Creates `packages/core/src/tools/task-tools/` with 4 pure-functional SDK Tool implementations + `defineSdkTool` factory
- Adds Vitest unit tests (24 assertions across 4 test files)
- Re-uses existing `TaskTreeNode` from `packages/contracts/src/tasks.ts` (no duplicate)

## Files Added

**Contracts (packages/contracts/src/tools/):**
- `build-task-tree.ts` — BuildTaskTreeInput, BuildTaskTreeOptions, BuildTaskTreeResult
- `compute-critical-path.ts` — CriticalPathNode, CriticalPathEdge, CriticalPathResult
- `score-task-priority.ts` — ScoreTaskInput, ScoreTaskContext, ScoreFactor, ScoreTaskResult
- `render-task-tree.ts` — RenderTaskTreeInput
- `index.ts` — barrel

**Core (packages/core/src/tools/task-tools/):**
- `build-task-tree.ts` — `buildTaskTree(tasks, rootId?, opts?)`
- `compute-critical-path.ts` — `computeCriticalPath(nodes, edges, epicId)`
- `score-task-priority.ts` — `scoreTask(task, ctx)` with per-factor breakdown
- `render-task-tree.ts` — `renderTaskTreeText` + `renderTaskTreeMermaid`
- `sdk-tool.ts` — `defineSdkTool(spec)` factory for schema-annotated tool registration
- `index.ts` — barrel

## Acceptance Criteria

- [x] buildTaskTree, computeCriticalPath, scoreTask, renderTaskTreeText/Mermaid all implemented
- [x] Pure-functional — no I/O, no DB access
- [x] Contracts-typed inputs/outputs from @cleocode/contracts
- [x] TSDoc with @example on each exported function
- [x] 24 vitest assertions (happy-path + edge cases) — all green
- [x] `pnpm biome check --write` — no issues
- [x] `pnpm --filter @cleocode/contracts run build` — passes
- [x] `pnpm --filter @cleocode/core run build` — same pre-existing errors as main (no new failures)
- [x] 1007 core unit tests pass, 0 regressions
- [x] No `any`/`unknown`/`as unknown as` casts
- [x] Code placed in `packages/core/` per Package-Boundary Check
- [x] Types in `packages/contracts/src/tools/` — no inline types

## Task

- Saga T9831 / Epic T9835 / Sub-task T10068