### PR TITLE
feat(T10069): ProjectTools SDK (T9835b — Saga T9831)

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1330,6 +1330,15 @@ export type {
   ProjectType,
   TestFramework,
 } from './project-context.js';
+// === ProjectTools Contracts (scaffold-project, doctor-project, scaffold-global — T10069 / T9835b) ===
+export type {
+  DoctorProjectOptions,
+  DoctorProjectResult,
+  ScaffoldGlobalResult,
+  ScaffoldProjectOptions,
+  ScaffoldProjectResult,
+  ScaffoldProjectStep,
+} from './project-tools.js';
 // === Provenance Graph Unions (T9955 — promoted from core/store/tasks-schema.ts) ===
 // Note: ReleaseChannel/ReleaseKind/ReleaseScheme/ReleaseStatus collide with the
 // existing `./release/channel.js` + `./release/plan.js` + `./task.js` exports

--- a/packages/contracts/src/project-tools.ts
+++ b/packages/contracts/src/project-tools.ts
@@ -1,0 +1,117 @@
+/**
+ * ProjectTools contracts — input/output types for scaffold-project,
+ * doctor-project, and scaffold-global SDK tools.
+ *
+ * These are pure-functional, harness-agnostic operation contracts. Each
+ * tool function accepts an options bag and returns a typed result envelope —
+ * no I/O is performed inside the contract shapes themselves.
+ *
+ * Taxonomy: Category B SDK Tool (ADR-064).
+ *
+ * @since SG-ARCH-SOLID Saga T9831 · E-CORE-TOOLS T9835 (T9835b)
+ */
+
+import type { CheckResult, ScaffoldResult } from './scaffold-diagnostics.js';
+
+// ── scaffold-project ──────────────────────────────────────────────────
+
+/**
+ * Options for {@link ScaffoldProjectResult} — controls idempotency and override.
+ */
+export interface ScaffoldProjectOptions {
+  /**
+   * Absolute path to the project root (directory that contains `.cleo/`).
+   * Defaults to `process.cwd()` if omitted.
+   */
+  projectRoot?: string;
+  /**
+   * When `true`, re-writes files even if they already exist (mirrors the
+   * `--force` flag in `cleo init`).
+   *
+   * @default false
+   */
+  force?: boolean;
+}
+
+/**
+ * Result of a {@link scaffoldProject} call.
+ *
+ * Aggregates the individual {@link ScaffoldResult} returned by each
+ * `ensure*` step so callers can inspect per-step outcomes without re-running
+ * discovery.
+ */
+export interface ScaffoldProjectResult {
+  /** Absolute project root that was operated on. */
+  projectRoot: string;
+  /** Per-step results, in canonical execution order. */
+  steps: ScaffoldProjectStep[];
+  /** Whether all steps completed without an exception (individual steps may still report `repaired`). */
+  success: boolean;
+  /** Aggregated human-readable summary (e.g. "3 created, 8 skipped"). */
+  summary: string;
+}
+
+/**
+ * One step within a {@link ScaffoldProjectResult}.
+ */
+export interface ScaffoldProjectStep {
+  /** Stable step name used in diagnostics (e.g. `"cleo-structure"`, `"config"`). */
+  name: string;
+  /** Outcome of the corresponding `ensure*` call. Absent when the step was skipped due to an error. */
+  result?: ScaffoldResult;
+  /** Non-null when the step threw an exception (logged but not fatal). */
+  error?: string;
+}
+
+// ── doctor-project ────────────────────────────────────────────────────
+
+/**
+ * Options for {@link doctorProject}.
+ */
+export interface DoctorProjectOptions {
+  /**
+   * Absolute path to the project root.
+   * Defaults to `process.cwd()` if omitted.
+   */
+  projectRoot?: string;
+  /**
+   * Override the global cleo home used for CLI-level checks.
+   * Defaults to `getCleoHome()` if omitted.
+   */
+  cleoHome?: string;
+}
+
+/**
+ * Result of a {@link doctorProject} call — aggregates all synchronous
+ * diagnostic checks into a flat list.
+ */
+export interface DoctorProjectResult {
+  /** Absolute project root that was inspected. */
+  projectRoot: string;
+  /** Flat list of all check outcomes, global + project-scoped. */
+  checks: CheckResult[];
+  /**
+   * Rolled-up exit-code style status:
+   * - `0`  — all checks passed
+   * - `50` — at least one warning, no failures
+   * - `52` — at least one failure
+   */
+  exitCode: 0 | 50 | 52;
+}
+
+// ── scaffold-global ───────────────────────────────────────────────────
+
+/**
+ * Result of a {@link scaffoldGlobal} call — mirrors the return shape of
+ * the underlying `ensureGlobalScaffold()` call with added provenance.
+ */
+export interface ScaffoldGlobalResult {
+  /** Outcome of `ensureGlobalHome()`. */
+  home: ScaffoldResult;
+  /** Outcome of `ensureGlobalTemplates()`. */
+  templates: ScaffoldResult;
+  /** Outcome of `ensureCleoOsHub()`. */
+  cleoosHub: ScaffoldResult;
+  /** Whether all three steps completed without throwing. */
+  success: boolean;
+}

--- a/packages/core/src/tools/__tests__/project-tools.test.ts
+++ b/packages/core/src/tools/__tests__/project-tools.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Vitest tests for ProjectTools SDK — scaffold-project, doctor-project,
+ * scaffold-global (T10069 / T9835b).
+ *
+ * All tests operate against temporary directories so the suite is safe to
+ * run in parallel and never touches the real CLEO project root.
+ *
+ * @task T10069
+ * @epic T9835
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { doctorProject } from '../doctor-project.js';
+import { scaffoldProject } from '../scaffold-project.js';
+
+// ── scaffold-project ──────────────────────────────────────────────────
+
+describe('scaffoldProject', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-t10069-scaffold-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns the resolved projectRoot in the result', async () => {
+    const result = await scaffoldProject({ projectRoot: tmpRoot });
+    expect(result.projectRoot).toBe(tmpRoot);
+  });
+
+  it('succeeds on a fresh directory', async () => {
+    const result = await scaffoldProject({ projectRoot: tmpRoot });
+    expect(result.success).toBe(true);
+  });
+
+  it('returns a non-empty steps array', async () => {
+    const result = await scaffoldProject({ projectRoot: tmpRoot });
+    expect(result.steps.length).toBeGreaterThan(0);
+  });
+
+  it('reports a non-empty summary string', async () => {
+    const result = await scaffoldProject({ projectRoot: tmpRoot });
+    expect(typeof result.summary).toBe('string');
+    expect(result.summary.length).toBeGreaterThan(0);
+  });
+
+  it('is idempotent — second call has all steps skipped or repaired', async () => {
+    await scaffoldProject({ projectRoot: tmpRoot });
+    const second = await scaffoldProject({ projectRoot: tmpRoot });
+    expect(second.success).toBe(true);
+    const created = second.steps.filter((s) => s.result?.action === 'created');
+    expect(created.length).toBe(0);
+  });
+
+  it('step names include expected scaffold operations', async () => {
+    const result = await scaffoldProject({ projectRoot: tmpRoot });
+    const names = result.steps.map((s) => s.name);
+    expect(names).toContain('cleo-structure');
+    expect(names).toContain('config');
+    expect(names).toContain('gitignore');
+    expect(names).toContain('project-info');
+  });
+
+  it('step results have valid ScaffoldResult action values', async () => {
+    const result = await scaffoldProject({ projectRoot: tmpRoot });
+    const validActions = new Set(['created', 'repaired', 'skipped']);
+    for (const step of result.steps) {
+      if (step.result !== undefined) {
+        expect(validActions.has(step.result.action)).toBe(true);
+      }
+    }
+  });
+});
+
+// ── doctor-project ────────────────────────────────────────────────────
+
+describe('doctorProject', () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-t10069-doctor-'));
+    // Scaffold first so the checks have something to inspect
+    await scaffoldProject({ projectRoot: tmpRoot });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns the resolved projectRoot in the result', async () => {
+    const result = await doctorProject({ projectRoot: tmpRoot });
+    expect(result.projectRoot).toBe(tmpRoot);
+  });
+
+  it('returns a non-empty checks array', async () => {
+    const result = await doctorProject({ projectRoot: tmpRoot });
+    expect(result.checks.length).toBeGreaterThan(0);
+  });
+
+  it('exitCode is one of the valid values (0 | 50 | 52)', async () => {
+    const result = await doctorProject({ projectRoot: tmpRoot });
+    expect([0, 50, 52]).toContain(result.exitCode);
+  });
+
+  it('check entries have a string id field', async () => {
+    const result = await doctorProject({ projectRoot: tmpRoot });
+    for (const check of result.checks) {
+      expect(typeof check.id).toBe('string');
+      expect(check.id.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('check entries have a valid status', async () => {
+    const result = await doctorProject({ projectRoot: tmpRoot });
+    const validStatuses = new Set(['passed', 'failed', 'warning', 'info']);
+    for (const check of result.checks) {
+      expect(validStatuses.has(check.status)).toBe(true);
+    }
+  });
+
+  it('exitCode 52 when at least one check failed (uninitialised project)', async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'cleo-t10069-noproject-'));
+    try {
+      const result = await doctorProject({ projectRoot: emptyDir });
+      const hasFailed = result.checks.some((c) => c.status === 'failed');
+      // An uninitialised dir MUST produce at least one failure.
+      expect(hasFailed).toBe(true);
+      expect(result.exitCode).toBe(52);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/tools/doctor-project.ts
+++ b/packages/core/src/tools/doctor-project.ts
@@ -1,0 +1,103 @@
+/**
+ * doctor-project SDK Tool — composes all synchronous `check*` calls into a
+ * single typed diagnostic result.
+ *
+ * This is the pure, side-effect-free alternative to `coreDoctorReport()`
+ * (which runs async dependency + SQLite integrity probes). `doctorProject`
+ * runs ONLY the synchronous filesystem / configuration checks from
+ * `packages/core/src/scaffold.ts` and
+ * `packages/core/src/validation/doctor/checks.ts`, making it safe to call
+ * in any context without worrying about database availability.
+ *
+ * Taxonomy: Category B SDK Tool (ADR-064).
+ *
+ * @example
+ * ```typescript
+ * import { doctorProject } from '@cleocode/core/tools/doctor-project';
+ *
+ * const result = await doctorProject({ projectRoot: '/my/project' });
+ * if (result.exitCode !== 0) {
+ *   const failed = result.checks.filter(c => c.status === 'failed');
+ *   console.error('Failed checks:', failed.map(c => c.check));
+ * }
+ * ```
+ *
+ * @task T10069 (T9835b — Saga T9831)
+ * @epic T9835
+ */
+
+import type { DoctorProjectOptions, DoctorProjectResult } from '@cleocode/contracts/project-tools';
+import { resolveOrCwd } from '../paths.js';
+import {
+  checkBrainDb,
+  checkCleoGitRepo,
+  checkCleoStructure,
+  checkConfig,
+  checkLogDir,
+  checkMemoryBridge,
+  checkNexusBridge,
+  checkProjectContext,
+  checkProjectInfo,
+  checkSqliteDb,
+} from '../scaffold.js';
+import { calculateHealthStatus, runAllGlobalChecks } from '../validation/doctor/checks.js';
+
+export type { DoctorProjectOptions, DoctorProjectResult };
+
+/**
+ * Run all synchronous project and global diagnostic checks.
+ *
+ * Combines:
+ * - Global checks from `runAllGlobalChecks()` (CLI version, node version,
+ *   gitignore patterns, CAAMP injection chain, schema health, orphan audit)
+ * - Project-scoped scaffold checks (structure, config, databases, git repo,
+ *   memory bridge, nexus bridge, project info, project context, log dir)
+ *
+ * Excludes async operations (dependency network probes, SQLite integrity
+ * check, adapter health) — use `coreDoctorReport()` for the full picture.
+ *
+ * @param options - Optional project root and cleo home override.
+ * @returns Flat list of check results with rolled-up exit code.
+ */
+export async function doctorProject(
+  options: DoctorProjectOptions = {},
+): Promise<DoctorProjectResult> {
+  const projectRoot = resolveOrCwd(options.projectRoot);
+  const cleoHome = options.cleoHome;
+
+  let globalChecks: import('@cleocode/contracts/scaffold-diagnostics').CheckResult[];
+  try {
+    globalChecks = runAllGlobalChecks(cleoHome, projectRoot);
+  } catch (err) {
+    globalChecks = [
+      {
+        id: 'global_checks',
+        category: 'global',
+        status: 'failed',
+        message: `Global checks could not run: ${err instanceof Error ? err.message : String(err)}`,
+        details: {},
+        fix: 'cleo init',
+      },
+    ];
+  }
+
+  const projectChecks = [
+    checkCleoStructure(projectRoot),
+    checkConfig(projectRoot),
+    checkSqliteDb(projectRoot),
+    checkBrainDb(projectRoot),
+    checkCleoGitRepo(projectRoot),
+    checkLogDir(projectRoot),
+    checkProjectInfo(projectRoot),
+    checkProjectContext(projectRoot),
+    checkMemoryBridge(projectRoot),
+    checkNexusBridge(projectRoot),
+  ];
+
+  const checks = [...globalChecks, ...projectChecks];
+  const rawStatus = calculateHealthStatus(checks);
+
+  const exitCode = rawStatus === 52 ? 52 : rawStatus === 50 ? 50 : 0;
+
+  return { projectRoot, checks, exitCode };
+}

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -14,6 +14,9 @@
  * @epic T1566
  */
 
+export type { DoctorProjectOptions, DoctorProjectResult } from './doctor-project.js';
+// ProjectTools SDK Tools (Category B) — scaffold + doctor primitives (T10069 / T9835b)
+export { doctorProject } from './doctor-project.js';
 // Engine operations — tools domain (ENG-MIG-8 / T1575)
 export {
   toolsAdapterActivate,
@@ -46,5 +49,13 @@ export {
   toolsSkillUninstall,
   toolsSkillVerify,
 } from './engine-ops.js';
+export type { ScaffoldGlobalResult } from './scaffold-global.js';
+export { scaffoldGlobal } from './scaffold-global.js';
+export type {
+  ScaffoldProjectOptions,
+  ScaffoldProjectResult,
+  ScaffoldProjectStep,
+} from './scaffold-project.js';
+export { scaffoldProject } from './scaffold-project.js';
 // SDK Tools (Category B) — harness-agnostic infrastructure (T1768 / ADR-064)
 export * from './sdk/index.js';

--- a/packages/core/src/tools/scaffold-global.ts
+++ b/packages/core/src/tools/scaffold-global.ts
@@ -1,0 +1,47 @@
+/**
+ * scaffold-global SDK Tool — pure-functional label on `ensureGlobalScaffold`.
+ *
+ * Wraps the three global-scope `ensure*` calls (home, templates, CleoOS hub)
+ * into a single typed entry point for SDK consumers that need to provision
+ * the global `~/.local/share/cleo/` directory tree without going through
+ * the `cleo init` command.
+ *
+ * Taxonomy: Category B SDK Tool (ADR-064).
+ *
+ * @example
+ * ```typescript
+ * import { scaffoldGlobal } from '@cleocode/core/tools/scaffold-global';
+ *
+ * const result = await scaffoldGlobal();
+ * console.log(result.home.action);      // 'created' | 'repaired' | 'skipped'
+ * console.log(result.templates.action); // 'created' | 'repaired' | 'skipped'
+ * ```
+ *
+ * @task T10069 (T9835b — Saga T9831)
+ * @epic T9835
+ */
+
+import type { ScaffoldGlobalResult } from '@cleocode/contracts/project-tools';
+import { ensureGlobalScaffold } from '../scaffold.js';
+
+export type { ScaffoldGlobalResult };
+
+/**
+ * Provision the global CLEO home directory tree.
+ *
+ * Delegates to `ensureGlobalScaffold()` and adds a `success` flag so
+ * callers can treat the result uniformly alongside other SDK tool results.
+ *
+ * Steps:
+ * - `home`      — `~/.local/share/cleo/` (or platform equivalent)
+ * - `templates` — `~/.local/share/cleo/templates/`
+ * - `cleoosHub` — CleoOS hub directory tree copied from npm package templates
+ *
+ * All three steps are idempotent and never overwrite existing files.
+ *
+ * @returns Typed result for each global scaffold step plus `success` flag.
+ */
+export async function scaffoldGlobal(): Promise<ScaffoldGlobalResult> {
+  const { home, templates, cleoosHub } = await ensureGlobalScaffold();
+  return { home, templates, cleoosHub, success: true };
+}

--- a/packages/core/src/tools/scaffold-project.ts
+++ b/packages/core/src/tools/scaffold-project.ts
@@ -1,0 +1,123 @@
+/**
+ * scaffold-project SDK Tool — composes the 11 canonical `ensure*` calls
+ * from `packages/core/src/scaffold.ts` in execution order.
+ *
+ * This is a pure-functional wrapper: it accepts a project root, runs each
+ * idempotent `ensure*` step in sequence, and returns a typed result
+ * envelope. It never interacts with a CLI renderer, a harness adapter, or
+ * any I/O surface beyond the scaffold primitives it delegates to.
+ *
+ * Taxonomy: Category B SDK Tool (ADR-064).
+ *
+ * @example
+ * ```typescript
+ * import { scaffoldProject } from '@cleocode/core/tools/scaffold-project';
+ *
+ * const result = await scaffoldProject({ projectRoot: '/my/project' });
+ * if (!result.success) {
+ *   console.error('Some scaffold steps failed:', result.steps.filter(s => s.error));
+ * }
+ * ```
+ *
+ * @task T10069 (T9835b — Saga T9831)
+ * @epic T9835
+ */
+
+import type {
+  ScaffoldProjectOptions,
+  ScaffoldProjectResult,
+  ScaffoldProjectStep,
+} from '@cleocode/contracts/project-tools';
+import { resolveOrCwd } from '../paths.js';
+import {
+  ensureBrainDb,
+  ensureCleoGitRepo,
+  ensureCleoStructure,
+  ensureConfig,
+  ensureGitignore,
+  ensureProjectContext,
+  ensureProjectGitInitialCommit,
+  ensureProjectInfo,
+  ensureSqliteDb,
+  ensureWorktreeInclude,
+} from '../scaffold.js';
+
+export type { ScaffoldProjectOptions, ScaffoldProjectResult, ScaffoldProjectStep };
+
+/**
+ * Run the canonical 11-step project scaffold sequence.
+ *
+ * Each step is idempotent: calling `scaffoldProject` on an already-
+ * initialised project root returns all steps as `"skipped"` with
+ * `success: true`.
+ *
+ * Steps (in canonical order matching `cleo init`):
+ * 1. `cleo-structure`      — `.cleo/` subdirectory tree
+ * 2. `config`              — `.cleo/config.json`
+ * 3. `sqlite-db`           — `.cleo/tasks.db`
+ * 4. `brain-db`            — `.cleo/brain.db`
+ * 5. `gitignore`           — `.cleo/.gitignore`
+ * 6. `worktree-include`    — `.cleo/worktree-include`
+ * 7. `cleo-git-repo`       — `.cleo/.git` (isolated checkpoint)
+ * 8. `initial-commit`      — empty initial commit when HEAD is unborn
+ * 9. `project-info`        — `.cleo/project-info.json`
+ * 10. `project-context`   — `.cleo/project-context.json`
+ * 11. `contributor-mcp`   — `.cleo/contributor-mcp.json` (best-effort)
+ *
+ * Note: `ensureContributorMcp` is intentionally excluded from this tool
+ * because it requires network access (fetching MCP server metadata) and
+ * would violate the pure/side-effect-isolated contract for SDK Tools.
+ * Callers that need contributor-MCP setup should invoke it directly.
+ *
+ * @param options - Optional project root and force flag.
+ * @returns Aggregated step results and success flag.
+ */
+export async function scaffoldProject(
+  options: ScaffoldProjectOptions = {},
+): Promise<ScaffoldProjectResult> {
+  const projectRoot = resolveOrCwd(options.projectRoot);
+  const force = options.force ?? false;
+
+  const steps: ScaffoldProjectStep[] = [];
+
+  async function run(
+    name: string,
+    fn: () => Promise<import('@cleocode/contracts/scaffold-diagnostics').ScaffoldResult>,
+  ): Promise<void> {
+    try {
+      const result = await fn();
+      steps.push({ name, result });
+    } catch (err) {
+      steps.push({ name, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  await run('cleo-structure', () => ensureCleoStructure(projectRoot));
+  await run('config', () => ensureConfig(projectRoot, { force }));
+  await run('sqlite-db', () => ensureSqliteDb(projectRoot));
+  await run('brain-db', () => ensureBrainDb(projectRoot));
+  await run('gitignore', () => ensureGitignore(projectRoot));
+  await run('worktree-include', () => ensureWorktreeInclude(projectRoot));
+  await run('cleo-git-repo', () => ensureCleoGitRepo(projectRoot));
+  await run('initial-commit', () => ensureProjectGitInitialCommit(projectRoot));
+  await run('project-info', () => ensureProjectInfo(projectRoot, { force }));
+  await run('project-context', () => ensureProjectContext(projectRoot, { force }));
+
+  const errorSteps = steps.filter((s) => s.error !== undefined);
+  const created = steps.filter((s) => s.result?.action === 'created').length;
+  const repaired = steps.filter((s) => s.result?.action === 'repaired').length;
+  const skipped = steps.filter((s) => s.result?.action === 'skipped').length;
+
+  const parts: string[] = [];
+  if (created > 0) parts.push(`${created} created`);
+  if (repaired > 0) parts.push(`${repaired} repaired`);
+  if (skipped > 0) parts.push(`${skipped} skipped`);
+  if (errorSteps.length > 0) parts.push(`${errorSteps.length} errored`);
+
+  return {
+    projectRoot,
+    steps,
+    success: errorSteps.length === 0,
+    summary: parts.join(', ') || 'no steps run',
+  };
+}


### PR DESCRIPTION
## Summary

- `packages/contracts/src/project-tools.ts` — typed contracts for `scaffold-project`, `doctor-project`, and `scaffold-global`
- `packages/core/src/tools/scaffold-project.ts` — composes 10 canonical `ensure*` calls in execution order; pure-functional, idempotent
- `packages/core/src/tools/doctor-project.ts` — composes all synchronous `check*` calls (global + project-scoped) with try-catch guard on `runAllGlobalChecks`
- `packages/core/src/tools/scaffold-global.ts` — typed label on `ensureGlobalScaffold()`
- 13 Vitest assertions, all green

## Test plan

- [x] `pnpm biome check` — clean (no unfixed violations)
- [x] `pnpm --filter @cleocode/core exec vitest run src/tools/__tests__/project-tools.test.ts` — 13/13 passed
- [x] No `any`/`unknown`/`as unknown as` casts
- [x] All types sourced from `@cleocode/contracts/project-tools`

Closes T10069 / Epic T9835 / Saga T9831

🤖 Generated with [Claude Code](https://claude.com/claude-code)