### PR TITLE
feat(T10070): BrainTools SDK (T9835c — Saga T9831)

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -275,7 +275,7 @@ export { CANONICAL_DOMAINS } from './dispatch/identity.js';
 // === Dispatch OperationDef + Resolution (T9954 — Phase 0b of SG-ARCH-SOLID / E-CONTRACTS-FOUNDATION) ===
 export type { OperationDef, Resolution } from './dispatch/operation-def.js';
 // === Dispatch OPERATIONS data + builder helpers (T10061 — T9833b / E-CLI-BOUNDARY / SG-ARCH-SOLID) ===
-export { OPERATIONS, defineOp, defineDomain } from './dispatch/operations-registry.js';
+export { defineDomain, defineOp, OPERATIONS } from './dispatch/operations-registry.js';
 // === DocsAccessor Contracts (T9063) ===
 export type {
   DocExportFormat,
@@ -1730,7 +1730,17 @@ export type {
   TesseraTemplate,
   TesseraVariable,
 } from './tessera.js';
-// === Task SDK Tool Contracts (T10068 / T9835) ===
+export type { FetchBrainEntriesInput, FetchBrainEntriesOutput } from './tools/brain-fetch.js';
+export type { ObserveBrainInput, ObserveBrainOutput } from './tools/brain-observe.js';
+// === SDK Tool Contracts (T10068 / T10070 / T9835) ===
+// BrainTools (T10070 / T9835c)
+export type { SearchBrainInput, SearchBrainOutput } from './tools/brain-search.js';
+export type { TimelineBrainInput, TimelineBrainOutput } from './tools/brain-timeline.js';
+export type {
+  BuildRetrievalBundleInput,
+  BuildRetrievalBundleOutput,
+} from './tools/build-retrieval-bundle.js';
+// TaskTools (T10068 / T9835b)
 export type {
   BuildTaskTreeInput,
   BuildTaskTreeOptions,

--- a/packages/contracts/src/tools/brain-fetch.ts
+++ b/packages/contracts/src/tools/brain-fetch.ts
@@ -1,0 +1,25 @@
+/**
+ * Contract types for the fetchBrainEntries SDK tool.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, pure-functional wrapper
+ * @task T10070
+ * @epic T9835
+ */
+
+import type { FetchBrainEntriesParams, FetchBrainEntriesResult } from '../memory/fetch.js';
+
+export type { FetchBrainEntriesParams, FetchBrainEntriesResult };
+
+/** Input accepted by the fetchBrainEntries SDK tool. */
+export interface FetchBrainEntriesInput {
+  /** Project root directory for DB resolution. */
+  projectRoot: string;
+  /** Fetch parameters forwarded to fetchBrainEntries. */
+  params: FetchBrainEntriesParams;
+}
+
+/** Output produced by the fetchBrainEntries SDK tool. */
+export interface FetchBrainEntriesOutput {
+  /** Result from fetchBrainEntries. */
+  result: FetchBrainEntriesResult;
+}

--- a/packages/contracts/src/tools/brain-observe.ts
+++ b/packages/contracts/src/tools/brain-observe.ts
@@ -1,0 +1,25 @@
+/**
+ * Contract types for the observeBrain SDK tool.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, pure-functional wrapper
+ * @task T10070
+ * @epic T9835
+ */
+
+import type { ObserveBrainParams, ObserveBrainResult } from '../memory/observe.js';
+
+export type { ObserveBrainParams, ObserveBrainResult };
+
+/** Input accepted by the observeBrain SDK tool. */
+export interface ObserveBrainInput {
+  /** Project root directory for DB resolution. */
+  projectRoot: string;
+  /** Observation data forwarded to observeBrain. */
+  params: ObserveBrainParams;
+}
+
+/** Output produced by the observeBrain SDK tool. */
+export interface ObserveBrainOutput {
+  /** Result from observeBrain. */
+  result: ObserveBrainResult;
+}

--- a/packages/contracts/src/tools/brain-search.ts
+++ b/packages/contracts/src/tools/brain-search.ts
@@ -1,0 +1,25 @@
+/**
+ * Contract types for the searchBrain SDK tool.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, pure-functional wrapper
+ * @task T10070
+ * @epic T9835
+ */
+
+import type { SearchBrainCompactParams, SearchBrainCompactResult } from '../memory/search.js';
+
+export type { SearchBrainCompactParams, SearchBrainCompactResult };
+
+/** Input accepted by the searchBrain SDK tool. */
+export interface SearchBrainInput {
+  /** Project root directory for DB resolution. */
+  projectRoot: string;
+  /** Search parameters forwarded to searchBrainCompact. */
+  params: SearchBrainCompactParams;
+}
+
+/** Output produced by the searchBrain SDK tool. */
+export interface SearchBrainOutput {
+  /** Compact search results from searchBrainCompact. */
+  result: SearchBrainCompactResult;
+}

--- a/packages/contracts/src/tools/brain-timeline.ts
+++ b/packages/contracts/src/tools/brain-timeline.ts
@@ -1,0 +1,25 @@
+/**
+ * Contract types for the timelineBrain SDK tool.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, pure-functional wrapper
+ * @task T10070
+ * @epic T9835
+ */
+
+import type { TimelineBrainParams, TimelineBrainResult } from '../memory/timeline.js';
+
+export type { TimelineBrainParams, TimelineBrainResult };
+
+/** Input accepted by the timelineBrain SDK tool. */
+export interface TimelineBrainInput {
+  /** Project root directory for DB resolution. */
+  projectRoot: string;
+  /** Timeline parameters forwarded to timelineBrain. */
+  params: TimelineBrainParams;
+}
+
+/** Output produced by the timelineBrain SDK tool. */
+export interface TimelineBrainOutput {
+  /** Result from timelineBrain. */
+  result: TimelineBrainResult;
+}

--- a/packages/contracts/src/tools/build-retrieval-bundle.ts
+++ b/packages/contracts/src/tools/build-retrieval-bundle.ts
@@ -1,0 +1,25 @@
+/**
+ * Contract types for the buildRetrievalBundle SDK tool.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, pure-functional wrapper
+ * @task T10070
+ * @epic T9835
+ */
+
+import type { RetrievalBundle, RetrievalRequest } from '../operations/memory.js';
+
+export type { RetrievalBundle, RetrievalRequest };
+
+/** Input accepted by the buildRetrievalBundle SDK tool. */
+export interface BuildRetrievalBundleInput {
+  /** Retrieval request forwarded to buildRetrievalBundle. */
+  req: RetrievalRequest;
+  /** Project root directory for DB resolution. */
+  projectRoot: string;
+}
+
+/** Output produced by the buildRetrievalBundle SDK tool. */
+export interface BuildRetrievalBundleOutput {
+  /** Fully-structured retrieval bundle with token accounting. */
+  bundle: RetrievalBundle;
+}

--- a/packages/contracts/src/tools/index.ts
+++ b/packages/contracts/src/tools/index.ts
@@ -1,11 +1,23 @@
 /**
- * Task SDK tool contract types.
+ * SDK Tool contract types.
  *
- * @arch Contracts barrel for Category B SDK Tools in packages/core/src/tools/task-tools/
+ * @arch Contracts barrel for Category B SDK Tools in packages/core/src/tools/
  * @task T10068
+ * @task T10070
  * @epic T9835
  */
 
+export type { FetchBrainEntriesInput, FetchBrainEntriesOutput } from './brain-fetch.js';
+export type { ObserveBrainInput, ObserveBrainOutput } from './brain-observe.js';
+// === BrainTools (T10070 / T9835c) ===
+export type { SearchBrainInput, SearchBrainOutput } from './brain-search.js';
+export type { TimelineBrainInput, TimelineBrainOutput } from './brain-timeline.js';
+export type {
+  BuildRetrievalBundleInput,
+  BuildRetrievalBundleOutput,
+} from './build-retrieval-bundle.js';
+
+// === TaskTools (T10068 / T9835b) ===
 export type {
   BuildTaskTreeInput,
   BuildTaskTreeOptions,

--- a/packages/core/src/memory/__tests__/build-retrieval-bundle-refusal-gate.test.ts
+++ b/packages/core/src/memory/__tests__/build-retrieval-bundle-refusal-gate.test.ts
@@ -34,16 +34,22 @@ afterEach(async () => {
   try {
     const { closeBrainDb } = await import('../../store/memory-sqlite.js');
     closeBrainDb();
-  } catch { /* not loaded */ }
+  } catch {
+    /* not loaded */
+  }
   try {
     const { closeNexusDb, resetNexusDbState } = await import('../../store/nexus-sqlite.js');
     closeNexusDb();
     resetNexusDbState();
-  } catch { /* not loaded */ }
+  } catch {
+    /* not loaded */
+  }
   try {
     const { closeDb } = await import('../../store/sqlite.js');
     closeDb();
-  } catch { /* not loaded */ }
+  } catch {
+    /* not loaded */
+  }
 
   delete process.env['CLEO_DIR'];
   delete process.env['CLEO_HOME'];
@@ -78,12 +84,18 @@ function seedObservation(
   // Ensure peer_id column exists (may be added by T1084 migration)
   try {
     db.exec(`ALTER TABLE brain_observations ADD COLUMN peer_id TEXT NOT NULL DEFAULT 'global'`);
-  } catch { /* already exists */ }
+  } catch {
+    /* already exists */
+  }
 
   // Ensure provenance_class column exists (added by T1260 migration)
   try {
-    db.exec(`ALTER TABLE brain_observations ADD COLUMN provenance_class TEXT DEFAULT 'unswept-pre-T1151'`);
-  } catch { /* already exists */ }
+    db.exec(
+      `ALTER TABLE brain_observations ADD COLUMN provenance_class TEXT DEFAULT 'unswept-pre-T1151'`,
+    );
+  } catch {
+    /* already exists */
+  }
 
   try {
     db.prepare(

--- a/packages/core/src/tools/__tests__/brain-tools/brain-tools.test.ts
+++ b/packages/core/src/tools/__tests__/brain-tools/brain-tools.test.ts
@@ -1,0 +1,152 @@
+/**
+ * BrainTools SDK tool registration tests.
+ *
+ * Validates that each BrainTool is correctly registered (identity, schemas)
+ * and that the fn wrappers forward correctly without top-level I/O.
+ *
+ * @task T10070
+ * @epic T9835
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fetchBrainEntries } from '../../brain-tools/brain-fetch.js';
+import { observeBrain } from '../../brain-tools/brain-observe.js';
+import { searchBrain } from '../../brain-tools/brain-search.js';
+import { timelineBrain } from '../../brain-tools/brain-timeline.js';
+import { buildRetrievalBundle } from '../../brain-tools/build-retrieval-bundle.js';
+
+// ---------------------------------------------------------------------------
+// searchBrain
+// ---------------------------------------------------------------------------
+describe('searchBrain (SDK tool registration)', () => {
+  it('has a stable identity', () => {
+    expect(searchBrain.identity.name).toBe('search-brain');
+    expect(searchBrain.identity.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(typeof searchBrain.identity.description).toBe('string');
+  });
+
+  it('exposes inputSchema and outputSchema', () => {
+    expect(searchBrain.inputSchema.type).toBe('object');
+    expect(searchBrain.outputSchema.type).toBe('object');
+    expect(searchBrain.inputSchema.required).toContain('projectRoot');
+    expect(searchBrain.inputSchema.required).toContain('params');
+  });
+
+  it('invoke is a function', () => {
+    expect(typeof searchBrain.invoke).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// observeBrain
+// ---------------------------------------------------------------------------
+describe('observeBrain (SDK tool registration)', () => {
+  it('has a stable identity', () => {
+    expect(observeBrain.identity.name).toBe('observe-brain');
+    expect(observeBrain.identity.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(typeof observeBrain.identity.description).toBe('string');
+  });
+
+  it('exposes inputSchema and outputSchema', () => {
+    expect(observeBrain.inputSchema.type).toBe('object');
+    expect(observeBrain.outputSchema.type).toBe('object');
+    expect(observeBrain.inputSchema.required).toContain('projectRoot');
+    expect(observeBrain.inputSchema.required).toContain('params');
+  });
+
+  it('inputSchema params require text', () => {
+    const paramsSchema = observeBrain.inputSchema.properties?.['params'] as {
+      required?: string[];
+    };
+    expect(paramsSchema?.required).toContain('text');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchBrainEntries
+// ---------------------------------------------------------------------------
+describe('fetchBrainEntries (SDK tool registration)', () => {
+  it('has a stable identity', () => {
+    expect(fetchBrainEntries.identity.name).toBe('fetch-brain-entries');
+    expect(fetchBrainEntries.identity.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(typeof fetchBrainEntries.identity.description).toBe('string');
+  });
+
+  it('exposes inputSchema and outputSchema', () => {
+    expect(fetchBrainEntries.inputSchema.type).toBe('object');
+    expect(fetchBrainEntries.outputSchema.type).toBe('object');
+    expect(fetchBrainEntries.inputSchema.required).toContain('projectRoot');
+    expect(fetchBrainEntries.inputSchema.required).toContain('params');
+  });
+
+  it('inputSchema params require ids array', () => {
+    const paramsSchema = fetchBrainEntries.inputSchema.properties?.['params'] as {
+      required?: string[];
+    };
+    expect(paramsSchema?.required).toContain('ids');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// timelineBrain
+// ---------------------------------------------------------------------------
+describe('timelineBrain (SDK tool registration)', () => {
+  it('has a stable identity', () => {
+    expect(timelineBrain.identity.name).toBe('timeline-brain');
+    expect(timelineBrain.identity.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(typeof timelineBrain.identity.description).toBe('string');
+  });
+
+  it('exposes inputSchema and outputSchema', () => {
+    expect(timelineBrain.inputSchema.type).toBe('object');
+    expect(timelineBrain.outputSchema.type).toBe('object');
+    expect(timelineBrain.inputSchema.required).toContain('projectRoot');
+    expect(timelineBrain.inputSchema.required).toContain('params');
+  });
+
+  it('inputSchema params require anchor', () => {
+    const paramsSchema = timelineBrain.inputSchema.properties?.['params'] as {
+      required?: string[];
+    };
+    expect(paramsSchema?.required).toContain('anchor');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRetrievalBundle
+// ---------------------------------------------------------------------------
+describe('buildRetrievalBundle (SDK tool registration)', () => {
+  it('has a stable identity', () => {
+    expect(buildRetrievalBundle.identity.name).toBe('build-retrieval-bundle');
+    expect(buildRetrievalBundle.identity.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(typeof buildRetrievalBundle.identity.description).toBe('string');
+  });
+
+  it('exposes inputSchema and outputSchema', () => {
+    expect(buildRetrievalBundle.inputSchema.type).toBe('object');
+    expect(buildRetrievalBundle.outputSchema.type).toBe('object');
+    expect(buildRetrievalBundle.inputSchema.required).toContain('req');
+    expect(buildRetrievalBundle.inputSchema.required).toContain('projectRoot');
+  });
+
+  it('inputSchema req requires peerId and sessionId', () => {
+    const reqSchema = buildRetrievalBundle.inputSchema.properties?.['req'] as {
+      required?: string[];
+    };
+    expect(reqSchema?.required).toContain('peerId');
+    expect(reqSchema?.required).toContain('sessionId');
+  });
+
+  it('all 5 brain tools are frozen (immutable identity)', () => {
+    const tools = [
+      searchBrain,
+      observeBrain,
+      fetchBrainEntries,
+      timelineBrain,
+      buildRetrievalBundle,
+    ];
+    for (const tool of tools) {
+      expect(Object.isFrozen(tool)).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/tools/brain-tools/brain-fetch.ts
+++ b/packages/core/src/tools/brain-tools/brain-fetch.ts
@@ -1,0 +1,91 @@
+/**
+ * fetchBrainEntries — SDK tool wrapping fetchBrainEntries from memory/retrieval.
+ *
+ * Layer 3 of the 3-layer BRAIN retrieval pattern (search → timeline → fetch).
+ * Batch-fetches full entry details by IDs, grouped by type prefix.
+ *
+ * @arch SDK Tool (Category B) — pure-functional, contracts-typed, no I/O at top level
+ * @task T10070
+ * @epic T9835
+ */
+
+import type { FetchBrainEntriesInput, FetchBrainEntriesOutput } from '@cleocode/contracts';
+import type { JsonSchema, RegisteredSdkTool } from '../task-tools/sdk-tool.js';
+import { defineSdkTool } from '../task-tools/sdk-tool.js';
+
+const INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    projectRoot: { type: 'string', description: 'Absolute path to the project root.' },
+    params: {
+      type: 'object',
+      description: 'Fetch parameters forwarded to fetchBrainEntries.',
+      properties: {
+        ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Entry identifiers to fetch in a single batch.',
+        },
+      },
+      required: ['ids'],
+    },
+  },
+  required: ['projectRoot', 'params'],
+};
+
+const OUTPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    result: {
+      type: 'object',
+      properties: {
+        results: { type: 'array', description: 'Resolved entries with full row payload.' },
+        notFound: { type: 'array', description: 'IDs that could not be resolved.' },
+        tokensEstimated: { type: 'number', description: 'Approximate token cost.' },
+      },
+    },
+  },
+};
+
+/**
+ * Batch-fetch full BRAIN entry details by IDs.
+ *
+ * Delegates to `fetchBrainEntries` from the memory/retrieval module.
+ * Groups IDs by prefix (D-, P-, L-, O-) to query the correct tables.
+ *
+ * @param input - Project root and fetch params with IDs
+ * @returns Full entry data for each resolved ID, plus not-found list
+ *
+ * @example
+ * ```typescript
+ * const output = await fetchBrainEntries.invoke({
+ *   projectRoot: '/mnt/projects/cleocode',
+ *   params: { ids: ['D-arch-001', 'O-abc123'] },
+ * });
+ * console.assert(Array.isArray(output.result.results));
+ * console.assert(Array.isArray(output.result.notFound));
+ * ```
+ */
+async function fetchBrainEntriesFn(
+  input: FetchBrainEntriesInput,
+): Promise<FetchBrainEntriesOutput> {
+  const { fetchBrainEntries: fetch } = await import('../../memory/retrieval/fetch.js');
+  const result = await fetch(input.projectRoot, input.params);
+  return { result };
+}
+
+/** Registered SDK tool for batch-fetching full BRAIN entry details (Layer 3). */
+export const fetchBrainEntries: RegisteredSdkTool<
+  FetchBrainEntriesInput,
+  Promise<FetchBrainEntriesOutput>
+> = defineSdkTool({
+  identity: {
+    name: 'fetch-brain-entries',
+    description:
+      'Batch-fetch full BRAIN entry details by IDs (Layer 3 of the 3-layer retrieval pattern).',
+    version: '1.0.0',
+  },
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OUTPUT_SCHEMA,
+  fn: fetchBrainEntriesFn,
+});

--- a/packages/core/src/tools/brain-tools/brain-observe.ts
+++ b/packages/core/src/tools/brain-tools/brain-observe.ts
@@ -1,0 +1,94 @@
+/**
+ * observeBrain — SDK tool wrapping the observeBrain write path from memory/retrieval.
+ *
+ * Unified BRAIN write path that persists agent observations into brain_observations.
+ * Auto-classifies observation type from text when not provided.
+ *
+ * @arch SDK Tool (Category B) — pure-functional, contracts-typed, no I/O at top level
+ * @task T10070
+ * @epic T9835
+ */
+
+import type { ObserveBrainInput, ObserveBrainOutput } from '@cleocode/contracts';
+import type { JsonSchema, RegisteredSdkTool } from '../task-tools/sdk-tool.js';
+import { defineSdkTool } from '../task-tools/sdk-tool.js';
+
+const INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    projectRoot: { type: 'string', description: 'Absolute path to the project root.' },
+    params: {
+      type: 'object',
+      description: 'Observation data forwarded to observeBrain.',
+      properties: {
+        text: { type: 'string', description: 'Observation narrative to persist.' },
+        title: {
+          type: 'string',
+          description: 'Optional display title; auto-derived when omitted.',
+        },
+        type: { type: 'string', description: 'Observation type (feature, bugfix, decision, …).' },
+        sourceType: { type: 'string', description: 'How the observation was created.' },
+        agent: { type: 'string', description: 'Agent provenance identifier.' },
+      },
+      required: ['text'],
+    },
+  },
+  required: ['projectRoot', 'params'],
+};
+
+const OUTPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    result: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'ID of the newly-persisted observation.' },
+        type: { type: 'string', description: 'Resolved observation type.' },
+        createdAt: { type: 'string', description: 'ISO 8601 creation timestamp.' },
+      },
+    },
+  },
+};
+
+/**
+ * Save an observation to the BRAIN.
+ *
+ * Delegates to `observeBrain` from the memory/retrieval module.
+ * Auto-classifies type from text when `params.type` is omitted.
+ *
+ * @param input - Project root and observation params
+ * @returns Created observation ID, type, and timestamp
+ *
+ * @example
+ * ```typescript
+ * const output = await observeBrain.invoke({
+ *   projectRoot: '/mnt/projects/cleocode',
+ *   params: {
+ *     text: 'Decided to use ESM-only imports for better tree-shaking.',
+ *     title: 'ESM-only import decision',
+ *     type: 'decision',
+ *   },
+ * });
+ * console.assert(output.result.id.startsWith('O-'));
+ * ```
+ */
+async function observeBrainFn(input: ObserveBrainInput): Promise<ObserveBrainOutput> {
+  const { observeBrain: observe } = await import('../../memory/retrieval/observe.js');
+  const result = await observe(input.projectRoot, input.params);
+  return { result };
+}
+
+/** Registered SDK tool for saving BRAIN observations. */
+export const observeBrain: RegisteredSdkTool<
+  ObserveBrainInput,
+  Promise<ObserveBrainOutput>
+> = defineSdkTool({
+  identity: {
+    name: 'observe-brain',
+    description: 'Unified BRAIN write path — saves an observation to brain_observations.',
+    version: '1.0.0',
+  },
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OUTPUT_SCHEMA,
+  fn: observeBrainFn,
+});

--- a/packages/core/src/tools/brain-tools/brain-search.ts
+++ b/packages/core/src/tools/brain-tools/brain-search.ts
@@ -1,0 +1,92 @@
+/**
+ * searchBrain — SDK tool wrapping searchBrainCompact from memory/retrieval.
+ *
+ * Layer 1 of the 3-layer BRAIN retrieval pattern (search → timeline → fetch).
+ * Returns compact index-level hits (~50 tokens/hit) for cheap candidate scanning.
+ *
+ * @arch SDK Tool (Category B) — pure-functional, contracts-typed, no I/O at top level
+ * @task T10070
+ * @epic T9835
+ */
+
+import type { SearchBrainInput, SearchBrainOutput } from '@cleocode/contracts';
+import type { JsonSchema, RegisteredSdkTool } from '../task-tools/sdk-tool.js';
+import { defineSdkTool } from '../task-tools/sdk-tool.js';
+
+const INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    projectRoot: { type: 'string', description: 'Absolute path to the project root.' },
+    params: {
+      type: 'object',
+      description: 'Search parameters forwarded to searchBrainCompact.',
+      properties: {
+        query: { type: 'string', description: 'Free-text search query.' },
+        limit: { type: 'number', description: 'Maximum hits to return.' },
+        tables: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Restrict to specific BRAIN tables.',
+        },
+        mode: { type: 'string', description: 'Ranking mode: hybrid | lexical | recency.' },
+      },
+      required: ['query'],
+    },
+  },
+  required: ['projectRoot', 'params'],
+};
+
+const OUTPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    result: {
+      type: 'object',
+      properties: {
+        results: { type: 'array', description: 'Compact BRAIN hits.' },
+        total: { type: 'number', description: 'Total matches before limit.' },
+        tokensEstimated: { type: 'number', description: 'Approximate token cost.' },
+      },
+    },
+  },
+};
+
+/**
+ * Search the BRAIN for compact hits matching a query.
+ *
+ * Delegates to `searchBrainCompact` from the memory/retrieval module.
+ * The implementation is async and performs DB I/O internally but is
+ * wrapped here as a pure-signature SDK tool for harness-agnostic registration.
+ *
+ * @param input - Project root and search params
+ * @returns Compact search result envelope
+ *
+ * @example
+ * ```typescript
+ * const output = await searchBrain.invoke({
+ *   projectRoot: '/mnt/projects/cleocode',
+ *   params: { query: 'auth decisions', limit: 5 },
+ * });
+ * console.assert(Array.isArray(output.result.results));
+ * ```
+ */
+async function searchBrainFn(input: SearchBrainInput): Promise<SearchBrainOutput> {
+  const { searchBrainCompact } = await import('../../memory/retrieval/search.js');
+  const result = await searchBrainCompact(input.projectRoot, input.params);
+  return { result };
+}
+
+/** Registered SDK tool for BRAIN compact search (Layer 1). */
+export const searchBrain: RegisteredSdkTool<
+  SearchBrainInput,
+  Promise<SearchBrainOutput>
+> = defineSdkTool({
+  identity: {
+    name: 'search-brain',
+    description:
+      'Token-efficient compact search across BRAIN tables (Layer 1 of the 3-layer retrieval pattern).',
+    version: '1.0.0',
+  },
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OUTPUT_SCHEMA,
+  fn: searchBrainFn,
+});

--- a/packages/core/src/tools/brain-tools/brain-timeline.ts
+++ b/packages/core/src/tools/brain-tools/brain-timeline.ts
@@ -1,0 +1,93 @@
+/**
+ * timelineBrain — SDK tool wrapping timelineBrain from memory/retrieval.
+ *
+ * Layer 2 of the 3-layer BRAIN retrieval pattern (search → timeline → fetch).
+ * Surfaces chronological neighbors around an anchor entry for context reconstruction.
+ *
+ * @arch SDK Tool (Category B) — pure-functional, contracts-typed, no I/O at top level
+ * @task T10070
+ * @epic T9835
+ */
+
+import type { TimelineBrainInput, TimelineBrainOutput } from '@cleocode/contracts';
+import type { JsonSchema, RegisteredSdkTool } from '../task-tools/sdk-tool.js';
+import { defineSdkTool } from '../task-tools/sdk-tool.js';
+
+const INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    projectRoot: { type: 'string', description: 'Absolute path to the project root.' },
+    params: {
+      type: 'object',
+      description: 'Timeline parameters forwarded to timelineBrain.',
+      properties: {
+        anchor: { type: 'string', description: 'Anchor entry ID to build the timeline around.' },
+        depthBefore: {
+          type: 'number',
+          description: 'Chronologically-earlier neighbors to include (default 3).',
+        },
+        depthAfter: {
+          type: 'number',
+          description: 'Chronologically-later neighbors to include (default 3).',
+        },
+      },
+      required: ['anchor'],
+    },
+  },
+  required: ['projectRoot', 'params'],
+};
+
+const OUTPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    result: {
+      type: 'object',
+      properties: {
+        anchor: { description: 'Anchor entry with full row payload, or null.' },
+        before: { type: 'array', description: 'Chronologically-earlier neighbors.' },
+        after: { type: 'array', description: 'Chronologically-later neighbors.' },
+      },
+    },
+  },
+};
+
+/**
+ * Get chronological context around an anchor BRAIN entry.
+ *
+ * Delegates to `timelineBrain` from the memory/retrieval module.
+ * Queries all 4 BRAIN tables via UNION ALL to find neighbors.
+ *
+ * @param input - Project root and timeline params with anchor ID
+ * @returns Anchor entry with surrounding chronological neighbor entries
+ *
+ * @example
+ * ```typescript
+ * const output = await timelineBrain.invoke({
+ *   projectRoot: '/mnt/projects/cleocode',
+ *   params: { anchor: 'O-abc123', depthBefore: 5, depthAfter: 5 },
+ * });
+ * console.assert(Array.isArray(output.result.before));
+ * console.assert(Array.isArray(output.result.after));
+ * ```
+ */
+async function timelineBrainFn(input: TimelineBrainInput): Promise<TimelineBrainOutput> {
+  const { timelineBrain: timeline } = await import('../../memory/retrieval/timeline.js');
+  const result = await timeline(input.projectRoot, input.params);
+  return { result };
+}
+
+/** Registered SDK tool for BRAIN chronological timeline (Layer 2). */
+export const timelineBrain: RegisteredSdkTool<
+  TimelineBrainInput,
+  Promise<TimelineBrainOutput>
+> = defineSdkTool({
+  identity: {
+    name: 'timeline-brain',
+    description:
+      'Get chronological context around a BRAIN anchor entry (Layer 2 of the 3-layer retrieval pattern).',
+    version: '1.0.0',
+  },
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OUTPUT_SCHEMA,
+  fn: timelineBrainFn,
+});

--- a/packages/core/src/tools/brain-tools/build-retrieval-bundle.ts
+++ b/packages/core/src/tools/brain-tools/build-retrieval-bundle.ts
@@ -1,0 +1,123 @@
+/**
+ * buildRetrievalBundle — SDK tool wrapping the multi-pass retrieval bundle builder.
+ *
+ * Executes up to three passes in parallel (cold/warm/hot) to assemble a
+ * structured context bundle for agent briefing within a token budget.
+ *
+ * @arch SDK Tool (Category B) — pure-functional, contracts-typed, no I/O at top level
+ * @task T10070
+ * @epic T9835
+ */
+
+import type { BuildRetrievalBundleInput, BuildRetrievalBundleOutput } from '@cleocode/contracts';
+import type { JsonSchema, RegisteredSdkTool } from '../task-tools/sdk-tool.js';
+import { defineSdkTool } from '../task-tools/sdk-tool.js';
+
+const INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    req: {
+      type: 'object',
+      description: 'Retrieval request: peerId, sessionId, optional query and passMask.',
+      properties: {
+        peerId: { type: 'string', description: 'CANT peer identifier.' },
+        sessionId: { type: 'string', description: 'Active session identifier.' },
+        query: { type: 'string', description: 'Optional search term to scope learnings.' },
+        tokenBudget: {
+          type: 'number',
+          description: 'Maximum tokens for the bundle (default 4000).',
+        },
+        passMask: {
+          type: 'object',
+          description: 'Enable/disable cold, warm, and hot passes.',
+          properties: {
+            cold: { type: 'boolean' },
+            warm: { type: 'boolean' },
+            hot: { type: 'boolean' },
+          },
+        },
+      },
+      required: ['peerId', 'sessionId'],
+    },
+    projectRoot: { type: 'string', description: 'Absolute path to the project root.' },
+  },
+  required: ['req', 'projectRoot'],
+};
+
+const OUTPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    bundle: {
+      type: 'object',
+      description: 'Multi-pass retrieval bundle with cold/warm/hot passes and token counts.',
+      properties: {
+        cold: { type: 'object', description: 'User profile + peer instructions + sigil card.' },
+        warm: { type: 'object', description: 'Peer learnings + patterns + decisions.' },
+        hot: {
+          type: 'object',
+          description: 'Session narrative + recent observations + active tasks.',
+        },
+        tokenCounts: {
+          type: 'object',
+          description: 'Per-pass and total token estimate.',
+          properties: {
+            cold: { type: 'number' },
+            warm: { type: 'number' },
+            hot: { type: 'number' },
+            total: { type: 'number' },
+          },
+        },
+      },
+    },
+  },
+};
+
+/**
+ * Build a multi-pass BRAIN retrieval bundle for agent briefing.
+ *
+ * Delegates to `buildRetrievalBundle` from the memory/retrieval module.
+ * Runs cold (20%), warm (50%), and hot (30%) passes in parallel and
+ * enforces token budget by trimming the hot pass first.
+ *
+ * @param input - Retrieval request and project root
+ * @returns Fully-structured retrieval bundle with token accounting
+ *
+ * @example
+ * ```typescript
+ * const output = await buildRetrievalBundle.invoke({
+ *   req: {
+ *     peerId: 'cleo-prime',
+ *     sessionId: 'ses_abc',
+ *     passMask: { cold: true, warm: true, hot: false },
+ *   },
+ *   projectRoot: '/mnt/projects/cleocode',
+ * });
+ * console.assert(typeof output.bundle.tokenCounts.total === 'number');
+ * console.assert(Array.isArray(output.bundle.warm.peerLearnings));
+ * ```
+ */
+async function buildRetrievalBundleFn(
+  input: BuildRetrievalBundleInput,
+): Promise<BuildRetrievalBundleOutput> {
+  const { buildRetrievalBundle: build } = await import(
+    '../../memory/retrieval/build-retrieval-bundle.js'
+  );
+  const bundle = await build(input.req, input.projectRoot);
+  return { bundle };
+}
+
+/** Registered SDK tool for building multi-pass BRAIN retrieval bundles. */
+export const buildRetrievalBundle: RegisteredSdkTool<
+  BuildRetrievalBundleInput,
+  Promise<BuildRetrievalBundleOutput>
+> = defineSdkTool({
+  identity: {
+    name: 'build-retrieval-bundle',
+    description:
+      'Build a multi-pass BRAIN retrieval bundle (cold/warm/hot) for agent briefing within a token budget.',
+    version: '1.0.0',
+  },
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OUTPUT_SCHEMA,
+  fn: buildRetrievalBundleFn,
+});

--- a/packages/core/src/tools/brain-tools/index.ts
+++ b/packages/core/src/tools/brain-tools/index.ts
@@ -1,0 +1,22 @@
+/**
+ * BrainTools barrel — pure-functional SDK tools for BRAIN retrieval and observation.
+ *
+ * All tools are Category B SDK Tools (harness-agnostic, pure-functional, I/O isolated).
+ * Input/output types are defined in `@cleocode/contracts` — never inline.
+ *
+ * Exposed tools:
+ *   searchBrain           — Layer 1: compact FTS/RRF search (~50 tokens/hit)
+ *   observeBrain          — unified BRAIN write path (observations)
+ *   fetchBrainEntries     — Layer 3: batch-fetch full entry details by IDs
+ *   timelineBrain         — Layer 2: chronological context around an anchor
+ *   buildRetrievalBundle  — multi-pass cold/warm/hot bundle for agent briefing
+ *
+ * @arch SDK Tools (Category B) — T10070 / Epic T9835 / Saga T9831
+ * @task T10070
+ */
+
+export { fetchBrainEntries } from './brain-fetch.js';
+export { observeBrain } from './brain-observe.js';
+export { searchBrain } from './brain-search.js';
+export { timelineBrain } from './brain-timeline.js';
+export { buildRetrievalBundle } from './build-retrieval-bundle.js';

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -14,6 +14,8 @@
  * @epic T1566
  */
 
+// BrainTools (Category B) — pure-functional BRAIN retrieval SDK tools (T10070 / T9835)
+export * from './brain-tools/index.js';
 export type { DoctorProjectOptions, DoctorProjectResult } from './doctor-project.js';
 // ProjectTools SDK Tools (Category B) — scaffold + doctor primitives (T10069 / T9835b)
 export { doctorProject } from './doctor-project.js';


### PR DESCRIPTION
## Summary

- Add 5 Category B SDK tools wrapping `packages/core/src/memory/retrieval/` in `packages/core/src/tools/brain-tools/`:
  - `searchBrain` — Layer 1: compact FTS/RRF search via `searchBrainCompact` (~50 tokens/hit)
  - `observeBrain` — unified BRAIN write path via `observeBrain` (brain_observations)
  - `fetchBrainEntries` — Layer 3: batch-fetch full entry details by IDs
  - `timelineBrain` — Layer 2: chronological context around an anchor entry
  - `buildRetrievalBundle` — multi-pass cold/warm/hot briefing bundle
- Add 5 matching contract type files in `packages/contracts/src/tools/` (brain-search, brain-observe, brain-fetch, brain-timeline, build-retrieval-bundle)
- Each tool: pure-functional wrapper with dynamic import for I/O isolation, contracts-typed, TSDoc with `@example`, registered via `defineSdkTool`
- Export all tools from `packages/core/src/tools/index.ts` and `packages/contracts/src/index.ts`
- 16 Vitest assertions, all passing — zero regressions in tools test suite (65 tests pass)

## Test plan

- [ ] `pnpm biome check --write .` — passes (no lint errors)
- [ ] `pnpm run build` — passes (60.9s build success)
- [ ] `npx vitest run src/tools/` in `packages/core` — 65 tests pass, 0 failures
- [ ] `npx vitest run src/tools/__tests__/brain-tools/` — 16 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)