### PR TITLE
refactor(T10062): extract 8 fat handlers to packages/core/ (T9833c — Saga T9831)

### DIFF
--- a/packages/cleo/src/cli/commands/agent.ts
+++ b/packages/cleo/src/cli/commands/agent.ts
@@ -43,6 +43,18 @@ import {
   getHealthReport,
   STALE_THRESHOLD_MS,
 } from '@cleocode/core/agents';
+import {
+  cleanupInstallTempDir,
+  resolveAgentCantPath,
+} from '@cleocode/core/agents/install-pipeline.js';
+import {
+  inferTierFromRole,
+  scaffoldAgent,
+  validateName,
+  validateRole,
+  validateTier,
+} from '@cleocode/core/agents/scaffold.js';
+import { startWorkLoop } from '@cleocode/core/agents/work-loop.js';
 import { defineCommand, showUsage } from 'citty';
 import { AGENTS_SUBDIR, CANT_AGENTS_SUBDIR, CLEO_DIR_NAME } from '../paths.js';
 import { cliError, cliOutput, humanLine, humanWarn } from '../renderers/index.js';
@@ -958,9 +970,6 @@ const workCommand = defineCommand({
       const { createRuntime } = await import('@cleocode/runtime');
       const { existsSync } = await import('node:fs');
       const { join } = await import('node:path');
-      const { execFile } = await import('node:child_process');
-      const { promisify } = await import('node:util');
-      const execFileAsync = promisify(execFile);
       await getDb();
       const registry = new AgentRegistryAccessor(getProjectRoot());
       const credential = await registry.get(args.agentId);
@@ -1003,105 +1012,25 @@ const workCommand = defineCommand({
         { command: 'agent work' },
       );
 
-      // Parse LAFS envelope from CLI stdout (handles both minimal and full shapes)
-      const parseLafs = <T = unknown>(raw: string): T | undefined => {
-        const lines = raw.trim().split('\n');
-        const envLine = [...lines].reverse().find((l) => l.startsWith('{'));
-        if (!envLine) return undefined;
-        try {
-          const env = JSON.parse(envLine) as {
-            ok?: boolean;
-            r?: T;
-            success?: boolean;
-            result?: T;
-            data?: T;
-          };
-          if (env.ok === true) return env.r;
-          if (env.success === true) return (env.result ?? env.data) as T | undefined;
-          return undefined;
-        } catch {
-          return undefined;
-        }
-      };
-
-      const runCleo = async (cleoArgs: string[], timeoutMs = 15000): Promise<string> => {
-        const { stdout } = await execFileAsync('cleo', cleoArgs, {
-          encoding: 'utf-8',
-          timeout: timeoutMs,
-        });
-        return stdout;
-      };
-
       const taskInterval = Number.parseInt(args['poll-interval'], 10);
-      let inFlight = false;
-      let iterations = 0;
-      const workLoop = setInterval(async () => {
-        if (inFlight) return;
-        inFlight = true;
-        iterations += 1;
-        try {
-          const currentRaw = await runCleo(['current']).catch(() => '');
-          if (currentRaw.trim()) {
-            // A task is already in progress — skip
-            return;
-          }
-
-          // Resolve next ready task (respect epic restriction when set)
-          const nextArgs = epicRestrict ? ['orchestrate', 'next', epicRestrict] : ['next'];
-          const nextRaw = await runCleo(nextArgs).catch(() => '');
-          if (!nextRaw.trim()) return;
-
-          const nextData = parseLafs<{
-            nextTask?: { id?: string; title?: string } | null;
-            id?: string;
-            title?: string;
-          }>(nextRaw);
-          const taskId =
-            nextData?.nextTask?.id ?? (typeof nextData?.id === 'string' ? nextData.id : undefined);
-
-          if (!taskId) return;
-
-          if (!executeMode) {
-            // Watch-only legacy behaviour: advertise availability
-            humanLine(
-              `[${args.agentId}] Task available: ${taskId}. Pass --execute to run autonomously.`,
-            );
-            return;
-          }
-
-          // Phase 3 Conductor Loop: actually execute via orchestrate.spawn.execute
-          const spawnArgs = ['orchestrate', 'spawn', taskId];
-          if (adapterRestrict) {
-            spawnArgs.push('--adapter', adapterRestrict);
-          }
-          const spawnRaw = await runCleo(spawnArgs, 60000).catch((e) => {
-            humanWarn(`[${args.agentId}] conductor-loop: spawn failed for ${taskId}: ${String(e)}`);
-            return '';
-          });
-          const spawnData = parseLafs<{
-            instanceId?: string;
-            taskId?: string;
-            status?: string;
-          }>(spawnRaw);
-          if (spawnData?.instanceId) {
-            humanLine(
-              `[${args.agentId}] conductor-loop spawned task=${taskId} instance=${spawnData.instanceId} status=${spawnData.status ?? 'unknown'}`,
-            );
-          }
-        } catch {
-          /* non-fatal — loop continues */
-        } finally {
-          inFlight = false;
-        }
-      }, taskInterval);
+      const loop = startWorkLoop(
+        {
+          agentId: args.agentId,
+          pollIntervalMs: taskInterval,
+          executeMode,
+          epicRestrict,
+          adapterRestrict,
+        },
+        {
+          onInfo: (msg) => humanLine(msg),
+          onWarn: (msg) => humanWarn(msg),
+        },
+      );
 
       const shutdown = () => {
-        clearInterval(workLoop);
+        loop.stop();
         runtime.stop();
         void registry.update(args.agentId, { isActive: false }).catch(() => {});
-        if (executeMode) {
-          humanLine(`[${args.agentId}] conductor-loop shutdown after ${iterations} iterations.`);
-        }
         process.exit(0);
       };
       process.on('SIGINT', shutdown);
@@ -2039,11 +1968,8 @@ const installCommand = defineCommand({
   async run({ args }) {
     let tempDir: string | null = null;
     try {
-      const { existsSync, mkdirSync, statSync, readdirSync, copyFileSync } = await import(
-        'node:fs'
-      );
-      const { join, basename, resolve, extname } = await import('node:path');
-      const { tmpdir } = await import('node:os');
+      const { existsSync } = await import('node:fs');
+      const { basename, resolve } = await import('node:path');
 
       const resolvedPath = resolve(args.path);
 
@@ -2062,119 +1988,23 @@ const installCommand = defineCommand({
         return;
       }
 
-      // Resolve the eventual `.cant` path that will be handed to the install
-      // pipeline. Three input shapes are accepted:
-      //   1. <id>.cant           — used as-is.
-      //   2. <pkg>.cantz         — extracted; persona.cant inside is renamed
-      //                            to `<agentId>.cant` in the temp tree.
-      //   3. <dir>/persona.cant  — same flow as .cantz; rename into tmp.
-      let cantPath: string;
-      const stat = statSync(resolvedPath);
-      const ext = extname(resolvedPath);
-
-      if (stat.isFile() && ext === '.cant') {
-        cantPath = resolvedPath;
-      } else if (stat.isFile() && ext === '.cantz') {
-        const { execFileSync } = await import('node:child_process');
-        tempDir = join(tmpdir(), `cleo-agent-install-${Date.now()}`);
-        mkdirSync(tempDir, { recursive: true });
-        try {
-          execFileSync('unzip', ['-o', '-q', resolvedPath, '-d', tempDir], {
-            encoding: 'utf-8',
-            timeout: 30_000,
-          });
-        } catch (unzipErr) {
-          cliOutput(
-            {
-              success: false,
-              error: {
-                code: 'E_VALIDATION',
-                message: `Failed to extract .cantz archive: ${String(unzipErr)}`,
-              },
-            },
-            { command: 'agent install' },
-          );
-          process.exitCode = 6;
-          return;
-        }
-        const topLevel = readdirSync(tempDir).filter((entry) =>
-          statSync(join(tempDir as string, entry)).isDirectory(),
-        );
-        if (topLevel.length !== 1) {
-          cliOutput(
-            {
-              success: false,
-              error: {
-                code: 'E_VALIDATION',
-                message: `Archive must contain exactly one top-level directory, found ${topLevel.length}`,
-              },
-            },
-            { command: 'agent install' },
-          );
-          process.exitCode = 6;
-          return;
-        }
-        const agentName = topLevel[0];
-        const personaPath = join(tempDir, agentName, 'persona.cant');
-        if (!existsSync(personaPath)) {
-          cliOutput(
-            {
-              success: false,
-              error: {
-                code: 'E_VALIDATION',
-                message: `Archive must contain persona.cant: ${personaPath}`,
-              },
-            },
-            { command: 'agent install' },
-          );
-          process.exitCode = 6;
-          return;
-        }
-        // The pipeline requires filename base === agent name; materialize a
-        // renamed copy into the temp dir so the check passes.
-        cantPath = join(tempDir, `${agentName}.cant`);
-        copyFileSync(personaPath, cantPath);
-      } else if (stat.isDirectory()) {
-        const agentName = basename(resolvedPath);
-        const personaPath = join(resolvedPath, 'persona.cant');
-        if (!existsSync(personaPath)) {
-          cliOutput(
-            {
-              success: false,
-              error: {
-                code: 'E_VALIDATION',
-                message: `Agent directory must contain persona.cant: ${personaPath}`,
-              },
-            },
-            { command: 'agent install' },
-          );
-          process.exitCode = 6;
-          return;
-        }
-        tempDir = join(tmpdir(), `cleo-agent-install-${Date.now()}`);
-        mkdirSync(tempDir, { recursive: true });
-        cantPath = join(tempDir, `${agentName}.cant`);
-        copyFileSync(personaPath, cantPath);
-      } else {
+      let resolved: Awaited<ReturnType<typeof resolveAgentCantPath>>;
+      try {
+        resolved = resolveAgentCantPath({ resolvedPath });
+      } catch (resolveErr) {
+        const message = resolveErr instanceof Error ? resolveErr.message : String(resolveErr);
         cliOutput(
-          {
-            success: false,
-            error: {
-              code: 'E_VALIDATION',
-              message: `Path must be a .cant, .cantz, or agent directory: ${resolvedPath}`,
-            },
-          },
+          { success: false, error: { code: 'E_VALIDATION', message } },
           { command: 'agent install' },
         );
         process.exitCode = 6;
         return;
       }
+      const { cantPath, tempDir: resolvedTempDir } = resolved;
+      tempDir = resolvedTempDir;
 
-      // Lazy-import the core facade so test mocks can intercept these symbols.
       const { installAgentFromCant, attachAgentToProject } = await import('@cleocode/core/agents');
       const { openCleoDb } = await import('@cleocode/core/store/open-cleo-db');
-
-      // Open via chokepoint — applies pragma SSoT (T9047, T9189)
       const { db: _sdDb } = await openCleoDb('signaldock');
       const db = _sdDb as import('node:sqlite').DatabaseSync;
 
@@ -2183,10 +2013,6 @@ const installCommand = defineCommand({
       const projectRoot = getProjectRoot();
 
       try {
-        // `--resync`: drop+reinstall the registry row but preserve the
-        // on-disk `.cant`. Implementation: delete the existing row BEFORE
-        // calling the pipeline, then let the pipeline handle it as a fresh
-        // insert. The file copy over itself is still atomic.
         if (args.resync) {
           const parsedName = basename(cantPath, '.cant');
           const row = db.prepare('SELECT id FROM agents WHERE agent_id = ?').get(parsedName) as
@@ -2266,14 +2092,7 @@ const installCommand = defineCommand({
       cliOutput({ success: false, error: { code, message } }, { command: 'agent install' });
       process.exitCode = 1;
     } finally {
-      if (tempDir) {
-        try {
-          const { rmSync } = await import('node:fs');
-          rmSync(tempDir, { recursive: true, force: true });
-        } catch {
-          // best-effort cleanup — don't mask the primary error
-        }
-      }
+      cleanupInstallTempDir(tempDir);
     }
   },
 });
@@ -2466,10 +2285,6 @@ const createCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { existsSync, mkdirSync, writeFileSync } = await import('node:fs');
-      const { join } = await import('node:path');
-      const { homedir } = await import('node:os');
-
       const name = args.name;
       const role = args.role;
       const tier = args.tier ?? inferTierFromRole(role);
@@ -2479,15 +2294,15 @@ const createCommand = defineCommand({
       const seedBrain = args['seed-brain'] === true;
       const parent = args.parent as string | undefined;
 
-      // Validate role
-      const validRoles = ['orchestrator', 'lead', 'worker', 'docs-worker'];
-      if (!validRoles.includes(role)) {
+      try {
+        validateRole(role);
+      } catch (e) {
         cliOutput(
           {
             success: false,
             error: {
               code: 'E_VALIDATION',
-              message: `Invalid role "${role}". Must be one of: ${validRoles.join(', ')}`,
+              message: String(e instanceof Error ? e.message : e),
               fix: `cleo agent create --name ${name} --role worker`,
             },
           },
@@ -2497,15 +2312,15 @@ const createCommand = defineCommand({
         return;
       }
 
-      // Validate tier
-      const validTiers = ['low', 'mid', 'high'];
-      if (!validTiers.includes(tier)) {
+      try {
+        validateTier(tier);
+      } catch (e) {
         cliOutput(
           {
             success: false,
             error: {
               code: 'E_VALIDATION',
-              message: `Invalid tier "${tier}". Must be one of: ${validTiers.join(', ')}`,
+              message: String(e instanceof Error ? e.message : e),
               fix: `cleo agent create --name ${name} --role ${role} --tier mid`,
             },
           },
@@ -2515,14 +2330,15 @@ const createCommand = defineCommand({
         return;
       }
 
-      // Validate name is kebab-case
-      if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(name)) {
+      try {
+        validateName(name);
+      } catch (e) {
         cliOutput(
           {
             success: false,
             error: {
               code: 'E_VALIDATION',
-              message: `Agent name must be kebab-case: "${name}"`,
+              message: String(e instanceof Error ? e.message : e),
               fix: 'Use lowercase letters, numbers, and hyphens. Must start with a letter.',
             },
           },
@@ -2532,26 +2348,28 @@ const createCommand = defineCommand({
         return;
       }
 
-      // Determine target directory
-      let targetRoot: string;
-      if (isGlobal) {
-        const home = homedir();
-        const xdgData = process.env['XDG_DATA_HOME'] ?? join(home, '.local', 'share');
-        targetRoot = join(xdgData, 'cleo', 'cant', 'agents');
-      } else {
-        targetRoot = join(getProjectRoot(), CLEO_DIR_NAME, CANT_AGENTS_SUBDIR);
-      }
-
-      const agentDir = join(targetRoot, name);
-
-      // Check if agent directory already exists
-      if (existsSync(agentDir)) {
+      let scaffoldResult: Awaited<ReturnType<typeof scaffoldAgent>>;
+      try {
+        scaffoldResult = scaffoldAgent({
+          name,
+          role,
+          tier,
+          team,
+          domain,
+          parent,
+          global: isGlobal,
+          seedBrain,
+          projectRoot: isGlobal ? undefined : getProjectRoot(),
+          cleoDirName: CLEO_DIR_NAME,
+          cantAgentsSubdir: CANT_AGENTS_SUBDIR,
+        });
+      } catch (e) {
         cliOutput(
           {
             success: false,
             error: {
               code: 'E_VALIDATION',
-              message: `Agent directory already exists: ${agentDir}`,
+              message: String(e instanceof Error ? e.message : e),
               fix: 'Remove the existing directory or choose a different name.',
             },
           },
@@ -2561,50 +2379,8 @@ const createCommand = defineCommand({
         return;
       }
 
-      // Create directory structure
-      mkdirSync(agentDir, { recursive: true });
-
-      // Generate persona.cant from role template
-      const personaContent = generatePersonaCant({
-        name,
-        role,
-        tier,
-        team,
-        domain,
-        parent,
-      });
-      writeFileSync(join(agentDir, 'persona.cant'), personaContent, 'utf-8');
-
-      // Generate manifest.json
-      const manifest = generateManifest({ name, role, tier, domain });
-      writeFileSync(
-        join(agentDir, 'manifest.json'),
-        `${JSON.stringify(manifest, null, 2)}\n`,
-        'utf-8',
-      );
-
-      // Track created files for summary
-      const createdFiles: string[] = [
-        join(agentDir, 'persona.cant'),
-        join(agentDir, 'manifest.json'),
-      ];
-
-      // Generate team config if team specified
-      if (team) {
-        const teamConfigContent = generateTeamConfig(name, role, team);
-        writeFileSync(join(agentDir, 'team-config.cant'), teamConfigContent, 'utf-8');
-        createdFiles.push(join(agentDir, 'team-config.cant'));
-      }
-
-      // Seed brain expertise if requested
+      // Best-effort BRAIN observation via CLI when --seed-brain
       if (seedBrain) {
-        const expertiseDir = join(agentDir, 'expertise');
-        mkdirSync(expertiseDir, { recursive: true });
-        const seedContent = generateMentalModelSeed(name, role, domain);
-        writeFileSync(join(expertiseDir, 'mental-model-seed.md'), seedContent, 'utf-8');
-        createdFiles.push(join(expertiseDir, 'mental-model-seed.md'));
-
-        // Best-effort BRAIN observation via CLI
         try {
           const { execFile } = await import('node:child_process');
           const { promisify } = await import('node:util');
@@ -2636,12 +2412,9 @@ const createCommand = defineCommand({
         const existing = await registry.get(name);
 
         if (!existing) {
-          const descMatch = personaContent.match(/description:\s*"([^"]+)"/);
-          const displayName = descMatch?.[1] ?? name;
-
           await registry.register({
             agentId: name,
-            displayName,
+            displayName: name,
             apiKey: 'local-created',
             apiBaseUrl: 'local',
             classification: role,
@@ -2662,14 +2435,8 @@ const createCommand = defineCommand({
         {
           success: true,
           data: {
-            agent: name,
-            role,
-            tier,
-            directory: agentDir,
-            scope: isGlobal ? 'global' : 'project',
-            files: createdFiles,
+            ...scaffoldResult,
             registered,
-            brainSeeded: seedBrain,
           },
         },
         { command: 'agent create' },
@@ -3014,523 +2781,4 @@ export const agentCommand = defineCommand({
   },
 });
 
-// ---------------------------------------------------------------------------
-// Agent create template helpers
-// ---------------------------------------------------------------------------
-
-/** Agent role type for template generation. */
-type AgentRole = 'orchestrator' | 'lead' | 'worker' | 'docs-worker';
-
-/** Parameters for persona.cant generation. */
-interface PersonaParams {
-  name: string;
-  role: string;
-  tier: string;
-  team?: string;
-  domain?: string;
-  parent?: string;
-}
-
-/** Parameters for manifest.json generation. */
-interface ManifestParams {
-  name: string;
-  role: string;
-  tier: string;
-  domain?: string;
-}
-
-/**
- * Infer the default tier from the agent role.
- *
- * - orchestrator -> high
- * - lead -> mid
- * - worker -> mid
- * - docs-worker -> mid
- *
- * @param role - The agent role string.
- * @returns The inferred tier string.
- */
-function inferTierFromRole(role: string): string {
-  if (role === 'orchestrator') return 'high';
-  return 'mid';
-}
-
-/**
- * Generate a `persona.cant` file from role-based templates.
- *
- * Templates are derived from the canonical starter-bundle agents at
- * `packages/cleo-os/starter-bundle/agents/`. Each role maps to a
- * specific set of tools, permissions, context sources, and behavioral
- * hooks.
- *
- * @param params - Agent persona parameters.
- * @returns The complete persona.cant file content.
- *
- * @see packages/agents/templates/project-orchestrator.cant
- * @see packages/agents/templates/project-dev-lead.cant
- * @see packages/agents/templates/project-code-worker.cant
- * @see packages/agents/templates/project-docs-worker.cant
- */
-function generatePersonaCant(params: PersonaParams): string {
-  const { name, role, tier, team, domain, parent } = params;
-
-  switch (role as AgentRole) {
-    case 'orchestrator':
-      return generateOrchestratorPersona(name, tier, team, parent);
-    case 'lead':
-      return generateLeadPersona(name, tier, team, domain, parent);
-    case 'worker':
-      return generateWorkerPersona(name, tier, team, domain, parent);
-    case 'docs-worker':
-      return generateDocsWorkerPersona(name, tier, team, domain, parent);
-    default:
-      return generateWorkerPersona(name, tier, team, domain, parent);
-  }
-}
-
-/**
- * Generate an orchestrator persona.cant.
- *
- * Orchestrators coordinate work but do not execute code. They hold
- * read-only core tools (Read, Grep, Glob) plus dispatch tools for
- * routing work to leads and workers.
- *
- * @param name - Agent name (kebab-case).
- * @param tier - Agent tier.
- * @param team - Optional team name.
- * @param parent - Optional parent agent.
- * @returns The persona.cant content string.
- */
-function generateOrchestratorPersona(
-  name: string,
-  tier: string,
-  team?: string,
-  parent?: string,
-): string {
-  const parentLine = parent ? `\n  parent: ${parent}` : '';
-  const teamComment = team ? `\n# Team: ${team}` : '';
-
-  return `---
-kind: agent
-version: "1"
----
-
-# ${name} — orchestrator agent.${teamComment}
-# Coordinates the team, classifies work, dispatches to leads/workers.
-
-agent ${name}:
-  role: orchestrator${parentLine}
-  tier: ${tier}
-  description: "Orchestrator agent. Reads task context, classifies work, dispatches to leads, and synthesizes results. Does not execute code — coordinates."
-  consult-when: "Cross-team decisions, scope changes, human-in-the-loop escalation, or when a lead reports a blocking ambiguity"
-
-  context_sources:
-    - source: decisions
-      query: "recent architectural and project decisions"
-      max_entries: 5
-    - source: patterns
-      query: "project conventions and established patterns"
-      max_entries: 3
-  on_overflow: escalate_tier
-
-  mental_model:
-    scope: project
-    max_tokens: 2000
-    on_load:
-      validate: true
-
-  permissions:
-    tasks: read, write
-    session: read, write
-    memory: read, write
-
-  skills:
-    - ct-cleo
-    - ct-task-executor
-
-  tools:
-    core: [Read, Grep, Glob]
-    dispatch: [dispatch_worker, report_to_user]
-
-  on SessionStart:
-    session "Read active tasks and recent decisions to build situational awareness"
-      context: [active-tasks, memory-bridge, recent-decisions]
-
-  on TaskCompleted:
-    if **the completed task unblocks downstream work**:
-      session "Reassess task queue and dispatch next work"
-`;
-}
-
-/**
- * Generate a lead persona.cant.
- *
- * Leads decide HOW to build and dispatch work to workers. They hold
- * read-only tools per TEAM-002 / ULTRAPLAN 10.3 — no Edit, Write, or
- * Bash access.
- *
- * @param name - Agent name (kebab-case).
- * @param tier - Agent tier.
- * @param team - Optional team name.
- * @param domain - Optional domain description.
- * @param parent - Optional parent agent.
- * @returns The persona.cant content string.
- */
-function generateLeadPersona(
-  name: string,
-  tier: string,
-  team?: string,
-  domain?: string,
-  parent?: string,
-): string {
-  const parentLine = parent ? `\n  parent: ${parent}` : '\n  parent: project-orchestrator';
-  const teamComment = team ? `\n# Team: ${team}` : '';
-  const domainDesc = domain ? ` Specializes in ${domain}.` : '';
-
-  return `---
-kind: agent
-version: "1"
----
-
-# ${name} — lead agent.${teamComment}
-# Decomposes tasks, reviews worker output, decides technical approach.
-# MUST NOT hold Edit/Write/Bash tools (TEAM-002 / ULTRAPLAN 10.3).
-
-agent ${name}:
-  role: lead${parentLine}
-  tier: ${tier}
-  description: "Development lead.${domainDesc} Decomposes tasks into concrete implementation steps, reviews worker output, and decides technical approach. Does not write code directly."
-  consult-when: "Implementation strategy, code architecture, refactoring direction, task decomposition, or when workers need clarification"
-
-  context_sources:
-    - source: patterns
-      query: "codebase conventions and architecture patterns"
-      max_entries: 5
-    - source: decisions
-      query: "technical decisions affecting implementation"
-      max_entries: 3
-  on_overflow: escalate_tier
-
-  mental_model:
-    scope: project
-    max_tokens: 1000
-    on_load:
-      validate: true
-
-  permissions:
-    files:
-      read: ["**/*"]
-
-  skills:
-    - ct-cleo
-    - ct-dev-workflow
-    - ct-task-executor
-
-  tools:
-    core: [Read, Grep, Glob]
-    dispatch: [dispatch_worker, report_to_orchestrator]
-
-  on SessionStart:
-    session "Review current task assignments and worker availability"
-      context: [active-tasks, memory-bridge]
-
-  on TaskCompleted:
-    if **the completed task introduced new code**:
-      session "Review worker output for quality and completeness before reporting to orchestrator"
-`;
-}
-
-/**
- * Generate a worker persona.cant.
- *
- * Workers execute code changes within declared file globs. They hold
- * the full tool set (Read, Edit, Write, Bash, Glob, Grep) and operate
- * within file permission boundaries derived from the `--domain` flag.
- *
- * @param name - Agent name (kebab-case).
- * @param tier - Agent tier.
- * @param team - Optional team name.
- * @param domain - Optional domain description for file permissions.
- * @param parent - Optional parent agent.
- * @returns The persona.cant content string.
- */
-function generateWorkerPersona(
-  name: string,
-  tier: string,
-  team?: string,
-  domain?: string,
-  parent?: string,
-): string {
-  const parentLine = parent ? `\n  parent: ${parent}` : '\n  parent: dev-lead';
-  const teamComment = team ? `\n# Team: ${team}` : '';
-  const domainDesc = domain ? ` Specializes in ${domain}.` : '';
-  const writeGlobs = deriveWriteGlobs(domain);
-
-  return `---
-kind: agent
-version: "1"
----
-
-# ${name} — worker agent.${teamComment}
-# Executes code changes within declared file globs.
-
-agent ${name}:
-  role: worker${parentLine}
-  tier: ${tier}
-  description: "Code worker.${domainDesc} Reads requirements, writes code, runs tests, and validates changes. Operates within declared file permission globs."
-  consult-when: "Writing code, fixing bugs, running tests, formatting, or any file modification task"
-
-  context_sources:
-    - source: patterns
-      query: "coding conventions and testing patterns"
-      max_entries: 5
-    - source: learnings
-      query: "past implementation mistakes and fixes"
-      max_entries: 3
-  on_overflow: escalate_tier
-
-  mental_model:
-    scope: project
-    max_tokens: 1000
-    on_load:
-      validate: true
-
-  permissions:
-    files:
-      write: ${JSON.stringify(writeGlobs)}
-      read: ["**/*"]
-      delete: ${JSON.stringify(writeGlobs)}
-
-  skills:
-    - ct-cleo
-    - ct-dev-workflow
-    - ct-task-executor
-
-  tools:
-    core: [Read, Edit, Write, Bash, Glob, Grep]
-
-  on SessionStart:
-    session "Check assigned task and read relevant source files before starting work"
-      context: [active-tasks, memory-bridge]
-
-  on PostToolUse:
-    if tool.name == "Write" or tool.name == "Edit":
-      session "Verify the change compiles and passes lint before proceeding"
-`;
-}
-
-/**
- * Generate a docs-worker persona.cant.
- *
- * Documentation workers write and maintain documentation within declared
- * documentation file globs. They carry documentation-specific skills and
- * context sources.
- *
- * @param name - Agent name (kebab-case).
- * @param tier - Agent tier.
- * @param team - Optional team name.
- * @param domain - Optional domain description.
- * @param parent - Optional parent agent.
- * @returns The persona.cant content string.
- */
-function generateDocsWorkerPersona(
-  name: string,
-  tier: string,
-  team?: string,
-  domain?: string,
-  parent?: string,
-): string {
-  const parentLine = parent ? `\n  parent: ${parent}` : '\n  parent: dev-lead';
-  const teamComment = team ? `\n# Team: ${team}` : '';
-  const domainDesc = domain ? ` Specializes in ${domain} documentation.` : '';
-
-  return `---
-kind: agent
-version: "1"
----
-
-# ${name} — documentation worker agent.${teamComment}
-# Writes and maintains documentation within declared globs.
-
-agent ${name}:
-  role: worker${parentLine}
-  tier: ${tier}
-  description: "Documentation worker.${domainDesc} Writes READMEs, updates guides, adds TSDoc comments, and maintains project documentation. Operates within declared documentation file globs."
-  consult-when: "Writing documentation, updating READMEs, adding TSDoc comments, or improving existing docs"
-
-  context_sources:
-    - source: patterns
-      query: "documentation conventions and style patterns"
-      max_entries: 3
-    - source: decisions
-      query: "architectural decisions needing documentation"
-      max_entries: 3
-  on_overflow: escalate_tier
-
-  mental_model:
-    scope: project
-    max_tokens: 1000
-    on_load:
-      validate: true
-
-  permissions:
-    files:
-      write: ["docs/**", "**/*.md", "**/*.mdx"]
-      read: ["**/*"]
-      delete: ["docs/**"]
-
-  skills:
-    - ct-cleo
-    - ct-documentor
-    - ct-docs-write
-
-  tools:
-    core: [Read, Edit, Write, Bash, Glob, Grep]
-
-  on SessionStart:
-    session "Check assigned documentation task and review existing docs for context"
-      context: [active-tasks, memory-bridge]
-
-  on PostToolUse:
-    if tool.name == "Write" or tool.name == "Edit":
-      session "Verify markdown renders correctly and follows project style conventions"
-`;
-}
-
-/**
- * Derive file write globs from a domain description string.
- *
- * Maps common domain keywords to appropriate file glob patterns.
- * Falls back to the default `["src/**", "packages/**"]` when no
- * domain is specified or no keywords match.
- *
- * @param domain - Optional domain description string.
- * @returns Array of glob pattern strings for file write permissions.
- */
-function deriveWriteGlobs(domain?: string): string[] {
-  const defaults = ['src/**', 'packages/**', 'lib/**', 'test/**', 'tests/**'];
-  if (!domain) return defaults;
-
-  const lower = domain.toLowerCase();
-
-  // Domain-specific glob mappings
-  if (lower.includes('frontend') || lower.includes('ui') || lower.includes('component')) {
-    return ['src/**', 'packages/**', 'components/**', 'styles/**', 'public/**', 'test/**'];
-  }
-  if (lower.includes('backend') || lower.includes('api') || lower.includes('server')) {
-    return ['src/**', 'packages/**', 'lib/**', 'api/**', 'test/**', 'tests/**'];
-  }
-  if (lower.includes('infra') || lower.includes('deploy') || lower.includes('ci')) {
-    return ['.github/**', 'infra/**', 'deploy/**', 'scripts/**', 'Dockerfile*'];
-  }
-  if (lower.includes('test') || lower.includes('qa') || lower.includes('quality')) {
-    return ['test/**', 'tests/**', 'src/**/*.test.*', 'src/**/*.spec.*', 'packages/**/*.test.*'];
-  }
-  if (lower.includes('rust') || lower.includes('crate')) {
-    return ['crates/**', 'src/**', 'Cargo.toml', 'test/**'];
-  }
-  if (lower.includes('doc')) {
-    return ['docs/**', '**/*.md', '**/*.mdx'];
-  }
-
-  return defaults;
-}
-
-/**
- * Generate a `manifest.json` object for the agent package.
- *
- * Conforms to the CANTZ-PACKAGE-STANDARD.md Section 2.3 schema.
- *
- * @param params - Manifest generation parameters.
- * @returns A plain object ready for JSON serialization.
- */
-function generateManifest(params: ManifestParams): Record<string, unknown> {
-  return {
-    name: params.name,
-    version: '1.0.0',
-    description: `${capitalizeFirst(params.role)} agent${params.domain ? ` for ${params.domain}` : ''}`,
-    cant: {
-      minVersion: '1',
-      tier: params.tier,
-      role: params.role === 'docs-worker' ? 'worker' : params.role,
-    },
-    createdAt: new Date().toISOString(),
-  };
-}
-
-/**
- * Generate a team configuration CANT file fragment.
- *
- * Creates a minimal team-config.cant that declares the agent's
- * membership in a named team.
- *
- * @param name - Agent name.
- * @param role - Agent role.
- * @param team - Team name.
- * @returns The team-config.cant content string.
- */
-function generateTeamConfig(name: string, role: string, team: string): string {
-  return `---
-kind: team-config
-version: "1"
----
-
-# Team membership for ${name}
-
-team ${team}:
-  member ${name}:
-    role: ${role}
-    status: active
-`;
-}
-
-/**
- * Generate a mental model seed markdown file.
- *
- * Creates an initial expertise document with placeholder sections
- * for the agent to populate as it learns about the project domain.
- *
- * @param name - Agent name.
- * @param role - Agent role.
- * @param domain - Optional domain description.
- * @returns The mental-model-seed.md content string.
- */
-function generateMentalModelSeed(name: string, role: string, domain?: string): string {
-  const domainSection = domain
-    ? `## Domain\n\n${domain}\n`
-    : `## Domain\n\nTODO: Describe the domain this agent specializes in.\n`;
-
-  return `# Mental Model Seed: ${name}
-
-> Auto-generated at ${new Date().toISOString()}
-> Role: ${role}
-
-${domainSection}
-## Key Patterns
-
-TODO: Document recurring patterns this agent should recognize.
-
-## Known Pitfalls
-
-TODO: Document common mistakes or anti-patterns in this domain.
-
-## Decision History
-
-TODO: Track important decisions and their rationale.
-
-## Learning Log
-
-TODO: Record discoveries and insights as the agent operates.
-`;
-}
-
-/**
- * Capitalize the first letter of a string.
- *
- * @param str - Input string.
- * @returns String with the first character uppercased.
- */
-function capitalizeFirst(str: string): string {
-  if (str.length === 0) return str;
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}
+// Template helpers have moved to packages/core/src/agents/scaffold.ts (T10062 T9833c)

--- a/packages/cleo/src/cli/commands/memory.ts
+++ b/packages/cleo/src/cli/commands/memory.ts
@@ -40,10 +40,6 @@
  * @epic T4763 T627
  */
 
-import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
 import { getProjectRoot } from '@cleocode/core';
 import {
   getBrainDb,
@@ -54,90 +50,14 @@ import {
   setEntryTier,
   triggerManualDream,
 } from '@cleocode/core/memory';
+import { importMemoryFiles } from '@cleocode/core/memory/import-from-provider.js';
+import { streamMemoryWatchEvents } from '@cleocode/core/memory/watch-stream.js';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli, dispatchRaw, handleRawError } from '../../dispatch/adapters/cli.js';
 import { CLEO_DIR_NAME, MIGRATE_MEMORY_HASHES_JSON } from '../paths.js';
 import { cliError, cliOutput } from '../renderers/index.js';
 
-// ---------------------------------------------------------------------------
-// Memory import helpers (T629 — provider-agnostic migration)
-// ---------------------------------------------------------------------------
-
-/**
- * Parse YAML frontmatter from a markdown string.
- * Supports simple `key: value` pairs only (no nested YAML).
- *
- * @param raw - Raw file content
- * @returns Extracted frontmatter fields and body text
- */
-function parseMemoryFileFrontmatter(raw: string): {
-  name?: string;
-  description?: string;
-  type?: string;
-  body: string;
-} {
-  const lines = raw.split('\n');
-  if (!lines[0]?.trim().startsWith('---')) {
-    return { body: raw.trim() };
-  }
-
-  const endIdx = lines.slice(1).findIndex((l) => /^---\s*$/.test(l));
-  if (endIdx === -1) {
-    return { body: raw.trim() };
-  }
-
-  const fmLines = lines.slice(1, endIdx + 1);
-  const body = lines
-    .slice(endIdx + 2)
-    .join('\n')
-    .trim();
-
-  const fm: Record<string, string> = {};
-  for (const line of fmLines) {
-    const colonIdx = line.indexOf(':');
-    if (colonIdx === -1) continue;
-    const key = line.slice(0, colonIdx).trim();
-    const value = line.slice(colonIdx + 1).trim();
-    if (key && value) fm[key] = value;
-  }
-
-  return {
-    name: fm['name'],
-    description: fm['description'],
-    type: fm['type'],
-    body,
-  };
-}
-
-/**
- * Compute a 16-char hex content fingerprint for dedup.
- *
- * @param title - Entry title
- * @param body - Entry body text
- * @returns 16-char hex prefix of SHA-256 hash
- */
-function memoryContentHash(title: string, body: string): string {
-  return createHash('sha256').update(`${title}\n${body}`).digest('hex').slice(0, 16);
-}
-
-/** Load set of already-imported content hashes from the dedup state file. */
-function loadImportHashes(stateFile: string): Set<string> {
-  try {
-    if (!existsSync(stateFile)) return new Set();
-    const raw = readFileSync(stateFile, 'utf-8');
-    const parsed = JSON.parse(raw) as { hashes: string[] };
-    return new Set(parsed.hashes);
-  } catch {
-    return new Set();
-  }
-}
-
-/** Persist updated set of imported hashes to the dedup state file. */
-function saveImportHashes(stateFile: string, hashes: Set<string>): void {
-  const dir = stateFile.slice(0, stateFile.lastIndexOf('/'));
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(stateFile, JSON.stringify({ hashes: [...hashes] }, null, 2), 'utf-8');
-}
+// Memory import helpers moved to packages/core/src/memory/import-from-provider.ts (T10062 T9833c)
 
 // ---------------------------------------------------------------------------
 // Subcommands
@@ -1283,128 +1203,40 @@ const importCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const sourceDir =
-      args.from ?? join(homedir(), '.claude', 'projects', '-mnt-projects-cleocode', 'memory');
+    const sourceDir = args.from as string | undefined;
     const isDryRun = !!args['dry-run'];
     const projectRoot = getProjectRoot();
-    const stateFile = join(projectRoot, CLEO_DIR_NAME, MIGRATE_MEMORY_HASHES_JSON);
 
-    if (!existsSync(sourceDir)) {
-      cliError(`Source directory not found: ${sourceDir}`, 'E_NOT_FOUND', { name: 'E_NOT_FOUND' });
-      process.exit(1);
-      return;
-    }
-
-    const files = readdirSync(sourceDir)
-      .filter((f) => f.endsWith('.md') && f !== 'MEMORY.md')
-      .map((f) => join(sourceDir, f));
-
-    const importedHashes = isDryRun ? new Set<string>() : loadImportHashes(stateFile);
-    const stats = { total: files.length, imported: 0, skipped: 0, errors: 0 };
-    const importedEntries: Array<{ file: string; type: string; title: string }> = [];
-    const skippedEntries: Array<{ file: string; reason: string }> = [];
-    const errorEntries: Array<{ file: string; error: string }> = [];
-
-    for (const filePath of files) {
-      const fileName = filePath.split('/').pop() ?? filePath;
-      try {
-        const raw = readFileSync(filePath, 'utf-8');
-        if (!raw.trim()) {
-          stats.skipped++;
-          skippedEntries.push({ file: fileName, reason: 'empty file' });
-          continue;
-        }
-
-        const { name, description, type, body } = parseMemoryFileFrontmatter(raw);
-        const title = name ?? fileName.replace(/\.md$/, '').replace(/-/g, ' ');
-        const bodyParts = [description, body].filter(Boolean);
-        const fullText = bodyParts.join('\n\n').trim();
-
-        if (!fullText) {
-          stats.skipped++;
-          skippedEntries.push({ file: fileName, reason: 'empty body' });
-          continue;
-        }
-
-        const hash = memoryContentHash(title, fullText);
-
-        if (!isDryRun && importedHashes.has(hash)) {
-          stats.skipped++;
-          skippedEntries.push({ file: fileName, reason: `already imported (hash: ${hash})` });
-          continue;
-        }
-
-        const entryType = type ?? 'project';
-
-        if (!isDryRun) {
-          // Route by frontmatter type
-          if (entryType === 'feedback') {
-            // Feedback → learning
-            await dispatchFromCli(
-              'mutate',
-              'memory',
-              'learning.store',
-              {
-                insight: `[MIGRATED] ${title}: ${fullText}`,
-                source: 'manual',
-                confidence: 0.8,
-                actionable: false,
-              },
-              { command: 'memory', operation: 'memory.learning.store' },
-            );
-          } else {
-            // project | reference | user | default → observation
-            const observeType =
-              entryType === 'project'
-                ? 'feature'
-                : entryType === 'reference'
-                  ? 'discovery'
-                  : entryType === 'user'
-                    ? 'change'
-                    : 'discovery';
-
-            await dispatchFromCli(
-              'mutate',
-              'memory',
-              'observe',
-              {
-                text: `[MIGRATED] ${title}: ${fullText}`,
-                title: `[MIGRATED] ${title}`,
-                type: observeType,
-                sourceType: 'manual',
-              },
-              { command: 'memory', operation: 'memory.observe' },
-            );
-          }
-
-          importedHashes.add(hash);
-        }
-
-        stats.imported++;
-        importedEntries.push({ file: fileName, type: entryType, title });
-      } catch (err) {
-        stats.errors++;
-        const message = err instanceof Error ? err.message : String(err);
-        errorEntries.push({ file: fileName, error: message });
-      }
-    }
-
-    if (!isDryRun) {
-      saveImportHashes(stateFile, importedHashes);
-    }
-
-    cliOutput(
-      {
-        ...stats,
+    try {
+      const result = await importMemoryFiles({
+        sourceDir,
         dryRun: isDryRun,
-        imported: importedEntries,
-        skipped: skippedEntries,
-        errors: errorEntries,
-      },
-      { command: 'memory-import', operation: 'memory.import' },
-    );
+        projectRoot,
+        cleoDirName: CLEO_DIR_NAME,
+        hasheFileName: MIGRATE_MEMORY_HASHES_JSON,
+        dispatch: dispatchFromCli,
+      });
 
-    if (stats.errors > 0) process.exit(1);
+      cliOutput(
+        {
+          total: result.total,
+          imported: result.imported,
+          skipped: result.skipped,
+          errors: result.errors,
+          dryRun: isDryRun,
+          importedEntries: result.importedEntries,
+          skippedEntries: result.skippedEntries,
+          errorEntries: result.errorEntries,
+        },
+        { command: 'memory-import', operation: 'memory.import' },
+      );
+
+      if (result.errors > 0) process.exit(1);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(message, 'E_NOT_FOUND', { name: 'E_NOT_FOUND' });
+      process.exit(1);
+    }
   },
 });
 
@@ -2170,60 +2002,36 @@ const watchCommand = defineCommand({
       return;
     }
 
-    // Follow mode: SSE-style stdout stream. Emit a `ping` event, then poll
-    // `memory.watch` every interval, emitting each event as
-    // `event: observation\ndata: <json>\n\n`. Graceful shutdown on SIGINT.
-    const intervalMs = args.interval !== undefined ? parseInt(args.interval as string, 10) : 1000;
-    let cursor = args.cursor as string | undefined;
-    let running = true;
+    // Follow mode: SSE-style stdout stream via AsyncIterable from core.
+    const abortController = new AbortController();
 
-    const onSignal = (): void => {
-      running = false;
-    };
+    const onSignal = (): void => abortController.abort();
     process.once('SIGINT', onSignal);
     process.once('SIGTERM', onSignal);
 
-    // Initial ping so downstream EventSource-like clients see the stream open.
-    process.stdout.write(
-      `event: ping\ndata: ${JSON.stringify({ ts: new Date().toISOString() })}\n\n`,
-    );
+    const stream = streamMemoryWatchEvents({
+      cursor: args.cursor as string | undefined,
+      limit: args.limit !== undefined ? parseInt(args.limit as string, 10) : undefined,
+      intervalMs: args.interval !== undefined ? parseInt(args.interval as string, 10) : 1000,
+      dispatchRaw,
+      signal: abortController.signal,
+    });
 
-    while (running) {
-      const response = await dispatchRaw('query', 'memory', 'watch', buildParams(cursor));
-      if (!response.success) {
-        handleRawError(response, { command: 'memory-watch', operation: 'memory.watch' });
-        return; // handleRawError calls process.exit on failure
+    for await (const item of stream) {
+      if (item.kind === 'ping') {
+        process.stdout.write(`event: ping\ndata: ${JSON.stringify({ ts: item.ts })}\n\n`);
+      } else if (item.kind === 'events') {
+        for (const event of item.events) {
+          process.stdout.write(`event: observation\ndata: ${JSON.stringify(event)}\n\n`);
+        }
+      } else if (item.kind === 'error') {
+        cliError(item.message, 1, { name: item.code }, { operation: 'memory.watch' });
+        process.exit(1);
+        return;
+      } else if (item.kind === 'close') {
+        process.stdout.write(`event: close\ndata: ${JSON.stringify({ ts: item.ts })}\n\n`);
       }
-
-      const data = response.data as {
-        events?: Array<{ created_at?: string } & Record<string, unknown>>;
-        nextCursor?: string | null;
-      };
-
-      const events = data.events ?? [];
-      for (const event of events) {
-        process.stdout.write(`event: observation\ndata: ${JSON.stringify(event)}\n\n`);
-      }
-
-      if (typeof data.nextCursor === 'string') {
-        cursor = data.nextCursor;
-      }
-
-      if (!running) break;
-
-      // Fixed-interval sleep between polls. Resolves early on SIGINT because
-      // `running` is re-checked on the next loop pass.
-      await new Promise<void>((resolve) => {
-        const timer = setTimeout(resolve, intervalMs);
-        // Allow the process to exit cleanly even if the timer is outstanding.
-        timer.unref?.();
-      });
     }
-
-    // Graceful stream close marker.
-    process.stdout.write(
-      `event: close\ndata: ${JSON.stringify({ ts: new Date().toISOString() })}\n\n`,
-    );
   },
 });
 

--- a/packages/cleo/src/cli/commands/nexus.ts
+++ b/packages/cleo/src/cli/commands/nexus.ts
@@ -18,7 +18,10 @@ import { appendFile, mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { getProjectRoot } from '@cleocode/core';
-import { generateGexf, getSymbolImpact } from '@cleocode/core/nexus';
+import { getSymbolImpact } from '@cleocode/core/nexus';
+import { runNexusAnalysis } from '@cleocode/core/nexus/analyze-orchestrator.js';
+import { exportNexusGraph } from '@cleocode/core/nexus/export.js';
+import { runNexusWiki } from '@cleocode/core/nexus/wiki-orchestrator.js';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli, dispatchRaw } from '../../dispatch/adapters/cli.js';
 import { buildNexusMetaExtensions } from '../../dispatch/nexus-decorator.js';
@@ -980,128 +983,44 @@ const analyzeCommand = defineCommand({
     const projectIdOverride = args['project-id'] as string | undefined;
     const isIncremental = !!args.incremental;
     const ctx = getFormatContext();
-
-    // Resolve target path
     const repoPath = args.path ? path.resolve(args.path as string) : getProjectRoot();
 
     humanInfo(`[nexus] Analyzing: ${repoPath}${isIncremental ? ' (incremental)' : ''}`);
+    if (!isIncremental) humanInfo('[nexus] Clearing existing index for project...');
 
     try {
-      // SSoT-EXEMPT:pipeline-progress — runPipeline requires a progress callback
-      // (CLI-only rendering concern) and direct DB handle access. No dispatch op
-      // can expose this without introducing CLI rendering concerns into the dispatch
-      // layer. The full analyze pipeline is fundamentally CLI-side-orchestrated.
-      // Lazy imports to avoid loading heavy dependencies until needed
-      const [{ getNexusDb, nexusSchema }, { runPipeline }, { eq }] = await Promise.all([
-        import('@cleocode/core/store/nexus-sqlite' as string),
-        import('@cleocode/nexus/pipeline' as string),
-        import('drizzle-orm' as string),
-      ]);
-
-      // Determine project ID — use override or derive from path
-      const projectId =
-        projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
-
-      // Get DB and table references
-      const db = await getNexusDb();
-      const tables = {
-        nexusNodes: nexusSchema.nexusNodes,
-        nexusRelations: nexusSchema.nexusRelations,
-      };
-
-      // For full (non-incremental) runs: delete existing index first.
-      // NodeSQLiteDatabase uses sync Drizzle — no await, wrap in try-catch.
-      if (!isIncremental) {
-        humanInfo('[nexus] Clearing existing index for project...');
-        try {
-          db.delete(nexusSchema.nexusNodes)
-            .where(eq(nexusSchema.nexusNodes.projectId, projectId))
-            .run();
-        } catch {
-          // Table may not have rows — ignore
-        }
-        try {
-          db.delete(nexusSchema.nexusRelations)
-            .where(eq(nexusSchema.nexusRelations.projectId, projectId))
-            .run();
-        } catch {
-          // Table may not have rows — ignore
-        }
-      }
-
-      // Run the pipeline (full or incremental)
-      const result = await runPipeline(
+      const result = await runNexusAnalysis({
         repoPath,
-        projectId,
-        db,
-        tables,
-        ctx.format === 'json'
-          ? undefined
-          : (current: number, total: number, filePath: string) => {
-              if (current % 50 === 0 || current === total) {
-                const pct = total > 0 ? Math.round((current / total) * 100) : 100;
-                humanInfo(`[nexus] Progress: ${current}/${total} files (${pct}%) — ${filePath}`);
-              }
-            },
-        { incremental: isIncremental },
-      );
+        projectIdOverride,
+        incremental: isIncremental,
+        onProgress:
+          ctx.format === 'json'
+            ? undefined
+            : (current, total, filePath) => {
+                if (current % 50 === 0 || current === total) {
+                  const pct = total > 0 ? Math.round((current / total) * 100) : 100;
+                  humanInfo(`[nexus] Progress: ${current}/${total} files (${pct}%) — ${filePath}`);
+                }
+              },
+      });
 
-      const durationMs = Date.now() - startTime;
-
-      // Write nexus-bridge.md after a successful pipeline run (best-effort)
-      try {
-        const { refreshNexusBridge } = await import('@cleocode/core/internal' as string);
-        await refreshNexusBridge(repoPath, projectId);
-        humanInfo(`[nexus] nexus-bridge.md refreshed at ${repoPath}/.cleo/nexus-bridge.md`);
-      } catch {
-        // Non-fatal — bridge refresh failure should not fail the analyze command
-      }
-
-      // Auto-register project and update index stats in the multi-project registry (best-effort)
-      try {
-        const { nexusUpdateIndexStats } = await import('@cleocode/core/internal' as string);
-        await nexusUpdateIndexStats(repoPath, {
-          nodeCount: result.nodeCount,
-          relationCount: result.relationCount,
-          fileCount: result.fileCount,
-        });
-        humanInfo('[nexus] Project registered/updated in multi-project registry.');
-      } catch {
-        // Non-fatal — registry update must never fail the analyze command
-      }
-
-      // Post-hook: sweep git log and link task IDs to symbols (best-effort, idempotent)
-      try {
-        const { runGitLogTaskLinker } = await import('@cleocode/core/nexus' as string);
-        const sweeperResult = await runGitLogTaskLinker(repoPath);
-        // Diagnostic stderr message — emit unconditionally regardless of
-        // ctx.format. Stderr does NOT pollute --json stdout (separate stream)
-        // and sandbox/CI assertions parse the combined stdout+stderr stream.
-        // Removing this conditional preserves pre-W4 behavior the
-        // living-brain-e2e scenario depends on.
-        if (sweeperResult.commitsProcessed > 0) {
-          process.stderr.write(
-            `[nexus] Task-symbol sweep: ${sweeperResult.commitsProcessed} commit(s), ${sweeperResult.tasksFound} task(s), ${sweeperResult.linked} edge(s) linked.\n`,
-          );
-        }
-      } catch {
-        // Non-fatal — task sweeper failure must never fail the analyze command
-      }
+      humanInfo(`[nexus] nexus-bridge.md refreshed at ${repoPath}/.cleo/nexus-bridge.md`);
+      humanInfo('[nexus] Project registered/updated in multi-project registry.');
 
       cliOutput(
         {
-          projectId,
+          projectId: result.projectId,
           repoPath,
           incremental: isIncremental,
           nodeCount: result.nodeCount,
           relationCount: result.relationCount,
           fileCount: result.fileCount,
-          durationMs,
+          durationMs: result.durationMs,
         },
         {
           command: 'nexus-analyze',
           operation: 'nexus.analyze',
-          extensions: { duration_ms: durationMs },
+          extensions: { duration_ms: result.durationMs },
         },
       );
     } catch (err) {
@@ -1630,83 +1549,17 @@ const exportCommand = defineCommand({
     const projectFilter = args.project as string | undefined;
 
     try {
-      // SSoT-EXEMPT:file-serialization — GEXF/JSON graph export writes raw bytes
-      // to stdout/file; requires direct nexus.db access for node/relation queries.
-      // Cannot be a standard LAFS dispatch envelope without binary data concerns.
-      const { getNexusDb, nexusSchema } = await import(
-        '@cleocode/core/store/nexus-sqlite' as string
-      );
-      const db = await getNexusDb();
-
-      // Load all nodes and relations
-      let allNodes: Array<Record<string, unknown>> = [];
-      let allRelations: Array<Record<string, unknown>> = [];
-      try {
-        allNodes = db.select().from(nexusSchema.nexusNodes).all() as Array<Record<string, unknown>>;
-        allRelations = db.select().from(nexusSchema.nexusRelations).all() as Array<
-          Record<string, unknown>
-        >;
-      } catch {
-        // DB may be empty
-      }
-
-      // Filter by project if specified
-      const nodes = projectFilter
-        ? allNodes.filter((n) => n['projectId'] === projectFilter)
-        : allNodes;
-      const relations = projectFilter
-        ? allRelations.filter((r) => r['projectId'] === projectFilter)
-        : allRelations;
-
-      let output = '';
-
-      if (format === 'json') {
-        output = JSON.stringify(
-          {
-            nodes: nodes.map((n) => ({
-              id: n['id'],
-              kind: n['kind'],
-              label: n['label'],
-              name: n['name'],
-              filePath: n['filePath'],
-              language: n['language'],
-              isExported: n['isExported'],
-              startLine: n['startLine'],
-              endLine: n['endLine'],
-              projectId: n['projectId'],
-            })),
-            edges: relations.map((r) => ({
-              id: r['id'],
-              source: r['sourceId'],
-              target: r['targetId'],
-              type: r['type'],
-              confidence: r['confidence'],
-              reason: r['reason'],
-            })),
-          },
-          null,
-          2,
-        );
-      } else if (format === 'gexf') {
-        // GEXF format (Gephi standard)
-        output = generateGexf(nodes, relations);
-      } else {
-        cliError(
-          `Unknown format '${format}'. Supported: gexf, json`,
-          1,
-          { name: 'E_INVALID_INPUT' },
-          { operation: 'nexus.export' },
-        );
-        process.exitCode = 1;
-        return;
-      }
+      const result = await exportNexusGraph({
+        format: format as 'gexf' | 'json',
+        projectFilter,
+      });
 
       if (outputFile) {
         const { writeFileSync } = await import('node:fs');
-        writeFileSync(outputFile, output, 'utf-8');
+        writeFileSync(outputFile, result.content, 'utf-8');
         const durationMs = Date.now() - startTime;
         cliOutput(
-          { outputFile, nodeCount: nodes.length, edgeCount: relations.length },
+          { outputFile, nodeCount: result.nodeCount, edgeCount: result.edgeCount },
           {
             command: 'nexus-export',
             operation: 'nexus.export',
@@ -1718,12 +1571,16 @@ const exportCommand = defineCommand({
         // Raw file output — write directly to stdout (binary/text graph data).
         // Intentionally NOT routed through humanLine — this IS the command's
         // primary stdout payload (the exported graph file content).
-        process.stdout.write(output);
-        if (!output.endsWith('\n')) process.stdout.write('\n');
+        process.stdout.write(result.content);
+        if (!result.content.endsWith('\n')) process.stdout.write('\n');
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      cliError(msg, 1, { name: 'E_EXPORT_FAILED' }, { operation: 'nexus.export' });
+      if (msg.includes('Unknown format')) {
+        cliError(msg, 1, { name: 'E_INVALID_INPUT' }, { operation: 'nexus.export' });
+      } else {
+        cliError(msg, 1, { name: 'E_EXPORT_FAILED' }, { operation: 'nexus.export' });
+      }
       process.exitCode = 1;
     }
   },
@@ -2629,65 +2486,21 @@ const wikiCommand = defineCommand({
   async run({ args }) {
     applyJsonFlag(args.json as boolean | undefined);
     const startTime = Date.now();
-    const outputDir =
-      (args.output as string | undefined) ?? path.join(getProjectRoot(), '.cleo', 'wiki');
+    const outputDir = (args.output as string | undefined) ?? undefined;
     const communityFilter = (args.community as string | undefined) ?? undefined;
     const isIncremental = !!(args.incremental as boolean | undefined);
 
-    // SSoT-EXEMPT:loom-provider — LLM backend resolution for wiki generation requires
-    // CLI-side async provider wiring that cannot be passed through the dispatch layer.
-    // The dispatch 'wiki' op always uses loomProvider=null (scaffold mode). CLI-side
-    // wiring enables real LLM narratives when a backend is available.
-    // Resolve LOOM provider via the existing LLM backend resolver (warm tier).
-    // Falls back gracefully — null means scaffold mode.
-    // The 'ai' package lives in @cleocode/core's deps; we load it transitively.
-    let loomProvider: ((prompt: string) => Promise<string>) | null = null;
     try {
-      const { resolveLlmBackend } = await import('@cleocode/core/memory/llm-backend-resolver.js');
-      const backend = await resolveLlmBackend('warm');
-      if (backend !== null && backend.name !== 'transformers') {
-        // Wire as a simple text-completion function using the 'ai' package
-        // loaded via @cleocode/core's node_modules (avoids duplicate dep in cleo).
-        loomProvider = async (prompt: string): Promise<string> => {
-          // Dynamic import at call time to avoid top-level resolution in cleo
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const aiMod = await import('ai' as string);
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          const generateTextFn = aiMod.generateText as (opts: {
-            model: unknown;
-            prompt: string;
-            maxTokens: number;
-          }) => Promise<{ text: string }>;
-          const { text } = await generateTextFn({
-            model: backend.model,
-            prompt,
-            maxTokens: 256,
-          });
-          return text;
-        };
-      }
-    } catch {
-      // LOOM unavailable — scaffold mode (logged inside generateNexusWikiIndex)
-      loomProvider = null;
-    }
-
-    try {
-      // SSoT-EXEMPT:loom-provider — must call generateNexusWikiIndex directly to pass
-      // loomProvider. The dispatch 'wiki' op does not accept a loomProvider param.
-      const { generateNexusWikiIndex } = await import(
-        '@cleocode/core/nexus/wiki-index.js' as string
-      );
-      const result = await generateNexusWikiIndex(outputDir, getProjectRoot(), {
+      const result = await runNexusWiki({
+        projectRoot: getProjectRoot(),
+        outputDir,
         communityFilter,
         incremental: isIncremental,
-        loomProvider,
-        projectRoot: getProjectRoot(),
       });
-      const durationMs = Date.now() - startTime;
 
       if (!result.success) {
         cliError(
-          `wiki generation failed: ${result.error}`,
+          `wiki generation failed: ${result.error ?? 'unknown'}`,
           1,
           { name: 'E_WIKI_GENERATION_FAILED' },
           { operation: 'nexus.wiki' },
@@ -2697,8 +2510,12 @@ const wikiCommand = defineCommand({
       }
 
       cliOutput(
-        { ...result, _outputDir: outputDir, _durationMs: durationMs },
-        { command: 'nexus-wiki', operation: 'nexus.wiki', extensions: { duration_ms: durationMs } },
+        { ...result, _outputDir: result.outputDir, _durationMs: result.durationMs },
+        {
+          command: 'nexus-wiki',
+          operation: 'nexus.wiki',
+          extensions: { duration_ms: result.durationMs },
+        },
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -275,7 +275,7 @@ export { CANONICAL_DOMAINS } from './dispatch/identity.js';
 // === Dispatch OperationDef + Resolution (T9954 — Phase 0b of SG-ARCH-SOLID / E-CONTRACTS-FOUNDATION) ===
 export type { OperationDef, Resolution } from './dispatch/operation-def.js';
 // === Dispatch OPERATIONS data + builder helpers (T10061 — T9833b / E-CLI-BOUNDARY / SG-ARCH-SOLID) ===
-export { OPERATIONS, defineOp, defineDomain } from './dispatch/operations-registry.js';
+export { defineDomain, defineOp, OPERATIONS } from './dispatch/operations-registry.js';
 // === DocsAccessor Contracts (T9063) ===
 export type {
   DocExportFormat,

--- a/packages/core/src/agents/install-pipeline.ts
+++ b/packages/core/src/agents/install-pipeline.ts
@@ -1,0 +1,137 @@
+/**
+ * Agent install pipeline — business logic extracted from `cleo agent install`.
+ *
+ * Handles three input shapes (.cant file, .cantz archive, agent directory) and
+ * delegates to the `installAgentFromCant` core function. The CLI handler calls
+ * {@link resolveAgentCantPath} to normalize inputs, then passes the resolved
+ * `.cant` path to the core installation function directly.
+ *
+ * @module agents/install-pipeline
+ * @epic T9833
+ * @task T10062
+ */
+
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, extname, join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Three input shapes accepted by the install command. */
+export type AgentInstallInputKind = 'cant-file' | 'cantz-archive' | 'agent-directory';
+
+/** Result of {@link resolveAgentCantPath}. */
+export interface ResolvedCantPath {
+  /** Absolute path to the canonical `.cant` file ready for the pipeline. */
+  cantPath: string;
+  /** Input shape that was resolved. */
+  kind: AgentInstallInputKind;
+  /**
+   * Temp directory created during extraction (only set for `cantz-archive`
+   * and `agent-directory` shapes). The caller is responsible for cleanup.
+   */
+  tempDir: string | null;
+}
+
+/** Options for {@link resolveAgentCantPath}. */
+export interface ResolveAgentCantPathOptions {
+  /** Absolute path to the input file or directory. */
+  resolvedPath: string;
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a user-supplied path into a canonical `.cant` file path.
+ *
+ * Three shapes are handled:
+ * 1. `<id>.cant`          — used as-is.
+ * 2. `<pkg>.cantz`        — extracted to a temp dir; `persona.cant` renamed to
+ *                           `<agentId>.cant`.
+ * 3. `<dir>/persona.cant` — copied from directory into a temp dir.
+ *
+ * @param opts - Resolution options
+ * @returns The resolved `.cant` path and cleanup metadata
+ * @throws {Error} When the path is not a valid input shape
+ */
+export function resolveAgentCantPath(opts: ResolveAgentCantPathOptions): ResolvedCantPath {
+  const { resolvedPath } = opts;
+
+  const stat = statSync(resolvedPath);
+  const ext = extname(resolvedPath);
+
+  if (stat.isFile() && ext === '.cant') {
+    return { cantPath: resolvedPath, kind: 'cant-file', tempDir: null };
+  }
+
+  if (stat.isFile() && ext === '.cantz') {
+    const tempDir = join(tmpdir(), `cleo-agent-install-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+
+    execFileSync('unzip', ['-o', '-q', resolvedPath, '-d', tempDir], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+
+    const topLevel = readdirSync(tempDir).filter((entry) =>
+      statSync(join(tempDir, entry)).isDirectory(),
+    );
+    if (topLevel.length !== 1) {
+      throw new Error(
+        `Archive must contain exactly one top-level directory, found ${topLevel.length}`,
+      );
+    }
+
+    const agentName = topLevel[0] as string;
+    const personaPath = join(tempDir, agentName, 'persona.cant');
+    if (!existsSync(personaPath)) {
+      throw new Error(`Archive must contain persona.cant: ${personaPath}`);
+    }
+
+    const cantPath = join(tempDir, `${agentName}.cant`);
+    copyFileSync(personaPath, cantPath);
+    return { cantPath, kind: 'cantz-archive', tempDir };
+  }
+
+  if (stat.isDirectory()) {
+    const agentName = basename(resolvedPath);
+    const personaPath = join(resolvedPath, 'persona.cant');
+    if (!existsSync(personaPath)) {
+      throw new Error(`Agent directory must contain persona.cant: ${personaPath}`);
+    }
+
+    const tempDir = join(tmpdir(), `cleo-agent-install-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    const cantPath = join(tempDir, `${agentName}.cant`);
+    copyFileSync(personaPath, cantPath);
+    return { cantPath, kind: 'agent-directory', tempDir };
+  }
+
+  throw new Error(`Path must be a .cant, .cantz, or agent directory: ${resolvedPath}`);
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove a temp directory created during install resolution.
+ *
+ * Best-effort — never throws. Should be called in a `finally` block after the
+ * installation completes or fails.
+ *
+ * @param tempDir - Directory to remove (null is a no-op)
+ */
+export function cleanupInstallTempDir(tempDir: string | null): void {
+  if (!tempDir) return;
+  try {
+    rmSync(tempDir, { recursive: true, force: true });
+  } catch {
+    // best-effort — do not mask the primary error
+  }
+}

--- a/packages/core/src/agents/scaffold.ts
+++ b/packages/core/src/agents/scaffold.ts
@@ -1,0 +1,610 @@
+/**
+ * Agent scaffold — persona.cant / manifest.json / team-config generation.
+ *
+ * Extracted from `cleo agent create` (packages/cleo). Contains all role-based
+ * template helpers and the directory-creation logic. CLI remains a thin wrapper
+ * that calls `scaffoldAgent` and emits the LAFS envelope.
+ *
+ * @module agents/scaffold
+ * @epic T9833
+ * @task T10062
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Valid agent roles for template generation. */
+export type AgentRole = 'orchestrator' | 'lead' | 'worker' | 'docs-worker';
+
+/** Parameters accepted by {@link scaffoldAgent}. */
+export interface ScaffoldAgentParams {
+  name: string;
+  role: string;
+  /** Defaults to role-inferred value when omitted. */
+  tier?: string;
+  team?: string;
+  domain?: string;
+  parent?: string;
+  /**
+   * Install into the global XDG-data agents tier instead of the project tree.
+   */
+  global?: boolean;
+  /** Whether to create `expertise/mental-model-seed.md` and seed BRAIN. */
+  seedBrain?: boolean;
+  /**
+   * Absolute project root — required when `global` is false.
+   * Used to resolve `.cleo/cant/agents/`.
+   */
+  projectRoot?: string;
+  /**
+   * CLEO directory name inside the project root (default: `.cleo`).
+   */
+  cleoDirName?: string;
+  /** Sub-directory under `.cleo` for CANT agent definitions. */
+  cantAgentsSubdir?: string;
+}
+
+/** Result of a successful scaffold operation. */
+export interface ScaffoldAgentResult {
+  agent: string;
+  role: string;
+  tier: string;
+  directory: string;
+  scope: 'global' | 'project';
+  files: string[];
+  registered: false;
+  brainSeeded: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Scaffold a new agent package on disk.
+ *
+ * Creates the agent directory, `persona.cant`, `manifest.json`, an optional
+ * `team-config.cant`, and an optional mental-model seed. Does NOT register
+ * the agent in the SignalDock registry — the CLI handler handles that as a
+ * best-effort step.
+ *
+ * @param params - Scaffold parameters
+ * @returns Metadata about the created files
+ * @throws {Error} When the directory already exists or validation fails
+ */
+export function scaffoldAgent(params: ScaffoldAgentParams): ScaffoldAgentResult {
+  const {
+    name,
+    role,
+    team,
+    domain,
+    parent,
+    global: isGlobal = false,
+    seedBrain = false,
+    projectRoot,
+    cleoDirName = '.cleo',
+    cantAgentsSubdir = 'cant/agents',
+  } = params;
+
+  const tier = params.tier ?? inferTierFromRole(role);
+
+  validateRole(role);
+  validateTier(tier);
+  validateName(name);
+
+  const targetRoot = resolveTargetRoot({ isGlobal, projectRoot, cleoDirName, cantAgentsSubdir });
+  const agentDir = join(targetRoot, name);
+
+  if (existsSync(agentDir)) {
+    throw new Error(`Agent directory already exists: ${agentDir}`);
+  }
+
+  mkdirSync(agentDir, { recursive: true });
+
+  const personaContent = generatePersonaCant({ name, role, tier, team, domain, parent });
+  const personaPath = join(agentDir, 'persona.cant');
+  writeFileSync(personaPath, personaContent, 'utf-8');
+
+  const manifest = generateManifest({ name, role, tier, domain });
+  const manifestPath = join(agentDir, 'manifest.json');
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+
+  const createdFiles: string[] = [personaPath, manifestPath];
+
+  if (team) {
+    const teamConfigPath = join(agentDir, 'team-config.cant');
+    writeFileSync(teamConfigPath, generateTeamConfig(name, role, team), 'utf-8');
+    createdFiles.push(teamConfigPath);
+  }
+
+  if (seedBrain) {
+    const expertiseDir = join(agentDir, 'expertise');
+    mkdirSync(expertiseDir, { recursive: true });
+    const seedPath = join(expertiseDir, 'mental-model-seed.md');
+    writeFileSync(seedPath, generateMentalModelSeed(name, role, domain), 'utf-8');
+    createdFiles.push(seedPath);
+  }
+
+  return {
+    agent: name,
+    role,
+    tier,
+    directory: agentDir,
+    scope: isGlobal ? 'global' : 'project',
+    files: createdFiles,
+    registered: false,
+    brainSeeded: seedBrain,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+const VALID_ROLES: AgentRole[] = ['orchestrator', 'lead', 'worker', 'docs-worker'];
+const VALID_TIERS = ['low', 'mid', 'high'];
+
+/** @throws {Error} when role is not in {@link VALID_ROLES}. */
+export function validateRole(role: string): void {
+  if (!VALID_ROLES.includes(role as AgentRole)) {
+    throw new Error(`Invalid role "${role}". Must be one of: ${VALID_ROLES.join(', ')}`);
+  }
+}
+
+/** @throws {Error} when tier is not in `['low', 'mid', 'high']`. */
+export function validateTier(tier: string): void {
+  if (!VALID_TIERS.includes(tier)) {
+    throw new Error(`Invalid tier "${tier}". Must be one of: ${VALID_TIERS.join(', ')}`);
+  }
+}
+
+/** @throws {Error} when name is not kebab-case. */
+export function validateName(name: string): void {
+  if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(name)) {
+    throw new Error(
+      `Agent name must be kebab-case: "${name}". Use lowercase letters, numbers, and hyphens.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+interface ResolveTargetRootOpts {
+  isGlobal: boolean;
+  projectRoot?: string;
+  cleoDirName: string;
+  cantAgentsSubdir: string;
+}
+
+function resolveTargetRoot(opts: ResolveTargetRootOpts): string {
+  if (opts.isGlobal) {
+    const home = homedir();
+    const xdgData = process.env['XDG_DATA_HOME'] ?? join(home, '.local', 'share');
+    return join(xdgData, 'cleo', 'cant', 'agents');
+  }
+  if (!opts.projectRoot) {
+    throw new Error('projectRoot is required for non-global agent scaffold');
+  }
+  return join(opts.projectRoot, opts.cleoDirName, opts.cantAgentsSubdir);
+}
+
+// ---------------------------------------------------------------------------
+// Tier inference
+// ---------------------------------------------------------------------------
+
+/**
+ * Infer the default tier from the agent role.
+ *
+ * - `orchestrator` → `high`
+ * - everything else → `mid`
+ */
+export function inferTierFromRole(role: string): string {
+  return role === 'orchestrator' ? 'high' : 'mid';
+}
+
+// ---------------------------------------------------------------------------
+// Template generators
+// ---------------------------------------------------------------------------
+
+interface PersonaParams {
+  name: string;
+  role: string;
+  tier: string;
+  team?: string;
+  domain?: string;
+  parent?: string;
+}
+
+interface ManifestParams {
+  name: string;
+  role: string;
+  tier: string;
+  domain?: string;
+}
+
+/**
+ * Generate `persona.cant` content from role-based templates.
+ *
+ * @see packages/cleo-os/starter-bundle/agents/ — canonical format reference
+ */
+export function generatePersonaCant(params: PersonaParams): string {
+  const { name, role, tier, team, domain, parent } = params;
+  switch (role as AgentRole) {
+    case 'orchestrator':
+      return generateOrchestratorPersona(name, tier, team, parent);
+    case 'lead':
+      return generateLeadPersona(name, tier, team, domain, parent);
+    case 'docs-worker':
+      return generateDocsWorkerPersona(name, tier, team, domain, parent);
+    default:
+      return generateWorkerPersona(name, tier, team, domain, parent);
+  }
+}
+
+/** Generate `persona.cant` for the `orchestrator` role. */
+export function generateOrchestratorPersona(
+  name: string,
+  tier: string,
+  team?: string,
+  parent?: string,
+): string {
+  const parentLine = parent ? `\n  parent: ${parent}` : '';
+  const teamComment = team ? `\n# Team: ${team}` : '';
+  return `---
+kind: agent
+version: "1"
+---
+
+# ${name} — orchestrator agent.${teamComment}
+# Coordinates the team, classifies work, dispatches to leads/workers.
+
+agent ${name}:
+  role: orchestrator${parentLine}
+  tier: ${tier}
+  description: "Orchestrator agent. Reads task context, classifies work, dispatches to leads, and synthesizes results. Does not execute code — coordinates."
+  consult-when: "Cross-team decisions, scope changes, human-in-the-loop escalation, or when a lead reports a blocking ambiguity"
+
+  context_sources:
+    - source: decisions
+      query: "recent architectural and project decisions"
+      max_entries: 5
+    - source: patterns
+      query: "project conventions and established patterns"
+      max_entries: 3
+  on_overflow: escalate_tier
+
+  mental_model:
+    scope: project
+    max_tokens: 2000
+    on_load:
+      validate: true
+
+  permissions:
+    tasks: read, write
+    session: read, write
+    memory: read, write
+
+  skills:
+    - ct-cleo
+    - ct-task-executor
+
+  tools:
+    core: [Read, Grep, Glob]
+    dispatch: [dispatch_worker, report_to_user]
+
+  on SessionStart:
+    session "Read active tasks and recent decisions to build situational awareness"
+      context: [active-tasks, memory-bridge, recent-decisions]
+
+  on TaskCompleted:
+    if **the completed task unblocks downstream work**:
+      session "Reassess task queue and dispatch next work"
+`;
+}
+
+/** Generate `persona.cant` for the `lead` role. */
+export function generateLeadPersona(
+  name: string,
+  tier: string,
+  team?: string,
+  domain?: string,
+  parent?: string,
+): string {
+  const parentLine = parent ? `\n  parent: ${parent}` : '\n  parent: project-orchestrator';
+  const teamComment = team ? `\n# Team: ${team}` : '';
+  const domainDesc = domain ? ` Specializes in ${domain}.` : '';
+  return `---
+kind: agent
+version: "1"
+---
+
+# ${name} — lead agent.${teamComment}
+# Decomposes tasks, reviews worker output, decides technical approach.
+# MUST NOT hold Edit/Write/Bash tools (TEAM-002 / ULTRAPLAN 10.3).
+
+agent ${name}:
+  role: lead${parentLine}
+  tier: ${tier}
+  description: "Development lead.${domainDesc} Decomposes tasks into concrete implementation steps, reviews worker output, and decides technical approach. Does not write code directly."
+  consult-when: "Implementation strategy, code architecture, refactoring direction, task decomposition, or when workers need clarification"
+
+  context_sources:
+    - source: patterns
+      query: "codebase conventions and architecture patterns"
+      max_entries: 5
+    - source: decisions
+      query: "technical decisions affecting implementation"
+      max_entries: 3
+  on_overflow: escalate_tier
+
+  mental_model:
+    scope: project
+    max_tokens: 1000
+    on_load:
+      validate: true
+
+  permissions:
+    files:
+      read: ["**/*"]
+
+  skills:
+    - ct-cleo
+    - ct-dev-workflow
+    - ct-task-executor
+
+  tools:
+    core: [Read, Grep, Glob]
+    dispatch: [dispatch_worker, report_to_orchestrator]
+
+  on SessionStart:
+    session "Review current task assignments and worker availability"
+      context: [active-tasks, memory-bridge]
+
+  on TaskCompleted:
+    if **the completed task introduced new code**:
+      session "Review worker output for quality and completeness before reporting to orchestrator"
+`;
+}
+
+/** Generate `persona.cant` for the `worker` role. */
+export function generateWorkerPersona(
+  name: string,
+  tier: string,
+  team?: string,
+  domain?: string,
+  parent?: string,
+): string {
+  const parentLine = parent ? `\n  parent: ${parent}` : '\n  parent: dev-lead';
+  const teamComment = team ? `\n# Team: ${team}` : '';
+  const domainDesc = domain ? ` Specializes in ${domain}.` : '';
+  const writeGlobs = deriveWriteGlobs(domain);
+  return `---
+kind: agent
+version: "1"
+---
+
+# ${name} — worker agent.${teamComment}
+# Executes code changes within declared file globs.
+
+agent ${name}:
+  role: worker${parentLine}
+  tier: ${tier}
+  description: "Code worker.${domainDesc} Reads requirements, writes code, runs tests, and validates changes. Operates within declared file permission globs."
+  consult-when: "Writing code, fixing bugs, running tests, formatting, or any file modification task"
+
+  context_sources:
+    - source: patterns
+      query: "coding conventions and testing patterns"
+      max_entries: 5
+    - source: learnings
+      query: "past implementation mistakes and fixes"
+      max_entries: 3
+  on_overflow: escalate_tier
+
+  mental_model:
+    scope: project
+    max_tokens: 1000
+    on_load:
+      validate: true
+
+  permissions:
+    files:
+      write: ${JSON.stringify(writeGlobs)}
+      read: ["**/*"]
+      delete: ${JSON.stringify(writeGlobs)}
+
+  skills:
+    - ct-cleo
+    - ct-dev-workflow
+    - ct-task-executor
+
+  tools:
+    core: [Read, Edit, Write, Bash, Glob, Grep]
+
+  on SessionStart:
+    session "Check assigned task and read relevant source files before starting work"
+      context: [active-tasks, memory-bridge]
+
+  on PostToolUse:
+    if tool.name == "Write" or tool.name == "Edit":
+      session "Verify the change compiles and passes lint before proceeding"
+`;
+}
+
+/** Generate `persona.cant` for the `docs-worker` role. */
+export function generateDocsWorkerPersona(
+  name: string,
+  tier: string,
+  team?: string,
+  domain?: string,
+  parent?: string,
+): string {
+  const parentLine = parent ? `\n  parent: ${parent}` : '\n  parent: dev-lead';
+  const teamComment = team ? `\n# Team: ${team}` : '';
+  const domainDesc = domain ? ` Specializes in ${domain} documentation.` : '';
+  return `---
+kind: agent
+version: "1"
+---
+
+# ${name} — documentation worker agent.${teamComment}
+# Writes and maintains documentation within declared globs.
+
+agent ${name}:
+  role: worker${parentLine}
+  tier: ${tier}
+  description: "Documentation worker.${domainDesc} Writes READMEs, updates guides, adds TSDoc comments, and maintains project documentation. Operates within declared documentation file globs."
+  consult-when: "Writing documentation, updating READMEs, adding TSDoc comments, or improving existing docs"
+
+  context_sources:
+    - source: patterns
+      query: "documentation conventions and style patterns"
+      max_entries: 3
+    - source: decisions
+      query: "architectural decisions needing documentation"
+      max_entries: 3
+  on_overflow: escalate_tier
+
+  mental_model:
+    scope: project
+    max_tokens: 1000
+    on_load:
+      validate: true
+
+  permissions:
+    files:
+      write: ["docs/**", "**/*.md", "**/*.mdx"]
+      read: ["**/*"]
+      delete: ["docs/**"]
+
+  skills:
+    - ct-cleo
+    - ct-documentor
+    - ct-docs-write
+
+  tools:
+    core: [Read, Edit, Write, Bash, Glob, Grep]
+
+  on SessionStart:
+    session "Check assigned documentation task and review existing docs for context"
+      context: [active-tasks, memory-bridge]
+
+  on PostToolUse:
+    if tool.name == "Write" or tool.name == "Edit":
+      session "Verify markdown renders correctly and follows project style conventions"
+`;
+}
+
+/**
+ * Derive file write globs from a domain description string.
+ *
+ * Maps common domain keywords to appropriate file glob patterns.
+ * Falls back to the project-wide defaults when no domain is specified.
+ */
+export function deriveWriteGlobs(domain?: string): string[] {
+  const defaults = ['src/**', 'packages/**', 'lib/**', 'test/**', 'tests/**'];
+  if (!domain) return defaults;
+  const lower = domain.toLowerCase();
+  if (lower.includes('frontend') || lower.includes('ui') || lower.includes('component')) {
+    return ['src/**', 'packages/**', 'components/**', 'styles/**', 'public/**', 'test/**'];
+  }
+  if (lower.includes('backend') || lower.includes('api') || lower.includes('server')) {
+    return ['src/**', 'packages/**', 'lib/**', 'api/**', 'test/**', 'tests/**'];
+  }
+  if (lower.includes('infra') || lower.includes('deploy') || lower.includes('ci')) {
+    return ['.github/**', 'infra/**', 'deploy/**', 'scripts/**', 'Dockerfile*'];
+  }
+  if (lower.includes('test') || lower.includes('qa') || lower.includes('quality')) {
+    return ['test/**', 'tests/**', 'src/**/*.test.*', 'src/**/*.spec.*', 'packages/**/*.test.*'];
+  }
+  if (lower.includes('rust') || lower.includes('crate')) {
+    return ['crates/**', 'src/**', 'Cargo.toml', 'test/**'];
+  }
+  if (lower.includes('doc')) {
+    return ['docs/**', '**/*.md', '**/*.mdx'];
+  }
+  return defaults;
+}
+
+/**
+ * Generate a `manifest.json` object conforming to CANTZ-PACKAGE-STANDARD.md §2.3.
+ */
+export function generateManifest(params: ManifestParams): Record<string, unknown> {
+  return {
+    name: params.name,
+    version: '1.0.0',
+    description: `${capitalizeFirst(params.role)} agent${params.domain ? ` for ${params.domain}` : ''}`,
+    cant: {
+      minVersion: '1',
+      tier: params.tier,
+      role: params.role === 'docs-worker' ? 'worker' : params.role,
+    },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Generate a `team-config.cant` fragment declaring the agent's team membership.
+ */
+export function generateTeamConfig(name: string, role: string, team: string): string {
+  return `---
+kind: team-config
+version: "1"
+---
+
+# Team membership for ${name}
+
+team ${team}:
+  member ${name}:
+    role: ${role}
+    status: active
+`;
+}
+
+/**
+ * Generate a mental-model seed markdown file for BRAIN seeding.
+ */
+export function generateMentalModelSeed(name: string, role: string, domain?: string): string {
+  const domainSection = domain
+    ? `## Domain\n\n${domain}\n`
+    : `## Domain\n\nTODO: Describe the domain this agent specializes in.\n`;
+  return `# Mental Model Seed: ${name}
+
+> Auto-generated at ${new Date().toISOString()}
+> Role: ${role}
+
+${domainSection}
+## Key Patterns
+
+TODO: Document recurring patterns this agent should recognize.
+
+## Known Pitfalls
+
+TODO: Document common mistakes or anti-patterns in this domain.
+
+## Decision History
+
+TODO: Track important decisions and their rationale.
+
+## Learning Log
+
+TODO: Record discoveries and insights as the agent operates.
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/** Capitalize the first character of a string. */
+function capitalizeFirst(str: string): string {
+  if (str.length === 0) return str;
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/packages/core/src/agents/work-loop.ts
+++ b/packages/core/src/agents/work-loop.ts
@@ -1,0 +1,188 @@
+/**
+ * Autonomous agent work loop — business logic extracted from `cleo agent work`.
+ *
+ * The CLI handler delegates here after resolving credentials and starting the
+ * runtime. This module owns the poll-and-dispatch loop, LAFS envelope parsing,
+ * and clean shutdown coordination.
+ *
+ * @module agents/work-loop
+ * @epic T9833
+ * @task T10062
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Configuration for the autonomous work loop. */
+export interface WorkLoopConfig {
+  /** The agent ID running the loop. */
+  agentId: string;
+  /** Poll interval in milliseconds (default: 30 000). */
+  pollIntervalMs: number;
+  /** When true, tasks are executed via `orchestrate.spawn.execute`. */
+  executeMode: boolean;
+  /** Restrict autonomous execution to this epic ID (optional). */
+  epicRestrict?: string;
+  /** Route spawns through this adapter ID (optional). */
+  adapterRestrict?: string;
+}
+
+/** Callbacks the CLI layer provides for output and shutdown wiring. */
+export interface WorkLoopCallbacks {
+  /** Emit a human-readable info line. */
+  onInfo: (message: string) => void;
+  /** Emit a human-readable warning line. */
+  onWarn: (message: string) => void;
+  /** Called when shutdown is requested. */
+  onShutdown?: () => void;
+}
+
+/** Summary emitted after the loop terminates. */
+export interface WorkLoopSummary {
+  agentId: string;
+  mode: 'conductor-loop' | 'watch-only';
+  iterations: number;
+}
+
+// ---------------------------------------------------------------------------
+// LAFS envelope parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a LAFS envelope from raw CLI stdout.
+ *
+ * Handles both the minimal `{ok, r}` and full `{success, result|data}` shapes.
+ *
+ * @internal
+ */
+function parseLafs<T = unknown>(raw: string): T | undefined {
+  const lines = raw.trim().split('\n');
+  const envLine = [...lines].reverse().find((l) => l.startsWith('{'));
+  if (!envLine) return undefined;
+  try {
+    const env = JSON.parse(envLine) as {
+      ok?: boolean;
+      r?: T;
+      success?: boolean;
+      result?: T;
+      data?: T;
+    };
+    if (env.ok === true) return env.r;
+    if (env.success === true) return (env.result ?? env.data) as T | undefined;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// runCleo helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Invoke a sibling `cleo` CLI command and return its stdout.
+ *
+ * @param args - CLI arguments after `cleo`
+ * @param timeoutMs - Execution timeout (default: 15 000)
+ */
+async function runCleo(args: string[], timeoutMs = 15_000): Promise<string> {
+  const { stdout } = await execFileAsync('cleo', args, {
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+  });
+  return stdout;
+}
+
+// ---------------------------------------------------------------------------
+// Work loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the autonomous work loop and return a handle to stop it.
+ *
+ * The loop polls for the next ready task on every `pollIntervalMs` tick. In
+ * watch-only mode it announces available tasks. In conductor-loop mode it
+ * actually spawns them via `cleo orchestrate spawn`.
+ *
+ * @param config - Loop parameters
+ * @param callbacks - Output / lifecycle callbacks
+ * @returns A function that stops the loop and resolves to a summary.
+ */
+export function startWorkLoop(
+  config: WorkLoopConfig,
+  callbacks: WorkLoopCallbacks,
+): { stop: () => WorkLoopSummary } {
+  const { agentId, pollIntervalMs, executeMode, epicRestrict, adapterRestrict } = config;
+  const { onInfo, onWarn } = callbacks;
+
+  let inFlight = false;
+  let iterations = 0;
+
+  const workLoop = setInterval(async () => {
+    if (inFlight) return;
+    inFlight = true;
+    iterations += 1;
+    try {
+      const currentRaw = await runCleo(['current']).catch(() => '');
+      if (currentRaw.trim()) return; // task already in progress
+
+      const nextArgs = epicRestrict ? ['orchestrate', 'next', epicRestrict] : ['next'];
+      const nextRaw = await runCleo(nextArgs).catch(() => '');
+      if (!nextRaw.trim()) return;
+
+      const nextData = parseLafs<{
+        nextTask?: { id?: string; title?: string } | null;
+        id?: string;
+        title?: string;
+      }>(nextRaw);
+      const taskId =
+        nextData?.nextTask?.id ?? (typeof nextData?.id === 'string' ? nextData.id : undefined);
+
+      if (!taskId) return;
+
+      if (!executeMode) {
+        onInfo(`[${agentId}] Task available: ${taskId}. Pass --execute to run autonomously.`);
+        return;
+      }
+
+      const spawnArgs = ['orchestrate', 'spawn', taskId];
+      if (adapterRestrict) spawnArgs.push('--adapter', adapterRestrict);
+
+      const spawnRaw = await runCleo(spawnArgs, 60_000).catch((e) => {
+        onWarn(`[${agentId}] conductor-loop: spawn failed for ${taskId}: ${String(e)}`);
+        return '';
+      });
+
+      const spawnData = parseLafs<{
+        instanceId?: string;
+        taskId?: string;
+        status?: string;
+      }>(spawnRaw);
+      if (spawnData?.instanceId) {
+        onInfo(
+          `[${agentId}] conductor-loop spawned task=${taskId} instance=${spawnData.instanceId} status=${spawnData.status ?? 'unknown'}`,
+        );
+      }
+    } catch {
+      // non-fatal — loop continues
+    } finally {
+      inFlight = false;
+    }
+  }, pollIntervalMs);
+
+  return {
+    stop(): WorkLoopSummary {
+      clearInterval(workLoop);
+      if (executeMode) {
+        onInfo(`[${agentId}] conductor-loop shutdown after ${iterations} iterations.`);
+      }
+      return { agentId, mode: executeMode ? 'conductor-loop' : 'watch-only', iterations };
+    },
+  };
+}

--- a/packages/core/src/memory/__tests__/build-retrieval-bundle-refusal-gate.test.ts
+++ b/packages/core/src/memory/__tests__/build-retrieval-bundle-refusal-gate.test.ts
@@ -34,16 +34,22 @@ afterEach(async () => {
   try {
     const { closeBrainDb } = await import('../../store/memory-sqlite.js');
     closeBrainDb();
-  } catch { /* not loaded */ }
+  } catch {
+    /* not loaded */
+  }
   try {
     const { closeNexusDb, resetNexusDbState } = await import('../../store/nexus-sqlite.js');
     closeNexusDb();
     resetNexusDbState();
-  } catch { /* not loaded */ }
+  } catch {
+    /* not loaded */
+  }
   try {
     const { closeDb } = await import('../../store/sqlite.js');
     closeDb();
-  } catch { /* not loaded */ }
+  } catch {
+    /* not loaded */
+  }
 
   delete process.env['CLEO_DIR'];
   delete process.env['CLEO_HOME'];
@@ -78,12 +84,18 @@ function seedObservation(
   // Ensure peer_id column exists (may be added by T1084 migration)
   try {
     db.exec(`ALTER TABLE brain_observations ADD COLUMN peer_id TEXT NOT NULL DEFAULT 'global'`);
-  } catch { /* already exists */ }
+  } catch {
+    /* already exists */
+  }
 
   // Ensure provenance_class column exists (added by T1260 migration)
   try {
-    db.exec(`ALTER TABLE brain_observations ADD COLUMN provenance_class TEXT DEFAULT 'unswept-pre-T1151'`);
-  } catch { /* already exists */ }
+    db.exec(
+      `ALTER TABLE brain_observations ADD COLUMN provenance_class TEXT DEFAULT 'unswept-pre-T1151'`,
+    );
+  } catch {
+    /* already exists */
+  }
 
   try {
     db.prepare(

--- a/packages/core/src/memory/import-from-provider.ts
+++ b/packages/core/src/memory/import-from-provider.ts
@@ -1,0 +1,305 @@
+/**
+ * Provider-agnostic memory import — business logic extracted from `cleo memory import`.
+ *
+ * Reads `*.md` files from a provider memory directory, parses YAML frontmatter,
+ * deduplicates by content hash, and dispatches observations into `brain.db` via
+ * the CLEO dispatch layer. The CLI handler calls {@link importMemoryFiles}.
+ *
+ * @module memory/import-from-provider
+ * @epic T9833
+ * @task T10062
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for {@link importMemoryFiles}. */
+export interface ImportMemoryFilesOptions {
+  /**
+   * Source directory containing `*.md` memory files.
+   * Defaults to `~/.claude/projects/-mnt-projects-cleocode/memory`.
+   */
+  sourceDir?: string;
+  /** When true, log what would be imported without writing to `brain.db`. */
+  dryRun?: boolean;
+  /** Project root used to locate the dedup state file. */
+  projectRoot: string;
+  /** CLEO directory name inside the project root (default: `.cleo`). */
+  cleoDirName?: string;
+  /** File name for the import-hash dedup state (default: `migrate-memory-hashes.json`). */
+  hasheFileName?: string;
+  /**
+   * Dispatch function — matches the `dispatchFromCli` signature from the CLI
+   * adapter. Injected here to keep the core module decoupled from CLI internals.
+   */
+  dispatch: (
+    gateway: 'mutate' | 'query',
+    domain: string,
+    operation: string,
+    params: Record<string, unknown>,
+    output: { command: string; operation: string },
+  ) => Promise<void>;
+}
+
+/** Per-entry import record. */
+export interface ImportedEntry {
+  file: string;
+  type: string;
+  title: string;
+}
+
+/** Per-entry skip record. */
+export interface SkippedEntry {
+  file: string;
+  reason: string;
+}
+
+/** Per-entry error record. */
+export interface ErrorEntry {
+  file: string;
+  error: string;
+}
+
+/** Summary returned by {@link importMemoryFiles}. */
+export interface ImportMemoryResult {
+  total: number;
+  imported: number;
+  skipped: number;
+  errors: number;
+  dryRun: boolean;
+  importedEntries: ImportedEntry[];
+  skippedEntries: SkippedEntry[];
+  errorEntries: ErrorEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse YAML frontmatter from a markdown string.
+ *
+ * Supports simple `key: value` pairs only (no nested YAML).
+ *
+ * @param raw - Raw file content
+ * @returns Extracted frontmatter fields and body text
+ */
+export function parseMemoryFileFrontmatter(raw: string): {
+  name?: string;
+  description?: string;
+  type?: string;
+  body: string;
+} {
+  const lines = raw.split('\n');
+  if (!lines[0]?.trim().startsWith('---')) {
+    return { body: raw.trim() };
+  }
+
+  const endIdx = lines.slice(1).findIndex((l) => /^---\s*$/.test(l));
+  if (endIdx === -1) {
+    return { body: raw.trim() };
+  }
+
+  const fmLines = lines.slice(1, endIdx + 1);
+  const body = lines
+    .slice(endIdx + 2)
+    .join('\n')
+    .trim();
+
+  const fm: Record<string, string> = {};
+  for (const line of fmLines) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1).trim();
+    if (key && value) fm[key] = value;
+  }
+
+  return {
+    name: fm['name'],
+    description: fm['description'],
+    type: fm['type'],
+    body,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Content hash
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a 16-char hex content fingerprint for deduplication.
+ *
+ * @param title - Entry title
+ * @param body - Entry body text
+ * @returns 16-char hex prefix of SHA-256 hash
+ */
+export function memoryContentHash(title: string, body: string): string {
+  return createHash('sha256').update(`${title}\n${body}`).digest('hex').slice(0, 16);
+}
+
+// ---------------------------------------------------------------------------
+// Hash state persistence
+// ---------------------------------------------------------------------------
+
+/** Load the set of already-imported content hashes from the dedup state file. */
+function loadImportHashes(stateFile: string): Set<string> {
+  try {
+    if (!existsSync(stateFile)) return new Set();
+    const raw = readFileSync(stateFile, 'utf-8');
+    const parsed = JSON.parse(raw) as { hashes: string[] };
+    return new Set(parsed.hashes);
+  } catch {
+    return new Set();
+  }
+}
+
+/** Persist the updated set of imported hashes to the dedup state file. */
+function saveImportHashes(stateFile: string, hashes: Set<string>): void {
+  const dir = stateFile.slice(0, stateFile.lastIndexOf('/'));
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(stateFile, JSON.stringify({ hashes: [...hashes] }, null, 2), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Import `*.md` memory files from a provider directory into `brain.db`.
+ *
+ * Skips `MEMORY.md`, empty files, and previously imported entries (by content
+ * hash). Routes `feedback` type entries to `memory.learning.store`; all other
+ * types go to `memory.observe`.
+ *
+ * @param opts - Import options
+ * @returns Summary of the import operation
+ * @throws {Error} When the source directory does not exist
+ */
+export async function importMemoryFiles(
+  opts: ImportMemoryFilesOptions,
+): Promise<ImportMemoryResult> {
+  const {
+    dryRun = false,
+    projectRoot,
+    cleoDirName = '.cleo',
+    hasheFileName = 'migrate-memory-hashes.json',
+    dispatch,
+  } = opts;
+
+  const sourceDir =
+    opts.sourceDir ?? join(homedir(), '.claude', 'projects', '-mnt-projects-cleocode', 'memory');
+
+  if (!existsSync(sourceDir)) {
+    throw new Error(`Source directory not found: ${sourceDir}`);
+  }
+
+  const stateFile = join(projectRoot, cleoDirName, hasheFileName);
+  const files = readdirSync(sourceDir)
+    .filter((f) => f.endsWith('.md') && f !== 'MEMORY.md')
+    .map((f) => join(sourceDir, f));
+
+  const importedHashes = dryRun ? new Set<string>() : loadImportHashes(stateFile);
+  const stats = { total: files.length, imported: 0, skipped: 0, errors: 0 };
+  const importedEntries: ImportedEntry[] = [];
+  const skippedEntries: SkippedEntry[] = [];
+  const errorEntries: ErrorEntry[] = [];
+
+  for (const filePath of files) {
+    const fileName = filePath.split('/').pop() ?? filePath;
+    try {
+      const raw = readFileSync(filePath, 'utf-8');
+      if (!raw.trim()) {
+        stats.skipped++;
+        skippedEntries.push({ file: fileName, reason: 'empty file' });
+        continue;
+      }
+
+      const { name, description, type, body } = parseMemoryFileFrontmatter(raw);
+      const title = name ?? fileName.replace(/\.md$/, '').replace(/-/g, ' ');
+      const bodyParts = [description, body].filter(Boolean);
+      const fullText = bodyParts.join('\n\n').trim();
+
+      if (!fullText) {
+        stats.skipped++;
+        skippedEntries.push({ file: fileName, reason: 'empty body' });
+        continue;
+      }
+
+      const hash = memoryContentHash(title, fullText);
+
+      if (!dryRun && importedHashes.has(hash)) {
+        stats.skipped++;
+        skippedEntries.push({ file: fileName, reason: `already imported (hash: ${hash})` });
+        continue;
+      }
+
+      const entryType = type ?? 'project';
+
+      if (!dryRun) {
+        if (entryType === 'feedback') {
+          await dispatch(
+            'mutate',
+            'memory',
+            'learning.store',
+            {
+              insight: `[MIGRATED] ${title}: ${fullText}`,
+              source: 'manual',
+              confidence: 0.8,
+              actionable: false,
+            },
+            { command: 'memory', operation: 'memory.learning.store' },
+          );
+        } else {
+          const observeType =
+            entryType === 'project'
+              ? 'feature'
+              : entryType === 'reference'
+                ? 'discovery'
+                : entryType === 'user'
+                  ? 'change'
+                  : 'discovery';
+
+          await dispatch(
+            'mutate',
+            'memory',
+            'observe',
+            {
+              text: `[MIGRATED] ${title}: ${fullText}`,
+              title: `[MIGRATED] ${title}`,
+              type: observeType,
+              sourceType: 'manual',
+            },
+            { command: 'memory', operation: 'memory.observe' },
+          );
+        }
+        importedHashes.add(hash);
+      }
+
+      stats.imported++;
+      importedEntries.push({ file: fileName, type: entryType, title });
+    } catch (err) {
+      stats.errors++;
+      const message = err instanceof Error ? err.message : String(err);
+      errorEntries.push({ file: fileName, error: message });
+    }
+  }
+
+  if (!dryRun) {
+    saveImportHashes(stateFile, importedHashes);
+  }
+
+  return {
+    ...stats,
+    dryRun,
+    importedEntries,
+    skippedEntries,
+    errorEntries,
+  };
+}

--- a/packages/core/src/memory/watch-stream.ts
+++ b/packages/core/src/memory/watch-stream.ts
@@ -1,0 +1,131 @@
+/**
+ * Memory watch stream — business logic extracted from `cleo memory watch --follow`.
+ *
+ * Provides an `AsyncIterable` of brain write events that the CLI handler
+ * can consume and format as SSE-style stdout events. The non-follow (single
+ * poll) path stays thin in the CLI handler via `dispatchFromCli`.
+ *
+ * @module memory/watch-stream
+ * @epic T9833
+ * @task T10062
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single brain write event. */
+export interface MemoryWatchEvent {
+  [key: string]: unknown;
+  created_at?: string;
+}
+
+/** Options for {@link streamMemoryWatchEvents}. */
+export interface MemoryWatchStreamOptions {
+  /** Resume cursor (created_at lower bound from a previous watch call). */
+  cursor?: string;
+  /** Maximum events per poll (default: 10). */
+  limit?: number;
+  /** Poll interval in milliseconds (default: 1 000). */
+  intervalMs?: number;
+  /**
+   * Raw dispatch function — matches `dispatchRaw` from the CLI adapter.
+   * Injected to keep this module decoupled from the CLI layer.
+   */
+  dispatchRaw: (
+    gateway: 'mutate' | 'query',
+    domain: string,
+    operation: string,
+    params: Record<string, unknown>,
+  ) => Promise<{
+    success: boolean;
+    data?: unknown;
+    error?: { message?: string; code?: string };
+  }>;
+  /** AbortSignal for stopping the stream cleanly. */
+  signal?: AbortSignal;
+}
+
+/** A yielded item from the watch stream. */
+export type MemoryWatchYield =
+  | { kind: 'ping'; ts: string }
+  | { kind: 'events'; events: MemoryWatchEvent[]; nextCursor: string | null }
+  | { kind: 'error'; message: string; code: string }
+  | { kind: 'close'; ts: string };
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Stream brain write events as an `AsyncIterable`.
+ *
+ * Yields a `ping` item immediately, then polls `memory.watch` on every
+ * `intervalMs` tick. Yields `events` items (potentially empty) on each poll,
+ * an `error` item on dispatch failure, and a `close` item when the signal
+ * fires or the caller's `for await` loop breaks.
+ *
+ * The caller is responsible for process signal wiring and stdout emission.
+ *
+ * @param opts - Stream configuration
+ */
+export async function* streamMemoryWatchEvents(
+  opts: MemoryWatchStreamOptions,
+): AsyncIterable<MemoryWatchYield> {
+  const { cursor: initialCursor, limit, intervalMs = 1_000, dispatchRaw, signal } = opts;
+
+  // Initial ping
+  yield { kind: 'ping', ts: new Date().toISOString() };
+
+  let cursor = initialCursor;
+
+  while (!signal?.aborted) {
+    const params: Record<string, unknown> = {};
+    if (cursor !== undefined) params['cursor'] = cursor;
+    if (limit !== undefined) params['limit'] = limit;
+
+    const response = await dispatchRaw('query', 'memory', 'watch', params);
+
+    if (!response.success) {
+      yield {
+        kind: 'error',
+        message: response.error?.message ?? 'Unknown error',
+        code: response.error?.code ?? 'E_WATCH_FAILED',
+      };
+      return;
+    }
+
+    const data = response.data as {
+      events?: MemoryWatchEvent[];
+      nextCursor?: string | null;
+    };
+
+    yield {
+      kind: 'events',
+      events: data.events ?? [],
+      nextCursor: data.nextCursor ?? null,
+    };
+
+    if (typeof data.nextCursor === 'string') {
+      cursor = data.nextCursor;
+    }
+
+    if (signal?.aborted) break;
+
+    // Fixed-interval sleep — resolves early on abort
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, intervalMs);
+      timer.unref?.();
+      signal?.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+  }
+
+  yield { kind: 'close', ts: new Date().toISOString() };
+}

--- a/packages/core/src/nexus/analyze-orchestrator.ts
+++ b/packages/core/src/nexus/analyze-orchestrator.ts
@@ -1,0 +1,149 @@
+/**
+ * Nexus analyze orchestrator — business logic extracted from `cleo nexus analyze`.
+ *
+ * Runs the code-intelligence pipeline, clears the existing index for full runs,
+ * refreshes the nexus-bridge, updates the multi-project registry, and sweeps
+ * the git log for task–symbol links. All side-effects are best-effort and do
+ * not fail the pipeline on error.
+ *
+ * @module nexus/analyze-orchestrator
+ * @epic T9833
+ * @task T10062
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Parameters for {@link runNexusAnalysis}. */
+export interface NexusAnalysisParams {
+  /** Absolute path to the repository to analyze. */
+  repoPath: string;
+  /** Override the project ID (default: `base64url(repoPath).slice(0, 32)`). */
+  projectIdOverride?: string;
+  /** When true, only re-index files that changed since the last run. */
+  incremental?: boolean;
+  /**
+   * Progress callback invoked every 50 files (and on completion).
+   * Omit for JSON output mode.
+   */
+  onProgress?: (current: number, total: number, filePath: string) => void;
+}
+
+/** Result of a successful {@link runNexusAnalysis} call. */
+export interface NexusAnalysisResult {
+  projectId: string;
+  repoPath: string;
+  incremental: boolean;
+  nodeCount: number;
+  relationCount: number;
+  fileCount: number;
+  durationMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the nexus code-intelligence pipeline on a repository.
+ *
+ * This function:
+ * 1. Derives the project ID.
+ * 2. For full runs, clears the existing nexus index.
+ * 3. Runs `@cleocode/nexus` pipeline.
+ * 4. Best-effort: refreshes `nexus-bridge.md`.
+ * 5. Best-effort: updates the multi-project registry.
+ * 6. Best-effort: sweeps the git log for task–symbol links.
+ *
+ * @param params - Analysis configuration
+ * @returns Pipeline result with node/relation/file counts and duration
+ * @throws {Error} When the pipeline itself fails (best-effort steps never throw)
+ */
+export async function runNexusAnalysis(params: NexusAnalysisParams): Promise<NexusAnalysisResult> {
+  const { repoPath, projectIdOverride, incremental = false, onProgress } = params;
+
+  const startTime = Date.now();
+
+  // SSoT-EXEMPT:pipeline-progress — requires direct DB handle access and a
+  // progress callback that is CLI-only. Extracted here to keep the core
+  // runnable without the CLI layer, but the DB/pipeline imports still happen
+  // via dynamic imports so the CLI controls when heavy deps are loaded.
+  const [{ getNexusDb, nexusSchema }, { runPipeline }, { eq }] = await Promise.all([
+    import('@cleocode/core/store/nexus-sqlite' as string),
+    import('@cleocode/nexus/pipeline' as string),
+    import('drizzle-orm' as string),
+  ]);
+
+  const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
+
+  const db = await getNexusDb();
+  const tables = {
+    nexusNodes: nexusSchema.nexusNodes,
+    nexusRelations: nexusSchema.nexusRelations,
+  };
+
+  if (!incremental) {
+    try {
+      db.delete(nexusSchema.nexusNodes)
+        .where(eq(nexusSchema.nexusNodes.projectId, projectId))
+        .run();
+    } catch {
+      // table may be empty — ignore
+    }
+    try {
+      db.delete(nexusSchema.nexusRelations)
+        .where(eq(nexusSchema.nexusRelations.projectId, projectId))
+        .run();
+    } catch {
+      // table may be empty — ignore
+    }
+  }
+
+  const result = await runPipeline(repoPath, projectId, db, tables, onProgress, {
+    incremental,
+  });
+
+  // Best-effort: refresh nexus-bridge.md
+  try {
+    const { refreshNexusBridge } = await import('@cleocode/core/internal' as string);
+    await refreshNexusBridge(repoPath, projectId);
+  } catch {
+    // non-fatal
+  }
+
+  // Best-effort: update multi-project registry
+  try {
+    const { nexusUpdateIndexStats } = await import('@cleocode/core/internal' as string);
+    await nexusUpdateIndexStats(repoPath, {
+      nodeCount: result.nodeCount,
+      relationCount: result.relationCount,
+      fileCount: result.fileCount,
+    });
+  } catch {
+    // non-fatal
+  }
+
+  // Best-effort: sweep git log for task–symbol links
+  try {
+    const { runGitLogTaskLinker } = await import('@cleocode/core/nexus' as string);
+    const sweeperResult = await runGitLogTaskLinker(repoPath);
+    if (sweeperResult.commitsProcessed > 0) {
+      process.stderr.write(
+        `[nexus] Task-symbol sweep: ${sweeperResult.commitsProcessed} commit(s), ${sweeperResult.tasksFound} task(s), ${sweeperResult.linked} edge(s) linked.\n`,
+      );
+    }
+  } catch {
+    // non-fatal
+  }
+
+  return {
+    projectId,
+    repoPath,
+    incremental,
+    nodeCount: result.nodeCount,
+    relationCount: result.relationCount,
+    fileCount: result.fileCount,
+    durationMs: Date.now() - startTime,
+  };
+}

--- a/packages/core/src/nexus/export.ts
+++ b/packages/core/src/nexus/export.ts
@@ -1,0 +1,115 @@
+/**
+ * Nexus graph export — business logic extracted from `cleo nexus export`.
+ *
+ * Queries nexus.db for nodes and relations and serializes them to GEXF or
+ * JSON. The CLI handler calls {@link exportNexusGraph} and routes output to
+ * stdout or a file.
+ *
+ * @module nexus/export
+ * @epic T9833
+ * @task T10062
+ */
+
+import { generateGexf } from './gexf-export.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Output format for the graph export. */
+export type NexusExportFormat = 'gexf' | 'json';
+
+/** Options for {@link exportNexusGraph}. */
+export interface NexusExportOptions {
+  /** Serialization format (default: `'gexf'`). */
+  format?: NexusExportFormat;
+  /** When set, only nodes/relations belonging to this project are exported. */
+  projectFilter?: string;
+}
+
+/** Result of {@link exportNexusGraph}. */
+export interface NexusExportResult {
+  /** Serialized graph content (GEXF XML or JSON string). */
+  content: string;
+  /** Number of nodes included in the export. */
+  nodeCount: number;
+  /** Number of edges included in the export. */
+  edgeCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Export the nexus graph as GEXF or JSON.
+ *
+ * Queries `nexus.db` for all nodes and relations, applies an optional project
+ * filter, and serializes to the requested format.
+ *
+ * @param opts - Export options
+ * @returns Serialized content and counts
+ * @throws {Error} On unknown format or database errors
+ */
+export async function exportNexusGraph(opts: NexusExportOptions = {}): Promise<NexusExportResult> {
+  const format = opts.format ?? 'gexf';
+  const projectFilter = opts.projectFilter;
+
+  // SSoT-EXEMPT:file-serialization — requires direct nexus.db access for
+  // node/relation queries. Cannot be a LAFS dispatch op without binary data concerns.
+  const { getNexusDb, nexusSchema } = await import('@cleocode/core/store/nexus-sqlite' as string);
+  const db = await getNexusDb();
+
+  let allNodes: Array<Record<string, unknown>> = [];
+  let allRelations: Array<Record<string, unknown>> = [];
+  try {
+    allNodes = db.select().from(nexusSchema.nexusNodes).all() as Array<Record<string, unknown>>;
+    allRelations = db.select().from(nexusSchema.nexusRelations).all() as Array<
+      Record<string, unknown>
+    >;
+  } catch {
+    // DB may be empty
+  }
+
+  const nodes = projectFilter ? allNodes.filter((n) => n['projectId'] === projectFilter) : allNodes;
+  const relations = projectFilter
+    ? allRelations.filter((r) => r['projectId'] === projectFilter)
+    : allRelations;
+
+  let content: string;
+
+  if (format === 'json') {
+    content = JSON.stringify(
+      {
+        nodes: nodes.map((n) => ({
+          id: n['id'],
+          kind: n['kind'],
+          label: n['label'],
+          name: n['name'],
+          filePath: n['filePath'],
+          language: n['language'],
+          isExported: n['isExported'],
+          startLine: n['startLine'],
+          endLine: n['endLine'],
+          projectId: n['projectId'],
+        })),
+        edges: relations.map((r) => ({
+          id: r['id'],
+          source: r['sourceId'],
+          target: r['targetId'],
+          type: r['type'],
+          confidence: r['confidence'],
+          reason: r['reason'],
+        })),
+      },
+      null,
+      2,
+    );
+  } else if (format === 'gexf') {
+    content = generateGexf(nodes, relations);
+  } else {
+    throw new Error(`Unknown format '${format}'. Supported: gexf, json`);
+  }
+
+  return { content, nodeCount: nodes.length, edgeCount: relations.length };
+}

--- a/packages/core/src/nexus/wiki-orchestrator.ts
+++ b/packages/core/src/nexus/wiki-orchestrator.ts
@@ -1,0 +1,104 @@
+/**
+ * Nexus wiki orchestrator — business logic extracted from `cleo nexus wiki`.
+ *
+ * Resolves the LOOM provider (if available), then delegates to
+ * `generateNexusWikiIndex`. The CLI handler calls {@link runNexusWiki} and
+ * emits the LAFS envelope.
+ *
+ * @module nexus/wiki-orchestrator
+ * @epic T9833
+ * @task T10062
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for {@link runNexusWiki}. */
+export interface NexusWikiOptions {
+  /** Absolute path to the project root. */
+  projectRoot: string;
+  /** Output directory for generated wiki files (default: `<projectRoot>/.cleo/wiki`). */
+  outputDir?: string;
+  /** When set, restrict generation to a single community ID. */
+  communityFilter?: string;
+  /** Only regenerate communities whose symbols changed since the last wiki run. */
+  incremental?: boolean;
+}
+
+/** Result of a successful {@link runNexusWiki} call. */
+export interface NexusWikiResult {
+  success: boolean;
+  error?: string;
+  outputDir: string;
+  durationMs: number;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate the community-grouped wiki index from the nexus code graph.
+ *
+ * Attempts to wire a LOOM provider via `resolveLlmBackend('warm')` for
+ * LLM-driven narratives; falls back to scaffold mode when no backend is
+ * available. All LOOM resolution errors are swallowed — the wiki always runs.
+ *
+ * @param opts - Wiki generation options
+ * @returns Result envelope forwarded from `generateNexusWikiIndex`
+ * @throws {Error} When `generateNexusWikiIndex` throws
+ */
+export async function runNexusWiki(opts: NexusWikiOptions): Promise<NexusWikiResult> {
+  const { projectRoot, communityFilter, incremental = false } = opts;
+
+  const { join } = await import('node:path');
+  const outputDir = opts.outputDir ?? join(projectRoot, '.cleo', 'wiki');
+
+  const startTime = Date.now();
+
+  // SSoT-EXEMPT:loom-provider — LLM backend resolution for wiki generation
+  // requires CLI-side async provider wiring that cannot be passed through the
+  // dispatch layer. The dispatch 'wiki' op always uses loomProvider=null.
+  let loomProvider: ((prompt: string) => Promise<string>) | null = null;
+  try {
+    const { resolveLlmBackend } = await import('@cleocode/core/memory/llm-backend-resolver.js');
+    const backend = await resolveLlmBackend('warm');
+    if (backend !== null && backend.name !== 'transformers') {
+      loomProvider = async (prompt: string): Promise<string> => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const aiMod = await import('ai' as string);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        const generateTextFn = aiMod.generateText as (opts: {
+          model: unknown;
+          prompt: string;
+          maxTokens: number;
+        }) => Promise<{ text: string }>;
+        const { text } = await generateTextFn({
+          model: backend.model,
+          prompt,
+          maxTokens: 256,
+        });
+        return text;
+      };
+    }
+  } catch {
+    // LOOM unavailable — scaffold mode
+    loomProvider = null;
+  }
+
+  const { generateNexusWikiIndex } = await import('@cleocode/core/nexus/wiki-index.js' as string);
+  const result = await generateNexusWikiIndex(outputDir, projectRoot, {
+    communityFilter,
+    incremental,
+    loomProvider,
+    projectRoot,
+  });
+
+  return {
+    ...result,
+    outputDir,
+    durationMs: Date.now() - startTime,
+  };
+}


### PR DESCRIPTION
## Summary

- **8 core modules created** in `packages/core/src/{agents,nexus,memory}/`, each containing the business logic extracted from fat CLI handlers in `packages/cleo/src/cli/commands/{agent,nexus,memory}.ts`
- **3 CLI command files reduced** to thin dispatch wrappers using handler-toolkit primitives + new core APIs
- **~480 LOC persona templates** moved from agent.ts to `packages/core/src/agents/scaffold.ts`
- Zero behavior change — all extractions preserve identical runtime behavior

### Extractions (T10062 acceptance criteria)

| Core module | Extracted from |
|---|---|
| `agents/work-loop.ts` | `agent.ts:workCommand` — parseLafs, runCleo, conductor-loop |
| `agents/scaffold.ts` | `agent.ts:createCommand` + 480 LOC persona templates |
| `agents/install-pipeline.ts` | `agent.ts:installCommand` — path resolution + cleanup |
| `nexus/analyze-orchestrator.ts` | `nexus.ts:analyzeCommand` — pipeline + bridge + registry + sweeper |
| `nexus/export.ts` | `nexus.ts:exportCommand` — GEXF/JSON serialization |
| `nexus/wiki-orchestrator.ts` | `nexus.ts:wikiCommand` — LOOM provider wiring |
| `memory/import-from-provider.ts` | `memory.ts:importCommand` — frontmatter parse + hash dedup |
| `memory/watch-stream.ts` | `memory.ts:watchCommand --follow` — AsyncIterable SSE stream |

## Test plan

- [x] `pnpm biome check --write .` — clean (no errors)
- [x] `pnpm run build` — Build complete
- [x] Core/cleo test failures confirmed pre-existing (stash verified: `precompact-flush`, `wiki-index`, `query.getCurrentProject` fail on baseline branch)
- [x] No new test failures introduced

Task T10062 / Epic T9833 / Saga T9831