### PR TITLE
feat(T10071): describe-schema SDK tool (T9835d — Saga T9831)

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -275,7 +275,7 @@ export { CANONICAL_DOMAINS } from './dispatch/identity.js';
 // === Dispatch OperationDef + Resolution (T9954 — Phase 0b of SG-ARCH-SOLID / E-CONTRACTS-FOUNDATION) ===
 export type { OperationDef, Resolution } from './dispatch/operation-def.js';
 // === Dispatch OPERATIONS data + builder helpers (T10061 — T9833b / E-CLI-BOUNDARY / SG-ARCH-SOLID) ===
-export { OPERATIONS, defineOp, defineDomain } from './dispatch/operations-registry.js';
+export { defineDomain, defineOp, OPERATIONS } from './dispatch/operations-registry.js';
 // === DocsAccessor Contracts (T9063) ===
 export type {
   DocExportFormat,
@@ -1741,6 +1741,12 @@ export type {
   CriticalPathNode,
   CriticalPathResult,
 } from './tools/compute-critical-path.js';
+export type {
+  SchemaColumn,
+  SchemaDescriptor,
+  SchemaIndex,
+  SchemaTableDescriptor,
+} from './tools/describe-schema.js';
 export type { RenderTaskTreeInput } from './tools/render-task-tree.js';
 export type {
   ScoreFactor,

--- a/packages/contracts/src/tools/describe-schema.ts
+++ b/packages/contracts/src/tools/describe-schema.ts
@@ -1,0 +1,43 @@
+/**
+ * Contract types for the describeSchema SDK tool.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, pure-functional
+ * @task T10071
+ * @epic T9835
+ */
+
+/** A single column in a table descriptor. */
+export interface SchemaColumn {
+  /** Column name as declared in the drizzle schema. */
+  name: string;
+  /** SQLite data type (e.g. "TEXT", "INTEGER", "REAL", "BLOB"). */
+  type: string;
+  /** True when the column has a NOT NULL constraint. */
+  notNull: boolean;
+  /** True when the column is part of the primary key. */
+  primaryKey: boolean;
+}
+
+/** A single index in a table descriptor. */
+export interface SchemaIndex {
+  /** Index name as declared in the drizzle schema. */
+  name: string;
+  /** True when the index enforces uniqueness. */
+  unique: boolean;
+}
+
+/** Descriptor for one database table. */
+export interface SchemaTableDescriptor {
+  /** Table name as stored in SQLite (snake_case). */
+  name: string;
+  /** Ordered list of column descriptors. */
+  columns: SchemaColumn[];
+  /** List of indexes defined on this table (may be empty). */
+  indexes: SchemaIndex[];
+}
+
+/** Full output of describeSchema — all tables in the drizzle schema. */
+export interface SchemaDescriptor {
+  /** One entry per drizzle table exported from the schema barrel. */
+  tables: SchemaTableDescriptor[];
+}

--- a/packages/contracts/src/tools/index.ts
+++ b/packages/contracts/src/tools/index.ts
@@ -16,6 +16,12 @@ export type {
   CriticalPathNode,
   CriticalPathResult,
 } from './compute-critical-path.js';
+export type {
+  SchemaColumn,
+  SchemaDescriptor,
+  SchemaIndex,
+  SchemaTableDescriptor,
+} from './describe-schema.js';
 export type { RenderTaskTreeInput } from './render-task-tree.js';
 export type {
   ScoreFactor,

--- a/packages/core/src/tools/__tests__/task-tools/describe-schema.test.ts
+++ b/packages/core/src/tools/__tests__/task-tools/describe-schema.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { describeSchema, describeSchemaRegistered } from '../../task-tools/describe-schema.js';
+
+describe('describeSchema', () => {
+  it('returns at least 10 tables', () => {
+    const { tables } = describeSchema();
+    expect(tables.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('tables are sorted alphabetically by name', () => {
+    const { tables } = describeSchema();
+    const names = tables.map((t) => t.name);
+    expect(names).toEqual([...names].sort());
+  });
+
+  it('snapshot — tasks table shape', () => {
+    const { tables } = describeSchema();
+    const tasks = tables.find((t) => t.name === 'tasks');
+    expect(tasks).toBeDefined();
+
+    const idCol = tasks!.columns.find((c) => c.name === 'id');
+    expect(idCol).toMatchObject({ name: 'id', primaryKey: true, notNull: true });
+
+    const titleCol = tasks!.columns.find((c) => c.name === 'title');
+    expect(titleCol).toMatchObject({ name: 'title', notNull: true });
+
+    const statusCol = tasks!.columns.find((c) => c.name === 'status');
+    expect(statusCol).toMatchObject({ name: 'status', notNull: true });
+
+    expect(tasks!.indexes.length).toBeGreaterThan(0);
+    const indexNames = tasks!.indexes.map((i) => i.name);
+    expect(indexNames).toContain('idx_tasks_status');
+    expect(indexNames).toContain('idx_tasks_priority');
+  });
+
+  it('snapshot — sessions table shape', () => {
+    const { tables } = describeSchema();
+    const sessions = tables.find((t) => t.name === 'sessions');
+    expect(sessions).toBeDefined();
+
+    const idCol = sessions!.columns.find((c) => c.name === 'id');
+    expect(idCol).toMatchObject({ name: 'id', primaryKey: true, notNull: true });
+
+    expect(sessions!.columns.map((c) => c.name)).toContain('status');
+    expect(sessions!.columns.map((c) => c.name)).toContain('started_at');
+  });
+
+  it('snapshot — lifecycle_pipelines table shape', () => {
+    const { tables } = describeSchema();
+    const lp = tables.find((t) => t.name === 'lifecycle_pipelines');
+    expect(lp).toBeDefined();
+
+    const idCol = lp!.columns.find((c) => c.name === 'id');
+    expect(idCol).toMatchObject({ name: 'id', primaryKey: true, notNull: true });
+
+    expect(lp!.columns.map((c) => c.name)).toContain('task_id');
+    expect(lp!.columns.map((c) => c.name)).toContain('status');
+  });
+
+  it('all columns have non-empty name and type', () => {
+    const { tables } = describeSchema();
+    for (const table of tables) {
+      for (const col of table.columns) {
+        expect(col.name.length).toBeGreaterThan(0);
+        expect(col.type.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('registered tool identity matches', () => {
+    expect(describeSchemaRegistered.identity.name).toBe('describe-schema');
+    expect(describeSchemaRegistered.identity.version).toBe('1.0.0');
+  });
+
+  it('registered tool invoke returns same result as describeSchema()', () => {
+    const direct = describeSchema();
+    const viaRegistered = describeSchemaRegistered.invoke({});
+    expect(viaRegistered).toEqual(direct);
+  });
+});

--- a/packages/core/src/tools/task-tools/describe-schema.ts
+++ b/packages/core/src/tools/task-tools/describe-schema.ts
@@ -1,0 +1,179 @@
+/**
+ * describeSchema — pure-functional SDK tool that returns a JSON descriptor of
+ * all drizzle tables and their columns, sourced from the tasks-schema barrel.
+ *
+ * This is a Category B SDK Tool: harness-agnostic, no I/O, no database
+ * connection required. The drizzle schema objects are introspected statically
+ * via `getTableColumns` and the internal `ExtraConfigBuilder` symbol.
+ *
+ * @arch SDK Tool (Category B) — T10071 / Epic T9835 / Saga T9831
+ * @task T10071
+ *
+ * @example
+ * ```typescript
+ * import { describeSchema } from './describe-schema.js';
+ *
+ * const descriptor = describeSchema();
+ * console.log(descriptor.tables.map((t) => t.name));
+ * // => ['tasks', 'task_dependencies', 'sessions', ...]
+ *
+ * const tasksCols = descriptor.tables.find((t) => t.name === 'tasks')?.columns;
+ * console.log(tasksCols?.map((c) => c.name));
+ * // => ['id', 'title', 'status', ...]
+ * ```
+ */
+
+import type {
+  SchemaColumn,
+  SchemaDescriptor,
+  SchemaIndex,
+  SchemaTableDescriptor,
+} from '@cleocode/contracts';
+import type { Column, Table } from 'drizzle-orm';
+import { getTableColumns, getTableName } from 'drizzle-orm';
+import * as schema from '../../store/schema/index.js';
+import { defineSdkTool } from './sdk-tool.js';
+
+/** Internal drizzle symbol that holds the extra-config builder (indexes, checks, FKs). */
+const ExtraConfigBuilder = Symbol.for('drizzle:ExtraConfigBuilder');
+
+/** Narrow IndexBuilder interface — only the runtime fields we need. */
+interface IndexBuilderRuntime {
+  config: {
+    name: string;
+    unique: boolean;
+  };
+}
+
+function isTable(value: unknown): value is Table {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    Symbol.for('drizzle:IsDrizzleTable') in (value as Record<symbol, unknown>)
+  );
+}
+
+function isIndexBuilder(value: unknown): value is IndexBuilderRuntime {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'config' in (value as object) &&
+    typeof (value as IndexBuilderRuntime).config?.name === 'string'
+  );
+}
+
+/** Drizzle table extended with internal ExtraConfigBuilder symbol. */
+interface TableWithExtraConfig {
+  [ExtraConfigBuilder]?: (cols: Record<string, Column>) => unknown;
+}
+
+/** Extract index descriptors from a drizzle table's ExtraConfigBuilder. */
+function extractIndexes(table: Table & TableWithExtraConfig): SchemaIndex[] {
+  const builder = table[ExtraConfigBuilder];
+  if (typeof builder !== 'function') return [];
+
+  const columns = getTableColumns(table);
+  let rawConfig: unknown;
+  try {
+    rawConfig = builder(columns);
+  } catch {
+    return [];
+  }
+
+  const entries: unknown[] = Array.isArray(rawConfig)
+    ? rawConfig
+    : typeof rawConfig === 'object' && rawConfig !== null
+      ? Object.values(rawConfig)
+      : [];
+
+  const indexes: SchemaIndex[] = [];
+  for (const entry of entries) {
+    if (isIndexBuilder(entry)) {
+      indexes.push({ name: entry.config.name, unique: entry.config.unique ?? false });
+    }
+  }
+  return indexes;
+}
+
+/** Build a full table descriptor from a drizzle table object. */
+function describeTable(table: Table & TableWithExtraConfig): SchemaTableDescriptor {
+  const name = getTableName(table);
+  const rawColumns = getTableColumns(table);
+
+  const columns: SchemaColumn[] = Object.values(rawColumns).map((col) => ({
+    name: col.name,
+    type: col.getSQLType(),
+    notNull: col.notNull,
+    primaryKey: col.primary,
+  }));
+
+  const indexes = extractIndexes(table);
+
+  return { name, columns, indexes };
+}
+
+/**
+ * Return a static JSON descriptor of all drizzle tables in the tasks schema.
+ *
+ * No database connection is required — introspection is performed on the
+ * drizzle table objects exported from `packages/core/src/store/schema/`.
+ *
+ * @returns SchemaDescriptor with one entry per drizzle table
+ *
+ * @example
+ * ```typescript
+ * const { tables } = describeSchema();
+ * const tasksTable = tables.find((t) => t.name === 'tasks');
+ * // => { name: 'tasks', columns: [...], indexes: [...] }
+ * ```
+ */
+export function describeSchema(): SchemaDescriptor {
+  const tables: SchemaTableDescriptor[] = [];
+
+  for (const value of Object.values(schema)) {
+    if (isTable(value)) {
+      tables.push(describeTable(value as Table & TableWithExtraConfig));
+    }
+  }
+
+  tables.sort((a, b) => a.name.localeCompare(b.name));
+
+  return { tables };
+}
+
+/**
+ * Registered SDK tool wrapping describeSchema for external discovery.
+ *
+ * @example
+ * ```typescript
+ * import { describeSchemaRegistered } from './describe-schema.js';
+ * const result = describeSchemaRegistered.invoke({});
+ * ```
+ */
+export const describeSchemaRegistered = defineSdkTool<Record<string, never>, SchemaDescriptor>({
+  identity: {
+    name: 'describe-schema',
+    description: 'Returns a JSON descriptor of all drizzle tables and columns in the tasks schema.',
+    version: '1.0.0',
+  },
+  inputSchema: { type: 'object', properties: {}, required: [] },
+  outputSchema: {
+    type: 'object',
+    properties: {
+      tables: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            columns: { type: 'array', items: { type: 'object' } },
+            indexes: { type: 'array', items: { type: 'object' } },
+          },
+          required: ['name', 'columns', 'indexes'],
+        },
+      },
+    },
+    required: ['tables'],
+  },
+  fn: () => describeSchema(),
+});

--- a/packages/core/src/tools/task-tools/index.ts
+++ b/packages/core/src/tools/task-tools/index.ts
@@ -18,6 +18,7 @@
 
 export { buildTaskTree } from './build-task-tree.js';
 export { computeCriticalPath } from './compute-critical-path.js';
+export { describeSchema, describeSchemaRegistered } from './describe-schema.js';
 export { renderTaskTreeMermaid, renderTaskTreeText } from './render-task-tree.js';
 export { scoreTask } from './score-task-priority.js';
 export type { JsonSchema, RegisteredSdkTool, SdkToolSpec } from './sdk-tool.js';


### PR DESCRIPTION
## Summary

- Implements `describeSchema()` — a pure-functional SDK tool (Category B) that returns a JSON descriptor of all drizzle tables and columns from the tasks schema barrel
- No database connection required; introspection via `getTableColumns` + internal `ExtraConfigBuilder` symbol for indexes
- `SchemaDescriptor`, `SchemaColumn`, `SchemaIndex`, `SchemaTableDescriptor` types added to `@cleocode/contracts`
- `describeSchemaRegistered` wraps the function with `defineSdkTool` for external discovery
- 8 vitest assertions covering `tasks`, `sessions`, `lifecycle_pipelines` tables + column/index invariants + registered tool

## Depends On

- T10065 (schema split) — merged to main ✓
- T10068 (sdk-tool factory) — merged to main ✓

## Test plan

- [ ] `pnpm biome check --write .` — no violations
- [ ] `pnpm run build` — Build complete
- [ ] `pnpm exec vitest run src/tools/__tests__/task-tools/describe-schema.test.ts` — 8/8 pass

## Files Changed

- `packages/contracts/src/tools/describe-schema.ts` — new: SchemaDescriptor types
- `packages/contracts/src/tools/index.ts` — re-export new types
- `packages/contracts/src/index.ts` — re-export new types
- `packages/core/src/tools/task-tools/describe-schema.ts` — new: describeSchema() + describeSchemaRegistered
- `packages/core/src/tools/task-tools/index.ts` — export new functions
- `packages/core/src/tools/__tests__/task-tools/describe-schema.test.ts` — new: 8 tests

Task T10071 / Epic T9835 / Saga T9831

🤖 Generated with [Claude Code](https://claude.com/claude-code)