### PR TITLE
fix: caamp @types/node version match

### DIFF
--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -84,7 +84,7 @@
     "@biomejs/biome": "2.4.11",
     "@forge-ts/cli": "0.23.0",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^24.3.0",
+    "@types/node": "25.5.0",
     "@vitest/coverage-v8": "^4.1.4",
     "env-paths": "^4.0.0",
     "tsup": "^8.5.0",


### PR DESCRIPTION
Follow-up hotfix to #480 — caamp @types/node should be 25.5.0 (matching lockfile), not ^24.3.0.