### PR TITLE
chore(T9979): Bump Rust toolchain to 1.94 workspace-wide

### DIFF
--- a/.changeset/t9979-rust-194-toolchain-bump.md
+++ b/.changeset/t9979-rust-194-toolchain-bump.md
@@ -1,0 +1,13 @@
+---
+"@cleocode/cleo": patch
+---
+
+chore(T9979): bump Rust toolchain to 1.94 workspace-wide
+
+Workspace-wide bump from 1.88 → 1.94 to unblock Saga T9977 SG-WORKTRUNK-OWN
+(donor worktrunk requires 1.94). Updates rust-toolchain.toml, per-crate
+rust-version fields, regenerates Cargo.lock, updates CI matrix.
+
+Saga: T9977
+Decision: D010
+Closes: T9994, T9995, T9996, T9997, T9998

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 version = "2026.5.99"
-rust-version = "1.88"
+rust-version = "1.94"
 
 [workspace.dependencies]
 # Async runtime
@@ -150,7 +150,7 @@ expect_used = "deny"
 name = "cleocode-workspace"
 version = "2026.5.99"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 
 [lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/crates/cant-core/Cargo.toml
+++ b/crates/cant-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cant-core"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Canonical CANT grammar parser for CLEO ecosystem"
 
 [lib]

--- a/crates/cant-lsp/Cargo.toml
+++ b/crates/cant-lsp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cant-lsp"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Language Server Protocol implementation for CANT DSL"
 
 [[bin]]

--- a/crates/cant-napi/Cargo.toml
+++ b/crates/cant-napi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cant-napi"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "napi-rs bindings for cant-core CANT parser"
 
 [lib]

--- a/crates/cant-router/Cargo.toml
+++ b/crates/cant-router/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cant-router"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "CleoOS v2 model router — 3-layer classifier + router + pipeline"
 
 [lib]

--- a/crates/cant-runtime/Cargo.toml
+++ b/crates/cant-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cant-runtime"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "CANT DSL runtime - pipeline executor"
 
 [lib]

--- a/crates/cleo-llm-native/Cargo.toml
+++ b/crates/cleo-llm-native/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cleo-llm-native"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "napi-rs bindings for CLEO LLM hot-path operations (think-scrubber, rate-limit-guard)"
 
 [lib]

--- a/crates/conduit-core/Cargo.toml
+++ b/crates/conduit-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "conduit-core"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Canonical Conduit wire types for CLEO ecosystem"
 
 [lib]

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "integration-tests"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Integration tests for the CLEO Rust crate ecosystem"
 publish = false
 

--- a/crates/lafs-core/Cargo.toml
+++ b/crates/lafs-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lafs-core"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Canonical LAFS envelope types and validation for CLEO ecosystem"
 
 [lib]

--- a/crates/lafs-napi/Cargo.toml
+++ b/crates/lafs-napi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lafs-napi"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "napi-rs bindings for lafs-core schema validation"
 
 [lib]

--- a/crates/signaldock-core/Cargo.toml
+++ b/crates/signaldock-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signaldock-core"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Shared domain types for the SignalDock agent messaging platform"
 
 [lib]

--- a/crates/signaldock-payments/Cargo.toml
+++ b/crates/signaldock-payments/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signaldock-payments"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "x402 payment protocol for SignalDock agent services"
 publish = false
 

--- a/crates/signaldock-protocol/Cargo.toml
+++ b/crates/signaldock-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signaldock-protocol"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Thin re-export layer over canonical cleocode crates + server-specific error types"
 publish = false
 

--- a/crates/signaldock-runtime/Cargo.toml
+++ b/crates/signaldock-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signaldock-runtime"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Universal agent connector for SignalDock — 2-step install for any agent on any platform"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/CleoAgent/signaldock-runtime"

--- a/crates/signaldock-sdk/Cargo.toml
+++ b/crates/signaldock-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signaldock-sdk"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Service layer and delivery orchestration for SignalDock"
 publish = false
 

--- a/crates/signaldock-storage/Cargo.toml
+++ b/crates/signaldock-storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signaldock-storage"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Storage traits and Diesel database adapters (SQLite + PostgreSQL) for SignalDock"
 publish = false
 

--- a/crates/signaldock-transport/Cargo.toml
+++ b/crates/signaldock-transport/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signaldock-transport"
 version.workspace = true
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Transport traits and delivery adapters (SSE, Webhook, WebSocket, HTTP/2) for SignalDock"
 publish = false
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.94.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Bundles T9994-T9998 into one PR per Saga T9977 plan. Unblocks E3 worktrunk-core vendoring (donor requires 1.94).

## Changes
- `rust-toolchain.toml`: 1.88.0 -> 1.94.0
- Per-crate `rust-version`: bumped to 1.94 (17 crates touched + workspace root)
- `Cargo.lock`: regenerated (no diff — deps already compatible)
- CI workflows: no edits required (no explicit Rust pin found; workflows read `rust-toolchain.toml`)

## Verification (local)
- `cargo check --workspace` clean under 1.94
- `cargo build --workspace` clean under 1.94
- `cargo build --release -p cant-napi -p lafs-napi` clean
- `pnpm run build` clean (full TS + esbuild + napi-rs)
- Only pre-existing warnings (missing-docs in `signaldock-storage::schema`)

## Saga/Decision
- Saga: T9977 SG-WORKTRUNK-OWN
- Decision: D010 (vendor worktrunk + Rust 1.94 workspace-wide)
- Closes: T9994 T9995 T9996 T9997 T9998

## Test plan
- [x] cargo build --workspace clean on Linux
- [ ] CI matrix green (Linux + macOS + Windows)