### PR TITLE
fix(T10177)!: release-prepare.yml scoped to @cleocode/* workspaces

### DIFF
--- a/.changeset/t10177-release-prepare-fix.md
+++ b/.changeset/t10177-release-prepare-fix.md
@@ -1,0 +1,21 @@
+---
+"@cleocode/cleo": patch
+---
+
+fix(T10177)!: release-prepare.yml scoped to @cleocode/* workspaces (SAGA T10176)
+
+Makes the v5.101 surgical revert (commit d26b76751) permanent. release-prepare.yml
+now only bumps @cleocode/* workspace versions — external deps (tree-sitter,
+drizzle-orm, @forge-ts/cli, @biomejs/biome, @types/node, typedoc, simple-git,
+etc.) are never touched.
+
+- Extract bump logic from inline jq into scripts/bump-workspace-deps.mjs (testable).
+- Filter is now key-based (key starts with `@cleocode/`) instead of the previous
+  value-based "starts with a digit" heuristic that ate 10 externals in v5.100.
+- Add scripts/__tests__/bump-workspace-deps.test.mjs (21 regression cases) covering
+  every external dep the v5.100 workflow bumped + every @cleocode/* ref-shape.
+- Reattach scripts/__tests__/*.test.mjs to the vitest workspace via a dedicated
+  `scripts` project; previously these tests silently dropped out of CI shards
+  after T9079 switched to projects-mode.
+- Add `(strict mode)` label to lint-cli-package-boundary fail banner (latent
+  T10076 test now exercised by the re-attached scripts project).

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -125,19 +125,13 @@ jobs:
         env:
           VERSION_BARE: ${{ steps.version.outputs.version_bare }}
         run: |
-          # Update any @cleocode/* dep pinned to a specific numeric version
-          # (not workspace:* -- those are handled by pnpm at publish time).
-          for PKG_JSON in packages/*/package.json; do
-            updated=$(jq --arg v "$VERSION_BARE" '
-              def bump_if_numeric:
-                if . and (test("^[0-9]")) then $v else . end;
-              (if has("dependencies") then .dependencies |= with_entries(.value |= bump_if_numeric) else . end) |
-              (if has("devDependencies") then .devDependencies |= with_entries(.value |= bump_if_numeric) else . end) |
-              (if has("peerDependencies") then .peerDependencies |= with_entries(.value |= bump_if_numeric) else . end)
-            ' "$PKG_JSON")
-            echo "$updated" > "$PKG_JSON"
-          done
-          echo "Workspace @cleocode/* numeric dep refs updated"
+          # Only @cleocode/* numeric pins move -- external deps (tree-sitter,
+          # drizzle-orm, @forge-ts/*, @biomejs/*, @types/*, etc.) are NEVER
+          # touched. This is the permanent fix for the v2026.5.100 / v2026.5.101
+          # regression that scoped bumps by "value starts with a digit" instead
+          # of "key starts with @cleocode/". See T10177 / surgical revert
+          # commit d26b76751 / SAGA T10176.
+          node scripts/bump-workspace-deps.mjs --version "$VERSION_BARE"
 
       - name: Bump Cargo.toml workspace version
         env:

--- a/scripts/__tests__/bump-workspace-deps.test.mjs
+++ b/scripts/__tests__/bump-workspace-deps.test.mjs
@@ -1,0 +1,316 @@
+/**
+ * Regression tests for scripts/bump-workspace-deps.mjs (T10177).
+ *
+ * Critical guarantee under test: the release-prepare workflow's "Bump workspace
+ * @cleocode/* dependency refs" step MUST only touch keys matching @cleocode/*.
+ * External deps (tree-sitter, drizzle-orm, @forge-ts/cli, @biomejs/biome,
+ * @types/node, typedoc, simple-git, etc.) MUST be left exactly as written —
+ * regardless of whether their pinned value starts with a digit.
+ *
+ * Background: in v2026.5.100 the in-workflow jq filter bumped 10 external deps
+ * to the workspace CalVer version. PR #480/#481 reverted them. v2026.5.101 hit
+ * the same bug again (surgical revert at commit d26b76751). T10177 entrenches
+ * the fix by extracting the bump logic to this script + tests.
+ *
+ * Strategy:
+ *   - Build a synthetic monorepo under a tmpdir with the exact pathological
+ *     deps the workflow ate in v5.100 (tree-sitter@0.21.1, drizzle-orm@0.30.0,
+ *     @forge-ts/cli@^0.4.0, @types/node@^22.0.0).
+ *   - Also pin synthetic @cleocode/* numeric deps that MUST move.
+ *   - Run the script via both the API surface (bumpWorkspaceDeps) and the CLI
+ *     surface (node scripts/bump-workspace-deps.mjs --version --root ...).
+ *   - Assert ZERO external dep movement and EXACT @cleocode/* dep movement.
+ *
+ * @task T10177
+ * @saga T10176
+ * @decision D010
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { bumpWorkspaceDeps, rewriteDepMap, shouldBump } from '../bump-workspace-deps.mjs';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+const REPO_ROOT = resolve(__dirname, '../..');
+const SCRIPT_PATH = resolve(REPO_ROOT, 'scripts/bump-workspace-deps.mjs');
+
+/** Build a synthetic monorepo. Returns the tmpdir root. */
+function buildFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'bump-deps-test-'));
+  mkdirSync(join(root, 'packages'), { recursive: true });
+
+  // packages/alpha — has the v5.100 pathological external deps + valid @cleocode/* deps.
+  mkdirSync(join(root, 'packages/alpha'), { recursive: true });
+  writeFileSync(
+    join(root, 'packages/alpha/package.json'),
+    `${JSON.stringify(
+      {
+        name: '@cleocode/alpha',
+        version: '2026.5.99',
+        dependencies: {
+          // External deps that v5.100 ate (must NOT bump):
+          'tree-sitter': '0.21.1',
+          'tree-sitter-c': '0.23.2',
+          'tree-sitter-python': '0.23.4',
+          'tree-sitter-rust': '0.23.1',
+          'tree-sitter-cpp': '^0.23.4',
+          'drizzle-orm': '0.30.0',
+          'simple-git': '^3.20.0',
+          '@forge-ts/cli': '^0.4.0',
+          '@biomejs/biome': '^1.9.0',
+          '@types/node': '^22.0.0',
+          typedoc: '^0.26.0',
+          '@aflsolutions/graphology-communities-leiden': '0.1.0',
+          // Workspace refs (must remain workspace:*):
+          '@cleocode/core': 'workspace:*',
+          '@cleocode/contracts': 'workspace:*',
+          // file: refs (must NOT bump):
+          '@cleocode/worktree-napi': 'file:../../crates/worktree-napi',
+          // Numeric @cleocode/* deps (MUST bump to new version):
+          '@cleocode/legacy-numeric': '2026.5.99',
+          '@cleocode/legacy-caret': '^2026.4.13',
+        },
+        devDependencies: {
+          // External (must NOT bump):
+          vitest: '^2.0.0',
+          // Numeric @cleocode/* (MUST bump):
+          '@cleocode/dev-tool': '2026.5.99',
+        },
+        peerDependencies: {
+          // Numeric @cleocode/* (MUST bump):
+          '@cleocode/peer': '2026.5.99',
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  // packages/beta — workspace-only, nothing to bump.
+  mkdirSync(join(root, 'packages/beta'), { recursive: true });
+  writeFileSync(
+    join(root, 'packages/beta/package.json'),
+    `${JSON.stringify(
+      {
+        name: '@cleocode/beta',
+        version: '2026.5.99',
+        dependencies: { '@cleocode/core': 'workspace:*' },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  // packages/gamma — empty package.json with only name+version, no deps section.
+  mkdirSync(join(root, 'packages/gamma'), { recursive: true });
+  writeFileSync(
+    join(root, 'packages/gamma/package.json'),
+    `${JSON.stringify({ name: '@cleocode/gamma', version: '2026.5.99' }, null, 2)}\n`,
+  );
+
+  return root;
+}
+
+describe('shouldBump (T10177 — unit-level guard)', () => {
+  it('returns true for @cleocode/* with bare CalVer value', () => {
+    expect(shouldBump('@cleocode/core', '2026.5.99')).toBe(true);
+  });
+
+  it('returns true for @cleocode/* with caret-pinned value', () => {
+    expect(shouldBump('@cleocode/core', '^2026.5.99')).toBe(true);
+  });
+
+  it('returns false for @cleocode/* with workspace:* value', () => {
+    expect(shouldBump('@cleocode/core', 'workspace:*')).toBe(false);
+  });
+
+  it('returns false for @cleocode/* with file: ref', () => {
+    expect(shouldBump('@cleocode/worktree-napi', 'file:../../crates/worktree-napi')).toBe(false);
+  });
+
+  it('returns false for tree-sitter@0.21.1 (the v5.100 bug class)', () => {
+    expect(shouldBump('tree-sitter', '0.21.1')).toBe(false);
+  });
+
+  it('returns false for drizzle-orm@0.30.0', () => {
+    expect(shouldBump('drizzle-orm', '0.30.0')).toBe(false);
+  });
+
+  it('returns false for @forge-ts/cli (different scope)', () => {
+    expect(shouldBump('@forge-ts/cli', '^0.4.0')).toBe(false);
+  });
+
+  it('returns false for @types/node', () => {
+    expect(shouldBump('@types/node', '^22.0.0')).toBe(false);
+  });
+
+  it('returns false for @biomejs/biome', () => {
+    expect(shouldBump('@biomejs/biome', '^1.9.0')).toBe(false);
+  });
+
+  it('returns false for non-string inputs', () => {
+    expect(shouldBump(null, '2026.5.99')).toBe(false);
+    expect(shouldBump('@cleocode/x', null)).toBe(false);
+  });
+});
+
+describe('rewriteDepMap (T10177 — section-level guard)', () => {
+  it('rewrites only @cleocode/* numeric refs, leaving externals untouched', () => {
+    const map = {
+      '@cleocode/core': '2026.5.99',
+      '@cleocode/api': '^2026.4.13',
+      '@cleocode/runtime': 'workspace:*',
+      'tree-sitter': '0.21.1',
+      'drizzle-orm': '0.30.0',
+      '@forge-ts/cli': '^0.4.0',
+    };
+    const changes = rewriteDepMap(map, '2026.5.100');
+    expect(changes).toEqual([
+      { key: '@cleocode/core', from: '2026.5.99', to: '2026.5.100' },
+      { key: '@cleocode/api', from: '^2026.4.13', to: '2026.5.100' },
+    ]);
+    expect(map).toEqual({
+      '@cleocode/core': '2026.5.100',
+      '@cleocode/api': '2026.5.100',
+      '@cleocode/runtime': 'workspace:*',
+      'tree-sitter': '0.21.1',
+      'drizzle-orm': '0.30.0',
+      '@forge-ts/cli': '^0.4.0',
+    });
+  });
+
+  it('is a no-op on empty / missing dep map', () => {
+    expect(rewriteDepMap({}, '2026.5.99')).toEqual([]);
+    expect(rewriteDepMap(null, '2026.5.99')).toEqual([]);
+    expect(rewriteDepMap(undefined, '2026.5.99')).toEqual([]);
+  });
+});
+
+describe('bumpWorkspaceDeps (T10177 — integration against synthetic monorepo)', () => {
+  /** @type {string} */
+  let fixtureRoot;
+
+  beforeEach(() => {
+    fixtureRoot = buildFixture();
+  });
+
+  afterEach(() => {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it('leaves ALL external deps untouched on alpha', async () => {
+    await bumpWorkspaceDeps({ version: '2026.6.1', root: fixtureRoot });
+    const alpha = JSON.parse(
+      readFileSync(join(fixtureRoot, 'packages/alpha/package.json'), 'utf8'),
+    );
+    expect(alpha.dependencies['tree-sitter']).toBe('0.21.1');
+    expect(alpha.dependencies['tree-sitter-c']).toBe('0.23.2');
+    expect(alpha.dependencies['tree-sitter-python']).toBe('0.23.4');
+    expect(alpha.dependencies['tree-sitter-rust']).toBe('0.23.1');
+    expect(alpha.dependencies['tree-sitter-cpp']).toBe('^0.23.4');
+    expect(alpha.dependencies['drizzle-orm']).toBe('0.30.0');
+    expect(alpha.dependencies['simple-git']).toBe('^3.20.0');
+    expect(alpha.dependencies['@forge-ts/cli']).toBe('^0.4.0');
+    expect(alpha.dependencies['@biomejs/biome']).toBe('^1.9.0');
+    expect(alpha.dependencies['@types/node']).toBe('^22.0.0');
+    expect(alpha.dependencies['typedoc']).toBe('^0.26.0');
+    expect(alpha.dependencies['@aflsolutions/graphology-communities-leiden']).toBe('0.1.0');
+    expect(alpha.devDependencies['vitest']).toBe('^2.0.0');
+  });
+
+  it('moves every @cleocode/* numeric ref to the new version', async () => {
+    await bumpWorkspaceDeps({ version: '2026.6.1', root: fixtureRoot });
+    const alpha = JSON.parse(
+      readFileSync(join(fixtureRoot, 'packages/alpha/package.json'), 'utf8'),
+    );
+    expect(alpha.dependencies['@cleocode/legacy-numeric']).toBe('2026.6.1');
+    expect(alpha.dependencies['@cleocode/legacy-caret']).toBe('2026.6.1');
+    expect(alpha.devDependencies['@cleocode/dev-tool']).toBe('2026.6.1');
+    expect(alpha.peerDependencies['@cleocode/peer']).toBe('2026.6.1');
+  });
+
+  it('leaves workspace:* and file: refs untouched', async () => {
+    await bumpWorkspaceDeps({ version: '2026.6.1', root: fixtureRoot });
+    const alpha = JSON.parse(
+      readFileSync(join(fixtureRoot, 'packages/alpha/package.json'), 'utf8'),
+    );
+    expect(alpha.dependencies['@cleocode/core']).toBe('workspace:*');
+    expect(alpha.dependencies['@cleocode/contracts']).toBe('workspace:*');
+    expect(alpha.dependencies['@cleocode/worktree-napi']).toBe('file:../../crates/worktree-napi');
+  });
+
+  it('returns an accurate change report', async () => {
+    const report = await bumpWorkspaceDeps({ version: '2026.6.1', root: fixtureRoot });
+    expect(report.version).toBe('2026.6.1');
+    expect(report.filesScanned).toBe(3);
+    expect(report.filesChanged).toBe(1); // only alpha has bumpable refs
+    expect(report.changes.length).toBe(4);
+    const keys = report.changes.map((c) => `${c.kind}.${c.key}`).sort();
+    expect(keys).toEqual([
+      'dependencies.@cleocode/legacy-caret',
+      'dependencies.@cleocode/legacy-numeric',
+      'devDependencies.@cleocode/dev-tool',
+      'peerDependencies.@cleocode/peer',
+    ]);
+  });
+
+  it('does not write files in dry-run mode', async () => {
+    const before = readFileSync(join(fixtureRoot, 'packages/alpha/package.json'), 'utf8');
+    const report = await bumpWorkspaceDeps({
+      version: '2026.6.1',
+      root: fixtureRoot,
+      dryRun: true,
+    });
+    const after = readFileSync(join(fixtureRoot, 'packages/alpha/package.json'), 'utf8');
+    expect(after).toBe(before);
+    expect(report.changes.length).toBe(4);
+  });
+
+  it('throws on invalid version', async () => {
+    await expect(bumpWorkspaceDeps({ version: 'not-calver', root: fixtureRoot })).rejects.toThrow(
+      /Invalid version/,
+    );
+  });
+
+  it('CLI invocation produces the same report and leaves externals alone', () => {
+    const result = spawnSync(
+      'node',
+      [SCRIPT_PATH, '--version', '2026.6.1', '--root', fixtureRoot, '--json'],
+      { encoding: 'utf8' },
+    );
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout);
+    expect(report.version).toBe('2026.6.1');
+    expect(report.changes.length).toBe(4);
+    const alpha = JSON.parse(
+      readFileSync(join(fixtureRoot, 'packages/alpha/package.json'), 'utf8'),
+    );
+    expect(alpha.dependencies['tree-sitter']).toBe('0.21.1');
+    expect(alpha.dependencies['drizzle-orm']).toBe('0.30.0');
+    expect(alpha.dependencies['@cleocode/legacy-numeric']).toBe('2026.6.1');
+  });
+
+  it('CLI rejects invalid version with exit 1', () => {
+    const result = spawnSync(
+      'node',
+      [SCRIPT_PATH, '--version', 'not-calver', '--root', fixtureRoot],
+      { encoding: 'utf8' },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/Invalid version/);
+  });
+});
+
+describe('Regression guard: real repo packages/* (T10177)', () => {
+  it('script exists and is executable as a module', () => {
+    // Sanity: importing the named exports above succeeded — this test asserts
+    // the file is wired and prevents an accidental rename without test update.
+    expect(typeof bumpWorkspaceDeps).toBe('function');
+    expect(typeof rewriteDepMap).toBe('function');
+    expect(typeof shouldBump).toBe('function');
+  });
+});

--- a/scripts/bump-workspace-deps.mjs
+++ b/scripts/bump-workspace-deps.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Bump @cleocode/* workspace dependency refs across packages/* package.json files.
+ *
+ * Scope (NON-NEGOTIABLE):
+ *   - ONLY rewrites keys that match /^@cleocode\//.
+ *   - Skips `workspace:*`, `file:`, `link:`, `npm:`, `git+` ref-style values.
+ *   - LEAVES every external dep untouched (tree-sitter, drizzle-orm, @forge-ts/*,
+ *     @biomejs/*, @types/*, etc.).
+ *
+ * Background:
+ *   The previous in-workflow jq filter matched "any value starting with a digit"
+ *   which incorrectly bumped 10 external deps in v2026.5.100 (PR #480/#481) and
+ *   again in v2026.5.101 (surgical revert d26b76751). T10177 entrenches the fix
+ *   by extracting the bump logic to a testable script.
+ *
+ * Usage:
+ *   node scripts/bump-workspace-deps.mjs --version 2026.5.99 [--root /path/to/repo]
+ *   node scripts/bump-workspace-deps.mjs --version 2026.5.99 --dry-run
+ *   node scripts/bump-workspace-deps.mjs --version 2026.5.99 --json
+ *
+ * Exit codes:
+ *   0 — success (or dry-run completed)
+ *   1 — argument error
+ *   2 — IO error
+ *
+ * @task T10177
+ * @saga T10176
+ * @decision D010
+ */
+
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const CALVER_REGEX = /^\d{4}\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+const WORKSPACE_SCOPE_PREFIX = '@cleocode/';
+const NON_NUMERIC_REF_PREFIXES = ['workspace:', 'file:', 'link:', 'npm:', 'git+', 'github:'];
+
+function usage() {
+  process.stderr.write(
+    [
+      'Usage: node scripts/bump-workspace-deps.mjs --version <calver> [options]',
+      '',
+      'Options:',
+      '  --version <v>   CalVer version to set (e.g. 2026.5.99)',
+      '  --root <dir>    Repo root (default: cwd)',
+      '  --dry-run       Do not write files; print intended changes',
+      '  --json          Emit a JSON report on stdout',
+      '',
+      'Examples:',
+      '  node scripts/bump-workspace-deps.mjs --version 2026.5.99',
+      '  node scripts/bump-workspace-deps.mjs --version 2026.5.99 --dry-run --json',
+      '',
+    ].join('\n'),
+  );
+}
+
+function parseArgs(argv) {
+  const out = { version: null, root: process.cwd(), dryRun: false, json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--version') {
+      out.version = argv[i + 1] ?? null;
+      i += 1;
+    } else if (arg === '--root') {
+      out.root = path.resolve(argv[i + 1] ?? '.');
+      i += 1;
+    } else if (arg === '--dry-run') {
+      out.dryRun = true;
+    } else if (arg === '--json') {
+      out.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    } else {
+      process.stderr.write(`Unknown argument: ${arg}\n`);
+      usage();
+      process.exit(1);
+    }
+  }
+  return out;
+}
+
+/**
+ * Decide whether a single dependency entry should be rewritten.
+ *
+ * @param {string} depName  e.g. "@cleocode/core" or "tree-sitter"
+ * @param {string} depValue e.g. "workspace:*", "0.21.1", "2026.5.99"
+ * @returns {boolean} true iff this dep is an @cleocode/* numeric pin
+ */
+export function shouldBump(depName, depValue) {
+  if (typeof depName !== 'string' || typeof depValue !== 'string') return false;
+  if (!depName.startsWith(WORKSPACE_SCOPE_PREFIX)) return false;
+  for (const prefix of NON_NUMERIC_REF_PREFIXES) {
+    if (depValue.startsWith(prefix)) return false;
+  }
+  // Accept either bare or caret-pinned numeric refs (we still bump to the bare
+  // canonical CalVer — release-publish drops the ^).
+  const stripped =
+    depValue.startsWith('^') || depValue.startsWith('~') ? depValue.slice(1) : depValue;
+  return /^[0-9]/.test(stripped);
+}
+
+/**
+ * Rewrite a dep-map in place. Returns the per-key change log.
+ *
+ * @param {Record<string,string>} depMap
+ * @param {string} newVersion
+ * @returns {Array<{ key: string, from: string, to: string }>}
+ */
+export function rewriteDepMap(depMap, newVersion) {
+  const changes = [];
+  if (!depMap || typeof depMap !== 'object') return changes;
+  for (const [key, value] of Object.entries(depMap)) {
+    if (shouldBump(key, value)) {
+      changes.push({ key, from: value, to: newVersion });
+      depMap[key] = newVersion;
+    }
+  }
+  return changes;
+}
+
+async function getPackageJsonPaths(root) {
+  const packagesDir = path.join(root, 'packages');
+  /** @type {string[]} */
+  const paths = [];
+  let entries;
+  try {
+    entries = await readdir(packagesDir, { withFileTypes: true });
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return paths;
+    throw err;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    paths.push(path.join(packagesDir, entry.name, 'package.json'));
+  }
+  return paths;
+}
+
+async function readJson(filePath) {
+  const raw = await readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function writeJson(filePath, data) {
+  await writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Walk every packages/&#42;/package.json and bump matching @cleocode/* deps.
+ *
+ * @param {{ version: string, root: string, dryRun?: boolean }} opts
+ * @returns {Promise<{
+ *   version: string,
+ *   filesScanned: number,
+ *   filesChanged: number,
+ *   changes: Array<{ file: string, kind: string, key: string, from: string, to: string }>
+ * }>}
+ */
+export async function bumpWorkspaceDeps({ version, root, dryRun = false }) {
+  if (!version || !CALVER_REGEX.test(version)) {
+    throw new Error(`Invalid version '${version}'. Expected CalVer YYYY.M.PATCH[-suffix].`);
+  }
+  const packageJsonPaths = await getPackageJsonPaths(root);
+  /** @type {Array<{ file: string, kind: string, key: string, from: string, to: string }>} */
+  const allChanges = [];
+  let filesChanged = 0;
+  for (const pkgPath of packageJsonPaths) {
+    let pkg;
+    try {
+      pkg = await readJson(pkgPath);
+    } catch (err) {
+      throw new Error(
+        `Failed to read ${pkgPath}: ${err && err.message ? err.message : String(err)}`,
+      );
+    }
+    const relPath = path.relative(root, pkgPath);
+    const sections = ['dependencies', 'devDependencies', 'peerDependencies'];
+    let touched = false;
+    for (const kind of sections) {
+      const changes = rewriteDepMap(pkg[kind], version);
+      for (const c of changes) {
+        allChanges.push({ file: relPath, kind, key: c.key, from: c.from, to: c.to });
+        touched = true;
+      }
+    }
+    if (touched && !dryRun) {
+      await writeJson(pkgPath, pkg);
+    }
+    if (touched) filesChanged += 1;
+  }
+  return {
+    version,
+    filesScanned: packageJsonPaths.length,
+    filesChanged,
+    changes: allChanges,
+  };
+}
+
+async function main() {
+  const { version, root, dryRun, json } = parseArgs(process.argv.slice(2));
+  if (!version) {
+    usage();
+    process.exit(1);
+  }
+  if (!CALVER_REGEX.test(version)) {
+    process.stderr.write(
+      `ERROR: Invalid version '${version}'. Expected CalVer format YYYY.M.PATCH or YYYY.M.PATCH-suffix\n`,
+    );
+    process.exit(1);
+  }
+
+  let report;
+  try {
+    report = await bumpWorkspaceDeps({ version, root, dryRun });
+  } catch (err) {
+    process.stderr.write(`ERROR: ${err && err.message ? err.message : String(err)}\n`);
+    process.exit(2);
+  }
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+
+  const banner = dryRun ? '[dry-run] ' : '';
+  if (report.changes.length === 0) {
+    process.stdout.write(
+      `${banner}No @cleocode/* numeric deps required bumping (scanned ${report.filesScanned} package.json files).\n`,
+    );
+    return;
+  }
+
+  process.stdout.write(
+    `${banner}Bumped ${report.changes.length} @cleocode/* dep ref(s) across ${report.filesChanged}/${report.filesScanned} package.json file(s) to ${report.version}:\n`,
+  );
+  for (const c of report.changes) {
+    process.stdout.write(`  ${c.file} :: ${c.kind}.${c.key}  ${c.from} -> ${c.to}\n`);
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname);
+if (invokedDirectly) {
+  await main();
+}

--- a/scripts/lint-cli-package-boundary.mjs
+++ b/scripts/lint-cli-package-boundary.mjs
@@ -387,7 +387,7 @@ if (MODE_STRICT) {
     process.stderr.write(`\n`);
     process.stderr.write(`=============================================================\n`);
     process.stderr.write(
-      `CLI-BOUNDARY VIOLATION — ${violations.length} helper function(s) > ${LOC_THRESHOLD} LOC\n`,
+      `CLI-BOUNDARY VIOLATION (strict mode) — ${violations.length} helper function(s) > ${LOC_THRESHOLD} LOC\n`,
     );
     process.stderr.write(`=============================================================\n\n`);
 

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+/**
+ * Vitest project config for `scripts/__tests__/*.test.mjs` unit tests.
+ *
+ * Why this exists:
+ *   The root `vitest.config.ts` switched to projects-mode in T9079. Once a
+ *   `projects:` array is set, vitest 4 uses ONLY the projects to discover
+ *   tests — the root `include` field is ignored for test discovery. Without
+ *   a dedicated project, the long-standing `scripts/__tests__/*.test.mjs`
+ *   tests (commit-msg-release-lint, lint-cli-package-boundary, etc.) silently
+ *   stopped running in CI shards.
+ *
+ *   This project re-attaches the scripts tests to the workspace and gives
+ *   them a stable `scripts` project name so they can be invoked with:
+ *     pnpm exec vitest run --project=scripts
+ *
+ * @task T10177
+ * @saga T10176
+ * @decision D010
+ */
+export default defineConfig({
+  test: {
+    extends: true,
+    name: 'scripts',
+    root: __dirname,
+    include: ['__tests__/*.test.mjs'],
+    environment: 'node',
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -280,6 +280,12 @@ export default defineConfig({
       'packages/skills/vitest.config.ts',
       'packages/studio/vitest.config.ts',
       'packages/worktree/vitest.config.ts',
+      // T10177: scripts/__tests__/*.test.mjs unit tests (bump-workspace-deps,
+      // commit-msg-release-lint, lint-cli-package-boundary, etc.) re-attached
+      // to the workspace as a dedicated `scripts` project. The root-level
+      // `include` field is ignored once `projects:` is set, so without this
+      // entry these tests silently stopped running in CI shards.
+      'scripts/vitest.config.ts',
     ],
   },
 });


### PR DESCRIPTION
## Summary

P0 fix entrenching v5.101's surgical revert (commit `d26b76751`). The release-prepare workflow now only bumps @cleocode/* workspace versions; external deps are never touched. Same regression class as the v5.100 hotfix PRs #480/#481 — this PR makes it permanent and CI-enforced.

## Root cause

The previous in-workflow jq filter matched "any value starting with a digit" rather than "key starts with `@cleocode/`". External deps with numeric pins (`tree-sitter: "0.21.1"`, `drizzle-orm: "0.30.0"`, `@aflsolutions/graphology-communities-leiden: "0.1.0"`, etc.) silently got rewritten to the workspace CalVer at release-prep time.

## Changes

- `.github/workflows/release-prepare.yml` — replace inline jq with `node scripts/bump-workspace-deps.mjs`.
- `scripts/bump-workspace-deps.mjs` — new testable module. Key-based `@cleocode/*` filter. Skips `workspace:*` / `file:` / `link:` / `npm:` / `git+` / `github:` refs.
- `scripts/__tests__/bump-workspace-deps.test.mjs` — 21 regression cases covering every external dep the v5.100 workflow ate (`tree-sitter`, `drizzle-orm`, `@forge-ts/cli`, `@biomejs/biome`, `@types/node`, `typedoc`, `simple-git`, `@aflsolutions/graphology-communities-leiden`) and every `@cleocode/*` ref-shape (`workspace:*`, `file:`, numeric, caret).
- `scripts/vitest.config.ts` + root `vitest.config.ts` — register a dedicated `scripts` vitest project. T9079's switch to projects-mode silently dropped `scripts/__tests__/*.test.mjs` from CI shards. They run again now.
- `scripts/lint-cli-package-boundary.mjs` — tiny latent-bug fix: `(strict mode)` label now appears in the fail banner so the previously unexercised T10076 strict-mode test passes.
- `.changeset/t10177-release-prepare-fix.md` — patch entry for `@cleocode/cleo`.

## Acceptance criteria

- [x] AC1: `release-prepare.yml` only bumps `@cleocode/*` workspace versions
- [x] AC2: External deps are NEVER touched by release-prepare
- [x] AC3: Regression test added to verify behavior (21 test cases)
- [x] AC4: Surgical fix in v5.101 (commit `d26b76751`) documented and made permanent

## Test plan

- [x] `pnpm exec vitest run --project=scripts` -> 8 files, 144 tests pass (all 21 T10177 cases green)
- [x] `node scripts/bump-workspace-deps.mjs --version 2026.6.1 --dry-run` on this repo -> "No @cleocode/* numeric deps required bumping" (zero false positives)
- [x] `pnpm run build` -> green across all packages
- [x] `pnpm biome check --write` -> clean
- [ ] CI green on this PR

Closes T10177
Saga: T10176
Decision: D010