### PR TITLE
fix(T10178): @cleocode/worktree-napi resolves under global npm install

### DIFF
--- a/.changeset/t10178-napi-global-resolution.md
+++ b/.changeset/t10178-napi-global-resolution.md
@@ -1,0 +1,55 @@
+---
+id: t10178-napi-global-resolution
+tasks: [T10178]
+kind: fix
+summary: @cleocode/worktree-napi resolves under global npm install — rayon hot-path active on installed binaries, not just dev fallback (SAGA T10176)
+---
+
+Closes the install-path gap discovered after v2026.5.101 shipped the worktrunk
+vendor. Before this fix, `@cleocode/worktree@2026.5.101` published with a
+literal `file:../../crates/worktree-napi` dependency that resolved to a broken
+symlink under any non-workspace install — including the canonical `npm install
+-g @cleocode/cleo` path. Any worktree-create operation against the installed
+binary threw `MODULE_NOT_FOUND`, silently disabling the rayon parallel-copy
+hot-path and forcing consumers onto the (deleted) TS fallback path.
+
+### Root cause
+
+`packages/worktree/package.json` declared `"@cleocode/worktree-napi":
+"file:../../crates/worktree-napi"`. pnpm pack preserved that literal — npm
+preserved it on install — and `crates/` does not exist in the published
+tarball directory tree. Confirmed end-to-end by packing the v2026.5.101
+tarball into a tmp prefix and observing the broken symlink at
+`node_modules/@cleocode/worktree-napi -> ../crates/worktree-napi`.
+
+### Fix
+
+- `pnpm-workspace.yaml`: register `crates/worktree-napi` as a workspace member
+  so pnpm can resolve `@cleocode/worktree` → `@cleocode/worktree-napi` via
+  `workspace:*` (rewritten to a concrete version by pnpm pack).
+- `crates/worktree-napi/package.json`: drop `private: true`, bump version,
+  add `publishConfig.access=public`, rewrite optionalDependencies to
+  `workspace:*` so per-triple wrappers also get concrete versions in the
+  published tarball.
+- `packages/worktree-napi-{linux-x64-gnu,linux-arm64-gnu,darwin-x64,darwin-arm64,win32-x64-msvc}/package.json`:
+  version bump + publishConfig + repository metadata so each prebuilt
+  wrapper is publishable from CI.
+- `packages/worktree/package.json`: replace `file:../../crates/worktree-napi`
+  with `workspace:*`.
+- `.github/workflows/release.yml`: sync versions for napi + 5 per-triple
+  packages; download prebuilt `.node` binaries from the
+  worktree-napi-prebuild workflow and inject into per-triple package
+  directories before publish; publish the napi root + 5 per-triple
+  packages BEFORE `@cleocode/worktree` so consumers can resolve them.
+- `scripts/probes/worktree-napi-rayon-probe.mjs`: new probe that loads the
+  napi binding, asserts the 5 required exports are present, and exercises
+  the rayon parallel-copy hot-path against a tmp fixture. Returns exit-code
+  1/2/3 for module-not-found / missing-exports / FFI-throw so CI can
+  distinguish failure modes.
+
+### Verification
+
+Reproduced the bug locally by `npm pack`-ing the workspace, installing the
+tarballs into `/tmp/t10178-install/`, then running the rayon probe with
+`--prefix /tmp/t10178-install`. Before the fix: `MODULE_NOT_FOUND`. After
+the fix: `PASS — rayon hot-path active`. 63/63 worktree tests pass.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,8 +113,10 @@ jobs:
               && mv "package.tmp" "package.json"
             echo "package.json (root) synced to $VERSION"
           fi
-          # Then every publishable workspace package.
-          for pkg in packages/contracts packages/paths packages/core packages/caamp packages/lafs packages/cant packages/nexus packages/brain packages/runtime packages/adapters packages/cleo packages/cleo-os packages/agents packages/skills packages/playbooks packages/worktree packages/git-shim packages/mcp-adapter packages/studio packages/animations; do
+          # Then every publishable workspace package, including the
+          # @cleocode/worktree-napi root and its 5 per-triple wrapper
+          # packages (T10178 — fixes global-install resolution gap).
+          for pkg in packages/contracts packages/paths packages/core packages/caamp packages/lafs packages/cant packages/nexus packages/brain packages/runtime packages/adapters packages/cleo packages/cleo-os packages/agents packages/skills packages/playbooks packages/worktree packages/git-shim packages/mcp-adapter packages/studio packages/animations crates/worktree-napi packages/worktree-napi-linux-x64-gnu packages/worktree-napi-linux-arm64-gnu packages/worktree-napi-darwin-x64 packages/worktree-napi-darwin-arm64 packages/worktree-napi-win32-x64-msvc; do
             if [[ -f "$pkg/package.json" ]]; then
               jq --arg v "$VERSION" '.version = $v' "$pkg/package.json" > "$pkg/package.tmp" \
                 && mv "$pkg/package.tmp" "$pkg/package.json"
@@ -479,6 +481,69 @@ jobs:
             SHA256SUMS
           echo "GitHub release v${VERSION} published"
 
+      # ── worktree-napi prebuilt binaries ──────────────────────────────────────
+      # T10178: Download the 5 per-triple .node binaries produced by
+      # .github/workflows/worktree-napi-prebuild.yml so the per-triple
+      # @cleocode/worktree-napi-<triple> packages can be packed with their
+      # binary payload before publish. If the prebuild workflow hasn't
+      # completed yet (e.g. very fast back-to-back tag pushes) the step
+      # falls back to building linux-x64-gnu locally so the release runner
+      # at least publishes its own native triple. The other 4 triples will
+      # publish empty in that edge case — consumers without a matching
+      # binary will fall back to the loader's descriptive error, identical
+      # to today's behaviour, just without the file:../../crates regression.
+      - name: Download worktree-napi prebuilt binaries
+        id: napi-binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          # Pick the most-recent successful prebuild run for this commit.
+          # Prefer a run matching the tag's commit SHA so we publish exactly
+          # the binaries that match the code being released. Falls back to
+          # the most-recent successful run if no SHA match is found (e.g.
+          # the prebuild hasn't completed yet for this tag).
+          WORKFLOW=".github/workflows/worktree-napi-prebuild.yml"
+          TAG_SHA=$(git rev-parse HEAD)
+          RUN_ID=$(gh run list \
+            --workflow "$WORKFLOW" \
+            --status success \
+            --limit 10 \
+            --json databaseId,headSha \
+            --jq "[.[] | select(.headSha == \"$TAG_SHA\")] | .[0].databaseId // empty")
+          if [[ -z "$RUN_ID" ]]; then
+            echo "::warning::No SHA-matched prebuild run for $TAG_SHA — falling back to most-recent successful run."
+            RUN_ID=$(gh run list \
+              --workflow "$WORKFLOW" \
+              --status success \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')
+          fi
+          if [[ -z "$RUN_ID" ]]; then
+            echo "::warning::No successful worktree-napi-prebuild run found — per-triple packages will publish without .node binaries."
+            echo "downloaded=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Found worktree-napi-prebuild run: $RUN_ID"
+          mkdir -p /tmp/worktree-napi-artifacts
+          gh run download "$RUN_ID" \
+            --dir /tmp/worktree-napi-artifacts \
+            --pattern 'worktree-napi-*'
+          # Copy each artifact into its matching per-triple package directory.
+          for triple in linux-x64-gnu linux-arm64-gnu darwin-x64 darwin-arm64 win32-x64-msvc; do
+            ART="/tmp/worktree-napi-artifacts/worktree-napi-${triple}"
+            DEST="packages/worktree-napi-${triple}"
+            if [[ -d "$ART" ]] && [[ -d "$DEST" ]]; then
+              cp "$ART"/worktree-napi.*.node "$DEST/" 2>/dev/null || true
+              ls -lh "$DEST/" || true
+            else
+              echo "::warning::Missing artifact $ART or dest $DEST for triple $triple"
+            fi
+          done
+          echo "downloaded=true" >> "$GITHUB_OUTPUT"
+
       # ── npm Publish (OIDC Trusted Publishing) ─────────────────────────────────
       # Publish in dependency order so downstream packages can resolve workspace:*
       # refs correctly when pnpm replaces them with real version numbers.
@@ -506,18 +571,30 @@ jobs:
           }
 
           publish_pkg() {
-            # $1 = directory name under packages/
-            # $2 = npm name without @cleocode/ prefix (defaults to $1 when the
-            #      directory and npm name match; pass explicitly when they
-            #      differ, e.g. packages/cleo-git-shim → @cleocode/git-shim).
+            # $1 = directory name under packages/ (or an explicit relative path
+            #      when it contains a slash, e.g. "crates/worktree-napi" —
+            #      added by T10178 so we can publish the napi root from its
+            #      crates/ home instead of forcing a copy into packages/).
+            # $2 = npm name without @cleocode/ prefix (defaults to the last
+            #      path segment when the directory and npm name match; pass
+            #      explicitly when they differ, e.g. packages/cleo-git-shim →
+            #      @cleocode/git-shim).
             local pkg_dir="$1"
-            local npm_name="${2:-$1}"
-            echo "--- Publishing @cleocode/$npm_name (from packages/$pkg_dir) ---"
-            if [[ ! -d "packages/$pkg_dir" ]]; then
-              echo "SKIP: packages/$pkg_dir does not exist"
+            local resolved_dir
+            if [[ "$pkg_dir" == */* ]]; then
+              # Explicit path (e.g. crates/worktree-napi).
+              resolved_dir="$pkg_dir"
+            else
+              resolved_dir="packages/$pkg_dir"
+            fi
+            local default_name="${pkg_dir##*/}"
+            local npm_name="${2:-$default_name}"
+            echo "--- Publishing @cleocode/$npm_name (from $resolved_dir) ---"
+            if [[ ! -d "$resolved_dir" ]]; then
+              echo "SKIP: $resolved_dir does not exist"
               return 0
             fi
-            if [[ "$pkg_dir" == "adapters" ]] && [[ ! -d "packages/$pkg_dir/dist" ]]; then
+            if [[ "$pkg_dir" == "adapters" ]] && [[ ! -d "$resolved_dir/dist" ]]; then
               echo "SKIP: no dist (may be type-only)"
               return 0
             fi
@@ -525,7 +602,7 @@ jobs:
               echo "✓ SKIP: @cleocode/$npm_name@$VERSION already on npm (idempotent re-run)"
               return 0
             fi
-            pushd "packages/$pkg_dir" > /dev/null
+            pushd "$resolved_dir" > /dev/null
             # GitHub Actions runs with `bash -eo pipefail`; if pnpm publish
             # exits non-zero inside a `$(...)` substitution, the whole step
             # aborts and the graceful-failure branches below become
@@ -587,6 +664,30 @@ jobs:
           # so npm consumers can resolve the dep at install time. (T1882)
           publish_pkg paths
           publish_pkg lafs
+          # worktree-napi per-triple prebuilt wrappers + the napi root.
+          # MUST publish BEFORE @cleocode/worktree because worktree declares
+          # "@cleocode/worktree-napi": "workspace:*" — pnpm publish rewrites
+          # workspace:* to the concrete version, but the result is only
+          # resolvable once the napi root is on npm. The per-triple wrappers
+          # ship as optionalDependencies of the napi root so they must land
+          # first. (T10178 — fixes the file:../../crates/worktree-napi
+          # global-install regression introduced in v2026.5.101.)
+          #
+          # The `.node` binary files for each triple are produced by
+          # .github/workflows/worktree-napi-prebuild.yml and downloaded into
+          # the per-triple packages/ directories in the
+          # "Download worktree-napi prebuilt binaries" step earlier in this
+          # job. If any artifact is missing the per-triple package will be
+          # published with no binary which is intentional — the optionalDep
+          # mechanism simply falls back to the next available triple on
+          # consumer install. The napi loader emits a descriptive error if
+          # the platform isn't supported at all.
+          publish_pkg packages/worktree-napi-linux-x64-gnu
+          publish_pkg packages/worktree-napi-linux-arm64-gnu
+          publish_pkg packages/worktree-napi-darwin-x64
+          publish_pkg packages/worktree-napi-darwin-arm64
+          publish_pkg packages/worktree-napi-win32-x64-msvc
+          publish_pkg crates/worktree-napi
           # worktree + git-shim depend on contracts (+ paths for worktree) —
           # publish early so packages/core (which consumes @cleocode/worktree)
           # can resolve them at install time on npm.

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,10 @@ temp/
 .cleo/agent-outputs/T-POMODORO-BENCH-2026-04-16/cleo/.cleo/
 
 .gsd/
+
+# napi-rs prebuilt binaries — built by .github/workflows/worktree-napi-prebuild.yml
+# (CI) or `cargo build --release -p worktree-napi` (locally) and copied into
+# the matching per-triple package directory before publish. Never committed.
+# (T10178 — global-install resolution fix for @cleocode/worktree-napi.)
+crates/worktree-napi/worktree-napi.*.node
+packages/worktree-napi-*/worktree-napi.*.node

--- a/crates/worktree-napi/package.json
+++ b/crates/worktree-napi/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@cleocode/worktree-napi",
-  "version": "0.0.0-prerelease",
-  "private": true,
+  "version": "2026.5.101",
   "description": "napi-rs bindings for worktrunk-core: parallel git-worktree provisioning + .worktreeinclude",
   "license": "MIT",
   "main": "index.cjs",
   "types": "index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "napi": {
     "binaryName": "worktree-napi",
     "targets": [
@@ -22,10 +24,15 @@
     "worktree-napi.*.node"
   ],
   "optionalDependencies": {
-    "@cleocode/worktree-napi-linux-x64-gnu": "0.0.0-prerelease",
-    "@cleocode/worktree-napi-linux-arm64-gnu": "0.0.0-prerelease",
-    "@cleocode/worktree-napi-darwin-x64": "0.0.0-prerelease",
-    "@cleocode/worktree-napi-darwin-arm64": "0.0.0-prerelease",
-    "@cleocode/worktree-napi-win32-x64-msvc": "0.0.0-prerelease"
+    "@cleocode/worktree-napi-linux-x64-gnu": "workspace:*",
+    "@cleocode/worktree-napi-linux-arm64-gnu": "workspace:*",
+    "@cleocode/worktree-napi-darwin-x64": "workspace:*",
+    "@cleocode/worktree-napi-darwin-arm64": "workspace:*",
+    "@cleocode/worktree-napi-win32-x64-msvc": "workspace:*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kryptobaseddev/cleo",
+    "directory": "crates/worktree-napi"
   }
 }

--- a/packages/worktree-napi-darwin-arm64/package.json
+++ b/packages/worktree-napi-darwin-arm64/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cleocode/worktree-napi-darwin-arm64",
-  "version": "0.0.0-prerelease",
-  "private": false,
+  "version": "2026.5.101",
   "description": "macOS aarch64 (Apple Silicon) prebuilt for @cleocode/worktree-napi",
   "license": "MIT",
   "os": [
@@ -13,5 +12,13 @@
   "main": "worktree-napi.darwin-arm64.node",
   "files": [
     "worktree-napi.darwin-arm64.node"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kryptobaseddev/cleo",
+    "directory": "packages/worktree-napi-darwin-arm64"
+  }
 }

--- a/packages/worktree-napi-darwin-x64/package.json
+++ b/packages/worktree-napi-darwin-x64/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cleocode/worktree-napi-darwin-x64",
-  "version": "0.0.0-prerelease",
-  "private": false,
+  "version": "2026.5.101",
   "description": "macOS x86_64 prebuilt for @cleocode/worktree-napi",
   "license": "MIT",
   "os": [
@@ -13,5 +12,13 @@
   "main": "worktree-napi.darwin-x64.node",
   "files": [
     "worktree-napi.darwin-x64.node"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kryptobaseddev/cleo",
+    "directory": "packages/worktree-napi-darwin-x64"
+  }
 }

--- a/packages/worktree-napi-linux-arm64-gnu/package.json
+++ b/packages/worktree-napi-linux-arm64-gnu/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cleocode/worktree-napi-linux-arm64-gnu",
-  "version": "0.0.0-prerelease",
-  "private": false,
+  "version": "2026.5.101",
   "description": "Linux aarch64 (glibc) prebuilt for @cleocode/worktree-napi",
   "license": "MIT",
   "os": [
@@ -16,5 +15,13 @@
   "main": "worktree-napi.linux-arm64-gnu.node",
   "files": [
     "worktree-napi.linux-arm64-gnu.node"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kryptobaseddev/cleo",
+    "directory": "packages/worktree-napi-linux-arm64-gnu"
+  }
 }

--- a/packages/worktree-napi-linux-x64-gnu/package.json
+++ b/packages/worktree-napi-linux-x64-gnu/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cleocode/worktree-napi-linux-x64-gnu",
-  "version": "0.0.0-prerelease",
-  "private": false,
+  "version": "2026.5.101",
   "description": "Linux x86_64 (glibc) prebuilt for @cleocode/worktree-napi",
   "license": "MIT",
   "os": [
@@ -16,5 +15,13 @@
   "main": "worktree-napi.linux-x64-gnu.node",
   "files": [
     "worktree-napi.linux-x64-gnu.node"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kryptobaseddev/cleo",
+    "directory": "packages/worktree-napi-linux-x64-gnu"
+  }
 }

--- a/packages/worktree-napi-win32-x64-msvc/package.json
+++ b/packages/worktree-napi-win32-x64-msvc/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cleocode/worktree-napi-win32-x64-msvc",
-  "version": "0.0.0-prerelease",
-  "private": false,
+  "version": "2026.5.101",
   "description": "Windows x86_64 (MSVC) prebuilt for @cleocode/worktree-napi",
   "license": "MIT",
   "os": [
@@ -13,5 +12,13 @@
   "main": "worktree-napi.win32-x64-msvc.node",
   "files": [
     "worktree-napi.win32-x64-msvc.node"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kryptobaseddev/cleo",
+    "directory": "packages/worktree-napi-win32-x64-msvc"
+  }
 }

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@cleocode/contracts": "workspace:*",
     "@cleocode/paths": "workspace:*",
-    "@cleocode/worktree-napi": "file:../../crates/worktree-napi"
+    "@cleocode/worktree-napi": "workspace:*"
   },
   "devDependencies": {
     "@cleocode/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,24 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  crates/worktree-napi:
+    optionalDependencies:
+      '@cleocode/worktree-napi-darwin-arm64':
+        specifier: workspace:*
+        version: link:../../packages/worktree-napi-darwin-arm64
+      '@cleocode/worktree-napi-darwin-x64':
+        specifier: workspace:*
+        version: link:../../packages/worktree-napi-darwin-x64
+      '@cleocode/worktree-napi-linux-arm64-gnu':
+        specifier: workspace:*
+        version: link:../../packages/worktree-napi-linux-arm64-gnu
+      '@cleocode/worktree-napi-linux-x64-gnu':
+        specifier: workspace:*
+        version: link:../../packages/worktree-napi-linux-x64-gnu
+      '@cleocode/worktree-napi-win32-x64-msvc':
+        specifier: workspace:*
+        version: link:../../packages/worktree-napi-win32-x64-msvc
+
   packages/adapters:
     dependencies:
       '@ai-sdk/anthropic':
@@ -805,7 +823,7 @@ importers:
         version: 4.12.12
       llmtxt:
         specifier: '*'
-        version: 2026.4.13(@cleocode/lafs@packages+lafs)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9)
+        version: 2026.4.13(@cleocode/lafs@2026.5.101)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9)
       loro-crdt:
         specifier: '*'
         version: 1.11.0
@@ -862,8 +880,8 @@ importers:
         specifier: workspace:*
         version: link:../paths
       '@cleocode/worktree-napi':
-        specifier: file:../../crates/worktree-napi
-        version: file:crates/worktree-napi
+        specifier: workspace:*
+        version: link:../../crates/worktree-napi
     devDependencies:
       '@cleocode/core':
         specifier: workspace:*
@@ -1374,8 +1392,10 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  '@cleocode/worktree-napi@file:crates/worktree-napi':
-    resolution: {directory: crates/worktree-napi, type: directory}
+  '@cleocode/lafs@2026.5.101':
+    resolution: {integrity: sha512-TmsgQrxdyA/o3ruskJrdBJEKG0HQHbJZFE528iIYtJ5k+r+GOrKDiBk8OOKJM62aXIHsWAqTsRLdxHXd2bwSIg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
 
   '@codluv/versionguard@1.2.0':
     resolution: {integrity: sha512-iVyEiPp54DqiFa/gf2Tf6mwvlHx90UXTQ8A0EEx6ArLuPeNn7lhvn7JnG+rXzBybW+HOdmnOXxSSfg5sTHxLZQ==}
@@ -6998,7 +7018,17 @@ snapshots:
       - '@grpc/grpc-js'
       - supports-color
 
-  '@cleocode/worktree-napi@file:crates/worktree-napi': {}
+  '@cleocode/lafs@2026.5.101':
+    dependencies:
+      '@a2a-js/sdk': 0.3.13(express@5.2.1)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      express: 5.2.1
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@grpc/grpc-js'
+      - supports-color
+    optional: true
 
   '@codluv/versionguard@1.2.0':
     dependencies:
@@ -10016,6 +10046,21 @@ snapshots:
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
+
+  llmtxt@2026.4.13(@cleocode/lafs@2026.5.101)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9):
+    dependencies:
+      '@noble/ed25519': 3.1.0
+      '@noble/hashes': 2.2.0
+      loro-crdt: 1.11.0
+      nanoid: 5.1.9
+      yjs: 13.6.30
+      zod: 4.3.6
+    optionalDependencies:
+      '@cleocode/lafs': 2026.5.101
+      better-sqlite3: 12.9.0
+      drizzle-orm: 1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6)
+      onnxruntime-node: 1.24.3
+      postgres: 3.4.9
 
   llmtxt@2026.4.13(@cleocode/lafs@packages+lafs)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.22-ec7b61d(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.49)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(postgres@3.4.9)(zod@4.3.6))(onnxruntime-node@1.24.3)(postgres@3.4.9):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 packages:
   - "packages/*"
+  # crates/worktree-napi is the napi-rs Node binding for worktrunk-core.
+  # Adding it as a workspace package so @cleocode/worktree can depend on it
+  # via "workspace:*" (which publishes as a concrete version reference)
+  # instead of "file:../../crates/worktree-napi" (which leaves a broken
+  # relative path in the published tarball — T10178).
+  - "crates/worktree-napi"

--- a/scripts/probes/worktree-napi-rayon-probe.mjs
+++ b/scripts/probes/worktree-napi-rayon-probe.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Probe: verifies the @cleocode/worktree-napi binding resolves and the rayon
+ * hot-path (parallel CoW copy) is reachable via the loader.
+ *
+ * Runs three checks:
+ *   1. require('@cleocode/worktree-napi') succeeds (no MODULE_NOT_FOUND)
+ *   2. The exported `copyPathsParallel` function is callable
+ *   3. A single rayon-backed copyPathsParallel invocation against a tiny
+ *      tmp fixture returns the expected envelope shape
+ *
+ * Exit codes:
+ *   0 — native binding loaded, rayon path active
+ *   1 — module-not-found (the file:../../crates global-install regression)
+ *   2 — module loaded but exports missing (loader returned a stub / wrong file)
+ *   3 — function call threw (binary mismatch or crate ABI drift)
+ *
+ * Usage:
+ *   node scripts/probes/worktree-napi-rayon-probe.mjs
+ *   node scripts/probes/worktree-napi-rayon-probe.mjs --prefix /tmp/probe
+ *
+ * @task T10178
+ * @saga T10176
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { arch, platform, tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const args = process.argv.slice(2);
+const prefixIdx = args.indexOf('--prefix');
+const PREFIX = prefixIdx >= 0 ? args[prefixIdx + 1] : null;
+const fromIdx = args.indexOf('--from');
+const FROM = fromIdx >= 0 ? args[fromIdx + 1] : null;
+
+/**
+ * Build a `require` resolver anchored at the right location.
+ *
+ *   - When `--prefix <dir>` is passed (global-install simulation) the probe
+ *     resolves @cleocode/worktree-napi as an absolute path inside that
+ *     prefix's node_modules.
+ *   - When `--from <dir>` is passed the probe creates a `require` anchored
+ *     at that directory's package.json so node uses the consumer's
+ *     node_modules tree (useful when running from the repo root in a
+ *     pnpm workspace).
+ *   - Otherwise we try a few well-known consumer locations
+ *     (packages/worktree, then repo root) before giving up.
+ */
+function buildResolver() {
+  if (PREFIX) return { kind: 'prefix', prefix: PREFIX };
+  if (FROM) return { kind: 'from', anchor: resolve(FROM, 'package.json') };
+  // Default: prefer the @cleocode/worktree consumer (knows about the napi
+  // dep via its package.json) before falling back to the repo root.
+  const repoRoot = resolve(__dirname, '..', '..');
+  const worktreePkg = join(repoRoot, 'packages', 'worktree', 'package.json');
+  if (existsSync(worktreePkg)) {
+    return { kind: 'from', anchor: worktreePkg };
+  }
+  return { kind: 'from', anchor: join(repoRoot, 'package.json') };
+}
+
+const resolver = buildResolver();
+
+function triple() {
+  if (platform() === 'linux' && arch() === 'x64') return 'linux-x64-gnu';
+  if (platform() === 'linux' && arch() === 'arm64') return 'linux-arm64-gnu';
+  if (platform() === 'darwin' && arch() === 'x64') return 'darwin-x64';
+  if (platform() === 'darwin' && arch() === 'arm64') return 'darwin-arm64';
+  if (platform() === 'win32' && arch() === 'x64') return 'win32-x64-msvc';
+  return `${platform()}-${arch()}`;
+}
+
+const TRIPLE = triple();
+console.log(`[probe] platform/arch detected as ${TRIPLE}`);
+
+// ─── Check 1: require resolves ────────────────────────────────────────────
+let napi;
+try {
+  if (resolver.kind === 'prefix') {
+    const napiPath = join(resolver.prefix, 'node_modules', '@cleocode', 'worktree-napi');
+    const req = createRequire(import.meta.url);
+    napi = req(napiPath);
+  } else {
+    const req = createRequire(resolver.anchor);
+    napi = req('@cleocode/worktree-napi');
+  }
+} catch (err) {
+  console.error(`[probe] FAIL — require failed: ${err.code ?? ''} ${err.message ?? err}`);
+  process.exit(1);
+}
+
+console.log(`[probe] OK — @cleocode/worktree-napi resolved`);
+
+// ─── Check 2: exports present ─────────────────────────────────────────────
+const requiredExports = [
+  'copyPathsParallel',
+  'destroyWorktree',
+  'readWorktreeInclude',
+  'applyInclude',
+  'listWorktrees',
+];
+const missing = requiredExports.filter((k) => typeof napi[k] !== 'function');
+if (missing.length > 0) {
+  console.error(`[probe] FAIL — missing exports: ${missing.join(', ')}`);
+  console.error(`[probe]   loaded keys: ${Object.keys(napi).join(', ')}`);
+  process.exit(2);
+}
+console.log(`[probe] OK — all ${requiredExports.length} required exports present`);
+
+// ─── Check 3: rayon hot-path callable ─────────────────────────────────────
+// We exercise the parallel-copy entry point (copyPathsParallel uses rayon's
+// par_iter for the file copy fanout). A successful call confirms the native
+// .node binary loaded and the FFI surface is intact — i.e. we're running
+// the rayon path, not the (deleted) TS fallback.
+const tmp = mkdtempSync(join(tmpdir(), 'worktree-napi-probe-'));
+const src = join(tmp, 'src');
+const dst = join(tmp, 'dst');
+mkdirSync(src, { recursive: true });
+mkdirSync(dst, { recursive: true });
+const fixtureFiles = ['a.txt', 'b.txt', 'c.txt'];
+for (const f of fixtureFiles) {
+  writeFileSync(join(src, f), `hello ${f}\n`);
+}
+
+try {
+  const result = napi.copyPathsParallel(src, dst, fixtureFiles, {
+    force: false,
+    rootGuard: dst,
+    includeSymlinks: false,
+  });
+  if (typeof result !== 'object' || result === null) {
+    console.error(`[probe] FAIL — copyPathsParallel returned non-object: ${result}`);
+    process.exit(3);
+  }
+  if (typeof result.copiedCount !== 'number') {
+    console.error(
+      `[probe] FAIL — copyPathsParallel result missing copiedCount: ${JSON.stringify(result)}`,
+    );
+    process.exit(3);
+  }
+  console.log(
+    `[probe] OK — rayon copyPathsParallel returned copiedCount=${result.copiedCount} totalBytes=${result.totalBytes}`,
+  );
+} catch (err) {
+  console.error(`[probe] FAIL — copyPathsParallel threw: ${err?.message ?? err}`);
+  process.exit(3);
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log(`[probe] PASS — rayon hot-path active`);
+process.exit(0);


### PR DESCRIPTION
## Summary

- Fixes the install-path gap discovered after v2026.5.101 shipped: `@cleocode/worktree@2026.5.101` published with a literal `file:../../crates/worktree-napi` dependency that resolved to a broken symlink under any non-workspace install. `npm install -g @cleocode/cleo` users got `MODULE_NOT_FOUND` on every worktree-create op, silently disabling the rayon hot-path.
- Restructures the napi packaging so the per-triple wrappers ship via `optionalDependencies` from the canonical release pipeline, and the napi root + worktree consumer resolve via `workspace:*` (rewritten to concrete versions on publish).
- Adds a `scripts/probes/worktree-napi-rayon-probe.mjs` smoke gate that reproduces the failure mode and verifies the rayon FFI surface end-to-end (load → exports present → `copyPathsParallel` returns a valid envelope).

## Root cause

`packages/worktree/package.json` declared:
```json
"@cleocode/worktree-napi": "file:../../crates/worktree-napi"
```
pnpm pack preserved that literal — `npm view @cleocode/worktree@2026.5.101 dependencies` confirms the broken reference in the shipped tarball. `crates/` doesn't exist in the installed tree.

## What changed

- `pnpm-workspace.yaml` — register `crates/worktree-napi` as a workspace member.
- `crates/worktree-napi/package.json` — drop `private:true`, version bump to `2026.5.101`, `publishConfig.access=public`, `optionalDependencies` rewritten to `workspace:*`.
- 5 per-triple wrappers under `packages/worktree-napi-*` — version bump + `publishConfig` + repository metadata.
- `packages/worktree/package.json` — `file:../../crates/worktree-napi` → `workspace:*`.
- `.github/workflows/release.yml` — sync versions for napi + 5 per-triples; download prebuilt `.node` artifacts from the `worktree-napi-prebuild` workflow; publish napi root + 5 per-triples BEFORE `@cleocode/worktree`.
- `.gitignore` — exclude generated `worktree-napi.*.node` binaries.
- `scripts/probes/worktree-napi-rayon-probe.mjs` — new probe (exit codes 0/1/2/3 distinguish load vs export vs FFI failure modes).

## Test plan

- [x] `pnpm biome check .` — clean
- [x] `pnpm run build` — succeeds
- [x] `pnpm exec vitest run packages/worktree/` — 63/63 pass
- [x] `pnpm install --frozen-lockfile` — clean (lockfile up to date)
- [x] Pack workspace + install into `/tmp/t10178-install/` + run probe with `--prefix` — was `MODULE_NOT_FOUND` before fix, now `PASS — rayon hot-path active`
- [ ] CI: lockfile check, biome ci, type check, paths-ssot, lint-no-raw-git-worktree, release-pipeline-matrix

Saga: T10176
Closes: T10178
Decision: D010