### PR TITLE
feat(T10197): populate BOUNDARY_REGISTRY (19 crates + 20 packages)

### DIFF
--- a/.changeset/t10197-boundary-registry-data.md
+++ b/.changeset/t10197-boundary-registry-data.md
@@ -1,0 +1,11 @@
+---
+"@cleocode/contracts": minor
+---
+
+feat(T10197): populate BOUNDARY_REGISTRY with all 19 crates + 20 packages (SAGA T10176)
+
+Translates the verified decision matrices (sg-boundary-{crates,packages}-decision-matrix)
+into BoundaryEntry literals per ADR-078. Signaldock crates flagged migration-pending
+(pointing to /mnt/projects/signaldock/ per T10180). cleo-llm-native flagged for deletion
+via T10205 amendment. Every entry carries a populated rationale citing the consumer-count
+and workload reasoning from the decision matrix.

--- a/packages/contracts/src/boundary.ts
+++ b/packages/contracts/src/boundary.ts
@@ -189,16 +189,721 @@ export interface BoundaryEntry {
 }
 
 // ============================================================
-// Registry skeleton — populated by T10197
+// Registry — populated by T10197 from the verified decision matrices
 // ============================================================
 
 /**
- * Canonical Boundary Registry for cleocode. Empty skeleton in T10196; populated
- * with per-module entries by T10197; CI gates over this data ship in T10198 / T10199.
+ * Canonical Boundary Registry for cleocode. Skeleton shipped in T10196; populated
+ * with per-module entries by T10197 from the verified decision matrices
+ * (`sg-boundary-crates-decision-matrix` + `sg-boundary-packages-decision-matrix`).
+ * CI gates over this data ship in T10198 / T10199.
+ *
+ * Entry order: crates first (19 entries), then packages (20 entries). Within each
+ * group entries are alphabetical by `module` for diff-friendliness.
  *
  * Entries are added/modified ONLY via ADR amendment + PR per the static-with-amendment
  * policy declared in ADR-078.
  *
  * @see ADR-078 — Boundary Registry as SSoT for Rust/TS layering
  */
-export const BOUNDARY_REGISTRY: readonly BoundaryEntry[] = [] as const;
+export const BOUNDARY_REGISTRY: readonly BoundaryEntry[] = [
+  // ============================================================
+  // Crates (19 entries) — from sg-boundary-crates-decision-matrix
+  // ============================================================
+
+  {
+    module: 'cant-core',
+    intent: 'cpu-bound',
+    rustCore: 'crates/cant-core',
+    tsWrapper: 'packages/cant',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 5,
+      latency_p99_ms: 50,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Cant parser/compiler (19,002 LOC) — CPU-bound hot path consumed by cant-runtime, cant-lsp, cant-napi, signaldock-protocol, signaldock-sdk, integration-tests, and via napi from packages/cant. Flip publish=true to expose as a Rust SDK for external consumers.',
+  },
+  {
+    module: 'cant-lsp',
+    intent: 'cpu-bound',
+    rustCore: 'crates/cant-lsp',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 50,
+      latency_p99_ms: 500,
+      startup_max_ms: 200,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Cant Language Server Protocol binary (1,935 LOC) invoked by editors. Internal-only: publish=false since it ships as a binary, not a library consumed by other crates.',
+  },
+  {
+    module: 'cant-napi',
+    intent: 'ffi-surface',
+    napiBinding: 'crates/cant-napi',
+    tsWrapper: 'packages/cant',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 5,
+      latency_p99_ms: 50,
+      startup_max_ms: 100,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'napi binding shim (736 LOC) for cant-core. Loaded via packages/cant/src/native-loader.ts and packages/core/src/system/dependencies.ts. Internal-only — shipped via per-platform packages/cant-napi-* npm packages, not crates.io.',
+  },
+  {
+    module: 'cant-router',
+    intent: 'cpu-bound',
+    rustCore: 'crates/cant-router',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 5,
+      latency_p99_ms: 50,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Cant Router (984 LOC) — CPU-bound dispatch consumed by cant-napi and integration-tests. Flip publish=true: useful externally for cant ecosystem consumers.',
+  },
+  {
+    module: 'cant-runtime',
+    intent: 'cpu-bound',
+    rustCore: 'crates/cant-runtime',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 5,
+      latency_p99_ms: 50,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Cant runtime / pipeline orchestration (1,221 LOC) consumed by cant-napi. Partial TS parallel impl exists; Rust is canonical. Flip publish=true to ship alongside cant-core.',
+  },
+  {
+    module: 'cleo-llm-native',
+    intent: 'migration-pending',
+    rustCore: 'crates/cleo-llm-native',
+    canonicalHome: 'archived',
+    perfBudget: {
+      latency_p50_ms: 5,
+      latency_p99_ms: 50,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: ['adr-078-boundary-registry'],
+    rationale:
+      'Verified-dead code: 531 LOC Rust crate referenced ONLY by packages/core/src/llm/rust/__tests__/. Production transports (chat-completions/gemini/openai) import StreamingThinkScrubber from the TS think-scrubber.js path. CLEO_USE_RUST gate is never set in any workflow. Scheduled for deletion in T10205; see ADR-078 implementation tasks.',
+  },
+  {
+    module: 'conduit-core',
+    intent: 'data-manifest',
+    rustCore: 'crates/conduit-core',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 10,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Conduit serde-types crate (681 LOC) — stable contract surface consumed by cant-core, signaldock-protocol, signaldock-core, integration-tests, AND external /mnt/projects/signaldock-core + /mnt/projects/signaldock/backend via git deps. Mirrors @cleocode/contracts/conduit.ts. Forced KEEP+publish=true: deleting breaks production, and signaldock-protocol publish requires it.',
+  },
+  {
+    module: 'integration-tests',
+    intent: 'cpu-bound',
+    rustCore: 'crates/integration-tests',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 100,
+      latency_p99_ms: 2000,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Internal Rust test harness (241 LOC) over lafs-core/conduit-core/cant-core/cant-router/signaldock-core. publish=false intentional — test code never ships.',
+  },
+  {
+    module: 'lafs-core',
+    intent: 'cpu-bound',
+    rustCore: 'crates/lafs-core',
+    tsWrapper: 'packages/lafs',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 5,
+      latency_p99_ms: 50,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'LAFS envelope serialization core (1,432 LOC) consumed by conduit-core, signaldock-protocol, lafs-napi, integration-tests. Mirrors @cleocode/lafs/src/envelope.ts. Flip publish=true to expose canonical envelope spec as a Rust library.',
+  },
+  {
+    module: 'lafs-napi',
+    intent: 'ffi-surface',
+    napiBinding: 'crates/lafs-napi',
+    tsWrapper: 'packages/lafs',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 5,
+      latency_p99_ms: 50,
+      startup_max_ms: 100,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'napi binding shim (95 LOC) for lafs-core. Loaded via packages/lafs/src/native-loader.ts. Internal-only — shipped via packages/lafs-napi-* per-platform npm packages.',
+  },
+  {
+    module: 'signaldock-core',
+    intent: 'migration-pending',
+    rustCore: 'crates/signaldock-core',
+    canonicalHome: { external: '/mnt/projects/signaldock/' },
+    perfBudget: {
+      latency_p50_ms: 10,
+      latency_p99_ms: 100,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+      network_egress: 'allowed',
+    },
+    amendments: ['adr-078-boundary-registry'],
+    rationale:
+      'Signaldock cloud core (1,332 LOC) — currently in cleocode but production /mnt/projects/signaldock/backend consumes via git dep. Migration target: signaldock-monorepo per Saga T10180. Until extraction, publish=true to unblock Railway registry-pinned builds.',
+  },
+  {
+    module: 'signaldock-payments',
+    intent: 'migration-pending',
+    rustCore: 'crates/signaldock-payments',
+    canonicalHome: { external: '/mnt/projects/signaldock/' },
+    perfBudget: {
+      latency_p50_ms: 50,
+      latency_p99_ms: 1000,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+      network_egress: 'allowed',
+    },
+    amendments: ['adr-078-boundary-registry'],
+    rationale:
+      'Signaldock payments adapter (297 LOC) — sole consumer is external /mnt/projects/signaldock/backend. Migration target: signaldock-monorepo per Saga T10180. publish=true required: currently publish=false blocks cloud build.',
+  },
+  {
+    module: 'signaldock-protocol',
+    intent: 'migration-pending',
+    rustCore: 'crates/signaldock-protocol',
+    canonicalHome: { external: '/mnt/projects/signaldock/' },
+    perfBudget: {
+      latency_p50_ms: 10,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: ['adr-078-boundary-registry'],
+    rationale:
+      'Thin re-export protocol layer (531 LOC) consumed by signaldock-transport/sdk/storage and external signaldock/backend + signaldock-core. Migration target: signaldock-monorepo per Saga T10180. publish=true to enable registry pinning.',
+  },
+  {
+    module: 'signaldock-runtime',
+    intent: 'migration-pending',
+    rustCore: 'crates/signaldock-runtime',
+    canonicalHome: { external: '/mnt/projects/signaldock-runtime/' },
+    perfBudget: {
+      latency_p50_ms: 50,
+      latency_p99_ms: 1000,
+      startup_max_ms: 500,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+      network_egress: 'allowed',
+    },
+    amendments: ['adr-078-boundary-registry'],
+    rationale:
+      'Signaldock CLI runtime binary (1,782 LOC). No consumer inside cleocode; external /mnt/projects/signaldock-runtime/ is a divergent fork with 283 LOC (health.rs + sse_receiver) not in cleocode. Reconciliation per Saga T10180: absorb the 283 LOC, then migrate canonical home outside cleocode.',
+  },
+  {
+    module: 'signaldock-sdk',
+    intent: 'migration-pending',
+    rustCore: 'crates/signaldock-sdk',
+    canonicalHome: { external: '/mnt/projects/signaldock/' },
+    perfBudget: {
+      latency_p50_ms: 50,
+      latency_p99_ms: 1000,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+      network_egress: 'allowed',
+    },
+    amendments: ['adr-078-boundary-registry'],
+    rationale:
+      'Signaldock cloud SDK (2,049 LOC) — top of cloud stack, sole external consumer is /mnt/projects/signaldock/backend. Migration target: signaldock-monorepo per Saga T10180. publish=true to enable registry pinning.',
+  },
+  {
+    module: 'signaldock-storage',
+    intent: 'migration-pending',
+    rustCore: 'crates/signaldock-storage',
+    canonicalHome: { external: '/mnt/projects/signaldock/' },
+    perfBudget: {
+      latency_p50_ms: 10,
+      latency_p99_ms: 100,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: ['adr-078-boundary-registry'],
+    rationale:
+      'Signaldock storage layer (4,629 LOC, sqlite+postgres features) consumed by signaldock-sdk and external /mnt/projects/signaldock/backend. Migration target: signaldock-monorepo per Saga T10180.',
+  },
+  {
+    module: 'signaldock-transport',
+    intent: 'migration-pending',
+    rustCore: 'crates/signaldock-transport',
+    canonicalHome: { external: '/mnt/projects/signaldock/' },
+    perfBudget: {
+      latency_p50_ms: 50,
+      latency_p99_ms: 1000,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+      network_egress: 'allowed',
+    },
+    amendments: ['adr-078-boundary-registry'],
+    rationale:
+      'Signaldock transport adapter (1,893 LOC) consumed by signaldock-sdk and external /mnt/projects/signaldock/backend. Migration target: signaldock-monorepo per Saga T10180.',
+  },
+  {
+    module: 'worktree-napi',
+    intent: 'ffi-surface',
+    napiBinding: 'crates/worktree-napi',
+    tsWrapper: 'packages/worktree',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 5,
+      latency_p99_ms: 50,
+      startup_max_ms: 100,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+    },
+    amendments: ['adr-077-worktreeinclude'],
+    rationale:
+      'napi binding shim (515 LOC) for worktrunk-core, used by packages/core spawn-pipeline tests, packages/core/src/scaffold/ensure-config.ts, and shipped via packages/worktree-napi-* per-platform npm packages. Internal-only.',
+  },
+  {
+    module: 'worktrunk-core',
+    intent: 'cpu-bound',
+    rustCore: 'crates/worktrunk-core',
+    tsWrapper: 'packages/worktree',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 5,
+      latency_p99_ms: 50,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: ['adr-077-worktreeinclude', 'adr-078-boundary-registry'],
+    rationale:
+      'Worktree primitives core (1,352 LOC) vendored from /mnt/projects/worktrunk per D010, consumed by worktree-napi. Reference implementation of the boundary-registry pattern. Internal-only today; publish=true is a future option if external worktree-tooling emerges.',
+  },
+
+  // ============================================================
+  // Packages (20 entries) — from sg-boundary-packages-decision-matrix
+  // ============================================================
+
+  {
+    module: 'adapters',
+    intent: 'harness-adapter',
+    tsWrapper: 'packages/adapters',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 100,
+      latency_p99_ms: 2000,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'allowed-with-justification',
+      network_egress: 'allowed',
+      fs_writes_outside_root: 'audited',
+    },
+    amendments: [],
+    rationale:
+      'Claude Code / Cursor / OpenCode harness adapters (10,661 LOC) consumed only by core. Provider-specific FS layouts + child_process spawning; TS-only fit.',
+  },
+  {
+    module: 'agents',
+    intent: 'data-manifest',
+    tsWrapper: 'packages/agents',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 10,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Asset-only package (0 TS LOC) — ships .cant + templates consumed by 2 packages. No logic; pure data manifest.',
+  },
+  {
+    module: 'animations',
+    intent: 'frontend',
+    tsWrapper: 'packages/animations',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 16,
+      latency_p99_ms: 33,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'TTY render animations (1,351 LOC) consumed by cleo. 60fps frame budget; terminal output is irrelevant for Rust.',
+  },
+  {
+    module: 'brain',
+    intent: 'io-coordination',
+    tsWrapper: 'packages/brain',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 100,
+      latency_p99_ms: 1000,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Multi-DB substrate adapter (1,628 LOC) consumed by studio + self. IO-bound over better-sqlite3 + drizzle; no Rust port warranted today. Hot path (embeddings) lives in core/src/memory/, not here.',
+  },
+  {
+    module: 'caamp',
+    intent: 'orchestration-glue',
+    tsWrapper: 'packages/caamp',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 100,
+      latency_p99_ms: 2000,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+      fs_writes_outside_root: 'audited',
+    },
+    amendments: [],
+    rationale:
+      'CAAMP packaging + harness registry (28,439 LOC) consumed by 3 packages. FS layouts + provider quirks fit TS; no Rust hot path.',
+  },
+  {
+    module: 'cant',
+    intent: 'ffi-surface',
+    tsWrapper: 'packages/cant',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 10,
+      latency_p99_ms: 100,
+      startup_max_ms: 100,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Thin TS wrapper (4,960 LOC) over cant-core/cant-napi/cant-runtime Rust crates. 651 LOC is the native-loader; remaining glue is composer/bundle/migrate/markdown-parser/mental-model. Working hybrid — no deletion needed.',
+  },
+  {
+    module: 'cleo',
+    intent: 'orchestration-glue',
+    tsWrapper: 'packages/cleo',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 100,
+      latency_p99_ms: 2000,
+      startup_max_ms: 500,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+      fs_writes_outside_root: 'audited',
+    },
+    amendments: [],
+    rationale:
+      'CLI dispatch binary (83,143 LOC, 0 consumers — top of stack). Decomposition tracked under SG-ARCH-SOLID T9833. TS-only orchestration glue; no Rust hot path.',
+  },
+  {
+    module: 'cleo-os',
+    intent: 'harness-adapter',
+    tsWrapper: 'packages/cleo-os',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 100,
+      latency_p99_ms: 2000,
+      startup_max_ms: 500,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'allowed-with-justification',
+      fs_writes_outside_root: 'audited',
+    },
+    amendments: [],
+    rationale:
+      'Pi launcher wrapper (3,598 LOC) — 0 consumers (binary). Wraps JS-only Pi harness; TS-only fit.',
+  },
+  {
+    module: 'contracts',
+    intent: 'data-manifest',
+    tsWrapper: 'packages/contracts',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 10,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: ['adr-078-boundary-registry'],
+    rationale:
+      'Typed contracts SSoT (35,905 LOC, Zod schemas) consumed by 15 packages. Pure types; no logic; TS-only by definition (it defines the type surface). Hosts BOUNDARY_REGISTRY itself.',
+  },
+  {
+    module: 'core',
+    intent: 'orchestration-glue',
+    tsWrapper: 'packages/core',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 100,
+      latency_p99_ms: 2000,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+      fs_writes_outside_root: 'audited',
+    },
+    amendments: [],
+    rationale:
+      'SDK runtime (295,846 LOC) consumed by 10 packages — currently a god-package. Decomposition tracked under SG-ARCH-SOLID T9834. Mixed workload; most paths are IO-coordination but no module is CPU-bound enough to mandate a Rust port today.',
+  },
+  {
+    module: 'git-shim',
+    intent: 'ffi-surface',
+    tsWrapper: 'packages/git-shim',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 50,
+      latency_p99_ms: 1000,
+      startup_max_ms: 100,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+      fs_writes_outside_root: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'PATH-binary git shim (1,452 LOC) — standalone, 0 in-repo consumers. Must fork+exec; bin must be Node for npm distribution. TS-only fit.',
+  },
+  {
+    module: 'lafs',
+    intent: 'io-coordination',
+    tsWrapper: 'packages/lafs',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 50,
+      latency_p99_ms: 1000,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+      network_egress: 'allowed',
+    },
+    amendments: [],
+    rationale:
+      'Envelope + A2A bridge (11,353 LOC) consumed by 6 packages. Rust core (lafs-core + lafs-napi) handles canonical envelope serialization; TS layer is A2A express bridge + envelope validation glue (2,600 LOC a2a/* uses JS-only @a2a-js/sdk).',
+  },
+  {
+    module: 'mcp-adapter',
+    intent: 'orchestration-glue',
+    tsWrapper: 'packages/mcp-adapter',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 100,
+      latency_p99_ms: 2000,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+      network_egress: 'allowed',
+    },
+    amendments: [],
+    rationale:
+      'External MCP bridge (379 LOC) — 0 in-repo consumers (binary only). MCP SDK is JS-native; TS-only fit.',
+  },
+  {
+    module: 'nexus',
+    intent: 'cpu-bound',
+    tsWrapper: 'packages/nexus',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 50,
+      latency_p99_ms: 500,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Code-intelligence (16,431 LOC) consumed by cleo + core. CPU-bound (tree-sitter AST + graphology), but tree-sitter is already native via npm. Pure-JS graphology hot loop is the only candidate; future SG-NEXUS-RUST-CORE saga (out-of-scope per ADR-078) may add a nexus-core Rust crate. Keep TS for now.',
+  },
+  {
+    module: 'paths',
+    intent: 'data-manifest',
+    tsWrapper: 'packages/paths',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 5,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'XDG paths SSoT (588 LOC) consumed by 9 packages. Leaf data-manifest with no logic beyond path resolution; TS-only.',
+  },
+  {
+    module: 'playbooks',
+    intent: 'orchestration-glue',
+    tsWrapper: 'packages/playbooks',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 100,
+      latency_p99_ms: 2000,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Playbook state machine (3,094 LOC) consumed by cleo + adapters. Pure DI; IO-coordination dominated. TS-only fit.',
+  },
+  {
+    module: 'runtime',
+    intent: 'io-coordination',
+    tsWrapper: 'packages/runtime',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 100,
+      latency_p99_ms: 1000,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+      network_egress: 'allowed',
+    },
+    amendments: [],
+    rationale:
+      'Poller/SSE/heartbeat runtime (681 LOC) consumed by cleo. Node event loop + fetch are the natural fit; no Rust port warranted.',
+  },
+  {
+    module: 'skills',
+    intent: 'data-manifest',
+    tsWrapper: 'packages/skills',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 10,
+    },
+    safetyBudget: {
+      panic_unwind: 'forbidden',
+      root_escape: 'forbidden',
+    },
+    amendments: [],
+    rationale:
+      'Asset-only package (0 TS LOC) — ships JSON skill registry + generated index.js consumed by core. No logic; pure data manifest.',
+  },
+  {
+    module: 'studio',
+    intent: 'frontend',
+    tsWrapper: 'packages/studio',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 16,
+      latency_p99_ms: 33,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+      network_egress: 'allowed',
+    },
+    amendments: [],
+    rationale:
+      'SvelteKit frontend (16,636 LOC, d3/three/sigma) — 0 in-repo consumers. SvelteKit + browser code; TS always.',
+  },
+  {
+    module: 'worktree',
+    intent: 'ffi-surface',
+    tsWrapper: 'packages/worktree',
+    canonicalHome: 'cleocode',
+    perfBudget: {
+      latency_p50_ms: 50,
+      latency_p99_ms: 1000,
+      startup_max_ms: 100,
+    },
+    safetyBudget: {
+      panic_unwind: 'allowed-with-recovery',
+      root_escape: 'forbidden',
+      fs_writes_outside_root: 'audited',
+    },
+    amendments: ['adr-077-worktreeinclude', 'adr-078-boundary-registry'],
+    rationale:
+      'Worktree SSoT primitive layer (1,972 LOC) — canonical create/destroy/list/prune/include/copy-on-write bound by @cleocode/paths. Post-PR-#487 the responsibilities are distinct from packages/core/src/worktree/ (SDK-level enrichment). Consumes worktrunk-core via worktree-napi.',
+  },
+] as const;


### PR DESCRIPTION
## Summary
- Populates `BOUNDARY_REGISTRY` in `packages/contracts/src/boundary.ts` from the verified Saga T10176 decision matrices.
- 19 crate entries + 20 package entries = 39 total BoundaryEntry literals.
- Every entry carries `module`, `intent`, `canonicalHome`, `perfBudget`, `safetyBudget`, `amendments: []`, and a populated `rationale` field per ADR-078 schema.

## Source-of-truth
- `cleo docs fetch sg-boundary-crates-decision-matrix` — per-crate verdicts (with verified consumer paths)
- `cleo docs fetch sg-boundary-packages-decision-matrix` — per-package verdicts
- ADR-078 (proposed) — schema defined and shipped in PR #495

## Notable per-module decisions
- **cleo-llm-native** → `intent: 'migration-pending'`, `canonicalHome: 'archived'`. Verified-dead: production transports import `StreamingThinkScrubber` from TS, `CLEO_USE_RUST` is never set in any workflow. Scheduled for deletion in T10205.
- **signaldock-{core,protocol,storage,transport,sdk,payments,runtime}** → `intent: 'migration-pending'`, `canonicalHome: { external: '/mnt/projects/signaldock/' }` per Saga T10180 extraction.
- **worktrunk-core** → `intent: 'cpu-bound'`, amendments cite D010 (reference impl of the boundary-registry pattern) + ADR-077 (worktreeinclude).
- **contracts** → self-referential `amendments: ['adr-078-boundary-registry']` because this package hosts the registry.

## Perf/safety budget defaults
Per ADR-078 §"Two-axis intent system":
- `cpu-bound`: `latency_p50_ms: 5, latency_p99_ms: 50, panic_unwind: 'forbidden'`
- `io-coordination`: `latency_p50_ms: 100, latency_p99_ms: 1000`
- `ffi-surface`: `startup_max_ms: 100, panic_unwind: 'allowed-with-recovery'`
- `orchestration-glue`: `latency_p50_ms: 100, latency_p99_ms: 2000, root_escape: 'forbidden'`
- `data-manifest`: `latency_p50_ms: 5-10` (read-mostly)
- `frontend`: `latency_p50_ms: 16` (60fps)
- `migration-pending`: budgets recorded as if module were staying — destination repo inherits them.

## Test plan
- [x] `pnpm biome check --write packages/contracts/` → clean (no fixes applied)
- [x] `pnpm --filter @cleocode/contracts run build` → green (tsc + emit-schemas)
- [x] `pnpm exec vitest run packages/contracts/` → 17 files, 341 tests pass

## Acceptance criteria coverage
- [x] AC1: Every crates/<X> has an entry (19/19)
- [x] AC2: Every packages/<X> has an entry (20/20)
- [x] AC3: Signaldock crates flagged `migration-pending` pointing to `/mnt/projects/signaldock/`
- [x] AC4: cleo-llm-native flagged for deletion via T10205 amendment ref (`adr-078-boundary-registry`)
- [x] AC5: `rationale` field populated for every entry (39/39, 1-3 sentences each)

## Refs
Closes T10197 · Saga: T10176 · Decision: D010 · ADR: ADR-078