### PR TITLE
feat(T10206): conduit-core publish=true + criterion serde round-trip bench

### DIFF
--- a/.changeset/t10206-conduit-core-publish.md
+++ b/.changeset/t10206-conduit-core-publish.md
@@ -1,0 +1,18 @@
+---
+"@cleocode/cleo": patch
+---
+
+feat(T10206): conduit-core publish=true + criterion serde round-trip bench (SAGA T10176)
+
+Flips `crates/conduit-core/Cargo.toml` to `publish = true` (forced by the
+signaldock-protocol publishing chain per sg-boundary-crates-decision-matrix,
+Decision D010, ADR-078). Adds the canonical perf-floor bench at
+`crates/conduit-core/benches/envelope_serde.rs` — two criterion bench
+functions exercising JSON serialize → deserialize on the `ConduitMessage`
+envelope:
+
+- `conduit_message_roundtrip_minimal` — all-`None` optional fields. p50 ≈ 196.6 ns.
+- `conduit_message_roundtrip_full`    — full CANT metadata + tags + nested JSON. p50 ≈ 1.98 µs.
+
+Per ADR-078 perf-budget contract, these floors will be declared in the
+T10197 boundary registry entry for conduit-core.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +333,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +372,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -439,6 +478,7 @@ dependencies = [
 name = "conduit-core"
 version = "2026.5.99"
 dependencies = [
+ "criterion",
  "lafs-core",
  "serde",
  "serde_json",
@@ -489,6 +529,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +588,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1083,6 +1165,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,10 +1557,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1943,6 +2056,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2202,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "postgres-protocol"
@@ -2333,7 +2480,7 @@ dependencies = [
  "bytes",
  "combine",
  "futures-util",
- "itertools",
+ "itertools 0.13.0",
  "itoa",
  "num-bigint",
  "percent-encoding",
@@ -2409,6 +2556,18 @@ dependencies = [
  "libc",
  "rustix",
  "windows",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3137,6 +3296,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/conduit-core/Cargo.toml
+++ b/crates/conduit-core/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition = "2024"
 rust-version = "1.94"
 description = "Canonical Conduit wire types for CLEO ecosystem"
+license = "MIT"
+repository = "https://github.com/kryptobaseddev/cleo"
+publish = true
 
 [lib]
 crate-type = ["rlib"]
@@ -12,6 +15,13 @@ crate-type = ["rlib"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lafs-core = { path = "../lafs-core" }
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "envelope_serde"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/conduit-core/benches/envelope_serde.rs
+++ b/crates/conduit-core/benches/envelope_serde.rs
@@ -1,0 +1,94 @@
+//! Criterion benches for conduit-core canonical envelope serde round-trip.
+//!
+//! Captures the perf-budget floor declared in the SG-BOUNDARY-REGISTRY
+//! `boundary.ts` entry for conduit-core (ADR-078, Saga T10176).
+//!
+//! Two benches are exposed:
+//!
+//! - `conduit_message_roundtrip_minimal` — minimal envelope (no optional
+//!   fields, no metadata). Establishes the absolute serde floor.
+//! - `conduit_message_roundtrip_full` — representative envelope with
+//!   CANT metadata, tags, threadId/groupId, and a small nested JSON
+//!   metadata payload. Mirrors the on-wire shape for real CLEO
+//!   agent-to-agent messages.
+//!
+//! Each bench runs JSON serialize → JSON deserialize so the measured
+//! time captures both directions of the round-trip on the canonical
+//! hot-path consumers (signaldock-protocol, signaldock-backend).
+
+#![allow(missing_docs)]
+
+use conduit_core::{CantMetadata, CantOperation, ConduitMessage};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+/// Minimal canonical envelope — all optional fields `None`.
+fn make_minimal_message() -> ConduitMessage {
+    ConduitMessage {
+        id: "msg-001".to_string(),
+        from: "agent-a".to_string(),
+        content: "Hello from agent A".to_string(),
+        tags: None,
+        thread_id: None,
+        group_id: None,
+        timestamp: "2026-05-22T12:00:00Z".to_string(),
+        metadata: None,
+    }
+}
+
+/// Representative full envelope — CANT metadata + tags + threading + nested JSON.
+/// Mirrors the on-wire shape signaldock-protocol consumers serialize.
+fn make_full_message() -> ConduitMessage {
+    let cant = CantMetadata {
+        directive: Some("please review T5678".to_string()),
+        directive_type: "actionable".to_string(),
+        addresses: vec!["@cleo-core".to_string(), "@cleo-prime".to_string()],
+        task_refs: vec!["T5678".to_string(), "T10206".to_string()],
+        tags: vec!["#review".to_string(), "#urgent".to_string()],
+        operation: Some(CantOperation {
+            gateway: "query".to_string(),
+            domain: "tasks".to_string(),
+            operation: "show".to_string(),
+            params: Some(serde_json::json!({"id": "T5678", "verbose": true})),
+        }),
+    };
+    ConduitMessage {
+        id: "msg-bench-full".to_string(),
+        from: "agent-bench".to_string(),
+        content: "Representative payload for SG-BOUNDARY-REGISTRY perf-floor bench".to_string(),
+        tags: Some(vec!["#status".to_string(), "#decision".to_string()]),
+        thread_id: Some("thread-bench-001".to_string()),
+        group_id: Some("group-bench-001".to_string()),
+        timestamp: "2026-05-22T12:00:00Z".to_string(),
+        metadata: None,
+    }
+    .with_cant_metadata(cant)
+}
+
+fn bench_minimal_roundtrip(c: &mut Criterion) {
+    let msg = make_minimal_message();
+    c.bench_function("conduit_message_roundtrip_minimal", |b| {
+        b.iter(|| {
+            let serialized =
+                serde_json::to_string(black_box(&msg)).expect("serialize minimal envelope");
+            let deserialized: ConduitMessage =
+                serde_json::from_str(black_box(&serialized)).expect("deserialize minimal envelope");
+            black_box(deserialized);
+        });
+    });
+}
+
+fn bench_full_roundtrip(c: &mut Criterion) {
+    let msg = make_full_message();
+    c.bench_function("conduit_message_roundtrip_full", |b| {
+        b.iter(|| {
+            let serialized =
+                serde_json::to_string(black_box(&msg)).expect("serialize full envelope");
+            let deserialized: ConduitMessage =
+                serde_json::from_str(black_box(&serialized)).expect("deserialize full envelope");
+            black_box(deserialized);
+        });
+    });
+}
+
+criterion_group!(benches, bench_minimal_roundtrip, bench_full_roundtrip);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Saga **T10176** (SG-BOUNDARY-REGISTRY) · Epic **T10194** (E3 — Vendor + Wire) · Decision **D010** · ADR-078.

Flips `crates/conduit-core/Cargo.toml` to `publish = true` (forced by the
signaldock-protocol publishing chain per `sg-boundary-crates-decision-matrix`)
and adds the canonical perf-floor criterion bench at
`crates/conduit-core/benches/envelope_serde.rs`.

## Why

Per ADR-078 §"Polyglot SDK upside", every `<X>-core` crate MUST be
`publishable=true + has a criterion bench`. conduit-core is 681 LOC of
canonical Conduit wire types consumed by:

- `crates/signaldock-protocol`
- `/mnt/projects/signaldock-core/Cargo.toml:71` (external git dep)
- `/mnt/projects/signaldock/backend/Cargo.toml` (transitively)

Publishing is therefore forced. The bench captures the canonical
serde-round-trip hot-path so the T10197 boundary registry can declare a
`PerfBudget` floor that future PRs must not regress.

## Changes

- `crates/conduit-core/Cargo.toml`
  - Adds `publish = true` (explicit)
  - Adds `license = "MIT"` + `repository = "..."` (required for crates.io)
  - Adds `[dev-dependencies] criterion = "0.5"`
  - Adds `[[bench]] name = "envelope_serde", harness = false`
- `crates/conduit-core/benches/envelope_serde.rs` (NEW)
  - `conduit_message_roundtrip_minimal` — all-`None` optionals
  - `conduit_message_roundtrip_full` — CANT metadata + tags + nested JSON
- `Cargo.lock` — picks up criterion transitive deps (dev-only)
- `.changeset/t10206-conduit-core-publish.md`

## Bench results (local, x86_64-linux, release profile)

| Bench | p50 |
|---|---|
| `conduit_message_roundtrip_minimal` | **196.60 ns** |
| `conduit_message_roundtrip_full`    | **1.9810 µs** |

These are the candidate floors for the conduit-core entry in T10197's
boundary registry.

## Verification

```
cargo build -p conduit-core           # clean, 8.00s
cargo build -p conduit-core --benches # clean, 9.75s
cargo test  -p conduit-core           # 23 passed, 0 failed
cargo bench -p conduit-core           # 2 benches run green
pnpm biome check --write .            # 2776 files, no fixes
```

## Note on the local pre-commit bypass

The `ferrous-forge` pre-commit validator flagged a **pre-existing**
rust-version SSoT drift (`.ferrous-forge/config.toml` declares
`required_rust_version = "1.88"`; every Cargo.toml on `main` declares
`rust-version = "1.94"`) plus a tarpaulin config-missing error — both
unrelated to this PR's scope. Used the documented audited path
`ferrous-forge safety bypass --stage=pre-commit --reason="..."` (NOT
`--no-verify`). Audit log entry created. CI gates run the real checks.

## Acceptance Criteria

- [x] AC1 — `crates/conduit-core/Cargo.toml`: `publish = true`
- [x] AC2 — `benches/` directory created with at least one criterion bench
- [x] AC3 — `cargo bench -p conduit-core` runs green
- [x] AC4 — Bench captures canonical hot-path (serde round-trip on ConduitMessage)
- [x] AC5 — PerfBudget floor captured (196.6 ns minimal / 1.98 µs full) for T10197

Closes T10206
Saga: T10176
Decision: D010