### PR TITLE
feat(T10198): boundary-registry CI gate (registry-vs-filesystem invariant)

### DIFF
--- a/.changeset/t10198-lint-boundary-registry.md
+++ b/.changeset/t10198-lint-boundary-registry.md
@@ -1,0 +1,10 @@
+---
+"@cleocode/cleo": patch
+---
+
+feat(T10198): boundary-registry CI gate (SAGA T10176, ADR-078)
+
+scripts/lint-boundary-registry.mjs enforces registry-vs-filesystem invariant:
+orphan modules + missing modules + drift all fail the gate. Wired into CI as
+required check via .github/workflows/boundary-registry-lint.yml. Poison test
+under scripts/__tests__/.

--- a/.github/workflows/boundary-registry-lint.yml
+++ b/.github/workflows/boundary-registry-lint.yml
@@ -1,0 +1,55 @@
+name: Boundary Registry Lint (T10198)
+
+# T10198 · Saga T10176 · ADR-078 · Decision D010
+#
+# Validates packages/contracts/src/boundary.ts → BOUNDARY_REGISTRY against
+# the actual contents of `crates/` and `packages/`. Required check on every
+# PR — drift between registry and filesystem is rejected at PR-time.
+#
+# The lint script lives at scripts/lint-boundary-registry.mjs. It loads the
+# COMPILED registry from packages/contracts/dist/boundary.js, so this workflow
+# must run `pnpm --filter @cleocode/contracts run build` before invoking the
+# script. The poison test verifies every branch (clean / orphan / missing /
+# intent-drift / CLI plumbing) without touching the canonical registry.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  boundary-registry-lint:
+    name: Boundary Registry Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.0
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @cleocode/contracts
+        run: pnpm --filter @cleocode/contracts run build
+
+      - name: Lint boundary registry against filesystem
+        run: node scripts/lint-boundary-registry.mjs
+
+      - name: Run boundary registry poison tests
+        run: pnpm exec vitest run scripts/__tests__/lint-boundary-registry.test.mjs

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:changed": "pnpm --filter \"...[HEAD~1]\" run test",
     "lint": "biome check . && node scripts/lint-no-raw-cr-writes.mjs",
     "lint:fix": "biome check --write . && node scripts/lint-no-raw-cr-writes.mjs",
+    "lint:boundary-registry": "pnpm --filter @cleocode/contracts run build && node scripts/lint-boundary-registry.mjs",
     "lint:changesets": "node scripts/lint-changesets.mjs",
     "lint:cleo-errors": "node scripts/lint-cleo-errors.mjs",
     "lint:contracts-dep": "node scripts/lint-contracts-dep.mjs",

--- a/scripts/__tests__/lint-boundary-registry.test.mjs
+++ b/scripts/__tests__/lint-boundary-registry.test.mjs
@@ -1,0 +1,283 @@
+/**
+ * Poison tests for scripts/lint-boundary-registry.mjs.
+ *
+ * Strategy:
+ *   - The script accepts a `--fixture <path>` flag that bypasses the canonical
+ *     compiled registry and loads BOUNDARY_REGISTRY from a synthetic ESM module
+ *     instead. This lets us exercise every branch (clean, orphan, missing,
+ *     intent-drift) without mutating the real packages/contracts/dist/boundary.js.
+ *   - Each test writes a small fixture .mjs file under a tmpdir, runs the
+ *     script with that fixture, and asserts on exit code + JSON output.
+ *   - Disk enumeration still runs against the real cleocode tree, so fixtures
+ *     either include EVERY on-disk crate/package (to demonstrate "clean"), or
+ *     intentionally omit some entries (to demonstrate "orphan").
+ *
+ * @task T10198
+ * @saga T10176
+ * @adr ADR-078
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+const REPO_ROOT = resolve(__dirname, '../..');
+const SCRIPT = join(REPO_ROOT, 'scripts/lint-boundary-registry.mjs');
+
+/** @type {string} */
+let tmpRoot;
+/** @type {string} */
+let fixturePath;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-boundary-lint-'));
+  fixturePath = join(tmpRoot, 'fixture-registry.mjs');
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/**
+ * Write a fixture module that exports a BOUNDARY_REGISTRY array.
+ *
+ * @param {object[]} entries
+ */
+function writeFixture(entries) {
+  const src = `export const BOUNDARY_REGISTRY = ${JSON.stringify(entries, null, 2)};\n`;
+  writeFileSync(fixturePath, src);
+}
+
+/**
+ * Run the lint script with a fixture path.
+ *
+ * @param {string[]} extraArgs
+ */
+function runLint(extraArgs = []) {
+  return spawnSync('node', [SCRIPT, '--fixture', fixturePath, ...extraArgs], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: REPO_ROOT,
+  });
+}
+
+/**
+ * Build a registry entry that mirrors a real on-disk crate so the script
+ * treats it as known-good. Returns the minimal shape the linter inspects.
+ *
+ * @param {object} overrides
+ */
+function entry(overrides) {
+  return {
+    module: 'sample',
+    intent: 'cpu-bound',
+    canonicalHome: 'cleocode',
+    perfBudget: {},
+    safetyBudget: { panic_unwind: 'forbidden', root_escape: 'forbidden' },
+    amendments: [],
+    rationale: 'fixture entry',
+    ...overrides,
+  };
+}
+
+/**
+ * Read all the real on-disk crates + packages so a "clean" fixture can
+ * register every one of them. Mirrors the script's own enumeration so the
+ * fixture matches the linter's expected universe exactly.
+ *
+ * @returns {{crates: string[], packages: string[]}}
+ */
+function enumerateDisk() {
+  const cratesDir = join(REPO_ROOT, 'crates');
+  const pkgDir = join(REPO_ROOT, 'packages');
+  const crates = readdirSync(cratesDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((n) => existsSync(join(cratesDir, n, 'Cargo.toml')))
+    .sort();
+  const packages = readdirSync(pkgDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((n) => existsSync(join(pkgDir, n, 'package.json')))
+    .filter((n) => !/-napi-(linux|darwin|win32)(-[a-z0-9]+)+$/.test(n))
+    .sort();
+  return { crates, packages };
+}
+
+/**
+ * Build a registry that covers EVERY on-disk module — represents a "clean" state.
+ *
+ * @returns {object[]}
+ */
+function buildCleanFixture() {
+  const { crates, packages } = enumerateDisk();
+  const entries = [];
+  for (const c of crates) {
+    entries.push(
+      entry({
+        module: c,
+        // napi crates get napiBinding instead of rustCore so the intent-drift
+        // heuristic stays happy.
+        ...(c.endsWith('-napi')
+          ? { napiBinding: `crates/${c}`, intent: 'ffi-surface' }
+          : { rustCore: `crates/${c}` }),
+      }),
+    );
+  }
+  for (const p of packages) {
+    entries.push(entry({ module: p, tsWrapper: `packages/${p}`, intent: 'orchestration-glue' }));
+  }
+  return entries;
+}
+
+// ============================================================================
+// Clean-state fixture
+// ============================================================================
+
+describe('lint-boundary-registry — clean fixture', () => {
+  it('exits 0 when every on-disk module has a matching registry entry', () => {
+    writeFixture(buildCleanFixture());
+    const result = runLint(['--json']);
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.counts.orphans).toBe(0);
+    expect(parsed.counts.missing).toBe(0);
+    expect(parsed.counts.driftIntent).toBe(0);
+  });
+});
+
+// ============================================================================
+// ORPHAN — disk module missing from registry
+// ============================================================================
+
+describe('lint-boundary-registry — orphan detection', () => {
+  it('exits 1 and reports a crate orphan when registry omits an on-disk crate', () => {
+    // Drop ALL crate entries — every on-disk crate should be reported as orphan.
+    const clean = buildCleanFixture();
+    const noCrates = clean.filter((e) => !e.rustCore && !e.napiBinding);
+    writeFixture(noCrates);
+    const result = runLint(['--json']);
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.counts.orphans).toBeGreaterThan(0);
+    const orphanKinds = parsed.orphans.map((o) => o.kind);
+    expect(orphanKinds).toContain('crate');
+  });
+
+  it('exits 1 and reports a package orphan when registry omits an on-disk package', () => {
+    // Drop ALL package entries — every on-disk package should be reported.
+    const clean = buildCleanFixture();
+    const noPackages = clean.filter((e) => !e.tsWrapper);
+    writeFixture(noPackages);
+    const result = runLint(['--json']);
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.counts.orphans).toBeGreaterThan(0);
+    const orphanKinds = parsed.orphans.map((o) => o.kind);
+    expect(orphanKinds).toContain('package');
+  });
+});
+
+// ============================================================================
+// MISSING — registry references a path that does not exist on disk
+// ============================================================================
+
+describe('lint-boundary-registry — missing detection', () => {
+  it('exits 1 when a registry rustCore path does not exist on disk', () => {
+    const clean = buildCleanFixture();
+    clean.push(
+      entry({
+        module: 'phantom-crate',
+        rustCore: 'crates/does-not-exist-on-disk',
+        intent: 'cpu-bound',
+      }),
+    );
+    writeFixture(clean);
+    const result = runLint(['--json']);
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.counts.missing).toBeGreaterThanOrEqual(1);
+    expect(parsed.missing.some((m) => m.module === 'phantom-crate')).toBe(true);
+  });
+
+  it('exits 1 when a registry tsWrapper path does not exist on disk', () => {
+    const clean = buildCleanFixture();
+    clean.push(
+      entry({
+        module: 'phantom-package',
+        tsWrapper: 'packages/does-not-exist-on-disk',
+        intent: 'orchestration-glue',
+      }),
+    );
+    writeFixture(clean);
+    const result = runLint(['--json']);
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.counts.missing).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does NOT report MISSING when canonicalHome === "archived"', () => {
+    const clean = buildCleanFixture();
+    clean.push(
+      entry({
+        module: 'phantom-archived',
+        rustCore: 'crates/does-not-exist-on-disk',
+        intent: 'migration-pending',
+        canonicalHome: 'archived',
+      }),
+    );
+    writeFixture(clean);
+    const result = runLint(['--json']);
+    // Archived path is exempt from missing — exit 0 unless other failures exist.
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.counts.missing).toBe(0);
+  });
+});
+
+// ============================================================================
+// INTENT DRIFT — napiBinding declared but workload intent doesn't match
+// ============================================================================
+
+describe('lint-boundary-registry — intent drift', () => {
+  it('exits 1 when napiBinding is declared but intent is not ffi-surface', () => {
+    const clean = buildCleanFixture();
+    // Pick an existing napi crate but tag it with a non-ffi intent.
+    const napiCrateIdx = clean.findIndex((e) => e.napiBinding);
+    expect(napiCrateIdx).toBeGreaterThanOrEqual(0);
+    clean[napiCrateIdx] = { ...clean[napiCrateIdx], intent: 'data-manifest' };
+    writeFixture(clean);
+    const result = runLint(['--json']);
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.counts.driftIntent).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ============================================================================
+// CLI plumbing — fixture flag validation
+// ============================================================================
+
+describe('lint-boundary-registry — CLI plumbing', () => {
+  it('exits 2 when --fixture path does not exist', () => {
+    const result = spawnSync('node', [SCRIPT, '--fixture', join(tmpRoot, 'no-such-file.mjs')], {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('fixture not found');
+  });
+
+  it('exits 2 when fixture does not export BOUNDARY_REGISTRY', () => {
+    writeFileSync(fixturePath, 'export const NOT_THE_REGISTRY = [];\n');
+    const result = runLint();
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('does not export BOUNDARY_REGISTRY');
+  });
+});

--- a/scripts/lint-boundary-registry.mjs
+++ b/scripts/lint-boundary-registry.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+// scripts/lint-boundary-registry.mjs
+//
+// T10198 · Saga T10176 · ADR-078 · Decision D010
+//
+// Enforces the registry-vs-filesystem invariant for the Boundary Registry
+// (packages/contracts/src/boundary.ts → BOUNDARY_REGISTRY).
+//
+// Rules:
+//   1. ORPHAN — A crate/package exists on disk but has no BOUNDARY_REGISTRY entry.
+//   2. MISSING — A BOUNDARY_REGISTRY entry references a rustCore/napiBinding/tsWrapper
+//      path that no longer exists on disk (exempt when canonicalHome === 'archived'
+//      or canonicalHome is { external: ... } AND the entry's intent indicates
+//      a migration-pending / migrated-out posture).
+//   3. INTENT_DRIFT — A registry entry declares ffi-surface but its declared
+//      napi binding is missing on disk, OR vice-versa (lightweight heuristic).
+//
+// The script loads the COMPILED registry from packages/contracts/dist/boundary.js,
+// so `pnpm --filter @cleocode/contracts run build` MUST run first (CI handles this).
+//
+// Usage:
+//   node scripts/lint-boundary-registry.mjs               # default — fails on any violation
+//   node scripts/lint-boundary-registry.mjs --json        # machine-readable JSON report
+//   node scripts/lint-boundary-registry.mjs --verbose     # also list OK modules
+//   node scripts/lint-boundary-registry.mjs --fixture <p> # load a synthetic registry (poison-test mode)
+//
+// Exit codes:
+//   0 — All registry entries match disk reality.
+//   1 — One or more violations found.
+//   2 — Setup/load error (compiled registry missing, etc.) — distinct from real violations
+//       so CI surfaces the diagnostic separately.
+//
+// No untrusted input used — pure static analysis of checked-in source + the
+// compiled registry artifact.
+
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const REPO_ROOT = resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+const jsonOutput = args.includes('--json');
+const verbose = args.includes('--verbose');
+
+// Optional fixture path for poison-testing — when provided we load the
+// registry from the fixture module instead of the canonical compiled artifact.
+let fixturePath = null;
+const fixtureIdx = args.indexOf('--fixture');
+if (fixtureIdx !== -1) {
+  fixturePath = args[fixtureIdx + 1];
+  if (!fixturePath) {
+    console.error('ERROR: --fixture requires a path argument');
+    process.exit(2);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Registry loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the canonical BOUNDARY_REGISTRY from the compiled contracts artifact
+ * (or a fixture path when poison-testing).
+ *
+ * @param {string|null} fixture - Optional absolute path to a fixture module.
+ * @returns {Promise<readonly object[]>} The registry entries.
+ */
+async function loadRegistry(fixture) {
+  if (fixture) {
+    const abs = resolve(process.cwd(), fixture);
+    if (!existsSync(abs)) {
+      console.error(`ERROR: fixture not found: ${abs}`);
+      process.exit(2);
+    }
+    const mod = await import(pathToFileURL(abs).href);
+    if (!Array.isArray(mod.BOUNDARY_REGISTRY)) {
+      console.error(`ERROR: fixture at ${abs} does not export BOUNDARY_REGISTRY array`);
+      process.exit(2);
+    }
+    return mod.BOUNDARY_REGISTRY;
+  }
+
+  const compiled = join(REPO_ROOT, 'packages/contracts/dist/boundary.js');
+  if (!existsSync(compiled)) {
+    console.error(
+      'ERROR: compiled boundary registry not found at packages/contracts/dist/boundary.js\n' +
+        'Run: pnpm --filter @cleocode/contracts run build',
+    );
+    process.exit(2);
+  }
+  const mod = await import(pathToFileURL(compiled).href);
+  if (!Array.isArray(mod.BOUNDARY_REGISTRY)) {
+    console.error(
+      'ERROR: packages/contracts/dist/boundary.js does not export BOUNDARY_REGISTRY array',
+    );
+    process.exit(2);
+  }
+  return mod.BOUNDARY_REGISTRY;
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem enumeration
+// ---------------------------------------------------------------------------
+
+/**
+ * Enumerate Rust crate directories under `crates/`. A directory is treated as
+ * a crate iff it contains a `Cargo.toml`.
+ *
+ * @returns {string[]} Sorted list of crate directory basenames.
+ */
+function enumerateCrates() {
+  const cratesDir = join(REPO_ROOT, 'crates');
+  if (!existsSync(cratesDir)) return [];
+  return readdirSync(cratesDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => existsSync(join(cratesDir, name, 'Cargo.toml')))
+    .sort();
+}
+
+/**
+ * Enumerate npm package directories under `packages/`. A directory is treated
+ * as a package iff it contains a `package.json`. Per-platform napi sidecar
+ * packages (`<module>-napi-<triple>` such as `worktree-napi-linux-x64-gnu`)
+ * are filtered OUT: they ship as artifacts of the canonical napi entry
+ * already registered in BOUNDARY_REGISTRY and would otherwise produce false
+ * ORPHAN reports.
+ *
+ * @returns {string[]} Sorted list of package directory basenames.
+ */
+function enumeratePackages() {
+  const pkgDir = join(REPO_ROOT, 'packages');
+  if (!existsSync(pkgDir)) return [];
+  return readdirSync(pkgDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => existsSync(join(pkgDir, name, 'package.json')))
+    .filter((name) => !isNapiPlatformPackage(name))
+    .sort();
+}
+
+/**
+ * Returns true for per-platform napi sidecar packages whose canonical home
+ * is the corresponding `<base>-napi` entry already in the registry.
+ *
+ * Matches names of the form `<base>-napi-<triple>` where `<triple>` looks
+ * like `linux-x64-gnu`, `darwin-arm64`, `win32-x64-msvc`, etc.
+ *
+ * @param {string} name - Package directory name.
+ * @returns {boolean}
+ */
+function isNapiPlatformPackage(name) {
+  return /-napi-(linux|darwin|win32)(-[a-z0-9]+)+$/.test(name);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-check
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when a registry entry is allowed to reference a missing
+ * on-disk module (e.g. migrated-out shells whose path may be deleted).
+ *
+ * @param {object} entry - BoundaryEntry row.
+ * @returns {boolean}
+ */
+function isMissingExempt(entry) {
+  if (entry.canonicalHome === 'archived') return true;
+  if (
+    typeof entry.canonicalHome === 'object' &&
+    entry.canonicalHome &&
+    'external' in entry.canonicalHome
+  ) {
+    // External canonical home — module body MAY have been deleted from cleocode.
+    // Only exempt when the workload intent matches the migration posture.
+    if (entry.intent === 'migrated-out') return true;
+  }
+  return false;
+}
+
+/**
+ * Cross-check the registry against on-disk reality.
+ *
+ * @param {readonly object[]} registry - Loaded BOUNDARY_REGISTRY entries.
+ * @returns {{orphans: object[], missing: object[], driftIntent: object[], ok: object[]}}
+ */
+function crossCheck(registry) {
+  const cratesOnDisk = enumerateCrates();
+  const packagesOnDisk = enumeratePackages();
+
+  // Collect every disk-relative path declared by the registry.
+  const declaredRustCores = new Set();
+  const declaredNapiBindings = new Set();
+  const declaredTsWrappers = new Set();
+  for (const entry of registry) {
+    if (entry.rustCore) declaredRustCores.add(entry.rustCore);
+    if (entry.napiBinding) declaredNapiBindings.add(entry.napiBinding);
+    if (entry.tsWrapper) declaredTsWrappers.add(entry.tsWrapper);
+  }
+
+  const orphans = [];
+  const missing = [];
+  const driftIntent = [];
+  const ok = [];
+
+  // Rule 1 — ORPHAN: crates on disk with no registry entry.
+  for (const crate of cratesOnDisk) {
+    const cratePath = `crates/${crate}`;
+    const inRegistry = declaredRustCores.has(cratePath) || declaredNapiBindings.has(cratePath);
+    if (!inRegistry) {
+      orphans.push({ kind: 'crate', path: cratePath });
+    }
+  }
+
+  // Rule 1 — ORPHAN: packages on disk with no registry entry.
+  for (const pkg of packagesOnDisk) {
+    const pkgPath = `packages/${pkg}`;
+    const inRegistry = declaredTsWrappers.has(pkgPath) || declaredNapiBindings.has(pkgPath);
+    if (!inRegistry) {
+      orphans.push({ kind: 'package', path: pkgPath });
+    }
+  }
+
+  // Rule 2 — MISSING: registry path that no longer exists on disk.
+  // Rule 3 — INTENT_DRIFT: declared intent contradicts on-disk shape.
+  for (const entry of registry) {
+    const exemptMissing = isMissingExempt(entry);
+    let entryOk = true;
+
+    if (entry.rustCore) {
+      const absPath = join(REPO_ROOT, entry.rustCore);
+      const exists = existsSync(absPath) && statSync(absPath).isDirectory();
+      if (!exists && !exemptMissing) {
+        missing.push({ module: entry.module, kind: 'rustCore', path: entry.rustCore });
+        entryOk = false;
+      }
+    }
+    if (entry.napiBinding) {
+      const absPath = join(REPO_ROOT, entry.napiBinding);
+      const exists = existsSync(absPath) && statSync(absPath).isDirectory();
+      if (!exists && !exemptMissing) {
+        missing.push({ module: entry.module, kind: 'napiBinding', path: entry.napiBinding });
+        entryOk = false;
+      }
+      // Intent drift — napi binding declared but workload intent is not ffi-surface
+      // AND not a migration-pending shell. Heuristic; tolerated for some
+      // archive states.
+      if (
+        entry.intent !== 'ffi-surface' &&
+        entry.intent !== 'migration-pending' &&
+        entry.intent !== 'migrated-out'
+      ) {
+        driftIntent.push({
+          module: entry.module,
+          declaredIntent: entry.intent,
+          reason: 'napiBinding present but intent !== ffi-surface',
+        });
+        entryOk = false;
+      }
+    }
+    if (entry.tsWrapper) {
+      const absPath = join(REPO_ROOT, entry.tsWrapper);
+      const exists = existsSync(absPath) && statSync(absPath).isDirectory();
+      if (!exists && !exemptMissing) {
+        missing.push({ module: entry.module, kind: 'tsWrapper', path: entry.tsWrapper });
+        entryOk = false;
+      }
+    }
+
+    if (entryOk) ok.push(entry.module);
+  }
+
+  return { orphans, missing, driftIntent, ok };
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+/**
+ * Print a human-readable report to stderr/stdout and return the appropriate
+ * exit code.
+ *
+ * @param {ReturnType<typeof crossCheck>} report - Cross-check result.
+ * @returns {number} Process exit code.
+ */
+function printReport(report) {
+  const { orphans, missing, driftIntent, ok } = report;
+  const total = orphans.length + missing.length + driftIntent.length;
+
+  if (jsonOutput) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: total === 0,
+          counts: {
+            orphans: orphans.length,
+            missing: missing.length,
+            driftIntent: driftIntent.length,
+            okEntries: ok.length,
+          },
+          orphans,
+          missing,
+          driftIntent,
+        },
+        null,
+        2,
+      ),
+    );
+    return total === 0 ? 0 : 1;
+  }
+
+  if (total === 0) {
+    console.log(`Boundary registry matches filesystem reality. ${ok.length} entries verified.`);
+    if (verbose) {
+      for (const m of ok) console.log(`  ok  ${m}`);
+    }
+    return 0;
+  }
+
+  console.error('Boundary registry drift detected.');
+  console.error('');
+  if (orphans.length > 0) {
+    console.error(`ORPHANS (${orphans.length}) — on disk but missing from BOUNDARY_REGISTRY:`);
+    for (const o of orphans) {
+      console.error(`  ${o.kind.padEnd(8)} ${o.path}`);
+    }
+    console.error('');
+  }
+  if (missing.length > 0) {
+    console.error(
+      `MISSING (${missing.length}) — registry entry references a path that does not exist:`,
+    );
+    for (const m of missing) {
+      console.error(`  ${m.module.padEnd(28)} ${m.kind.padEnd(12)} ${m.path}`);
+    }
+    console.error('');
+  }
+  if (driftIntent.length > 0) {
+    console.error(`INTENT DRIFT (${driftIntent.length}) — declared intent contradicts shape:`);
+    for (const d of driftIntent) {
+      console.error(`  ${d.module.padEnd(28)} intent=${d.declaredIntent}  ${d.reason}`);
+    }
+    console.error('');
+  }
+  console.error('Fix: amend BOUNDARY_REGISTRY in packages/contracts/src/boundary.ts');
+  console.error('via an ADR-078 amendment + PR. See AGENTS.md "Boundary Registry" section.');
+  return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const registry = await loadRegistry(fixturePath);
+const report = crossCheck(registry);
+process.exit(printReport(report));


### PR DESCRIPTION
## Summary

T10198 — SG-BOUNDARY-REGISTRY (Saga T10176) — E2 task. Wires the registry
shipped in T10197 (PR #503: 39 entries — 19 crates + 20 packages) to a CI
gate that rejects drift between `BOUNDARY_REGISTRY` and the actual contents
of `crates/` + `packages/` at PR-time.

- `scripts/lint-boundary-registry.mjs` — loads compiled
  `packages/contracts/dist/boundary.js`, enumerates disk, applies three
  rules: ORPHAN (disk module missing from registry), MISSING (registry
  path no longer on disk; exempt when `canonicalHome === 'archived'` or
  `{ external }` + `migrated-out`), INTENT_DRIFT (napiBinding declared
  but `intent !== 'ffi-surface'`). `--json` / `--verbose` / `--fixture`
  / exit codes 0|1|2.
- `.github/workflows/boundary-registry-lint.yml` — required check on
  `push:main` + `pull_request:main`. Builds contracts, runs linter +
  poison tests.
- `scripts/__tests__/lint-boundary-registry.test.mjs` — 9 cases covering
  clean state, orphan (crate + package), missing (rustCore + tsWrapper),
  archived-exemption regression for T10205, intent drift, and CLI plumbing.
- `package.json` — adds `lint:boundary-registry` script.

## First-run results on current main

```
$ node scripts/lint-boundary-registry.mjs
Boundary registry matches filesystem reality. 39 entries verified.
```

Zero orphans, zero missing, zero drift. T10197's registry is complete and
the archived-exemption correctly handles `cleo-llm-native` after the
T10205 crate deletion (PR #502).

## Test plan

- [x] `pnpm --filter @cleocode/contracts run build` (precondition)
- [x] `node scripts/lint-boundary-registry.mjs` → exit 0, 39 entries verified
- [x] `pnpm exec vitest run scripts/__tests__/lint-boundary-registry.test.mjs` → 9/9 pass
- [x] `pnpm biome check` → clean
- [x] `pnpm run lint:boundary-registry` end-to-end works
- [ ] CI: `Boundary Registry Lint` workflow green (this PR)

Closes T10198
Saga: T10176 (SG-BOUNDARY-REGISTRY)
Decision: D010
ADR: ADR-078

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>