### PR TITLE
feat(T10115): saga enforcement runtime gates (I3/I5/I7)

### DIFF
--- a/.changeset/T10115-saga-enforcement.md
+++ b/.changeset/T10115-saga-enforcement.md
@@ -1,0 +1,11 @@
+---
+"@cleocode/core": patch
+"@cleocode/contracts": patch
+---
+
+feat(T10115): saga enforcement runtime gates (I3/I5/I7)
+
+Pure-function guards assertSagaInvariantI3/I5/I7 in packages/core/src/sagas/enforcement.ts.
+Throws SagaInvariantViolationError with code E_SAGA_INVARIANT_VIOLATION_I{3,5,7} and
+structured diag payload. Foundation for T10118 sagaAdd wiring + T10119 doctor audit.
+Saga: T10113. Epic: T10209.

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -234,6 +234,67 @@ export class LeadBypassDetectedError extends Error {
 }
 
 /**
+ * LAFS error code emitted when a saga-labeled epic carries forbidden parent or
+ * `depends` edges — ADR-073 §1.2 invariant **I3** violation.
+ *
+ * Sagas MUST link to member Epics exclusively via
+ * `task_relations.type='groups'`; a parent or depends edge re-introduces the
+ * depth-budget consumption the saga tier was created to avoid.
+ *
+ * Runtime guard: `assertSagaInvariantI3` (in `@cleocode/core` saga module).
+ *
+ * @task T10115
+ * @saga T10113
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+export const E_SAGA_INVARIANT_VIOLATION_I3 = 'E_SAGA_INVARIANT_VIOLATION_I3' as const;
+
+/**
+ * LAFS error code emitted when a saga-labeled row has a non-null `parentId` —
+ * ADR-073 §1.2 invariant **I5** violation.
+ *
+ * Sagas are top-level groupings; they do not nest under any task. A non-null
+ * `parentId` on a saga-labeled row indicates storage corruption or a faulty
+ * import path.
+ *
+ * Runtime guard: `assertSagaInvariantI5` (in `@cleocode/core` saga module).
+ *
+ * @task T10115
+ * @saga T10113
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+export const E_SAGA_INVARIANT_VIOLATION_I5 = 'E_SAGA_INVARIANT_VIOLATION_I5' as const;
+
+/**
+ * LAFS error code emitted when a saga-member candidate is itself a saga —
+ * ADR-073 §1.2 invariant **I7** violation (no nested sagas).
+ *
+ * Nested sagas would re-introduce the multi-release grouping depth the tier
+ * was created to flatten.
+ *
+ * Runtime guard: `assertSagaInvariantI7` (in `@cleocode/core` saga module).
+ *
+ * @task T10115
+ * @saga T10113
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+export const E_SAGA_INVARIANT_VIOLATION_I7 = 'E_SAGA_INVARIANT_VIOLATION_I7' as const;
+
+/**
+ * Union of saga-invariant LAFS error codes (I3 / I5 / I7).
+ *
+ * Useful for narrowing thrown error codes from
+ * `assertSagaInvariantI{3,5,7}` in dispatch handlers.
+ *
+ * @task T10115
+ * @saga T10113
+ */
+export type SagaInvariantErrorCode =
+  | typeof E_SAGA_INVARIANT_VIOLATION_I3
+  | typeof E_SAGA_INVARIANT_VIOLATION_I5
+  | typeof E_SAGA_INVARIANT_VIOLATION_I7;
+
+/**
  * Normalize any thrown value into a standardized error object.
  *
  * Handles:

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -344,12 +344,16 @@ export {
   TASK_SEVERITIES,
   TASK_SIZES,
 } from './enums.js';
+export type { SagaInvariantErrorCode } from './errors.js';
 // === Error Utilities ===
 export {
   ClassifierUnregisteredAgentError,
   createErrorResult,
   createSuccessResult,
   DecisionValidatorFailedError,
+  E_SAGA_INVARIANT_VIOLATION_I3,
+  E_SAGA_INVARIANT_VIOLATION_I5,
+  E_SAGA_INVARIANT_VIOLATION_I7,
   formatError,
   getErrorMessage,
   isErrorResult,

--- a/packages/core/src/sagas/__tests__/enforcement.test.ts
+++ b/packages/core/src/sagas/__tests__/enforcement.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for the saga enforcement guards (ADR-073 §1.2 invariants I3 / I5 / I7).
+ *
+ * The guards are pure functions — no DB, no filesystem. Tests synthesize
+ * minimal {@link Task} fixtures and assert each guard accepts valid input
+ * and throws a typed {@link SagaInvariantViolationError} (with stable
+ * `.code` and structured `.diag`) on invariant breach.
+ *
+ * Includes the T9831-nested-in-T9799 regression fixture for I7 — the
+ * historical scenario where the orchestrator could have attempted to link a
+ * saga (`T9831` SG-ARCH-SOLID) as a member of another saga (`T9799` skill
+ * maintenance), which I7 forbids.
+ *
+ * @task T10115
+ * @saga T10113
+ * @epic T10209
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+
+import type { Task } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { SAGA_LABEL } from '../constants.js';
+import {
+  assertSagaInvariantI3,
+  assertSagaInvariantI5,
+  assertSagaInvariantI7,
+  E_SAGA_INVARIANT_VIOLATION_I3,
+  E_SAGA_INVARIANT_VIOLATION_I5,
+  E_SAGA_INVARIANT_VIOLATION_I7,
+  isSagaInvariantViolationError,
+  SagaInvariantViolationError,
+} from '../enforcement.js';
+
+/** Build a minimal {@link Task} fixture for guard tests. */
+function makeTask(overrides: Partial<Task> & Pick<Task, 'id'>): Task {
+  return {
+    id: overrides.id,
+    title: overrides.title ?? `Task ${overrides.id}`,
+    description: overrides.description ?? `Description for ${overrides.id}`,
+    status: overrides.status ?? 'pending',
+    priority: overrides.priority ?? 'medium',
+    type: overrides.type ?? 'epic',
+    parentId: overrides.parentId ?? null,
+    labels: overrides.labels,
+    depends: overrides.depends,
+    ...overrides,
+  };
+}
+
+describe('assertSagaInvariantI3 — sagas link via groups only', () => {
+  it('accepts a valid saga with no parent and no depends edges', () => {
+    const saga = makeTask({
+      id: 'T9000',
+      labels: [SAGA_LABEL],
+      parentId: null,
+    });
+    expect(() => assertSagaInvariantI3(saga)).not.toThrow();
+  });
+
+  it('is a no-op for a non-saga task (no saga label)', () => {
+    const epic = makeTask({
+      id: 'T9001',
+      labels: [],
+      parentId: 'T9000',
+      depends: ['T9100'],
+    });
+    expect(() => assertSagaInvariantI3(epic)).not.toThrow();
+  });
+
+  it('throws E_SAGA_INVARIANT_VIOLATION_I3 when a saga has a parentId', () => {
+    const saga = makeTask({
+      id: 'T9000',
+      labels: [SAGA_LABEL],
+      parentId: 'T8000',
+    });
+    let caught: unknown;
+    try {
+      assertSagaInvariantI3(saga);
+    } catch (err) {
+      caught = err;
+    }
+    expect(isSagaInvariantViolationError(caught)).toBe(true);
+    const error = caught as SagaInvariantViolationError;
+    expect(error.code).toBe(E_SAGA_INVARIANT_VIOLATION_I3);
+    expect(error.diag.invariant).toBe('I3');
+    expect(error.diag.sagaId).toBe('T9000');
+    expect(error.diag.offendingId).toBe('T9000');
+    expect(error.message).toContain('T9000');
+    expect(error.message).toContain('parentId');
+  });
+
+  it('throws E_SAGA_INVARIANT_VIOLATION_I3 when a saga has depends edges', () => {
+    const saga = makeTask({
+      id: 'T9000',
+      labels: [SAGA_LABEL],
+      parentId: null,
+      depends: ['T8100'],
+    });
+    expect(() => assertSagaInvariantI3(saga)).toThrow(SagaInvariantViolationError);
+    try {
+      assertSagaInvariantI3(saga);
+    } catch (err) {
+      const error = err as SagaInvariantViolationError;
+      expect(error.code).toBe(E_SAGA_INVARIANT_VIOLATION_I3);
+      expect(error.diag.invariant).toBe('I3');
+      expect(error.message).toContain('depends');
+    }
+  });
+});
+
+describe('assertSagaInvariantI5 — saga.parentId MUST be NULL', () => {
+  it('accepts a valid saga with parentId=null', () => {
+    const saga = makeTask({
+      id: 'T9000',
+      labels: [SAGA_LABEL],
+      parentId: null,
+    });
+    expect(() => assertSagaInvariantI5(saga)).not.toThrow();
+  });
+
+  it('accepts a valid saga with parentId omitted', () => {
+    const saga = makeTask({
+      id: 'T9000',
+      labels: [SAGA_LABEL],
+    });
+    expect(() => assertSagaInvariantI5(saga)).not.toThrow();
+  });
+
+  it('is a no-op for a non-saga task with a parentId', () => {
+    const epic = makeTask({
+      id: 'T9001',
+      labels: ['feature'],
+      parentId: 'T9000',
+    });
+    expect(() => assertSagaInvariantI5(epic)).not.toThrow();
+  });
+
+  it('throws E_SAGA_INVARIANT_VIOLATION_I5 when a saga has parentId != null', () => {
+    const saga = makeTask({
+      id: 'T9000',
+      labels: [SAGA_LABEL],
+      parentId: 'T8000',
+    });
+    let caught: unknown;
+    try {
+      assertSagaInvariantI5(saga);
+    } catch (err) {
+      caught = err;
+    }
+    expect(isSagaInvariantViolationError(caught)).toBe(true);
+    const error = caught as SagaInvariantViolationError;
+    expect(error.code).toBe(E_SAGA_INVARIANT_VIOLATION_I5);
+    expect(error.diag.invariant).toBe('I5');
+    expect(error.diag.sagaId).toBe('T9000');
+    expect(error.diag.offendingId).toBe('T9000');
+    expect(error.message).toContain('T9000');
+  });
+
+  it('throws E_SAGA_INVARIANT_VIOLATION_I5 when a saga has empty-string parentId only on truthy non-null', () => {
+    // Empty string is a degenerate case we treat as null (see guard logic).
+    const saga = makeTask({
+      id: 'T9000',
+      labels: [SAGA_LABEL],
+      parentId: '',
+    });
+    expect(() => assertSagaInvariantI5(saga)).not.toThrow();
+  });
+});
+
+describe('assertSagaInvariantI7 — no nested sagas', () => {
+  it('accepts a regular epic candidate (no saga label)', () => {
+    expect(() => assertSagaInvariantI7('T9100', ['feature'])).not.toThrow();
+  });
+
+  it('accepts a candidate with empty labels', () => {
+    expect(() => assertSagaInvariantI7('T9100', [])).not.toThrow();
+  });
+
+  it('throws E_SAGA_INVARIANT_VIOLATION_I7 when the candidate has the saga label', () => {
+    let caught: unknown;
+    try {
+      assertSagaInvariantI7('T9100', [SAGA_LABEL], 'T9000');
+    } catch (err) {
+      caught = err;
+    }
+    expect(isSagaInvariantViolationError(caught)).toBe(true);
+    const error = caught as SagaInvariantViolationError;
+    expect(error.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+    expect(error.diag.invariant).toBe('I7');
+    expect(error.diag.sagaId).toBe('T9000');
+    expect(error.diag.offendingId).toBe('T9100');
+    expect(error.message).toContain('T9100');
+    expect(error.message).toContain('nested');
+  });
+
+  it('omits sagaId from diag when not provided', () => {
+    try {
+      assertSagaInvariantI7('T9100', [SAGA_LABEL]);
+    } catch (err) {
+      const error = err as SagaInvariantViolationError;
+      expect(error.diag.sagaId).toBeUndefined();
+      expect(error.diag.offendingId).toBe('T9100');
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // T9831-nested-in-T9799 regression fixture
+  //
+  // Historical context (see MEMORY.md, Saga T9831 SG-ARCH-SOLID + Saga
+  // T9799 skill maintenance discipline). Both T9831 and T9799 are sagas.
+  // If a future code path attempted to link T9831 as a member of T9799,
+  // I7 must reject it — a saga cannot itself be a saga member.
+  // ──────────────────────────────────────────────────────────────────────
+  it('regression: rejects linking saga T9831 as a member of saga T9799 (T9831-nested-in-T9799)', () => {
+    // T9831 is itself a saga ('SG-ARCH-SOLID') — labels contain 'saga'.
+    const candidateLabels = [SAGA_LABEL] as const;
+    let caught: unknown;
+    try {
+      assertSagaInvariantI7('T9831', candidateLabels, 'T9799');
+    } catch (err) {
+      caught = err;
+    }
+    expect(isSagaInvariantViolationError(caught)).toBe(true);
+    const error = caught as SagaInvariantViolationError;
+    expect(error.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+    expect(error.diag).toEqual({
+      sagaId: 'T9799',
+      offendingId: 'T9831',
+      invariant: 'I7',
+    });
+    expect(error.message).toContain('T9831');
+    expect(error.message).toContain(SAGA_LABEL);
+  });
+});
+
+describe('SagaInvariantViolationError shape', () => {
+  it('extends Error and carries name="SagaInvariantViolationError"', () => {
+    const err = new SagaInvariantViolationError(E_SAGA_INVARIANT_VIOLATION_I3, 'test', {
+      invariant: 'I3',
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('SagaInvariantViolationError');
+    expect(err.code).toBe(E_SAGA_INVARIANT_VIOLATION_I3);
+  });
+
+  it('isSagaInvariantViolationError returns false for non-saga errors', () => {
+    expect(isSagaInvariantViolationError(new Error('generic'))).toBe(false);
+    expect(isSagaInvariantViolationError('string')).toBe(false);
+    expect(isSagaInvariantViolationError(null)).toBe(false);
+    expect(isSagaInvariantViolationError(undefined)).toBe(false);
+  });
+});

--- a/packages/core/src/sagas/enforcement.ts
+++ b/packages/core/src/sagas/enforcement.ts
@@ -1,0 +1,222 @@
+/**
+ * Saga enforcement — pure-function runtime gates for ADR-073 invariants.
+ *
+ * Each guard accepts already-loaded task data and throws
+ * {@link SagaInvariantViolationError} when an invariant is breached. The
+ * guards perform NO database access — callers (dispatch handlers, doctor
+ * audits) are responsible for resolving rows first and passing them in.
+ *
+ * Wiring into the saga-write paths (`sagaAdd`, `sagaCreate`, ...) is the
+ * scope of T10118. Wiring into the doctor audit is T10119. This module
+ * exposes the guards in isolation so they can be unit-tested without a
+ * database fixture and reused by both runtime + audit callers.
+ *
+ * @task T10115
+ * @saga T10113 — SG-SAGA-FIRST-CLASS
+ * @epic T10209 — E-SAGA-ENFORCEMENT
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+
+import type { Task } from '@cleocode/contracts';
+import { SAGA_LABEL } from './constants.js';
+
+/**
+ * LAFS error code for a saga-labeled epic that carries forbidden parent or
+ * `depends` edges (ADR-073 §1.2 invariant I3).
+ */
+export const E_SAGA_INVARIANT_VIOLATION_I3 = 'E_SAGA_INVARIANT_VIOLATION_I3' as const;
+
+/**
+ * LAFS error code for a saga row whose `parentId` is non-null
+ * (ADR-073 §1.2 invariant I5).
+ */
+export const E_SAGA_INVARIANT_VIOLATION_I5 = 'E_SAGA_INVARIANT_VIOLATION_I5' as const;
+
+/**
+ * LAFS error code for a saga-member candidate that is itself a saga
+ * (ADR-073 §1.2 invariant I7 — no nested sagas).
+ */
+export const E_SAGA_INVARIANT_VIOLATION_I7 = 'E_SAGA_INVARIANT_VIOLATION_I7' as const;
+
+/**
+ * Union of stable error codes emitted by the saga enforcement guards.
+ */
+export type SagaInvariantCode =
+  | typeof E_SAGA_INVARIANT_VIOLATION_I3
+  | typeof E_SAGA_INVARIANT_VIOLATION_I5
+  | typeof E_SAGA_INVARIANT_VIOLATION_I7;
+
+/**
+ * Structured diagnostic payload attached to every saga invariant violation.
+ *
+ * Mirrors the LAFS `meta` shape so dispatch handlers can forward it into the
+ * envelope without re-shaping.
+ */
+export interface SagaInvariantDiag {
+  /** Saga task ID (when known). */
+  sagaId?: string;
+  /** Offending task ID — the row that violated the invariant. */
+  offendingId?: string;
+  /** Stable invariant identifier (e.g. `'I3'`, `'I5'`, `'I7'`). */
+  invariant: 'I3' | 'I5' | 'I7';
+}
+
+/**
+ * Thrown by the saga enforcement guards when an ADR-073 §1.2 invariant is
+ * violated. Carries a stable `.code` and a structured `.diag` payload so
+ * dispatch handlers can surface a typed LAFS error rather than a generic
+ * `Error`.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   assertSagaInvariantI3(saga);
+ * } catch (err) {
+ *   if (err instanceof SagaInvariantViolationError) {
+ *     // err.code === 'E_SAGA_INVARIANT_VIOLATION_I3'
+ *     // err.diag.invariant === 'I3'
+ *   }
+ * }
+ * ```
+ */
+export class SagaInvariantViolationError extends Error {
+  /**
+   * @param code - Stable LAFS error code for the violated invariant.
+   * @param message - Human-readable description of the violation.
+   * @param diag - Structured diagnostic payload (saga / offending IDs, invariant tag).
+   */
+  constructor(
+    public readonly code: SagaInvariantCode,
+    message: string,
+    public readonly diag: SagaInvariantDiag,
+  ) {
+    super(message);
+    this.name = 'SagaInvariantViolationError';
+  }
+}
+
+/**
+ * Type guard — true when `value` is a {@link SagaInvariantViolationError}.
+ *
+ * Useful in dispatch handlers that need to forward `.code` + `.diag` into a
+ * LAFS envelope without instanceof-ing across module boundaries.
+ *
+ * @param value - Any thrown value.
+ * @returns True when the value is a SagaInvariantViolationError.
+ */
+export function isSagaInvariantViolationError(
+  value: unknown,
+): value is SagaInvariantViolationError {
+  return value instanceof SagaInvariantViolationError;
+}
+
+/**
+ * Determine whether a task row carries the `'saga'` label.
+ *
+ * @param labels - The task's labels array (may be undefined / empty).
+ * @returns True when `'saga'` appears in the label list.
+ */
+function hasSagaLabel(labels: readonly string[] | undefined): boolean {
+  return Array.isArray(labels) && labels.includes(SAGA_LABEL);
+}
+
+/**
+ * ADR-073 §1.2 invariant **I3** — sagas link via
+ * `task_relations.type='groups'` only.
+ *
+ * A saga-labeled epic MUST NOT carry `parentId` or any entries in `depends`.
+ * Member discovery flows through `task_relations.type='groups'`; a parent or
+ * depends edge would re-introduce the depth-budget consumption the saga tier
+ * was created to avoid.
+ *
+ * The guard is a no-op when the input is not a saga (no `'saga'` label) —
+ * callers can pass any task without first filtering.
+ *
+ * @param saga - Task row to check.
+ * @throws {@link SagaInvariantViolationError} with
+ *   {@link E_SAGA_INVARIANT_VIOLATION_I3} when the row violates I3.
+ *
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+export function assertSagaInvariantI3(saga: Task): void {
+  if (!hasSagaLabel(saga.labels)) {
+    return;
+  }
+  if (saga.parentId != null && saga.parentId !== '') {
+    throw new SagaInvariantViolationError(
+      E_SAGA_INVARIANT_VIOLATION_I3,
+      `E_SAGA_INVARIANT_VIOLATION_I3: saga '${saga.id}' has parentId='${saga.parentId}'; ` +
+        "sagas MUST link to members via task_relations.type='groups' (ADR-073 §1.2 I3).",
+      { sagaId: saga.id, offendingId: saga.id, invariant: 'I3' },
+    );
+  }
+  if (Array.isArray(saga.depends) && saga.depends.length > 0) {
+    throw new SagaInvariantViolationError(
+      E_SAGA_INVARIANT_VIOLATION_I3,
+      `E_SAGA_INVARIANT_VIOLATION_I3: saga '${saga.id}' has ${saga.depends.length} depends edge(s); ` +
+        "sagas MUST link only via task_relations.type='groups' (ADR-073 §1.2 I3).",
+      { sagaId: saga.id, offendingId: saga.id, invariant: 'I3' },
+    );
+  }
+}
+
+/**
+ * ADR-073 §1.2 invariant **I5** — a saga row's `parentId` MUST be NULL.
+ *
+ * Sagas are top-level groupings; they do not nest under any task. A non-null
+ * `parentId` on a saga-labeled row is a storage corruption / import bug.
+ *
+ * The guard is a no-op when the input is not a saga (no `'saga'` label).
+ *
+ * @param saga - Task row to check.
+ * @throws {@link SagaInvariantViolationError} with
+ *   {@link E_SAGA_INVARIANT_VIOLATION_I5} when the row violates I5.
+ *
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+export function assertSagaInvariantI5(saga: Task): void {
+  if (!hasSagaLabel(saga.labels)) {
+    return;
+  }
+  if (saga.parentId != null && saga.parentId !== '') {
+    throw new SagaInvariantViolationError(
+      E_SAGA_INVARIANT_VIOLATION_I5,
+      `E_SAGA_INVARIANT_VIOLATION_I5: saga '${saga.id}' has parentId='${saga.parentId}', expected NULL ` +
+        '(ADR-073 §1.2 I5 — sagas are top-level).',
+      { sagaId: saga.id, offendingId: saga.id, invariant: 'I5' },
+    );
+  }
+}
+
+/**
+ * ADR-073 §1.2 invariant **I7** — no nested sagas.
+ *
+ * A saga-member candidate (i.e. a task being linked into a saga via
+ * `task_relations.type='groups'`) MUST NOT itself carry the `'saga'` label.
+ * Nested sagas would re-introduce the multi-release grouping depth the tier
+ * was created to flatten.
+ *
+ * @param candidateId - Task ID being considered as a saga member.
+ * @param candidateLabels - The candidate's labels array.
+ * @param sagaId - Optional ID of the saga the candidate would be linked into
+ *   (surfaced in the diag payload when provided).
+ * @throws {@link SagaInvariantViolationError} with
+ *   {@link E_SAGA_INVARIANT_VIOLATION_I7} when the candidate is a saga.
+ *
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+export function assertSagaInvariantI7(
+  candidateId: string,
+  candidateLabels: readonly string[],
+  sagaId?: string,
+): void {
+  if (!hasSagaLabel(candidateLabels)) {
+    return;
+  }
+  throw new SagaInvariantViolationError(
+    E_SAGA_INVARIANT_VIOLATION_I7,
+    `E_SAGA_INVARIANT_VIOLATION_I7: candidate '${candidateId}' already has label='${SAGA_LABEL}'; ` +
+      'nested sagas are forbidden (ADR-073 §1.2 I7).',
+    { sagaId, offendingId: candidateId, invariant: 'I7' },
+  );
+}

--- a/packages/core/src/sagas/index.ts
+++ b/packages/core/src/sagas/index.ts
@@ -15,6 +15,18 @@
 export { type SagaAddParams, type SagaAddResult, sagaAdd } from './add.js';
 export { LIST_BINDING_SAGA_GROUPS, SAGA_GROUPS_RELATION, SAGA_LABEL } from './constants.js';
 export { type SagaCreateParams, sagaCreate } from './create.js';
+export {
+  assertSagaInvariantI3,
+  assertSagaInvariantI5,
+  assertSagaInvariantI7,
+  E_SAGA_INVARIANT_VIOLATION_I3,
+  E_SAGA_INVARIANT_VIOLATION_I5,
+  E_SAGA_INVARIANT_VIOLATION_I7,
+  isSagaInvariantViolationError,
+  type SagaInvariantCode,
+  type SagaInvariantDiag,
+  SagaInvariantViolationError,
+} from './enforcement.js';
 export { type SagaListResult, sagaList } from './list.js';
 export {
   type SagaMemberEntry,


### PR DESCRIPTION
## Summary

Adds pure-function runtime gates for ADR-073 saga invariants:
- I3 — sagas link via groups relation only
- I5 — saga.parentId is NULL
- I7 — no nested sagas

Each guard throws `SagaInvariantViolationError` with typed `.code` and
structured `.diag` payload (NOT generic Error).

Foundation for T10118 (sagaAdd wiring) and T10119 (doctor audit).

## Test plan

- [x] pnpm biome check
- [x] pnpm run build
- [x] pnpm exec vitest run packages/core/src/sagas
- [x] T9831-nested-in-T9799 regression fixture in I7 tests

Closes T10115; Saga T10113; Epic T10209.