### PR TITLE
feat(T10224): publish=true + criterion benches for 4 cleocode crates

### DIFF
--- a/.changeset/t10224-publish-flips.md
+++ b/.changeset/t10224-publish-flips.md
@@ -1,0 +1,54 @@
+---
+"@cleocode/cleo": patch
+---
+
+feat(T10224): publish=true + criterion benches for cant-{core,router,runtime} + lafs-core (SAGA T10176)
+
+Completes the cleocode publish chain unblocked by T10206 (conduit-core flip).
+Each crate now has a criterion bench per ADR-078 perf-budget contract.
+Signaldock crates remain publish=false (handled by parallel saga T10180).
+
+Flips (4 crates):
+- cant-core: publish=true + license + repository + keywords + categories.
+- cant-router: publish=true + license + repository + keywords + categories.
+- cant-runtime: publish=true + license + repository + keywords + categories.
+- lafs-core: publish=true + license + repository + keywords + categories.
+
+Benches (one per crate, criterion harness):
+- cant-core/benches/parse_message.rs — minimal + full CANT parse round-trip
+  (p50: 98 ns minimal, 2.78 µs full).
+- cant-router/benches/route_decision.rs — simple + complex prompt classify+route
+  (p50: 697 ns simple, 2.68 µs complex).
+- cant-runtime/benches/env_resolve.rs — simple + full pipeline-args variable
+  resolve (p50: 143 ns simple, 1.09 µs full). T07 single-pass invariant
+  hot-path.
+- lafs-core/benches/envelope_serde.rs — success + error envelope JSON
+  round-trip (p50: 2.53 µs success, 2.74 µs error).
+
+Publish-chain unblockers (the real T10206 follow-on):
+- lafs-core: vendor `packages/lafs/schemas/v1/envelope.schema.json` into
+  `crates/lafs-core/schemas/v1/` so `include_str!` is crate-relative.
+  `cargo publish` rejects paths that traverse outside the crate dir.
+- cant-core: vendor `packages/caamp/providers/hook-mappings.json` into
+  `crates/cant-core/vendor/caamp/` and update `build.rs` to prefer the
+  workspace canonical when present, fall back to the vendored copy in
+  publish-tarball mode.
+- conduit-core: also add `version` to its `lafs-core` path dep (was the
+  missing piece from T10206 that blocked the chain).
+
+Parity CI gates (TS canonical stays authoritative):
+- `scripts/lint-lafs-schema-parity.mjs` — byte-identity check.
+- `scripts/lint-cant-core-hook-mappings-parity.mjs` — byte-identity check.
+- New CI job `Rust Vendor Parity Lint (T10224)` wires both into `.github/workflows/ci.yml`.
+
+Verification:
+- `cargo build --workspace --all-features` — green.
+- `cargo bench --no-run` for all 4 new benches — green.
+- `cargo package -p lafs-core -p conduit-core -p cant-core -p cant-router -p cant-runtime --allow-dirty` —
+  green (full workspace-aware publish-chain dry-run, including the
+  conduit-core gate from AC8).
+- `cargo test -p lafs-core` — 37 unit + 2 doctests green (vendored schema
+  validates the same as canonical).
+- 5 `starter_bundle_*` test failures in `crates/cant-core/tests/parse_new_sections.rs`
+  are PRE-EXISTING on origin/main (`packages/agents/starter-bundle/` doesn't
+  exist on main); not caused by this PR. Filed as follow-up.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,30 @@ jobs:
       - name: Lint JSON stream hygiene in cli/commands + core JSON paths
         run: node scripts/lint-json-stream-hygiene.mjs
 
+  rust-vendor-parity-lint:
+    # T10224 / SG-BOUNDARY-REGISTRY (T10176) — enforce parity between
+    # TypeScript canonical sources and the Rust vendored copies that allow
+    # cant-core + lafs-core to ship to crates.io. `cargo publish` rejects
+    # `include_str!` / build-script paths that traverse outside the crate
+    # directory, so the canonical schema (`packages/lafs/schemas/v1/...`)
+    # and hook-mappings (`packages/caamp/providers/hook-mappings.json`) are
+    # mirrored into `crates/lafs-core/schemas/v1/` and
+    # `crates/cant-core/vendor/caamp/` respectively. Drift between the TS
+    # canonical and the Rust vendor is a wire-protocol regression vector.
+    # Pure static analysis of checked-in files — no untrusted input.
+    name: Rust Vendor Parity Lint (T10224)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Enforce LAFS schema parity (TS canonical <-> lafs-core vendor)
+        run: node scripts/lint-lafs-schema-parity.mjs --exit-on-fail
+      - name: Enforce hook-mappings parity (TS canonical <-> cant-core vendor)
+        run: node scripts/lint-cant-core-hook-mappings-parity.mjs --exit-on-fail
+
   contracts-dep-lint:
     name: Contracts Dep Lint
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ name = "cant-core"
 version = "2026.5.99"
 dependencies = [
  "conduit-core",
+ "criterion",
  "nom",
  "serde",
  "serde_json",
@@ -316,6 +317,7 @@ dependencies = [
 name = "cant-router"
 version = "2026.5.99"
 dependencies = [
+ "criterion",
  "serde",
  "serde_json",
 ]
@@ -325,6 +327,7 @@ name = "cant-runtime"
 version = "2026.5.99"
 dependencies = [
  "cant-core",
+ "criterion",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1628,6 +1631,7 @@ name = "lafs-core"
 version = "2026.5.99"
 dependencies = [
  "chrono",
+ "criterion",
  "jsonschema",
  "serde",
  "serde_json",

--- a/crates/cant-core/Cargo.toml
+++ b/crates/cant-core/Cargo.toml
@@ -4,6 +4,11 @@ version.workspace = true
 edition = "2024"
 rust-version = "1.94"
 description = "Canonical CANT grammar parser for CLEO ecosystem"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/kryptobaseddev/cleo"
+keywords = ["cleo", "cant", "parser", "dsl", "agent"]
+categories = ["parser-implementations", "development-tools"]
+publish = true
 
 [lib]
 crate-type = ["rlib"]
@@ -12,10 +17,17 @@ crate-type = ["rlib"]
 nom = "7.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-conduit-core = { path = "../conduit-core" }
+conduit-core = { path = "../conduit-core", version = "2026.5.99" }
 
 [build-dependencies]
 serde_json = "1.0"
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "parse_message"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/cant-core/benches/parse_message.rs
+++ b/crates/cant-core/benches/parse_message.rs
@@ -1,0 +1,54 @@
+//! Criterion benches for cant-core canonical CANT message parsing.
+//!
+//! Captures the perf-budget floor declared in the SG-BOUNDARY-REGISTRY
+//! `boundary.ts` entry for cant-core (ADR-078, Saga T10176).
+//!
+//! Two benches are exposed:
+//!
+//! - `cant_parse_minimal` — bare directive-only header. Establishes the
+//!   absolute parse floor for short agent-to-agent ack messages.
+//! - `cant_parse_full` — representative real-world CANT message with a
+//!   directive, multiple addresses, task refs, tags, plus a multi-line
+//!   body that itself contains task references and addresses. Mirrors
+//!   the on-wire shape conduit-core / signaldock-protocol consumers
+//!   actually receive.
+//!
+//! Each bench calls [`cant_core::parse`] end-to-end so the measured time
+//! captures header/body split, header element extraction, body scanning,
+//! and directive classification — the full canonical hot path.
+
+#![allow(missing_docs)]
+
+use cant_core::parse;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+const MINIMAL_MESSAGE: &str = "/ack";
+
+const FULL_MESSAGE: &str = "/done @cleo-prime @signaldock-core T10224 T10206 #shipped #boundary-registry\n\
+\n\
+## SG-BOUNDARY-REGISTRY Wave E3 complete\n\
+\n\
+@versionguard please verify v2026.5.99 against the publish chain.\n\
+T10194 and T10206 land together — see #ADR-078 for the perf-budget contract.\n\
+Follow-up: T10180 owns signaldock-* publish flips. #follow-up";
+
+fn bench_parse_minimal(c: &mut Criterion) {
+    c.bench_function("cant_parse_minimal", |b| {
+        b.iter(|| {
+            let parsed = parse(black_box(MINIMAL_MESSAGE));
+            black_box(parsed);
+        });
+    });
+}
+
+fn bench_parse_full(c: &mut Criterion) {
+    c.bench_function("cant_parse_full", |b| {
+        b.iter(|| {
+            let parsed = parse(black_box(FULL_MESSAGE));
+            black_box(parsed);
+        });
+    });
+}
+
+criterion_group!(benches, bench_parse_minimal, bench_parse_full);
+criterion_main!(benches);

--- a/crates/cant-core/build.rs
+++ b/crates/cant-core/build.rs
@@ -51,8 +51,20 @@ fn main() {
             process::exit(1);
         }
     };
-    let json_path =
+    // Canonical source — the TypeScript-owned hook-mappings file in the
+    // workspace. Preferred when present (in-tree builds).
+    let workspace_path =
         Path::new(&manifest_dir).join("../../packages/caamp/providers/hook-mappings.json");
+    // Vendored fallback — a byte-identical copy inside the crate directory so
+    // `cargo publish` (which packages only the crate dir) still builds. Parity
+    // with the workspace canonical is enforced at CI time by
+    // `scripts/lint-cant-core-hook-mappings-parity.mjs` (T10224).
+    let vendored_path = Path::new(&manifest_dir).join("vendor/caamp/hook-mappings.json");
+    let json_path = if workspace_path.exists() {
+        workspace_path
+    } else {
+        vendored_path
+    };
 
     // Rerun if either the source of truth or the generator itself changes.
     println!("cargo:rerun-if-changed={}", json_path.display());

--- a/crates/cant-core/vendor/caamp/hook-mappings.json
+++ b/crates/cant-core/vendor/caamp/hook-mappings.json
@@ -1,0 +1,497 @@
+{
+  "$schema": "./hook-mappings.schema.json",
+  "version": "2.0.0",
+  "lastUpdated": "2026-04-06",
+  "description": "CAAMP canonical hook event mappings to provider-native event names. The top-level `canonicalEvents` block is the CAAMP taxonomy that all providers translate to/from. The sibling `piEventCatalog` block is Pi's native lifecycle catalog, consulted when a provider's `capabilities.hooks.nativeEventCatalog` is `\"pi\"`.",
+  "canonicalEvents": {
+    "SessionStart": {
+      "category": "session",
+      "source": "provider",
+      "description": "Session begins, resumes, or is cleared",
+      "canBlock": false
+    },
+    "SessionEnd": {
+      "category": "session",
+      "source": "provider",
+      "description": "Session terminates or exits",
+      "canBlock": false
+    },
+    "PromptSubmit": {
+      "category": "prompt",
+      "source": "provider",
+      "description": "User submits a prompt, before agent processes it",
+      "canBlock": true
+    },
+    "ResponseComplete": {
+      "category": "prompt",
+      "source": "provider",
+      "description": "Agent finishes responding to a turn",
+      "canBlock": false
+    },
+    "PreToolUse": {
+      "category": "tool",
+      "source": "provider",
+      "description": "Before a tool call executes (can block/modify)",
+      "canBlock": true
+    },
+    "PostToolUse": {
+      "category": "tool",
+      "source": "provider",
+      "description": "After a tool call succeeds",
+      "canBlock": false
+    },
+    "PostToolUseFailure": {
+      "category": "tool",
+      "source": "provider",
+      "description": "After a tool call fails or times out",
+      "canBlock": false
+    },
+    "PermissionRequest": {
+      "category": "tool",
+      "source": "provider",
+      "description": "Permission dialog appears for a tool action",
+      "canBlock": true
+    },
+    "SubagentStart": {
+      "category": "agent",
+      "source": "provider",
+      "description": "A subagent is spawned",
+      "canBlock": true
+    },
+    "SubagentStop": {
+      "category": "agent",
+      "source": "provider",
+      "description": "A subagent finishes execution",
+      "canBlock": false
+    },
+    "PreModel": {
+      "category": "agent",
+      "source": "provider",
+      "description": "Before sending a request to the LLM",
+      "canBlock": true
+    },
+    "PostModel": {
+      "category": "agent",
+      "source": "provider",
+      "description": "After receiving an LLM response",
+      "canBlock": false
+    },
+    "PreCompact": {
+      "category": "context",
+      "source": "provider",
+      "description": "Before context window compaction",
+      "canBlock": false
+    },
+    "PostCompact": {
+      "category": "context",
+      "source": "provider",
+      "description": "After context window compaction completes",
+      "canBlock": false
+    },
+    "Notification": {
+      "category": "context",
+      "source": "provider",
+      "description": "System notification or alert is emitted",
+      "canBlock": false
+    },
+    "ConfigChange": {
+      "category": "context",
+      "source": "provider",
+      "description": "Configuration file changes during a session",
+      "canBlock": false
+    },
+    "TaskCreated": {
+      "category": "task",
+      "source": "domain",
+      "description": "A CLEO task has been created via tasks.add",
+      "canBlock": false
+    },
+    "TaskStarted": {
+      "category": "task",
+      "source": "domain",
+      "description": "A CLEO task has been started via tasks.start",
+      "canBlock": false
+    },
+    "TaskCompleted": {
+      "category": "task",
+      "source": "domain",
+      "description": "A CLEO task has been marked complete via tasks.complete",
+      "canBlock": false
+    },
+    "TaskBlocked": {
+      "category": "task",
+      "source": "domain",
+      "description": "A CLEO task has been blocked",
+      "canBlock": false
+    },
+    "MemoryObserved": {
+      "category": "memory",
+      "source": "domain",
+      "description": "An observation has been recorded to brain.db via memory.observe",
+      "canBlock": false
+    },
+    "MemoryPatternStored": {
+      "category": "memory",
+      "source": "domain",
+      "description": "A pattern has been stored via memory.pattern.store",
+      "canBlock": false
+    },
+    "MemoryLearningStored": {
+      "category": "memory",
+      "source": "domain",
+      "description": "A learning has been stored via memory.learning.store",
+      "canBlock": false
+    },
+    "MemoryDecisionStored": {
+      "category": "memory",
+      "source": "domain",
+      "description": "A decision has been stored via memory.decision.store",
+      "canBlock": false
+    },
+    "PipelineStageCompleted": {
+      "category": "pipeline",
+      "source": "domain",
+      "description": "A LOOM lifecycle gate has passed validation",
+      "canBlock": false
+    },
+    "PipelineManifestAppended": {
+      "category": "pipeline",
+      "source": "domain",
+      "description": "A manifest entry has been appended to `pipeline_manifest` (`SQLite` table per ADR-027)",
+      "canBlock": false
+    },
+    "SessionStarted": {
+      "category": "session",
+      "source": "domain",
+      "description": "A CLEO session has been started via session.start",
+      "canBlock": false
+    },
+    "SessionEnded": {
+      "category": "session",
+      "source": "domain",
+      "description": "A CLEO session has ended via session.end",
+      "canBlock": false
+    },
+    "ApprovalRequested": {
+      "category": "session",
+      "source": "domain",
+      "description": "A workflow approval gate has fired, awaiting human approval",
+      "canBlock": false
+    },
+    "ApprovalGranted": {
+      "category": "session",
+      "source": "domain",
+      "description": "A workflow approval has been granted via /approve token",
+      "canBlock": false
+    },
+    "ApprovalExpired": {
+      "category": "session",
+      "source": "domain",
+      "description": "A workflow approval token has expired without response",
+      "canBlock": false
+    }
+  },
+  "domainSources": {
+    "cleo": {
+      "version": "1.0.0",
+      "description": "CLEO task management, memory, and session system",
+      "categories": ["task", "memory", "pipeline", "session"],
+      "operationMapping": {
+        "TaskCreated":             { "domain": "tasks",    "operation": "add",      "phase": "post" },
+        "TaskStarted":             { "domain": "tasks",    "operation": "start",    "phase": "post" },
+        "TaskCompleted":           { "domain": "tasks",    "operation": "complete", "phase": "post" },
+        "TaskBlocked":             { "domain": "tasks",    "operation": "update",   "phase": "post" },
+        "MemoryObserved":          { "domain": "memory",   "operation": "observe",  "phase": "post" },
+        "MemoryPatternStored":     { "domain": "memory",   "operation": "store",    "phase": "post" },
+        "MemoryLearningStored":    { "domain": "memory",   "operation": "store",    "phase": "post" },
+        "MemoryDecisionStored":    { "domain": "memory",   "operation": "store",    "phase": "post" },
+        "PipelineStageCompleted":  { "domain": "pipeline", "operation": "validate", "phase": "post" },
+        "PipelineManifestAppended":{ "domain": "pipeline", "operation": "append",   "phase": "post" },
+        "SessionStarted":          { "domain": "session",  "operation": "start",    "phase": "post" },
+        "SessionEnded":            { "domain": "session",  "operation": "end",      "phase": "post" },
+        "ApprovalRequested":       { "domain": "session",  "operation": "suspend",  "phase": "post" },
+        "ApprovalGranted":         { "domain": "session",  "operation": "resume",   "phase": "post" },
+        "ApprovalExpired":         { "domain": "session",  "operation": "suspend",  "phase": "post" }
+      }
+    }
+  },
+  "providerMappings": {
+    "claude-code": {
+      "hookSystem": "config",
+      "hookConfigPath": "$HOME/.claude/settings.json",
+      "hookFormat": "json",
+      "handlerTypes": ["command", "http", "prompt", "agent"],
+      "experimental": false,
+      "mappings": {
+        "SessionStart": { "nativeName": "SessionStart", "supported": true },
+        "SessionEnd": { "nativeName": "SessionEnd", "supported": true },
+        "PromptSubmit": { "nativeName": "UserPromptSubmit", "supported": true },
+        "ResponseComplete": { "nativeName": "Stop", "supported": true },
+        "PreToolUse": { "nativeName": "PreToolUse", "supported": true },
+        "PostToolUse": { "nativeName": "PostToolUse", "supported": true },
+        "PostToolUseFailure": { "nativeName": "PostToolUseFailure", "supported": true },
+        "PermissionRequest": { "nativeName": "PermissionRequest", "supported": true },
+        "SubagentStart": { "nativeName": "SubagentStart", "supported": true },
+        "SubagentStop": { "nativeName": "SubagentStop", "supported": true },
+        "PreModel": { "nativeName": null, "supported": false },
+        "PostModel": { "nativeName": null, "supported": false },
+        "PreCompact": { "nativeName": "PreCompact", "supported": true },
+        "PostCompact": { "nativeName": "PostCompact", "supported": true },
+        "Notification": { "nativeName": "Notification", "supported": true },
+        "ConfigChange": { "nativeName": "ConfigChange", "supported": true }
+      },
+      "providerOnlyEvents": [
+        "StopFailure",
+        "TeammateIdle",
+        "TaskCompleted",
+        "InstructionsLoaded",
+        "WorktreeCreate",
+        "WorktreeRemove",
+        "Elicitation",
+        "ElicitationResult"
+      ]
+    },
+    "cursor": {
+      "hookSystem": "config",
+      "hookConfigPath": ".cursor/hooks.json",
+      "hookFormat": "json",
+      "handlerTypes": ["command", "prompt"],
+      "experimental": true,
+      "mappings": {
+        "SessionStart": { "nativeName": "sessionStart", "supported": true },
+        "SessionEnd": { "nativeName": "sessionEnd", "supported": true },
+        "PromptSubmit": { "nativeName": "beforeSubmitPrompt", "supported": true },
+        "ResponseComplete": { "nativeName": "stop", "supported": true },
+        "PreToolUse": { "nativeName": "preToolUse", "supported": true },
+        "PostToolUse": { "nativeName": "postToolUse", "supported": true },
+        "PostToolUseFailure": { "nativeName": "postToolUseFailure", "supported": true },
+        "PermissionRequest": { "nativeName": null, "supported": false },
+        "SubagentStart": { "nativeName": "subagentStart", "supported": true },
+        "SubagentStop": { "nativeName": "subagentStop", "supported": true },
+        "PreModel": { "nativeName": null, "supported": false },
+        "PostModel": { "nativeName": null, "supported": false },
+        "PreCompact": { "nativeName": "preCompact", "supported": true },
+        "PostCompact": { "nativeName": null, "supported": false },
+        "Notification": { "nativeName": null, "supported": false },
+        "ConfigChange": { "nativeName": null, "supported": false }
+      },
+      "providerOnlyEvents": [
+        "beforeShellExecution",
+        "afterShellExecution",
+        "beforeMCPExecution",
+        "afterMCPExecution",
+        "beforeReadFile",
+        "afterFileEdit",
+        "afterAgentResponse",
+        "afterAgentThought",
+        "beforeTabFileRead",
+        "afterTabFileEdit"
+      ]
+    },
+    "gemini-cli": {
+      "hookSystem": "config",
+      "hookConfigPath": "$HOME/.gemini/settings.json",
+      "hookFormat": "json",
+      "handlerTypes": ["command"],
+      "experimental": false,
+      "mappings": {
+        "SessionStart": { "nativeName": "SessionStart", "supported": true },
+        "SessionEnd": { "nativeName": "SessionEnd", "supported": true },
+        "PromptSubmit": { "nativeName": "BeforeAgent", "supported": true },
+        "ResponseComplete": { "nativeName": "AfterAgent", "supported": true },
+        "PreToolUse": { "nativeName": "BeforeTool", "supported": true },
+        "PostToolUse": { "nativeName": "AfterTool", "supported": true },
+        "PostToolUseFailure": { "nativeName": null, "supported": false },
+        "PermissionRequest": { "nativeName": null, "supported": false },
+        "SubagentStart": { "nativeName": null, "supported": false },
+        "SubagentStop": { "nativeName": null, "supported": false },
+        "PreModel": { "nativeName": "BeforeModel", "supported": true },
+        "PostModel": { "nativeName": "AfterModel", "supported": true },
+        "PreCompact": { "nativeName": "PreCompress", "supported": true },
+        "PostCompact": { "nativeName": null, "supported": false },
+        "Notification": { "nativeName": "Notification", "supported": true },
+        "ConfigChange": { "nativeName": null, "supported": false }
+      },
+      "providerOnlyEvents": [
+        "BeforeToolSelection"
+      ]
+    },
+    "codex": {
+      "hookSystem": "config",
+      "hookConfigPath": ".codex/hooks.json",
+      "hookFormat": "json",
+      "handlerTypes": ["command"],
+      "experimental": true,
+      "mappings": {
+        "SessionStart": { "nativeName": "SessionStart", "supported": true },
+        "SessionEnd": { "nativeName": null, "supported": false },
+        "PromptSubmit": { "nativeName": "UserPromptSubmit", "supported": true },
+        "ResponseComplete": { "nativeName": "Stop", "supported": true },
+        "PreToolUse": { "nativeName": null, "supported": false },
+        "PostToolUse": { "nativeName": null, "supported": false },
+        "PostToolUseFailure": { "nativeName": null, "supported": false },
+        "PermissionRequest": { "nativeName": null, "supported": false },
+        "SubagentStart": { "nativeName": null, "supported": false },
+        "SubagentStop": { "nativeName": null, "supported": false },
+        "PreModel": { "nativeName": null, "supported": false },
+        "PostModel": { "nativeName": null, "supported": false },
+        "PreCompact": { "nativeName": null, "supported": false },
+        "PostCompact": { "nativeName": null, "supported": false },
+        "Notification": { "nativeName": null, "supported": false },
+        "ConfigChange": { "nativeName": null, "supported": false }
+      },
+      "providerOnlyEvents": []
+    },
+    "opencode": {
+      "hookSystem": "plugin",
+      "hookConfigPath": ".opencode/plugins/",
+      "hookFormat": "javascript",
+      "handlerTypes": ["plugin"],
+      "experimental": false,
+      "mappings": {
+        "SessionStart": { "nativeName": "event:session.created", "supported": true, "notes": "Via bus event subscriber" },
+        "SessionEnd": { "nativeName": "event:session.deleted", "supported": true, "notes": "Via bus event subscriber" },
+        "PromptSubmit": { "nativeName": "chat.message", "supported": true },
+        "ResponseComplete": { "nativeName": "event:session.idle", "supported": true, "notes": "Via bus event subscriber" },
+        "PreToolUse": { "nativeName": "tool.execute.before", "supported": true },
+        "PostToolUse": { "nativeName": "tool.execute.after", "supported": true },
+        "PostToolUseFailure": { "nativeName": null, "supported": false },
+        "PermissionRequest": { "nativeName": "permission.ask", "supported": true },
+        "SubagentStart": { "nativeName": null, "supported": false },
+        "SubagentStop": { "nativeName": null, "supported": false },
+        "PreModel": { "nativeName": "chat.params", "supported": true, "notes": "Modify LLM params before request" },
+        "PostModel": { "nativeName": null, "supported": false },
+        "PreCompact": { "nativeName": "experimental.session.compacting", "supported": true },
+        "PostCompact": { "nativeName": "event:session.compacted", "supported": true, "notes": "Via bus event subscriber" },
+        "Notification": { "nativeName": null, "supported": false },
+        "ConfigChange": { "nativeName": null, "supported": false }
+      },
+      "providerOnlyEvents": [
+        "chat.headers",
+        "shell.env",
+        "tool.definition",
+        "command.execute.before",
+        "experimental.chat.messages.transform",
+        "experimental.chat.system.transform",
+        "experimental.text.complete"
+      ]
+    },
+    "kimi": {
+      "hookSystem": "none",
+      "hookConfigPath": null,
+      "hookFormat": null,
+      "handlerTypes": [],
+      "experimental": false,
+      "mappings": {
+        "SessionStart": { "nativeName": null, "supported": false },
+        "SessionEnd": { "nativeName": null, "supported": false },
+        "PromptSubmit": { "nativeName": null, "supported": false },
+        "ResponseComplete": { "nativeName": null, "supported": false },
+        "PreToolUse": { "nativeName": null, "supported": false },
+        "PostToolUse": { "nativeName": null, "supported": false },
+        "PostToolUseFailure": { "nativeName": null, "supported": false },
+        "PermissionRequest": { "nativeName": null, "supported": false },
+        "SubagentStart": { "nativeName": null, "supported": false },
+        "SubagentStop": { "nativeName": null, "supported": false },
+        "PreModel": { "nativeName": null, "supported": false },
+        "PostModel": { "nativeName": null, "supported": false },
+        "PreCompact": { "nativeName": null, "supported": false },
+        "PostCompact": { "nativeName": null, "supported": false },
+        "Notification": { "nativeName": null, "supported": false },
+        "ConfigChange": { "nativeName": null, "supported": false }
+      },
+      "providerOnlyEvents": []
+    },
+    "pi": {
+      "hookSystem": "extension",
+      "hookConfigPath": "$PI_CODING_AGENT_DIR/extensions/",
+      "hookFormat": "typescript",
+      "handlerTypes": ["extension"],
+      "experimental": false,
+      "notes": "Pi is CAAMP's first-class primary harness (ADR-035). Events use snake_case. Extensions live at ~/.pi/agent/extensions/ (global) or <projectDir>/.pi/extensions/ (project).",
+      "nativeEventCatalog": "pi",
+      "mappings": {
+        "SessionStart":        { "nativeName": "session_start",            "supported": true },
+        "SessionEnd":          { "nativeName": "session_shutdown",         "supported": true },
+        "PromptSubmit":        { "nativeName": "input",                    "supported": true },
+        "ResponseComplete":    { "nativeName": null,                       "supported": false },
+        "PreToolUse":          { "nativeName": "tool_call",                "supported": true },
+        "PostToolUse":         { "nativeName": "tool_result",              "supported": true },
+        "PostToolUseFailure":  { "nativeName": null,                       "supported": false },
+        "PermissionRequest":   { "nativeName": null,                       "supported": false },
+        "SubagentStart":       { "nativeName": "before_agent_start",       "supported": true },
+        "SubagentStop":        { "nativeName": "agent_end",                "supported": true },
+        "PreModel":            { "nativeName": "before_provider_request",  "supported": true },
+        "PostModel":           { "nativeName": null,                       "supported": false },
+        "PreCompact":          { "nativeName": "context",                  "supported": true, "notes": "Pi's context assembly event is the closest proxy for pre-compaction" },
+        "PostCompact":         { "nativeName": null,                       "supported": false },
+        "Notification":        { "nativeName": "turn_end",                 "supported": true, "notes": "Pi emits turn_end when the assistant turn completes, which is the best proxy for a notification event" },
+        "ConfigChange":        { "nativeName": null,                       "supported": false }
+      },
+      "providerOnlyEvents": [
+        "session_switch",
+        "session_fork",
+        "agent_start",
+        "turn_start",
+        "message_start",
+        "message_update",
+        "message_end",
+        "tool_execution_start",
+        "tool_execution_end",
+        "user_bash",
+        "model_select",
+        "resources_discover"
+      ]
+    },
+    "antigravity": {
+      "hookSystem": "none",
+      "hookConfigPath": null,
+      "hookFormat": null,
+      "handlerTypes": [],
+      "experimental": false,
+      "mappings": {
+        "SessionStart": { "nativeName": null, "supported": false },
+        "SessionEnd": { "nativeName": null, "supported": false },
+        "PromptSubmit": { "nativeName": null, "supported": false },
+        "ResponseComplete": { "nativeName": null, "supported": false },
+        "PreToolUse": { "nativeName": null, "supported": false },
+        "PostToolUse": { "nativeName": null, "supported": false },
+        "PostToolUseFailure": { "nativeName": null, "supported": false },
+        "PermissionRequest": { "nativeName": null, "supported": false },
+        "SubagentStart": { "nativeName": null, "supported": false },
+        "SubagentStop": { "nativeName": null, "supported": false },
+        "PreModel": { "nativeName": null, "supported": false },
+        "PostModel": { "nativeName": null, "supported": false },
+        "PreCompact": { "nativeName": null, "supported": false },
+        "PostCompact": { "nativeName": null, "supported": false },
+        "Notification": { "nativeName": null, "supported": false },
+        "ConfigChange": { "nativeName": null, "supported": false }
+      },
+      "providerOnlyEvents": []
+    }
+  },
+  "piEventCatalog": {
+    "session_start":            { "canonicalEquivalent": "SessionStart",  "category": "session", "description": "Pi session created" },
+    "session_shutdown":         { "canonicalEquivalent": "SessionEnd",    "category": "session", "description": "Pi session ended" },
+    "session_switch":           { "canonicalEquivalent": null,             "category": "session", "description": "User switched between sessions in interactive mode" },
+    "session_fork":             { "canonicalEquivalent": null,             "category": "session", "description": "User forked a session" },
+    "before_agent_start":       { "canonicalEquivalent": null,             "category": "agent",   "description": "Pi agent loop is about to start a new turn" },
+    "agent_start":              { "canonicalEquivalent": null,             "category": "agent",   "description": "Pi agent loop started a new turn" },
+    "agent_end":                { "canonicalEquivalent": null,             "category": "agent",   "description": "Pi agent loop finished a turn" },
+    "turn_start":               { "canonicalEquivalent": null,             "category": "agent",   "description": "Conversation turn started" },
+    "turn_end":                 { "canonicalEquivalent": null,             "category": "agent",   "description": "Conversation turn ended" },
+    "message_start":            { "canonicalEquivalent": null,             "category": "agent",   "description": "Streaming message started" },
+    "message_update":           { "canonicalEquivalent": null,             "category": "agent",   "description": "Streaming message chunk received" },
+    "message_end":              { "canonicalEquivalent": null,             "category": "agent",   "description": "Streaming message ended" },
+    "context":                  { "canonicalEquivalent": null,             "category": "context", "description": "Context (system prompt + history) is being assembled" },
+    "before_provider_request":  { "canonicalEquivalent": "PreModel",       "category": "agent",   "description": "About to call the LLM provider" },
+    "tool_call":                { "canonicalEquivalent": "PreToolUse",    "category": "tool",    "description": "Tool is about to be called" },
+    "tool_result":              { "canonicalEquivalent": "PostToolUse",   "category": "tool",    "description": "Tool result received" },
+    "tool_execution_start":     { "canonicalEquivalent": "PreToolUse",    "category": "tool",    "description": "Tool execution started (separate from tool_call)" },
+    "tool_execution_end":       { "canonicalEquivalent": "PostToolUse",   "category": "tool",    "description": "Tool execution ended" },
+    "input":                    { "canonicalEquivalent": "PromptSubmit",  "category": "prompt",  "description": "User submitted input" },
+    "user_bash":                { "canonicalEquivalent": null,             "category": "tool",    "description": "User ran a bash command directly" },
+    "model_select":             { "canonicalEquivalent": null,             "category": "agent",   "description": "User changed the active model" },
+    "resources_discover":       { "canonicalEquivalent": null,             "category": "context", "description": "Pi is discovering skills/extensions/themes" }
+  }
+}

--- a/crates/cant-router/Cargo.toml
+++ b/crates/cant-router/Cargo.toml
@@ -4,6 +4,11 @@ version.workspace = true
 edition = "2024"
 rust-version = "1.94"
 description = "CleoOS v2 model router — 3-layer classifier + router + pipeline"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/kryptobaseddev/cleo"
+keywords = ["cleo", "router", "classifier", "llm", "agent"]
+categories = ["development-tools", "algorithms"]
+publish = true
 
 [lib]
 crate-type = ["rlib"]
@@ -11,6 +16,13 @@ crate-type = ["rlib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "route_decision"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/cant-router/benches/route_decision.rs
+++ b/crates/cant-router/benches/route_decision.rs
@@ -1,0 +1,56 @@
+//! Criterion benches for cant-router canonical 3-layer routing decision.
+//!
+//! Captures the perf-budget floor declared in the SG-BOUNDARY-REGISTRY
+//! `boundary.ts` entry for cant-router (ADR-078, Saga T10176).
+//!
+//! Two benches are exposed:
+//!
+//! - `cant_router_simple_prompt` — short low-complexity prompt; exercises
+//!   the Layer 1 feature extraction → Layer 2 classifier → Layer 3 router
+//!   path that maps to the `Tier::Low` selection.
+//! - `cant_router_complex_prompt` — refactor-style prompt with file
+//!   references, brackets, and reasoning keywords; exercises the same
+//!   pipeline but maps to the `Tier::High` selection. This is the
+//!   representative hot path consumers (CleoOS dispatch) hit on every
+//!   model-selection event.
+//!
+//! Each bench runs `extract_features → classify → route` so the measured
+//! time captures the full classification + selection round trip.
+
+#![allow(missing_docs)]
+
+use cant_router::{classify, extract_features, route};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+const SIMPLE_PROMPT: &str = "Format this JSON file.";
+
+const COMPLEX_PROMPT: &str = "Refactor the auth module in src/auth.rs and src/session.rs to use \
+JWT tokens. Consider the trade-offs between cookie-based sessions and \
+token-based authentication, then explain why JWT is the better choice \
+for our microservices architecture. Update tests in tests/auth/ and \
+benchmarks in benches/auth_bench.rs.";
+
+fn bench_route_simple(c: &mut Criterion) {
+    c.bench_function("cant_router_simple_prompt", |b| {
+        b.iter(|| {
+            let features = extract_features(black_box(SIMPLE_PROMPT));
+            let classification = classify(features);
+            let selection = route(classification);
+            black_box(selection);
+        });
+    });
+}
+
+fn bench_route_complex(c: &mut Criterion) {
+    c.bench_function("cant_router_complex_prompt", |b| {
+        b.iter(|| {
+            let features = extract_features(black_box(COMPLEX_PROMPT));
+            let classification = classify(features);
+            let selection = route(classification);
+            black_box(selection);
+        });
+    });
+}
+
+criterion_group!(benches, bench_route_simple, bench_route_complex);
+criterion_main!(benches);

--- a/crates/cant-runtime/Cargo.toml
+++ b/crates/cant-runtime/Cargo.toml
@@ -4,12 +4,17 @@ version.workspace = true
 edition = "2024"
 rust-version = "1.94"
 description = "CANT DSL runtime - pipeline executor"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/kryptobaseddev/cleo"
+keywords = ["cleo", "cant", "runtime", "pipeline", "agent"]
+categories = ["development-tools", "asynchronous"]
+publish = true
 
 [lib]
 crate-type = ["rlib"]
 
 [dependencies]
-cant-core = { path = "../cant-core" }
+cant-core = { path = "../cant-core", version = "2026.5.99" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "time", "io-util"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -18,6 +23,11 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+criterion = "0.5"
+
+[[bench]]
+name = "env_resolve"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/cant-runtime/benches/env_resolve.rs
+++ b/crates/cant-runtime/benches/env_resolve.rs
@@ -1,0 +1,86 @@
+//! Criterion benches for cant-runtime canonical variable resolution.
+//!
+//! Captures the perf-budget floor declared in the SG-BOUNDARY-REGISTRY
+//! `boundary.ts` entry for cant-runtime (ADR-078, Saga T10176).
+//!
+//! Two benches are exposed:
+//!
+//! - `cant_runtime_resolve_simple_arg` — single `{var}` placeholder in a
+//!   command argument. Establishes the per-arg variable resolution floor.
+//! - `cant_runtime_resolve_full_pipeline_args` — full step argument
+//!   vector with multiple placeholders mixing prior step outputs
+//!   (`<step>.stdout`, `<step>.exitCode`) and workflow inputs. Mirrors
+//!   the canonical pipeline-step hot path executed on every pipeline
+//!   step invocation by [`cant_runtime::pipeline::execute_pipeline`].
+//!
+//! Variable resolution is the security-critical T07 invariant boundary:
+//! single-pass, no nested expansion. The bench locks the per-call cost
+//! so regressions on this hot path are caught before merge.
+
+#![allow(missing_docs)]
+
+use cant_runtime::env::StepEnv;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+fn make_simple_env() -> (StepEnv, Vec<String>) {
+    let mut env = StepEnv::new();
+    env.set("target_branch", "main");
+    (env, vec!["--branch".to_string(), "{target_branch}".to_string()])
+}
+
+fn make_full_pipeline_env() -> (StepEnv, Vec<String>) {
+    let mut env = StepEnv::new();
+    env.set("owner", "kryptobaseddev");
+    env.set("repo", "cleo");
+    env.set("pr_number", "504");
+    env.set("target_branch", "main");
+    env.record_step_output(
+        "fetch_diff",
+        "diff --git a/foo b/foo\nindex abc..def 100644\n--- a/foo\n+++ b/foo\n",
+        "",
+        0,
+    );
+    env.record_step_output("checkout", "Switched to branch 'main'\n", "", 0);
+    let args = vec![
+        "--repo".to_string(),
+        "{owner}/{repo}".to_string(),
+        "--pr".to_string(),
+        "{pr_number}".to_string(),
+        "--base".to_string(),
+        "{target_branch}".to_string(),
+        "--diff".to_string(),
+        "{fetch_diff.stdout}".to_string(),
+        "--last-checkout".to_string(),
+        "{checkout.stdout}".to_string(),
+        "--exit-code".to_string(),
+        "{checkout.exitCode}".to_string(),
+    ];
+    (env, args)
+}
+
+fn bench_resolve_simple(c: &mut Criterion) {
+    let (env, args) = make_simple_env();
+    c.bench_function("cant_runtime_resolve_simple_arg", |b| {
+        b.iter(|| {
+            let resolved = env
+                .resolve_args(black_box(&args))
+                .expect("simple resolve must succeed");
+            black_box(resolved);
+        });
+    });
+}
+
+fn bench_resolve_full(c: &mut Criterion) {
+    let (env, args) = make_full_pipeline_env();
+    c.bench_function("cant_runtime_resolve_full_pipeline_args", |b| {
+        b.iter(|| {
+            let resolved = env
+                .resolve_args(black_box(&args))
+                .expect("full resolve must succeed");
+            black_box(resolved);
+        });
+    });
+}
+
+criterion_group!(benches, bench_resolve_simple, bench_resolve_full);
+criterion_main!(benches);

--- a/crates/conduit-core/Cargo.toml
+++ b/crates/conduit-core/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-lafs-core = { path = "../lafs-core" }
+lafs-core = { path = "../lafs-core", version = "2026.5.99" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/lafs-core/Cargo.toml
+++ b/crates/lafs-core/Cargo.toml
@@ -4,6 +4,11 @@ version.workspace = true
 edition = "2024"
 rust-version = "1.94"
 description = "Canonical LAFS envelope types and validation for CLEO ecosystem"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/kryptobaseddev/cleo"
+keywords = ["cleo", "lafs", "envelope", "schema", "agent"]
+categories = ["data-structures", "encoding", "api-bindings"]
+publish = true
 
 [lib]
 crate-type = ["rlib"]
@@ -14,6 +19,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 jsonschema = "0.28.3"
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "envelope_serde"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/lafs-core/benches/envelope_serde.rs
+++ b/crates/lafs-core/benches/envelope_serde.rs
@@ -1,0 +1,93 @@
+//! Criterion benches for lafs-core canonical envelope serde round-trip.
+//!
+//! Captures the perf-budget floor declared in the SG-BOUNDARY-REGISTRY
+//! `boundary.ts` entry for lafs-core (ADR-078, Saga T10176).
+//!
+//! Two benches are exposed:
+//!
+//! - `lafs_envelope_success_roundtrip` — canonical success envelope with
+//!   a small structured result payload. Establishes the absolute serde
+//!   floor for CLI response envelopes.
+//! - `lafs_envelope_error_roundtrip` — canonical error envelope with a
+//!   structured [`LafsError`] including category, retryability, agent
+//!   action, and a nested `details` payload. Mirrors the on-wire shape
+//!   consumers (cleo CLI dispatch, agent SDKs) actually receive on the
+//!   error path.
+//!
+//! Each bench runs JSON serialize → JSON deserialize so the measured
+//! time captures both directions of the round-trip on the canonical
+//! hot-path consumed by every CLEO operation envelope.
+
+#![allow(missing_docs)]
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use lafs_core::{
+    LafsAgentAction, LafsEnvelope, LafsError, LafsErrorCategory, LafsMeta, LafsTransport,
+};
+
+fn make_success_envelope() -> LafsEnvelope {
+    let meta = LafsMeta::new("tasks.list", LafsTransport::Cli);
+    let result = serde_json::json!({
+        "tasks": [
+            { "id": "T10224", "title": "Publish flips", "status": "in_progress" },
+            { "id": "T10206", "title": "conduit-core flip", "status": "done" },
+            { "id": "T10194", "title": "E3 epic", "status": "in_progress" },
+        ],
+        "totalCount": 3,
+    });
+    LafsEnvelope::success(result, meta)
+}
+
+fn make_error_envelope() -> LafsEnvelope {
+    let meta = LafsMeta::new("tasks.complete", LafsTransport::Cli);
+    let error = LafsError {
+        code: "E_EVIDENCE_MISSING".to_string(),
+        message: "Gate testsPassed requires evidence atom".to_string(),
+        category: LafsErrorCategory::Validation,
+        retryable: false,
+        retry_after_ms: None,
+        details: serde_json::json!({
+            "gate": "testsPassed",
+            "taskId": "T10224",
+            "requiredAtoms": ["tool:test", "test-run:<json>", "pr:<num>"],
+        }),
+        agent_action: Some(LafsAgentAction::RetryModified),
+        escalation_required: Some(false),
+        suggested_action: Some(
+            "Run `cleo verify T10224 --gate testsPassed --evidence \"tool:test\"`".to_string(),
+        ),
+        doc_url: Some(
+            "https://lafs.dev/errors/E_EVIDENCE_MISSING".to_string(),
+        ),
+    };
+    LafsEnvelope::error(error, meta)
+}
+
+fn bench_success_roundtrip(c: &mut Criterion) {
+    let envelope = make_success_envelope();
+    c.bench_function("lafs_envelope_success_roundtrip", |b| {
+        b.iter(|| {
+            let serialized = serde_json::to_string(black_box(&envelope))
+                .expect("serialize success envelope");
+            let deserialized: LafsEnvelope = serde_json::from_str(black_box(&serialized))
+                .expect("deserialize success envelope");
+            black_box(deserialized);
+        });
+    });
+}
+
+fn bench_error_roundtrip(c: &mut Criterion) {
+    let envelope = make_error_envelope();
+    c.bench_function("lafs_envelope_error_roundtrip", |b| {
+        b.iter(|| {
+            let serialized = serde_json::to_string(black_box(&envelope))
+                .expect("serialize error envelope");
+            let deserialized: LafsEnvelope = serde_json::from_str(black_box(&serialized))
+                .expect("deserialize error envelope");
+            black_box(deserialized);
+        });
+    });
+}
+
+criterion_group!(benches, bench_success_roundtrip, bench_error_roundtrip);
+criterion_main!(benches);

--- a/crates/lafs-core/schemas/v1/envelope.schema.json
+++ b/crates/lafs-core/schemas/v1/envelope.schema.json
@@ -1,0 +1,306 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lafs.dev/schemas/v1/envelope.schema.json",
+  "title": "LAFS Envelope v1",
+  "type": "object",
+  "required": [
+    "$schema",
+    "_meta",
+    "success",
+    "result"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://lafs.dev/schemas/v1/envelope.schema.json"
+    },
+    "_meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "specVersion",
+        "schemaVersion",
+        "timestamp",
+        "operation",
+        "requestId",
+        "transport",
+        "strict",
+        "mvi",
+        "contextVersion"
+      ],
+      "properties": {
+        "specVersion": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "schemaVersion": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "operation": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "requestId": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 128
+        },
+        "transport": {
+          "type": "string",
+          "enum": ["cli", "http", "grpc", "sdk"]
+        },
+        "strict": {
+          "type": "boolean"
+        },
+        "mvi": {
+          "type": "string",
+          "enum": ["minimal", "standard", "full", "custom"],
+          "description": "Disclosure level: minimal (MVI only), standard (common fields), full (all fields), custom (per _fields parameter)"
+        },
+        "contextVersion": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sessionId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "Session identifier for correlating multi-step agent workflows"
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "code": { "type": "string", "description": "Warning identifier (e.g., DEPRECATED_FIELD)" },
+              "message": { "type": "string", "description": "Human-readable warning" },
+              "deprecated": { "type": "string", "description": "The deprecated feature or field name" },
+              "replacement": { "type": "string", "description": "Suggested replacement, if any" },
+              "removeBy": { "type": "string", "description": "Version when the deprecated feature will be removed" }
+            },
+            "required": ["code", "message"]
+          },
+          "description": "Non-fatal advisory warnings (deprecations, migration hints)"
+        }
+      }
+    },
+    "success": {
+      "type": "boolean"
+    },
+    "result": {
+      "type": ["object", "array", "null"]
+    },
+    "error": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "required": [
+        "code",
+        "message",
+        "category",
+        "retryable",
+        "retryAfterMs",
+        "details"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^E_[A-Z0-9]+_[A-Z0-9_]+$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "VALIDATION",
+            "AUTH",
+            "PERMISSION",
+            "NOT_FOUND",
+            "CONFLICT",
+            "RATE_LIMIT",
+            "TRANSIENT",
+            "INTERNAL",
+            "CONTRACT",
+            "MIGRATION"
+          ]
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "retryAfterMs": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "details": {
+          "type": "object"
+        },
+        "agentAction": {
+          "type": "string",
+          "enum": ["retry", "retry_modified", "escalate", "stop", "wait", "refresh_context", "authenticate"],
+          "description": "Machine-actionable instruction for the consuming agent"
+        },
+        "escalationRequired": {
+          "type": "boolean",
+          "description": "Whether human/owner intervention is required"
+        },
+        "suggestedAction": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Brief actionable instruction for error recovery"
+        },
+        "docUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Documentation URL for this error type"
+        }
+      }
+    },
+    "page": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["offset", "cursor", "none"]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "offset": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "nextCursor": {
+          "type": ["string", "null"],
+          "maxLength": 2048
+        },
+        "hasMore": {
+          "type": "boolean"
+        },
+        "total": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "type": "object",
+            "properties": { "mode": { "const": "cursor" } },
+            "required": ["mode"]
+          },
+          "then": {
+            "required": ["mode", "nextCursor", "hasMore"],
+            "properties": {
+              "mode": true,
+              "nextCursor": true,
+              "hasMore": true,
+              "limit": true,
+              "total": true
+            }
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": { "mode": { "const": "offset" } },
+            "required": ["mode"]
+          },
+          "then": {
+            "required": ["mode", "limit", "offset", "hasMore"],
+            "properties": {
+              "mode": true,
+              "limit": true,
+              "offset": true,
+              "hasMore": true,
+              "total": true
+            }
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": { "mode": { "const": "none" } },
+            "required": ["mode"]
+          },
+          "then": {
+            "required": ["mode"],
+            "properties": {
+              "mode": true
+            }
+          }
+        }
+      ]
+    },
+    "_extensions": {
+      "type": "object",
+      "description": "Vendor extensions. Keys SHOULD use x- prefix (e.g., x-myvendor-trace-id).",
+      "additionalProperties": true
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "success": { "const": true }
+        }
+      },
+      "then": {
+        "properties": {
+          "error": { "type": "null" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "success": { "const": false }
+        }
+      },
+      "then": {
+        "required": ["error"],
+        "properties": {
+          "error": { "type": "object" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "_meta": {
+            "type": "object",
+            "properties": {
+              "strict": { "const": true }
+            }
+          }
+        }
+      },
+      "then": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": true,
+          "_meta": true,
+          "success": true,
+          "result": true,
+          "error": true,
+          "page": true,
+          "_extensions": true
+        }
+      },
+      "else": {
+        "additionalProperties": true
+      }
+    }
+  ]
+}

--- a/crates/lafs-core/src/lib.rs
+++ b/crates/lafs-core/src/lib.rs
@@ -389,8 +389,12 @@ impl LafsEnvelope {
 use std::sync::OnceLock;
 
 /// The embedded LAFS envelope JSON Schema, compiled into the binary.
-static LAFS_ENVELOPE_SCHEMA: &str =
-    include_str!("../../../packages/lafs/schemas/v1/envelope.schema.json");
+///
+/// Vendored from `packages/lafs/schemas/v1/envelope.schema.json` (the TypeScript
+/// canonical SSoT) into `crates/lafs-core/schemas/v1/envelope.schema.json` so the
+/// crate is publishable to crates.io. Parity is enforced at CI time by
+/// `scripts/lint-lafs-schema-parity.mjs` (T10224).
+static LAFS_ENVELOPE_SCHEMA: &str = include_str!("../schemas/v1/envelope.schema.json");
 
 /// Lazily compiled schema validator (compiled once, shared across calls).
 static COMPILED_VALIDATOR: OnceLock<jsonschema::Validator> = OnceLock::new();

--- a/scripts/lint-cant-core-hook-mappings-parity.mjs
+++ b/scripts/lint-cant-core-hook-mappings-parity.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * scripts/lint-cant-core-hook-mappings-parity.mjs
+ *
+ * Enforces parity between the TypeScript canonical hook-mappings file
+ * (`packages/caamp/providers/hook-mappings.json`) and the Rust vendored
+ * copy (`crates/cant-core/vendor/caamp/hook-mappings.json`).
+ *
+ * The Rust copy MUST be byte-identical to the TS canonical source. Drift
+ * means the published `cant-core` crate generates a stale event enum
+ * while the TypeScript stack uses the current mapping — a hook-routing
+ * regression vector.
+ *
+ * Why vendor at all: `cargo publish` rejects build-script paths that
+ * traverse outside the crate directory. Vendoring keeps the crate
+ * publishable without sacrificing the TS-as-canonical contract. See
+ * SAGA T10176 and ADR-078.
+ *
+ * Usage:
+ *   node scripts/lint-cant-core-hook-mappings-parity.mjs        # report only
+ *   node scripts/lint-cant-core-hook-mappings-parity.mjs --fix  # copy TS -> Rust
+ *   node scripts/lint-cant-core-hook-mappings-parity.mjs --exit-on-fail  # CI mode
+ *
+ * Exit codes:
+ *   0  parity OK (or --fix succeeded)
+ *   1  parity drift detected (CI mode) OR copy/read failure
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO = process.cwd();
+const TS_CANONICAL = resolve(REPO, 'packages/caamp/providers/hook-mappings.json');
+const RUST_VENDOR = resolve(REPO, 'crates/cant-core/vendor/caamp/hook-mappings.json');
+
+const args = new Set(process.argv.slice(2));
+const FIX = args.has('--fix');
+const EXIT_ON_FAIL = args.has('--exit-on-fail');
+
+function fail(msg, code = 1) {
+  console.error(`[lint-cant-core-hook-mappings-parity] ${msg}`);
+  process.exit(code);
+}
+
+if (!existsSync(TS_CANONICAL)) {
+  fail(`TS canonical hook-mappings missing: ${TS_CANONICAL}`);
+}
+if (!existsSync(RUST_VENDOR)) {
+  if (FIX) {
+    const ts = readFileSync(TS_CANONICAL);
+    writeFileSync(RUST_VENDOR, ts);
+    console.log(`[lint-cant-core-hook-mappings-parity] created Rust vendor copy from TS canonical`);
+    process.exit(0);
+  }
+  fail(`Rust vendor hook-mappings missing: ${RUST_VENDOR}`);
+}
+
+const tsBytes = readFileSync(TS_CANONICAL);
+const rustBytes = readFileSync(RUST_VENDOR);
+
+if (tsBytes.equals(rustBytes)) {
+  console.log(
+    '[lint-cant-core-hook-mappings-parity] OK — TS canonical and Rust vendor are byte-identical',
+  );
+  process.exit(0);
+}
+
+if (FIX) {
+  writeFileSync(RUST_VENDOR, tsBytes);
+  console.log('[lint-cant-core-hook-mappings-parity] FIXED — copied TS canonical to Rust vendor');
+  process.exit(0);
+}
+
+console.error('[lint-cant-core-hook-mappings-parity] DRIFT detected:');
+console.error(`  TS canonical: ${TS_CANONICAL} (${tsBytes.length} bytes)`);
+console.error(`  Rust vendor:  ${RUST_VENDOR} (${rustBytes.length} bytes)`);
+console.error('');
+console.error('  Run `node scripts/lint-cant-core-hook-mappings-parity.mjs --fix` to sync.');
+
+process.exit(EXIT_ON_FAIL ? 1 : 0);

--- a/scripts/lint-lafs-schema-parity.mjs
+++ b/scripts/lint-lafs-schema-parity.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * scripts/lint-lafs-schema-parity.mjs
+ *
+ * Enforces parity between the TypeScript canonical LAFS envelope schema
+ * (`packages/lafs/schemas/v1/envelope.schema.json`) and the Rust vendored
+ * copy (`crates/lafs-core/schemas/v1/envelope.schema.json`).
+ *
+ * The Rust copy MUST be byte-identical to the TS canonical source. Drift
+ * means the published `lafs-core` crate validates a stale schema while
+ * the TypeScript stack uses the current one — a wire-protocol regression
+ * vector.
+ *
+ * Why vendor at all: `cargo publish` rejects `include_str!` paths that
+ * traverse outside the crate directory. Vendoring keeps the crate
+ * publishable without sacrificing the TS-as-canonical contract. See
+ * SAGA T10176 and ADR-078.
+ *
+ * Usage:
+ *   node scripts/lint-lafs-schema-parity.mjs        # report only
+ *   node scripts/lint-lafs-schema-parity.mjs --fix  # copy TS -> Rust
+ *   node scripts/lint-lafs-schema-parity.mjs --exit-on-fail  # CI mode
+ *
+ * Exit codes:
+ *   0  parity OK (or --fix succeeded)
+ *   1  parity drift detected (CI mode) OR copy/read failure
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO = process.cwd();
+const TS_CANONICAL = resolve(REPO, 'packages/lafs/schemas/v1/envelope.schema.json');
+const RUST_VENDOR = resolve(REPO, 'crates/lafs-core/schemas/v1/envelope.schema.json');
+
+const args = new Set(process.argv.slice(2));
+const FIX = args.has('--fix');
+const EXIT_ON_FAIL = args.has('--exit-on-fail');
+
+function fail(msg, code = 1) {
+  console.error(`[lint-lafs-schema-parity] ${msg}`);
+  process.exit(code);
+}
+
+if (!existsSync(TS_CANONICAL)) {
+  fail(`TS canonical schema missing: ${TS_CANONICAL}`);
+}
+if (!existsSync(RUST_VENDOR)) {
+  if (FIX) {
+    const ts = readFileSync(TS_CANONICAL);
+    writeFileSync(RUST_VENDOR, ts);
+    console.log(`[lint-lafs-schema-parity] created Rust vendor copy from TS canonical`);
+    process.exit(0);
+  }
+  fail(`Rust vendor schema missing: ${RUST_VENDOR}`);
+}
+
+const tsBytes = readFileSync(TS_CANONICAL);
+const rustBytes = readFileSync(RUST_VENDOR);
+
+if (tsBytes.equals(rustBytes)) {
+  console.log('[lint-lafs-schema-parity] OK — TS canonical and Rust vendor are byte-identical');
+  process.exit(0);
+}
+
+if (FIX) {
+  writeFileSync(RUST_VENDOR, tsBytes);
+  console.log('[lint-lafs-schema-parity] FIXED — copied TS canonical to Rust vendor');
+  process.exit(0);
+}
+
+console.error('[lint-lafs-schema-parity] DRIFT detected:');
+console.error(`  TS canonical: ${TS_CANONICAL} (${tsBytes.length} bytes)`);
+console.error(`  Rust vendor:  ${RUST_VENDOR} (${rustBytes.length} bytes)`);
+console.error('');
+console.error('  Run `node scripts/lint-lafs-schema-parity.mjs --fix` to sync.');
+
+process.exit(EXIT_ON_FAIL ? 1 : 0);


### PR DESCRIPTION
## Summary

Closes **T10224**; Saga: **T10176** (SG-BOUNDARY-REGISTRY); Decision: **D010**; ADR: **ADR-078**.

Flips 4 cleocode crates to `publish=true` with criterion benches per ADR-078 perf-budget contract, and fixes the publish chain that was incomplete after **T10206** shipped the `conduit-core` flip (PR #504).

## Crate flips (AC1-4)

All 4 add `license = "MIT OR Apache-2.0"`, `repository`, `keywords`, `categories`:
- `cant-core` (AC1) — also adds `version = "2026.5.99"` to its `conduit-core` path dep
- `cant-router` (AC2)
- `cant-runtime` (AC3) — also adds version to its `cant-core` path dep
- `lafs-core` (AC4)

**Signaldock-* crates are NOT touched** (AC7) — they remain publish=false; saga T10180's territory.

## Criterion benches (AC5)

One canonical hot-path per crate, p50 results (local, --warm-up-time 0.5 --measurement-time 1 --sample-size 10):

| Crate         | Bench                  | Minimal/Simple | Full/Complex |
|---------------|------------------------|----------------|--------------|
| cant-core     | parse_message          | 98 ns          | 2.78 µs      |
| cant-router   | route_decision         | 697 ns         | 2.68 µs      |
| cant-runtime  | env_resolve            | 143 ns         | 1.09 µs      |
| lafs-core     | envelope_serde         | 2.53 µs        | 2.74 µs      |

`cant-runtime/env_resolve` is the T07 single-pass variable-resolution invariant — pinning regressions on the security-critical pipeline-step hot path.

## Publish-chain unblockers (AC6, AC8)

`cargo publish` rejects `include_str!` and build-script paths that traverse outside the crate dir. This commit vendors both:

- **lafs-core**: `crates/lafs-core/schemas/v1/envelope.schema.json` vendored from `packages/lafs/schemas/v1/`.
- **cant-core**: `crates/cant-core/vendor/caamp/hook-mappings.json` vendored from `packages/caamp/providers/`. `build.rs` prefers the workspace canonical when present, falls back to the vendored copy in publish-tarball mode.
- **conduit-core**: adds `version = "2026.5.99"` to its `lafs-core` path dep (was the missing piece from T10206 that blocked the chain).

### TS canonical stays authoritative

Two parity CI gates (byte-identity check):
- `scripts/lint-lafs-schema-parity.mjs`
- `scripts/lint-cant-core-hook-mappings-parity.mjs`

Wired into new CI job **Rust Vendor Parity Lint (T10224)** in `.github/workflows/ci.yml`.

## Pre-existing carryforward (NOT caused by this PR)

5 `starter_bundle_*_cant_parses_clean` tests in `crates/cant-core/tests/parse_new_sections.rs` fail on origin/main because `packages/agents/starter-bundle/` doesn't exist on main. Will be filed as follow-up.

## Test plan

- [x] `cargo build --workspace --all-features` — green
- [x] `cargo bench --no-run` for all 4 new benches — green; p50 captured (above)
- [x] `cargo package -p lafs-core -p conduit-core -p cant-core -p cant-router -p cant-runtime --allow-dirty` — **green end-to-end** (full workspace-aware publish-chain dry-run; conduit-core verifies through lafs-core, the AC8 gate)
- [x] `cargo test -p lafs-core` — 37 unit + 2 doctests green (vendored schema validates identically)
- [x] `pnpm biome check --write .` — no new warnings
- [x] `node scripts/lint-lafs-schema-parity.mjs` — OK
- [x] `node scripts/lint-cant-core-hook-mappings-parity.mjs` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)