### PR TITLE
feat(T9546): cleo worktree list — structured JSON for all worktrees

### DIFF
--- a/.changeset/t9546-worktree-list.md
+++ b/.changeset/t9546-worktree-list.md
@@ -1,0 +1,24 @@
+---
+"@cleocode/cleo": minor
+"@cleocode/core": minor
+"@cleocode/contracts": minor
+---
+
+feat(T9546): cleo worktree list — structured JSON for all CLEO-managed worktrees (SAGA T10176)
+
+Extends the `worktree.list` dispatch op so every entry returned by
+`cleo worktree list` now exposes the full AC4 shape:
+`{ taskId, path, branch, source, createdAt, lockState, ... }`. The new
+`createdAt` field is derived from `<gitCommonDir>/worktrees/<name>/HEAD`
+mtime for git-native entries and falls back to the sentinel index
+`adoptedAt` timestamp for adopted external worktrees. The new
+`lockState: 'locked' | 'unlocked'` field mirrors `isLocked` as a
+human-readable token for downstream consumers.
+
+Sentinel-only `.cleo/worktrees.json` entries (D009 hybrid pattern) are
+unioned into the listing so adopted Claude Code Agent / manual worktrees
+surface alongside canonical CLEO-spawned ones per ADR-055.
+
+Adds 7 new integration tests under
+`packages/core/src/__tests__/worktree-list.test.ts` covering AC1–AC4
+with real on-disk git fixtures (no mocks).

--- a/packages/contracts/src/operations/worktree.ts
+++ b/packages/contracts/src/operations/worktree.ts
@@ -449,8 +449,38 @@ export interface WorktreeInfo {
   owningAgent: string | null;
   /** ISO-8601 timestamp of last activity (newest commit OR mtime of working tree). */
   lastActivity: string;
+  /**
+   * ISO-8601 timestamp recording when this worktree was first created.
+   *
+   * Resolution order:
+   *  1. For git-native entries — mtime of the per-worktree admin file
+   *     `<gitCommonDir>/worktrees/<basename(path)>/HEAD`. Git writes this once
+   *     at `git worktree add` time and never rewrites it during normal usage,
+   *     making it a faithful proxy for creation time.
+   *  2. For sentinel-only entries — the `adoptedAt` timestamp persisted in
+   *     `.cleo/worktrees.json`.
+   *  3. Fallback — mtime of the worktree directory itself.
+   *
+   * Distinct from {@link lastActivity}, which moves with each new commit on
+   * the branch. The two values diverge for any worktree that has had at least
+   * one commit since creation.
+   *
+   * @task T9546
+   */
+  createdAt: string;
   /** Whether `git worktree list --porcelain` reports the worktree as locked. */
   isLocked: boolean;
+  /**
+   * Lock-state string mirroring {@link isLocked} as a discriminated literal.
+   *
+   * Provided for downstream consumers that want a single human-readable token
+   * rather than a boolean — `'locked'` when porcelain reports the worktree as
+   * locked, `'unlocked'` otherwise. Always equivalent to
+   * `isLocked ? 'locked' : 'unlocked'`.
+   *
+   * @task T9546
+   */
+  lockState: 'locked' | 'unlocked';
   /** Whether the worktree is stale: no activity > N days AND (task done/cancelled OR branch merged). */
   isStale: boolean;
   /** Whether the branch is reachable from `main` (already integrated). */

--- a/packages/core/src/__tests__/worktree-list.test.ts
+++ b/packages/core/src/__tests__/worktree-list.test.ts
@@ -20,14 +20,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import {
-  mkdirSync,
-  mkdtempSync,
-  realpathSync,
-  rmSync,
-  utimesSync,
-  writeFileSync,
-} from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';

--- a/packages/core/src/__tests__/worktree-list.test.ts
+++ b/packages/core/src/__tests__/worktree-list.test.ts
@@ -20,7 +20,14 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -46,7 +53,11 @@ interface Fixture {
  * pipeline. Real `git worktree add` calls are issued from each test body.
  */
 function makeFixture(): Fixture {
-  const tmp = mkdtempSync(join(tmpdir(), 'cleo-worktree-list-it-'));
+  // macOS resolves `/var/folders/...` (the OS tmpdir) through a symlink to
+  // `/private/var/folders/...`. Git porcelain emits the realpath, so we
+  // canonicalise the tmp root here to keep path comparisons portable across
+  // macOS + Linux runners.
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'cleo-worktree-list-it-')));
   const projectRoot = join(tmp, 'project');
   const worktreesRoot = join(tmp, 'worktrees');
   mkdirSync(worktreesRoot, { recursive: true });

--- a/packages/core/src/__tests__/worktree-list.test.ts
+++ b/packages/core/src/__tests__/worktree-list.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Integration test for the structured `worktree list` primitive (T9546 AC5).
+ *
+ * Unlike `packages/core/src/worktree/__tests__/list.test.ts` (which mocks
+ * `execFileSync` to drive every classifier branch), this suite spins up a
+ * real on-disk git repository plus real `git worktree add` calls so the
+ * end-to-end envelope shape is validated against actual git output.
+ *
+ * Coverage matrix:
+ *  - AC1: structured JSON returned for all CLEO-managed worktrees
+ *  - AC2: worktrees rooted under the canonical `<cleoHome>/worktrees/...`
+ *         path bubble up correctly (covered by the spawned-style worktree)
+ *  - AC3: sentinel `.cleo/worktrees.json` entries are unioned into the listing
+ *  - AC4: every entry exposes
+ *         `{ taskId, path, branch, source, createdAt, lockState }`
+ *
+ * @task T9546
+ * @epic T10192
+ * @saga T10176
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { listWorktrees } from '../worktree/list.js';
+import { type SentinelWorktreeEntry, writeSentinelIndex } from '../worktree/sentinel-index.js';
+
+interface Fixture {
+  /** Absolute path to the project root inside a fresh tmp dir. */
+  projectRoot: string;
+  /** Absolute path to a sibling directory used as the "<cleoHome>/worktrees" parent. */
+  worktreesRoot: string;
+  /** Cleanup callback — removes tmp dirs. */
+  cleanup: () => void;
+}
+
+/**
+ * Build a fresh on-disk repo with one commit on `main`, plus a sibling
+ * `worktrees/` directory that holds the linked worktrees this test creates.
+ *
+ * We do NOT depend on `spawnWorktree` here so the integration test exercises
+ * `listWorktrees` directly without coupling to the broader worktree-napi
+ * pipeline. Real `git worktree add` calls are issued from each test body.
+ */
+function makeFixture(): Fixture {
+  const tmp = mkdtempSync(join(tmpdir(), 'cleo-worktree-list-it-'));
+  const projectRoot = join(tmp, 'project');
+  const worktreesRoot = join(tmp, 'worktrees');
+  mkdirSync(worktreesRoot, { recursive: true });
+
+  execFileSync('git', ['init', '-b', 'main', projectRoot], { stdio: 'pipe' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], {
+    cwd: projectRoot,
+    stdio: 'pipe',
+  });
+  execFileSync('git', ['config', 'user.name', 'Test'], {
+    cwd: projectRoot,
+    stdio: 'pipe',
+  });
+  writeFileSync(join(projectRoot, 'README.md'), '# fixture\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: projectRoot, stdio: 'pipe' });
+  execFileSync('git', ['commit', '-q', '-m', 'init'], {
+    cwd: projectRoot,
+    stdio: 'pipe',
+  });
+
+  return {
+    projectRoot,
+    worktreesRoot,
+    cleanup() {
+      try {
+        // `git worktree remove` would be cleaner but tests may legitimately
+        // leave administrative state behind; rm -rf is safe inside tmpdir.
+        rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    },
+  };
+}
+
+/**
+ * Create a linked git worktree on a fresh branch and return its absolute path.
+ *
+ * Mirrors `git worktree add -b task/<taskId> <root>/<taskId> main` — the same
+ * shape `cleo orchestrate spawn` produces, minus the XDG location override.
+ */
+function addLinkedWorktree(fixture: Fixture, taskId: string): string {
+  const path = join(fixture.worktreesRoot, taskId);
+  execFileSync('git', ['worktree', 'add', '-b', `task/${taskId}`, path, 'main'], {
+    cwd: fixture.projectRoot,
+    stdio: 'pipe',
+  });
+  return path;
+}
+
+describe('listWorktrees — integration (T9546 AC1-AC5)', () => {
+  let fixture: Fixture | undefined;
+
+  beforeEach(() => {
+    fixture = makeFixture();
+  });
+
+  afterEach(() => {
+    fixture?.cleanup();
+    fixture = undefined;
+  });
+
+  it('returns a structured envelope with one entry per worktree (AC1)', async () => {
+    if (!fixture) throw new Error('fixture not initialised');
+    addLinkedWorktree(fixture, 'T9546-it-a');
+    addLinkedWorktree(fixture, 'T9546-it-b');
+
+    const result = await listWorktrees({ projectRoot: fixture.projectRoot });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('expected success');
+    // Primary + 2 linked = 3 total.
+    expect(result.data.worktrees).toHaveLength(3);
+
+    const paths = result.data.worktrees.map((w) => w.path).sort();
+    expect(paths).toContain(join(fixture.worktreesRoot, 'T9546-it-a'));
+    expect(paths).toContain(join(fixture.worktreesRoot, 'T9546-it-b'));
+    expect(paths).toContain(fixture.projectRoot);
+  });
+
+  it('every entry exposes taskId, path, branch, source, createdAt, lockState (AC4)', async () => {
+    if (!fixture) throw new Error('fixture not initialised');
+    addLinkedWorktree(fixture, 'T9546-shape');
+
+    const result = await listWorktrees({ projectRoot: fixture.projectRoot });
+    if (!result.success) throw new Error('expected success');
+
+    // Inspect the linked worktree specifically — it has a deterministic
+    // taskId derived from the branch name (`task/T9546-shape` → null because
+    // the regex is `^task\/(T\d+)$` which excludes hyphenated suffixes).
+    // Use a numeric-only task ID for the shape assertion.
+    const linked = result.data.worktrees.find((w) => w.path.endsWith('T9546-shape'));
+    expect(linked).toBeDefined();
+    if (!linked) throw new Error('expected linked worktree in listing');
+
+    expect(typeof linked.path).toBe('string');
+    expect(typeof linked.branch).toBe('string');
+    expect(linked.branch).toBe('task/T9546-shape');
+    // T9546-shape does NOT match `^task\/(T\d+)$` (hyphenated suffix) → taskId is null.
+    expect(linked.taskId).toBeNull();
+    expect(linked.source).toBe('cleo-spawn');
+    expect(typeof linked.createdAt).toBe('string');
+    expect(() => new Date(linked.createdAt).toISOString()).not.toThrow();
+    expect(linked.lockState).toBe('unlocked');
+    expect(linked.isLocked).toBe(false);
+  });
+
+  it('extracts taskId from the canonical `task/T####` branch convention (AC4)', async () => {
+    if (!fixture) throw new Error('fixture not initialised');
+    // Numeric-only taskId so the `^task\/(T\d+)$` regex matches.
+    addLinkedWorktree(fixture, 'T1234');
+
+    const result = await listWorktrees({ projectRoot: fixture.projectRoot });
+    if (!result.success) throw new Error('expected success');
+
+    const linked = result.data.worktrees.find((w) => w.path.endsWith('T1234'));
+    expect(linked).toBeDefined();
+    expect(linked?.taskId).toBe('T1234');
+    expect(linked?.branch).toBe('task/T1234');
+    expect(linked?.source).toBe('cleo-spawn');
+  });
+
+  it('unions sentinel-index entries with claude-agent source (AC3)', async () => {
+    if (!fixture) throw new Error('fixture not initialised');
+
+    // Write a sentinel index entry whose path is NOT a real worktree — the
+    // integration test covers the "registered externally" code path where
+    // the sentinel index is the only place CLEO knows about the worktree.
+    const sentinelPath = join(fixture.worktreesRoot, 'claude-session-abc');
+    mkdirSync(sentinelPath, { recursive: true });
+    const sentinel: SentinelWorktreeEntry = {
+      path: sentinelPath,
+      branch: 'feat/T9546-claude-agent',
+      taskId: 'T9546',
+      source: 'claude-agent',
+      adoptedAt: '2026-05-22T12:34:56.000Z',
+      adoptedBy: 'claude-agent-test',
+    };
+    writeSentinelIndex(fixture.projectRoot, [sentinel]);
+
+    const result = await listWorktrees({ projectRoot: fixture.projectRoot });
+    if (!result.success) throw new Error('expected success');
+
+    const adopted = result.data.worktrees.find((w) => w.path === sentinelPath);
+    expect(adopted).toBeDefined();
+    if (!adopted) throw new Error('expected sentinel-only entry in listing');
+    expect(adopted.source).toBe('claude-agent');
+    expect(adopted.branch).toBe('feat/T9546-claude-agent');
+    expect(adopted.taskId).toBe('T9546');
+    // createdAt MUST fall back to the sentinel's adoptedAt timestamp for
+    // sentinel-only entries (AC4 — createdAt derivation).
+    expect(adopted.createdAt).toBe('2026-05-22T12:34:56.000Z');
+    expect(adopted.lockState).toBe('unlocked');
+  });
+
+  it('labels git-native worktrees as source=cleo-spawn when not in sentinel index (AC4)', async () => {
+    if (!fixture) throw new Error('fixture not initialised');
+    addLinkedWorktree(fixture, 'T5555');
+
+    const result = await listWorktrees({ projectRoot: fixture.projectRoot });
+    if (!result.success) throw new Error('expected success');
+
+    const linked = result.data.worktrees.find((w) => w.path.endsWith('T5555'));
+    expect(linked?.source).toBe('cleo-spawn');
+  });
+
+  it('createdAt is derived from .git/worktrees/<name>/HEAD mtime for linked worktrees (AC4)', async () => {
+    if (!fixture) throw new Error('fixture not initialised');
+    addLinkedWorktree(fixture, 'T9999');
+
+    // Touch the admin HEAD file backwards in time so we can assert the
+    // listing reads from THAT file (not from the worktree dir mtime).
+    const adminHead = join(fixture.projectRoot, '.git', 'worktrees', 'T9999', 'HEAD');
+    const targetMs = Date.UTC(2024, 0, 15, 10, 30, 0); // 2024-01-15T10:30:00Z
+    utimesSync(adminHead, targetMs / 1000, targetMs / 1000);
+
+    const result = await listWorktrees({ projectRoot: fixture.projectRoot });
+    if (!result.success) throw new Error('expected success');
+
+    const linked = result.data.worktrees.find((w) => w.path.endsWith('T9999'));
+    expect(linked).toBeDefined();
+    expect(linked?.createdAt).toBe(new Date(targetMs).toISOString());
+  });
+
+  it('reports locked worktrees with lockState=locked (AC4)', async () => {
+    if (!fixture) throw new Error('fixture not initialised');
+    const lockedPath = addLinkedWorktree(fixture, 'T9546-locked');
+    execFileSync('git', ['worktree', 'lock', lockedPath], {
+      cwd: fixture.projectRoot,
+      stdio: 'pipe',
+    });
+
+    const result = await listWorktrees({ projectRoot: fixture.projectRoot });
+    if (!result.success) throw new Error('expected success');
+
+    const locked = result.data.worktrees.find((w) => w.path === lockedPath);
+    expect(locked).toBeDefined();
+    expect(locked?.lockState).toBe('locked');
+    expect(locked?.isLocked).toBe(true);
+    expect(locked?.statusCategory).toBe('locked');
+  });
+});

--- a/packages/core/src/worktree/list.ts
+++ b/packages/core/src/worktree/list.ts
@@ -40,7 +40,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
-import { join, resolve as resolvePath } from 'node:path';
+import { basename, join, resolve as resolvePath } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import {
   type EngineResult,
@@ -150,6 +150,16 @@ export async function listWorktrees(
   // project root.
   const primaryWorktreePath = resolvePrimaryWorktreePath(projectRoot);
 
+  // Pre-resolve the git common dir so `createdAt` can stat the per-worktree
+  // admin file `<gitCommonDir>/worktrees/<basename(path)>/HEAD`, which is
+  // written exactly once by `git worktree add` and therefore acts as a stable
+  // creation-timestamp proxy. Null on failure → callers fall back to dir mtime.
+  const gitCommonDir = resolveGitCommonDir(projectRoot);
+  // Build a sentinel-path → adoptedAt lookup so adopted entries that ARE in
+  // git porcelain (i.e. registered both ways) report the sentinel timestamp
+  // as their createdAt — the adopt time is the canonical "tracked by CLEO" moment.
+  const sentinelAdoptedAtByPath = new Map(sentinelEntries.map((e) => [e.path, e.adoptedAt]));
+
   // --- Build WorktreeInfo entries from git-native porcelain output ---
   const worktrees: WorktreeInfo[] = porcelainEntries.map((entry) => {
     const taskId = branchToTaskId.get(entry.branch) ?? null;
@@ -185,13 +195,26 @@ export async function listWorktrees(
     const sentinelSource = sentinelByPath.get(entry.path)?.source;
     const source: WorktreeSource = sentinelSource ?? 'cleo-spawn';
 
+    // T9546 AC4: createdAt — resolved from the per-worktree git admin file
+    // when available, then sentinel adoptedAt, then dir mtime. The git admin
+    // HEAD is set exactly once at `git worktree add` time, so its mtime is the
+    // best available creation-time proxy for git-native entries.
+    const createdAt = resolveCreatedAt({
+      worktreePath: entry.path,
+      gitCommonDir,
+      primaryWorktreePath,
+      sentinelAdoptedAt: sentinelAdoptedAtByPath.get(entry.path),
+    });
+
     return {
       path: entry.path,
       branch: entry.branch,
       taskId,
       owningAgent,
       lastActivity,
+      createdAt,
       isLocked: entry.locked,
+      lockState: entry.locked ? 'locked' : 'unlocked',
       isStale,
       isMerged,
       owningTaskStatus,
@@ -232,7 +255,12 @@ export async function listWorktrees(
       taskId,
       owningAgent: null,
       lastActivity,
+      // For sentinel-only entries the canonical creation moment is the
+      // adopt time (the directory may have been mtime-touched arbitrarily
+      // since registration).
+      createdAt: sentinel.adoptedAt,
       isLocked: false,
+      lockState: 'unlocked',
       isStale,
       isMerged: false,
       owningTaskStatus,
@@ -516,6 +544,85 @@ function resolveMainBranch(projectRoot: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the absolute path to the repository's `.git` common directory.
+ *
+ * For the primary worktree this is `<projectRoot>/.git`. For linked worktrees
+ * this is also the primary's `.git` (the common dir is shared across all
+ * worktrees — each linked worktree only owns its admin subdirectory under
+ * `.git/worktrees/<name>/`).
+ *
+ * Returns null on failure — callers degrade gracefully to dir-mtime for the
+ * `createdAt` field.
+ *
+ * @param projectRoot - Project root for the git invocation.
+ * @returns Absolute path to the `.git` common directory, or null.
+ * @internal Exported for tests only.
+ */
+export function resolveGitCommonDir(projectRoot: string): string | null {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      timeout: GIT_TIMEOUT_MS,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the `createdAt` ISO timestamp for a worktree entry (T9546 AC4).
+ *
+ * Resolution order:
+ *  1. Per-worktree admin file `<gitCommonDir>/worktrees/<basename(path)>/HEAD`.
+ *     Git writes this exactly once at `git worktree add` time; its mtime is the
+ *     most reliable proxy for worktree creation time.
+ *  2. For the primary worktree (which has no per-worktree admin dir), the
+ *     mtime of the `.git` common dir itself — set when the repo was created
+ *     or cloned.
+ *  3. Sentinel index `adoptedAt`, when the entry was registered via
+ *     `cleo worktree adopt`.
+ *  4. Fallback — `mtime` of the worktree directory.
+ *
+ * @internal Exported for tests only.
+ */
+export function resolveCreatedAt(input: {
+  worktreePath: string;
+  gitCommonDir: string | null;
+  primaryWorktreePath: string | null;
+  sentinelAdoptedAt: string | undefined;
+}): string {
+  // Primary worktree: stat the .git common dir itself.
+  if (
+    input.gitCommonDir !== null &&
+    isPrimaryWorktree(input.worktreePath, input.primaryWorktreePath)
+  ) {
+    try {
+      return new Date(statSync(input.gitCommonDir).mtimeMs).toISOString();
+    } catch {
+      // Fall through to other resolvers.
+    }
+  }
+  // Linked worktree: stat the per-worktree admin HEAD file.
+  if (input.gitCommonDir !== null) {
+    const adminHead = join(input.gitCommonDir, 'worktrees', basename(input.worktreePath), 'HEAD');
+    if (existsSync(adminHead)) {
+      try {
+        return new Date(statSync(adminHead).mtimeMs).toISOString();
+      } catch {
+        // Fall through.
+      }
+    }
+  }
+  // Sentinel adopted entry that also lives in git porcelain.
+  if (input.sentinelAdoptedAt !== undefined) return input.sentinelAdoptedAt;
+  // Final fallback — worktree dir mtime.
+  return new Date(mtimeMs(input.worktreePath)).toISOString();
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements **T9546** — `cleo worktree list` structured JSON for all CLEO-managed worktrees (Saga T10176 · Decision D010 · Epic T10192 · 2 of 5 worktree-lifecycle).

- Adds `createdAt` (ISO-8601) and `lockState` (`'locked' | 'unlocked'`) to every `WorktreeInfo` entry, completing AC4 of the epic.
- `createdAt` is derived from `<gitCommonDir>/worktrees/<name>/HEAD` mtime for git-native entries (git writes this once at `git worktree add` time, so it's a faithful creation-timestamp proxy); falls back to the sentinel index `adoptedAt` timestamp for adopted external worktrees; final fallback is worktree dir mtime.
- `lockState` mirrors `isLocked` as a human-readable string token for downstream consumers.
- Sentinel-only `.cleo/worktrees.json` entries (D009 hybrid pattern) continue to be unioned into the listing — no behavioural change to AC3, only the new fields are populated.
- Adds 7 integration tests under `packages/core/src/__tests__/worktree-list.test.ts` covering AC1–AC4 with real on-disk git fixtures (no mocks). The existing 35-test classifier unit suite remains green.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/worktree/ packages/core/src/__tests__/worktree-list.test.ts` — 132/132 pass
- [x] `pnpm exec vitest run packages/contracts/` — 341/341 pass (no contract regressions)
- [x] `pnpm run build` — full monorepo build green
- [x] `pnpm biome check --write` — formatter clean
- [x] CLI smoke: `node packages/cleo/dist/cli/index.js worktree list --json` returns the new shape end-to-end on the live `cleocode` repo (15 worktrees enumerated, every entry has `createdAt` + `lockState`)

Closes T9546
Saga: T10176
Decision: D010
Epic: T10192