### PR TITLE
feat(T10119): cleo doctor saga audit (I5/I7/depth/drift)

### DIFF
--- a/.changeset/T10119-doctor-saga-audit.md
+++ b/.changeset/T10119-doctor-saga-audit.md
@@ -1,0 +1,28 @@
+---
+"@cleocode/cleo": patch
+"@cleocode/core": patch
+"@cleocode/contracts": patch
+---
+
+feat(T10119): cleo doctor saga-depth audit (I5/I7/depth/auto-close drift)
+
+Extends `cleo doctor` with a Saga Hierarchy section that audits every saga for
+ADR-073 §1.2 invariant violations (I5: saga parentId NOT NULL; I7: nested
+sagas), depth-ladder overflow, and auto-close drift (all members done but
+saga still pending — regression detector once T10116 ships).
+
+The audit reuses the runtime guards `assertSagaInvariantI5/I7` from
+`packages/core/src/sagas/enforcement.ts` (T10115) so audit + runtime share
+one definition of "violation".
+
+Surface:
+- `cleo doctor --audit-sagas` — explicit, single-envelope LAFS output
+- `cleo doctor` (default) — appends Saga Hierarchy section as human-only
+  trailing block (silent under --json so the LAFS envelope stays clean)
+
+Each violation names the offending IDs and a canonical repair command
+(`cleo saga repair`, `cleo saga detach`, `cleo saga reconcile`).
+Doctor exits with code 2 when any I5/I7/depth invariant fails;
+auto-close drift is a soft warning that does NOT alone drive exit.
+
+Saga: T10113 (SG-SAGA-FIRST-CLASS). Epic: T10209 (E-SAGA-ENFORCEMENT).

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -299,6 +299,21 @@ export const doctorCommand = defineCommand({
         'Audit orphaned CLEO-generated temp directories and report what cleo gc --temp would remove (T9043)',
     },
     /**
+     * T10119: audit every Saga (`type='epic'` + `label='saga'`) for
+     * ADR-073 §1.2 invariant violations (I5/I7 + depth ladder) and
+     * auto-close drift. Read-only; non-zero exit when any I-invariant
+     * fails so the check is CI-gateable.
+     *
+     * @task T10119
+     * @saga T10113
+     * @epic T10209
+     */
+    'audit-sagas': {
+      type: 'boolean',
+      description:
+        'Audit every Saga for ADR-073 §1.2 invariant violations (I5/I7/depth) + auto-close drift (T10119)',
+    },
+    /**
      * T9983: migrate the worktree-include file location from
      * `<root>/.cleo/worktree-include` (legacy) to `<root>/.worktreeinclude`
      * (canonical, matches Claude Code Desktop + worktrunk-core). Backs the
@@ -803,6 +818,22 @@ export const doctorCommand = defineCommand({
         ) {
           process.exitCode = 2;
         }
+      } else if (args['audit-sagas']) {
+        // T10119: ADR-073 §1.2 saga-hierarchy audit (I5/I7/depth + drift).
+        progress.step(0, 'Auditing Saga hierarchy for ADR-073 invariants');
+        const { auditSagaHierarchy } = await import('@cleocode/core/doctor/saga-audit.js');
+        const projectRoot = getProjectRoot();
+        const result = await auditSagaHierarchy(projectRoot);
+
+        const summary =
+          `Saga audit complete — ${result.sagas.length} saga(s) inspected, ` +
+          `${result.count} invariant violation(s), ${result.driftCount} drift warning(s)`;
+        progress.complete(summary);
+
+        cliOutput(result, { command: 'doctor', operation: 'doctor.audit-sagas' });
+        if (result.count > 0 && (process.exitCode === undefined || process.exitCode === 0)) {
+          process.exitCode = 2;
+        }
       } else {
         progress.step(0, 'Checking CLEO directory');
         await dispatchFromCli(
@@ -844,6 +875,45 @@ export const doctorCommand = defineCommand({
           }
         } catch {
           progress.complete('Health check complete');
+        }
+
+        // Saga Hierarchy audit — runs on every default `cleo doctor` invocation
+        // so ADR-073 §1.2 I5/I7/depth violations and auto-close drift surface
+        // without requiring `--audit-sagas`. Any hard invariant violation
+        // raises the exit code to 2; auto-close drift is a soft warning.
+        // @task T10119 @saga T10113 @epic T10209
+        try {
+          const projectRoot = getProjectRoot();
+          const { auditSagaHierarchy } = await import('@cleocode/core/doctor/saga-audit.js');
+          const sagaAudit = await auditSagaHierarchy(projectRoot);
+
+          if (sagaAudit.sagas.length === 0) {
+            humanLine('\nSaga Hierarchy: no sagas found in tasks.db');
+          } else {
+            const header =
+              `\nSaga Hierarchy (${sagaAudit.sagas.length} saga(s), ` +
+              `${sagaAudit.count} violation(s), ${sagaAudit.driftCount} drift warning(s)):`;
+            humanLine(header);
+            for (const s of sagaAudit.sagas) {
+              const violationSuffix =
+                s.violations.length > 0 ? `, ${s.violations.length} violation(s)` : '';
+              humanLine(
+                `  ${s.sagaId} · status=${s.status} · ${s.doneCount}/${s.memberCount} members done${violationSuffix}`,
+              );
+              for (const v of s.violations) {
+                humanLine(`    [${v.kind}] ${v.message}`);
+              }
+            }
+          }
+
+          if (sagaAudit.count > 0 && (process.exitCode === undefined || process.exitCode === 0)) {
+            process.exitCode = 2;
+          }
+        } catch (err) {
+          // Audit must never crash the default doctor run; surface as a
+          // soft warning instead.
+          const msg = err instanceof Error ? err.message : String(err);
+          humanLine(`\nSaga Hierarchy: audit skipped (${msg})`);
         }
       }
     } catch (err) {

--- a/packages/contracts/src/doctor.ts
+++ b/packages/contracts/src/doctor.ts
@@ -202,6 +202,90 @@ export interface OrphanScanResult {
   softWarnMessage?: string;
 }
 
+// ============================================================================
+// Saga Hierarchy Audit (T10119 — ADR-073 §1.2 invariant + drift detection)
+// ============================================================================
+
+/**
+ * Stable invariant identifiers surfaced by the saga hierarchy audit
+ * (ADR-073 §1.2). `I5` and `I7` mirror the runtime guards in
+ * `packages/core/src/sagas/enforcement.ts`. `depth` covers the I5/I7 depth
+ * ladder (saga → member-Epic → Task → Subtask = 3 hops max). `auto-close-drift`
+ * is a soft-drift detector (no invariant strictly broken — the saga is
+ * structurally valid, but every member is done while the saga still says
+ * pending; T10116 fixes the root cause).
+ */
+export type SagaAuditViolationKind = 'I5' | 'I7' | 'depth' | 'auto-close-drift';
+
+/**
+ * One violation surfaced by {@link auditSagaHierarchy}.
+ *
+ * Each violation is actionable: the `repairCommand` field names the
+ * canonical `cleo` invocation an operator should run to resolve it.
+ */
+export interface SagaAuditViolation {
+  /** Stable violation identifier (`I5`, `I7`, `depth`, `auto-close-drift`). */
+  kind: SagaAuditViolationKind;
+  /** Saga task ID where the violation was detected. */
+  sagaId: string;
+  /**
+   * The offending member task ID. Equal to `sagaId` for I5 violations
+   * (the saga row itself is the offender). For I7 violations, the
+   * nested-saga candidate. For `auto-close-drift`, equal to `sagaId`.
+   */
+  offendingId: string;
+  /** Human-readable message naming both IDs and the repair command. */
+  message: string;
+  /** Canonical `cleo` command an operator should run to resolve. */
+  repairCommand: string;
+}
+
+/**
+ * Per-saga audit summary returned by {@link auditSagaHierarchy}.
+ *
+ * Carries enough context for the doctor CLI to render a one-line summary
+ * (`Saga T#### · status=… · 4/5 members done · 0 violations`) without a
+ * second database round-trip.
+ */
+export interface SagaAuditEntry {
+  /** Saga task ID. */
+  sagaId: string;
+  /** Saga title (for human-readable rendering). */
+  title: string;
+  /** Saga status (`pending`, `active`, `done`, …). */
+  status: string;
+  /** Total member-Epic count. */
+  memberCount: number;
+  /** Member-Epics with `status='done'`. */
+  doneCount: number;
+  /**
+   * Violations attributable to this saga. Always returned (possibly
+   * empty) so callers can render a stable rows-then-violations layout.
+   */
+  violations: SagaAuditViolation[];
+}
+
+/**
+ * Aggregated result returned by {@link auditSagaHierarchy}.
+ *
+ * `count` is the total number of `I5`/`I7`/`depth` invariant violations
+ * across all sagas — the doctor CLI uses this to decide whether to set
+ * a non-zero exit code (`auto-close-drift` is a soft warning and does
+ * NOT alone trigger exit≠0; tests pass with drift but no I-invariant
+ * failure).
+ *
+ * `driftCount` is the number of `auto-close-drift` warnings (kept
+ * separate so CI gates can opt-in to treating drift as failure).
+ */
+export interface SagaAuditResult {
+  /** All sagas audited, sorted by `sagaId` ascending. */
+  sagas: SagaAuditEntry[];
+  /** Total I5/I7/depth invariant violations across all sagas. */
+  count: number;
+  /** Total auto-close-drift warnings across all sagas. */
+  driftCount: number;
+}
+
 /**
  * One line appended to `.cleo/audit/worktree-prune.jsonl` per prune
  * operation. Extends the existing audit-log schema (timestamp +

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -312,12 +312,17 @@ export {
   DocKindRegistry,
 } from './docs-taxonomy.js';
 // === Doctor: Worktree-Orphan Audit + Prune Types (T9790, T9808, T9962) ===
+// === Doctor: Saga Hierarchy Audit (T10119 — ADR-073 §1.2) ===
 export type {
   ComprehensiveAuditResult,
   OrphanEntry,
   OrphanScanResult,
   PruneAuditEntry,
   PruneResult,
+  SagaAuditEntry,
+  SagaAuditResult,
+  SagaAuditViolation,
+  SagaAuditViolationKind,
   WorktreeAnomaly,
   WorktreeAnomalyKind,
 } from './doctor.js';

--- a/packages/core/src/doctor/__tests__/saga-audit.test.ts
+++ b/packages/core/src/doctor/__tests__/saga-audit.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for `auditSagaHierarchy` (T10119).
+ *
+ * Covers the four detection branches:
+ *
+ *   1. Clean saga — zero violations + zero drift.
+ *   2. I5 violation — saga row has a non-null `parentId`.
+ *   3. I7 violation — a saga-member candidate carries `label='saga'`.
+ *   4. auto-close-drift — all members done but saga still pending
+ *      (`count` stays at 0; `driftCount` rises). T10116 fixes the root
+ *      cause; this branch becomes a regression detector once that ships.
+ *
+ * Tests insert tasks directly into a real in-process SQLite tasks.db
+ * via the same `getDb` + `getNativeDb` surface used by the rest of the
+ * core doctor tests.
+ *
+ * @task T10119
+ * @saga T10113
+ * @epic T10209
+ */
+
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let tempDir: string;
+
+interface NativeDbForTest {
+  prepare: (sql: string) => { run: (...args: (string | number | null)[]) => void };
+}
+
+/**
+ * Insert a single task row directly. Bypasses the higher-level `taskAdd`
+ * path so the test can construct exactly the shape it wants (including
+ * deliberately invariant-breaking rows for I5 / I7).
+ *
+ * `pipeline_stage` is set to `'contribution'` whenever `status='done'` so
+ * the T877 status/pipeline_stage invariant trigger does not fire — the
+ * audit under test cares about saga structure, not lifecycle bookkeeping.
+ */
+function insertTask(
+  db: NativeDbForTest,
+  row: {
+    id: string;
+    title: string;
+    type: 'epic' | 'task' | 'subtask';
+    status?: 'pending' | 'active' | 'done' | 'blocked';
+    parentId?: string | null;
+    labels?: string[];
+  },
+): void {
+  const status = row.status ?? 'pending';
+  const pipelineStage = status === 'done' ? 'contribution' : null;
+  db.prepare(
+    'INSERT INTO tasks (id, title, type, status, parent_id, labels_json, pipeline_stage) VALUES (?, ?, ?, ?, ?, ?, ?)',
+  ).run(
+    row.id,
+    row.title,
+    row.type,
+    status,
+    row.parentId ?? null,
+    JSON.stringify(row.labels ?? []),
+    pipelineStage,
+  );
+}
+
+/** Link a member task into a saga via `task_relations.type='groups'`. */
+function linkMember(db: NativeDbForTest, sagaId: string, memberId: string): void {
+  db.prepare(
+    "INSERT INTO task_relations (task_id, related_to, relation_type) VALUES (?, ?, 'groups')",
+  ).run(sagaId, memberId);
+}
+
+describe('auditSagaHierarchy (T10119)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-saga-audit-'));
+    await mkdir(join(tempDir, '.cleo'), { recursive: true });
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+
+    // Initialize tasks.db.
+    const { getDb } = await import('../../store/sqlite.js');
+    await getDb(tempDir);
+  });
+
+  afterEach(async () => {
+    try {
+      const { closeDb } = await import('../../store/sqlite.js');
+      closeDb();
+    } catch {
+      /* may not be loaded */
+    }
+    delete process.env['CLEO_DIR'];
+    await Promise.race([
+      rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 300 }).catch(() => {}),
+      new Promise<void>((resolve) => setTimeout(resolve, 8_000)),
+    ]);
+  });
+
+  it('returns empty result when no sagas exist', async () => {
+    const { auditSagaHierarchy } = await import('../saga-audit.js');
+    const result = await auditSagaHierarchy(tempDir);
+    expect(result.sagas).toEqual([]);
+    expect(result.count).toBe(0);
+    expect(result.driftCount).toBe(0);
+  });
+
+  it('reports zero violations for a clean saga with valid members', async () => {
+    const { getNativeDb } = await import('../../store/sqlite.js');
+    const db = getNativeDb() as NativeDbForTest | null;
+    if (!db) throw new Error('nativeDb not initialized');
+
+    // Clean saga + one normal Epic member.
+    insertTask(db, { id: 'SG001', title: 'Clean Saga', type: 'epic', labels: ['saga'] });
+    insertTask(db, { id: 'E001', title: 'Member Epic', type: 'epic' });
+    linkMember(db, 'SG001', 'E001');
+
+    const { auditSagaHierarchy } = await import('../saga-audit.js');
+    const result = await auditSagaHierarchy(tempDir);
+
+    expect(result.sagas).toHaveLength(1);
+    expect(result.sagas[0]?.sagaId).toBe('SG001');
+    expect(result.sagas[0]?.violations).toEqual([]);
+    expect(result.sagas[0]?.memberCount).toBe(1);
+    expect(result.count).toBe(0);
+    expect(result.driftCount).toBe(0);
+  });
+
+  it('detects I5 violation when saga has a non-null parentId', async () => {
+    const { getNativeDb } = await import('../../store/sqlite.js');
+    const db = getNativeDb() as NativeDbForTest | null;
+    if (!db) throw new Error('nativeDb not initialized');
+
+    insertTask(db, { id: 'E_PARENT', title: 'Parent Epic', type: 'epic' });
+    insertTask(db, {
+      id: 'SG002',
+      title: 'Saga with parent',
+      type: 'epic',
+      labels: ['saga'],
+      parentId: 'E_PARENT',
+    });
+
+    const { auditSagaHierarchy } = await import('../saga-audit.js');
+    const result = await auditSagaHierarchy(tempDir);
+
+    const sg002 = result.sagas.find((s) => s.sagaId === 'SG002');
+    expect(sg002).toBeDefined();
+    const i5 = sg002?.violations.find((v) => v.kind === 'I5');
+    expect(i5).toBeDefined();
+    expect(i5?.offendingId).toBe('SG002');
+    expect(i5?.message).toContain('I5');
+    expect(i5?.message).toContain('E_PARENT');
+    expect(i5?.repairCommand).toBe('cleo saga repair SG002');
+    expect(result.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('detects I7 violation when a saga member is itself a saga', async () => {
+    const { getNativeDb } = await import('../../store/sqlite.js');
+    const db = getNativeDb() as NativeDbForTest | null;
+    if (!db) throw new Error('nativeDb not initialized');
+
+    insertTask(db, { id: 'SG003', title: 'Outer Saga', type: 'epic', labels: ['saga'] });
+    // Nested saga — invariant I7 violation.
+    insertTask(db, { id: 'SG003_INNER', title: 'Inner Saga', type: 'epic', labels: ['saga'] });
+    linkMember(db, 'SG003', 'SG003_INNER');
+
+    const { auditSagaHierarchy } = await import('../saga-audit.js');
+    const result = await auditSagaHierarchy(tempDir);
+
+    const outer = result.sagas.find((s) => s.sagaId === 'SG003');
+    expect(outer).toBeDefined();
+    const i7 = outer?.violations.find((v) => v.kind === 'I7');
+    expect(i7).toBeDefined();
+    expect(i7?.offendingId).toBe('SG003_INNER');
+    expect(i7?.message).toContain('I7');
+    expect(i7?.message).toContain('SG003_INNER');
+    expect(i7?.repairCommand).toBe('cleo saga detach SG003 SG003_INNER');
+  });
+
+  it('detects auto-close drift when all members done but saga pending', async () => {
+    const { getNativeDb } = await import('../../store/sqlite.js');
+    const db = getNativeDb() as NativeDbForTest | null;
+    if (!db) throw new Error('nativeDb not initialized');
+
+    insertTask(db, {
+      id: 'SG004',
+      title: 'Drifting Saga',
+      type: 'epic',
+      status: 'pending',
+      labels: ['saga'],
+    });
+    insertTask(db, { id: 'E_M1', title: 'Member 1', type: 'epic', status: 'done' });
+    insertTask(db, { id: 'E_M2', title: 'Member 2', type: 'epic', status: 'done' });
+    linkMember(db, 'SG004', 'E_M1');
+    linkMember(db, 'SG004', 'E_M2');
+
+    const { auditSagaHierarchy } = await import('../saga-audit.js');
+    const result = await auditSagaHierarchy(tempDir);
+
+    const drifting = result.sagas.find((s) => s.sagaId === 'SG004');
+    expect(drifting).toBeDefined();
+    expect(drifting?.memberCount).toBe(2);
+    expect(drifting?.doneCount).toBe(2);
+
+    const drift = drifting?.violations.find((v) => v.kind === 'auto-close-drift');
+    expect(drift).toBeDefined();
+    expect(drift?.message).toContain('2/2 members done');
+    expect(drift?.message).toContain('status=pending');
+    expect(drift?.repairCommand).toBe('cleo saga reconcile SG004');
+
+    // Auto-close-drift is a soft warning — it does NOT count toward the
+    // hard `count` total (only I5/I7/depth do).
+    expect(result.driftCount).toBe(1);
+    expect(result.count).toBe(0);
+  });
+
+  it('does NOT flag auto-close drift when saga.status=done matches members', async () => {
+    const { getNativeDb } = await import('../../store/sqlite.js');
+    const db = getNativeDb() as NativeDbForTest | null;
+    if (!db) throw new Error('nativeDb not initialized');
+
+    insertTask(db, {
+      id: 'SG005',
+      title: 'Closed Saga',
+      type: 'epic',
+      status: 'done',
+      labels: ['saga'],
+    });
+    insertTask(db, { id: 'E_M3', title: 'Member 3', type: 'epic', status: 'done' });
+    linkMember(db, 'SG005', 'E_M3');
+
+    const { auditSagaHierarchy } = await import('../saga-audit.js');
+    const result = await auditSagaHierarchy(tempDir);
+
+    const closed = result.sagas.find((s) => s.sagaId === 'SG005');
+    expect(closed?.violations.find((v) => v.kind === 'auto-close-drift')).toBeUndefined();
+    expect(result.driftCount).toBe(0);
+  });
+});

--- a/packages/core/src/doctor/index.ts
+++ b/packages/core/src/doctor/index.ts
@@ -18,6 +18,7 @@
  * @epic T9808
  */
 
+export { auditSagaHierarchy } from './saga-audit.js';
 export type { PruneOptions, ScanOptions } from './worktree-orphans.js';
 export {
   auditWorktreeOrphansComprehensive,

--- a/packages/core/src/doctor/saga-audit.ts
+++ b/packages/core/src/doctor/saga-audit.ts
@@ -1,0 +1,291 @@
+/**
+ * Saga hierarchy audit primitive for `cleo doctor`.
+ *
+ * Walks every Saga (`type='epic'` + `label='saga'`) and surfaces violations
+ * of the ADR-073 §1.2 invariant ladder:
+ *
+ *   - **I5** — saga `parentId` MUST be NULL.
+ *   - **I7** — saga members MUST NOT themselves carry `label='saga'`
+ *     (no nested sagas).
+ *   - **depth** — saga → member → member-children depth ladder MUST
+ *     stay ≤ 3 hops (saga is hop 0, member-Epic is hop 1, the Epic's
+ *     direct task children are hop 2, subtasks are hop 3 — anything
+ *     deeper is structurally invalid for the saga hierarchy).
+ *
+ * Plus one soft-drift detector:
+ *
+ *   - **auto-close-drift** — every member is `status='done'` but the
+ *     saga still says `pending` or `active`. ADR-073 §1.3 says a saga
+ *     auto-completes when all members do; T10116 implements that closure
+ *     hook at the rollup layer, so this branch becomes a regression
+ *     detector once T10116 ships.
+ *
+ * Each violation is actionable — the result carries the offending IDs and
+ * the canonical `cleo` command an operator should run to repair it. The
+ * doctor CLI converts these into one-line summary rows; the LAFS envelope
+ * carries the full structured `SagaAuditResult` payload.
+ *
+ * Reuses the runtime guards in `packages/core/src/sagas/enforcement.ts`
+ * (T10115) so the audit + runtime gate share one definition of "violation".
+ *
+ * @task T10119
+ * @saga T10113 — SG-SAGA-FIRST-CLASS
+ * @epic T10209 — E-SAGA-ENFORCEMENT
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+
+import type {
+  SagaAuditEntry,
+  SagaAuditResult,
+  SagaAuditViolation,
+  Task,
+} from '@cleocode/contracts';
+import {
+  assertSagaInvariantI5,
+  assertSagaInvariantI7,
+  isSagaInvariantViolationError,
+  SAGA_GROUPS_RELATION,
+  SAGA_LABEL,
+} from '../sagas/index.js';
+import { taskList } from '../tasks/list.js';
+import { taskShow } from '../tasks/show.js';
+
+/**
+ * Maximum saga-hierarchy depth permitted by ADR-073 §1.2 (I5/I7 depth
+ * ladder).
+ *
+ * The hop count is counted FROM the saga row:
+ *   - hop 0: the saga itself.
+ *   - hop 1: a member Epic linked via `task_relations.type='groups'`.
+ *   - hop 2: a direct child of the member Epic (task or subtask).
+ *   - hop 3: a grandchild of the member Epic (subtask of subtask is
+ *            already over-budget).
+ *
+ * Anything that lives strictly deeper than the member Epic's direct
+ * children violates the depth ladder — sagas are not meant to host
+ * deeply-nested trees beneath each member.
+ */
+const SAGA_HIERARCHY_MAX_DEPTH = 3;
+
+/**
+ * Cast a {@link TaskRecord}-shaped row from `taskList` / `taskShow` to the
+ * narrower {@link Task} shape the saga enforcement guards expect.
+ *
+ * The two types share the relevant fields (`id`, `labels`, `parentId`,
+ * `depends`) — only the union-typed columns (status/priority/...) widen
+ * in `TaskRecord`. A direct structural narrow is safe here.
+ */
+interface TaskLike {
+  id: string;
+  title?: string;
+  status?: string;
+  parentId?: string | null;
+  labels?: string[];
+  depends?: string[];
+  relates?: Array<{ taskId: string; type: string }>;
+}
+
+/**
+ * Walk a saga member's sub-tree and return the maximum hop count
+ * encountered relative to the saga root.
+ *
+ * Iterative BFS so we never blow the stack on a wide tree; bounded by
+ * `maxDepth + 1` to short-circuit as soon as an over-budget node is
+ * found.
+ *
+ * @param projectRoot - Absolute path to the project root.
+ * @param rootMemberId - The saga member Epic's task ID (hop 1 from the saga).
+ * @param maxDepth - The hop-budget; iteration stops one level beyond.
+ * @returns The deepest hop count reached. Returns `1` for a leaf member,
+ *          `maxDepth + 1` if the tree exceeds the budget.
+ */
+async function measureMemberSubtreeDepth(
+  projectRoot: string,
+  rootMemberId: string,
+  maxDepth: number,
+): Promise<number> {
+  let frontier: string[] = [rootMemberId];
+  let depth = 1; // hop 1: the member Epic itself.
+  while (frontier.length > 0 && depth <= maxDepth) {
+    const nextFrontier: string[] = [];
+    for (const id of frontier) {
+      const childResult = await taskList(projectRoot, { parent: id });
+      if (!childResult.success || !childResult.data?.tasks) continue;
+      for (const child of childResult.data.tasks) {
+        const cid = (child as { id?: string }).id;
+        if (typeof cid === 'string') {
+          nextFrontier.push(cid);
+        }
+      }
+    }
+    if (nextFrontier.length === 0) {
+      return depth;
+    }
+    depth += 1;
+    frontier = nextFrontier;
+  }
+  return depth;
+}
+
+/**
+ * Audit every Saga in the project's task store for ADR-073 §1.2
+ * invariant violations and auto-close drift.
+ *
+ * Read-only — performs zero writes. Safe to invoke from `cleo doctor`
+ * without any `--fix`-style flag.
+ *
+ * @param projectRoot - Absolute path to the project root.
+ * @returns Aggregated result. `count` is the I-invariant + depth
+ *          violation total (drives non-zero exit). `driftCount` is the
+ *          soft auto-close-drift warning total (does NOT drive exit on
+ *          its own).
+ *
+ * @example
+ * ```typescript
+ * const audit = await auditSagaHierarchy(projectRoot);
+ * for (const v of audit.sagas.flatMap((s) => s.violations)) {
+ *   console.log(v.message); // includes offending IDs + repair command
+ * }
+ * if (audit.count > 0) process.exitCode = 2;
+ * ```
+ */
+export async function auditSagaHierarchy(projectRoot: string): Promise<SagaAuditResult> {
+  // Step 1 — list every saga-labeled epic (ADR-073 I1).
+  const listResult = await taskList(projectRoot, { type: 'epic', label: SAGA_LABEL });
+  const sagas: SagaAuditEntry[] = [];
+  if (!listResult.success || !listResult.data?.tasks) {
+    return { sagas: [], count: 0, driftCount: 0 };
+  }
+
+  let totalInvariantViolations = 0;
+  let totalDrift = 0;
+
+  // Iterate sagas in stable id order so the doctor output is deterministic.
+  const sagaRows = (listResult.data.tasks as TaskLike[]).slice().sort((a, b) => {
+    return (a.id ?? '').localeCompare(b.id ?? '');
+  });
+
+  for (const sagaRow of sagaRows) {
+    if (!sagaRow.id) continue;
+
+    const violations: SagaAuditViolation[] = [];
+
+    // --- I5 check (sagaRow.parentId IS NULL) ---
+    // Reuse the runtime guard so audit + runtime share one definition.
+    try {
+      assertSagaInvariantI5({
+        id: sagaRow.id,
+        labels: sagaRow.labels ?? [],
+        parentId: sagaRow.parentId ?? null,
+        depends: sagaRow.depends ?? [],
+      } as unknown as Task);
+    } catch (err) {
+      if (isSagaInvariantViolationError(err) && err.diag.invariant === 'I5') {
+        violations.push({
+          kind: 'I5',
+          sagaId: sagaRow.id,
+          offendingId: sagaRow.id,
+          message:
+            `Saga ${sagaRow.id} violates I5: parentId=${sagaRow.parentId ?? '<null>'}` +
+            ` — run \`cleo saga repair ${sagaRow.id}\``,
+          repairCommand: `cleo saga repair ${sagaRow.id}`,
+        });
+      }
+    }
+
+    // --- Load relates so we can audit members ---
+    const showResult = await taskShow(projectRoot, sagaRow.id);
+    const relates =
+      showResult.success && showResult.data?.task.relates ? showResult.data.task.relates : [];
+    const memberIds: string[] = [];
+    const seenMembers = new Set<string>();
+    for (const rel of relates) {
+      if (rel.type !== SAGA_GROUPS_RELATION) continue;
+      if (seenMembers.has(rel.taskId)) continue;
+      seenMembers.add(rel.taskId);
+      memberIds.push(rel.taskId);
+    }
+
+    let doneCount = 0;
+
+    for (const memberId of memberIds) {
+      const memberShow = await taskShow(projectRoot, memberId);
+      if (!memberShow.success || !memberShow.data?.task) continue;
+      const member = memberShow.data.task as TaskLike;
+
+      if (member.status === 'done') {
+        doneCount += 1;
+      }
+
+      // --- I7 check (member must NOT be label=saga) ---
+      try {
+        assertSagaInvariantI7(memberId, member.labels ?? [], sagaRow.id);
+      } catch (err) {
+        if (isSagaInvariantViolationError(err) && err.diag.invariant === 'I7') {
+          violations.push({
+            kind: 'I7',
+            sagaId: sagaRow.id,
+            offendingId: memberId,
+            message:
+              `Saga ${sagaRow.id} violates I7: member ${memberId} has label=saga` +
+              ` — run \`cleo saga detach ${sagaRow.id} ${memberId}\``,
+            repairCommand: `cleo saga detach ${sagaRow.id} ${memberId}`,
+          });
+        }
+      }
+
+      // --- depth check (member sub-tree must stay ≤ MAX hops) ---
+      const observedDepth = await measureMemberSubtreeDepth(
+        projectRoot,
+        memberId,
+        SAGA_HIERARCHY_MAX_DEPTH,
+      );
+      if (observedDepth > SAGA_HIERARCHY_MAX_DEPTH) {
+        violations.push({
+          kind: 'depth',
+          sagaId: sagaRow.id,
+          offendingId: memberId,
+          message:
+            `Saga ${sagaRow.id} violates depth ladder: member ${memberId} sub-tree exceeds ` +
+            `${SAGA_HIERARCHY_MAX_DEPTH} hops — flatten via \`cleo show ${memberId}\` then ` +
+            `reorganize`,
+          repairCommand: `cleo show ${memberId}`,
+        });
+      }
+    }
+
+    // --- auto-close-drift (soft warning, does NOT count as invariant break) ---
+    const totalMembers = memberIds.length;
+    const sagaStatus = sagaRow.status ?? 'pending';
+    if (totalMembers > 0 && doneCount === totalMembers && sagaStatus !== 'done') {
+      violations.push({
+        kind: 'auto-close-drift',
+        sagaId: sagaRow.id,
+        offendingId: sagaRow.id,
+        message:
+          `Saga ${sagaRow.id} auto-close drift: ${doneCount}/${totalMembers} members done` +
+          ` but status=${sagaStatus} — run \`cleo saga reconcile ${sagaRow.id}\``,
+        repairCommand: `cleo saga reconcile ${sagaRow.id}`,
+      });
+      totalDrift += 1;
+    }
+
+    // Tally only hard invariant violations toward the exit-driving total.
+    for (const v of violations) {
+      if (v.kind !== 'auto-close-drift') {
+        totalInvariantViolations += 1;
+      }
+    }
+
+    sagas.push({
+      sagaId: sagaRow.id,
+      title: sagaRow.title ?? '',
+      status: sagaStatus,
+      memberCount: totalMembers,
+      doneCount,
+      violations,
+    });
+  }
+
+  return { sagas, count: totalInvariantViolations, driftCount: totalDrift };
+}


### PR DESCRIPTION
## Summary

Adds Saga Hierarchy audit section to `cleo doctor`:
- I5 (saga `parentId` NOT NULL) violations
- I7 (nested-saga) violations
- Depth ladder overflow (saga → member → child > 3 hops)
- Auto-close drift (regression detector for T10116)

Reuses runtime guards `assertSagaInvariantI5/I7` from `packages/core/src/sagas/enforcement.ts` (T10115) so audit + runtime share one definition of "violation".

Each violation line is actionable — names the offending IDs and the canonical `cleo saga repair`/`detach`/`reconcile` repair command.

## Surface

- `cleo doctor --audit-sagas` — explicit, single-envelope LAFS output
- `cleo doctor` (default) — appends Saga Hierarchy section as human-only trailing block (silent under `--json` so the envelope stays clean)

## Exit code

`process.exitCode = 2` when any I5/I7/depth invariant fails (CI-gateable). Auto-close drift is a soft warning and does NOT alone drive exit.

## Tests

- 6 new vitest cases in `packages/core/src/doctor/__tests__/saga-audit.test.ts` covering clean / I5 / I7 / drift / closed scenarios
- All 46 existing doctor + saga tests still green

## Files

- `packages/core/src/doctor/saga-audit.ts` (new)
- `packages/core/src/doctor/__tests__/saga-audit.test.ts` (new)
- `packages/core/src/doctor/index.ts` (export `auditSagaHierarchy`)
- `packages/contracts/src/doctor.ts` (new `SagaAuditResult/Entry/Violation/Kind`)
- `packages/contracts/src/index.ts` (re-exports)
- `packages/cleo/src/cli/commands/doctor.ts` (new flag + default-path section)
- `.changeset/T10119-doctor-saga-audit.md`

Closes T10119. Saga T10113. Epic T10209.