### PR TITLE
feat(T10118): I7 gate in sagaAdd + cleo saga detach (T9831/T9799 repair)

### DIFF
--- a/.changeset/T10118-saga-i7-detach.md
+++ b/.changeset/T10118-saga-i7-detach.md
@@ -1,0 +1,12 @@
+---
+"@cleocode/cleo": patch
+"@cleocode/core": patch
+"@cleocode/contracts": patch
+---
+
+feat(T10118): wire I7 gate into sagaAdd + cleo saga detach verb
+
+sagaAdd now calls assertSagaInvariantI7 — rejects member candidates whose labels
+include 'saga' with E_SAGA_INVARIANT_VIOLATION_I7. Adds cleo saga detach <sagaId>
+<memberId> idempotent repair verb (audit log at .cleo/audit/saga-detach.jsonl).
+Detaches T9831 from T9799 in dogfood. Saga: T10113. Epic: T10209.

--- a/packages/cleo/src/cli/commands/saga.ts
+++ b/packages/cleo/src/cli/commands/saga.ts
@@ -8,6 +8,7 @@
  * Commands:
  *   cleo saga create --title <t> [--description <d>] [--acceptance <a>]
  *   cleo saga add <sagaId> <epicId>
+ *   cleo saga detach <sagaId> <memberId> [--reason "..."]
  *   cleo saga list
  *   cleo saga members <sagaId>
  *   cleo saga rollup <sagaId>
@@ -16,7 +17,9 @@
  * @see ADR-073 — Above-Epic Naming (Saga, prefix SG-)
  * @task T9521
  * @task T10117 — saga repair verb
+ * @task T10118 — `detach` verb wired for ADR-073 §1.2 I7 repair
  * @epic T9518
+ * @epic T10209 — E-SAGA-ENFORCEMENT
  */
 
 import { parseAcceptanceCriteria } from '@cleocode/core';
@@ -89,6 +92,48 @@ const addCommand = defineCommand({
       'saga.add',
       { sagaId: args.sagaId, epicId: args.epicId },
       { command: 'saga', operation: 'tasks.saga.add' },
+    );
+  },
+});
+
+/**
+ * cleo saga detach <sagaId> <memberId> — remove a single groups relation.
+ * Idempotent (no-op if already removed). Always appends to
+ * `.cleo/audit/saga-detach.jsonl`. Primary use case: repair an ADR-073 §1.2
+ * I7 violation where a saga was linked as a member of another saga.
+ *
+ * @task T10118
+ */
+const detachCommand = defineCommand({
+  meta: {
+    name: 'detach',
+    description:
+      'Remove a Saga member relation (task_relations type=groups) — idempotent, audit-logged',
+  },
+  args: {
+    sagaId: {
+      type: 'positional',
+      description: 'Saga task ID',
+      required: true,
+    },
+    memberId: {
+      type: 'positional',
+      description: 'Member task ID to detach from the Saga',
+      required: true,
+    },
+    reason: {
+      type: 'string',
+      description: 'Human-readable reason recorded in the audit log entry',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    await dispatchFromCli(
+      'mutate',
+      'tasks',
+      'saga.detach',
+      { sagaId: args.sagaId, memberId: args.memberId, reason: args.reason },
+      { command: 'saga', operation: 'tasks.saga.detach' },
     );
   },
 });
@@ -198,6 +243,7 @@ export const sagaCommand = defineCommand({
   subCommands: {
     create: createCommand,
     add: addCommand,
+    detach: detachCommand,
     list: listCommand,
     members: membersCommand,
     rollup: rollupCommand,

--- a/packages/cleo/src/dispatch/domains/tasks.ts
+++ b/packages/cleo/src/dispatch/domains/tasks.ts
@@ -6,7 +6,8 @@
  * current, add, update, complete, delete, archive, restore, reparent,
  * promote, reorder, relates.add, relates.remove, start, stop,
  * sync.reconcile, sync.links, sync.links.remove,
- * saga.create, saga.add, saga.list, saga.members, saga.rollup.
+ * saga.create, saga.add, saga.detach, saga.list, saga.members, saga.rollup,
+ * saga.repair.
  *
  * Query operations delegate to task-engine; start/stop/current delegate
  * to session-engine (which hosts task-work functions).
@@ -27,9 +28,11 @@ import { getLogger, getProjectRoot } from '@cleocode/core';
 import { createAttachmentStore } from '@cleocode/core/internal';
 // Saga core ops — pure business logic moved out of dispatch in T10124.
 // T10117 adds `sagaRepair` (`saga.repair`) for I5 violation cleanup.
+// T10118 adds the `detach` op for repair of nested-saga relations.
 import {
   sagaAdd as coreSagaAdd,
   sagaCreate as coreSagaCreate,
+  detachSagaMember as coreSagaDetach,
   sagaList as coreSagaList,
   sagaMembers as coreSagaMembers,
   repairSaga as coreSagaRepair,
@@ -664,6 +667,8 @@ const MUTATE_OPS = new Set<string>([
   'saga.add',
   // T10117 — repair an I5-violating saga (detach parentId, write groups edge).
   'saga.repair',
+  // T10118 — repair verb for ADR-073 §1.2 I7 violations (detach saga member).
+  'saga.detach',
 ]);
 
 // ---------------------------------------------------------------------------
@@ -692,6 +697,22 @@ async function sagaAdd(params: Record<string, unknown>): Promise<LafsEnvelope<un
   const sagaId = typeof params.sagaId === 'string' ? params.sagaId : '';
   const epicId = typeof params.epicId === 'string' ? params.epicId : '';
   return wrapCoreResult(await coreSagaAdd(getProjectRoot(), { sagaId, epicId }), 'saga.add');
+}
+
+/**
+ * saga.detach — remove a `task_relations.type='groups'` row between a saga
+ * and a member. Idempotent + audit-logged. See `core/sagas/detach.ts`.
+ *
+ * @task T10118
+ */
+async function sagaDetach(params: Record<string, unknown>): Promise<LafsEnvelope<unknown>> {
+  const sagaId = typeof params.sagaId === 'string' ? params.sagaId : '';
+  const memberId = typeof params.memberId === 'string' ? params.memberId : '';
+  const reason = typeof params.reason === 'string' ? params.reason : undefined;
+  return wrapCoreResult(
+    await coreSagaDetach(getProjectRoot(), { sagaId, memberId, reason }),
+    'saga.detach',
+  );
 }
 
 /** saga.list — list all top-level Sagas. See `core/sagas/list.ts`. */
@@ -863,6 +884,16 @@ export class TasksHandler implements DomainHandler {
           startTime,
         );
       }
+      if (operation === 'saga.detach') {
+        const envelope = await sagaDetach(params ?? {});
+        return wrapResult(
+          envelopeToEngineResult(envelope),
+          'mutate',
+          'tasks',
+          operation,
+          startTime,
+        );
+      }
     } catch (error) {
       getLogger('domain:tasks').error(
         { gateway: 'mutate', domain: 'tasks', operation, err: error },
@@ -944,6 +975,8 @@ export class TasksHandler implements DomainHandler {
         'saga.add',
         // T10117 — repair an I5-violating saga.
         'saga.repair',
+        // T10118 — repair verb for ADR-073 §1.2 I7 violations
+        'saga.detach',
       ],
     };
   }

--- a/packages/contracts/src/dispatch/operations-registry.ts
+++ b/packages/contracts/src/dispatch/operations-registry.ts
@@ -2396,6 +2396,39 @@ export const OPERATIONS: OperationDef[] = [
     ] satisfies ParamDef[],
   },
   {
+    gateway: 'mutate',
+    domain: 'tasks',
+    operation: 'saga.detach',
+    description:
+      'tasks.saga.detach (mutate) — remove a Saga member relation (task_relations type=groups); idempotent; appends to .cleo/audit/saga-detach.jsonl (T10118)',
+    tier: 0,
+    idempotent: true,
+    sessionRequired: false,
+    requiredParams: ['sagaId', 'memberId'],
+    params: [
+      {
+        name: 'sagaId',
+        type: 'string',
+        required: true,
+        description: 'Saga task ID',
+        cli: { positional: true },
+      },
+      {
+        name: 'memberId',
+        type: 'string',
+        required: true,
+        description: 'Member task ID to detach from the Saga',
+        cli: { positional: true },
+      },
+      {
+        name: 'reason',
+        type: 'string',
+        required: false,
+        description: 'Human-readable reason recorded in the audit log entry',
+      },
+    ] satisfies ParamDef[],
+  },
+  {
     gateway: 'query',
     domain: 'tasks',
     operation: 'saga.list',

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1170,6 +1170,8 @@ export type {
   TasksSagaAddResult,
   TasksSagaCreateParams,
   TasksSagaCreateResult,
+  TasksSagaDetachParams,
+  TasksSagaDetachResult,
   TasksSagaListParams,
   TasksSagaListResult,
   TasksSagaMembersParams,

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -1048,6 +1048,41 @@ export interface TasksSagaAddResult {
   added: boolean;
 }
 
+/**
+ * Params for `tasks.saga.detach` — remove a Saga member relation
+ * (`task_relations.type='groups'`). Idempotent.
+ *
+ * @task T10118
+ * @see ADR-073-above-epic-naming.md §1.2 invariant I7
+ */
+export interface TasksSagaDetachParams {
+  /** Saga task ID (the `from` side of the groups relation). */
+  sagaId: string;
+  /** Member task ID (the `to` side of the groups relation). */
+  memberId: string;
+  /** Optional human-readable reason recorded in the audit log entry. */
+  reason?: string;
+}
+
+/**
+ * Result of `tasks.saga.detach` — relation removal confirmation + audit
+ * record (always appended even on idempotent no-op).
+ *
+ * @task T10118
+ */
+export interface TasksSagaDetachResult {
+  /** Saga task ID. */
+  sagaId: string;
+  /** Member task ID that was detached. */
+  memberId: string;
+  /** True when a row was actually removed; false on idempotent no-op. */
+  removed: boolean;
+  /** Reason recorded in the audit log entry. */
+  reason: string;
+  /** ISO 8601 timestamp recorded in the audit log entry. */
+  timestamp: string;
+}
+
 /** Params for `tasks.saga.list` — list all Sagas. */
 export type TasksSagaListParams = Record<string, never>;
 
@@ -1227,6 +1262,7 @@ export type TasksOps = {
   // Saga sub-domain ops (ADR-073)
   readonly 'saga.create': readonly [TasksSagaCreateParams, TasksSagaCreateResult];
   readonly 'saga.add': readonly [TasksSagaAddParams, TasksSagaAddResult];
+  readonly 'saga.detach': readonly [TasksSagaDetachParams, TasksSagaDetachResult];
   readonly 'saga.list': readonly [TasksSagaListParams, TasksSagaListResult];
   readonly 'saga.members': readonly [TasksSagaMembersParams, TasksSagaMembersResult];
   readonly 'saga.rollup': readonly [TasksSagaRollupParams, TasksSagaRollupResult];

--- a/packages/core/src/sagas/__tests__/add.test.ts
+++ b/packages/core/src/sagas/__tests__/add.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression tests for the T10118 I7 wiring inside `sagaAdd`.
+ *
+ * The pure-function guard `assertSagaInvariantI7` is exhaustively unit-tested
+ * in `enforcement.test.ts`. This file asserts the integration boundary:
+ * sagaAdd MUST call the guard with the candidate's actual labels, MUST
+ * convert the typed `SagaInvariantViolationError` into an EngineResult with
+ * the stable `E_SAGA_INVARIANT_VIOLATION_I7` code, and MUST refuse to write
+ * the `task_relations.type='groups'` row when the guard rejects.
+ *
+ * Includes the historical T9831-nested-in-T9799 fixture (both rows carry
+ * `label='saga'`).
+ *
+ * @task T10118
+ * @saga T10113 — SG-SAGA-FIRST-CLASS
+ * @epic T10209 — E-SAGA-ENFORCEMENT
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+
+import { mkdirSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createTask, getDb, taskRelates } from '@cleocode/core/internal';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { sagaAdd } from '../add.js';
+import { E_SAGA_INVARIANT_VIOLATION_I7 } from '../enforcement.js';
+
+let TEST_ROOT: string;
+
+/**
+ * Seed two sagas (T-S1 + T-S2) and a regular epic (T-E1) so we can assert
+ * both the happy path and the nested-saga rejection path.
+ */
+async function seedTwoSagasFixture(testRoot: string): Promise<void> {
+  const cleoDir = join(testRoot, '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+  // validateProjectRoot requires `.git/` sibling for the walk-up.
+  mkdirSync(join(testRoot, '.git'), { recursive: true });
+  await getDb(testRoot);
+
+  const ts = '2026-05-22T00:00:00Z';
+  const rows = [
+    {
+      id: 'T-S1',
+      title: 'Saga One',
+      description: 'First saga',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'high' as const,
+      labels: ['saga'],
+      createdAt: ts,
+      updatedAt: null,
+    },
+    {
+      id: 'T-S2',
+      title: 'Saga Two',
+      description: 'Second saga — must NOT be linkable into T-S1',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'high' as const,
+      labels: ['saga'],
+      createdAt: ts,
+      updatedAt: null,
+    },
+    {
+      id: 'T-E1',
+      title: 'Regular Epic',
+      description: 'Non-saga epic — legal saga member',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'medium' as const,
+      createdAt: ts,
+      updatedAt: null,
+    },
+  ];
+
+  for (const row of rows) {
+    await createTask(row as Parameters<typeof createTask>[0], testRoot);
+  }
+}
+
+beforeEach(async () => {
+  TEST_ROOT = await mkdtemp(join(tmpdir(), 'cleo-saga-add-i7-test-'));
+  await seedTwoSagasFixture(TEST_ROOT);
+});
+
+afterEach(async () => {
+  try {
+    const { closeAllDatabases } = await import('@cleocode/core/internal');
+    await closeAllDatabases();
+  } catch {
+    // ignore cleanup errors
+  }
+  await rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('sagaAdd — ADR-073 §1.2 invariant I7 (no nested sagas)', () => {
+  it('accepts a regular epic as a saga member (happy path)', async () => {
+    const result = await sagaAdd(TEST_ROOT, { sagaId: 'T-S1', epicId: 'T-E1' });
+    expect(result.success, JSON.stringify(result)).toBe(true);
+    if (!result.success) return;
+    expect(result.data?.added).toBe(true);
+    expect(result.data?.sagaId).toBe('T-S1');
+    expect(result.data?.epicId).toBe('T-E1');
+
+    // Sanity: relation row exists after the success.
+    const relations = await taskRelates(TEST_ROOT, 'T-S1');
+    expect(relations.success).toBe(true);
+    const members = relations.data?.relations?.filter((r) => r.type === 'groups') ?? [];
+    expect(members.map((m) => m.taskId)).toContain('T-E1');
+  });
+
+  it('rejects a saga-labeled candidate with E_SAGA_INVARIANT_VIOLATION_I7', async () => {
+    const result = await sagaAdd(TEST_ROOT, { sagaId: 'T-S1', epicId: 'T-S2' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error?.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+    expect(result.error?.message).toContain('T-S2');
+    expect(result.error?.message).toContain('saga');
+    // Diag payload preserved through engineError.details.
+    const diag = result.error?.details as
+      | { sagaId?: string; offendingId?: string; invariant?: string }
+      | undefined;
+    expect(diag?.sagaId).toBe('T-S1');
+    expect(diag?.offendingId).toBe('T-S2');
+    expect(diag?.invariant).toBe('I7');
+    // Fix hint mentions the detach verb (T10118 wire-up).
+    expect(result.error?.fix ?? '').toContain('detach');
+  });
+
+  it('does NOT persist a groups relation when I7 rejects the candidate', async () => {
+    const before = await taskRelates(TEST_ROOT, 'T-S1');
+    const beforeMembers =
+      before.data?.relations?.filter((r) => r.type === 'groups').map((m) => m.taskId) ?? [];
+
+    const result = await sagaAdd(TEST_ROOT, { sagaId: 'T-S1', epicId: 'T-S2' });
+    expect(result.success).toBe(false);
+
+    const after = await taskRelates(TEST_ROOT, 'T-S1');
+    const afterMembers =
+      after.data?.relations?.filter((r) => r.type === 'groups').map((m) => m.taskId) ?? [];
+    expect(afterMembers).toEqual(beforeMembers);
+    expect(afterMembers).not.toContain('T-S2');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // T9831-nested-in-T9799 regression fixture
+  // Historical: T9831 (SG-ARCH-SOLID) carries label='saga' and could
+  // theoretically have been linked into T9799 (skill-maintenance saga). I7
+  // forbids this. The reproduction uses real-world IDs so the failure
+  // message matches what an operator would see.
+  // ────────────────────────────────────────────────────────────────────────
+  it('regression: rejects linking T9831 (saga) as a member of T9799 (saga)', async () => {
+    // Override the fixture with real-world IDs.
+    const realRoot = await mkdtemp(join(tmpdir(), 'cleo-saga-add-t9831-test-'));
+    try {
+      mkdirSync(join(realRoot, '.cleo'), { recursive: true });
+      mkdirSync(join(realRoot, '.git'), { recursive: true });
+      await getDb(realRoot);
+      const ts = '2026-05-22T00:00:00Z';
+      const rows = [
+        {
+          id: 'T9799',
+          title: 'Saga T9799 (skill maintenance)',
+          description: 'Top-level saga',
+          type: 'epic' as const,
+          status: 'active' as const,
+          priority: 'high' as const,
+          labels: ['saga'],
+          createdAt: ts,
+          updatedAt: null,
+        },
+        {
+          id: 'T9831',
+          title: 'Saga T9831 (SG-ARCH-SOLID)',
+          description: 'Top-level saga that must NOT nest under T9799',
+          type: 'epic' as const,
+          status: 'active' as const,
+          priority: 'high' as const,
+          labels: ['saga'],
+          createdAt: ts,
+          updatedAt: null,
+        },
+      ];
+      for (const row of rows) {
+        await createTask(row as Parameters<typeof createTask>[0], realRoot);
+      }
+
+      const result = await sagaAdd(realRoot, { sagaId: 'T9799', epicId: 'T9831' });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error?.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+      expect(result.error?.message).toContain('T9831');
+      const diag = result.error?.details as { sagaId?: string; offendingId?: string } | undefined;
+      expect(diag?.sagaId).toBe('T9799');
+      expect(diag?.offendingId).toBe('T9831');
+    } finally {
+      try {
+        const { closeAllDatabases } = await import('@cleocode/core/internal');
+        await closeAllDatabases();
+      } catch {
+        // ignore cleanup errors
+      }
+      await rm(realRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/sagas/__tests__/detach.test.ts
+++ b/packages/core/src/sagas/__tests__/detach.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for {@link detachSagaMember} — the T10118 repair verb that removes a
+ * single `task_relations.type='groups'` row between a saga and a member.
+ *
+ * The function is idempotent — re-running against an already-removed
+ * relation succeeds with `removed: false` — and always appends a JSON line
+ * to `.cleo/audit/saga-detach.jsonl`.
+ *
+ * @task T10118
+ * @saga T10113
+ * @epic T10209
+ * @see ADR-073-above-epic-naming.md §1.2 invariant I7
+ */
+
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { addRelation, createTask, getDb, taskRelates } from '@cleocode/core/internal';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { detachSagaMember, SAGA_DETACH_AUDIT_FILE, SAGA_DETACH_DEFAULT_REASON } from '../detach.js';
+
+let TEST_ROOT: string;
+
+/**
+ * Seed one saga (T-S) + two epics (T-E1, T-E2), then link them via
+ * `task_relations.type='groups'`.
+ */
+async function seedFixture(testRoot: string): Promise<void> {
+  mkdirSync(join(testRoot, '.cleo'), { recursive: true });
+  mkdirSync(join(testRoot, '.git'), { recursive: true });
+  await getDb(testRoot);
+
+  const ts = '2026-05-22T00:00:00Z';
+  const rows = [
+    {
+      id: 'T-S',
+      title: 'Saga',
+      description: 'Saga with two members',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'high' as const,
+      labels: ['saga'],
+      createdAt: ts,
+      updatedAt: null,
+    },
+    {
+      id: 'T-E1',
+      title: 'Epic One',
+      description: 'Member one',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'medium' as const,
+      createdAt: ts,
+      updatedAt: null,
+    },
+    {
+      id: 'T-E2',
+      title: 'Epic Two',
+      description: 'Member two',
+      type: 'epic' as const,
+      status: 'active' as const,
+      priority: 'medium' as const,
+      createdAt: ts,
+      updatedAt: null,
+    },
+  ];
+  for (const row of rows) {
+    await createTask(row as Parameters<typeof createTask>[0], testRoot);
+  }
+  await addRelation('T-S', 'T-E1', 'groups', testRoot);
+  await addRelation('T-S', 'T-E2', 'groups', testRoot);
+}
+
+interface SagaDetachAuditLine {
+  timestamp: string;
+  sagaId: string;
+  memberId: string;
+  removed: boolean;
+  reason: string;
+}
+
+/** Read every JSON line currently present in the saga-detach audit log. */
+function readAuditLines(testRoot: string): SagaDetachAuditLine[] {
+  const file = join(testRoot, SAGA_DETACH_AUDIT_FILE);
+  if (!existsSync(file)) {
+    return [];
+  }
+  return readFileSync(file, 'utf-8')
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as SagaDetachAuditLine);
+}
+
+beforeEach(async () => {
+  TEST_ROOT = await mkdtemp(join(tmpdir(), 'cleo-saga-detach-test-'));
+  await seedFixture(TEST_ROOT);
+});
+
+afterEach(async () => {
+  try {
+    const { closeAllDatabases } = await import('@cleocode/core/internal');
+    await closeAllDatabases();
+  } catch {
+    // ignore cleanup errors
+  }
+  await rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('detachSagaMember — relation removal + audit log', () => {
+  it('removes a single groups relation on first call (removed: true)', async () => {
+    const before = await taskRelates(TEST_ROOT, 'T-S');
+    const beforeMembers =
+      before.data?.relations?.filter((r) => r.type === 'groups').map((m) => m.taskId) ?? [];
+    expect(beforeMembers.sort()).toEqual(['T-E1', 'T-E2']);
+
+    const result = await detachSagaMember(TEST_ROOT, { sagaId: 'T-S', memberId: 'T-E1' });
+    expect(result.success, JSON.stringify(result)).toBe(true);
+    if (!result.success) return;
+    expect(result.data?.removed).toBe(true);
+    expect(result.data?.sagaId).toBe('T-S');
+    expect(result.data?.memberId).toBe('T-E1');
+    expect(result.data?.reason).toBe(SAGA_DETACH_DEFAULT_REASON);
+    expect(typeof result.data?.timestamp).toBe('string');
+
+    const after = await taskRelates(TEST_ROOT, 'T-S');
+    const afterMembers =
+      after.data?.relations?.filter((r) => r.type === 'groups').map((m) => m.taskId) ?? [];
+    expect(afterMembers).toEqual(['T-E2']);
+  });
+
+  it('is idempotent — re-running returns removed=false without error', async () => {
+    const first = await detachSagaMember(TEST_ROOT, { sagaId: 'T-S', memberId: 'T-E1' });
+    expect(first.success).toBe(true);
+    if (first.success) expect(first.data?.removed).toBe(true);
+
+    const second = await detachSagaMember(TEST_ROOT, { sagaId: 'T-S', memberId: 'T-E1' });
+    expect(second.success, JSON.stringify(second)).toBe(true);
+    if (!second.success) return;
+    expect(second.data?.removed).toBe(false);
+    expect(second.data?.sagaId).toBe('T-S');
+    expect(second.data?.memberId).toBe('T-E1');
+  });
+
+  it('appends a JSON-line entry to .cleo/audit/saga-detach.jsonl per invocation', async () => {
+    await detachSagaMember(TEST_ROOT, { sagaId: 'T-S', memberId: 'T-E1' });
+    await detachSagaMember(TEST_ROOT, { sagaId: 'T-S', memberId: 'T-E1' });
+
+    const lines = readAuditLines(TEST_ROOT);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]?.sagaId).toBe('T-S');
+    expect(lines[0]?.memberId).toBe('T-E1');
+    expect(lines[0]?.removed).toBe(true);
+    expect(lines[0]?.reason).toBe(SAGA_DETACH_DEFAULT_REASON);
+    expect(lines[1]?.removed).toBe(false);
+  });
+
+  it('records a caller-supplied reason in the audit log entry', async () => {
+    const customReason = 'manual repair for T9831/T9799 nesting';
+    const result = await detachSagaMember(TEST_ROOT, {
+      sagaId: 'T-S',
+      memberId: 'T-E2',
+      reason: customReason,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data?.reason).toBe(customReason);
+
+    const lines = readAuditLines(TEST_ROOT);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]?.reason).toBe(customReason);
+  });
+
+  it('rejects missing sagaId or memberId with E_INVALID_INPUT', async () => {
+    const a = await detachSagaMember(TEST_ROOT, { sagaId: '', memberId: 'T-E1' });
+    expect(a.success).toBe(false);
+    if (!a.success) expect(a.error?.code).toBe('E_INVALID_INPUT');
+
+    const b = await detachSagaMember(TEST_ROOT, { sagaId: 'T-S', memberId: '' });
+    expect(b.success).toBe(false);
+    if (!b.success) expect(b.error?.code).toBe('E_INVALID_INPUT');
+  });
+});

--- a/packages/core/src/sagas/add.ts
+++ b/packages/core/src/sagas/add.ts
@@ -4,6 +4,8 @@
  * Validates that:
  *   - the saga task exists and carries `label='saga'`
  *   - the epic task exists and has `type='epic'`
+ *   - the epic candidate is NOT itself a saga (ADR-073 §1.2 invariant I7 —
+ *     wired in T10118 via `assertSagaInvariantI7`)
  *
  * Returns an EngineResult — the dispatch layer wraps it in a LAFS envelope.
  *
@@ -12,7 +14,9 @@
  *
  * @task T10124
  * @task T10120
+ * @task T10118 — wire I7 enforcement gate before persisting
  * @epic T10208
+ * @epic T10209 — E-SAGA-ENFORCEMENT
  * @see ADR-073-above-epic-naming.md §1
  */
 
@@ -20,6 +24,11 @@ import { type EngineResult, engineError, engineSuccess } from '../engine-result.
 import { taskShow } from '../tasks/show.js';
 import { taskRelatesAdd } from '../tasks/task-ops.js';
 import { SAGA_GROUPS_RELATION, SAGA_LABEL } from './constants.js';
+import {
+  assertSagaInvariantI7,
+  isSagaInvariantViolationError,
+  type SagaInvariantViolationError,
+} from './enforcement.js';
 
 /** Input parameters for {@link sagaAdd}. */
 export interface SagaAddParams {
@@ -74,6 +83,27 @@ export async function sagaAdd(
       'E_INVALID_INPUT',
       `Task ${epicId} has type='${String(epicType)}', expected type='epic'`,
     );
+  }
+
+  // ADR-073 §1.2 invariant I7 — no nested sagas. The candidate epic MUST NOT
+  // itself carry label='saga'. Wired in T10118 after T10115 shipped the
+  // pure-function guard. The structured `SagaInvariantViolationError` thrown
+  // here is converted into a typed `engineError` so the dispatch layer can
+  // surface a LAFS envelope with the stable I7 code + diag payload.
+  const candidateLabels: readonly string[] = epicResult.data.task.labels ?? [];
+  try {
+    assertSagaInvariantI7(epicId, candidateLabels, sagaId);
+  } catch (err: unknown) {
+    if (isSagaInvariantViolationError(err)) {
+      const violation = err as SagaInvariantViolationError;
+      return engineError(violation.code, violation.message, {
+        details: violation.diag,
+        fix:
+          `Use 'cleo saga detach ${sagaId} ${epicId}' if this row was previously linked, ` +
+          'or relabel the candidate so it no longer carries the saga label.',
+      });
+    }
+    throw err;
   }
 
   const relResult = await taskRelatesAdd(projectRoot, sagaId, epicId, SAGA_GROUPS_RELATION);

--- a/packages/core/src/sagas/detach.ts
+++ b/packages/core/src/sagas/detach.ts
@@ -1,0 +1,153 @@
+/**
+ * saga.detach — remove a `task_relations.type='groups'` edge between a Saga
+ * and a member.
+ *
+ * Idempotent: re-running against a relation that no longer exists succeeds
+ * with `removed: false`. Every invocation (whether or not it removed a row)
+ * appends a single JSON line to `.cleo/audit/saga-detach.jsonl` so the
+ * repair history is auditable — mirroring the append-only pattern used by
+ * `appendContractViolation` in `audit.ts`.
+ *
+ * Primary use case: repair ADR-073 §1.2 invariant I7 violations (a saga
+ * accidentally linked as a member of another saga — historical
+ * T9831-nested-in-T9799 scenario). Dogfooded in the T10118 ship PR.
+ *
+ * @task T10118
+ * @saga T10113 — SG-SAGA-FIRST-CLASS
+ * @epic T10209 — E-SAGA-ENFORCEMENT
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
+import { getLogger } from '../logger.js';
+import { taskRelates, taskRelatesRemove } from '../tasks/task-ops.js';
+import { SAGA_GROUPS_RELATION } from './constants.js';
+
+const log = getLogger('sagas:detach');
+
+/** Relative path within project root for the saga-detach audit log. */
+export const SAGA_DETACH_AUDIT_FILE = '.cleo/audit/saga-detach.jsonl';
+
+/** Default human-readable reason recorded when the caller does not supply one. */
+export const SAGA_DETACH_DEFAULT_REASON = 'ADR-073 I7 violation repair';
+
+/** Input parameters for {@link detachSagaMember}. */
+export interface DetachSagaMemberParams {
+  /** Saga task ID (the `from` side of the groups relation). */
+  sagaId: string;
+  /** Member task ID (the `to` side of the groups relation). */
+  memberId: string;
+  /** Optional human-readable reason recorded in the audit entry. */
+  reason?: string;
+}
+
+/** Result payload for {@link detachSagaMember}. */
+export interface DetachResult {
+  sagaId: string;
+  memberId: string;
+  /** True when an actual row was removed; false on idempotent no-op. */
+  removed: boolean;
+  /** Reason recorded in the audit log entry. */
+  reason: string;
+  /** ISO 8601 timestamp recorded in the audit log entry. */
+  timestamp: string;
+}
+
+/** Single JSON-line entry written to `.cleo/audit/saga-detach.jsonl`. */
+interface SagaDetachAuditEntry {
+  timestamp: string;
+  sagaId: string;
+  memberId: string;
+  removed: boolean;
+  reason: string;
+}
+
+/**
+ * Append a single JSON-line entry to the saga-detach audit log. Errors are
+ * swallowed: audit writes MUST NOT block the operation.
+ */
+function appendSagaDetachAudit(projectRoot: string, entry: SagaDetachAuditEntry): void {
+  try {
+    const filePath = join(projectRoot, SAGA_DETACH_AUDIT_FILE);
+    mkdirSync(dirname(filePath), { recursive: true });
+    appendFileSync(filePath, `${JSON.stringify(entry)}\n`, { encoding: 'utf-8' });
+  } catch (err: unknown) {
+    log.warn({ err }, 'Failed to append saga-detach audit entry — continuing');
+  }
+}
+
+/**
+ * Remove a single `task_relations.type='groups'` row between a Saga and a
+ * member. Idempotent — if the relation does not exist the call still
+ * succeeds with `removed: false`. Always appends an entry to
+ * `.cleo/audit/saga-detach.jsonl`.
+ *
+ * Used to repair an ADR-073 §1.2 invariant I7 violation (a nested-saga
+ * relation that bypassed `sagaAdd`'s pre-T10118 add path).
+ *
+ * @param projectRoot - Absolute path to the project root.
+ * @param params - sagaId + memberId of the groups relation to remove.
+ * @returns EngineResult with `{ sagaId, memberId, removed, reason, timestamp }`.
+ *
+ * @example
+ * ```typescript
+ * const result = await detachSagaMember('/repo', {
+ *   sagaId: 'T9799',
+ *   memberId: 'T9831',
+ *   reason: 'ADR-073 I7 violation repair',
+ * });
+ * // result.data.removed === true on first call, false on subsequent calls.
+ * ```
+ */
+export async function detachSagaMember(
+  projectRoot: string,
+  params: DetachSagaMemberParams,
+): Promise<EngineResult<DetachResult>> {
+  const sagaId = params.sagaId;
+  const memberId = params.memberId;
+  if (!sagaId || !memberId) {
+    return engineError('E_INVALID_INPUT', 'sagaId and memberId are required');
+  }
+  const reason = params.reason ?? SAGA_DETACH_DEFAULT_REASON;
+  const timestamp = new Date().toISOString();
+
+  // Detect existing-relation state BEFORE deletion. `taskRelatesRemove`
+  // returns `removed: true` whether or not a row actually existed (the
+  // underlying drizzle DELETE is a no-op when 0 rows match) — so we
+  // inspect the saga's current relations to report idempotency accurately.
+  const relationsBefore = await taskRelates(projectRoot, sagaId);
+  if (!relationsBefore.success) {
+    return engineError(
+      'E_GENERAL',
+      relationsBefore.error?.message ?? 'Failed to read saga relations before detach',
+    );
+  }
+  const existedBefore =
+    relationsBefore.data?.relations?.some(
+      (r) => r.type === SAGA_GROUPS_RELATION && r.taskId === memberId,
+    ) ?? false;
+
+  const relResult = await taskRelatesRemove(projectRoot, sagaId, memberId, SAGA_GROUPS_RELATION);
+  if (!relResult.success) {
+    // Persist a failure-shaped audit entry so the attempted repair is still
+    // recoverable from the journal even on the error path.
+    appendSagaDetachAudit(projectRoot, {
+      timestamp,
+      sagaId,
+      memberId,
+      removed: false,
+      reason: `${reason} (failed: ${relResult.error?.message ?? 'unknown error'})`,
+    });
+    return engineError(
+      'E_GENERAL',
+      relResult.error?.message ?? 'Failed to remove saga member relation',
+    );
+  }
+
+  // `removed` reflects ACTUAL state change, not just success.
+  const removed = existedBefore;
+  appendSagaDetachAudit(projectRoot, { timestamp, sagaId, memberId, removed, reason });
+  return engineSuccess({ sagaId, memberId, removed, reason, timestamp });
+}

--- a/packages/core/src/sagas/index.ts
+++ b/packages/core/src/sagas/index.ts
@@ -16,6 +16,13 @@ export { type SagaAddParams, type SagaAddResult, sagaAdd } from './add.js';
 export { LIST_BINDING_SAGA_GROUPS, SAGA_GROUPS_RELATION, SAGA_LABEL } from './constants.js';
 export { type SagaCreateParams, sagaCreate } from './create.js';
 export {
+  type DetachResult,
+  type DetachSagaMemberParams,
+  detachSagaMember,
+  SAGA_DETACH_AUDIT_FILE,
+  SAGA_DETACH_DEFAULT_REASON,
+} from './detach.js';
+export {
   assertSagaInvariantI3,
   assertSagaInvariantI5,
   assertSagaInvariantI7,


### PR DESCRIPTION
## Summary

Wires the ADR-073 §1.2 I7 invariant gate into `sagaAdd` and adds an idempotent
`cleo saga detach <sagaId> <memberId>` repair verb. Detaches `T9831` from
`T9799` in this PR's dogfood step — closes the actual nested-saga violation
that existed in production data.

### What changed

- **`sagaAdd`** now calls `assertSagaInvariantI7(candidateId, candidateLabels, sagaId)`
  before persisting the `task_relations.type='groups'` row. Saga-labeled
  candidates are rejected with `E_SAGA_INVARIANT_VIOLATION_I7`; the typed
  `SagaInvariantViolationError` is converted to a structured `engineError` so
  the LAFS envelope carries `code` + `details.{sagaId,offendingId,invariant}`
  + a `fix` hint pointing at the new detach verb.

- **`cleo saga detach <sagaId> <memberId> [--reason …]`** — new mutate op
  `tasks.saga.detach`. Idempotent (re-runs return `removed:false`). Every
  invocation appends a JSON-line entry to `.cleo/audit/saga-detach.jsonl`.

- **Dogfood**: T9831 (`SG-ARCH-SOLID`) detached from T9799 (skill-maintenance
  saga). T9799 member count 9 → 8. CLI re-test confirms `cleo saga add T9799
  T9831` now returns `E_SAGA_INVARIANT_VIOLATION_I7` instead of silently
  writing the nesting.

## Test plan

- [x] `pnpm biome check .` — clean (only pre-existing warnings in untouched files)
- [x] `pnpm run build` — workspace build green
- [x] `pnpm run typecheck` — `tsc -b` exit 0
- [x] `pnpm exec vitest run packages/core/src/sagas/` — 25 tests pass
- [x] `pnpm exec vitest run packages/contracts/src/__tests__/` — 284 tests pass
- [x] Dogfood: T9831 detached from T9799 in live worktree (members 9 → 8)
- [x] Idempotency: re-run returns `removed:false`, audit log shows both entries
- [x] I7 gate: `cleo saga add T9799 T9831` returns `E_SAGA_INVARIANT_VIOLATION_I7`
- [x] T9831-nested-in-T9799 regression fixture in `add.test.ts`

Closes T10118; Saga T10113; Epic T10209.