### PR TITLE
feat(T10221): extract lifecycle SDK primitives (cache+remove_dir+sync+diff)

### DIFF
--- a/.changeset/t10221-extract-lifecycle.md
+++ b/.changeset/t10221-extract-lifecycle.md
@@ -1,0 +1,48 @@
+---
+"@cleocode/cleo": patch
+---
+
+feat(T10221): extract lifecycle SDK primitives into worktrunk-core (SAGA T10176, T10218)
+
+Pure-function refactor of cache + remove_dir + sync + diff per ADR-078 SoC contract.
+Builds on T10219's `Repo` trait + `ProcessRepo` substitute. Four new top-level
+modules under `crates/worktrunk-core/src/`:
+
+- `cache.rs` — on-disk JSON cache primitives (read/write/sweep/clear). Donor
+  dependency on `Repository::wt_dir()` replaced with explicit `&Path` argument
+  at the SDK boundary. Logging dependency (`log` crate) dropped — the SDK no
+  longer has an opinion on diagnostic frameworks.
+- `remove_dir.rs` — recursive parallel directory removal with optional
+  progress reporting. Uses the existing SDK `Progress` type. `LazyLock` pool
+  initializer now degrades gracefully (4-thread → 1-thread → panic) matching
+  the `copy.rs` policy.
+- `sync.rs` — counting semaphore (`Semaphore` + `SemaphoreGuard`). Pure
+  std-only; `Mutex` poison recovery via `PoisonError::into_inner` so SDK
+  consumers do not panic on contention races.
+- `diff.rs` — pure git-diff parsers (`LineDiff`, `DiffStats`,
+  `parse_numstat_line`, `parse_shortstat`). The donor's `cformat!`-styled
+  `format_summary` was intentionally dropped — CLI consumers compose color
+  themselves from the raw struct fields. Inline ANSI-strip implemented
+  locally so the `ansi_str` crate stays out of the SDK dep graph.
+
+Opportunistic Repo trait promotion: `Repo::diff_stats_summary` flipped from
+`unimplemented_in_sdk` to a real `ProcessRepo` impl. Integration test
+demonstrates the pipe `Repo::diff_stats_summary` → `DiffStats::from_shortstat`
+end-to-end.
+
+CLI-binary-only modules documented: a `# CLI-binary-only modules` section
+in `lib.rs` now explains why `worktrunk::priority` and
+`worktrunk::signal_forwarder` are intentionally NOT vendored — both are
+process-lifecycle side effects that mutate the host's signal disposition /
+OS scheduling priority and would silently break napi consumers if invoked
+from a library.
+
+Test count: 104 unit + 6 integration + 2 doctest = 112 passing
+(was 69 in T10219; +35 new tests for the four lifecycle modules + the
+`diff_stats_summary` promotion).
+
+Cargo:
+- `cargo build -p worktrunk-core --all-features` — green
+- `cargo test -p worktrunk-core --all-features` — 112 / 112 pass
+- `cargo clippy -p worktrunk-core --all-features --no-deps -- -D warnings` — zero
+- `pnpm biome check --write .` — zero new findings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +415,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +451,16 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -627,6 +665,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1729,6 +1777,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2085,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/worktrunk-core/src/cache.rs
+++ b/crates/worktrunk-core/src/cache.rs
@@ -22,7 +22,7 @@
 //!
 //! Writes use a plain [`fs::write`], not temp-file-plus-rename. A crash in
 //! the middle of a write produces a truncated file at the expected path,
-//! which [`read_json`] rejects as corrupt JSON — indistinguishable from a
+//! which [`read_json_at`] rejects as corrupt JSON — indistinguishable from a
 //! cache miss from the caller's perspective. Two concurrent writers for the
 //! same key produce the same value for content-addressed caches (benign)
 //! and the last writer wins for TTL-based ones (benign — the next read
@@ -30,10 +30,10 @@
 //!
 //! # Error policy
 //!
-//! - [`read_json`] returns `None` on any failure (missing file, I/O error,
+//! - [`read_json_at`] returns `None` on any failure (missing file, I/O error,
 //!   corrupt JSON) — callers treat all three as a cache miss. Corrupt JSON
 //!   is logged at debug.
-//! - [`write_json`] degrades silently. Callers never observe cache write
+//! - [`write_json_at`] degrades silently. Callers never observe cache write
 //!   failures because a failed write just means the next access re-computes.
 //! - [`clear_one`] and [`clear_json_files`] propagate non-`NotFound` I/O
 //!   errors so cache-clear CLI commands can report truthfully when they
@@ -62,7 +62,7 @@ pub fn cache_dir_at(wt_dir: &Path, kind: &str) -> PathBuf {
 ///
 /// Returns `None` on any failure. Corrupt JSON is logged at debug — a torn
 /// write is indistinguishable from a cache miss at this layer.
-pub fn read_json<T: DeserializeOwned>(path: &Path) -> Option<T> {
+pub fn read_json_at<T: DeserializeOwned>(path: &Path) -> Option<T> {
     let json = fs::read_to_string(path).ok()?;
     match serde_json::from_str::<T>(&json) {
         Ok(value) => Some(value),
@@ -83,7 +83,7 @@ pub fn read_json<T: DeserializeOwned>(path: &Path) -> Option<T> {
 /// Degrades silently on any failure — parent dir creation, serialization,
 /// or the write itself. A failed write just means the next access
 /// re-computes; callers must never observe the error.
-pub fn write_json<T: Serialize>(path: &Path, value: &T) {
+pub fn write_json_at<T: Serialize>(path: &Path, value: &T) {
     if let Some(parent) = path.parent()
         && let Err(e) = fs::create_dir_all(parent)
     {
@@ -118,13 +118,13 @@ pub fn write_json<T: Serialize>(path: &Path, value: &T) {
 /// layout. Returns `None` on any failure (missing file, I/O error, corrupt
 /// JSON).
 pub fn read<T: DeserializeOwned>(wt_dir: &Path, kind: &str, key: &str) -> Option<T> {
-    read_json(&cache_dir_at(wt_dir, kind).join(key))
+    read_json_at(&cache_dir_at(wt_dir, kind).join(key))
 }
 
 /// Write a JSON entry at `<wt_dir>/cache/<kind>/<key>`, then sweep the kind
 /// directory so it holds at most `max_entries` top-level `.json` files.
 ///
-/// Combines [`write_json`] with [`sweep_lru`] — the "write + bound" pattern
+/// Combines [`write_json_at`] with [`sweep_lru`] — the "write + bound" pattern
 /// every `sha_cache` `put_*` function repeats. Degrades silently on write
 /// failure; the sweep runs regardless so a torn write still triggers the
 /// size bound check.
@@ -136,7 +136,7 @@ pub fn write_with_lru<T: Serialize>(
     max_entries: usize,
 ) {
     let dir = cache_dir_at(wt_dir, kind);
-    write_json(&dir.join(key), value);
+    write_json_at(&dir.join(key), value);
     sweep_lru(&dir, max_entries);
 }
 
@@ -291,11 +291,11 @@ mod tests {
         let path = tmp.path().join("sub/entry.json");
 
         // Missing file is a miss.
-        assert!(read_json::<V>(&path).is_none());
+        assert!(read_json_at::<V>(&path).is_none());
 
         // Write creates parent dirs and round-trips.
-        write_json(&path, &V { x: 42 });
-        assert_eq!(read_json::<V>(&path), Some(V { x: 42 }));
+        write_json_at(&path, &V { x: 42 });
+        assert_eq!(read_json_at::<V>(&path), Some(V { x: 42 }));
     }
 
     #[test]
@@ -303,14 +303,14 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("bad.json");
         fs::write(&path, "not json {{").unwrap();
-        assert!(read_json::<V>(&path).is_none());
+        assert!(read_json_at::<V>(&path).is_none());
     }
 
     #[test]
     fn read_at_kind_key_resolves_subpath() {
         let tmp = TempDir::new().unwrap();
         let wt = tmp.path();
-        write_json(&cache_dir_at(wt, "k").join("a"), &V { x: 7 });
+        write_json_at(&cache_dir_at(wt, "k").join("a"), &V { x: 7 });
         assert_eq!(read::<V>(wt, "k", "a"), Some(V { x: 7 }));
         assert!(read::<V>(wt, "k", "missing").is_none());
     }

--- a/crates/worktrunk-core/src/cache.rs
+++ b/crates/worktrunk-core/src/cache.rs
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 kryptobaseddev
+//
+// This file is part of crates/worktrunk-core in the CleoCode monorepo.
+
+//! Shared primitives for on-disk JSON caches under `<wt-dir>/cache/`.
+//!
+//! This module is the pure-data extraction of worktrunk's `src/cache.rs`
+//! (T10221, ADR-078 separation-of-concerns contract). It owns only the
+//! filesystem mechanics —
+//! read/write/sweep/clear — so callers (`sha_cache`, `ci_status::cache`,
+//! `summary`, …) can keep their own layout and freshness rules without
+//! re-implementing the on-disk I/O three times.
+//!
+//! The SDK accepts the cache root directory as a plain `&Path` argument
+//! rather than depending on worktrunk's `Repository::wt_dir()`. CLI consumers
+//! that previously called `cache_dir(&repo, "ci-status")` now call
+//! [`cache_dir_at`] with `repo.wt_dir()` resolved at the boundary, keeping
+//! `Repository` out of the SDK.
+//!
+//! # Torn-write semantics
+//!
+//! Writes use a plain [`fs::write`], not temp-file-plus-rename. A crash in
+//! the middle of a write produces a truncated file at the expected path,
+//! which [`read_json`] rejects as corrupt JSON — indistinguishable from a
+//! cache miss from the caller's perspective. Two concurrent writers for the
+//! same key produce the same value for content-addressed caches (benign)
+//! and the last writer wins for TTL-based ones (benign — the next read
+//! re-fetches if stale). Neither case justifies the rename dance.
+//!
+//! # Error policy
+//!
+//! - [`read_json`] returns `None` on any failure (missing file, I/O error,
+//!   corrupt JSON) — callers treat all three as a cache miss. Corrupt JSON
+//!   is logged at debug.
+//! - [`write_json`] degrades silently. Callers never observe cache write
+//!   failures because a failed write just means the next access re-computes.
+//! - [`clear_one`] and [`clear_json_files`] propagate non-`NotFound` I/O
+//!   errors so cache-clear CLI commands can report truthfully when they
+//!   can't delete a file (e.g. permission denied). `NotFound` is counted as
+//!   "already gone" so concurrent clearers don't fight each other.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::{Serialize, de::DeserializeOwned};
+
+/// Compose a cache subdirectory path under a worktree's cache root.
+///
+/// Returns `<wt_dir>/cache/<kind>/`. The `kind` is the subdirectory name
+/// (e.g. `"ci-status"`, `"summary"`, `"is-ancestor"`).
+///
+/// CLI consumers resolve `wt_dir` from `Repository::wt_dir()` at the SDK
+/// boundary and pass the resulting path here.
+#[must_use]
+pub fn cache_dir_at(wt_dir: &Path, kind: &str) -> PathBuf {
+    wt_dir.join("cache").join(kind)
+}
+
+/// Read and deserialize a JSON cache entry.
+///
+/// Returns `None` on any failure. Corrupt JSON is logged at debug — a torn
+/// write is indistinguishable from a cache miss at this layer.
+pub fn read_json<T: DeserializeOwned>(path: &Path) -> Option<T> {
+    let json = fs::read_to_string(path).ok()?;
+    match serde_json::from_str::<T>(&json) {
+        Ok(value) => Some(value),
+        Err(e) => {
+            log_debug(&format_args!(
+                "cache: corrupt entry at {}: {}",
+                path.display(),
+                e
+            ));
+            None
+        }
+    }
+}
+
+/// Serialize and write a JSON cache entry, creating parent directories as
+/// needed.
+///
+/// Degrades silently on any failure — parent dir creation, serialization,
+/// or the write itself. A failed write just means the next access
+/// re-computes; callers must never observe the error.
+pub fn write_json<T: Serialize>(path: &Path, value: &T) {
+    if let Some(parent) = path.parent()
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        log_debug(&format_args!(
+            "cache: failed to create dir {}: {}",
+            parent.display(),
+            e
+        ));
+        return;
+    }
+
+    let Ok(json) = serde_json::to_string(value) else {
+        log_debug(&format_args!(
+            "cache: failed to serialize entry for {}",
+            path.display()
+        ));
+        return;
+    };
+
+    if let Err(e) = fs::write(path, &json) {
+        log_debug(&format_args!(
+            "cache: failed to write {}: {}",
+            path.display(),
+            e
+        ));
+    }
+}
+
+/// Read a JSON entry at `<wt_dir>/cache/<kind>/<key>`.
+///
+/// Paired with [`write_with_lru`] for the flat-dir "kind + key filename"
+/// layout. Returns `None` on any failure (missing file, I/O error, corrupt
+/// JSON).
+pub fn read<T: DeserializeOwned>(wt_dir: &Path, kind: &str, key: &str) -> Option<T> {
+    read_json(&cache_dir_at(wt_dir, kind).join(key))
+}
+
+/// Write a JSON entry at `<wt_dir>/cache/<kind>/<key>`, then sweep the kind
+/// directory so it holds at most `max_entries` top-level `.json` files.
+///
+/// Combines [`write_json`] with [`sweep_lru`] — the "write + bound" pattern
+/// every `sha_cache` `put_*` function repeats. Degrades silently on write
+/// failure; the sweep runs regardless so a torn write still triggers the
+/// size bound check.
+pub fn write_with_lru<T: Serialize>(
+    wt_dir: &Path,
+    kind: &str,
+    key: &str,
+    value: &T,
+    max_entries: usize,
+) {
+    let dir = cache_dir_at(wt_dir, kind);
+    write_json(&dir.join(key), value);
+    sweep_lru(&dir, max_entries);
+}
+
+/// Enforce a size bound on `dir`. If it holds more than `max` top-level
+/// `.json` entries, delete the oldest-mtime files until the count is back
+/// at `max`.
+///
+/// The fast path is a single directory listing and `count_json_files` — no
+/// per-file `stat` when the cache is under the bound. Only falls through
+/// to stat+sort when trimming is actually needed.
+///
+/// Best-effort: I/O errors during the sweep are logged at debug and ignored
+/// because the cache is always an optimization over re-computation.
+pub fn sweep_lru(dir: &Path, max: usize) {
+    if count_json_files(dir) <= max {
+        return;
+    }
+
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let json_entries: Vec<_> = entries
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.file_name().to_str().is_some_and(|s| s.ends_with(".json")))
+        .collect();
+    if json_entries.len() <= max {
+        return;
+    }
+
+    let mut with_mtime: Vec<(PathBuf, SystemTime)> = json_entries
+        .into_iter()
+        .filter_map(|e| {
+            let mtime = e.metadata().ok()?.modified().ok()?;
+            Some((e.path(), mtime))
+        })
+        .collect();
+    with_mtime.sort_by_key(|(_, mtime)| *mtime);
+
+    let excess = with_mtime.len().saturating_sub(max);
+    for (path, _) in with_mtime.iter().take(excess) {
+        let _ = fs::remove_file(path);
+    }
+    log_debug(&format_args!(
+        "cache: swept {} entries from {}",
+        excess,
+        dir.display()
+    ));
+}
+
+/// Remove a single cache entry.
+///
+/// Returns `Ok(true)` if a file was removed, `Ok(false)` if it was already
+/// gone (a concurrent clearer, or the caller being paranoid). Propagates
+/// other I/O errors with the path attached, so cache-clear UI can report
+/// "Cleared"/"No cache" truthfully instead of swallowing a permission-denied
+/// failure.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error (with path context) for any failure
+/// other than `NotFound`.
+pub fn clear_one(path: &Path) -> anyhow::Result<bool> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => {
+            Err(anyhow::Error::new(e).context(format!("failed to remove {}", path.display())))
+        }
+    }
+}
+
+/// Remove every top-level `.json` file in `dir`, returning the count
+/// removed.
+///
+/// Missing directory is `Ok(0)` — the caller's cache is already empty.
+/// Concurrent removal of individual entries is counted as "already gone".
+/// Non-`.json` siblings (e.g. leftover `.json.tmp` from old code, or a
+/// stray `README`) are left in place.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error (with path context) when `read_dir`
+/// fails for a reason other than `NotFound`, or when removing an individual
+/// `.json` entry fails for a reason other than `NotFound`.
+pub fn clear_json_files(dir: &Path) -> anyhow::Result<usize> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => {
+            return Err(anyhow::Error::new(e).context(format!("failed to read {}", dir.display())));
+        }
+    };
+
+    let mut cleared = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|ext| ext != "json") {
+            continue;
+        }
+        if clear_one(&path)? {
+            cleared += 1;
+        }
+    }
+    Ok(cleared)
+}
+
+/// Count top-level `.json` files in `dir`, returning `0` when the directory
+/// is missing.
+#[must_use]
+pub fn count_json_files(dir: &Path) -> usize {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+        .count()
+}
+
+/// Logging shim — `log` crate optional in the SDK, so emit via `eprintln!`
+/// behind a debug feature in the future. For now we silently swallow so
+/// the SDK has no opinion on logging frameworks.
+///
+/// The donor crate (`worktrunk`) used `log::debug!` here. We keep the
+/// observability surface but drop the `log` crate dependency to keep the
+/// SDK's transitive dep graph minimal — consumers that want diagnostic
+/// breadcrumbs can call the public API and inspect their own state.
+#[inline]
+fn log_debug(_args: &std::fmt::Arguments<'_>) {
+    // intentionally no-op: see fn-level doc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+    struct V {
+        x: u32,
+    }
+
+    #[test]
+    fn cache_dir_at_composes_kind_under_wt_dir() {
+        let path = cache_dir_at(Path::new("/repo/.git/wt"), "ci-status");
+        assert_eq!(path, PathBuf::from("/repo/.git/wt/cache/ci-status"));
+    }
+
+    #[test]
+    fn read_write_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("sub/entry.json");
+
+        // Missing file is a miss.
+        assert!(read_json::<V>(&path).is_none());
+
+        // Write creates parent dirs and round-trips.
+        write_json(&path, &V { x: 42 });
+        assert_eq!(read_json::<V>(&path), Some(V { x: 42 }));
+    }
+
+    #[test]
+    fn read_corrupt_json_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("bad.json");
+        fs::write(&path, "not json {{").unwrap();
+        assert!(read_json::<V>(&path).is_none());
+    }
+
+    #[test]
+    fn read_at_kind_key_resolves_subpath() {
+        let tmp = TempDir::new().unwrap();
+        let wt = tmp.path();
+        write_json(&cache_dir_at(wt, "k").join("a"), &V { x: 7 });
+        assert_eq!(read::<V>(wt, "k", "a"), Some(V { x: 7 }));
+        assert!(read::<V>(wt, "k", "missing").is_none());
+    }
+
+    #[test]
+    fn clear_one_missing_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("nope.json");
+        assert!(!clear_one(&path).unwrap());
+    }
+
+    #[test]
+    fn clear_one_propagates_non_not_found() {
+        let tmp = TempDir::new().unwrap();
+        // Put a directory where a file is expected so remove_file returns
+        // EISDIR (or similar), not NotFound.
+        let path = tmp.path().join("dir.json");
+        fs::create_dir(&path).unwrap();
+        let err = clear_one(&path).unwrap_err();
+        assert!(err.to_string().contains("failed to remove"), "got: {err}");
+    }
+
+    #[test]
+    fn clear_json_files_counts_and_skips() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("c");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("a.json"), "{}").unwrap();
+        fs::write(dir.join("b.json"), "{}").unwrap();
+        // Non-.json siblings must be skipped and left in place.
+        fs::write(dir.join("README"), "stray").unwrap();
+        fs::write(dir.join("a.json.tmp"), "leftover").unwrap();
+
+        assert_eq!(clear_json_files(&dir).unwrap(), 2);
+        assert!(!dir.join("a.json").exists());
+        assert!(!dir.join("b.json").exists());
+        assert!(dir.join("README").exists());
+        assert!(dir.join("a.json.tmp").exists());
+    }
+
+    #[test]
+    fn clear_json_files_missing_dir_is_zero() {
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(clear_json_files(&tmp.path().join("nope")).unwrap(), 0);
+    }
+
+    #[test]
+    fn clear_json_files_propagates_read_dir_error() {
+        let tmp = TempDir::new().unwrap();
+        // Put a file where a directory is expected — read_dir returns
+        // NotADirectory (not NotFound).
+        let path = tmp.path().join("not-a-dir");
+        fs::write(&path, "file").unwrap();
+        let err = clear_json_files(&path).unwrap_err();
+        assert!(err.to_string().contains("failed to read"), "got: {err}");
+    }
+
+    #[test]
+    fn count_json_files_skips_non_json() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("c");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("a.json"), "{}").unwrap();
+        fs::write(dir.join("README"), "stray").unwrap();
+
+        assert_eq!(count_json_files(&dir), 1);
+        assert_eq!(count_json_files(&tmp.path().join("nope")), 0);
+    }
+
+    #[test]
+    fn sweep_lru_trims_oldest_entries() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("c");
+        fs::create_dir_all(&dir).unwrap();
+
+        for i in 0..5 {
+            fs::write(dir.join(format!("entry{i}.json")), "true").unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        sweep_lru(&dir, 3);
+
+        let mut remaining: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        remaining.sort();
+        assert_eq!(remaining, ["entry2.json", "entry3.json", "entry4.json"]);
+    }
+
+    #[test]
+    fn sweep_lru_no_op_under_bound() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("c");
+        fs::create_dir_all(&dir).unwrap();
+
+        for i in 0..3 {
+            fs::write(dir.join(format!("entry{i}.json")), "true").unwrap();
+        }
+
+        sweep_lru(&dir, 5);
+
+        let count = fs::read_dir(&dir).unwrap().count();
+        assert_eq!(count, 3, "should not delete anything when under bound");
+    }
+
+    #[test]
+    fn write_with_lru_writes_and_bounds_kind_dir() {
+        let tmp = TempDir::new().unwrap();
+        let wt = tmp.path();
+
+        for i in 0..4 {
+            write_with_lru(wt, "k", &format!("e{i}.json"), &V { x: i }, 2);
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        let entries = count_json_files(&cache_dir_at(wt, "k"));
+        assert_eq!(entries, 2, "kind dir capped at max_entries");
+    }
+}

--- a/crates/worktrunk-core/src/diff.rs
+++ b/crates/worktrunk-core/src/diff.rs
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 kryptobaseddev
+//
+// This file is part of crates/worktrunk-core in the CleoCode monorepo.
+
+//! Pure-data git diff parsers (line totals + shortstat / numstat).
+//!
+//! Pure-Rust SDK extraction of worktrunk's `src/git/diff.rs` per the T10221
+//! refactor (ADR-078 separation-of-concerns contract). Owns ONLY the parsing
+//! primitives —
+//! [`LineDiff`], [`DiffStats`], [`parse_numstat_line`], [`parse_shortstat`].
+//! Color rendering of summaries (the donor's `format_summary` using
+//! `color_print::cformat!` + `green/red` markup) is intentionally NOT
+//! vendored — that's CLI styling, not data. CLI consumers compose color
+//! themselves from a `(files, insertions, deletions)` tuple.
+//!
+//! Inline ANSI-strip is implemented locally so the SDK can drop the
+//! `ansi_str` crate from its dependency graph. Reproduces the small subset of
+//! `AnsiStr::ansi_strip` the donor used: strip CSI sequences (ESC `[` … cmd)
+//! and OSC sequences (ESC `]` … BEL or ESC `\`) before parsing.
+
+/// Line-level diff totals (added/deleted counts) used across git operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct LineDiff {
+    /// Number of inserted lines.
+    pub added: usize,
+    /// Number of deleted lines.
+    pub deleted: usize,
+}
+
+impl LineDiff {
+    /// Parse `git diff --shortstat` output into line totals.
+    ///
+    /// Shortstat produces a single line like:
+    ///   ` 3 files changed, 45 insertions(+), 12 deletions(-)`
+    /// with optional parts omitted when zero. Extracts numbers by position
+    /// relative to the `(+)` and `(-)` markers, which are locale-independent.
+    #[must_use]
+    pub fn from_shortstat(output: &str) -> Self {
+        parse_shortstat(output).map_or(Self::default(), |(_, ins, del)| Self {
+            added: ins,
+            deleted: del,
+        })
+    }
+
+    /// `true` if both insertions and deletions are zero.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.added == 0 && self.deleted == 0
+    }
+}
+
+impl From<LineDiff> for (usize, usize) {
+    fn from(diff: LineDiff) -> Self {
+        (diff.added, diff.deleted)
+    }
+}
+
+impl From<(usize, usize)> for LineDiff {
+    fn from(value: (usize, usize)) -> Self {
+        Self {
+            added: value.0,
+            deleted: value.1,
+        }
+    }
+}
+
+/// Diff statistics (files changed, insertions, deletions).
+///
+/// Public in the SDK — CLI consumers that previously formatted via the
+/// donor's `format_summary` should pull `(files, insertions, deletions)`
+/// out of this struct and apply their own color rendering. The SDK has no
+/// opinion on rendering.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct DiffStats {
+    /// Number of files changed.
+    pub files: usize,
+    /// Number of inserted lines.
+    pub insertions: usize,
+    /// Number of deleted lines.
+    pub deletions: usize,
+}
+
+impl DiffStats {
+    /// Construct stats from `git diff --shortstat` output.
+    #[must_use]
+    pub fn from_shortstat(output: &str) -> Self {
+        parse_shortstat(output).map_or(Self::default(), |(files, ins, del)| Self {
+            files,
+            insertions: ins,
+            deletions: del,
+        })
+    }
+}
+
+/// Parse a git numstat line and extract insertions/deletions.
+///
+/// Supports standard `git diff --numstat` output as well as `git log`
+/// output with `--graph --color=always` prefixes (ANSI escapes are stripped
+/// before parsing). Returns `None` for binary entries (which git renders as
+/// `-` counts).
+#[must_use]
+pub fn parse_numstat_line(line: &str) -> Option<(usize, usize)> {
+    // Strip ANSI escape sequences (graph coloring contains digits that
+    // confuse parsing). Inline strip — see module doc for rationale.
+    let stripped = strip_ansi(line);
+
+    // Strip graph prefix (e.g., "| ") and find tab-separated values.
+    let trimmed = stripped.trim_start_matches(|c: char| !c.is_ascii_digit() && c != '-');
+
+    let mut parts = trimmed.split('\t');
+    let added_str = parts.next()?;
+    let deleted_str = parts.next()?;
+
+    // "-" means binary file; line counts are unavailable, so skip.
+    if added_str == "-" || deleted_str == "-" {
+        return None;
+    }
+
+    let added = added_str.parse().ok()?;
+    let deleted = deleted_str.parse().ok()?;
+
+    Some((added, deleted))
+}
+
+/// Parse `git diff --shortstat` output into `(files, insertions, deletions)`.
+///
+/// The format is: ` N file(s) changed, N insertion(s)(+), N deletion(s)(-)`
+/// with optional parts omitted when zero. The `(+)` and `(-)` markers are
+/// hardcoded in git's C source (`diff.c`) and not subject to localization.
+#[must_use]
+pub fn parse_shortstat(output: &str) -> Option<(usize, usize, usize)> {
+    let line = output.trim();
+    if line.is_empty() {
+        return None;
+    }
+
+    let mut files = 0;
+    let mut insertions = 0;
+    let mut deletions = 0;
+
+    // Split on commas: "N file(s) changed", "N insertion(s)(+)", "N deletion(s)(-)"
+    for (i, part) in line.split(',').enumerate() {
+        let num = part
+            .split_whitespace()
+            .find_map(|w| w.parse::<usize>().ok())
+            .unwrap_or(0);
+
+        if i == 0 {
+            files = num;
+        } else if part.contains("(+)") {
+            insertions = num;
+        } else if part.contains("(-)") {
+            deletions = num;
+        }
+    }
+
+    Some((files, insertions, deletions))
+}
+
+/// Strip ANSI CSI (`ESC [ … cmd`) and OSC (`ESC ] … BEL|ESC \`) sequences
+/// from `s`.
+///
+/// Limited to the subset the donor's `ansi_str::AnsiStr::ansi_strip` needed
+/// for parsing `git log --graph --color=always` output. Not a general-purpose
+/// terminal-escape stripper — designed for parsing, not display.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\x1b' {
+            out.push(c);
+            continue;
+        }
+        // ESC seen. Inspect the next char to classify the sequence.
+        match chars.next() {
+            None => {
+                // Trailing lone ESC — preserve nothing (matches ansi_str behavior).
+                break;
+            }
+            Some('[') => {
+                // CSI: parameter bytes 0x30-0x3F, intermediate 0x20-0x2F, final 0x40-0x7E.
+                for ch in chars.by_ref() {
+                    if ('\x40'..='\x7e').contains(&ch) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                // OSC: terminated by BEL (0x07) or ST (ESC \).
+                while let Some(ch) = chars.next() {
+                    if ch == '\x07' {
+                        break;
+                    }
+                    if ch == '\x1b' {
+                        // ST = ESC \
+                        if let Some('\\') = chars.peek() {
+                            chars.next();
+                        }
+                        break;
+                    }
+                }
+            }
+            Some(_) => {
+                // Two-byte ESC sequence (e.g. ESC = for keypad mode); already
+                // consumed the second byte by calling chars.next() above.
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // LineDiff ----------------------------------------------------------------
+
+    #[test]
+    fn line_diff_is_empty() {
+        assert!(LineDiff::default().is_empty());
+        assert!(
+            !LineDiff {
+                added: 5,
+                deleted: 0
+            }
+            .is_empty()
+        );
+        assert!(
+            !LineDiff {
+                added: 0,
+                deleted: 5
+            }
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn line_diff_tuple_roundtrip() {
+        let diff: LineDiff = (10, 5).into();
+        assert_eq!(diff.added, 10);
+        assert_eq!(diff.deleted, 5);
+        let tuple: (usize, usize) = diff.into();
+        assert_eq!(tuple, (10, 5));
+    }
+
+    // parse_numstat_line ------------------------------------------------------
+
+    #[test]
+    fn parse_numstat_line_basic() {
+        let result = parse_numstat_line("10\t5\tfile.rs");
+        assert_eq!(result, Some((10, 5)));
+    }
+
+    #[test]
+    fn parse_numstat_line_insertions_only() {
+        let result = parse_numstat_line("15\t0\tfile.rs");
+        assert_eq!(result, Some((15, 0)));
+    }
+
+    #[test]
+    fn parse_numstat_line_deletions_only() {
+        let result = parse_numstat_line("0\t8\tfile.rs");
+        assert_eq!(result, Some((0, 8)));
+    }
+
+    #[test]
+    fn parse_numstat_line_binary_file() {
+        let result = parse_numstat_line("-\t-\timage.png");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn parse_numstat_line_with_graph_prefix() {
+        // Plain graph prefix
+        let result = parse_numstat_line("| 10\t5\tfile.rs");
+        assert_eq!(result, Some((10, 5)));
+
+        // First numstat line after commit has "* | " prefix
+        let result = parse_numstat_line("* | 11\t0\tCargo.toml");
+        assert_eq!(result, Some((11, 0)));
+
+        // Subsequent numstat lines have "| " prefix
+        let result = parse_numstat_line("| 17\t3\tsrc/main.rs");
+        assert_eq!(result, Some((17, 3)));
+
+        // With ANSI colors (--color=always adds escape codes to graph)
+        // ESC[31m = red, ESC[m = reset
+        let esc = '\x1b';
+        let ansi_colored = format!("{esc}[31m|{esc}[m 11\t0\tCargo.toml");
+        let result = parse_numstat_line(&ansi_colored);
+        assert_eq!(result, Some((11, 0)));
+    }
+
+    #[test]
+    fn parse_numstat_line_not_numstat() {
+        assert_eq!(parse_numstat_line("* abc1234 Fix bug"), None);
+        assert_eq!(parse_numstat_line(""), None);
+        assert_eq!(parse_numstat_line("regular text"), None);
+    }
+
+    // parse_shortstat / DiffStats / LineDiff::from_shortstat ------------------
+
+    #[test]
+    fn parse_shortstat_all_parts() {
+        let output = " 23 files changed, 624 insertions(+), 160 deletions(-)";
+        let (files, ins, del) = parse_shortstat(output).unwrap();
+        assert_eq!(files, 23);
+        assert_eq!(ins, 624);
+        assert_eq!(del, 160);
+    }
+
+    #[test]
+    fn parse_shortstat_insertions_only() {
+        let output = " 1 file changed, 6 insertions(+)";
+        let (files, ins, del) = parse_shortstat(output).unwrap();
+        assert_eq!(files, 1);
+        assert_eq!(ins, 6);
+        assert_eq!(del, 0);
+    }
+
+    #[test]
+    fn parse_shortstat_deletions_only() {
+        let output = " 2 files changed, 10 deletions(-)";
+        let (files, ins, del) = parse_shortstat(output).unwrap();
+        assert_eq!(files, 2);
+        assert_eq!(ins, 0);
+        assert_eq!(del, 10);
+    }
+
+    #[test]
+    fn parse_shortstat_empty() {
+        assert_eq!(parse_shortstat(""), None);
+        assert_eq!(parse_shortstat("  "), None);
+        assert_eq!(parse_shortstat("\n"), None);
+    }
+
+    #[test]
+    fn parse_shortstat_single_file_singular() {
+        let output = " 1 file changed, 1 insertion(+), 1 deletion(-)";
+        let (files, ins, del) = parse_shortstat(output).unwrap();
+        assert_eq!(files, 1);
+        assert_eq!(ins, 1);
+        assert_eq!(del, 1);
+    }
+
+    #[test]
+    fn line_diff_from_shortstat() {
+        let output = " 5 files changed, 100 insertions(+), 50 deletions(-)";
+        let diff = LineDiff::from_shortstat(output);
+        assert_eq!(diff.added, 100);
+        assert_eq!(diff.deleted, 50);
+    }
+
+    #[test]
+    fn line_diff_from_shortstat_empty() {
+        let diff = LineDiff::from_shortstat("");
+        assert!(diff.is_empty());
+    }
+
+    #[test]
+    fn diff_stats_from_shortstat() {
+        let output = " 3 files changed, 45 insertions(+), 12 deletions(-)";
+        let stats = DiffStats::from_shortstat(output);
+        assert_eq!(stats.files, 3);
+        assert_eq!(stats.insertions, 45);
+        assert_eq!(stats.deletions, 12);
+    }
+
+    #[test]
+    fn diff_stats_from_shortstat_empty() {
+        let stats = DiffStats::from_shortstat("");
+        assert_eq!(stats.files, 0);
+        assert_eq!(stats.insertions, 0);
+        assert_eq!(stats.deletions, 0);
+    }
+
+    // strip_ansi --------------------------------------------------------------
+
+    #[test]
+    fn strip_ansi_drops_csi_sequences() {
+        let esc = '\x1b';
+        let input = format!("{esc}[31mred{esc}[0m plain");
+        assert_eq!(strip_ansi(&input), "red plain");
+    }
+
+    #[test]
+    fn strip_ansi_drops_osc_terminated_by_bel() {
+        let esc = '\x1b';
+        let bel = '\x07';
+        let input = format!("a{esc}]0;titlewith;semicolons{bel}b");
+        assert_eq!(strip_ansi(&input), "ab");
+    }
+
+    #[test]
+    fn strip_ansi_drops_osc_terminated_by_st() {
+        let esc = '\x1b';
+        let input = format!("a{esc}]0;title{esc}\\b");
+        assert_eq!(strip_ansi(&input), "ab");
+    }
+
+    #[test]
+    fn strip_ansi_preserves_text_without_escapes() {
+        assert_eq!(strip_ansi("plain text"), "plain text");
+    }
+}

--- a/crates/worktrunk-core/src/git/repo.rs
+++ b/crates/worktrunk-core/src/git/repo.rs
@@ -1044,4 +1044,29 @@ mod tests {
         let t = repo.detect_ref_type("main").unwrap();
         assert_eq!(t, RefType::LocalBranch);
     }
+
+    #[test]
+    fn diff_stats_summary_returns_shortstat_parseable_by_sdk() {
+        let d = init_repo();
+        let repo = ProcessRepo::at(d.path()).unwrap();
+
+        // Add a second commit so we have a range to diff.
+        std::fs::write(d.path().join("a.txt"), "alpha\nbeta\ngamma\n").unwrap();
+        Command::new("git")
+            .args(["add", "a.txt"])
+            .current_dir(d.path())
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-q", "-m", "second"])
+            .current_dir(d.path())
+            .status()
+            .unwrap();
+
+        let shortstat = repo.diff_stats_summary("HEAD~1", "HEAD").unwrap();
+        let stats = crate::diff::DiffStats::from_shortstat(&shortstat);
+        assert_eq!(stats.files, 1, "exactly one file changed");
+        assert_eq!(stats.insertions, 3, "three lines inserted");
+        assert_eq!(stats.deletions, 0, "no deletions");
+    }
 }

--- a/crates/worktrunk-core/src/lib.rs
+++ b/crates/worktrunk-core/src/lib.rs
@@ -15,10 +15,24 @@
 //!
 //! # Modules
 //!
+//! - [`cache`] — on-disk JSON cache primitives (read/write/sweep/clear) under
+//!   `<wt_dir>/cache/<kind>/`. Extracted from worktrunk's `src/cache.rs` per
+//!   T10221 (ADR-078). No `Repository` dependency — callers pass the cache
+//!   root as a `&Path`.
 //! - [`copy`] — reflink (COW) + rayon parallel directory copy with progress
 //!   callbacks and path-root guards.
+//! - [`diff`] — pure git-diff parsers ([`diff::LineDiff`], [`diff::DiffStats`],
+//!   [`diff::parse_numstat_line`], [`diff::parse_shortstat`]). Extracted from
+//!   `worktrunk::git::diff` per T10221; the donor's `cformat!`-styled summary
+//!   was intentionally dropped (CLI consumers compose color themselves).
 //! - [`path`] — path canonicalization that works for non-existent paths,
 //!   plus user-facing path display formatting.
+//! - [`remove_dir`] — recursive parallel directory removal with optional
+//!   progress reporting. Extracted from worktrunk's `src/remove_dir.rs` per
+//!   T10221.
+//! - [`sync`] — counting semaphore for limiting concurrency
+//!   ([`sync::Semaphore`]). Extracted from worktrunk's `src/sync.rs` per
+//!   T10221.
 //! - [`worktreeinclude`] — parser for `.worktreeinclude` files using the
 //!   `ignore::gitignore` matcher (correct glob match, not literal `existsSync`).
 //! - [`git_wt`] — minimal `git worktree` primitives (add, remove, list, lock,
@@ -32,6 +46,36 @@
 //!   [`config::CopyIgnoredConfig`]).
 //! - [`progress`] — opt-in progress reporter; defaults to a zero-cost no-op so
 //!   napi consumers pay nothing.
+//!
+//! # CLI-binary-only modules (intentionally NOT vendored)
+//!
+//! Two donor modules — `worktrunk::priority` and `worktrunk::signal_forwarder`
+//! — were deliberately left out of `worktrunk-core` per the T10221 audit and
+//! ADR-078's separation-of-concerns contract:
+//!
+//! - `worktrunk::priority` (donor `/mnt/projects/worktrunk/src/priority.rs`):
+//!   shells out to `nice`/`ionice`/`taskpolicy` to lower the OS-level priority
+//!   of the calling process so foreground sessions get the CPU/IO budget.
+//!   This is a CLI-binary side effect — it mutates per-process resource
+//!   limits and depends on which shell helpers the host environment ships
+//!   (Darwin `taskpolicy`, Linux `nice` + `ionice`, no-op elsewhere). SDK
+//!   consumers (napi worker threads, embedded `cleo orchestrate spawn`)
+//!   already run with whatever priority their host process chose; they
+//!   MUST NOT silently re-nice their host.
+//!
+//! - `worktrunk::signal_forwarder` (donor
+//!   `/mnt/projects/worktrunk/src/signal_forwarder.rs`): installs SIGINT /
+//!   SIGTERM handlers on the foreground `wt` binary and forwards them to
+//!   child process groups. The entire module is `#[cfg(unix)]` and depends
+//!   on POSIX pgroup semantics that only make sense when there IS a
+//!   foreground binary owning the signal disposition. SDK consumers do not
+//!   own the foreground signal disposition (the host process does), so
+//!   re-installing handlers from a library is unsafe and would silently
+//!   break napi shutdown.
+//!
+//! Both modules stay in the `worktrunk` CLI binary. Any SDK consumer that
+//! needs equivalent behavior is responsible for managing it in its OWN
+//! process-lifecycle layer.
 //!
 //! # Example
 //!
@@ -51,18 +95,23 @@
 //! println!("Copied {files} files ({bytes} bytes)");
 //! ```
 
+pub mod cache;
 pub mod config;
 pub mod copy;
+pub mod diff;
 pub mod git;
 pub mod git_wt;
 pub mod path;
 pub mod paths;
 pub mod progress;
+pub mod remove_dir;
 pub mod step;
+pub mod sync;
 pub mod worktreeinclude;
 
 pub use config::{CopyIgnoredConfig, UserConfigDto};
 pub use copy::{copy_dir_recursive, copy_leaf};
+pub use diff::{DiffStats, LineDiff, parse_numstat_line, parse_shortstat};
 pub use git::{
     BranchDeletionMode, BranchRef, ProcessRepo, RefEntry, RefKind, RefSnapshot, RefType,
     RemovalPlan, Repo,
@@ -74,4 +123,6 @@ pub use git_wt::{
 pub use path::{canonicalize_with_parents, format_path_for_display, paths_match};
 pub use paths::{compute_project_hash, resolve_task_worktree_path, resolve_worktree_root_for_hash};
 pub use progress::Progress;
+pub use remove_dir::remove_dir_with_progress;
+pub use sync::{Semaphore, SemaphoreGuard};
 pub use worktreeinclude::{IncludePattern, apply_include_matcher, read_include_patterns};

--- a/crates/worktrunk-core/src/remove_dir.rs
+++ b/crates/worktrunk-core/src/remove_dir.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 kryptobaseddev
+//
+// This file is part of crates/worktrunk-core in the CleoCode monorepo.
+
+//! Recursive parallel directory removal with optional progress reporting.
+//!
+//! Pure-Rust SDK extraction of worktrunk's `src/remove_dir.rs` per the T10221
+//! refactor (ADR-078 separation-of-concerns contract). Walks the tree
+//! iteratively (no recursion),
+//! unlinks files in parallel via a capped rayon pool, then removes the now-empty
+//! directories deepest-first. Each unlinked leaf bumps a [`Progress`] counter so
+//! a TTY spinner can render live updates; the returned `(files, bytes)` tuple
+//! drives the matching post-op summary.
+//!
+//! Best-effort by design: this is the trash-cleanup phase that runs *after* a
+//! worktree has already been pruned from git's metadata, so a partial cleanup
+//! leaves the user with a stale directory under `.git/wt/trash/` —
+//! recoverable, not catastrophic. read/unlink/rmdir errors are swallowed so the
+//! caller can always report the count of leaves we did manage to remove.
+//!
+//! Parallel unlink runs on a dedicated 4-thread pool — file removal is
+//! filesystem latency, not CPU, so a small pool gives most of the speedup
+//! without the per-process thread cost of rayon's default `2× CPU cores`
+//! global pool (which adds up across many subprocesses in test runs).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+use rayon::prelude::*;
+
+use crate::progress::Progress;
+
+/// Capped at 4 threads — same reasoning as the copy pool (filesystem I/O,
+/// don't oversubscribe CPU when many subprocesses run in parallel).
+///
+/// `LazyLock` initializers cannot return errors. On the (unreachable in
+/// practice) path where `ThreadPoolBuilder::build` fails — the OS has refused
+/// to spawn a thread — we fall back to single-threaded execution. If both
+/// attempts fail the host is unusable; we panic with a descriptive message,
+/// matching the [`crate::copy`] pool policy.
+static REMOVE_POOL: LazyLock<rayon::ThreadPool> = LazyLock::new(build_remove_pool);
+
+#[allow(clippy::panic)]
+fn build_remove_pool() -> rayon::ThreadPool {
+    if let Ok(pool) = rayon::ThreadPoolBuilder::new().num_threads(4).build() {
+        return pool;
+    }
+    if let Ok(pool) = rayon::ThreadPoolBuilder::new().num_threads(1).build() {
+        return pool;
+    }
+    panic!("worktrunk-core: rayon refuses to build any thread pool — host unusable");
+}
+
+/// Remove a directory tree, reporting per-file progress.
+///
+/// Returns `(files_removed, bytes_removed)`. Bytes use `symlink_metadata`, so
+/// symlinks count as their own size, not the target's. Any I/O errors are
+/// silently skipped — a leaf that can't be unlinked is simply not counted.
+///
+/// Callers that don't want progress should pass [`Progress::disabled`] —
+/// every `record` call is a zero-cost no-op.
+#[must_use]
+pub fn remove_dir_with_progress(path: &Path, progress: &Progress) -> (usize, u64) {
+    let mut leaves: Vec<PathBuf> = Vec::new();
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let mut stack = vec![path.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        // read_dir failure (NotFound, EACCES, anything else) -> skip this
+        // subtree. We still try to rmdir it later in case it's actually empty.
+        let Ok(entries) = fs::read_dir(&dir) else {
+            dirs.push(dir);
+            continue;
+        };
+        // Push parents first; we'll reverse before rmdir so children unlink first.
+        dirs.push(dir);
+        for entry in entries.flatten() {
+            // entry.file_type() is an lstat on Unix - symlinks report
+            // is_dir() == false and fall through to the leaf branch, which
+            // is what we want (unlink the link, not the target).
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            let entry_path = entry.path();
+            if file_type.is_dir() {
+                stack.push(entry_path);
+            } else {
+                leaves.push(entry_path);
+            }
+        }
+    }
+
+    let removed_files = AtomicUsize::new(0);
+    let removed_bytes = AtomicU64::new(0);
+    REMOVE_POOL.install(|| {
+        leaves.par_iter().for_each(|leaf| {
+            // Capture size before unlinking. Best-effort: symlink_metadata may
+            // fail on a racy delete, in which case we still try to unlink and
+            // count the leaf with zero bytes.
+            let bytes = leaf.symlink_metadata().map(|m| m.len()).unwrap_or(0);
+            if fs::remove_file(leaf).is_ok() {
+                removed_files.fetch_add(1, Ordering::Relaxed);
+                removed_bytes.fetch_add(bytes, Ordering::Relaxed);
+                progress.record(bytes);
+            }
+        });
+    });
+
+    // Pop order pushed parents before children, so reversing gives
+    // deepest-first - exactly what rmdir needs.
+    for dir in dirs.iter().rev() {
+        let _ = fs::remove_dir(dir);
+    }
+
+    (removed_files.into_inner(), removed_bytes.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remove_dir_with_progress_empty_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().join("empty");
+        std::fs::create_dir(&dir).unwrap();
+
+        let (files, bytes) = remove_dir_with_progress(&dir, &Progress::disabled());
+
+        assert_eq!(files, 0);
+        assert_eq!(bytes, 0);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn remove_dir_with_progress_counts_files_and_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("tree");
+        std::fs::create_dir_all(root.join("a/b")).unwrap();
+        std::fs::write(root.join("a/file1.txt"), b"hello").unwrap(); // 5 bytes
+        std::fs::write(root.join("a/b/file2.txt"), b"world!").unwrap(); // 6 bytes
+        std::fs::write(root.join("top.txt"), b"x").unwrap(); // 1 byte
+
+        let (files, bytes) = remove_dir_with_progress(&root, &Progress::disabled());
+
+        assert_eq!(files, 3);
+        assert_eq!(bytes, 12);
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn remove_dir_with_progress_missing_root_is_ok() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("does-not-exist");
+
+        let (files, bytes) = remove_dir_with_progress(&missing, &Progress::disabled());
+
+        assert_eq!(files, 0);
+        assert_eq!(bytes, 0);
+    }
+
+    #[test]
+    fn remove_dir_with_progress_records_into_counting_progress() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("tree");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("a"), b"abc").unwrap();
+        std::fs::write(root.join("b"), b"defg").unwrap();
+
+        let progress = Progress::counting();
+        let (files, bytes) = remove_dir_with_progress(&root, &progress);
+
+        assert_eq!(files, 2);
+        assert_eq!(bytes, 7);
+        let (p_files, p_bytes) = progress.snapshot();
+        assert_eq!(p_files, 2, "Progress::record should fire per leaf");
+        assert_eq!(p_bytes, 7, "Progress should aggregate byte counts");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_dir_with_progress_handles_symlinks() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("tree");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("real.txt"), b"abc").unwrap();
+        std::os::unix::fs::symlink(root.join("real.txt"), root.join("link")).unwrap();
+
+        let (files, _bytes) = remove_dir_with_progress(&root, &Progress::disabled());
+
+        // 1 file + 1 symlink = 2 leaves removed; the symlink is unlinked
+        // without following.
+        assert_eq!(files, 2);
+        assert!(!root.exists());
+    }
+
+    /// Cover the read_dir-fails path. Permission-denied is the realistic
+    /// non-NotFound failure; the function should silently skip the subtree
+    /// and still rmdir what it can. Skipped when running as root (the kernel
+    /// ignores mode-0 directories for euid 0).
+    #[cfg(unix)]
+    #[test]
+    fn remove_dir_with_progress_skips_unreadable_subtree() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("tree");
+        let blocked = root.join("blocked");
+        std::fs::create_dir_all(&blocked).unwrap();
+        std::fs::write(blocked.join("hidden.txt"), b"x").unwrap();
+        // Make blocked unreadable. Also blocks rmdir of blocked itself, but
+        // that's fine - we want to exercise the read_dir error branch and
+        // verify the function returns gracefully.
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // Skip if running as root: euid 0 ignores DAC mode bits, so the
+        // walk would succeed and unlink hidden.txt. Probe via a read attempt.
+        if std::fs::read_dir(&blocked).is_ok() {
+            std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o755)).ok();
+            eprintln!("Skipping - running with elevated privileges");
+            return;
+        }
+
+        let (files, bytes) = remove_dir_with_progress(&root, &Progress::disabled());
+
+        // Restore so the tempdir's Drop can clean up.
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o755)).ok();
+
+        assert_eq!(files, 0, "no leaves should be unlinked when blocked");
+        assert_eq!(bytes, 0);
+    }
+}

--- a/crates/worktrunk-core/src/sync.rs
+++ b/crates/worktrunk-core/src/sync.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 kryptobaseddev
+//
+// This file is part of crates/worktrunk-core in the CleoCode monorepo.
+
+//! Synchronization primitives.
+//!
+//! Pure-Rust SDK extraction of worktrunk's `src/sync.rs` per the T10221
+//! refactor (ADR-078 separation-of-concerns contract). Provides a counting
+//! semaphore for
+//! limiting concurrency across rayon worker pools and `std::process::Command`
+//! invocations — the same shape consumers use today, with zero CLI / styling
+//! / hook dependencies.
+
+use std::sync::{Arc, Condvar, Mutex};
+
+/// A counting semaphore for limiting concurrency.
+///
+/// Used to prevent resource exhaustion when many parallel operations need
+/// to run. Provides RAII-based permit management through [`SemaphoreGuard`].
+#[derive(Clone)]
+pub struct Semaphore {
+    state: Arc<(Mutex<usize>, Condvar)>,
+}
+
+/// RAII guard that releases a semaphore permit on drop.
+///
+/// Created by [`Semaphore::acquire`]. The permit is automatically released
+/// when this guard is dropped, even if the code panics.
+pub struct SemaphoreGuard {
+    state: Arc<(Mutex<usize>, Condvar)>,
+}
+
+impl Semaphore {
+    /// Create a new semaphore with the given number of permits.
+    #[must_use]
+    pub fn new(permits: usize) -> Self {
+        Self {
+            state: Arc::new((Mutex::new(permits), Condvar::new())),
+        }
+    }
+
+    /// Acquire a permit, blocking until one is available.
+    ///
+    /// Returns a guard that releases the permit when dropped.
+    ///
+    /// Mutex poisoning is recovered transparently — the donor's `.unwrap()`
+    /// would panic on poisoning, which is the wrong policy in an SDK shared
+    /// across long-lived workers. Recovering the inner state matches the
+    /// rest of the SDK's "total API" contract.
+    #[must_use]
+    pub fn acquire(&self) -> SemaphoreGuard {
+        let (lock, cvar) = &*self.state;
+        let mut available = lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Wait until a permit is available
+        while *available == 0 {
+            available = cvar
+                .wait(available)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+
+        // Take a permit
+        *available -= 1;
+
+        SemaphoreGuard {
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+impl Drop for SemaphoreGuard {
+    fn drop(&mut self) {
+        let (lock, cvar) = &*self.state;
+        let mut available = lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *available += 1;
+        cvar.notify_one();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn semaphore_limits_concurrency() {
+        let sem = Semaphore::new(2);
+        let counter = Arc::new(AtomicUsize::new(0));
+        let max_concurrent = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = vec![];
+
+        for _ in 0..10 {
+            let sem = sem.clone();
+            let counter = Arc::clone(&counter);
+            let max_concurrent = Arc::clone(&max_concurrent);
+
+            let handle = thread::spawn(move || {
+                let _guard = sem.acquire();
+
+                // Increment counter
+                let current = counter.fetch_add(1, Ordering::SeqCst) + 1;
+
+                // Track max concurrent
+                max_concurrent.fetch_max(current, Ordering::SeqCst);
+
+                // Simulate work
+                thread::sleep(Duration::from_millis(10));
+
+                // Decrement counter
+                counter.fetch_sub(1, Ordering::SeqCst);
+            });
+
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Should never have more than 2 threads running concurrently
+        assert!(max_concurrent.load(Ordering::SeqCst) <= 2);
+    }
+
+    #[test]
+    fn semaphore_guard_drop_releases_permit() {
+        let sem = Semaphore::new(1);
+        let guard = sem.acquire();
+        drop(guard);
+        // If release worked, a second acquire returns immediately.
+        let _g = sem.acquire();
+    }
+}


### PR DESCRIPTION
## Summary

Pure-function refactor of worktrunk's lifecycle modules into top-level modules under `crates/worktrunk-core/src/` per ADR-078 separation-of-concerns contract. Builds on T10219's `Repo` trait + `ProcessRepo` substitute shipped in PR #507.

- **4 new SDK modules** at `crates/worktrunk-core/src/{cache,remove_dir,sync,diff}.rs` (1215 LOC total)
- **CLI-binary-only modules documented** in `lib.rs`: `worktrunk::priority` + `worktrunk::signal_forwarder` deliberately stay in the CLI binary (process-lifecycle side effects unsafe in a library)
- **Repo trait promotion**: `Repo::diff_stats_summary` flipped from `unimplemented_in_sdk` → real `ProcessRepo` impl
- **Dep graph stripped**: dropped `log`, `ansi_str`, `color_print` (SDK no longer imports any of them)

## Modules

| Module | LOC | Purpose | Donor |
|---|---|---|---|
| `cache.rs` | 434 | JSON cache (read/write/sweep/clear) | `worktrunk/src/cache.rs` |
| `remove_dir.rs` | 235 | parallel recursive directory removal | `worktrunk/src/remove_dir.rs` |
| `sync.rs` | 140 | counting semaphore + RAII guard | `worktrunk/src/sync.rs` |
| `diff.rs` | 406 | pure git-diff parsers (LineDiff, DiffStats, …) | `worktrunk/src/git/diff.rs` |

## Test plan

- [x] `cargo build -p worktrunk-core --all-features` — green
- [x] `cargo test -p worktrunk-core --all-features` — 112 / 112 pass (69 → 104 unit + 6 integration + 2 doctest)
- [x] `cargo clippy -p worktrunk-core --all-features --no-deps -- -D warnings` — zero
- [x] `pnpm biome check --write .` — zero new findings
- [x] `Repo::diff_stats_summary` → `DiffStats::from_shortstat` round-trip exercised by `diff_stats_summary_returns_shortstat_parseable_by_sdk`

## Coordination with T10220

T10220 (step/* extraction) runs in parallel. Disjoint by file convention:
- T10221 (this PR): top-level modules at `crates/worktrunk-core/src/<op>.rs`
- T10220: nested modules at `crates/worktrunk-core/src/step/<name>.rs`

`lib.rs` mod declarations may conflict on the `pub mod` lines — straightforward rebase + cargo build to land second.

---

Closes T10221  
Saga: T10176  
Decision: D010  
Epic: T10218  
ADR: ADR-078