### PR TITLE
feat(T10116): saga auto-close in completeTask (root-cause T10090)

### DIFF
--- a/.changeset/T10116-saga-autoclose.md
+++ b/.changeset/T10116-saga-autoclose.md
@@ -1,0 +1,10 @@
+---
+"@cleocode/core": patch
+---
+
+feat(T10116): saga auto-close integrated into completeTask
+
+Mirrors the epic auto-close pattern at complete.ts:498-539 but resolves members via
+task_relations.type='groups'. When the last group member transitions to done, the
+saga's status auto-flips to done with synthesized evidence. Root-cause fix for T10090.
+Saga: T10113. Epic: T10210.

--- a/packages/core/src/sagas/__tests__/storage.test.ts
+++ b/packages/core/src/sagas/__tests__/storage.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for the T10116 saga storage helpers:
+ *
+ *   - `findSagasGroupingTask` — backward member-lookup walking the saga
+ *     catalog for `task_relations.type='groups'` edges.
+ *   - `buildSagaAutoCloseEvidence` — synthesized verification envelope
+ *     attached to an auto-closing saga (ADR-073 §1.2 invariants I3+I5).
+ *
+ * Sibling integration tests in
+ * `packages/core/src/tasks/__tests__/complete-saga-autoclose.test.ts`
+ * cover the end-to-end completeTask path; this file pins the pure
+ * helper contracts so a future refactor cannot drift their shape
+ * silently.
+ *
+ * @task T10116
+ * @epic T10210 — E-SAGA-AUTO-CLOSE
+ * @saga T10113 — SG-SAGA-FIRST-CLASS
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, seedTasks, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { SAGA_GROUPS_RELATION } from '../constants.js';
+import { buildSagaAutoCloseEvidence, findSagasGroupingTask } from '../storage.js';
+
+describe('findSagasGroupingTask (T10116)', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+  });
+
+  afterEach(async () => {
+    await env.cleanup();
+  });
+
+  it('returns the saga(s) whose groups edges include the target task', async () => {
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'TS-FIND-1',
+        title: 'Saga grouping M1',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TS-FIND-2',
+        title: 'Saga NOT grouping M1',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TM-M1',
+        title: 'Member 1',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+      {
+        id: 'TM-M2',
+        title: 'Member 2 — unrelated',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+    ]);
+    await accessor.addRelation('TS-FIND-1', 'TM-M1', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-FIND-2', 'TM-M2', SAGA_GROUPS_RELATION);
+
+    const sagas = await findSagasGroupingTask(accessor, 'TM-M1');
+    expect(sagas.map((s) => s.id)).toEqual(['TS-FIND-1']);
+  });
+
+  it('returns an empty array when no saga groups the target task', async () => {
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'T-LONELY',
+        title: 'Task with no saga membership',
+        type: 'task',
+        status: 'pending',
+        priority: 'medium',
+        createdAt: now,
+      },
+    ]);
+
+    const sagas = await findSagasGroupingTask(accessor, 'T-LONELY');
+    expect(sagas).toEqual([]);
+  });
+
+  it('ignores non-saga relations of the same type id (only `groups` matches)', async () => {
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'TS-REL-1',
+        title: 'Saga linking via groups',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TM-R1',
+        title: 'Member via groups',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+      {
+        id: 'TM-R2',
+        title: 'Related-but-not-grouped',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+    ]);
+    await accessor.addRelation('TS-REL-1', 'TM-R1', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-REL-1', 'TM-R2', 'related');
+
+    const groupedSagas = await findSagasGroupingTask(accessor, 'TM-R1');
+    expect(groupedSagas.map((s) => s.id)).toEqual(['TS-REL-1']);
+
+    const relatedSagas = await findSagasGroupingTask(accessor, 'TM-R2');
+    expect(relatedSagas).toEqual([]);
+  });
+
+  it('returns multiple sagas when the same task is grouped by several', async () => {
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'TS-MULTI-1',
+        title: 'Saga A',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TS-MULTI-2',
+        title: 'Saga B',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TM-SHARED',
+        title: 'Member of both',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+    ]);
+    await accessor.addRelation('TS-MULTI-1', 'TM-SHARED', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-MULTI-2', 'TM-SHARED', SAGA_GROUPS_RELATION);
+
+    const sagas = await findSagasGroupingTask(accessor, 'TM-SHARED');
+    expect(sagas.map((s) => s.id).sort()).toEqual(['TS-MULTI-1', 'TS-MULTI-2']);
+  });
+});
+
+describe('buildSagaAutoCloseEvidence (T10116)', () => {
+  it('synthesizes a fully-populated TaskVerification with the three required atom kinds', () => {
+    const verification = buildSagaAutoCloseEvidence(
+      'TS-EVIDENCE',
+      ['TM-X1', 'TM-X2', 'TM-X3'],
+      '2026-05-22T10:00:00.000Z',
+    );
+
+    expect(verification.passed).toBe(true);
+    expect(verification.round).toBe(1);
+    expect(verification.gates.implemented).toBe(true);
+    expect(verification.gates.testsPassed).toBe(true);
+    expect(verification.gates.qaPassed).toBe(true);
+    expect(verification.gates.cleanupDone).toBe(true);
+    expect(verification.gates.securityPassed).toBe(true);
+    expect(verification.gates.documented).toBe(true);
+
+    // Every standard gate carries the three-atom envelope.
+    for (const gate of [
+      'implemented',
+      'testsPassed',
+      'qaPassed',
+      'cleanupDone',
+      'securityPassed',
+      'documented',
+    ] as const) {
+      const ev = verification.evidence?.[gate];
+      expect(ev).toBeDefined();
+      expect(ev?.capturedBy).toBe('system:saga-auto-close');
+      const notes = (ev?.atoms ?? []).map((a) => a.note);
+      expect(notes).toContainEqual(`saga-auto-close-via-completeTask:TS-EVIDENCE:${gate}`);
+      expect(notes).toContainEqual('members:TM-X1,TM-X2,TM-X3');
+      expect(notes).toContainEqual('adr:ADR-073 §1.2 invariants I3+I5');
+    }
+  });
+
+  it('preserves the timestamp passed in by the caller verbatim', () => {
+    const ts = '2026-05-22T12:34:56.789Z';
+    const verification = buildSagaAutoCloseEvidence('TS-TS', ['TM-1'], ts);
+    expect(verification.lastUpdated).toBe(ts);
+    expect(verification.initializedAt).toBe(ts);
+    expect(verification.evidence?.implemented?.capturedAt).toBe(ts);
+  });
+
+  it('handles an empty members list (defensive — never happens at the caller)', () => {
+    const verification = buildSagaAutoCloseEvidence('TS-EMPTY', [], '2026-01-01T00:00:00.000Z');
+    const notes = (verification.evidence?.implemented?.atoms ?? []).map((a) => a.note);
+    expect(notes).toContainEqual('members:');
+  });
+});

--- a/packages/core/src/sagas/index.ts
+++ b/packages/core/src/sagas/index.ts
@@ -43,4 +43,8 @@ export {
 } from './members.js';
 export { type RepairSagaParams, type RepairSagaResult, repairSaga } from './repair.js';
 export { type SagaRollupParams, type SagaRollupResult, sagaRollup } from './rollup.js';
-export { resolveSagaMemberIds } from './storage.js';
+export {
+  buildSagaAutoCloseEvidence,
+  findSagasGroupingTask,
+  resolveSagaMemberIds,
+} from './storage.js';

--- a/packages/core/src/sagas/storage.ts
+++ b/packages/core/src/sagas/storage.ts
@@ -10,10 +10,15 @@
  *
  * @task T10123
  * @task T10120
+ * @task T10116 — `findSagasGroupingTask` + `buildSagaAutoCloseEvidence`
+ *               helpers consumed by the saga auto-close branch in
+ *               `tasks/complete.ts`.
  * @epic T10208
+ * @epic T10210 — E-SAGA-AUTO-CLOSE
  * @see ADR-073-above-epic-naming.md §1
  */
 
+import type { GateEvidence, Task, TaskVerification, VerificationGate } from '@cleocode/contracts';
 import type { DataAccessor } from '../store/data-accessor.js';
 import { SAGA_GROUPS_RELATION, SAGA_LABEL } from './constants.js';
 
@@ -54,4 +59,152 @@ export async function resolveSagaMemberIds(
     memberIds.push(relation.taskId);
   }
   return memberIds;
+}
+
+/**
+ * Find every saga that groups the given task as a member.
+ *
+ * Walks the saga catalog (every row with `type='epic'` AND
+ * `labels.includes('saga')`) and returns the subset whose populated
+ * `relates` array contains a `task_relations.type='groups'` edge pointing
+ * at `memberId`.
+ *
+ * Consumed by the saga auto-close branch in `tasks/complete.ts` — when a
+ * task transitions to `done`, the completion path needs to know which
+ * sagas (if any) should be considered for auto-close as a side-effect of
+ * that transition. The returned sagas are loaded with their full
+ * `relates` array so the caller can immediately resolve their member IDs
+ * without a second round-trip.
+ *
+ * Implementation notes:
+ *   - Uses `queryTasks({ type: 'epic', label: 'saga' })`, which already
+ *     populates `relates` via `loadRelationsForTasks` in the SQLite
+ *     accessor — no additional `loadSingleTask` calls per saga are
+ *     needed.
+ *   - Filters out any saga whose row no longer carries the `'saga'`
+ *     label after rehydration (defence-in-depth — `queryTasks` is
+ *     authoritative, but a future schema migration could relax the
+ *     label index without notice).
+ *
+ * @param accessor - Data accessor backing the lookup.
+ * @param memberId - Task ID to test for saga membership.
+ * @returns Every saga grouping `memberId`, in stable saga-ID order.
+ *
+ * @task T10116
+ * @epic T10210
+ * @see ADR-073-above-epic-naming.md §1
+ */
+export async function findSagasGroupingTask(
+  accessor: DataAccessor,
+  memberId: string,
+): Promise<Task[]> {
+  const { tasks: sagas } = await accessor.queryTasks({ type: 'epic', label: 'saga' });
+  const matches: Task[] = [];
+  for (const saga of sagas) {
+    if (!(saga.labels ?? []).includes(SAGA_LABEL)) continue;
+    const hasMemberEdge = (saga.relates ?? []).some(
+      (relation) => relation.type === SAGA_GROUPS_RELATION && relation.taskId === memberId,
+    );
+    if (!hasMemberEdge) continue;
+    matches.push(saga);
+  }
+  return matches;
+}
+
+/**
+ * Standard verification gates synthesized when a saga auto-closes.
+ *
+ * Mirrors the canonical gate sequence used elsewhere (see
+ * {@link buildRollupEvidence} in `coordination-parent.ts`). Saga members
+ * are Epics, not subtasks — every gate is delivered by a member's own
+ * completion chain, so the saga's rollup synthesizes a `note`-atom
+ * envelope that names the closing event and points at ADR-073.
+ */
+const SAGA_AUTO_CLOSE_GATES: ReadonlyArray<VerificationGate> = [
+  'implemented',
+  'testsPassed',
+  'qaPassed',
+  'cleanupDone',
+  'securityPassed',
+  'documented',
+] as const;
+
+/**
+ * Synthesize a {@link TaskVerification} envelope for an auto-closing saga.
+ *
+ * A saga's status flips to `done` as a side-effect of the last pending
+ * member completing. Sagas never run their own evidence pipeline (their
+ * scope is delivered by member Epics), so the auto-close path needs to
+ * fabricate a verification record that:
+ *
+ *   1. Points back at the closing trigger
+ *      (`note:saga-auto-close-via-completeTask`).
+ *   2. Names every terminal member so an auditor can reconstruct the
+ *      rollup without re-walking the relation table
+ *      (`note:members:<csv>`).
+ *   3. Cites the ADR that authorises the synthesis path
+ *      (`note:adr:ADR-073 §1.2 invariants I3+I5`).
+ *
+ * Each standard gate receives the same three-atom envelope. `passed=true`
+ * is set unconditionally — the caller has already verified that every
+ * member is terminal (`done` or `cancelled`) before entering this path.
+ *
+ * @param sagaId - The saga task ID being auto-closed.
+ * @param memberIds - Member Epic IDs that delivered the saga's scope
+ *   (terminal or cancelled). Order is preserved verbatim in the `members`
+ *   note atom so the audit row is stable across re-runs.
+ * @param now - ISO-8601 timestamp captured by the caller (kept consistent
+ *   with the rest of the completion path's `now` stamp).
+ * @returns A fully-populated {@link TaskVerification} ready for upsert.
+ *
+ * @task T10116
+ * @epic T10210
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+export function buildSagaAutoCloseEvidence(
+  sagaId: string,
+  memberIds: readonly string[],
+  now: string,
+): TaskVerification {
+  const memberCsv = memberIds.join(',');
+
+  /**
+   * Build the three-atom envelope shared by every gate. The atoms
+   * preserve the closing event, the member rollup digest, and the ADR
+   * citation so a future doctor audit can re-verify the synthesis.
+   */
+  function makeGateEvidence(gate: VerificationGate): GateEvidence {
+    return {
+      atoms: [
+        { kind: 'note', note: `saga-auto-close-via-completeTask:${sagaId}:${gate}` },
+        { kind: 'note', note: `members:${memberCsv}` },
+        { kind: 'note', note: 'adr:ADR-073 §1.2 invariants I3+I5' },
+      ],
+      capturedAt: now,
+      capturedBy: 'system:saga-auto-close',
+    };
+  }
+
+  const evidence: Partial<Record<VerificationGate, GateEvidence>> = {};
+  for (const gate of SAGA_AUTO_CLOSE_GATES) {
+    evidence[gate] = makeGateEvidence(gate);
+  }
+
+  return {
+    round: 1,
+    passed: true,
+    gates: {
+      implemented: true,
+      testsPassed: true,
+      qaPassed: true,
+      cleanupDone: true,
+      securityPassed: true,
+      documented: true,
+    },
+    evidence,
+    lastAgent: null,
+    lastUpdated: now,
+    failureLog: [],
+    initializedAt: now,
+  } satisfies TaskVerification;
 }

--- a/packages/core/src/tasks/__tests__/complete-saga-autoclose.test.ts
+++ b/packages/core/src/tasks/__tests__/complete-saga-autoclose.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Regression tests for the T10116 saga auto-close branch inside
+ * {@link completeTask}.
+ *
+ * Validates that when a saga member transitions to `done`, the completion
+ * path:
+ *
+ *   - Auto-closes any saga whose remaining members are all terminal
+ *     (`done` or `cancelled`).
+ *   - Resolves saga members via `task_relations.type='groups'` rather
+ *     than the `parentId` column (ADR-073 §1.2 invariants I3/I5).
+ *   - Synthesizes a verification envelope citing the closing event,
+ *     the member rollup digest, and ADR-073.
+ *   - Stays idempotent — a saga that is already `done` MUST NOT be
+ *     re-touched on subsequent completeTask calls.
+ *
+ * Historical regression fixtures (T9787, T9800, T9831) all manifested
+ * the T10090 drift bug — their sagas had every member done but the
+ * saga row itself stayed `pending`. T10116 is the root-cause fix.
+ *
+ * @task T10116 — saga auto-close in completeTask
+ * @task T10090 — saga drift bug (root-cause fixed here)
+ * @epic T10210 — E-SAGA-AUTO-CLOSE
+ * @saga T10113 — SG-SAGA-FIRST-CLASS
+ * @see ADR-073-above-epic-naming.md §1.2
+ */
+
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SAGA_GROUPS_RELATION } from '../../sagas/constants.js';
+import { createTestDb, seedTasks, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { resetDbState } from '../../store/sqlite.js';
+import { completeTask } from '../complete.js';
+
+describe('completeTask — saga auto-close (T10116)', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  const writeConfig = async (config: Record<string, unknown>): Promise<void> => {
+    await writeFile(join(env.cleoDir, 'config.json'), JSON.stringify(config));
+  };
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+    await writeConfig({
+      enforcement: {
+        session: { requiredForMutate: false },
+        acceptance: { mode: 'off' },
+      },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    });
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  it('auto-closes a saga when its last member completes (T9800 fixture)', async () => {
+    // Saga TS-T9800 groups three member Epics. Two are already done; the
+    // third (TM-E3) is the last pending member. Completing TM-E3 should
+    // flip the saga to `done` with synthesized evidence atoms.
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'TS-T9800',
+        title: 'SG-WORKTREE-CANON',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TM-E1',
+        title: 'Member Epic 1',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        createdAt: now,
+        completedAt: now,
+      },
+      {
+        id: 'TM-E2',
+        title: 'Member Epic 2',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        createdAt: now,
+        completedAt: now,
+      },
+      {
+        id: 'TM-E3',
+        title: 'Last pending member',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+    ]);
+    await accessor.addRelation('TS-T9800', 'TM-E1', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-T9800', 'TM-E2', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-T9800', 'TM-E3', SAGA_GROUPS_RELATION);
+
+    const result = await completeTask({ taskId: 'TM-E3' }, env.tempDir, accessor);
+
+    expect(result.task.status).toBe('done');
+    expect(result.autoCompleted).toContain('TS-T9800');
+
+    // Re-load the saga from the DB and assert the on-disk state.
+    const saga = await accessor.loadSingleTask('TS-T9800');
+    expect(saga?.status).toBe('done');
+    expect(saga?.completedAt).toBeDefined();
+    expect(saga?.pipelineStage).toBe('contribution');
+
+    // AC4 — synthesized evidence carries the three required atoms.
+    const evidence = saga?.verification?.evidence?.implemented;
+    expect(evidence?.atoms).toBeDefined();
+    const atomNotes = (evidence?.atoms ?? []).map((a) => a.note);
+    expect(atomNotes.some((n) => n?.startsWith('saga-auto-close-via-completeTask:'))).toBe(true);
+    expect(atomNotes.some((n) => n?.startsWith('members:'))).toBe(true);
+    expect(atomNotes.some((n) => n === 'adr:ADR-073 §1.2 invariants I3+I5')).toBe(true);
+    expect(evidence?.capturedBy).toBe('system:saga-auto-close');
+  });
+
+  it('auto-closes a saga with cancelled members in the rollup (T9831 fixture)', async () => {
+    // Saga TS-T9831 has two done members + one cancelled member + one
+    // last pending member. The auto-close path treats `cancelled` as
+    // terminal so completing the last pending member fires the rollup.
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'TS-T9831',
+        title: 'SG-ARCH-SOLID',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TM-A1',
+        title: 'Member A1',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        createdAt: now,
+        completedAt: now,
+      },
+      {
+        id: 'TM-A2',
+        title: 'Member A2 (cancelled)',
+        type: 'epic',
+        status: 'cancelled',
+        priority: 'high',
+        createdAt: now,
+        cancelledAt: now,
+      },
+      {
+        id: 'TM-A3',
+        title: 'Member A3',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        createdAt: now,
+        completedAt: now,
+      },
+      {
+        id: 'TM-A4',
+        title: 'Last pending member',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+    ]);
+    await accessor.addRelation('TS-T9831', 'TM-A1', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-T9831', 'TM-A2', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-T9831', 'TM-A3', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-T9831', 'TM-A4', SAGA_GROUPS_RELATION);
+
+    const result = await completeTask({ taskId: 'TM-A4' }, env.tempDir, accessor);
+    expect(result.autoCompleted).toContain('TS-T9831');
+
+    const saga = await accessor.loadSingleTask('TS-T9831');
+    expect(saga?.status).toBe('done');
+  });
+
+  it('does NOT auto-close when a non-current member is still pending (mixed-state guard)', async () => {
+    // Two members are pending. Completing one of them MUST NOT flip the
+    // saga — the other member still blocks rollup. The completing
+    // task's own status flips as usual.
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'TS-MIX',
+        title: 'SG-MIXED-STATE',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TM-X1',
+        title: 'Done member',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        createdAt: now,
+        completedAt: now,
+      },
+      {
+        id: 'TM-X2',
+        title: 'Still pending — blocks rollup',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+      {
+        id: 'TM-X3',
+        title: 'Completing now',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+    ]);
+    await accessor.addRelation('TS-MIX', 'TM-X1', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-MIX', 'TM-X2', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-MIX', 'TM-X3', SAGA_GROUPS_RELATION);
+
+    const result = await completeTask({ taskId: 'TM-X3' }, env.tempDir, accessor);
+    expect(result.task.status).toBe('done');
+    expect(result.autoCompleted ?? []).not.toContain('TS-MIX');
+
+    const saga = await accessor.loadSingleTask('TS-MIX');
+    expect(saga?.status).toBe('pending');
+  });
+
+  it('is idempotent — re-running completeTask on a sibling does not re-touch an already-done saga', async () => {
+    // Saga has every member done EXCEPT the current target. Completing
+    // it flips the saga once. A subsequent re-attempt on a separate
+    // member (which is already done) MUST be rejected by the
+    // already-completed guard without re-touching the saga.
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'TS-IDEM',
+        title: 'SG-IDEMPOTENCY',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TM-I1',
+        title: 'Already done',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        createdAt: now,
+        completedAt: now,
+      },
+      {
+        id: 'TM-I2',
+        title: 'Last member',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+    ]);
+    await accessor.addRelation('TS-IDEM', 'TM-I1', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-IDEM', 'TM-I2', SAGA_GROUPS_RELATION);
+
+    // First completion fires the saga auto-close.
+    const first = await completeTask({ taskId: 'TM-I2' }, env.tempDir, accessor);
+    expect(first.autoCompleted).toContain('TS-IDEM');
+    const sagaAfterFirst = await accessor.loadSingleTask('TS-IDEM');
+    expect(sagaAfterFirst?.status).toBe('done');
+    const completedAtAfterFirst = sagaAfterFirst?.completedAt;
+
+    // Second attempt on the same task MUST raise 'already completed' —
+    // proving the saga auto-close path is not re-entered for a no-op
+    // call. The saga's completedAt stamp MUST be unchanged.
+    await expect(completeTask({ taskId: 'TM-I2' }, env.tempDir, accessor)).rejects.toThrow(
+      'already completed',
+    );
+    const sagaAfterSecond = await accessor.loadSingleTask('TS-IDEM');
+    expect(sagaAfterSecond?.status).toBe('done');
+    expect(sagaAfterSecond?.completedAt).toBe(completedAtAfterFirst);
+  });
+
+  it('auto-closes multiple sagas in a single completion when the same task is a member of several', async () => {
+    // The completing task is a member of TWO sagas. Both have every
+    // other member done. Completing this task MUST flip BOTH sagas in
+    // the same transaction.
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'TS-MULT-A',
+        title: 'SG-A',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TS-MULT-B',
+        title: 'SG-B',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+      },
+      {
+        id: 'TM-SHARED',
+        title: 'Member of both sagas',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+      {
+        id: 'TM-A-OTHER',
+        title: 'Other member of SG-A',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        createdAt: now,
+        completedAt: now,
+      },
+      {
+        id: 'TM-B-OTHER',
+        title: 'Other member of SG-B',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        createdAt: now,
+        completedAt: now,
+      },
+    ]);
+    await accessor.addRelation('TS-MULT-A', 'TM-SHARED', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-MULT-A', 'TM-A-OTHER', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-MULT-B', 'TM-SHARED', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-MULT-B', 'TM-B-OTHER', SAGA_GROUPS_RELATION);
+
+    const result = await completeTask({ taskId: 'TM-SHARED' }, env.tempDir, accessor);
+    expect(result.autoCompleted).toEqual(expect.arrayContaining(['TS-MULT-A', 'TS-MULT-B']));
+
+    const sagaA = await accessor.loadSingleTask('TS-MULT-A');
+    const sagaB = await accessor.loadSingleTask('TS-MULT-B');
+    expect(sagaA?.status).toBe('done');
+    expect(sagaB?.status).toBe('done');
+  });
+
+  it('skips a saga whose status is already terminal (done)', async () => {
+    // Saga is already `done`. Completing a still-pending sibling MUST
+    // NOT re-touch the saga (no double-write, no audit churn).
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'TS-DONE',
+        title: 'Already-done saga',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        labels: ['saga'],
+        createdAt: now,
+        completedAt: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: 'TM-D1',
+        title: 'Member D1',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        createdAt: now,
+        completedAt: now,
+      },
+      {
+        id: 'TM-D2',
+        title: 'Member D2 — still pending',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+    ]);
+    await accessor.addRelation('TS-DONE', 'TM-D1', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-DONE', 'TM-D2', SAGA_GROUPS_RELATION);
+
+    const result = await completeTask({ taskId: 'TM-D2' }, env.tempDir, accessor);
+    expect(result.autoCompleted ?? []).not.toContain('TS-DONE');
+
+    const saga = await accessor.loadSingleTask('TS-DONE');
+    expect(saga?.status).toBe('done');
+    // completedAt MUST be the original timestamp — proving the saga was
+    // not re-written on this call.
+    expect(saga?.completedAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('is a no-op when the completing task is not a saga member', async () => {
+    // A regular epic + child task with no saga relation MUST behave
+    // exactly as before — no extra DB reads / writes on the saga path.
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'T-PLAIN',
+        title: 'Plain task — no saga membership',
+        type: 'task',
+        status: 'pending',
+        priority: 'medium',
+        createdAt: now,
+      },
+    ]);
+
+    const result = await completeTask({ taskId: 'T-PLAIN' }, env.tempDir, accessor);
+    expect(result.task.status).toBe('done');
+    expect(result.autoCompleted).toBeUndefined();
+  });
+});

--- a/packages/core/src/tasks/__tests__/task-engine.test.ts
+++ b/packages/core/src/tasks/__tests__/task-engine.test.ts
@@ -154,6 +154,11 @@ function makeCompletableAccessorMock(opts: {
     getDependents: vi.fn().mockResolvedValue([]),
     transaction: vi.fn(async (fn: (tx: typeof tx) => Promise<unknown>) => fn(tx)),
     updateTaskFields,
+    // T10116: completeTask now scans the saga catalog via queryTasks to drive
+    // the auto-close branch. The mock returns an empty saga list so the
+    // post-coordination-parent loop is a no-op for these legacy fixtures.
+    queryTasks: vi.fn().mockResolvedValue({ tasks: [], total: 0 }),
+    loadTasks: vi.fn().mockResolvedValue([]),
   };
 }
 

--- a/packages/core/src/tasks/complete.ts
+++ b/packages/core/src/tasks/complete.ts
@@ -13,6 +13,7 @@ import { CleoError } from '../errors.js';
 import { getIvtrState, type IvtrPhase } from '../lifecycle/ivtr-loop.js';
 import { getLogger } from '../logger.js';
 import { getProjectRoot, resolveOrCwd } from '../paths.js';
+import { buildSagaAutoCloseEvidence, findSagasGroupingTask } from '../sagas/storage.js';
 import { wrapWithAgentSession } from '../sessions/agent-session-adapter.js';
 import { requireActiveSession } from '../sessions/session-enforcement.js';
 import type { DataAccessor } from '../store/data-accessor.js';
@@ -595,6 +596,82 @@ export async function completeTask(
             }
           }
         }
+      }
+
+      // T10116: Saga auto-close (mirrors epic auto-close lines ~480-541).
+      //
+      // Sagas (`label='saga'` epics, ADR-073 §1.2) link to their member
+      // Epics via `task_relations.type='groups'` instead of `parentId`. The
+      // existing epic + coordination-parent branches above only walk the
+      // `parentId` column, so a saga whose member just completed would stay
+      // `pending` forever — the T10090 drift bug class (T9787, T9800,
+      // T9831 all manifested this way).
+      //
+      // This branch fires whenever the completing task is a member of one
+      // or more sagas. For each saga that groups this task:
+      //   1. Skip if the saga is already terminal (idempotency).
+      //   2. Skip if we have already queued it on this `completeTask` call.
+      //   3. Resolve member IDs via the saga's populated `relates` array.
+      //   4. Auto-close only when EVERY non-cancelled member is terminal
+      //      (`done` or `cancelled`), treating the current task as `done`
+      //      because its DB write happens immediately after this branch.
+      //   5. Synthesize a verification envelope citing the closing event,
+      //      the member rollup digest, and ADR-073 (AC4).
+      //
+      // The saga loop runs after the coordination-parent branch so a task
+      // that is BOTH a coordination-parent child AND a saga member rolls
+      // both up in a single call. Each saga is appended to the same
+      // `autoCompletedTasks` list so the transaction below upserts every
+      // synthesized close in one commit.
+      const sagasGroupingThisTask = await findSagasGroupingTask(acc, task.id);
+      for (const saga of sagasGroupingThisTask) {
+        if (saga.status === 'done' || saga.status === 'cancelled') continue;
+        if (autoCompleted.includes(saga.id)) continue;
+
+        // Resolve member IDs directly from the saga's populated `relates`
+        // array — `findSagasGroupingTask` already loaded it via
+        // `queryTasks`, so we avoid an extra `resolveSagaMemberIds` call.
+        const memberIds: string[] = [];
+        const seen = new Set<string>();
+        for (const relation of saga.relates ?? []) {
+          if (relation.type !== 'groups') continue;
+          if (seen.has(relation.taskId)) continue;
+          seen.add(relation.taskId);
+          memberIds.push(relation.taskId);
+        }
+        if (memberIds.length === 0) continue;
+
+        const memberTasks = await acc.loadTasks(memberIds);
+        // Overlay the current task as `done` so the rollup check sees the
+        // post-write state without a DB round-trip — same approach used by
+        // the epic auto-close branch above.
+        const allMembersTerminal = memberTasks.every((m) => {
+          if (m.id === task.id) return true;
+          return m.status === 'done' || m.status === 'cancelled';
+        });
+        // Guard: require we actually loaded every member ID we expected.
+        // A member ID present on the saga's `relates` but missing from
+        // the DB (cascade-orphan) MUST block auto-close until reconciled.
+        if (memberTasks.length !== memberIds.length) continue;
+        if (!allMembersTerminal) continue;
+
+        // Synthesize evidence + flip the saga to terminal. The saga write
+        // joins `autoCompletedTasks` so the transaction below upserts it
+        // alongside the current task and any epic / coordination-parent
+        // that also rolled up.
+        const terminalMemberIds = memberTasks
+          .filter((m) => m.id === task.id || m.status === 'done' || m.status === 'cancelled')
+          .map((m) => m.id);
+        saga.verification = buildSagaAutoCloseEvidence(saga.id, terminalMemberIds, now);
+        saga.status = 'done';
+        saga.completedAt = now;
+        saga.updatedAt = now;
+        // T871: keep `pipelineStage` aligned with `status='done'`.
+        if (!isTerminalPipelineStage(saga.pipelineStage)) {
+          saga.pipelineStage = 'contribution';
+        }
+        autoCompleted.push(saga.id);
+        autoCompletedTasks.push(saga);
       }
 
       // Wrap writes in a transaction for TOCTOU safety (T023)


### PR DESCRIPTION
## Summary

Integrates saga auto-close into completeTask() — mirrors epic auto-close at
complete.ts:498-539 but uses task_relations.type='groups' for member resolution.
Root-cause fix for the T10090 auto-close drift bug.

## Affected sagas (auto-close as side-effect after merge + first mutation)

- T9787 (10 members done, status=pending — closes once T9790 mutates again)
- T9800 (members all done, status=pending)
- T9831 (members all done, status=pending)

## Test plan

- [x] biome / build / vitest
- [x] T9800/T9831 regression fixtures
- [x] Idempotency: re-run completeTask is no-op on done sagas
- [x] Dogfood verified via cleo saga rollup

Closes T10116; Saga T10113; Epic T10210.