### PR TITLE
feat(T10105): release plan fail-loud YAML + always-write CHANGELOG + gh schema (Saga T10099)

### DIFF
--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -519,3 +519,74 @@ export function isErrorResult(result: {
 }): result is { success: false; error: string } {
   return !result.success;
 }
+
+/**
+ * Structured details payload attached to {@link ChangesetYamlInvalidError}.
+ *
+ * Carries the offending file path, the 1-based line number where the YAML
+ * parser bailed (when determinable), and an optional snippet of the parsed
+ * region to surface in CLI output and CI logs.
+ *
+ * @task T10105
+ * @epic E-RELEASE-PLAN-CHANGELOG
+ */
+export interface ChangesetYamlInvalidDetails {
+  /** Absolute or process-relative path to the offending `.md` file. */
+  file: string;
+  /** 1-based line number reported by the YAML parser; `null` when unknown. */
+  line: number | null;
+  /** Optional short excerpt around the failure (≤ 120 chars). */
+  snippet?: string;
+  /** Underlying parser message, propagated verbatim for diagnostics. */
+  parserMessage: string;
+}
+
+/**
+ * Thrown when `cleo release plan` (or the lint script) encounters a `.changeset/*.md`
+ * file whose YAML frontmatter cannot be parsed.
+ *
+ * Replaces the pre-T10105 silent-skip behaviour where a single malformed
+ * file (e.g. an unquoted colon in `summary:`) caused the aggregator to
+ * silently drop ALL changeset entries for that release. The v2026.5.100
+ * ship lost the v5.100/v5.101/v5.103 CHANGELOG entries to exactly this
+ * vector — see Saga T10099 SG-RELEASE-AUDIT-V2.
+ *
+ * @remarks
+ * Carries `exitCode` aligned with {@link ExitCode.VALIDATION_ERROR} (6) so
+ * the CLI surfaces a deterministic non-zero exit when invoked from CI.
+ *
+ * @example
+ * ```typescript
+ * throw new ChangesetYamlInvalidError({
+ *   file: '.changeset/bad.md',
+ *   line: 4,
+ *   parserMessage: 'Nested mappings are not allowed in compact mappings',
+ * });
+ * ```
+ *
+ * @task T10105
+ * @epic E-RELEASE-PLAN-CHANGELOG
+ * @saga T10099
+ */
+export class ChangesetYamlInvalidError extends Error {
+  /** Stable LAFS error code string for envelope emission. */
+  readonly code = 'E_CHANGESET_YAML_INVALID';
+  /** Numeric exit code aligned with {@link ExitCode.VALIDATION_ERROR} (6). */
+  readonly exitCode: ExitCode = ExitCode.VALIDATION_ERROR;
+  /** Structured payload describing the offending file + location. */
+  readonly details: ChangesetYamlInvalidDetails;
+
+  /**
+   * @param details - Structured failure context including file path and
+   *   line number. The constructor builds a deterministic human-readable
+   *   message of the form `<file>:<line> invalid YAML frontmatter: <msg>`.
+   */
+  constructor(details: ChangesetYamlInvalidDetails) {
+    const linePart = details.line !== null ? `:${details.line}` : '';
+    super(
+      `E_CHANGESET_YAML_INVALID: ${details.file}${linePart} invalid YAML frontmatter: ${details.parserMessage}`,
+    );
+    this.name = 'ChangesetYamlInvalidError';
+    this.details = details;
+  }
+}

--- a/packages/contracts/src/exit-codes.ts
+++ b/packages/contracts/src/exit-codes.ts
@@ -267,6 +267,19 @@ export const E_PLAN_NOT_FOUND = 'E_PLAN_NOT_FOUND' as const;
 /** Generic release-plan validation failure (e.g. schema). Exit code 6. */
 export const E_RELEASE_PLAN_INVALID = 'E_RELEASE_PLAN_INVALID' as const;
 /**
+ * `cleo release plan` (or the lint script) encountered a `.changeset/*.md`
+ * file whose YAML frontmatter cannot be parsed. Exit code 6 (VALIDATION_ERROR).
+ *
+ * Replaces the pre-T10105 silent-skip that caused the v2026.5.100 ship to
+ * lose v5.100/v5.101/v5.103 CHANGELOG entries when a single changeset had
+ * an unquoted colon in `summary:`.
+ *
+ * @task T10105
+ * @epic E-RELEASE-PLAN-CHANGELOG
+ * @saga T10099
+ */
+export const E_CHANGESET_YAML_INVALID = 'E_CHANGESET_YAML_INVALID' as const;
+/**
  * Release row exists but is not in the status FSM state required by the
  * caller (R-051 — `cleo release open` requires status='planned'). Exit code 6.
  * `error.details.currentStatus` MUST report the actual status; `error.details.expectedStatus`

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -349,9 +349,10 @@ export {
   TASK_SEVERITIES,
   TASK_SIZES,
 } from './enums.js';
-export type { SagaInvariantErrorCode } from './errors.js';
+export type { ChangesetYamlInvalidDetails, SagaInvariantErrorCode } from './errors.js';
 // === Error Utilities ===
 export {
+  ChangesetYamlInvalidError,
   ClassifierUnregisteredAgentError,
   createErrorResult,
   createSuccessResult,
@@ -397,6 +398,8 @@ export {
 } from './evidence-record-schema.js';
 // === Exit Codes ===
 export {
+  // T10105 / Saga T10099 — fail-loud changeset parse
+  E_CHANGESET_YAML_INVALID,
   // SPEC-T9345 release pipeline v2 error code names (T9525)
   E_CHANNEL_MISMATCH,
   E_DIRTY_TREE,

--- a/packages/core/src/changesets/__tests__/parser.test.ts
+++ b/packages/core/src/changesets/__tests__/parser.test.ts
@@ -8,6 +8,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { ChangesetYamlInvalidError } from '@cleocode/contracts';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { parseChangesetDir, parseChangesetFile } from '../parser.js';
 
@@ -180,6 +181,46 @@ describe('parseChangesetFile', () => {
     );
 
     expect(() => parseChangesetFile(path)).toThrow(/does not match filename slug/);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // T10105 — fail-loud YAML parse (v2026.5.100 silent-skip repro)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('throws ChangesetYamlInvalidError when summary has an unquoted colon (v5.100 repro)', () => {
+    const path = writeEntry(
+      'v5100-repro.md',
+      [
+        '---',
+        'id: v5100-repro',
+        'tasks: [T1]',
+        'kind: feat',
+        'summary: feat(T1): unquoted colon eats the entry',
+        '---',
+      ].join('\n'),
+    );
+
+    let captured: unknown;
+    try {
+      parseChangesetFile(path);
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ChangesetYamlInvalidError);
+    const e = captured as ChangesetYamlInvalidError;
+    expect(e.code).toBe('E_CHANGESET_YAML_INVALID');
+    expect(e.details.file).toBe(path);
+    expect(e.details.line).toBeTypeOf('number');
+    expect(e.details.line).toBeGreaterThan(0);
+    expect(e.details.parserMessage).toMatch(/.+/);
+    expect(e.message).toMatch(/v5100-repro\.md/);
+    expect(e.message).toMatch(/invalid YAML frontmatter/);
+  });
+
+  it('throws ChangesetYamlInvalidError when frontmatter is structurally broken YAML', () => {
+    const path = writeEntry('broken-yaml.md', ['---', '  [unmatched: bracket', '---'].join('\n'));
+
+    expect(() => parseChangesetFile(path)).toThrow(ChangesetYamlInvalidError);
   });
 });
 

--- a/packages/core/src/changesets/parser.ts
+++ b/packages/core/src/changesets/parser.ts
@@ -17,8 +17,51 @@
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
-import { type ChangesetEntry, ChangesetEntrySchema } from '@cleocode/contracts';
+import {
+  type ChangesetEntry,
+  ChangesetEntrySchema,
+  ChangesetYamlInvalidError,
+} from '@cleocode/contracts';
 import { parse as parseYaml } from 'yaml';
+
+// ─── YAML error introspection (T10105) ───────────────────────────────────────
+
+/**
+ * Extract the 1-based line number from a `yaml@2.x` YAMLParseError.
+ *
+ * The error carries `linePos: [{line, col}, ...]` when the parser localised
+ * the failure; returns `null` for non-localised errors or non-YAMLParseError
+ * exceptions.
+ *
+ * @internal
+ * @task T10105
+ */
+function extractYamlLine(err: unknown): number | null {
+  if (err === null || typeof err !== 'object') return null;
+  const linePos = (err as { linePos?: unknown }).linePos;
+  if (!Array.isArray(linePos) || linePos.length === 0) return null;
+  const first = linePos[0];
+  if (first === null || typeof first !== 'object') return null;
+  const line = (first as { line?: unknown }).line;
+  return typeof line === 'number' ? line : null;
+}
+
+/**
+ * Extract a short snippet (≤ 120 chars) of the offending line for surface
+ * in CLI output. Returns `undefined` when the line is out of range so the
+ * error envelope omits the field rather than carrying an empty string.
+ *
+ * @internal
+ * @task T10105
+ */
+function extractSnippet(frontmatter: string, line: number): string | undefined {
+  const lines = frontmatter.split(/\r?\n/);
+  // YAML line numbers are 1-based; arrays are 0-based.
+  const target = lines[line - 1];
+  if (target === undefined) return undefined;
+  const trimmed = target.length > 120 ? `${target.slice(0, 117)}...` : target;
+  return trimmed;
+}
 
 // ─── Frontmatter splitting ────────────────────────────────────────────────────
 
@@ -98,8 +141,22 @@ export function parseChangesetFile(path: string): ChangesetEntry {
   try {
     frontmatterData = parseYaml(split.frontmatter);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`${path}:${split.frontmatterStartLine} invalid YAML frontmatter: ${msg}`);
+    const parserMessage = err instanceof Error ? err.message : String(err);
+    // T10105: surface the offending line. yaml@2.x sets `linePos[0].line` on
+    // YAMLParseError; fall back to the frontmatter opening fence (line 1)
+    // when the parser did not localize the failure.
+    const yamlLine = extractYamlLine(err);
+    // Frontmatter starts on line AFTER the opening `---` fence. The reported
+    // YAML line is relative to the frontmatter substring; add the offset so
+    // the surfaced line number matches the actual file line.
+    const line = yamlLine !== null ? split.frontmatterStartLine + yamlLine : null;
+    const snippet = yamlLine !== null ? extractSnippet(split.frontmatter, yamlLine) : undefined;
+    throw new ChangesetYamlInvalidError({
+      file: path,
+      line,
+      ...(snippet !== undefined ? { snippet } : {}),
+      parserMessage,
+    });
   }
 
   if (frontmatterData === null || typeof frontmatterData !== 'object') {

--- a/packages/core/src/release/__tests__/aggregator-ssot-first.test.ts
+++ b/packages/core/src/release/__tests__/aggregator-ssot-first.test.ts
@@ -151,16 +151,16 @@ describe('readChangesetsSsotFirst', () => {
     expect(aggregated).toEqual([]);
   });
 
-  it('tolerates a malformed file in the directory by skipping the whole file batch', async () => {
-    // Write one valid file alongside one structurally-broken file.
+  it('propagates parser failures (T10105 fail-loud)', async () => {
+    // Write one valid file alongside one structurally-broken file. Per
+    // T10105 (Saga T10099) the aggregator NO LONGER silently swallows
+    // parse errors — they propagate so `cleo release plan` can abort
+    // with `E_CHANGESET_YAML_INVALID` instead of dropping CHANGELOG
+    // entries the way the v2026.5.100 ship did.
     writeFileOnly('t9793-valid', renderMinimal('t9793-valid', ['T9793'], 'Survives.'));
     writeFileOnly('t9793-broken', '--- this is not a valid YAML frontmatter document at all');
 
-    // The aggregator MUST not throw. It skips the whole file batch on
-    // parser failure (the lint gate surfaces specific errors at PR time)
-    // and returns whatever SSoT had (here: empty).
-    const aggregated = await readChangesetsSsotFirst(projectRoot);
-    expect(Array.isArray(aggregated)).toBe(true);
+    await expect(readChangesetsSsotFirst(projectRoot)).rejects.toThrow();
   });
 });
 

--- a/packages/core/src/release/__tests__/open.test.ts
+++ b/packages/core/src/release/__tests__/open.test.ts
@@ -248,7 +248,12 @@ describe('releaseOpen — happy path', () => {
     const dispatched = runner.calls.find((c) => c.args[0] === 'workflow' && c.args[1] === 'run');
     expect(dispatched).toBeDefined();
     expect(dispatched?.args).toContain(`version=${version}`);
-    expect(dispatched?.args.some((a) => a.startsWith('plan-blob-sha256='))).toBe(true);
+    // T10105: `plan-blob-sha256` is NO LONGER passed as a workflow field
+    // because the release-prepare.yml workflow_dispatch.inputs block does
+    // not declare it (GitHub returns HTTP 422 for unknown fields). The
+    // sha256 is still computed and returned in the result envelope for
+    // downstream provenance tracking — see `planBlobSha256` assertion above.
+    expect(dispatched?.args.some((a) => a.startsWith('plan-blob-sha256='))).toBe(false);
 
     // releases row updated
     const db = await getDb(testDir);

--- a/packages/core/src/release/__tests__/plan-saga-leaf-changelog.test.ts
+++ b/packages/core/src/release/__tests__/plan-saga-leaf-changelog.test.ts
@@ -588,9 +588,11 @@ describe('releasePlan writes CHANGELOG.md (T9838 Fix 3)', () => {
     expect(existsSync(result.data.changelogPath)).toBe(false);
   });
 
-  it('skips the CHANGELOG write when aggregated release notes are empty', async () => {
-    // No `.changeset/` entries → aggregated.markdown is empty → CHANGELOG
-    // remains untouched even with writeChangelog=true (default).
+  it('writes a placeholder CHANGELOG section when aggregated release notes are empty (T10105)', async () => {
+    // No `.changeset/` entries → aggregated.markdown is empty. Per T10105
+    // (Saga T10099 AC2/AC3) the section MUST still be written with a
+    // placeholder body — the pre-T10105 silent-skip caused the v2026.5.100
+    // ship to drop CHANGELOG entries for v5.100/v5.101/v5.103.
     await seedEpicWithChildren('T9999', 1);
 
     const result = await releasePlan({
@@ -602,8 +604,11 @@ describe('releasePlan writes CHANGELOG.md (T9838 Fix 3)', () => {
     });
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
-    expect(result.data.changelogWritten).toBe(false);
-    expect(existsSync(result.data.changelogPath)).toBe(false);
+    expect(result.data.changelogWritten).toBe(true);
+    expect(existsSync(result.data.changelogPath)).toBe(true);
+    const body = readFileSync(result.data.changelogPath, 'utf8');
+    expect(body).toMatch(/^## \[2026\.6\.0\] \(\d{4}-\d{2}-\d{2}\)/m);
+    expect(body).toMatch(/No changeset entries parsed for this release/);
   });
 
   it('preserves unrelated sections when inserting the new ## [version] block', async () => {

--- a/packages/core/src/release/__tests__/release-open-field-schema.test.ts
+++ b/packages/core/src/release/__tests__/release-open-field-schema.test.ts
@@ -1,0 +1,271 @@
+/**
+ * T10105 — keep `cleo release open --field` lockstep with
+ * `.github/workflows/release-prepare.yml workflow_dispatch.inputs`.
+ *
+ * The pre-T10105 implementation passed a `plan-blob-sha256` field that the
+ * workflow does not declare; the GitHub Actions API rejects unknown
+ * inputs with HTTP 422 "Unexpected inputs provided". This test parses
+ * both the YAML and the runtime call list and asserts they agree.
+ *
+ * Failure modes covered:
+ *   - YAML declares an input not passed by `cleo release open` → MISSING.
+ *   - `cleo release open` passes a `--field foo=bar` whose key is not in
+ *     the YAML → EXTRA.
+ *
+ * @task T10105
+ * @epic E-RELEASE-PLAN-CHANGELOG
+ * @saga T10099
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import type { ReleasePlan } from '@cleocode/contracts';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+import { closeDb, getDb, resetDbState } from '../../store/sqlite.js';
+import * as schema from '../../store/tasks-schema.js';
+import { DEFAULT_OPEN_WORKFLOW, type ReleaseOpenRunner, releaseOpen } from '../open.js';
+
+let testDir: string;
+
+// Canonical path to release-prepare.yml in the actual repo. Resolved from
+// __dirname so the test works in any cwd.
+const REPO_WORKFLOW_PATH = resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  '.github',
+  'workflows',
+  'release-prepare.yml',
+);
+
+function readWorkflowInputs(): string[] {
+  const raw = readFileSync(REPO_WORKFLOW_PATH, 'utf8');
+  const parsed = parseYaml(raw) as {
+    on?: { workflow_dispatch?: { inputs?: Record<string, unknown> } };
+  };
+  const inputs = parsed.on?.workflow_dispatch?.inputs;
+  if (inputs === undefined || inputs === null) return [];
+  return Object.keys(inputs);
+}
+
+function makePlan(version: string): ReleasePlan {
+  const nowIso = new Date().toISOString();
+  return {
+    $schema: 'https://cleocode.io/schemas/release-plan/v1.json',
+    version,
+    resolvedVersion: version,
+    suffixApplied: false,
+    scheme: 'calver',
+    channel: 'latest',
+    epicId: 'T9999',
+    releaseKind: 'regular',
+    createdAt: nowIso,
+    createdBy: 'test',
+    previousVersion: null,
+    previousTag: null,
+    previousShippedAt: null,
+    tasks: [
+      {
+        id: 'T10001',
+        kind: 'feat',
+        impact: 'minor',
+        userFacingSummary: 'Test feature',
+        evidenceAtoms: ['commit:abc1234567'],
+        epicAncestor: 'T9999',
+      },
+    ],
+    changelog: { features: ['T10001'], fixes: [], chores: [], breaking: [] },
+    gates: [
+      { name: 'test', atom: 'tool:test', status: 'passed', lastVerifiedAt: nowIso },
+      { name: 'build', atom: 'tool:build', status: 'passed', lastVerifiedAt: nowIso },
+      { name: 'lint', atom: 'tool:lint', status: 'passed', lastVerifiedAt: nowIso },
+      { name: 'typecheck', atom: 'tool:typecheck', status: 'passed', lastVerifiedAt: nowIso },
+      { name: 'audit', atom: 'tool:audit', status: 'skipped', lastVerifiedAt: nowIso },
+      {
+        name: 'security-scan',
+        atom: 'tool:security-scan',
+        status: 'skipped',
+        lastVerifiedAt: nowIso,
+      },
+    ],
+    platformMatrix: [{ platform: 'any', publisher: 'npm', package: '@cleocode/cleo' }],
+    preflightSummary: {
+      esbuildExternalsDrift: false,
+      lockfileDrift: false,
+      epicCompletenessClean: true,
+      doubleListingClean: true,
+      preflightWarnings: [],
+    },
+    workflowRunUrl: null,
+    prUrl: null,
+    mergeCommitSha: null,
+    status: 'planned',
+    meta: { firstEverRelease: true, archetype: 'node' },
+  };
+}
+
+function writePlanFile(version: string): string {
+  const releaseDir = join(testDir, '.cleo', 'release');
+  mkdirSync(releaseDir, { recursive: true });
+  const planPath = join(releaseDir, `${version}.plan.json`);
+  writeFileSync(planPath, `${JSON.stringify(makePlan(version), null, 2)}\n`, 'utf-8');
+  return planPath;
+}
+
+function writeStubWorkflow(): void {
+  const workflowDir = join(testDir, '.github', 'workflows');
+  mkdirSync(workflowDir, { recursive: true });
+  writeFileSync(
+    join(workflowDir, DEFAULT_OPEN_WORKFLOW),
+    'name: release-prepare\non: workflow_dispatch\njobs: {}\n',
+    'utf-8',
+  );
+}
+
+async function seedReleaseRow(version: string): Promise<void> {
+  const db = await getDb(testDir);
+  await db
+    .insert(schema.releases)
+    .values({
+      id: `testhash:${version}`,
+      version,
+      scheme: 'calver',
+      channel: 'latest',
+      epicId: null,
+      releaseKind: 'regular',
+      status: 'planned',
+      plannedAt: new Date().toISOString(),
+      projectHash: 'testhash',
+    })
+    .run();
+}
+
+function makeStubRunner(): ReleaseOpenRunner & {
+  calls: Array<{ cmd: string; args: readonly string[] }>;
+} {
+  const calls: Array<{ cmd: string; args: readonly string[] }> = [];
+  return {
+    calls,
+    checkGhAuth: () => {
+      calls.push({ cmd: 'gh', args: ['auth', 'status'] });
+      return true;
+    },
+    runGh: (args) => {
+      calls.push({ cmd: 'gh', args });
+      if (args[0] === 'workflow' && args[1] === 'run') return '';
+      if (args[0] === 'run' && args[1] === 'list') {
+        return JSON.stringify([
+          {
+            url: 'https://github.com/cleocode/cleo/actions/runs/12345',
+            databaseId: 12345,
+            status: 'in_progress',
+          },
+        ]);
+      }
+      return '';
+    },
+  };
+}
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'cleo-open-field-schema-'));
+  await mkdir(join(testDir, '.cleo'), { recursive: true });
+  writeFileSync(
+    join(testDir, '.cleo', 'config.json'),
+    JSON.stringify({
+      enforcement: { session: { requiredForMutate: false } },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+  writeFileSync(
+    join(testDir, '.cleo', 'project-info.json'),
+    JSON.stringify({
+      projectHash: 'testhash',
+      projectId: 'test-project-id',
+      projectRoot: testDir,
+      projectName: 'test',
+    }),
+  );
+  execFileSync('git', ['init', '--quiet', testDir], { encoding: 'utf-8' });
+  execFileSync('git', ['-C', testDir, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', testDir, 'config', 'user.name', 'Test']);
+  execFileSync('git', ['-C', testDir, 'config', 'commit.gpgsign', 'false']);
+  resetDbState();
+});
+
+afterEach(async () => {
+  try {
+    closeDb();
+  } catch {
+    /* best-effort */
+  }
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe('releaseOpen — workflow input schema parity (T10105)', () => {
+  it('release-prepare.yml declares exactly the `version` input', () => {
+    const inputs = readWorkflowInputs();
+    expect(inputs.sort()).toEqual(['version']);
+  });
+
+  it('`cleo release open` passes ONLY fields declared in the workflow YAML', async () => {
+    const version = 'v2026.6.0';
+    writePlanFile(version);
+    writeStubWorkflow();
+    await seedReleaseRow(version);
+
+    const runner = makeStubRunner();
+    const result = await releaseOpen({ version, projectRoot: testDir }, runner);
+    expect(result.success).toBe(true);
+
+    const dispatched = runner.calls.find((c) => c.args[0] === 'workflow' && c.args[1] === 'run');
+    expect(dispatched).toBeDefined();
+
+    // Collect every `--field key=val` pair.
+    const passedKeys: string[] = [];
+    if (dispatched) {
+      const args = dispatched.args;
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--field' && typeof args[i + 1] === 'string') {
+          const eq = (args[i + 1] as string).indexOf('=');
+          if (eq > 0) passedKeys.push((args[i + 1] as string).slice(0, eq));
+        }
+      }
+    }
+
+    const declaredKeys = readWorkflowInputs();
+
+    // EXTRA check — every key passed at runtime MUST be declared in YAML.
+    const extra = passedKeys.filter((k) => !declaredKeys.includes(k));
+    expect(extra).toEqual([]);
+
+    // MISSING check — every REQUIRED YAML input MUST be passed at runtime.
+    // (We assume `required: true` for every declared input today; if that
+    //  ever changes, refine to parse the per-key `required:` flag.)
+    const missing = declaredKeys.filter((k) => !passedKeys.includes(k));
+    expect(missing).toEqual([]);
+
+    // Belt-and-braces: `plan-blob-sha256` MUST NOT be passed (T10105
+    // regression lock — this was the v2026.5.100 silent-422 bug).
+    expect(passedKeys).not.toContain('plan-blob-sha256');
+
+    // The releases row was nevertheless updated — the dispatch succeeded.
+    const db = await getDb(testDir);
+    const rows = await db
+      .select()
+      .from(schema.releases)
+      .where(eq(schema.releases.version, version))
+      .all();
+    expect(rows[0]?.status).toBe('pr-opened');
+  });
+});

--- a/packages/core/src/release/__tests__/release-plan-always-changelog.test.ts
+++ b/packages/core/src/release/__tests__/release-plan-always-changelog.test.ts
@@ -1,0 +1,216 @@
+/**
+ * T10105 — `cleo release plan` MUST always write the CHANGELOG section.
+ *
+ * Pre-T10105 behaviour: when zero changeset entries parsed, the
+ * `writeChangelogSection` call was skipped (guarded by
+ * `aggregated.markdown.trim().length > 0`). Result: the v2026.5.100 ship
+ * never wrote a `## [v2026.5.100]` block to CHANGELOG.md, and the section
+ * appeared to "skip" straight from v5.102 → v5.99.
+ *
+ * Post-T10105 behaviour: the section is ALWAYS written. When the
+ * aggregator produced no content, a placeholder body is inserted instead
+ * + a WARN-level log explicitly states the empty-content reason.
+ *
+ * @task T10105
+ * @epic E-RELEASE-PLAN-CHANGELOG
+ * @saga T10099
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Task } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, resetDbState } from '../../store/sqlite.js';
+import { createSqliteDataAccessor } from '../../store/sqlite-data-accessor.js';
+import { releasePlan } from '../plan.js';
+
+let testDir: string;
+
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    title: overrides.title ?? `Task ${overrides.id}`,
+    description: overrides.description ?? `Description for ${overrides.id}`,
+    status: overrides.status ?? 'done',
+    priority: overrides.priority ?? 'medium',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    pipelineStage: overrides.pipelineStage ?? 'contribution',
+    verification: overrides.verification ?? {
+      passed: true,
+      round: 1,
+      gates: { implemented: true },
+      evidence: {
+        implemented: {
+          atoms: [{ kind: 'commit', sha: 'abc1234567', shortSha: 'abc1234' }],
+          capturedAt: new Date().toISOString(),
+          capturedBy: 'test-agent',
+        },
+      },
+      lastAgent: null,
+      lastUpdated: new Date().toISOString(),
+      failureLog: [],
+    },
+    ...overrides,
+  } as Task;
+}
+
+async function initTestGit(): Promise<void> {
+  execFileSync('git', ['init', '--quiet', testDir], { encoding: 'utf-8' });
+  execFileSync('git', ['-C', testDir, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', testDir, 'config', 'user.name', 'Test']);
+}
+
+async function seedEpicWithChild(epicId: string, childId: string): Promise<void> {
+  const accessor = await createSqliteDataAccessor(testDir);
+  try {
+    await accessor.setMetaValue('schema_version', '2.10.0');
+    await accessor.upsertSingleTask(
+      makeTask({ id: epicId, type: 'epic', title: 'Epic', pipelineStage: 'contribution' }),
+    );
+    await accessor.upsertSingleTask(makeTask({ id: childId, parentId: epicId }));
+  } finally {
+    await accessor.close();
+  }
+}
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'cleo-plan-always-cl-'));
+  await mkdir(join(testDir, '.cleo'), { recursive: true });
+  writeFileSync(
+    join(testDir, '.cleo', 'config.json'),
+    JSON.stringify({
+      enforcement: { session: { requiredForMutate: false } },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+  writeFileSync(
+    join(testDir, '.cleo', 'project-info.json'),
+    JSON.stringify({
+      projectHash: 'testhash00000',
+      projectId: 'test-project-id',
+      projectRoot: testDir,
+      projectName: 'test',
+    }),
+  );
+  await initTestGit();
+  resetDbState();
+});
+
+afterEach(async () => {
+  try {
+    closeDb();
+  } catch {
+    /* best-effort */
+  }
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe('releasePlan — always writes CHANGELOG.md section (T10105)', () => {
+  it('writes a placeholder section when ZERO changesets are present', async () => {
+    await seedEpicWithChild('T9999', 'T10001');
+    // Deliberately do NOT create `.changeset/` — exercises the path that
+    // pre-T10105 silently elided the CHANGELOG entry.
+
+    const result = await releasePlan({
+      version: 'v2026.5.100',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.changelogWritten).toBe(true);
+    expect(result.data.changesetEntryCount).toBe(0);
+
+    const changelogPath = join(testDir, 'CHANGELOG.md');
+    expect(existsSync(changelogPath)).toBe(true);
+    const body = readFileSync(changelogPath, 'utf8');
+    expect(body).toMatch(/^## \[2026\.5\.100\] \(\d{4}-\d{2}-\d{2}\)/m);
+    expect(body).toMatch(/No changeset entries parsed for this release/);
+  });
+
+  it('writes a placeholder section when the .changeset directory exists but is empty', async () => {
+    await seedEpicWithChild('T9999', 'T10001');
+    // Create the directory with only README.md so parseChangesetDir returns [].
+    await mkdir(join(testDir, '.changeset'), { recursive: true });
+    writeFileSync(join(testDir, '.changeset', 'README.md'), '# Empty\n', 'utf8');
+
+    const result = await releasePlan({
+      version: 'v2026.5.101',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.changelogWritten).toBe(true);
+
+    const body = readFileSync(join(testDir, 'CHANGELOG.md'), 'utf8');
+    expect(body).toMatch(/^## \[2026\.5\.101\] \(\d{4}-\d{2}-\d{2}\)/m);
+    expect(body).toMatch(/No changeset entries parsed for this release/);
+  });
+
+  it('writes real release notes when at least one changeset is present', async () => {
+    await seedEpicWithChild('T9999', 'T10001');
+    await mkdir(join(testDir, '.changeset'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.changeset', 'real-entry.md'),
+      [
+        '---',
+        'id: real-entry',
+        'tasks: [T10001]',
+        'kind: feat',
+        'prs: [123]',
+        'summary: Real feature shipped.',
+        '---',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = await releasePlan({
+      version: 'v2026.5.103',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.changelogWritten).toBe(true);
+    expect(result.data.changesetEntryCount).toBe(1);
+
+    const body = readFileSync(join(testDir, 'CHANGELOG.md'), 'utf8');
+    expect(body).toMatch(/^## \[2026\.5\.103\] \(\d{4}-\d{2}-\d{2}\)/m);
+    expect(body).toMatch(/Real feature shipped/);
+    // Placeholder must NOT be present when real entries exist.
+    expect(body).not.toMatch(/No changeset entries parsed for this release/);
+  });
+
+  it('honours writeChangelog=false (opt-out) and skips the write entirely', async () => {
+    await seedEpicWithChild('T9999', 'T10001');
+
+    const result = await releasePlan({
+      version: 'v2026.5.104',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      writeChangelog: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.changelogWritten).toBe(false);
+    expect(existsSync(join(testDir, 'CHANGELOG.md'))).toBe(false);
+  });
+});

--- a/packages/core/src/release/__tests__/release-plan-yaml-invalid.test.ts
+++ b/packages/core/src/release/__tests__/release-plan-yaml-invalid.test.ts
@@ -1,0 +1,215 @@
+/**
+ * T10105 — Vitest reproduction of the v2026.5.100 silent-skip bug.
+ *
+ * Pre-T10105 behaviour: a `.changeset/*.md` whose YAML frontmatter could
+ * not be parsed (e.g. an unquoted colon in `summary:`) caused
+ * `parseChangesetDir` to throw, which `readChangesetEntries` swallowed at
+ * WARN level + returned `[]`. The aggregator then emitted empty release
+ * notes, so the CHANGELOG.md section for that release was effectively
+ * skipped. v5.100 / v5.101 / v5.103 were all dropped this way.
+ *
+ * Post-T10105: `cleo release plan` ABORTS with
+ * `E_CHANGESET_YAML_INVALID`, surfaces the offending `file:line`, and
+ * never silently drops the batch.
+ *
+ * @task T10105
+ * @epic E-RELEASE-PLAN-CHANGELOG
+ * @saga T10099
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Task } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, resetDbState } from '../../store/sqlite.js';
+import { createSqliteDataAccessor } from '../../store/sqlite-data-accessor.js';
+import { releasePlan } from '../plan.js';
+
+let testDir: string;
+
+/**
+ * Build a Task with sensible defaults for plan-time evidence checks.
+ *
+ * Evidence atoms default to a single `commit:` atom on the `implemented`
+ * gate so the task passes the R-301 evidence-completeness check.
+ */
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    title: overrides.title ?? `Task ${overrides.id}`,
+    description: overrides.description ?? `Description for ${overrides.id}`,
+    status: overrides.status ?? 'done',
+    priority: overrides.priority ?? 'medium',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    pipelineStage: overrides.pipelineStage ?? 'contribution',
+    verification: overrides.verification ?? {
+      passed: true,
+      round: 1,
+      gates: { implemented: true },
+      evidence: {
+        implemented: {
+          atoms: [{ kind: 'commit', sha: 'abc1234567', shortSha: 'abc1234' }],
+          capturedAt: new Date().toISOString(),
+          capturedBy: 'test-agent',
+        },
+      },
+      lastAgent: null,
+      lastUpdated: new Date().toISOString(),
+      failureLog: [],
+    },
+    ...overrides,
+  } as Task;
+}
+
+async function initTestGit(): Promise<void> {
+  execFileSync('git', ['init', '--quiet', testDir], { encoding: 'utf-8' });
+  execFileSync('git', ['-C', testDir, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', testDir, 'config', 'user.name', 'Test']);
+}
+
+async function seedEpicWithChild(epicId: string, childId: string): Promise<void> {
+  const accessor = await createSqliteDataAccessor(testDir);
+  try {
+    await accessor.setMetaValue('schema_version', '2.10.0');
+    await accessor.upsertSingleTask(
+      makeTask({ id: epicId, type: 'epic', title: 'Epic', pipelineStage: 'contribution' }),
+    );
+    await accessor.upsertSingleTask(makeTask({ id: childId, parentId: epicId }));
+  } finally {
+    await accessor.close();
+  }
+}
+
+function writeChangeset(slug: string, content: string): void {
+  const dir = join(testDir, '.changeset');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${slug}.md`), content, 'utf8');
+}
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'cleo-plan-yaml-invalid-'));
+  await mkdir(join(testDir, '.cleo'), { recursive: true });
+  writeFileSync(
+    join(testDir, '.cleo', 'config.json'),
+    JSON.stringify({
+      enforcement: { session: { requiredForMutate: false } },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+  writeFileSync(
+    join(testDir, '.cleo', 'project-info.json'),
+    JSON.stringify({
+      projectHash: 'testhash00000',
+      projectId: 'test-project-id',
+      projectRoot: testDir,
+      projectName: 'test',
+    }),
+  );
+  await initTestGit();
+  resetDbState();
+});
+
+afterEach(async () => {
+  try {
+    closeDb();
+  } catch {
+    /* best-effort */
+  }
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe('releasePlan — fail-loud on invalid YAML (T10105 / Saga T10099)', () => {
+  it('aborts with E_CHANGESET_YAML_INVALID when a changeset has an unquoted colon in summary (v5.100 repro)', async () => {
+    await seedEpicWithChild('T9999', 'T10001');
+
+    // The exact shape of the v2026.5.100 silent-skip bug: a valid filename,
+    // valid task ID, but `summary: foo: bar` is two compact mappings to YAML
+    // which `yaml@2.x` rejects with BLOCK_AS_IMPLICIT_KEY at line 4.
+    writeChangeset(
+      'v5100-repro',
+      [
+        '---',
+        'id: v5100-repro',
+        'tasks: [T10001]',
+        'kind: feat',
+        'summary: feat(T10001): unquoted colon eats the entry',
+        '---',
+        '',
+      ].join('\n'),
+    );
+
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      writeChangelog: false,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error.code).toBe('E_CHANGESET_YAML_INVALID');
+    expect(result.error.message).toMatch(/v5100-repro\.md/);
+    expect(result.error.message).toMatch(/invalid YAML frontmatter/);
+    expect(result.error.fix).toMatch(/quotes/);
+    expect(result.error.details).toMatchObject({
+      file: expect.stringMatching(/v5100-repro\.md$/),
+      line: expect.any(Number),
+      parserMessage: expect.any(String),
+    });
+    // Line must be 1-based and inside the file body (not zero/negative).
+    expect((result.error.details as { line: number }).line).toBeGreaterThan(0);
+  });
+
+  it('does NOT silently drop a sibling valid changeset when one is malformed', async () => {
+    await seedEpicWithChild('T9999', 'T10001');
+
+    // One good entry, one bad — pre-T10105 dropped BOTH. Post-T10105 the
+    // bad entry aborts the run.
+    writeChangeset(
+      'good-entry',
+      [
+        '---',
+        'id: good-entry',
+        'tasks: [T10001]',
+        'kind: feat',
+        'summary: A valid summary line.',
+        '---',
+        '',
+      ].join('\n'),
+    );
+    writeChangeset(
+      'bad-entry',
+      [
+        '---',
+        'id: bad-entry',
+        'tasks: [T10001]',
+        'kind: fix',
+        'summary: fix(T10001): unquoted colon breaks parse',
+        '---',
+        '',
+      ].join('\n'),
+    );
+
+    const result = await releasePlan({
+      version: 'v2026.6.0',
+      epicId: 'T9999',
+      channel: 'latest',
+      scheme: 'calver',
+      projectRoot: testDir,
+      writeChangelog: false,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    // Parser runs files in alphabetical order — `bad-entry.md` sorts BEFORE
+    // `good-entry.md`, so the failure surfaces on bad-entry.
+    expect(result.error.code).toBe('E_CHANGESET_YAML_INVALID');
+    expect((result.error.details as { file: string }).file).toMatch(/bad-entry\.md$/);
+  });
+});

--- a/packages/core/src/release/changesets-aggregator.ts
+++ b/packages/core/src/release/changesets-aggregator.ts
@@ -385,17 +385,13 @@ export async function readChangesetsSsotFirst(
   }
 
   // ── 2. File pass — fill in slugs SSoT did not cover. ───────────────────
+  // T10105: parse failures (YAML or schema) propagate to the caller. The
+  // pre-T10105 silent-skip caused the v2026.5.100 ship to drop CHANGELOG
+  // entries for v5.100/v5.101/v5.103. Operators (or CI) get a
+  // ChangesetYamlInvalidError naming the offending file:line.
   const changesetDir = join(projectRoot, '.changeset');
   if (existsSync(changesetDir)) {
-    let fileEntries: ChangesetEntry[] = [];
-    try {
-      fileEntries = parseChangesetDir(changesetDir);
-    } catch {
-      /* Malformed file in the directory — skip the whole batch; the lint
-       * gate (`scripts/lint-changesets.mjs`) surfaces the parse error
-       * separately at PR-review time. */
-      fileEntries = [];
-    }
+    const fileEntries = parseChangesetDir(changesetDir);
     for (const entry of fileEntries) {
       if (bySlug.has(entry.id)) continue;
       bySlug.set(entry.id, { entry, meta: { source: 'file' } });
@@ -447,11 +443,10 @@ export async function readChangesetEntriesSsotFirst(
 export function readChangesetEntriesFileOnly(projectRoot: string): ChangesetEntry[] {
   const dir = join(projectRoot, '.changeset');
   if (!existsSync(dir)) return [];
-  try {
-    return parseChangesetDir(dir);
-  } catch {
-    return [];
-  }
+  // T10105: NO try/catch — ChangesetYamlInvalidError propagates so the
+  // calling release verb aborts with a deterministic error envelope rather
+  // than silently dropping every entry on one malformed file.
+  return parseChangesetDir(dir);
 }
 
 /**

--- a/packages/core/src/release/open.ts
+++ b/packages/core/src/release/open.ts
@@ -115,7 +115,14 @@ export interface ReleaseOpenResult {
   watching: boolean;
   /** True iff this invocation was a no-op because status was already `pr-opened`. */
   idempotent?: boolean;
-  /** Plan file sha256, supplied as `plan-blob-sha256` field to the workflow dispatch. */
+  /**
+   * Plan file sha256, computed for downstream provenance tracking and
+   * returned in the result envelope. Per T10105 this is NO LONGER passed
+   * as a `--field` to `gh workflow run`, because the
+   * `release-prepare.yml workflow_dispatch.inputs` block does not declare
+   * the field and the GitHub Actions API rejected the dispatch with
+   * HTTP 422 "Unexpected inputs provided" during the v2026.5.100 ship.
+   */
   planBlobSha256: string;
 }
 
@@ -532,20 +539,18 @@ export async function releaseOpen(
     }
   }
 
-  // ── R-060: dispatch the workflow ──────────────────────────────────────
+  // ── R-060 / T10105: dispatch the workflow ─────────────────────────────
+  // Canonical input schema for `release-prepare.yml workflow_dispatch.inputs`:
+  //   - `version` (string, required) — CalVer release version with v-prefix
+  //
+  // The pre-T10105 implementation also passed `plan-blob-sha256` which is
+  // NOT declared in the workflow's `inputs:` block; `gh workflow run`
+  // tolerated it locally but the GitHub Actions API rejected it with
+  // HTTP 422 "Unexpected inputs provided" on at least one ship attempt.
+  // Keep this `--field` set in lockstep with the YAML inputs declaration
+  // and the `release-open-field-schema.test.ts` parity check.
   try {
-    runner.runGh(
-      [
-        'workflow',
-        'run',
-        workflow,
-        '--field',
-        `version=${opts.version}`,
-        '--field',
-        `plan-blob-sha256=${planBlobSha256}`,
-      ],
-      projectRoot,
-    );
+    runner.runGh(['workflow', 'run', workflow, '--field', `version=${opts.version}`], projectRoot);
   } catch (err) {
     return engineError<ReleaseOpenResult>(
       E_GH_NOT_AUTHENTICATED,

--- a/packages/core/src/release/plan.ts
+++ b/packages/core/src/release/plan.ts
@@ -19,6 +19,8 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from '
 import { join } from 'node:path';
 import type { ChangesetEntry, EvidenceAtom, Task } from '@cleocode/contracts';
 import {
+  ChangesetYamlInvalidError,
+  E_CHANGESET_YAML_INVALID,
   E_CHANNEL_MISMATCH,
   E_DIRTY_TREE,
   E_EPIC_EMPTY,
@@ -862,6 +864,20 @@ function writePlanFile(plan: ReleasePlan, projectRoot: string): string {
 const DEFAULT_CHANGELOG_HEADER = '# Changelog\n\nAll notable changes to this project.\n';
 
 /**
+ * Placeholder body used when `cleo release plan` runs with zero parsed
+ * changeset entries. Per T10105 AC3 the section MUST still be written so the
+ * `## [<version>] (<date>)` header is never absent. Operators can fill in
+ * the body manually (or add a changeset and re-run).
+ *
+ * @internal
+ * @task T10105
+ * @epic E-RELEASE-PLAN-CHANGELOG
+ */
+const EMPTY_CHANGELOG_PLACEHOLDER =
+  '_No changeset entries parsed for this release._\n\n' +
+  '_Add entries under `.changeset/*.md` and re-run `cleo release plan` to populate this section._\n';
+
+/**
  * Idempotently write (or replace) the `## [<version>] (<date>)` section in
  * `CHANGELOG.md` with the rendered release notes from
  * {@link aggregateChangesetsForRelease}.
@@ -1086,28 +1102,26 @@ async function upsertReleasesRow(
 /**
  * Read parsed changeset entries from `<projectRoot>/.changeset/`.
  *
- * Returns an empty array when the directory is missing, when the directory has
- * no `.md` files apart from `README.md`, or when parsing fails — failures are
- * logged at warn level but never propagated, because changeset entries are
- * advisory metadata, not a blocking precondition for the plan verb.
+ * Returns an empty array when the directory is missing OR when the directory
+ * has no `.md` files apart from `README.md`. Parse failures are NO LONGER
+ * silently swallowed — {@link ChangesetYamlInvalidError} propagates so that
+ * `cleo release plan` aborts with `E_CHANGESET_YAML_INVALID` and the
+ * offending `file:line` is surfaced to the operator (T10105).
  *
  * @internal
- * @task T9753
+ * @task T10105
+ * @epic E-RELEASE-PLAN-CHANGELOG
  */
 function readChangesetEntries(projectRoot: string): ChangesetEntry[] {
   const changesetDir = join(projectRoot, '.changeset');
   if (!existsSync(changesetDir)) {
     return [];
   }
-  try {
-    return parseChangesetDir(changesetDir);
-  } catch (err: unknown) {
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err), dir: changesetDir },
-      'parseChangesetDir failed during release plan — treating as zero entries',
-    );
-    return [];
-  }
+  // T10105: deliberately NO try/catch. ChangesetYamlInvalidError propagates
+  // to releasePlan() which converts it into an EngineResult error envelope
+  // with code=E_CHANGESET_YAML_INVALID. The pre-T10105 silent-skip caused
+  // the v2026.5.100 ship to drop v5.100/v5.101/v5.103 CHANGELOG entries.
+  return parseChangesetDir(changesetDir);
 }
 
 /**
@@ -1394,11 +1408,39 @@ export async function releasePlan(
   // ── R-305 / R-370: platform matrix ────────────────────────────────────
   const platformMatrix = enumeratePlatformMatrix(projectRoot);
 
-  // ── T9753: CLEO-native changesets — read + aggregate ────────────────
+  // ── T10105: CLEO-native changesets — read + aggregate (fail-loud) ─────
   // Reads `.changeset/*.md` and aggregates into a CHANGELOG markdown section
-  // embedded under `meta.releaseNotes`. Failure is non-blocking (warn-and-skip)
-  // because changesets are advisory; the plan itself is built from task data.
-  const changesetEntries = readChangesetEntries(projectRoot);
+  // embedded under `meta.releaseNotes`. Per T10105 (Saga T10099), a YAML
+  // parse failure on ANY entry now aborts the plan with
+  // E_CHANGESET_YAML_INVALID — the pre-T10105 silent-skip caused the
+  // v2026.5.100 ship to drop v5.100/v5.101/v5.103 CHANGELOG entries.
+  let changesetEntries: ChangesetEntry[];
+  try {
+    changesetEntries = readChangesetEntries(projectRoot);
+  } catch (err: unknown) {
+    if (err instanceof ChangesetYamlInvalidError) {
+      return engineError<ReleasePlanResult>(E_CHANGESET_YAML_INVALID, err.message, {
+        exitCode: ExitCode.VALIDATION_ERROR,
+        fix: `Fix the YAML in ${err.details.file} (line ${err.details.line ?? '?'}). Common cause: an unquoted colon in 'summary:'. Wrap the value in quotes — e.g. summary: "feat(T1234): thing".`,
+        details: {
+          file: err.details.file,
+          line: err.details.line,
+          ...(err.details.snippet !== undefined ? { snippet: err.details.snippet } : {}),
+          parserMessage: err.details.parserMessage,
+        },
+      });
+    }
+    // T10105: schema-violation errors (missing fields, wrong enum, etc.)
+    // surface as the same code. The parser's error message already
+    // includes the offending file:line and Zod issue path, so callers
+    // get an actionable error envelope rather than an uncaught throw.
+    const message = err instanceof Error ? err.message : String(err);
+    return engineError<ReleasePlanResult>(E_CHANGESET_YAML_INVALID, message, {
+      exitCode: ExitCode.VALIDATION_ERROR,
+      fix: 'Run `node scripts/lint-changesets.mjs` to surface every offending entry. Common causes: missing required fields (id, tasks, kind, summary), invalid kind enum, or filename slug ≠ id.',
+      details: { parserMessage: message },
+    });
+  }
   const aggregated = aggregateChangesetsForRelease({
     entries: changesetEntries,
     version: normalizedVersion,
@@ -1490,18 +1532,33 @@ export async function releasePlan(
         'persistReleaseChangesets failed — plan envelope still written',
       );
     }
-    // ── T9838 Fix 3: auto-write CHANGELOG.md ──────────────────────────
-    // Closes the manual-paste loop that v5.91-v5.93 ships were stuck in.
-    // Writes (or replaces) the `## [<version>] (<date>)` block with the
-    // aggregated release notes. Idempotent on re-run. Failure is logged but
-    // NEVER blocks the plan — the plan envelope remains the canonical sink.
-    if (writeChangelog && aggregated.markdown.trim().length > 0) {
+    // ── T10105: ALWAYS write the CHANGELOG.md section ───────────────────
+    // Per Saga T10099 AC2: `cleo release plan` MUST always write the
+    // `## [<version>] (<date>)` section. When the aggregator emits no
+    // content (zero parsed entries), insert a placeholder body + emit a
+    // WARN-level log. The pre-T10105 conditional skip (only-write-if-non-empty)
+    // is what caused the v2026.5.100 ship to silently elide CHANGELOG
+    // sections for v5.100/v5.101/v5.103. Failure is logged but NEVER
+    // blocks the plan — the plan envelope remains the canonical sink.
+    if (writeChangelog) {
+      const notesMarkdown =
+        aggregated.markdown.trim().length > 0 ? aggregated.markdown : EMPTY_CHANGELOG_PLACEHOLDER;
+      if (aggregated.markdown.trim().length === 0) {
+        log.warn(
+          {
+            changelogPath,
+            version: normalizedVersion,
+            changesetEntryCount: aggregated.entryCount,
+          },
+          'No changeset entries parsed for this release — writing placeholder CHANGELOG section (T10105)',
+        );
+      }
       try {
         const result = await writeChangelogSection({
           changelogPath,
           version: normalizedVersion,
           date: createdAt.slice(0, 10),
-          notesMarkdown: aggregated.markdown,
+          notesMarkdown,
         });
         changelogWritten = result.written;
       } catch (err: unknown) {


### PR DESCRIPTION
## Summary

Fixes the v2026.5.100 silent-skip bug class: a `.changeset/*.md` with an
unquoted colon in `summary:` (e.g. `summary: feat(T1): thing`) caused
`yaml@2.x` to throw `BLOCK_AS_IMPLICIT_KEY`. The pre-T10105 parser caught
this at WARN level and returned an empty entry list, so `cleo release plan`
wrote no `## [<version>]` section and the head of CHANGELOG.md jumped
from v5.102 → v5.99 (missing v5.100, v5.101, v5.103).

This PR closes the gap on three vectors:

- **AC1 — fail-loud parser:** any YAML-parse OR schema-violation in
  `.changeset/*.md` aborts `cleo release plan` with new error code
  `E_CHANGESET_YAML_INVALID`, surfacing `file:line` and an offending
  snippet. New `ChangesetYamlInvalidError` class in `@cleocode/contracts`.
- **AC2/AC3 — always write CHANGELOG:** the `## [<version>] (<date>)`
  section is now ALWAYS written when `writeChangelog=true` (the default).
  Zero parsed entries → placeholder body + WARN-level log explicitly
  stating the empty-content reason. Pre-T10105 the
  `aggregated.markdown.length > 0` guard caused silent elision.
- **AC5 — gh schema parity:** `cleo release open` no longer passes the
  `plan-blob-sha256` field that `release-prepare.yml workflow_dispatch.inputs`
  does not declare (GitHub Actions API was rejecting with HTTP 422
  "Unexpected inputs provided"). The sha256 is still computed and
  returned in the result envelope for downstream provenance tracking.

## Acceptance criteria (all met)

- AC1 — Invalid YAML aborts `cleo release plan` with
  `E_CHANGESET_YAML_INVALID` + offending file:line ✓
- AC2 — `cleo release plan` always writes the `## [v<version>]` block ✓
- AC3 — Zero changesets → placeholder body + WARN log ✓
- AC4 — Vitest fixture for the v2026.5.100 unquoted-colon scenario ✓
- AC5 — `gh workflow run` field set lockstep with workflow YAML inputs ✓

## Reproduction of the v5.100 bug

\`\`\`bash
\$ head -8 CHANGELOG.md  # before T10105
# Changelog
...
## [2026.5.102] (...)
## [2026.5.99] (...)   # ← v5.100, v5.101, v5.103 silently dropped
\`\`\`

After T10105: a malformed entry causes \`cleo release plan\` to abort with
\`E_CHANGESET_YAML_INVALID: <file>:<line> invalid YAML frontmatter: ...\`
and the operator must fix the YAML before the release can proceed. No
silent skip is possible.

## Files touched

| Area | File | Change |
|---|---|---|
| contracts | `packages/contracts/src/errors.ts` | New `ChangesetYamlInvalidError` + `ChangesetYamlInvalidDetails` |
| contracts | `packages/contracts/src/exit-codes.ts` | New `E_CHANGESET_YAML_INVALID` const |
| contracts | `packages/contracts/src/index.ts` | Re-export new symbols |
| parser | `packages/core/src/changesets/parser.ts` | Throw `ChangesetYamlInvalidError` with line+snippet |
| plan | `packages/core/src/release/plan.ts` | Surface as `engineError`; ALWAYS write CHANGELOG; placeholder body |
| open | `packages/core/src/release/open.ts` | Drop `plan-blob-sha256` from gh dispatch field set |
| aggregator | `packages/core/src/release/changesets-aggregator.ts` | Stop silent-skipping on parse failure |
| tests | `packages/core/src/release/__tests__/release-plan-yaml-invalid.test.ts` | v5.100 repro + sibling-valid test |
| tests | `packages/core/src/release/__tests__/release-plan-always-changelog.test.ts` | Empty-changeset placeholder + opt-out + real-entry tests |
| tests | `packages/core/src/release/__tests__/release-open-field-schema.test.ts` | YAML↔runtime field-key parity check |
| tests | `packages/core/src/changesets/__tests__/parser.test.ts` | Adds 2 fail-loud parser tests |

## Test plan

- [x] \`pnpm --filter @cleocode/contracts run build\` — green
- [x] \`pnpm run build\` (full monorepo) — green
- [x] \`pnpm biome check .\` — 2813 files, no errors
- [x] \`pnpm --filter @cleocode/core exec vitest run src/release/__tests__ src/changesets/__tests__\` — 338 passed | 2 skipped (36 files)
- [x] \`pnpm --filter @cleocode/cleo exec vitest run src/cli/__tests__/changeset-add.test.ts\` (via root config) — 14 passed
- [x] Verified the 4 pre-existing \`archive-reason-invariant.test.ts\` failures are NOT caused by this PR (reproduced on origin/main)

Closes T10105
Saga: T10099