### PR TITLE
refactor(T10129): migrate format-helpers to packages/core/render (B4)

### DIFF
--- a/.changeset/t10129-format-helpers-migration.md
+++ b/.changeset/t10129-format-helpers-migration.md
@@ -1,0 +1,10 @@
+---
+"@cleocode/cleo": patch
+"@cleocode/core": minor
+---
+
+refactor(T10129): migrate format-helpers (kvBlock, dataTable, truncated) from packages/cleo → packages/core/render (B4)
+
+Pure structural move — zero behavior change. Resolves AGENTS.md Package-Boundary Check violation: rendering logic belongs in `packages/core/`, not in the CLI thin shell. All callers updated to import from `@cleocode/core`.
+
+Closes T10129. Epic: T10114. ADR: adr-077-human-render-contract.

--- a/packages/cleo/src/cli/commands/changeset.ts
+++ b/packages/cleo/src/cli/commands/changeset.ts
@@ -29,9 +29,8 @@ import {
   type ChangesetKind,
   ExitCode,
 } from '@cleocode/contracts';
-import { changesets, getProjectRoot } from '@cleocode/core';
+import { changesets, dataTable, getProjectRoot } from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
-import { dataTable } from '../renderers/format-helpers.js';
 import { cliError, cliOutput, humanInfo, humanLine, isHumanOutput } from '../renderers/index.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/packages/cleo/src/cli/renderers/index.ts
+++ b/packages/cleo/src/cli/renderers/index.ts
@@ -26,13 +26,18 @@ function generateRequestId(): string {
  * @epic T4663
  */
 
-import { drainWarnings, type FormatOptions, formatSuccess } from '@cleocode/core';
+import {
+  drainWarnings,
+  type FormatOptions,
+  formatSuccess,
+  metaFooter,
+  pagerFooter,
+} from '@cleocode/core';
 import type { CliEnvelope, CliMeta, Warning } from '@cleocode/lafs';
 import { applyFieldFilter, extractFieldFromResult } from '@cleocode/lafs';
 import type { DispatchResponseMeta } from '../../dispatch/types.js';
 import { getFieldContext } from '../field-context.js';
 import { getFormatContext } from '../format-context.js';
-import { metaFooter, pagerFooter } from './format-helpers.js';
 import { emitLafsViolation, LafsViolationError, validateLafsShape } from './lafs-validator.js';
 import { normalizeForHuman } from './normalizer.js';
 // System renderers

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -521,6 +521,8 @@ export {
 } from './mvi-helpers.js';
 // Reconciliation
 export { reconcile } from './reconciliation/index.js';
+// Render — shared --human formatting primitives (T10129)
+export * from './render/index.js';
 export type {
   BootstrapDaemonOptions,
   StudioStatus,

--- a/packages/core/src/render/__tests__/helpers.test.ts
+++ b/packages/core/src/render/__tests__/helpers.test.ts
@@ -7,7 +7,11 @@
  *   - pagerFooter visibility rules (suppresses 1-of-1, fires on pagination/filter)
  *   - metaFooter surfaces _nexus + deprecated + duration_ms
  *
+ * Migrated from `packages/cleo/src/cli/renderers/__tests__/format-helpers.test.ts`
+ * alongside the helpers themselves (T10129 · pure structural move).
+ *
  * @task T9393
+ * @task T10129
  */
 
 import { describe, expect, it } from 'vitest';
@@ -20,7 +24,7 @@ import {
   truncated,
   truncateVisible,
   visibleLength,
-} from '../format-helpers.js';
+} from '../helpers.js';
 
 describe('visibleLength', () => {
   it('ignores ANSI color escapes', () => {

--- a/packages/core/src/render/ansi.ts
+++ b/packages/core/src/render/ansi.ts
@@ -1,0 +1,27 @@
+/**
+ * Minimal ANSI escape primitives used by the shared render helpers.
+ *
+ * Kept tiny and self-contained so `@cleocode/core/render` has zero coupling
+ * to the cleo CLI's larger colors module. Respects `NO_COLOR` and
+ * `FORCE_COLOR` envs the same way (https://no-color.org).
+ *
+ * @task T10129
+ */
+
+/** Whether ANSI color escape codes should be emitted. */
+const colorsEnabled: boolean = (() => {
+  if (process.env['NO_COLOR'] !== undefined) return false;
+  if (process.env['FORCE_COLOR'] !== undefined) return true;
+  return process.stdout.isTTY === true;
+})();
+
+function ansi(code: string): string {
+  return colorsEnabled ? code : '';
+}
+
+/** Bold text. */
+export const BOLD = ansi('\x1b[1m');
+/** Dim text. */
+export const DIM = ansi('\x1b[2m');
+/** Reset (no-color). */
+export const NC = ansi('\x1b[0m');

--- a/packages/core/src/render/helpers.ts
+++ b/packages/core/src/render/helpers.ts
@@ -8,7 +8,7 @@
  * Design goals:
  *   - Terminal-width aware (truncate cells instead of overflowing)
  *   - Zero new runtime dependencies (no `cli-table` etc.) — uses only ANSI
- *     escapes from {@link ./colors.ts}.
+ *     escapes from {@link ./ansi.ts}.
  *   - Pure: every helper returns a string; no stdout writes.
  *   - LAFS-aware: {@link metaFooter} surfaces decorator-stamped
  *     `meta._nexus`, `meta.deprecated`, and `meta.duration_ms` chrome that
@@ -16,10 +16,15 @@
  *   - Pagination-aware: {@link pagerFooter} formats the `page.{limit,offset,
  *     hasMore,total}` block so users know a list is windowed.
  *
+ * Originally lived under `packages/cleo/src/cli/renderers/format-helpers.ts`.
+ * Migrated to `@cleocode/core/render` per AGENTS.md Package-Boundary Check —
+ * rendering logic belongs in core, not the CLI thin shell.
+ *
  * @task T9393
+ * @task T10129
  */
 
-import { BOLD, DIM, NC } from './colors.js';
+import { BOLD, DIM, NC } from './ansi.js';
 
 // ---------------------------------------------------------------------------
 // Terminal width detection

--- a/packages/core/src/render/index.ts
+++ b/packages/core/src/render/index.ts
@@ -1,0 +1,13 @@
+/**
+ * `@cleocode/core/render` — shared `--human` rendering primitives.
+ *
+ * Pure formatting helpers (no stdout writes, no side effects) used by the
+ * CLI thin shell and any other surface that needs to format LAFS envelopes
+ * for human consumption. Originally lived under `packages/cleo/src/cli/
+ * renderers/format-helpers.ts`; migrated here per AGENTS.md
+ * Package-Boundary Check.
+ *
+ * @task T10129
+ */
+
+export * from './helpers.js';


### PR DESCRIPTION
## Summary
- Moves `kvBlock`, `dataTable`, `truncated` (and siblings: `visibleLength`, `padVisible`, `truncateVisible`, `terminalWidth`, `sectionHeader`, `pagerFooter`, `metaFooter`) from `packages/cleo/src/cli/renderers/format-helpers.ts` to `packages/core/src/render/helpers.ts`.
- Adds a tiny internal `packages/core/src/render/ansi.ts` (BOLD/DIM/NC primitives, same env-var rules as the cleo colors module) so the new home stays self-contained — no core→cleo back-import.
- Re-exports the new module from `@cleocode/core` via a `render/index.ts` barrel + a `export * from './render/index.js'` line in the core barrel.
- Updates all 2 callers (`packages/cleo/src/cli/renderers/index.ts`, `packages/cleo/src/cli/commands/changeset.ts`) to import from `@cleocode/core`.
- Migrates the test file alongside (`packages/core/src/render/__tests__/helpers.test.ts`).
- Deletes the old files.
- Zero behavior change — all 20 helper unit tests pass identically; all 114 cleo renderer tests (system + brain + tree + render-waves + warnings-drain) pass unchanged.

## Why
- AGENTS.md Package-Boundary Check: pure rendering primitives belong in `packages/core/`, not the CLI thin shell.
- First migration step under Epic T10114 (E11-HUMAN-RENDER-CONTRACT — 5,541 LOC total to move; this PR handles 342 LOC of helpers + 181 LOC of tests).

## Test plan
- [x] `pnpm biome check --write .` (clean — no fixes applied on final pass)
- [x] `pnpm run build` (full graph build green — 26s)
- [x] `pnpm exec vitest run src/render` in `packages/core` — 20/20 pass
- [x] `pnpm exec vitest run packages/cleo/src/cli/renderers/__tests__/cli-output-response-meta.test.ts` (exercises migrated `metaFooter`) — 6/6 pass
- [x] `pnpm exec vitest run packages/cleo/src/cli/__tests__/changeset-add.test.ts` (exercises migrated `dataTable`) — 14/14 pass
- [x] Renderer test sweep (system + brain + warnings-drain + tree-priority-blocker + render-waves) — 114/114 pass

## Refs
Closes T10129
Epic: T10114 (E11-HUMAN-RENDER-CONTRACT)
ADR: adr-077-human-render-contract