### PR TITLE
release: ship v2026.5.105 -- Saga T10099 closeout (T10103 + T10105)

### DIFF
--- a/.changeset/t10105-release-plan-fail-loud-yaml.md
+++ b/.changeset/t10105-release-plan-fail-loud-yaml.md
@@ -1,0 +1,9 @@
+---
+id: t10105-release-plan-fail-loud-yaml
+tasks: [T10105, T9780]
+kind: feat
+summary: cleo release plan now aborts on changeset YAML parse with E_CHANGESET_YAML_INVALID + always writes the CHANGELOG section (placeholder if zero entries) + aligns gh workflow run input schema with release open field set
+prs: [539]
+---
+
+Hit on v5.100 ship: changeset with unquoted colon caused parseChangesetDir to log WARN and silently skip, leaving CHANGELOG without the version section and forcing manual #482 hotfix. Adds ChangesetYamlInvalidError contract type with file:line:snippet payload. Also corrects cleo release open --field set to match release-prepare.yml workflow_dispatch.inputs (drops unknown plan-blob-sha256 field that caused HTTP 422). New vitest fixtures cover v5.100 reproduction. Closes T9780 (skip+warn approach was superseded by user-mandated fail-loud).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2026.5.105] (2026-05-23)
+
+### Features
+
+- **Release verb matrix + DELETE `cleo release ship` + new `cleo release ship-e2e-smoke` (Saga T10099, Epic T10103)** — `docs/release/verb-matrix.md` is now the SSoT mapping every release state transition to its owning verb. The deprecated `cleo release ship` monolith (post-T9540 follow-up) is REMOVED (not just deprecated). New `cleo release ship-e2e-smoke <version> --epic <id> [--execute]` one-shot walker covers plan → open → wait-PR → wait-tag → verify-npm-published; dry-run by default, idempotent, resumable. SSoT `defineCommand` factory landed at `packages/cleo/src/cli/lib/define-cli-command.ts` (T10072 enablement, raw-citty baseline 139→138). `ct-release-orchestrator` SKILL.md rewritten — was describing the deleted 12-step shipv monolith (canonical Saga T9799 skill-drift example). AGENTS.md Release section + user-facing fix strings in `core/{engine-ops, reconcile, release-manifest, spawn-prompt}` updated. Bonus: fixed pre-existing main breakage at `packages/cleo/src/dispatch/__tests__/registry.test.ts:56` (asserted `release.ship` resolves; was removed in T9540 but test never updated). (#538)
+
+### Bug fixes
+
+- **`cleo release plan` fail-loud YAML + always-write CHANGELOG section + gh schema parity (Saga T10099, Epic T10105 + child T9780)** — v5.100 silent-skip bug class permanently closed. Parser now throws new `ChangesetYamlInvalidError` (`E_CHANGESET_YAML_INVALID`) with `{file, line, snippet, parserMessage}` payload on any malformed `.changeset/*.md` instead of logging WARN and silently dropping ALL entries. `cleo release plan` ALWAYS writes the `## [<version>] (<date>)` CHANGELOG section — placeholder body + WARN log when zero changesets parsed, never silently skips. `cleo release open` no longer passes `plan-blob-sha256` to `gh workflow run` — workflow's `inputs:` block only declares `version`; new `release-open-field-schema.test.ts` parity test asserts the key-sets match (extras + missing detection). New vitest fixtures cover the v5.100 unquoted-colon-in-summary reproduction. Closes T9780 (skip+warn approach superseded by user-mandated fail-loud). (#539)
+
 ## [2026.5.104] (2026-05-23)
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cant-core"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "cleo-conduit-core",
  "criterion",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "cant-lsp"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "cant-core",
  "serde",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "cant-napi"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "cant-router"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "criterion",
  "serde",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "cant-runtime"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "cant-core",
  "criterion",
@@ -311,7 +311,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cleo-conduit-core"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "criterion",
  "lafs-core",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cleocode-workspace"
-version = "2026.5.104"
+version = "2026.5.105"
 
 [[package]]
 name = "convert_case"
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "cant-core",
  "cant-router",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-core"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "chrono",
  "criterion",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "lafs-napi"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "lafs-core",
  "napi",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "worktree-napi"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "anyhow",
  "napi",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "worktrunk-core"
-version = "2026.5.104"
+version = "2026.5.105"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.104"
+version = "2026.5.105"
 rust-version = "1.94"
 
 [workspace.dependencies]
@@ -75,7 +75,7 @@ tower-lsp = "0.20"
 
 # Local workspace crates
 lafs-core = { path = "crates/lafs-core" }
-cleo-conduit-core = { path = "crates/cleo-conduit-core", version = "=2026.5.104" }
+cleo-conduit-core = { path = "crates/cleo-conduit-core", version = "=2026.5.105" }
 cant-core = { path = "crates/cant-core" }
 cant-lsp = { path = "crates/cant-lsp" }
 cant-napi = { path = "crates/cant-napi" }

--- a/crates/cant-core/Cargo.toml
+++ b/crates/cant-core/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["rlib"]
 nom = "7.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-cleo-conduit-core = { path = "../cleo-conduit-core", version = "=2026.5.104" }
+cleo-conduit-core = { path = "../cleo-conduit-core", version = "=2026.5.105" }
 
 [build-dependencies]
 serde_json = "1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.104",
+  "version": "2026.5.105",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Release v2026.5.105

Closes the v5.105 ship window for the remaining 2 of 5 Saga T10099 (SG-RELEASE-AUDIT-V2) epics that landed on main AFTER v5.104 was cut:

- **T10103** — release verb matrix + DELETE \`cleo release ship\` + new \`cleo release ship-e2e-smoke\` + SSoT \`defineCommand\` factory (PR #538)
- **T10105** — \`cleo release plan\` fail-loud YAML + always-write CHANGELOG + gh schema parity + closes T9780 (PR #539)

The other 3 epics (T10104, T10106, T10102) shipped in v2026.5.104.

## What this PR does
- Bumps root \`package.json\` and 21 \`packages/*/package.json\` to \`2026.5.105\`
- Bumps \`Cargo.toml\` workspace version to \`2026.5.105\`
- Adds CHANGELOG.md \`## [2026.5.105]\` section documenting T10103 + T10105
- Files the missing T10105 changeset (\`.changeset/t10105-release-plan-fail-loud-yaml.md\`)

## Live E2E test for T10104
This PR is the live E2E for T10104's new \`auto-tag-on-release-merge.yml\` workflow. On merge:
1. The workflow should fire (PR title matches \`^release: ship v\`)
2. It should tag the merge commit as \`v2026.5.105\` via \`github-actions[bot]\`
3. \`release.yml\` should fire on the tag push and publish to npm

If the auto-tag misfires, manual \`git tag v2026.5.105 && git push origin v2026.5.105\` remains as fallback (idempotent on existing tag).

## Saga T10099 Status
Saga T10099 SG-RELEASE-AUDIT-V2: **5/5 complete** (100%). All 5 epics + 1 child task (T9780) closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)