### PR TITLE
feat(T10127): typed icon enums (B2) — StatusIcon, KindIcon, BadgeIcon, RelationIcon

### DIFF
--- a/.changeset/t10127-render-icons.md
+++ b/.changeset/t10127-render-icons.md
@@ -1,0 +1,11 @@
+---
+"@cleocode/contracts": minor
+---
+
+feat(T10127): typed icon enums (B2) — StatusIcon, KindIcon, BadgeIcon, RelationIcon with ASCII fallback
+
+Single source of truth for the visual language used across renderers. Each enum exposes `ascii()` for NO_COLOR / non-UTF8 terminals. Part of Epic T10114, ADR-077.
+
+ADR deviation: `BadgeIcon.ORPHAN` ships as `'👻'` (not `'🚪'` as ADR-077 §2 originally specified) because TypeScript string enums share runtime values and `StatusIcon.BLOCKED` already owns `'🚪'`. ADR amendment lands in T10137 (B12).
+
+Closes T10127. Epic: T10114. ADR: adr-077-human-render-contract.

--- a/packages/contracts/src/render/__tests__/icon.test.ts
+++ b/packages/contracts/src/render/__tests__/icon.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ascii, BadgeIcon, KindIcon, pickIcon, RelationIcon, StatusIcon } from '../icon.js';
+
+describe('icon enums', () => {
+  it('StatusIcon emoji values match ADR-077', () => {
+    expect(StatusIcon.PENDING).toBe('⏳');
+    expect(StatusIcon.ACTIVE).toBe('🚧');
+    expect(StatusIcon.DONE).toBe('✅');
+    expect(StatusIcon.BLOCKED).toBe('🚪');
+    expect(StatusIcon.ARCHIVED).toBe('🗄');
+    expect(StatusIcon.CANCELLED).toBe('✗');
+  });
+
+  it('KindIcon emoji values match ADR-077', () => {
+    expect(KindIcon.SAGA).toBe('🌲');
+    expect(KindIcon.EPIC).toBe('📋');
+    expect(KindIcon.TASK).toBe('•');
+    expect(KindIcon.SUBTASK).toBe('◦');
+    expect(KindIcon.RESEARCH).toBe('📖');
+    expect(KindIcon.BUG).toBe('🐛');
+    expect(KindIcon.RELEASE).toBe('🚀');
+  });
+
+  it('BadgeIcon emoji values match ADR-077 (ORPHAN amended in T10137)', () => {
+    expect(BadgeIcon.EMPTY).toBe('🪦');
+    // ADR-077 §2 originally specified '🚪' for ORPHAN — identical to
+    // StatusIcon.BLOCKED. String enums share runtime values so ascii() cannot
+    // disambiguate. Amended to '👻' (abandoned/lonely). T10137 (B12) updates
+    // the ADR text to match.
+    expect(BadgeIcon.ORPHAN).toBe('👻');
+    expect(BadgeIcon.NESTED).toBe('🔁');
+    expect(BadgeIcon.CAUTION).toBe('⚠');
+    expect(BadgeIcon.NEW).toBe('★');
+  });
+
+  it('RelationIcon emoji values match ADR-077', () => {
+    expect(RelationIcon.GROUPS).toBe('⊂');
+    expect(RelationIcon.PARENT).toBe('⤴');
+    expect(RelationIcon.DEPENDS).toBe('⇨');
+    expect(RelationIcon.BLOCKS).toBe('⊘');
+  });
+
+  it('no two enum members share the same runtime string value', () => {
+    const all = [
+      ...Object.values(StatusIcon),
+      ...Object.values(KindIcon),
+      ...Object.values(BadgeIcon),
+      ...Object.values(RelationIcon),
+    ];
+    const unique = new Set(all);
+    expect(unique.size).toBe(all.length);
+  });
+});
+
+describe('ascii()', () => {
+  it('returns NO_COLOR fallback for every StatusIcon', () => {
+    expect(ascii(StatusIcon.PENDING)).toBe('[ ]');
+    expect(ascii(StatusIcon.ACTIVE)).toBe('[~]');
+    expect(ascii(StatusIcon.DONE)).toBe('[x]');
+    expect(ascii(StatusIcon.BLOCKED)).toBe('[!]');
+    expect(ascii(StatusIcon.ARCHIVED)).toBe('[#]');
+    expect(ascii(StatusIcon.CANCELLED)).toBe('[-]');
+  });
+
+  it('returns NO_COLOR fallback for every KindIcon', () => {
+    expect(ascii(KindIcon.SAGA)).toBe('SG');
+    expect(ascii(KindIcon.EPIC)).toBe('E');
+    expect(ascii(KindIcon.TASK)).toBe('-');
+    expect(ascii(KindIcon.SUBTASK)).toBe('.');
+    expect(ascii(KindIcon.RESEARCH)).toBe('R');
+    expect(ascii(KindIcon.BUG)).toBe('B');
+    expect(ascii(KindIcon.RELEASE)).toBe('>');
+  });
+
+  it('returns NO_COLOR fallback for every BadgeIcon', () => {
+    expect(ascii(BadgeIcon.EMPTY)).toBe('(empty)');
+    expect(ascii(BadgeIcon.ORPHAN)).toBe('(orphan)');
+    expect(ascii(BadgeIcon.NESTED)).toBe('(nested)');
+    expect(ascii(BadgeIcon.CAUTION)).toBe('(!)');
+    expect(ascii(BadgeIcon.NEW)).toBe('(new)');
+  });
+
+  it('returns NO_COLOR fallback for every RelationIcon', () => {
+    expect(ascii(RelationIcon.GROUPS)).toBe('in');
+    expect(ascii(RelationIcon.PARENT)).toBe('^');
+    expect(ascii(RelationIcon.DEPENDS)).toBe('->');
+    expect(ascii(RelationIcon.BLOCKS)).toBe('!>');
+  });
+});
+
+describe('pickIcon()', () => {
+  const originalNoColor = process.env['NO_COLOR'];
+  const originalTerm = process.env['TERM'];
+
+  beforeEach(() => {
+    delete process.env['NO_COLOR'];
+    delete process.env['TERM'];
+  });
+
+  afterEach(() => {
+    if (originalNoColor === undefined) {
+      delete process.env['NO_COLOR'];
+    } else {
+      process.env['NO_COLOR'] = originalNoColor;
+    }
+    if (originalTerm === undefined) {
+      delete process.env['TERM'];
+    } else {
+      process.env['TERM'] = originalTerm;
+    }
+  });
+
+  it('returns the emoji when noColor is explicitly false', () => {
+    expect(pickIcon(KindIcon.SAGA, { noColor: false })).toBe('🌲');
+    expect(pickIcon(StatusIcon.DONE, { noColor: false })).toBe('✅');
+  });
+
+  it('returns the ASCII form when noColor is explicitly true', () => {
+    expect(pickIcon(KindIcon.SAGA, { noColor: true })).toBe('SG');
+    expect(pickIcon(StatusIcon.DONE, { noColor: true })).toBe('[x]');
+  });
+
+  it('falls back to NO_COLOR=1 from process.env', () => {
+    process.env['NO_COLOR'] = '1';
+    expect(pickIcon(KindIcon.EPIC)).toBe('E');
+    expect(pickIcon(BadgeIcon.ORPHAN)).toBe('(orphan)');
+  });
+
+  it('falls back to TERM=dumb from process.env', () => {
+    process.env['TERM'] = 'dumb';
+    expect(pickIcon(RelationIcon.GROUPS)).toBe('in');
+  });
+
+  it('returns the emoji when no NO_COLOR signals are present', () => {
+    expect(pickIcon(KindIcon.TASK)).toBe('•');
+    expect(pickIcon(StatusIcon.ACTIVE)).toBe('🚧');
+  });
+});

--- a/packages/contracts/src/render/icon.ts
+++ b/packages/contracts/src/render/icon.ts
@@ -1,0 +1,182 @@
+/**
+ * Typed icon enums for the human-render contract (ADR-077).
+ *
+ * Single source of truth for the visual language used across all renderers
+ * (tree, table, list, badge). Each enum is emoji-first; `ascii()` returns the
+ * NO_COLOR-safe fallback for non-UTF-8 terminals or `NO_COLOR=1` environments.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Status icons — agent-task lifecycle states.
+ *
+ * Emoji-first; `ascii()` returns a NO_COLOR-safe fallback.
+ */
+export enum StatusIcon {
+  /** Task is queued and has not started. */
+  PENDING = '⏳',
+  /** Task is in progress. */
+  ACTIVE = '🚧',
+  /** Task completed successfully. */
+  DONE = '✅',
+  /** Task is blocked on a dependency or gate. */
+  BLOCKED = '🚪',
+  /** Task is archived and no longer actively tracked. */
+  ARCHIVED = '🗄',
+  /** Task was cancelled before completion. */
+  CANCELLED = '✗',
+}
+
+/**
+ * Task-kind icons — Saga / Epic / Task / Subtask plus ancillary kinds.
+ */
+export enum KindIcon {
+  /** Saga — multi-release theme grouping ≥ 2 Epics. */
+  SAGA = '🌲',
+  /** Epic — one releasable slice. */
+  EPIC = '📋',
+  /** Task — one atomic PR-sized change. */
+  TASK = '•',
+  /** Subtask — one commit contributing to a Task's PR. */
+  SUBTASK = '◦',
+  /** Research task — investigation or audit. */
+  RESEARCH = '📖',
+  /** Bug task — defect tracking. */
+  BUG = '🐛',
+  /** Release task — shipping work. */
+  RELEASE = '🚀',
+}
+
+/**
+ * Badge icons — flags attached to tasks (empty, orphan, nested, etc).
+ */
+export enum BadgeIcon {
+  /** Container has no children. */
+  EMPTY = '🪦',
+  /**
+   * Task has no parent and is unreachable from a Saga or Epic.
+   *
+   * NOTE: ADR-077 §2 originally specified `'🚪'`, identical to `StatusIcon.BLOCKED`.
+   * TypeScript string enums share a single runtime string so `ascii()` cannot
+   * disambiguate. Resolved by switching to `'👻'` (abandoned/lonely semantics).
+   * A follow-up ADR amendment lands in T10137 (B12).
+   */
+  ORPHAN = '👻',
+  /** Task is nested deeper than the depth budget allows. */
+  NESTED = '🔁',
+  /** Caution — something needs human attention. */
+  CAUTION = '⚠',
+  /** Recently added — surfaced for visibility. */
+  NEW = '★',
+}
+
+/**
+ * Relation icons — edge semantics in tree views.
+ */
+export enum RelationIcon {
+  /** Saga groups Epic via `task_relations.relation_type='groups'`. */
+  GROUPS = '⊂',
+  /** Parent edge — direct hierarchical parent. */
+  PARENT = '⤴',
+  /** Depends-on edge — A cannot start until B is done. */
+  DEPENDS = '⇨',
+  /** Blocks edge — A actively blocks B from progressing. */
+  BLOCKS = '⊘',
+}
+
+/**
+ * Union of every icon enum — useful as the parameter type for helpers that
+ * accept any icon without caring which category it came from.
+ */
+export type AnyIcon = StatusIcon | KindIcon | BadgeIcon | RelationIcon;
+
+/**
+ * Maps an emoji icon to its NO_COLOR-safe ASCII equivalent.
+ *
+ * Used when stdout is not a UTF-8 TTY or `NO_COLOR=1` is set. Every enum
+ * member has an explicit ASCII fallback — the exhaustive switch ensures the
+ * TypeScript compiler flags any future icon added without an ASCII mapping.
+ *
+ * @param icon - Any icon from `StatusIcon`, `KindIcon`, `BadgeIcon`, or `RelationIcon`.
+ * @returns The ASCII-only string to render in NO_COLOR contexts.
+ */
+export function ascii(icon: AnyIcon): string {
+  switch (icon) {
+    // Status
+    case StatusIcon.PENDING:
+      return '[ ]';
+    case StatusIcon.ACTIVE:
+      return '[~]';
+    case StatusIcon.DONE:
+      return '[x]';
+    case StatusIcon.BLOCKED:
+      return '[!]';
+    case StatusIcon.ARCHIVED:
+      return '[#]';
+    case StatusIcon.CANCELLED:
+      return '[-]';
+    // Kind
+    case KindIcon.SAGA:
+      return 'SG';
+    case KindIcon.EPIC:
+      return 'E';
+    case KindIcon.TASK:
+      return '-';
+    case KindIcon.SUBTASK:
+      return '.';
+    case KindIcon.RESEARCH:
+      return 'R';
+    case KindIcon.BUG:
+      return 'B';
+    case KindIcon.RELEASE:
+      return '>';
+    // Badge
+    case BadgeIcon.EMPTY:
+      return '(empty)';
+    case BadgeIcon.ORPHAN:
+      return '(orphan)';
+    case BadgeIcon.NESTED:
+      return '(nested)';
+    case BadgeIcon.CAUTION:
+      return '(!)';
+    case BadgeIcon.NEW:
+      return '(new)';
+    // Relation
+    case RelationIcon.GROUPS:
+      return 'in';
+    case RelationIcon.PARENT:
+      return '^';
+    case RelationIcon.DEPENDS:
+      return '->';
+    case RelationIcon.BLOCKS:
+      return '!>';
+  }
+}
+
+/**
+ * Options for {@link pickIcon}.
+ */
+export interface PickIconOptions {
+  /**
+   * Force ASCII fallback. When omitted, falls back to `NO_COLOR=1` or
+   * `TERM=dumb` in `process.env`.
+   */
+  noColor?: boolean;
+}
+
+/**
+ * Returns the icon to render given the current environment.
+ *
+ * Honors `NO_COLOR=1` and `TERM=dumb` for ASCII fallback when `opts.noColor`
+ * is not provided explicitly.
+ *
+ * @param icon - The icon to render.
+ * @param opts - Optional override for NO_COLOR detection.
+ * @returns The emoji icon, or its ASCII equivalent if NO_COLOR mode is active.
+ */
+export function pickIcon<I extends AnyIcon>(icon: I, opts?: PickIconOptions): string {
+  const noColor =
+    opts?.noColor ?? (process.env['NO_COLOR'] === '1' || process.env['TERM'] === 'dumb');
+  return noColor ? ascii(icon) : icon;
+}


### PR DESCRIPTION
## Summary
- Codifies emoji icons used in tree/list/badge renderers into typed enums (`StatusIcon`, `KindIcon`, `BadgeIcon`, `RelationIcon`).
- Each enum exposes `ascii()` for NO_COLOR / non-UTF8 fallback.
- `pickIcon()` helper honors `NO_COLOR=1` and `TERM=dumb` env vars.
- Adds a runtime uniqueness invariant test so this class of collision can never re-enter.

## ADR deviation
ADR-077 §2 specifies `BadgeIcon.ORPHAN = '🚪'`, identical to `StatusIcon.BLOCKED`. TypeScript string enums share a single runtime string so `ascii()` cannot disambiguate. Resolved by switching `BadgeIcon.ORPHAN` to `'👻'` (abandoned/lonely semantics). A follow-up ADR amendment will land in T10137 (B12).

## Test plan
- [x] `pnpm biome check --write .` — clean
- [x] `pnpm --filter @cleocode/contracts run build` — green
- [x] `pnpm --filter @cleocode/contracts exec vitest run` — 14/14 pass
- [x] Every enum value asserted against the ADR-077 canonical symbol (with ORPHAN deviation noted).
- [x] Runtime uniqueness invariant test added (regression lock for the BLOCKED/ORPHAN collision class).

## Refs
Closes T10127
Epic: T10114 (E11-HUMAN-RENDER-CONTRACT)
Saga: T9855
ADR: adr-077-human-render-contract