### PR TITLE
feat(T10130): renderEnvelopeForHuman() public API + registry (B5)

### DIFF
--- a/.changeset/t10130-render-envelope-entry.md
+++ b/.changeset/t10130-render-envelope-entry.md
@@ -1,0 +1,9 @@
+---
+"@cleocode/core": minor
+---
+
+feat(T10130): renderEnvelopeForHuman() public API + registry (B5)
+
+Adds the single public entry point for human rendering: routes a typed `RenderableEnvelope<T>` by `(command, kind)` to a registered renderer, with a generic fallback that handles every envelope kind via inline string concatenation + B4 helpers (kvBlock, dataTable). Pure function — no I/O, no DB. Foundation for B6/B7/B8 per-command renderers.
+
+Closes T10130. Epic: T10114. ADR: adr-077-human-render-contract.

--- a/packages/core/src/render/__tests__/render-envelope.test.ts
+++ b/packages/core/src/render/__tests__/render-envelope.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for the B5 public render entry point.
+ *
+ * Covers:
+ *   - JSON-format suppression
+ *   - Generic fallback when no renderer is registered
+ *   - (command, kind) routing of registered renderers
+ *   - Cross-kind isolation (a 'table' renderer never serves a 'tree' envelope)
+ *   - Fallback per-kind output (tree / table / list / grouped-list / section /
+ *     single / generic)
+ *   - Registry semantics (register, lookup, last-write-wins, reset)
+ *
+ * @epic T10114
+ * @task T10130
+ */
+
+import type { RenderableEnvelope } from '@cleocode/contracts';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  _resetRegistryForTests,
+  listRegisteredRenderers,
+  lookupRenderer,
+  registerRenderer,
+  renderEnvelopeForHuman,
+} from '../index.js';
+
+describe('renderEnvelopeForHuman', () => {
+  beforeEach(() => _resetRegistryForTests());
+
+  it('returns empty string for json format', () => {
+    const env: RenderableEnvelope<unknown> = { kind: 'generic', data: { x: 1 } };
+    expect(renderEnvelopeForHuman(env, 'whatever', { format: 'json' })).toBe('');
+  });
+
+  it('falls back to generic renderer when none registered', () => {
+    const env: RenderableEnvelope<unknown> = { kind: 'generic', data: { foo: 'bar' } };
+    const out = renderEnvelopeForHuman(env, 'unknown.command', {});
+    expect(out).toContain('foo');
+    expect(out).toContain('bar');
+  });
+
+  it('routes to a registered renderer by (command, kind)', () => {
+    registerRenderer('tasks.list', 'table', () => 'CUSTOM_TABLE_OUT');
+    const env: RenderableEnvelope<unknown> = {
+      kind: 'table',
+      data: { rows: [], schema: { columns: [] }, total: 0 },
+    };
+    expect(renderEnvelopeForHuman(env, 'tasks.list', {})).toBe('CUSTOM_TABLE_OUT');
+  });
+
+  it('does NOT route cross-kind (table renderer cannot serve tree envelope)', () => {
+    registerRenderer('tasks.list', 'table', () => 'CUSTOM_TABLE_OUT');
+    const treeEnv: RenderableEnvelope<unknown> = {
+      kind: 'tree',
+      data: { tree: [], root: 'T1', totalNodes: 0, maxDepth: 0 },
+    };
+    const out = renderEnvelopeForHuman(treeEnv, 'tasks.list', {});
+    expect(out).not.toBe('CUSTOM_TABLE_OUT');
+  });
+
+  it('does NOT route cross-command (renderer for cmdA cannot serve cmdB)', () => {
+    registerRenderer('cmdA', 'generic', () => 'A_OUT');
+    const env: RenderableEnvelope<unknown> = { kind: 'generic', data: { foo: 'bar' } };
+    expect(renderEnvelopeForHuman(env, 'cmdA', {})).toBe('A_OUT');
+    expect(renderEnvelopeForHuman(env, 'cmdB', {})).not.toBe('A_OUT');
+  });
+
+  it('passes opts through to a registered renderer', () => {
+    registerRenderer('cmd', 'generic', (_env, opts) => `verbose=${opts.verbose ?? false}`);
+    const env: RenderableEnvelope<unknown> = { kind: 'generic', data: {} };
+    expect(renderEnvelopeForHuman(env, 'cmd', { verbose: true })).toBe('verbose=true');
+  });
+
+  it('fallback renders tree with depth-based indent', () => {
+    const env: RenderableEnvelope<{ note: string }> = {
+      kind: 'tree',
+      data: {
+        root: 'T1',
+        totalNodes: 3,
+        maxDepth: 2,
+        tree: [
+          {
+            id: 'T1',
+            parentId: null,
+            depth: 0,
+            kind: 'epic',
+            status: 'pending',
+            title: 'root',
+            metadata: { note: 'r' },
+          },
+          {
+            id: 'T2',
+            parentId: 'T1',
+            depth: 1,
+            kind: 'task',
+            status: 'pending',
+            title: 'child',
+            metadata: { note: 'c' },
+          },
+          {
+            id: 'T3',
+            parentId: 'T2',
+            depth: 2,
+            kind: 'subtask',
+            status: 'pending',
+            title: 'grand',
+            metadata: { note: 'g' },
+          },
+        ],
+      },
+    };
+    const out = renderEnvelopeForHuman(env, 'unknown', {});
+    expect(out).toContain('root');
+    expect(out).toContain('child');
+    expect(out).toContain('grand');
+    // ASCII bracket prefixes (no emoji icons — B2 owns that).
+    expect(out).toContain('[epic]');
+    expect(out).toContain('[task]');
+    expect(out).toContain('[subtask]');
+  });
+
+  it('fallback renders empty tree as empty string', () => {
+    const env: RenderableEnvelope<unknown> = {
+      kind: 'tree',
+      data: { tree: [], root: '', totalNodes: 0, maxDepth: 0 },
+    };
+    expect(renderEnvelopeForHuman(env, 'unknown', {})).toBe('');
+  });
+
+  it('fallback renders table via dataTable helper from B4', () => {
+    const env: RenderableEnvelope<{ id: string; title: string }> = {
+      kind: 'table',
+      data: {
+        total: 2,
+        rows: [
+          { id: 'T1', title: 'first' },
+          { id: 'T2', title: 'second' },
+        ],
+        schema: {
+          columns: [
+            { key: 'id', header: 'ID' },
+            { key: 'title', header: 'Title' },
+          ],
+        },
+      },
+    };
+    const out = renderEnvelopeForHuman(env, 'unknown', {});
+    expect(out).toContain('T1');
+    expect(out).toContain('first');
+    expect(out).toContain('T2');
+    expect(out).toContain('second');
+  });
+
+  it('fallback renders list items with `- ` prefix', () => {
+    const env: RenderableEnvelope<string> = {
+      kind: 'list',
+      data: { items: ['alpha', 'beta'], total: 2 },
+    };
+    const out = renderEnvelopeForHuman(env, 'unknown', {});
+    expect(out).toContain('- alpha');
+    expect(out).toContain('- beta');
+  });
+
+  it('fallback renders grouped-list with one section per group', () => {
+    const env: RenderableEnvelope<string> = {
+      kind: 'grouped-list',
+      data: {
+        total: 3,
+        groups: [
+          { key: 'a', label: 'Group A', items: ['a1', 'a2'] },
+          { key: 'b', label: 'Group B', items: ['b1'] },
+        ],
+      },
+    };
+    const out = renderEnvelopeForHuman(env, 'unknown', {});
+    expect(out).toContain('Group A');
+    expect(out).toContain('- a1');
+    expect(out).toContain('- a2');
+    expect(out).toContain('Group B');
+    expect(out).toContain('- b1');
+  });
+
+  it('fallback renders section header + items', () => {
+    const env: RenderableEnvelope<unknown> = {
+      kind: 'section',
+      data: { header: 'Active', items: ['T1 alpha', 'T2 beta'] },
+    };
+    const out = renderEnvelopeForHuman(env, 'briefing.next', {});
+    expect(out).toContain('Active');
+    expect(out).toContain('T1 alpha');
+    expect(out).toContain('T2 beta');
+  });
+
+  it('fallback renders single (object payload) via kvBlock', () => {
+    const env: RenderableEnvelope<{ id: string; status: string }> = {
+      kind: 'single',
+      data: { id: 'T1', status: 'pending' },
+    };
+    const out = renderEnvelopeForHuman(env, 'unknown', {});
+    expect(out).toContain('id');
+    expect(out).toContain('T1');
+    expect(out).toContain('status');
+    expect(out).toContain('pending');
+  });
+
+  it('fallback renders single (scalar payload) via String()', () => {
+    const env: RenderableEnvelope<number> = { kind: 'single', data: 42 };
+    expect(renderEnvelopeForHuman(env, 'unknown', {})).toBe('42');
+  });
+
+  it('fallback renders generic envelope via kvBlock', () => {
+    const env: RenderableEnvelope<unknown> = {
+      kind: 'generic',
+      data: { a: 1, b: 'two' },
+    };
+    const out = renderEnvelopeForHuman(env, 'unknown', {});
+    expect(out).toContain('a');
+    expect(out).toContain('1');
+    expect(out).toContain('b');
+    expect(out).toContain('two');
+  });
+});
+
+describe('registry', () => {
+  beforeEach(() => _resetRegistryForTests());
+
+  it('registers + retrieves a renderer', () => {
+    const fn = () => 'X';
+    registerRenderer('cmd', 'tree', fn);
+    expect(lookupRenderer('cmd', 'tree')).toBe(fn);
+  });
+
+  it('returns undefined for an unregistered key', () => {
+    expect(lookupRenderer('absent', 'generic')).toBeUndefined();
+  });
+
+  it('last-write wins for same (command, kind)', () => {
+    registerRenderer('cmd', 'tree', () => 'A');
+    registerRenderer('cmd', 'tree', () => 'B');
+    const renderer = lookupRenderer('cmd', 'tree');
+    expect(renderer).toBeDefined();
+    const env: RenderableEnvelope<unknown> = {
+      kind: 'tree',
+      data: { tree: [], root: '', totalNodes: 0, maxDepth: 0 },
+    };
+    expect(renderer?.(env, {})).toBe('B');
+  });
+
+  it('listRegisteredRenderers returns sorted snapshot', () => {
+    registerRenderer('beta', 'generic', () => '');
+    registerRenderer('alpha', 'table', () => '');
+    registerRenderer('alpha', 'tree', () => '');
+    const keys = listRegisteredRenderers();
+    expect(keys).toEqual(['alpha:table', 'alpha:tree', 'beta:generic']);
+  });
+
+  it('_resetRegistryForTests clears every registration', () => {
+    registerRenderer('cmd', 'tree', () => 'X');
+    expect(listRegisteredRenderers()).toHaveLength(1);
+    _resetRegistryForTests();
+    expect(listRegisteredRenderers()).toHaveLength(0);
+  });
+});

--- a/packages/core/src/render/fallback.ts
+++ b/packages/core/src/render/fallback.ts
@@ -1,0 +1,214 @@
+/**
+ * Generic kind-based fallback renderer.
+ *
+ * When {@link ./render-envelope.ts | renderEnvelopeForHuman} cannot find a
+ * `(command, kind)`-specific renderer, it delegates here. The fallback covers
+ * every {@link RenderableEnvelope} variant using inline string concatenation
+ * plus the B4 helpers ({@link ./helpers.ts | kvBlock, dataTable, truncated}).
+ *
+ * Constraints (ADR-077):
+ *   - Pure function — no I/O, no DB access.
+ *   - No imports from `packages/animations/` — B3 primitives are owned by B3
+ *     and wired in by the per-command renderers landing in B6/B7/B8.
+ *   - No emoji icons — B2 (T10127) owns the icon enum.
+ *
+ * @epic T10114
+ * @task T10130
+ */
+
+import type {
+  FlatTreeNode,
+  GroupedListResponse,
+  ListResponse,
+  RenderableEnvelope,
+  SectionResponse,
+  TableResponse,
+  TreeResponse,
+} from '@cleocode/contracts';
+import { type DataTableColumn, dataTable, kvBlock } from './helpers.js';
+import type { RenderOptions } from './types.js';
+
+/**
+ * Render any {@link RenderableEnvelope} to a human-readable string using the
+ * generic per-kind fallback strategy.
+ *
+ * @typeParam T — envelope payload shape (opaque to the fallback).
+ */
+export function renderFallback<T>(envelope: RenderableEnvelope<T>, _opts: RenderOptions): string {
+  switch (envelope.kind) {
+    case 'tree':
+      return renderTreeFallback(envelope.data);
+    case 'table':
+      return renderTableFallback(envelope.data);
+    case 'list':
+      return renderListFallback(envelope.data);
+    case 'grouped-list':
+      return renderGroupedListFallback(envelope.data);
+    case 'section':
+      return renderSectionFallback(envelope.data);
+    case 'single':
+      return renderSingleFallback(envelope.data);
+    case 'generic':
+      return renderGenericFallback(envelope.data);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// tree
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk a {@link TreeResponse} and emit one line per node with depth-based
+ * indentation. Last-sibling detection uses the next-node lookahead — when the
+ * next row's depth is less than or equal to the current row, the current row
+ * is a last sibling.
+ *
+ * NO emoji icons (B2 owns those); plain ASCII bracket prefixes derived from
+ * `node.kind` give a stable, lossless rendering.
+ */
+function renderTreeFallback<T>(data: TreeResponse<T>): string {
+  const nodes = data.tree;
+  if (nodes.length === 0) return '';
+
+  // Track per-depth "is the path to this depth still on a last-sibling chain?"
+  // so we can draw correct continuation pipes without needing parent ids.
+  const lastAtDepth: boolean[] = [];
+  const lines: string[] = [];
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i] as FlatTreeNode<T>;
+    const next = nodes[i + 1];
+    // Current row is a last sibling when no later node is at the same depth
+    // before depth decreases below it (lookahead until depth drops below).
+    const isLast = isLastSibling(nodes, i);
+    lastAtDepth[node.depth] = isLast;
+
+    const prefix = renderTreePrefix(node.depth, isLast, lastAtDepth);
+    const kindTag = `[${node.kind}]`;
+    lines.push(`${prefix}${kindTag} ${node.id} ${node.title}`);
+    // If this row is last AND next exists at shallower depth, we don't strictly
+    // need to clear deeper levels — the next iteration recomputes from scratch.
+    void next;
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Detect whether `nodes[i]` is the final sibling at its depth — true when no
+ * later node at the same depth appears before depth drops below `node.depth`.
+ */
+function isLastSibling<T>(nodes: ReadonlyArray<FlatTreeNode<T>>, i: number): boolean {
+  const cur = nodes[i] as FlatTreeNode<T>;
+  for (let j = i + 1; j < nodes.length; j++) {
+    const candidate = nodes[j] as FlatTreeNode<T>;
+    if (candidate.depth < cur.depth) return true;
+    if (candidate.depth === cur.depth) return false;
+  }
+  return true;
+}
+
+/**
+ * Build the indent prefix string for a tree row.
+ *
+ * - Ancestors that are still on a last-sibling chain contribute spaces.
+ * - Ancestors with more siblings contribute a vertical pipe.
+ * - The final segment is `└─ ` for last siblings, `├─ ` otherwise.
+ * - Depth 0 (root) gets no prefix.
+ */
+function renderTreePrefix(depth: number, isLast: boolean, lastAtDepth: boolean[]): string {
+  if (depth === 0) return '';
+  let out = '';
+  for (let d = 0; d < depth - 1; d++) {
+    out += lastAtDepth[d] === true ? '   ' : '│  ';
+  }
+  out += isLast ? '└─ ' : '├─ ';
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// table
+// ---------------------------------------------------------------------------
+
+/**
+ * Delegate to the B4 `dataTable` helper. Each schema column becomes a
+ * `DataTableColumn` whose getter looks up `row[column.key]` and applies any
+ * supplied `format` function (otherwise falls back to `String(value)`).
+ */
+function renderTableFallback<T>(data: TableResponse<T>): string {
+  const columns: DataTableColumn<T>[] = data.schema.columns.map((col) => ({
+    header: col.header,
+    get: (row) => {
+      const raw = (row as Record<string, unknown>)[col.key];
+      if (col.format) return col.format(raw);
+      return String(raw ?? '');
+    },
+    ...(typeof col.width === 'number' ? { maxWidth: col.width } : {}),
+  }));
+  return dataTable(data.rows, columns);
+}
+
+// ---------------------------------------------------------------------------
+// list / grouped-list
+// ---------------------------------------------------------------------------
+
+/** Render one item via `kvBlock` when it's an object, else `String(item)`. */
+function renderListItem<T>(item: T): string {
+  if (item !== null && typeof item === 'object') {
+    const rows: Array<[string, string]> = Object.entries(item as Record<string, unknown>).map(
+      ([k, v]) => [k, String(v ?? '')],
+    );
+    return kvBlock(rows, 0);
+  }
+  return String(item);
+}
+
+function renderListFallback<T>(data: ListResponse<T>): string {
+  if (data.items.length === 0) return '';
+  return data.items.map((item) => `- ${renderListItem(item)}`).join('\n');
+}
+
+function renderGroupedListFallback<T>(data: GroupedListResponse<T>): string {
+  if (data.groups.length === 0) return '';
+  return data.groups
+    .map((group) => {
+      const header = group.label;
+      const body =
+        group.items.length === 0
+          ? ''
+          : `\n${group.items.map((item) => `- ${renderListItem(item)}`).join('\n')}`;
+      return `${header}${body}`;
+    })
+    .join('\n\n');
+}
+
+// ---------------------------------------------------------------------------
+// section
+// ---------------------------------------------------------------------------
+
+function renderSectionFallback(data: SectionResponse): string {
+  const headerPrefix = data.icon ? `${data.icon} ` : '';
+  const header = `${headerPrefix}${data.header}`;
+  if (data.items.length === 0) return header;
+  const body = data.items.map((item) => `- ${item}`).join('\n');
+  return `${header}\n${body}`;
+}
+
+// ---------------------------------------------------------------------------
+// single / generic
+// ---------------------------------------------------------------------------
+
+function renderSingleFallback<T>(data: T): string {
+  if (data !== null && typeof data === 'object') {
+    const rows: Array<[string, string]> = Object.entries(data as Record<string, unknown>).map(
+      ([k, v]) => [k, String(v ?? '')],
+    );
+    return kvBlock(rows);
+  }
+  return String(data);
+}
+
+function renderGenericFallback(data: Record<string, unknown>): string {
+  const rows: Array<[string, string]> = Object.entries(data).map(([k, v]) => [k, String(v ?? '')]);
+  return kvBlock(rows);
+}

--- a/packages/core/src/render/index.ts
+++ b/packages/core/src/render/index.ts
@@ -10,4 +10,9 @@
  * @task T10129
  */
 
+export * from './ansi.js';
+export * from './fallback.js';
 export * from './helpers.js';
+export * from './registry.js';
+export * from './render-envelope.js';
+export * from './types.js';

--- a/packages/core/src/render/registry.ts
+++ b/packages/core/src/render/registry.ts
@@ -1,0 +1,66 @@
+/**
+ * Singleton registry mapping `(command, kind)` → renderer.
+ *
+ * The registry is process-global; per-command renderers register themselves
+ * at module-load time and {@link ./render-envelope.ts | renderEnvelopeForHuman}
+ * looks them up at call time. Last-write wins when two registrations target
+ * the same `(command, kind)` slot — this keeps test setup simple and lets
+ * later modules override earlier registrations when needed.
+ *
+ * @epic T10114
+ * @task T10130
+ */
+
+import type { RenderableEnvelope } from '@cleocode/contracts';
+import type { RegistryKey, Renderer } from './types.js';
+
+const REGISTRY = new Map<RegistryKey, Renderer>();
+
+/**
+ * Register a renderer for a specific `(command, kind)` pair.
+ *
+ * Last-write wins — registering twice for the same key replaces the previous
+ * entry without warning. Callers that need uniqueness checks should call
+ * {@link lookupRenderer} first.
+ *
+ * @typeParam T — envelope payload shape the renderer understands.
+ * @param command Command identifier (e.g. `'tasks.list'`).
+ * @param kind Envelope discriminator (e.g. `'tree'`, `'table'`).
+ * @param renderer Function that converts the envelope to a string.
+ */
+export function registerRenderer<T>(
+  command: string,
+  kind: RenderableEnvelope<T>['kind'],
+  renderer: Renderer<T>,
+): void {
+  REGISTRY.set(`${command}:${kind}` as RegistryKey, renderer as Renderer);
+}
+
+/**
+ * Look up the renderer registered for `(command, kind)`.
+ *
+ * @typeParam T — expected envelope payload shape.
+ * @returns The registered renderer, or `undefined` when none is registered.
+ */
+export function lookupRenderer<T>(
+  command: string,
+  kind: RenderableEnvelope<T>['kind'],
+): Renderer<T> | undefined {
+  return REGISTRY.get(`${command}:${kind}` as RegistryKey) as Renderer<T> | undefined;
+}
+
+/**
+ * Test-only — clear every registration. Production code MUST NOT call this.
+ */
+export function _resetRegistryForTests(): void {
+  REGISTRY.clear();
+}
+
+/**
+ * Snapshot the registered keys in sorted order. Useful for telemetry and
+ * debug surfaces that need to enumerate which `(command, kind)` slots are
+ * covered.
+ */
+export function listRegisteredRenderers(): RegistryKey[] {
+  return Array.from(REGISTRY.keys()).sort() as RegistryKey[];
+}

--- a/packages/core/src/render/render-envelope.ts
+++ b/packages/core/src/render/render-envelope.ts
@@ -1,0 +1,44 @@
+/**
+ * `renderEnvelopeForHuman` — the single public entry point for converting a
+ * typed {@link RenderableEnvelope} into a human-readable string.
+ *
+ * Routes by `(command, envelope.kind)` to a registered renderer; falls back to
+ * the generic kind-based fallback when no specific renderer is registered.
+ * Pure function — no I/O, no DB access, no animations module imports.
+ *
+ * @epic T10114
+ * @task T10130
+ */
+
+import type { RenderableEnvelope } from '@cleocode/contracts';
+import { renderFallback } from './fallback.js';
+import { lookupRenderer } from './registry.js';
+import type { RenderOptions } from './types.js';
+
+/**
+ * Render a typed {@link RenderableEnvelope} as a human-readable string.
+ *
+ * Routing rules:
+ *   1. When `opts.format === 'json'`, return `''` immediately — the JSON
+ *      path is the caller's responsibility.
+ *   2. Look up a renderer registered for exactly `(command, envelope.kind)`.
+ *      If present, delegate.
+ *   3. Otherwise delegate to {@link renderFallback}, which handles every
+ *      envelope kind via inline string concatenation + B4 helpers.
+ *
+ * @typeParam T — envelope payload shape.
+ * @param envelope The typed envelope produced by an operation.
+ * @param command  The command that produced the envelope (e.g. `'tasks.list'`).
+ * @param opts     Per-call render options. Defaults to an empty object.
+ * @returns The string to write to stdout. Empty string suppresses output.
+ */
+export function renderEnvelopeForHuman<T>(
+  envelope: RenderableEnvelope<T>,
+  command: string,
+  opts: RenderOptions = {},
+): string {
+  if (opts.format === 'json') return '';
+  const specific = lookupRenderer<T>(command, envelope.kind);
+  if (specific) return specific(envelope, opts);
+  return renderFallback(envelope, opts);
+}

--- a/packages/core/src/render/types.ts
+++ b/packages/core/src/render/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Local render types — not shared via `@cleocode/contracts`.
+ *
+ * Caller-facing options for {@link ./render-envelope.ts | renderEnvelopeForHuman}
+ * plus the `Renderer<T>` function shape used by the registry. These types live
+ * in core (not contracts) because they describe presenter behaviour rather
+ * than wire-format payloads — the contracts package stays pure-data.
+ *
+ * @epic T10114
+ * @task T10130
+ */
+
+import type { RenderableEnvelope } from '@cleocode/contracts';
+
+/**
+ * Per-call render options. Mirrors the format axes already used by the CLI
+ * but lives in core so non-CLI callers (tests, programmatic consumers) can
+ * pass them too.
+ */
+export interface RenderOptions {
+  /** Output format. `'human'` (default) returns a formatted string; `'json'` suppresses output. */
+  readonly format?: 'human' | 'json';
+  /** When `true`, suppress ANSI color escapes in the output. */
+  readonly noColor?: boolean;
+  /** Terminal width hint in columns. Defaults to 80 when not provided. */
+  readonly width?: number;
+  /** When `true`, presenters MAY emit extended detail. */
+  readonly verbose?: boolean;
+}
+
+/**
+ * A renderer accepts a typed envelope plus per-call options and returns the
+ * string to write to stdout. Returning `''` suppresses output for that call.
+ *
+ * @typeParam T — caller-defined envelope payload shape.
+ */
+export type Renderer<T = unknown> = (
+  envelope: RenderableEnvelope<T>,
+  opts: RenderOptions,
+) => string;
+
+/**
+ * Registry key — `${command}:${kind}` uniquely addresses a renderer slot.
+ *
+ * `command` is the CLEO command that produced the envelope (e.g.
+ * `'tasks.list'`); `kind` is the discriminator on `RenderableEnvelope<T>`.
+ */
+export type RegistryKey = `${string}:${RenderableEnvelope<unknown>['kind']}`;


### PR DESCRIPTION
## Summary
- Adds \`renderEnvelopeForHuman(envelope, command, opts)\` — single public entry point in \`packages/core/src/render/\`.
- Adds typed \`(command, kind)\` → \`Renderer\` registry with \`registerRenderer\` / \`lookupRenderer\` / \`listRegisteredRenderers\` / \`_resetRegistryForTests\`.
- Adds generic fallback that handles every envelope kind (\`tree\` / \`table\` / \`list\` / \`grouped-list\` / \`section\` / \`single\` / \`generic\`) via inline string + B4 helpers.
- Zero \`packages/animations/\` imports — B3 primitives are owned by B3 and will be wired in by B6/B7/B8.
- Zero \`packages/cleo/\` imports — core never depends on cleo.
- Pure function — no I/O, no DB access in the render path.

## Test plan
- [x] \`pnpm biome check --write .\` — clean
- [x] \`pnpm run build\` — full repo dep graph green
- [x] \`pnpm --filter @cleocode/core exec vitest run src/render/__tests__/\` — 40/40 passing (20 new + 20 existing B4 helper tests)
- [x] Entry point routes registered renderers + falls back for unregistered.
- [x] Cross-kind routing isolation (a \`table\` renderer never serves a \`tree\` envelope).
- [x] Cross-command routing isolation (a renderer for \`cmdA\` never serves \`cmdB\`).
- [x] Fallback covers tree / table / list / grouped-list / section / single / generic.
- [x] Registry: register + lookup + last-write-wins + sorted snapshot + reset.

## Refs
Closes T10130
Epic: T10114 (E11-HUMAN-RENDER-CONTRACT)
Saga: T9855
ADR: adr-077-human-render-contract