### PR TITLE
chore(T10185): drop unused cleo-conduit-core dep from cant-core

### DIFF
--- a/.changeset/T10185-cant-cleanup.md
+++ b/.changeset/T10185-cant-cleanup.md
@@ -1,0 +1,8 @@
+---
+'@cleocode/cleo': patch
+---
+
+chore(T10185): drop unused cleo-conduit-core dep from cant-core (saga T10180).
+cant-core never referenced any conduit symbol across 60+ src files — pre-existing
+bogus Cargo coupling. Removing makes cant-core a true leaf crate, ready for
+crates.io publish in any order alongside lafs-core and cleo-conduit-core.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,6 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 name = "cant-core"
 version = "2026.5.105"
 dependencies = [
- "cleo-conduit-core",
  "criterion",
  "nom",
  "serde",
@@ -321,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "cleocode-workspace"
-version = "2026.5.105"
+version = "2026.5.104"
 
 [[package]]
 name = "convert_case"

--- a/crates/cant-core/Cargo.toml
+++ b/crates/cant-core/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = ["rlib"]
 nom = "7.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-cleo-conduit-core = { path = "../cleo-conduit-core", version = "=2026.5.105" }
 
 [build-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
## Summary

cant-core has a `cleo-conduit-core` dep in `[dependencies]` that is **never used** in source: `grep -rn "conduit_core" crates/cant-core/src/` returns 0 across 60+ files. Pre-existing bogus Cargo coupling.

Removing it makes cant-core a true leaf crate (`nom + serde + serde_json` only), respecting the architectural boundary where CANT (instruction parsing) and Conduit (agent-to-agent messaging) are orthogonal concerns. TS confirms: `packages/cant/src/index.ts` imports `@cleocode/lafs` but never `@cleocode/conduit`.

Unblocks crates.io publish of cleo-conduit-core, lafs-core, and cant-core in any order (no more enforced dep order).

## Test plan

- [x] `grep -rn "conduit_core" crates/cant-core/src/` → 0
- [ ] CI cargo check --workspace passes (covers ferrous-forge intercept)
- [ ] CI cargo test --workspace passes

Saga: T10180  
Decision: D003