### PR TITLE
fix(release): strip v prefix from VERSION before CalVer parsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          BASE_VERSION="${VERSION%%-*}"
+          BASE_VERSION="${VERSION#v}"; BASE_VERSION="${BASE_VERSION%%-*}"
           TAG_YEAR="${BASE_VERSION%%.*}"
           TAG_MONTH="${BASE_VERSION#*.}"; TAG_MONTH="${TAG_MONTH%%.*}"
           CURRENT_YEAR=$(date -u +%Y)


### PR DESCRIPTION
One-line fix. Was failing 'v2026' != '2026' on every v2026.5.102+ Release workflow run. Unblocks T10176 saga release v2026.5.106.