### PR TITLE
fix(T10185): align lafs-core + cant-core version pins for crates.io publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,9 @@ napi-build = "1"
 tower-lsp = "0.20"
 
 # Local workspace crates
-lafs-core = { path = "crates/lafs-core" }
+lafs-core = { path = "crates/lafs-core", version = "=2026.5.105" }
 cleo-conduit-core = { path = "crates/cleo-conduit-core", version = "=2026.5.105" }
-cant-core = { path = "crates/cant-core" }
+cant-core = { path = "crates/cant-core", version = "=2026.5.105" }
 cant-lsp = { path = "crates/cant-lsp" }
 cant-napi = { path = "crates/cant-napi" }
 cant-runtime = { path = "crates/cant-runtime" }

--- a/crates/cleo-conduit-core/Cargo.toml
+++ b/crates/cleo-conduit-core/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-lafs-core = { path = "../lafs-core", version = "2026.5.99" }
+lafs-core = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
## Summary

Two pre-publish fixes for the imminent crates.io initial publish of lafs-core, cleo-conduit-core, cant-core (saga T10180 W4):

1. **cleocode/Cargo.toml [workspace.dependencies]**: added `version = \"=2026.5.105\"` pins to `lafs-core` and `cant-core` (previously path-only — crates.io rejects path-only deps for publish, and downstream consumers need a resolvable version).
2. **cleo-conduit-core/Cargo.toml**: dropped hardcoded stale `lafs-core = { ..., version = \"2026.5.99\" }` pin. Switched to `lafs-core = { workspace = true }` for single SSoT (workspace.package.version drives the dep version automatically).

Without these, the publish chain breaks: cleo-conduit-core would try to resolve `lafs-core = \"2026.5.99\"` from crates.io after lafs-core is published as `2026.5.105`.

## Test plan
- [ ] CI lint passes
- [ ] cargo build --workspace works (workspace.deps still resolve)

Saga: T10180  
Decision: D003