### PR TITLE
feat(T10128): animations static UI primitives — tree/table/section/badge/legend (B3)

### DIFF
--- a/.changeset/t10128-animations-render-primitives.md
+++ b/.changeset/t10128-animations-render-primitives.md
@@ -1,0 +1,10 @@
+---
+"@cleocode/animations": minor
+---
+
+feat(T10128): static UI primitives — Tree, Table, Section, Badge, Legend (B3)
+
+Extends @cleocode/animations with `./render` sub-export shipping 5 pure-string primitives consuming the typed contracts from B1 (T10126) and icon enums from B2 (T10127). All AnimateContext-gated for JSON/quiet/no-TTY/no-color silence parity with existing spinners.
+
+Subtasks: T10142 tree, T10143 table, T10144 section, T10145 badge, T10146 legend.
+Closes T10128. Epic: T10114. ADR: adr-077-human-render-contract.

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -37,6 +37,10 @@
       "types": "./dist/src/spinner-handle.d.ts",
       "import": "./dist/src/spinner-handle.js"
     },
+    "./render": {
+      "types": "./dist/src/render/index.d.ts",
+      "import": "./dist/src/render/index.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -74,6 +78,9 @@
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0"
+  },
+  "dependencies": {
+    "@cleocode/contracts": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/packages/animations/src/index.ts
+++ b/packages/animations/src/index.ts
@@ -46,10 +46,27 @@ export {
   progressBars,
   renderProgressBar,
 } from './progress.js';
-
+// === Static UI primitives (T10128 — tree, table, section, badge, legend) ===
+export {
+  type LegendItem,
+  type RenderBadgeOptions,
+  type RenderLegendInput,
+  type RenderSectionInput,
+  type RenderSummaryInput,
+  type RenderTableOptions,
+  type RenderTreeViewOptions,
+  renderBadge,
+  renderLegend,
+  renderSection,
+  renderStatusBadge,
+  renderSummary,
+  renderTable,
+  renderTree,
+  type StatusBadgeName,
+  type SummaryCount,
+} from './render/index.js';
 // === Sparks (one-shot accents) ===
 export { type Spark, type SparkName, sparkDurationMs, sparks } from './spark.js';
-
 // === Spinner handle (canonical owner of \r writes) ===
 export {
   createSpinnerHandle,

--- a/packages/animations/src/render/__tests__/badge.test.ts
+++ b/packages/animations/src/render/__tests__/badge.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for renderBadge / renderStatusBadge — single-glyph emoji + ASCII output.
+ *
+ * Covers every icon enum + ASCII fallback + AnimateContext gating.
+ */
+
+import { BadgeIcon, KindIcon, RelationIcon, StatusIcon } from '@cleocode/contracts/render/icon.js';
+import { describe, expect, it } from 'vitest';
+import { createAnimateContext, SILENT_CONTEXT } from '../../animate-context.js';
+import { renderBadge, renderStatusBadge, type StatusBadgeName } from '../badge.js';
+
+const enabledCtx = createAnimateContext({
+  flagResolution: { format: 'human', quiet: false },
+  isTTY: true,
+  noColor: false,
+});
+
+// NOTE: createAnimateContext({ noColor: true }) returns enabled=false (silences
+// rendering entirely). To exercise the ASCII fallback path, we pass `ascii: true`
+// explicitly OR construct a synthetic context whose `inputs.noColor` is true but
+// `enabled` remains true. The explicit `ascii` flag is the public knob.
+const asciiOpts = { ctx: enabledCtx, ascii: true } as const;
+
+describe('renderBadge', () => {
+  it('returns empty string when context is silent', () => {
+    expect(renderBadge(StatusIcon.DONE, { ctx: SILENT_CONTEXT })).toBe('');
+  });
+
+  it('renders every StatusIcon as emoji', () => {
+    expect(renderBadge(StatusIcon.PENDING, { ctx: enabledCtx })).toBe('⏳');
+    expect(renderBadge(StatusIcon.ACTIVE, { ctx: enabledCtx })).toBe('🚧');
+    expect(renderBadge(StatusIcon.DONE, { ctx: enabledCtx })).toBe('✅');
+    expect(renderBadge(StatusIcon.BLOCKED, { ctx: enabledCtx })).toBe('🚪');
+    expect(renderBadge(StatusIcon.ARCHIVED, { ctx: enabledCtx })).toBe('🗄');
+    expect(renderBadge(StatusIcon.CANCELLED, { ctx: enabledCtx })).toBe('✗');
+  });
+
+  it('renders every StatusIcon as ASCII under noColor context', () => {
+    expect(renderBadge(StatusIcon.PENDING, asciiOpts)).toBe('[ ]');
+    expect(renderBadge(StatusIcon.ACTIVE, asciiOpts)).toBe('[~]');
+    expect(renderBadge(StatusIcon.DONE, asciiOpts)).toBe('[x]');
+    expect(renderBadge(StatusIcon.BLOCKED, asciiOpts)).toBe('[!]');
+    expect(renderBadge(StatusIcon.ARCHIVED, asciiOpts)).toBe('[#]');
+    expect(renderBadge(StatusIcon.CANCELLED, asciiOpts)).toBe('[-]');
+  });
+
+  it('renders every KindIcon as emoji', () => {
+    expect(renderBadge(KindIcon.SAGA, { ctx: enabledCtx })).toBe('🌲');
+    expect(renderBadge(KindIcon.EPIC, { ctx: enabledCtx })).toBe('📋');
+    expect(renderBadge(KindIcon.TASK, { ctx: enabledCtx })).toBe('•');
+    expect(renderBadge(KindIcon.SUBTASK, { ctx: enabledCtx })).toBe('◦');
+    expect(renderBadge(KindIcon.RESEARCH, { ctx: enabledCtx })).toBe('📖');
+    expect(renderBadge(KindIcon.BUG, { ctx: enabledCtx })).toBe('🐛');
+    expect(renderBadge(KindIcon.RELEASE, { ctx: enabledCtx })).toBe('🚀');
+  });
+
+  it('renders every KindIcon as ASCII under noColor context', () => {
+    expect(renderBadge(KindIcon.SAGA, asciiOpts)).toBe('SG');
+    expect(renderBadge(KindIcon.EPIC, asciiOpts)).toBe('E');
+    expect(renderBadge(KindIcon.TASK, asciiOpts)).toBe('-');
+    expect(renderBadge(KindIcon.SUBTASK, asciiOpts)).toBe('.');
+    expect(renderBadge(KindIcon.RESEARCH, asciiOpts)).toBe('R');
+    expect(renderBadge(KindIcon.BUG, asciiOpts)).toBe('B');
+    expect(renderBadge(KindIcon.RELEASE, asciiOpts)).toBe('>');
+  });
+
+  it('renders every BadgeIcon — note ORPHAN is 👻 (B2 deviation from ADR-077)', () => {
+    expect(renderBadge(BadgeIcon.EMPTY, { ctx: enabledCtx })).toBe('🪦');
+    expect(renderBadge(BadgeIcon.ORPHAN, { ctx: enabledCtx })).toBe('👻');
+    expect(renderBadge(BadgeIcon.NESTED, { ctx: enabledCtx })).toBe('🔁');
+    expect(renderBadge(BadgeIcon.CAUTION, { ctx: enabledCtx })).toBe('⚠');
+    expect(renderBadge(BadgeIcon.NEW, { ctx: enabledCtx })).toBe('★');
+  });
+
+  it('renders every RelationIcon', () => {
+    expect(renderBadge(RelationIcon.GROUPS, { ctx: enabledCtx })).toBe('⊂');
+    expect(renderBadge(RelationIcon.PARENT, { ctx: enabledCtx })).toBe('⤴');
+    expect(renderBadge(RelationIcon.DEPENDS, { ctx: enabledCtx })).toBe('⇨');
+    expect(renderBadge(RelationIcon.BLOCKS, { ctx: enabledCtx })).toBe('⊘');
+  });
+
+  it('honors explicit ascii=true override regardless of context', () => {
+    expect(renderBadge(StatusIcon.DONE, { ctx: enabledCtx, ascii: true })).toBe('[x]');
+  });
+
+  it('honors explicit ascii=false override regardless of context inputs', () => {
+    // Synthetic enabled context whose inputs.noColor is true — verifies the
+    // explicit `ascii: false` knob wins over the context's noColor signal.
+    const enabledNoColor = {
+      enabled: true as const,
+      reason: 'enabled' as const,
+      inputs: { format: 'human' as const, quiet: false, isTTY: true, noColor: true },
+    };
+    expect(renderBadge(StatusIcon.DONE, { ctx: enabledNoColor, ascii: false })).toBe('✅');
+  });
+});
+
+describe('renderStatusBadge', () => {
+  it('returns empty string when context is silent', () => {
+    expect(renderStatusBadge('done', { ctx: SILENT_CONTEXT })).toBe('');
+  });
+
+  it.each<[StatusBadgeName, string, string]>([
+    ['pending', '⏳', '[ ]'],
+    ['in_progress', '🚧', '[~]'],
+    ['done', '✅', '[x]'],
+    ['blocked', '🚪', '[!]'],
+    ['cancelled', '✗', '[-]'],
+    ['archived', '🗄', '[#]'],
+  ])('maps %s → emoji=%s, ascii=%s', (name, emoji, ascii) => {
+    expect(renderStatusBadge(name, { ctx: enabledCtx })).toBe(emoji);
+    expect(renderStatusBadge(name, asciiOpts)).toBe(ascii);
+  });
+});

--- a/packages/animations/src/render/__tests__/legend.test.ts
+++ b/packages/animations/src/render/__tests__/legend.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for renderLegend / renderSummary — compact glossary + aggregate footer.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type AnimateContext,
+  createAnimateContext,
+  SILENT_CONTEXT,
+} from '../../animate-context.js';
+import { renderLegend, renderSummary } from '../legend.js';
+
+const enabledCtx = createAnimateContext({
+  flagResolution: { format: 'human', quiet: false },
+  isTTY: true,
+  noColor: false,
+});
+
+// Synthetic context: enabled (so rendering runs) but with `inputs.noColor: true`
+// so the primitive's ASCII branch fires. createAnimateContext silences NO_COLOR
+// at construction, so we hand-build this for ASCII-path coverage.
+const enabledNoColorCtx: AnimateContext = {
+  enabled: true,
+  reason: 'enabled',
+  inputs: { format: 'human', quiet: false, isTTY: true, noColor: true },
+};
+
+describe('renderLegend', () => {
+  it('returns empty string when context is silent', () => {
+    expect(
+      renderLegend({
+        ctx: SILENT_CONTEXT,
+        items: [{ icon: '✅', label: 'done' }],
+      }),
+    ).toBe('');
+  });
+
+  it('returns empty string when items array is empty', () => {
+    expect(renderLegend({ ctx: enabledCtx, items: [] })).toBe('');
+  });
+
+  it('renders short legend (4 items) as a single line', () => {
+    expect(
+      renderLegend({
+        ctx: enabledCtx,
+        items: [
+          { icon: '✅', label: 'done' },
+          { icon: '🚧', label: 'active' },
+          { icon: '⏳', label: 'pending' },
+          { icon: '🚪', label: 'blocked' },
+        ],
+      }),
+    ).toMatchInlineSnapshot(`"✅ done  🚧 active  ⏳ pending  🚪 blocked"`);
+  });
+
+  it('renders long legend (10 items > default threshold 8) as multi-line', () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({
+      icon: '•',
+      label: `item-${i}`,
+    }));
+    const out = renderLegend({ ctx: enabledCtx, items });
+    expect(out.split('\n')).toHaveLength(10);
+    expect(out).toContain('• item-0\n• item-1');
+  });
+
+  it('respects custom multiLineThreshold', () => {
+    const items = [
+      { icon: 'A', label: 'a' },
+      { icon: 'B', label: 'b' },
+      { icon: 'C', label: 'c' },
+    ];
+    const oneLine = renderLegend({ ctx: enabledCtx, items, multiLineThreshold: 3 });
+    expect(oneLine).toBe('A a  B b  C c');
+
+    const multi = renderLegend({ ctx: enabledCtx, items, multiLineThreshold: 2 });
+    expect(multi.split('\n')).toHaveLength(3);
+  });
+});
+
+describe('renderSummary', () => {
+  it('returns empty string when context is silent', () => {
+    expect(
+      renderSummary({
+        ctx: SILENT_CONTEXT,
+        counts: [{ label: 'Sagas', n: 1 }],
+      }),
+    ).toBe('');
+  });
+
+  it('returns empty string when counts array is empty', () => {
+    expect(renderSummary({ ctx: enabledCtx, counts: [] })).toBe('');
+  });
+
+  it('renders the ADR-077 canonical summary footer with middle-dot separator', () => {
+    expect(
+      renderSummary({
+        ctx: enabledCtx,
+        counts: [
+          { label: 'Sagas', n: 15 },
+          { label: 'member Epics', n: 89 },
+          { label: 'orphan', n: 1 },
+        ],
+      }),
+    ).toBe('15 Sagas · 89 member Epics · 1 orphan');
+  });
+
+  it('uses pipe separator when ctx.inputs.noColor is true', () => {
+    expect(
+      renderSummary({
+        ctx: enabledNoColorCtx,
+        counts: [
+          { label: 'Sagas', n: 15 },
+          { label: 'orphan', n: 1 },
+        ],
+      }),
+    ).toBe('15 Sagas | 1 orphan');
+  });
+});

--- a/packages/animations/src/render/__tests__/section.test.ts
+++ b/packages/animations/src/render/__tests__/section.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for renderSection — labelled block with indented items.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createAnimateContext, SILENT_CONTEXT } from '../../animate-context.js';
+import { renderSection } from '../section.js';
+
+const enabledCtx = createAnimateContext({
+  flagResolution: { format: 'human', quiet: false },
+  isTTY: true,
+  noColor: false,
+});
+
+describe('renderSection', () => {
+  it('returns empty string when context is silent', () => {
+    expect(renderSection({ ctx: SILENT_CONTEXT, header: 'DONE', items: ['T1', 'T2'] })).toBe('');
+  });
+
+  it('renders header only when items is empty', () => {
+    expect(renderSection({ ctx: enabledCtx, header: 'DONE', items: [] })).toBe('DONE');
+  });
+
+  it('renders header plus indented items', () => {
+    expect(
+      renderSection({
+        ctx: enabledCtx,
+        header: 'DONE',
+        items: ['T1 thing', 'T2 other thing'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "DONE
+        T1 thing
+        T2 other thing"
+    `);
+  });
+
+  it('renders the ✅ DONE canonical section', () => {
+    expect(
+      renderSection({
+        ctx: enabledCtx,
+        icon: '✅',
+        header: 'DONE',
+        subtitle: '3 epics shipped',
+        items: ['T9832 contracts foundation', 'T9836 test helpers', 'T9837 SSoT enforcement'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "✅ DONE — 3 epics shipped
+        T9832 contracts foundation
+        T9836 test helpers
+        T9837 SSoT enforcement"
+    `);
+  });
+
+  it('renders the 🚧 ACTIVE canonical section', () => {
+    expect(
+      renderSection({
+        ctx: enabledCtx,
+        icon: '🚧',
+        header: 'ACTIVE',
+        items: ['T10128 animations render primitives'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "🚧 ACTIVE
+        T10128 animations render primitives"
+    `);
+  });
+
+  it('renders the 🪦 EMPTY canonical section (no items, with icon)', () => {
+    expect(
+      renderSection({
+        ctx: enabledCtx,
+        icon: '🪦',
+        header: 'EMPTY',
+        subtitle: 'no children',
+        items: [],
+      }),
+    ).toMatchInlineSnapshot(`"🪦 EMPTY — no children"`);
+  });
+
+  it('renders the 👻 ORPHAN canonical section (BadgeIcon.ORPHAN deviation)', () => {
+    expect(
+      renderSection({
+        ctx: enabledCtx,
+        icon: '👻',
+        header: 'ORPHAN',
+        items: ['T9999 unreachable task'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "👻 ORPHAN
+        T9999 unreachable task"
+    `);
+  });
+
+  it('omits the em-dash when subtitle is the empty string', () => {
+    expect(
+      renderSection({
+        ctx: enabledCtx,
+        header: 'BARE',
+        subtitle: '',
+        items: ['a'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "BARE
+        a"
+    `);
+  });
+});

--- a/packages/animations/src/render/__tests__/table.test.ts
+++ b/packages/animations/src/render/__tests__/table.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for renderTable — column-aligned rows with width-aware truncation.
+ */
+
+import type { TableResponse } from '@cleocode/contracts/render/table.js';
+import { describe, expect, it } from 'vitest';
+import { createAnimateContext, SILENT_CONTEXT } from '../../animate-context.js';
+import { renderTable } from '../table.js';
+
+const enabledCtx = createAnimateContext({
+  flagResolution: { format: 'human', quiet: false },
+  isTTY: true,
+  noColor: false,
+});
+
+// noColorCtx is silenced by createAnimateContext (NO_COLOR halts rendering).
+// To test the ASCII glyph path, pass `asciiBoxDrawing: true` while keeping the
+// enabled context — that's the public knob for caller-driven ASCII output.
+
+interface TaskRow {
+  readonly id: string;
+  readonly title: string;
+  readonly status: string;
+}
+
+const TASK_TABLE: TableResponse<TaskRow> = {
+  rows: [
+    { id: 'T9832', title: 'Contracts foundation', status: 'done' },
+    { id: 'T9836', title: 'Test helpers', status: 'done' },
+    { id: 'T10128', title: 'Animations render primitives', status: 'in_progress' },
+    { id: 'T9837', title: 'SSoT enforcement', status: 'pending' },
+    { id: 'T9854', title: 'Saga rollup', status: 'pending' },
+  ],
+  schema: {
+    columns: [
+      { key: 'id', header: 'ID' },
+      { key: 'title', header: 'Title' },
+      { key: 'status', header: 'Status' },
+    ],
+  },
+  total: 5,
+};
+
+describe('renderTable', () => {
+  it('returns empty string when context is silent', () => {
+    expect(renderTable(TASK_TABLE, { ctx: SILENT_CONTEXT })).toBe('');
+  });
+
+  it('renders the canonical 3-column task list at width 120', () => {
+    expect(renderTable(TASK_TABLE, { ctx: enabledCtx, maxWidth: 120 })).toMatchInlineSnapshot(`
+      "ID      Title                         Status
+      ──────  ────────────────────────────  ───────────
+      T9832   Contracts foundation          done
+      T9836   Test helpers                  done
+      T10128  Animations render primitives  in_progress
+      T9837   SSoT enforcement              pending
+      T9854   Saga rollup                   pending
+      (5 rows)"
+    `);
+  });
+
+  it('renders ASCII fallback when asciiBoxDrawing=true', () => {
+    expect(
+      renderTable(TASK_TABLE, {
+        ctx: enabledCtx,
+        maxWidth: 120,
+        asciiBoxDrawing: true,
+      }),
+    ).toMatchInlineSnapshot(`
+      "ID      Title                         Status
+      ------  ----------------------------  -----------
+      T9832   Contracts foundation          done
+      T9836   Test helpers                  done
+      T10128  Animations render primitives  in_progress
+      T9837   SSoT enforcement              pending
+      T9854   Saga rollup                   pending
+      (5 rows)"
+    `);
+  });
+
+  it('shrinks wide string columns and truncates cells when total width > maxWidth', () => {
+    const wide: TableResponse<TaskRow> = {
+      rows: [
+        {
+          id: 'T0001',
+          title: 'A really long descriptive task title that absolutely will not fit',
+          status: 'in_progress',
+        },
+      ],
+      schema: TASK_TABLE.schema,
+      total: 1,
+    };
+    const out = renderTable(wide, { ctx: enabledCtx, maxWidth: 40 });
+    // Each emitted line (excluding the footer) MUST be <= maxWidth.
+    for (const line of out.split('\n')) {
+      if (line.startsWith('(')) continue;
+      expect(line.length).toBeLessThanOrEqual(40);
+    }
+    // Truncation indicator present in the data row.
+    expect(out).toMatch(/…|\.{3}/);
+  });
+
+  it('renders a single-column narrow id-only list', () => {
+    const idsOnly: TableResponse<{ id: string }> = {
+      rows: [{ id: 'T1' }, { id: 'T2' }, { id: 'T3' }],
+      schema: { columns: [{ key: 'id', header: 'ID' }] },
+      total: 3,
+    };
+    expect(renderTable(idsOnly, { ctx: enabledCtx, maxWidth: 80 })).toMatchInlineSnapshot(`
+      "ID
+      ──
+      T1
+      T2
+      T3
+      (3 rows)"
+    `);
+  });
+
+  it('respects column alignment hints', () => {
+    interface Numbered {
+      readonly k: string;
+      readonly v: number;
+    }
+    const t: TableResponse<Numbered> = {
+      rows: [
+        { k: 'a', v: 1 },
+        { k: 'bb', v: 22 },
+        { k: 'ccc', v: 333 },
+      ],
+      schema: {
+        columns: [
+          { key: 'k', header: 'Key', align: 'left' },
+          { key: 'v', header: 'Val', align: 'right' },
+        ],
+      },
+      total: 3,
+    };
+    expect(renderTable(t, { ctx: enabledCtx, maxWidth: 80 })).toMatchInlineSnapshot(`
+      "Key  Val
+      ───  ───
+      a      1
+      bb    22
+      ccc  333
+      (3 rows)"
+    `);
+  });
+
+  it('renders the singular "row" footer when total === 1', () => {
+    const one: TableResponse<{ id: string }> = {
+      rows: [{ id: 'T1' }],
+      schema: { columns: [{ key: 'id', header: 'ID' }] },
+      total: 1,
+    };
+    const out = renderTable(one, { ctx: enabledCtx, maxWidth: 80 });
+    expect(out).toContain('(1 row)');
+    expect(out).not.toContain('(1 rows)');
+  });
+});

--- a/packages/animations/src/render/__tests__/tree.test.ts
+++ b/packages/animations/src/render/__tests__/tree.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for renderTree — box-drawing hierarchy with depth, fold, icons.
+ */
+
+import type {
+  FlatTreeNode,
+  TreeNodeKind,
+  TreeNodeStatus,
+  TreeResponse,
+} from '@cleocode/contracts/render/tree.js';
+import { describe, expect, it } from 'vitest';
+import { createAnimateContext, SILENT_CONTEXT } from '../../animate-context.js';
+import { renderTree } from '../tree.js';
+
+const enabledCtx = createAnimateContext({
+  flagResolution: { format: 'human', quiet: false },
+  isTTY: true,
+  noColor: false,
+});
+
+// noColorCtx is silenced by createAnimateContext (NO_COLOR halts rendering).
+// To test the ASCII glyph path, pass `asciiBoxDrawing: true` while keeping the
+// enabled context — that's the public knob for caller-driven ASCII output.
+
+function node(
+  id: string,
+  parentId: string | null,
+  depth: number,
+  kind: TreeNodeKind,
+  status: TreeNodeStatus,
+  title: string,
+): FlatTreeNode<Record<string, never>> {
+  return { id, parentId, depth, kind, status, title, metadata: {} };
+}
+
+/** Canonical Saga family — 1 saga + 3 epics + 6 tasks (2 per epic). */
+const SAGA_FAMILY: TreeResponse<Record<string, never>> = {
+  root: 'SG-DEMO',
+  totalNodes: 10,
+  maxDepth: 2,
+  tree: [
+    node('SG-DEMO', null, 0, 'saga', 'done', 'SG-DEMO demo saga'),
+    node('T1', 'SG-DEMO', 1, 'epic', 'done', 'Epic one'),
+    node('T1a', 'T1', 2, 'task', 'done', 'Task 1a'),
+    node('T1b', 'T1', 2, 'task', 'done', 'Task 1b'),
+    node('T2', 'SG-DEMO', 1, 'epic', 'in_progress', 'Epic two'),
+    node('T2a', 'T2', 2, 'task', 'in_progress', 'Task 2a'),
+    node('T2b', 'T2', 2, 'task', 'pending', 'Task 2b'),
+    node('T3', 'SG-DEMO', 1, 'epic', 'pending', 'Epic three'),
+    node('T3a', 'T3', 2, 'task', 'pending', 'Task 3a'),
+    node('T3b', 'T3', 2, 'task', 'blocked', 'Task 3b'),
+  ],
+};
+
+describe('renderTree', () => {
+  it('returns empty string when context is silent', () => {
+    expect(renderTree(SAGA_FAMILY, { ctx: SILENT_CONTEXT })).toBe('');
+  });
+
+  it('returns empty string for an empty tree', () => {
+    expect(
+      renderTree({ tree: [], root: 'X', totalNodes: 0, maxDepth: 0 }, { ctx: enabledCtx }),
+    ).toBe('');
+  });
+
+  it('renders the canonical saga family (emoji)', () => {
+    expect(renderTree(SAGA_FAMILY, { ctx: enabledCtx })).toMatchInlineSnapshot(`
+      "🌲 SG-DEMO demo saga ✅
+      ├─ 📋 Epic one ✅
+      │  ├─ • Task 1a ✅
+      │  └─ • Task 1b ✅
+      ├─ 📋 Epic two 🚧
+      │  ├─ • Task 2a 🚧
+      │  └─ • Task 2b ⏳
+      └─ 📋 Epic three ⏳
+         ├─ • Task 3a ⏳
+         └─ • Task 3b 🚪"
+    `);
+  });
+
+  it('renders the canonical saga family (ASCII)', () => {
+    expect(
+      renderTree(SAGA_FAMILY, { ctx: enabledCtx, asciiBoxDrawing: true }),
+    ).toMatchInlineSnapshot(`
+      "SG SG-DEMO demo saga [x]
+      +- E Epic one [x]
+      |  +- - Task 1a [x]
+      |  +- - Task 1b [x]
+      +- E Epic two [~]
+      |  +- - Task 2a [~]
+      |  +- - Task 2b [ ]
+      +- E Epic three [ ]
+         +- - Task 3a [ ]
+         +- - Task 3b [!]"
+    `);
+  });
+
+  it('renders a deeply nested single-path tree (depth 3+)', () => {
+    const deep: TreeResponse<Record<string, never>> = {
+      root: 'SG-X',
+      totalNodes: 4,
+      maxDepth: 3,
+      tree: [
+        node('SG-X', null, 0, 'saga', 'in_progress', 'Saga X'),
+        node('E1', 'SG-X', 1, 'epic', 'in_progress', 'Epic one'),
+        node('T1', 'E1', 2, 'task', 'in_progress', 'Task one'),
+        node('S1', 'T1', 3, 'subtask', 'done', 'Subtask one'),
+      ],
+    };
+    expect(renderTree(deep, { ctx: enabledCtx })).toMatchInlineSnapshot(`
+      "🌲 Saga X 🚧
+      └─ 📋 Epic one 🚧
+         └─ • Task one 🚧
+            └─ ◦ Subtask one ✅"
+    `);
+  });
+
+  it('folds a parent with more direct children than foldAt', () => {
+    const kids: FlatTreeNode<Record<string, never>>[] = [];
+    for (let i = 1; i <= 60; i++) {
+      kids.push(node(`T${i}`, 'E-BIG', 1, 'task', 'pending', `Task ${i}`));
+    }
+    const big: TreeResponse<Record<string, never>> = {
+      root: 'E-BIG',
+      totalNodes: 61,
+      maxDepth: 1,
+      tree: [node('E-BIG', null, 0, 'epic', 'in_progress', 'Big epic'), ...kids],
+    };
+    const out = renderTree(big, { ctx: enabledCtx, foldAt: 50 });
+    const lines = out.split('\n');
+    // 1 root + 49 visible children + 1 fold summary = 51 lines.
+    expect(lines).toHaveLength(51);
+    expect(lines[0]).toBe('📋 Big epic 🚧');
+    expect(lines[49]).toBe('├─ • Task 49 ⏳');
+    expect(lines[50]).toBe('└─ … and 11 more tasks (run cleo tree E-BIG --depth +1 to expand)');
+  });
+
+  it('renders nothing when the root cannot be resolved', () => {
+    const bad: TreeResponse<Record<string, never>> = {
+      root: 'missing',
+      totalNodes: 1,
+      maxDepth: 0,
+      tree: [node('present', null, 0, 'task', 'done', 'present')],
+    };
+    expect(renderTree(bad, { ctx: enabledCtx })).toBe('');
+  });
+});

--- a/packages/animations/src/render/badge.ts
+++ b/packages/animations/src/render/badge.ts
@@ -1,0 +1,102 @@
+/**
+ * Static badge rendering — single-icon glyphs with ASCII fallback.
+ *
+ * @remarks
+ * Part of the Human Render Contract (Epic T10114, ADR-077). Every CLI status,
+ * kind, badge, or relation glyph that surfaces in `--human` mode flows through
+ * one of these two helpers. The {@link AnimateContext} gate guarantees JSON /
+ * quiet / non-TTY / NO_COLOR outputs emit nothing, mirroring the silence
+ * contract enforced by {@link createSpinnerHandle}.
+ *
+ * @epic T10114
+ * @task T10128
+ * @subtask T10145
+ */
+
+import {
+  ascii,
+  type BadgeIcon,
+  type KindIcon,
+  type RelationIcon,
+  StatusIcon,
+} from '@cleocode/contracts/render/icon.js';
+import type { AnimateContext } from '../animate-context.js';
+
+/**
+ * Common options for badge rendering.
+ *
+ * @remarks
+ * `ascii` is an explicit override. When omitted the helper falls back to
+ * `ctx.inputs.noColor` so callers can simply thread the context through.
+ */
+export interface RenderBadgeOptions {
+  /** Render gate — primitive returns `''` when `enabled === false`. */
+  readonly ctx: AnimateContext;
+  /**
+   * When `true`, force the ASCII fallback regardless of the context's
+   * `noColor` signal. When `false`, force the emoji form. When omitted,
+   * defer to `ctx.inputs.noColor`.
+   */
+  readonly ascii?: boolean;
+}
+
+/** Lifecycle status names accepted by {@link renderStatusBadge}. */
+export type StatusBadgeName =
+  | 'pending'
+  | 'in_progress'
+  | 'done'
+  | 'blocked'
+  | 'cancelled'
+  | 'archived';
+
+/**
+ * Render a single icon as its emoji form or ASCII fallback.
+ *
+ * @param icon - Any member of {@link StatusIcon}, {@link KindIcon},
+ *   {@link BadgeIcon}, or {@link RelationIcon}.
+ * @param opts - Render gate + optional ASCII override.
+ * @returns The emoji or ASCII glyph. Empty string when `opts.ctx.enabled` is `false`.
+ *
+ * @example
+ * ```ts
+ * renderBadge(StatusIcon.DONE, { ctx: enabledCtx });          // '✅'
+ * renderBadge(StatusIcon.DONE, { ctx: enabledCtx, ascii: true }); // '[x]'
+ * renderBadge(StatusIcon.DONE, { ctx: disabledCtx });          // ''
+ * ```
+ */
+export function renderBadge(
+  icon: StatusIcon | KindIcon | BadgeIcon | RelationIcon,
+  opts: RenderBadgeOptions,
+): string {
+  if (!opts.ctx.enabled) return '';
+  const useAscii = opts.ascii ?? opts.ctx.inputs.noColor;
+  return useAscii ? ascii(icon) : icon;
+}
+
+/** Internal mapping — lifecycle status name → canonical {@link StatusIcon}. */
+const STATUS_NAME_TO_ICON: Readonly<Record<StatusBadgeName, StatusIcon>> = {
+  pending: StatusIcon.PENDING,
+  in_progress: StatusIcon.ACTIVE,
+  done: StatusIcon.DONE,
+  blocked: StatusIcon.BLOCKED,
+  cancelled: StatusIcon.CANCELLED,
+  archived: StatusIcon.ARCHIVED,
+};
+
+/**
+ * Render a lifecycle status string as a badge glyph.
+ *
+ * @param status - Canonical task status name (`'pending'`, `'in_progress'`, …).
+ * @param opts - Render gate + optional ASCII override.
+ * @returns The emoji or ASCII glyph for the status. Empty string when
+ *   `opts.ctx.enabled` is `false`.
+ *
+ * @example
+ * ```ts
+ * renderStatusBadge('done', { ctx });          // '✅'
+ * renderStatusBadge('pending', { ctx: ascii }); // '[ ]'
+ * ```
+ */
+export function renderStatusBadge(status: StatusBadgeName, opts: RenderBadgeOptions): string {
+  return renderBadge(STATUS_NAME_TO_ICON[status], opts);
+}

--- a/packages/animations/src/render/index.ts
+++ b/packages/animations/src/render/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Static UI primitives — tree, table, section, badge, legend.
+ *
+ * @remarks
+ * Companion to the spinner / progress / spark animations in this package.
+ * Every primitive is a pure function that returns a string and respects the
+ * {@link AnimateContext} gate — emitting `''` when the context is silent
+ * (JSON, quiet, no-TTY, NO_COLOR).
+ *
+ * Consumes typed contracts from `@cleocode/contracts/render/*` (Epic T10114,
+ * ADR-077) and icon enums from `@cleocode/contracts/render/icon.js`.
+ *
+ * @epic T10114
+ * @task T10128
+ * @packageDocumentation
+ */
+
+export {
+  type RenderBadgeOptions,
+  renderBadge,
+  renderStatusBadge,
+  type StatusBadgeName,
+} from './badge.js';
+export {
+  type LegendItem,
+  type RenderLegendInput,
+  type RenderSummaryInput,
+  renderLegend,
+  renderSummary,
+  type SummaryCount,
+} from './legend.js';
+export {
+  type RenderSectionInput,
+  renderSection,
+} from './section.js';
+export {
+  type RenderTableOptions,
+  renderTable,
+} from './table.js';
+export {
+  type RenderTreeViewOptions,
+  renderTree,
+} from './tree.js';

--- a/packages/animations/src/render/legend.ts
+++ b/packages/animations/src/render/legend.ts
@@ -1,0 +1,125 @@
+/**
+ * Legend and summary footer rendering.
+ *
+ * @remarks
+ * `renderLegend` produces a compact glossary mapping icons to labels — e.g.
+ * `✅ done  🚧 active  ⏳ pending` — that complements a tree, table, or list.
+ * `renderSummary` produces a one-line aggregate footer such as
+ * `15 Sagas · 89 member Epics · 1 orphan`.
+ *
+ * Both helpers honor the {@link AnimateContext} gate and emit the empty string
+ * when rendering is disabled.
+ *
+ * @epic T10114
+ * @task T10128
+ * @subtask T10146
+ */
+
+import type { AnimateContext } from '../animate-context.js';
+
+/** Default item count above which {@link renderLegend} emits multi-line output. */
+const DEFAULT_MULTILINE_THRESHOLD = 8;
+
+/** Middle-dot separator used in summaries (U+00B7). */
+const SUMMARY_SEPARATOR = ' · ';
+
+/** ASCII fallback separator used when the context is in `no-color` mode. */
+const SUMMARY_SEPARATOR_ASCII = ' | ';
+
+/** One legend entry — icon glyph + plain-text label. */
+export interface LegendItem {
+  /** Pre-resolved icon glyph (caller is responsible for ASCII selection). */
+  readonly icon: string;
+  /** Plain-text label rendered after the icon. */
+  readonly label: string;
+}
+
+/** Inputs to {@link renderLegend}. */
+export interface RenderLegendInput {
+  /** Icon → label pairs rendered in order. */
+  readonly items: ReadonlyArray<LegendItem>;
+  /** Render gate — primitive returns `''` when `enabled === false`. */
+  readonly ctx: AnimateContext;
+  /**
+   * When the item count is `<=` this threshold the legend renders as a single
+   * line; above it the legend renders one item per line. Defaults to `8`.
+   */
+  readonly multiLineThreshold?: number;
+}
+
+/**
+ * Render an icon legend — one-line for small counts, multi-line otherwise.
+ *
+ * @param input - Legend items, render gate, and optional threshold.
+ * @returns The formatted legend string. Empty when `input.ctx.enabled` is `false`
+ *   or `input.items` is empty.
+ *
+ * @example
+ * ```ts
+ * renderLegend({
+ *   ctx,
+ *   items: [
+ *     { icon: '✅', label: 'done' },
+ *     { icon: '🚧', label: 'active' },
+ *     { icon: '⏳', label: 'pending' },
+ *   ],
+ * });
+ * // → '✅ done  🚧 active  ⏳ pending'
+ * ```
+ */
+export function renderLegend(input: RenderLegendInput): string {
+  if (!input.ctx.enabled) return '';
+  if (input.items.length === 0) return '';
+
+  const threshold = input.multiLineThreshold ?? DEFAULT_MULTILINE_THRESHOLD;
+  const formatted = input.items.map((item) => `${item.icon} ${item.label}`);
+
+  if (input.items.length <= threshold) {
+    return formatted.join('  ');
+  }
+  return formatted.join('\n');
+}
+
+/** One aggregate count cell in {@link renderSummary}. */
+export interface SummaryCount {
+  /** Human-readable label (e.g. `'Sagas'`, `'member Epics'`). */
+  readonly label: string;
+  /** Numeric count rendered before the label. */
+  readonly n: number;
+}
+
+/** Inputs to {@link renderSummary}. */
+export interface RenderSummaryInput {
+  /** Counts rendered left-to-right, separated by middle dots. */
+  readonly counts: ReadonlyArray<SummaryCount>;
+  /** Render gate — primitive returns `''` when `enabled === false`. */
+  readonly ctx: AnimateContext;
+}
+
+/**
+ * Render a one-line aggregate summary footer.
+ *
+ * @param input - Counts to render and the gate context.
+ * @returns The formatted summary string. Empty when `input.ctx.enabled` is `false`
+ *   or `input.counts` is empty.
+ *
+ * @example
+ * ```ts
+ * renderSummary({
+ *   ctx,
+ *   counts: [
+ *     { label: 'Sagas', n: 15 },
+ *     { label: 'member Epics', n: 89 },
+ *     { label: 'orphan', n: 1 },
+ *   ],
+ * });
+ * // → '15 Sagas · 89 member Epics · 1 orphan'
+ * ```
+ */
+export function renderSummary(input: RenderSummaryInput): string {
+  if (!input.ctx.enabled) return '';
+  if (input.counts.length === 0) return '';
+
+  const separator = input.ctx.inputs.noColor ? SUMMARY_SEPARATOR_ASCII : SUMMARY_SEPARATOR;
+  return input.counts.map((c) => `${c.n} ${c.label}`).join(separator);
+}

--- a/packages/animations/src/render/section.ts
+++ b/packages/animations/src/render/section.ts
@@ -1,0 +1,80 @@
+/**
+ * Static section rendering — header (optional icon + subtitle) over indented items.
+ *
+ * @remarks
+ * Part of the Human Render Contract (Epic T10114, ADR-077). Sections are the
+ * canonical "labelled block" presenter — used for `cleo saga show` deviation
+ * lists, doctor reports, and similar ad-hoc human output. Items are
+ * pre-formatted; this primitive only owns the header + indentation.
+ *
+ * Section bodies are indented by 2 spaces. An empty `items` array renders only
+ * the header line.
+ *
+ * @epic T10114
+ * @task T10128
+ * @subtask T10144
+ */
+
+import type { AnimateContext } from '../animate-context.js';
+
+/** Inputs to {@link renderSection}. */
+export interface RenderSectionInput {
+  /**
+   * Optional leading glyph (emoji or ASCII). Caller picks the right form for
+   * the active terminal — this primitive renders it verbatim.
+   */
+  readonly icon?: string;
+  /** Section heading rendered on the first line. */
+  readonly header: string;
+  /** Optional subtitle appended after the header with an em-dash separator. */
+  readonly subtitle?: string;
+  /** Pre-formatted item strings rendered as an indented block. */
+  readonly items: ReadonlyArray<string>;
+  /** Render gate — primitive returns `''` when `enabled === false`. */
+  readonly ctx: AnimateContext;
+}
+
+/** Two-space indent applied to every item line. */
+const ITEM_INDENT = '  ';
+
+/** Em-dash separator between header and subtitle. */
+const SUBTITLE_SEPARATOR = ' — ';
+
+/**
+ * Render a section block — header line plus indented items.
+ *
+ * @param input - Header text, optional icon/subtitle, items, and gate context.
+ * @returns A multi-line string. Empty when `input.ctx.enabled` is `false`.
+ *
+ * @example
+ * ```ts
+ * renderSection({
+ *   ctx,
+ *   icon: '✅',
+ *   header: 'DONE',
+ *   subtitle: '3 epics shipped',
+ *   items: ['T9832 contracts foundation', 'T9836 test helpers', 'T9837 SSoT enforcement'],
+ * });
+ * // ✅ DONE — 3 epics shipped
+ * //   T9832 contracts foundation
+ * //   T9836 test helpers
+ * //   T9837 SSoT enforcement
+ * ```
+ */
+export function renderSection(input: RenderSectionInput): string {
+  if (!input.ctx.enabled) return '';
+
+  const iconPart = input.icon !== undefined && input.icon.length > 0 ? `${input.icon} ` : '';
+  const subtitlePart =
+    input.subtitle !== undefined && input.subtitle.length > 0
+      ? `${SUBTITLE_SEPARATOR}${input.subtitle}`
+      : '';
+  const headerLine = `${iconPart}${input.header}${subtitlePart}`;
+
+  if (input.items.length === 0) {
+    return headerLine;
+  }
+
+  const itemLines = input.items.map((item) => `${ITEM_INDENT}${item}`);
+  return [headerLine, ...itemLines].join('\n');
+}

--- a/packages/animations/src/render/table.ts
+++ b/packages/animations/src/render/table.ts
@@ -1,0 +1,225 @@
+/**
+ * Static table rendering — column-aligned rows with terminal-width awareness.
+ *
+ * @remarks
+ * Part of the Human Render Contract (Epic T10114, ADR-077). Consumes a typed
+ * {@link TableResponse} (schema + rows + total) and emits an aligned monospace
+ * table that fits within the active terminal width. Wide string columns shrink
+ * proportionally when the total width exceeds the budget; narrow numeric
+ * columns are preserved.
+ *
+ * @epic T10114
+ * @task T10128
+ * @subtask T10143
+ */
+
+import type { ColumnAlign, TableColumn, TableResponse } from '@cleocode/contracts/render/table.js';
+import type { AnimateContext } from '../animate-context.js';
+
+/** Options to {@link renderTable}. */
+export interface RenderTableOptions {
+  /** Render gate — primitive returns `''` when `enabled === false`. */
+  readonly ctx: AnimateContext;
+  /**
+   * Maximum line width. Defaults to `process.stdout.columns` and falls back to
+   * `80` when the column count is unavailable. The renderer never produces a
+   * row longer than this.
+   */
+  readonly maxWidth?: number;
+  /**
+   * When `true`, force ASCII separator characters. When `false`, force the
+   * Unicode form. When omitted, defer to `ctx.inputs.noColor`.
+   */
+  readonly asciiBoxDrawing?: boolean;
+}
+
+/** Unicode horizontal rule used between header and data. */
+const HRULE_UNICODE = '─';
+/** ASCII fallback horizontal rule. */
+const HRULE_ASCII = '-';
+
+/** Unicode ellipsis used for truncated cell values. */
+const ELLIPSIS_UNICODE = '…';
+/** ASCII fallback ellipsis. */
+const ELLIPSIS_ASCII = '...';
+
+/** Two-space column separator. */
+const COLUMN_GAP = '  ';
+
+/** Minimum width retained for any string column after proportional shrink. */
+const MIN_COLUMN_WIDTH = 4;
+
+/**
+ * Render a {@link TableResponse} as an aligned columnar string.
+ *
+ * @param resp - Typed table response (schema + rows + total).
+ * @param opts - Render gate + width / ASCII overrides.
+ * @returns Multi-line aligned table. Empty when `opts.ctx.enabled` is `false`.
+ *
+ * @example
+ * ```ts
+ * renderTable(
+ *   {
+ *     rows: [{ id: 'T1', title: 'Implement', status: 'done' }],
+ *     schema: {
+ *       columns: [
+ *         { key: 'id', header: 'ID' },
+ *         { key: 'title', header: 'Title' },
+ *         { key: 'status', header: 'Status' },
+ *       ],
+ *     },
+ *     total: 1,
+ *   },
+ *   { ctx },
+ * );
+ * ```
+ */
+export function renderTable<T>(resp: TableResponse<T>, opts: RenderTableOptions): string {
+  if (!opts.ctx.enabled) return '';
+
+  const useAscii = opts.asciiBoxDrawing ?? opts.ctx.inputs.noColor;
+  const hrule = useAscii ? HRULE_ASCII : HRULE_UNICODE;
+  const ellipsis = useAscii ? ELLIPSIS_ASCII : ELLIPSIS_UNICODE;
+
+  const columns: ReadonlyArray<TableColumn<T>> = resp.schema.columns;
+  if (columns.length === 0) {
+    return `(${resp.total} rows)`;
+  }
+
+  const formatted: string[][] = resp.rows.map((row: T): string[] =>
+    columns.map((col: TableColumn<T>): string => formatCell(row, col)),
+  );
+
+  // 1. Natural widths — max(header, every-cell).
+  const naturalWidths: number[] = columns.map((col: TableColumn<T>, idx: number): number => {
+    let max = col.header.length;
+    for (const fmtRow of formatted) {
+      const cell = fmtRow[idx] ?? '';
+      if (cell.length > max) max = cell.length;
+    }
+    if (typeof col.width === 'number' && col.width > 0) {
+      return Math.min(max, col.width);
+    }
+    return max;
+  });
+
+  // 2. Apply max-width shrink if needed (string columns only).
+  const maxWidth = opts.maxWidth ?? process.stdout.columns ?? 80;
+  const finalWidths = applyMaxWidth(naturalWidths, columns, maxWidth);
+
+  // 3. Render header.
+  const headerRow = renderRow(
+    columns.map((col: TableColumn<T>): string => col.header),
+    columns,
+    finalWidths,
+    ellipsis,
+  );
+
+  // 4. Render separator.
+  const separatorRow = finalWidths.map((w) => hrule.repeat(w)).join(COLUMN_GAP);
+
+  // 5. Render data rows.
+  const dataRows = formatted.map((row) => renderRow(row, columns, finalWidths, ellipsis));
+
+  // 6. Footer.
+  const footer = `(${resp.total} ${resp.total === 1 ? 'row' : 'rows'})`;
+
+  return [headerRow, separatorRow, ...dataRows, footer].join('\n');
+}
+
+/** Extract the cell value for `column` from `row` and run it through `format`. */
+function formatCell<T>(row: T, column: TableColumn<T>): string {
+  const raw = (row as Record<string, unknown>)[column.key];
+  if (column.format !== undefined) return column.format(raw);
+  if (raw === null || raw === undefined) return '';
+  return String(raw);
+}
+
+/**
+ * Compute the final per-column widths.
+ *
+ * @remarks
+ * The total width budget is `maxWidth - (columns.length - 1) * COLUMN_GAP`.
+ * If the naturally-required widths fit, return them unchanged. Otherwise
+ * shrink columns whose `align` is unset or `'left'` (treated as string
+ * columns) proportionally to their natural width. Numeric / right-aligned /
+ * center-aligned columns and any column with an explicit `width` are not
+ * shrunk.
+ */
+function applyMaxWidth<T>(
+  naturalWidths: number[],
+  columns: ReadonlyArray<TableColumn<T>>,
+  maxWidth: number,
+): number[] {
+  const totalGap = (columns.length - 1) * COLUMN_GAP.length;
+  const budget = Math.max(MIN_COLUMN_WIDTH * columns.length, maxWidth - totalGap);
+  const natural = naturalWidths.reduce((a, b) => a + b, 0);
+  if (natural <= budget) return [...naturalWidths];
+
+  const isShrinkable = columns.map(
+    (col) => (col.align === undefined || col.align === 'left') && col.width === undefined,
+  );
+  const fixedSum = naturalWidths.reduce((sum, w, idx) => sum + (isShrinkable[idx] ? 0 : w), 0);
+  const shrinkableSum = naturalWidths.reduce((sum, w, idx) => sum + (isShrinkable[idx] ? w : 0), 0);
+
+  const shrinkBudget = Math.max(0, budget - fixedSum);
+  if (shrinkableSum === 0 || shrinkBudget === 0) return [...naturalWidths];
+
+  return naturalWidths.map((w, idx) => {
+    if (!isShrinkable[idx]) return w;
+    const scaled = Math.floor((w * shrinkBudget) / shrinkableSum);
+    return Math.max(MIN_COLUMN_WIDTH, scaled);
+  });
+}
+
+/** Render one aligned row joined by {@link COLUMN_GAP}. */
+function renderRow<T>(
+  cells: ReadonlyArray<string>,
+  columns: ReadonlyArray<TableColumn<T>>,
+  widths: ReadonlyArray<number>,
+  ellipsis: string,
+): string {
+  // The trailing column is rendered without padding — there is no neighbour
+  // to align to, and pad-right whitespace makes snapshot diffs noisy.
+  const lastIdx = cells.length - 1;
+  return cells
+    .map((cell, idx) => {
+      const width = widths[idx] ?? cell.length;
+      const align = columns[idx]?.align ?? 'left';
+      const truncated = truncate(cell, width, ellipsis);
+      if (idx === lastIdx && align === 'left') return truncated;
+      return alignCell(truncated, width, align);
+    })
+    .join(COLUMN_GAP);
+}
+
+/**
+ * Truncate `text` to `width` characters by replacing the tail with `ellipsis`.
+ *
+ * @remarks
+ * No-op when `text.length <= width`. When `width <= ellipsis.length`, returns
+ * the leading slice of `text` without an ellipsis to avoid producing output
+ * wider than the budget.
+ */
+function truncate(text: string, width: number, ellipsis: string): string {
+  if (text.length <= width) return text;
+  if (width <= ellipsis.length) return text.slice(0, width);
+  return text.slice(0, width - ellipsis.length) + ellipsis;
+}
+
+/** Pad `text` to `width` characters according to `align`. */
+function alignCell(text: string, width: number, align: ColumnAlign): string {
+  if (text.length >= width) return text;
+  const padding = width - text.length;
+  switch (align) {
+    case 'right':
+      return ' '.repeat(padding) + text;
+    case 'center': {
+      const left = Math.floor(padding / 2);
+      const right = padding - left;
+      return ' '.repeat(left) + text + ' '.repeat(right);
+    }
+    default:
+      return text + ' '.repeat(padding);
+  }
+}

--- a/packages/animations/src/render/tree.ts
+++ b/packages/animations/src/render/tree.ts
@@ -1,0 +1,233 @@
+/**
+ * Static tree rendering — box-drawing hierarchy with depth, fold, and icons.
+ *
+ * @remarks
+ * Part of the Human Render Contract (Epic T10114, ADR-077). Consumes a
+ * {@link TreeResponse} (flat, pre-order list of {@link FlatTreeNode}s) and
+ * emits a box-drawing tree that mirrors the canonical Saga → Epic → Task →
+ * Subtask layout.
+ *
+ * Connector glyphs:
+ * - `├─` non-last child
+ * - `└─` last child
+ * - `│ ` vertical continuation across a non-last ancestor
+ * - `   ` last-sibling ancestor (no vertical bar)
+ *
+ * Each rendered row carries the matching {@link KindIcon} prefix and a
+ * trailing {@link StatusIcon}. When the {@link AnimateContext} indicates
+ * `noColor` mode (or `opts.asciiBoxDrawing === true`) glyphs collapse to
+ * ASCII fallbacks (`+-`, `| `, `   `) and icons resolve via {@link ascii}.
+ *
+ * @epic T10114
+ * @task T10128
+ * @subtask T10142
+ */
+
+import { ascii, KindIcon, StatusIcon } from '@cleocode/contracts/render/icon.js';
+import type {
+  FlatTreeNode,
+  TreeNodeKind,
+  TreeNodeStatus,
+  TreeResponse,
+} from '@cleocode/contracts/render/tree.js';
+import type { AnimateContext } from '../animate-context.js';
+
+/** Options for {@link renderTree}. */
+export interface RenderTreeViewOptions {
+  /** Render gate — primitive returns `''` when `enabled === false`. */
+  readonly ctx: AnimateContext;
+  /**
+   * When a node has more direct children than this threshold, only the first
+   * `foldAt - 1` are rendered and a `…` summary line replaces the rest.
+   *
+   * @defaultValue `50`
+   */
+  readonly foldAt?: number;
+  /**
+   * When `true`, force ASCII box-drawing glyphs regardless of the context's
+   * `noColor` signal. When `false`, force Unicode. When omitted, defer to
+   * `ctx.inputs.noColor`.
+   */
+  readonly asciiBoxDrawing?: boolean;
+}
+
+/** Default fold threshold — match ADR-077 §3 guidance. */
+const DEFAULT_FOLD_AT = 50;
+
+/**
+ * Connector glyph set — vertical bar continuations, branch / leaf elbows,
+ * and blank spacer.
+ */
+interface ConnectorSet {
+  readonly branch: string;
+  readonly leaf: string;
+  readonly vertical: string;
+  readonly blank: string;
+}
+
+/** Unicode connector glyphs. */
+const CONNECTOR_UNICODE: ConnectorSet = Object.freeze({
+  branch: '├─ ',
+  leaf: '└─ ',
+  vertical: '│  ',
+  blank: '   ',
+});
+
+/** ASCII fallback connector glyphs. */
+const CONNECTOR_ASCII: ConnectorSet = Object.freeze({
+  branch: '+- ',
+  leaf: '+- ',
+  vertical: '|  ',
+  blank: '   ',
+});
+
+/** Pretty kind label appended to the fold summary line. */
+const KIND_LABEL: Readonly<Record<TreeNodeKind, string>> = {
+  saga: 'sagas',
+  epic: 'epics',
+  task: 'tasks',
+  subtask: 'subtasks',
+};
+
+/**
+ * Render a {@link TreeResponse} as a multi-line box-drawing tree.
+ *
+ * @param resp - The flattened tree response to render.
+ * @param opts - Render gate + fold + ASCII overrides.
+ * @returns The formatted tree. Empty when `opts.ctx.enabled` is `false`.
+ *
+ * @example
+ * ```ts
+ * renderTree(saga, { ctx });
+ * // 🌲 SG-WORKTRUNK-OWN ✅
+ * // ├─ 📋 T9977 Worktree native ownership ✅
+ * // │  ├─ • T9983 Reader cache 🚧
+ * // │  └─ • T9984 NAPI shim ✅
+ * // └─ 📋 T9981 Doctor budget ⏳
+ * ```
+ */
+export function renderTree<T>(resp: TreeResponse<T>, opts: RenderTreeViewOptions): string {
+  if (!opts.ctx.enabled) return '';
+  if (resp.tree.length === 0) return '';
+
+  const useAscii = opts.asciiBoxDrawing ?? opts.ctx.inputs.noColor;
+  const connectors = useAscii ? CONNECTOR_ASCII : CONNECTOR_UNICODE;
+  const foldAt = opts.foldAt ?? DEFAULT_FOLD_AT;
+
+  // Build the parent → ordered-children map from the pre-order flat list.
+  // Preserves the input order — callers control sibling order via the wire
+  // payload, this primitive must not re-sort.
+  const childrenByParent = new Map<string, FlatTreeNode<T>[]>();
+  let rootNode: FlatTreeNode<T> | undefined;
+  for (const node of resp.tree) {
+    if (node.parentId === null) {
+      if (node.id === resp.root) rootNode = node;
+      continue;
+    }
+    const bucket = childrenByParent.get(node.parentId);
+    if (bucket) bucket.push(node);
+    else childrenByParent.set(node.parentId, [node]);
+  }
+
+  if (rootNode === undefined) return '';
+
+  const lines: string[] = [];
+
+  // Root line — no connector prefix.
+  lines.push(formatRow(rootNode, '', useAscii));
+
+  emitChildren(rootNode.id, [], childrenByParent, connectors, foldAt, useAscii, lines);
+
+  return lines.join('\n');
+}
+
+/**
+ * Recursively emit children of `parentId` with the correct ancestor prefix.
+ *
+ * @param ancestorIsLast - For each ancestor, whether it was the last sibling
+ *   in its parent's child list. Drives the `│ ` vs `   ` continuation glyph.
+ * @param connectors - Resolved connector set (Unicode or ASCII).
+ */
+function emitChildren<T>(
+  parentId: string,
+  ancestorIsLast: ReadonlyArray<boolean>,
+  childrenByParent: ReadonlyMap<string, ReadonlyArray<FlatTreeNode<T>>>,
+  connectors: ConnectorSet,
+  foldAt: number,
+  useAscii: boolean,
+  out: string[],
+): void {
+  const children = childrenByParent.get(parentId);
+  if (children === undefined || children.length === 0) return;
+
+  const ancestorPrefix = ancestorIsLast
+    .map((isLast) => (isLast ? connectors.blank : connectors.vertical))
+    .join('');
+
+  const shouldFold = children.length > foldAt;
+  const visibleCount = shouldFold ? foldAt - 1 : children.length;
+  const visible = children.slice(0, visibleCount);
+
+  for (let i = 0; i < visible.length; i++) {
+    const child = visible[i];
+    if (child === undefined) continue;
+    const isLastInBatch = !shouldFold && i === children.length - 1;
+    const connector = isLastInBatch ? connectors.leaf : connectors.branch;
+    out.push(formatRow(child, `${ancestorPrefix}${connector}`, useAscii));
+    emitChildren(
+      child.id,
+      [...ancestorIsLast, isLastInBatch],
+      childrenByParent,
+      connectors,
+      foldAt,
+      useAscii,
+      out,
+    );
+  }
+
+  if (shouldFold) {
+    const hidden = children.length - visibleCount;
+    const sampleKind = children[0]?.kind ?? 'task';
+    const label = KIND_LABEL[sampleKind];
+    out.push(
+      `${ancestorPrefix}${connectors.leaf}… and ${hidden} more ${label} (run cleo tree ${parentId} --depth +1 to expand)`,
+    );
+  }
+}
+
+/** Build a single tree row: `<connectors><kind icon> <title> <status icon>`. */
+function formatRow<T>(node: FlatTreeNode<T>, prefix: string, useAscii: boolean): string {
+  const kindIcon = resolveKindIcon(node.kind, useAscii);
+  const statusIcon = resolveStatusIcon(node.status, useAscii);
+  return `${prefix}${kindIcon} ${node.title} ${statusIcon}`.trimEnd();
+}
+
+/** Pick the {@link KindIcon} for a node kind, falling back to ASCII when asked. */
+function resolveKindIcon(kind: TreeNodeKind, useAscii: boolean): string {
+  const icon = KIND_BY_NODE_KIND[kind];
+  return useAscii ? ascii(icon) : icon;
+}
+
+/** Pick the {@link StatusIcon} for a node status, falling back to ASCII. */
+function resolveStatusIcon(status: TreeNodeStatus, useAscii: boolean): string {
+  const icon = STATUS_BY_NODE_STATUS[status];
+  return useAscii ? ascii(icon) : icon;
+}
+
+/** Node-kind → KindIcon. Subtask uses bullet-like glyph per ADR-077. */
+const KIND_BY_NODE_KIND: Readonly<Record<TreeNodeKind, KindIcon>> = {
+  saga: KindIcon.SAGA,
+  epic: KindIcon.EPIC,
+  task: KindIcon.TASK,
+  subtask: KindIcon.SUBTASK,
+};
+
+/** Node-status → StatusIcon. */
+const STATUS_BY_NODE_STATUS: Readonly<Record<TreeNodeStatus, StatusIcon>> = {
+  pending: StatusIcon.PENDING,
+  in_progress: StatusIcon.ACTIVE,
+  done: StatusIcon.DONE,
+  blocked: StatusIcon.BLOCKED,
+  cancelled: StatusIcon.CANCELLED,
+  archived: StatusIcon.ARCHIVED,
+};

--- a/packages/animations/tsconfig.json
+++ b/packages/animations/tsconfig.json
@@ -19,5 +19,6 @@
     "types": ["node", "vitest/globals"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules"],
+  "references": [{ "path": "../contracts" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,10 @@ importers:
   packages/agents: {}
 
   packages/animations:
+    dependencies:
+      '@cleocode/contracts':
+        specifier: workspace:*
+        version: link:../contracts
     devDependencies:
       '@types/node':
         specifier: ^24.3.0


### PR DESCRIPTION
## Summary
- Adds `packages/animations/src/render/` with 5 pure-string UI primitives.
- All gated through `AnimateContext` — silent in JSON / quiet / no-TTY / NO_COLOR.
- Consumes B1 typed contracts + B2 icon enums.
- ASCII fallback for non-Unicode terminals via `asciiBoxDrawing` / `ascii` opts.

## Subtasks
- T10142 (B3.1): tree — box-drawing, depth, fold
- T10143 (B3.2): table — alignment, truncation, footer
- T10144 (B3.3): section — header + indented items
- T10145 (B3.4): badge + status badge
- T10146 (B3.5): legend + summary footer

## Design notes
- `BadgeIcon.ORPHAN = '👻'` (B2 deviation; ADR-077 §2 originally specified `🚪`).
- The trailing left-aligned column is rendered without right-pad whitespace — keeps snapshot diffs and CLI output clean.
- ASCII path is reachable via either an explicit `asciiBoxDrawing: true` / `ascii: true` option OR a context whose `inputs.noColor` is true (the latter would only fire for hand-built contexts since `createAnimateContext({ noColor: true })` silences rendering entirely).
- Tests bypass `createAnimateContext`'s NO_COLOR silencing by either using the explicit option flags or constructing a synthetic enabled-noColor context — both paths are documented in-line in the test files.

## Test plan
- [x] `pnpm biome check --write packages/animations/`
- [x] `pnpm --filter @cleocode/animations run build`
- [x] `pnpm --filter @cleocode/animations exec vitest run` → 200 tests pass (11 files)
- [x] Snapshot tests for ADR-077 canonical tree/table/section/badge/legend examples (emoji + ASCII)
- [x] Every primitive returns `''` for `SILENT_CONTEXT` / disabled `AnimateContext`

## Refs
Closes T10128
Subtasks: T10142, T10143, T10144, T10145, T10146
Epic: T10114 (E11-HUMAN-RENDER-CONTRACT)
ADR: adr-077-human-render-contract