### PR TITLE
feat(T10254): adopt cargo-release for cleocode Rust workspace publishes (saga T10180 W4)

### DIFF
--- a/.changeset/T10254-cargo-release.md
+++ b/.changeset/T10254-cargo-release.md
@@ -1,0 +1,21 @@
+---
+'@cleocode/cleo': patch
+---
+
+T10254 (saga T10180 W4 prep): adopt cargo-release for atomic Rust workspace
+publishes. Adds `release.toml` with `shared-version = true` and
+pre-release-replacements regex that auto-bumps in-workspace
+`[workspace.dependencies]` version pins on every `cargo release version`.
+Replaces the rejected PR #548 approach of hand-edited per-pin version
+bumps.
+
+Also normalises [workspace.dependencies] pins for the 3 publishable
+crates (lafs-core, cleo-conduit-core, cant-core) to `= 2026.5.105`,
+and switches cleo-conduit-core's stale `lafs-core` pin (`2026.5.99`)
+to workspace inheritance (`{ workspace = true }`).
+
+Future release flow:
+  cargo release version <calver> --workspace --execute
+  cargo publish -p <crate>  # explicit per-crate (workspace mode hits rate limit)
+
+Initial crates.io publish (this saga) executes immediately after merge.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,10 +73,11 @@ napi-build = "1"
 # LSP
 tower-lsp = "0.20"
 
-# Local workspace crates
-lafs-core = { path = "crates/lafs-core" }
+# Local workspace crates (publish=true ones have versions kept in sync
+# by cargo-release pre-release-replacements — see release.toml)
+lafs-core = { path = "crates/lafs-core", version = "=2026.5.105" }
 cleo-conduit-core = { path = "crates/cleo-conduit-core", version = "=2026.5.105" }
-cant-core = { path = "crates/cant-core" }
+cant-core = { path = "crates/cant-core", version = "=2026.5.105" }
 cant-lsp = { path = "crates/cant-lsp" }
 cant-napi = { path = "crates/cant-napi" }
 cant-runtime = { path = "crates/cant-runtime" }

--- a/crates/cleo-conduit-core/Cargo.toml
+++ b/crates/cleo-conduit-core/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-lafs-core = { path = "../lafs-core", version = "2026.5.99" }
+lafs-core = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,45 @@
+# cargo-release configuration for cleocode Rust workspace (T10254, saga T10180 W4)
+#
+# Purpose: keep in-workspace [workspace.dependencies] version pins for
+# publish=true crates auto-synced with workspace.package.version on every
+# `cargo release version` invocation. Replaces hand-edited per-pin
+# updates (PR #548 attempted, owner correctly rejected as maintenance
+# liability).
+#
+# Owner flow (FUTURE releases):
+#   cargo release version <next-calver> --workspace --execute
+#   cargo release publish --workspace --execute
+#
+# This file documents the SSoT for Rust release config — do not duplicate
+# elsewhere.
+
+# All publish=true crates share workspace.package.version (CalVer).
+shared-version = true
+
+# Only allow release flow from main or release branches.
+allow-branch = ["main", "release/*"]
+
+# cleocode uses gh PRs for everything; never push directly.
+push = false
+sign-commit = false
+sign-tag = false
+
+# Skip git tag creation — cleocode/release pipeline owns tagging
+# via release-publish.yml (per T9540 + ADR-065). cargo-release just
+# handles publish.
+tag = false
+
+# Run cargo verify before publish (cargo publish does this anyway,
+# but explicit).
+verify = true
+
+# Pre-release replacements: keep [workspace.dependencies] pins
+# aligned with workspace.package.version automatically.
+# {{version}} = the new version cargo-release is bumping to.
+pre-release-replacements = [
+  # cleocode/Cargo.toml workspace.dependencies pins for in-workspace
+  # publishable crates.
+  { file = "Cargo.toml", search = "(lafs-core\\s*=\\s*\\{[^}]*version\\s*=\\s*)\"=?[^\"]+\"", replace = "$1\"={{version}}\"", min = 0 },
+  { file = "Cargo.toml", search = "(cleo-conduit-core\\s*=\\s*\\{[^}]*version\\s*=\\s*)\"=?[^\"]+\"", replace = "$1\"={{version}}\"", min = 0 },
+  { file = "Cargo.toml", search = "(cant-core\\s*=\\s*\\{[^}]*version\\s*=\\s*)\"=?[^\"]+\"", replace = "$1\"={{version}}\"", min = 0 },
+]


### PR DESCRIPTION
## Summary

Adds `release.toml` at cleocode workspace root configuring [cargo-release](https://github.com/crate-ci/cargo-release) for atomic Rust workspace publishes.

**Key config** (`shared-version = true` + `pre-release-replacements`):
- workspace.package.version is the SSoT (CalVer)
- All `[workspace.dependencies]` pins for in-workspace publishable crates (lafs-core, cleo-conduit-core, cant-core) auto-bump together via regex on every `cargo release version` invocation
- Replaces hand-edited per-pin updates (rejected by owner in [PR #548](https://github.com/kryptobaseddev/cleo/pull/548) as a maintenance liability)

**Also normalises pin state**:
- `lafs-core` and `cant-core` workspace.deps entries gained `version = "=2026.5.105"` (previously path-only — crates.io rejects path-only deps for publish)
- `cleo-conduit-core/Cargo.toml`: dropped stale hardcoded `lafs-core = { ..., version = "2026.5.99" }` → switched to `lafs-core = { workspace = true }` for single SSoT

**Dry-run validation** (clean):
```
$ cargo release version 2026.5.106 --workspace
   Upgrading workspace to version 2026.5.106
   Upgrading cant-core 2026.5.105 → 2026.5.106 (inherited)
   Upgrading lafs-core 2026.5.105 → 2026.5.106 (inherited)
   Upgrading cleo-conduit-core 2026.5.105 → 2026.5.106 (inherited)
   Updating workspace's dependency from =2026.5.105 to =2026.5.106  (×3 pins)
```

## Future release flow (post-merge)

```bash
# Bump versions atomically:
cargo release version <next-calver> --workspace --execute
# Publish each (--workspace mode hits crates.io 5-crate-rate-limit):
cargo publish -p lafs-core
cargo publish -p cleo-conduit-core
cargo publish -p cant-core
```

## Saga T10180 W4 unblocker

This PR + the 3 cargo publish invocations close epic T10216 (E-SIGNALDOCK-CRATESIO-PUBLISH). Subsequent w4b worker rewires signaldock-side to consume the registry versions.

Closes T10254  
Saga: T10180  
Decision: D003