### PR TITLE
feat(T9860): deployed template parity CI gate (Saga T9855)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       runtime: ${{ steps.filter.outputs.runtime }}
       skills: ${{ steps.filter.outputs.skills }}
       worktree: ${{ steps.filter.outputs.worktree }}
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -55,6 +56,11 @@ jobs:
             schemas:
               - 'packages/*/schemas/**'
               - 'packages/*/templates/**'
+            workflows:
+              - '.github/workflows/**'
+              - 'packages/*/templates/workflows/**'
+              - 'scripts/lint-deployed-template-parity.mjs'
+              - '.lint-deployed-template-parity-baseline.json'
             core:
               - 'packages/core/**'
             cleo:
@@ -485,6 +491,44 @@ jobs:
         # the cleo CLI requires a live database. The strict mode does not
         # need task verification (it blocks everything unconditionally).
         run: node scripts/lint-no-ssot-exempt.mjs --strict --base origin/main
+
+  deployed-template-parity:
+    # T9860 / Saga T9855 SG-TEMPLATE-CONFIG-SSOT — dogfood gate.
+    # `packages/cleo/templates/workflows/*.yml.tmpl` (being relocated to
+    # `packages/core/templates/workflows/*.yml.tmpl` by T9858) are the canonical
+    # sources for GitHub Actions workflows shipped to consuming projects via
+    # `cleo init --workflows`. The deployed copies under .github/workflows/
+    # here are supposed to BE the rendered output. Today they drift — this
+    # gate establishes a baseline of the accepted drift and fails CI on any
+    # NEW divergence. The drift itself is closed by a SEPARATE follow-up.
+    # Runs whenever workflows, templates, the script, or the baseline change.
+    # Pure static analysis of checked-in source — no untrusted input.
+    name: Deployed Template Parity (T9860)
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.30.0'
+          run_install: false
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
+      - name: Lint deployed workflows against shipped templates (baseline mode)
+        run: node scripts/lint-deployed-template-parity.mjs
 
   cli-boundary-lint:
     # T10076 / Epic T9837 / Saga T9831 SG-ARCH-SOLID — CLI package boundary gate.

--- a/.lint-deployed-template-parity-baseline.json
+++ b/.lint-deployed-template-parity-baseline.json
@@ -1,0 +1,23 @@
+{
+  "gate": "deployed-template-parity",
+  "task": "T9860",
+  "saga": "T9855",
+  "total": 8,
+  "generatedAt": "2026-05-23T15:16:10.679Z",
+  "results": [
+    {
+      "template": "packages/core/templates/workflows/release-prepare.yml.tmpl",
+      "deployed": ".github/workflows/release-prepare.yml",
+      "findings": [
+        "on: triggers/inputs differ — expected {\"workflow_dispatch\":{\"inputs\":[\"channel\",\"epic\",\"plan-blob-sha256\",\"version\"]}}, got {\"workflow_dispatch\":{\"inputs\":[\"version\"]}}",
+        "permissions: differ — expected {\"contents\":\"write\",\"id-token\":\"write\",\"pull-requests\":\"write\"}, got {\"contents\":\"write\",\"pull-requests\":\"write\"}",
+        "jobs.cleanup-on-failure: missing in deployed",
+        "jobs.preflight: missing in deployed",
+        "jobs.prepare.steps: missing 10 run-step(s) — [\"BRANCH=\\\"release/${{ inputs.version }}\\\" git checkout -b \\\"$BRANCH\\\" echo \\\"name=$...\", \"PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo \\\"\\\") if [ -n \\\"$P...\", \"cleo version-bump --version \\\"${{ inputs.version }}\\\"\"] (+7 more)",
+        "jobs.prepare.steps: extra 12 run-step(s) — [\"# All publishable workspace packages -- keep in sync with release.yml PACKAGE...\", \"# Only @cleocode/* numeric pins move -- external deps (tree-sitter, # drizzle...\", \"PLAN_FILE=\\\".cleo/release/${VERSION_BARE}.plan.json\\\" if [[ -f \\\"$PLAN_FILE\\\" ]];...\"] (+9 more)",
+        "jobs.prepare.uses: missing [\"actions/checkout@v4.1\",\"actions/setup-node@v4.0\"]",
+        "jobs.prepare.uses: extra [\"actions/checkout@v4\",\"actions/setup-node@v4\",\"pnpm/action-setup@v4\"]"
+      ]
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,6 +471,55 @@ async function buildChangelogSection(tasks: Task[]): Promise<string> {
 **Current mode:** baseline (fails on increase; count decreases always pass).
 Flip to `--strict` after E-CLI-BOUNDARY (T9833) fully closes.
 
+## Dogfood: Deployed Template Parity (T9860 · Saga T9855)
+
+`packages/cleo/templates/workflows/*.yml.tmpl` (being relocated to
+`packages/core/templates/workflows/*.yml.tmpl` by T9858) are the canonical
+sources for the GitHub Actions workflows shipped to consuming projects via
+`cleo init --workflows`. The deployed copies in `.github/workflows/` of *this*
+repo are supposed to BE the rendered output. Today the deployed
+`release-prepare.yml` has drifted: it lacks the SPEC-T9345 R-200/R-260
+preflight job, hardcodes its node version + install command + branch prefix,
+and skips the canonical placeholder substitution pass entirely.
+
+This gate doesn't fix the drift — it pins the current state as a baseline and
+prevents NEW divergence from creeping in. Closing the drift itself is a
+separate follow-up.
+
+| Command | What it does |
+|---|---|
+| `node scripts/lint-deployed-template-parity.mjs` | Default (baseline) — fails when finding count exceeds `.lint-deployed-template-parity-baseline.json` |
+| `node scripts/lint-deployed-template-parity.mjs --strict` | Zero-tolerance — any divergence fails |
+| `node scripts/lint-deployed-template-parity.mjs --update-baseline` | Regenerate the baseline JSON to accept the current state |
+
+The script renders each template's `{{KEY}}` placeholders using project-context
+defaults (NODE_VERSION=24, INSTALL_CMD=`pnpm install --frozen-lockfile`,
+LINT_CMD=`pnpm biome check .`, TYPECHECK_CMD=`pnpm run typecheck`,
+TEST_CMD=`pnpm run test`, BUILD_CMD=`pnpm run build`, BRANCH_PREFIX=`release`,
+PR_LABEL=`release`), parses both the rendered template and the deployed YAML,
+and compares structurally — `on:` triggers + inputs, `permissions`, and per-job
+`runs-on`/`run`-step set/`uses`-step set. Whitespace, comment order, and
+re-ordering of independent steps with the same `run:` body do not register as
+divergence.
+
+### Adding a new template → deployed pair
+
+Edit `PARITY_MAP` in `scripts/lint-deployed-template-parity.mjs`:
+
+```js
+const PARITY_MAP = [
+  {
+    template: 'packages/core/templates/workflows/<name>.yml.tmpl',
+    deployed: '.github/workflows/<name>.yml',
+    fallbackTemplate: 'packages/cleo/templates/workflows/<name>.yml.tmpl', // optional
+  },
+];
+```
+
+Then run `--update-baseline` to capture the new entry's accepted drift.
+
+CI gate: `Deployed Template Parity (T9860)` job in `.github/workflows/ci.yml`.
+
 ## Package-Boundary Check (MANDATORY)
 
 Before creating or relocating ANY source file, verify the correct package by the

--- a/scripts/__tests__/lint-deployed-template-parity.test.mjs
+++ b/scripts/__tests__/lint-deployed-template-parity.test.mjs
@@ -1,0 +1,370 @@
+/**
+ * Tests for scripts/lint-deployed-template-parity.mjs (T9860 / Saga T9855).
+ *
+ * Strategy
+ * --------
+ *   - Create an isolated tmpdir with a synthetic template + deployed workflow
+ *     pair under the same relative paths the script expects.
+ *   - The script resolves REPO_ROOT from `process.cwd()`. Tests invoke the
+ *     real script with `cwd` set to the synthetic tmpdir, so `import 'yaml'`
+ *     still resolves through the repo's node_modules.
+ *
+ * Cases covered
+ * -------------
+ *   - PASS (strict): template + deployed are structurally identical
+ *   - FAIL (strict): deployed missing a job present in template
+ *   - FAIL (strict): deployed has different `on:` triggers
+ *   - FAIL (strict): deployed missing run-steps
+ *   - PASS (baseline, no file): clean state → exit 0
+ *   - FAIL (baseline, no file): drift present → exit 1 with hint
+ *   - PASS (baseline, count <= baseline): baseline accepts existing drift
+ *   - FAIL (baseline, count > baseline): regression detected, mentions REGRESSION
+ *   - --update-baseline writes the JSON file and exits 0
+ *
+ * @task T9860
+ * @saga T9855
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+const REPO_ROOT = resolve(__dirname, '../..');
+const SCRIPT = join(REPO_ROOT, 'scripts/lint-deployed-template-parity.mjs');
+
+// A template that, when rendered, defines a `preflight` + `prepare` shape
+// mirroring the canonical release-prepare.yml.tmpl skeleton.
+const TEMPLATE_YAML = `name: Test Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: {{INSTALL_CMD}}
+      - run: {{LINT_CMD}}
+      - run: {{TEST_CMD}}
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    needs: preflight
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "prepared"
+`;
+
+const DEPLOYED_MATCHING = `name: Test Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm biome check .
+      - run: pnpm run test
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    needs: preflight
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "prepared"
+`;
+
+const DEPLOYED_MISSING_JOB = `name: Test Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "prepared"
+`;
+
+const DEPLOYED_DIFFERENT_ON = `name: Test Workflow
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm biome check .
+      - run: pnpm run test
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    needs: preflight
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "prepared"
+`;
+
+const DEPLOYED_MISSING_RUN_STEPS = `name: Test Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pnpm install --frozen-lockfile
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    needs: preflight
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "prepared"
+`;
+
+/** Synthetic repo root with a templates dir and a .github/workflows dir. */
+let tmpRoot;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-deployed-tmpl-parity-'));
+
+  // Create the directories the script expects relative to its cwd.
+  const templateDir = join(tmpRoot, 'packages', 'core', 'templates', 'workflows');
+  const deployedDir = join(tmpRoot, '.github', 'workflows');
+  mkdirSync(templateDir, { recursive: true });
+  mkdirSync(deployedDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/**
+ * Run the lint script with cwd=tmpRoot so REPO_ROOT resolves to the synthetic
+ * project. The script itself lives at the real path under the repo's
+ * scripts/ dir, so `import 'yaml'` still resolves through node_modules.
+ * @param {string[]} extraArgs
+ */
+function runLint(extraArgs = []) {
+  return spawnSync('node', [SCRIPT, ...extraArgs], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: tmpRoot,
+  });
+}
+
+/** Write the template at the canonical path. */
+function writeTemplate(content) {
+  writeFileSync(
+    join(tmpRoot, 'packages/core/templates/workflows/release-prepare.yml.tmpl'),
+    content,
+  );
+}
+
+/** Write the deployed workflow at the canonical path. */
+function writeDeployed(content) {
+  writeFileSync(join(tmpRoot, '.github/workflows/release-prepare.yml'), content);
+}
+
+// ============================================================================
+// Strict mode — detects drift unconditionally
+// ============================================================================
+
+describe('lint-deployed-template-parity — --strict', () => {
+  it('exits 0 when deployed matches the rendered template', () => {
+    writeTemplate(TEMPLATE_YAML);
+    writeDeployed(DEPLOYED_MATCHING);
+    const result = runLint(['--strict']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('PASS');
+  });
+
+  it('exits 1 when a job is missing in the deployed file', () => {
+    writeTemplate(TEMPLATE_YAML);
+    writeDeployed(DEPLOYED_MISSING_JOB);
+    const result = runLint(['--strict']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('jobs.preflight');
+    expect(result.stderr).toContain('missing');
+  });
+
+  it('exits 1 when on: triggers differ', () => {
+    writeTemplate(TEMPLATE_YAML);
+    writeDeployed(DEPLOYED_DIFFERENT_ON);
+    const result = runLint(['--strict']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('on:');
+  });
+
+  it('exits 1 when run-steps are missing inside a job', () => {
+    writeTemplate(TEMPLATE_YAML);
+    writeDeployed(DEPLOYED_MISSING_RUN_STEPS);
+    const result = runLint(['--strict']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/jobs\.preflight\.steps:.*missing/);
+  });
+});
+
+// ============================================================================
+// Default (baseline) mode
+// ============================================================================
+
+describe('lint-deployed-template-parity — baseline (default) mode', () => {
+  it('exits 0 when no baseline exists and no drift is present', () => {
+    writeTemplate(TEMPLATE_YAML);
+    writeDeployed(DEPLOYED_MATCHING);
+    const result = runLint();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('PASS');
+  });
+
+  it('exits 1 when no baseline exists and drift is present', () => {
+    writeTemplate(TEMPLATE_YAML);
+    writeDeployed(DEPLOYED_MISSING_JOB);
+    const result = runLint();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Baseline file not found');
+  });
+
+  it('exits 0 when finding count is at-or-below baseline (accepted drift)', () => {
+    writeTemplate(TEMPLATE_YAML);
+    writeDeployed(DEPLOYED_MISSING_JOB);
+    // First update-baseline to lock in the current drift.
+    runLint(['--update-baseline']);
+    // Default run should now accept it.
+    const result = runLint();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('PASS');
+  });
+
+  it('exits 1 with REGRESSION when finding count exceeds baseline', () => {
+    writeTemplate(TEMPLATE_YAML);
+    // Lock in a baseline where deployed matches template (0 findings).
+    writeDeployed(DEPLOYED_MATCHING);
+    runLint(['--update-baseline']);
+    // Now introduce drift.
+    writeDeployed(DEPLOYED_MISSING_JOB);
+    const result = runLint();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('REGRESSION');
+  });
+});
+
+// ============================================================================
+// --update-baseline
+// ============================================================================
+
+describe('lint-deployed-template-parity — --update-baseline', () => {
+  it('writes a JSON baseline file and exits 0', () => {
+    writeTemplate(TEMPLATE_YAML);
+    writeDeployed(DEPLOYED_MISSING_JOB);
+    const result = runLint(['--update-baseline']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Baseline written');
+
+    const baselinePath = join(tmpRoot, '.lint-deployed-template-parity-baseline.json');
+    expect(existsSync(baselinePath)).toBe(true);
+    const baseline = JSON.parse(readFileSync(baselinePath, 'utf-8'));
+    expect(baseline.gate).toBe('deployed-template-parity');
+    expect(baseline.task).toBe('T9860');
+    expect(baseline.total).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(baseline.results)).toBe(true);
+  });
+
+  it('baseline captures per-entry findings', () => {
+    writeTemplate(TEMPLATE_YAML);
+    writeDeployed(DEPLOYED_MISSING_JOB);
+    runLint(['--update-baseline']);
+
+    const baselinePath = join(tmpRoot, '.lint-deployed-template-parity-baseline.json');
+    const baseline = JSON.parse(readFileSync(baselinePath, 'utf-8'));
+    expect(baseline.results.length).toBeGreaterThanOrEqual(1);
+    const r = baseline.results[0];
+    expect(r).toHaveProperty('template');
+    expect(r).toHaveProperty('deployed');
+    expect(r).toHaveProperty('findings');
+    expect(Array.isArray(r.findings)).toBe(true);
+  });
+});
+
+// ============================================================================
+// Error surface
+// ============================================================================
+
+describe('lint-deployed-template-parity — error surface', () => {
+  it('exits 2 when deployed file is missing', () => {
+    writeTemplate(TEMPLATE_YAML);
+    // No deployed file written.
+    const result = runLint();
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('deployed file not found');
+  });
+
+  it('exits 2 when neither template nor fallback exists', () => {
+    writeDeployed(DEPLOYED_MATCHING);
+    // No template written.
+    const result = runLint();
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('template file not found');
+  });
+});
+
+// ============================================================================
+// Fallback template resolution (cleo→core relocation window)
+// ============================================================================
+
+describe('lint-deployed-template-parity — fallback template', () => {
+  it('falls back to packages/cleo/... when packages/core/... missing', () => {
+    // Write template ONLY at the fallback path.
+    const fallbackDir = join(tmpRoot, 'packages/cleo/templates/workflows');
+    mkdirSync(fallbackDir, { recursive: true });
+    writeFileSync(join(fallbackDir, 'release-prepare.yml.tmpl'), TEMPLATE_YAML);
+    writeDeployed(DEPLOYED_MATCHING);
+
+    const result = runLint(['--strict']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('PASS');
+  });
+});

--- a/scripts/lint-deployed-template-parity.mjs
+++ b/scripts/lint-deployed-template-parity.mjs
@@ -471,3 +471,4 @@ function emitFailureReport(results, totalFindings) {
 }
 
 process.exit(main());
+// re-trigger

--- a/scripts/lint-deployed-template-parity.mjs
+++ b/scripts/lint-deployed-template-parity.mjs
@@ -1,0 +1,473 @@
+#!/usr/bin/env node
+/**
+ * Lint rule: deployed-template parity gate (T9860 / SG-TEMPLATE-CONFIG-SSOT T9855).
+ *
+ * Why this matters
+ * ----------------
+ * `packages/cleo/templates/workflows/*.yml.tmpl` (being relocated to
+ * `packages/core/templates/workflows/*.yml.tmpl` by T9858) are the canonical
+ * sources for GitHub Actions workflows shipped to consuming projects via
+ * `cleo init --workflows`. The deployed copies under `.github/workflows/`
+ * in *this* repo are the rendered output of those templates and should
+ * therefore track them faithfully (modulo project-context placeholder
+ * substitution).
+ *
+ * Today the deployed `release-prepare.yml` has drifted: it lacks the
+ * preflight job mandated by SPEC-T9345 R-200/R-260, hardcodes its node
+ * version + install command + branch prefix, and skips the canonical
+ * placeholder pass entirely. This gate documents that drift as a baseline
+ * and prevents NEW divergence from creeping in.
+ *
+ * What this script does
+ * ---------------------
+ * 1. For each entry in PARITY_MAP, read the template file and substitute
+ *    `{{KEY}}` placeholders using project-context defaults.
+ * 2. Compare the rendered template against the deployed file structurally:
+ *      - `on:` triggers and their inputs
+ *      - `permissions`
+ *      - `jobs.<name>.runs-on` and steps (`run:` set + `uses:` set)
+ * 3. Report PASS or FAIL with the structural divergences enumerated.
+ *
+ * Modes
+ * -----
+ * (default)         Baseline mode. Compares finding count against the file
+ *                   at `.lint-deployed-template-parity-baseline.json` and
+ *                   fails only on net-add (regression prevention).
+ * --strict          Zero-tolerance — any divergence fails the gate.
+ * --update-baseline Regenerate the baseline JSON from current state, exit 0.
+ *
+ * @task T9860
+ * @epic T9860 (E5-DOGFOOD-CI-GATES)
+ * @saga T9855 SG-TEMPLATE-CONFIG-SSOT
+ * @see AGENTS.md § "Dogfood: Deployed Template Parity (T9860 · Saga T9855)"
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+/**
+ * REPO_ROOT resolves to `process.cwd()`. The script is intended to be
+ * invoked from the repository root (either by CI or `pnpm`), and tests run
+ * the script with `cwd` set to a synthetic project tmpdir. Pinning to cwd
+ * (instead of `__dirname`-relative) keeps the script trivially testable
+ * without copying it out of `node_modules` reach.
+ */
+const REPO_ROOT = process.cwd();
+
+// ============================================================================
+// CLI args
+// ============================================================================
+
+const args = process.argv.slice(2);
+const MODE_STRICT = args.includes('--strict');
+const MODE_UPDATE_BASELINE = args.includes('--update-baseline');
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const BASELINE_PATH = join(REPO_ROOT, '.lint-deployed-template-parity-baseline.json');
+
+/**
+ * Default placeholder substitutions for cleocode itself. These mirror what
+ * `cleo init --workflows` resolves from `.cleo/project-context.json` at
+ * scaffold time. Keep them in sync with the cleocode root `package.json`
+ * (engines.node) and the canonical `pnpm`-based commands.
+ */
+const DEFAULT_SUBSTITUTIONS = {
+  NODE_VERSION: '24',
+  INSTALL_CMD: 'pnpm install --frozen-lockfile',
+  LINT_CMD: 'pnpm biome check .',
+  TYPECHECK_CMD: 'pnpm run typecheck',
+  TEST_CMD: 'pnpm run test',
+  BUILD_CMD: 'pnpm run build',
+  BRANCH_PREFIX: 'release',
+  PR_LABEL: 'release',
+};
+
+/**
+ * Mapping of canonical template → deployed-file pair. Each entry MAY include
+ * a `fallbackTemplate` path to handle the cleo→core relocation window
+ * (T9858) — if the primary template path doesn't exist on disk, the
+ * fallback is read instead. This avoids a hard cross-PR dependency.
+ */
+const PARITY_MAP = [
+  {
+    template: 'packages/core/templates/workflows/release-prepare.yml.tmpl',
+    deployed: '.github/workflows/release-prepare.yml',
+    fallbackTemplate: 'packages/cleo/templates/workflows/release-prepare.yml.tmpl',
+  },
+];
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Substitute `{{KEY}}` placeholders using the supplied substitution map.
+ *
+ * Keys not present in `subs` are left as-is so that the diff surfaces
+ * missing substitutions rather than silently rendering `undefined`.
+ *
+ * @param {string} source
+ * @param {Record<string, string>} subs
+ */
+function renderTemplate(source, subs) {
+  return source.replace(/{{\s*([A-Z_]+)\s*}}/g, (match, key) => {
+    if (Object.hasOwn(subs, key)) return subs[key];
+    return match;
+  });
+}
+
+/**
+ * Parse a YAML workflow document, returning a normalized JS object. Throws
+ * a descriptive error if parsing fails.
+ *
+ * @param {string} yamlText
+ * @param {string} label
+ */
+function parseWorkflow(yamlText, label) {
+  try {
+    return parseYaml(yamlText) ?? {};
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse ${label} as YAML: ${msg}`);
+  }
+}
+
+/**
+ * Build a structural fingerprint of a workflow document — just the bits we
+ * care about for parity:
+ *   - top-level `on:` shape (trigger names + input names)
+ *   - top-level `permissions:` map
+ *   - jobs map → { runsOn, runs: string[], uses: string[] }
+ *
+ * Whitespace, comments, and step ordering for steps with identical `run:`
+ * content do not affect the fingerprint.
+ *
+ * @param {Record<string, unknown>} doc
+ */
+function fingerprint(doc) {
+  const out = {
+    on: undefined,
+    permissions: undefined,
+    jobs: {},
+  };
+
+  if (doc && typeof doc === 'object') {
+    // YAML's `on:` key collides with the JS boolean true — yaml@2 emits the
+    // string 'on' AND occasionally `true` depending on quoting. Accept both.
+    const onValue = doc.on ?? doc[true];
+    out.on = normalizeOn(onValue);
+
+    if (doc.permissions !== undefined) {
+      out.permissions = sortObject(doc.permissions);
+    }
+
+    if (doc.jobs && typeof doc.jobs === 'object') {
+      for (const [jobName, job] of Object.entries(doc.jobs)) {
+        if (!job || typeof job !== 'object') continue;
+        const j = /** @type {Record<string, unknown>} */ (job);
+        const steps = Array.isArray(j.steps) ? j.steps : [];
+        const runs = [];
+        const uses = [];
+        for (const step of steps) {
+          if (!step || typeof step !== 'object') continue;
+          const s = /** @type {Record<string, unknown>} */ (step);
+          if (typeof s.run === 'string') runs.push(s.run.trim());
+          if (typeof s.uses === 'string') uses.push(s.uses.trim());
+        }
+        runs.sort();
+        uses.sort();
+        out.jobs[jobName] = {
+          runsOn: j['runs-on'] ?? null,
+          runs,
+          uses,
+        };
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Normalize the `on:` trigger to a `{ <triggerName>: { inputs: string[] } }`
+ * shape, sorted for stable comparison.
+ *
+ * @param {unknown} on
+ */
+function normalizeOn(on) {
+  if (!on || typeof on !== 'object') return on ?? null;
+  const result = {};
+  for (const [trigger, body] of Object.entries(on)) {
+    if (body && typeof body === 'object' && 'inputs' in body) {
+      const inputs = Object.keys(/** @type {Record<string, unknown>} */ (body).inputs ?? {}).sort();
+      result[trigger] = { inputs };
+    } else {
+      result[trigger] = body ?? null;
+    }
+  }
+  return result;
+}
+
+/**
+ * Sort object keys recursively so JSON.stringify output is deterministic.
+ *
+ * @param {unknown} value
+ */
+function sortObject(value) {
+  if (Array.isArray(value)) return value.map(sortObject);
+  if (value && typeof value === 'object') {
+    const sorted = {};
+    for (const k of Object.keys(value).sort()) {
+      sorted[k] = sortObject(/** @type {Record<string, unknown>} */ (value)[k]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * Diff two fingerprints and return an array of human-readable divergence
+ * descriptions. Empty array means "structurally identical".
+ *
+ * @param {ReturnType<typeof fingerprint>} expected
+ * @param {ReturnType<typeof fingerprint>} actual
+ */
+function diffFingerprints(expected, actual) {
+  const findings = [];
+
+  const expOn = JSON.stringify(expected.on);
+  const actOn = JSON.stringify(actual.on);
+  if (expOn !== actOn) {
+    findings.push(`on: triggers/inputs differ — expected ${expOn}, got ${actOn}`);
+  }
+
+  const expPerm = JSON.stringify(expected.permissions ?? null);
+  const actPerm = JSON.stringify(actual.permissions ?? null);
+  if (expPerm !== actPerm) {
+    findings.push(`permissions: differ — expected ${expPerm}, got ${actPerm}`);
+  }
+
+  const expJobNames = Object.keys(expected.jobs).sort();
+  const actJobNames = Object.keys(actual.jobs).sort();
+  const missingJobs = expJobNames.filter((j) => !actJobNames.includes(j));
+  const extraJobs = actJobNames.filter((j) => !expJobNames.includes(j));
+  for (const j of missingJobs) findings.push(`jobs.${j}: missing in deployed`);
+  for (const j of extraJobs) findings.push(`jobs.${j}: extra in deployed (not in template)`);
+
+  for (const jobName of expJobNames) {
+    if (!actJobNames.includes(jobName)) continue;
+    const e = expected.jobs[jobName];
+    const a = actual.jobs[jobName];
+
+    const expRuns = JSON.stringify(e.runs);
+    const actRuns = JSON.stringify(a.runs);
+    if (expRuns !== actRuns) {
+      const missingRuns = e.runs.filter((r) => !a.runs.includes(r));
+      const extraRuns = a.runs.filter((r) => !e.runs.includes(r));
+      if (missingRuns.length > 0) {
+        findings.push(
+          `jobs.${jobName}.steps: missing ${missingRuns.length} run-step(s) — ${truncateList(missingRuns)}`,
+        );
+      }
+      if (extraRuns.length > 0) {
+        findings.push(
+          `jobs.${jobName}.steps: extra ${extraRuns.length} run-step(s) — ${truncateList(extraRuns)}`,
+        );
+      }
+    }
+
+    const expUses = JSON.stringify(e.uses);
+    const actUses = JSON.stringify(a.uses);
+    if (expUses !== actUses) {
+      const missingUses = e.uses.filter((u) => !a.uses.includes(u));
+      const extraUses = a.uses.filter((u) => !e.uses.includes(u));
+      if (missingUses.length > 0) {
+        findings.push(`jobs.${jobName}.uses: missing ${JSON.stringify(missingUses)}`);
+      }
+      if (extraUses.length > 0) {
+        findings.push(`jobs.${jobName}.uses: extra ${JSON.stringify(extraUses)}`);
+      }
+    }
+  }
+
+  return findings;
+}
+
+/** Truncate the list to its first 3 entries (each shortened) so output stays readable. */
+function truncateList(items) {
+  const head = items.slice(0, 3).map((s) => {
+    const oneLine = s.replace(/\s+/g, ' ').trim();
+    return oneLine.length > 80 ? `${oneLine.slice(0, 77)}...` : oneLine;
+  });
+  const more = items.length > 3 ? ` (+${items.length - 3} more)` : '';
+  return `[${head.map((h) => JSON.stringify(h)).join(', ')}]${more}`;
+}
+
+/**
+ * Process one PARITY_MAP entry and return its structured result.
+ *
+ * @param {(typeof PARITY_MAP)[number]} entry
+ */
+function processEntry(entry) {
+  const deployedPath = join(REPO_ROOT, entry.deployed);
+  if (!existsSync(deployedPath)) {
+    return {
+      template: entry.template,
+      deployed: entry.deployed,
+      status: 'error',
+      reason: 'deployed file not found',
+      findings: [],
+    };
+  }
+
+  const templateCandidates = [entry.template, entry.fallbackTemplate].filter(Boolean);
+  let templatePath = null;
+  for (const candidate of templateCandidates) {
+    const abs = join(REPO_ROOT, candidate);
+    if (existsSync(abs)) {
+      templatePath = abs;
+      break;
+    }
+  }
+  if (!templatePath) {
+    return {
+      template: entry.template,
+      deployed: entry.deployed,
+      status: 'error',
+      reason: `template file not found (tried: ${templateCandidates.join(', ')})`,
+      findings: [],
+    };
+  }
+
+  const templateRaw = readFileSync(templatePath, 'utf-8');
+  const deployedRaw = readFileSync(deployedPath, 'utf-8');
+
+  const rendered = renderTemplate(templateRaw, DEFAULT_SUBSTITUTIONS);
+
+  let expectedDoc;
+  let actualDoc;
+  try {
+    expectedDoc = parseWorkflow(rendered, `rendered ${entry.template}`);
+    actualDoc = parseWorkflow(deployedRaw, `deployed ${entry.deployed}`);
+  } catch (err) {
+    return {
+      template: entry.template,
+      deployed: entry.deployed,
+      status: 'error',
+      reason: err instanceof Error ? err.message : String(err),
+      findings: [],
+    };
+  }
+
+  const expectedFp = fingerprint(expectedDoc);
+  const actualFp = fingerprint(actualDoc);
+  const findings = diffFingerprints(expectedFp, actualFp);
+
+  return {
+    template: entry.template,
+    templateActual: templatePath.replace(`${REPO_ROOT}/`, ''),
+    deployed: entry.deployed,
+    status: findings.length === 0 ? 'pass' : 'fail',
+    reason: null,
+    findings,
+  };
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+function main() {
+  const results = PARITY_MAP.map(processEntry);
+  const totalFindings = results.reduce((sum, r) => sum + r.findings.length, 0);
+  const errors = results.filter((r) => r.status === 'error');
+
+  if (errors.length > 0) {
+    for (const e of errors) {
+      process.stderr.write(`ERROR: ${e.template} -> ${e.deployed}: ${e.reason}\n`);
+    }
+    return 2;
+  }
+
+  if (MODE_UPDATE_BASELINE) {
+    const baseline = {
+      gate: 'deployed-template-parity',
+      task: 'T9860',
+      saga: 'T9855',
+      total: totalFindings,
+      generatedAt: new Date().toISOString(),
+      results: results.map((r) => ({
+        template: r.template,
+        deployed: r.deployed,
+        findings: r.findings,
+      })),
+    };
+    writeFileSync(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`);
+    process.stdout.write(`Baseline written: ${BASELINE_PATH} (total=${totalFindings})\n`);
+    return 0;
+  }
+
+  if (MODE_STRICT) {
+    if (totalFindings === 0) {
+      process.stdout.write('PASS — deployed matches template (strict mode)\n');
+      return 0;
+    }
+    emitFailureReport(results, totalFindings);
+    process.stderr.write('Strict mode — any divergence fails the gate.\n');
+    return 1;
+  }
+
+  // Default: baseline mode.
+  if (!existsSync(BASELINE_PATH)) {
+    if (totalFindings === 0) {
+      process.stdout.write('PASS — deployed matches template (no baseline; clean)\n');
+      return 0;
+    }
+    emitFailureReport(results, totalFindings);
+    process.stderr.write(
+      `\nBaseline file not found at ${BASELINE_PATH}. Run with --update-baseline to accept the current state.\n`,
+    );
+    return 1;
+  }
+
+  let baseline;
+  try {
+    baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8'));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`ERROR: failed to read baseline ${BASELINE_PATH}: ${msg}\n`);
+    return 2;
+  }
+
+  const baselineTotal = typeof baseline.total === 'number' ? baseline.total : 0;
+  if (totalFindings <= baselineTotal) {
+    process.stdout.write(
+      `PASS — deployed matches template (findings=${totalFindings}, baseline=${baselineTotal})\n`,
+    );
+    return 0;
+  }
+
+  emitFailureReport(results, totalFindings);
+  process.stderr.write(
+    `\nREGRESSION — findings=${totalFindings} exceeds baseline=${baselineTotal}.\n` +
+      `If this is intentional, run: node scripts/lint-deployed-template-parity.mjs --update-baseline\n`,
+  );
+  return 1;
+}
+
+function emitFailureReport(results, totalFindings) {
+  process.stderr.write(`FAIL — ${totalFindings} divergence(s):\n`);
+  for (const r of results) {
+    if (r.findings.length === 0) continue;
+    process.stderr.write(`\n  ${r.template} -> ${r.deployed}\n`);
+    for (const f of r.findings) {
+      process.stderr.write(`    - ${f}\n`);
+    }
+  }
+}
+
+process.exit(main());


### PR DESCRIPTION
## Summary

Dogfood CI gate for Saga T9855 SG-TEMPLATE-CONFIG-SSOT, Epic T9860 E5-DOGFOOD-CI-GATES.

- Adds `scripts/lint-deployed-template-parity.mjs` — renders shipped workflow templates with project-context placeholders + compares against deployed `.github/workflows/*.yml`. Structural diff covers `on:` triggers/inputs, `permissions`, per-job `runs-on`/`run`-step set/`uses`-step set.
- Establishes baseline at the **current drifted state** of `release-prepare.yml`: no preflight job, hardcoded node 24 / branch prefix / install command. Baseline pins 8 accepted divergences; CI fails on any NEW divergence (regression prevention).
- Wires `deployed-template-parity` job into `ci.yml` under a new `workflows` paths-filter that triggers on changes to `.github/workflows/**`, `packages/*/templates/workflows/**`, the lint script, or the baseline.
- `AGENTS.md` gets a new section "Dogfood: Deployed Template Parity (T9860 · Saga T9855)" documenting modes and how to add new template→deployed pairs.

## What this PR does NOT do

It does not rewrite `.github/workflows/release-prepare.yml` to match the template. Closing the drift is a separate follow-up — this PR ONLY establishes the gate so the drift cannot widen silently.

## Modes

| Command | Behavior |
|---|---|
| `node scripts/lint-deployed-template-parity.mjs` | Default (baseline) — fails on net-add only |
| `node scripts/lint-deployed-template-parity.mjs --strict` | Zero-tolerance — any divergence fails |
| `node scripts/lint-deployed-template-parity.mjs --update-baseline` | Regenerate baseline JSON |

## Cleo→core relocation window (T9858)

PARITY_MAP entries support `fallbackTemplate`. Today the canonical path is `packages/cleo/templates/workflows/`; once T9858 lands `packages/core/templates/workflows/`, the script picks up the new location automatically.

## Test plan

- [x] `node scripts/lint-deployed-template-parity.mjs --strict` reports 8 divergences against current `.github/workflows/release-prepare.yml` (documented drift)
- [x] `node scripts/lint-deployed-template-parity.mjs --update-baseline` writes `.lint-deployed-template-parity-baseline.json` with `total=8`
- [x] `node scripts/lint-deployed-template-parity.mjs` (default) passes — `PASS — deployed matches template (findings=8, baseline=8)`
- [x] `pnpm exec vitest run --project=scripts scripts/__tests__/lint-deployed-template-parity.test.mjs` — 13/13 pass
- [x] `pnpm biome check --write` — clean
- [x] CI: new `Deployed Template Parity (T9860)` job runs and passes against baseline

## Acceptance criteria

- [x] Script written + tested (13 vitest cases)
- [x] CI gate wired (job in `ci.yml`)
- [x] Baseline established (`.lint-deployed-template-parity-baseline.json`, 8 findings)
- [x] AGENTS.md updated
- [x] Fallback template path supports T9858 cleo→core relocation

Saga: T9855 SG-TEMPLATE-CONFIG-SSOT
Epic: T9860 E5-DOGFOOD-CI-GATES