### PR TITLE
feat(T10134): generic cleo tree — parent + groups edges, full depth (B9)

### DIFF
--- a/.changeset/t10134-generic-cleo-tree.md
+++ b/.changeset/t10134-generic-cleo-tree.md
@@ -1,0 +1,11 @@
+---
+"@cleocode/cleo": minor
+"@cleocode/core": minor
+"@cleocode/animations": patch
+---
+
+feat(T10134): generic `cleo tree <id>` — walks parent + groups edges to full depth, KindIcon + RelationIcon prefixes (B9)
+
+`cleo tree T9855` now shows the full saga membership tree (12 members + their subtrees), not just the 2 parent-edge children. Walks `task_relations.relation_type='groups'` AND `parent_id` edges recursively to full depth. Shows ancestor chain upward from root. KindIcon (🌲/📋/•/◦) before each node, RelationIcon.GROUPS (⊂) prefix on saga members. Derives from typed `TreeResponse<T>` contract; uses `renderTree` primitive from `@cleocode/animations/render`. NO `--root`/`--depth`/`--kinds` flags. `--withDeps` and `--blockers` preserved.
+
+Closes T10134. Epic: T10114. ADR: adr-077-human-render-contract.

--- a/build.mjs
+++ b/build.mjs
@@ -415,6 +415,17 @@ const cleoBuildOptions = {
       // Inline its source so the published CLI works without a separately built
       // animations dist/ — mirrors the same pattern used for @cleocode/playbooks.
       '@cleocode/animations': resolve(__dirname, 'packages/animations/src/index.ts'),
+      // T10134: the `./render` subpath ships the static B3 primitives
+      // (renderTree, renderTable, renderBadge, etc.) consumed by
+      // `cleo tree` and the broader Human Render Contract. Same inline
+      // rationale as the bare-package alias above — without this entry,
+      // esbuild treats `@cleocode/animations/render` as external and the
+      // published CLI breaks at runtime when the animations dist/ is not
+      // physically present alongside the cleo bundle.
+      '@cleocode/animations/render': resolve(
+        __dirname,
+        'packages/animations/src/render/index.ts',
+      ),
     }),
   ],
 };

--- a/packages/animations/src/render/__tests__/tree.test.ts
+++ b/packages/animations/src/render/__tests__/tree.test.ts
@@ -132,7 +132,7 @@ describe('renderTree', () => {
     expect(lines).toHaveLength(51);
     expect(lines[0]).toBe('📋 Big epic 🚧');
     expect(lines[49]).toBe('├─ • Task 49 ⏳');
-    expect(lines[50]).toBe('└─ … and 11 more tasks (run cleo tree E-BIG --depth +1 to expand)');
+    expect(lines[50]).toBe('└─ … and 11 more tasks (run cleo tree E-BIG to expand)');
   });
 
   it('renders nothing when the root cannot be resolved', () => {

--- a/packages/animations/src/render/tree.ts
+++ b/packages/animations/src/render/tree.ts
@@ -190,7 +190,7 @@ function emitChildren<T>(
     const sampleKind = children[0]?.kind ?? 'task';
     const label = KIND_LABEL[sampleKind];
     out.push(
-      `${ancestorPrefix}${connectors.leaf}… and ${hidden} more ${label} (run cleo tree ${parentId} --depth +1 to expand)`,
+      `${ancestorPrefix}${connectors.leaf}… and ${hidden} more ${label} (run cleo tree ${parentId} to expand)`,
     );
   }
 }

--- a/packages/cleo/src/cli/commands/deps.ts
+++ b/packages/cleo/src/cli/commands/deps.ts
@@ -8,14 +8,21 @@
  * @task T4464
  * @epic T4454
  * @task T1857 — deps validate + deps tree subcommands (T1855 guardrails)
+ * @task T10134 — `cleo tree <id>` walks parent + groups edges to full depth.
+ * @epic T10114 — E11-HUMAN-RENDER-CONTRACT (ADR-077).
  */
 
 import { ExitCode } from '@cleocode/contracts';
-import { depsCriticalPath, resolveProjectRoot } from '@cleocode/core/internal';
+import {
+  buildGenericTaskTree,
+  depsCriticalPath,
+  resolveProjectRoot,
+} from '@cleocode/core/internal';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
+import { isJsonFormat, isQuiet } from '../format-context.js';
+import { renderGenericTree } from '../renderers/generic-tree.js';
 import { cliError, cliOutput } from '../renderers/index.js';
-import { setTreeContext } from '../tree-context.js';
 
 /** cleo deps overview — overview of all dependencies */
 const overviewCommand = defineCommand({
@@ -257,44 +264,72 @@ export const depsCommand = defineCommand({
 });
 
 /**
- * Standalone tree command — task hierarchy tree visualization.
+ * Standalone tree command — generic task-graph visualization (T10134).
  *
  * @remarks
- * Kept as a separate export so that index.ts can wire it to `cleo tree`.
+ * Walks the task graph rooted at the given `<id>` through BOTH `parent_id`
+ * edges AND `task_relations.relation_type='groups'` edges, recursively to
+ * full depth. Also surfaces the upward parent-chain ancestors so the user
+ * sees where the rendered root sits in the broader hierarchy.
  *
- * Flags:
- * - `--with-deps`  — inline each task's direct dependency chain below the task line.
- * - `--blockers`   — render transitive blocker chain + leaf blockers for every
- *                    blocked task in the tree.
+ * Node-kind discrimination uses the canonical `KindIcon` enum (🌲 saga, 📋
+ * epic, • task, ◦ subtask). Groups-edge rows are additionally prefixed with
+ * `RelationIcon.GROUPS` (⊂) so the user can distinguish a parent-edge child
+ * from a saga-membership child at a glance.
+ *
+ * Args:
+ * - `<id>`         — required positional task ID. The root the tree walks from.
+ * - `--withDeps`   — append the direct `depends` list below each annotated node.
+ * - `--blockers`   — append the transitive blocker chain + leaf-blocker summary.
+ *
+ * The obsolete `--root`/`--depth`/`--kinds` flags were removed per ADR-077:
+ * the full graph IS the default behaviour, and re-rooting is achieved by
+ * passing a different `<id>`.
+ *
+ * @epic T10114
+ * @task T10134
  */
 export const treeCommand = defineCommand({
   meta: { name: 'tree', description: 'Task hierarchy tree visualization' },
   args: {
     rootId: {
       type: 'positional',
-      description: 'Root task ID (optional)',
-      required: false,
+      description: 'Root task ID — walks parent + groups edges from here',
+      required: true,
     },
     withDeps: {
       type: 'boolean',
-      description: 'Inline dependency chain below each task that has deps',
+      description: 'Append direct depends chain below each task that has deps',
       default: false,
     },
     blockers: {
       type: 'boolean',
-      description: 'Render transitive blocker chain and leaf blockers below each blocked task',
+      description: 'Append transitive blocker chain and leaf blockers below each blocked task',
       default: false,
     },
   },
   async run({ args }) {
-    // Store flags in the tree context so renderTree can read them.
-    setTreeContext({ withDeps: args.withDeps, withBlockers: args.blockers });
-    await dispatchFromCli(
-      'query',
-      'tasks',
-      'tree',
-      { taskId: args.rootId, withBlockers: args.blockers },
-      { command: 'tree', operation: 'tasks.tree' },
-    );
+    const cwd = resolveProjectRoot();
+    try {
+      const result = await buildGenericTaskTree(cwd, args.rootId, {
+        withBlockers: args.blockers,
+      });
+
+      if (isJsonFormat()) {
+        cliOutput(result, { command: 'tree', operation: 'tasks.graphTree' });
+        return;
+      }
+
+      const text = renderGenericTree(result, {
+        withDeps: args.withDeps,
+        withBlockers: args.blockers,
+        quiet: isQuiet(),
+      });
+      if (text) process.stdout.write(`${text}\n`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      cliError(`tree: ${msg}`, ExitCode.NOT_FOUND, { name: 'E_NOT_FOUND' });
+      process.exit(ExitCode.NOT_FOUND);
+    }
   },
 });

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -45,7 +44,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description:
+      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,8 +63,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +84,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,20 +102,23 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -135,7 +141,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -244,7 +251,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -267,14 +275,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -298,7 +308,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -309,7 +320,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -322,7 +334,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -358,7 +371,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -381,7 +395,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description:
+      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -412,7 +427,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -435,14 +451,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -471,7 +490,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -513,14 +533,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -549,7 +572,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -561,13 +585,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -610,7 +636,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -621,7 +648,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -657,7 +685,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description:
+      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -669,7 +698,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -681,7 +711,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -729,13 +760,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description:
+      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -813,7 +846,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -825,13 +859,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description:
+      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -44,8 +45,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description:
-      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -84,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -102,23 +99,20 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -141,8 +135,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -251,8 +244,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -275,16 +267,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -308,8 +298,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -320,8 +309,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -334,8 +322,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -371,8 +358,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -395,8 +381,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description:
-      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -427,8 +412,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -451,17 +435,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -490,8 +471,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -533,17 +513,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -572,8 +549,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -585,15 +561,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -636,8 +610,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -648,8 +621,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description:
-      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -685,8 +657,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description:
-      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -698,8 +669,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -711,8 +681,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -760,15 +729,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -846,8 +813,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -859,15 +825,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description:
-      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/renderers/__tests__/generic-tree.test.ts
+++ b/packages/cleo/src/cli/renderers/__tests__/generic-tree.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for `renderGenericTree` — the renderer that drives `cleo tree <id>`
+ * (T10134).
+ *
+ * Covers the canonical SG-TEMPLATE-CONFIG-SSOT-shaped saga (AC10) plus the
+ * ancestor-banner + groups-edge prefix behaviour spelled out in the task
+ * acceptance criteria. Fixtures are inlined (no DB) so the renderer is
+ * exercised in isolation.
+ *
+ * @epic T10114
+ * @task T10134
+ * @see ADR-077-human-render-contract.md
+ */
+
+import { createAnimateContext } from '@cleocode/animations';
+import type { FlatTreeNode, TreeResponse } from '@cleocode/contracts';
+import type { GenericTreeMetadata, GenericTreeResult } from '@cleocode/core/internal';
+import { describe, expect, it } from 'vitest';
+import { renderGenericTree } from '../generic-tree.js';
+
+/**
+ * Forced-enabled context — bypasses the no-TTY guard inside
+ * `createAnimateContext` so the renderer output is deterministic in CI.
+ * Production callers never opt-in this way; they go through the format
+ * context which respects TTY + NO_COLOR.
+ */
+const enabledCtx = createAnimateContext({
+  flagResolution: { format: 'human', quiet: false },
+  isTTY: true,
+  noColor: false,
+});
+
+/** Build a `FlatTreeNode` with sensible defaults to keep fixtures terse. */
+function node(
+  overrides: Partial<FlatTreeNode<GenericTreeMetadata>> & {
+    id: string;
+    title: string;
+    metadata: Partial<GenericTreeMetadata>;
+  },
+): FlatTreeNode<GenericTreeMetadata> {
+  return {
+    id: overrides.id,
+    parentId: overrides.parentId ?? null,
+    depth: overrides.depth ?? 0,
+    kind: overrides.kind ?? 'task',
+    status: overrides.status ?? 'pending',
+    title: overrides.title,
+    metadata: {
+      edgeType: overrides.metadata.edgeType ?? 'parent',
+      priority: overrides.metadata.priority ?? 'medium',
+      depends: overrides.metadata.depends ?? [],
+      blockedBy: overrides.metadata.blockedBy ?? [],
+      ready: overrides.metadata.ready ?? false,
+      ...(overrides.metadata.blockerChain !== undefined
+        ? { blockerChain: overrides.metadata.blockerChain }
+        : {}),
+      ...(overrides.metadata.leafBlockers !== undefined
+        ? { leafBlockers: overrides.metadata.leafBlockers }
+        : {}),
+    },
+  };
+}
+
+/**
+ * Build the canonical SG-TEMPLATE-CONFIG-SSOT-shaped fixture: 1 saga + 12
+ * member epics + a couple of parent-edge children on the first member.
+ *
+ * Rows are emitted in PRE-ORDER so the renderer's flat-list-to-tree
+ * reconstruction matches what `buildGenericTaskTree` produces in production.
+ */
+function sagaFixture(): GenericTreeResult {
+  const tree: FlatTreeNode<GenericTreeMetadata>[] = [
+    node({
+      id: 'SG-TPL',
+      title: 'SG-TEMPLATE-CONFIG-SSOT',
+      kind: 'saga',
+      status: 'pending',
+      metadata: { edgeType: 'root' },
+    }),
+    // Member Epic 01 — visited first; its parent-edge children are emitted
+    // immediately after it (DFS preorder).
+    node({
+      id: 'E-MEM-01',
+      title: 'Member Epic 01',
+      kind: 'epic',
+      status: 'pending',
+      parentId: 'SG-TPL',
+      depth: 1,
+      metadata: { edgeType: 'groups' },
+    }),
+    node({
+      id: 'T-CHILD-01',
+      title: 'Child task A',
+      parentId: 'E-MEM-01',
+      depth: 2,
+      metadata: { edgeType: 'parent' },
+    }),
+    node({
+      id: 'T-CHILD-02',
+      title: 'Child task B',
+      parentId: 'E-MEM-01',
+      depth: 2,
+      status: 'in_progress',
+      metadata: { edgeType: 'parent' },
+    }),
+  ];
+  // Remaining members 02–12 — no parent-edge children to emit.
+  for (let i = 2; i <= 12; i++) {
+    tree.push(
+      node({
+        id: `E-MEM-${i.toString().padStart(2, '0')}`,
+        title: `Member Epic ${i.toString().padStart(2, '0')}`,
+        kind: 'epic',
+        status: 'pending',
+        parentId: 'SG-TPL',
+        depth: 1,
+        metadata: { edgeType: 'groups' },
+      }),
+    );
+  }
+
+  const response: TreeResponse<GenericTreeMetadata> = {
+    tree,
+    root: 'SG-TPL',
+    totalNodes: tree.length,
+    maxDepth: 2,
+  };
+
+  return { tree: response, ancestors: [] };
+}
+
+describe('renderGenericTree (T10134)', () => {
+  it('renders the canonical SG-TEMPLATE-CONFIG-SSOT shape with groups prefix', () => {
+    const out = renderGenericTree(sagaFixture(), {
+      withDeps: false,
+      withBlockers: false,
+      quiet: false,
+      ctx: enabledCtx,
+    });
+    const lines = out.split('\n');
+
+    // Root saga line — KindIcon.SAGA + StatusIcon.PENDING in Unicode.
+    expect(lines[0]).toBe('🌲 SG-TEMPLATE-CONFIG-SSOT ⏳');
+
+    // First member — groups-edge children carry RelationIcon.GROUPS (⊂)
+    // prefix; connectors are Unicode box-drawing.
+    expect(lines[1]).toBe('├─ 📋 ⊂ Member Epic 01 ⏳');
+
+    // Child tasks live one level deeper under the first member.
+    expect(lines[2]).toBe('│  ├─ • Child task A ⏳');
+    expect(lines[3]).toBe('│  └─ • Child task B 🚧');
+
+    // Last member — `└─` instead of `├─` because it's the last sibling.
+    expect(lines[14]).toBe('└─ 📋 ⊂ Member Epic 12 ⏳');
+
+    // 1 root + 12 members + 2 child tasks = 15 rows.
+    expect(lines).toHaveLength(15);
+  });
+
+  it('emits the ancestor banner when the root has parent-chain ancestors', () => {
+    const fixture = sagaFixture();
+    const ancestors: ReadonlyArray<FlatTreeNode<GenericTreeMetadata>> = [
+      node({
+        id: 'E-PARENT',
+        title: 'Parent Epic',
+        kind: 'epic',
+        metadata: { edgeType: 'parent' },
+      }),
+      node({
+        id: 'SG-ROOT',
+        title: 'Root Saga',
+        kind: 'saga',
+        metadata: { edgeType: 'parent' },
+      }),
+    ];
+    const decorated: GenericTreeResult = { ...fixture, ancestors };
+    const out = renderGenericTree(decorated, {
+      withDeps: false,
+      withBlockers: false,
+      quiet: false,
+      ctx: enabledCtx,
+    });
+
+    // Banner shows root → … → (here) in Unicode mode using `↑` + `›` arrows.
+    // The first line MUST cover all ancestor kinds + the (here) terminator
+    // so a user reading L-to-R sees the upward chain ending at the rendered root.
+    const firstLine = out.split('\n')[0] ?? '';
+    expect(firstLine).toContain('🌲 SG-ROOT');
+    expect(firstLine).toContain('📋 E-PARENT');
+    expect(firstLine).toContain('(here)');
+    expect(firstLine.startsWith('↑')).toBe(true);
+  });
+
+  it('appends withDeps annotations beneath the tree', () => {
+    const fixture = sagaFixture();
+    // Inject a dep onto the first child task.
+    const decoratedRows = fixture.tree.tree.map((n) =>
+      n.id === 'T-CHILD-01' ? { ...n, metadata: { ...n.metadata, depends: ['T-OTHER'] } } : n,
+    );
+    const decorated: GenericTreeResult = {
+      ...fixture,
+      tree: { ...fixture.tree, tree: decoratedRows },
+    };
+    const out = renderGenericTree(decorated, {
+      withDeps: true,
+      withBlockers: false,
+      quiet: false,
+      ctx: enabledCtx,
+    });
+    expect(out).toContain('T-CHILD-01 depends-on: T-OTHER');
+  });
+
+  it('quiet mode emits one ID per line in preorder', () => {
+    const out = renderGenericTree(sagaFixture(), {
+      withDeps: false,
+      withBlockers: false,
+      quiet: true,
+      ctx: enabledCtx,
+    });
+    const lines = out.split('\n');
+    expect(lines[0]).toBe('SG-TPL');
+    expect(lines[1]).toBe('E-MEM-01');
+    expect(lines[2]).toBe('T-CHILD-01');
+    expect(lines).toHaveLength(15);
+  });
+});

--- a/packages/cleo/src/cli/renderers/generic-tree.ts
+++ b/packages/cleo/src/cli/renderers/generic-tree.ts
@@ -1,0 +1,193 @@
+/**
+ * Renderer for the generic `cleo tree <id>` envelope.
+ *
+ * Produces the human-readable view of {@link GenericTreeResult} envelopes
+ * (parent + groups edges, walked to full depth, plus the upward ancestor
+ * chain). Delegates the actual box-drawing to {@link renderTree} from
+ * `@cleocode/animations/render` — this module owns ONLY the assembly:
+ *
+ * 1. Ancestor banner (when the rendered root sits below a broader root).
+ * 2. `renderTree` output with {@link RelationIcon.GROUPS} (`⊂`) prepended
+ *    to titles whose `metadata.edgeType === 'groups'`.
+ * 3. Optional `--withDeps` / `--blockers` annotations appended below.
+ *
+ * @epic T10114
+ * @task T10134
+ * @see ADR-077-human-render-contract.md
+ */
+
+import { type AnimateContext, createAnimateContext } from '@cleocode/animations';
+import { renderTree } from '@cleocode/animations/render';
+import type { FlatTreeNode, TreeResponse } from '@cleocode/contracts';
+import { ascii, KindIcon, pickIcon, RelationIcon } from '@cleocode/contracts/render/icon.js';
+import type { GenericTreeMetadata, GenericTreeResult } from '@cleocode/core/internal';
+import { getFormatContext } from '../format-context.js';
+import { DIM, NC } from './colors.js';
+
+/** Per-render options consumed by {@link renderGenericTree}. */
+export interface RenderGenericTreeOptions {
+  /** When `true`, append the direct `depends` list under each annotated node. */
+  readonly withDeps: boolean;
+  /**
+   * When `true`, append the transitive blocker chain + leaf-blocker summary
+   * under each blocked node. Requires `result.tree` to have been built with
+   * `BuildGenericTreeOptions.withBlockers === true`.
+   */
+  readonly withBlockers: boolean;
+  /**
+   * Suppress decorations and emit one node ID per line — script-friendly. The
+   * tree connectors are still drawn so the hierarchy stays visible.
+   */
+  readonly quiet: boolean;
+  /**
+   * Optional override for the {@link AnimateContext} that gates the renderer.
+   *
+   * Production callers OMIT this — the renderer resolves the context from
+   * the CLI format context. Tests pass an explicit enabled context to bypass
+   * the non-TTY / no-color silencing that {@link createAnimateContext}
+   * applies in CI environments.
+   */
+  readonly ctx?: AnimateContext;
+}
+
+/**
+ * Render a {@link GenericTreeResult} as a multi-line string suitable for
+ * direct write to stdout.
+ *
+ * Returns an empty string for `--format=json` (the JSON branch is the
+ * caller's responsibility).
+ *
+ * @param result - The envelope produced by `buildGenericTaskTree`.
+ * @param opts   - Per-invocation render options.
+ */
+export function renderGenericTree(
+  result: GenericTreeResult,
+  opts: RenderGenericTreeOptions,
+): string {
+  const ctx = opts.ctx ?? resolveAnimateContext();
+  if (!ctx.enabled) return '';
+
+  if (opts.quiet) return renderQuiet(result);
+
+  const useAscii = ctx.inputs.noColor;
+  const lines: string[] = [];
+
+  // Ancestor banner — strict parent_id chain UPWARD from the rendered root.
+  if (result.ancestors.length > 0) {
+    lines.push(formatAncestorBanner(result.ancestors, useAscii));
+    lines.push('');
+  }
+
+  // Tree body — transform titles so groups-edge nodes carry the `⊂` prefix
+  // before delegating to the canonical box-drawing primitive.
+  const treeWithGlyphs = decorateGroupsEdges(result.tree, useAscii);
+  const body = renderTree(treeWithGlyphs, { ctx });
+  if (body) lines.push(body);
+
+  // Optional annotations beneath each node.
+  if (opts.withDeps || opts.withBlockers) {
+    const annotations = renderAnnotations(result.tree, opts);
+    if (annotations) lines.push(annotations);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Build a TreeResponse whose groups-edge node titles carry the
+ * {@link RelationIcon.GROUPS} (`⊂`) prefix.
+ *
+ * The wire envelope is immutable; we return a fresh object with cloned rows
+ * so the upstream caller's data is not mutated.
+ */
+function decorateGroupsEdges(
+  tree: TreeResponse<GenericTreeMetadata>,
+  useAscii: boolean,
+): TreeResponse<GenericTreeMetadata> {
+  const glyph = useAscii ? ascii(RelationIcon.GROUPS) : RelationIcon.GROUPS;
+  const prefix = `${glyph} `;
+  const rows: FlatTreeNode<GenericTreeMetadata>[] = tree.tree.map((node) =>
+    node.metadata.edgeType === 'groups' ? { ...node, title: `${prefix}${node.title}` } : node,
+  );
+  return { ...tree, tree: rows };
+}
+
+/**
+ * Format the ancestor chain as a single banner line ordered root → … → root-1
+ * so the user reads it left-to-right toward the rendered root.
+ */
+function formatAncestorBanner(
+  ancestors: ReadonlyArray<FlatTreeNode<GenericTreeMetadata>>,
+  useAscii: boolean,
+): string {
+  // ancestors[] is nearest-first; reverse for root-first display order.
+  const ordered = [...ancestors].reverse();
+  const parts = ordered.map((node) => {
+    const icon = pickIcon(kindIconOf(node.kind), { noColor: useAscii });
+    return `${icon} ${node.id}`;
+  });
+  const arrow = useAscii ? ' > ' : ' › ';
+  const upGlyph = useAscii ? '^' : '↑';
+  const tip = arrow.trim();
+  const chain = parts.join(arrow);
+  return `${DIM}${upGlyph} ${chain}${tip}(here)${NC}`;
+}
+
+/** Quiet mode — preorder ID list, one per line. */
+function renderQuiet(result: GenericTreeResult): string {
+  return result.tree.tree.map((node) => node.id).join('\n');
+}
+
+/**
+ * Build the `--withDeps` / `--blockers` annotation block.
+ *
+ * Each annotation references the node by ID so the user can correlate it
+ * with the rendered tree row above without ambiguity.
+ */
+function renderAnnotations(
+  tree: TreeResponse<GenericTreeMetadata>,
+  opts: RenderGenericTreeOptions,
+): string {
+  const lines: string[] = [];
+  for (const node of tree.tree) {
+    if (opts.withDeps && node.metadata.depends.length > 0) {
+      lines.push(`${DIM}  ${node.id} depends-on: ${node.metadata.depends.join(', ')}${NC}`);
+    }
+    if (opts.withBlockers) {
+      const chain = node.metadata.blockerChain ?? [];
+      if (chain.length > 0) {
+        lines.push(`${DIM}  ${node.id} blocker-chain: ${chain.join(' → ')}${NC}`);
+      }
+      const leaves = node.metadata.leafBlockers ?? [];
+      if (leaves.length > 0) {
+        lines.push(`${DIM}  ${node.id} leaf-blockers: ${leaves.join(', ')}${NC}`);
+      }
+    }
+  }
+  return lines.length > 0 ? `\n${lines.join('\n')}` : '';
+}
+
+/** Map a {@link FlatTreeNode.kind} to the corresponding {@link KindIcon}. */
+function kindIconOf(kind: FlatTreeNode<GenericTreeMetadata>['kind']): KindIcon {
+  switch (kind) {
+    case 'saga':
+      return KindIcon.SAGA;
+    case 'epic':
+      return KindIcon.EPIC;
+    case 'task':
+      return KindIcon.TASK;
+    case 'subtask':
+      return KindIcon.SUBTASK;
+  }
+}
+
+/**
+ * Resolve the {@link AnimateContext} from the current CLI format context.
+ *
+ * Mirrors `animation-bridge.ts` — `getFormatContext()` always returns a
+ * sensible default (JSON, no quiet) when the preAction hook has not run, so
+ * tests and direct callers inherit a silent context without extra branching.
+ */
+function resolveAnimateContext(): AnimateContext {
+  return createAnimateContext({ flagResolution: getFormatContext() });
+}

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -60,6 +60,30 @@ export default defineConfig({
         '../../packages/contracts/src/provenance.ts',
         import.meta.url,
       ).pathname,
+      // T10134: render subpath aliases — animations/render imports these via
+      // `@cleocode/contracts/render/*.js`. Without explicit aliases the
+      // bare-package alias below rewrites the subpath to
+      // `index.ts/render/icon.js` and Node's loader errors with ENOTDIR.
+      '@cleocode/contracts/render/icon.js': new URL(
+        '../../packages/contracts/src/render/icon.ts',
+        import.meta.url,
+      ).pathname,
+      '@cleocode/contracts/render/tree.js': new URL(
+        '../../packages/contracts/src/render/tree.ts',
+        import.meta.url,
+      ).pathname,
+      '@cleocode/contracts/render/table.js': new URL(
+        '../../packages/contracts/src/render/table.ts',
+        import.meta.url,
+      ).pathname,
+      '@cleocode/contracts/render/list.js': new URL(
+        '../../packages/contracts/src/render/list.ts',
+        import.meta.url,
+      ).pathname,
+      '@cleocode/contracts/render/envelope.js': new URL(
+        '../../packages/contracts/src/render/envelope.ts',
+        import.meta.url,
+      ).pathname,
       '@cleocode/contracts': new URL('../../packages/contracts/src/index.ts', import.meta.url)
         .pathname,
       '@cleocode/core/internal': new URL('../../packages/core/src/internal.ts', import.meta.url)

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1346,6 +1346,14 @@ export {
 export type { RunGatesOptions } from './tasks/gate-runner.js';
 // Gate runner (T813)
 export { extractTypedGates, runGates } from './tasks/gate-runner.js';
+// Generic graph-aware tree walker — parent + groups edges (T10134).
+export type {
+  BuildGenericTreeOptions,
+  GenericTreeEdgeType,
+  GenericTreeMetadata,
+  GenericTreeResult,
+} from './tasks/generic-tree.js';
+export { buildGenericTaskTree } from './tasks/generic-tree.js';
 export { getCriticalPath } from './tasks/graph-ops.js';
 export type { TaskTreeNode } from './tasks/hierarchy.js';
 // Project-agnostic tool resolution + cache + semaphore (T1534 / ADR-061)

--- a/packages/core/src/tasks/__tests__/generic-tree.test.ts
+++ b/packages/core/src/tasks/__tests__/generic-tree.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for `buildGenericTaskTree` — the parent + groups edge walker
+ * powering `cleo tree <id>` (T10134).
+ *
+ * Covers the eleven acceptance criteria spelled out for B9 / Epic T10114:
+ *
+ *   AC1 — walks BOTH parent_id and `task_relations.relation_type='groups'`
+ *          edges to full depth from any root, no flag required.
+ *   AC2 — `cleo tree T9855` shows every saga member + its subtree.
+ *   AC4 — leaf rooted-tree exposes the upward ancestor chain.
+ *   AC5 — node-kind discrimination via the typed `TreeNodeKind` enum.
+ *   AC6 — edge-type metadata identifies groups-edge rows (`⊂` prefix is
+ *          the renderer's job — the data layer surfaces `edgeType`).
+ *   AC9 — derives from the typed `TreeResponse<T>` contract.
+ *
+ * @epic T10114
+ * @task T10134
+ * @see ADR-077-human-render-contract.md
+ */
+
+import type { TreeResponse } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SAGA_GROUPS_RELATION } from '../../sagas/constants.js';
+import { createTestDb, seedTasks, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import { buildGenericTaskTree, type GenericTreeMetadata } from '../generic-tree.js';
+
+let env: TestDbEnv;
+
+beforeEach(async () => {
+  env = await createTestDb();
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+/**
+ * Materialise the canonical SG-TEMPLATE-CONFIG-SSOT-shaped fixture: one saga
+ * grouping twelve member Epics, with two of the Epics carrying parent-edge
+ * children so we exercise the full mixed-edge walk.
+ *
+ * The shape mirrors the production T9855 / SG-TEMPLATE-CONFIG-SSOT saga used
+ * by the regression smoke (AC2 + AC10).
+ */
+async function seedSagaFixture(): Promise<void> {
+  const baseEpic = (id: string, title: string) => ({
+    id,
+    title,
+    type: 'epic' as const,
+    status: 'pending' as const,
+    priority: 'high' as const,
+  });
+
+  await seedTasks(env.accessor, [
+    {
+      id: 'SG-TPL',
+      title: 'SG-TEMPLATE-CONFIG-SSOT',
+      type: 'epic',
+      status: 'pending',
+      priority: 'high',
+      labels: ['saga'],
+    },
+    baseEpic('E-MEM-01', 'Member Epic 01'),
+    baseEpic('E-MEM-02', 'Member Epic 02'),
+    baseEpic('E-MEM-03', 'Member Epic 03'),
+    baseEpic('E-MEM-04', 'Member Epic 04'),
+    baseEpic('E-MEM-05', 'Member Epic 05'),
+    baseEpic('E-MEM-06', 'Member Epic 06'),
+    baseEpic('E-MEM-07', 'Member Epic 07'),
+    baseEpic('E-MEM-08', 'Member Epic 08'),
+    baseEpic('E-MEM-09', 'Member Epic 09'),
+    baseEpic('E-MEM-10', 'Member Epic 10'),
+    baseEpic('E-MEM-11', 'Member Epic 11'),
+    baseEpic('E-MEM-12', 'Member Epic 12'),
+    // Two of the member Epics have parent-edge children.
+    {
+      id: 'T-CHILD-01',
+      title: 'Child task A',
+      type: 'task',
+      status: 'pending',
+      priority: 'medium',
+      parentId: 'E-MEM-01',
+      position: 0,
+    },
+    {
+      id: 'T-CHILD-02',
+      title: 'Child task B',
+      type: 'task',
+      status: 'active',
+      priority: 'medium',
+      parentId: 'E-MEM-01',
+      position: 1,
+    },
+    {
+      id: 'T-CHILD-03',
+      title: 'Child task C',
+      type: 'task',
+      status: 'done',
+      priority: 'medium',
+      parentId: 'E-MEM-07',
+      position: 0,
+    },
+  ]);
+
+  // Wire the saga's `groups` edges in stable insertion order.
+  for (let i = 1; i <= 12; i++) {
+    const id = `E-MEM-${i.toString().padStart(2, '0')}`;
+    await env.accessor.addRelation('SG-TPL', id, SAGA_GROUPS_RELATION);
+  }
+}
+
+describe('buildGenericTaskTree (T10134)', () => {
+  it('walks groups edges from a saga and emits all 12 member Epics + parent-edge children', async () => {
+    await seedSagaFixture();
+
+    const result = await buildGenericTaskTree(env.tempDir, 'SG-TPL');
+
+    // Root row first.
+    expect(result.tree.root).toBe('SG-TPL');
+    const rootRow = result.tree.tree[0];
+    expect(rootRow?.id).toBe('SG-TPL');
+    expect(rootRow?.kind).toBe('saga');
+    expect(rootRow?.metadata.edgeType).toBe('root');
+
+    // Twelve member Epics emitted under the saga via groups edges.
+    const memberRows = result.tree.tree.filter(
+      (n) => n.parentId === 'SG-TPL' && n.metadata.edgeType === 'groups',
+    );
+    expect(memberRows).toHaveLength(12);
+    for (const row of memberRows) {
+      expect(row.kind).toBe('epic');
+      expect(row.depth).toBe(1);
+    }
+
+    // Three parent-edge children carried under their member Epics.
+    const parentChildren = result.tree.tree.filter((n) => n.metadata.edgeType === 'parent');
+    expect(parentChildren.map((n) => n.id).sort()).toEqual([
+      'T-CHILD-01',
+      'T-CHILD-02',
+      'T-CHILD-03',
+    ]);
+    for (const child of parentChildren) {
+      expect(child.kind).toBe('task');
+      expect(child.depth).toBe(2);
+    }
+
+    // Total = 1 saga + 12 epics + 3 child tasks.
+    expect(result.tree.totalNodes).toBe(16);
+    expect(result.tree.maxDepth).toBe(2);
+
+    // No ancestors above a top-level saga.
+    expect(result.ancestors).toHaveLength(0);
+  });
+
+  it('preserves the insertion order of groups edges in the emitted tree', async () => {
+    await seedSagaFixture();
+
+    const result = await buildGenericTaskTree(env.tempDir, 'SG-TPL');
+    const memberIds = result.tree.tree.filter((n) => n.parentId === 'SG-TPL').map((n) => n.id);
+    expect(memberIds).toEqual([
+      'E-MEM-01',
+      'E-MEM-02',
+      'E-MEM-03',
+      'E-MEM-04',
+      'E-MEM-05',
+      'E-MEM-06',
+      'E-MEM-07',
+      'E-MEM-08',
+      'E-MEM-09',
+      'E-MEM-10',
+      'E-MEM-11',
+      'E-MEM-12',
+    ]);
+  });
+
+  it('walks parent_id edges from an Epic root and emits every descendant', async () => {
+    await seedTasks(env.accessor, [
+      { id: 'E-PARENT', title: 'Epic root', type: 'epic', status: 'pending', priority: 'high' },
+      ...Array.from({ length: 5 }, (_, i) => ({
+        id: `T-CH-${i}`,
+        title: `Child ${i}`,
+        type: 'task' as const,
+        status: 'pending' as const,
+        priority: 'medium' as const,
+        parentId: 'E-PARENT',
+        position: i,
+      })),
+    ]);
+
+    const result = await buildGenericTaskTree(env.tempDir, 'E-PARENT');
+    expect(result.tree.totalNodes).toBe(6); // 1 epic + 5 children
+    expect(result.tree.tree[0]?.kind).toBe('epic');
+    for (const row of result.tree.tree.slice(1)) {
+      expect(row.metadata.edgeType).toBe('parent');
+      expect(row.depth).toBe(1);
+    }
+  });
+
+  it('exposes the upward ancestor chain when rooted at a leaf task', async () => {
+    await seedTasks(env.accessor, [
+      {
+        id: 'SG-A',
+        title: 'Saga',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        labels: ['saga'],
+      },
+      { id: 'E-A', title: 'Epic', type: 'epic', status: 'pending', priority: 'high' },
+      {
+        id: 'T-A',
+        title: 'Task',
+        type: 'task',
+        status: 'pending',
+        priority: 'medium',
+        parentId: 'E-A',
+      },
+      {
+        id: 'ST-A',
+        title: 'Subtask',
+        type: 'subtask',
+        status: 'pending',
+        priority: 'medium',
+        parentId: 'T-A',
+      },
+    ]);
+    await env.accessor.addRelation('SG-A', 'E-A', SAGA_GROUPS_RELATION);
+
+    const result = await buildGenericTaskTree(env.tempDir, 'ST-A');
+    // Tree itself is just the subtask (no descendants).
+    expect(result.tree.totalNodes).toBe(1);
+    expect(result.tree.tree[0]?.kind).toBe('subtask');
+
+    // Ancestors walk parent_id upward (groups edges are NOT followed upward).
+    // ST-A → T-A → E-A. SG-A is reachable only via a groups edge, so it
+    // does not appear in the parent-only ancestor chain.
+    const ancestorIds = result.ancestors.map((a) => a.id);
+    expect(ancestorIds).toEqual(['T-A', 'E-A']);
+  });
+
+  it('is cycle-safe when a parent loop is present in the data', async () => {
+    // Synthetic regression — a corrupted DB row pointing parent → child loop.
+    // The walker must terminate via the visited set rather than recurse forever.
+    await seedTasks(env.accessor, [
+      { id: 'L-A', title: 'A', type: 'task', status: 'pending', priority: 'medium' },
+      {
+        id: 'L-B',
+        title: 'B',
+        type: 'task',
+        status: 'pending',
+        priority: 'medium',
+        parentId: 'L-A',
+      },
+      {
+        id: 'L-C',
+        title: 'C',
+        type: 'task',
+        status: 'pending',
+        priority: 'medium',
+        parentId: 'L-B',
+      },
+    ]);
+    // Manufacture a back-edge L-A → L-C via a groups relation so the DFS would
+    // re-encounter L-A from L-C through a different edge type.
+    await env.accessor.addRelation('L-C', 'L-A', SAGA_GROUPS_RELATION);
+
+    const result = await buildGenericTaskTree(env.tempDir, 'L-A');
+    expect(result.tree.totalNodes).toBe(3);
+    const ids = result.tree.tree.map((n) => n.id);
+    // L-A appears exactly once even though the DFS would loop without the
+    // visited set.
+    expect(ids.filter((id) => id === 'L-A')).toHaveLength(1);
+  });
+
+  it('returns a typed TreeResponse<GenericTreeMetadata> envelope', async () => {
+    await seedTasks(env.accessor, [
+      { id: 'X-1', title: 'X', type: 'task', status: 'pending', priority: 'medium' },
+    ]);
+    const result = await buildGenericTaskTree(env.tempDir, 'X-1');
+    const tree: TreeResponse<GenericTreeMetadata> = result.tree;
+    expect(tree.root).toBe('X-1');
+    expect(tree.tree).toHaveLength(1);
+    expect(tree.maxDepth).toBe(0);
+  });
+
+  it('throws an E_NOT_FOUND-shaped error for an unknown root', async () => {
+    await seedTasks(env.accessor, []);
+    await expect(buildGenericTaskTree(env.tempDir, 'T-MISSING')).rejects.toThrow(
+      /Task 'T-MISSING' not found/,
+    );
+  });
+});

--- a/packages/core/src/tasks/generic-tree.ts
+++ b/packages/core/src/tasks/generic-tree.ts
@@ -1,0 +1,342 @@
+/**
+ * Generic task-graph walker — produces a typed {@link TreeResponse} that
+ * covers BOTH `parent_id` edges AND `task_relations.relation_type='groups'`
+ * edges from any root, recursively to full depth.
+ *
+ * Used by `cleo tree <id>` to surface the complete task graph rooted at a
+ * given task. Walks downward via parent edges + groups edges, and emits a
+ * separate ancestor chain (parent edges only) so the caller sees where the
+ * root sits in the broader hierarchy.
+ *
+ * @epic T10114
+ * @task T10134
+ * @see ADR-077-human-render-contract.md
+ * @see ADR-073-above-epic-naming.md §1 — Saga ↔ Epic linkage
+ */
+
+import type {
+  FlatTreeNode,
+  Task,
+  TaskPriority,
+  TaskStatus,
+  TreeNodeKind,
+  TreeNodeStatus,
+  TreeResponse,
+} from '@cleocode/contracts';
+import { SAGA_GROUPS_RELATION, SAGA_LABEL } from '../sagas/constants.js';
+import { getTaskAccessor } from '../store/data-accessor.js';
+import { getLeafBlockers, getTransitiveBlockers } from './dependency-check.js';
+
+/**
+ * Edge type that placed a node under its parent in the rendered tree.
+ *
+ * - `'parent'` — node was reached via the `parent_id` column (default hierarchy).
+ * - `'groups'` — node was reached via `task_relations.relation_type='groups'`
+ *                (saga membership edge).
+ * - `'root'`   — the node is the rendered root; it has no incoming edge.
+ *
+ * Used by the renderer to prefix saga-membership rows with
+ * {@link RelationIcon.GROUPS} (`⊂`) so the user can distinguish a parent edge
+ * from a groups edge at a glance.
+ */
+export type GenericTreeEdgeType = 'parent' | 'groups' | 'root';
+
+/**
+ * Per-node metadata carried in {@link FlatTreeNode.metadata} for every row
+ * produced by {@link buildGenericTaskTree}.
+ *
+ * Mirrors the dependency-annotation fields exposed by the legacy
+ * `FlatTreeNode` in `task-tree.ts` so the CLI's existing `--withDeps` and
+ * `--blockers` annotations continue to work without a second DB round-trip.
+ */
+export interface GenericTreeMetadata {
+  /**
+   * Edge that placed this node under its parent. `'root'` for the rendered
+   * root itself.
+   */
+  readonly edgeType: GenericTreeEdgeType;
+  /** Task priority. Defaulted to `'medium'` when the source row omits it. */
+  readonly priority: TaskPriority;
+  /** Raw `depends` IDs from the task record. Empty when the task has no deps. */
+  readonly depends: ReadonlyArray<string>;
+  /**
+   * Open (unresolved) dependency IDs that are currently blocking this task.
+   *
+   * A dependency is considered open when its status is not `'done'` or
+   * `'cancelled'`.
+   */
+  readonly blockedBy: ReadonlyArray<string>;
+  /**
+   * Whether this task is immediately actionable — `true` when `blockedBy`
+   * is empty AND the task's status is `'pending'` or `'active'`.
+   */
+  readonly ready: boolean;
+  /**
+   * Full transitive blocker chain. Populated only when the caller requests
+   * blocker enrichment (`withBlockers: true`).
+   */
+  readonly blockerChain?: ReadonlyArray<string>;
+  /**
+   * Leaf-level blockers — root-cause tasks that must be resolved first.
+   * Populated only when the caller requests blocker enrichment.
+   */
+  readonly leafBlockers?: ReadonlyArray<string>;
+}
+
+/**
+ * Result of {@link buildGenericTaskTree}.
+ *
+ * The returned `tree` envelope walks downward from `rootId` (covering both
+ * parent and groups edges). The optional `ancestors` array carries the upward
+ * chain from `rootId` to the eventual root of the broader hierarchy — strict
+ * parent-only walk, useful when `rootId` is a leaf task and the caller wants
+ * to show context above it.
+ */
+export interface GenericTreeResult {
+  /** Flat, pre-order tree envelope rooted at the requested task. */
+  readonly tree: TreeResponse<GenericTreeMetadata>;
+  /**
+   * Ancestor chain from the rendered root upward through parent_id edges.
+   * Ordered nearest-first (immediate parent at index 0). Empty when the
+   * rendered root has no parent.
+   */
+  readonly ancestors: ReadonlyArray<FlatTreeNode<GenericTreeMetadata>>;
+}
+
+/**
+ * Options for {@link buildGenericTaskTree}.
+ */
+export interface BuildGenericTreeOptions {
+  /**
+   * Enrich each node with `blockerChain` and `leafBlockers` metadata.
+   * Equivalent to the `withBlockers` flag on the legacy `coreTaskTree`.
+   *
+   * @defaultValue false
+   */
+  readonly withBlockers?: boolean;
+}
+
+/**
+ * Map a CLEO {@link TaskStatus} to the typed {@link TreeNodeStatus}.
+ *
+ * `'active'` collapses to `'in_progress'` (renderer naming); `'proposed'`
+ * collapses to `'pending'` since the tree contract does not carry a
+ * proposed-only state.
+ */
+function toTreeStatus(status: TaskStatus): TreeNodeStatus {
+  switch (status) {
+    case 'active':
+      return 'in_progress';
+    case 'pending':
+    case 'proposed':
+      return 'pending';
+    case 'done':
+      return 'done';
+    case 'blocked':
+      return 'blocked';
+    case 'cancelled':
+      return 'cancelled';
+    case 'archived':
+      return 'archived';
+  }
+}
+
+/**
+ * Map a {@link Task} record to the typed {@link TreeNodeKind} discriminator.
+ *
+ * Sagas are stored as `type='epic'` rows that carry the `'saga'` label —
+ * those resolve to `'saga'`. Everything else maps 1:1 from `Task.type`,
+ * with `'task'` as the safe fallback when the type column is missing.
+ */
+function toTreeKind(task: Task): TreeNodeKind {
+  if (task.type === 'epic' && (task.labels ?? []).includes(SAGA_LABEL)) return 'saga';
+  if (task.type === 'epic') return 'epic';
+  if (task.type === 'subtask') return 'subtask';
+  return 'task';
+}
+
+/**
+ * Resolve members linked from `task` through `task_relations.type='groups'`
+ * edges. Preserves edge order and deduplicates by member ID.
+ */
+function resolveGroupsMembers(task: Task): string[] {
+  const seen = new Set<string>();
+  const memberIds: string[] = [];
+  for (const relation of task.relates ?? []) {
+    if (relation.type !== SAGA_GROUPS_RELATION) continue;
+    if (seen.has(relation.taskId)) continue;
+    seen.add(relation.taskId);
+    memberIds.push(relation.taskId);
+  }
+  return memberIds;
+}
+
+/**
+ * Build the typed tree envelope rooted at `rootId`, walking BOTH parent edges
+ * AND groups edges to full depth. Cycle-safe via a single visited set spanning
+ * both edge types.
+ *
+ * Children of a node are emitted in this stable order:
+ *   1. `parent_id` children (sorted by `position ASC` like the legacy walker)
+ *   2. `groups` members (in edge-insertion order)
+ *
+ * The two sets do not overlap in well-formed data because sagas hold members
+ * via `groups` edges instead of `parent_id`. If a future schema change allows
+ * overlap, the visited set guarantees each node is emitted exactly once and
+ * the first edge wins.
+ *
+ * Each emitted node carries {@link GenericTreeMetadata} so the renderer (and
+ * downstream `--withDeps`/`--blockers` annotations) has everything it needs
+ * without a second DB round-trip.
+ *
+ * @param projectRoot - Absolute project root used to resolve the data accessor.
+ * @param rootId      - Task ID to root the tree at. Required — the legacy
+ *                      "all roots" walk is intentionally not supported here
+ *                      because `cleo tree <id>` always takes a positional ID.
+ * @param opts        - Optional enrichment flags.
+ * @throws `Error` with `E_NOT_FOUND` semantics when `rootId` is unknown.
+ */
+export async function buildGenericTaskTree(
+  projectRoot: string,
+  rootId: string,
+  opts: BuildGenericTreeOptions = {},
+): Promise<GenericTreeResult> {
+  const accessor = await getTaskAccessor(projectRoot);
+  const { tasks: allTasks } = await accessor.queryTasks({});
+  const taskMap = new Map<string, Task>(allTasks.map((t) => [t.id, t]));
+
+  const rootTask = taskMap.get(rootId);
+  if (!rootTask) {
+    throw new Error(`Task '${rootId}' not found`);
+  }
+
+  // Precompute parent_id → ordered child list once so DFS lookups are O(1).
+  const childrenByParent = new Map<string, Task[]>();
+  for (const task of allTasks) {
+    if (task.parentId === null || task.parentId === undefined) continue;
+    const bucket = childrenByParent.get(task.parentId);
+    if (bucket) bucket.push(task);
+    else childrenByParent.set(task.parentId, [task]);
+  }
+  for (const bucket of childrenByParent.values()) {
+    bucket.sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+  }
+
+  // For blocker enrichment the helpers want the raw flat array — capture the
+  // reference once so the recursive walk doesn't re-materialise it per node.
+  const allTasksFlat = opts.withBlockers === true ? allTasks : undefined;
+
+  const flat: FlatTreeNode<GenericTreeMetadata>[] = [];
+  const visited = new Set<string>();
+
+  /**
+   * DFS walker — pushes one row per visited task into `flat`.
+   *
+   * @param task     - Task being emitted.
+   * @param depth    - Distance from the rendered root (root = 0).
+   * @param parentId - Edge target; `null` only for the root.
+   * @param edgeType - Edge that placed this task under `parentId`.
+   */
+  function emit(
+    task: Task,
+    depth: number,
+    parentId: string | null,
+    edgeType: GenericTreeEdgeType,
+  ): void {
+    if (visited.has(task.id)) return;
+    visited.add(task.id);
+
+    flat.push(buildFlatNode(task, depth, parentId, edgeType, taskMap, allTasksFlat));
+
+    // 1. parent_id children (sorted by position ASC).
+    const parentChildren = childrenByParent.get(task.id) ?? [];
+    for (const child of parentChildren) {
+      emit(child, depth + 1, task.id, 'parent');
+    }
+
+    // 2. groups members (saga membership edges).
+    const memberIds = resolveGroupsMembers(task);
+    for (const memberId of memberIds) {
+      const member = taskMap.get(memberId);
+      if (!member) continue; // dangling edge — skip silently
+      emit(member, depth + 1, task.id, 'groups');
+    }
+  }
+
+  emit(rootTask, 0, null, 'root');
+
+  // Ancestor chain — strict parent_id walk upward from the rendered root.
+  // Cycle-safe via the existing `visited` set so we never re-emit a node.
+  const ancestorChain: FlatTreeNode<GenericTreeMetadata>[] = [];
+  let cursor: Task | undefined = rootTask;
+  // Use a parallel set so an unrelated ancestor doesn't get blocked by a
+  // duplicate ID inside the downstream tree.
+  const ancestorSeen = new Set<string>([rootTask.id]);
+  while (cursor && cursor.parentId !== null && cursor.parentId !== undefined) {
+    const parent = taskMap.get(cursor.parentId);
+    if (!parent) break;
+    if (ancestorSeen.has(parent.id)) break;
+    ancestorSeen.add(parent.id);
+    ancestorChain.push(
+      buildFlatNode(parent, ancestorChain.length, null, 'parent', taskMap, allTasksFlat),
+    );
+    cursor = parent;
+  }
+
+  let maxDepth = 0;
+  for (const row of flat) {
+    if (row.depth > maxDepth) maxDepth = row.depth;
+  }
+
+  const tree: TreeResponse<GenericTreeMetadata> = {
+    tree: flat,
+    root: rootId,
+    totalNodes: flat.length,
+    maxDepth,
+  };
+
+  return { tree, ancestors: ancestorChain };
+}
+
+/**
+ * Build one {@link FlatTreeNode} row with full metadata.
+ */
+function buildFlatNode(
+  task: Task,
+  depth: number,
+  parentId: string | null,
+  edgeType: GenericTreeEdgeType,
+  taskMap: ReadonlyMap<string, Task>,
+  allTasksFlat: ReadonlyArray<Task> | undefined,
+): FlatTreeNode<GenericTreeMetadata> {
+  const depends = task.depends ?? [];
+  const blockedBy = depends.filter((depId) => {
+    const dep = taskMap.get(depId);
+    if (!dep) return false;
+    return dep.status !== 'done' && dep.status !== 'cancelled';
+  });
+  const ready = blockedBy.length === 0 && (task.status === 'pending' || task.status === 'active');
+
+  const blockerChain = allTasksFlat ? getTransitiveBlockers(task.id, [...allTasksFlat]) : undefined;
+  const leafBlockers = allTasksFlat ? getLeafBlockers(task.id, [...allTasksFlat]) : undefined;
+
+  const metadata: GenericTreeMetadata = {
+    edgeType,
+    priority: task.priority,
+    depends,
+    blockedBy,
+    ready,
+    ...(blockerChain !== undefined ? { blockerChain } : {}),
+    ...(leafBlockers !== undefined ? { leafBlockers } : {}),
+  };
+
+  return {
+    id: task.id,
+    parentId,
+    depth,
+    kind: toTreeKind(task),
+    status: toTreeStatus(task.status),
+    title: task.title,
+    metadata,
+  };
+}


### PR DESCRIPTION
## Summary
- `cleo tree <id>` now walks BOTH `parent_id` AND `task_relations.relation_type='groups'` edges, recursively to full depth.
- `cleo tree T9855` shows all 12 saga members + their subtree (109 nodes, depth 4) — not just 2 parent-edge children.
- Ancestor chain UPWARD from root for context (`cleo tree T10158` shows `T10157` in the chain).
- `KindIcon` prefix (🌲/📋/•/◦) per node.
- `RelationIcon.GROUPS` (⊂) prefix for saga-membership edges.
- Derives from typed `TreeResponse<T>` contract; uses `renderTree` primitive from `@cleocode/animations/render`.
- Removes `--root`/`--depth`/`--kinds` flags. Preserves `--withDeps`/`--blockers`.

## Test plan
- [x] `pnpm biome check --write .` — clean
- [x] `pnpm --filter @cleocode/core run build` — clean
- [x] `pnpm --filter @cleocode/cleo run build` — clean
- [x] `pnpm --filter @cleocode/core run typecheck` — clean
- [x] `pnpm --filter @cleocode/cleo run typecheck` — clean
- [x] New unit tests: 7 passing in `packages/core/src/tasks/__tests__/generic-tree.test.ts`
- [x] New snapshot tests: 4 passing in `packages/cleo/src/cli/renderers/__tests__/generic-tree.test.ts`
- [x] Existing animations tests: 47 passing (fold-summary message updated to drop obsolete `--depth +1` reference)
- [x] All 190 cleo renderer tests passing
- [x] Smoke against real `tasks.db`: `cleo tree T9855` JSON envelope returns 109 nodes, 12 saga members under root with `edgeType='groups'`, max depth 4. Warm helper runtime: 161ms (under the 200ms AC11 target).
- [x] Architectural baseline (`scripts/lint-no-raw-define-command.mjs --check`): no regression (138 ≤ 139 baseline)

## Refs
Closes T10134
Epic: T10114 (E11-HUMAN-RENDER-CONTRACT)
ADR: adr-077-human-render-contract