### PR TITLE
fix(T10352): cleo tree --human emits canonical tree in non-TTY (Epic T10114 dogfood gap)

### DIFF
--- a/.changeset/t10352-tree-human-render.md
+++ b/.changeset/t10352-tree-human-render.md
@@ -1,0 +1,19 @@
+---
+id: t10352-tree-human-render
+tasks: [T10352]
+kind: fix
+summary: "cleo tree --human emits canonical box-drawn tree in non-TTY (was empty)"
+---
+
+`cleo tree <id> --human` rendered to empty string when stdout was a pipe,
+redirect, or CI log because the renderer gated through `AnimateContext`,
+which silences when `isTTY === false`. That gate is correct for animation
+primitives (spinners must not flicker in pipes) but wrong for static tree
+rendering — the user explicitly asked for `--human` output.
+
+`resolveAnimateContext()` now force-sets `isTTY: true` and `noColor: false`
+when format is human so the static render path always emits. The ASCII
+box-drawing fallback is preserved by reading `process.env.NO_COLOR`
+directly inside `renderGenericTree`, and only for the resolved (non-explicit)
+context path — explicit `ctx` callers (tests, programmatic usage) honour
+`ctx.inputs.noColor` exclusively. Closes the Epic T10114 dogfood gap.

--- a/packages/cleo/src/cli/renderers/__tests__/generic-tree.test.ts
+++ b/packages/cleo/src/cli/renderers/__tests__/generic-tree.test.ts
@@ -15,7 +15,8 @@
 import { createAnimateContext } from '@cleocode/animations';
 import type { FlatTreeNode, TreeResponse } from '@cleocode/contracts';
 import type { GenericTreeMetadata, GenericTreeResult } from '@cleocode/core/internal';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { setFormatContext } from '../../format-context.js';
 import { renderGenericTree } from '../generic-tree.js';
 
 /**
@@ -222,5 +223,62 @@ describe('renderGenericTree (T10134)', () => {
     expect(lines[1]).toBe('E-MEM-01');
     expect(lines[2]).toBe('T-CHILD-01');
     expect(lines).toHaveLength(15);
+  });
+
+  describe('T10352 — non-TTY --human regression', () => {
+    const originalNoColor = process.env['NO_COLOR'];
+
+    beforeEach(() => {
+      delete process.env['NO_COLOR'];
+      setFormatContext({ format: 'human', source: 'flag', quiet: false });
+    });
+
+    afterEach(() => {
+      if (originalNoColor === undefined) {
+        delete process.env['NO_COLOR'];
+      } else {
+        process.env['NO_COLOR'] = originalNoColor;
+      }
+      setFormatContext({ format: 'json', source: 'default', quiet: false });
+    });
+
+    it('renders non-empty output for format=human even when stdout is not a TTY', () => {
+      // No `ctx` override — the renderer resolves the context from
+      // getFormatContext(), exercising the production path that was broken
+      // (animation gate silenced static render in non-TTY).
+      const out = renderGenericTree(sagaFixture(), {
+        withDeps: false,
+        withBlockers: false,
+        quiet: false,
+      });
+      expect(out.length).toBeGreaterThan(0);
+      // Saga root MUST appear in the rendered body.
+      expect(out).toContain('SG-TEMPLATE-CONFIG-SSOT');
+    });
+
+    it('returns empty string when format is json', () => {
+      setFormatContext({ format: 'json', source: 'flag', quiet: false });
+      const out = renderGenericTree(sagaFixture(), {
+        withDeps: false,
+        withBlockers: false,
+        quiet: false,
+      });
+      expect(out).toBe('');
+    });
+
+    it('falls back to ASCII glyphs when NO_COLOR is set but still renders', () => {
+      process.env['NO_COLOR'] = '1';
+      const out = renderGenericTree(sagaFixture(), {
+        withDeps: false,
+        withBlockers: false,
+        quiet: false,
+      });
+      expect(out.length).toBeGreaterThan(0);
+      expect(out).toContain('SG-TEMPLATE-CONFIG-SSOT');
+      // ASCII tree connectors per @cleocode/animations CONNECTOR_ASCII —
+      // NOT the Unicode `├─` / `└─` / `│  ` box-drawing forms.
+      expect(out).toContain('+- ');
+      expect(out).not.toContain('├─');
+    });
   });
 });

--- a/packages/cleo/src/cli/renderers/generic-tree.ts
+++ b/packages/cleo/src/cli/renderers/generic-tree.ts
@@ -64,12 +64,23 @@ export function renderGenericTree(
   result: GenericTreeResult,
   opts: RenderGenericTreeOptions,
 ): string {
+  const explicitCtx = opts.ctx !== undefined;
   const ctx = opts.ctx ?? resolveAnimateContext();
   if (!ctx.enabled) return '';
 
   if (opts.quiet) return renderQuiet(result);
 
-  const useAscii = ctx.inputs.noColor;
+  // ASCII fallback decision:
+  //  - Explicit-ctx callers (tests, programmatic usage) decide via
+  //    `ctx.inputs.noColor` — `NO_COLOR=1` in CI must not override an
+  //    opt-in Unicode render.
+  //  - Production callers resolve via {@link resolveAnimateContext}, which
+  //    force-sets `noColor=false` so the gate stays enabled in non-TTY
+  //    `--human` runs (T10352). For these, fall back to ASCII when
+  //    `NO_COLOR` is set in the environment.
+  const useAscii = explicitCtx
+    ? ctx.inputs.noColor
+    : ctx.inputs.noColor || process.env['NO_COLOR'] != null;
   const lines: string[] = [];
 
   // Ancestor banner — strict parent_id chain UPWARD from the rendered root.
@@ -79,9 +90,12 @@ export function renderGenericTree(
   }
 
   // Tree body — transform titles so groups-edge nodes carry the `⊂` prefix
-  // before delegating to the canonical box-drawing primitive.
+  // before delegating to the canonical box-drawing primitive. Forward
+  // `asciiBoxDrawing` explicitly so the connector glyphs match the ancestor
+  // banner — `renderTree` otherwise derives ASCII purely from
+  // `ctx.inputs.noColor`, which T10352's force-enabled context zeroes out.
   const treeWithGlyphs = decorateGroupsEdges(result.tree, useAscii);
-  const body = renderTree(treeWithGlyphs, { ctx });
+  const body = renderTree(treeWithGlyphs, { ctx, asciiBoxDrawing: useAscii });
   if (body) lines.push(body);
 
   // Optional annotations beneath each node.
@@ -187,7 +201,25 @@ function kindIconOf(kind: FlatTreeNode<GenericTreeMetadata>['kind']): KindIcon {
  * Mirrors `animation-bridge.ts` — `getFormatContext()` always returns a
  * sensible default (JSON, no quiet) when the preAction hook has not run, so
  * tests and direct callers inherit a silent context without extra branching.
+ *
+ * T10352: when format is human, force `isTTY=true` + `noColor=false` so the
+ * static render path is not silenced in non-TTY contexts (pipes, redirects,
+ * CI logs). The TTY / NO_COLOR gates in {@link createAnimateContext} are
+ * correct for animation primitives — spinners must not flicker in pipes —
+ * but a static tree render explicitly requested via `--human` should always
+ * emit. Forcing `noColor=false` keeps the gate enabled; the
+ * NO_COLOR-aware ASCII fallback inside {@link renderGenericTree} reads
+ * `process.env.NO_COLOR` directly so the box-drawing degrades to ASCII
+ * without going silent.
  */
 function resolveAnimateContext(): AnimateContext {
-  return createAnimateContext({ flagResolution: getFormatContext() });
+  const fmt = getFormatContext();
+  if (fmt.format !== 'human') {
+    return createAnimateContext({ flagResolution: fmt });
+  }
+  return createAnimateContext({
+    flagResolution: fmt,
+    isTTY: true,
+    noColor: false,
+  });
 }


### PR DESCRIPTION
## Summary
- `cleo tree <id> --human` rendered empty in non-TTY contexts (pipes, redirects, CI logs).
- Root cause: `renderGenericTree` gated through `AnimateContext`, which returns `enabled=false` when `isTTY=false`. That gate is correct for animation primitives (spinners must not flicker in pipes), wrong for static tree render.
- Fix: in `resolveAnimateContext()`, when format is human, force `isTTY=true` and `noColor=false`. ASCII fallback decision now reads `process.env.NO_COLOR` directly for production (resolved-ctx) callers; explicit-ctx callers (tests) still honour `ctx.inputs.noColor` so `NO_COLOR=1` in CI cannot override an opt-in Unicode render.

## Dogfood verification (local, in worktree)
- `cleo tree T9855 --human` now produces 103 lines of canonical 🌲 saga-tree.
- `NO_COLOR=1 cleo tree T9855 --human` falls back to ASCII `+- ` / `|  ` connectors (still emits).
- `cleo tree T9855 --json` still returns the JSON envelope (renderer returns '' for json path).

## Test plan
- [x] `pnpm biome check --write packages/cleo/src/cli/renderers/generic-tree.ts packages/cleo/src/cli/renderers/__tests__/generic-tree.test.ts`
- [x] `pnpm --filter @cleocode/cleo run build`
- [x] Regression tests added in \`__tests__/generic-tree.test.ts\` — 3 new tests asserting non-empty output for \`format=human + isTTY=false\`, empty for \`format=json\`, and ASCII fallback when \`NO_COLOR\` set. All 7 tests pass locally.

## Refs
Closes T10352
Epic: T10114 (E11-HUMAN-RENDER-CONTRACT dogfood gap)
ADR: adr-077-human-render-contract