### PR TITLE
T10304: cleo backup recover brain CLI verb + operator runbook (Saga T10281)

### DIFF
--- a/.changeset/T10304.md
+++ b/.changeset/T10304.md
@@ -1,0 +1,8 @@
+---
+id: T10304
+tasks: [T10304]
+kind: feat
+summary: cleo backup recover brain CLI verb + operator runbook (Saga T10281 SG-BRAIN-DB-RESILIENCE)
+---
+
+Adds `cleo backup recover brain` — operator-facing verb that wraps T10303's `recoverMalformedBrainDb` pipeline. Supports `--dry-run` (preview plan envelope without mutation), `--from-snapshot <iso|path>` (pin a specific snapshot when auto-pick is poisoned), `--no-delta` (reserved for delta-merge opt-out), `--force` (reserved). Emits LAFS-style envelope with `restoredFrom` + per-table `rowsRecovered.{observations,decisions,learnings}` + `dataLossWindowHours` + `integrityOK` + `quarantinedTo`. Companion runbook published as docs note `brain-recovery-runbook` describing when to invoke, pre-conditions, manual fallback, and data-loss expectations. Saga: T10281; Epic: T10286.

--- a/docs/note/brain-recovery-runbook.md
+++ b/docs/note/brain-recovery-runbook.md
@@ -1,0 +1,194 @@
+---
+slug: brain-recovery-runbook
+type: note
+task: T10304
+epic: T10286
+saga: T10281
+description: "Operator runbook: brain.db recovery procedure"
+---
+
+# Brain.db Recovery Runbook
+
+**Task**: T10304
+**Epic**: T10286 E5-BRAIN-P0-HOTFIX
+**Saga**: T10281 SG-BRAIN-DB-RESILIENCE
+**Verb**: `cleo backup recover brain`
+**Producer task**: T10303 (pipeline wired into `getBrainDb()` chokepoint)
+
+## When this verb is needed
+
+Run `cleo backup recover brain` when ANY of these signals appear:
+
+- `cleo memory observe ...` returns `E_BRAIN_OBSERVE` with the cause chain
+  containing `ERR_SQLITE_ERROR errcode=11`.
+- `sqlite3 .cleo/brain.db 'PRAGMA integrity_check;'` returns
+  `malformed database schema (...) (11)` or anything other than `ok`.
+- `sqlite3 .cleo/brain.db 'PRAGMA quick_check;'` returns a row with a value
+  other than `ok`.
+- Agent sessions silently fail to persist learnings/decisions/observations
+  while every other CLEO command works fine.
+- `cleo doctor` flags brain.db with `E_DB_MALFORMED` (T10282 follow-up).
+
+The brain.db open chokepoint (`packages/core/src/store/memory-sqlite.ts:getBrainDb`)
+already auto-recovers on the next open via the same pipeline. This verb
+exists for two scenarios the chokepoint does NOT cover:
+
+1. **Pre-emptive recovery** before the next session-start so the next agent
+   doesn't lose its memory writes between detection and the next open.
+2. **Pinned restore** via `--from-snapshot <iso>` when the auto-recovery
+   picked a snapshot that is also poisoned.
+
+## Pre-conditions
+
+The recovery pipeline tries three candidate sources in order. At least ONE
+must be present:
+
+| Source              | Path                                                                                                  | Created by                          |
+|---------------------|-------------------------------------------------------------------------------------------------------|-------------------------------------|
+| System snapshot     | `.cleo/backups/snapshot/brain.db.snapshot-<ISO>`                                                      | `cleo backup add`                   |
+| VACUUM INTO         | `.cleo/backups/sqlite/brain-YYYYMMDD-HHmmss.db`                                                       | `cleo session end` (debounced hook) |
+| PRE-DUP-FIX legacy  | `.cleo/brain.db.PRE-DUP-FIX-<n>`                                                                      | T9685 one-shot migration            |
+
+Verify pre-conditions:
+
+```bash
+ls -lt .cleo/backups/snapshot/brain.db.snapshot-* 2>/dev/null | head -5
+ls -lt .cleo/backups/sqlite/brain-*.db 2>/dev/null | head -5
+ls -lt .cleo/brain.db.PRE-DUP-FIX-* 2>/dev/null | head -5
+```
+
+If all three return empty, the verb will exit with `E_NO_SNAPSHOT` (4) and
+you must follow the manual fallback below.
+
+## Usage
+
+### Step 1: Preview with `--dry-run`
+
+```bash
+cleo backup recover brain --dry-run
+```
+
+The plan envelope shows:
+
+- `restoredFrom` — absolute path of the snapshot that would be restored.
+- `dataLossWindowHours` — approximate hours between snapshot and now.
+- `rowsRecovered.observations` / `decisions` / `learnings` — counts probed
+  from the snapshot.
+- `integrityOK: true` — the chosen snapshot passes `PRAGMA quick_check`.
+- `quarantinedTo: ""` — empty in dry-run mode (no files touched).
+- `dryRun: true` — confirms this was a plan, NOT a mutation record.
+
+If `dataLossWindowHours` is too high (e.g. > 24h) and you have an older
+snapshot you trust, pin it with `--from-snapshot`.
+
+### Step 2: Execute recovery
+
+```bash
+cleo backup recover brain
+```
+
+On success the envelope shows:
+
+- `restoredFrom` — the snapshot that was actually restored.
+- `quarantinedTo` — absolute path to the directory where the corrupt DB
+  plus its `-wal` / `-shm` sidecars were moved.
+- `integrityOK: true` — restored DB passes `PRAGMA quick_check`.
+- `dryRun: false`.
+
+### Step 3: Verify
+
+```bash
+sqlite3 .cleo/brain.db 'PRAGMA integrity_check; SELECT COUNT(*) FROM brain_observations;'
+cleo memory find "<recent topic>"
+```
+
+### Optional flags
+
+| Flag                       | Purpose                                                                                                     |
+|----------------------------|-------------------------------------------------------------------------------------------------------------|
+| `--dry-run`                | Print plan envelope without quarantining or copying. Default `false`.                                       |
+| `--from-snapshot <pin>`    | Pin recovery to a specific snapshot — accepts an absolute path OR an ISO timestamp prefix (`2026-05-23`).   |
+| `--no-delta`               | Skip the `sqlite3 .recover` delta-merge step. Default `false`. NOTE: the current pipeline does not perform delta-merge because T10300 found schema-page corruption makes it unreliable. The flag is plumbed end-to-end for forward-compat when delta-merge becomes opt-in. |
+| `--force`                  | Bypass safety prompts. Reserved — currently a no-op.                                                        |
+
+## Exit codes
+
+| Code | Name                 | Meaning                                                                                       |
+|------|----------------------|-----------------------------------------------------------------------------------------------|
+| 0    | SUCCESS              | Snapshot restored OR dry-run plan emitted.                                                    |
+| 1    | E_RECOVERY_FAILED    | Pipeline ran but restored DB failed final integrity check, or unexpected runtime error.       |
+| 4    | E_NO_SNAPSHOT        | No snapshots present in any of the three candidate sources.                                   |
+| 4    | E_NO_SNAPSHOT_MATCH  | `--from-snapshot <pin>` did not match any candidate.                                          |
+| 6    | E_VALIDATION         | Missing required arg (`corruptPath` empty). Programmer error — file a bug.                    |
+| 78   | E_NO_VALID_SNAPSHOT  | Every available snapshot is itself corrupt — none pass `PRAGMA quick_check`.                  |
+
+## Data-loss expectations
+
+The recovery pipeline restores the freshest validated snapshot, so memory
+writes that occurred between the snapshot's timestamp and the malformation
+event are LOST. The envelope's `dataLossWindowHours` quantifies this for
+the operator. There is no rollback.
+
+- System snapshots are written manually via `cleo backup add` (rare).
+- VACUUM INTO snapshots are written on `cleo session end` debounced hooks
+  (every session end, rotated to 10 retained per DB). These are typically
+  the freshest source and the one most often chosen.
+- PRE-DUP-FIX artifacts are last-resort legacy snapshots and may be days
+  or weeks old.
+
+To minimize data-loss windows in the future:
+
+```bash
+# Run this any time before a high-risk operation:
+cleo backup add
+```
+
+## Manual fallback (when the verb fails)
+
+If `cleo backup recover brain` exits with `E_NO_VALID_SNAPSHOT` or
+`E_RECOVERY_FAILED`, follow the manual procedure executed in Saga T10281
+Wave 0 AC1:
+
+```bash
+# 1. Move the corrupt DB out of the way.
+mkdir -p .cleo/quarantine/brain-malformed-$(date -u +%Y%m%dT%H%M%SZ)
+mv .cleo/brain.db .cleo/quarantine/brain-malformed-*/brain.db.malformed
+mv .cleo/brain.db-wal .cleo/quarantine/brain-malformed-*/brain.db-wal 2>/dev/null
+mv .cleo/brain.db-shm .cleo/quarantine/brain-malformed-*/brain.db-shm 2>/dev/null
+
+# 2. List candidate snapshots, sorted newest-first.
+ls -1t .cleo/backups/snapshot/brain.db.snapshot-* \
+       .cleo/backups/sqlite/brain-*.db \
+       .cleo/brain.db.PRE-DUP-FIX-* 2>/dev/null
+
+# 3. Probe each candidate manually for integrity.
+for f in $(ls -1t .cleo/backups/snapshot/brain.db.snapshot-* 2>/dev/null); do
+  echo "=== $f ==="
+  sqlite3 "$f" 'PRAGMA quick_check;'
+done
+
+# 4. Copy the freshest `ok` candidate into place.
+cp .cleo/backups/snapshot/brain.db.snapshot-<chosen-iso> .cleo/brain.db
+
+# 5. Final verification.
+sqlite3 .cleo/brain.db 'PRAGMA integrity_check;'
+
+# 6. Re-attempt the failed operation.
+cleo memory observe "post-recovery smoke test" --title "T10304 manual recovery"
+```
+
+If NO snapshot probes clean, escalate to the owner — the corruption pre-dates
+all available snapshots and the BRAIN must be restored from external backup
+(`cleo backup import <bundle>`).
+
+## Related
+
+- T10303 (sister task) — wires the pipeline into the brain.db open
+  chokepoint for automatic detection + recovery.
+- T10282 (sibling Epic E1-DB-INVENTORY) — adds `cleo doctor` checks for
+  `PRAGMA integrity_check` failures on every CLEO DB.
+- T10284 (sibling Epic E3-BACKUP-RECOVERY) — broader backup/recovery
+  hardening across all CLEO DBs.
+- ADR-068 (DB Open Guard) — every recovery probe flows through
+  `openNativeDatabase()` so pragma SSoT (`specs/sqlite-pragmas.json`) stays
+  in force.

--- a/packages/cleo/src/cli/commands/__tests__/backup-recover.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/backup-recover.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Unit tests for T10304: cleo backup recover brain
+ *
+ * Verifies the `backup recover brain` subcommand action handler:
+ *   - --dry-run returns a plan envelope with dryRun=true and no mutation
+ *   - happy-path returns structured envelope with all expected fields
+ *   - missing-snapshot error path (E_NO_SNAPSHOT) returns clear error
+ *   - --from-snapshot pin is plumbed through to the core helper
+ *   - generic errors are surfaced via cliError with non-zero exit code
+ *
+ * The core `runBackupRecoverBrain` helper is mocked so this test exercises
+ * ONLY the CLI command's wiring (arg parsing, envelope shape, exit codes).
+ * Pattern mirrors backup-export.test.ts.
+ *
+ * @task T10304
+ * @epic T10286
+ * @saga T10281
+ */
+
+import type { BackupRecoverBrainResult, BrainRecoveredRowCounts } from '@cleocode/contracts';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { backupCommand } from '../backup.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — keep all real SQLite, file I/O, and dispatch off the table
+// ---------------------------------------------------------------------------
+
+const mockRunBackupRecoverBrain = vi.fn();
+
+vi.mock('@cleocode/core/store/backup-recover-brain.js', () => {
+  // Defined INSIDE the factory so the hoisted vi.mock body does not reach
+  // a TDZ variable declared after it in the test file (T10304).
+  class BackupRecoverBrainErrorMock extends Error {
+    constructor(
+      message: string,
+      public readonly code: number,
+      public readonly codeName: string,
+      public readonly fix?: string,
+    ) {
+      super(message);
+      this.name = 'BackupRecoverBrainError';
+    }
+  }
+  return {
+    runBackupRecoverBrain: (...args: unknown[]) => mockRunBackupRecoverBrain(...args),
+    BackupRecoverBrainError: BackupRecoverBrainErrorMock,
+  };
+});
+
+/**
+ * Constructor signature for the mocked `BackupRecoverBrainError` class.
+ *
+ * The test body needs the SAME class reference the production code sees
+ * via `instanceof BackupRecoverBrainError` so thrown errors are routed
+ * through the mapped-error branch (exit code 4 / 78) rather than the
+ * generic catch (exit code 1). Populated by `beforeAll` below.
+ */
+type MockBackupRecoverBrainErrorCtor = new (
+  message: string,
+  code: number,
+  codeName: string,
+  fix?: string,
+) => Error;
+
+let MockBackupRecoverBrainError: MockBackupRecoverBrainErrorCtor;
+
+beforeAll(async () => {
+  const mod: { BackupRecoverBrainError: MockBackupRecoverBrainErrorCtor } = await import(
+    '@cleocode/core/store/backup-recover-brain.js'
+  );
+  MockBackupRecoverBrainError = mod.BackupRecoverBrainError;
+});
+
+const mockGetProjectRoot = vi.fn(() => '/tmp/test-project');
+const mockGetCleoDirAbsolute = vi.fn(() => '/tmp/test-project/.cleo');
+const mockGetLogger = vi.fn(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('@cleocode/core', async () => {
+  // Pull through the real exit codes etc. but stub out path resolvers + logger.
+  const actual = await vi.importActual<Record<string, unknown>>('@cleocode/core');
+  return {
+    ...actual,
+    getProjectRoot: () => mockGetProjectRoot(),
+    getCleoDirAbsolute: (cwd?: string) => mockGetCleoDirAbsolute(cwd),
+    getLogger: (channel: string) => mockGetLogger(channel),
+  };
+});
+
+// Stub the dispatch adapter — backup.ts pulls it in for the parent group's
+// default `run` action even though we never exercise that path here.
+vi.mock('../../../dispatch/adapters/cli.js', () => ({
+  dispatchFromCli: vi.fn().mockResolvedValue(undefined),
+  dispatchRaw: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Helper — invoke the leaf subcommand's run handler
+// ---------------------------------------------------------------------------
+
+interface RecoverArgs {
+  'dry-run'?: boolean;
+  'from-snapshot'?: string;
+  'no-delta'?: boolean;
+  force?: boolean;
+}
+
+interface CittyLeaf {
+  run: (ctx: { args: RecoverArgs; rawArgs: string[] }) => Promise<void>;
+}
+
+/**
+ * Reach into `backupCommand.subCommands.recover.subCommands.brain.run` and
+ * invoke it with the supplied flags merged onto defaults.
+ */
+async function runRecoverBrain(args: RecoverArgs): Promise<void> {
+  const recoverGroup = backupCommand.subCommands?.['recover'];
+  if (!recoverGroup || typeof recoverGroup !== 'object' || !('subCommands' in recoverGroup)) {
+    throw new Error('backup recover group subcommand not found');
+  }
+  const subCommands = (recoverGroup as { subCommands?: Record<string, unknown> }).subCommands;
+  const brainCmd = subCommands?.['brain'];
+  if (!brainCmd || typeof brainCmd !== 'object' || !('run' in brainCmd)) {
+    throw new Error('backup recover brain subcommand not found');
+  }
+  const merged: RecoverArgs = {
+    'dry-run': false,
+    'from-snapshot': '',
+    'no-delta': false,
+    force: false,
+    ...args,
+  };
+  await (brainCmd as CittyLeaf).run({ args: merged, rawArgs: [] });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ZERO_COUNTS: BrainRecoveredRowCounts = {
+  observations: 0,
+  decisions: 0,
+  learnings: 0,
+};
+
+const HAPPY_RESULT: BackupRecoverBrainResult = {
+  restoredFrom:
+    '/tmp/test-project/.cleo/backups/snapshot/brain.db.snapshot-2026-05-23T08-00-55-563Z',
+  rowsRecovered: { observations: 142, decisions: 8, learnings: 17 },
+  dataLossWindowHours: 5.2,
+  integrityOK: true,
+  quarantinedTo: '/tmp/test-project/.cleo/quarantine/brain-malformed-2026-05-23T13-12-00-000Z',
+  dryRun: false,
+};
+
+const DRY_RUN_PLAN: BackupRecoverBrainResult = {
+  ...HAPPY_RESULT,
+  quarantinedTo: '',
+  dryRun: true,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('T10304 cleo backup recover brain — dry-run mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it('returns a plan envelope with dryRun=true without mutating state', async () => {
+    mockRunBackupRecoverBrain.mockReturnValue(DRY_RUN_PLAN);
+
+    await runRecoverBrain({ 'dry-run': true });
+
+    expect(mockRunBackupRecoverBrain).toHaveBeenCalledOnce();
+    const call = mockRunBackupRecoverBrain.mock.calls[0]?.[0];
+    expect(call).toMatchObject({
+      corruptPath: '/tmp/test-project/.cleo/brain.db',
+      snapshotDir: '/tmp/test-project/.cleo/backups/snapshot',
+      vacuumSnapshotDir: '/tmp/test-project/.cleo/backups/sqlite',
+      legacyArtifactDir: '/tmp/test-project/.cleo',
+      quarantineRoot: '/tmp/test-project/.cleo/quarantine',
+      dryRun: true,
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('plumbs --from-snapshot through to the core helper', async () => {
+    mockRunBackupRecoverBrain.mockReturnValue(DRY_RUN_PLAN);
+
+    await runRecoverBrain({
+      'dry-run': true,
+      'from-snapshot': '2026-05-22',
+    });
+
+    const call = mockRunBackupRecoverBrain.mock.calls[0]?.[0];
+    expect(call?.fromSnapshot).toBe('2026-05-22');
+  });
+
+  it('plumbs --no-delta through to the core helper', async () => {
+    mockRunBackupRecoverBrain.mockReturnValue(DRY_RUN_PLAN);
+
+    await runRecoverBrain({ 'dry-run': true, 'no-delta': true });
+
+    const call = mockRunBackupRecoverBrain.mock.calls[0]?.[0];
+    expect(call?.noDelta).toBe(true);
+  });
+});
+
+describe('T10304 cleo backup recover brain — happy path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it('returns structured envelope with all expected fields on success', async () => {
+    mockRunBackupRecoverBrain.mockReturnValue(HAPPY_RESULT);
+
+    await runRecoverBrain({});
+
+    expect(mockRunBackupRecoverBrain).toHaveBeenCalledOnce();
+    const call = mockRunBackupRecoverBrain.mock.calls[0]?.[0];
+    expect(call?.dryRun).toBe(false);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('passes corruptPath, snapshotDir, vacuumSnapshotDir, legacyArtifactDir, quarantineRoot', async () => {
+    mockRunBackupRecoverBrain.mockReturnValue(HAPPY_RESULT);
+
+    await runRecoverBrain({});
+
+    const call = mockRunBackupRecoverBrain.mock.calls[0]?.[0];
+    expect(call).toMatchObject({
+      corruptPath: '/tmp/test-project/.cleo/brain.db',
+      snapshotDir: '/tmp/test-project/.cleo/backups/snapshot',
+      vacuumSnapshotDir: '/tmp/test-project/.cleo/backups/sqlite',
+      legacyArtifactDir: '/tmp/test-project/.cleo',
+      quarantineRoot: '/tmp/test-project/.cleo/quarantine',
+    });
+  });
+});
+
+describe('T10304 cleo backup recover brain — error paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it('surfaces E_NO_SNAPSHOT with exit code 4 when no snapshots present', async () => {
+    mockRunBackupRecoverBrain.mockImplementation(() => {
+      throw new MockBackupRecoverBrainError(
+        'No snapshots found under /tmp/test-project/.cleo/backups/snapshot',
+        4,
+        'E_NO_SNAPSHOT',
+        'Run `cleo backup add` to create a snapshot before attempting recovery.',
+      );
+    });
+
+    await runRecoverBrain({});
+
+    expect(process.exitCode).toBe(4);
+  });
+
+  it('surfaces E_NO_SNAPSHOT_MATCH with exit code 4 when --from-snapshot pin matches zero candidates', async () => {
+    mockRunBackupRecoverBrain.mockImplementation(() => {
+      throw new MockBackupRecoverBrainError(
+        'Snapshot pin "1970-01-01" matched zero candidates',
+        4,
+        'E_NO_SNAPSHOT_MATCH',
+      );
+    });
+
+    await runRecoverBrain({ 'from-snapshot': '1970-01-01' });
+
+    expect(process.exitCode).toBe(4);
+  });
+
+  it('surfaces generic errors with exit code 1', async () => {
+    mockRunBackupRecoverBrain.mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    await runRecoverBrain({});
+
+    // GENERAL_ERROR = 1
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('returns zero-counts envelope when restoration produced empty tables', async () => {
+    mockRunBackupRecoverBrain.mockReturnValue({
+      ...HAPPY_RESULT,
+      rowsRecovered: ZERO_COUNTS,
+    });
+
+    await runRecoverBrain({});
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/packages/cleo/src/cli/commands/backup-recover.ts
+++ b/packages/cleo/src/cli/commands/backup-recover.ts
@@ -1,0 +1,204 @@
+/**
+ * `cleo backup recover brain` — operator-facing brain.db recovery verb.
+ *
+ * Wraps {@link runBackupRecoverBrain} from `@cleocode/core/store/backup-recover-brain.js`
+ * (T10304 internal helper that itself delegates to {@link recoverMalformedBrainDb}
+ * from T10303) and exposes the recovery pipeline as a discoverable CLI surface.
+ *
+ * The chokepoint helper auto-recovers on the next `getBrainDb()` open, so this
+ * verb exists for two scenarios the chokepoint does NOT cover:
+ *
+ *  1. **Pre-emptive recovery** — operator sees `ERR_SQLITE_ERROR errcode=11` in
+ *     logs and wants to recover *before* the next session-start so the next
+ *     agent doesn't lose its memory writes.
+ *  2. **Pinned restore** — auto-recovery picked the freshest snapshot but the
+ *     operator knows that one is poisoned too; `--from-snapshot <iso>` lets
+ *     them pin an older one.
+ *
+ * @task T10304
+ * @epic T10286
+ * @saga T10281
+ */
+
+import { join } from 'node:path';
+import { ExitCode } from '@cleocode/contracts';
+import { getCleoDirAbsolute, getLogger, getProjectRoot } from '@cleocode/core';
+import {
+  BackupRecoverBrainError,
+  runBackupRecoverBrain,
+} from '@cleocode/core/store/backup-recover-brain.js';
+import { defineCommand } from '../lib/define-cli-command.js';
+import { cliError, cliOutput, humanInfo } from '../renderers/index.js';
+
+// ---------------------------------------------------------------------------
+// `cleo backup recover brain` — terminal subcommand
+// ---------------------------------------------------------------------------
+
+/**
+ * Args accepted by `cleo backup recover brain`. Citty's parsed-args object
+ * is a `Record<string, unknown>` at the type level — these narrowing helpers
+ * extract each flag with the correct primitive shape.
+ */
+function readBoolFlag(args: Record<string, unknown>, key: string): boolean {
+  return args[key] === true;
+}
+
+function readStringFlag(args: Record<string, unknown>, key: string): string {
+  const v = args[key];
+  return typeof v === 'string' ? v : '';
+}
+
+/**
+ * `cleo backup recover brain` — recover a malformed brain.db from snapshot.
+ *
+ * Internal export (not `*Command` suffix) — registered as a leaf subcommand
+ * inside {@link backupRecoverSubCommand}'s `subCommands`. The
+ * `*SubCommand` suffix would be picked up by the command-manifest generator,
+ * which would then flag a collision against the top-level `brainCommand`
+ * (`cleo brain ...`). Keeping the export name out of the `*Command` /
+ * `*SubCommand` pattern avoids the false-positive.
+ *
+ * @task T10304
+ * @epic T10286
+ */
+export const backupRecoverBrainLeaf = defineCommand({
+  meta: {
+    name: 'brain',
+    description:
+      'Recover a malformed brain.db from the freshest validated snapshot (Saga T10281 SG-BRAIN-DB-RESILIENCE)',
+  },
+  args: {
+    'dry-run': {
+      type: 'boolean',
+      description: 'Print what would be done without quarantining or copying any files',
+      default: false,
+    },
+    'from-snapshot': {
+      type: 'string',
+      description:
+        'Pin recovery to a specific snapshot — absolute path or ISO timestamp prefix (e.g. 2026-05-23)',
+      default: '',
+    },
+    'no-delta': {
+      type: 'boolean',
+      description:
+        'Skip the sqlite3 .recover delta-merge step (reserved — current pipeline does not delta-merge; flag plumbed for forward-compat)',
+      default: false,
+    },
+    force: {
+      type: 'boolean',
+      description: 'Bypass any safety prompts (currently a no-op; reserved)',
+      default: false,
+    },
+  },
+  async run({ args }): Promise<void> {
+    const projectRoot = getProjectRoot();
+    const cleoDir = getCleoDirAbsolute();
+
+    const corruptPath = join(cleoDir, 'brain.db');
+    const snapshotDir = join(cleoDir, 'backups', 'snapshot');
+    const vacuumSnapshotDir = join(cleoDir, 'backups', 'sqlite');
+    const quarantineRoot = join(cleoDir, 'quarantine');
+
+    const argsBag: Record<string, unknown> = args;
+    const dryRun = readBoolFlag(argsBag, 'dry-run');
+    const fromSnapshot = readStringFlag(argsBag, 'from-snapshot');
+    const noDelta = readBoolFlag(argsBag, 'no-delta');
+
+    try {
+      const result = runBackupRecoverBrain({
+        corruptPath,
+        snapshotDir,
+        vacuumSnapshotDir,
+        legacyArtifactDir: cleoDir,
+        quarantineRoot,
+        logger: getLogger('backup-recover-brain'),
+        dryRun,
+        fromSnapshot: fromSnapshot.length > 0 ? fromSnapshot : undefined,
+        noDelta,
+      });
+
+      cliOutput(result, {
+        command: 'backup',
+        operation: 'backup.recover.brain',
+      });
+
+      if (result.dryRun) {
+        humanInfo(
+          `[dry-run] Would restore from ${result.restoredFrom} (${
+            result.dataLossWindowHours !== null
+              ? `~${result.dataLossWindowHours}h data-loss window`
+              : 'data-loss window unknown'
+          }). Re-run without --dry-run to execute (project root: ${projectRoot}).`,
+        );
+      } else {
+        humanInfo(
+          `Recovered brain.db from ${result.restoredFrom}. Corrupt DB quarantined at ${result.quarantinedTo}.`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof BackupRecoverBrainError) {
+        cliError(
+          err.message,
+          err.code,
+          {
+            name: err.codeName,
+            ...(err.fix ? { fix: err.fix } : {}),
+          },
+          { operation: 'backup.recover.brain' },
+        );
+        process.exitCode = err.code;
+        return;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(
+        message,
+        ExitCode.GENERAL_ERROR,
+        { name: 'E_RECOVERY_FAILED' },
+        { operation: 'backup.recover.brain' },
+      );
+      process.exitCode = ExitCode.GENERAL_ERROR;
+    }
+  },
+});
+
+// ---------------------------------------------------------------------------
+// `cleo backup recover` — group command (currently only `brain`)
+// ---------------------------------------------------------------------------
+
+/**
+ * `cleo backup recover` — recovery verb group.
+ *
+ * Currently hosts only `cleo backup recover brain` (T10304). Reserved for
+ * future per-DB recovery verbs (`tasks`, `nexus`, `signaldock`).
+ *
+ * @task T10304
+ * @epic T10286
+ */
+export const backupRecoverSubCommand = defineCommand({
+  meta: {
+    name: 'recover',
+    description: 'Recover a malformed CLEO database from snapshot',
+  },
+  subCommands: {
+    brain: backupRecoverBrainLeaf,
+  },
+  async run({ args }): Promise<void> {
+    // When invoked with no subcommand, surface the usage. citty fires the
+    // parent `run` AFTER the subcommand resolves, so this branch only
+    // triggers when the operator typed `cleo backup recover` with no leaf.
+    const argsBag: Record<string, unknown> = args;
+    const positional = argsBag['_'];
+    if (Array.isArray(positional) && positional.length > 0) return;
+    cliError(
+      'Missing subcommand. Try `cleo backup recover brain` (currently the only available recovery verb).',
+      ExitCode.VALIDATION_ERROR,
+      {
+        name: 'E_VALIDATION',
+        fix: 'Run `cleo backup recover brain --help` to see available flags.',
+      },
+      { operation: 'backup.recover' },
+    );
+    process.exitCode = ExitCode.VALIDATION_ERROR;
+  },
+});

--- a/packages/cleo/src/cli/commands/backup.ts
+++ b/packages/cleo/src/cli/commands/backup.ts
@@ -27,6 +27,7 @@ import {
 } from '../paths.js';
 import { cliOutput, humanInfo } from '../renderers/index.js';
 import { backupInspectSubCommand } from './backup-inspect.js';
+import { backupRecoverSubCommand } from './backup-recover.js';
 
 // ---------------------------------------------------------------------------
 // Internal helper — passphrase prompt (TTY only; agents use env var)
@@ -532,6 +533,7 @@ export const backupCommand = defineCommand({
     export: exportCommand,
     import: importCommand,
     inspect: backupInspectSubCommand,
+    recover: backupRecoverSubCommand,
   },
   async run({ cmd, rawArgs }) {
     // Parent run() fires after subcommand per citty@0.2.x — skip default

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -121,6 +121,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
       (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
+    exportName: 'backupRecoverSubCommand',
+    name: 'recover',
+    description: 'Recover a malformed CLEO database from snapshot',
+    load: async () =>
+      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+  },
+  {
     exportName: 'backupCommand',
     name: 'backup',
     description: 'Add backup of todo files or list available backups',

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -114,6 +114,13 @@ export default defineConfig({
         '../../packages/core/src/store/nexus-schema.ts',
         import.meta.url,
       ).pathname,
+      // T10304: backup-recover-brain SSoT (Saga T10281 Epic T10286) — used by
+      // `cleo backup recover brain` CLI verb. vi.mock against this subpath needs
+      // an alias so source-tree resolution wins under vitest.
+      '@cleocode/core/store/backup-recover-brain.js': new URL(
+        '../../packages/core/src/store/backup-recover-brain.ts',
+        import.meta.url,
+      ).pathname,
       // T946 sentient daemon consumes these subpath exports at runtime.
       '@cleocode/core/sdk': new URL('../../packages/core/src/cleo.ts', import.meta.url).pathname,
       '@cleocode/core/tasks': new URL(

--- a/packages/contracts/src/brain.ts
+++ b/packages/contracts/src/brain.ts
@@ -136,3 +136,77 @@ export interface BrainRecoveryResult {
    */
   quarantineDir: string | null;
 }
+
+// ============================================================
+// T10304 — `cleo backup recover brain` CLI verb (Saga T10281 / Epic T10286)
+// ============================================================
+
+/**
+ * Per-table row counts probed from the restored brain.db.
+ *
+ * Best-effort — any individual count may be `null` when the table is
+ * missing (very old snapshot predating that schema rev) or when the count
+ * query throws. The values feed both the `cleo backup recover brain`
+ * envelope and the recovery runbook's user-facing diagnostics.
+ *
+ * @task T10304
+ * @epic T10286
+ * @saga T10281
+ */
+export interface BrainRecoveredRowCounts {
+  /** `brain_observations` row count, or `null` when the count failed. */
+  observations: number | null;
+  /** `brain_decisions` row count, or `null` when the count failed. */
+  decisions: number | null;
+  /** `brain_learnings` row count, or `null` when the count failed. */
+  learnings: number | null;
+}
+
+/**
+ * Envelope payload returned by `cleo backup recover brain`.
+ *
+ * The CLI verb (T10304) wraps {@link BrainRecoveryResult} from
+ * {@link recoverMalformedBrainDb} (T10303) and enriches it with per-table
+ * row counts plus the operator-friendly snapshot/quarantine paths required
+ * by the AC envelope shape.
+ *
+ * Surfaces:
+ * - `--dry-run` plan envelopes (with `restoredFrom` being the snapshot that
+ *   *would* be restored and `quarantinedTo` being the directory the corrupt
+ *   DB *would* be moved to).
+ * - Real-recovery envelopes after the pipeline has executed.
+ *
+ * @task T10304
+ * @epic T10286
+ * @saga T10281
+ */
+export interface BackupRecoverBrainResult {
+  /**
+   * Absolute path to the snapshot that was (or would be) restored. Empty
+   * string when no snapshot was available — the envelope's caller surfaces
+   * that as a failure mode.
+   */
+  restoredFrom: string;
+  /** Per-table row counts probed from the restored DB. */
+  rowsRecovered: BrainRecoveredRowCounts;
+  /**
+   * Approximate hours between the snapshot's timestamp and the recovery
+   * event. `null` when the snapshot timestamp could not be parsed (e.g.
+   * legacy `brain.db.PRE-DUP-FIX-*` fallback artifact).
+   */
+  dataLossWindowHours: number | null;
+  /** `true` when the restored DB passes `PRAGMA quick_check`. */
+  integrityOK: boolean;
+  /**
+   * Absolute path to the quarantine directory where the corrupt DB plus
+   * its `-wal`/`-shm` sidecars were moved. Empty string in `--dry-run`
+   * mode where no files were touched.
+   */
+  quarantinedTo: string;
+  /**
+   * `true` when invoked with `--dry-run` — indicates the envelope is a
+   * plan, NOT a record of mutations performed. Consumers MUST check this
+   * before treating `restoredFrom` as a post-condition.
+   */
+  dryRun: boolean;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -140,10 +140,12 @@ export type {
 export { BOUNDARY_REGISTRY } from './boundary.js';
 // === Brain/Memory Types ===
 export type {
+  BackupRecoverBrainResult,
   BrainCognitiveType,
   BrainEntryRef,
   BrainEntrySummary,
   BrainMemoryTier,
+  BrainRecoveredRowCounts,
   BrainRecoveryResult,
   BrainSourceConfidence,
   ContradictionDetail,

--- a/packages/core/src/store/backup-recover-brain.ts
+++ b/packages/core/src/store/backup-recover-brain.ts
@@ -1,0 +1,647 @@
+/**
+ * CLI-facing wrapper around {@link recoverMalformedBrainDb} (T10303).
+ *
+ * Exposes the recovery pipeline to the `cleo backup recover brain` verb
+ * (T10304) with three additions that don't belong in the chokepoint module:
+ *
+ *  1. **Dry-run planning** — enumerates snapshot candidates, validates the
+ *     freshest one via `PRAGMA quick_check`, and returns the envelope WITHOUT
+ *     quarantining or copying anything. Operators use this to preview the
+ *     freshness window before pulling the trigger.
+ *  2. **Per-table row counts** — probes `brain_observations`, `brain_decisions`,
+ *     `brain_learnings` post-restore so the runbook surfaces the recovered
+ *     scope (NOT just observation count as the chokepoint helper does).
+ *  3. **Snapshot pinning** — accepts `fromSnapshot` (absolute path or ISO
+ *     prefix) so operators can roll back to a specific snapshot when the
+ *     freshest is also poisoned.
+ *
+ * The pipeline itself is NEVER re-implemented here — every code path either
+ * delegates to {@link recoverMalformedBrainDb} or to private helpers that
+ * mirror its candidate-enumeration logic for the dry-run preview.
+ *
+ * @task T10304
+ * @epic T10286
+ * @saga T10281
+ */
+
+import { copyFileSync, existsSync, mkdirSync, readdirSync, renameSync, statSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import type { BackupRecoverBrainResult, BrainRecoveredRowCounts } from '@cleocode/contracts';
+import { type RecoveryLogger, recoverMalformedBrainDb } from './recover-brain-db.js';
+import { openNativeDatabase } from './sqlite-native.js';
+
+// ---------------------------------------------------------------------------
+// Canonical snapshot filename patterns — kept in sync with recover-brain-db.ts
+// ---------------------------------------------------------------------------
+
+/** System-backup snapshot filename (created via `cleo backup add`). */
+const SNAPSHOT_FILENAME_RE = /^brain\.db\.snapshot-(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z)$/;
+
+/** VACUUM INTO snapshot filename (created on session-end hooks). */
+const VACUUM_FILENAME_RE = /^brain-(\d{8})-(\d{6})\.db$/;
+
+/** Legacy pre-T9685 dup-fix backup pattern. */
+const PRE_DUP_FIX_RE = /^brain\.db\.PRE-DUP-FIX-/;
+
+/** Internal candidate record used for planning + pinning. */
+interface SnapshotCandidate {
+  /** Absolute path to the snapshot file. */
+  path: string;
+  /** Best-available timestamp for ordering (epoch ms). */
+  timestampMs: number;
+  /** Source taxonomy — for diagnostic logging only. */
+  source: 'system-snapshot' | 'vacuum-snapshot' | 'pre-dup-fix';
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Options accepted by {@link runBackupRecoverBrain}.
+ */
+export interface BackupRecoverBrainOptions {
+  /**
+   * Absolute path to the corrupt `brain.db`. Required even in `dryRun`
+   * mode so the planner can compute the canonical quarantine target.
+   */
+  corruptPath: string;
+  /** Absolute path to `.cleo/backups/snapshot/`. */
+  snapshotDir: string;
+  /** Absolute path to `.cleo/backups/sqlite/` (VACUUM INTO snapshots). */
+  vacuumSnapshotDir?: string;
+  /** Absolute path to `.cleo/` for legacy `brain.db.PRE-DUP-FIX-*` fallback. */
+  legacyArtifactDir?: string;
+  /**
+   * Absolute path to the quarantine root. Defaults to
+   * `<dirname(corruptPath)>/quarantine` to match the chokepoint helper.
+   */
+  quarantineRoot?: string;
+  /** Pino-shaped logger for the recovery announcement. */
+  logger: RecoveryLogger;
+  /**
+   * When `true`, enumerate candidates + validate the freshest one and
+   * return the planned envelope WITHOUT quarantining or copying.
+   */
+  dryRun?: boolean;
+  /**
+   * Optional snapshot pin — either an absolute path to a specific
+   * snapshot file OR an ISO timestamp prefix (e.g. `2026-05-23`) that
+   * resolves to the freshest validated snapshot whose timestamp begins
+   * with that prefix. When unset, the freshest validated candidate wins.
+   */
+  fromSnapshot?: string;
+  /**
+   * When `true`, skip the future `sqlite3 .recover` delta-merge step.
+   * Reserved for future extension — the current pipeline does not
+   * perform delta-merge because T10300 found schema-page corruption
+   * makes it unreliable. The flag is plumbed end-to-end so the CLI surface
+   * stays stable when delta-merge becomes opt-in.
+   */
+  noDelta?: boolean;
+}
+
+/**
+ * Error thrown when the recovery pre-conditions cannot be satisfied.
+ *
+ * Distinct from runtime recovery failures (which are reported via the
+ * envelope's `integrityOK: false` field) — these errors signal that the
+ * CLI cannot even attempt recovery (no snapshots present at all,
+ * `fromSnapshot` does not resolve, etc.).
+ */
+export class BackupRecoverBrainError extends Error {
+  /** Stable numeric exit code. */
+  readonly code: number;
+  /** Stable string error code for envelope `codeName`. */
+  readonly codeName: string;
+  /** Optional remediation hint surfaced to the operator. */
+  readonly fix?: string;
+
+  /**
+   * @param message  - Human-readable error message.
+   * @param code     - Numeric exit code for the CLI surface.
+   * @param codeName - Stable error code (e.g. `'E_NO_SNAPSHOT'`).
+   * @param fix      - Optional remediation hint.
+   */
+  constructor(message: string, code: number, codeName: string, fix?: string) {
+    super(message);
+    this.name = 'BackupRecoverBrainError';
+    this.code = code;
+    this.codeName = codeName;
+    this.fix = fix;
+  }
+}
+
+/**
+ * Run the brain.db recovery pipeline as an operator-facing one-shot.
+ *
+ * In `dryRun` mode this returns the plan envelope (which snapshot would be
+ * picked, where the corrupt DB would be quarantined) without mutating any
+ * files on disk.
+ *
+ * In execute mode this delegates to {@link recoverMalformedBrainDb} for the
+ * actual quarantine + copy + integrity-check pipeline, then probes the
+ * restored DB for per-table row counts to enrich the envelope.
+ *
+ * @param opts - Recovery inputs (corrupt path, snapshot dirs, mode flags).
+ * @returns The recovery envelope (plan or post-mutation).
+ * @throws {BackupRecoverBrainError} When pre-conditions fail (no snapshots
+ *         at all, `fromSnapshot` cannot be resolved, etc.).
+ *
+ * @example
+ * ```typescript
+ * import { runBackupRecoverBrain } from '@cleocode/core/store/backup-recover-brain';
+ * import { getLogger } from '@cleocode/core/logger';
+ *
+ * const result = runBackupRecoverBrain({
+ *   corruptPath: '/repo/.cleo/brain.db',
+ *   snapshotDir: '/repo/.cleo/backups/snapshot',
+ *   vacuumSnapshotDir: '/repo/.cleo/backups/sqlite',
+ *   legacyArtifactDir: '/repo/.cleo',
+ *   logger: getLogger('backup-recover-brain'),
+ *   dryRun: true,
+ * });
+ * if (!result.integrityOK) {
+ *   process.exitCode = 1;
+ * }
+ * ```
+ */
+export function runBackupRecoverBrain(opts: BackupRecoverBrainOptions): BackupRecoverBrainResult {
+  if (!opts.corruptPath) {
+    throw new BackupRecoverBrainError('corruptPath is required', 6, 'E_VALIDATION');
+  }
+
+  const candidates = collectSnapshotCandidates(opts);
+  if (candidates.length === 0) {
+    throw new BackupRecoverBrainError(
+      `No snapshots found under ${opts.snapshotDir}` +
+        (opts.vacuumSnapshotDir ? ` or ${opts.vacuumSnapshotDir}` : '') +
+        (opts.legacyArtifactDir ? ` or ${opts.legacyArtifactDir}/brain.db.PRE-DUP-FIX-*` : ''),
+      4,
+      'E_NO_SNAPSHOT',
+      'Run `cleo backup add` to create a snapshot before attempting recovery.',
+    );
+  }
+
+  // Apply `--from-snapshot` filter when provided. The argument is either
+  // an exact absolute path OR an ISO prefix matching the snapshot stamp.
+  const filtered = opts.fromSnapshot
+    ? candidates.filter((c) => snapshotMatchesPin(c, opts.fromSnapshot ?? ''))
+    : candidates;
+
+  if (opts.fromSnapshot && filtered.length === 0) {
+    throw new BackupRecoverBrainError(
+      `Snapshot pin "${opts.fromSnapshot}" matched zero candidates`,
+      4,
+      'E_NO_SNAPSHOT_MATCH',
+      'List available snapshots with `ls .cleo/backups/snapshot/` (or `.cleo/backups/sqlite/`) and supply an exact path or ISO prefix.',
+    );
+  }
+
+  // Probe candidates in freshness order to find the first that quick_checks.
+  const chosen = pickFreshestValidSnapshot(filtered);
+  if (!chosen) {
+    throw new BackupRecoverBrainError(
+      'No candidate snapshot passed PRAGMA quick_check',
+      78,
+      'E_NO_VALID_SNAPSHOT',
+      'Every available snapshot is itself corrupt. Restore from an external backup or use `cleo backup import`.',
+    );
+  }
+
+  const quarantineRoot = opts.quarantineRoot ?? join(dirname(opts.corruptPath), 'quarantine');
+
+  if (opts.dryRun === true) {
+    // Plan envelope — count rows in the chosen snapshot WITHOUT touching disk.
+    const rowsRecovered = probeRowCounts(chosen.path);
+    return {
+      restoredFrom: chosen.path,
+      rowsRecovered,
+      dataLossWindowHours: computeDataLossWindowHours(chosen.timestampMs),
+      integrityOK: true,
+      quarantinedTo: '',
+      dryRun: true,
+    };
+  }
+
+  // Execute mode — delegate to the canonical pipeline. The chokepoint
+  // helper enumerates candidates internally, so we let it pick the same
+  // snapshot it would pick at open time (the candidate ranking is
+  // deterministic). When the operator pinned a snapshot via `fromSnapshot`,
+  // we pre-pre-copy the pinned snapshot path to the canonical home so the
+  // chokepoint's freshness-first selection still wins.
+  if (opts.fromSnapshot) {
+    // Pinning path — quarantine the corrupt DB ourselves, then copy the
+    // pinned snapshot in place. We deliberately avoid re-implementing
+    // recoverMalformedBrainDb's logic by keeping the operations symmetric:
+    // quarantine → copy → verify (same three steps the chokepoint runs).
+    return runPinnedRestore({
+      corruptPath: opts.corruptPath,
+      quarantineRoot,
+      chosen,
+      logger: opts.logger,
+    });
+  }
+
+  // Unpinned path — delegate to the chokepoint helper directly.
+  const result = recoverMalformedBrainDb({
+    corruptPath: opts.corruptPath,
+    snapshotDir: opts.snapshotDir,
+    vacuumSnapshotDir: opts.vacuumSnapshotDir,
+    legacyArtifactDir: opts.legacyArtifactDir,
+    quarantineRoot,
+    logger: opts.logger,
+  });
+
+  if (!result.integrityOK || !result.restoredFrom) {
+    throw new BackupRecoverBrainError(
+      'Recovery pipeline completed but restored DB failed integrity check',
+      78,
+      'E_RECOVERY_FAILED',
+      'Inspect the quarantine directory and try `--from-snapshot <iso>` with an older snapshot.',
+    );
+  }
+
+  const rowsRecovered = probeRowCounts(opts.corruptPath);
+  return {
+    restoredFrom: result.restoredFrom,
+    rowsRecovered,
+    dataLossWindowHours: result.dataLossWindowHours,
+    integrityOK: result.integrityOK,
+    quarantinedTo: result.quarantineDir ?? '',
+    dryRun: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pinned-restore implementation — mirrors recoverMalformedBrainDb's I/O steps
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a pinned restore: quarantine the corrupt DB, copy the pinned
+ * snapshot, verify integrity.
+ *
+ * Kept symmetric with {@link recoverMalformedBrainDb}'s pipeline so the two
+ * paths produce indistinguishable on-disk results.
+ *
+ * @internal
+ */
+function runPinnedRestore(args: {
+  corruptPath: string;
+  quarantineRoot: string;
+  chosen: SnapshotCandidate;
+  logger: RecoveryLogger;
+}): BackupRecoverBrainResult {
+  let quarantineDir = '';
+  try {
+    if (existsSync(args.corruptPath)) {
+      quarantineDir = quarantineCorruptDb(args.corruptPath, args.quarantineRoot);
+    }
+  } catch (err) {
+    args.logger.error(
+      { err, corruptPath: args.corruptPath, quarantineRoot: args.quarantineRoot },
+      'BRAIN pinned recovery aborted: could not quarantine corrupt DB',
+    );
+    throw new BackupRecoverBrainError(
+      `Could not quarantine corrupt DB: ${err instanceof Error ? err.message : String(err)}`,
+      1,
+      'E_QUARANTINE_FAILED',
+    );
+  }
+
+  try {
+    copyFileSync(args.chosen.path, args.corruptPath);
+  } catch (err) {
+    args.logger.error(
+      { err, snapshotPath: args.chosen.path, dest: args.corruptPath },
+      'BRAIN pinned recovery failed: copy from snapshot to live path threw',
+    );
+    throw new BackupRecoverBrainError(
+      `Could not copy snapshot to live path: ${err instanceof Error ? err.message : String(err)}`,
+      1,
+      'E_COPY_FAILED',
+    );
+  }
+
+  // Final verification — probe via the same quick_check helper.
+  if (!probeQuickCheck(args.corruptPath)) {
+    throw new BackupRecoverBrainError(
+      'Pinned snapshot restored but final quick_check failed',
+      78,
+      'E_RECOVERY_FAILED',
+    );
+  }
+
+  const rowsRecovered = probeRowCounts(args.corruptPath);
+  const dataLossWindowHours = computeDataLossWindowHours(args.chosen.timestampMs);
+
+  args.logger.warn(
+    {
+      event: 'brain.pinned-recovery',
+      restoredFrom: args.chosen.path,
+      source: args.chosen.source,
+      dataLossWindowHours,
+      quarantineDir,
+    },
+    `BRAIN pinned recovery completed from ${args.chosen.path} (T10304)`,
+  );
+
+  return {
+    restoredFrom: args.chosen.path,
+    rowsRecovered,
+    dataLossWindowHours,
+    integrityOK: true,
+    quarantinedTo: quarantineDir,
+    dryRun: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot candidate enumeration — kept in sync with recover-brain-db.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Enumerate snapshot candidates and return them newest-first.
+ *
+ * Mirrors {@link recoverMalformedBrainDb}'s candidate-collection logic but
+ * lives separately so dry-run planning does not need to invoke the full
+ * pipeline. Any changes to the freshness-ranking algorithm MUST be applied
+ * to both files in the same PR.
+ *
+ * @internal
+ */
+function collectSnapshotCandidates(opts: BackupRecoverBrainOptions): SnapshotCandidate[] {
+  const out: SnapshotCandidate[] = [];
+
+  if (existsSync(opts.snapshotDir)) {
+    try {
+      for (const name of readdirSync(opts.snapshotDir)) {
+        const m = SNAPSHOT_FILENAME_RE.exec(name);
+        const stamp = m?.[1];
+        if (!stamp) continue;
+        out.push({
+          path: join(opts.snapshotDir, name),
+          timestampMs: parseSystemSnapshotTimestamp(stamp),
+          source: 'system-snapshot',
+        });
+      }
+    } catch {
+      // unreadable directory — fall through to other sources
+    }
+  }
+
+  if (opts.vacuumSnapshotDir && existsSync(opts.vacuumSnapshotDir)) {
+    try {
+      for (const name of readdirSync(opts.vacuumSnapshotDir)) {
+        const m = VACUUM_FILENAME_RE.exec(name);
+        const datePart = m?.[1];
+        const timePart = m?.[2];
+        if (!datePart || !timePart) continue;
+        out.push({
+          path: join(opts.vacuumSnapshotDir, name),
+          timestampMs: parseVacuumSnapshotTimestamp(datePart, timePart),
+          source: 'vacuum-snapshot',
+        });
+      }
+    } catch {
+      // non-fatal
+    }
+  }
+
+  if (opts.legacyArtifactDir && existsSync(opts.legacyArtifactDir)) {
+    try {
+      for (const name of readdirSync(opts.legacyArtifactDir)) {
+        if (!PRE_DUP_FIX_RE.test(name)) continue;
+        const fullPath = join(opts.legacyArtifactDir, name);
+        let ts = 0;
+        try {
+          ts = statSync(fullPath).mtimeMs;
+        } catch {
+          continue;
+        }
+        out.push({ path: fullPath, timestampMs: ts, source: 'pre-dup-fix' });
+      }
+    } catch {
+      // non-fatal
+    }
+  }
+
+  const rank: Record<SnapshotCandidate['source'], number> = {
+    'system-snapshot': 0,
+    'vacuum-snapshot': 1,
+    'pre-dup-fix': 2,
+  };
+  out.sort((a, b) => {
+    if (b.timestampMs !== a.timestampMs) return b.timestampMs - a.timestampMs;
+    return rank[a.source] - rank[b.source];
+  });
+  return out;
+}
+
+/**
+ * Pick the first candidate (newest-first) whose `PRAGMA quick_check` returns
+ * `ok`. Returns `null` when no candidate passes.
+ *
+ * @internal
+ */
+function pickFreshestValidSnapshot(candidates: SnapshotCandidate[]): SnapshotCandidate | null {
+  for (const candidate of candidates) {
+    if (probeQuickCheck(candidate.path)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Determine whether a candidate matches the operator's `--from-snapshot`
+ * pin. Accepts both an exact absolute path and an ISO timestamp prefix.
+ *
+ * @internal
+ */
+function snapshotMatchesPin(candidate: SnapshotCandidate, pin: string): boolean {
+  if (!pin) return false;
+  if (candidate.path === pin) return true;
+  // ISO prefix match against the basename's timestamp portion.
+  const name = basename(candidate.path);
+  const systemMatch = SNAPSHOT_FILENAME_RE.exec(name);
+  if (systemMatch?.[1]) {
+    // Convert dashed ISO back to canonical form for prefix matching:
+    // `2026-05-23T08-00-55-563Z` → `2026-05-23T08:00:55.563Z`.
+    const iso = systemMatch[1].replace(
+      /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
+      '$1T$2:$3:$4.$5Z',
+    );
+    if (iso.startsWith(pin)) return true;
+    if (systemMatch[1].startsWith(pin)) return true;
+  }
+  const vacuumMatch = VACUUM_FILENAME_RE.exec(name);
+  if (vacuumMatch?.[1]?.startsWith(pin)) {
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// I/O helpers — kept symmetric with recover-brain-db.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a system-snapshot ISO-with-dashes timestamp into epoch ms.
+ *
+ * @internal
+ */
+function parseSystemSnapshotTimestamp(stamp: string): number {
+  const iso = stamp.replace(
+    /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
+    '$1T$2:$3:$4.$5Z',
+  );
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? 0 : ms;
+}
+
+/**
+ * Parse a VACUUM INTO snapshot timestamp (`20260523-130026`) into epoch ms.
+ *
+ * @internal
+ */
+function parseVacuumSnapshotTimestamp(datePart: string, timePart: string): number {
+  const yyyy = Number.parseInt(datePart.slice(0, 4), 10);
+  const mm = Number.parseInt(datePart.slice(4, 6), 10);
+  const dd = Number.parseInt(datePart.slice(6, 8), 10);
+  const hh = Number.parseInt(timePart.slice(0, 2), 10);
+  const mi = Number.parseInt(timePart.slice(2, 4), 10);
+  const ss = Number.parseInt(timePart.slice(4, 6), 10);
+  if ([yyyy, mm, dd, hh, mi, ss].some((n) => Number.isNaN(n))) return 0;
+  return new Date(yyyy, mm - 1, dd, hh, mi, ss).getTime();
+}
+
+/**
+ * Probe a candidate file with `PRAGMA quick_check`.
+ *
+ * @internal
+ */
+function probeQuickCheck(path: string): boolean {
+  let handle: DatabaseSync | null = null;
+  try {
+    handle = openNativeDatabase(path, { readonly: true, enableWal: false });
+    const quick = handle.prepare('PRAGMA quick_check').get() as
+      | { quick_check?: string }
+      | undefined;
+    return (quick?.quick_check ?? '') === 'ok';
+  } catch {
+    return false;
+  } finally {
+    if (handle) {
+      try {
+        handle.close();
+      } catch {
+        // non-fatal
+      }
+    }
+  }
+}
+
+/**
+ * Probe a DB for per-table row counts. Each count is best-effort — a missing
+ * table or count failure surfaces as `null` instead of throwing so the
+ * envelope always serializes cleanly.
+ *
+ * @internal
+ */
+function probeRowCounts(path: string): BrainRecoveredRowCounts {
+  const result: BrainRecoveredRowCounts = {
+    observations: null,
+    decisions: null,
+    learnings: null,
+  };
+
+  let handle: DatabaseSync | null = null;
+  try {
+    handle = openNativeDatabase(path, { readonly: true, enableWal: false });
+    for (const [table, key] of [
+      ['brain_observations', 'observations'],
+      ['brain_decisions', 'decisions'],
+      ['brain_learnings', 'learnings'],
+    ] as const) {
+      try {
+        const row = handle.prepare(`SELECT COUNT(*) AS cnt FROM ${table}`).get() as
+          | { cnt?: number }
+          | undefined;
+        if (typeof row?.cnt === 'number') {
+          result[key] = row.cnt;
+        }
+      } catch {
+        // table missing in this snapshot rev — leave the value null
+      }
+    }
+  } catch {
+    // unopenable — leave all counts null
+  } finally {
+    if (handle) {
+      try {
+        handle.close();
+      } catch {
+        // non-fatal
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Compute the data-loss window in hours from a snapshot's epoch-ms
+ * timestamp. Returns `null` when the timestamp could not be parsed.
+ *
+ * @internal
+ */
+function computeDataLossWindowHours(timestampMs: number): number | null {
+  if (!timestampMs || timestampMs <= 0) return null;
+  const deltaMs = Date.now() - timestampMs;
+  return Math.max(0, Math.round((deltaMs / 3_600_000) * 10) / 10);
+}
+
+/**
+ * Format an epoch-ms timestamp into the canonical quarantine directory
+ * name suffix — ISO-8601 with filesystem-safe `-` separators.
+ *
+ * @internal
+ */
+function formatQuarantineSuffix(epochMs: number): string {
+  return new Date(epochMs).toISOString().replace(/[:.]/g, '-');
+}
+
+/**
+ * Move the corrupt DB plus `-wal`/`-shm` sidecars into a quarantine directory.
+ *
+ * Mirrors {@link recoverMalformedBrainDb}'s internal helper of the same name
+ * so the pinned-restore path produces identical on-disk results.
+ *
+ * @internal
+ */
+function quarantineCorruptDb(corruptPath: string, quarantineRoot: string): string {
+  const quarantineDir = join(
+    quarantineRoot,
+    `brain-malformed-${formatQuarantineSuffix(Date.now())}`,
+  );
+  mkdirSync(quarantineDir, { recursive: true });
+
+  const dest = join(quarantineDir, 'brain.db.malformed');
+  renameSync(corruptPath, dest);
+
+  for (const suffix of ['-wal', '-shm']) {
+    const sidecarSrc = corruptPath + suffix;
+    if (existsSync(sidecarSrc)) {
+      const sidecarDest = join(quarantineDir, basename(corruptPath) + '.malformed' + suffix);
+      try {
+        renameSync(sidecarSrc, sidecarDest);
+      } catch {
+        // Sidecar move failure is non-fatal
+      }
+    }
+  }
+
+  return quarantineDir;
+}

--- a/scripts/.lint-stdout-discipline-baseline.json
+++ b/scripts/.lint-stdout-discipline-baseline.json
@@ -19,7 +19,7 @@
     "packages/cleo-os/src/postinstall.ts:376",
     "packages/cleo-os/src/postinstall.ts:393",
     "packages/cleo-os/src/postinstall.ts:428",
-    "packages/cleo/src/cli/commands/backup.ts:58",
+    "packages/cleo/src/cli/commands/backup.ts:59",
     "packages/cleo/src/cli/commands/brain.ts:393",
     "packages/cleo/src/cli/commands/briefing.ts:192",
     "packages/cleo/src/cli/commands/check.ts:451",
@@ -78,5 +78,5 @@
     "packages/mcp-adapter/src/server.ts:133",
     "packages/mcp-adapter/src/server.ts:137"
   ],
-  "updatedAt": "2026-05-23T22:16:02.541Z"
+  "updatedAt": "2026-05-23T22:34:01.961Z"
 }


### PR DESCRIPTION
## Summary

- Adds `cleo backup recover brain` — operator-facing verb wrapping T10303's `recoverMalformedBrainDb` pipeline (the sister task that wired auto-recovery into the brain.db open chokepoint).
- Surfaces two scenarios the chokepoint helper does NOT cover: (1) **pre-emptive recovery** before the next session-start, and (2) **pinned restore** via `--from-snapshot <iso|path>` when the auto-picked snapshot is also poisoned.
- Publishes the operator runbook at `docs/note/brain-recovery-runbook.md` (slug `brain-recovery-runbook`) covering when to invoke, pre-conditions, manual fallback (the procedure executed today in Saga T10281 Wave 0 AC1), exit codes, and data-loss expectations.

## Surface

```
cleo backup recover brain [--dry-run] [--from-snapshot <iso|path>] [--no-delta] [--force]
```

Envelope payload:

```ts
{
  ok: true,
  data: {
    restoredFrom: string,
    rowsRecovered: { observations: number | null, decisions: number | null, learnings: number | null },
    dataLossWindowHours: number | null,
    integrityOK: boolean,
    quarantinedTo: string,
    dryRun: boolean,
  },
  meta: { operation: 'backup.recover.brain', ... }
}
```

## Architecture

- `packages/core/src/store/backup-recover-brain.ts` (NEW) — thin CLI-facing wrapper around T10303's `recoverMalformedBrainDb`. Adds (a) dry-run planning, (b) per-table row counts via `openNativeDatabase` (pragma SSoT, ADR-068), and (c) snapshot pinning. NEVER re-implements the pipeline; delegates to `recoverMalformedBrainDb` for the unpinned path and mirrors its three I/O steps (quarantine → copy → verify) for the pinned path so on-disk results are indistinguishable.
- `packages/cleo/src/cli/commands/backup-recover.ts` (NEW) — citty wiring via the SSoT factory at `packages/cleo/src/cli/lib/define-cli-command.ts`. Wired into `cleo backup recover brain` as a leaf subcommand of the new `cleo backup recover` group.
- `packages/contracts/src/brain.ts` — adds `BackupRecoverBrainResult` + `BrainRecoveredRowCounts`.
- Leaf sub-sub-command exported as `backupRecoverBrainLeaf` (not `*Command` suffix) so `generate-command-manifest.mjs` doesn't flag a false collision against the top-level `brainCommand` (`cleo brain ...`).

## Quality Gates

- `pnpm biome check --write .` — clean.
- `pnpm run build` — green across all 9 build waves.
- New vitest suite passes 9/9 (verified locally via a per-test config because the `packages/cleo/vitest.config.ts` root-relative include glob has a pre-existing workspace-mode regression that prevents both `--project @cleocode/cleo` and file-filter invocations from finding any cleo test — affects the entire cleo project on this branch, not specific to T10304). The new alias for `@cleocode/core/store/backup-recover-brain.js` is added to `packages/cleo/vitest.config.ts` so the test resolves correctly once the workspace-mode issue is unblocked.
- Built CLI verb works end-to-end: `node packages/cleo/dist/cli/index.js backup recover brain --help` returns the expected usage envelope.

## Test plan

- [ ] CI green on all gates (biome, build, contracts dep-lint).
- [ ] `cleo backup recover brain --help` after install renders the new verb.
- [ ] `cleo backup recover brain --dry-run` returns a plan envelope on a project with snapshots present.
- [ ] `cleo backup recover brain` happy-path restores from the freshest validated snapshot.
- [ ] `cleo backup recover brain --from-snapshot 2026-05-22` pins recovery to an ISO prefix.
- [ ] Missing-snapshot error returns `E_NO_SNAPSHOT` (exit 4) with the documented `fix` hint.

## References

- **Sister task**: T10303 (producer) — wired the pipeline into `getBrainDb()`. PR #573 merged at `6b1956690`.
- **Epic**: T10286 E5-BRAIN-P0-HOTFIX.
- **Saga**: T10281 SG-BRAIN-DB-RESILIENCE.
- **ADR**: ADR-068 (DB Open Guard) — every recovery probe flows through `openNativeDatabase()`.

Closes T10304.