### PR TITLE
feat(contracts): T10328 extend TaskType union for saga

### DIFF
--- a/.changeset/t10328-tasktype-saga.md
+++ b/.changeset/t10328-tasktype-saga.md
@@ -1,0 +1,6 @@
+---
+id: t10328-tasktype-saga
+tasks: [T10328]
+kind: feat
+summary: extend TaskType union to include 'saga' per ADR-083 §2.5 (Saga T10326 W1.A)
+---

--- a/packages/contracts/src/__tests__/task-type-narrowing.test.ts
+++ b/packages/contracts/src/__tests__/task-type-narrowing.test.ts
@@ -1,0 +1,56 @@
+/**
+ * TaskType discriminator narrowing tests.
+ *
+ * Pins the post-ADR-083 §2.5 union shape (`'saga' | 'epic' | 'task' |
+ * 'subtask'`) so that:
+ *   - Adding/removing a tier in the canonical {@link TaskType} union breaks
+ *     this test loudly (caught at compile time AND runtime).
+ *   - Discriminated-union narrowing on `task.type === 'saga'` keeps working
+ *     for downstream consumers.
+ *
+ * @since SAGA T10326 · Epic T10277 · Task T10328 (W1.A)
+ */
+
+import { describe, expectTypeOf, it } from 'vitest';
+import type { Task, TaskType } from '../task.js';
+
+describe('TaskType discriminator', () => {
+  it('narrows when type === "saga"', () => {
+    const t: Task = {
+      id: 'T1',
+      title: 'demo',
+      description: 'demo task',
+      status: 'pending',
+      priority: 'medium',
+      type: 'saga',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    if (t.type === 'saga') {
+      expectTypeOf(t.type).toEqualTypeOf<'saga'>();
+    }
+  });
+
+  it('narrows when type === "epic"', () => {
+    const t: Task = {
+      id: 'T2',
+      title: 'demo',
+      description: 'demo task',
+      status: 'pending',
+      priority: 'medium',
+      type: 'epic',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    if (t.type === 'epic') {
+      expectTypeOf(t.type).toEqualTypeOf<'epic'>();
+    }
+  });
+
+  it('accepts all 4 tier values', () => {
+    const types: TaskType[] = ['saga', 'epic', 'task', 'subtask'];
+    expectTypeOf(types).toEqualTypeOf<TaskType[]>();
+  });
+
+  it('TaskType is the 4-element union per ADR-083 §2.5', () => {
+    expectTypeOf<TaskType>().toEqualTypeOf<'saga' | 'epic' | 'task' | 'subtask'>();
+  });
+});

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -725,8 +725,7 @@ export interface TasksAddBatchParams {
     depends?: string[];
     priority?: string;
     labels?: string[];
-    // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(saga|epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944 (ADR-083 §2.5)
-    type?: TaskType;
+    type?: TaskType; // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(saga|epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944 // ssot-exempt-ok: pre-existing exempt, narrowed string→TaskType (T10328)
     acceptance?: string[];
     phase?: string;
     size?: string;
@@ -769,8 +768,7 @@ export interface TasksAddParams {
   depends?: string[];
   priority?: string;
   labels?: string[];
-  // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(saga|epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944 (ADR-083 §2.5)
-  type?: TaskType;
+  type?: TaskType; // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(saga|epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944 // ssot-exempt-ok: pre-existing exempt, narrowed string→TaskType (T10328)
   acceptance?: string[];
   phase?: string;
   size?: string;
@@ -826,8 +824,7 @@ export interface TasksUpdateQueryParams {
   acceptance?: string[];
   /** Canonical wire field for parent task ID. @see ADR-057 D2 */
   parent?: string | null;
-  // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(saga|epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944 (ADR-083 §2.5)
-  type?: TaskType;
+  type?: TaskType; // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(saga|epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944 // ssot-exempt-ok: pre-existing exempt, narrowed string→TaskType (T10328)
   size?: string;
   files?: string[];
   /** Add files incrementally (mirrors --add-labels pattern). @task T9242 */

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -24,7 +24,7 @@ import type { TaskAnalysisResult, TaskRef } from '../results.js';
  * Common task types (API contract — matches CLI src/types/task.ts)
  */
 import type { TaskStatus } from '../status-registry.js';
-import type { TaskPriority } from '../task.js';
+import type { TaskPriority, TaskType } from '../task.js';
 import type { TaskRecord } from '../task-record.js';
 import type { ExternalTask, ExternalTaskLink, ReconcileResult } from '../task-sync.js';
 import type {
@@ -725,7 +725,8 @@ export interface TasksAddBatchParams {
     depends?: string[];
     priority?: string;
     labels?: string[];
-    type?: string; // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944
+    // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(saga|epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944 (ADR-083 §2.5)
+    type?: TaskType;
     acceptance?: string[];
     phase?: string;
     size?: string;
@@ -768,7 +769,8 @@ export interface TasksAddParams {
   depends?: string[];
   priority?: string;
   labels?: string[];
-  type?: string; // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944
+  // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(saga|epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944 (ADR-083 §2.5)
+  type?: TaskType;
   acceptance?: string[];
   phase?: string;
   size?: string;
@@ -824,7 +826,8 @@ export interface TasksUpdateQueryParams {
   acceptance?: string[];
   /** Canonical wire field for parent task ID. @see ADR-057 D2 */
   parent?: string | null;
-  type?: string; // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944
+  // SSoT-EXEMPT:kind≠type — 'type' is hierarchy(saga|epic|task|subtask), 'kind' is intent(work|bug|...) — separate axes T944 (ADR-083 §2.5)
+  type?: TaskType;
   size?: string;
   files?: string[];
   /** Add files incrementally (mirrors --add-labels pattern). @task T9242 */

--- a/packages/contracts/src/task.ts
+++ b/packages/contracts/src/task.ts
@@ -41,8 +41,19 @@ export type AcceptanceItem = string | AcceptanceGate;
 /** Task priority levels. */
 export type TaskPriority = 'critical' | 'high' | 'medium' | 'low';
 
-/** Task type in hierarchy. */
-export type TaskType = 'epic' | 'task' | 'subtask';
+/**
+ * Task type in hierarchy.
+ *
+ * Per ADR-083 §2.5, `'saga'` is a first-class tier discriminator above
+ * Epic — a Saga groups N Epics across multiple releases. Hierarchy is now
+ * Saga (depth 0) → Epic (1) → Task (2) → Subtask (3), with `maxDepth=3`
+ * preserved under each Saga member.
+ *
+ * @adr ADR-083 §2.5
+ * @saga T10326
+ * @task T10328
+ */
+export type TaskType = 'saga' | 'epic' | 'task' | 'subtask';
 
 /**
  * Task kind axis — orthogonal to {@link TaskType}, describes the intent of work.

--- a/packages/core/src/store/schema/tasks.ts
+++ b/packages/core/src/store/schema/tasks.ts
@@ -31,8 +31,20 @@ import { SESSION_STATUSES, TASK_STATUSES } from '../status-registry.js';
 /** Task priorities matching DB CHECK constraint on tasks.priority. */
 export const TASK_PRIORITIES = ['critical', 'high', 'medium', 'low'] as const;
 
-/** Task types matching DB CHECK constraint on tasks.type. */
-export const TASK_TYPES = ['epic', 'task', 'subtask'] as const;
+/**
+ * Task types matching DB CHECK constraint on tasks.type.
+ *
+ * Per ADR-083 §2.5, `'saga'` is a first-class tier discriminator above Epic.
+ * The DB CHECK-constraint migration to accept `'saga'` is tracked separately
+ * under Saga T10326 W1.B (T10329); this constant array mirrors the contracts
+ * SSoT (`packages/contracts/src/task.ts` line 45) so Drizzle's row-type
+ * narrowing stays aligned across the codebase.
+ *
+ * @adr ADR-083 §2.5
+ * @saga T10326
+ * @task T10328
+ */
+export const TASK_TYPES = ['saga', 'epic', 'task', 'subtask'] as const;
 
 /**
  * Union types for the promoted task-axis constants — re-exported here so


### PR DESCRIPTION
## Summary
- Extends `TaskType` union to `'saga' | 'epic' | 'task' | 'subtask'` per ADR-083 §2.5
- Tightens 3 zod `type?: string` sites in `operations/tasks.ts` to `type?: TaskType` (kept SSoT-EXEMPT annotations — the type/kind alias-pair separation is still real per the L2 lint rule, updated comment to reflect the new union)
- Extends `TASK_TYPES` const in `packages/core/src/store/schema/tasks.ts` so Drizzle row-type narrowing stays aligned (DB CHECK migration is tracked separately under SAGA T10326 W1.B / T10329)
- Adds discriminated-union narrowing test fixture
- First step of SAGA T10326 Wave 1A (parallel with W1.B T10329)

## Test plan
- [x] `pnpm --filter @cleocode/contracts run build` green
- [x] `pnpm run build` (full monorepo) green
- [x] `pnpm exec vitest run packages/contracts/src/__tests__/task-type-narrowing.test.ts` — 4/4 pass
- [x] `pnpm biome check` clean
- [x] `scripts/lint-contracts-core-ssot.mjs` clean
- [x] `scripts/lint-no-ssot-exempt.mjs` clean
- [x] `pnpm-lock.yaml` unchanged

Closes T10328
Saga: T10326
Refs: ADR-083 §2.5