### PR TITLE
feat(core): T10329 saga TaskType Drizzle migration

### DIFF
--- a/.changeset/T10329.md
+++ b/.changeset/T10329.md
@@ -1,0 +1,29 @@
+---
+"@cleocode/core": minor
+---
+
+feat(T10329): widen TASK_TYPES Drizzle enum + reversible saga migration
+
+Promotes `'saga'` from a soft label on epics to a first-class TaskType per
+ADR-083 §2.5 (W1.B of Saga T10326 SG-SUBSTRATE-RECONCILIATION / Epic T10277
+E-SAGA-TYPE-MIGRATION).
+
+Schema changes:
+
+- `packages/core/src/store/schema/tasks.ts`: `TASK_TYPES` is now
+  `['saga', 'epic', 'task', 'subtask']`.
+- New migration `20260523213708_t10277-saga-tasktype/` rebuilds the `tasks`
+  table with a CHECK constraint enumerating the four canonical TaskType
+  values, plus an I5 CHECK (`type != 'saga' OR parent_id IS NULL`) that
+  enforces ADR-073 §1.2 I5 at the storage layer.
+- The forward migration converts every label-encoded saga
+  (`type='epic' AND parent_id IS NULL AND 'saga' IN labels_json`) to
+  `type='saga'` and strips the redundant 'saga' label from `labels_json`.
+- The accompanying `revert.sql` reverses every change (rebuilds without the
+  new CHECKs, flips `type='saga'` rows back to `type='epic'`, and re-prepends
+  the 'saga' label). A round-trip regression test
+  (`packages/core/src/store/__tests__/t10277-saga-tasktype.test.ts`) seeds
+  five saga fixtures plus three control rows and asserts up → down restores
+  byte-identical state for every column.
+
+Saga: T10326. Epic: T10277.

--- a/packages/core/migrations/drizzle-tasks/20260523213708_t10277-saga-tasktype/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260523213708_t10277-saga-tasktype/migration.sql
@@ -1,0 +1,300 @@
+-- T10277 / T10329 — Promote 'saga' from a soft label on epics to a first-class TaskType.
+--
+-- Background
+-- ──────────
+-- ADR-073 §1 and ADR-076 originally encoded "Saga" as a label on a top-level
+-- Epic row (`type='epic' AND labels_json LIKE '%saga%' AND parent_id IS NULL`).
+-- ADR-083 §2.5 (LOCKED 2026-05-23) reverses that decision: Saga becomes its
+-- own `TaskType` value, orthogonal to Epic/Task/Subtask, so the 4-scope axis
+-- (Saga → Epic → Task → Subtask) is uniformly storable in the discriminator
+-- column rather than via a side-channel label.
+--
+-- This migration:
+--   1. Adds a CHECK constraint on `tasks.type` that enumerates the four
+--      canonical TaskType values: 'saga', 'epic', 'task', 'subtask' (NULL
+--      remains permitted for legacy rows that have no type assigned).
+--   2. Adds a CHECK constraint enforcing ADR-073 §1.2 I5: any row with
+--      `type = 'saga'` MUST have `parent_id IS NULL` (Sagas are roots).
+--   3. Re-labels existing label-encoded saga rows: every row matching
+--      `type='epic' AND parent_id IS NULL AND 'saga' IN labels_json` is
+--      flipped to `type='saga'` AND the 'saga' label is stripped from
+--      `labels_json` (so the label is not double-counted with the type).
+--
+-- SQLite limitations
+-- ──────────────────
+-- SQLite has no native enum and cannot ALTER COLUMN to add a CHECK; the
+-- standard recipe is to rebuild the table. We follow the exact pattern
+-- established by `20260512000000_t1899-origin-check-backfill` (T1899): drop
+-- triggers + indexes, create `__new_tasks` with the additional CHECK, copy
+-- rows in, drop+rename, restore triggers + indexes.
+--
+-- Idempotency
+-- ───────────
+-- Step (3)'s UPDATE is guarded by `WHERE type = 'epic' AND parent_id IS NULL
+-- AND <label list contains 'saga'>`. After the migration runs once, matching
+-- rows now have `type = 'saga'` and the 'saga' label removed, so the WHERE
+-- clause yields zero rows on replay — the UPDATE is a no-op. Step (1) and
+-- (2) only run inside the table rebuild, which Drizzle's journal guarantees
+-- runs exactly once via its migration hash.
+--
+-- Round-trip
+-- ──────────
+-- `revert.sql` reverses every change: rebuilds `tasks` WITHOUT the type +
+-- I5 CHECKs, flips `type='saga'` rows back to `type='epic'`, and prepends
+-- 'saga' to `labels_json` (which restores byte-identical labels because the
+-- forward migration appends; the revert prepends to mirror, see test
+-- fixture). The round-trip is verified by
+-- `packages/core/src/store/__tests__/t10277-saga-tasktype.test.ts`.
+--
+-- ADR-073 §1.2 I5: "Sagas have no parent — `parent_id IS NULL` is invariant
+-- at storage layer for `type='saga'` rows."
+--
+-- @task T10329
+-- @epic T10277
+-- @saga T10326
+-- @see .cleo/adrs/ADR-083-saga-as-tasktype.md §2.5
+-- @see .cleo/adrs/ADR-073-above-epic-naming.md §1.2 I5
+-- @see packages/core/migrations/drizzle-tasks/20260512000000_t1899-origin-check-backfill/migration.sql
+
+PRAGMA foreign_keys = OFF;
+--> statement-breakpoint
+
+-- ── Step 0: Drop triggers + indexes (table rebuild prerequisite) ────────
+DROP TRIGGER IF EXISTS `trg_tasks_status_pipeline_insert`;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS `trg_tasks_status_pipeline_update`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_status`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_parent_id`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_phase`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_type`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_priority`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_session_id`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_pipeline_stage`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_assignee`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_parent_status`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_status_priority`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_type_phase`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_status_archive_reason`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_role`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_scope`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_role_status`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_sentient_proposals_today`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_origin`;
+--> statement-breakpoint
+
+-- ── Step 1: Create `__new_tasks` with type + I5 CHECKs ─────────────────
+-- Schema mirrors the post-T1899 shape (the most recent table rebuild) plus
+-- two new CHECK constraints on the `type` column:
+--   (a) ENUM CHECK — type IS NULL OR type IN ('saga','epic','task','subtask')
+--   (b) I5 CHECK   — type != 'saga' OR parent_id IS NULL  (Sagas are roots)
+CREATE TABLE `__new_tasks` (
+  `id` text PRIMARY KEY,
+  `title` text NOT NULL,
+  `description` text,
+  `status` text DEFAULT 'pending' NOT NULL,
+  `priority` text DEFAULT 'medium' NOT NULL,
+  `type` text CHECK (
+    `type` IS NULL OR `type` IN ('saga','epic','task','subtask')
+  ),
+  `parent_id` text,
+  `phase` text,
+  `size` text,
+  `position` integer,
+  `position_version` integer DEFAULT 0,
+  `labels_json` text DEFAULT '[]',
+  `notes_json` text DEFAULT '[]',
+  `acceptance_json` text DEFAULT '[]',
+  `files_json` text DEFAULT '[]',
+  `origin` text,
+  `blocked_by` text,
+  `epic_lifecycle` text,
+  `no_auto_complete` integer,
+  `created_at` text DEFAULT (datetime('now')) NOT NULL,
+  `updated_at` text,
+  `completed_at` text,
+  `cancelled_at` text,
+  `cancellation_reason` text,
+  `archived_at` text,
+  `archive_reason` text CHECK (
+    `archive_reason` IS NULL OR `archive_reason` IN (
+      'verified',
+      'reconciled',
+      'superseded',
+      'shadowed',
+      'cancelled',
+      'completed-unverified'
+    )
+  ),
+  `cycle_time_days` integer,
+  `verification_json` text,
+  `created_by` text,
+  `modified_by` text,
+  `session_id` text,
+  `pipeline_stage` text,
+  `assignee` text,
+  `ivtr_state` text,
+  `role` TEXT NOT NULL DEFAULT 'work'
+    CHECK (`role` IN ('work','research','experiment','bug','spike','release')),
+  `scope` TEXT NOT NULL DEFAULT 'feature'
+    CHECK (`scope` IN ('project','feature','unit')),
+  `severity` TEXT
+    CHECK (`severity` IS NULL OR `severity` IN ('P0','P1','P2','P3')),
+  -- T10329: ADR-073 §1.2 I5 — Sagas have no parent.
+  CONSTRAINT `chk_tasks_saga_no_parent` CHECK (
+    `type` != 'saga' OR `parent_id` IS NULL
+  ),
+  CONSTRAINT `fk_tasks_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `__new_tasks`(`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_tasks_session_id` FOREIGN KEY (`session_id`) REFERENCES `sessions`(`id`) ON DELETE SET NULL
+);
+--> statement-breakpoint
+
+-- ── Step 2: Copy rows verbatim into the new table ──────────────────────
+-- Pre-existing label-encoded saga rows still carry `type='epic'` at this
+-- point; they will be flipped to `type='saga'` in Step 4 below (post-copy).
+-- Copying with `type='epic'` first satisfies the new ENUM CHECK because
+-- 'epic' is in the allowed set.
+INSERT INTO `__new_tasks` (
+  `id`, `title`, `description`, `status`, `priority`, `type`, `parent_id`,
+  `phase`, `size`, `position`, `position_version`, `labels_json`, `notes_json`,
+  `acceptance_json`, `files_json`, `origin`, `blocked_by`, `epic_lifecycle`,
+  `no_auto_complete`, `created_at`, `updated_at`, `completed_at`, `cancelled_at`,
+  `cancellation_reason`, `archived_at`, `archive_reason`, `cycle_time_days`,
+  `verification_json`, `created_by`, `modified_by`, `session_id`, `pipeline_stage`,
+  `assignee`, `ivtr_state`, `role`, `scope`, `severity`
+)
+SELECT
+  `id`, `title`, `description`, `status`, `priority`, `type`, `parent_id`,
+  `phase`, `size`, `position`, `position_version`, `labels_json`, `notes_json`,
+  `acceptance_json`, `files_json`, `origin`, `blocked_by`, `epic_lifecycle`,
+  `no_auto_complete`, `created_at`, `updated_at`, `completed_at`, `cancelled_at`,
+  `cancellation_reason`, `archived_at`, `archive_reason`, `cycle_time_days`,
+  `verification_json`, `created_by`, `modified_by`, `session_id`, `pipeline_stage`,
+  `assignee`, `ivtr_state`, `role`, `scope`, `severity`
+FROM `tasks`;
+--> statement-breakpoint
+
+DROP TABLE `tasks`;
+--> statement-breakpoint
+ALTER TABLE `__new_tasks` RENAME TO `tasks`;
+--> statement-breakpoint
+
+-- ── Step 3: Flip type='epic' → 'saga' for label-encoded sagas ──────────
+-- Identification rule (ADR-076-era encoding):
+--   type='epic' AND parent_id IS NULL AND labels_json contains 'saga'.
+--
+-- Ordering matters: flip TYPE first, then strip the 'saga' label. If we
+-- stripped the label first, the WHERE clause below could no longer detect
+-- which rows were originally label-encoded sagas.
+--
+-- The new I5 CHECK (`type != 'saga' OR parent_id IS NULL`) is satisfied
+-- because we only touch rows where `parent_id IS NULL`.
+--
+-- Idempotency: on replay, every formerly-label-encoded row now has
+-- type='saga' (so the `type = 'epic'` predicate is empty) AND no 'saga'
+-- label in labels_json (so the EXISTS predicate is empty too). Both
+-- UPDATEs become no-ops.
+UPDATE `tasks`
+SET `type` = 'saga'
+WHERE `type` = 'epic'
+  AND `parent_id` IS NULL
+  AND json_valid(`labels_json`)
+  AND EXISTS (
+    SELECT 1 FROM json_each(`tasks`.`labels_json`) WHERE value = 'saga'
+  );
+--> statement-breakpoint
+
+-- ── Step 4: Strip 'saga' from labels_json for the just-promoted rows ───
+-- Rebuilds labels_json from json_each, filtering out the 'saga' element,
+-- then re-aggregating via json_group_array. Guard with json_valid() so a
+-- malformed labels_json row does not abort the migration.
+UPDATE `tasks`
+SET `labels_json` = (
+  SELECT COALESCE(json_group_array(value), '[]')
+    FROM json_each(`tasks`.`labels_json`)
+   WHERE value != 'saga'
+)
+WHERE `type` = 'saga'
+  AND json_valid(`labels_json`)
+  AND EXISTS (
+    SELECT 1 FROM json_each(`tasks`.`labels_json`) WHERE value = 'saga'
+  );
+--> statement-breakpoint
+
+-- ── Step 5: Recreate indexes + triggers ────────────────────────────────
+-- Index list mirrors the post-T1899 set (idx_tasks_origin included).
+CREATE INDEX `idx_tasks_status` ON `tasks` (`status`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_parent_id` ON `tasks` (`parent_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_phase` ON `tasks` (`phase`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_type` ON `tasks` (`type`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_priority` ON `tasks` (`priority`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_session_id` ON `tasks` (`session_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_pipeline_stage` ON `tasks` (`pipeline_stage`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_assignee` ON `tasks` (`assignee`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_parent_status` ON `tasks` (`parent_id`, `status`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_status_priority` ON `tasks` (`status`, `priority`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_type_phase` ON `tasks` (`type`, `phase`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_status_archive_reason` ON `tasks` (`status`, `archive_reason`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_role` ON `tasks` (`role`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_scope` ON `tasks` (`scope`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_role_status` ON `tasks` (`role`, `status`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_sentient_proposals_today`
+  ON `tasks` (date(`created_at`))
+  WHERE `labels_json` LIKE '%sentient-tier2%';
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_origin` ON `tasks` (`origin`);
+--> statement-breakpoint
+
+-- Recreate T877 status/pipeline_stage invariant triggers.
+CREATE TRIGGER `trg_tasks_status_pipeline_insert`
+BEFORE INSERT ON `tasks`
+FOR EACH ROW
+WHEN (NEW.`status` = 'done'      AND (NEW.`pipeline_stage` IS NULL OR NEW.`pipeline_stage` NOT IN ('contribution','cancelled')))
+  OR (NEW.`status` = 'cancelled' AND (NEW.`pipeline_stage` IS NULL OR NEW.`pipeline_stage` != 'cancelled'))
+BEGIN
+  SELECT RAISE(ABORT, 'T877_INVARIANT_VIOLATION: status/pipeline_stage mismatch. status=done requires pipeline_stage IN (contribution,cancelled); status=cancelled requires pipeline_stage=cancelled.');
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `trg_tasks_status_pipeline_update`
+BEFORE UPDATE OF `status`, `pipeline_stage` ON `tasks`
+FOR EACH ROW
+WHEN (NEW.`status` = 'done'      AND (NEW.`pipeline_stage` IS NULL OR NEW.`pipeline_stage` NOT IN ('contribution','cancelled')))
+  OR (NEW.`status` = 'cancelled' AND (NEW.`pipeline_stage` IS NULL OR NEW.`pipeline_stage` != 'cancelled'))
+BEGIN
+  SELECT RAISE(ABORT, 'T877_INVARIANT_VIOLATION: status/pipeline_stage mismatch. status=done requires pipeline_stage IN (contribution,cancelled); status=cancelled requires pipeline_stage=cancelled.');
+END;
+--> statement-breakpoint
+
+PRAGMA foreign_keys = ON;

--- a/packages/core/migrations/drizzle-tasks/20260523213708_t10277-saga-tasktype/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260523213708_t10277-saga-tasktype/revert.sql
@@ -1,0 +1,243 @@
+-- Revert T10277/T10329 — Demote 'saga' TaskType back to a label on Epics.
+--
+-- Steps (inverse of migration.sql, run in reverse order):
+--   1. Rebuild `tasks` WITHOUT the new CHECK constraints on `type` and
+--      WITHOUT the I5 (saga implies parent_id IS NULL) constraint.
+--   2. Re-add 'saga' to `labels_json` for every row currently typed 'saga'.
+--      The label is PREPENDED to the array — this restores byte-identical
+--      JSON when the forward migration's input had 'saga' at index 0 (the
+--      conventional / test-fixture encoding).
+--   3. Flip `type = 'saga'` rows back to `type = 'epic'`.
+--   4. Recreate the same indexes + triggers the migration drops.
+--
+-- Round-trip byte-identity caveat
+-- ───────────────────────────────
+-- The forward migration's Step 4 used `json_each(...) WHERE value != 'saga'`
+-- which preserves the relative order of the OTHER labels. Round-tripping
+-- back via PREPEND restores byte-identical `labels_json` IFF the original
+-- labels array had 'saga' at index 0. The accompanying integration test
+-- (`packages/core/src/store/__tests__/t10277-saga-tasktype.test.ts`)
+-- enforces this invariant by seeding fixtures with 'saga' first.
+--
+-- Idempotency: this revert is NOT idempotent — re-running it would re-add
+-- a second 'saga' element. The convention in this codebase is that revert
+-- scripts run exactly once during a manual rollback; downgrade tooling is
+-- responsible for tracking application state.
+--
+-- @task T10329
+-- @epic T10277
+-- @see migration.sql
+
+PRAGMA foreign_keys = OFF;
+--> statement-breakpoint
+
+-- ── Step 0: Drop triggers + indexes (table rebuild prerequisite) ────────
+DROP TRIGGER IF EXISTS `trg_tasks_status_pipeline_insert`;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS `trg_tasks_status_pipeline_update`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_status`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_parent_id`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_phase`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_type`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_priority`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_session_id`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_pipeline_stage`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_assignee`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_parent_status`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_status_priority`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_type_phase`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_status_archive_reason`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_role`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_scope`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_role_status`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_sentient_proposals_today`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_origin`;
+--> statement-breakpoint
+
+-- ── Step 1: Re-prepend 'saga' label to currently-typed-saga rows ───────
+-- Must run BEFORE we flip type='saga' → type='epic' so the WHERE predicate
+-- can identify the right rows.
+--
+-- SQLite's JSON1 has no array-splice primitive: `json_insert($[0], ...)`
+-- is a no-op when index 0 is already populated. We instead build the new
+-- array textually: open with '["saga"', then concatenate either ']' (if
+-- the source was an empty array) or ',<rest-of-array-body>' (if it had
+-- elements). The `labels_json` schema always stores a JSON array, so
+-- SUBSTR(labels_json, 2) extracts everything past the leading '['.
+UPDATE `tasks`
+SET `labels_json` = (
+  CASE
+    WHEN `labels_json` IS NULL OR NOT json_valid(`labels_json`)
+      THEN '["saga"]'
+    WHEN json_type(`labels_json`) != 'array'
+      THEN '["saga"]'
+    WHEN `labels_json` = '[]'
+      THEN '["saga"]'
+    ELSE '["saga",' || SUBSTR(`labels_json`, 2)
+  END
+)
+WHERE `type` = 'saga';
+--> statement-breakpoint
+
+-- ── Step 2: Flip type='saga' back to type='epic' ───────────────────────
+UPDATE `tasks` SET `type` = 'epic' WHERE `type` = 'saga';
+--> statement-breakpoint
+
+-- ── Step 3: Rebuild `tasks` WITHOUT the type/I5 CHECK constraints ──────
+-- Schema matches the post-T1899 shape (the pre-T10329 state).
+CREATE TABLE `__new_tasks` (
+  `id` text PRIMARY KEY,
+  `title` text NOT NULL,
+  `description` text,
+  `status` text DEFAULT 'pending' NOT NULL,
+  `priority` text DEFAULT 'medium' NOT NULL,
+  `type` text,
+  `parent_id` text,
+  `phase` text,
+  `size` text,
+  `position` integer,
+  `position_version` integer DEFAULT 0,
+  `labels_json` text DEFAULT '[]',
+  `notes_json` text DEFAULT '[]',
+  `acceptance_json` text DEFAULT '[]',
+  `files_json` text DEFAULT '[]',
+  `origin` text,
+  `blocked_by` text,
+  `epic_lifecycle` text,
+  `no_auto_complete` integer,
+  `created_at` text DEFAULT (datetime('now')) NOT NULL,
+  `updated_at` text,
+  `completed_at` text,
+  `cancelled_at` text,
+  `cancellation_reason` text,
+  `archived_at` text,
+  `archive_reason` text CHECK (
+    `archive_reason` IS NULL OR `archive_reason` IN (
+      'verified',
+      'reconciled',
+      'superseded',
+      'shadowed',
+      'cancelled',
+      'completed-unverified'
+    )
+  ),
+  `cycle_time_days` integer,
+  `verification_json` text,
+  `created_by` text,
+  `modified_by` text,
+  `session_id` text,
+  `pipeline_stage` text,
+  `assignee` text,
+  `ivtr_state` text,
+  `role` TEXT NOT NULL DEFAULT 'work'
+    CHECK (`role` IN ('work','research','experiment','bug','spike','release')),
+  `scope` TEXT NOT NULL DEFAULT 'feature'
+    CHECK (`scope` IN ('project','feature','unit')),
+  `severity` TEXT
+    CHECK (`severity` IS NULL OR `severity` IN ('P0','P1','P2','P3')),
+  CONSTRAINT `fk_tasks_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `__new_tasks`(`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_tasks_session_id` FOREIGN KEY (`session_id`) REFERENCES `sessions`(`id`) ON DELETE SET NULL
+);
+--> statement-breakpoint
+
+INSERT INTO `__new_tasks` (
+  `id`, `title`, `description`, `status`, `priority`, `type`, `parent_id`,
+  `phase`, `size`, `position`, `position_version`, `labels_json`, `notes_json`,
+  `acceptance_json`, `files_json`, `origin`, `blocked_by`, `epic_lifecycle`,
+  `no_auto_complete`, `created_at`, `updated_at`, `completed_at`, `cancelled_at`,
+  `cancellation_reason`, `archived_at`, `archive_reason`, `cycle_time_days`,
+  `verification_json`, `created_by`, `modified_by`, `session_id`, `pipeline_stage`,
+  `assignee`, `ivtr_state`, `role`, `scope`, `severity`
+)
+SELECT
+  `id`, `title`, `description`, `status`, `priority`, `type`, `parent_id`,
+  `phase`, `size`, `position`, `position_version`, `labels_json`, `notes_json`,
+  `acceptance_json`, `files_json`, `origin`, `blocked_by`, `epic_lifecycle`,
+  `no_auto_complete`, `created_at`, `updated_at`, `completed_at`, `cancelled_at`,
+  `cancellation_reason`, `archived_at`, `archive_reason`, `cycle_time_days`,
+  `verification_json`, `created_by`, `modified_by`, `session_id`, `pipeline_stage`,
+  `assignee`, `ivtr_state`, `role`, `scope`, `severity`
+FROM `tasks`;
+--> statement-breakpoint
+
+DROP TABLE `tasks`;
+--> statement-breakpoint
+ALTER TABLE `__new_tasks` RENAME TO `tasks`;
+--> statement-breakpoint
+
+-- ── Step 4: Recreate indexes + triggers ────────────────────────────────
+CREATE INDEX `idx_tasks_status` ON `tasks` (`status`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_parent_id` ON `tasks` (`parent_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_phase` ON `tasks` (`phase`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_type` ON `tasks` (`type`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_priority` ON `tasks` (`priority`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_session_id` ON `tasks` (`session_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_pipeline_stage` ON `tasks` (`pipeline_stage`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_assignee` ON `tasks` (`assignee`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_parent_status` ON `tasks` (`parent_id`, `status`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_status_priority` ON `tasks` (`status`, `priority`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_type_phase` ON `tasks` (`type`, `phase`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_status_archive_reason` ON `tasks` (`status`, `archive_reason`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_role` ON `tasks` (`role`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_scope` ON `tasks` (`scope`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_role_status` ON `tasks` (`role`, `status`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_sentient_proposals_today`
+  ON `tasks` (date(`created_at`))
+  WHERE `labels_json` LIKE '%sentient-tier2%';
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_origin` ON `tasks` (`origin`);
+--> statement-breakpoint
+
+CREATE TRIGGER `trg_tasks_status_pipeline_insert`
+BEFORE INSERT ON `tasks`
+FOR EACH ROW
+WHEN (NEW.`status` = 'done'      AND (NEW.`pipeline_stage` IS NULL OR NEW.`pipeline_stage` NOT IN ('contribution','cancelled')))
+  OR (NEW.`status` = 'cancelled' AND (NEW.`pipeline_stage` IS NULL OR NEW.`pipeline_stage` != 'cancelled'))
+BEGIN
+  SELECT RAISE(ABORT, 'T877_INVARIANT_VIOLATION: status/pipeline_stage mismatch. status=done requires pipeline_stage IN (contribution,cancelled); status=cancelled requires pipeline_stage=cancelled.');
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `trg_tasks_status_pipeline_update`
+BEFORE UPDATE OF `status`, `pipeline_stage` ON `tasks`
+FOR EACH ROW
+WHEN (NEW.`status` = 'done'      AND (NEW.`pipeline_stage` IS NULL OR NEW.`pipeline_stage` NOT IN ('contribution','cancelled')))
+  OR (NEW.`status` = 'cancelled' AND (NEW.`pipeline_stage` IS NULL OR NEW.`pipeline_stage` != 'cancelled'))
+BEGIN
+  SELECT RAISE(ABORT, 'T877_INVARIANT_VIOLATION: status/pipeline_stage mismatch. status=done requires pipeline_stage IN (contribution,cancelled); status=cancelled requires pipeline_stage=cancelled.');
+END;
+--> statement-breakpoint
+
+PRAGMA foreign_keys = ON;

--- a/packages/core/src/orchestrate/__tests__/orchestrate-plan.test.ts
+++ b/packages/core/src/orchestrate/__tests__/orchestrate-plan.test.ts
@@ -91,13 +91,17 @@ const EPIC_TASKS: Array<Record<string, unknown>> = [
 ];
 
 // Non-epic task (for E_VALIDATION test).
+// T10329: `type` value must be a canonical TaskType (saga|epic|task|subtask)
+// to satisfy the SQL CHECK constraint added by 20260523213708_t10277-saga-tasktype.
+// 'task' is a non-epic value and still triggers the E_VALIDATION path under
+// orchestratePlan because the planner only accepts epics.
 const LEAF_TASK: Record<string, unknown> = {
   id: 'T610',
   title: 'Leaf task',
   description: 'No children, not an epic',
   status: 'pending',
   priority: 'medium',
-  type: 'feature',
+  type: 'task',
   files: ['packages/core/src/c.ts'],
   createdAt: ISO,
   updatedAt: ISO,

--- a/packages/core/src/store/__tests__/t10277-saga-tasktype.test.ts
+++ b/packages/core/src/store/__tests__/t10277-saga-tasktype.test.ts
@@ -1,0 +1,409 @@
+/**
+ * T10329 (Saga T10326 W1.B / Epic T10277) — saga TaskType migration regression lock.
+ *
+ * Validates the invariants of `20260523213708_t10277-saga-tasktype`:
+ *
+ *   1. Forward migration adds a CHECK constraint on `tasks.type` enumerating
+ *      ('saga','epic','task','subtask') and an I5 CHECK enforcing
+ *      `type != 'saga' OR parent_id IS NULL` (ADR-073 §1.2 I5).
+ *   2. Rows matching the pre-T10329 saga encoding (`type='epic' AND
+ *      parent_id IS NULL AND 'saga' IN labels_json`) are flipped to
+ *      `type='saga'` AND the 'saga' label is stripped from labels_json.
+ *   3. Re-applying the migration is a no-op (idempotent).
+ *   4. The revert script restores byte-identical row state for fixtures
+ *      that seed 'saga' as the first label (the conventional encoding).
+ *   5. The new CHECK on `(type='saga' implies parent_id IS NULL)` rejects
+ *      inserts that violate I5 at the storage layer.
+ *
+ * @task T10329
+ * @epic T10277
+ * @saga T10326
+ * @see .cleo/adrs/ADR-083-saga-as-tasktype.md §2.5
+ * @see .cleo/adrs/ADR-073-above-epic-naming.md §1.2 I5
+ * @see packages/core/migrations/drizzle-tasks/20260523213708_t10277-saga-tasktype/
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (path: string) => import('node:sqlite').DatabaseSync;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const MIGRATION_DIR = '20260523213708_t10277-saga-tasktype';
+
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+function readSql(name: 'migration.sql' | 'revert.sql'): string {
+  return readFileSync(join(migrationsDir(), MIGRATION_DIR, name), 'utf-8');
+}
+
+function runStatements(nativeDb: import('node:sqlite').DatabaseSync, sql: string): void {
+  const statements = sql.split('--> statement-breakpoint');
+  for (const stmt of statements) {
+    const trimmed = stmt.trim();
+    if (!trimmed) continue;
+    nativeDb.exec(trimmed);
+  }
+}
+
+/**
+ * Materialise the pre-T10329 `tasks` schema by hand. We model only the
+ * columns + constraints that exist at the post-T1899 baseline; this
+ * mirrors what a freshly-applied migration chain produces up to (but
+ * not including) T10329.
+ *
+ * The `sessions` table is needed for the FK reference to compile; we
+ * elide its full shape because the migration does not touch it.
+ *
+ * @internal
+ */
+function applyPreT10329Schema(dbPath: string): import('node:sqlite').DatabaseSync {
+  const nativeDb = new DatabaseSync(dbPath);
+  // Sessions stub — minimum for the FK target to exist.
+  nativeDb.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY
+    );
+
+    CREATE TABLE tasks (
+      id text PRIMARY KEY,
+      title text NOT NULL,
+      description text,
+      status text DEFAULT 'pending' NOT NULL,
+      priority text DEFAULT 'medium' NOT NULL,
+      type text,
+      parent_id text,
+      phase text,
+      size text,
+      position integer,
+      position_version integer DEFAULT 0,
+      labels_json text DEFAULT '[]',
+      notes_json text DEFAULT '[]',
+      acceptance_json text DEFAULT '[]',
+      files_json text DEFAULT '[]',
+      origin text,
+      blocked_by text,
+      epic_lifecycle text,
+      no_auto_complete integer,
+      created_at text DEFAULT (datetime('now')) NOT NULL,
+      updated_at text,
+      completed_at text,
+      cancelled_at text,
+      cancellation_reason text,
+      archived_at text,
+      archive_reason text CHECK (
+        archive_reason IS NULL OR archive_reason IN (
+          'verified','reconciled','superseded','shadowed','cancelled','completed-unverified'
+        )
+      ),
+      cycle_time_days integer,
+      verification_json text,
+      created_by text,
+      modified_by text,
+      session_id text,
+      pipeline_stage text,
+      assignee text,
+      ivtr_state text,
+      role TEXT NOT NULL DEFAULT 'work'
+        CHECK (role IN ('work','research','experiment','bug','spike','release')),
+      scope TEXT NOT NULL DEFAULT 'feature'
+        CHECK (scope IN ('project','feature','unit')),
+      severity TEXT
+        CHECK (severity IS NULL OR severity IN ('P0','P1','P2','P3')),
+      CONSTRAINT fk_tasks_parent_id FOREIGN KEY (parent_id) REFERENCES tasks(id) ON DELETE SET NULL,
+      CONSTRAINT fk_tasks_session_id FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE SET NULL
+    );
+  `);
+  return nativeDb;
+}
+
+type SagaSeed = {
+  id: string;
+  title: string;
+  labels: string[];
+};
+
+/**
+ * Seed five canonical saga rows in the pre-T10329 encoding:
+ *   type='epic', parent_id=NULL, labels_json starts with 'saga'.
+ *
+ * Putting 'saga' at index 0 lets the revert (which PREPENDs the saga
+ * label) restore byte-identical labels_json.
+ */
+const SAGA_FIXTURES: ReadonlyArray<SagaSeed> = [
+  { id: 'SG-001', title: 'Saga One', labels: ['saga'] },
+  { id: 'SG-002', title: 'Saga Two', labels: ['saga', 'arch'] },
+  { id: 'SG-003', title: 'Saga Three', labels: ['saga', 'arch', 'foundation'] },
+  { id: 'SG-004', title: 'Saga Four', labels: ['saga', 'release-theme'] },
+  { id: 'SG-005', title: 'Saga Five', labels: ['saga', 'a', 'b', 'c'] },
+];
+
+/** Non-saga control rows that must round-trip untouched. */
+const CONTROL_FIXTURES = [
+  {
+    id: 'E-001',
+    title: 'Plain Epic',
+    type: 'epic',
+    parent_id: null,
+    labels: ['foundation'],
+  },
+  {
+    id: 'T-001',
+    title: 'Plain Task',
+    type: 'task',
+    parent_id: 'E-001',
+    labels: ['work'],
+  },
+  // An epic that happens to be a CHILD epic — must NOT be promoted to saga
+  // even if it has 'saga' in its labels (parent_id is non-null).
+  {
+    id: 'E-002',
+    title: 'Child Epic with stray saga label',
+    type: 'epic',
+    parent_id: 'E-001',
+    labels: ['saga', 'misc'],
+  },
+] as const;
+
+function seedFixtures(nativeDb: import('node:sqlite').DatabaseSync): void {
+  // Insert in order — children reference parents, so parents first.
+  const insert = nativeDb.prepare(`
+    INSERT INTO tasks (id, title, type, parent_id, labels_json, status, priority, created_at)
+    VALUES (?, ?, ?, ?, ?, 'pending', 'medium', '2026-05-23T00:00:00Z')
+  `);
+  // Sagas (no parent).
+  for (const s of SAGA_FIXTURES) {
+    insert.run(s.id, s.title, 'epic', null, JSON.stringify(s.labels));
+  }
+  // Controls — order matters for FK: E-001 first.
+  for (const c of CONTROL_FIXTURES) {
+    insert.run(c.id, c.title, c.type, c.parent_id, JSON.stringify(c.labels));
+  }
+}
+
+type Snapshot = Map<string, Record<string, unknown>>;
+
+/**
+ * Capture every column of every row in `tasks`, keyed by id. Used to
+ * compare pre-migration vs post-revert state for byte-identical assertion.
+ */
+function snapshotTasks(nativeDb: import('node:sqlite').DatabaseSync): Snapshot {
+  const rows = nativeDb.prepare('SELECT * FROM tasks ORDER BY id').all() as Array<
+    Record<string, unknown>
+  >;
+  const out: Snapshot = new Map();
+  for (const r of rows) {
+    out.set(String(r.id), { ...r });
+  }
+  return out;
+}
+
+describe('T10329 saga TaskType migration', () => {
+  let tempDir: string;
+  let nativeDb: import('node:sqlite').DatabaseSync;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-t10329-mig-'));
+    nativeDb = applyPreT10329Schema(join(tempDir, 'tasks.db'));
+    seedFixtures(nativeDb);
+  });
+
+  afterEach(() => {
+    try {
+      nativeDb.close();
+    } catch {
+      // already closed
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('forward: promotes label-encoded sagas to type=saga + strips the saga label', () => {
+    runStatements(nativeDb, readSql('migration.sql'));
+
+    for (const s of SAGA_FIXTURES) {
+      const row = nativeDb
+        .prepare('SELECT type, labels_json, parent_id FROM tasks WHERE id = ?')
+        .get(s.id) as { type: string; labels_json: string; parent_id: string | null };
+      expect(row.type).toBe('saga');
+      expect(row.parent_id).toBeNull();
+      const labels = JSON.parse(row.labels_json) as string[];
+      expect(labels).not.toContain('saga');
+      // The non-saga labels must be preserved verbatim in original order.
+      const expectedRest = s.labels.filter((l) => l !== 'saga');
+      expect(labels).toEqual(expectedRest);
+    }
+  });
+
+  it('forward: leaves non-saga rows untouched (controls)', () => {
+    runStatements(nativeDb, readSql('migration.sql'));
+
+    const e1 = nativeDb
+      .prepare('SELECT type, labels_json, parent_id FROM tasks WHERE id = ?')
+      .get('E-001') as { type: string; labels_json: string; parent_id: string | null };
+    expect(e1.type).toBe('epic');
+    expect(JSON.parse(e1.labels_json)).toEqual(['foundation']);
+    expect(e1.parent_id).toBeNull();
+
+    const t1 = nativeDb
+      .prepare('SELECT type, labels_json, parent_id FROM tasks WHERE id = ?')
+      .get('T-001') as { type: string; labels_json: string; parent_id: string | null };
+    expect(t1.type).toBe('task');
+    expect(JSON.parse(t1.labels_json)).toEqual(['work']);
+    expect(t1.parent_id).toBe('E-001');
+
+    // Child epic with a stray 'saga' label MUST NOT be promoted because it
+    // has a non-null parent_id. The label is also preserved (we only strip
+    // it from genuine promotions).
+    const e2 = nativeDb
+      .prepare('SELECT type, labels_json, parent_id FROM tasks WHERE id = ?')
+      .get('E-002') as { type: string; labels_json: string; parent_id: string | null };
+    expect(e2.type).toBe('epic');
+    expect(JSON.parse(e2.labels_json)).toEqual(['saga', 'misc']);
+    expect(e2.parent_id).toBe('E-001');
+  });
+
+  it('round-trip: up then down restores byte-identical row state', () => {
+    const before = snapshotTasks(nativeDb);
+
+    runStatements(nativeDb, readSql('migration.sql'));
+    // Sanity — sagas are promoted in the middle state.
+    expect(
+      (
+        nativeDb.prepare("SELECT COUNT(*) AS n FROM tasks WHERE type = 'saga'").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(SAGA_FIXTURES.length);
+
+    runStatements(nativeDb, readSql('revert.sql'));
+    const after = snapshotTasks(nativeDb);
+
+    expect(after.size).toBe(before.size);
+    for (const [id, beforeRow] of before) {
+      const afterRow = after.get(id);
+      expect(afterRow, `row ${id} missing post-revert`).toBeDefined();
+      // Every column must match byte-for-byte.
+      expect(afterRow).toEqual(beforeRow);
+    }
+  });
+
+  it('idempotent: re-running the forward migration is a no-op', () => {
+    runStatements(nativeDb, readSql('migration.sql'));
+    const afterFirst = snapshotTasks(nativeDb);
+
+    // Drizzle would skip the table rebuild on replay (journal hash match);
+    // we cannot rerun the CREATE TABLE __new_tasks because tasks already
+    // has the new shape. Test instead that the DATA-mutation steps (3+4)
+    // are individually idempotent: applying just those statements again
+    // must not change any row.
+    const sql = readSql('migration.sql');
+    // Extract only the saga-promotion UPDATEs (Step 3 + Step 4). After
+    // splitting on the statement breakpoint marker, each chunk contains
+    // a leading SQL-comment block (`-- ── Step N …`) followed by the
+    // actual DML. We strip comment lines before pattern-matching.
+    const stripComments = (s: string): string =>
+      s
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('--'))
+        .join('\n')
+        .trim();
+    const dataMutations = sql
+      .split('--> statement-breakpoint')
+      .map(stripComments)
+      .filter((s) => /^UPDATE\s+`tasks`/i.test(s))
+      .join(';\n');
+    expect(dataMutations).toContain("SET `type` = 'saga'");
+    expect(dataMutations).toContain('labels_json');
+
+    nativeDb.exec(dataMutations);
+    const afterSecond = snapshotTasks(nativeDb);
+
+    expect(afterSecond.size).toBe(afterFirst.size);
+    for (const [id, firstRow] of afterFirst) {
+      expect(afterSecond.get(id)).toEqual(firstRow);
+    }
+  });
+
+  it('I5 CHECK: rejects insert of type=saga with non-null parent_id', () => {
+    runStatements(nativeDb, readSql('migration.sql'));
+
+    // Seed a candidate parent first so the FK target exists.
+    nativeDb.exec(`
+      INSERT INTO tasks (id, title, type, parent_id, status, priority, created_at)
+      VALUES ('SG-PARENT', 'parent saga', 'saga', NULL, 'pending', 'medium', '2026-05-23');
+    `);
+
+    // Attempting to insert a saga with a non-null parent_id must fail the
+    // I5 CHECK constraint.
+    expect(() => {
+      nativeDb.exec(`
+        INSERT INTO tasks (id, title, type, parent_id, status, priority, created_at)
+        VALUES ('SG-CHILD', 'illegal child saga', 'saga', 'SG-PARENT', 'pending', 'medium', '2026-05-23');
+      `);
+    }).toThrow(/CHECK constraint failed.*chk_tasks_saga_no_parent|CHECK constraint failed/i);
+  });
+
+  it('ENUM CHECK: rejects insert of type with an unknown value', () => {
+    runStatements(nativeDb, readSql('migration.sql'));
+
+    expect(() => {
+      nativeDb.exec(`
+        INSERT INTO tasks (id, title, type, parent_id, status, priority, created_at)
+        VALUES ('X-001', 'bogus', 'kanban', NULL, 'pending', 'medium', '2026-05-23');
+      `);
+    }).toThrow(/CHECK constraint failed/i);
+  });
+
+  it('ENUM CHECK: permits NULL type (legacy compatibility)', () => {
+    runStatements(nativeDb, readSql('migration.sql'));
+
+    // Some rows historically have NULL type — the CHECK allows that.
+    expect(() => {
+      nativeDb.exec(`
+        INSERT INTO tasks (id, title, type, parent_id, status, priority, created_at)
+        VALUES ('LEGACY-001', 'no type', NULL, NULL, 'pending', 'medium', '2026-05-23');
+      `);
+    }).not.toThrow();
+  });
+
+  it('forward: tolerates malformed labels_json without aborting', () => {
+    // Insert a saga-candidate with malformed labels (json_valid returns 0).
+    // The migration's json_valid() guard must skip it rather than fail.
+    nativeDb.exec(`
+      INSERT INTO tasks (id, title, type, parent_id, labels_json, status, priority, created_at)
+      VALUES ('BAD-001', 'malformed labels', 'epic', NULL, 'not-json{{', 'pending', 'medium', '2026-05-23');
+    `);
+
+    expect(() => runStatements(nativeDb, readSql('migration.sql'))).not.toThrow();
+
+    const row = nativeDb
+      .prepare('SELECT type, labels_json FROM tasks WHERE id = ?')
+      .get('BAD-001') as { type: string; labels_json: string };
+    // Type stays 'epic' (the guard skipped it); labels_json preserved verbatim.
+    expect(row.type).toBe('epic');
+    expect(row.labels_json).toBe('not-json{{');
+  });
+});
+
+// Migration files are read via fs at runtime so changes to the SQL are
+// always picked up by this test without rebuilding.

--- a/packages/core/src/store/schema/tasks.ts
+++ b/packages/core/src/store/schema/tasks.ts
@@ -34,15 +34,21 @@ export const TASK_PRIORITIES = ['critical', 'high', 'medium', 'low'] as const;
 /**
  * Task types matching DB CHECK constraint on tasks.type.
  *
- * Per ADR-083 §2.5, `'saga'` is a first-class tier discriminator above Epic.
- * The DB CHECK-constraint migration to accept `'saga'` is tracked separately
- * under Saga T10326 W1.B (T10329); this constant array mirrors the contracts
- * SSoT (`packages/contracts/src/task.ts` line 45) so Drizzle's row-type
- * narrowing stays aligned across the codebase.
+ * Per ADR-083 §2.5, `'saga'` is a first-class tier discriminator above
+ * Epic. The contracts SSoT (`packages/contracts/src/task.ts` line 45)
+ * was widened to include `'saga'` by T10328; this constant mirrors it
+ * so Drizzle's row-type narrowing stays aligned across the codebase.
+ *
+ * The DB-layer CHECK constraint enforcing this enum (plus the ADR-073
+ * §1.2 I5 invariant `CHECK (type != 'saga' OR parent_id IS NULL)`) is
+ * installed by `20260523213708_t10277-saga-tasktype/migration.sql`
+ * (T10329, Saga T10326 W1.B).
  *
  * @adr ADR-083 §2.5
+ * @adr ADR-073 §1.2 I5
  * @saga T10326
  * @task T10328
+ * @task T10329
  */
 export const TASK_TYPES = ['saga', 'epic', 'task', 'subtask'] as const;
 


### PR DESCRIPTION
## Summary
- Widens TASK_TYPES enum to ['saga','epic','task','subtask']
- Reversible migration: type='epic' AND label='saga' → type='saga'
- CHECK constraint enforces ADR-073 I5 (saga.parent_id IS NULL)
- Round-trip test proves byte-identical reversibility for 5 fixtures
- Wave 1B of SAGA T10326 (parallel with W1.A T10328)

## Test plan
- [x] pnpm --filter @cleocode/core run build green
- [x] reversibility test green (up → down → byte-identical)
- [x] idempotent re-up test green
- [x] CHECK constraint blocks saga with non-null parent_id

Closes T10329
Saga: T10326
Refs: ADR-083 §2.5, ADR-073 §1.2 I5