### PR TITLE
feat(T10392): central slug allocator chokepoint (E1.1)

### DIFF
--- a/.changeset/T10392-e1-slug-allocator.md
+++ b/.changeset/T10392-e1-slug-allocator.md
@@ -1,0 +1,37 @@
+---
+id: t10392-e1-slug-allocator
+tasks: [T10392]
+kind: feat
+summary: "T10392 E1.1: central slug allocator chokepoint"
+---
+
+Introduces `packages/core/src/docs/slug-allocator.ts:reserveSlug` — the
+chokepoint module that every attachment-slug writer (`cleo docs add`,
+`cleo changeset add`, future writers) MUST call BEFORE invoking
+`attachmentStore.put({ slug })`.
+
+The allocator:
+
+- Normalises slugs to canonical kebab-case via {@link normalizeSlug}.
+- Acquires a per-slug in-process Mutex so concurrent reservations
+  serialise within a single CLEO process.
+- Probes the `attachments` table for an existing row holding the slug.
+- Returns `{ ok: true, normalizedSlug }` on a free slug, or
+  `{ ok: false, code: 'E_SLUG_RESERVED', suggestions }` on collision —
+  suggestions are derived via the shared `deriveSlugSuggestions` helper
+  so the shape matches `SlugCollisionError.suggestions`.
+- Releases the per-slug lock BEFORE any caller acquires the global
+  write lock — no deadlock between the two locks is possible because
+  the allocator never escalates to the write lock.
+
+`attachmentStore.put` adds a runtime assert (opt-in via
+`CLEO_STRICT_SLUG_ALLOCATOR=1` in this PR; strict default flipped on by
+T10386 / T10388) that throws `SlugNotReservedByAllocatorError` if a
+writer attempts to write a slug that was not first reserved.
+
+Closes the slug-collision class root cause uncovered by the T10294
+spike (PR #576): two writers reaching the constraint through different
+code paths and surfacing different envelopes for the same conflict.
+
+Foundation for the T-E1.2 / T-E1.3 writer-wiring tasks under Saga
+T10288 (SG-DOCS-INTEGRITY) Epic T10289 (E1-DOCS-SLUG-NAMESPACE).

--- a/packages/core/src/docs/__tests__/slug-allocator.test.ts
+++ b/packages/core/src/docs/__tests__/slug-allocator.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for the central slug allocator chokepoint (T10392).
+ *
+ * Each test uses an isolated temporary `.cleo/` so the tasks.db singleton is
+ * reset between runs (same pattern as attachment-slug-type.test.ts).
+ *
+ * @task T10392
+ * @epic T10289
+ * @saga T10288
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let tempDir: string;
+
+describe('reserveSlug (central allocator chokepoint)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-slug-alloc-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+
+    const { _resetSlugAllocatorState_TESTING_ONLY } = await import('../slug-allocator.js');
+    _resetSlugAllocatorState_TESTING_ONLY();
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+    const { _resetSlugAllocatorState_TESTING_ONLY } = await import('../slug-allocator.js');
+    _resetSlugAllocatorState_TESTING_ONLY();
+    delete process.env['CLEO_DIR'];
+    delete process.env['CLEO_STRICT_SLUG_ALLOCATOR'];
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('reserves a free slug and returns ok with normalised slug', async () => {
+    const { reserveSlug } = await import('../slug-allocator.js');
+
+    const result = await reserveSlug('changeset', 'foo');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.normalizedSlug).toBe('foo');
+    }
+  });
+
+  it('returns E_SLUG_RESERVED with 3 suggestions when slug is in-process reserved', async () => {
+    const { reserveSlug } = await import('../slug-allocator.js');
+
+    const first = await reserveSlug('changeset', 'shared');
+    expect(first.ok).toBe(true);
+
+    const second = await reserveSlug('changeset', 'shared');
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.code).toBe('E_SLUG_RESERVED');
+      expect(second.suggestions).toHaveLength(3);
+      for (const s of second.suggestions) {
+        expect(typeof s).toBe('string');
+        expect(s.length).toBeGreaterThan(0);
+      }
+      // Suggestions must be distinct.
+      expect(new Set(second.suggestions).size).toBe(3);
+    }
+  });
+
+  it('returns E_SLUG_RESERVED when slug exists in DB but not in reserved set', async () => {
+    const { reserveSlug } = await import('../slug-allocator.js');
+    const { createAttachmentStore } = await import('../../store/attachment-store.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    // Seed the DB with a slug WITHOUT going through the allocator (simulates
+    // a row left over from a previous CLI invocation in a different process).
+    const store = createAttachmentStore();
+    await store.put(
+      Buffer.from('seed content', 'utf-8'),
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: 12 },
+      'task',
+      'T001',
+      'test',
+      undefined,
+      { slug: 'db-occupied' },
+    );
+
+    const result = await reserveSlug('changeset', 'db-occupied');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('E_SLUG_RESERVED');
+      expect(result.suggestions).toHaveLength(3);
+    }
+  });
+
+  it('normalises mixed-case + non-kebab input to canonical kebab-case', async () => {
+    const { reserveSlug, normalizeSlug } = await import('../slug-allocator.js');
+
+    expect(normalizeSlug('Foo-Bar')).toBe('foo-bar');
+    expect(normalizeSlug('My  Doc.Title')).toBe('my-doc-title');
+    expect(normalizeSlug('  --leading-trailing--  ')).toBe('leading-trailing');
+
+    const result = await reserveSlug('research', 'Foo-Bar');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.normalizedSlug).toBe('foo-bar');
+    }
+
+    // Second call with a different casing of the SAME normalised form must collide.
+    const second = await reserveSlug('research', 'FOO-BAR');
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.code).toBe('E_SLUG_RESERVED');
+    }
+  });
+
+  it('serialises concurrent contention — exactly one OK, the rest E_SLUG_RESERVED', async () => {
+    const { reserveSlug } = await import('../slug-allocator.js');
+
+    const results = await Promise.all([
+      reserveSlug('changeset', 'concurrent'),
+      reserveSlug('changeset', 'concurrent'),
+      reserveSlug('changeset', 'concurrent'),
+    ]);
+
+    const okCount = results.filter((r) => r.ok).length;
+    const errCount = results.filter((r) => !r.ok).length;
+
+    expect(okCount).toBe(1);
+    expect(errCount).toBe(2);
+
+    for (const r of results) {
+      if (!r.ok) {
+        expect(r.code).toBe('E_SLUG_RESERVED');
+        expect(r.suggestions).toHaveLength(3);
+      }
+    }
+  });
+
+  it('treats slugs as a GLOBAL namespace across DocKinds (per E1.5 decision T10390)', async () => {
+    const { reserveSlug } = await import('../slug-allocator.js');
+
+    const first = await reserveSlug('changeset', 'cross-kind');
+    expect(first.ok).toBe(true);
+
+    // Different kind, same slug — must collide because the namespace is global.
+    const second = await reserveSlug('research', 'cross-kind');
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.code).toBe('E_SLUG_RESERVED');
+    }
+  });
+
+  it('releaseReservedSlug allows a subsequent reservation to succeed (abort path)', async () => {
+    const { reserveSlug, releaseReservedSlug } = await import('../slug-allocator.js');
+
+    const first = await reserveSlug('changeset', 'aborted');
+    expect(first.ok).toBe(true);
+
+    // Caller decides not to proceed and explicitly releases.
+    releaseReservedSlug('aborted');
+
+    // Next reservation must succeed.
+    const second = await reserveSlug('changeset', 'aborted');
+    expect(second.ok).toBe(true);
+  });
+
+  it('isSlugReserved reflects the reservation state', async () => {
+    const { reserveSlug, isSlugReserved, releaseReservedSlug } = await import(
+      '../slug-allocator.js'
+    );
+
+    expect(isSlugReserved('checkstate')).toBe(false);
+
+    const result = await reserveSlug('changeset', 'checkstate');
+    expect(result.ok).toBe(true);
+    expect(isSlugReserved('checkstate')).toBe(true);
+
+    releaseReservedSlug('checkstate');
+    expect(isSlugReserved('checkstate')).toBe(false);
+  });
+});
+
+describe('attachmentStore.put runtime assert (T10392 chokepoint enforcement)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-slug-assert-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+    process.env['CLEO_STRICT_SLUG_ALLOCATOR'] = '1';
+
+    const { _resetSlugAllocatorState_TESTING_ONLY } = await import('../slug-allocator.js');
+    _resetSlugAllocatorState_TESTING_ONLY();
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+    const { _resetSlugAllocatorState_TESTING_ONLY } = await import('../slug-allocator.js');
+    _resetSlugAllocatorState_TESTING_ONLY();
+    delete process.env['CLEO_DIR'];
+    delete process.env['CLEO_STRICT_SLUG_ALLOCATOR'];
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('put({ slug }) without prior reserveSlug throws SlugNotReservedByAllocatorError', async () => {
+    const { createAttachmentStore, SlugNotReservedByAllocatorError } = await import(
+      '../../store/attachment-store.js'
+    );
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStore();
+    const bytes = Buffer.from('chokepoint test', 'utf-8');
+
+    await expect(
+      store.put(
+        bytes,
+        { kind: 'blob', storageKey: '', mime: 'text/plain', size: bytes.length },
+        'task',
+        'T001',
+        'test',
+        undefined,
+        { slug: 'unreserved' },
+      ),
+    ).rejects.toBeInstanceOf(SlugNotReservedByAllocatorError);
+  });
+
+  it('put({ slug }) AFTER reserveSlug succeeds and consumes the reservation', async () => {
+    const { createAttachmentStore } = await import('../../store/attachment-store.js');
+    const { reserveSlug, isSlugReserved } = await import('../slug-allocator.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    const reserved = await reserveSlug('changeset', 'happy-path');
+    expect(reserved.ok).toBe(true);
+    expect(isSlugReserved('happy-path')).toBe(true);
+
+    const store = createAttachmentStore();
+    const bytes = Buffer.from('happy path bytes', 'utf-8');
+    const meta = await store.put(
+      bytes,
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: bytes.length },
+      'task',
+      'T001',
+      'test',
+      undefined,
+      { slug: 'happy-path' },
+    );
+
+    expect(meta.id).toBeTruthy();
+    // Reservation should have been consumed by put().
+    expect(isSlugReserved('happy-path')).toBe(false);
+  });
+
+  it('put() without a slug never trips the allocator assert (slugless callers unaffected)', async () => {
+    const { createAttachmentStore } = await import('../../store/attachment-store.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStore();
+    const bytes = Buffer.from('no slug here', 'utf-8');
+
+    // No `extras` argument — must succeed even with strict mode on.
+    const meta = await store.put(
+      bytes,
+      { kind: 'blob', storageKey: '', mime: 'text/plain', size: bytes.length },
+      'task',
+      'T002',
+      'test',
+    );
+    expect(meta.id).toBeTruthy();
+  });
+});

--- a/packages/core/src/docs/slug-allocator.ts
+++ b/packages/core/src/docs/slug-allocator.ts
@@ -1,0 +1,340 @@
+/**
+ * Central slug allocator chokepoint for the docs SSoT.
+ *
+ * ## Why this module exists
+ *
+ * Before this module, slug uniqueness was enforced LATE — inside the BEGIN
+ * IMMEDIATE transaction at {@link
+ * https://github.com/kryptobaseddev/cleocode/blob/main/packages/core/src/store/attachment-store.ts
+ * | `attachmentStore.put`} via a `SELECT ... WHERE slug = ?` probe and the
+ * `uniq_attachments_slug` partial UNIQUE INDEX. Both writers
+ * (`cleo docs add`, `cleo changeset add`) reached the constraint through
+ * different code paths and surfaced the same conflict through DIFFERENT
+ * envelopes. T10294 (PR #576) RCA classified this as the slug-collision class
+ * — see Decision option (c): collapse writers AND introduce a chokepoint
+ * allocator. This module is the allocator half. The writer-collapse half is
+ * delivered by T10386 / T10388 / T10393.
+ *
+ * ## Contract
+ *
+ * Every writer that intends to assign a slug to an attachment row MUST
+ * call {@link reserveSlug} BEFORE invoking `attachmentStore.put({ slug })`.
+ * The allocator:
+ *
+ *   1. Normalises the slug to canonical kebab-case (lowercase, single
+ *      hyphens, trimmed).
+ *   2. Acquires an in-process per-slug Mutex so concurrent reservations
+ *      for the same slug serialise.
+ *   3. Probes the DB for an existing row with the normalised slug.
+ *   4. If free, records the slug in an in-process "reserved" set and
+ *      returns `{ ok: true, normalizedSlug }`.
+ *   5. If taken, derives 3 suggestions via the shared {@link
+ *      ../store/attachment-store.deriveSlugSuggestions} helper (so the
+ *      suggestion shape matches `SlugCollisionError.suggestions`) and
+ *      returns `{ ok: false, code: 'E_SLUG_RESERVED', suggestions }`.
+ *
+ * `attachmentStore.put` enforces a RUNTIME ASSERT that the slug it is
+ * about to write has been reserved by this allocator. A writer that
+ * bypasses the chokepoint trips `SlugNotReservedByAllocatorError` —
+ * a programmer error that surfaces during dev/CI rather than silent
+ * envelope drift in production.
+ *
+ * The assert is **opt-in via `CLEO_STRICT_SLUG_ALLOCATOR=1`** in this
+ * T10392 PR — strict default is flipped on in T10386 / T10388 once
+ * both writers (`cleo docs add`, `cleo changeset add`) are wired.
+ * Tests in this PR set the env var explicitly to exercise the assert.
+ *
+ * ## Why in-process Mutex (NOT SQLite advisory locks)
+ *
+ * `node:sqlite` does not expose `sqlite_set_authorizer` or any equivalent
+ * advisory-lock primitive. The two options the council weighed:
+ *
+ *   (a) SQLite advisory lock via sentinel-row INSERT/DELETE — adds 2
+ *       extra round-trips per allocation, leaks rows on crash, and
+ *       still needs the in-process Mutex as the same-process backstop.
+ *
+ *   (b) **In-process `Map<slug, Mutex>` with the SQLite partial UNIQUE
+ *       INDEX as the cross-process backstop**.
+ *
+ * We chose (b) because:
+ *   - Within a single CLEO process the Mutex map is sufficient — concurrent
+ *     `reserveSlug` calls on the same slug serialise correctly.
+ *   - Across processes the `uniq_attachments_slug` partial UNIQUE INDEX
+ *     is the hard backstop. A losing process gets a DB-level constraint
+ *     violation at `put`-time, which the writer surfaces as the same
+ *     `SlugCollisionError` envelope the allocator emits — uniform shape
+ *     regardless of which layer caught it.
+ *   - CLEO writers are dominated by a SINGLE process at a time (CLI verb
+ *     dispatch, sentient daemon, IVTR worker). Cross-process write
+ *     contention is rare and the UNIQUE INDEX backstop handles it.
+ *
+ * ## Lock ordering (deadlock prevention)
+ *
+ * Per T10392 implementation contract:
+ *
+ *   1. `reserveSlug` MUST be called BEFORE `withWriteLock` in
+ *      `attachmentStore.put`. The allocator holds the per-slug Mutex
+ *      only for the duration of its DB probe; it releases BEFORE the
+ *      caller acquires the global write lock.
+ *
+ *   2. The allocator NEVER acquires the global write lock. There is
+ *      therefore no chance of deadlock between the per-slug Mutex and
+ *      the global write lock.
+ *
+ *   3. The reserved set is consulted INSIDE `attachmentStore.put` after
+ *      the global write lock is acquired — a cheap set lookup, no lock
+ *      escalation.
+ *
+ * ## Global namespace (per E1.5 decision T10390)
+ *
+ * Slugs are allocated in a GLOBAL namespace across all DocKinds. The
+ * `uniq_attachments_slug` partial UNIQUE INDEX (migration
+ * `20260519000001`) keys on `slug` alone — NOT `(kind, slug)`. The
+ * allocator matches that: `reserveSlug('changeset', 'foo')` followed by
+ * `reserveSlug('research', 'foo')` returns `E_SLUG_RESERVED` for the
+ * second call. The `kind` argument is retained for future per-kind
+ * extensions (and for richer suggestion derivation) but does NOT
+ * partition the namespace.
+ *
+ * @task T10392
+ * @epic T10289
+ * @saga T10288
+ * @adr ADR-076 (canon routing), ADR-083 (Cleo persona)
+ */
+
+import type { BuiltinDocKind } from '@cleocode/contracts';
+import { deriveSlugSuggestionsForAllocator } from '../store/attachment-store.js';
+import { getDb } from '../store/sqlite.js';
+
+// ─── Public surface ───────────────────────────────────────────────────────────
+
+/**
+ * Successful reservation outcome — the slug is now reserved in the
+ * current process and a subsequent `attachmentStore.put({ slug })` is
+ * permitted to write it.
+ */
+export interface SlugReserveOk {
+  readonly ok: true;
+  /** The normalised kebab-case form of the input slug. */
+  readonly normalizedSlug: string;
+}
+
+/**
+ * Failed reservation outcome — the slug is already taken in this project.
+ *
+ * Suggestions are derived via the shared `deriveSlugSuggestions` helper so
+ * the shape matches `SlugCollisionError.suggestions`. Always exactly 3.
+ */
+export interface SlugReserveErr {
+  readonly ok: false;
+  readonly code: 'E_SLUG_RESERVED';
+  /** Exactly 3 free alternative slugs. */
+  readonly suggestions: readonly string[];
+}
+
+/** Discriminated union returned by {@link reserveSlug}. */
+export type SlugReserveResult = SlugReserveOk | SlugReserveErr;
+
+/**
+ * Options accepted by {@link reserveSlug}.
+ *
+ * `cwd` is forwarded to `getDb(cwd)` — same convention used elsewhere in
+ * `@cleocode/core` for path resolution.
+ */
+export interface ReserveSlugOptions {
+  /** Optional working directory for `.cleo/` resolution. */
+  readonly cwd?: string;
+}
+
+// ─── Per-slug Mutex map (in-process serialisation) ────────────────────────────
+
+/**
+ * Per-slug Mutex implementation. We model each Mutex as a Promise chain
+ * keyed by the normalised slug. Acquiring the lock pushes a new tail
+ * onto the chain; releasing resolves the tail so the next waiter runs.
+ *
+ * The map is keyed by the NORMALISED slug — `Foo-Bar` and `foo-bar`
+ * share the same lock. The chain is pruned lazily when the trailing
+ * waiter finishes (so the map stays bounded by concurrent contention,
+ * not historical usage).
+ */
+const slugLockChain = new Map<string, Promise<void>>();
+
+/**
+ * Acquire the per-slug Mutex. Returns the release callback which the
+ * caller MUST invoke (always — try/finally) to let the next waiter
+ * proceed.
+ *
+ * @param normalizedSlug - The kebab-cased slug.
+ * @returns Release callback. Idempotent — calling it twice is a no-op.
+ */
+async function acquireSlugLock(normalizedSlug: string): Promise<() => void> {
+  const prev = slugLockChain.get(normalizedSlug) ?? Promise.resolve();
+  let release!: () => void;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  slugLockChain.set(normalizedSlug, next);
+  await prev;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    release();
+    // Prune the map entry if no further waiters chained on after us.
+    if (slugLockChain.get(normalizedSlug) === next) {
+      slugLockChain.delete(normalizedSlug);
+    }
+  };
+}
+
+// ─── Reserved-slug set (allocator → put handshake) ────────────────────────────
+
+/**
+ * Slugs that have been reserved by {@link reserveSlug} in this process and
+ * are awaiting a follow-up `attachmentStore.put` call. The set keys on the
+ * NORMALISED slug; writers MUST pass the normalised form to `put`.
+ *
+ * The set is process-local: it does NOT persist across CLI invocations
+ * and is NOT visible to other processes. It exists purely so
+ * `attachmentStore.put` can detect a writer that bypassed the allocator
+ * chokepoint (programmer error → throws `E_SLUG_NOT_RESERVED_BY_ALLOCATOR`).
+ *
+ * @internal
+ */
+const reservedSlugs = new Set<string>();
+
+/**
+ * Check whether the allocator has reserved `slug` in this process.
+ *
+ * Exported for use by `attachmentStore.put` (runtime assert).
+ *
+ * @internal
+ */
+export function isSlugReserved(slug: string): boolean {
+  return reservedSlugs.has(normalizeSlug(slug));
+}
+
+/**
+ * Mark a slug as consumed — typically called by `attachmentStore.put` after
+ * a successful write so the reserved set does not grow unbounded.
+ *
+ * @internal
+ */
+export function consumeReservedSlug(slug: string): void {
+  reservedSlugs.delete(normalizeSlug(slug));
+}
+
+/**
+ * Test-only escape hatch — clears the in-process reserved set + lock map.
+ *
+ * Vitest beforeEach hooks call this to ensure cross-test isolation when
+ * the same vitest worker reuses the module instance across files.
+ *
+ * @internal
+ */
+export function _resetSlugAllocatorState_TESTING_ONLY(): void {
+  reservedSlugs.clear();
+  slugLockChain.clear();
+}
+
+// ─── Slug normalisation ───────────────────────────────────────────────────────
+
+/**
+ * Normalise a free-form slug to canonical kebab-case.
+ *
+ * Steps:
+ *   1. Unicode NFKD normalise + strip combining diacritics.
+ *   2. Lowercase.
+ *   3. Replace any non-`[a-z0-9]` run with a single hyphen.
+ *   4. Trim leading/trailing hyphens.
+ *
+ * Note: This is intentionally the SAME algorithm as
+ * `packages/core/src/docs/import/slug.ts:slugify`. Inlined here to
+ * avoid a circular import (the import module already depends on
+ * attachment-store via the accessor).
+ *
+ * @param input - Raw slug from the caller.
+ * @returns Canonical kebab-case form. May be empty if input had no alphanumerics.
+ */
+export function normalizeSlug(input: string): string {
+  return input
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// ─── Main allocator entry point ───────────────────────────────────────────────
+
+/**
+ * Reserve a slug for an upcoming `attachmentStore.put` call.
+ *
+ * The reservation lives only in-process and is released either when
+ * `put` consumes it (success path) or when {@link releaseReservedSlug}
+ * is called explicitly (caller abort path). The DB-level UNIQUE INDEX
+ * remains the cross-process backstop.
+ *
+ * @param kind - The DocKind requesting the slug. Retained for future
+ *               per-kind extensions; does NOT partition the namespace
+ *               (see module-level docs §"Global namespace").
+ * @param slug - Raw slug from the caller — will be normalised.
+ * @param opts - Optional cwd for path resolution.
+ * @returns Discriminated union: `{ ok: true }` or `{ ok: false, code, suggestions }`.
+ * @task T10392
+ */
+export async function reserveSlug(
+  kind: BuiltinDocKind | string,
+  slug: string,
+  opts?: ReserveSlugOptions,
+): Promise<SlugReserveResult> {
+  void kind; // Reserved for future per-kind suggestion derivation (T10390).
+  const normalizedSlug = normalizeSlug(slug);
+
+  // Acquire the per-slug Mutex. Released inside the try/finally below.
+  const releaseLock = await acquireSlugLock(normalizedSlug);
+
+  try {
+    // Same-process check first — another in-flight reservation already
+    // claimed this slug.
+    if (reservedSlugs.has(normalizedSlug)) {
+      const db = await getDb(opts?.cwd);
+      const suggestions = await deriveSlugSuggestionsForAllocator(db, normalizedSlug);
+      return { ok: false, code: 'E_SLUG_RESERVED', suggestions };
+    }
+
+    // Probe the DB for an existing row holding this slug.
+    const db = await getDb(opts?.cwd);
+    const { attachments } = await import('../store/tasks-schema.js');
+    const { eq } = await import('drizzle-orm');
+    const conflict = await db
+      .select()
+      .from(attachments)
+      .where(eq(attachments.slug, normalizedSlug))
+      .get();
+
+    if (conflict) {
+      const suggestions = await deriveSlugSuggestionsForAllocator(db, normalizedSlug);
+      return { ok: false, code: 'E_SLUG_RESERVED', suggestions };
+    }
+
+    // Free — reserve it for the imminent `put`.
+    reservedSlugs.add(normalizedSlug);
+    return { ok: true, normalizedSlug };
+  } finally {
+    releaseLock();
+  }
+}
+
+/**
+ * Release a reserved slug without consuming it (abort path).
+ *
+ * Use when the caller decided NOT to proceed with `put` after a
+ * successful `reserveSlug`. Calling on an unreserved slug is a no-op.
+ *
+ * @param slug - The slug as passed to `reserveSlug` (will be re-normalised).
+ */
+export function releaseReservedSlug(slug: string): void {
+  reservedSlugs.delete(normalizeSlug(slug));
+}

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -248,6 +248,21 @@ export {
   tempWorktreeDirForSlug,
   validatePublishSlug,
 } from './docs/publish-pr.js';
+// Central slug allocator chokepoint (T10392 / Saga T10288 / Epic T10289)
+export type {
+  ReserveSlugOptions,
+  SlugReserveErr,
+  SlugReserveOk,
+  SlugReserveResult,
+} from './docs/slug-allocator.js';
+export {
+  _resetSlugAllocatorState_TESTING_ONLY,
+  consumeReservedSlug,
+  isSlugReserved,
+  normalizeSlug,
+  releaseReservedSlug,
+  reserveSlug,
+} from './docs/slug-allocator.js';
 // Git hooks (T1588) — project-agnostic POSIX commit-msg + pre-push T-ID enforcement
 export type {
   CleoHookName,
@@ -1115,6 +1130,7 @@ export {
   AttachmentIntegrityError,
   createAttachmentStore,
   SlugCollisionError,
+  SlugNotReservedByAllocatorError,
 } from './store/attachment-store.js';
 // Attachment store v2 — unified llmtxt/legacy wrapper (T947 Wave B)
 export type {

--- a/packages/core/src/store/attachment-store.ts
+++ b/packages/core/src/store/attachment-store.ts
@@ -80,6 +80,31 @@ export class SlugCollisionError extends Error {
 }
 
 /**
+ * Error thrown by {@link AttachmentStore.put} when a writer attempts to
+ * assign a slug that was NOT first reserved through the central
+ * {@link import('../docs/slug-allocator.js').reserveSlug} chokepoint.
+ *
+ * This is a PROGRAMMER ERROR — production CLI verbs must always call
+ * `reserveSlug` before `put({ slug })`. Surfacing the bypass at the
+ * write call protects against dual-writer drift (the bug class
+ * described in T10294 RCA and tracked under Saga T10288 / Epic T10289).
+ *
+ * @task T10392
+ * @epic T10289
+ * @saga T10288
+ */
+export class SlugNotReservedByAllocatorError extends Error {
+  constructor(public readonly slug: string) {
+    super(
+      `Slug '${slug}' was passed to attachmentStore.put() without first being reserved by ` +
+        `reserveSlug(). The slug allocator chokepoint MUST be called before any write — ` +
+        `see packages/core/src/docs/slug-allocator.ts (T10392).`,
+    );
+    this.name = 'SlugNotReservedByAllocatorError';
+  }
+}
+
+/**
  * Side-table extension for {@link AttachmentStore.put} carrying optional
  * project-scoped metadata (slug, type) that lives directly on the
  * `attachments` row rather than inside the discriminated-union JSON blob.
@@ -431,6 +456,11 @@ type DrizzleDb = Awaited<ReturnType<typeof getDb>>;
  * found. The lookup is bounded by a maximum of 32 probes per candidate so
  * a pathological dataset can never block the request.
  *
+ * Re-exported under {@link deriveSlugSuggestionsForAllocator} for the
+ * central slug allocator (T10392) so both the late-bound
+ * `SlugCollisionError` path and the early-bound `reserveSlug` path emit
+ * the SAME suggestion shape.
+ *
  * @task T9636
  */
 async function deriveSlugSuggestions(db: DrizzleDb, base: string): Promise<string[]> {
@@ -471,6 +501,30 @@ async function deriveSlugSuggestions(db: DrizzleDb, base: string): Promise<strin
   }
 
   return out.slice(0, 3);
+}
+
+/**
+ * Re-export of {@link deriveSlugSuggestions} for the central slug
+ * allocator (T10392).
+ *
+ * Lives in this module rather than the allocator so the suggestion
+ * algorithm has exactly ONE implementation. Both the late-bound
+ * `SlugCollisionError` path inside `attachmentStore.put` and the
+ * early-bound `reserveSlug` chokepoint use the same helper, so the
+ * suggestion shape is uniform regardless of which layer caught the
+ * conflict.
+ *
+ * Loose typing on `db` matches the internal `DrizzleDb` alias so
+ * cross-package consumers do not have to import drizzle types.
+ *
+ * @task T10392
+ * @internal
+ */
+export async function deriveSlugSuggestionsForAllocator(
+  db: DrizzleDb,
+  base: string,
+): Promise<string[]> {
+  return deriveSlugSuggestions(db, base);
 }
 
 /**
@@ -526,6 +580,28 @@ export function createAttachmentStore(): AttachmentStore {
         const db = await getDb(cwd);
         const nativeDb = getNativeTasksDb();
         if (!nativeDb) throw new Error('Database not initialized');
+
+        // Allocator chokepoint runtime assert (T10392) — every writer with
+        // a slug SHOULD have first called reserveSlug(). The lookup is a
+        // cheap in-process Set; SQLite UNIQUE INDEX remains the
+        // cross-process backstop.
+        //
+        // OPT-IN BEHAVIOUR: this T10392 PR introduces the allocator module
+        // but does NOT yet wire the writers — that lands in T10386 (docs
+        // add) and T10388 (changeset add). Until both wiring PRs merge,
+        // the assert is OPT-IN via the `CLEO_STRICT_SLUG_ALLOCATOR=1` env
+        // var so existing legacy writers continue to work and the wiring
+        // PRs can flip the default to strict in their own commit. The
+        // env var also lets tests exercise the assert path explicitly.
+        if (slug !== undefined && process.env['CLEO_STRICT_SLUG_ALLOCATOR'] === '1') {
+          const { isSlugReserved, consumeReservedSlug } = await import('../docs/slug-allocator.js');
+          if (!isSlugReserved(slug)) {
+            throw new SlugNotReservedByAllocatorError(slug);
+          }
+          // Consume the reservation now so retries do NOT re-trip the
+          // assert and the in-process Set does not grow unbounded.
+          consumeReservedSlug(slug);
+        }
 
         // Pre-check slug collision OUTSIDE the BEGIN IMMEDIATE window so the
         // caller receives SlugCollisionError without leaving a half-written

--- a/packages/skills/skills/ct-documentor/SKILL.md
+++ b/packages/skills/skills/ct-documentor/SKILL.md
@@ -92,7 +92,8 @@ cleo docs add T1234 docs/drafts/feature-x.md \
 - `--type` MUST be one of `spec | adr | research | handoff | note | llm-readme`.
   Pick the type by the document's purpose, not its filename.
 - `--slug` is the human-friendly retrieval handle (kebab-case). If taken the
-  CLI returns `E_SLUG_TAKEN` with 3 alternatives — pick one, do not overwrite.
+  CLI returns `E_SLUG_RESERVED` (legacy alias `E_SLUG_TAKEN`) with 3
+  alternatives — pick one, do not overwrite.
 - The owner ID (`T1234` above) auto-classifies the attachment by prefix:
   `T###` → task, `ses_*` → session, `O-*` → observation.
 
@@ -125,6 +126,30 @@ The accepted positional + named surface is enumerated in
 `cleo docs add --help` — agents MUST consult `--help` rather than guessing
 flag names. Use the `--flag=value` form (`--type=spec`) or
 `--flag value` (`--type spec`) — both are recognised.
+
+#### Slug allocation goes through ONE chokepoint (T10392 · Saga T10288)
+
+Every code path that writes an attachment with a slug — `cleo docs add`,
+`cleo changeset add`, and any future writer — MUST first call the central
+allocator at `packages/core/src/docs/slug-allocator.ts:reserveSlug` BEFORE
+invoking `attachmentStore.put({ slug })`. The allocator:
+
+1. Normalises the slug to canonical kebab-case (lowercase, trim, single
+   hyphens).
+2. Acquires a per-slug in-process Mutex so concurrent reservations
+   serialise.
+3. Returns `{ ok: false, code: 'E_SLUG_RESERVED', suggestions }` when the
+   slug is taken — uniform shape across both writers.
+
+The `attachmentStore.put` chokepoint enforces this via a runtime assert
+(`SlugNotReservedByAllocatorError`) when `CLEO_STRICT_SLUG_ALLOCATOR=1`
+is set. Strict mode becomes default once `cleo docs add` (T10386) and
+`cleo changeset add` (T10388) finish wiring through the allocator.
+
+Slugs share a GLOBAL namespace across all DocKinds — `reserveSlug('changeset',
+'foo')` followed by `reserveSlug('research', 'foo')` collides (decision
+T10390 / E1.5). Matches the `uniq_attachments_slug` partial UNIQUE INDEX in
+migration `20260519000001`.
 
 ### Publish to a git-tracked path (when the doc must live on disk)
 


### PR DESCRIPTION
## Summary

Introduces `packages/core/src/docs/slug-allocator.ts:reserveSlug` — the chokepoint module that every attachment-slug writer (`cleo docs add`, `cleo changeset add`, future writers) MUST call BEFORE invoking `attachmentStore.put({ slug })`.

- **`reserveSlug(kind, slug, opts?)`** — normalises slug, acquires per-slug in-process Mutex, probes DB for collision, returns `{ ok: true, normalizedSlug }` or `{ ok: false, code: 'E_SLUG_RESERVED', suggestions }` (3 suggestions, uniform shape with `SlugCollisionError`).
- **`attachmentStore.put` runtime assert** — when `CLEO_STRICT_SLUG_ALLOCATOR=1` is set, `put({ slug })` throws `SlugNotReservedByAllocatorError` if the slug was not first reserved. Opt-in for this PR; strict default flipped on by T10386 / T10388 once both writers are wired.
- **Shared suggestion algorithm** — re-exports `deriveSlugSuggestions` from `attachment-store.ts` so allocator and late-bound `SlugCollisionError` emit the same shape.
- **Global namespace** — slugs are NOT partitioned by kind (per E1.5 decision T10390). Matches the `uniq_attachments_slug` partial UNIQUE INDEX in migration `20260519000001`.
- **`ct-documentor` SKILL.md updated** — tier-0 same-PR drift requirement satisfied (v3.1.0 -> v3.2.0).

## Lock implementation choice

In-process `Map<slug, Mutex>` with the SQLite partial UNIQUE INDEX as the cross-process backstop. `node:sqlite` does not expose advisory-lock primitives, so SQLite-side advisory locks would require sentinel rows (extra round-trips, crash-leaked rows) — and would still need the in-process Mutex as the same-process backstop. The Mutex map serialises within a single process; the UNIQUE INDEX catches cross-process races. Rationale in the module-level docs `§"Why in-process Mutex"`.

## Lock ordering (deadlock prevention)

`reserveSlug` is called BEFORE `withWriteLock`. The allocator NEVER acquires the global write lock. No deadlock between the two locks is possible.

## Saga / Epic

- Saga: **T10288** (SG-DOCS-INTEGRITY) — Wave 1.A
- Epic: **T10289** (E1-DOCS-SLUG-NAMESPACE)
- Foundation for: T-E1.2 (T10386 `cleo docs add` wiring) + T-E1.3 (T10388 `cleo changeset add` wiring)
- RCA: closes the slug-collision class identified in T10294 spike PR #576

## Test plan

- [x] **11 new tests pass** in `packages/core/src/docs/__tests__/slug-allocator.test.ts`
  - empty DB reserve → ok + normalised slug
  - in-process re-reserve → E_SLUG_RESERVED + 3 distinct suggestions
  - DB-pre-existing slug → E_SLUG_RESERVED
  - case + non-kebab normalisation → canonical kebab form
  - concurrent `Promise.all` contention → exactly 1 OK, rest E_SLUG_RESERVED
  - cross-kind (`changeset` then `research`) → second collides (global namespace)
  - `releaseReservedSlug` allows subsequent reservation
  - `isSlugReserved` reflects state
  - `put({ slug })` without prior `reserveSlug` (strict mode) → `SlugNotReservedByAllocatorError`
  - `put({ slug })` after `reserveSlug` → consumed
  - `put()` without slug → never trips assert
- [x] **8 existing `attachment-slug-type.test.ts` tests still pass** (opt-in default preserves backwards-compat)
- [x] `pnpm biome check` clean
- [x] `pnpm run build` green (full monorepo)