### PR TITLE
T10308: orphan project-root DB detection in cleo doctor db-substrate (Saga T10281 / E1)

### DIFF
--- a/.changeset/T10308.md
+++ b/.changeset/T10308.md
@@ -1,0 +1,23 @@
+---
+id: T10308
+tasks: [T10308]
+kind: feat
+summary: "Orphan project-root DB detection in cleo doctor db-substrate (Saga T10281 / E1)"
+---
+
+Extends the `cleo doctor db-substrate` walker (T10307) with strengthened
+orphan project-root detection — the T9550 regression class. For every
+project the walker visits, it now climbs one directory level: if the
+parent carries a `.cleo/` directory that is NOT itself a legitimate CLEO
+project root (legitimacy = `project-info.json` AND `tasks.db` BOTH
+present), the parent is flagged as an orphan.
+
+When the orphan parent carries a `.cleo/.context-state.json`, the
+walker surfaces the `workspace` field as `warning.parentWorkspace` —
+attributing the orphan write to the offending sibling workspace (the
+2026-05-23 live regression case where `/mnt/projects/.cleo/` was being
+written from `/mnt/projects/awesome-skills/`).
+
+Pure additive — `DbSubstrateWarning.parentWorkspace` is optional, every
+prior consumer remains source-compatible. CLI subcommand surface is
+unchanged; warning context is enriched.

--- a/packages/cleo/src/cli/commands/__tests__/doctor-db-substrate.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/doctor-db-substrate.test.ts
@@ -33,6 +33,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 // uses the same approach).
 import {
   detectOrphanProjectRootWarning,
+  isLegitimateCleoProjectRoot,
+  readParentWorkspace,
   resolveInventoryFilePath,
   surveyDbSubstrate,
   surveyFleetDbSubstrate,
@@ -289,6 +291,134 @@ describe('doctor db-substrate (T10307)', () => {
     expect(resolveInventoryFilePath(nexusEntry, projectRoot)).toBe(
       join(cleoHomeOverride, 'nexus.db'),
     );
+  });
+
+  it('T10308: orphan warning suppressed when parent .cleo/ is a legitimate project (project-info.json + tasks.db)', async () => {
+    await import('@cleocode/paths').then(({ _resetCleoPlatformPathsCache }) =>
+      _resetCleoPlatformPathsCache(),
+    );
+    // Parent has a fully-legitimate CLEO project root — both markers
+    // present. T10308 AC2 says we MUST NOT flag this as an orphan even
+    // though `<parent>/.cleo/` exists.
+    const parentCleoDir = join(fleetRoot, '.cleo');
+    mkdirSync(parentCleoDir, { recursive: true });
+    writeFileSync(join(parentCleoDir, 'project-info.json'), JSON.stringify({ name: 'parent' }));
+    seedHealthyDb(join(parentCleoDir, 'tasks.db'));
+
+    const childProjectRoot = createProjectWithTasksDb('child');
+
+    expect(isLegitimateCleoProjectRoot(parentCleoDir)).toBe(true);
+    expect(detectOrphanProjectRootWarning(childProjectRoot)).toBeNull();
+
+    const result = surveyDbSubstrate(childProjectRoot);
+    const orphans = result.warnings.filter((w) => w.kind === 'orphan-project-root');
+    expect(orphans.length).toBe(0);
+  });
+
+  it('T10308: orphan warning still fires when parent .cleo/ has project-info.json BUT NO tasks.db', () => {
+    // Half-legitimate state — `cleo init` was started but the SQLite
+    // store never materialised, OR a stray writer dropped only
+    // project-info.json. Either case is an orphan per AC2.
+    const parentCleoDir = join(fleetRoot, '.cleo');
+    mkdirSync(parentCleoDir, { recursive: true });
+    writeFileSync(join(parentCleoDir, 'project-info.json'), JSON.stringify({ name: 'half' }));
+
+    const childProjectRoot = createProjectWithTasksDb('child');
+
+    expect(isLegitimateCleoProjectRoot(parentCleoDir)).toBe(false);
+    const warning = detectOrphanProjectRootWarning(childProjectRoot);
+    expect(warning).not.toBeNull();
+    expect(warning?.path).toBe(parentCleoDir);
+  });
+
+  it('T10308: orphan warning still fires when parent .cleo/ has tasks.db BUT NO project-info.json', () => {
+    // The other half-legitimate state — DB was opened first via an
+    // import path that bypassed `cleo init`. Still orphan per AC2.
+    const parentCleoDir = join(fleetRoot, '.cleo');
+    mkdirSync(parentCleoDir, { recursive: true });
+    seedHealthyDb(join(parentCleoDir, 'tasks.db'));
+
+    const childProjectRoot = createProjectWithTasksDb('child');
+
+    expect(isLegitimateCleoProjectRoot(parentCleoDir)).toBe(false);
+    const warning = detectOrphanProjectRootWarning(childProjectRoot);
+    expect(warning).not.toBeNull();
+    expect(warning?.path).toBe(parentCleoDir);
+  });
+
+  it('T10308: orphan warning attributes parentWorkspace from .context-state.json', () => {
+    // The 2026-05-23 live regression case: /mnt/projects/.cleo/ being
+    // written from /mnt/projects/awesome-skills/. Verifies the
+    // `parentWorkspace` field round-trips correctly.
+    const parentCleoDir = join(fleetRoot, '.cleo');
+    mkdirSync(parentCleoDir, { recursive: true });
+    writeFileSync(
+      join(parentCleoDir, '.context-state.json'),
+      JSON.stringify({ workspace: '/mnt/projects/awesome-skills' }),
+    );
+
+    const childProjectRoot = createProjectWithTasksDb('child');
+
+    const warning = detectOrphanProjectRootWarning(childProjectRoot);
+    expect(warning).not.toBeNull();
+    expect(warning?.kind).toBe('orphan-project-root');
+    expect(warning?.path).toBe(parentCleoDir);
+    expect(warning?.parentWorkspace).toBe('/mnt/projects/awesome-skills');
+
+    // Round-trips through surveyDbSubstrate too.
+    const result = surveyDbSubstrate(childProjectRoot);
+    const surveyWarning = result.warnings.find((w) => w.kind === 'orphan-project-root');
+    expect(surveyWarning?.parentWorkspace).toBe('/mnt/projects/awesome-skills');
+  });
+
+  it('T10308: parentWorkspace=null when .context-state.json is absent', () => {
+    const parentCleoDir = join(fleetRoot, '.cleo');
+    mkdirSync(parentCleoDir, { recursive: true });
+    // No .context-state.json — orphan still fires, but parentWorkspace=null.
+
+    const childProjectRoot = createProjectWithTasksDb('child');
+
+    const warning = detectOrphanProjectRootWarning(childProjectRoot);
+    expect(warning).not.toBeNull();
+    expect(warning?.parentWorkspace).toBeNull();
+  });
+
+  it('T10308: parentWorkspace=null when .context-state.json is unparseable', () => {
+    const parentCleoDir = join(fleetRoot, '.cleo');
+    mkdirSync(parentCleoDir, { recursive: true });
+    writeFileSync(join(parentCleoDir, '.context-state.json'), '{ malformed json');
+
+    const childProjectRoot = createProjectWithTasksDb('child');
+
+    expect(readParentWorkspace(parentCleoDir)).toBeNull();
+    const warning = detectOrphanProjectRootWarning(childProjectRoot);
+    expect(warning?.parentWorkspace).toBeNull();
+  });
+
+  it('T10308: parentWorkspace=null when workspace field is missing or non-string', () => {
+    const parentCleoDir = join(fleetRoot, '.cleo');
+    mkdirSync(parentCleoDir, { recursive: true });
+    writeFileSync(
+      join(parentCleoDir, '.context-state.json'),
+      JSON.stringify({ workspace: 42, other: 'data' }),
+    );
+
+    expect(readParentWorkspace(parentCleoDir)).toBeNull();
+  });
+
+  it('T10308: fleet mode suppresses orphan when fleetRoot itself is a legitimate project', () => {
+    // Fleet-mode mirror of the single-project legitimacy check. If the
+    // fleetRoot directory itself looks like a real CLEO project, we
+    // should NOT flag its .cleo/ as orphan.
+    const fleetCleoDir = join(fleetRoot, '.cleo');
+    mkdirSync(fleetCleoDir, { recursive: true });
+    writeFileSync(join(fleetCleoDir, 'project-info.json'), JSON.stringify({ name: 'root' }));
+    seedHealthyDb(join(fleetCleoDir, 'tasks.db'));
+    createProjectWithTasksDb('child-project');
+
+    const result = surveyFleetDbSubstrate(fleetRoot);
+    const orphans = result.warnings.filter((w) => w.kind === 'orphan-project-root');
+    expect(orphans.length).toBe(0);
   });
 
   it('aggregates summary counters across all inventory entries', async () => {

--- a/packages/cleo/src/cli/commands/doctor-db-substrate.ts
+++ b/packages/cleo/src/cli/commands/doctor-db-substrate.ts
@@ -45,6 +45,17 @@ const DEFAULT_FLEET_ROOT = '/mnt/projects';
  */
 function pushSubstrateWarnings(result: DbSubstrateAuditResult): void {
   for (const warning of result.warnings) {
+    // Build a base context shared by every warning kind; orphan-project-root
+    // warnings additionally carry `parentWorkspace` (T10308 attribution
+    // for the offending sibling workspace).
+    const context: Record<string, string | number | null> = {
+      kind: warning.kind,
+      path: warning.path,
+      lastWriteMs: warning.lastWriteMs,
+    };
+    if (warning.kind === 'orphan-project-root') {
+      context['parentWorkspace'] = warning.parentWorkspace ?? null;
+    }
     pushWarning({
       code:
         warning.kind === 'orphan-project-root'
@@ -52,14 +63,13 @@ function pushSubstrateWarnings(result: DbSubstrateAuditResult): void {
           : 'W_DB_SUBSTRATE_NESTED_NEXUS_DUPLICATE',
       message:
         warning.kind === 'orphan-project-root'
-          ? `Orphan project-root .cleo/ at ${warning.path} (T9550 regression class — review then remove)`
+          ? `Orphan project-root .cleo/ at ${warning.path} (T9550 regression class — review then remove)` +
+            (warning.parentWorkspace
+              ? ` — attributed to workspace: ${warning.parentWorkspace}`
+              : '')
           : `Nested-nexus duplicate at ${warning.path} (structural duplicate of the canonical flat layout)`,
       severity: 'warn',
-      context: {
-        kind: warning.kind,
-        path: warning.path,
-        lastWriteMs: warning.lastWriteMs,
-      },
+      context,
     });
   }
 }

--- a/packages/contracts/src/doctor.ts
+++ b/packages/contracts/src/doctor.ts
@@ -366,6 +366,7 @@ export type DbSubstrateWarningKind = 'orphan-project-root' | 'nested-nexus-dupli
  * One warning entry surfaced in the envelope's `meta.warnings` list.
  *
  * @task T10307
+ * @task T10308 — added `parentWorkspace` for orphan-project-root attribution.
  */
 export interface DbSubstrateWarning {
   /** Machine-readable warning class. */
@@ -377,6 +378,16 @@ export interface DbSubstrateWarning {
    * `null` when stat() threw (e.g. ephemeral race during scan).
    */
   lastWriteMs: number | null;
+  /**
+   * For `orphan-project-root` warnings only: the `workspace` field read
+   * from `<path>/.context-state.json` when present. Identifies which
+   * outside workspace last wrote into this orphan `.cleo/` directory
+   * (audit trail for the T9550 regression class). `null` when the
+   * file is absent, unreadable, or carries no `workspace` field.
+   *
+   * @task T10308
+   */
+  parentWorkspace?: string | null;
 }
 
 /**

--- a/packages/core/src/doctor/db-substrate.ts
+++ b/packages/core/src/doctor/db-substrate.ts
@@ -27,7 +27,7 @@
  * @see ADR-068 — CLEO Database Charter
  */
 
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import {
   DB_INVENTORY,
@@ -260,17 +260,118 @@ export function surveyProjectDbSubstrate(projectRoot: string): DbSubstrateProjec
 }
 
 /**
+ * Decide whether the `.cleo/` directory at `cleoDirPath` belongs to a
+ * legitimate CLEO project root.
+ *
+ * @remarks
+ * The legitimacy heuristic (T10308 AC2):
+ *
+ *   "If `<dir>/.cleo/` exists AND `<dir>/.cleo/project-info.json` AND
+ *    `<dir>/.cleo/tasks.db` BOTH exist, the directory IS a legitimate
+ *    project root. Otherwise it's an orphan."
+ *
+ * Both markers must be present for legitimacy — `project-info.json` is
+ * written by `cleo init`, and `tasks.db` is the canonical SQLite store.
+ * A `.cleo/` directory missing EITHER one is treated as an orphan
+ * (regression class T9550: stray `.cleo/.context-state.json` writes
+ * from sibling workspaces).
+ *
+ * @param cleoDirPath - Absolute path to a `.cleo/` directory (i.e. the
+ *   directory under suspicion, NOT its parent).
+ * @returns `true` when both legitimacy markers exist; `false` otherwise.
+ *
+ * @task T10308
+ */
+export function isLegitimateCleoProjectRoot(cleoDirPath: string): boolean {
+  return (
+    existsSync(join(cleoDirPath, 'project-info.json')) && existsSync(join(cleoDirPath, 'tasks.db'))
+  );
+}
+
+/**
+ * Best-effort read of the `workspace` field from
+ * `<cleoDirPath>/.context-state.json`.
+ *
+ * @remarks
+ * The 2026-05-23 audit found that `/mnt/projects/.cleo/.context-state.json`
+ * carried `{ workspace: '/mnt/projects/awesome-skills' }` — irrefutable
+ * evidence that the orphan was being written by the `awesome-skills`
+ * workspace via mis-resolved cwd. This helper surfaces that attribution
+ * so operators can identify the offending workspace and patch it.
+ *
+ * Any failure mode (missing file, unparseable JSON, missing field, wrong
+ * type) returns `null` — never throws.
+ *
+ * @param cleoDirPath - Absolute path to the `.cleo/` directory under
+ *   investigation.
+ * @returns The `workspace` field when present and a string; `null`
+ *   otherwise.
+ *
+ * @task T10308
+ */
+export function readParentWorkspace(cleoDirPath: string): string | null {
+  const statePath = join(cleoDirPath, '.context-state.json');
+  if (!existsSync(statePath)) return null;
+  try {
+    const raw = readFileSync(statePath, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'workspace' in parsed &&
+      typeof (parsed as { workspace: unknown }).workspace === 'string'
+    ) {
+      return (parsed as { workspace: string }).workspace;
+    }
+    return null;
+  } catch {
+    // Parse error, IO error — surface as "no attribution available".
+    return null;
+  }
+}
+
+/**
+ * Build a fully-populated orphan-project-root warning for a `.cleo/`
+ * directory that has been confirmed as an orphan.
+ *
+ * @param cleoDirPath - Absolute path to the orphan `.cleo/` directory.
+ * @returns A populated {@link DbSubstrateWarning} of kind
+ *   `'orphan-project-root'`.
+ *
+ * @task T10308
+ */
+function buildOrphanWarning(cleoDirPath: string): DbSubstrateWarning {
+  let lastWriteMs: number | null = null;
+  try {
+    lastWriteMs = statSync(cleoDirPath).mtimeMs;
+  } catch {
+    // Ignore — leave null.
+  }
+  return {
+    kind: 'orphan-project-root',
+    path: cleoDirPath,
+    lastWriteMs,
+    parentWorkspace: readParentWorkspace(cleoDirPath),
+  };
+}
+
+/**
  * Detect orphan project-root `.cleo/` directories at the PARENT of a
  * known project root.
  *
  * @remarks
  * The T9550 regression class wrote `.cleo/` at a project's parent path
  * (e.g. `/mnt/projects/.cleo/`) when `cwd` resolution miscascaded. This
- * helper checks the parent for a `.cleo/` directory and, if found,
- * surfaces it as a warning.
+ * helper checks the parent for a `.cleo/` directory and, if found AND
+ * the parent is NOT itself a legitimate CLEO project root (per
+ * {@link isLegitimateCleoProjectRoot}), surfaces it as a warning.
+ *
+ * T10308 strengthens the original T10307 implementation with the
+ * legitimacy check + `.context-state.json` attribution.
  *
  * @param projectRoot - Absolute path to one project root.
- * @returns A warning if `<parent>/.cleo/` exists; otherwise `null`.
+ * @returns A warning if `<parent>/.cleo/` exists AND is not itself a
+ *   legitimate project root; otherwise `null`.
  */
 export function detectOrphanProjectRootWarning(projectRoot: string): DbSubstrateWarning | null {
   const parent = dirname(projectRoot);
@@ -278,21 +379,17 @@ export function detectOrphanProjectRootWarning(projectRoot: string): DbSubstrate
     // We're at the filesystem root — no parent to scan.
     return null;
   }
-  const orphanCleoPath = join(parent, '.cleo');
-  if (!existsSync(orphanCleoPath)) {
+  const parentCleoPath = join(parent, '.cleo');
+  if (!existsSync(parentCleoPath)) {
     return null;
   }
-  let lastWriteMs: number | null = null;
-  try {
-    lastWriteMs = statSync(orphanCleoPath).mtimeMs;
-  } catch {
-    // Ignore — leave null.
+  // Legitimacy heuristic (T10308 AC2): if the parent has BOTH
+  // project-info.json and tasks.db, it's a real CLEO project root —
+  // surveying the child was the misuse, not the parent's existence.
+  if (isLegitimateCleoProjectRoot(parentCleoPath)) {
+    return null;
   }
-  return {
-    kind: 'orphan-project-root',
-    path: orphanCleoPath,
-    lastWriteMs,
-  };
+  return buildOrphanWarning(parentCleoPath);
 }
 
 /**
@@ -457,21 +554,13 @@ export function surveyFleetDbSubstrate(fleetRoot: string): DbSubstrateAuditResul
     }
   }
 
-  // Fleet-wide warnings: orphan project-root .cleo/ at fleetRoot itself,
-  // plus per-project parent-orphan detection, plus nested-nexus.
+  // Fleet-wide warnings: orphan project-root .cleo/ at fleetRoot itself
+  // (subject to the same legitimacy heuristic as the single-project case
+  // — T10308 AC2), plus nested-nexus.
   const warnings: DbSubstrateWarning[] = [];
-  if (existsSync(join(fleetRoot, '.cleo'))) {
-    let lastWriteMs: number | null = null;
-    try {
-      lastWriteMs = statSync(join(fleetRoot, '.cleo')).mtimeMs;
-    } catch {
-      // Ignore — leave null.
-    }
-    warnings.push({
-      kind: 'orphan-project-root',
-      path: join(fleetRoot, '.cleo'),
-      lastWriteMs,
-    });
+  const fleetRootCleoPath = join(fleetRoot, '.cleo');
+  if (existsSync(fleetRootCleoPath) && !isLegitimateCleoProjectRoot(fleetRootCleoPath)) {
+    warnings.push(buildOrphanWarning(fleetRootCleoPath));
   }
   warnings.push(...detectNestedNexusDuplicates());
 


### PR DESCRIPTION
## Summary

Extends `cleo doctor db-substrate` (shipped by T10307 / PR #588) with legitimacy-aware orphan project-root detection — the T9550 regression class. Live regression: `/mnt/projects/.cleo/` was being written from `/mnt/projects/awesome-skills/` workspace as of 2026-05-23 02:00.

### What changed

- **`isLegitimateCleoProjectRoot(cleoDirPath)`** — heuristic from AC2: a `.cleo/` directory qualifies as a legitimate CLEO project root iff BOTH `project-info.json` AND `tasks.db` are present. Anything else is an orphan.
- **`readParentWorkspace(cleoDirPath)`** — best-effort reader for `<orphan-cleo>/.context-state.json` that surfaces the `workspace` field. Safe against missing-file / unparseable-JSON / wrong-type — returns `null` rather than throwing.
- **`detectOrphanProjectRootWarning()`** now applies the legitimacy heuristic before flagging the parent — a parent that IS a real CLEO project root is no longer falsely flagged.
- **`surveyFleetDbSubstrate()`** applies the same heuristic at `<fleetRoot>/.cleo/`.
- **`DbSubstrateWarning.parentWorkspace`** added as optional contract field. The CLI surfaces it in `meta.warnings[].context` and the human message appends `attributed to workspace: …` when present.

Contract change is pure-additive — no prior consumer needs to migrate.

### Acceptance criteria

- [x] Extend `db-substrate.ts` walker T10307 just shipped — no fork
- [x] Legitimacy heuristic on parent `.cleo/`: skip when both `project-info.json` + `tasks.db` present
- [x] `meta.warnings[]` carries `kind: 'orphan-project-root'`, `path`, `parentWorkspace?`, `lastWriteMs`
- [x] No new CLI subcommand — enriches existing envelope from T10307
- [x] Tests extended in `doctor-db-substrate.test.ts` (+8 new tests, 16 total — all green)
- [x] `lint-project-root-anti-pattern.mjs --strict` baseline=0 preserved
- [x] biome / build / vitest gates green
- [x] Changeset `.changeset/T10308.md`

### Test plan

- [x] `pnpm exec vitest run --no-coverage --config packages/cleo/vitest.config.ts --no-file-parallelism src/cli/commands/__tests__/doctor-db-substrate.test.ts` → 16/16 pass
- [x] `pnpm exec vitest run --no-coverage --config packages/core/vitest.config.ts src/doctor/__tests__/` → 30/30 pass (core doctor)
- [x] Contracts tests green (21 files / 379 tests)
- [x] `node scripts/lint-project-root-anti-pattern.mjs --strict` → STRICT OK
- [x] `node scripts/lint-no-direct-db-open.mjs` → baseline 0
- [x] `node scripts/lint-paths-ssot.mjs` → 14/17 (improved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)