### PR TITLE
feat(core): T10330 retype saga gates against SagaTask discriminator

### DIFF
--- a/.changeset/T10330.md
+++ b/.changeset/T10330.md
@@ -1,0 +1,5 @@
+---
+"@cleocode/core": minor
+---
+
+T10330: retype assertSagaInvariantI3/I5/I7 against SagaTask with dual-shape window (Saga T10326 W2.A)

--- a/packages/core/src/doctor/saga-audit.ts
+++ b/packages/core/src/doctor/saga-audit.ts
@@ -34,18 +34,14 @@
  * @see ADR-073-above-epic-naming.md §1.2
  */
 
-import type {
-  SagaAuditEntry,
-  SagaAuditResult,
-  SagaAuditViolation,
-  Task,
-} from '@cleocode/contracts';
+import type { SagaAuditEntry, SagaAuditResult, SagaAuditViolation } from '@cleocode/contracts';
 import {
   assertSagaInvariantI5,
   assertSagaInvariantI7,
   isSagaInvariantViolationError,
   SAGA_GROUPS_RELATION,
   SAGA_LABEL,
+  type SagaTask,
 } from '../sagas/index.js';
 import { taskList } from '../tasks/list.js';
 import { taskShow } from '../tasks/show.js';
@@ -172,13 +168,19 @@ export async function auditSagaHierarchy(projectRoot: string): Promise<SagaAudit
 
     // --- I5 check (sagaRow.parentId IS NULL) ---
     // Reuse the runtime guard so audit + runtime share one definition.
+    // Cast to SagaTask: audit only iterates rows already known to be sagas
+    // (returned by `taskList({ label: 'saga' })` upstream), so the dual-shape
+    // window guarantee in SagaTask holds. T10330 retyped the gate; this
+    // cast is the audit's pre-narrowing handshake (T10331 callsite sweep
+    // will replace with explicit isSagaShape narrowing on a typed task row).
     try {
       assertSagaInvariantI5({
         id: sagaRow.id,
         labels: sagaRow.labels ?? [],
         parentId: sagaRow.parentId ?? null,
         depends: sagaRow.depends ?? [],
-      } as unknown as Task);
+        type: 'epic',
+      } as unknown as SagaTask);
     } catch (err) {
       if (isSagaInvariantViolationError(err) && err.diag.invariant === 'I5') {
         violations.push({

--- a/packages/core/src/sagas/__tests__/enforcement.test.ts
+++ b/packages/core/src/sagas/__tests__/enforcement.test.ts
@@ -6,15 +6,25 @@
  * and throws a typed {@link SagaInvariantViolationError} (with stable
  * `.code` and structured `.diag`) on invariant breach.
  *
+ * **Dual-shape window (T10330, Saga T10326)**: each gate is now retyped
+ * against {@link SagaTask}, a discriminated union that accepts EITHER the
+ * new-shape (`type === 'saga'`) row introduced by T10277, OR the old-shape
+ * (`type === 'epic' && labels.includes('saga')`) row that pre-existed.
+ * The `isSagaShape` predicate replaces the legacy soft early-return.
+ *
  * Includes the T9831-nested-in-T9799 regression fixture for I7 — the
  * historical scenario where the orchestrator could have attempted to link a
  * saga (`T9831` SG-ARCH-SOLID) as a member of another saga (`T9799` skill
  * maintenance), which I7 forbids.
  *
  * @task T10115
+ * @task T10330
  * @saga T10113
+ * @saga T10326
  * @epic T10209
+ * @epic T10277 — E-SAGA-TYPE-MIGRATION
  * @see ADR-073-above-epic-naming.md §1.2
+ * @see ADR-083 §2.5 — Saga as first-class TaskType
  */
 
 import type { Task } from '@cleocode/contracts';
@@ -24,11 +34,14 @@ import {
   assertSagaInvariantI3,
   assertSagaInvariantI5,
   assertSagaInvariantI7,
+  assertSagaInvariantI7Typed,
   E_SAGA_INVARIANT_VIOLATION_I3,
   E_SAGA_INVARIANT_VIOLATION_I5,
   E_SAGA_INVARIANT_VIOLATION_I7,
   isSagaInvariantViolationError,
+  isSagaShape,
   SagaInvariantViolationError,
+  type SagaTask,
 } from '../enforcement.js';
 
 /** Build a minimal {@link Task} fixture for guard tests. */
@@ -47,32 +60,78 @@ function makeTask(overrides: Partial<Task> & Pick<Task, 'id'>): Task {
   };
 }
 
+/** Build a new-shape SagaTask fixture (post-T10277: `type === 'saga'`). */
+function makeNewShapeSaga(overrides: Partial<Task> & Pick<Task, 'id'>): SagaTask {
+  // The fixture is a SagaTask under the new-shape arm of the union.
+  const task = makeTask({ ...overrides, type: 'saga' });
+  // Narrow via the predicate — proves the fixture is dual-shape-acceptable.
+  if (!isSagaShape(task)) {
+    throw new Error('test fixture failed isSagaShape narrowing');
+  }
+  return task;
+}
+
+/** Build an old-shape SagaTask fixture (pre-T10277: `type === 'epic' + 'saga' label`). */
+function makeOldShapeSaga(overrides: Partial<Task> & Pick<Task, 'id'>): SagaTask {
+  // The fixture is a SagaTask under the old-shape arm of the union.
+  const labels = overrides.labels ?? [SAGA_LABEL];
+  const task = makeTask({ ...overrides, type: 'epic', labels });
+  if (!isSagaShape(task)) {
+    throw new Error('test fixture failed isSagaShape narrowing');
+  }
+  return task;
+}
+
+describe('isSagaShape — dual-shape predicate', () => {
+  it('returns true for new-shape saga (type=saga)', () => {
+    const task = makeTask({ id: 'T9000', type: 'saga' });
+    expect(isSagaShape(task)).toBe(true);
+  });
+
+  it('returns true for new-shape saga even without saga label', () => {
+    const task = makeTask({ id: 'T9000', type: 'saga', labels: [] });
+    expect(isSagaShape(task)).toBe(true);
+  });
+
+  it('returns true for old-shape saga (epic + saga label)', () => {
+    const task = makeTask({ id: 'T9000', type: 'epic', labels: [SAGA_LABEL] });
+    expect(isSagaShape(task)).toBe(true);
+  });
+
+  it('returns false for an epic without saga label', () => {
+    const task = makeTask({ id: 'T9000', type: 'epic', labels: ['feature'] });
+    expect(isSagaShape(task)).toBe(false);
+  });
+
+  it('returns false for a regular task', () => {
+    const task = makeTask({ id: 'T9000', type: 'task' });
+    expect(isSagaShape(task)).toBe(false);
+  });
+
+  it('returns false for a subtask', () => {
+    const task = makeTask({ id: 'T9000', type: 'subtask' });
+    expect(isSagaShape(task)).toBe(false);
+  });
+
+  it('returns false when labels is undefined and type=epic', () => {
+    const task = makeTask({ id: 'T9000', type: 'epic', labels: undefined });
+    expect(isSagaShape(task)).toBe(false);
+  });
+});
+
 describe('assertSagaInvariantI3 — sagas link via groups only', () => {
-  it('accepts a valid saga with no parent and no depends edges', () => {
-    const saga = makeTask({
-      id: 'T9000',
-      labels: [SAGA_LABEL],
-      parentId: null,
-    });
+  it('accepts a valid new-shape saga with no parent and no depends edges', () => {
+    const saga = makeNewShapeSaga({ id: 'T9000', parentId: null });
     expect(() => assertSagaInvariantI3(saga)).not.toThrow();
   });
 
-  it('is a no-op for a non-saga task (no saga label)', () => {
-    const epic = makeTask({
-      id: 'T9001',
-      labels: [],
-      parentId: 'T9000',
-      depends: ['T9100'],
-    });
-    expect(() => assertSagaInvariantI3(epic)).not.toThrow();
+  it('accepts a valid old-shape saga with no parent and no depends edges', () => {
+    const saga = makeOldShapeSaga({ id: 'T9000', parentId: null });
+    expect(() => assertSagaInvariantI3(saga)).not.toThrow();
   });
 
-  it('throws E_SAGA_INVARIANT_VIOLATION_I3 when a saga has a parentId', () => {
-    const saga = makeTask({
-      id: 'T9000',
-      labels: [SAGA_LABEL],
-      parentId: 'T8000',
-    });
+  it('throws E_SAGA_INVARIANT_VIOLATION_I3 when a new-shape saga has a parentId', () => {
+    const saga = makeNewShapeSaga({ id: 'T9000', parentId: 'T8000' });
     let caught: unknown;
     try {
       assertSagaInvariantI3(saga);
@@ -89,13 +148,22 @@ describe('assertSagaInvariantI3 — sagas link via groups only', () => {
     expect(error.message).toContain('parentId');
   });
 
-  it('throws E_SAGA_INVARIANT_VIOLATION_I3 when a saga has depends edges', () => {
-    const saga = makeTask({
-      id: 'T9000',
-      labels: [SAGA_LABEL],
-      parentId: null,
-      depends: ['T8100'],
-    });
+  it('throws E_SAGA_INVARIANT_VIOLATION_I3 when an old-shape saga has a parentId', () => {
+    const saga = makeOldShapeSaga({ id: 'T9000', parentId: 'T8000' });
+    let caught: unknown;
+    try {
+      assertSagaInvariantI3(saga);
+    } catch (err) {
+      caught = err;
+    }
+    expect(isSagaInvariantViolationError(caught)).toBe(true);
+    const error = caught as SagaInvariantViolationError;
+    expect(error.code).toBe(E_SAGA_INVARIANT_VIOLATION_I3);
+    expect(error.diag.invariant).toBe('I3');
+  });
+
+  it('throws E_SAGA_INVARIANT_VIOLATION_I3 when a saga has depends edges (new shape)', () => {
+    const saga = makeNewShapeSaga({ id: 'T9000', parentId: null, depends: ['T8100'] });
     expect(() => assertSagaInvariantI3(saga)).toThrow(SagaInvariantViolationError);
     try {
       assertSagaInvariantI3(saga);
@@ -106,41 +174,31 @@ describe('assertSagaInvariantI3 — sagas link via groups only', () => {
       expect(error.message).toContain('depends');
     }
   });
+
+  it('throws E_SAGA_INVARIANT_VIOLATION_I3 when a saga has depends edges (old shape)', () => {
+    const saga = makeOldShapeSaga({ id: 'T9000', parentId: null, depends: ['T8100'] });
+    expect(() => assertSagaInvariantI3(saga)).toThrow(SagaInvariantViolationError);
+  });
 });
 
 describe('assertSagaInvariantI5 — saga.parentId MUST be NULL', () => {
-  it('accepts a valid saga with parentId=null', () => {
-    const saga = makeTask({
-      id: 'T9000',
-      labels: [SAGA_LABEL],
-      parentId: null,
-    });
+  it('accepts a valid new-shape saga with parentId=null', () => {
+    const saga = makeNewShapeSaga({ id: 'T9000', parentId: null });
     expect(() => assertSagaInvariantI5(saga)).not.toThrow();
   });
 
-  it('accepts a valid saga with parentId omitted', () => {
-    const saga = makeTask({
-      id: 'T9000',
-      labels: [SAGA_LABEL],
-    });
+  it('accepts a valid old-shape saga with parentId=null', () => {
+    const saga = makeOldShapeSaga({ id: 'T9000', parentId: null });
     expect(() => assertSagaInvariantI5(saga)).not.toThrow();
   });
 
-  it('is a no-op for a non-saga task with a parentId', () => {
-    const epic = makeTask({
-      id: 'T9001',
-      labels: ['feature'],
-      parentId: 'T9000',
-    });
-    expect(() => assertSagaInvariantI5(epic)).not.toThrow();
+  it('accepts a valid saga with parentId omitted (new shape)', () => {
+    const saga = makeNewShapeSaga({ id: 'T9000' });
+    expect(() => assertSagaInvariantI5(saga)).not.toThrow();
   });
 
-  it('throws E_SAGA_INVARIANT_VIOLATION_I5 when a saga has parentId != null', () => {
-    const saga = makeTask({
-      id: 'T9000',
-      labels: [SAGA_LABEL],
-      parentId: 'T8000',
-    });
+  it('throws E_SAGA_INVARIANT_VIOLATION_I5 when a new-shape saga has parentId != null', () => {
+    const saga = makeNewShapeSaga({ id: 'T9000', parentId: 'T8000' });
     let caught: unknown;
     try {
       assertSagaInvariantI5(saga);
@@ -156,19 +214,32 @@ describe('assertSagaInvariantI5 — saga.parentId MUST be NULL', () => {
     expect(error.message).toContain('T9000');
   });
 
-  it('throws E_SAGA_INVARIANT_VIOLATION_I5 when a saga has empty-string parentId only on truthy non-null', () => {
-    // Empty string is a degenerate case we treat as null (see guard logic).
-    const saga = makeTask({
-      id: 'T9000',
-      labels: [SAGA_LABEL],
-      parentId: '',
-    });
+  it('throws E_SAGA_INVARIANT_VIOLATION_I5 when an old-shape saga has parentId != null', () => {
+    const saga = makeOldShapeSaga({ id: 'T9000', parentId: 'T8000' });
+    let caught: unknown;
+    try {
+      assertSagaInvariantI5(saga);
+    } catch (err) {
+      caught = err;
+    }
+    expect(isSagaInvariantViolationError(caught)).toBe(true);
+    const error = caught as SagaInvariantViolationError;
+    expect(error.code).toBe(E_SAGA_INVARIANT_VIOLATION_I5);
+  });
+
+  it('treats empty-string parentId as null on saga (new shape)', () => {
+    const saga = makeNewShapeSaga({ id: 'T9000', parentId: '' });
+    expect(() => assertSagaInvariantI5(saga)).not.toThrow();
+  });
+
+  it('treats empty-string parentId as null on saga (old shape)', () => {
+    const saga = makeOldShapeSaga({ id: 'T9000', parentId: '' });
     expect(() => assertSagaInvariantI5(saga)).not.toThrow();
   });
 });
 
 describe('assertSagaInvariantI7 — no nested sagas', () => {
-  it('accepts a regular epic candidate (no saga label)', () => {
+  it('accepts a regular epic candidate (no saga label, no saga type)', () => {
     expect(() => assertSagaInvariantI7('T9100', ['feature'])).not.toThrow();
   });
 
@@ -176,7 +247,7 @@ describe('assertSagaInvariantI7 — no nested sagas', () => {
     expect(() => assertSagaInvariantI7('T9100', [])).not.toThrow();
   });
 
-  it('throws E_SAGA_INVARIANT_VIOLATION_I7 when the candidate has the saga label', () => {
+  it('throws E_SAGA_INVARIANT_VIOLATION_I7 when the candidate has the saga label (old shape)', () => {
     let caught: unknown;
     try {
       assertSagaInvariantI7('T9100', [SAGA_LABEL], 'T9000');
@@ -191,6 +262,28 @@ describe('assertSagaInvariantI7 — no nested sagas', () => {
     expect(error.diag.offendingId).toBe('T9100');
     expect(error.message).toContain('T9100');
     expect(error.message).toContain('nested');
+  });
+
+  it('throws E_SAGA_INVARIANT_VIOLATION_I7 when the candidate has type=saga (new shape)', () => {
+    let caught: unknown;
+    try {
+      assertSagaInvariantI7('T9100', [], 'T9000', 'saga');
+    } catch (err) {
+      caught = err;
+    }
+    expect(isSagaInvariantViolationError(caught)).toBe(true);
+    const error = caught as SagaInvariantViolationError;
+    expect(error.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+    expect(error.diag.invariant).toBe('I7');
+    expect(error.diag.sagaId).toBe('T9000');
+    expect(error.diag.offendingId).toBe('T9100');
+  });
+
+  it('throws E_SAGA_INVARIANT_VIOLATION_I7 when BOTH new and old shape markers present', () => {
+    // Belt + braces — type=saga AND label=saga should still fire exactly once.
+    expect(() => assertSagaInvariantI7('T9100', [SAGA_LABEL], 'T9000', 'saga')).toThrow(
+      SagaInvariantViolationError,
+    );
   });
 
   it('omits sagaId from diag when not provided', () => {
@@ -230,6 +323,153 @@ describe('assertSagaInvariantI7 — no nested sagas', () => {
     });
     expect(error.message).toContain('T9831');
     expect(error.message).toContain(SAGA_LABEL);
+  });
+
+  it('regression (new shape): rejects linking a type=saga T9831 as a member of T9799', () => {
+    // Post-T10277 migration, T9831 would be stored as type='saga' with no label.
+    let caught: unknown;
+    try {
+      assertSagaInvariantI7('T9831', [], 'T9799', 'saga');
+    } catch (err) {
+      caught = err;
+    }
+    expect(isSagaInvariantViolationError(caught)).toBe(true);
+    const error = caught as SagaInvariantViolationError;
+    expect(error.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+    expect(error.diag).toEqual({
+      sagaId: 'T9799',
+      offendingId: 'T9831',
+      invariant: 'I7',
+    });
+  });
+});
+
+describe('assertSagaInvariantI7Typed — typed overload', () => {
+  it('always throws when passed a new-shape SagaTask', () => {
+    const candidate = makeNewShapeSaga({ id: 'T9831' });
+    let caught: unknown;
+    try {
+      assertSagaInvariantI7Typed(candidate, 'T9799');
+    } catch (err) {
+      caught = err;
+    }
+    expect(isSagaInvariantViolationError(caught)).toBe(true);
+    const error = caught as SagaInvariantViolationError;
+    expect(error.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+    expect(error.diag.sagaId).toBe('T9799');
+    expect(error.diag.offendingId).toBe('T9831');
+  });
+
+  it('always throws when passed an old-shape SagaTask', () => {
+    const candidate = makeOldShapeSaga({ id: 'T9831' });
+    expect(() => assertSagaInvariantI7Typed(candidate, 'T9799')).toThrow(
+      SagaInvariantViolationError,
+    );
+  });
+
+  it('throws with sagaId undefined when not provided', () => {
+    const candidate = makeNewShapeSaga({ id: 'T9831' });
+    try {
+      assertSagaInvariantI7Typed(candidate);
+    } catch (err) {
+      const error = err as SagaInvariantViolationError;
+      expect(error.diag.sagaId).toBeUndefined();
+      expect(error.diag.offendingId).toBe('T9831');
+    }
+  });
+});
+
+describe('dual-shape acceptance — identical pass/fail outcomes across shapes', () => {
+  it('I3: new and old shape produce identical OK outcome for valid saga', () => {
+    const newShape = makeNewShapeSaga({ id: 'T9000', parentId: null });
+    const oldShape = makeOldShapeSaga({ id: 'T9000', parentId: null });
+    expect(() => assertSagaInvariantI3(newShape)).not.toThrow();
+    expect(() => assertSagaInvariantI3(oldShape)).not.toThrow();
+  });
+
+  it('I3: new and old shape produce identical FAIL outcome on parentId violation', () => {
+    const newShape = makeNewShapeSaga({ id: 'T9000', parentId: 'T8000' });
+    const oldShape = makeOldShapeSaga({ id: 'T9000', parentId: 'T8000' });
+    let newErr: SagaInvariantViolationError | undefined;
+    let oldErr: SagaInvariantViolationError | undefined;
+    try {
+      assertSagaInvariantI3(newShape);
+    } catch (e) {
+      newErr = e as SagaInvariantViolationError;
+    }
+    try {
+      assertSagaInvariantI3(oldShape);
+    } catch (e) {
+      oldErr = e as SagaInvariantViolationError;
+    }
+    expect(newErr?.code).toBe(E_SAGA_INVARIANT_VIOLATION_I3);
+    expect(oldErr?.code).toBe(E_SAGA_INVARIANT_VIOLATION_I3);
+    expect(newErr?.diag).toEqual(oldErr?.diag);
+  });
+
+  it('I5: new and old shape produce identical OK outcome for valid saga', () => {
+    const newShape = makeNewShapeSaga({ id: 'T9000', parentId: null });
+    const oldShape = makeOldShapeSaga({ id: 'T9000', parentId: null });
+    expect(() => assertSagaInvariantI5(newShape)).not.toThrow();
+    expect(() => assertSagaInvariantI5(oldShape)).not.toThrow();
+  });
+
+  it('I5: new and old shape produce identical FAIL outcome on parentId violation', () => {
+    const newShape = makeNewShapeSaga({ id: 'T9000', parentId: 'T8000' });
+    const oldShape = makeOldShapeSaga({ id: 'T9000', parentId: 'T8000' });
+    let newErr: SagaInvariantViolationError | undefined;
+    let oldErr: SagaInvariantViolationError | undefined;
+    try {
+      assertSagaInvariantI5(newShape);
+    } catch (e) {
+      newErr = e as SagaInvariantViolationError;
+    }
+    try {
+      assertSagaInvariantI5(oldShape);
+    } catch (e) {
+      oldErr = e as SagaInvariantViolationError;
+    }
+    expect(newErr?.code).toBe(E_SAGA_INVARIANT_VIOLATION_I5);
+    expect(oldErr?.code).toBe(E_SAGA_INVARIANT_VIOLATION_I5);
+    expect(newErr?.diag).toEqual(oldErr?.diag);
+  });
+
+  it('I7: new and old shape candidates produce identical violation outcome', () => {
+    let newErr: SagaInvariantViolationError | undefined;
+    let oldErr: SagaInvariantViolationError | undefined;
+    try {
+      assertSagaInvariantI7('T9100', [], 'T9000', 'saga');
+    } catch (e) {
+      newErr = e as SagaInvariantViolationError;
+    }
+    try {
+      assertSagaInvariantI7('T9100', [SAGA_LABEL], 'T9000');
+    } catch (e) {
+      oldErr = e as SagaInvariantViolationError;
+    }
+    expect(newErr?.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+    expect(oldErr?.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+    expect(newErr?.diag).toEqual(oldErr?.diag);
+  });
+
+  it('I7: typed overload produces identical violation outcome across shapes', () => {
+    const newShape = makeNewShapeSaga({ id: 'T9100' });
+    const oldShape = makeOldShapeSaga({ id: 'T9100' });
+    let newErr: SagaInvariantViolationError | undefined;
+    let oldErr: SagaInvariantViolationError | undefined;
+    try {
+      assertSagaInvariantI7Typed(newShape, 'T9000');
+    } catch (e) {
+      newErr = e as SagaInvariantViolationError;
+    }
+    try {
+      assertSagaInvariantI7Typed(oldShape, 'T9000');
+    } catch (e) {
+      oldErr = e as SagaInvariantViolationError;
+    }
+    expect(newErr?.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+    expect(oldErr?.code).toBe(E_SAGA_INVARIANT_VIOLATION_I7);
+    expect(newErr?.diag).toEqual(oldErr?.diag);
   });
 });
 

--- a/packages/core/src/sagas/enforcement.ts
+++ b/packages/core/src/sagas/enforcement.ts
@@ -21,6 +21,79 @@ import type { Task } from '@cleocode/contracts';
 import { SAGA_LABEL } from './constants.js';
 
 /**
+ * Determine whether a task row carries the `'saga'` label.
+ *
+ * @param labels - The task's labels array (may be undefined / empty).
+ * @returns True when `'saga'` appears in the label list.
+ */
+function hasSagaLabel(labels: readonly string[] | undefined): boolean {
+  return Array.isArray(labels) && labels.includes(SAGA_LABEL);
+}
+
+/**
+ * SagaTask — the narrowed Task shape the saga invariant gates operate on.
+ *
+ * This is a deprecation-window discriminated union (T10330, Saga T10326
+ * SG-SUBSTRATE-RECONCILIATION). It accepts EITHER:
+ *
+ * - **New shape** (post-T10277): `type === 'saga'` — the first-class TaskType
+ *   introduced by Wave 1 (T10328 contracts + T10329 schema migration).
+ * - **Old shape** (deprecation window): `type === 'epic' && labels.includes('saga')`
+ *   — the pre-T10277 storage shape, still present for not-yet-migrated rows
+ *   in long-lived sessions. Removed in W3.C cutover (T10334).
+ *
+ * Callers narrow with {@link isSagaShape} before invoking the gates. The
+ * gate bodies never read `type`, so the union is safe — they only check
+ * `id`, `parentId`, `depends` which are common to both shapes.
+ *
+ * @see ADR-083 §2.5 — Saga as first-class TaskType
+ * @see ADR-073 §1.2 — Invariants I3 / I5 / I7
+ * @task T10330
+ * @saga T10326
+ */
+export type SagaTask = (Task & { type: 'saga' }) | (Task & { type: 'epic' });
+
+/**
+ * Type predicate — true when `task` carries either the new-shape saga
+ * discriminator (`type === 'saga'`) or the old-shape saga marker
+ * (`type === 'epic' && labels.includes('saga')`).
+ *
+ * The deprecation-window dual acceptance is intentional: while not-yet-
+ * migrated rows still exist in long-lived sessions, both shapes MUST be
+ * recognised as sagas. W3.C cutover (T10334) drops the old-shape branch.
+ *
+ * Use this BEFORE passing a {@link Task} to the saga invariant gates —
+ * replaces the legacy soft early-return on `labels.includes('saga')`.
+ *
+ * @param task - Task row to inspect.
+ * @returns True when the task is a saga in either shape.
+ *
+ * @example
+ * ```typescript
+ * if (isSagaShape(task)) {
+ *   // task is now narrowed to SagaTask — safe to pass to gates.
+ *   assertSagaInvariantI3(task);
+ *   assertSagaInvariantI5(task);
+ * }
+ * ```
+ *
+ * @task T10330
+ * @saga T10326
+ * @see ADR-083 §2.5
+ */
+export function isSagaShape(task: Task): task is SagaTask {
+  // New shape — first-class 'saga' TaskType (T10277 cutover).
+  if (task.type === 'saga') {
+    return true;
+  }
+  // Old shape — labelled epic (deprecation-window dual acceptance, T10334 drops).
+  if (task.type === 'epic' && hasSagaLabel(task.labels)) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * LAFS error code for a saga-labeled epic that carries forbidden parent or
  * `depends` edges (ADR-073 §1.2 invariant I3).
  */
@@ -111,37 +184,29 @@ export function isSagaInvariantViolationError(
 }
 
 /**
- * Determine whether a task row carries the `'saga'` label.
- *
- * @param labels - The task's labels array (may be undefined / empty).
- * @returns True when `'saga'` appears in the label list.
- */
-function hasSagaLabel(labels: readonly string[] | undefined): boolean {
-  return Array.isArray(labels) && labels.includes(SAGA_LABEL);
-}
-
-/**
  * ADR-073 §1.2 invariant **I3** — sagas link via
  * `task_relations.type='groups'` only.
  *
- * A saga-labeled epic MUST NOT carry `parentId` or any entries in `depends`.
- * Member discovery flows through `task_relations.type='groups'`; a parent or
- * depends edge would re-introduce the depth-budget consumption the saga tier
- * was created to avoid.
+ * A saga MUST NOT carry `parentId` or any entries in `depends`. Member
+ * discovery flows through `task_relations.type='groups'`; a parent or
+ * depends edge would re-introduce the depth-budget consumption the saga
+ * tier was created to avoid.
  *
- * The guard is a no-op when the input is not a saga (no `'saga'` label) —
- * callers can pass any task without first filtering.
+ * The gate accepts a {@link SagaTask} (new or old shape — see
+ * deprecation-window dual acceptance). Callers narrow via {@link isSagaShape}
+ * before invoking — the soft `labels.includes('saga')` early-return that
+ * previously lived in this function has been REMOVED in favour of
+ * compile-time TypeScript narrowing (T10330, ADR-083 §2.5).
  *
- * @param saga - Task row to check.
+ * @param saga - Saga-shaped task row, pre-narrowed by {@link isSagaShape}.
  * @throws {@link SagaInvariantViolationError} with
  *   {@link E_SAGA_INVARIANT_VIOLATION_I3} when the row violates I3.
  *
  * @see ADR-073-above-epic-naming.md §1.2
+ * @task T10330
+ * @saga T10326
  */
-export function assertSagaInvariantI3(saga: Task): void {
-  if (!hasSagaLabel(saga.labels)) {
-    return;
-  }
+export function assertSagaInvariantI3(saga: SagaTask): void {
   if (saga.parentId != null && saga.parentId !== '') {
     throw new SagaInvariantViolationError(
       E_SAGA_INVARIANT_VIOLATION_I3,
@@ -164,20 +229,23 @@ export function assertSagaInvariantI3(saga: Task): void {
  * ADR-073 §1.2 invariant **I5** — a saga row's `parentId` MUST be NULL.
  *
  * Sagas are top-level groupings; they do not nest under any task. A non-null
- * `parentId` on a saga-labeled row is a storage corruption / import bug.
+ * `parentId` on a saga row is a storage corruption / import bug.
  *
- * The guard is a no-op when the input is not a saga (no `'saga'` label).
+ * The gate accepts a {@link SagaTask} (new or old shape — see
+ * deprecation-window dual acceptance). Callers narrow via {@link isSagaShape}
+ * before invoking — the soft `labels.includes('saga')` early-return that
+ * previously lived in this function has been REMOVED in favour of
+ * compile-time TypeScript narrowing (T10330, ADR-083 §2.5).
  *
- * @param saga - Task row to check.
+ * @param saga - Saga-shaped task row, pre-narrowed by {@link isSagaShape}.
  * @throws {@link SagaInvariantViolationError} with
  *   {@link E_SAGA_INVARIANT_VIOLATION_I5} when the row violates I5.
  *
  * @see ADR-073-above-epic-naming.md §1.2
+ * @task T10330
+ * @saga T10326
  */
-export function assertSagaInvariantI5(saga: Task): void {
-  if (!hasSagaLabel(saga.labels)) {
-    return;
-  }
+export function assertSagaInvariantI5(saga: SagaTask): void {
   if (saga.parentId != null && saga.parentId !== '') {
     throw new SagaInvariantViolationError(
       E_SAGA_INVARIANT_VIOLATION_I5,
@@ -192,25 +260,49 @@ export function assertSagaInvariantI5(saga: Task): void {
  * ADR-073 §1.2 invariant **I7** — no nested sagas.
  *
  * A saga-member candidate (i.e. a task being linked into a saga via
- * `task_relations.type='groups'`) MUST NOT itself carry the `'saga'` label.
- * Nested sagas would re-introduce the multi-release grouping depth the tier
- * was created to flatten.
+ * `task_relations.type='groups'`) MUST NOT itself be saga-shaped. Nested
+ * sagas would re-introduce the multi-release grouping depth the tier was
+ * created to flatten.
+ *
+ * The retained `(candidateId, candidateLabels, sagaId?)` signature exists
+ * for caller compat during the Saga T10326 sweep — callers that hold only
+ * an ID + labels (e.g. partial task rows from saga-audit) can still invoke
+ * it directly. Internally the predicate runs both shapes:
+ *
+ * - **New shape**: `candidateType === 'saga'` (synthesised by the typed
+ *   overload below).
+ * - **Old shape**: `candidateLabels.includes('saga')` (deprecation window).
+ *
+ * The {@link assertSagaInvariantI7Typed} overload accepts a pre-narrowed
+ * {@link SagaTask} for callers that already hold a full task — passing a
+ * `SagaTask` is itself proof of the violation (the candidate IS saga-shaped),
+ * so the typed overload always throws.
  *
  * @param candidateId - Task ID being considered as a saga member.
  * @param candidateLabels - The candidate's labels array.
  * @param sagaId - Optional ID of the saga the candidate would be linked into
  *   (surfaced in the diag payload when provided).
+ * @param candidateType - Optional new-shape TaskType discriminator. When
+ *   `'saga'` is supplied, the gate fires regardless of `candidateLabels`.
  * @throws {@link SagaInvariantViolationError} with
- *   {@link E_SAGA_INVARIANT_VIOLATION_I7} when the candidate is a saga.
+ *   {@link E_SAGA_INVARIANT_VIOLATION_I7} when the candidate is a saga
+ *   under either shape.
  *
  * @see ADR-073-above-epic-naming.md §1.2
+ * @task T10330
+ * @saga T10326
  */
 export function assertSagaInvariantI7(
   candidateId: string,
   candidateLabels: readonly string[],
   sagaId?: string,
+  candidateType?: Task['type'],
 ): void {
-  if (!hasSagaLabel(candidateLabels)) {
+  // New-shape acceptance: type='saga' discriminator (post-T10277 cutover).
+  const isNewShapeSaga = candidateType === 'saga';
+  // Old-shape acceptance: epic + 'saga' label (deprecation window — T10334 drops).
+  const isOldShapeSaga = hasSagaLabel(candidateLabels);
+  if (!isNewShapeSaga && !isOldShapeSaga) {
     return;
   }
   throw new SagaInvariantViolationError(
@@ -219,4 +311,24 @@ export function assertSagaInvariantI7(
       'nested sagas are forbidden (ADR-073 §1.2 I7).',
     { sagaId, offendingId: candidateId, invariant: 'I7' },
   );
+}
+
+/**
+ * Typed overload of {@link assertSagaInvariantI7} — accepts a pre-narrowed
+ * {@link SagaTask}. Passing a `SagaTask` is itself proof of I7 violation
+ * (the candidate IS saga-shaped), so this overload always throws.
+ *
+ * Prefer this entry point when the caller already holds a full task row
+ * and has narrowed via {@link isSagaShape}.
+ *
+ * @param candidate - Pre-narrowed saga-shaped candidate task.
+ * @param sagaId - Optional ID of the saga the candidate would be linked into.
+ * @throws {@link SagaInvariantViolationError} with
+ *   {@link E_SAGA_INVARIANT_VIOLATION_I7} — always, since input is saga-shaped.
+ *
+ * @task T10330
+ * @saga T10326
+ */
+export function assertSagaInvariantI7Typed(candidate: SagaTask, sagaId?: string): void {
+  assertSagaInvariantI7(candidate.id, candidate.labels ?? [], sagaId, candidate.type);
 }

--- a/packages/core/src/sagas/index.ts
+++ b/packages/core/src/sagas/index.ts
@@ -26,13 +26,16 @@ export {
   assertSagaInvariantI3,
   assertSagaInvariantI5,
   assertSagaInvariantI7,
+  assertSagaInvariantI7Typed,
   E_SAGA_INVARIANT_VIOLATION_I3,
   E_SAGA_INVARIANT_VIOLATION_I5,
   E_SAGA_INVARIANT_VIOLATION_I7,
   isSagaInvariantViolationError,
+  isSagaShape,
   type SagaInvariantCode,
   type SagaInvariantDiag,
   SagaInvariantViolationError,
+  type SagaTask,
 } from './enforcement.js';
 export { type SagaInvariantI5Warning, type SagaListResult, sagaList } from './list.js';
 export {


### PR DESCRIPTION
## Summary
- Retypes `assertSagaInvariantI3` / `assertSagaInvariantI5` / `assertSagaInvariantI7` against `SagaTask = (Task & { type: 'saga' }) | (Task & { type: 'epic' })` — the deprecation-window discriminated union per ADR-083 §2.5.
- Adds `isSagaShape()` type predicate replacing the legacy soft `labels.includes('saga')` early-return with compile-time TypeScript narrowing.
- Adds `assertSagaInvariantI7Typed(candidate: SagaTask, sagaId?)` overload for callers holding a full task row.
- Extends `assertSagaInvariantI7` with optional `candidateType?: TaskType` (back-compat: existing 3-arg callers unaffected — `saga-audit.ts:222` and `sagas/add.ts:95`).
- Migrates `saga-audit.ts` I5 callsite to import `SagaTask` (cast target swap only; T10331 sweep replaces with explicit `isSagaShape` narrowing).
- Wave 2A of SAGA T10326 SG-SUBSTRATE-RECONCILIATION (parallel with W2.B T10331 callsite sweep).

## Test plan
- [x] `enforcement.test.ts` extended with dual-shape acceptance suite (39 tests total).
- [x] Both old + new shape produce identical pass/fail outcomes for I3/I5/I7 — parametrised in dedicated `describe('dual-shape acceptance')` block.
- [x] T9831-nested-in-T9799 regression fixture extended to cover both new-shape (`type='saga'`) and old-shape (`label='saga'`) cases.
- [x] `pnpm exec vitest run packages/core/src/sagas/` — 77/77 tests pass.
- [x] `pnpm exec vitest run packages/core/src/doctor/__tests__/saga-audit.test.ts` — 6/6 tests pass.
- [x] `pnpm run build` — full monorepo build green (45s).
- [x] No `any` / `as unknown as` introduced in new code; pure TS narrowing via `task is SagaTask` predicate.
- [x] `pnpm-lock.yaml` unchanged.

Closes T10330
Saga: T10326
Refs: ADR-083 §2.5, ADR-073 §1.2 invariants I3 / I5 / I7