### PR TITLE
T10316: vacuumIntoBackupAll brain backup gap — eager-open via openCleoDb chokepoint (Saga T10281 / E3)

### DIFF
--- a/.changeset/T10316.md
+++ b/.changeset/T10316.md
@@ -1,0 +1,16 @@
+---
+id: T10316
+tasks: [T10316]
+kind: fix
+summary: vacuumIntoBackupAll brain backup gap — eager-open via openCleoDb chokepoint (Saga T10281 / E3-BACKUP-RECOVERY)
+---
+
+Fixes the production brain backup gap captured live during Saga T10281: `vacuumIntoBackupAll` (wired into `cleo session end` via `backup-session-end` hook) was silently skipping brain.db whenever its native singleton handle had not been lazily opened earlier in the process. Real-world evidence: `.cleo/backups/sqlite/` accumulated 22 `tasks-*.db` snapshots and ZERO `brain-*.db` snapshots despite every session-end firing the snapshot pipeline.
+
+Root cause: `snapshotOne()` early-returned when `target.getDb()` (the in-process handle cache) returned `null`. Mock-based unit tests passed because they injected a non-null handle.
+
+Fix: extend `SnapshotTarget` with `openDb(cwd)` — the canonical per-DB chokepoint opener (ADR-068). When the fast-path returns null, snapshot now eagerly opens brain via `getBrainDb(cwd)`, tasks via `getDb(cwd)`, conduit via `ensureConduitDb(projectRoot)`, nexus via `getNexusDb()`, and signaldock via `ensureGlobalSignaldockDb()`. All openers live in `packages/core/src/store/**` — the canonical allowlist under the db-open-guard CI gate.
+
+Adds a real-process regression test (`packages/core/src/store/__tests__/sqlite-backup-real-process.test.ts`) that spawns a fresh node child, runs `vacuumIntoBackupAll` with no prior brain open, and asserts `brain-YYYYMMDD-HHmmss.db` lands in the backup dir. The existing mock-based TC-100 unit test stays as the inner-contract guard with one new assertion covering the openDb fallback path.
+
+Saga: T10281; Epic: T10284.

--- a/packages/core/src/store/__tests__/sqlite-backup-real-process.test.ts
+++ b/packages/core/src/store/__tests__/sqlite-backup-real-process.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Real-process regression test for the T10316 brain backup gap.
+ *
+ * Spawns a node child via `child_process.spawnSync('node', ['-e', '...'])` that
+ * imports the compiled `vacuumIntoBackupAll` from `packages/core/dist/`. The
+ * child:
+ *
+ * 1. Sets `CLEO_HOME` and `CLEO_DIR` to absolute paths inside a per-test
+ *    temp dir (no contamination of the live `$XDG_DATA_HOME/cleo/` or the
+ *    project's `.cleo/`).
+ * 2. Does NOT call `cleo memory observe` or any code path that would lazily
+ *    open brain.db. The brain native-handle singleton starts as `null`.
+ * 3. Invokes `vacuumIntoBackupAll({ cwd: tempDir, force: true })`.
+ * 4. Exits cleanly.
+ *
+ * The parent process then asserts that a `brain-YYYYMMDD-HHmmss.db` file
+ * landed in `<tempDir>/.cleo/backups/sqlite/`. Before the T10316 fix the
+ * fast-path returned `null` and snapshotOne silently skipped brain — so
+ * the only artifacts were `tasks-*.db` snapshots.
+ *
+ * This test deliberately bypasses vitest mocks because the bug surfaces only
+ * in a real process where module-singleton caches are empty. The mock-based
+ * unit guard (`sqlite-backup.test.ts`, the `vacuumIntoBackupAll calls openDb
+ * for brain when getBrainNativeDb is null (T10316)` case) remains in place
+ * as the inner-contract guard.
+ *
+ * @task T10316
+ * @saga T10281
+ * @epic T10284 (E3-BACKUP-RECOVERY)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// packages/core/src/store/__tests__/ → packages/core
+const CORE_PKG_ROOT = resolve(__dirname, '..', '..', '..');
+const SQLITE_BACKUP_DIST = resolve(CORE_PKG_ROOT, 'dist', 'store', 'sqlite-backup.js');
+
+describe('sqlite-backup real-process (T10316)', () => {
+  let workDir: string;
+  let cleoHome: string;
+  let cleoDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'cleo-t10316-real-'));
+    cleoHome = join(workDir, 'cleo-home');
+    cleoDir = join(workDir, 'project', '.cleo');
+    mkdirSync(cleoHome, { recursive: true });
+    mkdirSync(cleoDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(workDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort — tmp cleanup is non-fatal.
+    }
+  });
+
+  it('produces brain-YYYYMMDD-HHmmss.db even when no caller pre-opened brain.db', () => {
+    // The compiled dist MUST exist — the test depends on the real module
+    // graph (no vitest module mocks). Builds run before tests via the
+    // monorepo workflow; a missing dist is a clear signal to rebuild.
+    expect(existsSync(SQLITE_BACKUP_DIST)).toBe(true);
+
+    // T10316: brain.db is NEVER opened in the child process before the
+    // snapshot call. The bug is that vacuumIntoBackupAll would silently
+    // skip brain when getBrainNativeDb() returns null. The fix is the
+    // eager-open via target.openDb.
+    const projectRoot = join(workDir, 'project');
+    const childScript = `
+      const path = ${JSON.stringify(SQLITE_BACKUP_DIST)};
+      (async () => {
+        const mod = await import(path);
+        await mod.vacuumIntoBackupAll({ cwd: ${JSON.stringify(projectRoot)}, force: true });
+      })().catch((err) => {
+        process.stderr.write(String((err && err.stack) || err));
+        process.exit(2);
+      });
+    `;
+
+    const result = spawnSync(process.execPath, ['-e', childScript], {
+      env: {
+        ...process.env,
+        // Test isolation: ensure no contamination of the developer's real
+        // ~/.local/share/cleo/ or project .cleo/. CLEO_HOME pins the
+        // global tier; CLEO_DIR pins the project tier (absolute path —
+        // bypasses getProjectRoot walk per paths.ts §getCleoDir line 283).
+        CLEO_HOME: cleoHome,
+        CLEO_DIR: cleoDir,
+        // Belt-and-suspenders: route any unintended global open to the
+        // throwaway home, never the developer's machine.
+        XDG_DATA_HOME: cleoHome,
+      },
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+
+    // The child MUST succeed end-to-end — backup failure is supposed to be
+    // non-fatal, but spawning failure is a test infrastructure problem we
+    // want to see surfaced.
+    if (result.status !== 0) {
+      throw new Error(
+        `Child exited with status ${result.status}\n` +
+          `stdout: ${result.stdout}\nstderr: ${result.stderr}`,
+      );
+    }
+
+    // Assert: brain snapshot landed in <CLEO_DIR>/backups/sqlite/.
+    const backupDir = join(cleoDir, 'backups', 'sqlite');
+    expect(existsSync(backupDir)).toBe(true);
+
+    const files = readdirSync(backupDir);
+    const brainSnapshots = files.filter((f) => /^brain-\d{8}-\d{6}\.db$/.test(f));
+    const tasksSnapshots = files.filter((f) => /^tasks-\d{8}-\d{6}\.db$/.test(f));
+
+    // Headline regression check: at LEAST one brain-*.db snapshot file.
+    // Pre-fix, this count was 0 in production despite tasks-*.db being healthy.
+    expect(brainSnapshots.length).toBeGreaterThanOrEqual(1);
+
+    // Sanity: tasks snapshot should also exist — confirms the eager-open
+    // contract holds for the previously-working path too.
+    expect(tasksSnapshots.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/core/src/store/__tests__/sqlite-backup.test.ts
+++ b/packages/core/src/store/__tests__/sqlite-backup.test.ts
@@ -12,6 +12,8 @@
  *
  * @task T4874
  * @task T5158 — extended to cover brain.db + vacuumIntoBackupAll
+ * @task T10316 — eager-open openers mocked to keep the unit-layer guard
+ *               passing under the new SnapshotTarget.openDb contract
  * @epic T4867
  */
 
@@ -27,18 +29,41 @@ describe('sqlite-backup', () => {
   });
 
   it('is non-fatal when getNativeDb() returns null', async () => {
-    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => null }));
-    vi.doMock('../memory-sqlite.js', () => ({ getBrainNativeDb: () => null }));
-    vi.doMock('../../paths.js', () => ({ getCleoDir: () => tmpdir() }));
+    // T10316: stub the eager-open paths too so they don't throw when the
+    // singleton lookup returns null. The unit-layer contract is preserved —
+    // both fast-path and eager-open returning null is still a clean skip.
+    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => null, getDb: async () => null }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => null,
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tmpdir(),
+      resolveOrCwd: (cwd?: string) => cwd ?? tmpdir(),
+    }));
 
     const { vacuumIntoBackup } = await import('../sqlite-backup.js');
     await expect(vacuumIntoBackup({ force: true })).resolves.not.toThrow();
   });
 
   it('is non-fatal when getBrainNativeDb() returns null', async () => {
-    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => null }));
-    vi.doMock('../memory-sqlite.js', () => ({ getBrainNativeDb: () => null }));
-    vi.doMock('../../paths.js', () => ({ getCleoDir: () => tmpdir() }));
+    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => null, getDb: async () => null }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => null,
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tmpdir(),
+      resolveOrCwd: (cwd?: string) => cwd ?? tmpdir(),
+    }));
 
     const { vacuumIntoBackupAll } = await import('../sqlite-backup.js');
     await expect(vacuumIntoBackupAll({ force: true })).resolves.not.toThrow();
@@ -46,10 +71,23 @@ describe('sqlite-backup', () => {
 
   it('calls PRAGMA wal_checkpoint(TRUNCATE) before VACUUM INTO for tasks.db', async () => {
     const execMock = vi.fn();
-    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => ({ exec: execMock }) }));
-    vi.doMock('../memory-sqlite.js', () => ({ getBrainNativeDb: () => null }));
+    vi.doMock('../sqlite.js', () => ({
+      getNativeDb: () => ({ exec: execMock }),
+      getDb: async () => null,
+    }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => null,
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
     const tempDir = join(tmpdir(), `cleo-test-wal-${Date.now()}`);
-    vi.doMock('../../paths.js', () => ({ getCleoDir: () => tempDir }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tempDir,
+      resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
+    }));
 
     const { vacuumIntoBackup } = await import('../sqlite-backup.js');
     await vacuumIntoBackup({ force: true });
@@ -63,12 +101,25 @@ describe('sqlite-backup', () => {
 
   it('enforces maximum 10 tasks.db snapshots via rotation', async () => {
     const execMock = vi.fn();
-    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => ({ exec: execMock }) }));
-    vi.doMock('../memory-sqlite.js', () => ({ getBrainNativeDb: () => null }));
+    vi.doMock('../sqlite.js', () => ({
+      getNativeDb: () => ({ exec: execMock }),
+      getDb: async () => null,
+    }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => null,
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
     const tempDir = join(tmpdir(), `cleo-test-rot-${Date.now()}`);
     const backupDir = join(tempDir, 'backups', 'sqlite');
     mkdirSync(backupDir, { recursive: true });
-    vi.doMock('../../paths.js', () => ({ getCleoDir: () => tempDir }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tempDir,
+      resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
+    }));
 
     // Seed 11 fake snapshot files with valid YYYYMMDD-HHMMSS format
     for (let i = 0; i < 11; i++) {
@@ -88,12 +139,25 @@ describe('sqlite-backup', () => {
   it('enforces rotation independently per prefix (tasks + brain)', async () => {
     const tasksExec = vi.fn();
     const brainExec = vi.fn();
-    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => ({ exec: tasksExec }) }));
-    vi.doMock('../memory-sqlite.js', () => ({ getBrainNativeDb: () => ({ exec: brainExec }) }));
+    vi.doMock('../sqlite.js', () => ({
+      getNativeDb: () => ({ exec: tasksExec }),
+      getDb: async () => null,
+    }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => ({ exec: brainExec }),
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
     const tempDir = join(tmpdir(), `cleo-test-rot-prefix-${Date.now()}`);
     const backupDir = join(tempDir, 'backups', 'sqlite');
     mkdirSync(backupDir, { recursive: true });
-    vi.doMock('../../paths.js', () => ({ getCleoDir: () => tempDir }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tempDir,
+      resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
+    }));
 
     // Seed 11 tasks.db and 11 brain.db stale snapshots.
     for (let i = 0; i < 11; i++) {
@@ -115,10 +179,23 @@ describe('sqlite-backup', () => {
   it('vacuumIntoBackupAll snapshots both tasks.db and brain.db', async () => {
     const tasksExec = vi.fn();
     const brainExec = vi.fn();
-    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => ({ exec: tasksExec }) }));
-    vi.doMock('../memory-sqlite.js', () => ({ getBrainNativeDb: () => ({ exec: brainExec }) }));
+    vi.doMock('../sqlite.js', () => ({
+      getNativeDb: () => ({ exec: tasksExec }),
+      getDb: async () => null,
+    }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => ({ exec: brainExec }),
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
     const tempDir = join(tmpdir(), `cleo-test-both-${Date.now()}`);
-    vi.doMock('../../paths.js', () => ({ getCleoDir: () => tempDir }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tempDir,
+      resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
+    }));
 
     const { vacuumIntoBackupAll } = await import('../sqlite-backup.js');
     await vacuumIntoBackupAll({ force: true });
@@ -135,10 +212,23 @@ describe('sqlite-backup', () => {
 
   it('debounce skips second call within debounce window (tasks prefix)', async () => {
     const execMock = vi.fn();
-    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => ({ exec: execMock }) }));
-    vi.doMock('../memory-sqlite.js', () => ({ getBrainNativeDb: () => null }));
+    vi.doMock('../sqlite.js', () => ({
+      getNativeDb: () => ({ exec: execMock }),
+      getDb: async () => null,
+    }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => null,
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
     const tempDir = join(tmpdir(), `cleo-test-debounce-${Date.now()}`);
-    vi.doMock('../../paths.js', () => ({ getCleoDir: () => tempDir }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tempDir,
+      resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
+    }));
 
     const { vacuumIntoBackup } = await import('../sqlite-backup.js');
     // First call with force sets _lastBackupEpoch
@@ -150,14 +240,67 @@ describe('sqlite-backup', () => {
     expect(execMock.mock.calls.length).toBe(callCountAfterFirst);
   });
 
+  // T10316 regression: when getBrainNativeDb() returns null (brain.db not
+  // opened earlier in this process), vacuumIntoBackupAll MUST still produce
+  // a brain.db snapshot by eagerly opening brain via the canonical opener.
+  // The mock-based unit guard exercises the SnapshotTarget.openDb contract;
+  // the real-process variant lives in sqlite-backup-real-process.test.ts.
+  it('vacuumIntoBackupAll calls openDb for brain when getBrainNativeDb is null (T10316)', async () => {
+    const tasksExec = vi.fn();
+    const brainExec = vi.fn();
+    const getBrainDbMock = vi.fn(async () => null); // resolves; native handle below
+    vi.doMock('../sqlite.js', () => ({
+      getNativeDb: () => ({ exec: tasksExec }),
+      getDb: async () => null,
+    }));
+    // First call to getBrainNativeDb returns null (fast path miss). The
+    // openDb fallback awaits getBrainDb then re-queries getBrainNativeDb,
+    // which returns the live handle on the second call.
+    let brainCallCount = 0;
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => {
+        brainCallCount += 1;
+        return brainCallCount === 1 ? null : { exec: brainExec };
+      },
+      getBrainDb: getBrainDbMock,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
+    const tempDir = join(tmpdir(), `cleo-test-eager-${Date.now()}`);
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tempDir,
+      resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
+    }));
+
+    const { vacuumIntoBackupAll } = await import('../sqlite-backup.js');
+    await vacuumIntoBackupAll({ force: true });
+
+    expect(getBrainDbMock).toHaveBeenCalledTimes(1);
+    // After eager-open, the brain VACUUM INTO must have executed.
+    const brainCalls = brainExec.mock.calls.map((c) => c[0] as string);
+    expect(brainCalls.some((c) => c.includes('wal_checkpoint'))).toBe(true);
+    expect(brainCalls.some((c) => c.includes('VACUUM INTO'))).toBe(true);
+  });
+
   it('listSqliteBackups and listBrainBackups return prefix-specific entries newest-first', async () => {
-    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => null }));
-    vi.doMock('../memory-sqlite.js', () => ({ getBrainNativeDb: () => null }));
-    vi.doMock('../conduit-sqlite.js', () => ({ getConduitNativeDb: () => null }));
+    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => null, getDb: async () => null }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => null,
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
     const tempDir = join(tmpdir(), `cleo-test-list-${Date.now()}`);
     const backupDir = join(tempDir, 'backups', 'sqlite');
     mkdirSync(backupDir, { recursive: true });
-    vi.doMock('../../paths.js', () => ({ getCleoDir: () => tempDir }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tempDir,
+      resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
+    }));
 
     // Write files then explicitly set mtimes so the listing sort (by mtime
     // descending) is deterministic regardless of filesystem timestamp

--- a/packages/core/src/store/sqlite-backup.ts
+++ b/packages/core/src/store/sqlite-backup.ts
@@ -26,13 +26,13 @@ import {
   unlinkSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { getCleoDir, getCleoHome } from '../paths.js';
-import { getConduitNativeDb } from './conduit-sqlite.js';
+import { getCleoDir, getCleoHome, resolveOrCwd } from '../paths.js';
+import { ensureConduitDb, getConduitNativeDb } from './conduit-sqlite.js';
 import { getGlobalSaltPath } from './global-salt.js';
-import { getBrainNativeDb } from './memory-sqlite.js';
-import { getNexusNativeDb } from './nexus-sqlite.js';
-import { getGlobalSignaldockNativeDb } from './signaldock-sqlite.js';
-import { getNativeDb } from './sqlite.js';
+import { getBrainDb, getBrainNativeDb } from './memory-sqlite.js';
+import { getNexusDb, getNexusNativeDb } from './nexus-sqlite.js';
+import { ensureGlobalSignaldockDb, getGlobalSignaldockNativeDb } from './signaldock-sqlite.js';
+import { getDb, getNativeDb } from './sqlite.js';
 
 /** Maximum number of snapshots retained per database (oldest rotated out). */
 const MAX_SNAPSHOTS = 10;
@@ -46,16 +46,75 @@ const DEBOUNCE_MS = 30_000; // 30 seconds
 const _lastBackupEpoch: Record<string, number> = {};
 
 /**
+ * Minimal shape of the handle used by the snapshot pipeline — only `exec()`
+ * is required to issue `PRAGMA wal_checkpoint(TRUNCATE)` + `VACUUM INTO`.
+ */
+type SnapshotDbHandle = { exec: (sql: string) => void };
+
+/**
  * Registered snapshot target — each one maps a logical key (prefix used in
  * snapshot filenames) to a function returning the live {@link DatabaseSync}
  * handle. `null` means the database has not been initialized in the current
- * process and its snapshot step should be skipped.
+ * process; in that case {@link SnapshotTarget.openDb} (T10316) eagerly opens
+ * the canonical singleton through the per-DB chokepoint so the snapshot
+ * pipeline never silently skips a target.
+ *
+ * @task T10316 — added `openDb` so `vacuumIntoBackupAll` snapshots EVERY
+ *               registered DB even when no caller in this process has
+ *               lazily opened it earlier (brain backup gap, Saga T10281 / E3).
  */
 interface SnapshotTarget {
   /** Canonical name used in snapshot filenames, e.g. `"tasks"` or `"brain"`. */
   prefix: string;
   /** Resolves the live native handle, or `null` if not yet initialized. */
-  getDb: () => { exec: (sql: string) => void } | null;
+  getDb: () => SnapshotDbHandle | null;
+  /**
+   * Eagerly opens the canonical singleton when {@link getDb} returns `null`.
+   * MUST flow through the per-DB chokepoint (ADR-068) — these openers all
+   * live in `packages/core/src/store/**` (the allowlist root) so this is
+   * pragma-consistent and singleton-managed. Returns `null` only when the
+   * underlying opener legitimately has nothing to open (e.g. missing
+   * project context); callers MUST treat `null` as "skip silently".
+   */
+  openDb: (cwd?: string) => Promise<SnapshotDbHandle | null>;
+}
+
+/**
+ * Open the canonical brain.db singleton via {@link getBrainDb} and return its
+ * native handle. Used as the eager-open fallback for the `brain` snapshot
+ * target when no earlier code in this process lazily opened brain.db
+ * (T10316 — fixes the brain backup gap).
+ *
+ * `getBrainDb` is the canonical chokepoint for brain.db opens
+ * (`packages/core/src/store/memory-sqlite.ts`, allowlisted under
+ * `packages/core/src/store/**`). We call it directly rather than via
+ * `openCleoDb('brain', cwd)` because the latter is currently misrouted to
+ * `getTasksDb` — a separate routing bug tracked outside T10316. Calling the
+ * canonical opener guarantees brain.db is actually opened.
+ */
+async function openBrainDbForSnapshot(cwd?: string): Promise<SnapshotDbHandle | null> {
+  await getBrainDb(cwd);
+  // After getBrainDb resolves, the native singleton MUST be populated.
+  return getBrainNativeDb();
+}
+
+/**
+ * Open the canonical tasks.db singleton via {@link getDb} and return its
+ * native handle. Mirrors {@link openBrainDbForSnapshot}; same rationale.
+ */
+async function openTasksDbForSnapshot(cwd?: string): Promise<SnapshotDbHandle | null> {
+  await getDb(cwd);
+  return getNativeDb();
+}
+
+/**
+ * Open the canonical conduit.db singleton via {@link ensureConduitDb}
+ * (sync) and return its native handle.
+ */
+async function openConduitDbForSnapshot(cwd?: string): Promise<SnapshotDbHandle | null> {
+  // ensureConduitDb requires an absolute project root.
+  ensureConduitDb(resolveOrCwd(cwd));
+  return getConduitNativeDb();
 }
 
 /**
@@ -63,13 +122,19 @@ interface SnapshotTarget {
  * snapshots first (highest-value operational state), then brain.db, then
  * conduit.db (project messaging state).
  *
+ * Every entry MUST provide both `getDb` (fast in-process lookup) and `openDb`
+ * (eager open via chokepoint). The latter closes the T10316 gap where a
+ * session-end snapshot found a `null` handle and silently skipped the DB.
+ *
  * @task T369
+ * @task T10316 — added eager-open openers for every project target
  * @epic T310
  */
 const SNAPSHOT_TARGETS: SnapshotTarget[] = [
-  { prefix: 'tasks', getDb: getNativeDb },
-  { prefix: 'brain', getDb: getBrainNativeDb },
-  { prefix: 'conduit', getDb: getConduitNativeDb }, // Added T369 — project messaging DB
+  { prefix: 'tasks', getDb: getNativeDb, openDb: openTasksDbForSnapshot },
+  { prefix: 'brain', getDb: getBrainNativeDb, openDb: openBrainDbForSnapshot },
+  // Added T369 — project messaging DB. openDb added T10316.
+  { prefix: 'conduit', getDb: getConduitNativeDb, openDb: openConduitDbForSnapshot },
 ];
 
 /**
@@ -141,6 +206,11 @@ export interface VacuumOptions {
  * consistent snapshot, then issues `VACUUM INTO '<dest>'` which SQLite
  * implements as an atomic, fully defragmented clone.
  *
+ * If `target.getDb()` returns `null` (the DB has not been lazily opened
+ * earlier in this process), T10316 added an eager-open fallback via
+ * `target.openDb(cwd)` — the canonical per-DB chokepoint. Only when BOTH
+ * lookups return `null` does the snapshot step skip the target.
+ *
  * Non-fatal: all errors are swallowed via the outer try in
  * {@link vacuumIntoBackupAll}; failures here must never block normal
  * operation.
@@ -148,10 +218,32 @@ export interface VacuumOptions {
  * @param target — snapshot target descriptor (prefix + native DB getter)
  * @param backupDir — absolute path to `.cleo/backups/sqlite/`
  * @param now — reference timestamp for the filename
+ * @param cwd — optional working directory propagated to `target.openDb`
+ *
+ * @task T10316 — eager-open via openCleoDb chokepoint (Saga T10281 / E3)
  */
-function snapshotOne(target: SnapshotTarget, backupDir: string, now: Date): void {
-  const db = target.getDb();
-  if (!db) return; // DB not initialized in this process — skip silently
+async function snapshotOne(
+  target: SnapshotTarget,
+  backupDir: string,
+  now: Date,
+  cwd?: string,
+): Promise<void> {
+  let db = target.getDb();
+  if (!db) {
+    // T10316: eager-open via the canonical per-DB chokepoint so the
+    // session-end backup never silently skips a registered target. This is
+    // the brain backup gap captured live in Saga T10281 / E3 — every
+    // session-end fired with brain.db handle = null in production despite
+    // the mock-based TC-100 unit test passing.
+    try {
+      db = await target.openDb(cwd);
+    } catch {
+      // Non-fatal — opener failure (e.g. missing project context) must
+      // not block snapshots of other registered targets.
+      return;
+    }
+    if (!db) return;
+  }
 
   const dest = join(backupDir, `${target.prefix}-${formatTimestamp(now)}.db`);
 
@@ -201,7 +293,7 @@ export async function vacuumIntoBackup(opts: VacuumOptions = {}): Promise<void> 
     const target = SNAPSHOT_TARGETS.find((t) => t.prefix === prefix);
     if (!target) return;
 
-    snapshotOne(target, backupDir, new Date());
+    await snapshotOne(target, backupDir, new Date(), opts.cwd);
     _lastBackupEpoch[prefix] = Date.now();
   } catch {
     // non-fatal — backup failure must never interrupt normal operation
@@ -238,7 +330,7 @@ export async function vacuumIntoBackupAll(opts: VacuumOptions = {}): Promise<voi
       continue; // debounced — skip this target only
     }
     try {
-      snapshotOne(target, backupDir, now);
+      await snapshotOne(target, backupDir, now, opts.cwd);
       _lastBackupEpoch[target.prefix] = Date.now();
     } catch {
       // non-fatal — continue with remaining targets
@@ -327,15 +419,46 @@ export function listSqliteBackupsAll(
 export type BackupScope = 'project' | 'global';
 
 /**
+ * Open the canonical nexus.db singleton via {@link getNexusDb} and return
+ * its native handle. Symmetric counterpart to {@link openBrainDbForSnapshot}
+ * — eager-open via per-DB chokepoint so global-tier snapshots also work
+ * when the in-process handle cache is empty.
+ *
+ * @task T10316
+ */
+async function openNexusDbForSnapshot(): Promise<SnapshotDbHandle | null> {
+  await getNexusDb();
+  return getNexusNativeDb();
+}
+
+/**
+ * Open the canonical global signaldock.db singleton via
+ * {@link ensureGlobalSignaldockDb} and return its native handle.
+ *
+ * @task T10316
+ */
+async function openSignaldockDbForSnapshot(): Promise<SnapshotDbHandle | null> {
+  await ensureGlobalSignaldockDb();
+  return getGlobalSignaldockNativeDb();
+}
+
+/**
  * Registered global-tier snapshot targets. Both `nexus` and `signaldock` are
- * active as of T369 (epic T310).
+ * active as of T369 (epic T310). T10316 added eager-open `openDb` functions
+ * to mirror the project-tier behaviour and close the same handle-cache gap.
  *
  * @task T369
+ * @task T10316 — eager-open via openCleoDb chokepoint
  * @epic T310
  */
 const GLOBAL_SNAPSHOT_TARGETS: SnapshotTarget[] = [
-  { prefix: 'nexus', getDb: getNexusNativeDb },
-  { prefix: 'signaldock', getDb: getGlobalSignaldockNativeDb }, // Activated T369 — global agent registry
+  { prefix: 'nexus', getDb: getNexusNativeDb, openDb: openNexusDbForSnapshot },
+  // Activated T369 — global agent registry. openDb added T10316.
+  {
+    prefix: 'signaldock',
+    getDb: getGlobalSignaldockNativeDb,
+    openDb: openSignaldockDbForSnapshot,
+  },
 ];
 
 /**
@@ -383,9 +506,19 @@ export async function vacuumIntoGlobalBackup(
     return { snapshotPath: '', rotated: [] };
   }
 
-  const db = target.getDb();
+  // T10316: eager-open via per-DB chokepoint when the in-process singleton
+  // is empty. Mirrors the project-tier fix in `snapshotOne` (Saga T10281 /
+  // E3 — brain backup gap).
+  let db = target.getDb();
   if (!db) {
-    return { snapshotPath: '', rotated: [] };
+    try {
+      db = await target.openDb();
+    } catch {
+      return { snapshotPath: '', rotated: [] };
+    }
+    if (!db) {
+      return { snapshotPath: '', rotated: [] };
+    }
   }
 
   const now = new Date();


### PR DESCRIPTION
## Summary

Closes the brain backup gap captured live during Saga T10281 (E3-BACKUP-RECOVERY). `vacuumIntoBackupAll` — wired into the `backup-session-end` hook fired on every `cleo session end` — was silently skipping brain.db whenever its native singleton handle had not been lazily opened earlier in the process. Production evidence: 22 `tasks-*.db` snapshots accumulated under `.cleo/backups/sqlite/`, zero `brain-*.db` snapshots, despite every session-end firing the pipeline. The mock-based TC-100 unit test passed because it injected a non-null handle directly.

**Root cause** (`packages/core/src/store/sqlite-backup.ts:152`):
```ts
function snapshotOne(target, backupDir, now) {
  const db = target.getDb();
  if (!db) return; // DB not initialized — skip silently
```
`target.getDb` is the fast-path in-process cache lookup — empty on any fresh node process that never lazily opened brain.

**Fix** (Option A from the forensic note): extend `SnapshotTarget` with an `openDb(cwd)` method that flows through the canonical per-DB chokepoint (ADR-068). `snapshotOne` falls through to `target.openDb(cwd)` when the fast path misses. Brain opens via `getBrainDb(cwd)`, tasks via `getDb(cwd)`, conduit via `ensureConduitDb`, nexus via `getNexusDb()`, signaldock via `ensureGlobalSignaldockDb()`. All openers live in `packages/core/src/store/**` — the canonical allowlist root under the db-open-guard CI gate. `vacuumIntoGlobalBackup` gets the same eager-open treatment.

## Tests

- **New real-process regression test** (`packages/core/src/store/__tests__/sqlite-backup-real-process.test.ts`) — spawns a fresh node child via `spawnSync`, sets isolated `CLEO_HOME` + `CLEO_DIR` + `XDG_DATA_HOME` per the forensic note's contract, invokes `vacuumIntoBackupAll({ cwd, force: true })`, asserts `brain-YYYYMMDD-HHmmss.db` lands in the backup dir. Confirmed locally: brain, tasks, AND conduit snapshot files all land in `<cwd>/.cleo/backups/sqlite/` after the fix.
- **Extended TC-100 mock test** — one new case proves the openDb fallback fires when `getBrainNativeDb` returns null. Original 8 unit tests stay as the inner-contract guard. All 9 mock tests + 1 real-process test pass.

## Gates

- Biome: clean (2922 files)
- Build: full monorepo green
- Tests: all 25 sqlite-backup tests pass; 4 pre-existing `import-logging.test.ts` failures are unrelated (verified via `git stash` against main — same failures reproduce on main with my changes stashed, blocked by an unrelated project-root resolution issue under the per-worktree test runner).

## Test plan

- [x] `pnpm biome check .` — clean across 2922 files
- [x] `pnpm --filter @cleocode/core run build` — green
- [x] `pnpm --filter @cleocode/core exec vitest run src/store/__tests__/sqlite-backup{,-global,-real-process}.test.ts` — 25/25 pass
- [x] Real-process child writes `brain-*.db` to `<cwd>/.cleo/backups/sqlite/` (manual verification)
- [ ] Orchestrator dogfoods `cleo backup add --force` from main worktree on live brain.db (out of this PR's scope — handled by orchestrator per task instructions)

Closes T10316
Saga: T10281
Epic: T10284