### PR TITLE
feat(T10366): DocKind Writer Registry foundation (E2.1)

### DIFF
--- a/.changeset/t10366-e2-writer-registry.md
+++ b/.changeset/t10366-e2-writer-registry.md
@@ -1,0 +1,6 @@
+---
+id: t10366-e2-writer-registry
+tasks: [T10366]
+kind: feat
+summary: T10366 E2.1: DocKind Writer Registry foundation
+---

--- a/packages/core/src/docs/__tests__/writer-registry.test.ts
+++ b/packages/core/src/docs/__tests__/writer-registry.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for the DocKind Writer Registry (T10366).
+ *
+ * The registry maps every `BuiltinDocKind` to exactly ONE writer descriptor.
+ * Tests assert:
+ *
+ *   - Every `BUILTIN_DOC_KINDS` entry has a descriptor (coverage).
+ *   - No DocKind has more than one descriptor (no multi-writer collision).
+ *   - `for()` returns the correct verb + mode for representative kinds.
+ *   - `for()` throws `E_INVALID_KIND` on unknown kind.
+ *   - `validateNoCollisions()` returns `{ ok: true }` for the built-in map.
+ *   - `write()` consults the slug allocator before the writer (foundation).
+ *   - `.cleo/canon.yml` parity: every `ssot-first` descriptor matches a
+ *     `canonicalHome: 'ssot-first'` kind in the canon registry, and vice
+ *     versa.
+ *
+ * @task T10366
+ * @epic T10290
+ * @saga T10288
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { BUILTIN_DOC_KIND_VALUES, type BuiltinDocKind } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadCanonRegistry } from '../../session/canon-lint.js';
+import { WriterRegistry, WriterRegistryCollisionError } from '../writer-registry.js';
+
+// Project root — used by the canon.yml parity test to load the canonical
+// routing taxonomy. Walks up from this test file location to the repo root.
+// __dirname-equivalent via `import.meta.url` would also work; resolving from
+// process.cwd() is simpler and matches how vitest already runs.
+const PROJECT_ROOT = resolve(__dirname, '..', '..', '..', '..', '..');
+
+describe('WriterRegistry — coverage + uniqueness', () => {
+  it('every BUILTIN_DOC_KINDS entry has exactly one descriptor', () => {
+    const descriptors = WriterRegistry.list();
+    const registeredKinds = new Set(descriptors.map((d) => d.kind));
+
+    // Every builtin kind has a descriptor.
+    for (const kind of BUILTIN_DOC_KIND_VALUES) {
+      expect(registeredKinds.has(kind as BuiltinDocKind)).toBe(true);
+    }
+
+    // No descriptor references a non-builtin kind.
+    const builtinSet = new Set(BUILTIN_DOC_KIND_VALUES);
+    for (const desc of descriptors) {
+      expect(builtinSet.has(desc.kind)).toBe(true);
+    }
+
+    // Descriptor count matches builtin count (no duplicates, no extras).
+    expect(descriptors.length).toBe(BUILTIN_DOC_KIND_VALUES.length);
+  });
+
+  it('expects exactly 10 builtin DocKinds (T10366 snapshot)', () => {
+    // Pin the count so a new kind addition forces a deliberate registry
+    // update. When a kind is added to BUILTIN_DOC_KINDS, this assertion
+    // fails AND the coverage assertion above fails — both must be updated
+    // together.
+    expect(BUILTIN_DOC_KIND_VALUES.length).toBe(10);
+    expect(WriterRegistry.list().length).toBe(10);
+  });
+
+  it('hasCompleteCoverage returns true for the built-in map', () => {
+    expect(WriterRegistry.hasCompleteCoverage()).toBe(true);
+  });
+
+  it('validateNoCollisions returns { ok: true } for the built-in map', () => {
+    expect(WriterRegistry.validateNoCollisions()).toEqual({ ok: true });
+  });
+});
+
+describe('WriterRegistry.for — per-kind descriptor shape', () => {
+  it("returns a descriptor with mode 'ssot-first' for 'changeset'", () => {
+    const desc = WriterRegistry.for('changeset');
+    expect(desc.kind).toBe('changeset');
+    expect(desc.mode).toBe('ssot-first');
+    expect(desc.verb).toBe('changeset add');
+    expect(desc.dispatchOp).toBe('changeset.add');
+    expect(desc.coreFn).toBe('writeChangesetEntry');
+    expect(desc.sourcePath).toBe('packages/core/src/changesets/writer.ts');
+  });
+
+  it("returns a descriptor with mode 'ssot' for 'adr'", () => {
+    const desc = WriterRegistry.for('adr');
+    expect(desc.kind).toBe('adr');
+    expect(desc.mode).toBe('ssot');
+    expect(desc.verb).toBe('docs add');
+    expect(desc.dispatchOp).toBe('docs.add');
+  });
+
+  it("returns a 'system-managed' descriptor for 'llm-readme'", () => {
+    const desc = WriterRegistry.for('llm-readme');
+    expect(desc.mode).toBe('system-managed');
+    expect(desc.verb).toBe('system-managed');
+    expect(desc.coreFn).toBe('generateDocsLlmsTxt');
+  });
+
+  it("returns a 'system-managed' descriptor for 'release-note'", () => {
+    const desc = WriterRegistry.for('release-note');
+    expect(desc.mode).toBe('system-managed');
+    expect(desc.verb).toBe('system-managed');
+  });
+
+  it('throws E_INVALID_KIND when the kind is not registered', () => {
+    expect(() => WriterRegistry.for('not-a-real-kind' as BuiltinDocKind)).toThrow(/E_INVALID_KIND/);
+  });
+});
+
+describe('WriterRegistry — canon.yml parity', () => {
+  it('every ssot-first descriptor matches canon.yml canonicalHome', () => {
+    const canon = loadCanonRegistry(PROJECT_ROOT);
+    if (!canon) {
+      throw new Error(
+        `canon.yml not found at ${PROJECT_ROOT}/.cleo/canon.yml — ` + 'cannot run parity test',
+      );
+    }
+
+    for (const desc of WriterRegistry.list()) {
+      if (desc.mode !== 'ssot-first') continue;
+      const canonEntry = canon.kinds[desc.kind];
+      expect(canonEntry).toBeDefined();
+      if (canonEntry) {
+        expect(canonEntry.canonicalHome).toBe('ssot-first');
+      }
+    }
+  });
+
+  it('every ssot descriptor matches canon.yml canonicalHome (or maps to a system-managed routing)', () => {
+    const canon = loadCanonRegistry(PROJECT_ROOT);
+    if (!canon) {
+      throw new Error(`canon.yml not found at ${PROJECT_ROOT}/.cleo/canon.yml`);
+    }
+
+    for (const desc of WriterRegistry.list()) {
+      if (desc.mode !== 'ssot') continue;
+      const canonEntry = canon.kinds[desc.kind];
+      // ssot descriptors MUST exist in canon.yml — they are user-routed.
+      expect(canonEntry).toBeDefined();
+      if (canonEntry) {
+        // canon.yml may classify it as ssot OR ssot-first — both are valid
+        // "exists in canon" outcomes. The descriptor mode is the writer-side
+        // routing decision; canon is the consumer-side gate.
+        expect(['ssot', 'ssot-first']).toContain(canonEntry.canonicalHome);
+      }
+    }
+  });
+
+  it('every canon.yml ssot-first kind has a matching ssot-first descriptor (reverse parity)', () => {
+    const canon = loadCanonRegistry(PROJECT_ROOT);
+    if (!canon) {
+      throw new Error(`canon.yml not found at ${PROJECT_ROOT}/.cleo/canon.yml`);
+    }
+
+    const ssotFirstDescriptorKinds = new Set(
+      WriterRegistry.list()
+        .filter((d) => d.mode === 'ssot-first')
+        .map((d) => d.kind as string),
+    );
+
+    for (const [kind, entry] of Object.entries(canon.kinds)) {
+      if (entry.canonicalHome === 'ssot-first') {
+        expect(ssotFirstDescriptorKinds.has(kind)).toBe(true);
+      }
+    }
+  });
+});
+
+describe('WriterRegistry.write — slug allocator handshake (foundation)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-writer-registry-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+
+    const { _resetSlugAllocatorState_TESTING_ONLY } = await import('../slug-allocator.js');
+    _resetSlugAllocatorState_TESTING_ONLY();
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+    const { _resetSlugAllocatorState_TESTING_ONLY } = await import('../slug-allocator.js');
+    _resetSlugAllocatorState_TESTING_ONLY();
+    delete process.env['CLEO_DIR'];
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns E_INVALID_KIND for an unknown kind WITHOUT calling the allocator', async () => {
+    const result = await WriterRegistry.write({
+      kind: 'unknown-kind' as BuiltinDocKind,
+      slug: 'irrelevant',
+      payload: { slug: 'irrelevant' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('E_INVALID_KIND');
+    }
+  });
+
+  it('calls reserveSlug FIRST — returns E_NOT_IMPLEMENTED on success path (T10366 foundation)', async () => {
+    // T10366 is the foundation only; actual writer delegation lands in
+    // T10367 + T10368. The success path of `write()` therefore returns
+    // E_NOT_IMPLEMENTED with the resolved descriptor so callers can prove
+    // the registry was consulted and the slug was reserved.
+    const result = await WriterRegistry.write({
+      kind: 'changeset',
+      slug: 't10366-foundation',
+      payload: { slug: 't10366-foundation' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('E_NOT_IMPLEMENTED');
+      const details = result.details as { descriptor?: { kind?: string }; normalizedSlug?: string };
+      expect(details.descriptor?.kind).toBe('changeset');
+      expect(details.normalizedSlug).toBe('t10366-foundation');
+    }
+  });
+
+  it('short-circuits on E_SLUG_RESERVED — collision returns the allocator suggestions', async () => {
+    const { reserveSlug } = await import('../slug-allocator.js');
+
+    // Pre-reserve the slug so the registry's allocator call collides.
+    const pre = await reserveSlug('changeset', 'pre-taken');
+    expect(pre.ok).toBe(true);
+
+    const result = await WriterRegistry.write({
+      kind: 'changeset',
+      slug: 'pre-taken',
+      payload: { slug: 'pre-taken' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('E_SLUG_RESERVED');
+      const details = result.details as { suggestions?: string[] };
+      expect(details.suggestions).toHaveLength(3);
+    }
+  });
+});
+
+describe('WriterRegistryCollisionError', () => {
+  it('carries the offending kind + count', () => {
+    const err = new WriterRegistryCollisionError('changeset', 2);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('WriterRegistryCollisionError');
+    expect(err.kind).toBe('changeset');
+    expect(err.message).toContain('changeset');
+    expect(err.message).toContain('2');
+  });
+});

--- a/packages/core/src/docs/writer-registry.ts
+++ b/packages/core/src/docs/writer-registry.ts
@@ -1,0 +1,460 @@
+/**
+ * DocKind Writer Registry — single source of truth for "which verb writes
+ * which DocKind".
+ *
+ * ## Why this module exists
+ *
+ * Before this module, the mapping from `BuiltinDocKind` to its canonical
+ * writer was implicit and spread across multiple call sites:
+ *
+ *   - `cleo docs add`        → `packages/cleo/src/dispatch/domains/docs.ts:add`
+ *   - `cleo changeset add`   → `packages/core/src/changesets/writer.ts:writeChangesetEntry`
+ *   - System-managed kinds   → no exported writer (composed by tooling)
+ *
+ * Two parallel writer paths can (and historically did) call
+ * `attachmentStore.put({ slug })` for the SAME `BuiltinDocKind` through
+ * different code paths and surface conflicts through DIFFERENT envelopes.
+ * T10294 (PR #576) RCA classified this as the slug-collision class — see
+ * `option (c)`: collapse writers AND introduce a chokepoint allocator.
+ *
+ * This module is the writer-registry half of that fix. The allocator half is
+ * already delivered by T10392 (`reserveSlug` in
+ * {@link ./slug-allocator.js}). Together they make the contract explicit:
+ *
+ *   1. For every `BuiltinDocKind` there is EXACTLY ONE
+ *      {@link WriterDescriptor} in the registry.
+ *   2. Every caller that wants to write a doc of a given kind goes through
+ *      {@link WriterRegistry.write}, which calls {@link reserveSlug} BEFORE
+ *      the actual writer.
+ *   3. A multi-writer regression trips {@link WriterRegistry.for} at
+ *      registry-build time — surfaced as a programmer error in dev/CI
+ *      rather than a silent envelope drift in production.
+ *
+ * ## Scope of THIS task (T10366)
+ *
+ * T10366 establishes the registry CONTRACT and shape. Actual writer
+ * delegation wiring lands in T10367 + T10368. {@link WriterRegistry.write}
+ * therefore currently:
+ *   - Validates the kind.
+ *   - Calls {@link reserveSlug} (the T10392 chokepoint).
+ *   - Returns a placeholder `attachmentId` on success — downstream tasks
+ *     replace the placeholder with the actual writer dispatch.
+ *
+ * The descriptor map IS the contract — downstream consumers (T10367 wires
+ * `docs add`, T10368 wires `changeset add`) read the `coreFn`/`dispatchOp`
+ * fields to resolve the writer at the same call site.
+ *
+ * ## canon.yml parity
+ *
+ * Every descriptor with `mode: 'ssot-first'` MUST match a kind in
+ * `.cleo/canon.yml` whose `canonicalHome === 'ssot-first'`. The parity
+ * test (`writer-registry.test.ts`) enforces this by loading both the
+ * registry and the canon-yml file and asserting one-for-one alignment.
+ *
+ * @task T10366
+ * @epic T10290
+ * @saga T10288
+ * @adr ADR-076 (canon routing), ADR-083 (Cleo persona)
+ */
+
+import type { BuiltinDocKind } from '@cleocode/contracts';
+import { BUILTIN_DOC_KIND_VALUES } from '@cleocode/contracts';
+import { reserveSlug, type SlugReserveResult } from './slug-allocator.js';
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/**
+ * Verb classification for a writer descriptor.
+ *
+ * - `'docs add'`          — the kind is created via `cleo docs add`.
+ * - `'changeset add'`     — the kind is created via `cleo changeset add`
+ *                            (dual-write to file + SSoT).
+ * - `'system-managed'`    — the kind is written by tooling (e.g. release
+ *                            composer, llms.txt generator) rather than a
+ *                            user-facing CLI verb. `coreFn` is still set
+ *                            so downstream code can resolve the producer.
+ */
+export type WriterVerb = 'docs add' | 'changeset add' | 'system-managed';
+
+/**
+ * Routing taxonomy parallel to `.cleo/canon.yml`'s `canonicalHome`.
+ *
+ * - `'ssot'`            — canonical bytes live ONLY in the blob store.
+ * - `'ssot-first'`      — dual-write via a dedicated `cleo` verb; the
+ *                          publishMirror is git-tracked by contract.
+ * - `'system-managed'`  — written by tooling; SSoT routing is implicit
+ *                          (no user-facing routing decision).
+ */
+export type WriterMode = 'ssot' | 'ssot-first' | 'system-managed';
+
+/**
+ * Canonical descriptor for the writer of a single `BuiltinDocKind`.
+ *
+ * Every field is intentionally a primitive so the descriptor map can be
+ * serialised, inspected by drift tooling, and asserted against
+ * `.cleo/canon.yml` in tests.
+ */
+export interface WriterDescriptor {
+  /** The DocKind this descriptor governs. */
+  readonly kind: BuiltinDocKind;
+  /** User-facing CLI verb that writes this kind. */
+  readonly verb: WriterVerb;
+  /** Dispatch op identifier — matches `<domain>.<op>` in the dispatch layer. */
+  readonly dispatchOp: string;
+  /**
+   * Name of the canonical core function that actually writes the bytes.
+   *
+   * For `'docs add'` the entry point IS the dispatch handler (no exported
+   * core function), so `coreFn` points at the dispatch op shorthand. For
+   * `'changeset add'` it points at the core writer
+   * ({@link writeChangesetEntry}). For `'system-managed'` it names the
+   * producer function (e.g. `generateDocsLlmsTxt`).
+   */
+  readonly coreFn: string;
+  /** Routing mode — parallel to `.cleo/canon.yml`'s `canonicalHome`. */
+  readonly mode: WriterMode;
+  /** Repo-relative path where the writer code lives. */
+  readonly sourcePath: string;
+}
+
+/**
+ * Result of a {@link WriterRegistry.write} call.
+ *
+ * Discriminated by `ok`. On failure the `code` field carries the canonical
+ * error identifier; `details` is reserved for downstream tasks to attach
+ * `suggestions` (slug-collision case) or wrapped writer errors.
+ */
+export type WriteResult =
+  | {
+      readonly ok: true;
+      readonly attachmentId: string;
+      readonly slug: string;
+    }
+  | {
+      readonly ok: false;
+      readonly code:
+        | 'E_SLUG_RESERVED'
+        | 'E_INVALID_KIND'
+        | 'E_FILE_WRITE_FAILED'
+        | 'E_SSOT_WRITE_FAILED'
+        | 'E_NOT_IMPLEMENTED';
+      readonly details?: unknown;
+    };
+
+/**
+ * Payload shape accepted by {@link WriterRegistry.write}.
+ *
+ * Intentionally permissive — each kind's writer (wired by T10367/T10368)
+ * narrows the payload further at the delegation site. The registry only
+ * cares about the slug for the allocator handshake; the rest is opaque.
+ */
+export interface WritePayload {
+  readonly slug: string;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Options forwarded to {@link reserveSlug} (and, downstream, to the actual
+ * writer).
+ */
+export interface WriteOptions {
+  /** Optional cwd for `.cleo/` resolution. */
+  readonly cwd?: string;
+}
+
+/**
+ * Argument shape accepted by {@link WriterRegistry.write}.
+ */
+export interface WriteArgs {
+  readonly kind: BuiltinDocKind;
+  readonly slug: string;
+  readonly payload: WritePayload;
+  readonly opts?: WriteOptions;
+}
+
+// ─── Custom error thrown by `for(kind)` on multi-writer collision ────────────
+
+/**
+ * Programmer-error raised by {@link WriterRegistry.for} when more than one
+ * descriptor exists for the same DocKind.
+ *
+ * Multi-writer collision is the slug-collision class root cause T10294
+ * identified. Catching it at registry build time keeps the regression from
+ * shipping. Tests assert this is never raised under the built-in map.
+ */
+export class WriterRegistryCollisionError extends Error {
+  /** The DocKind that had more than one descriptor. */
+  readonly kind: BuiltinDocKind;
+
+  constructor(kind: BuiltinDocKind, count: number) {
+    super(
+      `WriterRegistry: kind '${kind}' has ${count} descriptors; ` +
+        'exactly one writer per DocKind is required (T10366)',
+    );
+    this.name = 'WriterRegistryCollisionError';
+    this.kind = kind;
+  }
+}
+
+// ─── Descriptor list (declaration order = test enumeration order) ────────────
+
+/**
+ * Canonical descriptor list — exactly ONE entry per `BuiltinDocKind`.
+ *
+ * Declared as an array so the test suite can detect duplicates by counting
+ * occurrences of each kind. {@link WriterRegistry} consumes this and
+ * materialises the lookup map.
+ *
+ * Order matches `BUILTIN_DOC_KINDS` so a diff between the two surfaces is
+ * easy to spot. A new kind in {@link
+ * '@cleocode/contracts'.BUILTIN_DOC_KINDS} REQUIRES a matching descriptor
+ * here — the test suite enforces this by asserting `kinds === values`.
+ */
+const DESCRIPTORS: ReadonlyArray<WriterDescriptor> = Object.freeze([
+  {
+    kind: 'adr',
+    verb: 'docs add',
+    dispatchOp: 'docs.add',
+    coreFn: 'docs.add (dispatch handler)',
+    mode: 'ssot',
+    sourcePath: 'packages/cleo/src/dispatch/domains/docs.ts',
+  },
+  {
+    kind: 'spec',
+    verb: 'docs add',
+    dispatchOp: 'docs.add',
+    coreFn: 'docs.add (dispatch handler)',
+    mode: 'ssot',
+    sourcePath: 'packages/cleo/src/dispatch/domains/docs.ts',
+  },
+  {
+    kind: 'research',
+    verb: 'docs add',
+    dispatchOp: 'docs.add',
+    coreFn: 'docs.add (dispatch handler)',
+    mode: 'ssot',
+    sourcePath: 'packages/cleo/src/dispatch/domains/docs.ts',
+  },
+  {
+    kind: 'handoff',
+    verb: 'docs add',
+    dispatchOp: 'docs.add',
+    coreFn: 'docs.add (dispatch handler)',
+    mode: 'ssot',
+    sourcePath: 'packages/cleo/src/dispatch/domains/docs.ts',
+  },
+  {
+    kind: 'note',
+    verb: 'docs add',
+    dispatchOp: 'docs.add',
+    coreFn: 'docs.add (dispatch handler)',
+    mode: 'ssot',
+    sourcePath: 'packages/cleo/src/dispatch/domains/docs.ts',
+  },
+  {
+    kind: 'llm-readme',
+    verb: 'system-managed',
+    dispatchOp: 'docs.generate',
+    coreFn: 'generateDocsLlmsTxt',
+    mode: 'system-managed',
+    sourcePath: 'packages/core/src/docs/docs-generator.ts',
+  },
+  {
+    kind: 'changeset',
+    verb: 'changeset add',
+    dispatchOp: 'changeset.add',
+    coreFn: 'writeChangesetEntry',
+    mode: 'ssot-first',
+    sourcePath: 'packages/core/src/changesets/writer.ts',
+  },
+  {
+    kind: 'release-note',
+    verb: 'system-managed',
+    dispatchOp: 'release.reconcile',
+    coreFn: 'composeReleaseNotes',
+    mode: 'system-managed',
+    sourcePath: 'packages/core/src/release/reconcile.ts',
+  },
+  {
+    kind: 'plan',
+    verb: 'docs add',
+    dispatchOp: 'docs.add',
+    coreFn: 'docs.add (dispatch handler)',
+    mode: 'ssot',
+    sourcePath: 'packages/cleo/src/dispatch/domains/docs.ts',
+  },
+  {
+    kind: 'rcasd',
+    verb: 'docs add',
+    dispatchOp: 'docs.add',
+    coreFn: 'docs.add (dispatch handler)',
+    mode: 'ssot',
+    sourcePath: 'packages/cleo/src/dispatch/domains/docs.ts',
+  },
+]);
+
+// ─── Registry class ───────────────────────────────────────────────────────────
+
+/**
+ * Central registry mapping every `BuiltinDocKind` to its canonical writer.
+ *
+ * Static-only — there is exactly ONE registry per process. Tests that need
+ * to inspect descriptors use {@link WriterRegistry.list} (read-only). The
+ * static-class shape is deliberate: callers reach it as
+ * `WriterRegistry.for(kind)` mirroring `DocKindRegistry` in
+ * `@cleocode/contracts`, and the lazy `descriptors` field gives us a
+ * compile-time anchor for the collision check (runs once at module load).
+ *
+ * @task T10366
+ */
+// biome-ignore lint/complexity/noStaticOnlyClass: matches DocKindRegistry shape; static-readonly map runs the collision check at module load so a regression trips dev/CI immediately. A standalone-function form would lose the "registry as a typed namespace" affordance callers already use.
+export class WriterRegistry {
+  /**
+   * Internal lookup map. Built once at module load from {@link DESCRIPTORS}
+   * via {@link WriterRegistry.buildDescriptorMap}. Multi-writer collisions
+   * raise {@link WriterRegistryCollisionError} at build time.
+   *
+   * @internal
+   */
+  private static readonly descriptors: ReadonlyMap<BuiltinDocKind, WriterDescriptor> =
+    WriterRegistry.buildDescriptorMap();
+
+  /**
+   * Build the lookup map from {@link DESCRIPTORS}, asserting uniqueness.
+   *
+   * @internal
+   */
+  private static buildDescriptorMap(): ReadonlyMap<BuiltinDocKind, WriterDescriptor> {
+    const counts = new Map<BuiltinDocKind, number>();
+    for (const desc of DESCRIPTORS) {
+      counts.set(desc.kind, (counts.get(desc.kind) ?? 0) + 1);
+    }
+    for (const [kind, count] of counts) {
+      if (count > 1) {
+        throw new WriterRegistryCollisionError(kind, count);
+      }
+    }
+    const map = new Map<BuiltinDocKind, WriterDescriptor>();
+    for (const desc of DESCRIPTORS) {
+      map.set(desc.kind, desc);
+    }
+    return map;
+  }
+
+  /**
+   * Look up the writer descriptor for a given DocKind.
+   *
+   * @throws Error with code `E_INVALID_KIND` when `kind` is not registered.
+   */
+  static for(kind: BuiltinDocKind): WriterDescriptor {
+    const desc = WriterRegistry.descriptors.get(kind);
+    if (!desc) {
+      throw new Error(`E_INVALID_KIND: no writer registered for DocKind '${kind}'`);
+    }
+    return desc;
+  }
+
+  /**
+   * Read-only view of every registered descriptor (declaration order).
+   *
+   * Used by tests + drift tooling — never mutate the result. Built-in
+   * kinds always sort in the order declared by `BUILTIN_DOC_KINDS`.
+   */
+  static list(): ReadonlyArray<WriterDescriptor> {
+    return DESCRIPTORS;
+  }
+
+  /**
+   * Confirm the registry holds exactly one descriptor per `BuiltinDocKind`.
+   *
+   * Tests assert this as a fast smoke check. Returns the offending kind on
+   * collision (the build-time constructor would have thrown earlier, but the
+   * static helper keeps the test surface friendly).
+   */
+  static validateNoCollisions():
+    | { readonly ok: true }
+    | {
+        readonly ok: false;
+        readonly kind: BuiltinDocKind;
+        readonly count: number;
+      } {
+    const counts = new Map<BuiltinDocKind, number>();
+    for (const desc of DESCRIPTORS) {
+      counts.set(desc.kind, (counts.get(desc.kind) ?? 0) + 1);
+    }
+    for (const [kind, count] of counts) {
+      if (count > 1) return { ok: false, kind, count };
+    }
+    return { ok: true };
+  }
+
+  /**
+   * True when every `BuiltinDocKind` from
+   * {@link BUILTIN_DOC_KIND_VALUES} has a descriptor.
+   *
+   * Used by the parity test to fail-fast when a new kind is added to
+   * `BUILTIN_DOC_KINDS` without a matching writer descriptor.
+   */
+  static hasCompleteCoverage(): boolean {
+    const registered = new Set(DESCRIPTORS.map((d) => d.kind));
+    for (const kind of BUILTIN_DOC_KIND_VALUES) {
+      if (!registered.has(kind as BuiltinDocKind)) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Foundation entry point for the unified write contract.
+   *
+   * T10366 (this task) wires the slug-allocator handshake; T10367 +
+   * T10368 layer in the actual writer delegation. Behaviour today:
+   *
+   *   1. Look up the descriptor for `args.kind` — `E_INVALID_KIND` on miss.
+   *   2. Call {@link reserveSlug} — `E_SLUG_RESERVED` propagates on conflict.
+   *   3. Return `E_NOT_IMPLEMENTED` with the descriptor so downstream tasks
+   *      can prove the registry was consulted.
+   *
+   * Once T10367/T10368 wire delegation the `E_NOT_IMPLEMENTED` branch is
+   * replaced by an actual writer dispatch — the public signature stays
+   * unchanged.
+   *
+   * @param args - The kind, slug, payload, and optional cwd.
+   * @returns Discriminated `WriteResult`.
+   */
+  static async write(args: WriteArgs): Promise<WriteResult> {
+    // 1. Resolve the descriptor (throws on unknown kind).
+    let descriptor: WriterDescriptor;
+    try {
+      descriptor = WriterRegistry.for(args.kind);
+    } catch {
+      return { ok: false, code: 'E_INVALID_KIND', details: { kind: args.kind } };
+    }
+
+    // 2. Reserve the slug through the T10392 chokepoint.
+    const reservation: SlugReserveResult = await reserveSlug(args.kind, args.slug, args.opts);
+    if (!reservation.ok) {
+      return {
+        ok: false,
+        code: 'E_SLUG_RESERVED',
+        details: { suggestions: reservation.suggestions },
+      };
+    }
+
+    // 3. Delegation placeholder — downstream tasks (T10367/T10368) replace
+    // this branch with the actual writer dispatch. The descriptor is
+    // surfaced so callers can verify the registry was consulted, and the
+    // reserved slug is returned via `details` so the caller's release path
+    // can call `releaseReservedSlug` if it decides to abort.
+    return {
+      ok: false,
+      code: 'E_NOT_IMPLEMENTED',
+      details: {
+        message:
+          'WriterRegistry.write is a foundation entry point — actual writer ' +
+          'delegation lands in T10367 (docs add) and T10368 (changeset add).',
+        descriptor,
+        normalizedSlug: reservation.normalizedSlug,
+      },
+    };
+  }
+}

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -263,6 +263,17 @@ export {
   releaseReservedSlug,
   reserveSlug,
 } from './docs/slug-allocator.js';
+// DocKind Writer Registry (T10366 / Saga T10288 / Epic T10290)
+export type {
+  WriteArgs,
+  WriteOptions,
+  WritePayload,
+  WriteResult,
+  WriterDescriptor,
+  WriterMode,
+  WriterVerb,
+} from './docs/writer-registry.js';
+export { WriterRegistry, WriterRegistryCollisionError } from './docs/writer-registry.js';
 // Git hooks (T1588) — project-agnostic POSIX commit-msg + pre-push T-ID enforcement
 export type {
   CleoHookName,

--- a/packages/skills/skills/ct-documentor/SKILL.md
+++ b/packages/skills/skills/ct-documentor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ct-documentor
 description: Documentation coordinator with CLEO style guide compliance. Routes every canonical-doc write (spec, adr, research, handoff, note, llm-readme) through the docs SSoT via `cleo docs add` / `cleo docs publish` / `cleo docs fetch` — never raw filesystem writes. Coordinates ct-docs-lookup, ct-docs-write, ct-docs-review, ct-spec-writer, and ct-adr-recorder. Use when creating or updating documentation files, consolidating scattered documentation, or validating documentation against style standards. Triggers on documentation tasks, doc update requests, or style guide compliance checks.
-version: 3.2.0
+version: 3.3.0
 tier: 3
 core: false
 category: specialist
@@ -150,6 +150,36 @@ Slugs share a GLOBAL namespace across all DocKinds — `reserveSlug('changeset',
 'foo')` followed by `reserveSlug('research', 'foo')` collides (decision
 T10390 / E1.5). Matches the `uniq_attachments_slug` partial UNIQUE INDEX in
 migration `20260519000001`.
+
+#### One writer per DocKind — WriterRegistry SSoT (T10366 · Saga T10288 / Epic T10290)
+
+`packages/core/src/docs/writer-registry.ts:WriterRegistry` is the SSoT for
+"which CLI verb writes which DocKind". Every `BuiltinDocKind` maps to EXACTLY
+ONE writer descriptor — multi-writer regressions trip the registry at build
+time (the slug-collision class root-cause from T10294).
+
+```ts
+import { WriterRegistry } from '@cleocode/core/internal';
+
+const desc = WriterRegistry.for('changeset');
+// → { kind: 'changeset', verb: 'changeset add', dispatchOp: 'changeset.add',
+//     coreFn: 'writeChangesetEntry', mode: 'ssot-first',
+//     sourcePath: 'packages/core/src/changesets/writer.ts' }
+```
+
+Descriptor modes mirror `.cleo/canon.yml`'s `canonicalHome`:
+- `'ssot'` — bytes live in the blob store; published copy is a mirror.
+- `'ssot-first'` — dual-write via a dedicated verb (`changeset` today).
+- `'system-managed'` — tooling-composed (e.g. `llm-readme`, `release-note`).
+
+Test parity: every `ssot-first` descriptor MUST match a kind whose
+`canonicalHome: 'ssot-first'` in `.cleo/canon.yml`, and vice versa.
+
+T10366 establishes the registry contract; T10367 (docs add) and T10368
+(changeset add) wire the actual writer delegation. Until those land,
+`WriterRegistry.write()` returns `E_NOT_IMPLEMENTED` after consulting the
+allocator — callers should continue invoking the existing writers
+(`cleo docs add` dispatch handler, `writeChangesetEntry`) directly.
 
 ### Publish to a git-tracked path (when the doc must live on disk)
 


### PR DESCRIPTION
## Summary
- WriterRegistry maps every BuiltinDocKind to ONE writer descriptor
- Consumes T10392 reserveSlug allocator (chokepoint)
- canon.yml parity test for ssot-first kinds (forward + reverse parity)
- Tier-0 ct-documentor SKILL.md drift in the same PR

## Saga
- Saga: T10288 SG-DOCS-INTEGRITY (Wave 2.A)
- Epic: T10290 E2-DOCS-DOCKIND-WRITER-DEDUP
- Builds on T10392 (E1.1, PR #587)
- Foundation for T-E2.2 (T10367), T-E2.3 (T10368)

## Test plan
- [x] All 16 WriterRegistry tests pass locally
- [x] canon.yml parity test asserts every ssot-first descriptor matches `.cleo/canon.yml`
- [x] reverse parity: every ssot-first canon kind has matching ssot-first descriptor
- [x] Coverage: 10 BuiltinDocKinds, 10 descriptors (exactly one per kind)
- [x] `WriterRegistry.write()` short-circuits on E_SLUG_RESERVED with allocator suggestions