### PR TITLE
T10317: vacuumIntoBackupAll covers every DB_INVENTORY entry (Saga T10281 / E3)

### DIFF
--- a/.changeset/T10317.md
+++ b/.changeset/T10317.md
@@ -1,0 +1,24 @@
+---
+id: T10317
+tasks: [T10317]
+kind: feat
+summary: vacuumIntoBackupAll covers every DB_INVENTORY entry (Saga T10281 / Epic T10284 / E3-BACKUP-RECOVERY)
+---
+
+Extends the SQLite snapshot pipeline so EVERY row in `DB_INVENTORY` (`@cleocode/contracts`) produces a snapshot at session-end / `cleo backup add`. Closes the long-tail gap T10316 surfaced: even with the brain eager-open fix in place, `vacuumIntoBackupAll` still ignored telemetry, skills, signaldock-global, the llmtxt reserved row, the signaldock-project historical row, and the two `global-brain` / `global-tasks` orphans surfaced by the saga T10281 inventory audit.
+
+**What changed**
+
+- `packages/core/src/store/sqlite-backup.ts` now derives `SNAPSHOT_TARGETS` + `GLOBAL_SNAPSHOT_TARGETS` from `DB_INVENTORY` instead of a hand-rolled list. Each inventory row is classified into one of three snapshot strategies:
+  - **`chokepoint-opener`** — `tasks`, `brain`, `conduit`, `nexus`, `signaldock-global`, `telemetry`, `skills`. Snapshot via the canonical per-DB opener (`getDb`, `getBrainDb`, `ensureConduitDb`, `getNexusDb`, `ensureGlobalSignaldockDb`, `getTelemetryDb`, `openSkillsDb`) — all live under `packages/core/src/store/**`, the canonical allowlist root for the db-open-guard CI gate (ADR-068).
+  - **`raw-file-vacuum-readonly`** — `llmtxt` (RESERVED), `signaldock-project` (HISTORICAL), `global-brain` / `global-tasks` (UNREGISTERED ORPHANS), and `manifest` when opted in. The path is resolved via the inventory's `filePathTemplate`, the file is checked for existence, then opened read-only via a one-shot `DatabaseSync` (allowlisted under the chokepoint root) to emit `PRAGMA wal_checkpoint(TRUNCATE)` + `VACUUM INTO`, then closed.
+  - **`skip-derived`** — `manifest` (`tier === 'derived'`, `backupPath === 'rebuildable-from-blob-store'`). Listed in coverage and surfaced in `listSqliteBackupsAll` as an always-empty bucket, but never snapshotted — its content is rebuildable from the blob CAS.
+- New public exports: `vacuumIntoGlobalBackupAll(opts)`, `listGlobalSqliteBackupsAll(cleoHomeOverride?)`, `describeSnapshotCoverage()`, `GlobalBackupName` extended with `telemetry`, `skills`, `global-brain`, `global-tasks`.
+- `getTelemetryNativeDb()` added to `packages/core/src/telemetry/sqlite.ts` so the backup pipeline can issue `wal_checkpoint` + `VACUUM INTO` against the live singleton without re-resolving the path.
+
+**Tests**
+
+- Mock-driven coverage in `sqlite-backup.test.ts` extended with three T10317 assertions: every inventory role surfaces in `describeSnapshotCoverage()` exactly once, chokepoint roles always classify to `chokepoint-opener`, derived rows always classify to `skip-derived`. Existing snapshot tests neutralise the new telemetry / skills / signaldock-global / nexus imports so they cannot leak filesystem writes into the developer's `$XDG_DATA_HOME`.
+- New TC-200 through TC-205 in `sqlite-backup-global.test.ts` exercise the global-tier surface: telemetry + skills via chokepoint opener, `global-brain` via the raw-file read-only path, `global-tasks` clean-skip when the on-disk file is absent, full-fleet iteration via `vacuumIntoGlobalBackupAll`, and the audit listing in `listGlobalSqliteBackupsAll`.
+
+Saga: T10281; Epic: T10284 (E3-BACKUP-RECOVERY).

--- a/packages/core/src/store/__tests__/sqlite-backup-global.test.ts
+++ b/packages/core/src/store/__tests__/sqlite-backup-global.test.ts
@@ -547,6 +547,301 @@ describe('sqlite-backup global tier', () => {
     expect(all['conduit']?.[0]?.name).toBe('conduit-20260101-120000.db');
   });
 
+  // ==========================================================================
+  // T10317 — fleet snapshot coverage for every DB_INVENTORY global-tier row
+  // ==========================================================================
+
+  /**
+   * TC-200: vacuumIntoGlobalBackup('telemetry') writes a snapshot to the
+   * global backups dir when the live telemetry.db handle is non-null.
+   *
+   * @task T10317
+   * @saga T10281
+   * @epic T10284
+   */
+  it('TC-200: vacuumIntoGlobalBackup(telemetry) writes snapshot to global backups dir', async () => {
+    vi.resetModules();
+    const cleoHome = join(tmpdir(), `cleo-tc200-${Date.now()}`);
+    const telemetryDbPath = join(cleoHome, 'telemetry.db');
+    mkdirSync(cleoHome, { recursive: true });
+    seedSqliteDb(telemetryDbPath);
+
+    const telDb = new DatabaseSync(telemetryDbPath);
+    vi.doMock('../../telemetry/sqlite.js', () => ({
+      getTelemetryDb: async () => null,
+      getTelemetryNativeDb: () => telDb,
+    }));
+    vi.doMock('../nexus-sqlite.js', () => ({ getNexusNativeDb: () => null }));
+    vi.doMock('../signaldock-sqlite.js', () => ({
+      getGlobalSignaldockNativeDb: () => null,
+      ensureGlobalSignaldockDb: async () => undefined,
+    }));
+    vi.doMock('../skills-db.js', () => ({
+      openSkillsDb: async () => null,
+      getSkillsNativeDb: () => null,
+    }));
+    vi.doMock('../../paths.js', () => ({ getCleoHome: () => cleoHome }));
+
+    const { vacuumIntoGlobalBackup } = await import('../sqlite-backup.js');
+    const result = await vacuumIntoGlobalBackup('telemetry', { cleoHomeOverride: cleoHome });
+
+    telDb.close();
+
+    expect(result.snapshotPath).toBeTruthy();
+    expect(result.snapshotPath).toContain('telemetry-');
+    expect(result.snapshotPath).toContain(join(cleoHome, 'backups', 'sqlite'));
+    expect(existsSync(result.snapshotPath)).toBe(true);
+
+    // Integrity check on the snapshot.
+    const snap = new DatabaseSync(result.snapshotPath, { readOnly: true });
+    try {
+      const row = snap.prepare('PRAGMA integrity_check').get() as Record<string, unknown>;
+      expect(row?.['integrity_check'] ?? row?.['integrity check']).toBe('ok');
+    } finally {
+      snap.close();
+    }
+  });
+
+  /**
+   * TC-201: vacuumIntoGlobalBackup('skills') writes a snapshot to the
+   * global backups dir when the live skills.db handle is non-null.
+   *
+   * @task T10317
+   */
+  it('TC-201: vacuumIntoGlobalBackup(skills) writes snapshot to global backups dir', async () => {
+    vi.resetModules();
+    const cleoHome = join(tmpdir(), `cleo-tc201-${Date.now()}`);
+    const skillsDbPath = join(cleoHome, 'skills.db');
+    mkdirSync(cleoHome, { recursive: true });
+    seedSqliteDb(skillsDbPath);
+
+    const skDb = new DatabaseSync(skillsDbPath);
+    vi.doMock('../skills-db.js', () => ({
+      openSkillsDb: async () => null,
+      getSkillsNativeDb: () => skDb,
+    }));
+    vi.doMock('../../telemetry/sqlite.js', () => ({
+      getTelemetryDb: async () => null,
+      getTelemetryNativeDb: () => null,
+    }));
+    vi.doMock('../nexus-sqlite.js', () => ({ getNexusNativeDb: () => null }));
+    vi.doMock('../signaldock-sqlite.js', () => ({
+      getGlobalSignaldockNativeDb: () => null,
+      ensureGlobalSignaldockDb: async () => undefined,
+    }));
+    vi.doMock('../../paths.js', () => ({ getCleoHome: () => cleoHome }));
+
+    const { vacuumIntoGlobalBackup } = await import('../sqlite-backup.js');
+    const result = await vacuumIntoGlobalBackup('skills', { cleoHomeOverride: cleoHome });
+
+    skDb.close();
+
+    expect(result.snapshotPath).toBeTruthy();
+    expect(result.snapshotPath).toContain('skills-');
+    expect(existsSync(result.snapshotPath)).toBe(true);
+  });
+
+  /**
+   * TC-202: vacuumIntoGlobalBackup('global-brain') snapshots the orphan
+   * file via the raw-file-vacuum-readonly strategy. Orphan files exist on
+   * disk without a registered live opener; the snapshot path opens them
+   * read-only via a one-shot DatabaseSync.
+   *
+   * @task T10317
+   */
+  it('TC-202: vacuumIntoGlobalBackup(global-brain) snapshots via raw-file-vacuum-readonly', async () => {
+    vi.resetModules();
+    const cleoHome = join(tmpdir(), `cleo-tc202-${Date.now()}`);
+    const orphanPath = join(cleoHome, 'brain.db');
+    mkdirSync(cleoHome, { recursive: true });
+    seedSqliteDb(orphanPath);
+
+    // Provide neutral stubs for all chokepoint-opener modules so they do
+    // not leak file-system writes to the developer's machine.
+    vi.doMock('../nexus-sqlite.js', () => ({ getNexusNativeDb: () => null }));
+    vi.doMock('../signaldock-sqlite.js', () => ({
+      getGlobalSignaldockNativeDb: () => null,
+      ensureGlobalSignaldockDb: async () => undefined,
+    }));
+    vi.doMock('../skills-db.js', () => ({
+      openSkillsDb: async () => null,
+      getSkillsNativeDb: () => null,
+    }));
+    vi.doMock('../../telemetry/sqlite.js', () => ({
+      getTelemetryDb: async () => null,
+      getTelemetryNativeDb: () => null,
+    }));
+    vi.doMock('../../paths.js', () => ({ getCleoHome: () => cleoHome }));
+
+    const { vacuumIntoGlobalBackup } = await import('../sqlite-backup.js');
+    const result = await vacuumIntoGlobalBackup('global-brain', { cleoHomeOverride: cleoHome });
+
+    expect(result.snapshotPath).toBeTruthy();
+    expect(result.snapshotPath).toContain('global-brain-');
+    expect(existsSync(result.snapshotPath)).toBe(true);
+
+    const snap = new DatabaseSync(result.snapshotPath, { readOnly: true });
+    try {
+      const row = snap.prepare('PRAGMA integrity_check').get() as Record<string, unknown>;
+      expect(row?.['integrity_check'] ?? row?.['integrity check']).toBe('ok');
+    } finally {
+      snap.close();
+    }
+  });
+
+  /**
+   * TC-203: vacuumIntoGlobalBackup('global-tasks') with NO file on disk is
+   * a clean skip (returns empty result, no throw). Raw-file-vacuum-readonly
+   * MUST NOT materialise a fresh DB just to snapshot an empty one.
+   *
+   * @task T10317
+   */
+  it('TC-203: vacuumIntoGlobalBackup(global-tasks) without on-disk file returns empty result', async () => {
+    vi.resetModules();
+    const cleoHome = join(tmpdir(), `cleo-tc203-${Date.now()}`);
+    mkdirSync(cleoHome, { recursive: true });
+    // Deliberately do NOT create cleoHome/tasks.db — the raw-file opener
+    // must detect the missing file and skip cleanly.
+
+    vi.doMock('../nexus-sqlite.js', () => ({ getNexusNativeDb: () => null }));
+    vi.doMock('../signaldock-sqlite.js', () => ({
+      getGlobalSignaldockNativeDb: () => null,
+      ensureGlobalSignaldockDb: async () => undefined,
+    }));
+    vi.doMock('../skills-db.js', () => ({
+      openSkillsDb: async () => null,
+      getSkillsNativeDb: () => null,
+    }));
+    vi.doMock('../../telemetry/sqlite.js', () => ({
+      getTelemetryDb: async () => null,
+      getTelemetryNativeDb: () => null,
+    }));
+    vi.doMock('../../paths.js', () => ({ getCleoHome: () => cleoHome }));
+
+    const { vacuumIntoGlobalBackup } = await import('../sqlite-backup.js');
+    const result = await vacuumIntoGlobalBackup('global-tasks', { cleoHomeOverride: cleoHome });
+
+    expect(result.snapshotPath).toBe('');
+    expect(result.rotated).toEqual([]);
+  });
+
+  /**
+   * TC-204: vacuumIntoGlobalBackupAll iterates every global-tier inventory
+   * row. Each row contributes a result entry in the returned array. Targets
+   * with live handles produce snapshots; targets with no on-disk file
+   * produce empty `{snapshotPath:'', rotated:[]}` entries.
+   *
+   * Headline assertion: every DB_INVENTORY global-tier role surfaces in the
+   * result — none silently dropped.
+   *
+   * @task T10317
+   */
+  it('TC-204: vacuumIntoGlobalBackupAll returns one entry per global-tier inventory row', async () => {
+    vi.resetModules();
+    const cleoHome = join(tmpdir(), `cleo-tc204-${Date.now()}`);
+    mkdirSync(cleoHome, { recursive: true });
+
+    // Seed only the nexus DB — the other targets should surface with empty
+    // results without throwing.
+    const nexusPath = join(cleoHome, 'nexus.db');
+    seedSqliteDb(nexusPath);
+    const nexusDb = new DatabaseSync(nexusPath);
+
+    vi.doMock('../nexus-sqlite.js', () => ({
+      getNexusNativeDb: () => nexusDb,
+      getNexusDb: async () => null,
+    }));
+    vi.doMock('../signaldock-sqlite.js', () => ({
+      getGlobalSignaldockNativeDb: () => null,
+      ensureGlobalSignaldockDb: async () => undefined,
+    }));
+    vi.doMock('../skills-db.js', () => ({
+      openSkillsDb: async () => null,
+      getSkillsNativeDb: () => null,
+    }));
+    vi.doMock('../../telemetry/sqlite.js', () => ({
+      getTelemetryDb: async () => null,
+      getTelemetryNativeDb: () => null,
+    }));
+    vi.doMock('../../paths.js', () => ({ getCleoHome: () => cleoHome }));
+
+    const { vacuumIntoGlobalBackupAll, describeSnapshotCoverage } = await import(
+      '../sqlite-backup.js'
+    );
+    const results = await vacuumIntoGlobalBackupAll({ cleoHomeOverride: cleoHome });
+
+    nexusDb.close();
+
+    // Coverage parity: result has exactly the global-tier roles from inventory.
+    const globalRolesFromCoverage = describeSnapshotCoverage()
+      .filter((r) => r.tier === 'global')
+      .map((r) => r.role)
+      .sort();
+    const resultRoles = results.map((r) => r.role).sort();
+    expect(resultRoles).toEqual(globalRolesFromCoverage);
+
+    // The nexus entry should have a snapshot path.
+    const nexusResult = results.find((r) => r.role === 'nexus');
+    expect(nexusResult?.snapshotPath).toBeTruthy();
+    expect(nexusResult?.snapshotPath).toContain('nexus-');
+
+    // Roles with no on-disk file return empty snapshotPath but are PRESENT.
+    for (const role of [
+      'signaldock-global',
+      'telemetry',
+      'skills',
+      'global-brain',
+      'global-tasks',
+    ]) {
+      expect(resultRoles).toContain(role);
+    }
+  });
+
+  /**
+   * TC-205: listGlobalSqliteBackupsAll surfaces every global-tier prefix —
+   * even prefixes whose bucket is empty. Provides a single audit surface
+   * for `cleo doctor db-substrate` follow-ups.
+   *
+   * @task T10317
+   */
+  it('TC-205: listGlobalSqliteBackupsAll surfaces every global-tier prefix', async () => {
+    vi.resetModules();
+    const cleoHome = join(tmpdir(), `cleo-tc205-${Date.now()}`);
+    const backupDir = join(cleoHome, 'backups', 'sqlite');
+    mkdirSync(backupDir, { recursive: true });
+
+    vi.doMock('../../paths.js', () => ({ getCleoHome: () => cleoHome }));
+    vi.doMock('../nexus-sqlite.js', () => ({ getNexusNativeDb: () => null }));
+    vi.doMock('../signaldock-sqlite.js', () => ({
+      getGlobalSignaldockNativeDb: () => null,
+      ensureGlobalSignaldockDb: async () => undefined,
+    }));
+    vi.doMock('../skills-db.js', () => ({
+      openSkillsDb: async () => null,
+      getSkillsNativeDb: () => null,
+    }));
+    vi.doMock('../../telemetry/sqlite.js', () => ({
+      getTelemetryDb: async () => null,
+      getTelemetryNativeDb: () => null,
+    }));
+
+    // Seed a single nexus snapshot to verify non-empty buckets are populated.
+    writeFileSync(join(backupDir, 'nexus-20260101-120000.db'), 'fake-nexus');
+
+    const { listGlobalSqliteBackupsAll } = await import('../sqlite-backup.js');
+    const map = listGlobalSqliteBackupsAll(cleoHome);
+
+    // Every global-tier role from DB_INVENTORY surfaces as a key. Mapping
+    // role → prefix is identity except for signaldock-global → 'signaldock'.
+    expect(Object.keys(map).sort()).toEqual(
+      ['nexus', 'signaldock', 'telemetry', 'skills', 'global-brain', 'global-tasks'].sort(),
+    );
+
+    expect(map['nexus']?.length).toBe(1);
+    expect(map['signaldock']?.length).toBe(0);
+    expect(map['telemetry']?.length).toBe(0);
+  });
+
   /**
    * TC-105: listGlobalSqliteBackups('signaldock') returns only the global
    * signaldock snapshots, not nexus ones.

--- a/packages/core/src/store/__tests__/sqlite-backup.test.ts
+++ b/packages/core/src/store/__tests__/sqlite-backup.test.ts
@@ -14,6 +14,8 @@
  * @task T5158 — extended to cover brain.db + vacuumIntoBackupAll
  * @task T10316 — eager-open openers mocked to keep the unit-layer guard
  *               passing under the new SnapshotTarget.openDb contract
+ * @task T10317 — inventory-driven targets; mocks extended to telemetry +
+ *               skills + signaldock so every chokepoint role is stubbed
  * @epic T4867
  */
 
@@ -21,6 +23,35 @@ import { mkdirSync, readdirSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Stub the chokepoint openers we don't care about for a given test case.
+ *
+ * After T10317 the snapshot pipeline imports `telemetry/sqlite.js`,
+ * `skills-db.js`, `signaldock-sqlite.js`, and `nexus-sqlite.js` at module
+ * top-level. Tests that mock only `sqlite.js` + `memory-sqlite.js` +
+ * `conduit-sqlite.js` MUST also neutralise these so the real modules don't
+ * leak file-system writes to the developer's $XDG_DATA_HOME.
+ */
+function stubOtherChokepointOpeners(): void {
+  vi.doMock('../../telemetry/sqlite.js', () => ({
+    getTelemetryDb: async () => null,
+    getTelemetryNativeDb: () => null,
+  }));
+  vi.doMock('../skills-db.js', () => ({
+    openSkillsDb: async () => null,
+    getSkillsNativeDb: () => null,
+  }));
+  vi.doMock('../signaldock-sqlite.js', () => ({
+    ensureGlobalSignaldockDb: async () => undefined,
+    getGlobalSignaldockNativeDb: () => null,
+  }));
+  vi.doMock('../nexus-sqlite.js', () => ({
+    getNexusDb: async () => null,
+    getNexusNativeDb: () => null,
+  }));
+  vi.doMock('../global-salt.js', () => ({ getGlobalSaltPath: () => '' }));
+}
 
 describe('sqlite-backup', () => {
   beforeEach(() => {
@@ -41,8 +72,10 @@ describe('sqlite-backup', () => {
       getConduitNativeDb: () => null,
       ensureConduitDb: () => ({ action: 'exists', path: '' }),
     }));
+    stubOtherChokepointOpeners();
     vi.doMock('../../paths.js', () => ({
       getCleoDir: () => tmpdir(),
+      getCleoHome: () => tmpdir(),
       resolveOrCwd: (cwd?: string) => cwd ?? tmpdir(),
     }));
 
@@ -60,8 +93,10 @@ describe('sqlite-backup', () => {
       getConduitNativeDb: () => null,
       ensureConduitDb: () => ({ action: 'exists', path: '' }),
     }));
+    stubOtherChokepointOpeners();
     vi.doMock('../../paths.js', () => ({
       getCleoDir: () => tmpdir(),
+      getCleoHome: () => tmpdir(),
       resolveOrCwd: (cwd?: string) => cwd ?? tmpdir(),
     }));
 
@@ -83,9 +118,11 @@ describe('sqlite-backup', () => {
       getConduitNativeDb: () => null,
       ensureConduitDb: () => ({ action: 'exists', path: '' }),
     }));
+    stubOtherChokepointOpeners();
     const tempDir = join(tmpdir(), `cleo-test-wal-${Date.now()}`);
     vi.doMock('../../paths.js', () => ({
       getCleoDir: () => tempDir,
+      getCleoHome: () => tempDir,
       resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
     }));
 
@@ -113,11 +150,13 @@ describe('sqlite-backup', () => {
       getConduitNativeDb: () => null,
       ensureConduitDb: () => ({ action: 'exists', path: '' }),
     }));
+    stubOtherChokepointOpeners();
     const tempDir = join(tmpdir(), `cleo-test-rot-${Date.now()}`);
     const backupDir = join(tempDir, 'backups', 'sqlite');
     mkdirSync(backupDir, { recursive: true });
     vi.doMock('../../paths.js', () => ({
       getCleoDir: () => tempDir,
+      getCleoHome: () => tempDir,
       resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
     }));
 
@@ -151,11 +190,13 @@ describe('sqlite-backup', () => {
       getConduitNativeDb: () => null,
       ensureConduitDb: () => ({ action: 'exists', path: '' }),
     }));
+    stubOtherChokepointOpeners();
     const tempDir = join(tmpdir(), `cleo-test-rot-prefix-${Date.now()}`);
     const backupDir = join(tempDir, 'backups', 'sqlite');
     mkdirSync(backupDir, { recursive: true });
     vi.doMock('../../paths.js', () => ({
       getCleoDir: () => tempDir,
+      getCleoHome: () => tempDir,
       resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
     }));
 
@@ -191,9 +232,11 @@ describe('sqlite-backup', () => {
       getConduitNativeDb: () => null,
       ensureConduitDb: () => ({ action: 'exists', path: '' }),
     }));
+    stubOtherChokepointOpeners();
     const tempDir = join(tmpdir(), `cleo-test-both-${Date.now()}`);
     vi.doMock('../../paths.js', () => ({
       getCleoDir: () => tempDir,
+      getCleoHome: () => tempDir,
       resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
     }));
 
@@ -224,9 +267,11 @@ describe('sqlite-backup', () => {
       getConduitNativeDb: () => null,
       ensureConduitDb: () => ({ action: 'exists', path: '' }),
     }));
+    stubOtherChokepointOpeners();
     const tempDir = join(tmpdir(), `cleo-test-debounce-${Date.now()}`);
     vi.doMock('../../paths.js', () => ({
       getCleoDir: () => tempDir,
+      getCleoHome: () => tempDir,
       resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
     }));
 
@@ -268,9 +313,11 @@ describe('sqlite-backup', () => {
       getConduitNativeDb: () => null,
       ensureConduitDb: () => ({ action: 'exists', path: '' }),
     }));
+    stubOtherChokepointOpeners();
     const tempDir = join(tmpdir(), `cleo-test-eager-${Date.now()}`);
     vi.doMock('../../paths.js', () => ({
       getCleoDir: () => tempDir,
+      getCleoHome: () => tempDir,
       resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
     }));
 
@@ -294,11 +341,13 @@ describe('sqlite-backup', () => {
       getConduitNativeDb: () => null,
       ensureConduitDb: () => ({ action: 'exists', path: '' }),
     }));
+    stubOtherChokepointOpeners();
     const tempDir = join(tmpdir(), `cleo-test-list-${Date.now()}`);
     const backupDir = join(tempDir, 'backups', 'sqlite');
     mkdirSync(backupDir, { recursive: true });
     vi.doMock('../../paths.js', () => ({
       getCleoDir: () => tempDir,
+      getCleoHome: () => tempDir,
       resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
     }));
 
@@ -330,11 +379,161 @@ describe('sqlite-backup', () => {
       'tasks-20260101-120000.db',
     ]);
     expect(brainList.map((e) => e.name)).toEqual(['brain-20260103-120000.db']);
-    // conduit is now a registered prefix (T369); no conduit files exist in
-    // this temp dir so its bucket is empty but still present in the map.
-    expect(Object.keys(all).sort()).toEqual(['brain', 'conduit', 'tasks']);
+    // T10317: every project-tier + derived inventory row now contributes a
+    // bucket to listSqliteBackupsAll(). Empty buckets surface as `[]`.
+    expect(Object.keys(all).sort()).toEqual(
+      ['brain', 'conduit', 'llmtxt', 'manifest', 'signaldock-project', 'tasks'].sort(),
+    );
     expect(all['tasks']?.length).toBe(2);
     expect(all['brain']?.length).toBe(1);
     expect(all['conduit']?.length).toBe(0);
+    // Derived (manifest) + reserved (llmtxt) + historical (signaldock-project)
+    // surface as empty arrays — covered, not snapshotted in this fixture.
+    expect(all['manifest']?.length).toBe(0);
+    expect(all['llmtxt']?.length).toBe(0);
+    expect(all['signaldock-project']?.length).toBe(0);
+  });
+
+  // ==========================================================================
+  // T10317 — inventory coverage (Saga T10281 / Epic T10284 / E3)
+  // ==========================================================================
+
+  /**
+   * describeSnapshotCoverage MUST return one row per DB_INVENTORY entry. Every
+   * row carries a `strategy` that classifies how the snapshot pipeline handles
+   * the role: chokepoint-opener / raw-file-vacuum-readonly / skip-derived.
+   *
+   * This is the regression guard against future inventory additions slipping
+   * through without a corresponding snapshot strategy.
+   */
+  it('describeSnapshotCoverage covers every DB_INVENTORY entry exactly once', async () => {
+    stubOtherChokepointOpeners();
+    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => null, getDb: async () => null }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => null,
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tmpdir(),
+      getCleoHome: () => tmpdir(),
+      resolveOrCwd: (cwd?: string) => cwd ?? tmpdir(),
+    }));
+
+    const { DB_INVENTORY } = await import('@cleocode/contracts');
+    const { describeSnapshotCoverage } = await import('../sqlite-backup.js');
+    const rows = describeSnapshotCoverage();
+
+    // One row per inventory entry — no silent drop, no duplicate.
+    const inventoryRoles = DB_INVENTORY.map((e) => e.role).sort();
+    const coverageRoles = rows.map((r) => r.role).sort();
+    expect(coverageRoles).toEqual(inventoryRoles);
+
+    // Every project + global row resolves to a real strategy (never undefined).
+    for (const r of rows) {
+      expect(['chokepoint-opener', 'raw-file-vacuum-readonly', 'skip-derived']).toContain(
+        r.strategy,
+      );
+    }
+
+    // The 7 chokepoint roles MUST land on chokepoint-opener strategy.
+    const chokepointRoles = new Set([
+      'tasks',
+      'brain',
+      'conduit',
+      'nexus',
+      'signaldock-global',
+      'telemetry',
+      'skills',
+    ]);
+    for (const r of rows) {
+      if (chokepointRoles.has(r.role)) {
+        expect(r.strategy).toBe('chokepoint-opener');
+      }
+    }
+
+    // Derived rows MUST be skip-derived.
+    for (const r of rows) {
+      if (r.tier === 'derived') {
+        expect(r.strategy).toBe('skip-derived');
+      }
+    }
+  });
+
+  /**
+   * vacuumIntoBackupAll iterates project + derived inventory rows. Targets
+   * with chokepoint openers produce a snapshot when their handle is non-null.
+   * Targets without a live opener AND no file on disk fall through cleanly.
+   *
+   * The fixture seeds the project + derived snapshot dir, then verifies that
+   * every chokepoint role with a real native handle gets a VACUUM INTO call.
+   */
+  it('vacuumIntoBackupAll fires VACUUM INTO for every project chokepoint target with a live handle', async () => {
+    const tasksExec = vi.fn();
+    const brainExec = vi.fn();
+    const conduitExec = vi.fn();
+    vi.doMock('../sqlite.js', () => ({
+      getNativeDb: () => ({ exec: tasksExec }),
+      getDb: async () => null,
+    }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => ({ exec: brainExec }),
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => ({ exec: conduitExec }),
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
+    stubOtherChokepointOpeners();
+    const tempDir = join(tmpdir(), `cleo-t10317-project-${Date.now()}`);
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tempDir,
+      getCleoHome: () => tempDir,
+      resolveOrCwd: (cwd?: string) => cwd ?? tempDir,
+    }));
+
+    const { vacuumIntoBackupAll } = await import('../sqlite-backup.js');
+    await vacuumIntoBackupAll({ force: true });
+
+    // Every project chokepoint role with a live handle MUST have received
+    // both a wal_checkpoint and a VACUUM INTO call.
+    for (const mock of [tasksExec, brainExec, conduitExec]) {
+      const calls = mock.mock.calls.map((c) => c[0] as string);
+      expect(calls.some((c) => c.includes('wal_checkpoint'))).toBe(true);
+      expect(calls.some((c) => c.includes('VACUUM INTO'))).toBe(true);
+    }
+  });
+
+  /**
+   * Manifest (derived row, `backupPath === 'rebuildable-from-blob-store'`)
+   * MUST be skipped — the snapshot pipeline must NOT emit a VACUUM INTO or
+   * even attempt to open the file. Otherwise we double-snapshot blob CAS
+   * content.
+   */
+  it('manifest (derived) row is skipped — strategy is skip-derived', async () => {
+    stubOtherChokepointOpeners();
+    vi.doMock('../sqlite.js', () => ({ getNativeDb: () => null, getDb: async () => null }));
+    vi.doMock('../memory-sqlite.js', () => ({
+      getBrainNativeDb: () => null,
+      getBrainDb: async () => null,
+    }));
+    vi.doMock('../conduit-sqlite.js', () => ({
+      getConduitNativeDb: () => null,
+      ensureConduitDb: () => ({ action: 'exists', path: '' }),
+    }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoDir: () => tmpdir(),
+      getCleoHome: () => tmpdir(),
+      resolveOrCwd: (cwd?: string) => cwd ?? tmpdir(),
+    }));
+
+    const { describeSnapshotCoverage } = await import('../sqlite-backup.js');
+    const manifest = describeSnapshotCoverage().find((r) => r.role === 'manifest');
+    expect(manifest).toBeDefined();
+    expect(manifest?.strategy).toBe('skip-derived');
+    expect(manifest?.tier).toBe('derived');
   });
 });

--- a/packages/core/src/store/sqlite-backup.ts
+++ b/packages/core/src/store/sqlite-backup.ts
@@ -51,7 +51,7 @@ import {
   unlinkSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { DatabaseSync } from 'node:sqlite';
+import type { DatabaseSync } from 'node:sqlite';
 import { DB_INVENTORY, type DbInventoryEntry, type DbRole } from '@cleocode/contracts';
 import { getCleoDir, getCleoHome, resolveOrCwd } from '../paths.js';
 import { getTelemetryDb, getTelemetryNativeDb } from '../telemetry/sqlite.js';
@@ -326,6 +326,12 @@ function buildRawFileVacuumOpener(
     if (!path) return null;
     if (!existsSync(path)) return null;
     try {
+      // Dynamic import preserves the T1331 lazy-init contract: importing
+      // sqlite.ts (which statically imports sqlite-backup.ts for
+      // `listSqliteBackups`) MUST NOT pull node:sqlite into module-load
+      // time. Only the raw-file-vacuum-readonly path needs the
+      // constructor, and it is exercised at snapshot-time, not load-time.
+      const { DatabaseSync } = await import('node:sqlite');
       return new DatabaseSync(path, { readOnly: true });
     } catch {
       // The file might be locked by another writer, corrupt, or otherwise

--- a/packages/core/src/store/sqlite-backup.ts
+++ b/packages/core/src/store/sqlite-backup.ts
@@ -1,18 +1,43 @@
 /**
  * SQLite backup via VACUUM INTO with snapshot rotation.
  *
- * Produces self-contained, WAL-free copies of CLEO SQLite databases
- * (tasks.db, brain.db, conduit.db at project tier; nexus.db, signaldock.db at
- * global tier) into `.cleo/backups/sqlite/` (project) or
- * `$XDG_DATA_HOME/cleo/backups/sqlite/` (global) with a configurable rotation
- * limit. Also provides raw-file backup for the global-salt binary (not SQLite).
- * All errors are swallowed — backup failure must never interrupt normal operation.
+ * Produces self-contained, WAL-free copies of every CLEO SQLite database
+ * (`DB_INVENTORY` from `@cleocode/contracts`) into:
+ *
+ *   - `.cleo/backups/sqlite/`                  — project-tier (and `derived` rows
+ *                                                that opt into snapshotting)
+ *   - `$XDG_DATA_HOME/cleo/backups/sqlite/`    — global-tier
+ *
+ * with a configurable rotation limit. Also provides raw-file backup for the
+ * global-salt binary (not SQLite). All errors are swallowed — backup failure
+ * must never interrupt normal operation.
+ *
+ * Snapshot targets are derived from the canonical inventory in
+ * `db-inventory.json` so the snapshot pipeline cannot drift from the charter
+ * (Saga T10281 / Epic T10284 / E3-BACKUP-RECOVERY). Every inventory entry is
+ * classified into one of two strategies:
+ *
+ *   - **chokepoint-opener**     — role has a registered canonical opener
+ *                                 (tasks, brain, conduit, nexus,
+ *                                 signaldock-global, telemetry, skills).
+ *                                 Snapshot via the opener's native handle.
+ *   - **raw-file-vacuum-readonly** — role has NO live opener (llmtxt reserved,
+ *                                 signaldock-project historical, global-brain
+ *                                 / global-tasks orphans, manifest derived
+ *                                 when opted in). Snapshot by opening the
+ *                                 file read-only and issuing `VACUUM INTO`.
+ *
+ * Both strategies live under `packages/core/src/store/**` — the canonical
+ * allowlist root for direct `DatabaseSync` construction (ADR-068).
  *
  * @task T4873
  * @task T5158 — extended to cover brain.db
  * @task T306  — extended to cover global-tier nexus.db (epic T299)
  * @task T369  — extended to cover conduit.db (project), signaldock.db (global),
  *               and global-salt raw-file backup (epic T310)
+ * @task T10316 — eager-open via per-DB chokepoint (brain backup gap)
+ * @task T10317 — every `DB_INVENTORY` row now produces a snapshot
+ *                (Saga T10281 / Epic T10284 / E3)
  * @epic T4867
  */
 
@@ -26,12 +51,16 @@ import {
   unlinkSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { DB_INVENTORY, type DbInventoryEntry, type DbRole } from '@cleocode/contracts';
 import { getCleoDir, getCleoHome, resolveOrCwd } from '../paths.js';
+import { getTelemetryDb, getTelemetryNativeDb } from '../telemetry/sqlite.js';
 import { ensureConduitDb, getConduitNativeDb } from './conduit-sqlite.js';
 import { getGlobalSaltPath } from './global-salt.js';
 import { getBrainDb, getBrainNativeDb } from './memory-sqlite.js';
 import { getNexusDb, getNexusNativeDb } from './nexus-sqlite.js';
 import { ensureGlobalSignaldockDb, getGlobalSignaldockNativeDb } from './signaldock-sqlite.js';
+import { getSkillsNativeDb, openSkillsDb } from './skills-db.js';
 import { getDb, getNativeDb } from './sqlite.js';
 
 /** Maximum number of snapshots retained per database (oldest rotated out). */
@@ -52,6 +81,57 @@ const _lastBackupEpoch: Record<string, number> = {};
 type SnapshotDbHandle = { exec: (sql: string) => void };
 
 /**
+ * Snapshot strategy classification.
+ *
+ *   - `chokepoint-opener`        — role has a canonical opener (`getDb`,
+ *                                  `getBrainDb`, `ensureConduitDb`,
+ *                                  `getNexusDb`, `ensureGlobalSignaldockDb`,
+ *                                  `getTelemetryDb`, `openSkillsDb`).
+ *   - `raw-file-vacuum-readonly` — role has NO live opener; the file is
+ *                                  opened read-only via a one-shot
+ *                                  `DatabaseSync` (allowlisted under
+ *                                  `packages/core/src/store/**`) just to
+ *                                  emit `VACUUM INTO`, then closed.
+ *   - `skip-derived`             — `tier === 'derived'`; the canonical
+ *                                  charter row marks the file as rebuildable
+ *                                  (`backupPath === 'rebuildable-from-blob-store'`).
+ *                                  Excluded from the snapshot pipeline. The
+ *                                  row IS surfaced in `listSqliteBackupsAll`
+ *                                  for completeness but its bucket stays empty.
+ *
+ * @task T10317
+ */
+type SnapshotStrategy = 'chokepoint-opener' | 'raw-file-vacuum-readonly' | 'skip-derived';
+
+/**
+ * Resolve the path on disk for a given `DB_INVENTORY` row.
+ *
+ * Substitutes the documented path tokens:
+ *
+ *   - `<projectRoot>`  → resolved via {@link resolveOrCwd}
+ *   - `$XDG_DATA_HOME` → resolved via {@link getCleoHome} (env-paths SSoT)
+ *
+ * Returns `null` when the project tier is requested without a resolvable
+ * project root (e.g. `getCleoDir()` throws because no project context).
+ *
+ * @task T10317
+ */
+function resolveInventoryPath(entry: DbInventoryEntry, cwd?: string): string | null {
+  try {
+    if (entry.tier === 'global') {
+      // Replace the leading `$XDG_DATA_HOME/cleo/` token with `getCleoHome()`.
+      const cleoHome = getCleoHome();
+      return entry.filePathTemplate.replace(/^\$XDG_DATA_HOME\/cleo/, cleoHome);
+    }
+    // Project + derived (derived is project-rooted in the inventory).
+    const projectRoot = resolveOrCwd(cwd);
+    return entry.filePathTemplate.replace(/^<projectRoot>/, projectRoot);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Registered snapshot target — each one maps a logical key (prefix used in
  * snapshot filenames) to a function returning the live {@link DatabaseSync}
  * handle. `null` means the database has not been initialized in the current
@@ -62,12 +142,20 @@ type SnapshotDbHandle = { exec: (sql: string) => void };
  * @task T10316 — added `openDb` so `vacuumIntoBackupAll` snapshots EVERY
  *               registered DB even when no caller in this process has
  *               lazily opened it earlier (brain backup gap, Saga T10281 / E3).
+ * @task T10317 — added `role`, `tier`, `strategy`, and `resolveFile` to
+ *               cover every `DB_INVENTORY` entry uniformly.
  */
 interface SnapshotTarget {
-  /** Canonical name used in snapshot filenames, e.g. `"tasks"` or `"brain"`. */
-  prefix: string;
+  /** Canonical role from `DB_INVENTORY`. */
+  readonly role: DbRole;
+  /** Canonical name used in snapshot filenames, e.g. `"tasks"` or `"global-brain"`. */
+  readonly prefix: string;
+  /** Inventory tier — determines which backup directory the snapshot lands in. */
+  readonly tier: DbInventoryEntry['tier'];
+  /** How this target obtains a live handle. See {@link SnapshotStrategy}. */
+  readonly strategy: SnapshotStrategy;
   /** Resolves the live native handle, or `null` if not yet initialized. */
-  getDb: () => SnapshotDbHandle | null;
+  readonly getDb: () => SnapshotDbHandle | null;
   /**
    * Eagerly opens the canonical singleton when {@link getDb} returns `null`.
    * MUST flow through the per-DB chokepoint (ADR-068) — these openers all
@@ -75,9 +163,25 @@ interface SnapshotTarget {
    * pragma-consistent and singleton-managed. Returns `null` only when the
    * underlying opener legitimately has nothing to open (e.g. missing
    * project context); callers MUST treat `null` as "skip silently".
+   *
+   * For `raw-file-vacuum-readonly` targets, this resolves the on-disk path
+   * and opens a one-shot read-only `DatabaseSync`. The returned handle is
+   * ephemeral — `snapshotOne` closes it after `VACUUM INTO`.
    */
-  openDb: (cwd?: string) => Promise<SnapshotDbHandle | null>;
+  readonly openDb: (cwd?: string) => Promise<SnapshotDbHandle | null>;
+  /**
+   * When non-null, `snapshotOne` calls this AFTER `VACUUM INTO` to release
+   * the ephemeral handle opened by {@link openDb}. Used by
+   * `raw-file-vacuum-readonly` targets (which open a one-shot
+   * `DatabaseSync`). Chokepoint-opener targets manage their own singletons
+   * and MUST NOT close them — leave this `null`.
+   */
+  readonly closeDb: ((db: SnapshotDbHandle) => void) | null;
 }
+
+// ---------------------------------------------------------------------------
+// Project-tier openers (chokepoint-opener strategy)
+// ---------------------------------------------------------------------------
 
 /**
  * Open the canonical brain.db singleton via {@link getBrainDb} and return its
@@ -117,25 +221,302 @@ async function openConduitDbForSnapshot(cwd?: string): Promise<SnapshotDbHandle 
   return getConduitNativeDb();
 }
 
+// ---------------------------------------------------------------------------
+// Global-tier openers (chokepoint-opener strategy)
+// ---------------------------------------------------------------------------
+
 /**
- * Canonical list of snapshot targets. Ordering is insertion order — tasks.db
- * snapshots first (highest-value operational state), then brain.db, then
- * conduit.db (project messaging state).
+ * Open the canonical nexus.db singleton via {@link getNexusDb} and return
+ * its native handle. Symmetric counterpart to {@link openBrainDbForSnapshot}
+ * — eager-open via per-DB chokepoint so global-tier snapshots also work
+ * when the in-process handle cache is empty.
  *
- * Every entry MUST provide both `getDb` (fast in-process lookup) and `openDb`
- * (eager open via chokepoint). The latter closes the T10316 gap where a
- * session-end snapshot found a `null` handle and silently skipped the DB.
- *
- * @task T369
- * @task T10316 — added eager-open openers for every project target
- * @epic T310
+ * @task T10316
  */
-const SNAPSHOT_TARGETS: SnapshotTarget[] = [
-  { prefix: 'tasks', getDb: getNativeDb, openDb: openTasksDbForSnapshot },
-  { prefix: 'brain', getDb: getBrainNativeDb, openDb: openBrainDbForSnapshot },
-  // Added T369 — project messaging DB. openDb added T10316.
-  { prefix: 'conduit', getDb: getConduitNativeDb, openDb: openConduitDbForSnapshot },
-];
+async function openNexusDbForSnapshot(): Promise<SnapshotDbHandle | null> {
+  await getNexusDb();
+  return getNexusNativeDb();
+}
+
+/**
+ * Open the canonical global signaldock.db singleton via
+ * {@link ensureGlobalSignaldockDb} and return its native handle.
+ *
+ * @task T10316
+ */
+async function openSignaldockDbForSnapshot(): Promise<SnapshotDbHandle | null> {
+  await ensureGlobalSignaldockDb();
+  return getGlobalSignaldockNativeDb();
+}
+
+/**
+ * Open the canonical telemetry.db singleton via {@link getTelemetryDb} and
+ * return its native handle. Telemetry is opt-in but the singleton is
+ * resolved lazily on first event — when no event has fired, the on-disk
+ * file simply doesn't exist and {@link snapshotOne} skips after a clean
+ * `null` from {@link openDb}.
+ *
+ * @task T10317 — fleet snapshot coverage for `telemetry` role
+ *                (Saga T10281 / E3)
+ */
+async function openTelemetryDbForSnapshot(): Promise<SnapshotDbHandle | null> {
+  // If the underlying file does not exist, skip without provoking creation
+  // — telemetry is opt-in; we MUST NOT materialise a fresh DB on the disk
+  // just to snapshot an empty one.
+  // The path resolver uses `getCleoHome()` from the same module, so the
+  // SSoT path remains consistent with the live opener.
+  try {
+    // Lazily resolve the live path; mirrors `getTelemetryDbPath()` without
+    // pulling in the dedicated import (one less stub for test mocks).
+    const path = join(getCleoHome(), 'telemetry.db');
+    if (!existsSync(path)) return null;
+  } catch {
+    return null;
+  }
+  await getTelemetryDb();
+  return getTelemetryNativeDb();
+}
+
+/**
+ * Open the canonical skills.db singleton via {@link openSkillsDb} and
+ * return its native handle.
+ *
+ * @task T10317
+ */
+async function openSkillsDbForSnapshot(): Promise<SnapshotDbHandle | null> {
+  await openSkillsDb();
+  return getSkillsNativeDb();
+}
+
+// ---------------------------------------------------------------------------
+// Raw-file-VACUUM strategy (no canonical opener)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a `raw-file-vacuum-readonly` opener for an inventory row whose role
+ * has NO live chokepoint opener (llmtxt RESERVED, signaldock-project
+ * HISTORICAL, global-brain / global-tasks UNREGISTERED ORPHANS).
+ *
+ * The returned function:
+ *
+ *   1. Resolves the inventory file path with {@link resolveInventoryPath}.
+ *   2. Returns `null` immediately if the file does not exist (clean skip —
+ *      not every project / global home has every orphan).
+ *   3. Otherwise opens a one-shot `DatabaseSync` in **read-only** mode and
+ *      returns the handle. The caller (`snapshotOne`) issues `VACUUM INTO`
+ *      then calls {@link SnapshotTarget.closeDb} to release the handle.
+ *
+ * Read-only is the right mode because (a) the file may belong to a different
+ * process with an open writer (rare for these orphans, but possible), and
+ * (b) VACUUM INTO is an explicit out-of-place operation that does not write
+ * to the source DB.
+ *
+ * The `new DatabaseSync(...)` call is allowed here because this file is
+ * under the canonical chokepoint allowlist `packages/core/src/store/**`
+ * — the db-open-guard lint baseline already covers it. No per-line
+ * `db-open-allowed` annotation is needed.
+ *
+ * @task T10317
+ */
+function buildRawFileVacuumOpener(
+  entry: DbInventoryEntry,
+): (cwd?: string) => Promise<SnapshotDbHandle | null> {
+  return async (cwd?: string): Promise<SnapshotDbHandle | null> => {
+    const path = resolveInventoryPath(entry, cwd);
+    if (!path) return null;
+    if (!existsSync(path)) return null;
+    try {
+      return new DatabaseSync(path, { readOnly: true });
+    } catch {
+      // The file might be locked by another writer, corrupt, or otherwise
+      // unopenable. Skip silently — snapshot failure must never block
+      // normal operation (and the malformed-DB case is exactly why the
+      // saga exists).
+      return null;
+    }
+  };
+}
+
+/**
+ * Close an ephemeral `DatabaseSync` handle opened by a
+ * `raw-file-vacuum-readonly` strategy. Idempotent and silent on error —
+ * the backup pipeline MUST NOT propagate close failures.
+ *
+ * @task T10317
+ */
+function closeEphemeralHandle(db: SnapshotDbHandle): void {
+  try {
+    const handle = db as DatabaseSync;
+    if (typeof handle.close === 'function' && handle.isOpen) {
+      handle.close();
+    }
+  } catch {
+    // non-fatal
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inventory-driven snapshot target registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps `DB_INVENTORY` rows that use the chokepoint-opener strategy to their
+ * concrete openers. Roles absent from this map fall back to either:
+ *
+ *   - `raw-file-vacuum-readonly` (when the on-disk file exists), or
+ *   - `skip-derived` (when `tier === 'derived'` AND `backupPath` is the
+ *     `rebuildable-from-blob-store` sentinel).
+ *
+ * @task T10317
+ */
+const CHOKEPOINT_OPENERS: Partial<
+  Record<
+    DbRole,
+    {
+      readonly getDb: () => SnapshotDbHandle | null;
+      readonly openDb: (cwd?: string) => Promise<SnapshotDbHandle | null>;
+    }
+  >
+> = {
+  tasks: { getDb: getNativeDb, openDb: openTasksDbForSnapshot },
+  brain: { getDb: getBrainNativeDb, openDb: openBrainDbForSnapshot },
+  conduit: { getDb: getConduitNativeDb, openDb: openConduitDbForSnapshot },
+  nexus: { getDb: getNexusNativeDb, openDb: openNexusDbForSnapshot },
+  'signaldock-global': {
+    getDb: getGlobalSignaldockNativeDb,
+    openDb: openSignaldockDbForSnapshot,
+  },
+  telemetry: { getDb: getTelemetryNativeDb, openDb: openTelemetryDbForSnapshot },
+  skills: { getDb: getSkillsNativeDb, openDb: openSkillsDbForSnapshot },
+};
+
+/**
+ * Snapshot filename prefix for each role.
+ *
+ * For most roles the prefix is the role itself. The two project/global
+ * variants that share a base name disambiguate via the role string itself
+ * (`signaldock-project` ≠ `signaldock-global`; `global-brain` ≠ `brain`).
+ *
+ * `'signaldock-global'` is the SOLE exception: it keeps the historical
+ * `signaldock` prefix so existing `.cleo/backups/sqlite/signaldock-*.db`
+ * filenames continue to match `listGlobalSqliteBackups('signaldock', ...)`.
+ *
+ * @task T10317
+ */
+function prefixForRole(role: DbRole): string {
+  if (role === 'signaldock-global') return 'signaldock';
+  return role;
+}
+
+/**
+ * Whether an inventory row should be SKIPPED from the snapshot pipeline
+ * entirely. Today this is just `manifest` — the canonical charter row
+ * marks it as rebuildable from the blob store (`backupPath ===
+ * 'rebuildable-from-blob-store'`), so re-snapshotting would duplicate the
+ * exact same content that the blob CAS already stores.
+ *
+ * Future opt-in (`cleo backup add --include-derived`) is tracked under
+ * Saga T10281 / E3 follow-ups — when implemented, the flag would flip
+ * derived rows from `skip-derived` to `raw-file-vacuum-readonly`.
+ *
+ * @task T10317
+ */
+function isSkipDerived(entry: DbInventoryEntry): boolean {
+  return entry.tier === 'derived' && entry.backupPath === 'rebuildable-from-blob-store';
+}
+
+/**
+ * Classify an inventory row into a snapshot strategy.
+ *
+ * @task T10317
+ */
+function strategyFor(entry: DbInventoryEntry): SnapshotStrategy {
+  if (isSkipDerived(entry)) return 'skip-derived';
+  if (CHOKEPOINT_OPENERS[entry.role]) return 'chokepoint-opener';
+  return 'raw-file-vacuum-readonly';
+}
+
+/**
+ * Build a {@link SnapshotTarget} for the given inventory row.
+ *
+ * @task T10317
+ */
+function buildTarget(entry: DbInventoryEntry): SnapshotTarget {
+  const strategy = strategyFor(entry);
+  const prefix = prefixForRole(entry.role);
+
+  if (strategy === 'skip-derived') {
+    // Build a no-op target so `listSqliteBackupsAll` still surfaces the
+    // row's bucket (always empty). Snapshot iteration skips it.
+    return {
+      role: entry.role,
+      prefix,
+      tier: entry.tier,
+      strategy,
+      getDb: () => null,
+      openDb: async () => null,
+      closeDb: null,
+    };
+  }
+
+  if (strategy === 'chokepoint-opener') {
+    const opener = CHOKEPOINT_OPENERS[entry.role];
+    if (!opener) {
+      // Defensive — strategyFor() guarantees this branch unreachable. Fall
+      // through to the raw-file strategy so we never crash the snapshot
+      // pipeline.
+      return {
+        role: entry.role,
+        prefix,
+        tier: entry.tier,
+        strategy: 'raw-file-vacuum-readonly',
+        getDb: () => null,
+        openDb: buildRawFileVacuumOpener(entry),
+        closeDb: closeEphemeralHandle,
+      };
+    }
+    return {
+      role: entry.role,
+      prefix,
+      tier: entry.tier,
+      strategy,
+      getDb: opener.getDb,
+      openDb: opener.openDb,
+      closeDb: null,
+    };
+  }
+
+  // raw-file-vacuum-readonly
+  return {
+    role: entry.role,
+    prefix,
+    tier: entry.tier,
+    strategy,
+    getDb: () => null,
+    openDb: buildRawFileVacuumOpener(entry),
+    closeDb: closeEphemeralHandle,
+  };
+}
+
+/**
+ * Snapshot targets for every project + derived inventory row. Derived rows
+ * with `skip-derived` strategy retain a present-but-empty bucket in
+ * `listSqliteBackupsAll`.
+ *
+ * @task T10317
+ */
+const SNAPSHOT_TARGETS: readonly SnapshotTarget[] = DB_INVENTORY.filter(
+  (entry) => entry.tier === 'project' || entry.tier === 'derived',
+).map(buildTarget);
+
+/**
+ * Snapshot targets for every global-tier inventory row.
+ *
+ * @task T10317
+ */
+const GLOBAL_SNAPSHOT_TARGETS: readonly SnapshotTarget[] = DB_INVENTORY.filter(
+  (entry) => entry.tier === 'global',
+).map(buildTarget);
 
 /**
  * Format a Date as `YYYYMMDD-HHmmss` (local time) for snapshot filenames.
@@ -211,16 +592,24 @@ export interface VacuumOptions {
  * `target.openDb(cwd)` — the canonical per-DB chokepoint. Only when BOTH
  * lookups return `null` does the snapshot step skip the target.
  *
+ * Targets with `strategy === 'skip-derived'` are bypassed entirely — their
+ * inventory row documents `backupPath === 'rebuildable-from-blob-store'`.
+ *
+ * For `raw-file-vacuum-readonly` targets, the eager-open returns a one-shot
+ * `DatabaseSync` that this function closes via {@link SnapshotTarget.closeDb}
+ * after `VACUUM INTO` completes.
+ *
  * Non-fatal: all errors are swallowed via the outer try in
  * {@link vacuumIntoBackupAll}; failures here must never block normal
  * operation.
  *
- * @param target — snapshot target descriptor (prefix + native DB getter)
- * @param backupDir — absolute path to `.cleo/backups/sqlite/`
+ * @param target — snapshot target descriptor (role + prefix + native DB getter)
+ * @param backupDir — absolute path to the snapshot directory
  * @param now — reference timestamp for the filename
  * @param cwd — optional working directory propagated to `target.openDb`
  *
  * @task T10316 — eager-open via openCleoDb chokepoint (Saga T10281 / E3)
+ * @task T10317 — raw-file-vacuum-readonly strategy for opener-less roles
  */
 async function snapshotOne(
   target: SnapshotTarget,
@@ -228,39 +617,54 @@ async function snapshotOne(
   now: Date,
   cwd?: string,
 ): Promise<void> {
+  if (target.strategy === 'skip-derived') {
+    // Derived row — file is rebuildable from the blob CAS. Inventory row
+    // documents `backupPath === 'rebuildable-from-blob-store'`. Nothing to do.
+    return;
+  }
+
   let db = target.getDb();
+  let opened: SnapshotDbHandle | null = null;
   if (!db) {
-    // T10316: eager-open via the canonical per-DB chokepoint so the
-    // session-end backup never silently skips a registered target. This is
-    // the brain backup gap captured live in Saga T10281 / E3 — every
-    // session-end fired with brain.db handle = null in production despite
-    // the mock-based TC-100 unit test passing.
+    // T10316 / T10317: eager-open via the canonical per-DB chokepoint (for
+    // chokepoint-opener roles) or a one-shot read-only `DatabaseSync` (for
+    // raw-file-vacuum-readonly roles). Either way, the snapshot pipeline
+    // never silently skips a registered target just because the in-process
+    // handle cache is empty.
     try {
       db = await target.openDb(cwd);
     } catch {
-      // Non-fatal — opener failure (e.g. missing project context) must
-      // not block snapshots of other registered targets.
+      // Non-fatal — opener failure (e.g. missing project context, locked
+      // file, malformed orphan) must not block snapshots of other targets.
       return;
     }
     if (!db) return;
+    opened = db;
   }
 
   const dest = join(backupDir, `${target.prefix}-${formatTimestamp(now)}.db`);
 
-  // TRUNCATE checkpoint: flushes all WAL frames to the main DB and truncates
-  // the WAL file to zero bytes, ensuring a consistent DB state before the
-  // VACUUM INTO snapshot (ADR-013, section 3 point 7). This is safe because
-  // the .db files are excluded from project git tracking (.gitignore + git
-  // rm --cached), so git operations cannot restore a stale WAL. The root
-  // cause of the 2026-02-25 data loss was that WAL files were still tracked
-  // in the project git index; that has been resolved (T4894, T5158).
-  db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  try {
+    // TRUNCATE checkpoint: flushes all WAL frames to the main DB and truncates
+    // the WAL file to zero bytes, ensuring a consistent DB state before the
+    // VACUUM INTO snapshot (ADR-013, section 3 point 7). For read-only opens
+    // of orphan files there is no WAL to truncate, but the pragma is a no-op
+    // in that case so we keep the call uniform.
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
 
-  rotateSnapshots(backupDir, target.prefix);
+    rotateSnapshots(backupDir, target.prefix);
 
-  // Escape single quotes in path (path is programmatic, but be safe).
-  const safeDest = dest.replace(/'/g, "''");
-  db.exec(`VACUUM INTO '${safeDest}'`);
+    // Escape single quotes in path (path is programmatic, but be safe).
+    const safeDest = dest.replace(/'/g, "''");
+    db.exec(`VACUUM INTO '${safeDest}'`);
+  } finally {
+    // Release the ephemeral handle for raw-file-vacuum-readonly targets.
+    // Chokepoint-opener handles (`closeDb === null`) remain owned by their
+    // module singleton and MUST NOT be closed here.
+    if (opened && target.closeDb) {
+      target.closeDb(opened);
+    }
+  }
 }
 
 /**
@@ -271,8 +675,8 @@ async function snapshotOne(
  * in `data-safety.ts` / `data-safety-central.ts` that only snapshot tasks.db.
  *
  * Prefer {@link vacuumIntoBackupAll} for new code — it snapshots every
- * registered database (currently tasks.db + brain.db) and shares the same
- * debounce + rotation guarantees.
+ * inventory-registered database and shares the same debounce + rotation
+ * guarantees.
  *
  * Non-fatal: all errors are swallowed — backup failure must never
  * interrupt normal operation.
@@ -301,15 +705,23 @@ export async function vacuumIntoBackup(opts: VacuumOptions = {}): Promise<void> 
 }
 
 /**
- * Create VACUUM INTO snapshots of all registered CLEO SQLite databases
- * (currently tasks.db + brain.db). Each database is debounced independently.
+ * Create VACUUM INTO snapshots of every project-tier (and opt-in `derived`)
+ * SQLite database registered in `DB_INVENTORY`. Each database is debounced
+ * independently.
  *
  * This is the preferred entry point for session-lifecycle hooks and
  * pre-destructive-operation snapshots — it guarantees that BRAIN memory is
- * snapshotted alongside task state.
+ * snapshotted alongside task state, plus every other inventory-registered
+ * project-tier DB.
  *
- * Non-fatal: errors are swallowed per database so a brain.db failure cannot
- * block a tasks.db snapshot (and vice versa).
+ * Non-fatal: errors are swallowed per database so any single failure cannot
+ * block snapshots of the rest.
+ *
+ * Global-tier rotation is the responsibility of
+ * {@link vacuumIntoGlobalBackupAll}.
+ *
+ * @task T5158
+ * @task T10317 — extended to every `DB_INVENTORY` project + derived row
  */
 export async function vacuumIntoBackupAll(opts: VacuumOptions = {}): Promise<void> {
   const nowMs = Date.now();
@@ -325,6 +737,7 @@ export async function vacuumIntoBackupAll(opts: VacuumOptions = {}): Promise<voi
   }
 
   for (const target of SNAPSHOT_TARGETS) {
+    if (target.strategy === 'skip-derived') continue;
     const last = _lastBackupEpoch[target.prefix] ?? 0;
     if (!opts.force && nowMs - last < DEBOUNCE_MS) {
       continue; // debounced — skip this target only
@@ -390,9 +803,12 @@ export function listBrainBackups(
 /**
  * Aggregated listing of all registered SQLite snapshots.
  *
- * Returns an object keyed by snapshot prefix (`tasks`, `brain`) where each
- * value is the per-prefix list sorted newest-first. Missing prefixes are
- * represented as empty arrays.
+ * Returns an object keyed by snapshot prefix (`tasks`, `brain`, `conduit`,
+ * `llmtxt`, `signaldock-project`, `manifest`) where each value is the
+ * per-prefix list sorted newest-first. Missing prefixes are represented as
+ * empty arrays. Derived rows (`manifest`) keep an always-empty bucket so
+ * downstream code can detect "covered by inventory, not snapshotted by
+ * design" vs "unknown prefix".
  */
 export function listSqliteBackupsAll(
   cwd?: string,
@@ -419,49 +835,6 @@ export function listSqliteBackupsAll(
 export type BackupScope = 'project' | 'global';
 
 /**
- * Open the canonical nexus.db singleton via {@link getNexusDb} and return
- * its native handle. Symmetric counterpart to {@link openBrainDbForSnapshot}
- * — eager-open via per-DB chokepoint so global-tier snapshots also work
- * when the in-process handle cache is empty.
- *
- * @task T10316
- */
-async function openNexusDbForSnapshot(): Promise<SnapshotDbHandle | null> {
-  await getNexusDb();
-  return getNexusNativeDb();
-}
-
-/**
- * Open the canonical global signaldock.db singleton via
- * {@link ensureGlobalSignaldockDb} and return its native handle.
- *
- * @task T10316
- */
-async function openSignaldockDbForSnapshot(): Promise<SnapshotDbHandle | null> {
-  await ensureGlobalSignaldockDb();
-  return getGlobalSignaldockNativeDb();
-}
-
-/**
- * Registered global-tier snapshot targets. Both `nexus` and `signaldock` are
- * active as of T369 (epic T310). T10316 added eager-open `openDb` functions
- * to mirror the project-tier behaviour and close the same handle-cache gap.
- *
- * @task T369
- * @task T10316 — eager-open via openCleoDb chokepoint
- * @epic T310
- */
-const GLOBAL_SNAPSHOT_TARGETS: SnapshotTarget[] = [
-  { prefix: 'nexus', getDb: getNexusNativeDb, openDb: openNexusDbForSnapshot },
-  // Activated T369 — global agent registry. openDb added T10316.
-  {
-    prefix: 'signaldock',
-    getDb: getGlobalSignaldockNativeDb,
-    openDb: openSignaldockDbForSnapshot,
-  },
-];
-
-/**
  * Resolve the global-tier backup directory, creating it on first use.
  *
  * Uses `cleoHomeOverride` when provided (test isolation) or falls back to
@@ -473,27 +846,58 @@ function resolveGlobalBackupDir(cleoHomeOverride?: string): string {
 }
 
 /**
+ * Names accepted by {@link vacuumIntoGlobalBackup}. Mirrors
+ * {@link DbRole} for the global-tier subset PLUS the historical
+ * `'signaldock'` alias kept for backward compatibility with callers that
+ * pre-date the inventory split.
+ *
+ * @task T10317 — extended to cover every global-tier inventory entry
+ */
+export type GlobalBackupName =
+  | 'nexus'
+  | 'signaldock'
+  | 'signaldock-global'
+  | 'telemetry'
+  | 'skills'
+  | 'global-brain'
+  | 'global-tasks';
+
+/**
+ * Resolve a {@link GlobalBackupName} to the matching global snapshot
+ * target. Accepts the historical `'signaldock'` alias as a synonym for
+ * `'signaldock-global'`.
+ */
+function findGlobalTarget(name: GlobalBackupName): SnapshotTarget | undefined {
+  if (name === 'signaldock') {
+    return GLOBAL_SNAPSHOT_TARGETS.find((t) => t.role === 'signaldock-global');
+  }
+  return GLOBAL_SNAPSHOT_TARGETS.find((t) => t.role === name);
+}
+
+/**
  * Snapshot a global-tier SQLite database via VACUUM INTO.
  *
- * Writes to `$XDG_DATA_HOME/cleo/backups/sqlite/<dbName>-YYYYMMDD-HHmmss.db`
+ * Writes to `$XDG_DATA_HOME/cleo/backups/sqlite/<prefix>-YYYYMMDD-HHmmss.db`
  * and enforces a per-prefix rotation window (default 10 snapshots).
  *
  * Non-fatal: errors from any individual step are surfaced via the return value
  * but never thrown — a failed snapshot MUST NOT interrupt normal operation.
  *
- * @param dbName         - Which global-tier DB to snapshot (`'nexus'` or `'signaldock'`)
+ * @param dbName         - Which global-tier DB to snapshot
+ *                         (see {@link GlobalBackupName})
  * @param opts.rotation  - Maximum retained snapshots per prefix (default 10)
  * @param opts.cleoHomeOverride - Override `getCleoHome()` path (use in tests to target a tmp dir)
  * @returns Object containing the new snapshot path and any rotated (deleted) file paths
  *
  * @task T306
  * @task T369 — activated signaldock target (epic T310)
+ * @task T10317 — every `DB_INVENTORY` global-tier row covered
  * @epic T299
  * @why ADR-036 §Backup Mechanism requires VACUUM INTO rotation at the global tier;
  *      nexus.db has zero backup coverage prior to v2026.4.11.
  */
 export async function vacuumIntoGlobalBackup(
-  dbName: 'nexus' | 'signaldock',
+  dbName: GlobalBackupName,
   opts?: { rotation?: number; cleoHomeOverride?: string },
 ): Promise<{ snapshotPath: string; rotated: string[] }> {
   const maxSnaps = opts?.rotation ?? MAX_SNAPSHOTS;
@@ -501,15 +905,17 @@ export async function vacuumIntoGlobalBackup(
 
   mkdirSync(backupDir, { recursive: true });
 
-  const target = GLOBAL_SNAPSHOT_TARGETS.find((t) => t.prefix === dbName);
-  if (!target) {
+  const target = findGlobalTarget(dbName);
+  if (!target || target.strategy === 'skip-derived') {
     return { snapshotPath: '', rotated: [] };
   }
 
   // T10316: eager-open via per-DB chokepoint when the in-process singleton
-  // is empty. Mirrors the project-tier fix in `snapshotOne` (Saga T10281 /
-  // E3 — brain backup gap).
+  // is empty. T10317: also covers raw-file-vacuum-readonly targets (orphan
+  // global-brain / global-tasks). Mirrors the project-tier fix in
+  // `snapshotOne` (Saga T10281 / E3).
   let db = target.getDb();
+  let opened: SnapshotDbHandle | null = null;
   if (!db) {
     try {
       db = await target.openDb();
@@ -519,16 +925,17 @@ export async function vacuumIntoGlobalBackup(
     if (!db) {
       return { snapshotPath: '', rotated: [] };
     }
+    opened = db;
   }
 
   const now = new Date();
-  const snapshotName = `${dbName}-${formatTimestamp(now)}.db`;
+  const snapshotName = `${target.prefix}-${formatTimestamp(now)}.db`;
   const snapshotPath = join(backupDir, snapshotName);
 
   // Collect files that will be rotated out before writing the new one.
   const rotated: string[] = [];
   try {
-    const pattern = snapshotPattern(dbName);
+    const pattern = snapshotPattern(target.prefix);
     const existing = readdirSync(backupDir)
       .filter((f) => pattern.test(f))
       .map((f) => ({
@@ -553,12 +960,62 @@ export async function vacuumIntoGlobalBackup(
     // non-fatal — continue even if rotation enumeration fails
   }
 
-  // Checkpoint then VACUUM INTO for a WAL-free, atomic snapshot.
-  db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
-  const safeDest = snapshotPath.replace(/'/g, "''");
-  db.exec(`VACUUM INTO '${safeDest}'`);
+  try {
+    // Checkpoint then VACUUM INTO for a WAL-free, atomic snapshot.
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    const safeDest = snapshotPath.replace(/'/g, "''");
+    db.exec(`VACUUM INTO '${safeDest}'`);
+  } finally {
+    // Release ephemeral handle for raw-file-vacuum-readonly targets.
+    if (opened && target.closeDb) {
+      target.closeDb(opened);
+    }
+  }
 
   return { snapshotPath, rotated };
+}
+
+/**
+ * Snapshot every global-tier database registered in `DB_INVENTORY`.
+ *
+ * Iterates {@link GLOBAL_SNAPSHOT_TARGETS} and invokes
+ * {@link vacuumIntoGlobalBackup} for each entry that resolves to a present
+ * on-disk file. Non-fatal per target — one failure does not block the rest.
+ *
+ * Useful for session-end + `cleo backup add` flows so the global tier
+ * (nexus, signaldock, telemetry, skills, plus any orphan files) gets the
+ * same per-session rotation treatment as the project tier.
+ *
+ * @param opts.cleoHomeOverride - Override `getCleoHome()` path (test isolation)
+ * @param opts.rotation         - Maximum retained snapshots per prefix (default 10)
+ * @returns Array of per-target results (matches insertion order of inventory).
+ *          Skipped or failed targets surface as `{ snapshotPath: '', rotated: [] }`
+ *          so callers can audit coverage without consulting the inventory.
+ *
+ * @task T10317 — fleet snapshot at session-end (Saga T10281 / E3)
+ */
+export async function vacuumIntoGlobalBackupAll(opts?: {
+  cleoHomeOverride?: string;
+  rotation?: number;
+}): Promise<Array<{ role: DbRole; snapshotPath: string; rotated: string[] }>> {
+  const out: Array<{ role: DbRole; snapshotPath: string; rotated: string[] }> = [];
+  for (const target of GLOBAL_SNAPSHOT_TARGETS) {
+    if (target.strategy === 'skip-derived') {
+      out.push({ role: target.role, snapshotPath: '', rotated: [] });
+      continue;
+    }
+    try {
+      // Map role → the global-backup name; `signaldock-global` keeps its
+      // canonical role here (the historical alias is only honoured at the
+      // public API boundary in `vacuumIntoGlobalBackup`).
+      const name: GlobalBackupName = target.role as GlobalBackupName;
+      const r = await vacuumIntoGlobalBackup(name, opts);
+      out.push({ role: target.role, ...r });
+    } catch {
+      out.push({ role: target.role, snapshotPath: '', rotated: [] });
+    }
+  }
+  return out;
 }
 
 /**
@@ -611,6 +1068,59 @@ export function listGlobalSqliteBackups(
   } catch {
     return [];
   }
+}
+
+/**
+ * Aggregated listing of every global-tier snapshot bucket. Returns a map
+ * keyed by canonical snapshot prefix (`nexus`, `signaldock`, `telemetry`,
+ * `skills`, `global-brain`, `global-tasks`) with each value sorted
+ * newest-first by mtime. Empty arrays surface for buckets with no snapshots
+ * yet — callers can distinguish "covered by inventory, nothing on disk" vs
+ * "unknown prefix".
+ *
+ * @task T10317
+ */
+export function listGlobalSqliteBackupsAll(
+  cleoHomeOverride?: string,
+): Record<string, GlobalBackupEntry[]> {
+  const out: Record<string, GlobalBackupEntry[]> = {};
+  for (const target of GLOBAL_SNAPSHOT_TARGETS) {
+    out[target.prefix] = listGlobalSqliteBackups(target.prefix, cleoHomeOverride);
+  }
+  return out;
+}
+
+// ============================================================================
+// Inventory coverage introspection
+// ============================================================================
+
+/**
+ * Inventory coverage report. Lists every {@link DbRole} and the snapshot
+ * strategy that covers it. Used by test suites and `cleo doctor` follow-ups
+ * to assert no inventory entry is silently uncovered.
+ *
+ * @task T10317
+ */
+export interface InventoryCoverageRow {
+  readonly role: DbRole;
+  readonly tier: DbInventoryEntry['tier'];
+  readonly prefix: string;
+  readonly strategy: SnapshotStrategy;
+}
+
+/**
+ * Return the strategy + filename prefix that the snapshot pipeline applies
+ * to each `DB_INVENTORY` row.
+ *
+ * @task T10317
+ */
+export function describeSnapshotCoverage(): readonly InventoryCoverageRow[] {
+  return [...SNAPSHOT_TARGETS, ...GLOBAL_SNAPSHOT_TARGETS].map((t) => ({
+    role: t.role,
+    tier: t.tier,
+    prefix: t.prefix,
+    strategy: t.strategy,
+  }));
 }
 
 // ============================================================================

--- a/packages/core/src/telemetry/sqlite.ts
+++ b/packages/core/src/telemetry/sqlite.ts
@@ -97,6 +97,21 @@ export function resetTelemetryDbState(): void {
 }
 
 /**
+ * Return the raw `node:sqlite` handle for the open telemetry.db (or `null`
+ * if not yet initialised). Exposed so the backup pipeline can issue
+ * `PRAGMA wal_checkpoint(TRUNCATE)` + `VACUUM INTO` against the live
+ * singleton without re-resolving the path or opening a second handle.
+ *
+ * Mirrors {@link getNexusNativeDb}, {@link getBrainNativeDb}, etc.
+ *
+ * @task T10317 — fleet snapshot coverage for every `DB_INVENTORY` entry
+ *               (Saga T10281 / Epic T10284 / E3)
+ */
+export function getTelemetryNativeDb(): DatabaseSync | null {
+  return _nativeDb;
+}
+
+/**
  * Initialize telemetry.db (lazy singleton).
  * Creates the file and runs migrations on first call.
  */


### PR DESCRIPTION
Closes T10317. Saga T10281 / Epic T10284 / E3-BACKUP-RECOVERY.

## Summary

Extends the SQLite snapshot pipeline so EVERY row in `DB_INVENTORY`
(`@cleocode/contracts`) produces a snapshot at session-end and
`cleo backup add`. Closes the long-tail gap T10316 surfaced: even with
the brain eager-open fix in place, `vacuumIntoBackupAll` still ignored
telemetry, skills, signaldock-global, the llmtxt reserved row, the
signaldock-project historical row, and the two `global-brain` /
`global-tasks` orphans surfaced by the saga T10281 inventory audit.

`SNAPSHOT_TARGETS` and `GLOBAL_SNAPSHOT_TARGETS` are now derived from
`DB_INVENTORY` directly. Each row classifies into one of three
strategies:

- **chokepoint-opener** — `tasks`, `brain`, `conduit`, `nexus`,
  `signaldock-global`, `telemetry`, `skills`. Snapshot via the canonical
  per-DB opener: `getDb`, `getBrainDb`, `ensureConduitDb`, `getNexusDb`,
  `ensureGlobalSignaldockDb`, `getTelemetryDb`, `openSkillsDb`. All
  allowlisted under `packages/core/src/store/**` per ADR-068.
- **raw-file-vacuum-readonly** — `llmtxt` (RESERVED), `signaldock-project`
  (HISTORICAL), `global-brain` / `global-tasks` (UNREGISTERED ORPHANS).
  Opens the on-disk file read-only via a one-shot `DatabaseSync` to emit
  `PRAGMA wal_checkpoint(TRUNCATE)` + `VACUUM INTO`, then closes.
- **skip-derived** — `manifest` (`tier === 'derived'`,
  `backupPath === 'rebuildable-from-blob-store'`). Surfaces in coverage
  and `listSqliteBackupsAll` as an always-empty bucket; never
  snapshotted (content is rebuildable from the blob CAS).

## New / changed exports

- `vacuumIntoGlobalBackupAll(opts)` — fleet snapshot at session-end.
- `listGlobalSqliteBackupsAll(cleoHomeOverride?)` — single audit
  surface for `cleo doctor db-substrate` follow-ups.
- `describeSnapshotCoverage()` — inventory coverage introspection.
- `GlobalBackupName` extended with `telemetry`, `skills`, `global-brain`,
  `global-tasks`.
- `getTelemetryNativeDb()` added to `packages/core/src/telemetry/sqlite.ts`
  so the backup pipeline can checkpoint + VACUUM INTO against the live
  telemetry singleton.

## Test plan

- [x] Inventory-coverage assertion: `describeSnapshotCoverage()` covers
      every `DB_INVENTORY` entry exactly once with a real strategy.
- [x] All 7 chokepoint roles classify to `chokepoint-opener`.
- [x] Derived rows (`manifest`) classify to `skip-derived`.
- [x] TC-200: telemetry chokepoint snapshot integrity.
- [x] TC-201: skills chokepoint snapshot.
- [x] TC-202: `global-brain` raw-file-vacuum-readonly snapshot integrity.
- [x] TC-203: `global-tasks` clean-skip when on-disk file absent.
- [x] TC-204: `vacuumIntoGlobalBackupAll` returns one entry per
      global-tier inventory row (coverage parity with
      `describeSnapshotCoverage`).
- [x] TC-205: `listGlobalSqliteBackupsAll` surfaces every prefix
      (`nexus`, `signaldock`, `telemetry`, `skills`, `global-brain`,
      `global-tasks`) even when buckets are empty.
- [x] `sqlite-backup-real-process.test.ts` (T10316 regression) still
      passes — brain backup eager-open intact.
- [x] All 33 tests across `sqlite-backup.test.ts` +
      `sqlite-backup-global.test.ts` green locally.

## Constraints honoured

- All DB opens flow through canonical chokepoint openers (`getDb`,
  `getBrainDb`, `ensureConduitDb`, `getNexusDb`,
  `ensureGlobalSignaldockDb`, `getTelemetryDb`, `openSkillsDb`) — NOT
  raw `openCleoDb('brain')` (which is misrouted per the P0 bug T10397).
- Raw-file `DatabaseSync` opens live under `packages/core/src/store/**`
  — the canonical allowlist root for the db-open-guard CI gate.
- No `any` / `unknown` shortcuts; no `as unknown as` casting chains.
- Backup failures remain non-fatal (`try { ... } catch { /* swallow */ }`)
  — backup MUST NOT block normal operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)