### PR TITLE
T10310: per-DB pragma drift in cleo doctor db-substrate (Saga T10281 / E2)

### DIFF
--- a/.changeset/T10310.md
+++ b/.changeset/T10310.md
@@ -1,0 +1,45 @@
+---
+id: T10310
+tasks: [T10310]
+kind: feat
+summary: "doctor db-substrate: per-DB pragma drift detection (Saga T10281 / Epic T10283)"
+---
+
+Extends `cleo doctor db-substrate` (T10307) with a per-DB pragma walker
+that detects drift against the canonical `specs/sqlite-pragmas.json` SSoT.
+
+For every existing DB that passes `PRAGMA integrity_check`, the survey now
+walks the six pragmas declared in `specs/sqlite-pragmas.json#driftPragmas`
+on a raw read-only snapshot (no pragma application). Each pragma whose
+actual on-disk value diverges from the canonical expectation lands in the
+new `dbs[role].pragmaDrift: PragmaDriftItem[]` field:
+
+- `journal_mode` — expected `WAL`
+- `busy_timeout` — expected `5000`
+- `foreign_keys` — expected `ON`
+- `synchronous` — expected `NORMAL`
+- `page_size` — expected `4096` (declared in `fileInvariants`)
+- `application_id` — expected `0` (declared in `fileInvariants`)
+
+`pragmaDrift` is `null` when the DB does not exist or failed
+integrity_check (a corrupt journal is not reliably queryable). Empty
+array `[]` means the DB matches every queried pragma exactly.
+
+Integer-coded pragmas (`synchronous: 0|1|2|3`, `foreign_keys: 0|1`) are
+normalised to their symbolic names (`NORMAL`, `ON`, …) before equality so
+SQLite's wire format does not produce false-positive drift reports.
+
+Each drift item is additionally surfaced via `meta.warnings` under
+`W_DB_SUBSTRATE_PRAGMA_DRIFT` so operators see drift in the standard
+warning stream regardless of which output channel they consume.
+
+Two new SSoT exports under `@cleocode/core/doctor`:
+
+- `loadPragmaSsot()` — returns the embedded `(name, expected)` map +
+  ordered drift-query list. Backed by a TypeScript literal that is
+  byte-equivalent to the JSON spec; a sibling test guards against drift.
+- `normalisePragmaValue(pragma, raw)` — case-insensitive normaliser with
+  integer-to-symbolic resolution.
+
+Adds a new contract `PragmaDriftItem` to `@cleocode/contracts` and a
+new field `pragmaDrift: PragmaDriftItem[] | null` to `DbSubstrateEntry`.

--- a/packages/cleo/src/cli/commands/__tests__/doctor-db-substrate.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/doctor-db-substrate.test.ts
@@ -40,7 +40,12 @@ import {
   resolveInventoryMigrationsFolder,
   surveyDbSubstrate,
   surveyFleetDbSubstrate,
+  walkPragmaDrift,
 } from '../../../../../core/src/doctor/db-substrate.js';
+import {
+  loadPragmaSsot,
+  normalisePragmaValue,
+} from '../../../../../core/src/doctor/pragma-ssot.js';
 
 const _require = createRequire(import.meta.url);
 const { DatabaseSync: DatabaseSyncCtor } = _require('node:sqlite') as {
@@ -646,5 +651,166 @@ describe('doctor db-substrate (T10307)', () => {
     const withoutSlash = resolveInventoryMigrationsFolder('packages/core/migrations/drizzle-tasks');
     expect(withSlash).toBe(withoutSlash);
     expect(withSlash.endsWith('drizzle-tasks')).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // T10310 — Per-DB pragma drift detection
+  // ──────────────────────────────────────────────────────────────────────
+
+  it('T10310: pragma SSoT loader resolves canonical entries for every drift pragma', () => {
+    const ssot = loadPragmaSsot();
+    expect(ssot.driftPragmas.length).toBe(6);
+    expect(ssot.driftPragmas).toContain('journal_mode');
+    expect(ssot.driftPragmas).toContain('busy_timeout');
+    expect(ssot.driftPragmas).toContain('foreign_keys');
+    expect(ssot.driftPragmas).toContain('synchronous');
+    expect(ssot.driftPragmas).toContain('page_size');
+    expect(ssot.driftPragmas).toContain('application_id');
+
+    // Every drift pragma MUST resolve to a non-empty expected value.
+    for (const name of ssot.driftPragmas) {
+      const expected = ssot.expectedByName.get(name.toLowerCase());
+      expect(expected).toBeDefined();
+      expect(typeof expected).toBe('string');
+      expect((expected ?? '').length).toBeGreaterThan(0);
+    }
+  });
+
+  it('T10310: normalisePragmaValue resolves integer codes to symbolic names', () => {
+    expect(normalisePragmaValue('synchronous', '1')).toBe('NORMAL');
+    expect(normalisePragmaValue('synchronous', '2')).toBe('FULL');
+    expect(normalisePragmaValue('foreign_keys', '0')).toBe('OFF');
+    expect(normalisePragmaValue('foreign_keys', '1')).toBe('ON');
+    // Non-coded pragmas just upper-case.
+    expect(normalisePragmaValue('journal_mode', 'wal')).toBe('WAL');
+    expect(normalisePragmaValue('page_size', '4096')).toBe('4096');
+  });
+
+  it('T10310: pragmaDrift is null when the DB does not exist', async () => {
+    await import('@cleocode/paths').then(({ _resetCleoPlatformPathsCache }) =>
+      _resetCleoPlatformPathsCache(),
+    );
+    const projectRoot = join(fleetRoot, 'no-db-project');
+    mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+    // Intentionally do NOT seed tasks.db — survey should produce a missing entry.
+
+    const result = surveyDbSubstrate(projectRoot);
+    const tasks = result.projects[0]?.dbs['tasks'];
+    expect(tasks).toBeDefined();
+    if (!tasks) throw new Error('tasks entry absent');
+    expect(tasks.exists).toBe(false);
+    expect(tasks.pragmaDrift).toBeNull();
+  });
+
+  it('T10310: pragmaDrift is null when the DB is corrupt (integrityOK=false)', async () => {
+    await import('@cleocode/paths').then(({ _resetCleoPlatformPathsCache }) =>
+      _resetCleoPlatformPathsCache(),
+    );
+    const projectRoot = createProjectWithTasksDb('corrupt-pragma-project');
+    seedCorruptDb(join(projectRoot, '.cleo', 'tasks.db'));
+
+    const result = surveyDbSubstrate(projectRoot);
+    const tasks = result.projects[0]?.dbs['tasks'];
+    if (!tasks) throw new Error('tasks entry absent');
+    expect(tasks.integrityOK).toBe(false);
+    expect(tasks.pragmaDrift).toBeNull();
+  });
+
+  it('T10310: pragmaDrift surfaces busy_timeout drift on a freshly-created DB', async () => {
+    // A freshly-created node:sqlite DB defaults to busy_timeout=0, but the
+    // SSoT expects 5000. A raw read-only snapshot (no applyPragmas) will
+    // therefore report drift on `busy_timeout`. Same for `foreign_keys`
+    // (default 0/OFF) and `synchronous` (default 2/FULL). page_size + journal_mode
+    // + application_id will match the SSoT defaults (4096, no-WAL, 0 stamp).
+    await import('@cleocode/paths').then(({ _resetCleoPlatformPathsCache }) =>
+      _resetCleoPlatformPathsCache(),
+    );
+    const projectRoot = createProjectWithTasksDb('drift-project');
+
+    const result = surveyDbSubstrate(projectRoot);
+    const tasks = result.projects[0]?.dbs['tasks'];
+    if (!tasks) throw new Error('tasks entry absent');
+    expect(tasks.integrityOK).toBe(true);
+    expect(tasks.pragmaDrift).not.toBeNull();
+    const drift = tasks.pragmaDrift ?? [];
+    const pragmas = drift.map((d) => d.pragma);
+    // busy_timeout will drift (default 0 vs canonical 5000).
+    expect(pragmas).toContain('busy_timeout');
+    // journal_mode WILL drift on a fresh DB because seedHealthyDb does
+    // not switch the file to WAL — default is `delete`.
+    expect(pragmas).toContain('journal_mode');
+    // The journal_mode drift entry should record the actual on-disk mode.
+    const journalEntry = drift.find((d) => d.pragma === 'journal_mode');
+    expect(journalEntry?.expected).toBe('WAL');
+    expect((journalEntry?.actual ?? '').toLowerCase()).not.toBe('wal');
+  });
+
+  it('T10310: pragmaDrift detects an explicitly overridden persistent pragma', async () => {
+    // Explicitly override journal_mode to `delete` AND application_id to a
+    // non-canonical value on disk, then verify the survey surfaces both as
+    // drift items.
+    await import('@cleocode/paths').then(({ _resetCleoPlatformPathsCache }) =>
+      _resetCleoPlatformPathsCache(),
+    );
+    const projectRoot = createProjectWithTasksDb('override-pragma-project');
+    const dbPath = join(projectRoot, '.cleo', 'tasks.db');
+
+    const writer = new DatabaseSyncCtor(dbPath);
+    try {
+      writer.exec('PRAGMA journal_mode = DELETE');
+      writer.exec('PRAGMA application_id = 12345');
+    } finally {
+      writer.close();
+    }
+
+    const result = surveyDbSubstrate(projectRoot);
+    const tasks = result.projects[0]?.dbs['tasks'];
+    if (!tasks) throw new Error('tasks entry absent');
+    const drift = tasks.pragmaDrift ?? [];
+
+    const journal = drift.find((d) => d.pragma === 'journal_mode');
+    expect(journal).toBeDefined();
+    expect(journal?.expected).toBe('WAL');
+    expect((journal?.actual ?? '').toLowerCase()).toBe('delete');
+
+    const appId = drift.find((d) => d.pragma === 'application_id');
+    expect(appId).toBeDefined();
+    expect(appId?.expected).toBe('0');
+    expect(appId?.actual).toBe('12345');
+  });
+
+  it('T10310: walkPragmaDrift reports zero drift when every queried pragma matches the SSoT', () => {
+    // Construct an in-memory DB and explicitly set every drift pragma to
+    // its canonical value, then assert the walker reports zero drift.
+    const db = new DatabaseSyncCtor(':memory:');
+    try {
+      // page_size MUST be set before any table is created — picked first.
+      db.exec('PRAGMA page_size = 4096');
+      // Apply every canonical pragma the walker checks.
+      db.exec('PRAGMA journal_mode = WAL');
+      db.exec('PRAGMA busy_timeout = 5000');
+      db.exec('PRAGMA foreign_keys = ON');
+      db.exec('PRAGMA synchronous = NORMAL');
+      db.exec('PRAGMA application_id = 0');
+      // Force a write so journal_mode + page_size persist.
+      db.exec('CREATE TABLE t (id INTEGER); INSERT INTO t VALUES (1);');
+
+      const drift = walkPragmaDrift(db);
+      // :memory: has documented quirks:
+      // - journal_mode cannot use WAL — falls back to `memory`.
+      // - busy_timeout via `exec()` may not stick on freshly-opened
+      //   :memory: handles in some node:sqlite builds.
+      // The override-pragma + drift-project tests above cover the
+      // file-backed real-world case. Here we assert that every OTHER
+      // queried pragma (page_size, foreign_keys, synchronous,
+      // application_id) is not flagged as drift after explicit
+      // canonical setup.
+      const drifted = drift
+        .map((d) => d.pragma)
+        .filter((p) => p !== 'journal_mode' && p !== 'busy_timeout');
+      expect(drifted).toEqual([]);
+    } finally {
+      db.close();
+    }
   });
 });

--- a/packages/cleo/src/cli/commands/doctor-db-substrate.ts
+++ b/packages/cleo/src/cli/commands/doctor-db-substrate.ts
@@ -72,6 +72,31 @@ function pushSubstrateWarnings(result: DbSubstrateAuditResult): void {
       context,
     });
   }
+
+  // T10310 — surface every pragma-drift item as a per-DB warning so
+  // operators see drift in `meta.warnings` even when the per-entry
+  // `pragmaDrift` array is only inspected by structured-output consumers.
+  for (const projectSurvey of result.projects) {
+    for (const [role, entry] of Object.entries(projectSurvey.dbs)) {
+      if (entry.pragmaDrift === null || entry.pragmaDrift.length === 0) continue;
+      for (const drift of entry.pragmaDrift) {
+        pushWarning({
+          code: 'W_DB_SUBSTRATE_PRAGMA_DRIFT',
+          message:
+            `Pragma drift on ${role} (${entry.filePath}): ` +
+            `expected ${drift.pragma}=${drift.expected}, actual=${drift.actual ?? '<unmeasurable>'}`,
+          severity: 'warn',
+          context: {
+            role,
+            filePath: entry.filePath,
+            pragma: drift.pragma,
+            expected: drift.expected,
+            actual: drift.actual,
+          },
+        });
+      }
+    }
+  }
 }
 
 /**

--- a/packages/contracts/src/doctor.ts
+++ b/packages/contracts/src/doctor.ts
@@ -356,6 +356,54 @@ export interface DbSubstrateEntry {
    * @task T10311
    */
   migrationCoverage: DbSubstrateMigrationCoverage | null;
+  /**
+   * Pragma drift entries — one per pragma whose actual value (read from
+   * a raw read-only snapshot of this DB, no pragma application) differs
+   * from the SSoT expectation in `specs/sqlite-pragmas.json`.
+   *
+   * @remarks
+   * `null` when the DB does not exist on disk (no snapshot to query) OR
+   * the integrity_check failed (a corrupt DB cannot be reliably queried
+   * for pragmas). Empty array `[]` means the DB matches the canonical
+   * pragma SSoT exactly.
+   *
+   * @task T10310
+   */
+  pragmaDrift: PragmaDriftItem[] | null;
+}
+
+/**
+ * One pragma drift item surfaced in {@link DbSubstrateEntry.pragmaDrift}.
+ *
+ * @remarks
+ * Compared values are normalised to lower-case strings before equality
+ * is asserted, matching SQLite's pragma-output conventions
+ * (`journal_mode` returns `wal` not `WAL`, `synchronous` returns
+ * `2` for `NORMAL`, etc. — see {@link PRAGMA_VALUE_NORMALISERS}).
+ *
+ * The triple `(pragma, expected, actual)` is stable across runs so
+ * downstream consumers can deduplicate / aggregate drift reports.
+ *
+ * @task T10310
+ * @epic T10283
+ * @saga T10281
+ */
+export interface PragmaDriftItem {
+  /** Name of the pragma (e.g. `journal_mode`, `busy_timeout`). */
+  pragma: string;
+  /**
+   * Expected value as declared in `specs/sqlite-pragmas.json`. Always a
+   * string — values are stored as strings in the SSoT so a future
+   * `0x12345` application_id literal does not lose its hex form to a
+   * number cast.
+   */
+  expected: string;
+  /**
+   * Actual value as returned by `PRAGMA <name>` on a raw read-only
+   * snapshot. `null` when the pragma query threw (e.g. an exotic pragma
+   * name not implemented by this SQLite build).
+   */
+  actual: string | null;
 }
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -344,6 +344,7 @@ export type {
   LegacyBackupScanResult,
   OrphanEntry,
   OrphanScanResult,
+  PragmaDriftItem,
   PruneAuditEntry,
   PruneResult,
   SagaAuditEntry,

--- a/packages/core/src/doctor/__tests__/pragma-ssot.test.ts
+++ b/packages/core/src/doctor/__tests__/pragma-ssot.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Equivalence guard for the T10310 embedded pragma SSoT mirror.
+ *
+ * Asserts the TypeScript literal embedded in
+ * `packages/core/src/doctor/pragma-ssot.ts` is byte-equivalent to the
+ * canonical JSON at `specs/sqlite-pragmas.json`. Drift between the two
+ * sides would silently break the drift walker without this guard.
+ *
+ * Mirrors the pattern established by
+ * `packages/core/src/store/__tests__/sqlite-pragmas-ssot.test.ts` for
+ * the performance-pragma applier.
+ *
+ * @task T10310
+ * @epic T10283
+ * @saga T10281
+ * @see packages/core/src/store/__tests__/sqlite-pragmas-ssot.test.ts
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { loadPragmaSsot, normalisePragmaValue } from '../pragma-ssot.js';
+
+interface SqlitePragmaSpecFile {
+  readonly version: number;
+  readonly pragmas: ReadonlyArray<readonly [string, string]>;
+  readonly fileInvariants: ReadonlyArray<readonly [string, string]>;
+  readonly driftPragmas: readonly string[];
+}
+
+function loadJsonSsot(): SqlitePragmaSpecFile {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const specPath = resolve(here, '..', '..', '..', '..', '..', 'specs', 'sqlite-pragmas.json');
+  return JSON.parse(readFileSync(specPath, 'utf8')) as SqlitePragmaSpecFile;
+}
+
+describe('pragma-ssot loader (T10310)', () => {
+  it('embedded literal matches the JSON SSoT pragmas array byte-for-byte', () => {
+    const json = loadJsonSsot();
+    const ssot = loadPragmaSsot();
+
+    // Every JSON pragma entry MUST appear in the loader's entries array.
+    for (const [name, expected] of json.pragmas) {
+      const found = ssot.entries.find((e) => e[0] === name);
+      expect(found, `pragma ${name} missing from embedded SSoT`).toBeDefined();
+      expect(found?.[1]).toBe(expected);
+    }
+  });
+
+  it('embedded literal matches the JSON SSoT fileInvariants array', () => {
+    const json = loadJsonSsot();
+    const ssot = loadPragmaSsot();
+    for (const [name, expected] of json.fileInvariants) {
+      const found = ssot.entries.find((e) => e[0] === name);
+      expect(found, `fileInvariant ${name} missing from embedded SSoT`).toBeDefined();
+      expect(found?.[1]).toBe(expected);
+    }
+  });
+
+  it('embedded driftPragmas list matches the JSON SSoT exactly', () => {
+    const json = loadJsonSsot();
+    const ssot = loadPragmaSsot();
+    expect(ssot.driftPragmas).toEqual(json.driftPragmas);
+  });
+
+  it('every driftPragma resolves to an expected value', () => {
+    const ssot = loadPragmaSsot();
+    for (const name of ssot.driftPragmas) {
+      const expected = ssot.expectedByName.get(name.toLowerCase());
+      expect(expected, `driftPragma ${name} has no expected value`).toBeDefined();
+    }
+  });
+
+  it('normalisePragmaValue handles integer-coded values', () => {
+    expect(normalisePragmaValue('synchronous', '0')).toBe('OFF');
+    expect(normalisePragmaValue('synchronous', '1')).toBe('NORMAL');
+    expect(normalisePragmaValue('synchronous', '2')).toBe('FULL');
+    expect(normalisePragmaValue('synchronous', '3')).toBe('EXTRA');
+    expect(normalisePragmaValue('foreign_keys', '0')).toBe('OFF');
+    expect(normalisePragmaValue('foreign_keys', '1')).toBe('ON');
+  });
+
+  it('normalisePragmaValue passes through symbolic values upper-cased', () => {
+    expect(normalisePragmaValue('journal_mode', 'wal')).toBe('WAL');
+    expect(normalisePragmaValue('journal_mode', 'WAL')).toBe('WAL');
+    expect(normalisePragmaValue('journal_mode', 'delete')).toBe('DELETE');
+    expect(normalisePragmaValue('temp_store', 'memory')).toBe('MEMORY');
+  });
+
+  it('normalisePragmaValue is case-insensitive on the pragma name', () => {
+    expect(normalisePragmaValue('Synchronous', '1')).toBe('NORMAL');
+    expect(normalisePragmaValue('SYNCHRONOUS', '1')).toBe('NORMAL');
+  });
+});

--- a/packages/core/src/doctor/db-substrate.ts
+++ b/packages/core/src/doctor/db-substrate.ts
@@ -41,11 +41,13 @@ import {
   type DbSubstrateProjectSurvey,
   type DbSubstrateSummary,
   type DbSubstrateWarning,
+  type PragmaDriftItem,
 } from '@cleocode/contracts';
 import { getCleoHome } from '@cleocode/paths';
 import { readMigrationFiles } from 'drizzle-orm/migrator';
 import { openCleoDbSnapshot } from '../store/open-cleo-db.js';
 import { resolveCorePackageMigrationsFolder } from '../store/resolve-migrations-folder.js';
+import { loadPragmaSsot, normalisePragmaValue } from './pragma-ssot.js';
 
 /**
  * Number of representative tables to row-count per DB.
@@ -115,6 +117,88 @@ function pickRepresentativeTables(
     .all() as SchemaRow[];
   const filtered = rows.map((r) => r.name).filter((n) => !ROW_COUNT_TABLE_BLOCKLIST.has(n));
   return filtered.slice(0, REPRESENTATIVE_TABLE_LIMIT);
+}
+
+/**
+ * Walk the canonical drift-pragma list against an open snapshot handle
+ * and report every pragma whose actual value diverges from the SSoT.
+ *
+ * @remarks
+ * Reads each pragma name from {@link PragmaSsot.driftPragmas} (sourced
+ * from `specs/sqlite-pragmas.json#driftPragmas`), runs `PRAGMA <name>`
+ * against `snapshotDb`, normalises the result via
+ * {@link normalisePragmaValue}, and compares against the SSoT-declared
+ * expected value (case-insensitively).
+ *
+ * Pragmas whose query throws are surfaced with `actual: null` so the
+ * envelope reader can distinguish "differs" from "could not measure".
+ *
+ * **Important**: this function expects the snapshot to have been opened
+ * WITHOUT `applyPragmas` (i.e. `applyPragmas: false`). The drift report
+ * measures what the DB actually carries on disk + the connection's
+ * defaults, NOT what `applyPerfPragmas` would set after open. This
+ * captures the case where a discovery tool or legacy opener queries the
+ * DB without going through the SSoT — exactly the regression class
+ * Saga T10281 / Epic T10283 was filed to surface.
+ *
+ * @param snapshotDb - Open read-only snapshot handle.
+ * @returns Drift items; empty array when every queried pragma matches
+ *   the canonical expectation.
+ *
+ * @task T10310
+ * @epic T10283
+ * @saga T10281
+ */
+export function walkPragmaDrift(
+  snapshotDb: ReturnType<typeof openCleoDbSnapshot>['db'],
+): PragmaDriftItem[] {
+  const ssot = loadPragmaSsot();
+  const drift: PragmaDriftItem[] = [];
+
+  for (const pragmaName of ssot.driftPragmas) {
+    const expected = ssot.expectedByName.get(pragmaName.toLowerCase());
+    if (expected === undefined) {
+      // The SSoT lists a pragma in driftPragmas but no expectation —
+      // surface as null actual to make the misconfiguration visible
+      // rather than silently skipping.
+      drift.push({ pragma: pragmaName, expected: '<missing-ssot>', actual: null });
+      continue;
+    }
+
+    let actualRaw: string | null = null;
+    try {
+      // PRAGMA <name> returns a single row keyed by the pragma name.
+      // We narrow the unknown row to a string-or-number value and
+      // stringify defensively.
+      const row = snapshotDb.prepare(`PRAGMA ${pragmaName}`).get() as
+        | Record<string, string | number | bigint | null>
+        | undefined;
+      if (row !== undefined) {
+        const rowValue = row[pragmaName];
+        if (rowValue !== null && rowValue !== undefined) {
+          actualRaw = typeof rowValue === 'bigint' ? String(rowValue) : String(rowValue);
+        }
+      }
+    } catch {
+      actualRaw = null;
+    }
+
+    if (actualRaw === null) {
+      // Pragma query failed entirely OR returned no row — surface drift
+      // with actual=null so the envelope reader can spot it without
+      // a separate "could not measure" channel.
+      drift.push({ pragma: pragmaName, expected, actual: null });
+      continue;
+    }
+
+    const expectedNormalised = normalisePragmaValue(pragmaName, expected);
+    const actualNormalised = normalisePragmaValue(pragmaName, actualRaw);
+    if (expectedNormalised !== actualNormalised) {
+      drift.push({ pragma: pragmaName, expected, actual: actualRaw });
+    }
+  }
+
+  return drift;
 }
 
 /**
@@ -298,6 +382,7 @@ export function inspectDbFile(entry: DbInventoryEntry, filePath: string): DbSubs
       error: null,
       suggestedFix: null,
       migrationCoverage: null,
+      pragmaDrift: null,
     };
   }
 
@@ -322,6 +407,7 @@ export function inspectDbFile(entry: DbInventoryEntry, filePath: string): DbSubs
     const integrityOK = integrityRows.length === 1 && integrityRows[0]?.integrity_check === 'ok';
 
     let rowCounts: Record<string, number> | null = null;
+    let pragmaDrift: PragmaDriftItem[] | null = null;
     if (integrityOK) {
       const tables = pickRepresentativeTables(snapshot.db);
       if (tables.length > 0) {
@@ -333,6 +419,11 @@ export function inspectDbFile(entry: DbInventoryEntry, filePath: string): DbSubs
           }
         }
       }
+      // Pragma drift walk — only meaningful on a DB that passed
+      // integrity_check. A corrupt DB's pragmas are not reliably
+      // queryable (and the survey already surfaces `integrityOK=false`
+      // which is the higher-priority signal).
+      pragmaDrift = walkPragmaDrift(snapshot.db);
     }
 
     // Migration coverage cross-check (T10311). Only attempted when the
@@ -362,6 +453,7 @@ export function inspectDbFile(entry: DbInventoryEntry, filePath: string): DbSubs
       error: null,
       suggestedFix: integrityOK ? null : `cleo backup recover ${entry.role}`,
       migrationCoverage,
+      pragmaDrift,
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -375,6 +467,7 @@ export function inspectDbFile(entry: DbInventoryEntry, filePath: string): DbSubs
       error: message,
       suggestedFix: `cleo backup recover ${entry.role}`,
       migrationCoverage: null,
+      pragmaDrift: null,
     };
   } finally {
     snapshot?.close();

--- a/packages/core/src/doctor/index.ts
+++ b/packages/core/src/doctor/index.ts
@@ -19,6 +19,7 @@
  */
 
 // T10307 — DB-substrate survey (Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10282)
+// T10310 — Per-DB pragma drift (Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10283)
 export {
   computeSubstrateProjectId,
   detectNestedNexusDuplicates,
@@ -29,6 +30,7 @@ export {
   surveyDbSubstrate,
   surveyFleetDbSubstrate,
   surveyProjectDbSubstrate,
+  walkPragmaDrift,
 } from './db-substrate.js';
 // T10309 — Legacy-backup walker (Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10282)
 export type { LegacyBackupPruneOptions, LegacyBackupScanOptions } from './legacy-backups.js';
@@ -42,6 +44,12 @@ export {
   recommendForBackup,
   scanLegacyBackups,
 } from './legacy-backups.js';
+export type { PragmaSsot, PragmaSsotEntry } from './pragma-ssot.js';
+export {
+  loadPragmaSsot,
+  normalisePragmaValue,
+  PRAGMA_VALUE_NORMALISERS,
+} from './pragma-ssot.js';
 export { auditSagaHierarchy } from './saga-audit.js';
 export type { PruneOptions, ScanOptions } from './worktree-orphans.js';
 export {

--- a/packages/core/src/doctor/pragma-ssot.ts
+++ b/packages/core/src/doctor/pragma-ssot.ts
@@ -1,0 +1,185 @@
+/**
+ * Pragma SSoT loader for `cleo doctor db-substrate` drift detection (T10310).
+ *
+ * Exposes the canonical (pragma → expected-value) map used by the per-DB
+ * pragma walker. Sourced from a TypeScript literal that MUST stay
+ * byte-equivalent to `specs/sqlite-pragmas.json` v1 (mirrors the pattern
+ * established by `packages/core/src/store/sqlite-pragmas.ts` for T9157
+ * — embedded literal avoids `readFileSync` paths that break in
+ * npm-installed consumers).
+ *
+ * The drift walker checks the six pragmas declared in
+ * `specs/sqlite-pragmas.json#driftPragmas` (the AC list for T10310):
+ *
+ *   - `journal_mode`, `busy_timeout`, `synchronous`, `foreign_keys` —
+ *     also live in `pragmas` (T9157 SSoT).
+ *   - `page_size`, `application_id` — additional file-level invariants
+ *     declared in the JSON spec's `fileInvariants` array.
+ *
+ * The equivalence test in `__tests__/pragma-ssot.test.ts` asserts this
+ * module's embedded literal matches the on-disk JSON exactly so the
+ * two cannot drift silently.
+ *
+ * @task T10310
+ * @epic T10283
+ * @saga T10281
+ * @see specs/sqlite-pragmas.json
+ * @see packages/core/src/store/sqlite-pragmas.ts (sibling embedded SSoT
+ *      for the performance pragma applier — same pattern for the same
+ *      installability reason)
+ */
+
+/**
+ * One canonical (name, value) pair from the SSoT — exposed as a
+ * `readonly tuple` to keep callers honest about immutability.
+ */
+export type PragmaSsotEntry = readonly [name: string, expectedValue: string];
+
+/**
+ * Result of {@link loadPragmaSsot}.
+ *
+ * `expectedByName` is the (lower-cased name) → expected-value map the
+ * walker uses for O(1) lookups. `driftPragmas` is the ordered list of
+ * pragma names the walker queries, derived directly from the SSoT
+ * `driftPragmas` array.
+ */
+export interface PragmaSsot {
+  /** Ordered list of (pragma, expected) pairs from `pragmas` + `fileInvariants`. */
+  readonly entries: readonly PragmaSsotEntry[];
+  /**
+   * Lowercased pragma-name → expected-value lookup. Keys are lower-cased
+   * because SQLite returns pragma names lower-cased on output (and
+   * stores them case-insensitively).
+   */
+  readonly expectedByName: ReadonlyMap<string, string>;
+  /**
+   * Ordered list of pragma names the drift walker queries — mirrors
+   * `specs/sqlite-pragmas.json#driftPragmas`. Every entry MUST resolve
+   * via {@link expectedByName} or the walker throws at load time
+   * (caught and surfaced as an empty drift array — a misconfigured SSoT
+   * should not break the substrate survey).
+   */
+  readonly driftPragmas: readonly string[];
+}
+
+/**
+ * Embedded byte-equivalent mirror of `specs/sqlite-pragmas.json`.
+ * Keep in sync with that file. The pragma-ssot-test asserts equivalence
+ * against the on-disk JSON when the repo layout is present.
+ */
+const EMBEDDED_SSOT = {
+  // Same shape as sqlite-pragmas.ts SPEC, plus `fileInvariants` and
+  // `driftPragmas`. Only the fields we consume are typed.
+  pragmas: [
+    ['busy_timeout', '5000'],
+    ['journal_mode', 'WAL'],
+    ['synchronous', 'NORMAL'],
+    ['foreign_keys', 'ON'],
+    ['cache_size', '-64000'],
+    ['mmap_size', '268435456'],
+    ['temp_store', 'MEMORY'],
+    ['wal_autocheckpoint', '1000'],
+  ] as ReadonlyArray<readonly [string, string]>,
+  fileInvariants: [
+    ['page_size', '4096'],
+    ['application_id', '0'],
+  ] as ReadonlyArray<readonly [string, string]>,
+  driftPragmas: [
+    'journal_mode',
+    'busy_timeout',
+    'foreign_keys',
+    'synchronous',
+    'page_size',
+    'application_id',
+  ] as readonly string[],
+} as const;
+
+/**
+ * Build the pragma SSoT used by the drift walker.
+ *
+ * @remarks
+ * Implementation intentionally returns the embedded literal — no
+ * `readFileSync`. The on-disk JSON spec is the canonical source for
+ * human review and the Rust applicator, but at runtime the TS side
+ * relies on the embedded mirror for npm-install safety (matches the
+ * T9157 pattern). The test suite asserts byte-equivalence.
+ *
+ * @returns A fully-populated {@link PragmaSsot}.
+ *
+ * @task T10310
+ */
+export function loadPragmaSsot(): PragmaSsot {
+  const entries: PragmaSsotEntry[] = [...EMBEDDED_SSOT.pragmas, ...EMBEDDED_SSOT.fileInvariants];
+  const expectedByName = new Map<string, string>();
+  for (const [name, value] of entries) {
+    expectedByName.set(name.toLowerCase(), value);
+  }
+  return {
+    entries,
+    expectedByName,
+    driftPragmas: EMBEDDED_SSOT.driftPragmas,
+  };
+}
+
+/**
+ * Canonical pragma name-synonyms that need a post-query normalisation
+ * step before equality is asserted.
+ *
+ * SQLite returns several pragma values as integer codes rather than the
+ * symbolic name that the SSoT records:
+ *
+ *   - `synchronous`: `0`=OFF, `1`=NORMAL, `2`=FULL, `3`=EXTRA.
+ *   - `foreign_keys`: `0`=OFF, `1`=ON.
+ *
+ * The walker resolves the actual integer code to the canonical symbolic
+ * name before comparing against the SSoT so the equality check is
+ * meaningful.
+ *
+ * @task T10310
+ */
+export const PRAGMA_VALUE_NORMALISERS: ReadonlyMap<string, ReadonlyMap<string, string>> = new Map([
+  [
+    'synchronous',
+    new Map<string, string>([
+      ['0', 'OFF'],
+      ['1', 'NORMAL'],
+      ['2', 'FULL'],
+      ['3', 'EXTRA'],
+    ]),
+  ],
+  [
+    'foreign_keys',
+    new Map<string, string>([
+      ['0', 'OFF'],
+      ['1', 'ON'],
+    ]),
+  ],
+]);
+
+/**
+ * Normalise a raw pragma value to its canonical form for comparison.
+ *
+ * @remarks
+ * - For pragmas with integer-coded values (see
+ *   {@link PRAGMA_VALUE_NORMALISERS}), resolves the integer to its
+ *   symbolic name (`'1'` → `'ON'`).
+ * - Otherwise returns the input upper-cased to make the comparison
+ *   case-insensitive (`'wal'` → `'WAL'`, `'memory'` → `'MEMORY'`).
+ *
+ * @param pragmaName - Pragma name (case-insensitive).
+ * @param rawValue - Raw value as returned by `PRAGMA <name>`.
+ * @returns Normalised value suitable for string-equality comparison
+ *   against the SSoT.
+ *
+ * @task T10310
+ */
+export function normalisePragmaValue(pragmaName: string, rawValue: string): string {
+  const normaliser = PRAGMA_VALUE_NORMALISERS.get(pragmaName.toLowerCase());
+  if (normaliser !== undefined) {
+    const resolved = normaliser.get(rawValue);
+    if (resolved !== undefined) {
+      return resolved.toUpperCase();
+    }
+  }
+  return rawValue.toUpperCase();
+}

--- a/specs/sqlite-pragmas.json
+++ b/specs/sqlite-pragmas.json
@@ -15,5 +15,19 @@
     ["mmap_size", "268435456"],
     ["temp_store", "MEMORY"],
     ["wal_autocheckpoint", "1000"]
+  ],
+  "$fileInvariantsNote": "T10310 — additional file-persistent invariants checked by `cleo doctor db-substrate` against every DB in DB_INVENTORY. NOT consumed by the Rust applicator (build.rs reads `pragmas` only). Format: [pragma_name, expected_value_as_string]. Values are compared case-insensitively. Expected page_size of 4096 matches the SQLite default; application_id 0 means no app-id tag (CLEO does not stamp one today).",
+  "fileInvariants": [
+    ["page_size", "4096"],
+    ["application_id", "0"]
+  ],
+  "$driftPragmasNote": "T10310 — canonical PRAGMA queries that `cleo doctor db-substrate` walks for every DB in DB_INVENTORY. Drift is reported when the actual value (on a raw read-only snapshot — no pragma application) differs from the expected value declared in `pragmas` or `fileInvariants`.",
+  "driftPragmas": [
+    "journal_mode",
+    "busy_timeout",
+    "foreign_keys",
+    "synchronous",
+    "page_size",
+    "application_id"
   ]
 }


### PR DESCRIPTION
## Summary

Extends `cleo doctor db-substrate` (T10307) with a per-DB pragma walker
that detects drift against the canonical `specs/sqlite-pragmas.json` SSoT.

Saga: **T10281 SG-BRAIN-DB-RESILIENCE**, Epic: **T10283 E2-DB-INTEGRITY**.

## What's new

For every existing DB that passes `PRAGMA integrity_check`, the survey now
walks the six pragmas declared in `specs/sqlite-pragmas.json#driftPragmas`
on a raw read-only snapshot (no pragma application) and reports drift in the
new `dbs[role].pragmaDrift: PragmaDriftItem[]` field:

- `journal_mode` (expected `WAL`)
- `busy_timeout` (expected `5000`)
- `foreign_keys` (expected `ON`)
- `synchronous`  (expected `NORMAL`)
- `page_size`       (expected `4096`; declared in `fileInvariants`)
- `application_id`  (expected `0`; declared in `fileInvariants`)

- `pragmaDrift` is **`null`** when the DB does not exist or failed
  `integrity_check` (a corrupt journal is not reliably queryable).
- Empty array `[]` means every queried pragma matches the SSoT exactly.

Integer-coded pragmas (`synchronous: 0|1|2|3`, `foreign_keys: 0|1`) are
normalised to symbolic names before equality so SQLite's wire format does
not yield false-positive drift reports.

Each drift item is additionally surfaced via `meta.warnings` under
`W_DB_SUBSTRATE_PRAGMA_DRIFT` so operators see drift in the standard
warning stream regardless of which output channel they consume.

## New SSoT exports (`@cleocode/core/doctor`)

- `loadPragmaSsot()` — embedded mirror of `specs/sqlite-pragmas.json`. Guarded
  by a byte-equivalence test (`pragma-ssot.test.ts`) so the TypeScript
  literal cannot drift from the JSON SSoT silently.
- `normalisePragmaValue(pragma, raw)` — case-insensitive normaliser with
  integer→symbolic resolution for `synchronous` and `foreign_keys`.
- `walkPragmaDrift(snapshotDb)` — per-DB drift walker, consumed by
  `inspectDbFile`.

## Contracts (`@cleocode/contracts`)

- New: `PragmaDriftItem { pragma, expected, actual }`
- Extended: `DbSubstrateEntry.pragmaDrift: PragmaDriftItem[] | null`

## Test plan

- [x] `pnpm exec vitest run packages/core/src/doctor` — 4 files, 37 tests pass
- [x] `pnpm exec vitest run packages/core/src/store/__tests__/sqlite-pragmas` — sibling SSoT test still green
- [x] `pnpm biome check --write .` clean
- [x] `pnpm --filter @cleocode/contracts run build` clean
- [x] `pnpm --filter @cleocode/core run build` clean
- [x] `pnpm --filter @cleocode/cleo run build` clean
- [x] All DB opens flow through `openCleoDbSnapshot` (canonical opener, db-open-guard allowlist) — no raw `DatabaseSync` in src
- [x] No `any`/`unknown`/`as unknown as` chains

Closes T10310.