### PR TITLE
docs(T10370): SKILL.md align with WriterRegistry (E2.5)

### DIFF
--- a/.changeset/t10370-e2-skill-align.md
+++ b/.changeset/t10370-e2-skill-align.md
@@ -1,0 +1,6 @@
+---
+id: t10370-e2-skill-align
+tasks: [T10370]
+kind: docs
+summary: T10370 E2.5: ct-documentor + ct-docs-write reference WriterRegistry SSoT
+---

--- a/.cleo/canon.yml
+++ b/.cleo/canon.yml
@@ -4,6 +4,15 @@
 # `cleo check canon docs` to detect raw-markdown writes that should have
 # routed through SSoT (via `cleo docs add`) instead.
 #
+# Related SSoT — verb-to-DocKind mapping:
+#   packages/core/src/docs/writer-registry.ts (T10366 · Saga T10288 · Epic T10290)
+#
+# canon.yml answers "WHERE does this DocKind live + which raw paths are CI-gated?".
+# writer-registry.ts answers "WHICH CLI verb (and core function) writes this DocKind?".
+# Together they cover the full routing contract — one for storage, one for entry point.
+# Parity is enforced by `writer-registry.test.ts`: every `ssot-first` descriptor in the
+# registry MUST match a kind here whose `canonicalHome: 'ssot-first'`, and vice versa.
+#
 # Schema is enforced at runtime — see .cleo/canon.schema.json.
 #
 # Routing taxonomy (one of):

--- a/packages/skills/skills.json
+++ b/packages/skills/skills.json
@@ -137,7 +137,7 @@
     {
       "name": "ct-documentor",
       "description": "Documentation creation, editing, and review with CLEO style guide compliance. Coordinates specialized skills for lookup, writing, and review.",
-      "version": "3.2.0",
+      "version": "3.4.0",
       "path": "skills/ct-documentor/SKILL.md",
       "references": [],
       "core": false,
@@ -169,7 +169,7 @@
     {
       "name": "ct-docs-write",
       "description": "Documentation writing with CLEO's conversational, clear, user-focused style. Use when creating, editing, or improving documentation files.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "path": "skills/ct-docs-write/SKILL.md",
       "references": [],
       "core": false,

--- a/packages/skills/skills/ct-docs-write/SKILL.md
+++ b/packages/skills/skills/ct-docs-write/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ct-docs-write
 description: This skill should be used when creating, editing, or reviewing documentation files (markdown, MDX, README, guides). Use when the user asks to "write docs", "create documentation", "edit the README", "improve doc clarity", "make docs more readable", "follow the style guide", or "write user-facing content". Applies CLEO's conversational, clear, and user-focused writing style.
-version: 1.0.0
+version: 1.1.0
 tier: 3
 core: false
 category: composition
@@ -147,6 +147,32 @@ Match complexity to audience. Mismatch is the biggest style failure.
 
 Declare the audience in frontmatter — `audience: end-user | agent | maintainer`
 — so reviewers can apply the right rubric.
+
+## Verb Selection — pick the right writer
+
+`packages/core/src/docs/writer-registry.ts` is the SSoT for "which CLI verb
+writes which DocKind". Every `BuiltinDocKind` maps to EXACTLY ONE writer —
+the registry rejects multi-writer regressions at build time (T10366 ·
+Saga T10288 / Epic T10290). The decision tree:
+
+```text
+if kind === 'changeset'  → cleo changeset add --slug <handle> --kind <bump> --summary "..."
+elif kind === 'llm-readme'    → tooling-composed (system-managed; do not author by hand)
+elif kind === 'release-note'  → cleo release reconcile (system-managed)
+else                          → cleo docs add <ownerId> <path> --type <kind> --slug <handle>
+```
+
+`cleo changeset add` is the dedicated dual-write verb for `changeset` —
+the kind's `canonicalHome` is `ssot-first` in `.cleo/canon.yml`, so the
+`.changeset/*.md` file IS part of the contract (it's git-tracked). For
+every other human-authored kind (`adr`, `spec`, `research`, `handoff`,
+`note`, `plan`, `rcasd`) the canonical verb is `cleo docs add --type <kind>`.
+
+**Migration rule for examples in this guide:** any example that
+hand-writes `.changeset/*.md`, `.cleo/adrs/*.md`, `.cleo/research/*.md`,
+or `.cleo/agent-outputs/*.md` is OBSOLETE. Update it to use the
+registered verb instead. The CI gate `cleo check canon docs` will fail
+the PR otherwise (T9796).
 
 ## Through SDK (preferred)
 

--- a/packages/skills/skills/ct-documentor/SKILL.md
+++ b/packages/skills/skills/ct-documentor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ct-documentor
 description: Documentation coordinator with CLEO style guide compliance. Routes every canonical-doc write (spec, adr, research, handoff, note, llm-readme) through the docs SSoT via `cleo docs add` / `cleo docs publish` / `cleo docs fetch` — never raw filesystem writes. Coordinates ct-docs-lookup, ct-docs-write, ct-docs-review, ct-spec-writer, and ct-adr-recorder. Use when creating or updating documentation files, consolidating scattered documentation, or validating documentation against style standards. Triggers on documentation tasks, doc update requests, or style guide compliance checks.
-version: 3.3.0
+version: 3.4.0
 tier: 3
 core: false
 category: specialist
@@ -165,6 +165,17 @@ etc.) — this is what makes cross-kind collisions structurally near-impossible.
 ONE writer descriptor — multi-writer regressions trip the registry at build
 time (the slug-collision class root-cause from T10294).
 
+**Decision tree — pick the verb without guessing:**
+
+```text
+if kind === 'changeset'          → cleo changeset add
+elif kind === 'llm-readme'       → tooling-composed (system-managed)
+elif kind === 'release-note'     → cleo release reconcile (system-managed)
+else                              → cleo docs add --type <kind>
+```
+
+In code:
+
 ```ts
 import { WriterRegistry } from '@cleocode/core/internal';
 
@@ -172,6 +183,9 @@ const desc = WriterRegistry.for('changeset');
 // → { kind: 'changeset', verb: 'changeset add', dispatchOp: 'changeset.add',
 //     coreFn: 'writeChangesetEntry', mode: 'ssot-first',
 //     sourcePath: 'packages/core/src/changesets/writer.ts' }
+
+// Resolve the verb programmatically — no string-matching in caller code.
+const verb = WriterRegistry.for(kind).verb; // 'docs add' | 'changeset add' | 'system-managed'
 ```
 
 Descriptor modes mirror `.cleo/canon.yml`'s `canonicalHome`:
@@ -181,6 +195,23 @@ Descriptor modes mirror `.cleo/canon.yml`'s `canonicalHome`:
 
 Test parity: every `ssot-first` descriptor MUST match a kind whose
 `canonicalHome: 'ssot-first'` in `.cleo/canon.yml`, and vice versa.
+
+**Legitimate bypass — `WriterRegistry.systemManaged` (T10368):** writers
+for `system-managed` kinds (e.g. `generateDocsLlmsTxt`, `composeReleaseNotes`)
+do not go through `cleo docs add` because the bytes are tooling-composed
+rather than human-authored. The registry still names the producer via
+`coreFn`, so drift tooling can follow the breadcrumb from kind →
+core function without an exception list. Do NOT invent NEW `system-managed`
+entries to dodge the docs-add path — every kind authored by a human MUST
+flow through `cleo docs add` or `cleo changeset add`.
+
+**Cross-link to the allocator contract:** the registry calls
+{@link reserveSlug} BEFORE the writer delegates. A taken slug returns
+`{ ok: false, code: 'E_SLUG_RESERVED', details: { suggestions } }`
+with the SAME shape both `cleo docs add` and `cleo changeset add` surface
+to callers (closing the T10294 envelope-drift bug). See the
+"Slug allocation goes through ONE chokepoint" section above for the
+allocator contract and the legacy `E_SLUG_TAKEN` alias.
 
 T10366 establishes the registry contract; T10367 (docs add) and T10368
 (changeset add) wire the actual writer delegation. Until those land,


### PR DESCRIPTION
## Summary
- ct-documentor + ct-docs-write reference writer-registry.ts as SSoT
- canon.yml header cross-links the registry
- Tier-0 strict drift policy honoured (ct-documentor is tier-0)

## Saga
- Saga: T10288 SG-DOCS-INTEGRITY (Wave 2.B)
- Epic: T10290 E2-DOCS-DOCKIND-WRITER-DEDUP
- Builds on T10366 (E2.1 WriterRegistry)