### PR TITLE
T10322: openCleoDb project_id gate + T10397 brain misroute fix (Saga T10281 / E4)

### DIFF
--- a/.changeset/T10322.md
+++ b/.changeset/T10322.md
@@ -1,0 +1,58 @@
+---
+id: T10322
+tasks: [T10322, T10397]
+kind: fix
+summary: "openCleoDb brain misroute (T10397) + project_id consistency gate (Saga T10281 / Epic T10285)"
+---
+
+Two correctness fixes to the `openCleoDb` chokepoint
+(`packages/core/src/store/open-cleo-db.ts`).
+
+## T10397 — brain role misroute (P0 data-corruption hotfix)
+
+Prior to this change, `ROLE_OPENERS.brain` was set to `getTasksDb`, so every
+consumer that called `openCleoDb('brain', cwd)` was handed a `tasks.db`
+handle. Brain-schema writes either silently no-op'd against tasks.db or
+surfaced as schema errors at `prepare()`-time. The map now routes `brain`
+to a dedicated `openBrainDbHandle` that delegates to `getBrainDb` from
+`memory-sqlite.ts`.
+
+A new regression test
+(`openCleoDb(brain) exposes brain.db schema (brain_observations table) — T10397 regression`)
+asserts the returned handle exposes `brain_observations` and does NOT
+expose `tasks` — pinning the routing so the misroute cannot regress.
+
+The `sessions` role remains aliased to `getTasksDb` intentionally — there
+is no separate `sessions.db` file; the `sessions` table lives inside
+`tasks.db`.
+
+## T10322 — project_id consistency gate
+
+Adds `validateProjectIdConsistency(role, db, cwd)` and wires it into the
+`openCleoDb` chokepoint. The gate fires on every open of a
+project-id-tracking DB (currently just `nexus`) and cross-checks:
+
+- `.cleo/project-info.json::projectId` for the caller's project root, AND
+- `nexus.db.project_registry.project_id WHERE project_path = projectRoot`
+
+Mismatch throws `CleoError(CONFIG_ERROR, "E_PROJECT_ID_DRIFT", ...)` with
+a diagnostic that names both sides and suggests a reconciliation path.
+
+The gate intentionally no-ops in every legitimate non-drift case:
+
+- Role does not track `project_id` (`tasks`, `brain`, `conduit`,
+  `sessions`, `signaldock`, `skills`). Project-tier DBs already inherit
+  project identity from their parent `.cleo/` directory; the path layer
+  (T9803) and worktree-isolation guard (T9806) prevent cross-project
+  misroutes for those roles.
+- `.cleo/project-info.json` is missing (pre-init / fresh clone).
+- `projectId` field is empty (pre-T5333 install).
+- `project_registry` table does not yet exist (pre-bootstrap nexus.db).
+- No registry row matches the caller's project root (project not yet
+  registered with nexus).
+
+Eight new tests under
+`packages/core/src/store/__tests__/open-cleo-db.test.ts` exercise the
+gate's positive path, every no-op branch, and the mismatch diagnostic.
+
+Closes T10322 T10397. Saga: T10281.

--- a/packages/core/src/store/__tests__/open-cleo-db.test.ts
+++ b/packages/core/src/store/__tests__/open-cleo-db.test.ts
@@ -2,15 +2,17 @@
  * Smoke tests for openCleoDb — canonical database chokepoint.
  *
  * @task T9050
+ * @task T10322 (project_id consistency gate + brain misroute regression)
+ * @task T10397 (brain role MUST resolve to brain.db, not tasks.db)
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { openCleoDb, openCleoDbSnapshot } from '../open-cleo-db.js';
+import { openCleoDb, openCleoDbSnapshot, validateProjectIdConsistency } from '../open-cleo-db.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -53,11 +55,49 @@ describe('openCleoDb', () => {
   });
 
   it('opens brain.db and returns a DBHandle with correct role', async () => {
+    // Reset the brain singleton — earlier tests in the same vitest worker
+    // may have opened brain.db against a different cwd.
+    const { resetBrainDbState } = await import('../memory-sqlite.js');
+    resetBrainDbState();
+
     const handle = await openCleoDb('brain', tempDir);
-    expect(handle.role).toBe('brain');
-    expect(handle.db).toBeDefined();
-    expect(handle.db.prepare('SELECT 1').get()).toEqual({ '1': 1 });
-    handle.close();
+    try {
+      expect(handle.role).toBe('brain');
+      expect(handle.db).toBeDefined();
+      expect(handle.db.prepare('SELECT 1').get()).toEqual({ '1': 1 });
+    } finally {
+      handle.close();
+      resetBrainDbState();
+    }
+  });
+
+  // T10397 regression: prior to this fix, ROLE_OPENERS.brain pointed at
+  // getTasksDb, so callers got tasks.db schema and every brain-table
+  // write silently corrupted data. This test asserts the handle exposes
+  // brain.db's canonical schema (brain_observations) and NOT tasks.db's
+  // canonical schema (tasks).
+  it('openCleoDb(brain) exposes brain.db schema (brain_observations table) — T10397 regression', async () => {
+    const { resetBrainDbState } = await import('../memory-sqlite.js');
+    resetBrainDbState();
+
+    const handle = await openCleoDb('brain', tempDir);
+    try {
+      // Brain schema MUST contain brain_observations after migrations run.
+      const brainRow = handle.db
+        .prepare('SELECT name FROM sqlite_schema WHERE type = ? AND name = ?')
+        .get('table', 'brain_observations') as { name?: string } | undefined;
+      expect(brainRow?.name).toBe('brain_observations');
+
+      // Tasks schema MUST NOT be present on brain.db — if this passes,
+      // it means the handle is still pointed at tasks.db (the T10397 bug).
+      const tasksRow = handle.db
+        .prepare('SELECT name FROM sqlite_schema WHERE type = ? AND name = ?')
+        .get('table', 'tasks') as { name?: string } | undefined;
+      expect(tasksRow?.name).toBeUndefined();
+    } finally {
+      handle.close();
+      resetBrainDbState();
+    }
   });
 
   it('opens sessions.db (alias to tasks.db) and returns a DBHandle with correct role', async () => {
@@ -173,6 +213,157 @@ describe('openCleoDbSnapshot', () => {
       }).toThrow();
     } finally {
       snap.close();
+    }
+  });
+});
+
+// ============================================================================
+// T10322 — project_id consistency gate
+// ============================================================================
+
+describe('validateProjectIdConsistency (T10322)', () => {
+  let tempDir: string;
+
+  // Use createRequire to materialise an in-process DatabaseSync with the
+  // bits of nexus.db's project_registry schema the gate cares about.
+  function makeFakeNexusDb(rows: Array<{ id: string; path: string }>): DatabaseSync {
+    const _require = createRequire(import.meta.url);
+    const { DatabaseSync: DatabaseSyncCtor } = _require('node:sqlite') as {
+      DatabaseSync: new (...args: ConstructorParameters<typeof DatabaseSync>) => DatabaseSync;
+    };
+    const db = new DatabaseSyncCtor(':memory:');
+    db.exec(
+      `CREATE TABLE project_registry (
+        project_id   TEXT PRIMARY KEY,
+        project_path TEXT NOT NULL UNIQUE
+      );`,
+    );
+    const ins = db.prepare('INSERT INTO project_registry (project_id, project_path) VALUES (?, ?)');
+    for (const row of rows) {
+      ins.run(row.id, row.path);
+    }
+    return db;
+  }
+
+  function seedProjectInfo(projectRoot: string, projectId: string): void {
+    const cleoDir = join(projectRoot, '.cleo');
+    mkdirSync(cleoDir, { recursive: true });
+    writeFileSync(
+      join(cleoDir, 'project-info.json'),
+      JSON.stringify({
+        projectHash: 'abcdef012345',
+        projectId,
+        projectRoot,
+        lastUpdated: new Date().toISOString(),
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it('no-ops when role does not track project_id (tasks, brain, conduit, sessions)', () => {
+    seedProjectInfo(tempDir, 'pid-canonical');
+    const db = makeFakeNexusDb([{ id: 'pid-drift', path: tempDir }]);
+    try {
+      // Even though the registry would drift, non-tracking roles skip the gate.
+      expect(() => validateProjectIdConsistency('tasks', db, tempDir)).not.toThrow();
+      expect(() => validateProjectIdConsistency('brain', db, tempDir)).not.toThrow();
+      expect(() => validateProjectIdConsistency('conduit', db, tempDir)).not.toThrow();
+      expect(() => validateProjectIdConsistency('sessions', db, tempDir)).not.toThrow();
+      expect(() => validateProjectIdConsistency('signaldock', db, tempDir)).not.toThrow();
+      expect(() => validateProjectIdConsistency('skills', db, tempDir)).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('no-ops when project-info.json is missing (fresh clone, pre-init)', () => {
+    // No project-info.json seeded.
+    const db = makeFakeNexusDb([{ id: 'pid-anything', path: tempDir }]);
+    try {
+      expect(() => validateProjectIdConsistency('nexus', db, tempDir)).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('no-ops when projectId is empty (pre-T5333 install)', () => {
+    seedProjectInfo(tempDir, '');
+    const db = makeFakeNexusDb([{ id: 'pid-anything', path: tempDir }]);
+    try {
+      expect(() => validateProjectIdConsistency('nexus', db, tempDir)).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('no-ops when project_registry table does not exist (pre-bootstrap nexus.db)', () => {
+    seedProjectInfo(tempDir, 'pid-canonical');
+    const _require = createRequire(import.meta.url);
+    const { DatabaseSync: DatabaseSyncCtor } = _require('node:sqlite') as {
+      DatabaseSync: new (...args: ConstructorParameters<typeof DatabaseSync>) => DatabaseSync;
+    };
+    const db = new DatabaseSyncCtor(':memory:');
+    try {
+      expect(() => validateProjectIdConsistency('nexus', db, tempDir)).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('no-ops when project not yet registered with nexus (no row for this path)', () => {
+    seedProjectInfo(tempDir, 'pid-canonical');
+    const db = makeFakeNexusDb([{ id: 'pid-someone-else', path: '/some/other/project' }]);
+    try {
+      expect(() => validateProjectIdConsistency('nexus', db, tempDir)).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('succeeds when projectId matches (the happy path)', () => {
+    seedProjectInfo(tempDir, 'pid-canonical');
+    const db = makeFakeNexusDb([{ id: 'pid-canonical', path: tempDir }]);
+    try {
+      expect(() => validateProjectIdConsistency('nexus', db, tempDir)).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('throws E_PROJECT_ID_DRIFT when registry project_id mismatches project-info.json', () => {
+    seedProjectInfo(tempDir, 'pid-canonical');
+    const db = makeFakeNexusDb([{ id: 'pid-drift', path: tempDir }]);
+    try {
+      expect(() => validateProjectIdConsistency('nexus', db, tempDir)).toThrow(
+        /E_PROJECT_ID_DRIFT/,
+      );
+    } finally {
+      db.close();
+    }
+  });
+
+  it('drift error message names both sides of the mismatch', () => {
+    seedProjectInfo(tempDir, 'canonical-12');
+    const db = makeFakeNexusDb([{ id: 'drift-99', path: tempDir }]);
+    try {
+      let caught: Error | null = null;
+      try {
+        validateProjectIdConsistency('nexus', db, tempDir);
+      } catch (err: unknown) {
+        caught = err instanceof Error ? err : new Error(String(err));
+      }
+      expect(caught).not.toBeNull();
+      expect(caught?.message).toContain('canonical-12');
+      expect(caught?.message).toContain('drift-99');
+    } finally {
+      db.close();
     }
   });
 });

--- a/packages/core/src/store/open-cleo-db.ts
+++ b/packages/core/src/store/open-cleo-db.ts
@@ -40,8 +40,12 @@
 
 import { createRequire } from 'node:module';
 import type { DatabaseSync } from 'node:sqlite';
+import { ExitCode } from '@cleocode/contracts';
+import { CleoError } from '../errors.js';
 import { resolveOrCwd } from '../paths.js';
+import { getProjectInfoSync } from '../project-info.js';
 import { getConduitNativeDb } from './conduit-sqlite.js';
+import { getBrainDb } from './memory-sqlite.js';
 import { getNexusDb } from './nexus-sqlite.js';
 import { ensureGlobalSignaldockDb, getGlobalSignaldockNativeDb } from './signaldock-sqlite.js';
 import { openSkillsDb } from './skills-db.js';
@@ -106,9 +110,28 @@ async function openSkillsDbHandle(_cwd?: string): Promise<unknown> {
   return openSkillsDb();
 }
 
+/**
+ * Open brain.db via its canonical lifecycle module (memory-sqlite.ts).
+ *
+ * T10397 fix: prior to this task, the `brain` role was silently aliased to
+ * `getTasksDb`, so every consumer that called `openCleoDb('brain')` was
+ * handed a `tasks.db` handle. Writes to brain tables either no-op'd against
+ * tasks.db or surfaced as schema errors at prepare()-time.
+ *
+ * @task T10397
+ */
+async function openBrainDbHandle(cwd?: string): Promise<unknown> {
+  return getBrainDb(cwd);
+}
+
 const ROLE_OPENERS: Record<ImplementedCleoDbRole, DbOpener> = {
   tasks: getTasksDb as unknown as DbOpener,
-  brain: getTasksDb as unknown as DbOpener,
+  // T10397: brain role MUST resolve to brain.db, NOT tasks.db. Prior to
+  // this fix the entry was `getTasksDb`, silently corrupting every
+  // brain-table write that flowed through the chokepoint.
+  brain: openBrainDbHandle,
+  // sessions table lives inside tasks.db — there is no separate sessions.db
+  // file. The alias is intentional.
   sessions: getTasksDb as unknown as DbOpener,
   signaldock: openSignaldockDb,
   conduit: openConduitDb,
@@ -125,6 +148,114 @@ function unwrapNativeSqliteDb(db: unknown): unknown {
 
 function isDatabaseSync(db: unknown): db is DatabaseSync {
   return Boolean(db && typeof db === 'object' && 'exec' in db && 'prepare' in db);
+}
+
+/**
+ * Roles whose DBs track per-project `project_id` and therefore need to be
+ * cross-checked against `.cleo/project-info.json` on every open.
+ *
+ * Today this is just `nexus` — its `project_registry` table records one row
+ * per known project with `(project_id PRIMARY KEY, project_path UNIQUE)`.
+ * The drift check verifies that a row whose `project_path` matches the
+ * caller's project root has the same `project_id` as the caller's
+ * `.cleo/project-info.json`. Mismatch → `E_PROJECT_ID_DRIFT`.
+ *
+ * Project-tier DBs (`tasks`, `brain`, `conduit`, `sessions`) do NOT carry a
+ * `project_id` column — they live under per-project `.cleo/` and inherit
+ * project identity from their parent directory. The path-layer (T9803) and
+ * worktree-isolation guard (T9806) already prevent cross-project misroutes
+ * for those roles. Global-tier DBs (`signaldock`, `skills`) carry no
+ * project identity at all.
+ *
+ * @task T10322
+ * @saga T10281
+ * @adr ADR-068
+ */
+const PROJECT_ID_TRACKING_ROLES: ReadonlySet<CleoDbRole> = new Set<CleoDbRole>(['nexus']);
+
+interface ProjectRegistryRow {
+  project_id: string;
+  project_path: string;
+}
+
+/**
+ * Cross-check `.cleo/project-info.json::projectId` against the project_id
+ * recorded for this project's path inside the DB being opened.
+ *
+ * No-ops (returns silently) for ALL non-drift cases:
+ * - The role does not track `project_id` (see {@link PROJECT_ID_TRACKING_ROLES}).
+ * - `.cleo/project-info.json` is missing or unparseable (pre-init / fresh clone).
+ * - The `projectId` field is empty (pre-T5333 install).
+ * - The DB's project-tracking table does not yet exist (pre-bootstrap).
+ * - No row in the tracking table matches the caller's project path
+ *   (project not yet registered with nexus).
+ *
+ * Throws `CleoError(CONFIG_ERROR, "E_PROJECT_ID_DRIFT", ...)` IFF every
+ * condition is satisfied:
+ * 1. The role tracks project_id, AND
+ * 2. `.cleo/project-info.json` reports a non-empty `projectId`, AND
+ * 3. The DB has a project-registry row for the caller's `projectRoot`, AND
+ * 4. That row's `project_id` differs from the project-info projectId.
+ *
+ * Read-only: never writes to the DB.
+ *
+ * @task T10322
+ * @saga T10281 (SG-BRAIN-DB-RESILIENCE)
+ * @epic T10285 (E4-DB-CROSS-LINKS)
+ * @adr ADR-068
+ */
+export function validateProjectIdConsistency(role: CleoDbRole, db: unknown, cwd?: string): void {
+  if (!PROJECT_ID_TRACKING_ROLES.has(role)) {
+    return;
+  }
+  if (!isDatabaseSync(db)) {
+    // Cannot probe the schema without a native handle; let the caller
+    // surface the underlying type error rather than masking it here.
+    return;
+  }
+
+  const projectRoot = resolveOrCwd(cwd);
+  const projectInfo = getProjectInfoSync(projectRoot);
+  if (!projectInfo || projectInfo.projectId.length === 0) {
+    // Pre-init or pre-T5333 install — nothing to drift against.
+    return;
+  }
+
+  let row: ProjectRegistryRow | undefined;
+  try {
+    const stmt = db.prepare(
+      'SELECT project_id, project_path FROM project_registry WHERE project_path = ? LIMIT 1',
+    );
+    row = stmt.get(projectInfo.projectRoot) as ProjectRegistryRow | undefined;
+  } catch {
+    // `project_registry` may not exist yet (fresh nexus.db before
+    // migrations have run). Bootstrap is not drift.
+    return;
+  }
+  if (!row || typeof row.project_id !== 'string' || row.project_id.length === 0) {
+    // Project not yet registered with the nexus — that's a normal first-open
+    // state, not drift.
+    return;
+  }
+
+  if (row.project_id !== projectInfo.projectId) {
+    throw new CleoError(
+      ExitCode.CONFIG_ERROR,
+      `E_PROJECT_ID_DRIFT: ${role} DB reports project_id=${row.project_id} for ` +
+        `path=${projectInfo.projectRoot} but .cleo/project-info.json reports ` +
+        `projectId=${projectInfo.projectId}. The DB and project-info.json are ` +
+        `not pointing at the same project — a backup/restore or directory move ` +
+        `has left them inconsistent.`,
+      {
+        fix:
+          `Inspect both values: \`cat ${projectInfo.projectRoot}/.cleo/project-info.json\` ` +
+          `and the corresponding row in nexus.db's project_registry. Reconcile by ` +
+          `either (a) updating project-info.json to the canonical ID, or (b) ` +
+          `re-registering this project with \`cleo init --reset\` if the registry ` +
+          `entry is stale.`,
+      },
+    );
+  }
 }
 
 /**
@@ -159,6 +290,12 @@ export async function openCleoDb(role: CleoDbRole, cwd?: string): Promise<CleoDb
   if (isDatabaseSync(db)) {
     applyPerfPragmas(db);
   }
+
+  // T10322: runtime gate — every project-id-tracking DB open is
+  // cross-checked against .cleo/project-info.json::projectId. Mismatch
+  // throws E_PROJECT_ID_DRIFT. No-ops for project-tier and global-tier
+  // roles that don't carry a project_id column.
+  validateProjectIdConsistency(role, db, cwd);
 
   return {
     db,

--- a/packages/core/src/store/sqlite-backup.ts
+++ b/packages/core/src/store/sqlite-backup.ts
@@ -191,10 +191,11 @@ interface SnapshotTarget {
  *
  * `getBrainDb` is the canonical chokepoint for brain.db opens
  * (`packages/core/src/store/memory-sqlite.ts`, allowlisted under
- * `packages/core/src/store/**`). We call it directly rather than via
- * `openCleoDb('brain', cwd)` because the latter is currently misrouted to
- * `getTasksDb` — a separate routing bug tracked outside T10316. Calling the
- * canonical opener guarantees brain.db is actually opened.
+ * `packages/core/src/store/**`). Historically this was called directly
+ * because `openCleoDb('brain')` was misrouted to `getTasksDb` (T10397) —
+ * that bug is now fixed in `open-cleo-db.ts`, so direct calls here remain
+ * valid but redundant; keeping the direct call avoids re-applying pragmas
+ * and the project_id consistency gate on the snapshot path.
  */
 async function openBrainDbForSnapshot(cwd?: string): Promise<SnapshotDbHandle | null> {
   await getBrainDb(cwd);


### PR DESCRIPTION
## Summary

Two correctness fixes to the `openCleoDb` chokepoint (`packages/core/src/store/open-cleo-db.ts`).

### T10397 — brain role misroute (P0 data-corruption hotfix)

`ROLE_OPENERS.brain` was silently aliased to `getTasksDb`, so every consumer that called `openCleoDb('brain', cwd)` was handed a `tasks.db` handle. The map now routes `brain` to a dedicated `openBrainDbHandle` that delegates to `getBrainDb` from `memory-sqlite.ts`. A new regression test asserts the returned handle exposes `brain.db`'s `brain_observations` table and does NOT expose `tasks.db`'s `tasks` table, pinning the routing so the misroute cannot regress.

`sessions` remains aliased to `getTasksDb` intentionally — there is no separate `sessions.db`; the `sessions` table lives inside `tasks.db`.

### T10322 — project_id consistency gate

Adds `validateProjectIdConsistency(role, db, cwd)` and wires it into the `openCleoDb` chokepoint. The gate fires on every open of a project-id-tracking DB (currently just `nexus`) and cross-checks:

- `.cleo/project-info.json::projectId` for the caller's project root, AND
- `nexus.db.project_registry.project_id WHERE project_path = projectRoot`

Mismatch throws `CleoError(CONFIG_ERROR, "E_PROJECT_ID_DRIFT", ...)` with a diagnostic naming both sides and a reconciliation fix-hint.

The gate intentionally no-ops in every legitimate non-drift case (non-tracking role, missing `project-info.json`, empty `projectId`, missing `project_registry` table, unregistered project).

## Test plan

- [x] Gates green: `pnpm biome check .`, `pnpm run build`, `pnpm exec vitest run packages/core/src/store`
- [x] 19/19 tests in `packages/core/src/store/__tests__/open-cleo-db.test.ts` pass (11 new)
- [x] 1192/1192 tests in `packages/core/src/store/` pass
- [x] 987/988 tests in `packages/core/src/memory/` pass (1 pre-existing skip)
- [x] Architectural Boundary Check (T9837): db-open guard 0 violations; no-raw-define-command 138/139 baseline; ssot-exempt no diff violations; contracts-fan-out OK

## Notes

- Spec mentioned `.cleo/project-context.json`, but `projectId` actually lives in `.cleo/project-info.json` (the canonical store written by scaffold + T5333). The gate reads `project-info.json` via `getProjectInfoSync` — the spec wording was lossy.
- Only `nexus.db` tracks `project_id` columns today; `tasks/brain/conduit/sessions` inherit project identity from their parent `.cleo/`. The path layer (T9803) and worktree-isolation guard (T9806) already prevent cross-project misroutes for those roles.

Closes T10322 T10397
Saga: T10281