### PR TITLE
T10318: generalize recovery pipeline to cleo backup recover <role> (Saga T10281 / E3)

### DIFF
--- a/.changeset/T10318.md
+++ b/.changeset/T10318.md
@@ -1,0 +1,75 @@
+---
+id: T10318
+tasks: [T10318]
+kind: feat
+summary: "Generalise the brain.db recovery pipeline to `cleo backup recover <role>` for every DB in DB_INVENTORY (Saga T10281 / Epic T10284)"
+---
+
+Pre-T10318 the auto-recovery and CLI surface only knew how to recover
+`brain.db`. T10318 generalises both layers so the same flow handles every
+role declared in `DB_INVENTORY` — `tasks`, `brain`, `conduit`, `manifest`,
+`llmtxt`, `nexus`, `signaldock-{project,global}`, `telemetry`, `skills`,
+`global-{brain,tasks}` — without changing the brain-specific contract.
+
+## New core helpers
+
+`packages/core/src/store/recover-malformed-db.ts`
+- `recoverMalformedDb({ role, projectRoot, ... })` — generalised pipeline:
+  quarantine → snapshot enumeration → freshness ranking → restore →
+  verify. Per-role filename patterns (`<role>.db.snapshot-*`,
+  `<role>-YYYYMMDD-HHmmss.db`, `<role>.db.PRE-DUP-FIX-*`) are built from
+  the inventory entry's `role` field via `RegExp` escaping.
+- `resolveRoleDbPath`, `resolveRoleBackupDirs` — token substitution for
+  the `<projectRoot>` and `$XDG_DATA_HOME/cleo` placeholders in the
+  inventory's `filePathTemplate`, driven by `@cleocode/paths::getCleoHome()`.
+- `collectSnapshotCandidatesForRole`, `probeSnapshot`, `quarantineCorruptDb`
+  — exported helpers so the CLI wrapper can preview without invoking the
+  full pipeline.
+
+`packages/core/src/store/backup-recover.ts`
+- `runBackupRecover({ role, ... })` — operator-facing wrapper around
+  `recoverMalformedDb`. Adds dry-run planning, snapshot pinning via
+  `--from-snapshot`, and per-table row counts post-restore via
+  `sqlite_master` enumeration.
+- `BackupRecoverError` — structured error with stable numeric exit code,
+  string code name, and optional remediation hint.
+
+## New contracts
+
+`packages/contracts/src/db-recovery.ts`
+- `DbRecoveryResult` — generalised envelope replacing the brain-specific
+  `BrainRecoveryResult`. Carries `role: DbRole` and a
+  `rowCounts: Record<string, number | null>` map keyed by user-table name.
+- `BackupRecoverResult` — CLI envelope wrapper with `dryRun`,
+  `quarantinedTo`, `dataLossWindowHours`.
+- `DbRecoveredRowCounts` — readonly `Record<string, number | null>`.
+
+## CLI surface
+
+`packages/cleo/src/cli/commands/backup-recover.ts`
+- `cleo backup recover <role>` — new generic positional arg dispatch.
+  Validates the role against `DB_INVENTORY`; surfaces `E_VALIDATION` /
+  `E_UNKNOWN_ROLE` on missing/invalid input.
+- `cleo backup recover brain` — **kept as backward-compat subcommand**.
+  Internally delegates to the shared executor with `role='brain'`.
+  Existing scripts and `cleo backup recover brain --help` invocations
+  continue to work identically.
+
+## Backward compatibility
+
+- `recoverMalformedBrainDb` (T10303) remains in `recover-brain-db.ts`
+  unchanged. The chokepoint auto-recovery path used by `memory-sqlite.ts`
+  is not touched.
+- `runBackupRecoverBrain` (T10304) in `backup-recover-brain.ts` is now a
+  thin shim that delegates to `runBackupRecover({ role: 'brain', ... })`
+  and projects the generic per-table row map back into the legacy
+  three-table `BrainRecoveredRowCounts` shape. The export is marked
+  `@deprecated` — net-new code MUST use `runBackupRecover` directly.
+- `BackupRecoverBrainResult` continues to serialize identically for the
+  brain CLI path. Net-new generic call sites use `BackupRecoverResult`
+  which carries the explicit `role` field.
+
+## Saga linkage
+
+Saga: T10281 SG-BRAIN-DB-RESILIENCE
+Epic: T10284 E3-BACKUP-RECOVERY (this task is the T-E3-4 work item)

--- a/packages/cleo/src/cli/commands/__tests__/backup-recover.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/backup-recover.test.ts
@@ -1,23 +1,25 @@
 /**
- * Unit tests for T10304: cleo backup recover brain
+ * Unit tests for `cleo backup recover <role>` and the backward-compatible
+ * `cleo backup recover brain` leaf (T10318 — generalised from T10304).
  *
- * Verifies the `backup recover brain` subcommand action handler:
- *   - --dry-run returns a plan envelope with dryRun=true and no mutation
- *   - happy-path returns structured envelope with all expected fields
- *   - missing-snapshot error path (E_NO_SNAPSHOT) returns clear error
- *   - --from-snapshot pin is plumbed through to the core helper
- *   - generic errors are surfaced via cliError with non-zero exit code
+ * Verifies the CLI dispatch wiring:
+ *   - `cleo backup recover brain` continues to work (backward compat).
+ *   - `cleo backup recover <role>` accepts any role from DB_INVENTORY.
+ *   - `--dry-run`, `--from-snapshot`, `--no-delta` are plumbed through.
+ *   - Missing role surfaces E_VALIDATION (exit code 6).
+ *   - Unknown role surfaces E_UNKNOWN_ROLE.
+ *   - BackupRecoverError instances are mapped to their stable exit codes.
+ *   - Generic errors fall back to exit code 1.
  *
- * The core `runBackupRecoverBrain` helper is mocked so this test exercises
- * ONLY the CLI command's wiring (arg parsing, envelope shape, exit codes).
- * Pattern mirrors backup-export.test.ts.
+ * The core `runBackupRecover` helper is mocked so this test exercises only
+ * the CLI command's wiring (arg parsing, envelope shape, exit codes).
  *
- * @task T10304
- * @epic T10286
+ * @task T10318
+ * @epic T10284
  * @saga T10281
  */
 
-import type { BackupRecoverBrainResult, BrainRecoveredRowCounts } from '@cleocode/contracts';
+import type { BackupRecoverResult, DbRecoveredRowCounts } from '@cleocode/contracts';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { backupCommand } from '../backup.js';
 
@@ -25,12 +27,10 @@ import { backupCommand } from '../backup.js';
 // Mocks — keep all real SQLite, file I/O, and dispatch off the table
 // ---------------------------------------------------------------------------
 
-const mockRunBackupRecoverBrain = vi.fn();
+const mockRunBackupRecover = vi.fn();
 
-vi.mock('@cleocode/core/store/backup-recover-brain.js', () => {
-  // Defined INSIDE the factory so the hoisted vi.mock body does not reach
-  // a TDZ variable declared after it in the test file (T10304).
-  class BackupRecoverBrainErrorMock extends Error {
+vi.mock('@cleocode/core/store/backup-recover.js', () => {
+  class BackupRecoverErrorMock extends Error {
     constructor(
       message: string,
       public readonly code: number,
@@ -38,41 +38,39 @@ vi.mock('@cleocode/core/store/backup-recover-brain.js', () => {
       public readonly fix?: string,
     ) {
       super(message);
-      this.name = 'BackupRecoverBrainError';
+      this.name = 'BackupRecoverError';
     }
   }
   return {
-    runBackupRecoverBrain: (...args: unknown[]) => mockRunBackupRecoverBrain(...args),
-    BackupRecoverBrainError: BackupRecoverBrainErrorMock,
+    runBackupRecover: (...args: unknown[]) => mockRunBackupRecover(...args),
+    BackupRecoverError: BackupRecoverErrorMock,
   };
 });
 
 /**
- * Constructor signature for the mocked `BackupRecoverBrainError` class.
+ * Constructor signature for the mocked `BackupRecoverError` class.
  *
  * The test body needs the SAME class reference the production code sees
- * via `instanceof BackupRecoverBrainError` so thrown errors are routed
- * through the mapped-error branch (exit code 4 / 78) rather than the
- * generic catch (exit code 1). Populated by `beforeAll` below.
+ * via `instanceof BackupRecoverError` so thrown errors are routed
+ * through the mapped-error branch rather than the generic catch.
  */
-type MockBackupRecoverBrainErrorCtor = new (
+type MockBackupRecoverErrorCtor = new (
   message: string,
   code: number,
   codeName: string,
   fix?: string,
 ) => Error;
 
-let MockBackupRecoverBrainError: MockBackupRecoverBrainErrorCtor;
+let MockBackupRecoverError: MockBackupRecoverErrorCtor;
 
 beforeAll(async () => {
-  const mod: { BackupRecoverBrainError: MockBackupRecoverBrainErrorCtor } = await import(
-    '@cleocode/core/store/backup-recover-brain.js'
+  const mod: { BackupRecoverError: MockBackupRecoverErrorCtor } = await import(
+    '@cleocode/core/store/backup-recover.js'
   );
-  MockBackupRecoverBrainError = mod.BackupRecoverBrainError;
+  MockBackupRecoverError = mod.BackupRecoverError;
 });
 
 const mockGetProjectRoot = vi.fn(() => '/tmp/test-project');
-const mockGetCleoDirAbsolute = vi.fn(() => '/tmp/test-project/.cleo');
 const mockGetLogger = vi.fn(() => ({
   warn: vi.fn(),
   error: vi.fn(),
@@ -86,7 +84,6 @@ vi.mock('@cleocode/core', async () => {
   return {
     ...actual,
     getProjectRoot: () => mockGetProjectRoot(),
-    getCleoDirAbsolute: (cwd?: string) => mockGetCleoDirAbsolute(cwd),
     getLogger: (channel: string) => mockGetLogger(channel),
   };
 });
@@ -99,10 +96,11 @@ vi.mock('../../../dispatch/adapters/cli.js', () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Helper — invoke the leaf subcommand's run handler
+// Helpers — invoke either the brain leaf or the generic recover group
 // ---------------------------------------------------------------------------
 
 interface RecoverArgs {
+  role?: string;
   'dry-run'?: boolean;
   'from-snapshot'?: string;
   'no-delta'?: boolean;
@@ -114,8 +112,8 @@ interface CittyLeaf {
 }
 
 /**
- * Reach into `backupCommand.subCommands.recover.subCommands.brain.run` and
- * invoke it with the supplied flags merged onto defaults.
+ * Resolve the `cleo backup recover brain` subcommand and invoke its run
+ * handler with the supplied flags merged onto defaults.
  */
 async function runRecoverBrain(args: RecoverArgs): Promise<void> {
   const recoverGroup = backupCommand.subCommands?.['recover'];
@@ -137,37 +135,69 @@ async function runRecoverBrain(args: RecoverArgs): Promise<void> {
   await (brainCmd as CittyLeaf).run({ args: merged, rawArgs: [] });
 }
 
+/**
+ * Resolve the `cleo backup recover` parent and invoke its run handler with
+ * the supplied positional `role` arg and flags. Exercises the generic
+ * `cleo backup recover <role>` dispatch path.
+ */
+async function runRecoverGeneric(args: RecoverArgs): Promise<void> {
+  const recoverGroup = backupCommand.subCommands?.['recover'];
+  if (!recoverGroup || typeof recoverGroup !== 'object' || !('run' in recoverGroup)) {
+    throw new Error('backup recover group subcommand not found');
+  }
+  const merged: RecoverArgs = {
+    role: '',
+    'dry-run': false,
+    'from-snapshot': '',
+    'no-delta': false,
+    force: false,
+    ...args,
+  };
+  await (recoverGroup as CittyLeaf).run({ args: merged, rawArgs: [] });
+}
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const ZERO_COUNTS: BrainRecoveredRowCounts = {
-  observations: 0,
-  decisions: 0,
-  learnings: 0,
+const BRAIN_ROW_COUNTS: DbRecoveredRowCounts = {
+  brain_observations: 142,
+  brain_decisions: 8,
+  brain_learnings: 17,
 };
 
-const HAPPY_RESULT: BackupRecoverBrainResult = {
+const ZERO_ROW_COUNTS: DbRecoveredRowCounts = {};
+
+const HAPPY_RESULT: BackupRecoverResult = {
+  role: 'brain',
   restoredFrom:
     '/tmp/test-project/.cleo/backups/snapshot/brain.db.snapshot-2026-05-23T08-00-55-563Z',
-  rowsRecovered: { observations: 142, decisions: 8, learnings: 17 },
+  rowsRecovered: BRAIN_ROW_COUNTS,
   dataLossWindowHours: 5.2,
   integrityOK: true,
   quarantinedTo: '/tmp/test-project/.cleo/quarantine/brain-malformed-2026-05-23T13-12-00-000Z',
   dryRun: false,
 };
 
-const DRY_RUN_PLAN: BackupRecoverBrainResult = {
+const DRY_RUN_PLAN: BackupRecoverResult = {
   ...HAPPY_RESULT,
   quarantinedTo: '',
   dryRun: true,
 };
 
+const TASKS_HAPPY_RESULT: BackupRecoverResult = {
+  ...HAPPY_RESULT,
+  role: 'tasks',
+  restoredFrom:
+    '/tmp/test-project/.cleo/backups/snapshot/tasks.db.snapshot-2026-05-23T08-00-55-563Z',
+  rowsRecovered: { tasks: 250 } satisfies DbRecoveredRowCounts,
+};
+
 // ---------------------------------------------------------------------------
-// Tests
+// Tests — backward-compat `cleo backup recover brain` leaf
 // ---------------------------------------------------------------------------
 
-describe('T10304 cleo backup recover brain — dry-run mode', () => {
+describe('cleo backup recover brain — dry-run mode (T10318 backward compat)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.exitCode = undefined;
@@ -178,46 +208,43 @@ describe('T10304 cleo backup recover brain — dry-run mode', () => {
   });
 
   it('returns a plan envelope with dryRun=true without mutating state', async () => {
-    mockRunBackupRecoverBrain.mockReturnValue(DRY_RUN_PLAN);
+    mockRunBackupRecover.mockReturnValue(DRY_RUN_PLAN);
 
     await runRecoverBrain({ 'dry-run': true });
 
-    expect(mockRunBackupRecoverBrain).toHaveBeenCalledOnce();
-    const call = mockRunBackupRecoverBrain.mock.calls[0]?.[0];
+    expect(mockRunBackupRecover).toHaveBeenCalledOnce();
+    const call = mockRunBackupRecover.mock.calls[0]?.[0];
     expect(call).toMatchObject({
-      corruptPath: '/tmp/test-project/.cleo/brain.db',
-      snapshotDir: '/tmp/test-project/.cleo/backups/snapshot',
-      vacuumSnapshotDir: '/tmp/test-project/.cleo/backups/sqlite',
-      legacyArtifactDir: '/tmp/test-project/.cleo',
-      quarantineRoot: '/tmp/test-project/.cleo/quarantine',
+      role: 'brain',
+      projectRoot: '/tmp/test-project',
       dryRun: true,
     });
     expect(process.exitCode).toBeUndefined();
   });
 
   it('plumbs --from-snapshot through to the core helper', async () => {
-    mockRunBackupRecoverBrain.mockReturnValue(DRY_RUN_PLAN);
+    mockRunBackupRecover.mockReturnValue(DRY_RUN_PLAN);
 
     await runRecoverBrain({
       'dry-run': true,
       'from-snapshot': '2026-05-22',
     });
 
-    const call = mockRunBackupRecoverBrain.mock.calls[0]?.[0];
+    const call = mockRunBackupRecover.mock.calls[0]?.[0];
     expect(call?.fromSnapshot).toBe('2026-05-22');
   });
 
   it('plumbs --no-delta through to the core helper', async () => {
-    mockRunBackupRecoverBrain.mockReturnValue(DRY_RUN_PLAN);
+    mockRunBackupRecover.mockReturnValue(DRY_RUN_PLAN);
 
     await runRecoverBrain({ 'dry-run': true, 'no-delta': true });
 
-    const call = mockRunBackupRecoverBrain.mock.calls[0]?.[0];
+    const call = mockRunBackupRecover.mock.calls[0]?.[0];
     expect(call?.noDelta).toBe(true);
   });
 });
 
-describe('T10304 cleo backup recover brain — happy path', () => {
+describe('cleo backup recover brain — happy path (T10318 backward compat)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.exitCode = undefined;
@@ -228,33 +255,31 @@ describe('T10304 cleo backup recover brain — happy path', () => {
   });
 
   it('returns structured envelope with all expected fields on success', async () => {
-    mockRunBackupRecoverBrain.mockReturnValue(HAPPY_RESULT);
+    mockRunBackupRecover.mockReturnValue(HAPPY_RESULT);
 
     await runRecoverBrain({});
 
-    expect(mockRunBackupRecoverBrain).toHaveBeenCalledOnce();
-    const call = mockRunBackupRecoverBrain.mock.calls[0]?.[0];
+    expect(mockRunBackupRecover).toHaveBeenCalledOnce();
+    const call = mockRunBackupRecover.mock.calls[0]?.[0];
+    expect(call?.role).toBe('brain');
     expect(call?.dryRun).toBe(false);
     expect(process.exitCode).toBeUndefined();
   });
 
-  it('passes corruptPath, snapshotDir, vacuumSnapshotDir, legacyArtifactDir, quarantineRoot', async () => {
-    mockRunBackupRecoverBrain.mockReturnValue(HAPPY_RESULT);
+  it('passes role=brain and projectRoot through', async () => {
+    mockRunBackupRecover.mockReturnValue(HAPPY_RESULT);
 
     await runRecoverBrain({});
 
-    const call = mockRunBackupRecoverBrain.mock.calls[0]?.[0];
+    const call = mockRunBackupRecover.mock.calls[0]?.[0];
     expect(call).toMatchObject({
-      corruptPath: '/tmp/test-project/.cleo/brain.db',
-      snapshotDir: '/tmp/test-project/.cleo/backups/snapshot',
-      vacuumSnapshotDir: '/tmp/test-project/.cleo/backups/sqlite',
-      legacyArtifactDir: '/tmp/test-project/.cleo',
-      quarantineRoot: '/tmp/test-project/.cleo/quarantine',
+      role: 'brain',
+      projectRoot: '/tmp/test-project',
     });
   });
 });
 
-describe('T10304 cleo backup recover brain — error paths', () => {
+describe('cleo backup recover brain — error paths (T10318 backward compat)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.exitCode = undefined;
@@ -265,12 +290,12 @@ describe('T10304 cleo backup recover brain — error paths', () => {
   });
 
   it('surfaces E_NO_SNAPSHOT with exit code 4 when no snapshots present', async () => {
-    mockRunBackupRecoverBrain.mockImplementation(() => {
-      throw new MockBackupRecoverBrainError(
-        'No snapshots found under /tmp/test-project/.cleo/backups/snapshot',
+    mockRunBackupRecover.mockImplementation(() => {
+      throw new MockBackupRecoverError(
+        'No snapshots found for role "brain"',
         4,
         'E_NO_SNAPSHOT',
-        'Run `cleo backup add` to create a snapshot before attempting recovery.',
+        'Run `cleo backup add` to create a snapshot for role "brain" before attempting recovery.',
       );
     });
 
@@ -280,9 +305,9 @@ describe('T10304 cleo backup recover brain — error paths', () => {
   });
 
   it('surfaces E_NO_SNAPSHOT_MATCH with exit code 4 when --from-snapshot pin matches zero candidates', async () => {
-    mockRunBackupRecoverBrain.mockImplementation(() => {
-      throw new MockBackupRecoverBrainError(
-        'Snapshot pin "1970-01-01" matched zero candidates',
+    mockRunBackupRecover.mockImplementation(() => {
+      throw new MockBackupRecoverError(
+        'Snapshot pin "1970-01-01" matched zero candidates for role "brain"',
         4,
         'E_NO_SNAPSHOT_MATCH',
       );
@@ -294,7 +319,7 @@ describe('T10304 cleo backup recover brain — error paths', () => {
   });
 
   it('surfaces generic errors with exit code 1', async () => {
-    mockRunBackupRecoverBrain.mockImplementation(() => {
+    mockRunBackupRecover.mockImplementation(() => {
       throw new Error('disk full');
     });
 
@@ -304,14 +329,78 @@ describe('T10304 cleo backup recover brain — error paths', () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it('returns zero-counts envelope when restoration produced empty tables', async () => {
-    mockRunBackupRecoverBrain.mockReturnValue({
+  it('returns empty-counts envelope when restoration produced empty tables', async () => {
+    mockRunBackupRecover.mockReturnValue({
       ...HAPPY_RESULT,
-      rowsRecovered: ZERO_COUNTS,
+      rowsRecovered: ZERO_ROW_COUNTS,
     });
 
     await runRecoverBrain({});
 
     expect(process.exitCode).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — new generic `cleo backup recover <role>` surface
+// ---------------------------------------------------------------------------
+
+describe('cleo backup recover <role> — generic surface (T10318)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it('accepts an explicit positional role from DB_INVENTORY', async () => {
+    mockRunBackupRecover.mockReturnValue(TASKS_HAPPY_RESULT);
+
+    await runRecoverGeneric({ role: 'tasks' });
+
+    expect(mockRunBackupRecover).toHaveBeenCalledOnce();
+    const call = mockRunBackupRecover.mock.calls[0]?.[0];
+    expect(call?.role).toBe('tasks');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('surfaces E_VALIDATION with exit code 6 when no role is supplied', async () => {
+    await runRecoverGeneric({ role: '' });
+
+    expect(mockRunBackupRecover).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(6);
+  });
+
+  it('surfaces E_UNKNOWN_ROLE when an unknown role is supplied', async () => {
+    await runRecoverGeneric({ role: 'not-a-real-role' });
+
+    expect(mockRunBackupRecover).not.toHaveBeenCalled();
+    expect(typeof process.exitCode).toBe('number');
+    expect(process.exitCode).not.toBe(0);
+  });
+
+  it('plumbs --dry-run, --from-snapshot, --no-delta into the generic path', async () => {
+    mockRunBackupRecover.mockReturnValue({
+      ...TASKS_HAPPY_RESULT,
+      dryRun: true,
+      quarantinedTo: '',
+    });
+
+    await runRecoverGeneric({
+      role: 'tasks',
+      'dry-run': true,
+      'from-snapshot': '2026-05-22',
+      'no-delta': true,
+    });
+
+    const call = mockRunBackupRecover.mock.calls[0]?.[0];
+    expect(call).toMatchObject({
+      role: 'tasks',
+      dryRun: true,
+      fromSnapshot: '2026-05-22',
+      noDelta: true,
+    });
   });
 });

--- a/packages/cleo/src/cli/commands/backup-recover.ts
+++ b/packages/cleo/src/cli/commands/backup-recover.ts
@@ -1,65 +1,142 @@
 /**
- * `cleo backup recover brain` — operator-facing brain.db recovery verb.
+ * `cleo backup recover <role>` — operator-facing CLEO database recovery verb
+ * (T10318 — generalised from the brain-only T10304 verb).
  *
- * Wraps {@link runBackupRecoverBrain} from `@cleocode/core/store/backup-recover-brain.js`
- * (T10304 internal helper that itself delegates to {@link recoverMalformedBrainDb}
- * from T10303) and exposes the recovery pipeline as a discoverable CLI surface.
+ * Wraps {@link runBackupRecover} from `@cleocode/core/store/backup-recover.js`
+ * (T10318 internal helper that itself delegates to {@link recoverMalformedDb}
+ * from T10318 / generalised T10303) and exposes the recovery pipeline as a
+ * discoverable CLI surface for every role in {@link DB_INVENTORY}.
  *
- * The chokepoint helper auto-recovers on the next `getBrainDb()` open, so this
- * verb exists for two scenarios the chokepoint does NOT cover:
+ * The chokepoint helper auto-recovers on the next `openCleoDb(role)` open,
+ * so this verb exists for two scenarios the chokepoint does NOT cover:
  *
- *  1. **Pre-emptive recovery** — operator sees `ERR_SQLITE_ERROR errcode=11` in
- *     logs and wants to recover *before* the next session-start so the next
- *     agent doesn't lose its memory writes.
+ *  1. **Pre-emptive recovery** — operator sees `ERR_SQLITE_ERROR errcode=11`
+ *     in logs and wants to recover *before* the next session-start.
  *  2. **Pinned restore** — auto-recovery picked the freshest snapshot but the
  *     operator knows that one is poisoned too; `--from-snapshot <iso>` lets
  *     them pin an older one.
  *
- * @task T10304
- * @epic T10286
+ * Backward compatibility: `cleo backup recover brain` continues to work as an
+ * explicit subcommand (a thin alias over `cleo backup recover <role>` with
+ * `role='brain'`).
+ *
+ * @task T10318
+ * @epic T10284
  * @saga T10281
  */
 
-import { join } from 'node:path';
-import { ExitCode } from '@cleocode/contracts';
-import { getCleoDirAbsolute, getLogger, getProjectRoot } from '@cleocode/core';
-import {
-  BackupRecoverBrainError,
-  runBackupRecoverBrain,
-} from '@cleocode/core/store/backup-recover-brain.js';
+import { DB_INVENTORY, type DbRole, ExitCode } from '@cleocode/contracts';
+import { getLogger, getProjectRoot } from '@cleocode/core';
+import { BackupRecoverError, runBackupRecover } from '@cleocode/core/store/backup-recover.js';
 import { defineCommand } from '../lib/define-cli-command.js';
 import { cliError, cliOutput, humanInfo } from '../renderers/index.js';
 
 // ---------------------------------------------------------------------------
-// `cleo backup recover brain` — terminal subcommand
+// Flag-narrowing helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Args accepted by `cleo backup recover brain`. Citty's parsed-args object
- * is a `Record<string, unknown>` at the type level — these narrowing helpers
- * extract each flag with the correct primitive shape.
- */
+/** Read a boolean flag from citty's `Record<string, unknown>` parsed args. */
 function readBoolFlag(args: Record<string, unknown>, key: string): boolean {
   return args[key] === true;
 }
 
+/** Read a string flag from citty's `Record<string, unknown>` parsed args. */
 function readStringFlag(args: Record<string, unknown>, key: string): string {
   const v = args[key];
   return typeof v === 'string' ? v : '';
 }
 
+// ---------------------------------------------------------------------------
+// Shared executor — every leaf delegates to this single function
+// ---------------------------------------------------------------------------
+
 /**
- * `cleo backup recover brain` — recover a malformed brain.db from snapshot.
+ * Shared executor used by both the generic `cleo backup recover <role>` path
+ * and the brain-specific backward-compat alias. Centralises envelope-emission
+ * and error-mapping so the two surfaces stay byte-identical for the brain
+ * case post-T10318.
  *
- * Internal export (not `*Command` suffix) — registered as a leaf subcommand
- * inside {@link backupRecoverSubCommand}'s `subCommands`. The
- * `*SubCommand` suffix would be picked up by the command-manifest generator,
- * which would then flag a collision against the top-level `brainCommand`
- * (`cleo brain ...`). Keeping the export name out of the `*Command` /
- * `*SubCommand` pattern avoids the false-positive.
+ * @internal
+ */
+function executeRecover(role: DbRole, args: Record<string, unknown>): void {
+  const projectRoot = getProjectRoot();
+  const dryRun = readBoolFlag(args, 'dry-run');
+  const fromSnapshot = readStringFlag(args, 'from-snapshot');
+  const noDelta = readBoolFlag(args, 'no-delta');
+  const operation = `backup.recover.${role}`;
+
+  try {
+    const result = runBackupRecover({
+      role,
+      projectRoot,
+      logger: getLogger(`backup-recover-${role}`),
+      dryRun,
+      fromSnapshot: fromSnapshot.length > 0 ? fromSnapshot : undefined,
+      noDelta,
+    });
+
+    cliOutput(result, {
+      command: 'backup',
+      operation,
+    });
+
+    if (result.dryRun) {
+      humanInfo(
+        `[dry-run] Would restore role "${role}" from ${result.restoredFrom} (${
+          result.dataLossWindowHours !== null
+            ? `~${result.dataLossWindowHours}h data-loss window`
+            : 'data-loss window unknown'
+        }). Re-run without --dry-run to execute (project root: ${projectRoot}).`,
+      );
+    } else {
+      humanInfo(
+        `Recovered "${role}" DB from ${result.restoredFrom}. Corrupt DB quarantined at ${result.quarantinedTo}.`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof BackupRecoverError) {
+      cliError(
+        err.message,
+        err.code,
+        {
+          name: err.codeName,
+          ...(err.fix ? { fix: err.fix } : {}),
+        },
+        { operation },
+      );
+      process.exitCode = err.code;
+      return;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    cliError(message, ExitCode.GENERAL_ERROR, { name: 'E_RECOVERY_FAILED' }, { operation });
+    process.exitCode = ExitCode.GENERAL_ERROR;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Backward-compat leaf — `cleo backup recover brain`
+// ---------------------------------------------------------------------------
+
+/**
+ * `cleo backup recover brain` — backward-compatible brain.db recovery leaf.
  *
- * @task T10304
- * @epic T10286
+ * Pre-T10318 this was the only `cleo backup recover` subcommand. Post-T10318
+ * it is a thin alias over the generic executor with `role='brain'`. The
+ * envelope shape (which now carries an explicit `role: 'brain'` field) is the
+ * one observable behaviour change — every other field stays identical to
+ * the T10304 surface.
+ *
+ * Kept as an explicit subcommand (rather than dispatched via the generic
+ * positional `<role>` arg) so:
+ * - `cleo backup recover brain --help` continues to surface specifically.
+ * - Existing scripts that hard-code `cleo backup recover brain` keep working.
+ *
+ * The export name deliberately omits the `*Command` / `*SubCommand` suffix to
+ * keep the command-manifest generator from flagging a collision against the
+ * top-level `brainCommand` (`cleo brain ...`).
+ *
+ * @task T10318
+ * @epic T10284
  */
 export const backupRecoverBrainLeaf = defineCommand({
   meta: {
@@ -92,52 +169,112 @@ export const backupRecoverBrainLeaf = defineCommand({
     },
   },
   async run({ args }): Promise<void> {
-    const projectRoot = getProjectRoot();
-    const cleoDir = getCleoDirAbsolute();
-
-    const corruptPath = join(cleoDir, 'brain.db');
-    const snapshotDir = join(cleoDir, 'backups', 'snapshot');
-    const vacuumSnapshotDir = join(cleoDir, 'backups', 'sqlite');
-    const quarantineRoot = join(cleoDir, 'quarantine');
-
     const argsBag: Record<string, unknown> = args;
-    const dryRun = readBoolFlag(argsBag, 'dry-run');
-    const fromSnapshot = readStringFlag(argsBag, 'from-snapshot');
-    const noDelta = readBoolFlag(argsBag, 'no-delta');
+    executeRecover('brain', argsBag);
+  },
+});
 
+// ---------------------------------------------------------------------------
+// Generic group — `cleo backup recover <role>`
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a positional `<role>` arg against the canonical DB_INVENTORY.
+ *
+ * @internal
+ */
+function parseRoleArg(value: string): DbRole {
+  const trimmed = value.trim();
+  for (const entry of DB_INVENTORY) {
+    if (entry.role === trimmed) {
+      return entry.role;
+    }
+  }
+  const validRoles = DB_INVENTORY.map((e) => e.role).join(', ');
+  throw new BackupRecoverError(
+    `Unknown DB role "${trimmed}". Valid roles: ${validRoles}.`,
+    ExitCode.VALIDATION_ERROR,
+    'E_UNKNOWN_ROLE',
+    'Run `cleo backup recover --help` for the list of valid roles.',
+  );
+}
+
+/**
+ * `cleo backup recover` — recovery verb group.
+ *
+ * @remarks
+ * Accepts an optional positional `<role>` argument (T10318) that selects any
+ * role from {@link DB_INVENTORY}. When called with no argument, surfaces the
+ * usage. The brain-specific subcommand is kept as a backward-compat alias.
+ *
+ * @task T10318
+ * @epic T10284
+ */
+export const backupRecoverSubCommand = defineCommand({
+  meta: {
+    name: 'recover',
+    description:
+      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+  },
+  args: {
+    role: {
+      type: 'positional',
+      description: `Canonical DB role (one of: ${DB_INVENTORY.map((e) => e.role).join(', ')})`,
+      required: false,
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Print what would be done without quarantining or copying any files',
+      default: false,
+    },
+    'from-snapshot': {
+      type: 'string',
+      description:
+        'Pin recovery to a specific snapshot — absolute path or ISO timestamp prefix (e.g. 2026-05-23)',
+      default: '',
+    },
+    'no-delta': {
+      type: 'boolean',
+      description:
+        'Skip the sqlite3 .recover delta-merge step (reserved — current pipeline does not delta-merge; flag plumbed for forward-compat)',
+      default: false,
+    },
+    force: {
+      type: 'boolean',
+      description: 'Bypass any safety prompts (currently a no-op; reserved)',
+      default: false,
+    },
+  },
+  subCommands: {
+    brain: backupRecoverBrainLeaf,
+  },
+  async run({ args }): Promise<void> {
+    const argsBag: Record<string, unknown> = args;
+    const roleArg = readStringFlag(argsBag, 'role');
+
+    // No positional + no subcommand → surface usage. citty fires the parent
+    // `run` AFTER a subcommand resolves, so this branch only triggers when
+    // the operator typed `cleo backup recover` with no leaf and no role.
+    if (roleArg.length === 0) {
+      const validRoles = DB_INVENTORY.map((e) => e.role).join(', ');
+      cliError(
+        `Missing role. Try \`cleo backup recover <role>\` (one of: ${validRoles}).`,
+        ExitCode.VALIDATION_ERROR,
+        {
+          name: 'E_VALIDATION',
+          fix: 'Run `cleo backup recover --help` to see available roles and flags.',
+        },
+        { operation: 'backup.recover' },
+      );
+      process.exitCode = ExitCode.VALIDATION_ERROR;
+      return;
+    }
+
+    let role: DbRole;
     try {
-      const result = runBackupRecoverBrain({
-        corruptPath,
-        snapshotDir,
-        vacuumSnapshotDir,
-        legacyArtifactDir: cleoDir,
-        quarantineRoot,
-        logger: getLogger('backup-recover-brain'),
-        dryRun,
-        fromSnapshot: fromSnapshot.length > 0 ? fromSnapshot : undefined,
-        noDelta,
-      });
-
-      cliOutput(result, {
-        command: 'backup',
-        operation: 'backup.recover.brain',
-      });
-
-      if (result.dryRun) {
-        humanInfo(
-          `[dry-run] Would restore from ${result.restoredFrom} (${
-            result.dataLossWindowHours !== null
-              ? `~${result.dataLossWindowHours}h data-loss window`
-              : 'data-loss window unknown'
-          }). Re-run without --dry-run to execute (project root: ${projectRoot}).`,
-        );
-      } else {
-        humanInfo(
-          `Recovered brain.db from ${result.restoredFrom}. Corrupt DB quarantined at ${result.quarantinedTo}.`,
-        );
-      }
+      role = parseRoleArg(roleArg);
     } catch (err) {
-      if (err instanceof BackupRecoverBrainError) {
+      if (err instanceof BackupRecoverError) {
         cliError(
           err.message,
           err.code,
@@ -145,60 +282,14 @@ export const backupRecoverBrainLeaf = defineCommand({
             name: err.codeName,
             ...(err.fix ? { fix: err.fix } : {}),
           },
-          { operation: 'backup.recover.brain' },
+          { operation: 'backup.recover' },
         );
         process.exitCode = err.code;
         return;
       }
-      const message = err instanceof Error ? err.message : String(err);
-      cliError(
-        message,
-        ExitCode.GENERAL_ERROR,
-        { name: 'E_RECOVERY_FAILED' },
-        { operation: 'backup.recover.brain' },
-      );
-      process.exitCode = ExitCode.GENERAL_ERROR;
+      throw err;
     }
-  },
-});
 
-// ---------------------------------------------------------------------------
-// `cleo backup recover` — group command (currently only `brain`)
-// ---------------------------------------------------------------------------
-
-/**
- * `cleo backup recover` — recovery verb group.
- *
- * Currently hosts only `cleo backup recover brain` (T10304). Reserved for
- * future per-DB recovery verbs (`tasks`, `nexus`, `signaldock`).
- *
- * @task T10304
- * @epic T10286
- */
-export const backupRecoverSubCommand = defineCommand({
-  meta: {
-    name: 'recover',
-    description: 'Recover a malformed CLEO database from snapshot',
-  },
-  subCommands: {
-    brain: backupRecoverBrainLeaf,
-  },
-  async run({ args }): Promise<void> {
-    // When invoked with no subcommand, surface the usage. citty fires the
-    // parent `run` AFTER the subcommand resolves, so this branch only
-    // triggers when the operator typed `cleo backup recover` with no leaf.
-    const argsBag: Record<string, unknown> = args;
-    const positional = argsBag['_'];
-    if (Array.isArray(positional) && positional.length > 0) return;
-    cliError(
-      'Missing subcommand. Try `cleo backup recover brain` (currently the only available recovery verb).',
-      ExitCode.VALIDATION_ERROR,
-      {
-        name: 'E_VALIDATION',
-        fix: 'Run `cleo backup recover brain --help` to see available flags.',
-      },
-      { operation: 'backup.recover' },
-    );
-    process.exitCode = ExitCode.VALIDATION_ERROR;
+    executeRecover(role, argsBag);
   },
 });

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -123,7 +123,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description: 'Recover a malformed CLEO database from snapshot',
+    description:
+      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
     load: async () =>
       (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
@@ -336,6 +337,22 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'docs',
     description: 'Documentation attachment management (add/list/fetch/remove), ',
     load: async () => (await import('../commands/docs.js')).docsCommand as CommandDef,
+  },
+  {
+    exportName: 'doctorDbSubstrateCommand',
+    name: 'db-substrate',
+    description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
+    load: async () =>
+      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+  },
+  {
+    exportName: 'doctorLegacyBackupsCommand',
+    name: 'legacy-backups',
+    description:
+      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () =>
+      (await import('../commands/doctor-legacy-backups.js'))
+        .doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',

--- a/packages/contracts/src/db-recovery.ts
+++ b/packages/contracts/src/db-recovery.ts
@@ -1,0 +1,144 @@
+/**
+ * Generic CLEO database recovery contracts — generalised from the brain-only
+ * T10303/T10304 shapes so the same envelope works for every role declared in
+ * {@link DB_INVENTORY}.
+ *
+ * These types mirror {@link BrainRecoveryResult} + {@link BackupRecoverBrainResult}
+ * almost verbatim, with two adjustments:
+ *
+ * 1. `observationsRecovered: number | null` is generalised to
+ *    `rowCounts: DbRecoveredRowCounts` — a `Record<tableName, number | null>`
+ *    keyed by the user tables discovered in the restored DB via
+ *    `sqlite_master`. Tables that fail to count surface as `null`.
+ * 2. Every envelope carries the `role: DbRole` it pertains to so envelopes from
+ *    `cleo backup recover <role>` are self-describing across tools that may
+ *    fan recovery out across multiple DBs.
+ *
+ * The brain-specific shapes ({@link BrainRecoveryResult},
+ * {@link BackupRecoverBrainResult}, {@link BrainRecoveredRowCounts}) remain in
+ * {@link brain.ts} as the backward-compatible surface — the brain CLI verb
+ * (`cleo backup recover brain`) still emits the same envelope it did before
+ * T10318 generalised the pipeline.
+ *
+ * @task T10318
+ * @epic T10284
+ * @saga T10281
+ * @adr ADR-068
+ */
+
+import type { DbRole } from './db-inventory.js';
+
+/**
+ * Best-effort per-table row counts probed from a recovered CLEO database.
+ *
+ * @remarks
+ * The recovery pipeline enumerates user tables in the restored DB via
+ * `sqlite_master` (excluding internal `sqlite_*` and Drizzle journal tables)
+ * and runs `SELECT COUNT(*)` on each. Tables that fail to count — for
+ * example, a missing table in a very old snapshot, or a schema/version
+ * mismatch — surface as `null` instead of throwing so the envelope always
+ * serialises cleanly.
+ *
+ * Keys are exact SQLite table names (case-sensitive). Values are non-negative
+ * integers or `null`.
+ *
+ * @public
+ */
+export type DbRecoveredRowCounts = Readonly<Record<string, number | null>>;
+
+/**
+ * Result of a generic CLEO DB auto-recovery attempt.
+ *
+ * @remarks
+ * Returned by `recoverMalformedDb({ role, ... })` (T10318) when the chokepoint
+ * (or an operator invoking `cleo backup recover <role>`) detects malformation
+ * via `ERR_SQLITE_ERROR errcode=11` or a failing `PRAGMA integrity_check` /
+ * `PRAGMA quick_check`. The corrupt DB has been moved to a quarantine
+ * directory and the freshest validated snapshot has been copied to the
+ * canonical role path.
+ *
+ * Consumers read this structure to decide whether to re-attempt the open and
+ * to emit user-facing diagnostics with the data-loss window.
+ *
+ * @public
+ */
+export interface DbRecoveryResult {
+  /** Canonical role of the database that was recovered. */
+  role: DbRole;
+  /** Absolute path to the snapshot that was restored, or `null` if recovery failed. */
+  restoredFrom: string | null;
+  /**
+   * Approximate hours between the snapshot's timestamp and the recovery
+   * event. `null` when the snapshot timestamp could not be parsed.
+   * Used in the recovery warning to make the data-loss window legible.
+   */
+  dataLossWindowHours: number | null;
+  /**
+   * Per-table row counts probed from the restored DB. Each key is a user
+   * table name; each value is the row count, or `null` on count failure.
+   * Empty record `{}` when the restored DB has no user tables (or when
+   * the probe itself failed to open the DB).
+   */
+  rowCounts: DbRecoveredRowCounts;
+  /** `true` if the restored DB passes `PRAGMA quick_check`. */
+  integrityOK: boolean;
+  /**
+   * Absolute path to the quarantine directory where the corrupt DB plus
+   * its `-wal`/`-shm` sidecars were moved before restore. `null` when no
+   * corrupt DB existed at the canonical path (recovery into an empty slot).
+   */
+  quarantineDir: string | null;
+}
+
+/**
+ * Envelope payload returned by `cleo backup recover <role>`.
+ *
+ * @remarks
+ * Wraps {@link DbRecoveryResult} with three CLI-only additions:
+ *
+ * - `rowsRecovered` aliases `rowCounts` to keep the envelope shape compatible
+ *   with the brain-specific {@link BackupRecoverBrainResult}.
+ * - `quarantinedTo: string` is the non-nullable string form (empty string in
+ *   `--dry-run` mode where no files were touched) — easier for shell scripts
+ *   that pipe the envelope into `jq` and then path operations.
+ * - `dryRun: boolean` records whether the envelope is a *plan* (would-do)
+ *   versus a *record* (already-done). Consumers MUST check this before
+ *   treating `restoredFrom` as a post-condition.
+ *
+ * @task T10318
+ * @epic T10284
+ * @saga T10281
+ * @public
+ */
+export interface BackupRecoverResult {
+  /** Canonical role of the database that was (or would be) recovered. */
+  role: DbRole;
+  /**
+   * Absolute path to the snapshot that was (or would be) restored. Empty
+   * string when no snapshot was available — the envelope's caller surfaces
+   * that as a failure mode via a structured error.
+   */
+  restoredFrom: string;
+  /** Per-table row counts probed from the restored DB (or the plan target). */
+  rowsRecovered: DbRecoveredRowCounts;
+  /**
+   * Approximate hours between the snapshot's timestamp and the recovery
+   * event. `null` when the snapshot timestamp could not be parsed (e.g.
+   * legacy `<role>.db.PRE-DUP-FIX-*` fallback artifact).
+   */
+  dataLossWindowHours: number | null;
+  /** `true` when the restored DB passes `PRAGMA quick_check`. */
+  integrityOK: boolean;
+  /**
+   * Absolute path to the quarantine directory where the corrupt DB plus
+   * its `-wal`/`-shm` sidecars were moved. Empty string in `--dry-run`
+   * mode where no files were touched.
+   */
+  quarantinedTo: string;
+  /**
+   * `true` when invoked with `--dry-run` — indicates the envelope is a
+   * plan, NOT a record of mutations performed. Consumers MUST check this
+   * before treating `restoredFrom` as a post-condition.
+   */
+  dryRun: boolean;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -283,6 +283,12 @@ export type {
   DbTier,
 } from './db-inventory.js';
 export { DB_INVENTORY } from './db-inventory.js';
+// === DB Recovery (T10318 — Saga T10281 / Epic T10284 — generic across DB_INVENTORY) ===
+export type {
+  BackupRecoverResult,
+  DbRecoveredRowCounts,
+  DbRecoveryResult,
+} from './db-recovery.js';
 // === Dependency Registry Contracts ===
 export type {
   DependencyCategory,

--- a/packages/core/src/store/backup-recover-brain.ts
+++ b/packages/core/src/store/backup-recover-brain.ts
@@ -1,65 +1,53 @@
 /**
- * CLI-facing wrapper around {@link recoverMalformedBrainDb} (T10303).
+ * Brain-specific CLI wrapper around the generic recovery pipeline
+ * ({@link runBackupRecover}, T10318).
  *
- * Exposes the recovery pipeline to the `cleo backup recover brain` verb
- * (T10304) with three additions that don't belong in the chokepoint module:
+ * @remarks
+ * Pre-T10318 this module owned the entire brain.db recovery wrapper. T10318
+ * generalised the pipeline to every role in `DB_INVENTORY` and moved the
+ * implementation to {@link ../store/backup-recover.ts}. This module now
+ * exists purely as a backward-compatibility shim:
  *
- *  1. **Dry-run planning** — enumerates snapshot candidates, validates the
- *     freshest one via `PRAGMA quick_check`, and returns the envelope WITHOUT
- *     quarantining or copying anything. Operators use this to preview the
- *     freshness window before pulling the trigger.
- *  2. **Per-table row counts** — probes `brain_observations`, `brain_decisions`,
- *     `brain_learnings` post-restore so the runbook surfaces the recovered
- *     scope (NOT just observation count as the chokepoint helper does).
- *  3. **Snapshot pinning** — accepts `fromSnapshot` (absolute path or ISO
- *     prefix) so operators can roll back to a specific snapshot when the
- *     freshest is also poisoned.
+ * - The exported type aliases and {@link runBackupRecoverBrain} entry point
+ *   keep importers compiling without source changes.
+ * - The envelope shape (`BackupRecoverBrainResult` with the brain-specific
+ *   three-table row count) is preserved by projecting the generic
+ *   `BackupRecoverResult.rowsRecovered` map into the legacy
+ *   `{ observations, decisions, learnings }` shape.
  *
- * The pipeline itself is NEVER re-implemented here — every code path either
- * delegates to {@link recoverMalformedBrainDb} or to private helpers that
- * mirror its candidate-enumeration logic for the dry-run preview.
+ * Existing brain-only call sites SHOULD migrate to {@link runBackupRecover}
+ * with `role: 'brain'`. Net-new code MUST NOT import from this module.
  *
  * @task T10304
  * @epic T10286
  * @saga T10281
+ * @deprecated since T10318 — call `runBackupRecover({ role: 'brain', ... })` directly.
  */
 
-import { copyFileSync, existsSync, mkdirSync, readdirSync, renameSync, statSync } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
-import type { DatabaseSync } from 'node:sqlite';
 import type { BackupRecoverBrainResult, BrainRecoveredRowCounts } from '@cleocode/contracts';
-import { type RecoveryLogger, recoverMalformedBrainDb } from './recover-brain-db.js';
-import { openNativeDatabase } from './sqlite-native.js';
+import {
+  BackupRecoverError as GenericBackupRecoverError,
+  runBackupRecover,
+} from './backup-recover.js';
+import type { RecoveryLogger } from './recover-malformed-db.js';
 
 // ---------------------------------------------------------------------------
-// Canonical snapshot filename patterns — kept in sync with recover-brain-db.ts
-// ---------------------------------------------------------------------------
-
-/** System-backup snapshot filename (created via `cleo backup add`). */
-const SNAPSHOT_FILENAME_RE = /^brain\.db\.snapshot-(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z)$/;
-
-/** VACUUM INTO snapshot filename (created on session-end hooks). */
-const VACUUM_FILENAME_RE = /^brain-(\d{8})-(\d{6})\.db$/;
-
-/** Legacy pre-T9685 dup-fix backup pattern. */
-const PRE_DUP_FIX_RE = /^brain\.db\.PRE-DUP-FIX-/;
-
-/** Internal candidate record used for planning + pinning. */
-interface SnapshotCandidate {
-  /** Absolute path to the snapshot file. */
-  path: string;
-  /** Best-available timestamp for ordering (epoch ms). */
-  timestampMs: number;
-  /** Source taxonomy — for diagnostic logging only. */
-  source: 'system-snapshot' | 'vacuum-snapshot' | 'pre-dup-fix';
-}
-
-// ---------------------------------------------------------------------------
-// Public API
+// Backward-compat type re-exports
 // ---------------------------------------------------------------------------
 
 /**
+ * Pre-T10318 alias for the now-canonical {@link BackupRecoverError}.
+ *
+ * @deprecated since T10318 — import {@link BackupRecoverError} from
+ * `@cleocode/core/store/backup-recover.js` directly.
+ */
+export { GenericBackupRecoverError as BackupRecoverBrainError };
+
+/**
  * Options accepted by {@link runBackupRecoverBrain}.
+ *
+ * @deprecated since T10318 — use {@link BackupRecoverOptions} from
+ * `@cleocode/core/store/backup-recover.js`.
  */
 export interface BackupRecoverBrainOptions {
   /**
@@ -87,561 +75,80 @@ export interface BackupRecoverBrainOptions {
   dryRun?: boolean;
   /**
    * Optional snapshot pin — either an absolute path to a specific
-   * snapshot file OR an ISO timestamp prefix (e.g. `2026-05-23`) that
-   * resolves to the freshest validated snapshot whose timestamp begins
-   * with that prefix. When unset, the freshest validated candidate wins.
+   * snapshot file OR an ISO timestamp prefix.
    */
   fromSnapshot?: string;
   /**
    * When `true`, skip the future `sqlite3 .recover` delta-merge step.
-   * Reserved for future extension — the current pipeline does not
-   * perform delta-merge because T10300 found schema-page corruption
-   * makes it unreliable. The flag is plumbed end-to-end so the CLI surface
-   * stays stable when delta-merge becomes opt-in.
    */
   noDelta?: boolean;
 }
 
-/**
- * Error thrown when the recovery pre-conditions cannot be satisfied.
- *
- * Distinct from runtime recovery failures (which are reported via the
- * envelope's `integrityOK: false` field) — these errors signal that the
- * CLI cannot even attempt recovery (no snapshots present at all,
- * `fromSnapshot` does not resolve, etc.).
- */
-export class BackupRecoverBrainError extends Error {
-  /** Stable numeric exit code. */
-  readonly code: number;
-  /** Stable string error code for envelope `codeName`. */
-  readonly codeName: string;
-  /** Optional remediation hint surfaced to the operator. */
-  readonly fix?: string;
+// ---------------------------------------------------------------------------
+// Brain → generic envelope projection
+// ---------------------------------------------------------------------------
 
-  /**
-   * @param message  - Human-readable error message.
-   * @param code     - Numeric exit code for the CLI surface.
-   * @param codeName - Stable error code (e.g. `'E_NO_SNAPSHOT'`).
-   * @param fix      - Optional remediation hint.
-   */
-  constructor(message: string, code: number, codeName: string, fix?: string) {
-    super(message);
-    this.name = 'BackupRecoverBrainError';
-    this.code = code;
-    this.codeName = codeName;
-    this.fix = fix;
-  }
+/**
+ * Project the generic per-table `rowsRecovered` map into the brain-specific
+ * `{ observations, decisions, learnings }` shape that callers pre-T10318
+ * relied on.
+ *
+ * @internal
+ */
+function projectBrainRowCounts(
+  rowsRecovered: Readonly<Record<string, number | null>>,
+): BrainRecoveredRowCounts {
+  return {
+    observations:
+      typeof rowsRecovered.brain_observations === 'number'
+        ? rowsRecovered.brain_observations
+        : null,
+    decisions:
+      typeof rowsRecovered.brain_decisions === 'number' ? rowsRecovered.brain_decisions : null,
+    learnings:
+      typeof rowsRecovered.brain_learnings === 'number' ? rowsRecovered.brain_learnings : null,
+  };
 }
 
 /**
  * Run the brain.db recovery pipeline as an operator-facing one-shot.
  *
- * In `dryRun` mode this returns the plan envelope (which snapshot would be
- * picked, where the corrupt DB would be quarantined) without mutating any
- * files on disk.
+ * @remarks
+ * Thin shim over {@link runBackupRecover} with `role='brain'`. Returns the
+ * brain-shaped {@link BackupRecoverBrainResult} envelope by projecting the
+ * generic per-table row map into the legacy three-table shape.
  *
- * In execute mode this delegates to {@link recoverMalformedBrainDb} for the
- * actual quarantine + copy + integrity-check pipeline, then probes the
- * restored DB for per-table row counts to enrich the envelope.
+ * @deprecated since T10318 — call
+ * `runBackupRecover({ role: 'brain', ... })` directly and consume the
+ * generic envelope.
  *
  * @param opts - Recovery inputs (corrupt path, snapshot dirs, mode flags).
- * @returns The recovery envelope (plan or post-mutation).
- * @throws {BackupRecoverBrainError} When pre-conditions fail (no snapshots
- *         at all, `fromSnapshot` cannot be resolved, etc.).
+ * @returns The brain-shaped recovery envelope.
  *
- * @example
- * ```typescript
- * import { runBackupRecoverBrain } from '@cleocode/core/store/backup-recover-brain';
- * import { getLogger } from '@cleocode/core/logger';
- *
- * const result = runBackupRecoverBrain({
- *   corruptPath: '/repo/.cleo/brain.db',
- *   snapshotDir: '/repo/.cleo/backups/snapshot',
- *   vacuumSnapshotDir: '/repo/.cleo/backups/sqlite',
- *   legacyArtifactDir: '/repo/.cleo',
- *   logger: getLogger('backup-recover-brain'),
- *   dryRun: true,
- * });
- * if (!result.integrityOK) {
- *   process.exitCode = 1;
- * }
- * ```
+ * @task T10304
+ * @epic T10286
+ * @saga T10281
  */
 export function runBackupRecoverBrain(opts: BackupRecoverBrainOptions): BackupRecoverBrainResult {
-  if (!opts.corruptPath) {
-    throw new BackupRecoverBrainError('corruptPath is required', 6, 'E_VALIDATION');
-  }
-
-  const candidates = collectSnapshotCandidates(opts);
-  if (candidates.length === 0) {
-    throw new BackupRecoverBrainError(
-      `No snapshots found under ${opts.snapshotDir}` +
-        (opts.vacuumSnapshotDir ? ` or ${opts.vacuumSnapshotDir}` : '') +
-        (opts.legacyArtifactDir ? ` or ${opts.legacyArtifactDir}/brain.db.PRE-DUP-FIX-*` : ''),
-      4,
-      'E_NO_SNAPSHOT',
-      'Run `cleo backup add` to create a snapshot before attempting recovery.',
-    );
-  }
-
-  // Apply `--from-snapshot` filter when provided. The argument is either
-  // an exact absolute path OR an ISO prefix matching the snapshot stamp.
-  const filtered = opts.fromSnapshot
-    ? candidates.filter((c) => snapshotMatchesPin(c, opts.fromSnapshot ?? ''))
-    : candidates;
-
-  if (opts.fromSnapshot && filtered.length === 0) {
-    throw new BackupRecoverBrainError(
-      `Snapshot pin "${opts.fromSnapshot}" matched zero candidates`,
-      4,
-      'E_NO_SNAPSHOT_MATCH',
-      'List available snapshots with `ls .cleo/backups/snapshot/` (or `.cleo/backups/sqlite/`) and supply an exact path or ISO prefix.',
-    );
-  }
-
-  // Probe candidates in freshness order to find the first that quick_checks.
-  const chosen = pickFreshestValidSnapshot(filtered);
-  if (!chosen) {
-    throw new BackupRecoverBrainError(
-      'No candidate snapshot passed PRAGMA quick_check',
-      78,
-      'E_NO_VALID_SNAPSHOT',
-      'Every available snapshot is itself corrupt. Restore from an external backup or use `cleo backup import`.',
-    );
-  }
-
-  const quarantineRoot = opts.quarantineRoot ?? join(dirname(opts.corruptPath), 'quarantine');
-
-  if (opts.dryRun === true) {
-    // Plan envelope — count rows in the chosen snapshot WITHOUT touching disk.
-    const rowsRecovered = probeRowCounts(chosen.path);
-    return {
-      restoredFrom: chosen.path,
-      rowsRecovered,
-      dataLossWindowHours: computeDataLossWindowHours(chosen.timestampMs),
-      integrityOK: true,
-      quarantinedTo: '',
-      dryRun: true,
-    };
-  }
-
-  // Execute mode — delegate to the canonical pipeline. The chokepoint
-  // helper enumerates candidates internally, so we let it pick the same
-  // snapshot it would pick at open time (the candidate ranking is
-  // deterministic). When the operator pinned a snapshot via `fromSnapshot`,
-  // we pre-pre-copy the pinned snapshot path to the canonical home so the
-  // chokepoint's freshness-first selection still wins.
-  if (opts.fromSnapshot) {
-    // Pinning path — quarantine the corrupt DB ourselves, then copy the
-    // pinned snapshot in place. We deliberately avoid re-implementing
-    // recoverMalformedBrainDb's logic by keeping the operations symmetric:
-    // quarantine → copy → verify (same three steps the chokepoint runs).
-    return runPinnedRestore({
-      corruptPath: opts.corruptPath,
-      quarantineRoot,
-      chosen,
-      logger: opts.logger,
-    });
-  }
-
-  // Unpinned path — delegate to the chokepoint helper directly.
-  const result = recoverMalformedBrainDb({
+  const generic = runBackupRecover({
+    role: 'brain',
     corruptPath: opts.corruptPath,
     snapshotDir: opts.snapshotDir,
     vacuumSnapshotDir: opts.vacuumSnapshotDir,
     legacyArtifactDir: opts.legacyArtifactDir,
-    quarantineRoot,
+    quarantineRoot: opts.quarantineRoot,
     logger: opts.logger,
+    dryRun: opts.dryRun,
+    fromSnapshot: opts.fromSnapshot,
+    noDelta: opts.noDelta,
   });
 
-  if (!result.integrityOK || !result.restoredFrom) {
-    throw new BackupRecoverBrainError(
-      'Recovery pipeline completed but restored DB failed integrity check',
-      78,
-      'E_RECOVERY_FAILED',
-      'Inspect the quarantine directory and try `--from-snapshot <iso>` with an older snapshot.',
-    );
-  }
-
-  const rowsRecovered = probeRowCounts(opts.corruptPath);
   return {
-    restoredFrom: result.restoredFrom,
-    rowsRecovered,
-    dataLossWindowHours: result.dataLossWindowHours,
-    integrityOK: result.integrityOK,
-    quarantinedTo: result.quarantineDir ?? '',
-    dryRun: false,
+    restoredFrom: generic.restoredFrom,
+    rowsRecovered: projectBrainRowCounts(generic.rowsRecovered),
+    dataLossWindowHours: generic.dataLossWindowHours,
+    integrityOK: generic.integrityOK,
+    quarantinedTo: generic.quarantinedTo,
+    dryRun: generic.dryRun,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Pinned-restore implementation — mirrors recoverMalformedBrainDb's I/O steps
-// ---------------------------------------------------------------------------
-
-/**
- * Execute a pinned restore: quarantine the corrupt DB, copy the pinned
- * snapshot, verify integrity.
- *
- * Kept symmetric with {@link recoverMalformedBrainDb}'s pipeline so the two
- * paths produce indistinguishable on-disk results.
- *
- * @internal
- */
-function runPinnedRestore(args: {
-  corruptPath: string;
-  quarantineRoot: string;
-  chosen: SnapshotCandidate;
-  logger: RecoveryLogger;
-}): BackupRecoverBrainResult {
-  let quarantineDir = '';
-  try {
-    if (existsSync(args.corruptPath)) {
-      quarantineDir = quarantineCorruptDb(args.corruptPath, args.quarantineRoot);
-    }
-  } catch (err) {
-    args.logger.error(
-      { err, corruptPath: args.corruptPath, quarantineRoot: args.quarantineRoot },
-      'BRAIN pinned recovery aborted: could not quarantine corrupt DB',
-    );
-    throw new BackupRecoverBrainError(
-      `Could not quarantine corrupt DB: ${err instanceof Error ? err.message : String(err)}`,
-      1,
-      'E_QUARANTINE_FAILED',
-    );
-  }
-
-  try {
-    copyFileSync(args.chosen.path, args.corruptPath);
-  } catch (err) {
-    args.logger.error(
-      { err, snapshotPath: args.chosen.path, dest: args.corruptPath },
-      'BRAIN pinned recovery failed: copy from snapshot to live path threw',
-    );
-    throw new BackupRecoverBrainError(
-      `Could not copy snapshot to live path: ${err instanceof Error ? err.message : String(err)}`,
-      1,
-      'E_COPY_FAILED',
-    );
-  }
-
-  // Final verification — probe via the same quick_check helper.
-  if (!probeQuickCheck(args.corruptPath)) {
-    throw new BackupRecoverBrainError(
-      'Pinned snapshot restored but final quick_check failed',
-      78,
-      'E_RECOVERY_FAILED',
-    );
-  }
-
-  const rowsRecovered = probeRowCounts(args.corruptPath);
-  const dataLossWindowHours = computeDataLossWindowHours(args.chosen.timestampMs);
-
-  args.logger.warn(
-    {
-      event: 'brain.pinned-recovery',
-      restoredFrom: args.chosen.path,
-      source: args.chosen.source,
-      dataLossWindowHours,
-      quarantineDir,
-    },
-    `BRAIN pinned recovery completed from ${args.chosen.path} (T10304)`,
-  );
-
-  return {
-    restoredFrom: args.chosen.path,
-    rowsRecovered,
-    dataLossWindowHours,
-    integrityOK: true,
-    quarantinedTo: quarantineDir,
-    dryRun: false,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Snapshot candidate enumeration — kept in sync with recover-brain-db.ts
-// ---------------------------------------------------------------------------
-
-/**
- * Enumerate snapshot candidates and return them newest-first.
- *
- * Mirrors {@link recoverMalformedBrainDb}'s candidate-collection logic but
- * lives separately so dry-run planning does not need to invoke the full
- * pipeline. Any changes to the freshness-ranking algorithm MUST be applied
- * to both files in the same PR.
- *
- * @internal
- */
-function collectSnapshotCandidates(opts: BackupRecoverBrainOptions): SnapshotCandidate[] {
-  const out: SnapshotCandidate[] = [];
-
-  if (existsSync(opts.snapshotDir)) {
-    try {
-      for (const name of readdirSync(opts.snapshotDir)) {
-        const m = SNAPSHOT_FILENAME_RE.exec(name);
-        const stamp = m?.[1];
-        if (!stamp) continue;
-        out.push({
-          path: join(opts.snapshotDir, name),
-          timestampMs: parseSystemSnapshotTimestamp(stamp),
-          source: 'system-snapshot',
-        });
-      }
-    } catch {
-      // unreadable directory — fall through to other sources
-    }
-  }
-
-  if (opts.vacuumSnapshotDir && existsSync(opts.vacuumSnapshotDir)) {
-    try {
-      for (const name of readdirSync(opts.vacuumSnapshotDir)) {
-        const m = VACUUM_FILENAME_RE.exec(name);
-        const datePart = m?.[1];
-        const timePart = m?.[2];
-        if (!datePart || !timePart) continue;
-        out.push({
-          path: join(opts.vacuumSnapshotDir, name),
-          timestampMs: parseVacuumSnapshotTimestamp(datePart, timePart),
-          source: 'vacuum-snapshot',
-        });
-      }
-    } catch {
-      // non-fatal
-    }
-  }
-
-  if (opts.legacyArtifactDir && existsSync(opts.legacyArtifactDir)) {
-    try {
-      for (const name of readdirSync(opts.legacyArtifactDir)) {
-        if (!PRE_DUP_FIX_RE.test(name)) continue;
-        const fullPath = join(opts.legacyArtifactDir, name);
-        let ts = 0;
-        try {
-          ts = statSync(fullPath).mtimeMs;
-        } catch {
-          continue;
-        }
-        out.push({ path: fullPath, timestampMs: ts, source: 'pre-dup-fix' });
-      }
-    } catch {
-      // non-fatal
-    }
-  }
-
-  const rank: Record<SnapshotCandidate['source'], number> = {
-    'system-snapshot': 0,
-    'vacuum-snapshot': 1,
-    'pre-dup-fix': 2,
-  };
-  out.sort((a, b) => {
-    if (b.timestampMs !== a.timestampMs) return b.timestampMs - a.timestampMs;
-    return rank[a.source] - rank[b.source];
-  });
-  return out;
-}
-
-/**
- * Pick the first candidate (newest-first) whose `PRAGMA quick_check` returns
- * `ok`. Returns `null` when no candidate passes.
- *
- * @internal
- */
-function pickFreshestValidSnapshot(candidates: SnapshotCandidate[]): SnapshotCandidate | null {
-  for (const candidate of candidates) {
-    if (probeQuickCheck(candidate.path)) {
-      return candidate;
-    }
-  }
-  return null;
-}
-
-/**
- * Determine whether a candidate matches the operator's `--from-snapshot`
- * pin. Accepts both an exact absolute path and an ISO timestamp prefix.
- *
- * @internal
- */
-function snapshotMatchesPin(candidate: SnapshotCandidate, pin: string): boolean {
-  if (!pin) return false;
-  if (candidate.path === pin) return true;
-  // ISO prefix match against the basename's timestamp portion.
-  const name = basename(candidate.path);
-  const systemMatch = SNAPSHOT_FILENAME_RE.exec(name);
-  if (systemMatch?.[1]) {
-    // Convert dashed ISO back to canonical form for prefix matching:
-    // `2026-05-23T08-00-55-563Z` → `2026-05-23T08:00:55.563Z`.
-    const iso = systemMatch[1].replace(
-      /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
-      '$1T$2:$3:$4.$5Z',
-    );
-    if (iso.startsWith(pin)) return true;
-    if (systemMatch[1].startsWith(pin)) return true;
-  }
-  const vacuumMatch = VACUUM_FILENAME_RE.exec(name);
-  if (vacuumMatch?.[1]?.startsWith(pin)) {
-    return true;
-  }
-  return false;
-}
-
-// ---------------------------------------------------------------------------
-// I/O helpers — kept symmetric with recover-brain-db.ts
-// ---------------------------------------------------------------------------
-
-/**
- * Parse a system-snapshot ISO-with-dashes timestamp into epoch ms.
- *
- * @internal
- */
-function parseSystemSnapshotTimestamp(stamp: string): number {
-  const iso = stamp.replace(
-    /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
-    '$1T$2:$3:$4.$5Z',
-  );
-  const ms = Date.parse(iso);
-  return Number.isNaN(ms) ? 0 : ms;
-}
-
-/**
- * Parse a VACUUM INTO snapshot timestamp (`20260523-130026`) into epoch ms.
- *
- * @internal
- */
-function parseVacuumSnapshotTimestamp(datePart: string, timePart: string): number {
-  const yyyy = Number.parseInt(datePart.slice(0, 4), 10);
-  const mm = Number.parseInt(datePart.slice(4, 6), 10);
-  const dd = Number.parseInt(datePart.slice(6, 8), 10);
-  const hh = Number.parseInt(timePart.slice(0, 2), 10);
-  const mi = Number.parseInt(timePart.slice(2, 4), 10);
-  const ss = Number.parseInt(timePart.slice(4, 6), 10);
-  if ([yyyy, mm, dd, hh, mi, ss].some((n) => Number.isNaN(n))) return 0;
-  return new Date(yyyy, mm - 1, dd, hh, mi, ss).getTime();
-}
-
-/**
- * Probe a candidate file with `PRAGMA quick_check`.
- *
- * @internal
- */
-function probeQuickCheck(path: string): boolean {
-  let handle: DatabaseSync | null = null;
-  try {
-    handle = openNativeDatabase(path, { readonly: true, enableWal: false });
-    const quick = handle.prepare('PRAGMA quick_check').get() as
-      | { quick_check?: string }
-      | undefined;
-    return (quick?.quick_check ?? '') === 'ok';
-  } catch {
-    return false;
-  } finally {
-    if (handle) {
-      try {
-        handle.close();
-      } catch {
-        // non-fatal
-      }
-    }
-  }
-}
-
-/**
- * Probe a DB for per-table row counts. Each count is best-effort — a missing
- * table or count failure surfaces as `null` instead of throwing so the
- * envelope always serializes cleanly.
- *
- * @internal
- */
-function probeRowCounts(path: string): BrainRecoveredRowCounts {
-  const result: BrainRecoveredRowCounts = {
-    observations: null,
-    decisions: null,
-    learnings: null,
-  };
-
-  let handle: DatabaseSync | null = null;
-  try {
-    handle = openNativeDatabase(path, { readonly: true, enableWal: false });
-    for (const [table, key] of [
-      ['brain_observations', 'observations'],
-      ['brain_decisions', 'decisions'],
-      ['brain_learnings', 'learnings'],
-    ] as const) {
-      try {
-        const row = handle.prepare(`SELECT COUNT(*) AS cnt FROM ${table}`).get() as
-          | { cnt?: number }
-          | undefined;
-        if (typeof row?.cnt === 'number') {
-          result[key] = row.cnt;
-        }
-      } catch {
-        // table missing in this snapshot rev — leave the value null
-      }
-    }
-  } catch {
-    // unopenable — leave all counts null
-  } finally {
-    if (handle) {
-      try {
-        handle.close();
-      } catch {
-        // non-fatal
-      }
-    }
-  }
-
-  return result;
-}
-
-/**
- * Compute the data-loss window in hours from a snapshot's epoch-ms
- * timestamp. Returns `null` when the timestamp could not be parsed.
- *
- * @internal
- */
-function computeDataLossWindowHours(timestampMs: number): number | null {
-  if (!timestampMs || timestampMs <= 0) return null;
-  const deltaMs = Date.now() - timestampMs;
-  return Math.max(0, Math.round((deltaMs / 3_600_000) * 10) / 10);
-}
-
-/**
- * Format an epoch-ms timestamp into the canonical quarantine directory
- * name suffix — ISO-8601 with filesystem-safe `-` separators.
- *
- * @internal
- */
-function formatQuarantineSuffix(epochMs: number): string {
-  return new Date(epochMs).toISOString().replace(/[:.]/g, '-');
-}
-
-/**
- * Move the corrupt DB plus `-wal`/`-shm` sidecars into a quarantine directory.
- *
- * Mirrors {@link recoverMalformedBrainDb}'s internal helper of the same name
- * so the pinned-restore path produces identical on-disk results.
- *
- * @internal
- */
-function quarantineCorruptDb(corruptPath: string, quarantineRoot: string): string {
-  const quarantineDir = join(
-    quarantineRoot,
-    `brain-malformed-${formatQuarantineSuffix(Date.now())}`,
-  );
-  mkdirSync(quarantineDir, { recursive: true });
-
-  const dest = join(quarantineDir, 'brain.db.malformed');
-  renameSync(corruptPath, dest);
-
-  for (const suffix of ['-wal', '-shm']) {
-    const sidecarSrc = corruptPath + suffix;
-    if (existsSync(sidecarSrc)) {
-      const sidecarDest = join(quarantineDir, basename(corruptPath) + '.malformed' + suffix);
-      try {
-        renameSync(sidecarSrc, sidecarDest);
-      } catch {
-        // Sidecar move failure is non-fatal
-      }
-    }
-  }
-
-  return quarantineDir;
 }

--- a/packages/core/src/store/backup-recover.ts
+++ b/packages/core/src/store/backup-recover.ts
@@ -1,0 +1,481 @@
+/**
+ * CLI-facing wrapper around the generic {@link recoverMalformedDb} pipeline
+ * (T10318 SG-BRAIN-DB-RESILIENCE E3-BACKUP-RECOVERY).
+ *
+ * Exposes the recovery pipeline to the `cleo backup recover <role>` verb
+ * with three additions that don't belong in the chokepoint module:
+ *
+ *  1. **Dry-run planning** — enumerates snapshot candidates, validates the
+ *     freshest one via `PRAGMA quick_check`, and returns the envelope WITHOUT
+ *     quarantining or copying anything. Operators use this to preview the
+ *     freshness window before pulling the trigger.
+ *  2. **Per-table row counts** — probes user tables post-restore via
+ *     `sqlite_master` enumeration so the runbook surfaces the recovered
+ *     scope for any role (not just brain's three tables).
+ *  3. **Snapshot pinning** — accepts `fromSnapshot` (absolute path or ISO
+ *     prefix) so operators can roll back to a specific snapshot when the
+ *     freshest is also poisoned.
+ *
+ * The pipeline itself is NEVER re-implemented here — every code path
+ * delegates to {@link recoverMalformedDb} or to the shared candidate-
+ * enumeration / probe helpers re-exported from
+ * {@link ./recover-malformed-db.js}.
+ *
+ * @task T10318
+ * @epic T10284
+ * @saga T10281
+ */
+
+import { copyFileSync, existsSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import type { BackupRecoverResult, DbRole } from '@cleocode/contracts';
+import {
+  collectSnapshotCandidatesForRole,
+  probeSnapshot,
+  quarantineCorruptDb,
+  type RecoveryLogger,
+  recoverMalformedDb,
+  resolveRoleBackupDirs,
+  resolveRoleDbPath,
+} from './recover-malformed-db.js';
+
+// ---------------------------------------------------------------------------
+// Internal snapshot candidate shape (mirrors recover-malformed-db.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Snapshot candidate emitted by {@link collectSnapshotCandidatesForRole}.
+ *
+ * @internal
+ */
+interface SnapshotCandidate {
+  path: string;
+  timestampMs: number;
+  source: 'system-snapshot' | 'vacuum-snapshot' | 'pre-dup-fix';
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Options accepted by {@link runBackupRecover}.
+ *
+ * @task T10318
+ * @public
+ */
+export interface BackupRecoverOptions {
+  /** Canonical role to recover. Must exist in `DB_INVENTORY`. */
+  role: DbRole;
+  /**
+   * Absolute path to the corrupt DB file. When omitted, derived from the
+   * inventory entry with `<projectRoot>` substitution.
+   */
+  corruptPath?: string;
+  /**
+   * Absolute path to the project root. Used to resolve inventory templates
+   * for `project`-tier roles. Required when `corruptPath` is not supplied
+   * for a project-tier role.
+   */
+  projectRoot?: string;
+  /** Absolute path to `.cleo/backups/snapshot/` — overrides inventory-derived default. */
+  snapshotDir?: string;
+  /** Absolute path to `.cleo/backups/sqlite/` (VACUUM INTO snapshots) — overrides default. */
+  vacuumSnapshotDir?: string;
+  /** Absolute path to `.cleo/` for legacy `<role>.db.PRE-DUP-FIX-*` fallback — overrides default. */
+  legacyArtifactDir?: string;
+  /**
+   * Absolute path to the quarantine root. Defaults to
+   * `<dirname(corruptPath)>/quarantine` to match the chokepoint helper.
+   */
+  quarantineRoot?: string;
+  /** Pino-shaped logger for the recovery announcement. */
+  logger: RecoveryLogger;
+  /**
+   * When `true`, enumerate candidates + validate the freshest one and
+   * return the planned envelope WITHOUT quarantining or copying.
+   */
+  dryRun?: boolean;
+  /**
+   * Optional snapshot pin — either an absolute path to a specific
+   * snapshot file OR an ISO timestamp prefix (e.g. `2026-05-23`) that
+   * resolves to the freshest validated snapshot whose timestamp begins
+   * with that prefix. When unset, the freshest validated candidate wins.
+   */
+  fromSnapshot?: string;
+  /**
+   * When `true`, skip the future `sqlite3 .recover` delta-merge step.
+   * Reserved for future extension — the current pipeline does not
+   * perform delta-merge.
+   */
+  noDelta?: boolean;
+}
+
+/**
+ * Error thrown when the recovery pre-conditions cannot be satisfied.
+ *
+ * @remarks
+ * Distinct from runtime recovery failures (which are reported via the
+ * envelope's `integrityOK: false` field) — these errors signal that the
+ * CLI cannot even attempt recovery (no snapshots present at all,
+ * `fromSnapshot` does not resolve, etc.).
+ *
+ * @task T10318
+ * @public
+ */
+export class BackupRecoverError extends Error {
+  /** Stable numeric exit code. */
+  readonly code: number;
+  /** Stable string error code for envelope `codeName`. */
+  readonly codeName: string;
+  /** Optional remediation hint surfaced to the operator. */
+  readonly fix?: string;
+
+  /**
+   * @param message  - Human-readable error message.
+   * @param code     - Numeric exit code for the CLI surface.
+   * @param codeName - Stable error code (e.g. `'E_NO_SNAPSHOT'`).
+   * @param fix      - Optional remediation hint.
+   */
+  constructor(message: string, code: number, codeName: string, fix?: string) {
+    super(message);
+    this.name = 'BackupRecoverError';
+    this.code = code;
+    this.codeName = codeName;
+    this.fix = fix;
+  }
+}
+
+/**
+ * Resolve the per-role filesystem layout, merging CLI overrides with
+ * inventory-derived defaults.
+ *
+ * @internal
+ */
+function resolveLayout(opts: BackupRecoverOptions): {
+  corruptPath: string;
+  snapshotDir: string;
+  vacuumSnapshotDir: string;
+  legacyArtifactDir: string;
+  quarantineRoot: string;
+} {
+  const inventoryDirs = resolveRoleBackupDirs(opts.role, { projectRoot: opts.projectRoot });
+  const corruptPath =
+    opts.corruptPath ?? resolveRoleDbPath(opts.role, { projectRoot: opts.projectRoot });
+  return {
+    corruptPath,
+    snapshotDir: opts.snapshotDir ?? inventoryDirs.snapshotDir,
+    vacuumSnapshotDir: opts.vacuumSnapshotDir ?? inventoryDirs.vacuumSnapshotDir,
+    legacyArtifactDir:
+      opts.legacyArtifactDir !== undefined
+        ? opts.legacyArtifactDir
+        : inventoryDirs.legacyArtifactDir,
+    quarantineRoot: opts.quarantineRoot ?? join(dirname(corruptPath), 'quarantine'),
+  };
+}
+
+/**
+ * Determine whether a candidate matches the operator's `--from-snapshot` pin.
+ *
+ * Accepts both an exact absolute path and an ISO timestamp prefix. The ISO
+ * prefix is matched against the canonical (colon/dot) form so operators can
+ * paste timestamps from logs without having to re-encode the filename's
+ * dash-separated form.
+ *
+ * @internal
+ */
+function snapshotMatchesPin(role: DbRole, candidate: SnapshotCandidate, pin: string): boolean {
+  if (!pin) return false;
+  if (candidate.path === pin) return true;
+  const name = basename(candidate.path);
+  // System snapshot: `<role>.db.snapshot-2026-05-23T08-00-55-563Z`.
+  const systemPrefix = `${role}.db.snapshot-`;
+  if (name.startsWith(systemPrefix)) {
+    const stamp = name.slice(systemPrefix.length);
+    if (stamp.startsWith(pin)) return true;
+    const iso = stamp.replace(
+      /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
+      '$1T$2:$3:$4.$5Z',
+    );
+    if (iso.startsWith(pin)) return true;
+  }
+  // Vacuum snapshot: `<role>-20260523-130026.db`.
+  const vacuumPrefix = `${role}-`;
+  if (name.startsWith(vacuumPrefix) && name.endsWith('.db')) {
+    const tail = name.slice(vacuumPrefix.length, -3); // strip ".db"
+    if (tail.startsWith(pin)) return true;
+  }
+  return false;
+}
+
+/**
+ * Pick the first candidate (newest-first) whose `PRAGMA quick_check` returns
+ * `ok`. Returns `null` when no candidate passes.
+ *
+ * @internal
+ */
+function pickFreshestValidSnapshot(candidates: SnapshotCandidate[]): SnapshotCandidate | null {
+  for (const candidate of candidates) {
+    if (probeSnapshot(candidate.path).ok) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Compute the data-loss window in hours from a snapshot's epoch-ms
+ * timestamp. Returns `null` when the timestamp could not be parsed.
+ *
+ * @internal
+ */
+function computeDataLossWindowHours(timestampMs: number): number | null {
+  if (!timestampMs || timestampMs <= 0) return null;
+  const deltaMs = Date.now() - timestampMs;
+  return Math.max(0, Math.round((deltaMs / 3_600_000) * 10) / 10);
+}
+
+/**
+ * Run the database recovery pipeline as an operator-facing one-shot.
+ *
+ * @remarks
+ * In `dryRun` mode this returns the plan envelope (which snapshot would be
+ * picked, where the corrupt DB would be quarantined) without mutating any
+ * files on disk.
+ *
+ * In execute mode this delegates to {@link recoverMalformedDb} for the
+ * actual quarantine + copy + integrity-check pipeline, then probes the
+ * restored DB for per-table row counts to enrich the envelope.
+ *
+ * @param opts - Recovery inputs (role, corrupt path, snapshot dirs, mode flags).
+ * @returns The recovery envelope (plan or post-mutation).
+ * @throws {BackupRecoverError} When pre-conditions fail (no snapshots
+ *         at all, `fromSnapshot` cannot be resolved, etc.).
+ *
+ * @example
+ * ```typescript
+ * import { runBackupRecover } from '@cleocode/core/store/backup-recover';
+ * import { getLogger } from '@cleocode/core/logger';
+ *
+ * const result = runBackupRecover({
+ *   role: 'brain',
+ *   projectRoot: '/repo',
+ *   logger: getLogger('backup-recover'),
+ *   dryRun: true,
+ * });
+ * if (!result.integrityOK) {
+ *   process.exitCode = 1;
+ * }
+ * ```
+ *
+ * @task T10318
+ * @epic T10284
+ * @saga T10281
+ * @public
+ */
+export function runBackupRecover(opts: BackupRecoverOptions): BackupRecoverResult {
+  const layout = resolveLayout(opts);
+
+  const candidates = collectSnapshotCandidatesForRole({
+    role: opts.role,
+    snapshotDir: layout.snapshotDir,
+    vacuumSnapshotDir: layout.vacuumSnapshotDir,
+    legacyArtifactDir: layout.legacyArtifactDir.length > 0 ? layout.legacyArtifactDir : undefined,
+  });
+  if (candidates.length === 0) {
+    throw new BackupRecoverError(
+      `No snapshots found for role "${opts.role}" under ${layout.snapshotDir}` +
+        ` or ${layout.vacuumSnapshotDir}` +
+        (layout.legacyArtifactDir.length > 0
+          ? ` or ${layout.legacyArtifactDir}/${opts.role}.db.PRE-DUP-FIX-*`
+          : ''),
+      4,
+      'E_NO_SNAPSHOT',
+      `Run \`cleo backup add\` to create a snapshot for role "${opts.role}" before attempting recovery.`,
+    );
+  }
+
+  // Apply `--from-snapshot` filter when provided.
+  const filtered = opts.fromSnapshot
+    ? candidates.filter((c) => snapshotMatchesPin(opts.role, c, opts.fromSnapshot ?? ''))
+    : candidates;
+
+  if (opts.fromSnapshot && filtered.length === 0) {
+    throw new BackupRecoverError(
+      `Snapshot pin "${opts.fromSnapshot}" matched zero candidates for role "${opts.role}"`,
+      4,
+      'E_NO_SNAPSHOT_MATCH',
+      'List available snapshots with `ls .cleo/backups/snapshot/` (or `.cleo/backups/sqlite/`) and supply an exact path or ISO prefix.',
+    );
+  }
+
+  const chosen = pickFreshestValidSnapshot(filtered);
+  if (!chosen) {
+    throw new BackupRecoverError(
+      `No candidate snapshot for role "${opts.role}" passed PRAGMA quick_check`,
+      78,
+      'E_NO_VALID_SNAPSHOT',
+      'Every available snapshot is itself corrupt. Restore from an external backup or use `cleo backup import`.',
+    );
+  }
+
+  if (opts.dryRun === true) {
+    // Plan envelope — count rows in the chosen snapshot WITHOUT touching disk.
+    const probe = probeSnapshot(chosen.path);
+    return {
+      role: opts.role,
+      restoredFrom: chosen.path,
+      rowsRecovered: probe.rowCounts,
+      dataLossWindowHours: computeDataLossWindowHours(chosen.timestampMs),
+      integrityOK: probe.ok,
+      quarantinedTo: '',
+      dryRun: true,
+    };
+  }
+
+  // Execute mode.
+  if (opts.fromSnapshot) {
+    // Pinning path — quarantine the corrupt DB ourselves, then copy the
+    // pinned snapshot in place. We deliberately avoid re-implementing
+    // recoverMalformedDb's logic by keeping the operations symmetric:
+    // quarantine → copy → verify (same three steps the chokepoint runs).
+    return runPinnedRestore({
+      role: opts.role,
+      corruptPath: layout.corruptPath,
+      quarantineRoot: layout.quarantineRoot,
+      chosen,
+      logger: opts.logger,
+    });
+  }
+
+  // Unpinned path — delegate to the chokepoint helper directly.
+  const result = recoverMalformedDb({
+    role: opts.role,
+    corruptPath: layout.corruptPath,
+    snapshotDir: layout.snapshotDir,
+    vacuumSnapshotDir: layout.vacuumSnapshotDir,
+    legacyArtifactDir: layout.legacyArtifactDir,
+    quarantineRoot: layout.quarantineRoot,
+    projectRoot: opts.projectRoot,
+    logger: opts.logger,
+  });
+
+  if (!result.integrityOK || !result.restoredFrom) {
+    throw new BackupRecoverError(
+      `Recovery pipeline completed but restored "${opts.role}" DB failed integrity check`,
+      78,
+      'E_RECOVERY_FAILED',
+      'Inspect the quarantine directory and try `--from-snapshot <iso>` with an older snapshot.',
+    );
+  }
+
+  return {
+    role: opts.role,
+    restoredFrom: result.restoredFrom,
+    rowsRecovered: result.rowCounts,
+    dataLossWindowHours: result.dataLossWindowHours,
+    integrityOK: result.integrityOK,
+    quarantinedTo: result.quarantineDir ?? '',
+    dryRun: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pinned-restore implementation — mirrors recoverMalformedDb's I/O steps
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a pinned restore: quarantine the corrupt DB, copy the pinned
+ * snapshot, verify integrity.
+ *
+ * Kept symmetric with {@link recoverMalformedDb}'s pipeline so the two
+ * paths produce indistinguishable on-disk results.
+ *
+ * @internal
+ */
+function runPinnedRestore(args: {
+  role: DbRole;
+  corruptPath: string;
+  quarantineRoot: string;
+  chosen: SnapshotCandidate;
+  logger: RecoveryLogger;
+}): BackupRecoverResult {
+  let quarantineDir = '';
+  try {
+    if (existsSync(args.corruptPath)) {
+      quarantineDir = quarantineCorruptDb(args.role, args.corruptPath, args.quarantineRoot);
+    }
+  } catch (err) {
+    args.logger.error(
+      {
+        err,
+        role: args.role,
+        corruptPath: args.corruptPath,
+        quarantineRoot: args.quarantineRoot,
+      },
+      'CLEO DB pinned recovery aborted: could not quarantine corrupt DB',
+    );
+    throw new BackupRecoverError(
+      `Could not quarantine corrupt DB for role "${args.role}": ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      1,
+      'E_QUARANTINE_FAILED',
+    );
+  }
+
+  try {
+    copyFileSync(args.chosen.path, args.corruptPath);
+  } catch (err) {
+    args.logger.error(
+      {
+        err,
+        role: args.role,
+        snapshotPath: args.chosen.path,
+        dest: args.corruptPath,
+      },
+      'CLEO DB pinned recovery failed: copy from snapshot to live path threw',
+    );
+    throw new BackupRecoverError(
+      `Could not copy snapshot to live path for role "${args.role}": ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      1,
+      'E_COPY_FAILED',
+    );
+  }
+
+  // Final verification — probe via the shared helper.
+  const finalProbe = probeSnapshot(args.corruptPath);
+  if (!finalProbe.ok) {
+    throw new BackupRecoverError(
+      `Pinned snapshot restored but final quick_check failed for role "${args.role}"`,
+      78,
+      'E_RECOVERY_FAILED',
+    );
+  }
+
+  const dataLossWindowHours = computeDataLossWindowHours(args.chosen.timestampMs);
+
+  args.logger.warn(
+    {
+      event: 'cleo-db.pinned-recovery',
+      role: args.role,
+      restoredFrom: args.chosen.path,
+      source: args.chosen.source,
+      dataLossWindowHours,
+      quarantineDir,
+    },
+    `CLEO DB "${args.role}" pinned recovery completed from ${args.chosen.path} (T10318)`,
+  );
+
+  return {
+    role: args.role,
+    restoredFrom: args.chosen.path,
+    rowsRecovered: finalProbe.rowCounts,
+    dataLossWindowHours,
+    integrityOK: true,
+    quarantinedTo: quarantineDir,
+    dryRun: false,
+  };
+}

--- a/packages/core/src/store/recover-malformed-db.ts
+++ b/packages/core/src/store/recover-malformed-db.ts
@@ -1,0 +1,714 @@
+/**
+ * Generic CLEO database auto-recovery pipeline — generalised from the
+ * brain-only T10303 helper (`recoverMalformedBrainDb`) so the same flow
+ * works for every DB declared in {@link DB_INVENTORY}.
+ *
+ * Mirrors the EXACT semantics of {@link recoverMalformedBrainDb}:
+ *
+ * 1. Move the corrupt DB (plus `-wal` / `-shm` sidecars) to
+ *    `<cleoDir>/quarantine/<role>-malformed-<iso>/`.
+ * 2. Enumerate snapshot candidates from three sources:
+ *    - `<cleoDir>/backups/snapshot/<role>.db.snapshot-*` (system-backup format)
+ *    - `<cleoDir>/backups/sqlite/<role>-YYYYMMDD-HHmmss.db` (VACUUM INTO format)
+ *    - `<cleoDir>/<role>.db.PRE-DUP-FIX-*` (legacy artifact fallback)
+ *    Sort newest-first.
+ * 3. Validate each candidate via `PRAGMA quick_check` (best-effort, with
+ *    sqlite-internal busy timeout). Pick the freshest one that returns `ok`.
+ * 4. `copyFileSync` the chosen source to the canonical DB path and run one
+ *    final `quick_check` to confirm the restored file opens cleanly.
+ *
+ * The role is sourced from {@link DB_INVENTORY} via {@link getRoleConfig} —
+ * the inventory is the SSoT for which DBs exist and where they live.
+ *
+ * @task T10318
+ * @epic T10284
+ * @saga T10281
+ * @adr ADR-068
+ */
+
+import { copyFileSync, existsSync, mkdirSync, readdirSync, renameSync, statSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import {
+  DB_INVENTORY,
+  type DbInventoryEntry,
+  type DbRecoveredRowCounts,
+  type DbRecoveryResult,
+  type DbRole,
+} from '@cleocode/contracts';
+import { getCleoHome } from '@cleocode/paths';
+import { openNativeDatabase } from './sqlite-native.js';
+
+/**
+ * Minimal logger shape used by {@link recoverMalformedDb}.
+ *
+ * Matches the subset of `pino.Logger` invoked from this module. Declared
+ * locally so the recovery pipeline does not pull `pino` into modules that
+ * use it strictly as a value type.
+ *
+ * @task T10318
+ * @public
+ */
+export interface RecoveryLogger {
+  /** Structured warning — used for the single auto-recovery announcement. */
+  warn(obj: Record<string, unknown>, msg: string): void;
+  /** Structured error — used for non-fatal probe failures. */
+  error(obj: Record<string, unknown>, msg: string): void;
+}
+
+/**
+ * Options accepted by {@link recoverMalformedDb}.
+ *
+ * @task T10318
+ * @public
+ */
+export interface RecoverMalformedDbOptions {
+  /** Canonical role of the database to recover. Must exist in {@link DB_INVENTORY}. */
+  role: DbRole;
+  /**
+   * Absolute path to the corrupt DB file. When omitted, derived from the
+   * inventory entry's `filePathTemplate` with {@link projectRoot} substitution.
+   */
+  corruptPath?: string;
+  /**
+   * Absolute path to the snapshot directory (`.cleo/backups/snapshot/`).
+   * When omitted, derived from the inventory tier + {@link projectRoot}.
+   */
+  snapshotDir?: string;
+  /**
+   * Absolute path to the VACUUM-INTO snapshot directory
+   * (`.cleo/backups/sqlite/`). When omitted, derived from inventory tier +
+   * {@link projectRoot}.
+   */
+  vacuumSnapshotDir?: string;
+  /**
+   * Absolute path to the legacy artifact directory (`.cleo/` itself) used
+   * for `<role>.db.PRE-DUP-FIX-*` fallback enumeration. When omitted,
+   * derived from inventory tier + {@link projectRoot}. Pass an empty
+   * string to disable legacy fallback entirely.
+   */
+  legacyArtifactDir?: string;
+  /**
+   * Absolute path to the quarantine root. Defaults to
+   * `<dirname(corruptPath)>/quarantine`.
+   */
+  quarantineRoot?: string;
+  /**
+   * Absolute path to the project root used when resolving inventory paths.
+   * Required when {@link corruptPath} is not supplied for a `project`-tier
+   * role; ignored for `global`-tier roles whose paths resolve via
+   * `getCleoHome()`.
+   */
+  projectRoot?: string;
+  /** Pino-shaped logger for the single recovery announcement. */
+  logger: RecoveryLogger;
+}
+
+/** Source taxonomy for a snapshot candidate — diagnostic only. */
+type SnapshotSource = 'system-snapshot' | 'vacuum-snapshot' | 'pre-dup-fix';
+
+/** Internal candidate record used during snapshot ranking. */
+interface SnapshotCandidate {
+  /** Absolute path to the snapshot file. */
+  path: string;
+  /** Best-available timestamp for ordering (epoch ms). */
+  timestampMs: number;
+  /** Source taxonomy — for diagnostic logging only. */
+  source: SnapshotSource;
+}
+
+/** Result of a single snapshot probe via `PRAGMA quick_check`. */
+interface ProbeResult {
+  /** `true` when the file opens cleanly and `quick_check` returns `ok`. */
+  ok: boolean;
+  /** Best-effort per-table row counts in the probed DB. */
+  rowCounts: DbRecoveredRowCounts;
+}
+
+// ---------------------------------------------------------------------------
+// Inventory + path resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up an inventory entry by role.
+ *
+ * @internal
+ */
+function getRoleConfig(role: DbRole): DbInventoryEntry {
+  const entry = DB_INVENTORY.find((e) => e.role === role);
+  if (!entry) {
+    throw new Error(`Unknown DB role "${role}" — not present in DB_INVENTORY`);
+  }
+  return entry;
+}
+
+/**
+ * Substitute path tokens in an inventory `filePathTemplate`.
+ *
+ * @remarks
+ * Recognised tokens today:
+ * - `<projectRoot>` — substituted from {@link projectRoot}.
+ * - `$XDG_DATA_HOME/cleo` — substituted from {@link getCleoHome}().
+ *
+ * @internal
+ */
+function substitutePathTokens(template: string, projectRoot: string | undefined): string {
+  let out = template;
+  if (out.includes('<projectRoot>')) {
+    if (!projectRoot) {
+      throw new Error(
+        `Inventory template "${template}" requires <projectRoot> but none was supplied`,
+      );
+    }
+    out = out.replace(/<projectRoot>/g, projectRoot);
+  }
+  if (out.includes('$XDG_DATA_HOME/cleo')) {
+    out = out.replace(/\$XDG_DATA_HOME\/cleo/g, getCleoHome());
+  }
+  return out;
+}
+
+/**
+ * Resolve the canonical filesystem path for a role's DB file.
+ *
+ * @remarks
+ * Substitutes the inventory's `filePathTemplate` tokens. The two tokens
+ * recognised today are `<projectRoot>` and `$XDG_DATA_HOME/cleo` (the latter
+ * resolves via env-paths through `getCleoHome()`). For project-tier roles,
+ * pass {@link projectRoot}. For global-tier roles, the resolver uses
+ * `getCleoHome()` directly.
+ *
+ * Lives in this module rather than `@cleocode/paths` because resolution is
+ * SSoT-aware (driven by {@link DB_INVENTORY}) and recovery is the only
+ * consumer today. Promote upward when a second consumer appears.
+ *
+ * @task T10318
+ * @public
+ */
+export function resolveRoleDbPath(role: DbRole, ctx: { projectRoot?: string }): string {
+  const entry = getRoleConfig(role);
+  return substitutePathTokens(entry.filePathTemplate, ctx.projectRoot);
+}
+
+/**
+ * Resolve the canonical `.cleo/backups/snapshot/` and `.cleo/backups/sqlite/`
+ * dirs for a role's filesystem layout.
+ *
+ * @remarks
+ * For `project`-tier roles these resolve to
+ * `<projectRoot>/.cleo/backups/{snapshot,sqlite}`. For `global`-tier roles
+ * they resolve to `$XDG_DATA_HOME/cleo/backups/{snapshot,sqlite}`. The
+ * legacy artifact directory mirrors the parent `.cleo/` (project) or
+ * `cleo/` (global) home for `<role>.db.PRE-DUP-FIX-*` enumeration.
+ *
+ * @task T10318
+ * @public
+ */
+export function resolveRoleBackupDirs(
+  role: DbRole,
+  ctx: { projectRoot?: string },
+): {
+  /** Absolute path to the canonical DB home (parent directory of the DB file). */
+  cleoDir: string;
+  /** Absolute path to `<cleoDir>/backups/snapshot/`. */
+  snapshotDir: string;
+  /** Absolute path to `<cleoDir>/backups/sqlite/`. */
+  vacuumSnapshotDir: string;
+  /** Absolute path to `<cleoDir>` itself — for legacy PRE-DUP-FIX enumeration. */
+  legacyArtifactDir: string;
+  /** Absolute path to `<cleoDir>/quarantine/` — the quarantine root. */
+  quarantineRoot: string;
+} {
+  const dbPath = resolveRoleDbPath(role, ctx);
+  const cleoDir = dirname(dbPath);
+  return {
+    cleoDir,
+    snapshotDir: join(cleoDir, 'backups', 'snapshot'),
+    vacuumSnapshotDir: join(cleoDir, 'backups', 'sqlite'),
+    legacyArtifactDir: cleoDir,
+    quarantineRoot: join(cleoDir, 'quarantine'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot filename patterns — parameterised by role
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape a string for safe use inside a `RegExp` literal segment.
+ *
+ * @internal
+ */
+function escapeRegExpLiteral(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Build the per-role snapshot filename regex (matches
+ * `<role>.db.snapshot-2026-05-23T08-00-55-563Z`).
+ *
+ * @internal
+ */
+function buildSystemSnapshotRegex(role: DbRole): RegExp {
+  return new RegExp(
+    `^${escapeRegExpLiteral(role)}\\.db\\.snapshot-(\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}-\\d{3}Z)$`,
+  );
+}
+
+/**
+ * Build the per-role VACUUM-INTO snapshot filename regex (matches
+ * `<role>-20260523-130026.db`).
+ *
+ * @internal
+ */
+function buildVacuumSnapshotRegex(role: DbRole): RegExp {
+  return new RegExp(`^${escapeRegExpLiteral(role)}-(\\d{8})-(\\d{6})\\.db$`);
+}
+
+/**
+ * Build the per-role legacy PRE-DUP-FIX regex (matches
+ * `<role>.db.PRE-DUP-FIX-*`).
+ *
+ * @internal
+ */
+function buildPreDupFixRegex(role: DbRole): RegExp {
+  return new RegExp(`^${escapeRegExpLiteral(role)}\\.db\\.PRE-DUP-FIX-`);
+}
+
+// ---------------------------------------------------------------------------
+// Timestamp parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a snapshot ISO-with-dashes timestamp into epoch ms.
+ *
+ * @internal
+ */
+function parseSystemSnapshotTimestamp(stamp: string): number {
+  const iso = stamp.replace(
+    /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
+    '$1T$2:$3:$4.$5Z',
+  );
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? 0 : ms;
+}
+
+/**
+ * Parse a VACUUM INTO snapshot timestamp (`20260523-130026`) into epoch ms.
+ *
+ * @internal
+ */
+function parseVacuumSnapshotTimestamp(datePart: string, timePart: string): number {
+  const yyyy = Number.parseInt(datePart.slice(0, 4), 10);
+  const mm = Number.parseInt(datePart.slice(4, 6), 10);
+  const dd = Number.parseInt(datePart.slice(6, 8), 10);
+  const hh = Number.parseInt(timePart.slice(0, 2), 10);
+  const mi = Number.parseInt(timePart.slice(2, 4), 10);
+  const ss = Number.parseInt(timePart.slice(4, 6), 10);
+  if ([yyyy, mm, dd, hh, mi, ss].some((n) => Number.isNaN(n))) return 0;
+  return new Date(yyyy, mm - 1, dd, hh, mi, ss).getTime();
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot enumeration + probing
+// ---------------------------------------------------------------------------
+
+/**
+ * Enumerate all snapshot candidates for a role from system-snapshot,
+ * vacuum-snapshot, and PRE-DUP-FIX legacy sources. Returns newest-first.
+ *
+ * @internal
+ */
+export function collectSnapshotCandidatesForRole(opts: {
+  role: DbRole;
+  snapshotDir?: string;
+  vacuumSnapshotDir?: string;
+  legacyArtifactDir?: string;
+}): SnapshotCandidate[] {
+  const out: SnapshotCandidate[] = [];
+  const systemRe = buildSystemSnapshotRegex(opts.role);
+  const vacuumRe = buildVacuumSnapshotRegex(opts.role);
+  const preDupFixRe = buildPreDupFixRegex(opts.role);
+
+  // 1. System-backup snapshots.
+  if (opts.snapshotDir) {
+    try {
+      if (existsSync(opts.snapshotDir)) {
+        for (const name of readdirSync(opts.snapshotDir)) {
+          const m = systemRe.exec(name);
+          const stamp = m?.[1];
+          if (!stamp) continue;
+          out.push({
+            path: join(opts.snapshotDir, name),
+            timestampMs: parseSystemSnapshotTimestamp(stamp),
+            source: 'system-snapshot',
+          });
+        }
+      }
+    } catch {
+      // non-fatal — directory unreadable, continue to other sources
+    }
+  }
+
+  // 2. VACUUM INTO debounced snapshots.
+  if (opts.vacuumSnapshotDir) {
+    try {
+      if (existsSync(opts.vacuumSnapshotDir)) {
+        for (const name of readdirSync(opts.vacuumSnapshotDir)) {
+          const m = vacuumRe.exec(name);
+          const datePart = m?.[1];
+          const timePart = m?.[2];
+          if (!datePart || !timePart) continue;
+          out.push({
+            path: join(opts.vacuumSnapshotDir, name),
+            timestampMs: parseVacuumSnapshotTimestamp(datePart, timePart),
+            source: 'vacuum-snapshot',
+          });
+        }
+      }
+    } catch {
+      // non-fatal
+    }
+  }
+
+  // 3. Legacy PRE-DUP-FIX artifacts.
+  if (opts.legacyArtifactDir) {
+    try {
+      if (existsSync(opts.legacyArtifactDir)) {
+        for (const name of readdirSync(opts.legacyArtifactDir)) {
+          if (!preDupFixRe.test(name)) continue;
+          const fullPath = join(opts.legacyArtifactDir, name);
+          let ts = 0;
+          try {
+            ts = statSync(fullPath).mtimeMs;
+          } catch {
+            continue;
+          }
+          out.push({ path: fullPath, timestampMs: ts, source: 'pre-dup-fix' });
+        }
+      }
+    } catch {
+      // non-fatal
+    }
+  }
+
+  // Newest first. Stable secondary sort by source ranking when timestamps tie
+  // (system > vacuum > pre-dup-fix) so the freshest *promoted* artifact wins.
+  const rank: Record<SnapshotSource, number> = {
+    'system-snapshot': 0,
+    'vacuum-snapshot': 1,
+    'pre-dup-fix': 2,
+  };
+  out.sort((a, b) => {
+    if (b.timestampMs !== a.timestampMs) return b.timestampMs - a.timestampMs;
+    return rank[a.source] - rank[b.source];
+  });
+  return out;
+}
+
+/**
+ * Enumerate user-table names in a DB via `sqlite_master`, excluding internal
+ * `sqlite_*` tables and Drizzle journal tables.
+ *
+ * @internal
+ */
+function enumerateUserTables(handle: DatabaseSync): string[] {
+  try {
+    const rows = handle
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '__drizzle_%' ORDER BY name`,
+      )
+      .all() as Array<{ name?: unknown }>;
+    const out: string[] = [];
+    for (const row of rows) {
+      if (typeof row.name === 'string' && row.name.length > 0) {
+        out.push(row.name);
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Probe a candidate snapshot file by opening it read-only and running
+ * `PRAGMA quick_check`. Returns `{ ok: true, rowCounts }` only when the
+ * database opens cleanly and `quick_check` returns `ok`.
+ *
+ * The handle is always closed before this function returns.
+ *
+ * @internal
+ */
+export function probeSnapshot(path: string): ProbeResult {
+  let handle: DatabaseSync | null = null;
+  try {
+    handle = openNativeDatabase(path, { readonly: true, enableWal: false });
+
+    const quick = handle.prepare('PRAGMA quick_check').get() as
+      | { quick_check?: string }
+      | undefined;
+    const result = quick?.quick_check ?? '';
+    if (result !== 'ok') {
+      return { ok: false, rowCounts: {} };
+    }
+
+    // Best-effort per-table row counts. We enumerate user tables via
+    // sqlite_master and count each — any failure surfaces as null in the
+    // record. The empty record `{}` is reserved for cases where the DB has
+    // no user tables (or sqlite_master itself fails).
+    const tables = enumerateUserTables(handle);
+    const rowCounts: Record<string, number | null> = {};
+    for (const table of tables) {
+      try {
+        // Identifier validated against sqlite_master enumeration; safe to embed.
+        const row = handle.prepare(`SELECT COUNT(*) AS cnt FROM "${table}"`).get() as
+          | { cnt?: number }
+          | undefined;
+        rowCounts[table] = typeof row?.cnt === 'number' ? row.cnt : null;
+      } catch {
+        rowCounts[table] = null;
+      }
+    }
+
+    return { ok: true, rowCounts };
+  } catch {
+    return { ok: false, rowCounts: {} };
+  } finally {
+    if (handle) {
+      try {
+        handle.close();
+      } catch {
+        // close errors are non-fatal; handle is terminal anyway
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Quarantine
+// ---------------------------------------------------------------------------
+
+/**
+ * Format an epoch-ms timestamp into the canonical quarantine directory
+ * name suffix — ISO-8601 with filesystem-safe `-` separators.
+ *
+ * @internal
+ */
+function formatQuarantineSuffix(epochMs: number): string {
+  return new Date(epochMs).toISOString().replace(/[:.]/g, '-');
+}
+
+/**
+ * Move the corrupt DB and its `-wal`/`-shm` sidecars into a quarantine
+ * directory. Returns the absolute path to the quarantine directory.
+ *
+ * Uses `renameSync` (atomic on same-filesystem) — falls back to
+ * `copyFileSync` + unlink when rename crosses filesystems. We don't bother
+ * detecting cross-fs explicitly; `renameSync` returns EXDEV in that case
+ * which we catch as a recovery failure and the caller surfaces it.
+ *
+ * @internal
+ */
+export function quarantineCorruptDb(
+  role: DbRole,
+  corruptPath: string,
+  quarantineRoot: string,
+): string {
+  const quarantineDir = join(
+    quarantineRoot,
+    `${role}-malformed-${formatQuarantineSuffix(Date.now())}`,
+  );
+  mkdirSync(quarantineDir, { recursive: true });
+
+  const dest = join(quarantineDir, `${basename(corruptPath)}.malformed`);
+  renameSync(corruptPath, dest);
+
+  // Move sidecars too — their state matters for any forensic post-mortem.
+  for (const suffix of ['-wal', '-shm']) {
+    const sidecarSrc = corruptPath + suffix;
+    if (existsSync(sidecarSrc)) {
+      const sidecarDest = join(quarantineDir, basename(corruptPath) + '.malformed' + suffix);
+      try {
+        renameSync(sidecarSrc, sidecarDest);
+      } catch {
+        // Sidecar move failure is non-fatal — the main file is already gone.
+      }
+    }
+  }
+
+  return quarantineDir;
+}
+
+/**
+ * Try each candidate snapshot in newest-first order and return the first
+ * one that probes clean.
+ *
+ * @internal
+ */
+function pickFreshestValidSnapshot(
+  candidates: SnapshotCandidate[],
+  logger: RecoveryLogger,
+): { candidate: SnapshotCandidate; probe: ProbeResult } | null {
+  for (const candidate of candidates) {
+    const probe = probeSnapshot(candidate.path);
+    if (probe.ok) {
+      return { candidate, probe };
+    }
+    logger.error(
+      { snapshotPath: candidate.path, source: candidate.source },
+      'CLEO DB snapshot failed PRAGMA quick_check; trying next-freshest',
+    );
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Recover a malformed CLEO database by quarantining the corrupt file and
+ * restoring the freshest validated snapshot.
+ *
+ * @remarks
+ * Synchronous by design — recovery may run on the open-blocking critical
+ * path (e.g. brain.db auto-recovery in {@link memory-sqlite.ts}). Restoration
+ * is short (a few seconds) and the alternative is broken behavior.
+ *
+ * NEVER throws on a recoverable path; instead returns a structured
+ * {@link DbRecoveryResult} where `restoredFrom === null` and
+ * `integrityOK === false` indicate complete failure. The caller surfaces
+ * that case to the operator. Throws only on programmer-error inputs (e.g.
+ * unknown role, missing `projectRoot` for a project-tier role with no
+ * explicit `corruptPath`).
+ *
+ * @param opts - Recovery inputs.
+ * @returns The {@link DbRecoveryResult} envelope.
+ *
+ * @example
+ * ```typescript
+ * import { recoverMalformedDb } from '@cleocode/core/store/recover-malformed-db';
+ * import { getLogger } from '@cleocode/core/logger';
+ *
+ * const result = recoverMalformedDb({
+ *   role: 'brain',
+ *   projectRoot: '/repo',
+ *   logger: getLogger('brain-recover'),
+ * });
+ * if (result.integrityOK) {
+ *   // Retry the open.
+ * }
+ * ```
+ *
+ * @task T10318
+ * @epic T10284
+ * @saga T10281
+ * @public
+ */
+export function recoverMalformedDb(opts: RecoverMalformedDbOptions): DbRecoveryResult {
+  // Validate role + resolve canonical paths via the inventory SSoT.
+  const inventoryDirs = resolveRoleBackupDirs(opts.role, { projectRoot: opts.projectRoot });
+  const corruptPath =
+    opts.corruptPath ?? resolveRoleDbPath(opts.role, { projectRoot: opts.projectRoot });
+  const snapshotDir = opts.snapshotDir ?? inventoryDirs.snapshotDir;
+  const vacuumSnapshotDir = opts.vacuumSnapshotDir ?? inventoryDirs.vacuumSnapshotDir;
+  const legacyArtifactDir =
+    opts.legacyArtifactDir !== undefined ? opts.legacyArtifactDir : inventoryDirs.legacyArtifactDir;
+  const quarantineRoot = opts.quarantineRoot ?? join(dirname(corruptPath), 'quarantine');
+
+  const result: DbRecoveryResult = {
+    role: opts.role,
+    restoredFrom: null,
+    dataLossWindowHours: null,
+    rowCounts: {},
+    integrityOK: false,
+    quarantineDir: null,
+  };
+
+  // 1. Move the corrupt DB into quarantine. Errors here are fatal to the
+  //    recovery path because we cannot safely write a restored file on top
+  //    of a corrupt one that might still hold file descriptors.
+  try {
+    if (existsSync(corruptPath)) {
+      result.quarantineDir = quarantineCorruptDb(opts.role, corruptPath, quarantineRoot);
+    }
+  } catch (err) {
+    opts.logger.error(
+      { err, role: opts.role, corruptPath, quarantineRoot },
+      'CLEO DB auto-recovery aborted: could not quarantine corrupt DB',
+    );
+    return result;
+  }
+
+  // 2. Enumerate candidates and pick the freshest validated one.
+  const candidates = collectSnapshotCandidatesForRole({
+    role: opts.role,
+    snapshotDir,
+    vacuumSnapshotDir,
+    legacyArtifactDir: legacyArtifactDir.length > 0 ? legacyArtifactDir : undefined,
+  });
+  const chosen = pickFreshestValidSnapshot(candidates, opts.logger);
+  if (!chosen) {
+    opts.logger.error(
+      { role: opts.role, corruptPath, candidates: candidates.length },
+      'CLEO DB auto-recovery failed: no validated snapshot found across system/vacuum/legacy sources',
+    );
+    return result;
+  }
+
+  // 3. Restore via copyFileSync. The destination is the original DB path.
+  //    node:sqlite has not opened the file yet (we quarantined it), so a
+  //    raw copy is safe — no WAL/SHM exists at this point.
+  try {
+    copyFileSync(chosen.candidate.path, corruptPath);
+  } catch (err) {
+    opts.logger.error(
+      { err, role: opts.role, snapshotPath: chosen.candidate.path, dest: corruptPath },
+      'CLEO DB auto-recovery failed: copy from snapshot to live path threw',
+    );
+    return result;
+  }
+
+  // 4. Final verification — open the restored file readonly and quick_check it.
+  const finalProbe = probeSnapshot(corruptPath);
+  if (!finalProbe.ok) {
+    opts.logger.error(
+      { role: opts.role, restoredFrom: chosen.candidate.path, dest: corruptPath },
+      'CLEO DB auto-recovery failed: restored DB still fails PRAGMA quick_check',
+    );
+    return result;
+  }
+
+  // 5. Compose the result envelope.
+  result.restoredFrom = chosen.candidate.path;
+  result.integrityOK = true;
+  result.rowCounts = finalProbe.rowCounts;
+
+  if (chosen.candidate.timestampMs > 0) {
+    const deltaMs = Date.now() - chosen.candidate.timestampMs;
+    result.dataLossWindowHours = Math.max(0, Math.round((deltaMs / 3_600_000) * 10) / 10);
+  }
+
+  const isoStamp =
+    chosen.candidate.timestampMs > 0
+      ? new Date(chosen.candidate.timestampMs).toISOString()
+      : 'unknown';
+  const windowLabel =
+    result.dataLossWindowHours !== null ? `~${result.dataLossWindowHours}h` : 'unknown';
+
+  opts.logger.warn(
+    {
+      event: 'cleo-db.auto-recovery',
+      role: opts.role,
+      restoredFrom: chosen.candidate.path,
+      source: chosen.candidate.source,
+      dataLossWindowHours: result.dataLossWindowHours,
+      rowCounts: result.rowCounts,
+      quarantineDir: result.quarantineDir,
+    },
+    `CLEO DB "${opts.role}" auto-recovered from snapshot ${isoStamp}; ${windowLabel} of data may be lost (T10318)`,
+  );
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Generalises the brain-only recovery pipeline (T10303 + T10304) so the same
flow handles every role declared in `DB_INVENTORY`. The brain-specific
`cleo backup recover brain` verb is preserved as a backward-compat alias
and the underlying `recoverMalformedBrainDb` chokepoint helper used by
the memory-sqlite auto-recovery path is untouched.

## Surface

- `cleo backup recover <role>` — new generic CLI that accepts any role
  from `DB_INVENTORY` (tasks, brain, conduit, manifest, llmtxt, nexus,
  signaldock-{project,global}, telemetry, skills, global-{brain,tasks}).
- `cleo backup recover brain` — kept as an explicit subcommand
  (backward compat); internally delegates to the same shared executor.

## New core helpers

- `recoverMalformedDb({ role, projectRoot, ... })` in
  `packages/core/src/store/recover-malformed-db.ts` — quarantine +
  snapshot enumeration + freshness ranking + restore + verify.
- `runBackupRecover({ role, ... })` in
  `packages/core/src/store/backup-recover.ts` — operator-facing wrapper
  with dry-run planning, snapshot pinning via `--from-snapshot`, and
  per-table row counts via `sqlite_master` enumeration.
- `resolveRoleDbPath` / `resolveRoleBackupDirs` — inventory-driven path
  resolution via `@cleocode/paths::getCleoHome()` + `<projectRoot>` token
  substitution.

## New contracts

`packages/contracts/src/db-recovery.ts`:
- `DbRecoveryResult` — generalised envelope carrying `role: DbRole`
  and `rowCounts: Record<string, number | null>`.
- `BackupRecoverResult` — CLI envelope wrapper with `dryRun`,
  `quarantinedTo`, `dataLossWindowHours`.
- `DbRecoveredRowCounts` — readonly per-table count map.

## Backward compatibility

- `recoverMalformedBrainDb` (T10303) untouched — memory-sqlite chokepoint
  open path keeps working.
- `runBackupRecoverBrain` is now a `@deprecated` shim that delegates to
  `runBackupRecover` and projects the generic row-count map back into
  the legacy `BrainRecoveredRowCounts` `{ observations, decisions,
  learnings }` shape. Existing brain CLI envelopes serialise identically.

## Saga linkage

Closes T10318. Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10284
E3-BACKUP-RECOVERY.

## Test plan

- [x] `pnpm biome check --write .` — passes
- [x] `pnpm run build` — full monorepo build green
- [x] `pnpm run typecheck` — full monorepo typecheck green
- [x] Existing `recover-brain-db.test.ts` + `auto-recovery-chokepoint.test.ts`
  unmodified — exercise the unchanged T10303 chokepoint helper.
- [x] `backup-recover.test.ts` rewritten to mock the new
  `runBackupRecover` entry point; covers backward-compat brain leaf and
  the new generic `<role>` surface, including E_VALIDATION /
  E_UNKNOWN_ROLE paths.
- [ ] CI green