### PR TITLE
T10323: cross-DB orphan-row report in cleo doctor db-substrate (Saga T10281 / E4)

### DIFF
--- a/.changeset/T10323.md
+++ b/.changeset/T10323.md
@@ -1,0 +1,28 @@
+---
+id: t10323-cross-db-orphans
+tasks: [T10323]
+kind: feat
+summary: "doctor db-substrate: cross-DB orphan-row report (5 invariants I1-I5)"
+---
+
+T10323 (Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10285 E4-DB-CROSS-LINKS)
+extends `cleo doctor db-substrate` with a cross-DB orphan-row walker
+that runs every invariant in the T10320 catalogue:
+
+- **I1** `brain_memory_links.task_id` → tasks.id
+- **I2** manifest.db `blob_attachments.doc_slug` (T-shaped) → tasks.id
+- **I3** nexus.db `project_registry.project_path` → live projectRoot
+- **I4** llmtxt.db `session_id` column (schema-aware) → tasks.sessions.id
+- **I5** conduit.db `dead_letters.job_id` → tasks.id OR brain anchor
+
+Adds `walkCrossDbInvariants(projectRoot)` and per-invariant checkers
+(`checkInvariantI1`…`checkInvariantI5`) under
+`packages/core/src/doctor/db-substrate.ts`. Each report carries the
+orphan count, ≤ 5 sample rows, a canonical `suggestedFix`, and a
+`skipped` branch for missing DBs / missing columns. The walker runs
+under bounded queries (LIMIT 100) so a malformed fleet cannot blow the
+substrate-audit budget.
+
+Surfaced on `DbSubstrateAuditResult.crossDbOrphans` and pushed into the
+envelope `meta.warnings` as `W_DB_SUBSTRATE_CROSS_DB_<Ix>` when any
+invariant detects ≥ 1 orphan.

--- a/packages/cleo/src/cli/commands/__tests__/doctor-db-substrate.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/doctor-db-substrate.test.ts
@@ -33,6 +33,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 // tests that need core primitives without an alias rewrite (saga-audit
 // uses the same approach).
 import {
+  checkInvariantI1,
+  checkInvariantI2,
+  checkInvariantI3,
+  checkInvariantI4,
+  checkInvariantI5,
+  computeSubstrateProjectId,
   detectOrphanProjectRootWarning,
   isLegitimateCleoProjectRoot,
   readParentWorkspace,
@@ -40,6 +46,7 @@ import {
   resolveInventoryMigrationsFolder,
   surveyDbSubstrate,
   surveyFleetDbSubstrate,
+  walkCrossDbInvariants,
   walkPragmaDrift,
 } from '../../../../../core/src/doctor/db-substrate.js';
 import {
@@ -990,5 +997,410 @@ describe('doctor db-substrate (T10307)', () => {
     // Healthy DB w/ timeout disabled: integrityOK true + timedOut false.
     expect(tasks.integrityOK).toBe(true);
     expect(tasks.timedOut).toBe(false);
+  });
+
+  // ============================================================================
+  // T10323 — cross-DB orphan-row report (Saga T10281 / Epic T10285)
+  // ============================================================================
+
+  /**
+   * Seed a tasks.db with a single live task and a single live session so
+   * the I1/I4/I5 anchor lookups can distinguish present vs. orphan.
+   *
+   * Schema is the minimum needed by the cross-DB walker — `tasks(id)` and
+   * `sessions(id)` columns. Other tasks.db columns are not exercised.
+   */
+  function seedTasksDbForCrossDb(
+    dbPath: string,
+    options: { taskIds: string[]; sessionIds: string[] },
+  ): void {
+    const writer = new DatabaseSyncCtor(dbPath);
+    writer.exec(
+      `CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT);
+       CREATE TABLE sessions (id TEXT PRIMARY KEY, scope TEXT);`,
+    );
+    const insertTask = writer.prepare('INSERT INTO tasks (id, title) VALUES (?, ?)');
+    for (const id of options.taskIds) {
+      insertTask.run(id, `title-for-${id}`);
+    }
+    const insertSession = writer.prepare('INSERT INTO sessions (id, scope) VALUES (?, ?)');
+    for (const id of options.sessionIds) {
+      insertSession.run(id, 'global');
+    }
+    writer.close();
+  }
+
+  /**
+   * Seed a brain.db carrying brain_memory_links rows AND a trio of
+   * anchor tables (page_nodes, observations) so I5 anchor resolution
+   * can succeed.
+   */
+  function seedBrainDbForCrossDb(
+    dbPath: string,
+    options: { linkTaskIds: string[]; pageNodeIds?: string[]; observationIds?: string[] },
+  ): void {
+    const writer = new DatabaseSyncCtor(dbPath);
+    writer.exec(
+      `CREATE TABLE brain_memory_links (
+         memory_type TEXT NOT NULL,
+         memory_id   TEXT NOT NULL,
+         task_id     TEXT NOT NULL,
+         link_type   TEXT NOT NULL
+       );
+       CREATE TABLE brain_page_nodes (id TEXT PRIMARY KEY, kind TEXT);
+       CREATE TABLE brain_observations (id TEXT PRIMARY KEY, narrative TEXT);`,
+    );
+    const insertLink = writer.prepare(
+      'INSERT INTO brain_memory_links (memory_type, memory_id, task_id, link_type) VALUES (?, ?, ?, ?)',
+    );
+    for (const taskId of options.linkTaskIds) {
+      insertLink.run('observation', `O-mem-${taskId}`, taskId, 'context');
+    }
+    const insertNode = writer.prepare('INSERT INTO brain_page_nodes (id, kind) VALUES (?, ?)');
+    for (const id of options.pageNodeIds ?? []) {
+      insertNode.run(id, 'task');
+    }
+    const insertObs = writer.prepare(
+      'INSERT INTO brain_observations (id, narrative) VALUES (?, ?)',
+    );
+    for (const id of options.observationIds ?? []) {
+      insertObs.run(id, 'note');
+    }
+    writer.close();
+  }
+
+  /**
+   * Seed a manifest.db (BlobFsAdapter shape) with blob_attachments rows.
+   * Only the columns the I2 invariant reads are materialized.
+   */
+  function seedManifestDbForCrossDb(dbPath: string, docSlugs: string[]): void {
+    const writer = new DatabaseSyncCtor(dbPath);
+    writer.exec(
+      `CREATE TABLE blob_attachments (
+         id        TEXT PRIMARY KEY,
+         doc_slug  TEXT NOT NULL,
+         blob_name TEXT NOT NULL,
+         hash      TEXT NOT NULL,
+         deleted_at TEXT
+       );`,
+    );
+    const insert = writer.prepare(
+      'INSERT INTO blob_attachments (id, doc_slug, blob_name, hash) VALUES (?, ?, ?, ?)',
+    );
+    let i = 0;
+    for (const slug of docSlugs) {
+      i += 1;
+      insert.run(`atch-${i}`, slug, `blob-${i}.bin`, `${'0'.repeat(63)}${i % 10}`);
+    }
+    writer.close();
+  }
+
+  /**
+   * Seed a nexus.db's project_registry with the given (projectId, projectPath) pair.
+   */
+  function seedNexusDbForCrossDb(
+    dbPath: string,
+    rows: { projectId: string; projectPath: string }[],
+  ): void {
+    const writer = new DatabaseSyncCtor(dbPath);
+    writer.exec(
+      `CREATE TABLE project_registry (
+         project_id   TEXT PRIMARY KEY,
+         project_hash TEXT NOT NULL,
+         project_path TEXT NOT NULL,
+         name         TEXT NOT NULL
+       );`,
+    );
+    const insert = writer.prepare(
+      'INSERT INTO project_registry (project_id, project_hash, project_path, name) VALUES (?, ?, ?, ?)',
+    );
+    for (const row of rows) {
+      insert.run(row.projectId, row.projectId, row.projectPath, 'fixture');
+    }
+    writer.close();
+  }
+
+  /**
+   * Seed an llmtxt.db with a `documents` table that carries a `session_id`
+   * column — the schema-aware I4 check probes for ANY table with that
+   * column and the test verifies it is found.
+   */
+  function seedLlmtxtDbForCrossDb(dbPath: string, sessionIds: string[]): void {
+    const writer = new DatabaseSyncCtor(dbPath);
+    writer.exec(
+      `CREATE TABLE documents (
+         id         TEXT PRIMARY KEY,
+         doc_slug   TEXT NOT NULL,
+         session_id TEXT
+       );`,
+    );
+    const insert = writer.prepare(
+      'INSERT INTO documents (id, doc_slug, session_id) VALUES (?, ?, ?)',
+    );
+    let i = 0;
+    for (const sessionId of sessionIds) {
+      i += 1;
+      insert.run(`doc-${i}`, `slug-${i}`, sessionId);
+    }
+    writer.close();
+  }
+
+  /**
+   * Seed a conduit.db with a `dead_letters` table carrying job_id rows.
+   */
+  function seedConduitDbForCrossDb(dbPath: string, jobIds: string[]): void {
+    const writer = new DatabaseSyncCtor(dbPath);
+    writer.exec(
+      `CREATE TABLE dead_letters (
+         id         TEXT PRIMARY KEY,
+         message_id TEXT NOT NULL,
+         job_id     TEXT NOT NULL,
+         reason     TEXT NOT NULL,
+         attempts   INTEGER NOT NULL,
+         created_at INTEGER NOT NULL
+       );`,
+    );
+    const insert = writer.prepare(
+      'INSERT INTO dead_letters (id, message_id, job_id, reason, attempts, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    );
+    let i = 0;
+    for (const jobId of jobIds) {
+      i += 1;
+      insert.run(`dl-${i}`, `msg-${i}`, jobId, 'max-attempts', 6, Date.now());
+    }
+    writer.close();
+  }
+
+  /**
+   * Build a project root with the 6 DBs (tasks, brain, manifest, nexus,
+   * llmtxt, conduit) seeded with intentional orphans for every invariant
+   * I1..I5. Returns the project root path.
+   *
+   * Anchor coverage:
+   *  - tasks.db lives task T100, session ses_live.
+   *  - brain.db link points at orphan T999 (I1 orphan).
+   *  - manifest.db doc_slug T888 is an orphan (I2 orphan).
+   *  - nexus.db row carries a STALE project_path (I3 orphan).
+   *  - llmtxt.db documents.session_id=ses_orphan (I4 orphan).
+   *  - conduit.db dead_letters.job_id=J777 (I5 orphan — not in tasks
+   *    or brain anchor tables).
+   */
+  function seedCrossDbFixture(name: string): string {
+    const projectRoot = join(fleetRoot, name);
+    const cleoDir = join(projectRoot, '.cleo');
+    const blobsDir = join(cleoDir, 'blobs');
+    const llmtxtDir = join(cleoDir, 'llmtxt');
+    mkdirSync(blobsDir, { recursive: true });
+    mkdirSync(llmtxtDir, { recursive: true });
+
+    seedTasksDbForCrossDb(join(cleoDir, 'tasks.db'), {
+      taskIds: ['T100'],
+      sessionIds: ['ses_live'],
+    });
+    seedBrainDbForCrossDb(join(cleoDir, 'brain.db'), {
+      linkTaskIds: ['T100', 'T999'], // T999 is the orphan
+      pageNodeIds: ['task:T100'],
+      observationIds: ['O-anchor-1'],
+    });
+    seedManifestDbForCrossDb(join(blobsDir, 'manifest.db'), [
+      'T100', // live
+      'T888', // orphan
+      'cs-changeset-not-a-task', // not T-shaped — skipped by GLOB
+    ]);
+    // Nexus row uses an INTENTIONAL path mismatch so I3 fires.
+    const expectedId = computeSubstrateProjectId(projectRoot);
+    const nexusPath = join(cleoHomeOverride, 'nexus.db');
+    seedNexusDbForCrossDb(nexusPath, [
+      { projectId: expectedId, projectPath: `${projectRoot}-MOVED` },
+    ]);
+    seedLlmtxtDbForCrossDb(join(llmtxtDir, 'llmtxt.db'), ['ses_live', 'ses_orphan']);
+    seedConduitDbForCrossDb(join(cleoDir, 'conduit.db'), [
+      'T100', // resolves via tasks
+      'task:T100', // resolves via brain_page_nodes
+      'O-anchor-1', // resolves via brain_observations
+      'J777', // orphan
+    ]);
+    return projectRoot;
+  }
+
+  it('T10323: walkCrossDbInvariants returns one report per invariant in canonical order', async () => {
+    await import('@cleocode/paths').then(({ _resetCleoPlatformPathsCache }) =>
+      _resetCleoPlatformPathsCache(),
+    );
+    const projectRoot = createProjectWithTasksDb('cross-db-order');
+    const reports = walkCrossDbInvariants(projectRoot);
+    expect(reports).toHaveLength(5);
+    expect(reports.map((r) => r.invariant)).toEqual(['I1', 'I2', 'I3', 'I4', 'I5']);
+    // Every report carries the stable suggestedFix field — even when skipped.
+    for (const r of reports) {
+      expect(r.suggestedFix.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('T10323: 3-DB fixture detects orphans across every invariant', async () => {
+    await import('@cleocode/paths').then(({ _resetCleoPlatformPathsCache }) =>
+      _resetCleoPlatformPathsCache(),
+    );
+    const projectRoot = seedCrossDbFixture('cross-db-fixture');
+    const result = surveyDbSubstrate(projectRoot);
+
+    // Envelope carries crossDbOrphans on the payload.
+    expect(result.crossDbOrphans).toBeDefined();
+    expect(result.crossDbOrphans.length).toBe(5);
+
+    const byId = new Map(result.crossDbOrphans.map((r) => [r.invariant, r]));
+
+    const i1 = byId.get('I1');
+    expect(i1).toBeDefined();
+    expect(i1?.skipped).toBe(false);
+    expect(i1?.orphanCount).toBeGreaterThanOrEqual(1);
+    expect(i1?.sample).toContain('T999');
+    expect(i1?.suggestedFix).toContain('cleo memory observe');
+
+    const i2 = byId.get('I2');
+    expect(i2?.skipped).toBe(false);
+    expect(i2?.orphanCount).toBeGreaterThanOrEqual(1);
+    expect(i2?.sample).toContain('T888');
+    expect(i2?.suggestedFix).toContain('cleo docs prune');
+
+    const i3 = byId.get('I3');
+    expect(i3?.skipped).toBe(false);
+    expect(i3?.orphanCount).toBe(1);
+    expect(i3?.sample[0]).toContain('-MOVED');
+    expect(i3?.suggestedFix).toContain('cleo nexus reset-project-id');
+
+    const i4 = byId.get('I4');
+    expect(i4?.skipped).toBe(false);
+    expect(i4?.orphanCount).toBe(1);
+    expect(i4?.sample).toContain('ses_orphan');
+    expect(i4?.suggestedFix).toContain('cleo session start');
+
+    const i5 = byId.get('I5');
+    expect(i5?.skipped).toBe(false);
+    expect(i5?.orphanCount).toBe(1);
+    expect(i5?.sample).toContain('J777');
+    expect(i5?.suggestedFix).toMatch(/conduit/i);
+  });
+
+  it('T10323: skipped invariants when source/target DBs are absent', async () => {
+    await import('@cleocode/paths').then(({ _resetCleoPlatformPathsCache }) =>
+      _resetCleoPlatformPathsCache(),
+    );
+    // Fresh project: only tasks.db exists. brain/manifest/nexus/llmtxt/conduit
+    // are all absent — every cross-DB invariant should report skipped.
+    const projectRoot = createProjectWithTasksDb('cross-db-skipped');
+    const result = surveyDbSubstrate(projectRoot);
+    expect(result.crossDbOrphans.length).toBe(5);
+    for (const r of result.crossDbOrphans) {
+      expect(r.skipped).toBe(true);
+      expect(r.orphanCount).toBe(0);
+      expect(r.sample).toEqual([]);
+      expect(r.skipReason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('T10323: I1 reports zero orphans when every brain link anchors a live task', () => {
+    const projectRoot = join(fleetRoot, 'i1-clean');
+    mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+    seedTasksDbForCrossDb(join(projectRoot, '.cleo', 'tasks.db'), {
+      taskIds: ['T1', 'T2'],
+      sessionIds: [],
+    });
+    seedBrainDbForCrossDb(join(projectRoot, '.cleo', 'brain.db'), {
+      linkTaskIds: ['T1', 'T2'],
+    });
+
+    const reports = walkCrossDbInvariants(projectRoot);
+    const i1 = reports.find((r) => r.invariant === 'I1');
+    expect(i1?.skipped).toBe(false);
+    expect(i1?.orphanCount).toBe(0);
+    expect(i1?.sample).toEqual([]);
+  });
+
+  it('T10323: I3 returns 0 orphans when nexus project_path matches projectRoot', async () => {
+    await import('@cleocode/paths').then(({ _resetCleoPlatformPathsCache }) =>
+      _resetCleoPlatformPathsCache(),
+    );
+    const projectRoot = createProjectWithTasksDb('i3-match');
+    const expectedId = computeSubstrateProjectId(projectRoot);
+    seedNexusDbForCrossDb(join(cleoHomeOverride, 'nexus.db'), [
+      { projectId: expectedId, projectPath: projectRoot },
+    ]);
+
+    const reports = walkCrossDbInvariants(projectRoot);
+    const i3 = reports.find((r) => r.invariant === 'I3');
+    expect(i3?.skipped).toBe(false);
+    expect(i3?.orphanCount).toBe(0);
+  });
+
+  it('T10323: I4 stays skipped when the llmtxt schema has no session_id column', () => {
+    const projectRoot = join(fleetRoot, 'i4-no-column');
+    const cleoDir = join(projectRoot, '.cleo');
+    const llmtxtDir = join(cleoDir, 'llmtxt');
+    mkdirSync(llmtxtDir, { recursive: true });
+    seedTasksDbForCrossDb(join(cleoDir, 'tasks.db'), { taskIds: [], sessionIds: [] });
+
+    // Seed an llmtxt.db with a `documents` table that has NO session_id.
+    const writer = new DatabaseSyncCtor(join(llmtxtDir, 'llmtxt.db'));
+    writer.exec(
+      `CREATE TABLE documents (
+         id       TEXT PRIMARY KEY,
+         doc_slug TEXT NOT NULL
+       );`,
+    );
+    writer.close();
+
+    const reports = walkCrossDbInvariants(projectRoot);
+    const i4 = reports.find((r) => r.invariant === 'I4');
+    expect(i4?.skipped).toBe(true);
+    expect(i4?.skipReason).toMatch(/session_id/);
+  });
+
+  it('T10323: orphan reports are bounded — never more than 100 candidate rows scanned', () => {
+    const projectRoot = join(fleetRoot, 'i1-bounded');
+    mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+    seedTasksDbForCrossDb(join(projectRoot, '.cleo', 'tasks.db'), {
+      taskIds: [],
+      sessionIds: [],
+    });
+    // Seed 150 distinct orphan task IDs — well above the 100 LIMIT.
+    const ids: string[] = [];
+    for (let i = 0; i < 150; i += 1) {
+      ids.push(`T-orphan-${i}`);
+    }
+    seedBrainDbForCrossDb(join(projectRoot, '.cleo', 'brain.db'), { linkTaskIds: ids });
+
+    const reports = walkCrossDbInvariants(projectRoot);
+    const i1 = reports.find((r) => r.invariant === 'I1');
+    expect(i1?.skipped).toBe(false);
+    // Bounded query: at most 100 candidate rows; sample ≤ 5.
+    expect(i1?.orphanCount).toBeLessThanOrEqual(100);
+    expect((i1?.sample ?? []).length).toBeLessThanOrEqual(5);
+  });
+
+  it('T10323: per-invariant checkers can be invoked in isolation (unit-test boundary)', () => {
+    // Each exported checker accepts already-open snapshot handles + returns
+    // a well-formed report. Smoke test: feeding `null` for every snapshot
+    // produces a skipped report with the canonical suggestedFix.
+    const i1 = checkInvariantI1(null, null);
+    expect(i1.invariant).toBe('I1');
+    expect(i1.skipped).toBe(true);
+    expect(i1.suggestedFix).toContain('cleo memory observe');
+
+    const i2 = checkInvariantI2(null, null);
+    expect(i2.invariant).toBe('I2');
+    expect(i2.suggestedFix).toContain('cleo docs prune');
+
+    const i3 = checkInvariantI3('/tmp/no-such-project', null);
+    expect(i3.invariant).toBe('I3');
+    expect(i3.suggestedFix).toContain('reset-project-id');
+
+    const i4 = checkInvariantI4(null, null);
+    expect(i4.invariant).toBe('I4');
+    expect(i4.suggestedFix).toMatch(/cleo session start/);
+
+    const i5 = checkInvariantI5(null, null, null);
+    expect(i5.invariant).toBe('I5');
+    expect(i5.suggestedFix).toMatch(/conduit/i);
   });
 });

--- a/packages/cleo/src/cli/commands/doctor-db-substrate.ts
+++ b/packages/cleo/src/cli/commands/doctor-db-substrate.ts
@@ -103,6 +103,26 @@ function pushSubstrateWarnings(result: DbSubstrateAuditResult): void {
       }
     }
   }
+
+  // T10323: surface cross-DB orphan-row reports as `meta.warnings` too,
+  // one warning per invariant that detected ≥1 orphan. Skipped invariants
+  // are NOT surfaced as warnings — they're informational only.
+  for (const report of result.crossDbOrphans) {
+    if (report.skipped || report.orphanCount === 0) continue;
+    pushWarning({
+      code: `W_DB_SUBSTRATE_CROSS_DB_${report.invariant}`,
+      message: `${report.invariant}: ${report.orphanCount} orphan row${
+        report.orphanCount === 1 ? '' : 's'
+      } — ${report.description}. ${report.suggestedFix}`,
+      severity: 'warn',
+      context: {
+        invariant: report.invariant,
+        orphanCount: report.orphanCount,
+        sample: report.sample.join(','),
+        suggestedFix: report.suggestedFix,
+      },
+    });
+  }
 }
 
 /**

--- a/packages/contracts/src/doctor.ts
+++ b/packages/contracts/src/doctor.ts
@@ -640,6 +640,101 @@ export interface DbSubstrateAuditResult {
    * duplicates, etc. ALWAYS present (may be empty).
    */
   warnings: DbSubstrateWarning[];
+  /**
+   * Cross-DB orphan-row reports — one entry per invariant the survey
+   * was able to check. ALWAYS present (may be empty when no DBs exist,
+   * or when every invariant returned zero orphans).
+   *
+   * Surfaced to the envelope's `meta.crossDbOrphans` array by the
+   * `cleo doctor db-substrate` command via `pushWarning`. Per-invariant
+   * sample row IDs are capped at the first 5 to keep envelopes small.
+   *
+   * @task T10323
+   */
+  crossDbOrphans: DbCrossDbOrphanReport[];
+}
+
+/**
+ * Canonical identifiers for the cross-DB referential invariants surfaced by
+ * `cleo doctor db-substrate` (T10323). The catalogue is owned by the T10320
+ * ADR draft — every ID here MUST round-trip with the ADR enumeration.
+ *
+ * | ID | Source                                | Target                                      |
+ * |----|---------------------------------------|---------------------------------------------|
+ * | I1 | `brain_memory_links.task_id`          | `tasks.id` (tasks.db)                        |
+ * | I2 | `manifest.db blob_attachments.doc_slug` | `tasks.id` (tasks.db)                      |
+ * | I3 | `nexus.db project_registry.project_id`| `.cleo/project-context.json` (or computed)  |
+ * | I4 | `llmtxt.db documents.doc_slug` (or any `session_id` column) | `tasks.id` / `sessions.id` |
+ * | I5 | `conduit.db dead_letters.job_id`      | `tasks.id` / `brain_*.id`                    |
+ *
+ * Invariants I1 / I2 / I3 / I5 always run when both source + target DBs
+ * exist; I4 runs only when the source schema actually declares a candidate
+ * column (the live llmtxt schema has not yet introduced `session_id` — the
+ * check stays schema-aware to avoid false positives).
+ *
+ * @task T10323
+ * @epic T10285
+ * @saga T10281
+ */
+export type DbCrossDbInvariantId = 'I1' | 'I2' | 'I3' | 'I4' | 'I5';
+
+/**
+ * One cross-DB orphan-row finding produced by `walkCrossDbInvariants`.
+ *
+ * @remarks
+ * Every reported invariant carries a bounded sample (first 5 orphan keys)
+ * so operators can immediately see WHICH rows triggered the finding. The
+ * underlying SQL queries are capped at LIMIT 100 — a sample of 5 is
+ * sufficient for triage, and the full count is reported via `orphanCount`.
+ *
+ * `suggestedFix` is the canonical repair command (or hint) for the
+ * invariant class. When the invariant has no programmatic fix it carries
+ * a human-readable instruction.
+ *
+ * `skipped` indicates the invariant could not be checked (e.g. the source
+ * DB is missing, the column has not yet been added to the schema, or the
+ * snapshot opener threw). When `skipped === true`, `orphanCount === 0`
+ * and `sample === []`.
+ *
+ * @task T10323
+ */
+export interface DbCrossDbOrphanReport {
+  /** Canonical invariant identifier — see {@link DbCrossDbInvariantId}. */
+  invariant: DbCrossDbInvariantId;
+  /**
+   * Human-readable description of which (source → target) reference class
+   * this invariant tracks. Stable text — operators should be able to grep
+   * this in audit logs.
+   */
+  description: string;
+  /**
+   * Total number of orphan rows detected by the bounded query. When the
+   * query hit its `LIMIT 100` cap, this value is the cap; the actual
+   * orphan population may be larger.
+   */
+  orphanCount: number;
+  /**
+   * First N (≤ 5) orphan identifiers — usually the foreign-key column
+   * value. Order matches the source DB's natural read order (no ORDER BY).
+   * `[]` when `orphanCount === 0` OR `skipped === true`.
+   */
+  sample: string[];
+  /**
+   * Canonical repair command or hint. Stable text — wired into release
+   * notes and ADR-068 evidence atoms.
+   */
+  suggestedFix: string;
+  /**
+   * `true` when the invariant could not be checked (missing DB, missing
+   * column, opener threw). `orphanCount === 0` and `sample === []` when
+   * skipped. Carries the skip reason for triage.
+   */
+  skipped: boolean;
+  /**
+   * Free-form reason populated when `skipped === true`. Empty string
+   * otherwise. Stable text — operators rely on this for diagnostics.
+   */
+  skipReason: string;
 }
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -327,8 +327,11 @@ export {
 // === Doctor: Saga Hierarchy Audit (T10119 — ADR-073 §1.2) ===
 // === Doctor: DB-Substrate Survey (T10307 — Saga T10281 / Epic T10282) ===
 // === Doctor: Legacy-Backup Walker (T10309 — Saga T10281 / Epic T10282) ===
+// === Doctor: Cross-DB Invariants (T10323 — Saga T10281 / Epic T10285) ===
 export type {
   ComprehensiveAuditResult,
+  DbCrossDbInvariantId,
+  DbCrossDbOrphanReport,
   DbSubstrateAuditResult,
   DbSubstrateEntry,
   DbSubstrateMigrationCoverage,

--- a/packages/core/src/doctor/db-substrate.ts
+++ b/packages/core/src/doctor/db-substrate.ts
@@ -32,6 +32,8 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync 
 import { basename, dirname, join } from 'node:path';
 import {
   DB_INVENTORY,
+  type DbCrossDbInvariantId,
+  type DbCrossDbOrphanReport,
   type DbInventoryEntry,
   type DbSubstrateAuditResult,
   type DbSubstrateEntry,
@@ -705,6 +707,687 @@ export function inspectDbFile(
   }
 }
 
+// ============================================================================
+// Cross-DB invariant walker (T10323 — Saga T10281 / Epic T10285)
+// ============================================================================
+
+/**
+ * Max number of orphan rows the bounded queries will return per invariant.
+ *
+ * Keeps walk latency bounded: each invariant runs at most one query that
+ * scans at most this many candidate rows, so a fleet of malformed DBs
+ * cannot blow up the substrate audit's wall-clock budget.
+ *
+ * @task T10323
+ */
+const CROSS_DB_QUERY_LIMIT = 100;
+
+/**
+ * Number of sample orphan keys carried in each report. The full count is
+ * tracked separately on `DbCrossDbOrphanReport.orphanCount`.
+ *
+ * @task T10323
+ */
+const CROSS_DB_SAMPLE_LIMIT = 5;
+
+/** Stable text for the I3 path-mismatch invariant fix. */
+const I3_FIX = 'Run `cleo nexus reset-project-id` to realign nexus.db with project-context.json';
+/** Stable text for the I1 invariant fix. */
+const I1_FIX = 'Run `cleo memory observe --task <taskId>` to re-anchor';
+/** Stable text for the I2 invariant fix. */
+const I2_FIX = 'Run `cleo docs prune --remove-orphan-blobs`';
+/** Stable text for the I4 invariant fix. */
+const I4_FIX =
+  'Repair llmtxt session linkage — re-run `cleo session start --link-task <taskId>` or prune the orphan llmtxt session row';
+/** Stable text for the I5 invariant fix. */
+const I5_FIX =
+  'Repair conduit job anchor — re-anchor the job to a live tasks/brain row or run `cleo conduit prune --orphans`';
+
+/**
+ * Helper: open a snapshot of `filePath` when it exists, returning `null`
+ * (no throw) for every failure mode. The cross-DB walker tolerates every
+ * absent / corrupt / unreadable source DB without short-circuiting the
+ * rest of the invariants.
+ *
+ * @param filePath - Absolute path to the candidate SQLite file.
+ * @returns The open snapshot handle, or `null` when the file is missing
+ *   / opener threw.
+ */
+function tryOpenSnapshot(filePath: string): ReturnType<typeof openCleoDbSnapshot> | null {
+  if (!existsSync(filePath)) return null;
+  try {
+    return openCleoDbSnapshot(filePath, { readOnly: true, applyPragmas: false });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Helper: build a `skipped` report for an invariant whose prerequisites
+ * are not met (missing source DB, missing column, opener threw, etc.).
+ *
+ * @param invariant - Canonical invariant ID.
+ * @param description - Stable invariant description.
+ * @param suggestedFix - Canonical repair command.
+ * @param reason - Free-form skip reason for triage.
+ * @returns A populated {@link DbCrossDbOrphanReport} with `skipped: true`.
+ */
+function buildSkippedReport(
+  invariant: DbCrossDbInvariantId,
+  description: string,
+  suggestedFix: string,
+  reason: string,
+): DbCrossDbOrphanReport {
+  return {
+    invariant,
+    description,
+    orphanCount: 0,
+    sample: [],
+    suggestedFix,
+    skipped: true,
+    skipReason: reason,
+  };
+}
+
+/**
+ * Helper: check whether a SQLite snapshot has a given table.
+ *
+ * @param snapshot - The open snapshot handle (NOT null — caller checks).
+ * @param tableName - Exact table name to check (case-sensitive).
+ * @returns `true` when `sqlite_master` carries a row with `name=<tableName>`.
+ */
+function snapshotHasTable(
+  snapshot: ReturnType<typeof openCleoDbSnapshot>,
+  tableName: string,
+): boolean {
+  type Row = { name: string };
+  try {
+    const rows = snapshot.db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=? LIMIT 1")
+      .all(tableName) as Row[];
+    return rows.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Helper: check whether a SQLite snapshot has a given column on a given
+ * table.
+ *
+ * @param snapshot - The open snapshot handle (NOT null — caller checks).
+ * @param tableName - Exact table name.
+ * @param columnName - Exact column name (case-sensitive).
+ * @returns `true` when `PRAGMA table_info(<tableName>)` carries a row
+ *   with `name=<columnName>`.
+ */
+function snapshotHasColumn(
+  snapshot: ReturnType<typeof openCleoDbSnapshot>,
+  tableName: string,
+  columnName: string,
+): boolean {
+  // table_info accepts a quoted identifier; tableName is validated by
+  // caller (only used on hardcoded table names from this module).
+  type ColumnInfoRow = { name: string };
+  try {
+    const rows = snapshot.db.prepare(`PRAGMA table_info(${tableName})`).all() as ColumnInfoRow[];
+    return rows.some((r) => r.name === columnName);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * I1 invariant: `brain_memory_links.task_id` (brain.db) must reference an
+ * existing `tasks.id` row in tasks.db.
+ *
+ * @remarks
+ * Strategy: read every distinct `task_id` from brain.db's
+ * `brain_memory_links` (LIMIT 100), then for each candidate ask tasks.db
+ * whether the row exists. The walker scans at most 100 candidate IDs,
+ * regardless of how many orphan links the brain has — operators see
+ * "≥ 100" only when the population truly exceeds the cap.
+ *
+ * @param tasksSnap - Open snapshot of tasks.db, or `null` when missing.
+ * @param brainSnap - Open snapshot of brain.db, or `null` when missing.
+ * @returns A {@link DbCrossDbOrphanReport} for invariant I1.
+ */
+export function checkInvariantI1(
+  tasksSnap: ReturnType<typeof openCleoDbSnapshot> | null,
+  brainSnap: ReturnType<typeof openCleoDbSnapshot> | null,
+): DbCrossDbOrphanReport {
+  const description =
+    'brain_memory_links.task_id (brain.db) must reference an existing tasks.id row in tasks.db';
+
+  if (brainSnap === null) {
+    return buildSkippedReport('I1', description, I1_FIX, 'brain.db missing or unreadable');
+  }
+  if (tasksSnap === null) {
+    return buildSkippedReport('I1', description, I1_FIX, 'tasks.db missing or unreadable');
+  }
+  if (!snapshotHasTable(brainSnap, 'brain_memory_links')) {
+    return buildSkippedReport(
+      'I1',
+      description,
+      I1_FIX,
+      'brain.db has no brain_memory_links table',
+    );
+  }
+  if (!snapshotHasTable(tasksSnap, 'tasks')) {
+    return buildSkippedReport('I1', description, I1_FIX, 'tasks.db has no tasks table');
+  }
+
+  type LinkRow = { task_id: string };
+  let candidateIds: string[];
+  try {
+    const rows = brainSnap.db
+      .prepare(
+        `SELECT DISTINCT task_id FROM brain_memory_links WHERE task_id IS NOT NULL LIMIT ${CROSS_DB_QUERY_LIMIT}`,
+      )
+      .all() as LinkRow[];
+    candidateIds = rows.map((r) => r.task_id);
+  } catch (err) {
+    return buildSkippedReport(
+      'I1',
+      description,
+      I1_FIX,
+      `brain.db query threw: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const orphans: string[] = [];
+  const lookup = tasksSnap.db.prepare('SELECT id FROM tasks WHERE id = ? LIMIT 1');
+  for (const taskId of candidateIds) {
+    try {
+      const row = lookup.get(taskId) as { id: string } | undefined;
+      if (row === undefined) {
+        orphans.push(taskId);
+      }
+    } catch {
+      // Lookup threw — treat as inconclusive (skip this row, don't bias).
+    }
+  }
+
+  return {
+    invariant: 'I1',
+    description,
+    orphanCount: orphans.length,
+    sample: orphans.slice(0, CROSS_DB_SAMPLE_LIMIT),
+    suggestedFix: I1_FIX,
+    skipped: false,
+    skipReason: '',
+  };
+}
+
+/**
+ * I2 invariant: `blob_attachments.doc_slug` (manifest.db) used as a
+ * `T####`-shaped task identifier must reference an existing tasks.id row.
+ *
+ * @remarks
+ * CLEO uses `taskId` as the `docSlug` for blob attachments
+ * (see `packages/core/src/store/llmtxt-blob-adapter.ts`). Doc slugs that
+ * match the canonical `^T\d+$` shape MUST point at a live task; any
+ * other doc-slug shape (changesets, ADRs, research notes…) is out of
+ * scope for this invariant.
+ *
+ * @param tasksSnap - Open snapshot of tasks.db, or `null` when missing.
+ * @param manifestSnap - Open snapshot of manifest.db, or `null` when missing.
+ * @returns A {@link DbCrossDbOrphanReport} for invariant I2.
+ */
+export function checkInvariantI2(
+  tasksSnap: ReturnType<typeof openCleoDbSnapshot> | null,
+  manifestSnap: ReturnType<typeof openCleoDbSnapshot> | null,
+): DbCrossDbOrphanReport {
+  const description =
+    "manifest.db blob_attachments.doc_slug shaped like 'T####' must reference an existing tasks.id row";
+
+  if (manifestSnap === null) {
+    return buildSkippedReport('I2', description, I2_FIX, 'manifest.db missing or unreadable');
+  }
+  if (tasksSnap === null) {
+    return buildSkippedReport('I2', description, I2_FIX, 'tasks.db missing or unreadable');
+  }
+  if (!snapshotHasTable(manifestSnap, 'blob_attachments')) {
+    return buildSkippedReport(
+      'I2',
+      description,
+      I2_FIX,
+      'manifest.db has no blob_attachments table',
+    );
+  }
+  if (!snapshotHasTable(tasksSnap, 'tasks')) {
+    return buildSkippedReport('I2', description, I2_FIX, 'tasks.db has no tasks table');
+  }
+
+  type SlugRow = { doc_slug: string };
+  let candidates: string[];
+  try {
+    // Only T-shaped slugs. SQLite GLOB beats LIKE for prefix discrimination.
+    const rows = manifestSnap.db
+      .prepare(
+        `SELECT DISTINCT doc_slug FROM blob_attachments WHERE doc_slug GLOB 'T[0-9]*' AND doc_slug IS NOT NULL LIMIT ${CROSS_DB_QUERY_LIMIT}`,
+      )
+      .all() as SlugRow[];
+    candidates = rows.map((r) => r.doc_slug);
+  } catch (err) {
+    return buildSkippedReport(
+      'I2',
+      description,
+      I2_FIX,
+      `manifest.db query threw: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const orphans: string[] = [];
+  const lookup = tasksSnap.db.prepare('SELECT id FROM tasks WHERE id = ? LIMIT 1');
+  for (const slug of candidates) {
+    try {
+      const row = lookup.get(slug) as { id: string } | undefined;
+      if (row === undefined) {
+        orphans.push(slug);
+      }
+    } catch {
+      // Lookup threw — skip silently.
+    }
+  }
+
+  return {
+    invariant: 'I2',
+    description,
+    orphanCount: orphans.length,
+    sample: orphans.slice(0, CROSS_DB_SAMPLE_LIMIT),
+    suggestedFix: I2_FIX,
+    skipped: false,
+    skipReason: '',
+  };
+}
+
+/**
+ * I3 invariant: nexus.db's `project_registry.project_path` row for the
+ * current project must match `projectRoot` (or, when no row exists, the
+ * project simply has not been registered with the nexus yet — that is
+ * skipped, not flagged).
+ *
+ * @remarks
+ * `.cleo/project-context.json` does NOT carry a `projectId` field; the
+ * canonical identifier is derived from `base64url(path).slice(0, 32)`.
+ * The invariant therefore asserts that the nexus registry's recorded
+ * `project_path` MATCHES the live project root for the computed ID.
+ *
+ * Detected drift: a single nexus row whose `project_path` no longer
+ * matches `projectRoot` (e.g. project was moved on disk; the
+ * registry still points at the old location).
+ *
+ * @param projectRoot - Absolute path to the project root being audited.
+ * @param nexusSnap - Open snapshot of nexus.db, or `null` when missing.
+ * @returns A {@link DbCrossDbOrphanReport} for invariant I3.
+ */
+export function checkInvariantI3(
+  projectRoot: string,
+  nexusSnap: ReturnType<typeof openCleoDbSnapshot> | null,
+): DbCrossDbOrphanReport {
+  const description =
+    'nexus.db project_registry.project_path must match the live projectRoot for this project_id';
+
+  if (nexusSnap === null) {
+    return buildSkippedReport('I3', description, I3_FIX, 'nexus.db missing or unreadable');
+  }
+  if (!snapshotHasTable(nexusSnap, 'project_registry')) {
+    return buildSkippedReport('I3', description, I3_FIX, 'nexus.db has no project_registry table');
+  }
+
+  const expectedProjectId = computeSubstrateProjectId(projectRoot);
+
+  type RegistryRow = { project_id: string; project_path: string };
+  let row: RegistryRow | undefined;
+  try {
+    row = nexusSnap.db
+      .prepare('SELECT project_id, project_path FROM project_registry WHERE project_id = ? LIMIT 1')
+      .get(expectedProjectId) as RegistryRow | undefined;
+  } catch (err) {
+    return buildSkippedReport(
+      'I3',
+      description,
+      I3_FIX,
+      `nexus.db query threw: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // No registry row: project simply isn't tracked by the nexus yet — not
+  // a violation. The invariant only fires when a row exists AND its
+  // recorded path differs from the live projectRoot.
+  if (row === undefined) {
+    return buildSkippedReport(
+      'I3',
+      description,
+      I3_FIX,
+      `nexus.db has no project_registry row for projectId=${expectedProjectId}`,
+    );
+  }
+
+  const orphans: string[] = [];
+  if (row.project_path !== projectRoot) {
+    orphans.push(`${row.project_id} (path: ${row.project_path}, expected: ${projectRoot})`);
+  }
+
+  return {
+    invariant: 'I3',
+    description,
+    orphanCount: orphans.length,
+    sample: orphans.slice(0, CROSS_DB_SAMPLE_LIMIT),
+    suggestedFix: I3_FIX,
+    skipped: false,
+    skipReason: '',
+  };
+}
+
+/**
+ * I4 invariant: llmtxt.db's `session_id` (if the schema declares one)
+ * must reference an existing `sessions.id` row in tasks.db.
+ *
+ * @remarks
+ * Schema-aware: the live llmtxt schema (`llmtxt@2026.4.x`) does NOT yet
+ * declare a `session_id` column on any table. The walker probes
+ * `sqlite_master` for tables carrying a `session_id` column and runs
+ * the check only when one exists. The check stays compatible with future
+ * llmtxt schemas that introduce session linkage without code changes.
+ *
+ * When a candidate column is found, the bounded query gathers distinct
+ * `session_id` values (LIMIT 100) and cross-references each against
+ * tasks.db's `sessions` table.
+ *
+ * @param tasksSnap - Open snapshot of tasks.db, or `null` when missing.
+ * @param llmtxtSnap - Open snapshot of llmtxt.db, or `null` when missing.
+ * @returns A {@link DbCrossDbOrphanReport} for invariant I4.
+ */
+export function checkInvariantI4(
+  tasksSnap: ReturnType<typeof openCleoDbSnapshot> | null,
+  llmtxtSnap: ReturnType<typeof openCleoDbSnapshot> | null,
+): DbCrossDbOrphanReport {
+  const description =
+    'llmtxt.db tables carrying a session_id column must reference an existing sessions.id row in tasks.db';
+
+  if (llmtxtSnap === null) {
+    return buildSkippedReport('I4', description, I4_FIX, 'llmtxt.db missing or unreadable');
+  }
+  if (tasksSnap === null) {
+    return buildSkippedReport('I4', description, I4_FIX, 'tasks.db missing or unreadable');
+  }
+  if (!snapshotHasTable(tasksSnap, 'sessions')) {
+    return buildSkippedReport('I4', description, I4_FIX, 'tasks.db has no sessions table');
+  }
+
+  // Find any user table in llmtxt.db that has a `session_id` column.
+  // The schema may evolve — we don't hardcode a table name.
+  //
+  // NOTE: SQL `LIKE '__%'` matches ANY two-character-prefixed name (the
+  // underscore is a single-character wildcard in SQL). Use a literal
+  // escape so we exclude only the Drizzle/CLEO bookkeeping tables that
+  // genuinely begin with `__`.
+  type TableRow = { name: string };
+  let userTables: string[];
+  try {
+    const rows = llmtxtSnap.db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite\\_%' ESCAPE '\\' AND name NOT LIKE '\\_\\_%' ESCAPE '\\'",
+      )
+      .all() as TableRow[];
+    userTables = rows.map((r) => r.name);
+  } catch (err) {
+    return buildSkippedReport(
+      'I4',
+      description,
+      I4_FIX,
+      `llmtxt.db schema query threw: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const tablesWithSessionId: string[] = [];
+  for (const t of userTables) {
+    if (snapshotHasColumn(llmtxtSnap, t, 'session_id')) {
+      tablesWithSessionId.push(t);
+    }
+  }
+
+  if (tablesWithSessionId.length === 0) {
+    return buildSkippedReport(
+      'I4',
+      description,
+      I4_FIX,
+      'llmtxt.db has no table with a session_id column (schema does not yet declare session linkage)',
+    );
+  }
+
+  type SessionRow = { session_id: string };
+  const allCandidates = new Set<string>();
+  for (const tableName of tablesWithSessionId) {
+    if (allCandidates.size >= CROSS_DB_QUERY_LIMIT) break;
+    // Identifier safety: tableName comes from sqlite_master so it's
+    // already a valid identifier. Belt-and-braces regex check below.
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(tableName)) continue;
+    const remaining = CROSS_DB_QUERY_LIMIT - allCandidates.size;
+    try {
+      const rows = llmtxtSnap.db
+        .prepare(
+          `SELECT DISTINCT session_id FROM ${tableName} WHERE session_id IS NOT NULL LIMIT ${remaining}`,
+        )
+        .all() as SessionRow[];
+      for (const r of rows) {
+        allCandidates.add(r.session_id);
+      }
+    } catch {
+      // Skip this table on failure — don't bias the report.
+    }
+  }
+
+  const orphans: string[] = [];
+  const lookup = tasksSnap.db.prepare('SELECT id FROM sessions WHERE id = ? LIMIT 1');
+  for (const sessionId of allCandidates) {
+    try {
+      const row = lookup.get(sessionId) as { id: string } | undefined;
+      if (row === undefined) {
+        orphans.push(sessionId);
+      }
+    } catch {
+      // skip silently
+    }
+  }
+
+  return {
+    invariant: 'I4',
+    description,
+    orphanCount: orphans.length,
+    sample: orphans.slice(0, CROSS_DB_SAMPLE_LIMIT),
+    suggestedFix: I4_FIX,
+    skipped: false,
+    skipReason: '',
+  };
+}
+
+/**
+ * I5 invariant: `dead_letters.job_id` (conduit.db) must reference either
+ * an existing tasks.id row OR a brain anchor (page node, observation, …).
+ *
+ * @remarks
+ * Conduit jobs anchor against the broader CLEO substrate — a job's
+ * `job_id` may be a task ID (`T####`) or a brain entity (e.g.
+ * `observation:O-…`). The walker resolves each candidate against both
+ * targets and only flags rows that match neither.
+ *
+ * @param tasksSnap - Open snapshot of tasks.db, or `null` when missing.
+ * @param brainSnap - Open snapshot of brain.db, or `null` when missing.
+ * @param conduitSnap - Open snapshot of conduit.db, or `null` when missing.
+ * @returns A {@link DbCrossDbOrphanReport} for invariant I5.
+ */
+export function checkInvariantI5(
+  tasksSnap: ReturnType<typeof openCleoDbSnapshot> | null,
+  brainSnap: ReturnType<typeof openCleoDbSnapshot> | null,
+  conduitSnap: ReturnType<typeof openCleoDbSnapshot> | null,
+): DbCrossDbOrphanReport {
+  const description =
+    'conduit.db dead_letters.job_id must reference an existing tasks.id row OR a brain anchor (brain_page_nodes.id / brain_observations.id)';
+
+  if (conduitSnap === null) {
+    return buildSkippedReport('I5', description, I5_FIX, 'conduit.db missing or unreadable');
+  }
+  if (!snapshotHasTable(conduitSnap, 'dead_letters')) {
+    return buildSkippedReport('I5', description, I5_FIX, 'conduit.db has no dead_letters table');
+  }
+  // Both targets missing → cannot resolve; skip.
+  if (tasksSnap === null && brainSnap === null) {
+    return buildSkippedReport(
+      'I5',
+      description,
+      I5_FIX,
+      'both tasks.db and brain.db missing — cannot resolve job anchors',
+    );
+  }
+
+  type JobRow = { job_id: string };
+  let candidates: string[];
+  try {
+    const rows = conduitSnap.db
+      .prepare(
+        `SELECT DISTINCT job_id FROM dead_letters WHERE job_id IS NOT NULL LIMIT ${CROSS_DB_QUERY_LIMIT}`,
+      )
+      .all() as JobRow[];
+    candidates = rows.map((r) => r.job_id);
+  } catch (err) {
+    return buildSkippedReport(
+      'I5',
+      description,
+      I5_FIX,
+      `conduit.db query threw: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const tasksLookup =
+    tasksSnap !== null && snapshotHasTable(tasksSnap, 'tasks')
+      ? tasksSnap.db.prepare('SELECT id FROM tasks WHERE id = ? LIMIT 1')
+      : null;
+  const brainPageLookup =
+    brainSnap !== null && snapshotHasTable(brainSnap, 'brain_page_nodes')
+      ? brainSnap.db.prepare('SELECT id FROM brain_page_nodes WHERE id = ? LIMIT 1')
+      : null;
+  const brainObsLookup =
+    brainSnap !== null && snapshotHasTable(brainSnap, 'brain_observations')
+      ? brainSnap.db.prepare('SELECT id FROM brain_observations WHERE id = ? LIMIT 1')
+      : null;
+
+  const orphans: string[] = [];
+  for (const jobId of candidates) {
+    let anchored = false;
+    try {
+      if (tasksLookup !== null && (tasksLookup.get(jobId) as { id: string } | undefined)) {
+        anchored = true;
+      }
+    } catch {
+      // skip
+    }
+    if (!anchored) {
+      try {
+        if (
+          brainPageLookup !== null &&
+          (brainPageLookup.get(jobId) as { id: string } | undefined)
+        ) {
+          anchored = true;
+        }
+      } catch {
+        // skip
+      }
+    }
+    if (!anchored) {
+      try {
+        if (brainObsLookup !== null && (brainObsLookup.get(jobId) as { id: string } | undefined)) {
+          anchored = true;
+        }
+      } catch {
+        // skip
+      }
+    }
+    if (!anchored) {
+      orphans.push(jobId);
+    }
+  }
+
+  return {
+    invariant: 'I5',
+    description,
+    orphanCount: orphans.length,
+    sample: orphans.slice(0, CROSS_DB_SAMPLE_LIMIT),
+    suggestedFix: I5_FIX,
+    skipped: false,
+    skipReason: '',
+  };
+}
+
+/**
+ * Run every cross-DB invariant in the T10320 catalogue (I1–I5) and
+ * return per-invariant orphan reports.
+ *
+ * @remarks
+ * Resolves every DB path through the inventory SSoT, opens each as a
+ * read-only snapshot, runs the bounded invariant queries, and closes
+ * the snapshots before returning. Every failure mode — missing file,
+ * malformed DB, missing column, missing table — is captured on the
+ * corresponding report's `skipped: true` branch; the walker never
+ * throws.
+ *
+ * Each invariant has its own dedicated checker (exported for unit
+ * tests) so the integration suite can verify the per-invariant
+ * semantics in isolation.
+ *
+ * @param projectRoot - Absolute path to the project root.
+ * @returns Five {@link DbCrossDbOrphanReport} entries — one per invariant,
+ *   always in the canonical order I1, I2, I3, I4, I5.
+ *
+ * @task T10323
+ * @epic T10285
+ * @saga T10281
+ */
+export function walkCrossDbInvariants(projectRoot: string): DbCrossDbOrphanReport[] {
+  // Resolve every DB path through the inventory SSoT — no hardcoded
+  // paths. Roles we care about: tasks, brain, conduit, manifest,
+  // llmtxt, nexus.
+  const resolveByRole = (role: string): string | null => {
+    const entry = DB_INVENTORY.find((e) => e.role === role);
+    return entry ? resolveInventoryFilePath(entry, projectRoot) : null;
+  };
+
+  const tasksPath = resolveByRole('tasks');
+  const brainPath = resolveByRole('brain');
+  const conduitPath = resolveByRole('conduit');
+  const manifestPath = resolveByRole('manifest');
+  const llmtxtPath = resolveByRole('llmtxt');
+  const nexusPath = resolveByRole('nexus');
+
+  const tasksSnap = tasksPath ? tryOpenSnapshot(tasksPath) : null;
+  const brainSnap = brainPath ? tryOpenSnapshot(brainPath) : null;
+  const conduitSnap = conduitPath ? tryOpenSnapshot(conduitPath) : null;
+  const manifestSnap = manifestPath ? tryOpenSnapshot(manifestPath) : null;
+  const llmtxtSnap = llmtxtPath ? tryOpenSnapshot(llmtxtPath) : null;
+  const nexusSnap = nexusPath ? tryOpenSnapshot(nexusPath) : null;
+
+  try {
+    const reports: DbCrossDbOrphanReport[] = [
+      checkInvariantI1(tasksSnap, brainSnap),
+      checkInvariantI2(tasksSnap, manifestSnap),
+      checkInvariantI3(projectRoot, nexusSnap),
+      checkInvariantI4(tasksSnap, llmtxtSnap),
+      checkInvariantI5(tasksSnap, brainSnap, conduitSnap),
+    ];
+    return reports;
+  } finally {
+    // Close every snapshot we opened, regardless of which checks ran.
+    tasksSnap?.close();
+    brainSnap?.close();
+    conduitSnap?.close();
+    manifestSnap?.close();
+    llmtxtSnap?.close();
+    nexusSnap?.close();
+  }
+}
+
 /**
  * Walk the inventory and survey every project-tier + global-tier
  * database visible from one project root.
@@ -951,11 +1634,14 @@ export function surveyDbSubstrate(
     warnings.push(orphan);
   }
   warnings.push(...detectNestedNexusDuplicates());
+  // T10323: cross-DB invariants are checked once per project per audit.
+  const crossDbOrphans = walkCrossDbInvariants(projectRoot);
   return {
     scope: 'project',
     projects: [projectSurvey],
     summary: summarizeSubstrateSurveys([projectSurvey]),
     warnings,
+    crossDbOrphans,
   };
 }
 
@@ -1048,10 +1734,19 @@ export function surveyFleetDbSubstrate(
   }
   warnings.push(...detectNestedNexusDuplicates());
 
+  // T10323: in fleet mode we run cross-DB invariants per project. The
+  // global-tier shape (nexus.db) is shared, but I1/I2/I4/I5 are
+  // project-scoped — we want one set of reports per project root.
+  const crossDbOrphans: DbCrossDbOrphanReport[] = [];
+  for (const survey of projectSurveys) {
+    crossDbOrphans.push(...walkCrossDbInvariants(survey.projectRoot));
+  }
+
   return {
     scope: 'fleet',
     projects: projectSurveys,
     summary: summarizeSubstrateSurveys(projectSurveys),
     warnings,
+    crossDbOrphans,
   };
 }

--- a/packages/core/src/doctor/index.ts
+++ b/packages/core/src/doctor/index.ts
@@ -20,7 +20,13 @@
 
 // T10307 — DB-substrate survey (Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10282)
 // T10310 — Per-DB pragma drift (Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10283)
+// T10323 — Cross-DB orphan-row walker (Saga T10281 / Epic T10285)
 export {
+  checkInvariantI1,
+  checkInvariantI2,
+  checkInvariantI3,
+  checkInvariantI4,
+  checkInvariantI5,
   computeSubstrateProjectId,
   detectNestedNexusDuplicates,
   detectOrphanProjectRootWarning,
@@ -30,6 +36,7 @@ export {
   surveyDbSubstrate,
   surveyFleetDbSubstrate,
   surveyProjectDbSubstrate,
+  walkCrossDbInvariants,
   walkPragmaDrift,
 } from './db-substrate.js';
 // T10309 — Legacy-backup walker (Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10282)


### PR DESCRIPTION
## Summary

Extends `cleo doctor db-substrate` (T10307 + follow-ups) with a cross-DB
invariant walker covering the T10320 catalogue (I1-I5).

- **I1** `brain_memory_links.task_id` → `tasks.id`
- **I2** manifest.db `blob_attachments.doc_slug` (T-shaped) → `tasks.id`
- **I3** nexus.db `project_registry.project_path` → live `projectRoot`
- **I4** llmtxt.db tables carrying a `session_id` column (schema-aware) → `tasks.sessions.id`
- **I5** conduit.db `dead_letters.job_id` → `tasks.id` OR brain anchor

Each report carries:
- canonical invariant ID (`I1`..`I5`)
- orphan count + ≤ 5 sample identifiers
- stable `suggestedFix` repair command
- `skipped: true` when prerequisites are absent (missing DB / column / opener throws)

Bounded queries (LIMIT 100) keep the audit budget stable on malformed
fleets. Reports surface on `DbSubstrateAuditResult.crossDbOrphans` and
land in the LAFS envelope `meta.warnings` as
`W_DB_SUBSTRATE_CROSS_DB_<Ix>` when any invariant detects ≥ 1 orphan.

All DB opens flow through the canonical `openCleoDbSnapshot` chokepoint
(read-only, `db-open-guard` allowlist compliant — T10073). Zero
`any` / `unknown` / `as unknown as` casts.

## Files

- `packages/contracts/src/doctor.ts` — added `DbCrossDbInvariantId`, `DbCrossDbOrphanReport`, extended `DbSubstrateAuditResult` with `crossDbOrphans`
- `packages/core/src/doctor/db-substrate.ts` — `walkCrossDbInvariants` + per-invariant checkers `checkInvariantI1`..`checkInvariantI5`
- `packages/cleo/src/cli/commands/doctor-db-substrate.ts` — surface findings as `meta.warnings`
- `packages/cleo/src/cli/commands/__tests__/doctor-db-substrate.test.ts` — 8 new T10323 integration tests (3-DB fixture, skip semantics, bounded query, isolation smoke)
- `.changeset/T10323.md`

## Test plan

- [x] `pnpm biome check --write` — passes
- [x] `pnpm --filter @cleocode/core run build` — passes
- [x] `pnpm --filter @cleocode/cleo run build` — passes
- [x] `pnpm --filter @cleocode/contracts run test` — 379/379 pass
- [x] Doctor-db-substrate test suite — 31/31 pass (8 new T10323 tests)
- [x] Pre-existing `doctor-projects` failures confirmed not introduced by this PR (fail on `main` too)

## Hard constraints honoured

- All DB opens via `openCleoDbSnapshot` (canonical chokepoint)
- No `any` / `unknown` / `as unknown as`
- Each invariant check has a bounded query (LIMIT 100, sample ≤ 5)
- Snapshots always closed via `try/finally` in `walkCrossDbInvariants`

Closes #T10323
Saga: T10281