### PR TITLE
T10314: idempotency contract tests across DBs (Saga T10281 / E2)

### DIFF
--- a/.changeset/T10314.md
+++ b/.changeset/T10314.md
@@ -1,0 +1,44 @@
+---
+id: T10314
+tasks: [T10314]
+kind: test
+summary: "Idempotency contract tests for brain/conduit/llmtxt/manifest DBs (Saga T10281 / Epic T10283)"
+---
+
+Adds idempotency contract tests for the four remaining CLEO SQLite
+chokepoints not already covered by ADR-013 §9's tasks.db regression
+suite: `brain.db`, `conduit.db`, `manifest.db`, and the reserved
+`llmtxt` role. Each test opens the canonical chokepoint twice, replays
+identical write operations, and asserts that the second run produces
+no side effects (no duplicate rows, no re-applied migrations, no PRAGMA
+drift, no leaked filesystem state).
+
+New test files:
+
+- `packages/brain/src/__tests__/brain-idempotency.test.ts` — exercises
+  the brain-package reader chokepoint `getBrainDb(ctx)`.
+- `packages/core/src/store/__tests__/brain-idempotency.test.ts` —
+  exercises the canonical writer chokepoint `getBrainDb(cwd?)` in
+  `memory-sqlite.ts` (migration journal stability + schema-version
+  sentinel + INSERT OR IGNORE on `brain_sticky_notes`).
+- `packages/core/src/store/__tests__/conduit-idempotency.test.ts` —
+  exercises `ensureConduitDb(projectRoot)` (action='created' →
+  action='exists' sentinel fast-path, `_conduit_meta` row count
+  stability, ON CONFLICT upsert on `project_agent_refs`).
+- `packages/core/src/store/__tests__/manifest-idempotency.test.ts` —
+  exercises `CleoBlobStore.open` (single-instance open idempotency,
+  close + reopen with same projectRoot finds existing blobs, identical
+  attach calls dedupe by SHA-256).
+- `packages/core/src/store/__tests__/llmtxt-idempotency.test.ts` —
+  pins the error-stability contract for the reserved `llmtxt` role
+  (`openCleoDb('llmtxt')` throws identically on every call; no
+  `.cleo/llmtxt/` directory leaked by the failed open).
+
+All tests sandbox via `mkdtempSync` and never touch the live `.cleo/`.
+
+Amends ADR-013 §9 (Runtime Data Safety) with a new "Idempotency
+contract tests (T10314)" subsection that documents the five test
+files and the chokepoint each one covers.
+
+Closes T10314.
+Saga: T10281.

--- a/.cleo/adrs/ADR-013-data-integrity-checkpoint-architecture.md
+++ b/.cleo/adrs/ADR-013-data-integrity-checkpoint-architecture.md
@@ -211,6 +211,22 @@ The safety guards documented in §8 caught new *stages* of the DB files but did 
    - `packages/core/src/system/__tests__/backup.test.ts` (new) — validates VACUUM INTO call ordering, atomic JSON writes, sidecar metadata, and restore behavior.
    - `packages/cleo/src/cli/commands/__tests__/init-gitignore.test.ts` — asserts the template NEVER re-includes `config.json` / `project-info.json` and DOES explicit-deny them.
 
+### Idempotency contract tests (T10314 — Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10283 E2-DB-INTEGRITY)
+
+The git-untracked policy resolved the data-loss vector on branch switch, but it left an under-tested invariant: **opening any of the runtime SQLite chokepoints twice + replaying identical writes must not produce side-effects on the second run.** Without that guarantee, agents that re-open `brain.db` / `conduit.db` / `manifest.db` between CLI invocations could silently grow migration journals, double-write schema-version sentinels, or duplicate manifest rows.
+
+T10314 codifies the contract as four sibling test files:
+
+| Test file (absolute path)                                                            | Chokepoint under test                                       | Asserts                                                                                                                |
+|--------------------------------------------------------------------------------------|-------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `packages/core/src/store/__tests__/brain-idempotency.test.ts`                        | `getBrainDb(cwd?)` in `memory-sqlite.ts` (canonical writer) | Re-open does not re-run migrations; PRAGMAs stable (WAL/foreign_keys); `INSERT OR IGNORE` on `brain_sticky_notes` is a no-op on second run. |
+| `packages/brain/src/__tests__/brain-idempotency.test.ts`                             | `getBrainDb(ctx)` in `db-connections.ts` (brain-pkg reader) | Reader returns null when file absent; PRAGMAs stable; reader-side `INSERT OR IGNORE` is idempotent.                    |
+| `packages/core/src/store/__tests__/conduit-idempotency.test.ts`                      | `ensureConduitDb(projectRoot)` in `conduit-sqlite.ts`       | First call returns `action: 'created'`, second returns `'exists'` (sentinel fast-path); `_conduit_meta` sentinel row count stable; PRAGMAs stable; `ON CONFLICT DO UPDATE` on `project_agent_refs` does not duplicate. |
+| `packages/core/src/store/__tests__/manifest-idempotency.test.ts`                     | `CleoBlobStore.open` in `llmtxt-blob-adapter.ts`            | `open()` is idempotent within a single instance; close + reopen finds existing `manifest.db` + blob bytes; identical `attach()` calls dedupe by SHA-256 with exactly one file on disk under `.cleo/blobs/blobs/`. |
+| `packages/core/src/store/__tests__/llmtxt-idempotency.test.ts`                       | `openCleoDb('llmtxt', cwd)` in `open-cleo-db.ts` (reserved) | Reserved opener throws `"llmtxt is not yet implemented"` identically on every call (error-stability contract); no `.cleo/llmtxt/` directory leaked to disk by the failed open. |
+
+Each test sandboxes via `mkdtempSync` and never touches the live `.cleo/`. The tasks.db idempotency contract is already covered by the existing `tasks-sqlite.test.ts` + `sqlite.test.ts` suites — T10314 closes the coverage gap for the remaining four DBs.
+
 ### Recovery story (for users affected by corruption or rollback)
 
 All four runtime files are now recoverable via out-of-band mechanisms instead of git:

--- a/packages/brain/src/__tests__/brain-idempotency.test.ts
+++ b/packages/brain/src/__tests__/brain-idempotency.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Brain reader chokepoint idempotency contract test.
+ *
+ * Saga T10281 / Epic T10283 E2-DB-INTEGRITY / Task T10314.
+ *
+ * Asserts that the brain-package reader chokepoint
+ * (`getBrainDb(ctx)` in `db-connections.ts`) is fully idempotent:
+ *
+ *   1. Opening twice against the same file does NOT mutate the DB
+ *      (pragma application is the only write performed, and it is a
+ *      no-op on a database that already has WAL / FK / cache pragmas
+ *      applied).
+ *   2. Running the SAME `INSERT OR IGNORE` twice against the brain
+ *      reader handle does NOT duplicate rows.
+ *   3. The reader returns `null` when the file does not exist
+ *      (negative path) and a usable handle when it does exist (positive
+ *      path).
+ *
+ * Because `@cleocode/brain` deliberately does NOT depend on
+ * `@cleocode/core` (package boundary, AGENTS.md §"Package Boundary"),
+ * this test pre-bootstraps the brain.db file by hand using
+ * `node:sqlite` directly: it creates the minimal `brain_sticky_notes`
+ * table, then exercises the brain reader against that file.
+ *
+ * Sandboxing: every test runs inside an `mkdtempSync` directory.
+ * Cross-link: ADR-013 §9 — brain.db is excluded from git tracking;
+ * this test pins the post-untrack invariant on the read side.
+ *
+ * @task T10314
+ * @epic T10283
+ * @saga T10281
+ * @adr ADR-013
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync as DatabaseSyncType } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getBrainDb } from '../db-connections.js';
+import type { ProjectContext } from '../project-context.js';
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (...args: ConstructorParameters<typeof DatabaseSyncType>) => DatabaseSyncType;
+};
+
+/**
+ * Create a minimal brain.db at the given path with just enough schema
+ * to exercise an idempotent INSERT path. We deliberately do NOT depend
+ * on `@cleocode/core` here — that would violate the brain-package
+ * boundary.
+ */
+function bootstrapMinimalBrainDb(dbPath: string): void {
+  mkdirSync(join(dbPath, '..'), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA foreign_keys = ON;
+      CREATE TABLE IF NOT EXISTS brain_sticky_notes (
+        id TEXT PRIMARY KEY,
+        content TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+  } finally {
+    db.close();
+  }
+}
+
+describe('brain reader idempotency contract (T10314)', () => {
+  let tempDir: string;
+  let cleoDir: string;
+  let brainDbPath: string;
+  let ctx: ProjectContext;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-brain-pkg-idempotency-'));
+    cleoDir = join(tempDir, '.cleo');
+    brainDbPath = join(cleoDir, 'brain.db');
+    ctx = {
+      projectPath: tempDir,
+      brainDbPath,
+      tasksDbPath: join(cleoDir, 'tasks.db'),
+    };
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns null when brain.db does not exist (negative path)', () => {
+    const db = getBrainDb(ctx);
+    expect(db).toBeNull();
+  });
+
+  it('opens twice against the same file with stable PRAGMAs (no churn)', () => {
+    bootstrapMinimalBrainDb(brainDbPath);
+
+    const firstHandle = getBrainDb(ctx);
+    expect(firstHandle).not.toBeNull();
+
+    const firstJournal = firstHandle!.prepare('PRAGMA journal_mode').get() as {
+      journal_mode: string;
+    };
+    expect(firstJournal.journal_mode).toBe('wal');
+
+    const firstFk = firstHandle!.prepare('PRAGMA foreign_keys').get() as {
+      foreign_keys: number;
+    };
+    expect(firstFk.foreign_keys).toBe(1);
+
+    firstHandle!.close();
+
+    const secondHandle = getBrainDb(ctx);
+    expect(secondHandle).not.toBeNull();
+
+    const secondJournal = secondHandle!.prepare('PRAGMA journal_mode').get() as {
+      journal_mode: string;
+    };
+    expect(secondJournal.journal_mode).toBe('wal');
+
+    const secondFk = secondHandle!.prepare('PRAGMA foreign_keys').get() as {
+      foreign_keys: number;
+    };
+    expect(secondFk.foreign_keys).toBe(1);
+
+    secondHandle!.close();
+  });
+
+  it('identical INSERT OR IGNORE writes do not duplicate rows across opens', () => {
+    bootstrapMinimalBrainDb(brainDbPath);
+
+    const insertSql =
+      "INSERT OR IGNORE INTO brain_sticky_notes (id, content, status) VALUES ('idem-1', 'first', 'active')";
+
+    // Open #1: run the insert, observe count = 1.
+    const handle1 = getBrainDb(ctx);
+    expect(handle1).not.toBeNull();
+    handle1!.exec(insertSql);
+    const count1 = handle1!.prepare('SELECT count(*) AS n FROM brain_sticky_notes').get() as {
+      n: number;
+    };
+    expect(count1.n).toBe(1);
+    handle1!.close();
+
+    // Open #2: re-run the SAME insert, observe count is still 1.
+    const handle2 = getBrainDb(ctx);
+    expect(handle2).not.toBeNull();
+    handle2!.exec(insertSql);
+    const count2 = handle2!.prepare('SELECT count(*) AS n FROM brain_sticky_notes').get() as {
+      n: number;
+    };
+    expect(count2.n).toBe(1);
+    handle2!.close();
+  });
+});

--- a/packages/core/src/store/__tests__/brain-idempotency.test.ts
+++ b/packages/core/src/store/__tests__/brain-idempotency.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Brain DB idempotency contract test.
+ *
+ * Saga T10281 / Epic T10283 E2-DB-INTEGRITY / Task T10314.
+ *
+ * Asserts that opening the canonical brain.db chokepoint twice and
+ * running the SAME write twice does not produce side-effects on the
+ * second run. The contract under test:
+ *
+ *   1. {@link getBrainDb} (the writer-side canonical opener in
+ *      `@cleocode/core/store/memory-sqlite.ts`) is the single chokepoint
+ *      for creating and migrating `brain.db`. It is idempotent across
+ *      calls inside the same process AND across process simulations
+ *      (close + re-open).
+ *   2. Identical INSERT statements with the same primary key + `INSERT
+ *      OR IGNORE` semantics do not duplicate rows on second run.
+ *   3. Migrations applied on the first open are NOT re-applied on the
+ *      second open (the Drizzle migration journal advances exactly once).
+ *   4. PRAGMA application is idempotent — the second open observes the
+ *      same WAL journal mode, the same foreign_keys, and the same
+ *      schema version sentinel.
+ *
+ * Sandboxing: every test runs inside an `mkdtempSync` directory and
+ * scopes the brain.db location via `CLEO_DIR`. The real user's
+ * `.cleo/` is never touched.
+ *
+ * Cross-link: ADR-013 §9 (Runtime Data Safety) — the brain DB is one
+ * of the four files explicitly excluded from git tracking; this test
+ * codifies the post-untrack invariant that re-opening the canonical
+ * chokepoint is safe regardless of how many times the developer
+ * switches branches or re-runs CLI verbs.
+ *
+ * @task T10314
+ * @epic T10283
+ * @saga T10281
+ * @adr ADR-013
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('brain.db idempotency contract (T10314)', () => {
+  let tempDir: string;
+  let cleoDir: string;
+  let originalCleoDir: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-brain-idempotency-'));
+    cleoDir = join(tempDir, '.cleo');
+    originalCleoDir = process.env['CLEO_DIR'];
+    process.env['CLEO_DIR'] = cleoDir;
+  });
+
+  afterEach(async () => {
+    const { closeBrainDb } = await import('../memory-sqlite.js');
+    closeBrainDb();
+    if (originalCleoDir === undefined) {
+      delete process.env['CLEO_DIR'];
+    } else {
+      process.env['CLEO_DIR'] = originalCleoDir;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('opening getBrainDb twice does not re-run migrations or duplicate rows', async () => {
+    const { getBrainDb, getBrainNativeDb, closeBrainDb } = await import('../memory-sqlite.js');
+
+    // --- First open + migration cycle ---
+    await getBrainDb();
+    const nativeAfterFirst = getBrainNativeDb();
+    expect(nativeAfterFirst).not.toBeNull();
+
+    const migrationsAfterFirst = nativeAfterFirst!
+      .prepare(
+        "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='__drizzle_migrations'",
+      )
+      .get() as { n: number };
+    expect(migrationsAfterFirst.n).toBe(1);
+
+    const firstMigrationCount = nativeAfterFirst!
+      .prepare('SELECT count(*) AS n FROM __drizzle_migrations')
+      .get() as { n: number };
+
+    // Insert a sticky-note (simple PK-driven idempotency target).
+    const insertSql =
+      "INSERT OR IGNORE INTO brain_sticky_notes (id, content, status) VALUES ('sticky-1', 'idempotency probe', 'active')";
+    nativeAfterFirst!.exec(insertSql);
+
+    const rowsAfterFirstInsert = nativeAfterFirst!
+      .prepare('SELECT count(*) AS n FROM brain_sticky_notes')
+      .get() as { n: number };
+    expect(rowsAfterFirstInsert.n).toBe(1);
+
+    // --- Simulate second process: close and re-open ---
+    closeBrainDb();
+    await getBrainDb();
+    const nativeAfterSecond = getBrainNativeDb();
+    expect(nativeAfterSecond).not.toBeNull();
+
+    // The drizzle migration journal must NOT grow on a second open.
+    const secondMigrationCount = nativeAfterSecond!
+      .prepare('SELECT count(*) AS n FROM __drizzle_migrations')
+      .get() as { n: number };
+    expect(secondMigrationCount.n).toBe(firstMigrationCount.n);
+
+    // Re-run the SAME insert — the second invocation must be a no-op
+    // because the primary key already exists.
+    nativeAfterSecond!.exec(insertSql);
+
+    const rowsAfterSecondInsert = nativeAfterSecond!
+      .prepare('SELECT count(*) AS n FROM brain_sticky_notes')
+      .get() as { n: number };
+    expect(rowsAfterSecondInsert.n).toBe(1);
+  });
+
+  it('schema version sentinel is stable across opens (no version churn)', async () => {
+    const { getBrainDb, getBrainNativeDb, closeBrainDb, BRAIN_SCHEMA_VERSION } = await import(
+      '../memory-sqlite.js'
+    );
+
+    await getBrainDb();
+    const native = getBrainNativeDb();
+    expect(native).not.toBeNull();
+
+    const versionRow = native!
+      .prepare("SELECT value FROM brain_schema_meta WHERE key = 'schemaVersion'")
+      .get() as { value: string } | undefined;
+    expect(versionRow?.value).toBe(BRAIN_SCHEMA_VERSION);
+
+    // Capture meta-row count and re-open.
+    const firstMetaCount = native!.prepare('SELECT count(*) AS n FROM brain_schema_meta').get() as {
+      n: number;
+    };
+
+    closeBrainDb();
+    await getBrainDb();
+    const nativeReopened = getBrainNativeDb();
+    expect(nativeReopened).not.toBeNull();
+
+    const secondMetaCount = nativeReopened!
+      .prepare('SELECT count(*) AS n FROM brain_schema_meta')
+      .get() as { n: number };
+
+    // Sentinel must not grow — schema_version is INSERT OR IGNORE so the
+    // second open should observe an identical row count.
+    expect(secondMetaCount.n).toBe(firstMetaCount.n);
+
+    const versionRowAfter = nativeReopened!
+      .prepare("SELECT value FROM brain_schema_meta WHERE key = 'schemaVersion'")
+      .get() as { value: string } | undefined;
+    expect(versionRowAfter?.value).toBe(BRAIN_SCHEMA_VERSION);
+  });
+
+  it('PRAGMA application is idempotent (WAL + foreign_keys stable)', async () => {
+    const { getBrainDb, getBrainNativeDb, closeBrainDb } = await import('../memory-sqlite.js');
+
+    await getBrainDb();
+    const nativeFirst = getBrainNativeDb();
+    expect(nativeFirst).not.toBeNull();
+
+    const journalFirst = nativeFirst!.prepare('PRAGMA journal_mode').get() as {
+      journal_mode: string;
+    };
+    expect(journalFirst.journal_mode).toBe('wal');
+
+    const fkFirst = nativeFirst!.prepare('PRAGMA foreign_keys').get() as {
+      foreign_keys: number;
+    };
+    expect(fkFirst.foreign_keys).toBe(1);
+
+    closeBrainDb();
+    await getBrainDb();
+    const nativeSecond = getBrainNativeDb();
+    expect(nativeSecond).not.toBeNull();
+
+    const journalSecond = nativeSecond!.prepare('PRAGMA journal_mode').get() as {
+      journal_mode: string;
+    };
+    expect(journalSecond.journal_mode).toBe('wal');
+
+    const fkSecond = nativeSecond!.prepare('PRAGMA foreign_keys').get() as {
+      foreign_keys: number;
+    };
+    expect(fkSecond.foreign_keys).toBe(1);
+  });
+});

--- a/packages/core/src/store/__tests__/conduit-idempotency.test.ts
+++ b/packages/core/src/store/__tests__/conduit-idempotency.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Conduit DB idempotency contract test.
+ *
+ * Saga T10281 / Epic T10283 E2-DB-INTEGRITY / Task T10314.
+ *
+ * Asserts that the canonical conduit.db chokepoint
+ * ({@link ensureConduitDb}) is idempotent across both open cycles and
+ * write replays. The contract:
+ *
+ *   1. The first call to `ensureConduitDb(projectRoot)` returns
+ *      `action: 'created'`. The second call (after the singleton is
+ *      closed to simulate a separate process) returns
+ *      `action: 'exists'` — confirming the schema-version sentinel
+ *      fast-path is engaged.
+ *   2. Running the SAME INSERT against the conduit handle twice
+ *      produces exactly one row. The chosen statement uses
+ *      `INSERT INTO ... ON CONFLICT DO UPDATE` semantics (matching
+ *      the canonical writer `attachAgentToProject`) so the second
+ *      write upserts and does not duplicate.
+ *   3. PRAGMAs are stable across opens (WAL mode, foreign_keys on).
+ *
+ * Sandboxing: every test runs inside an `mkdtempSync` directory and
+ * pins the conduit.db location to `<tmp>/.cleo/conduit.db`. The real
+ * user's `.cleo/` is never touched.
+ *
+ * Cross-link: ADR-013 §9 — although conduit.db is NOT among the four
+ * git-untracked runtime files listed in the original resolution, it is
+ * still gitignored at the parent level via `*.db` rules and shares the
+ * same "reopen-after-branch-switch must be safe" invariant.
+ *
+ * @task T10314
+ * @epic T10283
+ * @saga T10281
+ * @adr ADR-013
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  closeConduitDb,
+  ensureConduitDb,
+  getConduitDbPath,
+  getConduitNativeDb,
+} from '../conduit-sqlite.js';
+
+describe('conduit.db idempotency contract (T10314)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-conduit-idempotency-'));
+    closeConduitDb();
+  });
+
+  afterEach(() => {
+    closeConduitDb();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('ensureConduitDb returns created on first call and exists on second', () => {
+    const first = ensureConduitDb(tempDir);
+    expect(first.action).toBe('created');
+    expect(first.path).toBe(getConduitDbPath(tempDir));
+
+    // Close singleton — simulates a second CLI process.
+    closeConduitDb();
+
+    const second = ensureConduitDb(tempDir);
+    expect(second.action).toBe('exists');
+    expect(second.path).toBe(first.path);
+  });
+
+  it('identical agent attach writes do not duplicate rows', () => {
+    ensureConduitDb(tempDir);
+    const dbFirst = getConduitNativeDb();
+    expect(dbFirst).not.toBeNull();
+
+    const attachedAt = '2026-05-23T00:00:00.000Z';
+    const insertSql = `
+      INSERT INTO project_agent_refs (agent_id, attached_at, role, capabilities_override, last_used_at, enabled)
+      VALUES ('idem-agent', '${attachedAt}', NULL, NULL, NULL, 1)
+      ON CONFLICT(agent_id) DO UPDATE SET
+        enabled = 1,
+        attached_at = project_agent_refs.attached_at
+    `;
+    dbFirst!.exec(insertSql);
+
+    const countFirst = dbFirst!
+      .prepare('SELECT count(*) AS n FROM project_agent_refs WHERE agent_id = ?')
+      .get('idem-agent') as { n: number };
+    expect(countFirst.n).toBe(1);
+
+    // Simulate a second process — close singleton, reopen.
+    closeConduitDb();
+    const reopen = ensureConduitDb(tempDir);
+    expect(reopen.action).toBe('exists');
+
+    const dbSecond = getConduitNativeDb();
+    expect(dbSecond).not.toBeNull();
+
+    // Re-run the SAME insert. ON CONFLICT must keep row count at 1.
+    dbSecond!.exec(insertSql);
+
+    const countSecond = dbSecond!
+      .prepare('SELECT count(*) AS n FROM project_agent_refs WHERE agent_id = ?')
+      .get('idem-agent') as { n: number };
+    expect(countSecond.n).toBe(1);
+
+    // Original attached_at must be preserved by the ON CONFLICT clause —
+    // the second open's upsert intentionally keeps the historical value.
+    const row = dbSecond!
+      .prepare('SELECT attached_at, enabled FROM project_agent_refs WHERE agent_id = ?')
+      .get('idem-agent') as { attached_at: string; enabled: number };
+    expect(row.attached_at).toBe(attachedAt);
+    expect(row.enabled).toBe(1);
+  });
+
+  it('schema version sentinel does not double-write on second open', () => {
+    ensureConduitDb(tempDir);
+    const dbFirst = getConduitNativeDb();
+    expect(dbFirst).not.toBeNull();
+
+    const metaCountFirst = dbFirst!.prepare('SELECT count(*) AS n FROM _conduit_meta').get() as {
+      n: number;
+    };
+
+    closeConduitDb();
+    ensureConduitDb(tempDir);
+
+    const dbSecond = getConduitNativeDb();
+    expect(dbSecond).not.toBeNull();
+
+    const metaCountSecond = dbSecond!.prepare('SELECT count(*) AS n FROM _conduit_meta').get() as {
+      n: number;
+    };
+
+    // The sentinel uses INSERT OR REPLACE on a single `schema_version`
+    // key — row count must be identical on the second open.
+    expect(metaCountSecond.n).toBe(metaCountFirst.n);
+  });
+
+  it('PRAGMAs are stable across opens (WAL + foreign_keys)', () => {
+    ensureConduitDb(tempDir);
+    const dbFirst = getConduitNativeDb();
+    expect(dbFirst).not.toBeNull();
+
+    const journalFirst = dbFirst!.prepare('PRAGMA journal_mode').get() as {
+      journal_mode: string;
+    };
+    expect(journalFirst.journal_mode).toBe('wal');
+    const fkFirst = dbFirst!.prepare('PRAGMA foreign_keys').get() as { foreign_keys: number };
+    expect(fkFirst.foreign_keys).toBe(1);
+
+    closeConduitDb();
+    ensureConduitDb(tempDir);
+    const dbSecond = getConduitNativeDb();
+    expect(dbSecond).not.toBeNull();
+
+    const journalSecond = dbSecond!.prepare('PRAGMA journal_mode').get() as {
+      journal_mode: string;
+    };
+    expect(journalSecond.journal_mode).toBe('wal');
+    const fkSecond = dbSecond!.prepare('PRAGMA foreign_keys').get() as { foreign_keys: number };
+    expect(fkSecond.foreign_keys).toBe(1);
+  });
+});

--- a/packages/core/src/store/__tests__/llmtxt-idempotency.test.ts
+++ b/packages/core/src/store/__tests__/llmtxt-idempotency.test.ts
@@ -1,0 +1,95 @@
+/**
+ * `llmtxt` DB role idempotency contract test.
+ *
+ * Saga T10281 / Epic T10283 E2-DB-INTEGRITY / Task T10314.
+ *
+ * The canonical DB inventory (`packages/core/src/store/db-inventory.json`)
+ * registers `llmtxt` as a **reserved** role at
+ * `<projectRoot>/.cleo/llmtxt/llmtxt.db` whose opener
+ * (`openCleoDb('llmtxt', cwd)`) currently throws
+ * `"CLEO DB role llmtxt is not yet implemented"` (see
+ * `packages/core/src/store/open-cleo-db.ts:138`). Until the llmtxt-core
+ * package wires a live opener under this role, the idempotency contract
+ * for the role is the *error-stability* contract:
+ *
+ *   1. Calling `openCleoDb('llmtxt')` MUST throw a recognisable error
+ *      every single time — never partially succeed and never leave
+ *      stray file descriptors or DB files on disk.
+ *   2. Repeated invocations MUST throw the SAME error message — no
+ *      drift across calls, no nondeterminism that could leak through
+ *      to a caller relying on `catch (err)` and message-matching.
+ *   3. No `.cleo/llmtxt/` directory is materialised as a side-effect
+ *      of the failed open — the disk state observed before and after
+ *      the throw is identical.
+ *
+ * When the live llmtxt opener lands (tracked outside this task), this
+ * test is the canonical place to flip from "rejects identically" to
+ * "opens idempotently across two cycles + does not duplicate rows on
+ * identical writes."
+ *
+ * Sandboxing: every test runs inside an `mkdtempSync` directory.
+ *
+ * Cross-link: ADR-013 §9 — once live, the llmtxt DB joins tasks.db,
+ * brain.db, manifest.db, and conduit.db as a runtime-data SQLite file
+ * excluded from git tracking. This test pins the reopen invariant
+ * forward-compatibly.
+ *
+ * @task T10314
+ * @epic T10283
+ * @saga T10281
+ * @adr ADR-013
+ */
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { openCleoDb } from '../open-cleo-db.js';
+
+describe('llmtxt DB role idempotency contract (T10314)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-llmtxt-idempotency-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('openCleoDb("llmtxt") throws the canonical "not yet implemented" error', async () => {
+    await expect(openCleoDb('llmtxt', tempDir)).rejects.toThrow(/llmtxt is not yet implemented/);
+  });
+
+  it('repeated openCleoDb("llmtxt") calls throw identical messages (no drift)', async () => {
+    let firstMessage: string | undefined;
+    let secondMessage: string | undefined;
+
+    try {
+      await openCleoDb('llmtxt', tempDir);
+    } catch (err) {
+      firstMessage = err instanceof Error ? err.message : String(err);
+    }
+
+    try {
+      await openCleoDb('llmtxt', tempDir);
+    } catch (err) {
+      secondMessage = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(firstMessage).toBeDefined();
+    expect(secondMessage).toBeDefined();
+    expect(secondMessage).toBe(firstMessage);
+  });
+
+  it('no .cleo/llmtxt/ directory is materialised by a failed open', async () => {
+    const llmtxtDir = join(tempDir, '.cleo', 'llmtxt');
+    expect(existsSync(llmtxtDir)).toBe(false);
+
+    await expect(openCleoDb('llmtxt', tempDir)).rejects.toThrow();
+
+    // Disk state must be unchanged after the throw — failed open is
+    // forbidden to leak filesystem side-effects.
+    expect(existsSync(llmtxtDir)).toBe(false);
+  });
+});

--- a/packages/core/src/store/__tests__/manifest-idempotency.test.ts
+++ b/packages/core/src/store/__tests__/manifest-idempotency.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Manifest DB idempotency contract test.
+ *
+ * Saga T10281 / Epic T10283 E2-DB-INTEGRITY / Task T10314.
+ *
+ * `manifest.db` is the blob-attachment manifest SQLite database
+ * registered as `role: "manifest"` in
+ * `packages/core/src/store/db-inventory.json`. It lives at
+ * `<projectRoot>/.cleo/blobs/manifest.db` and is opened indirectly via
+ * the canonical chokepoint {@link CleoBlobStore.open}, which wraps
+ * llmtxt's `BlobFsAdapter` over a Drizzle handle.
+ *
+ * This test pins the manifest-DB idempotency invariants:
+ *
+ *   1. `open()` is idempotent within a single instance — a second call
+ *      is a no-op.
+ *   2. Opening a fresh store against the same `projectRoot` after
+ *      `close()` finds the existing `manifest.db` AND its existing
+ *      content-addressed blob bytes without recreating either.
+ *   3. Calling `attach(taskId, name, data)` twice with identical bytes
+ *      under the same `(taskId, name)` key resolves to the SAME
+ *      content-address SHA-256, and the underlying blob bytes do NOT
+ *      double-store on disk (BlobFsAdapter dedupes by hash).
+ *   4. The manifest survives across opens — `list(taskId)` after
+ *      reopen returns the attachment seeded in the first open cycle.
+ *
+ * Sandboxing: every test runs inside an `mkdtempSync` directory.
+ *
+ * Cross-link: ADR-013 §9 — `manifest.db` is the third project-tier
+ * SQLite database CLEO writes to (alongside tasks.db and brain.db).
+ * It joins the four originally-listed runtime files as a git-untracked
+ * runtime file; the reopen-after-branch-switch invariant must hold here
+ * too.
+ *
+ * @task T10314
+ * @epic T10283
+ * @saga T10281
+ * @adr ADR-013
+ */
+
+import { existsSync, readdirSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * Probe whether `node:sqlite` + `drizzle-orm/node-sqlite` are resolvable.
+ * Both ship with Node 24 and drizzle-orm v1.0.0-beta — this guard
+ * mirrors the existing llmtxt-blob-adapter.test.ts skip-if pattern.
+ */
+async function hasNodeSqlite(): Promise<boolean> {
+  try {
+    await import('node:sqlite');
+    await import('drizzle-orm/node-sqlite');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let peerDepsAvailable = false;
+beforeAll(async () => {
+  peerDepsAvailable = await hasNodeSqlite();
+});
+
+describe.skipIf(!(await hasNodeSqlite()))('manifest.db idempotency contract (T10314)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-manifest-idempotency-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('open() is idempotent within a single instance', async () => {
+    const { CleoBlobStore } = await import('../llmtxt-blob-adapter.js');
+    const store = new CleoBlobStore({ projectRoot: tempDir });
+
+    await store.open();
+    // Second open() must be a no-op — must not throw, must not
+    // re-bootstrap the manifest table.
+    await store.open();
+
+    // Smoke probe — store is still usable after the second open.
+    const data = new TextEncoder().encode('idempotency probe');
+    const first = await store.attach('T999', 'probe.txt', data, 'text/plain');
+    expect(first.attachmentId).toBeTruthy();
+
+    await store.close();
+  });
+
+  it('identical attach calls dedupe to the same SHA-256 and do not duplicate bytes', async () => {
+    const { CleoBlobStore } = await import('../llmtxt-blob-adapter.js');
+    const store = new CleoBlobStore({ projectRoot: tempDir });
+    await store.open();
+    try {
+      const data = new TextEncoder().encode('CLEO idempotency contract bytes');
+
+      const first = await store.attach('T314', 'doc.txt', data, 'text/plain');
+      const second = await store.attach('T314', 'doc.txt', data, 'text/plain');
+
+      // Same bytes ⇒ same content-address. (Attachment-id is per-row
+      // and may differ — LWW semantics — but the hash MUST be stable.)
+      expect(second.sha256).toBe(first.sha256);
+      expect(second.size).toBe(first.size);
+      expect(second.contentType).toBe(first.contentType);
+
+      // BlobFsAdapter stores bytes at `<storagePath>/blobs/<sha>` — a
+      // single file regardless of how many manifest rows reference it.
+      const blobsDir = join(tempDir, '.cleo', 'blobs', 'blobs');
+      expect(existsSync(blobsDir)).toBe(true);
+      const blobsOnDisk = readdirSync(blobsDir);
+      expect(blobsOnDisk).toHaveLength(1);
+
+      // The active manifest row for (taskId, name) returns the latest
+      // attachment.
+      const fetched = await store.get('T314', 'doc.txt');
+      expect(fetched).not.toBeNull();
+      expect(fetched!.hash).toBe(first.sha256);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('manifest.db survives close + reopen against the same projectRoot', async () => {
+    const { CleoBlobStore } = await import('../llmtxt-blob-adapter.js');
+
+    // First open cycle — seed an attachment.
+    const storeA = new CleoBlobStore({ projectRoot: tempDir });
+    await storeA.open();
+    const data = new TextEncoder().encode('persistence probe');
+    await storeA.attach('T315', 'note.txt', data, 'text/plain');
+    await storeA.close();
+
+    // Sanity: manifest.db exists on disk.
+    const manifestPath = join(tempDir, '.cleo', 'blobs', 'manifest.db');
+    expect(existsSync(manifestPath)).toBe(true);
+
+    // Second open cycle — fresh store instance, same projectRoot.
+    const storeB = new CleoBlobStore({ projectRoot: tempDir });
+    await storeB.open();
+    try {
+      // The list() call must return the attachment seeded in cycle A.
+      const items = await storeB.list('T315');
+      expect(items).toHaveLength(1);
+      expect(items[0].blobName).toBe('note.txt');
+
+      // Reissuing the same attach against the same bytes must not
+      // duplicate blob bytes on disk.
+      await storeB.attach('T315', 'note.txt', data, 'text/plain');
+
+      const blobsDir = join(tempDir, '.cleo', 'blobs', 'blobs');
+      const blobsOnDisk = readdirSync(blobsDir);
+      expect(blobsOnDisk).toHaveLength(1);
+    } finally {
+      await storeB.close();
+    }
+  });
+});
+
+// Reference the probe to silence "value assigned but never read" complaints
+// from analyzers that don't see vitest's lazy skip-if semantics. The variable
+// is set in `beforeAll` for diagnostic clarity.
+void peerDepsAvailable;


### PR DESCRIPTION
## Summary

Adds idempotency contract tests for the four remaining CLEO SQLite
chokepoints not already covered by ADR-013 §9's `tasks.db` regression
suite: `brain.db`, `conduit.db`, `manifest.db`, and the reserved
`llmtxt` role.

Each test opens the canonical chokepoint twice, replays identical
write operations, and asserts that the second run produces no
side-effects: no duplicate rows, no re-applied migrations, no
PRAGMA drift, no leaked filesystem state.

### New tests (5 files / 16 cases)

| File | Chokepoint under test | Cases |
|---|---|---|
| `packages/core/src/store/__tests__/brain-idempotency.test.ts` | `getBrainDb(cwd?)` in `memory-sqlite.ts` (writer) | 3 |
| `packages/brain/src/__tests__/brain-idempotency.test.ts` | `getBrainDb(ctx)` in `db-connections.ts` (reader) | 3 |
| `packages/core/src/store/__tests__/conduit-idempotency.test.ts` | `ensureConduitDb` in `conduit-sqlite.ts` | 4 |
| `packages/core/src/store/__tests__/manifest-idempotency.test.ts` | `CleoBlobStore.open` in `llmtxt-blob-adapter.ts` | 3 |
| `packages/core/src/store/__tests__/llmtxt-idempotency.test.ts` | `openCleoDb('llmtxt')` reserved-error contract | 3 |

### ADR-013 §9 amendment

A new subsection `Idempotency contract tests (T10314 — Saga T10281
SG-BRAIN-DB-RESILIENCE / Epic T10283 E2-DB-INTEGRITY)` was added to
the Resolution section of ADR-013, documenting which chokepoint each
file covers and the invariants asserted.

### Hard constraints met

- ✅ Uses canonical chokepoint openers (`getBrainDb`/`ensureConduitDb`/`openCleoDb`/`CleoBlobStore.open`).
- ✅ No `any`/`unknown`/`as unknown as` chains.
- ✅ ALL test setup uses `mkdtempSync` — the real user's `.cleo/` is never touched.

## Test plan

- [x] `pnpm biome check --write .` — clean (no fixes after rebase)
- [x] `pnpm run build` — clean (all packages, no TS errors)
- [x] `pnpm exec vitest run` on the 5 new files — 16/16 pass
- [x] `pnpm --filter @cleocode/brain run test` — 72/72 pass
- [x] `pnpm exec vitest run packages/core/src/store/__tests__/` — 1214/1214 pass
- [ ] CI green on PR

Closes T10314.
Saga: T10281.