### PR TITLE
refactor(core,cleo): T10331 sweep saga callsites to type discriminator

### DIFF
--- a/.changeset/T10331.md
+++ b/.changeset/T10331.md
@@ -1,0 +1,71 @@
+---
+id: T10331
+tasks: [T10331]
+kind: refactor
+summary: "Sweep production saga callsites from labels.includes('saga') to isSagaType / type==='saga' (Saga T10326 W2.B)"
+---
+
+W2.B of Saga T10326 SG-SUBSTRATE-RECONCILIATION (Epic T10277
+E-SAGA-TYPE-MIGRATION). Replaces production READ callsites that detected
+sagas via the legacy `labels.includes('saga')` / `hasSagaLabel(...)` /
+`isSagaEpic(...)` predicates with the dual-shape `isSagaType` (or
+`isSagaShape` for fully-typed `Task` rows) so the codebase keeps working
+during the deprecation window between W1's `type='saga'` introduction and
+W3.C's eventual removal of the old shape.
+
+## New helper
+
+`packages/core/src/sagas/is-saga-type.ts`
+- `isSagaType(t)` — lenient dual-shape predicate accepting any object with
+  optional `type` (`string | null`) and `labels` (`readonly string[] | null`)
+  fields. Matches NEW shape (`type === 'saga'`) OR OLD shape
+  (`type === 'epic' && labels.includes('saga')`).
+- Complements `isSagaShape` (W2.A T10330): `isSagaShape` narrows a typed
+  `Task` to `SagaTask`; `isSagaType` accepts wider `TaskRecord`-style rows
+  and returns a plain `boolean`.
+
+## Production sweep
+
+- `packages/cleo/src/dispatch/domains/focus.ts` (named anchor — AC13
+  persona linkage): `labels.includes('saga')` → `sagas.isSagaType(task)`.
+- `packages/core/src/tasks/generic-tree.ts` (named anchor): `toTreeKind`
+  dual-shape via `isSagaShape`.
+- `packages/core/src/sagas/list.ts:113-` (named anchor — dual-predicate
+  collapses to one): single `taskList({ type: 'epic', label: 'saga' })`
+  query split into two parallel `taskList` calls (`type: 'saga'` +
+  `type: 'epic', label: 'saga'`), merged + deduped by id.
+- `packages/core/src/sagas/storage.ts` (`resolveSagaMemberIds`,
+  `findSagasGroupingTask`): dual-shape detection via `isSagaShape` and
+  parallel union-query.
+- `packages/core/src/sagas/reconcile.ts` (no-`sagaId` branch): same
+  union-query pattern.
+- `packages/core/src/doctor/saga-audit.ts`: union-query + direct
+  `parentId != null` I5 check (removes the `as unknown as SagaTask`
+  escape-hatch from W2.A per AGENTS.md Type Safety rule).
+- `packages/core/src/release/plan.ts`: `(saga.labels ?? []).includes(SAGA_LABEL)`
+  → `isSagaShape(saga)`.
+- `packages/core/src/orchestrate/query-ops.ts`: `isSagaEpic(...)` body
+  widened to detect both shapes + `@deprecated` JSDoc pointer to
+  `isSagaShape`. Internal callsites (4) rewired to `isSagaShape`.
+
+## SAGA_LABEL deprecation
+
+`packages/core/src/sagas/constants.ts` — `SAGA_LABEL` declaration now
+carries a `@deprecated` JSDoc pointing at ADR-083 §2.5 + ADR-073 §1.2 I3.
+The identifier remains exported during the deprecation window so the
+saga write/repair paths and the I7 audit error string keep compiling.
+W3.C T10334 removes the export once the cutover metric confirms no live
+system still emits the legacy shape.
+
+## Tests
+
+Tests intentionally retain the legacy shape (`type='epic' + label='saga'`
+fixtures) to exercise the deprecation-window dual acceptance — they
+remain untouched. `isSagaShape` test coverage from W2.A already exercises
+both branches.
+
+## Saga linkage
+
+Saga: T10326 SG-SUBSTRATE-RECONCILIATION
+Epic: T10277 E-SAGA-TYPE-MIGRATION (W2.B)
+Refs: ADR-083 §2.5 (Saga as first-class TaskType), ADR-073 §1.2 I3

--- a/packages/cleo/src/dispatch/domains/focus.ts
+++ b/packages/cleo/src/dispatch/domains/focus.ts
@@ -36,6 +36,7 @@ import {
   createAttachmentStore,
   memoryFind,
   orchestrateReady,
+  sagas,
   taskRelates,
   taskShow,
 } from '@cleocode/core/internal';
@@ -244,8 +245,11 @@ async function buildFocusEnvelope(
   const task = showResult.data!.task;
 
   // ── 2. Determine entity tier ──────────────────────────────────────────────
-  const labels = Array.isArray(task.labels) ? (task.labels as string[]) : [];
-  const isSaga = labels.includes('saga');
+  // Dual-shape saga detection (T10331, Saga T10326 W2.B): accept both the
+  // canonical post-migration shape (`type === 'saga'`) and the legacy
+  // label-encoded shape (`type === 'epic' && labels.includes('saga')`).
+  // W3.C T10334 drops the legacy clause.
+  const isSaga = sagas.isSagaType(task);
   const isEpic = task.type === 'epic' && !isSaga;
   const entityType = isSaga ? 'saga' : isEpic ? 'epic' : 'task';
 

--- a/packages/core/src/doctor/saga-audit.ts
+++ b/packages/core/src/doctor/saga-audit.ts
@@ -36,12 +36,9 @@
 
 import type { SagaAuditEntry, SagaAuditResult, SagaAuditViolation } from '@cleocode/contracts';
 import {
-  assertSagaInvariantI5,
   assertSagaInvariantI7,
   isSagaInvariantViolationError,
   SAGA_GROUPS_RELATION,
-  SAGA_LABEL,
-  type SagaTask,
 } from '../sagas/index.js';
 import { taskList } from '../tasks/list.js';
 import { taskShow } from '../tasks/show.js';
@@ -146,18 +143,34 @@ async function measureMemberSubtreeDepth(
  * ```
  */
 export async function auditSagaHierarchy(projectRoot: string): Promise<SagaAuditResult> {
-  // Step 1 — list every saga-labeled epic (ADR-073 I1).
-  const listResult = await taskList(projectRoot, { type: 'epic', label: SAGA_LABEL });
+  // Step 1 — list every saga row (ADR-073 I1). T10331 (Saga T10326 W2.B):
+  // dual-shape sweep — query BOTH the canonical `type='saga'` rows AND the
+  // legacy `type='epic' + label='saga'` rows so not-yet-migrated rows still
+  // surface during the deprecation window. W3.C T10334 collapses to one query.
+  const [newShape, oldShape] = await Promise.all([
+    taskList(projectRoot, { type: 'saga' }),
+    taskList(projectRoot, { type: 'epic', label: 'saga' }),
+  ]);
   const sagas: SagaAuditEntry[] = [];
-  if (!listResult.success || !listResult.data?.tasks) {
+  if (!newShape.success && !oldShape.success) {
     return { sagas: [], count: 0, driftCount: 0 };
   }
 
   let totalInvariantViolations = 0;
   let totalDrift = 0;
 
-  // Iterate sagas in stable id order so the doctor output is deterministic.
-  const sagaRows = (listResult.data.tasks as TaskLike[]).slice().sort((a, b) => {
+  // Merge + dedupe by id, then iterate in stable id order so the doctor
+  // output is deterministic across runs.
+  const seenIds = new Set<string>();
+  const mergedRows: TaskLike[] = [];
+  const newShapeRows: TaskLike[] = newShape.success ? (newShape.data.tasks as TaskLike[]) : [];
+  const oldShapeRows: TaskLike[] = oldShape.success ? (oldShape.data.tasks as TaskLike[]) : [];
+  for (const row of [...newShapeRows, ...oldShapeRows]) {
+    if (!row.id || seenIds.has(row.id)) continue;
+    seenIds.add(row.id);
+    mergedRows.push(row);
+  }
+  const sagaRows = mergedRows.slice().sort((a, b) => {
     return (a.id ?? '').localeCompare(b.id ?? '');
   });
 
@@ -167,32 +180,25 @@ export async function auditSagaHierarchy(projectRoot: string): Promise<SagaAudit
     const violations: SagaAuditViolation[] = [];
 
     // --- I5 check (sagaRow.parentId IS NULL) ---
-    // Reuse the runtime guard so audit + runtime share one definition.
-    // Cast to SagaTask: audit only iterates rows already known to be sagas
-    // (returned by `taskList({ label: 'saga' })` upstream), so the dual-shape
-    // window guarantee in SagaTask holds. T10330 retyped the gate; this
-    // cast is the audit's pre-narrowing handshake (T10331 callsite sweep
-    // will replace with explicit isSagaShape narrowing on a typed task row).
-    try {
-      assertSagaInvariantI5({
-        id: sagaRow.id,
-        labels: sagaRow.labels ?? [],
-        parentId: sagaRow.parentId ?? null,
-        depends: sagaRow.depends ?? [],
-        type: 'epic',
-      } as unknown as SagaTask);
-    } catch (err) {
-      if (isSagaInvariantViolationError(err) && err.diag.invariant === 'I5') {
-        violations.push({
-          kind: 'I5',
-          sagaId: sagaRow.id,
-          offendingId: sagaRow.id,
-          message:
-            `Saga ${sagaRow.id} violates I5: parentId=${sagaRow.parentId ?? '<null>'}` +
-            ` — run \`cleo saga repair ${sagaRow.id}\``,
-          repairCommand: `cleo saga repair ${sagaRow.id}`,
-        });
-      }
+    // T10331 (Saga T10326 W2.B): the audit iterates rows already known to
+    // be sagas (returned by the dual-shape merged query above), so the I5
+    // invariant — `parentId MUST be NULL` (ADR-073 §1.2) — reduces to a
+    // direct field check. We previously cast `TaskLike` to `SagaTask` to
+    // route through `assertSagaInvariantI5`; that cast carried an
+    // `as unknown as` escape hatch and the gate only inspects `parentId`
+    // anyway. Inlining keeps the no-escape-hatch rule (AGENTS.md Type
+    // Safety) and preserves the violation message verbatim.
+    const sagaParentId = sagaRow.parentId ?? null;
+    if (sagaParentId !== null && sagaParentId !== '') {
+      violations.push({
+        kind: 'I5',
+        sagaId: sagaRow.id,
+        offendingId: sagaRow.id,
+        message:
+          `Saga ${sagaRow.id} violates I5: parentId=${sagaRow.parentId ?? '<null>'}` +
+          ` — run \`cleo saga repair ${sagaRow.id}\``,
+        repairCommand: `cleo saga repair ${sagaRow.id}`,
+      });
     }
 
     // --- Load relates so we can audit members ---

--- a/packages/core/src/orchestrate/query-ops.ts
+++ b/packages/core/src/orchestrate/query-ops.ts
@@ -24,6 +24,7 @@ import type { EnrichedWave } from '../orchestration/waves.js';
 import { getEnrichedWaves } from '../orchestration/waves.js';
 import { getProjectRoot } from '../paths.js';
 import { SAGA_GROUPS_RELATION, SAGA_LABEL } from '../sagas/constants.js';
+import { isSagaShape } from '../sagas/enforcement.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import type { DepGraphIssue } from '../tasks/dep-graph-validator.js';
 import { runValidation } from '../tasks/dep-graph-validator.js';
@@ -122,21 +123,38 @@ export type OrchestrateTraversal = 'parent' | 'saga' | 'both';
 /**
  * Single source of truth for the saga-shaped-epic check (ADR-073).
  *
- * A task is a saga when its `labels` array contains `'saga'` AND its `type`
- * is `'epic'`. Sagas are top-level grouping nodes whose members are linked
- * via `task_relations.type='groups'` rather than `parentId`.
+ * Dual-shape acceptance (T10331, Saga T10326 W2.B):
+ *   - Canonical post-migration shape: `type === 'saga'` — first-class
+ *     {@link TaskType} value introduced by W1.A T10328 (ADR-083 §2.5).
+ *   - Legacy label-encoded shape: `type === 'epic' && labels.includes('saga')`
+ *     — still produced by fixtures and not-yet-migrated rows during the
+ *     deprecation window. Removed in W3.C cutover (T10334).
+ *
+ * Sagas are top-level grouping nodes whose members are linked via
+ * `task_relations.type='groups'` rather than `parentId`.
  *
  * @param task - The task to inspect. Pass either a fully-loaded {@link Task}
  *               (with `labels` populated by `loadSingleTask` / `queryTasks`)
  *               or `null`/`undefined` (returns `false`).
- * @returns `true` when `task` is a saga-labeled epic.
+ * @returns `true` when `task` is a saga under either shape.
+ *
+ * @deprecated Prefer {@link isSagaShape} (`packages/core/src/sagas/enforcement.ts`)
+ *   when the caller holds a fully-typed {@link Task} — it returns a
+ *   compile-time type-narrowing predicate (`task is SagaTask`) instead of a
+ *   plain `boolean`. `isSagaEpic` remains for the in-file query-ops callers
+ *   that hold `Pick<Task,'type'|'labels'>` rows.
  *
  * @bug gh-390
  * @adr ADR-073
+ * @adr ADR-083 — Saga as first-class TaskType
  * @task T9839
+ * @task T10331
  */
 export function isSagaEpic(task: Pick<Task, 'type' | 'labels'> | null | undefined): boolean {
   if (!task) return false;
+  // New shape — first-class 'saga' TaskType (T10277 cutover).
+  if (task.type === 'saga') return true;
+  // Old shape — labelled epic (deprecation-window dual acceptance, T10334 drops).
   if (task.type !== 'epic') return false;
   return (task.labels ?? []).includes(SAGA_LABEL);
 }
@@ -422,7 +440,8 @@ export async function orchestrateReady(
     // detect the saga shape and aggregate ready-sets across member epics.
     // -------------------------------------------------------------------------
     const via: OrchestrateTraversal = opts?.via ?? 'both';
-    const sagaShaped = isSagaEpic(epic);
+    // T10331 (Saga T10326 W2.B): dual-shape saga detection via isSagaShape.
+    const sagaShaped = isSagaShape(epic);
     const useSagaWalk = via === 'saga' || (via === 'both' && sagaShaped);
 
     const accessor = await getTaskAccessor(root);
@@ -451,7 +470,8 @@ export async function orchestrateReady(
         // itself saga-labeled, skip it and surface the anomaly in meta rather
         // than recursing — preserves O(N) aggregation.
         const memberTask = tasks.find((t) => t.id === memberId);
-        if (memberTask && isSagaEpic(memberTask)) {
+        // T10331 (Saga T10326 W2.B): dual-shape saga detection via isSagaShape.
+        if (memberTask && isSagaShape(memberTask)) {
           skippedNested.push(memberId);
           continue;
         }
@@ -665,7 +685,8 @@ export async function orchestrateWaves(
     }
 
     const via: OrchestrateTraversal = opts?.via ?? 'both';
-    const sagaShaped = isSagaEpic(epic);
+    // T10331 (Saga T10326 W2.B): dual-shape saga detection via isSagaShape.
+    const sagaShaped = isSagaShape(epic);
     const useSagaWalk = via === 'saga' || (via === 'both' && sagaShaped);
 
     if (!useSagaWalk) {
@@ -684,7 +705,8 @@ export async function orchestrateWaves(
 
     for (const memberId of members) {
       const memberTask = await accessor.loadSingleTask(memberId);
-      if (memberTask && isSagaEpic(memberTask)) {
+      // T10331 (Saga T10326 W2.B): dual-shape saga detection via isSagaShape.
+      if (memberTask && isSagaShape(memberTask)) {
         skippedNested.push(memberId);
         continue;
       }

--- a/packages/core/src/release/plan.ts
+++ b/packages/core/src/release/plan.ts
@@ -53,7 +53,8 @@ import { parseChangesetDir } from '../changesets/index.js';
 import { getLogger } from '../logger.js';
 import { getCleoDirAbsolute, getProjectRoot } from '../paths.js';
 import { getProjectInfoSync } from '../project-info.js';
-import { SAGA_GROUPS_RELATION, SAGA_LABEL } from '../sagas/constants.js';
+import { SAGA_GROUPS_RELATION } from '../sagas/constants.js';
+import { isSagaShape } from '../sagas/enforcement.js';
 import { atomicWrite } from '../store/atomic.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { getDb } from '../store/sqlite.js';
@@ -455,7 +456,10 @@ async function resolveSagaTasks(sagaId: string, projectRoot: string): Promise<Sa
         memberResolutions: new Map(),
       };
     }
-    if (!(saga.labels ?? []).includes(SAGA_LABEL)) {
+    // T10331 (Saga T10326 W2.B): dual-shape saga detection — accept both the
+    // canonical `type='saga'` row and the legacy label-encoded epic until
+    // W3.C T10334 drops the old clause.
+    if (!isSagaShape(saga)) {
       return {
         tasks: [],
         sagaExists: true,

--- a/packages/core/src/sagas/constants.ts
+++ b/packages/core/src/sagas/constants.ts
@@ -22,6 +22,22 @@
  * member Epics through `task_relations.type='groups'` edges instead of the
  * `parentId` column.
  *
+ * @deprecated Since Wave 1 of Saga T10326 (Epic T10277) — saga is now a
+ *   first-class {@link TaskType} value. Migrated rows carry `type='saga'`
+ *   directly and no longer require this label (ADR-083 §2.5). The constant
+ *   is retained during the deprecation window so legacy `type='epic' AND
+ *   label='saga'` rows in long-lived sessions remain detectable via
+ *   {@link isSagaShape}. Removal is gated to W3.C T10334 once the cutover
+ *   metric confirms no live system still emits the legacy shape.
+ *
+ * Sweeps in W2.B (T10331) migrated production READ callsites to
+ * {@link isSagaShape}; the SAGA_LABEL identifier remains referenced only by
+ * (1) the saga write/repair paths that intentionally emit the label as a
+ * migration-shim, (2) the I7 audit comparison string, and (3) tests that
+ * exercise the deprecation-window dual-shape acceptance.
+ *
+ * @see ADR-083-saga-as-tasktype.md §2.5
+ * @see ADR-073-above-epic-naming.md §1.2 — invariant I3 (label is migration-only)
  * @see ADR-073-above-epic-naming.md §1 — Task Hierarchy Charter
  */
 export const SAGA_LABEL = 'saga' as const;

--- a/packages/core/src/sagas/index.ts
+++ b/packages/core/src/sagas/index.ts
@@ -37,6 +37,7 @@ export {
   SagaInvariantViolationError,
   type SagaTask,
 } from './enforcement.js';
+export { isSagaType } from './is-saga-type.js';
 export { type SagaInvariantI5Warning, type SagaListResult, sagaList } from './list.js';
 export {
   type SagaMemberEntry,

--- a/packages/core/src/sagas/is-saga-type.ts
+++ b/packages/core/src/sagas/is-saga-type.ts
@@ -1,0 +1,61 @@
+/**
+ * isSagaType — dual-shape saga discriminator for the deprecation window.
+ *
+ * After Wave 1 of Saga T10326 (Epic T10277), `'saga'` is a first-class
+ * {@link TaskType} value (ADR-083 §2.5). Existing rows with
+ * `type='epic' AND label='saga' AND parent_id IS NULL` were migrated to
+ * `type='saga'` and stripped of the redundant label by the
+ * `20260523213708_t10277-saga-tasktype` migration.
+ *
+ * This helper accepts BOTH shapes so the codebase keeps working while the
+ * deprecation window closes:
+ *
+ *   1. Canonical post-migration shape: `task.type === 'saga'`.
+ *   2. Legacy label-encoded shape: `task.type === 'epic' && labels.includes('saga')`
+ *      — still produced by fixtures, external imports, and test data that
+ *      intentionally exercises the deprecation window.
+ *
+ * Wave 3 of the saga (T10334) drops the OR clause once the cutover metric
+ * confirms no live system still emits the legacy shape. Until then, every
+ * production read MUST go through this helper (or {@link isSagaShape} for
+ * fully-typed {@link Task} rows) rather than inlining
+ * `labels.includes('saga')`.
+ *
+ * Complement to {@link isSagaShape} (W2.A T10330): `isSagaShape` narrows
+ * a strictly-typed `Task` to `SagaTask`; `isSagaType` accepts the wider
+ * `TaskRecord`-style row shape (where `type` is `string` rather than the
+ * `TaskType` union) and returns a plain `boolean`. Use `isSagaShape` when
+ * the caller holds a fully-typed `Task` and wants compile-time narrowing
+ * into the saga-gate input; use `isSagaType` when the caller holds a
+ * `TaskRecord` (e.g. from `taskShow` / `taskList`) or a partial row from
+ * a list response.
+ *
+ * @param t - Any object with `type` and optional `labels` fields.
+ * @returns `true` when the task is a saga under either shape.
+ *
+ * @example
+ * ```typescript
+ * const result = await taskShow(projectRoot, id);
+ * const task = result.data!.task; // TaskRecord — `type` is `string`
+ * if (isSagaType(task)) {
+ *   // dual-shape match — task is a saga (new OR legacy).
+ * }
+ * ```
+ *
+ * @task T10331 — W2.B sweep production callsites to isSagaType
+ * @saga T10326 — SG-SUBSTRATE-RECONCILIATION
+ * @epic T10277 — E-SAGA-TYPE-MIGRATION
+ * @see ADR-083-saga-as-tasktype.md §2.5
+ * @see ADR-073-above-epic-naming.md §1.2 invariant I3 — label is migration-only
+ */
+export function isSagaType(t: {
+  type?: string | null;
+  labels?: readonly string[] | null;
+}): boolean {
+  if (t.type === 'saga') return true;
+  if (t.type === 'epic') {
+    const labels = t.labels ?? [];
+    return labels.includes('saga');
+  }
+  return false;
+}

--- a/packages/core/src/sagas/list.ts
+++ b/packages/core/src/sagas/list.ts
@@ -111,15 +111,34 @@ const SAGA_LIST_HARD_LIMIT = 1000;
  * @param projectRoot - Absolute path to the project root.
  */
 export async function sagaList(projectRoot: string): Promise<EngineResult<SagaListResult>> {
-  const result = await taskList(projectRoot, {
-    type: 'epic',
-    label: 'saga',
-    limit: SAGA_LIST_HARD_LIMIT,
-  });
-  if (!result.success) {
-    return engineError('E_GENERAL', result.error?.message ?? 'Failed to list Sagas');
+  // T10331 (Saga T10326 W2.B): dual-shape sweep — query BOTH the canonical
+  // `type='saga'` rows AND the legacy `type='epic' + label='saga'` rows. The
+  // two predicates union into a single saga catalog during the deprecation
+  // window; W3.C T10334 collapses to the single new-shape query.
+  const [newShape, oldShape] = await Promise.all([
+    taskList(projectRoot, { type: 'saga', limit: SAGA_LIST_HARD_LIMIT }),
+    taskList(projectRoot, {
+      type: 'epic',
+      label: 'saga',
+      limit: SAGA_LIST_HARD_LIMIT,
+    }),
+  ]);
+  if (!newShape.success) {
+    return engineError('E_GENERAL', newShape.error?.message ?? 'Failed to list Sagas');
   }
-  const tasks = result.data?.tasks ?? [];
+  if (!oldShape.success) {
+    return engineError('E_GENERAL', oldShape.error?.message ?? 'Failed to list Sagas');
+  }
+  // Merge + dedupe by id (insertion-order stable: new-shape rows first).
+  const seenIds = new Set<string>();
+  const newShapeTasks = newShape.data?.tasks ?? [];
+  const oldShapeTasks = oldShape.data?.tasks ?? [];
+  const tasks: Array<(typeof newShapeTasks)[number]> = [];
+  for (const t of [...newShapeTasks, ...oldShapeTasks]) {
+    if (seenIds.has(t.id)) continue;
+    seenIds.add(t.id);
+    tasks.push(t);
+  }
 
   // T10117: loud-include — every saga-labeled row surfaces, with one warning
   // per I5 violator. We collect warnings inline rather than filtering them

--- a/packages/core/src/sagas/reconcile.ts
+++ b/packages/core/src/sagas/reconcile.ts
@@ -631,19 +631,37 @@ export async function reconcileSaga(
   if (params.sagaId && params.sagaId.length > 0) {
     sagaIds = [params.sagaId];
   } else {
-    const listResult = await taskList(projectRoot, { type: 'epic', label: SAGA_LABEL });
-    if (!listResult.success) {
+    // T10331 (Saga T10326 W2.B): dual-shape sweep — query BOTH the canonical
+    // `type='saga'` rows AND the legacy `type='epic' + label='saga'` rows so
+    // not-yet-migrated rows still surface during the deprecation window.
+    // W3.C T10334 collapses to a single new-shape query.
+    const [newShape, oldShape] = await Promise.all([
+      taskList(projectRoot, { type: 'saga' }),
+      taskList(projectRoot, { type: 'epic', label: SAGA_LABEL }),
+    ]);
+    if (!newShape.success) {
       return engineError(
         'E_GENERAL',
-        listResult.error?.message ?? 'Failed to list sagas for reconcile',
+        newShape.error?.message ?? 'Failed to list sagas for reconcile',
       );
     }
-    const rows = listResult.data?.tasks ?? [];
-    sagaIds = rows
-      .map((t) => (t as { id?: string }).id)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0)
-      // Stable order so cron output is deterministic across runs.
-      .sort((a, b) => a.localeCompare(b));
+    if (!oldShape.success) {
+      return engineError(
+        'E_GENERAL',
+        oldShape.error?.message ?? 'Failed to list sagas for reconcile',
+      );
+    }
+    const seenSagaIds = new Set<string>();
+    const mergedIds: string[] = [];
+    for (const t of [...(newShape.data?.tasks ?? []), ...(oldShape.data?.tasks ?? [])]) {
+      const id = (t as { id?: string }).id;
+      if (typeof id !== 'string' || id.length === 0) continue;
+      if (seenSagaIds.has(id)) continue;
+      seenSagaIds.add(id);
+      mergedIds.push(id);
+    }
+    // Stable order so cron output is deterministic across runs.
+    sagaIds = mergedIds.sort((a, b) => a.localeCompare(b));
   }
 
   const entries: SagaReconcileEntry[] = [];

--- a/packages/core/src/sagas/storage.ts
+++ b/packages/core/src/sagas/storage.ts
@@ -20,7 +20,8 @@
 
 import type { GateEvidence, Task, TaskVerification, VerificationGate } from '@cleocode/contracts';
 import type { DataAccessor } from '../store/data-accessor.js';
-import { SAGA_GROUPS_RELATION, SAGA_LABEL } from './constants.js';
+import { SAGA_GROUPS_RELATION } from './constants.js';
+import { isSagaShape } from './enforcement.js';
 
 /**
  * Resolve Saga member Epic IDs through `task_relations.type='groups'` edges.
@@ -49,7 +50,8 @@ export async function resolveSagaMemberIds(
 ): Promise<string[] | null> {
   const sagaTask = await accessor.loadSingleTask(sagaId);
   if (!sagaTask) return null;
-  if (!(sagaTask.labels ?? []).includes(SAGA_LABEL)) return null;
+  // T10331 (Saga T10326 W2.B): dual-shape acceptance via isSagaShape.
+  if (!isSagaShape(sagaTask)) return null;
   const seen = new Set<string>();
   const memberIds: string[] = [];
   for (const relation of sagaTask.relates ?? []) {
@@ -98,10 +100,20 @@ export async function findSagasGroupingTask(
   accessor: DataAccessor,
   memberId: string,
 ): Promise<Task[]> {
-  const { tasks: sagas } = await accessor.queryTasks({ type: 'epic', label: 'saga' });
+  // T10331 (Saga T10326 W2.B): dual-shape sweep — query BOTH the canonical
+  // `type='saga'` rows AND the legacy `type='epic' + label='saga'` rows so
+  // not-yet-migrated rows in long-lived sessions still surface during the
+  // deprecation window. W3.C T10334 collapses to the single new-shape query.
+  const [newShape, oldShape] = await Promise.all([
+    accessor.queryTasks({ type: 'saga' }),
+    accessor.queryTasks({ type: 'epic', label: 'saga' }),
+  ]);
+  const seenIds = new Set<string>();
   const matches: Task[] = [];
-  for (const saga of sagas) {
-    if (!(saga.labels ?? []).includes(SAGA_LABEL)) continue;
+  for (const saga of [...newShape.tasks, ...oldShape.tasks]) {
+    if (seenIds.has(saga.id)) continue;
+    seenIds.add(saga.id);
+    if (!isSagaShape(saga)) continue;
     const hasMemberEdge = (saga.relates ?? []).some(
       (relation) => relation.type === SAGA_GROUPS_RELATION && relation.taskId === memberId,
     );

--- a/packages/core/src/tasks/generic-tree.ts
+++ b/packages/core/src/tasks/generic-tree.ts
@@ -23,7 +23,8 @@ import type {
   TreeNodeStatus,
   TreeResponse,
 } from '@cleocode/contracts';
-import { SAGA_GROUPS_RELATION, SAGA_LABEL } from '../sagas/constants.js';
+import { SAGA_GROUPS_RELATION } from '../sagas/constants.js';
+import { isSagaShape } from '../sagas/enforcement.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { getLeafBlockers, getTransitiveBlockers } from './dependency-check.js';
 
@@ -144,12 +145,18 @@ function toTreeStatus(status: TaskStatus): TreeNodeStatus {
 /**
  * Map a {@link Task} record to the typed {@link TreeNodeKind} discriminator.
  *
- * Sagas are stored as `type='epic'` rows that carry the `'saga'` label —
- * those resolve to `'saga'`. Everything else maps 1:1 from `Task.type`,
- * with `'task'` as the safe fallback when the type column is missing.
+ * Dual-shape saga acceptance (T10331, Saga T10326 W2.B):
+ *   - Canonical post-migration shape: `type === 'saga'` — first-class
+ *     {@link TaskType} value introduced by W1.A T10328 (ADR-083 §2.5).
+ *   - Legacy label-encoded shape: `type === 'epic' && labels.includes('saga')`
+ *     — still produced by fixtures and not-yet-migrated rows during the
+ *     deprecation window. Removed in W3.C cutover (T10334).
+ *
+ * Everything else maps 1:1 from `Task.type`, with `'task'` as the safe
+ * fallback when the type column is missing.
  */
 function toTreeKind(task: Task): TreeNodeKind {
-  if (task.type === 'epic' && (task.labels ?? []).includes(SAGA_LABEL)) return 'saga';
+  if (isSagaShape(task)) return 'saga';
   if (task.type === 'epic') return 'epic';
   if (task.type === 'subtask') return 'subtask';
   return 'task';


### PR DESCRIPTION
## Summary
- Sweeps production callsites from `labels.includes('saga')` / `hasSagaLabel` / `isSagaEpic` to dual-shape `isSagaType` / `isSagaShape`
- SAGA_LABEL retained with `@deprecated`; removal gated to W3.C T10334
- Tests intentionally retain legacy shape (deprecation-window assertions)
- Wave 2B of SAGA T10326 (W2.A T10330 shipped via PR #598)

## New helper
`packages/core/src/sagas/is-saga-type.ts` — `isSagaType(t)`: lenient dual-shape predicate accepting any object with optional `type` / `labels` fields. Matches NEW shape (`type === 'saga'`) OR OLD shape (`type === 'epic' && labels.includes('saga')`). Complements `isSagaShape` (W2.A T10330) which narrows fully-typed `Task` to `SagaTask`.

## Callsite count
- Pre-sweep production hits: **55**
- Post-sweep production hits: **46** (only `@deprecated` SAGA_LABEL constant, docstring/JSDoc references, and saga write-path validators remain — all intentional for the deprecation window)

## Files touched (production)
- `packages/cleo/src/dispatch/domains/focus.ts` — named anchor (AC13 persona linkage)
- `packages/core/src/tasks/generic-tree.ts` — named anchor (`toTreeKind`)
- `packages/core/src/sagas/list.ts` — named anchor (dual-predicate collapses via parallel union-query)
- `packages/core/src/sagas/storage.ts` — `resolveSagaMemberIds`, `findSagasGroupingTask`
- `packages/core/src/sagas/reconcile.ts` — no-sagaId branch dual-shape query
- `packages/core/src/doctor/saga-audit.ts` — union-query + direct `parentId` check (removes `as unknown as SagaTask` escape-hatch from W2.A)
- `packages/core/src/release/plan.ts` — `isSagaShape`
- `packages/core/src/orchestrate/query-ops.ts` — `isSagaEpic` widened + `@deprecated`, 4 internal callsites swept to `isSagaShape`
- `packages/core/src/sagas/constants.ts` — `SAGA_LABEL` `@deprecated` JSDoc
- `packages/core/src/sagas/index.ts` — re-export `isSagaType`

## Test plan
- [x] `pnpm run build` green (contracts + core + cleo + all packages)
- [x] All 124 saga/orchestrate/release/doctor/dispatch vitest files green (1575 tests)
- [x] `focus.ts` persona linkage uses `isSagaType` via `sagas.isSagaType(task)`
- [x] `sagas/list.ts` + `generic-tree.ts` use the helpers
- [x] No new `any` / `as unknown as` casts — removed W2.A's audit cast
- [x] `pnpm-lock.yaml` unchanged
- [x] `ADR-057 SSoT lint` passed
- [x] Pre-existing flakes in `audit/reconstruct`, `llm/credential-writeback`, `release/backfill` are unrelated to sagas

Closes T10331
Saga: T10326 SG-SUBSTRATE-RECONCILIATION
Epic: T10277 E-SAGA-TYPE-MIGRATION
Refs: ADR-083 §2.5, ADR-073 §1.2 I3