### PR TITLE
T10313: SQLite version pin + upstream bug-tracker reference (Saga T10281 / E2)

### DIFF
--- a/.changeset/T10313.md
+++ b/.changeset/T10313.md
@@ -1,0 +1,28 @@
+---
+id: t10313-sqlite-version-pin
+tasks: [T10313]
+kind: feat
+summary: "Pin SQLite version + reference upstream bug-tracker in specs/sqlite-pragmas.json"
+---
+
+Adds `sqliteVersionPin` block to `specs/sqlite-pragmas.json` declaring the
+currently-pinned node:sqlite SQLite library version (3.51.2), the minimum
+Node runtime (`24.13.0`), and the upstream bug-tracker URL
+(`https://sqlite.org/src/timeline`).
+
+Saga T10281 / Epic T10283 (E2-DB-INTEGRITY) recorded a live brain.db
+malformation on 2026-05-23 under node:sqlite v3.51.2 (`ERR_SQLITE_ERROR
+errcode=11`; `epic:T1075` signature in the diagnostic dump). T10301 RCA
+(D012) identified an upstream concurrent-write race as the suspect class.
+The pin is held until the upstream fix is confirmed via the bug tracker.
+
+Bumps `engines.node` to `>=24.13.0` in the monorepo root, `@cleocode/core`,
+and `@cleocode/cleo` package.json files.
+
+Adds `packages/core/src/__tests__/sqlite-version-pin.test.ts` — a soft pin
+assertion that fails only when the JSON SSoT loses the `sqliteVersionPin`
+block, and warns (without failing) when `process.versions.sqlite` drifts
+from the declared version.
+
+Documents the pin rationale near the consumer in
+`packages/core/src/store/sqlite-pragmas.ts`.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.30.0",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.13.0"
   },
   "scripts": {
     "build": "node build.mjs",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -60,7 +60,7 @@
     }
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.13.0"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -381,7 +381,7 @@
     "jsonrepair": "^3.8.0"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.13.0"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/core/src/__tests__/sqlite-version-pin.test.ts
+++ b/packages/core/src/__tests__/sqlite-version-pin.test.ts
@@ -1,0 +1,130 @@
+/**
+ * SQLite version pin assertion — T10313 (Saga T10281 / Epic T10283).
+ *
+ * `specs/sqlite-pragmas.json` declares `sqliteVersionPin.version` — the
+ * node:sqlite SQLite library version that the CLEO project is currently
+ * pinned against. The live brain.db malformation recorded in Saga T10281
+ * on 2026-05-23 (`epic:T1075` signature, `ERR_SQLITE_ERROR errcode=11`)
+ * occurred under node:sqlite v3.51.2; upstream concurrent-write race is
+ * suspected per T10301 RCA (D012).
+ *
+ * The pin is held until the upstream fix is confirmed via
+ * `https://sqlite.org/src/timeline`.
+ *
+ * **Soft pin semantics**: this test logs a warning when
+ * `process.versions.sqlite` differs from the declared pin but does NOT
+ * fail the suite. Hard-failing on every Node minor release would break
+ * the whole pipeline; the goal is observability + a deliberate review
+ * step when the upstream library changes.
+ *
+ * The assertion that DOES fail: the JSON SSoT must declare a
+ * `sqliteVersionPin` block with a well-formed `version` string. That
+ * guarantees the pin can never be silently removed.
+ *
+ * @task T10313
+ * @saga T10281
+ * @epic T10283
+ * @see specs/sqlite-pragmas.json (SSoT for the pin)
+ * @see packages/core/src/store/sqlite-pragmas.ts (consumer docs)
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Shape of the SQLite version pin block in `specs/sqlite-pragmas.json`.
+ * Only the fields this test consumes are typed.
+ */
+interface SqliteVersionPin {
+  readonly version: string;
+  readonly source: string;
+  readonly nodeMinimum: string;
+  readonly upstreamBugTracker: string;
+  readonly rationale: string;
+}
+
+/**
+ * Shape of the parts of `specs/sqlite-pragmas.json` this test reads.
+ */
+interface SqlitePragmaSpecWithPin {
+  readonly version: number;
+  readonly sqliteVersionPin: SqliteVersionPin;
+}
+
+/**
+ * Load the SSoT JSON from the repo specs directory.
+ */
+function loadSpec(): SqlitePragmaSpecWithPin {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // packages/core/src/__tests__/ → repo root is 5 levels up
+  const specPath = resolve(here, '..', '..', '..', '..', 'specs', 'sqlite-pragmas.json');
+  const raw = readFileSync(specPath, 'utf8');
+  return JSON.parse(raw) as SqlitePragmaSpecWithPin;
+}
+
+/** Match `X.Y.Z` semver-ish strings (numbers only — no pre-release tags). */
+const SEMVER_TRIPLE = /^\d+\.\d+\.\d+$/;
+
+describe('sqlite version pin (T10313 · Saga T10281)', () => {
+  it('specs/sqlite-pragmas.json declares a well-formed sqliteVersionPin block', () => {
+    const spec = loadSpec();
+    expect(spec.sqliteVersionPin).toBeDefined();
+
+    const pin = spec.sqliteVersionPin;
+    expect(typeof pin.version).toBe('string');
+    expect(pin.version).toMatch(SEMVER_TRIPLE);
+
+    expect(typeof pin.nodeMinimum).toBe('string');
+    expect(pin.nodeMinimum).toMatch(SEMVER_TRIPLE);
+
+    expect(typeof pin.source).toBe('string');
+    expect(pin.source.length).toBeGreaterThan(0);
+
+    expect(typeof pin.upstreamBugTracker).toBe('string');
+    expect(pin.upstreamBugTracker).toMatch(/^https?:\/\//);
+
+    expect(typeof pin.rationale).toBe('string');
+    expect(pin.rationale.length).toBeGreaterThan(20);
+  });
+
+  it('warns (but does not fail) when process.versions.sqlite drifts from the pin', () => {
+    const spec = loadSpec();
+    const declared = spec.sqliteVersionPin.version;
+    const actual = process.versions.sqlite;
+
+    // process.versions.sqlite is set by node:sqlite on Node >= 22.5 with
+    // --experimental-sqlite, and unconditionally on Node 24+. If the
+    // runtime is older or the field is absent, skip the comparison (the
+    // pin still asserts via the structural test above).
+    if (typeof actual !== 'string' || actual.length === 0) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[T10313] process.versions.sqlite is not exposed by this Node runtime — ` +
+          `pin comparison skipped (declared pin: ${declared}).`,
+      );
+      return;
+    }
+
+    if (actual !== declared) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[T10313] node:sqlite drift detected: process.versions.sqlite=${actual} ` +
+          `but specs/sqlite-pragmas.json sqliteVersionPin.version=${declared}. ` +
+          `Saga T10281 records the live brain.db malformation under ${declared}; ` +
+          `if upstream has shipped a fix, confirm via ` +
+          `${spec.sqliteVersionPin.upstreamBugTracker} and bump the pin.`,
+      );
+    }
+
+    // Soft pin: always pass. The warning above is the signal.
+    expect(typeof actual).toBe('string');
+  });
+
+  it('declares an upstream bug-tracker URL for traceability', () => {
+    const spec = loadSpec();
+    const url = spec.sqliteVersionPin.upstreamBugTracker;
+    expect(url).toMatch(/^https?:\/\/.+/);
+  });
+});

--- a/packages/core/src/store/sqlite-pragmas.ts
+++ b/packages/core/src/store/sqlite-pragmas.ts
@@ -62,7 +62,19 @@
  * `journal_mode = WAL` if not already set) silently no-op on read-only
  * handles, which is fine — the writer set WAL when it created the DB.
  *
- * @task T-PERF-PRAGMAS, T9053, T9157
+ * @task T-PERF-PRAGMAS, T9053, T9157, T10313
+ *
+ * @remarks SQLite version pin (T10313, Saga T10281 / Epic T10283 E2-DB-INTEGRITY)
+ *
+ * `specs/sqlite-pragmas.json` declares `sqliteVersionPin.version = "3.51.2"` and
+ * `nodeMinimum = "24.13.0"`. This saga's brain.db malformation (T10281,
+ * 2026-05-23) occurred under node:sqlite v3.51.2 — upstream concurrent-write
+ * race suspected per T10301 RCA (D012). Pin maintained until upstream fix
+ * confirmed via `https://sqlite.org/src/timeline`.
+ *
+ * The pin is enforced as a SOFT pin: `sqlite-version-pin.test.ts` warns when
+ * `process.versions.sqlite` differs from the declared version but does NOT
+ * fail the gate. Hard-pinning here would break every Node minor release.
  */
 
 import type { DatabaseSync } from 'node:sqlite';

--- a/specs/sqlite-pragmas.json
+++ b/specs/sqlite-pragmas.json
@@ -6,6 +6,17 @@
     "title": "CLEO SQLite performance pragma policy",
     "description": "Tuned for multi-process CLI workloads against shared project DBs (tasks.db, brain.db, conduit.db). WAL + NORMAL synchronous gives durable-on-commit with last-tx tolerance on power cut; busy_timeout queues concurrent writers; cache_size and mmap_size keep hot pages in memory."
   },
+  "sqliteVersionPin": {
+    "version": "3.51.2",
+    "source": "node:sqlite (bundled with Node.js 24.13.x)",
+    "nodeMinimum": "24.13.0",
+    "upstreamBugTracker": "https://sqlite.org/src/timeline",
+    "nodeSqliteIssues": "https://github.com/nodejs/node/issues?q=is%3Aissue+label%3Asqlite",
+    "rationale": "Saga T10281 (E-DB-INTEGRITY) recorded a live brain.db malformation on 2026-05-23 under node:sqlite v3.51.2 (errcode=11 ERR_SQLITE_ERROR; `epic:T1075` signature in the diagnostic dump). T10301 RCA (D012) identified upstream concurrent-write race as the suspect class. This pin is held until the upstream fix is confirmed via the bug tracker above. The pin is a soft pin (warn on mismatch, do not fail) — `packages/core/src/__tests__/sqlite-version-pin.test.ts` is the gate.",
+    "task": "T10313",
+    "saga": "T10281",
+    "epic": "T10283"
+  },
   "pragmas": [
     ["busy_timeout", "5000"],
     ["journal_mode", "WAL"],


### PR DESCRIPTION
## Summary

- Adds `sqliteVersionPin` block to `specs/sqlite-pragmas.json` declaring the currently-pinned node:sqlite SQLite library version (3.51.2), `nodeMinimum` (24.13.0), and the upstream bug-tracker URL (`https://sqlite.org/src/timeline`).
- Bumps `engines.node` to `>=24.13.0` in the monorepo root, `@cleocode/core`, and `@cleocode/cleo` package.json files. Node 24.13.x ships `node:sqlite` v3.51.2.
- Adds `packages/core/src/__tests__/sqlite-version-pin.test.ts` — a SOFT pin: warns (without failing) when `process.versions.sqlite` drifts from the declared version; structurally fails only if the pin block is removed.
- Documents the rationale + saga link near the consumer in `packages/core/src/store/sqlite-pragmas.ts`.
- Adds `.changeset/T10313.md`.

## Why

Saga T10281 (Epic T10283 E-DB-INTEGRITY) recorded a live `brain.db` malformation on 2026-05-23 under `node:sqlite` v3.51.2 (`ERR_SQLITE_ERROR errcode=11`; `epic:T1075` signature in the diagnostic dump). T10301 RCA (D012) identified an upstream concurrent-write race as the suspect class. This pin is held until the upstream fix is confirmed via the bug tracker.

The pin is intentionally SOFT — hard-failing on every Node minor release would break the whole pipeline; the goal is observability + a deliberate review step when the upstream library changes.

## Test plan

- [x] `pnpm biome check --write .` — clean (0 fixes applied)
- [x] `pnpm run build` — green
- [x] `pnpm exec vitest run packages/core` — 3/3 new tests pass; existing `sqlite-pragmas-ssot.test.ts` + `pragma-drift-guard.test.ts` still pass; 2 unrelated pre-existing failures (audit/reconstruct, credential-writeback, release/backfill) untouched
- [x] No `any` / `unknown` / `as unknown as` introduced
- [x] All file changes within `packages/core/`, `packages/cleo/`, root `package.json`, `specs/`, `.changeset/` — no boundary violations

Closes T10313
Saga: T10281