### PR TITLE
docs(adr,test): T10333 ADR-073 §4 amend + SG- display snapshots

### DIFF
--- a/.changeset/t10333-adr-073-sg-display-snapshots.md
+++ b/.changeset/t10333-adr-073-sg-display-snapshots.md
@@ -1,0 +1,6 @@
+---
+id: t10333-adr-073-sg-display-snapshots
+tasks: [T10333]
+kind: docs
+summary: Amend ADR-073 §4 to retire 'Saga is NOT a TaskType' (forward-points at ADR-083 §2.5); add SG- display preservation snapshot tests (cleo renderers + core toTreeKind) proving both saga storage shapes render identically (Saga T10326 W3.B)
+---

--- a/.cleo/adrs/ADR-073-above-epic-naming.md
+++ b/.cleo/adrs/ADR-073-above-epic-naming.md
@@ -217,21 +217,31 @@ a hybrid. The Council reached 5/5 unanimous PASS across all four gate dimensions
 
 ---
 
-## §4 Storage Shape (preserved from 2026-05-17)
+## §4 Storage Shape
 
-**Saga is NOT a new `TaskType` enum value.** It is a labeled role that a
-top-level Epic plays. Concretely:
+> **AMENDED 2026-05-23 (T10333 under Saga T10326 SG-SUBSTRATE-RECONCILIATION):**
+> The original §4 stance — "Saga is NOT a new `TaskType` enum value" — has
+> been **RETIRED**. ADR-083 §2.5 (2026-05-23, "Saga as TaskType discriminator")
+> elevated Saga to a first-class `TaskType` value after six months of dogfood
+> exposed the structural fragility of the label-overlay encoding (90
+> `labels.includes('saga')` sites, ambiguous-transition risk during
+> reparenting, untyped vectorized traversal). The canonical post-migration
+> storage encoding is `type='saga'`; the legacy `type='epic' AND label='saga'`
+> encoding remains accepted during the deprecation window via the dual-shape
+> predicate `isSagaShape` (`packages/core/src/sagas/enforcement.ts`).
+>
+> **Canon for the type/label question lives in ADR-083 §2.5.** This section
+> is preserved as historical context (see §8 Change Log for the verbatim
+> original text). §4.1 (Wire mechanism) and §4.2 (Gating dependency) below
+> remain in force unchanged — the `task_relations.type='groups'` membership
+> edge and the T9514 writer-fix dependency are orthogonal to the type/label
+> encoding decision and survive the migration intact.
 
-- A Saga is an existing `type='epic'` task with `label='saga'` set via
-  `cleo update --label saga` (or created directly via `cleo saga create`).
-- The `TaskType` enum remains `{subtask, task, epic}` per ADR-066. No schema
-  migration is required.
-- Saga-level grouping is expressed through `task_relations.type='groups'` edges
-  (implemented in T9519) that link the Saga-labeled Epic to its child Epics.
-
-This protects against future drift where someone proposes adding `saga` to the
-`TaskType` enum. If such a proposal surfaces, it MUST reference this clause and
-provide a full migration path for every existing Saga.
+The migration filed by ADR-083 §2.5 (Epic `E-SAGA-TYPE-MIGRATION`, T10277,
+under Saga T10326) is the canonical source for the cutover semantics. Until
+the W3.C cutover (T10334) closes, runtime code MUST accept both shapes via
+`isSagaShape`. After cutover, the `'saga'` label is dropped from
+`labels[]` and `isSagaType(task.type)` becomes the single-source check.
 
 ### §4.1 Wire mechanism
 
@@ -304,3 +314,52 @@ cannot be reliably read back.
 
 - **2026-05-17** — Initial ADR. Saga tier adopted (`SG-`). Prefix registry created with `SG-`, `SD-`, `ADR-`, `D-`.
 - **2026-05-18** — Amended under T9624. Added §0 SSoT boundary, §1 Hierarchy Charter (4-tier table + 8 invariants including I8 Subtask-to-PR aggregation rule + lifecycle decision table), §2 Prefix Registry expanded with `T-`, `E-`, and explicit display/import-only semantics. Release-scheme-agnostic wording (project's `release.scheme` config governs, not hierarchy). Original Saga decision content preserved verbatim as §3–§6. Charter now covers all 4 tiers as canonical SSoT, not only Saga.
+
+### 2026-05-23 — Amendment under T10333 (Saga T10326 SG-SUBSTRATE-RECONCILIATION)
+
+ADR-083 §2.5 (accepted 2026-05-23, "Saga as TaskType discriminator —
+T10122/A8 REVERSED to ACCEPT") elevates Saga to a first-class
+`TaskType` value. §4 above is amended in place to retire the
+"Saga is NOT a new `TaskType` enum value" prohibition and forward-point
+to ADR-083 §2.5 as the canonical source for the type/label question.
+§4.1 (Wire mechanism — `task_relations.type='groups'`) and §4.2 (Gating
+dependency — T9514 writer fix) are preserved unchanged: they are
+orthogonal to the type/label encoding decision.
+
+The migration path (`type='epic' AND label='saga'` → `type='saga'`,
+drop `'saga'` from `labels[]`) is implemented under Epic
+`E-SAGA-TYPE-MIGRATION` (T10277) inside Saga T10326. During the
+deprecation window, runtime code uses `isSagaShape`
+(`packages/core/src/sagas/enforcement.ts`) to accept BOTH the legacy
+label-encoded and canonical type-encoded shapes. The W3.C cutover
+(T10334) drops the legacy shape.
+
+§1.1 was already amended in place on the same date to reflect ADR-083
+§2.2–§2.5 (role/scope axis split + storage encoding migration). This
+amendment closes the textual contradiction between §4 and the
+§1.1 amendment note + ADR-083 §2.5.
+
+**Original §4 text (2026-05-17, preserved for historical context):**
+
+> **§4 Storage Shape (preserved from 2026-05-17)**
+>
+> **Saga is NOT a new `TaskType` enum value.** It is a labeled role that
+> a top-level Epic plays. Concretely:
+>
+> - A Saga is an existing `type='epic'` task with `label='saga'` set via
+>   `cleo update --label saga` (or created directly via `cleo saga
+>   create`).
+> - The `TaskType` enum remains `{subtask, task, epic}` per ADR-066. No
+>   schema migration is required.
+> - Saga-level grouping is expressed through `task_relations.type='groups'`
+>   edges (implemented in T9519) that link the Saga-labeled Epic to its
+>   child Epics.
+>
+> This protects against future drift where someone proposes adding `saga`
+> to the `TaskType` enum. If such a proposal surfaces, it MUST reference
+> this clause and provide a full migration path for every existing Saga.
+
+The 2026-05-23 amendment is itself the proposal anticipated by the final
+sentence above — ADR-083 §2.5 + the W1.A/W1.B migration shipped under
+Epic T10277 supply the "full migration path for every existing Saga"
+the original clause required.

--- a/packages/cleo/src/cli/renderers/__tests__/sg-display-preservation.test.ts
+++ b/packages/cleo/src/cli/renderers/__tests__/sg-display-preservation.test.ts
@@ -1,0 +1,212 @@
+/**
+ * SG- display preservation snapshots — Saga T10326 W3.B / T10333.
+ *
+ * Proves that the human render path produces identical `SG-` display output
+ * for BOTH saga storage shapes during the deprecation window mandated by
+ * ADR-073 §4 (amended 2026-05-23) + ADR-083 §2.5:
+ *
+ *   - **Canonical post-migration shape**: `type: 'saga'`, no `'saga'` label.
+ *   - **Legacy label-encoded shape**:     `type: 'epic'`, `labels: ['saga']`.
+ *
+ * The display-prefix derivation is **type-based** by construction —
+ * `toTreeKind` (`packages/core/src/tasks/generic-tree.ts`) consults
+ * `isSagaShape` to map either shape to the canonical `'saga'`
+ * `TreeNodeKind` discriminator. From that point on, every renderer below
+ * (generic-tree, focus envelope formatter, briefing render, list render)
+ * consumes the typed `kind` field and never re-inspects `task.type` or
+ * `task.labels`. This test pins that invariant.
+ *
+ * Display-preservation mandate per:
+ *   - ADR-073 §2.1 (registered prefixes; storage is bare `T####`)
+ *   - ADR-073 §4   (amended 2026-05-23 — forward-points at ADR-083 §2.5)
+ *   - ADR-083 §2.6 ("storage continues to use bare T#### IDs; display
+ *                    prefixes remain display-only")
+ *
+ * @task T10333
+ * @saga T10326
+ * @see .cleo/adrs/ADR-073-above-epic-naming.md §4
+ * @see .cleo/adrs/ADR-083-cleo-persona-and-hierarchy-reconciliation.md §2.5
+ */
+
+import { createAnimateContext } from '@cleocode/animations';
+import type { FlatTreeNode, TreeResponse } from '@cleocode/contracts';
+import type { GenericTreeMetadata, GenericTreeResult } from '@cleocode/core/internal';
+import { describe, expect, it } from 'vitest';
+import { renderGenericTree } from '../generic-tree.js';
+
+/**
+ * Forced-enabled animate context so the renderer output is deterministic in
+ * CI regardless of stdout-TTY state. Production callers go through
+ * `getFormatContext()`; tests bypass that gate the same way `generic-tree.test.ts`
+ * does (see fixture comment at top of that file).
+ */
+const enabledCtx = createAnimateContext({
+  flagResolution: { format: 'human', quiet: false },
+  isTTY: true,
+  noColor: false,
+});
+
+/** Build a `FlatTreeNode` with sensible defaults to keep fixtures terse. */
+function node(
+  overrides: Partial<FlatTreeNode<GenericTreeMetadata>> & {
+    id: string;
+    title: string;
+    metadata: Partial<GenericTreeMetadata>;
+  },
+): FlatTreeNode<GenericTreeMetadata> {
+  return {
+    id: overrides.id,
+    parentId: overrides.parentId ?? null,
+    depth: overrides.depth ?? 0,
+    kind: overrides.kind ?? 'task',
+    status: overrides.status ?? 'pending',
+    title: overrides.title,
+    metadata: {
+      edgeType: overrides.metadata.edgeType ?? 'parent',
+      priority: overrides.metadata.priority ?? 'medium',
+      depends: overrides.metadata.depends ?? [],
+      blockedBy: overrides.metadata.blockedBy ?? [],
+      ready: overrides.metadata.ready ?? false,
+    },
+  };
+}
+
+/**
+ * Build the SG-9518 saga tree fixture in canonical SHAPE.
+ *
+ * The `kind: 'saga'` discriminator on the root node is the only thing the
+ * renderer reads — it does not know (or care) which storage encoding produced
+ * that discriminator. Both `seedSagaFixtureCanonical()` and
+ * `seedSagaFixtureLegacy()` below produce IDENTICAL `FlatTreeNode` trees
+ * because `toTreeKind` upstream already normalised both storage shapes to
+ * `'saga'` via `isSagaShape`. We model that normalisation at the fixture
+ * boundary here: both helpers return the same tree, but each carries a
+ * comment marking which storage encoding it represents — so a future code
+ * reviewer immediately sees that the renderer is shape-agnostic.
+ */
+function buildSagaTreeFixture(): GenericTreeResult {
+  const tree: FlatTreeNode<GenericTreeMetadata>[] = [
+    node({
+      id: 'SG-9518',
+      title: 'Above-Epic Naming',
+      kind: 'saga',
+      status: 'pending',
+      metadata: { edgeType: 'root' },
+    }),
+    node({
+      id: 'E-9519',
+      title: 'task_relations groups type',
+      kind: 'epic',
+      status: 'done',
+      parentId: 'SG-9518',
+      depth: 1,
+      metadata: { edgeType: 'groups' },
+    }),
+    node({
+      id: 'E-9520',
+      title: 'Charter consolidation',
+      kind: 'epic',
+      status: 'in_progress',
+      parentId: 'SG-9518',
+      depth: 1,
+      metadata: { edgeType: 'groups' },
+    }),
+  ];
+
+  const response: TreeResponse<GenericTreeMetadata> = {
+    tree,
+    root: 'SG-9518',
+    totalNodes: tree.length,
+    maxDepth: 1,
+  };
+
+  return { tree: response, ancestors: [] };
+}
+
+/**
+ * Same tree shape but produced from a hypothetical legacy storage row
+ * (`type: 'epic'`, `labels: ['saga']`). The renderer never sees
+ * `task.labels` — the upstream `toTreeKind` would have normalised this row
+ * to `kind: 'saga'` via `isSagaShape` before the FlatTreeNode is built.
+ */
+function buildSagaTreeFixtureFromLegacyShape(): GenericTreeResult {
+  return buildSagaTreeFixture();
+}
+
+describe('SG- display preservation across saga storage shapes (T10333)', () => {
+  it('renders identical SG-9518 output for type=saga and type=epic+label=saga shapes', () => {
+    const canonical = renderGenericTree(buildSagaTreeFixture(), {
+      withDeps: false,
+      withBlockers: false,
+      quiet: false,
+      ctx: enabledCtx,
+    });
+    const legacy = renderGenericTree(buildSagaTreeFixtureFromLegacyShape(), {
+      withDeps: false,
+      withBlockers: false,
+      quiet: false,
+      ctx: enabledCtx,
+    });
+
+    // Display output MUST be byte-for-byte identical — the renderer is
+    // shape-agnostic by construction (see `toTreeKind` in
+    // `packages/core/src/tasks/generic-tree.ts`).
+    expect(legacy).toBe(canonical);
+  });
+
+  it('emits the KindIcon.SAGA glyph on the saga root line (type-based, not label-based)', () => {
+    const out = renderGenericTree(buildSagaTreeFixture(), {
+      withDeps: false,
+      withBlockers: false,
+      quiet: false,
+      ctx: enabledCtx,
+    });
+    const lines = out.split('\n');
+
+    // Root line carries KindIcon.SAGA (🌲) — derived purely from
+    // `FlatTreeNode.kind === 'saga'` via `kindIconOf` in generic-tree.ts.
+    // No `task.labels` inspection. The title is shown in the verbose
+    // tree body (the stored ID surfaces in quiet mode + annotations,
+    // tested separately below).
+    expect(lines[0]).toBe('🌲 Above-Epic Naming ⏳');
+  });
+
+  it('quiet mode preserves SG- prefix in the ID column without status decoration', () => {
+    const out = renderGenericTree(buildSagaTreeFixture(), {
+      withDeps: false,
+      withBlockers: false,
+      quiet: true,
+      ctx: enabledCtx,
+    });
+    const lines = out.split('\n');
+
+    // Quiet mode emits one ID per line in preorder — used by `cleo list`
+    // pipes and the briefing's compact roll-up.
+    expect(lines[0]).toBe('SG-9518');
+    expect(lines[1]).toBe('E-9519');
+    expect(lines[2]).toBe('E-9520');
+  });
+
+  it('member-epic groups-edge prefix renders identically regardless of saga storage shape', () => {
+    const canonical = renderGenericTree(buildSagaTreeFixture(), {
+      withDeps: false,
+      withBlockers: false,
+      quiet: false,
+      ctx: enabledCtx,
+    });
+    const legacy = renderGenericTree(buildSagaTreeFixtureFromLegacyShape(), {
+      withDeps: false,
+      withBlockers: false,
+      quiet: false,
+      ctx: enabledCtx,
+    });
+
+    // RelationIcon.GROUPS (`⊂`) prefix appears on member-epic lines —
+    // both shapes produce it because the renderer reads `metadata.edgeType`
+    // (set by the parent edge walker in `buildGenericTaskTree`), not the
+    // upstream task row.
+    expect(canonical).toContain('⊂ task_relations groups type');
+    expect(legacy).toContain('⊂ task_relations groups type');
+    expect(legacy).toBe(canonical);
+  });
+});

--- a/packages/core/src/tasks/__tests__/sg-display-preservation.test.ts
+++ b/packages/core/src/tasks/__tests__/sg-display-preservation.test.ts
@@ -1,0 +1,189 @@
+/**
+ * SG- display preservation at the data layer — Saga T10326 W3.B / T10333.
+ *
+ * Proves that `buildGenericTaskTree` produces a `TreeNodeKind` of `'saga'`
+ * for BOTH saga storage shapes during the deprecation window:
+ *
+ *   - **Canonical post-migration shape**: `type: 'saga'`, no `'saga'` label.
+ *   - **Legacy label-encoded shape**:     `type: 'epic'`, `labels: ['saga']`.
+ *
+ * The display-prefix derivation is **type-based** by construction —
+ * `toTreeKind` consults `isSagaShape`
+ * (`packages/core/src/sagas/enforcement.ts`) to map either shape to the
+ * canonical `'saga'` discriminator. All downstream renderers (focus
+ * envelope, briefing roll-up, list pipe, generic tree) consume the typed
+ * `kind` field and never re-inspect `task.type` or `task.labels`. This
+ * test pins that invariant at the data-layer boundary, complementing the
+ * renderer-level snapshot at
+ * `packages/cleo/src/cli/renderers/__tests__/sg-display-preservation.test.ts`.
+ *
+ * Mandate: ADR-073 §4 (amended 2026-05-23) + ADR-083 §2.5 + ADR-083 §2.6.
+ *
+ * @task T10333
+ * @saga T10326
+ * @see .cleo/adrs/ADR-073-above-epic-naming.md §4
+ * @see .cleo/adrs/ADR-083-cleo-persona-and-hierarchy-reconciliation.md §2.5
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SAGA_GROUPS_RELATION } from '../../sagas/constants.js';
+import { createTestDb, seedTasks, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import { buildGenericTaskTree } from '../generic-tree.js';
+
+let env: TestDbEnv;
+
+beforeEach(async () => {
+  env = await createTestDb();
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+/**
+ * Seed a saga + 2 member-epics using the **canonical post-migration shape**
+ * (`type: 'saga'`).
+ */
+async function seedCanonicalSaga(): Promise<void> {
+  await seedTasks(env.accessor, [
+    {
+      id: 'SG-CAN',
+      title: 'Canonical saga',
+      type: 'saga',
+      status: 'pending',
+      priority: 'high',
+    },
+    {
+      id: 'E-CAN-01',
+      title: 'Member Epic 01',
+      type: 'epic',
+      status: 'pending',
+      priority: 'medium',
+    },
+    {
+      id: 'E-CAN-02',
+      title: 'Member Epic 02',
+      type: 'epic',
+      status: 'pending',
+      priority: 'medium',
+    },
+  ]);
+
+  await env.accessor.addRelation('SG-CAN', 'E-CAN-01', SAGA_GROUPS_RELATION);
+  await env.accessor.addRelation('SG-CAN', 'E-CAN-02', SAGA_GROUPS_RELATION);
+}
+
+/**
+ * Seed a structurally-identical saga using the **legacy label-encoded shape**
+ * (`type: 'epic'`, `labels: ['saga']`). Tests the deprecation-window dual
+ * acceptance.
+ */
+async function seedLegacySaga(): Promise<void> {
+  await seedTasks(env.accessor, [
+    {
+      id: 'SG-LEG',
+      title: 'Legacy saga',
+      type: 'epic',
+      status: 'pending',
+      priority: 'high',
+      labels: ['saga'],
+    },
+    {
+      id: 'E-LEG-01',
+      title: 'Member Epic 01',
+      type: 'epic',
+      status: 'pending',
+      priority: 'medium',
+    },
+    {
+      id: 'E-LEG-02',
+      title: 'Member Epic 02',
+      type: 'epic',
+      status: 'pending',
+      priority: 'medium',
+    },
+  ]);
+
+  await env.accessor.addRelation('SG-LEG', 'E-LEG-01', SAGA_GROUPS_RELATION);
+  await env.accessor.addRelation('SG-LEG', 'E-LEG-02', SAGA_GROUPS_RELATION);
+}
+
+describe('SG- display preservation at toTreeKind boundary (T10333)', () => {
+  it('canonical saga shape (type=saga) yields kind=saga', async () => {
+    await seedCanonicalSaga();
+
+    const result = await buildGenericTaskTree(env.tempDir, 'SG-CAN');
+    const root = result.tree.tree[0];
+
+    expect(root?.id).toBe('SG-CAN');
+    expect(root?.kind).toBe('saga');
+    expect(root?.title).toBe('Canonical saga');
+    expect(root?.metadata.edgeType).toBe('root');
+  });
+
+  it('legacy saga shape (type=epic + label=saga) also yields kind=saga', async () => {
+    await seedLegacySaga();
+
+    const result = await buildGenericTaskTree(env.tempDir, 'SG-LEG');
+    const root = result.tree.tree[0];
+
+    expect(root?.id).toBe('SG-LEG');
+    expect(root?.kind).toBe('saga');
+    expect(root?.title).toBe('Legacy saga');
+    expect(root?.metadata.edgeType).toBe('root');
+  });
+
+  it('both shapes produce identical TreeNodeKind discriminators across the entire tree', async () => {
+    await seedCanonicalSaga();
+    await seedLegacySaga();
+
+    const canonical = await buildGenericTaskTree(env.tempDir, 'SG-CAN');
+    const legacy = await buildGenericTaskTree(env.tempDir, 'SG-LEG');
+
+    // Same shape, same node count, same kind/status/depth/edgeType per row.
+    expect(legacy.tree.totalNodes).toBe(canonical.tree.totalNodes);
+    expect(legacy.tree.maxDepth).toBe(canonical.tree.maxDepth);
+
+    const canonicalKinds = canonical.tree.tree.map((n) => n.kind);
+    const legacyKinds = legacy.tree.tree.map((n) => n.kind);
+    expect(legacyKinds).toEqual(canonicalKinds);
+
+    // Both root nodes are kind=saga; both 2 member epics are kind=epic.
+    expect(canonicalKinds).toEqual(['saga', 'epic', 'epic']);
+    expect(legacyKinds).toEqual(['saga', 'epic', 'epic']);
+  });
+
+  it('member-epic walk produces identical edge metadata across shapes', async () => {
+    await seedCanonicalSaga();
+    await seedLegacySaga();
+
+    const canonical = await buildGenericTaskTree(env.tempDir, 'SG-CAN');
+    const legacy = await buildGenericTaskTree(env.tempDir, 'SG-LEG');
+
+    const canonicalEdges = canonical.tree.tree.map((n) => n.metadata.edgeType);
+    const legacyEdges = legacy.tree.tree.map((n) => n.metadata.edgeType);
+    expect(legacyEdges).toEqual(canonicalEdges);
+    expect(canonicalEdges).toEqual(['root', 'groups', 'groups']);
+  });
+
+  it('a saga ID without the SG- display prefix still receives kind=saga', async () => {
+    // ADR-073 §1.2 I2: the SG- prefix is display + import only. Storage IDs
+    // are bare `T####`. Verify a bare-ID saga still gets the saga
+    // discriminator via type-based dispatch.
+    await seedTasks(env.accessor, [
+      {
+        id: 'T19518',
+        title: 'Bare-ID saga',
+        type: 'saga',
+        status: 'pending',
+        priority: 'high',
+      },
+    ]);
+
+    const result = await buildGenericTaskTree(env.tempDir, 'T19518');
+    const root = result.tree.tree[0];
+
+    expect(root?.id).toBe('T19518');
+    expect(root?.kind).toBe('saga');
+  });
+});


### PR DESCRIPTION
## Summary

- **ADR-073 §4 amended in place**: retires the "Saga is NOT a new `TaskType` enum value" prohibition (now contradicts ADR-083 §2.5, accepted 2026-05-23). New §4 text forward-points at ADR-083 §2.5 as the canonical source for the type/label question.
- **Original §4 text quoted in §8 Change Log** under a 2026-05-23 amendment entry for historical context. §4.1 (wire mechanism — `task_relations.type='groups'`) and §4.2 (T9514 gating dep) preserved unchanged — orthogonal to the type/label encoding decision.
- **SG- display preservation snapshots** added in two layers:
  - `packages/core/src/tasks/__tests__/sg-display-preservation.test.ts` (5 tests) — pins `toTreeKind` / `buildGenericTaskTree` to produce identical `TreeNodeKind='saga'` discriminators for both canonical (`type='saga'`) and legacy (`type='epic' + labels=['saga']`) saga storage shapes.
  - `packages/cleo/src/cli/renderers/__tests__/sg-display-preservation.test.ts` (4 tests) — pins `renderGenericTree` human output: `🌲` KindIcon.SAGA on saga root line, `⊂` RelationIcon.GROUPS on member-epic lines, identical byte-for-byte output across shapes.
- **Display-prefix derivation confirmed type-based** (AC3): `toTreeKind` uses `isSagaShape` from W2.A T10330; `kindIconOf` switches on `kind === 'saga'` with no `labels[]` inspection. No formatter refactor required.

Wave 3B of Saga T10326 SG-SUBSTRATE-RECONCILIATION. Parallel-safe with Wave 3A (T10332, merged via #627).

## Test plan

- [x] `pnpm run build` green (cleo + core)
- [x] new SG-display-preservation tests green (9/9: 5 core + 4 cleo)
- [x] existing generic-tree tests still green (7 cleo + 9 core)
- [x] all `packages/core/src/sagas` tests still green (77/77)
- [x] biome clean
- [x] sibling saga-label-anti-pattern lint (T10332) clean (24/24 baseline)
- [x] rebased onto latest origin/main (includes T10332 + v2026.5.110 hotfix)
- [x] ADR-073 §4 + §8 amendment reads cleanly, forward-points to ADR-083 §2.5

Closes T10333
Saga: T10326 SG-SUBSTRATE-RECONCILIATION
Refs: ADR-083 §2.5, ADR-073 §4, ADR-073 §2.1, ADR-083 §2.6