### PR TITLE
ci(T10372): manual-write sweep audit script (E5.2)

### DIFF
--- a/.changeset/t10372-e5-manual-write-sweep.md
+++ b/.changeset/t10372-e5-manual-write-sweep.md
@@ -1,0 +1,6 @@
+---
+id: t10372-e5-manual-write-sweep
+tasks: [T10372]
+kind: chore
+summary: T10372 E5.2: manual-write sweep audit script for canon.yml rawMdPaths
+---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,6 +618,61 @@ jobs:
         # Pure static analysis of checked-in source files — no untrusted input.
         run: node scripts/lint-dockind-writer-uniqueness.mjs
 
+  manual-write-sweep:
+    # T10372 / Epic T10293 / Saga T10288 SG-DOCS-INTEGRITY E5.2 — repo-wide
+    # manual-write sweep. Walks every `.md` file added under `.cleo/canon.yml`'s
+    # `rawMdPaths` directories since the T9791 docs-import cutoff
+    # (commit 251814e86), hashes it, and queries the docs SSoT to classify
+    # each file as `in-sync`, `drift`, or `orphan`. Emits a structured JSON
+    # report under `audit/manual-write-sweep-<date>.json`.
+    #
+    # READ-ONLY: the script mutates nothing. Initially wired with
+    # `continue-on-error: true` so the existing orphan corpus does not fail
+    # CI; flips to strict after Saga T10288 / Epic T10293 E5.3 lands the
+    # orphan cleanup migration. The report artefact is uploaded on every
+    # run so reviewers can see the unresolved count trend.
+    name: Manual Write Sweep (T10372)
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history required for git log --diff-filter=A
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.30.0'
+          run_install: false
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
+      - name: Build cleo CLI (sweep shells out to `cleo docs list/fetch`)
+        run: pnpm run build
+      - name: Run manual-write sweep
+        # The script exits 1 when orphans or drift exist — wrap with
+        # --allow-unresolved so CI is informational until E5.3 cleans up.
+        # --cleo-bin invokes the just-built local CLI bundle.
+        run: node scripts/sweep-manual-doc-writes.mjs --allow-unresolved --cleo-bin "node packages/cleo/dist/cli/index.js"
+      - name: Upload sweep report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: manual-write-sweep
+          path: audit/manual-write-sweep-*.json
+          if-no-files-found: warn
+
   canon-drift:
     name: Canon Drift Check
     needs: [biome]

--- a/audit/manual-write-sweep-2026-05-24.json
+++ b/audit/manual-write-sweep-2026-05-24.json
@@ -1,0 +1,170 @@
+{
+  "generatedAt": "2026-05-24T06:25:40.955Z",
+  "rawMdPaths": [
+    ".cleo/adrs/",
+    ".cleo/research/",
+    ".cleo/rcasd/",
+    ".cleo/agent-outputs/"
+  ],
+  "summary": {
+    "cutoff": "251814e86",
+    "totalFiles": 16,
+    "orphan": 5,
+    "drift": 0,
+    "inSync": 11,
+    "deleted": 0,
+    "unresolved": 5
+  },
+  "grouped": {
+    "orphan": [
+      {
+        "file": ".cleo/adrs/ADR-083-cleo-persona-and-hierarchy-reconciliation.md",
+        "fileSha": "bd8c14ab55430125c0909e0b42d9f0f1e453c1116e1e25f821c6b34ece6c4c2f",
+        "remediation": "orphan",
+        "ssotSlug": null,
+        "ssotType": null,
+        "ssotAttachmentId": null,
+        "ssotSha": null
+      },
+      {
+        "file": ".cleo/adrs/ADR-085-cross-db-invariants.md",
+        "fileSha": "677ad407b1751d889cded48aa7de9cc26274e852cc41ee9c37f8bbedd4625a13",
+        "remediation": "orphan",
+        "ssotSlug": null,
+        "ssotType": null,
+        "ssotAttachmentId": null,
+        "ssotSha": null
+      },
+      {
+        "file": ".cleo/agent-outputs/T10268-saga-closeout.md",
+        "fileSha": "cbc9da442d4d3304fc6fb591275fe8f6b59335256cec1cb5cb3e6944a5fec75d",
+        "remediation": "orphan",
+        "ssotSlug": null,
+        "ssotType": null,
+        "ssotAttachmentId": null,
+        "ssotSha": null
+      },
+      {
+        "file": ".cleo/research/t10292-e4-cli-verb-matrix.md",
+        "fileSha": "b4b4240616b35f250a1b5aaa3bd84b75a859448a62b7cfa76e3eac5ada150092",
+        "remediation": "orphan",
+        "ssotSlug": null,
+        "ssotType": null,
+        "ssotAttachmentId": null,
+        "ssotSha": null
+      },
+      {
+        "file": ".cleo/research/t10292-e4-sdk-import-edges.md",
+        "fileSha": "9e4d21fd18ad983d98dee545c239f458cbb5c96c9d3574007a030fd0c09b2b64",
+        "remediation": "orphan",
+        "ssotSlug": null,
+        "ssotType": null,
+        "ssotAttachmentId": null,
+        "ssotSha": null
+      }
+    ],
+    "drift": [],
+    "in-sync": [
+      {
+        "file": ".cleo/adrs/ADR-079-docs-sdk-boundary-contract.md",
+        "fileSha": "0113f7f7ab1818fb681c0b7d1f601fb306819686ed08b07e18b1461fa746d22c",
+        "remediation": "in-sync",
+        "ssotSlug": "adr-079-docs-sdk-boundary-contract",
+        "ssotType": "adr",
+        "ssotAttachmentId": "c72ef9db-7155-4671-8fa3-215c15effe26",
+        "ssotSha": "0113f7f7ab1818fb681c0b7d1f601fb306819686ed08b07e18b1461fa746d22c"
+      },
+      {
+        "file": ".cleo/agent-outputs/T10269-ivtr-external-systems.md",
+        "fileSha": "6eb47aeef575b18b77f59cdc2ef8fd91b3b84fbd12c1528e9fbf594eb1ec2437",
+        "remediation": "in-sync",
+        "ssotSlug": "ivtr-external-systems-steal-table",
+        "ssotType": "research",
+        "ssotAttachmentId": "1a68e4c8-fe7f-4bb1-b446-b01416b678b9",
+        "ssotSha": "6eb47aeef575b18b77f59cdc2ef8fd91b3b84fbd12c1528e9fbf594eb1ec2437"
+      },
+      {
+        "file": ".cleo/agent-outputs/T10270/ivtr-audit.md",
+        "fileSha": "5d938074b998e858aae98b9720bd926ff956f31ad4841ace4a3c5d5cf99b4797",
+        "remediation": "in-sync",
+        "ssotSlug": "ivtr-current-state-audit",
+        "ssotType": "research",
+        "ssotAttachmentId": "6ad5cb60-4ed6-4066-807c-4331129ba57b",
+        "ssotSha": "5d938074b998e858aae98b9720bd926ff956f31ad4841ace4a3c5d5cf99b4797"
+      },
+      {
+        "file": ".cleo/agent-outputs/T10271/adr-079-docs-as-active-validator.md",
+        "fileSha": "843dbc8262d605f026b56a4da12ed70d1ef7f8c09fc3e5885a5db3e4d570b125",
+        "remediation": "in-sync",
+        "ssotSlug": "adr-079-docs-as-active-validator",
+        "ssotType": "adr",
+        "ssotAttachmentId": "402fe89c-a0fa-406e-8932-3cc8625ffff9",
+        "ssotSha": "843dbc8262d605f026b56a4da12ed70d1ef7f8c09fc3e5885a5db3e4d570b125"
+      },
+      {
+        "file": ".cleo/agent-outputs/T10271/adr-ac-stable-ids.md",
+        "fileSha": "c9dbe64e656d144adc08b4132c1e17d77c9d181f6f78d1bfc9f7522ddd45cfe5",
+        "remediation": "in-sync",
+        "ssotSlug": "adr-079-ac-stable-ids",
+        "ssotType": "adr",
+        "ssotAttachmentId": "4e972d45-d6e4-418d-a291-c914d3b7e618",
+        "ssotSha": "c9dbe64e656d144adc08b4132c1e17d77c9d181f6f78d1bfc9f7522ddd45cfe5"
+      },
+      {
+        "file": ".cleo/agent-outputs/T10271/adr-independent-validator.md",
+        "fileSha": "d04d3f3313afdfec7da76a7fd90c4cd1b60539c7148a2f225773c1eeaad3ae05",
+        "remediation": "in-sync",
+        "ssotSlug": "adr-079-independent-validator",
+        "ssotType": "adr",
+        "ssotAttachmentId": "7bc414f1-e97d-4624-9c5c-c34fde342348",
+        "ssotSha": "d04d3f3313afdfec7da76a7fd90c4cd1b60539c7148a2f225773c1eeaad3ae05"
+      },
+      {
+        "file": ".cleo/agent-outputs/T10272/ivtr-council-verdict.md",
+        "fileSha": "a539d0bf5aa7a45bd9e96743f6ba047d81b3a7b17eca008e66bd5e0bdedd592c",
+        "remediation": "in-sync",
+        "ssotSlug": "ivtr-council-verdict",
+        "ssotType": "research",
+        "ssotAttachmentId": "eda42785-ef9f-4329-b75b-fee6a31bfee4",
+        "ssotSha": "a539d0bf5aa7a45bd9e96743f6ba047d81b3a7b17eca008e66bd5e0bdedd592c"
+      },
+      {
+        "file": ".cleo/agent-outputs/T10273/ivtr-decomposition-plan.md",
+        "fileSha": "2279e1698bf84c82b8ce2c5d78e86b70c7db50195d28f8f3f31a2e0583f7739b",
+        "remediation": "in-sync",
+        "ssotSlug": "ivtr-decomposition-plan",
+        "ssotType": "research",
+        "ssotAttachmentId": "613bccac-68cf-4663-b29e-61823a5442bb",
+        "ssotSha": "2279e1698bf84c82b8ce2c5d78e86b70c7db50195d28f8f3f31a2e0583f7739b"
+      },
+      {
+        "file": ".cleo/agent-outputs/adr-core-tools-first-class.md",
+        "fileSha": "3a4dd1d59f9c9f5451e98926c32ba98f814c0ccd99248bf587ac81c889b0e9c8",
+        "remediation": "in-sync",
+        "ssotSlug": "adr-079-core-tools-first-class",
+        "ssotType": "adr",
+        "ssotAttachmentId": "26adba95-e56b-4161-b48c-0ae140a7b0af",
+        "ssotSha": "3a4dd1d59f9c9f5451e98926c32ba98f814c0ccd99248bf587ac81c889b0e9c8"
+      },
+      {
+        "file": ".cleo/agent-outputs/sg-signaldock-extract-closure-report.md",
+        "fileSha": "fee0dca1e93f5efb58af4943f6d7f9443560aed7afe5a951967e2d2625856240",
+        "remediation": "in-sync",
+        "ssotSlug": "sg-signaldock-extract-closure-report",
+        "ssotType": "note",
+        "ssotAttachmentId": "83830ba3-6878-4a81-93a8-810e82e20644",
+        "ssotSha": "fee0dca1e93f5efb58af4943f6d7f9443560aed7afe5a951967e2d2625856240"
+      },
+      {
+        "file": ".cleo/research/t10292-e4-gap-verdicts.md",
+        "fileSha": "241d810bf99eb8a417608553aabc7d2ab76f18661075bcfd68e909dd05f848e1",
+        "remediation": "in-sync",
+        "ssotSlug": "t10292-e4-gap-verdicts",
+        "ssotType": "research",
+        "ssotAttachmentId": "b3114265-a0d6-4761-b808-387062ba3b58",
+        "ssotSha": "241d810bf99eb8a417608553aabc7d2ab76f18661075bcfd68e909dd05f848e1"
+      }
+    ],
+    "deleted": []
+  }
+}

--- a/packages/skills/skills/ct-documentor/SKILL.md
+++ b/packages/skills/skills/ct-documentor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ct-documentor
 description: Documentation coordinator with CLEO style guide compliance. Routes every canonical-doc write (spec, adr, research, handoff, note, llm-readme) through the docs SSoT via `cleo docs add` / `cleo docs publish` / `cleo docs fetch` — never raw filesystem writes. Coordinates ct-docs-lookup, ct-docs-write, ct-docs-review, ct-spec-writer, and ct-adr-recorder. Use when creating or updating documentation files, consolidating scattered documentation, or validating documentation against style standards. Triggers on documentation tasks, doc update requests, or style guide compliance checks.
-version: 3.6.0
+version: 3.7.0
 tier: 3
 core: false
 category: specialist
@@ -292,6 +292,45 @@ the canonical `changeset` DocKind) are allowlisted in the script.
 
 Per-line opt-out (use sparingly): append
 `// dockind-writer-allowed: <reason>` on the writeFile line.
+
+#### Audit complement — manual-write sweep (T10372)
+
+`scripts/sweep-manual-doc-writes.mjs` (CI job:
+`Manual Write Sweep (T10372)`) is the read-only audit counterpart to
+the writer-uniqueness lint. Where T10369 prevents *new* raw `.md`
+writers from landing in `packages/core/src/**`, this sweep walks every
+`*.md` file *already* added under `.cleo/canon.yml`'s `rawMdPaths`
+directories since the T9791 docs-import cutoff (commit `251814e86`)
+and classifies each one against the docs SSoT:
+
+| Remediation | Meaning | Fix |
+|---|---|---|
+| `in-sync` | File SHA matches a blob already in the SSoT — bytes are tracked. | None. |
+| `drift` | Slug exists in SSoT but the on-disk content has changed. | Re-publish via `cleo docs publish` or re-add as a new version. |
+| `orphan` | Neither SHA nor slug resolves — the file is a raw fs write that bypassed `cleo docs add`. | Migrate via `cleo docs add <ownerId> <file> --type <kind> --slug <slug>`. |
+| `deleted` | File was added since the cutoff but no longer exists on disk. | Informational only — does not count toward `unresolved`. |
+
+Each run writes a timestamped report to
+`audit/manual-write-sweep-<date>.json` and prints the summary block to
+stdout. The CI job uploads the report as a workflow artefact on every
+run and is wired with `continue-on-error: true` initially so the
+existing orphan corpus does not break PRs. Saga T10288 / Epic T10293
+E5.3 closes the orphan migration; the gate flips strict after that
+lands.
+
+```bash
+# Local invocation — uses the globally-installed `cleo` on PATH.
+node scripts/sweep-manual-doc-writes.mjs
+
+# CI / monorepo build — point at the just-built local CLI bundle.
+node scripts/sweep-manual-doc-writes.mjs \
+  --cleo-bin "node packages/cleo/dist/cli/index.js" \
+  --allow-unresolved
+```
+
+Exit codes: `0` (clean OR `--allow-unresolved`), `1` (at least one
+`orphan` or `drift` entry), `2` (canon.yml parse failure, git not
+available, SSoT query failed).
 
 ### Slug similarity warn (T10361 · closes T10167)
 

--- a/scripts/__tests__/sweep-manual-doc-writes.test.mjs
+++ b/scripts/__tests__/sweep-manual-doc-writes.test.mjs
@@ -1,0 +1,324 @@
+/**
+ * Tests for scripts/sweep-manual-doc-writes.mjs.
+ *
+ * Strategy:
+ *   - Build a tiny synthetic git repo under tmpdir() with a fake
+ *     `.cleo/canon.yml`, a fake cutoff commit, and a known mix of
+ *     pre-cutoff + post-cutoff markdown files.
+ *   - Stub `cleo` on PATH with a shell shim that emits canned SSoT
+ *     responses (one file matches by sha → in-sync; one slug exists
+ *     but with a different sha → drift; one neither matches → orphan).
+ *   - Invoke the sweep script with `--repo-root` against the sandbox
+ *     and assert the resulting summary + per-item classifications.
+ *
+ * @task T10372
+ * @epic T10293
+ * @saga T10288
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+const REPO_ROOT = resolve(__dirname, '../..');
+const SCRIPT = join(REPO_ROOT, 'scripts/sweep-manual-doc-writes.mjs');
+
+/** @type {string} */
+let sandbox;
+/** @type {string} */
+let projectRoot;
+/** @type {string} */
+let stubBin;
+
+const CANON_YML = `version: 1
+kinds:
+  adr:
+    canonicalHome: ssot
+    publishMirror: docs/adr/
+    rawMdAllowed: false
+    rawMdPaths:
+      - .cleo/adrs/
+  research:
+    canonicalHome: ssot
+    publishMirror: docs/research/
+    rawMdAllowed: false
+    rawMdPaths:
+      - .cleo/research/
+  llm-readme:
+    canonicalHome: ssot
+    publishMirror: .
+    rawMdAllowed: true
+`;
+
+function sha256(s) {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+function gitInit(dir) {
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'test',
+    GIT_AUTHOR_EMAIL: 't@e',
+    GIT_COMMITTER_NAME: 'test',
+    GIT_COMMITTER_EMAIL: 't@e',
+  };
+  spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: dir, env });
+  spawnSync('git', ['config', 'user.email', 't@e'], { cwd: dir, env });
+  spawnSync('git', ['config', 'user.name', 'test'], { cwd: dir, env });
+}
+
+function gitCommit(dir, msg) {
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'test',
+    GIT_AUTHOR_EMAIL: 't@e',
+    GIT_COMMITTER_NAME: 'test',
+    GIT_COMMITTER_EMAIL: 't@e',
+  };
+  spawnSync('git', ['add', '-A'], { cwd: dir, env });
+  const r = spawnSync('git', ['commit', '-q', '-m', msg], { cwd: dir, env });
+  if (r.status !== 0) throw new Error(`git commit failed: ${r.stderr.toString()}`);
+}
+
+function gitHead(dir) {
+  const r = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: dir, encoding: 'utf-8' });
+  return r.stdout.trim();
+}
+
+/**
+ * Write a `cleo` shim into `stubBin`. The shim parses argv for
+ * `docs list` and `docs fetch <sha>` and returns canned envelopes.
+ *
+ * Stub config is written to `<stubBin>/cleo-stub-config.json`:
+ *   { listAttachments: [{slug,type,sha256,id}, ...], blobBySha: {sha:meta, ...} }
+ */
+function writeStub(config) {
+  const configPath = join(stubBin, 'cleo-stub-config.json');
+  writeFileSync(configPath, JSON.stringify(config, null, 2));
+  // Node-based shim — portable & avoids bash quoting hell.
+  const script = `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const config = JSON.parse(fs.readFileSync(path.join(__dirname, 'cleo-stub-config.json'), 'utf-8'));
+const argv = process.argv.slice(2);
+function emit(env, status = 0) {
+  process.stdout.write(JSON.stringify(env));
+  process.exit(status);
+}
+if (argv[0] === 'docs' && argv[1] === 'list') {
+  emit({ success: true, data: { attachments: config.listAttachments || [] } });
+}
+if (argv[0] === 'docs' && argv[1] === 'fetch') {
+  const sha = argv[2];
+  const meta = (config.blobBySha || {})[sha];
+  if (!meta) {
+    emit({ success: false, error: { code: 4, codeName: 'E_NOT_FOUND', message: 'not found' } }, 4);
+  }
+  emit({ success: true, data: { metadata: { ...meta, sha256: sha } } });
+}
+emit({ success: false, error: { code: 1, codeName: 'E_UNKNOWN_VERB', message: 'unknown' } }, 1);
+`;
+  const stubPath = join(stubBin, 'cleo');
+  writeFileSync(stubPath, script);
+  chmodSync(stubPath, 0o755);
+}
+
+beforeEach(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'cleo-sweep-test-'));
+  projectRoot = join(sandbox, 'project');
+  stubBin = join(sandbox, 'bin');
+  mkdirSync(projectRoot, { recursive: true });
+  mkdirSync(stubBin, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe('sweep-manual-doc-writes — classification', () => {
+  it('classifies each file as in-sync, drift, or orphan against the SSoT stub', () => {
+    // Build sandbox project with canon.yml + a pre-cutoff legacy file.
+    mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+    mkdirSync(join(projectRoot, '.cleo/adrs'), { recursive: true });
+    mkdirSync(join(projectRoot, '.cleo/research'), { recursive: true });
+    writeFileSync(join(projectRoot, '.cleo/canon.yml'), CANON_YML);
+
+    gitInit(projectRoot);
+    // Pre-cutoff commit — files here should NOT appear in the sweep.
+    writeFileSync(join(projectRoot, '.cleo/adrs/ADR-001-legacy.md'), '# legacy\n');
+    gitCommit(projectRoot, 'pre-cutoff');
+    const cutoffSha = gitHead(projectRoot);
+
+    // Post-cutoff: three files exercising every classification branch.
+    const insyncBody = '# in-sync ADR\n\nMatches SSoT exactly.\n';
+    const driftBody = '# drifted ADR\n\nLocal edits since last publish.\n';
+    const orphanBody = '# orphan research\n\nNever made it into SSoT.\n';
+    writeFileSync(join(projectRoot, '.cleo/adrs/ADR-002-insync.md'), insyncBody);
+    writeFileSync(join(projectRoot, '.cleo/adrs/ADR-003-drift.md'), driftBody);
+    writeFileSync(join(projectRoot, '.cleo/research/r-orphan.md'), orphanBody);
+    gitCommit(projectRoot, 'post-cutoff additions');
+
+    // Stub `cleo`:
+    //   - ADR-002 in-sync   → blobBySha keyed by file SHA
+    //   - ADR-003 drift     → list contains slug 'adr-003-drift' but with a
+    //                          different sha (the on-disk SHA is NOT in blobBySha)
+    //   - r-orphan          → neither index has it
+    const insyncSha = sha256(insyncBody);
+    writeStub({
+      listAttachments: [
+        { slug: 'adr-002-insync', type: 'adr', sha256: insyncSha.slice(0, 8) + '…', id: 'att-1' },
+        { slug: 'adr-003-drift', type: 'adr', sha256: 'deadbeef…', id: 'att-2' },
+      ],
+      blobBySha: {
+        [insyncSha]: { slug: 'adr-002-insync', type: 'adr', id: 'att-1' },
+      },
+    });
+
+    const env = { ...process.env, PATH: `${stubBin}:${process.env.PATH}` };
+    const result = spawnSync(
+      'node',
+      [
+        SCRIPT,
+        '--repo-root',
+        projectRoot,
+        '--cutoff',
+        cutoffSha,
+        '--out',
+        join(sandbox, 'report.json'),
+        '--allow-unresolved',
+      ],
+      { encoding: 'utf-8', env },
+    );
+
+    // The summary printed to stdout is the non-JSON-only branch — parse the
+    // first JSON object only.
+    const stdoutFirstBlock = result.stdout.split('}\n')[0] + '}';
+    const summary = JSON.parse(stdoutFirstBlock);
+    expect(summary.totalFiles).toBe(3);
+    expect(summary.inSync).toBe(1);
+    expect(summary.drift).toBe(1);
+    expect(summary.orphan).toBe(1);
+    expect(summary.deleted).toBe(0);
+
+    // Report file should mirror the in-memory classification.
+    const report = JSON.parse(readFileSync(join(sandbox, 'report.json'), 'utf-8'));
+    expect(report.grouped.orphan).toHaveLength(1);
+    expect(report.grouped.orphan[0].file).toBe('.cleo/research/r-orphan.md');
+    expect(report.grouped.drift).toHaveLength(1);
+    expect(report.grouped.drift[0].file).toBe('.cleo/adrs/ADR-003-drift.md');
+    expect(report.grouped.drift[0].ssotSlug).toBe('adr-003-drift');
+    expect(report.grouped['in-sync']).toHaveLength(1);
+    expect(report.grouped['in-sync'][0].file).toBe('.cleo/adrs/ADR-002-insync.md');
+    // Pre-cutoff file MUST NOT appear.
+    const allFiles = [
+      ...report.grouped.orphan,
+      ...report.grouped.drift,
+      ...report.grouped['in-sync'],
+    ].map((i) => i.file);
+    expect(allFiles).not.toContain('.cleo/adrs/ADR-001-legacy.md');
+  });
+
+  it('exits 1 when orphans exist and --allow-unresolved is not passed', () => {
+    mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+    mkdirSync(join(projectRoot, '.cleo/adrs'), { recursive: true });
+    writeFileSync(join(projectRoot, '.cleo/canon.yml'), CANON_YML);
+    gitInit(projectRoot);
+    writeFileSync(join(projectRoot, 'README.md'), '# placeholder\n');
+    gitCommit(projectRoot, 'init');
+    const cutoffSha = gitHead(projectRoot);
+    writeFileSync(join(projectRoot, '.cleo/adrs/ADR-100-orphan.md'), '# orphan\n');
+    gitCommit(projectRoot, 'add orphan');
+
+    writeStub({ listAttachments: [], blobBySha: {} });
+
+    const env = { ...process.env, PATH: `${stubBin}:${process.env.PATH}` };
+    const result = spawnSync(
+      'node',
+      [
+        SCRIPT,
+        '--repo-root',
+        projectRoot,
+        '--cutoff',
+        cutoffSha,
+        '--out',
+        join(sandbox, 'report.json'),
+      ],
+      { encoding: 'utf-8', env },
+    );
+    expect(result.status).toBe(1);
+  });
+
+  it('exits 0 when sweep is clean (no post-cutoff raw writes)', () => {
+    mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+    mkdirSync(join(projectRoot, '.cleo/adrs'), { recursive: true });
+    writeFileSync(join(projectRoot, '.cleo/canon.yml'), CANON_YML);
+    gitInit(projectRoot);
+    writeFileSync(join(projectRoot, 'README.md'), '# placeholder\n');
+    gitCommit(projectRoot, 'init');
+    const cutoffSha = gitHead(projectRoot);
+    // No post-cutoff commits at all — file list is empty.
+
+    writeStub({ listAttachments: [], blobBySha: {} });
+
+    const env = { ...process.env, PATH: `${stubBin}:${process.env.PATH}` };
+    const result = spawnSync(
+      'node',
+      [
+        SCRIPT,
+        '--repo-root',
+        projectRoot,
+        '--cutoff',
+        cutoffSha,
+        '--out',
+        join(sandbox, 'report.json'),
+      ],
+      { encoding: 'utf-8', env },
+    );
+    expect(result.status).toBe(0);
+    const report = JSON.parse(readFileSync(join(sandbox, 'report.json'), 'utf-8'));
+    expect(report.summary.totalFiles).toBe(0);
+    expect(report.summary.unresolved).toBe(0);
+  });
+
+  it('classifies files removed after cutoff as deleted (informational only)', () => {
+    mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+    mkdirSync(join(projectRoot, '.cleo/adrs'), { recursive: true });
+    writeFileSync(join(projectRoot, '.cleo/canon.yml'), CANON_YML);
+    gitInit(projectRoot);
+    writeFileSync(join(projectRoot, 'README.md'), '# placeholder\n');
+    gitCommit(projectRoot, 'init');
+    const cutoffSha = gitHead(projectRoot);
+    const addedPath = join(projectRoot, '.cleo/adrs/ADR-999-ephemeral.md');
+    writeFileSync(addedPath, '# ephemeral\n');
+    gitCommit(projectRoot, 'add ephemeral');
+    // Now delete it (simulate post-add cleanup).
+    rmSync(addedPath);
+    gitCommit(projectRoot, 'remove ephemeral');
+
+    writeStub({ listAttachments: [], blobBySha: {} });
+    const env = { ...process.env, PATH: `${stubBin}:${process.env.PATH}` };
+    const result = spawnSync(
+      'node',
+      [
+        SCRIPT,
+        '--repo-root',
+        projectRoot,
+        '--cutoff',
+        cutoffSha,
+        '--out',
+        join(sandbox, 'report.json'),
+      ],
+      { encoding: 'utf-8', env },
+    );
+    // Deleted file does not count toward unresolved → exit 0.
+    expect(result.status).toBe(0);
+    const report = JSON.parse(readFileSync(join(sandbox, 'report.json'), 'utf-8'));
+    expect(report.summary.deleted).toBe(1);
+    expect(report.summary.unresolved).toBe(0);
+  });
+});

--- a/scripts/sweep-manual-doc-writes.mjs
+++ b/scripts/sweep-manual-doc-writes.mjs
@@ -1,0 +1,402 @@
+#!/usr/bin/env node
+/**
+ * scripts/sweep-manual-doc-writes.mjs
+ *
+ * Repo-wide audit of manual `*.md` writes under `.cleo/canon.yml`'s
+ * `rawMdPaths` directories since the T9791 docs-import cutoff
+ * (commit 251814e86, 2026-05-20).
+ *
+ * READ-ONLY. Mutates nothing. Walks the git history, computes content
+ * SHA-256 per file, queries the docs SSoT, and classifies each entry as:
+ *
+ *   - `in-sync`   — file SHA matches a blob already in the SSoT.
+ *   - `drift`     — slug exists in SSoT but the on-disk SHA differs;
+ *                   the file should be re-published or re-imported.
+ *   - `orphan`    — no SSoT entry resolves either by SHA or by slug;
+ *                   the file is a raw fs write that bypassed `cleo
+ *                   docs add` and should be migrated.
+ *   - `deleted`   — file was added since the cutoff but no longer
+ *                   exists on disk (informational only, not counted as
+ *                   unresolved).
+ *
+ * Emits a structured JSON report under `audit/manual-write-sweep-<date>.json`
+ * (idempotent — the same script invocation on the same git state and
+ * SSoT snapshot rewrites the same file). The report's `summary` is also
+ * printed to stdout. Exit code:
+ *
+ *   0 — clean (zero orphan + zero drift) OR `--allow-unresolved`
+ *   1 — at least one orphan/drift entry exists (regression gate)
+ *   2 — internal error (canon.yml parse failure, git not available, …)
+ *
+ * Designed to wire into CI as a non-blocking job initially (until
+ * Saga T10288 / Epic T10293 E5.3 lands the orphan cleanup migration),
+ * then flip strict by removing `continue-on-error: true`.
+ *
+ * Usage:
+ *   node scripts/sweep-manual-doc-writes.mjs                # default
+ *   node scripts/sweep-manual-doc-writes.mjs --json         # stdout JSON only
+ *   node scripts/sweep-manual-doc-writes.mjs --allow-unresolved
+ *   node scripts/sweep-manual-doc-writes.mjs --cutoff <sha> # override
+ *   node scripts/sweep-manual-doc-writes.mjs --out <path>   # report dest
+ *
+ * @task T10372
+ * @epic T10293
+ * @saga T10288
+ * @adr ADR-076
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// T9791 docs-import cutoff — the commit that bulk-imported the legacy
+// markdown corpus into the SSoT. Files added BEFORE this commit are
+// considered legacy and are not classified by this sweep; the gate is
+// forward-only, matching `cleo check canon docs`.
+const T9791_CUTOFF = '251814e86';
+
+/**
+ * Parse CLI arguments into a flat options object. The script is
+ * intentionally small — no commander/citty dep — to keep startup fast
+ * for CI runs.
+ *
+ * @param {string[]} argv
+ * @returns {{json: boolean, allowUnresolved: boolean, cutoff: string, out: string | null, repoRoot: string, cleoBin: string[]}}
+ */
+function parseArgs(argv) {
+  const opts = {
+    json: false,
+    allowUnresolved: false,
+    cutoff: T9791_CUTOFF,
+    out: null,
+    repoRoot: resolve(__dirname, '..'),
+    /** @type {string[]} argv prefix for invoking cleo; defaults to globally-installed `cleo` */
+    cleoBin: ['cleo'],
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--json') opts.json = true;
+    else if (arg === '--allow-unresolved') opts.allowUnresolved = true;
+    else if (arg === '--cutoff') opts.cutoff = argv[++i];
+    else if (arg === '--out') opts.out = argv[++i];
+    else if (arg === '--repo-root') opts.repoRoot = resolve(argv[++i]);
+    else if (arg === '--cleo-bin') opts.cleoBin = argv[++i].split(' ').filter(Boolean);
+    else if (arg === '--help' || arg === '-h') {
+      console.log(
+        'Usage: sweep-manual-doc-writes.mjs [--json] [--allow-unresolved] [--cutoff <sha>] [--out <path>] [--repo-root <dir>] [--cleo-bin <cmd>]',
+      );
+      process.exit(0);
+    }
+  }
+  return opts;
+}
+
+/**
+ * Load `.cleo/canon.yml` and collect every `rawMdPaths` entry whose
+ * kind has `rawMdAllowed: false`. These are the directories where new
+ * raw `.md` writes are forbidden by `cleo check canon docs`, and thus
+ * the directories this sweep audits.
+ *
+ * @param {string} repoRoot
+ * @returns {string[]}
+ */
+function loadRawMdPaths(repoRoot) {
+  const canonPath = resolve(repoRoot, '.cleo/canon.yml');
+  if (!existsSync(canonPath)) {
+    throw new Error(`canon.yml not found at ${canonPath}`);
+  }
+  const canon = parseYaml(readFileSync(canonPath, 'utf-8'));
+  /** @type {string[]} */
+  const paths = [];
+  for (const def of Object.values(canon.kinds || {})) {
+    if (def.rawMdAllowed === false && Array.isArray(def.rawMdPaths)) {
+      for (const p of def.rawMdPaths) paths.push(p);
+    }
+  }
+  return Array.from(new Set(paths));
+}
+
+/**
+ * Enumerate every `*.md` file added under one of `paths` since
+ * `cutoffSha` using a single `git log --diff-filter=A` invocation per
+ * pathspec. Returns a deduplicated sorted list.
+ *
+ * @param {string} cutoffSha
+ * @param {string[]} paths
+ * @param {string} repoRoot
+ * @returns {string[]}
+ */
+function listMdFilesAddedSince(cutoffSha, paths, repoRoot) {
+  /** @type {Set<string>} */
+  const result = new Set();
+  for (const p of paths) {
+    const proc = spawnSync(
+      'git',
+      ['log', '--diff-filter=A', '--name-only', `${cutoffSha}..HEAD`, '--pretty=format:', '--', p],
+      { cwd: repoRoot, encoding: 'utf-8' },
+    );
+    if (proc.status !== 0) {
+      throw new Error(`git log failed for ${p}: ${proc.stderr}`);
+    }
+    for (const line of proc.stdout.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.endsWith('.md')) result.add(trimmed);
+    }
+  }
+  return Array.from(result).sort();
+}
+
+/**
+ * Compute the SHA-256 of a Buffer as lowercase hex. Matches the
+ * canonical encoding used by `packages/core/src/store/attachments.ts`.
+ *
+ * @param {Buffer} content
+ * @returns {string}
+ */
+function sha256Hex(content) {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Build a slug→{type,sha256,attachmentId} index from `cleo docs list`.
+ *
+ * The list command paginates; we ask for an unbounded result set
+ * (`--limit 0`) and accept that the `sha256` field is rendered with a
+ * unicode ellipsis (`…`) for table-friendly display. The truncation
+ * makes `sha256` unsuitable for equality comparisons here — we use the
+ * full SHA via `cleo docs fetch <fullSha>` only when probing for
+ * in-sync status. Slug + type from the listing is the cheap part.
+ *
+ * @param {string} repoRoot
+ * @param {string[]} cleoBin
+ * @returns {Map<string, { type: string, sha256: string, attachmentId: string }>}
+ */
+function loadSlugIndex(repoRoot, cleoBin) {
+  const [cmd, ...prefix] = cleoBin;
+  const proc = spawnSync(
+    cmd,
+    [...prefix, 'docs', 'list', '--project', '--limit', '0', '--orderBy', 'slug', '--json'],
+    { cwd: repoRoot, encoding: 'utf-8' },
+  );
+  if (proc.status !== 0) {
+    throw new Error(`cleo docs list failed: ${proc.stderr || proc.stdout}`);
+  }
+  const env = JSON.parse(proc.stdout);
+  if (!env.success) {
+    throw new Error(`cleo docs list returned non-success envelope: ${proc.stdout}`);
+  }
+  /** @type {Map<string, { type: string, sha256: string, attachmentId: string }>} */
+  const index = new Map();
+  for (const a of env.data.attachments || []) {
+    if (!a.slug) continue;
+    // Last-wins is fine — slug is unique per project per DocKind in
+    // the post-T10288/E1 world; the truncated SHA here is only used as
+    // a tie-breaker hint, not for content equality.
+    index.set(a.slug, {
+      type: a.type ?? 'unknown',
+      sha256: typeof a.sha256 === 'string' ? a.sha256.replace(/…$/, '') : '',
+      attachmentId: a.id,
+    });
+  }
+  return index;
+}
+
+/**
+ * Probe the SSoT for an attachment by full SHA-256. Returns the parsed
+ * metadata when present, or null on `E_NOT_FOUND`. Any other failure
+ * mode (network, db lock, …) re-throws so the sweep fails loudly.
+ *
+ * @param {string} sha
+ * @param {string} repoRoot
+ * @param {string[]} cleoBin
+ * @returns {{ slug?: string, type?: string, attachmentId: string, sha256: string } | null}
+ */
+function fetchBySha(sha, repoRoot, cleoBin) {
+  const [cmd, ...prefix] = cleoBin;
+  const proc = spawnSync(cmd, [...prefix, 'docs', 'fetch', sha], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+  });
+  // `cleo docs fetch` exits non-zero on E_NOT_FOUND but still emits a
+  // valid envelope. We always parse stdout when present.
+  let env;
+  try {
+    env = JSON.parse(proc.stdout);
+  } catch {
+    if (proc.status !== 0) return null;
+    throw new Error(`cleo docs fetch ${sha} stdout not JSON: ${proc.stdout}`);
+  }
+  if (!env.success) {
+    if (env.error?.codeName === 'E_NOT_FOUND') return null;
+    throw new Error(
+      `cleo docs fetch ${sha} unexpected error: ${env.error?.message ?? proc.stderr}`,
+    );
+  }
+  const meta = env.data?.metadata;
+  if (!meta) return null;
+  return {
+    slug: meta.slug,
+    type: meta.type,
+    attachmentId: meta.id,
+    sha256: meta.sha256,
+  };
+}
+
+/**
+ * Derive a canonical slug candidate from a markdown filename. Examples:
+ *   `.cleo/adrs/ADR-085-cross-db-invariants.md` → `adr-085-cross-db-invariants`
+ *   `.cleo/research/sg-arch-solid-master-plan.md` → `sg-arch-solid-master-plan`
+ *
+ * @param {string} filePath
+ * @returns {string}
+ */
+function deriveSlugCandidate(filePath) {
+  const base = filePath.split('/').pop() || filePath;
+  return base.replace(/\.md$/, '').toLowerCase();
+}
+
+/**
+ * Classify one file against the SSoT.
+ *
+ * @param {string} file
+ * @param {string} fileSha
+ * @param {Map<string, { type: string, sha256: string, attachmentId: string }>} slugIndex
+ * @param {string} repoRoot
+ * @param {string[]} cleoBin
+ * @returns {{ remediation: 'in-sync' | 'drift' | 'orphan', ssotSlug: string | null, ssotType: string | null, ssotAttachmentId: string | null, ssotSha: string | null }}
+ */
+function classify(file, fileSha, slugIndex, repoRoot, cleoBin) {
+  // 1. Cheapest probe — does ANY blob with this exact SHA exist in
+  //    the SSoT? If yes, the file is in-sync regardless of slug.
+  const byShaHit = fetchBySha(fileSha, repoRoot, cleoBin);
+  if (byShaHit) {
+    return {
+      remediation: 'in-sync',
+      ssotSlug: byShaHit.slug ?? null,
+      ssotType: byShaHit.type ?? null,
+      ssotAttachmentId: byShaHit.attachmentId,
+      ssotSha: byShaHit.sha256,
+    };
+  }
+  // 2. SHA not found — try the derived slug. If the slug exists, the
+  //    content has drifted and the SSoT needs a re-publish.
+  const slug = deriveSlugCandidate(file);
+  const bySlug = slugIndex.get(slug);
+  if (bySlug) {
+    return {
+      remediation: 'drift',
+      ssotSlug: slug,
+      ssotType: bySlug.type,
+      ssotAttachmentId: bySlug.attachmentId,
+      // The listing SHA is intentionally truncated — surface what we
+      // know but the canonical truth lives in the per-attachment row.
+      ssotSha: bySlug.sha256,
+    };
+  }
+  // 3. Neither SHA nor slug resolves — the file is an orphan and
+  //    needs to be migrated through `cleo docs add`.
+  return {
+    remediation: 'orphan',
+    ssotSlug: null,
+    ssotType: null,
+    ssotAttachmentId: null,
+    ssotSha: null,
+  };
+}
+
+/**
+ * Entry point. Returns the structured report and exit code so the
+ * test harness can drive the script as an in-process library.
+ *
+ * @param {string[]} argv
+ * @returns {{ report: object, exitCode: number }}
+ */
+export function runSweep(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  const rawPaths = loadRawMdPaths(opts.repoRoot);
+  const files = listMdFilesAddedSince(opts.cutoff, rawPaths, opts.repoRoot);
+  const slugIndex = loadSlugIndex(opts.repoRoot, opts.cleoBin);
+
+  /** @type {Array<{file: string, fileSha: string | null, remediation: string, ssotSlug: string | null, ssotType: string | null, ssotAttachmentId: string | null, ssotSha: string | null}>} */
+  const items = [];
+  for (const file of files) {
+    const abs = resolve(opts.repoRoot, file);
+    if (!existsSync(abs)) {
+      items.push({
+        file,
+        fileSha: null,
+        remediation: 'deleted',
+        ssotSlug: null,
+        ssotType: null,
+        ssotAttachmentId: null,
+        ssotSha: null,
+      });
+      continue;
+    }
+    const content = readFileSync(abs);
+    const fileSha = sha256Hex(content);
+    const cls = classify(file, fileSha, slugIndex, opts.repoRoot, opts.cleoBin);
+    items.push({ file, fileSha, ...cls });
+  }
+
+  const grouped = { orphan: [], drift: [], 'in-sync': [], deleted: [] };
+  for (const it of items) {
+    (grouped[it.remediation] ?? grouped.orphan).push(it);
+  }
+  const summary = {
+    cutoff: opts.cutoff,
+    totalFiles: items.length,
+    orphan: grouped.orphan.length,
+    drift: grouped.drift.length,
+    inSync: grouped['in-sync'].length,
+    deleted: grouped.deleted.length,
+    unresolved: grouped.orphan.length + grouped.drift.length,
+  };
+  const report = {
+    generatedAt: new Date().toISOString(),
+    rawMdPaths: rawPaths,
+    summary,
+    grouped,
+  };
+
+  const reportPath =
+    opts.out ?? resolve(opts.repoRoot, `audit/manual-write-sweep-${todayUtc()}.json`);
+  mkdirSync(dirname(reportPath), { recursive: true });
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+
+  if (!opts.json) {
+    console.log(JSON.stringify(summary, null, 2));
+    console.log(`Report: ${reportPath}`);
+  } else {
+    console.log(JSON.stringify(report, null, 2));
+  }
+
+  const exitCode = !opts.allowUnresolved && summary.unresolved > 0 ? 1 : 0;
+  return { report, exitCode };
+}
+
+/**
+ * Format today's date as `YYYY-MM-DD` in UTC. Stable across runs in
+ * the same calendar day, even across timezones.
+ *
+ * @returns {string}
+ */
+function todayUtc() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const { exitCode } = runSweep();
+    process.exit(exitCode);
+  } catch (err) {
+    console.error(`sweep-manual-doc-writes: ${err.message}`);
+    process.exit(2);
+  }
+}


### PR DESCRIPTION
## Summary
- `scripts/sweep-manual-doc-writes.mjs` — read-only audit script that walks every `*.md` file added under `.cleo/canon.yml`'s `rawMdPaths` directories since the T9791 docs-import cutoff (commit `251814e86`, 2026-05-20), hashes it, and queries the docs SSoT to classify each file as `in-sync`, `drift`, `orphan`, or `deleted`.
- Initial baseline `audit/manual-write-sweep-2026-05-24.json` checked in: **16 files / 11 in-sync / 5 orphan / 0 drift**. The 5 orphans become the input to E5.3's migration sweep.
- `Manual Write Sweep (T10372)` CI job wired with `continue-on-error: true` + `--allow-unresolved` initially (informational). The report is uploaded as a workflow artefact on every run. Flips strict after E5.3 lands the orphan cleanup.
- Tier-0 skill drift: `ct-documentor` SKILL.md v3.6 -> 3.7 documents the sweep as the read-only audit complement to the T10369 writer-uniqueness lint (same PR, per AGENTS.md tier-0 rule).

## Saga
- Saga: T10288 SG-DOCS-INTEGRITY
- Epic: T10293 E5-DOCS-RETROACTIVE-NORMALIZE (Wave 3 / first E5 task)
- Dependencies in place: T10366 WriterRegistry merged, T10369 lint gate merged
- Task ID: T10372 (T-E5.2)

## Test plan
- [x] 4/4 vitest cases pass (`scripts/__tests__/sweep-manual-doc-writes.test.mjs`): covers in-sync / drift / orphan / deleted classification, exit-1 on unresolved, exit-0 on clean
- [x] Live sweep against this repo produces stable summary across multiple runs
- [x] Sister lint `lint-dockind-writer-uniqueness.mjs` still clean (no regression)
- [ ] CI green on PR (manual-write-sweep job is non-blocking)