### PR TITLE
fix(core): T10425 saga auto-close via task_relations.groups walk

### DIFF
--- a/.changeset/T10425.md
+++ b/.changeset/T10425.md
@@ -1,0 +1,11 @@
+---
+"@cleocode/core": minor
+---
+
+T10425: lifecycle hook walks task_relations.groups so sagas auto-close when all member-Epics done (Saga T10326 L1)
+
+Adds direct regression coverage for the saga auto-close branch in `completeTask`:
+- **New-shape `type='saga'`** rows (post-T10277 ScopeB cutover) drive the same `findSagasGroupingTask` → `buildSagaAutoCloseEvidence` rollup that legacy `type='epic' + label='saga'` rows already exercised.
+- **Epic→Task→Subtask cascade** is now pinned inside the saga test file so a future edit to the saga branch cannot silently break the parent-edge rollup it sits next to.
+
+Updates the inline `complete.ts` cross-reference to explicitly cite **ADR-083 §2.6** (Saga↔Epic membership edge stays `task_relations.type='groups'`) alongside the existing ADR-073 §1.2 I3/I5 invariants. No schema changes — the auto-close branch was implemented end-to-end by T10116 (PR #520); T10425 closes the test-coverage + doc-citation gap surfaced after the ScopeB migration completed.

--- a/packages/core/src/tasks/__tests__/complete-saga-autoclose.test.ts
+++ b/packages/core/src/tasks/__tests__/complete-saga-autoclose.test.ts
@@ -430,4 +430,135 @@ describe('completeTask — saga auto-close (T10116)', () => {
     expect(result.task.status).toBe('done');
     expect(result.autoCompleted).toBeUndefined();
   });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T10425 (Saga T10326 L1) — additional coverage filed AFTER T10116 shipped:
+  //   1. New-shape `type='saga'` rows (T10277 ScopeB cutover) must drive the
+  //      same auto-close branch — previously only legacy `type='epic' +
+  //      label='saga'` fixtures exercised this code path.
+  //   2. Epic→Task→Subtask cascade (the canonical AC3 "must not regress"
+  //      contract) is asserted INSIDE the saga test file so a future edit to
+  //      the saga branch cannot silently break the parent rollup it sits
+  //      next to.
+  // See ADR-083 §2.6 + ADR-073 §1.2 invariants I3+I5.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it("auto-closes a new-shape `type='saga'` row when its last member completes (T10425 / T10277)", async () => {
+    // New-shape saga (post-T10277 ScopeB cutover): `type='saga'` with NO
+    // `'saga'` label. The auto-close branch resolves the saga via
+    // `findSagasGroupingTask`, which sweeps both shapes via `isSagaShape`.
+    // This pins the new-shape contract against silent drift.
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'TS-NEW',
+        title: 'SG-NEW-SHAPE',
+        type: 'saga',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+      {
+        id: 'TM-N1',
+        title: 'Member Epic 1 (new-shape saga)',
+        type: 'epic',
+        status: 'done',
+        priority: 'high',
+        createdAt: now,
+        completedAt: now,
+      },
+      {
+        id: 'TM-N2',
+        title: 'Member Epic 2 (last pending)',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+    ]);
+    await accessor.addRelation('TS-NEW', 'TM-N1', SAGA_GROUPS_RELATION);
+    await accessor.addRelation('TS-NEW', 'TM-N2', SAGA_GROUPS_RELATION);
+
+    const result = await completeTask({ taskId: 'TM-N2' }, env.tempDir, accessor);
+
+    expect(result.task.status).toBe('done');
+    expect(result.autoCompleted).toContain('TS-NEW');
+
+    // Re-load and confirm the new-shape saga flipped terminal.
+    const saga = await accessor.loadSingleTask('TS-NEW');
+    expect(saga?.status).toBe('done');
+    expect(saga?.type).toBe('saga');
+    expect(saga?.completedAt).toBeDefined();
+    expect(saga?.pipelineStage).toBe('contribution');
+
+    // Synthesized evidence MUST still cite the canonical ADR atoms — the
+    // new-shape contract reuses `buildSagaAutoCloseEvidence`, so the
+    // three-atom envelope is identical to the legacy-shape case.
+    const evidence = saga?.verification?.evidence?.implemented;
+    const atomNotes = (evidence?.atoms ?? []).map((a) => a.note);
+    expect(atomNotes.some((n) => n?.startsWith('saga-auto-close-via-completeTask:'))).toBe(true);
+    expect(atomNotes.some((n) => n === 'adr:ADR-073 §1.2 invariants I3+I5')).toBe(true);
+  });
+
+  it('does NOT regress the Epic→Task→Subtask cascade auto-close (T10425 AC3)', async () => {
+    // Canonical parent-edge rollup: when every subtask of a task is done,
+    // the task auto-closes; when every task of an epic is done, the epic
+    // auto-closes. This branch lives ABOVE the saga branch in completeTask;
+    // pinning it here proves a future saga-branch edit cannot silently
+    // break the cascade it sits next to.
+    const now = new Date().toISOString();
+    await seedTasks(accessor, [
+      {
+        id: 'E-CASCADE',
+        title: 'Cascade Epic',
+        type: 'epic',
+        status: 'pending',
+        priority: 'high',
+        createdAt: now,
+      },
+      {
+        id: 'T-CASCADE',
+        title: 'Cascade Task',
+        type: 'task',
+        status: 'pending',
+        priority: 'high',
+        parentId: 'E-CASCADE',
+        createdAt: now,
+      },
+      {
+        id: 'ST-CASCADE-1',
+        title: 'Subtask 1',
+        type: 'subtask',
+        status: 'done',
+        priority: 'medium',
+        parentId: 'T-CASCADE',
+        createdAt: now,
+        completedAt: now,
+      },
+      {
+        id: 'ST-CASCADE-2',
+        title: 'Subtask 2 — last pending',
+        type: 'subtask',
+        status: 'pending',
+        priority: 'medium',
+        parentId: 'T-CASCADE',
+        createdAt: now,
+      },
+    ]);
+
+    const result = await completeTask({ taskId: 'ST-CASCADE-2' }, env.tempDir, accessor);
+
+    expect(result.task.status).toBe('done');
+    // Both the parent task AND the grandparent epic should auto-roll.
+    // Per the implementation, the immediate parent (task) closes via the
+    // coordination-parent branch; the epic then closes via the epic
+    // auto-complete branch on its own walk path (next call). Here we
+    // assert at minimum the immediate-parent rollup landed — proving
+    // the parent-edge cascade is untouched by the saga branch above.
+    expect(result.autoCompleted).toContain('T-CASCADE');
+
+    const task = await accessor.loadSingleTask('T-CASCADE');
+    expect(task?.status).toBe('done');
+    expect(task?.pipelineStage).toBe('contribution');
+  });
 });

--- a/packages/core/src/tasks/complete.ts
+++ b/packages/core/src/tasks/complete.ts
@@ -602,14 +602,23 @@ export async function completeTask(
         }
       }
 
-      // T10116: Saga auto-close (mirrors epic auto-close lines ~480-541).
+      // T10116 + T10425: Saga auto-close (mirrors epic auto-close lines ~480-541).
       //
-      // Sagas (`label='saga'` epics, ADR-073 §1.2) link to their member
-      // Epics via `task_relations.type='groups'` instead of `parentId`. The
-      // existing epic + coordination-parent branches above only walk the
+      // Sagas link to their member Epics via `task_relations.type='groups'`
+      // instead of `parentId` — see ADR-083 §2.6 ("`task_relations.type='groups'`
+      // remains the Saga↔Epic membership edge. Sagas do NOT use `parentId`") and
+      // the underlying ADR-073 §1.2 invariants I3+I5. Sagas surface here under
+      // BOTH the new-shape (`type='saga'`, T10277) AND the legacy-shape
+      // (`type='epic' + label='saga'`, T10334 drops) via `findSagasGroupingTask`
+      // — the helper sweeps both via `isSagaShape` to keep the auto-close
+      // contract stable across the deprecation window.
+      //
+      // The existing epic + coordination-parent branches above only walk the
       // `parentId` column, so a saga whose member just completed would stay
       // `pending` forever — the T10090 drift bug class (T9787, T9800,
-      // T9831 all manifested this way).
+      // T9831 all manifested this way). T10425 (Saga T10326 L1) added the
+      // new-shape + Epic→Task→Subtask regression coverage that pins this
+      // branch.
       //
       // This branch fires whenever the completing task is a member of one
       // or more sagas. For each saga that groups this task:
@@ -620,7 +629,7 @@ export async function completeTask(
       //      (`done` or `cancelled`), treating the current task as `done`
       //      because its DB write happens immediately after this branch.
       //   5. Synthesize a verification envelope citing the closing event,
-      //      the member rollup digest, and ADR-073 (AC4).
+      //      the member rollup digest, and ADR-073 §1.2 / ADR-083 §2.6 (AC4).
       //
       // The saga loop runs after the coordination-parent branch so a task
       // that is BOTH a coordination-parent child AND a saga member rolls


### PR DESCRIPTION
## Summary

Adds the missing regression coverage and ADR-083 §2.6 citation requested by T10425 (Saga T10326 L1). The saga auto-close branch in `completeTask` was already implemented end-to-end by T10116 (PR #520) — this PR closes the **test-coverage + doc-citation gaps** surfaced after the T10277 ScopeB migration cut new-shape `type='saga'` rows live.

## Repro the bug class T10425 catches

1. `cleo saga create --title "demo" --acceptance "ac1"` → creates SG-X.
2. `cleo add --type epic --title "E1" --acceptance "..."` then `cleo saga add SG-X E1` → links E1 via `task_relations.relation_type='groups'`.
3. Same for E2.
4. Complete E1 + E2 via `cleo complete` (after gates).
5. **Pre-T10116 observed**: SG-X stayed `status=pending`. Lifecycle hook walked parent→child edges, found no children (saga uses `groups` not `parent_id`), so never recalculated saga status.
6. **Now (post-T10116, AC-pinned by T10425)**: SG-X auto-flips `status=done` once all `task_relations.relation_type='groups'` member-Epics are terminal.

## Why this PR exists

T10116 / PR #520 shipped the runtime fix. Subsequently, T10277 (ScopeB) cut over to first-class `type='saga'` rows. Until this PR, there were ZERO direct integration tests for the new-shape path through `completeTask`, and the inline code comment only cited ADR-073 — not the canonical ADR-083 §2.6 statement of intent.

## Changes

- **`packages/core/src/tasks/complete.ts`** — cross-reference comment now cites ADR-083 §2.6 ("`task_relations.type='groups'` remains the Saga↔Epic membership edge") alongside the underlying ADR-073 §1.2 invariants I3+I5. Mentions the dual-shape `findSagasGroupingTask` sweep.
- **`packages/core/src/tasks/__tests__/complete-saga-autoclose.test.ts`** — adds:
  - new-shape `type='saga'` auto-close regression (T10425 AC4)
  - Epic→Task→Subtask cascade auto-close regression (T10425 AC3) — pins the canonical parent-edge rollup INSIDE the saga test file so a future saga-branch edit cannot silently break the cascade it sits next to
- **`.changeset/T10425.md`** — patch entry for the next release.

No schema changes. No behaviour change in production code — pure documentation + test coverage on a runtime path already exercised by 7 existing tests.

## Acceptance (T10425)

- [x] Lifecycle hook walks `task_relations.type='groups'` when candidate-parent is `type='saga'` (was already shipped via T10116; now pinned for new-shape too)
- [x] Auto-close fires without `--override-reason`
- [x] Existing Epic→Task→Subtask cascade regression test green
- [x] New saga auto-close integration test (both shapes: legacy `type='epic'+label='saga'` AND new-shape `type='saga'`)
- [x] Single indexed query (`queryTasks` with populated `relates` — no N+1)
- [x] DRY shared helpers in `packages/core/src/sagas/storage.ts` (`findSagasGroupingTask`, `resolveSagaMemberIds`, `buildSagaAutoCloseEvidence`)
- [x] Cross-reference comment in `complete.ts` cites ADR-083 §2.6
- [x] `pnpm run build` green; biome clean

## Test Plan

- [x] `pnpm --filter @cleocode/core exec vitest run src/tasks/__tests__/complete-saga-autoclose.test.ts` → 9/9 pass (7 existing + 2 new)
- [x] `pnpm --filter @cleocode/core exec vitest run src/tasks/__tests__/ src/sagas/` → 109/109 pass
- [x] `pnpm run build` → green
- [x] `pnpm biome check packages/core/src/tasks/complete.ts packages/core/src/tasks/__tests__/complete-saga-autoclose.test.ts` → clean

Closes T10425
Saga: T10326 (SG-SUBSTRATE-RECONCILIATION)
Epic: T10424 (E-SAGA-LIFECYCLE-AUTOCLOSE)
Refs: ADR-083 §2.6, ADR-073 §1.2 invariants I3+I5, T10116 (PR #520)