### PR TITLE
refactor(core,contracts): T10339 release-registry consumes central invariants substrate

### DIFF
--- a/.changeset/T10339.md
+++ b/.changeset/T10339.md
@@ -1,0 +1,6 @@
+---
+"@cleocode/contracts": minor
+"@cleocode/core": minor
+---
+
+T10339: release/invariants/registry.ts becomes CONSUMER of central INVARIANTS_REGISTRY; ADR-056 D1-D6 registered in central substrate (Saga T10326 R5)

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -563,6 +563,7 @@ export type {
   RegisteredInvariant,
 } from './invariants/index.js';
 export {
+  ADR_056_INVARIANTS,
   ADR_073_INVARIANTS,
   getInvariant,
   getInvariantsByAdr,

--- a/packages/contracts/src/invariants/__tests__/adr-056-release.test.ts
+++ b/packages/contracts/src/invariants/__tests__/adr-056-release.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the ADR-056 D1-D6 entries in the central invariants
+ * registry (T10339 — R5).
+ *
+ * The release-side executable subsystem at
+ * `packages/core/src/release/invariants/registry.ts` consumes these
+ * metadata entries via `getInvariantsByAdr('ADR-056')`. The tests below
+ * assert the metadata shape downstream consumers (R4 CI gate, R6 doctor
+ * audit, R8 docs renderer) rely on.
+ *
+ * @epic T10327 — E-INVARIANT-REGISTRY-SSOT
+ * @saga T10326 — SG-SUBSTRATE-RECONCILIATION
+ * @task T10339 — R5: release-registry consumes central substrate
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  ADR_056_INVARIANTS,
+  getInvariant,
+  getInvariantsByAdr,
+  INVARIANTS_REGISTRY,
+} from '../index.js';
+
+describe('ADR-056 invariants — central registry entries', () => {
+  it('registers all six ADR-056 decisions D1-D6 under predictable keys', () => {
+    for (let i = 1; i <= 6; i++) {
+      const key = `ADR-056.D${i}`;
+      expect(INVARIANTS_REGISTRY[key]).toBeDefined();
+      expect(INVARIANTS_REGISTRY[key]?.adr).toBe('ADR-056');
+      expect(INVARIANTS_REGISTRY[key]?.code).toBe(`D${i}`);
+    }
+  });
+
+  it('getInvariantsByAdr("ADR-056") returns D1..D6 in declaration order', () => {
+    const adr056 = getInvariantsByAdr('ADR-056');
+    expect(adr056).toHaveLength(6);
+    expect(adr056.map((e) => e.code)).toEqual(['D1', 'D2', 'D3', 'D4', 'D5', 'D6']);
+  });
+
+  it('ADR_056_INVARIANTS convenience binding matches getInvariantsByAdr output', () => {
+    expect(ADR_056_INVARIANTS).toHaveLength(6);
+    const enumerated = getInvariantsByAdr('ADR-056');
+    expect(enumerated).toHaveLength(ADR_056_INVARIANTS.length);
+    for (let i = 0; i < ADR_056_INVARIANTS.length; i++) {
+      expect(enumerated[i]?.code).toBe(ADR_056_INVARIANTS[i]?.code);
+    }
+  });
+
+  it('every entry carries a non-empty name and description', () => {
+    for (const entry of ADR_056_INVARIANTS) {
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('D4 is the archive-reason runtime gate (severity:error)', () => {
+    const d4 = getInvariant('ADR-056.D4');
+    expect(d4).toBeDefined();
+    expect(d4?.severity).toBe('error');
+    expect(d4?.runtimeGate).not.toBeNull();
+    expect(d4?.runtimeGate?.functionName).toBe('assertArchiveReason');
+    expect(d4?.runtimeGate?.module).toBe('packages/contracts/src/tasks/archive.ts');
+  });
+
+  it('D5 points at the release-invariants registry runtime gate', () => {
+    const d5 = getInvariant('ADR-056.D5');
+    expect(d5).toBeDefined();
+    expect(d5?.severity).toBe('warning');
+    expect(d5?.runtimeGate).not.toBeNull();
+    expect(d5?.runtimeGate?.functionName).toBe('runInvariants');
+    expect(d5?.runtimeGate?.module).toBe('packages/core/src/release/invariants/registry.ts');
+  });
+
+  it('D6 carries a lintRule pointer to the commit-msg hook (info severity)', () => {
+    const d6 = getInvariant('ADR-056.D6');
+    expect(d6).toBeDefined();
+    expect(d6?.severity).toBe('info');
+    expect(d6?.runtimeGate).toBeNull();
+    expect(d6?.lintRule?.lintScript).toBe('scripts/hooks/commit-msg-release-lint.mjs');
+  });
+
+  it('D1, D2, D3 are info-tier topology/convention decisions with no runtime gate', () => {
+    for (const code of ['D1', 'D2', 'D3'] as const) {
+      const entry = getInvariant(`ADR-056.${code}`);
+      expect(entry).toBeDefined();
+      expect(entry?.severity).toBe('info');
+      expect(entry?.runtimeGate).toBeNull();
+    }
+  });
+
+  it('every severity:"error" ADR-056 entry has a non-null runtimeGate', () => {
+    const errorTier = ADR_056_INVARIANTS.filter((e) => e.severity === 'error');
+    expect(errorTier.length).toBeGreaterThan(0);
+    for (const entry of errorTier) {
+      expect(entry.runtimeGate).not.toBeNull();
+      if (entry.runtimeGate !== null) {
+        expect(entry.runtimeGate.module.length).toBeGreaterThan(0);
+        expect(entry.runtimeGate.functionName.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/contracts/src/invariants/adr-056-release.ts
+++ b/packages/contracts/src/invariants/adr-056-release.ts
@@ -1,0 +1,154 @@
+/**
+ * ADR-056 decisions D1-D6 registered against the central invariants
+ * registry (`./index.ts`).
+ *
+ * The six decisions govern the per-domain SQLite SSoT topology + the
+ * release-completion invariant (archiveReason enum + post-release gate).
+ *
+ *   - D1 — Database topology: keep per-domain split (no consolidation).
+ *   - D2 — Naming convention `<domain>-schema.ts` + `<domain>-sqlite.ts`.
+ *   - D3 — Migration runner SSoT under `migration-manager.ts`.
+ *   - D4 — `archiveReason` 6-value enum with tombstone semantics.
+ *   - D5 — Post-release reconciliation: registry-driven `cleo verify --release`.
+ *   - D6 — Commit-message lint for release commits.
+ *
+ * D4 carries a runtime guard (the `assertArchiveReason` function in
+ * `@cleocode/contracts` tasks/archive module) and surfaces as the
+ * `E_ARCHIVE_REASON_TOMBSTONE` LAFS error code on tombstone-write attempts.
+ * D5 carries a registry-driven runtime gate at
+ * `packages/core/src/release/invariants/registry.ts` (the per-release
+ * executable invariants subsystem this central entry catalogues). D1, D2,
+ * D3, D6 are topology / convention / CI-hook decisions — they carry
+ * `lintRule` or `runtimeGate:null` markers per the per-decision
+ * enforcement surface, matching the ADR-073 pattern for I1, I2, I4, I6, I8.
+ *
+ * @epic T10327 — E-INVARIANT-REGISTRY-SSOT
+ * @saga T10326 — SG-SUBSTRATE-RECONCILIATION
+ * @task T10339 — R5: release-registry consumes central substrate
+ * @see ADR-056-db-ssot-and-release-completion-invariant.md §Decision
+ * @see packages/core/src/release/invariants/registry.ts — D5 executable subsystem
+ */
+
+import type { RegisteredInvariant } from './index.js';
+
+/**
+ * Module path that hosts the `assertArchiveReason` runtime guard.
+ *
+ * Held as a constant so the D4 entry shares one source-of-truth pointer —
+ * touching the path once propagates to every guard ref.
+ */
+const ARCHIVE_REASON_MODULE = 'packages/contracts/src/tasks/archive.ts';
+
+/**
+ * Module path that hosts the release-invariants registry — the executable
+ * subsystem catalogued by D5. The registry exposes `registerInvariant`,
+ * `getInvariants`, and `runInvariants`; the archive-reason invariant is its
+ * first customer.
+ */
+const RELEASE_INVARIANTS_REGISTRY_MODULE = 'packages/core/src/release/invariants/registry.ts';
+
+/**
+ * Repo-rooted path to the release commit-msg lint script (D6 enforcement).
+ */
+const RELEASE_COMMIT_MSG_HOOK = 'scripts/hooks/commit-msg-release-lint.mjs';
+
+/**
+ * ADR-056 invariants D1-D6 in declaration order.
+ *
+ * Severity mapping (see `RegisteredInvariant` JSDoc for tier semantics):
+ * - D1, D2, D3, D6 → `info` (topology / convention / CI hook concerns).
+ * - D4 → `error` (tombstone-write rejection — `E_ARCHIVE_REASON_TOMBSTONE`).
+ * - D5 → `warning` (post-release gate produces follow-up tasks rather than
+ *   throwing — failures are caught + recorded via the audit log).
+ */
+export const ADR_056_INVARIANTS: readonly RegisteredInvariant[] = Object.freeze([
+  {
+    adr: 'ADR-056',
+    code: 'D1',
+    name: 'Database topology: keep per-domain split',
+    description:
+      'CLEO retains the six per-domain SQLite databases (tasks, brain, conduit, nexus, signaldock, telemetry) documented in DATABASE-ERDS.md. Consolidation is rejected to preserve per-DB WAL throughput, per-DB rollback granularity, and avoid single-writer contention during multi-agent waves.',
+    severity: 'info',
+    // D1 is a topology decision; the absence of consolidation is its only
+    // enforcement surface. No runtime guard, no lint script.
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [],
+  },
+  {
+    adr: 'ADR-056',
+    code: 'D2',
+    name: 'Store-layer naming convention',
+    description:
+      'New always-on store-layer domains MUST use the kebab-case pair `packages/core/src/store/<domain>-schema.ts` (Drizzle defs) + `packages/core/src/store/<domain>-sqlite.ts` (open/init/CRUD). Opt-in / isolated domains MAY use the folder variant `packages/core/src/<domain>/{schema,sqlite}.ts` (currently telemetry only).',
+    severity: 'info',
+    // D2 is a naming-convention decision; enforced by code review and the
+    // ADR-073/ADR-056 doctor audit. No runtime guard.
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [],
+  },
+  {
+    adr: 'ADR-056',
+    code: 'D3',
+    name: 'Migration runner SSoT under migration-manager.ts',
+    description:
+      'All six SQLite databases MUST be initialized via `packages/core/src/migration/migration-manager.ts` (`migrateWithRetry()` + `reconcileJournal()`). Per-DB bespoke runners are prohibited for new domains. Rust Diesel migrations for cloud signaldock-storage MUST NOT touch the local SQLite signaldock.db at runtime.',
+    severity: 'info',
+    // D3 is enforced by the absence of bespoke runners — every domain's
+    // `<domain>-sqlite.ts` open path delegates to migration-manager. No
+    // single runtime guard; per-DB chokepoints are the enforcement surface.
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [],
+  },
+  {
+    adr: 'ADR-056',
+    code: 'D4',
+    name: 'archiveReason 6-value enum with tombstone semantics',
+    description:
+      "The tasks.archive_reason column is constrained to exactly six values (verified, reconciled, superseded, shadowed, cancelled, completed-unverified) via SQLite CHECK constraint AND Zod z.enum validation. Writing 'completed-unverified' from non-migration code MUST throw E_ARCHIVE_REASON_TOMBSTONE — the tombstone is reserved for the T1408 backfill migration only.",
+    severity: 'error',
+    runtimeGate: {
+      module: ARCHIVE_REASON_MODULE,
+      functionName: 'assertArchiveReason',
+    },
+    lintRule: null,
+    doctorAudit: null,
+    tests: ['packages/contracts/src/tasks/__tests__/archive.test.ts'],
+  },
+  {
+    adr: 'ADR-056',
+    code: 'D5',
+    name: 'Post-release reconciliation: registry-driven cleo verify --release',
+    description:
+      'Post-release reconciliation flows through the executable invariants registry at packages/core/src/release/invariants/registry.ts. Customers register via registerInvariant() and the CLI runs every entry on `cleo verify --release <tag>`. First customer: archive-reason-invariant.ts (stamps verified tasks done; creates follow-up tasks for unverified references).',
+    severity: 'warning',
+    runtimeGate: {
+      module: RELEASE_INVARIANTS_REGISTRY_MODULE,
+      functionName: 'runInvariants',
+    },
+    lintRule: null,
+    doctorAudit: null,
+    tests: ['packages/core/src/release/invariants/__tests__/archive-reason-invariant.test.ts'],
+  },
+  {
+    adr: 'ADR-056',
+    code: 'D6',
+    name: 'Commit-message lint for release commits',
+    description:
+      'Every commit whose subject matches `^(chore|feat)\\(release\\):` MUST contain at least one `T\\d+` task reference in the commit body. Enforced by scripts/hooks/commit-msg-release-lint.mjs (T1410). Bypass via CLEO_OWNER_OVERRIDE=1 with audited justification.',
+    severity: 'info',
+    // D6 is a CI-hook concern. The hook itself is the enforcement surface
+    // — represented here via lintRule for cross-reference rendering.
+    runtimeGate: null,
+    lintRule: {
+      lintScript: RELEASE_COMMIT_MSG_HOOK,
+    },
+    doctorAudit: null,
+    tests: [],
+  },
+]);

--- a/packages/contracts/src/invariants/index.ts
+++ b/packages/contracts/src/invariants/index.ts
@@ -26,10 +26,12 @@
  * @see ADR-073-above-epic-naming.md §1.2
  */
 
+import { ADR_056_INVARIANTS } from './adr-056-release.js';
 import { ADR_073_INVARIANTS } from './adr-073-saga.js';
 
 // Re-exported so consumers can import either the per-ADR list or the merged
 // registry from one place.
+export { ADR_056_INVARIANTS } from './adr-056-release.js';
 export { ADR_073_INVARIANTS } from './adr-073-saga.js';
 
 /**
@@ -149,7 +151,7 @@ function buildKey(invariant: RegisteredInvariant): string {
  * @internal
  */
 function buildRegistry(): Readonly<Record<string, RegisteredInvariant>> {
-  const entries: RegisteredInvariant[] = [...ADR_073_INVARIANTS];
+  const entries: RegisteredInvariant[] = [...ADR_073_INVARIANTS, ...ADR_056_INVARIANTS];
   const record: Record<string, RegisteredInvariant> = {};
   for (const entry of entries) {
     const key = buildKey(entry);

--- a/packages/core/src/release/index.ts
+++ b/packages/core/src/release/index.ts
@@ -128,6 +128,8 @@ export {
 export type { DoubleListingResult, EpicCompletenessResult } from './guards.js';
 export { checkDoubleListing, checkEpicCompleteness } from './guards.js';
 // Post-release invariants registry (ADR-056 D5 / T1411)
+// T10339 — R5: this executable subsystem is catalogued by the central
+// metadata registry at `@cleocode/contracts/invariants/adr-056-release.ts`.
 export type {
   InvariantReport,
   InvariantResult,
@@ -136,12 +138,14 @@ export type {
   ReconcileAction,
   ReconcileAuditRow,
   RegisteredInvariant,
+  RegisteredReleaseInvariant,
 } from './invariants/index.js';
 export {
   ARCHIVE_REASON_INVARIANT_ID,
   clearInvariants,
   extractTaskIds,
   getInvariants,
+  getRegisteredAdr056Invariants,
   RECONCILE_AUDIT_FILE,
   registerArchiveReasonInvariant,
   registerInvariant,

--- a/packages/core/src/release/invariants/__tests__/central-registry-bridge.test.ts
+++ b/packages/core/src/release/invariants/__tests__/central-registry-bridge.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for the release-side bridge that consumes the central ADR-056
+ * metadata from `@cleocode/contracts` (T10339 — R5).
+ *
+ * The release-time registry at `packages/core/src/release/invariants/registry.ts`
+ * exposes `getRegisteredAdr056Invariants()` which proxies through to
+ * `getInvariantsByAdr('ADR-056')` in the central registry. The two views
+ * MUST stay in sync — this test pins the contract.
+ *
+ * @epic T10327 — E-INVARIANT-REGISTRY-SSOT
+ * @saga T10326 — SG-SUBSTRATE-RECONCILIATION
+ * @task T10339 — R5: release-registry consumes central substrate
+ */
+
+import { getInvariantsByAdr } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { getRegisteredAdr056Invariants } from '../registry.js';
+
+describe('getRegisteredAdr056Invariants — release-side central-registry bridge', () => {
+  it('returns the same six entries as getInvariantsByAdr("ADR-056")', () => {
+    const fromBridge = getRegisteredAdr056Invariants();
+    const fromCentral = getInvariantsByAdr('ADR-056');
+
+    expect(fromBridge).toHaveLength(6);
+    expect(fromBridge).toHaveLength(fromCentral.length);
+
+    for (let i = 0; i < fromBridge.length; i++) {
+      expect(fromBridge[i]?.adr).toBe(fromCentral[i]?.adr);
+      expect(fromBridge[i]?.code).toBe(fromCentral[i]?.code);
+      expect(fromBridge[i]?.name).toBe(fromCentral[i]?.name);
+      expect(fromBridge[i]?.severity).toBe(fromCentral[i]?.severity);
+    }
+  });
+
+  it('surfaces D1..D6 in declaration order', () => {
+    const entries = getRegisteredAdr056Invariants();
+    expect(entries.map((e) => e.code)).toEqual(['D1', 'D2', 'D3', 'D4', 'D5', 'D6']);
+  });
+
+  it('D5 points at the release-time registry runInvariants entry', () => {
+    const d5 = getRegisteredAdr056Invariants().find((e) => e.code === 'D5');
+    expect(d5).toBeDefined();
+    expect(d5?.runtimeGate?.module).toBe('packages/core/src/release/invariants/registry.ts');
+    expect(d5?.runtimeGate?.functionName).toBe('runInvariants');
+  });
+});

--- a/packages/core/src/release/invariants/archive-reason-invariant.ts
+++ b/packages/core/src/release/invariants/archive-reason-invariant.ts
@@ -2,6 +2,11 @@
  * Archive-reason post-release invariant — first customer of the registry
  * defined in {@link ./registry}.
  *
+ * The release-time `RegisteredInvariant` shape consumed below is the
+ * executable counterpart of ADR-056 D5; the central metadata for this
+ * invariant subsystem is catalogued in
+ * `@cleocode/contracts/invariants/adr-056-release.ts` (T10339 — R5).
+ *
  * Workflow (per ADR-056 D5 step 2):
  *   1. Read the tag annotation (`git tag <tag> -l --format='%(contents)'`)
  *      and every commit between `<previousTag>..<tag>` (inclusive of `<tag>`).

--- a/packages/core/src/release/invariants/index.ts
+++ b/packages/core/src/release/invariants/index.ts
@@ -13,9 +13,21 @@
  * `register…Invariant()` call below. The registry preserves insertion order
  * which doubles as render order in the CLI report.
  *
+ * ---
+ *
+ * **Cross-reference to the central invariants registry (T10339 — R5):**
+ *
+ * This release-time registry is the EXECUTABLE subsystem catalogued by
+ * ADR-056 D5 in the central invariants registry at
+ * `@cleocode/contracts/invariants/adr-056-release.ts`. The central registry
+ * holds metadata; this module holds the implementation that the metadata
+ * `runtimeGate` field points to. See `./registry.ts` for the full
+ * relationship rationale.
+ *
  * @task T1411
  * @epic T1407
  * @adr ADR-056 D5
+ * @see packages/contracts/src/invariants/adr-056-release.ts — central metadata
  */
 
 export type { ReconcileAction, ReconcileAuditRow } from './archive-reason-invariant.js';
@@ -31,10 +43,12 @@ export type {
   InvariantRunOptions,
   InvariantSeverity,
   RegisteredInvariant,
+  RegisteredReleaseInvariant,
 } from './registry.js';
 export {
   clearInvariants,
   getInvariants,
+  getRegisteredAdr056Invariants,
   registerInvariant,
   runInvariants,
 } from './registry.js';

--- a/packages/core/src/release/invariants/registry.ts
+++ b/packages/core/src/release/invariants/registry.ts
@@ -1,5 +1,6 @@
 /**
- * Registry-driven post-release invariants gate (ADR-056 D5).
+ * Registry-driven post-release invariants gate (ADR-056 D5) — EXECUTABLE
+ * subsystem catalogued by the central invariants registry.
  *
  * Defines the registration API + execution loop for release-time invariants.
  * This module is intentionally generic: it knows nothing about archiveReason,
@@ -12,11 +13,37 @@
  * plumbing on top of T1411's already-scoped hook code retires the entire
  * class of drift bugs that ADR-054's six patches paid for ad-hoc.
  *
+ * ---
+ *
+ * **Relationship to the central invariants registry (`@cleocode/contracts`):**
+ *
+ * The central registry at `packages/contracts/src/invariants/` is the SSoT
+ * for invariant *metadata* — every system-wide invariant carries an entry
+ * with `(adr, code, name, severity, runtimeGate, tests)` for cross-system
+ * tooling (R4 CI gate, R6 doctor audit, R8 docs renderer).
+ *
+ * This module is the *executable* counterpart specific to release-time
+ * reconciliation. ADR-056 D5 is registered in the central registry
+ * (`packages/contracts/src/invariants/adr-056-release.ts`); the `runtimeGate`
+ * field of that entry points HERE (the `runInvariants` export below). The
+ * central entry is the catalogue; this module is the implementation.
+ *
+ * Consumers wanting to enumerate ADR-056 metadata SHOULD call
+ * `getInvariantsByAdr('ADR-056')` from `@cleocode/contracts`. Consumers
+ * wanting to register or run an executable release-time invariant continue
+ * to use `registerInvariant` / `runInvariants` from this module.
+ *
  * @task T1411
  * @epic T1407
  * @adr ADR-056 D5
+ * @see packages/contracts/src/invariants/adr-056-release.ts — central metadata entry
+ * @see ADR-056-db-ssot-and-release-completion-invariant.md §Decision D5
  */
 
+import {
+  type RegisteredInvariant as CentralRegisteredInvariant,
+  getInvariantsByAdr,
+} from '@cleocode/contracts';
 import { getProjectRoot } from '../../paths.js';
 
 /**
@@ -93,10 +120,22 @@ export interface InvariantReport {
 }
 
 /**
- * Specification for a registered invariant.
+ * Specification for a registered EXECUTABLE release invariant.
  *
  * `check` is invoked once per `runInvariants(tag, …)` call; it MUST be
  * idempotent on dry-run inputs and idempotent-on-success on live inputs.
+ *
+ * NOTE: this type is distinct from
+ * `@cleocode/contracts`'s `RegisteredInvariant` — that one is the
+ * cross-system *metadata* shape (`adr`, `code`, `name`, `severity`,
+ * `runtimeGate`, `tests`). The two registries serve complementary roles:
+ *
+ * - **Central (metadata):** catalogues every invariant for tooling
+ *   (CI gate, doctor audit, docs renderer).
+ * - **Release (executable):** runs reconciliation logic per release tag.
+ *
+ * @see RegisteredReleaseInvariant — canonical alias going forward.
+ * @see CentralRegisteredInvariant — metadata counterpart from contracts.
  */
 export interface RegisteredInvariant {
   /** Stable identifier (kebab-case recommended). */
@@ -108,6 +147,15 @@ export interface RegisteredInvariant {
   /** Implementation that performs the check (and reconciliation, if applicable). */
   check: (options: InvariantRunOptions) => Promise<InvariantResult>;
 }
+
+/**
+ * Canonical alias for the executable release-invariant shape.
+ *
+ * Prefer this name in new code; the bare `RegisteredInvariant` export is
+ * preserved as a backward-compatible alias for existing consumers
+ * (archive-reason-invariant.ts, the release barrel, etc.).
+ */
+export type RegisteredReleaseInvariant = RegisteredInvariant;
 
 /**
  * Module-local registry. Single global instance — invariants register on
@@ -208,4 +256,25 @@ export async function runInvariants(
     ...aggregate,
     results,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Central registry bridge (T10339 — R5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the ADR-056 metadata entries from the central invariants registry
+ * (`@cleocode/contracts`).
+ *
+ * This release-side module is the executable subsystem catalogued by
+ * ADR-056 D5 in the central registry. Consumers (doctor audit, docs
+ * renderer, the CI gate added by R4 T10338) can use this helper to surface
+ * the metadata for every ADR-056 decision without reaching across into
+ * `@cleocode/contracts` directly.
+ *
+ * @returns The six ADR-056 metadata entries (D1..D6) in declaration order.
+ * @see packages/contracts/src/invariants/adr-056-release.ts
+ */
+export function getRegisteredAdr056Invariants(): CentralRegisteredInvariant[] {
+  return getInvariantsByAdr('ADR-056');
 }


### PR DESCRIPTION
## Summary

R5 of Epic **T10327** (E-INVARIANT-REGISTRY-SSOT), Saga **T10326** (SG-SUBSTRATE-RECONCILIATION).

Two competing invariant registries are now reconciled into one substrate:

- **Central metadata registry** (`packages/contracts/src/invariants/`, T10335 SSoT) gains `adr-056-release.ts` with ADR-056 decisions D1-D6.
- **Release executable registry** (`packages/core/src/release/invariants/registry.ts`) becomes a CONSUMER of the central substrate via the new `getRegisteredAdr056Invariants()` bridge helper. All existing function signatures preserved.

### Key invariants

| Code | Severity | Runtime gate | Notes |
|------|----------|--------------|-------|
| ADR-056.D1 | info | none | Topology: keep per-domain SQLite split |
| ADR-056.D2 | info | none | Naming convention `<domain>-{schema,sqlite}.ts` |
| ADR-056.D3 | info | none | Migration runner SSoT under migration-manager.ts |
| ADR-056.D4 | error | `assertArchiveReason` in contracts/tasks/archive.ts | 6-value enum + tombstone semantics |
| ADR-056.D5 | warning | `runInvariants` in core/release/invariants/registry.ts | Post-release reconciliation |
| ADR-056.D6 | info | lintRule → `scripts/hooks/commit-msg-release-lint.mjs` | Release commit-msg lint |

### Backward compatibility

- `RegisteredInvariant` (release-side) retained as alias for existing consumers (archive-reason-invariant.ts, release barrel).
- `RegisteredReleaseInvariant` introduced as the canonical new name to disambiguate from the central metadata shape.
- `registerInvariant`, `runInvariants`, `getInvariants`, `clearInvariants` signatures all unchanged.
- No behaviour change in `cleo release reconcile` or any release verb.

### Coordination

- Sibling **T10336** (R2 ORC codes) writes `adr-070-orchestration.ts` and touches the same `invariants/index.ts` barrel — rebase is mechanical (append-only).

## Test plan

- [x] 8 new cases in `packages/contracts/src/invariants/__tests__/adr-056-release.test.ts`
- [x] 3 new cases in `packages/core/src/release/invariants/__tests__/central-registry-bridge.test.ts`
- [x] All 450 `@cleocode/contracts` tests pass
- [x] 2 pre-existing failures in `archive-reason-invariant.test.ts` (E_INVALID_PROJECT_ROOT — worktree-root resolution) unchanged by this refactor
- [x] Full monorepo build green (`pnpm run build`)
- [x] Biome check clean

Closes **T10339**
Saga: **T10326**
Refs: **ADR-056**, **ADR-073**