### PR TITLE
feat(contracts,adr): T10336 enumerate ADR-070 ORC codes + register

### DIFF
--- a/.changeset/T10336.md
+++ b/.changeset/T10336.md
@@ -1,0 +1,7 @@
+---
+"@cleocode/contracts": minor
+---
+
+T10336: enumerate ADR-070 ORC-### orchestration codes + register in central invariants substrate (Saga T10326 R2)
+
+Adds `packages/contracts/src/invariants/adr-070-orchestration.ts` with 14 ORC-001..ORC-014 entries merged into the central INVARIANTS_REGISTRY introduced by T10335. Hard-enforced gates (ORC-006 atomic scope, ORC-012 thin-agent, ORC-013 worktree location, ORC-014 lead-bypass) carry runtime-gate pointers; 9 warning-severity entries with `runtimeGate: null` document the prompt-only / filed-but-unshipped gaps (ORC-010 → T10278, ORC-011 → T10279) so the R6 doctor audit (T10340) can surface them. ADR-070 markdown amended with full enumeration table. ThinAgentViolationError + LeadBypassDetectedError JSDoc cross-ref the registry entries.

--- a/.cleo/adrs/ADR-070-three-tier-orchestration.md
+++ b/.cleo/adrs/ADR-070-three-tier-orchestration.md
@@ -166,6 +166,46 @@ The following T9080 children consume this ADR:
 - **T9086** — Manifest aggregation rules for Phase Lead roll-ups
   (per ADR-027 § append semantics).
 
+## ORC-### Invariant Enumeration (T10336 / SG-SUBSTRATE-RECONCILIATION R2)
+
+The ORC codes that govern Orchestrator / Lead / Worker behaviour are
+registered in the central invariants registry
+(`packages/contracts/src/invariants/adr-070-orchestration.ts`) and keyed
+under `INVARIANTS_REGISTRY['ADR-070.ORC-XXX']`. Every entry carries
+severity, runtime-gate location, lint-rule reference, and test paths so
+the R6 doctor audit (T10340) and R8 docs renderer (T10342) can chase the
+enforcement surface programmatically.
+
+| Code     | Name                                                  | Severity | Enforcement                                                                                  |
+|----------|-------------------------------------------------------|----------|----------------------------------------------------------------------------------------------|
+| ORC-001  | Orchestrator is the HITL interface                    | warning  | Prompt-time — `ct-orchestrator/SKILL.md`. No dispatch gate.                                  |
+| ORC-002  | Orchestrator MUST NOT write or edit code              | warning  | Prompt-time — `ct-orchestrator/SKILL.md`. No dispatch gate.                                  |
+| ORC-003  | Orchestrator MUST NOT read full source files          | warning  | Prompt-time — `ct-orchestrator/SKILL.md`. No dispatch gate.                                  |
+| ORC-004  | Dependency-ordered spawning                           | warning  | `validateSpawnReadiness` (V_MISSING_DEP / V_UNMET_DEP) + skill-orchestrator validator.       |
+| ORC-005  | Orchestrator context budget ≈ 10 K tokens             | warning  | `estimateContext` advisory; surfaced via `cleo orchestrate context`.                         |
+| ORC-006  | Worker scope ≤ 3 files per spawn                      | error    | `validateSpawnReadiness` (V_ATOMIC_SCOPE_MISSING / V_ATOMIC_SCOPE_TOO_LARGE).                |
+| ORC-007  | All work traced to an Epic                            | warning  | ADR-066 acceptance-criteria gate + cleo find. No single ORC-named runtime guard.             |
+| ORC-008  | Zero architectural decisions during execution         | warning  | Prompt-time — held by skill + ADR-066 acceptance criteria.                                   |
+| ORC-009  | Manifest-mediated handoffs                            | warning  | Prompt-time — held by ct-orchestrator/SKILL.md and reinforced by ORC-005 budget pressure.    |
+| ORC-010  | Lead-interposition for Epic-child Workers             | warning  | FILED (T10278) — dispatch gate `E_LEAD_REQUIRED_FOR_EPIC_CHILD` unshipped per ADR-083 §2.4.  |
+| ORC-011  | Orchestrator-depth ≤ 3                                | warning  | FILED (T10279) — dispatch gate `E_ORCHESTRATOR_DEPTH_EXCEEDED` unshipped per ADR-083 §2.2.   |
+| ORC-012  | Thin-agent inversion-of-control                       | error    | `enforceThinAgent` → `ThinAgentViolationError` → `E_THIN_AGENT_VIOLATION` (exit 68).         |
+| ORC-013  | Worktree provisioning at canonical XDG location       | error    | `assertCanonicalWorktreeLocation` → `E_WT_LOCATION_FORBIDDEN`. CI: lint-worktree-location.   |
+| ORC-014  | Lead-bypass detection at session end                  | error    | `endSession` → `LeadBypassDetectedError` → `E_LEAD_BYPASS_DETECTED` (exit 107).              |
+
+**Registry shape.** Every entry follows the `RegisteredInvariant`
+contract: stable `adr` + `code` pair → name + description + severity +
+optional `runtimeGate` (module + functionName) + optional `lintRule`
+(lint-script path) + optional `doctorAudit` + test-file refs +
+optional `deprecated` flag. Lookup helpers `getInvariant` and
+`getInvariantsByAdr` are exported from `@cleocode/contracts`.
+
+**Gap visibility.** Nine of the fourteen entries are `severity:'warning'`
+with `runtimeGate: null` — the gap is intentional and documented in each
+entry's `description` so the R6 doctor audit surfaces unenforced ORC
+contracts to the operator alongside the enforced ones. ORC-010 / ORC-011
+in particular are FILED but UNSHIPPED — tracked under T10278 / T10279.
+
 ## References
 
 - ADR-027 — Manifest contract (workers append their own rows).
@@ -173,6 +213,11 @@ The following T9080 children consume this ADR:
   values used here: `orchestrator`, `leaf`).
 - ADR-069 — Coordination Layers (forthcoming; covers Lead crash
   recovery and cross-epic dependency negotiation).
-- ct-orchestrator skill — Orchestrator role contract.
+- ADR-083 §2.2 — Cleo persona singleton + recursion bound (depth ≤ 3).
+- ADR-083 §2.4 — Lead-interposition contract for Epic-child Workers.
+- ct-orchestrator skill — Orchestrator role contract (source of ORC-001..ORC-009).
 - ct-lead skill (T9084) — Phase Lead role contract (forthcoming).
 - T1252 — `parseTopicName` and the `epic-<TID>.wave-<n>` primitive.
+- T10326 SG-SUBSTRATE-RECONCILIATION — saga that produced this enumeration.
+- T10335 R1 — central INVARIANTS_REGISTRY introduced.
+- T10336 R2 — this enumeration (current task).

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -29,6 +29,8 @@ import { ExitCode } from './exit-codes.js';
  *
  * @task T889 Orchestration Coherence v3
  * @task T907 Thin-agent enforcement
+ * @see INVARIANTS_REGISTRY['ADR-070.ORC-012'] — central-registry entry
+ *   for this invariant. Source: `./invariants/adr-070-orchestration.ts`.
  */
 export class ThinAgentViolationError extends Error {
   /** Stable LAFS error code string for envelope emission. */
@@ -209,6 +211,8 @@ export class DecisionValidatorFailedError extends Error {
  * @codeName E_LEAD_BYPASS_DETECTED
  * @task T9230
  * @adr ADR-070
+ * @see INVARIANTS_REGISTRY['ADR-070.ORC-014'] — central-registry entry
+ *   for this invariant. Source: `./invariants/adr-070-orchestration.ts`.
  */
 export class LeadBypassDetectedError extends Error {
   /** Stable LAFS error code string for envelope emission. */

--- a/packages/contracts/src/invariants/__tests__/adr-070-orchestration.test.ts
+++ b/packages/contracts/src/invariants/__tests__/adr-070-orchestration.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for the ADR-070 ORC-### orchestration invariants (T10336).
+ *
+ * The ORC codes are the Orchestrator / Lead / Worker behavioural contract
+ * surfaced through the central INVARIANTS_REGISTRY. The tests below assert:
+ *
+ * 1. At least 10 ORC-### entries are registered (we ship 14).
+ * 2. ORC-012 (the only ORC rule with a hard-enforced dispatch gate today)
+ *    points at the `enforceThinAgent` function in
+ *    `packages/core/src/orchestration/thin-agent.ts`.
+ * 3. Every `severity:'warning'` entry with `runtimeGate: null` carries
+ *    explanatory `description` text — the gap MUST be documented, not
+ *    silent.
+ * 4. ORC keys are emitted under the `ADR-070.` prefix in declaration
+ *    order and are merged into the central registry.
+ *
+ * @epic T10327 — E-INVARIANT-REGISTRY-SSOT
+ * @saga T10326 — SG-SUBSTRATE-RECONCILIATION
+ * @task T10336 — R2: enumerate ADR-070 ORC codes + register
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  ADR_070_INVARIANT_COUNT,
+  ADR_070_INVARIANTS,
+  ADR_070_MIN_ENTRIES,
+} from '../adr-070-orchestration.js';
+import {
+  getInvariant,
+  getInvariantsByAdr,
+  INVARIANTS_REGISTRY,
+  type RegisteredInvariant,
+} from '../index.js';
+
+/**
+ * Minimum ORC-### entry count required by AC1 — "Inventory ~ORC-001
+ * through ~ORC-020". We ship 14 today; the floor is 10 so future
+ * removals trip the gate before silently dropping coverage.
+ */
+const MIN_ORC_ENTRIES = 10;
+
+/**
+ * The ORC entry that has a hard-enforced dispatch-time guard today.
+ * Other entries either prompt-time (skill text) or filed-but-unshipped
+ * (ORC-010 / ORC-011 → T10278 / T10279).
+ */
+const HARD_ENFORCED_ORC_CODE = 'ORC-012';
+
+/**
+ * Expected runtime-gate module + function for ORC-012. Asserting both
+ * fields prevents silent drift if the thin-agent module is renamed or
+ * the export is shadowed.
+ */
+const ORC_012_RUNTIME_GATE = {
+  module: 'packages/core/src/orchestration/thin-agent.ts',
+  functionName: 'enforceThinAgent',
+} as const;
+
+describe('ADR_070_INVARIANTS — enumeration shape', () => {
+  it('exposes at least 10 ORC-### entries', () => {
+    expect(ADR_070_INVARIANTS.length).toBeGreaterThanOrEqual(MIN_ORC_ENTRIES);
+  });
+
+  it('keeps ADR_070_INVARIANT_COUNT in sync with the array length', () => {
+    expect(ADR_070_INVARIANT_COUNT).toBe(ADR_070_INVARIANTS.length);
+  });
+
+  it('declares ADR_070_MIN_ENTRIES at or above the AC1 floor', () => {
+    expect(ADR_070_MIN_ENTRIES).toBeGreaterThanOrEqual(MIN_ORC_ENTRIES);
+    expect(ADR_070_MIN_ENTRIES).toBeLessThanOrEqual(ADR_070_INVARIANTS.length);
+  });
+
+  it('every entry sets adr="ADR-070" and a non-empty ORC-#### code', () => {
+    for (const entry of ADR_070_INVARIANTS) {
+      expect(entry.adr).toBe('ADR-070');
+      expect(entry.code).toMatch(/^ORC-\d{3}$/);
+    }
+  });
+
+  it('every entry carries a non-empty name and description', () => {
+    for (const entry of ADR_070_INVARIANTS) {
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('codes are unique across the ADR-070 enumeration', () => {
+    const codes = ADR_070_INVARIANTS.map((e) => e.code);
+    const uniqueCodes = new Set(codes);
+    expect(uniqueCodes.size).toBe(codes.length);
+  });
+});
+
+describe('ADR-070 ORC-012 — thin-agent dispatch gate (hard-enforced)', () => {
+  it('points at enforceThinAgent in packages/core/src/orchestration/thin-agent.ts', () => {
+    const entry = ADR_070_INVARIANTS.find((e) => e.code === HARD_ENFORCED_ORC_CODE);
+    expect(entry).toBeDefined();
+    expect(entry?.severity).toBe('error');
+    expect(entry?.runtimeGate).not.toBeNull();
+    expect(entry?.runtimeGate?.module).toBe(ORC_012_RUNTIME_GATE.module);
+    expect(entry?.runtimeGate?.functionName).toBe(ORC_012_RUNTIME_GATE.functionName);
+  });
+
+  it('is reachable via INVARIANTS_REGISTRY["ADR-070.ORC-012"]', () => {
+    const fromRegistry = INVARIANTS_REGISTRY['ADR-070.ORC-012'];
+    expect(fromRegistry).toBeDefined();
+    expect(fromRegistry?.runtimeGate?.functionName).toBe(ORC_012_RUNTIME_GATE.functionName);
+  });
+});
+
+describe('ADR-070 gap documentation — warning + runtimeGate:null entries', () => {
+  it('every warning entry with runtimeGate:null carries explanatory description text', () => {
+    const gaps: RegisteredInvariant[] = ADR_070_INVARIANTS.filter(
+      (e) => e.severity === 'warning' && e.runtimeGate === null,
+    );
+
+    // We expect at least the prompt-only ORC entries (ORC-001..003, 008, 009)
+    // plus the filed-but-unshipped depth/lead entries (ORC-010 / ORC-011).
+    expect(gaps.length).toBeGreaterThanOrEqual(5);
+
+    // Each gap MUST explain WHY no runtime gate exists. We probe for the
+    // documented surface markers ("UNENFORCED", "Prompt-time",
+    // "FILED but UNSHIPPED" — and the related verb forms). At least one of
+    // these phrases is required so the R6 doctor audit can rely on the
+    // description as a human-readable gap explanation.
+    const gapMarkers = ['UNENFORCED', 'prompt-time', 'Prompt-time', 'UNSHIPPED', 'unshipped'];
+    for (const entry of gaps) {
+      const hasMarker = gapMarkers.some((m) => entry.description.includes(m));
+      expect(hasMarker, `Entry ${entry.code} description is missing a gap marker`).toBe(true);
+      // Sanity check: description is substantive, not a stub.
+      expect(entry.description.length).toBeGreaterThanOrEqual(80);
+    }
+  });
+
+  it('filed-but-unshipped ORC-010 / ORC-011 reference their tracking tasks', () => {
+    const orc010 = ADR_070_INVARIANTS.find((e) => e.code === 'ORC-010');
+    const orc011 = ADR_070_INVARIANTS.find((e) => e.code === 'ORC-011');
+    expect(orc010?.description).toContain('T10278');
+    expect(orc011?.description).toContain('T10279');
+  });
+});
+
+describe('central registry — ADR-070 entries merged via index.ts', () => {
+  it('every ADR-070 entry is reachable via getInvariant("ADR-070.<code>")', () => {
+    for (const entry of ADR_070_INVARIANTS) {
+      const key = `ADR-070.${entry.code}`;
+      const fromRegistry = getInvariant(key);
+      expect(fromRegistry, `Missing registry entry for ${key}`).toBeDefined();
+      expect(fromRegistry?.code).toBe(entry.code);
+    }
+  });
+
+  it('getInvariantsByAdr("ADR-070") returns every entry in declaration order', () => {
+    const adr070 = getInvariantsByAdr('ADR-070');
+    expect(adr070).toHaveLength(ADR_070_INVARIANTS.length);
+    for (let i = 0; i < ADR_070_INVARIANTS.length; i++) {
+      expect(adr070[i]?.code).toBe(ADR_070_INVARIANTS[i]?.code);
+    }
+  });
+
+  it('does not collide with ADR-073 entries under the merged key space', () => {
+    const adr070Keys = ADR_070_INVARIANTS.map((e) => `ADR-070.${e.code}`);
+    const adr073Keys = getInvariantsByAdr('ADR-073').map((e) => `ADR-073.${e.code}`);
+    const intersection = adr070Keys.filter((k) => adr073Keys.includes(k));
+    expect(intersection).toEqual([]);
+  });
+});
+
+describe('ADR-070 severity:"error" entries — runtime gate invariant', () => {
+  it('every error-tier entry has a non-null runtimeGate (R4 T10338 strict gate)', () => {
+    const errorTier: RegisteredInvariant[] = ADR_070_INVARIANTS.filter(
+      (e) => e.severity === 'error',
+    );
+    expect(errorTier.length).toBeGreaterThan(0);
+    for (const entry of errorTier) {
+      expect(
+        entry.runtimeGate,
+        `Error-tier entry ${entry.code} missing runtimeGate`,
+      ).not.toBeNull();
+      if (entry.runtimeGate !== null) {
+        expect(entry.runtimeGate.module.length).toBeGreaterThan(0);
+        expect(entry.runtimeGate.functionName.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/contracts/src/invariants/adr-070-orchestration.ts
+++ b/packages/contracts/src/invariants/adr-070-orchestration.ts
@@ -1,0 +1,317 @@
+/**
+ * ADR-070 ORC-### orchestration invariants registered against the central
+ * invariants registry (`./index.ts`).
+ *
+ * ORC codes govern the three-tier spawn topology — Orchestrator (HITL
+ * interface) → Lead (phase coordinator) → Worker (leaf task) — defined by
+ * ADR-070 and refined by ADR-083 §2 (Cleo persona + recursion bounds).
+ *
+ * Severity mapping (see `RegisteredInvariant` JSDoc for tier semantics):
+ *
+ * - **ORC-012** (thin-agent inversion-of-control) is the only ORC rule with
+ *   a hard-enforced runtime gate today (`enforceThinAgent` +
+ *   `ThinAgentViolationError`). It surfaces as
+ *   `E_THIN_AGENT_VIOLATION` (LAFS error code + exit 68). Tier: `error`.
+ * - **ORC-001..ORC-009** are the skill-injection rules shipped through
+ *   `ct-orchestrator/SKILL.md`. They constrain the Orchestrator's runtime
+ *   behaviour (no code writes, dependency-ordered spawning, 10 K context
+ *   budget, etc.) but live as prompt-time invariants rather than dispatch
+ *   guards. Tier: `warning`, `runtimeGate: null` — the gap is documented
+ *   explicitly so the R6 doctor audit (T10340) can surface it.
+ * - **ORC-010** (Lead-interposition: a Worker spawn for an Epic-child Task
+ *   requires a preceding Lead spawn) and **ORC-011** (Orchestrator-depth
+ *   ≤ 3) are filed against ADR-083 §2.4 + §6 but the dispatch-time gate
+ *   has not yet shipped (tracked T10278 + T10279). They are registered
+ *   here as `warning` with `runtimeGate: null` so the gap surfaces in the
+ *   audit pipeline.
+ * - **ORC-013** (worktree provisioning per ADR-055 / D009) IS enforced at
+ *   `createWorktree` time via `assertCanonicalWorktreeLocation` — it
+ *   carries `severity: 'error'` and a runtime gate. The companion CI gate
+ *   `lint-worktree-location.mjs` is recorded under `lintRule`.
+ * - **ORC-014** (Lead-bypass detection at session end) IS enforced by
+ *   `endSession` via `LeadBypassDetectedError`. Tier: `error`.
+ *
+ * @epic T10327 — E-INVARIANT-REGISTRY-SSOT
+ * @saga T10326 — SG-SUBSTRATE-RECONCILIATION
+ * @task T10336 — R2 (ADR-070 ORC codes)
+ * @see ADR-070-three-tier-orchestration.md
+ * @see ADR-083-section-2.4 — Cleo persona + recursion bounds
+ */
+
+import type { RegisteredInvariant } from './index.js';
+
+/**
+ * Module path that hosts the thin-agent enforcement function.
+ */
+const THIN_AGENT_MODULE = 'packages/core/src/orchestration/thin-agent.ts';
+
+/**
+ * Module path that hosts the session lifecycle entrypoint enforcing
+ * Lead-bypass detection at session end.
+ */
+const SESSIONS_MODULE = 'packages/core/src/sessions/index.ts';
+
+/**
+ * Module path that hosts the worktree creation guard (canonical XDG
+ * location enforcement per ADR-055 + Council D009).
+ */
+const WORKTREE_CREATE_MODULE = 'packages/worktree/src/worktree-create.ts';
+
+/**
+ * Canonical ct-orchestrator skill that injects ORC-001..ORC-009 into the
+ * Orchestrator's prompt at spawn time. Referenced from every prompt-time
+ * ORC entry so downstream tooling (R8 docs renderer) can chase the source.
+ */
+const CT_ORCHESTRATOR_SKILL = 'packages/skills/skills/ct-orchestrator/SKILL.md';
+
+/**
+ * Path to the spawn-prompt builder that materialises ORC-006 worker budget
+ * constraints into spawn payloads (referenced from ORC-006 below).
+ */
+const SPAWN_PROMPT_MODULE = 'packages/core/src/orchestration/spawn-prompt.ts';
+
+/**
+ * Path to the validate-spawn module that materialises ORC-006 atomic-scope
+ * checks via `V_ATOMIC_SCOPE_MISSING` / `V_ATOMIC_SCOPE_TOO_LARGE` codes.
+ */
+const VALIDATE_SPAWN_MODULE = 'packages/core/src/orchestration/validate-spawn.ts';
+
+/**
+ * Skill-validator test that exercises ORC-004 / ORC-005 manifest checks.
+ */
+const SKILL_VALIDATOR_TESTS = 'packages/core/src/skills/orchestrator/__tests__/validator.test.ts';
+
+/**
+ * ADR-070 ORC-### invariants in declaration order.
+ *
+ * The 14 entries cover:
+ *  - ORC-001..ORC-009 — ct-orchestrator skill behavioural constraints.
+ *  - ORC-010..ORC-011 — ADR-083 §2.4 recursion-bound gaps (filed,
+ *    runtime gate unimplemented — tracked T10278 / T10279).
+ *  - ORC-012 — thin-agent inversion-of-control (hard-enforced).
+ *  - ORC-013 — worktree provisioning per ADR-055 / D009 (hard-enforced).
+ *  - ORC-014 — Lead-bypass detection at session end (hard-enforced).
+ *
+ * Every `severity: 'warning'` entry with `runtimeGate: null` carries an
+ * explicit description of WHY the gate is absent, satisfying the gap-
+ * documentation invariant asserted in the unit test below.
+ */
+export const ADR_070_INVARIANTS: readonly RegisteredInvariant[] = Object.freeze([
+  {
+    adr: 'ADR-070',
+    code: 'ORC-001',
+    name: 'Orchestrator is the HITL interface',
+    description:
+      'The Orchestrator (Cleo) is the single subagent that talks to the human operator. It plans, decomposes, and delegates — it never produces line-level implementation. Source-of-truth lives in ct-orchestrator/SKILL.md row ORC-001 and is injected into the Orchestrator prompt at spawn time. UNENFORCED at the dispatch layer: this is a prompt-time invariant with no runtime guard today.',
+    severity: 'warning',
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [CT_ORCHESTRATOR_SKILL],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-002',
+    name: 'Orchestrator MUST NOT write or edit code',
+    description:
+      'Every line of code is written by a spawned subagent. The Orchestrator delegates implementation work via cleo orchestrate spawn / delegate_task. UNENFORCED at the dispatch layer: this is a prompt-time invariant — there is no runtime gate that blocks the Orchestrator from calling Edit/Write, so the contract is held by the ct-orchestrator skill text.',
+    severity: 'warning',
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [CT_ORCHESTRATOR_SKILL],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-003',
+    name: 'Orchestrator MUST NOT read full source files',
+    description:
+      'Orchestrator reads only pipeline manifests, task envelopes, and rolled-up phase summaries returned by Phase Leads. Workers read code; the Orchestrator reads summaries. UNENFORCED at the dispatch layer — held by the ct-orchestrator skill text and reinforced by ORC-005 budget pressure.',
+    severity: 'warning',
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [CT_ORCHESTRATOR_SKILL],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-004',
+    name: 'Dependency-ordered spawning',
+    description:
+      'Spawns within a wave are ordered by task.depends — a Worker MUST NOT be dispatched until its declared dependencies are status=done. Surfaced by validateSpawnReadiness via V_MISSING_DEP / V_UNMET_DEP codes; surfaced by the skill-orchestrator validator via the ORC-004_DEPENDENCY_ORDER warning emitted from packages/core/src/skills/orchestrator/validator.ts. Tier: warning because the validator surfaces ordering issues but does not throw — workers can still proceed if the operator overrides.',
+    severity: 'warning',
+    runtimeGate: {
+      module: VALIDATE_SPAWN_MODULE,
+      functionName: 'validateSpawnReadiness',
+    },
+    lintRule: null,
+    doctorAudit: null,
+    tests: [
+      'packages/core/src/orchestration/__tests__/validate-spawn.test.ts',
+      SKILL_VALIDATOR_TESTS,
+    ],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-005',
+    name: 'Orchestrator context budget ≈ 10 K tokens',
+    description:
+      'The Orchestrator MUST keep its working context under ~10 K tokens; delegate at 80 %. Surfaced by cleo orchestrate context (estimateContext) and by the skill-orchestrator validator (ORC-005_NO_MANIFEST / ORC-005_EMPTY_MANIFEST). UNENFORCED as a hard gate — the budget is advisory, surfaced to the Orchestrator as a warning so the human operator can intervene.',
+    severity: 'warning',
+    runtimeGate: {
+      module: 'packages/core/src/orchestration/context.ts',
+      functionName: 'estimateContext',
+    },
+    lintRule: null,
+    doctorAudit: null,
+    tests: ['packages/core/src/orchestration/__tests__/'],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-006',
+    name: 'Worker scope ≤ 3 files per spawn',
+    description:
+      'Cross-file reasoning quality degrades beyond ~3 files for a single Worker. Enforced at spawn-time by validateSpawnReadiness — V_ATOMIC_SCOPE_MISSING when task.files is empty, V_ATOMIC_SCOPE_TOO_LARGE when files.length > MAX_WORKER_FILES (currently 3). Spawn-prompt builder injects a Worker Budget Constraints section so the Worker sees the budget inline. Tier: error because the gate refuses to spawn an over-scoped Worker.',
+    severity: 'error',
+    runtimeGate: {
+      module: VALIDATE_SPAWN_MODULE,
+      functionName: 'validateSpawnReadiness',
+    },
+    lintRule: null,
+    doctorAudit: null,
+    tests: [
+      'packages/core/src/orchestration/__tests__/validate-spawn.test.ts',
+      'packages/core/src/orchestration/__tests__/spawn-prompt.test.ts',
+    ],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-007',
+    name: 'All work traced to an Epic',
+    description:
+      'Every Task and Subtask MUST attach to a parent Epic (directly or transitively). No orphan work — orphans are filed against the ADR-066 acceptance-criteria gate and surface via cleo find. UNENFORCED at the dispatch layer; the parent-id requirement is materialised through cleo add validation rather than a single ORC-named guard. R6 doctor audit should walk the task graph to surface orphans.',
+    severity: 'warning',
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [CT_ORCHESTRATOR_SKILL],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-008',
+    name: 'Zero architectural decisions during execution',
+    description:
+      'Architectural choices MUST be pre-decided via RCASD consensus or HITL — never inside a worker session. UNENFORCED at the dispatch layer: this is a behavioural invariant held by the ct-orchestrator skill text plus the ADR-066 acceptance criterion that every task must declare its architecture-relevant decisions before spawn.',
+    severity: 'warning',
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [CT_ORCHESTRATOR_SKILL],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-009',
+    name: 'Manifest-mediated handoffs',
+    description:
+      'Orchestrator reads only the key_findings field of pipeline_manifest rows when reconciling worker output. Subagents read the full task description and supporting files. UNENFORCED at the dispatch layer: the contract is held by the ct-orchestrator skill text and reinforced by ORC-003 + ORC-005 budget pressure.',
+    severity: 'warning',
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [CT_ORCHESTRATOR_SKILL],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-010',
+    name: 'Lead-interposition required for Epic-child Workers',
+    description:
+      'A Worker spawn against a Task whose parent is type=epic MUST be preceded by a Lead spawn for the same Task (ADR-083 §2.4 / §6). The intended runtime gate (composeSpawnPayload throwing E_LEAD_REQUIRED_FOR_EPIC_CHILD) is FILED but UNSHIPPED — tracked under T10278. Registered here as a warning + runtimeGate:null so the gap is visible in the R6 doctor audit.',
+    severity: 'warning',
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-011',
+    name: 'Orchestrator-depth cap at 3',
+    description:
+      'Recursive Orchestrator spawns (Cleo → sub-Orchestrator → sub-Orchestrator → …) MUST stop at depth 3 (ADR-083 §2.2 + §2.4). The intended runtime gate (composeSpawnPayload throwing E_ORCHESTRATOR_DEPTH_EXCEEDED) is FILED but UNSHIPPED — tracked under T10279. Registered here as a warning + runtimeGate:null so the gap is visible in the R6 doctor audit.',
+    severity: 'warning',
+    runtimeGate: null,
+    lintRule: null,
+    doctorAudit: null,
+    tests: [],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-012',
+    name: 'Thin-agent inversion-of-control',
+    description:
+      'Workers MUST NOT spawn other subagents. The spawn-capable tools (Agent / Task / TaskCreate) are stripped from the Worker tool list at .cant compile time, and any survivor at spawn time triggers ThinAgentViolationError → E_THIN_AGENT_VIOLATION (exit 68). The only ORC rule with a hard-enforced dispatch-time gate today.',
+    severity: 'error',
+    runtimeGate: {
+      module: THIN_AGENT_MODULE,
+      functionName: 'enforceThinAgent',
+    },
+    lintRule: null,
+    doctorAudit: null,
+    tests: [
+      'packages/core/src/orchestration/__tests__/thin-agent.test.ts',
+      'packages/cant/src/__tests__/hierarchy.test.ts',
+    ],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-013',
+    name: 'Worktree provisioning at canonical XDG location',
+    description:
+      'Every agent worktree MUST be created under <cleoHome>/worktrees/<projectHash>/<taskId>/ (ADR-055 + Council D009). createWorktree throws E_WT_LOCATION_FORBIDDEN before any git worktree add call when the computed path falls outside the canonical root. CI gate lint-worktree-location.mjs enforces the same invariant on every PR. The single-most-load-bearing orchestration guard after ORC-012.',
+    severity: 'error',
+    runtimeGate: {
+      module: WORKTREE_CREATE_MODULE,
+      functionName: 'assertCanonicalWorktreeLocation',
+    },
+    lintRule: {
+      lintScript: 'scripts/lint-worktree-location.mjs',
+    },
+    doctorAudit: null,
+    tests: ['packages/worktree/src/__tests__/'],
+  },
+  {
+    adr: 'ADR-070',
+    code: 'ORC-014',
+    name: 'Lead-bypass detection at session end',
+    description:
+      'A Lead session (CLEO_AGENT_ROLE=lead) that ends with tasks_completed > 0 AND delegate_task_count = 0 is rejected with LeadBypassDetectedError → E_LEAD_BYPASS_DETECTED (exit 107). Leads MUST fan out work to Workers; a Lead that did the work itself defeats the three-tier topology. Override via CLEO_OWNER_OVERRIDE=1 (audited to force-bypass.jsonl).',
+    severity: 'error',
+    runtimeGate: {
+      module: SESSIONS_MODULE,
+      functionName: 'endSession',
+    },
+    lintRule: null,
+    doctorAudit: null,
+    tests: ['packages/core/src/sessions/__tests__/'],
+  },
+]);
+
+/** Sentinel referenced by the unit test — keep in sync with array length. */
+export const ADR_070_INVARIANT_COUNT = ADR_070_INVARIANTS.length;
+
+/** Sentinel — minimum entries the central registry must merge from this file. */
+export const ADR_070_MIN_ENTRIES = 14;
+
+/**
+ * Export the prompt-only module reference so other ADR-070 ORC modules can
+ * cross-reference the canonical skill location without restating the path.
+ * @internal
+ */
+export const ADR_070_PROMPT_SOURCE = CT_ORCHESTRATOR_SKILL;
+
+/**
+ * Re-export for symmetry with the spawn-prompt builder consumers — used by
+ * the R8 docs renderer to chase the prompt-injection source for ORC-006.
+ * @internal
+ */
+export const ADR_070_SPAWN_PROMPT_MODULE = SPAWN_PROMPT_MODULE;

--- a/packages/contracts/src/invariants/index.ts
+++ b/packages/contracts/src/invariants/index.ts
@@ -11,7 +11,8 @@
  * 5. Render documentation via the downstream R8 auto-render pipeline.
  *
  * Downstream consumers:
- * - R2 (T10336): register ADR-070 ORC codes into this same registry.
+ * - R2 (T10336, SHIPPED): registers ADR-070 ORC-001..ORC-014 codes into
+ *   this same registry via `./adr-070-orchestration.ts`.
  * - R4 (T10338): CI gate validates that every `severity:'error'` entry has
  *   a non-null `runtimeGate` AND a matching error-code in `errors.ts`.
  * - R5 (T10339): refactor `packages/core/src/release/invariants/registry.ts`
@@ -27,11 +28,13 @@
  */
 
 import { ADR_056_INVARIANTS } from './adr-056-release.js';
+import { ADR_070_INVARIANTS } from './adr-070-orchestration.js';
 import { ADR_073_INVARIANTS } from './adr-073-saga.js';
 
 // Re-exported so consumers can import either the per-ADR list or the merged
 // registry from one place.
 export { ADR_056_INVARIANTS } from './adr-056-release.js';
+export { ADR_070_INVARIANTS } from './adr-070-orchestration.js';
 export { ADR_073_INVARIANTS } from './adr-073-saga.js';
 
 /**
@@ -151,7 +154,11 @@ function buildKey(invariant: RegisteredInvariant): string {
  * @internal
  */
 function buildRegistry(): Readonly<Record<string, RegisteredInvariant>> {
-  const entries: RegisteredInvariant[] = [...ADR_073_INVARIANTS, ...ADR_056_INVARIANTS];
+  const entries: RegisteredInvariant[] = [
+    ...ADR_073_INVARIANTS,
+    ...ADR_056_INVARIANTS,
+    ...ADR_070_INVARIANTS,
+  ];
   const record: Record<string, RegisteredInvariant> = {};
   for (const entry of entries) {
     const key = buildKey(entry);


### PR DESCRIPTION
## Summary

Wave 1 R2 of Saga T10326 SG-SUBSTRATE-RECONCILIATION (Epic T10327 E-INVARIANT-REGISTRY-SSOT). Enumerates the ADR-070 ORC-### orchestration invariants and registers them in the central INVARIANTS_REGISTRY introduced by T10335.

## ORC entries shipped (14)

| Code | Severity | Runtime gate | Status |
|------|----------|--------------|--------|
| ORC-001 | warning | none | prompt-only (ct-orchestrator/SKILL.md) |
| ORC-002 | warning | none | prompt-only |
| ORC-003 | warning | none | prompt-only |
| ORC-004 | warning | `validateSpawnReadiness` | advisory (V_MISSING_DEP / V_UNMET_DEP) |
| ORC-005 | warning | `estimateContext` | advisory (budget ~10 K tokens) |
| ORC-006 | error | `validateSpawnReadiness` | hard gate (V_ATOMIC_SCOPE_*) |
| ORC-007 | warning | none | ADR-066 acceptance gate |
| ORC-008 | warning | none | prompt-only |
| ORC-009 | warning | none | prompt-only |
| ORC-010 | warning | none | FILED unshipped (T10278) |
| ORC-011 | warning | none | FILED unshipped (T10279) |
| ORC-012 | error | `enforceThinAgent` | hard gate (`E_THIN_AGENT_VIOLATION`, exit 68) |
| ORC-013 | error | `assertCanonicalWorktreeLocation` | hard gate (`E_WT_LOCATION_FORBIDDEN`) |
| ORC-014 | error | `endSession` | hard gate (`E_LEAD_BYPASS_DETECTED`, exit 107) |

**Gap count:** 9 warning-severity entries with `runtimeGate: null` — each carries explanatory text so the R6 doctor audit (T10340) can surface unenforced contracts alongside enforced ones.

## Files touched

- `packages/contracts/src/invariants/adr-070-orchestration.ts` (NEW — 14 entries)
- `packages/contracts/src/invariants/index.ts` (merge ADR-070 into registry)
- `packages/contracts/src/invariants/__tests__/adr-070-orchestration.test.ts` (NEW — 14 assertions across 5 suites)
- `packages/contracts/src/errors.ts` (JSDoc `@see` cross-refs on `ThinAgentViolationError` + `LeadBypassDetectedError`)
- `.cleo/adrs/ADR-070-three-tier-orchestration.md` (new enumeration table + references section update)
- `.changeset/T10336.md`

## Test plan

- [x] `pnpm --filter @cleocode/contracts run build` — green
- [x] `pnpm --filter @cleocode/core run build` — green
- [x] `pnpm --filter @cleocode/cleo run build` — green
- [x] `pnpm --filter @cleocode/contracts run test` — 455/455 green (24 new ADR-070 + existing 16 ADR-073 registry + 415 other)
- [x] `git diff --stat pnpm-lock.yaml` — empty
- [x] No `any` / `as unknown as`
- [x] Worktree at canonical XDG path

Closes T10336
Saga: T10326
Refs: ADR-070, ADR-083 §2.4