### PR TITLE
feat(contracts): TemplateManifest (T9875 / Saga T9855)

### DIFF
--- a/.changeset/t9875-template-manifest.md
+++ b/.changeset/t9875-template-manifest.md
@@ -1,0 +1,6 @@
+---
+id: t9875-template-manifest
+tasks: [T9875]
+kind: feat
+summary: TemplateManifest contract types + Zod schemas (Saga T9855 / ADR-076)
+---

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1845,6 +1845,25 @@ export type {
   TaskViewNextAction,
   TaskViewPipelineStage,
 } from './tasks.js';
+// === Template Manifest (T9875 / Saga T9855) ===
+export type {
+  PlaceholderSource,
+  PlaceholderSpec,
+  PlaceholderSpecInput,
+  TemplateKind,
+  TemplateManifestEntry,
+  TemplateManifestEntryInput,
+  TemplateSubstitution,
+  UpdateStrategy,
+} from './templates/manifest.js';
+export {
+  PLACEHOLDER_SOURCES,
+  PlaceholderSpecSchema,
+  TEMPLATE_KINDS,
+  TEMPLATE_SUBSTITUTIONS,
+  TEMPLATE_UPDATE_STRATEGIES,
+  TemplateManifestEntrySchema,
+} from './templates/manifest.js';
 // === Tessera Types ===
 export type {
   TesseraInstantiationInput,

--- a/packages/contracts/src/templates/__tests__/manifest.test.ts
+++ b/packages/contracts/src/templates/__tests__/manifest.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Contract tests for the TemplateManifest schema.
+ *
+ * Asserts:
+ *
+ * 1. A valid entry for every {@link TemplateKind} parses successfully.
+ * 2. An entry with an unknown `kind` is rejected.
+ * 3. An entry missing `installPath` is rejected.
+ * 4. The {@link PlaceholderSpec} `source` field is exhaustively typed —
+ *    every member of {@link PLACEHOLDER_SOURCES} parses, and a bogus
+ *    source value is rejected.
+ *
+ * @task T9875
+ * @epic T9874
+ * @saga T9855
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  PLACEHOLDER_SOURCES,
+  PlaceholderSpecSchema,
+  TEMPLATE_KINDS,
+  type TemplateKind,
+  type TemplateManifestEntry,
+  TemplateManifestEntrySchema,
+} from '../manifest.js';
+
+/**
+ * Build a valid baseline entry parameterized by `kind` so each
+ * assertion below stays minimal.
+ */
+function baseEntry(kind: TemplateKind): TemplateManifestEntry {
+  return {
+    id: `sample-${kind}`,
+    kind,
+    sourcePath: `packages/core/templates/${kind}s/sample.tmpl`,
+    installPath: `.cleo/${kind}s/sample`,
+    substitution: 'regex-tmpl',
+    placeholders: [
+      {
+        name: 'NODE_VERSION',
+        source: 'project-context',
+        sourcePath: 'engines.node',
+        defaultValue: 24,
+      },
+    ],
+    updateStrategy: 'overwrite-on-bump',
+  };
+}
+
+describe('TemplateManifestEntrySchema (T9875)', () => {
+  it('accepts a valid entry for every TemplateKind', () => {
+    for (const kind of TEMPLATE_KINDS) {
+      const entry = baseEntry(kind);
+      const parsed = TemplateManifestEntrySchema.parse(entry);
+      expect(parsed.kind, `kind '${kind}' must round-trip`).toBe(kind);
+      expect(parsed.installPath).toBe(entry.installPath);
+    }
+  });
+
+  it('rejects an entry with an unknown kind', () => {
+    const bogus = {
+      ...baseEntry('workflow'),
+      kind: 'not-a-real-kind',
+    };
+    const result = TemplateManifestEntrySchema.safeParse(bogus);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an entry missing installPath', () => {
+    const { installPath: _drop, ...rest } = baseEntry('config');
+    const result = TemplateManifestEntrySchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an entry whose placeholders array is empty', () => {
+    const entry = { ...baseEntry('doc'), placeholders: [] };
+    const result = TemplateManifestEntrySchema.safeParse(entry);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a defaultValue of every supported literal type and null', () => {
+    const types = [
+      { defaultValue: 'string-default' },
+      { defaultValue: 42 },
+      { defaultValue: true },
+      { defaultValue: null },
+      {},
+    ] as const;
+    for (const extra of types) {
+      const result = PlaceholderSpecSchema.safeParse({
+        name: 'X',
+        source: 'literal',
+        sourcePath: 'X',
+        ...extra,
+      });
+      expect(result.success, `defaultValue case ${JSON.stringify(extra)} must parse`).toBe(true);
+    }
+  });
+});
+
+describe('PlaceholderSpecSchema source enum (T9875)', () => {
+  it('exhaustively accepts every member of PLACEHOLDER_SOURCES', () => {
+    for (const source of PLACEHOLDER_SOURCES) {
+      const result = PlaceholderSpecSchema.safeParse({
+        name: 'PLACEHOLDER',
+        source,
+        sourcePath: 'some.path',
+      });
+      expect(result.success, `source '${source}' must parse`).toBe(true);
+    }
+  });
+
+  it('rejects an unknown source value', () => {
+    const result = PlaceholderSpecSchema.safeParse({
+      name: 'PLACEHOLDER',
+      source: 'not-a-source',
+      sourcePath: 'some.path',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty name', () => {
+    const result = PlaceholderSpecSchema.safeParse({
+      name: '',
+      source: 'project-context',
+      sourcePath: 'some.path',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty sourcePath', () => {
+    const result = PlaceholderSpecSchema.safeParse({
+      name: 'X',
+      source: 'project-context',
+      sourcePath: '',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/templates/manifest.ts
+++ b/packages/contracts/src/templates/manifest.ts
@@ -1,0 +1,208 @@
+/**
+ * TemplateManifest contract — SSoT for every template CLEO ships, installs,
+ * or rewrites during `cleo init` / `cleo upgrade` / `cleo scaffold-*`.
+ *
+ * A {@link TemplateManifestEntry} declares one template file: where its
+ * source lives in the monorepo, where it installs into a consumer project,
+ * how its placeholders are substituted, which placeholders it accepts, and
+ * how it MUST be reconciled when the shipped version moves ahead of the
+ * deployed copy.
+ *
+ * This contract is the leaf type. The CORE-side template registry
+ * (T9877) consumes it; the CLI verbs (`cleo init --workflows`,
+ * `cleo upgrade`, the scaffold sweeper) read the manifest at runtime to
+ * decide what to write, what to skip, and what to diff-prompt the user on.
+ *
+ * @example minimal workflow template entry
+ * ```ts
+ * import { TemplateManifestEntrySchema, type TemplateManifestEntry } from '@cleocode/contracts';
+ *
+ * const entry: TemplateManifestEntry = TemplateManifestEntrySchema.parse({
+ *   id: 'ci.yml',
+ *   kind: 'workflow',
+ *   sourcePath: 'packages/core/templates/workflows/ci.yml.tmpl',
+ *   installPath: '.github/workflows/ci.yml',
+ *   substitution: 'regex-tmpl',
+ *   placeholders: [
+ *     {
+ *       name: 'NODE_VERSION',
+ *       source: 'project-context',
+ *       sourcePath: 'engines.node',
+ *       defaultValue: 24,
+ *     },
+ *   ],
+ *   updateStrategy: 'overwrite-on-bump',
+ * });
+ * ```
+ *
+ * @task T9875
+ * @epic T9874
+ * @saga T9855
+ * @see ADR-076 (canonical doc routing — same boundary discipline applies here)
+ */
+
+import { z } from 'zod';
+
+// ─── TemplateKind ─────────────────────────────────────────────────────────────
+
+/**
+ * Allowed categories of template the manifest can describe.
+ *
+ * - `workflow`  — GitHub Actions / CI workflow files.
+ * - `config`    — Configuration files (e.g. `.editorconfig`, `tsconfig.json`).
+ * - `agent`     — Agent definition files shipped to `.claude/agents/` etc.
+ * - `skill`     — Skill markdown shipped to `.claude/skills/` etc.
+ * - `provider`  — Provider-specific bootstrap files (Anthropic, OpenAI, …).
+ * - `doc`       — Documentation scaffolds (e.g. README.md, AGENTS.md).
+ */
+export const TEMPLATE_KINDS = ['workflow', 'config', 'agent', 'skill', 'provider', 'doc'] as const;
+
+/** Discriminator for the category of file a template represents. */
+export type TemplateKind = (typeof TEMPLATE_KINDS)[number];
+
+// ─── TemplateSubstitution ─────────────────────────────────────────────────────
+
+/**
+ * Allowed substitution strategies a template can request.
+ *
+ * - `regex-tmpl` — `{{KEY}}` placeholder substitution via regex.
+ * - `static`     — No substitution; the file is copied byte-for-byte.
+ * - `json-merge` — The template is parsed as JSON and merged into any
+ *                  existing JSON file at `installPath`; placeholders inside
+ *                  string values still go through `regex-tmpl`.
+ */
+export const TEMPLATE_SUBSTITUTIONS = ['regex-tmpl', 'static', 'json-merge'] as const;
+
+/** Strategy the installer uses to materialize a template's `sourcePath`. */
+export type TemplateSubstitution = (typeof TEMPLATE_SUBSTITUTIONS)[number];
+
+// ─── UpdateStrategy ───────────────────────────────────────────────────────────
+
+/**
+ * How an installed template is reconciled with the shipped copy on
+ * `cleo upgrade` / `cleo init --force`.
+ *
+ * - `overwrite-on-bump` — Always overwrite when the manifest version is
+ *                        newer than the deployed copy.
+ * - `diff-prompt`       — Show a diff and ask the user before overwriting.
+ * - `immutable`         — Never overwrite once installed.
+ * - `manifest-merge`    — Apply structural merge (e.g. JSON deep-merge,
+ *                        respecting existing user keys).
+ */
+export const TEMPLATE_UPDATE_STRATEGIES = [
+  'overwrite-on-bump',
+  'diff-prompt',
+  'immutable',
+  'manifest-merge',
+] as const;
+
+/** Reconciliation policy for an installed template on upgrade. */
+export type UpdateStrategy = (typeof TEMPLATE_UPDATE_STRATEGIES)[number];
+
+// ─── PlaceholderSpec ──────────────────────────────────────────────────────────
+
+/**
+ * Allowed resolver sources a {@link PlaceholderSpec} can reference.
+ *
+ * - `project-context` — `.cleo/project-context.json` (detected ecosystem hints).
+ * - `project-info`    — `.cleo/project-info.json` (per-project metadata).
+ * - `.cleo/config`    — Per-project config (`<projectRoot>/.cleo/config.json`).
+ * - `~/.cleo/config`  — User-global config (`$XDG_CONFIG_HOME/cleo/config.json`).
+ * - `tool-resolver`   — Resolved via the per-language tool resolver
+ *                       (e.g. `pnpm` vs `npm` chosen by `primaryType`).
+ * - `literal`         — Hard-coded value baked into the manifest entry.
+ */
+export const PLACEHOLDER_SOURCES = [
+  'project-context',
+  'project-info',
+  '.cleo/config',
+  '~/.cleo/config',
+  'tool-resolver',
+  'literal',
+] as const;
+
+/** Resolver source enum for {@link PlaceholderSpec.source}. */
+export type PlaceholderSource = (typeof PLACEHOLDER_SOURCES)[number];
+
+/**
+ * Zod schema for a single placeholder declaration on a template entry.
+ *
+ * Each placeholder is resolved at install time by reading `sourcePath` from
+ * the named `source`. If resolution returns `undefined`, the installer
+ * falls back to `defaultValue`; if neither yields a value, installation
+ * fails with `E_PLACEHOLDER_UNRESOLVED`.
+ */
+export const PlaceholderSpecSchema = z.object({
+  /**
+   * Placeholder identifier as it appears in the template body
+   * (e.g. `NODE_VERSION` matches `{{NODE_VERSION}}`).
+   */
+  name: z.string().min(1, 'placeholder name must be non-empty'),
+  /** Resolver source the installer consults for this placeholder. */
+  source: z.enum(PLACEHOLDER_SOURCES),
+  /**
+   * Path expression evaluated against `source` (e.g. `engines.node` against
+   * `project-context`, `defaults.branchModel` against `.cleo/config`).
+   * For `literal` source, this MAY be the literal value's identifier.
+   */
+  sourcePath: z.string().min(1, 'placeholder sourcePath must be non-empty'),
+  /**
+   * Fallback value used when `source[sourcePath]` resolves to `undefined`.
+   * `null` is permitted to explicitly mark "no default — failure required".
+   */
+  defaultValue: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+});
+
+/**
+ * Zod-inferred input shape for a placeholder declaration.
+ *
+ * Identical to {@link PlaceholderSpec} — there are no schema transforms.
+ */
+export type PlaceholderSpecInput = z.infer<typeof PlaceholderSpecSchema>;
+
+/** Declared placeholder on a {@link TemplateManifestEntry}. */
+export type PlaceholderSpec = PlaceholderSpecInput;
+
+// ─── TemplateManifestEntry ────────────────────────────────────────────────────
+
+/**
+ * Zod schema for a single template manifest entry.
+ *
+ * Validates the full descriptor a template registry consumer needs to
+ * install a template file:
+ *
+ * - `id`             — Stable identifier (kebab-case, matches install basename
+ *                      or a domain-unique slug).
+ * - `kind`           — One of {@link TEMPLATE_KINDS}.
+ * - `sourcePath`     — Repo-relative path of the template source.
+ * - `installPath`    — Project-relative path where the rendered file lands.
+ * - `substitution`   — One of {@link TEMPLATE_SUBSTITUTIONS}.
+ * - `placeholders`   — Declared placeholders the installer must resolve.
+ * - `updateStrategy` — Reconciliation policy on upgrade.
+ */
+export const TemplateManifestEntrySchema = z.object({
+  /** Stable identifier for this template entry. */
+  id: z.string().min(1, 'id must be non-empty'),
+  /** Category of file this template represents. */
+  kind: z.enum(TEMPLATE_KINDS),
+  /** Repo-relative path of the template source file. */
+  sourcePath: z.string().min(1, 'sourcePath must be non-empty'),
+  /** Project-relative path where the rendered template installs. */
+  installPath: z.string().min(1, 'installPath must be non-empty'),
+  /** Substitution strategy the installer applies to `sourcePath`. */
+  substitution: z.enum(TEMPLATE_SUBSTITUTIONS),
+  /** Declared placeholders this template requires. May be empty. */
+  placeholders: z.array(PlaceholderSpecSchema),
+  /** Reconciliation policy on upgrade. */
+  updateStrategy: z.enum(TEMPLATE_UPDATE_STRATEGIES),
+});
+
+/**
+ * Zod-inferred input shape for a template manifest entry.
+ *
+ * Identical to {@link TemplateManifestEntry} — there are no schema transforms.
+ */
+export type TemplateManifestEntryInput = z.infer<typeof TemplateManifestEntrySchema>;
+
+/** Public type for a fully-validated template manifest entry. */
+export type TemplateManifestEntry = TemplateManifestEntryInput;


### PR DESCRIPTION
## Summary
- Adds `packages/contracts/src/templates/manifest.ts` with TemplateKind/Substitution/UpdateStrategy/PlaceholderSpec/TemplateManifestEntry types + Zod schemas.
- Foundation for T9877 (CORE registry) and the full Saga T9855 template+config SSoT.
- Per ADR-076 boundary: contracts live in `packages/contracts/`.

## Test plan
- [x] `pnpm biome check`
- [x] `pnpm -F @cleocode/contracts run build`
- [x] `pnpm exec vitest run packages/contracts/src/templates/`

Closes T9875
Saga: T9855
ADR: 076