### PR TITLE
feat(contracts): ConfigManifest (T9876 / Saga T9855)

### DIFF
--- a/.changeset/t9876-config-manifest.md
+++ b/.changeset/t9876-config-manifest.md
@@ -1,0 +1,6 @@
+---
+id: t9876-config-manifest
+tasks: [T9876]
+kind: feat
+summary: ConfigManifest types + 4 built-in entries with merge precedence (Saga T9855 / ADR-076)
+---

--- a/packages/contracts/src/config/__tests__/manifest.test.ts
+++ b/packages/contracts/src/config/__tests__/manifest.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the ConfigManifest contract (T9876 / Saga T9855 / ADR-076).
+ *
+ * Covers:
+ * - Schema round-trip for each of the 4 built-in entries.
+ * - Merge-precedence invariant (project > global > defaults).
+ * - Metadata-scope isolation (NOT in the merge chain).
+ * - {@link DriftDetection} exhaustiveness via a `never` fallback switch.
+ *
+ * @task T9876
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  CLEO_CONFIG_MANIFEST,
+  CONFIG_MANIFEST_ENTRIES,
+  type ConfigManifestEntry,
+  type ConfigScope,
+  configManifestEntrySchema,
+  type DriftDetection,
+  GLOBAL_CLEO_CONFIG_MANIFEST,
+  PROJECT_CONTEXT_MANIFEST,
+  PROJECT_INFO_MANIFEST,
+} from '../manifest.js';
+
+describe('ConfigManifest built-in entries', () => {
+  const builtins: ReadonlyArray<readonly [string, ConfigManifestEntry]> = [
+    ['PROJECT_INFO_MANIFEST', PROJECT_INFO_MANIFEST],
+    ['PROJECT_CONTEXT_MANIFEST', PROJECT_CONTEXT_MANIFEST],
+    ['CLEO_CONFIG_MANIFEST', CLEO_CONFIG_MANIFEST],
+    ['GLOBAL_CLEO_CONFIG_MANIFEST', GLOBAL_CLEO_CONFIG_MANIFEST],
+  ];
+
+  for (const [name, entry] of builtins) {
+    it(`${name} validates against configManifestEntrySchema`, () => {
+      const parsed = configManifestEntrySchema.parse(entry);
+      expect(parsed.id).toBe(entry.id);
+      expect(parsed.scope).toBe(entry.scope);
+      expect(parsed.path).toBe(entry.path);
+      expect(parsed.mergePrecedence).toBe(entry.mergePrecedence);
+      expect(parsed.driftDetection).toBe(entry.driftDetection);
+    });
+  }
+
+  it('CONFIG_MANIFEST_ENTRIES contains all 4 built-in entries', () => {
+    const ids = CONFIG_MANIFEST_ENTRIES.map((e) => e.id).sort();
+    expect(ids).toEqual([
+      'cleo-config-global',
+      'cleo-config-project',
+      'project-context',
+      'project-info',
+    ]);
+  });
+
+  it('CONFIG_MANIFEST_ENTRIES is frozen', () => {
+    expect(Object.isFrozen(CONFIG_MANIFEST_ENTRIES)).toBe(true);
+  });
+});
+
+describe('Merge-precedence invariant (project > global > defaults)', () => {
+  it('project precedence > global precedence (higher wins)', () => {
+    expect(CLEO_CONFIG_MANIFEST.mergePrecedence).toBeGreaterThan(
+      GLOBAL_CLEO_CONFIG_MANIFEST.mergePrecedence,
+    );
+  });
+
+  it('canonical precedence values: project=20, global=10, metadata=0', () => {
+    expect(CLEO_CONFIG_MANIFEST.mergePrecedence).toBe(20);
+    expect(GLOBAL_CLEO_CONFIG_MANIFEST.mergePrecedence).toBe(10);
+    expect(PROJECT_INFO_MANIFEST.mergePrecedence).toBe(0);
+    expect(PROJECT_CONTEXT_MANIFEST.mergePrecedence).toBe(0);
+  });
+
+  it('cascade-resolver sort order yields global then project (project wins)', () => {
+    const cascadeEntries = CONFIG_MANIFEST_ENTRIES.filter(
+      (e): e is ConfigManifestEntry & { scope: ConfigScope } =>
+        e.scope === 'global' || e.scope === 'project',
+    )
+      .slice() // copy before sort — array is frozen
+      .sort((a, b) => a.mergePrecedence - b.mergePrecedence);
+
+    expect(cascadeEntries.map((e) => e.scope)).toEqual(['global', 'project']);
+  });
+});
+
+describe('Metadata-scope isolation', () => {
+  it('metadata entries are NOT in the cascade merge chain', () => {
+    const cascadeScopes = CONFIG_MANIFEST_ENTRIES.filter((e) => e.scope !== 'metadata').map(
+      (e) => e.scope,
+    );
+    expect(cascadeScopes).toEqual(expect.arrayContaining(['global', 'project']));
+    expect(cascadeScopes).not.toContain('metadata');
+  });
+
+  it('all metadata entries have mergePrecedence 0 (separate channel)', () => {
+    const metadataEntries = CONFIG_MANIFEST_ENTRIES.filter((e) => e.scope === 'metadata');
+    expect(metadataEntries.length).toBeGreaterThan(0);
+    for (const e of metadataEntries) {
+      expect(e.mergePrecedence).toBe(0);
+    }
+  });
+});
+
+describe('DriftDetection exhaustiveness (type-level)', () => {
+  it('switch over DriftDetection covers all variants with never fallback', () => {
+    const describe_ = (d: DriftDetection): string => {
+      switch (d) {
+        case 'schema-validate':
+          return 'schema-validate';
+        case 'staleness-gate':
+          return 'staleness-gate';
+        case 'value-diff':
+          return 'value-diff';
+        case 'none':
+          return 'none';
+        default: {
+          // If a new variant is added without updating this switch, TS will
+          // refuse to assign it to `never` at compile time.
+          const _exhaustive: never = d;
+          return _exhaustive;
+        }
+      }
+    };
+
+    expect(describe_('schema-validate')).toBe('schema-validate');
+    expect(describe_('staleness-gate')).toBe('staleness-gate');
+    expect(describe_('value-diff')).toBe('value-diff');
+    expect(describe_('none')).toBe('none');
+  });
+});
+
+describe('configManifestEntrySchema rejects invalid input', () => {
+  it('rejects empty id', () => {
+    const result = configManifestEntrySchema.safeParse({
+      id: '',
+      scope: 'project',
+      path: '.cleo/config.json',
+      mergePrecedence: 20,
+      driftDetection: 'schema-validate',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown scope', () => {
+    const result = configManifestEntrySchema.safeParse({
+      id: 'x',
+      scope: 'workspace',
+      path: '.cleo/x.json',
+      mergePrecedence: 0,
+      driftDetection: 'none',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative mergePrecedence', () => {
+    const result = configManifestEntrySchema.safeParse({
+      id: 'x',
+      scope: 'project',
+      path: '.cleo/x.json',
+      mergePrecedence: -1,
+      driftDetection: 'none',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown driftDetection variant', () => {
+    const result = configManifestEntrySchema.safeParse({
+      id: 'x',
+      scope: 'project',
+      path: '.cleo/x.json',
+      mergePrecedence: 0,
+      driftDetection: 'sha-compare',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/config/manifest.ts
+++ b/packages/contracts/src/config/manifest.ts
@@ -1,0 +1,218 @@
+/**
+ * ConfigManifest contract — declarative registry of every config-like file CLEO
+ * reads, writes, or merges, with its scope, schema, merge precedence, and the
+ * drift-detection strategy applied to it.
+ *
+ * Foundation for the CORE SSoT config registry (T9878) and the `resolveCleoConfig`
+ * cascade resolver. Built-in entries cover the four canonical CLEO files:
+ *
+ * - `~/.cleo/config.json`          (`global`,   precedence 10)
+ * - `<project>/.cleo/config.json`  (`project`,  precedence 20)
+ * - `<project>/.cleo/project-info.json`    (`metadata`, separate channel)
+ * - `<project>/.cleo/project-context.json` (`metadata`, separate channel)
+ *
+ * Merge semantics: higher `mergePrecedence` wins. The `metadata` scope is
+ * intentionally OUTSIDE the project ↔ global merge chain — those files are
+ * read-only consumer state and must NEVER be merged into resolved CleoConfig.
+ *
+ * @task T9876
+ * @saga T9855
+ * @adr 076
+ */
+
+import { type ZodTypeAny, z } from 'zod';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scope + drift unions
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Cascade-participating scopes for the project ↔ global merge chain.
+ *
+ * - `'global'`  — `~/.cleo/config.json`        (precedence 10)
+ * - `'project'` — `<project>/.cleo/config.json` (precedence 20, higher wins)
+ *
+ * Note: `'metadata'` is NOT part of this union — metadata-scoped files are
+ * read-only consumer state and live on a separate channel. See
+ * {@link ConfigManifestScope} for the full union including metadata.
+ *
+ * @task T9876
+ */
+export type ConfigScope = 'global' | 'project';
+
+/**
+ * Full scope union covering cascade scopes AND the read-only `metadata`
+ * channel used by `project-info.json` and `project-context.json`.
+ *
+ * Metadata-scoped entries are NEVER merged into the resolved CleoConfig —
+ * they are surfaced separately as consumer state and validated only for
+ * schema conformance / staleness.
+ *
+ * @task T9876
+ */
+export type ConfigManifestScope = ConfigScope | 'metadata';
+
+/**
+ * Drift-detection strategy applied to a manifest entry.
+ *
+ * - `'schema-validate'` — Re-parse the file's contents against {@link ConfigManifestEntry.schema}
+ *   on read. Any parse error is reported as drift.
+ * - `'staleness-gate'`  — Compare the file's `detectedAt` (or equivalent freshness key)
+ *   against a freshness threshold. Stale files are flagged but not rejected.
+ * - `'value-diff'`      — Diff the file's resolved values against the manifest's
+ *   `defaults` baseline and report changed keys. Useful for invariant tracking.
+ * - `'none'`            — No drift detection. Entry is informational-only.
+ *
+ * @task T9876
+ */
+export type DriftDetection = 'schema-validate' | 'staleness-gate' | 'value-diff' | 'none';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Manifest entry shape
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * A single registry entry describing one config-like file CLEO is aware of.
+ *
+ * `mergePrecedence` orders entries within the SAME scope channel. Across
+ * channels, the cascade-resolver consumes entries with `scope` in
+ * {@link ConfigScope} (global/project) and merges by ascending precedence
+ * (higher wins). Metadata entries are surfaced separately.
+ *
+ * @task T9876
+ */
+export interface ConfigManifestEntry {
+  /** Stable identifier for the entry (e.g. `'cleo-config-project'`). */
+  id: string;
+  /** Where the file lives in the precedence hierarchy. */
+  scope: ConfigManifestScope;
+  /** Absolute or `~`-rooted path to the file on disk. */
+  path: string;
+  /**
+   * Optional Zod schema used by the `'schema-validate'` drift detector to
+   * re-parse the file's contents. `null` disables schema validation even when
+   * `driftDetection === 'schema-validate'` (advisory-only mode).
+   */
+  schema?: ZodTypeAny | null;
+  /**
+   * Numeric merge precedence within the cascade. Higher wins.
+   *
+   * Canonical values:
+   * - `0`  — defaults / metadata (NOT part of the merge chain)
+   * - `10` — global
+   * - `20` — project
+   */
+  mergePrecedence: number;
+  /** Drift-detection strategy to apply to this entry. */
+  driftDetection: DriftDetection;
+  /** Optional default values used as the baseline for `'value-diff'` drift detection. */
+  defaults?: Record<string, unknown>;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Built-in manifest entries (4 canonical CLEO files)
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Manifest entry for `<project>/.cleo/project-info.json`.
+ *
+ * Metadata channel (NOT part of the merge cascade). Schema-validated on
+ * read because the file is consumer state with a stable shape.
+ *
+ * @task T9876
+ */
+export const PROJECT_INFO_MANIFEST: ConfigManifestEntry = {
+  id: 'project-info',
+  scope: 'metadata',
+  path: '.cleo/project-info.json',
+  mergePrecedence: 0,
+  driftDetection: 'schema-validate',
+};
+
+/**
+ * Manifest entry for `<project>/.cleo/project-context.json`.
+ *
+ * Metadata channel. Staleness-gated because the file is regenerated by
+ * project-detection scans and consumers care about freshness, not exact shape.
+ *
+ * @task T9876
+ */
+export const PROJECT_CONTEXT_MANIFEST: ConfigManifestEntry = {
+  id: 'project-context',
+  scope: 'metadata',
+  path: '.cleo/project-context.json',
+  mergePrecedence: 0,
+  driftDetection: 'staleness-gate',
+};
+
+/**
+ * Manifest entry for `<project>/.cleo/config.json` (project-scoped CleoConfig).
+ *
+ * Project scope; precedence 20 — wins over global. Schema-validated.
+ *
+ * @task T9876
+ */
+export const CLEO_CONFIG_MANIFEST: ConfigManifestEntry = {
+  id: 'cleo-config-project',
+  scope: 'project',
+  path: '.cleo/config.json',
+  mergePrecedence: 20,
+  driftDetection: 'schema-validate',
+};
+
+/**
+ * Manifest entry for `~/.cleo/config.json` (global CleoConfig).
+ *
+ * Global scope; precedence 10 — loses to project. Schema-validated.
+ *
+ * @task T9876
+ */
+export const GLOBAL_CLEO_CONFIG_MANIFEST: ConfigManifestEntry = {
+  id: 'cleo-config-global',
+  scope: 'global',
+  path: '~/.cleo/config.json',
+  mergePrecedence: 10,
+  driftDetection: 'schema-validate',
+};
+
+/**
+ * Frozen registry of all built-in manifest entries shipped with the contracts
+ * package. Order is informational only — consumers MUST sort by
+ * `mergePrecedence` when applying the cascade.
+ *
+ * @task T9876
+ */
+export const CONFIG_MANIFEST_ENTRIES: readonly ConfigManifestEntry[] = Object.freeze([
+  PROJECT_INFO_MANIFEST,
+  PROJECT_CONTEXT_MANIFEST,
+  GLOBAL_CLEO_CONFIG_MANIFEST,
+  CLEO_CONFIG_MANIFEST,
+]);
+
+// ───────────────────────────────────────────────────────────────────────────
+// Runtime validation schema
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Zod schema for {@link ConfigManifestEntry}.
+ *
+ * Treats `schema` as `unknown` because `ZodTypeAny` instances cannot be
+ * validated through Zod itself without infinite recursion — schema-shape
+ * checking is the responsibility of the consumer that constructs the entry.
+ *
+ * @task T9876
+ */
+export const configManifestEntrySchema = z.object({
+  id: z.string().min(1),
+  scope: z.union([z.literal('global'), z.literal('project'), z.literal('metadata')]),
+  path: z.string().min(1),
+  schema: z.unknown().optional(),
+  mergePrecedence: z.number().int().nonnegative(),
+  driftDetection: z.union([
+    z.literal('schema-validate'),
+    z.literal('staleness-gate'),
+    z.literal('value-diff'),
+    z.literal('none'),
+  ]),
+  defaults: z.record(z.string(), z.unknown()).optional(),
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -224,6 +224,21 @@ export type {
   ConduitTopicSubscribeOptions,
   ConduitUnsubscribe,
 } from './conduit.js';
+// === Config Manifest (T9876 / Saga T9855) ===
+export type {
+  ConfigManifestEntry,
+  ConfigManifestScope,
+  ConfigScope,
+  DriftDetection,
+} from './config/manifest.js';
+export {
+  CLEO_CONFIG_MANIFEST,
+  CONFIG_MANIFEST_ENTRIES,
+  configManifestEntrySchema,
+  GLOBAL_CLEO_CONFIG_MANIFEST,
+  PROJECT_CONTEXT_MANIFEST,
+  PROJECT_INFO_MANIFEST,
+} from './config/manifest.js';
 // === Configuration Types ===
 export type {
   BackupConfig,


### PR DESCRIPTION
## Summary
- Adds `packages/contracts/src/config/manifest.ts` with `ConfigScope`/`ConfigManifestScope`/`DriftDetection`/`ConfigManifestEntry` + 4 built-in entries (`PROJECT_INFO_MANIFEST`, `PROJECT_CONTEXT_MANIFEST`, `CLEO_CONFIG_MANIFEST`, `GLOBAL_CLEO_CONFIG_MANIFEST`).
- Precedence: defaults=0, global=10, project=20 (higher wins); metadata channel separate.
- `configManifestEntrySchema` Zod runtime validator + `CONFIG_MANIFEST_ENTRIES` frozen registry.
- Foundation for T9878 (CORE registry / `resolveCleoConfig`).

## Test plan
- [x] `pnpm biome check --write packages/contracts/src/config/` (auto-fixed import order)
- [x] `pnpm -F @cleocode/contracts run build` (tsc green, asset+schema emit OK)
- [x] `pnpm exec vitest run packages/contracts/src/config/` — 16/16 tests pass

Closes T9876
Saga: T9855
ADR: 076