### PR TITLE
chore(T10373): remediate 5 sweep orphans (E5.3)

### DIFF
--- a/.changeset/t10373-e5-remediate-sweep-orphans.md
+++ b/.changeset/t10373-e5-remediate-sweep-orphans.md
@@ -1,0 +1,6 @@
+---
+id: t10373-e5-remediate-sweep-orphans
+tasks: [T10373]
+kind: chore
+summary: T10373 E5.3: remediate sweep-identified orphan manual writes (5 files migrated into SSoT via cleo docs add with preserved slugs; round-trip parity tests added; ct-documentor SKILL.md updated)
+---

--- a/audit/manual-write-sweep-2026-05-24.json
+++ b/audit/manual-write-sweep-2026-05-24.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-24T06:25:40.955Z",
+  "generatedAt": "2026-05-24T07:16:18.716Z",
   "rawMdPaths": [
     ".cleo/adrs/",
     ".cleo/research/",
@@ -9,60 +9,14 @@
   "summary": {
     "cutoff": "251814e86",
     "totalFiles": 16,
-    "orphan": 5,
+    "orphan": 0,
     "drift": 0,
-    "inSync": 11,
+    "inSync": 16,
     "deleted": 0,
-    "unresolved": 5
+    "unresolved": 0
   },
   "grouped": {
-    "orphan": [
-      {
-        "file": ".cleo/adrs/ADR-083-cleo-persona-and-hierarchy-reconciliation.md",
-        "fileSha": "bd8c14ab55430125c0909e0b42d9f0f1e453c1116e1e25f821c6b34ece6c4c2f",
-        "remediation": "orphan",
-        "ssotSlug": null,
-        "ssotType": null,
-        "ssotAttachmentId": null,
-        "ssotSha": null
-      },
-      {
-        "file": ".cleo/adrs/ADR-085-cross-db-invariants.md",
-        "fileSha": "677ad407b1751d889cded48aa7de9cc26274e852cc41ee9c37f8bbedd4625a13",
-        "remediation": "orphan",
-        "ssotSlug": null,
-        "ssotType": null,
-        "ssotAttachmentId": null,
-        "ssotSha": null
-      },
-      {
-        "file": ".cleo/agent-outputs/T10268-saga-closeout.md",
-        "fileSha": "cbc9da442d4d3304fc6fb591275fe8f6b59335256cec1cb5cb3e6944a5fec75d",
-        "remediation": "orphan",
-        "ssotSlug": null,
-        "ssotType": null,
-        "ssotAttachmentId": null,
-        "ssotSha": null
-      },
-      {
-        "file": ".cleo/research/t10292-e4-cli-verb-matrix.md",
-        "fileSha": "b4b4240616b35f250a1b5aaa3bd84b75a859448a62b7cfa76e3eac5ada150092",
-        "remediation": "orphan",
-        "ssotSlug": null,
-        "ssotType": null,
-        "ssotAttachmentId": null,
-        "ssotSha": null
-      },
-      {
-        "file": ".cleo/research/t10292-e4-sdk-import-edges.md",
-        "fileSha": "9e4d21fd18ad983d98dee545c239f458cbb5c96c9d3574007a030fd0c09b2b64",
-        "remediation": "orphan",
-        "ssotSlug": null,
-        "ssotType": null,
-        "ssotAttachmentId": null,
-        "ssotSha": null
-      }
-    ],
+    "orphan": [],
     "drift": [],
     "in-sync": [
       {
@@ -73,6 +27,33 @@
         "ssotType": "adr",
         "ssotAttachmentId": "c72ef9db-7155-4671-8fa3-215c15effe26",
         "ssotSha": "0113f7f7ab1818fb681c0b7d1f601fb306819686ed08b07e18b1461fa746d22c"
+      },
+      {
+        "file": ".cleo/adrs/ADR-083-cleo-persona-and-hierarchy-reconciliation.md",
+        "fileSha": "bd8c14ab55430125c0909e0b42d9f0f1e453c1116e1e25f821c6b34ece6c4c2f",
+        "remediation": "in-sync",
+        "ssotSlug": "adr-083-cleo-persona-and-hierarchy-reconciliation",
+        "ssotType": "adr",
+        "ssotAttachmentId": "69ae26c4-883e-42be-9186-5ab96ebc2a77",
+        "ssotSha": "bd8c14ab55430125c0909e0b42d9f0f1e453c1116e1e25f821c6b34ece6c4c2f"
+      },
+      {
+        "file": ".cleo/adrs/ADR-085-cross-db-invariants.md",
+        "fileSha": "677ad407b1751d889cded48aa7de9cc26274e852cc41ee9c37f8bbedd4625a13",
+        "remediation": "in-sync",
+        "ssotSlug": "adr-085-cross-db-invariants",
+        "ssotType": "adr",
+        "ssotAttachmentId": "a7d1a798-5ee4-4232-b134-9817266dcfa4",
+        "ssotSha": "677ad407b1751d889cded48aa7de9cc26274e852cc41ee9c37f8bbedd4625a13"
+      },
+      {
+        "file": ".cleo/agent-outputs/T10268-saga-closeout.md",
+        "fileSha": "cbc9da442d4d3304fc6fb591275fe8f6b59335256cec1cb5cb3e6944a5fec75d",
+        "remediation": "in-sync",
+        "ssotSlug": "t10268-saga-closeout",
+        "ssotType": "handoff",
+        "ssotAttachmentId": "d35b33cb-4aab-47ee-ab33-0302f5733c79",
+        "ssotSha": "cbc9da442d4d3304fc6fb591275fe8f6b59335256cec1cb5cb3e6944a5fec75d"
       },
       {
         "file": ".cleo/agent-outputs/T10269-ivtr-external-systems.md",
@@ -156,6 +137,15 @@
         "ssotSha": "fee0dca1e93f5efb58af4943f6d7f9443560aed7afe5a951967e2d2625856240"
       },
       {
+        "file": ".cleo/research/t10292-e4-cli-verb-matrix.md",
+        "fileSha": "b4b4240616b35f250a1b5aaa3bd84b75a859448a62b7cfa76e3eac5ada150092",
+        "remediation": "in-sync",
+        "ssotSlug": "t10292-e4-cli-verb-matrix",
+        "ssotType": "research",
+        "ssotAttachmentId": "7006abc1-f3e6-4e2e-bd7a-01904a9fca58",
+        "ssotSha": "b4b4240616b35f250a1b5aaa3bd84b75a859448a62b7cfa76e3eac5ada150092"
+      },
+      {
         "file": ".cleo/research/t10292-e4-gap-verdicts.md",
         "fileSha": "241d810bf99eb8a417608553aabc7d2ab76f18661075bcfd68e909dd05f848e1",
         "remediation": "in-sync",
@@ -163,6 +153,15 @@
         "ssotType": "research",
         "ssotAttachmentId": "b3114265-a0d6-4761-b808-387062ba3b58",
         "ssotSha": "241d810bf99eb8a417608553aabc7d2ab76f18661075bcfd68e909dd05f848e1"
+      },
+      {
+        "file": ".cleo/research/t10292-e4-sdk-import-edges.md",
+        "fileSha": "9e4d21fd18ad983d98dee545c239f458cbb5c96c9d3574007a030fd0c09b2b64",
+        "remediation": "in-sync",
+        "ssotSlug": "t10292-e4-sdk-import-edges",
+        "ssotType": "research",
+        "ssotAttachmentId": "68c26c11-3881-4f8b-8f8f-d5510d0cd6a2",
+        "ssotSha": "9e4d21fd18ad983d98dee545c239f458cbb5c96c9d3574007a030fd0c09b2b64"
       }
     ],
     "deleted": []

--- a/packages/core/src/docs/__tests__/sweep-remediation.test.ts
+++ b/packages/core/src/docs/__tests__/sweep-remediation.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Round-trip parity test for the T10373 (E5.3) sweep-identified orphan
+ * remediation.
+ *
+ * Background: T10372 (E5.2) shipped `scripts/sweep-manual-doc-writes.mjs`,
+ * which scans `rawMdPaths` declared in `.cleo/canon.yml` and classifies
+ * each `.md` file relative to the docs SSoT. The 2026-05-24 sweep
+ * surfaced FIVE orphans — files that exist on disk inside a `rawMdPaths`
+ * directory but have no corresponding `attachments` row in the SSoT:
+ *
+ *   - `.cleo/adrs/ADR-083-cleo-persona-and-hierarchy-reconciliation.md`
+ *   - `.cleo/adrs/ADR-085-cross-db-invariants.md`
+ *   - `.cleo/agent-outputs/T10268-saga-closeout.md`
+ *   - `.cleo/research/t10292-e4-cli-verb-matrix.md`
+ *   - `.cleo/research/t10292-e4-sdk-import-edges.md`
+ *
+ * The two research files are the canonical example of the failure mode
+ * Epic T10293 targets: T10353 and T10354 workers fell back to raw
+ * filesystem writes because the pre-T10389 worktree-unreachable bug made
+ * `cleo docs add` reject inside a spawned worktree. The two ADRs were
+ * authored before the worktree-router fix landed. The handoff was a
+ * direct worker write that never routed through the SSoT.
+ *
+ * T10373 migrated all five into the SSoT via `cleo docs add` with
+ * preserved slugs and the original task owner-ids (ADR-083 → T10333,
+ * ADR-085 → T10320, handoff → T10268, verb-matrix → T10353,
+ * import-edges → T10354). This test asserts the round-trip invariant
+ * for each: a fresh tempdir-backed `.cleo/`, re-imported bytes, identical
+ * sha256 on both ends. If a future migration silently rewrites or
+ * recompresses any blob, this test fails.
+ *
+ * Each canonical record:
+ *   - `adr-083-cleo-persona-and-hierarchy-reconciliation` → adr,      SHA bd8c14ab…
+ *   - `adr-085-cross-db-invariants`                       → adr,      SHA 677ad407…
+ *   - `t10268-saga-closeout`                              → handoff,  SHA cbc9da44…
+ *   - `t10292-e4-cli-verb-matrix`                         → research, SHA b4b42406…
+ *   - `t10292-e4-sdk-import-edges`                        → research, SHA 9e4d21fd…
+ *
+ * @task T10373
+ * @epic T10293
+ * @saga T10288
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let tempDir: string;
+
+/**
+ * Canonical SHA-256 of each remediated artifact, captured at T10373
+ * migration time (2026-05-24). These values are the contract — changing
+ * them means a future migration has silently rewritten the bytes and
+ * must be re-validated against the source files.
+ */
+const CANONICAL_SHA = {
+  adr083: 'bd8c14ab55430125c0909e0b42d9f0f1e453c1116e1e25f821c6b34ece6c4c2f',
+  adr085: '677ad407b1751d889cded48aa7de9cc26274e852cc41ee9c37f8bbedd4625a13',
+  t10268Handoff: 'cbc9da442d4d3304fc6fb591275fe8f6b59335256cec1cb5cb3e6944a5fec75d',
+  t10292CliVerbMatrix: 'b4b4240616b35f250a1b5aaa3bd84b75a859448a62b7cfa76e3eac5ada150092',
+  t10292SdkImportEdges: '9e4d21fd18ad983d98dee545c239f458cbb5c96c9d3574007a030fd0c09b2b64',
+} as const;
+
+/**
+ * Project-relative source paths for each remediated artifact. Kept as a
+ * lookup table so the test can lazy-load only the bytes it needs for a
+ * given assertion and so a future migration that moves any file fails
+ * loud rather than silently passing on a missing-file fallback.
+ */
+const SOURCE_PATHS = {
+  adr083: '.cleo/adrs/ADR-083-cleo-persona-and-hierarchy-reconciliation.md',
+  adr085: '.cleo/adrs/ADR-085-cross-db-invariants.md',
+  t10268Handoff: '.cleo/agent-outputs/T10268-saga-closeout.md',
+  t10292CliVerbMatrix: '.cleo/research/t10292-e4-cli-verb-matrix.md',
+  t10292SdkImportEdges: '.cleo/research/t10292-e4-sdk-import-edges.md',
+} as const;
+
+type RemediatedSlug = keyof typeof CANONICAL_SHA;
+
+/**
+ * SSoT slug + doc type + owner-task triple for each remediated artifact,
+ * mirroring the `cleo docs add` invocations T10373 ran in production.
+ */
+const REMEDIATION_PLAN: Record<RemediatedSlug, { slug: string; type: string; ownerId: string }> = {
+  adr083: {
+    slug: 'adr-083-cleo-persona-and-hierarchy-reconciliation',
+    type: 'adr',
+    ownerId: 'T10333',
+  },
+  adr085: {
+    slug: 'adr-085-cross-db-invariants',
+    type: 'adr',
+    ownerId: 'T10320',
+  },
+  t10268Handoff: {
+    slug: 't10268-saga-closeout',
+    type: 'handoff',
+    ownerId: 'T10268',
+  },
+  t10292CliVerbMatrix: {
+    slug: 't10292-e4-cli-verb-matrix',
+    type: 'research',
+    ownerId: 'T10353',
+  },
+  t10292SdkImportEdges: {
+    slug: 't10292-e4-sdk-import-edges',
+    type: 'research',
+    ownerId: 'T10354',
+  },
+};
+
+/**
+ * Compute SHA-256 of a Buffer as lowercase hex — matches
+ * `packages/core/src/store/attachment-store.ts` canonical encoding.
+ */
+function sha256Hex(content: Buffer): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Resolve a source-path key to absolute bytes loaded from the live
+ * working tree. The test relies on the source files surviving in-tree
+ * (T10373 deliberately did NOT delete them — see Epic T10293 sequencing).
+ */
+async function loadSource(key: RemediatedSlug): Promise<Buffer> {
+  // Tests run from the package root; walk up to find the repo root.
+  const repoRoot = resolve(__dirname, '../../../../..');
+  return readFile(join(repoRoot, SOURCE_PATHS[key]));
+}
+
+describe('T10373 sweep-remediation round-trip', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-t10373-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+    delete process.env['CLEO_DIR'];
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Source-file invariants — each on-disk source file must hash to the
+  // canonical SHA captured at T10373 migration time. If any file drifts
+  // post-remediation, the SSoT and the working-tree copy fall out of sync
+  // and the next sweep run would re-flag it as drift.
+  // ─────────────────────────────────────────────────────────────────────
+
+  for (const key of Object.keys(CANONICAL_SHA) as RemediatedSlug[]) {
+    it(`source file for ${REMEDIATION_PLAN[key].slug} hashes to canonical SHA`, async () => {
+      const bytes = await loadSource(key);
+      expect(sha256Hex(bytes)).toBe(CANONICAL_SHA[key]);
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Round-trip parity — re-import each remediated artifact into a fresh
+  // isolated SSoT and assert that `put → findBySlug` returns the same
+  // content SHA, type, and owner attribution.
+  // ─────────────────────────────────────────────────────────────────────
+
+  for (const key of Object.keys(CANONICAL_SHA) as RemediatedSlug[]) {
+    it(`round-trips ${REMEDIATION_PLAN[key].slug} through SSoT preserving SHA + type + owner`, async () => {
+      const { createAttachmentStore } = await import('../../store/attachment-store.js');
+      const { closeDb } = await import('../../store/sqlite.js');
+      closeDb();
+
+      const plan = REMEDIATION_PLAN[key];
+      const store = createAttachmentStore();
+      const bytes = await loadSource(key);
+
+      const meta = await store.put(
+        bytes,
+        { kind: 'blob', storageKey: '', mime: 'text/markdown', size: bytes.length },
+        'task',
+        plan.ownerId,
+        'cleo-t10373-test',
+        undefined,
+        { slug: plan.slug, type: plan.type },
+      );
+
+      expect(meta.sha256).toBe(CANONICAL_SHA[key]);
+
+      // findBySlug returns slug + type + metadata (no owner). Use
+      // listAllInProject (which exposes ownerId) to assert the full
+      // attribution triple was persisted.
+      const lookup = await store.findBySlug(plan.slug, undefined);
+      expect(lookup).not.toBeNull();
+      expect(lookup?.metadata.sha256).toBe(CANONICAL_SHA[key]);
+      expect(lookup?.type).toBe(plan.type);
+
+      const allRows = await store.listAllInProject(undefined, { type: plan.type });
+      const ownerRow = allRows.find((r) => r.slug === plan.slug);
+      expect(ownerRow).toBeDefined();
+      expect(ownerRow?.ownerType).toBe('task');
+      expect(ownerRow?.ownerId).toBe(plan.ownerId);
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Slug uniqueness — the five remediated slugs MUST resolve to five
+  // distinct SHA-256 values. Catches accidental slug-aliasing regressions
+  // (a real failure mode — see SAGA T10288 slug-collision bug T10294).
+  // ─────────────────────────────────────────────────────────────────────
+
+  it('the five remediated slugs map to five distinct content SHAs', () => {
+    const shas = new Set(Object.values(CANONICAL_SHA));
+    expect(shas.size).toBe(5);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Plan-shape invariants — the five remediated slugs MUST use only
+  // types that exist in the docs taxonomy. Catches a class of typo bugs
+  // where a future remediation mis-spells a `--type` value.
+  // ─────────────────────────────────────────────────────────────────────
+
+  it('every remediation plan uses an allowed doc type', () => {
+    const ALLOWED_TYPES = new Set([
+      'adr',
+      'spec',
+      'research',
+      'handoff',
+      'note',
+      'llm-readme',
+      'changeset',
+      'release-note',
+      'plan',
+      'rcasd',
+    ]);
+    for (const plan of Object.values(REMEDIATION_PLAN)) {
+      expect(ALLOWED_TYPES.has(plan.type)).toBe(true);
+    }
+  });
+});

--- a/packages/skills/skills/ct-documentor/SKILL.md
+++ b/packages/skills/skills/ct-documentor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ct-documentor
 description: Documentation coordinator with CLEO style guide compliance. Routes every canonical-doc write (spec, adr, research, handoff, note, llm-readme) through the docs SSoT via `cleo docs add` / `cleo docs publish` / `cleo docs fetch` — never raw filesystem writes. Coordinates ct-docs-lookup, ct-docs-write, ct-docs-review, ct-spec-writer, and ct-adr-recorder. Use when creating or updating documentation files, consolidating scattered documentation, or validating documentation against style standards. Triggers on documentation tasks, doc update requests, or style guide compliance checks.
-version: 3.8.0
+version: 3.9.0
 tier: 3
 core: false
 category: specialist
@@ -348,6 +348,52 @@ test embeds the canonical bytes inline and asserts that
 `createAttachmentStore().put(...) → findBySlug(...)` returns the same
 SHA-256 it started with. Any future migration that silently rewrites or
 recompresses these blobs fails the test.
+
+### Sweep-driven remediation loop (T10373)
+
+T10371 only covers the *known* manual-write set declared in the original
+Saga T10176 disposition. The T10372 sweep surfaces *every* orphan
+remaining under `rawMdPaths` at the moment it runs. T10373 closes the
+loop by consuming the sweep report and migrating each orphan into the
+SSoT using the same `cleo docs add --slug` pattern T10371 established.
+
+The recurring pattern (use this any time the sweep flags fresh
+orphans):
+
+1. Run the sweep: `node scripts/sweep-manual-doc-writes.mjs`. The
+   report lands at `audit/manual-write-sweep-<date>.json`.
+2. For each `orphan` entry, derive the migration tuple:
+   - `--type` from the file's parent directory (`.cleo/adrs/` → `adr`,
+     `.cleo/research/` → `research`, `.cleo/agent-outputs/` →
+     `handoff` or `note` based on content, `.cleo/rcasd/` → `rcasd`).
+   - `--slug` from the filename — lowercase, kebab-case, no
+     extension (e.g. `ADR-085-cross-db-invariants.md` →
+     `adr-085-cross-db-invariants`).
+   - `<owner-id>` from the file's frontmatter `task:` field if
+     present, otherwise from `cleo find "<filename-keyword>"`.
+3. Run `cleo docs add <ownerId> <file> --type <kind> --slug <slug>
+   --desc "<sweep-remediation context>"`. The `--desc` should
+   reference the originating task ID so future operators can trace
+   the migration.
+4. Verify via `cleo docs fetch <slug>` and re-run the sweep — the
+   `orphan` count MUST drop by the number of files migrated.
+5. Add the new (slug, sha256, type, ownerId) row to a
+   round-trip parity test alongside the T10371 set. The canonical
+   example lives at
+   `packages/core/src/docs/__tests__/sweep-remediation.test.ts`.
+
+T10373 migrated five orphans this way: `ADR-083`, `ADR-085`,
+`T10268-saga-closeout`, `t10292-e4-cli-verb-matrix`, and
+`t10292-e4-sdk-import-edges`. The last two were direct fallout from
+the pre-T10389 worktree-unreachable bug — T10353 and T10354 workers
+fell back to raw filesystem writes because `cleo docs add` rejected
+inside their spawned worktrees. Re-publishing the bytes via the SSoT
+proves the round-trip and closes the loop the bug opened.
+
+If a sweep run surfaces a file that should genuinely stay as raw
+markdown (e.g. an audit log not meant for SSoT propagation), add an
+entry to `audit/sweep-exemptions.yml` rather than migrating it. The
+sweep script honours exemptions and does not flag them as orphans.
 
 ### Slug similarity warn (T10361 · closes T10167)
 


### PR DESCRIPTION
## Summary

5 orphan manual-writes identified by the T10372 sweep migrated into the docs SSoT via `cleo docs add` with preserved slugs:

| Slug | Type | Owner | SHA-256 (prefix) |
|---|---|---|---|
| `adr-083-cleo-persona-and-hierarchy-reconciliation` | adr | T10333 | bd8c14ab |
| `adr-085-cross-db-invariants` | adr | T10320 | 677ad407 |
| `t10268-saga-closeout` | handoff | T10268 | cbc9da44 |
| `t10292-e4-cli-verb-matrix` | research | T10353 | b4b42406 |
| `t10292-e4-sdk-import-edges` | research | T10354 | 9e4d21fd |

The two research files were the canonical example of Epic T10293's target failure mode — T10353 and T10354 workers fell back to raw fs writes during the pre-T10389 worktree-unreachable window. Re-publishing via the SSoT closes the loop the bug opened.

## Verification

- Re-run sweep reports orphan=0, drift=0, in-sync=16 (was 5/0/11 before)
- 12 round-trip parity tests pass — `sha256(file) == sha256(SSoT blob)`, type + ownerId attribution verified via `listAllInProject`
- `manual-write-migration.test.ts` (T10371) still green (5 tests)

## Tier-3 skill drift

`ct-documentor` SKILL.md bumped 3.8.0 → 3.9.0 with new "Sweep-driven remediation loop (T10373)" section describing the recurring pattern (run sweep → derive (type, slug, ownerId) → `cleo docs add` → verify → add round-trip test).

## Saga / Epic
- Saga: T10288 SG-DOCS-INTEGRITY (Wave 3 — E5)
- Epic: T10293 E5-DOCS-RETROACTIVE-NORMALIZE
- Depends: T10371 (E5.1 PR #642), T10372 (E5.2 PR #638)

## Test plan
- [x] `pnpm exec vitest run packages/core/src/docs/__tests__/sweep-remediation.test.ts` — 12/12 green
- [x] `pnpm run build --filter @cleocode/core` — green
- [x] `node scripts/sweep-manual-doc-writes.mjs` — orphan count = 0
- [x] `cleo docs fetch <slug>` for all 5 slugs — content reachable