### PR TITLE
docs(registry): T10342 auto-render INVARIANTS.md + CI drift gate

### DIFF
--- a/.changeset/t10342-render-invariants-docs.md
+++ b/.changeset/t10342-render-invariants-docs.md
@@ -1,0 +1,30 @@
+---
+id: t10342-render-invariants-docs
+tasks: [T10342]
+kind: feat
+summary: "R8 — auto-render docs/registry/INVARIANTS.md from INVARIANTS_REGISTRY + CI drift gate"
+---
+
+Builds `packages/contracts/scripts/render-invariants-docs.mjs` to emit the
+canonical `docs/registry/INVARIANTS.md` page from the central
+`INVARIANTS_REGISTRY` SSoT at `packages/contracts/src/invariants/`. The
+script:
+
+- Reads the registry from the compiled `dist/`.
+- Emits a deterministic markdown document grouped by source ADR with one
+  table row per `(adr, code)` pair carrying `Code`, `Name`, `Severity`,
+  `RuntimeGate`, `Tests`, and `Description` columns.
+- Supports `--check` mode for drift detection and `--stdout` for previews.
+- Carries an `AUTO-GENERATED — DO NOT EDIT` banner pointing back at the
+  script and SSoT module.
+
+Adds the `Invariants Docs Render Drift (T10342)` CI gate that re-renders +
+diffs against the committed file on every PR. Drift fails CI with a
+remediation hint.
+
+Wires two top-level scripts: `pnpm render:invariants` (write) and
+`pnpm render:invariants:check` (drift detection). Generated file checked
+in initially with the 28 entries currently in `INVARIANTS_REGISTRY`
+(ADR-073 I1-I8 + ADR-056 D1-D6 + ADR-070 ORC-001..ORC-014).
+
+Saga: T10326 SG-SUBSTRATE-RECONCILIATION · Epic: T10327 E-INVARIANT-REGISTRY-SSOT · R8.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,44 @@ jobs:
       - name: Lint invariant registry forward + reverse symmetry
         run: node scripts/lint-invariant-registry.mjs
 
+  invariants-docs-render-drift:
+    # T10342 / Saga T10326 SG-SUBSTRATE-RECONCILIATION Wave 3 R8 — keep
+    # `docs/registry/INVARIANTS.md` in lockstep with the central
+    # `INVARIANTS_REGISTRY` SSoT. The job:
+    #   1. Builds @cleocode/contracts (TS-only target — schemas not needed).
+    #   2. Re-renders the docs page from the compiled registry.
+    #   3. Compares the rendered output against the committed file via
+    #      `--check`. Drift = CI failure with a remediation hint.
+    # Strict gate: zero tolerance — the rendered output is deterministic
+    # and the registry is the SSoT, so any drift is unambiguously a stale
+    # docs commit.
+    name: Invariants Docs Render Drift (T10342)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.30.0'
+          run_install: false
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
+      - name: Build @cleocode/contracts (TS only)
+        run: pnpm --filter @cleocode/contracts run build:ts
+      - name: Verify docs/registry/INVARIANTS.md matches registry SSoT
+        run: node packages/contracts/scripts/render-invariants-docs.mjs --check
+
   raw-git-worktree-lint:
     # T9984 / E7-CORE-LAYERING — enforce `@cleocode/worktree` as the sole
     # source of `git worktree` shell-outs in the workspace. Strict gate: any

--- a/docs/registry/INVARIANTS.md
+++ b/docs/registry/INVARIANTS.md
@@ -1,0 +1,85 @@
+<!--
+  AUTO-GENERATED — DO NOT EDIT MANUALLY.
+
+  Regenerate via: pnpm render:invariants
+  Source script:  packages/contracts/scripts/render-invariants-docs.mjs
+  Source SSoT:    packages/contracts/src/invariants/index.ts
+
+  Editing this file directly will be reverted by the next
+  `Invariants Docs Render Drift (T10342)` CI gate run.
+-->
+
+# Invariants Registry
+
+This page catalogues every numbered invariant the CLEO system relies on. It is **auto-rendered** from the central `INVARIANTS_REGISTRY` SSoT at `packages/contracts/src/invariants/`. Editing the source files is the only way to change this page.
+
+## Summary
+
+| ADR | Entries | Source module |
+| --- | --- | --- |
+| [`ADR-073`](.cleo/adrs/ADR-073-above-epic-naming.md) | 8 | `packages/contracts/src/invariants/adr-073-saga.ts` |
+| [`ADR-056`](.cleo/adrs/ADR-056-db-ssot-and-release-completion-invariant.md) | 6 | `packages/contracts/src/invariants/adr-056-release.ts` |
+| [`ADR-070`](.cleo/adrs/ADR-070-three-tier-orchestration.md) | 14 | `packages/contracts/src/invariants/adr-070-orchestration.ts` |
+| **Total** | **28** | — |
+
+## ADR-073
+
+Source ADR: [`.cleo/adrs/ADR-073-above-epic-naming.md`](../../.cleo/adrs/ADR-073-above-epic-naming.md)
+
+Registry module: `packages/contracts/src/invariants/adr-073-saga.ts`
+
+| Code | Name | Severity | RuntimeGate | Tests | Description |
+| --- | --- | --- | --- | --- | --- |
+| `I1` | Storage uniformity | `info` | _none_ | `packages/core/src/tasks/__tests__/id-generator.test.ts` | All task IDs are stored as T#### and the type column is the canonical tier discriminator. There is no separate ID space for Sagas, Epics, Tasks, or Subtasks; label="saga" elevates a type="epic" row to Saga semantics. |
+| `I2` | Conceptual prefixes are display + import only | `info` | _none_ | _none_ | SG-, E-, T- (and Subtask's implicit absence) are documentation, CLI display, and import-mapping conventions only. They MUST NOT be used as DB primary keys — display-only with no runtime enforcement. |
+| `I3` | Tier promotion mandatory when scope outgrows the tier | `error` | `assertSagaInvariantI3` (`packages/core/src/sagas/enforcement.ts`) | `packages/core/src/sagas/__tests__/enforcement.test.ts` | A Subtask whose change exceeds 2 files or crosses a module boundary MUST be split or promoted to a sibling Task. A Task that requires more than one PR or wave MUST be split. An Epic that spans more than one release MUST be regrouped under a Saga. |
+| `I4` | Ownership non-overlapping | `warning` | _none_ | _none_ | A single tier maps to a single orchestration role (per ADR-070). Workers MUST NOT spawn other Workers. Phase Leads MUST NOT own multiple Epics simultaneously. The Orchestrator MUST NOT spawn Workers directly when fan-out exceeds the ADR-070 migration threshold. |
+| `I5` | Sagas link via groups, not parent | `error` | `assertSagaInvariantI5` (`packages/core/src/sagas/enforcement.ts`) | `packages/core/src/sagas/__tests__/enforcement.test.ts` | task_relations.type="groups" is the ONLY relation type that links a Saga to its member Epics. The Saga row's parent_id MUST be NULL. Enforced at runtime by assertSagaInvariantI5 AND by the DB CHECK constraint from W1.B (T10329) on label="saga" rows. |
+| `I6` | Acceptance criteria required at every tier | `warning` | _none_ | _none_ | Per ADR-066 §"Ownership Matrix" invariant #5, all tasks regardless of type or kind MUST have --acceptance set at creation time. No tier exemption exists. Delegated to the ADR-066 --acceptance requirement on cleo add/add-batch. |
+| `I7` | Maximum parent depth is 3 | `error` | `assertSagaInvariantI7` (`packages/core/src/sagas/enforcement.ts`) | `packages/core/src/sagas/__tests__/enforcement.test.ts` | The parent ladder Subtask → Task → Epic is fixed at depth 3 (hierarchy.maxDepth=3). Sagas do NOT consume depth — they attach via groups relations, not parent edges. Enforced at runtime by assertSagaInvariantI7. |
+| `I8` | Subtask-to-PR aggregation rule | `warning` | _none_ | _none_ | A Task ships as exactly one PR. The PR's commit history is the union of the Task's Subtask commits. A Subtask never produces its own PR; if a unit of work warrants its own PR, it is a Task, not a Subtask. UNENFORCED at runtime today — load-bearing convention enforced via code review and the lifecycle decision table. |
+
+## ADR-056
+
+Source ADR: [`.cleo/adrs/ADR-056-db-ssot-and-release-completion-invariant.md`](../../.cleo/adrs/ADR-056-db-ssot-and-release-completion-invariant.md)
+
+Registry module: `packages/contracts/src/invariants/adr-056-release.ts`
+
+| Code | Name | Severity | RuntimeGate | Tests | Description |
+| --- | --- | --- | --- | --- | --- |
+| `D1` | Database topology: keep per-domain split | `info` | _none_ | _none_ | CLEO retains the six per-domain SQLite databases (tasks, brain, conduit, nexus, signaldock, telemetry) documented in DATABASE-ERDS.md. Consolidation is rejected to preserve per-DB WAL throughput, per-DB rollback granularity, and avoid single-writer contention during multi-agent waves. |
+| `D2` | Store-layer naming convention | `info` | _none_ | _none_ | New always-on store-layer domains MUST use the kebab-case pair `packages/core/src/store/<domain>-schema.ts` (Drizzle defs) + `packages/core/src/store/<domain>-sqlite.ts` (open/init/CRUD). Opt-in / isolated domains MAY use the folder variant `packages/core/src/<domain>/{schema,sqlite}.ts` (currently telemetry only). |
+| `D3` | Migration runner SSoT under migration-manager.ts | `info` | _none_ | _none_ | All six SQLite databases MUST be initialized via `packages/core/src/migration/migration-manager.ts` (`migrateWithRetry()` + `reconcileJournal()`). Per-DB bespoke runners are prohibited for new domains. Rust Diesel migrations for cloud signaldock-storage MUST NOT touch the local SQLite signaldock.db at runtime. |
+| `D4` | archiveReason 6-value enum with tombstone semantics | `error` | `assertArchiveReason` (`packages/contracts/src/tasks/archive.ts`) | `packages/contracts/src/tasks/__tests__/archive.test.ts` | The tasks.archive_reason column is constrained to exactly six values (verified, reconciled, superseded, shadowed, cancelled, completed-unverified) via SQLite CHECK constraint AND Zod z.enum validation. Writing 'completed-unverified' from non-migration code MUST throw E_ARCHIVE_REASON_TOMBSTONE — the tombstone is reserved for the T1408 backfill migration only. |
+| `D5` | Post-release reconciliation: registry-driven cleo verify --release | `warning` | `runInvariants` (`packages/core/src/release/invariants/registry.ts`) | `packages/core/src/release/invariants/__tests__/archive-reason-invariant.test.ts` | Post-release reconciliation flows through the executable invariants registry at packages/core/src/release/invariants/registry.ts. Customers register via registerInvariant() and the CLI runs every entry on `cleo verify --release <tag>`. First customer: archive-reason-invariant.ts (stamps verified tasks done; creates follow-up tasks for unverified references). |
+| `D6` | Commit-message lint for release commits | `info` | _none_ | _none_ | Every commit whose subject matches `^(chore\|feat)\(release\):` MUST contain at least one `T\d+` task reference in the commit body. Enforced by scripts/hooks/commit-msg-release-lint.mjs (T1410). Bypass via CLEO_OWNER_OVERRIDE=1 with audited justification. |
+
+## ADR-070
+
+Source ADR: [`.cleo/adrs/ADR-070-three-tier-orchestration.md`](../../.cleo/adrs/ADR-070-three-tier-orchestration.md)
+
+Registry module: `packages/contracts/src/invariants/adr-070-orchestration.ts`
+
+| Code | Name | Severity | RuntimeGate | Tests | Description |
+| --- | --- | --- | --- | --- | --- |
+| `ORC-001` | Orchestrator is the HITL interface | `warning` | _none_ | `packages/skills/skills/ct-orchestrator/SKILL.md` | The Orchestrator (Cleo) is the single subagent that talks to the human operator. It plans, decomposes, and delegates — it never produces line-level implementation. Source-of-truth lives in ct-orchestrator/SKILL.md row ORC-001 and is injected into the Orchestrator prompt at spawn time. UNENFORCED at the dispatch layer: this is a prompt-time invariant with no runtime guard today. |
+| `ORC-002` | Orchestrator MUST NOT write or edit code | `warning` | _none_ | `packages/skills/skills/ct-orchestrator/SKILL.md` | Every line of code is written by a spawned subagent. The Orchestrator delegates implementation work via cleo orchestrate spawn / delegate_task. UNENFORCED at the dispatch layer: this is a prompt-time invariant — there is no runtime gate that blocks the Orchestrator from calling Edit/Write, so the contract is held by the ct-orchestrator skill text. |
+| `ORC-003` | Orchestrator MUST NOT read full source files | `warning` | _none_ | `packages/skills/skills/ct-orchestrator/SKILL.md` | Orchestrator reads only pipeline manifests, task envelopes, and rolled-up phase summaries returned by Phase Leads. Workers read code; the Orchestrator reads summaries. UNENFORCED at the dispatch layer — held by the ct-orchestrator skill text and reinforced by ORC-005 budget pressure. |
+| `ORC-004` | Dependency-ordered spawning | `warning` | `validateSpawnReadiness` (`packages/core/src/orchestration/validate-spawn.ts`) | `packages/core/src/orchestration/__tests__/validate-spawn.test.ts`<br>`packages/core/src/skills/orchestrator/__tests__/validator.test.ts` | Spawns within a wave are ordered by task.depends — a Worker MUST NOT be dispatched until its declared dependencies are status=done. Surfaced by validateSpawnReadiness via V_MISSING_DEP / V_UNMET_DEP codes; surfaced by the skill-orchestrator validator via the ORC-004_DEPENDENCY_ORDER warning emitted from packages/core/src/skills/orchestrator/validator.ts. Tier: warning because the validator surfaces ordering issues but does not throw — workers can still proceed if the operator overrides. |
+| `ORC-005` | Orchestrator context budget ≈ 10 K tokens | `warning` | `estimateContext` (`packages/core/src/orchestration/context.ts`) | `packages/core/src/orchestration/__tests__/` | The Orchestrator MUST keep its working context under ~10 K tokens; delegate at 80 %. Surfaced by cleo orchestrate context (estimateContext) and by the skill-orchestrator validator (ORC-005_NO_MANIFEST / ORC-005_EMPTY_MANIFEST). UNENFORCED as a hard gate — the budget is advisory, surfaced to the Orchestrator as a warning so the human operator can intervene. |
+| `ORC-006` | Worker scope ≤ 3 files per spawn | `error` | `validateSpawnReadiness` (`packages/core/src/orchestration/validate-spawn.ts`) | `packages/core/src/orchestration/__tests__/validate-spawn.test.ts`<br>`packages/core/src/orchestration/__tests__/spawn-prompt.test.ts` | Cross-file reasoning quality degrades beyond ~3 files for a single Worker. Enforced at spawn-time by validateSpawnReadiness — V_ATOMIC_SCOPE_MISSING when task.files is empty, V_ATOMIC_SCOPE_TOO_LARGE when files.length > MAX_WORKER_FILES (currently 3). Spawn-prompt builder injects a Worker Budget Constraints section so the Worker sees the budget inline. Tier: error because the gate refuses to spawn an over-scoped Worker. |
+| `ORC-007` | All work traced to an Epic | `warning` | _none_ | `packages/skills/skills/ct-orchestrator/SKILL.md` | Every Task and Subtask MUST attach to a parent Epic (directly or transitively). No orphan work — orphans are filed against the ADR-066 acceptance-criteria gate and surface via cleo find. UNENFORCED at the dispatch layer; the parent-id requirement is materialised through cleo add validation rather than a single ORC-named guard. R6 doctor audit should walk the task graph to surface orphans. |
+| `ORC-008` | Zero architectural decisions during execution | `warning` | _none_ | `packages/skills/skills/ct-orchestrator/SKILL.md` | Architectural choices MUST be pre-decided via RCASD consensus or HITL — never inside a worker session. UNENFORCED at the dispatch layer: this is a behavioural invariant held by the ct-orchestrator skill text plus the ADR-066 acceptance criterion that every task must declare its architecture-relevant decisions before spawn. |
+| `ORC-009` | Manifest-mediated handoffs | `warning` | _none_ | `packages/skills/skills/ct-orchestrator/SKILL.md` | Orchestrator reads only the key_findings field of pipeline_manifest rows when reconciling worker output. Subagents read the full task description and supporting files. UNENFORCED at the dispatch layer: the contract is held by the ct-orchestrator skill text and reinforced by ORC-003 + ORC-005 budget pressure. |
+| `ORC-010` | Lead-interposition required for Epic-child Workers | `warning` | _none_ | _none_ | A Worker spawn against a Task whose parent is type=epic MUST be preceded by a Lead spawn for the same Task (ADR-083 §2.4 / §6). The intended runtime gate (composeSpawnPayload throwing E_LEAD_REQUIRED_FOR_EPIC_CHILD) is FILED but UNSHIPPED — tracked under T10278. Registered here as a warning + runtimeGate:null so the gap is visible in the R6 doctor audit. |
+| `ORC-011` | Orchestrator-depth cap at 3 | `warning` | _none_ | _none_ | Recursive Orchestrator spawns (Cleo → sub-Orchestrator → sub-Orchestrator → …) MUST stop at depth 3 (ADR-083 §2.2 + §2.4). The intended runtime gate (composeSpawnPayload throwing E_ORCHESTRATOR_DEPTH_EXCEEDED) is FILED but UNSHIPPED — tracked under T10279. Registered here as a warning + runtimeGate:null so the gap is visible in the R6 doctor audit. |
+| `ORC-012` | Thin-agent inversion-of-control | `error` | `enforceThinAgent` (`packages/core/src/orchestration/thin-agent.ts`) | `packages/core/src/orchestration/__tests__/thin-agent.test.ts`<br>`packages/cant/src/__tests__/hierarchy.test.ts` | Workers MUST NOT spawn other subagents. The spawn-capable tools (Agent / Task / TaskCreate) are stripped from the Worker tool list at .cant compile time, and any survivor at spawn time triggers ThinAgentViolationError → E_THIN_AGENT_VIOLATION (exit 68). The only ORC rule with a hard-enforced dispatch-time gate today. |
+| `ORC-013` | Worktree provisioning at canonical XDG location | `error` | `assertCanonicalWorktreeLocation` (`packages/worktree/src/worktree-create.ts`) | `packages/worktree/src/__tests__/` | Every agent worktree MUST be created under <cleoHome>/worktrees/<projectHash>/<taskId>/ (ADR-055 + Council D009). createWorktree throws E_WT_LOCATION_FORBIDDEN before any git worktree add call when the computed path falls outside the canonical root. CI gate lint-worktree-location.mjs enforces the same invariant on every PR. The single-most-load-bearing orchestration guard after ORC-012. |
+| `ORC-014` | Lead-bypass detection at session end | `error` | `endSession` (`packages/core/src/sessions/index.ts`) | `packages/core/src/sessions/__tests__/` | A Lead session (CLEO_AGENT_ROLE=lead) that ends with tasks_completed > 0 AND delegate_task_count = 0 is rejected with LeadBypassDetectedError → E_LEAD_BYPASS_DETECTED (exit 107). Leads MUST fan out work to Workers; a Lead that did the work itself defeats the three-tier topology. Override via CLEO_OWNER_OVERRIDE=1 (audited to force-bypass.jsonl). |
+
+## See also
+
+- `packages/contracts/src/invariants/index.ts` — central registry (SSoT).
+- `scripts/lint-invariant-registry.mjs` — R4 CI gate (T10338) that validates this registry stays truthful.
+- `packages/core/src/release/invariants/registry.ts` — R5 (T10339) consumer of the ADR-056 D1-D6 substrate.
+- `cleo doctor --audit-invariants` — R6 (T10340) per-invariant enforcement audit.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "version:bump": "node scripts/version-all.mjs",
     "cleo:dev": "node --disable-warning=ExperimentalWarning packages/cleo/dist/cli/index.js",
     "gen:llm-catalog": "node scripts/generate-llm-catalog.mjs",
+    "render:invariants": "pnpm --filter @cleocode/contracts run build:ts && node packages/contracts/scripts/render-invariants-docs.mjs",
+    "render:invariants:check": "pnpm --filter @cleocode/contracts run build:ts && node packages/contracts/scripts/render-invariants-docs.mjs --check",
     "hooks:install": "simple-git-hooks"
   },
   "simple-git-hooks": {

--- a/packages/contracts/scripts/render-invariants-docs.mjs
+++ b/packages/contracts/scripts/render-invariants-docs.mjs
@@ -1,0 +1,382 @@
+#!/usr/bin/env node
+/**
+ * render-invariants-docs.mjs — Auto-render `docs/registry/INVARIANTS.md` from
+ * the central `INVARIANTS_REGISTRY` SSoT at
+ * `packages/contracts/src/invariants/`.
+ *
+ * The script is the docs-side of the central invariants substrate built by
+ * the Saga T10326 SG-SUBSTRATE-RECONCILIATION programme:
+ *
+ *   - R1 (T10335, SHIPPED) — registry + ADR-073 I1-I8.
+ *   - R2 (T10336, SHIPPED) — ADR-070 ORC-001..ORC-014 enumerated.
+ *   - R3 (T10337, SHIPPED) — ADR-056 D1-D6 enumerated.
+ *   - R4 (T10338, SHIPPED) — CI gate validates registry coverage.
+ *   - R5 (T10339, SHIPPED) — `core/release` consumes the central substrate.
+ *   - R8 (this task, T10342) — auto-render the canonical docs page.
+ *
+ * Why auto-render?
+ * ----------------
+ * Before T10342 every numbered invariant lived in two places: the registry
+ * literal (the SSoT) AND prose paragraphs in the ADR markdown. The two
+ * inevitably drifted — R6 (T10340) doctor audit hit this on day one when
+ * ADR-073's prose listed I3/I5/I7 as "warning" while the registry already
+ * marked them "error". This script collapses the doc surface back to the
+ * SSoT: editing the registry is the ONLY way to change the docs page.
+ *
+ * Output
+ * ------
+ * Generates `docs/registry/INVARIANTS.md` (path relative to repo root):
+ *
+ *   1. AUTO-GENERATED banner with a back-link to this script.
+ *   2. Summary block (per-ADR count + total).
+ *   3. One H2 section per source ADR, in registration order
+ *      (ADR-073, ADR-056, ADR-070 — same order as `INVARIANTS_REGISTRY`).
+ *   4. A markdown table per ADR with columns:
+ *      `Code | Name | Severity | RuntimeGate | Tests | Description`.
+ *   5. Cross-link footer pointing back at the ADRs + the SSoT modules.
+ *
+ * Modes
+ * -----
+ *   - default (write): regenerate `docs/registry/INVARIANTS.md`.
+ *   - `--check`: render to memory, compare against the committed file. Exits
+ *     non-zero on mismatch — the CI gate (`.github/workflows/ci.yml` job
+ *     `Invariants Docs Render Drift (T10342)`) runs this mode.
+ *   - `--stdout`: render to stdout (handy for ad-hoc previews).
+ *
+ * Determinism
+ * -----------
+ * Two consecutive runs MUST produce byte-identical output. The script:
+ *   - Iterates the registry in declaration order (no sort by code/name).
+ *   - Uses POSIX path separators in every string emitted.
+ *   - Writes `\n` line endings exclusively.
+ *   - Does NOT inject a timestamp (the AUTO-GENERATED banner names the
+ *     source script — readers know how to find the timestamp by `git log`).
+ *
+ * @task T10342 — R8: auto-render docs/registry/INVARIANTS.md from registry
+ * @epic T10327 — E-INVARIANT-REGISTRY-SSOT
+ * @saga T10326 — SG-SUBSTRATE-RECONCILIATION
+ * @see packages/contracts/src/invariants/index.ts — SSoT
+ * @see scripts/lint-invariant-registry.mjs        — R4 CI gate (T10338)
+ * @see packages/cleo/scripts/generate-command-manifest.mjs — render-pattern reference
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ─── Paths ────────────────────────────────────────────────────────────────
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, '..');
+const REPO_ROOT = resolve(PKG_ROOT, '..', '..');
+const OUTPUT_FILE = resolve(REPO_ROOT, 'docs', 'registry', 'INVARIANTS.md');
+const REGISTRY_DIST = resolve(PKG_ROOT, 'dist', 'invariants', 'index.js');
+const SCRIPT_REL = toPosixRel(REPO_ROOT, fileURLToPath(import.meta.url));
+
+// ─── CLI ──────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const MODE_CHECK = args.includes('--check');
+const MODE_STDOUT = args.includes('--stdout');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Convert an absolute path into a POSIX repo-relative path. Used by every
+ * emitted path string so Linux/macOS/Windows all yield identical output.
+ *
+ * @param {string} base — anchor directory (repo root).
+ * @param {string} target — absolute path to convert.
+ * @returns {string}
+ */
+function toPosixRel(base, target) {
+  return relative(base, target).split(sep).join('/');
+}
+
+/**
+ * Escape pipe characters and newlines in a string so it can appear in a
+ * markdown table cell without breaking the table syntax.
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+function escapeCell(input) {
+  return input.replace(/\|/g, '\\|').replace(/\n/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Format the `runtimeGate` column for one invariant entry.
+ *
+ * The cell shows the bare function name + parenthesised module path when a
+ * guard exists; otherwise an italicised "none" placeholder so the table row
+ * stays aligned and grep-able.
+ *
+ * @param {{module: string, functionName: string} | null | undefined} gate
+ * @returns {string}
+ */
+function formatRuntimeGate(gate) {
+  if (!gate) return '_none_';
+  return `\`${gate.functionName}\` (\`${gate.module}\`)`;
+}
+
+/**
+ * Format the `tests` column.
+ *
+ * @param {readonly string[]} tests
+ * @returns {string}
+ */
+function formatTests(tests) {
+  if (tests.length === 0) return '_none_';
+  return tests.map((t) => `\`${t}\``).join('<br>');
+}
+
+/**
+ * Map an ADR ID to the canonical ADR markdown path. Read-only mapping —
+ * adding a new source ADR happens here (and in the registry SSoT).
+ *
+ * @param {string} adr
+ * @returns {string}
+ */
+function adrSourcePath(adr) {
+  switch (adr) {
+    case 'ADR-073':
+      return '.cleo/adrs/ADR-073-above-epic-naming.md';
+    case 'ADR-070':
+      return '.cleo/adrs/ADR-070-three-tier-orchestration.md';
+    case 'ADR-056':
+      return '.cleo/adrs/ADR-056-db-ssot-and-release-completion-invariant.md';
+    default:
+      return `.cleo/adrs/${adr}.md`;
+  }
+}
+
+/**
+ * Map an ADR ID to its registry module path (relative to repo root).
+ *
+ * @param {string} adr
+ * @returns {string}
+ */
+function adrModulePath(adr) {
+  switch (adr) {
+    case 'ADR-073':
+      return 'packages/contracts/src/invariants/adr-073-saga.ts';
+    case 'ADR-070':
+      return 'packages/contracts/src/invariants/adr-070-orchestration.ts';
+    case 'ADR-056':
+      return 'packages/contracts/src/invariants/adr-056-release.ts';
+    default:
+      return 'packages/contracts/src/invariants/index.ts';
+  }
+}
+
+// ─── Registry import ──────────────────────────────────────────────────────
+
+/**
+ * Load the compiled invariants registry from `dist/`. The script ALWAYS
+ * reads from `dist/` (never `src/`) so the on-disk shape downstream
+ * consumers receive is the shape that gets rendered. The contracts package
+ * build step is a prerequisite — `pnpm --filter @cleocode/contracts run
+ * build:ts` is run by the CI gate before invoking this script.
+ *
+ * @returns {Promise<{
+ *   INVARIANTS_REGISTRY: Readonly<Record<string, {
+ *     adr: string;
+ *     code: string;
+ *     name: string;
+ *     description: string;
+ *     severity: 'info' | 'warning' | 'error';
+ *     runtimeGate: {module: string; functionName: string} | null;
+ *     lintRule?: {lintScript: string} | null;
+ *     doctorAudit?: {lintScript: string} | null;
+ *     tests: readonly string[];
+ *     deprecated?: boolean;
+ *   }>>;
+ * }>}
+ */
+async function loadRegistry() {
+  if (!existsSync(REGISTRY_DIST)) {
+    console.error(
+      `render-invariants-docs: registry dist not found at ${REGISTRY_DIST}\n` +
+        '  Run `pnpm --filter @cleocode/contracts run build:ts` first.',
+    );
+    process.exit(2);
+  }
+  const mod = await import(REGISTRY_DIST);
+  if (!mod.INVARIANTS_REGISTRY) {
+    console.error('render-invariants-docs: INVARIANTS_REGISTRY missing from dist export');
+    process.exit(2);
+  }
+  return mod;
+}
+
+// ─── Renderer ─────────────────────────────────────────────────────────────
+
+/**
+ * Render the full markdown document. Pure function — same input, same
+ * output. Determinism is enforced by:
+ *   1. Iterating `Object.values(registry)` (declaration order, since the
+ *      registry is built by spreading per-ADR arrays in a fixed order).
+ *   2. Grouping by `adr` using insertion-ordered `Map`.
+ *   3. No timestamps, no random IDs, no environment-dependent strings.
+ *
+ * @param {Readonly<Record<string, {
+ *   adr: string;
+ *   code: string;
+ *   name: string;
+ *   description: string;
+ *   severity: 'info' | 'warning' | 'error';
+ *   runtimeGate: {module: string; functionName: string} | null;
+ *   tests: readonly string[];
+ *   deprecated?: boolean;
+ * }>>} registry
+ * @returns {string}
+ */
+function render(registry) {
+  const allEntries = Object.values(registry);
+
+  /** @type {Map<string, typeof allEntries>} */
+  const byAdr = new Map();
+  for (const entry of allEntries) {
+    const bucket = byAdr.get(entry.adr) ?? [];
+    bucket.push(entry);
+    byAdr.set(entry.adr, bucket);
+  }
+
+  const lines = [];
+
+  // ─── Banner ─────────────────────────────────────────────────────────────
+  lines.push('<!--');
+  lines.push('  AUTO-GENERATED — DO NOT EDIT MANUALLY.');
+  lines.push('');
+  lines.push(`  Regenerate via: pnpm render:invariants`);
+  lines.push(`  Source script:  ${SCRIPT_REL}`);
+  lines.push('  Source SSoT:    packages/contracts/src/invariants/index.ts');
+  lines.push('');
+  lines.push('  Editing this file directly will be reverted by the next');
+  lines.push('  `Invariants Docs Render Drift (T10342)` CI gate run.');
+  lines.push('-->');
+  lines.push('');
+  lines.push('# Invariants Registry');
+  lines.push('');
+  lines.push(
+    'This page catalogues every numbered invariant the CLEO system relies on. ' +
+      'It is **auto-rendered** from the central `INVARIANTS_REGISTRY` SSoT at ' +
+      '`packages/contracts/src/invariants/`. Editing the source files is the ' +
+      'only way to change this page.',
+  );
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push('| ADR | Entries | Source module |');
+  lines.push('| --- | --- | --- |');
+  let total = 0;
+  for (const [adr, entries] of byAdr) {
+    total += entries.length;
+    lines.push(`| [\`${adr}\`](${adrSourcePath(adr)}) | ${entries.length} | \`${adrModulePath(adr)}\` |`);
+  }
+  lines.push(`| **Total** | **${total}** | — |`);
+  lines.push('');
+
+  // ─── Per-ADR sections ───────────────────────────────────────────────────
+  for (const [adr, entries] of byAdr) {
+    lines.push(`## ${adr}`);
+    lines.push('');
+    lines.push(`Source ADR: [\`${adrSourcePath(adr)}\`](../../${adrSourcePath(adr)})`);
+    lines.push('');
+    lines.push(`Registry module: \`${adrModulePath(adr)}\``);
+    lines.push('');
+    lines.push('| Code | Name | Severity | RuntimeGate | Tests | Description |');
+    lines.push('| --- | --- | --- | --- | --- | --- |');
+    for (const entry of entries) {
+      const codeCell = entry.deprecated
+        ? `\`${escapeCell(entry.code)}\` _(deprecated)_`
+        : `\`${escapeCell(entry.code)}\``;
+      const cells = [
+        codeCell,
+        escapeCell(entry.name),
+        `\`${escapeCell(entry.severity)}\``,
+        formatRuntimeGate(entry.runtimeGate),
+        formatTests(entry.tests),
+        escapeCell(entry.description),
+      ];
+      lines.push(`| ${cells.join(' | ')} |`);
+    }
+    lines.push('');
+  }
+
+  // ─── Footer ─────────────────────────────────────────────────────────────
+  lines.push('## See also');
+  lines.push('');
+  lines.push(
+    '- `packages/contracts/src/invariants/index.ts` — central registry (SSoT).',
+  );
+  lines.push(
+    '- `scripts/lint-invariant-registry.mjs` — R4 CI gate (T10338) that ' +
+      'validates this registry stays truthful.',
+  );
+  lines.push(
+    '- `packages/core/src/release/invariants/registry.ts` — R5 (T10339) ' +
+      'consumer of the ADR-056 D1-D6 substrate.',
+  );
+  lines.push(
+    '- `cleo doctor --audit-invariants` — R6 (T10340) per-invariant ' +
+      'enforcement audit.',
+  );
+  lines.push('');
+
+  return `${lines.join('\n')}`;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────
+
+async function main() {
+  const { INVARIANTS_REGISTRY } = await loadRegistry();
+  const rendered = render(INVARIANTS_REGISTRY);
+
+  if (MODE_STDOUT) {
+    process.stdout.write(rendered);
+    return;
+  }
+
+  if (MODE_CHECK) {
+    if (!existsSync(OUTPUT_FILE)) {
+      console.error(
+        `render-invariants-docs: --check failed — ${toPosixRel(REPO_ROOT, OUTPUT_FILE)} does not exist.\n` +
+          '  Run `pnpm render:invariants` to generate it.',
+      );
+      process.exit(1);
+    }
+    const onDisk = readFileSync(OUTPUT_FILE, 'utf8');
+    if (onDisk === rendered) {
+      const entries = Object.keys(INVARIANTS_REGISTRY).length;
+      console.info(
+        `render-invariants-docs: --check passed (${entries} entries rendered, file matches).`,
+      );
+      return;
+    }
+    console.error(
+      `render-invariants-docs: --check failed — ${toPosixRel(REPO_ROOT, OUTPUT_FILE)} is out of sync with the registry.\n` +
+        '  Run `pnpm render:invariants` and commit the result.',
+    );
+    // Best-effort diff hint: print line-count delta so CI logs surface the
+    // scale of the drift even without piping into `git diff`.
+    const onDiskLines = onDisk.split('\n').length;
+    const renderedLines = rendered.split('\n').length;
+    console.error(
+      `  On-disk:   ${onDiskLines} lines\n  Rendered:  ${renderedLines} lines`,
+    );
+    process.exit(1);
+  }
+
+  mkdirSync(dirname(OUTPUT_FILE), { recursive: true });
+  writeFileSync(OUTPUT_FILE, rendered, 'utf8');
+  const entries = Object.keys(INVARIANTS_REGISTRY).length;
+  console.info(
+    `render-invariants-docs: wrote ${entries} entries to ${toPosixRel(REPO_ROOT, OUTPUT_FILE)}`,
+  );
+}
+
+main().catch((err) => {
+  console.error('render-invariants-docs: failed', err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Saga T10326 SG-SUBSTRATE-RECONCILIATION · Epic T10327 E-INVARIANT-REGISTRY-SSOT · **R8**.

Builds `packages/contracts/scripts/render-invariants-docs.mjs` to emit the canonical `docs/registry/INVARIANTS.md` page from the central `INVARIANTS_REGISTRY` SSoT at `packages/contracts/src/invariants/`. Editing the registry is now the only way to change the docs page.

- Renders **28 entries** (ADR-073 I1-I8 + ADR-056 D1-D6 + ADR-070 ORC-001..ORC-014).
- Markdown table per ADR with columns: `Code | Name | Severity | RuntimeGate | Tests | Description`.
- `AUTO-GENERATED — DO NOT EDIT` banner + cross-link back to the script and SSoT module.
- Deterministic — running twice yields byte-identical output (verified locally via `md5sum`).
- Wires `pnpm render:invariants` (write) and `pnpm render:invariants:check` (drift detection).

## CI Gate

New `Invariants Docs Render Drift (T10342)` job re-renders + diffs against the committed file. Drift fails CI with a remediation hint. Tested locally: appending one line to the rendered file → exit 1 with line-count delta.

## Test Plan

- [x] `pnpm render:invariants` produces 28 entries, `pnpm render:invariants:check` passes
- [x] Determinism: two consecutive runs produce byte-identical output (md5sum match)
- [x] Drift detection: appending a line to `docs/registry/INVARIANTS.md` makes `--check` exit 1
- [x] Full `pnpm run build` green
- [x] `pnpm biome check .` green
- [ ] CI green on this PR (new gate + all 30+ existing gates)

Closes T10342
Saga: T10326
Epic: T10327