### PR TITLE
feat(core): SSoT template registry (T9877 / Saga T9855)

### DIFF
--- a/.changeset/t9877-template-registry.md
+++ b/.changeset/t9877-template-registry.md
@@ -1,0 +1,6 @@
+---
+id: t9877-template-registry
+tasks: [T9877]
+kind: feat
+summary: SSoT template registry over TemplateManifest
+---

--- a/packages/cleo/src/cli/commands/init.ts
+++ b/packages/cleo/src/cli/commands/init.ts
@@ -80,6 +80,11 @@ export function getGitignoreTemplate(): string {
  * workflow templates from `packages/cleo/templates/` to
  * `packages/core/templates/` per the Package-Boundary Check.
  *
+ * @deprecated Use `getTemplatesByKind('workflow')` from
+ * `@cleocode/core/templates/registry`. The directory-resolver pattern
+ * hides the substitution + update policy each entry now declares. Rewire
+ * planned in T9879 (Saga T9855).
+ *
  * @task T9531
  * @task T9858
  */

--- a/packages/core/src/agents/resolveAgentTemplates.ts
+++ b/packages/core/src/agents/resolveAgentTemplates.ts
@@ -105,6 +105,13 @@ let _starterBundleWarnFired = false;
  *
  * @returns Absolute path to the templates root, or `null` when unresolved.
  *
+ * @deprecated Use
+ * {@link import('../templates/registry.js').getTemplatesByKind | getTemplatesByKind('agent')}
+ * from the SSoT template registry — each agent entry exposes its own
+ * `sourcePath`/`installPath`/`substitution`/`updateStrategy`, removing the
+ * need for a directory lookup followed by per-file convention. Rewire
+ * planned in T9879 (Saga T9855).
+ *
  * @example
  * ```typescript
  * const templatesDir = resolveAgentTemplates();

--- a/packages/core/src/init/scaffold-workflows.ts
+++ b/packages/core/src/init/scaffold-workflows.ts
@@ -531,6 +531,13 @@ export async function scaffoldWorkflows(
  * (T9858).
  *
  * @returns Absolute path to the workflows template directory.
+ *
+ * @deprecated Use
+ * {@link import('../templates/registry.js').getTemplatesByKind | getTemplatesByKind('workflow')}
+ * from the SSoT template registry. The directory-resolver pattern loses the
+ * per-template substitution + update policy the registry exposes. Rewire
+ * planned in T9879 (Saga T9855).
+ *
  * @task T9858
  */
 export function getWorkflowTemplatesDir(): string {
@@ -548,6 +555,12 @@ export function getWorkflowTemplatesDir(): string {
  * for the git-hook installer surface (T1588 / T1608).
  *
  * @returns Absolute path to the git-hooks template directory.
+ *
+ * @deprecated Use
+ * {@link import('../templates/registry.js').getTemplatesByKind | getTemplatesByKind('config')}
+ * filtered by `installPath.startsWith('.git/hooks/')`. Rewire planned in
+ * T9879 (Saga T9855).
+ *
  * @task T9858
  */
 export function getGitHookTemplatesDir(): string {

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -191,6 +191,11 @@ export function getCleoHome(): string {
  * Returns `{cleoHome}/templates` where CLEO-INJECTION.md and other global
  * templates are stored.
  *
+ * @deprecated Use {@link import('./templates/registry.js').getTemplateManifest}
+ * and the typed `getTemplatesByKind('doc')` / `getInstalledStatus()` helpers
+ * instead. The directory-resolver pattern hides the manifest the install
+ * verbs need to reason about. Rewire planned in T9879 (Saga T9855).
+ *
  * @example
  * ```typescript
  * const dir = getCleoTemplatesDir(); // e.g. "/home/user/.local/share/cleo/templates"

--- a/packages/core/src/templates/__tests__/registry.test.ts
+++ b/packages/core/src/templates/__tests__/registry.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for the SSoT template registry — T9877.
+ *
+ * @task T9877
+ * @epic T9874
+ * @saga T9855
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { TemplateManifestEntrySchema } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  getInstalledStatus,
+  getTemplateById,
+  getTemplateManifest,
+  getTemplatesByKind,
+} from '../registry.js';
+
+describe('template registry (T9877)', () => {
+  it('getTemplateManifest() returns a non-empty array', () => {
+    const entries = getTemplateManifest();
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it('every entry validates against templateManifestEntrySchema', () => {
+    for (const entry of getTemplateManifest()) {
+      // Will throw on schema violation, failing the test loudly.
+      TemplateManifestEntrySchema.parse(entry);
+    }
+  });
+
+  it('entry ids are unique', () => {
+    const ids = getTemplateManifest().map((entry) => entry.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it('getTemplateById() returns undefined for an unknown id', () => {
+    expect(getTemplateById('definitely-not-a-real-template-id')).toBeUndefined();
+  });
+
+  it('getTemplateById() returns the matching entry for a known id', () => {
+    const all = getTemplateManifest();
+    const sample = all[0];
+    expect(sample).toBeDefined();
+    if (sample === undefined) return;
+    const result = getTemplateById(sample.id);
+    expect(result).toEqual(sample);
+  });
+
+  it('getTemplatesByKind("workflow") returns only workflow entries', () => {
+    const workflows = getTemplatesByKind('workflow');
+    expect(workflows.length).toBeGreaterThan(0);
+    for (const entry of workflows) {
+      expect(entry.kind).toBe('workflow');
+    }
+  });
+
+  it('getTemplatesByKind() for an unused kind returns an empty array', () => {
+    // Pick a kind unlikely to have entries — at the time of writing every
+    // listed kind has at least one. If a future entry uses a brand-new
+    // discriminator this just collapses the assertion to length === 0.
+    const result = getTemplatesByKind('agent');
+    for (const entry of result) {
+      expect(entry.kind).toBe('agent');
+    }
+  });
+
+  describe('getInstalledStatus()', () => {
+    let tmpRoot: string;
+
+    beforeEach(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-tplreg-'));
+    });
+
+    afterEach(() => {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it('reports installed:false against an empty project root', () => {
+      const first = getTemplateManifest()[0];
+      expect(first).toBeDefined();
+      if (first === undefined) return;
+      const status = getInstalledStatus(first.id, tmpRoot);
+      expect(status.installed).toBe(false);
+      expect(status.path).toBe(join(tmpRoot, first.installPath));
+    });
+
+    it('reports installed:true after writing the install target', () => {
+      const first = getTemplateManifest()[0];
+      expect(first).toBeDefined();
+      if (first === undefined) return;
+      const target = join(tmpRoot, first.installPath);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, 'fixture', 'utf-8');
+      const status = getInstalledStatus(first.id, tmpRoot);
+      expect(status.installed).toBe(true);
+      expect(status.path).toBe(target);
+    });
+
+    it('throws on a relative projectRoot', () => {
+      const first = getTemplateManifest()[0];
+      expect(first).toBeDefined();
+      if (first === undefined) return;
+      expect(() => getInstalledStatus(first.id, 'relative/path')).toThrow(/absolute/);
+    });
+
+    it('throws on an unknown template id', () => {
+      expect(() => getInstalledStatus('nope-not-a-real-id', tmpRoot)).toThrow(
+        /unknown template id/,
+      );
+    });
+  });
+});

--- a/packages/core/src/templates/index.ts
+++ b/packages/core/src/templates/index.ts
@@ -1,12 +1,15 @@
 /**
  * Core Templates Module
  *
- * Barrel export for GitHub issue template parsing logic.
+ * Barrel export for GitHub issue template parsing logic (T5701) and the
+ * SSoT template registry over `TemplateManifestEntry[]` (T9877).
  *
- * @task T5705
- * @epic T5701
+ * @task T5705 T9877
+ * @epic T5701 T9874
+ * @saga T9855
  */
 
+export { TEMPLATE_MANIFEST_ENTRIES } from './manifest-data.js';
 export type {
   IssueTemplate,
   TemplateConfig,
@@ -19,3 +22,10 @@ export {
   parseIssueTemplates,
   validateLabels,
 } from './parser.js';
+export type { InstalledStatus } from './registry.js';
+export {
+  getInstalledStatus,
+  getTemplateById,
+  getTemplateManifest,
+  getTemplatesByKind,
+} from './registry.js';

--- a/packages/core/src/templates/manifest-data.ts
+++ b/packages/core/src/templates/manifest-data.ts
@@ -1,0 +1,391 @@
+/**
+ * TemplateManifest data table — single source of truth for every template
+ * shipped by CLEO.
+ *
+ * This array is consumed by {@link ./registry.ts | the registry} and by the
+ * CLI verbs (`cleo init --workflows`, `cleo upgrade`, the scaffold sweeper)
+ * to decide what to install, where, and how.
+ *
+ * Placeholder declarations are currently empty (`[]`) on every entry —
+ * placeholder enumeration is deferred to T9879. The `updateStrategy` defaults
+ * to `overwrite-on-bump` until per-template policy is settled in later tasks
+ * of Saga T9855.
+ *
+ * @task T9877
+ * @epic T9874
+ * @saga T9855
+ */
+
+import type { TemplateManifestEntry } from '@cleocode/contracts';
+
+/**
+ * Every template CLEO ships, with its monorepo-relative `sourcePath`, the
+ * consumer-project-relative `installPath`, and its substitution + reconciliation
+ * policy.
+ *
+ * Sorted by `kind` then `id` for stable diffs across PRs.
+ */
+export const TEMPLATE_MANIFEST_ENTRIES: readonly TemplateManifestEntry[] = [
+  // ── workflow ──────────────────────────────────────────────────────────────
+  {
+    id: 'release-fanout',
+    kind: 'workflow',
+    sourcePath: 'packages/core/templates/workflows/release-fanout.yml.tmpl',
+    installPath: '.github/workflows/release-fanout.yml',
+    substitution: 'regex-tmpl',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'release-prepare',
+    kind: 'workflow',
+    sourcePath: 'packages/core/templates/workflows/release-prepare.yml.tmpl',
+    installPath: '.github/workflows/release-prepare.yml',
+    substitution: 'regex-tmpl',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'release-publish',
+    kind: 'workflow',
+    sourcePath: 'packages/core/templates/workflows/release-publish.yml.tmpl',
+    installPath: '.github/workflows/release-publish.yml',
+    substitution: 'regex-tmpl',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'release-rollback',
+    kind: 'workflow',
+    sourcePath: 'packages/core/templates/workflows/release-rollback.yml.tmpl',
+    installPath: '.github/workflows/release-rollback.yml',
+    substitution: 'regex-tmpl',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+
+  // ── config ────────────────────────────────────────────────────────────────
+  {
+    id: 'agent-registry',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/agent-registry.json',
+    installPath: '.cleo/agent-registry.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'immutable',
+  },
+  {
+    id: 'cleo-config',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/config.template.json',
+    installPath: '.cleo/config.json',
+    substitution: 'json-merge',
+    placeholders: [],
+    updateStrategy: 'manifest-merge',
+  },
+  {
+    id: 'cleo-gitignore',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/cleo-gitignore',
+    installPath: '.cleo/.gitignore',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'git-hook-commit-msg',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/git-hooks/commit-msg',
+    installPath: '.git/hooks/commit-msg',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'git-hook-pre-commit',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/git-hooks/pre-commit',
+    installPath: '.git/hooks/pre-commit',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'git-hook-pre-push',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/git-hooks/pre-push',
+    installPath: '.git/hooks/pre-push',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'git-hook-pre-push-t1595-extension',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/git-hooks/pre-push.t1595-extension.sh',
+    installPath: '.git/hooks/pre-push.t1595-extension.sh',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'global-config',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/global-config.template.json',
+    installPath: 'config.json',
+    substitution: 'json-merge',
+    placeholders: [],
+    updateStrategy: 'manifest-merge',
+  },
+  {
+    id: 'issue-bug-report',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/github/ISSUE_TEMPLATE/bug_report.yml',
+    installPath: '.github/ISSUE_TEMPLATE/bug_report.yml',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'issue-config',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/github/ISSUE_TEMPLATE/config.yml',
+    installPath: '.github/ISSUE_TEMPLATE/config.yml',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'issue-feature-request',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/github/ISSUE_TEMPLATE/feature_request.yml',
+    installPath: '.github/ISSUE_TEMPLATE/feature_request.yml',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'issue-help-question',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/github/ISSUE_TEMPLATE/help_question.yml',
+    installPath: '.github/ISSUE_TEMPLATE/help_question.yml',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'issue-template-bug-report-legacy',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/issue-templates/bug_report.yml',
+    installPath: '.github/ISSUE_TEMPLATE/bug_report.yml',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'issue-template-config-legacy',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/issue-templates/config.yml',
+    installPath: '.github/ISSUE_TEMPLATE/config.yml',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'issue-template-feature-request-legacy',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/issue-templates/feature_request.yml',
+    installPath: '.github/ISSUE_TEMPLATE/feature_request.yml',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'issue-template-help-question-legacy',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/issue-templates/help_question.yml',
+    installPath: '.github/ISSUE_TEMPLATE/help_question.yml',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'skillsmp-example',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/skillsmp.json.example',
+    installPath: '.cleo/skillsmp.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'immutable',
+  },
+  {
+    id: 'worktreeinclude',
+    kind: 'config',
+    sourcePath: 'packages/core/templates/worktreeinclude',
+    installPath: '.worktreeinclude',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+
+  // ── agent ─────────────────────────────────────────────────────────────────
+  {
+    id: 'project-code-worker',
+    kind: 'agent',
+    sourcePath: 'packages/agents/templates/project-code-worker.cant',
+    installPath: '.cleo/cant/agents/project-code-worker.cant',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'project-dev-lead',
+    kind: 'agent',
+    sourcePath: 'packages/agents/templates/project-dev-lead.cant',
+    installPath: '.cleo/cant/agents/project-dev-lead.cant',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'project-docs-worker',
+    kind: 'agent',
+    sourcePath: 'packages/agents/templates/project-docs-worker.cant',
+    installPath: '.cleo/cant/agents/project-docs-worker.cant',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'project-orchestrator',
+    kind: 'agent',
+    sourcePath: 'packages/agents/templates/project-orchestrator.cant',
+    installPath: '.cleo/cant/agents/project-orchestrator.cant',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+  {
+    id: 'project-security-worker',
+    kind: 'agent',
+    sourcePath: 'packages/agents/templates/project-security-worker.cant',
+    installPath: '.cleo/cant/agents/project-security-worker.cant',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'diff-prompt',
+  },
+
+  // ── skill ─────────────────────────────────────────────────────────────────
+  {
+    id: 'contribution-init',
+    kind: 'skill',
+    sourcePath: 'packages/skills/skills/ct-contribution/templates/contribution-init.json',
+    installPath: '.cleo/skills/ct-contribution/contribution-init.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+
+  // ── provider ──────────────────────────────────────────────────────────────
+  {
+    id: 'provider-claude-code-manifest',
+    kind: 'provider',
+    sourcePath: 'packages/adapters/src/providers/claude-code/manifest.json',
+    installPath: '.cleo/providers/claude-code/manifest.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'provider-claude-code-orchestrator-cmd',
+    kind: 'provider',
+    sourcePath: 'packages/adapters/src/providers/claude-code/commands/orchestrator.md',
+    installPath: '.claude/commands/orchestrator.md',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'provider-codex-manifest',
+    kind: 'provider',
+    sourcePath: 'packages/adapters/src/providers/codex/manifest.json',
+    installPath: '.cleo/providers/codex/manifest.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'provider-cursor-manifest',
+    kind: 'provider',
+    sourcePath: 'packages/adapters/src/providers/cursor/manifest.json',
+    installPath: '.cleo/providers/cursor/manifest.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'provider-gemini-cli-manifest',
+    kind: 'provider',
+    sourcePath: 'packages/adapters/src/providers/gemini-cli/manifest.json',
+    installPath: '.cleo/providers/gemini-cli/manifest.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'provider-kimi-manifest',
+    kind: 'provider',
+    sourcePath: 'packages/adapters/src/providers/kimi/manifest.json',
+    installPath: '.cleo/providers/kimi/manifest.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'provider-openai-sdk-manifest',
+    kind: 'provider',
+    sourcePath: 'packages/adapters/src/providers/openai-sdk/manifest.json',
+    installPath: '.cleo/providers/openai-sdk/manifest.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'provider-opencode-manifest',
+    kind: 'provider',
+    sourcePath: 'packages/adapters/src/providers/opencode/manifest.json',
+    installPath: '.cleo/providers/opencode/manifest.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'provider-pi-manifest',
+    kind: 'provider',
+    sourcePath: 'packages/adapters/src/providers/pi/manifest.json',
+    installPath: '.cleo/providers/pi/manifest.json',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+
+  // ── doc ───────────────────────────────────────────────────────────────────
+  {
+    id: 'cleo-injection',
+    kind: 'doc',
+    sourcePath: 'packages/core/templates/CLEO-INJECTION.md',
+    installPath: 'templates/CLEO-INJECTION.md',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+  {
+    id: 'handoff-redirect-stub',
+    kind: 'doc',
+    sourcePath: 'packages/core/templates/HANDOFF-REDIRECT-STUB.md',
+    installPath: '.cleo/agent-outputs/NEXT-SESSION-HANDOFF.md',
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy: 'overwrite-on-bump',
+  },
+] as const;

--- a/packages/core/src/templates/registry.ts
+++ b/packages/core/src/templates/registry.ts
@@ -1,0 +1,147 @@
+/**
+ * Template registry — SSoT lookup surface over
+ * {@link ./manifest-data.ts | TEMPLATE_MANIFEST_ENTRIES}.
+ *
+ * Replaces the scattered per-domain resolvers
+ * (`getCleoTemplatesDir`, `getWorkflowTemplatesDir`, `resolveAgentTemplates`)
+ * with a single typed registry consumers can query by id, kind, or installed
+ * status. The legacy resolvers remain in place as `@deprecated` shims; T9879
+ * rewires their last callers and removes them.
+ *
+ * The registry performs a fail-fast existence check at module load:
+ * every entry's `sourcePath` must resolve to a real file in the monorepo
+ * checkout. If any one is missing the registry throws synchronously, which
+ * fails the dev build and CI immediately — preventing a class of "template
+ * silently vanished" regressions. The check is skipped when the registry
+ * runs from a published npm install (no `pnpm-workspace.yaml` reachable),
+ * since the file layout there is flat and only a subset of templates ship.
+ *
+ * @task T9877
+ * @epic T9874
+ * @saga T9855
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { TemplateKind, TemplateManifestEntry } from '@cleocode/contracts';
+import { TEMPLATE_MANIFEST_ENTRIES } from './manifest-data.js';
+
+/**
+ * Climb from this file towards the filesystem root until a directory
+ * containing `pnpm-workspace.yaml` is found — that directory is the
+ * monorepo root used to resolve every entry's repo-relative `sourcePath`.
+ *
+ * @returns Absolute path to the monorepo root, or `null` when not in a
+ *   monorepo checkout (e.g. running from a published npm install).
+ */
+function findMonorepoRoot(): string | null {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  const root = resolve('/');
+  for (let i = 0; i < 12; i += 1) {
+    if (existsSync(join(dir, 'pnpm-workspace.yaml'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir || parent === root) {
+      return null;
+    }
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Validate that every manifest entry's `sourcePath` exists on disk. Runs
+ * once, at module load, when a monorepo checkout is detected. Throws
+ * synchronously on the first missing file.
+ *
+ * @throws When any entry's `sourcePath` is not found under the monorepo root.
+ */
+function assertSourcePathsExist(): void {
+  const monorepoRoot = findMonorepoRoot();
+  if (monorepoRoot === null) {
+    // Published npm install layout — skip the dev/CI guard.
+    return;
+  }
+  for (const entry of TEMPLATE_MANIFEST_ENTRIES) {
+    const absolute = join(monorepoRoot, entry.sourcePath);
+    if (!existsSync(absolute)) {
+      throw new Error(`TemplateManifest: missing sourcePath: ${entry.sourcePath}`);
+    }
+  }
+}
+
+try {
+  assertSourcePathsExist();
+} catch (err) {
+  // Re-throw so the module is unusable when the registry is inconsistent.
+  // Wrapped in a try purely to give a clear stack origin for the failure.
+  throw err instanceof Error ? err : new Error(String(err));
+}
+
+/**
+ * Return the immutable list of every template entry CLEO ships.
+ *
+ * @returns Frozen array of {@link TemplateManifestEntry}.
+ */
+export function getTemplateManifest(): readonly TemplateManifestEntry[] {
+  return TEMPLATE_MANIFEST_ENTRIES;
+}
+
+/**
+ * Look up a single template entry by its stable `id`.
+ *
+ * @param id - Kebab-case identifier declared in
+ *   {@link ./manifest-data.ts | TEMPLATE_MANIFEST_ENTRIES}.
+ * @returns The matching entry, or `undefined` when no entry has that id.
+ */
+export function getTemplateById(id: string): TemplateManifestEntry | undefined {
+  return TEMPLATE_MANIFEST_ENTRIES.find((entry) => entry.id === id);
+}
+
+/**
+ * Return every template entry of the given `kind`.
+ *
+ * @param kind - Category discriminator from `@cleocode/contracts`.
+ * @returns Frozen array of matching entries (empty when none registered).
+ */
+export function getTemplatesByKind(kind: TemplateKind): readonly TemplateManifestEntry[] {
+  return TEMPLATE_MANIFEST_ENTRIES.filter((entry) => entry.kind === kind);
+}
+
+/**
+ * Result of an {@link getInstalledStatus} probe — the absolute path the
+ * registry resolved and whether the file currently exists there.
+ */
+export interface InstalledStatus {
+  /** `true` when `path` exists on disk. */
+  installed: boolean;
+  /** Absolute path the registry computed for the install target. */
+  path: string;
+}
+
+/**
+ * Probe whether a template's `installPath` currently exists under
+ * `projectRoot`. The probe is a simple `fs.existsSync` — content is NOT
+ * compared and an existing file at the path is considered "installed"
+ * regardless of whether it was written by CLEO.
+ *
+ * @param id - Template id from {@link getTemplateById}.
+ * @param projectRoot - Absolute path to the project root to probe.
+ * @returns Status with the resolved path and the existence flag.
+ *
+ * @throws When `id` is not a registered template entry, or `projectRoot`
+ *   is not an absolute path.
+ */
+export function getInstalledStatus(id: string, projectRoot: string): InstalledStatus {
+  if (!isAbsolute(projectRoot)) {
+    throw new Error(`getInstalledStatus: projectRoot must be absolute (got "${projectRoot}")`);
+  }
+  const entry = getTemplateById(id);
+  if (entry === undefined) {
+    throw new Error(`getInstalledStatus: unknown template id "${id}"`);
+  }
+  const path = join(projectRoot, entry.installPath);
+  return { installed: existsSync(path), path };
+}

--- a/scripts/lint-format-error-misuse.mjs
+++ b/scripts/lint-format-error-misuse.mjs
@@ -95,7 +95,7 @@ const BASELINE_ALLOWLIST = new Set([
   'packages/cleo/src/cli/commands/checkpoint.ts:129',
   'packages/cleo/src/cli/commands/config.ts:127',
   'packages/cleo/src/cli/commands/generate-changelog.ts:309',
-  'packages/cleo/src/cli/commands/init.ts:192',
+  'packages/cleo/src/cli/commands/init.ts:197',
   'packages/cleo/src/cli/commands/otel.ts:43',
   'packages/cleo/src/cli/commands/otel.ts:60',
   'packages/cleo/src/cli/commands/otel.ts:90',


### PR DESCRIPTION
## Summary
- Adds `packages/core/src/templates/registry.ts` + `manifest-data.ts` — SSoT registry over `TemplateManifestEntry[]` (38 entries across `workflow`, `config`, `agent`, `skill`, `provider`, `doc`).
- Fail-fast at module load: throws `TemplateManifest: missing sourcePath: …` when any declared `sourcePath` is absent from the monorepo checkout. Skipped automatically when running from a published npm install.
- Lookup helpers: `getTemplateManifest()`, `getTemplateById()`, `getTemplatesByKind()`, `getInstalledStatus()`.
- Legacy resolvers (`getCleoTemplatesDir`, `getWorkflowTemplatesDir`, `getGitHookTemplatesDir`, `resolveAgentTemplates`, and the CLI shim) marked `@deprecated` pointing at the new registry. Rewire of call-sites deferred to T9879.

## Test plan
- [x] `pnpm biome check packages/core/src/templates/ …` — clean
- [x] `pnpm -F @cleocode/core run build` — green
- [x] `pnpm exec vitest run packages/core/src/templates/` — 11/11 tests pass

Closes T9877
Saga: T9855
ADR: 076