### PR TITLE
feat(core): SSoT config registry / resolveCleoConfig (T9878 / Saga T9855)

### DIFF
--- a/.changeset/t9878-config-registry.md
+++ b/.changeset/t9878-config-registry.md
@@ -1,0 +1,6 @@
+---
+id: t9878-config-registry
+tasks: [T9878]
+kind: feat
+summary: feat(core): resolveCleoConfig + ConfigManifest registry with precedence chain (T9878 / Saga T9855)
+---

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -218,6 +218,10 @@ function parseEnvValue(value: string): unknown {
 /**
  * Load and merge configuration from all sources.
  * Priority: defaults < global config < project config < environment vars
+ *
+ * @deprecated Use `resolveCleoConfig` from `@cleocode/core/config/registry` instead.
+ *   The new resolver is driven by the ConfigManifest contract (T9876) and is the
+ *   SSoT for cascade resolution. Tracked for rewire under T9879.
  */
 export async function loadConfig(cwd?: string): Promise<CleoConfig> {
   // Start with defaults
@@ -258,6 +262,11 @@ export async function loadConfig(cwd?: string): Promise<CleoConfig> {
 /**
  * Get a single config value with source tracking.
  * Returns the value and which source it came from.
+ *
+ * @deprecated Use `getConfigValue` from `@cleocode/core/config/registry` instead.
+ *   The registry helper resolves over the ConfigManifest cascade (T9876). The
+ *   ResolvedValue source-tracking shape is being reconsidered under T9879 —
+ *   callers that need provenance should follow that thread.
  */
 export async function getConfigValue<T>(path: string, cwd?: string): Promise<ResolvedValue<T>> {
   // Check environment variables first
@@ -297,6 +306,9 @@ export async function getConfigValue<T>(path: string, cwd?: string): Promise<Res
  * Get a raw config value from the project config file only (no cascade).
  * Returns undefined if the key is not found.
  * Used by the engine layer for simple key lookups without source tracking.
+ *
+ * @deprecated Use `getConfigValue` from `@cleocode/core/config/registry` with
+ *   `scope: 'project'` instead. Tracked for rewire under T9879.
  * @task T4789
  */
 export async function getRawConfigValue(key: string, cwd?: string): Promise<unknown> {
@@ -312,6 +324,10 @@ export async function getRawConfigValue(key: string, cwd?: string): Promise<unkn
 /**
  * Get the full raw project config (no cascade).
  * Returns null if no config file exists.
+ *
+ * @deprecated Use `resolveCleoConfig` from `@cleocode/core/config/registry`
+ *   with `scope: 'project'` instead. Returns `{}` for missing files rather
+ *   than `null`. Tracked for rewire under T9879.
  * @task T4789
  */
 export async function getRawConfig(cwd?: string): Promise<Record<string, unknown> | null> {

--- a/packages/core/src/config/__tests__/registry.test.ts
+++ b/packages/core/src/config/__tests__/registry.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for the SSoT config registry — `resolveCleoConfig` + helpers.
+ *
+ * Uses a temporary XDG_DATA_HOME to isolate the global `~/.cleo/config.json`
+ * path resolved by `@cleocode/paths.getCleoHome()`, and a per-test temp
+ * project root for the project-scoped cascade entries.
+ *
+ * @task T9878
+ * @saga T9855
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CLEO_CONFIG_MANIFEST } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type ZodTypeAny, z } from 'zod';
+import {
+  checkDrift,
+  getConfigValue,
+  loadProjectContext,
+  loadProjectInfo,
+  resolveCleoConfig,
+  validateConfig,
+} from '../registry.js';
+
+// ---------------------------------------------------------------------------
+// Isolation harness
+// ---------------------------------------------------------------------------
+
+// vitest's per-fork setup (vitest.setup.ts) pins CLEO_HOME to a sandbox dir so
+// no test can clobber the developer's real ~/.cleo. To redirect the global
+// config file resolved by @cleocode/paths.getCleoHome(), we override
+// CLEO_HOME (which `createPlatformPathsResolver` honours as the data-dir
+// override) for the lifetime of each test, then restore it.
+const SAVED_CLEO_HOME = process.env['CLEO_HOME'];
+let cleoHomeRoot: string;
+let projectRoot: string;
+
+function uniqueDir(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+beforeEach(() => {
+  cleoHomeRoot = uniqueDir('cleo-registry-home');
+  projectRoot = uniqueDir('cleo-registry-proj');
+  mkdirSync(cleoHomeRoot, { recursive: true });
+  mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+  process.env['CLEO_HOME'] = cleoHomeRoot;
+});
+
+afterEach(() => {
+  if (SAVED_CLEO_HOME === undefined) {
+    delete process.env['CLEO_HOME'];
+  } else {
+    process.env['CLEO_HOME'] = SAVED_CLEO_HOME;
+  }
+  rmSync(cleoHomeRoot, { recursive: true, force: true });
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+function writeGlobalConfig(obj: unknown): void {
+  writeFileSync(join(cleoHomeRoot, 'config.json'), JSON.stringify(obj));
+}
+
+function writeProjectConfig(obj: unknown): void {
+  writeFileSync(join(projectRoot, '.cleo', 'config.json'), JSON.stringify(obj));
+}
+
+function writeProjectInfo(obj: unknown): void {
+  writeFileSync(join(projectRoot, '.cleo', 'project-info.json'), JSON.stringify(obj));
+}
+
+function writeProjectContext(obj: unknown): void {
+  writeFileSync(join(projectRoot, '.cleo', 'project-context.json'), JSON.stringify(obj));
+}
+
+// ---------------------------------------------------------------------------
+// resolveCleoConfig — precedence
+// ---------------------------------------------------------------------------
+
+describe('resolveCleoConfig', () => {
+  it('merged scope: project overrides global at every key path', async () => {
+    writeGlobalConfig({
+      release: { branchModel: 'feat-to-main', autoPush: true },
+      logging: { level: 'info' },
+      onlyGlobal: 'g',
+    });
+    writeProjectConfig({
+      release: { branchModel: 'release-branches' },
+      logging: { level: 'debug' },
+      onlyProject: 'p',
+    });
+    const merged = await resolveCleoConfig({ scope: 'merged', projectRoot });
+    expect(merged['release']).toEqual({ branchModel: 'release-branches', autoPush: true });
+    expect(merged['logging']).toEqual({ level: 'debug' });
+    expect(merged['onlyGlobal']).toBe('g');
+    expect(merged['onlyProject']).toBe('p');
+  });
+
+  it('global scope: returns only the global file unmodified', async () => {
+    writeGlobalConfig({ a: 1 });
+    writeProjectConfig({ a: 2, b: 3 });
+    const result = await resolveCleoConfig({ scope: 'global', projectRoot });
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('project scope: returns only the project file unmodified', async () => {
+    writeGlobalConfig({ a: 1 });
+    writeProjectConfig({ a: 2, b: 3 });
+    const result = await resolveCleoConfig({ scope: 'project', projectRoot });
+    expect(result).toEqual({ a: 2, b: 3 });
+  });
+
+  it('missing files: returns {} for both global and project on missing', async () => {
+    // no files written at all
+    expect(await resolveCleoConfig({ scope: 'global', projectRoot })).toEqual({});
+    expect(await resolveCleoConfig({ scope: 'project', projectRoot })).toEqual({});
+    expect(await resolveCleoConfig({ scope: 'merged', projectRoot })).toEqual({});
+  });
+
+  it('malformed JSON: throws with the file path embedded', async () => {
+    writeFileSync(join(projectRoot, '.cleo', 'config.json'), '{ this is not json');
+    await expect(resolveCleoConfig({ scope: 'project', projectRoot })).rejects.toThrow(
+      /Invalid JSON in .+\.cleo\/config\.json:/,
+    );
+  });
+
+  it('top-level non-object JSON: rejected with helpful message', async () => {
+    writeFileSync(join(projectRoot, '.cleo', 'config.json'), '[1, 2, 3]');
+    await expect(resolveCleoConfig({ scope: 'project', projectRoot })).rejects.toThrow(
+      /expected an object at top level/,
+    );
+  });
+
+  it('deep-merge does not mutate the source files on subsequent resolves', async () => {
+    writeGlobalConfig({ nested: { keep: true } });
+    writeProjectConfig({ nested: { add: 1 } });
+    const a = await resolveCleoConfig({ scope: 'merged', projectRoot });
+    const b = await resolveCleoConfig({ scope: 'merged', projectRoot });
+    expect(a).toEqual({ nested: { keep: true, add: 1 } });
+    expect(b).toEqual({ nested: { keep: true, add: 1 } });
+    // Mutating one result MUST not affect the other.
+    (a['nested'] as Record<string, unknown>)['add'] = 999;
+    expect((b['nested'] as Record<string, unknown>)['add']).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Metadata loaders
+// ---------------------------------------------------------------------------
+
+describe('metadata loaders', () => {
+  it('loadProjectInfo: returns null when absent', async () => {
+    expect(await loadProjectInfo(projectRoot)).toBeNull();
+  });
+
+  it('loadProjectInfo: returns parsed contents when present', async () => {
+    writeProjectInfo({ name: 'cleocode', version: '1.0.0' });
+    expect(await loadProjectInfo(projectRoot)).toEqual({ name: 'cleocode', version: '1.0.0' });
+  });
+
+  it('loadProjectContext: returns null when absent', async () => {
+    expect(await loadProjectContext(projectRoot)).toBeNull();
+  });
+
+  it('loadProjectContext: returns parsed contents when present', async () => {
+    writeProjectContext({ detectedAt: '2026-05-24T00:00:00Z', primaryType: 'node' });
+    expect(await loadProjectContext(projectRoot)).toEqual({
+      detectedAt: '2026-05-24T00:00:00Z',
+      primaryType: 'node',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getConfigValue
+// ---------------------------------------------------------------------------
+
+describe('getConfigValue', () => {
+  it('resolves a dotted key against the merged cascade by default', async () => {
+    writeGlobalConfig({ release: { branchModel: 'feat-to-main' } });
+    writeProjectConfig({ release: { branchModel: 'release-branches' } });
+    const v = await getConfigValue<string>('release.branchModel', { projectRoot });
+    expect(v).toBe('release-branches');
+  });
+
+  it('returns undefined for missing keys', async () => {
+    writeProjectConfig({ a: 1 });
+    expect(await getConfigValue('does.not.exist', { projectRoot })).toBeUndefined();
+  });
+
+  it('honours scope=global to bypass project overrides', async () => {
+    writeGlobalConfig({ x: 'g' });
+    writeProjectConfig({ x: 'p' });
+    expect(await getConfigValue('x', { scope: 'global', projectRoot })).toBe('g');
+    expect(await getConfigValue('x', { scope: 'project', projectRoot })).toBe('p');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateConfig
+// ---------------------------------------------------------------------------
+
+describe('validateConfig', () => {
+  it('returns ok=true when manifest has no attached schema', async () => {
+    writeProjectConfig({ anything: 'goes' });
+    // CLEO_CONFIG_MANIFEST.schema is undefined in the built-in entries.
+    expect(CLEO_CONFIG_MANIFEST.schema).toBeUndefined();
+    const result = await validateConfig('project', projectRoot);
+    expect(result).toEqual({ ok: true, issues: [] });
+  });
+
+  it('returns ok=true when the file does not exist', async () => {
+    const result = await validateConfig('project', projectRoot);
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('returns issues when a schema is attached and parse fails', async () => {
+    // Temporarily attach a schema to CLEO_CONFIG_MANIFEST for this test.
+    const originalSchema = CLEO_CONFIG_MANIFEST.schema;
+    const mutable = CLEO_CONFIG_MANIFEST as { schema?: ZodTypeAny | null };
+    mutable.schema = z.object({ requiredField: z.string() });
+    try {
+      writeProjectConfig({ wrongField: 1 });
+      const result = await validateConfig('project', projectRoot);
+      expect(result.ok).toBe(false);
+      expect(result.issues.length).toBeGreaterThan(0);
+      expect(result.issues[0]).toMatch(/requiredField/);
+    } finally {
+      mutable.schema = originalSchema;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkDrift — staleness gate
+// ---------------------------------------------------------------------------
+
+describe('checkDrift', () => {
+  it('staleness-gate: fresh detectedAt → no drift', async () => {
+    writeProjectContext({ detectedAt: new Date().toISOString() });
+    const result = await checkDrift('metadata', projectRoot);
+    expect(result.drift).toBe(false);
+  });
+
+  it('staleness-gate: detectedAt > 30 days old → drift', async () => {
+    const oldDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
+    writeProjectContext({ detectedAt: oldDate });
+    const result = await checkDrift('metadata', projectRoot);
+    expect(result.drift).toBe(true);
+    expect(result.reason).toMatch(/staleness-gate/);
+  });
+
+  it('staleness-gate: missing detectedAt → drift', async () => {
+    writeProjectContext({ noDetectedAt: true });
+    const result = await checkDrift('metadata', projectRoot);
+    expect(result.drift).toBe(true);
+    expect(result.reason).toMatch(/missing or non-string detectedAt/);
+  });
+
+  it('staleness-gate: missing file → no drift (consumer decides whether to scan)', async () => {
+    // no project-context.json written
+    const result = await checkDrift('metadata', projectRoot);
+    expect(result.drift).toBe(false);
+  });
+
+  it('schema-validate scope for project/global: no schema → no drift', async () => {
+    writeProjectConfig({ anything: 'goes' });
+    expect(await checkDrift('project', projectRoot)).toEqual({ drift: false });
+    expect(await checkDrift('global', projectRoot)).toEqual({ drift: false });
+  });
+});

--- a/packages/core/src/config/registry.ts
+++ b/packages/core/src/config/registry.ts
@@ -1,0 +1,461 @@
+/**
+ * SSoT config registry — `resolveCleoConfig` cascade resolver implementing the
+ * ConfigManifest contract from `@cleocode/contracts`.
+ *
+ * Precedence chain (higher wins):
+ * - `0`  — defaults / metadata baseline (NOT part of the merge chain)
+ * - `10` — `~/.cleo/config.json` (global)
+ * - `20` — `<projectRoot>/.cleo/config.json` (project)
+ *
+ * Metadata files (`project-info.json`, `project-context.json`) live on a
+ * separate channel and are surfaced through dedicated loaders — they are NEVER
+ * merged into the resolved CleoConfig.
+ *
+ * This module is pure JSON file IO. It does NOT open SQLite — the
+ * `DB Open Guard` SSoT contract (ADR-068) is preserved.
+ *
+ * Path resolution is delegated to `@cleocode/paths` (`getCleoHome`) per the
+ * Paths SSoT (T9802) — XDG / env-paths logic is NEVER hand-rolled here.
+ *
+ * @task T9878
+ * @saga T9855
+ * @adr 076
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  CLEO_CONFIG_MANIFEST,
+  CONFIG_MANIFEST_ENTRIES,
+  type ConfigManifestEntry,
+  GLOBAL_CLEO_CONFIG_MANIFEST,
+  PROJECT_CONTEXT_MANIFEST,
+  PROJECT_INFO_MANIFEST,
+} from '@cleocode/contracts';
+import { getCleoHome } from '@cleocode/paths';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Types
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Merged JSON shape of `.cleo/config.json`.
+ *
+ * Intentionally generic — the cascade resolver operates structurally and
+ * defers shape interpretation to the consumer. For typed reads, layer a Zod
+ * schema on top via {@link validateConfig} or the manifest's `schema` field.
+ *
+ * @public
+ */
+export type MergedConfig = { [key: string]: unknown };
+
+/**
+ * Read-only metadata channel for `.cleo/project-info.json`.
+ *
+ * @public
+ */
+export type ProjectInfo = Record<string, unknown>;
+
+/**
+ * Read-only metadata channel for `.cleo/project-context.json`.
+ *
+ * @public
+ */
+export type ProjectContext = Record<string, unknown>;
+
+/**
+ * Scope selector for {@link resolveCleoConfig} and {@link getConfigValue}.
+ *
+ * - `'global'`  — return ONLY the global file's contents (or `{}` if missing)
+ * - `'project'` — return ONLY the project file's contents (or `{}` if missing)
+ * - `'merged'`  — return the deep-merge of `{ ...defaults, ...global, ...project }`
+ *
+ * @public
+ */
+export type ResolveScope = 'global' | 'project' | 'merged';
+
+/**
+ * Scope selector for {@link validateConfig}.
+ *
+ * @public
+ */
+export type ValidateScope = 'global' | 'project';
+
+/**
+ * Scope selector for {@link checkDrift}.
+ *
+ * The `'metadata'` value runs drift checks against the two metadata-channel
+ * entries (`project-info`, `project-context`) and aggregates the worst case.
+ *
+ * @public
+ */
+export type DriftScope = 'global' | 'project' | 'metadata';
+
+/**
+ * Result of {@link validateConfig}.
+ *
+ * @public
+ */
+export interface ValidateResult {
+  /** `true` IFF every gate passed (or no schema was configured). */
+  ok: boolean;
+  /** Human-readable issues. Empty when `ok === true`. */
+  issues: string[];
+}
+
+/**
+ * Result of {@link checkDrift}.
+ *
+ * @public
+ */
+export interface DriftResult {
+  /** `true` IFF drift was detected. */
+  drift: boolean;
+  /** Optional human-readable reason for the drift verdict. */
+  reason?: string;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Internal: path resolution + IO
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the absolute path to the global `.cleo/config.json` (XDG canonical).
+ */
+function resolveGlobalConfigPath(): string {
+  return join(getCleoHome(), 'config.json');
+}
+
+/**
+ * Resolve the absolute path to a project-scoped `.cleo/<file>`.
+ */
+function resolveProjectFilePath(projectRoot: string, fileName: string): string {
+  return join(projectRoot, '.cleo', fileName);
+}
+
+/**
+ * Read a JSON file and parse it.
+ *
+ * Returns `null` IFF the file does not exist (ENOENT). All other IO errors
+ * propagate. Malformed JSON throws an `Error` whose message embeds the file
+ * path so the caller can pinpoint the source.
+ */
+async function readJsonOrNull(path: string): Promise<Record<string, unknown> | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (err) {
+    if (isErrnoException(err) && err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`Invalid JSON in ${path}: expected an object at top level`);
+    }
+    return parsed as Record<string, unknown>;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new Error(`Invalid JSON in ${path}: ${err.message}`);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Narrow an unknown thrown value to NodeJS.ErrnoException.
+ */
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && typeof (err as NodeJS.ErrnoException).code === 'string';
+}
+
+/**
+ * Deep-merge `overlay` into `base` at every key path.
+ *
+ * Plain objects are merged recursively; arrays and primitives are replaced
+ * wholesale by the overlay. Cloning is done via `structuredClone` to ensure
+ * the inputs are never mutated.
+ */
+function deepMergeObjects(
+  base: Record<string, unknown>,
+  overlay: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = structuredClone(base);
+  for (const [key, overlayVal] of Object.entries(overlay)) {
+    const baseVal = out[key];
+    if (isPlainObject(baseVal) && isPlainObject(overlayVal)) {
+      out[key] = deepMergeObjects(baseVal, overlayVal);
+    } else {
+      out[key] = structuredClone(overlayVal);
+    }
+  }
+  return out;
+}
+
+/**
+ * Tight type-guard for "plain object" — excludes arrays and null.
+ */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Resolve a `.`-separated key path against a plain object.
+ */
+function getNestedValue(obj: Record<string, unknown>, key: string): unknown {
+  if (key === '') return obj;
+  const segments = key.split('.');
+  let cursor: unknown = obj;
+  for (const seg of segments) {
+    if (!isPlainObject(cursor)) return undefined;
+    cursor = cursor[seg];
+  }
+  return cursor;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Public API — resolveCleoConfig + metadata loaders
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the CleoConfig cascade for a project.
+ *
+ * Precedence (higher wins): defaults (0) → global (10) → project (20).
+ *
+ * @param opts.scope - Which cascade slice to return. `'merged'` applies the
+ *   full precedence chain; `'global'` and `'project'` return their respective
+ *   files unmodified (or `{}` when missing).
+ * @param opts.projectRoot - Absolute path to the project root (the directory
+ *   containing `.cleo/`).
+ * @returns A merged `MergedConfig` for `'merged'` scope, or the raw file
+ *   contents for `'global'` / `'project'` scopes.
+ * @throws When a present file contains malformed JSON; missing files are
+ *   silently treated as `{}`.
+ *
+ * @example
+ * ```typescript
+ * const cfg = await resolveCleoConfig({ scope: 'merged', projectRoot: '/my/proj' });
+ * ```
+ *
+ * @public
+ */
+export async function resolveCleoConfig(opts: {
+  scope: ResolveScope;
+  projectRoot: string;
+}): Promise<MergedConfig> {
+  const { scope, projectRoot } = opts;
+
+  if (scope === 'global') {
+    return (await readJsonOrNull(resolveGlobalConfigPath())) ?? {};
+  }
+  if (scope === 'project') {
+    return (
+      (await readJsonOrNull(
+        resolveProjectFilePath(projectRoot, CLEO_CONFIG_MANIFEST.path.replace('.cleo/', '')),
+      )) ?? {}
+    );
+  }
+
+  // scope === 'merged' — apply the cascade in ascending precedence order.
+  const sorted = [...CONFIG_MANIFEST_ENTRIES]
+    .filter((e) => e.scope === 'global' || e.scope === 'project')
+    .sort((a, b) => a.mergePrecedence - b.mergePrecedence);
+
+  let merged: Record<string, unknown> = {};
+  for (const entry of sorted) {
+    const fileContents = await loadEntryFile(entry, projectRoot);
+    if (fileContents !== null) {
+      merged = deepMergeObjects(merged, fileContents);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Resolve and read a single manifest entry's underlying file.
+ *
+ * Returns `null` for missing files. Path resolution honours the entry's
+ * scope: `'global'` uses `getCleoHome()`; `'project'` and `'metadata'` are
+ * relative to the project root's `.cleo/` directory.
+ */
+async function loadEntryFile(
+  entry: ConfigManifestEntry,
+  projectRoot: string,
+): Promise<Record<string, unknown> | null> {
+  if (entry.scope === 'global') {
+    return readJsonOrNull(resolveGlobalConfigPath());
+  }
+  const fileName = entry.path.replace(/^\.cleo\//, '');
+  return readJsonOrNull(resolveProjectFilePath(projectRoot, fileName));
+}
+
+/**
+ * Load `<projectRoot>/.cleo/project-info.json`.
+ *
+ * Metadata channel — NEVER merged into the cascade. Returns `null` when the
+ * file is absent.
+ *
+ * @public
+ */
+export async function loadProjectInfo(projectRoot: string): Promise<ProjectInfo | null> {
+  const fileName = PROJECT_INFO_MANIFEST.path.replace(/^\.cleo\//, '');
+  return readJsonOrNull(resolveProjectFilePath(projectRoot, fileName));
+}
+
+/**
+ * Load `<projectRoot>/.cleo/project-context.json`.
+ *
+ * Metadata channel — NEVER merged into the cascade. Returns `null` when the
+ * file is absent.
+ *
+ * @public
+ */
+export async function loadProjectContext(projectRoot: string): Promise<ProjectContext | null> {
+  const fileName = PROJECT_CONTEXT_MANIFEST.path.replace(/^\.cleo\//, '');
+  return readJsonOrNull(resolveProjectFilePath(projectRoot, fileName));
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Lookup helpers — getConfigValue, validateConfig, checkDrift
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Read a single value out of the resolved cascade by `.`-separated key path.
+ *
+ * @param key - Dot-separated key (e.g. `'release.branchModel'`).
+ * @param opts.scope - Cascade slice to read from. Defaults to `'merged'`.
+ * @param opts.projectRoot - Absolute path to the project root.
+ * @returns The resolved value, or `undefined` when the key is absent.
+ *
+ * @public
+ */
+export async function getConfigValue<T = unknown>(
+  key: string,
+  opts: { scope?: ResolveScope; projectRoot: string },
+): Promise<T | undefined> {
+  const scope = opts.scope ?? 'merged';
+  const resolved = await resolveCleoConfig({ scope, projectRoot: opts.projectRoot });
+  return getNestedValue(resolved, key) as T | undefined;
+}
+
+/**
+ * Validate a scoped config file against its manifest entry's `schema`.
+ *
+ * When the entry has no schema attached (`schema === null` or `undefined`),
+ * validation is a no-op and `{ ok: true, issues: [] }` is returned.
+ *
+ * @public
+ */
+export async function validateConfig(
+  scope: ValidateScope,
+  projectRoot: string,
+): Promise<ValidateResult> {
+  const entry = scope === 'global' ? GLOBAL_CLEO_CONFIG_MANIFEST : CLEO_CONFIG_MANIFEST;
+  return validateEntry(entry, projectRoot);
+}
+
+/**
+ * Validate a single manifest entry against its schema (if any).
+ */
+async function validateEntry(
+  entry: ConfigManifestEntry,
+  projectRoot: string,
+): Promise<ValidateResult> {
+  const contents = await loadEntryFile(entry, projectRoot);
+  if (contents === null) {
+    // Missing files are validation no-ops — schema cannot reject a non-existent file.
+    return { ok: true, issues: [] };
+  }
+  if (entry.schema == null) {
+    return { ok: true, issues: [] };
+  }
+  const parseResult = entry.schema.safeParse(contents);
+  if (parseResult.success) {
+    return { ok: true, issues: [] };
+  }
+  const issues = parseResult.error.issues.map(
+    (i) => `${i.path.length ? i.path.join('.') : '<root>'}: ${i.message}`,
+  );
+  return { ok: false, issues };
+}
+
+/**
+ * Staleness threshold for `project-context.json` (30 days, in ms).
+ */
+const PROJECT_CONTEXT_STALENESS_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Apply the manifest's drift-detection strategy to a scoped file.
+ *
+ * - `'global'` / `'project'` — runs the configured strategy against the
+ *   matching cascade entry.
+ * - `'metadata'` — runs strategies for BOTH metadata entries and returns the
+ *   first drift hit (worst-case semantics).
+ *
+ * Strategy map:
+ * - `'schema-validate'` → delegate to {@link validateConfig}
+ * - `'staleness-gate'`  → compare `detectedAt` against
+ *   {@link PROJECT_CONTEXT_STALENESS_MS}
+ * - `'value-diff'`      → noop for now; returns `{ drift: false }`
+ * - `'none'`            → noop; returns `{ drift: false }`
+ *
+ * @public
+ */
+export async function checkDrift(scope: DriftScope, projectRoot: string): Promise<DriftResult> {
+  if (scope === 'metadata') {
+    for (const entry of [PROJECT_INFO_MANIFEST, PROJECT_CONTEXT_MANIFEST]) {
+      const result = await checkEntryDrift(entry, projectRoot);
+      if (result.drift) return result;
+    }
+    return { drift: false };
+  }
+  const entry = scope === 'global' ? GLOBAL_CLEO_CONFIG_MANIFEST : CLEO_CONFIG_MANIFEST;
+  return checkEntryDrift(entry, projectRoot);
+}
+
+/**
+ * Apply one manifest entry's drift strategy. Internal.
+ */
+async function checkEntryDrift(
+  entry: ConfigManifestEntry,
+  projectRoot: string,
+): Promise<DriftResult> {
+  switch (entry.driftDetection) {
+    case 'schema-validate': {
+      const result = await validateEntry(entry, projectRoot);
+      if (result.ok) return { drift: false };
+      return { drift: true, reason: `schema-validate failed: ${result.issues.join('; ')}` };
+    }
+    case 'staleness-gate': {
+      const contents = await loadEntryFile(entry, projectRoot);
+      if (contents === null) {
+        // Missing metadata file is not drift; consumers decide whether to scan.
+        return { drift: false };
+      }
+      const detectedAtRaw = contents['detectedAt'];
+      if (typeof detectedAtRaw !== 'string') {
+        return { drift: true, reason: 'staleness-gate: missing or non-string detectedAt' };
+      }
+      const detectedAt = Date.parse(detectedAtRaw);
+      if (Number.isNaN(detectedAt)) {
+        return { drift: true, reason: `staleness-gate: unparseable detectedAt=${detectedAtRaw}` };
+      }
+      const ageMs = Date.now() - detectedAt;
+      if (ageMs > PROJECT_CONTEXT_STALENESS_MS) {
+        const days = Math.floor(ageMs / (24 * 60 * 60 * 1000));
+        return {
+          drift: true,
+          reason: `staleness-gate: detectedAt is ${days}d old (>30d threshold)`,
+        };
+      }
+      return { drift: false };
+    }
+    case 'value-diff':
+      // Reserved for future invariant tracking — see ConfigManifestEntry.defaults.
+      return { drift: false };
+    case 'none':
+      return { drift: false };
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `packages/core/src/config/registry.ts` implementing `resolveCleoConfig({scope, projectRoot})` over `ConfigManifestEntry[]` from `@cleocode/contracts` (T9876).
- Precedence chain: defaults (0) -> global (10) -> project (20). `'merged'` deep-merges with project overriding global at every key path; `'global'` / `'project'` return their respective files unmodified.
- Metadata loaders (`loadProjectInfo`, `loadProjectContext`) for `.cleo/project-info.json` + `.cleo/project-context.json` on a separate channel — NEVER merged into the cascade.
- Drift detection: `'schema-validate'` delegates to `validateConfig`; `'staleness-gate'` compares `detectedAt` against a 30-day threshold; `'value-diff'` and `'none'` are no-ops for now.
- Path resolution delegated to `@cleocode/paths.getCleoHome()` per the Paths SSoT (T9802) — no hand-rolled XDG logic.
- Pure JSON file IO. Does NOT open SQLite — DB Open Guard (ADR-068) preserved.
- Legacy resolvers in `packages/core/src/config.ts` (`loadConfig`, `getConfigValue`, `getRawConfigValue`, `getRawConfig`) marked `@deprecated` ahead of T9879 rewire. No call-site rewiring in this PR.

## Test plan
- [x] `pnpm biome check packages/core/src/config/ packages/core/src/config.ts` — clean
- [x] `pnpm -F @cleocode/core run build` — green via `tsc -b` (project references built)
- [x] `pnpm exec vitest run packages/core/src/config/` — 33/33 passing (22 new + 11 existing)
- [x] `CLEO_HOME` swap in beforeEach/afterEach isolates the global config file per test under `tmpdir`, restoring the vitest-fork pin after each case

Closes T9878
Saga: T9855
ADR: 076