### PR TITLE
feat(core): validateOperationInput SSoT (T9915 / Saga T9855)

### DIFF
--- a/.changeset/t9915-validate-operation-input.md
+++ b/.changeset/t9915-validate-operation-input.md
@@ -1,0 +1,6 @@
+---
+id: t9915-validate-operation-input
+tasks: [T9915]
+kind: feat
+summary: SSoT validateOperationInput over OperationInputContract via AJV (Saga T9855 / E7.2)
+---

--- a/packages/core/src/dispatch/__tests__/validation.test.ts
+++ b/packages/core/src/dispatch/__tests__/validation.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for {@link validateOperationInput} (T9915 / Saga T9855 / E7).
+ *
+ * Covers the seven AC fixtures called out in the task brief: valid input,
+ * missing-required, wrong-type, enum violation, deeply nested path
+ * normalisation, custom `x-fix-hint` override, and compiled-validator
+ * caching across calls.
+ *
+ * @task T9915
+ */
+
+import type { OperationInputContract } from '@cleocode/contracts';
+import { describe, expect, it, vi } from 'vitest';
+import { _resetValidationCache, validateOperationInput } from '../validation.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+interface CreateTaskInput {
+  title: string;
+  acceptance: string;
+}
+
+const createTaskContract: OperationInputContract<CreateTaskInput> = {
+  operation: 'tasks.create.v1',
+  schema: {
+    type: 'object',
+    required: ['title', 'acceptance'],
+    additionalProperties: false,
+    properties: {
+      title: { type: 'string', minLength: 1, maxLength: 200 },
+      acceptance: { type: 'string', minLength: 1 },
+    },
+  },
+  examples: [
+    {
+      name: 'minimal',
+      value: { title: 'Ship E7', acceptance: 'PR merged' },
+    },
+  ],
+};
+
+interface TaskWithStatus {
+  status: 'pending' | 'active' | 'done';
+}
+
+const statusContract: OperationInputContract<TaskWithStatus> = {
+  operation: 'tasks.status.v1',
+  schema: {
+    type: 'object',
+    required: ['status'],
+    properties: {
+      status: { type: 'string', enum: ['pending', 'active', 'done'] },
+    },
+  },
+  examples: [{ name: 'pending', value: { status: 'pending' } }],
+};
+
+interface NestedInput {
+  items: Array<{ title: string }>;
+}
+
+const nestedContract: OperationInputContract<NestedInput> = {
+  operation: 'tasks.nested.v1',
+  schema: {
+    type: 'object',
+    required: ['items'],
+    properties: {
+      items: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['title'],
+          properties: {
+            title: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+  examples: [{ name: 'one-item', value: { items: [{ title: 'a' }] } }],
+};
+
+interface HintInput {
+  email: string;
+}
+
+const hintContract: OperationInputContract<HintInput> = {
+  operation: 'users.create.v1',
+  schema: {
+    type: 'object',
+    required: ['email'],
+    properties: {
+      email: {
+        type: 'string',
+        minLength: 5,
+        'x-fix-hint': 'pass a fully-qualified email address (foo@bar.com)',
+      },
+    },
+  },
+  examples: [{ name: 'minimal', value: { email: 'a@b.io' } }],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('validateOperationInput', () => {
+  describe('success path', () => {
+    it('returns { ok: true, value } when input matches the schema', () => {
+      const result = validateOperationInput(createTaskContract, {
+        title: 'Ship validator',
+        acceptance: 'tests green',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual({
+          title: 'Ship validator',
+          acceptance: 'tests green',
+        });
+      }
+    });
+
+    it('narrows value to the contract generic T', () => {
+      const result = validateOperationInput(createTaskContract, {
+        title: 't',
+        acceptance: 'a',
+      });
+      if (result.ok) {
+        const checked: CreateTaskInput = result.value;
+        expect(checked.title).toBe('t');
+      } else {
+        throw new Error('expected ok');
+      }
+    });
+  });
+
+  describe('missing required field', () => {
+    it('emits E_VAL_REQUIRED with the missing field name in fix', () => {
+      const result = validateOperationInput(createTaskContract, { title: 'has title' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const required = result.errors.find((e) => e.errorCode === 'E_VAL_REQUIRED');
+        expect(required).toBeDefined();
+        expect(required?.errorCode).toBe('E_VAL_REQUIRED');
+        expect(required?.fix).toContain('acceptance');
+        expect(required?.path).toBe('/acceptance');
+        expect(required?.expected).toContain('acceptance');
+        expect(required?.received).toBe('undefined');
+      }
+    });
+  });
+
+  describe('wrong type', () => {
+    it('emits E_VAL_TYPE and a quotes-hint for strings', () => {
+      const result = validateOperationInput(createTaskContract, {
+        title: 123,
+        acceptance: 'ok',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const typeErr = result.errors.find((e) => e.errorCode === 'E_VAL_TYPE');
+        expect(typeErr).toBeDefined();
+        expect(typeErr?.path).toBe('/title');
+        expect(typeErr?.expected).toBe('string');
+        expect(typeErr?.fix).toBe('wrap value in quotes');
+        expect(typeErr?.received).toBe('number');
+      }
+    });
+  });
+
+  describe('enum violation', () => {
+    it('emits E_VAL_ENUM listing allowed values', () => {
+      const result = validateOperationInput(statusContract, { status: 'archived' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const enumErr = result.errors.find((e) => e.errorCode === 'E_VAL_ENUM');
+        expect(enumErr).toBeDefined();
+        expect(enumErr?.path).toBe('/status');
+        expect(enumErr?.expected).toMatch(/pending/);
+        expect(enumErr?.expected).toMatch(/active/);
+        expect(enumErr?.expected).toMatch(/done/);
+        expect(enumErr?.fix).toContain('pending');
+        expect(enumErr?.fix).toContain('active');
+        expect(enumErr?.fix).toContain('done');
+      }
+    });
+  });
+
+  describe('deeply nested error path', () => {
+    it('normalises /items/2/title style paths verbatim from instancePath', () => {
+      const result = validateOperationInput(nestedContract, {
+        items: [{ title: 'a' }, { title: 'b' }, { title: 99 }],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const typeErr = result.errors.find((e) => e.path === '/items/2/title');
+        expect(typeErr).toBeDefined();
+        expect(typeErr?.errorCode).toBe('E_VAL_TYPE');
+        expect(typeErr?.expected).toBe('string');
+      }
+    });
+
+    it('synthesises a child pointer for required-keyword errors on nested objects', () => {
+      const result = validateOperationInput(nestedContract, { items: [{}] });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const required = result.errors.find((e) => e.errorCode === 'E_VAL_REQUIRED');
+        expect(required).toBeDefined();
+        expect(required?.path).toBe('/items/0/title');
+      }
+    });
+  });
+
+  describe('custom x-fix-hint override', () => {
+    it('prefers x-fix-hint over the generic per-keyword fix', () => {
+      _resetValidationCache(); // ensure fresh compile picks up hint
+      const result = validateOperationInput(hintContract, { email: 'a' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const lenErr = result.errors.find((e) => e.errorCode === 'E_VAL_MINLENGTH');
+        expect(lenErr).toBeDefined();
+        expect(lenErr?.fix).toBe('pass a fully-qualified email address (foo@bar.com)');
+      }
+    });
+  });
+
+  describe('compiled-validator cache', () => {
+    it('compiles a contracts AJV validator exactly once across multiple calls', async () => {
+      _resetValidationCache();
+      const ajvMod = await import('ajv');
+      const AjvCtor =
+        (ajvMod.default as unknown as { default?: unknown }).default ?? ajvMod.default;
+      const compileSpy = vi.spyOn(
+        (AjvCtor as { prototype: { compile: () => unknown } }).prototype,
+        'compile',
+      );
+
+      const contract: OperationInputContract<{ x: number }> = {
+        operation: 'cache.test.v1',
+        schema: {
+          type: 'object',
+          required: ['x'],
+          properties: { x: { type: 'number' } },
+        },
+        examples: [{ name: 'one', value: { x: 1 } }],
+      };
+
+      const before = compileSpy.mock.calls.length;
+      validateOperationInput(contract, { x: 1 });
+      validateOperationInput(contract, { x: 2 });
+      validateOperationInput(contract, { x: 3 });
+      const after = compileSpy.mock.calls.length;
+
+      expect(after - before).toBe(1);
+      compileSpy.mockRestore();
+    });
+  });
+
+  describe('additionalProperties rejection', () => {
+    it('emits E_VAL_ADDITIONALPROPERTIES when extra fields are present', () => {
+      const result = validateOperationInput(createTaskContract, {
+        title: 't',
+        acceptance: 'a',
+        rogue: 1,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const extra = result.errors.find((e) => e.errorCode === 'E_VAL_ADDITIONALPROPERTIES');
+        expect(extra).toBeDefined();
+        expect(extra?.expected).toBe('no extra fields');
+        expect(extra?.fix).toContain('rogue');
+      }
+    });
+  });
+});

--- a/packages/core/src/dispatch/validation.ts
+++ b/packages/core/src/dispatch/validation.ts
@@ -1,0 +1,370 @@
+/**
+ * SSoT input validator over {@link OperationInputContract}.
+ *
+ * This module is the SINGLE SOURCE OF TRUTH for validating raw operation
+ * payloads against the schema-first {@link OperationInputContract} surface
+ * introduced by T9914. It powers the `mutate(operation, input)` DX (Saga
+ * T9855 / E7) and feeds into the CLI transport adapter (T9916) plus every
+ * future per-operation retrofit (T9917+).
+ *
+ * Implementation notes:
+ * - Uses AJV draft-07 with `allErrors: true` so callers get every failure
+ *   in a single pass — never bail on the first.
+ * - Caches compiled validators in a Map keyed by `contract.operation`
+ *   because re-compiling AJV per invocation is the dominant hot-path cost.
+ * - Maps AJV errors into the wire-stable {@link ValidationError} shape with
+ *   JSON Pointer paths, per-keyword human-readable expected/received/fix
+ *   text, stable `E_VAL_<KEYWORD>` codes, and `x-fix-hint` overrides walked
+ *   off the contract schema by `schemaPath`.
+ *
+ * @packageDocumentation
+ * @module @cleocode/core/dispatch/validation
+ *
+ * @epic T9855
+ * @task T9915
+ */
+
+import type {
+  OperationInputContract,
+  ValidationError,
+  ValidationResult,
+} from '@cleocode/contracts';
+import type { Ajv as AjvInstance, ErrorObject, ValidateFunction } from 'ajv';
+import { default as AjvImport } from 'ajv';
+import { default as addFormatsImport } from 'ajv-formats';
+
+// ---------------------------------------------------------------------------
+// AJV ESM/CJS interop (matches packages/core/src/json-schema-validator.ts)
+// ---------------------------------------------------------------------------
+
+const ajvMod = AjvImport as Record<string, unknown>;
+const Ajv = (typeof ajvMod.default === 'function' ? ajvMod.default : AjvImport) as new (
+  opts?: Record<string, unknown>,
+) => AjvInstance;
+const fmtMod = addFormatsImport as Record<string, unknown>;
+const addFormats = (typeof fmtMod.default === 'function' ? fmtMod.default : addFormatsImport) as (
+  ajv: AjvInstance,
+) => AjvInstance;
+
+// ---------------------------------------------------------------------------
+// Lazy singleton AJV instance — shared across all compiled validators.
+// ---------------------------------------------------------------------------
+
+let ajvInstance: AjvInstance | null = null;
+
+function getAjv(): AjvInstance {
+  if (!ajvInstance) {
+    ajvInstance = new Ajv({
+      allErrors: true,
+      strict: false,
+      allowUnionTypes: true,
+    });
+    addFormats(ajvInstance);
+  }
+  return ajvInstance;
+}
+
+// ---------------------------------------------------------------------------
+// Compiled-validator cache keyed by contract.operation
+// ---------------------------------------------------------------------------
+
+const compiledCache = new Map<string, ValidateFunction>();
+
+/**
+ * Reset the compiled-validator cache. Intended for tests that want to
+ * assert AJV compilation behaviour across runs; production callers should
+ * never need this.
+ *
+ * @internal
+ */
+export function _resetValidationCache(): void {
+  compiledCache.clear();
+}
+
+function getCompiled<T>(contract: OperationInputContract<T>): ValidateFunction {
+  const cached = compiledCache.get(contract.operation);
+  if (cached) {
+    return cached;
+  }
+  const compiled = getAjv().compile(contract.schema as Record<string, unknown>);
+  compiledCache.set(contract.operation, compiled);
+  return compiled;
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize an AJV `instancePath` (JSON Pointer fragment, may be `''`)
+ * into the canonical leading-slash form used in {@link ValidationError}.
+ * AJV already emits JSON Pointer paths beginning with `/`, but missing-
+ * required errors anchor at the parent, so we keep the empty-root form
+ * intact and only ensure a single leading slash otherwise.
+ */
+function normalizePath(instancePath: string): string {
+  if (instancePath === '' || instancePath === '/') {
+    return '';
+  }
+  return instancePath.startsWith('/') ? instancePath : `/${instancePath}`;
+}
+
+/**
+ * Describe a runtime value by type/cardinality WITHOUT leaking its raw
+ * contents — matches the {@link ValidationError.received} contract.
+ */
+function describeReceived(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return `array of ${value.length}`;
+  if (typeof value === 'string') {
+    return value.length === 0 ? 'empty string' : `string of length ${value.length}`;
+  }
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'boolean') return 'boolean';
+  if (typeof value === 'object') {
+    const keys = Object.keys(value as Record<string, unknown>);
+    return `object with ${keys.length} field${keys.length === 1 ? '' : 's'}`;
+  }
+  return typeof value;
+}
+
+/**
+ * Read the value at a JSON-Pointer-style `instancePath` from a raw
+ * payload. AJV's `instancePath` is RFC 6901 with `~0` → `~`, `~1` → `/`.
+ */
+function readAtPath(root: unknown, instancePath: string): unknown {
+  if (instancePath === '' || instancePath === '/') return root;
+  const segments = instancePath
+    .split('/')
+    .slice(1)
+    .map((seg) => seg.replace(/~1/g, '/').replace(/~0/g, '~'));
+  let cursor: unknown = root;
+  for (const seg of segments) {
+    if (cursor === null || cursor === undefined) return undefined;
+    if (Array.isArray(cursor)) {
+      const idx = Number(seg);
+      if (!Number.isInteger(idx)) return undefined;
+      cursor = cursor[idx];
+      continue;
+    }
+    if (typeof cursor === 'object') {
+      cursor = (cursor as Record<string, unknown>)[seg];
+      continue;
+    }
+    return undefined;
+  }
+  return cursor;
+}
+
+/**
+ * Walk a contract schema by an AJV `schemaPath` (e.g.
+ * `#/properties/title/minLength`) and return the schema NODE that
+ * produced the error — used to detect `x-fix-hint` overrides.
+ */
+function walkSchema(schema: Record<string, unknown>, schemaPath: string): unknown {
+  if (!schemaPath || schemaPath === '#') return schema;
+  const segments = schemaPath
+    .replace(/^#\/?/, '')
+    .split('/')
+    .filter((s) => s.length > 0)
+    .map((seg) => seg.replace(/~1/g, '/').replace(/~0/g, '~'));
+  let cursor: unknown = schema;
+  for (const seg of segments) {
+    if (cursor === null || cursor === undefined || typeof cursor !== 'object') return undefined;
+    cursor = (cursor as Record<string, unknown>)[seg];
+  }
+  return cursor;
+}
+
+/**
+ * If the schema node addressed by `schemaPath` (or its parent for
+ * leaf-keyword errors) carries an `x-fix-hint: string`, return it.
+ * Walks one step up from the keyword leaf so a hint on
+ * `properties.title` can override the `minLength` failure on
+ * `#/properties/title/minLength`.
+ */
+function findFixHint(contract: OperationInputContract<unknown>, schemaPath: string): string | null {
+  const schema = contract.schema as Record<string, unknown>;
+
+  const direct = walkSchema(schema, schemaPath);
+  if (direct && typeof direct === 'object') {
+    const hint = (direct as Record<string, unknown>)['x-fix-hint'];
+    if (typeof hint === 'string') return hint;
+  }
+
+  // Walk up one level — leaf-keyword errors point at the keyword itself
+  // (e.g. `.../minLength`), but authors put hints on the field schema.
+  const parentPath = schemaPath.replace(/\/[^/]+$/, '');
+  if (parentPath && parentPath !== schemaPath) {
+    const parent = walkSchema(schema, parentPath);
+    if (parent && typeof parent === 'object') {
+      const hint = (parent as Record<string, unknown>)['x-fix-hint'];
+      if (typeof hint === 'string') return hint;
+    }
+  }
+
+  return null;
+}
+
+interface KeywordParams {
+  readonly missingProperty?: string;
+  readonly type?: string | string[];
+  readonly allowedValues?: ReadonlyArray<unknown>;
+  readonly limit?: number;
+  readonly additionalProperty?: string;
+}
+
+function paramsOf(err: ErrorObject): KeywordParams {
+  return (err.params ?? {}) as KeywordParams;
+}
+
+function expectedFor(err: ErrorObject): string {
+  const params = paramsOf(err);
+  switch (err.keyword) {
+    case 'required':
+      return `object with field ${params.missingProperty ?? '<unknown>'}`;
+    case 'type': {
+      const t = params.type;
+      return Array.isArray(t) ? t.join('|') : (t ?? 'unknown type');
+    }
+    case 'enum': {
+      const allowed = (params.allowedValues ?? []).map((v) => JSON.stringify(v));
+      return `one of: ${allowed.join('|')}`;
+    }
+    case 'minLength':
+      return `string with length >= ${params.limit ?? 0}`;
+    case 'maxLength':
+      return `string with length <= ${params.limit ?? 0}`;
+    case 'minimum':
+      return `number >= ${params.limit ?? 0}`;
+    case 'maximum':
+      return `number <= ${params.limit ?? 0}`;
+    case 'minItems':
+      return `array with length >= ${params.limit ?? 0}`;
+    case 'maxItems':
+      return `array with length <= ${params.limit ?? 0}`;
+    case 'additionalProperties':
+      return 'no extra fields';
+    default:
+      return err.message ?? err.keyword;
+  }
+}
+
+function fixFor(err: ErrorObject): string {
+  const params = paramsOf(err);
+  switch (err.keyword) {
+    case 'required':
+      return `add the ${params.missingProperty ?? '<missing>'} field`;
+    case 'type': {
+      const t = Array.isArray(params.type) ? params.type[0] : params.type;
+      if (t === 'string') return 'wrap value in quotes';
+      if (t === 'array') return 'wrap value in [...]';
+      if (t === 'number' || t === 'integer') return 'remove quotes if it is a number literal';
+      if (t === 'boolean') return 'use literal true or false';
+      if (t === 'object') return 'wrap value in { ... }';
+      return `change value to type ${t ?? 'unknown'}`;
+    }
+    case 'enum': {
+      const allowed = (params.allowedValues ?? []).map((v) =>
+        typeof v === 'string' ? v : JSON.stringify(v),
+      );
+      return `use one of: ${allowed.join(', ')}`;
+    }
+    case 'additionalProperties':
+      return `remove the extra field ${params.additionalProperty ?? ''}`.trim();
+    case 'minLength':
+      return `provide at least ${params.limit ?? 1} character(s)`;
+    case 'maxLength':
+      return `shorten to at most ${params.limit ?? 0} character(s)`;
+    case 'minimum':
+      return `provide a value >= ${params.limit ?? 0}`;
+    case 'maximum':
+      return `provide a value <= ${params.limit ?? 0}`;
+    default:
+      return `see ${err.schemaPath}`;
+  }
+}
+
+function errorCodeFor(err: ErrorObject): string {
+  return `E_VAL_${err.keyword.toUpperCase()}`;
+}
+
+function mapAjvError(
+  contract: OperationInputContract<unknown>,
+  rawInput: unknown,
+  err: ErrorObject,
+): ValidationError {
+  // For `required` errors AJV anchors `instancePath` at the parent
+  // object, not the missing child. Synthesise the child pointer so the
+  // error path actually points at the field the caller forgot.
+  const params = paramsOf(err);
+  let path = normalizePath(err.instancePath);
+  if (err.keyword === 'required' && params.missingProperty) {
+    path = `${path}/${params.missingProperty}`;
+  }
+
+  const receivedValue =
+    err.keyword === 'required' ? undefined : readAtPath(rawInput, err.instancePath);
+
+  const customHint = findFixHint(contract, err.schemaPath);
+
+  return {
+    path,
+    expected: expectedFor(err),
+    received: describeReceived(receivedValue),
+    fix: customHint ?? fixFor(err),
+    errorCode: errorCodeFor(err),
+    schemaPath: err.schemaPath,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API — validateOperationInput
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a raw operation payload against an {@link OperationInputContract}
+ * and return a strongly-typed {@link ValidationResult}.
+ *
+ * On success the result is `{ ok: true, value: rawInput as T }` — the
+ * validator does NOT clone or coerce the payload, it only narrows the
+ * type. On failure the result is `{ ok: false, errors: ValidationError[] }`
+ * with one entry per AJV error (AJV is configured with `allErrors: true`
+ * so callers see every problem in one pass).
+ *
+ * Compiled AJV validators are cached by `contract.operation` — the hot
+ * path therefore avoids re-compilation entirely.
+ *
+ * @typeParam T - The validated input shape produced on success.
+ * @param contract - Schema-first input contract (see T9914).
+ * @param rawInput - Raw, untrusted payload to validate.
+ * @returns Discriminated {@link ValidationResult} narrowed on `ok`.
+ *
+ * @example
+ * ```ts
+ * const result = validateOperationInput(createTaskContract, payload);
+ * if (result.ok) {
+ *   await dispatch.tasks.create(result.value);
+ * } else {
+ *   for (const e of result.errors) console.error(`${e.path}: ${e.fix}`);
+ * }
+ * ```
+ *
+ * @epic T9855
+ * @task T9915
+ */
+export function validateOperationInput<T>(
+  contract: OperationInputContract<T>,
+  rawInput: unknown,
+): ValidationResult<T> {
+  const validate = getCompiled(contract);
+  if (validate(rawInput)) {
+    return { ok: true, value: rawInput as T };
+  }
+  const ajvErrors: ReadonlyArray<ErrorObject> = validate.errors ?? [];
+  const errors: ValidationError[] = ajvErrors.map((err) =>
+    mapAjvError(contract as OperationInputContract<unknown>, rawInput, err),
+  );
+  return { ok: false, errors };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -624,6 +624,8 @@ export { updateTask } from './tasks/update.js';
 // can import them without violating lint-core-first RULE-3 (which bans
 // `@cleocode/core/internal` from CLI command files).
 
+// T9915 (Saga T9855 / E7.2) — SSoT input validator over OperationInputContract
+export { validateOperationInput } from './dispatch/validation.js';
 // Setup wizard `--config-json` merger
 export { mergeConfigJson, WIZARD_SECTION_IDS } from './setup/config-json-merge.js';
 // Backup bundle inspect primitives (tar parser, encryption detect, byte fmt)

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2408,6 +2408,10 @@ export { ConduitClient } from './conduit/conduit-client.js';
 export { createConduit } from './conduit/factory.js';
 export { HttpTransport } from './conduit/http-transport.js';
 export { decrypt, encrypt } from './crypto/credentials.js';
+// T9915 (Saga T9855 / E7.2) — SSoT input validator over OperationInputContract
+// Re-exported explicitly so CLI transport adapter (T9916) can resolve from
+// the internal barrel without traversing the public re-export chain.
+export { validateOperationInput } from './dispatch/validation.js';
 // Brain health dashboard (T1908 / BBTT-W2-4)
 export {
   type BrainHealthDashboard,


### PR DESCRIPTION
## Summary
- Adds `packages/core/src/dispatch/validation.ts` — SSoT validator over `OperationInputContract<T>` via AJV.
- Compiled-validator cache keyed by `contract.operation` (no re-compilation per call).
- Per-keyword human-readable `expected` / `received` / `fix`. Stable `E_VAL_<KEYWORD>` codes. `x-fix-hint` override walked off `schemaPath`.
- Exposed from both `@cleocode/core` (public) and `@cleocode/core/internal` (CLI adapter consumption).

## Why
Foundation for the schema-first `mutate(operation, input)` DX — CLI transport adapter (T9916) and `tasks.add` retrofit (T9917) build on top of this SSoT.

## Test plan
- [x] `pnpm biome check --write packages/core/src/dispatch/` (Biome clean)
- [x] `pnpm -F @cleocode/core run build` (tsc clean)
- [x] `pnpm exec vitest run packages/core/src/dispatch/__tests__/validation.test.ts` — 10/10 pass
  - Valid input → `{ ok: true, value }`
  - Generic narrowing to `T`
  - Missing required → `E_VAL_REQUIRED` with synthesised child pointer
  - Wrong type → `E_VAL_TYPE` + `wrap value in quotes`
  - Enum violation → `E_VAL_ENUM` listing allowed values
  - Nested error path `/items/2/title` normalises verbatim
  - Required-on-nested synthesises child pointer
  - `x-fix-hint` overrides generic fix
  - Compiled validator compiled exactly once across N calls (AJV.compile spy)
  - `additionalProperties: false` → `E_VAL_ADDITIONALPROPERTIES`

Closes T9915
Saga: T9855
ADR: 076