### PR TITLE
feat(core): attachments provenance migration (T10158 / Saga T9855)

### DIFF
--- a/.changeset/t10158-attachments-provenance-migration.md
+++ b/.changeset/t10158-attachments-provenance-migration.md
@@ -1,0 +1,6 @@
+---
+id: t10158-attachments-provenance-migration
+tasks: [T10158]
+kind: feat
+summary: Extend attachments table with 7 docs-provenance columns + 2 indexes mirroring brain_decisions supersession pattern (T10158 / Saga T9855 / E12)
+---

--- a/packages/core/migrations/drizzle-tasks/20260524000000_t10158-docs-provenance-columns/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260524000000_t10158-docs-provenance-columns/migration.sql
@@ -1,0 +1,64 @@
+-- T10158 — Extend `attachments` with 7 docs-provenance columns mirroring
+-- the proven supersession + classification pattern already shipped on
+-- `brain_decisions` by T1826 (see
+-- `packages/core/migrations/drizzle-brain/20260504000001_t1826-decisions-v2/migration.sql`).
+--
+-- Additive + forward-only: every new column is nullable or carries a
+-- safe DEFAULT, so SQLite ALTER TABLE ADD COLUMN does NOT rewrite the
+-- table and existing rows pass through with nulls / defaults. No data
+-- migration of legacy rows is required for this slice — downstream
+-- writers (T10162 supersede verb, T10164 graph CLI, etc.) populate the
+-- columns going forward.
+--
+-- Columns introduced:
+--   1. lifecycle_status TEXT NOT NULL DEFAULT 'draft'
+--        Document workflow state mirroring brain_decisions.confirmation_state.
+--        Allowed values (enforced at the dispatch layer, not via CHECK so
+--        future additions don't require a schema migration):
+--          draft | proposed | accepted | superseded | archived | deprecated
+--   2. supersedes      TEXT REFERENCES attachments(id)
+--        Self-FK to the attachment ID this doc replaces (forward pointer).
+--   3. superseded_by   TEXT REFERENCES attachments(id)
+--        Self-FK reverse pointer — set when a newer doc supersedes this one.
+--   4. summary         TEXT
+--        Short human-readable summary (≤ 1 sentence), distinct from the
+--        full body stored in attachment_json.
+--   5. keywords        TEXT
+--        JSON array of free-form keyword strings for search.
+--   6. topics          TEXT
+--        JSON array of canonical topic slugs (cross-cuts taxonomy).
+--   7. related_tasks   TEXT
+--        JSON array of T#### task IDs that this doc relates to.
+--
+-- Indices:
+--   - idx_attachments_lifecycle_status — graph filtering by lifecycle
+--   - idx_attachments_supersedes       — graph traversal (forward edges)
+--
+-- DEPENDS ON: 20260416000000_t796-attachments (creates `attachments`)
+-- SAFE FOR:   SQLite 3.35+ (ALTER TABLE ADD COLUMN with DEFAULT is atomic)
+--
+-- @task T10158
+-- @epic T10157 (C-DOCS-SSOT)
+-- @saga T9855 (SG-TEMPLATE-CONFIG-SSOT)
+-- @adr  ADR-078
+
+ALTER TABLE `attachments` ADD COLUMN `lifecycle_status` text NOT NULL DEFAULT 'draft';
+--> statement-breakpoint
+ALTER TABLE `attachments` ADD COLUMN `supersedes` text REFERENCES `attachments`(`id`);
+--> statement-breakpoint
+ALTER TABLE `attachments` ADD COLUMN `superseded_by` text REFERENCES `attachments`(`id`);
+--> statement-breakpoint
+ALTER TABLE `attachments` ADD COLUMN `summary` text;
+--> statement-breakpoint
+ALTER TABLE `attachments` ADD COLUMN `keywords` text;
+--> statement-breakpoint
+ALTER TABLE `attachments` ADD COLUMN `topics` text;
+--> statement-breakpoint
+ALTER TABLE `attachments` ADD COLUMN `related_tasks` text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_attachments_lifecycle_status`
+  ON `attachments` (`lifecycle_status`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_attachments_supersedes`
+  ON `attachments` (`supersedes`)
+  WHERE `supersedes` IS NOT NULL;

--- a/packages/core/migrations/drizzle-tasks/20260524000000_t10158-docs-provenance-columns/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260524000000_t10158-docs-provenance-columns/revert.sql
@@ -1,0 +1,25 @@
+-- Revert T10158 — drop the 7 docs-provenance columns + 2 indices.
+--
+-- SQLite supports ALTER TABLE DROP COLUMN since v3.35 (2021). Dropping
+-- a column implicitly drops indexes that reference it, but we list them
+-- explicitly for clarity and to keep the reversal idempotent.
+--
+-- Self-referential FKs (supersedes / superseded_by) drop with the columns.
+
+DROP INDEX IF EXISTS `idx_attachments_lifecycle_status`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_attachments_supersedes`;
+--> statement-breakpoint
+ALTER TABLE `attachments` DROP COLUMN `lifecycle_status`;
+--> statement-breakpoint
+ALTER TABLE `attachments` DROP COLUMN `supersedes`;
+--> statement-breakpoint
+ALTER TABLE `attachments` DROP COLUMN `superseded_by`;
+--> statement-breakpoint
+ALTER TABLE `attachments` DROP COLUMN `summary`;
+--> statement-breakpoint
+ALTER TABLE `attachments` DROP COLUMN `keywords`;
+--> statement-breakpoint
+ALTER TABLE `attachments` DROP COLUMN `topics`;
+--> statement-breakpoint
+ALTER TABLE `attachments` DROP COLUMN `related_tasks`;

--- a/packages/core/src/store/__tests__/t10158-attachments-provenance-schema.test.ts
+++ b/packages/core/src/store/__tests__/t10158-attachments-provenance-schema.test.ts
@@ -1,0 +1,306 @@
+/**
+ * T10158 — DB schema parity test: `attachments` table extended with 7
+ * docs-provenance columns (lifecycle_status + supersedes + superseded_by
+ * + summary + keywords + topics + related_tasks) and 2 supporting indexes,
+ * mirroring the proven supersession pattern shipped on `brain_decisions`
+ * by T1826.
+ *
+ * This test asserts:
+ *   1. The migration SQL file exists at the canonical drizzle-tasks path
+ *      and contains every expected ALTER + INDEX statement.
+ *   2. After running `migrateSanitized` on a fresh tasks.db, the
+ *      `attachments` table reports all 7 new columns via PRAGMA
+ *      table_info — with correct nullability and `lifecycle_status`
+ *      defaulting to `'draft'`.
+ *   3. PRAGMA index_list reports the 2 new indexes
+ *      (`idx_attachments_lifecycle_status`, `idx_attachments_supersedes`).
+ *   4. The `revert.sql` reversal is present and references every column
+ *      + index introduced by the forward migration (idempotency check).
+ *   5. The drizzle schema enum `ATTACHMENT_LIFECYCLE_STATUSES` is consistent
+ *      with the documented `'draft'` default.
+ *
+ * @task T10158
+ * @epic T10157 (C-DOCS-SSOT)
+ * @saga T9855 (SG-TEMPLATE-CONFIG-SSOT)
+ */
+
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ATTACHMENT_LIFECYCLE_STATUSES } from '../tasks-schema.js';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync: _DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (
+    path: string,
+    opts?: { readonly?: boolean },
+  ) => import('node:sqlite').DatabaseSync;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Resolve path to the drizzle-tasks migration folder. */
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+/** Resolve path to the T10158 migration directory. */
+function t10158MigrationDir(): string {
+  const all = readdirSync(migrationsDir(), { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+  const match = all.find((name) => name.includes('t10158-docs-provenance-columns'));
+  if (!match) {
+    throw new Error('T10158 migration directory not found under drizzle-tasks');
+  }
+  return join(migrationsDir(), match);
+}
+
+const EXPECTED_NEW_COLUMNS = [
+  'lifecycle_status',
+  'supersedes',
+  'superseded_by',
+  'summary',
+  'keywords',
+  'topics',
+  'related_tasks',
+] as const;
+
+const EXPECTED_NEW_INDEXES = [
+  'idx_attachments_lifecycle_status',
+  'idx_attachments_supersedes',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Section 1: Migration SQL content checks
+// ---------------------------------------------------------------------------
+
+describe('T10158 attachments provenance migration SQL', () => {
+  it('migration.sql file is present at the canonical path', () => {
+    const sqlPath = join(t10158MigrationDir(), 'migration.sql');
+    const sql = readFileSync(sqlPath, 'utf-8');
+    expect(sql.length).toBeGreaterThan(0);
+  });
+
+  it('contains an ALTER TABLE ADD COLUMN statement for every new column', () => {
+    const sql = readFileSync(join(t10158MigrationDir(), 'migration.sql'), 'utf-8');
+    for (const col of EXPECTED_NEW_COLUMNS) {
+      expect(sql, `Missing ALTER for column: ${col}`).toContain(`ADD COLUMN \`${col}\``);
+    }
+  });
+
+  it('declares `lifecycle_status` as NOT NULL with default `draft`', () => {
+    const sql = readFileSync(join(t10158MigrationDir(), 'migration.sql'), 'utf-8');
+    expect(sql).toMatch(/ADD COLUMN `lifecycle_status` text NOT NULL DEFAULT 'draft'/);
+  });
+
+  it('declares supersedes + superseded_by as self-referential FKs', () => {
+    const sql = readFileSync(join(t10158MigrationDir(), 'migration.sql'), 'utf-8');
+    expect(sql).toMatch(/ADD COLUMN `supersedes` text REFERENCES `attachments`\(`id`\)/);
+    expect(sql).toMatch(/ADD COLUMN `superseded_by` text REFERENCES `attachments`\(`id`\)/);
+  });
+
+  it('creates both new indexes', () => {
+    const sql = readFileSync(join(t10158MigrationDir(), 'migration.sql'), 'utf-8');
+    for (const idx of EXPECTED_NEW_INDEXES) {
+      expect(sql, `Missing CREATE INDEX for: ${idx}`).toContain(idx);
+    }
+  });
+
+  it('ships a revert.sql alongside the forward migration', () => {
+    const revertPath = join(t10158MigrationDir(), 'revert.sql');
+    const revert = readFileSync(revertPath, 'utf-8');
+    for (const col of EXPECTED_NEW_COLUMNS) {
+      expect(revert, `revert.sql missing DROP COLUMN: ${col}`).toContain(`DROP COLUMN \`${col}\``);
+    }
+    for (const idx of EXPECTED_NEW_INDEXES) {
+      expect(revert, `revert.sql missing DROP INDEX: ${idx}`).toContain(idx);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 2: Drizzle schema parity (enum consistency)
+// ---------------------------------------------------------------------------
+
+describe('T10158 drizzle schema parity', () => {
+  it('exports ATTACHMENT_LIFECYCLE_STATUSES enum with the documented states', () => {
+    expect(ATTACHMENT_LIFECYCLE_STATUSES).toEqual([
+      'draft',
+      'proposed',
+      'accepted',
+      'superseded',
+      'archived',
+      'deprecated',
+    ]);
+  });
+
+  it('contains `draft` (the schema default) in the enum', () => {
+    expect(ATTACHMENT_LIFECYCLE_STATUSES).toContain('draft');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 3: End-to-end migration apply on a fresh tasks.db
+// ---------------------------------------------------------------------------
+
+describe('T10158 fresh migration apply — attachments gains 7 columns + 2 indexes', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-t10158-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('applies all drizzle-tasks migrations cleanly', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    expect(() => migrateSanitized(db, { migrationsFolder })).not.toThrow();
+
+    nativeDb.close();
+  });
+
+  it('attachments table has all 7 new columns after migration', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-cols.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const cols = nativeDb.prepare('PRAGMA table_info(attachments)').all() as Array<{
+      name: string;
+      type: string;
+      notnull: number;
+      dflt_value: string | null;
+    }>;
+    const colMap = new Map(cols.map((c) => [c.name, c]));
+
+    for (const col of EXPECTED_NEW_COLUMNS) {
+      expect(colMap.has(col), `Column '${col}' missing from attachments table`).toBe(true);
+    }
+
+    const lifecycle = colMap.get('lifecycle_status');
+    expect(lifecycle, 'lifecycle_status column missing').toBeDefined();
+    expect(lifecycle?.notnull).toBe(1);
+    expect(lifecycle?.dflt_value).toBe("'draft'");
+
+    // The other 6 columns must be nullable (notnull=0) so existing rows pass through.
+    for (const col of [
+      'supersedes',
+      'superseded_by',
+      'summary',
+      'keywords',
+      'topics',
+      'related_tasks',
+    ] as const) {
+      expect(colMap.get(col)?.notnull, `Column '${col}' should be nullable`).toBe(0);
+    }
+
+    nativeDb.close();
+  });
+
+  it('attachments table has both new indexes after migration', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-idx.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const indexes = nativeDb.prepare('PRAGMA index_list(attachments)').all() as Array<{
+      name: string;
+    }>;
+    const indexNames = indexes.map((i) => i.name);
+
+    for (const idx of EXPECTED_NEW_INDEXES) {
+      expect(indexNames, `Index '${idx}' missing from attachments table`).toContain(idx);
+    }
+
+    nativeDb.close();
+  });
+
+  it('legacy attachment rows survive the migration and default lifecycle_status to draft', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-passthrough.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    // Insert a pre-T10158 style row WITHOUT touching the new columns.
+    const now = new Date().toISOString();
+    nativeDb
+      .prepare(
+        `INSERT INTO attachments (id, sha256, attachment_json, created_at, ref_count)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run('att_legacy_1', 'a'.repeat(64), '{"kind":"note","body":"legacy"}', now, 0);
+
+    const row = nativeDb
+      .prepare(
+        `SELECT id, lifecycle_status, supersedes, superseded_by, summary, keywords, topics, related_tasks
+           FROM attachments WHERE id = ?`,
+      )
+      .get('att_legacy_1') as {
+      id: string;
+      lifecycle_status: string;
+      supersedes: string | null;
+      superseded_by: string | null;
+      summary: string | null;
+      keywords: string | null;
+      topics: string | null;
+      related_tasks: string | null;
+    };
+
+    expect(row.id).toBe('att_legacy_1');
+    expect(row.lifecycle_status).toBe('draft');
+    expect(row.supersedes).toBeNull();
+    expect(row.superseded_by).toBeNull();
+    expect(row.summary).toBeNull();
+    expect(row.keywords).toBeNull();
+    expect(row.topics).toBeNull();
+    expect(row.related_tasks).toBeNull();
+
+    nativeDb.close();
+  });
+});

--- a/packages/core/src/store/schema/attachments.ts
+++ b/packages/core/src/store/schema/attachments.ts
@@ -5,7 +5,14 @@
  * @task T796
  */
 
-import { index, integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import {
+  type AnySQLiteColumn,
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+} from 'drizzle-orm/sqlite-core';
 
 const ATTACHMENT_OWNER_TYPES = [
   'task',
@@ -15,6 +22,30 @@ const ATTACHMENT_OWNER_TYPES = [
   'learning',
   'pattern',
 ] as const;
+
+/**
+ * Allowed lifecycle states for `attachments.lifecycle_status`.
+ *
+ * Mirrors the supersession workflow proven on `brain_decisions.confirmation_state`
+ * (T1826) and extended for documents with the `draft`, `archived`, and
+ * `deprecated` terminal states.
+ *
+ * Validation is enforced at the dispatch layer (not via a SQL CHECK constraint)
+ * so future taxonomy additions do NOT require a schema migration.
+ *
+ * @task T10158 (Epic T10157 / Saga T9855)
+ */
+export const ATTACHMENT_LIFECYCLE_STATUSES = [
+  'draft',
+  'proposed',
+  'accepted',
+  'superseded',
+  'archived',
+  'deprecated',
+] as const;
+
+/** Discriminated union of attachment lifecycle states. */
+export type AttachmentLifecycleStatus = (typeof ATTACHMENT_LIFECYCLE_STATUSES)[number];
 
 /**
  * Registry of stored attachments (blob content).
@@ -54,8 +85,85 @@ export const attachments = sqliteTable(
      * @task T9637 (Epic T9627 / Saga T9625)
      */
     type: text('type'),
+    /**
+     * Document workflow state — mirrors `brain_decisions.confirmation_state`
+     * (T1826) and extends it for the document-publishing lifecycle.
+     *
+     * Allowed values: `draft | proposed | accepted | superseded | archived | deprecated`.
+     * Defaults to `'draft'` for new rows; legacy rows pass through at this
+     * default after the T10158 migration. Validation is performed at the
+     * dispatch layer (no SQL CHECK constraint) so future states can be added
+     * without a schema migration.
+     *
+     * @see ATTACHMENT_LIFECYCLE_STATUSES — canonical enum
+     * @task T10158 (Epic T10157 / Saga T9855)
+     */
+    lifecycleStatus: text('lifecycle_status', { enum: ATTACHMENT_LIFECYCLE_STATUSES })
+      .notNull()
+      .default('draft'),
+    /**
+     * Self-referential FK forward pointer to the `attachments.id` row that
+     * this doc replaces. NULL when this doc does not supersede a prior one.
+     *
+     * The referenced row's `superseded_by` should be set to this row's ID on
+     * write — mirrors the brain_decisions supersession pattern (T1826).
+     *
+     * @see supersededBy — reverse pointer stored on the older row
+     * @task T10158 (Epic T10157 / Saga T9855)
+     */
+    supersedes: text('supersedes').references((): AnySQLiteColumn => attachments.id),
+    /**
+     * Self-referential FK reverse pointer to the `attachments.id` row that
+     * has superseded this doc. NULL while this doc is still active.
+     *
+     * Set when a newer doc's `supersedes` points to this row.
+     *
+     * @see supersedes — forward pointer stored on the newer row
+     * @task T10158 (Epic T10157 / Saga T9855)
+     */
+    supersededBy: text('superseded_by').references((): AnySQLiteColumn => attachments.id),
+    /**
+     * Optional short human-readable summary of the attachment (≤ 1 sentence),
+     * distinct from the full body stored in `attachment_json`. Surfaced in
+     * `cleo docs list` and graph-traversal envelopes.
+     *
+     * @task T10158 (Epic T10157 / Saga T9855)
+     */
+    summary: text('summary'),
+    /**
+     * Optional JSON array of free-form keyword strings for search.
+     *
+     * Stored as serialised JSON (not normalised to a sidecar table) to match
+     * the existing `attachment_json` storage discipline. Parsed at read time
+     * by the dispatch layer.
+     *
+     * @task T10158 (Epic T10157 / Saga T9855)
+     */
+    keywords: text('keywords'),
+    /**
+     * Optional JSON array of canonical topic slugs (cross-cuts taxonomy) — a
+     * higher-signal classification axis than `type`. Topics are project-defined
+     * and validated at the dispatch layer.
+     *
+     * @task T10158 (Epic T10157 / Saga T9855)
+     */
+    topics: text('topics'),
+    /**
+     * Optional JSON array of `T####` task IDs that this doc relates to.
+     *
+     * Soft cross-reference (no FK enforced) since tasks live in the same
+     * tasks.db but the `tasks` table is not always present during pure
+     * docs-graph traversal.
+     *
+     * @task T10158 (Epic T10157 / Saga T9855)
+     */
+    relatedTasks: text('related_tasks'),
   },
-  (table) => [index('idx_attachments_sha256').on(table.sha256)],
+  (table) => [
+    index('idx_attachments_sha256').on(table.sha256),
+    index('idx_attachments_lifecycle_status').on(table.lifecycleStatus),
+    index('idx_attachments_supersedes').on(table.supersedes),
+  ],
 );
 
 /**


### PR DESCRIPTION
## Summary

Forward-only migration extending the `attachments` table with **7 docs-provenance columns + 2 indexes**, mirroring the proven supersession pattern shipped on `brain_decisions` by T1826.

**Columns**
- `lifecycle_status` (`TEXT NOT NULL DEFAULT 'draft'`) — enum validated at the dispatch layer: `draft | proposed | accepted | superseded | archived | deprecated`
- `supersedes` / `superseded_by` — self-referential FK to `attachments.id`
- `summary` — short human-readable summary (≤ 1 sentence)
- `keywords` / `topics` / `related_tasks` — JSON-encoded arrays

**Indexes**
- `idx_attachments_lifecycle_status`
- `idx_attachments_supersedes` (partial, `WHERE supersedes IS NOT NULL`)

**Drizzle schema** (`packages/core/src/store/schema/attachments.ts`) extended with matching columns + `ATTACHMENT_LIFECYCLE_STATUSES` enum re-exported via the tasks-schema barrel. `revert.sql` ships alongside for ops symmetry (forward-only in production).

Foundation for the docs SSoT supersession-aware graph (T10162 supersede verb, T10164 graph CLI, T10165 `adr-index.jsonl` decommission).

## Test plan

- [x] `pnpm biome check` — clean on modified files
- [x] `pnpm run build` — full topo build green
- [x] `pnpm exec vitest run packages/core/src/store/__tests__/t10158-attachments-provenance-schema.test.ts` — **12/12 pass**
- [x] `pnpm exec vitest run packages/core/src/store/__tests__/ packages/core/src/migration/__tests__/` — **1349/1349 pass, 101/101 files**
- [x] Test asserts: migration SQL contains every ALTER + INDEX, `lifecycle_status` defaults to `'draft'`, supersedes/superseded_by are self-FKs, `revert.sql` references every column + index, legacy row passes through with `lifecycle_status='draft'` and all 6 nullable columns NULL after migration.

Closes T10158
Saga: T9855