### PR TITLE
fix(cleo): T10341 typed validation for --severity + --pipeline-stage at dispatch

### DIFF
--- a/.changeset/t10341-severity-pipeline-stage-validation.md
+++ b/.changeset/t10341-severity-pipeline-stage-validation.md
@@ -1,0 +1,33 @@
+---
+id: t10341-severity-pipeline-stage-validation
+tasks: [T10341]
+kind: fix
+summary: "cleo add/update: typed validation for --severity + --pipeline-stage at CLI dispatch"
+---
+
+Validates `--severity` and `--pipeline-stage` at the CLI dispatch
+boundary BEFORE the request reaches the database. Replaces the
+late-stage SQLite failure modes (`CHECK constraint failed: severity`,
+`CHECK constraint failed: pipeline_stage`) with typed contract errors
+naming the valid enum values:
+
+- `--severity X` validates against `TASK_SEVERITIES` (`P0|P1|P2|P3`).
+  Failure → `E_INVALID_SEVERITY_VALUE` (exit 6) with message
+  `severity must be one of: P0, P1, P2, P3 — got '<X>'`.
+- `--pipeline-stage X` (on `cleo update`) validates against
+  `TASK_PIPELINE_STAGES` and rejects backward transitions
+  (forward-only invariant). Failure → `E_INVALID_PIPELINE_STAGE`
+  (exit 6) with the valid forward stages listed in the `fix` hint.
+
+Adds two new error-code constants to `@cleocode/contracts`:
+`E_INVALID_SEVERITY_VALUE` and `E_INVALID_PIPELINE_STAGE`. Re-exports
+the pipeline-stage helpers (`TASK_PIPELINE_STAGES`,
+`isValidPipelineStage`, `isPipelineTransitionForward`,
+`validatePipelineStage`, `validatePipelineTransition`,
+`isTerminalPipelineStage`, `getPipelineStageOrder`,
+`TERMINAL_PIPELINE_STAGES`, `TaskPipelineStage`) from the public
+`@cleocode/core` barrel so CLI commands can consume them without
+violating the lint-core-first RULE-3 ban on `@cleocode/core/internal`.
+
+R7 of Saga T10326 / Epic T10327 — LLM ergonomics. DB CHECK constraints
+remain in place as defense-in-depth.

--- a/packages/cleo/src/cli/commands/__tests__/add-update-severity-pipeline-validation.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/add-update-severity-pipeline-validation.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for T10341: typed CLI-layer validation for --severity and
+ * --pipeline-stage on `cleo add` and `cleo update`.
+ *
+ * Before T10341 the CLI accepted any string and let SQLite's CHECK
+ * constraint reject the write with an opaque
+ * `CHECK constraint failed: severity` (or `pipeline_stage`) error.
+ *
+ * After T10341 the dispatch boundary validates the value against the
+ * canonical enums in `@cleocode/contracts` (`TASK_SEVERITIES`) and
+ * `@cleocode/core` (`TASK_PIPELINE_STAGES` + forward-only transitions)
+ * and short-circuits with a typed error code naming the valid members:
+ *   - `E_INVALID_SEVERITY_VALUE` for severity (exit 6)
+ *   - `E_INVALID_PIPELINE_STAGE` for pipeline-stage (exit 6)
+ *
+ * Tests mock the dispatcher layer so no real SQLite database is touched.
+ *
+ * @task T10341
+ * @epic T10327
+ * @saga T10326
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock dispatch and renderer before importing the command under test
+// ---------------------------------------------------------------------------
+
+const mockDispatchRaw = vi.fn();
+const mockHandleRawError = vi.fn();
+const mockDispatchFromCli = vi.fn();
+const mockCliError = vi.fn();
+const mockCliOutput = vi.fn();
+const mockHumanInfo = vi.fn();
+const mockHumanWarn = vi.fn();
+
+vi.mock('../../../dispatch/adapters/cli.js', () => ({
+  dispatchRaw: (...args: unknown[]) => mockDispatchRaw(...args),
+  handleRawError: (...args: unknown[]) => mockHandleRawError(...args),
+  dispatchFromCli: (...args: unknown[]) => mockDispatchFromCli(...args),
+}));
+
+vi.mock('../../renderers/index.js', () => ({
+  cliError: (...args: unknown[]) => mockCliError(...args),
+  cliOutput: (...args: unknown[]) => mockCliOutput(...args),
+  humanInfo: (...args: unknown[]) => mockHumanInfo(...args),
+  humanWarn: (...args: unknown[]) => mockHumanWarn(...args),
+}));
+
+// Mock Core inference + attestation — add.ts/update.ts delegate to these.
+const mockInferTaskAddParams = vi.fn();
+const mockAppendSignedSeverityAttestation = vi.fn();
+const mockParseAcceptanceCriteria = vi.fn();
+vi.mock('@cleocode/core', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@cleocode/core')>();
+  return {
+    ...original,
+    inferTaskAddParams: (...args: unknown[]) => mockInferTaskAddParams(...args),
+    appendSignedSeverityAttestation: (...args: unknown[]) =>
+      mockAppendSignedSeverityAttestation(...args),
+    parseAcceptanceCriteria: (...args: unknown[]) => mockParseAcceptanceCriteria(...args),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import commands after mocks are registered
+// ---------------------------------------------------------------------------
+
+import { addCommand } from '../add.js';
+import { updateCommand } from '../update.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noInference = { inferredParent: undefined, files: undefined, acceptance: undefined };
+
+async function invokeAdd(title: string, extraArgs: Record<string, unknown> = {}): Promise<void> {
+  const runFn = addCommand.run as (ctx: {
+    args: Record<string, unknown>;
+    rawArgs: string[];
+  }) => Promise<void>;
+  await runFn({ args: { title, ...extraArgs }, rawArgs: [] });
+}
+
+async function invokeUpdate(
+  taskId: string,
+  extraArgs: Record<string, unknown> = {},
+): Promise<void> {
+  const runFn = updateCommand.run as (ctx: {
+    args: Record<string, unknown>;
+    rawArgs: string[];
+  }) => Promise<void>;
+  await runFn({ args: { taskId, ...extraArgs }, rawArgs: [] });
+}
+
+function successResponse(data: Record<string, unknown> = { id: 'T001' }): Record<string, unknown> {
+  return {
+    success: true,
+    data,
+    _meta: {
+      gateway: 'mutate',
+      domain: 'tasks',
+      operation: 'add',
+      timestamp: new Date().toISOString(),
+      duration_ms: 0,
+      source: 'cli',
+      requestId: 'r-test',
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe('cleo add --severity validation (T10341)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInferTaskAddParams.mockResolvedValue(noInference);
+    mockAppendSignedSeverityAttestation.mockResolvedValue(undefined);
+    mockDispatchRaw.mockResolvedValue(successResponse());
+    vi.spyOn(process, 'exit').mockImplementation((_code?: string | number | null | undefined) => {
+      throw new Error(`process.exit(${_code})`);
+    });
+  });
+
+  it('rejects --severity CRITICAL with E_INVALID_SEVERITY_VALUE (exit 6)', async () => {
+    await expect(invokeAdd('Task with bad sev', { severity: 'CRITICAL' })).rejects.toThrow(
+      'process.exit(6)',
+    );
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [message, code, details] = mockCliError.mock.calls[0] as [
+      string,
+      number,
+      { name: string; fix: string },
+    ];
+    expect(code).toBe(6);
+    expect(details.name).toBe('E_INVALID_SEVERITY_VALUE');
+    expect(message).toContain('P0, P1, P2, P3');
+    expect(message).toContain("got 'CRITICAL'");
+    expect(details.fix).toContain('P0, P1, P2, P3');
+
+    // Dispatch MUST NOT have been called — validation aborts before dispatch.
+    expect(mockDispatchRaw).not.toHaveBeenCalled();
+    // Attestation MUST NOT have fired either — would leak an audit entry for
+    // a request the validator rejects.
+    expect(mockAppendSignedSeverityAttestation).not.toHaveBeenCalled();
+  });
+
+  it('rejects --severity P9 (numeric-but-invalid) with E_INVALID_SEVERITY_VALUE', async () => {
+    await expect(invokeAdd('Bad severity', { severity: 'P9' })).rejects.toThrow('process.exit(6)');
+
+    const [, , details] = mockCliError.mock.calls[0] as [string, number, { name: string }];
+    expect(details.name).toBe('E_INVALID_SEVERITY_VALUE');
+    expect(mockDispatchRaw).not.toHaveBeenCalled();
+  });
+
+  it.each(['P0', 'P1', 'P2', 'P3'])('accepts --severity %s as a valid enum member', async (sev) => {
+    await invokeAdd('Valid severity task', { severity: sev });
+    expect(mockCliError).not.toHaveBeenCalled();
+    expect(mockDispatchRaw).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT validate severity when flag is absent', async () => {
+    await invokeAdd('No severity task');
+    expect(mockCliError).not.toHaveBeenCalled();
+    expect(mockDispatchRaw).toHaveBeenCalledOnce();
+  });
+});
+
+describe('cleo update --severity validation (T10341)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAppendSignedSeverityAttestation.mockResolvedValue(undefined);
+    mockDispatchFromCli.mockResolvedValue(undefined);
+    mockDispatchRaw.mockResolvedValue(
+      successResponse({ id: 'T001', pipelineStage: 'implementation' }),
+    );
+    vi.spyOn(process, 'exit').mockImplementation((_code?: string | number | null | undefined) => {
+      throw new Error(`process.exit(${_code})`);
+    });
+  });
+
+  it('rejects --severity FATAL with E_INVALID_SEVERITY_VALUE (exit 6)', async () => {
+    await expect(invokeUpdate('T001', { severity: 'FATAL' })).rejects.toThrow('process.exit(6)');
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [message, code, details] = mockCliError.mock.calls[0] as [
+      string,
+      number,
+      { name: string },
+    ];
+    expect(code).toBe(6);
+    expect(details.name).toBe('E_INVALID_SEVERITY_VALUE');
+    expect(message).toContain("got 'FATAL'");
+    expect(mockDispatchFromCli).not.toHaveBeenCalled();
+    expect(mockAppendSignedSeverityAttestation).not.toHaveBeenCalled();
+  });
+
+  it('accepts --severity P0 (canonical enum member)', async () => {
+    await invokeUpdate('T001', { severity: 'P0' });
+    expect(mockCliError).not.toHaveBeenCalled();
+    expect(mockDispatchFromCli).toHaveBeenCalledOnce();
+  });
+});
+
+describe('cleo update --pipeline-stage validation (T10341)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAppendSignedSeverityAttestation.mockResolvedValue(undefined);
+    mockDispatchFromCli.mockResolvedValue(undefined);
+    vi.spyOn(process, 'exit').mockImplementation((_code?: string | number | null | undefined) => {
+      throw new Error(`process.exit(${_code})`);
+    });
+  });
+
+  it('rejects unknown --pipeline-stage value with E_INVALID_PIPELINE_STAGE (exit 6)', async () => {
+    // No show needed — validator short-circuits on unknown stage name
+    mockDispatchRaw.mockResolvedValue(successResponse({ id: 'T001', pipelineStage: 'research' }));
+
+    await expect(invokeUpdate('T001', { 'pipeline-stage': 'not-a-real-stage' })).rejects.toThrow(
+      'process.exit(6)',
+    );
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [message, code, details] = mockCliError.mock.calls[0] as [
+      string,
+      number,
+      { name: string; fix: string },
+    ];
+    expect(code).toBe(6);
+    expect(details.name).toBe('E_INVALID_PIPELINE_STAGE');
+    expect(message).toContain('research');
+    expect(message).toContain('implementation');
+    expect(message).toContain("got 'not-a-real-stage'");
+
+    // tasks.show MUST NOT have been called — invalid-name path short-circuits
+    // before the round trip.
+    expect(mockDispatchRaw).not.toHaveBeenCalled();
+    expect(mockDispatchFromCli).not.toHaveBeenCalled();
+  });
+
+  it('rejects backward --pipeline-stage transition with E_INVALID_PIPELINE_STAGE', async () => {
+    // Existing task is at 'testing' (order 8); attempting to move back to
+    // 'research' (order 1) must be rejected.
+    mockDispatchRaw.mockResolvedValue(successResponse({ id: 'T001', pipelineStage: 'testing' }));
+
+    await expect(invokeUpdate('T001', { 'pipeline-stage': 'research' })).rejects.toThrow(
+      'process.exit(6)',
+    );
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [message, code, details] = mockCliError.mock.calls[0] as [
+      string,
+      number,
+      { name: string; fix: string },
+    ];
+    expect(code).toBe(6);
+    expect(details.name).toBe('E_INVALID_PIPELINE_STAGE');
+    expect(message).toContain('forward-only');
+    expect(message).toContain("from 'testing'");
+    expect(message).toContain("to 'research'");
+    expect(details.fix).toContain('testing'); // current stage echoed in fix
+    expect(details.fix).toContain('release'); // a valid forward stage
+
+    // tasks.show was called once (to learn current stage), but tasks.update
+    // dispatch must NOT have fired.
+    expect(mockDispatchFromCli).not.toHaveBeenCalled();
+  });
+
+  it('accepts forward --pipeline-stage transition (implementation → testing)', async () => {
+    mockDispatchRaw.mockResolvedValue(
+      successResponse({ id: 'T001', pipelineStage: 'implementation' }),
+    );
+
+    await invokeUpdate('T001', { 'pipeline-stage': 'testing' });
+
+    expect(mockCliError).not.toHaveBeenCalled();
+    expect(mockDispatchFromCli).toHaveBeenCalledOnce();
+  });
+
+  it('accepts same-stage --pipeline-stage transition (idempotent)', async () => {
+    mockDispatchRaw.mockResolvedValue(
+      successResponse({ id: 'T001', pipelineStage: 'implementation' }),
+    );
+
+    await invokeUpdate('T001', { 'pipeline-stage': 'implementation' });
+
+    expect(mockCliError).not.toHaveBeenCalled();
+    expect(mockDispatchFromCli).toHaveBeenCalledOnce();
+  });
+
+  it('accepts --pipeline-stage when task has no current stage (first assignment)', async () => {
+    mockDispatchRaw.mockResolvedValue(successResponse({ id: 'T001', pipelineStage: null }));
+
+    await invokeUpdate('T001', { 'pipeline-stage': 'implementation' });
+
+    expect(mockCliError).not.toHaveBeenCalled();
+    expect(mockDispatchFromCli).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT validate pipeline-stage when flag is absent', async () => {
+    await invokeUpdate('T001', { title: 'just a title change' });
+
+    expect(mockCliError).not.toHaveBeenCalled();
+    expect(mockDispatchFromCli).toHaveBeenCalledOnce();
+    // No tasks.show round-trip when --pipeline-stage is absent.
+    expect(mockDispatchRaw).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cleo/src/cli/commands/add.ts
+++ b/packages/cleo/src/cli/commands/add.ts
@@ -13,6 +13,7 @@
  * @epic T4454
  */
 
+import { TASK_SEVERITIES } from '@cleocode/contracts';
 import {
   appendSignedSeverityAttestation,
   getProjectRoot,
@@ -219,6 +220,29 @@ export const addCommand = defineCommand({
       await showUsage(cmd);
       return;
     }
+
+    // T10341: validate --severity against the canonical TaskSeverity enum
+    // BEFORE dispatch. Replaces the late-stage SQLite
+    // `CHECK constraint failed: severity` failure mode with a typed
+    // E_INVALID_SEVERITY_VALUE that names the valid enum members.
+    if (
+      args.severity !== undefined &&
+      !TASK_SEVERITIES.includes(args.severity as (typeof TASK_SEVERITIES)[number])
+    ) {
+      const valid = TASK_SEVERITIES.join(', ');
+      cliError(
+        `severity must be one of: ${valid} — got '${args.severity}'`,
+        6,
+        {
+          name: 'E_INVALID_SEVERITY_VALUE',
+          fix: `Pass --severity with one of: ${valid}`,
+        },
+        { operation: 'tasks.add' },
+      );
+      process.exit(6);
+      return;
+    }
+
     const params: Record<string, unknown> = { title: args.title };
 
     if (args.status !== undefined) params['status'] = args.status;

--- a/packages/cleo/src/cli/commands/update.ts
+++ b/packages/cleo/src/cli/commands/update.ts
@@ -19,7 +19,14 @@
  * @epic T4454
  */
 
-import { appendSignedSeverityAttestation, parseAcceptanceCriteria } from '@cleocode/core';
+import { TASK_SEVERITIES } from '@cleocode/contracts';
+import {
+  appendSignedSeverityAttestation,
+  isPipelineTransitionForward,
+  isValidPipelineStage,
+  parseAcceptanceCriteria,
+  TASK_PIPELINE_STAGES,
+} from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli, dispatchRaw } from '../../dispatch/adapters/cli.js';
 import { cliError } from '../renderers/index.js';
@@ -246,6 +253,86 @@ export const updateCommand = defineCommand({
       await showUsage(cmd);
       return;
     }
+
+    // T10341: validate --severity against the canonical TaskSeverity enum
+    // BEFORE dispatch. Replaces the late-stage SQLite
+    // `CHECK constraint failed: severity` failure mode with a typed
+    // E_INVALID_SEVERITY_VALUE that names the valid enum members.
+    if (
+      args.severity !== undefined &&
+      !TASK_SEVERITIES.includes(args.severity as (typeof TASK_SEVERITIES)[number])
+    ) {
+      const valid = TASK_SEVERITIES.join(', ');
+      cliError(
+        `severity must be one of: ${valid} — got '${args.severity}'`,
+        6,
+        {
+          name: 'E_INVALID_SEVERITY_VALUE',
+          fix: `Pass --severity with one of: ${valid}`,
+        },
+        { operation: 'tasks.update' },
+      );
+      process.exit(6);
+      return;
+    }
+
+    // T10341: validate --pipeline-stage against the canonical
+    // TASK_PIPELINE_STAGES enum BEFORE dispatch. Catches both unknown
+    // stage names AND backward transitions (pipeline-stage is
+    // forward-only per RCASD-IVTR+C). Replaces the late-stage failure
+    // (DB CHECK constraint OR opaque core CleoError throw) with a
+    // typed E_INVALID_PIPELINE_STAGE that names the valid next stages.
+    if (args['pipeline-stage'] !== undefined) {
+      const requestedStage = String(args['pipeline-stage']);
+
+      // 1. Unknown stage name — short-circuit with a helpful enum list.
+      if (!isValidPipelineStage(requestedStage)) {
+        const valid = TASK_PIPELINE_STAGES.join(', ');
+        cliError(
+          `pipeline-stage must be one of: ${valid} — got '${requestedStage}'`,
+          6,
+          {
+            name: 'E_INVALID_PIPELINE_STAGE',
+            fix: `Pass --pipeline-stage with one of: ${valid}`,
+          },
+          { operation: 'tasks.update' },
+        );
+        process.exit(6);
+        return;
+      }
+
+      // 2. Backward transition — fetch existing task to learn current
+      // stage and reject if the request would move backward.
+      const showResponse = await dispatchRaw('query', 'tasks', 'show', {
+        taskId: args.taskId,
+      });
+      const existingTask = showResponse.success
+        ? (showResponse.data as Record<string, unknown> | undefined)
+        : undefined;
+      const currentStage =
+        typeof existingTask?.['pipelineStage'] === 'string'
+          ? (existingTask['pipelineStage'] as string)
+          : null;
+
+      if (currentStage && !isPipelineTransitionForward(currentStage, requestedStage)) {
+        const validForward = TASK_PIPELINE_STAGES.filter((s) => {
+          // Same predicate as core's validatePipelineTransition fix hint.
+          return isPipelineTransitionForward(currentStage, s);
+        }).join(', ');
+        cliError(
+          `pipeline-stage transition rejected: cannot move backward from '${currentStage}' to '${requestedStage}'. Pipeline stages are forward-only.`,
+          6,
+          {
+            name: 'E_INVALID_PIPELINE_STAGE',
+            fix: `Pass --pipeline-stage with a stage at or after '${currentStage}'. Valid forward stages: ${validForward}`,
+          },
+          { operation: 'tasks.update' },
+        );
+        process.exit(6);
+        return;
+      }
+    }
+
     const params: Record<string, unknown> = { taskId: args.taskId };
 
     if (args.title !== undefined) params['title'] = args.title;

--- a/packages/contracts/src/exit-codes.ts
+++ b/packages/contracts/src/exit-codes.ts
@@ -323,6 +323,45 @@ export const E_WORKFLOW_NOT_FOUND = 'E_WORKFLOW_NOT_FOUND' as const;
  */
 export const E_WRITE_CONTENTION = 'E_WRITE_CONTENTION' as const;
 
+/**
+ * E_INVALID_SEVERITY_VALUE — `--severity` was passed a value that is not one
+ * of the canonical {@link TASK_SEVERITIES} members (`P0|P1|P2|P3`).
+ *
+ * Returned by the `cleo add` and `cleo update` CLI commands at the dispatch
+ * boundary BEFORE the request reaches the database. Replaces the previous
+ * late-stage failure mode where SQLite surfaced a cryptic
+ * `CHECK constraint failed: severity` error after the write attempt.
+ *
+ * Maps to {@link ExitCode.VALIDATION_ERROR} (6) at the CLI boundary.
+ *
+ * @task T10341
+ * @epic T10327
+ * @saga T10326
+ */
+export const E_INVALID_SEVERITY_VALUE = 'E_INVALID_SEVERITY_VALUE' as const;
+
+/**
+ * E_INVALID_PIPELINE_STAGE — `--pipeline-stage` was passed a value that
+ * either (a) is not a recognised stage name in the canonical RCASD-IVTR+C
+ * pipeline (`research|consensus|architecture_decision|specification|`
+ * `decomposition|implementation|validation|testing|release|contribution|`
+ * `cancelled`), or (b) would move the task BACKWARD relative to its
+ * current stage. Pipeline stages are forward-only.
+ *
+ * Returned by the `cleo update` CLI command at the dispatch boundary BEFORE
+ * the request reaches the database. Replaces the previous late-stage
+ * failure mode where SQLite surfaced a cryptic
+ * `CHECK constraint failed: pipeline_stage` error or the core engine threw
+ * an opaque {@link CleoError} after a partial round-trip.
+ *
+ * Maps to {@link ExitCode.VALIDATION_ERROR} (6) at the CLI boundary.
+ *
+ * @task T10341
+ * @epic T10327
+ * @saga T10326
+ */
+export const E_INVALID_PIPELINE_STAGE = 'E_INVALID_PIPELINE_STAGE' as const;
+
 /** Check if an exit code represents an error (1-99). */
 export function isErrorCode(code: ExitCode): boolean {
   return code >= 1 && code < 100;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -531,6 +531,9 @@ export {
   E_EVIDENCE_INSUFFICIENT,
   // SPEC-T9345 release pipeline v2 error code names (T9530)
   E_GH_NOT_AUTHENTICATED,
+  // T10341 — typed CLI-layer validation for --severity + --pipeline-stage
+  E_INVALID_PIPELINE_STAGE,
+  E_INVALID_SEVERITY_VALUE,
   E_INVALID_STATE,
   E_PLAN_NOT_FOUND,
   E_RELEASE_PLAN_INVALID,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -602,6 +602,26 @@ export {
   parseAcceptanceCriteria,
 } from './tasks/infer-add-params.js';
 export { listTasks } from './tasks/list.js';
+// Pipeline-stage canonical helpers (T060, T871, T10341)
+//
+// Re-exported from the PUBLIC barrel so CLI commands can validate
+// --pipeline-stage arguments at dispatch entry without violating the
+// lint-core-first RULE-3 ban on `@cleocode/core/internal` imports.
+//
+// @task T10341
+// @epic T10327
+// @saga T10326
+export {
+  getPipelineStageOrder,
+  isPipelineTransitionForward,
+  isTerminalPipelineStage,
+  isValidPipelineStage,
+  TASK_PIPELINE_STAGES,
+  type TaskPipelineStage,
+  TERMINAL_PIPELINE_STAGES,
+  validatePipelineStage,
+  validatePipelineTransition,
+} from './tasks/pipeline-stage.js';
 // System-wide severity attestation primitive (T9071 / ADR-054 draft)
 export {
   type AppendSeverityAttestationOptions,


### PR DESCRIPTION
## Summary

- Validates `--severity` and `--pipeline-stage` at the CLI dispatch boundary BEFORE the request reaches SQLite. Replaces the cryptic late-stage `CHECK constraint failed: severity` (or `pipeline_stage`) failure mode with a typed contract error naming the valid enum members.
- New error codes: `E_INVALID_SEVERITY_VALUE`, `E_INVALID_PIPELINE_STAGE` (both `@cleocode/contracts`, both exit 6).
- Re-exports `TASK_PIPELINE_STAGES` + the pipeline-stage helpers (`isValidPipelineStage`, `isPipelineTransitionForward`, `validatePipelineStage`, `validatePipelineTransition`, `isTerminalPipelineStage`, `getPipelineStageOrder`, `TERMINAL_PIPELINE_STAGES`, `TaskPipelineStage`) from the `@cleocode/core` public barrel so CLI commands can consume them without violating the lint-core-first RULE-3 ban on `@cleocode/core/internal` imports.

## Before vs After

Before:
```
$ cleo add --severity CRITICAL "task"
Error: CHECK constraint failed: severity (1)
```

After:
```
$ cleo add --severity CRITICAL "task"
Error: severity must be one of: P0, P1, P2, P3 — got 'CRITICAL' (6)
Fix: Pass --severity with one of: P0, P1, P2, P3
```

Same pattern for `--pipeline-stage` (catches both unknown stage names and backward transitions before any DB round-trip).

## Test plan

- [x] `pnpm biome check` clean on touched files
- [x] `pnpm run build` clean (all 9 waves)
- [x] New regression test `add-update-severity-pipeline-validation.test.ts`: 15/15 pass — invalid severity (CRITICAL, P9), valid severity (P0..P3), invalid pipeline-stage (unknown name), backward transition (testing → research), forward transition (implementation → testing), same-stage idempotent, first-assignment (null current stage)
- [x] Full `@cleocode/cleo` test suite parity vs main baseline: 60 failed / 133 passed (identical numbers — all failures pre-existing, unrelated to T10341)
- [x] `@cleocode/contracts` test suite: 28/28 pass

Closes T10341
Saga: T10326
Refs: ADR-066

🤖 Generated with [Claude Code](https://claude.com/claude-code)