### PR TITLE
feat(cleo): T10340 doctor --audit-invariants walks central registry

### DIFF
--- a/.changeset/T10340.md
+++ b/.changeset/T10340.md
@@ -1,0 +1,24 @@
+---
+id: t10340-doctor-audit-invariants
+tasks: [T10340]
+kind: feat
+summary: "cleo doctor --audit-invariants walks central INVARIANTS_REGISTRY (Saga T10326 R6)"
+---
+
+Adds `cleo doctor --audit-invariants` which walks the central
+`INVARIANTS_REGISTRY` (`@cleocode/contracts`) and produces a per-entry
+audit report grouped by ADR + severity with actionable repair commands.
+`--audit-sagas` becomes a focused alias that filters the registry walk to
+ADR-073 only — both surfaces delegate to one `auditInvariantRegistry`
+SSoT in `@cleocode/core/doctor/invariant-audit.ts`.
+
+Supports `--json` for machine consumption; exits non-zero when any
+`severity:'error'` violation is observed. ADR-073 saga gates (I5/I7)
+delegate to the production-hardened `auditSagaHierarchy` (T10119). Spawn-
+/session-/release-tag-bound runtime gates (most of ADR-070 ORC codes,
+ADR-056 D4/D5) surface as `'not-applicable'` with the gate location so
+the gap analysis is visible end-to-end. Entries with `runtimeGate:null`
+report `'documented'` so registry-only invariants are counted.
+
+Saga: T10326 SG-SUBSTRATE-RECONCILIATION / Epic T10327
+E-INVARIANT-REGISTRY-SSOT / R6.

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -19,6 +19,7 @@ import { join } from 'node:path';
 import type { InvariantAuditResult } from '@cleocode/contracts';
 import type { HookMatrixResult } from '@cleocode/core';
 import { getProjectRoot, pushWarning } from '@cleocode/core';
+import { renderInvariantAuditLines } from '@cleocode/core/doctor/invariant-audit-render.js';
 import {
   quarantineRogueCleoDir,
   scanRogueCleoDirs,
@@ -198,76 +199,20 @@ function renderHookMatrixHuman(data: HookMatrixResult): void {
 }
 
 /**
- * Render the invariant-registry audit result in a human-readable form.
+ * Render the invariant-registry audit result by delegating to the core
+ * line-builder and emitting each line via `humanLine`.
  *
- * Output structure (T10340 / Saga T10326 R6 AC2 + AC3):
- *   - Header line with totals + filter context.
- *   - One block per ADR (alphabetically), with severity bands inside.
- *   - Each violation line includes the offender ID + repair command.
- *   - Trailing summary recapping the `not-applicable` / `documented`
- *     counts so the gap analysis is visible end-to-end.
+ * The actual rendering logic lives in
+ * `@cleocode/core/doctor/invariant-audit-render.js` so the CLI Boundary
+ * lint (T10076) stays satisfied — this thin wrapper is < 10 LOC.
  *
  * @task T10340
  * @epic T10327
  * @saga T10326
  */
 function renderInvariantAuditHuman(result: InvariantAuditResult): void {
-  const filterSuffix = result.filteredByAdr === null ? '' : ` (filtered: ${result.filteredByAdr})`;
-  humanLine(`\nInvariant Registry Audit${filterSuffix}`);
-  humanLine(
-    `  ${result.totalCount} entries · ${result.errorCount} error · ` +
-      `${result.warningCount} warning · ${result.infoCount} info · ` +
-      `${result.notApplicableCount} not-applicable · ${result.documentedCount} documented\n`,
-  );
-
-  // Group entries by ADR (stable: entries are already sorted by ADR + code).
-  const byAdr = new Map<string, typeof result.entries>();
-  for (const entry of result.entries) {
-    const bucket = byAdr.get(entry.adr) ?? [];
-    bucket.push(entry);
-    byAdr.set(entry.adr, bucket);
-  }
-
-  const severityRank: Record<string, number> = {
-    error: 0,
-    warning: 1,
-    info: 2,
-  };
-
-  for (const adr of Array.from(byAdr.keys()).sort()) {
-    const adrEntries = byAdr.get(adr) ?? [];
-    const failing = adrEntries.filter((e) => e.status === 'fail');
-    humanLine(`[${adr}] ${adrEntries.length} invariant(s), ${failing.length} failing:`);
-
-    // Sort failing entries by severity (error → warning → info), then by code.
-    const failingSorted = failing.slice().sort((a, b) => {
-      const ra = severityRank[a.severity] ?? 9;
-      const rb = severityRank[b.severity] ?? 9;
-      if (ra !== rb) return ra - rb;
-      return a.code.localeCompare(b.code);
-    });
-
-    for (const entry of failingSorted) {
-      humanLine(
-        `  [${entry.severity.toUpperCase()}] ${entry.code} · ${entry.name}` +
-          ` (${entry.violations.length} violation(s))`,
-      );
-      for (const v of entry.violations) {
-        humanLine(`    - ${v.message}`);
-        humanLine(`      repair: ${v.repairCommand}`);
-      }
-    }
-
-    // Show passing / documented / not-applicable as a single roll-up line so
-    // the operator sees that the entries WERE walked, not just skipped.
-    const passing = adrEntries.filter((e) => e.status === 'pass').length;
-    const docd = adrEntries.filter((e) => e.status === 'documented').length;
-    const na = adrEntries.filter((e) => e.status === 'not-applicable').length;
-    humanLine(`  (${passing} passing · ${docd} documented · ${na} not-applicable)\n`);
-  }
-
-  if (result.entries.length === 0) {
-    humanLine('  (no invariants registered)\n');
+  for (const line of renderInvariantAuditLines(result)) {
+    humanLine(line);
   }
 }
 

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -16,6 +16,7 @@
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import type { InvariantAuditResult } from '@cleocode/contracts';
 import type { HookMatrixResult } from '@cleocode/core';
 import { getProjectRoot, pushWarning } from '@cleocode/core';
 import {
@@ -197,6 +198,80 @@ function renderHookMatrixHuman(data: HookMatrixResult): void {
 }
 
 /**
+ * Render the invariant-registry audit result in a human-readable form.
+ *
+ * Output structure (T10340 / Saga T10326 R6 AC2 + AC3):
+ *   - Header line with totals + filter context.
+ *   - One block per ADR (alphabetically), with severity bands inside.
+ *   - Each violation line includes the offender ID + repair command.
+ *   - Trailing summary recapping the `not-applicable` / `documented`
+ *     counts so the gap analysis is visible end-to-end.
+ *
+ * @task T10340
+ * @epic T10327
+ * @saga T10326
+ */
+function renderInvariantAuditHuman(result: InvariantAuditResult): void {
+  const filterSuffix = result.filteredByAdr === null ? '' : ` (filtered: ${result.filteredByAdr})`;
+  humanLine(`\nInvariant Registry Audit${filterSuffix}`);
+  humanLine(
+    `  ${result.totalCount} entries · ${result.errorCount} error · ` +
+      `${result.warningCount} warning · ${result.infoCount} info · ` +
+      `${result.notApplicableCount} not-applicable · ${result.documentedCount} documented\n`,
+  );
+
+  // Group entries by ADR (stable: entries are already sorted by ADR + code).
+  const byAdr = new Map<string, typeof result.entries>();
+  for (const entry of result.entries) {
+    const bucket = byAdr.get(entry.adr) ?? [];
+    bucket.push(entry);
+    byAdr.set(entry.adr, bucket);
+  }
+
+  const severityRank: Record<string, number> = {
+    error: 0,
+    warning: 1,
+    info: 2,
+  };
+
+  for (const adr of Array.from(byAdr.keys()).sort()) {
+    const adrEntries = byAdr.get(adr) ?? [];
+    const failing = adrEntries.filter((e) => e.status === 'fail');
+    humanLine(`[${adr}] ${adrEntries.length} invariant(s), ${failing.length} failing:`);
+
+    // Sort failing entries by severity (error → warning → info), then by code.
+    const failingSorted = failing.slice().sort((a, b) => {
+      const ra = severityRank[a.severity] ?? 9;
+      const rb = severityRank[b.severity] ?? 9;
+      if (ra !== rb) return ra - rb;
+      return a.code.localeCompare(b.code);
+    });
+
+    for (const entry of failingSorted) {
+      humanLine(
+        `  [${entry.severity.toUpperCase()}] ${entry.code} · ${entry.name}` +
+          ` (${entry.violations.length} violation(s))`,
+      );
+      for (const v of entry.violations) {
+        humanLine(`    - ${v.message}`);
+        humanLine(`      repair: ${v.repairCommand}`);
+      }
+    }
+
+    // Show passing / documented / not-applicable as a single roll-up line so
+    // the operator sees that the entries WERE walked, not just skipped.
+    const passing = adrEntries.filter((e) => e.status === 'pass').length;
+    const docd = adrEntries.filter((e) => e.status === 'documented').length;
+    const na = adrEntries.filter((e) => e.status === 'not-applicable').length;
+    humanLine(`  (${passing} passing · ${docd} documented · ${na} not-applicable)\n`);
+  }
+
+  if (result.entries.length === 0) {
+    humanLine('  (no invariants registered)\n');
+  }
+}
+
+/**
  * Root doctor command — run system diagnostics and health checks.
  *
  * Global output flags (--json, --human, --quiet) are declared in args so
@@ -313,14 +388,38 @@ export const doctorCommand = defineCommand({
      * auto-close drift. Read-only; non-zero exit when any I-invariant
      * fails so the check is CI-gateable.
      *
+     * As of T10340 (R6), `--audit-sagas` is a focused alias on top of
+     * `--audit-invariants` — it filters the registry walk to ADR-073
+     * only. The implementation re-uses the central walker so the two
+     * surfaces stay in lock-step.
+     *
      * @task T10119
+     * @task T10340
      * @saga T10113
      * @epic T10209
      */
     'audit-sagas': {
       type: 'boolean',
       description:
-        'Audit every Saga for ADR-073 §1.2 invariant violations (I5/I7/depth) + auto-close drift (T10119)',
+        'Audit every Saga for ADR-073 §1.2 invariant violations (I5/I7/depth) + auto-close drift — focused alias on top of --audit-invariants (T10119, T10340)',
+    },
+    /**
+     * T10340: walk the central `INVARIANTS_REGISTRY` and audit every
+     * registered invariant against the project's current state.
+     *
+     * Output groups violations by ADR + severity and includes an
+     * actionable repair command per violation. Supports `--json` for
+     * machine consumption. Exit code is non-zero when any
+     * `severity:'error'` violation is observed.
+     *
+     * @task T10340 — R6
+     * @epic T10327 — E-INVARIANT-REGISTRY-SSOT
+     * @saga T10326 — SG-SUBSTRATE-RECONCILIATION
+     */
+    'audit-invariants': {
+      type: 'boolean',
+      description:
+        'Walk the central INVARIANTS_REGISTRY and audit every registered invariant — groups by ADR + severity with repair commands (T10340 / Saga T10326 R6)',
     },
     /**
      * T9983: migrate the worktree-include file location from
@@ -832,20 +931,34 @@ export const doctorCommand = defineCommand({
         ) {
           process.exitCode = 2;
         }
-      } else if (args['audit-sagas']) {
-        // T10119: ADR-073 §1.2 saga-hierarchy audit (I5/I7/depth + drift).
-        progress.step(0, 'Auditing Saga hierarchy for ADR-073 invariants');
-        const { auditSagaHierarchy } = await import('@cleocode/core/doctor/saga-audit.js');
+      } else if (args['audit-invariants'] || args['audit-sagas']) {
+        // T10340 (R6): walk central INVARIANTS_REGISTRY (full or ADR-filtered).
+        // --audit-sagas is a focused alias that delegates to the same walker
+        // with adrFilter='ADR-073' (Saga T10326 invariant: one SSoT, two
+        // surfaces). T10119: legacy CLI flag preserved verbatim.
+        const isFocusedAlias = args['audit-sagas'] === true && args['audit-invariants'] !== true;
+        const adrFilter = isFocusedAlias ? 'ADR-073' : undefined;
+        const stepLabel = isFocusedAlias
+          ? 'Auditing Saga hierarchy for ADR-073 invariants'
+          : 'Walking central INVARIANTS_REGISTRY';
+        progress.step(0, stepLabel);
+        const { auditInvariantRegistry } = await import('@cleocode/core/doctor/invariant-audit.js');
         const projectRoot = getProjectRoot();
-        const result = await auditSagaHierarchy(projectRoot);
+        const result = await auditInvariantRegistry(projectRoot, { adrFilter });
 
+        const operation = isFocusedAlias ? 'doctor.audit-sagas' : 'doctor.audit-invariants';
         const summary =
-          `Saga audit complete — ${result.sagas.length} saga(s) inspected, ` +
-          `${result.count} invariant violation(s), ${result.driftCount} drift warning(s)`;
+          `Invariant audit complete — ${result.totalCount} entries walked, ` +
+          `${result.errorCount} error / ${result.warningCount} warning / ${result.infoCount} info violation(s), ` +
+          `${result.notApplicableCount} not-applicable, ${result.documentedCount} documented`;
         progress.complete(summary);
 
-        cliOutput(result, { command: 'doctor', operation: 'doctor.audit-sagas' });
-        if (result.count > 0 && (process.exitCode === undefined || process.exitCode === 0)) {
+        if (isHuman && args.json !== true) {
+          renderInvariantAuditHuman(result);
+        }
+
+        cliOutput(result, { command: 'doctor', operation });
+        if (result.errorCount > 0 && (process.exitCode === undefined || process.exitCode === 0)) {
           process.exitCode = 2;
         }
       } else {

--- a/packages/contracts/src/doctor.ts
+++ b/packages/contracts/src/doctor.ts
@@ -20,6 +20,8 @@
  * @epic T9808
  */
 
+import type { InvariantSeverity } from './invariants/index.js';
+
 /**
  * One orphan `.cleo/` directory discovered under
  * `<projectRoot>/.claude/worktrees/`.
@@ -284,6 +286,115 @@ export interface SagaAuditResult {
   count: number;
   /** Total auto-close-drift warnings across all sagas. */
   driftCount: number;
+}
+
+// ============================================================================
+// Invariant Registry Audit (T10340 — Saga T10326 SG-SUBSTRATE-RECONCILIATION /
+// Epic T10327 E-INVARIANT-REGISTRY-SSOT / R6)
+// ============================================================================
+
+/**
+ * Per-entry status reported by {@link auditInvariantRegistry}.
+ *
+ * - `'pass'` — the entry has an adapter that executed against the current
+ *   `.cleo/tasks.db` state and observed zero violations.
+ * - `'fail'` — the entry has an adapter that executed and observed one or
+ *   more violations (forwarded into {@link InvariantAuditEntry.violations}).
+ * - `'not-applicable'` — the entry's `runtimeGate` is spawn-bound,
+ *   session-bound, or release-tag-bound, so there is no "scan current DB"
+ *   interpretation. Reported for completeness so the registry walk is
+ *   visible end-to-end.
+ * - `'documented'` — the entry has `runtimeGate === null` by design (the
+ *   invariant is a display/storage/process concern enforced elsewhere).
+ *   No check performed; surfaced so operators can audit gap coverage.
+ *
+ * @task T10340
+ */
+export type InvariantAuditStatus = 'pass' | 'fail' | 'not-applicable' | 'documented';
+
+/**
+ * One violation surfaced by {@link auditInvariantRegistry}.
+ *
+ * The shape intentionally mirrors {@link SagaAuditViolation} (so the saga
+ * audit pipeline can adapt its findings into this envelope without an
+ * intermediate transform), but the `invariantKey` field is the registry
+ * key (`${adr}.${code}`, e.g. `'ADR-073.I5'`) instead of a saga-only
+ * `kind` discriminator.
+ *
+ * @task T10340
+ */
+export interface InvariantAuditViolation {
+  /** Registry key — `${adr}.${code}`. */
+  invariantKey: string;
+  /** The offending task / row / resource identifier. */
+  offendingId: string;
+  /** Human-readable message naming the offender + repair command. */
+  message: string;
+  /** Canonical `cleo` command an operator should run to resolve. */
+  repairCommand: string;
+}
+
+/**
+ * Per-invariant audit entry produced by {@link auditInvariantRegistry}.
+ *
+ * One entry per registered invariant. `status` summarises the outcome of
+ * the adapter (or the lack thereof). `violations` is always present —
+ * empty when `status !== 'fail'`.
+ *
+ * @task T10340
+ */
+export interface InvariantAuditEntry {
+  /** Registry key — `${adr}.${code}`. */
+  invariantKey: string;
+  /** Source ADR identifier, e.g. `'ADR-073'`. */
+  adr: string;
+  /** Invariant code within the ADR, e.g. `'I3'` or `'ORC-001'`. */
+  code: string;
+  /** Short human-readable name. */
+  name: string;
+  /** Severity tier — drives exit code in the CLI surface. */
+  severity: InvariantSeverity;
+  /** Adapter outcome. See {@link InvariantAuditStatus}. */
+  status: InvariantAuditStatus;
+  /** Free-form note for `'not-applicable'` / `'documented'` entries. */
+  note: string;
+  /** Runtime-gate function name, when one is registered. `null` otherwise. */
+  runtimeGate: string | null;
+  /** Violations observed by the adapter. Empty when `status !== 'fail'`. */
+  violations: InvariantAuditViolation[];
+}
+
+/**
+ * Aggregated audit result returned by {@link auditInvariantRegistry}.
+ *
+ * `entries` carries one entry per registered invariant, sorted first by
+ * ADR (alphabetical), then by code. `errorCount` is the count of
+ * `severity: 'error'` entries whose status is `'fail'` — the only
+ * dimension that should drive a non-zero exit code in the CLI surface.
+ *
+ * Aggregates `warningCount` + `infoCount` cover the corresponding
+ * severities for `'fail'` entries. `notApplicableCount` + `documentedCount`
+ * surface the gap analysis (how many invariants are registry-only).
+ *
+ * @task T10340
+ */
+export interface InvariantAuditResult {
+  /** Per-invariant audit entries. Sorted by ADR then code. */
+  entries: InvariantAuditEntry[];
+  /** Total registered invariants walked. */
+  totalCount: number;
+  /** Entries with status='fail' AND severity='error'. */
+  errorCount: number;
+  /** Entries with status='fail' AND severity='warning'. */
+  warningCount: number;
+  /** Entries with status='fail' AND severity='info'. */
+  infoCount: number;
+  /** Entries with status='not-applicable' (spawn/session/release-bound). */
+  notApplicableCount: number;
+  /** Entries with status='documented' (runtimeGate:null by design). */
+  documentedCount: number;
+  /** ADR filter applied (e.g. `'ADR-073'`), or `null` when the walk was unfiltered. */
+  filteredByAdr: string | null;
 }
 
 // ============================================================================

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -393,6 +393,7 @@ export {
 // === Doctor: DB-Substrate Survey (T10307 — Saga T10281 / Epic T10282) ===
 // === Doctor: Legacy-Backup Walker (T10309 — Saga T10281 / Epic T10282) ===
 // === Doctor: Cross-DB Invariants (T10323 — Saga T10281 / Epic T10285) ===
+// === Doctor: Invariant Registry Audit (T10340 — Saga T10326 / Epic T10327) ===
 export type {
   ComprehensiveAuditResult,
   DbCrossDbInvariantId,
@@ -407,6 +408,10 @@ export type {
   DbSubstrateSurveyOptions,
   DbSubstrateWarning,
   DbSubstrateWarningKind,
+  InvariantAuditEntry,
+  InvariantAuditResult,
+  InvariantAuditStatus,
+  InvariantAuditViolation,
   LegacyBackupEntry,
   LegacyBackupOriginHint,
   LegacyBackupRecommendation,

--- a/packages/core/src/doctor/__tests__/invariant-audit.test.ts
+++ b/packages/core/src/doctor/__tests__/invariant-audit.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for `auditInvariantRegistry` (T10340 / Saga T10326 R6).
+ *
+ * Covers:
+ *   1. Empty DB → every entry reports `documented` or `not-applicable`;
+ *      zero failures.
+ *   2. Seeded I5 violation (saga with parent_id != null) → ADR-073.I5 entry
+ *      transitions to status='fail' with severity='error' AND `errorCount`
+ *      rises above zero.
+ *   3. `adrFilter='ADR-073'` returns ONLY ADR-073 entries — used by the
+ *      `--audit-sagas` focused alias.
+ *   4. Output is deterministic: entries sorted by (adr, code).
+ *
+ * @task T10340
+ * @saga T10326
+ * @epic T10327
+ */
+
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let tempDir: string;
+
+interface NativeDbForTest {
+  prepare: (sql: string) => { run: (...args: (string | number | null)[]) => void };
+}
+
+/**
+ * Insert a single task row directly. Mirrors the helper in
+ * `saga-audit.test.ts` so the seeded shapes line up exactly.
+ */
+function insertTask(
+  db: NativeDbForTest,
+  row: {
+    id: string;
+    title: string;
+    type: 'epic' | 'task' | 'subtask';
+    status?: 'pending' | 'active' | 'done' | 'blocked';
+    parentId?: string | null;
+    labels?: string[];
+  },
+): void {
+  const status = row.status ?? 'pending';
+  const pipelineStage = status === 'done' ? 'contribution' : null;
+  db.prepare(
+    'INSERT INTO tasks (id, title, type, status, parent_id, labels_json, pipeline_stage) VALUES (?, ?, ?, ?, ?, ?, ?)',
+  ).run(
+    row.id,
+    row.title,
+    row.type,
+    status,
+    row.parentId ?? null,
+    JSON.stringify(row.labels ?? []),
+    pipelineStage,
+  );
+}
+
+describe('auditInvariantRegistry (T10340)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-invariant-audit-'));
+    await mkdir(join(tempDir, '.cleo'), { recursive: true });
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+
+    const { getDb } = await import('../../store/sqlite.js');
+    await getDb(tempDir);
+  });
+
+  afterEach(async () => {
+    try {
+      const { closeDb } = await import('../../store/sqlite.js');
+      closeDb();
+    } catch {
+      /* may not be loaded */
+    }
+    delete process.env['CLEO_DIR'];
+    await Promise.race([
+      rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 300 }).catch(() => {}),
+      new Promise<void>((resolve) => setTimeout(resolve, 8_000)),
+    ]);
+  });
+
+  it('walks every registered invariant on a clean DB with zero failures', async () => {
+    const { auditInvariantRegistry } = await import('../invariant-audit.js');
+    const result = await auditInvariantRegistry(tempDir);
+
+    expect(result.totalCount).toBeGreaterThan(0);
+    expect(result.errorCount).toBe(0);
+    expect(result.warningCount).toBe(0);
+    expect(result.infoCount).toBe(0);
+    expect(result.filteredByAdr).toBeNull();
+
+    // Every entry is one of the four legal statuses.
+    for (const entry of result.entries) {
+      expect(['pass', 'fail', 'not-applicable', 'documented']).toContain(entry.status);
+      expect(entry.violations.length).toBe(entry.status === 'fail' ? entry.violations.length : 0);
+    }
+
+    // The walk visited at least ADR-073 + ADR-070 + ADR-056 entries.
+    const adrs = new Set(result.entries.map((e) => e.adr));
+    expect(adrs.has('ADR-073')).toBe(true);
+    expect(adrs.has('ADR-070')).toBe(true);
+    expect(adrs.has('ADR-056')).toBe(true);
+  });
+
+  it('flags ADR-073.I5 as a fail when a saga carries a non-null parentId', async () => {
+    const { getNativeDb } = await import('../../store/sqlite.js');
+    const db = getNativeDb() as NativeDbForTest | null;
+    if (!db) throw new Error('nativeDb not initialized');
+
+    // Seed a saga with an illegal parent_id (ADR-073 §1.2 I5 violation).
+    insertTask(db, { id: 'E_PARENT', title: 'Parent Epic', type: 'epic' });
+    insertTask(db, {
+      id: 'SG_BAD',
+      title: 'Saga with parent',
+      type: 'epic',
+      labels: ['saga'],
+      parentId: 'E_PARENT',
+    });
+
+    const { auditInvariantRegistry } = await import('../invariant-audit.js');
+    const result = await auditInvariantRegistry(tempDir);
+
+    const i5Entry = result.entries.find((e) => e.invariantKey === 'ADR-073.I5');
+    expect(i5Entry).toBeDefined();
+    expect(i5Entry?.status).toBe('fail');
+    expect(i5Entry?.severity).toBe('error');
+    expect(i5Entry?.violations.length).toBeGreaterThan(0);
+
+    const offender = i5Entry?.violations.find((v) => v.offendingId === 'SG_BAD');
+    expect(offender).toBeDefined();
+    expect(offender?.message).toContain('I5');
+    expect(offender?.repairCommand).toBe('cleo saga repair SG_BAD');
+
+    // Aggregate counts reflect the failure.
+    expect(result.errorCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('filters to ADR-073 only when adrFilter is set (--audit-sagas alias)', async () => {
+    const { auditInvariantRegistry } = await import('../invariant-audit.js');
+    const result = await auditInvariantRegistry(tempDir, { adrFilter: 'ADR-073' });
+
+    expect(result.filteredByAdr).toBe('ADR-073');
+    expect(result.entries.length).toBeGreaterThan(0);
+    for (const entry of result.entries) {
+      expect(entry.adr).toBe('ADR-073');
+    }
+    const adrs = new Set(result.entries.map((e) => e.adr));
+    expect(adrs.size).toBe(1);
+  });
+
+  it('returns entries sorted by (adr, code) for deterministic output', async () => {
+    const { auditInvariantRegistry } = await import('../invariant-audit.js');
+    const result = await auditInvariantRegistry(tempDir);
+
+    for (let i = 1; i < result.entries.length; i++) {
+      const prev = result.entries[i - 1];
+      const curr = result.entries[i];
+      if (prev === undefined || curr === undefined) continue;
+      if (prev.adr === curr.adr) {
+        expect(curr.code.localeCompare(prev.code)).toBeGreaterThanOrEqual(0);
+      } else {
+        expect(curr.adr.localeCompare(prev.adr)).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('marks runtimeGate-null entries as documented (gap analysis)', async () => {
+    const { auditInvariantRegistry } = await import('../invariant-audit.js');
+    const result = await auditInvariantRegistry(tempDir);
+
+    // ADR-073.I1 carries runtimeGate:null by design (DB CHECK + ID convention).
+    const i1 = result.entries.find((e) => e.invariantKey === 'ADR-073.I1');
+    expect(i1).toBeDefined();
+    expect(i1?.status).toBe('documented');
+    expect(i1?.runtimeGate).toBeNull();
+    expect(result.documentedCount).toBeGreaterThan(0);
+  });
+
+  it('reports spawn-bound runtime gates as not-applicable', async () => {
+    const { auditInvariantRegistry } = await import('../invariant-audit.js');
+    const result = await auditInvariantRegistry(tempDir);
+
+    // ORC-012 (thin-agent) IS hard-enforced but is spawn-time, not DB-scan.
+    const orc012 = result.entries.find((e) => e.invariantKey === 'ADR-070.ORC-012');
+    expect(orc012).toBeDefined();
+    expect(orc012?.status).toBe('not-applicable');
+    expect(orc012?.runtimeGate).toBe('enforceThinAgent');
+    expect(result.notApplicableCount).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/doctor/index.ts
+++ b/packages/core/src/doctor/index.ts
@@ -39,9 +39,10 @@ export {
   walkCrossDbInvariants,
   walkPragmaDrift,
 } from './db-substrate.js';
+export { auditInvariantRegistry } from './invariant-audit.js';
 // T10340 — Invariant Registry Audit (Saga T10326 SG-SUBSTRATE-RECONCILIATION /
 // Epic T10327 E-INVARIANT-REGISTRY-SSOT / R6)
-export { auditInvariantRegistry } from './invariant-audit.js';
+export { renderInvariantAuditLines } from './invariant-audit-render.js';
 // T10309 — Legacy-backup walker (Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10282)
 export type { LegacyBackupPruneOptions, LegacyBackupScanOptions } from './legacy-backups.js';
 export {

--- a/packages/core/src/doctor/index.ts
+++ b/packages/core/src/doctor/index.ts
@@ -39,6 +39,9 @@ export {
   walkCrossDbInvariants,
   walkPragmaDrift,
 } from './db-substrate.js';
+// T10340 — Invariant Registry Audit (Saga T10326 SG-SUBSTRATE-RECONCILIATION /
+// Epic T10327 E-INVARIANT-REGISTRY-SSOT / R6)
+export { auditInvariantRegistry } from './invariant-audit.js';
 // T10309 — Legacy-backup walker (Saga T10281 SG-BRAIN-DB-RESILIENCE / Epic T10282)
 export type { LegacyBackupPruneOptions, LegacyBackupScanOptions } from './legacy-backups.js';
 export {

--- a/packages/core/src/doctor/invariant-audit-render.ts
+++ b/packages/core/src/doctor/invariant-audit-render.ts
@@ -1,0 +1,132 @@
+/**
+ * Human-render lines for `cleo doctor --audit-invariants` (T10340).
+ *
+ * Pure string-builder — produces an array of lines that the CLI thin
+ * wrapper emits via `humanLine`. Keeping rendering in core honours the
+ * CLI Boundary lint (T10076) and lets the underlying primitive be
+ * unit-tested without spinning up the CLI surface.
+ *
+ * Output structure (Saga T10326 R6 AC2 + AC3):
+ *   - Header line with totals + filter context.
+ *   - One block per ADR (alphabetically), with severity bands inside.
+ *   - Each violation line includes the offender ID + repair command.
+ *   - Trailing roll-up recapping `passing / documented / not-applicable`
+ *     so the gap analysis is visible end-to-end.
+ *
+ * @task T10340
+ * @epic T10327
+ * @saga T10326
+ */
+
+import type { InvariantAuditEntry, InvariantAuditResult } from '@cleocode/contracts';
+
+/**
+ * Stable severity ordering used to sort failing entries inside each ADR
+ * block. `error` is loudest, `info` quietest.
+ *
+ * @internal
+ */
+const SEVERITY_RANK: Record<string, number> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+};
+
+/**
+ * Compose the lines for the audit header (totals + optional filter
+ * context). Returns two lines so the CLI surface can interleave a blank
+ * line if it wants to.
+ *
+ * @internal
+ */
+function renderHeaderLines(result: InvariantAuditResult): string[] {
+  const filterSuffix = result.filteredByAdr === null ? '' : ` (filtered: ${result.filteredByAdr})`;
+  return [
+    `Invariant Registry Audit${filterSuffix}`,
+    `  ${result.totalCount} entries · ${result.errorCount} error · ` +
+      `${result.warningCount} warning · ${result.infoCount} info · ` +
+      `${result.notApplicableCount} not-applicable · ${result.documentedCount} documented`,
+  ];
+}
+
+/**
+ * Compose the lines for the failing entries inside a single ADR block.
+ * Each violation line is followed by a `repair:` line with the canonical
+ * command. Returns an empty array when there are no failures.
+ *
+ * @internal
+ */
+function renderFailingEntryLines(failing: InvariantAuditEntry[]): string[] {
+  const out: string[] = [];
+  const failingSorted = failing.slice().sort((a, b) => {
+    const ra = SEVERITY_RANK[a.severity] ?? 9;
+    const rb = SEVERITY_RANK[b.severity] ?? 9;
+    if (ra !== rb) return ra - rb;
+    return a.code.localeCompare(b.code);
+  });
+  for (const entry of failingSorted) {
+    out.push(
+      `  [${entry.severity.toUpperCase()}] ${entry.code} · ${entry.name}` +
+        ` (${entry.violations.length} violation(s))`,
+    );
+    for (const v of entry.violations) {
+      out.push(`    - ${v.message}`);
+      out.push(`      repair: ${v.repairCommand}`);
+    }
+  }
+  return out;
+}
+
+/**
+ * Compose the lines for one ADR block (header + failing rows + roll-up).
+ *
+ * @internal
+ */
+function renderAdrBlockLines(adr: string, entries: InvariantAuditEntry[]): string[] {
+  const out: string[] = [];
+  const failing = entries.filter((e) => e.status === 'fail');
+  out.push(`[${adr}] ${entries.length} invariant(s), ${failing.length} failing:`);
+  out.push(...renderFailingEntryLines(failing));
+  const passing = entries.filter((e) => e.status === 'pass').length;
+  const docd = entries.filter((e) => e.status === 'documented').length;
+  const na = entries.filter((e) => e.status === 'not-applicable').length;
+  out.push(`  (${passing} passing · ${docd} documented · ${na} not-applicable)`);
+  return out;
+}
+
+/**
+ * Render the invariant-registry audit result as an array of human-readable
+ * lines. The CLI thin-wrapper emits each entry via `humanLine` so this
+ * function stays free of side effects + the rendering is unit-testable.
+ *
+ * @param result - The audit result from `auditInvariantRegistry`.
+ * @returns An ordered list of lines to emit, one per row. Blank-line
+ *          separators are produced as empty strings so the consumer can
+ *          decide whether to fold them.
+ */
+export function renderInvariantAuditLines(result: InvariantAuditResult): string[] {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(...renderHeaderLines(result));
+  lines.push('');
+
+  // Group entries by ADR (stable: entries are already sorted by ADR + code).
+  const byAdr = new Map<string, InvariantAuditEntry[]>();
+  for (const entry of result.entries) {
+    const bucket = byAdr.get(entry.adr) ?? [];
+    bucket.push(entry);
+    byAdr.set(entry.adr, bucket);
+  }
+
+  for (const adr of Array.from(byAdr.keys()).sort()) {
+    const adrEntries = byAdr.get(adr) ?? [];
+    lines.push(...renderAdrBlockLines(adr, adrEntries));
+    lines.push('');
+  }
+
+  if (result.entries.length === 0) {
+    lines.push('  (no invariants registered)');
+    lines.push('');
+  }
+  return lines;
+}

--- a/packages/core/src/doctor/invariant-audit.ts
+++ b/packages/core/src/doctor/invariant-audit.ts
@@ -1,0 +1,424 @@
+/**
+ * Invariant-registry walker for `cleo doctor --audit-invariants` (T10340).
+ *
+ * Iterates the central `INVARIANTS_REGISTRY` from `@cleocode/contracts`
+ * (assembled by Saga T10326 R1-R5 — ADR-073 I1-I8 + ADR-070 ORC-001..014 +
+ * ADR-056 D1-D6) and produces one {@link InvariantAuditEntry} per registered
+ * invariant. Entries whose `runtimeGate` resolves to a "scan current DB"
+ * audit adapter (today: ADR-073 sagas via `auditSagaHierarchy`) execute
+ * the adapter and forward violations into the entry. Entries whose
+ * runtime gates are spawn-bound, session-bound, or release-tag-bound (the
+ * majority of ADR-070 ORC codes + ADR-056 D5) report `not-applicable`
+ * with the gate location so operators can see the gap end-to-end. Entries
+ * with `runtimeGate: null` report `documented` so the gap analysis (how
+ * many invariants ARE registry-only) is visible in `--json` output.
+ *
+ * Design:
+ *   - **Read-only.** Performs zero writes against `.cleo/tasks.db`.
+ *   - **Adapter-pluggable.** New per-ADR adapters land via the
+ *     `ADAPTERS` map below; the walker code is invariant-shape-agnostic.
+ *   - **DRY.** The same `auditRegistryEntry` primitive feeds both the
+ *     `--audit-invariants` registry walk AND the focused `--audit-sagas`
+ *     alias (which filters to ADR-073 only).
+ *
+ * @task T10340 — R6: cleo doctor --audit-invariants
+ * @epic T10327 — E-INVARIANT-REGISTRY-SSOT
+ * @saga T10326 — SG-SUBSTRATE-RECONCILIATION
+ * @see packages/contracts/src/invariants/index.ts — registry SSoT
+ * @see packages/core/src/doctor/saga-audit.ts — ADR-073 adapter (consumed)
+ */
+
+import type {
+  InvariantAuditEntry,
+  InvariantAuditResult,
+  InvariantAuditStatus,
+  InvariantAuditViolation,
+  InvariantSeverity,
+  RegisteredInvariant,
+  SagaAuditViolation,
+} from '@cleocode/contracts';
+import { INVARIANTS_REGISTRY } from '@cleocode/contracts';
+import { auditSagaHierarchy } from './saga-audit.js';
+
+/**
+ * Per-ADR adapter shape.
+ *
+ * Adapters translate a registry entry into one of the four
+ * {@link InvariantAuditStatus} outcomes. Each adapter is keyed on the
+ * `${adr}.${code}` registry key in the {@link ADAPTERS} map below.
+ *
+ * @internal
+ */
+interface InvariantAuditAdapter {
+  /**
+   * Run the adapter against the project's current state.
+   *
+   * Returns `null` when the adapter cannot run in this context (e.g.
+   * ADR-056 D5 needs a release tag — irrelevant to a `cleo doctor` call).
+   * Returns a populated `{status, violations, note}` triple otherwise.
+   */
+  readonly check: (projectRoot: string) => Promise<{
+    status: InvariantAuditStatus;
+    violations: InvariantAuditViolation[];
+    note: string;
+  } | null>;
+}
+
+/**
+ * Module-level cache so a single `auditInvariantRegistry` call shares the
+ * saga audit across all three ADR-073 entries (I5, I7, depth) without
+ * re-querying the DB three times.
+ *
+ * Reset on every call to `auditInvariantRegistry` so test isolation holds.
+ *
+ * @internal
+ */
+interface SagaAuditCache {
+  result: Awaited<ReturnType<typeof auditSagaHierarchy>> | null;
+}
+
+/**
+ * Convert a {@link SagaAuditViolation} into the
+ * {@link InvariantAuditViolation} shape carried by `InvariantAuditEntry`.
+ *
+ * The saga audit reports `kind: 'I5' | 'I7' | 'depth' | 'auto-close-drift'`;
+ * the registry audit emits the canonical `${adr}.${code}` key instead.
+ *
+ * @internal
+ */
+function sagaViolationToInvariantViolation(
+  violation: SagaAuditViolation,
+  invariantKey: string,
+): InvariantAuditViolation {
+  return {
+    invariantKey,
+    offendingId: violation.offendingId,
+    message: violation.message,
+    repairCommand: violation.repairCommand,
+  };
+}
+
+/**
+ * Build the saga audit adapter shared by ADR-073 I5 / I7 / depth-related
+ * entries. The adapter reuses {@link auditSagaHierarchy} (already
+ * production-hardened by T10119) and filters its violations to those
+ * matching a specific saga-audit `kind`.
+ *
+ * @internal
+ */
+function makeSagaAdapter(
+  cache: SagaAuditCache,
+  matchKind: 'I5' | 'I7' | 'depth' | 'auto-close-drift',
+  invariantKey: string,
+): InvariantAuditAdapter {
+  return {
+    check: async (projectRoot) => {
+      if (cache.result === null) {
+        cache.result = await auditSagaHierarchy(projectRoot);
+      }
+      const result = cache.result;
+      const matchingViolations: SagaAuditViolation[] = [];
+      for (const saga of result.sagas) {
+        for (const v of saga.violations) {
+          if (v.kind === matchKind) {
+            matchingViolations.push(v);
+          }
+        }
+      }
+      const violations = matchingViolations.map((v) =>
+        sagaViolationToInvariantViolation(v, invariantKey),
+      );
+      return {
+        status: violations.length === 0 ? 'pass' : 'fail',
+        violations,
+        note:
+          violations.length === 0
+            ? `auditSagaHierarchy: 0 ${matchKind} violations across ${result.sagas.length} saga(s)`
+            : `auditSagaHierarchy: ${violations.length} ${matchKind} violation(s) detected`,
+      };
+    },
+  };
+}
+
+/**
+ * Build a stable note explaining why a spawn-/session-bound runtime gate
+ * is not applicable to the doctor walk.
+ *
+ * @internal
+ */
+function notApplicableNote(functionName: string, contextNote: string): string {
+  return `runtimeGate '${functionName}' is ${contextNote} — no current-DB scan equivalent`;
+}
+
+/**
+ * Resolve the adapter for a single registry entry. Returns `null` for
+ * entries whose `runtimeGate` exists but lacks a current-DB-scan
+ * interpretation; the walker classifies those as `'not-applicable'`.
+ *
+ * @internal
+ */
+function resolveAdapter(
+  invariant: RegisteredInvariant,
+  cache: SagaAuditCache,
+): InvariantAuditAdapter | null {
+  const key = `${invariant.adr}.${invariant.code}`;
+
+  // ADR-073 saga adapters — I5, I7, and depth all reuse the cached
+  // auditSagaHierarchy result. I3 is a saga-write-time gate (no current-
+  // DB-scan equivalent today; surfaces as 'not-applicable').
+  if (key === 'ADR-073.I5') return makeSagaAdapter(cache, 'I5', key);
+  if (key === 'ADR-073.I7') return makeSagaAdapter(cache, 'I7', key);
+
+  return null;
+}
+
+/**
+ * Audit a single registry entry. Shared internally by the registry walk
+ * (`auditInvariantRegistry`) AND by the focused `--audit-sagas` alias
+ * (which calls back into the walk with an `adrFilter`).
+ *
+ * The function NEVER throws — adapter exceptions are caught and surfaced
+ * as a single-violation `'fail'` entry so one misbehaving adapter cannot
+ * abort the whole registry walk.
+ *
+ * @param invariant - The registry entry to audit.
+ * @param projectRoot - Absolute path to the project root.
+ * @param cache - Module-local cache shared across one walk.
+ * @returns A populated {@link InvariantAuditEntry}.
+ *
+ * @internal
+ */
+async function auditRegistryEntry(
+  invariant: RegisteredInvariant,
+  projectRoot: string,
+  cache: SagaAuditCache,
+): Promise<InvariantAuditEntry> {
+  const key = `${invariant.adr}.${invariant.code}`;
+  const runtimeGateName = invariant.runtimeGate?.functionName ?? null;
+
+  // 1) runtimeGate === null → documented (display/storage/process).
+  if (invariant.runtimeGate === null) {
+    return {
+      invariantKey: key,
+      adr: invariant.adr,
+      code: invariant.code,
+      name: invariant.name,
+      severity: invariant.severity,
+      status: 'documented',
+      note: 'runtimeGate:null — invariant enforced by DB CHECK, convention, or CI lint',
+      runtimeGate: null,
+      violations: [],
+    };
+  }
+
+  // 2) Adapter resolves → execute it.
+  const adapter = resolveAdapter(invariant, cache);
+  if (adapter !== null) {
+    try {
+      const outcome = await adapter.check(projectRoot);
+      if (outcome === null) {
+        return {
+          invariantKey: key,
+          adr: invariant.adr,
+          code: invariant.code,
+          name: invariant.name,
+          severity: invariant.severity,
+          status: 'not-applicable',
+          note: 'adapter returned null — context unsupported',
+          runtimeGate: runtimeGateName,
+          violations: [],
+        };
+      }
+      return {
+        invariantKey: key,
+        adr: invariant.adr,
+        code: invariant.code,
+        name: invariant.name,
+        severity: invariant.severity,
+        status: outcome.status,
+        note: outcome.note,
+        runtimeGate: runtimeGateName,
+        violations: outcome.violations,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        invariantKey: key,
+        adr: invariant.adr,
+        code: invariant.code,
+        name: invariant.name,
+        severity: invariant.severity,
+        status: 'fail',
+        note: `adapter threw: ${message}`,
+        runtimeGate: runtimeGateName,
+        violations: [
+          {
+            invariantKey: key,
+            offendingId: '<adapter>',
+            message: `Adapter for ${key} threw: ${message}`,
+            repairCommand: `cleo doctor --audit-invariants  # rerun to retry`,
+          },
+        ],
+      };
+    }
+  }
+
+  // 3) No adapter → classify by ADR origin.
+  if (invariant.adr === 'ADR-073' && invariant.code === 'I3') {
+    return {
+      invariantKey: key,
+      adr: invariant.adr,
+      code: invariant.code,
+      name: invariant.name,
+      severity: invariant.severity,
+      status: 'not-applicable',
+      note: notApplicableNote(
+        invariant.runtimeGate.functionName,
+        'a saga-write-time gate (depends + parent inspection on the write path)',
+      ),
+      runtimeGate: runtimeGateName,
+      violations: [],
+    };
+  }
+  if (invariant.adr === 'ADR-056' && invariant.code === 'D5') {
+    return {
+      invariantKey: key,
+      adr: invariant.adr,
+      code: invariant.code,
+      name: invariant.name,
+      severity: invariant.severity,
+      status: 'not-applicable',
+      note: notApplicableNote(
+        invariant.runtimeGate.functionName,
+        'release-tag-bound (runs via `cleo verify --release <tag>`)',
+      ),
+      runtimeGate: runtimeGateName,
+      violations: [],
+    };
+  }
+  if (invariant.adr === 'ADR-056' && invariant.code === 'D4') {
+    return {
+      invariantKey: key,
+      adr: invariant.adr,
+      code: invariant.code,
+      name: invariant.name,
+      severity: invariant.severity,
+      status: 'not-applicable',
+      note: notApplicableNote(
+        invariant.runtimeGate.functionName,
+        'a write-path validator (assertArchiveReason runs on tasks.archive_reason writes)',
+      ),
+      runtimeGate: runtimeGateName,
+      violations: [],
+    };
+  }
+  if (invariant.adr === 'ADR-070') {
+    // ORC-006 / ORC-012 / ORC-013 / ORC-014: spawn-/session-bound runtime gates.
+    return {
+      invariantKey: key,
+      adr: invariant.adr,
+      code: invariant.code,
+      name: invariant.name,
+      severity: invariant.severity,
+      status: 'not-applicable',
+      note: notApplicableNote(
+        invariant.runtimeGate.functionName,
+        'a spawn-/session-time gate (no current-DB-scan equivalent)',
+      ),
+      runtimeGate: runtimeGateName,
+      violations: [],
+    };
+  }
+
+  // 4) Fallback: registered runtime gate with no adapter mapping.
+  return {
+    invariantKey: key,
+    adr: invariant.adr,
+    code: invariant.code,
+    name: invariant.name,
+    severity: invariant.severity,
+    status: 'not-applicable',
+    note: notApplicableNote(invariant.runtimeGate.functionName, 'unmapped to a doctor adapter'),
+    runtimeGate: runtimeGateName,
+    violations: [],
+  };
+}
+
+/**
+ * Walk the central invariants registry and audit every entry against the
+ * project's current `.cleo/tasks.db` state.
+ *
+ * Read-only. Safe to invoke without any `--fix`-style flag.
+ *
+ * @param projectRoot - Absolute path to the project root.
+ * @param options - Optional filters. Pass `{adrFilter: 'ADR-073'}` to
+ *                  restrict the walk to one ADR (used by `--audit-sagas`).
+ * @returns Aggregated {@link InvariantAuditResult}.
+ *
+ * @example
+ * ```typescript
+ * const audit = await auditInvariantRegistry(projectRoot);
+ * if (audit.errorCount > 0) process.exitCode = 2;
+ * for (const entry of audit.entries) {
+ *   if (entry.status === 'fail') {
+ *     for (const v of entry.violations) console.log(v.message);
+ *   }
+ * }
+ * ```
+ */
+export async function auditInvariantRegistry(
+  projectRoot: string,
+  options: { adrFilter?: string } = {},
+): Promise<InvariantAuditResult> {
+  const adrFilter = options.adrFilter ?? null;
+  const cache: SagaAuditCache = { result: null };
+
+  // Snapshot + sort by (adr, code) for deterministic output.
+  const allInvariants: RegisteredInvariant[] = [];
+  for (const key of Object.keys(INVARIANTS_REGISTRY)) {
+    const entry = INVARIANTS_REGISTRY[key];
+    if (entry === undefined) continue;
+    if (adrFilter !== null && entry.adr !== adrFilter) continue;
+    allInvariants.push(entry);
+  }
+  allInvariants.sort((a, b) => {
+    if (a.adr !== b.adr) return a.adr.localeCompare(b.adr);
+    return a.code.localeCompare(b.code);
+  });
+
+  const entries: InvariantAuditEntry[] = [];
+  for (const invariant of allInvariants) {
+    const entry = await auditRegistryEntry(invariant, projectRoot, cache);
+    entries.push(entry);
+  }
+
+  // Aggregate by status × severity.
+  let errorCount = 0;
+  let warningCount = 0;
+  let infoCount = 0;
+  let notApplicableCount = 0;
+  let documentedCount = 0;
+  for (const entry of entries) {
+    if (entry.status === 'fail') {
+      const sev: InvariantSeverity = entry.severity;
+      if (sev === 'error') errorCount += 1;
+      else if (sev === 'warning') warningCount += 1;
+      else infoCount += 1;
+    } else if (entry.status === 'not-applicable') {
+      notApplicableCount += 1;
+    } else if (entry.status === 'documented') {
+      documentedCount += 1;
+    }
+  }
+
+  return {
+    entries,
+    totalCount: entries.length,
+    errorCount,
+    warningCount,
+    infoCount,
+    notApplicableCount,
+    documentedCount,
+    filteredByAdr: adrFilter,
+  };
+}


### PR DESCRIPTION
## Summary

- New `cleo doctor --audit-invariants` flag iterates the central
  `INVARIANTS_REGISTRY` and audits every entry against the project's
  current `.cleo/tasks.db` state. Output groups by ADR + severity with
  one actionable repair command per violation. Supports `--json`;
  exit code 2 on any `severity:'error'` violation.
- `--audit-sagas` becomes a focused alias filtering the walk to
  ADR-073 only — both surfaces delegate to a single
  `auditInvariantRegistry` SSoT in
  `packages/core/src/doctor/invariant-audit.ts` (DRY).
- ADR-073 saga gates (I5/I7) delegate to the production-hardened
  `auditSagaHierarchy` (T10119). Spawn/session/release-tag-bound gates
  surface as `'not-applicable'` with the gate location so the gap
  analysis is visible end-to-end. `runtimeGate:null` entries report
  `'documented'`.
- New contracts types in `@cleocode/contracts/doctor`:
  `InvariantAuditResult`, `InvariantAuditEntry`,
  `InvariantAuditViolation`, `InvariantAuditStatus`.
- 6-test integration suite seeds a deliberate I5 violation against a
  real `tasks.db` and asserts JSON shape + ADR-filter + sort order +
  gap-analysis counters.

Saga T10326 SG-SUBSTRATE-RECONCILIATION advances. Epic T10327
E-INVARIANT-REGISTRY-SSOT R6 ships.

Closes T10340
Saga: T10326
Refs: ADR-073, ADR-070, ADR-056

## Test plan

- [x] `pnpm --filter @cleocode/contracts run build` green
- [x] `pnpm run build` green (full workspace)
- [x] `pnpm biome check` clean
- [x] `pnpm --filter @cleocode/core exec vitest run src/doctor/__tests__/` — 43/43 pass
- [x] Live smoke: `cleo doctor --audit-invariants --json` walks 28
  entries (10 ADR-073 sagas / 9 not-applicable / 17 documented),
  exit 0 on clean state
- [x] Live smoke: `cleo doctor --audit-sagas --json` filters to 8
  ADR-073 entries, operation tag `doctor.audit-sagas`
- [x] Live smoke: `cleo doctor --help` lists both flags