### PR TITLE
feat(cleo): collectMutateInput (T9916 / Saga T9855)

### DIFF
--- a/.changeset/t9916-collect-mutate-input.md
+++ b/.changeset/t9916-collect-mutate-input.md
@@ -1,0 +1,6 @@
+---
+id: t9916-collect-mutate-input
+tasks: [T9916]
+kind: feat
+summary: collectMutateInput CLI transport adapter — params/file/stdin/positional precedence (T9916 / Saga T9855)
+---

--- a/packages/cleo/src/cli/lib/__tests__/collect-input.test.ts
+++ b/packages/cleo/src/cli/lib/__tests__/collect-input.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for collect-input.ts (T9916 — Saga T9855 / E7.3).
+ *
+ * Covers the four-channel precedence ladder, JSON parse-error envelopes,
+ * filesystem error propagation, and stdin draining semantics.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  collectMutateInput,
+  readStdinJson,
+  type StdinLike,
+  wrapParseError,
+} from '../collect-input.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a piped (non-TTY) stdin double from a string.
+ */
+function pipedStdin(payload: string): StdinLike {
+  const stream = Readable.from([Buffer.from(payload, 'utf8')]) as StdinLike;
+  stream.isTTY = false;
+  return stream;
+}
+
+/**
+ * Build a TTY (interactive) stdin double — no piped data.
+ */
+function ttyStdin(): StdinLike {
+  const stream = Readable.from([]) as StdinLike;
+  stream.isTTY = true;
+  return stream;
+}
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'collect-input-test-'));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Precedence
+// ---------------------------------------------------------------------------
+
+describe('collectMutateInput — precedence', () => {
+  it('--params wins over --file, stdin, and positional', async () => {
+    const filePath = join(tmpDir, 'wins.json');
+    await writeFile(filePath, JSON.stringify({ from: 'file' }), 'utf8');
+    const result = await collectMutateInput(
+      {
+        params: JSON.stringify({ from: 'params' }),
+        file: filePath,
+        positional: ['from-positional'],
+      },
+      pipedStdin(JSON.stringify({ from: 'stdin' })),
+    );
+    expect(result).toEqual({ from: 'params' });
+  });
+
+  it('--file wins over stdin and positional when --params absent', async () => {
+    const filePath = join(tmpDir, 'wins.json');
+    await writeFile(filePath, JSON.stringify({ from: 'file' }), 'utf8');
+    const result = await collectMutateInput(
+      { file: filePath, positional: ['from-positional'] },
+      pipedStdin(JSON.stringify({ from: 'stdin' })),
+    );
+    expect(result).toEqual({ from: 'file' });
+  });
+
+  it('stdin wins over positional when --params and --file absent', async () => {
+    const result = await collectMutateInput(
+      { positional: ['from-positional'] },
+      pipedStdin(JSON.stringify({ from: 'stdin' })),
+    );
+    expect(result).toEqual({ from: 'stdin' });
+  });
+
+  it('positional returned as-is when no other source provided', async () => {
+    const result = await collectMutateInput({ positional: ['a', 'b', 'c'] }, ttyStdin());
+    expect(result).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns undefined when stdin is TTY and no other source provided', async () => {
+    const result = await collectMutateInput({}, ttyStdin());
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when positional is empty array on a TTY stdin', async () => {
+    const result = await collectMutateInput({ positional: [] }, ttyStdin());
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON parse errors
+// ---------------------------------------------------------------------------
+
+describe('collectMutateInput — JSON parse errors', () => {
+  it('throws with --params source label and snippet on bad JSON', async () => {
+    const bad = '{"title": "broken'; // missing closing quote + brace
+    await expect(collectMutateInput({ params: bad }, ttyStdin())).rejects.toThrow(
+      /Invalid JSON in --params:/,
+    );
+    await expect(collectMutateInput({ params: bad }, ttyStdin())).rejects.toThrow(
+      /got: \{"title": "broken/,
+    );
+  });
+
+  it('throws with --file <path> source label and snippet on bad JSON', async () => {
+    const filePath = join(tmpDir, 'bad.json');
+    await writeFile(filePath, '{not-json', 'utf8');
+    await expect(collectMutateInput({ file: filePath }, ttyStdin())).rejects.toThrow(
+      new RegExp(`Invalid JSON in --file ${filePath.replace(/[.\\/]/g, '\\$&')}`),
+    );
+    await expect(collectMutateInput({ file: filePath }, ttyStdin())).rejects.toThrow(
+      /got: \{not-json/,
+    );
+  });
+
+  it('propagates ENOENT-style errors for missing --file path', async () => {
+    const missing = join(tmpDir, 'does-not-exist.json');
+    await expect(collectMutateInput({ file: missing }, ttyStdin())).rejects.toThrow(
+      /ENOENT|no such file/i,
+    );
+  });
+
+  it('throws with stdin source label on bad piped JSON', async () => {
+    await expect(collectMutateInput({}, pipedStdin('{not-json'))).rejects.toThrow(
+      /Invalid JSON in stdin:/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stdin draining
+// ---------------------------------------------------------------------------
+
+describe('readStdinJson', () => {
+  it('parses a simple piped JSON object', async () => {
+    const result = await readStdinJson(pipedStdin('{"a":1}'));
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('reads a 10KB stdin payload without truncation', async () => {
+    const items = Array.from({ length: 1000 }, (_, i) => ({ idx: i, pad: 'x'.repeat(8) }));
+    const payload = JSON.stringify(items);
+    expect(payload.length).toBeGreaterThan(10_000);
+    const result = (await readStdinJson(pipedStdin(payload))) as Array<{ idx: number }>;
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1000);
+    expect(result[0]).toEqual({ idx: 0, pad: 'xxxxxxxx' });
+    expect(result[999]).toEqual({ idx: 999, pad: 'xxxxxxxx' });
+  });
+
+  it('rejects with descriptive error on invalid JSON', async () => {
+    await expect(readStdinJson(pipedStdin('not-json'))).rejects.toThrow(/Invalid JSON in stdin:/);
+  });
+
+  it('rejects when stream emits an error event', async () => {
+    const stream = new Readable({
+      read() {
+        this.destroy(new Error('boom from stream'));
+      },
+    });
+    await expect(readStdinJson(stream)).rejects.toThrow(/boom from stream/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapParseError
+// ---------------------------------------------------------------------------
+
+describe('wrapParseError', () => {
+  it('includes source label, parse message, and full input when short', () => {
+    const err = wrapParseError(
+      '{"a":}',
+      new SyntaxError('Unexpected token } in JSON at position 5'),
+      '--params',
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain('Invalid JSON in --params:');
+    expect(err.message).toContain('Unexpected token');
+    expect(err.message).toContain('got: {"a":}');
+  });
+
+  it('truncates long input with ellipsis', () => {
+    const long = 'x'.repeat(500);
+    const err = wrapParseError(long, new SyntaxError('bad'), 'stdin');
+    expect(err.message).toContain('Invalid JSON in stdin:');
+    expect(err.message).toContain('…');
+    // Snippet is clamped, but the message MUST NOT include the full 500-char body.
+    expect(err.message.length).toBeLessThan(500);
+  });
+});

--- a/packages/cleo/src/cli/lib/collect-input.ts
+++ b/packages/cleo/src/cli/lib/collect-input.ts
@@ -1,0 +1,235 @@
+/**
+ * collectMutateInput — thin CLI transport adapter for mutate operations.
+ *
+ * Collects structured input for any CLEO mutate operation from the four
+ * standard CLI input channels with a documented precedence order
+ * (higher wins, first-match returns):
+ *
+ *   1. `--params <json-string>` — inline JSON string
+ *   2. `--file <path>`          — JSON file on disk
+ *   3. stdin                    — piped JSON (when `!stdin.isTTY`)
+ *   4. positional               — raw positional args (no parse)
+ *
+ * This module is intentionally THIN: it collects and parses, it does NOT
+ * validate against any schema. Schema validation is owned by CORE via
+ * `validateOperationInput()` (T9915) using the {@link OperationInputContract}
+ * surface from `@cleocode/contracts/operations/input-contract` (T9914).
+ *
+ * Designed to be reused from every mutate CLI command: `add`, `add-batch`,
+ * `update`, `complete`, `delete`, etc.
+ *
+ * @packageDocumentation
+ * @module @cleocode/cleo/cli/lib/collect-input
+ *
+ * @task T9916
+ * @epic E7.3 — CLI mutate-input transport
+ * @saga T9855
+ * @adr ADR-076
+ */
+
+import { readFile } from 'node:fs/promises';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal subset of `NodeJS.ReadableStream` plus the `isTTY` discriminator
+ * used to detect piped (non-TTY) stdin.
+ *
+ * Accepting this loose shape (instead of `NodeJS.ReadStream`) lets tests
+ * pass a plain `Readable.from(...)` with a manually-set `isTTY` flag and
+ * keeps the public signature free of process-bound types.
+ */
+export type StdinLike = NodeJS.ReadableStream & { isTTY?: boolean };
+
+/**
+ * Argument bag passed by a CLI command handler to {@link collectMutateInput}.
+ *
+ * Every field is optional — the adapter walks the four channels in
+ * precedence order and returns the first one that resolves.
+ */
+export interface CollectMutateInputArgs {
+  /** Inline JSON string from `--params`. Parsed via {@link JSON.parse}. */
+  params?: string;
+  /** Filesystem path from `--file`. File is read as UTF-8 then parsed. */
+  file?: string;
+  /** Raw positional args — returned as-is (no parse, no validation). */
+  positional?: unknown[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum snippet length included in JSON parse-error messages.
+ *
+ * Snippets are clamped so a multi-megabyte malformed payload does not
+ * blow up the error message that gets logged or surfaced via cliError.
+ */
+const PARSE_ERROR_SNIPPET_MAX_LENGTH = 80;
+
+/**
+ * Wraps a {@link SyntaxError} from {@link JSON.parse} into a descriptive
+ * {@link Error} that names the source channel (`--params`, `--file <path>`,
+ * `stdin`) and includes a truncated snippet of the offending input.
+ *
+ * The returned error is a plain `Error` (not a subclass) so callers can
+ * surface the `.message` directly through `cliError()` without losing
+ * the source-label context.
+ *
+ * @param rawInput   - The raw input string that failed to parse.
+ * @param parseErr   - The {@link SyntaxError} thrown by {@link JSON.parse}.
+ * @param sourceLabel - Human-readable label naming the input channel
+ *                     (e.g. `'--params'`, `"--file /tmp/x.json"`, `'stdin'`).
+ *
+ * @returns A new {@link Error} with a structured, human-readable message.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   JSON.parse(raw);
+ * } catch (err) {
+ *   throw wrapParseError(raw, err as SyntaxError, '--params');
+ * }
+ * ```
+ */
+export function wrapParseError(
+  rawInput: string,
+  parseErr: SyntaxError,
+  sourceLabel: string,
+): Error {
+  const snippet =
+    rawInput.length > PARSE_ERROR_SNIPPET_MAX_LENGTH
+      ? `${rawInput.slice(0, PARSE_ERROR_SNIPPET_MAX_LENGTH)}…`
+      : rawInput;
+  return new Error(`Invalid JSON in ${sourceLabel}: ${parseErr.message} (got: ${snippet})`);
+}
+
+/**
+ * Reads all bytes from a {@link StdinLike} stream, concatenates them as
+ * UTF-8, and parses the result as JSON.
+ *
+ * Resolves with the parsed value (typed as `unknown` — CORE validates).
+ * Rejects with a descriptive {@link Error} (via {@link wrapParseError})
+ * when the stream contents are not valid JSON. Also rejects if the
+ * underlying stream emits an `error` event.
+ *
+ * The stream is consumed in object-mode-friendly fashion: each chunk is
+ * coerced to a `Buffer` (already-buffer or string) before concatenation,
+ * so callers can pass either a real process stream or a test double
+ * built from `Readable.from([Buffer.from('...')])`.
+ *
+ * @param stdin - The readable stream to drain.
+ *
+ * @returns A promise resolving to the parsed JSON value.
+ *
+ * @example
+ * ```ts
+ * const value = await readStdinJson(process.stdin);
+ * ```
+ */
+export function readStdinJson(stdin: NodeJS.ReadableStream): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stdin.on('data', (chunk: Buffer | string) => {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+    });
+    stdin.on('error', (err: Error) => {
+      reject(err);
+    });
+    stdin.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(wrapParseError(raw, err as SyntaxError, 'stdin'));
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Collects structured input for a mutate operation from the four standard
+ * CLI input channels, returning the first match in precedence order.
+ *
+ * Precedence (highest wins, first match returns immediately — later
+ * channels are NOT inspected once a higher-precedence channel resolves):
+ *
+ *   1. `args.params`     — inline JSON string from `--params`
+ *   2. `args.file`       — filesystem path from `--file`
+ *   3. stdin             — piped input (when `!stdin.isTTY`)
+ *   4. `args.positional` — raw positional args (returned as-is)
+ *
+ * If no channel matches (no `params`, no `file`, stdin is a TTY, and
+ * `positional` is undefined or empty), the function returns `undefined`.
+ *
+ * Schema validation is NOT performed here. CORE owns validation via
+ * `validateOperationInput()` (T9915). This adapter exists purely to
+ * normalize the four CLI input shapes into a single parsed value.
+ *
+ * @param args  - Argument bag from the citty command handler.
+ * @param stdin - The stdin stream to inspect. In production this is
+ *                `process.stdin`; in tests pass a `Readable.from(...)`
+ *                double with `isTTY: false` set explicitly.
+ *
+ * @returns A promise resolving to the parsed input value (typed as
+ *          `unknown` — CORE validates), or `undefined` when no channel
+ *          provides input.
+ *
+ * @throws {Error} When `--params` contains invalid JSON
+ *                 (message includes source label + snippet).
+ * @throws {Error} When `--file` contains invalid JSON or the file cannot
+ *                 be read (ENOENT and friends propagate).
+ * @throws {Error} When piped stdin contains invalid JSON.
+ *
+ * @example
+ * ```ts
+ * // From a citty command's `run` block:
+ * const input = await collectMutateInput(
+ *   { params: args.params, file: args.file, positional: args._ },
+ *   process.stdin,
+ * );
+ * const result = await validateOperationInput(contract, input);
+ * ```
+ */
+export async function collectMutateInput(
+  args: CollectMutateInputArgs,
+  stdin: StdinLike,
+): Promise<unknown> {
+  // 1. --params (highest precedence)
+  if (typeof args.params === 'string' && args.params.length > 0) {
+    try {
+      return JSON.parse(args.params);
+    } catch (err) {
+      throw wrapParseError(args.params, err as SyntaxError, '--params');
+    }
+  }
+
+  // 2. --file
+  if (typeof args.file === 'string' && args.file.length > 0) {
+    const raw = await readFile(args.file, 'utf8');
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw wrapParseError(raw, err as SyntaxError, `--file ${args.file}`);
+    }
+  }
+
+  // 3. stdin (only when piped — i.e. not a TTY)
+  if (stdin.isTTY !== true) {
+    return readStdinJson(stdin);
+  }
+
+  // 4. positional (no parse) — undefined when not supplied
+  if (args.positional !== undefined && args.positional.length > 0) {
+    return args.positional;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Adds `packages/cleo/src/cli/lib/collect-input.ts` — thin CLI adapter for mutate operation input.
- Precedence (higher wins): `--params` > `--file` > stdin > positional.
- Pairs with T9915 SSoT validator (CORE-owned) — this module collects + parses; CORE validates.

## Test plan
- [x] `pnpm biome check`
- [x] `pnpm -F @cleocode/cleo run build` (full workspace build green)
- [x] 16 unit tests passing (precedence, parse-error envelopes for `--params` / `--file` / stdin, ENOENT propagation, 10KB stdin payload, stream error events, snippet truncation)

Closes T9916
Saga: T9855
ADR: 076