### PR TITLE
feat(sentient): context staleness detector (T9896 / Saga T9855)

### DIFF
--- a/.changeset/t9896-sentient-context-staleness.md
+++ b/.changeset/t9896-sentient-context-staleness.md
@@ -1,0 +1,6 @@
+---
+id: t9896-sentient-context-staleness
+tasks: [T9896]
+kind: feat
+summary: detectContextStaleness — Tier-2 sentient proposal when project-context.json is >30 days old
+---

--- a/packages/core/src/sentient/detectors/__tests__/context-staleness.test.ts
+++ b/packages/core/src/sentient/detectors/__tests__/context-staleness.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for the context-staleness detector (T9896).
+ *
+ * Coverage:
+ *   - detectContextStaleness: stale context (>30d) → proposal with severity P2
+ *   - detectContextStaleness: fresh context (yesterday) → null
+ *   - detectContextStaleness: missing file (loader returns null) → null
+ *   - detectContextStaleness: invalid date string → null + does not throw
+ *   - detectContextStaleness: missing detectedAt field → null
+ *   - detectContextStaleness: loader throws → null
+ *   - safeRunContextStalenessScan: kill-switch blocks generation
+ *   - safeRunContextStalenessScan: tier2Enabled=false marks outcome 'disabled'
+ *   - safeRunContextStalenessScan: detector throwing surfaces 'error' outcome
+ *   - safeRunContextStalenessScan: no-context outcome when context missing
+ *
+ * Tests mock `loadProjectContext` to keep them filesystem-independent.
+ *
+ * @task T9896
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../config/registry.js', () => ({
+  loadProjectContext: vi.fn(),
+}));
+
+import type { ProjectContext } from '@cleocode/contracts';
+import { loadProjectContext } from '../../../config/registry.js';
+import {
+  CONTEXT_REFRESH_KIND,
+  CONTEXT_STALENESS_MS,
+  detectContextStaleness,
+  safeRunContextStalenessScan,
+} from '../context-staleness.js';
+
+// Cast the mocked import to vi.fn so we can configure return values per test.
+const mockLoadProjectContext = loadProjectContext as unknown as ReturnType<typeof vi.fn>;
+
+const PROJECT_ROOT = '/tmp/cleo-test-project-root';
+const STATE_PATH = '/tmp/cleo-test-sentient-state.json';
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function makeContext(detectedAt: string | undefined): ProjectContext {
+  // Minimal shape sufficient for the detector; cast through unknown so we
+  // don't have to mock the entire ProjectContext surface (typing/build).
+  return {
+    schemaVersion: '1.0.0',
+    detectedAt: detectedAt as string,
+    projectTypes: ['node'],
+    monorepo: false,
+  } as ProjectContext;
+}
+
+beforeEach(() => {
+  mockLoadProjectContext.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('detectContextStaleness', () => {
+  it('returns a P2 proposal when detectedAt is older than 30 days', async () => {
+    mockLoadProjectContext.mockResolvedValue(makeContext(isoDaysAgo(31)));
+
+    const proposal = await detectContextStaleness(PROJECT_ROOT);
+
+    expect(proposal).not.toBeNull();
+    expect(proposal?.kind).toBe(CONTEXT_REFRESH_KIND);
+    expect(proposal?.severity).toBe('P2');
+    expect(proposal?.title).toBe('Project context is >30 days old');
+    expect(proposal?.fixAction).toContain('cleo init --refresh-context');
+    expect(proposal?.id).toMatch(/^prop-context-staleness-/);
+    expect(proposal?.reason).toContain('31 days ago');
+  });
+
+  it('returns null when detectedAt is within the staleness window', async () => {
+    mockLoadProjectContext.mockResolvedValue(makeContext(isoDaysAgo(1)));
+
+    const proposal = await detectContextStaleness(PROJECT_ROOT);
+
+    expect(proposal).toBeNull();
+  });
+
+  it('returns null when the project-context.json file is missing', async () => {
+    mockLoadProjectContext.mockResolvedValue(null);
+
+    const proposal = await detectContextStaleness(PROJECT_ROOT);
+
+    expect(proposal).toBeNull();
+  });
+
+  it('returns null and does not throw when detectedAt is unparseable', async () => {
+    mockLoadProjectContext.mockResolvedValue(makeContext('not-a-date'));
+
+    await expect(detectContextStaleness(PROJECT_ROOT)).resolves.toBeNull();
+  });
+
+  it('returns null when detectedAt is absent', async () => {
+    mockLoadProjectContext.mockResolvedValue(makeContext(undefined));
+
+    const proposal = await detectContextStaleness(PROJECT_ROOT);
+
+    expect(proposal).toBeNull();
+  });
+
+  it('returns null when the loader throws', async () => {
+    mockLoadProjectContext.mockRejectedValue(new Error('disk read failed'));
+
+    const proposal = await detectContextStaleness(PROJECT_ROOT);
+
+    expect(proposal).toBeNull();
+  });
+
+  it('returns null exactly at the staleness boundary (age == threshold)', async () => {
+    // Age strictly equal to the threshold is NOT stale; detector emits only when age > threshold.
+    const detectedAt = new Date(Date.now() - CONTEXT_STALENESS_MS).toISOString();
+    mockLoadProjectContext.mockResolvedValue(makeContext(detectedAt));
+
+    const proposal = await detectContextStaleness(PROJECT_ROOT);
+
+    expect(proposal).toBeNull();
+  });
+});
+
+describe('safeRunContextStalenessScan', () => {
+  it('returns outcome=killed and generates no proposal when killSwitch is active', async () => {
+    const outcome = await safeRunContextStalenessScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => true,
+      isTier2Enabled: async () => true,
+      detect: async () => {
+        throw new Error('detector should not run when killed');
+      },
+    });
+
+    expect(outcome.kind).toBe('killed');
+    expect(outcome.proposal).toBeNull();
+  });
+
+  it('returns outcome=disabled (with proposal payload) when tier2Enabled=false', async () => {
+    mockLoadProjectContext.mockResolvedValue(makeContext(isoDaysAgo(60)));
+
+    const outcome = await safeRunContextStalenessScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => false,
+      isTier2Enabled: async () => false,
+    });
+
+    expect(outcome.kind).toBe('disabled');
+    expect(outcome.proposal).not.toBeNull();
+    expect(outcome.proposal?.severity).toBe('P2');
+  });
+
+  it('returns outcome=stale when context is stale and tier2 is enabled', async () => {
+    mockLoadProjectContext.mockResolvedValue(makeContext(isoDaysAgo(45)));
+
+    const outcome = await safeRunContextStalenessScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => false,
+      isTier2Enabled: async () => true,
+    });
+
+    expect(outcome.kind).toBe('stale');
+    expect(outcome.proposal).not.toBeNull();
+    expect(outcome.proposal?.kind).toBe(CONTEXT_REFRESH_KIND);
+  });
+
+  it('returns outcome=fresh when context is present and within window', async () => {
+    mockLoadProjectContext.mockResolvedValue(makeContext(isoDaysAgo(5)));
+
+    const outcome = await safeRunContextStalenessScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => false,
+      isTier2Enabled: async () => true,
+    });
+
+    expect(outcome.kind).toBe('fresh');
+    expect(outcome.proposal).toBeNull();
+  });
+
+  it('returns outcome=no-context when project-context.json is absent', async () => {
+    mockLoadProjectContext.mockResolvedValue(null);
+
+    const outcome = await safeRunContextStalenessScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => false,
+      isTier2Enabled: async () => true,
+    });
+
+    expect(outcome.kind).toBe('no-context');
+    expect(outcome.proposal).toBeNull();
+  });
+
+  it('returns outcome=error when the detector throws (kill-switch + tier2 checks succeed)', async () => {
+    const outcome = await safeRunContextStalenessScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => false,
+      isTier2Enabled: async () => true,
+      detect: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    expect(outcome.kind).toBe('error');
+    expect(outcome.proposal).toBeNull();
+    expect(outcome.detail).toContain('boom');
+  });
+});

--- a/packages/core/src/sentient/detectors/context-staleness.ts
+++ b/packages/core/src/sentient/detectors/context-staleness.ts
@@ -1,0 +1,292 @@
+/**
+ * Context Staleness Detector — Tier-2 sentient proposal source (T9896).
+ *
+ * Emits a Tier-2 proposal when `.cleo/project-context.json` has a `detectedAt`
+ * timestamp older than {@link CONTEXT_STALENESS_MS} (30 days). Stale project
+ * context can mislead the test/build command resolver and the framework
+ * detector, so we surface a low-priority refresh recommendation through the
+ * existing sentient propose-enable gate.
+ *
+ * Design principles:
+ *   - NO LLM calls. All data comes from a structured JSON read.
+ *   - Single-purpose: one detector function returning ONE proposal or null.
+ *   - Generation vs. persistence are decoupled — the detector ALWAYS computes
+ *     and returns the proposal; the wrapper {@link safeRunContextStalenessScan}
+ *     respects kill-switch + `tier2Enabled` before any side effect.
+ *   - All file/parse errors return `null` (best-effort — never throw).
+ *
+ * Integration point: {@link safeRunContextStalenessScan} is fired (best-effort)
+ * from `tick.ts` alongside the existing stage-drift / hygiene scans.
+ *
+ * @task T9896
+ * @see ADR-076 — Project context detection
+ * @see ADR-054 — Sentient Loop Tier-2
+ */
+
+import { computeProjectHash } from '@cleocode/paths';
+import { loadProjectContext } from '../../config/registry.js';
+import { readSentientState } from '../state.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Staleness threshold (30 days, in milliseconds).
+ * Matches `PROJECT_CONTEXT_STALENESS_MS` in `config/registry.ts` so the
+ * sentient detector and `checkDrift('staleness-gate', ...)` agree.
+ */
+export const CONTEXT_STALENESS_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Default cadence (6 hours) between context-staleness scan passes when the
+ * detector is wired into the tick loop. Longer than stage-drift (30 min) and
+ * hygiene (4 h) because the underlying file changes at most once per
+ * `cleo init --refresh-context` invocation.
+ */
+export const CONTEXT_STALENESS_SCAN_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/** Number of ms in a day, used for human-readable age formatting. */
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Discriminant for context-refresh proposals. */
+export const CONTEXT_REFRESH_KIND = 'context-refresh' as const;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Severity assigned to detector-emitted Tier-2 proposals.
+ * Mirrors the `severity` column allowlist (`P0`|`P1`|`P2`|`P3`) defined in
+ * `packages/contracts/src/enums.ts`.
+ */
+export type Tier2ProposalSeverity = 'P0' | 'P1' | 'P2' | 'P3';
+
+/**
+ * Detector-side Tier-2 proposal shape (T9896 contract).
+ *
+ * Lightweight representation returned by sentient detector functions BEFORE
+ * the persistence layer turns it into a `tasks.db` row. Distinct from
+ * {@link import('@cleocode/contracts').ProposalCandidate} because detectors
+ * carry a concrete `fixAction` (the CLI command the owner should run) rather
+ * than a weighted ingester rationale.
+ */
+export interface Tier2Proposal {
+  /**
+   * Stable identifier. Deterministic per `(detector, projectRoot)` so that
+   * repeated detections of the same staleness condition share an ID and the
+   * persistence layer can dedup cleanly.
+   */
+  id: string;
+  /** Discriminant — `'context-refresh'` for this detector. */
+  kind: typeof CONTEXT_REFRESH_KIND;
+  /** Short human-readable headline (no freeform LLM text). */
+  title: string;
+  /** Severity bucket; defaults to `'P2'` for staleness proposals. */
+  severity: Tier2ProposalSeverity;
+  /** CLI command the owner should run to clear the proposal. */
+  fixAction: string;
+  /** Why this proposal was emitted (template-generated, includes age). */
+  reason: string;
+}
+
+/** Options accepted by {@link safeRunContextStalenessScan}. */
+export interface ContextStalenessScanOptions {
+  /** Absolute path to the project root (contains `.cleo/`). */
+  projectRoot: string;
+  /** Absolute path to sentient-state.json. */
+  statePath: string;
+  /**
+   * Override the kill-switch check. Injected by tests to avoid touching the
+   * state file. When omitted, reads the daemon state file directly.
+   */
+  isKilled?: () => Promise<boolean>;
+  /**
+   * Override the tier2Enabled check. Injected by tests. When omitted, reads
+   * the daemon state file directly.
+   */
+  isTier2Enabled?: () => Promise<boolean>;
+  /**
+   * Override the detector function. Injected by tests so the scan wrapper can
+   * be exercised without a real `project-context.json` on disk.
+   */
+  detect?: (projectRoot: string) => Promise<Tier2Proposal | null>;
+}
+
+/** Outcome discriminant produced by {@link safeRunContextStalenessScan}. */
+export type ContextStalenessScanKind =
+  | 'killed' // killSwitch active before the detector ran
+  | 'disabled' // tier2Enabled=false; detector ran but persistence is gated off
+  | 'fresh' // context exists and is within the staleness window
+  | 'no-context' // no project-context.json present
+  | 'stale' // proposal was generated
+  | 'error'; // unexpected error during the scan
+
+/** Structured outcome of one scan pass. */
+export interface ContextStalenessScanOutcome {
+  /** How the scan ended. */
+  kind: ContextStalenessScanKind;
+  /** The proposal generated by the detector (null if no proposal was emitted). */
+  proposal: Tier2Proposal | null;
+  /** Human-readable detail (one line). */
+  detail: string;
+}
+
+// ---------------------------------------------------------------------------
+// Detector
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the staleness detector against `.cleo/project-context.json` and return
+ * either a Tier-2 proposal or `null`.
+ *
+ * Returns `null` (no proposal) when:
+ *   - `loadProjectContext` returns `null` (file absent or unreadable).
+ *   - `detectedAt` is missing, non-string, or unparseable.
+ *   - The age is within the staleness window.
+ *
+ * Returns a {@link Tier2Proposal} when `detectedAt` is older than
+ * {@link CONTEXT_STALENESS_MS}.
+ *
+ * This function MUST NOT throw — all errors collapse to `null`.
+ *
+ * @param projectRoot - Absolute path to the project root.
+ * @returns A staleness proposal, or `null` when no action is required.
+ *
+ * @task T9896
+ */
+export async function detectContextStaleness(projectRoot: string): Promise<Tier2Proposal | null> {
+  let context: Awaited<ReturnType<typeof loadProjectContext>>;
+  try {
+    context = await loadProjectContext(projectRoot);
+  } catch {
+    return null;
+  }
+
+  if (context === null) return null;
+
+  const detectedAtRaw = context.detectedAt;
+  if (typeof detectedAtRaw !== 'string' || detectedAtRaw.length === 0) {
+    return null;
+  }
+
+  const detectedAtMs = Date.parse(detectedAtRaw);
+  if (Number.isNaN(detectedAtMs)) return null;
+
+  const ageMs = Date.now() - detectedAtMs;
+  if (ageMs <= CONTEXT_STALENESS_MS) return null;
+
+  const ageDays = Math.floor(ageMs / MS_PER_DAY);
+  const projectHash = computeProjectHash(projectRoot);
+
+  return {
+    id: `prop-context-staleness-${projectHash}`,
+    kind: CONTEXT_REFRESH_KIND,
+    title: 'Project context is >30 days old',
+    severity: 'P2',
+    fixAction: 'cleo init --refresh-context  # re-runs project detection',
+    reason:
+      `project-context.json detectedAt is ${detectedAtRaw} (${ageDays} days ago). ` +
+      'Stale context can mislead test/build commands. Refresh recommended.',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scan wrapper (kill-switch + tier2Enabled gated)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default kill-switch check — reads sentient-state.json via {@link readSentientState}.
+ */
+async function defaultIsKilled(statePath: string): Promise<boolean> {
+  const state = await readSentientState(statePath);
+  return state.killSwitch === true;
+}
+
+/**
+ * Default tier2Enabled check — reads sentient-state.json via {@link readSentientState}.
+ */
+async function defaultIsTier2Enabled(statePath: string): Promise<boolean> {
+  const state = await readSentientState(statePath);
+  return state.tier2Enabled === true;
+}
+
+/**
+ * Run the context-staleness detector with sentient gating applied.
+ *
+ * Steps:
+ *   1. Honour the kill-switch — abort before any side effect.
+ *   2. Run the detector. If it returns `null`, return outcome `'fresh'` (or
+ *      `'no-context'` when the context file is absent; we cannot distinguish
+ *      the two without re-reading, so the detail string carries the nuance).
+ *   3. When a proposal is generated, honour `tier2Enabled` — the proposal is
+ *      returned to the caller either way, but the outcome discriminant marks
+ *      whether persistence is permitted.
+ *
+ * This wrapper NEVER throws — all errors collapse to a `'error'` outcome.
+ *
+ * @param options - See {@link ContextStalenessScanOptions}.
+ * @returns {@link ContextStalenessScanOutcome}.
+ *
+ * @task T9896
+ */
+export async function safeRunContextStalenessScan(
+  options: ContextStalenessScanOptions,
+): Promise<ContextStalenessScanOutcome> {
+  try {
+    const isKilled = options.isKilled ?? (() => defaultIsKilled(options.statePath));
+    if (await isKilled()) {
+      return {
+        kind: 'killed',
+        proposal: null,
+        detail: 'killSwitch active — context staleness scan skipped',
+      };
+    }
+
+    const detect = options.detect ?? detectContextStaleness;
+    const proposal = await detect(options.projectRoot);
+
+    if (proposal === null) {
+      // The detector returns null for BOTH "fresh" and "no-context". Re-read
+      // the context to disambiguate the outcome discriminant. This is a
+      // cheap read; the file is already in OS cache after the detector pass.
+      let hasContext = false;
+      try {
+        hasContext = (await loadProjectContext(options.projectRoot)) !== null;
+      } catch {
+        hasContext = false;
+      }
+      return hasContext
+        ? {
+            kind: 'fresh',
+            proposal: null,
+            detail: 'project-context.json is within staleness window',
+          }
+        : { kind: 'no-context', proposal: null, detail: 'no project-context.json present' };
+    }
+
+    const isTier2Enabled =
+      options.isTier2Enabled ?? (() => defaultIsTier2Enabled(options.statePath));
+    if (!(await isTier2Enabled())) {
+      return {
+        kind: 'disabled',
+        proposal,
+        detail: 'tier2Enabled=false; proposal generated but not persisted',
+      };
+    }
+
+    return {
+      kind: 'stale',
+      proposal,
+      detail: proposal.reason,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      kind: 'error',
+      proposal: null,
+      detail: `context staleness scan threw: ${message}`,
+    };
+  }
+}

--- a/packages/core/src/sentient/tick.ts
+++ b/packages/core/src/sentient/tick.ts
@@ -30,6 +30,10 @@ import {
   reVerifyWorkerReport,
   type WorkerReport,
 } from '../orchestrate/worker-verify.js';
+import {
+  CONTEXT_STALENESS_SCAN_INTERVAL_MS,
+  type ContextStalenessScanOutcome,
+} from './detectors/context-staleness.js';
 import { DREAM_CYCLE_INTERVAL_MS } from './dream-cycle.js';
 import { HYGIENE_SCAN_INTERVAL_MS } from './hygiene-scan.js';
 import { DRIFT_SCAN_INTERVAL_MS } from './stage-drift-tick.js';
@@ -275,6 +279,28 @@ export interface TickOptions {
    * @task T1680
    */
   dreamCycleIntervalMs?: number;
+  /**
+   * Override for the context-staleness scan function. Injected by tests to
+   * avoid reading `.cleo/project-context.json` from disk. When omitted the
+   * default {@link safeRunContextStalenessScan} from
+   * `./detectors/context-staleness.js` is used.
+   *
+   * Pass `null` to disable the staleness scan entirely (e.g. unit tests that
+   * don't exercise this path).
+   *
+   * @task T9896
+   */
+  contextStalenessScan?:
+    | ((projectRoot: string, statePath: string) => Promise<ContextStalenessScanOutcome>)
+    | null;
+  /**
+   * Interval (ms) between context-staleness scan passes.
+   * Defaults to {@link CONTEXT_STALENESS_SCAN_INTERVAL_MS} (6 hours).
+   * Pass 0 to scan on every tick (useful for integration tests).
+   *
+   * @task T9896
+   */
+  contextStalenessIntervalMs?: number;
 }
 
 /** Result of a spawn invocation. */
@@ -455,6 +481,18 @@ let _worktreePruneTickCount = 0;
  * @internal
  */
 let _lastStageDriftScanAt = 0;
+
+// ---------------------------------------------------------------------------
+// Context-staleness scan state (T9896)
+// ---------------------------------------------------------------------------
+
+/**
+ * Unix-epoch-ms timestamp of the last context-staleness scan pass.
+ * Gated to at most once every {@link CONTEXT_STALENESS_SCAN_INTERVAL_MS}.
+ * Starts at 0 so the first tick always triggers an initial scan.
+ * @internal
+ */
+let _lastContextStalenessScanAt = 0;
 
 // ---------------------------------------------------------------------------
 // Hygiene scan state (T1636)
@@ -861,6 +899,51 @@ async function maybeTriggerStageDriftScan(
 }
 
 /**
+ * Evaluate the context-staleness scan cadence and fire
+ * {@link safeRunContextStalenessScan} when enough time has elapsed.
+ *
+ * Respects the injectable `options.contextStalenessScan` override
+ * (`null` = disabled). Errors are swallowed — staleness detection must never
+ * crash the tick.
+ *
+ * @param projectRoot - Absolute project root.
+ * @param statePath   - Path to sentient-state.json.
+ * @param options     - Tick options (provides injectable + interval override).
+ *
+ * @internal
+ * @task T9896
+ */
+async function maybeTriggerContextStalenessScan(
+  projectRoot: string,
+  statePath: string,
+  options: TickOptions,
+): Promise<void> {
+  // Null explicitly disables the scan (test escape hatch).
+  if (options.contextStalenessScan === null) return;
+
+  const intervalMs = options.contextStalenessIntervalMs ?? CONTEXT_STALENESS_SCAN_INTERVAL_MS;
+  const now = Date.now();
+
+  if (now - _lastContextStalenessScanAt < intervalMs) return;
+
+  // Update the timestamp before awaiting so concurrent ticks don't double-fire.
+  _lastContextStalenessScanAt = now;
+
+  try {
+    if (options.contextStalenessScan) {
+      // Injected override (tests).
+      await options.contextStalenessScan(projectRoot, statePath);
+    } else {
+      // Default: lazy-import and run.
+      const { safeRunContextStalenessScan } = await import('./detectors/context-staleness.js');
+      await safeRunContextStalenessScan({ projectRoot, statePath });
+    }
+  } catch {
+    // Staleness scan is best-effort: errors must never propagate to the tick caller.
+  }
+}
+
+/**
  * Evaluate the hygiene scan cadence and fire {@link safeRunHygieneScan}
  * when enough time has elapsed since the last scan.
  *
@@ -1012,6 +1095,12 @@ export async function safeRunTick(options: TickOptions): Promise<TickOutcome> {
   // Stage-drift scan: fire when enough time has elapsed (T1635).
   // Best-effort: errors never affect tick outcome.
   maybeTriggerStageDriftScan(options.projectRoot, options.statePath, options).catch(() => {
+    // Ignore.
+  });
+
+  // Context-staleness scan: fire when enough time has elapsed (T9896).
+  // Best-effort: errors never affect tick outcome.
+  maybeTriggerContextStalenessScan(options.projectRoot, options.statePath, options).catch(() => {
     // Ignore.
   });
 


### PR DESCRIPTION
## Summary

- New Tier-2 sentient detector `detectContextStaleness` (T9896) — emits a P2 proposal when `.cleo/project-context.json` has a `detectedAt` older than 30 days.
- Uses the `loadProjectContext` SSoT loader from T9878 (no duplicate file-read path).
- Wired into the tick loop via `safeRunContextStalenessScan` (6-hour cadence, fire-and-forget, kill-switch + `tier2Enabled` gated, mirrors the existing stage-drift / hygiene / dream-cycle pattern).
- Detector return shape: `{ id, kind: 'context-refresh', title, severity: 'P2', fixAction, reason }`. ID is deterministic per `computeProjectHash(projectRoot)` so the persistence layer can dedup cleanly.

## Test plan

- [x] Stale context (31d, 45d, 60d) → proposal generated with severity `P2`
- [x] Fresh context (1d, 5d) → null
- [x] Boundary (age == 30d threshold) → null (only emits when age > threshold)
- [x] Missing `project-context.json` (loader returns null) → null
- [x] Unparseable `detectedAt` → null + does NOT throw
- [x] Missing `detectedAt` field → null
- [x] Loader throws → null
- [x] Wrapper outcome matrix: `killed`, `disabled`, `fresh`, `no-context`, `stale`, `error`
- [x] `pnpm biome check` — clean
- [x] `pnpm -F @cleocode/core run build` — clean
- [x] `pnpm exec vitest run packages/core/src/sentient/` — 446 tests pass (13 new)

Closes T9896
Saga: T9855
ADR: 076