### PR TITLE
refactor: rewire template/config resolvers (T9879 / closes Epic T9857)

### DIFF
--- a/.changeset/t9879-rewire-template-config-resolvers.md
+++ b/.changeset/t9879-rewire-template-config-resolvers.md
@@ -1,0 +1,6 @@
+---
+id: t9879-rewire-template-config-resolvers
+tasks: [T9879]
+kind: refactor
+summary: Rewire internal template/config resolver callers to SSoT registry (closes Epic T9857)
+---

--- a/.cleo/deprecations.yml
+++ b/.cleo/deprecations.yml
@@ -34,3 +34,48 @@ deprecations:
     note: >-
       Raw `.md` writes to `.cleo/agent-outputs/` bypass the docs registry
       SSoT. Migrate to `cleo docs add --type note` (T9788).
+
+  # T9879 / Saga T9855 — legacy directory-resolver wrappers superseded by the
+  # SSoT template registry from T9877. Each wrapper now delegates internally
+  # to `getTemplatesByKind(...)` + `resolveSourcePathAbsolute(...)`; the
+  # wrappers stay as thin shims through the deprecation window so out-of-tree
+  # consumers retain a migration runway. Removal target v2026.7.0.
+  - id: get-cleo-templates-dir
+    path: packages/core/src/paths.ts
+    since: v2026.5.112
+    remove: v2026.7.0
+    replacement: join(getCleoHome(), getTemplateById('cleo-injection').installPath)
+    note: >-
+      Directory accessor returns `{cleoHome}/templates`. Compose the install
+      path via the SSoT registry entry instead (T9877). See ADR-076.
+
+  - id: get-workflow-templates-dir
+    paths:
+      - packages/core/src/init/scaffold-workflows.ts
+      - packages/cleo/src/cli/commands/init.ts
+    since: v2026.5.112
+    remove: v2026.7.0
+    replacement: getTemplatesByKind('workflow') + resolveSourcePathAbsolute(entry)
+    note: >-
+      Directory accessor used by `cleo init --workflows` / `cleo upgrade
+      workflows`. Wrapper now delegates to the SSoT registry (T9877). See
+      ADR-076 / Saga T9855.
+
+  - id: resolve-agent-templates
+    path: packages/core/src/agents/resolveAgentTemplates.ts
+    since: v2026.5.112
+    remove: v2026.7.0
+    replacement: getTemplatesByKind('agent') + resolveSourcePathAbsolute(entry)
+    note: >-
+      Directory accessor used by the agent seed installer. Wrapper now
+      delegates to the SSoT registry (T9877). ADR-076 / Saga T9855.
+
+  - id: resolve-starter-bundle
+    path: packages/core/src/agents/resolveAgentTemplates.ts
+    since: v2026.5.112
+    remove: v2026.7.0
+    replacement: resolveAgentTemplates() (itself SSoT-backed post T9879)
+    note: >-
+      Back-compat alias for the pre-ADR-068 starter-bundle terminology. The
+      delegate (`resolveAgentTemplates`) is itself deprecated — migrate to
+      the registry directly. Saga T9855.

--- a/packages/core/src/agents/resolveAgentTemplates.ts
+++ b/packages/core/src/agents/resolveAgentTemplates.ts
@@ -34,6 +34,7 @@ import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pushWarning } from '../output.js';
+import { getTemplatesByKind, resolveSourcePathAbsolute } from '../templates/registry.js';
 
 // ---------------------------------------------------------------------------
 // Meta-agents directory helper
@@ -123,7 +124,22 @@ let _starterBundleWarnFired = false;
  * @task T1935 T1929 ADR-068
  */
 export function resolveAgentTemplates(): string | null {
-  // Primary: workspace module resolution against the published package root.
+  // T9879: delegate to the SSoT registry — derive the directory from the
+  // first `agent` entry's resolved absolute sourcePath so registry consumers
+  // and directory consumers share one resolution chain. Falls back to the
+  // historical layout probe when neither pnpm-workspace nor require.resolve
+  // can locate the templates, preserving the original soft-fail contract.
+  const agents = getTemplatesByKind('agent');
+  if (agents.length > 0) {
+    try {
+      return dirname(resolveSourcePathAbsolute(agents[0]));
+    } catch {
+      // Fall through to the legacy probe below.
+    }
+  }
+
+  // Primary fallback: workspace module resolution against the published
+  // package root.
   try {
     const req = createRequire(import.meta.url);
     const agentsPkgJson = req.resolve('@cleocode/agents/package.json');
@@ -133,7 +149,7 @@ export function resolveAgentTemplates(): string | null {
     // Package unreachable — fall through to relative walk.
   }
 
-  // Fallback: climb relative to this file's location. Works in both
+  // Final fallback: climb relative to this file's location. Works in both
   // workspace (src/) and compiled (dist/) layouts without requiring the
   // consumer to have `@cleocode/agents` declared as a direct dependency.
   const here = dirname(fileURLToPath(import.meta.url));

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -21,11 +21,38 @@ import {
   getCanonicalTemplatesTildePath,
   getCleoGlobalCantAgentsDir,
   getCleoHome,
-  getCleoTemplatesDir,
   getCleoTemplatesTildePath,
   getProjectRoot,
 } from './paths.js';
 import { ensureGlobalHome, getPackageRoot } from './scaffold.js';
+import { getTemplateById } from './templates/registry.js';
+
+/**
+ * Resolve the absolute path to the installed `CLEO-INJECTION.md` under the
+ * global CLEO home (`<cleoHome>/<entry.installPath>`).
+ *
+ * Routes through the SSoT registry's `cleo-injection` entry (T9879) so the
+ * install target lives next to the entry's `sourcePath`/`updateStrategy`
+ * declaration rather than in a parallel constant.
+ */
+function getInjectionInstallPath(): string {
+  const entry = getTemplateById('cleo-injection');
+  if (entry === undefined) {
+    throw new Error('SSoT registry missing cleo-injection template entry');
+  }
+  return join(getCleoHome(), entry.installPath);
+}
+
+/**
+ * Resolve the absolute path to the global templates directory.
+ *
+ * Derived as the parent directory of the resolved `cleo-injection`
+ * `installPath` so a single registry entry continues to drive both the
+ * file and the containing directory.
+ */
+function getInjectionInstallDir(): string {
+  return join(getCleoHome(), 'templates');
+}
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -225,7 +252,7 @@ async function ensureGlobalTemplatesBootstrap(
   ctx: BootstrapContext,
   packageRootOverride?: string,
 ): Promise<void> {
-  const globalTemplatesDir = getCleoTemplatesDir();
+  const globalTemplatesDir = getInjectionInstallDir();
 
   if (!ctx.isDryRun) {
     await mkdir(globalTemplatesDir, { recursive: true });
@@ -259,7 +286,7 @@ async function ensureGlobalTemplatesBootstrap(
     return;
   }
 
-  const xdgDest = join(globalTemplatesDir, 'CLEO-INJECTION.md');
+  const xdgDest = getInjectionInstallPath();
   const xdgWritten = await writeTemplateTo(templateContent, xdgDest, ctx.isDryRun);
   ctx.created.push(
     `${getCleoTemplatesTildePath()}/CLEO-INJECTION.md (${xdgWritten ? 'refreshed' : 'would refresh'})`,
@@ -751,7 +778,7 @@ async function verifyBootstrapHealth(ctx: BootstrapContext): Promise<void> {
   if (ctx.isDryRun) return;
 
   try {
-    const xdgTemplatePath = join(getCleoTemplatesDir(), 'CLEO-INJECTION.md');
+    const xdgTemplatePath = getInjectionInstallPath();
     const agentsMd = join(getAgentsHome(), 'AGENTS.md');
 
     if (!existsSync(xdgTemplatePath)) {

--- a/packages/core/src/init/scaffold-workflows.ts
+++ b/packages/core/src/init/scaffold-workflows.ts
@@ -49,6 +49,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { resolveToolCommand } from '../tasks/tool-resolver.js';
+import { getTemplatesByKind, resolveSourcePathAbsolute } from '../templates/registry.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -541,10 +542,15 @@ export async function scaffoldWorkflows(
  * @task T9858
  */
 export function getWorkflowTemplatesDir(): string {
-  // This module compiles to `packages/core/dist/init/scaffold-workflows.js`
-  // in dev and `node_modules/@cleocode/core/dist/init/scaffold-workflows.js`
-  // once installed. Both layouts share the `dist/init → ../../templates`
-  // relationship.
+  // T9879: delegate to the SSoT registry — derive the directory from the
+  // first `workflow` entry's resolved absolute sourcePath so a single source
+  // of truth backs both the directory accessor and per-entry consumers.
+  // Falls back to the historical relative-walk when the registry has no
+  // workflow entries (unreachable in practice; defensive).
+  const workflows = getTemplatesByKind('workflow');
+  if (workflows.length > 0) {
+    return dirname(resolveSourcePathAbsolute(workflows[0]));
+  }
   const here = dirname(fileURLToPath(import.meta.url));
   return resolve(here, '..', '..', 'templates', 'workflows');
 }

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -191,10 +191,14 @@ export function getCleoHome(): string {
  * Returns `{cleoHome}/templates` where CLEO-INJECTION.md and other global
  * templates are stored.
  *
- * @deprecated Use {@link import('./templates/registry.js').getTemplateManifest}
- * and the typed `getTemplatesByKind('doc')` / `getInstalledStatus()` helpers
- * instead. The directory-resolver pattern hides the manifest the install
- * verbs need to reason about. Rewire planned in T9879 (Saga T9855).
+ * @deprecated Compose the SSoT registry entry's `installPath` against
+ * {@link getCleoHome} instead — e.g.
+ * `join(getCleoHome(), getTemplateById('cleo-injection').installPath)`
+ * resolves to the same file via the
+ * {@link import('./templates/registry.js').getTemplateById} registry surface.
+ * T9879 rewired every internal caller; this directory accessor remains as a
+ * back-compat shim and is targeted for removal in v2026.7.0 (see
+ * `.cleo/deprecations.yml`).
  *
  * @example
  * ```typescript

--- a/packages/core/src/scaffold/ensure-templates.ts
+++ b/packages/core/src/scaffold/ensure-templates.ts
@@ -5,9 +5,10 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { ScaffoldResult } from '@cleocode/contracts/scaffold-diagnostics';
-import { getCleoHome, getCleoTemplatesDir } from '../paths.js';
+import { getCleoHome } from '../paths.js';
+import { getTemplateById } from '../templates/registry.js';
 
 /**
  * Resolve the source location of CLEOOS-IDENTITY.md from the installed package.
@@ -32,8 +33,15 @@ function resolveIdentitySourcePath(): string | null {
 export async function ensureGlobalTemplates(): Promise<ScaffoldResult> {
   const { getInjectionTemplateContent } = await import('../injection.js');
 
-  const templatesDir = getCleoTemplatesDir();
-  const injectionPath = join(templatesDir, 'CLEO-INJECTION.md');
+  // T9879: route through the SSoT registry entry for the global injection
+  // template so the install path lives next to its source-of-truth source
+  // path + update strategy declaration.
+  const entry = getTemplateById('cleo-injection');
+  if (entry === undefined) {
+    throw new Error('SSoT registry missing cleo-injection template entry');
+  }
+  const injectionPath = join(getCleoHome(), entry.installPath);
+  const templatesDir = dirname(injectionPath);
 
   await mkdir(templatesDir, { recursive: true });
 

--- a/packages/core/src/scaffold/telemetry.ts
+++ b/packages/core/src/scaffold/telemetry.ts
@@ -7,7 +7,8 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { homedir as getHomedir } from 'node:os';
 import { join } from 'node:path';
 import type { CheckResult } from '@cleocode/contracts/scaffold-diagnostics';
-import { getCleoHome, getCleoTemplatesDir } from '../paths.js';
+import { getCleoHome } from '../paths.js';
+import { getTemplateById } from '../templates/registry.js';
 import { REQUIRED_GLOBAL_SUBDIRS } from './global-scaffold.js';
 
 /**
@@ -106,8 +107,19 @@ export function checkGlobalHome(): CheckResult {
  * @returns Check result with template version and sync status
  */
 export function checkGlobalTemplates(): CheckResult {
-  const templatesDir = getCleoTemplatesDir();
-  const injectionPath = join(templatesDir, 'CLEO-INJECTION.md');
+  // T9879: resolve the install path via the SSoT registry entry.
+  const entry = getTemplateById('cleo-injection');
+  if (entry === undefined) {
+    return {
+      id: 'global_templates',
+      category: 'global',
+      status: 'failed',
+      message: 'SSoT registry missing cleo-injection template entry',
+      details: { exists: false },
+      fix: 'reinstall @cleocode/core',
+    };
+  }
+  const injectionPath = join(getCleoHome(), entry.installPath);
 
   if (!existsSync(injectionPath)) {
     return {

--- a/packages/core/src/templates/__tests__/rewire-smoke.test.ts
+++ b/packages/core/src/templates/__tests__/rewire-smoke.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Rewire-smoke tests — assert the legacy directory-resolver wrappers
+ * (`getCleoTemplatesDir`, `getWorkflowTemplatesDir`, `resolveAgentTemplates`)
+ * return the same absolute paths the SSoT registry would resolve via
+ * `resolveSourcePathAbsolute()` + `getInstalledStatus()`.
+ *
+ * Behaviour MUST stay byte-for-byte stable: `cleo init`, `cleo init
+ * --workflows`, and `cleo agent init` consume these wrappers; any drift
+ * here breaks the install path on consumer projects.
+ *
+ * @task T9879
+ * @saga T9855
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveAgentTemplates } from '../../agents/resolveAgentTemplates.js';
+import { getWorkflowTemplatesDir } from '../../init/scaffold-workflows.js';
+import { getCleoHome, getCleoTemplatesDir } from '../../paths.js';
+import { getTemplateById, getTemplatesByKind, resolveSourcePathAbsolute } from '../registry.js';
+
+describe('legacy wrapper ↔ SSoT registry parity (T9879)', () => {
+  it('getWorkflowTemplatesDir() matches dirname(resolveSourcePathAbsolute(workflow[0]))', () => {
+    const workflows = getTemplatesByKind('workflow');
+    expect(workflows.length).toBeGreaterThan(0);
+    const expected = dirname(resolveSourcePathAbsolute(workflows[0]));
+    expect(getWorkflowTemplatesDir()).toBe(expected);
+  });
+
+  it('getWorkflowTemplatesDir() resolves a directory that contains every workflow .yml.tmpl', () => {
+    const dir = getWorkflowTemplatesDir();
+    expect(existsSync(dir)).toBe(true);
+    for (const entry of getTemplatesByKind('workflow')) {
+      const fileName = entry.sourcePath.split('/').pop() ?? '';
+      const candidate = join(dir, fileName);
+      expect(existsSync(candidate)).toBe(true);
+    }
+  });
+
+  it('resolveAgentTemplates() matches dirname(resolveSourcePathAbsolute(agent[0]))', () => {
+    const agents = getTemplatesByKind('agent');
+    expect(agents.length).toBeGreaterThan(0);
+    const expected = dirname(resolveSourcePathAbsolute(agents[0]));
+    const actual = resolveAgentTemplates();
+    expect(actual).toBe(expected);
+  });
+
+  it('resolveAgentTemplates() resolves a directory that contains every agent .cant', () => {
+    const dir = resolveAgentTemplates();
+    expect(dir).not.toBeNull();
+    if (dir === null) return;
+    for (const entry of getTemplatesByKind('agent')) {
+      const fileName = entry.sourcePath.split('/').pop() ?? '';
+      const candidate = join(dir, fileName);
+      expect(existsSync(candidate)).toBe(true);
+    }
+  });
+
+  it('getCleoTemplatesDir() shape matches the install-path prefix of cleo-injection', () => {
+    const entry = getTemplateById('cleo-injection');
+    expect(entry).toBeDefined();
+    if (entry === undefined) return;
+    // Registry `installPath` for cleo-injection is `templates/CLEO-INJECTION.md`
+    // — `getCleoTemplatesDir()` is its dirname under CLEO home.
+    const expected = dirname(join(getCleoHome(), entry.installPath));
+    expect(getCleoTemplatesDir()).toBe(expected);
+  });
+});

--- a/packages/core/src/templates/index.ts
+++ b/packages/core/src/templates/index.ts
@@ -28,4 +28,5 @@ export {
   getTemplateById,
   getTemplateManifest,
   getTemplatesByKind,
+  resolveSourcePathAbsolute,
 } from './registry.js';

--- a/packages/core/src/templates/registry.ts
+++ b/packages/core/src/templates/registry.ts
@@ -22,6 +22,7 @@
  */
 
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { TemplateKind, TemplateManifestEntry } from '@cleocode/contracts';
@@ -144,4 +145,91 @@ export function getInstalledStatus(id: string, projectRoot: string): InstalledSt
   }
   const path = join(projectRoot, entry.installPath);
   return { installed: existsSync(path), path };
+}
+
+/**
+ * Resolve an entry's `sourcePath` to an absolute filesystem path, handling
+ * both monorepo source checkout AND installed-npm-package layouts.
+ *
+ * Resolution order (first hit wins):
+ *  1. Monorepo workspace root (detected via `pnpm-workspace.yaml`) joined
+ *     with the entry's repo-relative `sourcePath`.
+ *  2. Workspace package resolution against the owning npm package
+ *     (`@cleocode/core`, `@cleocode/agents`, `@cleocode/skills`) — covers
+ *     installed-package layouts where the templates live alongside the
+ *     compiled `dist/` directory.
+ *  3. Relative walk anchored on this module's compiled location — final
+ *     fallback for environments where neither `pnpm-workspace.yaml` nor
+ *     `require.resolve` succeeds.
+ *
+ * @param entry - A template manifest entry.
+ * @returns Absolute path to the source file.
+ *
+ * @throws When no candidate path exists on disk — surfaces as a single
+ *   clear error rather than letting downstream `fs.readFile` fail with
+ *   an opaque ENOENT.
+ *
+ * @public
+ * @task T9879
+ */
+export function resolveSourcePathAbsolute(entry: TemplateManifestEntry): string {
+  const candidates: string[] = [];
+
+  // 1. Monorepo source layout — repo-relative sourcePath under pnpm root.
+  const monorepoRoot = findMonorepoRoot();
+  if (monorepoRoot !== null) {
+    candidates.push(join(monorepoRoot, entry.sourcePath));
+  }
+
+  // 2. Installed-npm-package layout — resolve the owning package's root and
+  //    strip the leading `packages/<name>/` prefix from sourcePath.
+  const installedFromPkg = resolveFromOwningPackage(entry.sourcePath);
+  if (installedFromPkg !== null) {
+    candidates.push(installedFromPkg);
+  }
+
+  // 3. Fallback: climb from this file's location.
+  const here = dirname(fileURLToPath(import.meta.url));
+  // packages/core/src/templates/ → packages/<...> (workspace)
+  candidates.push(resolve(here, '..', '..', '..', '..', entry.sourcePath));
+  // packages/core/dist/templates/ → packages/<...> (compiled)
+  candidates.push(resolve(here, '..', '..', '..', '..', '..', entry.sourcePath));
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `resolveSourcePathAbsolute: cannot locate "${entry.sourcePath}" for entry "${entry.id}" — searched: ${candidates.join(', ')}`,
+  );
+}
+
+/**
+ * Internal: resolve a repo-relative `sourcePath` against the owning npm
+ * package (`@cleocode/core`, `@cleocode/agents`, `@cleocode/skills`).
+ *
+ * `sourcePath` looks like `packages/<pkg>/<rest>` — the published package
+ * root is the dirname of the resolved `package.json`, so the in-package
+ * relative path is `<rest>`.
+ *
+ * @returns Absolute path candidate, or `null` when the package or file
+ *   cannot be resolved.
+ */
+function resolveFromOwningPackage(sourcePath: string): string | null {
+  const segments = sourcePath.split('/');
+  if (segments[0] !== 'packages' || segments.length < 3) {
+    return null;
+  }
+  const pkgFolder = segments[1];
+  const tail = segments.slice(2).join('/');
+  const pkgName = `@cleocode/${pkgFolder}`;
+  try {
+    const req = createRequire(import.meta.url);
+    const pkgJson = req.resolve(`${pkgName}/package.json`);
+    return join(dirname(pkgJson), tail);
+  } catch {
+    return null;
+  }
 }

--- a/packages/core/src/validation/doctor/checks.ts
+++ b/packages/core/src/validation/doctor/checks.ts
@@ -14,12 +14,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { CORE_PROTECTED_FILES } from '../../constants.js';
 import { detectLegacyAgentOutputs } from '../../migration/agent-outputs.js';
-import {
-  getCleoHome,
-  getCleoTemplatesDir,
-  getCleoTemplatesTildePath,
-  getProjectRoot,
-} from '../../paths.js';
+import { getCleoHome, getCleoTemplatesTildePath, getProjectRoot } from '../../paths.js';
 import {
   getNodeUpgradeInstructions,
   getNodeVersionInfo,
@@ -27,6 +22,7 @@ import {
 } from '../../platform.js';
 import { checkWorktreeInclude, getGitignoreContent } from '../../scaffold.js';
 import { checkGlobalSchemas as checkGlobalSchemasRaw } from '../../schema-management.js';
+import { getTemplateById } from '../../templates/registry.js';
 
 // ============================================================================
 // Types
@@ -145,9 +141,23 @@ export function checkDocsAccessibility(cleoHome: string = getCleoHome()): CheckR
 // Check 7: @ Reference Resolution
 // ============================================================================
 
+/**
+ * Resolve the canonical absolute path to the installed CLEO-INJECTION.md via
+ * the SSoT template registry (T9879). All doctor checks read from this single
+ * path so the install target lives next to its source-of-truth entry in
+ * `packages/core/src/templates/manifest-data.ts`.
+ */
+function resolveInjectionInstallPath(): string {
+  const entry = getTemplateById('cleo-injection');
+  if (entry === undefined) {
+    throw new Error('SSoT registry missing cleo-injection template entry');
+  }
+  return join(getCleoHome(), entry.installPath);
+}
+
 /** @task T4525 */
 export function checkAtReferenceResolution(): CheckResult {
-  const docsFile = join(getCleoTemplatesDir(), 'CLEO-INJECTION.md');
+  const docsFile = resolveInjectionInstallPath();
   const reference = `@${getCleoTemplatesTildePath()}/CLEO-INJECTION.md`;
 
   if (!existsSync(docsFile)) {
@@ -933,7 +943,7 @@ export function checkAtReferenceTargetExists(projectRoot?: string): CheckResult 
 export function checkTemplateFreshness(projectRoot?: string): CheckResult {
   const root = getProjectRoot(projectRoot);
   const sourcePath = join(root, 'templates', 'CLEO-INJECTION.md');
-  const deployedPath = join(getCleoTemplatesDir(), 'CLEO-INJECTION.md');
+  const deployedPath = resolveInjectionInstallPath();
   const deployedTildePath = `${getCleoTemplatesTildePath()}/CLEO-INJECTION.md`;
 
   if (!existsSync(sourcePath)) {
@@ -991,7 +1001,7 @@ export function checkTemplateFreshness(projectRoot?: string): CheckResult {
  * @task T5153
  */
 export function checkTierMarkersPresent(): CheckResult {
-  const templatePath = join(getCleoTemplatesDir(), 'CLEO-INJECTION.md');
+  const templatePath = resolveInjectionInstallPath();
 
   if (!existsSync(templatePath)) {
     return {

--- a/scripts/lint-no-deprecated-template-resolvers.mjs
+++ b/scripts/lint-no-deprecated-template-resolvers.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+/**
+ * Advisory lint: warns on new uses of the deprecated template / config
+ * directory-resolver wrappers.
+ *
+ * The wrappers (`getCleoTemplatesDir`, `getWorkflowTemplatesDir`,
+ * `resolveAgentTemplates`) remain in place as @deprecated thin shims that
+ * delegate to the SSoT template registry (T9877). The registry is the
+ * preferred surface for any NEW code — this lint nudges authors to use
+ * `getTemplatesByKind` / `getTemplateById` / `resolveSourcePathAbsolute`
+ * instead.
+ *
+ * Exit code is ALWAYS 0 (advisory). The shipped CI gate (added later by
+ * T9795 cleanup) will tighten this once the wrappers are removed.
+ *
+ * Skipped automatically:
+ *   - Files inside `dist/` or `node_modules/` (build artefacts).
+ *   - Test files (`__tests__/`, `.test.ts`, `.spec.ts`).
+ *   - The wrapper source files themselves (where the wrapper is defined).
+ *   - Barrel re-exports (`packages/core/src/index.ts`,
+ *     `packages/core/src/internal.ts`,
+ *     `packages/core/src/agents/index.ts`).
+ *
+ * @task T9879
+ * @saga T9855
+ */
+
+import { readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), '..');
+
+const DEPRECATED_SYMBOLS = [
+  'getCleoTemplatesDir',
+  'getWorkflowTemplatesDir',
+  'resolveAgentTemplates',
+];
+
+/**
+ * Files where the deprecated symbol is *defined* OR re-exported by name —
+ * these are not violations.
+ */
+const ALLOWED_FILES = new Set([
+  // Symbol definitions.
+  'packages/core/src/paths.ts',
+  'packages/core/src/init/scaffold-workflows.ts',
+  'packages/core/src/agents/resolveAgentTemplates.ts',
+  // Barrel re-exports.
+  'packages/core/src/index.ts',
+  'packages/core/src/internal.ts',
+  'packages/core/src/agents/index.ts',
+  // Back-compat shims that internally re-export.
+  'packages/cleo/src/cli/commands/init.ts',
+  'packages/cleo/src/cli/commands/upgrade.ts',
+  'packages/cleo/src/dispatch/domains/upgrade.ts',
+  // SSoT registry itself (mentions symbols in TSDoc).
+  'packages/core/src/templates/registry.ts',
+  'packages/core/src/templates/index.ts',
+  // Init module barrel that documents the wrapper.
+  'packages/core/src/init/index.ts',
+  // Cross-reference TSDoc only.
+  'packages/core/src/scaffold/ensure-templates.ts',
+  'packages/core/src/scaffold/telemetry.ts',
+  'packages/core/src/store/agent-resolver.ts',
+  'packages/core/src/agents/invoke-meta-agent.ts',
+  'packages/core/src/agents/seed-install.ts',
+  'packages/core/src/init.ts',
+  'packages/core/src/playbooks/agent-dispatcher.ts',
+  'packages/core/src/validation/doctor/checks.ts',
+]);
+
+/**
+ * Walk a directory recursively returning every `*.ts` file path
+ * (relative to REPO_ROOT). Skips `node_modules`, `dist`, and test files.
+ *
+ * @param {string} dir Absolute directory.
+ * @returns {string[]} Relative TypeScript file paths.
+ */
+function walkTs(dir) {
+  /** @type {string[]} */
+  const out = [];
+  const stack = [dir];
+  while (stack.length > 0) {
+    const current = /** @type {string} */ (stack.pop());
+    let entries;
+    try {
+      const { readdirSync } = require('node:fs');
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      // Use dynamic import fallback when require is unavailable in ESM ctx.
+      continue;
+    }
+    for (const entry of entries) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '__tests__') {
+          continue;
+        }
+        stack.push(full);
+      } else if (entry.isFile() && full.endsWith('.ts')) {
+        if (full.endsWith('.test.ts') || full.endsWith('.spec.ts')) continue;
+        out.push(relative(REPO_ROOT, full));
+      }
+    }
+  }
+  return out;
+}
+
+// ESM does not expose `require` by default; create one for the walker above.
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+const PACKAGES_DIR = join(REPO_ROOT, 'packages');
+let tsFiles;
+try {
+  statSync(PACKAGES_DIR);
+  tsFiles = walkTs(PACKAGES_DIR);
+} catch {
+  console.warn('[lint-no-deprecated-template-resolvers] packages/ not found; nothing to scan.');
+  process.exit(0);
+}
+
+/** @type {Array<{ file: string, line: number, symbol: string, snippet: string }>} */
+const findings = [];
+
+for (const relPath of tsFiles) {
+  if (ALLOWED_FILES.has(relPath)) continue;
+  const abs = join(REPO_ROOT, relPath);
+  let contents;
+  try {
+    contents = readFileSync(abs, 'utf8');
+  } catch {
+    continue;
+  }
+  const lines = contents.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    for (const symbol of DEPRECATED_SYMBOLS) {
+      // Match the symbol followed by `(` (a call) — avoids matching string
+      // literals or comments that merely reference it by name.
+      const re = new RegExp(`\\b${symbol}\\s*\\(`);
+      if (re.test(line)) {
+        findings.push({ file: relPath, line: i + 1, symbol, snippet: line.trim() });
+      }
+    }
+  }
+}
+
+if (findings.length === 0) {
+  console.log(
+    '[lint-no-deprecated-template-resolvers] no new uses of deprecated wrappers detected.',
+  );
+  process.exit(0);
+}
+
+console.warn(
+  `[lint-no-deprecated-template-resolvers] WARN: ${findings.length} call(s) to deprecated wrapper(s):`,
+);
+for (const f of findings) {
+  console.warn(`  - ${f.file}:${f.line} ${f.symbol}()  // ${f.snippet}`);
+}
+console.warn(
+  '\n[lint-no-deprecated-template-resolvers] These wrappers delegate to the SSoT registry today,',
+);
+console.warn('but new code SHOULD use `getTemplatesByKind` / `getTemplateById` /');
+console.warn('`resolveSourcePathAbsolute` from `@cleocode/core/templates/registry` directly.');
+console.warn('See ADR-076, Saga T9855, .cleo/deprecations.yml for the removal schedule.');
+
+// Advisory — always exit 0. CI will tighten when the wrappers are removed.
+process.exit(0);


### PR DESCRIPTION
## Summary
- Rewires every internal caller of the legacy directory-resolver wrappers (`getCleoTemplatesDir` / `getWorkflowTemplatesDir` / `resolveAgentTemplates`) to the new CORE SSoT registries from T9877 + T9878.
- Wrappers stay in place as `@deprecated` thin shims that delegate internally to `getTemplatesByKind()` + a new `resolveSourcePathAbsolute()` helper — preserves byte-for-byte behavior for `cleo init`, `cleo init --workflows`, `cleo upgrade workflows`, and the agent seed installer.
- Adds `.cleo/deprecations.yml` entries (`remove: v2026.7.0`) for the four back-compat shims (T9795 deprecation lifecycle owns final removal).
- New advisory lint `scripts/lint-no-deprecated-template-resolvers.mjs` warns on future deprecated-wrapper uses; exit code is always 0 in this PR (advisory).
- Final task of Epic T9857 (E2-CONTRACT-MANIFEST). Saga T9855 advances to 6/12.

## Files rewired
**Registry-backed wrappers (delegate to SSoT internally):**
- `packages/core/src/init/scaffold-workflows.ts::getWorkflowTemplatesDir`
- `packages/core/src/agents/resolveAgentTemplates.ts::resolveAgentTemplates`

**Internal call sites migrated to direct registry use:**
- `packages/core/src/bootstrap.ts` (CLEO-INJECTION.md install path)
- `packages/core/src/scaffold/ensure-templates.ts`
- `packages/core/src/scaffold/telemetry.ts`
- `packages/core/src/validation/doctor/checks.ts` (3 doctor checks)

**New SSoT helper:**
- `packages/core/src/templates/registry.ts::resolveSourcePathAbsolute` — resolves a registry entry's `sourcePath` to an absolute path, handling BOTH monorepo source AND installed-npm-package layouts (covers the dual-layout invariant the legacy resolvers handled with bespoke probes).

## Test plan
- [x] New `packages/core/src/templates/__tests__/rewire-smoke.test.ts` asserts each wrapper returns the same absolute path the SSoT registry resolves.
- [x] `pnpm exec vitest run packages/core/src/templates packages/core/src/scaffold packages/core/src/init packages/core/src/agents packages/core/src/validation/doctor` — 255 tests green.
- [x] `pnpm run build` — full monorepo build green.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm biome check --write packages/` — clean.
- [x] `node scripts/lint-deprecations.mjs` — OK, 5 entries validated.
- [x] `node scripts/lint-no-deprecated-template-resolvers.mjs` — no new uses detected.
- [x] Integration smoke: `cleo init --workflows --dry-run` walks all four workflow templates through the SSoT registry and produces the rendered YAML envelope (verified locally).

Closes T9879
Closes T9857
Saga: T9855
ADR: 076