### PR TITLE
feat(cleo): cleo config CLI namespace (T9887 / Saga T9855)

### DIFF
--- a/.changeset/t9887-cleo-config-cli.md
+++ b/.changeset/t9887-cleo-config-cli.md
@@ -1,0 +1,6 @@
+---
+id: t9887-cleo-config-cli
+tasks: [T9887]
+kind: feat
+summary: cleo config {show,get,set,validate,drift-check} CLI namespace wrapping the SSoT ConfigManifest registry (T9876+T9878). Adds --scope global|project|merged on read verbs and --type string|number|boolean|json on set.
+---

--- a/build.mjs
+++ b/build.mjs
@@ -47,6 +47,9 @@ import { spawn } from 'node:child_process';
  * exports. Each dir is scanned one level deep (direct .ts files only).
  */
 const SUBPATH_DIRS = [
+  // T9887 — packages/core/src/config/registry.ts is exposed via the
+  // ./config/registry subpath export for `cleo config` (Saga T9855 E4).
+  'config',
   'sentient',
   'gc',
   'doctor',

--- a/packages/cleo/src/cli/commands/config.ts
+++ b/packages/cleo/src/cli/commands/config.ts
@@ -1,82 +1,52 @@
 /**
- * CLI command group: cleo config — configuration management.
+ * CLI command group: cleo config — SSoT ConfigManifest registry surface.
  *
- * Delegates to core/config.ts for business logic. For the `list` subcommand
- * the resolved config is read directly via `loadConfig()` (no dispatch op).
+ * `show`, `get`, `set`, `validate`, and `drift-check` are thin wrappers over
+ * the CORE registry from T9878 (`@cleocode/core/config/registry`) — they
+ * implement the operator surface for the ConfigManifest contract introduced
+ * in T9876.
+ *
+ * `set-preset`, `presets`, and `list` are legacy verbs that pre-date the SSoT
+ * registry and remain for backwards compatibility (they delegate through the
+ * dispatch admin domain to `loadConfig`/strictness-preset logic in
+ * `core/config.ts`).
  *
  * Subcommands:
- *   cleo config get <key>           — get a configuration value
- *   cleo config set <key> <value>   — set a configuration value
- *   cleo config set-preset <preset> — apply a strictness preset
- *   cleo config presets             — list all available presets
- *   cleo config list                — show all resolved configuration
+ *   cleo config show [--scope global|project|merged]      — read cascade
+ *   cleo config get <key> [--scope ...]                   — single lookup
+ *   cleo config set <key> <value> [--scope ...] [--type]  — write a value
+ *   cleo config validate [--scope global|project]         — schema gate
+ *   cleo config drift-check [--scope global|project|metadata] — drift gate
+ *   cleo config set-preset <preset>                       — apply preset (legacy)
+ *   cleo config presets                                   — list presets (legacy)
+ *   cleo config list                                      — resolved config (legacy)
  *
+ * @task T9887
  * @task T4454
  * @task T4795
  * @task T067
+ * @saga T9855
+ * @adr 076
  */
 
 import { CleoError, formatError, loadConfig } from '@cleocode/core';
-import { defineCommand, showUsage } from 'citty';
+import { showUsage } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
+import { defineCommand } from '../lib/define-cli-command.js';
 import { cliError, cliOutput } from '../renderers/index.js';
+import {
+  configDriftCheckCommand,
+  configGetCommand,
+  configSetCommand,
+  configShowCommand,
+  configValidateCommand,
+} from './config/index.js';
 
 const PRESET_DESCRIPTIONS: Record<string, string> = {
   strict: 'Block on missing AC, require session notes, enforce lifecycle pipeline.',
   standard: 'Warn on missing AC, optional session notes, advisory lifecycle pipeline.',
   minimal: 'No AC checking, no session requirement, lifecycle pipeline off.',
 };
-
-/** cleo config get — get a configuration value */
-const getCommand = defineCommand({
-  meta: { name: 'get', description: 'Get a configuration value' },
-  args: {
-    key: {
-      type: 'positional',
-      description: 'Configuration key to retrieve',
-      required: true,
-    },
-  },
-  async run({ args }) {
-    await dispatchFromCli(
-      'query',
-      'admin',
-      'config.show',
-      { key: args.key },
-      { command: 'config' },
-    );
-  },
-});
-
-/** cleo config set — set a configuration value */
-const setCommand = defineCommand({
-  meta: { name: 'set', description: 'Set a configuration value' },
-  args: {
-    key: {
-      type: 'positional',
-      description: 'Configuration key to set',
-      required: true,
-    },
-    value: {
-      type: 'positional',
-      description: 'Value to assign',
-      required: true,
-    },
-    global: {
-      type: 'boolean',
-      description: 'Set in global config instead of project config',
-    },
-  },
-  async run({ args }) {
-    await dispatchFromCli(
-      'mutate',
-      'admin',
-      'config.set',
-      { key: args.key, value: args.value },
-      { command: 'config' },
-    );
-  },
-});
 
 /** cleo config set-preset — apply a strictness preset to the project config */
 const setPresetCommand = defineCommand({
@@ -135,14 +105,25 @@ const listCommand = defineCommand({
 /**
  * Root config command group.
  *
- * Configuration management — read, write, and apply presets for project
- * and global CLEO configuration.
+ * Operator surface for the SSoT ConfigManifest registry (T9876 contracts +
+ * T9878 CORE registry). The new SSoT sub-verbs (`show`, `get`, `set`,
+ * `validate`, `drift-check`) live in `./config/` and are mounted alongside
+ * the legacy preset/list verbs.
+ *
+ * @public
  */
 export const configCommand = defineCommand({
-  meta: { name: 'config', description: 'Configuration management' },
+  meta: {
+    name: 'config',
+    description:
+      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+  },
   subCommands: {
-    get: getCommand,
-    set: setCommand,
+    show: configShowCommand,
+    get: configGetCommand,
+    set: configSetCommand,
+    validate: configValidateCommand,
+    'drift-check': configDriftCheckCommand,
     'set-preset': setPresetCommand,
     presets: presetsCommand,
     list: listCommand,

--- a/packages/cleo/src/cli/commands/config/__tests__/config.test.ts
+++ b/packages/cleo/src/cli/commands/config/__tests__/config.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for `cleo config {show, get, set, validate, drift-check}` — verifies
+ * the CLI namespace wires into the CORE SSoT registry (T9878) end-to-end.
+ *
+ * Each test uses an isolated `os.tmpdir()` project root so the live
+ * `.cleo/config.json` of the host repo is never touched. The renderer layer
+ * is mocked so `cliOutput`/`cliError` calls are observable.
+ *
+ * @task T9887
+ * @saga T9855
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the renderer so cliOutput/cliError become observable spies that do not
+// emit to stdout/stderr or call process.exit indirectly via field-extract.
+const mockCliOutput = vi.fn();
+const mockCliError = vi.fn();
+vi.mock('../../../renderers/index.js', () => ({
+  cliOutput: (...args: unknown[]) => mockCliOutput(...args),
+  cliError: (...args: unknown[]) => mockCliError(...args),
+}));
+
+// Replace `getProjectRoot()` with a per-test stub that points at our temp dir.
+let currentProjectRoot = '';
+vi.mock('@cleocode/core', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('@cleocode/core')>();
+  return {
+    ...orig,
+    getProjectRoot: () => currentProjectRoot,
+  };
+});
+
+// Import AFTER mocks are wired (vi.mock is hoisted, but the bindings the
+// commands close over are captured at import time).
+import { configDriftCheckCommand } from '../drift-check.js';
+import { configGetCommand } from '../get.js';
+import { configSetCommand } from '../set.js';
+import { configShowCommand } from '../show.js';
+import { configValidateCommand } from '../validate.js';
+
+type RunArgs = Record<string, unknown>;
+type CittyCommand = {
+  run?: (ctx: { args: RunArgs; rawArgs: string[] }) => Promise<void> | void;
+};
+
+async function invoke(cmd: CittyCommand, args: RunArgs): Promise<void> {
+  const run = cmd.run;
+  if (!run) throw new Error('command has no run()');
+  await run({ args, rawArgs: [] });
+}
+
+let tempRoot = '';
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), 'cleo-config-test-'));
+  mkdirSync(join(tempRoot, '.cleo'), { recursive: true });
+  currentProjectRoot = tempRoot;
+  vi.clearAllMocks();
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
+    throw new Error(`__EXIT__:${code ?? 0}`);
+  }) as never);
+});
+
+afterEach(() => {
+  exitSpy.mockRestore();
+  if (tempRoot) {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// cleo config show
+// ---------------------------------------------------------------------------
+
+describe('cleo config show', () => {
+  it('returns envelope-shaped payload with project config (scope=project)', async () => {
+    writeFileSync(
+      join(tempRoot, '.cleo', 'config.json'),
+      JSON.stringify({ foo: { bar: 1 } }),
+      'utf8',
+    );
+
+    await invoke(configShowCommand, { scope: 'project' });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data, opts] = mockCliOutput.mock.calls[0]!;
+    expect(data).toEqual({ scope: 'project', config: { foo: { bar: 1 } } });
+    expect(opts).toMatchObject({ command: 'config-show', operation: 'config.show' });
+    expect(mockCliError).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown --scope with a typed error envelope', async () => {
+    await expect(invoke(configShowCommand, { scope: 'bogus' })).rejects.toThrow(/__EXIT__:1/);
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [message, code, details] = mockCliError.mock.calls[0]!;
+    expect(message).toMatch(/invalid --scope/);
+    expect(code).toBe(1);
+    expect(details).toMatchObject({ name: 'E_CONFIG_SHOW_FAILED' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo config get
+// ---------------------------------------------------------------------------
+
+describe('cleo config get', () => {
+  it('returns E_NOT_FOUND for a missing key', async () => {
+    writeFileSync(join(tempRoot, '.cleo', 'config.json'), JSON.stringify({}), 'utf8');
+
+    await expect(invoke(configGetCommand, { key: 'nonexistent.key' })).rejects.toThrow(
+      /__EXIT__:4/,
+    );
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [message, code, details] = mockCliError.mock.calls[0]!;
+    expect(message).toMatch(/key "nonexistent\.key" not found/);
+    expect(code).toBe(4);
+    expect(details).toMatchObject({ name: 'E_NOT_FOUND' });
+  });
+
+  it('returns the value for an existing key (default merged scope)', async () => {
+    writeFileSync(
+      join(tempRoot, '.cleo', 'config.json'),
+      JSON.stringify({ release: { branchModel: 'feat-to-main' } }),
+      'utf8',
+    );
+
+    await invoke(configGetCommand, { key: 'release.branchModel' });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    expect(data).toEqual({
+      scope: 'merged',
+      key: 'release.branchModel',
+      value: 'feat-to-main',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo config set
+// ---------------------------------------------------------------------------
+
+describe('cleo config set', () => {
+  it('writes a project config value and round-trips through get', async () => {
+    await invoke(configSetCommand, { key: 'foo.bar', value: '42', type: 'number' });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [setData] = mockCliOutput.mock.calls[0]!;
+    expect(setData).toMatchObject({
+      scope: 'project',
+      key: 'foo.bar',
+      value: 42,
+      validate: { ok: true, issues: [] },
+    });
+
+    // Round-trip — `cleo config get foo.bar` should return 42.
+    mockCliOutput.mockClear();
+    await invoke(configGetCommand, { key: 'foo.bar', scope: 'project' });
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [getData] = mockCliOutput.mock.calls[0]!;
+    expect(getData).toEqual({ scope: 'project', key: 'foo.bar', value: 42 });
+  });
+
+  it('rejects --type number with a non-numeric value', async () => {
+    await expect(
+      invoke(configSetCommand, { key: 'foo', value: 'abc', type: 'number' }),
+    ).rejects.toThrow(/__EXIT__:2/);
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [message] = mockCliError.mock.calls[0]!;
+    expect(message).toMatch(/--type number cannot coerce "abc"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo config validate
+// ---------------------------------------------------------------------------
+
+describe('cleo config validate', () => {
+  it('returns ok envelope for a project config without a bound schema', async () => {
+    writeFileSync(
+      join(tempRoot, '.cleo', 'config.json'),
+      JSON.stringify({ anything: 'goes' }),
+      'utf8',
+    );
+
+    await invoke(configValidateCommand, { scope: 'project' });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    expect(data).toEqual({ scope: 'project', ok: true, issues: [] });
+    expect(mockCliError).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo config drift-check
+// ---------------------------------------------------------------------------
+
+describe('cleo config drift-check', () => {
+  it('reports drift on a stale project-context.json (metadata scope)', async () => {
+    // detectedAt set to >30 days ago triggers the staleness gate.
+    const stale = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
+    writeFileSync(
+      join(tempRoot, '.cleo', 'project-context.json'),
+      JSON.stringify({ detectedAt: stale }),
+      'utf8',
+    );
+
+    await expect(invoke(configDriftCheckCommand, { scope: 'metadata' })).rejects.toThrow(
+      /__EXIT__:6/,
+    );
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    expect(data).toMatchObject({
+      scope: 'metadata',
+      drift: true,
+    });
+    expect((data as { reason?: string }).reason).toMatch(/staleness-gate/);
+  });
+
+  it('returns drift=false when project config is well-formed', async () => {
+    writeFileSync(join(tempRoot, '.cleo', 'config.json'), JSON.stringify({}), 'utf8');
+
+    await invoke(configDriftCheckCommand, { scope: 'project' });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    expect(data).toMatchObject({ scope: 'project', drift: false });
+  });
+});

--- a/packages/cleo/src/cli/commands/config/drift-check.ts
+++ b/packages/cleo/src/cli/commands/config/drift-check.ts
@@ -1,0 +1,112 @@
+/**
+ * `cleo config drift-check` — apply the manifest entry's drift-detection
+ * strategy to a scoped file and emit a typed drift verdict.
+ *
+ * Thin wrapper over `checkDrift` from the CORE registry
+ * (`@cleocode/core/config/registry`, T9878). Exits non-zero when drift is
+ * detected so it composes with CI gates.
+ *
+ * The `'metadata'` scope walks both `project-info.json` and
+ * `project-context.json` and returns the first drift hit (worst-case
+ * semantics — matches the underlying registry behaviour).
+ *
+ * @task T9887
+ * @saga T9855
+ * @epic E4-DOCS-SDK-BOUNDARY
+ * @adr 076
+ */
+
+import { ExitCode } from '@cleocode/contracts';
+import { getProjectRoot } from '@cleocode/core';
+import { checkDrift, type DriftScope } from '@cleocode/core/config/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+/**
+ * Result shape returned by `cleo config drift-check`.
+ *
+ * @public
+ */
+export interface ConfigDriftCheckResult {
+  /** Scope that was checked. */
+  scope: DriftScope;
+  /** `true` IFF drift was detected. */
+  drift: boolean;
+  /** Optional human-readable reason for the verdict (only meaningful when `drift === true`). */
+  reason?: string;
+}
+
+/**
+ * citty command — `cleo config drift-check [--scope ...]`.
+ *
+ * @public
+ */
+export const configDriftCheckCommand = defineCommand({
+  meta: {
+    name: 'drift-check',
+    description:
+      'Check a scoped config file for drift (default scope: project; metadata covers project-info/project-context)',
+  },
+  args: {
+    scope: {
+      type: 'string',
+      description: 'Scope to check: global | project | metadata (default project)',
+      default: 'project',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    const scope = parseDriftScope(args['scope'] as string | undefined);
+    if (scope === null) {
+      cliError(
+        `config drift-check failed: invalid --scope (must be global|project|metadata)`,
+        ExitCode.GENERAL_ERROR,
+        { name: 'E_CONFIG_DRIFT_CHECK_FAILED' },
+      );
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    let driftResult: Awaited<ReturnType<typeof checkDrift>>;
+    try {
+      const projectRoot = getProjectRoot();
+      driftResult = await checkDrift(scope, projectRoot);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`config drift-check failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_CONFIG_DRIFT_CHECK_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    const result: ConfigDriftCheckResult = {
+      scope,
+      drift: driftResult.drift,
+      ...(driftResult.reason !== undefined ? { reason: driftResult.reason } : {}),
+    };
+    cliOutput(result, {
+      command: 'config-drift-check',
+      operation: 'config.drift-check',
+    });
+    if (driftResult.drift) {
+      process.exit(ExitCode.VALIDATION_ERROR);
+    }
+  },
+});
+
+/**
+ * Validate a string against the `DriftScope` union.
+ *
+ * @internal
+ */
+function parseDriftScope(raw: string | undefined): DriftScope | null {
+  const value = raw ?? 'project';
+  if (value === 'global' || value === 'project' || value === 'metadata') {
+    return value;
+  }
+  return null;
+}

--- a/packages/cleo/src/cli/commands/config/get.ts
+++ b/packages/cleo/src/cli/commands/config/get.ts
@@ -1,0 +1,126 @@
+/**
+ * `cleo config get <key>` — read a single value from the resolved cascade.
+ *
+ * Thin wrapper over `getConfigValue` from the CORE registry
+ * (`@cleocode/core/config/registry`, T9878). Returns `E_NOT_FOUND` when the
+ * key is absent — distinguishing missing keys from `null`/`false`/`0` values.
+ *
+ * @task T9887
+ * @saga T9855
+ * @epic E4-DOCS-SDK-BOUNDARY
+ * @adr 076
+ */
+
+import { ExitCode } from '@cleocode/contracts';
+import { getProjectRoot } from '@cleocode/core';
+import { getConfigValue, type ResolveScope } from '@cleocode/core/config/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+/**
+ * Result shape returned by `cleo config get`.
+ *
+ * Carries the resolved scope, the requested key, and the value so JSON
+ * consumers can compose the response without re-parsing.
+ *
+ * @public
+ */
+export interface ConfigGetResult {
+  /** The scope that produced the value. */
+  scope: ResolveScope;
+  /** The key (dot-separated path) that was requested. */
+  key: string;
+  /** The resolved value (any JSON-serialisable shape). */
+  value: unknown;
+}
+
+/**
+ * citty command — `cleo config get <key> [--scope ...]`.
+ *
+ * @public
+ */
+export const configGetCommand = defineCommand({
+  meta: {
+    name: 'get',
+    description: 'Read a single config value by dot-separated key (default scope: merged)',
+  },
+  args: {
+    key: {
+      type: 'positional',
+      required: true,
+      description: 'Dot-separated key path (e.g. release.branchModel)',
+    },
+    scope: {
+      type: 'string',
+      description: 'Cascade scope to read: global | project | merged (default merged)',
+      default: 'merged',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    const key = String(args['key'] ?? '').trim();
+    if (key.length === 0) {
+      cliError(`config get failed: <key> is required`, ExitCode.INVALID_INPUT, {
+        name: 'E_CONFIG_GET_FAILED',
+      });
+      process.exit(ExitCode.INVALID_INPUT);
+      return;
+    }
+
+    const scope = parseResolveScope(args['scope'] as string | undefined);
+    if (scope === null) {
+      cliError(
+        `config get failed: invalid --scope (must be global|project|merged)`,
+        ExitCode.GENERAL_ERROR,
+        { name: 'E_CONFIG_GET_FAILED' },
+      );
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    let value: unknown;
+    try {
+      const projectRoot = getProjectRoot();
+      value = await getConfigValue<unknown>(key, { scope, projectRoot });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`config get failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_CONFIG_GET_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    if (value === undefined) {
+      cliError(`config get failed: key "${key}" not found`, ExitCode.NOT_FOUND, {
+        name: 'E_NOT_FOUND',
+        details: { key, scope },
+      });
+      process.exit(ExitCode.NOT_FOUND);
+      return;
+    }
+
+    const result: ConfigGetResult = { scope, key, value };
+    cliOutput(result, {
+      command: 'config-get',
+      operation: 'config.get',
+    });
+  },
+});
+
+/**
+ * Validate a string against the `ResolveScope` union. Returns `null` for
+ * unknown inputs.
+ *
+ * @internal
+ */
+function parseResolveScope(raw: string | undefined): ResolveScope | null {
+  const value = raw ?? 'merged';
+  if (value === 'global' || value === 'project' || value === 'merged') {
+    return value;
+  }
+  return null;
+}

--- a/packages/cleo/src/cli/commands/config/index.ts
+++ b/packages/cleo/src/cli/commands/config/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Barrel for the `cleo config` command group.
+ *
+ * The dispatch wrapper lives at `packages/cleo/src/cli/commands/config.ts`
+ * (so the command-manifest generator — which only scans top-level
+ * `commands/*.ts` files — picks it up). The wrapper imports the individual
+ * subcommands from this barrel.
+ *
+ * @task T9887
+ * @saga T9855
+ * @epic E4-DOCS-SDK-BOUNDARY
+ * @adr 076
+ */
+
+export type { ConfigDriftCheckResult } from './drift-check.js';
+export { configDriftCheckCommand } from './drift-check.js';
+export type { ConfigGetResult } from './get.js';
+export { configGetCommand } from './get.js';
+export type { ConfigSetResult, ConfigSetValueType } from './set.js';
+export { configSetCommand } from './set.js';
+export type { ConfigShowResult } from './show.js';
+export { configShowCommand } from './show.js';
+export type { ConfigValidateResult } from './validate.js';
+export { configValidateCommand } from './validate.js';

--- a/packages/cleo/src/cli/commands/config/set.ts
+++ b/packages/cleo/src/cli/commands/config/set.ts
@@ -1,0 +1,216 @@
+/**
+ * `cleo config set <key> <value>` — write a value into project or global
+ * `.cleo/config.json` via the CORE writer.
+ *
+ * The writer side of the SSoT config registry. Uses CORE's `setConfigValue`
+ * (which already handles dot-notation, intermediate-object creation, and
+ * atomic JSON write) and post-validates the file via `validateConfig` from
+ * the T9878 registry — schema failures surface as a non-zero exit.
+ *
+ * Type coercion: by default values pass through `parseConfigValue` which
+ * auto-detects `true|false|null|<number>|<json>`. Pass `--type` to force a
+ * specific coercion.
+ *
+ * @task T9887
+ * @saga T9855
+ * @epic E4-DOCS-SDK-BOUNDARY
+ * @adr 076
+ */
+
+import { ExitCode } from '@cleocode/contracts';
+import { getProjectRoot, parseConfigValue, setConfigValue } from '@cleocode/core';
+import { type ValidateScope, validateConfig } from '@cleocode/core/config/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+/**
+ * Explicit `--type` flag values supported by `cleo config set`.
+ *
+ * `string`  — write raw string (no parsing).
+ * `number`  — parse as `Number(value)`; rejects `NaN`.
+ * `boolean` — accepts `true`/`false` only (case-insensitive).
+ * `json`    — parse as `JSON.parse(value)`.
+ *
+ * Omitting `--type` falls back to CORE's auto-detection via
+ * `parseConfigValue` (matches the historical legacy behaviour).
+ *
+ * @public
+ */
+export type ConfigSetValueType = 'string' | 'number' | 'boolean' | 'json';
+
+/**
+ * Result shape returned by `cleo config set`.
+ *
+ * @public
+ */
+export interface ConfigSetResult {
+  /** The scope written to (`project` or `global`). */
+  scope: 'project' | 'global';
+  /** The key path that was written. */
+  key: string;
+  /** The post-coercion value persisted to disk. */
+  value: unknown;
+  /** Schema validation result for the resulting file (always re-validated). */
+  validate: { ok: boolean; issues: string[] };
+}
+
+/**
+ * citty command — `cleo config set <key> <value> [--scope ...] [--type ...]`.
+ *
+ * @public
+ */
+export const configSetCommand = defineCommand({
+  meta: {
+    name: 'set',
+    description: 'Write a value into project or global .cleo/config.json',
+  },
+  args: {
+    key: {
+      type: 'positional',
+      required: true,
+      description: 'Dot-separated key path',
+    },
+    value: {
+      type: 'positional',
+      required: true,
+      description: 'Raw value (string). Use --type to coerce explicitly.',
+    },
+    scope: {
+      type: 'string',
+      description: 'Where to write: project | global (default project)',
+      default: 'project',
+    },
+    type: {
+      type: 'string',
+      description: 'Explicit value type: string | number | boolean | json',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    const key = String(args['key'] ?? '').trim();
+    if (key.length === 0) {
+      cliError(`config set failed: <key> is required`, ExitCode.INVALID_INPUT, {
+        name: 'E_CONFIG_SET_FAILED',
+      });
+      process.exit(ExitCode.INVALID_INPUT);
+      return;
+    }
+
+    const rawValue = String(args['value'] ?? '');
+    const scope = parseWriteScope(args['scope'] as string | undefined);
+    if (scope === null) {
+      cliError(
+        `config set failed: invalid --scope (must be global|project)`,
+        ExitCode.GENERAL_ERROR,
+        { name: 'E_CONFIG_SET_FAILED' },
+      );
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    const typeFlag = args['type'] as string | undefined;
+    let coerced: unknown;
+    try {
+      coerced = coerceValue(rawValue, typeFlag);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`config set failed: ${message}`, ExitCode.INVALID_INPUT, {
+        name: 'E_CONFIG_SET_FAILED',
+      });
+      process.exit(ExitCode.INVALID_INPUT);
+      return;
+    }
+
+    let written: Awaited<ReturnType<typeof setConfigValue>>;
+    let validate: Awaited<ReturnType<typeof validateConfig>>;
+    try {
+      const projectRoot = getProjectRoot();
+      written = await setConfigValue(key, coerced, projectRoot, {
+        global: scope === 'global',
+      });
+      validate = await validateConfig(scope as ValidateScope, projectRoot);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`config set failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_CONFIG_SET_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    const result: ConfigSetResult = {
+      scope: written.scope,
+      key: written.key,
+      value: written.value,
+      validate,
+    };
+    cliOutput(result, {
+      command: 'config-set',
+      operation: 'config.set',
+    });
+    if (!validate.ok) {
+      // Schema failed — emit non-zero exit but the user still has visibility
+      // into the value that was written. Mirrors `cleo config validate`.
+      process.exit(ExitCode.VALIDATION_ERROR);
+    }
+  },
+});
+
+/**
+ * Parse the `--scope` flag for write operations. Only `global` and `project`
+ * are valid sinks (`merged` is read-only and would be ambiguous to write).
+ *
+ * @internal
+ */
+function parseWriteScope(raw: string | undefined): 'global' | 'project' | null {
+  const value = raw ?? 'project';
+  if (value === 'global' || value === 'project') {
+    return value;
+  }
+  return null;
+}
+
+/**
+ * Coerce a raw CLI string value into the requested JS type.
+ *
+ * When `typeFlag` is absent, defers to CORE's auto-detector via
+ * `parseConfigValue`.
+ *
+ * @internal
+ */
+function coerceValue(raw: string, typeFlag: string | undefined): unknown {
+  if (typeFlag === undefined) {
+    return parseConfigValue(raw);
+  }
+  switch (typeFlag) {
+    case 'string':
+      return raw;
+    case 'number': {
+      const n = Number(raw);
+      if (Number.isNaN(n)) {
+        throw new Error(`--type number cannot coerce "${raw}"`);
+      }
+      return n;
+    }
+    case 'boolean': {
+      const lower = raw.toLowerCase();
+      if (lower === 'true') return true;
+      if (lower === 'false') return false;
+      throw new Error(`--type boolean accepts only "true"/"false" (got "${raw}")`);
+    }
+    case 'json':
+      try {
+        return JSON.parse(raw) as unknown;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`--type json failed to parse: ${msg}`);
+      }
+    default:
+      throw new Error(
+        `--type must be one of: string | number | boolean | json (got "${typeFlag}")`,
+      );
+  }
+}

--- a/packages/cleo/src/cli/commands/config/show.ts
+++ b/packages/cleo/src/cli/commands/config/show.ts
@@ -1,0 +1,104 @@
+/**
+ * `cleo config show` — print the resolved CleoConfig envelope.
+ *
+ * Thin CLI wrapper over `resolveCleoConfig` from the CORE registry
+ * (`@cleocode/core/config/registry`, T9878). Supports the cascade scope
+ * selector documented by the registry: `'global'`, `'project'`, or
+ * `'merged'` (default).
+ *
+ * @task T9887
+ * @saga T9855
+ * @epic E4-DOCS-SDK-BOUNDARY
+ * @adr 076
+ */
+
+import { ExitCode } from '@cleocode/contracts';
+import { getProjectRoot } from '@cleocode/core';
+import {
+  type MergedConfig,
+  type ResolveScope,
+  resolveCleoConfig,
+} from '@cleocode/core/config/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+/**
+ * Result shape returned by `cleo config show`.
+ *
+ * Carries the resolved (or scoped) config plus the requested scope so the
+ * envelope is self-describing — useful for JSON consumers chaining
+ * subsequent calls.
+ *
+ * @public
+ */
+export interface ConfigShowResult {
+  /** The scope that produced the contents. */
+  scope: ResolveScope;
+  /** The resolved config object (raw file for global/project, merged otherwise). */
+  config: MergedConfig;
+}
+
+/**
+ * citty command — `cleo config show [--scope ...]`.
+ *
+ * @public
+ */
+export const configShowCommand = defineCommand({
+  meta: {
+    name: 'show',
+    description: 'Print the resolved CleoConfig envelope (default scope: merged)',
+  },
+  args: {
+    scope: {
+      type: 'string',
+      description: 'Cascade scope to read: global | project | merged (default merged)',
+      default: 'merged',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    const scope = parseResolveScope(args['scope'] as string | undefined);
+    if (scope === null) {
+      cliError(
+        `config show failed: invalid --scope (must be global|project|merged)`,
+        ExitCode.GENERAL_ERROR,
+        { name: 'E_CONFIG_SHOW_FAILED' },
+      );
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    try {
+      const projectRoot = getProjectRoot();
+      const config = await resolveCleoConfig({ scope, projectRoot });
+      const result: ConfigShowResult = { scope, config };
+      cliOutput(result, {
+        command: 'config-show',
+        operation: 'config.show',
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`config show failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_CONFIG_SHOW_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+    }
+  },
+});
+
+/**
+ * Validate a string against the `ResolveScope` union. Returns `null` for
+ * unknown inputs so the caller can emit a typed envelope error.
+ *
+ * @internal
+ */
+function parseResolveScope(raw: string | undefined): ResolveScope | null {
+  const value = raw ?? 'merged';
+  if (value === 'global' || value === 'project' || value === 'merged') {
+    return value;
+  }
+  return null;
+}

--- a/packages/cleo/src/cli/commands/config/validate.ts
+++ b/packages/cleo/src/cli/commands/config/validate.ts
@@ -1,0 +1,107 @@
+/**
+ * `cleo config validate` — re-parse a scoped config file against its
+ * manifest's schema and emit pass/fail with detailed issues.
+ *
+ * Thin wrapper over `validateConfig` from the CORE registry
+ * (`@cleocode/core/config/registry`, T9878). Exits non-zero when the schema
+ * rejects the file so consumers can chain `&&`-style checks.
+ *
+ * @task T9887
+ * @saga T9855
+ * @epic E4-DOCS-SDK-BOUNDARY
+ * @adr 076
+ */
+
+import { ExitCode } from '@cleocode/contracts';
+import { getProjectRoot } from '@cleocode/core';
+import { type ValidateScope, validateConfig } from '@cleocode/core/config/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+/**
+ * Result shape returned by `cleo config validate`.
+ *
+ * @public
+ */
+export interface ConfigValidateResult {
+  /** Scope that was validated. */
+  scope: ValidateScope;
+  /** `true` IFF the file passed every schema gate (or no schema was bound). */
+  ok: boolean;
+  /** Human-readable issues. Empty when `ok === true`. */
+  issues: string[];
+}
+
+/**
+ * citty command — `cleo config validate [--scope ...]`.
+ *
+ * @public
+ */
+export const configValidateCommand = defineCommand({
+  meta: {
+    name: 'validate',
+    description: 'Validate a scoped config file against its schema (default scope: project)',
+  },
+  args: {
+    scope: {
+      type: 'string',
+      description: 'Scope to validate: global | project (default project)',
+      default: 'project',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    const scope = parseValidateScope(args['scope'] as string | undefined);
+    if (scope === null) {
+      cliError(
+        `config validate failed: invalid --scope (must be global|project)`,
+        ExitCode.GENERAL_ERROR,
+        { name: 'E_CONFIG_VALIDATE_FAILED' },
+      );
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    let validate: Awaited<ReturnType<typeof validateConfig>>;
+    try {
+      const projectRoot = getProjectRoot();
+      validate = await validateConfig(scope, projectRoot);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`config validate failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_CONFIG_VALIDATE_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    const result: ConfigValidateResult = {
+      scope,
+      ok: validate.ok,
+      issues: validate.issues,
+    };
+    cliOutput(result, {
+      command: 'config-validate',
+      operation: 'config.validate',
+    });
+    if (!validate.ok) {
+      process.exit(ExitCode.VALIDATION_ERROR);
+    }
+  },
+});
+
+/**
+ * Validate a string against the `ValidateScope` union.
+ *
+ * @internal
+ */
+function parseValidateScope(raw: string | undefined): ValidateScope | null {
+  const value = raw ?? 'project';
+  if (value === 'global' || value === 'project') {
+    return value;
+  }
+  return null;
+}

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -240,7 +240,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description: 'Configuration management',
+    description:
+      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -255,6 +255,12 @@ export default defineConfig({
         '../../packages/core/src/config.ts',
         import.meta.url,
       ).pathname,
+      // T9887: config/registry subpath — the SSoT `resolveCleoConfig` cascade
+      // resolver (Saga T9855 / E4) consumed by the `cleo config` CLI surface.
+      '@cleocode/core/config/registry': new URL(
+        '../../packages/core/src/config/registry.ts',
+        import.meta.url,
+      ).pathname,
       // T9416: llm subpath imports used by `cleo auth list` / `cleo auth remove`
       '@cleocode/core/llm/credential-pool.js': new URL(
         '../../packages/core/src/llm/credential-pool.ts',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -96,6 +96,11 @@
       "import": "./dist/setup/*.js",
       "require": "./dist/setup/*.js"
     },
+    "./config/registry": {
+      "types": "./dist/config/registry.d.ts",
+      "import": "./dist/config/registry.js",
+      "require": "./dist/config/registry.js"
+    },
     "./gc": {
       "types": "./dist/gc/index.d.ts",
       "import": "./dist/gc/index.js",


### PR DESCRIPTION
## Summary
- New `cleo config` namespace with 5 sub-verbs: `show` / `get` / `set` / `validate` / `drift-check`.
- Thin wrapper over the CORE SSoT `resolveCleoConfig` registry (T9878).
- Envelope-shaped output; `defineCommand` imported via the SSoT lib (T10072).
- Legacy `set-preset` / `presets` / `list` verbs preserved.

## Implementation notes
- `packages/cleo/src/cli/commands/config/` — one file per verb + `index.ts` barrel.
- `packages/cleo/src/cli/commands/config.ts` — dispatcher (mounts SSoT verbs + legacy).
- `packages/core/package.json` — adds `./config/registry` subpath export.
- `build.mjs` — adds `'config'` to `SUBPATH_DIRS` so the auto-scanner emits the entry point.
- `packages/cleo/vitest.config.ts` — adds `@cleocode/core/config/registry` alias.
- Bonus: converts existing `config.ts` to the `defineCommand` SSoT (lib factory), shrinking the SSoT-baseline counter by 2.

## Test plan
- [x] biome (8 files, no fixes needed after format pass)
- [x] build (full monorepo, 138s, success)
- [x] vitest — 9/9 tests in `packages/cleo/src/cli/commands/config/__tests__/config.test.ts` pass
- [x] `lint-no-raw-define-command --check` — PASS (137 vs baseline 139)
- [x] `lint-no-ssot-exempt --strict` — PASS (no new exemptions)

Closes T9887
Saga: T9855
ADR: 076