### PR TITLE
feat(cleo): schema --input + --examples (T9918 / Saga T9855)

### DIFF
--- a/.changeset/t9918-schema-input-examples.md
+++ b/.changeset/t9918-schema-input-examples.md
@@ -1,0 +1,6 @@
+---
+id: t9918-schema-input-examples
+tasks: [T9918]
+kind: feat
+summary: cleo schema --input + --examples for agent introspection (T9918 / Saga T9855)
+---

--- a/packages/cleo/src/cli/commands/__tests__/schema-flags.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/schema-flags.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for `cleo schema <op> --input` and `--examples` flags.
+ *
+ * Coverage:
+ *  1. `--input` returns `{ data.schema }` non-null for an op with a contract
+ *  2. `--examples` returns `{ data.examples }` array for an op with a contract
+ *  3. Bare `cleo schema <op>` (no flag) still returns the flat param list
+ *     (backwards-compat with the pre-T9918 surface).
+ *  4. Unknown op returns exit 4 / E_NOT_FOUND.
+ *  5. Known op with no registered contract returns the structured
+ *     "no contract" payload with a `meta.hint`.
+ *
+ * @task T9918
+ * @epic T9855
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { schemaCommand } from '../schema.js';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockCliOutput = vi.fn();
+const mockCliError = vi.fn();
+
+vi.mock('../../renderers/index.js', () => ({
+  cliOutput: (...args: unknown[]) => mockCliOutput(...args),
+  cliError: (...args: unknown[]) => mockCliError(...args),
+}));
+
+const mockSetFormatContext = vi.fn();
+vi.mock('../../format-context.js', () => ({
+  setFormatContext: (...args: unknown[]) => mockSetFormatContext(...args),
+  getFormatContext: () => ({ format: 'json', source: 'default', quiet: false }),
+}));
+
+const mockProcessExit = vi.spyOn(process, 'exit').mockImplementation((() => {
+  // noop — let tests assert on the error call then continue
+}) as (code?: number | string | null) => never);
+
+vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+// ---------------------------------------------------------------------------
+// Helper — invoke schemaCommand with explicit flags
+// ---------------------------------------------------------------------------
+
+interface InvokeOpts {
+  format?: string;
+  includeGates?: boolean;
+  includeExamples?: boolean;
+  input?: boolean;
+  examples?: boolean;
+}
+
+async function invokeSchema(operationArg: string, opts: InvokeOpts = {}): Promise<void> {
+  await schemaCommand.run?.({
+    args: {
+      operation: operationArg,
+      format: opts.format ?? 'json',
+      'include-gates': opts.includeGates !== false,
+      'include-examples': opts.includeExamples ?? false,
+      input: opts.input ?? false,
+      examples: opts.examples ?? false,
+    },
+    rawArgs: [],
+    cmd: schemaCommand,
+  } as Parameters<NonNullable<typeof schemaCommand.run>>[0]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('cleo schema <op> --input / --examples (T9918)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. --input
+  // -------------------------------------------------------------------------
+
+  describe('--input', () => {
+    it('returns an object with a non-null `schema` for tasks.add-batch', async () => {
+      await invokeSchema('tasks.add-batch', { input: true });
+
+      expect(mockCliOutput).toHaveBeenCalledOnce();
+      const [data] = mockCliOutput.mock.calls[0] as [
+        { operation: string; schema: unknown },
+        unknown,
+      ];
+
+      expect(data.operation).toBe('tasks.add-batch');
+      expect(data.schema).not.toBeNull();
+      expect(typeof data.schema).toBe('object');
+    });
+
+    it('returned schema has draft-07 $schema marker and object root', async () => {
+      await invokeSchema('tasks.add-batch', { input: true });
+
+      const [data] = mockCliOutput.mock.calls[0] as [{ schema: Record<string, unknown> }, unknown];
+
+      expect(data.schema).toHaveProperty('$schema');
+      expect(data.schema['type']).toBe('object');
+      expect(data.schema['required']).toEqual(['tasks']);
+    });
+
+    it('omits the `examples` key on --input', async () => {
+      await invokeSchema('tasks.add-batch', { input: true });
+
+      const [data] = mockCliOutput.mock.calls[0] as [Record<string, unknown>, unknown];
+
+      expect(data).not.toHaveProperty('examples');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. --examples
+  // -------------------------------------------------------------------------
+
+  describe('--examples', () => {
+    it('returns an `examples` array of example payloads', async () => {
+      await invokeSchema('tasks.add-batch', { examples: true });
+
+      expect(mockCliOutput).toHaveBeenCalledOnce();
+      const [data] = mockCliOutput.mock.calls[0] as [
+        { operation: string; examples: Array<{ name: string; value: unknown }> },
+        unknown,
+      ];
+
+      expect(data.operation).toBe('tasks.add-batch');
+      expect(Array.isArray(data.examples)).toBe(true);
+      expect(data.examples.length).toBeGreaterThan(0);
+    });
+
+    it('every example has `name` and `value`', async () => {
+      await invokeSchema('tasks.add-batch', { examples: true });
+
+      const [data] = mockCliOutput.mock.calls[0] as [
+        { examples: Array<{ name: string; value: unknown }> },
+        unknown,
+      ];
+
+      for (const ex of data.examples) {
+        expect(typeof ex.name).toBe('string');
+        expect(ex.name.length).toBeGreaterThan(0);
+        expect(ex.value).toBeDefined();
+      }
+    });
+
+    it('omits the `schema` key on --examples', async () => {
+      await invokeSchema('tasks.add-batch', { examples: true });
+
+      const [data] = mockCliOutput.mock.calls[0] as [Record<string, unknown>, unknown];
+
+      expect(data).not.toHaveProperty('schema');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Backwards-compat — bare invocation still returns the flat param list
+  // -------------------------------------------------------------------------
+
+  describe('backwards-compat (no flag)', () => {
+    it('cleo schema tasks.add-batch returns a flat params list with `tasks`', async () => {
+      await invokeSchema('tasks.add-batch');
+
+      expect(mockCliOutput).toHaveBeenCalledOnce();
+      const [data] = mockCliOutput.mock.calls[0] as [
+        { params: Array<{ name: string; required: boolean }> },
+        unknown,
+      ];
+
+      expect(Array.isArray(data.params)).toBe(true);
+      const paramNames = data.params.map((p) => p.name);
+      expect(paramNames).toContain('tasks');
+    });
+
+    it('bare invocation surface has `gateway` and `operation` keys (LAFS shape)', async () => {
+      await invokeSchema('tasks.add-batch');
+
+      const [data] = mockCliOutput.mock.calls[0] as [
+        { gateway: string; operation: string },
+        unknown,
+      ];
+
+      expect(data.gateway).toBe('mutate');
+      expect(data.operation).toBe('tasks.add-batch');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Unknown operation — E_NOT_FOUND (same path as bare invocation)
+  // -------------------------------------------------------------------------
+
+  describe('unknown op with --input', () => {
+    it('returns exit code 4 / E_NOT_FOUND', async () => {
+      await invokeSchema('tasks.totally-not-real', { input: true });
+
+      expect(mockCliError).toHaveBeenCalledOnce();
+      const [, code, details] = mockCliError.mock.calls[0] as [string, number, { name: string }];
+
+      expect(code).toBe(4);
+      expect(details.name).toBe('E_NOT_FOUND');
+      expect(mockProcessExit).toHaveBeenCalledWith(4);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Known op without a registered contract — graceful empty + hint
+  // -------------------------------------------------------------------------
+
+  describe('known op without registered contract', () => {
+    it('--input returns schema: null with a meta.hint', async () => {
+      // `tasks.add` exists in OPERATIONS but is not yet seeded into INPUT_CONTRACTS.
+      await invokeSchema('tasks.add', { input: true });
+
+      expect(mockCliError).not.toHaveBeenCalled();
+      expect(mockCliOutput).toHaveBeenCalledOnce();
+      const [data, opts] = mockCliOutput.mock.calls[0] as [
+        { schema: unknown; examples: unknown[] },
+        { extensions?: { hint?: string } },
+      ];
+
+      expect(data.schema).toBeNull();
+      expect(data.examples).toEqual([]);
+      expect(opts.extensions?.hint).toContain('No OperationInputContract registered');
+    });
+
+    it('--examples returns the same empty + hint payload', async () => {
+      await invokeSchema('tasks.add', { examples: true });
+
+      expect(mockCliError).not.toHaveBeenCalled();
+      const [data, opts] = mockCliOutput.mock.calls[0] as [
+        { schema: unknown; examples: unknown[] },
+        { extensions?: { hint?: string } },
+      ];
+
+      expect(data.examples).toEqual([]);
+      expect(data.schema).toBeNull();
+      expect(opts.extensions?.hint).toContain('No OperationInputContract registered');
+    });
+  });
+});

--- a/packages/cleo/src/cli/commands/schema.ts
+++ b/packages/cleo/src/cli/commands/schema.ts
@@ -9,13 +9,16 @@
  *   cleo schema tasks.add
  *   cleo schema tasks.add --format human
  *   cleo schema tasks.add --include-examples
+ *   cleo schema tasks.add-batch --input
+ *   cleo schema tasks.add-batch --examples
  *
  * All output routes through cliOutput() — no raw console.log / stdout writes.
  *
- * @task T340, T1729
- * @epic T335, T1691
+ * @task T340, T1729, T9918
+ * @epic T335, T1691, T9855
  */
 
+import { getInputContract } from '@cleocode/core';
 import { describeOperation, type OperationSchema } from '@cleocode/lafs';
 import { defineCommand, showUsage } from 'citty';
 import type { OperationDef } from '../../dispatch/registry.js';
@@ -95,6 +98,18 @@ export const schemaCommand = defineCommand({
       description: 'Include usage examples in output (default: false)',
       default: false,
     },
+    input: {
+      type: 'boolean',
+      description:
+        'Return the JSON Schema (draft-07) for the operation input payload, from OperationInputContract.schema (T9918)',
+      default: false,
+    },
+    examples: {
+      type: 'boolean',
+      description:
+        "Return canned example payloads from OperationInputContract.examples — pipeline: `cleo schema <op> --examples | jq '.examples[0].value' | cleo <verb> --params -` (T9918)",
+      default: false,
+    },
   },
   async run({ args, cmd }) {
     if (!args.operation) {
@@ -104,6 +119,8 @@ export const schemaCommand = defineCommand({
     const format = args.format ?? 'json';
     const includeGates = args['include-gates'] !== false;
     const includeExamples = args['include-examples'] === true;
+    const wantInput = args.input === true;
+    const wantExamples = args.examples === true;
 
     // Apply --format flag to the global format context so cliOutput routes correctly.
     if (format === 'human') {
@@ -122,6 +139,66 @@ export const schemaCommand = defineCommand({
         },
       );
       process.exit(4);
+      return;
+    }
+
+    // --input / --examples — schema-first surface (T9918 / E7.5 / Saga T9855).
+    // Routes to the OperationInputContract registry seeded in
+    // packages/core/src/dispatch/contracts/input-contracts.ts. When no
+    // contract is registered for the op, return a structured "no contract"
+    // payload with a hint pointing at the flag-based fallback — never error.
+    if (wantInput || wantExamples) {
+      const contract = getInputContract(args.operation);
+      if (contract === null) {
+        cliOutput(
+          {
+            operation: args.operation,
+            schema: null,
+            examples: [],
+          },
+          {
+            command: 'schema',
+            operation: `schema.${args.operation}`,
+            message: `No OperationInputContract registered for ${args.operation}`,
+            extensions: {
+              hint: `No OperationInputContract registered for ${args.operation}. Use plain flag-based invocation.`,
+            },
+          },
+        );
+        return;
+      }
+
+      if (wantInput) {
+        cliOutput(
+          {
+            operation: contract.operation,
+            schema: contract.schema,
+          },
+          {
+            command: 'schema',
+            operation: `schema.${args.operation}`,
+            message: `Input schema for ${contract.operation}`,
+          },
+        );
+        return;
+      }
+
+      // wantExamples — return the canned examples list.
+      cliOutput(
+        {
+          operation: contract.operation,
+          examples: contract.examples.map((ex) => ({
+            name: ex.name,
+            value: ex.value,
+            ...(ex.description !== undefined ? { description: ex.description } : {}),
+          })),
+        },
+        {
+          command: 'schema',
+          operation: `schema.${args.operation}`,
+          message: `Examples for ${contract.operation}`,
+        },
+      );
       return;
     }
 

--- a/packages/core/src/dispatch/contracts/input-contracts.ts
+++ b/packages/core/src/dispatch/contracts/input-contracts.ts
@@ -1,0 +1,268 @@
+/**
+ * Starter registry of {@link OperationInputContract} entries.
+ *
+ * Seeds the `OperationInputContractRegistry` introduced by T9914 with a
+ * minimal real-world example so the agent-introspection surface
+ * (`cleo schema <op> --input` / `--examples`, T9918) has something to
+ * return today. Additional contracts are added incrementally per
+ * E7 retrofit task (T9917+).
+ *
+ * The single seed entry is `tasks.add-batch` — the canonical bulk-create
+ * operation that benefits most from agents discovering its shape before
+ * piping a payload via `cleo add-batch --params -`.
+ *
+ * @packageDocumentation
+ * @module @cleocode/core/dispatch/contracts/input-contracts
+ *
+ * @epic T9855
+ * @task T9918
+ */
+
+import type { OperationInputContract, OperationInputContractRegistry } from '@cleocode/contracts';
+
+// ---------------------------------------------------------------------------
+// Wire-format task spec (mirrors AddBatchTaskSpec — kept in sync manually
+// rather than imported so contracts stay decoupled from internal Core types).
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire-format task spec accepted by `tasks.add-batch`. Local mirror of
+ * `AddBatchTaskSpec` from `packages/core/src/tasks/add-batch.ts` so the
+ * contract describes the public wire shape without importing internal
+ * Core types into the schema-registry module.
+ */
+interface AddBatchTaskSpecWire {
+  title: string;
+  description?: string;
+  parent?: string;
+  depends?: string[];
+  priority?: string;
+  labels?: string[];
+  type?: string;
+  acceptance?: string[];
+  phase?: string;
+  size?: string;
+  notes?: string;
+  files?: string[];
+  kind?: string;
+  scope?: string;
+  severity?: string;
+  forceDuplicate?: boolean;
+}
+
+/**
+ * Input shape for the `tasks.add-batch` operation.
+ *
+ * Matches the runtime params accepted by `tasksAddBatchOp` — an array of
+ * wire-format task specs, an optional shared default parent, and an
+ * optional dry-run flag.
+ */
+interface TasksAddBatchInput {
+  tasks: AddBatchTaskSpecWire[];
+  defaultParent?: string;
+  dryRun?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// tasks.add-batch contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema-first contract for `tasks.add-batch`.
+ *
+ * Mirrors the operation registry entry in
+ * `packages/contracts/src/dispatch/operations-registry.ts` and the
+ * runtime shape in `packages/core/src/tasks/add-batch.ts`. Examples
+ * showcase the two most common patterns: a minimal 2-task batch under a
+ * shared epic and an epic-decomposition batch using per-task `parent`.
+ */
+const tasksAddBatchContract: OperationInputContract<TasksAddBatchInput> = {
+  operation: 'tasks.add-batch',
+  schema: {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    type: 'object',
+    required: ['tasks'],
+    additionalProperties: false,
+    properties: {
+      tasks: {
+        type: 'array',
+        minItems: 1,
+        description: 'Array of task specs to insert atomically. At least one task is required.',
+        items: {
+          type: 'object',
+          required: ['title'],
+          additionalProperties: false,
+          properties: {
+            title: {
+              type: 'string',
+              minLength: 1,
+              maxLength: 200,
+              description: 'Human-readable task title (required).',
+            },
+            description: {
+              type: 'string',
+              description: 'Optional long-form task description.',
+            },
+            parent: {
+              type: 'string',
+              description: 'Parent task ID (ADR-057 D2 wire field — maps to parentId internally).',
+            },
+            depends: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'List of task IDs this task depends on.',
+            },
+            priority: {
+              type: 'string',
+              enum: ['low', 'medium', 'high', 'critical'],
+              description: 'Task priority.',
+            },
+            labels: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Free-form classification labels.',
+            },
+            type: {
+              type: 'string',
+              enum: ['epic', 'task', 'subtask', 'saga'],
+              description: 'Task tier (ADR-073 — saga elevates Epic via label).',
+            },
+            acceptance: {
+              type: 'array',
+              items: { type: 'string', minLength: 1 },
+              description: 'Acceptance criteria. REQUIRED for all tasks per ADR-066.',
+            },
+            phase: {
+              type: 'string',
+              description: 'Free-form phase grouping.',
+            },
+            size: {
+              type: 'string',
+              enum: ['small', 'medium', 'large'],
+              description: 'Sizing bucket (no time estimates).',
+            },
+            notes: {
+              type: 'string',
+              description: 'Initial note entry for the task.',
+            },
+            files: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'List of files this task is scoped to.',
+            },
+            kind: {
+              type: 'string',
+              enum: ['work', 'research', 'experiment', 'bug', 'spike', 'release'],
+              description: 'Task kind (orthogonal to type).',
+            },
+            scope: {
+              type: 'string',
+              description: 'Scope-of-change descriptor.',
+            },
+            severity: {
+              type: 'string',
+              enum: ['P0', 'P1', 'P2', 'P3'],
+              description: 'Severity (orthogonal to priority; triggers Ed25519 attestation).',
+            },
+            forceDuplicate: {
+              type: 'boolean',
+              description: 'Bypass duplicate-detection guards.',
+            },
+          },
+        },
+      },
+      defaultParent: {
+        type: 'string',
+        description: 'Optional default parent task ID applied when a task spec omits parent.',
+      },
+      dryRun: {
+        type: 'boolean',
+        description: 'Validate and predict IDs without writing to the database.',
+      },
+    },
+  },
+  examples: [
+    {
+      name: 'minimal-two-task-batch',
+      description:
+        'Smallest realistic batch — two tasks sharing a default parent epic, each with required acceptance.',
+      value: {
+        tasks: [
+          {
+            title: 'Spec the new dispatcher contract',
+            acceptance: ['Contract spec landed', 'Reviewed by team-lead'],
+          },
+          {
+            title: 'Implement the dispatcher contract',
+            acceptance: ['All tests pass', 'Wired to existing callers'],
+          },
+        ],
+        defaultParent: 'T1234',
+      },
+    },
+    {
+      name: 'epic-decomposition-with-explicit-parents',
+      description:
+        'Per-task parent assignment — useful when decomposing one epic into children of different sibling epics.',
+      value: {
+        tasks: [
+          {
+            title: 'Add --input flag to cleo schema',
+            parent: 'T9918',
+            acceptance: ['Flag accepted', 'JSON schema returned'],
+            priority: 'medium',
+            size: 'small',
+          },
+          {
+            title: 'Add --examples flag to cleo schema',
+            parent: 'T9918',
+            acceptance: ['Flag accepted', 'Examples array returned'],
+            priority: 'medium',
+            size: 'small',
+          },
+        ],
+      },
+    },
+    {
+      name: 'dry-run-preview',
+      description: 'Validate-only run — predicts IDs without writing to the database.',
+      value: {
+        tasks: [
+          {
+            title: 'Preview-only task',
+            acceptance: ['Dry run succeeds'],
+          },
+        ],
+        dryRun: true,
+      },
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical registry of every {@link OperationInputContract} known to the
+ * CLEO runtime. Consumers MUST treat this map as the SSoT for
+ * agent-introspection surfaces (`cleo schema <op> --input` /
+ * `--examples`) and for the schema-first `mutate(operation, input)` DX.
+ *
+ * Currently seeded with a single contract (`tasks.add-batch`) so
+ * T9918 has something concrete to return. Additional operations land
+ * incrementally via T9917+ retrofit tasks.
+ */
+export const INPUT_CONTRACTS: OperationInputContractRegistry = {
+  'tasks.add-batch': tasksAddBatchContract as OperationInputContract<unknown>,
+};
+
+/**
+ * Look up the {@link OperationInputContract} for a given operation key.
+ *
+ * @param operation - Fully-qualified operation key (e.g. `'tasks.add-batch'`).
+ * @returns The matching contract, or `null` when no contract is registered.
+ */
+export function getInputContract(operation: string): OperationInputContract<unknown> | null {
+  return INPUT_CONTRACTS[operation] ?? null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -644,6 +644,8 @@ export { updateTask } from './tasks/update.js';
 // can import them without violating lint-core-first RULE-3 (which bans
 // `@cleocode/core/internal` from CLI command files).
 
+// T9918 (Saga T9855 / E7.5) — OperationInputContract registry seed
+export { getInputContract, INPUT_CONTRACTS } from './dispatch/contracts/input-contracts.js';
 // T9915 (Saga T9855 / E7.2) — SSoT input validator over OperationInputContract
 export { validateOperationInput } from './dispatch/validation.js';
 // Setup wizard `--config-json` merger


### PR DESCRIPTION
## Summary
- Adds `--input` and `--examples` flags to `cleo schema <op>`.
- Seeds `INPUT_CONTRACTS` registry (`packages/core/src/dispatch/contracts/input-contracts.ts`) with a starter `tasks.add-batch` contract.
- Backwards-compat preserved for flat `cleo schema <op>`.
- When no contract is registered for an op, returns `{ schema: null, examples: [] }` with `meta.hint`: `'No OperationInputContract registered for <op>. Use plain flag-based invocation.'`.

## Agent pipeline (the win)
```
cleo schema tasks.add-batch --examples | jq '.examples[0].value' | cleo add-batch --params -
```

## Test plan
- [x] biome / build / vitest — 11 new tests + 16 existing schema tests = 27 passed
- [x] core + cleo + animations builds clean
- [x] Pre-commit hooks (Ferrous Forge Safety, ADR-057 SSoT lint, lockfile drift) all green

Closes T9918
Saga: T9855
ADR: 076