### PR TITLE
feat: doc body schema validation per DocKind (T10160 / Saga T9855)

### DIFF
--- a/.changeset/t10160-doc-body-schema.md
+++ b/.changeset/t10160-doc-body-schema.md
@@ -1,0 +1,8 @@
+---
+id: t10160-doc-body-schema
+tasks: [T10160]
+kind: feat
+summary: doc body schema validation per DocKind (requiredSections[]) with --strict gate — absorbs T10154
+---
+
+Adds requiredSections[] to DocKindMetadata in the canonical doc-kind taxonomy. Built-in kinds adr/spec/research/handoff/release-note/plan/rcasd ship with sensible defaults; note/llm-readme/changeset have empty arrays (no schema). New validateDocBody(kind, body) parses H2 sections (case-insensitive, hyphen/space tolerant). Wired into cleo docs add as advisory by default; --strict flag fails the write with E_DOC_SCHEMA_MISMATCH and details.missing. Extensions in .cleo/docs-config.json can declare their own requiredSections. Saga T9855 / E12 (T10157).

--- a/packages/cleo/src/cli/commands/__tests__/docs-add-strict-args.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/docs-add-strict-args.test.ts
@@ -42,6 +42,11 @@ const docsAddSchema = {
   'attached-by': { type: 'string' as const, description: 'Attached by' },
   slug: { type: 'string' as const, description: 'Slug' },
   type: { type: 'string' as const, description: 'Type' },
+  'allow-similar': {
+    type: 'boolean' as const,
+    description: 'Bypass slug similarity check (T10361)',
+  },
+  strict: { type: 'boolean' as const, description: 'Enforce body-schema validation (T10160)' },
 };
 
 describe('docs add — strict flag validation (T10359 / closes T10238)', () => {

--- a/packages/cleo/src/cli/commands/__tests__/docs-add-strict-body.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/docs-add-strict-body.test.ts
@@ -1,0 +1,209 @@
+/**
+ * End-to-end tests for `cleo docs add --strict` body-schema validation (T10160).
+ *
+ * Drives the compiled `cleo` CLI as a subprocess against an isolated tmp
+ * `CLEO_PROJECT_ROOT` to verify:
+ *
+ * 1. `--strict` on an ADR body missing the `Decision` H2 → E_DOC_SCHEMA_MISMATCH
+ *    envelope on stdout, non-zero exit, missing-sections list in details.
+ * 2. (default / advisory) the same body succeeds — the write completes and the
+ *    envelope still reports `success: true`.
+ * 3. `--strict` on a complete ADR body → write succeeds, no warning.
+ * 4. `--strict` for a kind with no `requiredSections` (e.g. `note`) → write
+ *    succeeds regardless of body shape.
+ *
+ * The strict-args schema mirror is kept in sync with the production schema
+ * by `docs-add-strict-args.test.ts`; this suite exercises the runtime
+ * behaviour wired in {@link import('../../../dispatch/domains/docs.js')}.
+ *
+ * @task T10160 (E12.C3 · absorbs T10154)
+ * @epic T10157
+ * @saga T9855
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PKG_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const CLI_DIST = resolve(PKG_ROOT, 'dist', 'cli', 'index.js');
+const CLI_DIST_AVAILABLE = existsSync(CLI_DIST);
+
+interface CliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number | null;
+}
+
+function runCli(args: readonly string[], projectRoot: string): CliResult {
+  const env = {
+    ...process.env,
+    CLEO_PROJECT_ROOT: projectRoot,
+    CLEO_ROOT: projectRoot,
+    CLEO_DIR: join(projectRoot, '.cleo'),
+    CLEO_OUTPUT_FORMAT: 'json',
+  };
+  const result = spawnSync('node', [CLI_DIST, ...args], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+    timeout: 30_000,
+    cwd: projectRoot,
+    env,
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status,
+  };
+}
+
+interface LafsEnvelope<TData = unknown> {
+  readonly success: boolean;
+  readonly data?: TData;
+  readonly error?: {
+    /** Numeric exit code (1 by default) — `codeName` carries the symbolic id. */
+    readonly code?: number | string;
+    /** Symbolic error name (e.g. `E_DOC_SCHEMA_MISMATCH`). */
+    readonly codeName?: string;
+    readonly message?: string;
+    readonly fix?: string;
+    readonly details?: Record<string, unknown>;
+  };
+  readonly meta?: {
+    readonly operation?: string;
+    readonly command?: string;
+    readonly timestamp?: string;
+    readonly warnings?: ReadonlyArray<{ code?: string; message?: string }>;
+  };
+}
+
+function parseEnvelope<T = unknown>(stdout: string): LafsEnvelope<T> {
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+  for (const line of lines) {
+    if (!line.trim().startsWith('{')) continue;
+    try {
+      return JSON.parse(line) as LafsEnvelope<T>;
+    } catch {
+      /* keep scanning */
+    }
+  }
+  throw new Error(`parseEnvelope: no JSON envelope on stdout. Got:\n${stdout.slice(0, 2000)}`);
+}
+
+let projectRoot: string;
+
+beforeEach(async () => {
+  projectRoot = await mkdtemp(join(tmpdir(), 'cleo-T10160-'));
+  await mkdir(join(projectRoot, '.cleo'), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(projectRoot, { recursive: true, force: true }).catch(() => {
+    /* never fail teardown */
+  });
+});
+
+describe.skipIf(!CLI_DIST_AVAILABLE)(
+  'T10160 — cleo docs add --strict body schema validation',
+  () => {
+    it('(a) --strict + ADR missing Decision → E_DOC_SCHEMA_MISMATCH with details.missing', async () => {
+      const file = join(projectRoot, 'bad-adr.md');
+      await writeFile(
+        file,
+        [
+          '## Status',
+          'Accepted',
+          '',
+          '## Date',
+          '2026-05-24',
+          '',
+          '## Context',
+          'why',
+          '',
+          '## Consequences',
+          'plus/minus',
+        ].join('\n'),
+        'utf-8',
+      );
+
+      const r = runCli(
+        ['docs', 'add', 'T-T10160-a', file, '--type', 'adr', '--strict'],
+        projectRoot,
+      );
+
+      expect(r.status, `expected non-zero exit; stdout=${r.stdout}`).not.toBe(0);
+      const env = parseEnvelope(r.stdout);
+      expect(env.success).toBe(false);
+      // Symbolic error name lives at `codeName`; `code` is the numeric exit code.
+      expect(env.error?.codeName).toBe('E_DOC_SCHEMA_MISMATCH');
+      expect(env.error?.message).toContain('Decision');
+      expect(env.error?.details).toMatchObject({
+        kind: 'adr',
+        missing: ['Decision'],
+        strict: true,
+      });
+    });
+
+    it('(b) advisory mode (default) + ADR missing Decision → write succeeds', async () => {
+      const file = join(projectRoot, 'advisory-adr.md');
+      await writeFile(file, '## Status\nA\n## Context\nC\n', 'utf-8');
+
+      const r = runCli(['docs', 'add', 'T-T10160-b', file, '--type', 'adr'], projectRoot);
+
+      expect(r.status, `expected success; stdout=${r.stdout} stderr=${r.stderr}`).toBe(0);
+      const env = parseEnvelope<{ sha256: string }>(r.stdout);
+      expect(env.success).toBe(true);
+      expect(env.data?.sha256).toBeTruthy();
+    });
+
+    it('(c) --strict + complete ADR body → write succeeds', async () => {
+      const file = join(projectRoot, 'good-adr.md');
+      await writeFile(
+        file,
+        [
+          '## Status',
+          'A',
+          '## Date',
+          'd',
+          '## Context',
+          'c',
+          '## Decision',
+          'do it',
+          '## Consequences',
+          'p',
+        ].join('\n'),
+        'utf-8',
+      );
+
+      const r = runCli(
+        ['docs', 'add', 'T-T10160-c', file, '--type', 'adr', '--strict'],
+        projectRoot,
+      );
+
+      expect(r.status, `expected success; stdout=${r.stdout} stderr=${r.stderr}`).toBe(0);
+      const env = parseEnvelope<{ sha256: string }>(r.stdout);
+      expect(env.success).toBe(true);
+    });
+
+    it('(d) --strict + kind with no requiredSections (note) → free-form body accepted', async () => {
+      const file = join(projectRoot, 'note.md');
+      await writeFile(file, 'free-form observation prose, no headers at all.\n', 'utf-8');
+
+      const r = runCli(
+        ['docs', 'add', 'O-T10160-d', file, '--type', 'note', '--strict'],
+        projectRoot,
+      );
+
+      expect(r.status, `expected success; stdout=${r.stdout} stderr=${r.stderr}`).toBe(0);
+      const env = parseEnvelope<{ sha256: string }>(r.stdout);
+      expect(env.success).toBe(true);
+    });
+  },
+);

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -262,6 +262,13 @@ const addCommand = defineCommand({
         'add a new doc with a near-duplicate slug (e.g. intentional fork). ' +
         'Every bypass is logged to .cleo/audit/similar-bypass.jsonl.',
     },
+    strict: {
+      type: 'boolean',
+      description:
+        "Enforce body-schema validation against the kind's requiredSections (T10160). " +
+        'When set, a missing H2 section fails the write with E_DOC_SCHEMA_MISMATCH. ' +
+        'Default (advisory) surfaces missing sections as a W_DOC_SCHEMA_MISMATCH warning.',
+    },
   },
   async run({ args, rawArgs }) {
     // T10359 — pre-parse strict flag validation. citty's underlying
@@ -454,6 +461,7 @@ const addCommand = defineCommand({
         ...(args['attached-by'] ? { attachedBy: args['attached-by'] } : {}),
         ...(args.slug ? { slug: args.slug } : {}),
         ...(args.type ? { type: args.type } : {}),
+        ...(args.strict === true ? { strict: true } : {}),
       },
       { command: 'docs add' },
     );

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -46,6 +46,7 @@ import type {
   DocsRemoveResult,
   DocsType,
 } from '@cleocode/contracts/operations/docs';
+import { pushWarning } from '@cleocode/core';
 import type {
   AttachmentRef,
   LlmsTxtAttachment,
@@ -66,6 +67,7 @@ import {
   reserveSlugForDispatch,
   resolveAttachmentBackend,
   SlugCollisionError,
+  validateDocBody,
   writeChangesetEntry,
 } from '@cleocode/core/internal';
 import { defineTypedHandler, lafsError, lafsSuccess, typedDispatch } from '../adapters/typed.js';
@@ -833,6 +835,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       attachedBy: rawAttachedBy,
       slug: rawSlug,
       type: rawType,
+      strict: strictMode,
     } = params;
     if (!ownerId) {
       return lafsError('E_INVALID_INPUT', 'ownerId is required', 'add');
@@ -1094,6 +1097,54 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
         bytes = await readFile(absPath);
       } catch {
         return lafsError('E_FILE_ERROR', `Cannot read file: ${absPath}`, 'add');
+      }
+
+      // T10160 — body schema validation per DocKind.
+      //
+      // Runs only when --type is supplied and the kind declares a
+      // non-empty `requiredSections` in the canonical doc-kind taxonomy.
+      // `strict: true` → missing sections fail the write with
+      // `E_DOC_SCHEMA_MISMATCH`. Default (advisory) → a warning surfaces
+      // through the AsyncLocalStorage warning collector so the envelope's
+      // `meta.warnings` carries it; the write proceeds.
+      //
+      // URL attachments are skipped — there are no local bytes to scan.
+      // Project-level extensions are picked up via `DocKindRegistry.load`
+      // so a kind declared in `.cleo/docs-config.json` with
+      // `requiredSections` participates in the same validator.
+      if (type !== undefined) {
+        const bodyText = bytes.toString('utf-8');
+        let registry: DocKindRegistry | undefined;
+        try {
+          registry = DocKindRegistry.load(getProjectRoot());
+        } catch {
+          // Malformed extension config — fall back to built-ins-only.
+          // `cleo check canon docs` surfaces the underlying diagnostic.
+          registry = undefined;
+        }
+        const check = validateDocBody(type, bodyText, registry);
+        if (!check.ok) {
+          const missingList = check.missing.join(', ');
+          if (strictMode === true) {
+            return lafsError(
+              'E_DOC_SCHEMA_MISMATCH',
+              `body for kind '${type}' is missing required section(s): ${missingList}`,
+              'add',
+              `Add the missing H2 section(s) — '## ${check.missing[0] ?? ''}' — then retry. ` +
+                `Pass --strict=false (default) to surface as an advisory warning instead of an error.`,
+              {
+                kind: type,
+                missing: check.missing,
+                strict: true,
+              },
+            );
+          }
+          // Advisory mode — push a warning and continue.
+          pushWarning({
+            code: 'W_DOC_SCHEMA_MISMATCH',
+            message: `body for kind '${type}' is missing required section(s): ${missingList}. Add '--strict' to fail on schema violations.`,
+          });
+        }
       }
 
       const mime = mimeFromPath(absPath);

--- a/packages/contracts/src/docs-taxonomy.ts
+++ b/packages/contracts/src/docs-taxonomy.ts
@@ -98,6 +98,20 @@ export interface DocKindMetadata {
    * Built-in kinds leave this unset; extensions set it to `true`.
    */
   readonly isExtension?: boolean;
+  /**
+   * Optional list of H2 section titles that MUST appear in the document
+   * body. Validated by `validateDocBody(kind, body)` (T10160).
+   *
+   * Match is case-insensitive and tolerant of hyphen-vs-space variants
+   * (e.g. `## Next Steps` and `## next-steps` both satisfy a required
+   * section of `Next Steps`).
+   *
+   * Empty or omitted → no body schema requirements for this kind.
+   *
+   * @task T10160 (E12.C3 · absorbs T10154)
+   * @epic T10157
+   */
+  readonly requiredSections?: ReadonlyArray<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -125,6 +139,7 @@ export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
     publishDir: 'docs/adr',
     requiresEntityId: true,
     entityIdPattern: /^adr-\d{3,4}-[a-z0-9-]+$/,
+    requiredSections: ['Status', 'Date', 'Context', 'Decision', 'Consequences'],
   },
   {
     kind: 'spec',
@@ -133,6 +148,7 @@ export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
     defaultOwnerKind: 'task',
     publishDir: 'docs/spec',
     requiresEntityId: false,
+    requiredSections: ['Goal', 'Non-Goals', 'Requirements', 'Out-of-Scope'],
   },
   {
     kind: 'research',
@@ -141,6 +157,7 @@ export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
     defaultOwnerKind: 'task',
     publishDir: 'docs/research',
     requiresEntityId: false,
+    requiredSections: ['Question', 'Findings', 'Sources'],
   },
   {
     kind: 'handoff',
@@ -149,6 +166,7 @@ export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
     defaultOwnerKind: 'session',
     publishDir: 'docs/handoff',
     requiresEntityId: false,
+    requiredSections: ['Context', 'State', 'Next-Steps'],
   },
   {
     kind: 'note',
@@ -157,6 +175,7 @@ export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
     defaultOwnerKind: 'observation',
     publishDir: 'docs/note',
     requiresEntityId: false,
+    requiredSections: [],
   },
   {
     kind: 'llm-readme',
@@ -165,6 +184,7 @@ export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
     defaultOwnerKind: 'project',
     publishDir: '.',
     requiresEntityId: false,
+    requiredSections: [],
   },
   {
     kind: 'changeset',
@@ -174,6 +194,7 @@ export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
     publishDir: '.changeset',
     requiresEntityId: true,
     entityIdPattern: /^t\d+-[a-z0-9-]+$/,
+    requiredSections: [],
   },
   {
     kind: 'release-note',
@@ -183,6 +204,7 @@ export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
     publishDir: 'docs/release',
     requiresEntityId: true,
     entityIdPattern: /^v\d{4}\.\d+\.\d+(-[a-z0-9-]+)?$/,
+    requiredSections: ['Changes', 'Migration'],
   },
   {
     kind: 'plan',
@@ -191,6 +213,7 @@ export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
     defaultOwnerKind: 'task',
     publishDir: 'docs/plan',
     requiresEntityId: false,
+    requiredSections: ['Goal', 'Steps', 'Owners'],
   },
   {
     kind: 'rcasd',
@@ -200,6 +223,7 @@ export const BUILTIN_DOC_KINDS: ReadonlyArray<DocKindMetadata> = [
     publishDir: '.cleo/rcasd',
     requiresEntityId: true,
     entityIdPattern: /^t\d+(-.+)?$/,
+    requiredSections: ['Root-Cause', 'Action', 'Schedule', 'Detection'],
   },
 ];
 
@@ -253,6 +277,16 @@ export interface DocKindExtensionConfig {
    * a malformed config can't trigger pathological backtracking.
    */
   readonly entityIdPattern?: string;
+  /**
+   * Optional list of required H2 section titles for this extension kind.
+   *
+   * Same semantics as {@link DocKindMetadata.requiredSections} — matched
+   * case-insensitively with hyphen/space normalisation. Omit or pass
+   * `[]` for kinds that have no body schema.
+   *
+   * @task T10160
+   */
+  readonly requiredSections?: ReadonlyArray<string>;
 }
 
 /**
@@ -596,6 +630,25 @@ function validateExtensionEntry(
     );
   }
 
+  let requiredSections: ReadonlyArray<string> | undefined;
+  if (obj.requiredSections !== undefined) {
+    if (!Array.isArray(obj.requiredSections)) {
+      throw new DocKindConfigError(`${where}: 'requiredSections' must be an array`, source);
+    }
+    const sections: string[] = [];
+    for (let i = 0; i < obj.requiredSections.length; i++) {
+      const item = obj.requiredSections[i];
+      if (typeof item !== 'string' || item.length === 0) {
+        throw new DocKindConfigError(
+          `${where}: 'requiredSections[${i}]' must be a non-empty string`,
+          source,
+        );
+      }
+      sections.push(item);
+    }
+    requiredSections = sections;
+  }
+
   return {
     kind,
     label,
@@ -604,6 +657,7 @@ function validateExtensionEntry(
     publishDir,
     requiresEntityId,
     ...(entityIdPattern !== undefined ? { entityIdPattern } : {}),
+    ...(requiredSections !== undefined ? { requiredSections } : {}),
   };
 }
 
@@ -633,6 +687,7 @@ function compileExtension(ext: DocKindExtensionConfig, source: string): DocKindM
     publishDir: ext.publishDir,
     requiresEntityId: ext.requiresEntityId,
     ...(entityIdPattern !== undefined ? { entityIdPattern } : {}),
+    ...(ext.requiredSections !== undefined ? { requiredSections: ext.requiredSections } : {}),
     isExtension: true,
   };
 }

--- a/packages/contracts/src/operations/docs.ts
+++ b/packages/contracts/src/operations/docs.ts
@@ -405,6 +405,22 @@ export interface DocsAddParams {
    * @task T9637 (T-DOCS-SLUG-2)
    */
   type?: DocsType;
+  /**
+   * When `true`, body-schema validation against
+   * {@link DocKindMetadata.requiredSections} is enforced — a missing
+   * required H2 section returns `E_DOC_SCHEMA_MISMATCH` with the
+   * missing-sections list in `details.missing`. When omitted or `false`,
+   * the validator runs in advisory mode: the write proceeds and any
+   * missing sections surface as a warning in the envelope's `meta`.
+   *
+   * Only meaningful when `file` is set; URL attachments skip body
+   * validation (no local bytes to scan).
+   *
+   * @task T10160 (E12.C3 · absorbs T10154)
+   * @epic T10157
+   * @saga T9855
+   */
+  strict?: boolean;
 }
 
 /**

--- a/packages/core/src/docs/__tests__/validate-body.test.ts
+++ b/packages/core/src/docs/__tests__/validate-body.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for {@link validateDocBody} — body-schema validation per DocKind.
+ *
+ * Covers the matrix declared in T10160 acceptance:
+ *   - all required H2 sections present → ok
+ *   - missing sections → reported by canonical name
+ *   - case-insensitive matching
+ *   - hyphen / space tolerance
+ *   - kinds with no `requiredSections` (e.g. `note`) → always ok
+ *   - unknown kinds → ok (advisory, additive)
+ *   - registry override for project extensions
+ *
+ * @task T10160 (E12.C3 · absorbs T10154)
+ * @epic T10157
+ * @saga T9855
+ */
+
+import { DocKindRegistry } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { validateDocBody } from '../validate-body.js';
+
+describe('validateDocBody', () => {
+  it('passes when every required H2 section is present (ADR)', () => {
+    const body = [
+      '# adr-001-foo',
+      '',
+      '## Status',
+      'Accepted',
+      '',
+      '## Date',
+      '2026-05-24',
+      '',
+      '## Context',
+      'why',
+      '',
+      '## Decision',
+      'do it',
+      '',
+      '## Consequences',
+      'plus and minus',
+    ].join('\n');
+
+    const r = validateDocBody('adr', body);
+
+    expect(r.ok).toBe(true);
+    expect(r.missing).toEqual([]);
+  });
+
+  it("reports a missing 'Decision' section for an ADR", () => {
+    const body = [
+      '## Status',
+      'Accepted',
+      '',
+      '## Date',
+      '2026-05-24',
+      '',
+      '## Context',
+      'why',
+      '',
+      '## Consequences',
+      'plus and minus',
+    ].join('\n');
+
+    const r = validateDocBody('adr', body);
+
+    expect(r.ok).toBe(false);
+    expect(r.missing).toEqual(['Decision']);
+  });
+
+  it('reports multiple missing sections in declaration order', () => {
+    const body = '## Status\nA\n\n## Decision\nDo it';
+
+    const r = validateDocBody('adr', body);
+
+    expect(r.ok).toBe(false);
+    expect(r.missing).toEqual(['Date', 'Context', 'Consequences']);
+  });
+
+  it('matches H2 headers case-insensitively (## decision === Decision)', () => {
+    const body = [
+      '## status',
+      'A',
+      '## date',
+      '2026-05-24',
+      '## context',
+      'why',
+      '## decision',
+      'do it',
+      '## consequences',
+      'plus and minus',
+    ].join('\n');
+
+    expect(validateDocBody('adr', body).ok).toBe(true);
+  });
+
+  it('treats hyphens and spaces as interchangeable (## Next Steps === Next-Steps)', () => {
+    const body = ['## Context', 'c', '## State', 's', '## Next Steps', 'n'].join('\n');
+
+    const r = validateDocBody('handoff', body);
+
+    expect(r.ok).toBe(true);
+    expect(r.missing).toEqual([]);
+  });
+
+  it('tolerates trailing punctuation in headers (## Decision:)', () => {
+    const body = [
+      '## Status:',
+      'A',
+      '## Date.',
+      'd',
+      '## Context',
+      'c',
+      '## Decision:',
+      'd',
+      '## Consequences',
+      'p',
+    ].join('\n');
+
+    expect(validateDocBody('adr', body).ok).toBe(true);
+  });
+
+  it('ignores H1 and H3 headers — only H2 (##) counts', () => {
+    const body = [
+      '# Decision',
+      'looks like a section but it is H1',
+      '### Decision',
+      'looks like a section but it is H3',
+      '## Status',
+      'A',
+      '## Date',
+      'd',
+      '## Context',
+      'c',
+      '## Consequences',
+      'p',
+    ].join('\n');
+
+    const r = validateDocBody('adr', body);
+
+    expect(r.ok).toBe(false);
+    expect(r.missing).toContain('Decision');
+  });
+
+  it('returns ok for a kind declared with no requiredSections (note)', () => {
+    const r = validateDocBody('note', 'free-form observation prose');
+
+    expect(r.ok).toBe(true);
+    expect(r.missing).toEqual([]);
+  });
+
+  it('returns ok for an unknown kind (advisory — no rules)', () => {
+    const r = validateDocBody('not-a-real-kind', 'whatever');
+
+    expect(r.ok).toBe(true);
+    expect(r.missing).toEqual([]);
+  });
+
+  it('returns ok on an empty body when the kind has no required sections', () => {
+    expect(validateDocBody('note', '').ok).toBe(true);
+  });
+
+  it('reports every required section as missing when body is empty', () => {
+    const r = validateDocBody('adr', '');
+
+    expect(r.ok).toBe(false);
+    expect(r.missing).toEqual(['Status', 'Date', 'Context', 'Decision', 'Consequences']);
+  });
+
+  it('honours a project-extension registry that adds a kind with requiredSections', () => {
+    const registry = DocKindRegistry.fromConfig({
+      extensions: [
+        {
+          kind: 'incident',
+          label: 'Incident',
+          description: 'Production incident write-up',
+          defaultOwnerKind: 'task',
+          publishDir: 'docs/incidents',
+          requiresEntityId: false,
+          requiredSections: ['Summary', 'Timeline', 'Resolution'],
+        },
+      ],
+    });
+
+    const bodyOk = '## Summary\ns\n## Timeline\nt\n## Resolution\nr';
+    const bodyBad = '## Summary\ns\n## Timeline\nt';
+
+    expect(validateDocBody('incident', bodyOk, registry).ok).toBe(true);
+    const bad = validateDocBody('incident', bodyBad, registry);
+    expect(bad.ok).toBe(false);
+    expect(bad.missing).toEqual(['Resolution']);
+  });
+
+  it('returns ok when an extension kind declares an empty requiredSections', () => {
+    const registry = DocKindRegistry.fromConfig({
+      extensions: [
+        {
+          kind: 'changelog-snippet',
+          label: 'Changelog Snippet',
+          description: 'Free-form changelog entry',
+          defaultOwnerKind: 'task',
+          publishDir: 'docs/changelog',
+          requiresEntityId: false,
+          requiredSections: [],
+        },
+      ],
+    });
+
+    expect(validateDocBody('changelog-snippet', 'anything', registry).ok).toBe(true);
+  });
+});

--- a/packages/core/src/docs/index.ts
+++ b/packages/core/src/docs/index.ts
@@ -49,7 +49,6 @@ export {
 
 export type { ExportDocumentOptions, ExportDocumentResult } from './export-document.js';
 export { exportDocument } from './export-document.js';
-
 // ── T10361 — slug similarity warn at docs add write-time ────────────────────
 export type {
   CheckSlugSimilarityOptions,
@@ -63,6 +62,9 @@ export {
   DEFAULT_SIMILARITY_THRESHOLD,
   parseSimilarityConfig,
 } from './similarity-check.js';
+// ── T10160 — body schema validation per DocKind (requiredSections[]) ────────
+export type { ValidateDocBodyResult } from './validate-body.js';
+export { validateDocBody } from './validate-body.js';
 
 // ── T9639 — cleo docs import (legacy .md migration) ─────────────────────────
 

--- a/packages/core/src/docs/validate-body.ts
+++ b/packages/core/src/docs/validate-body.ts
@@ -1,0 +1,124 @@
+/**
+ * Body-schema validation for canonical doc kinds (T10160).
+ *
+ * Scans a Markdown body for H2 (`## ...`) section headers and checks them
+ * against the {@link DocKindMetadata.requiredSections} list declared in the
+ * canonical doc-kind taxonomy. Comparison is:
+ *
+ * - case-insensitive (`## decision` matches `Decision`)
+ * - tolerant of hyphen vs space (`## Next Steps` matches `Next-Steps`)
+ * - tolerant of trailing punctuation in the header (`## Decision:` matches)
+ *
+ * Unknown kinds (not in the registry) and kinds with no `requiredSections`
+ * or an empty array always pass — this keeps the validator additive: a
+ * project that never opts a kind into a schema sees no behaviour change.
+ *
+ * The function is pure and synchronous — no filesystem, no DB. The CLI
+ * wires it into `cleo docs add` / `cleo docs publish` in advisory mode by
+ * default; `--strict` makes a body-schema mismatch fatal with
+ * `E_DOC_BODY_INVALID`.
+ *
+ * @task T10160 (E12.C3 · absorbs T10154)
+ * @epic T10157
+ * @saga T9855
+ */
+
+import { BUILTIN_DOC_KINDS, type DocKindMetadata, type DocKindRegistry } from '@cleocode/contracts';
+
+/**
+ * Result of {@link validateDocBody}.
+ */
+export interface ValidateDocBodyResult {
+  /** True when every required H2 section is present (or the kind has none). */
+  readonly ok: boolean;
+  /** Missing required-section titles, in declaration order. Empty when ok. */
+  readonly missing: ReadonlyArray<string>;
+}
+
+/**
+ * Internal — extract H2 titles (`## Title`) from a Markdown body.
+ *
+ * Strips ATX-style trailing `#` markers, trailing punctuation (`:`, `.`),
+ * and surrounding whitespace. The returned strings retain their original
+ * casing; normalisation for comparison happens in {@link normaliseSection}.
+ */
+function extractH2Sections(body: string): string[] {
+  const out: string[] = [];
+  const lines = body.split(/\r?\n/);
+  for (const line of lines) {
+    const match = /^##\s+(.+?)\s*#*\s*$/.exec(line);
+    if (!match) continue;
+    const title = match[1]!.replace(/[:.]+$/, '').trim();
+    if (title.length > 0) out.push(title);
+  }
+  return out;
+}
+
+/**
+ * Internal — fold a section title into a canonical comparison form:
+ * lowercased, hyphens collapsed to single spaces, whitespace trimmed +
+ * collapsed.
+ */
+function normaliseSection(title: string): string {
+  return title.toLowerCase().replace(/-+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Validate a Markdown body against the required-sections schema for `kind`.
+ *
+ * Behaviour:
+ * - Unknown kind → `{ ok: true, missing: [] }` (advisory — no schema rules).
+ * - Kind declared with no `requiredSections` (or `[]`) → always ok.
+ * - Otherwise → reports any required H2 section title not found in `body`.
+ *
+ * Matching ignores case and treats hyphens as spaces — `## next-steps`
+ * satisfies a requirement of `Next Steps` and vice versa.
+ *
+ * Built-ins-only fast path: the function pulls metadata from
+ * {@link BUILTIN_DOC_KINDS} so callers with no project root in scope
+ * (e.g. dispatch handlers operating on a worktree-routed file) can still
+ * validate. Extension-only kinds are reached through the optional
+ * {@link DocKindRegistry} parameter.
+ *
+ * @param kind - Canonical doc kind id (e.g. `'adr'`, `'spec'`).
+ * @param body - Markdown body to scan. Frontmatter is irrelevant — we
+ *               only look at `## ...` headers.
+ * @param registry - Optional registry (built-ins + project extensions).
+ *                   When omitted, only built-in kinds are considered.
+ */
+export function validateDocBody(
+  kind: string,
+  body: string,
+  registry?: DocKindRegistry,
+): ValidateDocBodyResult {
+  const meta = lookupMetadata(kind, registry);
+  if (!meta || !meta.requiredSections || meta.requiredSections.length === 0) {
+    return { ok: true, missing: [] };
+  }
+
+  const presentRaw = extractH2Sections(body);
+  const presentNorm = new Set(presentRaw.map(normaliseSection));
+
+  const missing: string[] = [];
+  for (const required of meta.requiredSections) {
+    if (!presentNorm.has(normaliseSection(required))) {
+      missing.push(required);
+    }
+  }
+
+  return { ok: missing.length === 0, missing };
+}
+
+/**
+ * Internal — look up metadata for `kind`, preferring the supplied registry
+ * when present and falling back to the built-in list otherwise.
+ */
+function lookupMetadata(
+  kind: string,
+  registry: DocKindRegistry | undefined,
+): DocKindMetadata | undefined {
+  if (registry) {
+    return registry.get(kind);
+  }
+  return BUILTIN_DOC_KINDS.find((m) => m.kind === kind);
+}

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -281,6 +281,9 @@ export {
   reserveSlug,
   reserveSlugForDispatch,
 } from './docs/slug-allocator.js';
+// Docs body-schema validation per DocKind (T10160 — E12.C3 · Saga T9855)
+export type { ValidateDocBodyResult } from './docs/validate-body.js';
+export { validateDocBody } from './docs/validate-body.js';
 // DocKind Writer Registry (T10366 / Saga T10288 / Epic T10290)
 export type {
   WriteArgs,

--- a/scripts/.lint-stdout-discipline-baseline.json
+++ b/scripts/.lint-stdout-discipline-baseline.json
@@ -26,8 +26,8 @@
     "packages/cleo/src/cli/commands/check.ts:621",
     "packages/cleo/src/cli/commands/check.ts:623",
     "packages/cleo/src/cli/commands/deps.ts:328",
-    "packages/cleo/src/cli/commands/docs.ts:768",
-    "packages/cleo/src/cli/commands/docs.ts:769",
+    "packages/cleo/src/cli/commands/docs.ts:776",
+    "packages/cleo/src/cli/commands/docs.ts:777",
     "packages/cleo/src/cli/commands/event.ts:238",
     "packages/cleo/src/cli/commands/event.ts:249",
     "packages/cleo/src/cli/commands/event.ts:251",
@@ -78,5 +78,5 @@
     "packages/mcp-adapter/src/server.ts:133",
     "packages/mcp-adapter/src/server.ts:137"
   ],
-  "updatedAt": "2026-05-24T04:10:27.560Z"
+  "updatedAt": "2026-05-24T09:09:45.369Z"
 }


### PR DESCRIPTION
## Summary
- DocKind taxonomy gains `requiredSections[]`. ADR / spec / research / handoff / release-note / plan / rcasd get sensible defaults; `note` / `llm-readme` / `changeset` ship `[]` (no schema).
- `validateDocBody(kind, body)` parses H2 (`## ...`) headers and reports missing required sections. Matching is case-insensitive and tolerant of hyphen-vs-space variants (`## next-steps` satisfies `Next Steps`).
- Wired into `cleo docs add` as advisory by default; `--strict` blocks the write with `E_DOC_SCHEMA_MISMATCH` + `details: { kind, missing: [...], strict: true }`.
- Extensions in `.cleo/docs-config.json` can declare their own `requiredSections` via the existing `DocKindRegistry` plumbing.

Absorbs T10154 per the SG-DOCS-INTEGRITY ADR-076 routing.

## Test plan
- [x] `validateDocBody` unit suite — 13 tests (all/missing/case/hyphen/punctuation/H1+H3 ignored/note/unknown/empty/extension registry)
- [x] CLI subprocess strict-body suite — 4 tests (strict failure, advisory pass, complete ADR, note kind)
- [x] `docs-add-strict-args` schema mirror updated to include `--strict` and `--allow-similar`
- [x] biome check passes on all touched files
- [x] full workspace build green
- [x] existing `docs-add-similarity`, `docs-error-envelopes`, `docs-list-ux`, `docs-idempotency`, `docs-taxonomy` suites still green (no regressions)

Closes T10160
Saga: T9855
ADR: 076