### PR TITLE
fix(cleo): T9887 CI gate fixes (followup to #660)

### DIFF
--- a/packages/cleo/src/cli/commands/config.ts
+++ b/packages/cleo/src/cli/commands/config.ts
@@ -29,7 +29,7 @@
  * @adr 076
  */
 
-import { CleoError, formatError, loadConfig } from '@cleocode/core';
+import { CleoError, loadConfig } from '@cleocode/core';
 import { showUsage } from 'citty';
 import { dispatchFromCli } from '../../dispatch/adapters/cli.js';
 import { defineCommand } from '../lib/define-cli-command.js';
@@ -94,7 +94,7 @@ const listCommand = defineCommand({
       cliOutput({ config: resolved }, { command: 'config' });
     } catch (err) {
       if (err instanceof CleoError) {
-        cliError(formatError(err), err.code, { name: 'E_CONFIG_LOAD' });
+        cliError(`config list failed: ${err.message}`, err.code, { name: 'E_CONFIG_LOAD' });
         process.exit(err.code);
       }
       throw err;

--- a/packages/cleo/src/cli/commands/config/set.ts
+++ b/packages/cleo/src/cli/commands/config/set.ts
@@ -182,35 +182,37 @@ function parseWriteScope(raw: string | undefined): 'global' | 'project' | null {
  * @internal
  */
 function coerceValue(raw: string, typeFlag: string | undefined): unknown {
-  if (typeFlag === undefined) {
-    return parseConfigValue(raw);
+  if (typeFlag === undefined) return parseConfigValue(raw);
+  if (typeFlag === 'string') return raw;
+  if (typeFlag === 'number') return coerceNumber(raw);
+  if (typeFlag === 'boolean') return coerceBoolean(raw);
+  if (typeFlag === 'json') return coerceJson(raw);
+  throw new Error(`--type must be one of: string | number | boolean | json (got "${typeFlag}")`);
+}
+
+/** Coerce a CLI string into a finite number; throws on `NaN`. @internal */
+function coerceNumber(raw: string): number {
+  const n = Number(raw);
+  if (Number.isNaN(n)) {
+    throw new Error(`--type number cannot coerce "${raw}"`);
   }
-  switch (typeFlag) {
-    case 'string':
-      return raw;
-    case 'number': {
-      const n = Number(raw);
-      if (Number.isNaN(n)) {
-        throw new Error(`--type number cannot coerce "${raw}"`);
-      }
-      return n;
-    }
-    case 'boolean': {
-      const lower = raw.toLowerCase();
-      if (lower === 'true') return true;
-      if (lower === 'false') return false;
-      throw new Error(`--type boolean accepts only "true"/"false" (got "${raw}")`);
-    }
-    case 'json':
-      try {
-        return JSON.parse(raw) as unknown;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`--type json failed to parse: ${msg}`);
-      }
-    default:
-      throw new Error(
-        `--type must be one of: string | number | boolean | json (got "${typeFlag}")`,
-      );
+  return n;
+}
+
+/** Coerce a CLI string into a boolean (`true`/`false`, case-insensitive). @internal */
+function coerceBoolean(raw: string): boolean {
+  const lower = raw.toLowerCase();
+  if (lower === 'true') return true;
+  if (lower === 'false') return false;
+  throw new Error(`--type boolean accepts only "true"/"false" (got "${raw}")`);
+}
+
+/** Coerce a CLI string via `JSON.parse`; rewraps SyntaxError into a CLI-shaped message. @internal */
+function coerceJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`--type json failed to parse: ${msg}`);
   }
 }


### PR DESCRIPTION
## Summary

T9887 PR #660 was merged before two CI gates went green:
- **CLI Boundary Lint (T10076 / T9837)** — `coerceValue` was 34 LOC (limit 30).
- **Format-Error Misuse Lint (T9789)** — legacy `cliError(formatError(err), ...)` double-wrap in the pre-existing `listCommand` catch arm tripped the gate because the file appeared in the PR diff.

This PR restores green for both.

## Changes

- `packages/cleo/src/cli/commands/config/set.ts` — split 34-LOC `coerceValue` into a 6-LOC dispatcher plus 3 single-purpose helpers (`coerceNumber`, `coerceBoolean`, `coerceJson`). No behavior change.
- `packages/cleo/src/cli/commands/config.ts` — rewrite legacy `listCommand` catch arm to the canonical `cliError(\`<verb> failed: \${err.message}\`, ...)` pattern. Drop unused `formatError` import.

## Verification

Local lints all pass:
- `node scripts/lint-cli-package-boundary.mjs --check` → PASS (28/28 baseline)
- `node scripts/lint-format-error-misuse.mjs` → OK
- `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/cli/commands/config` → 9/9 passing
- `pnpm run build` → success

Followup to #660 (T9887 / Saga T9855)