### PR TITLE
fix: biome organize-imports for T9879 lint script (Saga T9855 unblock)

### DIFF
--- a/scripts/lint-no-deprecated-template-resolvers.mjs
+++ b/scripts/lint-no-deprecated-template-resolvers.mjs
@@ -111,6 +111,7 @@ function walkTs(dir) {
 
 // ESM does not expose `require` by default; create one for the walker above.
 import { createRequire } from 'node:module';
+
 const require = createRequire(import.meta.url);
 
 const PACKAGES_DIR = join(REPO_ROOT, 'packages');


### PR DESCRIPTION
Hotfix: T9879 merged a lint script with an import-ordering issue that biome ci flags. This blocks every subsequent Saga T9855 worker PR. One-line fix: insert blank line after import-block per biome organize-imports rule.

Saga: T9855