### PR TITLE
feat(contracts,core): meta.suggestedNext envelope-wide (T9920 / Saga T9855)

### DIFF
--- a/.changeset/t9920-suggested-next-envelope-wide.md
+++ b/.changeset/t9920-suggested-next-envelope-wide.md
@@ -1,0 +1,6 @@
+---
+id: t9920-suggested-next-envelope-wide
+tasks: [T9920]
+kind: feat
+summary: feat(contracts,core): promote meta.suggestedNext to envelope-wide CliMeta field (T9920 / Saga T9855 / E8)
+---

--- a/.cleo/adrs/ADR-039-lafs-envelope-unification.md
+++ b/.cleo/adrs/ADR-039-lafs-envelope-unification.md
@@ -112,10 +112,47 @@ Cherry-picked from Wave 4 commits in the T335 epic. Wave 4 finisher (T338) close
 
 ---
 
+## Amendment — T9920 (Saga T9855 / E8.1, 2026-05-24)
+
+`CliMeta` is extended with an optional first-class
+`suggestedNext?: ReadonlyArray<string>` field. The field is the **canonical**
+envelope-wide LLM next-action hint: a flat array of copy-pasteable CLI
+commands the agent may run next as the natural chained-reasoning step.
+
+**Semantic.** Each entry MUST be a self-contained, copy-pasteable command
+string (e.g. `"cleo focus T1234"`, `"cleo verify T1234 --gate implemented"`).
+The list is ordered by relevance — earliest entry is the most likely
+follow-up. An empty array means "no follow-up suggested"; absent means
+"the producer did not consider follow-ups". Renderers MUST omit the field
+from human output when the array is empty.
+
+**Backward compatibility.** The pre-T9920 nexus-only structured form lives
+on at `meta._nexus.suggestedNext: ReadonlyArray<SuggestedNextOp>` (see
+`packages/contracts/src/operations/nexus-scope.ts`). The nexus decorator
+will additionally project a flat string form onto `meta.suggestedNext`
+under follow-on task T9921. Existing structured-shape consumers continue
+to function unchanged — this amendment **adds** the envelope-wide field
+without altering the nexus-internal one.
+
+**Producer guidance.** Operation handlers, decorators, and middleware
+SHOULD use the helper
+`attachSuggestedNext(envelope, suggestions)` from
+`@cleocode/core/dispatch/suggested-next` (re-exported from
+`@cleocode/core`) to add the field. The helper deep-clones `envelope.meta`
+so the input envelope is never mutated.
+
+Follow-ons: T9921 (auto-populate on mutate ops), T9925 (LAFS conformance
+test asserts shape across every operation).
+
+---
+
 ## References
 
 - T335 — LAFS Envelope Remediation epic
 - T338 — FIX-3: Wave 4 finisher
+- T9920 (Saga T9855 / E8.1) — envelope-wide `meta.suggestedNext` promotion
 - `packages/lafs/src/envelope.ts` — canonical `CliEnvelope`, `CliMeta`, `CliEnvelopeError` types
+- `packages/core/src/dispatch/suggested-next.ts` — `attachSuggestedNext` helper
+- `packages/contracts/src/operations/nexus-scope.ts` — pre-existing structured `NexusScopeMeta.suggestedNext`
 - `packages/cleo/src/dispatch/lib/proto-envelope.ts` — `_ProtoEnvelopeStub` bridge type
 - `packages/cleo/src/dispatch/types.ts` — `DispatchResponse.meta` (renamed from `_meta`)

--- a/packages/contracts/src/__tests__/cli-meta-suggested-next.test.ts
+++ b/packages/contracts/src/__tests__/cli-meta-suggested-next.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Type-shape contract test for the envelope-wide `meta.suggestedNext`
+ * field promoted in T9920 (Saga T9855 / E8.1).
+ *
+ * `CliMeta.suggestedNext` is the canonical LLM-next-action hint
+ * surfaced on every CLI envelope. This test asserts the type allows
+ * the optional `ReadonlyArray<string>` shape and never widens to
+ * `string | null` or to nested objects (which would re-introduce the
+ * pre-T9920 nexus-internal-only structured form at the envelope tier).
+ *
+ * The runtime `attachSuggestedNext` helper lives in
+ * `packages/core/src/dispatch/suggested-next.ts` and is exercised by
+ * `packages/core/src/dispatch/__tests__/suggested-next.test.ts` —
+ * contracts cannot import core without breaking the layering contract.
+ *
+ * @epic T9919
+ * @task T9920
+ * @saga T9855
+ */
+
+import type { CliEnvelope, CliMeta } from '@cleocode/lafs';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+describe('CliMeta.suggestedNext type shape (T9920)', () => {
+  it('allows ReadonlyArray<string>', () => {
+    const meta: CliMeta = {
+      operation: 'tasks.show',
+      requestId: '00000000-0000-0000-0000-000000000000',
+      duration_ms: 0,
+      timestamp: '2026-05-24T00:00:00.000Z',
+      suggestedNext: ['cleo focus T1234', 'cleo verify T1234'],
+    };
+    expect(meta.suggestedNext).toEqual(['cleo focus T1234', 'cleo verify T1234']);
+  });
+
+  it('is optional — omitting it leaves a valid CliMeta', () => {
+    const meta: CliMeta = {
+      operation: 'tasks.list',
+      requestId: '00000000-0000-0000-0000-000000000001',
+      duration_ms: 0,
+      timestamp: '2026-05-24T00:00:00.000Z',
+    };
+    expect(meta.suggestedNext).toBeUndefined();
+  });
+
+  it('accepts an empty array (explicit "no follow-up suggested")', () => {
+    const meta: CliMeta = {
+      operation: 'tasks.show',
+      requestId: '00000000-0000-0000-0000-000000000002',
+      duration_ms: 0,
+      timestamp: '2026-05-24T00:00:00.000Z',
+      suggestedNext: [],
+    };
+    expect(meta.suggestedNext).toEqual([]);
+    expect(Array.isArray(meta.suggestedNext)).toBe(true);
+  });
+
+  it('typechecks as ReadonlyArray<string> — never `null`, never nested objects', () => {
+    expectTypeOf<CliMeta['suggestedNext']>().toEqualTypeOf<ReadonlyArray<string> | undefined>();
+  });
+
+  it('flows through CliEnvelope<T>.meta verbatim', () => {
+    const envelope: CliEnvelope<{ taskId: string }> = {
+      success: true,
+      data: { taskId: 'T1234' },
+      meta: {
+        operation: 'tasks.show',
+        requestId: '00000000-0000-0000-0000-000000000003',
+        duration_ms: 1,
+        timestamp: '2026-05-24T00:00:00.000Z',
+        suggestedNext: ['cleo focus T1234'],
+      },
+    };
+    expect(envelope.meta.suggestedNext).toEqual(['cleo focus T1234']);
+  });
+});

--- a/packages/core/src/dispatch/__tests__/suggested-next.test.ts
+++ b/packages/core/src/dispatch/__tests__/suggested-next.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Runtime test for the `attachSuggestedNext` envelope helper
+ * promoted in T9920 (Saga T9855 / E8.1).
+ *
+ * Type-shape assertions for `CliMeta.suggestedNext` itself live in
+ * `packages/contracts/src/__tests__/cli-meta-suggested-next.test.ts` —
+ * contracts cannot depend on core, so the two concerns are split.
+ *
+ * @epic T9919
+ * @task T9920
+ * @saga T9855
+ */
+
+import type { CliEnvelope } from '@cleocode/lafs';
+import { describe, expect, it } from 'vitest';
+import { attachSuggestedNext } from '../suggested-next.js';
+
+function makeEnvelope<T>(data: T): CliEnvelope<T> {
+  return {
+    success: true,
+    data,
+    meta: {
+      operation: 'tasks.show',
+      requestId: '00000000-0000-0000-0000-000000000000',
+      duration_ms: 0,
+      timestamp: '2026-05-24T00:00:00.000Z',
+    },
+  };
+}
+
+describe('attachSuggestedNext (T9920)', () => {
+  it('produces a meta with a suggestedNext array', () => {
+    const envelope = makeEnvelope({ taskId: 'T1234' });
+    const enriched = attachSuggestedNext(envelope, [
+      'cleo focus T1234',
+      'cleo verify T1234 --gate implemented',
+    ]);
+    expect(enriched.meta.suggestedNext).toEqual([
+      'cleo focus T1234',
+      'cleo verify T1234 --gate implemented',
+    ]);
+  });
+
+  it('does not mutate the input envelope', () => {
+    const envelope = makeEnvelope({ taskId: 'T1234' });
+    const before = envelope.meta.suggestedNext;
+    attachSuggestedNext(envelope, ['cleo focus T1234']);
+    expect(envelope.meta.suggestedNext).toBe(before);
+    expect(envelope.meta.suggestedNext).toBeUndefined();
+  });
+
+  it('returns a fresh meta object (referential isolation)', () => {
+    const envelope = makeEnvelope({ taskId: 'T1234' });
+    const enriched = attachSuggestedNext(envelope, ['cleo focus T1234']);
+    expect(enriched.meta).not.toBe(envelope.meta);
+    expect(enriched).not.toBe(envelope);
+  });
+
+  it('preserves all other meta fields verbatim', () => {
+    const envelope: CliEnvelope<{ taskId: string }> = {
+      success: true,
+      data: { taskId: 'T1234' },
+      meta: {
+        operation: 'tasks.show',
+        requestId: '11111111-1111-1111-1111-111111111111',
+        duration_ms: 42,
+        timestamp: '2026-05-24T12:34:56.000Z',
+        sessionId: 's-abc',
+        _nexus: { canonicalCommand: 'cleo nexus query' },
+        deprecated: { since: 'v1.0.0' },
+      },
+    };
+    const enriched = attachSuggestedNext(envelope, ['cleo focus T1234']);
+    expect(enriched.meta.operation).toBe('tasks.show');
+    expect(enriched.meta.requestId).toBe('11111111-1111-1111-1111-111111111111');
+    expect(enriched.meta.duration_ms).toBe(42);
+    expect(enriched.meta.timestamp).toBe('2026-05-24T12:34:56.000Z');
+    expect(enriched.meta.sessionId).toBe('s-abc');
+    expect(enriched.meta['_nexus']).toEqual({ canonicalCommand: 'cleo nexus query' });
+    expect(enriched.meta['deprecated']).toEqual({ since: 'v1.0.0' });
+  });
+
+  it('accepts an empty suggestions array and still produces a valid envelope', () => {
+    const envelope = makeEnvelope({ taskId: 'T1234' });
+    const enriched = attachSuggestedNext(envelope, []);
+    expect(enriched.success).toBe(true);
+    expect(enriched.data).toEqual({ taskId: 'T1234' });
+    expect(enriched.meta.suggestedNext).toEqual([]);
+    expect(Array.isArray(enriched.meta.suggestedNext)).toBe(true);
+  });
+
+  it('clones the suggestions array — caller mutation does not leak', () => {
+    const envelope = makeEnvelope({ taskId: 'T1234' });
+    const suggestions = ['cleo focus T1234'];
+    const enriched = attachSuggestedNext(envelope, suggestions);
+    suggestions.push('cleo verify T1234');
+    expect(enriched.meta.suggestedNext).toEqual(['cleo focus T1234']);
+  });
+
+  it('overwrites prior meta.suggestedNext rather than appending', () => {
+    const envelope: CliEnvelope<{ taskId: string }> = {
+      success: true,
+      data: { taskId: 'T1234' },
+      meta: {
+        operation: 'tasks.show',
+        requestId: '00000000-0000-0000-0000-000000000000',
+        duration_ms: 0,
+        timestamp: '2026-05-24T00:00:00.000Z',
+        suggestedNext: ['cleo show T1234'],
+      },
+    };
+    const enriched = attachSuggestedNext(envelope, ['cleo focus T1234']);
+    expect(enriched.meta.suggestedNext).toEqual(['cleo focus T1234']);
+  });
+});

--- a/packages/core/src/dispatch/suggested-next.ts
+++ b/packages/core/src/dispatch/suggested-next.ts
@@ -1,0 +1,68 @@
+/**
+ * `attachSuggestedNext` — envelope-construction helper for the
+ * envelope-wide `meta.suggestedNext` field promoted in T9920.
+ *
+ * Before T9920, only the nexus domain stamped a structured
+ * `meta._nexus.suggestedNext: ReadonlyArray<SuggestedNextOp>` block on
+ * dispatch responses. T9920 promotes a flat `ReadonlyArray<string>`
+ * projection to {@link CliMeta.suggestedNext} so every operation
+ * (mutate, query, decorator) can attach chained-reasoning hints
+ * without leaking the richer nexus-internal shape across domain
+ * boundaries.
+ *
+ * This helper is intentionally tiny — it deep-clones `envelope.meta`
+ * and overwrites `suggestedNext`. The original envelope is never
+ * mutated (immutability is a stronger guarantee than the type
+ * system's `Readonly` markers, which only prevent direct assignment).
+ *
+ * @module @cleocode/core/dispatch/suggested-next
+ *
+ * @epic T9919
+ * @task T9920
+ * @saga T9855
+ */
+
+import type { CliEnvelope } from '@cleocode/lafs';
+
+/**
+ * Attach a list of suggested follow-up CLI commands to an envelope's
+ * canonical {@link CliMeta.suggestedNext} field.
+ *
+ * The returned envelope is a shallow copy with a fresh `meta` object —
+ * the input envelope is never mutated. Existing meta fields (including
+ * `_nexus.suggestedNext` if present) are preserved verbatim; only the
+ * top-level `meta.suggestedNext` array is replaced.
+ *
+ * Empty arrays are preserved (not dropped) so callers can explicitly
+ * signal "I considered this and there are no follow-ups" — renderers
+ * are responsible for hiding the field from human output when empty.
+ *
+ * @typeParam T - The envelope's `data` payload type.
+ * @param envelope - The envelope to enrich. Not mutated.
+ * @param suggestions - Copy-pasteable CLI command strings the agent may run next.
+ * @returns A new envelope with `meta.suggestedNext` populated.
+ *
+ * @example
+ * ```ts
+ * import { attachSuggestedNext } from '@cleocode/core/dispatch/suggested-next';
+ *
+ * const enriched = attachSuggestedNext(envelope, [
+ *   'cleo focus T1234',
+ *   'cleo verify T1234 --gate implemented --evidence "commit:abc123"',
+ * ]);
+ * ```
+ *
+ * @public
+ */
+export function attachSuggestedNext<T>(
+  envelope: CliEnvelope<T>,
+  suggestions: ReadonlyArray<string>,
+): CliEnvelope<T> {
+  return {
+    ...envelope,
+    meta: {
+      ...envelope.meta,
+      suggestedNext: [...suggestions],
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -646,6 +646,8 @@ export { updateTask } from './tasks/update.js';
 
 // T9918 (Saga T9855 / E7.5) — OperationInputContract registry seed
 export { getInputContract, INPUT_CONTRACTS } from './dispatch/contracts/input-contracts.js';
+// T9920 (Saga T9855 / E8.1) — envelope-wide meta.suggestedNext attach helper
+export { attachSuggestedNext } from './dispatch/suggested-next.js';
 // T9915 (Saga T9855 / E7.2) — SSoT input validator over OperationInputContract
 export { validateOperationInput } from './dispatch/validation.js';
 // Setup wizard `--config-json` merger

--- a/packages/lafs/src/envelope.ts
+++ b/packages/lafs/src/envelope.ts
@@ -744,6 +744,21 @@ export interface CliMeta {
   timestamp: string;
   /** Active session identifier, if present. */
   sessionId?: string;
+  /**
+   * Array of suggested follow-up commands (LAFS hint for chained reasoning).
+   *
+   * Envelope-wide first-class field promoted from the nexus-only
+   * `meta._nexus.suggestedNext` structured form (Saga T9855 / E8 — T9920).
+   * Each entry is a copy-pasteable CLI string the agent can run next.
+   * Producers (operation handlers, decorators) SHOULD attach this via
+   * `attachSuggestedNext()` from `@cleocode/core/dispatch/suggested-next`.
+   *
+   * Renderers MUST drop this field from human output when the array is
+   * empty. Backward-compatible: existing `meta._nexus.suggestedNext`
+   * structured consumers continue to function unchanged — this field is
+   * the flat string projection layered alongside.
+   */
+  suggestedNext?: ReadonlyArray<string>;
   /** Extensible metadata; vendor fields go here. */
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary
- Promotes `meta.suggestedNext` from a nexus-only field to an envelope-wide `CliMeta` field — every CLI envelope can now carry a flat `ReadonlyArray<string>` LLM next-action hint.
- Adds `attachSuggestedNext(envelope, suggestions)` helper in `packages/core/src/dispatch/suggested-next.ts` (re-exported from `@cleocode/core`).
- Amends ADR-039 documenting the new field, its semantic, the backward-compatibility story with the pre-existing `meta._nexus.suggestedNext` structured form, and producer guidance.
- Foundation for E8 follow-on tasks (T9921 auto-populate on mutate ops, T9925 LAFS conformance assertion).

## Acceptance
- [x] `packages/lafs/src/envelope.ts` `CliMeta` adds optional `suggestedNext?: ReadonlyArray<string>`
- [x] Envelope-build helper accepts `suggestedNext` (tests cover empty + non-empty + immutability + clone)
- [x] ADR-039 amended with the new field + LLM-next-action-hint semantic
- [x] Existing `meta._nexus.suggestedNext` consumers untouched (backward compatible)
- [x] Unit tests assert: optional, `ReadonlyArray<string>`, never null, never nested objects

## Test plan
- [x] `pnpm biome check --write packages/contracts/src/ packages/core/src/dispatch/ packages/lafs/src/envelope.ts`
- [x] `pnpm -F @cleocode/contracts run build` + `pnpm -F @cleocode/lafs run build` + full topo `pnpm run build`
- [x] `pnpm exec vitest run packages/contracts/src/__tests__/cli-meta-suggested-next.test.ts packages/core/src/dispatch/__tests__/suggested-next.test.ts` — 12/12 pass

## Notes
- Test split: type-shape assertions live in `packages/contracts/` (which already depends on `@cleocode/lafs`); runtime helper exercise lives in `packages/core/` because contracts cannot depend on core (would break the layering contract).

Closes T9920
Saga: T9855
ADR: 039