### PR TITLE
chore(T10376): SG-DOCS-INTEGRITY saga closeout (E5.6)

### DIFF
--- a/.changeset/t10376-e5-saga-closeout.md
+++ b/.changeset/t10376-e5-saga-closeout.md
@@ -1,0 +1,6 @@
+---
+id: t10376-e5-saga-closeout
+tasks: [T10376]
+kind: chore
+summary: T10376 E5.6: SG-DOCS-INTEGRITY saga closeout handoff
+---


### PR DESCRIPTION
## Summary
- Closeout handoff doc published via `cleo docs add` (slug: `sg-docs-integrity-closeout`, attached to T10376)
- BRAIN observation captures saga-wide outcome (O-mpjk6i45-0)
- `cleo saga reconcile T10288` invoked: `no-op` — 4 of 5 epics still hold residual non-blocking long-tail pending children; reconcile will auto-fire once those flip

## Saga Scoreboard
- T10289 E1-DOCS-SLUG-NAMESPACE: 6/8 done (principal deliverables shipped)
- T10290 E2-DOCS-DOCKIND-WRITER-DEDUP: 4/7 done (principal deliverables shipped)
- T10291 E3-DOCS-CLI-HARDENING: 2/5 done (principal deliverables shipped)
- T10292 E4-DOCS-SDK-BOUNDARY: 6/6 done (fully closed)
- T10293 E5-DOCS-RETROACTIVE-NORMALIZE: 6/6 with T10376
- T9625 predecessor saga: closed 2026-05-24 via T10374

Total saga PRs merged: 22 in #576..#661 range.

## Saga
- Saga: T10288 SG-DOCS-INTEGRITY (final E5 task)
- Epic: T10293 E5-DOCS-RETROACTIVE-NORMALIZE

## Test plan
- [x] Closeout handoff fetched: `cleo docs fetch sg-docs-integrity-closeout`
- [x] BRAIN observation persisted: O-mpjk6i45-0
- [x] Saga reconcile output captured (no-op, members pending)