### PR TITLE
feat(core,docs): atomic ID numbering (T10159 / Saga T9855)

### DIFF
--- a/.changeset/t10159-atomic-id-numbering.md
+++ b/.changeset/t10159-atomic-id-numbering.md
@@ -1,0 +1,6 @@
+---
+id: t10159-atomic-id-numbering
+tasks: [T10159]
+kind: feat
+summary: core,docs: atomic ID-numbering utility — replaces fs-readdir slug allocation (T10159 / Saga T9855 / E12; absorbs T10153)
+---

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -55,6 +55,8 @@ import type {
 } from '@cleocode/core/internal';
 import {
   type AttachmentBackend,
+  AUTO_TOKEN,
+  allocateAutoSlugForDispatch,
   createAttachmentStore,
   createAttachmentStoreV2,
   type DerefResult,
@@ -849,14 +851,28 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       );
     }
 
-    // T9636 — validate slug (shape only; uniqueness is checked by the store).
+    // T10159 (Saga T9855 / Epic T10157) — resolve the literal `AUTO` token
+    // BEFORE shape validation. The slug `adr-AUTO-saga-fix` carries an
+    // uppercase `AUTO` placeholder that would otherwise fail the strict
+    // lowercase-kebab regex. `allocateAutoSlug` atomically scans the
+    // `attachments` table for the kind's existing numeric portion (e.g.
+    // adr-077-...) and substitutes the next available number into the
+    // slug. Non-AUTO slugs pass through unchanged.
     let slug: string | undefined;
     if (rawSlug !== undefined) {
-      const check = validateSlug(rawSlug);
+      let candidate = rawSlug as string;
+      if (typeof candidate === 'string' && candidate.includes(AUTO_TOKEN)) {
+        const allocated = await allocateAutoSlugForDispatch(getProjectRoot(), {
+          kind: typeof rawType === 'string' ? rawType : '',
+          rawSlug: candidate,
+        });
+        candidate = allocated.resolvedSlug;
+      }
+      const check = validateSlug(candidate);
       if (!check.valid) {
         return lafsError('E_INVALID_SLUG', check.reason, 'add');
       }
-      slug = rawSlug as string;
+      slug = candidate;
     }
 
     // T9637 — validate type against the closed taxonomy set.

--- a/packages/core/src/docs/__tests__/numbering.test.ts
+++ b/packages/core/src/docs/__tests__/numbering.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for the atomic ID-numbering utility (T10159 — absorbs T10153).
+ *
+ * Each test uses an isolated temporary `.cleo/` so the tasks.db singleton is
+ * reset between runs (same pattern as slug-allocator.test.ts).
+ *
+ * @task T10159
+ * @epic T10157
+ * @saga T9855
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let tempDir: string;
+
+/**
+ * Seed an attachment row with the given `slug` so subsequent resolver calls
+ * see it as occupied. Uses the canonical `createAttachmentStore` write path
+ * so the row passes through the same schema + slug-pre-check that real
+ * writes do.
+ */
+async function seedSlug(slug: string, content: string): Promise<void> {
+  const { createAttachmentStore } = await import('../../store/attachment-store.js');
+  const store = createAttachmentStore();
+  await store.put(
+    Buffer.from(content, 'utf-8'),
+    { kind: 'blob', storageKey: '', mime: 'text/markdown', size: content.length },
+    'task',
+    'T9999',
+    'numbering-test',
+    undefined,
+    { slug, type: 'adr' },
+  );
+}
+
+describe('resolveNextDocNumber + applyAutoSlug (T10159)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-numbering-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+    const { _resetNumberingCache_TESTING_ONLY } = await import('../numbering.js');
+    _resetNumberingCache_TESTING_ONLY();
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+    const { _resetNumberingCache_TESTING_ONLY } = await import('../numbering.js');
+    _resetNumberingCache_TESTING_ONLY();
+    delete process.env['CLEO_DIR'];
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('resolves the next ADR number to 1 when no ADR rows exist', async () => {
+    const { resolveNextDocNumber } = await import('../numbering.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    const result = await resolveNextDocNumber('adr');
+    expect(result.kind).toBe('adr');
+    expect(result.sequence).toBe(1);
+  });
+
+  it('returns max+1 when prior ADR rows exist (single seed)', async () => {
+    const { resolveNextDocNumber } = await import('../numbering.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    await seedSlug('adr-077-saga-first-class', 'adr seed 077');
+
+    const result = await resolveNextDocNumber('adr');
+    expect(result.sequence).toBe(78);
+  });
+
+  it('returns max+1 across a mixed corpus (3-digit + 4-digit)', async () => {
+    const { resolveNextDocNumber } = await import('../numbering.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    await seedSlug('adr-001-first', 'a');
+    await seedSlug('adr-050-mid', 'b');
+    await seedSlug('adr-1234-far-future', 'c');
+
+    const result = await resolveNextDocNumber('adr');
+    expect(result.sequence).toBe(1235);
+  });
+
+  it('returns sequence:0 for non-numbered DocKinds (note)', async () => {
+    const { resolveNextDocNumber } = await import('../numbering.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    const result = await resolveNextDocNumber('note');
+    expect(result.kind).toBe('note');
+    expect(result.sequence).toBe(0);
+  });
+
+  it('applyAutoSlug pads adr numbers to 3 digits', async () => {
+    const { applyAutoSlug } = await import('../numbering.js');
+    expect(applyAutoSlug('adr-AUTO-saga-fix', 78, 'adr')).toBe('adr-078-saga-fix');
+    expect(applyAutoSlug('adr-AUTO-foo', 1, 'adr')).toBe('adr-001-foo');
+  });
+
+  it('applyAutoSlug widens past pad width for large N', async () => {
+    const { applyAutoSlug } = await import('../numbering.js');
+    expect(applyAutoSlug('adr-AUTO-overflow', 1235, 'adr')).toBe('adr-1235-overflow');
+  });
+
+  it('applyAutoSlug passes through unchanged when AUTO not present', async () => {
+    const { applyAutoSlug } = await import('../numbering.js');
+    expect(applyAutoSlug('adr-077-already-numbered', 99, 'adr')).toBe('adr-077-already-numbered');
+  });
+
+  it('applyAutoSlug does NOT pad when no kind hint is supplied (changeset shape)', async () => {
+    const { applyAutoSlug } = await import('../numbering.js');
+    expect(applyAutoSlug('t9999-AUTO-foo', 3)).toBe('t9999-3-foo');
+  });
+
+  it('parseSlugSequence extracts (kind, sequence, remainder) from a numbered adr slug', async () => {
+    const { parseSlugSequence } = await import('../numbering.js');
+    const parsed = parseSlugSequence('adr-078-saga-first-class');
+    expect(parsed).not.toBeNull();
+    if (parsed) {
+      expect(parsed.kind).toBe('adr');
+      expect(parsed.sequence).toBe(78);
+      expect(parsed.remainder).toBe('saga-first-class');
+    }
+  });
+
+  it('parseSlugSequence returns null for unprefixed slugs', async () => {
+    const { parseSlugSequence } = await import('../numbering.js');
+    expect(parseSlugSequence('foo')).toBeNull();
+    expect(parseSlugSequence('not-an-adr')).toBeNull();
+  });
+
+  it('parseSlugSequence returns null for short-digit adr slugs (must be 3-4 digits)', async () => {
+    const { parseSlugSequence } = await import('../numbering.js');
+    expect(parseSlugSequence('adr-7-too-short')).toBeNull();
+  });
+});
+
+describe('allocateAutoSlug — one-shot resolver (T10159)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-numbering-alloc-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+    delete process.env['CLEO_DIR'];
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('rewrites adr-AUTO-foo to adr-NNN-foo using the kind-canonical pad width', async () => {
+    const { allocateAutoSlug } = await import('../numbering.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    await seedSlug('adr-077-prior', 'seed');
+
+    const result = await allocateAutoSlug('adr', 'adr-AUTO-saga-fix');
+    expect(result).toBe('adr-078-saga-fix');
+  });
+
+  it('rewrites t<id>-AUTO-foo using a slug-derived descriptor (changeset shape)', async () => {
+    const { allocateAutoSlug } = await import('../numbering.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    const result = await allocateAutoSlug('changeset', 't9999-AUTO-foo');
+    // No prior t9999-N rows → starts at 1, no padding for slug-derived
+    // descriptors.
+    expect(result).toBe('t9999-1-foo');
+  });
+
+  it('returns the input unchanged when AUTO is absent', async () => {
+    const { allocateAutoSlug } = await import('../numbering.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    const result = await allocateAutoSlug('adr', 'adr-123-explicit');
+    expect(result).toBe('adr-123-explicit');
+  });
+
+  it('5 concurrent allocations return 5 DISTINCT sequence numbers (no duplicates)', async () => {
+    const { allocateAutoSlug } = await import('../numbering.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    // Seed one ADR so the starting point is non-trivial.
+    await seedSlug('adr-077-prior', 'seed');
+
+    const slugs = await Promise.all([
+      allocateAutoSlug('adr', 'adr-AUTO-a'),
+      allocateAutoSlug('adr', 'adr-AUTO-b'),
+      allocateAutoSlug('adr', 'adr-AUTO-c'),
+      allocateAutoSlug('adr', 'adr-AUTO-d'),
+      allocateAutoSlug('adr', 'adr-AUTO-e'),
+    ]);
+
+    // Extract the numeric portion of each result.
+    const numbers = slugs
+      .map((s) => /^adr-(\d{3,4})-/.exec(s)?.[1])
+      .filter((d): d is string => d !== undefined)
+      .map((d) => Number.parseInt(d, 10));
+
+    expect(numbers).toHaveLength(5);
+    expect(new Set(numbers).size).toBe(5);
+    // Every allocation must yield a number STRICTLY GREATER than the seed.
+    for (const n of numbers) {
+      expect(n).toBeGreaterThan(77);
+    }
+  });
+});

--- a/packages/core/src/docs/numbering.ts
+++ b/packages/core/src/docs/numbering.ts
@@ -1,0 +1,509 @@
+/**
+ * Atomic ID-numbering utility for docs slugs that carry a numeric portion.
+ *
+ * ## Why this module exists
+ *
+ * Before this module the `cleo docs add` path for kinds like ADR (slug
+ * pattern `adr-<NNN>-<rest>`) had no canonical way to pick the next number.
+ * Authoring agents resorted to filesystem `readdir(docs/adr/)` + parse
+ * `adr-<NNN>-...` → max → +1 — race-prone (two concurrent adds pick the
+ * same N) and inconsistent with the SSoT canon (the `attachments` table is
+ * the authority, not the publish-mirror directory).
+ *
+ * T10153 (the original sub-task that asked for `cleo docs add --type adr
+ * --next` semantics) is ABSORBED here per T10159 — the new entry point
+ * accepts an `AUTO` token in the caller-supplied slug, resolves it via
+ * a SQLite `BEGIN IMMEDIATE` transaction over the `attachments` table,
+ * and returns a fully-formed slug ready for {@link reserveSlug}.
+ *
+ * ## Contract
+ *
+ *   1. {@link resolveNextDocNumber}(kind, opts) — inspects every existing
+ *      `attachments` row whose `slug` matches the kind's pattern, parses
+ *      the numeric portion (per the regex captured at the `AUTO` position
+ *      derived from the kind's `entityIdPattern`), and returns
+ *      `max(seen) + 1` (or `1` when the table is empty).
+ *
+ *   2. {@link applyAutoSlug}(rawSlug, resolvedNumber) — replaces the
+ *      literal `AUTO` token in the caller-supplied slug with the resolved
+ *      number, zero-padding to the kind's expected width when the pattern
+ *      requires it (e.g. `adr-\d{3,4}` → pad to 3 digits).
+ *
+ *   3. {@link allocateAutoSlug}(kind, rawSlug, opts) — the high-level
+ *      convenience that combines both: detect `AUTO`, resolve, apply,
+ *      return the final slug. The DB probe + slug assembly happen inside
+ *      a single `BEGIN IMMEDIATE` transaction so two concurrent
+ *      `cleo docs add --slug adr-AUTO-foo` invocations in the same
+ *      process never pick the same N.
+ *
+ * ## Why BEGIN IMMEDIATE
+ *
+ * `node:sqlite` does not expose advisory-lock primitives. The `attachments`
+ * partial UNIQUE INDEX on `slug` is the cross-process backstop, but it
+ * fires LATE — after the writer has already chosen a number. By taking
+ * a `BEGIN IMMEDIATE` lock on the database BEFORE the MAX query we ensure
+ * that no other write transaction can sneak in between our read and the
+ * imminent INSERT performed by `attachmentStore.put`. Same-process callers
+ * additionally serialise via {@link reserveSlug} (per-slug Mutex) once the
+ * slug is fully formed.
+ *
+ * ## Pad-width policy
+ *
+ * Each DocKind's `entityIdPattern` (declared in `@cleocode/contracts`)
+ * encodes the expected numeric-portion width — e.g. `adr-\d{3,4}` means
+ * "3 or 4 digits". We pad to the LOWER bound (3) so newly-allocated
+ * numbers stay sortable lexicographically with the legacy corpus, and
+ * naturally widen to 4 once a project crosses N=1000 without any
+ * migration.
+ *
+ * Unknown / non-numeric DocKinds (e.g. `note`, `handoff`) — return
+ * `{ kind, sequence: 0 }` from {@link resolveNextDocNumber} and pass
+ * through the slug unchanged from {@link applyAutoSlug}.
+ *
+ * @task T10159 (absorbs T10153)
+ * @epic T10157
+ * @saga T9855
+ * @adr ADR-076 (canon routing)
+ */
+
+import { type AnyColumn, like, sql } from 'drizzle-orm';
+import { attachments } from '../store/schema/attachments.js';
+import { getDb, getNativeTasksDb } from '../store/sqlite.js';
+
+// ─── Public surface ───────────────────────────────────────────────────────────
+
+/**
+ * Options accepted by every public entry point.
+ *
+ * `cwd` is forwarded to `getDb(cwd)` — same convention used by
+ * {@link reserveSlug}.
+ */
+export interface DocNumberingOptions {
+  /** Optional working directory for `.cleo/` resolution. */
+  readonly cwd?: string;
+}
+
+/**
+ * Result of {@link resolveNextDocNumber}.
+ *
+ * `sequence === 0` signals that the kind does NOT have a numeric portion
+ * (the caller should leave the slug unchanged).
+ */
+export interface ResolveNextDocNumberResult {
+  /** The DocKind that was queried (echoed back for caller convenience). */
+  readonly kind: string;
+  /** Next available sequence number, or `0` for non-numeric kinds. */
+  readonly sequence: number;
+}
+
+/**
+ * Per-kind numbering descriptor — the surface area the resolver needs.
+ *
+ * Kept inline (rather than re-exported from `@cleocode/contracts`) because
+ * the contracts module declares only `entityIdPattern` and the LIKE prefix
+ * derivation logic is a numbering concern, not a taxonomy concern. The
+ * map below is intentionally narrow: only kinds that have an `AUTO` slot
+ * appear here.
+ */
+interface NumberingDescriptor {
+  /** SQL LIKE prefix used to narrow the `attachments` scan. */
+  readonly likePrefix: string;
+  /** Regex applied to each candidate slug — group 1 MUST be the digits. */
+  readonly extractRegex: RegExp;
+  /** Minimum digit width — controls zero-padding by {@link applyAutoSlug}. */
+  readonly padWidth: number;
+}
+
+/**
+ * Canonical numbering map.
+ *
+ * Each entry mirrors the kind's `entityIdPattern` in `BUILTIN_DOC_KINDS`:
+ *
+ *   - `adr`        → `adr-\d{3,4}-...`   (pad to 3, accept 4)
+ *   - `changeset`  → `t<id>-\d+-...`     (kind-only entry would over-match;
+ *                                          the AUTO position depends on the
+ *                                          caller-supplied prefix, so the
+ *                                          changeset row is consulted at
+ *                                          `allocateAutoSlug`-time rather
+ *                                          than from this map)
+ *
+ * Only kinds with a fixed prefix-then-digits shape sit here. Variable-prefix
+ * kinds (changeset, where the prefix carries the task ID) are resolved by
+ * deriving the descriptor from the raw input slug at call-time.
+ */
+const NUMBERING_BY_KIND: ReadonlyMap<string, NumberingDescriptor> = new Map<
+  string,
+  NumberingDescriptor
+>([
+  [
+    'adr',
+    {
+      likePrefix: 'adr-',
+      extractRegex: /^adr-(\d{3,4})-/,
+      padWidth: 3,
+    },
+  ],
+]);
+
+/**
+ * Literal token a caller embeds in a slug to ask the allocator to fill in
+ * the next sequence number. The literal is intentionally short, ALL-CAPS
+ * (to never collide with a valid kebab-case identifier), and unique enough
+ * that an accidental match is implausible.
+ */
+export const AUTO_TOKEN = 'AUTO';
+
+// ─── Slug-shape helpers ───────────────────────────────────────────────────────
+
+/**
+ * Pad `n` to at least `width` digits (left-pad with `'0'`). When `n` already
+ * exceeds the width the value is returned unchanged so historical 4-digit
+ * ADRs continue to widen naturally without a migration.
+ *
+ * @param n - Numeric value to render.
+ * @param width - Minimum digit count.
+ * @returns Zero-padded string representation.
+ */
+function padNumber(n: number, width: number): string {
+  const str = String(n);
+  if (str.length >= width) return str;
+  return str.padStart(width, '0');
+}
+
+/**
+ * Derive an inline {@link NumberingDescriptor} from a raw slug that uses
+ * the `AUTO` token.
+ *
+ * Algorithm:
+ *
+ *   1. Split the slug on the literal `AUTO` token. The portion BEFORE
+ *      `AUTO` is the prefix used both for the SQL LIKE probe and for
+ *      regex anchoring.
+ *   2. The portion AFTER `AUTO` is informational only — different rows
+ *      may have different suffixes, so the regex captures `(\d+)` then
+ *      requires a hyphen.
+ *   3. `padWidth` falls back to `1` (no padding) for inline descriptors —
+ *      explicit kind-level descriptors carry the canonical width.
+ *
+ * Returns `null` when the slug does not contain `AUTO`.
+ *
+ * @param rawSlug - Slug supplied by the caller (e.g. `adr-AUTO-foo`).
+ * @returns Numbering descriptor or `null`.
+ */
+function deriveDescriptorFromSlug(rawSlug: string): NumberingDescriptor | null {
+  const idx = rawSlug.indexOf(AUTO_TOKEN);
+  if (idx === -1) return null;
+  const prefix = rawSlug.slice(0, idx);
+  if (prefix.length === 0) return null;
+  // Anchor the regex with the literal prefix; escape regex metachars.
+  const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return {
+    likePrefix: prefix,
+    extractRegex: new RegExp(`^${escaped}(\\d+)`),
+    padWidth: 1,
+  };
+}
+
+// ─── Slug parser (T10159 acceptance) ──────────────────────────────────────────
+
+/**
+ * Parse a numbered slug into its `(kind, sequence, remainder)` parts.
+ *
+ * Recognises the canonical `adr-<NNN>-<rest>` shape today. Returns `null`
+ * for unprefixed slugs or slugs whose leading token does not match any
+ * known numbering pattern.
+ *
+ * @param slug - Slug to inspect.
+ * @returns Triple or `null`.
+ */
+export function parseSlugSequence(
+  slug: string,
+): { kind: string; sequence: number; remainder: string } | null {
+  for (const [kind, desc] of NUMBERING_BY_KIND.entries()) {
+    const match = desc.extractRegex.exec(slug);
+    if (!match) continue;
+    const digits = match[1];
+    if (digits === undefined) continue;
+    const sequence = Number.parseInt(digits, 10);
+    if (!Number.isFinite(sequence)) continue;
+    const remainder = slug.slice(match[0].length);
+    return { kind, sequence, remainder };
+  }
+  return null;
+}
+
+// ─── DB inspection (atomic) ───────────────────────────────────────────────────
+
+/**
+ * Module-level promise chain used as an in-process async Mutex around
+ * the BEGIN IMMEDIATE / MAX / COMMIT triple.
+ *
+ * `node:sqlite` uses ONE connection per process (the singleton returned
+ * by `getNativeTasksDb()`), so two concurrent `BEGIN IMMEDIATE` calls on
+ * the same connection raise `cannot start a transaction within a
+ * transaction`. The Mutex serialises same-process callers so each
+ * resolver sees a consistent MAX snapshot. Cross-process safety is
+ * provided by the SQLite engine's own write-locking + the partial
+ * UNIQUE INDEX on `attachments.slug` as the late-bound backstop.
+ */
+let scanLock: Promise<void> = Promise.resolve();
+
+/**
+ * Acquire {@link scanLock}, run `fn`, then release.
+ *
+ * @param fn - Async function to execute under the lock.
+ * @returns Whatever `fn` returns.
+ */
+async function withScanLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = scanLock;
+  let release!: () => void;
+  scanLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+/**
+ * In-process "highest sequence handed out" cache, keyed by
+ * `<cwd>::<likePrefix>`. The DB MAX is the floor; the cache prevents
+ * two concurrent same-process callers from picking the same N when
+ * neither has reached `attachmentStore.put` yet.
+ *
+ * The cache is bounded by the count of distinct (cwd, kind) pairs used
+ * in a single process — practically tiny. It is cleared in tests via
+ * {@link _resetNumberingCache_TESTING_ONLY}.
+ */
+const inFlightMax = new Map<string, number>();
+
+/** Reset in-process state — test-only escape hatch. */
+export function _resetNumberingCache_TESTING_ONLY(): void {
+  inFlightMax.clear();
+}
+
+/** Build the cache key for a given descriptor + cwd. */
+function cacheKey(descriptor: NumberingDescriptor, cwd: string | undefined): string {
+  return `${cwd ?? ''}::${descriptor.likePrefix}`;
+}
+
+/**
+ * Scan `attachments.slug` for rows matching `descriptor.likePrefix` and
+ * extract the maximum numeric portion captured by `descriptor.extractRegex`.
+ *
+ * Wrapped in BOTH a per-process Mutex AND a `BEGIN IMMEDIATE` transaction:
+ *
+ *   1. The Mutex serialises same-process callers so the single
+ *      `node:sqlite` connection never sees nested `BEGIN IMMEDIATE` calls
+ *      (which would raise `cannot start a transaction within a transaction`).
+ *   2. `BEGIN IMMEDIATE` upgrades to a RESERVED lock at the SQLite level,
+ *      so cross-process writers either wait or fail-fast with SQLITE_BUSY.
+ *
+ * Cross-process safety beyond the IMMEDIATE window is provided by the
+ * partial UNIQUE INDEX on `attachments.slug` — a losing process gets a
+ * constraint violation at INSERT time which the writer surfaces as the
+ * same `SlugCollisionError` envelope as any other late-bound conflict.
+ *
+ * @param descriptor - Numbering descriptor (kind-canonical or slug-derived).
+ * @param cwd - Optional working directory for `.cleo/` resolution.
+ * @returns Next available sequence (max + 1, or `1` when no rows match).
+ */
+async function scanMaxSequenceAtomically(
+  descriptor: NumberingDescriptor,
+  cwd: string | undefined,
+): Promise<number> {
+  return withScanLock(async () => {
+    const db = await getDb(cwd);
+    const nativeDb = getNativeTasksDb();
+    if (!nativeDb) throw new Error('Database not initialized');
+
+    let max = 0;
+    nativeDb.prepare('BEGIN IMMEDIATE').run();
+    try {
+      const rows = await db
+        .select({ slug: attachments.slug as AnyColumn })
+        .from(attachments)
+        .where(like(attachments.slug, `${descriptor.likePrefix}%`))
+        .all();
+      for (const row of rows) {
+        const slug = row.slug;
+        if (typeof slug !== 'string') continue;
+        const match = descriptor.extractRegex.exec(slug);
+        if (!match) continue;
+        const digits = match[1];
+        if (digits === undefined) continue;
+        const value = Number.parseInt(digits, 10);
+        if (Number.isFinite(value) && value > max) {
+          max = value;
+        }
+      }
+    } finally {
+      // Always release the lock — the writer takes its own fresh
+      // `BEGIN IMMEDIATE` when it actually performs the INSERT.
+      nativeDb.prepare('COMMIT').run();
+    }
+    // Touch `sql` so future inline-SQL extensions stay tree-shake-safe.
+    void sql;
+
+    // Combine the DB MAX with the in-process "highest handed out" cache
+    // so concurrent same-process callers get DISTINCT sequence numbers
+    // even when the imminent INSERTs haven't landed yet.
+    const key = cacheKey(descriptor, cwd);
+    const prevHandedOut = inFlightMax.get(key) ?? 0;
+    const next = Math.max(max, prevHandedOut) + 1;
+    inFlightMax.set(key, next);
+    return next;
+  });
+}
+
+// ─── Public entry points ──────────────────────────────────────────────────────
+
+/**
+ * Resolve the next sequence number for `kind`.
+ *
+ * Returns `{ kind, sequence: 0 }` for kinds that do not carry a numeric
+ * portion (e.g. `note`, `handoff`). Caller should leave the slug unchanged
+ * in that case.
+ *
+ * @param kind - DocKind to query (e.g. `'adr'`).
+ * @param opts - Optional cwd.
+ * @returns The next sequence number for this kind.
+ */
+export async function resolveNextDocNumber(
+  kind: string,
+  opts?: DocNumberingOptions,
+): Promise<ResolveNextDocNumberResult> {
+  const descriptor = NUMBERING_BY_KIND.get(kind);
+  if (!descriptor) {
+    return { kind, sequence: 0 };
+  }
+  const sequence = await scanMaxSequenceAtomically(descriptor, opts?.cwd);
+  return { kind, sequence };
+}
+
+/**
+ * Replace the `AUTO` token in `rawSlug` with `resolvedNumber`.
+ *
+ * Pad width is selected from the kind-canonical descriptor when one
+ * exists (so `adr` always pads to 3+ digits); slug-derived descriptors
+ * pad to 1 (no padding) since the AUTO position there is arbitrary.
+ *
+ * When `rawSlug` does not contain `AUTO` the input is returned unchanged.
+ *
+ * @param rawSlug - Slug supplied by the caller.
+ * @param resolvedNumber - Sequence number to substitute.
+ * @param kind - Optional DocKind — selects the canonical pad width.
+ * @returns Slug with `AUTO` replaced by the (padded) number.
+ */
+export function applyAutoSlug(rawSlug: string, resolvedNumber: number, kind?: string): string {
+  if (!rawSlug.includes(AUTO_TOKEN)) return rawSlug;
+  let padWidth = 1;
+  if (kind !== undefined) {
+    const desc = NUMBERING_BY_KIND.get(kind);
+    if (desc !== undefined) padWidth = desc.padWidth;
+  }
+  return rawSlug.replace(AUTO_TOKEN, padNumber(resolvedNumber, padWidth));
+}
+
+/**
+ * One-shot helper: detect `AUTO` in `rawSlug`, resolve the next sequence
+ * atomically, and return the fully-formed slug.
+ *
+ * Resolution path:
+ *
+ *   1. If the slug does not contain `AUTO`, return it unchanged.
+ *   2. If the slug starts with the kind's canonical prefix (e.g.
+ *      `adr-AUTO-...` with `kind === 'adr'`), use the kind descriptor for
+ *      width-correct padding.
+ *   3. Otherwise derive an inline descriptor from the slug itself — used
+ *      for variable-prefix kinds like `changeset` where the leading
+ *      `t<id>-` portion is part of the slug, not the kind.
+ *
+ * The DB probe runs inside `BEGIN IMMEDIATE` so two concurrent calls in
+ * the same process cannot pick the same N. Cross-process serialisation
+ * relies on the `attachments.slug` partial UNIQUE INDEX as the backstop.
+ *
+ * @param kind - DocKind hint (used for canonical pad width).
+ * @param rawSlug - Slug containing the `AUTO` token.
+ * @param opts - Optional cwd.
+ * @returns Slug with `AUTO` replaced — ready to forward to {@link reserveSlug}.
+ */
+export async function allocateAutoSlug(
+  kind: string,
+  rawSlug: string,
+  opts?: DocNumberingOptions,
+): Promise<string> {
+  if (!rawSlug.includes(AUTO_TOKEN)) return rawSlug;
+
+  // Prefer the kind-canonical descriptor when the slug starts with its
+  // expected prefix — keeps pad width consistent with legacy corpus.
+  const kindDescriptor = NUMBERING_BY_KIND.get(kind);
+  let descriptor: NumberingDescriptor | null = null;
+  if (kindDescriptor !== undefined && rawSlug.startsWith(kindDescriptor.likePrefix)) {
+    descriptor = kindDescriptor;
+  } else {
+    descriptor = deriveDescriptorFromSlug(rawSlug);
+  }
+  if (descriptor === null) {
+    // No way to resolve — return the slug as-is so the caller surfaces
+    // a downstream validation error rather than silently writing AUTO.
+    return rawSlug;
+  }
+
+  const next = await scanMaxSequenceAtomically(descriptor, opts?.cwd);
+  return rawSlug.replace(AUTO_TOKEN, padNumber(next, descriptor.padWidth));
+}
+
+// ─── ADR-057-compliant dispatch entry-point wrapper ───────────────────────────
+
+/**
+ * Params for {@link allocateAutoSlugForDispatch} — ADR-057 uniform signature.
+ *
+ * @task T10159
+ */
+export interface AllocateAutoSlugForDispatchParams {
+  /** DocKind hint — selects the canonical pad width when applicable. */
+  readonly kind: string;
+  /** Raw slug containing the `AUTO` token (or any slug — pass-through if no AUTO). */
+  readonly rawSlug: string;
+}
+
+/**
+ * Result of {@link allocateAutoSlugForDispatch} — the fully-resolved slug.
+ *
+ * Declared as an interface so the lint script's `<Op>Result` heuristic
+ * recognises it as a typed contract surface.
+ *
+ * @task T10159
+ */
+export interface AllocateAutoSlugForDispatchResult {
+  /** Slug with `AUTO` replaced (or input pass-through). */
+  readonly resolvedSlug: string;
+}
+
+/**
+ * Dispatch entry-point wrapper around {@link allocateAutoSlug} conforming
+ * to the ADR-057 uniform `(projectRoot, params)` signature.
+ *
+ * The wrapper exists so the `cleo docs add` dispatch handler can `await
+ * allocateAutoSlugForDispatch(projectRoot, params)` without tripping the
+ * `lint-contracts-core-ssot` L1 rule. `projectRoot` is forwarded to
+ * {@link allocateAutoSlug} as the `cwd` option for path resolution.
+ *
+ * @param projectRoot - Working directory for `.cleo/` resolution.
+ * @param params - The DocKind hint + raw slug pair.
+ * @returns The resolved slug wrapped in an envelope.
+ * @task T10159
+ */
+export async function allocateAutoSlugForDispatch(
+  projectRoot: string,
+  params: AllocateAutoSlugForDispatchParams,
+): Promise<AllocateAutoSlugForDispatchResult> {
+  const resolvedSlug = await allocateAutoSlug(params.kind, params.rawSlug, {
+    cwd: projectRoot,
+  });
+  return { resolvedSlug };
+}

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -222,6 +222,22 @@ export type {
   MigrationManifestEntry,
 } from './docs/migrate-agent-outputs.js';
 export { migrateAgentOutputs } from './docs/migrate-agent-outputs.js';
+// Atomic ID-numbering utility (T10159 — absorbs T10153 / Saga T9855 / Epic T10157)
+export type {
+  AllocateAutoSlugForDispatchParams,
+  AllocateAutoSlugForDispatchResult,
+  DocNumberingOptions,
+  ResolveNextDocNumberResult,
+} from './docs/numbering.js';
+export {
+  _resetNumberingCache_TESTING_ONLY,
+  AUTO_TOKEN,
+  allocateAutoSlug,
+  allocateAutoSlugForDispatch,
+  applyAutoSlug,
+  parseSlugSequence,
+  resolveNextDocNumber,
+} from './docs/numbering.js';
 // Docs publish-pr foundation + new-doc flow (T9716 + T9718 — T9644 / Epic T9630 / Saga T9625)
 export type {
   ProvisionResult,


### PR DESCRIPTION
## Summary
- Adds atomic SQLite-transactional ID-numbering utility for docs slugs (`adr-AUTO-foo` → `adr-078-foo`).
- BEGIN IMMEDIATE + per-process Mutex + in-flight cache prevents 5+ concurrent allocations from colliding.
- Wires AUTO-token resolution into `cleo docs add` dispatch BEFORE shape validation.
- Absorbs T10153.

## What's new
- `packages/core/src/docs/numbering.ts` — `resolveNextDocNumber`, `applyAutoSlug`, `allocateAutoSlug`, `allocateAutoSlugForDispatch` (ADR-057 uniform signature), `parseSlugSequence`.
- `packages/core/src/docs/__tests__/numbering.test.ts` — 15 tests including 5-way concurrency check.
- `packages/core/src/internal.ts` — barrel exports.
- `packages/cleo/src/dispatch/domains/docs.ts` — wires AUTO resolution into the `docs.add` handler.

## Test plan
- [x] `pnpm biome check --write packages/core/src/docs/ packages/cleo/src/dispatch/domains/docs.ts` clean.
- [x] `pnpm -F @cleocode/core run build` clean.
- [x] `pnpm -F @cleocode/cleo run build` clean.
- [x] `pnpm exec vitest run --project @cleocode/core src/docs/` — 204 tests pass (18 files).
- [x] `node scripts/lint-contracts-core-ssot.mjs` — clean.
- [x] Concurrency test: 5 parallel `allocateAutoSlug('adr', 'adr-AUTO-X')` returns 5 distinct sequence numbers.

Closes T10159
Saga: T9855
ADR: 076