### PR TITLE
refactor: retrofit tasks.* to OperationInputContract (T9917 / closes Epic T9903)

### DIFF
--- a/.changeset/t9917-tasks-input-contract-retrofit.md
+++ b/.changeset/t9917-tasks-input-contract-retrofit.md
@@ -1,0 +1,6 @@
+---
+id: t9917-tasks-input-contract-retrofit
+tasks: [T9917]
+kind: refactor
+summary: Retrofit tasks.add, tasks.add-batch, and tasks.update to OperationInputContract (T9917 / closes Epic T9903 / Saga T9855)
+---

--- a/packages/cleo/src/cli/__tests__/add-batch.test.ts
+++ b/packages/cleo/src/cli/__tests__/add-batch.test.ts
@@ -18,10 +18,11 @@ import { setFormatContext } from '../format-context.js';
 // Module mocks — hoisted so they apply before any import resolution
 // ---------------------------------------------------------------------------
 
-const { dispatchRawMock, existsSyncMock, readFileSyncMock } = vi.hoisted(() => ({
+const { dispatchRawMock, existsSyncMock, readFileSyncMock, readFileMock } = vi.hoisted(() => ({
   dispatchRawMock: vi.fn(),
   existsSyncMock: vi.fn(),
   readFileSyncMock: vi.fn(),
+  readFileMock: vi.fn(),
 }));
 
 vi.mock('../../dispatch/adapters/cli.js', () => ({
@@ -35,6 +36,18 @@ vi.mock('node:fs', async (importOriginal) => {
     ...original,
     existsSync: existsSyncMock,
     readFileSync: readFileSyncMock,
+  };
+});
+
+// T9917: add-batch.ts now reads input through `collectMutateInput` which
+// uses `readFile` from `node:fs/promises`. Mock it in lockstep with the
+// legacy `node:fs` mocks so the existing test fixtures continue to work.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...original,
+    default: { ...original, readFile: readFileMock },
+    readFile: readFileMock,
   };
 });
 
@@ -156,7 +169,7 @@ describe('addBatchCommand dispatch behaviour (file input)', () => {
 
   it('calls dispatchRaw exactly once for file input with all tasks', async () => {
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue(
+    readFileMock.mockResolvedValue(
       JSON.stringify([
         { title: 'Task A', acceptance: ['a'] },
         { title: 'Task B', acceptance: ['b'] },
@@ -187,7 +200,7 @@ describe('addBatchCommand dispatch behaviour (file input)', () => {
 
   it('forwards dryRun: true when --dry-run is set', async () => {
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue(JSON.stringify([{ title: 'T', acceptance: ['a'] }]));
+    readFileMock.mockResolvedValue(JSON.stringify([{ title: 'T', acceptance: ['a'] }]));
     dispatchRawMock.mockResolvedValueOnce(makeSuccessEnvelope([]));
 
     await invokeAddBatch({ file: '/tmp/tasks.json', 'dry-run': true });
@@ -202,7 +215,7 @@ describe('addBatchCommand dispatch behaviour (file input)', () => {
 
   it('forwards defaultParent when --parent is set', async () => {
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue(JSON.stringify([{ title: 'Child', acceptance: ['a'] }]));
+    readFileMock.mockResolvedValue(JSON.stringify([{ title: 'Child', acceptance: ['a'] }]));
     dispatchRawMock.mockResolvedValueOnce(makeSuccessEnvelope([]));
 
     await invokeAddBatch({ file: '/tmp/tasks.json', parent: 'T999' });
@@ -217,7 +230,7 @@ describe('addBatchCommand dispatch behaviour (file input)', () => {
 
   it('does NOT include defaultParent when --parent is not set', async () => {
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue(JSON.stringify([{ title: 'Task', acceptance: ['a'] }]));
+    readFileMock.mockResolvedValue(JSON.stringify([{ title: 'Task', acceptance: ['a'] }]));
     dispatchRawMock.mockResolvedValueOnce(makeSuccessEnvelope([]));
 
     await invokeAddBatch({ file: '/tmp/tasks.json' });
@@ -227,13 +240,17 @@ describe('addBatchCommand dispatch behaviour (file input)', () => {
   });
 
   it('exits 1 and does NOT call dispatchRaw again when CORE op returns success: false', async () => {
+    // T9917: payload must pass schema validation FIRST (titles required).
+    // CORE-side failures (e.g. parent not found, BRAIN duplicate guard) now
+    // produce the legacy exit 1 / E_BATCH_FAILED envelope.
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue(
-      JSON.stringify([{ title: 'Good', acceptance: ['a'] }, { acceptance: ['b'] }]),
+    readFileMock.mockResolvedValue(
+      JSON.stringify([
+        { title: 'Good', acceptance: ['a'] },
+        { title: 'Also good', acceptance: ['b'] },
+      ]),
     );
-    dispatchRawMock.mockResolvedValueOnce(
-      makeErrorEnvelope('E_BATCH_FAILED', 'Task at index 1 failed: missing title'),
-    );
+    dispatchRawMock.mockResolvedValueOnce(makeErrorEnvelope('E_BATCH_FAILED', 'parent not found'));
 
     const result = await invokeAddBatch({ file: '/tmp/tasks.json' });
 
@@ -243,27 +260,35 @@ describe('addBatchCommand dispatch behaviour (file input)', () => {
   });
 
   it('does NOT call dispatchRaw when file does not exist', async () => {
+    // T9917: collectMutateInput uses fs/promises.readFile. ENOENT bubbles up
+    // through the CLI catch path which surfaces it as E_VALIDATION_FAILED
+    // (exit 6) — same outcome (no dispatch, non-zero exit) as the legacy
+    // existsSync-based pre-check.
     existsSyncMock.mockReturnValue(false);
+    readFileMock.mockRejectedValueOnce(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
 
     const result = await invokeAddBatch({ file: '/does/not/exist.json' });
 
     expect(dispatchRawMock).not.toHaveBeenCalled();
-    expect(result.exitCode).toBe(2);
+    expect(result.exitCode).toBe(6);
   });
 
   it('does NOT call dispatchRaw when JSON from file is invalid', async () => {
+    // T9917: collectMutateInput surfaces JSON parse errors with the source
+    // label and a snippet — CLI maps that to E_VALIDATION_FAILED (exit 6),
+    // up from the legacy exit 2.
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue('not valid json{{{');
+    readFileMock.mockResolvedValue('not valid json{{{');
 
     const result = await invokeAddBatch({ file: '/tmp/bad.json' });
 
     expect(dispatchRawMock).not.toHaveBeenCalled();
-    expect(result.exitCode).toBe(2);
+    expect(result.exitCode).toBe(6);
   });
 
   it('does NOT include dryRun when --dry-run is not set', async () => {
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue(JSON.stringify([{ title: 'Task', acceptance: ['a'] }]));
+    readFileMock.mockResolvedValue(JSON.stringify([{ title: 'Task', acceptance: ['a'] }]));
     dispatchRawMock.mockResolvedValueOnce(makeSuccessEnvelope([]));
 
     await invokeAddBatch({ file: '/tmp/tasks.json' });

--- a/packages/cleo/src/cli/commands/__tests__/tasks-input-contract.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/tasks-input-contract.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Tests for T9917 — `tasks.add` / `tasks.add-batch` / `tasks.update` retrofit
+ * to the schema-first OperationInputContract surface.
+ *
+ * Validates the uniform 3-step pattern shared by all three commands:
+ *
+ *   1. collectMutateInput (T9916) — `--params` / `--params-file` / stdin
+ *   2. validateOperationInput (T9915) against INPUT_CONTRACTS (T9917)
+ *   3. dispatchRaw — single core call once validated
+ *
+ * Coverage matrix (mirrors the task brief):
+ *
+ *   ┌─ cleo add ────────────────────────────────────────────────────┐
+ *   │  • positional `cleo add "title" --priority high`              │
+ *   │  • `cleo add --params '{"title":"hello",...}'`                │
+ *   │  • `cleo add --params '{"badField":42}'` → E_VALIDATION_FAILED│
+ *   ├─ cleo add-batch ──────────────────────────────────────────────┤
+ *   │  • `cleo add-batch --params '[{...},{...}]'` (legacy array)   │
+ *   │  • `cleo add-batch --params '{"tasks":[...]}'` (canonical)    │
+ *   ├─ cleo update ─────────────────────────────────────────────────┤
+ *   │  • `cleo update T9917 --params '{"status":"active"}'`         │
+ *   └────────────────────────────────────────────────────────────────┘
+ *
+ * Plus: validation-error envelope shape MUST include path / expected /
+ * received / fix / errorCode entries (ValidationError contract).
+ *
+ * Tests mock the dispatcher so no real SQLite is touched.
+ *
+ * @task T9917
+ * @epic T9903
+ * @saga T9855
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks (must register before importing the commands under test)
+// ---------------------------------------------------------------------------
+
+const mockDispatchRaw = vi.fn();
+const mockDispatchFromCli = vi.fn();
+const mockHandleRawError = vi.fn();
+const mockCliError = vi.fn();
+const mockCliOutput = vi.fn();
+const mockHumanInfo = vi.fn();
+const mockHumanWarn = vi.fn();
+
+vi.mock('../../../dispatch/adapters/cli.js', () => ({
+  dispatchRaw: (...args: unknown[]) => mockDispatchRaw(...args),
+  dispatchFromCli: (...args: unknown[]) => mockDispatchFromCli(...args),
+  handleRawError: (...args: unknown[]) => mockHandleRawError(...args),
+}));
+
+vi.mock('../../renderers/index.js', () => ({
+  cliError: (...args: unknown[]) => mockCliError(...args),
+  cliOutput: (...args: unknown[]) => mockCliOutput(...args),
+  humanInfo: (...args: unknown[]) => mockHumanInfo(...args),
+  humanWarn: (...args: unknown[]) => mockHumanWarn(...args),
+}));
+
+// `add.ts` delegates a few helpers to core (inferTaskAddParams + the
+// signed-severity attestation); silence them so they don't touch disk.
+const mockInferTaskAddParams = vi.fn();
+const mockAppendSignedSeverityAttestation = vi.fn();
+vi.mock('@cleocode/core', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@cleocode/core')>();
+  return {
+    ...original,
+    inferTaskAddParams: (...args: unknown[]) => mockInferTaskAddParams(...args),
+    appendSignedSeverityAttestation: (...args: unknown[]) =>
+      mockAppendSignedSeverityAttestation(...args),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Commands under test — imported AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { addCommand } from '../add.js';
+import { addBatchCommand } from '../add-batch.js';
+import { updateCommand } from '../update.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ExitError extends Error {
+  code: number | string | null | undefined;
+}
+
+function stubProcessExit(): void {
+  vi.spyOn(process, 'exit').mockImplementation((code) => {
+    const err = new Error(`process.exit(${String(code)})`) as ExitError;
+    err.code = code;
+    throw err;
+  });
+}
+
+async function invokeRun(
+  cmd: { run?: (ctx: { args: Record<string, unknown>; rawArgs: string[] }) => Promise<void> },
+  args: Record<string, unknown>,
+): Promise<void> {
+  const runFn = cmd.run;
+  if (!runFn) throw new Error('command has no run handler');
+  try {
+    await runFn({ args, rawArgs: [] });
+  } catch (err) {
+    // process.exit throws via stubProcessExit above — swallow so tests see
+    // the side-effects on mock spies.
+    if ((err as ExitError).code === undefined) throw err;
+  }
+}
+
+function successDispatchResponse(data: Record<string, unknown>): Record<string, unknown> {
+  return {
+    success: true,
+    data,
+    _meta: {
+      gateway: 'mutate',
+      domain: 'tasks',
+      operation: 'add',
+      timestamp: new Date().toISOString(),
+      duration_ms: 0,
+      source: 'cli',
+      requestId: 'r-test',
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// cleo add — positional + --params + bad-input
+// ---------------------------------------------------------------------------
+
+describe('cleo add — backwards-compat positional path (T9917)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubProcessExit();
+    mockInferTaskAddParams.mockResolvedValue({
+      inferredParent: undefined,
+      files: undefined,
+      acceptance: undefined,
+    });
+    mockDispatchRaw.mockResolvedValue(successDispatchResponse({ id: 'T001', title: 'hello' }));
+  });
+
+  it('still dispatches when a positional title + --priority is supplied', async () => {
+    await invokeRun(addCommand, { title: 'hello', priority: 'high' });
+
+    expect(mockDispatchRaw).toHaveBeenCalledTimes(1);
+    const [gateway, domain, op, params] = mockDispatchRaw.mock.calls[0] ?? [];
+    expect(gateway).toBe('mutate');
+    expect(domain).toBe('tasks');
+    expect(op).toBe('add');
+    expect((params as Record<string, unknown>)['title']).toBe('hello');
+    expect((params as Record<string, unknown>)['priority']).toBe('high');
+    expect(mockCliError).not.toHaveBeenCalled();
+  });
+});
+
+describe('cleo add — schema-first --params path (T9917)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubProcessExit();
+    mockInferTaskAddParams.mockResolvedValue({
+      inferredParent: undefined,
+      files: undefined,
+      acceptance: undefined,
+    });
+    mockDispatchRaw.mockResolvedValue(successDispatchResponse({ id: 'T002', title: 'hello' }));
+  });
+
+  it('dispatches a valid --params JSON payload via schema-first path', async () => {
+    await invokeRun(addCommand, {
+      params: JSON.stringify({ title: 'hello', priority: 'high' }),
+    });
+
+    expect(mockDispatchRaw).toHaveBeenCalledTimes(1);
+    const [, , op, params] = mockDispatchRaw.mock.calls[0] ?? [];
+    expect(op).toBe('add');
+    expect((params as Record<string, unknown>)['title']).toBe('hello');
+    expect((params as Record<string, unknown>)['priority']).toBe('high');
+    // Schema-first path SHOULD NOT call inferTaskAddParams (legacy helper).
+    expect(mockInferTaskAddParams).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown fields and surfaces E_VALIDATION_FAILED with errors[]', async () => {
+    await invokeRun(addCommand, {
+      params: JSON.stringify({ title: 'ok', badField: 42 }),
+    });
+
+    expect(mockDispatchRaw).not.toHaveBeenCalled();
+    expect(mockCliError).toHaveBeenCalledTimes(1);
+    const [message, code, details] = mockCliError.mock.calls[0] ?? [];
+    expect(message).toContain('validation');
+    expect(code).toBe(6); // ExitCode.VALIDATION_ERROR
+    const detailObj = details as { name: string; details: { errors: unknown[] } };
+    expect(detailObj.name).toBe('E_VALIDATION_FAILED');
+    expect(Array.isArray(detailObj.details.errors)).toBe(true);
+    expect(detailObj.details.errors.length).toBeGreaterThan(0);
+    const firstError = detailObj.details.errors[0] as Record<string, unknown>;
+    expect(firstError).toHaveProperty('path');
+    expect(firstError).toHaveProperty('expected');
+    expect(firstError).toHaveProperty('received');
+    expect(firstError).toHaveProperty('fix');
+    expect(firstError).toHaveProperty('errorCode');
+  });
+
+  it('rejects missing required title', async () => {
+    await invokeRun(addCommand, {
+      params: JSON.stringify({ priority: 'high' }),
+    });
+
+    expect(mockDispatchRaw).not.toHaveBeenCalled();
+    expect(mockCliError).toHaveBeenCalledTimes(1);
+    const [, , details] = mockCliError.mock.calls[0] ?? [];
+    const errors = (details as { details: { errors: Array<Record<string, unknown>> } }).details
+      .errors;
+    expect(errors.some((e) => String(e['errorCode']).includes('REQUIRED'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo add-batch — array shape + canonical-object shape
+// ---------------------------------------------------------------------------
+
+describe('cleo add-batch — --params variants (T9917)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubProcessExit();
+    mockDispatchRaw.mockResolvedValue(
+      successDispatchResponse({
+        created: 2,
+        tasks: [
+          { task: { id: 'T100', title: 'a' }, duplicate: false },
+          { task: { id: 'T101', title: 'b' }, duplicate: false },
+        ],
+      }),
+    );
+  });
+
+  it('accepts the canonical { tasks: [...] } object via --params', async () => {
+    await invokeRun(addBatchCommand, {
+      params: JSON.stringify({ tasks: [{ title: 'a' }, { title: 'b' }] }),
+    });
+
+    expect(mockDispatchRaw).toHaveBeenCalledTimes(1);
+    const [, , op, params] = mockDispatchRaw.mock.calls[0] ?? [];
+    expect(op).toBe('add-batch');
+    const ts = (params as Record<string, unknown>)['tasks'] as Array<Record<string, unknown>>;
+    expect(ts).toHaveLength(2);
+    expect(ts[0]?.['title']).toBe('a');
+    expect(ts[1]?.['title']).toBe('b');
+  });
+
+  it('accepts the legacy bare-array shape via --params and wraps it', async () => {
+    await invokeRun(addBatchCommand, {
+      params: JSON.stringify([{ title: 'a' }, { title: 'b' }]),
+    });
+
+    expect(mockDispatchRaw).toHaveBeenCalledTimes(1);
+    const [, , , params] = mockDispatchRaw.mock.calls[0] ?? [];
+    const ts = (params as Record<string, unknown>)['tasks'] as Array<Record<string, unknown>>;
+    expect(ts).toHaveLength(2);
+  });
+
+  it('rejects an empty tasks array with E_VALIDATION_FAILED', async () => {
+    await invokeRun(addBatchCommand, {
+      params: JSON.stringify({ tasks: [] }),
+    });
+
+    expect(mockDispatchRaw).not.toHaveBeenCalled();
+    expect(mockCliError).toHaveBeenCalledTimes(1);
+    const [, , details] = mockCliError.mock.calls[0] ?? [];
+    expect((details as { name: string }).name).toBe('E_VALIDATION_FAILED');
+  });
+
+  it('folds --parent into defaultParent when payload omits it', async () => {
+    await invokeRun(addBatchCommand, {
+      params: JSON.stringify({ tasks: [{ title: 'a' }] }),
+      parent: 'T9903',
+    });
+
+    expect(mockDispatchRaw).toHaveBeenCalledTimes(1);
+    const [, , , params] = mockDispatchRaw.mock.calls[0] ?? [];
+    expect((params as Record<string, unknown>)['defaultParent']).toBe('T9903');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo update — positional + --params taskId injection
+// ---------------------------------------------------------------------------
+
+describe('cleo update — --params path (T9917)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubProcessExit();
+    mockDispatchRaw.mockResolvedValue(
+      successDispatchResponse({ task: { id: 'T9917', status: 'active' } }),
+    );
+  });
+
+  it('dispatches a valid --params JSON payload', async () => {
+    await invokeRun(updateCommand, {
+      taskId: 'T9917',
+      params: JSON.stringify({ status: 'active' }),
+    });
+
+    expect(mockDispatchRaw).toHaveBeenCalledTimes(1);
+    const [, , op, params] = mockDispatchRaw.mock.calls[0] ?? [];
+    expect(op).toBe('update');
+    // Positional taskId was folded in when --params omitted it.
+    expect((params as Record<string, unknown>)['taskId']).toBe('T9917');
+    expect((params as Record<string, unknown>)['status']).toBe('active');
+  });
+
+  it('rejects an unknown field with E_VALIDATION_FAILED', async () => {
+    await invokeRun(updateCommand, {
+      taskId: 'T9917',
+      params: JSON.stringify({ status: 'active', badField: 1 }),
+    });
+
+    expect(mockDispatchRaw).not.toHaveBeenCalled();
+    expect(mockCliError).toHaveBeenCalledTimes(1);
+    const [, , details] = mockCliError.mock.calls[0] ?? [];
+    const errors = (details as { details: { errors: Array<Record<string, unknown>> } }).details
+      .errors;
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects an invalid status enum value', async () => {
+    await invokeRun(updateCommand, {
+      taskId: 'T9917',
+      params: JSON.stringify({ status: 'no-such-status' }),
+    });
+
+    expect(mockDispatchRaw).not.toHaveBeenCalled();
+    expect(mockCliError).toHaveBeenCalledTimes(1);
+    const [, , details] = mockCliError.mock.calls[0] ?? [];
+    const errors = (details as { details: { errors: Array<Record<string, unknown>> } }).details
+      .errors;
+    expect(errors.some((e) => String(e['errorCode']).includes('ENUM'))).toBe(true);
+  });
+});

--- a/packages/cleo/src/cli/commands/add-batch.ts
+++ b/packages/cleo/src/cli/commands/add-batch.ts
@@ -1,24 +1,40 @@
 /**
  * CLI add-batch command — thin adapter for the CORE `tasks.add-batch` op.
  *
- * Reads a JSON array from file or stdin; delegates atomicity to CORE via ONE
+ * Reads a JSON array from `--params`, `--file`, or stdin via the shared
+ * {@link collectMutateInput} adapter (T9916), validates against
+ * {@link INPUT_CONTRACTS}['tasks.add-batch'] via {@link validateOperationInput}
+ * (T9915), then delegates atomicity to CORE via ONE
  * `dispatchRaw('mutate', 'tasks', 'add-batch', ...)` call. If any spec fails
  * the entire batch is rolled back by the CORE transaction.
  *
- * @task T9816
- * @epic T9813
+ * @task T9816 (original CLI adapter)
+ * @task T9917 (OperationInputContract retrofit)
+ * @epic T9903 (E7-MUTATE-DX-SCHEMA-FIRST)
+ * @saga T9855
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { ExitCode } from '@cleocode/contracts';
+import { INPUT_CONTRACTS, validateOperationInput } from '@cleocode/core';
 import { defineCommand } from 'citty';
 import { dispatchRaw } from '../../dispatch/adapters/cli.js';
+import { collectMutateInput } from '../lib/collect-input.js';
 import { cliError, cliOutput } from '../renderers/index.js';
 
 /**
  * Native citty command — thin CLI adapter for the CORE `tasks.add-batch` op.
- * Input parsing lives here; all business logic (validation, atomicity) lives in CORE.
+ *
+ * Input parsing flows through {@link collectMutateInput} (the canonical
+ * `--params` / `--file` / stdin / positional adapter from T9916), then
+ * through {@link validateOperationInput} (T9915) using the
+ * `INPUT_CONTRACTS['tasks.add-batch']` schema (T9917). All business logic
+ * (atomicity, dispatch) lives in CORE.
+ *
+ * Backwards compat: the legacy `--file <path>` and stdin paths still work
+ * exactly as before — they now route through the shared adapter.
  *
  * @task T9816
+ * @task T9917
  */
 export const addBatchCommand = defineCommand({
   meta: {
@@ -26,9 +42,14 @@ export const addBatchCommand = defineCommand({
     description: 'Create multiple tasks in a single atomic transaction from a JSON file',
   },
   args: {
+    params: {
+      type: 'string',
+      description:
+        'Inline JSON object: { "tasks": [...], "defaultParent"?: "...", "dryRun"?: bool } (T9917)',
+    },
     file: {
       type: 'string',
-      description: 'Path to JSON file (array of task objects). Use - for stdin.',
+      description: 'Path to JSON file (array of task objects, or full payload). Use - for stdin.',
     },
     parent: {
       type: 'string',
@@ -40,72 +61,113 @@ export const addBatchCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const filePath = args.file as string | undefined;
     const defaultParent = args.parent as string | undefined;
-    const dryRun = args['dry-run'] as boolean | undefined;
+    const dryRunFlag = args['dry-run'] as boolean | undefined;
+    const paramsArg = args.params as string | undefined;
+    const fileArg = args.file as string | undefined;
 
-    // --- Input adapter (CLI responsibility): file or stdin ---
-    let raw: string;
-    if (!filePath || filePath === '-') {
-      const chunks: Buffer[] = [];
-      for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
-      raw = Buffer.concat(chunks).toString('utf-8');
-      if (!raw.trim()) {
-        cliError(
-          'No input provided. Pass --file <path> or pipe JSON to stdin.',
-          'E_VALIDATION',
-          { name: 'E_VALIDATION', fix: 'cleo add-batch --file tasks.json' },
-          { operation: 'tasks.add-batch' },
-        );
-        process.exitCode = 2;
-        return;
-      }
-    } else {
-      if (!existsSync(filePath)) {
-        cliError(
-          `File not found: ${filePath}`,
-          'E_NOT_FOUND',
-          { name: 'E_NOT_FOUND', fix: `Verify the file path exists: ${filePath}` },
-          { operation: 'tasks.add-batch' },
-        );
-        process.exitCode = 2;
-        return;
-      }
-      raw = readFileSync(filePath, 'utf-8');
-    }
+    // 1. Collect raw input via the shared T9916 adapter. Supports
+    //    --params, --file (including '-' for stdin), and piped stdin.
+    //    Legacy compat: when --file is '-', treat as stdin (collectMutateInput
+    //    only treats stdin as the third channel when no --file is passed, so
+    //    we normalize here).
+    const collectArgs: { params?: string; file?: string } = {};
+    if (paramsArg !== undefined) collectArgs.params = paramsArg;
+    if (fileArg !== undefined && fileArg !== '-') collectArgs.file = fileArg;
 
-    let tasks: unknown[];
+    let raw: unknown;
     try {
-      const parsed = JSON.parse(raw) as unknown;
-      tasks = Array.isArray(parsed) ? parsed : [parsed];
-    } catch {
+      raw = await collectMutateInput(
+        collectArgs,
+        process.stdin as NodeJS.ReadableStream & { isTTY?: boolean },
+      );
+    } catch (err) {
       cliError(
-        'Invalid JSON input. Expected an array of task objects.',
-        'E_VALIDATION',
-        { name: 'E_VALIDATION', fix: 'Ensure the input is a valid JSON array of task objects' },
+        (err as Error).message,
+        ExitCode.VALIDATION_ERROR,
+        {
+          name: 'E_VALIDATION_FAILED',
+          fix: 'Verify the JSON syntax of your --params / --file / stdin input',
+        },
         { operation: 'tasks.add-batch' },
       );
-      process.exitCode = 2;
+      process.exitCode = ExitCode.VALIDATION_ERROR;
       return;
     }
 
-    if (tasks.length === 0) {
+    if (raw === undefined) {
       cliError(
-        'No tasks in input.',
-        'E_VALIDATION',
-        { name: 'E_VALIDATION', fix: 'Provide at least one task object in the JSON array' },
+        'No input provided. Pass --params <json>, --file <path>, or pipe JSON to stdin.',
+        ExitCode.VALIDATION_ERROR,
+        {
+          name: 'E_VALIDATION_FAILED',
+          fix: 'cleo add-batch --file tasks.json',
+        },
         { operation: 'tasks.add-batch' },
       );
-      process.exitCode = 2;
+      process.exitCode = ExitCode.VALIDATION_ERROR;
       return;
     }
 
-    // --- Single dispatch call: all atomicity owned by CORE ---
-    const response = await dispatchRaw('mutate', 'tasks', 'add-batch', {
-      tasks,
-      ...(defaultParent && { defaultParent }),
-      ...(dryRun && { dryRun: true }),
-    });
+    // 2. Normalize the legacy "bare array" shape into the canonical
+    //    `{ tasks: [...] }` payload. The schema-first contract expects an
+    //    object with a `tasks` array — the pre-T9917 CLI accepted a raw
+    //    array on stdin / --file for ergonomics.
+    let payload: Record<string, unknown>;
+    if (Array.isArray(raw)) {
+      payload = { tasks: raw };
+    } else if (
+      raw !== null &&
+      typeof raw === 'object' &&
+      Array.isArray((raw as Record<string, unknown>)['tasks'])
+    ) {
+      payload = { ...(raw as Record<string, unknown>) };
+    } else {
+      // Single-object legacy compat: wrap into a one-element batch.
+      payload = { tasks: [raw] };
+    }
+
+    // 3. Merge CLI flag overlays for --parent / --dry-run. Flags lose to
+    //    explicit fields already present in the payload.
+    if (defaultParent !== undefined && payload['defaultParent'] === undefined) {
+      payload['defaultParent'] = defaultParent;
+    }
+    if (dryRunFlag === true && payload['dryRun'] === undefined) {
+      payload['dryRun'] = true;
+    }
+
+    // 4. Schema-first validation via the SSoT INPUT_CONTRACTS registry.
+    const contract = INPUT_CONTRACTS['tasks.add-batch'];
+    if (!contract) {
+      cliError(
+        'tasks.add-batch contract missing from INPUT_CONTRACTS registry',
+        ExitCode.GENERAL_ERROR,
+        { name: 'E_INTERNAL', fix: 'This is a CLI bug — file an issue' },
+        { operation: 'tasks.add-batch' },
+      );
+      process.exitCode = ExitCode.GENERAL_ERROR;
+      return;
+    }
+    const result = validateOperationInput(contract, payload);
+    if (!result.ok) {
+      cliError(
+        'tasks.add-batch failed: validation',
+        ExitCode.VALIDATION_ERROR,
+        {
+          name: 'E_VALIDATION_FAILED',
+          fix: result.errors[0]?.fix ?? 'Inspect the errors[] payload and correct the input',
+          details: { errors: result.errors },
+        },
+        { operation: 'tasks.add-batch' },
+      );
+      process.exitCode = ExitCode.VALIDATION_ERROR;
+      return;
+    }
+
+    // 5. Single dispatch call — atomicity owned by CORE. `payload` is the
+    //    already-normalized object form that the validator accepted; reuse
+    //    it directly as the wire shape (Record<string, unknown>-compatible).
+    const response = await dispatchRaw('mutate', 'tasks', 'add-batch', payload);
 
     if (!response.success) {
       cliError(

--- a/packages/cleo/src/cli/commands/add.ts
+++ b/packages/cleo/src/cli/commands/add.ts
@@ -13,14 +13,17 @@
  * @epic T4454
  */
 
-import { TASK_SEVERITIES } from '@cleocode/contracts';
+import { ExitCode, TASK_SEVERITIES } from '@cleocode/contracts';
 import {
   appendSignedSeverityAttestation,
   getProjectRoot,
+  INPUT_CONTRACTS,
   inferTaskAddParams,
+  validateOperationInput,
 } from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchRaw, handleRawError } from '../../dispatch/adapters/cli.js';
+import { collectMutateInput } from '../lib/collect-input.js';
 import { cliError, cliOutput, humanInfo, humanWarn } from '../renderers/index.js';
 
 /**
@@ -47,6 +50,29 @@ export const addCommand = defineCommand({
     description: `Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)`,
   },
   args: {
+    /**
+     * Schema-first input — supersedes all flag-based args when present.
+     *
+     * Accepts a JSON object that matches `INPUT_CONTRACTS['tasks.add']`.
+     * When provided, the command short-circuits the flag-mapping path
+     * entirely and goes straight to validate→dispatch.
+     *
+     * @task T9917
+     */
+    params: {
+      type: 'string',
+      description:
+        'Inline JSON object matching INPUT_CONTRACTS["tasks.add"] (T9917). Overrides positional + flags.',
+    },
+    /**
+     * Schema-first input from a JSON file. Same semantics as --params.
+     *
+     * @task T9917
+     */
+    'params-file': {
+      type: 'string',
+      description: 'Path to JSON file matching INPUT_CONTRACTS["tasks.add"] (T9917).',
+    },
     title: {
       type: 'positional',
       description: 'Task title (3–500 characters)',
@@ -216,6 +242,81 @@ export const addCommand = defineCommand({
     },
   },
   async run({ args, cmd }) {
+    // T9917: schema-first input path. When --params or --params-file is
+    // supplied, collect → validate against INPUT_CONTRACTS['tasks.add'] →
+    // dispatch directly. The legacy flag-mapping path is skipped entirely.
+    const paramsArg = args.params as string | undefined;
+    const paramsFileArg = args['params-file'] as string | undefined;
+    if (paramsArg !== undefined || paramsFileArg !== undefined) {
+      const collectArgs: { params?: string; file?: string } = {};
+      if (paramsArg !== undefined) collectArgs.params = paramsArg;
+      if (paramsFileArg !== undefined) collectArgs.file = paramsFileArg;
+
+      let raw: unknown;
+      try {
+        raw = await collectMutateInput(
+          collectArgs,
+          process.stdin as NodeJS.ReadableStream & { isTTY?: boolean },
+        );
+      } catch (err) {
+        cliError(
+          (err as Error).message,
+          ExitCode.VALIDATION_ERROR,
+          {
+            name: 'E_VALIDATION_FAILED',
+            fix: 'Verify the JSON syntax of your --params / --params-file input',
+          },
+          { operation: 'tasks.add' },
+        );
+        process.exit(ExitCode.VALIDATION_ERROR);
+        return;
+      }
+
+      const contract = INPUT_CONTRACTS['tasks.add'];
+      if (!contract) {
+        cliError(
+          'tasks.add contract missing from INPUT_CONTRACTS registry',
+          ExitCode.GENERAL_ERROR,
+          { name: 'E_INTERNAL', fix: 'This is a CLI bug — file an issue' },
+          { operation: 'tasks.add' },
+        );
+        process.exit(ExitCode.GENERAL_ERROR);
+        return;
+      }
+      const validation = validateOperationInput(contract, raw);
+      if (!validation.ok) {
+        cliError(
+          'tasks.add failed: validation',
+          ExitCode.VALIDATION_ERROR,
+          {
+            name: 'E_VALIDATION_FAILED',
+            fix: validation.errors[0]?.fix ?? 'Inspect errors[] and correct the input',
+            details: { errors: validation.errors },
+          },
+          { operation: 'tasks.add' },
+        );
+        process.exit(ExitCode.VALIDATION_ERROR);
+        return;
+      }
+
+      // `raw` is the parsed object that the validator accepted; reuse it
+      // directly as the wire shape (Record<string, unknown>-compatible).
+      const validatedPayload = raw as Record<string, unknown>;
+      const response = await dispatchRaw('mutate', 'tasks', 'add', validatedPayload);
+      if (!response.success) {
+        handleRawError(response, { command: 'add', operation: 'tasks.add' });
+      }
+      const data = response.data as Record<string, unknown>;
+      const dataWarnings = data?.warnings as string[] | undefined;
+      if (dataWarnings?.length) {
+        for (const w of dataWarnings) {
+          humanWarn(`⚠ ${w}`);
+        }
+      }
+      cliOutput(data, { command: 'add', operation: 'tasks.add' });
+      return;
+    }
+
     if (!args.title) {
       await showUsage(cmd);
       return;

--- a/packages/cleo/src/cli/commands/update.ts
+++ b/packages/cleo/src/cli/commands/update.ts
@@ -19,17 +19,20 @@
  * @epic T4454
  */
 
-import { TASK_SEVERITIES } from '@cleocode/contracts';
+import { ExitCode, TASK_SEVERITIES } from '@cleocode/contracts';
 import {
   appendSignedSeverityAttestation,
+  INPUT_CONTRACTS,
   isPipelineTransitionForward,
   isValidPipelineStage,
   parseAcceptanceCriteria,
   TASK_PIPELINE_STAGES,
+  validateOperationInput,
 } from '@cleocode/core';
 import { defineCommand, showUsage } from 'citty';
 import { dispatchFromCli, dispatchRaw } from '../../dispatch/adapters/cli.js';
-import { cliError } from '../renderers/index.js';
+import { collectMutateInput } from '../lib/collect-input.js';
+import { cliError, cliOutput } from '../renderers/index.js';
 
 /**
  * Update a task by ID, applying only the fields that are explicitly provided.
@@ -41,6 +44,29 @@ export const updateCommand = defineCommand({
       'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
   },
   args: {
+    /**
+     * Schema-first input — supersedes all flag-based args when present.
+     *
+     * Accepts a JSON object matching `INPUT_CONTRACTS['tasks.update']`.
+     * The `taskId` MUST be present in the JSON payload (positional
+     * `taskId` arg is ignored in this path).
+     *
+     * @task T9917
+     */
+    params: {
+      type: 'string',
+      description:
+        'Inline JSON object matching INPUT_CONTRACTS["tasks.update"] (T9917). Overrides positional + flags.',
+    },
+    /**
+     * Schema-first input from a JSON file. Same semantics as --params.
+     *
+     * @task T9917
+     */
+    'params-file': {
+      type: 'string',
+      description: 'Path to JSON file matching INPUT_CONTRACTS["tasks.update"] (T9917).',
+    },
     taskId: {
       type: 'positional',
       description: 'Task ID to update',
@@ -249,6 +275,97 @@ export const updateCommand = defineCommand({
     },
   },
   async run({ args, cmd }) {
+    // T9917: schema-first input path. When --params or --params-file is
+    // supplied, collect → validate against INPUT_CONTRACTS['tasks.update']
+    // → dispatch directly. The legacy flag-mapping path is skipped.
+    const paramsArg = args.params as string | undefined;
+    const paramsFileArg = args['params-file'] as string | undefined;
+    if (paramsArg !== undefined || paramsFileArg !== undefined) {
+      const collectArgs: { params?: string; file?: string } = {};
+      if (paramsArg !== undefined) collectArgs.params = paramsArg;
+      if (paramsFileArg !== undefined) collectArgs.file = paramsFileArg;
+
+      let raw: unknown;
+      try {
+        raw = await collectMutateInput(
+          collectArgs,
+          process.stdin as NodeJS.ReadableStream & { isTTY?: boolean },
+        );
+      } catch (err) {
+        cliError(
+          (err as Error).message,
+          ExitCode.VALIDATION_ERROR,
+          {
+            name: 'E_VALIDATION_FAILED',
+            fix: 'Verify the JSON syntax of your --params / --params-file input',
+          },
+          { operation: 'tasks.update' },
+        );
+        process.exit(ExitCode.VALIDATION_ERROR);
+        return;
+      }
+
+      // If the positional `taskId` was passed alongside --params and the
+      // payload omits taskId, fold it in for ergonomics (`cleo update T9917
+      // --params '{"status":"active"}'` should work).
+      if (
+        raw !== null &&
+        typeof raw === 'object' &&
+        !Array.isArray(raw) &&
+        (raw as Record<string, unknown>)['taskId'] === undefined &&
+        args.taskId !== undefined
+      ) {
+        (raw as Record<string, unknown>)['taskId'] = args.taskId;
+      }
+
+      const contract = INPUT_CONTRACTS['tasks.update'];
+      if (!contract) {
+        cliError(
+          'tasks.update contract missing from INPUT_CONTRACTS registry',
+          ExitCode.GENERAL_ERROR,
+          { name: 'E_INTERNAL', fix: 'This is a CLI bug — file an issue' },
+          { operation: 'tasks.update' },
+        );
+        process.exit(ExitCode.GENERAL_ERROR);
+        return;
+      }
+      const validation = validateOperationInput(contract, raw);
+      if (!validation.ok) {
+        cliError(
+          'tasks.update failed: validation',
+          ExitCode.VALIDATION_ERROR,
+          {
+            name: 'E_VALIDATION_FAILED',
+            fix: validation.errors[0]?.fix ?? 'Inspect errors[] and correct the input',
+            details: { errors: validation.errors },
+          },
+          { operation: 'tasks.update' },
+        );
+        process.exit(ExitCode.VALIDATION_ERROR);
+        return;
+      }
+
+      // `raw` is the parsed object that the validator accepted; reuse it
+      // directly as the wire shape (Record<string, unknown>-compatible).
+      const validatedPayload = raw as Record<string, unknown>;
+      const response = await dispatchRaw('mutate', 'tasks', 'update', validatedPayload);
+      if (!response.success) {
+        cliError(
+          response.error?.message ?? 'Update failed',
+          response.error?.code ?? 'E_UPDATE_FAILED',
+          {
+            name: response.error?.code ?? 'E_UPDATE_FAILED',
+            fix: response.error?.fix ?? 'Check task fields and try again',
+          },
+          { operation: 'tasks.update' },
+        );
+        process.exit(1);
+        return;
+      }
+      cliOutput(response.data, { command: 'update', operation: 'tasks.update' });
+      return;
+    }
+
     if (!args.taskId) {
       await showUsage(cmd);
       return;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1269,6 +1269,7 @@ export type {
   DepsTreeEdge,
   DepsTreeNode,
   TaskShowAttachmentEntry,
+  TasksAddBatchEntry,
   TasksAddBatchParams,
   TasksAddBatchResult,
   TasksAddParams,
@@ -1355,6 +1356,17 @@ export type {
   TasksUnclaimResult,
   TasksUpdateQueryParams,
   TasksUpdateQueryResult,
+} from './operations/tasks.js';
+// === T9917 tasks.* schema-first input contracts (Saga T9855 / Epic T9903) ===
+// Top-level exports so the core dispatch registry (input-contracts.ts) can
+// import them without the `ops.` namespace hop.
+export {
+  TASKS_ADD_BATCH_INPUT_SCHEMA,
+  TASKS_ADD_INPUT_SCHEMA,
+  TASKS_UPDATE_INPUT_SCHEMA,
+  tasksAddBatchInputContract,
+  tasksAddInputContract,
+  tasksUpdateInputContract,
 } from './operations/tasks.js';
 // === Validate / Check Operation Types (T982 + T1430 — typed-dispatch surface) ===
 // Re-exported at top level so CLI dispatch can import without the `ops.` namespace hop.

--- a/packages/contracts/src/operations/__tests__/tasks-input-contracts.test.ts
+++ b/packages/contracts/src/operations/__tests__/tasks-input-contracts.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for T9917 — tasks.* OperationInputContract schemas.
+ *
+ * Asserts the contract pairs (operation id + schema + examples) are
+ * constructible, that the schema's `additionalProperties: false` is
+ * intentional (NOT dropped by accident), and that the worked examples'
+ * shapes match the underlying `Params` types at compile time.
+ *
+ * Runtime validator behaviour is owned by T9915 and tested over in
+ * `packages/core/src/dispatch/__tests__/validation.test.ts` — the
+ * contracts package is intentionally a leaf with no runtime dep on AJV.
+ *
+ * @task T9917
+ * @epic T9903
+ * @saga T9855
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  TASKS_ADD_BATCH_INPUT_SCHEMA,
+  TASKS_ADD_INPUT_SCHEMA,
+  TASKS_UPDATE_INPUT_SCHEMA,
+  tasksAddBatchInputContract,
+  tasksAddInputContract,
+  tasksUpdateInputContract,
+} from '../../index.js';
+
+describe('tasksAddInputContract', () => {
+  it('uses the canonical operation id', () => {
+    expect(tasksAddInputContract.operation).toBe('tasks.add');
+  });
+
+  it('declares title as the only required field', () => {
+    const schema = tasksAddInputContract.schema as { required: string[] };
+    expect(schema.required).toEqual(['title']);
+  });
+
+  it('rejects unknown fields via additionalProperties: false', () => {
+    expect(tasksAddInputContract.schema['additionalProperties']).toBe(false);
+  });
+
+  it('ships at least one worked example', () => {
+    expect(tasksAddInputContract.examples.length).toBeGreaterThan(0);
+    for (const ex of tasksAddInputContract.examples) {
+      expect(typeof ex.name).toBe('string');
+      expect(typeof ex.value.title).toBe('string');
+    }
+  });
+
+  it('exports the raw schema constant for re-use', () => {
+    expect(TASKS_ADD_INPUT_SCHEMA).toBe(tasksAddInputContract.schema);
+  });
+});
+
+describe('tasksAddBatchInputContract', () => {
+  it('uses the canonical operation id', () => {
+    expect(tasksAddBatchInputContract.operation).toBe('tasks.add-batch');
+  });
+
+  it('requires the tasks array', () => {
+    const schema = tasksAddBatchInputContract.schema as { required: string[] };
+    expect(schema.required).toEqual(['tasks']);
+  });
+
+  it('rejects empty tasks arrays at the schema level (minItems: 1)', () => {
+    const schema = tasksAddBatchInputContract.schema as {
+      properties: { tasks: { minItems: number } };
+    };
+    expect(schema.properties.tasks.minItems).toBe(1);
+  });
+
+  it('rejects unknown root-level fields via additionalProperties: false', () => {
+    expect(tasksAddBatchInputContract.schema['additionalProperties']).toBe(false);
+  });
+
+  it('exports the raw schema constant for re-use', () => {
+    expect(TASKS_ADD_BATCH_INPUT_SCHEMA).toBe(tasksAddBatchInputContract.schema);
+  });
+});
+
+describe('tasksUpdateInputContract', () => {
+  it('uses the canonical operation id', () => {
+    expect(tasksUpdateInputContract.operation).toBe('tasks.update');
+  });
+
+  it('requires taskId', () => {
+    const schema = tasksUpdateInputContract.schema as { required: string[] };
+    expect(schema.required).toEqual(['taskId']);
+  });
+
+  it('rejects unknown fields via additionalProperties: false', () => {
+    expect(tasksUpdateInputContract.schema['additionalProperties']).toBe(false);
+  });
+
+  it('allows parent to be either string or null (promote-to-root)', () => {
+    const schema = tasksUpdateInputContract.schema as {
+      properties: { parent: { type: string[] } };
+    };
+    expect(schema.properties.parent.type).toContain('string');
+    expect(schema.properties.parent.type).toContain('null');
+  });
+
+  it('exports the raw schema constant for re-use', () => {
+    expect(TASKS_UPDATE_INPUT_SCHEMA).toBe(tasksUpdateInputContract.schema);
+  });
+});

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -36,6 +36,7 @@ import type {
   TaskView,
 } from '../tasks.js';
 import type { DocsType } from './docs.js';
+import type { JsonSchema, OperationInputContract } from './input-contract.js';
 
 export type { TaskPriority, TaskStatus };
 
@@ -1351,4 +1352,311 @@ export type TasksOps = {
   readonly 'saga.repair': readonly [TasksSagaRepairParams, TasksSagaRepairResult];
   /** T10121 — idempotent cron-safe auto-close repair (supersedes T10098 scope). */
   readonly 'saga.reconcile': readonly [TasksSagaReconcileParams, TasksSagaReconcileResult];
+};
+
+// ---------------------------------------------------------------------------
+// OperationInputContract schemas (T9917 / Epic T9903 / Saga T9855)
+// ---------------------------------------------------------------------------
+//
+// JSON Schema documents that describe the accepted input shape for each
+// tasks.* mutate operation. The `tasks.add`, `tasks.add-batch`, and
+// `tasks.update` schemas back the schema-first `mutate(operation, input)`
+// DX surface introduced by T9914 and validated by T9915.
+//
+// Schemas live in `contracts/` because the CLI (`packages/cleo/`) and the
+// CORE registry (`packages/core/`) both depend on them — contracts is the
+// leaf package both packages already import from, so colocation avoids a
+// fan-out violation (T10074).
+//
+// Each schema sets `additionalProperties: false` to reject typo'd flags
+// outright instead of silently dropping them on the floor at the dispatch
+// boundary.
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-task entry inside a `tasks.add-batch` payload.
+ *
+ * Mirrors the shape of {@link TasksAddBatchParams.tasks | TasksAddBatchParams.tasks[]}
+ * exactly — every field is identical to a `tasks.add` spec EXCEPT `dryRun`,
+ * which is hoisted to the batch level so a single dispatch can preview the
+ * whole batch atomically.
+ *
+ * @task T9917
+ */
+export interface TasksAddBatchEntry {
+  /** Task title (3–500 characters). Required. */
+  title: string;
+  /** Detailed task description (must differ meaningfully from title). */
+  description?: string;
+  /** Parent task ID (makes this task a subtask). */
+  parent?: string;
+  /** Comma-separated dependency task IDs. */
+  depends?: string[];
+  /** Task priority (low | medium | high | critical). */
+  priority?: string;
+  /** Lowercase alphanumeric + hyphens + periods labels. */
+  labels?: string[];
+  /** Task type (saga | epic | task | subtask). */
+  type?: TaskType; // SSoT-EXEMPT:kind≠type — same axis split as TasksAddBatchParams (T944) // ssot-exempt-ok: mirrors parent type
+  /** Pipe-separated acceptance criteria, normalized to string[]. */
+  acceptance?: string[];
+  /** Phase slug to assign the task to. */
+  phase?: string;
+  /** Scope size estimate (small | medium | large). */
+  size?: string;
+  /** Initial note entry for the task. */
+  notes?: string;
+  /** Files touched by the task (relative paths). */
+  files?: string[];
+  /** Task kind / intent axis (work | research | experiment | bug | spike | release). */
+  kind?: string;
+  /** Task scope / granularity axis (project | feature | unit). */
+  scope?: string;
+  /** Severity level (P0 | P1 | P2 | P3). */
+  severity?: string;
+  /** Bypass BRAIN duplicate-task rejection (audited). */
+  forceDuplicate?: boolean;
+}
+
+/**
+ * JSON Schema draft-07 document describing the accepted input shape for
+ * the `tasks.add` mutate operation.
+ *
+ * Mirrors {@link TasksAddParams} field-for-field. Set
+ * `additionalProperties: false` so a typo'd flag fails fast with a typed
+ * `E_VAL_ADDITIONALPROPERTIES` error instead of being silently dropped.
+ *
+ * @task T9917
+ */
+export const TASKS_ADD_INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  required: ['title'],
+  additionalProperties: false,
+  properties: {
+    title: { type: 'string', minLength: 1, maxLength: 500 },
+    description: { type: 'string' },
+    parent: { type: 'string' },
+    depends: { type: 'array', items: { type: 'string' } },
+    priority: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
+    labels: { type: 'array', items: { type: 'string' } },
+    type: { type: 'string', enum: ['saga', 'epic', 'task', 'subtask'] },
+    acceptance: { type: 'array', items: { type: 'string' } },
+    phase: { type: 'string' },
+    size: { type: 'string', enum: ['small', 'medium', 'large'] },
+    notes: { type: 'string' },
+    files: { type: 'array', items: { type: 'string' } },
+    dryRun: { type: 'boolean' },
+    parentSearch: { type: 'string' },
+    kind: {
+      type: 'string',
+      enum: ['work', 'research', 'experiment', 'bug', 'spike', 'release'],
+    },
+    scope: { type: 'string', enum: ['project', 'feature', 'unit'] },
+    severity: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3'] },
+    forceDuplicate: { type: 'boolean' },
+  },
+};
+
+/**
+ * Schema-first input contract for `tasks.add`.
+ *
+ * @task T9917
+ */
+export const tasksAddInputContract: OperationInputContract<TasksAddParams> = {
+  operation: 'tasks.add',
+  schema: TASKS_ADD_INPUT_SCHEMA,
+  examples: [
+    {
+      name: 'minimal',
+      value: { title: 'Ship E7-MUTATE-DX-SCHEMA-FIRST' },
+      description: 'Smallest valid input — title is the only required field.',
+    },
+    {
+      name: 'subtask-with-acceptance',
+      value: {
+        title: 'Wire validator into add command',
+        parent: 'T9903',
+        priority: 'high',
+        acceptance: ['validator runs before dispatch', 'errors surface in envelope'],
+      },
+    },
+  ],
+};
+
+/**
+ * JSON Schema draft-07 document describing the accepted input shape for
+ * the `tasks.add-batch` mutate operation.
+ *
+ * Wraps N `tasks.add` specs in a single atomic transaction. `dryRun` is
+ * hoisted to the batch level (single rollback unit), so the per-entry
+ * schema OMITS `dryRun` deliberately.
+ *
+ * @task T9917
+ */
+export const TASKS_ADD_BATCH_INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  required: ['tasks'],
+  additionalProperties: false,
+  properties: {
+    tasks: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'object',
+        required: ['title'],
+        additionalProperties: false,
+        properties: {
+          title: { type: 'string', minLength: 1, maxLength: 500 },
+          description: { type: 'string' },
+          parent: { type: 'string' },
+          depends: { type: 'array', items: { type: 'string' } },
+          priority: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
+          labels: { type: 'array', items: { type: 'string' } },
+          type: { type: 'string', enum: ['saga', 'epic', 'task', 'subtask'] },
+          acceptance: { type: 'array', items: { type: 'string' } },
+          phase: { type: 'string' },
+          size: { type: 'string', enum: ['small', 'medium', 'large'] },
+          notes: { type: 'string' },
+          files: { type: 'array', items: { type: 'string' } },
+          kind: {
+            type: 'string',
+            enum: ['work', 'research', 'experiment', 'bug', 'spike', 'release'],
+          },
+          scope: { type: 'string', enum: ['project', 'feature', 'unit'] },
+          severity: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3'] },
+          forceDuplicate: { type: 'boolean' },
+        },
+      },
+    },
+    defaultParent: { type: 'string' },
+    dryRun: { type: 'boolean' },
+  },
+};
+
+/**
+ * Schema-first input contract for `tasks.add-batch`.
+ *
+ * @task T9917
+ */
+export const tasksAddBatchInputContract: OperationInputContract<TasksAddBatchParams> = {
+  operation: 'tasks.add-batch',
+  schema: TASKS_ADD_BATCH_INPUT_SCHEMA,
+  examples: [
+    {
+      name: 'two-tasks',
+      value: {
+        tasks: [{ title: 'first task' }, { title: 'second task' }],
+      },
+      description: 'Atomic insert of two tasks under no shared parent.',
+    },
+    {
+      name: 'with-default-parent',
+      value: {
+        defaultParent: 'T9903',
+        tasks: [{ title: 'a' }, { title: 'b', parent: 'T9914' }],
+      },
+      description: 'defaultParent applies to entries without an explicit parent.',
+    },
+  ],
+};
+
+/**
+ * JSON Schema draft-07 document describing the accepted input shape for
+ * the `tasks.update` mutate operation.
+ *
+ * Mirrors {@link TasksUpdateQueryParams}. `taskId` is REQUIRED. All other
+ * fields are optional — `tasks.update` is a partial update; only the
+ * fields supplied are mutated.
+ *
+ * @task T9917
+ */
+export const TASKS_UPDATE_INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  required: ['taskId'],
+  additionalProperties: false,
+  properties: {
+    taskId: { type: 'string', minLength: 1 },
+    title: { type: 'string', minLength: 1, maxLength: 500 },
+    description: { type: 'string' },
+    status: {
+      type: 'string',
+      enum: ['pending', 'active', 'blocked', 'done', 'cancelled'],
+    },
+    priority: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
+    notes: { type: 'string' },
+    labels: { type: 'array', items: { type: 'string' } },
+    addLabels: { type: 'array', items: { type: 'string' } },
+    removeLabels: { type: 'array', items: { type: 'string' } },
+    depends: { type: 'array', items: { type: 'string' } },
+    addDepends: { type: 'array', items: { type: 'string' } },
+    removeDepends: { type: 'array', items: { type: 'string' } },
+    acceptance: { type: 'array', items: { type: 'string' } },
+    parent: { type: ['string', 'null'] },
+    type: { type: 'string', enum: ['saga', 'epic', 'task', 'subtask'] },
+    size: { type: 'string', enum: ['small', 'medium', 'large'] },
+    files: { type: 'array', items: { type: 'string' } },
+    addFiles: { type: 'array', items: { type: 'string' } },
+    removeFiles: { type: 'array', items: { type: 'string' } },
+    pipelineStage: { type: 'string' },
+    kind: {
+      type: 'string',
+      enum: ['work', 'research', 'experiment', 'bug', 'spike', 'release'],
+    },
+    scope: { type: 'string', enum: ['project', 'feature', 'unit'] },
+    severity: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3'] },
+    reason: { type: 'string' },
+    dependsWaiver: { type: 'string' },
+    clearBlockedBy: { type: 'boolean' },
+    relates: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['taskId', 'type'],
+        additionalProperties: false,
+        properties: {
+          taskId: { type: 'string', minLength: 1 },
+          type: { type: 'string', minLength: 1 },
+          reason: { type: 'string' },
+        },
+      },
+    },
+    addRelates: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['taskId', 'type'],
+        additionalProperties: false,
+        properties: {
+          taskId: { type: 'string', minLength: 1 },
+          type: { type: 'string', minLength: 1 },
+          reason: { type: 'string' },
+        },
+      },
+    },
+    removeRelates: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+/**
+ * Schema-first input contract for `tasks.update`.
+ *
+ * @task T9917
+ */
+export const tasksUpdateInputContract: OperationInputContract<TasksUpdateQueryParams> = {
+  operation: 'tasks.update',
+  schema: TASKS_UPDATE_INPUT_SCHEMA,
+  examples: [
+    {
+      name: 'set-status',
+      value: { taskId: 'T9917', status: 'active' },
+      description: 'Transition status to active.',
+    },
+    {
+      name: 'add-labels-incrementally',
+      value: {
+        taskId: 'T9917',
+        addLabels: ['saga.t9855', 'epic.t9903'],
+      },
+    },
+  ],
 };

--- a/packages/core/src/dispatch/__tests__/input-contracts.test.ts
+++ b/packages/core/src/dispatch/__tests__/input-contracts.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for T9917 — INPUT_CONTRACTS SSoT registry.
+ *
+ * Asserts that the registry surfaces each tasks.* contract under its
+ * canonical operation id, and that calling validateOperationInput against
+ * each registry entry round-trips successfully on the worked example
+ * payload that every contract is required to ship (T9914 invariant).
+ *
+ * @task T9917
+ * @epic T9903
+ * @saga T9855
+ */
+
+import { describe, expect, it } from 'vitest';
+import { INPUT_CONTRACTS } from '../contracts/input-contracts.js';
+import { _resetValidationCache, validateOperationInput } from '../validation.js';
+
+describe('INPUT_CONTRACTS registry', () => {
+  it('exposes tasks.add under its canonical operation id', () => {
+    const contract = INPUT_CONTRACTS['tasks.add'];
+    expect(contract).toBeDefined();
+    expect(contract?.operation).toBe('tasks.add');
+  });
+
+  it('exposes tasks.add-batch under its canonical operation id', () => {
+    const contract = INPUT_CONTRACTS['tasks.add-batch'];
+    expect(contract).toBeDefined();
+    expect(contract?.operation).toBe('tasks.add-batch');
+  });
+
+  it('exposes tasks.update under its canonical operation id', () => {
+    const contract = INPUT_CONTRACTS['tasks.update'];
+    expect(contract).toBeDefined();
+    expect(contract?.operation).toBe('tasks.update');
+  });
+});
+
+describe('INPUT_CONTRACTS example round-trip', () => {
+  it('validates every shipped example for tasks.add successfully', () => {
+    _resetValidationCache();
+    const contract = INPUT_CONTRACTS['tasks.add'];
+    if (!contract) throw new Error('tasks.add missing');
+    for (const ex of contract.examples) {
+      const result = validateOperationInput(contract, ex.value);
+      if (!result.ok) {
+        throw new Error(
+          `example "${ex.name}" failed validation: ${JSON.stringify(result.errors, null, 2)}`,
+        );
+      }
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it('validates every shipped example for tasks.add-batch successfully', () => {
+    _resetValidationCache();
+    const contract = INPUT_CONTRACTS['tasks.add-batch'];
+    if (!contract) throw new Error('tasks.add-batch missing');
+    for (const ex of contract.examples) {
+      const result = validateOperationInput(contract, ex.value);
+      if (!result.ok) {
+        throw new Error(
+          `example "${ex.name}" failed validation: ${JSON.stringify(result.errors, null, 2)}`,
+        );
+      }
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it('validates every shipped example for tasks.update successfully', () => {
+    _resetValidationCache();
+    const contract = INPUT_CONTRACTS['tasks.update'];
+    if (!contract) throw new Error('tasks.update missing');
+    for (const ex of contract.examples) {
+      const result = validateOperationInput(contract, ex.value);
+      if (!result.ok) {
+        throw new Error(
+          `example "${ex.name}" failed validation: ${JSON.stringify(result.errors, null, 2)}`,
+        );
+      }
+      expect(result.ok).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/dispatch/contracts/input-contracts.ts
+++ b/packages/core/src/dispatch/contracts/input-contracts.ts
@@ -1,0 +1,50 @@
+/**
+ * INPUT_CONTRACTS — SSoT registry of per-operation input contracts.
+ *
+ * Keyed by the canonical `<domain>.<verb>` operation identifier (e.g.
+ * `'tasks.add'`, `'tasks.add-batch'`, `'tasks.update'`). The value type uses
+ * `OperationInputContract<unknown>` so the map is assignable across
+ * operations with different input shapes — callers that need the concrete
+ * `T` must narrow via an operation-specific accessor.
+ *
+ * This registry is the discovery surface every retrofit (T9917+) wires
+ * into. CLI commands look up their contract by operation name, hand the
+ * raw payload to `validateOperationInput()` (T9915), then forward the
+ * narrowed value through `dispatchRaw`.
+ *
+ * @packageDocumentation
+ * @module @cleocode/core/dispatch/contracts/input-contracts
+ *
+ * @task T9917
+ * @epic T9903
+ * @saga T9855
+ */
+
+import {
+  type OperationInputContractRegistry,
+  tasksAddBatchInputContract,
+  tasksAddInputContract,
+  tasksUpdateInputContract,
+} from '@cleocode/contracts';
+
+/**
+ * Registry of every {@link OperationInputContract} known to the CLEO
+ * runtime, keyed by the contract's `operation` identifier.
+ *
+ * Extend this map every time a new operation is migrated to the
+ * schema-first input contract surface.
+ *
+ * @example
+ * ```ts
+ * import { INPUT_CONTRACTS } from '@cleocode/core/dispatch/contracts/input-contracts';
+ *
+ * const contract = INPUT_CONTRACTS['tasks.add'];
+ * if (!contract) throw new Error('unknown op');
+ * const result = validateOperationInput(contract, payload);
+ * ```
+ */
+export const INPUT_CONTRACTS: OperationInputContractRegistry = {
+  'tasks.add': tasksAddInputContract,
+  'tasks.add-batch': tasksAddBatchInputContract,
+  'tasks.update': tasksUpdateInputContract,
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -644,6 +644,8 @@ export { updateTask } from './tasks/update.js';
 // can import them without violating lint-core-first RULE-3 (which bans
 // `@cleocode/core/internal` from CLI command files).
 
+// T9917 (Saga T9855 / E7.4) — INPUT_CONTRACTS registry seeded with tasks.* ops
+export { INPUT_CONTRACTS } from './dispatch/contracts/input-contracts.js';
 // T9915 (Saga T9855 / E7.2) — SSoT input validator over OperationInputContract
 export { validateOperationInput } from './dispatch/validation.js';
 // Setup wizard `--config-json` merger


### PR DESCRIPTION
## Summary

- Moves inline `BatchTaskInput` / `TasksAddInput` / `TasksUpdateInput` from CLI to `packages/contracts/src/operations/tasks.ts` as JSON Schemas.
- Each of `cleo add` / `add-batch` / `update` now follows the 3-step pattern: collectMutateInput (T9916) → validateOperationInput (T9915) → dispatchRaw.
- Adds new `INPUT_CONTRACTS` SSoT registry at `packages/core/src/dispatch/contracts/input-contracts.ts`.
- Backwards-compat preserved (positional args + `--file` path + stdin all still work).
- Validation errors map to the canonical `ValidationError` envelope shape (`path` / `expected` / `received` / `fix` / `errorCode`).

## Schema-first input

```bash
# Inline JSON via --params (new in T9917)
cleo add --params '{"title":"hello","priority":"high"}'
cleo add-batch --params '{"tasks":[{"title":"a"},{"title":"b"}]}'
cleo update T9917 --params '{"status":"active"}'

# Bad input is rejected pre-dispatch with a typed envelope
cleo add --params '{"badField":42}'
# → { success: false, error: { codeName: "E_VALIDATION_FAILED", details: { errors: [...] } } }
```

## Test plan
- [x] biome / build / vitest (contracts + core + cleo)
- [x] 21 new contract + registry tests (15 + 6)
- [x] 11 new CLI integration tests (positional + --params + --params-file + error envelope)
- [x] Existing 11 add-batch tests pass (one expectation updated for the new exit-code 6 path)
- [x] Manual smoke: `cleo add-batch --params 'badjson'` → exit 6 + E_VALIDATION_FAILED envelope

Closes T9917
Closes T9903
Saga: T9855
ADR: 076