### PR TITLE
feat(cleo): cleo templates CLI namespace (T9886 / Saga T9855)

### DIFF
--- a/.changeset/t9886-cleo-templates-cli.md
+++ b/.changeset/t9886-cleo-templates-cli.md
@@ -1,0 +1,6 @@
+---
+id: t9886-cleo-templates-cli
+tasks: [T9886]
+kind: feat
+summary: cleo templates {list,show,install,upgrade,diff,validate} CLI namespace (T9886 / Saga T9855 / E4)
+---

--- a/build.mjs
+++ b/build.mjs
@@ -50,6 +50,9 @@ const SUBPATH_DIRS = [
   // T9887 — packages/core/src/config/registry.ts is exposed via the
   // ./config/registry subpath export for `cleo config` (Saga T9855 E4).
   'config',
+  // T9886 — packages/core/src/templates/registry.ts is exposed via the
+  // ./templates/registry subpath export for `cleo templates` (Saga T9855 E4).
+  'templates',
   'sentient',
   'gc',
   'doctor',

--- a/packages/cleo/src/cli/commands/templates.ts
+++ b/packages/cleo/src/cli/commands/templates.ts
@@ -1,0 +1,62 @@
+/**
+ * CLI command group: cleo templates — SSoT TemplateManifest registry surface.
+ *
+ * Thin wrapper over the CORE registry from T9877
+ * (`@cleocode/core/templates/registry`) — exposes the operator surface for
+ * the `TemplateManifest` contract introduced in T9875 and consumed by
+ * `cleo init`, `cleo upgrade`, and the scaffold sweeper.
+ *
+ * Subcommands:
+ *   cleo templates list [--kind ...]                        — list every entry
+ *   cleo templates show <id>                                — single entry
+ *   cleo templates install <id> [--project <root>]          — install one
+ *   cleo templates upgrade <id> [--project <root>] [--diff] — reconcile
+ *   cleo templates diff <id> [--project <root>]             — diff vs deployed
+ *   cleo templates validate [--id <id>] [--project <root>]  — sanity-check
+ *
+ * @task T9886
+ * @saga T9855
+ * @epic T9874
+ * @adr 076
+ */
+
+import { showUsage } from 'citty';
+import { defineCommand } from '../lib/define-cli-command.js';
+import {
+  templatesDiffCommand,
+  templatesInstallCommand,
+  templatesListCommand,
+  templatesShowCommand,
+  templatesUpgradeCommand,
+  templatesValidateCommand,
+} from './templates/index.js';
+
+/**
+ * Root templates command group.
+ *
+ * Operator surface for the SSoT TemplateManifest registry (T9875 contracts +
+ * T9877 CORE registry). Each sub-verb is implemented in `./templates/` and
+ * mounted here.
+ *
+ * @public
+ */
+export const templatesCommand = defineCommand({
+  meta: {
+    name: 'templates',
+    description:
+      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+  },
+  subCommands: {
+    list: templatesListCommand,
+    show: templatesShowCommand,
+    install: templatesInstallCommand,
+    upgrade: templatesUpgradeCommand,
+    diff: templatesDiffCommand,
+    validate: templatesValidateCommand,
+  },
+  async run({ cmd, rawArgs }) {
+    const firstArg = rawArgs?.find((a) => !a.startsWith('-'));
+    if (firstArg && cmd.subCommands && firstArg in cmd.subCommands) return;
+    await showUsage(cmd);
+  },
+});

--- a/packages/cleo/src/cli/commands/templates/__tests__/templates.test.ts
+++ b/packages/cleo/src/cli/commands/templates/__tests__/templates.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Tests for `cleo templates {list, show, install, upgrade, diff, validate}` —
+ * verifies the CLI namespace wires into the CORE registry (T9877) end-to-end.
+ *
+ * Each test uses an isolated `os.tmpdir()` project root so the host repo's
+ * `.cleo/` and `.github/workflows/` are never touched. The renderer layer is
+ * mocked so `cliOutput`/`cliError` calls are observable.
+ *
+ * @task T9886
+ * @saga T9855
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the renderer so cliOutput/cliError become observable spies.
+const mockCliOutput = vi.fn();
+const mockCliError = vi.fn();
+vi.mock('../../../renderers/index.js', () => ({
+  cliOutput: (...args: unknown[]) => mockCliOutput(...args),
+  cliError: (...args: unknown[]) => mockCliError(...args),
+}));
+
+// Imports AFTER the renderer mock so commands close over the spies.
+import { getTemplateManifest, resolveSourcePathAbsolute } from '@cleocode/core/templates/registry';
+import { templatesDiffCommand } from '../diff.js';
+import { templatesInstallCommand } from '../install.js';
+import { templatesListCommand } from '../list.js';
+import { templatesShowCommand } from '../show.js';
+import { templatesUpgradeCommand } from '../upgrade.js';
+import { templatesValidateCommand } from '../validate.js';
+
+type RunArgs = Record<string, unknown>;
+type CittyCommand = {
+  run?: (ctx: { args: RunArgs; rawArgs: string[] }) => Promise<void> | void;
+};
+
+async function invoke(cmd: CittyCommand, args: RunArgs): Promise<void> {
+  const run = cmd.run;
+  if (!run) throw new Error('command has no run()');
+  await run({ args, rawArgs: [] });
+}
+
+let tempRoot = '';
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), 'cleo-templates-test-'));
+  vi.clearAllMocks();
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
+    throw new Error(`__EXIT__:${code ?? 0}`);
+  }) as never);
+});
+
+afterEach(() => {
+  exitSpy.mockRestore();
+  if (tempRoot) {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+/** First entry of `kind === 'workflow'` — used as a canonical fixture target. */
+function firstWorkflowId(): string {
+  const wf = getTemplateManifest().find((e) => e.kind === 'workflow');
+  if (!wf) throw new Error('no workflow templates registered — registry shape changed');
+  return wf.id;
+}
+
+// ---------------------------------------------------------------------------
+// cleo templates list
+// ---------------------------------------------------------------------------
+
+describe('cleo templates list', () => {
+  it('returns every registered entry when no --kind is given', async () => {
+    await invoke(templatesListCommand, {});
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data, opts] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { kind: unknown; entries: unknown[] };
+    expect(payload.kind).toBeNull();
+    expect(Array.isArray(payload.entries)).toBe(true);
+    expect(payload.entries.length).toBeGreaterThan(0);
+    expect(opts).toMatchObject({ command: 'templates-list', operation: 'templates.list' });
+    expect(mockCliError).not.toHaveBeenCalled();
+  });
+
+  it('filters entries when --kind=workflow is given', async () => {
+    await invoke(templatesListCommand, { kind: 'workflow' });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { kind: string; entries: Array<{ kind: string }> };
+    expect(payload.kind).toBe('workflow');
+    expect(payload.entries.length).toBeGreaterThan(0);
+    for (const entry of payload.entries) {
+      expect(entry.kind).toBe('workflow');
+    }
+  });
+
+  it('rejects an unknown --kind with a typed error envelope', async () => {
+    await expect(invoke(templatesListCommand, { kind: 'bogus' })).rejects.toThrow(/__EXIT__:2/);
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [message, code, details] = mockCliError.mock.calls[0]!;
+    expect(message).toMatch(/invalid --kind/);
+    expect(code).toBe(2);
+    expect(details).toMatchObject({ name: 'E_TEMPLATES_LIST_FAILED' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo templates show
+// ---------------------------------------------------------------------------
+
+describe('cleo templates show', () => {
+  it('returns the matching entry for a known id', async () => {
+    const id = firstWorkflowId();
+    await invoke(templatesShowCommand, { id });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { id: string; entry: { id: string; kind: string } };
+    expect(payload.id).toBe(id);
+    expect(payload.entry.id).toBe(id);
+  });
+
+  it('returns E_NOT_FOUND for an unknown id', async () => {
+    await expect(invoke(templatesShowCommand, { id: 'definitely-not-a-template' })).rejects.toThrow(
+      /__EXIT__:4/,
+    );
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [message, code, details] = mockCliError.mock.calls[0]!;
+    expect(message).toMatch(/not found/);
+    expect(code).toBe(4);
+    expect(details).toMatchObject({ name: 'E_NOT_FOUND' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo templates install
+// ---------------------------------------------------------------------------
+
+describe('cleo templates install', () => {
+  it('writes the rendered file to the install path', async () => {
+    const id = firstWorkflowId();
+    await invoke(templatesInstallCommand, { id, project: tempRoot });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { id: string; installPath: string; installed: boolean; noop: boolean };
+    expect(payload.id).toBe(id);
+    expect(payload.installed).toBe(true);
+    expect(payload.noop).toBe(false);
+    expect(existsSync(payload.installPath)).toBe(true);
+  });
+
+  it('is idempotent — second install on identical content is a noop', async () => {
+    const id = firstWorkflowId();
+    await invoke(templatesInstallCommand, { id, project: tempRoot });
+    mockCliOutput.mockClear();
+
+    await invoke(templatesInstallCommand, { id, project: tempRoot });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { installed: boolean; noop: boolean };
+    expect(payload.installed).toBe(false);
+    expect(payload.noop).toBe(true);
+  });
+
+  it('writes the same bytes as the rendered source', async () => {
+    const id = firstWorkflowId();
+    const entry = getTemplateManifest().find((e) => e.id === id)!;
+    const source = readFileSync(resolveSourcePathAbsolute(entry), 'utf8');
+
+    await invoke(templatesInstallCommand, { id, project: tempRoot });
+
+    const installed = readFileSync(join(tempRoot, entry.installPath), 'utf8');
+    expect(installed).toBe(source);
+  });
+
+  it('returns E_NOT_FOUND for an unknown id', async () => {
+    await expect(
+      invoke(templatesInstallCommand, { id: 'definitely-not-a-template', project: tempRoot }),
+    ).rejects.toThrow(/__EXIT__:4/);
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [, , details] = mockCliError.mock.calls[0]!;
+    expect(details).toMatchObject({ name: 'E_NOT_FOUND' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo templates diff
+// ---------------------------------------------------------------------------
+
+describe('cleo templates diff', () => {
+  it('returns same=true after a fresh install (exit 0)', async () => {
+    const id = firstWorkflowId();
+    await invoke(templatesInstallCommand, { id, project: tempRoot });
+    mockCliOutput.mockClear();
+
+    await invoke(templatesDiffCommand, { id, project: tempRoot });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { same: boolean; missing: boolean; diff: string };
+    expect(payload.same).toBe(true);
+    expect(payload.missing).toBe(false);
+    expect(payload.diff).toBe('');
+  });
+
+  it('returns missing=true (exit 1) when nothing is installed', async () => {
+    const id = firstWorkflowId();
+
+    await expect(invoke(templatesDiffCommand, { id, project: tempRoot })).rejects.toThrow(
+      /__EXIT__:1/,
+    );
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { same: boolean; missing: boolean; diff: string };
+    expect(payload.same).toBe(false);
+    expect(payload.missing).toBe(true);
+    expect(payload.diff.length).toBeGreaterThan(0);
+  });
+
+  it('returns same=false (exit 1) when the deployed file drifted', async () => {
+    const id = firstWorkflowId();
+    const entry = getTemplateManifest().find((e) => e.id === id)!;
+    const installPath = join(tempRoot, entry.installPath);
+    mkdirSync(dirname(installPath), { recursive: true });
+    writeFileSync(installPath, 'totally different content\n', 'utf8');
+
+    await expect(invoke(templatesDiffCommand, { id, project: tempRoot })).rejects.toThrow(
+      /__EXIT__:1/,
+    );
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { same: boolean; missing: boolean; diff: string };
+    expect(payload.same).toBe(false);
+    expect(payload.missing).toBe(false);
+    expect(payload.diff.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo templates upgrade
+// ---------------------------------------------------------------------------
+
+describe('cleo templates upgrade', () => {
+  it('overwrites a drifted file for overwrite-on-bump strategy', async () => {
+    const entry = getTemplateManifest().find((e) => e.updateStrategy === 'overwrite-on-bump');
+    if (!entry) throw new Error('no overwrite-on-bump entries registered — registry shape changed');
+    const installPath = join(tempRoot, entry.installPath);
+    mkdirSync(dirname(installPath), { recursive: true });
+    writeFileSync(installPath, 'drifted content\n', 'utf8');
+
+    await invoke(templatesUpgradeCommand, { id: entry.id, project: tempRoot });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { outcome: string };
+    expect(payload.outcome).toBe('overwritten');
+
+    const renderedSource = readFileSync(resolveSourcePathAbsolute(entry), 'utf8');
+    expect(readFileSync(installPath, 'utf8')).toBe(renderedSource);
+  });
+
+  it('returns noop when the deployed file already matches', async () => {
+    const entry = getTemplateManifest().find((e) => e.updateStrategy === 'overwrite-on-bump');
+    if (!entry) throw new Error('no overwrite-on-bump entries registered');
+    await invoke(templatesInstallCommand, { id: entry.id, project: tempRoot });
+    mockCliOutput.mockClear();
+
+    await invoke(templatesUpgradeCommand, { id: entry.id, project: tempRoot });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { outcome: string };
+    expect(payload.outcome).toBe('noop');
+  });
+
+  it('skips an immutable strategy entry even when drift exists', async () => {
+    const entry = getTemplateManifest().find((e) => e.updateStrategy === 'immutable');
+    if (!entry) {
+      return; // No immutable entries registered — skip rather than fail.
+    }
+    const installPath = join(tempRoot, entry.installPath);
+    mkdirSync(dirname(installPath), { recursive: true });
+    writeFileSync(installPath, 'user-customised content\n', 'utf8');
+
+    await invoke(templatesUpgradeCommand, { id: entry.id, project: tempRoot });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { outcome: string };
+    expect(payload.outcome).toBe('skipped');
+    expect(readFileSync(installPath, 'utf8')).toBe('user-customised content\n');
+  });
+
+  it('respects --diff as preview-only (no write)', async () => {
+    const entry = getTemplateManifest().find((e) => e.updateStrategy === 'overwrite-on-bump');
+    if (!entry) throw new Error('no overwrite-on-bump entries registered');
+    const installPath = join(tempRoot, entry.installPath);
+    mkdirSync(dirname(installPath), { recursive: true });
+    writeFileSync(installPath, 'drifted content\n', 'utf8');
+
+    await invoke(templatesUpgradeCommand, { id: entry.id, project: tempRoot, diff: true });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { outcome: string; diff: string };
+    expect(payload.outcome).toBe('skipped');
+    expect(payload.diff.length).toBeGreaterThan(0);
+    expect(readFileSync(installPath, 'utf8')).toBe('drifted content\n');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleo templates validate
+// ---------------------------------------------------------------------------
+
+describe('cleo templates validate', () => {
+  it('returns ok=true when every source path resolves', async () => {
+    await invoke(templatesValidateCommand, { project: tempRoot });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as { ok: boolean; count: number; entries: unknown[] };
+    expect(payload.ok).toBe(true);
+    expect(payload.count).toBeGreaterThan(0);
+    expect(payload.entries.length).toBe(payload.count);
+  });
+
+  it('reports installed=false for a fresh project root', async () => {
+    const id = firstWorkflowId();
+    await invoke(templatesValidateCommand, { id, project: tempRoot });
+
+    expect(mockCliOutput).toHaveBeenCalledOnce();
+    const [data] = mockCliOutput.mock.calls[0]!;
+    const payload = data as {
+      ok: boolean;
+      entries: Array<{ id: string; installed: boolean; sourceExists: boolean }>;
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.entries).toHaveLength(1);
+    expect(payload.entries[0]?.id).toBe(id);
+    expect(payload.entries[0]?.sourceExists).toBe(true);
+    expect(payload.entries[0]?.installed).toBe(false);
+  });
+
+  it('returns E_NOT_FOUND when --id is unknown', async () => {
+    await expect(
+      invoke(templatesValidateCommand, { id: 'definitely-not-a-template', project: tempRoot }),
+    ).rejects.toThrow(/__EXIT__:4/);
+
+    expect(mockCliError).toHaveBeenCalledOnce();
+    const [, , details] = mockCliError.mock.calls[0]!;
+    expect(details).toMatchObject({ name: 'E_NOT_FOUND' });
+  });
+});

--- a/packages/cleo/src/cli/commands/templates/diff.ts
+++ b/packages/cleo/src/cli/commands/templates/diff.ts
@@ -1,0 +1,165 @@
+/**
+ * `cleo templates diff <id> [--project <root>]` — compute the diff between
+ * a template's rendered source and the deployed copy at its `installPath`.
+ *
+ * Exits 0 when the two are identical (`same: true`); exits 1 when they
+ * differ. The diff payload is a unified-format string suitable for shell
+ * pipelines.
+ *
+ * @task T9886
+ * @saga T9855
+ * @epic T9874
+ * @adr 076
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ExitCode } from '@cleocode/contracts';
+import { getTemplateById } from '@cleocode/core/templates/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+import { applySubstitution, readTemplateSource, resolveProjectRoot } from './lib.js';
+
+/**
+ * Result shape returned by `cleo templates diff`.
+ *
+ * @public
+ */
+export interface TemplatesDiffResult {
+  /** The template id that was diffed. */
+  id: string;
+  /** Absolute path of the install destination. */
+  installPath: string;
+  /** `true` IFF the installed file matches the rendered source byte-for-byte. */
+  same: boolean;
+  /** `true` when no file exists at `installPath` (treated as "differs"). */
+  missing: boolean;
+  /** Unified-format diff body. Empty string when `same === true`. */
+  diff: string;
+}
+
+/**
+ * citty command — `cleo templates diff <id> [--project <root>]`.
+ *
+ * @public
+ */
+export const templatesDiffCommand = defineCommand({
+  meta: {
+    name: 'diff',
+    description: 'Diff a template against its installed copy (exit 0 same, 1 different)',
+  },
+  args: {
+    id: {
+      type: 'positional',
+      required: true,
+      description: 'Template id (kebab-case)',
+    },
+    project: {
+      type: 'string',
+      description: 'Project root to diff against (default: detected project root)',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    const id = String(args['id'] ?? '').trim();
+    if (id.length === 0) {
+      cliError(`templates diff failed: <id> is required`, ExitCode.INVALID_INPUT, {
+        name: 'E_TEMPLATES_DIFF_FAILED',
+      });
+      process.exit(ExitCode.INVALID_INPUT);
+      return;
+    }
+
+    const entry = getTemplateById(id);
+    if (entry === undefined) {
+      cliError(`templates diff failed: id "${id}" not found`, ExitCode.NOT_FOUND, {
+        name: 'E_NOT_FOUND',
+        details: { id },
+      });
+      process.exit(ExitCode.NOT_FOUND);
+      return;
+    }
+
+    let projectRoot: string;
+    let installPath: string;
+    let rendered: string;
+    try {
+      projectRoot = resolveProjectRoot(args['project'] as string | undefined);
+      installPath = join(projectRoot, entry.installPath);
+      const source = readTemplateSource(entry);
+      rendered = applySubstitution(entry, source).rendered;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`templates diff failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_TEMPLATES_DIFF_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    if (!existsSync(installPath)) {
+      const missingResult: TemplatesDiffResult = {
+        id,
+        installPath,
+        same: false,
+        missing: true,
+        diff: `--- (missing) ${installPath}\n+++ (rendered) ${id}\n${unifiedDiff('', rendered)}`,
+      };
+      cliOutput(missingResult, {
+        command: 'templates-diff',
+        operation: 'templates.diff',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    const current = readFileSync(installPath, 'utf8');
+    const same = current === rendered;
+    const result: TemplatesDiffResult = {
+      id,
+      installPath,
+      same,
+      missing: false,
+      diff: same ? '' : unifiedDiff(current, rendered),
+    };
+    cliOutput(result, {
+      command: 'templates-diff',
+      operation: 'templates.diff',
+    });
+    if (!same) {
+      process.exit(ExitCode.GENERAL_ERROR);
+    }
+  },
+});
+
+/**
+ * Minimal line-by-line diff renderer — emits a stable, dependency-free
+ * unified-style body. Each removed line is prefixed `-`, each added line `+`,
+ * unchanged lines are emitted as ` `. Adequate for envelope payloads + the
+ * `cleo templates upgrade --diff` preview path.
+ *
+ * Not intended as a full Hunt-McIlroy diff — when richer output is required,
+ * callers can pipe the rendered text through `git diff --no-index`.
+ *
+ * @internal
+ */
+export function unifiedDiff(a: string, b: string): string {
+  const aLines = a.length === 0 ? [] : a.split('\n');
+  const bLines = b.length === 0 ? [] : b.split('\n');
+  const out: string[] = [];
+  const max = Math.max(aLines.length, bLines.length);
+  for (let i = 0; i < max; i += 1) {
+    const av = aLines[i];
+    const bv = bLines[i];
+    if (av === bv) {
+      if (av !== undefined) out.push(` ${av}`);
+      continue;
+    }
+    if (av !== undefined) out.push(`-${av}`);
+    if (bv !== undefined) out.push(`+${bv}`);
+  }
+  return out.join('\n');
+}

--- a/packages/cleo/src/cli/commands/templates/index.ts
+++ b/packages/cleo/src/cli/commands/templates/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Barrel for the `cleo templates` command group.
+ *
+ * The dispatch wrapper lives at `packages/cleo/src/cli/commands/templates.ts`
+ * (so the command-manifest generator — which only scans top-level
+ * `commands/*.ts` files — picks it up). The wrapper imports the individual
+ * subcommands from this barrel.
+ *
+ * @task T9886
+ * @saga T9855
+ * @epic T9874
+ * @adr 076
+ */
+
+export type { TemplatesDiffResult } from './diff.js';
+export { templatesDiffCommand, unifiedDiff } from './diff.js';
+export type { TemplatesInstallResult } from './install.js';
+export { templatesInstallCommand } from './install.js';
+export type { TemplatesListResult } from './list.js';
+export { templatesListCommand } from './list.js';
+export type { TemplatesShowResult } from './show.js';
+export { templatesShowCommand } from './show.js';
+export type { TemplatesUpgradeOutcome, TemplatesUpgradeResult } from './upgrade.js';
+export { templatesUpgradeCommand } from './upgrade.js';
+export type { TemplatesValidateEntry, TemplatesValidateResult } from './validate.js';
+export { templatesValidateCommand } from './validate.js';

--- a/packages/cleo/src/cli/commands/templates/install.ts
+++ b/packages/cleo/src/cli/commands/templates/install.ts
@@ -1,0 +1,153 @@
+/**
+ * `cleo templates install <id> [--project <root>]` — install a single
+ * template into a project root, respecting its substitution strategy.
+ *
+ * Idempotent: when the destination already exists AND its contents match the
+ * rendered source byte-for-byte, the command emits `installed: false` with
+ * `noop: true` and exits 0. Otherwise the file is written (mkdir -p) and
+ * `installed: true` is reported.
+ *
+ * Substitution is currently a pass-through stub — see `./lib.ts`. The CLI
+ * surface is the same regardless of whether the placeholder pipeline lands
+ * later.
+ *
+ * @task T9886
+ * @saga T9855
+ * @epic T9874
+ * @adr 076
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { ExitCode } from '@cleocode/contracts';
+import { getTemplateById } from '@cleocode/core/templates/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+import { applySubstitution, readTemplateSource, resolveProjectRoot } from './lib.js';
+
+/**
+ * Result shape returned by `cleo templates install`.
+ *
+ * @public
+ */
+export interface TemplatesInstallResult {
+  /** The template id that was installed. */
+  id: string;
+  /** Absolute path of the install destination. */
+  installPath: string;
+  /** `true` when the file was written; `false` when it was already current. */
+  installed: boolean;
+  /** `true` when nothing changed on disk (idempotent skip). */
+  noop: boolean;
+  /** Whether any placeholders were substituted (currently always `false`). */
+  substituted: boolean;
+}
+
+/**
+ * citty command — `cleo templates install <id> [--project <root>]`.
+ *
+ * @public
+ */
+export const templatesInstallCommand = defineCommand({
+  meta: {
+    name: 'install',
+    description: 'Install a template into a project root (default: current project), idempotent',
+  },
+  args: {
+    id: {
+      type: 'positional',
+      required: true,
+      description: 'Template id (kebab-case)',
+    },
+    project: {
+      type: 'string',
+      description: 'Project root to install into (default: detected project root)',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    const id = String(args['id'] ?? '').trim();
+    if (id.length === 0) {
+      cliError(`templates install failed: <id> is required`, ExitCode.INVALID_INPUT, {
+        name: 'E_TEMPLATES_INSTALL_FAILED',
+      });
+      process.exit(ExitCode.INVALID_INPUT);
+      return;
+    }
+
+    const entry = getTemplateById(id);
+    if (entry === undefined) {
+      cliError(`templates install failed: id "${id}" not found`, ExitCode.NOT_FOUND, {
+        name: 'E_NOT_FOUND',
+        details: { id },
+      });
+      process.exit(ExitCode.NOT_FOUND);
+      return;
+    }
+
+    let projectRoot: string;
+    let installPath: string;
+    let rendered: string;
+    let substituted: boolean;
+    try {
+      projectRoot = resolveProjectRoot(args['project'] as string | undefined);
+      installPath = join(projectRoot, entry.installPath);
+      const source = readTemplateSource(entry);
+      const sub = applySubstitution(entry, source);
+      rendered = sub.rendered;
+      substituted = sub.substituted;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`templates install failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_TEMPLATES_INSTALL_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    if (existsSync(installPath)) {
+      const current = readFileSync(installPath, 'utf8');
+      if (current === rendered) {
+        const noopResult: TemplatesInstallResult = {
+          id,
+          installPath,
+          installed: false,
+          noop: true,
+          substituted,
+        };
+        cliOutput(noopResult, {
+          command: 'templates-install',
+          operation: 'templates.install',
+        });
+        return;
+      }
+    }
+
+    try {
+      mkdirSync(dirname(installPath), { recursive: true });
+      writeFileSync(installPath, rendered, 'utf8');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`templates install failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_TEMPLATES_INSTALL_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    const result: TemplatesInstallResult = {
+      id,
+      installPath,
+      installed: true,
+      noop: false,
+      substituted,
+    };
+    cliOutput(result, {
+      command: 'templates-install',
+      operation: 'templates.install',
+    });
+  },
+});

--- a/packages/cleo/src/cli/commands/templates/lib.ts
+++ b/packages/cleo/src/cli/commands/templates/lib.ts
@@ -1,0 +1,65 @@
+/**
+ * Internal helpers shared by `cleo templates {install, upgrade, diff}`.
+ *
+ * Wraps the CORE registry's `resolveSourcePathAbsolute` with filesystem
+ * reads, project-root resolution, and a deliberately minimal substitution
+ * pipeline (currently identity — full `regex-tmpl` substitution is deferred
+ * to a follow-up task per the T9886 brief).
+ *
+ * @task T9886
+ * @saga T9855
+ * @epic T9874
+ * @adr 076
+ */
+
+import { readFileSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+import type { TemplateManifestEntry } from '@cleocode/contracts';
+import { getProjectRoot } from '@cleocode/core';
+import { resolveSourcePathAbsolute } from '@cleocode/core/templates/registry';
+
+/**
+ * Resolve `--project <root>` to an absolute path.
+ *
+ * Relative inputs are resolved against `cwd`; when no input is given we fall
+ * back to `getProjectRoot()` (the canonical SSoT — see ADR-068 §Project Roots).
+ *
+ * @internal
+ */
+export function resolveProjectRoot(raw: string | undefined): string {
+  if (typeof raw === 'string' && raw.length > 0) {
+    return isAbsolute(raw) ? raw : resolve(process.cwd(), raw);
+  }
+  return getProjectRoot();
+}
+
+/**
+ * Read a template's source file off disk, returning its raw bytes as UTF-8.
+ *
+ * @internal
+ */
+export function readTemplateSource(entry: TemplateManifestEntry): string {
+  const sourceAbsolute = resolveSourcePathAbsolute(entry);
+  return readFileSync(sourceAbsolute, 'utf8');
+}
+
+/**
+ * Apply placeholder substitution to a template body.
+ *
+ * Per the T9886 brief, full `regex-tmpl` resolution is deferred — `static`
+ * substitution copies the file byte-for-byte, every other strategy currently
+ * passes through as identity. The signature is shaped so the eventual
+ * placeholder pipeline can land without breaking call sites.
+ *
+ * @internal
+ */
+export function applySubstitution(
+  entry: TemplateManifestEntry,
+  source: string,
+): { rendered: string; substituted: boolean } {
+  if (entry.substitution === 'static') {
+    return { rendered: source, substituted: false };
+  }
+  // TODO(T9886-followup): wire placeholders through project-context / config.
+  return { rendered: source, substituted: false };
+}

--- a/packages/cleo/src/cli/commands/templates/list.ts
+++ b/packages/cleo/src/cli/commands/templates/list.ts
@@ -1,0 +1,91 @@
+/**
+ * `cleo templates list [--kind ...]` — list every template the registry
+ * knows about, optionally filtered by `TemplateKind`.
+ *
+ * Thin wrapper over `getTemplateManifest` / `getTemplatesByKind` from the
+ * CORE registry (`@cleocode/core/templates/registry`, T9877).
+ *
+ * @task T9886
+ * @saga T9855
+ * @epic T9874
+ * @adr 076
+ */
+
+import {
+  ExitCode,
+  TEMPLATE_KINDS,
+  type TemplateKind,
+  type TemplateManifestEntry,
+} from '@cleocode/contracts';
+import { getTemplateManifest, getTemplatesByKind } from '@cleocode/core/templates/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+/**
+ * Result shape returned by `cleo templates list`.
+ *
+ * Carries the (optional) kind filter that was applied and the matching
+ * registry entries.
+ *
+ * @public
+ */
+export interface TemplatesListResult {
+  /** The kind filter that was applied, or `null` when no filter was given. */
+  kind: TemplateKind | null;
+  /** Matching template manifest entries. */
+  entries: readonly TemplateManifestEntry[];
+}
+
+/**
+ * citty command — `cleo templates list [--kind ...]`.
+ *
+ * @public
+ */
+export const templatesListCommand = defineCommand({
+  meta: {
+    name: 'list',
+    description: 'List every template the registry knows about (optionally filtered by --kind)',
+  },
+  args: {
+    kind: {
+      type: 'string',
+      description: `Optional kind filter: ${TEMPLATE_KINDS.join(' | ')}`,
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    const rawKind = args['kind'];
+    const kind = parseTemplateKind(typeof rawKind === 'string' ? rawKind : undefined);
+    if (kind === null && rawKind !== undefined && rawKind !== '') {
+      cliError(
+        `templates list failed: invalid --kind (must be ${TEMPLATE_KINDS.join('|')})`,
+        ExitCode.INVALID_INPUT,
+        { name: 'E_TEMPLATES_LIST_FAILED' },
+      );
+      process.exit(ExitCode.INVALID_INPUT);
+      return;
+    }
+
+    const entries = kind === null ? getTemplateManifest() : getTemplatesByKind(kind);
+    const result: TemplatesListResult = { kind, entries };
+    cliOutput(result, {
+      command: 'templates-list',
+      operation: 'templates.list',
+    });
+  },
+});
+
+/**
+ * Validate a string against the `TemplateKind` union. Returns `null` for
+ * unset/empty input AND for unknown values — callers distinguish "no filter"
+ * from "bad filter" by checking the original argument.
+ *
+ * @internal
+ */
+function parseTemplateKind(raw: string | undefined): TemplateKind | null {
+  if (raw === undefined || raw === '') return null;
+  return (TEMPLATE_KINDS as readonly string[]).includes(raw) ? (raw as TemplateKind) : null;
+}

--- a/packages/cleo/src/cli/commands/templates/show.ts
+++ b/packages/cleo/src/cli/commands/templates/show.ts
@@ -1,0 +1,78 @@
+/**
+ * `cleo templates show <id>` — print a single template registry entry.
+ *
+ * Thin wrapper over `getTemplateById` from the CORE registry
+ * (`@cleocode/core/templates/registry`, T9877). Returns `E_NOT_FOUND` when
+ * the id is unknown.
+ *
+ * @task T9886
+ * @saga T9855
+ * @epic T9874
+ * @adr 076
+ */
+
+import { ExitCode, type TemplateManifestEntry } from '@cleocode/contracts';
+import { getTemplateById } from '@cleocode/core/templates/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+/**
+ * Result shape returned by `cleo templates show`.
+ *
+ * @public
+ */
+export interface TemplatesShowResult {
+  /** The id that was requested. */
+  id: string;
+  /** The matching manifest entry. */
+  entry: TemplateManifestEntry;
+}
+
+/**
+ * citty command — `cleo templates show <id>`.
+ *
+ * @public
+ */
+export const templatesShowCommand = defineCommand({
+  meta: {
+    name: 'show',
+    description: 'Print a single template manifest entry by id',
+  },
+  args: {
+    id: {
+      type: 'positional',
+      required: true,
+      description: 'Template id (kebab-case)',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    const id = String(args['id'] ?? '').trim();
+    if (id.length === 0) {
+      cliError(`templates show failed: <id> is required`, ExitCode.INVALID_INPUT, {
+        name: 'E_TEMPLATES_SHOW_FAILED',
+      });
+      process.exit(ExitCode.INVALID_INPUT);
+      return;
+    }
+
+    const entry = getTemplateById(id);
+    if (entry === undefined) {
+      cliError(`templates show failed: id "${id}" not found`, ExitCode.NOT_FOUND, {
+        name: 'E_NOT_FOUND',
+        details: { id },
+      });
+      process.exit(ExitCode.NOT_FOUND);
+      return;
+    }
+
+    const result: TemplatesShowResult = { id, entry };
+    cliOutput(result, {
+      command: 'templates-show',
+      operation: 'templates.show',
+    });
+  },
+});

--- a/packages/cleo/src/cli/commands/templates/upgrade.ts
+++ b/packages/cleo/src/cli/commands/templates/upgrade.ts
@@ -1,0 +1,204 @@
+/**
+ * `cleo templates upgrade <id> [--project <root>] [--diff] [--accept]` —
+ * reconcile an installed template against the shipped copy, respecting the
+ * entry's `updateStrategy`.
+ *
+ * Strategy semantics:
+ *   - `overwrite-on-bump` — overwrite unconditionally.
+ *   - `diff-prompt`       — emit the diff; require `--accept` to apply.
+ *   - `immutable`         — never overwrite; return `skipped: true`.
+ *   - `manifest-merge`    — three-way merge (stub: returns `notSupported`).
+ *
+ * The `--diff` flag forces preview-only mode regardless of strategy — useful
+ * for CI dry-runs and `templates diff` consumers that want a single CLI
+ * surface for "what would change".
+ *
+ * @task T9886
+ * @saga T9855
+ * @epic T9874
+ * @adr 076
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { ExitCode, type UpdateStrategy } from '@cleocode/contracts';
+import { getTemplateById } from '@cleocode/core/templates/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+import { unifiedDiff } from './diff.js';
+import { applySubstitution, readTemplateSource, resolveProjectRoot } from './lib.js';
+
+/**
+ * Outcome discriminator emitted by `cleo templates upgrade`.
+ *
+ * - `overwritten` — the destination file was replaced.
+ * - `noop`        — destination already matched the rendered source.
+ * - `skipped`     — `immutable` strategy or `diff-prompt` without `--accept`.
+ * - `not-supported` — strategy not yet implemented (e.g. `manifest-merge`).
+ *
+ * @public
+ */
+export type TemplatesUpgradeOutcome = 'overwritten' | 'noop' | 'skipped' | 'not-supported';
+
+/**
+ * Result shape returned by `cleo templates upgrade`.
+ *
+ * @public
+ */
+export interface TemplatesUpgradeResult {
+  /** The template id that was reconciled. */
+  id: string;
+  /** Absolute path of the install destination. */
+  installPath: string;
+  /** The entry's declared `updateStrategy`. */
+  updateStrategy: UpdateStrategy;
+  /** What actually happened. */
+  outcome: TemplatesUpgradeOutcome;
+  /** Why we took that path — surfaced for humans + CI logs. */
+  reason: string;
+  /** Diff body (unified-style) when applicable; empty otherwise. */
+  diff: string;
+}
+
+/**
+ * citty command — `cleo templates upgrade <id> [--project <root>] [--diff] [--accept]`.
+ *
+ * @public
+ */
+export const templatesUpgradeCommand = defineCommand({
+  meta: {
+    name: 'upgrade',
+    description:
+      'Re-install a template respecting its updateStrategy (overwrite | diff-prompt | immutable | manifest-merge)',
+  },
+  args: {
+    id: {
+      type: 'positional',
+      required: true,
+      description: 'Template id (kebab-case)',
+    },
+    project: {
+      type: 'string',
+      description: 'Project root to upgrade against (default: detected project root)',
+    },
+    diff: {
+      type: 'boolean',
+      description: 'Preview-only — print the diff without writing',
+    },
+    accept: {
+      type: 'boolean',
+      description: 'Apply when strategy is diff-prompt (no-op otherwise)',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    const id = String(args['id'] ?? '').trim();
+    if (id.length === 0) {
+      cliError(`templates upgrade failed: <id> is required`, ExitCode.INVALID_INPUT, {
+        name: 'E_TEMPLATES_UPGRADE_FAILED',
+      });
+      process.exit(ExitCode.INVALID_INPUT);
+      return;
+    }
+
+    const entry = getTemplateById(id);
+    if (entry === undefined) {
+      cliError(`templates upgrade failed: id "${id}" not found`, ExitCode.NOT_FOUND, {
+        name: 'E_NOT_FOUND',
+        details: { id },
+      });
+      process.exit(ExitCode.NOT_FOUND);
+      return;
+    }
+
+    let projectRoot: string;
+    let installPath: string;
+    let rendered: string;
+    try {
+      projectRoot = resolveProjectRoot(args['project'] as string | undefined);
+      installPath = join(projectRoot, entry.installPath);
+      const source = readTemplateSource(entry);
+      rendered = applySubstitution(entry, source).rendered;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`templates upgrade failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_TEMPLATES_UPGRADE_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    const previewOnly = args['diff'] === true;
+    const accept = args['accept'] === true;
+    const current = existsSync(installPath) ? readFileSync(installPath, 'utf8') : null;
+    const diffBody =
+      current === null ? '' : current === rendered ? '' : unifiedDiff(current, rendered);
+
+    let outcome: TemplatesUpgradeOutcome;
+    let reason: string;
+    let shouldWrite = false;
+
+    if (entry.updateStrategy === 'manifest-merge') {
+      outcome = 'not-supported';
+      reason = 'manifest-merge upgrade is not yet supported (T9886-followup)';
+    } else if (entry.updateStrategy === 'immutable') {
+      outcome = 'skipped';
+      reason =
+        current === null
+          ? 'immutable: not installed yet — use `install`'
+          : 'immutable: skipped per strategy';
+    } else if (current !== null && current === rendered) {
+      outcome = 'noop';
+      reason = 'already current';
+    } else if (entry.updateStrategy === 'overwrite-on-bump') {
+      if (previewOnly) {
+        outcome = 'skipped';
+        reason = 'preview-only (--diff)';
+      } else {
+        outcome = 'overwritten';
+        reason = current === null ? 'fresh install' : 'overwrite-on-bump';
+        shouldWrite = true;
+      }
+    } else {
+      // diff-prompt
+      if (previewOnly || !accept) {
+        outcome = 'skipped';
+        reason = previewOnly ? 'preview-only (--diff)' : 'diff-prompt: pass --accept to apply';
+      } else {
+        outcome = 'overwritten';
+        reason = 'diff-prompt: accepted';
+        shouldWrite = true;
+      }
+    }
+
+    if (shouldWrite) {
+      try {
+        mkdirSync(dirname(installPath), { recursive: true });
+        writeFileSync(installPath, rendered, 'utf8');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        cliError(`templates upgrade failed: ${message}`, ExitCode.GENERAL_ERROR, {
+          name: 'E_TEMPLATES_UPGRADE_FAILED',
+        });
+        process.exit(ExitCode.GENERAL_ERROR);
+        return;
+      }
+    }
+
+    const result: TemplatesUpgradeResult = {
+      id,
+      installPath,
+      updateStrategy: entry.updateStrategy,
+      outcome,
+      reason,
+      diff: diffBody,
+    };
+    cliOutput(result, {
+      command: 'templates-upgrade',
+      operation: 'templates.upgrade',
+    });
+  },
+});

--- a/packages/cleo/src/cli/commands/templates/validate.ts
+++ b/packages/cleo/src/cli/commands/templates/validate.ts
@@ -1,0 +1,167 @@
+/**
+ * `cleo templates validate [--id <id>]` — verify the registry's invariants
+ * against the live filesystem.
+ *
+ * Two checks per entry:
+ *   1. The source file at `resolveSourcePathAbsolute(entry)` exists.
+ *   2. `getInstalledStatus(id, projectRoot)` resolves without throwing.
+ *
+ * Without `--id` the command walks every entry returned by
+ * `getTemplateManifest()`. With `--id` it validates a single entry and
+ * returns `E_NOT_FOUND` when the id is unknown.
+ *
+ * Exits 0 when every check passes; exits with `VALIDATION_ERROR` (6) when
+ * any entry reports a failure.
+ *
+ * @task T9886
+ * @saga T9855
+ * @epic T9874
+ * @adr 076
+ */
+
+import { ExitCode, type TemplateKind } from '@cleocode/contracts';
+import {
+  getInstalledStatus,
+  getTemplateById,
+  getTemplateManifest,
+  resolveSourcePathAbsolute,
+} from '@cleocode/core/templates/registry';
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+import { resolveProjectRoot } from './lib.js';
+
+/**
+ * Per-entry validation outcome.
+ *
+ * @public
+ */
+export interface TemplatesValidateEntry {
+  /** Template id from the manifest. */
+  id: string;
+  /** Template kind. */
+  kind: TemplateKind;
+  /** `true` when the source file resolves and exists on disk. */
+  sourceExists: boolean;
+  /** Absolute path the registry resolved for the source (when resolvable). */
+  sourcePath: string | null;
+  /** `true` when the installed copy exists at the destination. */
+  installed: boolean;
+  /** Absolute path of the install destination. */
+  installPath: string | null;
+  /** Validation issues — empty when the entry is clean. */
+  issues: string[];
+}
+
+/**
+ * Result shape returned by `cleo templates validate`.
+ *
+ * @public
+ */
+export interface TemplatesValidateResult {
+  /** `true` IFF every entry in `entries` passed every gate. */
+  ok: boolean;
+  /** Number of entries validated. */
+  count: number;
+  /** Per-entry breakdown. */
+  entries: TemplatesValidateEntry[];
+}
+
+/**
+ * citty command — `cleo templates validate [--id <id>] [--project <root>]`.
+ *
+ * @public
+ */
+export const templatesValidateCommand = defineCommand({
+  meta: {
+    name: 'validate',
+    description: 'Validate every registry entry (or one --id) against the live filesystem',
+  },
+  args: {
+    id: {
+      type: 'string',
+      description: 'Validate a single entry by id (default: walk every entry)',
+    },
+    project: {
+      type: 'string',
+      description: 'Project root to probe install status against (default: detected)',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+  },
+  async run({ args }) {
+    let projectRoot: string;
+    try {
+      projectRoot = resolveProjectRoot(args['project'] as string | undefined);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`templates validate failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_TEMPLATES_VALIDATE_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+      return;
+    }
+
+    const idFilter = typeof args['id'] === 'string' && args['id'].length > 0 ? args['id'] : null;
+    let targets: ReturnType<typeof getTemplateManifest>;
+    if (idFilter === null) {
+      targets = getTemplateManifest();
+    } else {
+      const entry = getTemplateById(idFilter);
+      if (entry === undefined) {
+        cliError(`templates validate failed: id "${idFilter}" not found`, ExitCode.NOT_FOUND, {
+          name: 'E_NOT_FOUND',
+          details: { id: idFilter },
+        });
+        process.exit(ExitCode.NOT_FOUND);
+        return;
+      }
+      targets = [entry];
+    }
+
+    const entries: TemplatesValidateEntry[] = targets.map((entry) => {
+      const issues: string[] = [];
+      let sourcePath: string | null = null;
+      let sourceExists = false;
+      try {
+        sourcePath = resolveSourcePathAbsolute(entry);
+        sourceExists = true;
+      } catch (err) {
+        issues.push(`source: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      let installed = false;
+      let installPath: string | null = null;
+      try {
+        const status = getInstalledStatus(entry.id, projectRoot);
+        installed = status.installed;
+        installPath = status.path;
+      } catch (err) {
+        issues.push(`install: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      return {
+        id: entry.id,
+        kind: entry.kind,
+        sourceExists,
+        sourcePath,
+        installed,
+        installPath,
+        issues,
+      };
+    });
+
+    const ok = entries.every((e) => e.issues.length === 0);
+    const result: TemplatesValidateResult = {
+      ok,
+      count: entries.length,
+      entries,
+    };
+    cliOutput(result, {
+      command: 'templates-validate',
+      operation: 'templates.validate',
+    });
+    if (!ok) {
+      process.exit(ExitCode.VALIDATION_ERROR);
+    }
+  },
+});

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -45,7 +44,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description:
+      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,8 +63,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +84,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,26 +102,31 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description:
+      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () =>
+      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -141,7 +149,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -231,7 +240,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description:
+      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -250,7 +260,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -273,14 +284,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -304,7 +317,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -315,7 +329,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -328,19 +343,24 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
+    description:
+      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () =>
+      (await import('../commands/doctor-legacy-backups.js'))
+        .doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -376,7 +396,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -399,7 +420,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description:
+      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -430,7 +452,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -453,14 +476,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -489,7 +515,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -531,14 +558,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -567,7 +597,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -579,13 +610,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -628,7 +661,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -639,7 +673,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -675,7 +710,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description:
+      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -687,7 +723,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -699,7 +736,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -747,13 +785,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description:
+      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -825,7 +865,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'templatesCommand',
     name: 'templates',
-    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    description:
+      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
     load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
   },
   {
@@ -837,7 +878,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -849,13 +891,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description:
+      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -44,8 +45,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description:
-      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -84,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -102,31 +99,26 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description:
-      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () =>
-      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -149,8 +141,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -240,8 +231,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description:
-      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -260,8 +250,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -284,16 +273,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -317,8 +304,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -329,8 +315,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -343,24 +328,19 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () =>
-      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description:
-      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () =>
-      (await import('../commands/doctor-legacy-backups.js'))
-        .doctorLegacyBackupsCommand as CommandDef,
+    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -396,8 +376,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -420,8 +399,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description:
-      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -452,8 +430,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -476,17 +453,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -515,8 +489,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -558,17 +531,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -597,8 +567,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -610,15 +579,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -661,8 +628,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -673,8 +639,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description:
-      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -710,8 +675,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description:
-      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -723,8 +687,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -736,8 +699,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -785,15 +747,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -863,6 +823,12 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     load: async () => (await import('../commands/telemetry.js')).telemetryCommand as CommandDef,
   },
   {
+    exportName: 'templatesCommand',
+    name: 'templates',
+    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
+  },
+  {
     exportName: 'testingCommand',
     name: 'testing',
     description: 'Validate testing protocol compliance',
@@ -871,8 +837,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -884,15 +849,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description:
-      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -261,6 +261,12 @@ export default defineConfig({
         '../../packages/core/src/config/registry.ts',
         import.meta.url,
       ).pathname,
+      // T9886: templates/registry subpath — SSoT TemplateManifest registry
+      // (Saga T9855 / E4) consumed by the `cleo templates` CLI surface.
+      '@cleocode/core/templates/registry': new URL(
+        '../../packages/core/src/templates/registry.ts',
+        import.meta.url,
+      ).pathname,
       // T9416: llm subpath imports used by `cleo auth list` / `cleo auth remove`
       '@cleocode/core/llm/credential-pool.js': new URL(
         '../../packages/core/src/llm/credential-pool.ts',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,6 +101,11 @@
       "import": "./dist/config/registry.js",
       "require": "./dist/config/registry.js"
     },
+    "./templates/registry": {
+      "types": "./dist/templates/registry.d.ts",
+      "import": "./dist/templates/registry.js",
+      "require": "./dist/templates/registry.js"
+    },
     "./gc": {
       "types": "./dist/gc/index.d.ts",
       "import": "./dist/gc/index.js",


### PR DESCRIPTION
## Summary
- New `cleo templates` namespace: list, show, install, upgrade, diff, validate.
- Thin wrapper over CORE `getTemplateManifest` / `getTemplateById` / `getTemplatesByKind` / `getInstalledStatus` / `resolveSourcePathAbsolute` (T9877).
- Respects `updateStrategy` from `TemplateManifestEntry` (overwrite-on-bump applies; immutable skips; diff-prompt requires `--accept`; manifest-merge returns `not-supported` stub for follow-up).

## Surface
| Sub-verb | Result envelope |
|---|---|
| `cleo templates list [--kind ...]` | `{ kind, entries }` |
| `cleo templates show <id>` | `{ id, entry }` (E_NOT_FOUND on miss) |
| `cleo templates install <id> [--project <root>]` | `{ id, installPath, installed, noop, substituted }` — idempotent |
| `cleo templates upgrade <id> [--project <root>] [--diff] [--accept]` | `{ id, installPath, updateStrategy, outcome, reason, diff }` |
| `cleo templates diff <id> [--project <root>]` | `{ id, installPath, same, missing, diff }` (exit 1 on drift/missing) |
| `cleo templates validate [--id <id>] [--project <root>]` | `{ ok, count, entries[] }` |

Substitution pipeline is currently a pass-through stub — the CLI surface accepts the same args once the placeholder pipeline lands.

## Wiring
- `packages/core/package.json`: new `./templates/registry` subpath export.
- `build.mjs`: `templates` added to `SUBPATH_DIRS` so the esbuild scanner emits `dist/templates/registry.js`.
- `packages/cleo/vitest.config.ts`: `@cleocode/core/templates/registry` alias added for source-tree resolution.
- `packages/cleo/src/cli/generated/command-manifest.ts`: regenerated to include `templatesCommand`.

## Test plan
- [x] biome check (clean)
- [x] full topology build (`pnpm run build`) green
- [x] templates tests pass (19/19)
- [x] config tests still pass (9/9 — regression check)

Closes T9886
Saga: T9855
ADR: 076