### PR TITLE
fix(T10326): validateTaskType accepts 'saga' (dogfood AC6 hotfix)

### DIFF
--- a/.changeset/t10159-atomic-id-numbering.md
+++ b/.changeset/t10159-atomic-id-numbering.md
@@ -1,0 +1,6 @@
+---
+id: t10159-atomic-id-numbering
+tasks: [T10159]
+kind: feat
+summary: core,docs: atomic ID-numbering utility — replaces fs-readdir slug allocation (T10159 / Saga T9855 / E12; absorbs T10153)
+---

--- a/.changeset/t10326-saga-validator.md
+++ b/.changeset/t10326-saga-validator.md
@@ -1,0 +1,15 @@
+---
+id: t10326-saga-validator
+tasks: [T10326]
+kind: fix
+summary: "validateTaskType accepts 'saga' (closes T10326 dogfood AC6 gap)"
+---
+
+Hotfix following SAGA T10326 SG-SUBSTRATE-RECONCILIATION ship (v2026.5.113):
+`packages/core/src/tasks/add.ts:276` had a hardcoded valid TaskType list
+`['epic', 'task', 'subtask']` that didn't include `'saga'`. This caused
+`cleo add --type saga` to reject with `Invalid task type: saga` despite the
+contract widening + DB enum widening that shipped under T10328 / T10329.
+
+Unblocks the AC6 dogfood requirement that `cleo add --type saga` works
+without label fallback.

--- a/.changeset/t9886-cleo-templates-cli.md
+++ b/.changeset/t9886-cleo-templates-cli.md
@@ -1,0 +1,6 @@
+---
+id: t9886-cleo-templates-cli
+tasks: [T9886]
+kind: feat
+summary: cleo templates {list,show,install,upgrade,diff,validate} CLI namespace (T9886 / Saga T9855 / E4)
+---

--- a/.changeset/t9917-tasks-input-contract-retrofit.md
+++ b/.changeset/t9917-tasks-input-contract-retrofit.md
@@ -1,0 +1,6 @@
+---
+id: t9917-tasks-input-contract-retrofit
+tasks: [T9917]
+kind: refactor
+summary: Retrofit tasks.add, tasks.add-batch, and tasks.update to OperationInputContract (T9917 / closes Epic T9903 / Saga T9855)
+---

--- a/packages/core/src/tasks/__tests__/add.test.ts
+++ b/packages/core/src/tasks/__tests__/add.test.ts
@@ -65,7 +65,8 @@ describe('validatePriority — tasks/add', () => {
 });
 
 describe('validateTaskType', () => {
-  it('accepts epic, task, subtask', () => {
+  it('accepts saga, epic, task, subtask', () => {
+    expect(() => validateTaskType('saga')).not.toThrow();
     expect(() => validateTaskType('epic')).not.toThrow();
     expect(() => validateTaskType('task')).not.toThrow();
     expect(() => validateTaskType('subtask')).not.toThrow();

--- a/packages/core/src/tasks/add.ts
+++ b/packages/core/src/tasks/add.ts
@@ -273,7 +273,7 @@ export function validatePriority(priority: string): asserts priority is TaskPrio
  * @task T4460
  */
 export function validateTaskType(type: string): asserts type is TaskType {
-  const valid: TaskType[] = ['epic', 'task', 'subtask'];
+  const valid: TaskType[] = ['saga', 'epic', 'task', 'subtask'];
   if (!valid.includes(type as TaskType)) {
     throw new CleoError(
       ExitCode.VALIDATION_ERROR,


### PR DESCRIPTION
## Summary

Hotfix following SAGA T10326 SG-SUBSTRATE-RECONCILIATION ship (v2026.5.113):

`packages/core/src/tasks/add.ts:276` had a hardcoded valid TaskType list `['epic', 'task', 'subtask']` that didn't include `'saga'`. This caused `cleo add --type saga` to reject with `Invalid task type: saga (must be epic|task|subtask)` despite the contract widening (T10328) + DB enum widening (T10329) already shipping `'saga'` as a valid TaskType.

Closes the dogfood AC6 gap from SAGA T10326 final closeout — without this fix, the saga's claim of "saga is a first-class TaskType discriminator" isn't actually true for the `cleo add` CLI path.

## Change

- `packages/core/src/tasks/add.ts:276` — add `'saga'` to the valid list
- `packages/core/src/tasks/__tests__/add.test.ts:67-76` — extend test to assert `validateTaskType('saga')` accepts

## Test plan
- [x] Old test that rejects `'story'` still passes
- [x] New assertion: `validateTaskType('saga')` no longer throws
- [x] AC6.2 dogfood: `cleo add --type saga --title 'smoke' --acceptance '...'` succeeds end-to-end after this PR + v2026.5.114 install

Saga: T10326
Refs: ADR-083 §2.5