### PR TITLE
feat(core): auto-populate suggestedNext (T9921 / Saga T9855)

### DIFF
--- a/.changeset/t9921-auto-populate-suggested-next.md
+++ b/.changeset/t9921-auto-populate-suggested-next.md
@@ -1,0 +1,6 @@
+---
+id: t9921-auto-populate-suggested-next
+tasks: [T9921]
+kind: feat
+summary: Auto-populate meta.suggestedNext for tasks.{add,add-batch,update,complete,find} (Saga T9855 / E8.2)
+---

--- a/packages/cleo/src/cli/renderers/index.ts
+++ b/packages/cleo/src/cli/renderers/index.ts
@@ -239,6 +239,10 @@ function pickDecoratorMetaExtensionsLocal(
   const out: Record<string, unknown> = {};
   if (responseMeta['_nexus'] !== undefined) out['_nexus'] = responseMeta['_nexus'];
   if (responseMeta['deprecated'] !== undefined) out['deprecated'] = responseMeta['deprecated'];
+  // T9921 (Saga T9855 / E8.2) — forward auto-populated tasks.* suggestedNext
+  if (responseMeta['suggestedNext'] !== undefined) {
+    out['suggestedNext'] = responseMeta['suggestedNext'];
+  }
   return out;
 }
 

--- a/packages/cleo/src/dispatch/domains/tasks.ts
+++ b/packages/cleo/src/dispatch/domains/tasks.ts
@@ -24,7 +24,7 @@
 
 import type { LafsEnvelope, TaskShowAttachmentEntry, TasksShowResult } from '@cleocode/contracts';
 import type { tasks as coreTasks } from '@cleocode/core';
-import { getLogger, getProjectRoot } from '@cleocode/core';
+import { getLogger, getProjectRoot, TASKS_SUGGESTED_NEXT_BUILDERS } from '@cleocode/core';
 import { createAttachmentStore } from '@cleocode/core/internal';
 // Saga core ops — pure business logic moved out of dispatch in T10124.
 // T10117 adds `sagaRepair` (`saga.repair`) for I5 violation cleanup.
@@ -772,6 +772,61 @@ async function sagaReconcile(params: Record<string, unknown>): Promise<LafsEnvel
 }
 
 // ---------------------------------------------------------------------------
+// suggestedNext auto-population (T9921 — Saga T9855 / E8.2)
+//
+// After a successful dispatch, look up the per-op suggestion builder in
+// `TASKS_SUGGESTED_NEXT_BUILDERS` and stamp the result onto
+// `response.meta.suggestedNext`. Failures (no builder, builder throws,
+// empty result) leave the response untouched — `suggestedNext` is purely
+// additive metadata and must never destabilise the dispatch path.
+//
+// The local `pickDecoratorMetaExtensionsLocal` in renderers/index.ts
+// forwards `suggestedNext` from `response.meta` onto the emitted
+// `CliEnvelope.meta` so agents see the hints in the JSON envelope.
+// ---------------------------------------------------------------------------
+
+/**
+ * Stamp `meta.suggestedNext` onto a successful tasks-domain dispatch response.
+ *
+ * Pure transformer — returns a new response object with `suggestedNext`
+ * merged into `meta`. The original response is never mutated. Errors,
+ * unsupported ops, and ops with no registered builder pass through
+ * unchanged.
+ *
+ * @param response  - The original dispatch response (may be success or error).
+ * @param operation - The tasks operation key (e.g. `'add'`, `'add-batch'`).
+ * @param params    - Raw params passed to the handler.
+ * @returns A new `DispatchResponse` with `meta.suggestedNext` populated
+ *   when a builder is registered and produces a non-empty array; otherwise
+ *   returns the input unchanged.
+ *
+ * @task T9921
+ */
+function stampSuggestedNext(
+  response: DispatchResponse,
+  operation: string,
+  params: Record<string, unknown>,
+): DispatchResponse {
+  if (!response.success) return response;
+  const builder = TASKS_SUGGESTED_NEXT_BUILDERS[operation];
+  if (!builder) return response;
+  let suggestions: string[];
+  try {
+    suggestions = builder(params, response.data);
+  } catch {
+    return response;
+  }
+  if (suggestions.length === 0) return response;
+  return {
+    ...response,
+    meta: {
+      ...response.meta,
+      suggestedNext: suggestions,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // TasksHandler — DomainHandler-compatible wrapper for the registry
 // ---------------------------------------------------------------------------
 
@@ -851,7 +906,14 @@ export class TasksHandler implements DomainHandler {
         operation as keyof TasksOps & string,
         params ?? {},
       );
-      return wrapResult(envelopeToEngineResult(envelope), 'query', 'tasks', operation, startTime);
+      const response = wrapResult(
+        envelopeToEngineResult(envelope),
+        'query',
+        'tasks',
+        operation,
+        startTime,
+      );
+      return stampSuggestedNext(response, operation, params ?? {});
     } catch (error) {
       getLogger('domain:tasks').error(
         { gateway: 'query', domain: 'tasks', operation, err: error },
@@ -947,7 +1009,14 @@ export class TasksHandler implements DomainHandler {
         operation as keyof TasksOps & string,
         params ?? {},
       );
-      return wrapResult(envelopeToEngineResult(envelope), 'mutate', 'tasks', operation, startTime);
+      const response = wrapResult(
+        envelopeToEngineResult(envelope),
+        'mutate',
+        'tasks',
+        operation,
+        startTime,
+      );
+      return stampSuggestedNext(response, operation, params ?? {});
     } catch (error) {
       getLogger('domain:tasks').error(
         { gateway: 'mutate', domain: 'tasks', operation, err: error },

--- a/packages/cleo/src/dispatch/nexus-decorator.ts
+++ b/packages/cleo/src/dispatch/nexus-decorator.ts
@@ -237,6 +237,10 @@ export function pickDecoratorMetaExtensions(
   const out: Record<string, unknown> = {};
   if (responseMeta['_nexus'] !== undefined) out['_nexus'] = responseMeta['_nexus'];
   if (responseMeta['deprecated'] !== undefined) out['deprecated'] = responseMeta['deprecated'];
+  // T9921 (Saga T9855 / E8.2) — forward auto-populated tasks.* suggestedNext
+  if (responseMeta['suggestedNext'] !== undefined) {
+    out['suggestedNext'] = responseMeta['suggestedNext'];
+  }
   return out;
 }
 

--- a/packages/core/src/dispatch/__tests__/suggested-next-auto-populate.test.ts
+++ b/packages/core/src/dispatch/__tests__/suggested-next-auto-populate.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the per-op `suggestedNext` builders introduced in T9921.
+ *
+ * Each builder is a pure `(params, data) => string[]`. The dispatch layer
+ * calls them on every successful tasks.* mutate/find op and stamps the
+ * result onto `DispatchResponse.meta.suggestedNext`. Asserting the pure
+ * function output here keeps the test free of the cleo dispatch
+ * infrastructure; integration coverage of the wiring lives in
+ * `packages/cleo/src/dispatch/domains/__tests__/`.
+ *
+ * @epic T9919
+ * @task T9921
+ * @saga T9855
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildTasksAddBatchSuggestedNext,
+  buildTasksAddSuggestedNext,
+  buildTasksCompleteSuggestedNext,
+  buildTasksFindSuggestedNext,
+  buildTasksUpdateSuggestedNext,
+  TASKS_SUGGESTED_NEXT_BUILDERS,
+} from '../suggested-next.js';
+
+describe('buildTasksAddSuggestedNext (T9921)', () => {
+  it('interpolates the created task id into both suggestions', () => {
+    const out = buildTasksAddSuggestedNext({}, { task: { id: 'T1234' } });
+    expect(out).toEqual(['cleo show T1234', 'cleo focus T1234']);
+  });
+
+  it('returns [] when result has no task id', () => {
+    expect(buildTasksAddSuggestedNext({}, undefined)).toEqual([]);
+    expect(buildTasksAddSuggestedNext({}, {})).toEqual([]);
+    expect(buildTasksAddSuggestedNext({}, { task: {} })).toEqual([]);
+  });
+
+  it('returns [] when task id is empty string', () => {
+    expect(buildTasksAddSuggestedNext({}, { task: { id: '' } })).toEqual([]);
+  });
+});
+
+describe('buildTasksAddBatchSuggestedNext (T9921)', () => {
+  it('returns 2 entries referencing the defaultParent param', () => {
+    const out = buildTasksAddBatchSuggestedNext({ defaultParent: 'T9999' }, {});
+    expect(out).toEqual(['cleo list --parent T9999', 'cleo orchestrate ready --epic T9999']);
+  });
+
+  it('returns [] when defaultParent is absent', () => {
+    expect(buildTasksAddBatchSuggestedNext({}, {})).toEqual([]);
+  });
+
+  it('returns [] when defaultParent is empty string', () => {
+    expect(buildTasksAddBatchSuggestedNext({ defaultParent: '' }, {})).toEqual([]);
+  });
+
+  it('returns [] when defaultParent is not a string', () => {
+    expect(buildTasksAddBatchSuggestedNext({ defaultParent: 42 }, {})).toEqual([]);
+  });
+});
+
+describe('buildTasksUpdateSuggestedNext (T9921)', () => {
+  it('interpolates the updated task id', () => {
+    const out = buildTasksUpdateSuggestedNext({}, { task: { id: 'T555' } });
+    expect(out).toEqual(['cleo show T555']);
+  });
+
+  it('returns [] when result has no task id', () => {
+    expect(buildTasksUpdateSuggestedNext({}, {})).toEqual([]);
+    expect(buildTasksUpdateSuggestedNext({}, undefined)).toEqual([]);
+  });
+});
+
+describe('buildTasksCompleteSuggestedNext (T9921)', () => {
+  it('emits 2 always-applicable next-step suggestions', () => {
+    const out = buildTasksCompleteSuggestedNext({}, { task: { id: 'T42' } });
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe('cleo next');
+    expect(out[1]).toBe('cleo memory observe "..." --title "..."');
+  });
+
+  it('emits the same suggestions even when result payload is empty', () => {
+    expect(buildTasksCompleteSuggestedNext({}, undefined)).toEqual([
+      'cleo next',
+      'cleo memory observe "..." --title "..."',
+    ]);
+  });
+});
+
+describe('buildTasksFindSuggestedNext (T9921)', () => {
+  it('returns 2 entries for the first result id', () => {
+    const out = buildTasksFindSuggestedNext(
+      {},
+      {
+        results: [{ id: 'T100' }, { id: 'T101' }],
+        total: 2,
+      },
+    );
+    expect(out).toEqual(['cleo show T100', 'cleo focus T100']);
+  });
+
+  it('returns [] when there are zero results', () => {
+    expect(buildTasksFindSuggestedNext({}, { results: [], total: 0 })).toEqual([]);
+    expect(buildTasksFindSuggestedNext({}, { results: undefined })).toEqual([]);
+    expect(buildTasksFindSuggestedNext({}, undefined)).toEqual([]);
+  });
+
+  it('returns [] when first result has no id', () => {
+    expect(buildTasksFindSuggestedNext({}, { results: [{}] })).toEqual([]);
+  });
+});
+
+describe('TASKS_SUGGESTED_NEXT_BUILDERS registry (T9921)', () => {
+  it('exposes all 5 tasks.* mutate/find op builders', () => {
+    expect(Object.keys(TASKS_SUGGESTED_NEXT_BUILDERS).sort()).toEqual(
+      ['add', 'add-batch', 'complete', 'find', 'update'].sort(),
+    );
+  });
+
+  it('looks up the correct builder by op key', () => {
+    expect(TASKS_SUGGESTED_NEXT_BUILDERS['add']).toBe(buildTasksAddSuggestedNext);
+    expect(TASKS_SUGGESTED_NEXT_BUILDERS['add-batch']).toBe(buildTasksAddBatchSuggestedNext);
+    expect(TASKS_SUGGESTED_NEXT_BUILDERS['update']).toBe(buildTasksUpdateSuggestedNext);
+    expect(TASKS_SUGGESTED_NEXT_BUILDERS['complete']).toBe(buildTasksCompleteSuggestedNext);
+    expect(TASKS_SUGGESTED_NEXT_BUILDERS['find']).toBe(buildTasksFindSuggestedNext);
+  });
+
+  it('returns undefined for unknown ops', () => {
+    expect(TASKS_SUGGESTED_NEXT_BUILDERS['delete']).toBeUndefined();
+    expect(TASKS_SUGGESTED_NEXT_BUILDERS['unknown']).toBeUndefined();
+  });
+});

--- a/packages/core/src/dispatch/suggested-next.ts
+++ b/packages/core/src/dispatch/suggested-next.ts
@@ -24,6 +24,195 @@
 
 import type { CliEnvelope } from '@cleocode/lafs';
 
+// ---------------------------------------------------------------------------
+// Per-op suggestion builders (T9921 — Saga T9855 / E8.2)
+//
+// Co-located with `attachSuggestedNext` so the SSoT for "what does each
+// tasks.* mutate op emit as `meta.suggestedNext`" lives next to the helper
+// that consumes it. The dispatch layer in `packages/cleo/src/dispatch/`
+// imports `buildTasksSuggestedNext` and stamps the result onto
+// `DispatchResponse.meta.suggestedNext` after a successful handler run.
+//
+// Builders are pure functions: `(params, data) => string[]`. They never
+// throw, never read the filesystem, never depend on env. When no concrete
+// follow-up makes sense (e.g. `tasks.find` with zero results), they
+// return `[]` — renderers hide empty arrays from human output.
+// ---------------------------------------------------------------------------
+
+/** Result shape returned by `tasks.add` — minimal subset needed for suggestions. */
+interface TasksAddResultShape {
+  task?: { id?: string };
+}
+
+/** Result shape returned by `tasks.update` and `tasks.complete`. */
+interface TasksTaskResultShape {
+  task?: { id?: string };
+}
+
+/** Result shape returned by `tasks.find`. */
+interface TasksFindResultShape {
+  results?: ReadonlyArray<{ id?: string }>;
+}
+
+/** Param shape for `tasks.add-batch` — only `defaultParent` is needed here. */
+interface TasksAddBatchParamsShape {
+  defaultParent?: unknown;
+}
+
+/**
+ * Operation-specific suggestion builder. Returns an array of copy-pasteable
+ * CLI commands the agent may run next. Empty arrays are valid — they signal
+ * "I considered this and no follow-up applies".
+ *
+ * @typeParam P - Operation params payload (raw `Record<string, unknown>` at the boundary).
+ * @typeParam D - Operation result payload type.
+ *
+ * @public
+ */
+export type SuggestedNextBuilder = (params: Record<string, unknown>, data: unknown) => string[];
+
+/**
+ * Build a `suggestedNext` array for the `tasks.add` operation.
+ *
+ * Suggests inspecting the newly-created task and focusing the agent on it.
+ * Returns `[]` when the result payload does not expose a task id.
+ *
+ * @param _params - Raw dispatch params (unused; preserved for builder signature uniformity).
+ * @param data    - The `AddTaskResult` returned by the engine.
+ * @returns Suggested follow-up CLI commands.
+ *
+ * @task T9921
+ *
+ * @public
+ */
+export function buildTasksAddSuggestedNext(
+  _params: Record<string, unknown>,
+  data: unknown,
+): string[] {
+  const id = (data as TasksAddResultShape | undefined)?.task?.id;
+  if (typeof id !== 'string' || id.length === 0) return [];
+  return [`cleo show ${id}`, `cleo focus ${id}`];
+}
+
+/**
+ * Build a `suggestedNext` array for the `tasks.add-batch` operation.
+ *
+ * Suggests listing the parent's children (so the operator sees the newly
+ * inserted tasks in context) and surfacing the ready wave for the parent
+ * epic. The parent id is read from `params.defaultParent` first, and falls
+ * back to the first inserted task's `parentId` is NOT inspected here —
+ * `defaultParent` is the canonical batch-level wire field.
+ *
+ * Returns `[]` when no `defaultParent` was supplied (per-task `parent`
+ * overrides cannot be aggregated into one suggestion).
+ *
+ * @param params - Raw dispatch params; only `defaultParent` is read.
+ * @param _data  - The `AddBatchResult` returned by the engine.
+ * @returns Suggested follow-up CLI commands.
+ *
+ * @task T9921
+ *
+ * @public
+ */
+export function buildTasksAddBatchSuggestedNext(
+  params: Record<string, unknown>,
+  _data: unknown,
+): string[] {
+  const parentId = (params as TasksAddBatchParamsShape).defaultParent;
+  if (typeof parentId !== 'string' || parentId.length === 0) return [];
+  return [`cleo list --parent ${parentId}`, `cleo orchestrate ready --epic ${parentId}`];
+}
+
+/**
+ * Build a `suggestedNext` array for the `tasks.update` operation.
+ *
+ * Suggests inspecting the just-updated task so the operator can confirm
+ * field changes landed as expected.
+ *
+ * @param _params - Raw dispatch params (unused).
+ * @param data    - The `UpdateTaskResult` returned by the engine.
+ * @returns Suggested follow-up CLI commands.
+ *
+ * @task T9921
+ *
+ * @public
+ */
+export function buildTasksUpdateSuggestedNext(
+  _params: Record<string, unknown>,
+  data: unknown,
+): string[] {
+  const id = (data as TasksTaskResultShape | undefined)?.task?.id;
+  if (typeof id !== 'string' || id.length === 0) return [];
+  return [`cleo show ${id}`];
+}
+
+/**
+ * Build a `suggestedNext` array for the `tasks.complete` operation.
+ *
+ * Suggests advancing to the next task in the ready wave and recording a
+ * memory observation about the just-completed work. Both suggestions are
+ * always-applicable — no concrete id is needed beyond `cleo next` defaults.
+ *
+ * @param _params - Raw dispatch params (unused).
+ * @param _data   - The `CompleteTaskResult` returned by the engine.
+ * @returns Suggested follow-up CLI commands.
+ *
+ * @task T9921
+ *
+ * @public
+ */
+export function buildTasksCompleteSuggestedNext(
+  _params: Record<string, unknown>,
+  _data: unknown,
+): string[] {
+  return ['cleo next', 'cleo memory observe "..." --title "..."'];
+}
+
+/**
+ * Build a `suggestedNext` array for the `tasks.find` operation.
+ *
+ * Suggests showing the first matching task and focusing the agent on it.
+ * Returns `[]` when the search produced zero results — no concrete id is
+ * available to interpolate.
+ *
+ * @param _params - Raw dispatch params (unused).
+ * @param data    - The `FindTasksResult` returned by the engine.
+ * @returns Suggested follow-up CLI commands.
+ *
+ * @task T9921
+ *
+ * @public
+ */
+export function buildTasksFindSuggestedNext(
+  _params: Record<string, unknown>,
+  data: unknown,
+): string[] {
+  const first = (data as TasksFindResultShape | undefined)?.results?.[0];
+  const id = first?.id;
+  if (typeof id !== 'string' || id.length === 0) return [];
+  return [`cleo show ${id}`, `cleo focus ${id}`];
+}
+
+/**
+ * Registry mapping `tasks.<op>` operation keys to their suggestion builders.
+ *
+ * The dispatch layer calls `TASKS_SUGGESTED_NEXT_BUILDERS[op]?.(params, data)`
+ * after a successful handler run to derive the `suggestedNext` array.
+ * Operations not present in the registry simply emit no suggestions —
+ * `meta.suggestedNext` is absent on the response.
+ *
+ * @task T9921
+ *
+ * @public
+ */
+export const TASKS_SUGGESTED_NEXT_BUILDERS: Readonly<Record<string, SuggestedNextBuilder>> = {
+  add: buildTasksAddSuggestedNext,
+  'add-batch': buildTasksAddBatchSuggestedNext,
+  update: buildTasksUpdateSuggestedNext,
+  complete: buildTasksCompleteSuggestedNext,
+  find: buildTasksFindSuggestedNext,
+};
+
 /**
  * Attach a list of suggested follow-up CLI commands to an envelope's
  * canonical {@link CliMeta.suggestedNext} field.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -647,7 +647,17 @@ export { updateTask } from './tasks/update.js';
 // T9918 (Saga T9855 / E7.5) — OperationInputContract registry seed
 export { getInputContract, INPUT_CONTRACTS } from './dispatch/contracts/input-contracts.js';
 // T9920 (Saga T9855 / E8.1) — envelope-wide meta.suggestedNext attach helper
-export { attachSuggestedNext } from './dispatch/suggested-next.js';
+// T9921 (Saga T9855 / E8.2) — per-op suggestion builders + tasks.* registry
+export {
+  attachSuggestedNext,
+  buildTasksAddBatchSuggestedNext,
+  buildTasksAddSuggestedNext,
+  buildTasksCompleteSuggestedNext,
+  buildTasksFindSuggestedNext,
+  buildTasksUpdateSuggestedNext,
+  type SuggestedNextBuilder,
+  TASKS_SUGGESTED_NEXT_BUILDERS,
+} from './dispatch/suggested-next.js';
 // T9915 (Saga T9855 / E7.2) — SSoT input validator over OperationInputContract
 export { validateOperationInput } from './dispatch/validation.js';
 // Setup wizard `--config-json` merger


### PR DESCRIPTION
## Summary
- 5 `tasks.*` mutate/find ops now emit `meta.suggestedNext` with concrete IDs
  interpolated (e.g. `cleo show T1234`, `cleo focus T1234`).
- Per-op suggestion builders live in `packages/core/src/dispatch/suggested-next.ts`
  alongside the `attachSuggestedNext` helper from T9920 — single SSoT for "what
  does each op suggest next" (registry `TASKS_SUGGESTED_NEXT_BUILDERS`).
- `TasksHandler` in cleo stamps `suggestedNext` onto `DispatchResponse.meta`
  after each successful dispatch; `pickDecoratorMetaExtensions` forwards the
  field into the emitted `CliEnvelope` for both human and JSON outputs.

## Test plan
- [x] 17 new unit tests in `packages/core/src/dispatch/__tests__/suggested-next-auto-populate.test.ts`
  — pure-function tests for each builder + registry lookup.
- [x] biome / build / vitest (T9920 helper + contracts type-shape tests still green).
- [x] `lint-format-error-misuse` + `lint-cli-package-boundary` gates pass (boundary
  count dropped to 28, baseline 29 — one violation cleaned up by the refactor).
- [x] Cleo dispatch test suite has the same 21 pre-existing failures with or without
  this change (verified via git stash) — no new regressions.

Closes T9921
Saga: T9855
ADR: 039