### PR TITLE
feat(sentient): template drift detector (T9895 / Saga T9855)

### DIFF
--- a/.changeset/t9895-sentient-template-drift-detector.md
+++ b/.changeset/t9895-sentient-template-drift-detector.md
@@ -1,0 +1,6 @@
+---
+id: t9895-sentient-template-drift-detector
+tasks: [T9895]
+kind: feat
+summary: feat(core,sentient): detectTemplateDrift Tier-2 detector for installed-template drift
+---

--- a/packages/core/src/sentient/detectors/__tests__/template-drift.test.ts
+++ b/packages/core/src/sentient/detectors/__tests__/template-drift.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for the template-drift detector (T9895).
+ *
+ * Coverage:
+ *   - detectTemplateDrift: drift detected on overwrite-on-bump entry → 1 P3 proposal
+ *   - detectTemplateDrift: manifest-merge drift also detected
+ *   - detectTemplateDrift: immutable entries always skipped (even when drifted)
+ *   - detectTemplateDrift: diff-prompt entries skipped (interactive flow owns reconcile)
+ *   - detectTemplateDrift: uninstalled entries skipped (no proposal)
+ *   - detectTemplateDrift: empty manifest → empty array
+ *   - detectTemplateDrift: in-sync content → empty array
+ *   - detectTemplateDrift: registry throws → empty array (best-effort, no rethrow)
+ *   - safeRunTemplateDriftScan: kill-switch blocks generation
+ *   - safeRunTemplateDriftScan: tier2Enabled=false marks outcome 'disabled'
+ *   - safeRunTemplateDriftScan: detector throwing surfaces 'error' outcome
+ *   - safeRunTemplateDriftScan: no-drift outcome when detector returns empty
+ *
+ * Tests mock `../../../templates/registry.js` so the detector can be
+ * exercised without a real monorepo checkout on disk.
+ *
+ * @task T9895
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../templates/registry.js', () => ({
+  getTemplateManifest: vi.fn(),
+  getInstalledStatus: vi.fn(),
+  resolveSourcePathAbsolute: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  };
+});
+
+import { existsSync, readFileSync } from 'node:fs';
+import type { TemplateManifestEntry, UpdateStrategy } from '@cleocode/contracts';
+import {
+  getInstalledStatus,
+  getTemplateManifest,
+  resolveSourcePathAbsolute,
+} from '../../../templates/registry.js';
+import {
+  detectTemplateDrift,
+  safeRunTemplateDriftScan,
+  TEMPLATE_REFRESH_KIND,
+} from '../template-drift.js';
+
+const mockGetTemplateManifest = getTemplateManifest as unknown as ReturnType<typeof vi.fn>;
+const mockGetInstalledStatus = getInstalledStatus as unknown as ReturnType<typeof vi.fn>;
+const mockResolveSourcePathAbsolute = resolveSourcePathAbsolute as unknown as ReturnType<
+  typeof vi.fn
+>;
+const mockExistsSync = existsSync as unknown as ReturnType<typeof vi.fn>;
+const mockReadFileSync = readFileSync as unknown as ReturnType<typeof vi.fn>;
+
+const PROJECT_ROOT = '/tmp/cleo-test-project-root';
+const STATE_PATH = '/tmp/cleo-test-sentient-state.json';
+
+/**
+ * Build a minimal TemplateManifestEntry sufficient for the detector.
+ * `kind` and `substitution` use safe defaults — they do not influence
+ * drift detection logic.
+ */
+function makeEntry(id: string, updateStrategy: UpdateStrategy): TemplateManifestEntry {
+  return {
+    id,
+    kind: 'workflow',
+    sourcePath: `packages/core/templates/${id}.tmpl`,
+    installPath: `.github/${id}`,
+    substitution: 'static',
+    placeholders: [],
+    updateStrategy,
+  };
+}
+
+/**
+ * Configure registry mocks for a per-entry installed/source-content scenario.
+ *
+ * Each scenario entry declares whether the file is installed and what the
+ * source vs installed content looks like. Drift is detected when both
+ * strings are non-equal AND `installed === true`.
+ */
+function arrangeFiles(
+  scenarios: Array<{
+    entry: TemplateManifestEntry;
+    installed: boolean;
+    source: string;
+    installedContent: string;
+    sourceExists?: boolean;
+  }>,
+): void {
+  mockGetTemplateManifest.mockReturnValue(scenarios.map((s) => s.entry));
+
+  mockGetInstalledStatus.mockImplementation((id: string, _root: string) => {
+    const found = scenarios.find((s) => s.entry.id === id);
+    if (!found) throw new Error(`unknown id ${id}`);
+    return { installed: found.installed, path: `${PROJECT_ROOT}/${found.entry.installPath}` };
+  });
+
+  mockResolveSourcePathAbsolute.mockImplementation((entry: TemplateManifestEntry) => {
+    const found = scenarios.find((s) => s.entry.id === entry.id);
+    if (!found) throw new Error(`unknown id ${entry.id}`);
+    return `/abs/${found.entry.sourcePath}`;
+  });
+
+  mockExistsSync.mockImplementation((path: unknown) => {
+    if (typeof path !== 'string') return false;
+    if (path.startsWith('/abs/')) {
+      const found = scenarios.find((s) => path === `/abs/${s.entry.sourcePath}`);
+      return found ? (found.sourceExists ?? true) : false;
+    }
+    return false;
+  });
+
+  mockReadFileSync.mockImplementation((path: unknown) => {
+    if (typeof path !== 'string') throw new Error('non-string path');
+    if (path.startsWith('/abs/')) {
+      const found = scenarios.find((s) => path === `/abs/${s.entry.sourcePath}`);
+      if (!found) throw new Error(`no source for ${path}`);
+      return found.source;
+    }
+    const found = scenarios.find((s) => path === `${PROJECT_ROOT}/${s.entry.installPath}`);
+    if (!found) throw new Error(`no installed for ${path}`);
+    return found.installedContent;
+  });
+}
+
+beforeEach(() => {
+  mockGetTemplateManifest.mockReset();
+  mockGetInstalledStatus.mockReset();
+  mockResolveSourcePathAbsolute.mockReset();
+  mockExistsSync.mockReset();
+  mockReadFileSync.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('detectTemplateDrift', () => {
+  it('returns one P3 proposal per drifted overwrite-on-bump entry', async () => {
+    arrangeFiles([
+      {
+        entry: makeEntry('ci.yml', 'overwrite-on-bump'),
+        installed: true,
+        source: 'name: CI\n',
+        installedContent: 'name: CI-OLD\n',
+      },
+    ]);
+
+    const proposals = await detectTemplateDrift(PROJECT_ROOT);
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]?.kind).toBe(TEMPLATE_REFRESH_KIND);
+    expect(proposals[0]?.severity).toBe('P3');
+    expect(proposals[0]?.id).toBe('prop-template-drift-ci.yml');
+    expect(proposals[0]?.title).toContain('ci.yml');
+    expect(proposals[0]?.fixAction).toBe('cleo templates upgrade ci.yml');
+    expect(proposals[0]?.reason).toContain('overwrite-on-bump');
+    expect(proposals[0]?.reason).toContain('.github/ci.yml');
+  });
+
+  it('detects drift on manifest-merge entries as well', async () => {
+    arrangeFiles([
+      {
+        entry: makeEntry('tsconfig.json', 'manifest-merge'),
+        installed: true,
+        source: '{"strict":true}',
+        installedContent: '{"strict":false}',
+      },
+    ]);
+
+    const proposals = await detectTemplateDrift(PROJECT_ROOT);
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]?.id).toBe('prop-template-drift-tsconfig.json');
+    expect(proposals[0]?.reason).toContain('manifest-merge');
+  });
+
+  it('skips immutable entries even when content has drifted', async () => {
+    arrangeFiles([
+      {
+        entry: makeEntry('locked.yml', 'immutable'),
+        installed: true,
+        source: 'A',
+        installedContent: 'B',
+      },
+    ]);
+
+    const proposals = await detectTemplateDrift(PROJECT_ROOT);
+
+    expect(proposals).toEqual([]);
+  });
+
+  it('skips diff-prompt entries even when drifted (interactive owns reconcile)', async () => {
+    arrangeFiles([
+      {
+        entry: makeEntry('prompted.yml', 'diff-prompt'),
+        installed: true,
+        source: 'A',
+        installedContent: 'B',
+      },
+    ]);
+
+    const proposals = await detectTemplateDrift(PROJECT_ROOT);
+
+    expect(proposals).toEqual([]);
+  });
+
+  it('skips uninstalled entries (no proposal — installation is a separate event)', async () => {
+    arrangeFiles([
+      {
+        entry: makeEntry('not-installed.yml', 'overwrite-on-bump'),
+        installed: false,
+        source: 'A',
+        installedContent: 'B',
+      },
+    ]);
+
+    const proposals = await detectTemplateDrift(PROJECT_ROOT);
+
+    expect(proposals).toEqual([]);
+  });
+
+  it('returns empty array when the manifest is empty', async () => {
+    mockGetTemplateManifest.mockReturnValue([]);
+
+    const proposals = await detectTemplateDrift(PROJECT_ROOT);
+
+    expect(proposals).toEqual([]);
+  });
+
+  it('returns empty array when installed content matches source byte-for-byte', async () => {
+    arrangeFiles([
+      {
+        entry: makeEntry('ci.yml', 'overwrite-on-bump'),
+        installed: true,
+        source: 'identical-content\n',
+        installedContent: 'identical-content\n',
+      },
+    ]);
+
+    const proposals = await detectTemplateDrift(PROJECT_ROOT);
+
+    expect(proposals).toEqual([]);
+  });
+
+  it('returns empty array when the registry throws (best-effort — never rethrows)', async () => {
+    mockGetTemplateManifest.mockImplementation(() => {
+      throw new Error('registry blew up');
+    });
+
+    await expect(detectTemplateDrift(PROJECT_ROOT)).resolves.toEqual([]);
+  });
+
+  it('processes a mixed manifest: 1 drifted refreshable + 1 in-sync + 1 immutable-drifted + 1 uninstalled', async () => {
+    arrangeFiles([
+      {
+        entry: makeEntry('a-drifted.yml', 'overwrite-on-bump'),
+        installed: true,
+        source: 'A1',
+        installedContent: 'A2',
+      },
+      {
+        entry: makeEntry('b-insync.yml', 'overwrite-on-bump'),
+        installed: true,
+        source: 'B',
+        installedContent: 'B',
+      },
+      {
+        entry: makeEntry('c-locked.yml', 'immutable'),
+        installed: true,
+        source: 'C1',
+        installedContent: 'C2',
+      },
+      {
+        entry: makeEntry('d-uninstalled.yml', 'manifest-merge'),
+        installed: false,
+        source: 'D1',
+        installedContent: 'D2',
+      },
+    ]);
+
+    const proposals = await detectTemplateDrift(PROJECT_ROOT);
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]?.id).toBe('prop-template-drift-a-drifted.yml');
+  });
+});
+
+describe('safeRunTemplateDriftScan', () => {
+  it('returns outcome=killed and generates no proposal when killSwitch is active', async () => {
+    const outcome = await safeRunTemplateDriftScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => true,
+      isTier2Enabled: async () => true,
+      detect: async () => {
+        throw new Error('detector should not run when killed');
+      },
+    });
+
+    expect(outcome.kind).toBe('killed');
+    expect(outcome.proposals).toEqual([]);
+  });
+
+  it('returns outcome=disabled (with proposal payload) when tier2Enabled=false', async () => {
+    const outcome = await safeRunTemplateDriftScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => false,
+      isTier2Enabled: async () => false,
+      detect: async () => [
+        {
+          id: 'prop-template-drift-x.yml',
+          kind: TEMPLATE_REFRESH_KIND,
+          title: 'x',
+          severity: 'P3',
+          fixAction: 'cleo templates upgrade x.yml',
+          reason: 'x drifted',
+        },
+      ],
+    });
+
+    expect(outcome.kind).toBe('disabled');
+    expect(outcome.proposals).toHaveLength(1);
+    expect(outcome.proposals[0]?.severity).toBe('P3');
+  });
+
+  it('returns outcome=drifted when proposals exist and tier2 is enabled', async () => {
+    const outcome = await safeRunTemplateDriftScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => false,
+      isTier2Enabled: async () => true,
+      detect: async () => [
+        {
+          id: 'prop-template-drift-a.yml',
+          kind: TEMPLATE_REFRESH_KIND,
+          title: 'a',
+          severity: 'P3',
+          fixAction: 'cleo templates upgrade a.yml',
+          reason: 'a drifted',
+        },
+        {
+          id: 'prop-template-drift-b.yml',
+          kind: TEMPLATE_REFRESH_KIND,
+          title: 'b',
+          severity: 'P3',
+          fixAction: 'cleo templates upgrade b.yml',
+          reason: 'b drifted',
+        },
+      ],
+    });
+
+    expect(outcome.kind).toBe('drifted');
+    expect(outcome.proposals).toHaveLength(2);
+    expect(outcome.detail).toContain('2');
+  });
+
+  it('returns outcome=no-drift when detector returns empty array', async () => {
+    const outcome = await safeRunTemplateDriftScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => false,
+      isTier2Enabled: async () => true,
+      detect: async () => [],
+    });
+
+    expect(outcome.kind).toBe('no-drift');
+    expect(outcome.proposals).toEqual([]);
+  });
+
+  it('returns outcome=error when the detector throws (kill-switch + tier2 checks succeed)', async () => {
+    const outcome = await safeRunTemplateDriftScan({
+      projectRoot: PROJECT_ROOT,
+      statePath: STATE_PATH,
+      isKilled: async () => false,
+      isTier2Enabled: async () => true,
+      detect: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    expect(outcome.kind).toBe('error');
+    expect(outcome.proposals).toEqual([]);
+    expect(outcome.detail).toContain('boom');
+  });
+});

--- a/packages/core/src/sentient/detectors/template-drift.ts
+++ b/packages/core/src/sentient/detectors/template-drift.ts
@@ -1,0 +1,329 @@
+/**
+ * Template Drift Detector — Tier-2 sentient proposal source (T9895).
+ *
+ * Emits a Tier-2 proposal for each {@link TemplateManifestEntry} whose
+ * deployed copy at `installPath` has drifted from the rendered source AND
+ * whose `updateStrategy` supports refresh (`'overwrite-on-bump'` or
+ * `'manifest-merge'`). `'immutable'` entries are intentionally locked and
+ * are never proposed; `'diff-prompt'` entries are skipped because they
+ * already require interactive owner action and a Tier-2 proposal would be
+ * redundant noise. Uninstalled entries are also skipped — installation is a
+ * separate lifecycle event handled by `cleo templates install`.
+ *
+ * Design principles:
+ *   - NO LLM calls. All data comes from a structured manifest read + a
+ *     byte-for-byte file comparison.
+ *   - Plural detector: returns an array of proposals (one per drifted
+ *     entry) rather than a single nullable proposal. Companion to T9896
+ *     {@link import('./context-staleness.js').detectContextStaleness}.
+ *   - Generation vs. persistence are decoupled — the detector ALWAYS
+ *     computes and returns proposals; the wrapper
+ *     {@link safeRunTemplateDriftScan} respects kill-switch + tier2Enabled
+ *     before any side effect.
+ *   - All file/read/registry errors collapse to empty array (best-effort —
+ *     never throw).
+ *
+ * Integration point: {@link safeRunTemplateDriftScan} is fired (best-effort)
+ * from `tick.ts` alongside the existing stage-drift / hygiene / context-
+ * staleness scans (wiring is a separate task — this module is the leaf).
+ *
+ * @task T9895
+ * @epic T9855
+ * @see T9896 — Context-staleness detector (pattern reference)
+ * @see T9886 — `cleo templates diff <id>` (CLI equivalent)
+ * @see T9877 — Template registry SSoT
+ * @see ADR-076 — Project context detection
+ * @see ADR-054 — Sentient Loop Tier-2
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import type { TemplateManifestEntry, UpdateStrategy } from '@cleocode/contracts';
+import {
+  getInstalledStatus,
+  getTemplateManifest,
+  resolveSourcePathAbsolute,
+} from '../../templates/registry.js';
+import { readSentientState } from '../state.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Default cadence (12 hours) between template-drift scan passes when the
+ * detector is wired into the tick loop. Longer than context-staleness
+ * (6 h) because template drift only changes when the consumer manually
+ * edits an installed template file — a low-frequency event.
+ */
+export const TEMPLATE_DRIFT_SCAN_INTERVAL_MS = 12 * 60 * 60 * 1000;
+
+/** Discriminant for template-refresh proposals. */
+export const TEMPLATE_REFRESH_KIND = 'template-refresh' as const;
+
+/**
+ * Update strategies that support automated refresh and therefore qualify
+ * for a Tier-2 proposal on drift. Order is incidental; uses `Set` for O(1)
+ * membership tests in the detector hot loop.
+ *
+ * - `overwrite-on-bump` — Safe to blindly rewrite when drift detected.
+ * - `manifest-merge`    — Structural merge can reconcile drift.
+ *
+ * Excluded by design:
+ * - `immutable`   — never overwrite (skipped per task brief).
+ * - `diff-prompt` — already prompts interactively on `cleo templates
+ *                   upgrade`; a Tier-2 proposal is redundant.
+ */
+const REFRESHABLE_STRATEGIES: ReadonlySet<UpdateStrategy> = new Set([
+  'overwrite-on-bump',
+  'manifest-merge',
+]);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Severity assigned to detector-emitted Tier-2 proposals.
+ * Mirrors the `severity` column allowlist (`P0`|`P1`|`P2`|`P3`) defined in
+ * `packages/contracts/src/enums.ts`.
+ */
+export type Tier2ProposalSeverity = 'P0' | 'P1' | 'P2' | 'P3';
+
+/**
+ * Detector-side Tier-2 proposal shape for template drift (T9895 contract).
+ *
+ * Same lightweight shape used by the sibling T9896 detector but with a
+ * dedicated `kind` discriminant. Each entry maps to ONE proposal so that
+ * the persistence layer can dedup on `id` and the orchestrator can render
+ * a per-template fix prompt.
+ */
+export interface Tier2Proposal {
+  /**
+   * Stable identifier — `prop-template-drift-<entry.id>`. Deterministic per
+   * `(detector, entry)` so repeated detections dedup cleanly on persistence.
+   */
+  id: string;
+  /** Discriminant — `'template-refresh'` for this detector. */
+  kind: typeof TEMPLATE_REFRESH_KIND;
+  /** Short human-readable headline. */
+  title: string;
+  /** Severity bucket; fixed at `'P3'` for template-drift (low priority). */
+  severity: Tier2ProposalSeverity;
+  /** CLI command the owner should run to reconcile the drift. */
+  fixAction: string;
+  /** Why this proposal was emitted (includes entry id, kind, paths, strategy). */
+  reason: string;
+}
+
+/** Options accepted by {@link safeRunTemplateDriftScan}. */
+export interface TemplateDriftScanOptions {
+  /** Absolute path to the project root (contains `.cleo/`). */
+  projectRoot: string;
+  /** Absolute path to sentient-state.json. */
+  statePath: string;
+  /**
+   * Override the kill-switch check. Injected by tests to avoid touching the
+   * state file. When omitted, reads the daemon state file directly.
+   */
+  isKilled?: () => Promise<boolean>;
+  /**
+   * Override the tier2Enabled check. Injected by tests. When omitted, reads
+   * the daemon state file directly.
+   */
+  isTier2Enabled?: () => Promise<boolean>;
+  /**
+   * Override the detector function. Injected by tests so the scan wrapper
+   * can be exercised without a real template registry on disk.
+   */
+  detect?: (projectRoot: string) => Promise<Tier2Proposal[]>;
+}
+
+/** Outcome discriminant produced by {@link safeRunTemplateDriftScan}. */
+export type TemplateDriftScanKind =
+  | 'killed' // killSwitch active before the detector ran
+  | 'disabled' // tier2Enabled=false; detector ran but persistence is gated off
+  | 'no-drift' // detector ran, no drifted templates found
+  | 'drifted' // one or more proposals were generated
+  | 'error'; // unexpected error during the scan
+
+/** Structured outcome of one scan pass. */
+export interface TemplateDriftScanOutcome {
+  /** How the scan ended. */
+  kind: TemplateDriftScanKind;
+  /** Every proposal generated by the detector (empty when none). */
+  proposals: Tier2Proposal[];
+  /** Human-readable detail (one line). */
+  detail: string;
+}
+
+// ---------------------------------------------------------------------------
+// Detector
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the Tier-2 proposal payload for a single drifted manifest entry.
+ *
+ * Pure function — no IO, no `Date.now()`, deterministic on inputs.
+ *
+ * @internal
+ */
+function buildProposal(entry: TemplateManifestEntry): Tier2Proposal {
+  return {
+    id: `prop-template-drift-${entry.id}`,
+    kind: TEMPLATE_REFRESH_KIND,
+    title: `Template ${entry.id} has drifted from source`,
+    severity: 'P3',
+    fixAction: `cleo templates upgrade ${entry.id}`,
+    reason:
+      `Template ${entry.id} (${entry.kind}) at ${entry.installPath} differs ` +
+      `from source ${entry.sourcePath}. Strategy: ${entry.updateStrategy}.`,
+  };
+}
+
+/**
+ * Compare a single template entry's installed copy against its rendered
+ * source and return `true` IFF they differ byte-for-byte.
+ *
+ * Errors (registry resolution, source read, install read) collapse to
+ * `false` — the detector is best-effort and MUST NOT emit a noisy
+ * "differs" proposal on a transient IO failure.
+ *
+ * @internal
+ */
+function isDrifted(entry: TemplateManifestEntry, projectRoot: string): boolean {
+  try {
+    const { installed, path: installPath } = getInstalledStatus(entry.id, projectRoot);
+    if (!installed) return false;
+    const sourceAbsolute = resolveSourcePathAbsolute(entry);
+    if (!existsSync(sourceAbsolute)) return false;
+    const source = readFileSync(sourceAbsolute, 'utf8');
+    const installed_ = readFileSync(installPath, 'utf8');
+    return source !== installed_;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run the template-drift detector against `projectRoot` and return one
+ * {@link Tier2Proposal} per drifted entry.
+ *
+ * Returns an empty array when:
+ *   - No templates are registered.
+ *   - Every refreshable entry is either uninstalled or in-sync.
+ *   - The registry cannot be enumerated (best-effort — never throws).
+ *
+ * Entries with `updateStrategy: 'immutable'` or `'diff-prompt'` are
+ * skipped (see {@link REFRESHABLE_STRATEGIES}). Entries that are not yet
+ * installed (`getInstalledStatus(...).installed === false`) are also
+ * skipped — installation is a separate lifecycle event.
+ *
+ * This function MUST NOT throw — all errors collapse to `[]`.
+ *
+ * @param projectRoot - Absolute path to the project root to probe.
+ * @returns Array of drift proposals (empty when no action is required).
+ *
+ * @task T9895
+ */
+export async function detectTemplateDrift(projectRoot: string): Promise<Tier2Proposal[]> {
+  let entries: readonly TemplateManifestEntry[];
+  try {
+    entries = getTemplateManifest();
+  } catch {
+    return [];
+  }
+
+  const proposals: Tier2Proposal[] = [];
+  for (const entry of entries) {
+    if (!REFRESHABLE_STRATEGIES.has(entry.updateStrategy)) continue;
+    if (!isDrifted(entry, projectRoot)) continue;
+    proposals.push(buildProposal(entry));
+  }
+  return proposals;
+}
+
+// ---------------------------------------------------------------------------
+// Scan wrapper (kill-switch + tier2Enabled gated)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default kill-switch check — reads sentient-state.json via {@link readSentientState}.
+ */
+async function defaultIsKilled(statePath: string): Promise<boolean> {
+  const state = await readSentientState(statePath);
+  return state.killSwitch === true;
+}
+
+/**
+ * Default tier2Enabled check — reads sentient-state.json via {@link readSentientState}.
+ */
+async function defaultIsTier2Enabled(statePath: string): Promise<boolean> {
+  const state = await readSentientState(statePath);
+  return state.tier2Enabled === true;
+}
+
+/**
+ * Run the template-drift detector with sentient gating applied.
+ *
+ * Steps:
+ *   1. Honour the kill-switch — abort before any side effect.
+ *   2. Run the detector. If it returns `[]`, return outcome `'no-drift'`.
+ *   3. When proposals are generated, honour `tier2Enabled` — the proposals
+ *      are returned to the caller either way, but the outcome discriminant
+ *      marks whether persistence is permitted.
+ *
+ * This wrapper NEVER throws — all errors collapse to an `'error'` outcome.
+ *
+ * @param options - See {@link TemplateDriftScanOptions}.
+ * @returns {@link TemplateDriftScanOutcome}.
+ *
+ * @task T9895
+ */
+export async function safeRunTemplateDriftScan(
+  options: TemplateDriftScanOptions,
+): Promise<TemplateDriftScanOutcome> {
+  try {
+    const isKilled = options.isKilled ?? (() => defaultIsKilled(options.statePath));
+    if (await isKilled()) {
+      return {
+        kind: 'killed',
+        proposals: [],
+        detail: 'killSwitch active — template drift scan skipped',
+      };
+    }
+
+    const detect = options.detect ?? detectTemplateDrift;
+    const proposals = await detect(options.projectRoot);
+
+    if (proposals.length === 0) {
+      return {
+        kind: 'no-drift',
+        proposals: [],
+        detail: 'no installed template differs from its source',
+      };
+    }
+
+    const isTier2Enabled =
+      options.isTier2Enabled ?? (() => defaultIsTier2Enabled(options.statePath));
+    if (!(await isTier2Enabled())) {
+      return {
+        kind: 'disabled',
+        proposals,
+        detail: `tier2Enabled=false; ${proposals.length} proposal(s) generated but not persisted`,
+      };
+    }
+
+    return {
+      kind: 'drifted',
+      proposals,
+      detail: `${proposals.length} template(s) drifted from source`,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      kind: 'error',
+      proposals: [],
+      detail: `template drift scan threw: ${message}`,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- New Tier-2 detector `detectTemplateDrift` in `packages/core/src/sentient/detectors/template-drift.ts` emitting P3 proposals on installed-template content drift.
- Uses TemplateManifest from T9877 (`getTemplateManifest`, `getInstalledStatus`, `resolveSourcePathAbsolute`) and the same diff semantics as `cleo templates diff` (T9886) — byte-for-byte compare of source vs installed copy.
- Skips entries with `updateStrategy: 'immutable'` (intentionally locked) and `'diff-prompt'` (interactive flow owns reconcile).
- Skips uninstalled entries (installation is a separate lifecycle event).
- Companion `safeRunTemplateDriftScan` wrapper enforces kill-switch + `tier2Enabled` gating (same shape as T9896 `safeRunContextStalenessScan`).
- 14 vitest cases covering refreshable drift, immutable/diff-prompt skip, uninstalled skip, in-sync, empty manifest, registry error, mixed manifest, plus 5 scan-wrapper outcome paths (`killed`/`disabled`/`drifted`/`no-drift`/`error`).

## Test plan
- [x] `pnpm biome check --write packages/core/src/sentient/detectors/`
- [x] `pnpm -F @cleocode/core run build` (full `pnpm run build` topo green)
- [x] `pnpm exec vitest run packages/core/src/sentient/detectors/__tests__/template-drift.test.ts` — 14/14
- [x] Sibling `context-staleness.test.ts` still passes — 27/27 in detector dir
- [x] `node scripts/lint-format-error-misuse.mjs` — OK

Closes T9895
Saga: T9855
ADR: 076