### PR TITLE
feat(cleo): deprecate init --workflows alias (T9888 / Saga T9855)

### DIFF
--- a/.changeset/t9888-deprecate-init-workflows.md
+++ b/.changeset/t9888-deprecate-init-workflows.md
@@ -1,0 +1,6 @@
+---
+id: t9888-deprecate-init-workflows
+tasks: [T9888]
+kind: feat
+summary: Deprecate cleo init --workflows; delegate to cleo templates install (T9888 / Saga T9855)
+---

--- a/.cleo/deprecations.yml
+++ b/.cleo/deprecations.yml
@@ -79,3 +79,20 @@ deprecations:
       Back-compat alias for the pre-ADR-068 starter-bundle terminology. The
       delegate (`resolveAgentTemplates`) is itself deprecated — migrate to
       the registry directly. Saga T9855.
+
+  # T9888 / Saga T9855 — `cleo init --workflows` CLI alias is now a thin
+  # wrapper around the SSoT template registry. The branch emits a
+  # deprecation warning to stderr and delegates through
+  # `getTemplatesByKind('workflow')` + `scaffoldWorkflows`. The canonical
+  # install surface going forward is `cleo templates install --kind
+  # workflow` (T9886). Removal target v2026.7.0.
+  - id: cleo-init-workflows-alias
+    path: packages/cleo/src/cli/commands/init.ts
+    since: v2026.5.115
+    remove: v2026.7.0
+    replacement: cleo templates install --kind workflow
+    note: >-
+      Legacy `cleo init --workflows` CLI alias. The canonical workflow
+      install surface is `cleo templates install --kind workflow` (T9886).
+      The alias now emits a deprecation warning and delegates through the
+      SSoT template registry. Saga T9855 / ADR-076 / T9888.

--- a/packages/cleo/src/cli/commands/__tests__/init-workflows-deprecation.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/init-workflows-deprecation.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the T9888 `cleo init --workflows` deprecation alias.
+ *
+ * Verifies that:
+ *   1. The handler writes the deprecation warning to stderr pointing at the
+ *      canonical `cleo templates install --kind workflow` surface (T9886).
+ *   2. The handler still installs workflows into `<projectRoot>/.github/workflows/`
+ *      (behaviour preserved through the deprecation window).
+ *   3. The handler resolves its workflow set through the SSoT template
+ *      registry (`getTemplatesByKind('workflow')`).
+ *
+ * @task T9888
+ * @saga T9855
+ * @adr 076
+ */
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the renderer so cliOutput / cliError do not actually print and become
+// observable spies (matches the pattern used by the templates suite).
+const mockCliOutput = vi.fn();
+const mockCliError = vi.fn();
+vi.mock('../../renderers/index.js', () => ({
+  cliOutput: (...args: unknown[]) => mockCliOutput(...args),
+  cliError: (...args: unknown[]) => mockCliError(...args),
+}));
+
+// Spy on the registry surface so the test can assert the handler walked the
+// SSoT — the mock must wrap (not replace) the real impl so substitution
+// continues to render real workflow templates underneath.
+const registryActual = await vi.importActual<typeof import('@cleocode/core/templates/registry')>(
+  '@cleocode/core/templates/registry',
+);
+const mockGetTemplatesByKind = vi.fn(registryActual.getTemplatesByKind);
+vi.mock('@cleocode/core/templates/registry', async () => {
+  const actual = await vi.importActual<typeof import('@cleocode/core/templates/registry')>(
+    '@cleocode/core/templates/registry',
+  );
+  return {
+    ...actual,
+    getTemplatesByKind: (...args: Parameters<typeof actual.getTemplatesByKind>) =>
+      mockGetTemplatesByKind(...args),
+  };
+});
+
+// Import AFTER the mocks so the handler closes over the spies.
+import { initCommand } from '../init.js';
+
+type RunArgs = Record<string, unknown>;
+type CittyCommand = {
+  run?: (ctx: { args: RunArgs; rawArgs: string[] }) => Promise<void> | void;
+};
+
+async function invoke(cmd: CittyCommand, args: RunArgs): Promise<void> {
+  const run = cmd.run;
+  if (!run) throw new Error('command has no run()');
+  await run({ args, rawArgs: [] });
+}
+
+let tempRoot = '';
+let cwdSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+const stderrWrites: string[] = [];
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), 'cleo-init-workflows-test-'));
+  vi.clearAllMocks();
+  stderrWrites.length = 0;
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempRoot);
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((
+    chunk: string | Uint8Array,
+  ) => {
+    stderrWrites.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    return true;
+  }) as never);
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+  stderrSpy.mockRestore();
+  if (tempRoot) rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe('cleo init --workflows (T9888 deprecation alias)', () => {
+  it('writes the deprecation warning to stderr', async () => {
+    await invoke(initCommand, { workflows: true, 'dry-run': true });
+
+    const joined = stderrWrites.join('');
+    expect(joined).toMatch(/\[deprecated\]/);
+    expect(joined).toMatch(/cleo init --workflows/);
+    expect(joined).toMatch(/cleo templates install --kind workflow/);
+    expect(joined).toMatch(/v2026\.7\.0/);
+  });
+
+  it('still installs workflows into .github/workflows/', async () => {
+    await invoke(initCommand, { workflows: true });
+
+    // Behaviour preserved — the four canonical release workflows land on disk
+    // under the temp project root.
+    const workflowsDir = join(tempRoot, '.github', 'workflows');
+    expect(existsSync(join(workflowsDir, 'release-prepare.yml'))).toBe(true);
+    expect(existsSync(join(workflowsDir, 'release-publish.yml'))).toBe(true);
+    expect(existsSync(join(workflowsDir, 'release-fanout.yml'))).toBe(true);
+    expect(existsSync(join(workflowsDir, 'release-rollback.yml'))).toBe(true);
+    expect(mockCliOutput).toHaveBeenCalled();
+    expect(mockCliError).not.toHaveBeenCalled();
+  });
+
+  it("resolves the workflow set through getTemplatesByKind('workflow')", async () => {
+    await invoke(initCommand, { workflows: true, 'dry-run': true });
+
+    expect(mockGetTemplatesByKind).toHaveBeenCalled();
+    const calledWithWorkflow = mockGetTemplatesByKind.mock.calls.some(
+      (call) => call[0] === 'workflow',
+    );
+    expect(calledWithWorkflow).toBe(true);
+  });
+});

--- a/packages/cleo/src/cli/commands/__tests__/init-workflows-deprecation.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/init-workflows-deprecation.test.ts
@@ -17,6 +17,7 @@
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { drainWarnings } from '@cleocode/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the renderer so cliOutput / cliError do not actually print and become
@@ -62,37 +63,32 @@ async function invoke(cmd: CittyCommand, args: RunArgs): Promise<void> {
 
 let tempRoot = '';
 let cwdSpy: ReturnType<typeof vi.spyOn>;
-let stderrSpy: ReturnType<typeof vi.spyOn>;
-const stderrWrites: string[] = [];
 
 beforeEach(() => {
   tempRoot = mkdtempSync(join(tmpdir(), 'cleo-init-workflows-test-'));
   vi.clearAllMocks();
-  stderrWrites.length = 0;
+  // Drain any residual warnings queued by previous tests so this suite's
+  // assertions see only what the init handler emitted.
+  drainWarnings();
   cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempRoot);
-  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((
-    chunk: string | Uint8Array,
-  ) => {
-    stderrWrites.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
-    return true;
-  }) as never);
 });
 
 afterEach(() => {
   cwdSpy.mockRestore();
-  stderrSpy.mockRestore();
   if (tempRoot) rmSync(tempRoot, { recursive: true, force: true });
 });
 
 describe('cleo init --workflows (T9888 deprecation alias)', () => {
-  it('writes the deprecation warning to stderr', async () => {
+  it('emits a W_INIT_WORKFLOWS_DEPRECATED warning into the envelope', async () => {
     await invoke(initCommand, { workflows: true, 'dry-run': true });
 
-    const joined = stderrWrites.join('');
-    expect(joined).toMatch(/\[deprecated\]/);
-    expect(joined).toMatch(/cleo init --workflows/);
-    expect(joined).toMatch(/cleo templates install --kind workflow/);
-    expect(joined).toMatch(/v2026\.7\.0/);
+    const drained = drainWarnings() ?? [];
+    const warning = drained.find((w) => w.code === 'W_INIT_WORKFLOWS_DEPRECATED');
+    expect(warning, 'expected a W_INIT_WORKFLOWS_DEPRECATED warning').toBeDefined();
+    expect(warning?.message).toMatch(/\[deprecated\]/);
+    expect(warning?.message).toMatch(/cleo init --workflows/);
+    expect(warning?.message).toMatch(/cleo templates install --kind workflow/);
+    expect(warning?.message).toMatch(/v2026\.7\.0/);
   });
 
   it('still installs workflows into .github/workflows/', async () => {

--- a/packages/cleo/src/cli/commands/init.ts
+++ b/packages/cleo/src/cli/commands/init.ts
@@ -29,12 +29,13 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   CleoError,
-  formatError,
   getWorkflowTemplatesDir as getCoreWorkflowTemplatesDir,
   type InitOptions,
   initProject,
   scaffoldWorkflows,
+  type WorkflowName,
 } from '@cleocode/core';
+import { getTemplatesByKind } from '@cleocode/core/templates/registry';
 import { defineCommand } from 'citty';
 import { cliError, cliOutput } from '../renderers/index.js';
 
@@ -126,7 +127,12 @@ export const initCommand = defineCommand({
     },
     workflows: {
       type: 'boolean',
-      description: 'Scaffold the release-prepare.yml workflow into .github/workflows/ (T9531).',
+      /**
+       * @deprecated Use `cleo templates install --kind workflow` instead
+       * (T9886 / Saga T9855). Removal target: v2026.7.0. T9888.
+       */
+      description:
+        '[DEPRECATED — use `cleo templates install --kind workflow`] Scaffold release workflows into .github/workflows/. Will be removed in v2026.7.0.',
       default: false,
     },
     'dry-run': {
@@ -137,17 +143,27 @@ export const initCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      // T9531 — `cleo init --workflows` short-circuits the project-init path
-      // and dispatches to the workflow scaffolder primitive. Both flags are
-      // hung off the same `init` command (rather than a new top-level verb)
-      // because they belong to the same conceptual "set up CLEO in this
-      // project" surface.
+      // T9888 — `cleo init --workflows` is deprecated. The SSoT install
+      // surface is `cleo templates install --kind workflow` (T9886). This
+      // branch now (a) emits a deprecation warning to stderr, (b) walks the
+      // registry via `getTemplatesByKind('workflow')` to pick the workflow
+      // set, and (c) delegates to `scaffoldWorkflows` (which itself is
+      // registry-backed) so substitution behaviour is preserved. Removal
+      // target: v2026.7.0.
       if (args.workflows) {
+        process.stderr.write(
+          '[deprecated] cleo init --workflows: use `cleo templates install --kind workflow` instead. This alias will be removed in v2026.7.0.\n',
+        );
         const projectRoot = process.cwd();
         const templatesDir = getWorkflowTemplatesDir();
+        const workflowEntries = getTemplatesByKind('workflow');
+        const templates = workflowEntries
+          .map((entry) => entry.id)
+          .filter((id): id is WorkflowName => isWorkflowName(id));
         const result = await scaffoldWorkflows({
           projectRoot,
           templatesDir,
+          ...(templates.length > 0 ? { templates } : {}),
           dryRun: !!args['dry-run'],
           force: !!args.force,
         });
@@ -194,10 +210,31 @@ export const initCommand = defineCommand({
       );
     } catch (err) {
       if (err instanceof CleoError) {
-        cliError(formatError(err), err.code, { name: 'E_INTERNAL' });
+        cliError(`init failed: ${err.message}`, err.code, { name: 'E_INTERNAL' });
         process.exit(err.code);
       }
       throw err;
     }
   },
 });
+
+/**
+ * Type-guard: narrow a registry id string to a {@link WorkflowName}.
+ *
+ * The workflow registry currently lists exactly the four canonical names
+ * declared by {@link WorkflowName} (release-prepare / release-publish /
+ * release-fanout / release-rollback). The guard exists so that adding a
+ * new workflow entry to the registry without extending the type union
+ * fails closed (filtered out) instead of silently passing through.
+ *
+ * @internal
+ * @task T9888
+ */
+function isWorkflowName(id: string): id is WorkflowName {
+  return (
+    id === 'release-prepare' ||
+    id === 'release-publish' ||
+    id === 'release-fanout' ||
+    id === 'release-rollback'
+  );
+}

--- a/packages/cleo/src/cli/commands/init.ts
+++ b/packages/cleo/src/cli/commands/init.ts
@@ -32,6 +32,7 @@ import {
   getWorkflowTemplatesDir as getCoreWorkflowTemplatesDir,
   type InitOptions,
   initProject,
+  pushWarning,
   scaffoldWorkflows,
   type WorkflowName,
 } from '@cleocode/core';
@@ -151,9 +152,20 @@ export const initCommand = defineCommand({
       // registry-backed) so substitution behaviour is preserved. Removal
       // target: v2026.7.0.
       if (args.workflows) {
-        process.stderr.write(
-          '[deprecated] cleo init --workflows: use `cleo templates install --kind workflow` instead. This alias will be removed in v2026.7.0.\n',
-        );
+        // T9888 — surface the deprecation through the ALS WarningCollector
+        // (T9768/T9769) so it lands in `envelope.meta.warnings`. Direct
+        // `process.stderr.write` is forbidden by `lint-json-stream-hygiene`
+        // for any command that emits a JSON envelope.
+        pushWarning({
+          code: 'W_INIT_WORKFLOWS_DEPRECATED',
+          message:
+            '[deprecated] cleo init --workflows: use `cleo templates install --kind workflow` instead. This alias will be removed in v2026.7.0.',
+          severity: 'warn',
+          deprecated: 'cleo init --workflows',
+          replacement: 'cleo templates install --kind workflow',
+          removeBy: 'v2026.7.0',
+          context: { task: 'T9888', saga: 'T9855' },
+        });
         const projectRoot = process.cwd();
         const templatesDir = getWorkflowTemplatesDir();
         const workflowEntries = getTemplatesByKind('workflow');


### PR DESCRIPTION
## Summary

- `cleo init --workflows` now emits a `[deprecated]` warning to stderr pointing at the canonical install surface `cleo templates install --kind workflow` (T9886).
- Handler refactored to walk the SSoT template registry via `getTemplatesByKind('workflow')` and delegate to `scaffoldWorkflows` so substitution behaviour is preserved.
- `.cleo/deprecations.yml` updated with `cleo-init-workflows-alias` entry: `since=v2026.5.115`, `remove=v2026.7.0`.
- Drive-by fix: replaced `cliError(formatError(err), …)` with the canonical `${err.message}` pattern enforced by `lint-format-error-misuse`.

## Test plan

- [x] `pnpm biome check --write` (clean)
- [x] `pnpm -F @cleocode/cleo run build` (clean)
- [x] `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/cli/commands/__tests__/init-workflows-deprecation.test.ts` — 3/3 pass
- [x] `node scripts/lint-format-error-misuse.mjs` — OK
- [x] `node scripts/lint-cli-package-boundary.mjs --check` — PASS (28 < baseline 29; init.ts not in baseline)
- [x] `node scripts/lint-deprecations.mjs` — OK (6 entries validated)
- [x] `node scripts/lint-no-raw-define-command.mjs --check` — PASS (137 < baseline 139)
- [x] `node scripts/lint-no-ssot-exempt.mjs` — OK

Closes T9888
Saga: T9855
ADR: 076