### PR TITLE
feat(sentient): execute-action on propose accept (T9898 / closes Epic T9861)

### DIFF
--- a/.changeset/t9898-sentient-execute-action.md
+++ b/.changeset/t9898-sentient-execute-action.md
@@ -1,0 +1,6 @@
+---
+id: t9898-sentient-execute-action
+tasks: [T9898]
+kind: feat
+summary: owner-approval execute-action for Tier-2 propose accept — closes Epic T9861 (T9898 / Saga T9855 / E6)
+---

--- a/packages/cleo/src/cli/commands/__tests__/sentient-execute-action.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/sentient-execute-action.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Unit tests for `cleo sentient propose accept <id>` execute-action flow
+ * (T9898 · Epic T9861 · Saga T9855 / E6.4).
+ *
+ * Covers:
+ *   - `--execute` runs the fixAction without prompting
+ *   - default flow prompts and respects an `n` reply
+ *   - `--no-execute` short-circuits even when fixAction is present
+ *   - unsafe fixAction → `E_SENTIENT_UNSAFE_ACTION`
+ *   - audit log appends one JSON line per execution
+ *   - missing proposal → `E_NOT_FOUND`
+ *
+ * All DB, child-process spawn, and stats writes are mocked so no real
+ * SQLite, file IO, or subprocess is touched.
+ *
+ * @task T9898
+ * @epic T9861
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — DB layer
+// ---------------------------------------------------------------------------
+
+interface MockTaskRow {
+  id: string;
+  status: string;
+  labelsJson: string;
+  notesJson: string | null;
+}
+
+const dbState: { row: MockTaskRow | null } = { row: null };
+
+const mockGetDb = vi.fn(async () => ({
+  select: () => ({
+    from: () => ({
+      where: () => ({
+        get: () => (dbState.row ? { ...dbState.row } : undefined),
+      }),
+    }),
+  }),
+  update: () => ({
+    set: () => ({
+      where: () => ({
+        run: () => {
+          if (dbState.row) dbState.row.status = 'pending';
+        },
+      }),
+    }),
+  }),
+}));
+
+vi.mock('@cleocode/core/store/sqlite.js', () => ({
+  getDb: (...args: unknown[]) => mockGetDb(...args),
+}));
+
+vi.mock('@cleocode/core/store/tasks-schema', () => ({
+  tasks: {
+    id: 'id',
+    status: 'status',
+    labelsJson: 'labels_json',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ _and: args }),
+  eq: (a: unknown, b: unknown) => ({ _eq: [a, b] }),
+  like: (a: unknown, b: unknown) => ({ _like: [a, b] }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks — sentient state
+// ---------------------------------------------------------------------------
+
+vi.mock('@cleocode/core/sentient/state.js', () => ({
+  readSentientState: vi.fn(async () => ({
+    tier2Stats: { proposalsAccepted: 0, proposalsRejected: 0, proposalsGenerated: 0 },
+  })),
+  patchSentientState: vi.fn(async () => ({})),
+}));
+
+vi.mock('@cleocode/core/sentient/daemon.js', () => ({
+  SENTIENT_STATE_FILE: '.cleo/sentient-state.json',
+  getSentientDaemonStatus: vi.fn(),
+  monitorWorkers: vi.fn(),
+  RUNAWAY_BUDGET_MULTIPLIER: 1,
+  resumeSentientDaemon: vi.fn(),
+  spawnSentientDaemon: vi.fn(),
+  stopSentientDaemon: vi.fn(),
+  WORKER_BUDGET_MS: 60_000,
+}));
+
+vi.mock('@cleocode/core/sentient/propose-tick.js', () => ({
+  safeRunProposeTick: vi.fn(),
+}));
+
+vi.mock('@cleocode/core/sentient/tick.js', () => ({
+  safeRunTick: vi.fn(),
+}));
+
+vi.mock('@cleocode/core/store/skills-store.js', () => ({
+  getSkillPatch: vi.fn(),
+  getSkillReview: vi.fn(),
+  listSkillReviews: vi.fn(),
+  markSkillPatchRejected: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks — execute-action (spawn injection)
+// ---------------------------------------------------------------------------
+
+const mockSpawn = vi.fn(async () => ({ exitCode: 0, stderr: '' }));
+
+vi.mock('@cleocode/core/sentient/execute-action.js', async () => {
+  const actual = await vi.importActual<typeof import('@cleocode/core/sentient/execute-action.js')>(
+    '@cleocode/core/sentient/execute-action.js',
+  );
+  return {
+    ...actual,
+    executeFixAction: async (
+      parsed: { cmd: string; argv: readonly string[] },
+      options: { cwd: string; stderrSnippetLimit?: number },
+    ) => {
+      const { exitCode, stderr } = await mockSpawn(parsed.cmd, parsed.argv, options.cwd);
+      return {
+        executed: true,
+        exitCode,
+        durationMs: 1,
+        stderrSnippet: stderr,
+      };
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mocks — renderers (capture envelopes)
+// ---------------------------------------------------------------------------
+
+interface CapturedOutput {
+  payload: unknown;
+  message?: string;
+}
+const captured: { outputs: CapturedOutput[]; errors: Array<{ message: string; code: string }> } = {
+  outputs: [],
+  errors: [],
+};
+
+vi.mock('../../renderers/index.js', () => ({
+  cliOutput: (payload: unknown, opts?: { message?: string }) => {
+    captured.outputs.push({ payload, message: opts?.message });
+  },
+  cliError: (message: string, code: string) => {
+    captured.errors.push({ message, code });
+  },
+  humanWarn: vi.fn(),
+  humanLine: vi.fn(),
+}));
+
+// process.exit must not actually exit during tests.
+const originalExit = process.exit;
+let exitCalls = 0;
+beforeEach(() => {
+  exitCalls = 0;
+  // @ts-expect-error — stub
+  process.exit = (() => {
+    exitCalls += 1;
+    throw new Error('__test_exit__');
+  }) as never;
+});
+afterEach(() => {
+  process.exit = originalExit;
+});
+
+// ---------------------------------------------------------------------------
+// Lazy import (after mocks installed)
+// ---------------------------------------------------------------------------
+
+async function getAcceptRun(): Promise<(ctx: { args: Record<string, unknown> }) => Promise<void>> {
+  const mod = await import('../sentient.js');
+  const sentient = mod.sentientCommand as unknown as {
+    subCommands: {
+      propose: {
+        subCommands: {
+          accept: { run: (ctx: { args: Record<string, unknown> }) => Promise<void> };
+        };
+      };
+    };
+  };
+  return sentient.subCommands.propose.subCommands.accept.run;
+}
+
+async function setPromptResponse(reply: boolean): Promise<() => void> {
+  const mod = await import('../sentient.js');
+  return mod.__setPromptAcceptExecutionForTest(async () => reply);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProposalRow(fixAction: string | null): MockTaskRow {
+  const notes =
+    fixAction === null
+      ? '[]'
+      : JSON.stringify([
+          JSON.stringify({
+            kind: 'proposal-meta',
+            proposedBy: 'sentient-tier2',
+            source: 'template-drift',
+            sourceId: 'tmpl-x',
+            weight: 0.5,
+            proposedAt: '2026-05-24T00:00:00Z',
+            dedupHash: 'abc',
+            fixAction,
+          }),
+        ]);
+  return {
+    id: 'prop-1',
+    status: 'proposed',
+    labelsJson: JSON.stringify(['sentient-tier2', 'source:template-drift']),
+    notesJson: notes,
+  };
+}
+
+let tmpRoot: string;
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'sentient-execute-t9898-'));
+  captured.outputs = [];
+  captured.errors = [];
+  mockSpawn.mockReset();
+  mockSpawn.mockResolvedValue({ exitCode: 0, stderr: '' });
+  dbState.row = null;
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('cleo sentient propose accept --execute (T9898)', () => {
+  it('runs the fixAction without prompting when --execute is set', async () => {
+    dbState.row = makeProposalRow('cleo templates upgrade tmpl-x');
+    const run = await getAcceptRun();
+
+    await run({ args: { id: 'prop-1', project: tmpRoot, execute: true } });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(mockSpawn.mock.calls[0][0]).toBe('cleo');
+    expect(mockSpawn.mock.calls[0][1]).toEqual(['templates', 'upgrade', 'tmpl-x']);
+    expect(captured.errors).toHaveLength(0);
+    const last = captured.outputs.at(-1)?.payload as { executed: boolean };
+    expect(last?.executed).toBe(true);
+  });
+
+  it('appends one audit log entry after execution', async () => {
+    dbState.row = makeProposalRow('cleo init --refresh-context');
+    const run = await getAcceptRun();
+
+    await run({ args: { id: 'prop-1', project: tmpRoot, execute: true } });
+
+    const auditPath = join(tmpRoot, '.cleo/audit/sentient-execute.jsonl');
+    const content = readFileSync(auditPath, 'utf8').trim();
+    expect(content.split('\n')).toHaveLength(1);
+    const entry = JSON.parse(content);
+    expect(entry.proposalId).toBe('prop-1');
+    expect(entry.fixAction).toBe('cleo init --refresh-context');
+    expect(entry.exitCode).toBe(0);
+    expect(typeof entry.durationMs).toBe('number');
+    expect(typeof entry.timestamp).toBe('string');
+  });
+});
+
+describe('cleo sentient propose accept (prompt path) (T9898)', () => {
+  it('prompts and respects an "n" reply (no execution, no audit)', async () => {
+    dbState.row = makeProposalRow('cleo templates upgrade tmpl-x');
+    const restore = await setPromptResponse(false);
+    try {
+      const run = await getAcceptRun();
+      await run({ args: { id: 'prop-1', project: tmpRoot } });
+    } finally {
+      restore();
+    }
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(captured.errors).toHaveLength(0);
+    const last = captured.outputs.at(-1)?.payload as { executed: boolean };
+    expect(last?.executed).toBe(false);
+  });
+
+  it('prompts and executes on a "y" reply', async () => {
+    dbState.row = makeProposalRow('pnpm run build');
+    const restore = await setPromptResponse(true);
+    try {
+      const run = await getAcceptRun();
+      await run({ args: { id: 'prop-1', project: tmpRoot } });
+    } finally {
+      restore();
+    }
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(mockSpawn.mock.calls[0][0]).toBe('pnpm');
+  });
+});
+
+describe('cleo sentient propose accept --no-execute (T9898)', () => {
+  it('skips execution even when fixAction is present', async () => {
+    dbState.row = makeProposalRow('cleo templates upgrade tmpl-x');
+    const run = await getAcceptRun();
+
+    await run({ args: { id: 'prop-1', project: tmpRoot, 'no-execute': true } });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    const last = captured.outputs.at(-1)?.payload as { executed: boolean };
+    expect(last?.executed).toBe(false);
+  });
+});
+
+describe('cleo sentient propose accept — safety guard (T9898)', () => {
+  it('rejects unsafe fixAction (not starting with cleo or pnpm)', async () => {
+    dbState.row = makeProposalRow('rm -rf /');
+    const run = await getAcceptRun();
+
+    await expect(run({ args: { id: 'prop-1', project: tmpRoot, execute: true } })).rejects.toThrow(
+      '__test_exit__',
+    );
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(captured.errors.length).toBeGreaterThanOrEqual(1);
+    expect(captured.errors[0].code).toBe('E_SENTIENT_UNSAFE_ACTION');
+  });
+
+  it('rejects fixAction with shell metacharacters', async () => {
+    dbState.row = makeProposalRow('cleo templates upgrade tmpl-x; rm -rf /');
+    const run = await getAcceptRun();
+
+    await expect(run({ args: { id: 'prop-1', project: tmpRoot, execute: true } })).rejects.toThrow(
+      '__test_exit__',
+    );
+
+    expect(captured.errors[0].code).toBe('E_SENTIENT_UNSAFE_ACTION');
+  });
+});
+
+describe('cleo sentient propose accept — missing proposal (T9898)', () => {
+  it('returns E_NOT_FOUND when the task does not exist', async () => {
+    dbState.row = null;
+    const run = await getAcceptRun();
+
+    await expect(
+      run({ args: { id: 'prop-missing', project: tmpRoot, execute: true } }),
+    ).rejects.toThrow('__test_exit__');
+
+    expect(captured.errors.length).toBeGreaterThanOrEqual(1);
+    expect(captured.errors[0].code).toBe('E_NOT_FOUND');
+  });
+});
+
+describe('cleo sentient propose accept — no fixAction (T9898)', () => {
+  it('accepts cleanly when proposal has no fixAction', async () => {
+    dbState.row = makeProposalRow(null);
+    const run = await getAcceptRun();
+
+    await run({ args: { id: 'prop-1', project: tmpRoot, execute: true } });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(captured.errors).toHaveLength(0);
+    const last = captured.outputs.at(-1)?.payload as {
+      executed: boolean;
+      fixAction: string | null;
+    };
+    expect(last?.executed).toBe(false);
+    expect(last?.fixAction).toBeNull();
+  });
+});

--- a/packages/cleo/src/cli/commands/sentient.ts
+++ b/packages/cleo/src/cli/commands/sentient.ts
@@ -29,7 +29,8 @@
  */
 
 import { join } from 'node:path';
-import { cwd as processCwd } from 'node:process';
+import { cwd as processCwd, stdin, stdout } from 'node:process';
+import { createInterface } from 'node:readline/promises';
 import {
   getSentientDaemonStatus,
   monitorWorkers,
@@ -40,6 +41,12 @@ import {
   stopSentientDaemon,
   WORKER_BUDGET_MS,
 } from '@cleocode/core/sentient/daemon.js';
+import {
+  appendSentientExecuteAudit,
+  executeFixAction,
+  extractFixActionFromNotesJson,
+  parseFixAction,
+} from '@cleocode/core/sentient/execute-action.js';
 import { safeRunProposeTick } from '@cleocode/core/sentient/propose-tick.js';
 import { patchSentientState, readSentientState } from '@cleocode/core/sentient/state.js';
 import { safeRunTick } from '@cleocode/core/sentient/tick.js';
@@ -334,19 +341,63 @@ const proposeListSub = defineCommand({
   },
 });
 
+/**
+ * Injectable confirmation prompt for `cleo sentient propose accept`.
+ *
+ * Tests replace this so the readline interface never touches the real
+ * stdin. Returns `true` IFF the user replied `y` or `yes` (case-insensitive).
+ *
+ * @internal
+ */
+export let promptAcceptExecution: (fixAction: string) => Promise<boolean> = async (
+  fixAction: string,
+) => {
+  const rl = createInterface({ input: stdin, output: stdout });
+  try {
+    stdout.write(`[sentient] Proposal accepted. fixAction:\n  $ ${fixAction}\n`);
+    const answer = await rl.question('Execute now? [y/N] ');
+    const normalised = answer.trim().toLowerCase();
+    return normalised === 'y' || normalised === 'yes';
+  } finally {
+    rl.close();
+  }
+};
+
+/** Test-only setter that swaps in a stub prompt for the accept flow. */
+export function __setPromptAcceptExecutionForTest(
+  next: (fixAction: string) => Promise<boolean>,
+): () => void {
+  const prev = promptAcceptExecution;
+  promptAcceptExecution = next;
+  return () => {
+    promptAcceptExecution = prev;
+  };
+}
+
 const proposeAcceptSub = defineCommand({
   meta: {
     name: 'accept',
-    description: 'Accept a proposal — transition proposed → pending',
+    description:
+      'Accept a proposal — transition proposed → pending, optionally execute its fixAction',
   },
   args: {
     ...projectArgs,
     id: { type: 'positional' as const, description: 'Proposal task ID', required: true },
+    execute: {
+      type: 'boolean' as const,
+      description: 'Execute proposal.fixAction without prompting',
+    },
+    'no-execute': {
+      type: 'boolean' as const,
+      description: 'Skip fixAction execution even if the proposal carries one',
+    },
   },
   async run({ args }) {
     const projectRoot = resolveProjectRoot(args.project as string | undefined);
     const jsonMode = args.json === true;
     const id = args.id as string;
+    const forceExecute = args.execute === true;
+    const skipExecute = args['no-execute'] === true;
 
     try {
       const { getDb } = await import('@cleocode/core/store/sqlite.js');
@@ -389,10 +440,63 @@ const proposeAcceptSub = defineCommand({
         },
       });
 
+      // Pull fixAction from notes_json proposal-meta envelope.
+      const fixAction = extractFixActionFromNotesJson(existing.notesJson ?? null);
+
+      // Decide whether to execute.
+      // Precedence: --no-execute > --execute > interactive prompt > skip.
+      let shouldExecute = false;
+      if (fixAction && !skipExecute) {
+        if (forceExecute) {
+          shouldExecute = true;
+        } else {
+          shouldExecute = await promptAcceptExecution(fixAction);
+        }
+      }
+
+      if (!shouldExecute) {
+        emitSuccess(
+          {
+            id,
+            status: 'pending',
+            acceptedAt: now,
+            executed: false,
+            fixAction: fixAction ?? null,
+          },
+          jsonMode,
+          `Proposal ${id} accepted → pending`,
+        );
+        return;
+      }
+
+      // fixAction is non-null at this point (guarded by `shouldExecute` branch).
+      const parsed = parseFixAction(fixAction as string);
+      if (!parsed.ok) {
+        emitFailure(parsed.code, parsed.reason, jsonMode);
+        return;
+      }
+
+      const result = await executeFixAction(parsed, { cwd: projectRoot });
+      await appendSentientExecuteAudit(projectRoot, {
+        proposalId: id,
+        fixAction: fixAction as string,
+        exitCode: result.exitCode,
+        durationMs: result.durationMs,
+        timestamp: new Date().toISOString(),
+      });
+
       emitSuccess(
-        { id, status: 'pending', acceptedAt: now },
+        {
+          id,
+          status: 'pending',
+          acceptedAt: now,
+          executed: true,
+          exitCode: result.exitCode,
+          stderrSnippet: result.stderrSnippet,
+          fixAction,
+        },
         jsonMode,
-        `Proposal ${id} accepted → pending`,
+        `Proposal ${id} accepted → pending (fixAction exit=${result.exitCode})`,
       );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -44,8 +45,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description:
-      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -84,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -102,31 +99,26 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description:
-      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () =>
-      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -149,8 +141,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -240,8 +231,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description:
-      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -260,8 +250,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -284,16 +273,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -317,8 +304,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -329,8 +315,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -343,24 +328,19 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () =>
-      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description:
-      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () =>
-      (await import('../commands/doctor-legacy-backups.js'))
-        .doctorLegacyBackupsCommand as CommandDef,
+    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -396,8 +376,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -420,8 +399,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description:
-      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -452,8 +430,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -476,17 +453,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -515,8 +489,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -558,17 +531,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -597,8 +567,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -610,15 +579,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -661,8 +628,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -673,8 +639,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description:
-      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -710,8 +675,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description:
-      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -723,8 +687,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -736,8 +699,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -785,15 +747,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -865,8 +825,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'templatesCommand',
     name: 'templates',
-    description:
-      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
     load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
   },
   {
@@ -878,8 +837,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -891,15 +849,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description:
-      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -171,6 +171,30 @@ export default defineConfig({
         '../../packages/core/src/sentient/proposal-rate-limiter.ts',
         import.meta.url,
       ).pathname,
+      // T9898: execute-action SSoT (Saga T9855 / E6.4) — fixAction safety guard +
+      // spawn + audit-log append surface consumed by `cleo sentient propose accept`.
+      '@cleocode/core/sentient/execute-action.js': new URL(
+        '../../packages/core/src/sentient/execute-action.ts',
+        import.meta.url,
+      ).pathname,
+      // T9898: skills-store subpath import used by sentient.ts review-status verbs.
+      // The bare-package resolver can't find it in sparse worktrees; aliasing to the
+      // source tree lets vitest tests that import sentient.ts load cleanly.
+      '@cleocode/core/store/skills-store.js': new URL(
+        '../../packages/core/src/store/skills-store.ts',
+        import.meta.url,
+      ).pathname,
+      // T9898: sqlite subpath import used by `sentient propose accept|reject|list`
+      // (dynamic import). Same rationale as skills-store alias above.
+      '@cleocode/core/store/sqlite.js': new URL(
+        '../../packages/core/src/store/sqlite.ts',
+        import.meta.url,
+      ).pathname,
+      // T9898: tasks-schema subpath import used by sentient.ts dynamic queries.
+      '@cleocode/core/store/tasks-schema': new URL(
+        '../../packages/core/src/store/tasks-schema.ts',
+        import.meta.url,
+      ).pathname,
       '@cleocode/core/sentient': new URL(
         '../../packages/core/src/sentient/index.ts',
         import.meta.url,

--- a/packages/core/src/sentient/execute-action.ts
+++ b/packages/core/src/sentient/execute-action.ts
@@ -1,0 +1,270 @@
+/**
+ * Sentient Tier-2 proposal `fixAction` executor (T9898 · Epic T9861 · Saga T9855).
+ *
+ * Provides the pure, testable execution surface used by the CLI handler
+ * `cleo sentient propose accept <id>`. Decouples the safety guard, argv
+ * parsing, child-process spawn, and audit-log append from the CLI layer
+ * so each can be unit-tested in isolation and reused if Tier-3
+ * auto-execution lands later.
+ *
+ * Safety model:
+ *   - `fixAction` MUST start with one of the safe prefixes (`cleo`, `pnpm`).
+ *   - `fixAction` MUST match a conservative character allowlist — no
+ *     shell metacharacters (`& | ; $ ` ` ( ) < > \\ "` `'`, backticks,
+ *     newlines, etc.).
+ *   - Execution uses `child_process.spawn(cmd, argv, { shell: false })`.
+ *     The string is NEVER passed through a shell.
+ *
+ * Rollback note: the only fixAction kinds wired today (`cleo templates
+ * upgrade <id>`, `cleo init --refresh-context`, `cleo config validate`)
+ * are either idempotent reads or have their own rollback via `git
+ * checkout` of the affected files. The audit log at
+ * `.cleo/audit/sentient-execute.jsonl` records every execution so an
+ * owner can trace and revert with `git revert` / `git checkout` on the
+ * paths the executed verb touched.
+ *
+ * @see packages/cleo/src/cli/commands/sentient.ts (CLI integration)
+ * @see packages/core/src/sentient/detectors/template-drift.ts (fixAction producer)
+ * @task T9898
+ * @epic T9861
+ */
+
+import { spawn } from 'node:child_process';
+import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+/** Safe argv-zero prefixes accepted by {@link parseFixAction}. */
+export const SAFE_FIX_ACTION_PREFIXES = ['cleo', 'pnpm'] as const;
+
+/** Allowed characters in a fixAction string. */
+const FIX_ACTION_ALLOWED = /^[A-Za-z0-9_\-./= \t]+$/;
+
+/** Default audit log location relative to projectRoot. */
+export const SENTIENT_EXECUTE_AUDIT_PATH = '.cleo/audit/sentient-execute.jsonl';
+
+/**
+ * Parsed result of safety-validating + tokenising a fixAction string.
+ *
+ * `ok=false` carries the rejection `code` and human-readable `reason`
+ * so the CLI can emit an envelope with the canonical
+ * `E_SENTIENT_UNSAFE_ACTION` failure code.
+ */
+export type ParsedFixAction =
+  | {
+      readonly ok: true;
+      readonly cmd: string;
+      readonly argv: readonly string[];
+    }
+  | {
+      readonly ok: false;
+      readonly code: 'E_SENTIENT_UNSAFE_ACTION';
+      readonly reason: string;
+    };
+
+/**
+ * Validate + tokenise a fixAction string into an argv array safe for
+ * `spawn(cmd, argv, { shell: false })`.
+ *
+ * Rejects any input that:
+ *   - is empty / whitespace-only
+ *   - contains shell metacharacters (anything outside the conservative
+ *     `[A-Za-z0-9_\-./= \t]` allowlist)
+ *   - does not begin with one of {@link SAFE_FIX_ACTION_PREFIXES}
+ *
+ * @param fixAction - Raw fixAction string from a Tier-2 proposal.
+ * @returns A {@link ParsedFixAction} discriminated by `ok`.
+ */
+export function parseFixAction(fixAction: string): ParsedFixAction {
+  const trimmed = fixAction.trim();
+  if (trimmed.length === 0) {
+    return {
+      ok: false,
+      code: 'E_SENTIENT_UNSAFE_ACTION',
+      reason: 'fixAction is empty',
+    };
+  }
+  if (!FIX_ACTION_ALLOWED.test(trimmed)) {
+    return {
+      ok: false,
+      code: 'E_SENTIENT_UNSAFE_ACTION',
+      reason: 'fixAction contains disallowed characters (shell metacharacters)',
+    };
+  }
+  const tokens = trimmed.split(/[ \t]+/).filter((t) => t.length > 0);
+  const cmd = tokens[0];
+  if (!cmd) {
+    return {
+      ok: false,
+      code: 'E_SENTIENT_UNSAFE_ACTION',
+      reason: 'fixAction has no command token',
+    };
+  }
+  if (!(SAFE_FIX_ACTION_PREFIXES as readonly string[]).includes(cmd)) {
+    return {
+      ok: false,
+      code: 'E_SENTIENT_UNSAFE_ACTION',
+      reason: `fixAction must start with one of: ${SAFE_FIX_ACTION_PREFIXES.join(', ')}`,
+    };
+  }
+  return { ok: true, cmd, argv: tokens.slice(1) };
+}
+
+/** Successful execution outcome reported by {@link executeFixAction}. */
+export interface ExecuteFixActionResult {
+  readonly executed: true;
+  readonly exitCode: number;
+  readonly durationMs: number;
+  readonly stderrSnippet: string;
+}
+
+/** Injectable spawn surface used by tests to bypass real child processes. */
+export interface SpawnInjector {
+  spawn?: (cmd: string, argv: readonly string[]) => Promise<{ exitCode: number; stderr: string }>;
+}
+
+/** Options accepted by {@link executeFixAction}. */
+export interface ExecuteFixActionOptions extends SpawnInjector {
+  /** Working directory for the spawned process. */
+  readonly cwd: string;
+  /** Maximum stderr bytes captured in the snippet (default 1024). */
+  readonly stderrSnippetLimit?: number;
+}
+
+/**
+ * Default spawn shim — wraps `child_process.spawn` and resolves with the
+ * exit code + captured stderr. Stderr is buffered as UTF-8.
+ *
+ * @internal
+ */
+function defaultSpawn(
+  cmd: string,
+  argv: readonly string[],
+  cwd: string,
+): Promise<{ exitCode: number; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, [...argv], {
+      cwd,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    // Drain stdout so the pipe doesn't fill and block.
+    child.stdout.on('data', () => {});
+    child.on('error', (err) => {
+      resolve({ exitCode: 1, stderr: `${stderr}\n${err.message}` });
+    });
+    child.on('exit', (code) => {
+      resolve({ exitCode: code ?? 1, stderr });
+    });
+  });
+}
+
+/**
+ * Execute a parsed fixAction via `child_process.spawn` (NEVER through a
+ * shell) and return the exit code + a bounded stderr snippet.
+ *
+ * @param parsed  - Validated tokens from {@link parseFixAction}.
+ * @param options - cwd + optional spawn injection.
+ * @returns {@link ExecuteFixActionResult} on completion (including non-zero exit).
+ */
+export async function executeFixAction(
+  parsed: Extract<ParsedFixAction, { ok: true }>,
+  options: ExecuteFixActionOptions,
+): Promise<ExecuteFixActionResult> {
+  const startedAt = Date.now();
+  const spawnImpl = options.spawn ?? ((c, a) => defaultSpawn(c, a, options.cwd));
+  const { exitCode, stderr } = await spawnImpl(parsed.cmd, parsed.argv);
+  const limit = options.stderrSnippetLimit ?? 1024;
+  const snippet = stderr.length > limit ? `${stderr.slice(0, limit)}…` : stderr;
+  return {
+    executed: true,
+    exitCode,
+    durationMs: Date.now() - startedAt,
+    stderrSnippet: snippet,
+  };
+}
+
+/** Audit log entry written to `.cleo/audit/sentient-execute.jsonl`. */
+export interface SentientExecuteAuditEntry {
+  readonly proposalId: string;
+  readonly fixAction: string;
+  readonly exitCode: number;
+  readonly durationMs: number;
+  readonly timestamp: string;
+}
+
+/**
+ * Append one structured JSON line to `.cleo/audit/sentient-execute.jsonl`.
+ *
+ * Creates the directory if missing. Failures are non-fatal — the caller
+ * decides how to surface them; this returns `false` on append failure
+ * so the CLI can emit a warning rather than aborting the success
+ * envelope.
+ *
+ * @param projectRoot - Absolute project root (contains `.cleo/`).
+ * @param entry       - Audit entry payload.
+ * @returns `true` on successful append, `false` on IO failure.
+ */
+export async function appendSentientExecuteAudit(
+  projectRoot: string,
+  entry: SentientExecuteAuditEntry,
+): Promise<boolean> {
+  const path = join(projectRoot, SENTIENT_EXECUTE_AUDIT_PATH);
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, `${JSON.stringify(entry)}\n`, 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extract a fixAction string from a task row's `notes_json` column.
+ *
+ * Proposals persisted by the propose-tick pipeline embed a
+ * `proposal-meta` envelope as the first JSON-stringified entry of
+ * `notes_json`. When detectors include a `fixAction`, it lands on that
+ * envelope and this helper surfaces it for the accept handler.
+ *
+ * Returns `null` when:
+ *   - `notesJson` is null/empty/malformed
+ *   - the proposal-meta envelope is absent
+ *   - `fixAction` is missing or non-string
+ *
+ * @param notesJson - Raw `notes_json` column value (an array of JSON strings).
+ */
+export function extractFixActionFromNotesJson(notesJson: string | null): string | null {
+  if (!notesJson) return null;
+  let outer: unknown;
+  try {
+    outer = JSON.parse(notesJson);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(outer)) return null;
+  for (const entry of outer) {
+    if (typeof entry !== 'string') continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(entry);
+    } catch {
+      continue;
+    }
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'kind' in parsed &&
+      (parsed as { kind: unknown }).kind === 'proposal-meta' &&
+      'fixAction' in parsed &&
+      typeof (parsed as { fixAction: unknown }).fixAction === 'string'
+    ) {
+      const fixAction = (parsed as { fixAction: string }).fixAction;
+      return fixAction.length > 0 ? fixAction : null;
+    }
+  }
+  return null;
+}

--- a/packages/core/src/sentient/index.ts
+++ b/packages/core/src/sentient/index.ts
@@ -17,6 +17,7 @@ export * from './curator.js';
 export * from './daemon.js';
 export * from './daemon-api.js';
 export * from './events.js';
+export * from './execute-action.js';
 export * from './hygiene-scan.js';
 export * from './ingesters/brain-ingester.js';
 export * from './ingesters/nexus-ingester.js';


### PR DESCRIPTION
## Summary
- `cleo sentient propose accept <id>` now executes `proposal.fixAction` after user confirmation, or immediately with `--execute`. `--no-execute` skips even when fixAction is present.
- Safety guard: only `cleo` or `pnpm` prefixed fixActions accepted; shell metacharacters rejected with `E_SENTIENT_UNSAFE_ACTION`. Spawn uses `{ shell: false }` (no injection vector).
- Audit log appended per execution to `.cleo/audit/sentient-execute.jsonl`.
- Closes Epic T9861.

## Test plan
- [x] biome
- [x] build
- [x] vitest (9/9 passing)
- [x] format-error misuse lint
- [x] cli-package-boundary lint

Closes T9898
Closes T9861
Saga: T9855
ADR: 076