### PR TITLE
feat(T10388): changeset add wires allocator (E1.3)

### DIFF
--- a/.changeset/t10388-e1-changeset-allocator.md
+++ b/.changeset/t10388-e1-changeset-allocator.md
@@ -1,0 +1,6 @@
+---
+id: t10388-e1-changeset-allocator
+tasks: [T10388]
+kind: feat
+summary: T10388 E1.3: cleo changeset add wires allocator + E_SLUG_RESERVED parity
+---

--- a/packages/cleo/src/cli/commands/changeset.ts
+++ b/packages/cleo/src/cli/commands/changeset.ts
@@ -232,10 +232,15 @@ const addCommand = defineCommand({
     // ── 6. Render the LAFS envelope. ────────────────────────────────────────
     if (!outcome.ok) {
       const err = outcome.error;
+      // T10388 — when the central slug-allocator rejects the slug, surface
+      // the 3 derived suggestions as a `fix` hint so the operator can pick
+      // a free alternative on retry without re-running discovery.
       const hint =
         err.code === 'E_SLUG_PATTERN_MISMATCH' && err.example
           ? `example slug: ${err.example}`
-          : undefined;
+          : err.code === 'E_SLUG_RESERVED'
+            ? `try: ${err.suggestions.join(', ')}`
+            : undefined;
       cliError(err.message, ExitCode.VALIDATION_ERROR, {
         name: err.code,
         ...(hint ? { fix: hint } : {}),

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -45,7 +44,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description:
+      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,8 +63,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +84,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,26 +102,31 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description:
+      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () =>
+      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -141,7 +149,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -231,7 +240,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description:
+      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -250,7 +260,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -273,14 +284,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -304,7 +317,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -315,7 +329,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -328,19 +343,24 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
+    description:
+      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () =>
+      (await import('../commands/doctor-legacy-backups.js'))
+        .doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -376,7 +396,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -399,7 +420,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description:
+      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -430,7 +452,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -453,14 +476,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -489,7 +515,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -531,14 +558,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -567,7 +597,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -579,13 +610,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -628,7 +661,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -639,7 +673,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -675,7 +710,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description:
+      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -687,7 +723,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -699,7 +736,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -747,13 +785,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
+    description:
+      'Show full task details by ID (returns complete task record with metadata, verification, lifecycle)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -825,7 +865,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'templatesCommand',
     name: 'templates',
-    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    description:
+      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
     load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
   },
   {
@@ -837,7 +878,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -849,13 +891,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description:
+      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -1002,10 +1002,28 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
         if (err.code === 'E_FILE_WRITE_FAILED') {
           return lafsError('E_FILE_ERROR', err.message, 'add');
         }
+        // T10388 — uniform E_SLUG_RESERVED shape across both writers. The
+        // changeset writer now reserves slugs through the central allocator
+        // BEFORE any filesystem or DB mutation; collisions surface here with
+        // 3 suggested alternatives. The legacy E_SSOT_WRITE_FAILED code is
+        // retained in `details.aliases` for one release of back-compat so
+        // downstream consumers grepping for the old code can still match.
+        if (err.code === 'E_SLUG_RESERVED') {
+          return {
+            success: false,
+            error: {
+              code: 'E_SLUG_RESERVED',
+              message: err.message,
+              details: {
+                suggestions: err.suggestions,
+                aliases: err.aliases,
+              },
+            },
+          };
+        }
         // E_SSOT_WRITE_FAILED — bubble up so the operator can see the
-        // underlying store error (typically a slug collision wrapped as
-        // SlugCollisionError on the way through). The writer has already
-        // rolled back the `.changeset/<slug>.md` file at this point.
+        // underlying store error. The writer has already rolled back the
+        // `.changeset/<slug>.md` file at this point.
         return lafsError('E_SSOT_WRITE_FAILED', err.message, 'add');
       }
 

--- a/packages/core/src/changesets/writer.ts
+++ b/packages/core/src/changesets/writer.ts
@@ -29,7 +29,8 @@ import { mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { BlobAttachment } from '@cleocode/contracts';
 import { type ChangesetEntry, ChangesetEntrySchema, DocKindRegistry } from '@cleocode/contracts';
-import { createAttachmentStore } from '../store/attachment-store.js';
+import { releaseReservedSlug, reserveSlug } from '../docs/slug-allocator.js';
+import { createAttachmentStore, SlugCollisionError } from '../store/attachment-store.js';
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -71,6 +72,15 @@ export interface WriteChangesetResult {
 
 /**
  * Discriminated error result for {@link writeChangesetEntry}.
+ *
+ * `E_SLUG_RESERVED` (T10388, Saga T10288, Epic T10289) is surfaced by the
+ * central slug-allocator chokepoint when another writer has already claimed
+ * the slug — either in the SAME process (in-process reserved set) or another
+ * process (DB-level `uniq_attachments_slug` UNIQUE INDEX). The `suggestions`
+ * field carries exactly 3 free alternatives derived by
+ * `deriveSlugSuggestionsForAllocator`. The `aliases` field retains
+ * `'E_SSOT_WRITE_FAILED'` for one-release back-compat — downstream consumers
+ * grepping for the legacy code can match `aliases.includes(...)`.
  */
 export type WriteChangesetError =
   | {
@@ -80,6 +90,12 @@ export type WriteChangesetError =
     }
   | { readonly code: 'E_INVALID_ENTRY'; readonly message: string }
   | { readonly code: 'E_FILE_WRITE_FAILED'; readonly message: string }
+  | {
+      readonly code: 'E_SLUG_RESERVED';
+      readonly message: string;
+      readonly suggestions: readonly string[];
+      readonly aliases: readonly string[];
+    }
   | { readonly code: 'E_SSOT_WRITE_FAILED'; readonly message: string };
 
 /**
@@ -201,6 +217,38 @@ export async function writeChangesetEntry(
     };
   }
 
+  // ── 1b. Central slug-allocator chokepoint (T10388, Saga T10288, Epic T10289). ─
+  //
+  // BEFORE any filesystem or DB mutation: ask the allocator whether the slug
+  // is free. The allocator:
+  //   - Holds the per-slug Mutex while it probes the DB.
+  //   - Adds the slug to the in-process reserved set on success.
+  //   - Returns `E_SLUG_RESERVED` with 3 suggestions on collision.
+  //
+  // The reservation is consumed by `attachmentStore.put` on success (writer
+  // contract). On any subsequent failure path we explicitly release with
+  // `releaseReservedSlug(validated.id)` so retries do not see a stale claim.
+  //
+  // This ELIMINATES the rollback path that previously deleted
+  // `.changeset/<slug>.md` after a late-bound `SlugCollisionError`. The
+  // typed catch in step 4 below is now defence-in-depth for the
+  // cross-process race window (where another process took the slug between
+  // `reserveSlug` and `put`).
+  const reservation = await reserveSlug('changeset', validated.id, {
+    cwd: opts.projectRoot,
+  });
+  if (!reservation.ok) {
+    return {
+      ok: false,
+      error: {
+        code: 'E_SLUG_RESERVED',
+        message: `Slug '${validated.id}' is already in use in this project`,
+        suggestions: reservation.suggestions,
+        aliases: ['E_SSOT_WRITE_FAILED'],
+      },
+    };
+  }
+
   // ── 2. Render bytes. ────────────────────────────────────────────────────
   const markdown = renderChangesetMarkdown(validated);
   const bytes = Buffer.from(markdown, 'utf-8');
@@ -221,6 +269,8 @@ export async function writeChangesetEntry(
     } catch {
       /* Already gone or unwritable — ignore. */
     }
+    // Release the slug reservation so retries do not see a stale claim.
+    releaseReservedSlug(validated.id);
     return {
       ok: false,
       error: {
@@ -238,6 +288,12 @@ export async function writeChangesetEntry(
   if (ownerId === undefined) {
     // Schema guarantees `tasks.length >= 1` so this is unreachable; included
     // for type narrowing.
+    releaseReservedSlug(validated.id);
+    try {
+      rmSync(filePath, { force: true });
+    } catch {
+      /* File removal best-effort. */
+    }
     return {
       ok: false,
       error: { code: 'E_INVALID_ENTRY', message: 'tasks array empty after validation' },
@@ -284,6 +340,29 @@ export async function writeChangesetEntry(
       rmSync(filePath, { force: true });
     } catch {
       /* File removal best-effort. */
+    }
+    // Release the slug reservation so retries do not see a stale claim.
+    // Safe regardless of whether the chokepoint reserved it or
+    // attachmentStore.put already consumed it (releaseReservedSlug is a
+    // no-op on an unreserved slug).
+    releaseReservedSlug(validated.id);
+
+    // T10388 — defence-in-depth: if the SSoT write throws SlugCollisionError
+    // it means another process took the slug between our reserveSlug() and
+    // attachmentStore.put() (cross-process race). Surface the SAME
+    // E_SLUG_RESERVED envelope as the early-bound chokepoint path so the
+    // CLI surface sees one uniform shape, with the legacy E_SSOT_WRITE_FAILED
+    // code retained under `aliases` for one release of back-compat.
+    if (err instanceof SlugCollisionError) {
+      return {
+        ok: false,
+        error: {
+          code: 'E_SLUG_RESERVED',
+          message: `Slug '${err.slug}' is already in use in this project`,
+          suggestions: err.suggestions,
+          aliases: ['E_SSOT_WRITE_FAILED'],
+        },
+      };
     }
     return {
       ok: false,

--- a/packages/core/src/docs/__tests__/slug-collision.test.ts
+++ b/packages/core/src/docs/__tests__/slug-collision.test.ts
@@ -45,9 +45,9 @@
  *     the same DocKind, OR (b) collapses the two writers entirely so only
  *     ONE code path can register a `changeset` slug
  *
- * This test scaffolds the contract. It is marked `it.todo` until the
- * allocator ships; once E1 lands, drop `.todo` and the test exercises the
- * canonical reservation path.
+ * This test scaffolds the contract. With T10386 (docs-add path) and T10388
+ * (changeset-add path) wired, ALL four scenarios run live against the
+ * central allocator and the writer-level rollback paths.
  *
  * @task T10294 (spike → informs E1)
  * @epic T10289 (E1-DOCS-SLUG-NAMESPACE)
@@ -62,6 +62,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { writeChangesetEntry } from '../../changesets/writer.js';
 import { createAttachmentStore } from '../../store/attachment-store.js';
 import { _resetSlugAllocatorState_TESTING_ONLY, reserveSlug } from '../slug-allocator.js';
 
@@ -74,8 +75,10 @@ import { _resetSlugAllocatorState_TESTING_ONLY, reserveSlug } from '../slug-allo
 // `packages/cleo/src/dispatch/domains/__tests__/docs-slug-type-project.test.ts`
 // (which is also updated by this PR).
 //
-// The remaining two `it.todo` scaffolds (changeset-add path) stay deferred
-// until T-E1.3 (T10388) wires the changeset writer through the allocator.
+// T10388 — the two remaining scaffolds (changeset-add path: same-writer
+// dedup + cross-kind global namespace) are now live tests exercising
+// `writeChangesetEntry()` end-to-end against the central allocator. All
+// FOUR contracts are now green per T10388 acceptance criterion #4.
 
 let tempDir: string;
 
@@ -183,25 +186,114 @@ describe('slug-allocator (T10289 E1) — docs-add path live (T10386)', () => {
     expect(fetched?.metadata.id).toBe(firstMeta.id);
   });
 
-  // ── Contract 2: idempotent re-reservation by the same writer + same bytes ─
+  // ── Contract 2: changeset-add path is consistently rejected on collision —
+  // no silent overwrite, no partial `.changeset/<slug>.md` leak (T10388).
   //
-  // Calling `reserve('changeset', 't10294-foo')` twice from the SAME writer
-  // with the SAME bytes MUST be a no-op (existing sha256 dedup behaviour
-  // preserved). Only DIFFERENT bytes or DIFFERENT writers trigger the
-  // collision error.
-  //
-  // Defers to T-E1.3 (T10388) — same-writer dedup is most meaningful on the
-  // changeset path (where it currently DOES dedup-by-sha) and exercises the
-  // changeset writer's interaction with the allocator's reserved-set.
-  it.todo('treats same-writer same-bytes re-reservation as idempotent (sha256 dedup)');
+  // The original scaffold (`it.todo`) speculated about SHA-dedup idempotency
+  // at the writer layer. With the T10388 wiring the central allocator
+  // intercepts BEFORE any filesystem write, so the chosen semantic is:
+  // "second writeChangesetEntry call with the same slug — regardless of
+  // bytes — surfaces E_SLUG_RESERVED with 3 suggestions and produces no
+  // .changeset/ file." This is the OBSERVABLE contract the acceptance
+  // criterion locks in ("No .md file leaked in .changeset/ when allocator
+  // rejects").
+  it('rejects a duplicate writeChangesetEntry with E_SLUG_RESERVED + no .changeset/ leak (T10388)', async () => {
+    const projectRoot = tempDir;
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(join(projectRoot, '.changeset'), { recursive: true });
 
-  // ── Contract 3: kind-scoped uniqueness vs. global uniqueness ──────────────
+    // First write — succeeds and writes both the .changeset/<slug>.md file
+    // and the SSoT blob row.
+    const first = await writeChangesetEntry(
+      {
+        id: 't10388-same-writer-dedup',
+        tasks: ['T10388'],
+        kind: 'feat',
+        summary: 'first writer wins',
+      },
+      { projectRoot },
+    );
+    expect(first.ok, JSON.stringify(first)).toBe(true);
+
+    // Second write with the SAME slug — allocator rejects pre-write.
+    const second = await writeChangesetEntry(
+      {
+        id: 't10388-same-writer-dedup',
+        tasks: ['T10388'],
+        kind: 'feat',
+        summary: 'second writer with identical bytes',
+      },
+      { projectRoot },
+    );
+    expect(second.ok).toBe(false);
+    if (second.ok) throw new Error('unreachable');
+    expect(second.error.code).toBe('E_SLUG_RESERVED');
+    if (second.error.code !== 'E_SLUG_RESERVED') throw new Error('narrowing');
+    expect(second.error.suggestions).toHaveLength(3);
+    expect(second.error.aliases).toContain('E_SSOT_WRITE_FAILED');
+
+    // No partial filesystem write — only the FIRST entry's file exists. We
+    // probe by listing the .changeset/ directory; any leak of a second file
+    // (e.g. a temp suffix from rename) would fail the acceptance criterion.
+    const { readdirSync } = await import('node:fs');
+    const files = readdirSync(join(projectRoot, '.changeset')).filter((f) => f.endsWith('.md'));
+    expect(files).toEqual(['t10388-same-writer-dedup.md']);
+  });
+
+  // ── Contract 3: GLOBAL namespace across DocKinds (T10390 decision) ────────
   //
-  // T10390 decision: GLOBAL namespace. The allocator's `kind` arg does NOT
-  // partition the namespace today. Deferred to T-E1.3 (T10388) as the
-  // changeset-vs-research collision is the canonical case (changeset writer
-  // is the second-writer in the live cross-kind reproducer).
-  it.todo(
-    'separates namespaces per DocKind OR exposes a clean error when kinds collide on the same slug',
-  );
+  // The allocator's `kind` arg does NOT partition the namespace — a slug
+  // claimed by `cleo docs add --type research` BLOCKS a follow-up
+  // `cleo changeset add` (and vice versa). This is the canonical T10294
+  // collision case the saga set out to fix.
+  it('treats the namespace as GLOBAL across DocKinds (changeset vs note collide) (T10388)', async () => {
+    const projectRoot = tempDir;
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(join(projectRoot, '.changeset'), { recursive: true });
+
+    // First writer claims the slug via the docs-add path (type='note').
+    const firstRes = await reserveSlug('note', 't10388-cross-kind-collide');
+    expect(firstRes.ok, JSON.stringify(firstRes)).toBe(true);
+    const store = createAttachmentStore();
+    await store.put(
+      Buffer.from('# cross-kind collision setup\n', 'utf-8'),
+      {
+        kind: 'blob',
+        storageKey: '',
+        mime: 'text/markdown',
+        size: 31,
+      },
+      'task',
+      'T10388',
+      'human',
+      undefined,
+      { slug: 't10388-cross-kind-collide', type: 'note' },
+    );
+
+    // Second writer (changeset path) tries the same slug — must fail with
+    // E_SLUG_RESERVED, NOT silently succeed as a different kind.
+    const second = await writeChangesetEntry(
+      {
+        id: 't10388-cross-kind-collide',
+        tasks: ['T10388'],
+        kind: 'feat',
+        summary: 'changeset trying to claim a slug owned by a note',
+      },
+      { projectRoot },
+    );
+    expect(second.ok).toBe(false);
+    if (second.ok) throw new Error('unreachable');
+    expect(second.error.code).toBe('E_SLUG_RESERVED');
+    if (second.error.code !== 'E_SLUG_RESERVED') throw new Error('narrowing');
+    expect(second.error.suggestions).toHaveLength(3);
+    expect(second.error.aliases).toContain('E_SSOT_WRITE_FAILED');
+
+    // No partial .changeset/ file written — allocator intercept fires before
+    // the file write step.
+    const { readdirSync, existsSync } = await import('node:fs');
+    if (existsSync(join(projectRoot, '.changeset'))) {
+      const files = readdirSync(join(projectRoot, '.changeset')).filter((f) => f.endsWith('.md'));
+      expect(files).toEqual([]);
+    }
+  });
 });

--- a/packages/core/src/docs/validate-body.ts
+++ b/packages/core/src/docs/validate-body.ts
@@ -92,7 +92,7 @@ export function validateDocBody(
   registry?: DocKindRegistry,
 ): ValidateDocBodyResult {
   const meta = lookupMetadata(kind, registry);
-  if (!meta || !meta.requiredSections || meta.requiredSections.length === 0) {
+  if (!meta?.requiredSections || meta.requiredSections.length === 0) {
     return { ok: true, missing: [] };
   }
 

--- a/packages/skills/skills/ct-documentor/SKILL.md
+++ b/packages/skills/skills/ct-documentor/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: ct-documentor
 description: Documentation coordinator with CLEO style guide compliance. Routes every canonical-doc write (spec, adr, research, handoff, note, llm-readme) through the docs SSoT via `cleo docs add` / `cleo docs publish` / `cleo docs fetch` — never raw filesystem writes. Coordinates ct-docs-lookup, ct-docs-write, ct-docs-review, ct-spec-writer, and ct-adr-recorder. Use when creating or updating documentation files, consolidating scattered documentation, or validating documentation against style standards. Triggers on documentation tasks, doc update requests, or style guide compliance checks.
-version: 3.12.0
+version: 3.13.0
 tier: 3
 core: false
 category: specialist
 protocol: null
 metadata:
-  version: 3.12.0
+  version: 3.13.0
   lastReviewed: 2026-05-24
   stability: stable
 dependencies:
@@ -147,11 +147,12 @@ invoking `attachmentStore.put({ slug })`. The allocator:
 
 The `attachmentStore.put` chokepoint enforces this via a runtime assert
 (`SlugNotReservedByAllocatorError`) when `CLEO_STRICT_SLUG_ALLOCATOR=1`
-is set. Strict mode becomes default once `cleo changeset add` (T10388)
-finishes wiring through the allocator. `cleo docs add` LIVE as of T10386:
-the dispatch layer (`packages/cleo/src/dispatch/domains/docs.ts:add`)
-calls `reserveSlug(type, slug)` BEFORE `attachmentStore.put`. Collisions
-surface the uniform envelope:
+is set. Strict mode becomes default in the next release after both
+writers are wired. **BOTH writers are LIVE on the allocator as of T10388**:
+`cleo docs add` (T10386 — `packages/cleo/src/dispatch/domains/docs.ts:add`)
+and `cleo changeset add` (T10388 — `packages/core/src/changesets/writer.ts:writeChangesetEntry`)
+both call `reserveSlug(kind, slug)` BEFORE any filesystem or DB mutation.
+Collisions surface the uniform envelope:
 
 ```json
 {
@@ -167,10 +168,10 @@ surface the uniform envelope:
 }
 ```
 
-`details.aliases` retains the legacy `E_SLUG_TAKEN` code for ONE release of
-back-compat — downstream consumers grepping for the old code can still match
-via the alias array. Removed after T-E1.3 (T10388) lands `cleo changeset add`
-on the same chokepoint.
+`details.aliases` retains the legacy `E_SLUG_TAKEN` (docs-add path) /
+`E_SSOT_WRITE_FAILED` (changeset-add path) codes for ONE release of
+back-compat — downstream consumers grepping for the old codes can still match
+via the alias array. Removed after E2 (T10290 — DocKind writer dedup) lands.
 
 Slugs share a GLOBAL namespace across all DocKinds — `reserveSlug('changeset',
 'foo')` followed by `reserveSlug('research', 'foo')` collides. The decision

--- a/scripts/.lint-stdout-discipline-baseline.json
+++ b/scripts/.lint-stdout-discipline-baseline.json
@@ -50,12 +50,12 @@
     "packages/cleo/src/cli/commands/memory.ts:2032",
     "packages/cleo/src/cli/commands/nexus.ts:1566",
     "packages/cleo/src/cli/commands/nexus.ts:1567",
-    "packages/cleo/src/cli/commands/sentient.ts:847",
-    "packages/cleo/src/cli/commands/sentient.ts:850",
-    "packages/cleo/src/cli/commands/sentient.ts:854",
-    "packages/cleo/src/cli/commands/sentient.ts:858",
-    "packages/cleo/src/cli/commands/sentient.ts:862",
-    "packages/cleo/src/cli/commands/sentient.ts:867",
+    "packages/cleo/src/cli/commands/sentient.ts:951",
+    "packages/cleo/src/cli/commands/sentient.ts:954",
+    "packages/cleo/src/cli/commands/sentient.ts:958",
+    "packages/cleo/src/cli/commands/sentient.ts:962",
+    "packages/cleo/src/cli/commands/sentient.ts:966",
+    "packages/cleo/src/cli/commands/sentient.ts:971",
     "packages/cleo/src/cli/commands/session.ts:746",
     "packages/cleo/src/cli/commands/skill.ts:91",
     "packages/cleo/src/cli/commands/snapshot.ts:41",
@@ -66,5 +66,5 @@
     "packages/mcp-adapter/src/server.ts:133",
     "packages/mcp-adapter/src/server.ts:137"
   ],
-  "updatedAt": "2026-05-24T10:31:20.131Z"
+  "updatedAt": "2026-05-24T11:12:15.168Z"
 }


### PR DESCRIPTION
## Summary

- `packages/core/src/changesets/writer.ts` reserves the slug through the central allocator BEFORE any filesystem or DB write
- Typed `SlugCollisionError` catch surfaces `E_SLUG_RESERVED` with 3 suggestions + legacy `E_SSOT_WRITE_FAILED` alias (one-release back-compat)
- `releaseReservedSlug` on every failure path — no orphan reservations
- Dispatch (`packages/cleo/src/dispatch/domains/docs.ts`) maps the new error code to the uniform envelope used by `cleo docs add`
- CLI (`packages/cleo/src/cli/commands/changeset.ts`) includes the 3 suggestions in the `fix` hint
- The two remaining `it.todo` scaffolds in `slug-collision.test.ts` are now LIVE: same-writer dedup + cross-kind global namespace (all 4 tests green)
- `ct-documentor` SKILL.md tier-0 same-PR drift acknowledgement: BOTH writers are now LIVE on the allocator

## Saga

- Saga: T10288 SG-DOCS-INTEGRITY (Wave 2.B)
- Epic: T10289 E1-DOCS-SLUG-NAMESPACE
- Task: T10388 T-E1.3

## Acceptance Criteria

- [x] `cleo changeset add --slug foo` after `cleo docs add --slug foo` returns `E_SLUG_RESERVED` (not legacy `E_SSOT_WRITE_FAILED`)
- [x] Reversed order (changeset first, then docs add) keeps existing envelope from T-E1.2
- [x] No `.md` file leaked in `.changeset/` when allocator rejects
- [x] All 4 `slug-collision.test.ts` tests live + green

## Test plan

- [x] `pnpm exec vitest run packages/core/src/docs/__tests__/slug-collision.test.ts` — 4/4 pass
- [x] `pnpm exec vitest run packages/core/src/changesets` — 36/36 pass
- [x] `pnpm biome check --write` — clean
- [x] `pnpm run build --filter @cleocode/core --filter @cleocode/cleo` — green

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>