### PR TITLE
feat(T10360): docs add --type adr auto-numbers (closes T10153)

### DIFF
--- a/.changeset/t10360-e3-adr-auto-number.md
+++ b/.changeset/t10360-e3-adr-auto-number.md
@@ -1,0 +1,6 @@
+---
+id: t10360-e3-adr-auto-number
+tasks: [T10360]
+kind: feat
+summary: T10360 E3.2: cleo docs add --type adr auto-numbers via allocator (closes T10153)
+---

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -213,6 +213,7 @@ const addCommand = defineCommand({
       '  --labels <csv>         Comma-separated labels (e.g. rfc,spec)\n' +
       '  --attached-by <name>   Agent identity that created the attachment (default: "human")\n' +
       '  --slug <kebab>         Human-friendly alias, unique per project (T9636)\n' +
+      '  --title <text>         Human-readable title — REQUIRED for --type adr when --slug is omitted (T10360)\n' +
       '  --type <kind>          Taxonomy classification — run `cleo docs list-types` for kinds\n' +
       '  --allow-similar        Bypass the slug-similarity warn — every bypass is audited\n' +
       '                         to .cleo/audit/similar-bypass.jsonl (T10361)\n' +
@@ -222,7 +223,8 @@ const addCommand = defineCommand({
       '  • Unknown flags → E_UNKNOWN_FLAG with did-you-mean suggestions (T10359)\n' +
       '  • Slug collision → E_SLUG_RESERVED + 3 alternative slugs (T10386)\n' +
       '  • Near-duplicate slug → W_SLUG_SIMILAR warning unless --allow-similar (T10361)\n' +
-      '  • TODO(T10360): --type adr will auto-allocate adr-NNN-<title> from a --title flag.',
+      '  • For --type adr without --slug, slug auto-allocates as `adr-NNN-<kebab-title>` via the\n' +
+      '    central allocator (T10360 — closes T10153). --title is required in this case.',
   },
   args: {
     'owner-id': {
@@ -257,6 +259,13 @@ const addCommand = defineCommand({
         'Human-friendly kebab-case alias for the attachment, unique per project (T9636). ' +
         'Collision returns E_SLUG_RESERVED with 3 alternative suggestions ' +
         '(legacy E_SLUG_TAKEN aliased under details.aliases for one release — T10386).',
+    },
+    title: {
+      type: 'string',
+      description:
+        'Human-readable title used to derive the kebab-slug tail when auto-allocating an ' +
+        'ADR slug. REQUIRED when --type adr is set AND --slug is omitted. Slugified via the ' +
+        'shared kebabize helper (lowercase, hyphen-separated, diacritics stripped) (T10360).',
     },
     type: {
       type: 'string',
@@ -307,6 +316,23 @@ const addCommand = defineCommand({
         name: 'E_VALIDATION',
         fix: 'Example: cleo docs add T123 docs/rfc.md --desc "RFC draft" — or — cleo docs add T123 --url https://example.com/spec',
       });
+      process.exit(6);
+    }
+
+    // T10360 — `--type adr` without `--slug` requires `--title` for the
+    // auto-allocator's kebab-title tail. Surfacing this at the CLI layer
+    // keeps the error close to the operator's input so the fix hint is
+    // copy-pasteable.
+    if (args.type === 'adr' && !args.slug && !args.title) {
+      cliError(
+        '--title <text> is required when --type adr is used without --slug — ' +
+          'the allocator needs a title to assemble adr-NNN-<kebab-title>',
+        6,
+        {
+          name: 'E_VALIDATION',
+          fix: 'Re-run with --title "Adopt Drizzle v1 beta" (or pass --slug adr-042-explicit-name to bypass auto-allocation).',
+        },
+      );
       process.exit(6);
     }
 
@@ -468,6 +494,7 @@ const addCommand = defineCommand({
         ...(args.labels ? { labels: args.labels } : {}),
         ...(args['attached-by'] ? { attachedBy: args['attached-by'] } : {}),
         ...(args.slug ? { slug: args.slug } : {}),
+        ...(args.title ? { title: args.title } : {}),
         ...(args.type ? { type: args.type } : {}),
         ...(args.strict === true ? { strict: true } : {}),
       },

--- a/packages/cleo/src/dispatch/domains/__tests__/docs-adr-auto-number.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/docs-adr-auto-number.test.ts
@@ -227,7 +227,8 @@ describe('docs dispatch — ADR auto-numbering (T10360 / closes T10153)', () => 
       };
     };
 
-    const result = await allocateAdrSlug('Always Fails', {
+    const result = await allocateAdrSlug(tempDir, {
+      title: 'Always Fails',
       reserveSlugImpl: failingReserve as never,
       startNumberOverride: 1,
     });

--- a/packages/cleo/src/dispatch/domains/__tests__/docs-adr-auto-number.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/docs-adr-auto-number.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Integration tests for the `cleo docs add --type adr` auto-numbering flow.
+ *
+ * Covers T10360 acceptance criteria:
+ *   (a) Sequential allocation: first ADR gets `adr-001-foo-bar`, second
+ *       gets `adr-002-...`, ... — verifies the highest-number probe.
+ *   (b) Explicit `--slug` bypasses the auto-allocator (back-compat).
+ *   (c) `--type adr` without `--title` AND without `--slug` returns
+ *       `E_VALIDATION` from the dispatch layer.
+ *   (d) Concurrent allocations don't collide (Promise.all × N with the
+ *       same title produces N distinct slugs).
+ *   (e) `E_ADR_NUMBER_EXHAUSTED` when the allocator's reservation step
+ *       fails {@link MAX_ADR_ALLOCATION_ATTEMPTS} times in a row (using
+ *       a fault-injected `reserveSlugImpl`).
+ *
+ * @task T10360 (closes T10153)
+ * @epic T10291 (E3-DOCS-CLI-HARDENING)
+ * @saga T10288 (SG-DOCS-INTEGRITY)
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DocsHandler } from '../docs.js';
+
+let tempDir: string;
+let fixtureA: string;
+let fixtureB: string;
+let fixtureC: string;
+let fixtureD: string;
+
+describe('docs dispatch — ADR auto-numbering (T10360 / closes T10153)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-adr-auto-num-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+
+    fixtureA = join(tempDir, 'a.md');
+    fixtureB = join(tempDir, 'b.md');
+    fixtureC = join(tempDir, 'c.md');
+    fixtureD = join(tempDir, 'd.md');
+    await writeFile(fixtureA, '# A\n\nadr fixture A', 'utf-8');
+    await writeFile(fixtureB, '# B\n\nadr fixture B (different bytes)', 'utf-8');
+    await writeFile(fixtureC, '# C\n\nadr fixture C (other bytes)', 'utf-8');
+    await writeFile(fixtureD, '# D\n\nadr fixture D (yet other bytes)', 'utf-8');
+
+    // Clear the in-process slug-allocator state so successive tests in
+    // the same vitest worker don't leak reservations to each other.
+    const { _resetSlugAllocatorState_TESTING_ONLY } = await import('@cleocode/core/internal');
+    _resetSlugAllocatorState_TESTING_ONLY();
+  });
+
+  afterEach(async () => {
+    const { closeDb, _resetSlugAllocatorState_TESTING_ONLY } = await import(
+      '@cleocode/core/internal'
+    );
+    closeDb();
+    _resetSlugAllocatorState_TESTING_ONLY();
+    delete process.env['CLEO_DIR'];
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // (a) Sequential allocation
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('docs.add --type adr --title auto-allocates adr-001 then adr-002', async () => {
+    const handler = new DocsHandler();
+
+    const first = await handler.mutate('add', {
+      ownerId: 'T1000',
+      file: fixtureA,
+      type: 'adr',
+      title: 'Adopt Drizzle v1 beta',
+    });
+    expect(first.success).toBe(true);
+    const firstData = first.data as { slug?: string; adrNumber?: number; type?: string };
+    expect(firstData.type).toBe('adr');
+    expect(firstData.slug).toBe('adr-001-adopt-drizzle-v1-beta');
+    expect(firstData.adrNumber).toBe(1);
+
+    const second = await handler.mutate('add', {
+      ownerId: 'T1001',
+      file: fixtureB,
+      type: 'adr',
+      title: 'Cleo Persona Lock',
+    });
+    expect(second.success).toBe(true);
+    const secondData = second.data as { slug?: string; adrNumber?: number };
+    expect(secondData.slug).toBe('adr-002-cleo-persona-lock');
+    expect(secondData.adrNumber).toBe(2);
+  });
+
+  it('auto-allocator picks the next number after the highest existing ADR slug', async () => {
+    const handler = new DocsHandler();
+
+    // Pre-seed with an explicit ADR slug at 42 — the next auto-allocated
+    // slug must land on 43, not 1.
+    const seed = await handler.mutate('add', {
+      ownerId: 'T1100',
+      file: fixtureA,
+      type: 'adr',
+      slug: 'adr-042-seeded-decision',
+    });
+    expect(seed.success).toBe(true);
+
+    const auto = await handler.mutate('add', {
+      ownerId: 'T1101',
+      file: fixtureB,
+      type: 'adr',
+      title: 'Next After Seed',
+    });
+    expect(auto.success).toBe(true);
+    const data = auto.data as { slug?: string; adrNumber?: number };
+    expect(data.adrNumber).toBe(43);
+    expect(data.slug).toBe('adr-043-next-after-seed');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // (b) Explicit --slug bypasses auto-numbering
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('docs.add --type adr --slug bypasses the allocator (back-compat)', async () => {
+    const handler = new DocsHandler();
+
+    const resp = await handler.mutate('add', {
+      ownerId: 'T1200',
+      file: fixtureA,
+      type: 'adr',
+      slug: 'adr-099-explicit-slug',
+      // Title is ignored when slug is explicit.
+      title: 'This Title Is Ignored',
+    });
+    expect(resp.success).toBe(true);
+    const data = resp.data as { slug?: string; adrNumber?: number };
+    expect(data.slug).toBe('adr-099-explicit-slug');
+    // No adrNumber is set when the slug was caller-provided.
+    expect(data.adrNumber).toBeUndefined();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // (c) Missing title rejection
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('docs.add --type adr without --slug AND without --title returns E_VALIDATION', async () => {
+    const handler = new DocsHandler();
+
+    const resp = await handler.mutate('add', {
+      ownerId: 'T1300',
+      file: fixtureA,
+      type: 'adr',
+    });
+    expect(resp.success).toBe(false);
+    expect(resp.error?.code).toBe('E_VALIDATION');
+    expect(resp.error?.message).toMatch(/title/i);
+  });
+
+  it('docs.add --type adr with whitespace-only --title returns E_VALIDATION', async () => {
+    const handler = new DocsHandler();
+
+    const resp = await handler.mutate('add', {
+      ownerId: 'T1300',
+      file: fixtureA,
+      type: 'adr',
+      title: '   ',
+    });
+    expect(resp.success).toBe(false);
+    expect(resp.error?.code).toBe('E_VALIDATION');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // (d) Concurrent allocations don't collide
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('concurrent docs.add calls with same title produce distinct slugs', async () => {
+    const handler = new DocsHandler();
+
+    // We need 4 separate fixtures so each put writes distinct bytes (the
+    // attachment store de-dupes blobs by sha256 — same content would
+    // surface as the SAME attachment id even with distinct slugs).
+    const fixtures = [fixtureA, fixtureB, fixtureC, fixtureD];
+    const responses = await Promise.all(
+      fixtures.map((file, i) =>
+        handler.mutate('add', {
+          ownerId: `T140${i}`,
+          file,
+          type: 'adr',
+          title: 'Concurrent Allocation',
+        }),
+      ),
+    );
+
+    for (const r of responses) {
+      expect(r.success).toBe(true);
+    }
+    const slugs = responses.map((r) => (r.data as { slug?: string }).slug);
+    const numbers = responses.map((r) => (r.data as { adrNumber?: number }).adrNumber);
+    // Slugs must be distinct.
+    expect(new Set(slugs).size).toBe(fixtures.length);
+    // Numbers must be distinct.
+    expect(new Set(numbers).size).toBe(fixtures.length);
+    // Every slug matches the expected pattern.
+    for (const s of slugs) {
+      expect(s).toMatch(/^adr-\d{3,}-concurrent-allocation$/);
+    }
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // (e) E_ADR_NUMBER_EXHAUSTED on persistent reservation failures
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('allocateAdrSlug surfaces E_ADR_NUMBER_EXHAUSTED after 5 reservation failures', async () => {
+    // Drive the core allocator directly with a stub reserveSlug that always
+    // returns E_SLUG_RESERVED — exercises the retry-cap branch without
+    // racing the real allocator.
+    const { allocateAdrSlug, MAX_ADR_ALLOCATION_ATTEMPTS } = await import(
+      '@cleocode/core/internal'
+    );
+
+    let attempts = 0;
+    const failingReserve = async () => {
+      attempts++;
+      return {
+        ok: false as const,
+        code: 'E_SLUG_RESERVED' as const,
+        suggestions: ['adr-001-x-1', 'adr-001-x-2', 'adr-001-x-3'] as const,
+      };
+    };
+
+    const result = await allocateAdrSlug('Always Fails', {
+      reserveSlugImpl: failingReserve as never,
+      startNumberOverride: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('E_ADR_NUMBER_EXHAUSTED');
+    }
+    expect(attempts).toBe(MAX_ADR_ALLOCATION_ATTEMPTS);
+  });
+});

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -1096,7 +1096,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           'add',
         );
       }
-      const allocation = await allocateAdrSlug(rawTitle, { cwd: getProjectRoot() });
+      const allocation = await allocateAdrSlug(getProjectRoot(), { title: rawTitle });
       if (!allocation.ok) {
         return lafsError(allocation.code, allocation.message, 'add');
       }

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -60,7 +60,9 @@ import type {
 import {
   type AttachmentBackend,
   AUTO_TOKEN,
+  allocateAdrSlug,
   allocateAutoSlugForDispatch,
+  consumeReservedSlug,
   createAttachmentStore,
   createAttachmentStoreV2,
   type DerefResult,
@@ -847,6 +849,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       labels: rawLabels,
       attachedBy: rawAttachedBy,
       slug: rawSlug,
+      title: rawTitle,
       type: rawType,
       strict: strictMode,
     } = params;
@@ -1073,6 +1076,34 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       );
     }
 
+    // T10360 — when `--type adr` is set AND `--slug` is omitted, auto-allocate
+    // the slug via the ADR chokepoint. The allocator probes the docs SSoT for
+    // the highest existing ADR number, increments by 1, and reserves
+    // `adr-NNN-<kebab-title>` via the T10392 reserveSlug chokepoint. The
+    // returned slug is consumed by the imminent `attachmentStore.put` call
+    // (same handshake as explicit `--slug` callers).
+    //
+    // `--title` is the canonical kebab-source. We validated its presence at
+    // the CLI layer; here we re-check defensively for non-CLI callers
+    // (HTTP, programmatic) so the error contract stays uniform.
+    let adrNumber: number | undefined;
+    if (type === 'adr' && slug === undefined) {
+      if (typeof rawTitle !== 'string' || rawTitle.trim().length === 0) {
+        return lafsError(
+          'E_VALIDATION',
+          'title is required when type=adr and slug is omitted — the allocator needs ' +
+            'a title to assemble adr-NNN-<kebab-title>',
+          'add',
+        );
+      }
+      const allocation = await allocateAdrSlug(rawTitle, { cwd: getProjectRoot() });
+      if (!allocation.ok) {
+        return lafsError(allocation.code, allocation.message, 'add');
+      }
+      slug = allocation.slug;
+      adrNumber = allocation.number;
+    }
+
     // T9788 — when the registered kind requires an entityId, enforce the
     // kind's slug pattern on top of the shape check above. We accept a
     // missing slug (the store will assign one) but reject mismatches
@@ -1081,6 +1112,8 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
     if (type !== undefined && slug !== undefined) {
       const patternCheck = getDocKindRegistry().validateSlug(type, slug);
       if (!patternCheck.ok) {
+        // Release the auto-allocated reservation so it doesn't leak.
+        if (adrNumber !== undefined) releaseReservedSlug(slug);
         const exampleHint = patternCheck.example ? ` (example: ${patternCheck.example})` : '';
         return lafsError('E_SLUG_PATTERN_MISMATCH', `${patternCheck.error}${exampleHint}`, 'add');
       }
@@ -1105,7 +1138,10 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
     // collapsed both writers onto a single error shape). Downstream
     // consumers grepping for the legacy code can match
     // `details.aliases: ['E_SLUG_TAKEN']` until E2 deprecates the alias.
-    if (slug !== undefined) {
+    // T10360 — when adrNumber is set, allocateAdrSlug() already reserved the
+    // slug via reserveSlug() internally; skip the second chokepoint call to
+    // avoid double-reservation. For all other paths the chokepoint runs.
+    if (slug !== undefined && adrNumber === undefined) {
       const reservation = await reserveSlugForDispatch(getProjectRoot(), {
         kind: type ?? '',
         slug,
@@ -1214,9 +1250,10 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           extras,
         );
       } catch (err) {
-        // Release any reservation held by the allocator so retries do not
-        // see a stale claim. Safe on any thrown error path because
-        // releaseReservedSlug() is a no-op for un-reserved slugs.
+        // Release any reservation held by the allocator (explicit reserveSlug
+        // OR auto-allocated ADR slug T10360) so retries do not see a stale
+        // claim. Safe on any thrown error path because releaseReservedSlug()
+        // is a no-op for un-reserved slugs.
         if (slug !== undefined) releaseReservedSlug(slug);
         if (err instanceof SlugCollisionError) {
           // T10386 — late-bound collision (cross-process race won by another
@@ -1239,6 +1276,12 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
         }
         throw err;
       }
+
+      // T10360 — `attachmentStore.put` only consumes the reservation when
+      // `CLEO_STRICT_SLUG_ALLOCATOR=1`. In non-strict mode (current default)
+      // the auto-allocated slug would otherwise leak in the in-process
+      // reservedSlugs set indefinitely. Consume defensively here.
+      if (adrNumber !== undefined && slug !== undefined) consumeReservedSlug(slug);
 
       // T947 Wave B — also mirror the write through the unified v2 store
       // so llmtxt-backed manifests learn about the attachment. The v2
@@ -1297,6 +1340,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           attachmentBackend: backend as DocsAddResult['attachmentBackend'],
           ...(slug !== undefined ? { slug } : {}),
           ...(type !== undefined ? { type } : {}),
+          ...(adrNumber !== undefined ? { adrNumber } : {}),
         },
         'add',
       );
@@ -1347,6 +1391,9 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
         throw err;
       }
 
+      // T10360 — consume the auto-allocated reservation (see file-path branch).
+      if (adrNumber !== undefined && slug !== undefined) consumeReservedSlug(slug);
+
       // T945 Stage A — mint `llmtxt:<sha256>` node + `embeds` edge for the
       // URL attachment (the URL itself is the content-addressable identity).
       import('@cleocode/core/internal')
@@ -1384,6 +1431,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           attachmentBackend: backend as DocsAddResult['attachmentBackend'],
           ...(slug !== undefined ? { slug } : {}),
           ...(type !== undefined ? { type } : {}),
+          ...(adrNumber !== undefined ? { adrNumber } : {}),
         },
         'add',
       );

--- a/packages/contracts/src/operations/docs.ts
+++ b/packages/contracts/src/operations/docs.ts
@@ -401,6 +401,15 @@ export interface DocsAddParams {
    */
   slug?: string;
   /**
+   * Optional human-readable title — used to derive the kebab-slug tail when
+   * auto-allocating an ADR slug. REQUIRED when `type === 'adr'` AND `slug`
+   * is omitted; ignored otherwise. The allocator slugifies the title via
+   * the shared kebabize helper.
+   *
+   * @task T10360 (closes T10153)
+   */
+  title?: string;
+  /**
    * Optional taxonomy classification. Must match one of
    * {@link DOCS_TYPE_VALUES}; an invalid value returns `E_INVALID_TYPE`.
    *
@@ -449,6 +458,13 @@ export interface DocsAddResult {
   slug?: string;
   /** Type classification recorded for this attachment, when provided (T9637). */
   type?: DocsType;
+  /**
+   * Auto-allocated ADR number, present iff the slug was minted by
+   * {@link allocateAdrSlug} (i.e. `--type adr` without `--slug`).
+   *
+   * @task T10360
+   */
+  adrNumber?: number;
 }
 
 // --------------------------------------------------------------------------

--- a/packages/core/src/docs/adr-allocator.ts
+++ b/packages/core/src/docs/adr-allocator.ts
@@ -104,8 +104,21 @@ export interface AdrAllocateErr {
 /** Discriminated union returned by {@link allocateAdrSlug}. */
 export type AdrAllocateResult = AdrAllocateOk | AdrAllocateErr;
 
-/** Options accepted by {@link allocateAdrSlug}. */
-export interface AllocateAdrOptions extends ReserveSlugOptions {
+/**
+ * Params accepted by {@link allocateAdrSlug}.
+ *
+ * Follows the canonical Core SSoT dispatch contract (ADR-057): the
+ * function takes `(projectRoot, params)` so it can be invoked from a
+ * `defineTypedHandler` block without the SSoT lint flagging it as a
+ * non-uniform signature.
+ */
+export interface AllocateAdrParams extends ReserveSlugOptions {
+  /**
+   * Human-readable title — slugified into the slug tail.
+   * Empty / whitespace-only titles return `E_VALIDATION`.
+   */
+  readonly title: string;
+
   /**
    * Override the starting ADR number. Used by unit tests to force the
    * allocator down the retry path without populating the DB first.
@@ -120,6 +133,15 @@ export interface AllocateAdrOptions extends ReserveSlugOptions {
    *
    * @internal
    */
+  readonly reserveSlugImpl?: typeof reserveSlug;
+}
+
+/**
+ * @deprecated Legacy positional shape — retained for one release of
+ * back-compat with internal callers. Prefer {@link AllocateAdrParams}.
+ */
+export interface AllocateAdrOptions extends ReserveSlugOptions {
+  readonly startNumberOverride?: number;
   readonly reserveSlugImpl?: typeof reserveSlug;
 }
 
@@ -216,16 +238,24 @@ export function assembleAdrSlug(number: number, title: string): string {
  * @param opts - Optional cwd + test overrides.
  * @returns `{ ok: true, number, slug }` or `{ ok: false, code, message }`.
  *
+ * @param projectRoot - Absolute path to the project root (the `.cleo/`
+ *                       parent). Used for DB resolution + slug
+ *                       reservation. Pass `getProjectRoot()` from the
+ *                       dispatch layer.
+ * @param params - Allocation params — `title` is the canonical kebab
+ *                 source. Test seams (`startNumberOverride`,
+ *                 `reserveSlugImpl`) are optional.
+ * @returns `{ ok: true, number, slug }` or `{ ok: false, code, message }`.
+ *
  * @task T10360
  */
-// SSoT-EXEMPT: internal SDK helper — not a dispatched (projectRoot, params) op. Title is the canonical input + opts only injects test seams. (T10360)
 export async function allocateAdrSlug(
-  title: string,
-  opts?: AllocateAdrOptions,
+  projectRoot: string,
+  params: AllocateAdrParams,
 ): Promise<AdrAllocateResult> {
   // Reject empty / whitespace-only titles up front so an empty kebab
   // tail (`adr-001-`) never lands in the DB.
-  const kebab = slugify(title);
+  const kebab = slugify(params.title);
   if (!kebab) {
     return {
       ok: false,
@@ -234,17 +264,17 @@ export async function allocateAdrSlug(
     };
   }
 
-  const reserve = opts?.reserveSlugImpl ?? reserveSlug;
-  const startNumber = opts?.startNumberOverride ?? (await findHighestAdrNumber(opts?.cwd)) + 1;
+  const reserve = params.reserveSlugImpl ?? reserveSlug;
+  const startNumber = params.startNumberOverride ?? (await findHighestAdrNumber(projectRoot)) + 1;
 
   // Try `startNumber`, `startNumber+1`, ... up to MAX_ADR_ALLOCATION_ATTEMPTS
   // increments. Each candidate is a fresh reservation attempt against the
   // central allocator chokepoint.
   for (let i = 0; i < MAX_ADR_ALLOCATION_ATTEMPTS; i++) {
     const candidateNumber = startNumber + i;
-    const candidateSlug = assembleAdrSlug(candidateNumber, title);
+    const candidateSlug = assembleAdrSlug(candidateNumber, params.title);
     const reservation: SlugReserveResult = await reserve('adr', candidateSlug, {
-      ...(opts?.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      cwd: projectRoot,
     });
     if (reservation.ok) {
       return { ok: true, number: candidateNumber, slug: reservation.normalizedSlug };

--- a/packages/core/src/docs/adr-allocator.ts
+++ b/packages/core/src/docs/adr-allocator.ts
@@ -1,0 +1,262 @@
+/**
+ * ADR slug auto-allocation chokepoint.
+ *
+ * ## Why this module exists
+ *
+ * Before T10360, `cleo docs add --type adr` required the caller to
+ * hand-craft an `adr-NNNN-<topic>` slug. Agents and humans both
+ * (a) had to discover the next available ADR number by grepping disk
+ * or `.cleo/adrs/` and (b) frequently picked colliding numbers when
+ * multiple agents drafted ADRs concurrently. That was the user-facing
+ * symptom T10153 originally tracked.
+ *
+ * This module centralises the allocation: callers provide `--type adr`
+ * + `--title "<human readable title>"` and the allocator:
+ *
+ *   1. Queries the docs SSoT for the highest existing ADR number.
+ *   2. Increments by 1 and assembles the candidate slug
+ *      `adr-<NNN>-<kebab-title>` (`NNN` zero-padded to width 3 — the
+ *      ADR numbering convention used across `.cleo/adrs/` and the
+ *      `docs/adr/` publish dir).
+ *   3. Calls {@link reserveSlug} (the T10392 central allocator
+ *      chokepoint) so the slug is reserved in the in-process Mutex
+ *      map AND probed against the `uniq_attachments_slug` partial
+ *      UNIQUE INDEX in a single chokepoint.
+ *   4. On `E_SLUG_RESERVED` (rare — two agents racing for the same
+ *      number despite the per-slug Mutex), retries with `N+1`,
+ *      `N+2`, ... up to {@link MAX_ADR_ALLOCATION_ATTEMPTS} before
+ *      surfacing `E_ADR_NUMBER_EXHAUSTED`.
+ *
+ * The allocator is project-scoped: it asks `.cleo/tasks.db` for the
+ * highest existing ADR number, NOT a global registry. Different
+ * projects keep independent ADR sequences.
+ *
+ * ## Why width 3 (`adr-001-...`)
+ *
+ * The historical `.cleo/adrs/` directory uses `ADR-NNN-<topic>.md`
+ * filenames with `NNN` zero-padded to 3 digits (e.g.
+ * `ADR-083-cleo-persona.md`). Auto-allocated slugs preserve that
+ * width so the slug ↔ filename mapping stays mechanically obvious
+ * for humans and orchestrators alike. The cap at 999 is a soft
+ * ceiling — ADRs that overflow it bump to 4 digits naturally
+ * (`adr-1000-...`) because the regex tolerates any digit length.
+ *
+ * ## Bypass
+ *
+ * Callers passing an explicit `--slug` skip the allocator entirely
+ * and are routed straight to {@link reserveSlug} on the provided
+ * value. This preserves backward compatibility with
+ * `ct-adr-recorder`'s historical recipe and lets HITL operators
+ * pick a specific number when superseding a deleted/withdrawn ADR.
+ *
+ * @task T10360
+ * @epic T10291 (E3-DOCS-CLI-HARDENING)
+ * @saga T10288 (SG-DOCS-INTEGRITY)
+ * @closes T10153
+ */
+
+import { sql } from 'drizzle-orm';
+import { getDb } from '../store/sqlite.js';
+import { slugify } from './import/slug.js';
+import { type ReserveSlugOptions, reserveSlug, type SlugReserveResult } from './slug-allocator.js';
+
+// ─── Public surface ───────────────────────────────────────────────────────────
+
+/**
+ * Maximum number of consecutive allocation attempts before giving up.
+ *
+ * In practice the per-slug Mutex + DB UNIQUE INDEX serialises
+ * reservations so a single increment is almost always enough. The
+ * cap defends against pathological concurrency races (e.g. 5+ agents
+ * racing on the same epoch) by surfacing `E_ADR_NUMBER_EXHAUSTED`
+ * rather than retrying forever.
+ */
+export const MAX_ADR_ALLOCATION_ATTEMPTS = 5;
+
+/**
+ * Successful ADR allocation outcome.
+ *
+ * `number` is the integer ADR id that was allocated. `slug` is the
+ * canonical form written to `attachments.slug`. `slug` matches
+ * `adr-<NNN>-<kebab-title>` for `number <= 999` and
+ * `adr-<NNNN>-<kebab-title>` for `number >= 1000`.
+ */
+export interface AdrAllocateOk {
+  readonly ok: true;
+  readonly number: number;
+  readonly slug: string;
+}
+
+/**
+ * Failed ADR allocation outcome.
+ *
+ * `code` discriminates between exhaustion (5+ reservation collisions
+ * in a row — `E_ADR_NUMBER_EXHAUSTED`) and validation failures
+ * (`E_VALIDATION` for an empty title that slugifies to nothing). The
+ * dispatch layer maps `code` straight into the LAFS error envelope.
+ */
+export interface AdrAllocateErr {
+  readonly ok: false;
+  readonly code: 'E_ADR_NUMBER_EXHAUSTED' | 'E_VALIDATION';
+  readonly message: string;
+}
+
+/** Discriminated union returned by {@link allocateAdrSlug}. */
+export type AdrAllocateResult = AdrAllocateOk | AdrAllocateErr;
+
+/** Options accepted by {@link allocateAdrSlug}. */
+export interface AllocateAdrOptions extends ReserveSlugOptions {
+  /**
+   * Override the starting ADR number. Used by unit tests to force the
+   * allocator down the retry path without populating the DB first.
+   *
+   * @internal
+   */
+  readonly startNumberOverride?: number;
+
+  /**
+   * Override the reserveSlug implementation. Used by unit tests to
+   * simulate persistent contention without hitting the real DB.
+   *
+   * @internal
+   */
+  readonly reserveSlugImpl?: typeof reserveSlug;
+}
+
+// ─── ADR number discovery ─────────────────────────────────────────────────────
+
+/**
+ * Match an ADR slug and capture its numeric segment.
+ *
+ * Accepts `adr-1-foo`, `adr-001-foo`, `adr-99-foo`, `adr-1234-foo`.
+ * The numeric segment is anchored so `adr-foo-001-bar` does NOT match.
+ *
+ * @internal
+ */
+const ADR_SLUG_PATTERN = /^adr-(\d+)-/;
+
+/**
+ * Find the highest ADR number currently recorded in the attachments
+ * table.
+ *
+ * Returns `0` when no ADR slugs exist yet (so the first allocation
+ * lands on `1` — `adr-001-<topic>`).
+ *
+ * @param cwd - Optional working directory for `.cleo/` resolution.
+ * @returns Highest ADR number, or `0` when none exist.
+ * @internal — exported for tests.
+ */
+export async function findHighestAdrNumber(cwd?: string): Promise<number> {
+  const db = await getDb(cwd);
+  // Raw SELECT keeps the query independent of the Drizzle schema barrel —
+  // we only need the slug strings, not full row objects.
+  const rows = await db
+    .select({ slug: sql<string>`slug` })
+    .from(sql`attachments`)
+    .where(sql`slug LIKE 'adr-%-%'`)
+    .all();
+
+  let highest = 0;
+  for (const row of rows) {
+    const slug = row.slug;
+    if (typeof slug !== 'string') continue;
+    const match = ADR_SLUG_PATTERN.exec(slug);
+    if (!match) continue;
+    // Use the captured digit run directly — Number.parseInt with base 10.
+    const n = Number.parseInt(match[1] ?? '', 10);
+    if (Number.isFinite(n) && n > highest) {
+      highest = n;
+    }
+  }
+  return highest;
+}
+
+// ─── Slug assembly ────────────────────────────────────────────────────────────
+
+/**
+ * Assemble the canonical ADR slug from a number and a free-form title.
+ *
+ * `number` is zero-padded to width 3 (the historical convention) when
+ * it fits, otherwise the natural-width string is used so `adr-1000-foo`
+ * stays well-formed.
+ *
+ * `title` is slugified via the shared {@link slugify} helper so the
+ * shape matches existing T9636 conventions and the
+ * `uniq_attachments_slug` regex constraints.
+ *
+ * @param number - The ADR number (>= 1).
+ * @param title - Raw human-readable title (e.g. "Adopt Drizzle v1 beta").
+ * @returns Canonical slug (e.g. `adr-042-adopt-drizzle-v1-beta`).
+ * @internal — exported for tests.
+ */
+export function assembleAdrSlug(number: number, title: string): string {
+  const padded = number < 1000 ? String(number).padStart(3, '0') : String(number);
+  const kebab = slugify(title);
+  return `adr-${padded}-${kebab}`;
+}
+
+// ─── Main allocator entry point ───────────────────────────────────────────────
+
+/**
+ * Auto-allocate an ADR slug for an upcoming `attachmentStore.put` call.
+ *
+ * Returns a discriminated union: on success the slug has been reserved
+ * via {@link reserveSlug} and the caller MUST proceed with `put` (or
+ * release explicitly via `releaseReservedSlug`). On failure the slug
+ * has NOT been reserved and the dispatch layer surfaces the error
+ * envelope verbatim.
+ *
+ * The allocator retries on `E_SLUG_RESERVED` up to
+ * {@link MAX_ADR_ALLOCATION_ATTEMPTS} times. Each retry increments
+ * the candidate number — concurrent allocators converge on distinct
+ * slugs without re-querying the DB on every attempt.
+ *
+ * @param title - Human-readable title — slugified into the slug tail.
+ *                Empty / whitespace-only titles return `E_VALIDATION`.
+ * @param opts - Optional cwd + test overrides.
+ * @returns `{ ok: true, number, slug }` or `{ ok: false, code, message }`.
+ *
+ * @task T10360
+ */
+// SSoT-EXEMPT: internal SDK helper — not a dispatched (projectRoot, params) op. Title is the canonical input + opts only injects test seams. (T10360)
+export async function allocateAdrSlug(
+  title: string,
+  opts?: AllocateAdrOptions,
+): Promise<AdrAllocateResult> {
+  // Reject empty / whitespace-only titles up front so an empty kebab
+  // tail (`adr-001-`) never lands in the DB.
+  const kebab = slugify(title);
+  if (!kebab) {
+    return {
+      ok: false,
+      code: 'E_VALIDATION',
+      message: 'title must contain at least one alphanumeric character after slugification',
+    };
+  }
+
+  const reserve = opts?.reserveSlugImpl ?? reserveSlug;
+  const startNumber = opts?.startNumberOverride ?? (await findHighestAdrNumber(opts?.cwd)) + 1;
+
+  // Try `startNumber`, `startNumber+1`, ... up to MAX_ADR_ALLOCATION_ATTEMPTS
+  // increments. Each candidate is a fresh reservation attempt against the
+  // central allocator chokepoint.
+  for (let i = 0; i < MAX_ADR_ALLOCATION_ATTEMPTS; i++) {
+    const candidateNumber = startNumber + i;
+    const candidateSlug = assembleAdrSlug(candidateNumber, title);
+    const reservation: SlugReserveResult = await reserve('adr', candidateSlug, {
+      ...(opts?.cwd !== undefined ? { cwd: opts.cwd } : {}),
+    });
+    if (reservation.ok) {
+      return { ok: true, number: candidateNumber, slug: reservation.normalizedSlug };
+    }
+    // Reservation lost — bump and retry.
+  }
+
+  return {
+    ok: false,
+    code: 'E_ADR_NUMBER_EXHAUSTED',
+    message:
+      `failed to allocate an ADR slug after ${MAX_ADR_ALLOCATION_ATTEMPTS} attempts ` +
+      `starting at adr-${startNumber} — check for concurrent allocators or pass --slug explicitly`,
+  };
+}

--- a/packages/core/src/docs/index.ts
+++ b/packages/core/src/docs/index.ts
@@ -15,6 +15,19 @@
  * @task T1612
  */
 
+export type {
+  AdrAllocateErr,
+  AdrAllocateOk,
+  AdrAllocateResult,
+  AllocateAdrOptions,
+} from './adr-allocator.js';
+export {
+  allocateAdrSlug,
+  assembleAdrSlug,
+  findHighestAdrNumber,
+  MAX_ADR_ALLOCATION_ATTEMPTS,
+} from './adr-allocator.js';
+
 export type { GenerateDocsOptions, GenerateDocsResult } from './docs-generator.js';
 export { generateDocsLlmsTxt } from './docs-generator.js';
 export type {

--- a/packages/core/src/docs/index.ts
+++ b/packages/core/src/docs/index.ts
@@ -20,6 +20,7 @@ export type {
   AdrAllocateOk,
   AdrAllocateResult,
   AllocateAdrOptions,
+  AllocateAdrParams,
 } from './adr-allocator.js';
 export {
   allocateAdrSlug,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -137,6 +137,7 @@ export type {
   AdrAllocateOk,
   AdrAllocateResult,
   AllocateAdrOptions,
+  AllocateAdrParams,
 } from './docs/adr-allocator.js';
 export {
   allocateAdrSlug,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -131,6 +131,19 @@ export {
   diagnosticsExport,
   diagnosticsStatus,
 } from './diagnostics/engine-ops.js';
+// ADR slug auto-numbering (T10360 / Saga T10288 / Epic T10291 / closes T10153)
+export type {
+  AdrAllocateErr,
+  AdrAllocateOk,
+  AdrAllocateResult,
+  AllocateAdrOptions,
+} from './docs/adr-allocator.js';
+export {
+  allocateAdrSlug,
+  assembleAdrSlug,
+  findHighestAdrNumber,
+  MAX_ADR_ALLOCATION_ATTEMPTS,
+} from './docs/adr-allocator.js';
 // Docs generator — llms.txt format generation (T798)
 export type { GenerateDocsOptions, GenerateDocsResult } from './docs/docs-generator.js';
 export { generateDocsLlmsTxt } from './docs/docs-generator.js';

--- a/scripts/.lint-stdout-discipline-baseline.json
+++ b/scripts/.lint-stdout-discipline-baseline.json
@@ -66,5 +66,5 @@
     "packages/mcp-adapter/src/server.ts:133",
     "packages/mcp-adapter/src/server.ts:137"
   ],
-  "updatedAt": "2026-05-24T12:55:38.090Z"
+  "updatedAt": "2026-05-24T13:35:16.884Z"
 }

--- a/scripts/.lint-stdout-discipline-baseline.json
+++ b/scripts/.lint-stdout-discipline-baseline.json
@@ -26,8 +26,8 @@
     "packages/cleo/src/cli/commands/check.ts:621",
     "packages/cleo/src/cli/commands/check.ts:623",
     "packages/cleo/src/cli/commands/deps.ts:328",
-    "packages/cleo/src/cli/commands/docs.ts:879",
-    "packages/cleo/src/cli/commands/docs.ts:880",
+    "packages/cleo/src/cli/commands/docs.ts:811",
+    "packages/cleo/src/cli/commands/docs.ts:812",
     "packages/cleo/src/cli/commands/event.ts:238",
     "packages/cleo/src/cli/commands/event.ts:249",
     "packages/cleo/src/cli/commands/event.ts:251",
@@ -66,5 +66,5 @@
     "packages/mcp-adapter/src/server.ts:133",
     "packages/mcp-adapter/src/server.ts:137"
   ],
-  "updatedAt": "2026-05-24T12:06:09.686Z"
+  "updatedAt": "2026-05-24T11:17:10.956Z"
 }

--- a/scripts/.lint-stdout-discipline-baseline.json
+++ b/scripts/.lint-stdout-discipline-baseline.json
@@ -26,8 +26,8 @@
     "packages/cleo/src/cli/commands/check.ts:621",
     "packages/cleo/src/cli/commands/check.ts:623",
     "packages/cleo/src/cli/commands/deps.ts:328",
-    "packages/cleo/src/cli/commands/docs.ts:811",
-    "packages/cleo/src/cli/commands/docs.ts:812",
+    "packages/cleo/src/cli/commands/docs.ts:906",
+    "packages/cleo/src/cli/commands/docs.ts:907",
     "packages/cleo/src/cli/commands/event.ts:238",
     "packages/cleo/src/cli/commands/event.ts:249",
     "packages/cleo/src/cli/commands/event.ts:251",
@@ -66,5 +66,5 @@
     "packages/mcp-adapter/src/server.ts:133",
     "packages/mcp-adapter/src/server.ts:137"
   ],
-  "updatedAt": "2026-05-24T11:17:10.956Z"
+  "updatedAt": "2026-05-24T12:55:38.090Z"
 }

--- a/scripts/.lint-stdout-write-allowlist-baseline.json
+++ b/scripts/.lint-stdout-write-allowlist-baseline.json
@@ -30,8 +30,8 @@
     "packages/cleo/src/cli/commands/check.ts:621",
     "packages/cleo/src/cli/commands/check.ts:623",
     "packages/cleo/src/cli/commands/deps.ts:328",
-    "packages/cleo/src/cli/commands/docs.ts:879",
-    "packages/cleo/src/cli/commands/docs.ts:880",
+    "packages/cleo/src/cli/commands/docs.ts:906",
+    "packages/cleo/src/cli/commands/docs.ts:907",
     "packages/cleo/src/cli/commands/event.ts:238",
     "packages/cleo/src/cli/commands/event.ts:249",
     "packages/cleo/src/cli/commands/event.ts:251",
@@ -71,5 +71,5 @@
     "packages/mcp-adapter/src/server.ts:137",
     "packages/nexus/src/__tests__/bench-nexus.ts:389"
   ],
-  "updatedAt": "2026-05-24T13:27:27.566Z"
+  "updatedAt": "2026-05-24T13:35:16.727Z"
 }

--- a/scripts/__tests__/lint-stdout-discipline.test.mjs
+++ b/scripts/__tests__/lint-stdout-discipline.test.mjs
@@ -29,8 +29,16 @@ const __dirname = resolve(fileURLToPath(import.meta.url), '..');
 const REPO_ROOT = resolve(__dirname, '../..');
 const SCRIPT = join(REPO_ROOT, 'scripts/lint-stdout-discipline.mjs');
 
-/** Fixture path lives under a non-allowlisted package so it must trigger. */
-const FIXTURE_PATH = join(REPO_ROOT, 'packages/contracts/src/__stdout_violation_fixture.ts');
+/**
+ * Fixture path lives under a non-allowlisted package so it must trigger.
+ * Suffixed with pid to avoid cross-contamination with the parallel
+ * lint-stdout-write-allowlist suite (T10360 — same scan tree, different
+ * lint scripts, must not see each other's fixtures).
+ */
+const FIXTURE_PATH = join(
+  REPO_ROOT,
+  `packages/contracts/src/__stdout_violation_fixture_${process.pid}.ts`,
+);
 
 /**
  * Run the lint script with optional extra args.
@@ -65,7 +73,9 @@ describe('lint-stdout-discipline — baseline mode (default)', () => {
     const result = runLint();
     expect(result.status).toBe(1);
     const combined = result.stdout + result.stderr;
-    expect(combined).toContain('packages/contracts/src/__stdout_violation_fixture.ts');
+    expect(combined).toContain(
+      `packages/contracts/src/__stdout_violation_fixture_${process.pid}.ts`,
+    );
     expect(combined).toMatch(/NEW violation/);
   });
 

--- a/scripts/__tests__/lint-stdout-write-allowlist.test.mjs
+++ b/scripts/__tests__/lint-stdout-write-allowlist.test.mjs
@@ -28,8 +28,16 @@ const __dirname = resolve(fileURLToPath(import.meta.url), '..');
 const REPO_ROOT = resolve(__dirname, '../..');
 const SCRIPT = join(REPO_ROOT, 'scripts/lint-stdout-write-allowlist.mjs');
 
-/** Fixture lives under a non-allowlisted package so it must trigger. */
-const FIXTURE_PATH = join(REPO_ROOT, 'packages/contracts/src/__stdout_write_violation_fixture.ts');
+/**
+ * Fixture lives under a non-allowlisted package so it must trigger.
+ * Suffixed with pid to avoid cross-contamination with the parallel
+ * lint-stdout-discipline suite (T10360 — same scan tree, different lint
+ * scripts, must not see each other's fixtures).
+ */
+const FIXTURE_PATH = join(
+  REPO_ROOT,
+  `packages/contracts/src/__stdout_write_violation_fixture_${process.pid}.ts`,
+);
 
 /**
  * Run the lint script with optional extra args.
@@ -63,7 +71,9 @@ describe('lint-stdout-write-allowlist — check mode (default)', () => {
     const result = runLint(['--check']);
     expect(result.status).toBe(1);
     const combined = result.stdout + result.stderr;
-    expect(combined).toContain('packages/contracts/src/__stdout_write_violation_fixture.ts');
+    expect(combined).toContain(
+      `packages/contracts/src/__stdout_write_violation_fixture_${process.pid}.ts`,
+    );
     expect(combined).toMatch(/NEW unannotated violation/);
   });
 

--- a/scripts/lint-stdout-discipline.mjs
+++ b/scripts/lint-stdout-discipline.mjs
@@ -116,6 +116,11 @@ const ALLOW_PATH_PREFIXES = [
 const ALLOW_PATH_REGEXES = [
   // All test directories
   /__tests__\//,
+  // Sibling lint test suite's fixture (lint-stdout-write-allowlist.test.mjs)
+  // — must be ignored here to prevent cross-contamination when tests run
+  // in parallel (T10360 fix). Our own fixture file (matching this lint's
+  // marker) is still scanned and validated.
+  /__stdout_write_violation_fixture(?:_\d+)?\.ts$/,
 ];
 
 /** Inline opt-out marker (must appear on the same source line). */

--- a/scripts/lint-stdout-write-allowlist.mjs
+++ b/scripts/lint-stdout-write-allowlist.mjs
@@ -78,6 +78,14 @@ const SCAN_EXTENSIONS = new Set(['.ts', '.tsx', '.mts']);
 const TEST_FILE_SUFFIXES = ['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx', '.test.mts'];
 
 /**
+ * Sibling lint test suite's fixture (lint-stdout-discipline.test.mjs) — must
+ * be ignored here to prevent cross-contamination when tests run in parallel
+ * (T10360 fix). Our own fixture file (matching this lint's marker) is still
+ * scanned and validated.
+ */
+const SIBLING_FIXTURE_REGEX = /__stdout_violation_fixture(?:_\d+)?\.ts$/;
+
+/**
  * The ONLY paths where `process.stdout.write` is implicitly allowed
  * without a per-line justification. This is intentionally narrower than
  * the T10135 sibling lint — only the renderer SSoT counts.
@@ -136,6 +144,7 @@ function scanFile(absPath) {
 
   if (isRendererSsot(relPath)) return;
   if (isTestFile(relPath)) return;
+  if (SIBLING_FIXTURE_REGEX.test(relPath)) return;
 
   const src = readFileSync(absPath, 'utf-8');
   const lines = src.split('\n');


### PR DESCRIPTION
## Summary
- adr-allocator.ts derives adr-NNN- via T10392 reserveSlug
- --title flag; required when --slug omitted for type=adr
- Concurrent allocations don't collide

## Saga
- Saga: T10288 SG-DOCS-INTEGRITY (Wave 2.B)
- Epic: T10291 E3-DOCS-CLI-HARDENING
- Closes absorbed T10153
- Builds on T10359 (E3.1) + T10392 (E1.1)