### PR TITLE
feat: --field jsonpointer flag (T9929 / Saga T9855)

### DIFF
--- a/.changeset/t9929-field-jsonpointer.md
+++ b/.changeset/t9929-field-jsonpointer.md
@@ -1,0 +1,6 @@
+---
+id: t9929-field-jsonpointer
+tasks: [T9929]
+kind: feat
+summary: feat(cleo,core): --field <jsonpointer> flag for scalar extraction (T9929 / Saga T9855 / E9)
+---

--- a/packages/cleo/src/cli/commands/__tests__/field-flag.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/field-flag.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for `--field <jsonpointer>` flag (T9929 / Saga T9855 / E9).
+ *
+ * Verifies that:
+ *  - `--field /data/title` extracts a nested string and prints it raw.
+ *  - `--field /data/0/id` extracts an array element's scalar.
+ *  - `--field /nonexistent` exits 4 with `E_FIELD_NOT_FOUND`.
+ *  - `--field /` returns the whole envelope (RFC 6901 + CLI alias).
+ *  - Booleans and numbers serialize via `JSON.stringify`.
+ *  - Objects/arrays serialize as indented JSON.
+ *  - The legacy fuzzy-field-name form (`--field title`) is unaffected.
+ *
+ * Mirrors the mock pattern in `../cli-output-flags.test.ts` so the
+ * test does not require an end-to-end CLI spawn.
+ *
+ * @task T9929
+ * @epic T9919
+ * @saga T9855
+ */
+
+import { extractByJsonPointer, isJsonPointer, serializePointerValue } from '@cleocode/core';
+import type { FieldExtractionResolution, FlagResolution } from '@cleocode/lafs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the format-context and field-context modules — keeps the test
+// hermetic against the global singleton state set during real CLI runs.
+vi.mock('../../format-context.js', () => ({
+  getFormatContext: vi.fn(),
+  setFormatContext: vi.fn(),
+  isJsonFormat: vi.fn(),
+  isHumanFormat: vi.fn(),
+  isQuiet: vi.fn(),
+}));
+
+vi.mock('../../field-context.js', () => ({
+  getFieldContext: vi.fn(),
+  setFieldContext: vi.fn(),
+  resolveFieldContext: vi.fn(),
+}));
+
+import { getFieldContext } from '../../field-context.js';
+import { getFormatContext } from '../../format-context.js';
+import { cliOutput } from '../../renderers/index.js';
+
+// ---------------------------------------------------------------------------
+// Pure-function tests for the projection helpers — these don't require
+// any CLI plumbing and lock the RFC 6901 grammar in place.
+// ---------------------------------------------------------------------------
+
+describe('extractByJsonPointer (RFC 6901)', () => {
+  const env = {
+    success: true,
+    data: {
+      task: { id: 'T123', title: 'Fix the thing', priority: 1, blocked: false },
+      items: [{ id: 'T1' }, { id: 'T2' }],
+      'a/b': 'slash-escaped-key',
+      'a~b': 'tilde-escaped-key',
+    },
+    meta: { operation: 'tasks.show' },
+  } as const;
+
+  it('returns the whole document for empty pointer (strict RFC 6901)', () => {
+    expect(extractByJsonPointer(env, '')).toBe(env);
+  });
+
+  it('returns the whole document for "/" (CLI convenience alias)', () => {
+    expect(extractByJsonPointer(env, '/')).toBe(env);
+  });
+
+  it('extracts a nested string scalar', () => {
+    expect(extractByJsonPointer(env, '/data/task/title')).toBe('Fix the thing');
+  });
+
+  it('extracts a nested number scalar', () => {
+    expect(extractByJsonPointer(env, '/data/task/priority')).toBe(1);
+  });
+
+  it('extracts a nested boolean scalar', () => {
+    expect(extractByJsonPointer(env, '/data/task/blocked')).toBe(false);
+  });
+
+  it('extracts an array element by numeric index', () => {
+    expect(extractByJsonPointer(env, '/data/items/0/id')).toBe('T1');
+    expect(extractByJsonPointer(env, '/data/items/1/id')).toBe('T2');
+  });
+
+  it('decodes ~1 to "/" per RFC 6901 §4', () => {
+    expect(extractByJsonPointer(env, '/data/a~1b')).toBe('slash-escaped-key');
+  });
+
+  it('decodes ~0 to "~" per RFC 6901 §4', () => {
+    expect(extractByJsonPointer(env, '/data/a~0b')).toBe('tilde-escaped-key');
+  });
+
+  it('returns undefined for a missing property', () => {
+    expect(extractByJsonPointer(env, '/data/task/missing')).toBeUndefined();
+  });
+
+  it('returns undefined for an out-of-range array index', () => {
+    expect(extractByJsonPointer(env, '/data/items/99/id')).toBeUndefined();
+  });
+
+  it('returns undefined for the array "-" indicator (write-only token)', () => {
+    expect(extractByJsonPointer(env, '/data/items/-')).toBeUndefined();
+  });
+
+  it('returns undefined for a non-numeric token on an array', () => {
+    expect(extractByJsonPointer(env, '/data/items/foo')).toBeUndefined();
+  });
+
+  it('returns undefined when descending into a primitive', () => {
+    expect(extractByJsonPointer(env, '/data/task/title/anything')).toBeUndefined();
+  });
+
+  it('returns undefined for a malformed pointer with no leading slash', () => {
+    expect(extractByJsonPointer(env, 'data/task/title')).toBeUndefined();
+  });
+});
+
+describe('isJsonPointer', () => {
+  it.each([
+    ['', true],
+    ['/', true],
+    ['/data/title', true],
+    ['/data/items/0', true],
+    ['title', false],
+    ['data.title', false],
+    ['data/title', false],
+  ])('isJsonPointer(%p) === %p', (input, expected) => {
+    expect(isJsonPointer(input)).toBe(expected);
+  });
+});
+
+describe('serializePointerValue', () => {
+  it('returns strings raw (no quotes)', () => {
+    expect(serializePointerValue('hello')).toBe('hello');
+  });
+
+  it('returns numbers via JSON.stringify', () => {
+    expect(serializePointerValue(42)).toBe('42');
+    expect(serializePointerValue(0.5)).toBe('0.5');
+  });
+
+  it('returns booleans via JSON.stringify', () => {
+    expect(serializePointerValue(true)).toBe('true');
+    expect(serializePointerValue(false)).toBe('false');
+  });
+
+  it('returns null as the literal "null"', () => {
+    expect(serializePointerValue(null)).toBe('null');
+  });
+
+  it('returns objects as indented JSON', () => {
+    expect(serializePointerValue({ a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+
+  it('returns arrays as indented JSON', () => {
+    expect(serializePointerValue([1, 2])).toBe('[\n  1,\n  2\n]');
+  });
+
+  it('throws on undefined (callers must guard)', () => {
+    expect(() => serializePointerValue(undefined)).toThrow(/undefined/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end `cliOutput` integration with --field /pointer
+// ---------------------------------------------------------------------------
+
+describe('cliOutput --field <jsonpointer>', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    // Throw on process.exit so we can assert exit-code intent without
+    // actually terminating the test runner.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code ?? 0}`);
+    }) as never);
+
+    vi.mocked(getFormatContext).mockReturnValue({
+      format: 'json',
+      source: 'default',
+      quiet: false,
+    } satisfies FlagResolution);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('cleo show T123 --field /data/title prints the title string only', () => {
+    vi.mocked(getFieldContext).mockReturnValue({
+      field: '/data/title',
+      mvi: 'minimal',
+      mviSource: 'default',
+      expectsCustomMvi: false,
+    } as FieldExtractionResolution);
+
+    cliOutput({ id: 'T123', title: 'Fix the thing' }, { command: 'show' });
+
+    expect(stdoutSpy).toHaveBeenCalledWith('Fix the thing\n');
+  });
+
+  it('cleo show T123 --field /nonexistent exits 4 with E_FIELD_NOT_FOUND', () => {
+    vi.mocked(getFieldContext).mockReturnValue({
+      field: '/nonexistent',
+      mvi: 'minimal',
+      mviSource: 'default',
+      expectsCustomMvi: false,
+    } as FieldExtractionResolution);
+
+    expect(() => cliOutput({ id: 'T123', title: 'x' }, { command: 'show' })).toThrow('__exit__:4');
+
+    // `cliError` in JSON mode (the test default) emits a LAFS error
+    // envelope to stdout. Assert the canonical code so consumers can grep
+    // `"codeName":"E_FIELD_NOT_FOUND"` from the JSON stream.
+    const stdoutText = stdoutSpy.mock.calls.map((c) => c[0] as string).join('');
+    expect(stdoutText).toContain('E_FIELD_NOT_FOUND');
+  });
+
+  it('cleo list --field /data/0/id prints the first task id', () => {
+    vi.mocked(getFieldContext).mockReturnValue({
+      field: '/data/0/id',
+      mvi: 'minimal',
+      mviSource: 'default',
+      expectsCustomMvi: false,
+    } as FieldExtractionResolution);
+
+    cliOutput(
+      [
+        { id: 'T1', title: 'first' },
+        { id: 'T2', title: 'second' },
+      ],
+      { command: 'list' },
+    );
+
+    expect(stdoutSpy).toHaveBeenCalledWith('T1\n');
+  });
+
+  it('--field / returns the whole envelope as indented JSON', () => {
+    vi.mocked(getFieldContext).mockReturnValue({
+      field: '/',
+      mvi: 'minimal',
+      mviSource: 'default',
+      expectsCustomMvi: false,
+    } as FieldExtractionResolution);
+
+    cliOutput({ id: 'T1' }, { command: 'show', operation: 'tasks.show' });
+
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const written = stdoutSpy.mock.calls[0]?.[0] as string;
+    // Indented JSON ends with a newline appended by cliOutput.
+    expect(written.endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(written.trimEnd());
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toEqual({ id: 'T1' });
+    expect(parsed.meta.operation).toBe('tasks.show');
+  });
+
+  it('boolean scalars serialize correctly', () => {
+    vi.mocked(getFieldContext).mockReturnValue({
+      field: '/data/verification/gates/implemented',
+      mvi: 'minimal',
+      mviSource: 'default',
+      expectsCustomMvi: false,
+    } as FieldExtractionResolution);
+
+    cliOutput({ verification: { gates: { implemented: true } } }, { command: 'show' });
+
+    expect(stdoutSpy).toHaveBeenCalledWith('true\n');
+  });
+
+  it('number scalars serialize correctly', () => {
+    vi.mocked(getFieldContext).mockReturnValue({
+      field: '/data/count',
+      mvi: 'minimal',
+      mviSource: 'default',
+      expectsCustomMvi: false,
+    } as FieldExtractionResolution);
+
+    cliOutput({ count: 42 }, { command: 'show' });
+
+    expect(stdoutSpy).toHaveBeenCalledWith('42\n');
+  });
+
+  it('object values serialize as indented JSON', () => {
+    vi.mocked(getFieldContext).mockReturnValue({
+      field: '/data/metadata',
+      mvi: 'minimal',
+      mviSource: 'default',
+      expectsCustomMvi: false,
+    } as FieldExtractionResolution);
+
+    cliOutput({ metadata: { key: 'value', n: 1 } }, { command: 'show' });
+
+    expect(stdoutSpy).toHaveBeenCalledWith('{\n  "key": "value",\n  "n": 1\n}\n');
+  });
+
+  it('null scalars serialize as the literal "null"', () => {
+    vi.mocked(getFieldContext).mockReturnValue({
+      field: '/data/owner',
+      mvi: 'minimal',
+      mviSource: 'default',
+      expectsCustomMvi: false,
+    } as FieldExtractionResolution);
+
+    cliOutput({ owner: null }, { command: 'show' });
+
+    expect(stdoutSpy).toHaveBeenCalledWith('null\n');
+  });
+
+  it('legacy fuzzy-field-name form (no leading slash) is unaffected', () => {
+    // Sanity check: passing a bare field name routes through the legacy
+    // extractor (which finds `title` one level down in `{ task: {…} }`).
+    // If the JSON-pointer path mistakenly intercepted this it would emit
+    // `E_FIELD_NOT_FOUND` because no top-level "title" key exists.
+    vi.mocked(getFieldContext).mockReturnValue({
+      field: 'title',
+      mvi: 'minimal',
+      mviSource: 'default',
+      expectsCustomMvi: false,
+    } as FieldExtractionResolution);
+
+    cliOutput({ task: { id: 'T1', title: 'legacy' } }, { command: 'show' });
+
+    expect(stdoutSpy).toHaveBeenCalledWith('legacy\n');
+  });
+});

--- a/packages/cleo/src/cli/renderers/index.ts
+++ b/packages/cleo/src/cli/renderers/index.ts
@@ -33,8 +33,10 @@ function generateRequestId(): string {
 // dispatcher hands off to it.
 import {
   drainWarnings,
+  extractByJsonPointer,
   type FormatOptions,
   formatSuccess,
+  isJsonPointer,
   metaFooter,
   pagerFooter,
   renderAuditReconstruct,
@@ -94,6 +96,7 @@ import {
   renderTree,
   renderVersion,
   renderWaves,
+  serializePointerValue,
 } from '@cleocode/core';
 import type { CliEnvelope, CliMeta, Warning } from '@cleocode/lafs';
 import { applyFieldFilter, extractFieldFromResult } from '@cleocode/lafs';
@@ -246,6 +249,35 @@ function pickDecoratorMetaExtensionsLocal(
   return out;
 }
 
+/**
+ * Build the in-memory CliEnvelope shape we use when resolving an RFC 6901
+ * `--field <pointer>` invocation. Mirrors the envelope produced by
+ * `formatSuccess` (success, data, meta, page?) so pointers like
+ * `/data/title`, `/meta/operation`, and `/page/total` all resolve.
+ *
+ * Decorator-stamped meta (`_nexus`, `deprecated`, `suggestedNext`) is
+ * merged in the same way `cliOutput`'s standard JSON path does, so the
+ * pointer surface matches what `--json` would emit.
+ *
+ * @task T9929
+ */
+function buildEnvelopeForPointer(data: unknown, opts: CliOutputOptions): Record<string, unknown> {
+  const decoratorExt = pickDecoratorMetaExtensionsLocal(opts.responseMeta);
+  const meta: Record<string, unknown> = {
+    ...decoratorExt,
+    ...(opts.extensions ?? {}),
+    operation: opts.operation ?? 'cli.output',
+  };
+  if (opts.message) meta['message'] = opts.message;
+  const envelope: Record<string, unknown> = {
+    success: true,
+    data,
+    meta,
+  };
+  if (opts.page) envelope['page'] = opts.page;
+  return envelope;
+}
+
 // ---------------------------------------------------------------------------
 // Options for cliOutput
 // ---------------------------------------------------------------------------
@@ -294,6 +326,24 @@ export interface CliOutputOptions {
 export function cliOutput(data: unknown, opts: CliOutputOptions): void {
   const ctx = getFormatContext();
   const fieldCtx = getFieldContext();
+
+  // T9929 (Saga T9855 / E9) — RFC 6901 JSON Pointer extraction.
+  //
+  // When `--field` looks like a JSON pointer (starts with `/`), resolve
+  // it against the WHOLE envelope (not just `data`). This lets agents
+  // write `cleo show T123 --field /data/title` and skip the `jq`
+  // dependency. The leading slash is the discriminator from legacy
+  // fuzzy-field-name lookups (`--field title`) handled below.
+  if (fieldCtx.field && isJsonPointer(fieldCtx.field)) {
+    const envelope = buildEnvelopeForPointer(data, opts);
+    const value = extractByJsonPointer(envelope, fieldCtx.field);
+    if (value === undefined) {
+      cliError(`Pointer "${fieldCtx.field}" did not resolve`, 4, { name: 'E_FIELD_NOT_FOUND' });
+      process.exit(4);
+    }
+    process.stdout.write(`${serializePointerValue(value)}\n`);
+    return;
+  }
 
   if (ctx.format === 'human') {
     let dataToRender = data as Record<string, unknown>;

--- a/packages/core/src/dispatch/projection.ts
+++ b/packages/core/src/dispatch/projection.ts
@@ -1,0 +1,173 @@
+/**
+ * Envelope projection helpers — RFC 6901 JSON Pointer extraction.
+ *
+ * `extractByJsonPointer` resolves an RFC 6901 JSON Pointer against an
+ * arbitrary envelope (or any plain JSON value) and returns the addressed
+ * value. The CLI surfaces this via `--field <pointer>` so agents can
+ * extract scalars from dispatch envelopes without a `jq` dependency:
+ *
+ * ```bash
+ * cleo show T123 --field /data/title
+ * cleo list --field /data/0/id
+ * cleo show T123 --field /data/verification/gates/implemented
+ * ```
+ *
+ * RFC 6901 conformance:
+ *   - The empty string `""` references the whole document.
+ *   - As a pragmatic extension, a single `/` also references the whole
+ *     document (operator convenience — `cleo show T123 --field /` reads
+ *     naturally as "the whole thing"). Strict RFC 6901 would interpret
+ *     `/` as "the property with the empty-string name", which is never
+ *     meaningful for our envelope shape.
+ *   - Tokens are decoded per §4: `~1` → `/`, `~0` → `~`.
+ *   - Numeric tokens on arrays are interpreted as zero-based indices.
+ *   - `undefined` is returned for any missing key, out-of-range index,
+ *     or traversal through a non-object/non-array value.
+ *
+ * @module @cleocode/core/dispatch/projection
+ *
+ * @epic T9919
+ * @task T9929
+ * @saga T9855
+ */
+
+/**
+ * Sentinel returned by {@link extractByJsonPointer} when the pointer
+ * does not address any value in the document. CLI callers convert this
+ * to `E_FIELD_NOT_FOUND` (exit 4).
+ *
+ * @public
+ */
+export type PointerResult = unknown;
+
+/**
+ * Decode a single RFC 6901 reference token (§4): `~1` → `/`, `~0` → `~`.
+ *
+ * The escape order matters — `~1` must be decoded BEFORE `~0` so that
+ * the literal sequence `~01` round-trips back to `~1` rather than `/`.
+ *
+ * @internal
+ */
+function decodeToken(token: string): string {
+  return token.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+/**
+ * Extract a value from a document using an RFC 6901 JSON Pointer.
+ *
+ * Returns the addressed value, or `undefined` when the pointer does not
+ * resolve. Never throws on missing paths — callers translate `undefined`
+ * to whatever error semantics they need.
+ *
+ * @param document - The root document (any JSON value).
+ * @param pointer  - RFC 6901 pointer string. Must start with `/`, or be
+ *                   the empty string `""`. The single character `/` is
+ *                   accepted as an alias for `""` (whole document).
+ * @returns The addressed value, or `undefined` when not found.
+ *
+ * @example
+ * ```ts
+ * const env = { success: true, data: { task: { id: 'T123', title: 'Fix' } } };
+ * extractByJsonPointer(env, '/data/task/title'); // => 'Fix'
+ * extractByJsonPointer(env, '/data/0/id');       // => undefined (data is not array)
+ * extractByJsonPointer(env, '');                 // => env (whole document)
+ * extractByJsonPointer(env, '/');                // => env (CLI convenience alias)
+ * ```
+ *
+ * @public
+ */
+export function extractByJsonPointer(document: unknown, pointer: string): PointerResult {
+  // Whole-document cases — both the strict RFC 6901 empty pointer and
+  // the CLI-convenience single-slash alias resolve to the root.
+  if (pointer === '' || pointer === '/') return document;
+
+  // RFC 6901 §3: every non-empty pointer MUST start with '/'. A
+  // malformed pointer (no leading slash) cannot address anything.
+  if (!pointer.startsWith('/')) return undefined;
+
+  // §3: split on '/' AFTER stripping the leading '/' so a pointer like
+  // '/a/b' yields the tokens ['a', 'b']. A trailing '/' yields a final
+  // empty token, which addresses the empty-string property name —
+  // unlikely in practice but kept faithful to the spec.
+  const tokens = pointer.slice(1).split('/').map(decodeToken);
+
+  let current: unknown = document;
+  for (const token of tokens) {
+    if (current === null || current === undefined) return undefined;
+
+    if (Array.isArray(current)) {
+      // §4: array indices are unsigned base-10 integers. The token '-'
+      // is the special "after the last element" indicator and never
+      // resolves to a member during read.
+      if (token === '-') return undefined;
+      if (!/^(0|[1-9][0-9]*)$/.test(token)) return undefined;
+      const index = Number(token);
+      if (index >= current.length) return undefined;
+      current = current[index];
+      continue;
+    }
+
+    if (typeof current === 'object') {
+      const record = current as Record<string, unknown>;
+      if (!Object.hasOwn(record, token)) return undefined;
+      current = record[token];
+      continue;
+    }
+
+    // Cannot descend into a primitive scalar.
+    return undefined;
+  }
+
+  return current;
+}
+
+/**
+ * Convenience predicate — `true` when the supplied string is a syntactic
+ * RFC 6901 pointer (empty string, or starts with `/`).
+ *
+ * Used by the CLI to discriminate the JSON-pointer `--field /data/title`
+ * form from the legacy fuzzy-field-name form (`--field title`). Pointers
+ * are exclusive to scalar extraction; field names go through the legacy
+ * `extractFieldFromResult` lookup for backward compatibility.
+ *
+ * @param value - The candidate string.
+ * @returns `true` when `value` is shaped like an RFC 6901 pointer.
+ *
+ * @public
+ */
+export function isJsonPointer(value: string): boolean {
+  return value === '' || value.startsWith('/');
+}
+
+/**
+ * Serialize an extracted pointer value for plain-text CLI output.
+ *
+ * The contract mirrors what scripts and agents expect when piping a
+ * `--field <pointer>` invocation:
+ *
+ *   - `string`           → raw value (no quotes, no trailing newline added here)
+ *   - `number | boolean` → `JSON.stringify` form (`true`, `false`, `42`, `0.5`)
+ *   - `null`             → the literal `"null"` (matches `JSON.stringify`)
+ *   - `object | array`   → `JSON.stringify` with 2-space indentation so
+ *                          structured results stay readable for humans
+ *                          AND parseable for downstream `jq` / scripts.
+ *
+ * `undefined` is rejected by the contract — callers must guard against
+ * missing-pointer cases before invoking this helper. The function throws
+ * on `undefined` so a bug in the CLI surface fails loudly during tests.
+ *
+ * @param value - The value returned by {@link extractByJsonPointer}.
+ * @returns The serialized scalar form, ready for `process.stdout.write`.
+ *
+ * @public
+ */
+export function serializePointerValue(value: unknown): string {
+  if (value === undefined) {
+    throw new TypeError('serializePointerValue: undefined is not serializable');
+  }
+  if (typeof value === 'string') return value;
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  return JSON.stringify(value, null, 2);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -647,6 +647,13 @@ export { updateTask } from './tasks/update.js';
 // T9918 (Saga T9855 / E7.5) — OperationInputContract registry seed
 // T9917 (Saga T9855 / E7.4) — extended with tasks.add + tasks.update via contracts package
 export { getInputContract, INPUT_CONTRACTS } from './dispatch/contracts/input-contracts.js';
+// T9929 (Saga T9855 / E9) — RFC 6901 JSON Pointer extractor for --field flag
+export {
+  extractByJsonPointer,
+  isJsonPointer,
+  type PointerResult,
+  serializePointerValue,
+} from './dispatch/projection.js';
 // T9920 (Saga T9855 / E8.1) — envelope-wide meta.suggestedNext attach helper
 // T9921 (Saga T9855 / E8.2) — per-op suggestion builders + tasks.* registry
 export {


### PR DESCRIPTION
## Summary
- New \`--field <pointer>\` flag on read commands.
- Scalar extraction without jq dependency.

## Test plan
- [x] biome / build / vitest

Closes T9929
Saga: T9855
ADR: 039