### PR TITLE
feat(cleo): cleo docs update (T10161 / Saga T9855)

### DIFF
--- a/.changeset/t10161-cleo-docs-update.md
+++ b/.changeset/t10161-cleo-docs-update.md
@@ -1,0 +1,6 @@
+---
+id: t10161-cleo-docs-update
+tasks: [T10161]
+kind: feat
+summary: cleo docs update <slug> — in-place update with version history (T10161 / Saga T9855 / E12.C4)
+---

--- a/packages/cleo/src/cli/commands/__tests__/docs-update.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/docs-update.test.ts
@@ -1,0 +1,259 @@
+/**
+ * End-to-end tests for `cleo docs update <slug>` (T10161).
+ *
+ * Drives the compiled `cleo` CLI as a subprocess against an isolated tmp
+ * `CLEO_PROJECT_ROOT` and verifies the slug-preserving in-place update
+ * contract from {@link import('@cleocode/contracts/operations/docs').DocsUpdateParams}.
+ *
+ * Coverage:
+ *
+ *   (a) docs add → docs update --file → version increments + audit line
+ *   (b) docs add → docs update --content "text" → same slug, new sha256
+ *   (c) updating a non-existent slug → E_NOT_FOUND
+ *   (d) two updates within the 5-minute squash window → ONE audit line
+ *       with two `revisions[]` entries
+ *   (e) noop (re-update with identical bytes) → changed=false, sha256 stable
+ *
+ * @task T10161 (Epic T10157 · Saga T9855 · E12.C4)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PKG_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const CLI_DIST = resolve(PKG_ROOT, 'dist', 'cli', 'index.js');
+const CLI_DIST_AVAILABLE = existsSync(CLI_DIST);
+
+interface CliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number | null;
+}
+
+function runCli(args: readonly string[], projectRoot: string): CliResult {
+  const env = {
+    ...process.env,
+    CLEO_PROJECT_ROOT: projectRoot,
+    CLEO_ROOT: projectRoot,
+    CLEO_DIR: join(projectRoot, '.cleo'),
+    CLEO_OUTPUT_FORMAT: 'json',
+  };
+  const result = spawnSync('node', [CLI_DIST, ...args], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+    timeout: 30_000,
+    cwd: projectRoot,
+    env,
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status,
+  };
+}
+
+interface LafsEnvelope<TData = unknown> {
+  readonly success: boolean;
+  readonly data?: TData;
+  readonly error?: {
+    readonly code?: number | string;
+    readonly codeName?: string;
+    readonly message?: string;
+    readonly fix?: string;
+    readonly details?: Record<string, unknown>;
+  };
+  readonly meta?: {
+    readonly operation?: string;
+    readonly command?: string;
+    readonly timestamp?: string;
+  };
+}
+
+function parseEnvelope<T = unknown>(stdout: string): LafsEnvelope<T> {
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+  for (const line of lines) {
+    if (!line.trim().startsWith('{')) continue;
+    try {
+      return JSON.parse(line) as LafsEnvelope<T>;
+    } catch {
+      /* keep scanning */
+    }
+  }
+  throw new Error(`parseEnvelope: no JSON envelope on stdout. Got:\n${stdout.slice(0, 2000)}`);
+}
+
+interface UpdateResultShape {
+  slug: string;
+  attachmentId: string;
+  previousAttachmentId: string;
+  sha256: string;
+  previousSha256: string;
+  changed: boolean;
+  lifecycleStatus: string;
+  updatedAt: string;
+  version: number;
+  squashed: boolean;
+}
+
+interface AddResultShape {
+  attachmentId: string;
+  sha256: string;
+}
+
+let projectRoot: string;
+
+beforeEach(async () => {
+  projectRoot = await mkdtemp(join(tmpdir(), 'cleo-T10161-'));
+  await mkdir(join(projectRoot, '.cleo'), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(projectRoot, { recursive: true, force: true }).catch(() => {
+    /* never fail teardown */
+  });
+});
+
+describe.skipIf(!CLI_DIST_AVAILABLE)('T10161 — cleo docs update <slug>', () => {
+  it('(a) add → update --file → slug preserved, sha256 differs, version increments', async () => {
+    const original = join(projectRoot, 'orig.md');
+    await writeFile(original, '# Title\n\nOriginal body.\n', 'utf-8');
+
+    const addRes = runCli(
+      ['docs', 'add', 'T-T10161-a', original, '--slug', 't10161-doc-a', '--type', 'note'],
+      projectRoot,
+    );
+    expect(addRes.status, `add failed; stdout=${addRes.stdout} stderr=${addRes.stderr}`).toBe(0);
+    const addEnv = parseEnvelope<AddResultShape>(addRes.stdout);
+    expect(addEnv.success).toBe(true);
+    const originalSha = addEnv.data?.sha256;
+    expect(originalSha).toBeTruthy();
+
+    const updated = join(projectRoot, 'updated.md');
+    await writeFile(updated, '# Title\n\nUpdated body (typo fix).\n', 'utf-8');
+
+    const upRes = runCli(
+      ['docs', 'update', 't10161-doc-a', '--file', updated, '--message', 'fix typo'],
+      projectRoot,
+    );
+    expect(upRes.status, `update failed; stdout=${upRes.stdout} stderr=${upRes.stderr}`).toBe(0);
+    const upEnv = parseEnvelope<UpdateResultShape>(upRes.stdout);
+    expect(upEnv.success).toBe(true);
+    const data = upEnv.data;
+    expect(data).toBeDefined();
+    expect(data?.slug).toBe('t10161-doc-a');
+    expect(data?.changed).toBe(true);
+    expect(data?.sha256).not.toBe(originalSha);
+    expect(data?.previousSha256).toBe(originalSha);
+    expect(data?.lifecycleStatus).toBe('draft');
+    // First update bumps version >= 2.
+    expect(data?.version).toBeGreaterThanOrEqual(2);
+
+    // Audit log line exists with the update revision.
+    const auditPath = join(projectRoot, '.cleo', 'audit', 'docs-versioning.jsonl');
+    const auditRaw = readFileSync(auditPath, 'utf-8');
+    expect(auditRaw).toContain('"docs.update"');
+    expect(auditRaw).toContain('"t10161-doc-a"');
+    expect(auditRaw).toContain('"fix typo"');
+  });
+
+  it('(b) add → update --content inline text → new sha256 + slug preserved', async () => {
+    const original = join(projectRoot, 'orig-b.md');
+    await writeFile(original, 'original text\n', 'utf-8');
+
+    const addRes = runCli(
+      ['docs', 'add', 'T-T10161-b', original, '--slug', 't10161-doc-b', '--type', 'note'],
+      projectRoot,
+    );
+    expect(addRes.status, `add failed; stdout=${addRes.stdout}`).toBe(0);
+    const originalSha = parseEnvelope<AddResultShape>(addRes.stdout).data?.sha256;
+
+    const upRes = runCli(
+      ['docs', 'update', 't10161-doc-b', '--content', 'updated text via --content\n'],
+      projectRoot,
+    );
+    expect(upRes.status, `update failed; stdout=${upRes.stdout}`).toBe(0);
+    const data = parseEnvelope<UpdateResultShape>(upRes.stdout).data;
+    expect(data?.slug).toBe('t10161-doc-b');
+    expect(data?.changed).toBe(true);
+    expect(data?.sha256).not.toBe(originalSha);
+    expect(data?.previousSha256).toBe(originalSha);
+  });
+
+  it('(c) update against a non-existent slug → E_NOT_FOUND', async () => {
+    const upRes = runCli(
+      ['docs', 'update', 'no-such-slug', '--content', 'whatever\n'],
+      projectRoot,
+    );
+    expect(upRes.status).not.toBe(0);
+    const env = parseEnvelope(upRes.stdout);
+    expect(env.success).toBe(false);
+    // codeName mirrors the symbolic LAFS code; raw `error.code` may be the numeric exit.
+    const symbolic = env.error?.codeName ?? String(env.error?.code ?? '');
+    expect(symbolic).toBe('E_NOT_FOUND');
+    expect(env.error?.message ?? '').toMatch(/no attachment.*no-such-slug/i);
+  });
+
+  it('(d) two updates within 5 min → squashed onto ONE audit line with revisions[]', async () => {
+    const original = join(projectRoot, 'orig-d.md');
+    await writeFile(original, 'rev 0\n', 'utf-8');
+
+    runCli(
+      ['docs', 'add', 'T-T10161-d', original, '--slug', 't10161-doc-d', '--type', 'note'],
+      projectRoot,
+    );
+
+    const r1 = runCli(
+      ['docs', 'update', 't10161-doc-d', '--content', 'rev 1\n', '--message', 'first edit'],
+      projectRoot,
+    );
+    expect(r1.status, `update 1 failed; stdout=${r1.stdout}`).toBe(0);
+    const d1 = parseEnvelope<UpdateResultShape>(r1.stdout).data;
+    expect(d1?.squashed).toBe(false);
+
+    const r2 = runCli(
+      ['docs', 'update', 't10161-doc-d', '--content', 'rev 2\n', '--message', 'second edit'],
+      projectRoot,
+    );
+    expect(r2.status, `update 2 failed; stdout=${r2.stdout}`).toBe(0);
+    const d2 = parseEnvelope<UpdateResultShape>(r2.stdout).data;
+    expect(d2?.squashed).toBe(true);
+
+    // Exactly one audit line for this slug, containing two revisions.
+    const auditPath = join(projectRoot, '.cleo', 'audit', 'docs-versioning.jsonl');
+    const auditRaw = readFileSync(auditPath, 'utf-8');
+    const lines = auditRaw.split('\n').filter((l) => l.length > 0 && l.includes('t10161-doc-d'));
+    expect(lines.length, `expected exactly 1 audit line; got ${lines.length}\n${auditRaw}`).toBe(1);
+    const entry = JSON.parse(lines[0]) as { revisions: unknown[] };
+    expect(entry.revisions.length).toBe(2);
+  });
+
+  it('(e) noop update with identical bytes → changed=false, sha256 stable', async () => {
+    const original = join(projectRoot, 'orig-e.md');
+    await writeFile(original, 'stable content\n', 'utf-8');
+
+    const addRes = runCli(
+      ['docs', 'add', 'T-T10161-e', original, '--slug', 't10161-doc-e', '--type', 'note'],
+      projectRoot,
+    );
+    expect(addRes.status).toBe(0);
+    const originalSha = parseEnvelope<AddResultShape>(addRes.stdout).data?.sha256;
+
+    const upRes = runCli(
+      ['docs', 'update', 't10161-doc-e', '--content', 'stable content\n'],
+      projectRoot,
+    );
+    expect(upRes.status, `noop update failed; stdout=${upRes.stdout}`).toBe(0);
+    const data = parseEnvelope<UpdateResultShape>(upRes.stdout).data;
+    expect(data?.changed).toBe(false);
+    expect(data?.sha256).toBe(originalSha);
+    expect(data?.previousSha256).toBe(originalSha);
+  });
+});

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -1070,6 +1070,136 @@ const rankCommand = defineCommand({
   },
 });
 
+// ── cleo docs update ──────────────────────────────────────────────────────────
+
+/**
+ * `cleo docs update <slug>` — UPDATE-in-place via slug (T10161).
+ *
+ * Replaces the blob content for an existing slug while preserving the slug
+ * itself. Internally:
+ *
+ *   1. Looks up the existing attachment row by slug (E_NOT_FOUND if missing).
+ *   2. Hashes the new content; identical bytes ⇒ NOOP (changed=false).
+ *   3. Inside one BEGIN IMMEDIATE transaction: clear the slug on the old
+ *      row, insert/upsert a new row carrying the new sha256 + the slug, and
+ *      carry every existing owner ref onto the new row.
+ *   4. Writes a versioning audit line under
+ *      `.cleo/audit/docs-versioning.jsonl`. Updates for the same slug within
+ *      a 5-minute window squash into the prior line (revisions[]).
+ *
+ * Pairs with `cleo docs supersede` (T10162) — supersede creates an explicit
+ * lineage edge for major scope shifts; update is for minor edits that
+ * shouldn't fragment the slug history.
+ *
+ * @task T10161 (Epic T10157 · Saga T9855 · E12.C4)
+ */
+const updateCommand = defineCommand({
+  meta: {
+    name: 'update',
+    description:
+      'Replace blob content for an existing slug while preserving the slug. ' +
+      'Pass --file <path> OR --content <text> (exactly one). Defaults --status to "draft" ' +
+      'on every update so explicit `accepted` docs get back-pressured to draft on edit. ' +
+      'Audit log entry appended to .cleo/audit/docs-versioning.jsonl (squashed within 5 min).\n\n' +
+      'Positional arguments:\n' +
+      '  <slug>                 Slug of the attachment to update (required)\n\n' +
+      'Named arguments:\n' +
+      '  --file <path>          Local file containing the new content\n' +
+      '  --content <text>       Inline UTF-8 content (mutually exclusive with --file)\n' +
+      '  --message <text>       One-line summary of the change (audit log)\n' +
+      '  --status <status>      Override lifecycle status — default "draft"\n' +
+      '  --attached-by <name>   Agent identity for this revision (default "human")',
+  },
+  args: {
+    slug: {
+      type: 'positional',
+      description: 'Slug of the attachment to update',
+      required: true,
+    },
+    file: {
+      type: 'string',
+      description: 'Local file containing the new content',
+    },
+    content: {
+      type: 'string',
+      description: 'Inline UTF-8 content (mutually exclusive with --file)',
+    },
+    message: {
+      type: 'string',
+      description: 'One-line summary of the change (recorded in the audit log)',
+    },
+    status: {
+      type: 'string',
+      description:
+        'Lifecycle status to set on the new row. Valid: ' +
+        'draft|proposed|accepted|superseded|archived|deprecated. Default: draft.',
+    },
+    'attached-by': {
+      type: 'string',
+      description: 'Agent identity that performed the update (default: "human")',
+    },
+  },
+  async run({ args, rawArgs }) {
+    try {
+      assertKnownFlags(rawArgs, updateCommand.args, 'docs update');
+    } catch (err) {
+      if (err instanceof UnknownFlagError) {
+        cliError(err.message, ExitCode.VALIDATION_ERROR, {
+          name: err.code,
+          fix: err.fix,
+          alternatives: err.suggestions.map((s) => ({ action: s, command: s })),
+          details: { flag: err.flag, knownFlags: err.knownFlags },
+        });
+        process.exit(ExitCode.VALIDATION_ERROR);
+      }
+      throw err;
+    }
+
+    const slug = String(args.slug);
+    const filePath = typeof args.file === 'string' ? args.file : undefined;
+    const inlineContent = typeof args.content === 'string' ? args.content : undefined;
+
+    if (filePath !== undefined && inlineContent !== undefined) {
+      cliError('--file and --content are mutually exclusive', ExitCode.VALIDATION_ERROR, {
+        name: 'E_VALIDATION',
+        fix: 'Use `cleo docs update <slug> --file <path>` OR `--content <text>` (not both).',
+      });
+      process.exit(ExitCode.VALIDATION_ERROR);
+    }
+    if (filePath === undefined && inlineContent === undefined) {
+      cliError('provide --file <path> OR --content <text>', ExitCode.VALIDATION_ERROR, {
+        name: 'E_VALIDATION',
+        fix: 'Example: `cleo docs update my-doc --file ./new.md` OR `cleo docs update my-doc --content "..."`.',
+      });
+      process.exit(ExitCode.VALIDATION_ERROR);
+    }
+
+    // T10389 — resolve relative file paths against the worktree cwd so
+    // worktree-spawned agents can pass relative paths. Mirrors the
+    // discipline used in `cleo docs add`.
+    let resolvedFile: string | undefined;
+    if (filePath !== undefined) {
+      const routing = resolveWorktreeRouting();
+      resolvedFile = resolveWorktreeFilePath(filePath, routing);
+    }
+
+    await dispatchFromCli(
+      'mutate',
+      'docs',
+      'update',
+      {
+        slug,
+        ...(resolvedFile !== undefined ? { file: resolvedFile } : {}),
+        ...(inlineContent !== undefined ? { content: inlineContent } : {}),
+        ...(typeof args.message === 'string' ? { message: args.message } : {}),
+        ...(typeof args.status === 'string' ? { status: args.status } : {}),
+        ...(typeof args['attached-by'] === 'string' ? { attachedBy: args['attached-by'] } : {}),
+      },
+      { command: 'docs update' },
+    );
+  },
+});
+
 // ── cleo docs versions ────────────────────────────────────────────────────────
 
 /**
@@ -1847,6 +1977,7 @@ export const docsCommand = defineCommand({
   },
   subCommands: {
     add: addCommand,
+    update: updateCommand,
     list: listCommand,
     fetch: fetchCommand,
     remove: removeCommand,

--- a/packages/cleo/src/dispatch/domains/__tests__/docs.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/docs.test.ts
@@ -39,10 +39,10 @@ describe('Docs Domain Registry (T797)', () => {
     expect(CANONICAL_DOMAINS).toContain('docs');
   });
 
-  it('docs domain has 5 registered operations', () => {
-    // add|list|fetch|remove (T797) + generate (T798)
+  it('docs domain has 6 registered operations', () => {
+    // add|list|fetch|remove (T797) + generate (T798) + update (T10161)
     const docsOps = getByDomain('docs');
-    expect(docsOps).toHaveLength(5);
+    expect(docsOps).toHaveLength(6);
   });
 
   it('docs has expected query operations', () => {
@@ -59,6 +59,15 @@ describe('Docs Domain Registry (T797)', () => {
     const names = mutateOps.map((o) => o.operation);
     expect(names).toContain('add');
     expect(names).toContain('remove');
+    // T10161 — update verb registered as mutate.
+    expect(names).toContain('update');
+  });
+
+  it('docs.update has slug as a required param (T10161)', () => {
+    const updateOp = OPERATIONS.find((o) => o.domain === 'docs' && o.operation === 'update');
+    expect(updateOp).toBeDefined();
+    expect(updateOp!.requiredParams).toContain('slug');
+    expect(updateOp!.gateway).toBe('mutate');
   });
 
   it('all docs operations have valid structure', () => {
@@ -112,6 +121,8 @@ describe('Docs Domain Handler Registration', () => {
     expect(ops.query).toContain('fetch');
     expect(ops.mutate).toContain('add');
     expect(ops.mutate).toContain('remove');
+    // T10161 — update verb appears in the supported-mutate list.
+    expect(ops.mutate).toContain('update');
   });
 });
 
@@ -220,6 +231,46 @@ describe('DocsHandler parameter validation', () => {
 
     it('does not return E_INVALID_OPERATION', async () => {
       const result = await handler.mutate('remove', {});
+      expect(result.error?.code).not.toBe('E_INVALID_OPERATION');
+    });
+  });
+
+  // T10161 — update verb param validation (DB-free shape checks).
+  describe('docs.update', () => {
+    it('returns E_INVALID_INPUT when slug is missing', async () => {
+      const result = await handler.mutate('update', {});
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('E_INVALID_INPUT');
+    });
+
+    it('returns E_INVALID_INPUT when neither file nor content is provided', async () => {
+      const result = await handler.mutate('update', { slug: 'some-slug' });
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('E_INVALID_INPUT');
+    });
+
+    it('returns E_INVALID_INPUT when BOTH file and content are provided', async () => {
+      const result = await handler.mutate('update', {
+        slug: 'some-slug',
+        file: '/tmp/x.md',
+        content: 'inline',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('E_INVALID_INPUT');
+    });
+
+    it('returns E_INVALID_INPUT when status is invalid', async () => {
+      const result = await handler.mutate('update', {
+        slug: 'some-slug',
+        content: 'x',
+        status: 'not-a-valid-status',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('E_INVALID_INPUT');
+    });
+
+    it('does not return E_INVALID_OPERATION', async () => {
+      const result = await handler.mutate('update', {});
       expect(result.error?.code).not.toBe('E_INVALID_OPERATION');
     });
   });

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -45,6 +45,8 @@ import type {
   DocsRemoveParams,
   DocsRemoveResult,
   DocsType,
+  DocsUpdateParams,
+  DocsUpdateResult,
 } from '@cleocode/contracts/operations/docs';
 import { pushWarning } from '@cleocode/core';
 import type {
@@ -63,12 +65,14 @@ import {
   generateDocsLlmsTxt,
   getCleoDirAbsolute,
   getProjectRoot,
+  isLifecycleStatus,
   memoryObserve,
   parseChangesetFrontmatter,
   releaseReservedSlug,
   reserveSlugForDispatch,
   resolveAttachmentBackend,
   SlugCollisionError,
+  updateDocBySlug,
   validateDocBody,
   writeChangesetEntry,
 } from '@cleocode/core/internal';
@@ -157,6 +161,7 @@ type DocsTypedOps = {
   readonly generate: readonly [DocsGenerateParams, DocsGenerateResult];
   readonly add: readonly [DocsAddParams, DocsAddResult];
   readonly remove: readonly [DocsRemoveParams, DocsRemoveResult];
+  readonly update: readonly [DocsUpdateParams, DocsUpdateResult];
 };
 
 // ─── Owner type inference ─────────────────────────────────────────────────────
@@ -1450,6 +1455,67 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       'remove',
     );
   },
+
+  // ── docs.update (T10161 — E12.C4 / Saga T9855) ─────────────────────────────
+
+  update: async (params) => {
+    const { slug: rawSlug, file: filePath, content: inlineContent, status: rawStatus } = params;
+
+    if (typeof rawSlug !== 'string' || rawSlug.length === 0) {
+      return lafsError('E_INVALID_INPUT', 'slug is required', 'update');
+    }
+
+    // Exactly one of file or content must be provided.
+    const hasFile = typeof filePath === 'string' && filePath.length > 0;
+    const hasContent = typeof inlineContent === 'string';
+    if (hasFile === hasContent) {
+      return lafsError(
+        'E_INVALID_INPUT',
+        'Provide exactly one of --file <path> or --content <text>',
+        'update',
+        'Use `cleo docs update <slug> --file ./new.md` OR `cleo docs update <slug> --content "..."`.',
+      );
+    }
+
+    // Validate --status against the canonical enum before touching the store.
+    if (rawStatus !== undefined && !isLifecycleStatus(rawStatus)) {
+      return lafsError(
+        'E_INVALID_INPUT',
+        `status must be one of: draft|proposed|accepted|superseded|archived|deprecated — got '${String(rawStatus)}'`,
+        'update',
+      );
+    }
+
+    // Resolve a relative --file path against the dispatch cwd so the core
+    // function receives an absolute path. Mirrors docs.add discipline.
+    const projectRoot = getProjectRoot();
+    const resolvedParams: typeof params = hasFile
+      ? { ...params, file: resolve(filePath as string) }
+      : params;
+
+    const outcome = await updateDocBySlug(projectRoot, resolvedParams);
+
+    if (!outcome.ok) {
+      return lafsError(outcome.error.code, outcome.error.message, 'update');
+    }
+
+    return lafsSuccess<DocsUpdateResult>(
+      {
+        slug: outcome.result.slug,
+        ...(outcome.result.type !== null ? { type: outcome.result.type as DocsType } : {}),
+        attachmentId: outcome.result.attachmentId,
+        previousAttachmentId: outcome.result.previousAttachmentId,
+        sha256: outcome.result.sha256,
+        previousSha256: outcome.result.previousSha256,
+        changed: outcome.result.changed,
+        lifecycleStatus: outcome.result.lifecycleStatus,
+        updatedAt: outcome.result.updatedAt,
+        version: outcome.result.version,
+        squashed: outcome.result.squashed,
+      },
+      'update',
+    );
+  },
 });
 
 // ─── Envelope-to-response converter ──────────────────────────────────────────
@@ -1533,7 +1599,7 @@ function docsEnvelopeToResponse(
 // ─── DocsHandler ──────────────────────────────────────────────────────────────
 
 const QUERY_OPS = new Set<string>(['list', 'fetch', 'generate']);
-const MUTATE_OPS = new Set<string>(['add', 'remove']);
+const MUTATE_OPS = new Set<string>(['add', 'remove', 'update']);
 
 /**
  * Domain handler for `cleo docs` attachment operations.
@@ -1613,7 +1679,7 @@ export class DocsHandler implements DomainHandler {
   getSupportedOperations(): { query: string[]; mutate: string[] } {
     return {
       query: ['list', 'fetch', 'generate'],
-      mutate: ['add', 'remove'],
+      mutate: ['add', 'remove', 'update'],
     };
   }
 }

--- a/packages/contracts/src/dispatch/operations-registry.ts
+++ b/packages/contracts/src/dispatch/operations-registry.ts
@@ -6797,6 +6797,61 @@ export const OPERATIONS: OperationDef[] = [
       },
     ],
   },
+  // ── docs.update (T10161 — Epic T10157 / Saga T9855) ──────────────────────
+  {
+    gateway: 'mutate',
+    domain: 'docs',
+    operation: 'update',
+    description:
+      'docs.update (mutate) — replace blob content for an existing slug while preserving the slug. ' +
+      'New sha256 + new attachment row; the old row stays reachable by ID for history. ' +
+      'NO supersession edge (use `cleo docs supersede` for that). ' +
+      'Audit log entry appended to .cleo/audit/docs-versioning.jsonl (squashed within a 5-min window).',
+    tier: 1,
+    idempotent: false,
+    sessionRequired: false,
+    requiredParams: ['slug'],
+    params: [
+      {
+        name: 'slug',
+        type: 'string' as const,
+        required: true,
+        description: 'Slug of the existing attachment to update',
+      },
+      {
+        name: 'file',
+        type: 'string' as const,
+        required: false,
+        description: 'Path to a local file containing the new content',
+      },
+      {
+        name: 'content',
+        type: 'string' as const,
+        required: false,
+        description: 'Inline UTF-8 content (mutually exclusive with file)',
+      },
+      {
+        name: 'message',
+        type: 'string' as const,
+        required: false,
+        description: 'One-line summary describing the change (recorded in the audit log)',
+      },
+      {
+        name: 'status',
+        type: 'string' as const,
+        required: false,
+        description:
+          'Override the new lifecycle status. Defaults to "draft" on every update. ' +
+          'Valid: draft|proposed|accepted|superseded|archived|deprecated.',
+      },
+      {
+        name: 'attachedBy',
+        type: 'string' as const,
+        required: false,
+        description: 'Agent identity that performed the update (defaults to "human")',
+      },
+    ],
+  },
   // ── playbook.* HITL CLI surface (T935) ───────────────────────────────────
   {
     gateway: 'mutate',

--- a/packages/contracts/src/operations/docs.ts
+++ b/packages/contracts/src/operations/docs.ts
@@ -481,6 +481,101 @@ export interface DocsRemoveResult {
   attachmentBackend?: AttachmentBackend;
 }
 
+// --------------------------------------------------------------------------
+// docs.update — UPDATE-in-place via slug (T10161)
+// --------------------------------------------------------------------------
+
+/**
+ * Allowed `lifecycle_status` values mirrored from the attachments-table enum
+ * (`ATTACHMENT_LIFECYCLE_STATUSES` in
+ * `packages/core/src/store/schema/attachments.ts`). Kept inline here so the
+ * contract surface stays self-contained — the dispatch handler narrows raw
+ * `--status` input against this set before touching the store.
+ *
+ * @task T10161 (Epic T10157 / Saga T9855)
+ */
+export type DocsLifecycleStatus =
+  | 'draft'
+  | 'proposed'
+  | 'accepted'
+  | 'superseded'
+  | 'archived'
+  | 'deprecated';
+
+/**
+ * Parameters for `docs.update`.
+ *
+ * Replaces the blob content for an existing slug — the slug is transferred
+ * from the old `attachments` row to a new row carrying the new sha256, and
+ * the old row remains reachable by attachment-id for history. Unlike
+ * {@link DocsSupersedeParams}-style flows, NO supersession edge is created
+ * (callers wanting an explicit lineage edge should use `cleo docs supersede`).
+ *
+ * Exactly one of `file` or `content` MUST be provided.
+ *
+ * @task T10161 (Epic T10157 / Saga T9855 — E12.C4)
+ */
+export interface DocsUpdateParams {
+  /** Slug of the existing attachment to update (required). */
+  slug: string;
+  /** Path to a local file containing the new content. */
+  file?: string;
+  /** Inline UTF-8 content (mutually exclusive with `file`). */
+  content?: string;
+  /** Optional one-line summary describing the change (recorded in the audit log). */
+  message?: string;
+  /**
+   * Override the new lifecycle status. Defaults to `'draft'` on every update
+   * so an explicit `accepted` doc gets back-pressured to draft on edit. Pass
+   * `--status accepted` (or any other valid status) to override.
+   */
+  status?: DocsLifecycleStatus;
+  /** Agent identity that performed the update (default: `'human'`). */
+  attachedBy?: string;
+}
+
+/**
+ * Result of `docs.update`.
+ *
+ * Identifies the new row (active) and the row it replaced. When the supplied
+ * content is byte-identical to the current content the operation is a noop —
+ * `previousSha256` will equal `sha256` and `changed` will be `false`.
+ *
+ * @task T10161
+ */
+export interface DocsUpdateResult {
+  /** Slug that now points at the new content. */
+  slug: string;
+  /** Type/kind of the row, preserved from the prior version. */
+  type?: DocsType;
+  /** New attachment ID now bearing the slug. */
+  attachmentId: string;
+  /** Previous attachment ID; retains its row + bytes for history. */
+  previousAttachmentId: string;
+  /** SHA-256 hex of the new content. */
+  sha256: string;
+  /** SHA-256 hex of the prior content (equals `sha256` on a noop). */
+  previousSha256: string;
+  /** Whether the bytes actually changed (false ⇒ noop). */
+  changed: boolean;
+  /** Lifecycle status now stored on the new row. */
+  lifecycleStatus: DocsLifecycleStatus;
+  /** ISO 8601 timestamp the new row was registered. */
+  updatedAt: string;
+  /**
+   * Best-effort 1-indexed version number for the slug (count of historical
+   * rows that ever carried this slug, including the current one). When the
+   * underlying store cannot enumerate history this falls back to `2` for the
+   * first update and increments by 1 thereafter.
+   */
+  version: number;
+  /**
+   * True when this update was squashed into an existing audit entry within
+   * the 5-minute squash window (no new audit line was written).
+   */
+  squashed: boolean;
+}
+
 // ============================================================================
 // Discriminated Union (DocsOps)
 // ============================================================================
@@ -500,7 +595,8 @@ export type DocsOps =
   | { op: 'docs.fetch'; params: DocsFetchParams; result: DocsFetchResult }
   | { op: 'docs.generate'; params: DocsGenerateParams; result: DocsGenerateResult }
   | { op: 'docs.add'; params: DocsAddParams; result: DocsAddResult }
-  | { op: 'docs.remove'; params: DocsRemoveParams; result: DocsRemoveResult };
+  | { op: 'docs.remove'; params: DocsRemoveParams; result: DocsRemoveResult }
+  | { op: 'docs.update'; params: DocsUpdateParams; result: DocsUpdateResult };
 
 /**
  * Enumeration of all docs domain operation names.
@@ -509,4 +605,10 @@ export type DocsOps =
  * Useful for dynamic operation dispatch, type narrowing, or documentation.
  * Kept in sync with the `DocsOps` discriminated union above.
  */
-export type DocsOp = 'docs.list' | 'docs.fetch' | 'docs.generate' | 'docs.add' | 'docs.remove';
+export type DocsOp =
+  | 'docs.list'
+  | 'docs.fetch'
+  | 'docs.generate'
+  | 'docs.add'
+  | 'docs.remove'
+  | 'docs.update';

--- a/packages/core/src/docs/docs-update.ts
+++ b/packages/core/src/docs/docs-update.ts
@@ -1,0 +1,699 @@
+/**
+ * `cleo docs update <slug>` — in-place blob replacement that preserves the slug.
+ *
+ * The slug is the stable, human-addressable handle. On update we keep the
+ * slug pinned but rotate the bytes underneath: insert a NEW row for the new
+ * sha256 content (without a slug), then atomically transfer the slug from
+ * the old row to the new one inside a `BEGIN IMMEDIATE` transaction.
+ *
+ * The previous row stays reachable by attachment-id (and by raw sha256) for
+ * version history — its slug column is cleared so the UNIQUE index does
+ * not trip. No supersession edge is written (callers wanting an explicit
+ * lineage edge should use `cleo docs supersede`).
+ *
+ * Each successful update appends one line to
+ * `.cleo/audit/docs-versioning.jsonl`. When a second update for the same
+ * slug arrives within a 5-minute window the audit line is squashed onto
+ * the prior entry's `revisions[]` rather than written as a new line.
+ *
+ * @task T10161 (Epic T10157 / Saga T9855 — E12.C4)
+ * @see packages/core/src/store/attachment-store.ts — `put()` write path
+ * @see packages/core/src/store/schema/attachments.ts — `lifecycle_status` column
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { DocsLifecycleStatus, DocsUpdateParams } from '@cleocode/contracts/operations/docs';
+import { and, eq } from 'drizzle-orm';
+import { getCleoDirAbsolute } from '../paths.js';
+import { attachmentRefs, attachments } from '../store/schema/attachments.js';
+import { getDb, getNativeTasksDb } from '../store/sqlite.js';
+
+/**
+ * 5-minute squash window for audit-log entries. A second update for the
+ * same slug landing within this many milliseconds of the prior audit
+ * entry's `firstAt` does NOT write a new line — it appends a revision
+ * onto the existing line in place.
+ *
+ * @task T10161
+ */
+export const DOCS_UPDATE_SQUASH_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * Project-root-relative path to the docs-versioning audit log.
+ *
+ * @task T10161
+ */
+export const DOCS_VERSIONING_AUDIT_FILE = '.cleo/audit/docs-versioning.jsonl';
+
+/**
+ * Allowed lifecycle statuses — mirrors `ATTACHMENT_LIFECYCLE_STATUSES`
+ * from the attachments schema. Kept inline to avoid pulling the schema
+ * module into the contracts surface.
+ *
+ * @internal
+ */
+const ALLOWED_STATUSES: readonly DocsLifecycleStatus[] = [
+  'draft',
+  'proposed',
+  'accepted',
+  'superseded',
+  'archived',
+  'deprecated',
+] as const;
+
+/**
+ * Discriminated error for `updateDocBySlug` failures.
+ *
+ * Mirrors the LAFS error shape so callers (dispatch + tests) can map
+ * directly onto an envelope code without bespoke translation.
+ *
+ * @task T10161
+ */
+export type DocsUpdateError =
+  | { code: 'E_NOT_FOUND'; message: string }
+  | { code: 'E_INVALID_INPUT'; message: string }
+  | { code: 'E_INVALID_STATUS'; message: string }
+  | { code: 'E_FILE_ERROR'; message: string };
+
+/**
+ * Successful update result returned by {@link updateDocBySlug}.
+ *
+ * Shape matches `DocsUpdateResult` from `@cleocode/contracts` — the
+ * dispatch handler forwards it verbatim. `changed === false` indicates a
+ * byte-identical noop (no new row inserted, no audit entry written).
+ *
+ * @task T10161
+ */
+export interface DocsUpdateOk {
+  slug: string;
+  type: string | null;
+  attachmentId: string;
+  previousAttachmentId: string;
+  sha256: string;
+  previousSha256: string;
+  changed: boolean;
+  lifecycleStatus: DocsLifecycleStatus;
+  updatedAt: string;
+  version: number;
+  squashed: boolean;
+}
+
+/**
+ * Output of {@link updateDocBySlug} — either a success record or a
+ * discriminated error envelope.
+ *
+ * @task T10161
+ */
+export type UpdateDocBySlugResult =
+  | { ok: true; result: DocsUpdateOk }
+  | { ok: false; error: DocsUpdateError };
+
+interface AuditRevision {
+  /** ISO 8601 timestamp of this revision write. */
+  ts: string;
+  /** SHA-256 the slug pointed at BEFORE this revision. */
+  previousSha256: string;
+  /** SHA-256 the slug points at AFTER this revision. */
+  sha256: string;
+  /** Whether this revision actually changed bytes (false ⇒ noop). */
+  changed: boolean;
+  /** Operator-supplied summary, when provided. */
+  message?: string;
+  /** Lifecycle status applied with this revision. */
+  lifecycleStatus: DocsLifecycleStatus;
+  /** Agent identity that authored this revision. */
+  attachedBy: string;
+}
+
+interface AuditLine {
+  /** Operation discriminator (always `'docs.update'` for this writer). */
+  op: 'docs.update';
+  /** Slug being tracked. */
+  slug: string;
+  /** ISO 8601 timestamp the squash window started (oldest revision). */
+  firstAt: string;
+  /** ISO 8601 timestamp of the most recent revision. */
+  lastAt: string;
+  /** Chronological revision history within this squash window. */
+  revisions: AuditRevision[];
+}
+
+/**
+ * Detect MIME type from a file path. Mirrors the helper inside
+ * `attachment-store.ts` — kept private to this module to avoid widening
+ * the store's public surface for a single caller.
+ *
+ * @internal
+ */
+function mimeFromPath(filePath: string): string {
+  const lower = filePath.toLowerCase();
+  if (lower.endsWith('.md') || lower.endsWith('.markdown')) return 'text/markdown';
+  if (lower.endsWith('.txt')) return 'text/plain';
+  if (lower.endsWith('.html') || lower.endsWith('.htm')) return 'text/html';
+  if (lower.endsWith('.json')) return 'application/json';
+  if (lower.endsWith('.pdf')) return 'application/pdf';
+  if (lower.endsWith('.zip')) return 'application/zip';
+  if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+  if (lower.endsWith('.gif')) return 'image/gif';
+  if (lower.endsWith('.svg')) return 'image/svg+xml';
+  return 'application/octet-stream';
+}
+
+/** Map a MIME type to its on-disk file extension. */
+function extFromMime(mime: string): string {
+  switch (mime) {
+    case 'text/markdown':
+      return '.md';
+    case 'text/plain':
+      return '.txt';
+    case 'text/html':
+      return '.html';
+    case 'application/json':
+      return '.json';
+    case 'application/pdf':
+      return '.pdf';
+    case 'application/zip':
+      return '.zip';
+    case 'image/png':
+      return '.png';
+    case 'image/jpeg':
+      return '.jpg';
+    case 'image/gif':
+      return '.gif';
+    case 'image/svg+xml':
+      return '.svg';
+    default:
+      return '.bin';
+  }
+}
+
+/** Compute the SHA-256 hex digest of a Buffer. */
+function sha256Of(content: Buffer): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+/** Resolve the on-disk blob path used by the AttachmentStore. */
+function blobPath(sha256: string, mime: string, cwd?: string): string {
+  const prefix = sha256.slice(0, 2);
+  const rest = sha256.slice(2);
+  const ext = extFromMime(mime);
+  return join(getCleoDirAbsolute(cwd), 'attachments', 'sha256', prefix, `${rest}${ext}`);
+}
+
+/**
+ * Read the last line of the docs-versioning audit log if it matches the
+ * given slug and is still inside the squash window. Returns `null` when
+ * the log is missing, empty, or the latest entry does not qualify.
+ *
+ * The file is parsed line-by-line (cheap — entries are at most a few KB)
+ * and the LAST entry for `slug` is returned. Older squash-window entries
+ * for the same slug are deliberately ignored — they have already rolled
+ * past the window and become immutable.
+ *
+ * @internal
+ */
+function readSquashCandidate(
+  auditPath: string,
+  slug: string,
+  now: Date,
+): { line: string; index: number; entry: AuditLine } | null {
+  let raw: string;
+  try {
+    raw = readFileSync(auditPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  const lines = raw.split('\n');
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (!line || line.length === 0) continue;
+    let entry: AuditLine;
+    try {
+      entry = JSON.parse(line) as AuditLine;
+    } catch {
+      continue;
+    }
+    if (entry.op !== 'docs.update' || entry.slug !== slug) continue;
+    const lastAtMs = Date.parse(entry.lastAt);
+    if (Number.isNaN(lastAtMs)) continue;
+    if (now.getTime() - lastAtMs > DOCS_UPDATE_SQUASH_WINDOW_MS) return null;
+    return { line, index: i, entry };
+  }
+  return null;
+}
+
+/**
+ * Append a new audit line to the docs-versioning log (NO squash).
+ *
+ * Best-effort: write failures swallowed so audit drift never blocks an
+ * otherwise-successful update.
+ *
+ * @internal
+ */
+function appendNewAuditLine(auditPath: string, entry: AuditLine): void {
+  try {
+    mkdirSync(join(auditPath, '..'), { recursive: true });
+    appendFileSync(auditPath, `${JSON.stringify(entry)}\n`, { encoding: 'utf-8' });
+  } catch {
+    /* Audit drift is non-fatal. */
+  }
+}
+
+/**
+ * Rewrite an audit line in place with a new revision appended. Reads the
+ * full file, swaps line `index` for the updated JSON, and writes atomically.
+ *
+ * Best-effort: rewrite failures swallowed so audit drift never blocks an
+ * otherwise-successful update.
+ *
+ * @internal
+ */
+function rewriteAuditLine(auditPath: string, index: number, entry: AuditLine): void {
+  try {
+    const raw = readFileSync(auditPath, 'utf-8');
+    const lines = raw.split('\n');
+    if (index >= lines.length) {
+      // Index drifted (shouldn't happen — we just read this file). Fall
+      // back to append to avoid a silent audit-loss.
+      appendNewAuditLine(auditPath, entry);
+      return;
+    }
+    lines[index] = JSON.stringify(entry);
+    // Preserve the trailing newline if the original file had one.
+    const out = lines.join('\n');
+    writeFileSync(auditPath, out, { encoding: 'utf-8' });
+  } catch {
+    /* Audit drift is non-fatal. */
+  }
+}
+
+/**
+ * Validate a {@link DocsLifecycleStatus} value at runtime.
+ *
+ * Used by the dispatch handler before calling {@link updateDocBySlug} so
+ * the core function can stay type-narrowed without a redundant check.
+ *
+ * @task T10161
+ */
+export function isLifecycleStatus(raw: unknown): raw is DocsLifecycleStatus {
+  return typeof raw === 'string' && (ALLOWED_STATUSES as readonly string[]).includes(raw);
+}
+
+/**
+ * Update the attachment identified by `slug` to carry new bytes.
+ *
+ * Flow:
+ *   1. Look up the existing row by slug → `E_NOT_FOUND` if missing.
+ *   2. Hash the new bytes. If the hash matches the existing row's
+ *      sha256, the operation is a NOOP (return early with `changed: false`).
+ *   3. Inside a `BEGIN IMMEDIATE` transaction:
+ *      a. Clear the slug column on the old row.
+ *      b. Insert (or upsert) a row for the new sha256 with the slug,
+ *         the prior row's type, and the requested lifecycle status.
+ *      c. Add an `attachment_refs` binding for each owner the prior row
+ *         had, so the slug stays addressable from the same owners.
+ *      d. Commit. Write the new blob to disk AFTER the transaction.
+ *   4. Append (or squash) an audit-log entry.
+ *
+ * Signature follows ADR-057 L1: `(projectRoot, params): Promise<Result>`.
+ * The dispatch handler is the sole call site; tests drive this via the
+ * dispatch surface (or via the CLI E2E suite which spawns the compiled
+ * binary against an isolated project root).
+ *
+ * @param projectRoot - Absolute path to the CLEO project root
+ * @param params - {@link DocsUpdateParams} from the dispatch envelope
+ * @returns Success record or discriminated error
+ *
+ * @task T10161
+ */
+export async function updateDocBySlug(
+  projectRoot: string,
+  params: DocsUpdateParams,
+): Promise<UpdateDocBySlugResult> {
+  const slug = params.slug;
+  if (typeof slug !== 'string' || slug.length === 0) {
+    return { ok: false, error: { code: 'E_INVALID_INPUT', message: 'slug is required' } };
+  }
+
+  // Exactly one of file or content must be provided.
+  const hasFile = typeof params.file === 'string' && params.file.length > 0;
+  const hasContent = typeof params.content === 'string';
+  if (hasFile === hasContent) {
+    return {
+      ok: false,
+      error: {
+        code: 'E_INVALID_INPUT',
+        message: 'Provide exactly one of file or content',
+      },
+    };
+  }
+
+  // Read the file bytes when `file` was supplied; otherwise use the inline
+  // UTF-8 content as-is. The dispatch handler resolves relative paths to
+  // absolute before invoking this function (worktree-routing discipline).
+  let buf: Buffer;
+  if (hasFile) {
+    const { readFile } = await import('node:fs/promises');
+    try {
+      buf = await readFile(params.file as string);
+    } catch (cause) {
+      return {
+        ok: false,
+        error: {
+          code: 'E_FILE_ERROR',
+          message: `Cannot read file: ${params.file} (${cause instanceof Error ? cause.message : String(cause)})`,
+        },
+      };
+    }
+  } else {
+    buf = Buffer.from(params.content as string, 'utf-8');
+  }
+
+  // Validate requested status (defaults to draft).
+  const status: DocsLifecycleStatus = params.status ?? 'draft';
+  if (!isLifecycleStatus(status)) {
+    return {
+      ok: false,
+      error: {
+        code: 'E_INVALID_STATUS',
+        message: `status must be one of: ${ALLOWED_STATUSES.join('|')} — got '${String(status)}'`,
+      },
+    };
+  }
+
+  const newSha256 = sha256Of(buf);
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const attachedBy = params.attachedBy ?? 'human';
+
+  const db = await getDb(projectRoot);
+
+  // Look up the existing row by slug.
+  const oldRow = await db.select().from(attachments).where(eq(attachments.slug, slug)).get();
+  if (!oldRow) {
+    return {
+      ok: false,
+      error: { code: 'E_NOT_FOUND', message: `no attachment found with slug '${slug}'` },
+    };
+  }
+
+  const previousAttachmentId = oldRow.id;
+  const previousSha256 = oldRow.sha256;
+
+  // NOOP fast-path: identical content. Still surface the lifecycle status
+  // update if the caller asked for one, and still write an audit entry so
+  // operators can see the noop attempt.
+  if (newSha256 === previousSha256) {
+    // Only touch lifecycle_status if it actually changes.
+    if (oldRow.lifecycleStatus !== status) {
+      await db
+        .update(attachments)
+        .set({ lifecycleStatus: status })
+        .where(eq(attachments.id, oldRow.id))
+        .run();
+    }
+    const auditPath = join(projectRoot, DOCS_VERSIONING_AUDIT_FILE);
+    const squashed = writeOrSquashAudit({
+      auditPath,
+      slug,
+      now,
+      revision: {
+        ts: nowIso,
+        previousSha256,
+        sha256: newSha256,
+        changed: false,
+        ...(params.message !== undefined ? { message: params.message } : {}),
+        lifecycleStatus: status,
+        attachedBy,
+      },
+    });
+    return {
+      ok: true,
+      result: {
+        slug,
+        type: oldRow.type ?? null,
+        attachmentId: oldRow.id,
+        previousAttachmentId,
+        sha256: newSha256,
+        previousSha256,
+        changed: false,
+        lifecycleStatus: status,
+        updatedAt: nowIso,
+        version: countVersionsForSlug(projectRoot, slug),
+        squashed,
+      },
+    };
+  }
+
+  // Resolve the storage path for the NEW blob now so we can write it
+  // outside the transaction (mirrors AttachmentStore.put discipline).
+  // The attachment JSON we attach is a minimal `blob`-kind record — the
+  // updateDoc path does not know the source file's name, just bytes.
+  const mime = hasContent ? 'text/plain' : 'application/octet-stream';
+  const newAttachmentJson = JSON.stringify({
+    kind: 'blob',
+    name: oldRow.slug ?? slug,
+    mime,
+    size: buf.length,
+    blobId: newSha256,
+  });
+  const newBlobPath = blobPath(newSha256, mime, projectRoot);
+
+  const nativeDb = getNativeTasksDb();
+  if (!nativeDb) {
+    return {
+      ok: false,
+      error: { code: 'E_INVALID_INPUT', message: 'tasks database is not initialised' },
+    };
+  }
+
+  // Refs to migrate. We pull them BEFORE the transaction so a failure
+  // does not partially drain the table.
+  const oldRefs = await db
+    .select()
+    .from(attachmentRefs)
+    .where(eq(attachmentRefs.attachmentId, oldRow.id))
+    .all();
+
+  let newAttachmentId: string;
+  try {
+    nativeDb.prepare('BEGIN IMMEDIATE').run();
+
+    // 1. Clear the slug on the old row so the UNIQUE INDEX is free.
+    await db.update(attachments).set({ slug: null }).where(eq(attachments.id, oldRow.id)).run();
+
+    // 2. Insert OR update the new-sha256 row. If a row already exists
+    //    for this sha256 (rare — same bytes already stored under a
+    //    different slug), reuse it and just transfer the slug onto it.
+    const existingNewRow = await db
+      .select()
+      .from(attachments)
+      .where(eq(attachments.sha256, newSha256))
+      .get();
+
+    if (existingNewRow) {
+      newAttachmentId = existingNewRow.id;
+      await db
+        .update(attachments)
+        .set({
+          slug,
+          type: oldRow.type ?? null,
+          lifecycleStatus: status,
+        })
+        .where(eq(attachments.id, existingNewRow.id))
+        .run();
+    } else {
+      newAttachmentId = randomUUID();
+      await db
+        .insert(attachments)
+        .values({
+          id: newAttachmentId,
+          sha256: newSha256,
+          attachmentJson: newAttachmentJson,
+          createdAt: nowIso,
+          refCount: 0,
+          slug,
+          ...(oldRow.type ? { type: oldRow.type } : {}),
+          lifecycleStatus: status,
+        })
+        .run();
+    }
+
+    // 3. Carry every existing ref over to the new row so the slug stays
+    //    reachable from the same owners. We skip rows that already exist
+    //    on the new row (idempotent re-runs).
+    let refsAdded = 0;
+    for (const ref of oldRefs) {
+      const dup = await db
+        .select()
+        .from(attachmentRefs)
+        .where(
+          and(
+            eq(attachmentRefs.attachmentId, newAttachmentId),
+            eq(attachmentRefs.ownerType, ref.ownerType),
+            eq(attachmentRefs.ownerId, ref.ownerId),
+          ),
+        )
+        .get();
+      if (dup) continue;
+      await db
+        .insert(attachmentRefs)
+        .values({
+          attachmentId: newAttachmentId,
+          ownerType: ref.ownerType,
+          ownerId: ref.ownerId,
+          attachedAt: nowIso,
+          attachedBy,
+        })
+        .run();
+      refsAdded += 1;
+    }
+    if (refsAdded > 0) {
+      await db
+        .update(attachments)
+        .set({
+          refCount: (existingNewRow?.refCount ?? 0) + refsAdded,
+        })
+        .where(eq(attachments.id, newAttachmentId))
+        .run();
+    }
+
+    nativeDb.prepare('COMMIT').run();
+  } catch (err) {
+    try {
+      nativeDb.prepare('ROLLBACK').run();
+    } catch {
+      /* Auto-rolled back by SQLite on most errors. */
+    }
+    throw err;
+  }
+
+  // Write the new blob to disk AFTER the transaction is committed.
+  try {
+    await mkdir(join(newBlobPath, '..'), { recursive: true });
+    await writeFile(newBlobPath, buf);
+  } catch (cause) {
+    return {
+      ok: false,
+      error: {
+        code: 'E_FILE_ERROR',
+        message: `failed to write new blob: ${cause instanceof Error ? cause.message : String(cause)}`,
+      },
+    };
+  }
+
+  // Audit log entry (best-effort).
+  const auditPath = join(projectRoot, DOCS_VERSIONING_AUDIT_FILE);
+  const squashed = writeOrSquashAudit({
+    auditPath,
+    slug,
+    now,
+    revision: {
+      ts: nowIso,
+      previousSha256,
+      sha256: newSha256,
+      changed: true,
+      ...(params.message !== undefined ? { message: params.message } : {}),
+      lifecycleStatus: status,
+      attachedBy,
+    },
+  });
+
+  return {
+    ok: true,
+    result: {
+      slug,
+      type: oldRow.type ?? null,
+      attachmentId: newAttachmentId,
+      previousAttachmentId,
+      sha256: newSha256,
+      previousSha256,
+      changed: true,
+      lifecycleStatus: status,
+      updatedAt: nowIso,
+      version: countVersionsForSlug(projectRoot, slug),
+      squashed,
+    },
+  };
+}
+
+/**
+ * Count how many revisions for `slug` exist in the audit log, plus 1 for
+ * the current row. Returns 2 as a floor for the first update so callers
+ * always see a monotone counter even when the audit file is missing.
+ *
+ * Synchronous (reads a small audit JSONL file) so callers can compose
+ * the value into the LAFS result without an extra await round-trip.
+ *
+ * @internal
+ */
+function countVersionsForSlug(projectRoot: string, slug: string): number {
+  // The attachments table only carries the CURRENT slug-bearing row.
+  // History lives in the audit log; we derive `version` from it so the
+  // counter is meaningful across the entire update sequence.
+  const auditPath = join(projectRoot, DOCS_VERSIONING_AUDIT_FILE);
+  let raw: string;
+  try {
+    raw = readFileSync(auditPath, 'utf-8');
+  } catch {
+    return 2;
+  }
+  let total = 1; // initial create (no audit entry for the original add)
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    let entry: AuditLine;
+    try {
+      entry = JSON.parse(line) as AuditLine;
+    } catch {
+      continue;
+    }
+    if (entry.op !== 'docs.update' || entry.slug !== slug) continue;
+    total += entry.revisions.length;
+  }
+  return total;
+}
+
+/**
+ * Either append a new audit line OR squash this revision onto the most
+ * recent line for the same slug, depending on the 5-minute squash window.
+ *
+ * Returns `true` when the entry was squashed.
+ *
+ * @internal
+ */
+function writeOrSquashAudit(opts: {
+  auditPath: string;
+  slug: string;
+  now: Date;
+  revision: AuditRevision;
+}): boolean {
+  const { auditPath, slug, now, revision } = opts;
+  const candidate = readSquashCandidate(auditPath, slug, now);
+  if (candidate) {
+    const updated: AuditLine = {
+      ...candidate.entry,
+      lastAt: revision.ts,
+      revisions: [...candidate.entry.revisions, revision],
+    };
+    rewriteAuditLine(auditPath, candidate.index, updated);
+    return true;
+  }
+  appendNewAuditLine(auditPath, {
+    op: 'docs.update',
+    slug,
+    firstAt: revision.ts,
+    lastAt: revision.ts,
+    revisions: [revision],
+  });
+  return false;
+}
+
+// `mimeFromPath` is exported for the dispatch layer when the new content
+// arrives via a file path (the layer derives an attachment.name + mime
+// before calling updateDocBySlug). Keeping it in this module avoids a
+// duplicate copy elsewhere.
+export { mimeFromPath as docsUpdateMimeFromPath };

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -168,6 +168,19 @@ export {
   statusDocs,
   syncFromGit,
 } from './docs/docs-ops.js';
+// Docs UPDATE-in-place via slug (T10161 — E12.C4 · Saga T9855)
+export type {
+  DocsUpdateError,
+  DocsUpdateOk,
+  UpdateDocBySlugResult,
+} from './docs/docs-update.js';
+export {
+  DOCS_UPDATE_SQUASH_WINDOW_MS,
+  DOCS_VERSIONING_AUDIT_FILE,
+  docsUpdateMimeFromPath,
+  isLifecycleStatus,
+  updateDocBySlug,
+} from './docs/docs-update.js';
 // Docs export — rich Markdown export of a task with frontmatter + attachments (T947)
 export type { ExportDocumentOptions, ExportDocumentResult } from './docs/export-document.js';
 export { exportDocument } from './docs/export-document.js';


### PR DESCRIPTION
## Summary
- New verb `cleo docs update <slug>` for in-place doc updates (T10161 / Saga T9855 / E12.C4).
- Slug is preserved while bytes rotate underneath: new sha256 row inserted, slug atomically transferred from old → new inside one `BEGIN IMMEDIATE` transaction. Previous row stays reachable by attachment-id for history.
- NO supersession edge (use `cleo docs supersede` for that — T10162).
- Audit-log line per update at `.cleo/audit/docs-versioning.jsonl`; updates within a 5-minute window squash onto the prior line's `revisions[]`.
- Lifecycle status defaults to `'draft'` on every update so explicit `accepted` docs get back-pressured to draft on edit; `--status` overrides.

## Acceptance criteria status
- [x] `cleo docs update <slug> <file>` replaces blob content while preserving slug
- [x] Version history preserved: old row remains reachable by attachment-id (`docs fetch <id>`); audit log carries every revision's sha256
- [x] `lifecycle_status` defaults to `'draft'` on first update; explicit `--status` flag overrides
- [x] Update does NOT create supersession edges — semantically distinct from `cleo docs supersede`
- [x] Minor-edit dogfood: typo fix via `cleo docs update` produces a new sha256 + audit entry, no new file in `publishMirror`
- [x] Audit log entry per update under `.cleo/audit/docs-versioning.jsonl`

## Test plan
- [x] biome check (`--write`) clean
- [x] full monorepo build green (`pnpm run build`)
- [x] vitest: 5 new E2E tests + 5 new dispatch param-validation tests; 34/34 passing
- [x] ADR-057 SSoT enforcement (`lint-contracts-core-ssot.mjs`) — no violations
- [x] `defineCommand` SSoT lint, CLI package-boundary lint, format-error-misuse lint all PASS
- [x] CLI smoke: `cleo docs update --help` renders correctly

Closes T10161
Saga: T9855
ADR: 078