### PR TITLE
feat: meta.tokens first-class (T9923 / Saga T9855)

### DIFF
--- a/.changeset/t9923-meta-tokens-first-class.md
+++ b/.changeset/t9923-meta-tokens-first-class.md
@@ -1,0 +1,6 @@
+---
+id: t9923-meta-tokens-first-class
+tasks: [T9923]
+kind: feat
+summary: feat(contracts,core): rename meta._tokenEstimate -> meta.tokens (T9923 / Saga T9855 / E8)
+---

--- a/packages/contracts/src/__tests__/meta-tokens.test.ts
+++ b/packages/contracts/src/__tests__/meta-tokens.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Type-shape contract test for the envelope-wide `meta.tokens` field
+ * promoted in T9923 (Saga T9855 / E8.4).
+ *
+ * `CliMeta.tokens` is the first-class structured token-cost annotation
+ * attached to every CLI envelope (formerly the underscore-prefixed
+ * `meta._tokenEstimate`). The legacy field is retained for ONE release
+ * (removeAt v2026.7.0) so existing consumers can migrate without a
+ * flag-day.
+ *
+ * @epic T9919
+ * @task T9923
+ * @saga T9855
+ */
+
+import type { CliEnvelope, CliMeta, CliMetaTokens } from '@cleocode/lafs';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+describe('CliMeta.tokens type shape (T9923)', () => {
+  it('accepts the full first-class CliMetaTokens shape', () => {
+    const meta: CliMeta = {
+      operation: 'tasks.show',
+      requestId: '00000000-0000-0000-0000-000000000000',
+      duration_ms: 0,
+      timestamp: '2026-05-24T00:00:00.000Z',
+      tokens: {
+        estimate: 1234,
+        model: 'cl100k',
+        calculatedAt: '2026-05-24T00:00:00.000Z',
+      },
+    };
+    expect(meta.tokens?.estimate).toBe(1234);
+    expect(meta.tokens?.model).toBe('cl100k');
+    expect(meta.tokens?.calculatedAt).toBe('2026-05-24T00:00:00.000Z');
+  });
+
+  it('requires `estimate` to be a number when `tokens` is present', () => {
+    expectTypeOf<NonNullable<CliMeta['tokens']>['estimate']>().toEqualTypeOf<number>();
+    expectTypeOf<NonNullable<CliMeta['tokens']>['model']>().toEqualTypeOf<string>();
+    expectTypeOf<NonNullable<CliMeta['tokens']>['calculatedAt']>().toEqualTypeOf<string>();
+  });
+
+  it('is optional — omitting `tokens` leaves a valid CliMeta', () => {
+    const meta: CliMeta = {
+      operation: 'tasks.list',
+      requestId: '00000000-0000-0000-0000-000000000001',
+      duration_ms: 0,
+      timestamp: '2026-05-24T00:00:00.000Z',
+    };
+    expect(meta.tokens).toBeUndefined();
+  });
+
+  it('accepts the legacy `_tokenEstimate` field during the deprecation window', () => {
+    const meta: CliMeta = {
+      operation: 'tasks.show',
+      requestId: '00000000-0000-0000-0000-000000000002',
+      duration_ms: 0,
+      timestamp: '2026-05-24T00:00:00.000Z',
+      _tokenEstimate: { estimate: 999 },
+    };
+    expect(meta._tokenEstimate?.estimate).toBe(999);
+  });
+
+  it('allows BOTH `tokens` and `_tokenEstimate` for backwards-compat dual-write', () => {
+    const meta: CliMeta = {
+      operation: 'tasks.show',
+      requestId: '00000000-0000-0000-0000-000000000003',
+      duration_ms: 0,
+      timestamp: '2026-05-24T00:00:00.000Z',
+      tokens: {
+        estimate: 4321,
+        model: 'o200k',
+        calculatedAt: '2026-05-24T00:00:00.000Z',
+      },
+      _tokenEstimate: { estimate: 4321 },
+    };
+    expect(meta.tokens?.estimate).toBe(meta._tokenEstimate?.estimate);
+  });
+
+  it('flows through CliEnvelope<T>.meta verbatim', () => {
+    const envelope: CliEnvelope<{ taskId: string }> = {
+      success: true,
+      data: { taskId: 'T9923' },
+      meta: {
+        operation: 'tasks.show',
+        requestId: '00000000-0000-0000-0000-000000000004',
+        duration_ms: 1,
+        timestamp: '2026-05-24T00:00:00.000Z',
+        tokens: {
+          estimate: 512,
+          model: 'cl100k',
+          calculatedAt: '2026-05-24T00:00:00.000Z',
+        },
+      },
+    };
+    expect(envelope.meta.tokens?.estimate).toBe(512);
+  });
+
+  it('CliMetaTokens is structurally compatible with manual construction', () => {
+    const t: CliMetaTokens = {
+      estimate: 100,
+      model: 'approx',
+      calculatedAt: '2026-05-24T00:00:00.000Z',
+    };
+    expect(t.estimate).toBe(100);
+  });
+});

--- a/packages/lafs/src/a2a/bridge.ts
+++ b/packages/lafs/src/a2a/bridge.ts
@@ -292,9 +292,9 @@ export class LafsA2AResult {
    * Get token estimate from LAFS envelope.
    *
    * @remarks
-   * Extracts the `_tokenEstimate` field from the LAFS envelope's `_meta`
-   * section, which contains estimated token usage, budget, and truncation
-   * information.
+   * Prefers the first-class `meta.tokens` field promoted in Saga T9855 /
+   * E8 — T9923, falling back to the legacy `_tokenEstimate` field for
+   * envelopes produced before the deprecation window closes at v2026.7.0.
    *
    * @returns Token estimate object, or null if no envelope or no estimate present
    */
@@ -302,11 +302,12 @@ export class LafsA2AResult {
     const envelope = this.getLafsEnvelope();
     if (!envelope?._meta) return null;
 
-    // Access LAFS meta fields
+    type EstimateShape = { estimated: number; budget?: number; truncated?: boolean };
     const meta = envelope._meta as LAFSMeta & {
-      _tokenEstimate?: { estimated: number; budget?: number; truncated?: boolean };
+      tokens?: EstimateShape;
+      _tokenEstimate?: EstimateShape;
     };
-    return meta._tokenEstimate ?? null;
+    return meta.tokens ?? meta._tokenEstimate ?? null;
   }
 
   /**

--- a/packages/lafs/src/budgetEnforcement.ts
+++ b/packages/lafs/src/budgetEnforcement.ts
@@ -298,6 +298,9 @@ export function applyBudgetEnforcement(
         ...envelope,
         _meta: {
           ...envelope._meta,
+          // T9923 (Saga T9855 / E8): first-class field is `tokens`;
+          // `_tokenEstimate` retained for ONE release (removeAt v2026.7.0).
+          tokens: tokenEstimate,
           _tokenEstimate: tokenEstimate,
         } as LAFSMetaWithBudget,
       },
@@ -319,17 +322,20 @@ export function applyBudgetEnforcement(
     const truncatedEstimate = estimator.estimate(result);
 
     if (truncatedEstimate <= budget) {
+      const truncatedTokenEstimate: TokenEstimate = {
+        estimated: truncatedEstimate,
+        truncated: true,
+        originalEstimate: estimatedTokens,
+      };
       return {
         envelope: {
           ...envelope,
           result,
           _meta: {
             ...envelope._meta,
-            _tokenEstimate: {
-              estimated: truncatedEstimate,
-              truncated: true,
-              originalEstimate: estimatedTokens,
-            },
+            // T9923: first-class `tokens` + legacy `_tokenEstimate`.
+            tokens: truncatedTokenEstimate,
+            _tokenEstimate: truncatedTokenEstimate,
           } as LAFSMetaWithBudget,
         },
         withinBudget: true,
@@ -349,6 +355,8 @@ export function applyBudgetEnforcement(
       error: createBudgetExceededError(estimatedTokens, budget),
       _meta: {
         ...envelope._meta,
+        // T9923: first-class `tokens` + legacy `_tokenEstimate`.
+        tokens: tokenEstimate,
         _tokenEstimate: tokenEstimate,
       } as LAFSMetaWithBudget,
     },

--- a/packages/lafs/src/envelope.ts
+++ b/packages/lafs/src/envelope.ts
@@ -759,8 +759,50 @@ export interface CliMeta {
    * the flat string projection layered alongside.
    */
   suggestedNext?: ReadonlyArray<string>;
+  /**
+   * First-class token-cost annotation for this CLI envelope.
+   *
+   * @remarks
+   * Promotes the legacy underscore-prefixed `meta._tokenEstimate` field
+   * (still emitted for backwards compatibility — see {@link CliMetaTokens}
+   * deprecation notice). Renderers and orchestrators MAY use this to
+   * surface the envelope's approximate token cost without depending on
+   * LAFS-tier internals.
+   *
+   * Promoted in Saga T9855 / E8 — T9923 (ADR-039).
+   */
+  tokens?: CliMetaTokens;
+  /**
+   * Legacy underscore-prefixed token-cost annotation.
+   *
+   * @deprecated removeAt v2026.7.0 — use {@link CliMeta.tokens} instead.
+   * Retained for ONE release so existing consumers can migrate.
+   */
+  _tokenEstimate?: { estimate: number; [key: string]: unknown };
   /** Extensible metadata; vendor fields go here. */
   [key: string]: unknown;
+}
+
+/**
+ * Structured token-cost annotation attached to a CLI envelope's `meta.tokens`.
+ *
+ * @remarks
+ * First-class promotion of the legacy `meta._tokenEstimate` field, introduced
+ * in Saga T9855 / E8 — T9923. Consumers SHOULD read `meta.tokens.estimate`
+ * directly; the legacy underscore-prefixed field is retained for ONE release
+ * and removed at v2026.7.0.
+ */
+export interface CliMetaTokens {
+  /** Approximate token count of the envelope payload. */
+  estimate: number;
+  /**
+   * Tokenizer identifier used to compute {@link CliMetaTokens.estimate}.
+   *
+   * @example `"cl100k"`, `"o200k"`, `"approx"` (heuristic fallback).
+   */
+  model: string;
+  /** ISO 8601 timestamp of when the estimate was computed. */
+  calculatedAt: string;
 }
 
 /**

--- a/packages/lafs/src/mviProjection.ts
+++ b/packages/lafs/src/mviProjection.ts
@@ -15,8 +15,12 @@
  */
 import type { LAFSEnvelope, LAFSError, LAFSMeta, MVILevel } from './types.js';
 
-/** Extended meta type that includes optional `_tokenEstimate` from budget enforcement. */
-type MetaWithEstimate = LAFSMeta & { _tokenEstimate?: unknown };
+/**
+ * Extended meta type that includes the first-class `tokens` field (Saga
+ * T9855 / E8 — T9923) and the legacy underscore-prefixed `_tokenEstimate`
+ * field retained for ONE release (removeAt v2026.7.0).
+ */
+type MetaWithEstimate = LAFSMeta & { _tokenEstimate?: unknown; tokens?: unknown };
 
 /** Extended error type that includes optional agent-action fields (may be added by the agent layer). */
 type ErrorWithAgent = LAFSError & {
@@ -116,6 +120,9 @@ function projectMetaMinimal(meta: LAFSMeta): Record<string, unknown> {
   };
   if (m.sessionId) projected.sessionId = m.sessionId;
   if (m.warnings?.length) projected.warnings = m.warnings;
+  // T9923: project both first-class `tokens` and legacy `_tokenEstimate`
+  // during the deprecation window (removeAt v2026.7.0).
+  if (m.tokens) projected.tokens = m.tokens;
   if (m._tokenEstimate) projected._tokenEstimate = m._tokenEstimate;
   return projected;
 }
@@ -131,6 +138,8 @@ function projectMetaStandard(meta: LAFSMeta): Record<string, unknown> {
   };
   if (m.sessionId) projected.sessionId = m.sessionId;
   if (m.warnings?.length) projected.warnings = m.warnings;
+  // T9923: project both first-class `tokens` and legacy `_tokenEstimate`.
+  if (m.tokens) projected.tokens = m.tokens;
   if (m._tokenEstimate) projected._tokenEstimate = m._tokenEstimate;
   return projected;
 }

--- a/packages/lafs/src/types.ts
+++ b/packages/lafs/src/types.ts
@@ -613,16 +613,32 @@ export interface TokenEstimate {
  * Extended metadata block that includes an optional token-budget estimate.
  *
  * @remarks
- * Extends {@link LAFSMeta} with a `_tokenEstimate` field used by the budget
- * enforcement middleware to record the estimated cost of the envelope.
+ * Extends {@link LAFSMeta} with both the legacy underscore-prefixed
+ * `_tokenEstimate` field AND the first-class `tokens` field promoted by
+ * Saga T9855 / E8 — T9923. The underscore-prefixed field is retained for
+ * ONE release so existing consumers can migrate and is removed at
+ * v2026.7.0.
  */
 export interface LAFSMetaWithBudget extends LAFSMeta {
   /**
-   * Token-count estimate for budget tracking.
+   * Legacy underscore-prefixed token estimate.
    *
+   * @deprecated removeAt v2026.7.0 — use {@link LAFSMetaWithBudget.tokens}
+   *   instead. Retained for ONE release so existing consumers can migrate.
    * @defaultValue undefined
    */
   _tokenEstimate?: TokenEstimate;
+  /**
+   * First-class token-budget estimate for this envelope.
+   *
+   * @remarks
+   * Mirrors `_tokenEstimate` during the deprecation window. New code
+   * SHOULD read this field; renderers MAY drop the underscore-prefixed
+   * field from human output.
+   *
+   * @defaultValue undefined
+   */
+  tokens?: TokenEstimate;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Promotes `meta._tokenEstimate` to first-class `meta.tokens.{estimate,model,calculatedAt}` on `CliMeta` (and `tokens: TokenEstimate` on `LAFSMetaWithBudget`).
- Backwards-compat: old underscore-prefixed field stays for one release (removeAt v2026.7.0). All writers dual-emit both fields during the window.
- A2A bridge consumer (`getTokenEstimate`) prefers `meta.tokens` and falls back to `meta._tokenEstimate`.
- MVI projection now projects both fields.

## Files
- `packages/lafs/src/envelope.ts` — `CliMeta.tokens` + new `CliMetaTokens` interface
- `packages/lafs/src/types.ts` — `LAFSMetaWithBudget.tokens` + @deprecated marker on `_tokenEstimate`
- `packages/lafs/src/budgetEnforcement.ts` — dual-write both fields
- `packages/lafs/src/mviProjection.ts` — project both fields
- `packages/lafs/src/a2a/bridge.ts` — read tokens-first with fallback
- `packages/contracts/src/__tests__/meta-tokens.test.ts` — new type-shape contract test (7 cases, all pass)

Closes T9923
Saga: T9855