### PR TITLE
feat: --output mode flag (T9930 / Saga T9855)

### DIFF
--- a/.changeset/t9930-output-mode-flag.md
+++ b/.changeset/t9930-output-mode-flag.md
@@ -1,0 +1,6 @@
+---
+id: t9930-output-mode-flag
+tasks: [T9930]
+kind: feat
+summary: feat(cleo): --output {envelope|id|table|count|silent} flag (T9930 / Saga T9855 / E9)
+---

--- a/packages/cleo/src/cli/commands/__tests__/output-mode.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/output-mode.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the `--output {envelope|id|table|count|silent}` flag
+ * renderer (T9930 · Saga T9855 · E9.3).
+ *
+ * Exercises {@link renderOutputMode} directly against representative
+ * envelope shapes (single-task add/show, list of tasks, generic
+ * ListResponse, bare id payloads). Subprocess end-to-end coverage is
+ * provided by the stdout-discipline integration suite under
+ * `packages/cleo/__tests__/integration/`.
+ *
+ * @task T9930
+ * @epic T9855
+ */
+
+import { describe, expect, it } from 'vitest';
+import { renderOutputMode } from '../../renderers/output-mode.js';
+
+describe('renderOutputMode — id', () => {
+  it('extracts id from a single-task envelope ({task: {id}})', () => {
+    const out = renderOutputMode('id', { task: { id: 'T9930', title: 'x', priority: 'medium' } });
+    expect(out.text).toBe('T9930');
+  });
+
+  it('extracts ids from a list envelope ({tasks: [...]})', () => {
+    const out = renderOutputMode('id', {
+      tasks: [
+        { id: 'T1', title: 'a' },
+        { id: 'T2', title: 'b' },
+        { id: 'T3', title: 'c' },
+      ],
+      total: 3,
+    });
+    expect(out.text).toBe('T1\nT2\nT3');
+  });
+
+  it('extracts ids from a generic ListResponse ({items: [...]})', () => {
+    const out = renderOutputMode('id', {
+      items: [{ id: 'A1' }, { id: 'A2' }],
+    });
+    expect(out.text).toBe('A1\nA2');
+  });
+
+  it('falls back to bare {id: ...}', () => {
+    const out = renderOutputMode('id', { id: 'S-42' });
+    expect(out.text).toBe('S-42');
+  });
+
+  it('returns empty text for an unrecognised shape', () => {
+    const out = renderOutputMode('id', { value: 7, foo: 'bar' });
+    expect(out.text).toBe('');
+  });
+
+  it('skips list entries that lack an id', () => {
+    const out = renderOutputMode('id', {
+      tasks: [{ id: 'T1' }, { title: 'no-id' }, { id: 'T3' }],
+    });
+    expect(out.text).toBe('T1\nT3');
+  });
+});
+
+describe('renderOutputMode — count', () => {
+  it('honours explicit `total` over array length', () => {
+    const out = renderOutputMode('count', {
+      tasks: [{ id: 'T1' }, { id: 'T2' }],
+      total: 17,
+    });
+    expect(out.text).toBe('17');
+  });
+
+  it('falls back to tasks.length when total is missing', () => {
+    const out = renderOutputMode('count', {
+      tasks: [{ id: 'T1' }, { id: 'T2' }, { id: 'T3' }],
+    });
+    expect(out.text).toBe('3');
+  });
+
+  it('counts items[] when no tasks key is present', () => {
+    const out = renderOutputMode('count', { items: [{ id: 'A' }, { id: 'B' }] });
+    expect(out.text).toBe('2');
+  });
+
+  it('reports 1 for a single-task envelope', () => {
+    const out = renderOutputMode('count', { task: { id: 'X' } });
+    expect(out.text).toBe('1');
+  });
+
+  it('reports 0 for an unrecognised shape', () => {
+    const out = renderOutputMode('count', { foo: 'bar' });
+    expect(out.text).toBe('0');
+  });
+});
+
+describe('renderOutputMode — table', () => {
+  it('renders a list of tasks as id/status/priority/title columns', () => {
+    const out = renderOutputMode('table', {
+      tasks: [
+        { id: 'T1', status: 'pending', priority: 'high', title: 'Short title' },
+        { id: 'T2', status: 'in_progress', priority: 'medium', title: 'Another' },
+      ],
+    });
+    const text = out.text ?? '';
+    expect(text).toContain('id');
+    expect(text).toContain('status');
+    expect(text).toContain('priority');
+    expect(text).toContain('title');
+    expect(text).toContain('T1');
+    expect(text).toContain('pending');
+    expect(text).toContain('high');
+    expect(text).toContain('Short title');
+    expect(text).toContain('T2');
+    expect(text).toContain('in_progress');
+  });
+
+  it('truncates titles longer than 60 chars with an ellipsis', () => {
+    const longTitle = 'a'.repeat(80);
+    const out = renderOutputMode('table', {
+      tasks: [{ id: 'T1', status: 'pending', priority: 'high', title: longTitle }],
+    });
+    const text = out.text ?? '';
+    // Truncated form ends with ellipsis; the raw 80-char string MUST NOT
+    // appear (otherwise the truncation cap is broken).
+    expect(text).not.toContain(longTitle);
+    expect(text).toContain('…');
+  });
+
+  it('falls back to a generic field/value table for non-list payloads', () => {
+    const out = renderOutputMode('table', { sessionId: 'sess-1', activeTask: 'T9930' });
+    const text = out.text ?? '';
+    expect(text).toContain('field');
+    expect(text).toContain('value');
+    expect(text).toContain('sessionId');
+    expect(text).toContain('sess-1');
+    expect(text).toContain('activeTask');
+    expect(text).toContain('T9930');
+  });
+
+  it('returns "No rows." for an empty list', () => {
+    const out = renderOutputMode('table', { tasks: [] });
+    expect(out.text).toBe('No rows.');
+  });
+});
+
+describe('renderOutputMode — silent', () => {
+  it('returns null text (caller must NOT write to stdout)', () => {
+    const out = renderOutputMode('silent', {
+      tasks: [{ id: 'T1' }, { id: 'T2' }],
+      total: 2,
+    });
+    expect(out.text).toBeNull();
+  });
+
+  it('returns null even for a single-record envelope', () => {
+    const out = renderOutputMode('silent', { task: { id: 'X' } });
+    expect(out.text).toBeNull();
+  });
+});
+
+describe('renderOutputMode — envelope', () => {
+  it('throws — envelope mode must be handled by the caller', () => {
+    expect(() => renderOutputMode('envelope', { task: { id: 'T1' } })).toThrow(
+      /envelope mode must be handled by caller/,
+    );
+  });
+});

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -45,7 +44,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description:
+      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,8 +63,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +84,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,26 +102,31 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description:
+      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () =>
+      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -141,7 +149,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -231,7 +240,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description:
+      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -250,7 +260,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -273,14 +284,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -304,7 +317,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -315,7 +329,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -328,19 +343,24 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
+    description:
+      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () =>
+      (await import('../commands/doctor-legacy-backups.js'))
+        .doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -376,7 +396,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -399,7 +420,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description:
+      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -430,7 +452,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -453,14 +476,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -489,7 +515,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -531,14 +558,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -567,7 +597,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -579,13 +610,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -628,7 +661,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -639,7 +673,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -675,7 +710,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description:
+      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -687,7 +723,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -699,7 +736,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -747,13 +785,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
+    description:
+      'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -825,7 +865,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'templatesCommand',
     name: 'templates',
-    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    description:
+      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
     load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
   },
   {
@@ -837,7 +878,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -849,13 +891,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description:
+      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/index.ts
+++ b/packages/cleo/src/cli/index.ts
@@ -57,6 +57,7 @@ import { lazyCommand } from './lazy-command.js';
 import { didYouMean } from './lib/did-you-mean.js';
 import { maybePromptFirstRun } from './lib/first-run-detection.js';
 import { resolveFormat } from './middleware/output-format.js';
+import { isOutputMode, type OutputMode, setOutputMode } from './output-context.js';
 import { setProjectionOptOut } from './projection-context.js';
 import { resolveSubCommandForHelp } from './resolve-subcommand.js';
 
@@ -131,6 +132,7 @@ async function startCli(): Promise<void> {
   // Parse global format + field flags from argv.
   const rawOpts: Record<string, unknown> = {};
   let verboseFlag = false;
+  let outputModeRaw: string | undefined;
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--json') rawOpts['json'] = true;
@@ -141,6 +143,8 @@ async function startCli(): Promise<void> {
     else if (arg === '--mvi' && i + 1 < argv.length) rawOpts['mvi'] = argv[++i];
     // T9922: MVI record projection opt-out. --full is an alias for --verbose.
     else if (arg === '--verbose' || arg === '--full') verboseFlag = true;
+    // T9930 — global --output {envelope|id|table|count|silent} flag.
+    else if (arg === '--output' && i + 1 < argv.length) outputModeRaw = argv[++i];
   }
 
   const formatResolution = resolveFormat(rawOpts);
@@ -158,6 +162,20 @@ async function startCli(): Promise<void> {
   // full record". --human also opts out because the human renderer needs every
   // field. JSON/agent paths (the common case) stay on MVI projection.
   setProjectionOptOut(verboseFlag || formatResolution.format === 'human');
+
+  // T9930 — resolve & validate --output BEFORE dispatch. Rejecting an unknown
+  // mode here gives the operator/agent a deterministic stderr error with a
+  // valid-modes list instead of silently falling through to the default.
+  if (outputModeRaw !== undefined) {
+    if (!isOutputMode(outputModeRaw)) {
+      process.stderr.write(
+        `Error: invalid --output mode "${outputModeRaw}"\n` +
+          `Valid modes: envelope, id, table, count, silent\n`,
+      );
+      process.exit(2);
+    }
+    setOutputMode(outputModeRaw as OutputMode);
+  }
 
   // ---------------------------------------------------------------------------
   // Fast-path for help / version / no-args invocations.

--- a/packages/cleo/src/cli/output-context.ts
+++ b/packages/cleo/src/cli/output-context.ts
@@ -1,0 +1,63 @@
+/**
+ * CLI output-mode resolution context.
+ *
+ * Singleton that holds the resolved `--output <mode>` selection for the
+ * current CLI invocation. Set once in the global flag parser in
+ * `cli/index.ts`; read by `cliOutput()` in `renderers/index.ts` to switch
+ * the render path AFTER dispatch has produced the canonical envelope.
+ *
+ * Mirrors the format-context.ts / field-context.ts pattern.
+ *
+ * Modes
+ * -----
+ * - `envelope` (default) — emit the canonical LAFS envelope JSON.
+ * - `id` — for mutate ops, print just the created/updated id (one per line).
+ *          For list ops, print one id per line.
+ * - `table` — render data as an ASCII table on stdout. List → grouped
+ *             id/status/priority/title columns. Other shapes fall back to
+ *             a generic key-value flatten.
+ * - `count` — print just the row count (single number).
+ * - `silent` — suppress stdout on success; on failure still emit a 1-line
+ *              error to stderr.
+ *
+ * Precedence with `--field` (T9929)
+ * ---------------------------------
+ * `--field` (single-field plain-text extraction) WINS when both flags are
+ * specified. The `--output` mode applies to the canonical envelope shape;
+ * `--field` short-circuits to a scalar projection before mode dispatch.
+ *
+ * @task T9930
+ * @epic T9855
+ */
+
+/** All valid `--output` modes. The literal union backs the {@link OutputMode} type. */
+export const OUTPUT_MODES = ['envelope', 'id', 'table', 'count', 'silent'] as const;
+
+/** Resolved `--output` mode for the current CLI invocation. */
+export type OutputMode = (typeof OUTPUT_MODES)[number];
+
+/** Current mode. Defaults to `'envelope'` (the canonical LAFS payload). */
+let currentMode: OutputMode = 'envelope';
+
+/**
+ * Set the resolved output mode for this CLI invocation.
+ * Called once from the global flag parser in `cli/index.ts`.
+ */
+export function setOutputMode(mode: OutputMode): void {
+  currentMode = mode;
+}
+
+/** Get the current resolved output mode. */
+export function getOutputMode(): OutputMode {
+  return currentMode;
+}
+
+/**
+ * Type guard: confirm a raw string corresponds to a valid {@link OutputMode}.
+ *
+ * Used by the global flag parser to reject `--output bogus` at startup
+ * BEFORE dispatch runs.
+ */
+export function isOutputMode(value: string): value is OutputMode {
+  return (OUTPUT_MODES as readonly string[]).includes(value);
+}

--- a/packages/cleo/src/cli/renderers/index.ts
+++ b/packages/cleo/src/cli/renderers/index.ts
@@ -103,8 +103,10 @@ import { applyFieldFilter, extractFieldFromResult } from '@cleocode/lafs';
 import type { DispatchResponseMeta } from '../../dispatch/types.js';
 import { getFieldContext } from '../field-context.js';
 import { getFormatContext } from '../format-context.js';
+import { getOutputMode } from '../output-context.js';
 import { emitLafsViolation, LafsViolationError, validateLafsShape } from './lafs-validator.js';
 import { normalizeForHuman } from './normalizer.js';
+import { renderOutputMode } from './output-mode.js';
 
 export type { RenderWavesMode, RenderWavesOptions } from '@cleocode/core';
 export { renderWaves };
@@ -332,6 +334,20 @@ export interface CliOutputOptions {
 export function cliOutput(data: unknown, opts: CliOutputOptions): void {
   const ctx = getFormatContext();
   const fieldCtx = getFieldContext();
+  const outputMode = getOutputMode();
+
+  // T9930 — --output {id|table|count|silent} re-renders the canonical envelope
+  // payload into the alternative shape the caller asked for. `--field` (T9929)
+  // takes precedence: when both are set, the field extraction below runs first
+  // and short-circuits to a scalar projection, never reaching this switch.
+  // `envelope` mode (default) falls through to the existing human/JSON paths.
+  if (outputMode !== 'envelope' && !fieldCtx.field) {
+    const out = renderOutputMode(outputMode, data);
+    if (out.text !== null && out.text.length > 0) {
+      process.stdout.write(out.text + '\n');
+    }
+    return;
+  }
 
   // T9929 (Saga T9855 / E9) — RFC 6901 JSON Pointer extraction.
   //
@@ -637,6 +653,15 @@ export function cliError(
   meta?: Partial<CliMeta>,
 ): void {
   const ctx = getFormatContext();
+  const outputMode = getOutputMode();
+
+  // T9930 — --output silent suppresses success stdout but failures still need
+  // a 1-line operator-visible signal on stderr. Skip the LAFS envelope (which
+  // would normally go to stdout) so the silent contract is preserved.
+  if (outputMode === 'silent') {
+    process.stderr.write(`Error: ${message}${code ? ` (${code})` : ''}\n`);
+    return;
+  }
 
   if (ctx.format === 'human') {
     process.stderr.write(`Error: ${message}${code ? ` (${code})` : ''}\n`);

--- a/packages/cleo/src/cli/renderers/output-mode.ts
+++ b/packages/cleo/src/cli/renderers/output-mode.ts
@@ -1,0 +1,255 @@
+/**
+ * Output-mode renderer for the `--output {envelope|id|table|count|silent}`
+ * flag (T9930 · Saga T9855 · E9.3).
+ *
+ * Dispatch produces ONE canonical envelope; this module RE-RENDERS that
+ * envelope into the alternative shape the operator/agent asked for. The
+ * `envelope` mode is the default and is handled inline by `cliOutput`.
+ *
+ * Coexistence with sibling flags
+ * ------------------------------
+ * - `--field` (T9929) — single-field plain-text projection. WINS when
+ *   both `--field` and `--output` are passed (`--field` short-circuits
+ *   to a scalar before `cliOutput` reaches this module). See the
+ *   precedence note in `output-context.ts`.
+ * - `--quiet` — affects the envelope/JSON path only. The id/table/count
+ *   modes have their own minimal shape so `--quiet` is redundant.
+ *
+ * @task T9930
+ * @epic T9855
+ */
+
+import type { OutputMode } from '../output-context.js';
+
+/**
+ * Heuristic id extraction across the family of envelope shapes the
+ * dispatch surface produces.
+ *
+ * Walked in order:
+ *   1. `data.task.id` — single-task mutate ops (`add`, `update`, ...).
+ *   2. `data.tasks[].id` — list / find responses.
+ *   3. `data.items[].id` — generic ListResponse from the SDK.
+ *   4. `data.id` — bare id payloads (e.g. `cleo session start`).
+ *
+ * @returns id strings in the same order they appeared in the envelope.
+ *          Empty array when no id can be located.
+ */
+function extractIds(data: unknown): string[] {
+  if (data === null || typeof data !== 'object') return [];
+  const rec = data as Record<string, unknown>;
+
+  // 1. Single nested task ({task: {id, ...}})
+  const task = rec['task'];
+  if (task && typeof task === 'object') {
+    const id = (task as Record<string, unknown>)['id'];
+    if (typeof id === 'string') return [id];
+  }
+
+  // 2. List of tasks ({tasks: [...]})
+  const tasks = rec['tasks'];
+  if (Array.isArray(tasks)) {
+    return tasks
+      .map((t) => (t && typeof t === 'object' ? (t as Record<string, unknown>)['id'] : undefined))
+      .filter((id): id is string => typeof id === 'string');
+  }
+
+  // 3. Generic SDK ListResponse ({items: [...]})
+  const items = rec['items'];
+  if (Array.isArray(items)) {
+    return items
+      .map((t) => (t && typeof t === 'object' ? (t as Record<string, unknown>)['id'] : undefined))
+      .filter((id): id is string => typeof id === 'string');
+  }
+
+  // 4. Bare id
+  const id = rec['id'];
+  if (typeof id === 'string') return [id];
+
+  return [];
+}
+
+/**
+ * Pick the row count from a dispatch envelope.
+ *
+ * Honours the explicit `total` field when present (which can exceed
+ * `tasks.length` after server-side pagination), otherwise falls back to
+ * the length of whatever array surface the payload exposes.
+ *
+ * @returns `0` when the data shape carries neither a counted collection
+ *          nor a recognisable total field.
+ */
+function extractCount(data: unknown): number {
+  if (data === null || typeof data !== 'object') return 0;
+  const rec = data as Record<string, unknown>;
+
+  const total = rec['total'];
+  if (typeof total === 'number' && Number.isFinite(total)) return total;
+
+  const tasks = rec['tasks'];
+  if (Array.isArray(tasks)) return tasks.length;
+
+  const items = rec['items'];
+  if (Array.isArray(items)) return items.length;
+
+  // Single-record envelopes (`{task: {...}}`) count as 1.
+  if (rec['task'] && typeof rec['task'] === 'object') return 1;
+  if (typeof rec['id'] === 'string') return 1;
+
+  return 0;
+}
+
+/**
+ * Truncate a cell value to `max` chars, appending `…` when shortened.
+ *
+ * Operates on the JS character (UTF-16 code unit) length — sufficient for
+ * the ASCII / BMP titles CLEO emits.
+ */
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return value.slice(0, Math.max(0, max - 1)) + '…';
+}
+
+/**
+ * Render a list-shaped payload as a fixed-width ASCII table.
+ *
+ * Columns: `id`, `status`, `priority`, `title` (truncated to 60 chars).
+ * Each column is sized to the widest cell up to the title cap so the
+ * output remains scannable in a 132-col terminal.
+ */
+function renderTableList(tasks: Array<Record<string, unknown>>): string {
+  if (tasks.length === 0) return 'No rows.';
+
+  const COL_TITLE_MAX = 60;
+  const rows = tasks.map((t) => ({
+    id: typeof t['id'] === 'string' ? t['id'] : '',
+    status: typeof t['status'] === 'string' ? t['status'] : '',
+    priority: typeof t['priority'] === 'string' ? t['priority'] : '',
+    title: truncate(typeof t['title'] === 'string' ? t['title'] : '', COL_TITLE_MAX),
+  }));
+
+  const widths = {
+    id: Math.max(2, ...rows.map((r) => r.id.length)),
+    status: Math.max(6, ...rows.map((r) => r.status.length)),
+    priority: Math.max(8, ...rows.map((r) => r.priority.length)),
+    title: Math.max(5, ...rows.map((r) => r.title.length)),
+  };
+
+  const pad = (s: string, w: number) => s + ' '.repeat(Math.max(0, w - s.length));
+
+  const header = `${pad('id', widths.id)}  ${pad('status', widths.status)}  ${pad(
+    'priority',
+    widths.priority,
+  )}  ${pad('title', widths.title)}`;
+  const sep = `${'-'.repeat(widths.id)}  ${'-'.repeat(widths.status)}  ${'-'.repeat(
+    widths.priority,
+  )}  ${'-'.repeat(widths.title)}`;
+  const body = rows
+    .map(
+      (r) =>
+        `${pad(r.id, widths.id)}  ${pad(r.status, widths.status)}  ${pad(
+          r.priority,
+          widths.priority,
+        )}  ${pad(r.title, widths.title)}`,
+    )
+    .join('\n');
+
+  return `${header}\n${sep}\n${body}`;
+}
+
+/**
+ * Generic table fallback for non-list payloads.
+ *
+ * Flattens the top-level object into a two-column `field | value` table.
+ * Nested objects/arrays are JSON-stringified so the output stays
+ * single-line per row.
+ */
+function renderTableGeneric(data: Record<string, unknown>): string {
+  const entries = Object.entries(data);
+  if (entries.length === 0) return '(empty)';
+
+  const rows = entries.map(([k, v]) => ({
+    field: k,
+    value:
+      v === null || v === undefined ? '' : typeof v === 'object' ? JSON.stringify(v) : String(v),
+  }));
+
+  const VAL_MAX = 80;
+  for (const r of rows) r.value = truncate(r.value, VAL_MAX);
+
+  const widths = {
+    field: Math.max(5, ...rows.map((r) => r.field.length)),
+    value: Math.max(5, ...rows.map((r) => r.value.length)),
+  };
+  const pad = (s: string, w: number) => s + ' '.repeat(Math.max(0, w - s.length));
+
+  const header = `${pad('field', widths.field)}  ${pad('value', widths.value)}`;
+  const sep = `${'-'.repeat(widths.field)}  ${'-'.repeat(widths.value)}`;
+  const body = rows
+    .map((r) => `${pad(r.field, widths.field)}  ${pad(r.value, widths.value)}`)
+    .join('\n');
+
+  return `${header}\n${sep}\n${body}`;
+}
+
+/**
+ * Result of {@link renderOutputMode}.
+ *
+ * `text` is the bytes the caller should write to stdout — `null` means
+ * the mode requested silence and stdout MUST be left untouched.
+ */
+export interface OutputModeResult {
+  /** Bytes to write to stdout (no trailing newline added by the renderer). */
+  text: string | null;
+}
+
+/**
+ * Re-render a successful dispatch envelope's `data` payload into the
+ * shape requested by the `--output` flag.
+ *
+ * @param mode - the resolved mode from `getOutputMode()`. Caller MUST
+ *               short-circuit when mode is `'envelope'` — this function
+ *               only handles the four alternative modes.
+ * @param data - the `DispatchResponse.data` payload (post field-filter).
+ *
+ * @example
+ * ```ts
+ * if (mode !== 'envelope') {
+ *   const out = renderOutputMode(mode, response.data);
+ *   if (out.text !== null) process.stdout.write(out.text + '\n');
+ *   return;
+ * }
+ * ```
+ */
+export function renderOutputMode(mode: OutputMode, data: unknown): OutputModeResult {
+  switch (mode) {
+    case 'id': {
+      const ids = extractIds(data);
+      return { text: ids.length === 0 ? '' : ids.join('\n') };
+    }
+    case 'count': {
+      return { text: String(extractCount(data)) };
+    }
+    case 'table': {
+      if (data && typeof data === 'object') {
+        const rec = data as Record<string, unknown>;
+        const tasks = rec['tasks'];
+        if (Array.isArray(tasks)) {
+          return { text: renderTableList(tasks as Array<Record<string, unknown>>) };
+        }
+        const items = rec['items'];
+        if (Array.isArray(items)) {
+          return { text: renderTableList(items as Array<Record<string, unknown>>) };
+        }
+        return { text: renderTableGeneric(rec) };
+      }
+      return { text: data === null || data === undefined ? '(empty)' : String(data) };
+    }
+    case 'silent': {
+      return { text: null };
+    }
+    case 'envelope':
+      // Caller is responsible for short-circuiting envelope mode — emitting
+      // here would double-render. Throwing keeps the contract explicit.
+      throw new Error('renderOutputMode: envelope mode must be handled by caller');
+  }
+}

--- a/scripts/.lint-stdout-write-allowlist-baseline.json
+++ b/scripts/.lint-stdout-write-allowlist-baseline.json
@@ -66,11 +66,11 @@
     "packages/cleo/src/cli/commands/snapshot.ts:42",
     "packages/cleo/src/cli/commands/status.ts:289",
     "packages/cleo/src/cli/commands/worktree.ts:274",
-    "packages/cleo/src/cli/index.ts:330",
+    "packages/cleo/src/cli/index.ts:348",
     "packages/mcp-adapter/src/server.ts:127",
     "packages/mcp-adapter/src/server.ts:133",
     "packages/mcp-adapter/src/server.ts:137",
     "packages/nexus/src/__tests__/bench-nexus.ts:389"
   ],
-  "updatedAt": "2026-05-24T11:24:03.061Z"
+  "updatedAt": "2026-05-24T12:03:31.616Z"
 }


### PR DESCRIPTION
## Summary
- Adds global `--output {envelope|id|table|count|silent}` flag.
- 5 modes: `envelope` (default LAFS JSON), `id` (one id per line for list ops; created id for mutates), `table` (ASCII id/status/priority/title, title cap 60 chars), `count` (just the row count), `silent` (success → no stdout; failure → 1-line stderr).
- Mode is parsed in the global flag parser in `cli/index.ts`, stored in a new `output-context.ts` singleton, then re-rendered in `cliOutput` AFTER dispatch produces the canonical envelope. Dispatch path is untouched.
- `--field` (T9929) wins when both flags are passed — documented in `output-context.ts`.
- Invalid modes are rejected at startup with exit 2 and a valid-modes hint on stderr.

## Test plan
- [x] In-process unit tests for `renderOutputMode` cover id / count / table / silent across single-task / list / generic ListResponse / bare id shapes.
- [x] End-to-end CLI smoke against built `dist/cli/index.js` against an isolated `CLEO_PROJECT_ROOT` confirms each mode produces the expected stdout shape on `cleo list`, `cleo add`, and an error path.
- [x] `pnpm biome check --write packages/` clean.
- [x] `pnpm run build` clean.
- [x] `node scripts/lint-format-error-misuse.mjs` clean.
- [x] `node scripts/lint-cli-package-boundary.mjs --check` PASS.
- [x] `node scripts/lint-stdout-discipline.mjs` OK at baseline (63 / 63 — no new violations).

Closes T9930
Saga: T9855