### PR TITLE
docs(adr): T9925 ADR-039 amendment + LAFS conformance (closes Epic T9919)

### DIFF
--- a/.changeset/T10319.md
+++ b/.changeset/T10319.md
@@ -1,0 +1,8 @@
+---
+id: T10319
+tasks: [T10319]
+kind: feat
+summary: cleo backup verify — per-DB freshness + integrity walker
+---
+
+Introduces `cleo backup verify` — a read-only CLI verb that walks every entry in `DB_INVENTORY` (`@cleocode/contracts`) and reports, for each role, the freshest snapshot in BOTH the canonical backup directory (`.cleo/backups/sqlite/` per T10315) and the legacy backup directory (`.cleo/backups/snapshot/`, kept read-only for one deprecation window). Each freshest snapshot is opened via the canonical chokepoint (`openCleoDbSnapshot`) and verified with `PRAGMA integrity_check`, bounded by a per-DB timeout (default 30 000ms, overridable via `--per-db-timeout-ms`). The structured envelope keys per-role reports under `data.dbs[role]` with `freshSnapshot`, `legacySnapshot`, `dataLossEstimateHours`, and a `verdict` (`healthy` | `stale` | `corrupt` | `missing`); aggregate counters land in `data.summary`. The verb exits non-zero (`ExitCode.GENERAL_ERROR`) when ANY DB is more than 24h since its last snapshot OR fails integrity, so operators can wire the command into CI gates. Core SDK helper `runBackupVerify` lives at `packages/core/src/store/backup-verify.ts`; CLI shell is a thin citty wrapper registered via the canonical `define-cli-command` factory. Saga: T10281; Epic: T10284.

--- a/.changeset/t9925-adr-039-amendment.md
+++ b/.changeset/t9925-adr-039-amendment.md
@@ -1,0 +1,6 @@
+---
+id: t9925-adr-039-amendment
+tasks: [T9925]
+kind: docs
+summary: ADR-039 amendment for E8 envelope fields + LAFS conformance updates (closes Epic T9919 / Saga T9855)
+---

--- a/.cleo/adrs/ADR-039-lafs-envelope-unification.md
+++ b/.cleo/adrs/ADR-039-lafs-envelope-unification.md
@@ -119,9 +119,13 @@ Cherry-picked from Wave 4 commits in the T335 epic. Wave 4 finisher (T338) close
 envelope-wide LLM next-action hint: a flat array of copy-pasteable CLI
 commands the agent may run next as the natural chained-reasoning step.
 
+**Canonical shape.** `ReadonlyArray<string>` — a flat, ordered list of
+self-contained, copy-pasteable command strings (e.g. `"cleo focus T1234"`,
+`"cleo verify T1234 --gate implemented"`). The `Readonly` modifier is part
+of the contract: producers MUST NOT mutate the array after attaching it.
+
 **Semantic.** Each entry MUST be a self-contained, copy-pasteable command
-string (e.g. `"cleo focus T1234"`, `"cleo verify T1234 --gate implemented"`).
-The list is ordered by relevance — earliest entry is the most likely
+string. The list is ordered by relevance — earliest entry is the most likely
 follow-up. An empty array means "no follow-up suggested"; absent means
 "the producer did not consider follow-ups". Renderers MUST omit the field
 from human output when the array is empty.
@@ -129,8 +133,8 @@ from human output when the array is empty.
 **Backward compatibility.** The pre-T9920 nexus-only structured form lives
 on at `meta._nexus.suggestedNext: ReadonlyArray<SuggestedNextOp>` (see
 `packages/contracts/src/operations/nexus-scope.ts`). The nexus decorator
-will additionally project a flat string form onto `meta.suggestedNext`
-under follow-on task T9921. Existing structured-shape consumers continue
+additionally projects a flat string form onto `meta.suggestedNext` under
+follow-on task T9921. Existing structured-shape consumers continue
 to function unchanged — this amendment **adds** the envelope-wide field
 without altering the nexus-internal one.
 
@@ -141,8 +145,132 @@ SHOULD use the helper
 `@cleocode/core`) to add the field. The helper deep-clones `envelope.meta`
 so the input envelope is never mutated.
 
-Follow-ons: T9921 (auto-populate on mutate ops), T9925 (LAFS conformance
-test asserts shape across every operation).
+---
+
+## Amendment — T9923 (Saga T9855 / E8.4, 2026-05-24)
+
+`CliMeta` is extended with an optional first-class
+`tokens?: CliMetaTokens` field. This promotes the legacy underscore-prefixed
+`meta._tokenEstimate` field into a stable, structured token-cost annotation
+that renderers and orchestrators MAY use without depending on LAFS-tier
+internals.
+
+**Canonical shape.**
+
+```ts
+export interface CliMetaTokens {
+  /** Approximate token count of the envelope payload. */
+  estimate: number;
+  /**
+   * Tokenizer identifier used to compute the estimate.
+   * @example "cl100k", "o200k", "approx" (heuristic fallback).
+   */
+  model: string;
+  /** ISO 8601 timestamp of when the estimate was computed. */
+  calculatedAt: string;
+}
+```
+
+All three fields are REQUIRED when `meta.tokens` is present. A partial object
+(e.g. `{ estimate: 42 }` without `model` and `calculatedAt`) is INVALID and
+MUST be rejected by conformance checks.
+
+**Backward compatibility.** The legacy `meta._tokenEstimate?: { estimate:
+number; [key: string]: unknown }` is retained for ONE release and removed
+at `v2026.7.0`. During the deprecation overlap window, an envelope MAY carry
+BOTH `meta.tokens` (canonical) AND `meta._tokenEstimate` (legacy mirror) —
+conformance MUST accept this configuration. Consumers SHOULD read
+`meta.tokens.estimate` and ignore `_tokenEstimate` when both are present.
+
+**Producer guidance.** Producers SHOULD set both `meta.tokens` and the
+legacy `meta._tokenEstimate` until v2026.7.0, then drop the legacy mirror.
+See `packages/lafs/src/envelope.ts` for the canonical type definitions.
+
+---
+
+## Amendment — T9922 (Saga T9855 / E8.3, 2026-05-24)
+
+Read operations now default to **MVI (Minimum Viable Information)**
+projection: the dispatch middleware trims response payloads down to the
+essential fields declared in `PROJECTION_PLANS`. Agents pay a fraction of
+the token cost they paid before for routine read calls.
+
+**Canonical shape.** `CliMeta` is extended with an optional
+`projection?: 'mvi' | 'full'` discriminator stamped by the
+`createMviRecordProjection()` middleware (see
+`packages/cleo/src/dispatch/middleware/mvi-record-projection.ts`).
+
+**Semantics.**
+
+- `projection: 'mvi'` — payload was trimmed per the operation's projection
+  plan. This is the **default** for any read op with a registered plan in
+  `PROJECTION_PLANS`.
+- `projection: 'full'` — payload is the full domain record; opt-out was
+  requested by the caller.
+- Absent — operation does not participate in MVI projection (the
+  middleware did not act on the response).
+
+**Opt-out flags.** The CLI surfaces three equivalent opt-out flags that
+all resolve to `_projection: 'full'`:
+
+- `--verbose` — canonical opt-out flag
+- `--full` — alias for `--verbose`
+- `--human` — implicit opt-out (humans always get the full record)
+
+The flag is read once per request via `getProjectionOptOut()` from the
+CLI projection context. Internal callers MAY also set
+`req.params._projection = 'full' | 'mvi'` directly for per-request override.
+
+**Backward compatibility.** Existing tooling that depends on full-record
+responses MUST add `--verbose` (or `--full` / `--human`) to its dispatch
+call. The middleware is **default-on** for read ops with a registered
+projection plan; mutate ops are unaffected.
+
+---
+
+## Amendment — T9924 (Saga T9855 / E8.5, 2026-05-24) — writer-allowlist principle
+
+Renderer SSoT and stdout-write allowlist enforcement.
+
+**Principle.** Every byte written to `process.stdout` from a CLEO CLI
+command MUST flow through the canonical renderer SSoT at
+`packages/core/src/render/`. Direct `process.stdout.write()` and bare
+`console.log()` calls outside the allowlist are anti-patterns: they bypass
+the canonical CLI envelope shape (ADR-039), the MVI projection middleware
+(T9922), and the human-render contract (ADR-077).
+
+**Enforcement.** CI gate
+`scripts/lint-stdout-write-allowlist.mjs` (job: `Stdout Write Allowlist`)
+maintains a baseline of legacy write sites and fails when net-new
+violations are added. The companion gate
+`scripts/lint-stdout-discipline.mjs` covers `console.log`/`console.error`
+discipline (75-site baseline locked by T10114).
+
+**Renderer location.** The canonical renderer-pipeline registry lives at
+`packages/core/src/render/` (relocated from
+`packages/cleo/src/cli/renderers/` by T10114 E11-HUMAN-RENDER-CONTRACT,
+v2026.5.108). New renderers register against
+`renderEnvelopeForHuman()` keyed on `(command, kind)`.
+
+---
+
+## Cross-reference — E7 / T9914 OperationInputContract
+
+These E8 envelope amendments form the **output half** of the
+input/output symmetry mandated by Epic T9914
+(E-OPERATION-INPUT-CONTRACT, ADR-049 amendment). The OperationInputContract
+defines a stable, contract-enforced shape for the **input** side of
+every operation; the E8 amendments (T9920 / T9923 / T9922 / T9924) define
+the matching stable shape for the **output** side:
+
+| Side    | Contract                              | Source of truth                                              |
+|---------|---------------------------------------|--------------------------------------------------------------|
+| Input   | `OperationInputContract<TArgs>` (T9914) | `packages/contracts/src/operations/`                       |
+| Output  | `CliEnvelope<T>` with extended `CliMeta` | `packages/lafs/src/envelope.ts`                            |
+
+Together they guarantee that an agent inspecting any operation can
+predict both the input it must construct and the output shape it will
+receive — no per-operation branching, no shape detection.
 
 ---
 
@@ -151,8 +279,19 @@ test asserts shape across every operation).
 - T335 — LAFS Envelope Remediation epic
 - T338 — FIX-3: Wave 4 finisher
 - T9920 (Saga T9855 / E8.1) — envelope-wide `meta.suggestedNext` promotion
-- `packages/lafs/src/envelope.ts` — canonical `CliEnvelope`, `CliMeta`, `CliEnvelopeError` types
+- T9921 (Saga T9855 / E8.2) — nexus decorator auto-populates `meta.suggestedNext`
+- T9922 (Saga T9855 / E8.3) — MVI record projection default + opt-out flags
+- T9923 (Saga T9855 / E8.4) — `meta.tokens` first-class token-cost annotation
+- T9924 (Saga T9855 / E8.5) — stdout-write allowlist + renderer SSoT principle
+- T9925 (Saga T9855 / E8.6) — this ADR amendment + LAFS conformance test extension
+- T9914 (E-OPERATION-INPUT-CONTRACT) — input/output symmetry counterpart
+- T10114 (E11-HUMAN-RENDER-CONTRACT) — renderer SSoT relocated to `packages/core/src/render/`
+- `packages/lafs/src/envelope.ts` — canonical `CliEnvelope`, `CliMeta`, `CliEnvelopeError`, `CliMetaTokens` types
 - `packages/core/src/dispatch/suggested-next.ts` — `attachSuggestedNext` helper
+- `packages/core/src/dispatch/mvi-projection.ts` — `resolveProjectionMode`, projection-plan registry
+- `packages/cleo/src/dispatch/middleware/mvi-record-projection.ts` — middleware that stamps `meta.projection`
 - `packages/contracts/src/operations/nexus-scope.ts` — pre-existing structured `NexusScopeMeta.suggestedNext`
 - `packages/cleo/src/dispatch/lib/proto-envelope.ts` — `_ProtoEnvelopeStub` bridge type
 - `packages/cleo/src/dispatch/types.ts` — `DispatchResponse.meta` (renamed from `_meta`)
+- `scripts/lint-stdout-write-allowlist.mjs` — writer-allowlist CI gate
+- `scripts/lint-stdout-discipline.mjs` — console-write discipline CI gate

--- a/packages/cleo/src/__tests__/lafs-conformance.test.ts
+++ b/packages/cleo/src/__tests__/lafs-conformance.test.ts
@@ -881,6 +881,318 @@ describe('runEnvelopeConformance — canonical tiered conformance (T4673)', () =
 });
 
 // ============================
+// E8 ENVELOPE FIELDS (Saga T9855 / T9920 / T9923 / T9922)
+// ============================
+
+/**
+ * Per-field structural validators for the E8 envelope additions.
+ *
+ * The canonical {@link isValidLafsEnvelope} helper above only enforces the
+ * baseline ADR-039 shape. These validators enforce the **additive** field
+ * contracts shipped under Saga T9855 / E8:
+ *
+ * - {@link assertSuggestedNext} — `meta.suggestedNext` (T9920)
+ * - {@link assertTokens}        — `meta.tokens` (T9923)
+ * - {@link assertProjection}    — `meta.projection` (T9922)
+ *
+ * Each validator returns `{ valid: true }` for present-and-well-formed,
+ * `{ valid: true }` for absent (every field is optional), and
+ * `{ valid: false, error }` for present-but-wrong-shape.
+ *
+ * @task T9925
+ */
+function assertSuggestedNext(meta: Record<string, unknown>): {
+  valid: boolean;
+  error?: string;
+} {
+  if (!('suggestedNext' in meta)) return { valid: true }; // absent is allowed
+  const v = meta['suggestedNext'];
+  if (!Array.isArray(v)) {
+    return {
+      valid: false,
+      error: `meta.suggestedNext MUST be ReadonlyArray<string> (got ${typeof v})`,
+    };
+  }
+  for (let i = 0; i < v.length; i++) {
+    if (typeof v[i] !== 'string') {
+      return {
+        valid: false,
+        error: `meta.suggestedNext[${i}] MUST be string (got ${typeof v[i]})`,
+      };
+    }
+  }
+  return { valid: true };
+}
+
+function assertTokens(meta: Record<string, unknown>): { valid: boolean; error?: string } {
+  if (!('tokens' in meta)) return { valid: true }; // absent is allowed
+  const v = meta['tokens'];
+  if (!v || typeof v !== 'object' || Array.isArray(v)) {
+    return { valid: false, error: 'meta.tokens MUST be an object' };
+  }
+  const t = v as Record<string, unknown>;
+  if (typeof t['estimate'] !== 'number') {
+    return { valid: false, error: 'meta.tokens.estimate MUST be number' };
+  }
+  if (typeof t['model'] !== 'string') {
+    return { valid: false, error: 'meta.tokens.model MUST be string' };
+  }
+  if (typeof t['calculatedAt'] !== 'string') {
+    return { valid: false, error: 'meta.tokens.calculatedAt MUST be string (ISO 8601)' };
+  }
+  return { valid: true };
+}
+
+function assertProjection(meta: Record<string, unknown>): { valid: boolean; error?: string } {
+  if (!('projection' in meta)) return { valid: true }; // absent is allowed (default 'mvi')
+  const v = meta['projection'];
+  if (v !== 'mvi' && v !== 'full') {
+    return {
+      valid: false,
+      error: `meta.projection MUST be 'mvi' | 'full' (got ${JSON.stringify(v)})`,
+    };
+  }
+  return { valid: true };
+}
+
+describe('E8 envelope fields — meta.suggestedNext (T9920)', () => {
+  it('absent field is valid (optional)', () => {
+    const json = formatSuccess({ ok: true }, undefined, 'tasks.show');
+    const parsed = JSON.parse(json);
+    expect(parsed.meta.suggestedNext).toBeUndefined();
+    expect(assertSuggestedNext(parsed.meta).valid).toBe(true);
+    // Canonical envelope still valid without the field
+    expect(isValidLafsEnvelope(json).valid).toBe(true);
+  });
+
+  it('empty array is valid (means "no follow-up suggested")', () => {
+    const meta = { suggestedNext: [] };
+    expect(assertSuggestedNext(meta).valid).toBe(true);
+  });
+
+  it('populated array of strings is valid', () => {
+    const meta = {
+      suggestedNext: ['cleo focus T1234', 'cleo verify T1234 --gate implemented'] as const,
+    };
+    expect(assertSuggestedNext(meta).valid).toBe(true);
+  });
+
+  it('rejects non-array (string instead of array)', () => {
+    const meta = { suggestedNext: 'cleo focus T1234' };
+    const result = assertSuggestedNext(meta);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('ReadonlyArray<string>');
+  });
+
+  it('rejects array with non-string element', () => {
+    const meta = { suggestedNext: ['cleo focus T1234', 42] };
+    const result = assertSuggestedNext(meta);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('[1]');
+  });
+
+  it('rejects object (not an array)', () => {
+    const meta = { suggestedNext: { 0: 'cleo focus T1234' } };
+    const result = assertSuggestedNext(meta);
+    expect(result.valid).toBe(false);
+  });
+
+  it('canonical envelope with valid suggestedNext passes isValidLafsEnvelope()', () => {
+    const json = formatSuccess({ ok: true }, undefined, {
+      operation: 'tasks.show',
+      // FormatOptions doesn't surface suggestedNext directly — we synthesise
+      // a post-hoc envelope to exercise the structural check.
+    });
+    const parsed = JSON.parse(json);
+    parsed.meta.suggestedNext = ['cleo list', 'cleo session status'] as const;
+    expect(assertSuggestedNext(parsed.meta).valid).toBe(true);
+    expect(isValidLafsEnvelope(JSON.stringify(parsed)).valid).toBe(true);
+  });
+});
+
+describe('E8 envelope fields — meta.tokens (T9923)', () => {
+  it('absent field is valid (optional)', () => {
+    const json = formatSuccess({ ok: true }, undefined, 'tasks.show');
+    const parsed = JSON.parse(json);
+    expect(parsed.meta.tokens).toBeUndefined();
+    expect(assertTokens(parsed.meta).valid).toBe(true);
+  });
+
+  it('all three fields present is valid', () => {
+    const meta = {
+      tokens: { estimate: 123, model: 'cl100k', calculatedAt: '2026-05-24T12:00:00Z' },
+    };
+    expect(assertTokens(meta).valid).toBe(true);
+  });
+
+  it('rejects partial tokens — missing model', () => {
+    const meta = { tokens: { estimate: 42, calculatedAt: '2026-05-24T12:00:00Z' } };
+    const result = assertTokens(meta);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('model');
+  });
+
+  it('rejects partial tokens — missing calculatedAt', () => {
+    const meta = { tokens: { estimate: 42, model: 'cl100k' } };
+    const result = assertTokens(meta);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('calculatedAt');
+  });
+
+  it('rejects partial tokens — missing estimate', () => {
+    const meta = { tokens: { model: 'cl100k', calculatedAt: '2026-05-24T12:00:00Z' } };
+    const result = assertTokens(meta);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('estimate');
+  });
+
+  it('rejects non-number estimate', () => {
+    const meta = { tokens: { estimate: '42', model: 'cl100k', calculatedAt: '2026-05-24Z' } };
+    const result = assertTokens(meta);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('estimate');
+  });
+
+  it('rejects array shape', () => {
+    const meta = { tokens: [42, 'cl100k', '2026-05-24Z'] };
+    const result = assertTokens(meta);
+    expect(result.valid).toBe(false);
+  });
+
+  it('canonical envelope with valid tokens passes isValidLafsEnvelope()', () => {
+    const json = formatSuccess({ ok: true }, undefined, 'tasks.show');
+    const parsed = JSON.parse(json);
+    parsed.meta.tokens = {
+      estimate: 256,
+      model: 'cl100k',
+      calculatedAt: new Date().toISOString(),
+    };
+    expect(assertTokens(parsed.meta).valid).toBe(true);
+    expect(isValidLafsEnvelope(JSON.stringify(parsed)).valid).toBe(true);
+  });
+
+  // ---- T9923 backwards-compat: meta._tokenEstimate (legacy, removeAt v2026.7.0)
+
+  it('backward compat: envelope with legacy meta._tokenEstimate is valid', () => {
+    const json = formatSuccess({ ok: true }, undefined, 'tasks.show');
+    const parsed = JSON.parse(json);
+    parsed.meta._tokenEstimate = { estimate: 99, vendor: 'legacy' };
+    // Legacy field has no strict shape check — open object permitted
+    expect(isValidLafsEnvelope(JSON.stringify(parsed)).valid).toBe(true);
+    // And does NOT trigger the new-field validator
+    expect(assertTokens(parsed.meta).valid).toBe(true);
+  });
+
+  it('backward compat: envelope with BOTH _tokenEstimate (legacy) AND tokens (canonical) is valid', () => {
+    const json = formatSuccess({ ok: true }, undefined, 'tasks.show');
+    const parsed = JSON.parse(json);
+    parsed.meta._tokenEstimate = { estimate: 99 };
+    parsed.meta.tokens = {
+      estimate: 99,
+      model: 'cl100k',
+      calculatedAt: '2026-05-24T12:00:00Z',
+    };
+    // Deprecation overlap window — both shapes coexist
+    expect(assertTokens(parsed.meta).valid).toBe(true);
+    expect(isValidLafsEnvelope(JSON.stringify(parsed)).valid).toBe(true);
+  });
+});
+
+describe('E8 envelope fields — meta.projection (T9922)', () => {
+  it("absent field is valid (default 'mvi' applies)", () => {
+    const json = formatSuccess({ ok: true }, undefined, 'system.status');
+    const parsed = JSON.parse(json);
+    expect(parsed.meta.projection).toBeUndefined();
+    expect(assertProjection(parsed.meta).valid).toBe(true);
+  });
+
+  it("'mvi' is valid", () => {
+    const meta = { projection: 'mvi' };
+    expect(assertProjection(meta).valid).toBe(true);
+  });
+
+  it("'full' is valid", () => {
+    const meta = { projection: 'full' };
+    expect(assertProjection(meta).valid).toBe(true);
+  });
+
+  it('rejects unknown value', () => {
+    const meta = { projection: 'partial' };
+    const result = assertProjection(meta);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('mvi');
+    expect(result.error).toContain('full');
+  });
+
+  it('rejects boolean value', () => {
+    const meta = { projection: true };
+    const result = assertProjection(meta);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    const meta = { projection: '' };
+    const result = assertProjection(meta);
+    expect(result.valid).toBe(false);
+  });
+
+  it("canonical envelope with projection='mvi' passes isValidLafsEnvelope()", () => {
+    const json = formatSuccess({ ok: true }, undefined, 'tasks.list');
+    const parsed = JSON.parse(json);
+    parsed.meta.projection = 'mvi';
+    expect(assertProjection(parsed.meta).valid).toBe(true);
+    expect(isValidLafsEnvelope(JSON.stringify(parsed)).valid).toBe(true);
+  });
+
+  it("canonical envelope with projection='full' (opt-out) passes isValidLafsEnvelope()", () => {
+    const json = formatSuccess({ ok: true }, undefined, 'tasks.list');
+    const parsed = JSON.parse(json);
+    parsed.meta.projection = 'full';
+    expect(assertProjection(parsed.meta).valid).toBe(true);
+    expect(isValidLafsEnvelope(JSON.stringify(parsed)).valid).toBe(true);
+  });
+});
+
+describe('E8 envelope fields — composite regression (T9920 + T9923 + T9922)', () => {
+  it('envelope with ALL E8 fields populated is valid', () => {
+    const json = formatSuccess({ ok: true }, undefined, 'tasks.list');
+    const parsed = JSON.parse(json);
+    parsed.meta.suggestedNext = ['cleo show T1234', 'cleo focus T1234'] as const;
+    parsed.meta.tokens = {
+      estimate: 512,
+      model: 'cl100k',
+      calculatedAt: '2026-05-24T12:00:00Z',
+    };
+    parsed.meta.projection = 'mvi';
+
+    expect(assertSuggestedNext(parsed.meta).valid).toBe(true);
+    expect(assertTokens(parsed.meta).valid).toBe(true);
+    expect(assertProjection(parsed.meta).valid).toBe(true);
+    expect(isValidLafsEnvelope(JSON.stringify(parsed)).valid).toBe(true);
+  });
+
+  it('envelope with NONE of the E8 fields still passes (regression: pre-E8 envelopes valid)', () => {
+    const json = formatSuccess({ ok: true }, undefined, 'tasks.list');
+    const parsed = JSON.parse(json);
+    expect(parsed.meta.suggestedNext).toBeUndefined();
+    expect(parsed.meta.tokens).toBeUndefined();
+    expect(parsed.meta.projection).toBeUndefined();
+    expect(isValidLafsEnvelope(json).valid).toBe(true);
+  });
+
+  it('error envelope MAY carry E8 fields (projection is stamped on errors too)', () => {
+    const err = new CleoError(ExitCode.NOT_FOUND, 'Task not found');
+    const json = formatError(err, 'tasks.show');
+    const parsed = JSON.parse(json);
+    parsed.meta.projection = 'mvi';
+    parsed.meta.suggestedNext = ['cleo find "T1234"'] as const;
+    expect(assertProjection(parsed.meta).valid).toBe(true);
+    expect(assertSuggestedNext(parsed.meta).valid).toBe(true);
+    expect(isValidLafsEnvelope(JSON.stringify(parsed)).valid).toBe(true);
+  });
+});
+
+// ============================
 // T5001: HIERARCHY POLICY CONFORMANCE
 // ============================
 


### PR DESCRIPTION
## Summary
- ADR-039 amended with E8 envelope additions: `meta.suggestedNext` (T9920), `meta.tokens` (T9923), `meta.projection` MVI-default + opt-out (T9922), writer-allowlist principle (T9924).
- Amendment cross-references E7 `OperationInputContract` (T9914) for input/output symmetry.
- `packages/cleo/src/__tests__/lafs-conformance.test.ts` extended with **28 new tests** covering positive + negative shape validation for each new field, plus backward-compat coverage for the deprecated `meta._tokenEstimate` overlap window.
- All 106 lafs-conformance tests pass; all 425 lafs-package tests pass.

## Closes
- T9925
- Epic T9919 (E8-LAFS-LLM-OPTIMIZATION)
- Saga T9855 advances one tick

## Test plan
- [x] biome check passed
- [x] build clean
- [x] vitest run packages/cleo/src/__tests__/lafs-conformance.test.ts (106/106 pass — 28 new E8 tests)
- [x] vitest run @cleocode/lafs (425/425 pass)
- [x] cli-package-boundary lint passed (28 violations, baseline 29 — one improvement)
- [x] format-error-misuse lint passed
- [x] stdout-discipline baseline preserved (63)

## ADR
- 039 (amended)