### PR TITLE
feat: minimal mutate envelopes (T9931 / Saga T9855)

### DIFF
--- a/.changeset/t9931-minimal-mutate-envelopes.md
+++ b/.changeset/t9931-minimal-mutate-envelopes.md
@@ -1,0 +1,6 @@
+---
+id: t9931-minimal-mutate-envelopes
+tasks: [T9931]
+kind: feat
+summary: core: minimal-by-default mutate envelopes — {count, ids[]} (T9931 / Saga T9855 / E9)
+---

--- a/packages/cleo/src/dispatch/adapters/cli.ts
+++ b/packages/cleo/src/dispatch/adapters/cli.ts
@@ -22,6 +22,7 @@ import { Dispatcher } from '../dispatcher.js';
 import { createDomainHandlers } from '../domains/index.js';
 import { createAudit } from '../middleware/audit.js';
 import { createFieldFilter } from '../middleware/field-filter.js';
+import { createMutateMinimalEnvelope } from '../middleware/mutate-minimal-envelope.js';
 import { createMviRecordProjection } from '../middleware/mvi-record-projection.js';
 import { createSanitizer } from '../middleware/sanitizer.js';
 import { createSessionResolver } from '../middleware/session-resolver.js';
@@ -167,6 +168,10 @@ export function createCliDispatcher(): Dispatcher {
       // before audit + telemetry record byte sizes. Sits before audit so the
       // audit trail captures the projected (final) bytes.
       createMviRecordProjection(),
+      // T9931 (Saga T9855 / E9.4): minimal envelopes for mutate ops. Mirror
+      // policy to the read-side projection — sits in the same pre-audit slot
+      // so audit/telemetry record the trimmed bytes.
+      createMutateMinimalEnvelope(),
       createAudit(), // T4959: CLI now gets audit trail
       createTelemetry(), // T624: opt-in self-improvement telemetry
     ],

--- a/packages/cleo/src/dispatch/middleware/__tests__/mutate-minimal-envelope.test.ts
+++ b/packages/cleo/src/dispatch/middleware/__tests__/mutate-minimal-envelope.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for the minimal mutate envelope middleware
+ * (T9931 / Saga T9855 / E9.4).
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { resetProjectionOptOut, setProjectionOptOut } from '../../../cli/projection-context.js';
+import type { DispatchRequest, DispatchResponse } from '../../types.js';
+import { createMutateMinimalEnvelope } from '../mutate-minimal-envelope.js';
+
+const FULL_TASK = {
+  id: 'T9931',
+  title: 'Minimal mutate envelopes',
+  description: 'Verbose body that the middleware should strip.',
+  status: 'pending' as const,
+  priority: 'high' as const,
+  type: 'task',
+  parentId: 'T9927',
+  acceptance: ['ac1', 'ac2'],
+  verification: { passed: false, round: 1 },
+};
+
+function makeRequest(
+  domain: string,
+  operation: string,
+  params?: Record<string, unknown>,
+): DispatchRequest {
+  return {
+    gateway: 'mutate',
+    domain,
+    operation,
+    params,
+    source: 'cli',
+    requestId: 'req-1',
+  };
+}
+
+function makeSuccessResponse(
+  operation: string,
+  data: unknown,
+  metaExtra?: Record<string, unknown>,
+): DispatchResponse {
+  return {
+    meta: {
+      gateway: 'mutate',
+      domain: 'tasks',
+      operation,
+      timestamp: '2026-05-24T00:00:00.000Z',
+      duration_ms: 1,
+      source: 'cli',
+      requestId: 'req-1',
+      ...metaExtra,
+    },
+    success: true,
+    data,
+  };
+}
+
+describe('createMutateMinimalEnvelope middleware', () => {
+  beforeEach(() => {
+    resetProjectionOptOut();
+  });
+
+  // ---------------------------------------------------------------------
+  // Each of the 5 mutate ops returns minimal shape by default
+  // ---------------------------------------------------------------------
+
+  it('tasks.add — returns {count, ids[], status} by default', async () => {
+    const mw = createMutateMinimalEnvelope();
+    const req = makeRequest('tasks', 'add', { title: 'x' });
+    const response = await mw(req, async () =>
+      makeSuccessResponse('add', { task: FULL_TASK, duplicate: false }),
+    );
+    const data = response.data as Record<string, unknown>;
+    expect(data['count']).toBe(1);
+    expect(data['ids']).toEqual(['T9931']);
+    expect(data['status']).toBe('pending');
+    expect(data['task']).toBeUndefined();
+    expect(data['description']).toBeUndefined();
+    expect(response.meta.mutateProjection).toBe('mvi');
+  });
+
+  it('tasks.add-batch — returns {count, ids[]} for the entire batch', async () => {
+    const mw = createMutateMinimalEnvelope();
+    const req = makeRequest('tasks', 'add-batch', { tasks: [{ title: 'a' }, { title: 'b' }] });
+    const response = await mw(req, async () =>
+      makeSuccessResponse('add-batch', {
+        created: 2,
+        tasks: [{ task: { id: 'T100', title: 'a' } }, { task: { id: 'T101', title: 'b' } }],
+      }),
+    );
+    const data = response.data as Record<string, unknown>;
+    expect(data['count']).toBe(2);
+    expect(data['ids']).toEqual(['T100', 'T101']);
+    expect(data['tasks']).toBeUndefined();
+    expect(response.meta.mutateProjection).toBe('mvi');
+  });
+
+  it('tasks.update — returns {count, ids[], changes, status}', async () => {
+    const mw = createMutateMinimalEnvelope();
+    const req = makeRequest('tasks', 'update', { taskId: 'T9931', title: 'new' });
+    const response = await mw(req, async () =>
+      makeSuccessResponse('update', { task: FULL_TASK, changes: ['title'] }),
+    );
+    const data = response.data as Record<string, unknown>;
+    expect(data['count']).toBe(1);
+    expect(data['ids']).toEqual(['T9931']);
+    expect(data['changes']).toEqual(['title']);
+    expect(data['status']).toBe('pending');
+    expect(data['task']).toBeUndefined();
+    expect(response.meta.mutateProjection).toBe('mvi');
+  });
+
+  it('tasks.complete — returns {count, ids[], status, completedAt}', async () => {
+    const mw = createMutateMinimalEnvelope();
+    const req = makeRequest('tasks', 'complete', { taskId: 'T9931' });
+    const completedTask = {
+      ...FULL_TASK,
+      status: 'completed' as const,
+      completedAt: '2026-05-24T00:00:00.000Z',
+    };
+    const response = await mw(req, async () =>
+      makeSuccessResponse('complete', { task: completedTask }),
+    );
+    const data = response.data as Record<string, unknown>;
+    expect(data['count']).toBe(1);
+    expect(data['ids']).toEqual(['T9931']);
+    expect(data['status']).toBe('completed');
+    expect(data['completedAt']).toBe('2026-05-24T00:00:00.000Z');
+    expect(data['task']).toBeUndefined();
+    expect(response.meta.mutateProjection).toBe('mvi');
+  });
+
+  it('tasks.delete — returns {count, ids[], status}', async () => {
+    const mw = createMutateMinimalEnvelope();
+    const req = makeRequest('tasks', 'delete', { taskId: 'T9931' });
+    const response = await mw(req, async () =>
+      makeSuccessResponse('delete', { deletedTask: FULL_TASK }),
+    );
+    const data = response.data as Record<string, unknown>;
+    expect(data['count']).toBe(1);
+    expect(data['ids']).toEqual(['T9931']);
+    expect(data['status']).toBe('pending');
+    expect(data['deletedTask']).toBeUndefined();
+    expect(response.meta.mutateProjection).toBe('mvi');
+  });
+
+  // ---------------------------------------------------------------------
+  // --full / --verbose / --human opt-out restores full shape
+  // ---------------------------------------------------------------------
+
+  it('--full opt-out (global) restores the full record for every mutate op', async () => {
+    setProjectionOptOut(true);
+    const mw = createMutateMinimalEnvelope();
+
+    for (const op of ['add', 'update', 'complete'] as const) {
+      const req = makeRequest('tasks', op);
+      const response = await mw(req, async () =>
+        makeSuccessResponse(op, { task: FULL_TASK, changes: ['title'] }),
+      );
+      const data = response.data as Record<string, unknown>;
+      const task = data['task'] as Record<string, unknown>;
+      expect(task).toBeDefined();
+      expect(task['description']).toBe(FULL_TASK.description);
+      expect(task['verification']).toEqual(FULL_TASK.verification);
+      expect(response.meta.mutateProjection).toBe('full');
+    }
+  });
+
+  it('honours a per-request _projection override even when the global flag is set', async () => {
+    setProjectionOptOut(true);
+    const mw = createMutateMinimalEnvelope();
+    const req = makeRequest('tasks', 'add', { _projection: 'mvi' });
+    const response = await mw(req, async () =>
+      makeSuccessResponse('add', { task: FULL_TASK, duplicate: false }),
+    );
+    const data = response.data as Record<string, unknown>;
+    expect(data['count']).toBe(1);
+    expect(data['ids']).toEqual(['T9931']);
+    expect(data['task']).toBeUndefined();
+    expect(response.meta.mutateProjection).toBe('mvi');
+  });
+
+  // ---------------------------------------------------------------------
+  // Meta preservation
+  // ---------------------------------------------------------------------
+
+  it('preserves meta.suggestedNext set by the upstream handler (T9921)', async () => {
+    const mw = createMutateMinimalEnvelope();
+    const req = makeRequest('tasks', 'add', { title: 'x' });
+    const response = await mw(req, async () =>
+      makeSuccessResponse(
+        'add',
+        { task: FULL_TASK, duplicate: false },
+        { suggestedNext: ['cleo show T9931', 'cleo verify T9931'] },
+      ),
+    );
+    expect(response.meta.suggestedNext).toEqual(['cleo show T9931', 'cleo verify T9931']);
+    expect(response.meta.mutateProjection).toBe('mvi');
+  });
+
+  // ---------------------------------------------------------------------
+  // Ops with no plan are passed through untouched
+  // ---------------------------------------------------------------------
+
+  it('does not project ops absent from MUTATE_PROJECTION_PLANS', async () => {
+    const mw = createMutateMinimalEnvelope();
+    const req = makeRequest('tasks', 'archive', { taskIds: ['T9931'] });
+    const response = await mw(req, async () =>
+      makeSuccessResponse('archive', { archivedIds: ['T9931'], count: 1 }),
+    );
+    const data = response.data as Record<string, unknown>;
+    // Original shape preserved — no `count`/`ids` rewrite.
+    expect(data['archivedIds']).toEqual(['T9931']);
+    expect(response.meta.mutateProjection).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------
+  // Error responses still get the projection stamp
+  // ---------------------------------------------------------------------
+
+  it('stamps meta.mutateProjection on error envelopes too', async () => {
+    const mw = createMutateMinimalEnvelope();
+    const req = makeRequest('tasks', 'add', { title: 'x' });
+    const errResponse: DispatchResponse = {
+      meta: {
+        gateway: 'mutate',
+        domain: 'tasks',
+        operation: 'add',
+        timestamp: '2026-05-24T00:00:00.000Z',
+        duration_ms: 1,
+        source: 'cli',
+        requestId: 'req-1',
+      },
+      success: false,
+      error: { code: 'E_VALIDATION', message: 'bad input' },
+    };
+    const response = await mw(req, async () => errResponse);
+    expect(response.meta.mutateProjection).toBe('mvi');
+    expect(response.success).toBe(false);
+  });
+});

--- a/packages/cleo/src/dispatch/middleware/mutate-minimal-envelope.ts
+++ b/packages/cleo/src/dispatch/middleware/mutate-minimal-envelope.ts
@@ -1,0 +1,82 @@
+/**
+ * Minimal-by-default mutate envelope middleware (T9931 / Saga T9855 / E9.4).
+ *
+ * Sibling to {@link createMviRecordProjection} — that middleware trims read-op
+ * payloads, this one trims mutate-op payloads. For the ops declared in
+ * {@link MUTATE_PROJECTION_PLANS} the data payload is replaced with a
+ * `{count, ids[]}` envelope plus per-op routing extras. The single global
+ * opt-out signal (`--full` / `--verbose` / `--human`, captured in
+ * {@link getProjectionOptOut}) restores the verbose payload everywhere.
+ *
+ * `meta.mutateProjection` is stamped on every response that ran through a
+ * planned mutate op so consumers can distinguish a minimal envelope from a
+ * full record without re-implementing the policy.
+ *
+ * @module @cleocode/cleo/dispatch/middleware/mutate-minimal-envelope
+ *
+ * @epic T9855
+ * @task T9931
+ */
+
+import {
+  applyMutateProjection,
+  MUTATE_PROJECTION_PLANS,
+  type ProjectionMode,
+  resolveProjectionMode,
+} from '@cleocode/core';
+import { getProjectionOptOut } from '../../cli/projection-context.js';
+import type { DispatchRequest, DispatchResponse, Middleware } from '../types.js';
+
+/**
+ * Resolve the projection mode for a single request.
+ *
+ * Priority: a per-request override carried as `req.params._projection` wins
+ * (used by tests and any internal caller that wants to bypass the global
+ * CLI flag). Otherwise the global opt-out signal from
+ * {@link getProjectionOptOut} decides.
+ */
+function resolveModeFor(req: DispatchRequest): ProjectionMode {
+  const override = req.params?.['_projection'];
+  if (override === 'full' || override === 'mvi') return override;
+  return resolveProjectionMode(getProjectionOptOut() || undefined);
+}
+
+/**
+ * Create the minimal mutate envelope middleware.
+ *
+ * @returns A `Middleware` that replaces mutate response data with a minimal
+ *          `{count, ids[]}` envelope per {@link MUTATE_PROJECTION_PLANS} and
+ *          stamps `meta.mutateProjection`.
+ */
+export function createMutateMinimalEnvelope(): Middleware {
+  return async (
+    req: DispatchRequest,
+    next: () => Promise<DispatchResponse>,
+  ): Promise<DispatchResponse> => {
+    // Resolve mode BEFORE stripping the override token so the per-request
+    // override survives the cleanup.
+    const mode = resolveModeFor(req);
+
+    // Note: we deliberately do NOT strip the `_projection` override here.
+    // The read-side MVI middleware (createMviRecordProjection) owns that
+    // strip step, runs in the same pipeline, and removes the token once.
+    // Stripping it twice would mask bugs where one middleware ran but the
+    // other didn't.
+
+    const opKey = `${req.domain}.${req.operation}`;
+    const hasPlan = MUTATE_PROJECTION_PLANS[opKey] !== undefined;
+
+    const response = await next();
+
+    if (!hasPlan) return response;
+
+    if (response.success && response.data !== undefined) {
+      response.data = applyMutateProjection(response.data, opKey, mode);
+    }
+    // Stamp the choice on every response that ran through a planned mutate
+    // op, including errors — agents inspecting an error envelope can still
+    // see which mode the request resolved to.
+    response.meta.mutateProjection = mode;
+    return response;
+  };
+}

--- a/packages/core/src/dispatch/__tests__/mutate-projection.test.ts
+++ b/packages/core/src/dispatch/__tests__/mutate-projection.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for minimal mutate envelope projection (T9931 / Saga T9855 / E9.4).
+ *
+ * Verifies the per-op extractors, the dispatch-level routing table, and the
+ * defensive fallback when an extractor cannot find any ID.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyMutateProjection, MUTATE_PROJECTION_PLANS } from '../mutate-projection.js';
+
+const FULL_TASK = {
+  id: 'T9931',
+  title: 'Minimal mutate envelopes',
+  description: 'Verbose body — should be stripped under MVI.',
+  status: 'pending',
+  priority: 'high',
+  type: 'task',
+  parentId: 'T9927',
+  acceptance: ['ac1', 'ac2'],
+  verification: { passed: false, round: 1 },
+  createdAt: '2026-05-21T16:31:48.186Z',
+  labels: ['e9'],
+} as const;
+
+describe('MUTATE_PROJECTION_PLANS — SSoT for mutate ops', () => {
+  it('declares plans for the 5 T9931 mutate ops', () => {
+    expect(MUTATE_PROJECTION_PLANS['tasks.add']).toBeDefined();
+    expect(MUTATE_PROJECTION_PLANS['tasks.add-batch']).toBeDefined();
+    expect(MUTATE_PROJECTION_PLANS['tasks.update']).toBeDefined();
+    expect(MUTATE_PROJECTION_PLANS['tasks.complete']).toBeDefined();
+    expect(MUTATE_PROJECTION_PLANS['tasks.delete']).toBeDefined();
+  });
+
+  it('does not project read ops', () => {
+    expect(MUTATE_PROJECTION_PLANS['tasks.show']).toBeUndefined();
+    expect(MUTATE_PROJECTION_PLANS['tasks.list']).toBeUndefined();
+    expect(MUTATE_PROJECTION_PLANS['tasks.find']).toBeUndefined();
+  });
+});
+
+describe('applyMutateProjection — full mode is always a no-op', () => {
+  it('returns the original data ref under full mode', () => {
+    const data = { task: FULL_TASK, duplicate: false };
+    expect(applyMutateProjection(data, 'tasks.add', 'full')).toBe(data);
+  });
+});
+
+describe('applyMutateProjection — tasks.add', () => {
+  it('extracts {count, ids, status}', () => {
+    const data = { task: FULL_TASK, duplicate: false };
+    const out = applyMutateProjection(data, 'tasks.add', 'mvi') as Record<string, unknown>;
+    expect(out['count']).toBe(1);
+    expect(out['ids']).toEqual(['T9931']);
+    expect(out['status']).toBe('pending');
+    // Verbose fields stripped:
+    expect(out['title']).toBeUndefined();
+    expect(out['description']).toBeUndefined();
+    expect(out['acceptance']).toBeUndefined();
+    expect(out['task']).toBeUndefined();
+  });
+
+  it('stamps duplicate: true when the core op flagged it', () => {
+    const data = { task: FULL_TASK, duplicate: true };
+    const out = applyMutateProjection(data, 'tasks.add', 'mvi') as Record<string, unknown>;
+    expect(out['duplicate']).toBe(true);
+  });
+
+  it('stamps dryRun: true on dry-run path', () => {
+    const data = { task: FULL_TASK, duplicate: false, dryRun: true };
+    const out = applyMutateProjection(data, 'tasks.add', 'mvi') as Record<string, unknown>;
+    expect(out['dryRun']).toBe(true);
+  });
+
+  it('falls back to original data when the task id is missing', () => {
+    const data = { task: { title: 'nope' }, duplicate: false };
+    // No id → envelope would be {count:0, ids:[]} → caller sees full payload
+    expect(applyMutateProjection(data, 'tasks.add', 'mvi')).toBe(data);
+  });
+});
+
+describe('applyMutateProjection — tasks.add-batch', () => {
+  it('aggregates {count, ids[]} across the batch', () => {
+    const data = {
+      created: 3,
+      tasks: [
+        { task: { id: 'T100', title: 'a' } },
+        { task: { id: 'T101', title: 'b' } },
+        { task: { id: 'T102', title: 'c' } },
+      ],
+    };
+    const out = applyMutateProjection(data, 'tasks.add-batch', 'mvi') as Record<string, unknown>;
+    expect(out['count']).toBe(3);
+    expect(out['ids']).toEqual(['T100', 'T101', 'T102']);
+    expect(out['tasks']).toBeUndefined();
+  });
+
+  it('reflects dryRun in the envelope', () => {
+    const data = {
+      created: 0,
+      dryRun: true,
+      tasks: [{ task: { id: 'T???' } }, { task: { id: 'T???' } }],
+    };
+    const out = applyMutateProjection(data, 'tasks.add-batch', 'mvi') as Record<string, unknown>;
+    expect(out['dryRun']).toBe(true);
+    expect(out['ids']).toEqual(['T???', 'T???']);
+  });
+
+  it('handles entries with an inline id (no `task` wrapper)', () => {
+    const data = { created: 2, tasks: [{ id: 'T200' }, { id: 'T201' }] };
+    const out = applyMutateProjection(data, 'tasks.add-batch', 'mvi') as Record<string, unknown>;
+    expect(out['count']).toBe(2);
+    expect(out['ids']).toEqual(['T200', 'T201']);
+  });
+
+  it('falls back to original data when nothing parseable is present', () => {
+    const data = { created: 0, tasks: [] };
+    // No ids → fallback so the caller sees the original shape and can debug.
+    expect(applyMutateProjection(data, 'tasks.add-batch', 'mvi')).toBe(data);
+  });
+});
+
+describe('applyMutateProjection — tasks.update', () => {
+  it('extracts {count, ids, changes, status}', () => {
+    const data = { task: FULL_TASK, changes: ['title', 'priority'] };
+    const out = applyMutateProjection(data, 'tasks.update', 'mvi') as Record<string, unknown>;
+    expect(out['count']).toBe(1);
+    expect(out['ids']).toEqual(['T9931']);
+    expect(out['changes']).toEqual(['title', 'priority']);
+    expect(out['status']).toBe('pending');
+    expect(out['task']).toBeUndefined();
+    expect(out['description']).toBeUndefined();
+  });
+});
+
+describe('applyMutateProjection — tasks.complete', () => {
+  it('extracts {count, ids, status, completedAt}', () => {
+    const completedTask = {
+      ...FULL_TASK,
+      status: 'completed',
+      completedAt: '2026-05-24T00:00:00.000Z',
+    };
+    const data = { task: completedTask };
+    const out = applyMutateProjection(data, 'tasks.complete', 'mvi') as Record<string, unknown>;
+    expect(out['count']).toBe(1);
+    expect(out['ids']).toEqual(['T9931']);
+    expect(out['status']).toBe('completed');
+    expect(out['completedAt']).toBe('2026-05-24T00:00:00.000Z');
+    expect(out['task']).toBeUndefined();
+  });
+
+  it('attaches autoCompleted when non-empty', () => {
+    const data = { task: FULL_TASK, autoCompleted: ['T9932', 'T9933'] };
+    const out = applyMutateProjection(data, 'tasks.complete', 'mvi') as Record<string, unknown>;
+    expect(out['autoCompleted']).toEqual(['T9932', 'T9933']);
+  });
+});
+
+describe('applyMutateProjection — tasks.delete', () => {
+  it('extracts {count, ids} from deletedTask wrapper', () => {
+    const data = { deletedTask: FULL_TASK };
+    const out = applyMutateProjection(data, 'tasks.delete', 'mvi') as Record<string, unknown>;
+    expect(out['count']).toBe(1);
+    expect(out['ids']).toEqual(['T9931']);
+    expect(out['deletedTask']).toBeUndefined();
+  });
+
+  it('rolls cascadeDeleted ids into the envelope', () => {
+    const data = { deletedTask: FULL_TASK, cascadeDeleted: ['T1', 'T2'] };
+    const out = applyMutateProjection(data, 'tasks.delete', 'mvi') as Record<string, unknown>;
+    expect(out['count']).toBe(3);
+    expect(out['ids']).toEqual(['T9931', 'T1', 'T2']);
+    expect(out['cascadeDeleted']).toEqual(['T1', 'T2']);
+  });
+});
+
+describe('applyMutateProjection — unknown ops + edge cases', () => {
+  it('returns data unchanged when the op has no plan', () => {
+    const data = { task: FULL_TASK };
+    expect(applyMutateProjection(data, 'tasks.archive', 'mvi')).toBe(data);
+    expect(applyMutateProjection(data, 'memory.observe', 'mvi')).toBe(data);
+  });
+
+  it('passes through null / undefined / primitive data', () => {
+    expect(applyMutateProjection(null, 'tasks.add', 'mvi')).toBeNull();
+    expect(applyMutateProjection(undefined, 'tasks.add', 'mvi')).toBeUndefined();
+    expect(applyMutateProjection(42, 'tasks.add', 'mvi')).toBe(42);
+  });
+});

--- a/packages/core/src/dispatch/mutate-projection.ts
+++ b/packages/core/src/dispatch/mutate-projection.ts
@@ -1,0 +1,252 @@
+/**
+ * Minimal-by-default mutate envelope projection (T9931 / Saga T9855 / E9.4).
+ *
+ * For state-modifying ops (`tasks.add`, `tasks.add-batch`, `tasks.update`,
+ * `tasks.complete`, `tasks.delete`) the dispatcher used to return the full
+ * post-mutation task record — title, description, acceptance, verification,
+ * createdAt, updatedAt, labels, the entire row. Agents almost never need any
+ * of that to keep working; they only need enough information to confirm the
+ * mutation landed and to feed the next operation. This module strips the
+ * payload down to `{count, ids[]}` (and, for single-task ops, a few extra
+ * routing keys like `status`, `completedAt`, or `changes`).
+ *
+ * This is the mutate-side analogue to {@link applyProjectionPlan} for read
+ * ops in `./mvi-projection.ts`. The two modules use the same opt-out signal
+ * (`--full` / `--verbose` / `--human`) so a single CLI flag restores verbose
+ * behaviour everywhere.
+ *
+ * @packageDocumentation
+ * @module @cleocode/core/dispatch/mutate-projection
+ *
+ * @epic T9855 (Saga)
+ * @task T9931 (E9.4)
+ */
+
+import type { ProjectionMode } from './mvi-projection.js';
+
+/**
+ * Minimal envelope shape returned for batch-style mutate ops.
+ *
+ * Always includes a count and the affected task IDs. For single-task ops
+ * (`add`, `update`, `complete`, `delete`) `count` is `1` and `ids` is a
+ * single-element array. For `add-batch` `count` and `ids` reflect the entire
+ * transaction.
+ */
+export interface MinimalMutateEnvelope {
+  /** Number of records the mutation affected. */
+  count: number;
+  /** Affected task IDs, in the order the operation processed them. */
+  ids: string[];
+  /**
+   * Per-op routing extras kept for single-task ops:
+   * - `status` — post-mutation task status (add, update, complete)
+   * - `completedAt` — ISO timestamp (complete only)
+   * - `changes` — list of fields that changed (update only)
+   * - `dryRun` — true when no DB write occurred (add, add-batch)
+   *
+   * Index signature is intentionally open so future ops can attach their
+   * own minimal extras without expanding the type registry.
+   */
+  [key: string]: unknown;
+}
+
+/**
+ * Plan describing how to derive a {@link MinimalMutateEnvelope} from a raw
+ * mutate op data payload.
+ *
+ * `extract` runs against `response.data` (NOT the full response) and must
+ * return a fresh object — callers treat the result as immutable.
+ */
+export interface MutateProjectionPlan {
+  /** Canonical `<domain>.<operation>` key this plan applies to. */
+  operation: string;
+  /**
+   * Extractor that turns the raw mutate result into the minimal envelope.
+   *
+   * Implementations MUST be defensive: the raw shape may be missing fields
+   * when the underlying core op returned partial data (e.g. a dry-run path
+   * that returned synthetic IDs). When the extractor cannot determine an
+   * ID it returns `count: 0, ids: []` rather than throwing — the original
+   * envelope is then returned unchanged by {@link applyMutateProjection}.
+   */
+  extract: (data: Record<string, unknown>) => MinimalMutateEnvelope;
+}
+
+/**
+ * Read a task `id` from a possibly-nested record shape.
+ *
+ * Several core ops wrap the task under `data.task` / `data.deletedTask`
+ * while others return the task fields at the root. This helper centralises
+ * the lookup so each plan stays trivial.
+ *
+ * @internal
+ */
+function readTaskId(record: unknown): string | undefined {
+  if (record === null || typeof record !== 'object') return undefined;
+  const obj = record as Record<string, unknown>;
+  const id = obj['id'];
+  return typeof id === 'string' ? id : undefined;
+}
+
+/**
+ * Read a string-typed field from a record.
+ *
+ * @internal
+ */
+function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * SSoT mapping of mutate operation → projection plan.
+ *
+ * The keys MUST match the canonical `<domain>.<operation>` identifier used
+ * by the dispatcher. Ops absent from this table opt OUT of minimal projection
+ * (the original payload flows through untouched).
+ */
+export const MUTATE_PROJECTION_PLANS: Readonly<Record<string, MutateProjectionPlan>> = {
+  'tasks.add': {
+    operation: 'tasks.add',
+    extract: (data) => {
+      const task = data['task'];
+      const id = readTaskId(task);
+      const status =
+        task && typeof task === 'object' ? (task as Record<string, unknown>)['status'] : undefined;
+      const envelope: MinimalMutateEnvelope = {
+        count: id ? 1 : 0,
+        ids: id ? [id] : [],
+      };
+      if (typeof status === 'string') envelope['status'] = status;
+      if (data['duplicate'] === true) envelope['duplicate'] = true;
+      if (data['dryRun'] === true) envelope['dryRun'] = true;
+      return envelope;
+    },
+  },
+  'tasks.add-batch': {
+    operation: 'tasks.add-batch',
+    extract: (data) => {
+      const tasksField = data['tasks'];
+      const ids: string[] = [];
+      if (Array.isArray(tasksField)) {
+        for (const entry of tasksField) {
+          if (entry === null || typeof entry !== 'object') continue;
+          const inner = (entry as Record<string, unknown>)['task'];
+          const id = readTaskId(inner) ?? readTaskId(entry);
+          if (id) ids.push(id);
+        }
+      }
+      const createdRaw = data['created'];
+      const created = typeof createdRaw === 'number' ? createdRaw : ids.length;
+      const envelope: MinimalMutateEnvelope = {
+        count: created,
+        ids,
+      };
+      if (data['dryRun'] === true) envelope['dryRun'] = true;
+      return envelope;
+    },
+  },
+  'tasks.update': {
+    operation: 'tasks.update',
+    extract: (data) => {
+      const task = data['task'];
+      const id = readTaskId(task);
+      const envelope: MinimalMutateEnvelope = {
+        count: id ? 1 : 0,
+        ids: id ? [id] : [],
+      };
+      const changes = data['changes'];
+      if (Array.isArray(changes)) envelope['changes'] = changes;
+      if (task && typeof task === 'object') {
+        const status = (task as Record<string, unknown>)['status'];
+        if (typeof status === 'string') envelope['status'] = status;
+      }
+      return envelope;
+    },
+  },
+  'tasks.complete': {
+    operation: 'tasks.complete',
+    extract: (data) => {
+      const task = data['task'];
+      const id = readTaskId(task);
+      const envelope: MinimalMutateEnvelope = {
+        count: id ? 1 : 0,
+        ids: id ? [id] : [],
+      };
+      if (task && typeof task === 'object') {
+        const inner = task as Record<string, unknown>;
+        const status = inner['status'];
+        const completedAt = inner['completedAt'];
+        if (typeof status === 'string') envelope['status'] = status;
+        if (typeof completedAt === 'string') envelope['completedAt'] = completedAt;
+      }
+      const autoCompleted = data['autoCompleted'];
+      if (Array.isArray(autoCompleted) && autoCompleted.length > 0) {
+        envelope['autoCompleted'] = autoCompleted;
+      }
+      return envelope;
+    },
+  },
+  'tasks.delete': {
+    operation: 'tasks.delete',
+    extract: (data) => {
+      const deleted = data['deletedTask'] ?? data['task'];
+      const id = readTaskId(deleted);
+      const envelope: MinimalMutateEnvelope = {
+        count: id ? 1 : 0,
+        ids: id ? [id] : [],
+      };
+      if (deleted && typeof deleted === 'object') {
+        const status = readString(deleted as Record<string, unknown>, 'status');
+        if (status) envelope['status'] = status;
+      }
+      const cascadeDeleted = data['cascadeDeleted'];
+      if (Array.isArray(cascadeDeleted) && cascadeDeleted.length > 0) {
+        envelope['cascadeDeleted'] = cascadeDeleted;
+        envelope['count'] = envelope['count'] + cascadeDeleted.length;
+        envelope['ids'] = [
+          ...envelope['ids'],
+          ...cascadeDeleted.filter((x): x is string => typeof x === 'string'),
+        ];
+      }
+      return envelope;
+    },
+  },
+};
+
+/**
+ * Apply the {@link MUTATE_PROJECTION_PLANS} entry for an operation, returning
+ * the minimal envelope when a plan exists and `mode` is `'mvi'`.
+ *
+ * Behaviour table:
+ *
+ * | mode    | plan present? | extractor returned count? | output                |
+ * |---------|---------------|---------------------------|-----------------------|
+ * | `full`  | any           | any                       | original `data`       |
+ * | `mvi`   | no            | n/a                       | original `data`       |
+ * | `mvi`   | yes           | `count > 0`               | minimal envelope      |
+ * | `mvi`   | yes           | `count === 0`             | original `data`       |
+ *
+ * The last row guards against silent data loss: if the extractor could not
+ * find any ID in the raw payload (e.g. an unexpected shape from a future
+ * core op revision) the caller still sees the full payload rather than an
+ * empty `{count:0, ids:[]}` envelope.
+ *
+ * @param data      - The dispatch response `data` payload.
+ * @param operation - The canonical `<domain>.<operation>` identifier.
+ * @param mode      - `'mvi'` applies the plan; `'full'` is a no-op.
+ * @returns Either the minimal envelope or the original `data` reference.
+ */
+export function applyMutateProjection(
+  data: unknown,
+  operation: string,
+  mode: ProjectionMode,
+): unknown {
+  if (mode === 'full') return data;
+  const plan = MUTATE_PROJECTION_PLANS[operation];
+  if (!plan) return data;
+  if (data === null || data === undefined || typeof data !== 'object') return data;
+  const envelope = plan.extract(data as Record<string, unknown>);
+  if (envelope.count === 0 && envelope.ids.length === 0) return data;
+  return envelope;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -647,6 +647,13 @@ export { updateTask } from './tasks/update.js';
 // T9918 (Saga T9855 / E7.5) — OperationInputContract registry seed
 // T9917 (Saga T9855 / E7.4) — extended with tasks.add + tasks.update via contracts package
 export { getInputContract, INPUT_CONTRACTS } from './dispatch/contracts/input-contracts.js';
+// T9931 (Saga T9855 / E9.4) — minimal mutate envelopes (default for mutate ops)
+export {
+  applyMutateProjection,
+  type MinimalMutateEnvelope,
+  MUTATE_PROJECTION_PLANS,
+  type MutateProjectionPlan,
+} from './dispatch/mutate-projection.js';
 // T9922 (Saga T9855 / E8.3) — MVI record projection (default for read ops)
 export {
   applyProjectionPlan,


### PR DESCRIPTION
Closes T9931. Saga T9855.

## Summary

Mutate ops (`tasks.add`, `tasks.add-batch`, `tasks.update`, `tasks.complete`, `tasks.delete`) now return `{count, ids[]}` (plus 1-3 routing keys per op) instead of the full task record by default. The existing global `--full` / `--verbose` / `--human` opt-out signal restores the verbose payload — no new flag, no separate CLI surface.

## Architecture

Mirrors the read-side MVI projection (T9922):

- **`packages/core/src/dispatch/mutate-projection.ts`** — new SSoT module. `MUTATE_PROJECTION_PLANS` declares one extractor per op; `applyMutateProjection()` runs the plan when the mode is `mvi`. Defensive: when an extractor cannot find any id (unexpected core-op shape) the full payload is returned untouched rather than emitting `{count:0, ids:[]}`.
- **`packages/cleo/src/dispatch/middleware/mutate-minimal-envelope.ts`** — new middleware. Reads the global projection opt-out (same singleton the read-side middleware uses) and replaces `response.data` for any op covered by a plan. Stamps `meta.mutateProjection` so consumers can tell minimal vs full apart without re-implementing the policy.
- **Wired into the CLI dispatch pipeline** at the same pre-audit slot as `createMviRecordProjection()` so audit/telemetry record the trimmed bytes.

`meta.suggestedNext` (T9921) is preserved because the per-op suggestion builder runs inside the domain handler BEFORE middleware sees the response.

## Behaviour table

| op             | minimal envelope keys                                       |
|----------------|-------------------------------------------------------------|
| tasks.add      | count, ids, status, duplicate?, dryRun?                     |
| tasks.add-batch| count, ids, dryRun?                                         |
| tasks.update   | count, ids, changes, status                                 |
| tasks.complete | count, ids, status, completedAt, autoCompleted?             |
| tasks.delete   | count, ids, status, cascadeDeleted? (rolled into count/ids) |

## Tests

- `packages/core/src/dispatch/__tests__/mutate-projection.test.ts` — 18 tests covering each extractor + the fallback-on-missing-id guard.
- `packages/cleo/src/dispatch/middleware/__tests__/mutate-minimal-envelope.test.ts` — 10 tests covering each of the 5 ops (default minimal + `--full` opt-out), the per-request `_projection` override, and `meta.suggestedNext` preservation.

All 78 `packages/core/src/dispatch` tests pass. All 56 `packages/cleo/src/dispatch/middleware` tests pass. CLI command tests for add/update unchanged.

## Compatibility

BREAKING for any consumer that read `task.title`/`task.description`/`task.verification` directly off a mutate response — those callers must either:
1. add `--full` to the call, or
2. follow up with `cleo show <id>` (the suggested-next builder already emits this for `tasks.add`).

The human renderer auto-opts-out via `formatResolution.format === 'human'` so interactive CLI use is unaffected.

## Test plan

- [x] `pnpm biome check --write packages/` — 3 files auto-fixed
- [x] `pnpm run build` — clean
- [x] `pnpm exec vitest run packages/core/src/dispatch` — 78 passed
- [x] `pnpm exec vitest run packages/cleo/src/dispatch/middleware` — 56 passed
- [x] `scripts/lint-stdout-write-allowlist.mjs` — baseline (no regression)
- [x] `scripts/lint-format-error-misuse.mjs` — OK
- [x] `scripts/lint-cli-package-boundary.mjs` — baseline -1 (improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)