### PR TITLE
feat(cleo): --summary flag (T9932 / Saga T9855)

### DIFF
--- a/.changeset/t9932-summary-flag.md
+++ b/.changeset/t9932-summary-flag.md
@@ -1,0 +1,6 @@
+---
+id: t9932-summary-flag
+tasks: [T9932]
+kind: feat
+summary: Add --summary flag for cleo show + cleo list: render 1 line per record (<id> [<status>] <title-truncated-60>)
+---

--- a/packages/cleo/src/cli/commands/__tests__/summary-flag.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/summary-flag.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for the `--summary` flag (T9932 · Saga T9855 · E9.5).
+ *
+ * Two layers:
+ *  1. {@link renderSummary} direct — representative envelope shapes
+ *     (single-task `cleo show`, list of tasks `cleo list`, generic SDK
+ *     ListResponse, bare id payloads).
+ *  2. `cliOutput` precedence — confirm `--summary` composes with the four
+ *     `--output` modes from T9930 per the precedence rules in
+ *     `summary-context.ts`:
+ *       `--field`           > `--output non-envelope` > `--summary`
+ *
+ * @task T9932
+ * @epic T9855
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setFieldContext } from '../../field-context.js';
+import { setFormatContext } from '../../format-context.js';
+import { setOutputMode } from '../../output-context.js';
+import { cliOutput } from '../../renderers/index.js';
+import { renderSummary } from '../../renderers/output-mode.js';
+import { setSummaryMode } from '../../summary-context.js';
+
+// ---------------------------------------------------------------------------
+// renderSummary — direct
+// ---------------------------------------------------------------------------
+
+describe('renderSummary — single record', () => {
+  it('renders a single-task envelope ({task: {id, status, title}})', () => {
+    const out = renderSummary({
+      task: { id: 'T9932', status: 'in_progress', title: 'Summary flag' },
+    });
+    expect(out.text).toBe('T9932 [in_progress] Summary flag');
+  });
+
+  it('renders a bare record envelope ({id, status, title})', () => {
+    const out = renderSummary({ id: 'S-42', status: 'pending', title: 'Bare' });
+    expect(out.text).toBe('S-42 [pending] Bare');
+  });
+
+  it('uses empty brackets when status is missing', () => {
+    const out = renderSummary({ task: { id: 'T1', title: 'No status' } });
+    expect(out.text).toBe('T1 [] No status');
+  });
+
+  it('uses empty trailing slot when title is missing', () => {
+    const out = renderSummary({ task: { id: 'T1', status: 'done' } });
+    expect(out.text).toBe('T1 [done] ');
+  });
+});
+
+describe('renderSummary — list', () => {
+  it('renders one line per task in a {tasks: []} envelope', () => {
+    const out = renderSummary({
+      tasks: [
+        { id: 'T1', status: 'pending', title: 'first' },
+        { id: 'T2', status: 'in_progress', title: 'second' },
+        { id: 'T3', status: 'done', title: 'third' },
+      ],
+      total: 3,
+    });
+    expect(out.text).toBe('T1 [pending] first\nT2 [in_progress] second\nT3 [done] third');
+  });
+
+  it('renders one line per item in a generic ListResponse ({items: []})', () => {
+    const out = renderSummary({
+      items: [
+        { id: 'A1', status: 'pending', title: 'alpha' },
+        { id: 'A2', status: 'done', title: 'beta' },
+      ],
+    });
+    expect(out.text).toBe('A1 [pending] alpha\nA2 [done] beta');
+  });
+
+  it('skips list entries that lack an id (consistent with --output id)', () => {
+    const out = renderSummary({
+      tasks: [
+        { id: 'T1', status: 'pending', title: 'first' },
+        { status: 'orphan', title: 'no-id' },
+        { id: 'T3', status: 'done', title: 'third' },
+      ],
+    });
+    expect(out.text).toBe('T1 [pending] first\nT3 [done] third');
+  });
+
+  it('returns "No rows." for an empty {tasks: []}', () => {
+    const out = renderSummary({ tasks: [] });
+    expect(out.text).toBe('No rows.');
+  });
+
+  it('returns "No rows." when no rows in a list survive id-filtering', () => {
+    const out = renderSummary({
+      tasks: [{ status: 'orphan', title: 'a' }, { title: 'b' }],
+    });
+    expect(out.text).toBe('No rows.');
+  });
+});
+
+describe('renderSummary — title truncation', () => {
+  it('truncates titles longer than 60 chars with a trailing ellipsis', () => {
+    const longTitle = 'x'.repeat(80);
+    const out = renderSummary({ task: { id: 'T1', status: 'pending', title: longTitle } });
+    expect(out.text).not.toContain(longTitle);
+    expect(out.text).toContain('…');
+    // Per renderSummaryRow contract: `<id> [<status>] <title-truncated-60>`.
+    // truncate keeps max-1 chars + '…' when shortened, so the title cell is
+    // exactly 60 chars wide (59 'x' + '…').
+    const expectedTitleCell = 'x'.repeat(59) + '…';
+    expect(out.text).toBe(`T1 [pending] ${expectedTitleCell}`);
+  });
+
+  it('leaves titles of exactly 60 chars untouched (no ellipsis)', () => {
+    const sixtyChar = 'y'.repeat(60);
+    const out = renderSummary({ task: { id: 'T1', status: 'done', title: sixtyChar } });
+    expect(out.text).toBe(`T1 [done] ${sixtyChar}`);
+    expect(out.text).not.toContain('…');
+  });
+});
+
+describe('renderSummary — unrecognised shapes', () => {
+  it('returns empty text for an object with no id / tasks / items / task key', () => {
+    const out = renderSummary({ foo: 'bar', count: 7 });
+    expect(out.text).toBe('');
+  });
+
+  it('returns empty text for null', () => {
+    expect(renderSummary(null).text).toBe('');
+  });
+
+  it('returns empty text for primitive data', () => {
+    expect(renderSummary('a-string').text).toBe('');
+    expect(renderSummary(42).text).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cliOutput precedence — confirm --summary composes with --output modes
+// ---------------------------------------------------------------------------
+
+describe('cliOutput — --summary precedence with --output modes', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    // JSON format keeps the render path predictable (no human chrome).
+    setFormatContext({ format: 'json', source: 'default', quiet: false });
+    setFieldContext({ mvi: 'minimal', mviSource: 'default', expectsCustomMvi: false });
+    setOutputMode('envelope');
+    setSummaryMode(false);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    setOutputMode('envelope');
+    setSummaryMode(false);
+  });
+
+  function captured(): string {
+    return stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+  }
+
+  it('--summary alone renders 1-line-per-record (envelope mode default)', () => {
+    setSummaryMode(true);
+    cliOutput(
+      { task: { id: 'T9932', status: 'in_progress', title: 'Summary flag' } },
+      { command: 'show' },
+    );
+    expect(captured()).toBe('T9932 [in_progress] Summary flag\n');
+  });
+
+  it('--summary list emits one line per task', () => {
+    setSummaryMode(true);
+    cliOutput(
+      {
+        tasks: [
+          { id: 'T1', status: 'pending', title: 'first' },
+          { id: 'T2', status: 'done', title: 'second' },
+        ],
+        total: 2,
+      },
+      { command: 'list' },
+    );
+    expect(captured()).toBe('T1 [pending] first\nT2 [done] second\n');
+  });
+
+  it('--summary + --output silent → silent wins (no stdout)', () => {
+    setSummaryMode(true);
+    setOutputMode('silent');
+    cliOutput(
+      { task: { id: 'T9932', status: 'pending', title: 'Summary flag' } },
+      { command: 'show' },
+    );
+    expect(captured()).toBe('');
+  });
+
+  it('--summary + --output count → count wins (numeric output)', () => {
+    setSummaryMode(true);
+    setOutputMode('count');
+    cliOutput({ tasks: [{ id: 'T1' }, { id: 'T2' }, { id: 'T3' }], total: 3 }, { command: 'list' });
+    expect(captured()).toBe('3\n');
+  });
+
+  it('--summary + --output id → id wins (one id per line)', () => {
+    setSummaryMode(true);
+    setOutputMode('id');
+    cliOutput(
+      {
+        tasks: [
+          { id: 'T1', title: 'a' },
+          { id: 'T2', title: 'b' },
+        ],
+      },
+      { command: 'list' },
+    );
+    expect(captured()).toBe('T1\nT2\n');
+  });
+
+  it('--summary + --output table → table wins (full ASCII table)', () => {
+    setSummaryMode(true);
+    setOutputMode('table');
+    cliOutput(
+      { tasks: [{ id: 'T1', status: 'pending', priority: 'high', title: 'first' }] },
+      { command: 'list' },
+    );
+    const out = captured();
+    // Table renderer emits a header line with all four columns.
+    expect(out).toContain('id');
+    expect(out).toContain('status');
+    expect(out).toContain('priority');
+    expect(out).toContain('title');
+    expect(out).toContain('T1');
+    // NOT the summary 1-line shape.
+    expect(out).not.toBe('T1 [pending] first\n');
+  });
+});
+
+describe('cliOutput — --summary + --field precedence', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    setFormatContext({ format: 'json', source: 'default', quiet: false });
+    setFieldContext({ mvi: 'minimal', mviSource: 'default', expectsCustomMvi: false });
+    setOutputMode('envelope');
+    setSummaryMode(false);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    setFieldContext({ mvi: 'minimal', mviSource: 'default', expectsCustomMvi: false });
+    setSummaryMode(false);
+  });
+
+  it('--field wins over --summary (single-field scalar)', () => {
+    setSummaryMode(true);
+    setFieldContext({
+      mvi: 'minimal',
+      mviSource: 'default',
+      expectsCustomMvi: false,
+      field: 'title',
+    });
+    cliOutput(
+      { task: { id: 'T9932', status: 'in_progress', title: 'Summary flag' } },
+      { command: 'show' },
+    );
+    const out = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    // --field extraction emits just the scalar, NOT the summary 1-liner.
+    expect(out).toBe('Summary flag\n');
+  });
+});

--- a/packages/cleo/src/cli/commands/list.ts
+++ b/packages/cleo/src/cli/commands/list.ts
@@ -38,6 +38,12 @@ const listArgs = {
     type: 'boolean',
     description: 'Alias for --verbose. T9922.',
   },
+  // T9932 — 1-line-per-record summary render. Global flag; parsed by cli/index.ts.
+  summary: {
+    type: 'boolean',
+    description:
+      'Render each task as a single line "<id> [<status>] <title-truncated-60>". Composes with --output: --output {id|table|count|silent} wins. T9932.',
+  },
 } as const;
 
 /**

--- a/packages/cleo/src/cli/commands/show.ts
+++ b/packages/cleo/src/cli/commands/show.ts
@@ -42,6 +42,12 @@ export const showCommand = defineCommand({
       type: 'boolean',
       description: 'Alias for --verbose. T9922.',
     },
+    // T9932 — 1-line summary render. Global flag; parsed by cli/index.ts.
+    summary: {
+      type: 'boolean',
+      description:
+        'Render the task as a single line "<id> [<status>] <title-truncated-60>". Composes with --output: --output {id|table|count|silent} wins. T9932.',
+    },
   },
   async run({ args }) {
     await dispatchFromCli(

--- a/packages/cleo/src/cli/index.ts
+++ b/packages/cleo/src/cli/index.ts
@@ -60,6 +60,7 @@ import { resolveFormat } from './middleware/output-format.js';
 import { isOutputMode, type OutputMode, setOutputMode } from './output-context.js';
 import { setProjectionOptOut } from './projection-context.js';
 import { resolveSubCommandForHelp } from './resolve-subcommand.js';
+import { setSummaryMode } from './summary-context.js';
 
 function getPackageVersion(): string {
   const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '../../package.json');
@@ -133,6 +134,7 @@ async function startCli(): Promise<void> {
   const rawOpts: Record<string, unknown> = {};
   let verboseFlag = false;
   let outputModeRaw: string | undefined;
+  let summaryFlag = false;
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--json') rawOpts['json'] = true;
@@ -145,6 +147,8 @@ async function startCli(): Promise<void> {
     else if (arg === '--verbose' || arg === '--full') verboseFlag = true;
     // T9930 — global --output {envelope|id|table|count|silent} flag.
     else if (arg === '--output' && i + 1 < argv.length) outputModeRaw = argv[++i];
+    // T9932 — global --summary flag: 1-line-per-record re-render.
+    else if (arg === '--summary') summaryFlag = true;
   }
 
   const formatResolution = resolveFormat(rawOpts);
@@ -176,6 +180,10 @@ async function startCli(): Promise<void> {
     }
     setOutputMode(outputModeRaw as OutputMode);
   }
+
+  // T9932 — 1-line-per-record summary render. See summary-context.ts for the
+  // precedence rules (--field > --output non-envelope > --summary > defaults).
+  setSummaryMode(summaryFlag);
 
   // ---------------------------------------------------------------------------
   // Fast-path for help / version / no-args invocations.

--- a/packages/cleo/src/cli/index.ts
+++ b/packages/cleo/src/cli/index.ts
@@ -353,7 +353,7 @@ async function runMainWithLafsEnvelope(
     // Match citty's plain-text version output for backward compat with scripts
     // that grep for the version string. The `cleo --version` agent path was
     // already handled earlier in startCli via cliOutput.
-    process.stdout.write(`${version}\n`);
+    process.stdout.write(`${version}\n`); // stdout-write-allowed: legacy citty version compat (pre-existing, line-shifted by T9932 --summary flag wiring)
     process.exit(0);
   }
 

--- a/packages/cleo/src/cli/renderers/index.ts
+++ b/packages/cleo/src/cli/renderers/index.ts
@@ -104,9 +104,10 @@ import type { DispatchResponseMeta } from '../../dispatch/types.js';
 import { getFieldContext } from '../field-context.js';
 import { getFormatContext } from '../format-context.js';
 import { getOutputMode } from '../output-context.js';
+import { getSummaryMode } from '../summary-context.js';
 import { emitLafsViolation, LafsViolationError, validateLafsShape } from './lafs-validator.js';
 import { normalizeForHuman } from './normalizer.js';
-import { renderOutputMode } from './output-mode.js';
+import { renderOutputMode, renderSummary } from './output-mode.js';
 
 export type { RenderWavesMode, RenderWavesOptions } from '@cleocode/core';
 export { renderWaves };
@@ -335,6 +336,7 @@ export function cliOutput(data: unknown, opts: CliOutputOptions): void {
   const ctx = getFormatContext();
   const fieldCtx = getFieldContext();
   const outputMode = getOutputMode();
+  const summary = getSummaryMode();
 
   // T9930 — --output {id|table|count|silent} re-renders the canonical envelope
   // payload into the alternative shape the caller asked for. `--field` (T9929)
@@ -343,6 +345,19 @@ export function cliOutput(data: unknown, opts: CliOutputOptions): void {
   // `envelope` mode (default) falls through to the existing human/JSON paths.
   if (outputMode !== 'envelope' && !fieldCtx.field) {
     const out = renderOutputMode(outputMode, data);
+    if (out.text !== null && out.text.length > 0) {
+      process.stdout.write(out.text + '\n');
+    }
+    return;
+  }
+
+  // T9932 — --summary re-renders the envelope payload as 1 line per record:
+  // `<id> [<status>] <title-truncated-60>`. Precedence (see summary-context.ts):
+  //   `--field` wins (handled below)
+  //   `--output {id|table|count|silent}` wins (handled above)
+  //   `--summary` runs here, BEFORE the default JSON/human paths.
+  if (summary && !fieldCtx.field) {
+    const out = renderSummary(data);
     if (out.text !== null && out.text.length > 0) {
       process.stdout.write(out.text + '\n');
     }

--- a/packages/cleo/src/cli/renderers/output-mode.ts
+++ b/packages/cleo/src/cli/renderers/output-mode.ts
@@ -203,6 +203,74 @@ export interface OutputModeResult {
 }
 
 /**
+ * Render the dispatch envelope's `data` payload as one line per record.
+ *
+ * Format: `<id> [<status>] <title-truncated-60>` per row.
+ *
+ * Single-record envelopes (`{task: {...}}`, bare `{id, status, title}`) emit
+ * exactly one line. List-shaped envelopes (`{tasks: []}` / `{items: []}`)
+ * emit one line per element. Records missing `id` are skipped (consistent
+ * with `--output id`). Empty arrays return `'No rows.'` to match the
+ * `--output table` empty contract.
+ *
+ * Title is truncated to 60 chars (UTF-16 code units) with a trailing `…`
+ * when shortened — matches the cell cap used by `renderTableList`.
+ *
+ * @task T9932
+ * @epic T9855
+ */
+export function renderSummary(data: unknown): OutputModeResult {
+  if (data === null || typeof data !== 'object') {
+    return { text: '' };
+  }
+  const rec = data as Record<string, unknown>;
+
+  // 1. List shapes — {tasks: [...]} or {items: [...]} from SDK ListResponse.
+  const tasks = rec['tasks'];
+  if (Array.isArray(tasks)) {
+    return { text: renderSummaryList(tasks as unknown[]) };
+  }
+  const items = rec['items'];
+  if (Array.isArray(items)) {
+    return { text: renderSummaryList(items as unknown[]) };
+  }
+
+  // 2. Single nested task ({task: {id, status, title}}) — e.g. `cleo show`.
+  const task = rec['task'];
+  if (task && typeof task === 'object') {
+    return { text: renderSummaryRow(task as Record<string, unknown>) };
+  }
+
+  // 3. Bare record (`{id, status, title}`).
+  if (typeof rec['id'] === 'string') {
+    return { text: renderSummaryRow(rec) };
+  }
+
+  return { text: '' };
+}
+
+/** Render a single record line: `<id> [<status>] <title-truncated-60>`. */
+function renderSummaryRow(record: Record<string, unknown>): string {
+  const id = typeof record['id'] === 'string' ? record['id'] : '';
+  const status = typeof record['status'] === 'string' ? record['status'] : '';
+  const title = truncate(typeof record['title'] === 'string' ? record['title'] : '', 60);
+  return `${id} [${status}] ${title}`;
+}
+
+/** Render a list of records, one line each. Skips rows lacking an id. */
+function renderSummaryList(rows: unknown[]): string {
+  if (rows.length === 0) return 'No rows.';
+  const lines: string[] = [];
+  for (const row of rows) {
+    if (!row || typeof row !== 'object') continue;
+    const rec = row as Record<string, unknown>;
+    if (typeof rec['id'] !== 'string') continue;
+    lines.push(renderSummaryRow(rec));
+  }
+  return lines.length === 0 ? 'No rows.' : lines.join('\n');
+}
+
+/**
  * Re-render a successful dispatch envelope's `data` payload into the
  * shape requested by the `--output` flag.
  *

--- a/packages/cleo/src/cli/summary-context.ts
+++ b/packages/cleo/src/cli/summary-context.ts
@@ -1,0 +1,48 @@
+/**
+ * CLI summary-flag resolution context.
+ *
+ * Singleton that holds the resolved `--summary` flag for the current CLI
+ * invocation. Set once in the global flag parser in `cli/index.ts`; read by
+ * `cliOutput()` in `renderers/index.ts` to switch the render path AFTER
+ * dispatch has produced the canonical envelope.
+ *
+ * Mirrors the format-context.ts / field-context.ts / output-context.ts pattern.
+ *
+ * Shape
+ * -----
+ * When `--summary` is passed, list-shaped and single-record envelopes are
+ * re-rendered as one line per record:
+ *
+ *   `<id> [<status>] <title-truncated-60>`
+ *
+ * Precedence (highest to lowest)
+ * ------------------------------
+ * 1. `--field <pointer>` (T9929)        — single-field scalar projection wins.
+ * 2. `--output {id|table|count|silent}` (T9930) — non-envelope modes win.
+ * 3. `--summary` (T9932)                — 1-line-per-record re-render.
+ * 4. Default `--output envelope` + format(json|human) — canonical paths.
+ *
+ * Rationale: `--summary` is a textual alternate render of the same envelope,
+ * so the more specialised `--output` modes (which already short-circuit to
+ * their own machine shapes) take precedence. `--field` always wins because
+ * it short-circuits to a scalar before any other render path runs.
+ *
+ * @task T9932
+ * @epic T9855
+ */
+
+/** Resolved `--summary` flag for the current CLI invocation. */
+let currentSummary = false;
+
+/**
+ * Set the resolved `--summary` flag for this CLI invocation.
+ * Called once from the global flag parser in `cli/index.ts`.
+ */
+export function setSummaryMode(on: boolean): void {
+  currentSummary = on;
+}
+
+/** Get the current resolved `--summary` flag. */
+export function getSummaryMode(): boolean {
+  return currentSummary;
+}


### PR DESCRIPTION
## Summary

Add a global `--summary` flag that re-renders the canonical envelope payload as one line per record:

```
<id> [<status>] <title-truncated-60>
```

Wired into `cleo show` (single-record envelopes) and `cleo list` (list-shaped `{tasks: []}` / `{items: []}` envelopes); also handles bare `{id, status, title}` payloads. Title is truncated to 60 chars with a trailing ellipsis when shortened — matches the cell cap used by `--output table`.

### Precedence (highest to lowest)

1. `--field` (T9929) — single-field scalar wins
2. `--output {id|table|count|silent}` (T9930) — non-envelope modes win
3. `--summary` (T9932) — 1-line-per-record render
4. Default — JSON envelope / human renderer

The new singleton lives in `src/cli/summary-context.ts` mirroring the existing `output-context.ts` pattern; the render logic is co-located with `renderOutputMode` in `src/cli/renderers/output-mode.ts` (`renderSummary` export).

### Files

- `packages/cleo/src/cli/summary-context.ts` (new) — singleton + precedence doc
- `packages/cleo/src/cli/renderers/output-mode.ts` — `renderSummary` + helpers
- `packages/cleo/src/cli/renderers/index.ts` — wire `--summary` path into `cliOutput`
- `packages/cleo/src/cli/index.ts` — global flag parser
- `packages/cleo/src/cli/commands/show.ts` — surface flag in `--help`
- `packages/cleo/src/cli/commands/list.ts` — surface flag in `--help`
- `packages/cleo/src/cli/commands/__tests__/summary-flag.test.ts` (new) — 21 tests

## Test plan

- [x] `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/cli/commands/__tests__/summary-flag.test.ts` — 21/21 pass
- [x] `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/cli/commands/__tests__/output-mode.test.ts` — 18/18 pass (no regression)
- [x] `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/cli/commands/__tests__/field-flag.test.ts packages/cleo/src/cli/commands/__tests__/output-mode.test.ts packages/cleo/src/cli/commands/__tests__/summary-flag.test.ts` — 76/76 pass
- [x] `pnpm run build` — clean
- [x] `pnpm biome check` on touched files — clean

@task T9932
@epic T9855

🤖 Generated with [Claude Code](https://claude.com/claude-code)