### PR TITLE
feat(cleo): --quiet flag (T9933 / Saga T9855)

### DIFF
--- a/.changeset/t9933-quiet-flag-stderr-policy.md
+++ b/.changeset/t9933-quiet-flag-stderr-policy.md
@@ -1,0 +1,6 @@
+---
+id: t9933-quiet-flag-stderr-policy
+tasks: [T9933]
+kind: feat
+summary: Add global --quiet flag with centralized stderr-suppression policy (logger silent, progress no-op)
+---

--- a/packages/cleo/src/__tests__/quiet-flag.test.ts
+++ b/packages/cleo/src/__tests__/quiet-flag.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the global `--quiet` flag and the stderr-suppression policy.
+ *
+ * Verifies:
+ *   1. `quietStderrWrite` honors the format-context `quiet` flag.
+ *   2. The core logger fallback respects `setLoggerQuiet(true)`.
+ *   3. The format-context `isQuiet()` propagates through the LAFS resolver.
+ *
+ * @task T9933
+ * @epic Saga T9855
+ */
+
+import { resolveOutputFormat } from '@cleocode/lafs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getLogger, isLoggerQuiet, setLoggerQuiet } from '../../../core/src/logger.js';
+import { isQuiet, setFormatContext } from '../cli/format-context.js';
+import { ProgressTracker } from '../cli/progress.js';
+import { quietStderrWrite } from '../cli/quiet-stderr.js';
+
+describe('--quiet flag — format-context propagation', () => {
+  afterEach(() => {
+    // Reset to safe defaults so cross-suite tests don't see leaked state.
+    setFormatContext({ format: 'json', source: 'default', quiet: false });
+    setLoggerQuiet(false);
+  });
+
+  it('LAFS resolveOutputFormat carries quiet:true when the input flag is set', () => {
+    const resolution = resolveOutputFormat({ jsonFlag: true, quiet: true });
+    expect(resolution.quiet).toBe(true);
+    expect(resolution.format).toBe('json');
+  });
+
+  it('LAFS resolveOutputFormat defaults quiet to false', () => {
+    const resolution = resolveOutputFormat({ jsonFlag: true });
+    expect(resolution.quiet).toBe(false);
+  });
+
+  it('isQuiet() reflects the format-context resolution', () => {
+    setFormatContext({ format: 'json', source: 'flag', quiet: true });
+    expect(isQuiet()).toBe(true);
+
+    setFormatContext({ format: 'human', source: 'flag', quiet: false });
+    expect(isQuiet()).toBe(false);
+  });
+});
+
+describe('--quiet flag — quietStderrWrite helper', () => {
+  let capturedStderr: string;
+  let originalWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    capturedStderr = '';
+    originalWrite = process.stderr.write.bind(process.stderr);
+    // Patch stderr.write to capture without printing. Cast through unknown
+    // because the signature has 3 overloads — we only need the string path.
+    (process.stderr as unknown as { write: (chunk: string) => boolean }).write = (
+      chunk: string,
+    ) => {
+      capturedStderr += chunk;
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    (process.stderr as unknown as { write: typeof originalWrite }).write = originalWrite;
+    setFormatContext({ format: 'json', source: 'default', quiet: false });
+  });
+
+  it('writes to stderr when quiet=false', () => {
+    setFormatContext({ format: 'human', source: 'flag', quiet: false });
+    quietStderrWrite('progress: doing work\n');
+    expect(capturedStderr).toBe('progress: doing work\n');
+  });
+
+  it('suppresses stderr when quiet=true', () => {
+    setFormatContext({ format: 'json', source: 'flag', quiet: true });
+    quietStderrWrite('progress: doing work\n');
+    expect(capturedStderr).toBe('');
+  });
+
+  it('round-trips many writes under quiet=true with zero output', () => {
+    setFormatContext({ format: 'json', source: 'flag', quiet: true });
+    for (let i = 0; i < 50; i++) {
+      quietStderrWrite(`line ${i}\n`);
+    }
+    expect(capturedStderr).toBe('');
+  });
+});
+
+describe('--quiet flag — core logger fallback', () => {
+  afterEach(() => {
+    setLoggerQuiet(false);
+  });
+
+  it('isLoggerQuiet() reflects setLoggerQuiet()', () => {
+    expect(isLoggerQuiet()).toBe(false);
+    setLoggerQuiet(true);
+    expect(isLoggerQuiet()).toBe(true);
+    setLoggerQuiet(false);
+    expect(isLoggerQuiet()).toBe(false);
+  });
+
+  it('fallback logger drops warn-level writes under quiet mode', () => {
+    setLoggerQuiet(true);
+    const logger = getLogger('test-subsystem-quiet');
+    // pino exposes `level` on every logger; quiet mode forces 'silent'.
+    expect(logger.level).toBe('silent');
+  });
+
+  it('fallback logger emits at warn level when quiet=false (default)', () => {
+    setLoggerQuiet(false);
+    const logger = getLogger('test-subsystem-loud');
+    expect(logger.level).toBe('warn');
+  });
+});
+
+describe('--quiet flag — ProgressTracker stderr gating', () => {
+  let capturedStderr: string;
+  let originalWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    capturedStderr = '';
+    originalWrite = process.stderr.write.bind(process.stderr);
+    (process.stderr as unknown as { write: (chunk: string) => boolean }).write = (
+      chunk: string,
+    ) => {
+      capturedStderr += chunk;
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    (process.stderr as unknown as { write: typeof originalWrite }).write = originalWrite;
+    setFormatContext({ format: 'json', source: 'default', quiet: false });
+  });
+
+  it('emits step + complete lines when enabled and quiet=false', () => {
+    setFormatContext({ format: 'human', source: 'flag', quiet: false });
+    const tracker = new ProgressTracker({
+      enabled: true,
+      prefix: 'TEST',
+      steps: ['First', 'Second'],
+    });
+    tracker.start();
+    tracker.step(0);
+    tracker.complete('done');
+    expect(capturedStderr).toContain('TEST');
+    expect(capturedStderr).toContain('First');
+    expect(capturedStderr).toContain('done');
+  });
+
+  it('suppresses every progress line when quiet=true even if enabled', () => {
+    setFormatContext({ format: 'human', source: 'flag', quiet: true });
+    const tracker = new ProgressTracker({
+      enabled: true,
+      prefix: 'TEST',
+      steps: ['First', 'Second'],
+    });
+    tracker.start();
+    tracker.step(0);
+    tracker.step(1);
+    tracker.complete('done');
+    tracker.error('oops');
+    expect(capturedStderr).toBe('');
+  });
+});

--- a/packages/cleo/src/cli/index.ts
+++ b/packages/cleo/src/cli/index.ts
@@ -201,6 +201,14 @@ async function startCli(): Promise<void> {
   }
 
   if (!isHelpOrVersion) {
+    // T9933 — propagate --quiet to the logger subsystem BEFORE startup
+    // maintenance so the pino fallback logger emits at level=silent instead
+    // of writing WARN-level entries to stderr during migration checks etc.
+    // Only runs on the non-fast-path; --help/--version with --quiet stays cheap.
+    if (rawOpts['quiet'] === true) {
+      const { setLoggerQuiet } = await import('@cleocode/core/internal');
+      setLoggerQuiet(true);
+    }
     await runStartupMaintenance();
   }
 

--- a/packages/cleo/src/cli/progress.ts
+++ b/packages/cleo/src/cli/progress.ts
@@ -6,6 +6,7 @@
  */
 
 import { stderr } from 'node:process';
+import { isQuiet } from './format-context.js';
 
 export interface ProgressOptions {
   /** Whether to show progress (true for human mode, false for JSON mode) */
@@ -35,7 +36,7 @@ export class ProgressTracker {
    * Start the progress tracker.
    */
   start(): void {
-    if (!this.enabled) return;
+    if (!this.enabled || isQuiet()) return;
     this.currentStep = 0;
     stderr.write(`\n${this.prefix}: Starting...\n`);
   }
@@ -44,7 +45,7 @@ export class ProgressTracker {
    * Update to a specific step.
    */
   step(index: number, message?: string): void {
-    if (!this.enabled) return;
+    if (!this.enabled || isQuiet()) return;
     this.currentStep = index;
     const stepName = this.steps[index] ?? message ?? 'Working...';
     const progress = `[${index + 1}/${this.totalSteps}]`;
@@ -67,7 +68,7 @@ export class ProgressTracker {
    * one JSON object per CLI invocation (ADR-039 / T927).
    */
   complete(summary?: string): void {
-    if (!this.enabled) return;
+    if (!this.enabled || isQuiet()) return;
     if (summary) {
       stderr.write(`\n${this.prefix}: \u2713 ${summary}\n\n`);
     } else {
@@ -79,7 +80,7 @@ export class ProgressTracker {
    * Report an error.
    */
   error(message: string): void {
-    if (!this.enabled) return;
+    if (!this.enabled || isQuiet()) return;
     stderr.write(`\n${this.prefix}: \u2717 ${message}\n\n`);
   }
 }
@@ -114,7 +115,7 @@ export class Spinner {
    * Start the spinner.
    */
   start(): void {
-    if (!this.enabled) return;
+    if (!this.enabled || isQuiet()) return;
     this.timer = setInterval(() => {
       const frame = this.frames[this.frameIndex];
       stderr.write(`\r${frame} ${this.message}`);
@@ -126,7 +127,7 @@ export class Spinner {
    * Stop the spinner.
    */
   stop(finalMessage?: string): void {
-    if (!this.enabled) return;
+    if (!this.enabled || isQuiet()) return;
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;

--- a/packages/cleo/src/cli/quiet-stderr.ts
+++ b/packages/cleo/src/cli/quiet-stderr.ts
@@ -1,0 +1,28 @@
+/**
+ * Quiet-aware stderr helper.
+ *
+ * Single SSoT for advisory / progress / warning stderr writes that MUST be
+ * suppressed under `--quiet`. Critical errors that cause non-zero exit
+ * continue to use `process.stderr.write` directly — they are the one signal
+ * `--quiet` MUST NOT silence.
+ *
+ * @task T9933
+ * @epic Saga T9855
+ */
+
+import { isQuiet } from './format-context.js';
+
+/**
+ * Write advisory text to stderr unless `--quiet` is active.
+ *
+ * Use for: progress lines, deprecation hints, "did you mean", routing logs,
+ * pino fallback warnings, and any other diagnostic noise that an operator
+ * piping JSON output expects to see absent under `--quiet`.
+ *
+ * Do NOT use for: fatal error envelopes (those go through `cliError`) or
+ * the LAFS stdout envelope itself.
+ */
+export function quietStderrWrite(text: string): void {
+  if (isQuiet()) return;
+  process.stderr.write(text);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -318,7 +318,14 @@ export { ensureInitialized, getVersion, initProject } from './init.js';
 export { checkSchema, validateAgainstSchema } from './json-schema-validator.js';
 export type { LoggerConfig } from './logger.js';
 // Logger
-export { closeLogger, getLogDir, getLogger, initLogger } from './logger.js';
+export {
+  closeLogger,
+  getLogDir,
+  getLogger,
+  initLogger,
+  isLoggerQuiet,
+  setLoggerQuiet,
+} from './logger.js';
 export type { FormatOptions } from './output.js';
 // Output formatting (LAFS envelope)
 export { drainWarnings, formatError, formatOutput, formatSuccess, pushWarning } from './output.js';

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -34,6 +34,36 @@ interface TransportStream {
 let rootLogger: pino.Logger | null = null;
 let currentLogDir: string | null = null;
 let currentTransport: TransportStream | null = null;
+let quietMode = false;
+
+/**
+ * Enable or disable quiet mode for the logger subsystem.
+ *
+ * When quiet=true:
+ *   - The stderr fallback `getLogger()` returns silent-level loggers.
+ *   - If the root logger is initialized, its level is set to 'silent'.
+ *
+ * Critical CLI errors that route through `cliError()` and `process.exit()`
+ * are emitted via direct stderr writes outside this subsystem and are NOT
+ * affected by quiet mode — see T9933 spec.
+ *
+ * @task T9933
+ */
+export function setLoggerQuiet(quiet: boolean): void {
+  quietMode = quiet;
+  if (quiet && rootLogger) {
+    rootLogger.level = 'silent';
+  }
+}
+
+/**
+ * Inspect the current quiet-mode flag. Exposed for tests + diagnostics.
+ *
+ * @task T9933
+ */
+export function isLoggerQuiet(): boolean {
+  return quietMode;
+}
 
 /**
  * Convert bytes to a human-readable size string for pino-roll.
@@ -139,10 +169,12 @@ export function initLogger(
  */
 export function getLogger(subsystem: string): pino.Logger {
   if (!rootLogger) {
-    // Fallback: stderr logger (stdout reserved for structured output)
+    // Fallback: stderr logger (stdout reserved for structured output).
+    // Under quiet mode (T9933), drop fallback warnings entirely so
+    // operators piping JSON output see clean stderr.
     return pino(
       {
-        level: 'warn',
+        level: quietMode ? 'silent' : 'warn',
         formatters: { level: (label: string) => ({ level: label.toUpperCase() }) },
       },
       pino.destination(2),


### PR DESCRIPTION
## Summary

Adds a centralized stderr-suppression policy for the global `--quiet` flag so that `cleo show T123 --quiet 2>&1 1>/dev/null` produces zero bytes on stderr — while critical errors that cause non-zero exit continue to reach stderr unchanged.

- **Logger fallback** — new `setLoggerQuiet(quiet)` / `isLoggerQuiet()` exports from `@cleocode/core`. When set, the pino fallback `getLogger()` (used before `initLogger` runs) emits at `level=silent` instead of WARN-to-stderr.
- **CLI bootstrap** — `packages/cleo/src/cli/index.ts` calls `setLoggerQuiet(true)` right before `runStartupMaintenance()` on the non-fast path when `--quiet` is set. Help/version remain on the fast path.
- **Progress + Spinner** — `packages/cleo/src/cli/progress.ts` now gates every stderr write on `!isQuiet()` in addition to the existing `enabled` flag. Callers don't need to change.
- **SSoT helper** — new `packages/cleo/src/cli/quiet-stderr.ts` exports `quietStderrWrite(text)` for any future advisory output that should respect `--quiet`.

The `--quiet` flag itself was already parsed by `startCli()` and threaded into `FormatContext.quiet` via the LAFS resolver — no flag-parser changes needed at this layer.

## Test plan

- [x] `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/__tests__/quiet-flag.test.ts` → 11/11 pass
- [x] `pnpm exec vitest run --config packages/core/vitest.config.ts src/__tests__/logger.test.ts` (from `packages/core`) → 5/5 pass
- [x] `pnpm run build` → all packages build green
- [x] `pnpm biome check ...` → no fixes applied on touched files
- [x] Manual smoke: `node packages/cleo/bin/cleo.js show T9933 --quiet 2>/tmp/err 1>/dev/null && wc -c /tmp/err` → **0 bytes**
- [x] Manual smoke: `node packages/cleo/bin/cleo.js show T9933 --quiet` stdout still parses as a valid LAFS envelope with `success=true`

## Acceptance criteria

- [x] AC1 — global `--quiet` flag parser (was already present; verified end-to-end)
- [x] AC2 — pino loggers respect quiet (fallback level → silent; root logger level → silent on `setLoggerQuiet(true)`)
- [x] AC3 — `cleo show T123 --quiet 2>&1 1>/dev/null` is empty
- [x] AC4 — critical errors still go to stderr (helper checks `isQuiet()`, the existing `cliError`/`process.stderr.write` paths for fatal envelopes are unchanged)
- [x] AC5 — tests in `packages/cleo/src/__tests__/quiet-flag.test.ts`

Refs: Saga T9855 / E9.6 / T9933.