### PR TITLE
fix(orchestrate): bootstrap saga T9862 — spawn timeout 60→180s + --orchestrator-defer flag (T9823 + T10430)

### DIFF
--- a/.changeset/T9823-bootstrap.md
+++ b/.changeset/T9823-bootstrap.md
@@ -1,0 +1,19 @@
+---
+"@cleocode/cleo": patch
+"@cleocode/core": patch
+"@cleocode/worktree": patch
+---
+
+fix(orchestrate): bump spawn timeout 60s→180s + wire --orchestrator-defer CLI flag
+
+T9823: large-repo `git worktree add` (10k files, ~95s) exceeded both
+`DEFAULT_GIT_TIMEOUT_MS` and `SPAWN_BUDGET_MS` (60s each). Bumped both
+to 180s — still bounds wedged children, accommodates real workloads.
+
+T10430: error hint for `E_ATOMICITY_NO_SCOPE` instructed orchestrators to use
+`--scope orchestrator-defer`, but `--scope` maps to sparse-checkout
+(`spawnScope`), not atomicity. Added a new `--orchestrator-defer` boolean
+flag that flows through `atomicityScope` → `composeSpawnPayload` scope →
+`checkAtomicity` waiver. Error hint updated to reference the real flag.
+
+Saga: T9862

--- a/packages/cleo/src/cli/commands/orchestrate.ts
+++ b/packages/cleo/src/cli/commands/orchestrate.ts
@@ -360,6 +360,13 @@ const spawnCommand = defineCommand({
         'Example: --scope packages/cleo creates a worktree with only that subtree checked out. ' +
         'Reduces disk usage and checkout time for tasks scoped to a single package.',
     },
+    'orchestrator-defer': {
+      type: 'boolean',
+      description:
+        'T9214 atomicity waiver: defer worker file-scope declaration to commit time. ' +
+        'Tier-1+ orchestrators only — records auditable atomicity_waiver in the spawn manifest. ' +
+        'Bypasses E_ATOMICITY_NO_SCOPE for worker tasks without explicit AC.files.',
+    },
   },
   async run({ args }) {
     // T892: --tier accepts auto|0|1|2. 'auto' (and undefined) are forwarded
@@ -372,6 +379,13 @@ const spawnCommand = defineCommand({
         tier = parsed;
       }
     }
+    // T10430: --orchestrator-defer flows through as atomicityScope so the
+    // engine can route the waiver into composeSpawnPayload → checkAtomicity.
+    // Distinct from --scope (sparse-checkout): atomicityScope governs the
+    // file-scope gate, spawnScope governs the worktree's checked-out tree.
+    const atomicityScope: 'orchestrator-defer' | undefined = args['orchestrator-defer']
+      ? 'orchestrator-defer'
+      : undefined;
     await dispatchFromCli(
       'mutate',
       'orchestrate',
@@ -382,6 +396,7 @@ const spawnCommand = defineCommand({
         tier,
         noWorktree: args['no-worktree'] === true,
         ...(args.scope ? { spawnScope: args.scope } : {}),
+        ...(atomicityScope ? { atomicityScope } : {}),
       },
       { command: 'orchestrate' },
     );

--- a/packages/cleo/src/dispatch/domains/__tests__/orchestrate.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/orchestrate.test.ts
@@ -154,3 +154,81 @@ describe('OrchestrateHandler.mutate("worktree.complete") — ADR-062 merge wirin
     expect(result.error?.code).toBe('E_INVALID_INPUT');
   });
 });
+
+// ---------------------------------------------------------------------------
+// spawn dispatch — T10430 --orchestrator-defer atomicity waiver wiring
+// ---------------------------------------------------------------------------
+
+describe('OrchestrateHandler.mutate("spawn") — T10430 atomicityScope wiring', () => {
+  let handler: OrchestrateHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new OrchestrateHandler();
+  });
+
+  it('forwards atomicityScope="orchestrator-defer" to orchestrateSpawn (T10430)', async () => {
+    // The dispatch layer imports orchestrateSpawn from '../lib/engine.js' (see
+    // the top-level vi.mock at line 3 — every engine helper is a vi.fn).
+    const engine = await import('../../lib/engine.js');
+    const spawnSpy = vi.mocked(engine.orchestrateSpawn);
+    spawnSpy.mockResolvedValue({
+      success: true,
+      data: {
+        taskId: 'T10430',
+        prompt: 'spawn prompt',
+        atomicity: {
+          allowed: true,
+          atomicity_waiver: 'orchestrator-scope-tier1-call',
+        },
+      },
+    });
+
+    const result = await handler.mutate('spawn', {
+      taskId: 'T10430',
+      atomicityScope: 'orchestrator-defer',
+    });
+
+    expect(result.success).toBe(true);
+    // The dispatch must forward the waiver as the seventh positional arg of
+    // orchestrateSpawn (after taskId, protocolType, projectRoot, tier,
+    // noWorktree, spawnScope).
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const callArgs = spawnSpy.mock.calls[0];
+    expect(callArgs?.[0]).toBe('T10430');
+    expect(callArgs?.[6]).toBe('orchestrator-defer');
+  });
+
+  it('rejects unknown atomicityScope values (defense-in-depth contract narrowing)', async () => {
+    const engine = await import('../../lib/engine.js');
+    const spawnSpy = vi.mocked(engine.orchestrateSpawn);
+    spawnSpy.mockResolvedValue({
+      success: true,
+      data: { taskId: 'T10430', prompt: 'spawn prompt', atomicity: { allowed: true } },
+    });
+
+    await handler.mutate('spawn', {
+      taskId: 'T10430',
+      // Anything other than the literal 'orchestrator-defer' MUST be dropped
+      // so a hostile caller cannot widen the waiver contract.
+      atomicityScope: 'arbitrary-string',
+    });
+
+    const callArgs = spawnSpy.mock.calls[0];
+    expect(callArgs?.[6]).toBeUndefined();
+  });
+
+  it('omits atomicityScope when the CLI did not pass --orchestrator-defer', async () => {
+    const engine = await import('../../lib/engine.js');
+    const spawnSpy = vi.mocked(engine.orchestrateSpawn);
+    spawnSpy.mockResolvedValue({
+      success: true,
+      data: { taskId: 'T10430', prompt: 'spawn prompt', atomicity: { allowed: true } },
+    });
+
+    await handler.mutate('spawn', { taskId: 'T10430' });
+
+    const callArgs = spawnSpy.mock.calls[0];
+    expect(callArgs?.[6]).toBeUndefined();
+  });
+});

--- a/packages/cleo/src/dispatch/domains/orchestrate.ts
+++ b/packages/cleo/src/dispatch/domains/orchestrate.ts
@@ -152,6 +152,14 @@ interface OrchestrateSpawnParams {
   noWorktree?: boolean;
   /** T9807 — sparse-checkout scope prefix (e.g. `packages/cleo`). */
   spawnScope?: string;
+  /**
+   * T9214 / T10430 — atomicity waiver flowing into `composeSpawnPayload`'s
+   * `scope` option. When `'orchestrator-defer'`, the worker file-scope gate
+   * grants the spawn and records `atomicity_waiver:
+   * 'orchestrator-scope-tier1-call'` instead of returning `E_ATOMICITY_NO_SCOPE`.
+   * Distinct from {@link spawnScope} (sparse-checkout cone path).
+   */
+  atomicityScope?: 'orchestrator-defer';
 }
 
 interface OrchestrateHandoffParams {
@@ -396,6 +404,7 @@ async function orchestrateSpawnOp(params: OrchestrateSpawnParams) {
     params.tier,
     params.noWorktree,
     params.spawnScope,
+    params.atomicityScope,
   );
 }
 
@@ -806,12 +815,20 @@ export class OrchestrateHandler implements DomainHandler {
           const tierRaw = params.tier;
           const tier =
             tierRaw === 0 || tierRaw === 1 || tierRaw === 2 ? (tierRaw as 0 | 1 | 2) : undefined;
+          // T10430 — accept the atomicity-waiver flag through the gateway so
+          // the CLI's `--orchestrator-defer` reaches `checkAtomicity` via
+          // `composeSpawnPayload.scope`. Validate the literal value so an
+          // arbitrary string cannot widen the contract.
+          const atomicityScopeRaw = params.atomicityScope;
+          const atomicityScope: 'orchestrator-defer' | undefined =
+            atomicityScopeRaw === 'orchestrator-defer' ? 'orchestrator-defer' : undefined;
           const p: OrchestrateSpawnParams = {
             taskId: params.taskId as string,
             protocolType: params.protocolType as string | undefined,
             tier,
             noWorktree: params.noWorktree as boolean | undefined,
             spawnScope: params.spawnScope as string | undefined,
+            ...(atomicityScope ? { atomicityScope } : {}),
           };
           return wrapResult(await coreOps.spawn(p), 'mutate', 'orchestrate', operation, startTime);
         }

--- a/packages/core/src/orchestrate/__tests__/orchestrate-engine-composer.test.ts
+++ b/packages/core/src/orchestrate/__tests__/orchestrate-engine-composer.test.ts
@@ -186,6 +186,37 @@ describe('T932 — orchestrate-engine integration with composeSpawnPayload', () 
     expect(details?.atomicity?.allowed).toBe(false);
   });
 
+  it('T10430 — atomicityScope=orchestrator-defer waives E_ATOMICITY_NO_SCOPE for worker without files', async () => {
+    // Re-uses READY_WORKER_NO_SCOPE (T932WX) — a worker task with no AC.files.
+    // Without the waiver this spawn returns E_ATOMICITY_NO_SCOPE (verified by
+    // the test above). Passing atomicityScope='orchestrator-defer' through
+    // the seventh positional arg routes the waiver into composeSpawnPayload
+    // → checkAtomicity so the spawn is granted with an audit-trail waiver.
+    const result = await orchestrateSpawn(
+      'T932WX',
+      undefined,
+      TEST_ROOT,
+      undefined,
+      true, // noWorktree — keep the test hermetic
+      undefined, // spawnScope (sparse-checkout) — distinct from atomicityScope
+      'orchestrator-defer',
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      atomicity: {
+        allowed: boolean;
+        atomicity_waiver?: string;
+        meta?: { fileCount: number; hasScope: boolean };
+      };
+    };
+    expect(data.atomicity.allowed).toBe(true);
+    // The waiver reason is stamped on the spawn payload so the manifest entry
+    // remains auditable downstream.
+    expect(data.atomicity.atomicity_waiver).toBe('orchestrator-scope-tier1-call');
+    expect(data.atomicity.meta).toEqual({ fileCount: 0, hasScope: false });
+  });
+
   it('T1014 — epic spawn auto-promotes to role=lead, bypassing atomicity file-scope gate', async () => {
     // T932EP is type=epic with no files declared. Without the T1014 fix this
     // would return E_ATOMICITY_NO_SCOPE because the default resolved role is

--- a/packages/core/src/orchestrate/__tests__/spawn-supervisor.test.ts
+++ b/packages/core/src/orchestrate/__tests__/spawn-supervisor.test.ts
@@ -186,6 +186,27 @@ describe('runTimeoutCleanup — bounded auto-cleanup helper (T9545)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// SPAWN_BUDGET_MS — T9823 regression lock
+// ---------------------------------------------------------------------------
+
+describe('SPAWN_BUDGET_MS (T9823 regression lock)', () => {
+  it('is pinned at 180_000ms so large-repo `git worktree add` can complete', () => {
+    // The legacy 60s budget caused E_WORKTREE_PROVISION_FAILED on every spawn
+    // against the cleocode monorepo (10k+ files). T9823 bumped to 180s.
+    expect(SPAWN_BUDGET_MS).toBe(180_000);
+  });
+
+  it('is strictly larger than the legacy 60s budget that caused T9823', () => {
+    expect(SPAWN_BUDGET_MS).toBeGreaterThan(60_000);
+  });
+
+  it('mirrors DEFAULT_GIT_TIMEOUT_MS so per-subprocess + overall budgets stay aligned', async () => {
+    const { DEFAULT_GIT_TIMEOUT_MS } = await import('@cleocode/worktree');
+    expect(SPAWN_BUDGET_MS).toBe(DEFAULT_GIT_TIMEOUT_MS);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // orchestrateSpawn — happy path and timeout-with-cleanup
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/orchestrate/spawn-ops.ts
+++ b/packages/core/src/orchestrate/spawn-ops.ts
@@ -96,12 +96,16 @@ export type { EngineResult };
  * milliseconds. Enforced via an {@link AbortController} that races against
  * the spawn pipeline; on expiry an `E_TIMEOUT` envelope is returned.
  *
- * 60s mirrors `DEFAULT_GIT_TIMEOUT_MS` so the wrapper never fires before a
- * single bounded subprocess would have surfaced its own timeout error.
+ * 180s mirrors `DEFAULT_GIT_TIMEOUT_MS` so the wrapper never fires before a
+ * single bounded subprocess would have surfaced its own timeout error. The
+ * prior 60s budget caused every spawn on large-repo monorepos (10k+ files)
+ * to fail with `E_WORKTREE_PROVISION_FAILED` because `git worktree add`
+ * routinely exceeded 60s during cold checkout (T9823).
  *
  * @task T9545
+ * @task T9823
  */
-export const SPAWN_BUDGET_MS = 60_000;
+export const SPAWN_BUDGET_MS = 180_000;
 
 /**
  * Bounded budget for the timeout-cleanup pass (Saga T10176 / D010). Cleanup
@@ -477,6 +481,18 @@ export async function composeSpawnForTask(
      * @task T9226
      */
     spawnCloneExclude?: readonly string[];
+    /**
+     * T9214 / T10430 atomicity waiver. When `'orchestrator-defer'`, flows
+     * through to {@link composeSpawnPayload}'s `scope` option so the worker
+     * file-scope gate records an auditable `atomicity_waiver` rather than
+     * rejecting the spawn with `E_ATOMICITY_NO_SCOPE`. Distinct from
+     * `spawnCloneExclude` (worktree-tree filter) — this governs the
+     * file-scope gate only.
+     *
+     * @task T9214
+     * @task T10430
+     */
+    atomicityScope?: 'orchestrator-defer';
   } = {},
 ): Promise<SpawnPayload> {
   const accessor = await getTaskAccessor(root);
@@ -512,6 +528,10 @@ export async function composeSpawnForTask(
       worktreeBranch: options.worktreeBranch,
       conduitSubscription: options.conduitSubscription,
       spawnCloneExclude: options.spawnCloneExclude,
+      // T10430 — pass the atomicity waiver into the composer. When set to
+      // 'orchestrator-defer', checkAtomicity grants the spawn for a worker
+      // without declared files and stamps atomicity_waiver in the result.
+      ...(options.atomicityScope ? { scope: options.atomicityScope } : {}),
     });
   } finally {
     db.close();
@@ -957,10 +977,19 @@ export async function orchestrateSpawnExecute(
  * @param projectRoot - Optional project root path.
  * @param tier - Optional spawn tier (0=worker, 1=lead, 2=orchestrator).
  * @param noWorktree - If true, skip worktree provisioning.
+ * @param spawnScope - T9807 sparse-checkout cone path (governs the worktree's
+ *   checked-out tree). Distinct from `atomicityScope`.
+ * @param atomicityScope - T9214 / T10430 atomicity waiver. When
+ *   `'orchestrator-defer'`, the composer routes the waiver into
+ *   {@link composeSpawnPayload} so the worker file-scope gate grants the
+ *   spawn and records `atomicity_waiver: 'orchestrator-scope-tier1-call'`
+ *   instead of returning `E_ATOMICITY_NO_SCOPE`.
  * @returns Engine result with spawn prompt data.
  * @task T4478
  * @task T932
  * @task T9545
+ * @task T9214
+ * @task T10430
  */
 export async function orchestrateSpawn(
   taskId: string,
@@ -969,6 +998,7 @@ export async function orchestrateSpawn(
   tier?: 0 | 1 | 2,
   noWorktree?: boolean,
   spawnScope?: string,
+  atomicityScope?: 'orchestrator-defer',
 ): Promise<EngineResult> {
   if (!taskId) {
     return engineError('E_INVALID_INPUT', 'taskId is required');
@@ -1231,6 +1261,10 @@ export async function orchestrateSpawn(
         worktreeBranch,
         conduitSubscription,
         spawnCloneExclude: appliedWorktreeExcludePatterns,
+        // T10430 — forward the atomicity waiver into the composer's scope
+        // option so workers without explicit AC.files can be spawned when
+        // an orchestrator passes `--orchestrator-defer`.
+        ...(atomicityScope ? { atomicityScope } : {}),
       }),
       budgetCtrl.signal,
       'compose-prompt',

--- a/packages/core/src/orchestration/atomicity.ts
+++ b/packages/core/src/orchestration/atomicity.ts
@@ -189,7 +189,7 @@ export function checkAtomicity(input: AtomicityInput): AtomicityResult {
       allowed: false,
       code: 'E_ATOMICITY_NO_SCOPE',
       message: `Worker role for task ${input.taskId} lacks file scope (AC.files). Workers MUST declare their files.`,
-      fixHint: `Child task ${input.taskId} has no file scope. Either spawn with --files <list>, or set --scope orchestrator-defer to let the worker declare scope at commit time.`,
+      fixHint: `Child task ${input.taskId} has no file scope. Either declare files on the task (e.g. \`cleo update ${input.taskId} --files "path/a.ts,path/b.ts"\`), or pass \`--orchestrator-defer\` to \`cleo orchestrate spawn\` to let the worker declare scope at commit time (tier-1+ orchestrators only).`,
       meta: { fileCount: 0, hasScope: false },
     };
   }

--- a/packages/worktree/src/__tests__/git.test.ts
+++ b/packages/worktree/src/__tests__/git.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression locks for the low-level git helpers in `@cleocode/worktree`.
+ *
+ * Currently asserts only the published value of {@link DEFAULT_GIT_TIMEOUT_MS}
+ * — T9823 bumped this from 60s to 180s so large-repo `git worktree add`
+ * (~95s on the cleocode monorepo with 10,712 files) can complete without
+ * triggering `spawnSync git ETIMEDOUT`. Keeping the bumped value pinned here
+ * prevents accidental regressions back to 60s.
+ *
+ * @task T9823
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_GIT_TIMEOUT_MS } from '../git.js';
+
+describe('DEFAULT_GIT_TIMEOUT_MS (T9823 regression lock)', () => {
+  it('is pinned at 180_000ms (3 minutes) so large-repo worktree add completes', () => {
+    expect(DEFAULT_GIT_TIMEOUT_MS).toBe(180_000);
+  });
+
+  it('is strictly larger than the legacy 60s budget that caused T9823', () => {
+    // The legacy value (60_000) was provably too tight for 10k+ file repos.
+    // Any future tuning MUST keep the value above 60s — this assertion catches
+    // an accidental revert without locking the new value in stone.
+    expect(DEFAULT_GIT_TIMEOUT_MS).toBeGreaterThan(60_000);
+  });
+});

--- a/packages/worktree/src/git.ts
+++ b/packages/worktree/src/git.ts
@@ -20,13 +20,15 @@ const execFileAsync = promisify(execFile);
 /**
  * Default per-subprocess timeout for every git invocation in this module.
  *
- * 60s mirrors the T9501 `runGitWithLockRetry` budget — long enough for normal
- * `git worktree add` on large repos, short enough that a hung child surfaces
- * a clear timeout error to the spawn pipeline supervisor.
+ * 180s allows large-repo `git worktree add` (~95s observed on the cleocode
+ * monorepo with 10,712 tracked files) to complete while still bounding wedged
+ * git children — a clear timeout error still surfaces to the spawn pipeline
+ * supervisor before the overall {@link SPAWN_BUDGET_MS} fires (T9823).
  *
  * @task T9545
+ * @task T9823
  */
-export const DEFAULT_GIT_TIMEOUT_MS = 60_000;
+export const DEFAULT_GIT_TIMEOUT_MS = 180_000;
 
 /**
  * Run a git command synchronously and return trimmed stdout.

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -40,6 +40,7 @@ export { copyPathsWithReflock } from './copy-on-write.js';
 export {
   type AddTransientWorktreeOptions,
   addTransientWorktree,
+  DEFAULT_GIT_TIMEOUT_MS,
   removeTransientWorktree,
 } from './git.js';
 export type { WorktreeAuditPayload } from './worktree-audit.js';


### PR DESCRIPTION
## Summary

Two infrastructure fixes unblocking SAGA T9862 SG-BUGS-2026-05-21 mass dispatch.

### T9823 — Worktree provision timeout
- `DEFAULT_GIT_TIMEOUT_MS`: 60s → 180s
- `SPAWN_BUDGET_MS`: 60s → 180s
- On the cleocode repo (10,712 files) `git worktree add` takes ~95s. The prior 60s budget caused every `cleo orchestrate spawn` to hard-fail with `E_WORKTREE_PROVISION_FAILED`.

### T10430 — Atomicity gate bypass
- New CLI flag `--orchestrator-defer` on `cleo orchestrate spawn`.
- Plumbed through `atomicityScope` engine param → `composeSpawnPayload` `scope` → `checkAtomicity` waiver path.
- Records auditable `atomicity_waiver: 'orchestrator-scope-tier1-call'` in the spawn payload meta.
- Error hint at `atomicity.ts:192` updated from broken `--scope orchestrator-defer` reference to the real flag.

## Test plan
- [x] `pnpm biome check --write .` (3070 files checked, 0 fixes applied)
- [x] `pnpm run build` (all packages green)
- [x] `pnpm exec vitest run packages/worktree/src/__tests__/git.test.ts` — 2/2 pass (new regression locks)
- [x] `pnpm exec vitest run packages/core/src/orchestrate/__tests__/spawn-supervisor.test.ts` — 9/9 pass (SPAWN_BUDGET_MS lock + existing supervisor coverage)
- [x] `pnpm exec vitest run packages/core/src/orchestrate/__tests__/orchestrate-engine-composer.test.ts` — 4/4 pass (added T10430 atomicityScope path)
- [x] `pnpm exec vitest run --config packages/cleo/vitest.config.ts packages/cleo/src/dispatch/domains/__tests__/orchestrate.test.ts` — 7/9 pass (my 3 new pass; 2 pre-existing failures on `worktree.complete` carry over from origin/main, unrelated to this PR)
- [x] `pnpm exec vitest run packages/core/src/orchestration/__tests__/atomicity.test.ts` — 24/24 pass (fixHint update keeps existing assertions green)
- [x] `pnpm exec vitest run packages/core/src/orchestrate packages/core/src/orchestration` — 485/487 pass (2 todo)
- [x] Scope regression check vs `origin/main`: `packages/worktree` baseline 12 failed → 10 failed after my change (+2 passes from new git.test.ts). `packages/cleo/src/cli/commands` baseline identical 34 failed | 586 passed — zero new failures.

## CI status
Unit Tests are failing in CI — diagnosed and confirmed **pre-existing on `origin/main`**, NOT introduced by this PR:

- `@cleocode/core/src/__tests__/injection-mvi-tiers.test.ts > Template size > is under 400 lines` — `expected 419 to be less than or equal to 400`. `packages/core/templates/CLEO-INJECTION.md` is 418 lines on `origin/main` (verified locally via `git checkout origin/main -- packages/core/templates/CLEO-INJECTION.md`). Regression landed via a recent merge (T10165 / T9933 sequence) before this branch was rebased.
- `@cleocode/cant tests/composer-wiring.test.ts` — `expected '' to contain 'DRY Pattern'` and `expected 1 to be +0`. Pre-existing on main.

Recent `origin/main` CI runs confirm these failures: `cbe104e52` (current HEAD) = `failure`, `6dfbe01f9` = `failure`, `e2edc0ea9` (my original base) = `failure`. Main is currently red and a separate hotfix is required to repair it — not in this PR's scope.

## Deviations
- The brief asked for a CLI-side test under `packages/cleo/src/cli/__tests__/`. The cleanest existing test pattern for verifying flag wiring is at the dispatch layer (`packages/cleo/src/dispatch/domains/__tests__/orchestrate.test.ts`), which exercises the same plumb-through path end-to-end without exporting `spawnCommand` from the CLI module. Three tests added there cover positive forwarding, defense-in-depth narrowing, and the no-flag default.
- Added `DEFAULT_GIT_TIMEOUT_MS` to the `@cleocode/worktree` barrel export so the regression-lock test can assert the constant from the package boundary.

Closes T9823. Closes T10430. Saga: T9862.