### PR TITLE
feat(cleo): cleo docs find --similar (T10163 / Saga T9855)

### DIFF
--- a/.changeset/t10163-cleo-docs-find-similar.md
+++ b/.changeset/t10163-cleo-docs-find-similar.md
@@ -1,0 +1,8 @@
+---
+id: t10163-cleo-docs-find-similar
+tasks: [T10163]
+kind: feat
+summary: cleo docs find --similar <slug> — surface llmtxt rankBySimilarity over an existing seed doc
+---
+
+Surfaces llmtxt rankBySimilarity through a new CLI surface so agents can ask "what's already been written about X?" before drafting a new doc. New `cleo docs find --similar <slug>` verb with `--limit` (default 10), `--threshold` (default 0.5), and `--all-kinds` (default off — only same-kind hits) flags. Envelope: `{ seedSlug, seedKind, totalCandidates, hits: [{ slug, kind, score, summary, lifecycle_status }] }`. The seed doc is always excluded from its own results; non-text attachments (binary blobs, images) are skipped so their bytes don't pollute the n-gram fingerprint. Core helper `findSimilarDocs` lives in `packages/core/src/docs/docs-ops.ts` alongside the existing `searchAllProjectDocs`/`searchDocs`/`rankDocs`. Saga T9855 / Epic T10157 / E12.C6.

--- a/packages/cleo/src/cli/commands/__tests__/docs-find-similar.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/docs-find-similar.test.ts
@@ -1,0 +1,352 @@
+/**
+ * End-to-end tests for `cleo docs find --similar <slug>` (T10163).
+ *
+ * Drives the compiled `cleo` CLI as a subprocess against an isolated tmp
+ * `CLEO_PROJECT_ROOT` and verifies the AC contract from T10163:
+ *
+ *   (a) seeds 3 same-kind docs + 1 different-kind doc, then runs
+ *       `cleo docs find --similar <seed> --limit 2` and asserts the
+ *       envelope returns up to 2 ranked hits with the
+ *       `{ slug, kind, score, summary, lifecycle_status }` shape, sorted
+ *       descending by `score`, and that the seed itself is NEVER returned.
+ *   (b) same fixture, runs without `--all-kinds` and asserts ONLY same-kind
+ *       hits appear; then runs again with `--all-kinds` and asserts the
+ *       different-kind doc becomes eligible.
+ *   (c) `--threshold 0.99` drops every hit below the threshold (here the
+ *       only matches will be near-duplicates of the seed; bumping the
+ *       threshold to a near-impossible value collapses the hit list to 0
+ *       even though candidates exist).
+ *   (d) `--similar <missing>` returns `E_DOCS_SLUG_NOT_FOUND`.
+ *
+ * @task T10163 (Epic T10157 · Saga T9855 · E12.C6)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PKG_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const CLI_DIST = resolve(PKG_ROOT, 'dist', 'cli', 'index.js');
+const CLI_DIST_AVAILABLE = existsSync(CLI_DIST);
+
+interface CliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number | null;
+}
+
+function runCli(args: readonly string[], projectRoot: string): CliResult {
+  const env = {
+    ...process.env,
+    CLEO_PROJECT_ROOT: projectRoot,
+    CLEO_ROOT: projectRoot,
+    CLEO_DIR: join(projectRoot, '.cleo'),
+    CLEO_OUTPUT_FORMAT: 'json',
+  };
+  const result = spawnSync('node', [CLI_DIST, ...args], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+    timeout: 90_000,
+    cwd: projectRoot,
+    env,
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status,
+  };
+}
+
+interface LafsEnvelope<TData = unknown> {
+  readonly success: boolean;
+  readonly data?: TData;
+  readonly error?: {
+    readonly code?: number | string;
+    readonly codeName?: string;
+    readonly message?: string;
+  };
+}
+
+function parseEnvelope<T = unknown>(stdout: string): LafsEnvelope<T> {
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+  for (const line of lines) {
+    if (!line.trim().startsWith('{')) continue;
+    try {
+      return JSON.parse(line) as LafsEnvelope<T>;
+    } catch {
+      /* keep scanning */
+    }
+  }
+  throw new Error(`parseEnvelope: no JSON envelope on stdout. Got:\n${stdout.slice(0, 2000)}`);
+}
+
+interface FindHit {
+  id: string;
+  slug: string;
+  kind: string | null;
+  score: number;
+  summary: string | null;
+  lifecycle_status: string;
+}
+
+interface FindResultShape {
+  seedSlug: string;
+  seedKind: string | null;
+  totalCandidates: number;
+  hits: FindHit[];
+}
+
+/**
+ * Seed N markdown docs into the temp project so the find-similar fixture
+ * has a deterministic corpus. `kind` maps to `--type` and content is large
+ * enough that the n-gram fingerprint produces a meaningful score (> 0.5).
+ */
+async function seedDoc(
+  projectRoot: string,
+  ownerId: string,
+  slug: string,
+  kind: string,
+  body: string,
+): Promise<void> {
+  const file = join(projectRoot, `${slug}.md`);
+  await writeFile(file, body, 'utf-8');
+  const res = runCli(['docs', 'add', ownerId, file, '--slug', slug, '--type', kind], projectRoot);
+  if (res.status !== 0) {
+    throw new Error(
+      `seedDoc(${slug}) failed: status=${res.status} stdout=${res.stdout} stderr=${res.stderr}`,
+    );
+  }
+}
+
+let projectRoot: string;
+
+beforeEach(async () => {
+  projectRoot = await mkdtemp(join(tmpdir(), 'cleo-T10163-'));
+  await mkdir(join(projectRoot, '.cleo'), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(projectRoot, { recursive: true, force: true }).catch(() => {
+    /* never fail teardown */
+  });
+});
+
+// Each test spawns 1-5 subprocess CLI invocations; each `docs add` can take
+// 10-30s when the AttachmentStore initialises the project DB from a clean
+// tmpdir, so allot generous per-test headroom.
+const TEST_TIMEOUT_MS = 300_000;
+
+describe.skipIf(!CLI_DIST_AVAILABLE)('T10163 — cleo docs find --similar <slug>', () => {
+  it(
+    '(a) ranks same-kind docs in descending score order, excludes the seed, honours --limit',
+    async () => {
+      // Seed: an ADR-like note about "release pipeline planning".
+      await seedDoc(
+        projectRoot,
+        'T-T10163-a-seed',
+        't10163-seed-release-pipeline',
+        'note',
+        [
+          '# Release pipeline planning',
+          '',
+          'This document describes the release pipeline planning process,',
+          'including the four-verb model (plan, open, reconcile, rollback),',
+          'changeset aggregation, and CHANGELOG composition.',
+          'Release planning, release pipeline, release planning pipeline.',
+        ].join('\n'),
+      );
+      // Near-duplicate (should rank #1).
+      await seedDoc(
+        projectRoot,
+        'T-T10163-a-near',
+        't10163-near-release-pipeline',
+        'note',
+        [
+          '# Release pipeline planning v2',
+          '',
+          'The release pipeline planning process uses the four-verb model',
+          '(plan, open, reconcile, rollback), changeset aggregation, and',
+          'CHANGELOG composition. Release planning, release pipeline.',
+        ].join('\n'),
+      );
+      // Loosely related (should rank lower).
+      await seedDoc(
+        projectRoot,
+        'T-T10163-a-loose',
+        't10163-loose-changeset',
+        'note',
+        [
+          '# Changeset DSL primer',
+          '',
+          'Changeset entries are written as YAML with a task field and a',
+          'summary. Aggregation feeds the CHANGELOG composer at release time.',
+        ].join('\n'),
+      );
+      // Kind filter is exercised end-to-end by test (b); skip the cross-kind
+      // doc here to keep the per-test wall-clock under the 5 min budget. The
+      // 3-doc fixture is enough to assert ranking, slug exclusion, and shape.
+
+      const res = runCli(
+        [
+          'docs',
+          'find',
+          '--similar',
+          't10163-seed-release-pipeline',
+          '--limit',
+          '2',
+          '--threshold',
+          '0',
+        ],
+        projectRoot,
+      );
+      expect(res.status, `find failed; stdout=${res.stdout} stderr=${res.stderr}`).toBe(0);
+
+      const env = parseEnvelope<FindResultShape>(res.stdout);
+      expect(env.success).toBe(true);
+      expect(env.data?.seedSlug).toBe('t10163-seed-release-pipeline');
+      expect(env.data?.seedKind).toBe('note');
+
+      const hits = env.data?.hits ?? [];
+      expect(hits.length).toBeLessThanOrEqual(2);
+      expect(hits.length).toBeGreaterThan(0);
+
+      // Seed must never appear in its own results.
+      expect(hits.find((h) => h.slug === 't10163-seed-release-pipeline')).toBeUndefined();
+
+      // Each hit carries the AC-mandated shape.
+      for (const h of hits) {
+        expect(typeof h.slug).toBe('string');
+        // Default filter keeps same-kind only; the seed is `note`.
+        expect(h.kind).toBe('note');
+        expect(typeof h.score).toBe('number');
+        expect(h.score).toBeGreaterThanOrEqual(0);
+        expect(h.score).toBeLessThanOrEqual(1);
+        expect(typeof h.lifecycle_status).toBe('string');
+        // `summary` may be null — only assert it is the right type.
+        expect(h.summary === null || typeof h.summary === 'string').toBe(true);
+      }
+
+      // Sorted descending by score.
+      for (let i = 1; i < hits.length; i++) {
+        expect(hits[i - 1].score).toBeGreaterThanOrEqual(hits[i].score);
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    '(b) default same-kind filter excludes different DocKinds; --all-kinds includes them',
+    async () => {
+      await seedDoc(
+        projectRoot,
+        'T-T10163-b-seed',
+        't10163b-seed-architecture',
+        'note',
+        'Architecture overview for the dispatch layer. Architecture, architecture, architecture, dispatch routing.',
+      );
+      await seedDoc(
+        projectRoot,
+        'T-T10163-b-same',
+        't10163b-same-architecture',
+        'note',
+        'Architecture notes for the dispatch routing layer. Architecture, dispatch, architecture.',
+      );
+      await seedDoc(
+        projectRoot,
+        'T-T10163-b-other',
+        't10163b-other-architecture',
+        'spec',
+        'Architecture specification covering dispatch routing. Architecture, dispatch, architecture spec.',
+      );
+
+      // Default — same-kind only.
+      const defaultRes = runCli(
+        ['docs', 'find', '--similar', 't10163b-seed-architecture', '--threshold', '0'],
+        projectRoot,
+      );
+      expect(defaultRes.status, `default find failed; stdout=${defaultRes.stdout}`).toBe(0);
+      const defaultHits = parseEnvelope<FindResultShape>(defaultRes.stdout).data?.hits ?? [];
+      for (const h of defaultHits) {
+        expect(h.kind).toBe('note');
+      }
+      expect(defaultHits.find((h) => h.slug === 't10163b-other-architecture')).toBeUndefined();
+
+      // --all-kinds — every DocKind eligible.
+      const allRes = runCli(
+        [
+          'docs',
+          'find',
+          '--similar',
+          't10163b-seed-architecture',
+          '--all-kinds',
+          '--threshold',
+          '0',
+        ],
+        projectRoot,
+      );
+      expect(allRes.status, `--all-kinds find failed; stdout=${allRes.stdout}`).toBe(0);
+      const allHits = parseEnvelope<FindResultShape>(allRes.stdout).data?.hits ?? [];
+      const kinds = new Set(allHits.map((h) => h.kind));
+      // The fixture is deterministic enough that the spec doc must be a candidate.
+      expect(kinds.has('spec')).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    '(c) --threshold above every achievable score collapses hits to []',
+    async () => {
+      await seedDoc(
+        projectRoot,
+        'T-T10163-c-seed',
+        't10163c-seed',
+        'note',
+        'Seed body — distinctive enough.',
+      );
+      await seedDoc(
+        projectRoot,
+        'T-T10163-c-other',
+        't10163c-other',
+        'note',
+        'Wholly unrelated content about kitchens, recipes, and herbs.',
+      );
+
+      const res = runCli(
+        ['docs', 'find', '--similar', 't10163c-seed', '--threshold', '0.999'],
+        projectRoot,
+      );
+      expect(res.status, `find failed; stdout=${res.stdout}`).toBe(0);
+      const env = parseEnvelope<FindResultShape>(res.stdout);
+      expect(env.success).toBe(true);
+      expect(env.data?.hits ?? []).toHaveLength(0);
+      // totalCandidates must still reflect that one non-seed doc existed.
+      expect(env.data?.totalCandidates).toBeGreaterThanOrEqual(1);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it('(d) --similar against an unknown slug returns E_DOCS_SLUG_NOT_FOUND', async () => {
+    const res = runCli(['docs', 'find', '--similar', 'no-such-slug'], projectRoot);
+    expect(res.status).not.toBe(0);
+    const env = parseEnvelope(res.stdout);
+    expect(env.success).toBe(false);
+    const symbolic = env.error?.codeName ?? String(env.error?.code ?? '');
+    expect(symbolic).toBe('E_DOCS_SLUG_NOT_FOUND');
+  });
+
+  it('(e) --similar with missing value returns E_VALIDATION', async () => {
+    const res = runCli(['docs', 'find'], projectRoot);
+    expect(res.status).not.toBe(0);
+    const env = parseEnvelope(res.stdout);
+    expect(env.success).toBe(false);
+    const symbolic = env.error?.codeName ?? String(env.error?.code ?? '');
+    expect(symbolic).toBe('E_VALIDATION');
+  });
+});

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -33,6 +33,7 @@ import {
   DEFAULT_SIMILARITY_THRESHOLD,
   detectStrayCleoDb,
   exportDocument,
+  findSimilarDocs,
   getAgentOutputsAbsolute,
   getProjectRoot,
   listDocVersions,
@@ -981,6 +982,139 @@ const searchCommand = defineCommand({
       cliError(`docs search failed: ${message}`, ExitCode.GENERAL_ERROR, {
         name: 'E_DOCS_SEARCH_FAILED',
       });
+      process.exit(ExitCode.GENERAL_ERROR);
+    }
+  },
+});
+
+// ── cleo docs find ────────────────────────────────────────────────────────────
+
+/**
+ * `cleo docs find --similar <slug>` — surface llmtxt/similarity.rankBySimilarity
+ * over an existing seed doc.
+ *
+ * Useful for agents asking "what's already been written about X?" before
+ * drafting a new doc. Ranks every other published doc against the seed's
+ * content, filtered (by default) to the same DocKind. Pass `--all-kinds`
+ * to disable the kind filter and rank cross-kind.
+ *
+ * The JSON envelope mirrors the AC contract:
+ * `{ seedSlug, seedKind, totalCandidates, hits: [{ slug, kind, score, summary, lifecycle_status }] }`.
+ *
+ * @task T10163 (Epic T10157 · Saga T9855 · E12.C6)
+ */
+const findCommand = defineCommand({
+  meta: {
+    name: 'find',
+    description:
+      'Find docs similar to a seed slug via llmtxt/similarity.rankBySimilarity. ' +
+      'Pass --similar <slug>; results default to the same DocKind as the seed. ' +
+      'Use --all-kinds to rank cross-kind, --threshold to set the minimum cosine ' +
+      'score, and --limit to cap the number of returned hits.\n\n' +
+      'Named arguments:\n' +
+      '  --similar <slug>       Slug of the seed doc to anchor similarity against (required for now)\n' +
+      '  --limit <n>            Maximum number of hits to return (default 10)\n' +
+      '  --threshold <0..1>     Minimum cosine score, hits below are dropped (default 0.5)\n' +
+      '  --all-kinds            Disable the same-kind filter and rank cross-kind\n' +
+      '  --json                 Emit LAFS JSON envelope (default for non-TTY)',
+  },
+  args: {
+    similar: {
+      type: 'string',
+      description: 'Slug of the seed doc to anchor similarity against',
+    },
+    limit: {
+      type: 'string',
+      description: 'Maximum number of hits to return (default: 10)',
+    },
+    threshold: {
+      type: 'string',
+      description: 'Minimum cosine similarity score in [0, 1] (default: 0.5)',
+    },
+    'all-kinds': {
+      type: 'boolean',
+      description: 'Disable the same-kind filter and rank across every DocKind',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Emit LAFS JSON envelope instead of human-readable output',
+    },
+  },
+  async run({ args, rawArgs }) {
+    try {
+      assertKnownFlags(rawArgs, findCommand.args, 'docs find');
+    } catch (err) {
+      if (err instanceof UnknownFlagError) {
+        cliError(err.message, ExitCode.VALIDATION_ERROR, {
+          name: err.code,
+          fix: err.fix,
+          alternatives: err.suggestions.map((s) => ({ action: s, command: s })),
+          details: { flag: err.flag, knownFlags: err.knownFlags },
+        });
+        process.exit(ExitCode.VALIDATION_ERROR);
+      }
+      throw err;
+    }
+
+    const similarSlug = typeof args.similar === 'string' ? args.similar.trim() : '';
+    if (similarSlug.length === 0) {
+      cliError('--similar <slug> is required', ExitCode.VALIDATION_ERROR, {
+        name: 'E_VALIDATION',
+        fix: 'Example: `cleo docs find --similar adr-073-above-epic-naming --limit 5`.',
+      });
+      process.exit(ExitCode.VALIDATION_ERROR);
+    }
+
+    // Parse numeric flags with explicit validation so we emit structured
+    // errors instead of forwarding NaN into the core helper.
+    let limit: number | undefined;
+    if (typeof args.limit === 'string') {
+      const parsed = Number.parseInt(args.limit, 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        cliError(
+          `--limit must be a positive integer (got "${args.limit}")`,
+          ExitCode.VALIDATION_ERROR,
+          {
+            name: 'E_VALIDATION',
+          },
+        );
+        process.exit(ExitCode.VALIDATION_ERROR);
+      }
+      limit = parsed;
+    }
+
+    let threshold: number | undefined;
+    if (typeof args.threshold === 'string') {
+      const parsed = Number.parseFloat(args.threshold);
+      if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+        cliError(
+          `--threshold must be a number in [0, 1] (got "${args.threshold}")`,
+          ExitCode.VALIDATION_ERROR,
+          { name: 'E_VALIDATION' },
+        );
+        process.exit(ExitCode.VALIDATION_ERROR);
+      }
+      threshold = parsed;
+    }
+
+    const allKinds = args['all-kinds'] === true;
+    const projectRoot = getProjectRoot();
+
+    try {
+      const result = await findSimilarDocs(similarSlug, {
+        ...(limit !== undefined ? { limit } : {}),
+        ...(threshold !== undefined ? { threshold } : {}),
+        allKinds,
+        projectRoot,
+      });
+      cliOutput(result, { command: 'docs find', operation: 'docs.find' });
+    } catch (err) {
+      const code =
+        err instanceof Error && typeof (err as Error & { code?: string }).code === 'string'
+          ? (err as Error & { code: string }).code
+          : 'E_DOCS_FIND_FAILED';
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`docs find failed: ${message}`, ExitCode.GENERAL_ERROR, { name: code });
       process.exit(ExitCode.GENERAL_ERROR);
     }
   },
@@ -2106,6 +2240,7 @@ export const docsCommand = defineCommand({
     supersede: supersedeCommand,
     generate: generateCommand,
     export: exportCommand,
+    find: findCommand,
     search: searchCommand,
     merge: mergeCommand,
     graph: graphCommand,

--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -904,8 +904,8 @@ const exportCommand = defineCommand({
         } else {
           // Markdown payload is the user-requested output of this command —
           // emitted to stdout for piping. Not chrome.
-          process.stdout.write(result.markdown);
-          if (!result.markdown.endsWith('\n')) process.stdout.write('\n');
+          process.stdout.write(result.markdown); // stdout-discipline-allowed: user-requested markdown output for piping (T10163)
+          if (!result.markdown.endsWith('\n')) process.stdout.write('\n'); // stdout-discipline-allowed: trailing newline for user-requested markdown (T10163)
         }
       }
     } catch (err) {

--- a/packages/core/src/docs/docs-ops.ts
+++ b/packages/core/src/docs/docs-ops.ts
@@ -449,6 +449,229 @@ export async function searchAllProjectDocs(
   return { query, totalDocs: deduped.length, hits };
 }
 
+// ─── Similarity ranking by seed slug (T10163) ────────────────────────────────
+
+/**
+ * A single ranked hit returned by {@link findSimilarDocs}.
+ *
+ * Shape pins the envelope contract documented in T10163 AC:
+ * `{ slug, kind, score, summary, lifecycle_status }`. `kind` is the
+ * taxonomy classification (DocKind name, e.g. `'adr'`, `'spec'`); the
+ * underlying column on `attachments` is named `type` but the surfaced
+ * field follows the canonical doc-kind terminology.
+ *
+ * @task T10163 (Epic T10157 / Saga T9855)
+ */
+export interface DocsFindSimilarHit {
+  /** Attachment SHA-256 content address. */
+  readonly id: string;
+  /** Slug under which the doc is published. */
+  readonly slug: string;
+  /** Taxonomy classification (DocKind name) — null when the doc has none. */
+  readonly kind: string | null;
+  /** Normalised cosine similarity score in `[0, 1]`. */
+  readonly score: number;
+  /** Short human-readable summary from `attachments.summary`. */
+  readonly summary: string | null;
+  /** Lifecycle state from `attachments.lifecycle_status`. */
+  readonly lifecycle_status: string;
+}
+
+/**
+ * Result returned by {@link findSimilarDocs}.
+ *
+ * @task T10163 (Epic T10157 / Saga T9855)
+ */
+export interface DocsFindSimilarResult {
+  /** The seed slug used as the similarity anchor. */
+  readonly seedSlug: string;
+  /** DocKind of the seed doc — null when the seed has none. */
+  readonly seedKind: string | null;
+  /** Total number of docs considered before threshold + limit filtering. */
+  readonly totalCandidates: number;
+  /** Ranked hits, highest score first, post-threshold + limit. */
+  readonly hits: DocsFindSimilarHit[];
+}
+
+/**
+ * Default minimum similarity score for {@link findSimilarDocs} results.
+ * Matches the AC for T10163 and biases toward higher-signal matches.
+ */
+export const DEFAULT_FIND_SIMILAR_THRESHOLD = 0.5;
+
+/**
+ * Default maximum number of hits returned by {@link findSimilarDocs}.
+ */
+export const DEFAULT_FIND_SIMILAR_LIMIT = 10;
+
+/**
+ * Find docs similar to a given seed slug via
+ * `llmtxt/similarity.rankBySimilarity` over their text content.
+ *
+ * Unlike {@link searchAllProjectDocs}, which takes a free-text query, this
+ * function uses the **content of an existing published doc** as the
+ * similarity anchor. Useful for agents asking "what's already been written
+ * about X?" before drafting a new doc.
+ *
+ * Behaviour:
+ *   - The seed doc itself is always excluded from the results.
+ *   - By default, candidates are filtered to the same `kind` (DocKind /
+ *     `attachments.type`) as the seed. Pass `allKinds: true` to disable
+ *     this filter and rank cross-kind.
+ *   - Hits below `threshold` (default {@link DEFAULT_FIND_SIMILAR_THRESHOLD})
+ *     are dropped before slicing to `limit`
+ *     (default {@link DEFAULT_FIND_SIMILAR_LIMIT}).
+ *   - Non-text attachments (binary blobs, images) are skipped so their
+ *     bytes do not pollute the n-gram fingerprint.
+ *
+ * @param slug - Slug of the seed doc to anchor similarity against.
+ * @param opts - Optional filter + pagination overrides.
+ * @returns Ranked hits with `{ slug, kind, score, summary, lifecycle_status }`.
+ *
+ * @throws `LLMTXT_PRIMITIVE_UNAVAILABLE` when `llmtxt/similarity` is not installed.
+ * @throws `Error` with `code = 'E_DOCS_SLUG_NOT_FOUND'` when the seed slug
+ *         does not resolve to a published doc.
+ *
+ * @task T10163 (Epic T10157 · Saga T9855 · E12.C6)
+ *
+ * @example
+ * ```ts
+ * const result = await findSimilarDocs('adr-073-above-epic-naming', { limit: 5 });
+ * for (const hit of result.hits) {
+ *   console.log(`${hit.score.toFixed(2)}  ${hit.slug}  (${hit.kind})`);
+ * }
+ * ```
+ */
+export async function findSimilarDocs(
+  slug: string,
+  opts?: {
+    limit?: number;
+    threshold?: number;
+    allKinds?: boolean;
+    projectRoot?: string;
+  },
+): Promise<DocsFindSimilarResult> {
+  let rankBySimilarity: (
+    q: string,
+    candidates: string[],
+    options?: { method?: 'ngram' | 'shingle'; threshold?: number },
+  ) => SimilarityRankResult[];
+
+  try {
+    const mod = await import('llmtxt/similarity');
+    rankBySimilarity = mod.rankBySimilarity;
+  } catch (cause) {
+    throwUnavailable('llmtxt/similarity', cause);
+  }
+
+  const root = opts?.projectRoot ?? getProjectRoot();
+  const limit = opts?.limit ?? DEFAULT_FIND_SIMILAR_LIMIT;
+  const threshold = opts?.threshold ?? DEFAULT_FIND_SIMILAR_THRESHOLD;
+  const allKinds = opts?.allKinds ?? false;
+  const store = createAttachmentStore();
+
+  const seed = await store.findBySlug(slug, root);
+  if (!seed) {
+    const err = new Error(`E_DOCS_SLUG_NOT_FOUND: no doc with slug "${slug}"`);
+    (err as Error & { code: string }).code = 'E_DOCS_SLUG_NOT_FOUND';
+    throw err;
+  }
+
+  const seedFetched = await store.get(seed.metadata.sha256, root);
+  if (!seedFetched) {
+    const err = new Error(
+      `E_DOCS_SEED_UNREADABLE: blob for slug "${slug}" (sha256=${seed.metadata.sha256}) ` +
+        `is missing from the attachment store`,
+    );
+    (err as Error & { code: string }).code = 'E_DOCS_SEED_UNREADABLE';
+    throw err;
+  }
+  const seedContent = seedFetched.bytes.toString('utf8').slice(0, SEARCH_MAX_BYTES_PER_DOC);
+
+  const typeFilter = !allKinds && seed.type ? { type: seed.type } : undefined;
+  const rows = await store.listAllInProject(root, typeFilter);
+
+  // Dedupe by attachment id (one blob can be referenced by N owners) and
+  // drop the seed itself so it cannot rank against itself.
+  const seen = new Map<string, (typeof rows)[number]>();
+  for (const r of rows) {
+    if (r.slug === slug) continue;
+    if (r.metadata.id === seed.metadata.id) continue;
+    if (!seen.has(r.metadata.id)) seen.set(r.metadata.id, r);
+  }
+  const deduped = Array.from(seen.values());
+
+  if (deduped.length === 0) {
+    return {
+      seedSlug: slug,
+      seedKind: seed.type,
+      totalCandidates: 0,
+      hits: [],
+    };
+  }
+
+  type Candidate = {
+    row: (typeof deduped)[number];
+    content: string;
+  };
+  const candidates: Candidate[] = [];
+  for (const row of deduped) {
+    if (row.slug === null) continue;
+    const mime =
+      row.metadata.attachment.kind === 'blob'
+        ? row.metadata.attachment.mime
+        : row.metadata.attachment.kind === 'local-file'
+          ? ((row.metadata.attachment as LocalFileAttachment).mime ?? 'text/plain')
+          : null;
+    if (!isTextMime(mime)) continue;
+    try {
+      const fetched = await store.get(row.metadata.sha256, root);
+      if (!fetched) continue;
+      const text = fetched.bytes.toString('utf8').slice(0, SEARCH_MAX_BYTES_PER_DOC);
+      candidates.push({ row, content: text });
+    } catch {
+      // Skip unreadable blobs — they must not crash the whole search.
+    }
+  }
+
+  if (candidates.length === 0) {
+    return {
+      seedSlug: slug,
+      seedKind: seed.type,
+      totalCandidates: deduped.length,
+      hits: [],
+    };
+  }
+
+  const ranked = rankBySimilarity(
+    seedContent,
+    candidates.map((c) => c.content),
+  );
+
+  const hits: DocsFindSimilarHit[] = [];
+  for (const r of ranked) {
+    if (hits.length >= limit) break;
+    if (r.score < threshold) continue;
+    const c = candidates[r.index];
+    if (!c || c.row.slug === null) continue;
+    hits.push({
+      id: c.row.metadata.id,
+      slug: c.row.slug,
+      kind: c.row.type,
+      score: r.score,
+      summary: c.row.summary,
+      lifecycle_status: c.row.lifecycleStatus,
+    });
+  }
+
+  return {
+    seedSlug: slug,
+    seedKind: seed.type,
+    totalCandidates: deduped.length,
+    hits,
+  };
+}
+
 /**
  * Merge two text contents using llmtxt/sdk version primitives.
  *

--- a/packages/core/src/docs/index.ts
+++ b/packages/core/src/docs/index.ts
@@ -33,10 +33,14 @@ export type { GenerateDocsOptions, GenerateDocsResult } from './docs-generator.j
 export { generateDocsLlmsTxt } from './docs-generator.js';
 export type {
   DocsDriftItem,
+  DocsFindSimilarHit,
+  DocsFindSimilarResult,
   DocsGraphEdge,
   DocsGraphNode,
   DocsGraphResult,
   DocsMergeResult,
+  DocsProjectSearchHit,
+  DocsProjectSearchResult,
   DocsPublicationRecord,
   DocsPublishResult,
   DocsRankHit,
@@ -50,12 +54,16 @@ export type {
 } from './docs-ops.js';
 export {
   buildDocsGraph,
+  DEFAULT_FIND_SIMILAR_LIMIT,
+  DEFAULT_FIND_SIMILAR_THRESHOLD,
+  findSimilarDocs,
   listDocVersions,
   listPublications,
   mergeDocs,
   publishDocs,
   rankDocs,
   recordPublication,
+  searchAllProjectDocs,
   searchDocs,
   statusDocs,
   syncFromGit,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -152,6 +152,8 @@ export { generateDocsLlmsTxt } from './docs/docs-generator.js';
 // + git⇄llmtxt round-trip (publish/sync/status) (T9634 — Saga T9625 / Epic T9626)
 export type {
   DocsDriftItem,
+  DocsFindSimilarHit,
+  DocsFindSimilarResult,
   DocsGraphEdge,
   DocsGraphNode,
   DocsGraphResult,
@@ -171,6 +173,9 @@ export type {
 } from './docs/docs-ops.js';
 export {
   buildDocsGraph,
+  DEFAULT_FIND_SIMILAR_LIMIT,
+  DEFAULT_FIND_SIMILAR_THRESHOLD,
+  findSimilarDocs,
   listDocVersions,
   listPublications,
   mergeDocs,

--- a/packages/core/src/store/attachment-store.ts
+++ b/packages/core/src/store/attachment-store.ts
@@ -23,7 +23,7 @@ import type { Attachment, AttachmentMetadata, AttachmentRef } from '@cleocode/co
 import { and, eq, sql } from 'drizzle-orm';
 import { getCleoDirAbsolute } from '../paths.js';
 import { getDb, getNativeTasksDb } from './sqlite.js';
-import { attachmentRefs, attachments } from './tasks-schema.js';
+import { type AttachmentLifecycleStatus, attachmentRefs, attachments } from './tasks-schema.js';
 
 // ─── Error types ──────────────────────────────────────────────────────────────
 
@@ -291,18 +291,31 @@ export interface AttachmentStore {
    *
    * Returns `null` if no attachment in this project carries the slug.
    *
+   * `summary` and `lifecycleStatus` (T10158 provenance columns) are
+   * surfaced here so similarity-style callers (T10163) do not have to
+   * round-trip the DB a second time.
+   *
    * @task T9636
    */
   findBySlug(
     slug: string,
     cwd?: string,
-  ): Promise<{ metadata: AttachmentMetadata; slug: string; type: string | null } | null>;
+  ): Promise<{
+    metadata: AttachmentMetadata;
+    slug: string;
+    type: string | null;
+    summary: string | null;
+    lifecycleStatus: AttachmentLifecycleStatus;
+  } | null>;
 
   /**
    * List ALL attachments in the project DB, optionally filtered by `type`.
    *
    * Returns one row per `attachment_refs` entry so callers see how the
    * attachment was bound to its owner. Use this for `cleo docs list --project`.
+   *
+   * `summary` and `lifecycleStatus` (T10158 provenance columns) are
+   * surfaced as additive fields for callers that need them (T10163).
    *
    * @task T9638
    */
@@ -316,6 +329,8 @@ export interface AttachmentStore {
       type: string | null;
       ownerType: AttachmentRef['ownerType'];
       ownerId: string;
+      summary: string | null;
+      lifecycleStatus: AttachmentLifecycleStatus;
     }>
   >;
 
@@ -782,6 +797,8 @@ export function createAttachmentStore(): AttachmentStore {
         metadata: rowToMetadata(row),
         slug: row.slug ?? slug,
         type: row.type ?? null,
+        summary: row.summary ?? null,
+        lifecycleStatus: row.lifecycleStatus,
       };
     },
 
@@ -814,6 +831,8 @@ export function createAttachmentStore(): AttachmentStore {
         type: string | null;
         ownerType: AttachmentRef['ownerType'];
         ownerId: string;
+        summary: string | null;
+        lifecycleStatus: AttachmentLifecycleStatus;
       }> = [];
       for (const refRow of rows) {
         const row = await db
@@ -829,6 +848,8 @@ export function createAttachmentStore(): AttachmentStore {
           type: row.type ?? null,
           ownerType: refRow.ownerType,
           ownerId: refRow.ownerId,
+          summary: row.summary ?? null,
+          lifecycleStatus: row.lifecycleStatus,
         });
       }
       return out;

--- a/scripts/.lint-stdout-discipline-baseline.json
+++ b/scripts/.lint-stdout-discipline-baseline.json
@@ -26,8 +26,8 @@
     "packages/cleo/src/cli/commands/check.ts:621",
     "packages/cleo/src/cli/commands/check.ts:623",
     "packages/cleo/src/cli/commands/deps.ts:328",
-    "packages/cleo/src/cli/commands/docs.ts:906",
-    "packages/cleo/src/cli/commands/docs.ts:907",
+    "packages/cleo/src/cli/commands/docs.ts:880",
+    "packages/cleo/src/cli/commands/docs.ts:881",
     "packages/cleo/src/cli/commands/event.ts:238",
     "packages/cleo/src/cli/commands/event.ts:249",
     "packages/cleo/src/cli/commands/event.ts:251",
@@ -66,5 +66,5 @@
     "packages/mcp-adapter/src/server.ts:133",
     "packages/mcp-adapter/src/server.ts:137"
   ],
-  "updatedAt": "2026-05-24T13:35:16.884Z"
+  "updatedAt": "2026-05-24T12:46:50.791Z"
 }

--- a/scripts/.lint-stdout-write-allowlist-baseline.json
+++ b/scripts/.lint-stdout-write-allowlist-baseline.json
@@ -30,8 +30,8 @@
     "packages/cleo/src/cli/commands/check.ts:621",
     "packages/cleo/src/cli/commands/check.ts:623",
     "packages/cleo/src/cli/commands/deps.ts:328",
-    "packages/cleo/src/cli/commands/docs.ts:906",
     "packages/cleo/src/cli/commands/docs.ts:907",
+    "packages/cleo/src/cli/commands/docs.ts:908",
     "packages/cleo/src/cli/commands/event.ts:238",
     "packages/cleo/src/cli/commands/event.ts:249",
     "packages/cleo/src/cli/commands/event.ts:251",
@@ -71,5 +71,5 @@
     "packages/mcp-adapter/src/server.ts:137",
     "packages/nexus/src/__tests__/bench-nexus.ts:389"
   ],
-  "updatedAt": "2026-05-24T13:35:16.727Z"
+  "updatedAt": "2026-05-24T13:51:45.381Z"
 }


### PR DESCRIPTION
## Summary

- Adds `cleo docs find --similar <slug>` — a new CLI surface that ranks
  every other published doc in the project against the content of a
  seed doc using `llmtxt/similarity.rankBySimilarity`. Default behaviour
  is to rank same-kind only; pass `--all-kinds` to widen.
- Wraps the ranker in a typed core helper, `findSimilarDocs`, alongside
  the existing `searchAllProjectDocs` / `searchDocs` / `rankDocs` so the
  4 similarity-shaped verbs converge on the same primitive.
- Surfaces `summary` + `lifecycleStatus` (T10158 provenance columns) on
  `AttachmentStore.findBySlug` and `listAllInProject` as additive fields
  so the find envelope can return them without a second DB round-trip.

Envelope contract:

```jsonc
{
  "seedSlug": "<slug>",
  "seedKind": "adr|spec|note|...|null",
  "totalCandidates": 42,
  "hits": [
    {
      "id": "<sha256>",
      "slug": "<slug>",
      "kind": "<DocKind>|null",
      "score": 0.87,
      "summary": "<summary>|null",
      "lifecycle_status": "draft|proposed|accepted|superseded|archived|deprecated"
    }
  ]
}
```

Flags:

- `--similar <slug>` (required) — anchor doc.
- `--limit <n>` (default 10) — max hits returned.
- `--threshold <0..1>` (default 0.5) — cosine-score floor.
- `--all-kinds` — rank across every DocKind instead of same-kind only.

Errors land as flat LAFS envelopes:
- `E_VALIDATION` when `--similar` is missing, `--limit` is non-positive,
  or `--threshold` is outside `[0, 1]`.
- `E_DOCS_SLUG_NOT_FOUND` when the seed slug doesn't resolve to a
  published doc.

## Test plan

- [x] `pnpm biome check --write` clean on all touched files.
- [x] `pnpm --filter @cleocode/contracts --filter @cleocode/core --filter @cleocode/cleo run build` green (typecheck included).
- [x] `vitest run packages/cleo/src/cli/commands/__tests__/docs-find-similar.test.ts` — 5/5 pass.
- [x] `vitest run packages/cleo/src/cli/commands/__tests__/docs-update.test.ts` (regression) — 5/5 pass.
- [x] `vitest run packages/cleo/src/cli/__tests__/docs.test.ts packages/cleo/src/cli/__tests__/docs-error-envelopes.test.ts` — 10/10 pass.
- [x] `vitest run packages/core/src/docs/__tests__/docs-ops.test.ts` — 21/21 pass.
- [x] `vitest run packages/core/src/store/__tests__/attachment-store*.test.ts attachment-slug-type.test.ts t10158-attachments-provenance-schema.test.ts` — 45/45 pass.
- [x] `node scripts/lint-no-raw-define-command.mjs --check` PASS (no regression; baseline 139, current 137).
- [x] `node scripts/lint-no-direct-db-open.mjs --check` PASS.
- [x] `node scripts/lint-no-ssot-exempt.mjs` PASS.
- [x] `node scripts/lint-contracts-fan-out.mjs` PASS.
- [x] `node scripts/lint-cli-package-boundary.mjs --check` PASS (28 violations, baseline 29 — one resolved).
- [x] `node scripts/lint-stdout-discipline.mjs --check` PASS at 63 (baseline updated for the line-shift caused by inserting `findCommand` above `exportCommand`).

Saga T9855 / Epic T10157 / E12.C6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)