### PR TITLE
fix(core/tests): bump CLEO-INJECTION.md size cap 400→450 (T10465 P0 hotfix)

### DIFF
--- a/.changeset/T10465.md
+++ b/.changeset/T10465.md
@@ -1,0 +1,13 @@
+---
+"@cleocode/core": patch
+---
+
+fix(core/tests): bump CLEO-INJECTION.md size cap 400→450 — unblocks main CI
+
+T10465 hotfix: ADR-086 CLI Output Contract section added ~19 lines in
+T9934 (commit 2712adaa5) pushing CLEO-INJECTION.md to 418 lines and
+breaking Unit Tests > Template size on every PR. Threshold bump
+restores headroom; the section is legitimate agent guidance, not bloat.
+Trim opportunities will be evaluated in a follow-up.
+
+Saga: T9862. Closes T10465.

--- a/packages/core/src/__tests__/injection-mvi-tiers.test.ts
+++ b/packages/core/src/__tests__/injection-mvi-tiers.test.ts
@@ -129,9 +129,9 @@ describe('CLEO-INJECTION v2.6.0 CLI-only template', () => {
   });
 
   describe('Template size', () => {
-    it('is under 400 lines (T9148 added HTML section anchors for cleo briefing inject — currently ~354 lines)', () => {
+    it('is under 450 lines (T9148 anchors + T9934/ADR-086 CLI Output Contract grew to ~418 lines)', () => {
       const lines = content.split('\n').length;
-      expect(lines).toBeLessThanOrEqual(400);
+      expect(lines).toBeLessThanOrEqual(450);
     });
 
     it('is at least 50 lines (not accidentally empty)', () => {


### PR DESCRIPTION
## Summary

P0 hotfix: `injection-mvi-tiers.test.ts > Template size` blocks every PR on main since T9934/ADR-086 grew `CLEO-INJECTION.md` from ~399 to 418 lines. Bumping the cap from 400 to 450 unblocks main + saga T9862 + all open PRs.

The new content (ADR-086 CLI Output Contract section, ~19 lines) is canonical agent guidance — not bloat. Trim opportunities deferred to follow-up.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/__tests__/injection-mvi-tiers.test.ts` — green (21 tests)
- [x] `pnpm biome check --write` — clean

Closes T10465. Saga: T9862.