### PR TITLE
ci: add merge_group triggers to PR workflows (T10444)

### DIFF
--- a/.github/workflows/arch-boundary-check.yml
+++ b/.github/workflows/arch-boundary-check.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/auto-tag-on-release-merge.yml
+++ b/.github/workflows/auto-tag-on-release-merge.yml
@@ -19,6 +19,7 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  merge_group:
 
 permissions:
   contents: write

--- a/.github/workflows/boundary-registry-lint.yml
+++ b/.github/workflows/boundary-registry-lint.yml
@@ -18,6 +18,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs-reingest.yml
+++ b/.github/workflows/docs-reingest.yml
@@ -38,6 +38,7 @@ name: Docs Re-ingest (PR merge)
 on:
   pull_request:
     types: [closed]
+  merge_group:
 
 permissions:
   contents: write

--- a/.github/workflows/dual-implementation-lint.yml
+++ b/.github/workflows/dual-implementation-lint.yml
@@ -20,6 +20,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/identity-pollution-check.yml
+++ b/.github/workflows/identity-pollution-check.yml
@@ -12,6 +12,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
 
 jobs:
   reject-polluted-identity:

--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -10,6 +10,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
 
 jobs:
   lockfile-consistency:

--- a/.github/workflows/release-pipeline-matrix.yml
+++ b/.github/workflows/release-pipeline-matrix.yml
@@ -37,6 +37,7 @@ on:
     paths:
       - 'packages/cleo/test/fixtures/release-test-**'
       - 'packages/cleo/test/integration/release-pipeline/**'
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/skills-depth-check.yml
+++ b/.github/workflows/skills-depth-check.yml
@@ -23,6 +23,7 @@ on:
     branches: [main]
     paths:
       - 'packages/skills/skills/**'
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/worktree-cleanup.yml
+++ b/.github/workflows/worktree-cleanup.yml
@@ -26,6 +26,7 @@ on:
     types: [closed]
   push:
     branches: [main]
+  merge_group:
 
 jobs:
   cleanup:

--- a/.github/workflows/worktree-napi-prebuild.yml
+++ b/.github/workflows/worktree-napi-prebuild.yml
@@ -20,6 +20,7 @@ on:
       - 'rust-toolchain.toml'
       - '.github/workflows/worktree-napi-prebuild.yml'
   workflow_dispatch:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
Adds merge_group triggers to all workflows that run on pull_request, enabling GitHub native merge queue.

Closes T10444
Refs: T10431