### PR TITLE
docs(adr): Worktree FFI Topology + slug ref cleanup (T10439)

### DIFF
--- a/docs/adr/ADR-087-worktree-ffi-topology.md
+++ b/docs/adr/ADR-087-worktree-ffi-topology.md
@@ -1,0 +1,74 @@
+---
+slug: adr-087-worktree-ffi-topology
+title: ADR-087 — Worktree FFI Topology (4-surface napi-rs canonical layout)
+saga: T10431
+date: 2026-05-24
+status: accepted
+stage: accepted
+acceptedAt: 2026-05-24
+acceptedBy: T10439
+---
+
+# ADR-087: Worktree FFI Topology
+
+- **Status**: Accepted
+- **Date**: 2026-05-24
+- **Saga**: T10431 SG-WORKTRUNK-OWN
+- **Implements**: T10439
+- **References**: T10288, T10178
+
+## Context
+
+The `packages/worktree` package is the TypeScript SDK surface for git-worktree
+operations. Under the hood it delegates CPU-bound primitives to a Rust core via
+napi-rs. During the SG-WORKTRUNK-OWN saga (T9977 → T10431) the exact packaging
+layout caused repeated confusion:
+
+- `packages/worktree` — TS wrapper / orchestration layer (npm package `@cleocode/worktree`)
+- `crates/worktree-napi` — napi-rs root binding crate (npm package `@cleocode/worktree-napi`)
+- `crates/worktree-napi/npm/*` — 5 per-platform prebuild packages (`darwin-x64`, `darwin-arm64`, `linux-x64-gnu`, `win32-x64-msvc`, `linux-arm64-gnu`)
+- `crates/worktrunk-core` — pure-Rust SDK (no npm package; consumed only by `worktree-napi`)
+
+This is the **canonical 4-surface napi-rs layout** used by:
+
+- `@swc/core`
+- `oxc`
+- `@napi-rs/canvas`
+- `cant-napi` and `lafs-napi` (siblings in this monorepo)
+
+The confusion was a **documentation gap**, not an architectural one. No code
+changes are required; the layout is already correct.
+
+## Decision
+
+**Keep the current 4-surface layout.**
+
+1. `worktrunk-core` stays a pure-Rust crate with no npm footprint.
+2. `worktree-napi` is the **single** napi-rs binding crate; it re-exports
+   `worktrunk-core` primitives via `#[napi]` macros.
+3. Per-platform prebuilds live under `crates/worktree-napi/npm/*` and are
+   published as scoped packages consumed by the root `@cleocode/worktree-napi`.
+4. `packages/worktree` remains the TypeScript orchestration layer; it imports
+   `@cleocode/worktree-napi` at runtime and adds CLEO-specific logic (XDG
+   layout, task-id preservation filters, hook orchestration, etc.).
+
+## Consequences
+
+- **Positive**: The layout is industry-standard, well-supported by napi-rs
+  tooling (`napi build`, `napi pre-publish`), and matches sibling packages in
+  this repo.
+- **Positive**: CI already builds and tests the full matrix; no pipeline changes
+  needed.
+- **Neutral**: New contributors may still need orientation. This ADR closes that
+  gap by making the topology explicit and referenceable.
+- **Negative**: None. The alternative (flattening into a single TS+Rust package)
+  would break platform-specific binary distribution and require custom
+  post-install scripts.
+
+## References
+
+- T10439 — Write ADR for Worktree FFI Topology, fix dangling slug refs
+- T10288 — napi-rs prebuild package wiring
+- T10178 — Initial worktree-napi scaffolding
+- `crates/worktree-napi/README.md`
+- `packages/worktree/README.md`

--- a/packages/contracts/src/boundary.ts
+++ b/packages/contracts/src/boundary.ts
@@ -492,7 +492,7 @@ export const BOUNDARY_REGISTRY: readonly BoundaryEntry[] = [
       panic_unwind: 'allowed-with-recovery',
       root_escape: 'forbidden',
     },
-    amendments: ['adr-077-worktreeinclude'],
+    amendments: ['adr-087-worktree-ffi-topology'],
     rationale:
       'napi binding shim (515 LOC) for worktrunk-core, used by packages/core spawn-pipeline tests, packages/core/src/scaffold/ensure-config.ts, and shipped via packages/worktree-napi-* per-platform npm packages. Internal-only.',
   },
@@ -510,7 +510,7 @@ export const BOUNDARY_REGISTRY: readonly BoundaryEntry[] = [
       panic_unwind: 'forbidden',
       root_escape: 'forbidden',
     },
-    amendments: ['adr-077-worktreeinclude', 'adr-078-boundary-registry'],
+    amendments: ['adr-077-worktreeinclude-canonical-location', 'adr-078-boundary-registry'],
     rationale:
       'Refactored SoC per ADR-078 amendment 2026-05-23. Worktree primitives core (1,352 LOC) vendored from /mnt/projects/worktrunk per D010, consumed by worktree-napi. Reference implementation of the boundary-registry pattern. Full SDK surface documented in crates/worktrunk-core/README.md (T10223). Internal-only today; publish=true is a future option if external worktree-tooling emerges.',
   },
@@ -868,7 +868,7 @@ export const BOUNDARY_REGISTRY: readonly BoundaryEntry[] = [
       root_escape: 'forbidden',
       fs_writes_outside_root: 'audited',
     },
-    amendments: ['adr-077-worktreeinclude', 'adr-078-boundary-registry'],
+    amendments: ['adr-087-worktree-ffi-topology', 'adr-078-boundary-registry'],
     rationale:
       'Worktree SSoT primitive layer (1,972 LOC) — canonical create/destroy/list/prune/include/copy-on-write bound by @cleocode/paths. Post-PR-#487 the responsibilities are distinct from packages/core/src/worktree/ (SDK-level enrichment). Consumes worktrunk-core via worktree-napi.',
   },

--- a/packages/worktree/src/napi-binding.ts
+++ b/packages/worktree/src/napi-binding.ts
@@ -66,7 +66,7 @@ interface WorktreeInfoNapi {
 /**
  * Options for the napi `pruneWorktrees` binding (T10203).
  *
- * Mirrors `crates/worktree-napi`'s `PruneOpts` — see ADR-078 for the
+ * Mirrors `crates/worktree-napi`'s `PruneOpts` — see ADR-087 for the
  * worktrunk-core SDK boundary contract.
  */
 interface PruneOptsNapi {

--- a/packages/worktree/src/worktree-prune.ts
+++ b/packages/worktree/src/worktree-prune.ts
@@ -2,7 +2,7 @@
  * Worktree prune operation for @cleocode/worktree.
  *
  * Thin orchestration over the `worktrunk_core` SDK exposed via
- * `@cleocode/worktree-napi` (T10203 / ADR-078). The native binding owns:
+ * `@cleocode/worktree-napi` (T10203 / ADR-087). The native binding owns:
  *
  * - Git-aware prune-plan construction (`napi.pruneWorktrees`) — read-only
  *   discovery of merged-in worktrees + orphan branches.


### PR DESCRIPTION
Documents the canonical 4-surface napi-rs layout and fixes dangling ADR slug references.

Closes T10439
Refs: T10431