### PR TITLE
fix(T9901): cleo docs add E_INTERNAL regression (gh-#98)

### DIFF
--- a/.changeset/T9901.md
+++ b/.changeset/T9901.md
@@ -1,0 +1,9 @@
+---
+"@cleocode/core": patch
+---
+
+fix(docs): cleo docs add succeeds (attachment-store-v2 regression) (T9901 / gh-#98)
+
+Lock in the regression for `cleo docs add` → `E_INTERNAL: Failed to run the query '\n'`. The original failure (cleo 2026.4.101) was a `better-sqlite3` binding fault inside drizzle's tagged-template surface — silently resolved by T1041 (commit 885a4e5d0, 2026-04-20) when the v2 store migrated to Node 24 `node:sqlite` + `drizzle-orm/node-sqlite`. No explicit regression test landed at the time. This adds one against the legacy backend so future bindings drift cannot silently re-open the bug class.
+
+Closes T9901. Closes #98. Saga: T9862.

--- a/packages/core/src/store/__tests__/attachment-store-v2.test.ts
+++ b/packages/core/src/store/__tests__/attachment-store-v2.test.ts
@@ -290,3 +290,91 @@ describe('createAttachmentStoreV2 (legacy backend, forced)', () => {
     await expect(store.remove('unknown-id', 'T999')).resolves.toBeUndefined();
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// T9901 / gh-#98 regression — `cleo docs add` MUST NOT raise
+// E_INTERNAL "Failed to run the query '\n'" on a clean project.
+//
+// The original bug (filed 2026-04-21 against cleo 2026.4.101) was a
+// `better-sqlite3` binding failure inside the drizzle template surface —
+// the v2 store opened a partially-bound DB, drizzle's tagged-template
+// rendered with no params, and the resulting SQL was a bare newline.
+// T1041 (commit 885a4e5d0, Apr 20 2026) migrated the entire v2 surface to
+// Node 24's built-in `node:sqlite` + `drizzle-orm/node-sqlite`, removing
+// the failing binding entirely.
+//
+// These tests assert the regression-locked behaviour: a clean project
+// must complete `put` without throwing, and must not surface the bare-
+// newline SQL string anywhere in the error path. The legacy fallback is
+// also covered so the fix holds on hosts without the llmtxt peer deps.
+//
+// @bug gh-#98
+// @task T9901
+// @saga T9862
+// @supersedes T1041 (which silently resolved this — no explicit regression test landed)
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('T9901 / gh-#98 — cleo docs add does NOT raise E_INTERNAL', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-t9901-regression-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+    delete process.env['CLEO_DIR'];
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 500 });
+  });
+
+  it('legacy backend put does not throw and returns a populated envelope', async () => {
+    const { createAttachmentStoreV2 } = await import('../attachment-store-v2.js');
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStoreV2(tempDir, { backend: 'legacy' });
+
+    // The bug surfaced as a SQLite query-failure thrown synchronously from
+    // the drizzle template surface — capture the entire put() invocation
+    // and assert no error is thrown AND the response matches the contract.
+    const payload = new TextEncoder().encode('# Auth Design\n\nJWT with ES256 signing.\n');
+    const result = await store.put('T9901', {
+      name: 'auth.md',
+      data: payload,
+      contentType: 'text/markdown',
+    });
+
+    expect(result).toBeDefined();
+    expect(result.backend).toBe('legacy');
+    expect(result.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.attachmentId).toBeTruthy();
+    expect(result.attachmentId.length).toBeGreaterThan(0);
+  });
+
+  it('legacy backend put does not surface a bare-newline SQL error', async () => {
+    const { createAttachmentStoreV2 } = await import('../attachment-store-v2.js');
+    const { closeDb } = await import('../sqlite.js');
+    closeDb();
+
+    const store = createAttachmentStoreV2(tempDir, { backend: 'legacy' });
+
+    // The original bug raised `Failed to run the query '\n'` — a bare
+    // newline SQL string. Even if some unrelated error were to leak, this
+    // exact message MUST never appear in the v2 store path on HEAD.
+    let caught: unknown;
+    try {
+      await store.put('T9901', {
+        name: 'regression.md',
+        data: new TextEncoder().encode('regression-anchor'),
+      });
+    } catch (err) {
+      caught = err;
+    }
+    if (caught instanceof Error) {
+      expect(caught.message).not.toMatch(/Failed to run the query\s*'\n'/);
+      expect(caught.message).not.toContain("'\\n'");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug**: `cleo docs add <owner-id> <file>` failed with `E_INTERNAL: Failed to run the query '\n'` — a bare-newline SQL string from drizzle's tagged-template surface — when the `better-sqlite3` binding partially loaded inside the v2 attachment store. Filed 2026-04-21 against cleo `2026.4.101` (gh-#98).
- **Resolution**: Silently fixed by **T1041** (commit `885a4e5d0`, 2026-04-20) when the v2 store migrated to Node 24 built-in `node:sqlite` + `drizzle-orm/node-sqlite`, eliminating the failing native binding entirely. No explicit regression test landed at the time.
- **This PR**: Adds the missing regression coverage so future native-binding drift cannot silently re-open the bug class. No production code change — `cleo docs add` is verifiably working on HEAD against both the installed `2026.5.114` cleo CLI and the freshly-built worktree HEAD.

## Verification

Manual end-to-end repro of the exact scenario from gh-#98 (clean greenfield project, `cleo docs add T### .cleo/test-attachments/auth.md`) succeeded with a valid LAFS envelope:

```json
{
  "success": true,
  "data": {
    "attachmentId": "7c5e07d8-50bd-4698-8cf1-fd6194a0f737",
    "sha256": "32312d7e8abf139c3b35153bd6489ab7de0b3613fc545be5ea54fd3d421a6749",
    "refCount": 1,
    "kind": "local-file",
    "ownerId": "T001",
    "ownerType": "task"
  }
}
```

`cleo docs list --task T001` and `cleo docs fetch <id>` also return valid envelopes — the entire downstream chain the original bug blocked (list/fetch/remove/publish/versions) works end-to-end.

## Tests Added

`packages/core/src/store/__tests__/attachment-store-v2.test.ts`, new `describe('T9901 / gh-#98 — cleo docs add does NOT raise E_INTERNAL')` block with 2 tests:

1. `legacy backend put does not throw and returns a populated envelope` — asserts the v2 store `put` against a clean project succeeds and returns `{ backend, sha256: /^[0-9a-f]{64}$/, attachmentId: <truthy> }`.
2. `legacy backend put does not surface a bare-newline SQL error` — explicit string-match against the original error signature (`Failed to run the query '\n'` and `'\n'` in any error message).

Both tests run against the **legacy** backend so the regression holds even on hosts without llmtxt peer deps (CI matrix coverage). The llmtxt path is already covered by 6 existing tests in the same suite.

## Quality Gates

- `pnpm biome check` — clean
- `pnpm run build` — clean
- `pnpm exec vitest run packages/core/src/store` — **1242/1242 pass** (was 1240, +2)
- `pnpm exec vitest run packages/core/src/docs packages/cleo/src/dispatch` — **219/219 pass**

## Test Plan

- [x] Reproduce gh-#98 scenario on a clean project → docs add succeeds
- [x] Verify the worktree-built HEAD `node packages/cleo/dist/cli/index.js docs add ...` succeeds
- [x] New regression tests pass on first run
- [x] No production code paths changed — pure test addition + changeset
- [x] Full `packages/core/src/store` suite green (1242 tests)
- [x] `packages/core/src/docs` + `packages/cleo/src/dispatch` suites green (219 tests)

## Provenance

- Closes T9901 (Saga T9862)
- Closes #98
- Supersedes the silent fix in T1041 (commit `885a4e5d0`) with explicit regression coverage