### PR TITLE
feat(spawn): lint-changesets gate in spawn prompt (T10448)

### DIFF
--- a/.changeset/T10448.md
+++ b/.changeset/T10448.md
@@ -1,0 +1,17 @@
+---
+"@cleocode/core": patch
+---
+
+feat(spawn): wire lint-changesets gate into spawn prompt (T10448)
+
+Adds a pre-spawn hygiene gate (`## Changeset Lint Gate`) to the canonical
+spawn prompt builder. The gate instructs every spawned subagent to run
+`scripts/lint-changesets.mjs` BEFORE starting implementation work.
+
+- Fails fast on malformed changesets (silent aggregator failures downstream)
+- References the absolute script path under `projectRoot`
+- Lists canonical kinds: feat|fix|perf|refactor|docs|test|chore|breaking
+- Positioned between Evidence Gate and Quality Gates in prompt ordering
+
+Closes T10448
+Saga: T10431

--- a/packages/core/src/orchestration/__tests__/spawn-prompt.test.ts
+++ b/packages/core/src/orchestration/__tests__/spawn-prompt.test.ts
@@ -92,6 +92,7 @@ describe('buildSpawnPrompt — core contract', () => {
     expect(p).toContain('## Session Linkage');
     expect(p).toContain('## Stage-Specific Guidance');
     expect(p).toContain('## Evidence-Based Gate Ritual');
+    expect(p).toContain('## Changeset Lint Gate');
     expect(p).toContain('## Quality Gates');
     expect(p).toContain('## Return Format Contract');
   });
@@ -762,6 +763,67 @@ describe('buildSpawnPrompt — task documents section (T1614)', () => {
       protocol: 'implementation',
       projectRoot: PROJECT_ROOT,
       docAttachments: [TEXT_ATTACHMENT, BINARY_ATTACHMENT],
+    });
+    expect(result.unresolvedTokens).toHaveLength(0);
+  });
+});
+
+describe('buildSpawnPrompt — changeset lint gate (T10448)', () => {
+  it('includes the changeset lint gate section in all tiers', () => {
+    for (const tier of [0, 1, 2] as SpawnTier[]) {
+      const result = buildSpawnPrompt({
+        task: BASE_TASK,
+        protocol: 'implementation',
+        tier,
+        projectRoot: PROJECT_ROOT,
+      });
+      expect(result.prompt).toContain('## Changeset Lint Gate');
+      expect(result.prompt).toContain('lint-changesets.mjs');
+      expect(result.prompt).toContain('run BEFORE starting work');
+    }
+  });
+
+  it('references the absolute script path under project root', () => {
+    const result = buildSpawnPrompt({
+      task: BASE_TASK,
+      protocol: 'implementation',
+      projectRoot: PROJECT_ROOT,
+    });
+    expect(result.prompt).toContain(`${PROJECT_ROOT}/scripts/lint-changesets.mjs`);
+  });
+
+  it('instructs the agent to fail fast on malformed changesets', () => {
+    const result = buildSpawnPrompt({
+      task: BASE_TASK,
+      protocol: 'implementation',
+      projectRoot: PROJECT_ROOT,
+    });
+    expect(result.prompt).toContain('Do NOT start implementation');
+    expect(result.prompt).toContain('Fail fast here');
+    expect(result.prompt).toContain('feat|fix|perf|refactor|docs|test|chore|breaking');
+  });
+
+  it('places the changeset lint gate between Evidence Gate and Quality Gates', () => {
+    const result = buildSpawnPrompt({
+      task: BASE_TASK,
+      protocol: 'implementation',
+      projectRoot: PROJECT_ROOT,
+    });
+    const evidenceIdx = result.prompt.indexOf('## Evidence-Based Gate Ritual');
+    const changesetIdx = result.prompt.indexOf('## Changeset Lint Gate');
+    const qualityIdx = result.prompt.indexOf('## Quality Gates');
+    expect(evidenceIdx).toBeGreaterThan(-1);
+    expect(changesetIdx).toBeGreaterThan(-1);
+    expect(qualityIdx).toBeGreaterThan(-1);
+    expect(evidenceIdx).toBeLessThan(changesetIdx);
+    expect(changesetIdx).toBeLessThan(qualityIdx);
+  });
+
+  it('produces zero unresolved tokens when changeset lint gate is present', () => {
+    const result = buildSpawnPrompt({
+      task: BASE_TASK,
+      protocol: 'implementation',
+      projectRoot: PROJECT_ROOT,
     });
     expect(result.unresolvedTokens).toHaveLength(0);
   });

--- a/packages/core/src/orchestration/spawn-prompt.ts
+++ b/packages/core/src/orchestration/spawn-prompt.ts
@@ -1025,6 +1025,29 @@ function buildEvidenceGateBlock(taskId: string): string {
   ].join('\n');
 }
 
+/** Build the changeset-lint hygiene gate block (T10448). */
+function buildChangesetLintGateBlock(projectRoot: string): string {
+  const scriptPath = join(projectRoot, 'scripts', 'lint-changesets.mjs');
+  return [
+    '## Changeset Lint Gate (T10448 — run BEFORE starting work)',
+    '',
+    '> Pre-spawn hygiene check: validate that all `.changeset/*.md` entries are well-formed before you begin implementation.',
+    '> Malformed changesets cause silent aggregator failures downstream. Fail fast here.',
+    '',
+    '```bash',
+    `node ${scriptPath}   # validates every .changeset/*.md file independently`,
+    '```',
+    '',
+    '**If this gate fails**:',
+    '1. Do NOT start implementation.',
+    '2. Fix the malformed changeset(s) listed in the output.',
+    '3. Re-run the lint gate until it passes.',
+    '4. Only then proceed to the Stage-Specific Guidance below.',
+    '',
+    'Canonical kinds: `feat|fix|perf|refactor|docs|test|chore|breaking`.',
+  ].join('\n');
+}
+
 /** Build the quality-gate block — biome + build + test. */
 function buildQualityGateBlock(): string {
   return [
@@ -1725,6 +1748,7 @@ export function buildSpawnPrompt(input: BuildSpawnPromptInput): BuildSpawnPrompt
   }
   authoredSections.push(buildStageGuidance(protocol, rcasdDir, outputDir));
   authoredSections.push(buildEvidenceGateBlock(taskId));
+  authoredSections.push(buildChangesetLintGateBlock(input.projectRoot));
   authoredSections.push(buildQualityGateBlock());
 
   // Tier-specific content — tier 0 pointer is authored; tier 1/2 embeds


### PR DESCRIPTION
## Summary

Wires the  hygiene gate into the canonical spawn prompt template.

### What changed
- Added  to 
- Injects a  section into every spawn prompt (all tiers 0/1/2)
- Positioned between Evidence Gate and Quality Gates
- References absolute  path
- Instructs agents to fail fast on malformed changesets before starting work

### Acceptance
- [x] lint-changesets.mjs referenced in spawn-prompt template
- [x] Fails fast on malformed changesets (gate runs before stage guidance)
- [x] Tested: 5 new shape-based tests added to spawn-prompt.test.ts (93 total, all pass)

Closes T10448
Saga: T10431