### PR TITLE
docs(T9900): document cleo verify NEVER auto-completes contract (GH #94)

### DIFF
--- a/.changeset/t9900-verify-never-auto-completes.md
+++ b/.changeset/t9900-verify-never-auto-completes.md
@@ -1,0 +1,24 @@
+---
+id: t9900-verify-never-auto-completes
+tasks: [T9900]
+kind: docs
+summary: "GH #94 / T9900: document the canonical contract — cleo verify NEVER auto-completes (verify→complete is explicit)"
+---
+
+Resolves the GH #94 auto-complete inconsistency report by documenting
+the canonical contract in `docs/specs/CLEO-TASKS-API-SPEC.md §7.1`:
+`cleo verify` is scoped exclusively to `task.verification.*` and MUST
+NEVER mutate `task.status`. Closing a task is a separate, explicit
+`cleo complete <id>` action that re-validates evidence atoms
+(E_EVIDENCE_STALE protection).
+
+This is the policy already implemented in
+`packages/core/src/validation/engine-ops.ts` (policy (b)); the hint
+field `"All gates green. Run: cleo complete <id>"` is emitted on every
+gate write that drives `verification.passed = true`. The change here
+is doc + a GH #94 reproduction test in
+`packages/core/src/validation/__tests__/gate-verify-hint.test.ts`
+that explicitly asserts `task.status === 'pending'` is preserved
+after all gates green (the exact scenario T448 / T466 hit).
+
+No production code behavior change.

--- a/docs/specs/CLEO-TASKS-API-SPEC.md
+++ b/docs/specs/CLEO-TASKS-API-SPEC.md
@@ -339,6 +339,45 @@ cleo complete T###
 The HTTP equivalent (PROPOSED) is `POST /api/tasks/:id/verify` per
 `docs/specs/CLEO-STUDIO-HTTP-SPEC.md` §2.
 
+### 7.1 Contract — `cleo verify` NEVER auto-completes a task (GH #94)
+
+A `cleo verify` write is scoped exclusively to `task.verification.*`. Even
+when the final gate write drives `verification.passed = true`, the engine
+**never** mutates `task.status`. Closing a task is a separate, explicit
+action: the user (or orchestrator) MUST call `cleo complete <id>`, which
+re-validates every hard evidence atom (commit reachability, file sha256,
+test-run hash) before flipping `status → done`.
+
+This is the canonical contract per ADR-051 §10 (Pre-Complete Gate Ritual) and
+is enforced in `packages/core/src/validation/engine-ops.ts` (the comment
+labelled "policy (b): verify NEVER auto-completes"). The decision rests on
+two operational invariants:
+
+1. **Evidence staleness protection.** If `verify` auto-flipped status,
+   nothing would force the staleness re-check at `complete` time. An agent
+   could verify, then tamper with files, and the status would already be
+   `done` — bypassing the E_EVIDENCE_STALE guard entirely.
+2. **Lifecycle audit clarity.** Every status transition to `done` MUST be
+   accompanied by an explicit `cleo complete` audit entry. Coupling `verify`
+   and `complete` would blur the audit trail and break per-task evidence
+   re-validation.
+
+The engine emits a `hint` field on every gate write that drives
+`verification.passed = true`, so the agent knows the next step:
+
+```json
+{
+  "taskId": "T###",
+  "passed": true,
+  "missingGates": [],
+  "hint": "All gates green. Run: cleo complete T###"
+}
+```
+
+**Reference**: `packages/core/src/validation/__tests__/gate-verify-hint.test.ts`
+(GH #94 reproduction test asserts `status: 'pending'` is preserved after
+all gates pass).
+
 ---
 
 ## 8. External Task Links (sync)

--- a/packages/core/src/validation/__tests__/gate-verify-hint.test.ts
+++ b/packages/core/src/validation/__tests__/gate-verify-hint.test.ts
@@ -252,4 +252,81 @@ describe('validateGateVerify — hint field (GH #94 / T919)', () => {
     expect(data.action).toBe('set_all');
     expect(data.hint).toBe('All gates green. Run: cleo complete T104');
   });
+
+  /**
+   * GH #94 / T9900 — Reproduction test for the original bug report.
+   *
+   * Per the canonical contract (ADR-051 Pre-Complete Gate Ritual + policy (b)
+   * in validateGateVerify): `cleo verify` is a write to `task.verification`
+   * ONLY. It MUST NOT mutate `task.status`. Even when the final gate write
+   * drives `verification.passed = true`, the task lifecycle stays put until
+   * an explicit `cleo complete <id>` runs and re-validates evidence
+   * (E_EVIDENCE_STALE protection).
+   *
+   * This test seeds a task with `status: 'pending'` (the exact shape the
+   * GH #94 reporter observed) and asserts:
+   *   1. The engine's response carries `status: 'pending'` after gates green
+   *   2. The hint field directs the user to run `cleo complete`
+   *   3. The task in the data store still has `status: 'pending'`
+   *      (verified by reloading via the accessor)
+   *
+   * @task T9900
+   * @gh 94
+   */
+  it('keeps task.status as pending after all gates green (GH #94 reproduction)', async () => {
+    const taskId = 'T9094';
+    // Seed task with status 'pending' — the exact scenario GH #94 reported
+    // for T448 / T466 (docs tasks shipped at commit d70129a).
+    const accessor = await createSqliteDataAccessor(TEST_ROOT);
+    await seedTasks(accessor, [
+      {
+        id: taskId,
+        title: `GH #94 reproduction task`,
+        type: 'task',
+        status: 'pending',
+        priority: 'medium',
+        acceptance: ['AC1'],
+        files: ['seed.ts'],
+      },
+    ]);
+    await accessor.close();
+    resetDbState();
+
+    // Drive both required gates green via separate verify calls (the path
+    // that GH #94 reported was the one to misbehave).
+    await validateGateVerify(TEST_ROOT, {
+      taskId,
+      gate: 'implemented',
+      value: true,
+      evidence: evidenceFor('implemented'),
+    });
+    resetDbState();
+    const result = await validateGateVerify(TEST_ROOT, {
+      taskId,
+      gate: 'testsPassed',
+      value: true,
+      evidence: evidenceFor('testsPassed'),
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+
+    // Contract assertion 1 — engine result reports verification.passed=true
+    // but task.status STAYS pending (never auto-transitions to 'done').
+    expect(data.passed).toBe(true);
+    expect(data.missingGates).toHaveLength(0);
+    expect(data.status).toBe('pending');
+
+    // Contract assertion 2 — hint instructs the user to call cleo complete.
+    expect(data.hint).toBe(`All gates green. Run: cleo complete ${taskId}`);
+
+    // Contract assertion 3 — re-read from the store confirms persistence:
+    // verification is set, but the lifecycle status is untouched.
+    resetDbState();
+    const verifyAccessor = await createSqliteDataAccessor(TEST_ROOT);
+    const reloaded = await verifyAccessor.loadSingleTask(taskId);
+    await verifyAccessor.close();
+    expect(reloaded).toBeDefined();
+    expect(reloaded?.status).toBe('pending');
+    expect(reloaded?.verification?.passed).toBe(true);
+  });
 });

--- a/packages/core/src/validation/engine-ops.ts
+++ b/packages/core/src/validation/engine-ops.ts
@@ -673,11 +673,15 @@ export async function validateGateVerify(
       result.override = override.override;
     }
 
-    // GH #94 / T919 — policy (b): verify NEVER auto-completes.
+    // GH #94 / T919 / T9900 — policy (b): verify NEVER auto-completes.
     // When the final gate write drives verification.passed to true, emit a
     // clear next-step hint so agents and users know they must explicitly run
     // `cleo complete`.  Only emitted on write actions (not view/reset) when
     // all required gates are green.
+    //
+    // Contract is documented at docs/specs/CLEO-TASKS-API-SPEC.md §7.1 and
+    // reproduction-tested in packages/core/src/validation/__tests__/
+    // gate-verify-hint.test.ts ("GH #94 reproduction").
     if (
       (action === 'set_gate' || action === 'set_all') &&
       verification.passed === true &&


### PR DESCRIPTION
## Summary

Resolves [GH #94](https://github.com/kryptobaseddev/cleo/issues/94) — task auto-complete inconsistency — by documenting the canonical contract and adding a reproduction test.

**Decision**: NO auto-complete on verify. The canonical contract is **explicit two-step verify → complete** per ADR-051 Pre-Complete Gate Ritual.

The contract was already implemented in `packages/core/src/validation/engine-ops.ts` (policy (b), emitted as a `hint` field on every gate write that drives `verification.passed = true`). This PR makes the contract discoverable to users and locks it in with a reproduction test.

## Rationale (why explicit two-step, not auto-complete)

1. **Evidence staleness protection.** If `verify` auto-flipped `task.status`, nothing would force the staleness re-check at `complete` time. An agent could verify, then tamper with files, and the status would already be `done` — bypassing `E_EVIDENCE_STALE` entirely.
2. **Lifecycle audit clarity.** Every status transition to `done` MUST carry an explicit `cleo complete` audit entry. Coupling `verify` and `complete` would blur the trail.

## Changes

- `docs/specs/CLEO-TASKS-API-SPEC.md §7.1` — new contract section with rationale, response shape with `hint` field, and reference to the reproduction test
- `packages/core/src/validation/__tests__/gate-verify-hint.test.ts` — new GH #94 reproduction test that:
  - seeds a task with `status: 'pending'` (mirroring T448 / T466 from the bug report)
  - drives both required gates green via separate `validateGateVerify` calls
  - asserts `data.passed === true`, `data.status === 'pending'`, and `data.hint === 'All gates green. Run: cleo complete T9094'`
  - reloads via `createSqliteDataAccessor` and confirms the persisted row still has `status: 'pending'` and `verification.passed: true`
- `packages/core/src/validation/engine-ops.ts` — source comment now points at the spec section and reproduction test

**No production code behavior change.**

## Test plan

- [x] `pnpm exec vitest run packages/core/src/validation/__tests__/gate-verify-hint.test.ts` — 6/6 pass (including new GH #94 reproduction)
- [x] `pnpm exec vitest run packages/core/src/validation/__tests__/` — 250/250 pass
- [x] `pnpm exec vitest run packages/core/src/tasks/__tests__/` — 1063/1063 pass
- [x] `pnpm biome check .` — clean
- [x] `pnpm run build` — green
- [x] `node scripts/lint-changesets.mjs` — 131/131 valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)