### PR TITLE
fix(T9824): label validator accepts uppercase task-ID labels

### DIFF
--- a/.changeset/T9824.md
+++ b/.changeset/T9824.md
@@ -1,0 +1,19 @@
+---
+id: t9824-uppercase-task-id-labels
+tasks: [T9824]
+kind: fix
+summary: "validateLabels: accept canonical uppercase task-ID labels (T9813) per ADR-073"
+---
+
+`cleo add --labels T9813` and `cleo add-batch` with `labels: ['T9813']`
+previously failed with `E_VALIDATION: Invalid label format: must be
+lowercase alphanumeric with hyphens/periods`. Agents canonically tag
+tasks with the parent task ID in canonical uppercase form per
+ADR-073, so the validator now accepts labels matching `/^T\d{3,}$/`
+alongside the existing lowercase-alnum rule. Case is preserved at
+storage (Option A — no auto-lowercasing) so the stored label keeps
+its ADR-073 canonical form.
+
+Existing lowercase labels (`bug`, `v0.5.0`, `security`) are
+unaffected. Malformed task-ID-like strings (`T12`, `T9813x`,
+`XT9813`) are still rejected.

--- a/packages/core/src/tasks/__tests__/add.test.ts
+++ b/packages/core/src/tasks/__tests__/add.test.ts
@@ -98,6 +98,28 @@ describe('validateLabels', () => {
     expect(() => validateLabels(['UPPERCASE'])).toThrow('Invalid label format');
     expect(() => validateLabels(['has space'])).toThrow('Invalid label format');
   });
+
+  // T9824 — uppercase task-ID-shaped labels are canonical per ADR-073 and
+  // MUST be accepted so agents can tag tasks with their parent task ID.
+  it('accepts uppercase task-ID-shaped labels (T9824 / ADR-073)', () => {
+    expect(() => validateLabels(['T9813'])).not.toThrow();
+    expect(() => validateLabels(['T9813', 'T9814'])).not.toThrow();
+    expect(() => validateLabels(['T123'])).not.toThrow();
+    expect(() => validateLabels(['T99999'])).not.toThrow();
+    // Mixed: task-ID labels alongside conventional lowercase labels
+    expect(() => validateLabels(['T9813', 'bug', 'security'])).not.toThrow();
+  });
+
+  it('still rejects malformed task-ID-like labels (T9824)', () => {
+    // Lowercase 't' is not a canonical task-ID prefix — must remain rejected
+    expect(() => validateLabels(['t9813'])).not.toThrow(); // already matches lowercase rule
+    // Too few digits (< 3) — not a real task ID shape
+    expect(() => validateLabels(['T1'])).toThrow('Invalid label format');
+    expect(() => validateLabels(['T12'])).toThrow('Invalid label format');
+    // Wrong shape — still rejected
+    expect(() => validateLabels(['T9813x'])).toThrow('Invalid label format');
+    expect(() => validateLabels(['XT9813'])).toThrow('Invalid label format');
+  });
 });
 
 describe('validatePhaseFormat', () => {

--- a/packages/core/src/tasks/add.ts
+++ b/packages/core/src/tasks/add.ts
@@ -306,18 +306,32 @@ export function validateSize(size: string): asserts size is TaskSize {
 
 /**
  * Validate label format.
+ *
+ * Labels must be one of:
+ * - Lowercase alphanumeric with hyphens/periods (`^[a-z][a-z0-9.-]*$`)
+ *   — e.g. `my-label`, `v1.0`, `bug`, `security`
+ * - A canonical task-ID-shaped label (`^T\d{3,}$`) — case preserved per ADR-073
+ *   so agents can tag tasks with their canonical parent task ID (e.g. `T9813`).
+ *
  * @task T4460
+ * @task T9824 — uppercase task-ID label acceptance
  */
 export function validateLabels(labels: string[]): void {
   for (const label of labels) {
     const trimmed = label.trim();
+    // Task-ID-shaped labels (e.g. T9813) are accepted as-is — ADR-073 canonical form.
+    if (/^T\d{3,}$/.test(trimmed)) continue;
     if (!/^[a-z][a-z0-9.-]*$/.test(trimmed)) {
       throw new CleoError(
         ExitCode.VALIDATION_ERROR,
-        `Invalid label format: '${trimmed}' (must be lowercase alphanumeric with hyphens/periods)`,
+        `Invalid label format: '${trimmed}' (must be lowercase alphanumeric with hyphens/periods, or a task ID like T9813)`,
         {
-          fix: `Labels must match pattern ^[a-z][a-z0-9.-]*$ (e.g. my-label, v1.0)`,
-          details: { field: 'labels', expected: '^[a-z][a-z0-9.-]*$', actual: trimmed },
+          fix: `Labels must match pattern ^[a-z][a-z0-9.-]*$ (e.g. my-label, v1.0) or ^T\\d{3,}$ (e.g. T9813)`,
+          details: {
+            field: 'labels',
+            expected: '^[a-z][a-z0-9.-]*$ or ^T\\d{3,}$',
+            actual: trimmed,
+          },
         },
       );
     }


### PR DESCRIPTION
## Summary

`cleo add --labels T9813` and `cleo add-batch` with `labels: ['T9813']` previously failed with `E_VALIDATION: Invalid label format: must be lowercase alphanumeric with hyphens/periods`. Agents canonically tag tasks with the parent task ID in uppercase per ADR-073, so this broke a natural workflow.

`validateLabels` in `packages/core/src/tasks/add.ts` now accepts labels matching `/^T\d{3,}$/` alongside the existing lowercase-alnum rule. Storage preserves case (Option A — no auto-lowercasing) so labels keep their ADR-073 canonical form.

## Approach chosen

**Option A** — regex auto-accepts task-ID-shaped labels with case preserved. Picked over Option B (auto-lowercase) because the stored form should match ADR-073 canonical uppercase. Confirmed against existing storage path: `previewTask.labels = options.labels.map((l) => l.trim())` — no normalization, so accepting as-is keeps `T9813` rendered as `T9813`.

## Acceptance Criteria

- **AC1** — Root cause: `validateLabels` at `packages/core/src/tasks/add.ts:311`
- **AC2** — Validator accepts `/^T\d{3,}$/` (case preserved per ADR-073)
- **AC3** — `cleo add --labels T9813` succeeds (live module smoke against built dist/ confirmed)
- **AC4** — `cleo add-batch` with `labels: ['T9813','T9814']` succeeds (same path)
- **AC5** — Regression tests added in `packages/core/src/tasks/__tests__/add.test.ts`:
  - Accepts `['T9813']`, `['T9813','T9814']`, `['T123']`, `['T99999']`, mixed `['T9813','bug','security']`
  - Still rejects `['T12']`, `['T9813x']`, `['XT9813']` (malformed task-ID-like)
- **AC6** — No breaking change: `bug`, `v0.5.0`, `security`, `t9813` (lowercase) all still pass

## Test plan

- [x] Targeted: `pnpm exec vitest run packages/core/src/tasks/__tests__/add.test.ts` → **36/36 pass**
- [x] Build: `pnpm run build` → **green** (all packages)
- [x] Lint: `pnpm biome check --write` on modified files → **clean**
- [x] Live module smoke against built `packages/core/dist/tasks/add.js` → all 5 cases behave as expected
- [ ] CI: full `pnpm run test` (pre-existing env-related failures unrelated to label validation)

Saga T9862 Wave 2.