### PR TITLE
fix(T9842): IVTR Lead full-suite scope on infra-path changes

### DIFF
--- a/.changeset/T9842.md
+++ b/.changeset/T9842.md
@@ -1,0 +1,38 @@
+---
+id: t9842-ivtr-lead-blast-radius
+tasks: [T9842]
+kind: fix
+summary: "IVTR Lead Validate-phase prompt auto-injects full per-package test guidance on infrastructure touches (T9814 precedent)"
+---
+
+Fixes a Lead-spawn protocol gap surfaced by T9814 R2 (2026-05-20). The Validate-phase
+prompt produced by `resolvePhasePrompt()` previously only listed the targeted tests
+named in the task spec. When a SAVEPOINT refactor in `DataAccessor.transaction()`
+shipped with 6/6 + 34/34 + 9/9 targeted tests green, the IVTR Lead approved on that
+scope and CI surfaced a regression in `agent-resolver.test.ts preferTier` seconds
+later. The hotfix commit `baa996d2b` restored the outer-transaction case.
+
+**Change**: when the Implement-phase evidence bundle has `filesChanged` entries that
+match canonical infrastructure paths (`packages/core/src/store/`,
+`packages/core/src/orchestration/`, `packages/core/src/dispatch/`,
+`packages/cleo/src/dispatch/`, `packages/contracts/src/`, `packages/worktree/src/`,
+`packages/core/src/migration/`, or any path whose basename contains `transaction`,
+`pragma`, or `migration`), the Validate-phase Lead prompt is auto-enriched with:
+
+1. A `### Blast-Radius Test Scope — MANDATORY (T9842)` section listing every touched
+   file plus the exact `pnpm --filter @cleocode/<pkg> run test` command per affected
+   package.
+2. A new REJECT criterion `Infra-test-scope violation (T9842)` that loops the task
+   back with reason `infra-test-scope-violation` when targeted-only test evidence is
+   attached on an infrastructure touch.
+
+Implementation:
+- New SSoT module `packages/core/src/lifecycle/infra-touch.ts` —
+  `INFRASTRUCTURE_PATH_PATTERNS`, `INFRASTRUCTURE_BASENAME_SUBSTRINGS`,
+  pure `detectInfrastructureTouch()` and `buildBlastRadiusTestScopeSection()`.
+- `buildValidatePhaseInstruction()` in `packages/core/src/lifecycle/ivtr-loop.ts`
+  composes the new section into the Validate-phase Lead prompt.
+- `ct-validator/SKILL.md` documents the rule under a new "Blast-Radius Test Scope"
+  section, citing the T9814 precedent.
+- 21 new infra-touch unit tests + 3 new ivtr-loop integration tests that exercise
+  the synthetic infrastructure-touch + targeted-only-Lead-review path (AC3).

--- a/packages/core/src/lifecycle/__tests__/infra-touch.test.ts
+++ b/packages/core/src/lifecycle/__tests__/infra-touch.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for IVTR Lead R2 blast-radius infrastructure-touch detection.
+ *
+ * @task T9842
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildBlastRadiusTestScopeSection,
+  detectInfrastructureTouch,
+  INFRASTRUCTURE_BASENAME_SUBSTRINGS,
+  INFRASTRUCTURE_PATH_PATTERNS,
+} from '../infra-touch.js';
+
+describe('detectInfrastructureTouch', () => {
+  it('returns affected=false for null / undefined / empty', () => {
+    expect(detectInfrastructureTouch(undefined).affected).toBe(false);
+    expect(detectInfrastructureTouch(null).affected).toBe(false);
+    expect(detectInfrastructureTouch([]).affected).toBe(false);
+  });
+
+  it('returns affected=false for non-infrastructure paths', () => {
+    const result = detectInfrastructureTouch([
+      'packages/cleo/src/cli/commands/show.ts',
+      'packages/cleo/src/cli/commands/list.ts',
+      'docs/release/branch-protection-setup.md',
+    ]);
+    expect(result.affected).toBe(false);
+    expect(result.matchedPaths).toEqual([]);
+    expect(result.packages).toEqual([]);
+  });
+
+  it('detects packages/core/src/store/** as infrastructure', () => {
+    const result = detectInfrastructureTouch([
+      'packages/core/src/store/sqlite-data-accessor.ts',
+      'packages/core/src/store/open-cleo-db.ts',
+    ]);
+    expect(result.affected).toBe(true);
+    expect(result.matchedPaths).toHaveLength(2);
+    expect(result.packages).toEqual(['core']);
+  });
+
+  it('detects packages/contracts/src/** as infrastructure', () => {
+    const result = detectInfrastructureTouch(['packages/contracts/src/envelope.ts']);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['contracts']);
+  });
+
+  it('detects packages/core/src/orchestration/** as infrastructure', () => {
+    const result = detectInfrastructureTouch(['packages/core/src/orchestration/spawn-prompt.ts']);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['core']);
+  });
+
+  it('detects packages/core/src/dispatch/** as infrastructure', () => {
+    const result = detectInfrastructureTouch(['packages/core/src/dispatch/router.ts']);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['core']);
+  });
+
+  it('detects packages/cleo/src/dispatch/** as infrastructure', () => {
+    const result = detectInfrastructureTouch(['packages/cleo/src/dispatch/domains/ivtr.ts']);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['cleo']);
+  });
+
+  it('detects packages/worktree/src/** as infrastructure', () => {
+    const result = detectInfrastructureTouch(['packages/worktree/src/worktree-create.ts']);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['worktree']);
+  });
+
+  it('detects packages/core/src/migration/** as infrastructure', () => {
+    const result = detectInfrastructureTouch(['packages/core/src/migration/m0001-init.ts']);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['core']);
+  });
+
+  it('detects "transaction" substring in basename even outside canonical dirs', () => {
+    const result = detectInfrastructureTouch(['packages/brain/src/some-transaction-helper.ts']);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['brain']);
+  });
+
+  it('detects "pragma" substring in basename', () => {
+    const result = detectInfrastructureTouch(['packages/agents/src/sqlite-pragmas.ts']);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['agents']);
+  });
+
+  it('detects "migration" substring in basename', () => {
+    const result = detectInfrastructureTouch([
+      'packages/studio/src/lib/server/db/migration-runner.ts',
+    ]);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['studio']);
+  });
+
+  it('returns alphabetically-sorted unique packages on mixed input', () => {
+    const result = detectInfrastructureTouch([
+      'packages/worktree/src/worktree-create.ts',
+      'packages/contracts/src/envelope.ts',
+      'packages/core/src/store/sqlite.ts',
+      'packages/contracts/src/operations.ts', // duplicate package
+      'packages/cleo/src/cli/commands/show.ts', // NOT infra — filtered
+    ]);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['contracts', 'core', 'worktree']);
+  });
+
+  it('preserves matchedPaths order from input', () => {
+    const result = detectInfrastructureTouch([
+      'packages/cleo/src/cli/commands/list.ts', // NOT infra
+      'packages/core/src/store/sqlite.ts', // infra (index 1)
+      'docs/release/x.md', // NOT infra
+      'packages/contracts/src/envelope.ts', // infra (index 3)
+    ]);
+    expect(result.matchedPaths).toEqual([
+      'packages/core/src/store/sqlite.ts',
+      'packages/contracts/src/envelope.ts',
+    ]);
+  });
+
+  it('normalizes windows backslashes', () => {
+    const result = detectInfrastructureTouch(['packages\\core\\src\\store\\sqlite.ts']);
+    expect(result.affected).toBe(true);
+    expect(result.packages).toEqual(['core']);
+  });
+
+  it('handles non-string / empty entries defensively', () => {
+    const result = detectInfrastructureTouch([
+      '',
+      'packages/core/src/store/sqlite.ts',
+      // @ts-expect-error — intentionally bad input
+      null,
+      // @ts-expect-error — intentionally bad input
+      123,
+    ]);
+    expect(result.affected).toBe(true);
+    expect(result.matchedPaths).toEqual(['packages/core/src/store/sqlite.ts']);
+  });
+
+  it('the canonical pattern constants are non-empty (registry sanity)', () => {
+    expect(INFRASTRUCTURE_PATH_PATTERNS.length).toBeGreaterThan(0);
+    expect(INFRASTRUCTURE_BASENAME_SUBSTRINGS.length).toBeGreaterThan(0);
+    // T9842 precedent — store/ is the path that broke T9814's IVTR review
+    expect(INFRASTRUCTURE_PATH_PATTERNS).toContain('packages/core/src/store/');
+  });
+});
+
+describe('buildBlastRadiusTestScopeSection', () => {
+  it('returns empty string when not affected', () => {
+    expect(
+      buildBlastRadiusTestScopeSection({ affected: false, matchedPaths: [], packages: [] }),
+    ).toBe('');
+  });
+
+  it('renders Blast-Radius header + T9842/T9814 citations + per-pkg commands', () => {
+    const section = buildBlastRadiusTestScopeSection({
+      affected: true,
+      matchedPaths: ['packages/core/src/store/sqlite-data-accessor.ts'],
+      packages: ['core'],
+    });
+    expect(section).toContain('Blast-Radius Test Scope');
+    expect(section).toContain('MANDATORY');
+    expect(section).toContain('T9842');
+    expect(section).toContain('T9814');
+    expect(section).toContain('agent-resolver');
+    expect(section).toContain('pnpm --filter @cleocode/core run test');
+    expect(section).toContain('packages/core/src/store/sqlite-data-accessor.ts');
+    expect(section).toContain('infra-test-scope-violation');
+  });
+
+  it('falls back to `pnpm run test` when affected but no package can be derived', () => {
+    // e.g. only a basename match like `Cargo.lock` won't yield a package dir.
+    const section = buildBlastRadiusTestScopeSection({
+      affected: true,
+      matchedPaths: ['some/odd/transaction.toml'],
+      packages: [],
+    });
+    expect(section).toContain('pnpm run test');
+    // Must not emit per-pkg commands for empty package list.
+    expect(section).not.toMatch(/pnpm --filter @cleocode\/[^ \n]+ run test/);
+  });
+
+  it('emits N pnpm --filter commands when N packages are touched', () => {
+    const section = buildBlastRadiusTestScopeSection({
+      affected: true,
+      matchedPaths: [
+        'packages/core/src/store/x.ts',
+        'packages/contracts/src/y.ts',
+        'packages/worktree/src/z.ts',
+      ],
+      packages: ['contracts', 'core', 'worktree'],
+    });
+    expect(section).toContain('pnpm --filter @cleocode/contracts run test');
+    expect(section).toContain('pnpm --filter @cleocode/core run test');
+    expect(section).toContain('pnpm --filter @cleocode/worktree run test');
+  });
+});

--- a/packages/core/src/lifecycle/__tests__/ivtr-loop.test.ts
+++ b/packages/core/src/lifecycle/__tests__/ivtr-loop.test.ts
@@ -303,6 +303,99 @@ describe('resolvePhasePrompt', () => {
     expect(prompt).toContain('REJECT criteria');
   });
 
+  it('injects Blast-Radius Test Scope into validate prompt when infrastructure files changed (T9842)', async () => {
+    await startIvtr('T999', { cwd: testDir });
+    const state = await advanceIvtr('T999', ['sha-impl'], { cwd: testDir });
+    const evidenceBundle: ImplEvidenceSummary[] = [
+      {
+        attachmentSha256: 'a'.repeat(64),
+        kind: 'impl-diff',
+        filesChanged: [
+          // Mirrors the T9814 precedent: a transaction primitive in core/store.
+          'packages/core/src/store/sqlite-data-accessor.ts',
+        ],
+        linesAdded: 12,
+        linesRemoved: 4,
+        durationMs: 1500,
+      },
+    ];
+    const prompt = resolvePhasePrompt(
+      'T999',
+      state,
+      'My Task',
+      'Refactor DataAccessor.transaction()',
+      undefined,
+      evidenceBundle,
+    );
+
+    // The synthetic infrastructure change with targeted-test-only Lead review
+    // would be caught by the updated protocol (AC3).
+    expect(prompt).toContain('Blast-Radius Test Scope');
+    expect(prompt).toContain('T9842');
+    // T9814 precedent must be cited in the Lead-spawn prompt (AC4).
+    expect(prompt).toContain('T9814');
+    expect(prompt).toContain('agent-resolver');
+    // Lead is instructed to run the full per-package vitest, not targeted-only.
+    expect(prompt).toContain('pnpm --filter @cleocode/core run test');
+    // New REJECT criterion is wired up.
+    expect(prompt).toContain('Infra-test-scope violation');
+    expect(prompt).toContain('infra-test-scope-violation');
+  });
+
+  it('does NOT inject Blast-Radius Test Scope when impl-diff is non-infrastructure (T9842)', async () => {
+    await startIvtr('T999', { cwd: testDir });
+    const state = await advanceIvtr('T999', ['sha-impl'], { cwd: testDir });
+    const evidenceBundle: ImplEvidenceSummary[] = [
+      {
+        attachmentSha256: 'b'.repeat(64),
+        kind: 'impl-diff',
+        filesChanged: [
+          'packages/cleo/src/cli/commands/show.ts',
+          'docs/release/branch-protection-setup.md',
+        ],
+      },
+    ];
+    const prompt = resolvePhasePrompt(
+      'T999',
+      state,
+      'My Task',
+      'CLI show polish',
+      undefined,
+      evidenceBundle,
+    );
+
+    expect(prompt).not.toContain('Blast-Radius Test Scope');
+    expect(prompt).not.toContain('infra-test-scope-violation');
+  });
+
+  it('aggregates filesChanged across multiple impl evidence entries (T9842)', async () => {
+    await startIvtr('T999', { cwd: testDir });
+    const state = await advanceIvtr('T999', ['sha-impl'], { cwd: testDir });
+    const evidenceBundle: ImplEvidenceSummary[] = [
+      {
+        attachmentSha256: 'a'.repeat(64),
+        kind: 'impl-diff',
+        filesChanged: ['packages/cleo/src/cli/commands/show.ts'],
+      },
+      {
+        attachmentSha256: 'c'.repeat(64),
+        kind: 'impl-diff',
+        filesChanged: ['packages/contracts/src/envelope.ts'],
+      },
+    ];
+    const prompt = resolvePhasePrompt(
+      'T999',
+      state,
+      'My Task',
+      'Mixed change',
+      undefined,
+      evidenceBundle,
+    );
+
+    expect(prompt).toContain('Blast-Radius Test Scope');
+    expect(prompt).toContain('pnpm --filter @cleocode/contracts run test');
+  });
+
   it('generates audit prompt after validate (T9216: audit phase added)', async () => {
     await startIvtr('T999', { cwd: testDir });
     await advanceIvtr('T999', ['sha-i'], { cwd: testDir });

--- a/packages/core/src/lifecycle/infra-touch.ts
+++ b/packages/core/src/lifecycle/infra-touch.ts
@@ -1,0 +1,265 @@
+/**
+ * Infrastructure-touch detection for IVTR Lead R2 (Validate phase).
+ *
+ * **Problem this solves (T9842):**
+ *
+ * The IVTR Lead spawn prompt previously instructed the Validate-phase agent to
+ * run only the test files explicitly named in the task spec. When an
+ * "implementation" change touched an infrastructure file — e.g. a transaction
+ * primitive in `packages/core/src/store/sqlite-data-accessor.ts` — the Lead
+ * verified targeted unit tests passed but missed cross-package regressions.
+ *
+ * **Precedent — T9814 R2 (2026-05-20):**
+ *
+ * T9814 swapped `BEGIN IMMEDIATE` for SAVEPOINTs inside `DataAccessor.transaction()`
+ * to support nested transactions for `add-batch`. The targeted tests passed (6/6
+ * for add-batch, 34/34 for add, 9/9 for allocate). IVTR Lead R2 approved on the
+ * targeted scope. CI then surfaced a regression in `agent-resolver.test.ts`
+ * (`preferTier` failed) because the agent-resolver depended on `BEGIN IMMEDIATE`
+ * outer-transaction semantics that SAVEPOINTs do not replicate verbatim. The
+ * hotfix commit `baa996d2b` restored the outer-tx case.
+ *
+ * **Rule (this module):**
+ *
+ * When the Implement-phase evidence bundle includes `filesChanged` that match
+ * any of the canonical infrastructure path patterns, the Lead's Validate-phase
+ * prompt MUST instruct it to run the full per-package vitest suite for every
+ * package whose source surface was touched — not the targeted tests alone.
+ *
+ * Infrastructure paths include:
+ *  - `packages/core/src/store/**`              (DB chokepoint, transactions, migrations)
+ *  - `packages/core/src/orchestration/**`      (spawn-prompt, dispatch resolution)
+ *  - `packages/core/src/dispatch/**`           (typed-dispatch, domain handlers)
+ *  - `packages/contracts/src/**`               (cross-package types — every consumer rebuilds)
+ *  - `packages/worktree/src/**`                (worktree-create / git-shim integration)
+ *  - `packages/core/src/migration/**`          (schema bootstrapping)
+ *  - any path containing `transaction` or `pragma` in its basename
+ *
+ * @task T9842 — IVTR Lead spawn prompt blast-radius test scope
+ * @precedent T9814 — SAVEPOINT refactor broke agent-resolver.preferTier despite green targeted tests
+ */
+
+// =============================================================================
+// CANONICAL PATH PATTERNS
+// =============================================================================
+
+/**
+ * Canonical infrastructure-path glob patterns.
+ *
+ * Each pattern is matched as a string-prefix test against forward-slashed paths
+ * (no real glob engine needed for the current shape — every pattern is a
+ * directory prefix or a substring match on `transaction`/`pragma`/`migration`).
+ *
+ * Order matters only for documentation: the matcher is a logical OR.
+ *
+ * @task T9842
+ */
+export const INFRASTRUCTURE_PATH_PATTERNS: readonly string[] = [
+  // Database / store chokepoint
+  'packages/core/src/store/',
+  // Orchestration surface — spawn prompts, dispatch resolution, IVTR
+  'packages/core/src/orchestration/',
+  // Typed dispatch — every CLI command routes through here
+  'packages/core/src/dispatch/',
+  'packages/cleo/src/dispatch/',
+  // Cross-package contracts — every consumer rebuilds against changes here
+  'packages/contracts/src/',
+  // Worktree provisioning + git-shim — orchestrator infrastructure
+  'packages/worktree/src/',
+  // Schema migrations — bootstrap path for every fresh init
+  'packages/core/src/migration/',
+] as const;
+
+/**
+ * Substring patterns matched against a path's basename (case-insensitive).
+ *
+ * A file outside the directory-prefix patterns above is still considered an
+ * infrastructure touch when its basename signals transactional / pragma /
+ * migration semantics — these change shared invariants regardless of the
+ * package they live in.
+ *
+ * @task T9842
+ */
+export const INFRASTRUCTURE_BASENAME_SUBSTRINGS: readonly string[] = [
+  'transaction',
+  'pragma',
+  'migration',
+] as const;
+
+// =============================================================================
+// PURE DETECTION
+// =============================================================================
+
+/**
+ * Result of {@link detectInfrastructureTouch}.
+ *
+ * @task T9842
+ */
+export interface InfrastructureTouchResult {
+  /** True iff any file in the input matches an infrastructure pattern. */
+  affected: boolean;
+  /** The subset of input paths that matched. Order preserved from input. */
+  matchedPaths: string[];
+  /**
+   * Sorted unique list of package directory names (e.g. `core`, `contracts`,
+   * `worktree`) that were touched. Useful for composing
+   * `pnpm --filter @cleocode/<pkg> run test` commands.
+   *
+   * Returned in ascending alphabetical order for deterministic prompt rendering.
+   */
+  packages: string[];
+}
+
+/**
+ * Normalize a path: collapse backslashes, strip leading `./`, lowercase.
+ */
+function normalize(p: string): string {
+  return p.replace(/\\/g, '/').replace(/^\.\//, '').toLowerCase();
+}
+
+/**
+ * Extract the `@cleocode/<pkg>` package short-name from a `packages/<pkg>/…`
+ * path. Returns `null` if the path is not under `packages/`.
+ */
+function packageOf(normalizedPath: string): string | null {
+  if (!normalizedPath.startsWith('packages/')) return null;
+  const rest = normalizedPath.slice('packages/'.length);
+  const slash = rest.indexOf('/');
+  if (slash <= 0) return null;
+  return rest.slice(0, slash);
+}
+
+/**
+ * Return the basename portion of a path (everything after the final `/`).
+ */
+function basenameOf(normalizedPath: string): string {
+  const slash = normalizedPath.lastIndexOf('/');
+  return slash === -1 ? normalizedPath : normalizedPath.slice(slash + 1);
+}
+
+/**
+ * Detect whether any file in `filesChanged` lives on a CLEO infrastructure
+ * code path that demands a full per-package test scope rather than targeted
+ * tests alone.
+ *
+ * **Semantics:**
+ *
+ * - A path matches when its normalized form starts with one of the directory
+ *   patterns in {@link INFRASTRUCTURE_PATH_PATTERNS}, **or** when its basename
+ *   contains one of {@link INFRASTRUCTURE_BASENAME_SUBSTRINGS} as a substring.
+ * - The match is case-insensitive and tolerant of `./` prefixes and Windows
+ *   backslashes.
+ * - The `packages` field is sorted alphabetically with duplicates removed so
+ *   the prompt renders deterministically.
+ *
+ * **Used by:** {@link buildValidatePhaseInstruction} in `./ivtr-loop.ts`.
+ *
+ * @param filesChanged - Relative repo paths from the Implement-phase evidence
+ *                       bundle (`ImplEvidenceSummary.filesChanged`). May be
+ *                       empty or undefined-flat.
+ * @returns Detection result. When `affected === false`, `matchedPaths` and
+ *          `packages` are empty arrays.
+ *
+ * @task T9842
+ * @example
+ * ```ts
+ * detectInfrastructureTouch([
+ *   'packages/core/src/store/sqlite-data-accessor.ts',
+ *   'packages/cleo/src/cli/commands/show.ts',
+ * ]);
+ * // → { affected: true,
+ * //     matchedPaths: ['packages/core/src/store/sqlite-data-accessor.ts'],
+ * //     packages: ['core'] }
+ * ```
+ */
+export function detectInfrastructureTouch(
+  filesChanged: readonly string[] | undefined | null,
+): InfrastructureTouchResult {
+  if (!filesChanged || filesChanged.length === 0) {
+    return { affected: false, matchedPaths: [], packages: [] };
+  }
+
+  const matched: string[] = [];
+  const packageSet = new Set<string>();
+
+  for (const raw of filesChanged) {
+    if (typeof raw !== 'string' || raw.length === 0) continue;
+    const norm = normalize(raw);
+
+    const prefixHit = INFRASTRUCTURE_PATH_PATTERNS.some((pat) => norm.startsWith(pat));
+    let basenameHit = false;
+    if (!prefixHit) {
+      const base = basenameOf(norm);
+      basenameHit = INFRASTRUCTURE_BASENAME_SUBSTRINGS.some((sub) => base.includes(sub));
+    }
+
+    if (prefixHit || basenameHit) {
+      matched.push(raw);
+      const pkg = packageOf(norm);
+      if (pkg) packageSet.add(pkg);
+    }
+  }
+
+  return {
+    affected: matched.length > 0,
+    matchedPaths: matched,
+    packages: [...packageSet].sort(),
+  };
+}
+
+// =============================================================================
+// PROMPT FRAGMENT
+// =============================================================================
+
+/**
+ * Build the "Blast-Radius Test Scope" prompt section to be injected into the
+ * Validate-phase Lead spawn prompt when an infrastructure touch is detected.
+ *
+ * The section instructs the Lead to run the FULL per-package vitest suite for
+ * every touched package, citing the T9814 precedent.
+ *
+ * Returns an empty string when `result.affected === false`, so callers can
+ * unconditionally append the output.
+ *
+ * @param result - Output of {@link detectInfrastructureTouch}.
+ * @returns Markdown section (or empty string).
+ *
+ * @task T9842
+ */
+export function buildBlastRadiusTestScopeSection(result: InfrastructureTouchResult): string {
+  if (!result.affected) return '';
+
+  const packageCommands =
+    result.packages.length > 0
+      ? result.packages.map((pkg) => `pnpm --filter @cleocode/${pkg} run test`).join('\n')
+      : 'pnpm run test';
+
+  const matchedList = result.matchedPaths.map((p) => `- \`${p}\``).join('\n');
+
+  return `### Blast-Radius Test Scope — MANDATORY (T9842)
+
+> **Infrastructure paths were touched in this task.** Targeted test files alone
+> are INSUFFICIENT — you MUST run the full per-package vitest suite for every
+> affected package before passing this Validate phase.
+>
+> **Precedent (T9814 R2)**: A SAVEPOINT refactor in \`DataAccessor.transaction()\`
+> passed every targeted test (6/6 add-batch, 34/34 add, 9/9 allocate) but broke
+> \`agent-resolver.test.ts preferTier\`. The IVTR Lead approved on the targeted
+> scope and CI caught the regression. Full per-package runs prevent this class
+> of failure.
+
+#### Infrastructure-touched files
+
+${matchedList}
+
+#### Required test commands
+
+\`\`\`bash
+${packageCommands}
+\`\`\`
+
+Attach the JSON output of each run as evidence (\`cleo docs add --labels test-output\`)
+and reference the sha256 set in your \`--next\` call. **Approving on targeted-only
+test results when infrastructure paths are touched is grounds for loop-back with
+reason \`infra-test-scope-violation\`.**`;
+}

--- a/packages/core/src/lifecycle/ivtr-loop.ts
+++ b/packages/core/src/lifecycle/ivtr-loop.ts
@@ -33,6 +33,7 @@ import { createAttachmentStore } from '../store/attachment-store.js';
 import { getDb } from '../store/sqlite.js';
 import * as schema from '../store/tasks-schema.js';
 import { extractTypedGates, runGates } from '../tasks/gate-runner.js';
+import { buildBlastRadiusTestScopeSection, detectInfrastructureTouch } from './infra-touch.js';
 
 const log = getLogger('lifecycle:ivtr');
 
@@ -569,6 +570,19 @@ function buildValidatePhaseInstruction(
           .join('\n')
       : '(enumerate REQ-IDs from the task specification above and cross-reference the impl-diff sha256 refs in the evidence bundle)';
 
+  // T9842 — Blast-radius infrastructure-touch detection. Aggregate every
+  // `filesChanged` array from the impl-phase evidence bundle and feed it to
+  // the detector. When the impl touched an infrastructure path, the rendered
+  // section instructs the Lead to run full per-package tests rather than the
+  // targeted subset called out in the task spec.
+  const allFilesChanged = evidenceBundle.flatMap((e) => e.filesChanged ?? []);
+  const infraTouch = detectInfrastructureTouch(allFilesChanged);
+  const blastRadiusSection = buildBlastRadiusTestScopeSection(infraTouch);
+  const blastRadiusBlock = blastRadiusSection ? `\n\n${blastRadiusSection}\n` : '';
+  const blastRadiusRejectLine = infraTouch.affected
+    ? '\n- **Infra-test-scope violation (T9842)**: infrastructure paths were touched (see the Blast-Radius Test Scope section above) but no full per-package vitest run was attached. Loop-back reason: `infra-test-scope-violation`.'
+    : '';
+
   return `## Phase: Validate
 You are the Validate agent for task ${taskId}. Read the impl diff + evidence listed in the Implement-Phase Evidence Bundle above. Check spec↔code alignment per each acceptance criterion and REQ-ID.${escalationNote}
 
@@ -598,14 +612,13 @@ You are the Validate agent for task ${taskId}. Read the impl diff + evidence lis
 
 ### Impl-diff attachment refs to review
 
-${implRefHint}
-
+${implRefHint}${blastRadiusBlock}
 ### REJECT criteria — trigger loop-back if ANY of the following are true
 
 - **Spec-code mismatch**: an acceptance criterion or REQ-ID has no traceable code change in the impl diff.
 - **Missing test**: an acceptance criterion that requires test coverage has no corresponding test added or updated in the diff.
 - **Undocumented deviation**: the implementation deviates from the task spec without a documented reason (comment, ADR reference, or inline note in the diff).
-- **Quality gate not run**: the impl-phase evidence does not include proof that \`pnpm biome check\` and \`pnpm run build\` both passed (lint-report or command-output attachment with exit code 0).`;
+- **Quality gate not run**: the impl-phase evidence does not include proof that \`pnpm biome check\` and \`pnpm run build\` both passed (lint-report or command-output attachment with exit code 0).${blastRadiusRejectLine}`;
 }
 
 /**

--- a/packages/skills/skills/ct-validator/SKILL.md
+++ b/packages/skills/skills/ct-validator/SKILL.md
@@ -77,6 +77,62 @@ Governance: see **ADR-051** (programmatic gate integrity) which defines the evid
 
 ---
 
+## Blast-Radius Test Scope (MANDATORY · T9842)
+
+When acting as the IVTR Lead in the **Validate** phase (R2), the targeted test
+files named in the task spec are NOT sufficient evidence on their own when the
+Implement phase touched an infrastructure file. Targeted-only test review is
+how cross-package regressions slip past the Lead.
+
+### Precedent — T9814 R2
+
+T9814 swapped `BEGIN IMMEDIATE` for SAVEPOINTs in
+`packages/core/src/store/sqlite-data-accessor.ts` to support nested
+transactions for `add-batch`. Every targeted test passed (6/6 add-batch,
+34/34 add, 9/9 allocate). IVTR Lead R2 approved on the targeted scope. CI
+then surfaced `agent-resolver.test.ts preferTier` failing — the resolver
+depended on the outer `BEGIN IMMEDIATE` semantics that SAVEPOINTs do not
+replicate verbatim. Hotfix commit `baa996d2b` restored the outer-tx case.
+The Lead's targeted-only review missed a regression CI caught seconds later.
+
+### Rule
+
+If ANY file in the impl-phase evidence bundle's `filesChanged` matches a
+canonical infrastructure path, the Lead MUST run the full per-package vitest
+suite for every touched package — NOT the targeted files alone.
+
+### Canonical infrastructure paths
+
+- `packages/core/src/store/**` — DB chokepoint, transactions, migrations
+- `packages/core/src/orchestration/**` — spawn-prompt, dispatch resolution, IVTR
+- `packages/core/src/dispatch/**` and `packages/cleo/src/dispatch/**` — typed dispatch
+- `packages/contracts/src/**` — cross-package types (every consumer rebuilds)
+- `packages/worktree/src/**` — worktree-create / git-shim integration
+- `packages/core/src/migration/**` — schema bootstrapping
+- any path whose basename contains `transaction`, `pragma`, or `migration`
+
+### Required test commands per touched package
+
+```bash
+pnpm --filter @cleocode/<pkg> run test  # for each touched package
+```
+
+Attach the JSON output of each run as evidence
+(`cleo docs add --labels test-output`) and reference the sha256 set in the
+`--next` call. Approving on targeted-only results when infrastructure paths
+are touched is grounds for loop-back with reason `infra-test-scope-violation`.
+
+### Enforcement
+
+The IVTR Lead spawn prompt is auto-enriched by `resolvePhasePrompt()` in
+`packages/core/src/lifecycle/ivtr-loop.ts` — when an infrastructure touch is
+detected via `detectInfrastructureTouch()` (`packages/core/src/lifecycle/infra-touch.ts`),
+a `### Blast-Radius Test Scope — MANDATORY (T9842)` block is appended to
+the Validate-phase Lead prompt, listing the touched packages and the exact
+`pnpm --filter` commands the Lead must run.
+
+---
+
 ## Output Format
 
 ### Validation Report Structure


### PR DESCRIPTION
## Summary

Closes the IVTR Lead-spawn protocol gap surfaced by **T9814 R2** (2026-05-20).
When an impl-phase change touches an infrastructure path, the Validate-phase Lead
prompt now auto-injects a **Blast-Radius Test Scope — MANDATORY (T9842)** section
listing the touched files and emitting exact `pnpm --filter @cleocode/<pkg> run test`
commands per affected package, plus a new REJECT criterion (`infra-test-scope-violation`).

## Why

T9814 R2 swapped `BEGIN IMMEDIATE` for SAVEPOINTs in `DataAccessor.transaction()`. All
targeted tests passed (6/6 add-batch · 34/34 add · 9/9 allocate). The IVTR Lead R2
approved on that scope; CI immediately surfaced `agent-resolver.test.ts preferTier`
failing — the resolver depended on the outer `BEGIN IMMEDIATE` semantic that SAVEPOINTs
do not replicate verbatim. Hotfix commit `baa996d2b` restored the outer-tx case.
Targeted-test-only Lead review is how cross-package infrastructure regressions slip past.

## Changes

- **New SSoT** `packages/core/src/lifecycle/infra-touch.ts` —
  `INFRASTRUCTURE_PATH_PATTERNS` (8 canonical dir prefixes) +
  `INFRASTRUCTURE_BASENAME_SUBSTRINGS` (`transaction` / `pragma` / `migration`) +
  pure `detectInfrastructureTouch()` + `buildBlastRadiusTestScopeSection()`.
- **`buildValidatePhaseInstruction()`** in `packages/core/src/lifecycle/ivtr-loop.ts`
  aggregates `filesChanged` across every impl evidence summary, runs the detector,
  and injects the blast-radius section + REJECT criterion.
- **`ct-validator/SKILL.md`** adds a "Blast-Radius Test Scope (MANDATORY · T9842)"
  section citing the T9814 precedent and enforcement surface.
- **21 unit tests** for the detector + builder, **3 integration tests** in
  `ivtr-loop.test.ts` proving a synthetic `packages/core/src/store/` touch yields the
  full Lead guidance.

## Acceptance (per task spec)

| AC | Status |
|---|---|
| 1. Lead prompt includes blast-radius-aware full-suite scope on infra paths | done |
| 2. ct-validator skill documents the rule | done |
| 3. Synthetic infra-change-with-targeted-only-review would be caught | done — integration tests in `ivtr-loop.test.ts` |
| 4. T9814 R2 precedent cited in orchestrator notes | done — prompt body, skill section, and commit message all cite T9814 |

## Test plan

- [x] `pnpm biome check .` — clean
- [x] `pnpm run build` — green (~25s)
- [x] `pnpm exec vitest run packages/core/src/lifecycle/__tests__/infra-touch.test.ts packages/core/src/lifecycle/__tests__/ivtr-loop.test.ts` — **58/58 passing**
- [x] `pnpm exec vitest run packages/core/src/orchestration packages/core/src/lifecycle packages/skills` — **49/49 files, 931/931 tests green**
- [x] `pnpm --filter @cleocode/core run test` (full per-package — dogfooding T9842 itself since `infra-touch.ts` lives in core) — **ZERO new failures vs baseline** (53 vs baseline 55 → net `+6 passing / -2 failing`; remaining 20 file failures pre-exist on `task/T9842` HEAD and are unrelated to this change).