### PR TITLE
fix(T9939): build.mjs declares cant as hard prereq of caamp via PACKAGE_DEPS

### DIFF
--- a/.changeset/t9939-build-cant-before-caamp.md
+++ b/.changeset/t9939-build-cant-before-caamp.md
@@ -1,0 +1,38 @@
+---
+id: t9939-build-cant-before-caamp
+tasks: [T9939]
+kind: fix
+summary: "build.mjs declares cant as a hard prereq of caamp via explicit PACKAGE_DEPS map (T9939)"
+---
+
+`caamp`'s tsup DTS step imports `@cleocode/cant` (via
+`rollup-plugin-dts` resolving `@cleocode/cant` declarations on disk). The
+previous wave structure in `build.mjs` ordered cant before caamp via
+comments only — a future refactor could silently break the ordering and
+produce a confusing `TS2307: Cannot find module '@cleocode/cant'` deep
+inside tsup's DTS output. Contributors hit this during T9853 hotfix prep
+and had to manually `pnpm --filter @cleocode/cant run build` before
+`pnpm run build` worked.
+
+Fix:
+
+- New module `scripts/build-deps.mjs` declaring the canonical
+  `PACKAGE_DEPS` map. Each entry maps a `packages/<pkg>/dist/` label to
+  the list of internal dist labels that MUST exist before that build
+  starts. The `cant -> caamp` edge is now data, not a comment.
+- New helper `assertDepsReady(label)` in `build.mjs` runs immediately
+  before every `buildPkg(...)` and before each raw `esbuild.build(...)`
+  call in waves 5, 6, and 8. Throws `E_BUILD_DEP_MISSING` with an
+  actionable message if any declared dep's `dist/` is absent, instead of
+  letting tsup explode 30 seconds later inside rollup-plugin-dts.
+- Regression test suite at `scripts/__tests__/build-deps.test.mjs` locks
+  the cant→caamp edge, asserts every dep is itself a known key (no
+  orphans), proves the graph is acyclic via Kahn's algorithm, and
+  verifies cant precedes caamp in the topological sort.
+
+Verified end-to-end: `rm -rf packages/cant/dist packages/caamp/dist &&
+pnpm run build` now succeeds without any manual filter-build of cant
+first (build complete in 25s). The negative path was also exercised —
+calling `assertDepsReady('packages/caamp/dist/')` with cant/dist absent
+correctly throws `E_BUILD_DEP_MISSING` referencing
+`packages/cant/dist/`.

--- a/build.mjs
+++ b/build.mjs
@@ -28,6 +28,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { resolve, dirname, join, relative, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
+import { depsFor } from './scripts/build-deps.mjs';
 
 // ---------------------------------------------------------------------------
 // Auto-scan: build core entry points by scanning the source tree rather than
@@ -543,16 +544,56 @@ function validateCoreEntryPoints() {
 // ---------------------------------------------------------------------------
 
 /**
+ * Hard-prereq assertion: throw `E_BUILD_DEP_MISSING` if any declared internal
+ * dep's `dist/` directory is absent before we start building `<label>`.
+ *
+ * Replaces the implicit "wave comments declare ordering" pattern with an
+ * explicit data-driven check (T9939). The dep declarations live in
+ * `scripts/build-deps.mjs`; if a future refactor reorders waves and breaks
+ * the topological invariant, this assertion fires at the wave gate with an
+ * actionable error instead of letting tsup explode with a confusing
+ * `TS2307: Cannot find module '@cleocode/cant'` deep in rollup-plugin-dts.
+ *
+ * Skips silently when the label is not in `PACKAGE_DEPS` — only declared
+ * deps are checked, never invented ones.
+ *
+ * @param {string} label - The dist label, e.g. `"packages/caamp/dist/"`.
+ * @throws Error with code `E_BUILD_DEP_MISSING` when a declared dep is absent.
+ */
+function assertDepsReady(label) {
+  const deps = depsFor(label);
+  if (deps.length === 0) return;
+  const missing = deps.filter((dep) => !existsSync(resolve(__dirname, dep)));
+  if (missing.length > 0) {
+    const err = new Error(
+      `E_BUILD_DEP_MISSING: ${label} depends on [${missing.join(', ')}] ` +
+        `but their dist/ directories are absent. ` +
+        `This indicates a wave-ordering regression in build.mjs — the wave ` +
+        `that builds ${label} must run AFTER every wave that builds its deps. ` +
+        `See scripts/build-deps.mjs for the canonical dependency declarations.`,
+    );
+    /** @type {any} */ (err).code = 'E_BUILD_DEP_MISSING';
+    throw err;
+  }
+}
+
+/**
  * Spawn `pnpm --filter <filter> run build` and return a Promise that resolves
  * when the process exits 0 or rejects with a descriptive error on non-zero exit.
  * Timing is logged on success so waves can be compared against the old
  * sequential baseline.
+ *
+ * Before spawning the child process, asserts that every internal dep declared
+ * in `scripts/build-deps.mjs` for this `label` has produced its `dist/`. This
+ * is the regression-locked guard for the cant→caamp dep (T9939) and every
+ * other inter-package ordering invariant.
  *
  * @param {string} filter - pnpm filter expression (e.g. "@cleocode/lafs")
  * @param {string} label  - human-readable label for log output
  * @returns {Promise<void>}
  */
 function buildPkg(filter, label) {
+  assertDepsReady(label);
   const start = Date.now();
   return new Promise((resolve, reject) => {
     const proc = spawnPnpm(['--filter', filter, 'run', 'build'], {
@@ -708,6 +749,7 @@ export declare function is_canonical(skillPath: string, options?: IsCanonicalOpt
   //   (deps caamp, nexus, worktree — all ready after waves 3–4)
   // ---------------------------------------------------------------------------
   console.log('\n[build] Wave 5: core (esbuild + tsc declarations)');
+  assertDepsReady('packages/core/dist/');
   await esbuild.build(coreBuildOptions);
   await sanitizeSourcemaps('packages/core/dist'); // T9184
   console.log('  -> packages/core/dist/index.js');
@@ -738,6 +780,7 @@ export declare function is_canonical(skillPath: string, options?: IsCanonicalOpt
     // adapters uses esbuild inline + tsc for .d.ts — wrap inline to keep
     // it in the same wave without a separate buildPkg invocation.
     (async () => {
+      assertDepsReady('packages/adapters/dist/');
       await esbuild.build(adaptersBuildOptions);
       await sanitizeSourcemaps('packages/adapters/dist'); // T9184
       console.log('  -> packages/adapters/dist/index.js (esbuild)');
@@ -784,6 +827,7 @@ export declare function is_canonical(skillPath: string, options?: IsCanonicalOpt
   // Wave 8: cleo esbuild bundle (deps adapters, playbooks, runtime — all ready)
   // ---------------------------------------------------------------------------
   console.log('\n[build] Wave 8: cleo (esbuild)');
+  assertDepsReady('packages/cleo/dist/');
   await esbuild.build(cleoBuildOptions);
   await sanitizeSourcemaps('packages/cleo/dist'); // T9184
   // Make CLI entry executable (shebang only works with +x)

--- a/scripts/__tests__/build-deps.test.mjs
+++ b/scripts/__tests__/build-deps.test.mjs
@@ -1,0 +1,139 @@
+/**
+ * Regression tests for scripts/build-deps.mjs (T9939).
+ *
+ * Locks two invariants that, if broken, would re-introduce the T9853 hotfix-
+ * prep blocker where contributors had to manually
+ * `pnpm --filter @cleocode/cant run build` before `pnpm run build` worked:
+ *
+ *   1. `@cleocode/cant` is declared as a HARD prereq of `@cleocode/caamp`.
+ *      Removing this edge is the literal regression we're guarding against.
+ *
+ *   2. The dependency graph is internally consistent: every dep referenced
+ *      in `PACKAGE_DEPS` is itself a known key in the map. Catches typos and
+ *      ghost references introduced during future refactors.
+ *
+ *   3. The graph is acyclic. A topological sort exists. (build.mjs's wave
+ *      structure already assumes this; the test makes the assumption explicit
+ *      so a future cycle introduction fails at PR time, not at runtime.)
+ *
+ * @task T9939
+ * @epic T9864
+ * @saga T9862
+ */
+
+import { describe, expect, it } from 'vitest';
+import { depsFor, PACKAGE_DEPS } from '../build-deps.mjs';
+
+describe('build-deps.mjs (T9939)', () => {
+  describe('regression-locked edges', () => {
+    it('declares @cleocode/cant as a hard prereq of @cleocode/caamp', () => {
+      // This is the literal T9939 regression. caamp's tsup DTS step imports
+      // @cleocode/cant. If a future refactor ever drops cant from caamp's
+      // dep list (or reorders waves so caamp builds before cant), this test
+      // fires before the bad PR can merge.
+      const caampDeps = depsFor('packages/caamp/dist/');
+      expect(caampDeps).toContain('packages/cant/dist/');
+    });
+
+    it('declares contracts + paths as prereqs of cant (the cant→caamp chain root)', () => {
+      // cant itself depends on contracts + lafs. If those are dropped, the
+      // wave-3 build of cant fails and the implicit cant→caamp chain breaks
+      // at a different layer than T9939 caught.
+      const cantDeps = depsFor('packages/cant/dist/');
+      expect(cantDeps).toContain('packages/contracts/dist/');
+      expect(cantDeps).toContain('packages/lafs/dist/');
+    });
+  });
+
+  describe('graph integrity', () => {
+    it('every declared dep is itself a known key in PACKAGE_DEPS', () => {
+      const knownKeys = new Set(Object.keys(PACKAGE_DEPS));
+      const orphans = [];
+      for (const [pkg, deps] of Object.entries(PACKAGE_DEPS)) {
+        for (const dep of deps) {
+          if (!knownKeys.has(dep)) {
+            orphans.push({ pkg, dep });
+          }
+        }
+      }
+      expect(orphans).toEqual([]);
+    });
+
+    it('produces a valid topological order (no cycles)', () => {
+      // Kahn's algorithm — succeeds iff the graph is a DAG.
+      const inDegree = new Map();
+      for (const pkg of Object.keys(PACKAGE_DEPS)) inDegree.set(pkg, 0);
+      for (const [pkg, deps] of Object.entries(PACKAGE_DEPS)) {
+        for (const dep of deps) {
+          // Edge: dep -> pkg (dep must build before pkg).
+          inDegree.set(pkg, (inDegree.get(pkg) ?? 0) + 1);
+        }
+      }
+      const ready = [];
+      for (const [pkg, deg] of inDegree.entries()) {
+        if (deg === 0) ready.push(pkg);
+      }
+      const order = [];
+      while (ready.length > 0) {
+        const next = ready.shift();
+        order.push(next);
+        // Decrement in-degree of every pkg that lists `next` as a dep.
+        for (const [pkg, deps] of Object.entries(PACKAGE_DEPS)) {
+          if (deps.includes(next)) {
+            const newDeg = (inDegree.get(pkg) ?? 0) - 1;
+            inDegree.set(pkg, newDeg);
+            if (newDeg === 0) ready.push(pkg);
+          }
+        }
+      }
+      // Every pkg should have been emitted; otherwise a cycle exists.
+      expect(order.length).toBe(Object.keys(PACKAGE_DEPS).length);
+    });
+
+    it('orders cant before caamp in the topological sort', () => {
+      // Stronger assertion: not only does a topo order exist, but the
+      // critical T9939 edge is honored. cant's index in the topo order must
+      // be strictly less than caamp's index.
+      const inDegree = new Map();
+      for (const pkg of Object.keys(PACKAGE_DEPS)) inDegree.set(pkg, 0);
+      for (const [pkg, deps] of Object.entries(PACKAGE_DEPS)) {
+        for (const _dep of deps) {
+          inDegree.set(pkg, (inDegree.get(pkg) ?? 0) + 1);
+        }
+      }
+      const ready = [];
+      for (const [pkg, deg] of inDegree.entries()) {
+        if (deg === 0) ready.push(pkg);
+      }
+      const order = [];
+      while (ready.length > 0) {
+        const next = ready.shift();
+        order.push(next);
+        for (const [pkg, deps] of Object.entries(PACKAGE_DEPS)) {
+          if (deps.includes(next)) {
+            const newDeg = (inDegree.get(pkg) ?? 0) - 1;
+            inDegree.set(pkg, newDeg);
+            if (newDeg === 0) ready.push(pkg);
+          }
+        }
+      }
+      const cantIdx = order.indexOf('packages/cant/dist/');
+      const caampIdx = order.indexOf('packages/caamp/dist/');
+      expect(cantIdx).toBeGreaterThanOrEqual(0);
+      expect(caampIdx).toBeGreaterThanOrEqual(0);
+      expect(cantIdx).toBeLessThan(caampIdx);
+    });
+  });
+
+  describe('depsFor()', () => {
+    it('returns an empty array for unknown labels (no throw)', () => {
+      expect(depsFor('packages/does-not-exist/dist/')).toEqual([]);
+    });
+
+    it('returns the declared deps for a known label', () => {
+      const deps = depsFor('packages/caamp/dist/');
+      expect(Array.isArray(deps)).toBe(true);
+      expect(deps.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/scripts/build-deps.mjs
+++ b/scripts/build-deps.mjs
@@ -1,0 +1,128 @@
+/**
+ * Build-order dependency declarations for the monorepo build orchestrator
+ * (`build.mjs`).
+ *
+ * This file makes inter-package build dependencies EXPLICIT in code, replacing
+ * the implicit ordering that previously lived only in `build.mjs`'s wave
+ * comments. The shape is consumed by:
+ *
+ *   1. `build.mjs` — `assertDepsReady(<pkgKey>)` is called immediately before
+ *      each `buildPkg(...)` invocation. It hard-fails the build with
+ *      `E_BUILD_DEP_MISSING` if any declared dep's `dist/` directory is absent.
+ *   2. `scripts/__tests__/build-deps.test.mjs` — regression-locks the critical
+ *      `cant -> caamp` edge (the original bug class from T9939) plus a wave-
+ *      ordering invariant check.
+ *
+ * ## Rationale (T9939)
+ *
+ * `caamp`'s tsup DTS step imports `@cleocode/cant` directly:
+ *
+ * ```ts
+ * // packages/caamp/src/manifest/validate.ts
+ * import { validateDocument } from '@cleocode/cant';
+ * ```
+ *
+ * tsup runs rollup-plugin-dts during the DTS phase, which requires `cant`'s
+ * `.d.ts` declarations to exist on disk BEFORE caamp builds. Without an
+ * explicit hard prereq, a future refactor of the wave structure could
+ * accidentally place caamp ahead of cant — the build would then fail with a
+ * confusing `TS2307: Cannot find module '@cleocode/cant'` deep inside the
+ * rollup-plugin-dts output, instead of an actionable error at the wave gate.
+ *
+ * Caught during T9853 hotfix prep, where contributors had to manually
+ * `pnpm --filter @cleocode/cant run build` BEFORE `pnpm run build` to unstick
+ * the caamp tsup DTS step.
+ *
+ * ## Adding a new package
+ *
+ * Add an entry whose key is the dist-path key used as the second arg of
+ * `buildPkg(...)` (e.g. `packages/caamp/dist/`) and whose value is the list of
+ * dist paths that MUST exist before that build starts. Internal deps only —
+ * external (npm) deps are out of scope. Test asserts every declared dep is a
+ * known dist key.
+ *
+ * @task T9939
+ * @epic T9864
+ * @saga T9862
+ */
+
+/**
+ * Canonical inter-package build dependency map.
+ *
+ * Keys and values are the same `packages/<pkg>/dist/` strings passed as the
+ * second arg to `buildPkg(...)` in `build.mjs`. Keeping a single canonical
+ * spelling means the assertion + the test can string-compare without a
+ * normalization step.
+ *
+ * @type {Readonly<Record<string, readonly string[]>>}
+ */
+export const PACKAGE_DEPS = Object.freeze({
+  // Wave 1: zero internal deps (true roots of the graph).
+  'packages/lafs/dist/': Object.freeze([]),
+  'packages/paths/dist/': Object.freeze([]),
+
+  // Wave 2: contracts depends on lafs (re-exports lafs envelope types).
+  'packages/contracts/dist/': Object.freeze(['packages/lafs/dist/']),
+
+  // Wave 3: worktree + git-shim + nexus + cant — all depend on
+  // contracts + paths (both ready after wave 2).
+  'packages/worktree/dist/': Object.freeze(['packages/contracts/dist/', 'packages/paths/dist/']),
+  'packages/git-shim/dist/': Object.freeze(['packages/contracts/dist/', 'packages/paths/dist/']),
+  'packages/nexus/dist/': Object.freeze(['packages/contracts/dist/', 'packages/paths/dist/']),
+  // ┌─ The critical edge this entire module exists to lock in. ─────────────┐
+  // │ cant declares contracts + lafs deps; the cant→caamp prereq lives on  │
+  // │ caamp's entry below.                                                  │
+  // └───────────────────────────────────────────────────────────────────────┘
+  'packages/cant/dist/': Object.freeze(['packages/contracts/dist/', 'packages/lafs/dist/']),
+
+  // Wave 4: caamp imports from @cleocode/cant in its tsup DTS step (T9939).
+  // This is the regression-locked edge — DO NOT remove cant from this list
+  // without also moving caamp to a wave that runs after wave 3.
+  'packages/caamp/dist/': Object.freeze([
+    'packages/cant/dist/',
+    'packages/contracts/dist/',
+    'packages/lafs/dist/',
+    'packages/paths/dist/',
+  ]),
+
+  // Wave 5: core depends on caamp, nexus, worktree, paths, contracts.
+  'packages/core/dist/': Object.freeze([
+    'packages/caamp/dist/',
+    'packages/contracts/dist/',
+    'packages/nexus/dist/',
+    'packages/paths/dist/',
+    'packages/worktree/dist/',
+  ]),
+
+  // Wave 6: runtime + adapters — both depend only on core (+ contracts).
+  'packages/runtime/dist/': Object.freeze(['packages/contracts/dist/', 'packages/core/dist/']),
+  'packages/adapters/dist/': Object.freeze(['packages/contracts/dist/', 'packages/core/dist/']),
+
+  // Wave 7: playbooks + mcp-adapter — both depend on core only.
+  'packages/playbooks/dist/': Object.freeze(['packages/contracts/dist/', 'packages/core/dist/']),
+  'packages/mcp-adapter/dist/': Object.freeze(['packages/contracts/dist/', 'packages/core/dist/']),
+
+  // Wave 8: cleo (esbuild) depends on adapters, playbooks, runtime, core.
+  'packages/cleo/dist/': Object.freeze([
+    'packages/adapters/dist/',
+    'packages/contracts/dist/',
+    'packages/core/dist/',
+    'packages/playbooks/dist/',
+    'packages/runtime/dist/',
+  ]),
+
+  // Wave 9: cleo-os depends on cleo + cant.
+  'packages/cleo-os/dist/': Object.freeze(['packages/cant/dist/', 'packages/cleo/dist/']),
+});
+
+/**
+ * Look up the declared deps for a given build target. Returns an empty array
+ * when the target has no declared deps (true roots) or is unknown.
+ *
+ * @param {string} distLabel - The `packages/<pkg>/dist/` label.
+ * @returns {readonly string[]}
+ */
+export function depsFor(distLabel) {
+  const found = PACKAGE_DEPS[distLabel];
+  return found ?? Object.freeze([]);
+}


### PR DESCRIPTION
## Summary

- Adds explicit, data-driven `PACKAGE_DEPS` map in `scripts/build-deps.mjs` declaring every inter-package build dependency in the monorepo. The critical `cant -> caamp` edge that broke T9853 hotfix prep is now regression-locked.
- New `assertDepsReady(label)` helper in `build.mjs` runs before every `buildPkg(...)` call and before each raw `esbuild.build(...)` in waves 5, 6, 8. Throws `E_BUILD_DEP_MISSING` with an actionable message if any declared dep's `dist/` is absent — instead of letting tsup explode 30s later inside `rollup-plugin-dts`.
- New vitest regression suite at `scripts/__tests__/build-deps.test.mjs` (7 tests) locks the `cant -> caamp` edge, asserts graph integrity (no orphan refs), proves acyclicity via Kahn's algorithm, and verifies `cant` precedes `caamp` in topological order.

## Test plan

- [x] Reproduce: `rm -rf packages/cant/dist packages/caamp/dist && pnpm run build` — succeeds in 25s without manual filter-build of cant
- [x] Negative path: simulated `assertDepsReady('packages/caamp/dist/')` with `cant/dist` absent — correctly throws `E_BUILD_DEP_MISSING` referencing `packages/cant/dist/`
- [x] All 7 new regression tests pass: `pnpm exec vitest run scripts/__tests__/build-deps.test.mjs`
- [x] All 248 existing scripts tests pass: `pnpm exec vitest run scripts/__tests__/`
- [x] Full repo biome check passes (3090 files)
- [x] Full `pnpm run build` succeeds from clean state

## Acceptance criteria (T9939)

- [x] caamp's tsup dts step imports `@cleocode/cant` and fails if cant dist is missing — confirmed, now caught at the wave gate with `E_BUILD_DEP_MISSING` before tsup runs
- [x] build.mjs declares cant as a hard prereq of caamp — explicit in `scripts/build-deps.mjs` `PACKAGE_DEPS['packages/caamp/dist/'].includes('packages/cant/dist/')`
- [x] Test: fresh checkout + `pnpm run build` succeeds without manual filter-build of cant first
- [x] Caught during T9853 hotfix prep — documented in changeset + scripts/build-deps.mjs rationale section

Refs: T9939, SAGA T9862, EPIC T9864