### PR TITLE
fix(T9947): cleo cancel verb + update --status cancelled regression locks

### DIFF
--- a/.changeset/T9947.md
+++ b/.changeset/T9947.md
@@ -1,0 +1,67 @@
+---
+id: T9947
+tasks: [T9947]
+kind: fix
+summary: "Regression-lock `cleo cancel <id>` + `cleo update --status cancelled` on pending tasks with no verification gates"
+---
+
+Two CLI cancellation papercuts reported during the v2026.5.93 ship of
+Saga T9787 are already fixed in HEAD (`cancel` is registered in
+`COMMAND_MANIFEST`; the engine wrapper no longer mis-labels
+`E_NOT_INITIALIZED`), but neither code path has been guarded by tests
+that would have caught the original regressions. T9947 adds those tests.
+
+### Bugs that were repro'd as fixed at HEAD (no source changes required)
+
+1. `cleo update <taskId> --status cancelled` succeeds on a pending task
+   whose `verification` row was never initialized via `cleo verify`. The
+   T9838-D + T9940 generalization (`cleoErrorToEngineResult`) closed the
+   misleading `E_NOT_INITIALIZED` blanket label.
+2. `cleo cancel <taskId>` is registered in
+   `packages/cleo/src/cli/generated/command-manifest.ts` and reaches the
+   `tasks.cancel` dispatch handler. The verb is also categorized under
+   "Task Management" in
+   `packages/core/src/routing/build-command-groups.ts`, so help text and
+   actual behavior agree.
+
+### Regression locks added
+
+- `packages/cleo/src/cli/__tests__/cancel.test.ts`:
+  - `cancel verb is registered in COMMAND_MANIFEST` — asserts the
+    manifest entry exists with `exportName: 'cancelCommand'`,
+    name=`cancel`, description matching the soft-terminal-state
+    wording, AND that `load()` resolves to the same `cancelCommand`
+    binding the CLI imports elsewhere (reference identity, so a future
+    generator drift cannot break the dispatch path without flagging).
+- `packages/cleo/src/dispatch/domains/__tests__/tasks.test.ts`:
+  - Four new dispatch tests cover the `mutate:tasks.cancel` handler:
+    delegation to `taskCancel(projectRoot, taskId, reason)`, `--reason`
+    forwarding, idempotent re-cancel surfacing `alreadyCancelled=true`,
+    and engine-error propagation (`E_INVALID_STATE` for a done task).
+  - The `getSupportedOperations` query + mutate expectations are
+    refreshed to include the ADR-073 saga sub-domain operations and the
+    new `cancel` entry is annotated as a T9947 regression lock so future
+    edits know why it MUST stay there.
+- `packages/core/src/tasks/__tests__/update-status-cancellation.test.ts`:
+  - Two new cases assert that a pending task with
+    `verification: undefined` (gates never initialized) cancels
+    cleanly via both `updateTask` (engine) and `taskUpdate` (engine-result
+    wrapper). The wrapper case re-confirms `success=true` rather than the
+    pre-T9838-D `E_NOT_INITIALIZED` failure mode.
+
+### Verified end-to-end
+
+Against the built CLI (v2026.5.116) on a fresh tempdir:
+
+- `cleo cancel T002 --reason "T9947 repro"` →
+  `{"success":true,"data":{"task":"T002","cancelled":true,"reason":"T9947 repro","cancelledAt":"..."}}`
+- `cleo update T003 --status cancelled` →
+  `{"success":true,"data":{"count":1,"ids":["T003"],"changes":["status","pipelineStage"],"status":"cancelled"}}`
+- `cleo --help | grep cancel` continues to list the verb under Task
+  Management; `cleo cancel --help` renders the verb-specific help block
+  (TASKID positional + `--reason` flag).
+
+Total: 8 new test cases added (2 CLI manifest registration + 4 dispatch
+cancel handler + 2 core engine wrapper) plus refreshed
+`getSupportedOperations` expectations to include the ADR-073 saga
+sub-domain operations.

--- a/packages/cleo/src/cli/__tests__/cancel.test.ts
+++ b/packages/cleo/src/cli/__tests__/cancel.test.ts
@@ -5,8 +5,16 @@
  *   - Command surface (name, description, taskId positional, --reason flag)
  *   - Dispatch call routes to `mutate` / `tasks` / `cancel` with the args
  *     supplied by the user (taskId + reason).
+ *   - **T9947 regression lock**: the `cancel` verb appears in
+ *     `COMMAND_MANIFEST` with the correct `exportName`, `name`,
+ *     `description`, and a `load()` function that resolves to the same
+ *     `cancelCommand` binding exported here. Pre-T9947 ship the help
+ *     generator surfaced `cancel` while the dispatch registry was missing
+ *     the entry, so invoking `cleo cancel <id>` returned `E_NOT_FOUND`
+ *     despite the `--help` text advertising it.
  *
  * @task T9838
+ * @task T9947
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -18,6 +26,7 @@ const { dispatchFromCli } = vi.hoisted(() => ({
 vi.mock('../../dispatch/adapters/cli.js', () => ({ dispatchFromCli }));
 
 import { cancelCommand } from '../commands/cancel.js';
+import { COMMAND_MANIFEST } from '../generated/command-manifest.js';
 
 describe('cancelCommand (CLI surface)', () => {
   beforeEach(() => {
@@ -76,5 +85,32 @@ describe('cancelCommand (CLI surface)', () => {
     expect(dispatchFromCli).toHaveBeenCalledTimes(1);
     const call = dispatchFromCli.mock.calls[0];
     expect(call[3]).toEqual({ taskId: 'T0002', reason: 'Superseded by T0003' });
+  });
+});
+
+describe('cancel verb is registered in COMMAND_MANIFEST (T9947 regression lock)', () => {
+  /**
+   * Pre-T9947 bug: the CLI help generator listed `cancel` under Task
+   * Management, but the `cleo` root subCommand registry never received a
+   * loader for it. Invoking `cleo cancel <id>` therefore exited with
+   * `E_NOT_FOUND`. This test asserts the manifest entry exists with the
+   * correct shape AND that its `load()` resolves to the same module export
+   * the rest of the CLI imports — making divergence impossible.
+   */
+  it('exposes a manifest entry with name="cancel"', () => {
+    const entry = COMMAND_MANIFEST.find((e) => e.name === 'cancel');
+    expect(entry).toBeDefined();
+    expect(entry?.exportName).toBe('cancelCommand');
+    expect(entry?.description).toMatch(/cancel/i);
+    expect(entry?.description).toMatch(/soft|reversible|restore/i);
+  });
+
+  it('manifest load() resolves to the same cancelCommand export', async () => {
+    const entry = COMMAND_MANIFEST.find((e) => e.name === 'cancel');
+    expect(entry).toBeDefined();
+    const loaded = await entry!.load();
+    // Reference identity: the manifest must load EXACTLY the binding the
+    // dispatch registry would otherwise miss.
+    expect(loaded).toBe(cancelCommand);
   });
 });

--- a/packages/cleo/src/dispatch/domains/__tests__/tasks.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/tasks.test.ts
@@ -73,6 +73,7 @@ import {
   taskAnalyze,
   taskArchive,
   taskBlockers,
+  taskCancel,
   taskComplexityEstimate,
   taskCurrentGet,
   taskDelete,
@@ -129,6 +130,10 @@ describe('TasksHandler', () => {
         'current',
         'label.list',
         'sync.links',
+        // ADR-073 — saga sub-domain (T9521 / T10125).
+        'saga.list',
+        'saga.members',
+        'saga.rollup',
       ]);
     });
 
@@ -138,6 +143,10 @@ describe('TasksHandler', () => {
         'add',
         'update',
         'complete',
+        // T9947 regression lock: `cancel` MUST appear in the dispatch registry
+        // so `cleo cancel <taskId>` is routable. Pre-T9947 ship the verb was
+        // surfaced in `--help` but absent from the registry — invoking it
+        // returned E_NOT_FOUND.
         'cancel',
         'delete',
         'archive',
@@ -152,6 +161,12 @@ describe('TasksHandler', () => {
         'sync.links.remove',
         'claim',
         'unclaim',
+        // ADR-073 — saga sub-domain (T9521 / T10125).
+        'saga.create',
+        'saga.add',
+        'saga.repair',
+        'saga.detach',
+        'saga.reconcile',
       ]);
     });
   });
@@ -834,6 +849,93 @@ describe('TasksHandler', () => {
 
       expect(result.success).toBe(true);
       expect(taskDelete).toHaveBeenCalledWith('/mock/project', 'T001', true);
+    });
+
+    // -------------------------------------------------------------------
+    // cancel — T9947 regression lock
+    //
+    // Two bugs reported against `cleo cancel`:
+    //   1. `cleo update <taskId> --status cancelled` returned E_NOT_INITIALIZED on
+    //      tasks whose verification gates had never been initialized (closed by
+    //      T9838-D — `taskUpdate` wrapper now surfaces real CleoError codes via
+    //      cleoErrorToEngineResult).
+    //   2. `cleo cancel <taskId>` was in `--help` output but invoking it returned
+    //      E_NOT_FOUND because the `cancel` operation was not reachable through
+    //      the dispatch registry.
+    //
+    // These tests lock both fixes in place against the TasksHandler:
+    //   - The 'cancel' op is dispatch-routable (handler.mutate('cancel', ...) returns
+    //     a real envelope rather than E_UNKNOWN_OPERATION).
+    //   - The cancel handler delegates to `taskCancel(projectRoot, taskId, reason)`.
+    //   - `--reason` is forwarded to the engine.
+    // -------------------------------------------------------------------
+    it('cancel - delegates to taskCancel (T9947 regression lock)', async () => {
+      vi.mocked(taskCancel).mockResolvedValue({
+        success: true,
+        data: {
+          task: 'T001',
+          cancelled: true,
+          cancelledAt: '2026-05-24T00:00:00.000Z',
+        },
+      });
+
+      const result = await handler.mutate('cancel', { taskId: 'T001' });
+
+      expect(result.success).toBe(true);
+      expect(taskCancel).toHaveBeenCalledWith('/mock/project', 'T001', undefined);
+    });
+
+    it('cancel - forwards --reason to engine (T9947)', async () => {
+      vi.mocked(taskCancel).mockResolvedValue({
+        success: true,
+        data: {
+          task: 'T002',
+          cancelled: true,
+          reason: 'Superseded by T003',
+          cancelledAt: '2026-05-24T00:00:00.000Z',
+        },
+      });
+
+      const result = await handler.mutate('cancel', {
+        taskId: 'T002',
+        reason: 'Superseded by T003',
+      });
+
+      expect(result.success).toBe(true);
+      expect(taskCancel).toHaveBeenCalledWith('/mock/project', 'T002', 'Superseded by T003');
+    });
+
+    it('cancel - surfaces idempotent re-cancel (alreadyCancelled=true) (T9947 / T9838)', async () => {
+      vi.mocked(taskCancel).mockResolvedValue({
+        success: true,
+        data: {
+          task: 'T003',
+          cancelled: true,
+          cancelledAt: '2026-05-20T00:00:00.000Z',
+          alreadyCancelled: true,
+        },
+      });
+
+      const result = await handler.mutate('cancel', { taskId: 'T003' });
+
+      expect(result.success).toBe(true);
+      // The wrapped engine payload propagates the alreadyCancelled flag.
+      expect((result.data as { alreadyCancelled?: boolean }).alreadyCancelled).toBe(true);
+    });
+
+    it('cancel - propagates engine error (E_INVALID_STATE for done task) (T9947)', async () => {
+      vi.mocked(taskCancel).mockResolvedValue({
+        success: false,
+        error: {
+          code: 'E_INVALID_STATE',
+          message: 'Cannot cancel a completed task',
+        },
+      });
+
+      const result = await handler.mutate('cancel', { taskId: 'T_DONE' });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('E_INVALID_STATE');
     });
 
     it('archive - delegates to taskArchive', async () => {

--- a/packages/core/src/tasks/__tests__/update-status-cancellation.test.ts
+++ b/packages/core/src/tasks/__tests__/update-status-cancellation.test.ts
@@ -77,6 +77,38 @@ describe('updateTask cancellation path (T9838-D)', () => {
     expect(result.changes).toContain('pipelineStage');
   });
 
+  it('pending task with NO verification gates initialized -> cancelled succeeds (T9947)', async () => {
+    // T9947 repro: a pending task with `verification` left explicitly null
+    // (gates never initialized via `cleo verify`) historically caused the
+    // engine wrapper to mis-label the rejection as `E_NOT_INITIALIZED`.
+    // Post-T9838-D + T9940 the wrapper surfaces real CleoError codes, but
+    // we lock the behaviour to prevent the regression class.
+    await seedTasks(accessor, [
+      {
+        id: 'T9947A',
+        title: 'Misfiled placeholder task',
+        status: 'pending',
+        priority: 'medium',
+        pipelineStage: 'research',
+        createdAt: new Date().toISOString(),
+        // verification is intentionally undefined — the task has never been
+        // routed through `cleo verify`, so no gate state exists.
+        verification: undefined,
+      },
+    ]);
+
+    const result = await updateTask(
+      { taskId: 'T9947A', status: 'cancelled' },
+      env.tempDir,
+      accessor,
+    );
+
+    expect(result.task.status).toBe('cancelled');
+    expect(result.task.cancelledAt).toBeTruthy();
+    expect(result.task.pipelineStage).toBe('cancelled');
+    expect(result.changes).toContain('status');
+  });
+
   it('active -> cancelled succeeds, stamps cancelledAt, syncs pipelineStage', async () => {
     await seedTasks(accessor, [
       {
@@ -250,6 +282,34 @@ describe('updateTask cancellation path (T9838-D)', () => {
         expect(result.error.code).not.toBe('E_NOT_INITIALIZED');
         // CleoError.toLAFSError() emits the catalog lafsCode for NOT_FOUND.
         expect(result.error.code).toBe('E_CLEO_NOT_FOUND');
+      }
+    });
+
+    it('pending task with verification=undefined cancels via wrapper (T9947)', async () => {
+      // T9947 repro through the engine wrapper:
+      // `cleo update <id> --status cancelled` on a pending task whose
+      // `verification` column is null/undefined MUST succeed. The earlier
+      // failure mode dressed an internal validation throw up as
+      // E_NOT_INITIALIZED at the wrapper layer.
+      await seedTasks(accessor, [
+        {
+          id: 'T9947B',
+          title: 'Wrapper repro — no gates initialized',
+          status: 'pending',
+          priority: 'medium',
+          pipelineStage: 'research',
+          createdAt: new Date().toISOString(),
+          verification: undefined,
+        },
+      ]);
+
+      const result = await taskUpdate(env.tempDir, 'T9947B', { status: 'cancelled' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.task.status).toBe('cancelled');
+        expect(result.data.task.cancelledAt).toBeTruthy();
+        expect(result.data.task.pipelineStage).toBe('cancelled');
       }
     });
   });


### PR DESCRIPTION
## Summary

Two CLI cancellation papercuts reported during the v2026.5.93 ship of Saga T9787 are already fixed in HEAD, but neither code path was guarded by tests that would have caught the original regressions. **T9947 adds those regression locks — zero source changes required.**

### Bugs verified fixed in HEAD

1. **`cleo update <taskId> --status cancelled` returned `E_NOT_INITIALIZED`** on tasks where verification gates were never initialized — closed by **T9838-D** + **T9940** (`cleoErrorToEngineResult`). Pending tasks with `verification: undefined` now flip to `cancelled` cleanly.
2. **`cleo cancel <taskId>` returned `E_NOT_FOUND`** despite being advertised in `--help` — closed when the cancel command landed in `COMMAND_MANIFEST` and was registered under "Task Management" in `build-command-groups.ts`.

## Tests added (8 new cases)

- `packages/cleo/src/cli/__tests__/cancel.test.ts` — **2 new tests** assert the `cancel` verb is in `COMMAND_MANIFEST` with the correct metadata, AND that its `load()` resolves to the same `cancelCommand` binding the rest of the CLI imports (reference identity → generator drift cannot break the dispatch path silently).
- `packages/cleo/src/dispatch/domains/__tests__/tasks.test.ts` — **4 new dispatch tests** cover the `mutate:tasks.cancel` handler: delegation to `taskCancel(projectRoot, taskId, reason)`, `--reason` forwarding, idempotent re-cancel surfacing `alreadyCancelled=true`, and engine error propagation (`E_INVALID_STATE` for a done task). Also refreshes `getSupportedOperations` expectations to include the ADR-073 saga sub-domain operations (closing **two pre-existing failures** on main).
- `packages/core/src/tasks/__tests__/update-status-cancellation.test.ts` — **2 new cases** assert a pending task with `verification: undefined` (gates never initialized) cancels cleanly via both `updateTask` (engine) and `taskUpdate` (engine-result wrapper).

## End-to-end verification against built CLI v2026.5.116

- `cleo cancel T002 --reason "T9947 repro"` → success envelope with `cancelled: true`
- `cleo update T003 --status cancelled` → success envelope with `changes: ['status', 'pipelineStage']`
- `cleo --help` lists `cancel` under Task Management; `cleo cancel --help` renders verb-specific help (TASKID positional + `--reason` flag)

## Test plan

- [x] `pnpm biome check --write .` clean
- [x] `pnpm run build` clean
- [x] `vitest run packages/cleo/src/cli/__tests__/cancel.test.ts` — 7 passed
- [x] `vitest run packages/cleo/src/dispatch/domains/__tests__/tasks.test.ts` — 50 passed (was 44 passed + 2 failed on main; +6 new pass, -2 pre-existing failures fixed)
- [x] `vitest run packages/core/src/tasks/__tests__/update-status-cancellation.test.ts` — 12 passed
- [x] `vitest run packages/core/src/tasks/__tests__/cancel-ops.test.ts packages/core/src/tasks/__tests__/core-task-cancel.test.ts` — 25 passed (no regressions in adjacent cancel coverage)
- [x] End-to-end repro of both bugs confirms fixed at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)