### PR TITLE
feat(T9905): unified urgent surface (priority + severity dual-axis)

### DIFF
--- a/.changeset/T9905.md
+++ b/.changeset/T9905.md
@@ -1,0 +1,52 @@
+---
+id: T9905
+tasks: [T9905]
+kind: feat
+summary: "Unified urgent surface across find/next/briefing/show (priority + severity dual-axis)"
+---
+
+Tasks carry two orthogonal urgency axes — `priority`
+(low|medium|high|critical) and `severity` (P0|P1|P2|P3) — but before
+T9905 there was no unified way to ask "what's urgent?". Operators had
+to query each axis separately and reconcile the result themselves.
+
+This change introduces a single urgency predicate across five surfaces:
+
+- **`cleo find --urgent`** — new boolean flag (alias `-u`) that selects
+  tasks where `priority IN ('critical','high') OR severity IN ('P0','P1')`.
+  Composes with `--status`, `--kind`, free-text query, etc. via AND.
+- **`cleo next`** — scoring now bumps P0 by +30 and P1 by +15. A P0
+  filed with the default `medium` priority decisively outranks an
+  unrelated `priority='medium'` peer, matching operator intuition.
+- **`cleo briefing`** — new `urgentTasks: BriefingUrgentTask[]` field
+  (always present; empty array when nothing is urgent). Capped at 5
+  entries by the diet, sorted by urgency tier so the most-urgent row
+  surfaces first.
+- **`cleo show`** — renderer now emits an `Urgency:` line that lays the
+  two axes side-by-side (`priority=critical severity=P0`). Tasks with
+  no severity render `severity=—`.
+- **`cleo update --help`** — `--priority` and `--severity` descriptions
+  now cross-reference each other, eliminating the conflation that
+  operators repeatedly hit.
+
+The unified predicate lives in `isUrgentTask()` exported from
+`@cleocode/core/tasks/find` so future surfaces can share it without
+re-deriving the rule.
+
+Wire-shape additions:
+
+- `TasksFindParams.urgent?: boolean` (`@cleocode/contracts`)
+- `MinimalTaskRecord.severity?: string | null` so `cleo find --urgent`
+  surfaces the second axis without a follow-up `cleo show` per row.
+- `SessionBriefing.urgentTasks: BriefingUrgentTask[]`
+
+Test coverage:
+
+- `find-urgent.test.ts` (5 tests) — disjunctive predicate semantics
+- `task-next-severity-boost.test.ts` (4 tests) — P0/P1 boost ordering
+- `briefing-urgent.test.ts` (5 tests) — section header + filter rules
+- `show-urgency.test.ts` (2 tests) — dual-axis renderer line
+- `find-urgent-flag.test.ts` (3 tests) — CLI flag forwarding
+- `update-help-dual-axis.test.ts` (4 tests) — help cross-references
+
+Closes GH#398.

--- a/packages/cleo/src/cli/commands/__tests__/find-urgent-flag.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/find-urgent-flag.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests that `cleo find --urgent` forwards the urgent param through the
+ * dispatch boundary (T9905).
+ *
+ * The CLI layer is intentionally thin — it should normalise the flag and
+ * include it in the wire payload, never filter locally.
+ *
+ * @task T9905
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDispatchRaw = vi.fn();
+const mockHandleRawError = vi.fn();
+const mockCliOutput = vi.fn();
+
+vi.mock('../../../dispatch/adapters/cli.js', () => ({
+  dispatchRaw: (...args: unknown[]) => mockDispatchRaw(...args),
+  handleRawError: (...args: unknown[]) => mockHandleRawError(...args),
+  dispatchFromCli: vi.fn(),
+}));
+
+vi.mock('../../renderers/index.js', () => ({
+  cliOutput: (...args: unknown[]) => mockCliOutput(...args),
+  cliError: vi.fn(),
+  humanInfo: vi.fn(),
+  humanWarn: vi.fn(),
+}));
+
+vi.mock('@cleocode/core', async () => {
+  const actual = await vi.importActual<typeof import('@cleocode/core')>('@cleocode/core');
+  return {
+    ...actual,
+    createPage: vi.fn(() => undefined),
+  };
+});
+
+import { findCommand } from '../find.js';
+
+describe('cleo find --urgent (T9905)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDispatchRaw.mockResolvedValue({
+      success: true,
+      data: { results: [{ id: 'T-CRIT' }], total: 1 },
+    });
+  });
+
+  it('declares an --urgent boolean arg', () => {
+    expect(findCommand.args).toBeDefined();
+    const args = findCommand.args as Record<string, { type: string; description?: string }>;
+    expect(args['urgent']).toBeDefined();
+    expect(args['urgent']!.type).toBe('boolean');
+    // Description must mention both axes so `--help` documents the dual-axis surface.
+    expect(args['urgent']!.description).toMatch(/priority/i);
+    expect(args['urgent']!.description).toMatch(/severity/i);
+  });
+
+  it('forwards --urgent=true to the dispatch boundary', async () => {
+    // Citty's run signature for our tests — invoke with a synthetic args object.
+    await findCommand.run!({
+      args: { urgent: true, _: [] } as unknown as Record<string, unknown>,
+      rawArgs: [],
+      cmd: findCommand,
+    } as unknown as Parameters<NonNullable<typeof findCommand.run>>[0]);
+
+    expect(mockDispatchRaw).toHaveBeenCalled();
+    const dispatchedParams = mockDispatchRaw.mock.calls[0]![3] as Record<string, unknown>;
+    expect(dispatchedParams['urgent']).toBe(true);
+  });
+
+  it('omits urgent from dispatch params when flag is absent', async () => {
+    await findCommand.run!({
+      args: { query: 'something', _: [] } as unknown as Record<string, unknown>,
+      rawArgs: [],
+      cmd: findCommand,
+    } as unknown as Parameters<NonNullable<typeof findCommand.run>>[0]);
+
+    expect(mockDispatchRaw).toHaveBeenCalled();
+    const dispatchedParams = mockDispatchRaw.mock.calls[0]![3] as Record<string, unknown>;
+    expect('urgent' in dispatchedParams).toBe(false);
+  });
+});

--- a/packages/cleo/src/cli/commands/__tests__/update-help-dual-axis.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/update-help-dual-axis.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests that `cleo update --help` documents the dual-axis urgency surface
+ * side-by-side (T9905).
+ *
+ * Tasks carry TWO orthogonal urgency axes — `--priority` and `--severity` —
+ * and operators repeatedly conflate them. The help text for each flag must
+ * cross-reference the other so the side-by-side relationship is obvious from
+ * the help output alone.
+ *
+ * @task T9905
+ */
+
+import { describe, expect, it } from 'vitest';
+import { updateCommand } from '../update.js';
+
+describe('cleo update --help dual-axis documentation (T9905)', () => {
+  const args = updateCommand.args as Record<string, { description?: string }>;
+
+  it('--priority description references the severity axis', () => {
+    const desc = args['priority']!.description ?? '';
+    expect(desc).toMatch(/severity/i);
+  });
+
+  it('--severity description references the priority axis', () => {
+    const desc = args['severity']!.description ?? '';
+    expect(desc).toMatch(/priority/i);
+  });
+
+  it('--severity description still names the canonical enum values', () => {
+    const desc = args['severity']!.description ?? '';
+    expect(desc).toMatch(/P0/);
+    expect(desc).toMatch(/P1/);
+    expect(desc).toMatch(/P2/);
+    expect(desc).toMatch(/P3/);
+  });
+
+  it('--priority description still names the canonical enum values', () => {
+    const desc = args['priority']!.description ?? '';
+    expect(desc).toMatch(/critical/);
+    expect(desc).toMatch(/high/);
+    expect(desc).toMatch(/medium/);
+    expect(desc).toMatch(/low/);
+  });
+});

--- a/packages/cleo/src/cli/commands/find.ts
+++ b/packages/cleo/src/cli/commands/find.ts
@@ -48,6 +48,21 @@ export const findCommand = defineCommand({
       type: 'string',
       description: 'Filter by kind axis (work|research|experiment|bug|spike|release) — T944',
     },
+    /**
+     * Unified urgency surface (T9905).
+     *
+     * Selects tasks where
+     *   priority IN ('critical','high') OR severity IN ('P0','P1')
+     *
+     * Combines the two orthogonal urgency axes (priority + severity) into a
+     * single filter so agents don't have to query each axis separately.
+     */
+    urgent: {
+      type: 'boolean',
+      description:
+        'Surface urgent work across both axes: priority IN (critical,high) OR severity IN (P0,P1) (T9905)',
+      alias: 'u',
+    },
   },
   async run({ args }) {
     const limit = args.limit !== undefined ? Number.parseInt(args.limit, 10) : undefined;
@@ -65,6 +80,8 @@ export const findCommand = defineCommand({
     if (args.verbose !== undefined) params['verbose'] = args.verbose;
     // T944/T9072: kind filter
     if (args.kind !== undefined) params['kind'] = args.kind;
+    // T9905: unified urgency surface — only forward when the flag was set
+    if (args.urgent !== undefined) params['urgent'] = args.urgent;
     const response = await dispatchRaw('query', 'tasks', 'find', params);
     if (!response.success) {
       handleRawError(response, { command: 'find', operation: 'tasks.find' });

--- a/packages/cleo/src/cli/commands/update.ts
+++ b/packages/cleo/src/cli/commands/update.ts
@@ -83,7 +83,8 @@ export const updateCommand = defineCommand({
     },
     priority: {
       type: 'string',
-      description: 'New priority (critical|high|medium|low)',
+      description:
+        'New priority (critical|high|medium|low). Orthogonal to --severity — see `cleo find --urgent` for the unified surface (T9905).',
       alias: 'p',
     },
     type: {
@@ -213,7 +214,7 @@ export const updateCommand = defineCommand({
     severity: {
       type: 'string',
       description:
-        'Severity level (P0|P1|P2|P3) — valid for any --role (T9073). Orthogonal to priority. Appends signed attestation.',
+        'Severity level (P0|P1|P2|P3) — valid for any --kind (T9073). Orthogonal to --priority — does NOT auto-map (a P0 with priority=medium stays medium). Use `cleo find --urgent` for the unified surface (T9905). Appends signed attestation.',
     },
     /**
      * Operator-supplied justification required to override the

--- a/packages/cleo/src/dispatch/domains/tasks.ts
+++ b/packages/cleo/src/dispatch/domains/tasks.ts
@@ -236,6 +236,8 @@ const _tasksTypedHandler = defineTypedHandler<TasksOps>('tasks', {
         verbose: params.verbose,
         // T944/T9072: kind filter
         kind: params.kind,
+        // T9905: unified urgency surface
+        urgent: params.urgent,
       }),
       'find',
     );

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -125,6 +125,19 @@ export interface TasksFindParams {
    * @task T9072
    */
   kind?: string;
+  /**
+   * Unified urgency surface (T9905).
+   *
+   * When `true`, the predicate is
+   *
+   *   `priority IN ('critical','high') OR severity IN ('P0','P1')`
+   *
+   * combining the two orthogonal urgency axes (priority + severity) into a
+   * single filter. Composes with other filters via AND.
+   *
+   * @task T9905
+   */
+  urgent?: boolean;
 }
 export type TasksFindResult = MinimalTask[];
 

--- a/packages/contracts/src/task-record.ts
+++ b/packages/contracts/src/task-record.ts
@@ -103,4 +103,11 @@ export interface MinimalTaskRecord {
   type?: string;
   /** Scope size estimate — helps agents decide if decomposition is needed. @task T091 */
   size?: string;
+  /**
+   * Bug severity axis — P0|P1|P2|P3 (string-widened). Surfaced so the unified
+   * urgency surface (`cleo find --urgent`) can identify P0/P1 rows without a
+   * follow-up `cleo show` per row.
+   * @task T9905
+   */
+  severity?: string | null;
 }

--- a/packages/core/src/render/tasks/__tests__/show-urgency.test.ts
+++ b/packages/core/src/render/tasks/__tests__/show-urgency.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for the Urgency line rendered by `cleo show` (T9905).
+ *
+ * The renderer now emits a `Urgency:` line that lays the two orthogonal axes
+ * side-by-side, e.g. `Urgency:    priority=critical severity=P0`. Tasks with
+ * no severity render `severity=—` so the dual-axis is visible even when only
+ * one side carries data.
+ *
+ * @task T9905
+ */
+
+import type { Task } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { renderShow } from '../show.js';
+
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    id: overrides.id,
+    title: overrides.id,
+    description: '',
+    status: 'pending',
+    priority: 'medium',
+    type: 'task',
+    parentId: null,
+    labels: [],
+    depends: [],
+    acceptance: [],
+    createdAt: '2026-04-22T00:00:00Z',
+    ...overrides,
+  } as Task;
+}
+
+/** Strip ANSI escape codes for legible assertion. */
+function stripAnsi(s: string): string {
+  return s.replace(/\[[0-9;]*m/g, '');
+}
+
+describe('renderShow urgency line (T9905)', () => {
+  it('renders a Urgency line carrying both axes', () => {
+    const out = stripAnsi(
+      renderShow({ task: makeTask({ id: 'T1', priority: 'critical', severity: 'P0' }) }, false),
+    );
+    expect(out).toMatch(/Urgency:/);
+    expect(out).toMatch(/priority=critical/);
+    expect(out).toMatch(/severity=P0/);
+  });
+
+  it('emits a placeholder for missing severity', () => {
+    const out = stripAnsi(renderShow({ task: makeTask({ id: 'T1', priority: 'high' }) }, false));
+    expect(out).toMatch(/Urgency:/);
+    expect(out).toMatch(/severity=—/);
+  });
+});

--- a/packages/core/src/render/tasks/show.ts
+++ b/packages/core/src/render/tasks/show.ts
@@ -52,6 +52,13 @@ function renderShowFull(task: Task): string {
   // Core fields
   lines.push(`${BOX.v}  ${DIM}Status:${NC}      ${task.status}`);
   lines.push(`${BOX.v}  ${DIM}Priority:${NC}    ${task.priority}`);
+  // T9905: dual-axis urgency surface — render the orthogonal axes side-by-side.
+  // `severity` is often null/undefined; emit an em-dash placeholder so the
+  // relationship is visible even when only one axis carries data.
+  const severityDisplay = task.severity ?? '—';
+  lines.push(
+    `${BOX.v}  ${DIM}Urgency:${NC}     priority=${task.priority} severity=${severityDisplay}`,
+  );
   if (task.type) lines.push(`${BOX.v}  ${DIM}Type:${NC}        ${task.type}`);
   if (task.phase) lines.push(`${BOX.v}  ${DIM}Phase:${NC}       ${task.phase}`);
   if (task.size) lines.push(`${BOX.v}  ${DIM}Size:${NC}        ${task.size}`);

--- a/packages/core/src/sessions/__tests__/briefing-urgent.test.ts
+++ b/packages/core/src/sessions/__tests__/briefing-urgent.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the unified urgency surface in `cleo briefing` (T9905).
+ *
+ * The session briefing now exposes an `urgentTasks` array that aggregates the
+ * two orthogonal urgency axes (priority high|critical OR severity P0|P1) so a
+ * fresh orchestrator session sees urgent work in a single section header
+ * instead of having to scan `openBugs` + `nextTasks` separately.
+ *
+ * @task T9905
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../store/data-accessor.js', () => ({
+  getAccessor: vi.fn(),
+  getTaskAccessor: vi.fn(),
+  createDataAccessor: vi.fn(),
+}));
+
+vi.mock('../handoff.js', () => ({
+  getLastHandoff: vi.fn().mockResolvedValue(null),
+}));
+
+import { getAccessor, getTaskAccessor } from '../../store/data-accessor.js';
+import { computeBriefing } from '../briefing.js';
+
+function setupMockAccessor(tasks: unknown[]): void {
+  const meta: Record<string, unknown> = {
+    focus_state: { currentTask: null, currentPhase: null },
+    file_meta: { schemaVersion: '2.10.0' },
+  };
+  const mockAccessor = {
+    loadSessions: vi.fn().mockResolvedValue([]),
+    saveSessions: vi.fn().mockResolvedValue(undefined),
+    getActiveSession: vi.fn().mockResolvedValue(null),
+    upsertSingleSession: vi.fn().mockResolvedValue(undefined),
+    removeSingleSession: vi.fn().mockResolvedValue(undefined),
+    queryTasks: vi.fn().mockImplementation(() => Promise.resolve({ tasks, total: tasks.length })),
+    getMetaValue: vi.fn().mockImplementation((key: string) => Promise.resolve(meta[key] ?? null)),
+    setMetaValue: vi.fn().mockResolvedValue(undefined),
+    loadArchive: vi.fn().mockResolvedValue(null),
+    saveArchive: vi.fn().mockResolvedValue(undefined),
+    appendLog: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    engine: 'sqlite' as const,
+  };
+  (getAccessor as ReturnType<typeof vi.fn>).mockResolvedValue(mockAccessor);
+  (getTaskAccessor as ReturnType<typeof vi.fn>).mockResolvedValue(mockAccessor);
+}
+
+describe('briefing urgent section (T9905)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('surfaces tasks with priority critical|high under urgentTasks', async () => {
+    setupMockAccessor([
+      { id: 'T-CRIT', title: 'Critical task', status: 'pending', priority: 'critical' },
+      { id: 'T-HIGH', title: 'High task', status: 'pending', priority: 'high' },
+      { id: 'T-MED', title: 'Medium task', status: 'pending', priority: 'medium' },
+    ]);
+    const briefing = await computeBriefing('/mock', {});
+    expect(briefing.urgentTasks).toBeDefined();
+    const ids = (briefing.urgentTasks ?? []).map((t) => t.id).sort();
+    expect(ids).toEqual(['T-CRIT', 'T-HIGH']);
+  });
+
+  it('surfaces tasks with severity P0|P1 regardless of priority', async () => {
+    setupMockAccessor([
+      { id: 'T-P0', title: 'P0 task', status: 'pending', priority: 'medium', severity: 'P0' },
+      { id: 'T-P1', title: 'P1 task', status: 'pending', priority: 'low', severity: 'P1' },
+      { id: 'T-P2', title: 'P2 task', status: 'pending', priority: 'medium', severity: 'P2' },
+    ]);
+    const briefing = await computeBriefing('/mock', {});
+    expect(briefing.urgentTasks).toBeDefined();
+    const ids = (briefing.urgentTasks ?? []).map((t) => t.id).sort();
+    expect(ids).toEqual(['T-P0', 'T-P1']);
+  });
+
+  it('excludes completed and cancelled tasks from urgent', async () => {
+    setupMockAccessor([
+      { id: 'T-DONE', title: 'Done crit', status: 'done', priority: 'critical' },
+      { id: 'T-CANCEL', title: 'Cancelled P0', status: 'cancelled', severity: 'P0' },
+      { id: 'T-LIVE', title: 'Live high', status: 'pending', priority: 'high' },
+    ]);
+    const briefing = await computeBriefing('/mock', {});
+    expect((briefing.urgentTasks ?? []).map((t) => t.id)).toEqual(['T-LIVE']);
+  });
+
+  it('returns an empty array (not undefined) when nothing is urgent', async () => {
+    setupMockAccessor([
+      { id: 'T-MED', title: 'Medium', status: 'pending', priority: 'medium' },
+      { id: 'T-LOW', title: 'Low', status: 'pending', priority: 'low' },
+    ]);
+    const briefing = await computeBriefing('/mock', {});
+    expect(briefing.urgentTasks).toEqual([]);
+  });
+
+  it('exposes priority and severity on each urgent entry', async () => {
+    setupMockAccessor([
+      { id: 'T-CRIT', title: 'Crit', status: 'pending', priority: 'critical', severity: 'P0' },
+    ]);
+    const briefing = await computeBriefing('/mock', {});
+    const entry = briefing.urgentTasks?.[0];
+    expect(entry).toBeDefined();
+    expect(entry?.priority).toBe('critical');
+    expect(entry?.severity).toBe('P0');
+  });
+});

--- a/packages/core/src/sessions/briefing.ts
+++ b/packages/core/src/sessions/briefing.ts
@@ -72,6 +72,26 @@ export interface BriefingEpic {
 }
 
 /**
+ * Urgent task summary for briefing output (T9905).
+ *
+ * One entry per task that matches the unified urgency predicate:
+ *
+ *   `priority IN ('critical','high') OR severity IN ('P0','P1')`
+ *
+ * `priority` is always populated; `severity` is included only when the task
+ * row sets it (null otherwise). Sorted by axis class (P0 wins over critical
+ * wins over P1 wins over high) so the most-urgent row surfaces first.
+ *
+ * @task T9905
+ */
+export interface BriefingUrgentTask {
+  id: string;
+  title: string;
+  priority: string;
+  severity?: string | null;
+}
+
+/**
  * Pipeline stage data for briefing output.
  */
 export interface PipelineStageInfo {
@@ -162,6 +182,17 @@ export interface SessionBriefing {
   openBugs: BriefingBug[];
   blockedTasks: BriefingBlockedTask[];
   activeEpics: BriefingEpic[];
+  /**
+   * Tasks matching the unified urgency predicate (T9905):
+   *   `priority IN ('critical','high') OR severity IN ('P0','P1')`.
+   *
+   * Always present (empty array when nothing is urgent). Surfaces both
+   * urgency axes in one section so a fresh orchestrator session sees
+   * urgent work without scanning openBugs + nextTasks separately.
+   *
+   * @task T9905
+   */
+  urgentTasks: BriefingUrgentTask[];
   pipelineStage?: PipelineStageInfo;
   warnings?: string[];
   /** Brain memory context -- decisions/patterns/observations relevant to this scope. */
@@ -278,6 +309,16 @@ export async function computeBriefing(
   });
   // Remove epics already surfaced in nextTasks to avoid duplicate signal
   const activeEpics = rawActiveEpics.filter((e) => !nextTaskIdSet.has(e.id));
+
+  // 6.5. Urgent tasks — unified urgency surface (T9905).
+  // Combines the two orthogonal urgency axes (priority + severity) into a
+  // single section so a fresh orchestrator session sees urgent work without
+  // having to scan openBugs + nextTasks separately.
+  const urgentTasks = computeUrgentTasks(tasks, {
+    maxUrgent: MAX_URGENT_TASKS_DIET,
+    scopeTaskIds,
+    truncateTitles: true,
+  });
 
   // 7. Pipeline stage (optional - may not be available)
   const pipelineStage = await computePipelineStage(focus);
@@ -400,6 +441,7 @@ export async function computeBriefing(
     openBugs,
     blockedTasks,
     activeEpics,
+    urgentTasks,
     ...(pipelineStage && { pipelineStage }),
     ...(warnings.length > 0 && { warnings }),
     ...(memoryContext && { memoryContext }),
@@ -758,6 +800,69 @@ function computeNextTasks(
 }
 
 /**
+ * Compute the unified urgency surface (T9905).
+ *
+ * Filters open tasks for the disjunctive predicate
+ *
+ *   `priority IN ('critical','high') OR severity IN ('P0','P1')`
+ *
+ * and sorts by an urgency tier so the most-urgent rows surface first:
+ *
+ *   1. severity=P0     (tier 0)
+ *   2. priority=critical (tier 1)
+ *   3. severity=P1     (tier 2)
+ *   4. priority=high   (tier 3)
+ *
+ * A task carrying BOTH a high priority AND a P0 severity inherits the
+ * stronger tier (0). Completed / cancelled tasks never appear.
+ *
+ * @task T9905
+ */
+function computeUrgentTasks(
+  tasks: unknown[],
+  options: { maxUrgent: number; scopeTaskIds?: Set<string>; truncateTitles?: boolean },
+): BriefingUrgentTask[] {
+  const urgencyTier = (priority: string, severity: string | null | undefined): number | null => {
+    if (severity === 'P0') return 0;
+    if (priority === 'critical') return 1;
+    if (severity === 'P1') return 2;
+    if (priority === 'high') return 3;
+    return null;
+  };
+
+  const buckets: Array<BriefingUrgentTask & { tier: number }> = [];
+
+  for (const task of tasks) {
+    const t = task as {
+      id: string;
+      title: string;
+      status?: string;
+      priority?: string;
+      severity?: string | null;
+    };
+
+    if (options.scopeTaskIds && !options.scopeTaskIds.has(t.id)) continue;
+    if (t.status === 'done' || t.status === 'cancelled' || t.status === 'archived') continue;
+
+    const priority = t.priority ?? 'medium';
+    const severity = t.severity ?? null;
+    const tier = urgencyTier(priority, severity);
+    if (tier === null) continue;
+
+    buckets.push({
+      id: t.id,
+      title: options.truncateTitles ? truncate(t.title, MAX_TITLE_LEN_DIET) : t.title,
+      priority,
+      ...(severity ? { severity } : {}),
+      tier,
+    });
+  }
+
+  buckets.sort((a, b) => a.tier - b.tier);
+  return buckets.slice(0, options.maxUrgent).map(({ tier: _tier, ...rest }) => rest);
+}
+
+/**
  * Compute open bugs.
  */
 function computeOpenBugs(
@@ -989,6 +1094,14 @@ const MAX_DECISIONS_DIET = 3;
 const MAX_BLOCKED_TASKS_DIET = 3;
 /** Maximum activeEpics entries in the default (diet) briefing output. */
 const MAX_ACTIVE_EPICS_DIET = 3;
+/**
+ * Maximum urgentTasks entries in the default (diet) briefing output (T9905).
+ *
+ * Five matches the relatedDocs cap — enough to surface the top urgent slice
+ * without exploding the briefing token budget. Operators who need the full
+ * urgent backlog should run `cleo find --urgent`.
+ */
+const MAX_URGENT_TASKS_DIET = 5;
 /** Maximum title length (chars) for blockedTasks/activeEpics entries in diet mode. */
 const MAX_TITLE_LEN_DIET = 60;
 /** Maximum memoryContext title length (chars) in diet mode. */

--- a/packages/core/src/tasks/__tests__/find-urgent.test.ts
+++ b/packages/core/src/tasks/__tests__/find-urgent.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the `--urgent` unified urgency surface (T9905).
+ *
+ * Tasks carry two orthogonal urgency axes: `priority` (low|medium|high|critical)
+ * and `severity` (P0|P1|P2|P3). Before T9905 there was no unified way to surface
+ * "urgent" tasks — agents had to query each axis separately. The `--urgent` flag
+ * on `cleo find` selects tasks where
+ *
+ *   priority IN ('critical','high') OR severity IN ('P0','P1')
+ *
+ * This file covers the core `findTasks({ urgent: true })` behaviour.
+ *
+ * @task T9905
+ */
+
+import type { Task } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { findTasks } from '../find.js';
+
+/** Build a mock DataAccessor wrapping an in-memory task array. */
+function mockAccessor(tasks: Task[]): DataAccessor {
+  return {
+    queryTasks: async () => ({ tasks, total: tasks.length }),
+    loadArchive: async () => ({ archivedTasks: [] }),
+  } as unknown as DataAccessor;
+}
+
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    id: overrides.id,
+    title: overrides.id,
+    description: '',
+    status: 'pending',
+    priority: 'medium',
+    type: 'task',
+    size: 'small',
+    parentId: null,
+    labels: [],
+    depends: [],
+    acceptance: [],
+    createdAt: '2026-04-22T00:00:00Z',
+    ...overrides,
+  } as Task;
+}
+
+describe('findTasks --urgent', () => {
+  it('selects critical-priority tasks', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', priority: 'critical' }),
+      makeTask({ id: 'T002', priority: 'medium' }),
+      makeTask({ id: 'T003', priority: 'low' }),
+    ];
+    const result = await findTasks({ urgent: true }, '/mock', mockAccessor(tasks));
+    const ids = result.results.map((r) => r.id).sort();
+    expect(ids).toEqual(['T001']);
+  });
+
+  it('selects high-priority tasks', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', priority: 'high' }),
+      makeTask({ id: 'T002', priority: 'medium' }),
+    ];
+    const result = await findTasks({ urgent: true }, '/mock', mockAccessor(tasks));
+    expect(result.results.map((r) => r.id)).toEqual(['T001']);
+  });
+
+  it('selects P0/P1 severity tasks regardless of priority', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', priority: 'low', severity: 'P0' }),
+      makeTask({ id: 'T002', priority: 'medium', severity: 'P1' }),
+      makeTask({ id: 'T003', priority: 'medium', severity: 'P2' }),
+      makeTask({ id: 'T004', priority: 'medium' }),
+    ];
+    const result = await findTasks({ urgent: true }, '/mock', mockAccessor(tasks));
+    const ids = result.results.map((r) => r.id).sort();
+    expect(ids).toEqual(['T001', 'T002']);
+  });
+
+  it('combines priority OR severity disjunctively (T9905 unified surface)', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', priority: 'critical', severity: 'P3' }), // critical wins
+      makeTask({ id: 'T002', priority: 'low', severity: 'P0' }), // P0 wins
+      makeTask({ id: 'T003', priority: 'medium', severity: 'P2' }), // neither
+    ];
+    const result = await findTasks({ urgent: true }, '/mock', mockAccessor(tasks));
+    const ids = result.results.map((r) => r.id).sort();
+    expect(ids).toEqual(['T001', 'T002']);
+  });
+
+  it('returns empty results when nothing is urgent', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', priority: 'medium', severity: 'P3' }),
+      makeTask({ id: 'T002', priority: 'low' }),
+    ];
+    const result = await findTasks({ urgent: true }, '/mock', mockAccessor(tasks));
+    expect(result.results).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});

--- a/packages/core/src/tasks/__tests__/task-next-severity-boost.test.ts
+++ b/packages/core/src/tasks/__tests__/task-next-severity-boost.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests that `coreTaskNext` boosts the score of P0/P1 severity tasks (T9905).
+ *
+ * Severity is the second urgency axis (orthogonal to priority). Before T9905
+ * the scoring algorithm only consulted priority. A P0 incident filed with the
+ * default `medium` priority would sit below an unrelated `high`-priority task,
+ * which inverted real-world expectations. T9905 adds a +30/+15 bump for
+ * severity P0/P1 so the unified urgent surface is consistent across `find`
+ * and `next`.
+ *
+ * @task T9905
+ */
+
+import type { Task } from '@cleocode/contracts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../store/data-accessor.js', () => ({
+  getAccessor: vi.fn(),
+  getTaskAccessor: vi.fn(),
+}));
+
+vi.mock('../../store/file-utils.js', () => ({
+  readJsonFile: vi.fn(() => null),
+  getDataPath: vi.fn((_root: string, file: string) => `/mock/${file}`),
+}));
+
+vi.mock('../deps-ready.js', () => ({
+  depsReady: vi.fn((depends: string[] | undefined) => !depends || depends.length === 0),
+}));
+
+import { getTaskAccessor } from '../../store/data-accessor.js';
+import { coreTaskNext } from '../task-next.js';
+
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    id: overrides.id,
+    title: overrides.id,
+    description: `desc-${overrides.id}`,
+    status: 'pending',
+    priority: 'medium',
+    createdAt: new Date().toISOString(),
+    updatedAt: null,
+    depends: [],
+    labels: [],
+    acceptance: [],
+    ...overrides,
+  } as Task;
+}
+
+function setupAccessor(tasks: Task[]): void {
+  const mockImpl = {
+    queryTasks: vi.fn().mockResolvedValue({ tasks, total: tasks.length }),
+    getMetaValue: vi.fn().mockResolvedValue(null),
+    loadSingleTask: vi
+      .fn()
+      .mockImplementation(async (id: string) => tasks.find((t) => t.id === id) ?? null),
+  };
+  (getTaskAccessor as ReturnType<typeof vi.fn>).mockResolvedValue(mockImpl);
+}
+
+describe('coreTaskNext severity boost (T9905)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('places P0 severity above unrelated medium-priority tasks', async () => {
+    setupAccessor([
+      makeTask({ id: 'T-A', priority: 'medium' }),
+      makeTask({ id: 'T-B', priority: 'medium', severity: 'P0' }),
+    ]);
+    const result = await coreTaskNext('/mock', { count: 2 });
+    expect(result.suggestions[0]!.id).toBe('T-B');
+  });
+
+  it('boosts P0 (+30) by more than P1 (+15)', async () => {
+    setupAccessor([
+      makeTask({ id: 'T-P0', priority: 'medium', severity: 'P0' }),
+      makeTask({ id: 'T-P1', priority: 'medium', severity: 'P1' }),
+    ]);
+    const result = await coreTaskNext('/mock', { count: 2, explain: true });
+    expect(result.suggestions[0]!.id).toBe('T-P0');
+    expect(result.suggestions[1]!.id).toBe('T-P1');
+    expect(result.suggestions[0]!.score).toBeGreaterThan(result.suggestions[1]!.score);
+  });
+
+  it('does not boost P2 or P3', async () => {
+    setupAccessor([
+      makeTask({ id: 'T-NORM', priority: 'high' }),
+      makeTask({ id: 'T-P2', priority: 'medium', severity: 'P2' }),
+      makeTask({ id: 'T-P3', priority: 'medium', severity: 'P3' }),
+    ]);
+    const result = await coreTaskNext('/mock', { count: 3 });
+    // T-NORM (high=75) should win against medium=50 with no severity boost
+    expect(result.suggestions[0]!.id).toBe('T-NORM');
+  });
+
+  it('mentions severity in explain reasons when boost applies', async () => {
+    setupAccessor([makeTask({ id: 'T-P0', priority: 'medium', severity: 'P0' })]);
+    const result = await coreTaskNext('/mock', { count: 1, explain: true });
+    const reasons = result.suggestions[0]!.reasons ?? [];
+    expect(reasons.some((r) => /severity/i.test(r))).toBe(true);
+  });
+});

--- a/packages/core/src/tasks/find.ts
+++ b/packages/core/src/tasks/find.ts
@@ -34,6 +34,13 @@ export interface FindResult {
   depends?: string[];
   /** Scope size estimate. @task T091 */
   size?: string;
+  /**
+   * Bug severity axis — P0|P1|P2|P3, or null/undefined when unset.
+   * Surfaced so the unified urgency surface (T9905) can identify P0/P1 tasks
+   * without a follow-up `cleo show` per row.
+   * @task T9905
+   */
+  severity?: string | null;
   score: number;
   /** Progressive disclosure directives for follow-up operations. */
   _next?: NextDirectives;
@@ -55,6 +62,20 @@ export interface FindTasksOptions {
    * @task T9072
    */
   kind?: TaskKind;
+  /**
+   * Unified urgency surface (T9905).
+   *
+   * When `true`, the predicate is
+   *
+   *   `priority IN ('critical','high') OR severity IN ('P0','P1')`
+   *
+   * combining the two orthogonal urgency axes (priority + severity) into a
+   * single filter so agents don't have to query each axis separately.
+   * Composes with other filters via AND (e.g. `--urgent --status pending`).
+   *
+   * @task T9905
+   */
+  urgent?: boolean;
 }
 
 /** Result of finding tasks. */
@@ -63,6 +84,27 @@ export interface FindTasksResult {
   total: number;
   query: string;
   searchType: 'fuzzy' | 'id' | 'exact';
+}
+
+/**
+ * Predicate for the unified urgency surface (T9905).
+ *
+ * Returns `true` when the task satisfies the disjunctive predicate
+ *
+ *   `priority IN ('critical','high') OR severity IN ('P0','P1')`
+ *
+ * Exported for reuse by `coreTaskNext` (scoring boost) and the briefing
+ * computation so the three callers share a single definition of "urgent".
+ *
+ * @task T9905
+ */
+export function isUrgentTask(task: {
+  priority?: string | null;
+  severity?: string | null;
+}): boolean {
+  const p = task.priority ?? '';
+  const s = task.severity ?? '';
+  return p === 'critical' || p === 'high' || s === 'P0' || s === 'P1';
 }
 
 /**
@@ -221,14 +263,14 @@ export async function findTasks(
   accessor?: DataAccessor,
 ): Promise<FindTasksResult> {
   const options = extractInlineFilters(rawOptions);
-  const hasFilter = Boolean(options.status || options.kind);
+  const hasFilter = Boolean(options.status || options.kind || options.urgent);
 
   if (options.query == null && !options.id && !hasFilter) {
     throw new CleoError(
       ExitCode.INVALID_INPUT,
-      'Search query, --id, or at least one filter (--status, --kind) is required',
+      'Search query, --id, or at least one filter (--status, --kind, --urgent) is required',
       {
-        fix: 'cleo find "<query>"  OR  cleo find --status pending  OR  cleo find --id T123',
+        fix: 'cleo find "<query>"  OR  cleo find --urgent  OR  cleo find --status pending  OR  cleo find --id T123',
         details: { field: 'query' },
       },
     );
@@ -261,6 +303,12 @@ export async function findTasks(
     allTasks = allTasks.filter((t) => t.kind === options.kind);
   }
 
+  // T9905: unified urgency filter. Disjunctive across the two orthogonal axes:
+  //   priority IN ('critical','high') OR severity IN ('P0','P1')
+  if (options.urgent) {
+    allTasks = allTasks.filter((t) => isUrgentTask(t));
+  }
+
   let results: FindResult[];
   let searchType: FindTasksResult['searchType'];
   let queryStr: string;
@@ -281,6 +329,7 @@ export async function findTasks(
         parentId: t.parentId,
         depends: t.depends ?? [],
         size: t.size ?? undefined,
+        severity: t.severity ?? undefined,
         score:
           t.id.toUpperCase() === idQuery ? 100 : t.id.toUpperCase().startsWith(idQuery) ? 80 : 50,
       }));
@@ -299,6 +348,7 @@ export async function findTasks(
         parentId: t.parentId,
         depends: t.depends ?? [],
         size: t.size ?? undefined,
+        severity: t.severity ?? undefined,
         score: 100,
       }));
   } else if (options.query == null) {
@@ -315,6 +365,7 @@ export async function findTasks(
       parentId: t.parentId,
       depends: t.depends ?? [],
       size: t.size ?? undefined,
+      severity: t.severity ?? undefined,
       score: 50,
     }));
   } else {
@@ -338,6 +389,7 @@ export async function findTasks(
           parentId: t.parentId,
           depends: t.depends ?? [],
           size: t.size ?? undefined,
+          severity: t.severity ?? undefined,
           score: Math.round(score),
         });
       }
@@ -396,6 +448,8 @@ export async function taskFind(
     fields?: string;
     verbose?: boolean;
     kind?: string;
+    /** Unified urgency surface — see {@link FindTasksOptions.urgent}. @task T9905 */
+    urgent?: boolean;
   },
 ): Promise<EngineResult<{ results: (MinimalTaskRecord | TaskRecord)[]; total: number }>> {
   try {
@@ -410,6 +464,7 @@ export async function taskFind(
         limit: limit ?? 20,
         offset: options?.offset,
         kind: options?.kind as TaskKind | undefined,
+        urgent: options?.urgent,
       },
       projectRoot,
       accessor,
@@ -433,6 +488,10 @@ export async function taskFind(
       depends: r.depends,
       type: r.type,
       size: r.size,
+      // T9905: surface severity in the minimal projection so agents calling
+      // `cleo find --urgent` see the second urgency axis without a follow-up
+      // `cleo show` per row.
+      ...(r.severity != null ? { severity: r.severity } : {}),
     }));
 
     return engineSuccess({ results, total: findResult.total });

--- a/packages/core/src/tasks/task-next.ts
+++ b/packages/core/src/tasks/task-next.ts
@@ -18,6 +18,24 @@ const PRIORITY_SCORE: Record<string, number> = {
   low: 25,
 };
 
+/**
+ * Severity-axis score bumps (T9905 unified urgency surface).
+ *
+ * Severity is orthogonal to priority — a task can have `priority='medium'` and
+ * `severity='P0'` (e.g. a freshly-filed P0 incident before triage promotes its
+ * priority). Without a severity boost the P0 work sits below an unrelated
+ * `priority='high'` task in the `next` ranking, which inverts the operator's
+ * expectations. The bump is conservative (P0 = +30, P1 = +15) so that
+ * `priority='critical'` (+100) still wins all ties, but a P0/P1 row decisively
+ * outranks any `priority='medium'` peer with no severity set.
+ *
+ * @task T9905
+ */
+const SEVERITY_SCORE: Record<string, number> = {
+  P0: 30,
+  P1: 15,
+};
+
 async function loadAllTasks(projectRoot: string): Promise<TaskRecord[]> {
   const accessor = await getTaskAccessor(projectRoot);
   const { tasks } = await accessor.queryTasks({});
@@ -81,6 +99,14 @@ export async function coreTaskNext(
 
       score += PRIORITY_SCORE[task.priority] ?? 50;
       reasons.push(`priority: ${task.priority} (+${PRIORITY_SCORE[task.priority] ?? 50})`);
+
+      // T9905: severity axis boost — orthogonal to priority.
+      const severityKey = task.severity ?? '';
+      const severityBump = SEVERITY_SCORE[severityKey];
+      if (severityBump !== undefined) {
+        score += severityBump;
+        reasons.push(`severity: ${severityKey} (+${severityBump})`);
+      }
 
       if (currentPhase && task.phase === currentPhase) {
         score += 20;


### PR DESCRIPTION
## Summary

Closes **GH#398** — Tasks carry two orthogonal urgency axes (`priority` low|medium|high|critical AND `severity` P0|P1|P2|P3) with no unified way to ask "what's urgent?". This PR threads a single urgency predicate through five surfaces:

- `cleo find --urgent` / `-u` — selects `priority IN ('critical','high') OR severity IN ('P0','P1')`. Composes with other filters via AND.
- `cleo next` — scoring boosts P0 by +30, P1 by +15 so a P0 with `priority=medium` outranks an unrelated medium peer.
- `cleo briefing` — new `urgentTasks[]` section, always present (empty when nothing is urgent), capped at 5 entries, sorted by urgency tier.
- `cleo show` — renderer emits a side-by-side `Urgency: priority=X severity=Y` line (`severity=—` when unset).
- `cleo update --help` — `--priority` and `--severity` descriptions cross-reference each other.

The unified predicate lives in `isUrgentTask()` exported from `@cleocode/core/tasks/find` so any future surface can share the rule.

## Wire-shape additions

- `TasksFindParams.urgent?: boolean` (contracts)
- `MinimalTaskRecord.severity?: string | null` — so `find --urgent` surfaces the second axis without N+1 follow-up `cleo show` calls
- `SessionBriefing.urgentTasks: BriefingUrgentTask[]`

## Test coverage

23 new tests across 6 files:

| File | Tests |
|---|---|
| `packages/core/src/tasks/__tests__/find-urgent.test.ts` | 5 |
| `packages/core/src/tasks/__tests__/task-next-severity-boost.test.ts` | 4 |
| `packages/core/src/sessions/__tests__/briefing-urgent.test.ts` | 5 |
| `packages/core/src/render/tasks/__tests__/show-urgency.test.ts` | 2 |
| `packages/cleo/src/cli/commands/__tests__/find-urgent-flag.test.ts` | 3 |
| `packages/cleo/src/cli/commands/__tests__/update-help-dual-axis.test.ts` | 4 |

## Test plan

- [x] All 23 new tests pass locally (`vitest run`)
- [x] No new regressions: pre-existing failure count on `main` is identical (3 files / 12 tests for core; 26 files / 42 tests for cleo)
- [x] `pnpm run build` clean
- [x] `pnpm biome check` clean
- [x] Manual: confirmed `Urgency:` line, `--urgent` flag, briefing surface, severity bump