### PR TITLE
feat(T9904): cleo labels <name> + cleo find --label <name>

### DIFF
--- a/.changeset/t9904.md
+++ b/.changeset/t9904.md
@@ -1,0 +1,46 @@
+---
+id: t9904
+tasks: [T9904]
+kind: feat
+summary: cleo labels <name> positional + cleo find --label <name>
+---
+
+Closes **GH#393** — `cleo labels` previously rejected any positional argument,
+leaving users with no way to "show tasks for label X" from the CLI.
+
+This task wires the missing surface in two complementary ways:
+
+- **`cleo labels <name>`** — adds an optional positional `name` arg to the root
+  `labels` command. When present, dispatches to `tasks.list` with a label
+  filter and returns the canonical `{label, tasks:[...], count}` envelope.
+  When absent, the legacy `tasks.label.list` behaviour is preserved
+  (backward compatible — `cleo labels` still lists every label with counts).
+
+- **`cleo find --label <name>`** — adds a `--label` string flag to `cleo find`
+  giving it parity with the positional form. Composes with every other
+  `find` filter (`--status`, `--kind`, `--urgent`, etc.) via AND. Filter-only
+  mode (`cleo find --label bug` with no query) is valid and returns every
+  task carrying the label.
+
+The inline `label:<value>` token in a fuzzy query is also lifted into the
+filter — matching the existing `status:`, `kind:`, and `id:` ergonomics
+from `extractInlineFilters`.
+
+### Surface
+
+- `packages/contracts/src/operations/tasks.ts` — `TasksFindParams.label?: string`
+- `packages/core/src/tasks/find.ts` — `FindTasksOptions.label` + filter wiring +
+  inline `label:value` parser entry
+- `packages/core/src/tasks/ops.ts` — `tasksFindOp` accepts `label`
+- `packages/cleo/src/cli/commands/find.ts` — `--label` flag
+- `packages/cleo/src/cli/commands/labels.ts` — positional `name` arg
+- `packages/cleo/src/dispatch/domains/tasks.ts` — wire `label` through to core
+
+### Tests
+
+- `packages/core/src/tasks/__tests__/find-label.test.ts` — 7 unit cases
+- `packages/cleo/src/cli/commands/__tests__/find-label-flag.test.ts` — 3 cases
+- `packages/cleo/src/cli/commands/__tests__/labels-positional.test.ts` — 4 cases
+
+All filter the result through the existing SQLite-backed `queryTasks({ label })`
+predicate — no new accessor surface required.

--- a/packages/cleo/src/cli/commands/__tests__/find-label-flag.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/find-label-flag.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests that `cleo find --label <name>` forwards the label param through
+ * the dispatch boundary (T9904).
+ *
+ * Mirrors the structure of {@link ./find-urgent-flag.test.ts}.
+ *
+ * @task T9904
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDispatchRaw = vi.fn();
+const mockHandleRawError = vi.fn();
+const mockCliOutput = vi.fn();
+
+vi.mock('../../../dispatch/adapters/cli.js', () => ({
+  dispatchRaw: (...args: unknown[]) => mockDispatchRaw(...args),
+  handleRawError: (...args: unknown[]) => mockHandleRawError(...args),
+  dispatchFromCli: vi.fn(),
+}));
+
+vi.mock('../../renderers/index.js', () => ({
+  cliOutput: (...args: unknown[]) => mockCliOutput(...args),
+  cliError: vi.fn(),
+  humanInfo: vi.fn(),
+  humanWarn: vi.fn(),
+}));
+
+vi.mock('@cleocode/core', async () => {
+  const actual = await vi.importActual<typeof import('@cleocode/core')>('@cleocode/core');
+  return {
+    ...actual,
+    createPage: vi.fn(() => undefined),
+  };
+});
+
+import { findCommand } from '../find.js';
+
+describe('cleo find --label (T9904)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDispatchRaw.mockResolvedValue({
+      success: true,
+      data: { results: [{ id: 'T-BUG' }], total: 1 },
+    });
+  });
+
+  it('declares a --label string arg', () => {
+    expect(findCommand.args).toBeDefined();
+    const args = findCommand.args as Record<string, { type: string; description?: string }>;
+    expect(args['label']).toBeDefined();
+    expect(args['label']!.type).toBe('string');
+    expect(args['label']!.description).toMatch(/label/i);
+  });
+
+  it('forwards --label=<name> to the dispatch boundary', async () => {
+    await findCommand.run!({
+      args: { label: 'bug', _: [] } as unknown as Record<string, unknown>,
+      rawArgs: [],
+      cmd: findCommand,
+    } as unknown as Parameters<NonNullable<typeof findCommand.run>>[0]);
+
+    expect(mockDispatchRaw).toHaveBeenCalled();
+    const dispatchedParams = mockDispatchRaw.mock.calls[0]![3] as Record<string, unknown>;
+    expect(dispatchedParams['label']).toBe('bug');
+  });
+
+  it('omits label from dispatch params when flag is absent', async () => {
+    await findCommand.run!({
+      args: { query: 'something', _: [] } as unknown as Record<string, unknown>,
+      rawArgs: [],
+      cmd: findCommand,
+    } as unknown as Parameters<NonNullable<typeof findCommand.run>>[0]);
+
+    expect(mockDispatchRaw).toHaveBeenCalled();
+    const dispatchedParams = mockDispatchRaw.mock.calls[0]![3] as Record<string, unknown>;
+    expect('label' in dispatchedParams).toBe(false);
+  });
+});

--- a/packages/cleo/src/cli/commands/__tests__/labels-positional.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/labels-positional.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests that `cleo labels <name>` (positional) routes to `tasks.list` with
+ * a label filter (T9904 — closes GH#393).
+ *
+ * The bare `cleo labels` must keep dispatching to `tasks.label.list`
+ * (backward compatible). Subcommands `list|show|stats` continue to
+ * dispatch as before.
+ *
+ * @task T9904
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDispatchFromCli = vi.fn();
+
+vi.mock('../../../dispatch/adapters/cli.js', () => ({
+  dispatchRaw: vi.fn(),
+  handleRawError: vi.fn(),
+  dispatchFromCli: (...args: unknown[]) => mockDispatchFromCli(...args),
+}));
+
+import { labelsCommand } from '../labels.js';
+
+type RunCtx = Parameters<NonNullable<typeof labelsCommand.run>>[0];
+
+describe('cleo labels — positional + dispatch routing (T9904)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDispatchFromCli.mockResolvedValue(undefined);
+  });
+
+  it('declares an optional positional `name` arg', () => {
+    expect(labelsCommand.args).toBeDefined();
+    const args = labelsCommand.args as Record<
+      string,
+      { type: string; required?: boolean; description?: string }
+    >;
+    expect(args['name']).toBeDefined();
+    expect(args['name']!.type).toBe('positional');
+    expect(args['name']!.required).toBe(false);
+  });
+
+  it('routes `cleo labels` (no args) to tasks.label.list', async () => {
+    await labelsCommand.run!({
+      args: { _: [] } as unknown as Record<string, unknown>,
+      rawArgs: [],
+      cmd: labelsCommand,
+    } as unknown as RunCtx);
+
+    expect(mockDispatchFromCli).toHaveBeenCalledTimes(1);
+    const call = mockDispatchFromCli.mock.calls[0]!;
+    expect(call[0]).toBe('query');
+    expect(call[1]).toBe('tasks');
+    expect(call[2]).toBe('label.list');
+    expect(call[3]).toEqual({});
+  });
+
+  it('routes `cleo labels <name>` to tasks.list with label filter', async () => {
+    await labelsCommand.run!({
+      args: { name: 'bug', _: [] } as unknown as Record<string, unknown>,
+      rawArgs: ['bug'],
+      cmd: labelsCommand,
+    } as unknown as RunCtx);
+
+    expect(mockDispatchFromCli).toHaveBeenCalledTimes(1);
+    const call = mockDispatchFromCli.mock.calls[0]!;
+    expect(call[0]).toBe('query');
+    expect(call[1]).toBe('tasks');
+    expect(call[2]).toBe('list');
+    expect(call[3]).toEqual({ label: 'bug' });
+  });
+
+  it('does NOT dispatch from root when subcommand (list/show/stats) was invoked', async () => {
+    await labelsCommand.run!({
+      args: { _: ['list'] } as unknown as Record<string, unknown>,
+      rawArgs: ['list'],
+      cmd: labelsCommand,
+    } as unknown as RunCtx);
+
+    // Citty dispatches the subcommand on its own — the root run must NOT
+    // double-dispatch.
+    expect(mockDispatchFromCli).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cleo/src/cli/commands/find.ts
+++ b/packages/cleo/src/cli/commands/find.ts
@@ -63,6 +63,16 @@ export const findCommand = defineCommand({
         'Surface urgent work across both axes: priority IN (critical,high) OR severity IN (P0,P1) (T9905)',
       alias: 'u',
     },
+    /**
+     * Filter by label — `cleo find --label <name>` returns every task
+     * whose `labels[]` includes the given value. Closes GH#393 and gives
+     * `find` parity with the positional `cleo labels <name>` surface.
+     * @task T9904
+     */
+    label: {
+      type: 'string',
+      description: 'Filter by label — return tasks whose labels[] includes this value (T9904)',
+    },
   },
   async run({ args }) {
     const limit = args.limit !== undefined ? Number.parseInt(args.limit, 10) : undefined;
@@ -82,6 +92,8 @@ export const findCommand = defineCommand({
     if (args.kind !== undefined) params['kind'] = args.kind;
     // T9905: unified urgency surface — only forward when the flag was set
     if (args.urgent !== undefined) params['urgent'] = args.urgent;
+    // T9904: label filter — forward when set
+    if (args.label !== undefined) params['label'] = args.label;
     const response = await dispatchRaw('query', 'tasks', 'find', params);
     if (!response.success) {
       handleRawError(response, { command: 'find', operation: 'tasks.find' });

--- a/packages/cleo/src/cli/commands/labels.ts
+++ b/packages/cleo/src/cli/commands/labels.ts
@@ -47,13 +47,36 @@ const statsCommand = defineCommand({
 /**
  * Root labels command group — list and filter tasks by label.
  *
- * Defaults to `list` when no subcommand is given.
+ * Behaviour matrix:
+ *   - `cleo labels`             → list all labels with counts (label.list)
+ *   - `cleo labels <name>`      → list tasks carrying that label (tasks.list)
+ *   - `cleo labels list`        → explicit alias for label.list
+ *   - `cleo labels show <name>` → explicit alias for the positional form
+ *   - `cleo labels stats`       → label statistics
+ *
+ * The positional `name` arg closes GH#393 (T9904) — `cleo labels <name>`
+ * used to be rejected because the root command had no positional arg.
+ * `cleo find --label <name>` is the parallel alternative wired in the
+ * same task.
+ *
  * The `tags` alias is registered separately in index.ts.
+ *
+ * @task T9904 — GH#393 cleo labels <name> rejected positional
  */
 export const labelsCommand = defineCommand({
   meta: {
     name: 'labels',
-    description: 'List all labels with counts or show tasks with specific label',
+    description: 'List all labels (no args), or show tasks for a label (cleo labels <name>)',
+  },
+  args: {
+    // Optional positional — when present, dispatches to tasks.list with the
+    // label filter; when absent, falls through to the legacy label.list path.
+    // Required:false keeps the bare `cleo labels` invocation working.
+    name: {
+      type: 'positional',
+      description: 'Label name to filter tasks by (omit to list all labels)',
+      required: false,
+    },
   },
   subCommands: {
     list: listCommand,
@@ -61,9 +84,20 @@ export const labelsCommand = defineCommand({
     stats: statsCommand,
   },
   async run(ctx) {
-    // Default: invoke list when no subcommand provided
-    if (!ctx.rawArgs.some((a) => ['list', 'show', 'stats'].includes(a))) {
-      await dispatchFromCli('query', 'tasks', 'label.list', {}, { command: 'labels' });
+    const rawArgs = ctx.rawArgs ?? [];
+    // If a subcommand was invoked, citty will dispatch to it — bail out.
+    if (rawArgs.some((a) => ['list', 'show', 'stats'].includes(a))) {
+      return;
     }
+    // T9904 — positional `name`: route to tasks.list with label filter.
+    // citty surfaces the positional under `args.name`. When absent the
+    // user wants the original "list all labels" behaviour.
+    const name = (ctx.args as { name?: string }).name;
+    if (typeof name === 'string' && name.length > 0) {
+      await dispatchFromCli('query', 'tasks', 'list', { label: name }, { command: 'labels' });
+      return;
+    }
+    // Default: invoke list when no subcommand AND no positional was given
+    await dispatchFromCli('query', 'tasks', 'label.list', {}, { command: 'labels' });
   },
 });

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -497,7 +497,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'labelsCommand',
     name: 'labels',
-    description: 'List all labels with counts or show tasks with specific label',
+    description: 'List all labels (no args), or show tasks for a label (cleo labels <name>)',
     load: async () => (await import('../commands/labels.js')).labelsCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/dispatch/domains/tasks.ts
+++ b/packages/cleo/src/dispatch/domains/tasks.ts
@@ -238,6 +238,8 @@ const _tasksTypedHandler = defineTypedHandler<TasksOps>('tasks', {
         kind: params.kind,
         // T9905: unified urgency surface
         urgent: params.urgent,
+        // T9904: label filter — `cleo find --label <name>` (closes GH#393).
+        label: params.label,
       }),
       'find',
     );

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -138,6 +138,16 @@ export interface TasksFindParams {
    * @task T9905
    */
   urgent?: boolean;
+  /**
+   * Filter by label — selects tasks whose `labels` array contains this
+   * value. Composes with other filters via AND.
+   *
+   * Closes GH#393 — gives `cleo find --label <name>` parity with the
+   * positional `cleo labels <name>` surface.
+   *
+   * @task T9904
+   */
+  label?: string;
 }
 export type TasksFindResult = MinimalTask[];
 

--- a/packages/core/src/tasks/__tests__/find-label.test.ts
+++ b/packages/core/src/tasks/__tests__/find-label.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the `--label` filter on `cleo find` (T9904).
+ *
+ * Closes GH#393 — `cleo labels <name>` rejected positional and there was no
+ * way to "show tasks for label X" via `cleo find` either. T9904 wires both:
+ *   - positional `cleo labels <name>` → filter tasks by label
+ *   - flag `cleo find --label <name>` → filter tasks by label
+ *
+ * This file covers the core `findTasks({ label })` behaviour and the
+ * `extractInlineFilters` inline `label:value` lift.
+ *
+ * @task T9904
+ */
+
+import type { Task, TaskQueryFilters } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { extractInlineFilters, findTasks } from '../find.js';
+
+/** Build a mock DataAccessor that honours the `label` filter. */
+function mockAccessor(tasks: Task[]): DataAccessor {
+  return {
+    queryTasks: async (filters: TaskQueryFilters | undefined) => {
+      let list = tasks;
+      if (filters?.status) list = list.filter((t) => t.status === filters.status);
+      if (filters?.label) list = list.filter((t) => (t.labels ?? []).includes(filters.label!));
+      return { tasks: list, total: list.length };
+    },
+    loadArchive: async () => ({ archivedTasks: [] }),
+  } as unknown as DataAccessor;
+}
+
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    id: overrides.id,
+    title: overrides.id,
+    description: '',
+    status: 'pending',
+    priority: 'medium',
+    type: 'task',
+    size: 'small',
+    parentId: null,
+    labels: [],
+    depends: [],
+    acceptance: [],
+    createdAt: '2026-04-22T00:00:00Z',
+    ...overrides,
+  } as Task;
+}
+
+describe('findTasks --label', () => {
+  it('selects only tasks that carry the requested label', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', labels: ['bug', 'frontend'] }),
+      makeTask({ id: 'T002', labels: ['bug'] }),
+      makeTask({ id: 'T003', labels: ['feature'] }),
+      makeTask({ id: 'T004' }),
+    ];
+    const result = await findTasks({ label: 'bug' }, '/mock', mockAccessor(tasks));
+    const ids = result.results.map((r) => r.id).sort();
+    expect(ids).toEqual(['T001', 'T002']);
+  });
+
+  it('returns empty when no task carries the label', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', labels: ['bug'] }),
+      makeTask({ id: 'T002', labels: ['feature'] }),
+    ];
+    const result = await findTasks({ label: 'nonexistent' }, '/mock', mockAccessor(tasks));
+    expect(result.results).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it('composes label with status filter (AND)', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', labels: ['bug'], status: 'pending' }),
+      makeTask({ id: 'T002', labels: ['bug'], status: 'done' }),
+      makeTask({ id: 'T003', labels: ['feature'], status: 'pending' }),
+    ];
+    const result = await findTasks(
+      { label: 'bug', status: 'pending' },
+      '/mock',
+      mockAccessor(tasks),
+    );
+    expect(result.results.map((r) => r.id)).toEqual(['T001']);
+  });
+
+  it('label filter alone (no query, no id) is valid filter-only mode', async () => {
+    const tasks = [makeTask({ id: 'T001', labels: ['bug'] })];
+    // Should NOT throw "query or --id required"
+    const result = await findTasks({ label: 'bug' }, '/mock', mockAccessor(tasks));
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]?.id).toBe('T001');
+  });
+});
+
+describe('extractInlineFilters — label:value', () => {
+  it('lifts label:value out of a pure-filter query', () => {
+    const out = extractInlineFilters({ query: 'label:bug' });
+    expect(out.label).toBe('bug');
+    expect(out.query).toBeUndefined();
+  });
+
+  it('lifts label:value and keeps remaining tokens as fuzzy text', () => {
+    const out = extractInlineFilters({ query: 'label:bug login crash' });
+    expect(out.label).toBe('bug');
+    expect(out.query).toBe('login crash');
+  });
+
+  it('explicit --label option wins when both inline and option set', () => {
+    const out = extractInlineFilters({ query: 'label:other thing', label: 'bug' });
+    expect(out.label).toBe('bug');
+    expect(out.query).toBe('thing');
+  });
+});

--- a/packages/core/src/tasks/find.ts
+++ b/packages/core/src/tasks/find.ts
@@ -76,6 +76,18 @@ export interface FindTasksOptions {
    * @task T9905
    */
   urgent?: boolean;
+  /**
+   * Filter by label — selects tasks whose `labels` array contains this
+   * value. Composes with other filters via AND (e.g. `--label bug --status pending`).
+   * Filter-only mode: passing only `--label` with no `query`/`--id` is valid
+   * and returns every task carrying the label.
+   *
+   * Closes GH#393 — gives `cleo find --label <name>` parity with the
+   * positional `cleo labels <name>` surface.
+   *
+   * @task T9904
+   */
+  label?: string;
 }
 
 /** Result of finding tasks. */
@@ -179,7 +191,7 @@ export function fuzzyScore(query: string, text: string): number {
  * the options so the filter lifts out of the query token and only the
  * remaining words stay in the free-text search.
  *
- * Recognised fields: `status`, `kind`, `priority`, `type`, `id`.
+ * Recognised fields: `status`, `kind`, `priority`, `type`, `id`, `label` (T9904).
  * Unrecognised `key:value` tokens pass through as-is (treated as fuzzy
  * text) to preserve user intent.
  *
@@ -215,7 +227,7 @@ export function extractInlineFilters(options: FindTasksOptions): FindTasksOption
   const remaining: string[] = [];
   const next: FindTasksOptions = { ...options };
   for (const tok of tokens) {
-    const m = tok.match(/^(status|kind|priority|type|id):(.+)$/i);
+    const m = tok.match(/^(status|kind|priority|type|id|label):(.+)$/i);
     if (!m) {
       remaining.push(tok);
       continue;
@@ -230,6 +242,12 @@ export function extractInlineFilters(options: FindTasksOptions): FindTasksOption
         break;
       case 'id':
         if (!next.id) next.id = value;
+        break;
+      case 'label':
+        // T9904 — lift inline `label:<value>` into the filter; explicit
+        // --label option wins (matches the precedence rule used by the
+        // other inline filters above).
+        if (!next.label) next.label = value;
         break;
       default:
         // priority/type aren't in FindTasksOptions today — pass through.
@@ -263,14 +281,14 @@ export async function findTasks(
   accessor?: DataAccessor,
 ): Promise<FindTasksResult> {
   const options = extractInlineFilters(rawOptions);
-  const hasFilter = Boolean(options.status || options.kind || options.urgent);
+  const hasFilter = Boolean(options.status || options.kind || options.urgent || options.label);
 
   if (options.query == null && !options.id && !hasFilter) {
     throw new CleoError(
       ExitCode.INVALID_INPUT,
-      'Search query, --id, or at least one filter (--status, --kind, --urgent) is required',
+      'Search query, --id, or at least one filter (--status, --kind, --urgent, --label) is required',
       {
-        fix: 'cleo find "<query>"  OR  cleo find --urgent  OR  cleo find --status pending  OR  cleo find --id T123',
+        fix: 'cleo find "<query>"  OR  cleo find --label bug  OR  cleo find --urgent  OR  cleo find --status pending  OR  cleo find --id T123',
         details: { field: 'query' },
       },
     );
@@ -278,10 +296,15 @@ export async function findTasks(
 
   const acc = accessor ?? (await getTaskAccessor(cwd));
 
-  // Use targeted query with status filter when available
+  // Use targeted query with status/label filters when available — push the
+  // label filter into the accessor so SQLite-backed accessors benefit from
+  // the existing label-aware queryTasks predicate. T9904.
   const filters: TaskQueryFilters = {};
   if (options.status) {
     filters.status = options.status;
+  }
+  if (options.label) {
+    filters.label = options.label;
   }
   const queryResult = await acc.queryTasks(filters);
   let allTasks: Task[] = [...queryResult.tasks];
@@ -293,6 +316,13 @@ export async function findTasks(
       let archivedTasks = archive.archivedTasks as Task[];
       if (options.status) {
         archivedTasks = archivedTasks.filter((t) => t.status === options.status);
+      }
+      if (options.label) {
+        // T9904 — archive doesn't flow through queryTasks; apply the label
+        // predicate here so includeArchive composes correctly.
+        archivedTasks = archivedTasks.filter((t) =>
+          (t.labels ?? []).includes(options.label as string),
+        );
       }
       allTasks = [...allTasks, ...archivedTasks];
     }
@@ -450,6 +480,8 @@ export async function taskFind(
     kind?: string;
     /** Unified urgency surface — see {@link FindTasksOptions.urgent}. @task T9905 */
     urgent?: boolean;
+    /** Filter by label — see {@link FindTasksOptions.label}. @task T9904 */
+    label?: string;
   },
 ): Promise<EngineResult<{ results: (MinimalTaskRecord | TaskRecord)[]; total: number }>> {
   try {
@@ -465,6 +497,7 @@ export async function taskFind(
         offset: options?.offset,
         kind: options?.kind as TaskKind | undefined,
         urgent: options?.urgent,
+        label: options?.label,
       },
       projectRoot,
       accessor,

--- a/packages/core/src/tasks/ops.ts
+++ b/packages/core/src/tasks/ops.ts
@@ -119,6 +119,8 @@ export async function tasksFindOp(
     includeArchive?: boolean;
     offset?: number;
     kind?: TaskKind;
+    /** Filter by label — selects tasks whose `labels[]` includes this value. @task T9904 */
+    label?: string;
   },
 ): Promise<FindTasksResult> {
   return findTasks(
@@ -131,6 +133,7 @@ export async function tasksFindOp(
       limit: params.limit,
       offset: params.offset,
       kind: params.kind,
+      label: params.label,
     },
     projectRoot,
   );


### PR DESCRIPTION
## Summary

Closes **GH#393** — `cleo labels` previously rejected any positional argument, leaving users with no way to "show tasks for label X" from the CLI.

- Add optional positional `name` arg to `cleo labels`; routes to `tasks.list` with label filter when present, preserves legacy `tasks.label.list` behaviour when absent (backward compatible).
- Add `--label <name>` flag to `cleo find`; composes with every other filter via AND. Filter-only mode (`cleo find --label bug` with no query) is valid.
- Lift inline `label:<value>` tokens in fuzzy queries via `extractInlineFilters` (matches existing status/kind/id ergonomics).

## Acceptance

- ✅ AC1: `cleo labels <name>` returns `{label, tasks:[...], count}` envelope via `tasks.list` dispatch with `{label}` filter
- ✅ AC2: `cleo find --label <name>` alternative wired and forwarded through the dispatch boundary
- ✅ AC3: JSON envelope shape matches `cleo find` canonical task list

## Surface

| File | Change |
|---|---|
| `packages/contracts/src/operations/tasks.ts` | `TasksFindParams.label?: string` |
| `packages/core/src/tasks/find.ts` | `FindTasksOptions.label` + filter wiring + inline `label:value` parser entry |
| `packages/core/src/tasks/ops.ts` | `tasksFindOp` accepts `label` |
| `packages/cleo/src/cli/commands/find.ts` | `--label` flag |
| `packages/cleo/src/cli/commands/labels.ts` | positional `name` arg (backward compatible) |
| `packages/cleo/src/dispatch/domains/tasks.ts` | wire `label` through `taskFind()` |

## Test plan

- [x] `packages/core/src/tasks/__tests__/find-label.test.ts` — 7 unit cases (filter selection, AND composition, empty result, filter-only mode, inline `label:value` lift, explicit-flag-wins precedence)
- [x] `packages/cleo/src/cli/commands/__tests__/find-label-flag.test.ts` — 3 cases (flag declared, forwarded to dispatch, omitted when absent)
- [x] `packages/cleo/src/cli/commands/__tests__/labels-positional.test.ts` — 4 cases (positional declared, root dispatch routing, no double-dispatch on subcommands)
- [x] No regression in existing find/label tests (41/41 pass core, 10/10 pass CLI)
- [x] Biome clean on all changed files
- [x] No new SSoT violations (`lint-no-raw-define-command`: 137 vs baseline 139)
- [x] Changeset added: `.changeset/t9904.md`

## Notes for reviewer

- The SQLite accessor already supported `queryTasks({ label })` via JSON LIKE — no new accessor surface required.
- Pre-existing breakage in this worktree: tsc emitDecl + 3 tasks test files fail on `main` as well; not introduced by this PR.

Saga: T9862 Wave 4