### PR TITLE
fix(T10108): cleo find --parent applies the filter

### DIFF
--- a/.changeset/T10108.md
+++ b/.changeset/T10108.md
@@ -1,0 +1,48 @@
+---
+id: T10108
+tasks: [T10108]
+kind: fix
+summary: "`cleo find --parent <id>` now applies the parent filter; empty-string query no longer bypasses filters"
+---
+
+`cleo find "" --parent T9758` returned the full unfiltered result set
+(1216 rows on this repo) instead of just the children of T9758. Two
+defects compounded:
+
+1. The CLI `find` command had no `--parent` flag — the value was
+   silently dropped before dispatch.
+2. The empty-string `""` query short-circuited to fuzzy-mode where
+   `fuzzyScore('', '<title>')` returned 80 for every task (substring
+   match of the empty string), so every row matched.
+
+Fix:
+
+- Add `parent?: string` to `FindTasksOptions`, `TasksFindParams`
+  contract, the dispatch handler, and the `cleo find` CLI surface
+  (with `--parent-id` legacy alias to match `cleo list`).
+- In `findTasks`, push the `parentId` filter down to the accessor for
+  plain parents; for Sagas (Epic with `labels.includes('saga')`),
+  reuse `resolveSagaMemberIds` from `@cleocode/core/sagas/storage` to
+  restrict the result set to `task_relations.type='groups'` member IDs
+  — same routing as `listTasks` (ADR-073 §1).
+- Normalise empty / whitespace-only `query` to `undefined` so it no
+  longer slips past the no-filter guard and no longer triggers the
+  empty-string `fuzzyScore` bypass.
+- Update the no-filter error message + fix-hint to mention `--parent`.
+- Regression-lock with 8 tests in
+  `packages/core/src/tasks/__tests__/find-parent-filter.test.ts`:
+  - `--parent` restricts to direct children
+  - empty-string / whitespace-only query is rejected when no filter
+  - empty-string `""` does NOT bypass `--parent`
+  - composition with `--status` and with a fuzzy query
+  - Saga member routing via `task_relations.type='groups'`
+  - parity with `cleo list --parent <id>` for the same parent
+
+Acceptance:
+
+1. `cleo find "" --parent T9758` returns only direct/transitive
+   children of T9758. (verified in mock-accessor regression test)
+2. `cleo find <query> --parent <id>` matches `cleo list --parent <id>`
+   for the parent filter axis. (parity test)
+3. Empty query string `""` does not bypass filters. (regression test)
+4. Regression test landed in `packages/core/src/tasks/__tests__/`.

--- a/packages/cleo/src/cli/commands/find.ts
+++ b/packages/cleo/src/cli/commands/find.ts
@@ -63,6 +63,21 @@ export const findCommand = defineCommand({
         'Surface urgent work across both axes: priority IN (critical,high) OR severity IN (P0,P1) (T9905)',
       alias: 'u',
     },
+    /**
+     * Filter by parent task ID (T10108).
+     *
+     * Restricts results to direct children of the given parent. Mirrors the
+     * `cleo list --parent` semantics — including Saga-aware routing via
+     * `task_relations.type='groups'` when the parent is an Epic labeled `saga`.
+     */
+    parent: {
+      type: 'string',
+      description: 'Filter results to direct children of <parent> (T10108)',
+    },
+    'parent-id': {
+      type: 'string',
+      description: 'Alias for --parent (legacy parentId compatibility)',
+    },
   },
   async run({ args }) {
     const limit = args.limit !== undefined ? Number.parseInt(args.limit, 10) : undefined;
@@ -82,6 +97,9 @@ export const findCommand = defineCommand({
     if (args.kind !== undefined) params['kind'] = args.kind;
     // T9905: unified urgency surface — only forward when the flag was set
     if (args.urgent !== undefined) params['urgent'] = args.urgent;
+    // T10108: --parent filter (with legacy --parent-id alias)
+    if (args.parent !== undefined) params['parent'] = args.parent;
+    if (args['parent-id'] !== undefined) params['parent'] = params['parent'] ?? args['parent-id'];
     const response = await dispatchRaw('query', 'tasks', 'find', params);
     if (!response.success) {
       handleRawError(response, { command: 'find', operation: 'tasks.find' });

--- a/packages/cleo/src/dispatch/domains/tasks.ts
+++ b/packages/cleo/src/dispatch/domains/tasks.ts
@@ -238,6 +238,8 @@ const _tasksTypedHandler = defineTypedHandler<TasksOps>('tasks', {
         kind: params.kind,
         // T9905: unified urgency surface
         urgent: params.urgent,
+        // T10108: --parent filter — mirrors `tasks.list --parent`
+        parent: params.parent,
       }),
       'find',
     );

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -138,6 +138,22 @@ export interface TasksFindParams {
    * @task T9905
    */
   urgent?: boolean;
+  /**
+   * Filter by parent task ID — restrict the result set to direct children of
+   * `parent`. Mirrors the `tasks.list --parent` semantics (ADR-073 §1) so
+   * `cleo find` and `cleo list` agree on the parent axis.
+   *
+   * When `parent` resolves to a Saga (Epic with `labels.includes('saga')`),
+   * children are resolved through `task_relations.type='groups'` edges
+   * instead of the `parentId` column — matching `tasks.list`.
+   *
+   * Composes with other filters via AND. Eliminates the empty-string
+   * `query=""` bypass that returned the full unfiltered result set
+   * (T10108 bug).
+   *
+   * @task T10108
+   */
+  parent?: string;
 }
 export type TasksFindResult = MinimalTask[];
 

--- a/packages/core/src/tasks/__tests__/find-parent-filter.test.ts
+++ b/packages/core/src/tasks/__tests__/find-parent-filter.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression tests for `cleo find --parent <id>` (T10108).
+ *
+ * Previously `cleo find "" --parent T9758` returned the full unfiltered set
+ * because:
+ *   1. The CLI `find` command had no `--parent` flag and silently dropped
+ *      the value before dispatch.
+ *   2. The empty-string `""` query short-circuited to fuzzy-mode where
+ *      `fuzzyScore('', '<title>')` returns 80 for every task (substring
+ *      match of the empty string), so every row "matched".
+ *
+ * The fix:
+ *   - `FindTasksOptions.parent` is now a first-class filter.
+ *   - An empty / whitespace-only `query` is treated as "no query supplied"
+ *     so the filter-only path runs.
+ *   - `--parent` is Saga-aware — when the target is a Saga (Epic labeled
+ *     `saga`), children are resolved through `task_relations.type='groups'`
+ *     edges instead of the `parentId` column, matching `listTasks`
+ *     (ADR-073 §1).
+ *
+ * @task T10108
+ */
+
+import type { Task } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { findTasks } from '../find.js';
+
+/** Build a mock DataAccessor wrapping an in-memory array. */
+function mockAccessor(tasks: Task[]): DataAccessor {
+  return {
+    queryTasks: async (filters) => {
+      let list = tasks;
+      if (filters?.status) list = list.filter((t) => t.status === filters.status);
+      if (filters?.parentId !== undefined) {
+        list = list.filter((t) => t.parentId === filters.parentId);
+      }
+      return { tasks: list, total: list.length };
+    },
+    loadArchive: async () => ({ archivedTasks: [] }),
+    loadSingleTask: async (id: string) => tasks.find((t) => t.id === id) ?? null,
+  } as unknown as DataAccessor;
+}
+
+function makeTask(overrides: Partial<Task>): Task {
+  return {
+    id: 'TX',
+    title: 't',
+    description: '',
+    status: 'pending',
+    priority: 'medium',
+    type: 'task',
+    size: 'small',
+    parentId: null,
+    labels: [],
+    depends: [],
+    acceptance: [],
+    createdAt: '2026-05-23T00:00:00Z',
+    ...overrides,
+  } as Task;
+}
+
+describe('findTasks — --parent filter (T10108)', () => {
+  it('restricts results to direct children of --parent', async () => {
+    const tasks = [
+      makeTask({ id: 'T100', title: 'epic parent', type: 'epic', parentId: null }),
+      makeTask({ id: 'T101', title: 'child A', parentId: 'T100' }),
+      makeTask({ id: 'T102', title: 'child B', parentId: 'T100' }),
+      makeTask({ id: 'T200', title: 'unrelated', parentId: null }),
+      makeTask({ id: 'T201', title: 'other-child', parentId: 'T200' }),
+    ];
+    const result = await findTasks({ parent: 'T100' }, undefined, mockAccessor(tasks));
+    expect(result.results.map((r) => r.id).sort()).toEqual(['T101', 'T102']);
+    expect(result.total).toBe(2);
+  });
+
+  it('rejects empty-string query when no other filter is supplied', async () => {
+    // The empty-string bypass: previously `findTasks({ query: '' })` would
+    // run fuzzy-mode and match every task via `fuzzyScore('', t.title) === 80`.
+    // Now `''` is normalised to undefined and the no-filter guard fires.
+    await expect(findTasks({ query: '' }, undefined, mockAccessor([]))).rejects.toThrow(
+      /query.*--id.*filter/i,
+    );
+  });
+
+  it('rejects whitespace-only query when no other filter is supplied', async () => {
+    await expect(findTasks({ query: '   ' }, undefined, mockAccessor([]))).rejects.toThrow(
+      /query.*--id.*filter/i,
+    );
+  });
+
+  it('does NOT bypass the --parent filter when query is empty string', async () => {
+    // The exact bug from T10108: `cleo find "" --parent T100` must NOT
+    // return the unfiltered global result set.
+    const tasks = [
+      makeTask({ id: 'T100', title: 'parent', type: 'epic' }),
+      makeTask({ id: 'T101', title: 'child', parentId: 'T100' }),
+      makeTask({ id: 'T999', title: 'stranger', parentId: null }),
+    ];
+    const result = await findTasks({ query: '', parent: 'T100' }, undefined, mockAccessor(tasks));
+    expect(result.results.map((r) => r.id)).toEqual(['T101']);
+    expect(result.total).toBe(1);
+  });
+
+  it('composes --parent with --status', async () => {
+    const tasks = [
+      makeTask({ id: 'T100', title: 'parent', type: 'epic' }),
+      makeTask({ id: 'T101', title: 'child A pending', parentId: 'T100', status: 'pending' }),
+      makeTask({ id: 'T102', title: 'child B done', parentId: 'T100', status: 'done' }),
+      makeTask({ id: 'T103', title: 'child C pending', parentId: 'T100', status: 'pending' }),
+    ];
+    const result = await findTasks(
+      { parent: 'T100', status: 'pending' },
+      undefined,
+      mockAccessor(tasks),
+    );
+    expect(result.results.map((r) => r.id).sort()).toEqual(['T101', 'T103']);
+  });
+
+  it('composes --parent with a fuzzy query', async () => {
+    const tasks = [
+      makeTask({ id: 'T100', title: 'parent', type: 'epic' }),
+      makeTask({ id: 'T101', title: 'implement auth flow', parentId: 'T100' }),
+      makeTask({ id: 'T102', title: 'fix docs', parentId: 'T100' }),
+      makeTask({ id: 'T201', title: 'auth in another epic', parentId: 'T200' }),
+    ];
+    const result = await findTasks(
+      { query: 'auth', parent: 'T100' },
+      undefined,
+      mockAccessor(tasks),
+    );
+    // Only T101 matches BOTH the fuzzy query AND the parent filter.
+    expect(result.results.map((r) => r.id)).toEqual(['T101']);
+  });
+
+  it('routes to saga members when --parent targets a saga', async () => {
+    // Sagas hold members through task_relations.type='groups', NOT parentId.
+    // resolveSagaMemberIds returns the member IDs; findTasks must restrict
+    // the result set to that member set even though the rows themselves
+    // have parentId=null (top-level Epics).
+    const sagaTask = makeTask({
+      id: 'SG_T9999',
+      title: 'saga root',
+      type: 'epic',
+      labels: ['saga'],
+      relates: [
+        { taskId: 'T800', type: 'groups' },
+        { taskId: 'T801', type: 'groups' },
+      ],
+    });
+    const tasks: Task[] = [
+      sagaTask,
+      makeTask({ id: 'T800', title: 'epic A', type: 'epic', parentId: null }),
+      makeTask({ id: 'T801', title: 'epic B', type: 'epic', parentId: null }),
+      makeTask({ id: 'T802', title: 'epic C — NOT a member', type: 'epic', parentId: null }),
+    ];
+    const result = await findTasks({ parent: 'SG_T9999' }, undefined, mockAccessor(tasks));
+    expect(result.results.map((r) => r.id).sort()).toEqual(['T800', 'T801']);
+  });
+
+  it('parity with cleo list --parent: identical id set for the same parent', async () => {
+    // Mirrors the AC2 contract: `cleo find <query> --parent <id>` works the
+    // same as `cleo list --parent <id>` for the parent filter axis.
+    const tasks = [
+      makeTask({ id: 'T100', title: 'parent', type: 'epic' }),
+      makeTask({ id: 'T101', title: 'child A', parentId: 'T100' }),
+      makeTask({ id: 'T102', title: 'child B', parentId: 'T100' }),
+      makeTask({ id: 'T103', title: 'child C', parentId: 'T100' }),
+      makeTask({ id: 'T999', title: 'not a child', parentId: null }),
+    ];
+    const findResult = await findTasks({ parent: 'T100' }, undefined, mockAccessor(tasks));
+    const findIds = findResult.results.map((r) => r.id).sort();
+
+    // Direct accessor query mirrors what `listTasks` would resolve for
+    // parentId='T100' without the Saga branch.
+    const listResult = await mockAccessor(tasks).queryTasks({ parentId: 'T100' });
+    const listIds = listResult.tasks.map((t) => t.id).sort();
+
+    expect(findIds).toEqual(listIds);
+  });
+});

--- a/packages/core/src/tasks/find.ts
+++ b/packages/core/src/tasks/find.ts
@@ -18,6 +18,7 @@ import { CleoError } from '../errors.js';
 import { cleoErrorToEngineResult } from '../errors-to-engine.js';
 import type { NextDirectives } from '../mvi-helpers.js';
 import { taskListItemNext } from '../mvi-helpers.js';
+import { resolveSagaMemberIds } from '../sagas/storage.js';
 import type { DataAccessor } from '../store/data-accessor.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { taskToRecord } from './engine-converters.js';
@@ -76,6 +77,21 @@ export interface FindTasksOptions {
    * @task T9905
    */
   urgent?: boolean;
+  /**
+   * Filter results to direct children of `parent`.
+   *
+   * Mirrors the `tasks.list --parent` semantics (ADR-073 §1). When `parent`
+   * resolves to a Saga (Epic with `labels.includes('saga')`), children are
+   * resolved through `task_relations.type='groups'` edges instead of the
+   * `parentId` column — same routing as `listTasks`.
+   *
+   * Composes with other filters via AND. Closes the empty-string `query=""`
+   * bypass where `cleo find "" --parent T123` previously returned the full
+   * unfiltered result set (T10108 bug).
+   *
+   * @task T10108
+   */
+  parent?: string;
 }
 
 /** Result of finding tasks. */
@@ -263,14 +279,24 @@ export async function findTasks(
   accessor?: DataAccessor,
 ): Promise<FindTasksResult> {
   const options = extractInlineFilters(rawOptions);
-  const hasFilter = Boolean(options.status || options.kind || options.urgent);
+
+  // T10108: treat an empty / whitespace-only query as "no query supplied",
+  // which closes the empty-string bypass where `cleo find ""` previously
+  // matched every task via `fuzzyScore('', '<title>') === 80`. The CLI passes
+  // through positional args verbatim, so users routinely typed
+  // `cleo find "" --parent T123` and got the full unfiltered set back.
+  if (typeof options.query === 'string' && options.query.trim() === '') {
+    options.query = undefined;
+  }
+
+  const hasFilter = Boolean(options.status || options.kind || options.urgent || options.parent);
 
   if (options.query == null && !options.id && !hasFilter) {
     throw new CleoError(
       ExitCode.INVALID_INPUT,
-      'Search query, --id, or at least one filter (--status, --kind, --urgent) is required',
+      'Search query, --id, or at least one filter (--status, --kind, --urgent, --parent) is required',
       {
-        fix: 'cleo find "<query>"  OR  cleo find --urgent  OR  cleo find --status pending  OR  cleo find --id T123',
+        fix: 'cleo find "<query>"  OR  cleo find --urgent  OR  cleo find --status pending  OR  cleo find --parent T123  OR  cleo find --id T123',
         details: { field: 'query' },
       },
     );
@@ -278,10 +304,26 @@ export async function findTasks(
 
   const acc = accessor ?? (await getTaskAccessor(cwd));
 
+  // T10108: Saga-aware --parent routing — mirror `listTasks`.
+  // When `--parent` targets a Saga (Epic with `labels.includes('saga')`),
+  // children live in `task_relations.type='groups'`, NOT in the `parentId`
+  // column. Detect once up-front; fall back to the default `parentId`-based
+  // filter when the parent is not a Saga (or does not exist).
+  let sagaMemberIds: string[] | null = null;
+  if (options.parent) {
+    sagaMemberIds = await resolveSagaMemberIds(acc, options.parent);
+  }
+
   // Use targeted query with status filter when available
   const filters: TaskQueryFilters = {};
   if (options.status) {
     filters.status = options.status;
+  }
+  // T10108: push the parent filter down to the accessor when this is a plain
+  // parent (not a Saga). For Sagas we filter in-memory below using the
+  // member-ID set returned by `resolveSagaMemberIds`.
+  if (options.parent && sagaMemberIds === null) {
+    filters.parentId = options.parent;
   }
   const queryResult = await acc.queryTasks(filters);
   let allTasks: Task[] = [...queryResult.tasks];
@@ -294,8 +336,19 @@ export async function findTasks(
       if (options.status) {
         archivedTasks = archivedTasks.filter((t) => t.status === options.status);
       }
+      // T10108: archive must respect the parent filter too. For Sagas, the
+      // member-set filter below covers archived rows uniformly.
+      if (options.parent && sagaMemberIds === null) {
+        archivedTasks = archivedTasks.filter((t) => t.parentId === options.parent);
+      }
       allTasks = [...allTasks, ...archivedTasks];
     }
+  }
+
+  // T10108: Saga-member filter — restrict to the saga's member Epic IDs.
+  if (sagaMemberIds !== null) {
+    const memberSet = new Set(sagaMemberIds);
+    allTasks = allTasks.filter((t) => memberSet.has(t.id));
   }
 
   // T944/T9072: kind filter — applied after status/archive resolution
@@ -450,6 +503,8 @@ export async function taskFind(
     kind?: string;
     /** Unified urgency surface — see {@link FindTasksOptions.urgent}. @task T9905 */
     urgent?: boolean;
+    /** Filter results to direct children of this parent. @task T10108 */
+    parent?: string;
   },
 ): Promise<EngineResult<{ results: (MinimalTaskRecord | TaskRecord)[]; total: number }>> {
   try {
@@ -465,6 +520,7 @@ export async function taskFind(
         offset: options?.offset,
         kind: options?.kind as TaskKind | undefined,
         urgent: options?.urgent,
+        parent: options?.parent,
       },
       projectRoot,
       accessor,


### PR DESCRIPTION
## Summary

Closes the T10108 bug where `cleo find "" --parent T9758` returned the
full unfiltered result set (1216 rows) instead of just the children of
T9758. Two compounding defects were the cause:

1. The CLI `find` command had no `--parent` flag, so the value was
   silently dropped before dispatch.
2. The empty-string `""` query short-circuited to fuzzy-mode where
   `fuzzyScore('', '<title>')` returned 80 for every task (substring
   match of the empty string), so every row "matched".

## Changes

- **Contract**: add `parent?: string` to `TasksFindParams` in
  `packages/contracts/src/operations/tasks.ts`.
- **Core (`findTasks`)**: add `parent?: string` to `FindTasksOptions`;
  push `parentId` to the accessor for plain parents; for Sagas (Epic
  with `labels.includes('saga')`), reuse `resolveSagaMemberIds` from
  `@cleocode/core/sagas/storage` to restrict via
  `task_relations.type='groups'` member IDs — same routing as
  `listTasks` (ADR-073 §1). Normalise empty / whitespace-only `query`
  to `undefined` so it no longer bypasses filters. Update no-filter
  error message + fix-hint to mention `--parent`.
- **Dispatch**: forward `parent` from `tasks.find` to `taskFind`.
- **CLI**: add `--parent` (and `--parent-id` legacy alias) to
  `cleo find`, matching the `cleo list` surface.

## Acceptance

| AC | Status |
|---|---|
| 1. `cleo find "" --parent T9758` returns only children of T9758 | covered by `find-parent-filter.test.ts` |
| 2. `cleo find <query> --parent <id>` works the same as `cleo list --parent <id>` for the parent axis | covered by the parity test |
| 3. Empty query string `""` does not bypass filters | covered by two regression tests |
| 4. Regression test in `packages/core` | `packages/core/src/tasks/__tests__/find-parent-filter.test.ts` (8 tests) |

## Test Plan

- [x] `pnpm exec vitest run packages/core/src/tasks/__tests__/find-parent-filter.test.ts` — 8/8 passed
- [x] `pnpm exec vitest run packages/core/src/tasks` — 1088/1088 passed
- [x] `pnpm exec vitest run packages/core/src/tasks/__tests__/find.test.ts packages/core/src/tasks/__tests__/find-filter-modes.test.ts packages/core/src/tasks/__tests__/find-urgent.test.ts packages/core/src/tasks/__tests__/find-parent-filter.test.ts` — 36/36 passed
- [x] `pnpm biome check` — clean
- [ ] Smoke against built CLI: `cleo find "" --parent T9758` returns the
      children-only set. (Deferred — build chain blocked by pre-existing
      `buildChangesetLintGateBlock` reference in
      `packages/core/src/orchestration/spawn-prompt.ts` on `origin/main`,
      unrelated to this fix. See "Deviations" below.)

## Deviations

The pre-existing CI breakage in
`packages/core/src/orchestration/spawn-prompt.ts:1729` — `Cannot find
name 'buildChangesetLintGateBlock'` — also fails on `origin/main`
without this PR's diff, and blocks `tsc --emitDeclarationOnly` for
`@cleocode/core` (which in turn blocks the rest of the build chain).
130 of the 760 failing tests in `packages/core` trace back to this
same root cause via `spawn-prompt.test.ts`, `spawn-prompt-hoist.test.ts`,
`orchestrate-engine*.test.ts`, etc. I verified the failures are
identical on `origin/main` with my changes stashed, so the fix here
is independent of that breakage.

## Closes

T10108