### PR TITLE
feat(T10155): CI gate failing PRs that introduce .claude/worktrees/*/.cleo/** files

### DIFF
--- a/.changeset/t10155-orphan-cleo-dir-check.md
+++ b/.changeset/t10155-orphan-cleo-dir-check.md
@@ -1,0 +1,8 @@
+---
+id: t10155-orphan-cleo-dir-check
+tasks: [T10155]
+kind: chore
+summary: CI gate failing PRs that introduce .claude/worktrees/*/.cleo/** files (T9550/T9580 regression guard)
+---
+
+Adds scripts/lint-orphan-cleo-dir.mjs + the Orphan .cleo/ Dir Check (T10155) CI job. Scans git diff --diff-filter=A between PR base and HEAD for newly-added paths matching .claude/worktrees/<sessionId>/.cleo/**. Fails with error referencing T9550/T9580 historical incidents. Complementary to lint-project-root-anti-pattern.mjs (T9584) — that gate catches source-level anti-patterns; this catches the materialised symptom. Includes 35 unit tests (positive + negative + CLI + self-test against live repo). Saga T9862 SG-WORKTREE-CANON Wave 5.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,35 @@ jobs:
         # rogue worktrees should exist. The script exits 0 when clean.
         run: node scripts/lint-worktree-location.mjs
 
+  orphan-cleo-dir-check:
+    # T10155 / Saga T9862 SG-WORKTREE-CANON Wave 5 — orphan-`.cleo/` regression
+    # guard. Scans `git diff --diff-filter=A` between the PR base and HEAD for
+    # any newly-added file matching `.claude/worktrees/<sessionId>/.cleo/**`.
+    # Fires with a clear error referencing T9550/T9580 (the two historical
+    # incidents) so the operator can find the in-source regression that
+    # synthesised the rogue path. Complementary to `lint-project-root-anti-
+    # pattern.mjs` (T9584) — that gate catches the source-level anti-pattern;
+    # this one catches the materialised symptom if a brand-new pattern slips
+    # through. Pure static analysis of `git diff` output — no untrusted input.
+    name: Orphan .cleo/ Dir Check (T10155)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history required so `git diff origin/<base>...HEAD` resolves
+          # both ends — shallow clones drop the base ref's commit.
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Resolve PR base ref
+        # `github.base_ref` is unset on pushes; fall back to `main` so direct
+        # pushes to feature branches are still scanned.
+        run: echo "BASE_REF=origin/${{ github.base_ref || 'main' }}" >> $GITHUB_ENV
+      - name: Lint orphan .cleo/ paths in PR-added files
+        run: node scripts/lint-orphan-cleo-dir.mjs --base "$BASE_REF"
+
   agent-outputs-registration:
     # T1617: Require every .md added to .cleo/agent-outputs/ to be registered
     # via (a) cleo docs add, (b) cleo memory observe, or (c) @no-cleo-register

--- a/scripts/__tests__/lint-orphan-cleo-dir.test.mjs
+++ b/scripts/__tests__/lint-orphan-cleo-dir.test.mjs
@@ -1,0 +1,252 @@
+/**
+ * Tests for scripts/lint-orphan-cleo-dir.mjs (T10155 / Saga T9862 Wave 5).
+ *
+ * Strategy:
+ *   - Import the pure helpers (isOrphanCleoPath, findOrphanPaths, parseArgs,
+ *     runLint with --files) and assert directly — no git shell-out, no
+ *     subprocess, fast and deterministic.
+ *   - Also exercise the CLI end-to-end via spawnSync with --files so the
+ *     argv-parsing + exit-code wiring is covered.
+ *
+ * Positive cases (orphan detection MUST trigger):
+ *   - .claude/worktrees/<id>/.cleo/tasks.db
+ *   - .claude/worktrees/<id>/.cleo/audit/foo.jsonl
+ *   - paths with task-style session IDs (T9550-foo)
+ *
+ * Negative cases (MUST NOT trigger):
+ *   - Top-level .cleo/* (canonical project root)
+ *   - .claude/worktrees/<id>/src/foo.ts (no .cleo segment)
+ *   - .claude/agents/foo.json (not under worktrees/)
+ *   - .claude/worktrees/.cleo/x (missing session-id segment)
+ *
+ * @task T10155
+ */
+
+import { spawnSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { findOrphanPaths, isOrphanCleoPath, parseArgs, runLint } from '../lint-orphan-cleo-dir.mjs';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+const REPO_ROOT = resolve(__dirname, '../..');
+const SCRIPT = join(REPO_ROOT, 'scripts/lint-orphan-cleo-dir.mjs');
+
+// ---------------------------------------------------------------------------
+// Pure helper — isOrphanCleoPath
+// ---------------------------------------------------------------------------
+
+describe('isOrphanCleoPath — positive cases', () => {
+  it.each([
+    '.claude/worktrees/abc123/.cleo/tasks.db',
+    '.claude/worktrees/T9550-foo/.cleo/config.json',
+    '.claude/worktrees/sess_42/.cleo/audit/force-bypass.jsonl',
+    '.claude/worktrees/x/.cleo/brain.db',
+    '.claude/worktrees/0/.cleo', // direct match without trailing slash
+  ])('matches %s', (path) => {
+    expect(isOrphanCleoPath(path)).toBe(true);
+  });
+});
+
+describe('isOrphanCleoPath — negative cases', () => {
+  it.each([
+    // Canonical top-level .cleo/ — the legitimate project root.
+    '.cleo/tasks.db',
+    '.cleo/config.json',
+    // Worktree but no .cleo segment.
+    '.claude/worktrees/abc123/src/foo.ts',
+    '.claude/worktrees/abc123/README.md',
+    // Not under worktrees/ at all.
+    '.claude/agents/foo.json',
+    '.claude/skills/bar.md',
+    // Missing the session-id middle segment — `.cleo` is the direct child
+    // of `.claude/worktrees/`, which is not a "worktree" itself.
+    '.claude/worktrees/.cleo/tasks.db',
+    // Package source paths.
+    'packages/core/src/foo.ts',
+    'scripts/lint-orphan-cleo-dir.mjs',
+    // Empty / pathological.
+    '',
+    '.claude',
+    '.claude/worktrees',
+  ])('does not match %s', (path) => {
+    expect(isOrphanCleoPath(path)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findOrphanPaths
+// ---------------------------------------------------------------------------
+
+describe('findOrphanPaths', () => {
+  it('returns only the offending paths from a mixed list', () => {
+    const input = [
+      'packages/core/src/paths.ts',
+      '.claude/worktrees/abc/.cleo/tasks.db',
+      '.cleo/tasks.db',
+      '.claude/worktrees/T9550/.cleo/brain.db',
+      'scripts/foo.mjs',
+    ];
+    expect(findOrphanPaths(input)).toEqual([
+      '.claude/worktrees/abc/.cleo/tasks.db',
+      '.claude/worktrees/T9550/.cleo/brain.db',
+    ]);
+  });
+
+  it('returns empty array when no orphans present', () => {
+    expect(findOrphanPaths(['.cleo/tasks.db', 'packages/core/src/foo.ts'])).toEqual([]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(findOrphanPaths([])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  it('defaults to origin/main when no --base supplied', () => {
+    expect(parseArgs([])).toEqual({
+      baseRef: 'origin/main',
+      explicitFiles: null,
+      help: false,
+    });
+  });
+
+  it('honours --base origin/release/v1', () => {
+    expect(parseArgs(['--base', 'origin/release/v1'])).toMatchObject({
+      baseRef: 'origin/release/v1',
+    });
+  });
+
+  it('accepts --base-ref as an alias', () => {
+    expect(parseArgs(['--base-ref', 'HEAD~3'])).toMatchObject({ baseRef: 'HEAD~3' });
+  });
+
+  it('captures everything after --files', () => {
+    const out = parseArgs(['--files', 'a.ts', 'b/c.ts', '.cleo/tasks.db']);
+    expect(out.explicitFiles).toEqual(['a.ts', 'b/c.ts', '.cleo/tasks.db']);
+  });
+
+  it('reports --help', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+  });
+
+  it('throws on unknown flag', () => {
+    expect(() => parseArgs(['--unknown'])).toThrow(/Unknown argument/);
+  });
+
+  it('throws when --base is missing its value', () => {
+    expect(() => parseArgs(['--base'])).toThrow(/--base requires/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runLint (programmatic API, --files bypass)
+// ---------------------------------------------------------------------------
+
+describe('runLint — programmatic', () => {
+  it('exits 0 on clean file list', () => {
+    const result = runLint(
+      { baseRef: 'origin/main', explicitFiles: ['.cleo/tasks.db', 'src/foo.ts'], help: false },
+      REPO_ROOT,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.offenders).toEqual([]);
+  });
+
+  it('exits 1 on orphan path', () => {
+    const result = runLint(
+      {
+        baseRef: 'origin/main',
+        explicitFiles: ['src/foo.ts', '.claude/worktrees/abc/.cleo/tasks.db'],
+        help: false,
+      },
+      REPO_ROOT,
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.offenders).toEqual(['.claude/worktrees/abc/.cleo/tasks.db']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI end-to-end (spawnSync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn the script with the given args. Captures stdout + stderr + status.
+ *
+ * @param {string[]} args
+ */
+function runCli(args) {
+  return spawnSync('node', [SCRIPT, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: REPO_ROOT,
+  });
+}
+
+describe('CLI bootstrap', () => {
+  it('--help exits 0 and prints usage', () => {
+    const r = runCli(['--help']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('lint-orphan-cleo-dir.mjs');
+    expect(r.stdout).toContain('--base');
+    expect(r.stdout).toContain('@task T10155');
+  });
+
+  it('exits 0 with OK banner on clean --files list', () => {
+    const r = runCli(['--files', 'src/foo.ts', '.cleo/tasks.db']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('OK');
+  });
+
+  it('exits 1 with FAIL banner when an orphan path is present', () => {
+    const r = runCli(['--files', '.claude/worktrees/abc/.cleo/tasks.db']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('FAIL');
+    expect(r.stderr).toContain('.claude/worktrees/abc/.cleo/tasks.db');
+    // The mandated error string from the acceptance criteria — verbatim.
+    expect(r.stderr).toContain('Orphan .cleo/ directory creation detected');
+    expect(r.stderr).toContain('T9550');
+    expect(r.stderr).toContain('T9580');
+  });
+
+  it('lists every offender when multiple orphans are added', () => {
+    const r = runCli([
+      '--files',
+      '.claude/worktrees/a/.cleo/x',
+      'src/foo.ts',
+      '.claude/worktrees/b/.cleo/y',
+    ]);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('.claude/worktrees/a/.cleo/x');
+    expect(r.stderr).toContain('.claude/worktrees/b/.cleo/y');
+    // The stable banner reports the count.
+    expect(r.stderr).toContain('2 orphan path(s)');
+  });
+
+  it('exits 2 on unknown flag', () => {
+    const r = runCli(['--no-such-flag']);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('Unknown argument');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Self-test against the live repo
+// ---------------------------------------------------------------------------
+
+describe('self-test against live repo', () => {
+  it('finds no orphan paths in the current PR diff against origin/main', () => {
+    const r = runCli(['--base', 'origin/main']);
+    // We accept exit 0 (clean) OR the git-warning fallback (status 0, stderr
+    // notes the no-op). The gate must NEVER report a FAIL on the current repo.
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toContain('FAIL');
+  });
+});

--- a/scripts/lint-orphan-cleo-dir.mjs
+++ b/scripts/lint-orphan-cleo-dir.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+/**
+ * lint-orphan-cleo-dir.mjs — CI gate against the T9550/T9580 orphan-`.cleo/`
+ * regression class.
+ *
+ * Why this matters (Saga T9862 Wave 5 · T10155)
+ * ---------------------------------------------
+ * Twice now CLEO has shipped a release where a `getCleoDirAbsolute`-class
+ * regression caused agent workflows to materialise a rogue `.cleo/` directory
+ * inside an unrelated worktree (typically Claude Code Agent's
+ * `.claude/worktrees/<sessionId>/`). The result is a split-brain CLEO state
+ * machine:
+ *
+ *   - The orphan `.cleo/` holds tasks the operator can never `cleo show`
+ *     (the canonical project root is somewhere else entirely).
+ *   - BRAIN observations and memory writes vanish into the orphan.
+ *   - `cleo doctor` from the wrong cwd repeats the offence.
+ *
+ * Historical incidents:
+ *   - T9550 — original sighting (Saga T9580 SG-PROJECT-ROOT). Long-tail
+ *     batches T9685-B1/B2/B3 drove the in-source baseline to zero.
+ *   - T9580 — closeout for the SAGA. Strict-mode flip locked
+ *     `lint-project-root-anti-pattern.mjs` at zero violations.
+ *
+ * `lint-project-root-anti-pattern.mjs` (T9584) regression-locks the
+ * SOURCE-CODE level (anti-patterns that synthesise the orphan path). This
+ * script regression-locks the OBSERVED-EFFECT level (the orphan directory
+ * itself, materialised on disk and accidentally committed in a PR). The two
+ * gates are complementary: the first catches drift before any code runs; the
+ * second catches the materialised symptom in case a brand-new anti-pattern
+ * slips past the source linter.
+ *
+ * Rule
+ * ----
+ * Any file added in the PR (`git diff --diff-filter=A <base>...HEAD`) whose
+ * path matches the glob `.claude/worktrees/<sessionId>/.cleo/...` fails the
+ * gate. The match is rooted (must start with `.claude/worktrees/`), the
+ * second segment is the session ID (free-form, no `/`), and the third
+ * segment is the literal `.cleo`.
+ *
+ * Usage:
+ *   node scripts/lint-orphan-cleo-dir.mjs                 # diff against origin/main
+ *   node scripts/lint-orphan-cleo-dir.mjs --base origin/main
+ *   node scripts/lint-orphan-cleo-dir.mjs --base HEAD~1
+ *   node scripts/lint-orphan-cleo-dir.mjs --files <file1> <file2>   # test-only
+ *
+ * Exit codes:
+ *   0 — clean (no orphan `.cleo/` paths in PR-added files)
+ *   1 — at least one orphan path detected
+ *   2 — usage / runtime error
+ *
+ * @task T10155
+ * @epic T9862
+ * @saga SG-WORKTREE-CANON
+ * @adr ADR-055
+ */
+
+import { spawnSync } from 'node:child_process';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * The orphan-detection regex. Matches paths beginning with `.claude/worktrees/`,
+ * then exactly one non-slash session-id segment, then `/.cleo/`, then anything.
+ *
+ * Examples that MATCH (rejected):
+ *   .claude/worktrees/abc123/.cleo/tasks.db
+ *   .claude/worktrees/T9550-foo/.cleo/config.json
+ *   .claude/worktrees/x/.cleo/audit/force-bypass.jsonl
+ *
+ * Examples that DO NOT match (accepted):
+ *   .claude/worktrees/abc123/src/foo.ts         — no .cleo segment
+ *   .cleo/tasks.db                              — top-level .cleo (canonical)
+ *   .claude/agents/foo.json                     — not under worktrees/
+ *   .claude/worktrees/.cleo/tasks.db            — missing session-id segment
+ */
+const ORPHAN_PATTERN = /^\.claude\/worktrees\/[^/]+\/\.cleo(?:\/|$)/;
+
+const DEFAULT_BASE_REF = 'origin/main';
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} Options
+ * @property {string} baseRef
+ * @property {string[] | null} explicitFiles
+ * @property {boolean} help
+ */
+
+/**
+ * Parse argv slice into a structured config object.
+ *
+ * @param {string[]} argv - Already-sliced argv (no `node` / script path).
+ * @returns {Options}
+ */
+export function parseArgs(argv) {
+  /** @type {Options} */
+  const opts = { baseRef: DEFAULT_BASE_REF, explicitFiles: null, help: false };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--base' || arg === '--base-ref') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('--base requires a git ref argument');
+      opts.baseRef = next;
+      i += 1;
+    } else if (arg === '--files') {
+      // Everything after --files is treated as a literal file path. Used by
+      // the unit tests to avoid shelling out to git.
+      opts.explicitFiles = argv.slice(i + 1);
+      break;
+    } else if (arg === '--help' || arg === '-h') {
+      opts.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return opts;
+}
+
+const HELP_TEXT = `lint-orphan-cleo-dir.mjs — reject newly-added .claude/worktrees/<id>/.cleo/** files.
+
+Usage:
+  node scripts/lint-orphan-cleo-dir.mjs [--base <git-ref>]
+  node scripts/lint-orphan-cleo-dir.mjs --files <path1> <path2> ...
+
+Options:
+  --base <ref>     Git ref to diff against (default: origin/main)
+  --files <list>   Bypass git diff and check the given paths literally (testing)
+  --help           Show this message
+
+Exit codes:
+  0 — no orphan paths in PR-added files
+  1 — orphan path(s) detected
+  2 — usage / runtime error
+
+@task T10155`;
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Return TRUE if `path` matches the orphan `.cleo/` glob.
+ *
+ * @param {string} path - Repo-relative POSIX path (forward slashes).
+ * @returns {boolean}
+ */
+export function isOrphanCleoPath(path) {
+  return ORPHAN_PATTERN.test(path);
+}
+
+/**
+ * List files added (status `A`) between `baseRef` and `HEAD`. Falls back to
+ * an empty list on git failure (e.g. the base ref does not exist locally),
+ * because the gate should be a no-op on broken setups rather than emit a
+ * spurious failure.
+ *
+ * @param {string} baseRef - The ref to diff against.
+ * @param {string} cwd - Working directory (must be inside a git repo).
+ * @returns {string[]} Repo-relative paths (POSIX-style).
+ */
+export function listAddedFiles(baseRef, cwd) {
+  const result = spawnSync('git', ['diff', '--name-only', '--diff-filter=A', `${baseRef}...HEAD`], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.status !== 0) {
+    // base ref unavailable or git not present — emit a single stderr line so
+    // CI logs explain the no-op, then return an empty list.
+    console.warn(
+      `[lint-orphan-cleo-dir] WARN: git diff against "${baseRef}" failed (status ${result.status}). Skipping.`,
+    );
+    return [];
+  }
+  return result.stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Filter the file list to only those matching the orphan-`.cleo/` pattern.
+ *
+ * @param {string[]} files - Repo-relative paths (POSIX-style).
+ * @returns {string[]} The offending paths (subset of `files`).
+ */
+export function findOrphanPaths(files) {
+  return files.filter((f) => isOrphanCleoPath(f));
+}
+
+// ---------------------------------------------------------------------------
+// Reporter
+// ---------------------------------------------------------------------------
+
+/**
+ * Print the failure banner explaining why CI rejected the PR.
+ *
+ * @param {string[]} offenders - The matched orphan paths.
+ */
+function reportViolations(offenders) {
+  const ghaAnnot = process.env['GITHUB_ACTIONS'] === 'true';
+  const banner = `Orphan .cleo/ directory creation detected — this indicates getCleoDirAbsolute regression like T9550/T9580. Verify your code does not synthesize a .cleo/ inside a worktree.`;
+
+  console.error(`[lint-orphan-cleo-dir] FAIL — ${offenders.length} orphan path(s):`);
+  for (const path of offenders) {
+    if (ghaAnnot) {
+      console.error(`::error file=${path}::${banner}`);
+    } else {
+      console.error(`  - ${path}`);
+    }
+  }
+  if (!ghaAnnot) {
+    console.error(`\n${banner}\n`);
+  }
+  console.error(
+    'Fix:\n' +
+      '  1. Find the code path that materialised "<repo>/.claude/worktrees/<id>/.cleo/".\n' +
+      '     Search for recent edits to packages/core/src/paths.ts or any\n' +
+      '     `process.cwd()`-based path resolver that bypasses getProjectRoot().\n' +
+      '  2. Remove the rogue .cleo/ from your working tree:\n' +
+      '       rm -rf .claude/worktrees/<sessionId>/.cleo/\n' +
+      '  3. Re-run `cleo doctor` from the project root and verify only the\n' +
+      '     canonical .cleo/ at the repo root exists.\n' +
+      '  4. See:\n' +
+      '       - scripts/lint-project-root-anti-pattern.mjs (T9584) for the\n' +
+      '         in-source regression gate.\n' +
+      '       - docs/project-root-conventions.md for the canonical resolution\n' +
+      '         chain.\n' +
+      '       - Saga T9580 / T9685 history for prior incidents.\n',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+/**
+ * Programmatic entry-point. Exposed so the unit tests can invoke the script
+ * without spawning a subprocess for the cheap paths.
+ *
+ * @param {Options} opts
+ * @param {string} cwd
+ * @returns {{ exitCode: number, offenders: string[] }}
+ */
+export function runLint(opts, cwd) {
+  const files = opts.explicitFiles ?? listAddedFiles(opts.baseRef, cwd);
+  const offenders = findOrphanPaths(files);
+  return { exitCode: offenders.length === 0 ? 0 : 1, offenders };
+}
+
+// ---------------------------------------------------------------------------
+// CLI bootstrap
+// ---------------------------------------------------------------------------
+
+// Only run when invoked directly (not when imported by the test suite).
+// Equivalent to `if (require.main === module)` for ESM.
+const invokedDirectly =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (invokedDirectly) {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`[lint-orphan-cleo-dir] ERROR: ${err.message}`);
+    console.error(HELP_TEXT);
+    process.exit(2);
+  }
+
+  if (opts.help) {
+    console.log(HELP_TEXT);
+    process.exit(0);
+  }
+
+  const { exitCode, offenders } = runLint(opts, process.cwd());
+  if (exitCode === 0) {
+    console.log('[lint-orphan-cleo-dir] OK — no orphan .cleo/ paths added.');
+  } else {
+    reportViolations(offenders);
+  }
+  process.exit(exitCode);
+}


### PR DESCRIPTION
## Summary

Saga T9862 SG-WORKTREE-CANON Wave 5 — Task T10155 (P2). Regression-locks the T9550/T9580 orphan-`.cleo/` bug class at the **observed-effect** level. Complementary to the source-level `lint-project-root-anti-pattern.mjs` (T9584) gate, which fires on the in-source anti-pattern. This gate fires on the materialised symptom if a brand-new pattern slips past the source linter.

## Acceptance (per task spec)

- [x] Adds `scripts/lint-orphan-cleo-dir.mjs` that scans `git diff --diff-filter=A <base>...HEAD` for newly-added paths matching `.claude/worktrees/<sessionId>/.cleo/**`.
- [x] Fails exit 1 with the verbatim error string from the task: `Orphan .cleo/ directory creation detected — this indicates getCleoDirAbsolute regression like T9550/T9580. Verify your code does not synthesize a .cleo/ inside a worktree.`
- [x] Wires into `.github/workflows/ci.yml` as `Orphan .cleo/ Dir Check (T10155)`.
- [x] Unit tests: positive cases (orphan paths detected), negative cases (canonical `.cleo/`, non-worktree `.claude/`, missing session-id segment), parseArgs, CLI bootstrap end-to-end, self-test against live repo.
- [x] Self-test on the current repo passes (zero orphans).

## Why two gates, not one?

`lint-project-root-anti-pattern.mjs` (T9584) catches **anti-patterns in source code** before they run (e.g. `join(process.cwd(), '.cleo', ...)`). That's the upstream gate.

This gate (T10155) catches the **disk symptom**: any newly-committed file under `.claude/worktrees/<id>/.cleo/`. If a future regression invents a new way to synthesise an orphan that the source linter doesn't recognise, this downstream gate still catches it because the disk path is unmistakable.

## Files

- `scripts/lint-orphan-cleo-dir.mjs` (new) — the lint script.
- `scripts/__tests__/lint-orphan-cleo-dir.test.mjs` (new) — 35 unit tests.
- `.github/workflows/ci.yml` — adds `orphan-cleo-dir-check` job.
- `.changeset/t10155-orphan-cleo-dir-check.md` (new) — changeset.

## Test plan

- [x] `pnpm exec vitest run --project=scripts scripts/__tests__/lint-orphan-cleo-dir.test.mjs` — 35/35 pass locally.
- [x] `node scripts/lint-orphan-cleo-dir.mjs --base origin/main` — exits 0 on current repo (no orphans).
- [x] Manual fixture: planting `.claude/worktrees/abc/.cleo/tasks.db` and re-running with `--files` flags the path correctly with the verbatim acceptance error string.
- [x] `pnpm biome check --write .` — clean on the four touched files.
- [ ] CI: `Orphan .cleo/ Dir Check (T10155)` job runs and passes on this PR (no orphans introduced).

## Integration

Integrates with T10093 Gate 2 worktree-cleanup-verification when that ships — together they cover the full "no orphan ever escapes" lifecycle.