### PR TITLE
fix(T10108): cleo find --parent applies the filter

### DIFF
--- a/.changeset/T10108.md
+++ b/.changeset/T10108.md
@@ -1,0 +1,15 @@
+---
+id: t10108-find-parent-filter
+tasks: [T10108]
+kind: fix
+summary: cleo find --parent applies the parent filter (closes T10108 — empty-string query no longer bypasses all filters)
+---
+
+Closes the T10108 bug where `cleo find "" --parent T9758` returned the full unfiltered task set instead of just the children of T9758. Two compounding defects:
+
+1. The CLI `find` command had no `--parent` flag — the value was silently dropped before dispatch.
+2. The empty-string `""` query short-circuited to fuzzy mode, where `fuzzyScore('', '<any title>')` returned 80 (every string contains the empty string), so every row "matched" regardless of any filter that had been set.
+
+This change wires `--parent` end-to-end through CLI → dispatch → core → accessor, normalises empty / whitespace-only queries to `undefined` so filter-only mode kicks in, and routes Saga parents through `task_relations.type='groups'` member IDs (ADR-073 §1) — same dual-path resolution `cleo list --parent` uses.
+
+8 new unit tests in `packages/core/src/tasks/__tests__/find-parent-filter.test.ts` lock in the behaviour: direct-children filtering, AND composition with status / label, filter-only mode, empty-string and whitespace-only regression cases, and Saga-aware routing.

--- a/packages/cleo/src/cli/commands/find.ts
+++ b/packages/cleo/src/cli/commands/find.ts
@@ -73,6 +73,24 @@ export const findCommand = defineCommand({
       type: 'string',
       description: 'Filter by label — return tasks whose labels[] includes this value (T9904)',
     },
+    /**
+     * Filter by parent task ID — `cleo find --parent <id>` returns only
+     * tasks whose `parentId` matches. Mirrors the `--parent` axis on
+     * `cleo list`. When the parent target is a Saga (Epic with
+     * `label='saga'`), routing goes through `task_relations.type='groups'`
+     * member IDs (ADR-073 §1) — same path as `cleo list --parent`.
+     *
+     * Closes T10108 — pre-fix the flag was missing entirely AND empty-string
+     * queries bypassed every filter via `fuzzyScore('', '<title>')===80`.
+     *
+     * @task T10108
+     * @saga T9862
+     */
+    parent: {
+      type: 'string',
+      description:
+        'Filter by parent task ID — Saga-aware via task_relations groups (ADR-073 §1) (T10108)',
+    },
   },
   async run({ args }) {
     const limit = args.limit !== undefined ? Number.parseInt(args.limit, 10) : undefined;
@@ -94,6 +112,8 @@ export const findCommand = defineCommand({
     if (args.urgent !== undefined) params['urgent'] = args.urgent;
     // T9904: label filter — forward when set
     if (args.label !== undefined) params['label'] = args.label;
+    // T10108: parent filter — forward when set
+    if (args.parent !== undefined) params['parent'] = args.parent;
     const response = await dispatchRaw('query', 'tasks', 'find', params);
     if (!response.success) {
       handleRawError(response, { command: 'find', operation: 'tasks.find' });

--- a/packages/cleo/src/dispatch/domains/tasks.ts
+++ b/packages/cleo/src/dispatch/domains/tasks.ts
@@ -240,6 +240,10 @@ const _tasksTypedHandler = defineTypedHandler<TasksOps>('tasks', {
         urgent: params.urgent,
         // T9904: label filter — `cleo find --label <name>` (closes GH#393).
         label: params.label,
+        // T10108: parent filter — `cleo find --parent <id>`. Saga-aware via
+        // resolveSagaMemberIds (ADR-073 §1) so saga members surface through
+        // the same routing as `cleo list --parent`.
+        parent: params.parent,
       }),
       'find',
     );

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -148,6 +148,22 @@ export interface TasksFindParams {
    * @task T9904
    */
   label?: string;
+  /**
+   * Filter by parent task ID — restricts the result set to tasks whose
+   * `parentId` equals this value. Mirrors the `--parent` axis on
+   * `cleo list`. When the parent task is a Saga (Epic with
+   * `label='saga'`), routing goes through `task_relations.type='groups'`
+   * member IDs instead of the `parentId` column (ADR-073 §1).
+   *
+   * Composes with other filters via AND. Closes T10108 — pre-fix,
+   * `cleo find "" --parent <id>` returned every task in the project
+   * because the empty-string query bypassed all filters via
+   * `fuzzyScore('', '<title>')===80`.
+   *
+   * @task T10108
+   * @saga T9862
+   */
+  parent?: string;
 }
 export type TasksFindResult = MinimalTask[];
 

--- a/packages/core/src/tasks/__tests__/find-parent-filter.test.ts
+++ b/packages/core/src/tasks/__tests__/find-parent-filter.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the `--parent` filter on `cleo find` (T10108).
+ *
+ * Closes the T10108 bug class where `cleo find "" --parent T9758` returned
+ * the full unfiltered task set (~1216 rows). Two compounding defects were
+ * the cause:
+ *
+ *   1. The CLI `find` command had no `--parent` flag, so the value was
+ *      silently dropped before dispatch.
+ *   2. The empty-string `""` query short-circuited to fuzzy mode, where
+ *      `fuzzyScore('', '<any title>')` returned 80 (substring match of the
+ *      empty string), so every row "matched".
+ *
+ * This file covers the core `findTasks({ parent })` behaviour and the
+ * empty-string normalisation that lets the filter compose with no query.
+ *
+ * @task T10108
+ * @saga T9862
+ */
+
+import type { Task, TaskQueryFilters } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { findTasks } from '../find.js';
+
+/** Build a mock DataAccessor that honours `parentId`, `status`, `label`. */
+function mockAccessor(tasks: Task[]): DataAccessor {
+  return {
+    queryTasks: async (filters: TaskQueryFilters | undefined) => {
+      let list = tasks;
+      if (filters?.status) list = list.filter((t) => t.status === filters.status);
+      if (filters?.label) list = list.filter((t) => (t.labels ?? []).includes(filters.label!));
+      if (filters?.parentId !== undefined) {
+        list = list.filter((t) => t.parentId === filters.parentId);
+      }
+      return { tasks: list, total: list.length };
+    },
+    loadArchive: async () => ({ archivedTasks: [] }),
+    loadSingleTask: async (id: string) => tasks.find((t) => t.id === id) ?? null,
+  } as unknown as DataAccessor;
+}
+
+/** Build a mock accessor that simulates a Saga (label='saga') + grouped members. */
+function mockAccessorWithSaga(tasks: Task[], sagaId: string, memberIds: string[]): DataAccessor {
+  // Inject the `relates` array onto the saga task so resolveSagaMemberIds picks it up.
+  const tasksWithRelations = tasks.map((t) => {
+    if (t.id === sagaId) {
+      return {
+        ...t,
+        type: 'epic' as const,
+        labels: ['saga', ...(t.labels ?? []).filter((l) => l !== 'saga')],
+        relates: memberIds.map((mid) => ({ taskId: mid, type: 'groups' })),
+      } as Task;
+    }
+    return t;
+  });
+  return {
+    queryTasks: async (filters: TaskQueryFilters | undefined) => {
+      let list = tasksWithRelations;
+      if (filters?.status) list = list.filter((t) => t.status === filters.status);
+      if (filters?.parentId !== undefined) {
+        list = list.filter((t) => t.parentId === filters.parentId);
+      }
+      return { tasks: list, total: list.length };
+    },
+    loadArchive: async () => ({ archivedTasks: [] }),
+    loadSingleTask: async (id: string) => tasksWithRelations.find((t) => t.id === id) ?? null,
+  } as unknown as DataAccessor;
+}
+
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    id: overrides.id,
+    title: overrides.id,
+    description: '',
+    status: 'pending',
+    priority: 'medium',
+    type: 'task',
+    size: 'small',
+    parentId: null,
+    labels: [],
+    depends: [],
+    acceptance: [],
+    createdAt: '2026-05-24T00:00:00Z',
+    ...overrides,
+  } as Task;
+}
+
+describe('findTasks --parent (T10108)', () => {
+  it('selects only direct children of the parent', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', parentId: 'T9758' }),
+      makeTask({ id: 'T002', parentId: 'T9758' }),
+      makeTask({ id: 'T003', parentId: 'T8000' }),
+      makeTask({ id: 'T004', parentId: null }),
+    ];
+    const result = await findTasks({ parent: 'T9758' }, '/mock', mockAccessor(tasks));
+    const ids = result.results.map((r) => r.id).sort();
+    expect(ids).toEqual(['T001', 'T002']);
+  });
+
+  it('returns empty when no task matches the parent', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', parentId: 'T9758' }),
+      makeTask({ id: 'T002', parentId: null }),
+    ];
+    const result = await findTasks({ parent: 'T9999' }, '/mock', mockAccessor(tasks));
+    expect(result.results).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it('composes parent with status filter (AND)', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', parentId: 'T9758', status: 'pending' }),
+      makeTask({ id: 'T002', parentId: 'T9758', status: 'done' }),
+      makeTask({ id: 'T003', parentId: 'T8000', status: 'pending' }),
+    ];
+    const result = await findTasks(
+      { parent: 'T9758', status: 'pending' },
+      '/mock',
+      mockAccessor(tasks),
+    );
+    expect(result.results.map((r) => r.id)).toEqual(['T001']);
+  });
+
+  it('composes parent with label filter (AND)', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', parentId: 'T9758', labels: ['bug'] }),
+      makeTask({ id: 'T002', parentId: 'T9758', labels: ['feature'] }),
+      makeTask({ id: 'T003', parentId: 'T8000', labels: ['bug'] }),
+    ];
+    const result = await findTasks({ parent: 'T9758', label: 'bug' }, '/mock', mockAccessor(tasks));
+    expect(result.results.map((r) => r.id)).toEqual(['T001']);
+  });
+
+  it('parent filter alone (no query, no id) is valid filter-only mode', async () => {
+    const tasks = [makeTask({ id: 'T001', parentId: 'T9758' })];
+    // Should NOT throw "query or --id required"
+    const result = await findTasks({ parent: 'T9758' }, '/mock', mockAccessor(tasks));
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]?.id).toBe('T001');
+  });
+
+  it('empty-string query with --parent does NOT bypass filter (T10108 regression)', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', parentId: 'T9758' }),
+      makeTask({ id: 'T002', parentId: 'T8000' }),
+      makeTask({ id: 'T003', parentId: null }),
+    ];
+    // Empty-string query MUST be treated as "no query" so the parent filter still applies.
+    // Pre-T10108: every task matched via fuzzyScore('', '<title>')===80, returning all 3.
+    const result = await findTasks({ query: '', parent: 'T9758' }, '/mock', mockAccessor(tasks));
+    expect(result.results.map((r) => r.id)).toEqual(['T001']);
+  });
+
+  it('whitespace-only query is treated as no query', async () => {
+    const tasks = [
+      makeTask({ id: 'T001', parentId: 'T9758' }),
+      makeTask({ id: 'T002', parentId: 'T8000' }),
+    ];
+    const result = await findTasks({ query: '   ', parent: 'T9758' }, '/mock', mockAccessor(tasks));
+    expect(result.results.map((r) => r.id)).toEqual(['T001']);
+  });
+
+  it('routes Saga parents through groups relation (ADR-073 §1)', async () => {
+    // Saga members are top-level Epics (parentId: null) linked via
+    // task_relations.type='groups'. The parentId column path won't find them,
+    // so findTasks must route through resolveSagaMemberIds like listTasks does.
+    const tasks = [
+      makeTask({ id: 'T9758', parentId: null, type: 'epic' }), // saga (label injected by helper)
+      makeTask({ id: 'EPIC001', parentId: null, type: 'epic' }), // member epic
+      makeTask({ id: 'EPIC002', parentId: null, type: 'epic' }), // member epic
+      makeTask({ id: 'EPIC003', parentId: null, type: 'epic' }), // NOT a member
+    ];
+    const result = await findTasks(
+      { parent: 'T9758' },
+      '/mock',
+      mockAccessorWithSaga(tasks, 'T9758', ['EPIC001', 'EPIC002']),
+    );
+    const ids = result.results.map((r) => r.id).sort();
+    expect(ids).toEqual(['EPIC001', 'EPIC002']);
+  });
+});

--- a/packages/core/src/tasks/find.ts
+++ b/packages/core/src/tasks/find.ts
@@ -18,6 +18,7 @@ import { CleoError } from '../errors.js';
 import { cleoErrorToEngineResult } from '../errors-to-engine.js';
 import type { NextDirectives } from '../mvi-helpers.js';
 import { taskListItemNext } from '../mvi-helpers.js';
+import { resolveSagaMemberIds } from '../sagas/storage.js';
 import type { DataAccessor } from '../store/data-accessor.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { taskToRecord } from './engine-converters.js';
@@ -88,6 +89,26 @@ export interface FindTasksOptions {
    * @task T9904
    */
   label?: string;
+  /**
+   * Filter by parent task ID — restricts the result set to tasks whose
+   * `parentId` equals this value. Mirrors the `--parent` axis on
+   * `cleo list`.
+   *
+   * When the parent target is a Saga (Epic with `labels.includes('saga')`),
+   * routing goes through `task_relations.type='groups'` member IDs (via
+   * `resolveSagaMemberIds`) instead of the `parentId` column — the same
+   * dual-path resolution `listTasks` uses (ADR-073 §1). Saga members are
+   * top-level Epics with `parentId: null`, so the parentId column would
+   * otherwise return zero rows.
+   *
+   * Composes with other filters via AND. Filter-only mode is valid:
+   * `cleo find --parent <id>` with no query / no --id returns every
+   * task that hangs under the parent.
+   *
+   * @task T10108
+   * @saga T9862
+   */
+  parent?: string;
 }
 
 /** Result of finding tasks. */
@@ -281,14 +302,26 @@ export async function findTasks(
   accessor?: DataAccessor,
 ): Promise<FindTasksResult> {
   const options = extractInlineFilters(rawOptions);
-  const hasFilter = Boolean(options.status || options.kind || options.urgent || options.label);
+
+  // T10108: an empty-string or whitespace-only `query` is the same as no
+  // query — without this, `fuzzyScore('', '<any title>')` returns 80 for
+  // every task (the empty string is a substring of every string), bypassing
+  // every filter and returning the full task set. Normalise to `undefined`
+  // so the filter-only branches below take over.
+  if (options.query != null && options.query.trim() === '') {
+    options.query = undefined;
+  }
+
+  const hasFilter = Boolean(
+    options.status || options.kind || options.urgent || options.label || options.parent,
+  );
 
   if (options.query == null && !options.id && !hasFilter) {
     throw new CleoError(
       ExitCode.INVALID_INPUT,
-      'Search query, --id, or at least one filter (--status, --kind, --urgent, --label) is required',
+      'Search query, --id, or at least one filter (--status, --kind, --urgent, --label, --parent) is required',
       {
-        fix: 'cleo find "<query>"  OR  cleo find --label bug  OR  cleo find --urgent  OR  cleo find --status pending  OR  cleo find --id T123',
+        fix: 'cleo find "<query>"  OR  cleo find --label bug  OR  cleo find --urgent  OR  cleo find --status pending  OR  cleo find --parent T123  OR  cleo find --id T123',
         details: { field: 'query' },
       },
     );
@@ -296,9 +329,21 @@ export async function findTasks(
 
   const acc = accessor ?? (await getTaskAccessor(cwd));
 
-  // Use targeted query with status/label filters when available — push the
-  // label filter into the accessor so SQLite-backed accessors benefit from
-  // the existing label-aware queryTasks predicate. T9904.
+  // T10108: Saga-aware --parent routing.
+  // When --parent targets a Saga (label='saga'), children live in
+  // task_relations.type='groups', NOT in the parentId column. Detect once
+  // up-front; falls back to the default parentId-based query when the
+  // parent is not a Saga (or does not exist — non-existent IDs collapse to
+  // an empty result via the default path, preserving historical behaviour).
+  // Mirrors `listTasks` (ADR-073 §1).
+  let sagaMemberIds: string[] | null = null;
+  if (options.parent) {
+    sagaMemberIds = await resolveSagaMemberIds(acc, options.parent);
+  }
+
+  // Use targeted query with status/label/parent filters when available —
+  // push them into the accessor so SQLite-backed accessors benefit from the
+  // existing query predicates. T9904 (label) / T10108 (parent).
   const filters: TaskQueryFilters = {};
   if (options.status) {
     filters.status = options.status;
@@ -306,8 +351,29 @@ export async function findTasks(
   if (options.label) {
     filters.label = options.label;
   }
+  // T10108: skip the parentId filter when routing through Saga groups —
+  // Saga members are top-level Epics with parentId=null, so the column
+  // wouldn't match. The member-set intersection below restricts the result
+  // in-memory instead.
+  if (options.parent && sagaMemberIds === null) {
+    filters.parentId = options.parent;
+  }
   const queryResult = await acc.queryTasks(filters);
   let allTasks: Task[] = [...queryResult.tasks];
+
+  // T10108: Saga path — restrict the queried set to the saga's member IDs,
+  // preserving the relation-order of the groups edges (matches listTasks).
+  if (sagaMemberIds !== null) {
+    const memberOrder = new Map<string, number>();
+    for (let idx = 0; idx < sagaMemberIds.length; idx++) {
+      const id = sagaMemberIds[idx];
+      if (id !== undefined) memberOrder.set(id, idx);
+    }
+    const memberSet = new Set(sagaMemberIds);
+    allTasks = allTasks
+      .filter((t) => memberSet.has(t.id))
+      .sort((a, b) => (memberOrder.get(a.id) ?? 0) - (memberOrder.get(b.id) ?? 0));
+  }
 
   // Include archive if requested
   if (options.includeArchive) {
@@ -482,6 +548,8 @@ export async function taskFind(
     urgent?: boolean;
     /** Filter by label — see {@link FindTasksOptions.label}. @task T9904 */
     label?: string;
+    /** Filter by parent task ID — see {@link FindTasksOptions.parent}. @task T10108 */
+    parent?: string;
   },
 ): Promise<EngineResult<{ results: (MinimalTaskRecord | TaskRecord)[]; total: number }>> {
   try {
@@ -498,6 +566,7 @@ export async function taskFind(
         kind: options?.kind as TaskKind | undefined,
         urgent: options?.urgent,
         label: options?.label,
+        parent: options?.parent,
       },
       projectRoot,
       accessor,


### PR DESCRIPTION
## Summary

Closes the T10108 bug where `cleo find "" --parent T9758` returned the
full unfiltered task set (~1216 rows) instead of just the children of
T9758. Two compounding defects:

1. The CLI `find` command had no `--parent` flag, so the value was
   silently dropped before dispatch.
2. The empty-string `""` query short-circuited to fuzzy mode where
   `fuzzyScore('', '<any title>')` returned 80 (substring match of the
   empty string), so every row "matched" regardless of which filter
   was set.

This is a **redo of closed PR #752** on a clean branch with the
conflicting T9904 (`--label`) and T9905 (`--urgent`) sibling features
already merged into main, so the three flags compose naturally.

## Changes

- **Contracts**: add `parent?: string` to `TasksFindParams` in
  `packages/contracts/src/operations/tasks.ts`.
- **Core (`findTasks`)**: add `parent?: string` to `FindTasksOptions`;
  push `parentId` into the accessor for plain parents; route Sagas
  (Epic with `labels.includes('saga')`) through `resolveSagaMemberIds`
  (ADR-073 §1) — same dual-path resolution `listTasks` uses. Normalise
  empty / whitespace-only `query` to `undefined` so filter-only mode
  kicks in. Update the no-filter error message + fix hint to surface
  `--parent`.
- **Dispatch**: forward `parent` from `tasks.find` to `taskFind`.
- **CLI**: add `--parent` to `cleo find`, matching the `cleo list`
  surface.

## Acceptance

| AC | Status |
|---|---|
| 1. `cleo find "" --parent T9758` returns only children of T9758 | covered by `find-parent-filter.test.ts` |
| 2. `cleo find <query> --parent <id>` mirrors `cleo list --parent <id>` parent filter | covered by composition tests |
| 3. Empty query `""` does not bypass filters | covered by two dedicated regression tests |
| 4. Regression test in `packages/core/src/tasks/__tests__/` | `find-parent-filter.test.ts` (8 tests) |

## Test plan

- [x] `pnpm exec vitest run src/tasks/__tests__/find-parent-filter.test.ts` — 8/8 pass
- [x] Full find suite — `find.test.ts`, `find-filter-modes.test.ts`, `find-urgent.test.ts`, `find-label.test.ts`, `find-parent-filter.test.ts` — 43/43 pass
- [x] `pnpm biome check` — clean on all 5 modified files
- [x] `pnpm exec tsc --noEmit` — zero new errors in `find.ts` / `tasks.ts` / `dispatch/tasks.ts`

## Deviations

- The pre-existing main TS6133 in `packages/core/src/orchestration/spawn-prompt.ts:1037` (`buildChangesetLintGateBlock declared but never read`, tracked as T10485) blocks `tsc --emitDeclarationOnly` for `@cleocode/core`. Identical failure on `origin/main` with my diff stashed — unrelated to this fix.
- The 12 test failures in `packages/core/src/tasks` (`update-relates.test.ts` × 4, `t9073-severity-cross-role.test.ts` × 7, `gate-runner.test.ts` × 1) are pre-existing on main and unrelated to find — verified by running the same suites on a `git stash`'d clean tree.

## Closes

T10108. Saga: T9862.