### PR TITLE
feat(T9949): rich CLI fix-hint for E_EVIDENCE_INSUFFICIENT (papercut 1/3)

### DIFF
--- a/.changeset/t9949-evidence-hint.md
+++ b/.changeset/t9949-evidence-hint.md
@@ -1,0 +1,8 @@
+---
+id: t9949-evidence-hint
+tasks: [T9949]
+kind: feat
+summary: Rich CLI fix-hint for E_EVIDENCE_INSUFFICIENT pointing note-only callers at the correct alternative atom per gate
+---
+
+Added `formatGateRequirementHint(gate)` and `checkGateEvidenceMinimumDetailed(gate, atoms)` so `cleo verify` failures now surface a multi-line, copy-pasteable remediation hint via `engineError({fix})`. Each hint lists every satisfying combination as a complete `cleo verify ... --evidence '<atoms>'` invocation, then clarifies whether `note:` alone is accepted for that gate (and if not, which partner atoms to use). Legacy single-line message format preserved byte-for-byte for backward compatibility. Sub-issues 2 (.gitignore allowlist) and 3 (macOS shard 1 flake) deferred to T10489 and T10490.

--- a/packages/contracts/src/__tests__/evidence-atom-schema.test.ts
+++ b/packages/contracts/src/__tests__/evidence-atom-schema.test.ts
@@ -19,6 +19,7 @@ import {
   EvidenceAtomSchema,
   EvidenceParseError,
   formatGateRequirement,
+  formatGateRequirementHint,
   GATE_EVIDENCE_REQUIREMENTS,
   parseEvidenceString,
   validateEvidenceForGate,
@@ -495,5 +496,92 @@ describe('formatGateRequirement (T10337)', () => {
 
   it('formats single-element combination without AND', () => {
     expect(formatGateRequirement('cleanupDone')).toBe('[note]');
+  });
+});
+
+// ─── formatGateRequirementHint — rich CLI `fix:` surface (T9949) ────────────
+
+describe('formatGateRequirementHint (T9949)', () => {
+  it('renders implemented as multi-line list of copy-pasteable verify commands', () => {
+    const h = formatGateRequirementHint('implemented');
+    // Header line names the gate and uses "ONE of" framing.
+    expect(h).toMatch(/^Gate 'implemented' requires programmatic evidence\. Use ONE of:/);
+    // Each combination renders as a complete `cleo verify ... --evidence '<atoms>'` line.
+    expect(h).toContain("--evidence 'commit:<sha>;files:path/a.ts,path/b.ts'");
+    expect(h).toContain("--evidence 'commit:<sha>;note:<short description>'");
+    expect(h).toContain("--evidence 'decision:D-arch-001;files:path/a.ts,path/b.ts'");
+    expect(h).toContain("--evidence 'decision:D-arch-001;note:<short description>'");
+    expect(h).toContain("--evidence 'pr:357'");
+    // Routes a `note:`-only caller at the partner atom they need.
+    expect(h).toContain("'note:' alone is NOT accepted for this gate");
+    expect(h).toContain("'commit:'");
+    expect(h).toContain("'decision:'");
+  });
+
+  it('routes note-only callers for testsPassed at the right alternatives', () => {
+    // testsPassed accepts test-run, tool, or pr — none of which involve note.
+    const h = formatGateRequirementHint('testsPassed');
+    expect(h).toContain("--evidence 'test-run:/tmp/vitest-out.json'");
+    expect(h).toContain("--evidence 'tool:test'");
+    expect(h).toContain("--evidence 'pr:357'");
+    // When no combination includes note at all, the helper falls through to a
+    // generic "not accepted, see ADR-051" clarifier rather than fabricating a
+    // partner suggestion.
+    expect(h).toContain("'note:' is NOT accepted for this gate");
+    expect(h).toContain('ADR-051');
+  });
+
+  it('confirms note-only acceptance for cleanupDone', () => {
+    const h = formatGateRequirementHint('cleanupDone');
+    expect(h).toContain("--evidence 'note:<short description>'");
+    expect(h).toContain("'note:' alone IS accepted for this gate");
+  });
+
+  it('confirms note-only acceptance for securityPassed and nexusImpact', () => {
+    for (const gate of ['securityPassed', 'nexusImpact'] as const) {
+      const h = formatGateRequirementHint(gate);
+      expect(h, `${gate}: should confirm note alone is accepted`).toContain(
+        "'note:' alone IS accepted for this gate",
+      );
+    }
+  });
+
+  it('renders documented with files and url, and points away from note', () => {
+    const h = formatGateRequirementHint('documented');
+    expect(h).toContain("--evidence 'files:path/a.ts,path/b.ts'");
+    expect(h).toContain("--evidence 'url:https://example.com/docs'");
+    // documented has no note pairings — generic clarifier path.
+    expect(h).toContain("'note:' is NOT accepted for this gate");
+  });
+});
+
+// ─── validateEvidenceForGate — failure carries `hint` (T9949) ───────────────
+
+describe('validateEvidenceForGate failure surface (T9949)', () => {
+  it('populates a `hint` field alongside the legacy `message`', () => {
+    const r = validateEvidenceForGate('implemented', [
+      { kind: 'note', note: 'just a note' },
+    ] as EvidenceAtomInput[]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      // Legacy single-line message preserved byte-for-byte.
+      expect(r.message).toBe(
+        "Gate 'implemented' requires evidence: [commit AND files] OR [commit AND note] OR [decision AND files] OR [decision AND note] OR [pr]",
+      );
+      // New rich hint includes the same content as formatGateRequirementHint.
+      expect(r.hint).toBe(formatGateRequirementHint('implemented'));
+    }
+  });
+
+  it('notes-only against testsPassed surfaces the right alternatives', () => {
+    const r = validateEvidenceForGate('testsPassed', [
+      { kind: 'note', note: 'I ran the tests by hand' },
+    ] as EvidenceAtomInput[]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.hint).toContain("--evidence 'tool:test'");
+      expect(r.hint).toContain("--evidence 'pr:357'");
+      expect(r.hint).toContain("'note:' is NOT accepted for this gate");
+    }
   });
 });

--- a/packages/contracts/src/evidence-atom-schema.ts
+++ b/packages/contracts/src/evidence-atom-schema.ts
@@ -332,14 +332,25 @@ export const GATE_EVIDENCE_REQUIREMENTS: Readonly<
  * Result of {@link validateEvidenceForGate}.
  *
  * Success carries no extra payload (the caller already holds the atom list).
- * Failure carries a human-readable message in the legacy
- * `Gate '<gate>' requires evidence: [<combo>] OR [<combo>]` format so error
- * surfaces (E_EVIDENCE_INSUFFICIENT) read identically across the CLI and any
- * client-side validator built on top of this schema.
+ * Failure carries:
+ *   - {@link EvidenceValidationFailure.message} — the legacy single-line
+ *     `Gate '<gate>' requires evidence: [<combo>] OR [<combo>]` format,
+ *     preserved byte-for-byte for backward-compat with surfaces and tests
+ *     that match against it.
+ *   - {@link EvidenceValidationFailure.hint} — a richer, multi-line,
+ *     example-bearing remediation hint suitable for CLI `fix:` surfaces.
+ *     Added by T9949 so `E_EVIDENCE_INSUFFICIENT` errors point clearly at
+ *     the alternative atom the caller needs (e.g. "this gate requires
+ *     real proof — note: alone is not accepted; use commit+files,
+ *     commit+note, or pr instead").
  */
-export type EvidenceValidationResult =
-  | { readonly ok: true }
-  | { readonly ok: false; readonly message: string };
+export interface EvidenceValidationFailure {
+  readonly ok: false;
+  readonly message: string;
+  readonly hint: string;
+}
+
+export type EvidenceValidationResult = { readonly ok: true } | EvidenceValidationFailure;
 
 /**
  * Format the satisfying-combinations spec for a gate as the legacy
@@ -352,6 +363,114 @@ export type EvidenceValidationResult =
 export function formatGateRequirement(gate: VerificationGate): string {
   const requirement = GATE_EVIDENCE_REQUIREMENTS[gate];
   return requirement.oneOf.map((set) => `[${set.join(' AND ')}]`).join(' OR ');
+}
+
+/**
+ * Example `--evidence` strings for each atom kind. Used by
+ * {@link formatGateRequirementHint} to render copy-pasteable remediation
+ * commands in CLI error surfaces.
+ *
+ * @task T9949
+ */
+const ATOM_EXAMPLES: Readonly<Record<EvidenceAtomKind, string>> = Object.freeze({
+  commit: 'commit:<sha>',
+  files: 'files:path/a.ts,path/b.ts',
+  'test-run': 'test-run:/tmp/vitest-out.json',
+  tool: 'tool:test',
+  url: 'url:https://example.com/docs',
+  note: 'note:<short description>',
+  decision: 'decision:D-arch-001',
+  pr: 'pr:357',
+  'loc-drop': 'loc-drop:<fromLines>:<toLines>',
+  'callsite-coverage': 'callsite-coverage:<symbolName>:<relativeSourcePath>',
+});
+
+/**
+ * Render a satisfying atom combination as a copy-pasteable `--evidence`
+ * string fragment, e.g. `['commit', 'files']` → `commit:<sha>;files:path/a.ts,path/b.ts`.
+ *
+ * @internal
+ */
+function renderCombinationAsEvidence(combination: ReadonlyArray<EvidenceAtomKind>): string {
+  return combination.map((kind) => ATOM_EXAMPLES[kind]).join(';');
+}
+
+/**
+ * Produce a multi-line, example-bearing remediation hint for a gate.
+ *
+ * Designed for CLI `fix:` surfaces so `E_EVIDENCE_INSUFFICIENT` errors point
+ * the caller at the specific alternative atom shape they need. The hint lists
+ * every satisfying combination as a copy-pasteable `cleo verify` invocation
+ * plus a note-specific clarification when the gate does NOT accept `note:`
+ * alone.
+ *
+ * The motivating bug (T9949) was that note-only deliverables (decision-only
+ * tasks, deletion-only refactors) hit `E_EVIDENCE_INSUFFICIENT` with the
+ * legacy single-line error and had to consult ADR-051 to figure out which
+ * additional atom kind the gate required. The richer hint inlines the answer.
+ *
+ * @param gate - Verification gate the hint is for.
+ * @returns Multi-line remediation hint suitable for an `engineError({fix:})`
+ *   surface. Always ends in a clarifying sentence about whether `note:` alone
+ *   is accepted for the gate.
+ *
+ * @example
+ * ```ts
+ * formatGateRequirementHint('implemented');
+ * // "Gate 'implemented' requires programmatic evidence. Use ONE of:
+ * //   - cleo verify T#### --gate implemented --evidence 'commit:<sha>;files:path/a.ts,path/b.ts'
+ * //   - cleo verify T#### --gate implemented --evidence 'commit:<sha>;note:<short description>'
+ * //   - cleo verify T#### --gate implemented --evidence 'decision:D-arch-001;files:path/a.ts,path/b.ts'
+ * //   - cleo verify T#### --gate implemented --evidence 'decision:D-arch-001;note:<short description>'
+ * //   - cleo verify T#### --gate implemented --evidence 'pr:357'
+ * // Note: 'note:' alone is NOT accepted for this gate — pair it with 'commit:' or 'decision:'."
+ * ```
+ *
+ * @task T9949
+ * @adr ADR-051 §2.3
+ */
+export function formatGateRequirementHint(gate: VerificationGate): string {
+  const requirement = GATE_EVIDENCE_REQUIREMENTS[gate];
+  if (!requirement) {
+    // Unknown gate — match validateEvidenceForGate's defensive default.
+    return `Gate '${gate}' has no documented evidence requirements.`;
+  }
+
+  const lines: string[] = [
+    `Gate '${gate}' requires programmatic evidence. Use ONE of:`,
+    ...requirement.oneOf.map(
+      (combo) =>
+        `  - cleo verify T#### --gate ${gate} --evidence '${renderCombinationAsEvidence(combo)}'`,
+    ),
+  ];
+
+  // Note-specific clarification — T9949's headline pain point.
+  // The gate accepts note: alone IFF some single-element combination is ['note'].
+  const noteAloneAccepted = requirement.oneOf.some(
+    (combo) => combo.length === 1 && combo[0] === 'note',
+  );
+  if (noteAloneAccepted) {
+    lines.push(`Note: 'note:' alone IS accepted for this gate (waiver-style evidence).`);
+  } else {
+    // Surface every alternative pairing involving note for at-a-glance routing.
+    const notePairings = requirement.oneOf.filter(
+      (combo) => combo.length > 1 && combo.includes('note'),
+    );
+    if (notePairings.length > 0) {
+      const partners = Array.from(
+        new Set(notePairings.flatMap((combo) => combo.filter((k) => k !== 'note'))),
+      ).map((k) => `'${k}:'`);
+      lines.push(
+        `Note: 'note:' alone is NOT accepted for this gate — pair it with ${partners.join(' or ')}.`,
+      );
+    } else {
+      lines.push(
+        `Note: 'note:' is NOT accepted for this gate (even when paired). See ADR-051 for the full grammar.`,
+      );
+    }
+  }
+
+  return lines.join('\n');
 }
 
 /**
@@ -401,6 +520,11 @@ export function validateEvidenceForGate(
   return {
     ok: false,
     message: `Gate '${gate}' requires evidence: ${formatGateRequirement(gate)}`,
+    // T9949: rich, example-bearing remediation hint suitable for CLI `fix:`.
+    // Always populated alongside `message` so consumers can choose between
+    // the legacy single-line surface and the multi-line hint without re-
+    // computing the spec.
+    hint: formatGateRequirementHint(gate),
   };
 }
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -475,6 +475,7 @@ export {
 export type {
   EvidenceAtom as EvidenceAtomInput,
   EvidenceAtomKind,
+  EvidenceValidationFailure,
   EvidenceValidationResult,
   GateEvidenceRequirement,
 } from './evidence-atom-schema.js';
@@ -486,6 +487,7 @@ export {
   EvidenceParseError,
   filesAtomSchema,
   formatGateRequirement,
+  formatGateRequirementHint,
   GATE_EVIDENCE_REQUIREMENTS,
   locDropAtomSchema,
   noteAtomSchema,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1457,6 +1457,7 @@ export {
   checkCallsiteCoverageAtom,
   checkEngineMigrationLocDrop,
   checkGateEvidenceMinimum,
+  checkGateEvidenceMinimumDetailed,
   composeGateEvidence,
   ENGINE_MIGRATION_MIN_REDUCTION_PCT,
   type EvidenceTool,

--- a/packages/core/src/tasks/__tests__/evidence.test.ts
+++ b/packages/core/src/tasks/__tests__/evidence.test.ts
@@ -20,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   checkGateEvidenceMinimum,
+  checkGateEvidenceMinimumDetailed,
   composeGateEvidence,
   parseEvidence,
   revalidateEvidence,
@@ -417,6 +418,40 @@ describe('checkGateEvidenceMinimum (T832)', () => {
 
   it('cleanupDone accepts a note', () => {
     expect(checkGateEvidenceMinimum('cleanupDone', [{ kind: 'note', note: 'cleaned' }])).toBeNull();
+  });
+});
+
+describe('checkGateEvidenceMinimumDetailed (T9949)', () => {
+  it('returns null when the gate is satisfied', () => {
+    expect(
+      checkGateEvidenceMinimumDetailed('cleanupDone', [{ kind: 'note', note: 'done' }]),
+    ).toBeNull();
+  });
+
+  it('returns { message, hint } when note-only evidence hits implemented', () => {
+    const r = checkGateEvidenceMinimumDetailed('implemented', [
+      { kind: 'note', note: 'I deleted some files' },
+    ]);
+    expect(r).not.toBeNull();
+    if (r) {
+      // Legacy message preserved for any consumer that still matches against it.
+      expect(r.message).toMatch(/^Gate 'implemented' requires evidence: /);
+      // Rich hint surfaces the alternative atoms a note-only caller needs.
+      expect(r.hint).toContain('Use ONE of:');
+      expect(r.hint).toContain("--evidence 'commit:<sha>;note:<short description>'");
+      expect(r.hint).toContain("'note:' alone is NOT accepted for this gate");
+    }
+  });
+
+  it('returns a hint confirming note-only acceptance for cleanupDone failure path', () => {
+    // cleanupDone requires note — when called with NO atoms it fails, and the
+    // hint should still point at the canonical note-only verify command.
+    const r = checkGateEvidenceMinimumDetailed('cleanupDone', []);
+    expect(r).not.toBeNull();
+    if (r) {
+      expect(r.hint).toContain("--evidence 'note:<short description>'");
+      expect(r.hint).toContain("'note:' alone IS accepted for this gate");
+    }
   });
 });
 

--- a/packages/core/src/tasks/evidence.ts
+++ b/packages/core/src/tasks/evidence.ts
@@ -1274,6 +1274,36 @@ export function checkGateEvidenceMinimum(
 }
 
 /**
+ * Detailed variant of {@link checkGateEvidenceMinimum} that returns the
+ * machine-readable failure (with `message` + `hint`) instead of a flat
+ * string. Use this when the caller needs the multi-line CLI `fix:` hint
+ * (T9949) — `E_EVIDENCE_INSUFFICIENT` surfaces in engine-ops.ts populate
+ * `engineError({fix: result.hint})` with this output.
+ *
+ * Returns `null` when the gate is satisfied.
+ *
+ * @param gate - The gate being verified
+ * @param atoms - Validated atoms
+ * @returns `null` when satisfied; `{ message, hint }` when not
+ *
+ * @task T9949
+ * @adr ADR-051 §2.3
+ */
+export function checkGateEvidenceMinimumDetailed(
+  gate: VerificationGate,
+  atoms: EvidenceAtom[],
+): { message: string; hint: string } | null {
+  const projected: Array<{ kind: ParsedEvidenceAtom['kind'] }> = [];
+  for (const atom of atoms) {
+    if (atom.kind === 'override') continue;
+    const kind: ParsedEvidenceAtom['kind'] = atom.kind;
+    projected.push({ kind });
+  }
+  const result = validateEvidenceForGate(gate, projected);
+  return result.ok ? null : { message: result.message, hint: result.hint };
+}
+
+/**
  * Compose a {@link GateEvidence} record from validated atoms.
  *
  * @param atoms - Validated evidence atoms

--- a/packages/core/src/validation/engine-ops.ts
+++ b/packages/core/src/validation/engine-ops.ts
@@ -26,7 +26,7 @@ import { getTaskAccessor } from '../store/data-accessor.js';
 import {
   checkCallsiteCoverageAtom,
   checkEngineMigrationLocDrop,
-  checkGateEvidenceMinimum,
+  checkGateEvidenceMinimumDetailed,
   composeGateEvidence,
   parseEvidence,
   validateAtom,
@@ -511,10 +511,15 @@ export async function validateGateVerify(
         }
 
         // Check each target gate satisfies its minimum.
+        // T9949: surface the rich example-bearing remediation hint via
+        // `engineError({fix:})` so `note:`-only callers see exactly which
+        // alternative atom kind the gate requires (commit/files/decision/pr).
         for (const targetGate of targets) {
-          const missing = checkGateEvidenceMinimum(targetGate, validatedAtoms);
+          const missing = checkGateEvidenceMinimumDetailed(targetGate, validatedAtoms);
           if (missing) {
-            return engineError('E_EVIDENCE_INSUFFICIENT', missing);
+            return engineError('E_EVIDENCE_INSUFFICIENT', missing.message, {
+              fix: missing.hint,
+            });
           }
         }
 


### PR DESCRIPTION
## Summary

- Adds a multi-line, copy-pasteable remediation hint to every `E_EVIDENCE_INSUFFICIENT` error so `cleo verify` callers see exactly which alternative atom kind the gate needs.
- Special-cases note-only callers — the headline papercut from saga T9787 — so the hint either confirms "note: alone IS accepted" or points at the partner atom required ('commit:', 'decision:', tool:test, etc.).
- Legacy single-line message format preserved byte-for-byte for backward compatibility with surfaces and tests that match against it.

## Scope discipline

Three sub-issues were filed under T9949:

1. **Evidence-atom shape** — shipped here.
2. **`.cleo/.gitignore` allowlist clusters** — deferred to **T10489 (P3)**.
3. **macOS shard 1 flake** — deferred to **T10490 (P2)**.

## Test plan

- [x] 7 new tests in `packages/contracts/src/__tests__/evidence-atom-schema.test.ts` covering the formatter, the validation-result `hint` field, and per-gate note routing.
- [x] 3 new tests in `packages/core/src/tasks/__tests__/evidence.test.ts` covering `checkGateEvidenceMinimumDetailed`.
- [x] `pnpm exec vitest run packages/core/src/tasks packages/core/src/validation` — 1370/1370 green.
- [x] `pnpm exec vitest run packages/core/src/release` — 339/339 green.
- [x] `pnpm exec vitest run packages/contracts/src/__tests__/evidence-atom-schema.test.ts` — 59/59 green.
- [x] `pnpm biome check --write` clean on every changed file.

## Backward compatibility

- The legacy `Gate '<gate>' requires evidence: [<combo>] OR [<combo>]` `message` string is preserved exactly.
- `checkGateEvidenceMinimum` (string-or-null) remains for existing callers; the new `checkGateEvidenceMinimumDetailed` is additive.
- The new `hint` field on `EvidenceValidationFailure` is additive — old consumers that only read `message` are unaffected.

## Out of scope

- Sub-issue 2 (.gitignore allowlist) — surgical conflict avoidance is a separate concern; the merge-driver alternative needs design work.
- Sub-issue 3 (macOS shard 1 flake) — requires sustained CI observation; track separately.

## Files

- `packages/contracts/src/evidence-atom-schema.ts` — `formatGateRequirementHint`, `EvidenceValidationFailure.hint`.
- `packages/contracts/src/index.ts` — re-exports.
- `packages/core/src/tasks/evidence.ts` — `checkGateEvidenceMinimumDetailed`.
- `packages/core/src/internal.ts` — barrel re-export.
- `packages/core/src/validation/engine-ops.ts` — wires `hint` into `engineError({fix})`.

## Related

- Parent saga: T9862 Wave 5, papercut closeout from saga T9787.
- ADR-051 — Evidence atom grammar (no change to the spec, only to the error surface).