### PR TITLE
fix(T10485): remove orphan buildChangesetLintGateBlock (unblock CI)

### DIFF
--- a/.changeset/T10485.md
+++ b/.changeset/T10485.md
@@ -1,0 +1,12 @@
+---
+"@cleocode/core": patch
+---
+
+fix(spawn): remove orphan buildChangesetLintGateBlock function (T10485)
+
+Function was deprecated by T10452 (its check was inlined into the Quality
+Gates block) but a subsequent merge collision in T9937 briefly restored
+it as an unused declaration, causing TS6133 on the dts build. This
+removes the orphan and locks T10452's single-inlined design as the SSoT.
+
+Closes T10485. Saga: T9862.

--- a/packages/core/src/orchestration/__tests__/spawn-prompt.test.ts
+++ b/packages/core/src/orchestration/__tests__/spawn-prompt.test.ts
@@ -102,7 +102,6 @@ describe('buildSpawnPrompt — core contract', () => {
     expect(p).toContain('## Session Linkage');
     expect(p).toContain('## Stage-Specific Guidance');
     expect(p).toContain('## Evidence-Based Gate Ritual');
-    expect(p).toContain('## Changeset Lint Gate');
     expect(p).toContain('## Quality Gates');
     expect(p).toContain('## Return Format Contract');
   });
@@ -778,8 +777,8 @@ describe('buildSpawnPrompt — task documents section (T1614)', () => {
   });
 });
 
-describe('buildSpawnPrompt — changeset lint gate (T10448)', () => {
-  it('includes the changeset lint gate section in all tiers', () => {
+describe('buildSpawnPrompt — changeset lint inline in Quality Gates (T10448 → T10452 → T10485)', () => {
+  it('includes the inlined lint-changesets.mjs check in all tiers Quality Gates', () => {
     for (const tier of [0, 1, 2] as SpawnTier[]) {
       const result = buildSpawnPrompt({
         task: BASE_TASK,
@@ -787,49 +786,28 @@ describe('buildSpawnPrompt — changeset lint gate (T10448)', () => {
         tier,
         projectRoot: PROJECT_ROOT,
       });
-      expect(result.prompt).toContain('## Changeset Lint Gate');
+      expect(result.prompt).toContain('## Quality Gates');
       expect(result.prompt).toContain('lint-changesets.mjs');
-      expect(result.prompt).toContain('run BEFORE starting work');
     }
   });
 
-  it('references the absolute script path under project root', () => {
-    const result = buildSpawnPrompt({
-      task: BASE_TASK,
-      protocol: 'implementation',
-      projectRoot: PROJECT_ROOT,
-    });
-    expect(result.prompt).toContain(`${PROJECT_ROOT}/scripts/lint-changesets.mjs`);
-  });
-
-  it('instructs the agent to fail fast on malformed changesets', () => {
-    const result = buildSpawnPrompt({
-      task: BASE_TASK,
-      protocol: 'implementation',
-      projectRoot: PROJECT_ROOT,
-    });
-    expect(result.prompt).toContain('Do NOT start implementation');
-    expect(result.prompt).toContain('Fail fast here');
-    expect(result.prompt).toContain('feat|fix|perf|refactor|docs|test|chore|breaking');
-  });
-
-  it('places the changeset lint gate between Evidence Gate and Quality Gates', () => {
+  it('places the inlined lint check inside Quality Gates (after Evidence Gate)', () => {
     const result = buildSpawnPrompt({
       task: BASE_TASK,
       protocol: 'implementation',
       projectRoot: PROJECT_ROOT,
     });
     const evidenceIdx = result.prompt.indexOf('## Evidence-Based Gate Ritual');
-    const changesetIdx = result.prompt.indexOf('## Changeset Lint Gate');
     const qualityIdx = result.prompt.indexOf('## Quality Gates');
+    const lintIdx = result.prompt.indexOf('lint-changesets.mjs');
     expect(evidenceIdx).toBeGreaterThan(-1);
-    expect(changesetIdx).toBeGreaterThan(-1);
     expect(qualityIdx).toBeGreaterThan(-1);
-    expect(evidenceIdx).toBeLessThan(changesetIdx);
-    expect(changesetIdx).toBeLessThan(qualityIdx);
+    expect(lintIdx).toBeGreaterThan(-1);
+    expect(evidenceIdx).toBeLessThan(qualityIdx);
+    expect(qualityIdx).toBeLessThan(lintIdx);
   });
 
-  it('produces zero unresolved tokens when changeset lint gate is present', () => {
+  it('produces zero unresolved tokens', () => {
     const result = buildSpawnPrompt({
       task: BASE_TASK,
       protocol: 'implementation',

--- a/packages/core/src/orchestration/spawn-prompt.ts
+++ b/packages/core/src/orchestration/spawn-prompt.ts
@@ -1025,36 +1025,12 @@ function buildEvidenceGateBlock(taskId: string): string {
   ].join('\n');
 }
 
-/**
- * Build the changeset-lint hygiene gate block (T10448).
- *
- * Note: this function was originally added in T10448 (commit 743db13f3) and
- * inadvertently removed by T10452 (commit 15d8bfef2) which left the call site
- * orphaned, breaking `tsc --emitDeclarationOnly`. Restored here as a
- * collateral fix while shipping T9937 (Saga T9862) so the build pipeline
- * stays green. Tracking bug: T10485.
- */
-function buildChangesetLintGateBlock(projectRoot: string): string {
-  const scriptPath = join(projectRoot, 'scripts', 'lint-changesets.mjs');
-  return [
-    '## Changeset Lint Gate (T10448 — run BEFORE starting work)',
-    '',
-    '> Pre-spawn hygiene check: validate that all `.changeset/*.md` entries are well-formed before you begin implementation.',
-    '> Malformed changesets cause silent aggregator failures downstream. Fail fast here.',
-    '',
-    '```bash',
-    `node ${scriptPath}   # validates every .changeset/*.md file independently`,
-    '```',
-    '',
-    '**If this gate fails**:',
-    '1. Do NOT start implementation.',
-    '2. Fix the malformed changeset(s) listed in the output.',
-    '3. Re-run the lint gate until it passes.',
-    '4. Only then proceed to the Stage-Specific Guidance below.',
-    '',
-    'Canonical kinds: `feat|fix|perf|refactor|docs|test|chore|breaking`.',
-  ].join('\n');
-}
+// T10485 closure: buildChangesetLintGateBlock removed.
+// Original T10448 standalone section was deprecated by T10452 which inlined
+// the check into buildQualityGateBlock (see `node scripts/lint-changesets.mjs`
+// line in the Quality Gates block). A subsequent merge collision in T9937
+// briefly restored this function as an orphan unused declaration. Removed
+// here per T10452's design intent — the single inlined version is the SSoT.
 
 /** Build the quality-gate block — biome + build + test + changeset hygiene. */
 function buildQualityGateBlock(): string {


### PR DESCRIPTION
## Summary

P0 main-CI hotfix. `buildChangesetLintGateBlock` was an orphan unused-declaration after T9937's merge collision restored it on top of f5ae3e45b's call-site removal. TS6133 broke `tsc --emitDeclarationOnly` and cascaded into every PR's Type Check / Unit Tests / Build & Verify.

Removes the orphan. The inlined `node scripts/lint-changesets.mjs` check in `buildQualityGateBlock` (added by T10452) remains authoritative.

## Test plan
- [x] `pnpm run build` clean
- [x] Quality Gates block still contains the inlined `lint-changesets.mjs` check

Closes T10485. Saga: T9862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)