### PR TITLE
fix(T10438): expand worktree-napi-prebuild.yml paths filter

### DIFF
--- a/.github/workflows/worktree-napi-prebuild.yml
+++ b/.github/workflows/worktree-napi-prebuild.yml
@@ -11,13 +11,21 @@ on:
     paths:
       - 'crates/worktree-napi/**'
       - 'crates/worktrunk-core/**'
+      - 'packages/worktree/**'
+      - 'packages/contracts/**'
+      - 'packages/worktree-napi-*/**'
       - 'rust-toolchain.toml'
+      - 'pnpm-lock.yaml'
       - '.github/workflows/worktree-napi-prebuild.yml'
   pull_request:
     paths:
       - 'crates/worktree-napi/**'
       - 'crates/worktrunk-core/**'
+      - 'packages/worktree/**'
+      - 'packages/contracts/**'
+      - 'packages/worktree-napi-*/**'
       - 'rust-toolchain.toml'
+      - 'pnpm-lock.yaml'
       - '.github/workflows/worktree-napi-prebuild.yml'
   workflow_dispatch:
   merge_group:


### PR DESCRIPTION
## Problem
The  filter in  was too narrow, only including:
- 
- 
- 
- 

This **starved** the workflow when release commits only touched TypeScript packages (e.g. , ) or  files. Result: zero prebuild artifacts → empty  payloads in .

## Fix
Expanded the  filter (both  and  triggers) to include all files that could affect the napi prebuild output:
-  — TS wrapper changes may need rebuild
-  —  changes affect FFI contract
-  — per-platform wrapper packages
-  — dependency changes

## Acceptance
- [x] AC1: Identify exact path-filter pattern causing starvation
- [x] AC2: Modify filter to include all files that could affect prebuild output
- [ ] AC3: Verify release.yml receives non-empty artifacts on next run (post-merge)

Refs: T10438, T10431