### PR TITLE
fix(T10499): narrow catch err in validate-spawn-readiness (unblock npm publish)

### DIFF
--- a/.changeset/T10499.md
+++ b/.changeset/T10499.md
@@ -1,0 +1,13 @@
+---
+"@cleocode/core": patch
+---
+
+fix(hygiene): replace `catch (err: any)` with proper narrowing (T10499)
+
+T10451 shipped `validateSpawnReadiness` with two `catch (err: any)` clauses
+which fail biome's `noExplicitAny` check during release.yml's lint step.
+Result: v5.118-121 release publishes all failed at the lint gate, leaving
+npm stuck at v5.120 despite tags reaching `main`. Narrowed both clauses
+to instanceof Error / structured shapes.
+
+Closes T10499. Saga: T9862.

--- a/packages/cleo/src/cli/commands/doctor-release-readiness.ts
+++ b/packages/cleo/src/cli/commands/doctor-release-readiness.ts
@@ -13,7 +13,7 @@
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { defineCommand } from '../lib/define-cli-command.js';
-import { cliOutput, cliError, humanLine } from '../renderers/index.js';
+import { cliOutput, humanLine } from '../renderers/index.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -161,8 +161,11 @@ export const doctorReleaseReadinessCommand = defineCommand({
     let oidcCheck: CheckResult;
     if (existsSync(packageJsonPath)) {
       try {
-        const pkg = JSON.parse(await import('node:fs').then((m) => m.readFileSync(packageJsonPath, 'utf8')));
-        const hasPublishConfig = typeof pkg.publishConfig === 'object' && pkg.publishConfig !== null;
+        const pkg = JSON.parse(
+          await import('node:fs').then((m) => m.readFileSync(packageJsonPath, 'utf8')),
+        );
+        const hasPublishConfig =
+          typeof pkg.publishConfig === 'object' && pkg.publishConfig !== null;
         const accessPublic = hasPublishConfig && pkg.publishConfig.access === 'public';
         oidcCheck = {
           name: 'npm-oidc-sanity',
@@ -198,17 +201,14 @@ export const doctorReleaseReadinessCommand = defineCommand({
 
     // ── 5. Tag-trigger sanity ───────────────────────────────────────────────
     // Verify that the auto-tag-on-release-merge.yml workflow exists and looks valid.
-    const tagWorkflowPath = join(
-      repoRoot,
-      '.github',
-      'workflows',
-      'auto-tag-on-release-merge.yml',
-    );
+    const tagWorkflowPath = join(repoRoot, '.github', 'workflows', 'auto-tag-on-release-merge.yml');
     const tagWorkflowExists = existsSync(tagWorkflowPath);
     let tagTriggerCheck: CheckResult;
     if (tagWorkflowExists) {
       try {
-        const content = await import('node:fs').then((m) => m.readFileSync(tagWorkflowPath, 'utf8'));
+        const content = await import('node:fs').then((m) =>
+          m.readFileSync(tagWorkflowPath, 'utf8'),
+        );
         const hasName = content.includes('name:');
         const hasOnTrigger = content.includes('on:') || content.includes('pull_request:');
         const valid = hasName && hasOnTrigger;

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -31,8 +31,8 @@ import { createDoctorProgress } from '../progress.js';
 import { cliError, cliOutput, humanLine } from '../renderers/index.js';
 import { doctorDbSubstrateCommand } from './doctor-db-substrate.js';
 import { doctorLegacyBackupsCommand } from './doctor-legacy-backups.js';
-import { doctorReleaseReadinessCommand } from './doctor-release-readiness.js';
 import { runDoctorProjects } from './doctor-projects.js';
+import { doctorReleaseReadinessCommand } from './doctor-release-readiness.js';
 import { readMigrationConflicts } from './migrate-agents-v2.js';
 
 // ============================================================================

--- a/packages/cleo/src/cli/commands/hygiene.ts
+++ b/packages/cleo/src/cli/commands/hygiene.ts
@@ -5,9 +5,9 @@
  * @saga T10431
  */
 
-import { defineCommand } from 'citty';
-import { runSpawnReadinessHygieneCli } from '@cleocode/core/hygiene/validate-spawn-readiness.js';
 import { getProjectRoot } from '@cleocode/core';
+import { runSpawnReadinessHygieneCli } from '@cleocode/core/hygiene/validate-spawn-readiness.js';
+import { defineCommand } from 'citty';
 
 export const hygieneCommand = defineCommand({
   meta: {

--- a/packages/cleo/src/cli/commands/release.ts
+++ b/packages/cleo/src/cli/commands/release.ts
@@ -339,7 +339,9 @@ const planCommand = defineCommand({
   async run({ args }) {
     // T10459 — release-readiness gate
     if (args['skip-readiness'] !== true) {
-      const { runSpawnReadinessHygieneCli } = await import('@cleocode/core/hygiene/validate-spawn-readiness.js');
+      const { runSpawnReadinessHygieneCli } = await import(
+        '@cleocode/core/hygiene/validate-spawn-readiness.js'
+      );
       await runSpawnReadinessHygieneCli();
       // If we reach here, all gates passed (runSpawnReadinessHygieneCli exits on failure)
     }

--- a/packages/core/src/hygiene/__tests__/validate-spawn-readiness.test.ts
+++ b/packages/core/src/hygiene/__tests__/validate-spawn-readiness.test.ts
@@ -7,7 +7,7 @@
 
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { runSpawnReadinessHygiene } from '../validate-spawn-readiness.js';
 
 describe('runSpawnReadinessHygiene', () => {

--- a/packages/core/src/hygiene/validate-spawn-readiness.ts
+++ b/packages/core/src/hygiene/validate-spawn-readiness.ts
@@ -58,10 +58,21 @@ function runChangesetLintGate(projectRoot: string): HygieneGateResult {
   }
   try {
     execSync(`node "${scriptPath}"`, { cwd: projectRoot, encoding: 'utf-8', timeout: 10_000 });
-    return { name: 'changeset-lint', passed: true, message: 'All changesets well-formed.', severity: 'error' };
-  } catch (err: any) {
-    const stderr = err.stderr || err.message || String(err);
-    return { name: 'changeset-lint', passed: false, message: `Changeset lint failed: ${stderr}`, severity: 'error' };
+    return {
+      name: 'changeset-lint',
+      passed: true,
+      message: 'All changesets well-formed.',
+      severity: 'error',
+    };
+  } catch (err) {
+    const e = err as { stderr?: string; message?: string };
+    const stderr = e.stderr || e.message || String(err);
+    return {
+      name: 'changeset-lint',
+      passed: false,
+      message: `Changeset lint failed: ${stderr}`,
+      severity: 'error',
+    };
   }
 }
 
@@ -77,26 +88,56 @@ function runChangelogDriftGate(projectRoot: string): HygieneGateResult {
     };
   }
   try {
-    const head = execSync('head -n 5 CHANGELOG.md', { cwd: projectRoot, encoding: 'utf-8', timeout: 5_000 });
+    const head = execSync('head -n 5 CHANGELOG.md', {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      timeout: 5_000,
+    });
     const hasHeader = /^## \[/.test(head);
     if (hasHeader) {
-      return { name: 'changelog-drift', passed: true, message: 'CHANGELOG.md has valid version header.', severity: 'error' };
+      return {
+        name: 'changelog-drift',
+        passed: true,
+        message: 'CHANGELOG.md has valid version header.',
+        severity: 'error',
+      };
     }
-    return { name: 'changelog-drift', passed: false, message: 'CHANGELOG.md missing version header (expected ## [YYYY.MM.PATCH]).', severity: 'error' };
-  } catch (err: any) {
-    return { name: 'changelog-drift', passed: false, message: `Failed to read CHANGELOG.md: ${err.message}`, severity: 'error' };
+    return {
+      name: 'changelog-drift',
+      passed: false,
+      message: 'CHANGELOG.md missing version header (expected ## [YYYY.MM.PATCH]).',
+      severity: 'error',
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      name: 'changelog-drift',
+      passed: false,
+      message: `Failed to read CHANGELOG.md: ${message}`,
+      severity: 'error',
+    };
   }
 }
 
 /** Run the worktree location gate. */
 function runWorktreeLocationGate(expectedPath?: string): HygieneGateResult {
   if (!expectedPath) {
-    return { name: 'worktree-location', passed: true, message: 'No worktree path provided — skipping location check.', severity: 'warn' };
+    return {
+      name: 'worktree-location',
+      passed: true,
+      message: 'No worktree path provided — skipping location check.',
+      severity: 'warn',
+    };
   }
   try {
     const cwd = execSync('pwd', { encoding: 'utf-8', timeout: 5_000 }).trim();
     if (cwd === expectedPath || cwd.includes(expectedPath)) {
-      return { name: 'worktree-location', passed: true, message: `cwd matches worktree (${cwd}).`, severity: 'error' };
+      return {
+        name: 'worktree-location',
+        passed: true,
+        message: `cwd matches worktree (${cwd}).`,
+        severity: 'error',
+      };
     }
     return {
       name: 'worktree-location',
@@ -104,8 +145,14 @@ function runWorktreeLocationGate(expectedPath?: string): HygieneGateResult {
       message: `cwd mismatch: expected ${expectedPath}, got ${cwd}`,
       severity: 'error',
     };
-  } catch (err: any) {
-    return { name: 'worktree-location', passed: false, message: `Failed to check cwd: ${err.message}`, severity: 'error' };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      name: 'worktree-location',
+      passed: false,
+      message: `Failed to check cwd: ${message}`,
+      severity: 'error',
+    };
   }
 }
 
@@ -161,7 +208,10 @@ export async function runSpawnReadinessHygieneCli(
     console.log('All gates passed — spawn readiness confirmed.');
     process.exitCode = 0;
   } else {
-    const failed = result.gates.filter((g) => !g.passed).map((g) => g.name).join(', ');
+    const failed = result.gates
+      .filter((g) => !g.passed)
+      .map((g) => g.name)
+      .join(', ');
     console.error(`FAILED gates: ${failed}`);
     process.exitCode = 1;
   }


### PR DESCRIPTION
## Summary

P0 release-pipeline hotfix. `validateSpawnReadiness` (T10451) shipped with two `catch (err: any)` clauses. biome's `noExplicitAny` rule rejected these during the `release.yml` lint step, blocking npm publish since v5.118. Latest published @cleocode/cleo is v5.120; v5.121 tag exists but isn't on npm.

Narrows both clauses to proper Error / structured types.

## Test plan
- [x] biome check clean on validate-spawn-readiness.ts
- [x] Behavior preserved (same error message extraction logic)

Closes T10499. Saga: T9862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)