### PR TITLE
docs(T10497): t9187 IVTR baseline + cost ROI spike

### DIFF
--- a/.changeset/t10497-t9187-baseline.md
+++ b/.changeset/t10497-t9187-baseline.md
@@ -1,0 +1,8 @@
+---
+id: t10497-t9187-baseline
+tasks: [T10497]
+kind: docs
+summary: t9187 IVTR false-positive baseline + 2-4x cost ROI measurement
+---
+
+Spike research for SAGA T10377 / Council action #7. Measures 61.5% baseline FP rate on 13-task t9187 corpus and projects 1.15x-3.6x cost multiplier under ADR-079 Validator role. Recommends adopting 2-4x as policy budget ceiling, not expected mean.


### PR DESCRIPTION
## Summary

Spike research closing Council §3.1 action #7 for SAGA T10377 SG-IVTR-AC-BINDING. Measures historical IVTR false-positive rate against the t9187 corpus and quantifies the ADR-079 Validator cost multiplier with concrete numbers.

## Findings

- **Baseline FP rate**: 8/13 = 61.5% on the t9187 corpus (caveats: small n, selection bias, era confound — directional only)
- **Validator catch-rate model**: ~75% under Phase-1 + Wave-2 AC stable IDs prerequisite
- **Cost multiplier**: 1.15x p50 / 2.30x p90 / 3.60x p99 — consistent with ADR-079 §3.1 "2-4x" framing
- **ROI ratio**: 250x-400x at t9187-era base rate; 5-20x at realistic post-T9337 base rate

## Recommendation

**ADOPT** the 2-4x multiplier as a Phase-1 **policy budget ceiling** (not expected mean) with:
- Per-severity caps: P0/P1=4x, P2=2.5x, P3=2x
- Phase 1 → Phase 2 gate: n ≥ 50 validator/worker pairs (not time-based alone)
- Suggested ADR-079 D7 amendment text included in research doc §5.3

## Artifacts

- Research doc: slug `t9187-ivtr-false-positive-baseline` (filed via `cleo docs add --type research`)
- Changeset: `.changeset/t10497-t9187-baseline.md`

## Test plan

- [x] `cleo docs fetch t9187-ivtr-false-positive-baseline` returns the doc (verified 17350 bytes)
- [x] `node scripts/lint-changesets.mjs` passes (155 entries validated)
- [ ] CI green on PR

Closes T10497. Saga: T10377. Decision: D013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)