### PR TITLE
docs(T10496): cleo-validator Max-N infra-fault rows

### DIFF
--- a/.changeset/t10496-max-n-infra-fault-rows.md
+++ b/.changeset/t10496-max-n-infra-fault-rows.md
@@ -1,0 +1,8 @@
+---
+id: t10496-max-n-infra-fault-rows
+tasks: [T10496]
+kind: docs
+summary: add timeout/conduit-drop/validator-OOM rows to cleo-validator Max-N table
+---
+
+Adds three infrastructure-fault rows (timeout, conduit-drop, validator-OOM) to the Max-N retry catalogue in `.cleo/skills/cleo-validator/SKILL.md` under SAGA T10377 SG-IVTR-AC-BINDING. Each row specifies retry count, backoff strategy, and transient-vs-permanent classification per Council §3.1 action #6. Companion change to T10495 — additive only, no replacements of existing semantic-fault rows.

--- a/.cleo/skills/cleo-validator/SKILL.md
+++ b/.cleo/skills/cleo-validator/SKILL.md
@@ -330,6 +330,38 @@ is reached:
   the Lead escalates to HITL via `cleo orchestrate pending --add
   <runId>` — never auto-attest, never auto-reject.
 
+### Max-N infra-fault row catalogue
+
+The Lead consumes one row per detected infra-fault and chooses retry
+strategy from this canonical table. Rows split into two families:
+**semantic faults** (validator decided but couldn't reach a verdict —
+e.g. missing AC list, tool not resolved) and **infrastructure faults**
+(validator process / transport itself failed before it could decide).
+Each row specifies retry count, backoff strategy, and
+transient-vs-permanent classification.
+
+| Fault | Family | Retry count | Backoff | Classification | Escalation atom |
+|-------|--------|-------------|---------|----------------|-----------------|
+| `validator-rejected-no-acs` | semantic | 0 | n/a | permanent | `E_VALIDATOR_NO_ACS` → HITL for AC backfill (ADR-066) |
+| `validator-partial` | semantic | 1 | immediate | transient on first occurrence | `E_VALIDATOR_PARTIAL` after retry → HITL |
+| `validator-unreachable` | semantic | 2 | exponential (10s / 30s) | transient | `E_VALIDATOR_UNREACHABLE` after retries → HITL |
+| `tool-not-resolved` | semantic | 0 | n/a | permanent | `E_TOOL_NOT_RESOLVED` → Lead backfills `.cleo/project-context.json` then re-spawns |
+| **`timeout`** | **infra** | **2** | **exponential (5s / 30s)** | **transient** | `E_VALIDATOR_TIMEOUT` after retries → HITL. Validator process exceeded `subagentTimeoutSeconds` (default 300s for tier-1). A slow LLM call often completes on retry; persistent timeouts indicate a stuck process or pathological task input — investigate input size before further retries. |
+| **`conduit-drop`** | **infra** | **3** | **immediate** | **transient** | `E_VALIDATOR_VERDICT_DROPPED` after retries → HITL. The `validator.verdict` message was emitted but lost on the Conduit transport before the orchestrator observed it. Conduit transport latency is low so immediate retry is safe; persistent drops indicate a Conduit subsystem failure (escalate to infra team, not HITL-AC-backfill). |
+| **`validator-OOM`** | **infra** | **1** | **immediate, downgraded model tier** (e.g. Sonnet → Haiku) | **permanent if downgrade also OOMs** | `E_VALIDATOR_OOM` after retry → HITL. Validator process killed by kernel OOM-killer or hit Node V8 heap limit. Single retry runs with a smaller model context window; second OOM indicates the task input itself is pathological (gigabyte-scale diff, runaway AC list) — Lead MUST investigate task input size BEFORE any further retry to avoid burning HITL budget on a structurally impossible validation. |
+
+**Retry-counter accounting**: each row consumes ONE slot of the
+`delegation.validatorRetryMax` budget (default N=3) regardless of family.
+Semantic + infra faults share the same counter — three consecutive
+faults of ANY mix triggers HITL escalation. This prevents an
+infinite-loop adversary where alternating fault kinds bypass the cap.
+
+**Permanent classification**: a row marked `permanent` short-circuits
+the retry loop immediately — Lead skips the remaining retry budget and
+escalates on the first occurrence. Use sparingly; reserve for faults
+where retry has zero chance of changing the outcome (missing ACs,
+unresolvable tool, post-downgrade OOM).
+
 ### Infra-fault vs reject — the critical distinction
 
 | Symptom | Classification | Why |


### PR DESCRIPTION
## Summary

Adds three infrastructure-fault rows to the Max-N retry catalogue table in `.cleo/skills/cleo-validator/SKILL.md` per Council §3.1 action #6.

Companion additive change to T10495 (PR #769) — same file, no existing rows replaced or refactored.

### New rows

| Fault | Retry | Backoff | Classification | Escalation |
|-------|-------|---------|----------------|------------|
| `timeout` | 2 | exponential (5s / 30s) | transient | `E_VALIDATOR_TIMEOUT` → HITL |
| `conduit-drop` | 3 | immediate | transient | `E_VALIDATOR_VERDICT_DROPPED` → HITL |
| `validator-OOM` | 1 | immediate w/ downgraded model tier | permanent if downgrade OOMs | `E_VALIDATOR_OOM` → HITL |

Each row distinguishes **infra family** (validator process / transport failed) from existing **semantic family** rows (validator decided but couldn't reach a verdict). Retry-counter accounting is shared so adversarial fault-kind alternation cannot bypass the `delegation.validatorRetryMax` cap.

## Task

- Closes T10496
- Saga: T10377 SG-IVTR-AC-BINDING
- Decision: D013
- Council action #6

## Test plan

- [x] Markdown ignored by biome (docs file) — no lint regression
- [x] `node scripts/lint-changesets.mjs` → 157 entries validated
- [x] No code/runtime surface touched — pure docs addition
- [x] Additive only — T10495's existing 410 lines unchanged