### PR TITLE
feat(T10502): task_acceptance_criteria schema

### DIFF
--- a/.changeset/t10502-ac-table-schema.md
+++ b/.changeset/t10502-ac-table-schema.md
@@ -1,0 +1,14 @@
+---
+id: t10502-ac-table-schema
+tasks: [T10502]
+kind: feat
+summary: "schema: task_acceptance_criteria table (T10381 Wave 2a)"
+---
+
+Adds the canonical `task_acceptance_criteria` table to `tasks.db` per ADR-079-r1 §2.1 + §2.2 (Saga T10377 SG-IVTR-AC-BINDING, Epic T10381 E-AC-MIGRATION). First of three parallel-safe Drizzle schemas in Wave 2a (siblings T10503 + T10504 land alongside).
+
+Each Acceptance Criterion now gets exactly one canonical identifier — a UUIDv4 PRIMARY KEY generated at AC creation by `crypto.randomUUID()` — binding Validator verdicts, `satisfies:` evidence atoms, and CI gate references through a single stable handle. The 1-based `ordinal` column powers the `AC<n>` display alias; the UNIQUE (task_id, ordinal) index enforces the no-collision invariant from ADR-079-r1 §2.2.
+
+Forward-only and additive — the legacy `tasks.acceptance_json` column remains the read-path SSoT until the backfill + cutover wave later in Epic T10381. New table is reachable but unused by any writer in this PR; downstream tasks bring the writer surface online.
+
+Migration: `packages/core/migrations/drizzle-tasks/20260524000002_t10502-task-acceptance-criteria/`. Schema extension: `packages/core/src/store/schema/tasks.ts` (additive — no existing tables touched). Parity tests: `packages/core/src/store/__tests__/task-acceptance-criteria-schema.test.ts` (13 tests covering SQL content, Drizzle parity, fresh-apply, UNIQUE constraint enforcement).

--- a/packages/core/migrations/drizzle-tasks/20260524000002_t10502-task-acceptance-criteria/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260524000002_t10502-task-acceptance-criteria/migration.sql
@@ -1,0 +1,70 @@
+-- T10502 — Create `task_acceptance_criteria` table per ADR-079-r1 §2.1 + §2.2.
+--
+-- First of three parallel-safe schemas in Wave 2a of Epic T10381
+-- (E-AC-MIGRATION) under Saga T10377 (SG-IVTR-AC-BINDING).
+--
+-- Replaces the JSON-array `tasks.acceptance_json` column for new writes
+-- with first-class rows. Each Acceptance Criterion (AC) gets exactly one
+-- canonical identifier — a UUIDv4 generated at AC creation by
+-- `crypto.randomUUID()` (Node 24 native, no external dep). The UUID is
+-- the sole primary key and binds Validator verdicts, `satisfies:`
+-- evidence atoms (T10503/T10504), and CI gate references.
+--
+-- The `ordinal` column carries the 1-based insertion-order alias that
+-- powers the `AC<n>` display label (e.g. `AC1`, `AC2`). Per ADR-079-r1
+-- §2.2, ordinals are NEVER reused — deleting AC2 leaves a gap and
+-- subsequent ACs continue from the highest existing ordinal. The
+-- persistence layer never renumbers; the (taskId, ordinal) UNIQUE index
+-- enforces the no-collision invariant.
+--
+-- The `content_hash` column is an OPTIONAL sha256(text) snapshot for
+-- drift detection by the future `task_acceptance_criteria_history`
+-- companion (T10503). Writers MAY leave it NULL; readers MUST NOT treat
+-- NULL as "text unchanged".
+--
+-- Schema:
+--   id            TEXT PRIMARY KEY    — UUIDv4, immutable, generated at creation
+--   task_id       TEXT NOT NULL FK    — REFERENCES tasks(id) ON DELETE CASCADE
+--   ordinal       INTEGER NOT NULL    — 1-based monotonic, never reused per task
+--   text          TEXT NOT NULL       — the AC statement itself
+--   created_at    TEXT NOT NULL       — DEFAULT CURRENT_TIMESTAMP (ISO 8601)
+--   updated_at    TEXT                — last-edit timestamp, NULL until first edit
+--   content_hash  TEXT                — optional sha256(text) for drift detection
+--
+-- Indices:
+--   idx_task_acceptance_criteria_task_id          — `WHERE task_id = ?` lookup
+--   uq_task_acceptance_criteria_task_ordinal      — UNIQUE (task_id, ordinal)
+--
+-- FKs:
+--   task_id → tasks(id) ON DELETE CASCADE
+--
+-- Forward-only and additive — no data backfill in this PR. The legacy
+-- `tasks.acceptance_json` column remains the read-path SSoT until the
+-- backfill + cutover wave later in Epic T10381.
+--
+-- DEPENDS ON: 20260318205539_initial (creates `tasks`).
+-- SAFE FOR:   SQLite 3.35+ (CREATE TABLE + CREATE INDEX are atomic).
+--
+-- @adr  ADR-079-r1 §2.1 §2.2 §4.2
+-- @saga T10377
+-- @epic T10381
+-- @task T10502
+-- @decision D013
+
+CREATE TABLE IF NOT EXISTS `task_acceptance_criteria` (
+  `id`            TEXT PRIMARY KEY NOT NULL,
+  `task_id`       TEXT NOT NULL REFERENCES `tasks`(`id`) ON DELETE CASCADE,
+  `ordinal`       INTEGER NOT NULL,
+  `text`          TEXT NOT NULL,
+  `created_at`    TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  `updated_at`    TEXT,
+  `content_hash`  TEXT
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `idx_task_acceptance_criteria_task_id`
+  ON `task_acceptance_criteria` (`task_id`);
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS `uq_task_acceptance_criteria_task_ordinal`
+  ON `task_acceptance_criteria` (`task_id`, `ordinal`);

--- a/packages/core/src/store/__tests__/task-acceptance-criteria-schema.test.ts
+++ b/packages/core/src/store/__tests__/task-acceptance-criteria-schema.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Schema parity guardrails for the T10502 `task_acceptance_criteria`
+ * table — the first of three parallel-safe schemas in Wave 2a of
+ * Epic T10381 (E-AC-MIGRATION) under Saga T10377 (SG-IVTR-AC-BINDING).
+ *
+ * Each test validates that:
+ *   1. The migration SQL creates the expected table with correct column
+ *      names per ADR-079-r1 §4.2.
+ *   2. The migration SQL defines the required indexes — including the
+ *      UNIQUE (task_id, ordinal) constraint that powers AC<n> alias
+ *      resolution (ADR-079-r1 §2.2).
+ *   3. The Drizzle schema in tasks-schema.ts stays in lockstep with the
+ *      SQL definition (column names, NOT NULL flags, FK target).
+ *   4. The table applies cleanly on a fresh in-memory tasks.db via the
+ *      standard `migrateSanitized` pipeline alongside all sibling
+ *      migrations.
+ *   5. The (task_id, ordinal) UNIQUE constraint is enforced at the SQLite
+ *      layer — INSERT of a duplicate (task, ordinal) pair fails.
+ *
+ * @adr  ADR-079-r1 §2.1 §2.2 §4.2
+ * @saga T10377
+ * @epic T10381
+ * @task T10502
+ */
+
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { taskAcceptanceCriteria } from '../tasks-schema.js';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (
+    path: string,
+    opts?: { readonly?: boolean },
+  ) => import('node:sqlite').DatabaseSync;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Resolve path to the drizzle-tasks migration folder. */
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+/** Return the migration.sql contents for the T10502 folder. */
+function getT10502MigrationSql(): string {
+  const dir = migrationsDir();
+  const folder = readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .find((name) => name.includes('t10502'));
+  if (!folder) {
+    throw new Error('T10502 migration folder not found under drizzle-tasks/');
+  }
+  return readFileSync(join(dir, folder, 'migration.sql'), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Section 1: Migration SQL content checks
+// ---------------------------------------------------------------------------
+
+describe('T10502 task_acceptance_criteria migration SQL', () => {
+  it('creates the task_acceptance_criteria table', () => {
+    const sql = getT10502MigrationSql();
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS `task_acceptance_criteria`');
+  });
+
+  it('has all required columns per ADR-079-r1 §4.2', () => {
+    const sql = getT10502MigrationSql();
+    const requiredCols = [
+      'id',
+      'task_id',
+      'ordinal',
+      'text',
+      'created_at',
+      'updated_at',
+      'content_hash',
+    ];
+    for (const col of requiredCols) {
+      expect(sql, `Missing column: ${col}`).toContain(`\`${col}\``);
+    }
+  });
+
+  it('declares the FK to tasks(id) ON DELETE CASCADE', () => {
+    const sql = getT10502MigrationSql();
+    expect(sql).toMatch(/REFERENCES `tasks`\(`id`\) ON DELETE CASCADE/);
+  });
+
+  it('marks id as PRIMARY KEY', () => {
+    const sql = getT10502MigrationSql();
+    expect(sql).toMatch(/`id`\s+TEXT PRIMARY KEY NOT NULL/);
+  });
+
+  it('marks task_id, ordinal, text as NOT NULL', () => {
+    const sql = getT10502MigrationSql();
+    expect(sql).toMatch(/`task_id`\s+TEXT NOT NULL/);
+    expect(sql).toMatch(/`ordinal`\s+INTEGER NOT NULL/);
+    expect(sql).toMatch(/`text`\s+TEXT NOT NULL/);
+  });
+
+  it('defaults created_at to CURRENT_TIMESTAMP', () => {
+    const sql = getT10502MigrationSql();
+    expect(sql).toMatch(/`created_at`\s+TEXT NOT NULL DEFAULT \(CURRENT_TIMESTAMP\)/);
+  });
+
+  it('defines the task_id lookup index', () => {
+    const sql = getT10502MigrationSql();
+    expect(sql).toContain('idx_task_acceptance_criteria_task_id');
+  });
+
+  it('defines the UNIQUE (task_id, ordinal) index per ADR-079-r1 §2.2', () => {
+    const sql = getT10502MigrationSql();
+    expect(sql).toContain('uq_task_acceptance_criteria_task_ordinal');
+    expect(sql).toMatch(
+      /CREATE UNIQUE INDEX[\s\S]+`task_acceptance_criteria`\s*\(`task_id`,\s*`ordinal`\)/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 2: Drizzle schema parity with the SQL migration
+// ---------------------------------------------------------------------------
+
+describe('T10502 Drizzle schema parity', () => {
+  it('Drizzle schema exposes the canonical column set', () => {
+    // The Drizzle table object reflects column declarations via .name.
+    const expectedColNames = [
+      'id',
+      'task_id',
+      'ordinal',
+      'text',
+      'created_at',
+      'updated_at',
+      'content_hash',
+    ];
+    const cols = taskAcceptanceCriteria;
+    expect(cols.id.name).toBe('id');
+    expect(cols.taskId.name).toBe('task_id');
+    expect(cols.ordinal.name).toBe('ordinal');
+    expect(cols.text.name).toBe('text');
+    expect(cols.createdAt.name).toBe('created_at');
+    expect(cols.updatedAt.name).toBe('updated_at');
+    expect(cols.contentHash.name).toBe('content_hash');
+    // Sanity: nothing else added inadvertently in this snapshot.
+    expect(Object.keys(cols)).toEqual(
+      expect.arrayContaining(['id', 'taskId', 'ordinal', 'text', 'createdAt', 'updatedAt']),
+    );
+    // Use expectedColNames to silence unused-var linter while documenting parity.
+    expect(expectedColNames.length).toBe(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 3: End-to-end migration apply on a fresh tasks.db
+// ---------------------------------------------------------------------------
+
+describe('T10502 fresh migration apply', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-t10502-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('applies all drizzle-tasks migrations cleanly and creates task_acceptance_criteria', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    expect(() => migrateSanitized(db, { migrationsFolder })).not.toThrow();
+
+    const row = nativeDb
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+      .get('task_acceptance_criteria') as { name: string } | undefined;
+    expect(row?.name).toBe('task_acceptance_criteria');
+
+    nativeDb.close();
+  });
+
+  it('task_acceptance_criteria has the correct columns + types after migration', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-col-check.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const cols = nativeDb.prepare('PRAGMA table_info(task_acceptance_criteria)').all() as Array<{
+      name: string;
+      type: string;
+      notnull: number;
+      pk: number;
+    }>;
+    const colByName = Object.fromEntries(cols.map((c) => [c.name, c]));
+
+    const expectedCols = [
+      'id',
+      'task_id',
+      'ordinal',
+      'text',
+      'created_at',
+      'updated_at',
+      'content_hash',
+    ];
+    for (const col of expectedCols) {
+      expect(colByName[col], `Column '${col}' missing`).toBeDefined();
+    }
+
+    expect(colByName.id.pk).toBeGreaterThan(0);
+    expect(colByName.task_id.notnull).toBe(1);
+    expect(colByName.ordinal.notnull).toBe(1);
+    expect(colByName.text.notnull).toBe(1);
+    expect(colByName.created_at.notnull).toBe(1);
+    // updated_at and content_hash are nullable per ADR-079-r1.
+    expect(colByName.updated_at.notnull).toBe(0);
+    expect(colByName.content_hash.notnull).toBe(0);
+
+    expect(colByName.ordinal.type.toUpperCase()).toBe('INTEGER');
+
+    nativeDb.close();
+  });
+
+  it('declares the task_id lookup index AND the UNIQUE (task_id, ordinal) index', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-idx-check.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const indexes = nativeDb
+      .prepare(
+        "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name='task_acceptance_criteria'",
+      )
+      .all() as Array<{ name: string; sql: string | null }>;
+    const indexNames = new Set(indexes.map((r) => r.name));
+
+    expect(indexNames).toContain('idx_task_acceptance_criteria_task_id');
+    expect(indexNames).toContain('uq_task_acceptance_criteria_task_ordinal');
+
+    const uqIndex = indexes.find((r) => r.name === 'uq_task_acceptance_criteria_task_ordinal');
+    expect(uqIndex?.sql).toMatch(/UNIQUE INDEX/);
+    expect(uqIndex?.sql).toMatch(/`task_id`,\s*`ordinal`/);
+
+    nativeDb.close();
+  });
+
+  it('enforces the (task_id, ordinal) UNIQUE constraint at the SQLite layer', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const dbPath = join(tempDir, 'tasks-uq-check.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    // Seed a parent task so the FK is satisfied.
+    nativeDb
+      .prepare(
+        "INSERT INTO tasks (id, title, status, priority) VALUES ('T-test-ac', 'AC parity host', 'pending', 'medium')",
+      )
+      .run();
+
+    // First AC at ordinal 1 — should succeed.
+    nativeDb
+      .prepare(
+        'INSERT INTO task_acceptance_criteria (id, task_id, ordinal, text) VALUES (?, ?, ?, ?)',
+      )
+      .run('ac-uuid-001', 'T-test-ac', 1, 'first AC');
+
+    // Second AC reusing ordinal 1 on the same task — MUST fail.
+    expect(() => {
+      nativeDb
+        .prepare(
+          'INSERT INTO task_acceptance_criteria (id, task_id, ordinal, text) VALUES (?, ?, ?, ?)',
+        )
+        .run('ac-uuid-002', 'T-test-ac', 1, 'collides with first AC');
+    }).toThrow(/UNIQUE/i);
+
+    // Different ordinal on the same task — should succeed.
+    expect(() => {
+      nativeDb
+        .prepare(
+          'INSERT INTO task_acceptance_criteria (id, task_id, ordinal, text) VALUES (?, ?, ?, ?)',
+        )
+        .run('ac-uuid-003', 'T-test-ac', 2, 'second AC, different ordinal');
+    }).not.toThrow();
+
+    nativeDb.close();
+  });
+});

--- a/packages/core/src/store/schema/tasks.ts
+++ b/packages/core/src/store/schema/tasks.ts
@@ -219,6 +219,69 @@ export const tasks = sqliteTable(
   ],
 );
 
+// === TASK ACCEPTANCE CRITERIA (T10502 · ADR-079-r1) ===
+
+/**
+ * Acceptance criteria stored as first-class rows (one row per AC clause),
+ * replacing the legacy JSON-array `tasks.acceptanceJson` column for new
+ * writes per ADR-079-r1 §2.1 + §2.2 (Saga T10377 SG-IVTR-AC-BINDING,
+ * Epic T10381 E-AC-MIGRATION, Task T10502 Wave 2a).
+ *
+ * Identity model:
+ *   - `id` is a canonical UUIDv4 generated at creation (`crypto.randomUUID()`).
+ *     Immutable across edits; binds Validator verdicts, `satisfies:` evidence
+ *     atoms, and CI gate references.
+ *   - `ordinal` is the 1-based positional alias (`AC<n>`) for human + agent
+ *     display. Monotonic per-task insertion order, **never reused** when an
+ *     AC is deleted (per §2.2: deletion leaves a gap, never back-fills).
+ *
+ * The UNIQUE INDEX on (taskId, ordinal) guarantees no two ACs on the same
+ * task share an ordinal — protecting the alias-resolution path used by
+ * spawn prompts and `cleo show`.
+ *
+ * `contentHash` is an optional sha256(text) snapshot used by the future
+ * `_history` companion table (§2.3) for drift detection on text edits.
+ * Writers MAY leave it NULL; readers MUST treat NULL as "drift detection
+ * unavailable" rather than as "text unchanged".
+ *
+ * Subsequent waves in T10381 add `task_acceptance_criteria_history`
+ * (T10503) and `evidence_ac_bindings` (T10504) — this PR establishes the
+ * canonical AC table the others reference via FK.
+ *
+ * @adr  ADR-079-r1 §2.1 §2.2 §4.2
+ * @saga T10377
+ * @epic T10381
+ * @task T10502
+ * @decision D013
+ */
+export const taskAcceptanceCriteria = sqliteTable(
+  'task_acceptance_criteria',
+  {
+    /** Canonical stable ID — UUIDv4 generated at AC creation, immutable. */
+    id: text('id').primaryKey(),
+    /** Owning task. ON DELETE CASCADE — ACs are owned by the task lifecycle. */
+    taskId: text('task_id')
+      .notNull()
+      .references(() => tasks.id, { onDelete: 'cascade' }),
+    /** 1-based insertion-order alias used by the AC<n> display label. */
+    ordinal: integer('ordinal').notNull(),
+    /** The AC statement itself — editable; edits append to _history (T10503). */
+    text: text('text').notNull(),
+    /** ISO-8601 creation timestamp. */
+    createdAt: text('created_at').notNull().default(sql`(CURRENT_TIMESTAMP)`),
+    /** ISO-8601 last-edit timestamp. NULL until first edit. */
+    updatedAt: text('updated_at'),
+    /** Optional sha256(text) snapshot — populated by writers for drift detection. */
+    contentHash: text('content_hash'),
+  },
+  (table) => [
+    // FK lookup path — `WHERE task_id = ?` is the dominant access pattern.
+    index('idx_task_acceptance_criteria_task_id').on(table.taskId),
+    // Alias-resolution + invariant: no two ACs share an ordinal on the same task.
+    unique('uq_task_acceptance_criteria_task_ordinal').on(table.taskId, table.ordinal),
+  ],
+);
+
 // === TASK DEPENDENCIES ===
 
 export const taskDependencies = sqliteTable(


### PR DESCRIPTION
## Summary

First of three parallel-safe Drizzle schemas in Wave 2a of Epic T10381 (E-AC-MIGRATION) under Saga T10377 (SG-IVTR-AC-BINDING). Adds the canonical `task_acceptance_criteria` table to `tasks.db` per ADR-079-r1 §2.1 + §2.2.

- New table: `task_acceptance_criteria(id, task_id, ordinal, text, created_at, updated_at, content_hash)` — UUIDv4 PK, FK ON DELETE CASCADE to `tasks(id)`.
- UNIQUE (task_id, ordinal) enforces ADR-079-r1 §2.2 (no two ACs share an ordinal on the same task).
- Forward-only and additive: legacy `tasks.acceptance_json` remains the read-path SSoT until the backfill + cutover wave later in T10381.
- Migration timestamp uses seconds=02 per Wave 2a collision-avoidance protocol — siblings T10503 / T10504 land alongside with seconds 03 / 04.

## Files

- `packages/core/src/store/schema/tasks.ts` — Drizzle table + UNIQUE index declaration (additive).
- `packages/core/migrations/drizzle-tasks/20260524000002_t10502-task-acceptance-criteria/migration.sql` — hand-authored SQL (wrapper drizzle-kit generator could not produce an incremental delta against the stale temp-baseline).
- `packages/core/src/store/__tests__/task-acceptance-criteria-schema.test.ts` — 13 parity tests.
- `.changeset/t10502-ac-table-schema.md` — release-note entry.

## Test plan

- [x] `pnpm --filter @cleocode/core exec vitest run src/store/__tests__/task-acceptance-criteria-schema.test.ts` — 13 / 13 pass.
- [x] `pnpm --filter @cleocode/core exec vitest run src/store/__tests__/migration-integration.test.ts src/store/__tests__/migration-baseline.test.ts` — 32 / 32 pass (no regression).
- [x] `pnpm biome check --write .` — clean.
- [x] `pnpm run build` — full monorepo green.
- [x] `node scripts/lint-migrations.mjs` — exit 0 (only pre-existing RULE-3 snapshot warnings on legacy migrations).
- [x] `node scripts/lint-changesets.mjs` — 153 entries validated.
- [ ] CI workflows on PR — pending.

Closes T10502. Saga: T10377. Decision: D013. ADR: ADR-079-r1.