### PR TITLE
feat(T10506): satisfies atom kind in evidence grammar

### DIFF
--- a/.changeset/t10506-satisfies-atom-grammar.md
+++ b/.changeset/t10506-satisfies-atom-grammar.md
@@ -1,0 +1,34 @@
+---
+id: t10506-satisfies-atom-grammar
+tasks: [T10506]
+kind: feat
+summary: "evidence: satisfies:<tid>#<aid> atom kind parser (T10381 Wave 2b)"
+---
+
+Adds the `satisfies:<task-id>#<ac-id>[@<version-pin>]` evidence atom kind
+to the ADR-051 grammar per ADR-079-r2 §2.1 ABNF.
+
+PARSING ONLY — accepts both UUID form
+(`satisfies:T1234#a1b2c3d4-5e6f-4890-abcd-ef1234567890`) and positional-
+alias form (`satisfies:T1234#AC2`), with the optional 14-digit version-pin
+suffix (`@YYYYMMDDhhmmss`). Strict per-field regexes enforce: task-id
+`/^T[0-9]{1,7}$/`, ac-uuid strict lowercase UUIDv4, ac-alias
+`/^AC[0-9]{1,4}$/`, version-pin 14 digits.
+
+The 5-check validator semantics (target task exists, target not terminal,
+AC exists by UUID-or-alias lookup, same-saga scope rule, alias-drift
+detection) ship in T10507 alongside the `evidence_satisfies_bindings`
+side-effect table writes. Until T10507 lands, the runtime validator
+returns `E_AC_BINDING_VALIDATOR_PENDING` to make the deferral explicit.
+
+Surfaces:
+- `packages/contracts/src/evidence-atom-schema.ts` — `satisfiesAtomSchema`
+  Zod discriminator, exported regexes (`AC_UUID_REGEX`, `AC_ALIAS_REGEX`,
+  `SATISFIES_TASK_ID_REGEX`, `SATISFIES_VERSION_PIN_REGEX`), and the new
+  `parseEvidenceString` case.
+- `packages/contracts/src/task.ts` — validated `EvidenceAtom` union gains
+  the `satisfies` shape with reserved `resolvedAcUuid` for T10507.
+- `packages/core/src/tasks/evidence.ts` — `ParsedAtom` union + runtime
+  validator switch updated; deferred-validator case added.
+
+Saga: T10377 (SG-IVTR-AC-BINDING). Epic: T10381. Decision: D013.

--- a/packages/contracts/src/__tests__/satisfies-atom.test.ts
+++ b/packages/contracts/src/__tests__/satisfies-atom.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for the ADR-079-r2 `satisfies:<task-id>#<ac-id>` evidence atom
+ * grammar (T10506).
+ *
+ * Coverage:
+ *   - Schema-level: per-field regex validation (task-id, ac-uuid, ac-alias,
+ *     version-pin) and discriminated-union acceptance.
+ *   - Parser-level: full {@link parseEvidenceString} round-trips for both
+ *     UUID and alias forms, mixed evidence strings, and the optional
+ *     `@<version-pin>` suffix.
+ *   - Malformed inputs: missing colon, missing hash, missing T-prefix,
+ *     mixed-case UUID, non-UUID non-alias ac-id, malformed version-pin.
+ *
+ * This file covers PARSING ONLY per T10506 acceptance criteria. The 5-check
+ * validator semantics (target exists, target not terminal, AC exists, same-
+ * saga scope rule, alias drift detection) ship in T10507 and are tested
+ * separately in `packages/core/src/tasks/__tests__/satisfies-validator.test.ts`.
+ *
+ * @task T10506
+ * @saga T10377
+ * @adr ADR-079-r2
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  AC_ALIAS_REGEX,
+  AC_UUID_REGEX,
+  EvidenceAtomSchema,
+  EvidenceParseError,
+  parseEvidenceString,
+  SATISFIES_TASK_ID_REGEX,
+  SATISFIES_VERSION_PIN_REGEX,
+  satisfiesAtomSchema,
+} from '../index.js';
+
+// ─── Per-field regex parity (ADR-079-r2 §2.1 ABNF) ────────────────────────
+
+describe('satisfies atom regexes (ADR-079-r2 §2.1)', () => {
+  describe('SATISFIES_TASK_ID_REGEX', () => {
+    it('accepts T<1-7 digits>', () => {
+      expect(SATISFIES_TASK_ID_REGEX.test('T1')).toBe(true);
+      expect(SATISFIES_TASK_ID_REGEX.test('T1234')).toBe(true);
+      expect(SATISFIES_TASK_ID_REGEX.test('T1234567')).toBe(true);
+    });
+    it('rejects T<8+ digits>', () => {
+      expect(SATISFIES_TASK_ID_REGEX.test('T12345678')).toBe(false);
+    });
+    it('rejects missing T prefix', () => {
+      expect(SATISFIES_TASK_ID_REGEX.test('1234')).toBe(false);
+    });
+    it('rejects lowercase t', () => {
+      expect(SATISFIES_TASK_ID_REGEX.test('t1234')).toBe(false);
+    });
+    it('rejects non-digit suffix', () => {
+      expect(SATISFIES_TASK_ID_REGEX.test('T12a')).toBe(false);
+    });
+  });
+
+  describe('AC_UUID_REGEX', () => {
+    it('accepts strict lowercase UUIDv4', () => {
+      expect(AC_UUID_REGEX.test('a1b2c3d4-5e6f-4890-abcd-ef1234567890')).toBe(true);
+      expect(AC_UUID_REGEX.test('00000000-0000-4000-8000-000000000000')).toBe(true);
+    });
+    it('rejects mixed-case', () => {
+      // Council-mandated strictness (ADR-079-r2 §2.2): "Validators MUST
+      // reject mixed-case to prevent silent dedupe failures."
+      expect(AC_UUID_REGEX.test('A1B2C3D4-5E6F-4890-ABCD-EF1234567890')).toBe(false);
+    });
+    it('rejects wrong version nibble (not 4)', () => {
+      expect(AC_UUID_REGEX.test('a1b2c3d4-5e6f-5890-abcd-ef1234567890')).toBe(false);
+    });
+    it('rejects wrong variant nibble (not 8/9/a/b)', () => {
+      expect(AC_UUID_REGEX.test('a1b2c3d4-5e6f-4890-cbcd-ef1234567890')).toBe(false);
+    });
+    it('rejects non-UUID strings', () => {
+      expect(AC_UUID_REGEX.test('not-a-uuid')).toBe(false);
+      expect(AC_UUID_REGEX.test('a1b2c3d45e6f4890abcdef1234567890')).toBe(false);
+    });
+  });
+
+  describe('AC_ALIAS_REGEX', () => {
+    it('accepts AC<1-4 digits>', () => {
+      expect(AC_ALIAS_REGEX.test('AC1')).toBe(true);
+      expect(AC_ALIAS_REGEX.test('AC9999')).toBe(true);
+    });
+    it('rejects AC<5+ digits>', () => {
+      expect(AC_ALIAS_REGEX.test('AC10000')).toBe(false);
+    });
+    it('rejects lowercase ac', () => {
+      expect(AC_ALIAS_REGEX.test('ac1')).toBe(false);
+    });
+    it('rejects bare integer', () => {
+      expect(AC_ALIAS_REGEX.test('1')).toBe(false);
+    });
+  });
+
+  describe('SATISFIES_VERSION_PIN_REGEX', () => {
+    it('accepts exactly 14 digits', () => {
+      expect(SATISFIES_VERSION_PIN_REGEX.test('20260524223045')).toBe(true);
+    });
+    it('rejects fewer than 14 digits', () => {
+      expect(SATISFIES_VERSION_PIN_REGEX.test('2026052422304')).toBe(false);
+    });
+    it('rejects more than 14 digits', () => {
+      expect(SATISFIES_VERSION_PIN_REGEX.test('202605242230451')).toBe(false);
+    });
+    it('rejects non-digit characters', () => {
+      expect(SATISFIES_VERSION_PIN_REGEX.test('2026-05-24T22:30')).toBe(false);
+    });
+  });
+});
+
+// ─── Zod schema (post-parse client-side validation) ────────────────────────
+
+describe('satisfiesAtomSchema (ADR-079-r2 §5.2)', () => {
+  it('accepts UUID form without version-pin', () => {
+    const a = satisfiesAtomSchema.parse({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcId: '8f4a2c1e-b09d-4f6a-9c3e-7a1d4f8c0b2e',
+    });
+    expect(a.targetTaskId).toBe('T10495');
+    expect(a.targetAcId).toBe('8f4a2c1e-b09d-4f6a-9c3e-7a1d4f8c0b2e');
+    expect(a.targetAcAlias).toBeUndefined();
+    expect(a.versionPin).toBeUndefined();
+  });
+
+  it('accepts alias form without version-pin', () => {
+    const a = satisfiesAtomSchema.parse({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcAlias: 'AC2',
+    });
+    expect(a.targetAcAlias).toBe('AC2');
+    expect(a.targetAcId).toBeUndefined();
+  });
+
+  it('accepts alias form with version-pin', () => {
+    const a = satisfiesAtomSchema.parse({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcAlias: 'AC2',
+      versionPin: '20260524223045',
+    });
+    expect(a.versionPin).toBe('20260524223045');
+  });
+
+  it('accepts UUID form with version-pin (highest-trust)', () => {
+    const a = satisfiesAtomSchema.parse({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcId: '8f4a2c1e-b09d-4f6a-9c3e-7a1d4f8c0b2e',
+      versionPin: '20260524223045',
+    });
+    expect(a.targetAcId).toBeDefined();
+    expect(a.versionPin).toBe('20260524223045');
+  });
+
+  it('rejects malformed targetTaskId via schema', () => {
+    const r = satisfiesAtomSchema.safeParse({
+      kind: 'satisfies',
+      targetTaskId: 'task-1234',
+      targetAcAlias: 'AC2',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects mixed-case UUID via schema', () => {
+    const r = satisfiesAtomSchema.safeParse({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcId: '8F4A2C1E-B09D-4F6A-9C3E-7A1D4F8C0B2E',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects malformed version-pin via schema', () => {
+    const r = satisfiesAtomSchema.safeParse({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcAlias: 'AC2',
+      versionPin: '2026-05-24T22:30',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('round-trips through the EvidenceAtomSchema discriminated union', () => {
+    const a = EvidenceAtomSchema.parse({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcAlias: 'AC2',
+    });
+    expect(a.kind).toBe('satisfies');
+  });
+});
+
+// ─── parseEvidenceString (CLI parser) ──────────────────────────────────────
+
+describe('parseEvidenceString — satisfies atom (T10506)', () => {
+  // ─── Valid forms ─────────────────────────────────────────────────────────
+
+  it('parses UUID form', () => {
+    const atoms = parseEvidenceString('satisfies:T10495#8f4a2c1e-b09d-4f6a-9c3e-7a1d4f8c0b2e');
+    expect(atoms).toHaveLength(1);
+    expect(atoms[0]).toEqual({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcId: '8f4a2c1e-b09d-4f6a-9c3e-7a1d4f8c0b2e',
+    });
+  });
+
+  it('parses alias form', () => {
+    const atoms = parseEvidenceString('satisfies:T10495#AC2');
+    expect(atoms).toHaveLength(1);
+    expect(atoms[0]).toEqual({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcAlias: 'AC2',
+    });
+  });
+
+  it('parses alias form with version-pin', () => {
+    const atoms = parseEvidenceString('satisfies:T10495#AC2@20260524223045');
+    expect(atoms).toHaveLength(1);
+    expect(atoms[0]).toEqual({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcAlias: 'AC2',
+      versionPin: '20260524223045',
+    });
+  });
+
+  it('parses UUID form with version-pin (canonical highest-trust)', () => {
+    const atoms = parseEvidenceString(
+      'satisfies:T10495#8f4a2c1e-b09d-4f6a-9c3e-7a1d4f8c0b2e@20260524223045',
+    );
+    expect(atoms).toHaveLength(1);
+    expect(atoms[0]).toEqual({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcId: '8f4a2c1e-b09d-4f6a-9c3e-7a1d4f8c0b2e',
+      versionPin: '20260524223045',
+    });
+  });
+
+  it('parses multiple satisfies atoms in one evidence string', () => {
+    const atoms = parseEvidenceString('satisfies:T10495#AC2;satisfies:T10493#AC1');
+    expect(atoms).toHaveLength(2);
+    expect(atoms[0]).toMatchObject({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcAlias: 'AC2',
+    });
+    expect(atoms[1]).toMatchObject({
+      kind: 'satisfies',
+      targetTaskId: 'T10493',
+      targetAcAlias: 'AC1',
+    });
+  });
+
+  it('parses mixed evidence: commit + files + satisfies', () => {
+    const atoms = parseEvidenceString(
+      'commit:abc1234;files:src/foo.ts,src/bar.ts;satisfies:T10495#AC2',
+    );
+    expect(atoms).toHaveLength(3);
+    expect(atoms[0]).toEqual({ kind: 'commit', sha: 'abc1234' });
+    expect(atoms[1]).toEqual({ kind: 'files', paths: ['src/foo.ts', 'src/bar.ts'] });
+    expect(atoms[2]).toEqual({
+      kind: 'satisfies',
+      targetTaskId: 'T10495',
+      targetAcAlias: 'AC2',
+    });
+  });
+
+  it('parses mixed evidence: satisfies + pr (single PR landing multiple ACs)', () => {
+    const atoms = parseEvidenceString('satisfies:T10506#AC1;satisfies:T10506#AC2;pr:773');
+    expect(atoms).toHaveLength(3);
+    expect(atoms[2]).toEqual({ kind: 'pr', prNumber: 773 });
+  });
+
+  // ─── Malformed: missing colon ────────────────────────────────────────────
+
+  it('rejects atom missing the kind-payload colon', () => {
+    // "satisfiesT10495#AC2" — no `:` separator at all
+    expect(() => parseEvidenceString('satisfiesT10495#AC2')).toThrow(EvidenceParseError);
+  });
+
+  // ─── Malformed: missing hash ─────────────────────────────────────────────
+
+  it('rejects atom missing the # separator between task-id and ac-id', () => {
+    expect(() => parseEvidenceString('satisfies:T10495-AC2')).toThrow(EvidenceParseError);
+    expect(() => parseEvidenceString('satisfies:T10495AC2')).toThrow(EvidenceParseError);
+  });
+
+  it('rejects atom with # at start of payload (empty task-id)', () => {
+    expect(() => parseEvidenceString('satisfies:#AC2')).toThrow(EvidenceParseError);
+  });
+
+  it('rejects atom with # at end of payload (empty ac-id)', () => {
+    expect(() => parseEvidenceString('satisfies:T10495#')).toThrow(EvidenceParseError);
+  });
+
+  // ─── Malformed: missing T-prefix on task-id ──────────────────────────────
+
+  it('rejects atom with non-T-prefixed task-id', () => {
+    expect(() => parseEvidenceString('satisfies:10495#AC2')).toThrow(EvidenceParseError);
+    expect(() => parseEvidenceString('satisfies:task-10495#AC2')).toThrow(EvidenceParseError);
+  });
+
+  it('rejects atom with lowercase t prefix', () => {
+    expect(() => parseEvidenceString('satisfies:t10495#AC2')).toThrow(EvidenceParseError);
+  });
+
+  it('rejects atom with task-id exceeding 7 digits', () => {
+    expect(() => parseEvidenceString('satisfies:T12345678#AC2')).toThrow(EvidenceParseError);
+  });
+
+  // ─── Malformed: ac-id ────────────────────────────────────────────────────
+
+  it('rejects atom with mixed-case UUID', () => {
+    // Council §2.2 strictness — silent dedupe prevention
+    expect(() =>
+      parseEvidenceString('satisfies:T10495#8F4A2C1E-B09D-4F6A-9C3E-7A1D4F8C0B2E'),
+    ).toThrow(EvidenceParseError);
+  });
+
+  it('rejects atom with ac-id that is neither UUID nor AC<digits> alias', () => {
+    expect(() => parseEvidenceString('satisfies:T10495#hello')).toThrow(EvidenceParseError);
+    expect(() => parseEvidenceString('satisfies:T10495#2')).toThrow(EvidenceParseError);
+  });
+
+  it('rejects atom with alias exceeding 4 digits', () => {
+    expect(() => parseEvidenceString('satisfies:T10495#AC10000')).toThrow(EvidenceParseError);
+  });
+
+  // ─── Malformed: version-pin ──────────────────────────────────────────────
+
+  it('rejects atom with malformed version-pin (not 14 digits)', () => {
+    expect(() => parseEvidenceString('satisfies:T10495#AC2@2026-05-24')).toThrow(
+      EvidenceParseError,
+    );
+    expect(() => parseEvidenceString('satisfies:T10495#AC2@2026052422304')).toThrow(
+      EvidenceParseError,
+    );
+  });
+
+  it('rejects atom with @ but empty version-pin payload', () => {
+    expect(() => parseEvidenceString('satisfies:T10495#AC2@')).toThrow(EvidenceParseError);
+  });
+
+  // ─── Error message smoke: ensures kind name appears in default-case ──────
+
+  it('includes "satisfies" in the unknown-kind error suggestion list', () => {
+    try {
+      parseEvidenceString('unknownkind:foo');
+      throw new Error('expected EvidenceParseError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EvidenceParseError);
+      expect((err as EvidenceParseError).fix).toContain('satisfies');
+    }
+  });
+});

--- a/packages/contracts/src/evidence-atom-schema.ts
+++ b/packages/contracts/src/evidence-atom-schema.ts
@@ -196,6 +196,117 @@ export const callsiteCoverageAtomSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// ADR-079-r2: satisfies atom — cross-task AC binding
+// ---------------------------------------------------------------------------
+
+/**
+ * Strict UUIDv4 regex (lowercase, hyphenated 8-4-4-4-12 with the `4` major
+ * version nibble and `[89ab]` variant nibble) per ADR-079-r2 §2.1 ABNF
+ * (`ac-uuid` production) and RFC 9562 §5.4. Used by the `satisfies:` atom
+ * to validate the target-AC UUID form.
+ *
+ * Validators MUST reject mixed-case to prevent silent dedupe failures — the
+ * canonical column casing is lowercase per ADR-079-r1 §2.1.
+ *
+ * @task T10506
+ * @adr ADR-079-r2 §2.1
+ */
+export const AC_UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+/**
+ * Positional-alias regex for `satisfies:` atom target-AC identifiers per
+ * ADR-079-r2 §2.1 ABNF (`ac-alias` production). Format: `AC<1-4 digits>`
+ * (capped at AC9999 — three orders of magnitude above realistic per-task AC
+ * counts).
+ *
+ * @task T10506
+ * @adr ADR-079-r2 §2.1
+ */
+export const AC_ALIAS_REGEX = /^AC[0-9]{1,4}$/;
+
+/**
+ * Task-id regex for `satisfies:` atom target-task identifiers per ADR-079-r2
+ * §2.1 ABNF (`task-id` production). Format: `T<1-7 digits>` (capped at
+ * T9999999 — three orders of magnitude above current CLEO task IDs as of
+ * 2026-05-24).
+ *
+ * @task T10506
+ * @adr ADR-079-r2 §2.1
+ */
+export const SATISFIES_TASK_ID_REGEX = /^T[0-9]{1,7}$/;
+
+/**
+ * Version-pin regex for `satisfies:` atom optional `@<ts>` suffix per
+ * ADR-079-r2 §2.1 ABNF (`version-pin` production). Format: `YYYYMMDDhhmmss`
+ * (ISO-8601-basic timestamp, 14 digits).
+ *
+ * @task T10506
+ * @adr ADR-079-r2 §2.1
+ */
+export const SATISFIES_VERSION_PIN_REGEX = /^[0-9]{14}$/;
+
+/**
+ * `satisfies:<task-id>#<ac-id>[@<version-pin>]` atom — cross-task AC binding
+ * per ADR-079-r2 §2.1 (full grammar) and ADR-079-r1 §2.4 (basic shape).
+ *
+ * Format:
+ *
+ *   - `satisfies:T1234#a1b2c3d4-5e6f-4890-abcd-ef1234567890`   — canonical
+ *     UUID form (preferred for long-lived specs).
+ *   - `satisfies:T1234#AC2`                                    — positional
+ *     alias form (preferred in fresh PRs where the target task's AC list
+ *     is stable).
+ *   - `satisfies:T1234#AC2@20260524223045`                     — alias +
+ *     optional version-pin (Validator emissions where pin-on-mint is
+ *     required by ADR-079-r2 §3.4).
+ *
+ * Exactly ONE of `targetAcId` (UUID form) or `targetAcAlias` (alias form)
+ * is populated per parsed atom. `versionPin` is always optional.
+ *
+ * ## Scope
+ *
+ * This Zod schema covers PARSING ONLY. The runtime validator semantics —
+ * the 5-check accept/reject pipeline (target exists, target not terminal,
+ * AC exists, same-saga scope rule) — ship in T10507 alongside the
+ * `evidence_satisfies_bindings` side-effect table.
+ *
+ * Per ADR-079-r2 §2.2 the maximum atom length is 120 chars; the schema does
+ * NOT enforce length here because the per-field regexes already cap the
+ * surface (`satisfies:` + 8-char T+digits + `#` + 36-char UUID + `@` +
+ * 14-char pin = 78 chars max — well under 120).
+ *
+ * @task T10506
+ * @adr ADR-079-r2 §2.1
+ * @adr ADR-079-r1 §2.4
+ */
+export const satisfiesAtomSchema = z.object({
+  kind: z.literal('satisfies'),
+  /** Target task ID — `T<1-7 digits>` per ADR-079-r2 §2.1. */
+  targetTaskId: z
+    .string()
+    .regex(SATISFIES_TASK_ID_REGEX, 'satisfies atom targetTaskId must match /^T[0-9]{1,7}$/'),
+  /** Lowercase UUIDv4 — populated for the canonical form; undefined for alias form. */
+  targetAcId: z
+    .string()
+    .regex(AC_UUID_REGEX, 'satisfies atom targetAcId must be a lowercase UUIDv4')
+    .optional(),
+  /** Positional alias `AC<1-4 digits>` — populated for alias form; undefined for UUID form. */
+  targetAcAlias: z
+    .string()
+    .regex(AC_ALIAS_REGEX, 'satisfies atom targetAcAlias must match /^AC[0-9]{1,4}$/')
+    .optional(),
+  /** Optional `@<14-digit YYYYMMDDhhmmss>` pin captured at mint time. */
+  versionPin: z
+    .string()
+    .regex(
+      SATISFIES_VERSION_PIN_REGEX,
+      'satisfies atom versionPin must be 14 digits (YYYYMMDDhhmmss)',
+    )
+    .optional(),
+});
+
+// ---------------------------------------------------------------------------
 // Discriminated union
 // ---------------------------------------------------------------------------
 
@@ -218,6 +329,8 @@ export const callsiteCoverageAtomSchema = z.object({
  *   - `pr`                 — merged-PR retroactive proof (T9764 / T9838)
  *   - `loc-drop`           — engine-migration LOC reduction (T1604)
  *   - `callsite-coverage`  — exported-symbol production callsite (T1605)
+ *   - `satisfies`          — cross-task AC binding (T10506 / ADR-079-r2;
+ *                            validator semantics ship in T10507)
  *
  * @task T10337
  * @adr ADR-051
@@ -233,6 +346,7 @@ export const EvidenceAtomSchema = z.discriminatedUnion('kind', [
   prAtomSchema,
   locDropAtomSchema,
   callsiteCoverageAtomSchema,
+  satisfiesAtomSchema,
 ]);
 
 /**
@@ -383,6 +497,7 @@ const ATOM_EXAMPLES: Readonly<Record<EvidenceAtomKind, string>> = Object.freeze(
   pr: 'pr:357',
   'loc-drop': 'loc-drop:<fromLines>:<toLines>',
   'callsite-coverage': 'callsite-coverage:<symbolName>:<relativeSourcePath>',
+  satisfies: 'satisfies:T1234#AC2',
 });
 
 /**
@@ -718,6 +833,78 @@ export function parseEvidenceString(raw: string): EvidenceAtom[] {
         atoms.push({ kind: 'callsite-coverage', symbolName, relativeSourcePath });
         break;
       }
+      case 'satisfies': {
+        // ADR-079-r2 §2.1 ABNF:
+        //   satisfies-atom = "satisfies:" task-id "#" ac-id [ "@" version-pin ]
+        // Payload shape: <task-id>#<ac-id>[@<version-pin>]
+        //
+        // PARSING ONLY per T10506 — runtime validator semantics (5-check
+        // accept pipeline + same-saga scope rule) ship in T10507.
+        const hashIdx = payload.indexOf('#');
+        if (hashIdx < 1 || hashIdx === payload.length - 1) {
+          throw new EvidenceParseError(
+            `Malformed satisfies atom: "${chunk}" (expected satisfies:<task-id>#<ac-id>[@<version-pin>])`,
+            'Use format: satisfies:T1234#AC2 or satisfies:T1234#<uuid> e.g. satisfies:T10506#AC1',
+          );
+        }
+        const targetTaskId = payload.slice(0, hashIdx).trim();
+        const acAndPin = payload.slice(hashIdx + 1).trim();
+
+        // task-id must match strict ABNF /^T[0-9]{1,7}$/
+        if (!SATISFIES_TASK_ID_REGEX.test(targetTaskId)) {
+          throw new EvidenceParseError(
+            `satisfies atom targetTaskId "${targetTaskId}" must match /^T[0-9]{1,7}$/ in "${chunk}"`,
+            'Use format: satisfies:T<digits>#<ac-id> e.g. satisfies:T1234#AC2',
+          );
+        }
+
+        // Split optional version-pin (after `@`)
+        const atIdx = acAndPin.indexOf('@');
+        let acIdRaw: string;
+        let versionPin: string | undefined;
+        if (atIdx === -1) {
+          acIdRaw = acAndPin;
+          versionPin = undefined;
+        } else {
+          if (atIdx < 1 || atIdx === acAndPin.length - 1) {
+            throw new EvidenceParseError(
+              `Malformed satisfies atom version-pin in "${chunk}" (expected <ac-id>@<14-digit YYYYMMDDhhmmss>)`,
+              'Use format: satisfies:T1234#AC2@20260524223045',
+            );
+          }
+          acIdRaw = acAndPin.slice(0, atIdx).trim();
+          versionPin = acAndPin.slice(atIdx + 1).trim();
+          if (!SATISFIES_VERSION_PIN_REGEX.test(versionPin)) {
+            throw new EvidenceParseError(
+              `satisfies atom versionPin "${versionPin}" must be 14 digits (YYYYMMDDhhmmss) in "${chunk}"`,
+              'Use format: satisfies:T1234#AC2@<YYYYMMDDhhmmss> e.g. satisfies:T1234#AC2@20260524223045',
+            );
+          }
+        }
+
+        // ac-id is EITHER a strict UUIDv4 OR an AC<digits> alias — exactly one.
+        let targetAcId: string | undefined;
+        let targetAcAlias: string | undefined;
+        if (AC_UUID_REGEX.test(acIdRaw)) {
+          targetAcId = acIdRaw;
+        } else if (AC_ALIAS_REGEX.test(acIdRaw)) {
+          targetAcAlias = acIdRaw;
+        } else {
+          throw new EvidenceParseError(
+            `satisfies atom ac-id "${acIdRaw}" must be either a lowercase UUIDv4 or AC<1-4 digits> in "${chunk}"`,
+            'Use format: satisfies:T1234#AC2 (alias) or satisfies:T1234#<lowercase-uuidv4> (canonical)',
+          );
+        }
+
+        atoms.push({
+          kind: 'satisfies',
+          targetTaskId,
+          ...(targetAcId !== undefined ? { targetAcId } : {}),
+          ...(targetAcAlias !== undefined ? { targetAcAlias } : {}),
+          ...(versionPin !== undefined ? { versionPin } : {}),
+        });
+        break;
+      }
       case 'state': {
         // T9838: explicit-form modifier for the preceding pr: atom.
         // Format: pr:<num>;state:MERGED. The resolver always requires
@@ -743,7 +930,7 @@ export function parseEvidenceString(raw: string): EvidenceAtom[] {
       default:
         throw new EvidenceParseError(
           `Unknown evidence kind: "${kind}" in atom "${chunk}"`,
-          'Valid kinds: commit, files, test-run, tool, url, note, loc-drop, callsite-coverage, decision, pr, state',
+          'Valid kinds: commit, files, test-run, tool, url, note, loc-drop, callsite-coverage, decision, pr, satisfies, state',
         );
     }
   }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -480,6 +480,8 @@ export type {
   GateEvidenceRequirement,
 } from './evidence-atom-schema.js';
 export {
+  AC_ALIAS_REGEX,
+  AC_UUID_REGEX,
   callsiteCoverageAtomSchema,
   commitAtomSchema,
   decisionAtomSchema,
@@ -493,6 +495,9 @@ export {
   noteAtomSchema,
   parseEvidenceString,
   prAtomSchema,
+  SATISFIES_TASK_ID_REGEX,
+  SATISFIES_VERSION_PIN_REGEX,
+  satisfiesAtomSchema,
   testRunAtomSchema,
   toolAtomSchema,
   urlAtomSchema,

--- a/packages/contracts/src/task.ts
+++ b/packages/contracts/src/task.ts
@@ -306,6 +306,45 @@ export type EvidenceAtom =
       successCount: number;
       /** Total number of checks evaluated in the rollup. */
       totalChecks: number;
+    }
+  | {
+      /**
+       * Satisfies atom — cross-task acceptance-criterion binding per
+       * ADR-079-r2.
+       *
+       * Carries the parsed form (one of `targetAcId` UUID or
+       * `targetAcAlias` `AC<digits>` will be populated; optional
+       * `versionPin` captures the target AC's `updated_at` at mint time)
+       * plus the validator-canonical `resolvedAcUuid` populated by the
+       * T10507 5-check pipeline (target exists, not terminal, AC exists,
+       * same-saga scope). T10506 only ships the parser — the validated
+       * form is reserved here so consumers of `EvidenceAtom` (sentinel
+       * tables, gate-checkers, audit logs) can pattern-match on
+       * `kind === 'satisfies'` from day one.
+       *
+       * Format: `satisfies:<task-id>#<ac-id>[@<version-pin>]`
+       *   - `satisfies:T1234#a1b2c3d4-5e6f-4890-abcd-ef1234567890` (UUID)
+       *   - `satisfies:T1234#AC2`                                  (alias)
+       *   - `satisfies:T1234#AC2@20260524223045`                   (pin)
+       *
+       * @task T10506
+       * @adr ADR-079-r2
+       */
+      kind: 'satisfies';
+      /** Target task ID — `T<1-7 digits>` per ADR-079-r2 §2.1. */
+      targetTaskId: string;
+      /** Lowercase UUIDv4 — populated for canonical form; undefined for alias form. */
+      targetAcId?: string;
+      /** `AC<1-4 digits>` alias — populated for alias form; undefined for UUID form. */
+      targetAcAlias?: string;
+      /** Optional `@<YYYYMMDDhhmmss>` pin captured at mint time. */
+      versionPin?: string;
+      /**
+       * Canonical UUID resolved by the T10507 validator from `targetAcId`
+       * (already canonical) or by looking up `(targetTaskId, alias-ordinal)`.
+       * Reserved here for forward compatibility; undefined under T10506.
+       */
+      resolvedAcUuid?: string;
     };
 
 /**

--- a/packages/core/src/tasks/evidence.ts
+++ b/packages/core/src/tasks/evidence.ts
@@ -188,6 +188,32 @@ export type ParsedAtom =
       kind: 'pr';
       /** PR number (positive integer). */
       prNumber: number;
+    }
+  | {
+      /**
+       * Cross-task AC-binding atom — references an acceptance criterion on
+       * another task in the same Saga (or root Epic when no Saga). The atom
+       * carries either the canonical UUIDv4 (`targetAcId`) OR the positional
+       * alias (`targetAcAlias`) — never both, never neither. Optional
+       * `versionPin` captures the target AC's `updated_at` at mint time.
+       *
+       * This entry covers PARSING ONLY (T10506); the 5-check validator
+       * semantics (target exists, target not terminal, AC exists, same-saga
+       * scope) ship in T10507. See ADR-079-r2 §2.1 for the ABNF and §2.4
+       * for the runtime validator contract.
+       *
+       * @task T10506
+       * @adr ADR-079-r2
+       */
+      kind: 'satisfies';
+      /** Target task ID — `T<1-7 digits>` per ADR-079-r2 §2.1. */
+      targetTaskId: string;
+      /** Lowercase UUIDv4 — populated for canonical form; undefined for alias form. */
+      targetAcId?: string;
+      /** `AC<1-4 digits>` alias — populated for alias form; undefined for UUID form. */
+      targetAcAlias?: string;
+      /** Optional `@<YYYYMMDDhhmmss>` pin captured at mint time. */
+      versionPin?: string;
     };
 
 /**
@@ -282,6 +308,21 @@ export async function validateAtom(
       return validateDecision(parsed.decisionId, projectRoot);
     case 'pr':
       return validatePrAtom(parsed.prNumber, projectRoot);
+    case 'satisfies':
+      // ADR-079-r2: parser accepted in T10506; 5-check validator semantics
+      // (target exists, target not terminal, AC exists, same-saga scope)
+      // ship in T10507. Until then, surface a deferred-validator reason so
+      // callers see exactly why the atom was rejected. Tests for the parser
+      // itself live in __tests__/satisfies-atom.test.ts and never call
+      // validateAtom — they exercise parseEvidenceString directly.
+      return {
+        ok: false,
+        reason:
+          `satisfies:<task-id>#<ac-id> validator semantics ship in T10507 — ` +
+          `parser accepted (T10506), runtime checks pending. ` +
+          `Target: ${parsed.targetTaskId}#${parsed.targetAcId ?? parsed.targetAcAlias ?? '?'}`,
+        codeName: 'E_AC_BINDING_VALIDATOR_PENDING',
+      };
     default: {
       // Exhaustiveness check — never reachable if ParsedAtom is complete.
       return { ok: false, reason: `Unknown parsed atom`, codeName: 'E_EVIDENCE_INVALID' };
@@ -1489,6 +1530,14 @@ export async function revalidateEvidence(
         // time. A merged PR's mergedAt is immutable, so the atom is trusted
         // as captured. Re-validation would require another `gh` round trip
         // and add network dependency to every `cleo complete` invocation.
+        break;
+      case 'satisfies':
+        // ADR-079-r2: satisfies bindings resolve to evidence_satisfies_bindings
+        // rows owned by the T10507 validator. The row's target_ac_uuid is the
+        // immutable canonical form; the W_AC_ALIAS_DRIFTED warning surface
+        // (validator-side) gives the author one cycle to update before the
+        // next verify rejects. No re-validation at complete time — the
+        // recorded canonical UUID is the immutable trust surface.
         break;
       default:
         // Exhaustiveness — unreachable if EvidenceAtom is complete.


### PR DESCRIPTION
## Summary

Closes **T10506** (Saga **T10377** SG-IVTR-AC-BINDING, Epic **T10381**, Decision **D013**). Wave 2b of the SG-IVTR-AC-BINDING saga — Wave 2a shipped the storage substrate (T10502 `task_acceptance_criteria`, T10503 `evidence_ac_bindings`, T10504 AC history). This PR adds the **grammar/parser** layer.

Adds the `satisfies:<task-id>#<ac-id>[@<version-pin>]` evidence atom kind to the ADR-051 grammar per [ADR-079-r2 §2.1 ABNF](https://github.com/kryptobaseddev/cleo/blob/main/.cleo/adrs/adr-079-r2-satisfies-binding.md).

**PARSING ONLY** — guardrail-honored per task spec. The 5-check validator semantics (target task exists, target not terminal, AC exists by UUID-or-alias lookup, same-saga scope rule per ADR-079-r2 §2.3, alias-drift detection) ship in **T10507** alongside the `evidence_satisfies_bindings` side-effect table writes. Until T10507 lands, the runtime validator returns `E_AC_BINDING_VALIDATOR_PENDING` to make the deferral explicit.

### Accepted atom forms (all syntactically valid; semantics validated in T10507)

- `satisfies:T10495#8f4a2c1e-b09d-4f6a-9c3e-7a1d4f8c0b2e` — canonical UUID
- `satisfies:T10495#AC2` — positional alias
- `satisfies:T10495#AC2@20260524223045` — alias + version-pin
- `satisfies:T10495#8f4a2c1e-...@20260524223045` — canonical + pin (highest-trust)

### Strict per-field grammar (ADR-079-r2 §2.1)

| Field | Regex | Notes |
|---|---|---|
| `task-id` | `/^T[0-9]{1,7}$/` | Caps at T9999999 |
| `ac-uuid` | strict lowercase UUIDv4 | Mixed-case rejected (silent-dedupe prevention) |
| `ac-alias` | `/^AC[0-9]{1,4}$/` | Caps at AC9999 |
| `version-pin` | `/^[0-9]{14}$/` | YYYYMMDDhhmmss |

## Surfaces touched

- `packages/contracts/src/evidence-atom-schema.ts` — `satisfiesAtomSchema` Zod discriminator, exported regex constants, parser case in `parseEvidenceString`.
- `packages/contracts/src/index.ts` — barrel exports for the new schema + regexes.
- `packages/contracts/src/task.ts` — validated `EvidenceAtom` union gains `satisfies` shape with reserved `resolvedAcUuid` for T10507.
- `packages/core/src/tasks/evidence.ts` — `ParsedAtom` union extended; `validateAtom` + runtime re-validation switch updated.
- `packages/contracts/src/__tests__/satisfies-atom.test.ts` — **46 new test cases**.

## Test plan

- [x] `pnpm exec biome check packages/contracts/src/... packages/core/src/tasks/evidence.ts` → clean
- [x] `pnpm run build` (full workspace) → green in 24s
- [x] `pnpm --filter @cleocode/contracts exec vitest run` → **609 tests passing** (46 new + 563 existing)
- [x] `pnpm --filter @cleocode/core exec vitest run src/tasks/__tests__/evidence.test.ts src/tasks/__tests__/evidence-content-intersect.test.ts src/release/__tests__/evidence-pr-atom.test.ts` → 121 tests passing (no regression from union shape change)
- [x] `node scripts/lint-changesets.mjs` → 162 entries valid
- [ ] Merge unblocks **T10507** (validator semantics) to enter Wave 2c

🤖 Generated with [Claude Code](https://claude.com/claude-code)