### PR TITLE
feat(T10505): backfill task_acceptance_criteria from legacy acceptance_json

### DIFF
--- a/.changeset/t10505-ac-backfill.md
+++ b/.changeset/t10505-ac-backfill.md
@@ -1,0 +1,14 @@
+---
+id: t10505-ac-backfill
+tasks: [T10505]
+kind: feat
+summary: "migration: backfill task_acceptance_criteria from tasks.acceptance_json (T10381 Wave 2b)"
+---
+
+Idempotent SQL-only data migration that walks every row in `tasks` and expands its legacy `acceptance_json` array into first-class `task_acceptance_criteria` rows (Saga T10377 SG-IVTR-AC-BINDING, Epic T10381 E-AC-MIGRATION). Wave 2b — PR 4 of 8 in the AC-binding migration train. Sits atop the Wave 2a schemas (T10502 AC table, T10503 evidence bindings, T10504 history) and is the first migration to write data, not just DDL.
+
+Each non-empty, non-whitespace AC entry becomes one row with a UUIDv4 `id` (generated in pure SQL via `printf`/`randomblob` — RFC 4122 version + variant bits both forced) and a 1-based `ordinal` derived from `ROW_NUMBER() OVER (PARTITION BY task_id)` preserving authorship order. Empty arrays, NULL columns, and malformed JSON are skipped via a `json_valid`/`json_type` CASE guard that wraps the input to `json_each` — without it a single bad row would abort the migration. Plain-text and `{criteria: "..."}` object element shapes are both handled (matching `parseAcceptanceJson` in `hygiene-scan.ts`). Whitespace is stripped with `trim(x, char(9,10,13,32))` because SQLite's default `trim()` only strips ASCII space.
+
+Every backfilled AC also gets one `task_acceptance_criteria_history` audit row with `reason='backfill'` and `previous_text = ac.text`. Both inserts are gated by `NOT EXISTS` clauses — re-running the SQL produces zero net new rows. The legacy `tasks.acceptance_json` column is NEVER altered or dropped; back-compat read paths (hygiene-scan, workflow-telemetry) continue to resolve through it until the cutover wave later in Epic T10381.
+
+Migration: `packages/core/migrations/drizzle-tasks/20260524000005_t10505-ac-backfill/{migration,revert}.sql`. Tests: `packages/core/src/store/__tests__/t10505-ac-backfill.test.ts` (18 tests covering SQL content, end-to-end fresh-DB apply across 9 fixture shapes, idempotency, ordinal assignment, UUIDv4 shape, history-row creation, whitespace/empty/NULL/malformed handling, and legacy-column preservation).

--- a/packages/core/migrations/drizzle-tasks/20260524000005_t10505-ac-backfill/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260524000005_t10505-ac-backfill/migration.sql
@@ -1,0 +1,187 @@
+-- T10505 — Backfill `task_acceptance_criteria` from legacy `tasks.acceptance_json`.
+--
+-- Wave 2b of Epic T10381 (E-AC-MIGRATION) under Saga T10377
+-- (SG-IVTR-AC-BINDING). PR 4 of 8 in the AC-binding migration train.
+--
+-- ## What this migration does
+--
+--   Step 1: For every task whose `acceptance_json` column contains a
+--           non-empty JSON array AND has NO existing rows in
+--           `task_acceptance_criteria`, expand each non-empty array
+--           element into a row in `task_acceptance_criteria`. The
+--           UUIDv4 `id` is generated in pure SQL via the canonical
+--           `printf` + `randomblob` pattern (see "UUID generation"
+--           below). The `ordinal` is the 1-based position within the
+--           source JSON array (preserving authorship order).
+--
+--   Step 2: For every newly-backfilled AC row that has NO existing
+--           `task_acceptance_criteria_history` row with reason='backfill',
+--           insert an audit row recording the original AC text and
+--           reason='backfill'. The history table's `ac_id` column is
+--           plain TEXT (not an FK, per T10504 design) so this works
+--           even though the AC rows were just inserted.
+--
+-- ## Why pure SQL (no JS data-migration runner)
+--
+-- CLEO's migration runtime (`packages/core/src/store/migration-manager.ts`)
+-- applies plain `.sql` files via drizzle-orm's `migrate()`. There is no
+-- post-DDL JavaScript callback hook (see the runtime contract in
+-- `packages/core/migrations/README.md` §"Runtime Contract"). Adding one
+-- would be an architectural change far larger than this backfill warrants.
+--
+-- Per AC8 the migration must handle: pipe/JSON-split correctness,
+-- idempotency, ordinal assignment, history-row creation, whitespace
+-- skipping — all of which SQLite's `json_each` + window functions
+-- support natively.
+--
+-- ## UUID generation (UUIDv4 in pure SQL)
+--
+-- The canonical writer path uses `crypto.randomUUID()` (Node 24 native).
+-- For migration-time backfill we must generate compatible UUIDv4s
+-- without a JS callback. SQLite's `randomblob(N)` returns N
+-- cryptographically-random bytes; `hex(...)` formats them as
+-- lowercase hex. We then assemble the canonical
+-- `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` UUIDv4 shape:
+--
+--   * Hex digit at position 13 is forced to `4` (version 4).
+--   * Hex digit at position 17 is forced to one of `8|9|a|b` (RFC 4122
+--     variant), selected uniformly from `'89ab'` via `abs(random()) % 4`.
+--
+-- The generated IDs are indistinguishable from `crypto.randomUUID()`
+-- output for downstream consumers. Collision probability with the
+-- existing PK space is 2^-122 — astronomically lower than a single
+-- hardware bit-flip on the same machine.
+--
+-- ## Idempotency contract (AC2)
+--
+-- The Step 1 `INSERT ... SELECT` is gated by
+--   `NOT EXISTS (SELECT 1 FROM task_acceptance_criteria ac
+--                WHERE ac.task_id = t.id)`
+-- This guarantees that re-running the migration on a DB whose AC table
+-- is already populated for the source task produces ZERO new rows. The
+-- Step 2 history insert is gated by
+--   `NOT EXISTS (SELECT 1 FROM task_acceptance_criteria_history h
+--                WHERE h.ac_id = ac.id AND h.reason = 'backfill')`
+-- which guarantees no duplicate audit rows on re-application.
+--
+-- Per the runtime contract, drizzle-orm's `__drizzle_migrations` journal
+-- already prevents re-application under normal operation; the gates
+-- above harden against journal-bypass recovery paths (Scenario 3 in
+-- migration-manager.ts).
+--
+-- ## Whitespace and shape handling (AC4 + AC5)
+--
+-- The CASE inside `split_ac` handles two `acceptance_json` element
+-- shapes observed in the wild (matching `parseAcceptanceJson` in
+-- `packages/core/src/sentient/hygiene-scan.ts`):
+--
+--   * Plain text: element is a JSON string, `j.type = 'text'`,
+--     `j.value` IS the raw text (NOT a quoted JSON literal).
+--   * Object form: element is `{"criteria": "..."}`, `j.type =
+--     'object'`, `j.value` is the JSON object string; we extract
+--     `$.criteria` via `json_extract`.
+--
+-- Each extracted text is `trim(..., char(9,10,13,32))`ed — explicit
+-- char set covers tab/newline/CR/space because SQLite's default
+-- `trim(x)` strips ASCII space ONLY. Any element trimming to the
+-- empty string is filtered out by the trailing `WHERE ac_text != ''`.
+-- This skips whitespace-only and empty-string elements per AC5.
+--
+-- ## Malformed-JSON safety
+--
+-- We wrap the `acceptance_json` input to `json_each(...)` in a CASE
+-- expression that returns `'[]'` whenever the value is NULL, not
+-- valid JSON, or not a JSON array. Without this guard, a single
+-- malformed row anywhere in `tasks` would abort the entire migration
+-- because `json_each` raises `SQLITE_ERROR: malformed JSON` at plan
+-- time. (Empirically verified — `json_valid` short-circuits inside
+-- a CASE but the `json_each(t.col)` form does not.)
+--
+-- ## Legacy column preservation (AC7)
+--
+-- This migration is READ-ONLY against `tasks.acceptance_json`. The
+-- column is NEVER altered or dropped — back-compat read paths
+-- (hygiene-scan, workflow-telemetry, etc.) still resolve AC text
+-- through `acceptance_json` until the cutover wave later in Epic
+-- T10381 retires it.
+--
+-- DEPENDS ON:
+--   * 20260524000002_t10502-task-acceptance-criteria   (AC table)
+--   * 20260524000004_t10504-ac-history                 (history table)
+-- Timestamp seconds `05` orders this AFTER both.
+--
+-- SAFE FOR: SQLite 3.35+ (RETURNING, window functions, json_each all GA).
+--
+-- @adr  ADR-079-r1 §2.1 §2.2 §D6
+-- @saga T10377
+-- @epic T10381
+-- @task T10505
+-- @decision D013
+
+-- ── Step 1: Expand acceptance_json into task_acceptance_criteria rows ──
+-- The CASE-wrapped json_each guards against malformed inputs without
+-- aborting the migration. The NOT EXISTS clause makes this idempotent.
+-- ROW_NUMBER() OVER (PARTITION BY task_id) emits the 1-based ordinal.
+WITH split_ac AS (
+  SELECT
+    t.`id`         AS task_id,
+    j.`key`        AS json_idx,
+    trim(
+      CASE
+        WHEN j.`type` = 'text'   THEN j.`value`
+        WHEN j.`type` = 'object' THEN COALESCE(json_extract(j.`value`, '$.criteria'), '')
+        ELSE ''
+      END,
+      char(9, 10, 13, 32)
+    )              AS ac_text
+  FROM `tasks` t, json_each(
+    CASE
+      WHEN t.`acceptance_json` IS NOT NULL
+        AND json_valid(t.`acceptance_json`)
+        AND json_type(t.`acceptance_json`) = 'array'
+      THEN t.`acceptance_json`
+      ELSE '[]'
+    END
+  ) j
+  WHERE NOT EXISTS (
+    SELECT 1
+      FROM `task_acceptance_criteria` ac
+     WHERE ac.`task_id` = t.`id`
+  )
+)
+INSERT INTO `task_acceptance_criteria` (`id`, `task_id`, `ordinal`, `text`)
+SELECT
+  -- UUIDv4 in pure SQL: see "UUID generation" header comment.
+  printf(
+    '%s-%s-4%s-%s%s-%s',
+    lower(hex(randomblob(4))),
+    lower(hex(randomblob(2))),
+    substr(lower(hex(randomblob(2))), 2, 3),
+    substr('89ab', abs(random()) % 4 + 1, 1),
+    substr(lower(hex(randomblob(2))), 2, 3),
+    lower(hex(randomblob(6)))
+  ),
+  `task_id`,
+  ROW_NUMBER() OVER (PARTITION BY `task_id` ORDER BY `json_idx`),
+  `ac_text`
+FROM `split_ac`
+WHERE `ac_text` != '';
+--> statement-breakpoint
+
+-- ── Step 2: Append backfill history rows for every newly-created AC ──
+-- The history table has no FK on ac_id (T10504 design — orphan-tolerant
+-- for drift forensics) so this works against the rows we just inserted.
+-- The NOT EXISTS clause prevents duplicate backfill audit rows on
+-- re-application of the migration.
+INSERT INTO `task_acceptance_criteria_history` (`ac_id`, `previous_text`, `reason`)
+SELECT
+  ac.`id`,
+  ac.`text`,
+  'backfill'
+FROM `task_acceptance_criteria` ac
+WHERE NOT EXISTS (
+  SELECT 1
+    FROM `task_acceptance_criteria_history` h
+   WHERE h.`ac_id`  = ac.`id`
+     AND h.`reason` = 'backfill'
+);

--- a/packages/core/migrations/drizzle-tasks/20260524000005_t10505-ac-backfill/revert.sql
+++ b/packages/core/migrations/drizzle-tasks/20260524000005_t10505-ac-backfill/revert.sql
@@ -1,0 +1,25 @@
+-- Revert T10505 — remove backfill rows from `task_acceptance_criteria`
+-- + `task_acceptance_criteria_history`.
+--
+-- Reverts the two INSERTs in the forward migration:
+--   * Step 1: backfilled AC rows. We delete every AC row whose `id`
+--     appears in a `task_acceptance_criteria_history` row with
+--     `reason='backfill'` — i.e. the rows this migration created.
+--     ACs created by post-backfill writers (which would have a
+--     `reason='edit'` or no history at all) are PRESERVED.
+--   * Step 2: backfill history rows. Drop them by `reason`.
+--
+-- Order: AC rows first, then history rows. The AC delete reads the
+-- history table to identify backfill-origin rows, so it must run
+-- before the history rows are removed.
+
+DELETE FROM `task_acceptance_criteria`
+WHERE `id` IN (
+  SELECT `ac_id`
+    FROM `task_acceptance_criteria_history`
+   WHERE `reason` = 'backfill'
+);
+--> statement-breakpoint
+
+DELETE FROM `task_acceptance_criteria_history`
+WHERE `reason` = 'backfill';

--- a/packages/core/src/store/__tests__/t10505-ac-backfill.test.ts
+++ b/packages/core/src/store/__tests__/t10505-ac-backfill.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Backfill verification for the T10505 data migration:
+ *   `task_acceptance_criteria` populated from legacy `tasks.acceptance_json`.
+ *
+ * Wave 2b of Epic T10381 (E-AC-MIGRATION) under Saga T10377
+ * (SG-IVTR-AC-BINDING). PR 4 of 8 in the AC-binding migration train.
+ *
+ * Each test validates that:
+ *   1. Migration SQL content references the canonical inputs/outputs
+ *      and contains the documented idempotency + whitespace guards.
+ *   2. End-to-end fresh-DB apply seeds rows from a representative
+ *      `acceptance_json` fixture (mixed shapes: text-only, object-form,
+ *      whitespace-only, empty, malformed, NULL).
+ *   3. Idempotency — re-running the entire migration suite from the
+ *      same data folder yields zero net new rows (per AC2).
+ *   4. Ordinal assignment is 1-based and preserves JSON array order.
+ *   5. History rows are created with `reason='backfill'` for each
+ *      backfilled AC and the `previous_text` matches the AC text
+ *      (per AC3).
+ *   6. Whitespace-only and empty-string array elements are skipped
+ *      with no AC rows created (per AC4 + AC5).
+ *   7. Empty/null `acceptance_json` produces zero AC rows (per AC4).
+ *   8. The legacy `tasks.acceptance_json` column survives the
+ *      migration intact (per AC7).
+ *
+ * @adr  ADR-079-r1 §2.1 §2.2 §D6
+ * @task T10505
+ * @epic T10381
+ * @saga T10377
+ * @decision D013
+ */
+
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const MIGRATION_FOLDER_TOKEN = 't10505';
+
+/** Absolute path to the drizzle-tasks migration folder. */
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+/** Read the T10505 migration SQL as a string. */
+function readMigrationSql(): string {
+  const dir = migrationsDir();
+  const folder = readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .find((name) => name.includes(MIGRATION_FOLDER_TOKEN));
+  if (!folder) {
+    throw new Error(`T10505 migration folder not found under ${dir}`);
+  }
+  return readFileSync(join(dir, folder, 'migration.sql'), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Section 1: Migration SQL content checks
+// ---------------------------------------------------------------------------
+
+describe('T10505 backfill migration SQL', () => {
+  it('reads from tasks.acceptance_json', () => {
+    const sql = readMigrationSql();
+    expect(sql).toMatch(/`acceptance_json`/);
+    expect(sql).toMatch(/json_each\s*\(/);
+  });
+
+  it('inserts into task_acceptance_criteria', () => {
+    const sql = readMigrationSql();
+    expect(sql).toMatch(/INSERT INTO\s+`task_acceptance_criteria`/);
+  });
+
+  it('inserts backfill rows into task_acceptance_criteria_history', () => {
+    const sql = readMigrationSql();
+    expect(sql).toMatch(/INSERT INTO\s+`task_acceptance_criteria_history`/);
+    expect(sql).toMatch(/'backfill'/);
+  });
+
+  it('idempotency: AC insert is gated by NOT EXISTS', () => {
+    const sql = readMigrationSql();
+    expect(sql).toMatch(/NOT EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+`task_acceptance_criteria`/i);
+  });
+
+  it('idempotency: history insert is gated by NOT EXISTS on reason=backfill', () => {
+    const sql = readMigrationSql();
+    expect(sql).toMatch(
+      /NOT EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+`task_acceptance_criteria_history`/i,
+    );
+  });
+
+  it('uses ROW_NUMBER OVER PARTITION BY task_id for ordinal assignment', () => {
+    const sql = readMigrationSql();
+    expect(sql).toMatch(/ROW_NUMBER\s*\(\s*\)\s+OVER\s*\(\s*PARTITION BY/i);
+  });
+
+  it('guards malformed acceptance_json via CASE-wrapped json_each input', () => {
+    const sql = readMigrationSql();
+    expect(sql).toMatch(/json_valid/i);
+    expect(sql).toMatch(/json_type/i);
+  });
+
+  it('skips whitespace-only entries via trim and WHERE ac_text != ""', () => {
+    const sql = readMigrationSql();
+    expect(sql).toMatch(/trim\s*\(/i);
+    expect(sql).toMatch(/ac_text\s*!=\s*''/);
+  });
+
+  it('NEVER alters or drops tasks.acceptance_json (AC7)', () => {
+    const sql = readMigrationSql();
+    expect(sql).not.toMatch(/ALTER\s+TABLE\s+`?tasks`?[\s\S]*acceptance_json/i);
+    expect(sql).not.toMatch(/DROP\s+COLUMN\s+`?acceptance_json`?/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 2: End-to-end fresh-DB apply + backfill behaviour
+// ---------------------------------------------------------------------------
+
+/**
+ * Representative `acceptance_json` fixture covering every shape the
+ * backfill is expected to handle. Inserted BEFORE the migration runs
+ * so the AC table is empty at backfill-time (matching production
+ * upgrade conditions).
+ */
+const FIXTURE_TASKS: ReadonlyArray<{
+  id: string;
+  title: string;
+  acceptanceJson: string | null;
+  expectedAcCount: number;
+  expectedTexts: ReadonlyArray<string>;
+}> = [
+  {
+    id: 'T-multi',
+    title: 'multiple plain-text ACs',
+    acceptanceJson: JSON.stringify(['first AC', 'second AC', 'third AC']),
+    expectedAcCount: 3,
+    expectedTexts: ['first AC', 'second AC', 'third AC'],
+  },
+  {
+    id: 'T-single',
+    title: 'single AC',
+    acceptanceJson: JSON.stringify(['only AC']),
+    expectedAcCount: 1,
+    expectedTexts: ['only AC'],
+  },
+  {
+    id: 'T-object',
+    title: 'object-form ACs with criteria field',
+    acceptanceJson: JSON.stringify([{ criteria: 'object AC one' }, { criteria: 'object AC two' }]),
+    expectedAcCount: 2,
+    expectedTexts: ['object AC one', 'object AC two'],
+  },
+  {
+    id: 'T-mixed',
+    title: 'mixed string + object',
+    acceptanceJson: JSON.stringify(['plain AC', { criteria: 'object AC' }]),
+    expectedAcCount: 2,
+    expectedTexts: ['plain AC', 'object AC'],
+  },
+  {
+    id: 'T-whitespace',
+    title: 'whitespace-only entries interleaved with valid ones',
+    acceptanceJson: JSON.stringify(['  ', '\t\n', 'real AC', '']),
+    expectedAcCount: 1,
+    expectedTexts: ['real AC'],
+  },
+  {
+    id: 'T-empty-array',
+    title: 'empty acceptance_json array',
+    acceptanceJson: JSON.stringify([]),
+    expectedAcCount: 0,
+    expectedTexts: [],
+  },
+  {
+    id: 'T-null',
+    title: 'NULL acceptance_json',
+    acceptanceJson: null,
+    expectedAcCount: 0,
+    expectedTexts: [],
+  },
+  {
+    id: 'T-malformed',
+    title: 'malformed acceptance_json (not valid JSON)',
+    acceptanceJson: 'this is not JSON',
+    expectedAcCount: 0,
+    expectedTexts: [],
+  },
+  {
+    id: 'T-trim',
+    title: 'AC text that needs trimming',
+    acceptanceJson: JSON.stringify(['  padded  ', '\nnewlines\n']),
+    expectedAcCount: 2,
+    expectedTexts: ['padded', 'newlines'],
+  },
+];
+
+describe('T10505 backfill end-to-end on fresh tasks.db', () => {
+  let tempDir: string;
+  let nativeDb: import('node:sqlite').DatabaseSync;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-t10505-'));
+  });
+
+  afterEach(() => {
+    try {
+      nativeDb?.close();
+    } catch {
+      // Already closed.
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Apply only the schema-creation migrations (NOT T10505 itself),
+   * seed the fixture, then apply T10505. This matches the production
+   * upgrade path: legacy data exists, schema migrations run, backfill
+   * is the final step.
+   *
+   * Note: drizzle-orm's `migrate()` applies ALL pending migrations in
+   * one shot, so we cannot interleave seeding mid-stream. Instead we
+   * apply the full set, then manually clear AC rows + seed the source
+   * tasks + re-run the backfill SQL — which is what production looks
+   * like when a fresh-install user later upgrades to a CLEO version
+   * that already had legacy `acceptance_json` data.
+   *
+   * To simulate the realistic "schema-then-backfill" sequence we
+   * (a) run all migrations, (b) DELETE the AC + history rows that the
+   * backfill produced from any test-fixture or empty source, (c) seed
+   * the fixture tasks, (d) re-execute the backfill SQL directly. Step
+   * (d) tests the SQL itself; the journal already records T10505 as
+   * applied, so a re-`migrate()` call would be a no-op.
+   */
+  async function applyMigrationsAndBackfill(dbPath: string): Promise<void> {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    nativeDb = openNativeDatabase(dbPath);
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    // The migrate() call above already executed T10505 against an
+    // empty tasks table — there were no rows to backfill. Clear out
+    // any artefacts and seed the fixture.
+    nativeDb.exec('DELETE FROM `task_acceptance_criteria_history`;');
+    nativeDb.exec('DELETE FROM `task_acceptance_criteria`;');
+    nativeDb.exec('DELETE FROM `tasks`;');
+
+    const insertTask = nativeDb.prepare(
+      'INSERT INTO `tasks` (`id`, `title`, `status`, `priority`, `acceptance_json`) VALUES (?, ?, ?, ?, ?)',
+    );
+    for (const fixture of FIXTURE_TASKS) {
+      insertTask.run(fixture.id, fixture.title, 'pending', 'medium', fixture.acceptanceJson);
+    }
+
+    // Re-apply just the T10505 backfill SQL by reading the file
+    // directly. This is what we are actually testing.
+    const sql = readMigrationSql();
+    nativeDb.exec(sql);
+  }
+
+  it('creates AC rows for every non-empty, non-whitespace acceptance_json entry', async () => {
+    await applyMigrationsAndBackfill(join(tempDir, 'tasks-ac-rows.db'));
+
+    for (const fixture of FIXTURE_TASKS) {
+      const rows = nativeDb
+        .prepare(
+          'SELECT `id`, `task_id`, `ordinal`, `text` FROM `task_acceptance_criteria` WHERE `task_id` = ? ORDER BY `ordinal`',
+        )
+        .all(fixture.id) as Array<{ id: string; task_id: string; ordinal: number; text: string }>;
+
+      expect(rows.length, `${fixture.id} (${fixture.title}) AC count`).toBe(
+        fixture.expectedAcCount,
+      );
+      expect(
+        rows.map((r) => r.text),
+        `${fixture.id} (${fixture.title}) AC texts`,
+      ).toEqual([...fixture.expectedTexts]);
+    }
+  });
+
+  it('assigns ordinals 1,2,3,... per task preserving JSON array order (AC1)', async () => {
+    await applyMigrationsAndBackfill(join(tempDir, 'tasks-ordinals.db'));
+
+    const multiAc = nativeDb
+      .prepare(
+        'SELECT `ordinal`, `text` FROM `task_acceptance_criteria` WHERE `task_id` = ? ORDER BY `ordinal`',
+      )
+      .all('T-multi') as Array<{ ordinal: number; text: string }>;
+
+    expect(multiAc).toEqual([
+      { ordinal: 1, text: 'first AC' },
+      { ordinal: 2, text: 'second AC' },
+      { ordinal: 3, text: 'third AC' },
+    ]);
+  });
+
+  it('generates a UUIDv4-shaped id per AC row (AC1)', async () => {
+    await applyMigrationsAndBackfill(join(tempDir, 'tasks-uuid.db'));
+
+    const rows = nativeDb.prepare('SELECT `id` FROM `task_acceptance_criteria`').all() as Array<{
+      id: string;
+    }>;
+
+    expect(rows.length).toBeGreaterThan(0);
+    const uuidV4Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+    for (const row of rows) {
+      expect(row.id, `id ${row.id} matches UUIDv4 shape`).toMatch(uuidV4Pattern);
+    }
+
+    // Uniqueness across the AC table.
+    const ids = new Set(rows.map((r) => r.id));
+    expect(ids.size).toBe(rows.length);
+  });
+
+  it('records a backfill history row per AC with previous_text matching the AC text (AC3)', async () => {
+    await applyMigrationsAndBackfill(join(tempDir, 'tasks-history.db'));
+
+    const acRows = nativeDb
+      .prepare('SELECT `id`, `text` FROM `task_acceptance_criteria`')
+      .all() as Array<{ id: string; text: string }>;
+    const historyRows = nativeDb
+      .prepare(
+        "SELECT `ac_id`, `previous_text`, `reason` FROM `task_acceptance_criteria_history` WHERE `reason` = 'backfill'",
+      )
+      .all() as Array<{ ac_id: string; previous_text: string; reason: string }>;
+
+    expect(historyRows.length).toBe(acRows.length);
+
+    // Every AC has exactly one matching history row with previous_text = ac.text.
+    const histByAc = new Map(historyRows.map((h) => [h.ac_id, h]));
+    for (const ac of acRows) {
+      const hist = histByAc.get(ac.id);
+      expect(hist, `history row exists for AC ${ac.id}`).toBeDefined();
+      expect(hist?.previous_text).toBe(ac.text);
+      expect(hist?.reason).toBe('backfill');
+    }
+  });
+
+  it('is idempotent: re-running the SQL yields zero new rows (AC2)', async () => {
+    await applyMigrationsAndBackfill(join(tempDir, 'tasks-idempotency.db'));
+
+    const acCountBefore = (
+      nativeDb.prepare('SELECT count(*) AS c FROM `task_acceptance_criteria`').get() as {
+        c: number;
+      }
+    ).c;
+    const historyCountBefore = (
+      nativeDb.prepare('SELECT count(*) AS c FROM `task_acceptance_criteria_history`').get() as {
+        c: number;
+      }
+    ).c;
+
+    expect(acCountBefore).toBeGreaterThan(0);
+    expect(historyCountBefore).toBe(acCountBefore);
+
+    // Re-run the same backfill SQL.
+    const sql = readMigrationSql();
+    nativeDb.exec(sql);
+
+    const acCountAfter = (
+      nativeDb.prepare('SELECT count(*) AS c FROM `task_acceptance_criteria`').get() as {
+        c: number;
+      }
+    ).c;
+    const historyCountAfter = (
+      nativeDb.prepare('SELECT count(*) AS c FROM `task_acceptance_criteria_history`').get() as {
+        c: number;
+      }
+    ).c;
+
+    expect(acCountAfter).toBe(acCountBefore);
+    expect(historyCountAfter).toBe(historyCountBefore);
+
+    // A third application also stays stable.
+    nativeDb.exec(sql);
+    const acCountThird = (
+      nativeDb.prepare('SELECT count(*) AS c FROM `task_acceptance_criteria`').get() as {
+        c: number;
+      }
+    ).c;
+    expect(acCountThird).toBe(acCountBefore);
+  });
+
+  it('skips whitespace-only and empty-string entries (AC5)', async () => {
+    await applyMigrationsAndBackfill(join(tempDir, 'tasks-whitespace.db'));
+
+    const whitespaceTaskAcs = nativeDb
+      .prepare(
+        'SELECT `text` FROM `task_acceptance_criteria` WHERE `task_id` = ? ORDER BY `ordinal`',
+      )
+      .all('T-whitespace') as Array<{ text: string }>;
+
+    // Only the single "real AC" entry should survive — the three
+    // whitespace-only/empty siblings are dropped.
+    expect(whitespaceTaskAcs.length).toBe(1);
+    expect(whitespaceTaskAcs[0]?.text).toBe('real AC');
+  });
+
+  it('skips NULL and empty acceptance_json (AC4)', async () => {
+    await applyMigrationsAndBackfill(join(tempDir, 'tasks-empty.db'));
+
+    const nullCount = (
+      nativeDb
+        .prepare('SELECT count(*) AS c FROM `task_acceptance_criteria` WHERE `task_id` = ?')
+        .get('T-null') as { c: number }
+    ).c;
+    const emptyCount = (
+      nativeDb
+        .prepare('SELECT count(*) AS c FROM `task_acceptance_criteria` WHERE `task_id` = ?')
+        .get('T-empty-array') as { c: number }
+    ).c;
+    const malformedCount = (
+      nativeDb
+        .prepare('SELECT count(*) AS c FROM `task_acceptance_criteria` WHERE `task_id` = ?')
+        .get('T-malformed') as { c: number }
+    ).c;
+
+    expect(nullCount).toBe(0);
+    expect(emptyCount).toBe(0);
+    expect(malformedCount).toBe(0);
+  });
+
+  it('preserves the legacy tasks.acceptance_json column (AC7)', async () => {
+    await applyMigrationsAndBackfill(join(tempDir, 'tasks-preserve.db'));
+
+    // The column still exists.
+    const cols = nativeDb.prepare('PRAGMA table_info(tasks)').all() as Array<{
+      name: string;
+    }>;
+    expect(cols.map((c) => c.name)).toContain('acceptance_json');
+
+    // The legacy values are intact for every fixture row.
+    for (const fixture of FIXTURE_TASKS) {
+      const row = nativeDb
+        .prepare('SELECT `acceptance_json` FROM `tasks` WHERE `id` = ?')
+        .get(fixture.id) as { acceptance_json: string | null } | undefined;
+      expect(row).toBeDefined();
+      expect(row?.acceptance_json).toBe(fixture.acceptanceJson);
+    }
+  });
+
+  it('trims surrounding whitespace from preserved AC text', async () => {
+    await applyMigrationsAndBackfill(join(tempDir, 'tasks-trim.db'));
+
+    const trimTaskAcs = nativeDb
+      .prepare(
+        'SELECT `text` FROM `task_acceptance_criteria` WHERE `task_id` = ? ORDER BY `ordinal`',
+      )
+      .all('T-trim') as Array<{ text: string }>;
+
+    expect(trimTaskAcs).toEqual([{ text: 'padded' }, { text: 'newlines' }]);
+  });
+});


### PR DESCRIPTION
## Summary

Wave 2b of Epic **T10381** (E-AC-MIGRATION) under Saga **T10377** (SG-IVTR-AC-BINDING). PR 4 of 8 in the AC-binding migration train. First data migration in the wave — atop the Wave 2a schemas (T10502/T10503/T10504).

Idempotent SQL-only data migration that walks every row in `tasks` and expands its legacy `acceptance_json` array into first-class `task_acceptance_criteria` rows, with one matching `task_acceptance_criteria_history` audit row per AC (reason=`'backfill'`).

## Acceptance criteria status

- **AC1** new idempotent migration scans tasks + splits + UUIDv4 per AC + 1-based ordinal — covered by `idempotency: AC insert is gated by NOT EXISTS` + ordinal assignment test
- **AC2** idempotent (re-runs are no-op) — covered by triple-apply idempotency test
- **AC3** each AC gets a history row (`reason='backfill'`, `previousText=<AC string>`) — covered by history-parity test
- **AC4** empty/null acceptance skipped — covered by `T-null` + `T-empty-array` + `T-malformed` fixtures
- **AC5** whitespace-only entries skipped — covered by `T-whitespace` fixture (3 of 4 entries dropped)
- **AC6** runs cleanly on a populated tasks.db without data loss — covered by end-to-end fixture run
- **AC7** legacy `tasks.acceptance_json` PRESERVED — covered by `preserves the legacy tasks.acceptance_json column` test + lint asserting `ALTER`/`DROP` absent
- **AC8** unit/integration test on seeded fixture DB — `packages/core/src/store/__tests__/t10505-ac-backfill.test.ts` (18 tests, all green)

## Implementation notes

- **Pure SQL** (no JS data-migration runner). CLEO's runtime migrator is SQL-only; introducing a JS hook would be an architectural change far larger than this backfill warrants.
- **UUIDv4 in SQL** — `printf('%s-%s-4%s-%s%s-%s', ..., substr('89ab', abs(random()) % 4 + 1, 1), ...)` with `randomblob(N)` for entropy. Output indistinguishable from `crypto.randomUUID()`.
- **Malformed-JSON safety** — `json_each` is wrapped in `CASE WHEN json_valid(...) AND json_type(...)='array' THEN ... ELSE '[]' END` because `json_each(badJson)` raises `SQLITE_ERROR: malformed JSON` at plan time, aborting the migration. Empirically verified.
- **Whitespace stripping** uses `trim(x, char(9,10,13,32))` — SQLite's default `trim(x)` only strips ASCII space.
- **Element shapes** — `j.type='text'` (raw text) and `j.type='object'` (extract `$.criteria`) both handled, matching `parseAcceptanceJson` in `hygiene-scan.ts`.
- **Timestamp** `20260524000005` orders cleanly after Wave 2a's `02`/`03`/`04`.

## Test plan

- [x] `pnpm --filter @cleocode/core exec vitest run src/store/__tests__/t10505-ac-backfill.test.ts` — 18/18 passing
- [x] `pnpm biome check --write .` — clean
- [x] `pnpm run build` — green
- [x] `node scripts/lint-migrations.mjs` — zero errors (only pre-existing RULE-3 warnings on snapshot chain)
- [x] `node scripts/lint-changesets.mjs` — 162 entries validated

## Files

- `packages/core/migrations/drizzle-tasks/20260524000005_t10505-ac-backfill/migration.sql` (forward)
- `packages/core/migrations/drizzle-tasks/20260524000005_t10505-ac-backfill/revert.sql` (revert by reason='backfill' lookup)
- `packages/core/src/store/__tests__/t10505-ac-backfill.test.ts` (18 tests)
- `.changeset/t10505-ac-backfill.md`