### PR TITLE
feat(T10508): wire cleo add/update --acceptance to AC table

### DIFF
--- a/.changeset/t10508-acceptance-uuid-wiring.md
+++ b/.changeset/t10508-acceptance-uuid-wiring.md
@@ -1,0 +1,18 @@
+---
+id: t10508-acceptance-uuid-wiring
+tasks: [T10508]
+kind: feat
+summary: "cleo add/update --acceptance writes to task_acceptance_criteria table (T10381 Wave 2b)"
+---
+
+Wires `cleo add --acceptance` and `cleo update --acceptance` to dual-write the new `task_acceptance_criteria` table from Wave 2a (T10502/T10504) — every AC now gets a UUIDv4 stable identifier the moment it is created, alongside the legacy `tasks.acceptance` JSON column that stays in sync for backward compatibility.
+
+Update paths handled per ADR-079-r1 §2.2 ordinal-monotonicity rule:
+
+- **extend** (was N, now N+M with prefix match): new ACs append at `maxOrdinal+1`; existing rows untouched, no history written.
+- **shrink** (was N, now M < N with strict prefix): trailing ACs append to `task_acceptance_criteria_history` with `reason='edit'` BEFORE the delete, kept prefix preserves its UUIDs + ordinals so `satisfies:` bindings survive.
+- **replace-all** (text drift / reorder / mid-edit): ALL existing rows → history; all new rows inserted with fresh UUIDs from ordinal=1.
+
+Plus a third surface: `cleo show <id>` now hydrates `acRows` from the new table when present, returning `{ id, alias, ordinal, text }` per criterion alongside the legacy `task.acceptance` field. Consumers should prefer `acRows` when populated and fall back to the legacy string otherwise.
+
+Core additions: `packages/core/src/tasks/ac-table.ts` (the planner — `buildFreshAcRows`, `planAcUpdate`, `applyAcPlan`). Contract additions: `TransactionAccessor.{insertAcRows, getAcRows, deleteAcRowsForTask, appendAcHistory}` + `DataAccessor.getAcRows` + `TasksShowResult.acRows` + `TaskShowAcRowEntry` + `AcRow`. CLI handlers stay thin — all business logic lives in core. Tests: 13 planner units + 7 end-to-end integration tests covering create-new, extend, shrink, replace-all, and dual-write parity.

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -44,8 +45,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description:
-      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -84,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -102,31 +99,26 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description:
-      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () =>
-      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -149,8 +141,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -240,8 +231,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description:
-      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -260,8 +250,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -284,16 +273,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -317,8 +304,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -329,8 +315,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -343,33 +328,25 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () =>
-      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description:
-      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () =>
-      (await import('../commands/doctor-legacy-backups.js'))
-        .doctorLegacyBackupsCommand as CommandDef,
+    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorReleaseReadinessCommand',
     name: 'release-readiness',
-    description:
-      'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
-    load: async () =>
-      (await import('../commands/doctor-release-readiness.js'))
-        .doctorReleaseReadinessCommand as CommandDef,
+    description: 'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
+    load: async () => (await import('../commands/doctor-release-readiness.js')).doctorReleaseReadinessCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -405,8 +382,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -429,8 +405,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description:
-      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -467,8 +442,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -491,17 +465,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -530,8 +501,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -573,17 +543,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -612,8 +579,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -625,15 +591,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -676,8 +640,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -688,8 +651,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description:
-      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -725,8 +687,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description:
-      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -738,8 +699,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -751,8 +711,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -800,15 +759,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
+    description: 'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -880,8 +837,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'templatesCommand',
     name: 'templates',
-    description:
-      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
     load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
   },
   {
@@ -893,8 +849,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -906,15 +861,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description:
-      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -45,7 +44,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description:
+      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,8 +63,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +84,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,26 +102,31 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description:
+      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () =>
+      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -141,7 +149,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -231,7 +240,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description:
+      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -250,7 +260,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -273,14 +284,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -304,7 +317,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -315,7 +329,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
@@ -328,25 +343,33 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
+    description:
+      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () =>
+      (await import('../commands/doctor-legacy-backups.js'))
+        .doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorReleaseReadinessCommand',
     name: 'release-readiness',
-    description: 'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
-    load: async () => (await import('../commands/doctor-release-readiness.js')).doctorReleaseReadinessCommand as CommandDef,
+    description:
+      'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
+    load: async () =>
+      (await import('../commands/doctor-release-readiness.js'))
+        .doctorReleaseReadinessCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -382,7 +405,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -405,7 +429,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description:
+      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -442,7 +467,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -465,14 +491,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -501,7 +530,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -543,14 +573,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -579,7 +612,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -591,13 +625,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -640,7 +676,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -651,7 +688,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -687,7 +725,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description:
+      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -699,7 +738,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -711,7 +751,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -759,13 +800,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
+    description:
+      'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -837,7 +880,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'templatesCommand',
     name: 'templates',
-    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    description:
+      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
     load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
   },
   {
@@ -849,7 +893,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -861,13 +906,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description:
+      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/dispatch/domains/tasks.ts
+++ b/packages/cleo/src/dispatch/domains/tasks.ts
@@ -22,10 +22,15 @@
  * @task T1445 — OpsFromCore inference migration
  */
 
-import type { LafsEnvelope, TaskShowAttachmentEntry, TasksShowResult } from '@cleocode/contracts';
+import type {
+  LafsEnvelope,
+  TaskShowAcRowEntry,
+  TaskShowAttachmentEntry,
+  TasksShowResult,
+} from '@cleocode/contracts';
 import type { tasks as coreTasks } from '@cleocode/core';
 import { getLogger, getProjectRoot, TASKS_SUGGESTED_NEXT_BUILDERS } from '@cleocode/core';
-import { createAttachmentStore } from '@cleocode/core/internal';
+import { createAttachmentStore, getTaskAccessor } from '@cleocode/core/internal';
 // Saga core ops — pure business logic moved out of dispatch in T10124.
 // T10117 adds `sagaRepair` (`saga.repair`) for I5 violation cleanup.
 // T10118 adds the `detach` op for repair of nested-saga relations.
@@ -158,6 +163,39 @@ async function fetchTaskAttachments(
   }
 }
 
+/**
+ * Fetch acceptance-criterion rows for a task from `task_acceptance_criteria`
+ * (T10502) and project them into the {@link TaskShowAcRowEntry} shape used
+ * by the `cleo show` envelope.
+ *
+ * Always resolves — returns the empty array on any failure (legacy DB
+ * pre-migration, missing table, etc.). Consumers that observe `[]` should
+ * fall back to the legacy `task.acceptance` JSON string field.
+ *
+ * @param projectRoot - Absolute path to the project root.
+ * @param taskId      - Task identifier (e.g. `"T10508"`).
+ * @returns Resolved array of AC entries, never rejects.
+ *
+ * @task T10508
+ * @epic T10381
+ */
+async function fetchTaskAcRows(projectRoot: string, taskId: string): Promise<TaskShowAcRowEntry[]> {
+  try {
+    const accessor = await getTaskAccessor(projectRoot);
+    const rows = await accessor.getAcRows(taskId);
+    return rows.map((row) => ({
+      id: row.id,
+      alias: `AC${row.ordinal}`,
+      ordinal: row.ordinal,
+      text: row.text,
+    }));
+  } catch {
+    // AC table missing or read failed — return empty array so the
+    // dispatch envelope omits the optional `acRows` key.
+    return [];
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Typed inner handler (T1425 / T1445 — typed-dispatch + OpsFromCore migration)
 //
@@ -179,10 +217,13 @@ const _tasksTypedHandler = defineTypedHandler<TasksOps>('tasks', {
     if (params.history) {
       return wrapCoreResult(await taskShowWithHistory(projectRoot, params.taskId, true), 'show');
     }
-    // Standard show: fetch task + attachments in parallel (T9966 — AC1: attachments[] always present)
-    const [coreResult, attachments] = await Promise.all([
+    // Standard show: fetch task + attachments + AC rows in parallel
+    // (T9966 — AC1: attachments[] always present; T10508 — acRows from
+    // task_acceptance_criteria when populated).
+    const [coreResult, attachments, acRows] = await Promise.all([
       taskShow(projectRoot, params.taskId),
       fetchTaskAttachments(projectRoot, params.taskId),
+      fetchTaskAcRows(projectRoot, params.taskId),
     ]);
     if (!coreResult.success) {
       return wrapCoreResult(coreResult, 'show');
@@ -191,6 +232,7 @@ const _tasksTypedHandler = defineTypedHandler<TasksOps>('tasks', {
       task: coreResult.data!.task,
       view: coreResult.data!.view,
       attachments,
+      ...(acRows.length > 0 ? { acRows } : {}),
     };
     return { success: true as const, data: showResult };
   },

--- a/packages/contracts/src/data-accessor.ts
+++ b/packages/contracts/src/data-accessor.ts
@@ -108,6 +108,28 @@ export interface TaskFieldUpdates {
 }
 
 /**
+ * A row of the `task_acceptance_criteria` table (T10502).
+ *
+ * @task T10508
+ */
+export interface AcRow {
+  /** UUIDv4 stable identifier, immutable for the AC's lifetime. */
+  id: string;
+  /** Owning task ID. */
+  taskId: string;
+  /** 1-based ordinal — never reused per task (gaps remain on shrink). */
+  ordinal: number;
+  /** The AC statement text. Structured gates are serialised as JSON. */
+  text: string;
+  /** ISO-8601 timestamp the row was created. */
+  createdAt: string;
+  /** ISO-8601 last-edit timestamp; null until first edit. */
+  updatedAt: string | null;
+  /** Optional sha256(text) snapshot; writers MAY populate, readers MUST treat null as "unknown". */
+  contentHash: string | null;
+}
+
+/**
  * Subset of DataAccessor methods available inside a transaction callback.
  * Write-only — reads use the outer accessor (snapshot isolation).
  */
@@ -129,7 +151,39 @@ export interface TransactionAccessor {
   removeRelation(taskId: string, relatedTo: string, relationType?: string): Promise<void>;
   /** Remove all relations for a task (both directions) — used for set-replace. @task T9514 */
   clearRelations(taskId: string): Promise<void>;
+  /**
+   * Insert AC rows into `task_acceptance_criteria` with caller-supplied
+   * UUIDs and ordinals. Ordinals MUST NOT collide with existing rows for
+   * the same task — the UNIQUE (task_id, ordinal) index enforces this.
+   * @task T10508
+   */
+  insertAcRows(
+    rows: Array<{ id: string; taskId: string; ordinal: number; text: string }>,
+  ): Promise<void>;
+  /**
+   * Read all AC rows for a task, ordered by ordinal ASC.
+   * Available inside transactions for shrink/replace flows that need to
+   * read the current state before deletion.
+   * @task T10508
+   */
+  getAcRows(taskId: string): Promise<AcRow[]>;
+  /**
+   * Delete all AC rows for a task. Used by update-replace-all + update-shrink
+   * flows AFTER the history rows have been appended.
+   * @task T10508
+   */
+  deleteAcRowsForTask(taskId: string): Promise<void>;
+  /**
+   * Append a history row to `task_acceptance_criteria_history` capturing the
+   * AC text that is about to be superseded.
+   * @task T10508
+   */
+  appendAcHistory(
+    rows: Array<{ acId: string; previousText: string; reason: string }>,
+  ): Promise<void>;
 }
+
+// Re-export AcRow at the module level for both transaction + outer accessor use.
 
 /**
  * DataAccessor interface.
@@ -192,6 +246,13 @@ export interface DataAccessor {
 
   /** Remove a row from the task_relations table (T9240). */
   removeRelation(taskId: string, relatedTo: string, relationType?: string): Promise<void>;
+
+  /**
+   * Read AC rows for a task from `task_acceptance_criteria`, ordered by
+   * ordinal ASC. Returns the empty array if no rows exist.
+   * @task T10508
+   */
+  getAcRows(taskId: string): Promise<AcRow[]>;
 
   // ---- Metadata (schema_meta KV store) ----
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -288,6 +288,7 @@ export type {
 export { parseClaudeCodeCredentials } from './credentials.js';
 // === DataAccessor Interface ===
 export type {
+  AcRow,
   ArchiveFields,
   ArchiveFile,
   DataAccessor,
@@ -1280,6 +1281,7 @@ export type {
   DepGraphIssue,
   DepsTreeEdge,
   DepsTreeNode,
+  TaskShowAcRowEntry,
   TaskShowAttachmentEntry,
   TasksAddBatchEntry,
   TasksAddBatchParams,

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -237,6 +237,38 @@ export interface TasksShowResult {
    * @task T9966
    */
   attachments: TaskShowAttachmentEntry[];
+  /**
+   * Acceptance-criterion rows hydrated from the `task_acceptance_criteria`
+   * table (T10502). Each entry carries the stable UUID `id`, the
+   * `AC<ordinal>` alias, the ordinal itself, and the canonical AC text.
+   *
+   * Optional — undefined when the task has no rows in the table (e.g.
+   * legacy tasks not yet backfilled by T10505). Consumers should fall
+   * back to `task.acceptance` (the legacy JSON string) in that case.
+   *
+   * @task T10508
+   * @epic T10381
+   */
+  acRows?: TaskShowAcRowEntry[];
+}
+
+/**
+ * One acceptance-criterion entry in {@link TasksShowResult.acRows}.
+ *
+ * Mirrors the `AcDetail` shape from `@cleocode/core/tasks/show.js` but
+ * lives in contracts so dispatch-layer consumers don't depend on core.
+ *
+ * @task T10508
+ */
+export interface TaskShowAcRowEntry {
+  /** UUIDv4 stable identifier, immutable for the AC's lifetime. */
+  id: string;
+  /** Display alias derived from ordinal — `AC1`, `AC2`, etc. */
+  alias: string;
+  /** 1-based ordinal — never reused per task (gaps remain on shrink). */
+  ordinal: number;
+  /** The AC statement text. Structured gates round-trip as JSON. */
+  text: string;
 }
 
 // tasks.tree dispatch params (with optional withBlockers flag — dispatch alias)

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2541,4 +2541,6 @@ export {
   resolveAgentsBatch,
 } from './store/agent-resolver.js';
 // assertTestEnv — test-DB isolation guard (T1906 / BBTT-W3-4)
-export { assertTestEnv } from './store/data-accessor.js';
+// getTaskAccessor — canonical task DataAccessor factory (T10508 — surface
+// `getAcRows` to dispatch-layer `tasks.show` handler).
+export { assertTestEnv, getTaskAccessor } from './store/data-accessor.js';

--- a/packages/core/src/store/safety-data-accessor.ts
+++ b/packages/core/src/store/safety-data-accessor.ts
@@ -197,6 +197,12 @@ export class SafetyDataAccessor implements DataAccessor {
     await this.inner.removeRelation(taskId, relatedTo, relationType);
   }
 
+  // ---- AC rows (T10508 — pass-through) ----
+
+  async getAcRows(taskId: string) {
+    return this.inner.getAcRows(taskId);
+  }
+
   // ---- Metadata (pass-through to inner) ----
 
   async getMetaValue<T>(key: string): Promise<T | null> {

--- a/packages/core/src/store/sqlite-data-accessor.ts
+++ b/packages/core/src/store/sqlite-data-accessor.ts
@@ -417,6 +417,35 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
       );
     },
 
+    // ---- AC rows (T10508) ----
+
+    async getAcRows(taskId: string) {
+      const db = await getDb(cwd);
+      const rows = await db
+        .select({
+          id: schema.taskAcceptanceCriteria.id,
+          taskId: schema.taskAcceptanceCriteria.taskId,
+          ordinal: schema.taskAcceptanceCriteria.ordinal,
+          text: schema.taskAcceptanceCriteria.text,
+          createdAt: schema.taskAcceptanceCriteria.createdAt,
+          updatedAt: schema.taskAcceptanceCriteria.updatedAt,
+          contentHash: schema.taskAcceptanceCriteria.contentHash,
+        })
+        .from(schema.taskAcceptanceCriteria)
+        .where(eq(schema.taskAcceptanceCriteria.taskId, taskId))
+        .orderBy(schema.taskAcceptanceCriteria.ordinal)
+        .all();
+      return rows.map((r) => ({
+        id: r.id,
+        taskId: r.taskId,
+        ordinal: r.ordinal,
+        text: r.text,
+        createdAt: r.createdAt,
+        updatedAt: r.updatedAt ?? null,
+        contentHash: r.contentHash ?? null,
+      }));
+    },
+
     async archiveSingleTask(taskId: string, fields: ArchiveFields): Promise<void> {
       const db = await getDb(cwd);
       // Verify the task exists before archiving
@@ -1010,6 +1039,69 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
             await db
               .delete(schema.taskRelations)
               .where(eq(schema.taskRelations.taskId, taskId))
+              .run();
+          },
+          // ---- AC rows (T10508) ----
+          async insertAcRows(
+            rows: Array<{ id: string; taskId: string; ordinal: number; text: string }>,
+          ): Promise<void> {
+            if (rows.length === 0) return;
+            await db
+              .insert(schema.taskAcceptanceCriteria)
+              .values(
+                rows.map((r) => ({
+                  id: r.id,
+                  taskId: r.taskId,
+                  ordinal: r.ordinal,
+                  text: r.text,
+                })),
+              )
+              .run();
+          },
+          async getAcRows(taskId: string) {
+            const out = await db
+              .select({
+                id: schema.taskAcceptanceCriteria.id,
+                taskId: schema.taskAcceptanceCriteria.taskId,
+                ordinal: schema.taskAcceptanceCriteria.ordinal,
+                text: schema.taskAcceptanceCriteria.text,
+                createdAt: schema.taskAcceptanceCriteria.createdAt,
+                updatedAt: schema.taskAcceptanceCriteria.updatedAt,
+                contentHash: schema.taskAcceptanceCriteria.contentHash,
+              })
+              .from(schema.taskAcceptanceCriteria)
+              .where(eq(schema.taskAcceptanceCriteria.taskId, taskId))
+              .orderBy(schema.taskAcceptanceCriteria.ordinal)
+              .all();
+            return out.map((r) => ({
+              id: r.id,
+              taskId: r.taskId,
+              ordinal: r.ordinal,
+              text: r.text,
+              createdAt: r.createdAt,
+              updatedAt: r.updatedAt ?? null,
+              contentHash: r.contentHash ?? null,
+            }));
+          },
+          async deleteAcRowsForTask(taskId: string): Promise<void> {
+            await db
+              .delete(schema.taskAcceptanceCriteria)
+              .where(eq(schema.taskAcceptanceCriteria.taskId, taskId))
+              .run();
+          },
+          async appendAcHistory(
+            rows: Array<{ acId: string; previousText: string; reason: string }>,
+          ): Promise<void> {
+            if (rows.length === 0) return;
+            await db
+              .insert(schema.taskAcceptanceCriteriaHistory)
+              .values(
+                rows.map((r) => ({
+                  acId: r.acId,
+                  previousText: r.previousText,
+                  reason: r.reason,
+                })),
+              )
               .run();
           },
         };

--- a/packages/core/src/store/umbrella-data-accessor.ts
+++ b/packages/core/src/store/umbrella-data-accessor.ts
@@ -234,6 +234,12 @@ export class UmbrellaDataAccessor implements DataAccessor {
     return (await this.tasks()).removeRelation(taskId, relatedTo, relationType);
   }
 
+  // ---- AC rows (T10508 — pass-through) ----
+
+  async getAcRows(taskId: string) {
+    return (await this.tasks()).getAcRows(taskId);
+  }
+
   async getMetaValue<T>(key: string): Promise<T | null> {
     return (await this.tasks()).getMetaValue<T>(key);
   }

--- a/packages/core/src/tasks/__tests__/ac-table.test.ts
+++ b/packages/core/src/tasks/__tests__/ac-table.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit coverage for the AC dual-write planner.
+ *
+ * These tests exercise the pure planning function `planAcUpdate` against
+ * the four canonical update paths called out in the T10508 acceptance
+ * criteria — create-new, update-extend, update-shrink, update-replace-all
+ * — plus the structured-gate JSON round-trip and the empty-input edge.
+ *
+ * @adr ADR-079-r1 §2.2 — ordinal monotonicity, never reused
+ * @epic T10381
+ * @saga T10377
+ * @task T10508
+ * @decision D013
+ */
+
+import type { AcRow } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { acItemToText, buildFreshAcRows, planAcUpdate } from '../ac-table.js';
+
+/**
+ * Build a synthetic AC row matching the shape `getAcRows` returns.
+ * The id/createdAt fields don't matter for planning — only ordinal + text do.
+ */
+function row(taskId: string, ordinal: number, text: string, id = `uuid-${ordinal}`): AcRow {
+  return {
+    id,
+    taskId,
+    ordinal,
+    text,
+    createdAt: '2026-05-24T00:00:00.000Z',
+    updatedAt: null,
+    contentHash: null,
+  };
+}
+
+describe('acItemToText', () => {
+  it('passes strings through unchanged (trimmed)', () => {
+    expect(acItemToText('  hello  ')).toBe('hello');
+    expect(acItemToText('plain text')).toBe('plain text');
+  });
+
+  it('JSON-serialises structured acceptance gates', () => {
+    const gate = { kind: 'test', description: 'unit run', command: 'pnpm test', expect: 'pass' };
+    const out = acItemToText(gate as never);
+    expect(out.startsWith('{')).toBe(true);
+    expect(JSON.parse(out)).toEqual(gate);
+  });
+});
+
+describe('buildFreshAcRows', () => {
+  it('returns empty array for undefined / empty input', () => {
+    expect(buildFreshAcRows('T001', undefined)).toEqual([]);
+    expect(buildFreshAcRows('T001', [])).toEqual([]);
+  });
+
+  it('assigns UUIDs + 1-based ordinals matching input order', () => {
+    const rows = buildFreshAcRows('T001', ['AC1', 'AC2', 'AC3']);
+    expect(rows).toHaveLength(3);
+    expect(rows[0].ordinal).toBe(1);
+    expect(rows[1].ordinal).toBe(2);
+    expect(rows[2].ordinal).toBe(3);
+    expect(rows.every((r) => r.taskId === 'T001')).toBe(true);
+    // Each id is a unique UUIDv4 (loose pattern check — randomUUID guarantees v4).
+    const ids = new Set(rows.map((r) => r.id));
+    expect(ids.size).toBe(3);
+    for (const r of rows) {
+      expect(r.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    }
+  });
+
+  it('preserves AC text via acItemToText', () => {
+    const rows = buildFreshAcRows('T002', [' alpha ', 'beta']);
+    expect(rows[0].text).toBe('alpha');
+    expect(rows[1].text).toBe('beta');
+  });
+});
+
+describe('planAcUpdate — create from empty (extend semantic)', () => {
+  it('inserts all rows when task has no existing AC rows', () => {
+    const plan = planAcUpdate('T010', [], ['AC1', 'AC2']);
+    expect(plan.history).toEqual([]);
+    expect(plan.fullDelete).toBe(false);
+    expect(plan.inserts).toHaveLength(2);
+    expect(plan.inserts[0].ordinal).toBe(1);
+    expect(plan.inserts[1].ordinal).toBe(2);
+    expect(plan.inserts[0].text).toBe('AC1');
+    expect(plan.inserts[1].text).toBe('AC2');
+  });
+});
+
+describe('planAcUpdate — extend (was N, now N+M with prefix match)', () => {
+  it('appends new rows at maxOrdinal+1 and leaves existing rows untouched', () => {
+    const existing = [row('T011', 1, 'AC1'), row('T011', 2, 'AC2')];
+    const plan = planAcUpdate('T011', existing, ['AC1', 'AC2', 'AC3']);
+
+    // Pure append — no history, no delete.
+    expect(plan.history).toEqual([]);
+    expect(plan.fullDelete).toBe(false);
+
+    // Only the new tail is inserted, at ordinal=3.
+    expect(plan.inserts).toHaveLength(1);
+    expect(plan.inserts[0].ordinal).toBe(3);
+    expect(plan.inserts[0].text).toBe('AC3');
+  });
+
+  it('continues from highest existing ordinal even when ordinals have gaps', () => {
+    // Existing rows skip ordinal 2 (post-shrink scenario).
+    const existing = [row('T012', 1, 'AC1'), row('T012', 5, 'AC5')];
+    const plan = planAcUpdate('T012', existing, ['AC1', 'AC5', 'AC-NEW']);
+    expect(plan.fullDelete).toBe(false);
+    expect(plan.history).toEqual([]);
+    expect(plan.inserts).toHaveLength(1);
+    // maxOrdinal was 5 → new tail starts at 6 (never reuses 2/3/4).
+    expect(plan.inserts[0].ordinal).toBe(6);
+    expect(plan.inserts[0].text).toBe('AC-NEW');
+  });
+});
+
+describe('planAcUpdate — shrink (was N, now M < N with strict prefix)', () => {
+  it('moves trailing rows to history and re-inserts the kept prefix', () => {
+    const existing = [row('T013', 1, 'AC1'), row('T013', 2, 'AC2'), row('T013', 3, 'AC3')];
+    const plan = planAcUpdate('T013', existing, ['AC1']);
+
+    // Tail (AC2, AC3) goes to history with reason='edit'.
+    expect(plan.history).toHaveLength(2);
+    expect(plan.history[0].previousText).toBe('AC2');
+    expect(plan.history[0].reason).toBe('edit');
+    expect(plan.history[0].acId).toBe('uuid-2');
+    expect(plan.history[1].previousText).toBe('AC3');
+    expect(plan.history[1].acId).toBe('uuid-3');
+
+    // Delete-then-reinsert path. The kept prefix re-inserts with the
+    // EXISTING UUIDs + ordinals so satisfies-bindings to AC1 survive.
+    expect(plan.fullDelete).toBe(true);
+    expect(plan.inserts).toHaveLength(1);
+    expect(plan.inserts[0].id).toBe('uuid-1'); // binding stability
+    expect(plan.inserts[0].ordinal).toBe(1);
+    expect(plan.inserts[0].text).toBe('AC1');
+  });
+});
+
+describe('planAcUpdate — replace-all (mid-edit / reorder / mixed)', () => {
+  it('treats text drift as wholesale rewrite — all existing → history, all new inserted from ordinal=1', () => {
+    const existing = [row('T014', 1, 'AC1-old'), row('T014', 2, 'AC2-old')];
+    const plan = planAcUpdate('T014', existing, ['AC1-new', 'AC2-new']);
+
+    // Both old rows recorded in history.
+    expect(plan.history).toHaveLength(2);
+    expect(plan.history.map((h) => h.previousText)).toEqual(['AC1-old', 'AC2-old']);
+    expect(plan.history.every((h) => h.reason === 'edit')).toBe(true);
+
+    // Full delete + fresh insert with new UUIDs starting from ordinal=1.
+    expect(plan.fullDelete).toBe(true);
+    expect(plan.inserts).toHaveLength(2);
+    expect(plan.inserts[0].ordinal).toBe(1);
+    expect(plan.inserts[1].ordinal).toBe(2);
+    expect(plan.inserts[0].text).toBe('AC1-new');
+    expect(plan.inserts[1].text).toBe('AC2-new');
+    // New UUIDs — NOT the existing ids (no prefix-stability path applied).
+    expect(plan.inserts[0].id).not.toBe('uuid-1');
+    expect(plan.inserts[1].id).not.toBe('uuid-2');
+  });
+
+  it('reorder counts as replace-all (no prefix match → full rewrite)', () => {
+    const existing = [row('T015', 1, 'A'), row('T015', 2, 'B'), row('T015', 3, 'C')];
+    const plan = planAcUpdate('T015', existing, ['C', 'B', 'A']);
+    expect(plan.fullDelete).toBe(true);
+    expect(plan.history).toHaveLength(3);
+    expect(plan.inserts.map((r) => r.text)).toEqual(['C', 'B', 'A']);
+  });
+});
+
+describe('planAcUpdate — idempotency (no-op when input equals existing)', () => {
+  it('extend-with-zero-tail emits empty plan when texts match exactly', () => {
+    const existing = [row('T016', 1, 'AC1'), row('T016', 2, 'AC2')];
+    const plan = planAcUpdate('T016', existing, ['AC1', 'AC2']);
+    // Same length + prefix-match → extend path with empty tail.
+    expect(plan.history).toEqual([]);
+    expect(plan.fullDelete).toBe(false);
+    expect(plan.inserts).toEqual([]);
+  });
+});
+
+describe('planAcUpdate — edge cases', () => {
+  it('handles empty incoming (shrink to zero) by moving all rows to history', () => {
+    const existing = [row('T017', 1, 'AC1'), row('T017', 2, 'AC2')];
+    const plan = planAcUpdate('T017', existing, []);
+    // Empty incoming with non-empty existing — strict prefix of length 0 → shrink.
+    expect(plan.history).toHaveLength(2);
+    expect(plan.fullDelete).toBe(true);
+    expect(plan.inserts).toEqual([]);
+  });
+});

--- a/packages/core/src/tasks/__tests__/ac-wiring.test.ts
+++ b/packages/core/src/tasks/__tests__/ac-wiring.test.ts
@@ -1,0 +1,301 @@
+/**
+ * End-to-end coverage for the AC dual-write integration.
+ *
+ * Verifies that the addTask + updateTask handlers correctly:
+ *   1. Insert AC rows into `task_acceptance_criteria` on creation.
+ *   2. Generate UUIDv4 per AC and 1-based ordinals matching input order.
+ *   3. Dual-write the legacy `tasks.acceptance` string in lock-step.
+ *   4. Append history rows BEFORE deleting on shrink/replace-all updates.
+ *   5. Keep extend updates ordinal-monotonic (never reuse ordinals).
+ *
+ * Covers the four canonical update paths called out in T10508 ACs:
+ *   create-new, update-extend, update-shrink, update-replace-all.
+ *
+ * @adr ADR-079-r1 §2.2 — ordinal monotonicity, never reused
+ * @epic T10381
+ * @saga T10377
+ * @task T10508
+ * @decision D013
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { resetDbState } from '../../store/sqlite.js';
+import { addTask } from '../add.js';
+import { updateTask } from '../update.js';
+
+describe('addTask — AC dual-write (T10508)', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  it('writes AC rows with UUIDs + 1-based ordinals on create', async () => {
+    const result = await addTask(
+      {
+        title: 'AC create test',
+        description: 'Creates with three ACs',
+        acceptance: ['First AC', 'Second AC', 'Third AC'],
+      },
+      env.tempDir,
+      accessor,
+    );
+
+    const rows = await accessor.getAcRows(result.task.id);
+    expect(rows).toHaveLength(3);
+    expect(rows[0].ordinal).toBe(1);
+    expect(rows[1].ordinal).toBe(2);
+    expect(rows[2].ordinal).toBe(3);
+    expect(rows[0].text).toBe('First AC');
+    expect(rows[1].text).toBe('Second AC');
+    expect(rows[2].text).toBe('Third AC');
+
+    // Every AC row id is a UUIDv4.
+    for (const r of rows) {
+      expect(r.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    }
+    // All ids are unique.
+    expect(new Set(rows.map((r) => r.id)).size).toBe(3);
+  });
+
+  it('keeps the legacy acceptance string in sync (dual-write)', async () => {
+    const result = await addTask(
+      {
+        title: 'AC dual-write check',
+        description: 'Dual-write the legacy string column too',
+        acceptance: ['Alpha', 'Beta'],
+      },
+      env.tempDir,
+      accessor,
+    );
+    // Legacy string field is mirrored on the in-memory task.
+    expect(result.task.acceptance).toEqual(['Alpha', 'Beta']);
+
+    // Reloading the task from the DB yields the same legacy field.
+    const reloaded = await accessor.loadSingleTask(result.task.id);
+    expect(reloaded?.acceptance).toEqual(['Alpha', 'Beta']);
+
+    // AND the new table has matching rows.
+    const rows = await accessor.getAcRows(result.task.id);
+    expect(rows.map((r) => r.text)).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('no AC rows written when --acceptance omitted', async () => {
+    const result = await addTask(
+      { title: 'No AC task', description: 'No acceptance criteria here' },
+      env.tempDir,
+      accessor,
+    );
+    const rows = await accessor.getAcRows(result.task.id);
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('updateTask — AC dual-write update paths (T10508)', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  it('update-extend: appends new AC at maxOrdinal+1 (no shift, no history)', async () => {
+    const created = await addTask(
+      {
+        title: 'Extend me',
+        description: 'Starts with two ACs, gains a third',
+        acceptance: ['AC1', 'AC2'],
+      },
+      env.tempDir,
+      accessor,
+    );
+    const beforeRows = await accessor.getAcRows(created.task.id);
+    const originalIds = new Set(beforeRows.map((r) => r.id));
+
+    await updateTask(
+      {
+        taskId: created.task.id,
+        acceptance: ['AC1', 'AC2', 'AC3'],
+        reason: 'T10508 unit test — extend path',
+      },
+      env.tempDir,
+      accessor,
+    );
+
+    const afterRows = await accessor.getAcRows(created.task.id);
+    expect(afterRows).toHaveLength(3);
+    expect(afterRows.map((r) => r.ordinal)).toEqual([1, 2, 3]);
+    expect(afterRows.map((r) => r.text)).toEqual(['AC1', 'AC2', 'AC3']);
+
+    // Original rows preserved by id (no shift) — the new tail has a fresh id.
+    expect(originalIds.has(afterRows[0].id)).toBe(true);
+    expect(originalIds.has(afterRows[1].id)).toBe(true);
+    expect(originalIds.has(afterRows[2].id)).toBe(false);
+
+    // Legacy field stays in sync.
+    const reloaded = await accessor.loadSingleTask(created.task.id);
+    expect(reloaded?.acceptance).toEqual(['AC1', 'AC2', 'AC3']);
+  });
+
+  it('update-shrink: trailing ACs move to history with reason="edit" BEFORE delete', async () => {
+    const created = await addTask(
+      {
+        title: 'Shrink me',
+        description: 'Starts with three ACs, drops to one',
+        acceptance: ['AC1-keep', 'AC2-drop', 'AC3-drop'],
+      },
+      env.tempDir,
+      accessor,
+    );
+    const beforeRows = await accessor.getAcRows(created.task.id);
+    const ac2Id = beforeRows.find((r) => r.ordinal === 2)!.id;
+    const ac3Id = beforeRows.find((r) => r.ordinal === 3)!.id;
+
+    await updateTask(
+      {
+        taskId: created.task.id,
+        acceptance: ['AC1-keep'],
+        reason: 'T10508 unit test — shrink path',
+      },
+      env.tempDir,
+      accessor,
+    );
+
+    const afterRows = await accessor.getAcRows(created.task.id);
+    expect(afterRows).toHaveLength(1);
+    expect(afterRows[0].ordinal).toBe(1);
+    expect(afterRows[0].text).toBe('AC1-keep');
+    // Kept row preserved its UUID — satisfies-binding stability.
+    expect(afterRows[0].id).toBe(beforeRows[0].id);
+
+    // History captured the two dropped rows with previousText + reason='edit'.
+    // Read history via raw SQL using the same native handle.
+    const { getNativeTasksDb } = await import('../../store/sqlite.js');
+    const native = getNativeTasksDb();
+    expect(native).toBeTruthy();
+    const historyRows = native!
+      .prepare(
+        'SELECT ac_id, previous_text, reason FROM task_acceptance_criteria_history ORDER BY id ASC',
+      )
+      .all() as Array<{ ac_id: string; previous_text: string; reason: string }>;
+    expect(historyRows).toHaveLength(2);
+    expect(historyRows.map((h) => h.ac_id)).toEqual([ac2Id, ac3Id]);
+    expect(historyRows.map((h) => h.previous_text)).toEqual(['AC2-drop', 'AC3-drop']);
+    expect(historyRows.every((h) => h.reason === 'edit')).toBe(true);
+
+    // Legacy field shrunk in lock-step.
+    const reloaded = await accessor.loadSingleTask(created.task.id);
+    expect(reloaded?.acceptance).toEqual(['AC1-keep']);
+  });
+
+  it('update-replace-all: every existing row → history, every new row inserted from ordinal=1', async () => {
+    const created = await addTask(
+      {
+        title: 'Replace me',
+        description: 'Wholesale rewrite with new text',
+        acceptance: ['Old A', 'Old B'],
+      },
+      env.tempDir,
+      accessor,
+    );
+    const beforeRows = await accessor.getAcRows(created.task.id);
+    const oldIds = beforeRows.map((r) => r.id);
+
+    await updateTask(
+      {
+        taskId: created.task.id,
+        acceptance: ['New A', 'New B'],
+        reason: 'T10508 unit test — replace-all path',
+      },
+      env.tempDir,
+      accessor,
+    );
+
+    const afterRows = await accessor.getAcRows(created.task.id);
+    expect(afterRows).toHaveLength(2);
+    expect(afterRows.map((r) => r.text)).toEqual(['New A', 'New B']);
+    expect(afterRows.map((r) => r.ordinal)).toEqual([1, 2]);
+    // Brand-new UUIDs (no id stability across replace-all).
+    expect(afterRows.every((r) => !oldIds.includes(r.id))).toBe(true);
+
+    // History captured both old rows.
+    const { getNativeTasksDb } = await import('../../store/sqlite.js');
+    const native = getNativeTasksDb();
+    const historyRows = native!
+      .prepare(
+        'SELECT ac_id, previous_text, reason FROM task_acceptance_criteria_history ORDER BY id ASC',
+      )
+      .all() as Array<{ ac_id: string; previous_text: string; reason: string }>;
+    expect(historyRows).toHaveLength(2);
+    expect(historyRows.map((h) => h.previous_text)).toEqual(['Old A', 'Old B']);
+    expect(historyRows.every((h) => h.reason === 'edit')).toBe(true);
+    expect(historyRows.map((h) => h.ac_id).sort()).toEqual([...oldIds].sort());
+
+    // Legacy field replaced.
+    const reloaded = await accessor.loadSingleTask(created.task.id);
+    expect(reloaded?.acceptance).toEqual(['New A', 'New B']);
+  });
+
+  it('update is transactional — history append precedes delete for shrink', async () => {
+    // This invariant is enforced by the planner ordering (appendAcHistory
+    // is called BEFORE deleteAcRowsForTask inside applyAcPlan) and by the
+    // surrounding `acc.transaction` wrap. If either statement failed
+    // mid-flow, the whole transaction would roll back; this test simply
+    // confirms the final state matches the expected order under success.
+    const created = await addTask(
+      {
+        title: 'Order check',
+        description: 'Validates history rows exist + tail rows gone',
+        acceptance: ['Keep1', 'Drop1', 'Drop2'],
+      },
+      env.tempDir,
+      accessor,
+    );
+    const beforeRows = await accessor.getAcRows(created.task.id);
+    const droppedIds = beforeRows.slice(1).map((r) => r.id);
+
+    await updateTask(
+      {
+        taskId: created.task.id,
+        acceptance: ['Keep1'],
+        reason: 'T10508 unit test — transactional order',
+      },
+      env.tempDir,
+      accessor,
+    );
+
+    // Surviving rows: only AC1 with its original UUID.
+    const surviving = await accessor.getAcRows(created.task.id);
+    expect(surviving).toHaveLength(1);
+    expect(surviving[0].id).toBe(beforeRows[0].id);
+
+    // History contains both dropped rows + references the now-deleted UUIDs.
+    const { getNativeTasksDb } = await import('../../store/sqlite.js');
+    const native = getNativeTasksDb();
+    const historyAcIds = (
+      native!
+        .prepare('SELECT ac_id FROM task_acceptance_criteria_history ORDER BY id ASC')
+        .all() as Array<{ ac_id: string }>
+    ).map((h) => h.ac_id);
+    expect(historyAcIds.sort()).toEqual([...droppedIds].sort());
+  });
+});

--- a/packages/core/src/tasks/ac-table.ts
+++ b/packages/core/src/tasks/ac-table.ts
@@ -1,0 +1,193 @@
+/**
+ * Helpers that compute the diff between an existing AC row set and an
+ * incoming AC text list, then apply the dual-write (rows + history) inside
+ * a caller-owned transaction. The legacy `tasks.acceptance` string column
+ * MUST stay in lock-step — the legacy writer lives in addTask/updateTask;
+ * this module only manages the row-table SSoT side.
+ *
+ * @adr ADR-079-r1 §2.2 — ordinal monotonicity, never reused
+ * @epic T10381 E-AC-MIGRATION
+ * @saga T10377 SG-IVTR-AC-BINDING
+ * @task T10508
+ * @decision D013
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { AcceptanceItem, AcRow, TransactionAccessor } from '@cleocode/contracts';
+
+/**
+ * Coerce an {@link AcceptanceItem} into the canonical row `text` form.
+ *
+ * Plain strings pass through; structured {@link import('@cleocode/contracts').AcceptanceGate}
+ * objects are JSON-serialised so the row preserves the structured payload
+ * for future round-tripping (decision D013 § "structured-gate retention").
+ *
+ * @param item — AC item from the in-memory Task.acceptance array
+ * @returns canonical text string for the `task_acceptance_criteria.text` column
+ */
+export function acItemToText(item: AcceptanceItem): string {
+  if (typeof item === 'string') return item.trim();
+  // Structured gate — preserve full shape as JSON. Readers may JSON-parse
+  // when they detect a leading `{`.
+  return JSON.stringify(item);
+}
+
+/**
+ * Compute the row payload for a fresh task with no pre-existing AC rows.
+ *
+ * Generates a UUIDv4 per AC and assigns 1-based ordinals matching the
+ * insertion order. Returns the empty array if the input is empty/undefined.
+ *
+ * @param taskId — owning task ID
+ * @param acceptance — pipe-split AC items in display order
+ * @returns rows ready for {@link TransactionAccessor.insertAcRows}
+ */
+export function buildFreshAcRows(
+  taskId: string,
+  acceptance: readonly AcceptanceItem[] | undefined,
+): Array<{ id: string; taskId: string; ordinal: number; text: string }> {
+  if (!acceptance || acceptance.length === 0) return [];
+  return acceptance.map((item, idx) => ({
+    id: randomUUID(),
+    taskId,
+    ordinal: idx + 1,
+    text: acItemToText(item),
+  }));
+}
+
+/**
+ * Result of `planAcUpdate` — the row + history mutations the caller must
+ * apply inside a transaction.
+ */
+export interface AcUpdatePlan {
+  /** AC rows to INSERT (new, never-before-seen AC text). */
+  inserts: Array<{ id: string; taskId: string; ordinal: number; text: string }>;
+  /** History rows to append BEFORE deleting any rows. */
+  history: Array<{ acId: string; previousText: string; reason: string }>;
+  /**
+   * When true the caller MUST issue {@link TransactionAccessor.deleteAcRowsForTask}
+   * BEFORE applying inserts. Used by replace-all + shrink paths to
+   * guarantee no stale (taskId, ordinal) conflicts survive.
+   */
+  fullDelete: boolean;
+}
+
+/**
+ * Plan the AC table mutations for a `cleo update --acceptance` call.
+ *
+ * Update semantics (per ADR-079-r1 §2.2 + task spec):
+ *   - **extend** (was 2, now 3): new AC gets ordinal=3; existing 1,2 unchanged.
+ *   - **shrink** (was 3, now 1): ACs 2 and 3 → history (reason='edit'); AC 1 stays.
+ *   - **replace-all**: ALL existing rows → history; new rows inserted from ordinal=1.
+ *
+ * "Replace-all" is detected when ANY of the in-place ordinals would change
+ * text — we can't tell from the input which existing AC each new AC maps
+ * to, so any text drift implies the operator wants a wholesale rewrite.
+ *
+ * "Extend" is the safe path: only when the new AC list is a strict prefix
+ * extension of the existing rows (all existing texts retained in order),
+ * we preserve the existing rows and append the new tail with continuing
+ * ordinals.
+ *
+ * "Shrink" is detected when the new list is a strict prefix of the
+ * existing texts (length N < existing length M, and texts 1..N match).
+ * The tail rows (N+1..M) are appended to history and then deleted.
+ *
+ * Any other shape (mid-edit, reorder, mixed) falls back to full
+ * replace-all — the safest semantic for the schema's "no ordinal reuse"
+ * invariant within a single transaction (ordinals only have to be unique
+ * after COMMIT, so a delete-then-insert in one tx is sound).
+ *
+ * @param taskId — task being updated
+ * @param existing — current AC rows from the table (ordered by ordinal ASC)
+ * @param incoming — new AC items from `--acceptance "a|b|c"`
+ * @returns plan to be applied in order: appendAcHistory → deleteAcRowsForTask (if fullDelete) → insertAcRows
+ */
+export function planAcUpdate(
+  taskId: string,
+  existing: readonly AcRow[],
+  incoming: readonly AcceptanceItem[],
+): AcUpdatePlan {
+  const incomingTexts = incoming.map(acItemToText);
+
+  // Case 1: extend — new list strictly extends the existing prefix.
+  if (incomingTexts.length >= existing.length) {
+    const isPrefixMatch = existing.every((row, idx) => row.text === incomingTexts[idx]);
+    if (isPrefixMatch) {
+      // Compute the starting ordinal for the new tail: highest existing
+      // ordinal + 1, OR 1 if there were none. Ordinals are NEVER reused,
+      // and the schema's UNIQUE (task_id, ordinal) enforces this.
+      const maxOrdinal = existing.reduce((m, row) => (row.ordinal > m ? row.ordinal : m), 0);
+      const tail = incomingTexts.slice(existing.length).map((text, i) => ({
+        id: randomUUID(),
+        taskId,
+        ordinal: maxOrdinal + 1 + i,
+        text,
+      }));
+      return { inserts: tail, history: [], fullDelete: false };
+    }
+  }
+
+  // Case 2: shrink — new list is a strict prefix of existing (no text drift).
+  if (incomingTexts.length < existing.length) {
+    const isStrictPrefix = incomingTexts.every((text, idx) => existing[idx]?.text === text);
+    if (isStrictPrefix) {
+      const tailRows = existing.slice(incomingTexts.length);
+      const history = tailRows.map((row) => ({
+        acId: row.id,
+        previousText: row.text,
+        reason: 'edit',
+      }));
+      // For shrink we DO need to delete the tail. We use the
+      // fullDelete-then-reinsert approach to keep the codepath uniform
+      // (insertAcRows below uses the kept prefix rows with their EXISTING
+      // ids + ordinals so binding stability survives).
+      const keepInserts = existing.slice(0, incomingTexts.length).map((row) => ({
+        id: row.id,
+        taskId,
+        ordinal: row.ordinal,
+        text: row.text,
+      }));
+      return { inserts: keepInserts, history, fullDelete: true };
+    }
+  }
+
+  // Case 3: replace-all (mid-edit, reorder, mixed, or text drift).
+  const history = existing.map((row) => ({
+    acId: row.id,
+    previousText: row.text,
+    reason: 'edit',
+  }));
+  const inserts = incomingTexts.map((text, idx) => ({
+    id: randomUUID(),
+    taskId,
+    ordinal: idx + 1,
+    text,
+  }));
+  return { inserts, history, fullDelete: true };
+}
+
+/**
+ * Convenience executor — apply an {@link AcUpdatePlan} against a transaction
+ * accessor in the required order: history append → delete (if requested) →
+ * insert. Caller MUST have already opened a transaction.
+ *
+ * @param tx — open transaction accessor
+ * @param taskId — task whose AC rows are being mutated
+ * @param plan — pre-computed plan from {@link planAcUpdate} or {@link buildFreshAcRows}
+ */
+export async function applyAcPlan(
+  tx: TransactionAccessor,
+  taskId: string,
+  plan: AcUpdatePlan,
+): Promise<void> {
+  if (plan.history.length > 0) {
+    await tx.appendAcHistory(plan.history);
+  }
+  if (plan.fullDelete) {
+    await tx.deleteAcRowsForTask(taskId);
+  }
+  if (plan.inserts.length > 0) {
+    await tx.insertAcRows(plan.inserts);
+  }
+}

--- a/packages/core/src/tasks/add.ts
+++ b/packages/core/src/tasks/add.ts
@@ -26,6 +26,7 @@ import { resolveOrCwd } from '../paths.js';
 import { allocateNextTaskId } from '../sequence/index.js';
 import { requireActiveSession } from '../sessions/session-enforcement.js';
 import type { DataAccessor, TransactionAccessor } from '../store/data-accessor.js';
+import { applyAcPlan, buildFreshAcRows } from './ac-table.js';
 import { createAcceptanceEnforcement } from './enforcement.js';
 import {
   findEpicAncestor,
@@ -1286,6 +1287,17 @@ export async function addTask(
 
     // Insert the new task
     await tx.upsertSingleTask(task);
+
+    // T10508 — DUAL WRITE: also persist AC rows into the new
+    // task_acceptance_criteria table (T10502). The legacy
+    // `tasks.acceptance` string lives on `task` and was just upserted
+    // above via upsertSingleTask. We additionally hydrate the row-table
+    // SSoT so future readers can resolve AC by stable UUID + ordinal.
+    if (options.acceptance?.length) {
+      const acRows = buildFreshAcRows(taskId, options.acceptance);
+      // Fresh task — no history, no delete. Insert is the only mutation.
+      await applyAcPlan(tx, taskId, { inserts: acRows, history: [], fullDelete: false });
+    }
 
     // Update project metadata if a new phase was created
     if (options.addPhase && phase && updatedProjectMeta?.phases?.[phase]) {

--- a/packages/core/src/tasks/show.ts
+++ b/packages/core/src/tasks/show.ts
@@ -24,6 +24,28 @@ import {
   toHistoryEntry,
 } from './engine-converters.js';
 
+/**
+ * Hydrated acceptance criterion row surfaced by `cleo show --verbose`.
+ *
+ * Surfaces the stable UUID (the binding target for `satisfies:<acId>`
+ * evidence atoms in T10503), the human-friendly `AC<ordinal>` alias, and
+ * the canonical text. Reads from `task_acceptance_criteria` (T10502) —
+ * NOT the legacy `tasks.acceptance` JSON string.
+ *
+ * @task T10508
+ * @epic T10381
+ */
+export interface AcDetail {
+  /** UUIDv4 stable identifier, immutable for the AC's lifetime. */
+  id: string;
+  /** Display alias derived from ordinal — `AC1`, `AC2`, etc. */
+  alias: string;
+  /** 1-based ordinal — never reused per task (gaps remain on shrink). */
+  ordinal: number;
+  /** The AC statement text. Structured gates round-trip as JSON. */
+  text: string;
+}
+
 /** Enriched task with hierarchy info. */
 export interface TaskDetail extends Task {
   children?: string[];
@@ -32,6 +54,15 @@ export interface TaskDetail extends Task {
   dependents?: string[];
   hierarchyPath?: string[];
   isArchived?: boolean;
+  /**
+   * Acceptance-criterion rows hydrated from `task_acceptance_criteria`.
+   * Present when the table contains AC rows for the task (post-T10508
+   * dual-write or T10505 backfill). Coexists with the legacy
+   * `acceptance` string field — readers should prefer `acRows` when
+   * present and fall back to `acceptance` otherwise.
+   * @task T10508
+   */
+  acRows?: AcDetail[];
   /** Progressive disclosure directives for follow-up operations. */
   _next?: NextDirectives;
 }
@@ -104,6 +135,25 @@ export async function showTask(
   }
 
   const detail: TaskDetail = { ...task, isArchived };
+
+  // T10508 — hydrate AC rows from the new task_acceptance_criteria table.
+  // Surfaced alongside the legacy `acceptance` string for dual-read.
+  // Surface zero rows as undefined so JSON output stays clean for tasks
+  // that haven't been backfilled yet.
+  try {
+    const acRows = await acc.getAcRows(taskId);
+    if (acRows.length > 0) {
+      detail.acRows = acRows.map((row) => ({
+        id: row.id,
+        alias: `AC${row.ordinal}`,
+        ordinal: row.ordinal,
+        text: row.text,
+      }));
+    }
+  } catch {
+    // AC table read is best-effort — never block `cleo show` if the
+    // table is missing (e.g. legacy DB pre-T10502 migration).
+  }
 
   // Add children (only check active tasks, archived tasks don't have active children)
   if (!isArchived) {

--- a/packages/core/src/tasks/update.ts
+++ b/packages/core/src/tasks/update.ts
@@ -25,6 +25,7 @@ import { requireActiveSession } from '../sessions/session-enforcement.js';
 import type { DataAccessor } from '../store/data-accessor.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { enforceAcceptanceImmutability } from './ac-immutability.js';
+import { applyAcPlan, planAcUpdate } from './ac-table.js';
 import {
   normalizePriority,
   validateLabels,
@@ -556,6 +557,7 @@ export async function updateTask(
   // Capture final relates state before transaction (built above from options)
   const finalRelates = task.relates ?? [];
   const isRelatesChange = changes.includes('relates');
+  const isAcceptanceChange = changes.includes('acceptance');
 
   // Wrap writes in a transaction for TOCTOU safety (T023)
   await acc.transaction(async (tx) => {
@@ -584,6 +586,18 @@ export async function updateTask(
           }
         }
       }
+    }
+
+    // T10508 — DUAL WRITE for `--acceptance`: the legacy
+    // `tasks.acceptance` JSON column was just upserted by
+    // upsertSingleTask above. We now plan the row-table SSoT mutations
+    // INSIDE the same transaction so a failure rolls both halves back.
+    // History rows are recorded BEFORE the delete, satisfying the
+    // shrink/replace-all ordering guarantee.
+    if (isAcceptanceChange && options.acceptance !== undefined) {
+      const existing = await tx.getAcRows(options.taskId);
+      const plan = planAcUpdate(options.taskId, existing, options.acceptance);
+      await applyAcPlan(tx, options.taskId, plan);
     }
 
     await tx.appendLog({


### PR DESCRIPTION
## Summary

Wires `cleo add --acceptance` and `cleo update --acceptance` to dual-write the new `task_acceptance_criteria` table from Wave 2a (T10502/T10504) — every AC now gets a UUIDv4 stable identifier the moment it is created, alongside the legacy `tasks.acceptance` JSON column that stays in sync for backward compatibility.

Saga: T10377 (SG-IVTR-AC-BINDING). Epic: T10381 (E-AC-MIGRATION). Decision: D013. ADR: ADR-079-r1.

## Update path semantics (ADR-079-r1 §2.2)

- **extend** (was N, now N+M with prefix match): new ACs append at `maxOrdinal+1`; existing rows untouched, no history written.
- **shrink** (was N, now M < N with strict prefix): trailing ACs append to `task_acceptance_criteria_history` with `reason='edit'` BEFORE the delete; kept prefix preserves its UUIDs + ordinals so `satisfies:` bindings (T10503) survive.
- **replace-all** (text drift / reorder / mid-edit): ALL existing rows → history; all new rows inserted with fresh UUIDs from ordinal=1.

All three paths run inside a single transaction wrapping the legacy `tasks.acceptance` write — failures roll both halves back.

## Surface changes

- **`cleo show <id>`** now hydrates `acRows` from `task_acceptance_criteria` when populated, returning `{ id, alias, ordinal, text }` per criterion. Consumers should prefer `acRows` and fall back to legacy `task.acceptance` when omitted.
- New `packages/core/src/tasks/ac-table.ts` — pure planner (`buildFreshAcRows`, `planAcUpdate`, `applyAcPlan`). CLI handlers stay thin per SG-ARCH-SOLID T9837.
- New `TransactionAccessor.{insertAcRows, getAcRows, deleteAcRowsForTask, appendAcHistory}` + `DataAccessor.getAcRows` + `TasksShowResult.acRows` + `TaskShowAcRowEntry` + `AcRow` contracts.

## Test plan

- [x] 13 planner units in `ac-table.test.ts` (acItemToText, buildFreshAcRows, all 4 update paths, idempotency, structured-gate JSON round-trip, empty-input edge)
- [x] 7 end-to-end integration tests in `ac-wiring.test.ts` (addTask AC writes, dual-write parity, all 4 update paths with history verification, transactional ordering)
- [x] `pnpm biome check --write` clean
- [x] `pnpm --filter @cleocode/core build` green
- [x] `pnpm --filter @cleocode/cleo build` green
- [x] `pnpm --filter @cleocode/contracts test` — 563/563 pass
- [x] `lint-changesets.mjs` — 162/162 entries valid
- [x] Verified pre-existing `update-relates.test.ts` + `import-logging.test.ts` failures exist on `main` (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)