### PR TITLE
feat(T10507): satisfies atom 5-check validator semantics

### DIFF
--- a/.changeset/t10507-satisfies-validator.md
+++ b/.changeset/t10507-satisfies-validator.md
@@ -1,0 +1,57 @@
+---
+id: t10507-satisfies-validator
+tasks: [T10507]
+kind: feat
+summary: "validator: 5-check satisfies atom semantics (T10381 Wave 2c)"
+---
+
+Implements the 5-check runtime validator for the
+`satisfies:<task-id>#<ac-id>[@<version-pin>]` evidence atom per ADR-079-r2
+§2.4. Replaces the `E_AC_BINDING_VALIDATOR_PENDING` placeholder T10506
+inserted in `packages/core/src/tasks/evidence.ts`.
+
+Pipeline (runs IN ORDER, first-failure-wins, NO further checks after
+the first failure):
+
+1. **malformed** → `E_AC_BINDING_MALFORMED` — defence-in-depth re-check
+   of the grammar (covers callers that bypass `parseEvidenceString`).
+2. **target-not-found** → `E_AC_BINDING_TARGET_NOT_FOUND` — target task
+   ID does not exist in the local `tasks` table.
+3. **target-terminal** → `E_AC_BINDING_TARGET_TERMINAL` — target task
+   is `cancelled` or `archived`. `done` is OK (workers routinely satisfy
+   ACs on already-shipped tasks per ADR-079-r2 §2.4 row 3).
+4. **ac-not-found** → `E_AC_BINDING_TARGET_AC_NOT_FOUND` — the AC
+   (resolved by UUID PK lookup OR `(task_id, ordinal)` alias lookup)
+   does not exist on the target task.
+5. **out-of-scope** → `E_AC_BINDING_OUT_OF_SCOPE` — source and target
+   tasks do not share a saga (or a root epic when neither is a saga
+   member). Same-saga membership resolved via the
+   `task_relations.relation_type='groups'` graph until T10494 ships
+   the forward-looking `tasks.saga_id` column.
+
+Alias-drift detection (ADR-079-r2 §3, hard-error path):
+`E_AC_ALIAS_DRIFTED` fires when an alias atom (`AC<n>`) resolves to a
+different canonical UUID than the one previously persisted in
+`evidence_ac_bindings` for the same `(source, target, alias)` triple.
+The worker MUST re-state the atom using the canonical UUID form. The
+soft `W_AC_ALIAS_DRIFTED` warning path is reserved for the
+AC-coverage gate (T10508).
+
+Surfaces:
+- `packages/core/src/lifecycle/verification/satisfies-validator.ts` —
+  new module owning the 5-check pipeline. Pure function of `(atom,
+  source-task-id, projectRoot)`; no side-effect writes (the binding
+  row insert is the dispatch layer's responsibility per the validator
+  invariant).
+- `packages/core/src/tasks/evidence.ts` — dispatch switch now delegates
+  the `satisfies` case to `validateSatisfiesAtom` via dynamic import,
+  mirroring the existing `validatePrAtom` pattern.
+- `packages/core/src/lifecycle/verification/__tests__/satisfies-validator.test.ts` —
+  25 tests covering all 5 failure paths, both happy paths (UUID + alias),
+  first-failure-wins ordering, alias drift detection (positive,
+  negative, UUID-form-immune), same-root-epic fallback, and
+  validateAtom-dispatch integration (regression guard against the
+  PENDING placeholder).
+
+Saga: T10377 (SG-IVTR-AC-BINDING). Epic: T10381. Decision: D013.
+ADR-079-r2 §2.4 + §3.

--- a/packages/core/src/lifecycle/verification/__tests__/satisfies-validator.test.ts
+++ b/packages/core/src/lifecycle/verification/__tests__/satisfies-validator.test.ts
@@ -1,0 +1,832 @@
+/**
+ * Unit tests for the ADR-079-r2 5-check satisfies-atom validator (T10507).
+ *
+ * Coverage:
+ *   - Each of the 5 failure paths (malformed, target-not-found,
+ *     target-terminal, ac-not-found, out-of-scope).
+ *   - The happy path for both UUID and alias atom forms.
+ *   - First-failure-wins ordering — a malformed atom never escalates
+ *     to a target-not-found check.
+ *   - Alias drift detection — when a previously-persisted binding
+ *     resolves the same `(source, target, alias)` triple to a different
+ *     UUID, the validator returns `E_AC_ALIAS_DRIFTED`.
+ *   - Same-saga scope is resolved via `task_relations.relation_type='groups'`
+ *     edges, with a same-root-epic fallback when neither side is a saga
+ *     member.
+ *
+ * @task T10507
+ * @epic T10381
+ * @saga T10377
+ * @adr ADR-079-r2
+ */
+
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createTestDb,
+  seedTasks,
+  type TestDbEnv,
+} from '../../../store/__tests__/test-db-helper.js';
+import { getDb } from '../../../store/sqlite.js';
+import * as schema from '../../../store/tasks-schema.js';
+import { validateAtom } from '../../../tasks/evidence.js';
+import { validateSatisfiesAtom } from '../satisfies-validator.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a strict lowercase UUIDv4 — the canonical AC id form per
+ * ADR-079-r2 §2.1 (the `ac-uuid` production). Wraps `crypto.randomUUID()`
+ * which already emits lowercase UUIDv4s with the correct version + variant
+ * nibbles.
+ */
+function uuid(): string {
+  return randomUUID();
+}
+
+/**
+ * Insert an AC row directly into `task_acceptance_criteria`. The test-db
+ * helper does not expose a high-level AC writer (none ships in T10502
+ * MVP), so we hit the table directly via drizzle.
+ */
+async function insertAc(
+  cwd: string,
+  acId: string,
+  taskId: string,
+  ordinal: number,
+  text = `AC body ${ordinal}`,
+): Promise<void> {
+  const db = await getDb(cwd);
+  await db.insert(schema.taskAcceptanceCriteria).values({ id: acId, taskId, ordinal, text }).run();
+}
+
+/**
+ * Insert an `evidence_ac_bindings` row to simulate a previously-persisted
+ * binding. Used by the alias-drift test.
+ */
+async function insertBinding(
+  cwd: string,
+  atomId: string,
+  acUuid: string,
+  bindingType: 'direct' | 'satisfies' | 'coverage' = 'satisfies',
+): Promise<void> {
+  const db = await getDb(cwd);
+  await db
+    .insert(schema.evidenceAcBindings)
+    .values({ id: uuid(), evidenceAtomId: atomId, acId: acUuid, bindingType })
+    .run();
+}
+
+/**
+ * Add a `task_relations.relation_type='groups'` edge from `sagaId` → `memberId`.
+ * Mirrors `accessor.addRelation` without going through the DataAccessor.
+ */
+async function linkSagaMember(cwd: string, sagaId: string, memberId: string): Promise<void> {
+  const db = await getDb(cwd);
+  await db
+    .insert(schema.taskRelations)
+    .values({ taskId: sagaId, relatedTo: memberId, relationType: 'groups' })
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('validateSatisfiesAtom — 5-check pipeline (T10507 · ADR-079-r2 §2.4)', () => {
+  let env: TestDbEnv;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await env.cleanup();
+  });
+
+  // ---------------------------------------------------------------------
+  // Check 1 — malformed
+  // ---------------------------------------------------------------------
+
+  describe('Check 1 — E_AC_BINDING_MALFORMED', () => {
+    it('rejects a targetTaskId that does not match /^T[0-9]{1,7}$/', async () => {
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'NOT_A_TASK_ID',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_MALFORMED');
+      expect(result.reason).toMatch(/targetTaskId/);
+    });
+
+    it('rejects when both UUID and alias are set', async () => {
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T100',
+          targetAcId: uuid(),
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_MALFORMED');
+    });
+
+    it('rejects when neither UUID nor alias is set', async () => {
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T100',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_MALFORMED');
+    });
+
+    it('rejects mixed-case UUIDs (ADR-079-r2 §2.2)', async () => {
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T100',
+          targetAcId: 'A1B2C3D4-5E6F-4890-ABCD-EF1234567890',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_MALFORMED');
+    });
+
+    it('rejects malformed version-pin (not 14 digits)', async () => {
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T100',
+          targetAcAlias: 'AC1',
+          versionPin: 'not-a-pin',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_MALFORMED');
+    });
+
+    it('first-failure-wins — malformed atom does NOT escalate to target-not-found', async () => {
+      // T999999999 (9 digits) is malformed AND the task does not exist.
+      // The validator MUST surface E_AC_BINDING_MALFORMED, NOT E_AC_BINDING_TARGET_NOT_FOUND.
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T999999999',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_MALFORMED');
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Check 2 — target task not found
+  // ---------------------------------------------------------------------
+
+  describe('Check 2 — E_AC_BINDING_TARGET_NOT_FOUND', () => {
+    it('rejects when target task does not exist in tasks table', async () => {
+      // Seed only the source task — target T200 is intentionally absent.
+      await seedTasks(env.accessor, [
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_TARGET_NOT_FOUND');
+      expect(result.reason).toMatch(/T200/);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Check 3 — target task terminal
+  // ---------------------------------------------------------------------
+
+  describe('Check 3 — E_AC_BINDING_TARGET_TERMINAL', () => {
+    it('rejects when target task status is "cancelled"', async () => {
+      await seedTasks(env.accessor, [
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        {
+          id: 'T200',
+          title: 'cancelled target',
+          type: 'task',
+          status: 'cancelled',
+          priority: 'medium',
+        },
+      ]);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_TARGET_TERMINAL');
+      expect(result.reason).toMatch(/cancelled/);
+    });
+
+    it('rejects when target task status is "archived"', async () => {
+      await seedTasks(env.accessor, [
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        {
+          id: 'T200',
+          title: 'archived target',
+          type: 'task',
+          status: 'archived',
+          priority: 'medium',
+        },
+      ]);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_TARGET_TERMINAL');
+    });
+
+    it('ACCEPTS targets with status "done" (ADR-079-r2 §2.4 row 3)', async () => {
+      // done is allowed — workers routinely satisfy ACs on already-shipped tasks.
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        {
+          id: 'T200',
+          title: 'done target',
+          type: 'task',
+          status: 'done',
+          priority: 'medium',
+          parentId: undefined,
+        },
+      ]);
+      // Both T100 and T200 are top-level (no parent), so they share root
+      // epic anchors of themselves — out-of-scope. Wire them into the same
+      // saga to pass check 5.
+      await seedTasks(env.accessor, [
+        {
+          id: 'TS-SAGA-1',
+          title: 'saga',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+      ]);
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T100');
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T200');
+      await insertAc(env.tempDir, acId, 'T200', 1);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error(`expected ok, got ${result.codeName}: ${result.reason}`);
+      expect(result.atom.resolvedAcUuid).toBe(acId);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Check 4 — AC not found
+  // ---------------------------------------------------------------------
+
+  describe('Check 4 — E_AC_BINDING_TARGET_AC_NOT_FOUND', () => {
+    it('rejects when UUID does not exist on the target task', async () => {
+      await seedTasks(env.accessor, [
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcId: uuid(),
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_TARGET_AC_NOT_FOUND');
+    });
+
+    it('rejects when alias does not resolve on the target task', async () => {
+      await seedTasks(env.accessor, [
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await insertAc(env.tempDir, uuid(), 'T200', 1); // only AC1 exists
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC42', // no AC at ordinal 42
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_TARGET_AC_NOT_FOUND');
+      expect(result.reason).toMatch(/AC42/);
+    });
+
+    it('rejects when UUID exists on a different task than the target', async () => {
+      const ac200 = uuid();
+      await seedTasks(env.accessor, [
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T300', title: 'other', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      // AC belongs to T300, not the target T200.
+      await insertAc(env.tempDir, ac200, 'T300', 1);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcId: ac200,
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_TARGET_AC_NOT_FOUND');
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Check 5 — out of scope
+  // ---------------------------------------------------------------------
+
+  describe('Check 5 — E_AC_BINDING_OUT_OF_SCOPE', () => {
+    it('rejects when source and target are not members of the same saga', async () => {
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        {
+          id: 'TS-SAGA-A',
+          title: 'saga A',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+        {
+          id: 'TS-SAGA-B',
+          title: 'saga B',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await linkSagaMember(env.tempDir, 'TS-SAGA-A', 'T100');
+      await linkSagaMember(env.tempDir, 'TS-SAGA-B', 'T200');
+      await insertAc(env.tempDir, acId, 'T200', 1);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_OUT_OF_SCOPE');
+    });
+
+    it('rejects when neither task is in any saga AND their root epics differ', async () => {
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        { id: 'E-A', title: 'epic A', type: 'epic', status: 'pending', priority: 'high' },
+        { id: 'E-B', title: 'epic B', type: 'epic', status: 'pending', priority: 'high' },
+        {
+          id: 'T100',
+          title: 'source',
+          type: 'task',
+          status: 'pending',
+          priority: 'medium',
+          parentId: 'E-A',
+        },
+        {
+          id: 'T200',
+          title: 'target',
+          type: 'task',
+          status: 'pending',
+          priority: 'medium',
+          parentId: 'E-B',
+        },
+      ]);
+      await insertAc(env.tempDir, acId, 'T200', 1);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_OUT_OF_SCOPE');
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Happy path — UUID + alias forms
+  // ---------------------------------------------------------------------
+
+  describe('Happy path', () => {
+    it('accepts canonical UUID form when same-saga + AC exists + target non-terminal', async () => {
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        {
+          id: 'TS-SAGA-1',
+          title: 'saga',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T100');
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T200');
+      await insertAc(env.tempDir, acId, 'T200', 1);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcId: acId,
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error(`expected ok, got ${result.codeName}: ${result.reason}`);
+      expect(result.atom.kind).toBe('satisfies');
+      expect(result.atom.targetTaskId).toBe('T200');
+      expect(result.atom.targetAcId).toBe(acId);
+      expect(result.atom.resolvedAcUuid).toBe(acId);
+    });
+
+    it('accepts alias form and populates resolvedAcUuid from the alias lookup', async () => {
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        {
+          id: 'TS-SAGA-1',
+          title: 'saga',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T100');
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T200');
+      await insertAc(env.tempDir, acId, 'T200', 2);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC2',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error(`expected ok, got ${result.codeName}: ${result.reason}`);
+      expect(result.atom.resolvedAcUuid).toBe(acId);
+      expect(result.atom.targetAcAlias).toBe('AC2');
+      expect(result.atom.targetAcId).toBeUndefined();
+    });
+
+    it('accepts when sourceTaskId is undefined (scope check skipped)', async () => {
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await insertAc(env.tempDir, acId, 'T200', 1);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        undefined, // sourceTaskId omitted — scope check skipped
+        env.tempDir,
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it('accepts self-binding (source == target) without scope check', async () => {
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        { id: 'T100', title: 'self', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await insertAc(env.tempDir, acId, 'T100', 1);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T100',
+          targetAcAlias: 'AC1',
+        },
+        'T100', // same as target — scope check short-circuits
+        env.tempDir,
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it('accepts cross-epic atoms when both tasks share the same root epic (fallback)', async () => {
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        { id: 'E-ROOT', title: 'root epic', type: 'epic', status: 'pending', priority: 'high' },
+        {
+          id: 'T100',
+          title: 'source',
+          type: 'task',
+          status: 'pending',
+          priority: 'medium',
+          parentId: 'E-ROOT',
+        },
+        {
+          id: 'T200',
+          title: 'target',
+          type: 'task',
+          status: 'pending',
+          priority: 'medium',
+          parentId: 'E-ROOT',
+        },
+      ]);
+      await insertAc(env.tempDir, acId, 'T200', 1);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Alias drift detection (ADR-079-r2 §3)
+  // ---------------------------------------------------------------------
+
+  describe('E_AC_ALIAS_DRIFTED', () => {
+    it('fires when alias resolves to a different UUID than the previously-persisted binding', async () => {
+      const oldAcId = uuid();
+      const newAcId = uuid();
+      await seedTasks(env.accessor, [
+        {
+          id: 'TS-SAGA-1',
+          title: 'saga',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T100');
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T200');
+      // AC1 on T200 now resolves to newAcId, but the old binding pointed at oldAcId.
+      await insertAc(env.tempDir, newAcId, 'T200', 1);
+
+      // Simulate the previously-persisted binding: atom id encodes
+      // source=T100, target=T200, alias=AC1; previously resolved to oldAcId.
+      await insertBinding(env.tempDir, 'satisfies:T100->T200#AC1', oldAcId);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_ALIAS_DRIFTED');
+      expect(result.reason).toMatch(/drifted/i);
+      expect(result.reason).toMatch(newAcId);
+    });
+
+    it('does NOT fire when previously-persisted binding matches the current resolution', async () => {
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        {
+          id: 'TS-SAGA-1',
+          title: 'saga',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T100');
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T200');
+      await insertAc(env.tempDir, acId, 'T200', 1);
+      // Previous binding pointed at the SAME UUID — no drift.
+      await insertBinding(env.tempDir, 'satisfies:T100->T200#AC1', acId);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it('integration — validateAtom dispatch delegates to the satisfies validator (no PENDING placeholder)', async () => {
+      // Regression guard: T10506 inserted an E_AC_BINDING_VALIDATOR_PENDING
+      // placeholder that T10507 must replace. This test fails if the
+      // placeholder is still in place.
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        {
+          id: 'TS-SAGA-1',
+          title: 'saga',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T100');
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T200');
+      await insertAc(env.tempDir, acId, 'T200', 1);
+
+      const result = await validateAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        env.tempDir,
+        'T100',
+      );
+      // Must NOT return the PENDING placeholder code.
+      if (!result.ok) {
+        expect(result.codeName).not.toBe('E_AC_BINDING_VALIDATOR_PENDING');
+      }
+      expect(result.ok).toBe(true);
+    });
+
+    it('integration — validateAtom dispatch rejects out-of-scope cross-saga atom', async () => {
+      const acId = uuid();
+      await seedTasks(env.accessor, [
+        {
+          id: 'TS-SAGA-A',
+          title: 'saga A',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+        {
+          id: 'TS-SAGA-B',
+          title: 'saga B',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await linkSagaMember(env.tempDir, 'TS-SAGA-A', 'T100');
+      await linkSagaMember(env.tempDir, 'TS-SAGA-B', 'T200');
+      await insertAc(env.tempDir, acId, 'T200', 1);
+
+      const result = await validateAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcAlias: 'AC1',
+        },
+        env.tempDir,
+        'T100',
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.codeName).toBe('E_AC_BINDING_OUT_OF_SCOPE');
+    });
+
+    it('does NOT fire on UUID-form atoms (only alias form is drift-prone)', async () => {
+      const acId = uuid();
+      const otherAcId = uuid();
+      await seedTasks(env.accessor, [
+        {
+          id: 'TS-SAGA-1',
+          title: 'saga',
+          type: 'epic',
+          status: 'pending',
+          priority: 'high',
+          labels: ['saga'],
+        },
+        { id: 'T100', title: 'source', type: 'task', status: 'pending', priority: 'medium' },
+        { id: 'T200', title: 'target', type: 'task', status: 'pending', priority: 'medium' },
+      ]);
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T100');
+      await linkSagaMember(env.tempDir, 'TS-SAGA-1', 'T200');
+      await insertAc(env.tempDir, acId, 'T200', 1);
+      // Even with a conflicting previous binding under an alias atom, the
+      // UUID-form atom should NOT trigger drift detection.
+      await insertBinding(env.tempDir, 'satisfies:T100->T200#AC1', otherAcId);
+
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: 'T200',
+          targetAcId: acId, // canonical form
+        },
+        'T100',
+        env.tempDir,
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/lifecycle/verification/satisfies-validator.ts
+++ b/packages/core/src/lifecycle/verification/satisfies-validator.ts
@@ -1,0 +1,559 @@
+/**
+ * Runtime validator for the ADR-079-r2 `satisfies:<task-id>#<ac-id>` evidence
+ * atom — the 5-check pipeline shipped by T10507.
+ *
+ * # Why a dedicated module
+ *
+ * The parser for the atom (T10506) lives in
+ * `packages/contracts/src/evidence-atom-schema.ts`. The dispatch entry
+ * point that consumes the parsed atom lives in
+ * `packages/core/src/tasks/evidence.ts::validateAtom`. The 5-check semantics
+ * are non-trivial — they touch the tasks table, the AC table, the AC-history
+ * table, and the saga membership graph — so they get their own module to
+ * keep `evidence.ts` focused on dispatch.
+ *
+ * # First-failure-wins
+ *
+ * Per ADR-079-r2 §2.4, the 5 checks run **in order** and the validator
+ * returns the FIRST failure with its corresponding error code. NO further
+ * checks run once one has failed. This is critical for stability: an atom
+ * with a malformed task-id MUST surface `E_AC_BINDING_MALFORMED`, not
+ * `E_AC_BINDING_TARGET_NOT_FOUND`, even though both would technically
+ * apply.
+ *
+ * The checks are ordered cheapest-first so a malformed atom does not
+ * touch the DB at all and an out-of-scope atom is detected only AFTER
+ * the cheap target+ac existence checks have passed.
+ *
+ * # Same-saga scope (ADR-079-r2 §2.3)
+ *
+ * The forward-looking `tasks.saga_id` column has not yet shipped (T10494
+ * owns the migration). Until it lands, same-saga membership is resolved
+ * via the `task_relations` table where `relation_type='groups'` (the
+ * canonical Saga-membership representation per ADR-073 §1.2 I3). The
+ * resolution is bi-directional: a task A and a task B share a saga IFF
+ * there exists a saga task S such that S→A and S→B both have
+ * `relation_type='groups'` edges. As a fallback (no saga membership on
+ * either task), A and B are considered "same scope" IFF they share the
+ * same root epic — resolved by walking `parent_id` ancestors until a
+ * top-level epic is reached.
+ *
+ * # Alias drift detection
+ *
+ * Per ADR-079-r2 §3, the `E_AC_ALIAS_DRIFTED` error fires when an atom
+ * captured under an alias (`AC<n>`) at mint time now resolves to a
+ * different canonical UUID than what was previously persisted in the
+ * binding side-effect table. The soft warning `W_AC_ALIAS_DRIFTED` is
+ * surfaced (NOT yet treated as an error) when an atom-rewrite would
+ * be required to keep the binding stable — implementation is reserved
+ * for the AC-coverage gate (T10508 / ADR-079-r4). T10507 ships the
+ * hard error path; the soft warning is a forward-looking placeholder.
+ *
+ * # Side effects
+ *
+ * On accept, the validator returns the canonicalised
+ * `EvidenceAtom` with `resolvedAcUuid` populated. Writing the binding
+ * row into `evidence_ac_bindings` is the dispatch layer's
+ * responsibility — keeping this module side-effect-free preserves the
+ * "validator is a pure function of (atom, state)" invariant the rest
+ * of the evidence pipeline relies on.
+ *
+ * @task T10507
+ * @epic T10381
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ * @adr ADR-079-r2
+ */
+
+import type { EvidenceAtom } from '@cleocode/contracts';
+import { TERMINAL_TASK_STATUSES } from '@cleocode/contracts';
+import { and, eq } from 'drizzle-orm';
+import { getDb } from '../../store/sqlite.js';
+import * as schema from '../../store/tasks-schema.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Parsed-atom shape consumed by {@link validateSatisfiesAtom}.
+ *
+ * Mirrors the `satisfies` arm of the `ParsedAtom` union exported from
+ * `evidence.ts` — duplicated here to keep this module standalone and
+ * avoid an import cycle through `tasks/evidence.ts`. The contract is
+ * pinned by ADR-079-r2 §2.1 ABNF.
+ */
+export interface ParsedSatisfiesAtom {
+  /** Atom discriminator. */
+  kind: 'satisfies';
+  /** `T<1-7 digits>` per ADR-079-r2 §2.1. */
+  targetTaskId: string;
+  /** Lowercase UUIDv4 — populated for canonical form. */
+  targetAcId?: string;
+  /** `AC<1-4 digits>` alias — populated for alias form. */
+  targetAcAlias?: string;
+  /** Optional `@YYYYMMDDhhmmss` pin captured at mint time. */
+  versionPin?: string;
+}
+
+/**
+ * Validator outcome — mirrors `AtomValidation` from `evidence.ts` but
+ * specialised for the satisfies atom so callers can pattern-match on
+ * the canonical `resolvedAcUuid` populated on success.
+ */
+export type SatisfiesValidation =
+  | { ok: true; atom: Extract<EvidenceAtom, { kind: 'satisfies' }> }
+  | { ok: false; reason: string; codeName: SatisfiesErrorCode };
+
+/**
+ * Hard-error codes surfaced by the 5-check validator pipeline.
+ *
+ * Codes follow the existing `E_<DOMAIN>_<REASON>` convention. The first
+ * five mirror ADR-079-r2 §3 exactly; `E_AC_ALIAS_DRIFTED` is the
+ * sixth code that fires at validate-time when the alias resolves to
+ * a UUID that differs from the one previously persisted under the
+ * same `(source, target_task, alias)` triple.
+ */
+export type SatisfiesErrorCode =
+  | 'E_AC_BINDING_MALFORMED'
+  | 'E_AC_BINDING_TARGET_NOT_FOUND'
+  | 'E_AC_BINDING_TARGET_TERMINAL'
+  | 'E_AC_BINDING_TARGET_AC_NOT_FOUND'
+  | 'E_AC_BINDING_OUT_OF_SCOPE'
+  | 'E_AC_ALIAS_DRIFTED';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate the surface shape of the parsed atom one more time. Per
+ * ADR-079-r2 §2.4 check 1, the validator MUST re-confirm the malformed
+ * grammar even though the parser already did — defence-in-depth against
+ * callers that construct a `ParsedSatisfiesAtom` programmatically and
+ * bypass `parseEvidenceString`.
+ */
+function isMalformed(atom: ParsedSatisfiesAtom): string | null {
+  if (typeof atom.targetTaskId !== 'string' || !/^T[0-9]{1,7}$/.test(atom.targetTaskId)) {
+    return `targetTaskId "${atom.targetTaskId}" must match /^T[0-9]{1,7}$/`;
+  }
+  const hasUuid = typeof atom.targetAcId === 'string';
+  const hasAlias = typeof atom.targetAcAlias === 'string';
+  // Exactly one of UUID / alias MUST be set — never both, never neither.
+  if (hasUuid === hasAlias) {
+    return `exactly one of targetAcId (UUID) or targetAcAlias (AC<n>) must be set`;
+  }
+  if (hasUuid && atom.targetAcId !== undefined) {
+    if (
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(atom.targetAcId)
+    ) {
+      return `targetAcId "${atom.targetAcId}" must be a lowercase UUIDv4`;
+    }
+  }
+  if (hasAlias && atom.targetAcAlias !== undefined) {
+    if (!/^AC[0-9]{1,4}$/.test(atom.targetAcAlias)) {
+      return `targetAcAlias "${atom.targetAcAlias}" must match /^AC[0-9]{1,4}$/`;
+    }
+  }
+  if (atom.versionPin !== undefined && !/^[0-9]{14}$/.test(atom.versionPin)) {
+    return `versionPin "${atom.versionPin}" must be 14 digits (YYYYMMDDhhmmss)`;
+  }
+  return null;
+}
+
+/** Drizzle DB type alias — opaque to consumers. */
+type Db = Awaited<ReturnType<typeof getDb>>;
+
+/**
+ * Walk `parent_id` ancestors of `taskId` until a top-level row
+ * (`parent_id IS NULL`) is reached, returning that row's id. Used as
+ * the same-saga scope fallback when neither the source nor the target
+ * is a member of any saga.
+ *
+ * Bounded to 32 hops as a defensive guard against cycles — the maxDepth
+ * invariant from ADR-073 §1.2 I7 is 3 but a corrupted DB could in
+ * principle introduce a longer chain. 32 is more than 10x the legitimate
+ * upper bound.
+ */
+async function resolveRootEpic(db: Db, taskId: string): Promise<string | null> {
+  let currentId: string = taskId;
+  for (let depth = 0; depth < 32; depth++) {
+    const rows: Array<{ id: string; parentId: string | null }> = await db
+      .select({ id: schema.tasks.id, parentId: schema.tasks.parentId })
+      .from(schema.tasks)
+      .where(eq(schema.tasks.id, currentId))
+      .all();
+    if (rows.length === 0) return null;
+    const row = rows[0];
+    if (row === undefined) return null;
+    if (row.parentId === null) {
+      return row.id;
+    }
+    currentId = row.parentId;
+  }
+  return null;
+}
+
+/**
+ * Find every saga task that groups `taskId` as a member via
+ * `task_relations.relation_type='groups'` edges. Returns the saga IDs
+ * in stable insertion order. Empty when `taskId` is not a saga
+ * member.
+ */
+async function findSagasGroupingTaskId(db: Db, taskId: string): Promise<string[]> {
+  const rows = await db
+    .select({ taskId: schema.taskRelations.taskId })
+    .from(schema.taskRelations)
+    .where(
+      and(
+        eq(schema.taskRelations.relatedTo, taskId),
+        eq(schema.taskRelations.relationType, 'groups'),
+      ),
+    )
+    .all();
+  return rows.map((r) => r.taskId);
+}
+
+/**
+ * Resolve the same-saga scope of `taskId`. Returns either:
+ *   - The set of saga IDs grouping `taskId` (non-empty when the task is
+ *     a saga member), OR
+ *   - A singleton set containing the task's root epic ID when no saga
+ *     groups it (per ADR-079-r2 §2.3 fallback).
+ *
+ * Returns `null` when the task cannot be resolved (deleted? corrupted
+ * parent chain?) — caller surfaces that as `E_AC_BINDING_TARGET_NOT_FOUND`
+ * or `E_AC_BINDING_OUT_OF_SCOPE` depending on which side of the binding
+ * is missing.
+ */
+async function resolveScopeAnchors(
+  db: Db,
+  taskId: string,
+): Promise<{ kind: 'saga'; anchors: string[] } | { kind: 'epic'; anchor: string } | null> {
+  const sagas = await findSagasGroupingTaskId(db, taskId);
+  if (sagas.length > 0) {
+    return { kind: 'saga', anchors: sagas };
+  }
+  const rootEpic = await resolveRootEpic(db, taskId);
+  if (rootEpic === null) return null;
+  return { kind: 'epic', anchor: rootEpic };
+}
+
+/**
+ * Check whether `sourceId` and `targetId` share a same-saga (or
+ * same-root-epic) anchor. The check is symmetric: A→B and B→A both
+ * resolve the same way.
+ */
+async function shareScope(db: Db, sourceId: string, targetId: string): Promise<boolean> {
+  const srcScope = await resolveScopeAnchors(db, sourceId);
+  const tgtScope = await resolveScopeAnchors(db, targetId);
+  if (srcScope === null || tgtScope === null) return false;
+  // Both anchored in saga(s) — at least one common saga.
+  if (srcScope.kind === 'saga' && tgtScope.kind === 'saga') {
+    const tgtSet = new Set(tgtScope.anchors);
+    return srcScope.anchors.some((s) => tgtSet.has(s));
+  }
+  // One side is saga-anchored, the other root-epic-anchored — only
+  // share scope if the root-epic anchor is one of the saga's member-
+  // walks. Defensive: such a configuration is rare in practice (one
+  // task in a saga, sibling not yet linked), so we treat it as
+  // out-of-scope and require the orchestrator to link explicitly.
+  if (srcScope.kind === 'saga' || tgtScope.kind === 'saga') {
+    return false;
+  }
+  // Both root-epic-anchored — share scope IFF root epics match.
+  return srcScope.anchor === tgtScope.anchor;
+}
+
+/**
+ * Resolve an `AC<n>` alias to the canonical `task_acceptance_criteria.id`
+ * UUID for the given target task. Returns `null` when the alias does not
+ * resolve (no AC with that ordinal on the task).
+ */
+async function resolveAliasToUuid(
+  db: Db,
+  targetTaskId: string,
+  alias: string,
+): Promise<string | null> {
+  const ordinalMatch = /^AC([0-9]{1,4})$/.exec(alias);
+  if (!ordinalMatch) return null;
+  const ordinal = Number.parseInt(ordinalMatch[1] ?? '', 10);
+  if (!Number.isFinite(ordinal) || ordinal < 1) return null;
+  const rows = await db
+    .select({ id: schema.taskAcceptanceCriteria.id })
+    .from(schema.taskAcceptanceCriteria)
+    .where(
+      and(
+        eq(schema.taskAcceptanceCriteria.taskId, targetTaskId),
+        eq(schema.taskAcceptanceCriteria.ordinal, ordinal),
+      ),
+    )
+    .all();
+  return rows[0]?.id ?? null;
+}
+
+/**
+ * Check whether `acUuid` exists on `targetTaskId`. Used for the
+ * UUID-form path of check 4.
+ */
+async function uuidExistsOnTask(db: Db, targetTaskId: string, acUuid: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: schema.taskAcceptanceCriteria.id })
+    .from(schema.taskAcceptanceCriteria)
+    .where(
+      and(
+        eq(schema.taskAcceptanceCriteria.id, acUuid),
+        eq(schema.taskAcceptanceCriteria.taskId, targetTaskId),
+      ),
+    )
+    .all();
+  return rows.length > 0;
+}
+
+/**
+ * Detect alias drift: the alias on the atom resolves to a UUID that
+ * differs from a previously-persisted binding for the same
+ * `(source_task, target_task, alias)` triple. Returns the previously-
+ * persisted UUID when drift is detected, `null` otherwise.
+ *
+ * Returns `null` when `evidence_ac_bindings` is unavailable (e.g.
+ * table not yet migrated — gracefully no-op).
+ */
+async function detectAliasDrift(
+  db: Db,
+  sourceTaskId: string | undefined,
+  targetTaskId: string,
+  alias: string,
+  currentUuid: string,
+): Promise<string | null> {
+  if (sourceTaskId === undefined) return null;
+  try {
+    const rows = await db
+      .select({
+        acId: schema.evidenceAcBindings.acId,
+        evidenceAtomId: schema.evidenceAcBindings.evidenceAtomId,
+      })
+      .from(schema.evidenceAcBindings)
+      .where(eq(schema.evidenceAcBindings.bindingType, 'satisfies'))
+      .all();
+    // The stable atom id pattern follows the form used by writers
+    // (T10505/T10506) but is not yet finalised — we match conservatively
+    // by scanning for any binding whose atom id encodes the same
+    // (source, target, alias) triple. The id format is opaque to this
+    // module; we expect it to contain the alias literal so the
+    // conservative substring match suffices.
+    const aliasMarker = `${targetTaskId}#${alias}`;
+    for (const row of rows) {
+      if (
+        typeof row.evidenceAtomId === 'string' &&
+        row.evidenceAtomId.includes(aliasMarker) &&
+        row.evidenceAtomId.includes(sourceTaskId) &&
+        row.acId !== currentUuid
+      ) {
+        return row.acId;
+      }
+    }
+    return null;
+  } catch {
+    // Table missing or schema mismatch — no historical record means no drift.
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public validator
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a parsed `satisfies:<task-id>#<ac-id>[@<version-pin>]` atom
+ * against the live tasks DB. Runs the 5 checks from ADR-079-r2 §2.4
+ * IN ORDER, returning the FIRST failure (early return — no further
+ * checks once one has failed).
+ *
+ * @param parsed - Parsed atom (post-grammar, pre-runtime check).
+ * @param sourceTaskId - The task that bears the atom — used for the
+ *   same-saga scope check. May be omitted by callers that don't have
+ *   the task context (e.g. CLI smoke tests); when undefined, check 5
+ *   (out-of-scope) is SKIPPED — caller is responsible for stamping
+ *   the task id before invoking `validateAtom`.
+ * @param projectRoot - Absolute path to project root (drives tasks-db
+ *   resolution).
+ * @returns Success carries the canonicalised
+ *   {@link EvidenceAtom['satisfies']} (with `resolvedAcUuid` populated);
+ *   failure carries the first applicable {@link SatisfiesErrorCode}.
+ *
+ * @adr ADR-079-r2 §2.4 (validator semantics)
+ * @adr ADR-079-r2 §3 (error codes)
+ * @task T10507
+ */
+export async function validateSatisfiesAtom(
+  parsed: ParsedSatisfiesAtom,
+  sourceTaskId: string | undefined,
+  projectRoot: string,
+): Promise<SatisfiesValidation> {
+  // -------------------------------------------------------------------
+  // Check 1 — Malformed (re-check; cheap, no DB)
+  // -------------------------------------------------------------------
+  const malformedReason = isMalformed(parsed);
+  if (malformedReason !== null) {
+    return {
+      ok: false,
+      reason: `satisfies atom malformed: ${malformedReason}`,
+      codeName: 'E_AC_BINDING_MALFORMED',
+    };
+  }
+
+  const db = await getDb(projectRoot);
+
+  // -------------------------------------------------------------------
+  // Check 2 — Target task exists
+  // -------------------------------------------------------------------
+  const targetTaskRows = await db
+    .select({ id: schema.tasks.id, status: schema.tasks.status })
+    .from(schema.tasks)
+    .where(eq(schema.tasks.id, parsed.targetTaskId))
+    .all();
+  if (targetTaskRows.length === 0) {
+    return {
+      ok: false,
+      reason:
+        `satisfies: target task "${parsed.targetTaskId}" does not exist in the local tasks table. ` +
+        `Verify the task ID via 'cleo find ${parsed.targetTaskId}' or 'cleo show ${parsed.targetTaskId}'.`,
+      codeName: 'E_AC_BINDING_TARGET_NOT_FOUND',
+    };
+  }
+  const targetTask = targetTaskRows[0];
+
+  // -------------------------------------------------------------------
+  // Check 3 — Target task NOT in terminal state
+  //
+  // ADR-079-r2 §2.4 row 3 says status ∈ {pending, active, done}.
+  // We use TERMINAL_TASK_STATUSES from contracts (cancelled, archived,
+  // done) and invert — but the ADR explicitly allows `done` because
+  // workers routinely satisfy ACs on already-shipped tasks. So the
+  // forbidden set is `cancelled` + `archived` (+ legacy `deleted` if
+  // such a status ever exists). `done` is OK.
+  // -------------------------------------------------------------------
+  const FORBIDDEN_STATUSES: ReadonlySet<string> = new Set(
+    [...TERMINAL_TASK_STATUSES].filter((s) => s !== 'done'),
+  );
+  if (typeof targetTask.status === 'string' && FORBIDDEN_STATUSES.has(targetTask.status)) {
+    return {
+      ok: false,
+      reason:
+        `satisfies: target task "${parsed.targetTaskId}" is in terminal state "${targetTask.status}". ` +
+        `Atoms may only target tasks in {pending, active, done}. ` +
+        `Cancelled or archived tasks cannot satisfy live evidence chains.`,
+      codeName: 'E_AC_BINDING_TARGET_TERMINAL',
+    };
+  }
+
+  // -------------------------------------------------------------------
+  // Check 4 — AC exists on the target task
+  //
+  // Resolve to the canonical UUID — even when the atom carried the
+  // alias form. The canonical UUID is what gets persisted in
+  // `evidence_ac_bindings` so the AC-coverage gate (T10508) is alias-
+  // drift-safe (per ADR-079-r2 §2.5).
+  // -------------------------------------------------------------------
+  let resolvedAcUuid: string | null = null;
+  if (parsed.targetAcId !== undefined) {
+    // Canonical UUID path — verify it actually exists on the target task
+    // (a free-floating UUID that does not belong to the target task is
+    // still an AC-not-found from the binding's perspective).
+    const exists = await uuidExistsOnTask(db, parsed.targetTaskId, parsed.targetAcId);
+    if (!exists) {
+      return {
+        ok: false,
+        reason:
+          `satisfies: AC "${parsed.targetAcId}" does not exist on target task "${parsed.targetTaskId}". ` +
+          `Run 'cleo show ${parsed.targetTaskId}' to list its acceptance criteria.`,
+        codeName: 'E_AC_BINDING_TARGET_AC_NOT_FOUND',
+      };
+    }
+    resolvedAcUuid = parsed.targetAcId;
+  } else if (parsed.targetAcAlias !== undefined) {
+    // Alias path — resolve via (task_id, ordinal) lookup.
+    resolvedAcUuid = await resolveAliasToUuid(db, parsed.targetTaskId, parsed.targetAcAlias);
+    if (resolvedAcUuid === null) {
+      return {
+        ok: false,
+        reason:
+          `satisfies: alias "${parsed.targetAcAlias}" does not resolve to any AC on target task "${parsed.targetTaskId}". ` +
+          `Run 'cleo show ${parsed.targetTaskId}' to list its acceptance criteria (the alias is the 1-based AC<n> position).`,
+        codeName: 'E_AC_BINDING_TARGET_AC_NOT_FOUND',
+      };
+    }
+    // -------------------------------------------------------------------
+    // Alias drift detection (ADR-079-r2 §3 — hard error path)
+    //
+    // Compare the alias's current canonical UUID against any
+    // previously-persisted binding for the same (source, target, alias)
+    // triple. When they disagree, the alias has shifted — the worker
+    // MUST re-state the atom using the canonical UUID form.
+    // -------------------------------------------------------------------
+    const driftedFrom = await detectAliasDrift(
+      db,
+      sourceTaskId,
+      parsed.targetTaskId,
+      parsed.targetAcAlias,
+      resolvedAcUuid,
+    );
+    if (driftedFrom !== null) {
+      return {
+        ok: false,
+        reason:
+          `satisfies: alias "${parsed.targetAcAlias}" on target "${parsed.targetTaskId}" has drifted — ` +
+          `previously resolved to ${driftedFrom}, now resolves to ${resolvedAcUuid}. ` +
+          `Re-emit the atom using the canonical UUID form to lock the binding: ` +
+          `satisfies:${parsed.targetTaskId}#${resolvedAcUuid}`,
+        codeName: 'E_AC_ALIAS_DRIFTED',
+      };
+    }
+  } else {
+    // Defence-in-depth — covered by check 1 but exhausting the union
+    // here keeps TypeScript exhaustiveness happy.
+    return {
+      ok: false,
+      reason: `satisfies: neither targetAcId nor targetAcAlias is set`,
+      codeName: 'E_AC_BINDING_MALFORMED',
+    };
+  }
+
+  // -------------------------------------------------------------------
+  // Check 5 — Same-saga (or same-root-epic) scope
+  //
+  // Costliest check — runs ONLY after target+ac existence verified.
+  // Skipped when `sourceTaskId` is undefined (caller is responsible
+  // for stamping the task id; see param docs).
+  // -------------------------------------------------------------------
+  if (sourceTaskId !== undefined && sourceTaskId !== parsed.targetTaskId) {
+    const shared = await shareScope(db, sourceTaskId, parsed.targetTaskId);
+    if (!shared) {
+      return {
+        ok: false,
+        reason:
+          `satisfies: source task "${sourceTaskId}" and target task "${parsed.targetTaskId}" ` +
+          `are not in the same saga (or root epic when no saga is present). ` +
+          `Atoms may only bind ACs across tasks that ship as a coherent unit per ADR-079-r2 §2.3. ` +
+          `If the cross-saga binding is genuinely required, escalate to the Lead — ` +
+          `the saga boundary is the binding boundary by design.`,
+        codeName: 'E_AC_BINDING_OUT_OF_SCOPE',
+      };
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // Success — return the canonicalised atom with resolvedAcUuid pinned
+  // -------------------------------------------------------------------
+  return {
+    ok: true,
+    atom: {
+      kind: 'satisfies',
+      targetTaskId: parsed.targetTaskId,
+      targetAcId: parsed.targetAcId,
+      targetAcAlias: parsed.targetAcAlias,
+      versionPin: parsed.versionPin,
+      resolvedAcUuid,
+    },
+  };
+}

--- a/packages/core/src/tasks/evidence.ts
+++ b/packages/core/src/tasks/evidence.ts
@@ -308,21 +308,31 @@ export async function validateAtom(
       return validateDecision(parsed.decisionId, projectRoot);
     case 'pr':
       return validatePrAtom(parsed.prNumber, projectRoot);
-    case 'satisfies':
-      // ADR-079-r2: parser accepted in T10506; 5-check validator semantics
-      // (target exists, target not terminal, AC exists, same-saga scope)
-      // ship in T10507. Until then, surface a deferred-validator reason so
-      // callers see exactly why the atom was rejected. Tests for the parser
-      // itself live in __tests__/satisfies-atom.test.ts and never call
-      // validateAtom — they exercise parseEvidenceString directly.
-      return {
-        ok: false,
-        reason:
-          `satisfies:<task-id>#<ac-id> validator semantics ship in T10507 — ` +
-          `parser accepted (T10506), runtime checks pending. ` +
-          `Target: ${parsed.targetTaskId}#${parsed.targetAcId ?? parsed.targetAcAlias ?? '?'}`,
-        codeName: 'E_AC_BINDING_VALIDATOR_PENDING',
-      };
+    case 'satisfies': {
+      // ADR-079-r2: 5-check validator pipeline shipped by T10507.
+      // Delegates to the dedicated validator module to keep the dispatch
+      // switch focused. The 5 checks run IN ORDER, first-failure-wins
+      // (see `lifecycle/verification/satisfies-validator.ts` for the
+      // detailed contract).
+      const { validateSatisfiesAtom } = await import(
+        '../lifecycle/verification/satisfies-validator.js'
+      );
+      const result = await validateSatisfiesAtom(
+        {
+          kind: 'satisfies',
+          targetTaskId: parsed.targetTaskId,
+          targetAcId: parsed.targetAcId,
+          targetAcAlias: parsed.targetAcAlias,
+          versionPin: parsed.versionPin,
+        },
+        taskId,
+        projectRoot,
+      );
+      if (!result.ok) {
+        return { ok: false, reason: result.reason, codeName: result.codeName };
+      }
+      return { ok: true, atom: result.atom };
+    }
     default: {
       // Exhaustiveness check — never reachable if ParsedAtom is complete.
       return { ok: false, reason: `Unknown parsed atom`, codeName: 'E_EVIDENCE_INVALID' };


### PR DESCRIPTION
## Summary

Replaces the `E_AC_BINDING_VALIDATOR_PENDING` placeholder shipped by T10506 with the full 5-check runtime validator for `satisfies:<task-id>#<ac-id>[@<version-pin>]` evidence atoms per ADR-079-r2 §2.4.

- New module `packages/core/src/lifecycle/verification/satisfies-validator.ts` owns the pipeline. Pure function of `(atom, source-task-id, projectRoot)`; no side-effect writes.
- `packages/core/src/tasks/evidence.ts` switch now delegates the `satisfies` case via dynamic import, mirroring the `validatePrAtom` pattern.
- First-failure-wins ordering (cheapest checks first, scope check last).

## 5-Check Pipeline (ADR-079-r2 §2.4)

| # | Check | Failure code |
|---|---|---|
| 1 | malformed (re-validates grammar) | `E_AC_BINDING_MALFORMED` |
| 2 | target task exists | `E_AC_BINDING_TARGET_NOT_FOUND` |
| 3 | target task not in `cancelled`/`archived` (done is OK) | `E_AC_BINDING_TARGET_TERMINAL` |
| 4 | AC exists on target (UUID PK or `(task_id, ordinal)` alias lookup) | `E_AC_BINDING_TARGET_AC_NOT_FOUND` |
| 5 | source + target share saga (or root epic when neither is a saga member) | `E_AC_BINDING_OUT_OF_SCOPE` |

Plus `E_AC_ALIAS_DRIFTED` (ADR-079-r2 §3) — fires when an alias atom resolves to a different UUID than the one previously persisted in `evidence_ac_bindings` for the same `(source, target, alias)` triple.

## Saga Scope Resolution

Same-saga membership resolved via `task_relations.relation_type='groups'` edges until T10494 ships the forward-looking `tasks.saga_id` column. Same-root-epic fallback applies when neither side is a saga member (per ADR-079-r2 §2.3).

## Test plan

- [x] 25 unit tests in `packages/core/src/lifecycle/verification/__tests__/satisfies-validator.test.ts`
- [x] All 5 failure paths covered
- [x] Happy paths for both UUID and alias atom forms
- [x] First-failure-wins ordering (malformed atom with non-existent target id surfaces `E_AC_BINDING_MALFORMED`, not `E_AC_BINDING_TARGET_NOT_FOUND`)
- [x] Alias drift: positive (drifted), negative (matching), UUID-form-immune (drift only applies to alias atoms)
- [x] `validateAtom` dispatch integration test (regression guard against the PENDING placeholder)
- [x] Cross-epic same-root-epic fallback
- [x] Self-binding (source == target) short-circuit
- [x] `pnpm biome check .` clean
- [x] `pnpm --filter @cleocode/core run build` clean
- [x] `pnpm --filter @cleocode/core exec vitest run src/lifecycle/verification/` — 25/25 pass

Closes T10507. Saga: T10377 (SG-IVTR-AC-BINDING). Epic: T10381. Decision: D013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)