### PR TITLE
feat(T10509): AC-coverage gate at cleo complete — closes IVTR rubber-stamp gap

### DIFF
--- a/.changeset/t10509-ac-coverage-gate.md
+++ b/.changeset/t10509-ac-coverage-gate.md
@@ -1,0 +1,30 @@
+---
+id: t10509-ac-coverage-gate
+tasks: [T10509]
+kind: feat
+summary: "complete: AC-coverage gate refuses unsatisfied ACs (T10381 Wave 2d — IVTR closure)"
+---
+
+`cleo complete <tid>` now runs an AC-coverage check BEFORE marking the
+task done. Every acceptance criterion on the task MUST have at least
+one `evidence_ac_bindings` row (any kind: `direct`, `satisfies`, or
+`coverage`); the call fails with `E_AC_COVERAGE_INCOMPLETE` listing the
+offenders otherwise. This closes the IVTR rubber-stamp gap — the core
+goal of Saga SG-IVTR-AC-BINDING.
+
+Two audited override paths exist:
+
+- `--waive-ac "<csv>" --waive-reason "<text>"` — per-AC waiver logged
+  to `.cleo/audit/ac-waiver.jsonl`. Tokens may be canonical AC UUIDs or
+  `AC<n>` aliases. The reason flag is mandatory.
+- `CLEO_OWNER_OVERRIDE=1` + `CLEO_OWNER_OVERRIDE_REASON=<text>` — full
+  bypass logged to `.cleo/audit/force-bypass.jsonl` with
+  `kind: "ac-coverage"`.
+
+The gate is a no-op for tasks that declare zero ACs (the existing
+`enforcement.acceptance.mode='block'` knob covers the "every task must
+declare ACs" case).
+
+Adds `AcBindingRow` + `DataAccessor.getAcBindings` to the contracts +
+core accessors so the gate reads through the canonical SSoT instead of
+poking the schema directly.

--- a/packages/cleo/src/cli/commands/complete.ts
+++ b/packages/cleo/src/cli/commands/complete.ts
@@ -65,6 +65,17 @@ export const completeCommand = defineCommand({
       description:
         'Reason for bypassing E_EPIC_HAS_PENDING_CHILDREN guard (audited to .cleo/audit/premature-close.jsonl)',
     },
+    // T10509 — AC-coverage gate (load-bearing IVTR closure)
+    'waive-ac': {
+      type: 'string',
+      description:
+        'Comma-separated AC tokens (UUIDs or AC<n> aliases) to waive from the AC-coverage gate. Requires --waive-reason. Audited to .cleo/audit/ac-waiver.jsonl.',
+    },
+    'waive-reason': {
+      type: 'string',
+      description:
+        'Mandatory justification text for --waive-ac. Captured verbatim in the audit row.',
+    },
   },
   async run({ args }) {
     const response = await dispatchRaw('mutate', 'tasks', 'complete', {
@@ -74,6 +85,9 @@ export const completeCommand = defineCommand({
       verificationNote: args['verification-note'] as string | undefined,
       acknowledgeRisk: args['acknowledge-risk'] as string | undefined,
       overrideReason: args['override-reason'] as string | undefined,
+      // T10509 — AC-coverage gate waiver path
+      waiveAc: args['waive-ac'] as string | undefined,
+      waiveReason: args['waive-reason'] as string | undefined,
     });
 
     if (!response.success) {

--- a/packages/cleo/src/dispatch/domains/tasks.ts
+++ b/packages/cleo/src/dispatch/domains/tasks.ts
@@ -516,6 +516,9 @@ const _tasksTypedHandler = defineTypedHandler<TasksOps>('tasks', {
       notes: params.notes,
       overrideReason: params.overrideReason,
       acknowledgeRisk: params.acknowledgeRisk,
+      // T10509 — AC-coverage gate waiver path
+      waiveAc: params.waiveAc,
+      waiveReason: params.waiveReason,
     });
     // T994: Track memory usage on task completion (fire-and-forget; must not block).
     // SSoT-EXEMPT: fire-and-forget side-effect that must not block the complete flow

--- a/packages/contracts/src/data-accessor.ts
+++ b/packages/contracts/src/data-accessor.ts
@@ -130,6 +130,27 @@ export interface AcRow {
 }
 
 /**
+ * A row of the `evidence_ac_bindings` table (T10503) — the M:N join between
+ * evidence atoms and acceptance criteria. Powers the AC-coverage gate
+ * (T10509) — "what evidence has been recorded against this AC?".
+ *
+ * @task T10509
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ */
+export interface AcBindingRow {
+  /** UUIDv4 — set by the writer (T10505/T10506). */
+  id: string;
+  /** Stable hash / composite key of the evidence atom. NOT an FK. */
+  evidenceAtomId: string;
+  /** FK → `task_acceptance_criteria(id)`. */
+  acId: string;
+  /** One of {direct, satisfies, coverage}. */
+  bindingType: 'direct' | 'satisfies' | 'coverage';
+  /** ISO-8601 timestamp of binding creation. */
+  createdAt: string;
+}
+
+/**
  * Subset of DataAccessor methods available inside a transaction callback.
  * Write-only — reads use the outer accessor (snapshot isolation).
  */
@@ -181,6 +202,17 @@ export interface TransactionAccessor {
   appendAcHistory(
     rows: Array<{ acId: string; previousText: string; reason: string }>,
   ): Promise<void>;
+  /**
+   * Read all `evidence_ac_bindings` rows whose `ac_id` ∈ the given set.
+   * Used by the AC-coverage gate (T10509) to compute which ACs are
+   * satisfied vs unsatisfied inside the same transaction that flips the
+   * task to `done`.
+   *
+   * Returns the empty array when `acIds` is empty.
+   *
+   * @task T10509
+   */
+  getAcBindings(acIds: readonly string[]): Promise<AcBindingRow[]>;
 }
 
 // Re-export AcRow at the module level for both transaction + outer accessor use.
@@ -253,6 +285,14 @@ export interface DataAccessor {
    * @task T10508
    */
   getAcRows(taskId: string): Promise<AcRow[]>;
+
+  /**
+   * Read `evidence_ac_bindings` rows whose `ac_id` ∈ the given set.
+   * Powers the AC-coverage gate (T10509). Returns the empty array when
+   * `acIds` is empty or no bindings exist for the supplied ids.
+   * @task T10509
+   */
+  getAcBindings(acIds: readonly string[]): Promise<AcBindingRow[]>;
 
   // ---- Metadata (schema_meta KV store) ----
 

--- a/packages/contracts/src/exit-codes.ts
+++ b/packages/contracts/src/exit-codes.ts
@@ -224,6 +224,29 @@ export enum ExitCode {
    * @task T9230
    */
   LEAD_BYPASS_DETECTED = 107,
+
+  /**
+   * `cleo complete <tid>` was rejected because one or more acceptance criteria
+   * on the task have no `evidence_ac_bindings` rows pointing at them. The
+   * coverage gate is the load-bearing IVTR closure piece — every AC the task
+   * declared MUST be backed by a `direct`, `satisfies`, or `coverage` binding
+   * before completion is allowed.
+   *
+   * `error.details.unsatisfied` carries the list of offending ACs (each row
+   * has `acId`, `alias` (`AC<n>`), and `text`). Recovery options:
+   *   1. Add programmatic evidence that resolves the AC via `cleo verify` so
+   *      a binding row is written.
+   *   2. Pass `--waive-ac "<csv>" --waive-reason "<text>"` on `cleo complete`
+   *      to record an audited waiver (`.cleo/audit/ac-waiver.jsonl`).
+   *   3. Set `CLEO_OWNER_OVERRIDE=1` + `CLEO_OWNER_OVERRIDE_REASON=<text>` for
+   *      a full bypass (logged to `.cleo/audit/force-bypass.jsonl`).
+   *
+   * @codeName E_AC_COVERAGE_INCOMPLETE
+   * @task T10509
+   * @saga T10377 (SG-IVTR-AC-BINDING)
+   * @adr ADR-079-r4
+   */
+  AC_COVERAGE_INCOMPLETE = 108,
 }
 
 // ---------------------------------------------------------------------------
@@ -361,6 +384,25 @@ export const E_INVALID_SEVERITY_VALUE = 'E_INVALID_SEVERITY_VALUE' as const;
  * @saga T10326
  */
 export const E_INVALID_PIPELINE_STAGE = 'E_INVALID_PIPELINE_STAGE' as const;
+
+/**
+ * E_AC_COVERAGE_INCOMPLETE — `cleo complete <tid>` was rejected because at
+ * least one acceptance criterion on the task has no `evidence_ac_bindings`
+ * row. The coverage gate is the load-bearing IVTR closure piece — every AC
+ * the task declared MUST be backed by a binding (`direct`, `satisfies`, or
+ * `coverage`) before completion is allowed.
+ *
+ * `error.details.unsatisfied` carries the offending ACs (each entry has
+ * `acId`, `alias`, and `text`). Recovery options live on the {@link ExitCode.AC_COVERAGE_INCOMPLETE}
+ * JSDoc.
+ *
+ * Maps to {@link ExitCode.AC_COVERAGE_INCOMPLETE} (108) at the CLI boundary.
+ *
+ * @task T10509
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ * @adr ADR-079-r4
+ */
+export const E_AC_COVERAGE_INCOMPLETE = 'E_AC_COVERAGE_INCOMPLETE' as const;
 
 /** Check if an exit code represents an error (1-99). */
 export function isErrorCode(code: ExitCode): boolean {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -288,6 +288,7 @@ export type {
 export { parseClaudeCodeCredentials } from './credentials.js';
 // === DataAccessor Interface ===
 export type {
+  AcBindingRow,
   AcRow,
   ArchiveFields,
   ArchiveFile,
@@ -533,6 +534,8 @@ export {
 } from './evidence-record-schema.js';
 // === Exit Codes ===
 export {
+  // T10509 / Saga T10377 — AC-coverage gate at cleo complete (IVTR closure)
+  E_AC_COVERAGE_INCOMPLETE,
   // T10105 / Saga T10099 — fail-loud changeset parse
   E_CHANGESET_YAML_INVALID,
   // SPEC-T9345 release pipeline v2 error code names (T9525)

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -958,6 +958,24 @@ export interface TasksCompleteQueryParams {
   overrideReason?: string;
   /** Reason for acknowledging CRITICAL nexus impact risk (bypasses nexusImpact gate). */
   acknowledgeRisk?: string;
+  /**
+   * Comma-separated AC tokens (UUIDs or `AC<n>` aliases) waived from the
+   * AC-coverage gate (T10509). MUST be paired with {@link waiveReason} —
+   * the gate rejects the call when one is set without the other.
+   *
+   * Waivers are recorded to `.cleo/audit/ac-waiver.jsonl` per ADR-079-r4 §4.
+   *
+   * @task T10509
+   * @saga T10377 (SG-IVTR-AC-BINDING)
+   */
+  waiveAc?: string;
+  /**
+   * Justification text for the {@link waiveAc} waiver. Mandatory whenever
+   * `waiveAc` is non-empty.
+   *
+   * @task T10509
+   */
+  waiveReason?: string;
 }
 /**
  * Result of `tasks.complete` — completion confirmation with unblocked tasks.

--- a/packages/core/src/store/safety-data-accessor.ts
+++ b/packages/core/src/store/safety-data-accessor.ts
@@ -203,6 +203,12 @@ export class SafetyDataAccessor implements DataAccessor {
     return this.inner.getAcRows(taskId);
   }
 
+  // ---- AC bindings (T10509 — pass-through) ----
+
+  async getAcBindings(acIds: readonly string[]) {
+    return this.inner.getAcBindings(acIds);
+  }
+
   // ---- Metadata (pass-through to inner) ----
 
   async getMetaValue<T>(key: string): Promise<T | null> {

--- a/packages/core/src/store/sqlite-data-accessor.ts
+++ b/packages/core/src/store/sqlite-data-accessor.ts
@@ -446,6 +446,31 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
       }));
     },
 
+    // ---- AC bindings (T10509 — AC-coverage gate) ----
+
+    async getAcBindings(acIds: readonly string[]) {
+      if (acIds.length === 0) return [];
+      const db = await getDb(cwd);
+      const rows = await db
+        .select({
+          id: schema.evidenceAcBindings.id,
+          evidenceAtomId: schema.evidenceAcBindings.evidenceAtomId,
+          acId: schema.evidenceAcBindings.acId,
+          bindingType: schema.evidenceAcBindings.bindingType,
+          createdAt: schema.evidenceAcBindings.createdAt,
+        })
+        .from(schema.evidenceAcBindings)
+        .where(inArray(schema.evidenceAcBindings.acId, acIds as string[]))
+        .all();
+      return rows.map((r) => ({
+        id: r.id,
+        evidenceAtomId: r.evidenceAtomId,
+        acId: r.acId,
+        bindingType: r.bindingType,
+        createdAt: r.createdAt,
+      }));
+    },
+
     async archiveSingleTask(taskId: string, fields: ArchiveFields): Promise<void> {
       const db = await getDb(cwd);
       // Verify the task exists before archiving
@@ -1103,6 +1128,28 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
                 })),
               )
               .run();
+          },
+          // ---- AC bindings (T10509 — AC-coverage gate) ----
+          async getAcBindings(acIds: readonly string[]) {
+            if (acIds.length === 0) return [];
+            const out = await db
+              .select({
+                id: schema.evidenceAcBindings.id,
+                evidenceAtomId: schema.evidenceAcBindings.evidenceAtomId,
+                acId: schema.evidenceAcBindings.acId,
+                bindingType: schema.evidenceAcBindings.bindingType,
+                createdAt: schema.evidenceAcBindings.createdAt,
+              })
+              .from(schema.evidenceAcBindings)
+              .where(inArray(schema.evidenceAcBindings.acId, acIds as string[]))
+              .all();
+            return out.map((r) => ({
+              id: r.id,
+              evidenceAtomId: r.evidenceAtomId,
+              acId: r.acId,
+              bindingType: r.bindingType,
+              createdAt: r.createdAt,
+            }));
           },
         };
 

--- a/packages/core/src/store/umbrella-data-accessor.ts
+++ b/packages/core/src/store/umbrella-data-accessor.ts
@@ -240,6 +240,12 @@ export class UmbrellaDataAccessor implements DataAccessor {
     return (await this.tasks()).getAcRows(taskId);
   }
 
+  // ---- AC bindings (T10509 — pass-through) ----
+
+  async getAcBindings(acIds: readonly string[]) {
+    return (await this.tasks()).getAcBindings(acIds);
+  }
+
   async getMetaValue<T>(key: string): Promise<T | null> {
     return (await this.tasks()).getMetaValue<T>(key);
   }

--- a/packages/core/src/tasks/__tests__/ac-coverage-gate.test.ts
+++ b/packages/core/src/tasks/__tests__/ac-coverage-gate.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Tests for the AC-coverage gate (T10509) — the load-bearing IVTR
+ * closure piece that refuses `cleo complete <tid>` when any AC has no
+ * `evidence_ac_bindings` row.
+ *
+ * Covers the six paths called out in T10509 AC #5:
+ *   1. complete-with-coverage  (happy path — direct binding satisfies AC)
+ *   2. complete-without-coverage (error path — unsatisfied ACs surfaced)
+ *   3. waive-with-reason  (waiver recorded to audit jsonl, completion proceeds)
+ *   4. waive-without-reason (rejected with structured error)
+ *   5. CLEO_OWNER_OVERRIDE  (full bypass, audit row written)
+ *   6. mixed coverage  (some satisfied + some not — gate fails on the residue)
+ *
+ * @task T10509
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ * @adr ADR-079-r4
+ */
+
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { ExitCode } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CleoError } from '../../errors.js';
+import { createTestDb, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { getDb, resetDbState } from '../../store/sqlite.js';
+import * as schema from '../../store/tasks-schema.js';
+import {
+  appendAcCoverageForceBypass,
+  appendAcWaiverAudit,
+  applyWaivers,
+  computeAcCoverage,
+  readOwnerOverride,
+  resolveWaivers,
+} from '../ac-coverage-gate.js';
+import { addTask } from '../add.js';
+import { completeTask } from '../complete.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a binding row directly via the Drizzle schema, mirroring the
+ * pattern used by `satisfies-validator.test.ts` (T10507). Used to seed
+ * coverage rows that the dispatch layer will later own (T10505/T10506
+ * writer wiring is out of scope for T10509).
+ */
+async function seedBinding(
+  cwd: string,
+  acId: string,
+  bindingType: 'direct' | 'satisfies' | 'coverage' = 'direct',
+  atomId: string = `commit:${randomUUID().replace(/-/g, '').slice(0, 12)}`,
+): Promise<void> {
+  const db = await getDb(cwd);
+  await db
+    .insert(schema.evidenceAcBindings)
+    .values({ id: randomUUID(), evidenceAtomId: atomId, acId, bindingType })
+    .run();
+}
+
+/**
+ * Read all lines from a JSONL audit file. Returns `[]` if the file does
+ * not exist (the audit dir is lazily created).
+ */
+async function readJsonl<T>(filePath: string): Promise<T[]> {
+  try {
+    const raw = await readFile(filePath, { encoding: 'utf8' });
+    return raw
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as T);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+/**
+ * Create a task with the given AC list and return both the task and its
+ * persisted AC rows (the rows carry the UUIDs we need to seed bindings).
+ *
+ * Pulls `addTask` from the same code path that writes to
+ * `task_acceptance_criteria` so the test always exercises the
+ * production AC writer.
+ */
+async function createTaskWithAcs(
+  accessor: DataAccessor,
+  projectRoot: string,
+  title: string,
+  acceptance: string[],
+) {
+  // T10509: anti-hallucination guard rejects title===description, so
+  // give the description a unique prefix.
+  const result = await addTask(
+    { title, description: `${title} — seeded fixture for the T10509 gate`, acceptance },
+    projectRoot,
+    accessor,
+  );
+  const acRows = await accessor.getAcRows(result.task.id);
+  return { task: result.task, acRows };
+}
+
+describe('ac-coverage-gate (T10509) — unit helpers', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    delete process.env['CLEO_OWNER_OVERRIDE'];
+    delete process.env['CLEO_OWNER_OVERRIDE_REASON'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  describe('computeAcCoverage', () => {
+    it('returns {ok:true} for a task with zero ACs (no-op gate)', async () => {
+      const { task } = await createTaskWithAcs(accessor, env.tempDir, 'No ACs', []);
+      const result = await computeAcCoverage(task.id, accessor);
+      expect(result.ok).toBe(true);
+    });
+
+    it('returns {ok:false} listing every uncovered AC', async () => {
+      const { task, acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Three ACs', [
+        'A',
+        'B',
+        'C',
+      ]);
+      expect(acRows).toHaveLength(3);
+      const result = await computeAcCoverage(task.id, accessor);
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.unsatisfied).toHaveLength(3);
+      expect(result.unsatisfied.map((u) => u.alias).sort()).toEqual(['AC1', 'AC2', 'AC3']);
+      expect(result.unsatisfied.map((u) => u.text).sort()).toEqual(['A', 'B', 'C']);
+    });
+
+    it('returns {ok:true} when every AC has at least one binding', async () => {
+      const { task, acRows } = await createTaskWithAcs(accessor, env.tempDir, 'All covered', [
+        'A',
+        'B',
+      ]);
+      for (const row of acRows) await seedBinding(env.tempDir, row.id);
+      const result = await computeAcCoverage(task.id, accessor);
+      expect(result.ok).toBe(true);
+    });
+
+    it('treats all three binding kinds (direct, satisfies, coverage) as satisfying', async () => {
+      const { task, acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Mixed kinds', [
+        'A',
+        'B',
+        'C',
+      ]);
+      await seedBinding(env.tempDir, acRows[0]!.id, 'direct');
+      await seedBinding(env.tempDir, acRows[1]!.id, 'satisfies');
+      await seedBinding(env.tempDir, acRows[2]!.id, 'coverage');
+      const result = await computeAcCoverage(task.id, accessor);
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('resolveWaivers', () => {
+    it('resolves UUID tokens against the task AC rows', async () => {
+      const { acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Waivers', ['A', 'B']);
+      const result = resolveWaivers(`${acRows[0]!.id},${acRows[1]!.id}`, acRows);
+      expect(result.acIds).toHaveLength(2);
+      expect(result.unresolved).toEqual([]);
+      expect(result.aliases).toEqual(['AC1', 'AC2']);
+    });
+
+    it('resolves AC<n> alias tokens', async () => {
+      const { acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Alias waivers', [
+        'A',
+        'B',
+        'C',
+      ]);
+      const result = resolveWaivers('AC1,AC3', acRows);
+      expect(result.acIds).toEqual([acRows[0]!.id, acRows[2]!.id]);
+      expect(result.aliases).toEqual(['AC1', 'AC3']);
+      expect(result.unresolved).toEqual([]);
+    });
+
+    it('surfaces unresolved tokens without crashing', async () => {
+      const { acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Unresolved', ['A']);
+      const result = resolveWaivers('AC1,AC99,not-a-uuid', acRows);
+      expect(result.aliases).toEqual(['AC1']);
+      expect(result.unresolved).toEqual(['AC99', 'not-a-uuid']);
+    });
+
+    it('returns empty descriptor for empty/undefined input', () => {
+      expect(resolveWaivers(undefined, [])).toEqual({
+        acIds: [],
+        aliases: [],
+        texts: [],
+        unresolved: [],
+      });
+      expect(resolveWaivers('   ', [])).toEqual({
+        acIds: [],
+        aliases: [],
+        texts: [],
+        unresolved: [],
+      });
+    });
+
+    it('deduplicates the same AC referenced twice', async () => {
+      const { acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Dedupe', ['A']);
+      const result = resolveWaivers(`AC1,${acRows[0]!.id}`, acRows);
+      expect(result.acIds).toHaveLength(1);
+    });
+  });
+
+  describe('applyWaivers', () => {
+    it('subtracts waived AC ids from the unsatisfied list', () => {
+      const unsatisfied = [
+        { acId: 'a', alias: 'AC1', text: 'a' },
+        { acId: 'b', alias: 'AC2', text: 'b' },
+      ];
+      const residual = applyWaivers(unsatisfied, new Set(['a']));
+      expect(residual).toEqual([{ acId: 'b', alias: 'AC2', text: 'b' }]);
+    });
+
+    it('is a no-op when the waiver set is empty', () => {
+      const unsatisfied = [{ acId: 'a', alias: 'AC1', text: 'a' }];
+      const residual = applyWaivers(unsatisfied, new Set());
+      expect(residual).toEqual(unsatisfied);
+    });
+  });
+
+  describe('readOwnerOverride', () => {
+    it('returns the reason when both env vars are set', () => {
+      const env = {
+        CLEO_OWNER_OVERRIDE: '1',
+        CLEO_OWNER_OVERRIDE_REASON: 'incident 1234',
+      } as NodeJS.ProcessEnv;
+      expect(readOwnerOverride(env)).toBe('incident 1234');
+    });
+
+    it('returns null when the flag is missing', () => {
+      const env = { CLEO_OWNER_OVERRIDE_REASON: 'r' } as NodeJS.ProcessEnv;
+      expect(readOwnerOverride(env)).toBeNull();
+    });
+
+    it('returns null when the reason is missing or blank', () => {
+      expect(readOwnerOverride({ CLEO_OWNER_OVERRIDE: '1' } as NodeJS.ProcessEnv)).toBeNull();
+      expect(
+        readOwnerOverride({
+          CLEO_OWNER_OVERRIDE: '1',
+          CLEO_OWNER_OVERRIDE_REASON: '   ',
+        } as NodeJS.ProcessEnv),
+      ).toBeNull();
+    });
+
+    it('accepts the alternate truthy spelling', () => {
+      expect(
+        readOwnerOverride({
+          CLEO_OWNER_OVERRIDE: 'true',
+          CLEO_OWNER_OVERRIDE_REASON: 'r',
+        } as NodeJS.ProcessEnv),
+      ).toBe('r');
+    });
+  });
+
+  describe('audit-log writers', () => {
+    it('appends an AC waiver entry to .cleo/audit/ac-waiver.jsonl', async () => {
+      await appendAcWaiverAudit(
+        {
+          timestamp: '2026-05-24T00:00:00Z',
+          taskId: 'T9999',
+          waivedAcs: ['ac-1'],
+          waivedAliases: ['AC1'],
+          reason: 'self-bootstrap test',
+          actor: 'test',
+          unresolvedTokens: [],
+        },
+        env.tempDir,
+      );
+      const rows = await readJsonl<Record<string, unknown>>(
+        join(env.tempDir, '.cleo', 'audit', 'ac-waiver.jsonl'),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.['taskId']).toBe('T9999');
+      expect(rows[0]?.['reason']).toBe('self-bootstrap test');
+    });
+
+    it('appends an AC-coverage bypass entry to .cleo/audit/force-bypass.jsonl', async () => {
+      await appendAcCoverageForceBypass(
+        {
+          kind: 'ac-coverage',
+          timestamp: '2026-05-24T00:00:00Z',
+          taskId: 'T9999',
+          reason: 'owner approved',
+          actor: 'owner',
+          unsatisfied: [{ acId: 'a', alias: 'AC1', text: 'a' }],
+        },
+        env.tempDir,
+      );
+      const rows = await readJsonl<Record<string, unknown>>(
+        join(env.tempDir, '.cleo', 'audit', 'force-bypass.jsonl'),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.['kind']).toBe('ac-coverage');
+      expect(rows[0]?.['unsatisfied']).toHaveLength(1);
+    });
+  });
+});
+
+describe('completeTask — AC-coverage gate end-to-end (T10509)', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+    // The default test config disables session enforcement + acceptance
+    // enforcement so the gate runs against the AC-coverage check alone.
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    delete process.env['CLEO_OWNER_OVERRIDE'];
+    delete process.env['CLEO_OWNER_OVERRIDE_REASON'];
+    delete process.env['CLEO_AGENT_ID'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  it('AC-1: happy path — all ACs covered → completion proceeds', async () => {
+    const { task, acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Coverage happy path', [
+      'First AC',
+      'Second AC',
+    ]);
+    for (const row of acRows) {
+      await seedBinding(env.tempDir, row.id, 'direct');
+    }
+    const result = await completeTask({ taskId: task.id }, env.tempDir, accessor);
+    expect(result.task.status).toBe('done');
+  });
+
+  it('AC-2: error path — uncovered AC → E_AC_COVERAGE_INCOMPLETE', async () => {
+    const { task } = await createTaskWithAcs(accessor, env.tempDir, 'Uncovered', ['Only AC']);
+    let caught: unknown;
+    try {
+      await completeTask({ taskId: task.id }, env.tempDir, accessor);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CleoError);
+    const ce = caught as CleoError;
+    expect(ce.code).toBe(ExitCode.AC_COVERAGE_INCOMPLETE);
+    expect(ce.details?.['codeName']).toBe('E_AC_COVERAGE_INCOMPLETE');
+    const unsat = ce.details?.['unsatisfied'] as Array<{ alias: string }>;
+    expect(unsat).toHaveLength(1);
+    expect(unsat[0]?.alias).toBe('AC1');
+  });
+
+  it('AC-3: --waive-ac with --waive-reason → audit row written + completion proceeds', async () => {
+    const { task, acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Waiver path', [
+      'Only AC',
+    ]);
+    process.env['CLEO_AGENT_ID'] = 'test-agent';
+    const result = await completeTask(
+      {
+        taskId: task.id,
+        waiveAc: acRows[0]!.id,
+        waiveReason: 'genuinely unverifiable in this codepath',
+      },
+      env.tempDir,
+      accessor,
+    );
+    expect(result.task.status).toBe('done');
+
+    const rows = await readJsonl<Record<string, unknown>>(
+      join(env.tempDir, '.cleo', 'audit', 'ac-waiver.jsonl'),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.['taskId']).toBe(task.id);
+    expect(rows[0]?.['reason']).toBe('genuinely unverifiable in this codepath');
+    expect(rows[0]?.['actor']).toBe('test-agent');
+    expect(rows[0]?.['waivedAliases']).toEqual(['AC1']);
+  });
+
+  it('AC-4: --waive-ac WITHOUT --waive-reason → rejected with structured error', async () => {
+    const { task, acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Missing reason', [
+      'Only AC',
+    ]);
+    let caught: unknown;
+    try {
+      await completeTask({ taskId: task.id, waiveAc: acRows[0]!.id }, env.tempDir, accessor);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CleoError);
+    const ce = caught as CleoError;
+    expect(ce.code).toBe(ExitCode.AC_COVERAGE_INCOMPLETE);
+    expect(ce.details?.['missingFlag']).toBe('waiveReason');
+    // Audit log was NOT written (no resolved waiver, no completion).
+    const rows = await readJsonl<unknown>(join(env.tempDir, '.cleo', 'audit', 'ac-waiver.jsonl'));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('AC-5: CLEO_OWNER_OVERRIDE → bypass + force-bypass.jsonl entry', async () => {
+    const { task } = await createTaskWithAcs(accessor, env.tempDir, 'Owner override bypass', [
+      'First AC',
+      'Second AC',
+    ]);
+    process.env['CLEO_OWNER_OVERRIDE'] = '1';
+    process.env['CLEO_OWNER_OVERRIDE_REASON'] = 'incident-1234 hotfix';
+    process.env['CLEO_AGENT_ID'] = 'owner';
+
+    const result = await completeTask({ taskId: task.id }, env.tempDir, accessor);
+    expect(result.task.status).toBe('done');
+
+    const rows = await readJsonl<Record<string, unknown>>(
+      join(env.tempDir, '.cleo', 'audit', 'force-bypass.jsonl'),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.['kind']).toBe('ac-coverage');
+    expect(rows[0]?.['reason']).toBe('incident-1234 hotfix');
+    expect(rows[0]?.['actor']).toBe('owner');
+    expect(rows[0]?.['unsatisfied']).toHaveLength(2);
+  });
+
+  it('AC-6: mixed coverage — some ACs satisfied, others not → only the unsatisfied surface', async () => {
+    const { task, acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Mixed coverage', [
+      'Covered',
+      'Not covered 1',
+      'Not covered 2',
+    ]);
+    // Seed binding for AC1 only.
+    await seedBinding(env.tempDir, acRows[0]!.id, 'direct');
+
+    let caught: unknown;
+    try {
+      await completeTask({ taskId: task.id }, env.tempDir, accessor);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CleoError);
+    const ce = caught as CleoError;
+    expect(ce.code).toBe(ExitCode.AC_COVERAGE_INCOMPLETE);
+    const unsat = ce.details?.['unsatisfied'] as Array<{ alias: string }>;
+    expect(unsat.map((u) => u.alias).sort()).toEqual(['AC2', 'AC3']);
+  });
+
+  it('partial waiver that leaves at least one AC unaddressed → still fails', async () => {
+    const { task, acRows } = await createTaskWithAcs(accessor, env.tempDir, 'Partial waiver', [
+      'A',
+      'B',
+    ]);
+    let caught: unknown;
+    try {
+      await completeTask(
+        {
+          taskId: task.id,
+          waiveAc: acRows[0]!.id, // only waive AC1
+          waiveReason: 'partial — AC2 still unaddressed',
+        },
+        env.tempDir,
+        accessor,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CleoError);
+    const ce = caught as CleoError;
+    expect(ce.code).toBe(ExitCode.AC_COVERAGE_INCOMPLETE);
+    const unsat = ce.details?.['unsatisfied'] as Array<{ alias: string }>;
+    expect(unsat.map((u) => u.alias)).toEqual(['AC2']);
+    // Audit row was written for the partial waiver attempt — forensic record.
+    const rows = await readJsonl<unknown>(join(env.tempDir, '.cleo', 'audit', 'ac-waiver.jsonl'));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('satisfies-binding kind satisfies the gate (cross-task evidence)', async () => {
+    const { task, acRows } = await createTaskWithAcs(accessor, env.tempDir, 'satisfies binding', [
+      'Only AC',
+    ]);
+    await seedBinding(env.tempDir, acRows[0]!.id, 'satisfies', 'satisfies:T200#AC1');
+    const result = await completeTask({ taskId: task.id }, env.tempDir, accessor);
+    expect(result.task.status).toBe('done');
+  });
+
+  it('task with zero ACs is a no-op for the gate', async () => {
+    const { task } = await createTaskWithAcs(accessor, env.tempDir, 'No ACs', []);
+    const result = await completeTask({ taskId: task.id }, env.tempDir, accessor);
+    expect(result.task.status).toBe('done');
+  });
+});

--- a/packages/core/src/tasks/__tests__/task-engine.test.ts
+++ b/packages/core/src/tasks/__tests__/task-engine.test.ts
@@ -159,6 +159,12 @@ function makeCompletableAccessorMock(opts: {
     // post-coordination-parent loop is a no-op for these legacy fixtures.
     queryTasks: vi.fn().mockResolvedValue({ tasks: [], total: 0 }),
     loadTasks: vi.fn().mockResolvedValue([]),
+    // T10509: the AC-coverage gate calls getAcRows BEFORE the status flip
+    // and short-circuits as ok when zero ACs are returned. The mocked
+    // task carries no acceptance criteria, so an empty array is the right
+    // shape; getAcBindings only fires when getAcRows returns rows.
+    getAcRows: vi.fn().mockResolvedValue([]),
+    getAcBindings: vi.fn().mockResolvedValue([]),
   };
 }
 

--- a/packages/core/src/tasks/ac-coverage-gate.ts
+++ b/packages/core/src/tasks/ac-coverage-gate.ts
@@ -1,0 +1,359 @@
+/**
+ * AC-coverage gate — the load-bearing IVTR-closure piece.
+ *
+ * Runs inside `cleo complete <tid>` BEFORE the status flip and refuses to
+ * mark a task done when any acceptance criterion has zero
+ * `evidence_ac_bindings` rows pointing at it. Closes the rubber-stamp
+ * loophole that let workers complete tasks whose ACs were never tied to
+ * evidence.
+ *
+ * # Binding semantics
+ *
+ * An AC is "covered" when at least one of the following kinds of binding
+ * row exists for its `ac_id`:
+ *   - `direct`    — Worker's own evidence atom emitted by the owning task
+ *   - `satisfies` — Cross-task atom via ADR-079-r2 `satisfies:<task>#<ac>`
+ *   - `coverage`  — Validator-computed transitive coverage marker
+ *
+ * All three counts contribute equally. Per ADR-079-r4 §3.
+ *
+ * # Override paths
+ *
+ * The gate is hard: programmatic evidence is the canonical satisfaction
+ * path. Two audited override paths exist for legitimate exceptions:
+ *   1. `--waive-ac "<csv>" --waive-reason "<text>"` — per-AC waiver
+ *      logged to `.cleo/audit/ac-waiver.jsonl`. Waivers are scoped to a
+ *      single `cleo complete` call; the unsatisfied AC list is
+ *      recomputed AFTER applying the waiver set so partially-waived
+ *      tasks fail when any AC is left unaddressed.
+ *   2. `CLEO_OWNER_OVERRIDE=1` (+ `CLEO_OWNER_OVERRIDE_REASON=<text>`)
+ *      — full bypass logged to `.cleo/audit/force-bypass.jsonl` per
+ *      existing convention (ADR-051 §6.2).
+ *
+ * # Tasks with zero ACs
+ *
+ * The gate is a no-op for tasks that declare zero acceptance criteria
+ * — nothing to satisfy means nothing to enforce. Operators that want
+ * "every task must have ACs" should turn on the existing
+ * `enforcement.acceptance.mode='block'` config knob, which fires
+ * earlier in the pipeline.
+ *
+ * # Transactional safety
+ *
+ * The coverage check is run as a pre-condition inside the caller's
+ * transaction context, BEFORE any state mutation. The DB read uses the
+ * same accessor handle as the subsequent writes so SQLite snapshot
+ * isolation pins the AC + binding rows for the duration of the
+ * completion call.
+ *
+ * @task T10509
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ * @epic T10381 (E-AC-MIGRATION)
+ * @adr ADR-079-r4
+ */
+
+import { appendFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+// AcBindingRow is the shape returned by accessor.getAcBindings — kept as a
+// type-only import for forward use by callers that build helpers on top of
+// `computeAcCoverage`. The current implementation only needs the `acId` field
+// (cardinality, not type), so the import is consumed transitively via the
+// accessor signature rather than locally. Importing it here pins the public
+// contract surface so a downstream re-export stays type-safe.
+import type { AcBindingRow as _AcBindingRow, AcRow, DataAccessor } from '@cleocode/contracts';
+
+/**
+ * Re-export so consumers of this module can pull the binding row shape
+ * without depending directly on `@cleocode/contracts`. Keeps the dispatch
+ * boundary thin per the SG-ARCH-SOLID contracts-fan-out invariant.
+ */
+export type AcBindingRow = _AcBindingRow;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-AC envelope returned on the `unsatisfied` array when the gate
+ * rejects completion. Powers the CLI message + JSON details payload.
+ */
+export interface UnsatisfiedAc {
+  /** UUIDv4 of the acceptance-criterion row. */
+  acId: string;
+  /** Display alias — `AC<ordinal>`. */
+  alias: string;
+  /** Verbatim AC text from `task_acceptance_criteria.text`. */
+  text: string;
+}
+
+/**
+ * Outcome of the AC-coverage check.
+ *
+ * `ok=true` when every AC has at least one binding (or when the task
+ * declared zero ACs). `ok=false` carries the offenders so the caller
+ * can shape the structured error.
+ */
+export type AcCoverageResult =
+  | { ok: true }
+  | {
+      ok: false;
+      unsatisfied: UnsatisfiedAc[];
+    };
+
+/**
+ * Result of resolving caller-supplied `--waive-ac` tokens against the
+ * task's actual AC rows. Powers the audit-log payload and the post-
+ * waiver coverage recompute.
+ */
+export interface ResolvedWaivers {
+  /** AC UUIDs that the operator explicitly waived. */
+  acIds: string[];
+  /** Display aliases of the waived ACs (`AC<ordinal>`). */
+  aliases: string[];
+  /** Verbatim AC texts captured at audit time for forensic traceability. */
+  texts: string[];
+  /** Tokens that did NOT resolve to any AC on the task. */
+  unresolved: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Coverage check
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute coverage for a task. Returns `{ok:true}` when every AC has
+ * at least one binding OR the task declared zero ACs; otherwise
+ * `{ok:false}` with the offending AC rows.
+ *
+ * @param taskId - The task being completed.
+ * @param accessor - DataAccessor used for the AC + binding reads.
+ * @returns Coverage outcome.
+ */
+export async function computeAcCoverage(
+  taskId: string,
+  accessor: DataAccessor,
+): Promise<AcCoverageResult> {
+  const acRows = await accessor.getAcRows(taskId);
+  if (acRows.length === 0) {
+    // No ACs → nothing to cover. Operators that want "every task must
+    // have ACs" should set `enforcement.acceptance.mode='block'`.
+    return { ok: true };
+  }
+
+  const acIds = acRows.map((r) => r.id);
+  const bindings = await accessor.getAcBindings(acIds);
+
+  // Build the "covered" set — an AC is covered when AT LEAST ONE binding
+  // row has its `ac_id`. All three binding kinds (direct, satisfies,
+  // coverage) count equally per ADR-079-r4 §3.
+  const covered = new Set<string>();
+  for (const b of bindings) {
+    covered.add(b.acId);
+  }
+
+  const unsatisfied = acRows
+    .filter((r) => !covered.has(r.id))
+    .map<UnsatisfiedAc>((r) => ({
+      acId: r.id,
+      alias: `AC${r.ordinal}`,
+      text: r.text,
+    }));
+
+  if (unsatisfied.length === 0) return { ok: true };
+  return { ok: false, unsatisfied };
+}
+
+// ---------------------------------------------------------------------------
+// Waiver resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the comma-separated `--waive-ac` token list against the
+ * task's AC rows. Tokens may be:
+ *   - A canonical UUIDv4 (`task_acceptance_criteria.id`)
+ *   - A display alias (`AC<ordinal>`)
+ *
+ * Tokens that resolve to neither are surfaced on `unresolved` so the
+ * caller can warn — they are NOT silently dropped, but they also do
+ * not fail the gate by themselves. The caller decides.
+ *
+ * @param waiveCsv - Comma-separated token list (may be empty / undefined).
+ * @param acRows - The task's AC rows (from `accessor.getAcRows`).
+ * @returns Resolved waiver descriptor.
+ */
+export function resolveWaivers(
+  waiveCsv: string | undefined,
+  acRows: readonly AcRow[],
+): ResolvedWaivers {
+  if (waiveCsv === undefined || waiveCsv.trim().length === 0) {
+    return { acIds: [], aliases: [], texts: [], unresolved: [] };
+  }
+
+  const tokens = waiveCsv
+    .split(',')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+
+  const byUuid = new Map<string, AcRow>();
+  const byAlias = new Map<string, AcRow>();
+  for (const row of acRows) {
+    byUuid.set(row.id.toLowerCase(), row);
+    byAlias.set(`AC${row.ordinal}`.toLowerCase(), row);
+  }
+
+  const acIds: string[] = [];
+  const aliases: string[] = [];
+  const texts: string[] = [];
+  const unresolved: string[] = [];
+  const seen = new Set<string>();
+
+  for (const token of tokens) {
+    const key = token.toLowerCase();
+    const row = byUuid.get(key) ?? byAlias.get(key);
+    if (row === undefined) {
+      unresolved.push(token);
+      continue;
+    }
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    acIds.push(row.id);
+    aliases.push(`AC${row.ordinal}`);
+    texts.push(row.text);
+  }
+
+  return { acIds, aliases, texts, unresolved };
+}
+
+/**
+ * Subtract a waiver set from an unsatisfied list. Returns the residual
+ * unsatisfied ACs. When the residual is empty, the gate passes; when
+ * non-empty the caller surfaces `E_AC_COVERAGE_INCOMPLETE` with the
+ * residual.
+ *
+ * @param unsatisfied - From {@link computeAcCoverage}.
+ * @param waivedAcIds - Set of canonical AC UUIDs the operator waived.
+ * @returns Residual unsatisfied list (ACs not covered AND not waived).
+ */
+export function applyWaivers(
+  unsatisfied: readonly UnsatisfiedAc[],
+  waivedAcIds: ReadonlySet<string>,
+): UnsatisfiedAc[] {
+  if (waivedAcIds.size === 0) return [...unsatisfied];
+  return unsatisfied.filter((u) => !waivedAcIds.has(u.acId));
+}
+
+// ---------------------------------------------------------------------------
+// Audit-log writers
+// ---------------------------------------------------------------------------
+
+/**
+ * One row in `.cleo/audit/ac-waiver.jsonl` — appended whenever a caller
+ * supplies `--waive-ac` with a reason. The schema is intentionally flat
+ * for grep-friendly post-mortem analysis.
+ */
+export interface AcWaiverAuditEntry {
+  /** ISO-8601 timestamp the waiver was recorded. */
+  timestamp: string;
+  /** Task that was completed under the waiver. */
+  taskId: string;
+  /** AC UUIDs that were waived (subset of the task's AC set). */
+  waivedAcs: string[];
+  /** Display aliases (`AC<n>`) — duplicates `waivedAcs` semantically but is grep-friendly. */
+  waivedAliases: string[];
+  /** Operator-supplied justification text. Mandatory. */
+  reason: string;
+  /** Agent / user identity that performed the completion. */
+  actor: string;
+  /** Tokens passed to `--waive-ac` that did NOT resolve to any AC. */
+  unresolvedTokens: string[];
+}
+
+/**
+ * Append a single waiver entry to `.cleo/audit/ac-waiver.jsonl`. Creates
+ * the audit directory on first use. Errors propagate — failure to write
+ * the audit row MUST block the completion since the audit trail is the
+ * forensic guarantee that backs the override.
+ *
+ * @param entry - Pre-built audit entry.
+ * @param projectRoot - Absolute path to the project root.
+ */
+export async function appendAcWaiverAudit(
+  entry: AcWaiverAuditEntry,
+  projectRoot: string,
+): Promise<void> {
+  const auditDir = join(projectRoot, '.cleo', 'audit');
+  await mkdir(auditDir, { recursive: true });
+  const filePath = join(auditDir, 'ac-waiver.jsonl');
+  const line = `${JSON.stringify(entry)}\n`;
+  await appendFile(filePath, line, { encoding: 'utf8' });
+}
+
+/**
+ * One row in `.cleo/audit/force-bypass.jsonl` written when an operator
+ * sets `CLEO_OWNER_OVERRIDE=1` to bypass the AC-coverage gate entirely.
+ * Mirrors the existing `ForceBypassRecord` shape from `gate-audit.ts`
+ * (T832) so the same downstream tools can read both. The `kind` field
+ * discriminates AC-coverage entries from the existing evidence-gate
+ * entries.
+ */
+export interface AcCoverageForceBypassEntry {
+  /** Discriminator — `'ac-coverage'` for this gate. */
+  kind: 'ac-coverage';
+  /** ISO-8601 timestamp of the bypass. */
+  timestamp: string;
+  /** Task that was completed under the override. */
+  taskId: string;
+  /** Operator-supplied justification (from `CLEO_OWNER_OVERRIDE_REASON`). */
+  reason: string;
+  /** Agent / user identity that performed the completion. */
+  actor: string;
+  /** Unsatisfied ACs that were skipped by the bypass — captured for post-mortem. */
+  unsatisfied: UnsatisfiedAc[];
+}
+
+/**
+ * Append an AC-coverage force-bypass entry to `.cleo/audit/force-bypass.jsonl`.
+ * Re-uses the canonical force-bypass log per ADR-051 §6.2; the `kind`
+ * discriminator on the entry distinguishes AC-coverage bypasses from
+ * existing evidence-gate bypasses.
+ *
+ * Errors propagate — like {@link appendAcWaiverAudit} the audit trail
+ * is load-bearing.
+ *
+ * @param entry - Pre-built audit entry.
+ * @param projectRoot - Absolute path to the project root.
+ */
+export async function appendAcCoverageForceBypass(
+  entry: AcCoverageForceBypassEntry,
+  projectRoot: string,
+): Promise<void> {
+  const auditDir = join(projectRoot, '.cleo', 'audit');
+  await mkdir(auditDir, { recursive: true });
+  const filePath = join(auditDir, 'force-bypass.jsonl');
+  const line = `${JSON.stringify(entry)}\n`;
+  await appendFile(filePath, line, { encoding: 'utf8' });
+}
+
+// ---------------------------------------------------------------------------
+// Owner-override env helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Inspect the runtime env for the canonical `CLEO_OWNER_OVERRIDE=1`
+ * + `CLEO_OWNER_OVERRIDE_REASON=<text>` pair. Returns the reason when
+ * BOTH are present; returns `null` when override is off or the reason
+ * is missing/blank.
+ *
+ * Centralised here so the gate, the audit writer, and the dispatch
+ * layer agree on the exact semantics. Mirrors the convention used by
+ * `gate-audit.ts`.
+ */
+export function readOwnerOverride(env: NodeJS.ProcessEnv = process.env): string | null {
+  const flag = env['CLEO_OWNER_OVERRIDE'];
+  if (flag !== '1' && flag !== 'true') return null;
+  const reason = env['CLEO_OWNER_OVERRIDE_REASON'];
+  if (typeof reason !== 'string') return null;
+  const trimmed = reason.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed;
+}

--- a/packages/core/src/tasks/complete.ts
+++ b/packages/core/src/tasks/complete.ts
@@ -23,6 +23,15 @@ import { requireActiveSession } from '../sessions/session-enforcement.js';
 import type { DataAccessor } from '../store/data-accessor.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { getActiveSession } from '../store/session-store.js';
+import {
+  appendAcCoverageForceBypass,
+  appendAcWaiverAudit,
+  applyWaivers,
+  computeAcCoverage,
+  readOwnerOverride,
+  resolveWaivers,
+  type UnsatisfiedAc,
+} from './ac-coverage-gate.js';
 import { buildRollupEvidence, isCoordinationParent } from './coordination-parent.js';
 import { createAcceptanceEnforcement } from './enforcement.js';
 import { revalidateEvidence } from './evidence.js';
@@ -57,6 +66,27 @@ export interface CompleteTaskOptions {
    * @task T1632
    */
   overrideReason?: string;
+  /**
+   * Comma-separated AC tokens (UUIDs or `AC<n>` aliases) that the caller
+   * waives from the AC-coverage gate (T10509). Each token MUST resolve to
+   * an AC row on the task. The {@link waiveReason} is mandatory whenever
+   * this field is set; supplying `waiveAc` without `waiveReason` is rejected
+   * with `E_AC_COVERAGE_INCOMPLETE`.
+   *
+   * Waivers are recorded to `.cleo/audit/ac-waiver.jsonl` for forensic
+   * traceability per ADR-079-r4 §4.
+   *
+   * @task T10509
+   * @saga T10377 (SG-IVTR-AC-BINDING)
+   */
+  waiveAc?: string;
+  /**
+   * Justification text for the {@link waiveAc} waiver. Mandatory whenever
+   * `waiveAc` is non-empty. Captured verbatim in the audit row.
+   *
+   * @task T10509
+   */
+  waiveReason?: string;
 }
 
 /**
@@ -184,6 +214,142 @@ export async function verifyEpicHasEvidence(task: Task, acc: DataAccessor): Prom
   }
 
   return false;
+}
+
+/**
+ * Resolve the absolute project root to write audit logs to. The gate
+ * call site has `cwd` as an optional parameter; we re-use the same
+ * canonical fallback the rest of `completeTask` uses ({@link getProjectRoot}).
+ *
+ * @internal
+ * @task T10509
+ */
+function projectRootForGate(cwd: string | undefined): string {
+  return cwd ?? getProjectRoot();
+}
+
+/**
+ * Enforce the AC-coverage gate (T10509). Throws when:
+ *   - Any AC has zero `evidence_ac_bindings` rows AND no override clears it.
+ *   - `--waive-ac` was supplied without a non-empty `--waive-reason`.
+ *
+ * Override precedence (highest first):
+ *   1. `CLEO_OWNER_OVERRIDE=1` + reason — full bypass; logged to
+ *      `force-bypass.jsonl`; coverage check still runs so the audit row
+ *      captures the offenders for post-mortem.
+ *   2. `--waive-ac` + `--waive-reason` — per-AC waiver; logged to
+ *      `ac-waiver.jsonl`; the residual unsatisfied set MUST be empty.
+ *
+ * The gate is a NO-OP for tasks with zero ACs.
+ *
+ * @internal
+ * @task T10509
+ */
+async function enforceAcCoverageGate(
+  options: CompleteTaskOptions,
+  projectRoot: string,
+  accessor: DataAccessor,
+): Promise<void> {
+  // 1. Validate `--waive-ac` arrives with a reason. Operators that pass
+  //    `--waive-ac` alone get a hard rejection — the reason is the
+  //    forensic anchor that justifies skipping the gate.
+  const waiveCsv = options.waiveAc?.trim();
+  if (waiveCsv !== undefined && waiveCsv.length > 0) {
+    const reason = options.waiveReason?.trim() ?? '';
+    if (reason.length === 0) {
+      throw new CleoError(
+        ExitCode.AC_COVERAGE_INCOMPLETE,
+        '--waive-ac requires --waive-reason "<text>" — the reason is the audit anchor.',
+        {
+          fix: 'Re-run with --waive-reason "<justification>" (the reason is captured in .cleo/audit/ac-waiver.jsonl).',
+          details: {
+            field: 'waiveReason',
+            codeName: 'E_AC_COVERAGE_INCOMPLETE',
+            missingFlag: 'waiveReason',
+          },
+        },
+      );
+    }
+  }
+
+  // 2. Compute base coverage. Short-circuit on zero-AC tasks.
+  const coverage = await computeAcCoverage(options.taskId, accessor);
+  if (coverage.ok) return;
+
+  // 3. Owner-override path (highest precedence) — log the bypass with
+  //    the FULL unsatisfied list so the audit row captures what was
+  //    skipped. The bypass is recorded BEFORE returning so a process
+  //    crash between audit + completion still leaves a forensic trail.
+  const ownerReason = readOwnerOverride();
+  if (ownerReason !== null) {
+    await appendAcCoverageForceBypass(
+      {
+        kind: 'ac-coverage',
+        timestamp: new Date().toISOString(),
+        taskId: options.taskId,
+        reason: ownerReason,
+        actor: process.env['CLEO_AGENT_ID'] ?? 'cleo',
+        unsatisfied: coverage.unsatisfied,
+      },
+      projectRoot,
+    );
+    return;
+  }
+
+  // 4. Waiver path — resolve the tokens against the task's AC rows,
+  //    subtract the waived set from the unsatisfied list, AND require
+  //    the residual to be empty. Partial waivers that leave any AC
+  //    unaddressed are rejected — operators must either waive all
+  //    offenders or provide programmatic evidence for the rest.
+  let residual: UnsatisfiedAc[] = coverage.unsatisfied;
+  let unresolvedTokens: string[] = [];
+  if (waiveCsv !== undefined && waiveCsv.length > 0) {
+    const acRows = await accessor.getAcRows(options.taskId);
+    const resolved = resolveWaivers(waiveCsv, acRows);
+    unresolvedTokens = resolved.unresolved;
+    residual = applyWaivers(coverage.unsatisfied, new Set(resolved.acIds));
+
+    // Write the audit row BEFORE deciding to fail or pass — even
+    // partial waivers that get rejected MUST be recorded so a worker
+    // cannot mask exploration of the gate.
+    await appendAcWaiverAudit(
+      {
+        timestamp: new Date().toISOString(),
+        taskId: options.taskId,
+        waivedAcs: resolved.acIds,
+        waivedAliases: resolved.aliases,
+        reason: (options.waiveReason ?? '').trim(),
+        actor: process.env['CLEO_AGENT_ID'] ?? 'cleo',
+        unresolvedTokens,
+      },
+      projectRoot,
+    );
+
+    if (residual.length === 0 && unresolvedTokens.length === 0) return;
+  }
+
+  // 5. Gate fails — surface the structured error with the residual ACs
+  //    AND any unresolved waiver tokens so the operator sees both
+  //    classes of problem in one shot.
+  const offenderList = residual.map((u) => `${u.alias} (${u.acId})`).join(', ');
+  const unresolvedHint =
+    unresolvedTokens.length > 0 ? ` Unresolved waive tokens: ${unresolvedTokens.join(', ')}.` : '';
+  throw new CleoError(
+    ExitCode.AC_COVERAGE_INCOMPLETE,
+    `Task ${options.taskId} cannot complete — ${residual.length} acceptance criterion/criteria have no evidence bindings: ${offenderList}.${unresolvedHint}`,
+    {
+      fix:
+        'Either (1) record evidence via `cleo verify <taskId> --gate … --evidence …` so a binding row is written, ' +
+        '(2) pass `--waive-ac "<csv>" --waive-reason "<text>"` to record an audited waiver, or ' +
+        '(3) set CLEO_OWNER_OVERRIDE=1 + CLEO_OWNER_OVERRIDE_REASON=<text> for a full bypass.',
+      details: {
+        field: 'acceptance',
+        codeName: 'E_AC_COVERAGE_INCOMPLETE',
+        unsatisfied: residual,
+        unresolvedTokens,
+      },
+    },
+  );
 }
 
 /**
@@ -404,6 +570,26 @@ export async function completeTask(
       );
     }
   }
+
+  // ---- T10509: AC-coverage gate (load-bearing IVTR closure) ----
+  //
+  // Every acceptance criterion MUST be backed by at least one
+  // `evidence_ac_bindings` row (any kind: direct, satisfies, coverage)
+  // before the task can be marked done. Override paths:
+  //   1. `--waive-ac "<csv>" --waive-reason "<text>"` — per-AC waiver
+  //      logged to `.cleo/audit/ac-waiver.jsonl`.
+  //   2. `CLEO_OWNER_OVERRIDE=1` + `CLEO_OWNER_OVERRIDE_REASON=<text>`
+  //      — full bypass logged to `.cleo/audit/force-bypass.jsonl`.
+  //
+  // The check is no-op for tasks with zero ACs (the existing
+  // `enforcement.acceptance.mode='block'` knob covers the "every task
+  // must declare ACs" case).
+  //
+  // Transactional safety: the read uses the SAME accessor handle as the
+  // subsequent transaction below. SQLite snapshot isolation pins the AC
+  // + binding rows between the read here and the writes inside the tx
+  // — no race window where the row set drifts.
+  await enforceAcCoverageGate(options, projectRootForGate(cwd), acc);
 
   const now = new Date().toISOString();
   const before = { ...task };
@@ -905,6 +1091,19 @@ export interface TaskCompleteEngineOptions {
   overrideReason?: string;
   /** Reason for acknowledging CRITICAL nexus impact risk. */
   acknowledgeRisk?: string;
+  /**
+   * Comma-separated AC tokens (UUIDs or `AC<n>` aliases) waived from the
+   * AC-coverage gate. {@link waiveReason} is mandatory whenever this is set.
+   * @see CompleteTaskOptions.waiveAc
+   * @task T10509
+   */
+  waiveAc?: string;
+  /**
+   * Justification text for the {@link waiveAc} waiver.
+   * @see CompleteTaskOptions.waiveReason
+   * @task T10509
+   */
+  waiveReason?: string;
 }
 
 /**
@@ -937,6 +1136,8 @@ export async function taskComplete(
         notes: opts.notes,
         overrideReason: opts.overrideReason,
         acknowledgeRisk: opts.acknowledgeRisk,
+        waiveAc: opts.waiveAc,
+        waiveReason: opts.waiveReason,
       },
       projectRoot,
       accessor,


### PR DESCRIPTION
## Summary

- `cleo complete <tid>` now refuses to mark a task done when any acceptance criterion lacks evidence bindings. Closes the IVTR rubber-stamp gap that motivated the entire saga.
- Two audited override paths: `--waive-ac "<csv>" --waive-reason "<text>"` (per-AC waiver to `.cleo/audit/ac-waiver.jsonl`) and `CLEO_OWNER_OVERRIDE=1` + `CLEO_OWNER_OVERRIDE_REASON=<text>` (full bypass to `.cleo/audit/force-bypass.jsonl`).
- Adds `ExitCode.AC_COVERAGE_INCOMPLETE` (108) + `E_AC_COVERAGE_INCOMPLETE` constant, `AcBindingRow` type, `DataAccessor.getAcBindings(acIds)` method, and the `ac-coverage-gate.ts` module that computes coverage, resolves waivers, and writes audit rows.

## Context

This is the load-bearing closure piece of Saga T10377 (SG-IVTR-AC-BINDING). Predecessors:
- T10502 PR #773 — `task_acceptance_criteria` table
- T10503 PR #772 — `evidence_ac_bindings` join
- T10504 PR #774 — `task_acceptance_criteria_history`
- T10505 PR #776 — AC backfill
- T10506 PR #775 — satisfies atom parser
- T10507 PR #778 — satisfies atom 5-check validator
- T10508 PR #777 — `cleo add/update --acceptance` writes through to the table
- **T10509 (this PR)** — query the bindings, refuse to complete unless covered

## Design notes

- Gate runs BEFORE the status flip. The DB read uses the same accessor handle that the subsequent transaction uses, so SQLite snapshot isolation pins the AC + binding rows between the check and the writes.
- All three binding kinds (`direct`, `satisfies`, `coverage`) count equally per ADR-079-r4 §3.
- Tasks with zero ACs are a no-op for the gate. The existing `enforcement.acceptance.mode='block'` knob covers "every task must declare ACs".
- Partial waivers that leave any AC unaddressed still fail — operators must waive ALL offenders or provide programmatic evidence for the rest. Audit row is written even for failed partial waivers (forensic record).
- `--waive-ac` without `--waive-reason` is rejected hard — the reason is the audit anchor.

## Test plan

- [x] 26 vitest cases pass: unit coverage of `computeAcCoverage`, `resolveWaivers`, `applyWaivers`, `readOwnerOverride`, and both audit-log writers, plus end-to-end coverage of the six AC#5 paths (happy, error, waive-with-reason, waive-without-reason, owner-override, mixed-coverage), the partial-waiver still-fails edge, satisfies-binding kind, and zero-AC no-op.
- [x] `pnpm biome check` clean on all touched files.
- [x] `pnpm --filter @cleocode/core run build` succeeds (pre-existing caamp/nexus build failures are unrelated and exist on main).
- [x] `pnpm --filter @cleocode/core exec vitest run src/tasks/__tests__/complete.test.ts ... task-complete-lifecycle-gate.test.ts` — all 71 existing complete-related tests still pass.
- [x] `node scripts/lint-changesets.mjs` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)