### PR TITLE
feat(T10510): validator role + envelope types in @cleocode/contracts

### DIFF
--- a/.changeset/t10510-validator-role-contracts.md
+++ b/.changeset/t10510-validator-role-contracts.md
@@ -1,0 +1,23 @@
+---
+id: t10510-validator-role-contracts
+tasks: [T10510]
+kind: feat
+summary: "contracts: validator role enum + ValidatorAttestation/Rejection/Finding/Verdict types (T10383 Wave 3a)"
+---
+
+Adds the `validator` role to `@cleocode/contracts` — the foundation that T10511 (SDK tools) and T10512 (Max-N runtime) consume to express the verdict a Validator agent returns after reviewing a Worker submission against a task's acceptance criteria.
+
+New contracts (under `packages/contracts/src/validator/`):
+
+- `AgentRole` — canonical 4-value enum (`orchestrator` | `lead` | `worker` | `validator`); ADDITIVE — existing per-file role unions (`PeerKind`, `AgentSpawnCapability`, `CLEO_AGENT_ROLE`, …) are UNCHANGED.
+- `ValidatorFinding` — single per-AC verdict row with `acId`, `status` (`pass` | `fail` | `inconclusive`), `reasoning`, optional `evidenceRefs`, `checkedAt`.
+- `ValidatorAttestation` — accept envelope (`verdict: 'attest'`); Zod schema enforces every finding has `status: 'pass'`.
+- `ValidatorRejection` — refuse envelope (`verdict: 'reject'`); Zod schema enforces at least one finding has `status !== 'pass'` AND `summary` is non-empty.
+- `ValidatorVerdict` — discriminated union via `verdict` discriminant.
+- Identity triad: `VALIDATOR_ID_REGEX` (`^validator-[a-z0-9][a-z0-9-]*$`) + `isAgentRole` + 3 envelope guards (`isValidatorAttestation`, `isValidatorRejection`, `isValidatorVerdict`).
+
+34 new vitest cases in `packages/contracts/src/__tests__/validator-types.test.ts` cover enum membership, regex acceptance, schema invariants (attestation can't contain fails; rejection can't be all-pass; rejection requires summary; wrong discriminant / schemaVersion rejected), and discriminated-union narrowing.
+
+Contracts package remains leaf — depends only on `zod` (already present).
+
+Saga: T10377 SG-IVTR-AC-BINDING. Epic: T10383 E-VALIDATOR-ROLE. Decision: D013.

--- a/docs/plan/cleo-canonical-north-star.md
+++ b/docs/plan/cleo-canonical-north-star.md
@@ -1,0 +1,291 @@
+# CLEO — Canonical North Star
+
+> **Status**: canonical · 2026-05-25 (v3 — full reconstruction after raw-write loss; integrates both work streams + decisions ledger inline with verified D1-D7 from actual `sg-mesh-decisions-ledger-2026-05-24-home-t10400` ledger blob)
+> **Supersedes**: nothing — consolidates two pre-existing canonical docs into a single navigable index
+> **Purpose**: single entrypoint for "where does this work fit?" — links the persona/memory roadmap (`CLEO-PRIME-SENTIENT-MASTERPLAN.md`) with the harness/IPC architecture (`CleoCode-Architecture-Harness-Planning.md`) and maps every live saga onto a tier.
+
+## 1. The two canonical source docs
+
+Both remain authoritative for their layer. **Do not re-litigate them in this doc.** Edit them in place; bump this index when their relationship to the saga graph changes.
+
+| Doc | Path | Layer it owns | Status |
+|---|---|---|---|
+| **Sentient Masterplan** | `docs/plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md` (1,587 lines) | BRAIN / persona / memory / PSYCHE / 14 tiers (Tier 1-14) | canonical |
+| **Harness Architecture** | `docs/research/CleoCode-Architecture-Harness-Planning.md` (95 lines) | UI / IPC / TUI / TS Daemon / ZeroMQ / VCM / PTY isolation | canonical — **promote to plans/ when first wave ships** |
+
+**The seam between them** is the LAFS envelope (ADR-039): the harness layer transports envelopes, the persona layer produces and consumes them. The envelope contract itself is hardened by **T10343 SG-ENVELOPE-FIRST** (filed 2026-05-23).
+
+## 1.5 Glossary — disambiguating "harness"
+
+The word **"harness"** is overloaded across canon docs and historical epics. Three distinct meanings show up:
+
+| Use | What it actually is | Where it lives | Owner saga |
+|---|---|---|---|
+| **"Daemon harness"** (the agent runtime) | TypeScript long-running process: `cleo daemon serve` + Gateway + VCM mutex + sentient loop + GC sidecar. Spawns workers, manages LLM calls, hosts the SDK API. Per T1737's original language "Native TypeScript + Rust via napi-rs" | `packages/cleo-os/src/` + `packages/core/src/sentient/` + `packages/core/src/gateway/` (new) | **T10401 SG-HARNESS-DAEMON-IPC** |
+| **"Cockpit harness"** (the operator TUI) | Rust binary: `ratatui` + `crossterm` + `tokio`. Separate process. Connects to the Daemon over envelope-IPC. Renders panes, PTY isolation, Living Brain visualization. NOT in-process with the kernel | `crates/cockpit/` (new) | **T10402 SG-COCKPIT-HARNESS** |
+| **"Harness layer"** (the architectural tier) | The whole Tier 0 of the system — both surfaces above PLUS the envelope contract that joins them. An abstract layer name, not a single artifact | spans T10400 + T10401 + T10402 + T10403 + T10409 + T10418 + T10419 | (no single saga — it's the tier name) |
+
+**Why this matters**: T1737's original "Native TypeScript + Rust via napi-rs" referred to the **Daemon harness**, NOT the Cockpit. The Cockpit being Rust does not contradict T1737 — they're two different surfaces. The TS Daemon stays TypeScript (event-loop friendly for LLM orchestration, async I/O, npm ecosystem). The Cockpit is Rust (crash-resistant UI, ratatui ecosystem, in-process PTY multiplexing). Both consume the same envelope contract.
+
+**Per envelope-first doctrine (T10343)**: language choice within a surface is implementation detail, NOT architecture. The architecture IS the envelope.
+
+## 2. Tier inventory — Sentient Masterplan + Harness Layer
+
+The masterplan defines Tier 1-14. The harness layer is **Tier 0** (not in the masterplan; introduced here). Lower tiers gate higher ones.
+
+| Tier | Name | Source doc | What it owns |
+|---|---|---|---|
+| **0** | **Harness Layer** (NEW) | Harness Architecture | Cockpit TUI · TS Daemon · ZeroMQ IPC · VCM mutex queue · PTY worker isolation · daemon heartbeats · vault/gateway |
+| **1** | Trust Foundation | Masterplan §5/Tier 1 | T9245 evidence-validator hardening · BBTT close-out · daemon liveness · **BRAIN-DB recoverability (P0 prereq, NOT in original masterplan — added 2026-05-23)** |
+| **2** | Provenance, Quarantine, Auto-Extract Repair | Masterplan §5/Tier 2 | origin columns · test-fixture quarantine · auto-extract repair · promotion-log fulfillment |
+| **3** | Peer-Graph Identity | Masterplan §5/Tier 3 | brain_peers · memory blocks · growing personas (CANT growth) · identity drift · sigil/diary/skills/rapport tables |
+| **4** | Mem0 Write-Time Extraction Gate | Masterplan §5/Tier 4 | verifyAndStore chokepoint · Mem0 V3 ADDITIVE_EXTRACTION envelope · audit-by-default |
+| **5** | Bitemporal + Four-Network Epistemology | Masterplan §5/Tier 5 | Graphiti bitemporal (created_at/expired_at/valid_at/invalid_at) · Hindsight 4-network (world/bank/opinion/observation) |
+| **6** | PSYCHE Pipeline | Masterplan §5/Tier 6 | dialectic evaluator · derivation queue · dreamer specialists · reconciler |
+| **7** | Four-Bus Integration | Masterplan §5/Tier 7 | spawn-context-builder · nexus.impact returns brainEvidence · pre-decomposition advisor · brain↔conduit handoff |
+| **8** | Continuous Living | Masterplan §5/Tier 8 | idle dream · memory-git per peer · skill distillation |
+| **9** | Sentient Tier-2 + Tier-3 | Masterplan §5/Tier 9 | Tier-2 detector wired · Tier-3 sandbox · CANT persona evolution |
+| **10** | Conduit A2A | Masterplan §5/Tier 10 | deferred (Wave 9) — agent-to-agent messaging mesh |
+| **11** | Memory Provider Plugin Substrate | Masterplan §17 | Hermes-Agent pattern |
+| **12** | Mastra-Style Pre-Composed Context | Masterplan §17 | prompt-cache discipline |
+| **13** | Episodes + LLM-edges + A-Mem Evolution | Masterplan §17 | LangMem episodes |
+| **14** | Honcho MCP Front-End vs Native | Masterplan §17 | deferred decision |
+
+## 3. Saga ↔ Tier mapping
+
+Every existing/proposed saga listed with its tier alignment, full children rosters, and current status. Updated 2026-05-25 with the **10-saga Tier-0 mesh** (8 filed 2026-05-23 + 2 added 2026-05-24 from T1737 triage). Decisions D1-D7 are embedded inline in §5 below.
+
+### Foundation (Tier 0-1) — must ship first
+
+| Saga | Tier | Status | Note |
+|---|---|---|---|
+| **T10281 SG-BRAIN-DB-RESILIENCE** | 1 (P0 prereq) | pending | Wave 0 (T10286 BRAIN P0 hotfix) **shipped 2026-05-23**; brain.db `integrity_check=ok` confirmed. E1-E4 still in flight. Outputs feed T10405 SG-PSYCHE-FOUNDATION Tier 4 chokepoint |
+| **T10343 SG-ENVELOPE-FIRST** (doctrine) | 0 (seam) | pending | LAFS envelope as canonical CLEO boundary; WorkloadIntent enum simplification; **implementation now lives in T10400 SG-CLEO-SDK-API** (via `extends` relation) |
+| **T10295 SG-PROJECT-AUTHORITY** | 1 + 7 | pending | projectId as truth (kill CWD-walk-up); enables Gateway projectId routing in T10401; `getVaultDbPath()` helper for T10409 |
+| T1892 BBTT | 1 | done | Tier 1 historical work; informed the masterplan |
+| T9245 evidence-validator | 1 | done | the loophole fix |
+| T9839 SG-GH-TRIAGE-2026-05-21 | 1 (cleanup) | done | bug triage round |
+
+### Harness Layer (Tier 0) — 10-saga mesh (8 filed 2026-05-23 + 2 added 2026-05-24 from T1737 triage)
+
+| Saga | Tier | Status | Children (T1737-absorption rosters in parens) | Depends on | Note |
+|---|---|---|---|---|---|
+| **T10400 SG-CLEO-SDK-API** | 0 (impl) | pending | T10417 vault-API (T1805, T1807, T1813) | T10343 doctrine | True Envelope SSoT + RESTful API surface; OpenAPI 3.2 spec; `@cleocode/cleo-sdk` client lib; CI gate `lint-envelope-compliance.mjs` |
+| **T10401 SG-HARNESS-DAEMON-IPC** | 0 | pending | 10 (T1738/T1750/T1751/T1752/T1753/T1783/T1792/T1802/T1808/T1811) | T10400 + T10409 | `cleo daemon serve` hosts `crates/cleo-gateway` (vendored per T10409); HTTPS MITM + VCM mutex + heartbeats + WASI/Docker sandbox; **absorbs T1737 CleoOS Sentient Harness v3** |
+| **T10402 SG-COCKPIT-HARNESS** | 0 | pending | T10420 (Wave 0 competitive intel — incl. RMUX + OpenCode 3-facet), T10345 (Wave 1 architecture decision), T1806, T1812 | T10401 + T10400 | **Rust** ratatui Cockpit TUI as separate process (distinct from TS Daemon harness — see §1.5 glossary); envelope-over-IPC to daemon; PTY worker isolation. **Multiplexer infra**: ADOPTING [**rmux**](https://github.com/helvesec/rmux) (native ratatui integration) per SG-WORKTRUNK-OWN vendor pattern — gated by T10420 council review. **Wave 0 = competitive intel survey before building** (4 categories: Rust TUI inspirations / agent harness competitors / memory + persona platforms / orchestration framework competitors) |
+| **T10403 SG-GENKIT-MIDDLEWARE** | cross-cutting | pending | T1744, T1788, T1810 | T10400 + T10409 | Genkit middleware: LLMLingua-2 compression + **gaze-pii via NAPI-RS** (REPLACES OpenRedaction per D1) + provider-agnostic prompt caching; new `@cleocode/cleo-genkit` + `crates/cleo-pii-napi`; **LLM credentials flow through T10409 vault** |
+| **T10404 SG-CANT-RUNTIME-V2** | cross-cutting | pending | 6 (T1747/T1748/T1749/T1784/T1804/T9154) | T10403 + T10400 | Harden CANT runtime per spec; wire `session` to Genkit Dotprompt under the hood; **approval-token state to conduit.db `conduit_approvals` table** (per D3) |
+| **T10409 SG-VAULT-CORE** | 0 (vault/security) | pending | T10410-T10417 (8 epic children) + T1781, T1782 | T10400 | **Vendor `crates/vault-core` + `crates/cleo-gateway` from onecli**; canonical secure SSoT for ALL credentials (LLM + external APIs); AES-256-GCM via `ring`; JWT agent auth via Proxy-Authorization; SQLite default at XDG `vault.db` + Postgres opt-in; collapses ~4,678 LOC of TS credential plumbing to ~200 LOC wrapper |
+| **T10418 SG-AGENT-TOOL-REGISTRY** *(NEW 2026-05-24)* | 0 (registry) | pending | 11 (T1739/T1740/T1741/T1742/T1743/T1746/T1785/T1786/T1787/T1790/T1791) | T10400 + T10404 + T10377 (IVTR coord) | 60+ tools registry (Hermes-Agent steal) — terminal/file/git/web/browser/memory/vision/media/cron + MCP client. Self-discovering agent-facing tool catalog. Coordinates with T10377 SG-IVTR-AC-BINDING's "4 CORE tools" subset to avoid duplication |
+| **T10419 SG-CHANNELS** *(NEW 2026-05-24)* | 0 (adapters/UX) | pending | 8 (T1793-T1800) | T10400 + T10401 + T10403 (HITL) | 18 platform/messaging adapters (Telegram/Discord/Slack/WhatsApp/Signal/Matrix/Mattermost/HA/Feishu/WeCom/Weixin/DingTalk/QQBot/Email/SMS/Webhook/API/BlueBubbles/Local TUI) + Session Store + Delivery Router. Potential home for T1806 Web UI pending council |
+
+### Persona / memory (Tier 3-9) — 2 new sagas filed 2026-05-23
+
+| Saga | Tier | Status | Children | Depends on | Note |
+|---|---|---|---|---|---|
+| **T10405 SG-PSYCHE-FOUNDATION** | 4 + 5 + 6 | pending | T1803, T1809 | T10281 + T10404 | Mem0 chokepoint + Graphiti bitemporal + Hindsight 4-network + PSYCHE pipeline (3 of 4 subsystems exist per masterplan §16.A); **absorbs T1075 PSYCHE Theory-of-Mind Layer** (archived; unarchive blocked by CLI quirk — `absorbs` relation captures intent) |
+| **T10406 SG-FOUR-BUS-INTEGRATION** | 7 | pending | T1745, T1789, T1801 | T10405 + T10295 + T9144 | BRAIN ↔ NEXUS ↔ TASKS ↔ CONDUIT seams: spawn-context-builder, wave-rollup BrainDigestEvent, conduit-ingester; subsumes parts of T9144 W2+W5 |
+| T1085 peer_id column | 3 | done | — | — | Wave 1-2 PSYCHE partial ship |
+| (Tier 8 Continuous Living) | 8 | NOT FILED | — | T10405, T10406 | Successor saga: idle dream, memory-git, skill distillation |
+| (Tier 9 Sentient + Tier-3 sandbox) | 9 | absorbed | — | T10401 | T1737 cleanup completed 2026-05-24; sentient + cron + self-healing children now live under T10401 |
+
+### Architecture / hygiene (cross-cutting)
+
+| Saga | Tier | Status | Note |
+|---|---|---|---|
+| T9831 SG-ARCH-SOLID | cross-cutting (refactor) | **done** | — |
+| T10176 SG-BOUNDARY-REGISTRY | cross-cutting (registry) | **done** | — |
+| T10288 SG-DOCS-INTEGRITY | cross-cutting (docs SSoT) | **shipped 2026-05-24** | closed T9625 predecessor via `cleo saga reconcile T9625`; enforces this very North Star routing |
+| T9787 SG-DOCS-CANON-CLOSURE | cross-cutting (docs) | **done** | — |
+| T9839 SG-GH-TRIAGE-2026-05-21 | cross-cutting (bug triage) | **done** | — |
+| T9800 SG-WORKTREE-CANON | cross-cutting (worktree) | **done 2026-05-24** | — |
+| T9977 SG-WORKTRUNK-OWN | cross-cutting (Rust vendor) | pending | — |
+| T9585 SG-CLEO-CORE-V2 | cross-cutting (CORE-first) | pending | — |
+| T10326 SG-SUBSTRATE-RECONCILIATION | cross-cutting (governance) | **done** | enforcement-code central registry (I#/E#/D#/P#/ORC#/R#/evidence-atoms) + saga-as-TaskType migration |
+| T10377 SG-IVTR-AC-BINDING | cross-cutting (validation) | pending | AC stable IDs + independent Validator role + 4 CORE tools for IVTR loop (coordinates with T10418 SG-AGENT-TOOL-REGISTRY) |
+
+### Product / surface (orthogonal to tier ladder)
+
+| Saga | Status | Note |
+|---|---|---|
+| T9625 SG-CLEO-DOCS-CANON | **closed** | via T10288 saga reconcile |
+| T9758 SG-CLEO-RELEASE-PRODUCT | pending | `cleo release` as canonical release-management product |
+| T9799 SG-CLEO-SKILLS-V2 | pending | Anthropic spec compliance — **absorbs T1754, T1755 (Hermes SKILL → CANT migration)** per T1737 triage |
+| T9855 SG-TEMPLATE-CONFIG-SSOT | pending | unify templates + 4 config files into single CORE-owned manifests |
+| T9862 SG-BUGS-2026-05-21 | **shipped v2026.5.121** | — |
+| T9863 SG-FEAT-2026-05-21 | pending | feature backlog parking |
+| T1042 Cleo Nexus vs GitNexus (Far-Exceed) | pending | top-level master; owns T9144 Nexus Restructure |
+| **T1737 CleoOS Sentient Harness v3** | **structurally retired 2026-05-24** | 52 pending children triaged into 11-saga mesh (8 originally + 2 new + 1 absorbing existing saga); 0 pending children remaining; status update to `cancelled` blocked by transient CLI dist issue (verify + cancel on next clean build). Relations: T10401 + T10418 + T10419 + T9799 `absorbs`, plus pre-existing T1910 `related` |
+
+## 4. Critical sequencing (updated 2026-05-25)
+
+Dependency-ordered ship sequence (post 2026-05-24 deltas):
+
+1. **DONE 2026-05-23** — T10286 BRAIN P0 hotfix shipped; brain.db `integrity_check=ok`
+2. **DONE 2026-05-24** — T10288 SG-DOCS-INTEGRITY shipped (5/5 epics, v2026.5.115); enforces canon doc routing including this very North Star
+3. **DONE 2026-05-24** — T9800 SG-WORKTREE-CANON shipped; T10326 SG-SUBSTRATE-RECONCILIATION shipped
+4. **DONE 2026-05-24** — T1737 CleoOS Sentient Harness v3 structurally retired; 52 children triaged into 11-saga mesh (61 reparents total)
+5. **NOW** — close remaining T10281 epics (E1 inventory + E2 integrity + E3 backup-recovery + E4 cross-links). Restores BRAIN trust ratchet
+6. **NOW (parallel-safe)** — T10295 SG-PROJECT-AUTHORITY (path-resolution rewrite). Different code surface; no conflict
+7. **NEXT** — T10343 SG-ENVELOPE-FIRST doctrine ratification (T10344 boundary-registry simplification + T10346 envelope-contract-hardening)
+8. **THEN sequenced** — T10400 SG-CLEO-SDK-API (consumes T10343 doctrine)
+9. **THEN sequenced** — T10409 SG-VAULT-CORE (vendors `crates/cleo-gateway` that T10401 hosts)
+10. **THEN parallel pair** — T10401 SG-HARNESS-DAEMON-IPC + T10403 SG-GENKIT-MIDDLEWARE (both consume T10400 SDK API + T10409 gateway)
+11. **THEN** — T10420 EP-COCKPIT-COMPETITIVE-INTEL (Wave 0 of T10402; RMUX + OpenCode council review)
+12. **THEN** — T10402 SG-COCKPIT-HARNESS (consumes T10401 daemon + T10400 API + T10420 council verdict)
+13. **THEN** — T10404 SG-CANT-RUNTIME-V2 (consumes T10403 Genkit/Dotprompt + T10400 SDK)
+14. **THEN parallel pair** — T10418 SG-AGENT-TOOL-REGISTRY + T10419 SG-CHANNELS (both consume T10400+T10401+T10404)
+15. **THEN** — T10405 SG-PSYCHE-FOUNDATION (consumes T10281 BRAIN substrate + T10404 CANT permissions for memory tools)
+16. **THEN** — T10406 SG-FOUR-BUS-INTEGRATION (consumes T10405 Mem0 chokepoint + T10295 projectId + T9144 partial ship)
+17. **FUTURE** — Tier 8 Continuous Living + Tier 11-14 from masterplan §17
+
+## 5. Genkit + CANT integration map + decisions ledger (inline)
+
+### 5.1 Decisions D1-D7 (ratified 2026-05-24, source: `sg-mesh-decisions-ledger-2026-05-24-home-t10400`)
+
+Mirrored from the actual decisions ledger blob attached to T10400 (slug suffix `-home-t10400` was auto-added by the docs SSoT). Decisions govern the data flow diagram in §5.2.
+
+| ID | Decision | Why |
+|---|---|---|
+| **D1** | **SDK-API + envelope-first split: KEEP AS PROPOSED** — T10343 = doctrine saga (LAFS envelope as canonical boundary); T10400 = implementation saga (OpenAPI 3.2 + `@cleocode/cleo-sdk` + CI gate). Relation: `T10343 supersedes T10400` (doctrine ratified by implementation), `T10400 extends T10343` | Clean separation of "rule" from "surface" makes both stable; doctrine changes infrequently, implementation evolves per provider/version drift |
+| **D2** | **Gateway transport: HYBRID** — HTTPS control plane (axum + hyper + tokio-rustls + rcgen MITM CA per T10409 AC2) for SDK API requests + JWT Proxy-Authorization (T10409 AC7); Unix socket fallback at `~/.local/share/cleo/daemon.sock` for same-machine high-trust ops; ZeroMQ PUB/SUB data plane for streaming (heartbeats 1Hz, brain pulses, PTY firehose per Harness doc §2) | REST ecosystem for control plane; skip TLS overhead for local ops; ZeroMQ for high-volume unidirectional streaming |
+| **D3** | **LLMLingua model: TinyBERT (57MB) default**; MobileBERT (99MB) / BERT-Base (710MB) / XLM-RoBERTa-Large (2.2GB GPU) selectable via `CLEO_LLMLINGUA_MODEL=<variant>` env OR `.cleo/config.json` `llmlingua.model` key. First use of non-default triggers HuggingFace download with operator confirmation prompt (no silent multi-GB downloads). T10403 AC9 locked 2026-05-24 | Ergonomics > accuracy in default install; opt-in for accuracy-critical workloads; per-project override > env |
+| **D4** | **PII engine: `gaze-pii` Rust crate via NAPI-RS bridge** (REPLACES OpenRedaction). gaze-pii v0.9.0 on crates.io 2026-05-16 + gaze-assembly v0.9.0 (StandardRulepack with GDPR/HIPAA presets). License: Apache-2.0 OR MIT (safe to consume). 10-50μs NAPI round-trip vs OpenRedaction's 300ms REST | Major architecture change: Rust NER+regex with cryptographic Manifest vs Node.js regex-first; bidirectional rehydration preserved; Rust hot path per ADR-078 |
+| **D5** | **CANT discretion rate limit: 100 evaluations/workflow default**; per-`.cant`-file override via frontmatter `discretion_budget: 500`; per-evaluator cost tracking surfaced via `cleo doctor cant` | Most workflows <10 discretion conditions; tight loops are rare and should be explicit opt-in; 100 is generous enough that legitimate single-workflow use never hits it; cost cap matters per CANT spec §7.3 |
+| **D6** | **Approval token state: `conduit.db` (`conduit_approvals` table)** — CANT spec §8 approval gates have 24h expiration; TS Daemon crash during window must NOT lose pending approvals. State persists to conduit.db, NOT a new dedicated DB | Approval gates ARE inter-agent communication artifacts (semantic fit); conduit already has `attachment_approvals` table as precedent for approval-pattern naming + schema; no new DB topology required (reduces T10281 BRAIN-DB-RESILIENCE inventory pressure) |
+| **D7** | **CANT discretion rate (confirmed by owner)** — owner agreed with D5 recommendation; no further action | Closes the open question from `sg-canonical-saga-mesh-2026-05-23` charter §7 |
+
+**Open decisions** (TBD by next planning agent):
+- **D8** — RMUX adoption for Cockpit multiplexer infra (gated by T10420 council review; ADOPT default per owner intent in `cockpit-competitive-intel-seed-2026-05-24`)
+- **D9** — OpenCode 3-facet evaluation outcomes: (a) harness arch → T10401, (b) Webapp GUI → T1806/T10419, (c) chat history → T10405/T10402
+- **D10** — T1806 Web UI placement: currently T10402; may move to T10401 (daemon admin surface) or T10419 (operator web channel surfaces) pending OpenCode Webapp evaluation in T10420
+
+**Investigation findings from ledger §3** (additional ground-truth, 2026-05-24):
+- `packages/core/src/llm/caching.ts` exists as Gemini-specific cached-content store (T1393) — T10403 EXTENDS this for Anthropic ephemeral + OpenAI prefix, does NOT rewrite
+- `packages/core/src/llm/context-engines/` exists but minimal (only `rule-based-truncation.ts`) — T10403 adds LLMLingua-2 as NEW context engine alongside
+- `packages/cant/src/` has parse + composer + types + mental-model + native-loader + hierarchy + document + worktree + bundle + context-provider-brain + migrate — **execution side is greenfield**
+- `packages/core/src/cant/` does NOT exist — CANT spec §7.2 names `packages/core/src/cant/workflow-executor.ts` which must be CREATED by T10404
+- `conduit.db` has precedent `attachment_approvals` table — schema pattern for D6 `conduit_approvals`
+
+### 5.2 End-to-end data flow
+
+How the new mesh threads together end-to-end:
+
+```
+USER input (CLI / Cockpit TUI)
+         │
+         ▼
+[cleo daemon serve] ── HTTPS Gateway (axum+hyper+tokio-rustls per T10409) ── SG-HARNESS-DAEMON-IPC (T10401)
+         │                                       │
+         │                                       └── ZeroMQ PUB/SUB for STREAMING (heartbeats 1Hz, brain pulses, PTY firehose)
+         ▼
+[Envelope contracts (Zod / OpenAPI 3.2)] ── SG-CLEO-SDK-API (T10400)
+         │
+         ▼
+[CANT workflow / pipeline dispatch] ── SG-CANT-RUNTIME-V2 (T10404)
+         │
+         ├── pipeline: Rust cant-runtime (NO LLM, deterministic shell-safe per spec P01-P07)
+         │
+         └── session: Genkit Dotprompt ── SG-GENKIT-MIDDLEWARE (T10403)
+                  │
+                  ▼
+              [Genkit middleware stack — onion order]
+                  ├── retry / fallback (out-of-box)
+                  ├── hardenedAgenticHarness:
+                  │   ├── gaze-pii NAPI-RS bridge (Rust, 10-50μs round-trip — REPLACES OpenRedaction per D1)
+                  │   ├── LLMLingua-2 token compression (TinyBERT default per D2; XLM-RoBERTa opt-in via CLEO_LLMLINGUA_MODEL)
+                  │   └── Recursive summarization (cheap model)
+                  ├── Provider cache structuring (Anthropic ephemeral / OpenAI prefix / Gemini context-cache)
+                  └── toolApproval (HITL gates persisted to conduit.db conduit_approvals table per D3)
+                  │
+                  ▼
+              [Provider URL rewritten to localhost gateway, placeholder key (FAKE_KEY)]
+                  │
+                  ▼
+              [Gateway (T10409) intercepts: vault.db lookup → AES-256-GCM decrypt → per-host header inject]
+                  │   ├── api.anthropic.com → x-api-key header
+                  │   └── else → Authorization: Bearer
+                  │   audit: telemetry log entry per injection
+                  ▼
+              [Provider API call with REAL credentials — agent NEVER sees them]
+                  │
+                  ▼
+              [Response → gaze-pii engine.restore() for tool execution]
+                  │
+                  ▼
+              [Memory writes through Mem0 chokepoint] ── SG-PSYCHE-FOUNDATION (T10405)
+                  │
+                  ▼
+              [BRAIN ↔ NEXUS ↔ TASKS ↔ CONDUIT seams] ── SG-FOUR-BUS-INTEGRATION (T10406)
+```
+
+## 6. Identified gaps remaining (after 10-saga mesh)
+
+### 6.1 Tier 8 Continuous Living — NOT FILED yet
+Successor saga to SG-PSYCHE-FOUNDATION. Idle dream, memory-git per peer, skill distillation. File when T10405 ships.
+
+### 6.2 T1075 archive→pending blocked by CLI quirk
+`cleo restore task T1075` returns "already active with status: archived" (logic contradiction). Filed as known CLI bug. `relates absorbs T10405→T1075` captures the intent; worker can navigate.
+
+### 6.3 T1737 structural retirement — status flip blocked
+52 children fully triaged into 11-saga mesh on 2026-05-24; 0 pending children remaining. Status update to `cancelled` blocked by transient CLI dist issue (`Cannot find package '@cleocode/worktree'` — needs rebuild). Verify + cancel on next clean build. Mapping documented above in Product/Surface table.
+
+### 6.4 "Feature backlog" epics still not tier-aligned
+T9863/T9864-T9870/T9903/T9919/T9927 — tactical work parking. Triage during next audit cycle.
+
+### 6.5 RAW-WRITE LOSS LESSON (2026-05-25)
+The original of this doc was written via raw `Write` to `docs/plans/` (wrong path; canon.yml says `docs/plan/`) and was NEVER committed — vanished via branch operations. **Lesson**: per AGENTS.md ADR-076 + the just-shipped T10288 SG-DOCS-INTEGRITY enforcement, EVERY canonical doc (plan / spec / research / handoff / note / adr / changeset / release-note / rcasd / llm-readme) MUST be created via `cleo docs add --type <kind>`. This reconstructed version IS routed via `cleo docs add --type plan` → SSoT blob + publish mirror at `docs/plan/cleo-canonical-north-star.md`. **The v2 reconstruction (2026-05-25) integrates BOTH work streams (vault-core additions from session A + RMUX/OpenCode/T1737-retirement from session B) plus inline decisions ledger D1-D7 since standalone ledger doc was never created (only referenced).**
+
+### 6.6 T1806 Web UI placement TBD (D10)
+T1806 (Web UI for daemon management) lives in `packages/cleo-os/src/web/` — daemon-side code, not cockpit-side. Currently under T10402 but may move to T10401 (daemon admin surface) or T10419 (operator web channel surface). Decision deferred to T10420 council review of OpenCode Webapp evaluation.
+
+### 6.7 Decisions ledger doc slug suffix discovered (RESOLVED in v3)
+v2 incorrectly stated `sg-mesh-decisions-ledger-2026-05-24` was missing. In v3 the actual slug `sg-mesh-decisions-ledger-2026-05-24-home-t10400` was discovered (docs SSoT appends `-home-<ownerId>` for clarity). The ledger blob is 17,434 bytes and IS attached to T10400 with full D1-D7 ratification + investigation findings §3. The inline §5.1 above mirrors the ledger; for full investigation findings §3 (existing surfaces audit + dependency availability) run `cleo docs fetch sg-mesh-decisions-ledger-2026-05-24-home-t10400`.
+
+## 7. Maintenance contract
+
+This doc is **two pages of map, not a plan**. Update it when:
+
+- A new saga is filed that doesn't fit a tier above
+- An existing saga changes status (pending → active → done)
+- A GAP row in §3 gets filled with a saga ID
+- The two source docs' canonical status changes
+- A new tier emerges in the masterplan (it's already added 4 tiers post-research-pass-2; future tiers welcome)
+- A new D# decision is ratified — add to §5.1 inline
+
+**Update mechanism**: `cleo docs update <slug>` OR write new content and re-run `cleo docs add --slug cleo-canonical-north-star --type plan --replace`. Then `cleo docs publish --for T10400 --to docs/plan/cleo-canonical-north-star.md` to refresh the mirror. **NEVER raw-write to `docs/plan/`** — that path is the publish mirror, not the SSoT.
+
+**After publish**: `git add docs/plan/ && git commit` to lock the mirror to the branch.
+
+Do NOT update this doc to:
+- Re-architect a tier (edit the masterplan instead)
+- Re-spec the harness layer (edit the harness doc instead)
+- Detail saga acceptance criteria (use `cleo show <id>` — the saga IS the spec)
+
+## 8. One-line summary
+
+**Two canonical plans, fourteen-plus-one tiers, ten Tier-0 sagas + two persona/memory sagas, gated by BRAIN-DB-first, surfaced through envelopes, integrated via Genkit-middleware + gaze-pii + CANT, ending in a persistent Cleo persona that knows every project on the user's machine.**
+
+## Appendix — file + slug references
+
+### Source docs
+- Sentient Masterplan: `docs/plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md`
+- Harness Architecture: `docs/research/CleoCode-Architecture-Harness-Planning.md`
+- CANT spec: `docs/specs/CANT-DSL-SPEC.md`
+- Genkit research: `docs/research/{GenKit-PromptCompression-CANT-DotPrompt.txt, Architectural-Design-AgenticHarness-Genkit.txt}`
+
+### Research doc slugs (via `cleo docs fetch <slug>`)
+- `sg-canonical-saga-mesh-2026-05-23` — original mesh charter (7 sagas → expanded to 10)
+- `sg-mesh-decisions-ledger-2026-05-24-home-t10400` — D1-D7 decisions ratification + investigation findings §3 (existing surfaces + dependency availability); mirrored inline in §5.1
+- `sg-brain-db-resilience-deep-audit-2026-05-23` — BRAIN substrate audit
+- `sg-project-authority-charter-2026-05-23` — projectId-as-truth charter
+- `sg-envelope-first-doctrine-2026-05-23` — envelope SSoT doctrine
+- `sg-vault-core-charter-2026-05-23` — vault + gateway vendor charter
+- `cockpit-competitive-intel-seed-2026-05-24` — RMUX + OpenCode steal-candidates seed (under T10420)
+
+### Key ADRs
+- ADR-039 — LAFS envelope (the seam)
+- ADR-073 — Saga/Epic/Task/Subtask hierarchy
+- ADR-076 — Canonical docs routing (T9796) — enforces this doc's SSoT routing
+- ADR-078 — Boundary Registry as SSoT for Rust/TS layering
+- ADR-083 — Persona substrate (Cleo singleton)

--- a/docs/plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md
+++ b/docs/plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md
@@ -1,8 +1,12 @@
 # CLEO Prime — Canonical Sentient Master Plan
 
 > **Canonical**: this document supersedes `~/.claude/plans/dreamy-yawning-pinwheel.md` and `~/.claude/plans/i-know-there-was-sequential-elephant.md`, merging both into a single layered roadmap.
-> **Status**: planning · DRAFT · 2026-05-15
+> **Status**: canonical (promoted from DRAFT 2026-05-23) · indexed by `cleo docs fetch cleo-canonical-north-star` (mirror: [`docs/plan/cleo-canonical-north-star.md`](../plan/cleo-canonical-north-star.md))
+> **Originally drafted**: 2026-05-15
 > **Floor**: `v2026.5.68` (T9261 Phase 4 W1-W4 — unified LLM provider architecture live)
+> **Sibling canon**: [`docs/research/CleoCode-Architecture-Harness-Planning.md`](../research/CleoCode-Architecture-Harness-Planning.md) — UI/IPC/TUI layer (Tier 0 added 2026-05-23)
+> **2026-05-23 addendum**: brain.db malformed in production; Tier 0 prerequisite **T10281 SG-BRAIN-DB-RESILIENCE** filed — Wave 0 (T10286 hotfix) shipped 2026-05-23
+> **2026-05-24 addendum**: 11-saga Tier-0 mesh + 2 persona/memory sagas — see `cleo docs fetch cleo-canonical-north-star` (v3 owner-shipped 2026-05-24 18:01 via commit 3064d10d5); T10288 SG-DOCS-INTEGRITY shipped (v2026.5.115), enforces canonical doc routing
 > **Author**: cleo-prime (orchestrator), synthesizing two parallel research-pass plans into one canon
 
 ---

--- a/docs/research/CleoCode-Architecture-Harness-Planning.md
+++ b/docs/research/CleoCode-Architecture-Harness-Planning.md
@@ -1,0 +1,108 @@
+# **Cleo Code: Agentic Harness Architecture Plan**
+
+> **Status**: canonical (2026-05-23) · indexed by `cleo docs fetch cleo-canonical-north-star` (mirror: [`docs/plan/cleo-canonical-north-star.md`](../plan/cleo-canonical-north-star.md))
+> **Layer owned**: Tier 0 Harness Layer (Cockpit TUI · TS Daemon · ZeroMQ IPC · VCM mutex · PTY isolation)
+> **Sibling canon**: [`docs/plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md`](../plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md) — persona/memory layer (Tier 1-14)
+> **Seam between layers**: LAFS envelope (ADR-039); contract hardened by saga **T10343 SG-ENVELOPE-FIRST**
+> **Filed sagas covering this doc's scope** (per `cleo docs fetch sg-canonical-saga-mesh-2026-05-23` + `sg-mesh-decisions-ledger-2026-05-24`):
+> - **T10401 SG-HARNESS-DAEMON-IPC** — `cleo daemon serve` + VCM mutex queue + ZeroMQ data plane + WASI/Docker sandbox (§§2, 7, 8.D, 8.E)
+> - **T10402 SG-COCKPIT-HARNESS** — Rust `ratatui` TUI as separate process consuming envelope-over-IPC (§§2, 6)
+> - **T10409 SG-VAULT-CORE** — vendored `crates/cleo-gateway` (axum + hyper + tokio-rustls + rcgen MITM CA) hosting the SDK API surface
+> - **T10403 SG-GENKIT-MIDDLEWARE** — context compression (LLMLingua-2) + bidirectional PII (gaze-pii NAPI-RS) addresses §8.C context window exhaustion
+> - **T9800 SG-WORKTREE-CANON** + **T9977 SG-WORKTRUNK-OWN** — addresses §8.A worktree dependency management
+> **2026-05-24 update**: HTTPS via vendored `crates/cleo-gateway` is the **primary** transport for the SDK API control plane; ZeroMQ retained for streaming/PUB-SUB only (heartbeats, brain pulses, PTY firehose) per §8.D heartbeat protocol. See decisions ledger D2.
+> **Promotion-to-plans/ pending**: when first Tier 0 wave ships, move this doc into `docs/plan/` via `cleo docs add --type plan`.
+
+## **1\. Executive Summary**
+
+Cleo Code is a bleeding-edge, autonomous agentic harness designed to manage complex software development lifecycles. It utilizes a hybrid architecture: a highly responsive, crash-resistant Rust Terminal User Interface (TUI) acting as the command cockpit, driven by a high-concurrency TypeScript Daemon that routes logic, orchestrates LLM agents, and manages file-system mutability.
+
+The system features a sentient-leaning Prime Orchestrator, a collaborative agent network (Conduit), an execution pipeline (LOOM), and a graph-connected memory system (The Living Brain).
+
+## **2\. Core Architecture & Inter-Process Communication (IPC)**
+
+The system is strictly divided to ensure UI responsiveness and deterministic execution without blocking the Node/Bun event loop.
+
+* **The TS Daemon (Traffic Cop):** Written in TypeScript. Handles LLM network I/O, state machine transitions, OS child-process spawning, and git lock management.  
+* **The Rust TUI (The Cockpit):** Built with ratatui and the cockpit crate. Renders the UI, multiplexes PTYs (Pseudo-Terminals) for worker isolation, and visualizes system state.  
+* **The IPC Bridge (ZeroMQ):** \* *PUB/SUB Socket:* High-volume, unidirectional firehose from TS Daemon to Rust TUI (streaming worker stdout, brain pulses, state changes).  
+  * *REQ/REP Socket:* Command channel for user input from the TUI to the Daemon.  
+  * *Payloads:* Strictly typed using Discriminated/Tagged Unions (CleoEnvelope, CleoEvent) mapped between TypeScript interfaces and Rust serde structs.
+
+## **3\. Project Lifecycle & Data Hierarchy (LOOM)**
+
+Development is tracked via a strict hierarchical pipeline to ensure LLMs maintain context and focus.
+
+### **The Hierarchy**
+
+1. **Sagas:** Grouped, overarching epics (e.g., "Implement User Authentication").  
+2. **Epics:** Full release packages tied to a Saga.  
+3. **Tasks:** PR-worthy grouped commits.  
+4. **Subtasks:** Atomic, isolated changes assigned to ephemeral workers.
+
+### **The Pipeline (LOOM)**
+
+Every Epic flows through two distinct loop phases:
+
+1. **RCASD:** Research, Consensus, Architecture Decision, Specification, Decomposition. (Managed by Lead Agents via the *Conduit* collaboration pipeline).  
+2. **IVTR:** Implementation, Validation, Testing, Release. (Executed by Ephemeral Workers in isolated environments).
+
+## **4\. Agent Hierarchy**
+
+* **Prime Orchestrator:** The single point of contact for the user. Manages global state, delegates Epics to Lead Agents, and monitors the Living Brain.  
+* **Lead Agents:** Domain-specific managers. They debate architecture in the Conduit, decompose Tasks into Subtasks, and review PRs.  
+* **Ephemeral Workers:** Highly focused, short-lived agents spawned to execute a single IVTR Subtask. They operate in isolated terminal sessions and git worktrees.
+
+## **5\. The Living Brain & Memory**
+
+A native Rust SDK utilizing SQLite, exposed to the TypeScript Daemon via **NAPI-RS**. This allows CPU-bound graph traversal to run on background C++ threads, keeping the TS event loop unblocked.
+
+* **Macro Topology (Braille Canvas):** TUI visualization using sub-character resolution to show neural "pulses" and connection activity.  
+* **Micro Semantics (Semantic Ledger):** TUI table showing exact contextual memory retrievals.  
+* **Dream States:** When the system is idle, a dedicated Node worker thread engages the NAPI-RS module to run compaction algorithms—forging ephemeral observations into deterministic rules. The UI visually shifts palettes to indicate this "Consolidation Mode."
+
+## **6\. The Cockpit TUI Layout**
+
+A single, clean terminal interface to monitor the entire harness.
+
+* **Left Sidebar (HUD):** System daemon health and The Living Brain visualization/Dream state gauges.  
+* **Right Sidebar (Pipeline):** Collapsible Saga/Epic tree with color-coded tags indicating LOOM phases (RCASD vs IVTR).  
+* **Center Top:** Prime Orchestrator Chat and the rolling Conduit agent-debate feed.  
+* **Center Bottom (Cockpit Isolation Zone):** Dynamic grid of cockpit PTY panes where ephemeral workers stream their compilation/test output in real-time. If a worker crashes, the PTY collapses safely without taking down the TUI.
+
+## **7\. Version Control & Isolation Manager (VCM)**
+
+To prevent agents from stepping on each other's toes during simultaneous IVTR loops, the system uses strict filesystem and process isolation.
+
+* **Git Worktrees:** Every ephemeral worker is assigned a dynamically generated git worktree to ensure file-system and git index isolation.  
+* **The VCM Mutex Queue:** A singleton class in the TS Daemon handling locked Git operations (branch, fetch, push, worktree add).  
+* **Fault Tolerance:** The VCM uses try/finally blocks, AbortController timeouts, and OS-level SIGKILL commands to guarantee that rogue, hanging Git processes cannot dead-lock the automated queue.
+
+## **8\. "Gotchas" & Research Areas**
+
+As development progresses, pay special attention to the following architectural risks:
+
+### **A. Dependency Management in Worktrees**
+
+* **The Problem:** git worktree isolates source code, but running npm install or cargo build in 10 simultaneous worktrees will exhaust disk space and CPU.  
+* **Action/Research:** Research hardlinking techniques. For Node/TS, leverage pnpm's global store. For Rust, configure a shared .cargo/config.toml injecting sccache and a shared CARGO\_TARGET\_DIR for the workers.
+
+### **B. SQLite Write Contention (The Brain)**
+
+* **The Problem:** During a Dream State, the background thread will heavily write/compact the SQLite database. If the Prime Orchestrator needs to read context simultaneously, SQLite might lock.  
+* **Action/Research:** Ensure the Rust SQLite connection is explicitly configured to use PRAGMA journal\_mode=WAL; (Write-Ahead Logging) to allow concurrent reads and writes.
+
+### **C. Context Window Exhaustion**
+
+* **The Problem:** Passing the Saga, Epic, Task, Subtask, and Brain Context into an LLM prompt will quickly exceed token limits or cause the LLM to lose focus ("lost in the middle" phenomenon).  
+* **Action/Research:** Develop strict summarization strategies within the Conduit pipeline. Lead Agents must compress the RCASD consensus into a terse specification before passing it to the ephemeral worker.
+
+### **D. ZeroMQ Zombie Sockets & TUI Disconnects**
+
+* **The Problem:** If the TS Daemon crashes unexpectedly, the Rust TUI might hang indefinitely waiting for a REQ/REP response.  
+* **Action/Research:** Implement heartbeat payloads on the PUB/SUB socket. If the Rust TUI misses 3 heartbeats, it should gracefully display a "Connection Lost" overlay rather than freezing.
+
+### **E. Security & Jailbreaking (Worker Containment)**
+
+* **The Problem:** Ephemeral workers operate with shell access via child\_process.spawn. An LLM hallucination could result in rm \-rf / or escaping the worktree.  
+* **Action/Research:** Research lightweight containment. Depending on the OS, restrict the spawned worker's permissions, strictly validate the cwd, or run workers inside lightweight Docker containers or WebAssembly (WASI) sandboxes if pure PTY isolation isn't secure enough.

--- a/packages/contracts/src/__tests__/validator-types.test.ts
+++ b/packages/contracts/src/__tests__/validator-types.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Type-level and runtime shape tests for T10510 Validator role contracts.
+ *
+ * Covers the AgentRole enum extension and the four envelope types
+ * (`ValidatorFinding`, `ValidatorAttestation`, `ValidatorRejection`,
+ * `ValidatorVerdict`) plus their Zod schemas and type guards.
+ *
+ * @task T10510
+ * @epic T10383 (E-VALIDATOR-ROLE)
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_ROLES,
+  type AgentRole,
+  isAgentRole,
+  isValidatorAttestation,
+  isValidatorRejection,
+  isValidatorVerdict,
+  VALIDATOR_ID_REGEX,
+  type ValidatorAttestation,
+  type ValidatorFinding,
+  type ValidatorRejection,
+  type ValidatorVerdict,
+  validatorAttestationSchema,
+  validatorFindingSchema,
+  validatorRejectionSchema,
+  validatorVerdictSchema,
+} from '../validator/index.js';
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+const NOW = '2026-05-24T12:00:00Z';
+
+const passFinding: ValidatorFinding = {
+  acId: '11111111-1111-4111-8111-111111111111',
+  status: 'pass',
+  reasoning: 'AC satisfied — implementation matches spec',
+  checkedAt: NOW,
+};
+
+const failFinding: ValidatorFinding = {
+  acId: '22222222-2222-4222-8222-222222222222',
+  status: 'fail',
+  reasoning: 'Missing error handling for the null branch',
+  evidenceRefs: ['src/foo.ts:42', 'tests/foo.test.ts:17'],
+  checkedAt: NOW,
+};
+
+const inconclusiveFinding: ValidatorFinding = {
+  acId: '33333333-3333-4333-8333-333333333333',
+  status: 'inconclusive',
+  reasoning: 'Cannot reproduce the claimed test — file not present',
+  checkedAt: NOW,
+};
+
+// ============================================================================
+// AgentRole enum
+// ============================================================================
+
+describe('AgentRole enum (T10510)', () => {
+  it('contains the four canonical roles', () => {
+    expect(AGENT_ROLES).toEqual(['orchestrator', 'lead', 'worker', 'validator']);
+  });
+
+  it('AGENT_ROLES is a readonly tuple of length 4', () => {
+    // `as const` is a compile-time readonly marker — there is no runtime
+    // freeze. The TS type guard below ensures mutation attempts are rejected
+    // by the compiler; runtime length is the structural invariant.
+    expect(AGENT_ROLES.length).toBe(4);
+    // @ts-expect-error — readonly tuple disallows .push at the type level.
+    AGENT_ROLES.push;
+  });
+
+  it('AgentRole type compiles for all four values', () => {
+    const roles: AgentRole[] = ['orchestrator', 'lead', 'worker', 'validator'];
+    expect(roles).toHaveLength(4);
+  });
+
+  it('isAgentRole accepts canonical values', () => {
+    for (const r of AGENT_ROLES) {
+      expect(isAgentRole(r)).toBe(true);
+    }
+  });
+
+  it('isAgentRole rejects unknown strings and non-strings', () => {
+    expect(isAgentRole('subagent')).toBe(false);
+    expect(isAgentRole('Validator')).toBe(false);
+    expect(isAgentRole('')).toBe(false);
+    expect(isAgentRole(undefined)).toBe(false);
+    expect(isAgentRole(null)).toBe(false);
+    expect(isAgentRole(42)).toBe(false);
+    expect(isAgentRole({})).toBe(false);
+  });
+});
+
+// ============================================================================
+// VALIDATOR_ID_REGEX
+// ============================================================================
+
+describe('VALIDATOR_ID_REGEX (T10510)', () => {
+  it('accepts canonical validator agentIds', () => {
+    expect(VALIDATOR_ID_REGEX.test('validator-prime')).toBe(true);
+    expect(VALIDATOR_ID_REGEX.test('validator-sec-001')).toBe(true);
+    expect(VALIDATOR_ID_REGEX.test('validator-a')).toBe(true);
+    expect(VALIDATOR_ID_REGEX.test('validator-9-test')).toBe(true);
+  });
+
+  it('rejects malformed validator agentIds', () => {
+    expect(VALIDATOR_ID_REGEX.test('validator-')).toBe(false);
+    expect(VALIDATOR_ID_REGEX.test('Validator-prime')).toBe(false);
+    expect(VALIDATOR_ID_REGEX.test('validator-Prime')).toBe(false);
+    expect(VALIDATOR_ID_REGEX.test('worker-prime')).toBe(false);
+    expect(VALIDATOR_ID_REGEX.test('validator-_x')).toBe(false);
+  });
+});
+
+// ============================================================================
+// ValidatorFinding
+// ============================================================================
+
+describe('ValidatorFinding (T10510)', () => {
+  it('accepts pass / fail / inconclusive', () => {
+    expect(validatorFindingSchema.safeParse(passFinding).success).toBe(true);
+    expect(validatorFindingSchema.safeParse(failFinding).success).toBe(true);
+    expect(validatorFindingSchema.safeParse(inconclusiveFinding).success).toBe(true);
+  });
+
+  it('rejects empty acId', () => {
+    const bad = { ...passFinding, acId: '' };
+    expect(validatorFindingSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects empty reasoning', () => {
+    const bad = { ...passFinding, reasoning: '' };
+    expect(validatorFindingSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects unknown status value', () => {
+    const bad = { ...passFinding, status: 'warn' };
+    expect(validatorFindingSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('accepts optional evidenceRefs array', () => {
+    const withRefs = { ...passFinding, evidenceRefs: ['a', 'b'] };
+    expect(validatorFindingSchema.safeParse(withRefs).success).toBe(true);
+  });
+});
+
+// ============================================================================
+// ValidatorAttestation
+// ============================================================================
+
+describe('ValidatorAttestation (T10510)', () => {
+  const baseAttestation: ValidatorAttestation = {
+    verdict: 'attest',
+    taskId: 'T10510',
+    validatorId: 'validator-prime',
+    findings: [passFinding],
+    attestedAt: NOW,
+    schemaVersion: '1',
+  };
+
+  it('accepts a well-formed attestation with all passes', () => {
+    expect(validatorAttestationSchema.safeParse(baseAttestation).success).toBe(true);
+  });
+
+  it('accepts optional summary', () => {
+    const withSummary = { ...baseAttestation, summary: 'All ACs verified' };
+    expect(validatorAttestationSchema.safeParse(withSummary).success).toBe(true);
+  });
+
+  it('accepts multiple pass findings', () => {
+    const multi = {
+      ...baseAttestation,
+      findings: [passFinding, { ...passFinding, acId: '44444444-4444-4444-8444-444444444444' }],
+    };
+    expect(validatorAttestationSchema.safeParse(multi).success).toBe(true);
+  });
+
+  it('REJECTS attestation containing any fail finding', () => {
+    const mixed = { ...baseAttestation, findings: [passFinding, failFinding] };
+    const r = validatorAttestationSchema.safeParse(mixed);
+    expect(r.success).toBe(false);
+  });
+
+  it('REJECTS attestation containing inconclusive finding', () => {
+    const mixed = { ...baseAttestation, findings: [passFinding, inconclusiveFinding] };
+    expect(validatorAttestationSchema.safeParse(mixed).success).toBe(false);
+  });
+
+  it('REJECTS empty findings array', () => {
+    const empty = { ...baseAttestation, findings: [] };
+    expect(validatorAttestationSchema.safeParse(empty).success).toBe(false);
+  });
+
+  it('REJECTS malformed validatorId', () => {
+    const bad = { ...baseAttestation, validatorId: 'worker-prime' };
+    expect(validatorAttestationSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('REJECTS wrong verdict discriminant', () => {
+    const bad = { ...baseAttestation, verdict: 'reject' };
+    expect(validatorAttestationSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('REJECTS wrong schemaVersion', () => {
+    const bad = { ...baseAttestation, schemaVersion: '2' };
+    expect(validatorAttestationSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+// ============================================================================
+// ValidatorRejection
+// ============================================================================
+
+describe('ValidatorRejection (T10510)', () => {
+  const baseRejection: ValidatorRejection = {
+    verdict: 'reject',
+    taskId: 'T10510',
+    validatorId: 'validator-sec-001',
+    findings: [failFinding],
+    summary: 'AC#2 fails — null branch unhandled',
+    rejectedAt: NOW,
+    schemaVersion: '1',
+  };
+
+  it('accepts a well-formed rejection with a fail finding', () => {
+    expect(validatorRejectionSchema.safeParse(baseRejection).success).toBe(true);
+  });
+
+  it('accepts a rejection with only an inconclusive finding', () => {
+    const inc = { ...baseRejection, findings: [inconclusiveFinding] };
+    expect(validatorRejectionSchema.safeParse(inc).success).toBe(true);
+  });
+
+  it('accepts mixed pass + fail findings', () => {
+    const mixed = { ...baseRejection, findings: [passFinding, failFinding] };
+    expect(validatorRejectionSchema.safeParse(mixed).success).toBe(true);
+  });
+
+  it('REJECTS rejection where every finding is pass', () => {
+    const allPass = { ...baseRejection, findings: [passFinding, passFinding] };
+    const r = validatorRejectionSchema.safeParse(allPass);
+    expect(r.success).toBe(false);
+  });
+
+  it('REJECTS empty findings array', () => {
+    const empty = { ...baseRejection, findings: [] };
+    expect(validatorRejectionSchema.safeParse(empty).success).toBe(false);
+  });
+
+  it('REJECTS empty summary', () => {
+    const bad = { ...baseRejection, summary: '' };
+    expect(validatorRejectionSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('accepts optional remediationHints', () => {
+    const withHints = {
+      ...baseRejection,
+      remediationHints: ['Add null guard to foo()', 'Add regression test'],
+    };
+    expect(validatorRejectionSchema.safeParse(withHints).success).toBe(true);
+  });
+});
+
+// ============================================================================
+// ValidatorVerdict discriminated union
+// ============================================================================
+
+describe('ValidatorVerdict (T10510)', () => {
+  const attestation: ValidatorAttestation = {
+    verdict: 'attest',
+    taskId: 'T10510',
+    validatorId: 'validator-prime',
+    findings: [passFinding],
+    attestedAt: NOW,
+    schemaVersion: '1',
+  };
+  const rejection: ValidatorRejection = {
+    verdict: 'reject',
+    taskId: 'T10510',
+    validatorId: 'validator-prime',
+    findings: [failFinding],
+    summary: 'fail',
+    rejectedAt: NOW,
+    schemaVersion: '1',
+  };
+
+  it('schema accepts both attest and reject envelopes', () => {
+    expect(validatorVerdictSchema.safeParse(attestation).success).toBe(true);
+    expect(validatorVerdictSchema.safeParse(rejection).success).toBe(true);
+  });
+
+  it('schema rejects envelope with unknown verdict', () => {
+    const bad = { ...attestation, verdict: 'maybe' };
+    expect(validatorVerdictSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('discriminant narrows in TypeScript at compile time', () => {
+    const handle = (v: ValidatorVerdict): string => {
+      if (v.verdict === 'attest') {
+        // TS narrows to ValidatorAttestation here
+        return `attested ${v.attestedAt}`;
+      }
+      // TS narrows to ValidatorRejection here
+      return `rejected ${v.rejectedAt} — ${v.summary}`;
+    };
+    expect(handle(attestation)).toContain('attested');
+    expect(handle(rejection)).toContain('rejected');
+  });
+});
+
+// ============================================================================
+// Type guards
+// ============================================================================
+
+describe('Validator type guards (T10510)', () => {
+  const attestation: ValidatorAttestation = {
+    verdict: 'attest',
+    taskId: 'T10510',
+    validatorId: 'validator-prime',
+    findings: [passFinding],
+    attestedAt: NOW,
+    schemaVersion: '1',
+  };
+  const rejection: ValidatorRejection = {
+    verdict: 'reject',
+    taskId: 'T10510',
+    validatorId: 'validator-prime',
+    findings: [failFinding],
+    summary: 'fail',
+    rejectedAt: NOW,
+    schemaVersion: '1',
+  };
+
+  it('isValidatorAttestation returns true only for attestations', () => {
+    expect(isValidatorAttestation(attestation)).toBe(true);
+    expect(isValidatorAttestation(rejection)).toBe(false);
+    expect(isValidatorAttestation(null)).toBe(false);
+    expect(isValidatorAttestation({})).toBe(false);
+  });
+
+  it('isValidatorRejection returns true only for rejections', () => {
+    expect(isValidatorRejection(rejection)).toBe(true);
+    expect(isValidatorRejection(attestation)).toBe(false);
+    expect(isValidatorRejection(null)).toBe(false);
+  });
+
+  it('isValidatorVerdict returns true for both shapes', () => {
+    expect(isValidatorVerdict(attestation)).toBe(true);
+    expect(isValidatorVerdict(rejection)).toBe(true);
+    expect(isValidatorVerdict({ verdict: 'attest' })).toBe(false);
+    expect(isValidatorVerdict(null)).toBe(false);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2004,6 +2004,31 @@ export type {
   Transport,
   TransportConnectConfig,
 } from './transport.js';
+// === Validator Role Contracts (T10510 / Saga T10377 SG-IVTR-AC-BINDING) ===
+// Canonical AgentRole enum + per-AC ValidatorFinding + ValidatorAttestation /
+// ValidatorRejection envelopes + ValidatorVerdict discriminated union. Consumed
+// by SDK tools (T10511) and the Max-N runtime (T10512) under Epic T10383
+// E-VALIDATOR-ROLE.
+export type {
+  AgentRole,
+  ValidatorAttestation,
+  ValidatorFinding,
+  ValidatorFindingStatus,
+  ValidatorRejection,
+  ValidatorVerdict,
+} from './validator/index.js';
+export {
+  AGENT_ROLES,
+  isAgentRole,
+  isValidatorAttestation,
+  isValidatorRejection,
+  isValidatorVerdict,
+  VALIDATOR_ID_REGEX,
+  validatorAttestationSchema,
+  validatorFindingSchema,
+  validatorRejectionSchema,
+  validatorVerdictSchema,
+} from './validator/index.js';
 // === WarpChain Types ===
 export type {
   ChainShape,

--- a/packages/contracts/src/validator/index.ts
+++ b/packages/contracts/src/validator/index.ts
@@ -1,0 +1,385 @@
+/**
+ * Validator role contracts — types consumed by the SDK tools (T10511) and the
+ * Max-N runtime (T10512) to express the verdict a Validator agent returns
+ * after reviewing a Worker submission against a task's acceptance criteria.
+ *
+ * The Validator is a NEW canonical role in the orchestration hierarchy,
+ * orthogonal to the existing Orchestrator → Lead → Worker triad. A Validator
+ * does NOT execute work and does NOT spawn other agents — it ONLY attests or
+ * rejects work claimed-done by another agent, per-AC.
+ *
+ * Identity triad:
+ *  - `agentId` follows the pattern `validator-<discriminator>` (e.g.
+ *    `validator-prime`, `validator-sec-001`).
+ *  - `role` is `'validator'` (see {@link AgentRole}).
+ *  - `sigilCard` is reused as-is from the existing peer/memory layer when
+ *    the Validator is registered as a CANT-defined persona.
+ *
+ * Design constraints (ADR-055 / D028 boundary rules):
+ *  - Lives in `packages/contracts/` — ZERO runtime dependencies (Zod only).
+ *  - Consumed by `packages/cleo-sdk-tools/` (T10511) and `packages/core/` (T10512).
+ *  - No cross-package relative imports.
+ *
+ * @module validator
+ * @task T10510
+ * @epic T10383 (E-VALIDATOR-ROLE)
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// AgentRole — canonical role enum with Validator extension
+// ============================================================================
+
+/**
+ * Canonical agent role classification across the CLEO orchestration hierarchy.
+ *
+ * Mirrors the three-tier model in {@link PeerKind} / {@link AgentSpawnCapability}
+ * with an additional `validator` tier introduced by Saga T10377
+ * SG-IVTR-AC-BINDING:
+ *
+ *  - `orchestrator` — coordinates multi-agent workflows; may spawn leads and workers
+ *  - `lead`         — specialist; dispatches workers only
+ *  - `worker`       — terminal executor; may not spawn
+ *  - `validator`    — terminal reviewer; attests or rejects another agent's
+ *                     work against the task's acceptance criteria. Does NOT
+ *                     execute work and does NOT spawn other agents.
+ *
+ * This type is ADDITIVE to the existing per-file role unions
+ * (`PeerKind` in `peer.ts`, `AgentSpawnCapability` in `agent-registry-v3.ts`,
+ * `CLEO_AGENT_ROLE` in `branch-lock.ts`, etc.). Existing unions are
+ * intentionally UNCHANGED — call sites that need the Validator role
+ * import {@link AgentRole} from this module.
+ *
+ * @task T10510
+ * @epic T10383
+ */
+export type AgentRole = 'orchestrator' | 'lead' | 'worker' | 'validator';
+
+/**
+ * Frozen list of canonical {@link AgentRole} values for runtime iteration
+ * (e.g. CLI flag validation, registry seeding).
+ *
+ * @task T10510
+ * @epic T10383
+ */
+export const AGENT_ROLES = ['orchestrator', 'lead', 'worker', 'validator'] as const;
+
+/**
+ * Type guard for {@link AgentRole}. Returns `true` when `value` is one of the
+ * four canonical role strings.
+ *
+ * @task T10510
+ */
+export function isAgentRole(value: unknown): value is AgentRole {
+  return typeof value === 'string' && (AGENT_ROLES as readonly string[]).includes(value);
+}
+
+// ============================================================================
+// ValidatorFinding — per-AC reasoning row
+// ============================================================================
+
+/**
+ * Status of a single Validator finding against one acceptance criterion.
+ *
+ *  - `pass`         — the AC is satisfied by the Worker's submission
+ *  - `fail`         — the AC is NOT satisfied; the Validator rejects this AC
+ *  - `inconclusive` — the Validator cannot determine pass/fail from the
+ *                     evidence presented (e.g. missing artifact, ambiguous
+ *                     wording). A Verdict containing any `inconclusive`
+ *                     finding is treated as a {@link ValidatorRejection} —
+ *                     the Worker MUST clarify and re-submit.
+ *
+ * @task T10510
+ */
+export type ValidatorFindingStatus = 'pass' | 'fail' | 'inconclusive';
+
+/**
+ * Single Validator finding scoped to one acceptance criterion.
+ *
+ * Produced per-AC during validator review and aggregated into either a
+ * {@link ValidatorAttestation} (all pass) or {@link ValidatorRejection}
+ * (any fail or inconclusive). Each finding carries the AC's stable UUID
+ * (matching `task_acceptance_criteria.id` — see {@link AcRow}) so downstream
+ * persistence (T10503 / T10509 AC-bindings) can join findings to ACs
+ * without depending on ordinal position.
+ *
+ * @task T10510
+ * @epic T10383
+ */
+export interface ValidatorFinding {
+  /**
+   * Stable AC identifier (UUIDv4) matching
+   * `task_acceptance_criteria.id`. See {@link AcRow.id}.
+   */
+  acId: string;
+  /** Pass / fail / inconclusive verdict for this AC. */
+  status: ValidatorFindingStatus;
+  /**
+   * Free-text reasoning explaining the verdict. Required for `fail` and
+   * `inconclusive`; recommended (but optional via the runtime guard) for
+   * `pass` so reviewers can audit the chain-of-thought later.
+   */
+  reasoning: string;
+  /**
+   * Optional evidence references that backed this finding — e.g. test
+   * file paths, commit shas, doc URLs. Free-form strings; the schema
+   * intentionally does NOT validate format here so the SDK tools layer
+   * (T10511) can shape its own evidence-atom narrowing.
+   */
+  evidenceRefs?: string[];
+  /** ISO-8601 timestamp at which this finding was recorded. */
+  checkedAt: string;
+}
+
+// ============================================================================
+// ValidatorAttestation — accept verdict envelope
+// ============================================================================
+
+/**
+ * Envelope returned by a Validator when the Worker's submission passes
+ * EVERY acceptance criterion on the task.
+ *
+ * Discriminated by `verdict: 'attest'`. When at least one finding has
+ * status `'fail'` or `'inconclusive'`, the Validator MUST emit a
+ * {@link ValidatorRejection} instead — never a partial-pass attestation.
+ *
+ * @task T10510
+ * @epic T10383
+ */
+export interface ValidatorAttestation {
+  /** Discriminant — always `'attest'`. */
+  verdict: 'attest';
+  /** Task being attested. Matches `tasks.id`. */
+  taskId: string;
+  /**
+   * Stable Validator agent identifier following the pattern
+   * `validator-<discriminator>` (e.g. `validator-prime`).
+   */
+  validatorId: string;
+  /**
+   * Per-AC findings. MUST contain one entry per AC on the task; EVERY
+   * entry MUST have `status: 'pass'`. The runtime validator
+   * ({@link isValidatorAttestation}) enforces this invariant.
+   */
+  findings: ValidatorFinding[];
+  /**
+   * Optional summary paragraph the Validator may include to capture
+   * holistic observations (e.g. "all 5 ACs pass; the implementation
+   * also tightened the error message in foo.ts which I checked").
+   */
+  summary?: string;
+  /** ISO-8601 timestamp at which the verdict was finalized. */
+  attestedAt: string;
+  /**
+   * Schema version for forward-compatible evolution. Pin to `'1'` for
+   * the initial T10510 contract.
+   */
+  schemaVersion: '1';
+}
+
+// ============================================================================
+// ValidatorRejection — refuse verdict envelope
+// ============================================================================
+
+/**
+ * Envelope returned by a Validator when at least one acceptance criterion
+ * fails or is inconclusive.
+ *
+ * Discriminated by `verdict: 'reject'`. The `findings` array MUST contain
+ * AT LEAST ONE entry with status `'fail'` or `'inconclusive'`; otherwise
+ * the Validator should have emitted a {@link ValidatorAttestation}.
+ *
+ * @task T10510
+ * @epic T10383
+ */
+export interface ValidatorRejection {
+  /** Discriminant — always `'reject'`. */
+  verdict: 'reject';
+  /** Task being rejected. Matches `tasks.id`. */
+  taskId: string;
+  /**
+   * Stable Validator agent identifier following the pattern
+   * `validator-<discriminator>` (e.g. `validator-prime`).
+   */
+  validatorId: string;
+  /**
+   * Per-AC findings. MUST contain one entry per AC on the task; AT
+   * LEAST ONE entry MUST have `status: 'fail'` or `'inconclusive'`.
+   */
+  findings: ValidatorFinding[];
+  /**
+   * Required summary paragraph describing the high-level reason for
+   * rejection. Distinct from per-AC `reasoning` — this is the
+   * human-facing message shown when the Worker is told to revise.
+   */
+  summary: string;
+  /**
+   * Suggested remediation steps. Free-form list of strings — the SDK
+   * tools layer (T10511) is responsible for any structured shape.
+   */
+  remediationHints?: string[];
+  /** ISO-8601 timestamp at which the verdict was finalized. */
+  rejectedAt: string;
+  /**
+   * Schema version for forward-compatible evolution. Pin to `'1'` for
+   * the initial T10510 contract.
+   */
+  schemaVersion: '1';
+}
+
+// ============================================================================
+// ValidatorVerdict — discriminated union
+// ============================================================================
+
+/**
+ * Discriminated union over the two Validator outcomes. Narrow via the
+ * `verdict` discriminant:
+ *
+ * ```ts
+ * function handle(v: ValidatorVerdict) {
+ *   if (v.verdict === 'attest') {
+ *     // v is ValidatorAttestation — every finding passes
+ *   } else {
+ *     // v is ValidatorRejection — summary + remediationHints available
+ *   }
+ * }
+ * ```
+ *
+ * @task T10510
+ * @epic T10383
+ */
+export type ValidatorVerdict = ValidatorAttestation | ValidatorRejection;
+
+// ============================================================================
+// Zod schemas — runtime validation
+// ============================================================================
+
+/**
+ * Regex validating the canonical Validator agentId pattern
+ * `validator-<discriminator>`. The discriminator is `[a-z0-9][a-z0-9-]*`
+ * (lowercase alphanumeric + hyphens, must start with alphanum).
+ *
+ * Examples that MATCH: `validator-prime`, `validator-sec-001`, `validator-a`.
+ * Examples that DO NOT match: `validator-`, `Validator-prime`, `validator--x`.
+ *
+ * @task T10510
+ */
+export const VALIDATOR_ID_REGEX = /^validator-[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Zod schema for {@link ValidatorFinding}. Enforces the AC-id presence,
+ * status enum, non-empty reasoning, and ISO-8601 timestamp shape.
+ *
+ * @task T10510
+ */
+export const validatorFindingSchema = z.object({
+  acId: z.string().min(1, 'acId must be non-empty'),
+  status: z.enum(['pass', 'fail', 'inconclusive']),
+  reasoning: z.string().min(1, 'reasoning must be non-empty'),
+  evidenceRefs: z.array(z.string()).optional(),
+  checkedAt: z.string().min(1, 'checkedAt must be a non-empty ISO-8601 string'),
+});
+
+/**
+ * Zod schema for {@link ValidatorAttestation}. Enforces:
+ *  - `verdict === 'attest'`
+ *  - `validatorId` matches {@link VALIDATOR_ID_REGEX}
+ *  - `findings` non-empty AND every entry has `status === 'pass'`
+ *  - `schemaVersion === '1'`
+ *
+ * @task T10510
+ */
+export const validatorAttestationSchema = z.object({
+  verdict: z.literal('attest'),
+  taskId: z.string().min(1),
+  validatorId: z
+    .string()
+    .regex(VALIDATOR_ID_REGEX, 'validatorId must match the pattern validator-<discriminator>'),
+  findings: z
+    .array(validatorFindingSchema)
+    .min(1, 'attestation must contain at least one finding')
+    .refine(
+      (findings) => findings.every((f) => f.status === 'pass'),
+      'attestation requires every finding to have status="pass"',
+    ),
+  summary: z.string().optional(),
+  attestedAt: z.string().min(1),
+  schemaVersion: z.literal('1'),
+});
+
+/**
+ * Zod schema for {@link ValidatorRejection}. Enforces:
+ *  - `verdict === 'reject'`
+ *  - `validatorId` matches {@link VALIDATOR_ID_REGEX}
+ *  - `findings` non-empty AND at least one entry has `status !== 'pass'`
+ *  - `summary` non-empty (rejection rationale is mandatory)
+ *  - `schemaVersion === '1'`
+ *
+ * @task T10510
+ */
+export const validatorRejectionSchema = z.object({
+  verdict: z.literal('reject'),
+  taskId: z.string().min(1),
+  validatorId: z
+    .string()
+    .regex(VALIDATOR_ID_REGEX, 'validatorId must match the pattern validator-<discriminator>'),
+  findings: z
+    .array(validatorFindingSchema)
+    .min(1, 'rejection must contain at least one finding')
+    .refine(
+      (findings) => findings.some((f) => f.status !== 'pass'),
+      'rejection requires at least one finding with status "fail" or "inconclusive"',
+    ),
+  summary: z.string().min(1, 'rejection summary must be non-empty'),
+  remediationHints: z.array(z.string()).optional(),
+  rejectedAt: z.string().min(1),
+  schemaVersion: z.literal('1'),
+});
+
+/**
+ * Zod schema for the {@link ValidatorVerdict} discriminated union.
+ * Routes parsing through the `verdict` discriminant.
+ *
+ * @task T10510
+ */
+export const validatorVerdictSchema = z.discriminatedUnion('verdict', [
+  validatorAttestationSchema,
+  validatorRejectionSchema,
+]);
+
+// ============================================================================
+// Type guards
+// ============================================================================
+
+/**
+ * Type guard validating that `value` conforms to {@link ValidatorAttestation}.
+ * Internally uses {@link validatorAttestationSchema}.
+ *
+ * @task T10510
+ */
+export function isValidatorAttestation(value: unknown): value is ValidatorAttestation {
+  return validatorAttestationSchema.safeParse(value).success;
+}
+
+/**
+ * Type guard validating that `value` conforms to {@link ValidatorRejection}.
+ * Internally uses {@link validatorRejectionSchema}.
+ *
+ * @task T10510
+ */
+export function isValidatorRejection(value: unknown): value is ValidatorRejection {
+  return validatorRejectionSchema.safeParse(value).success;
+}
+
+/**
+ * Type guard validating that `value` conforms to {@link ValidatorVerdict}
+ * (either an attestation or a rejection). Internally uses
+ * {@link validatorVerdictSchema}.
+ *
+ * @task T10510
+ */
+export function isValidatorVerdict(value: unknown): value is ValidatorVerdict {
+  return validatorVerdictSchema.safeParse(value).success;
+}


### PR DESCRIPTION
## Summary

Adds the `validator` role to `@cleocode/contracts` — the foundation that T10511 (SDK tools) and T10512 (Max-N runtime) consume to express the verdict a Validator agent returns after reviewing a Worker submission against a task's acceptance criteria.

## What's new

New contracts under `packages/contracts/src/validator/`:

- **`AgentRole`** — canonical 4-value enum (`orchestrator` | `lead` | `worker` | `validator`); **ADDITIVE** — existing per-file role unions (`PeerKind`, `AgentSpawnCapability`, `CLEO_AGENT_ROLE`, …) are UNCHANGED.
- **`ValidatorFinding`** — per-AC verdict row with `acId`, `status` (`pass` | `fail` | `inconclusive`), `reasoning`, optional `evidenceRefs`, `checkedAt`.
- **`ValidatorAttestation`** — accept envelope (`verdict: 'attest'`); Zod schema enforces every finding has `status: 'pass'`.
- **`ValidatorRejection`** — refuse envelope (`verdict: 'reject'`); Zod schema enforces at least one finding has `status !== 'pass'` AND `summary` is non-empty.
- **`ValidatorVerdict`** — discriminated union over the two outcomes via `verdict` discriminant.
- **Identity triad**: `VALIDATOR_ID_REGEX` (`^validator-[a-z0-9][a-z0-9-]*$`), `isAgentRole`, plus three envelope guards (`isValidatorAttestation`, `isValidatorRejection`, `isValidatorVerdict`).

All types + schemas + guards are re-exported from the contracts barrel at `packages/contracts/src/index.ts`.

## Test plan

- [x] 34 new vitest cases in `packages/contracts/src/__tests__/validator-types.test.ts` cover enum membership, regex acceptance, schema invariants (attestation can't contain fails; rejection can't be all-pass; rejection requires summary; wrong discriminant / schemaVersion rejected), and discriminated-union narrowing.
- [x] Full `@cleocode/contracts` test suite: **643/643 passing**.
- [x] `pnpm run build` clean across the workspace (TS strict mode).
- [x] `pnpm biome check` clean.
- [x] `node scripts/lint-contracts-fan-out.mjs` clean (additive types don't affect existing fan-out).
- [x] `node scripts/lint-changesets.mjs` clean (167/167 entries validated).
- [x] `node scripts/lint-no-direct-db-open.mjs` clean.
- [x] `node scripts/lint-no-raw-define-command.mjs` clean.

## Constraints met

- Contracts package stays leaf — depends only on `zod` (already present).
- ADDITIVE only — no existing role unions modified.
- ZERO runtime cross-package imports.

Closes T10510. Saga: **T10377 SG-IVTR-AC-BINDING**. Epic: **T10383 E-VALIDATOR-ROLE**. Decision: **D013**.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>