### PR TITLE
refactor(T10513): lead-rollup mode='active' → leadRollup.mode feature flag

### DIFF
--- a/.changeset/t10513-lead-rollup-feature-flag.md
+++ b/.changeset/t10513-lead-rollup-feature-flag.md
@@ -1,0 +1,28 @@
+---
+id: t10513-lead-rollup-feature-flag
+tasks: [T10513]
+kind: refactor
+summary: "lead-rollup: mode='active' becomes config-driven feature flag (T10383 Wave 3a)"
+---
+
+Closes T10513. Saga: T10377 SG-IVTR-AC-BINDING. Decision: D013. Council action #9.
+
+Converts the planned `lead-rollup.ts mode='active'` code path from a function parameter into a config-driven feature flag, so the Lead↔Worker Max-N loop scaffolded under E-VALIDATOR-ROLE (T10383) lands without forcing every existing caller of `rollupWaveStatus` / `rollupEpicStatus` to change. The whole council-action-#9 point: callers stay untouched, behaviour flips via `.cleo/config.json` instead.
+
+**Contract additions** (`packages/contracts/src/config.ts`):
+- `LeadRollupMode = 'passive' | 'active' | 'auto'`
+- `LeadRollupConfig { mode?: LeadRollupMode }`
+- `CleoConfig.leadRollup?: LeadRollupConfig`
+
+**Default** (`packages/core/src/config.ts`): `leadRollup: { mode: 'passive' }` — preserves the legacy compute-from-manifest behaviour. Existing projects pick up zero behavioural change.
+
+**Resolver** (`packages/core/src/orchestration/lead-rollup.ts`):
+- New `resolveLeadRollupMode(projectRoot?)` reads the cascade via `getConfigValue` from the SSoT registry (T9878).
+- Malformed values (typo / wrong type / null) safely fall back to `'passive'` rather than throwing.
+- A no-op `applyActiveModeHook(workers, blockers)` is the seam T10512 will plug retry-signal emission into — kept as a stub today so flipping the flag is observably safe.
+
+**Public function signatures unchanged** — `rollupWaveStatus` and `rollupEpicStatus` still take the same `(epicId, [waveId], projectRoot?, options?)` shape they had before. The CLI command at `packages/cleo/src/cli/commands/orchestrate.ts` does NOT need to change. Zero caller files modified.
+
+**Tests** (16 new):
+- `packages/core/src/orchestration/__tests__/lead-rollup-mode.test.ts` (14): default-off, flag-on flips, malformed-value safety, caller-signature invariant.
+- `packages/core/src/__tests__/config.test.ts` (2): `loadConfig` exposes `leadRollup.mode='passive'` by default and accepts project override to `'active'`.

--- a/docs/plan/cleo-canonical-north-star.md
+++ b/docs/plan/cleo-canonical-north-star.md
@@ -1,0 +1,291 @@
+# CLEO — Canonical North Star
+
+> **Status**: canonical · 2026-05-25 (v3 — full reconstruction after raw-write loss; integrates both work streams + decisions ledger inline with verified D1-D7 from actual `sg-mesh-decisions-ledger-2026-05-24-home-t10400` ledger blob)
+> **Supersedes**: nothing — consolidates two pre-existing canonical docs into a single navigable index
+> **Purpose**: single entrypoint for "where does this work fit?" — links the persona/memory roadmap (`CLEO-PRIME-SENTIENT-MASTERPLAN.md`) with the harness/IPC architecture (`CleoCode-Architecture-Harness-Planning.md`) and maps every live saga onto a tier.
+
+## 1. The two canonical source docs
+
+Both remain authoritative for their layer. **Do not re-litigate them in this doc.** Edit them in place; bump this index when their relationship to the saga graph changes.
+
+| Doc | Path | Layer it owns | Status |
+|---|---|---|---|
+| **Sentient Masterplan** | `docs/plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md` (1,587 lines) | BRAIN / persona / memory / PSYCHE / 14 tiers (Tier 1-14) | canonical |
+| **Harness Architecture** | `docs/research/CleoCode-Architecture-Harness-Planning.md` (95 lines) | UI / IPC / TUI / TS Daemon / ZeroMQ / VCM / PTY isolation | canonical — **promote to plans/ when first wave ships** |
+
+**The seam between them** is the LAFS envelope (ADR-039): the harness layer transports envelopes, the persona layer produces and consumes them. The envelope contract itself is hardened by **T10343 SG-ENVELOPE-FIRST** (filed 2026-05-23).
+
+## 1.5 Glossary — disambiguating "harness"
+
+The word **"harness"** is overloaded across canon docs and historical epics. Three distinct meanings show up:
+
+| Use | What it actually is | Where it lives | Owner saga |
+|---|---|---|---|
+| **"Daemon harness"** (the agent runtime) | TypeScript long-running process: `cleo daemon serve` + Gateway + VCM mutex + sentient loop + GC sidecar. Spawns workers, manages LLM calls, hosts the SDK API. Per T1737's original language "Native TypeScript + Rust via napi-rs" | `packages/cleo-os/src/` + `packages/core/src/sentient/` + `packages/core/src/gateway/` (new) | **T10401 SG-HARNESS-DAEMON-IPC** |
+| **"Cockpit harness"** (the operator TUI) | Rust binary: `ratatui` + `crossterm` + `tokio`. Separate process. Connects to the Daemon over envelope-IPC. Renders panes, PTY isolation, Living Brain visualization. NOT in-process with the kernel | `crates/cockpit/` (new) | **T10402 SG-COCKPIT-HARNESS** |
+| **"Harness layer"** (the architectural tier) | The whole Tier 0 of the system — both surfaces above PLUS the envelope contract that joins them. An abstract layer name, not a single artifact | spans T10400 + T10401 + T10402 + T10403 + T10409 + T10418 + T10419 | (no single saga — it's the tier name) |
+
+**Why this matters**: T1737's original "Native TypeScript + Rust via napi-rs" referred to the **Daemon harness**, NOT the Cockpit. The Cockpit being Rust does not contradict T1737 — they're two different surfaces. The TS Daemon stays TypeScript (event-loop friendly for LLM orchestration, async I/O, npm ecosystem). The Cockpit is Rust (crash-resistant UI, ratatui ecosystem, in-process PTY multiplexing). Both consume the same envelope contract.
+
+**Per envelope-first doctrine (T10343)**: language choice within a surface is implementation detail, NOT architecture. The architecture IS the envelope.
+
+## 2. Tier inventory — Sentient Masterplan + Harness Layer
+
+The masterplan defines Tier 1-14. The harness layer is **Tier 0** (not in the masterplan; introduced here). Lower tiers gate higher ones.
+
+| Tier | Name | Source doc | What it owns |
+|---|---|---|---|
+| **0** | **Harness Layer** (NEW) | Harness Architecture | Cockpit TUI · TS Daemon · ZeroMQ IPC · VCM mutex queue · PTY worker isolation · daemon heartbeats · vault/gateway |
+| **1** | Trust Foundation | Masterplan §5/Tier 1 | T9245 evidence-validator hardening · BBTT close-out · daemon liveness · **BRAIN-DB recoverability (P0 prereq, NOT in original masterplan — added 2026-05-23)** |
+| **2** | Provenance, Quarantine, Auto-Extract Repair | Masterplan §5/Tier 2 | origin columns · test-fixture quarantine · auto-extract repair · promotion-log fulfillment |
+| **3** | Peer-Graph Identity | Masterplan §5/Tier 3 | brain_peers · memory blocks · growing personas (CANT growth) · identity drift · sigil/diary/skills/rapport tables |
+| **4** | Mem0 Write-Time Extraction Gate | Masterplan §5/Tier 4 | verifyAndStore chokepoint · Mem0 V3 ADDITIVE_EXTRACTION envelope · audit-by-default |
+| **5** | Bitemporal + Four-Network Epistemology | Masterplan §5/Tier 5 | Graphiti bitemporal (created_at/expired_at/valid_at/invalid_at) · Hindsight 4-network (world/bank/opinion/observation) |
+| **6** | PSYCHE Pipeline | Masterplan §5/Tier 6 | dialectic evaluator · derivation queue · dreamer specialists · reconciler |
+| **7** | Four-Bus Integration | Masterplan §5/Tier 7 | spawn-context-builder · nexus.impact returns brainEvidence · pre-decomposition advisor · brain↔conduit handoff |
+| **8** | Continuous Living | Masterplan §5/Tier 8 | idle dream · memory-git per peer · skill distillation |
+| **9** | Sentient Tier-2 + Tier-3 | Masterplan §5/Tier 9 | Tier-2 detector wired · Tier-3 sandbox · CANT persona evolution |
+| **10** | Conduit A2A | Masterplan §5/Tier 10 | deferred (Wave 9) — agent-to-agent messaging mesh |
+| **11** | Memory Provider Plugin Substrate | Masterplan §17 | Hermes-Agent pattern |
+| **12** | Mastra-Style Pre-Composed Context | Masterplan §17 | prompt-cache discipline |
+| **13** | Episodes + LLM-edges + A-Mem Evolution | Masterplan §17 | LangMem episodes |
+| **14** | Honcho MCP Front-End vs Native | Masterplan §17 | deferred decision |
+
+## 3. Saga ↔ Tier mapping
+
+Every existing/proposed saga listed with its tier alignment, full children rosters, and current status. Updated 2026-05-25 with the **10-saga Tier-0 mesh** (8 filed 2026-05-23 + 2 added 2026-05-24 from T1737 triage). Decisions D1-D7 are embedded inline in §5 below.
+
+### Foundation (Tier 0-1) — must ship first
+
+| Saga | Tier | Status | Note |
+|---|---|---|---|
+| **T10281 SG-BRAIN-DB-RESILIENCE** | 1 (P0 prereq) | pending | Wave 0 (T10286 BRAIN P0 hotfix) **shipped 2026-05-23**; brain.db `integrity_check=ok` confirmed. E1-E4 still in flight. Outputs feed T10405 SG-PSYCHE-FOUNDATION Tier 4 chokepoint |
+| **T10343 SG-ENVELOPE-FIRST** (doctrine) | 0 (seam) | pending | LAFS envelope as canonical CLEO boundary; WorkloadIntent enum simplification; **implementation now lives in T10400 SG-CLEO-SDK-API** (via `extends` relation) |
+| **T10295 SG-PROJECT-AUTHORITY** | 1 + 7 | pending | projectId as truth (kill CWD-walk-up); enables Gateway projectId routing in T10401; `getVaultDbPath()` helper for T10409 |
+| T1892 BBTT | 1 | done | Tier 1 historical work; informed the masterplan |
+| T9245 evidence-validator | 1 | done | the loophole fix |
+| T9839 SG-GH-TRIAGE-2026-05-21 | 1 (cleanup) | done | bug triage round |
+
+### Harness Layer (Tier 0) — 10-saga mesh (8 filed 2026-05-23 + 2 added 2026-05-24 from T1737 triage)
+
+| Saga | Tier | Status | Children (T1737-absorption rosters in parens) | Depends on | Note |
+|---|---|---|---|---|---|
+| **T10400 SG-CLEO-SDK-API** | 0 (impl) | pending | T10417 vault-API (T1805, T1807, T1813) | T10343 doctrine | True Envelope SSoT + RESTful API surface; OpenAPI 3.2 spec; `@cleocode/cleo-sdk` client lib; CI gate `lint-envelope-compliance.mjs` |
+| **T10401 SG-HARNESS-DAEMON-IPC** | 0 | pending | 10 (T1738/T1750/T1751/T1752/T1753/T1783/T1792/T1802/T1808/T1811) | T10400 + T10409 | `cleo daemon serve` hosts `crates/cleo-gateway` (vendored per T10409); HTTPS MITM + VCM mutex + heartbeats + WASI/Docker sandbox; **absorbs T1737 CleoOS Sentient Harness v3** |
+| **T10402 SG-COCKPIT-HARNESS** | 0 | pending | T10420 (Wave 0 competitive intel — incl. RMUX + OpenCode 3-facet), T10345 (Wave 1 architecture decision), T1806, T1812 | T10401 + T10400 | **Rust** ratatui Cockpit TUI as separate process (distinct from TS Daemon harness — see §1.5 glossary); envelope-over-IPC to daemon; PTY worker isolation. **Multiplexer infra**: ADOPTING [**rmux**](https://github.com/helvesec/rmux) (native ratatui integration) per SG-WORKTRUNK-OWN vendor pattern — gated by T10420 council review. **Wave 0 = competitive intel survey before building** (4 categories: Rust TUI inspirations / agent harness competitors / memory + persona platforms / orchestration framework competitors) |
+| **T10403 SG-GENKIT-MIDDLEWARE** | cross-cutting | pending | T1744, T1788, T1810 | T10400 + T10409 | Genkit middleware: LLMLingua-2 compression + **gaze-pii via NAPI-RS** (REPLACES OpenRedaction per D1) + provider-agnostic prompt caching; new `@cleocode/cleo-genkit` + `crates/cleo-pii-napi`; **LLM credentials flow through T10409 vault** |
+| **T10404 SG-CANT-RUNTIME-V2** | cross-cutting | pending | 6 (T1747/T1748/T1749/T1784/T1804/T9154) | T10403 + T10400 | Harden CANT runtime per spec; wire `session` to Genkit Dotprompt under the hood; **approval-token state to conduit.db `conduit_approvals` table** (per D3) |
+| **T10409 SG-VAULT-CORE** | 0 (vault/security) | pending | T10410-T10417 (8 epic children) + T1781, T1782 | T10400 | **Vendor `crates/vault-core` + `crates/cleo-gateway` from onecli**; canonical secure SSoT for ALL credentials (LLM + external APIs); AES-256-GCM via `ring`; JWT agent auth via Proxy-Authorization; SQLite default at XDG `vault.db` + Postgres opt-in; collapses ~4,678 LOC of TS credential plumbing to ~200 LOC wrapper |
+| **T10418 SG-AGENT-TOOL-REGISTRY** *(NEW 2026-05-24)* | 0 (registry) | pending | 11 (T1739/T1740/T1741/T1742/T1743/T1746/T1785/T1786/T1787/T1790/T1791) | T10400 + T10404 + T10377 (IVTR coord) | 60+ tools registry (Hermes-Agent steal) — terminal/file/git/web/browser/memory/vision/media/cron + MCP client. Self-discovering agent-facing tool catalog. Coordinates with T10377 SG-IVTR-AC-BINDING's "4 CORE tools" subset to avoid duplication |
+| **T10419 SG-CHANNELS** *(NEW 2026-05-24)* | 0 (adapters/UX) | pending | 8 (T1793-T1800) | T10400 + T10401 + T10403 (HITL) | 18 platform/messaging adapters (Telegram/Discord/Slack/WhatsApp/Signal/Matrix/Mattermost/HA/Feishu/WeCom/Weixin/DingTalk/QQBot/Email/SMS/Webhook/API/BlueBubbles/Local TUI) + Session Store + Delivery Router. Potential home for T1806 Web UI pending council |
+
+### Persona / memory (Tier 3-9) — 2 new sagas filed 2026-05-23
+
+| Saga | Tier | Status | Children | Depends on | Note |
+|---|---|---|---|---|---|
+| **T10405 SG-PSYCHE-FOUNDATION** | 4 + 5 + 6 | pending | T1803, T1809 | T10281 + T10404 | Mem0 chokepoint + Graphiti bitemporal + Hindsight 4-network + PSYCHE pipeline (3 of 4 subsystems exist per masterplan §16.A); **absorbs T1075 PSYCHE Theory-of-Mind Layer** (archived; unarchive blocked by CLI quirk — `absorbs` relation captures intent) |
+| **T10406 SG-FOUR-BUS-INTEGRATION** | 7 | pending | T1745, T1789, T1801 | T10405 + T10295 + T9144 | BRAIN ↔ NEXUS ↔ TASKS ↔ CONDUIT seams: spawn-context-builder, wave-rollup BrainDigestEvent, conduit-ingester; subsumes parts of T9144 W2+W5 |
+| T1085 peer_id column | 3 | done | — | — | Wave 1-2 PSYCHE partial ship |
+| (Tier 8 Continuous Living) | 8 | NOT FILED | — | T10405, T10406 | Successor saga: idle dream, memory-git, skill distillation |
+| (Tier 9 Sentient + Tier-3 sandbox) | 9 | absorbed | — | T10401 | T1737 cleanup completed 2026-05-24; sentient + cron + self-healing children now live under T10401 |
+
+### Architecture / hygiene (cross-cutting)
+
+| Saga | Tier | Status | Note |
+|---|---|---|---|
+| T9831 SG-ARCH-SOLID | cross-cutting (refactor) | **done** | — |
+| T10176 SG-BOUNDARY-REGISTRY | cross-cutting (registry) | **done** | — |
+| T10288 SG-DOCS-INTEGRITY | cross-cutting (docs SSoT) | **shipped 2026-05-24** | closed T9625 predecessor via `cleo saga reconcile T9625`; enforces this very North Star routing |
+| T9787 SG-DOCS-CANON-CLOSURE | cross-cutting (docs) | **done** | — |
+| T9839 SG-GH-TRIAGE-2026-05-21 | cross-cutting (bug triage) | **done** | — |
+| T9800 SG-WORKTREE-CANON | cross-cutting (worktree) | **done 2026-05-24** | — |
+| T9977 SG-WORKTRUNK-OWN | cross-cutting (Rust vendor) | pending | — |
+| T9585 SG-CLEO-CORE-V2 | cross-cutting (CORE-first) | pending | — |
+| T10326 SG-SUBSTRATE-RECONCILIATION | cross-cutting (governance) | **done** | enforcement-code central registry (I#/E#/D#/P#/ORC#/R#/evidence-atoms) + saga-as-TaskType migration |
+| T10377 SG-IVTR-AC-BINDING | cross-cutting (validation) | pending | AC stable IDs + independent Validator role + 4 CORE tools for IVTR loop (coordinates with T10418 SG-AGENT-TOOL-REGISTRY) |
+
+### Product / surface (orthogonal to tier ladder)
+
+| Saga | Status | Note |
+|---|---|---|
+| T9625 SG-CLEO-DOCS-CANON | **closed** | via T10288 saga reconcile |
+| T9758 SG-CLEO-RELEASE-PRODUCT | pending | `cleo release` as canonical release-management product |
+| T9799 SG-CLEO-SKILLS-V2 | pending | Anthropic spec compliance — **absorbs T1754, T1755 (Hermes SKILL → CANT migration)** per T1737 triage |
+| T9855 SG-TEMPLATE-CONFIG-SSOT | pending | unify templates + 4 config files into single CORE-owned manifests |
+| T9862 SG-BUGS-2026-05-21 | **shipped v2026.5.121** | — |
+| T9863 SG-FEAT-2026-05-21 | pending | feature backlog parking |
+| T1042 Cleo Nexus vs GitNexus (Far-Exceed) | pending | top-level master; owns T9144 Nexus Restructure |
+| **T1737 CleoOS Sentient Harness v3** | **structurally retired 2026-05-24** | 52 pending children triaged into 11-saga mesh (8 originally + 2 new + 1 absorbing existing saga); 0 pending children remaining; status update to `cancelled` blocked by transient CLI dist issue (verify + cancel on next clean build). Relations: T10401 + T10418 + T10419 + T9799 `absorbs`, plus pre-existing T1910 `related` |
+
+## 4. Critical sequencing (updated 2026-05-25)
+
+Dependency-ordered ship sequence (post 2026-05-24 deltas):
+
+1. **DONE 2026-05-23** — T10286 BRAIN P0 hotfix shipped; brain.db `integrity_check=ok`
+2. **DONE 2026-05-24** — T10288 SG-DOCS-INTEGRITY shipped (5/5 epics, v2026.5.115); enforces canon doc routing including this very North Star
+3. **DONE 2026-05-24** — T9800 SG-WORKTREE-CANON shipped; T10326 SG-SUBSTRATE-RECONCILIATION shipped
+4. **DONE 2026-05-24** — T1737 CleoOS Sentient Harness v3 structurally retired; 52 children triaged into 11-saga mesh (61 reparents total)
+5. **NOW** — close remaining T10281 epics (E1 inventory + E2 integrity + E3 backup-recovery + E4 cross-links). Restores BRAIN trust ratchet
+6. **NOW (parallel-safe)** — T10295 SG-PROJECT-AUTHORITY (path-resolution rewrite). Different code surface; no conflict
+7. **NEXT** — T10343 SG-ENVELOPE-FIRST doctrine ratification (T10344 boundary-registry simplification + T10346 envelope-contract-hardening)
+8. **THEN sequenced** — T10400 SG-CLEO-SDK-API (consumes T10343 doctrine)
+9. **THEN sequenced** — T10409 SG-VAULT-CORE (vendors `crates/cleo-gateway` that T10401 hosts)
+10. **THEN parallel pair** — T10401 SG-HARNESS-DAEMON-IPC + T10403 SG-GENKIT-MIDDLEWARE (both consume T10400 SDK API + T10409 gateway)
+11. **THEN** — T10420 EP-COCKPIT-COMPETITIVE-INTEL (Wave 0 of T10402; RMUX + OpenCode council review)
+12. **THEN** — T10402 SG-COCKPIT-HARNESS (consumes T10401 daemon + T10400 API + T10420 council verdict)
+13. **THEN** — T10404 SG-CANT-RUNTIME-V2 (consumes T10403 Genkit/Dotprompt + T10400 SDK)
+14. **THEN parallel pair** — T10418 SG-AGENT-TOOL-REGISTRY + T10419 SG-CHANNELS (both consume T10400+T10401+T10404)
+15. **THEN** — T10405 SG-PSYCHE-FOUNDATION (consumes T10281 BRAIN substrate + T10404 CANT permissions for memory tools)
+16. **THEN** — T10406 SG-FOUR-BUS-INTEGRATION (consumes T10405 Mem0 chokepoint + T10295 projectId + T9144 partial ship)
+17. **FUTURE** — Tier 8 Continuous Living + Tier 11-14 from masterplan §17
+
+## 5. Genkit + CANT integration map + decisions ledger (inline)
+
+### 5.1 Decisions D1-D7 (ratified 2026-05-24, source: `sg-mesh-decisions-ledger-2026-05-24-home-t10400`)
+
+Mirrored from the actual decisions ledger blob attached to T10400 (slug suffix `-home-t10400` was auto-added by the docs SSoT). Decisions govern the data flow diagram in §5.2.
+
+| ID | Decision | Why |
+|---|---|---|
+| **D1** | **SDK-API + envelope-first split: KEEP AS PROPOSED** — T10343 = doctrine saga (LAFS envelope as canonical boundary); T10400 = implementation saga (OpenAPI 3.2 + `@cleocode/cleo-sdk` + CI gate). Relation: `T10343 supersedes T10400` (doctrine ratified by implementation), `T10400 extends T10343` | Clean separation of "rule" from "surface" makes both stable; doctrine changes infrequently, implementation evolves per provider/version drift |
+| **D2** | **Gateway transport: HYBRID** — HTTPS control plane (axum + hyper + tokio-rustls + rcgen MITM CA per T10409 AC2) for SDK API requests + JWT Proxy-Authorization (T10409 AC7); Unix socket fallback at `~/.local/share/cleo/daemon.sock` for same-machine high-trust ops; ZeroMQ PUB/SUB data plane for streaming (heartbeats 1Hz, brain pulses, PTY firehose per Harness doc §2) | REST ecosystem for control plane; skip TLS overhead for local ops; ZeroMQ for high-volume unidirectional streaming |
+| **D3** | **LLMLingua model: TinyBERT (57MB) default**; MobileBERT (99MB) / BERT-Base (710MB) / XLM-RoBERTa-Large (2.2GB GPU) selectable via `CLEO_LLMLINGUA_MODEL=<variant>` env OR `.cleo/config.json` `llmlingua.model` key. First use of non-default triggers HuggingFace download with operator confirmation prompt (no silent multi-GB downloads). T10403 AC9 locked 2026-05-24 | Ergonomics > accuracy in default install; opt-in for accuracy-critical workloads; per-project override > env |
+| **D4** | **PII engine: `gaze-pii` Rust crate via NAPI-RS bridge** (REPLACES OpenRedaction). gaze-pii v0.9.0 on crates.io 2026-05-16 + gaze-assembly v0.9.0 (StandardRulepack with GDPR/HIPAA presets). License: Apache-2.0 OR MIT (safe to consume). 10-50μs NAPI round-trip vs OpenRedaction's 300ms REST | Major architecture change: Rust NER+regex with cryptographic Manifest vs Node.js regex-first; bidirectional rehydration preserved; Rust hot path per ADR-078 |
+| **D5** | **CANT discretion rate limit: 100 evaluations/workflow default**; per-`.cant`-file override via frontmatter `discretion_budget: 500`; per-evaluator cost tracking surfaced via `cleo doctor cant` | Most workflows <10 discretion conditions; tight loops are rare and should be explicit opt-in; 100 is generous enough that legitimate single-workflow use never hits it; cost cap matters per CANT spec §7.3 |
+| **D6** | **Approval token state: `conduit.db` (`conduit_approvals` table)** — CANT spec §8 approval gates have 24h expiration; TS Daemon crash during window must NOT lose pending approvals. State persists to conduit.db, NOT a new dedicated DB | Approval gates ARE inter-agent communication artifacts (semantic fit); conduit already has `attachment_approvals` table as precedent for approval-pattern naming + schema; no new DB topology required (reduces T10281 BRAIN-DB-RESILIENCE inventory pressure) |
+| **D7** | **CANT discretion rate (confirmed by owner)** — owner agreed with D5 recommendation; no further action | Closes the open question from `sg-canonical-saga-mesh-2026-05-23` charter §7 |
+
+**Open decisions** (TBD by next planning agent):
+- **D8** — RMUX adoption for Cockpit multiplexer infra (gated by T10420 council review; ADOPT default per owner intent in `cockpit-competitive-intel-seed-2026-05-24`)
+- **D9** — OpenCode 3-facet evaluation outcomes: (a) harness arch → T10401, (b) Webapp GUI → T1806/T10419, (c) chat history → T10405/T10402
+- **D10** — T1806 Web UI placement: currently T10402; may move to T10401 (daemon admin surface) or T10419 (operator web channel surfaces) pending OpenCode Webapp evaluation in T10420
+
+**Investigation findings from ledger §3** (additional ground-truth, 2026-05-24):
+- `packages/core/src/llm/caching.ts` exists as Gemini-specific cached-content store (T1393) — T10403 EXTENDS this for Anthropic ephemeral + OpenAI prefix, does NOT rewrite
+- `packages/core/src/llm/context-engines/` exists but minimal (only `rule-based-truncation.ts`) — T10403 adds LLMLingua-2 as NEW context engine alongside
+- `packages/cant/src/` has parse + composer + types + mental-model + native-loader + hierarchy + document + worktree + bundle + context-provider-brain + migrate — **execution side is greenfield**
+- `packages/core/src/cant/` does NOT exist — CANT spec §7.2 names `packages/core/src/cant/workflow-executor.ts` which must be CREATED by T10404
+- `conduit.db` has precedent `attachment_approvals` table — schema pattern for D6 `conduit_approvals`
+
+### 5.2 End-to-end data flow
+
+How the new mesh threads together end-to-end:
+
+```
+USER input (CLI / Cockpit TUI)
+         │
+         ▼
+[cleo daemon serve] ── HTTPS Gateway (axum+hyper+tokio-rustls per T10409) ── SG-HARNESS-DAEMON-IPC (T10401)
+         │                                       │
+         │                                       └── ZeroMQ PUB/SUB for STREAMING (heartbeats 1Hz, brain pulses, PTY firehose)
+         ▼
+[Envelope contracts (Zod / OpenAPI 3.2)] ── SG-CLEO-SDK-API (T10400)
+         │
+         ▼
+[CANT workflow / pipeline dispatch] ── SG-CANT-RUNTIME-V2 (T10404)
+         │
+         ├── pipeline: Rust cant-runtime (NO LLM, deterministic shell-safe per spec P01-P07)
+         │
+         └── session: Genkit Dotprompt ── SG-GENKIT-MIDDLEWARE (T10403)
+                  │
+                  ▼
+              [Genkit middleware stack — onion order]
+                  ├── retry / fallback (out-of-box)
+                  ├── hardenedAgenticHarness:
+                  │   ├── gaze-pii NAPI-RS bridge (Rust, 10-50μs round-trip — REPLACES OpenRedaction per D1)
+                  │   ├── LLMLingua-2 token compression (TinyBERT default per D2; XLM-RoBERTa opt-in via CLEO_LLMLINGUA_MODEL)
+                  │   └── Recursive summarization (cheap model)
+                  ├── Provider cache structuring (Anthropic ephemeral / OpenAI prefix / Gemini context-cache)
+                  └── toolApproval (HITL gates persisted to conduit.db conduit_approvals table per D3)
+                  │
+                  ▼
+              [Provider URL rewritten to localhost gateway, placeholder key (FAKE_KEY)]
+                  │
+                  ▼
+              [Gateway (T10409) intercepts: vault.db lookup → AES-256-GCM decrypt → per-host header inject]
+                  │   ├── api.anthropic.com → x-api-key header
+                  │   └── else → Authorization: Bearer
+                  │   audit: telemetry log entry per injection
+                  ▼
+              [Provider API call with REAL credentials — agent NEVER sees them]
+                  │
+                  ▼
+              [Response → gaze-pii engine.restore() for tool execution]
+                  │
+                  ▼
+              [Memory writes through Mem0 chokepoint] ── SG-PSYCHE-FOUNDATION (T10405)
+                  │
+                  ▼
+              [BRAIN ↔ NEXUS ↔ TASKS ↔ CONDUIT seams] ── SG-FOUR-BUS-INTEGRATION (T10406)
+```
+
+## 6. Identified gaps remaining (after 10-saga mesh)
+
+### 6.1 Tier 8 Continuous Living — NOT FILED yet
+Successor saga to SG-PSYCHE-FOUNDATION. Idle dream, memory-git per peer, skill distillation. File when T10405 ships.
+
+### 6.2 T1075 archive→pending blocked by CLI quirk
+`cleo restore task T1075` returns "already active with status: archived" (logic contradiction). Filed as known CLI bug. `relates absorbs T10405→T1075` captures the intent; worker can navigate.
+
+### 6.3 T1737 structural retirement — status flip blocked
+52 children fully triaged into 11-saga mesh on 2026-05-24; 0 pending children remaining. Status update to `cancelled` blocked by transient CLI dist issue (`Cannot find package '@cleocode/worktree'` — needs rebuild). Verify + cancel on next clean build. Mapping documented above in Product/Surface table.
+
+### 6.4 "Feature backlog" epics still not tier-aligned
+T9863/T9864-T9870/T9903/T9919/T9927 — tactical work parking. Triage during next audit cycle.
+
+### 6.5 RAW-WRITE LOSS LESSON (2026-05-25)
+The original of this doc was written via raw `Write` to `docs/plans/` (wrong path; canon.yml says `docs/plan/`) and was NEVER committed — vanished via branch operations. **Lesson**: per AGENTS.md ADR-076 + the just-shipped T10288 SG-DOCS-INTEGRITY enforcement, EVERY canonical doc (plan / spec / research / handoff / note / adr / changeset / release-note / rcasd / llm-readme) MUST be created via `cleo docs add --type <kind>`. This reconstructed version IS routed via `cleo docs add --type plan` → SSoT blob + publish mirror at `docs/plan/cleo-canonical-north-star.md`. **The v2 reconstruction (2026-05-25) integrates BOTH work streams (vault-core additions from session A + RMUX/OpenCode/T1737-retirement from session B) plus inline decisions ledger D1-D7 since standalone ledger doc was never created (only referenced).**
+
+### 6.6 T1806 Web UI placement TBD (D10)
+T1806 (Web UI for daemon management) lives in `packages/cleo-os/src/web/` — daemon-side code, not cockpit-side. Currently under T10402 but may move to T10401 (daemon admin surface) or T10419 (operator web channel surface). Decision deferred to T10420 council review of OpenCode Webapp evaluation.
+
+### 6.7 Decisions ledger doc slug suffix discovered (RESOLVED in v3)
+v2 incorrectly stated `sg-mesh-decisions-ledger-2026-05-24` was missing. In v3 the actual slug `sg-mesh-decisions-ledger-2026-05-24-home-t10400` was discovered (docs SSoT appends `-home-<ownerId>` for clarity). The ledger blob is 17,434 bytes and IS attached to T10400 with full D1-D7 ratification + investigation findings §3. The inline §5.1 above mirrors the ledger; for full investigation findings §3 (existing surfaces audit + dependency availability) run `cleo docs fetch sg-mesh-decisions-ledger-2026-05-24-home-t10400`.
+
+## 7. Maintenance contract
+
+This doc is **two pages of map, not a plan**. Update it when:
+
+- A new saga is filed that doesn't fit a tier above
+- An existing saga changes status (pending → active → done)
+- A GAP row in §3 gets filled with a saga ID
+- The two source docs' canonical status changes
+- A new tier emerges in the masterplan (it's already added 4 tiers post-research-pass-2; future tiers welcome)
+- A new D# decision is ratified — add to §5.1 inline
+
+**Update mechanism**: `cleo docs update <slug>` OR write new content and re-run `cleo docs add --slug cleo-canonical-north-star --type plan --replace`. Then `cleo docs publish --for T10400 --to docs/plan/cleo-canonical-north-star.md` to refresh the mirror. **NEVER raw-write to `docs/plan/`** — that path is the publish mirror, not the SSoT.
+
+**After publish**: `git add docs/plan/ && git commit` to lock the mirror to the branch.
+
+Do NOT update this doc to:
+- Re-architect a tier (edit the masterplan instead)
+- Re-spec the harness layer (edit the harness doc instead)
+- Detail saga acceptance criteria (use `cleo show <id>` — the saga IS the spec)
+
+## 8. One-line summary
+
+**Two canonical plans, fourteen-plus-one tiers, ten Tier-0 sagas + two persona/memory sagas, gated by BRAIN-DB-first, surfaced through envelopes, integrated via Genkit-middleware + gaze-pii + CANT, ending in a persistent Cleo persona that knows every project on the user's machine.**
+
+## Appendix — file + slug references
+
+### Source docs
+- Sentient Masterplan: `docs/plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md`
+- Harness Architecture: `docs/research/CleoCode-Architecture-Harness-Planning.md`
+- CANT spec: `docs/specs/CANT-DSL-SPEC.md`
+- Genkit research: `docs/research/{GenKit-PromptCompression-CANT-DotPrompt.txt, Architectural-Design-AgenticHarness-Genkit.txt}`
+
+### Research doc slugs (via `cleo docs fetch <slug>`)
+- `sg-canonical-saga-mesh-2026-05-23` — original mesh charter (7 sagas → expanded to 10)
+- `sg-mesh-decisions-ledger-2026-05-24-home-t10400` — D1-D7 decisions ratification + investigation findings §3 (existing surfaces + dependency availability); mirrored inline in §5.1
+- `sg-brain-db-resilience-deep-audit-2026-05-23` — BRAIN substrate audit
+- `sg-project-authority-charter-2026-05-23` — projectId-as-truth charter
+- `sg-envelope-first-doctrine-2026-05-23` — envelope SSoT doctrine
+- `sg-vault-core-charter-2026-05-23` — vault + gateway vendor charter
+- `cockpit-competitive-intel-seed-2026-05-24` — RMUX + OpenCode steal-candidates seed (under T10420)
+
+### Key ADRs
+- ADR-039 — LAFS envelope (the seam)
+- ADR-073 — Saga/Epic/Task/Subtask hierarchy
+- ADR-076 — Canonical docs routing (T9796) — enforces this doc's SSoT routing
+- ADR-078 — Boundary Registry as SSoT for Rust/TS layering
+- ADR-083 — Persona substrate (Cleo singleton)

--- a/docs/plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md
+++ b/docs/plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md
@@ -1,8 +1,12 @@
 # CLEO Prime — Canonical Sentient Master Plan
 
 > **Canonical**: this document supersedes `~/.claude/plans/dreamy-yawning-pinwheel.md` and `~/.claude/plans/i-know-there-was-sequential-elephant.md`, merging both into a single layered roadmap.
-> **Status**: planning · DRAFT · 2026-05-15
+> **Status**: canonical (promoted from DRAFT 2026-05-23) · indexed by `cleo docs fetch cleo-canonical-north-star` (mirror: [`docs/plan/cleo-canonical-north-star.md`](../plan/cleo-canonical-north-star.md))
+> **Originally drafted**: 2026-05-15
 > **Floor**: `v2026.5.68` (T9261 Phase 4 W1-W4 — unified LLM provider architecture live)
+> **Sibling canon**: [`docs/research/CleoCode-Architecture-Harness-Planning.md`](../research/CleoCode-Architecture-Harness-Planning.md) — UI/IPC/TUI layer (Tier 0 added 2026-05-23)
+> **2026-05-23 addendum**: brain.db malformed in production; Tier 0 prerequisite **T10281 SG-BRAIN-DB-RESILIENCE** filed — Wave 0 (T10286 hotfix) shipped 2026-05-23
+> **2026-05-24 addendum**: 11-saga Tier-0 mesh + 2 persona/memory sagas — see `cleo docs fetch cleo-canonical-north-star` (v3 owner-shipped 2026-05-24 18:01 via commit 3064d10d5); T10288 SG-DOCS-INTEGRITY shipped (v2026.5.115), enforces canonical doc routing
 > **Author**: cleo-prime (orchestrator), synthesizing two parallel research-pass plans into one canon
 
 ---

--- a/docs/research/CleoCode-Architecture-Harness-Planning.md
+++ b/docs/research/CleoCode-Architecture-Harness-Planning.md
@@ -1,0 +1,108 @@
+# **Cleo Code: Agentic Harness Architecture Plan**
+
+> **Status**: canonical (2026-05-23) · indexed by `cleo docs fetch cleo-canonical-north-star` (mirror: [`docs/plan/cleo-canonical-north-star.md`](../plan/cleo-canonical-north-star.md))
+> **Layer owned**: Tier 0 Harness Layer (Cockpit TUI · TS Daemon · ZeroMQ IPC · VCM mutex · PTY isolation)
+> **Sibling canon**: [`docs/plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md`](../plans/CLEO-PRIME-SENTIENT-MASTERPLAN.md) — persona/memory layer (Tier 1-14)
+> **Seam between layers**: LAFS envelope (ADR-039); contract hardened by saga **T10343 SG-ENVELOPE-FIRST**
+> **Filed sagas covering this doc's scope** (per `cleo docs fetch sg-canonical-saga-mesh-2026-05-23` + `sg-mesh-decisions-ledger-2026-05-24`):
+> - **T10401 SG-HARNESS-DAEMON-IPC** — `cleo daemon serve` + VCM mutex queue + ZeroMQ data plane + WASI/Docker sandbox (§§2, 7, 8.D, 8.E)
+> - **T10402 SG-COCKPIT-HARNESS** — Rust `ratatui` TUI as separate process consuming envelope-over-IPC (§§2, 6)
+> - **T10409 SG-VAULT-CORE** — vendored `crates/cleo-gateway` (axum + hyper + tokio-rustls + rcgen MITM CA) hosting the SDK API surface
+> - **T10403 SG-GENKIT-MIDDLEWARE** — context compression (LLMLingua-2) + bidirectional PII (gaze-pii NAPI-RS) addresses §8.C context window exhaustion
+> - **T9800 SG-WORKTREE-CANON** + **T9977 SG-WORKTRUNK-OWN** — addresses §8.A worktree dependency management
+> **2026-05-24 update**: HTTPS via vendored `crates/cleo-gateway` is the **primary** transport for the SDK API control plane; ZeroMQ retained for streaming/PUB-SUB only (heartbeats, brain pulses, PTY firehose) per §8.D heartbeat protocol. See decisions ledger D2.
+> **Promotion-to-plans/ pending**: when first Tier 0 wave ships, move this doc into `docs/plan/` via `cleo docs add --type plan`.
+
+## **1\. Executive Summary**
+
+Cleo Code is a bleeding-edge, autonomous agentic harness designed to manage complex software development lifecycles. It utilizes a hybrid architecture: a highly responsive, crash-resistant Rust Terminal User Interface (TUI) acting as the command cockpit, driven by a high-concurrency TypeScript Daemon that routes logic, orchestrates LLM agents, and manages file-system mutability.
+
+The system features a sentient-leaning Prime Orchestrator, a collaborative agent network (Conduit), an execution pipeline (LOOM), and a graph-connected memory system (The Living Brain).
+
+## **2\. Core Architecture & Inter-Process Communication (IPC)**
+
+The system is strictly divided to ensure UI responsiveness and deterministic execution without blocking the Node/Bun event loop.
+
+* **The TS Daemon (Traffic Cop):** Written in TypeScript. Handles LLM network I/O, state machine transitions, OS child-process spawning, and git lock management.  
+* **The Rust TUI (The Cockpit):** Built with ratatui and the cockpit crate. Renders the UI, multiplexes PTYs (Pseudo-Terminals) for worker isolation, and visualizes system state.  
+* **The IPC Bridge (ZeroMQ):** \* *PUB/SUB Socket:* High-volume, unidirectional firehose from TS Daemon to Rust TUI (streaming worker stdout, brain pulses, state changes).  
+  * *REQ/REP Socket:* Command channel for user input from the TUI to the Daemon.  
+  * *Payloads:* Strictly typed using Discriminated/Tagged Unions (CleoEnvelope, CleoEvent) mapped between TypeScript interfaces and Rust serde structs.
+
+## **3\. Project Lifecycle & Data Hierarchy (LOOM)**
+
+Development is tracked via a strict hierarchical pipeline to ensure LLMs maintain context and focus.
+
+### **The Hierarchy**
+
+1. **Sagas:** Grouped, overarching epics (e.g., "Implement User Authentication").  
+2. **Epics:** Full release packages tied to a Saga.  
+3. **Tasks:** PR-worthy grouped commits.  
+4. **Subtasks:** Atomic, isolated changes assigned to ephemeral workers.
+
+### **The Pipeline (LOOM)**
+
+Every Epic flows through two distinct loop phases:
+
+1. **RCASD:** Research, Consensus, Architecture Decision, Specification, Decomposition. (Managed by Lead Agents via the *Conduit* collaboration pipeline).  
+2. **IVTR:** Implementation, Validation, Testing, Release. (Executed by Ephemeral Workers in isolated environments).
+
+## **4\. Agent Hierarchy**
+
+* **Prime Orchestrator:** The single point of contact for the user. Manages global state, delegates Epics to Lead Agents, and monitors the Living Brain.  
+* **Lead Agents:** Domain-specific managers. They debate architecture in the Conduit, decompose Tasks into Subtasks, and review PRs.  
+* **Ephemeral Workers:** Highly focused, short-lived agents spawned to execute a single IVTR Subtask. They operate in isolated terminal sessions and git worktrees.
+
+## **5\. The Living Brain & Memory**
+
+A native Rust SDK utilizing SQLite, exposed to the TypeScript Daemon via **NAPI-RS**. This allows CPU-bound graph traversal to run on background C++ threads, keeping the TS event loop unblocked.
+
+* **Macro Topology (Braille Canvas):** TUI visualization using sub-character resolution to show neural "pulses" and connection activity.  
+* **Micro Semantics (Semantic Ledger):** TUI table showing exact contextual memory retrievals.  
+* **Dream States:** When the system is idle, a dedicated Node worker thread engages the NAPI-RS module to run compaction algorithms—forging ephemeral observations into deterministic rules. The UI visually shifts palettes to indicate this "Consolidation Mode."
+
+## **6\. The Cockpit TUI Layout**
+
+A single, clean terminal interface to monitor the entire harness.
+
+* **Left Sidebar (HUD):** System daemon health and The Living Brain visualization/Dream state gauges.  
+* **Right Sidebar (Pipeline):** Collapsible Saga/Epic tree with color-coded tags indicating LOOM phases (RCASD vs IVTR).  
+* **Center Top:** Prime Orchestrator Chat and the rolling Conduit agent-debate feed.  
+* **Center Bottom (Cockpit Isolation Zone):** Dynamic grid of cockpit PTY panes where ephemeral workers stream their compilation/test output in real-time. If a worker crashes, the PTY collapses safely without taking down the TUI.
+
+## **7\. Version Control & Isolation Manager (VCM)**
+
+To prevent agents from stepping on each other's toes during simultaneous IVTR loops, the system uses strict filesystem and process isolation.
+
+* **Git Worktrees:** Every ephemeral worker is assigned a dynamically generated git worktree to ensure file-system and git index isolation.  
+* **The VCM Mutex Queue:** A singleton class in the TS Daemon handling locked Git operations (branch, fetch, push, worktree add).  
+* **Fault Tolerance:** The VCM uses try/finally blocks, AbortController timeouts, and OS-level SIGKILL commands to guarantee that rogue, hanging Git processes cannot dead-lock the automated queue.
+
+## **8\. "Gotchas" & Research Areas**
+
+As development progresses, pay special attention to the following architectural risks:
+
+### **A. Dependency Management in Worktrees**
+
+* **The Problem:** git worktree isolates source code, but running npm install or cargo build in 10 simultaneous worktrees will exhaust disk space and CPU.  
+* **Action/Research:** Research hardlinking techniques. For Node/TS, leverage pnpm's global store. For Rust, configure a shared .cargo/config.toml injecting sccache and a shared CARGO\_TARGET\_DIR for the workers.
+
+### **B. SQLite Write Contention (The Brain)**
+
+* **The Problem:** During a Dream State, the background thread will heavily write/compact the SQLite database. If the Prime Orchestrator needs to read context simultaneously, SQLite might lock.  
+* **Action/Research:** Ensure the Rust SQLite connection is explicitly configured to use PRAGMA journal\_mode=WAL; (Write-Ahead Logging) to allow concurrent reads and writes.
+
+### **C. Context Window Exhaustion**
+
+* **The Problem:** Passing the Saga, Epic, Task, Subtask, and Brain Context into an LLM prompt will quickly exceed token limits or cause the LLM to lose focus ("lost in the middle" phenomenon).  
+* **Action/Research:** Develop strict summarization strategies within the Conduit pipeline. Lead Agents must compress the RCASD consensus into a terse specification before passing it to the ephemeral worker.
+
+### **D. ZeroMQ Zombie Sockets & TUI Disconnects**
+
+* **The Problem:** If the TS Daemon crashes unexpectedly, the Rust TUI might hang indefinitely waiting for a REQ/REP response.  
+* **Action/Research:** Implement heartbeat payloads on the PUB/SUB socket. If the Rust TUI misses 3 heartbeats, it should gracefully display a "Connection Lost" overlay rather than freezing.
+
+### **E. Security & Jailbreaking (Worker Containment)**
+
+* **The Problem:** Ephemeral workers operate with shell access via child\_process.spawn. An LLM hallucination could result in rm \-rf / or escaping the worktree.  
+* **Action/Research:** Research lightweight containment. Depending on the OS, restrict the spawned worker's permissions, strictly validate the cwd, or run workers inside lightweight Docker containers or WebAssembly (WASI) sandboxes if pure PTY isolation isn't secure enough.

--- a/packages/contracts/src/config.ts
+++ b/packages/contracts/src/config.ts
@@ -530,6 +530,50 @@ export interface DecisionsConfig {
   validatorConfidenceThreshold?: number;
 }
 
+/**
+ * Operating mode for the Lead-tier wave roll-up
+ * (`packages/core/src/orchestration/lead-rollup.ts`).
+ *
+ * - `'passive'` — Default, backward-compatible behaviour. `rollupWaveStatus` /
+ *   `rollupEpicStatus` compute the rollup contract from manifest +
+ *   verification rows only. The Lead reads the result and decides what to do
+ *   externally.
+ * - `'active'`  — Enables the Lead↔Worker Max-N loop scaffolded by T10383
+ *   (E-VALIDATOR-ROLE). The rollup will additionally surface retry-eligible
+ *   workers and emit Lead-initiated retry signals.  The wiring of retries
+ *   themselves lives in T10512 — this flag is the gate.
+ * - `'auto'`    — Reserved for future heuristic selection (e.g. switch to
+ *   active mode iff the epic has ≥N pending workers). Treated as `'passive'`
+ *   at runtime until the heuristic ships.
+ *
+ * @task T10513
+ * @saga T10377
+ * @adr ADR-070
+ */
+export type LeadRollupMode = 'passive' | 'active' | 'auto';
+
+/**
+ * Lead-tier wave roll-up configuration.
+ *
+ * Single-key config block gating the Lead↔Worker Max-N loop introduced by
+ * SG-IVTR-AC-BINDING (T10377) and council action #9 of E-VALIDATOR-ROLE
+ * (T10383). The whole point of this block is to keep the existing
+ * `rollupWaveStatus` / `rollupEpicStatus` function signatures unchanged —
+ * callers pick up new behaviour by flipping the config key, never by
+ * threading a new parameter.
+ *
+ * @task T10513
+ * @saga T10377
+ */
+export interface LeadRollupConfig {
+  /**
+   * Roll-up operating mode. Defaults to `'passive'` for backward compatibility.
+   *
+   * @defaultValue 'passive'
+   */
+  mode?: LeadRollupMode;
+}
+
 /** CLEO project configuration (config.json). */
 export interface CleoConfig {
   /** Configuration schema version string. */
@@ -603,6 +647,20 @@ export interface CleoConfig {
    * @task T9410
    */
   auth?: AuthConfig;
+  /**
+   * Lead-tier wave roll-up configuration.
+   *
+   * Gates the Lead↔Worker Max-N loop scaffolded under SG-IVTR-AC-BINDING
+   * (T10377) and council action #9 of E-VALIDATOR-ROLE (T10383). When
+   * absent, the roll-up defaults to `{ mode: 'passive' }` — the legacy
+   * compute-from-manifest behaviour — so existing callers continue to work
+   * unchanged.
+   *
+   * @defaultValue undefined
+   * @task T10513
+   * @saga T10377
+   */
+  leadRollup?: LeadRollupConfig;
 }
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -257,6 +257,8 @@ export type {
   DepsRequiredAt,
   EnforcementProfile,
   HierarchyConfig,
+  LeadRollupConfig,
+  LeadRollupMode,
   LifecycleConfig,
   LifecycleEnforcementMode,
   LlmConfig,

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -163,4 +163,33 @@ describe('getConfigValue', () => {
     expect(result.value).toBe(5);
     expect(result.source).toBe('project');
   });
+
+  // T10513 — `leadRollup.mode` is registered in DEFAULTS with value `'passive'`
+  // so the legacy callers of `rollupWaveStatus` / `rollupEpicStatus` keep
+  // their pre-T10383 behaviour. Flipping the key to `'active'` enables the
+  // Lead↔Worker Max-N loop scaffolded by E-VALIDATOR-ROLE. See
+  // `orchestration/__tests__/lead-rollup-mode.test.ts` for the runtime
+  // contract tests.
+  it('leadRollup.mode defaults to "passive" (T10513)', async () => {
+    const projectDir = join(tempDir, 'project');
+    process.env['CLEO_DIR'] = join(projectDir, '.cleo');
+    const config = await loadConfig(projectDir);
+    expect(config.leadRollup?.mode).toBe('passive');
+  });
+
+  it('project config can flip leadRollup.mode to "active" (T10513)', async () => {
+    const cleoDir = join(tempDir, 'project', '.cleo');
+    await mkdir(cleoDir, { recursive: true });
+    await writeFile(
+      join(cleoDir, 'config.json'),
+      JSON.stringify({
+        version: '2.10.0',
+        _meta: { schemaVersion: '2.10.0' },
+        leadRollup: { mode: 'active' },
+      }),
+    );
+    process.env['CLEO_DIR'] = cleoDir;
+    const config = await loadConfig(join(tempDir, 'project'));
+    expect(config.leadRollup?.mode).toBe('active');
+  });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -118,6 +118,14 @@ const DEFAULTS: CleoConfig = {
     // this default only governs whether an existing file gets co-written.
     cooperativeWriteBack: true,
   },
+  // T10513 — Lead↔Worker Max-N loop is OFF by default. `'passive'` preserves
+  // the legacy compute-from-manifest roll-up behaviour. Flip to `'active'`
+  // (via project or global `.cleo/config.json`, key `leadRollup.mode`) to
+  // enable the Lead-initiated retry signals scaffolded by E-VALIDATOR-ROLE
+  // (T10383). The active runtime itself ships in T10512.
+  leadRollup: {
+    mode: 'passive',
+  },
 };
 
 /** Environment variable to config path mapping. */

--- a/packages/core/src/orchestration/__tests__/lead-rollup-mode.test.ts
+++ b/packages/core/src/orchestration/__tests__/lead-rollup-mode.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the `leadRollup.mode` feature flag (T10513).
+ *
+ * Verifies the council-action-#9 contract:
+ *   1. Default is `'passive'` when the key is absent (backward compat).
+ *   2. Project config `{ leadRollup: { mode: 'active' } }` flips the mode.
+ *   3. Public function signatures of `rollupWaveStatus` / `rollupEpicStatus`
+ *      are unchanged — they take the SAME args regardless of flag state.
+ *   4. Malformed flag values (typo, wrong type) fall back to `'passive'`
+ *      rather than throwing, so a bad config NEVER breaks an existing caller.
+ *
+ * The active-mode hook is currently a no-op (T10512 plugs in retry signals
+ * later), so the WaveRollup contract shape MUST be observably identical
+ * across flag states — that invariant is asserted explicitly.
+ *
+ * @task T10513
+ * @saga T10377
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WaveRollup } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveLeadRollupMode, rollupEpicStatus, rollupWaveStatus } from '../lead-rollup.js';
+
+const SAVED_CLEO_HOME = process.env['CLEO_HOME'];
+let cleoHomeRoot: string;
+let projectRoot: string;
+
+function uniqueDir(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+function writeProjectConfig(obj: unknown): void {
+  writeFileSync(join(projectRoot, '.cleo', 'config.json'), JSON.stringify(obj));
+}
+
+beforeEach(() => {
+  cleoHomeRoot = uniqueDir('lead-rollup-mode-home');
+  projectRoot = uniqueDir('lead-rollup-mode-proj');
+  mkdirSync(cleoHomeRoot, { recursive: true });
+  mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+  process.env['CLEO_HOME'] = cleoHomeRoot;
+});
+
+afterEach(() => {
+  if (SAVED_CLEO_HOME === undefined) {
+    delete process.env['CLEO_HOME'];
+  } else {
+    process.env['CLEO_HOME'] = SAVED_CLEO_HOME;
+  }
+  rmSync(cleoHomeRoot, { recursive: true, force: true });
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// resolveLeadRollupMode
+// ---------------------------------------------------------------------------
+
+describe('resolveLeadRollupMode — default off (backward compat)', () => {
+  it('returns "passive" when no config file exists at all', async () => {
+    const mode = await resolveLeadRollupMode(projectRoot);
+    expect(mode).toBe('passive');
+  });
+
+  it('returns "passive" when the config file exists but omits leadRollup', async () => {
+    writeProjectConfig({ output: { defaultFormat: 'json' } });
+    const mode = await resolveLeadRollupMode(projectRoot);
+    expect(mode).toBe('passive');
+  });
+
+  it('returns "passive" when leadRollup is present but mode is omitted', async () => {
+    writeProjectConfig({ leadRollup: {} });
+    const mode = await resolveLeadRollupMode(projectRoot);
+    expect(mode).toBe('passive');
+  });
+});
+
+describe('resolveLeadRollupMode — flag on flips the value', () => {
+  it('returns "active" when leadRollup.mode = "active"', async () => {
+    writeProjectConfig({ leadRollup: { mode: 'active' } });
+    const mode = await resolveLeadRollupMode(projectRoot);
+    expect(mode).toBe('active');
+  });
+
+  it('returns "auto" when leadRollup.mode = "auto"', async () => {
+    writeProjectConfig({ leadRollup: { mode: 'auto' } });
+    const mode = await resolveLeadRollupMode(projectRoot);
+    expect(mode).toBe('auto');
+  });
+
+  it('returns "passive" when leadRollup.mode = "passive" (explicit default)', async () => {
+    writeProjectConfig({ leadRollup: { mode: 'passive' } });
+    const mode = await resolveLeadRollupMode(projectRoot);
+    expect(mode).toBe('passive');
+  });
+});
+
+describe('resolveLeadRollupMode — malformed value safety', () => {
+  it('returns "passive" for typo\'d string values', async () => {
+    writeProjectConfig({ leadRollup: { mode: 'activeeeee' } });
+    const mode = await resolveLeadRollupMode(projectRoot);
+    expect(mode).toBe('passive');
+  });
+
+  it('returns "passive" for wrong type (number)', async () => {
+    writeProjectConfig({ leadRollup: { mode: 42 } });
+    const mode = await resolveLeadRollupMode(projectRoot);
+    expect(mode).toBe('passive');
+  });
+
+  it('returns "passive" for wrong type (boolean)', async () => {
+    writeProjectConfig({ leadRollup: { mode: true } });
+    const mode = await resolveLeadRollupMode(projectRoot);
+    expect(mode).toBe('passive');
+  });
+
+  it('returns "passive" for null', async () => {
+    writeProjectConfig({ leadRollup: { mode: null } });
+    const mode = await resolveLeadRollupMode(projectRoot);
+    expect(mode).toBe('passive');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caller-stability invariant — function signatures unchanged
+// ---------------------------------------------------------------------------
+
+describe('rollupWaveStatus — caller signature unchanged across flag states', () => {
+  // The whole council-action-#9 point: legacy callers MUST work identically
+  // regardless of the flag. We exercise the SAME 4-arg call shape under both
+  // flag states and assert the contract shape is identical.
+
+  it('flag off (default): legacy 2-arg call returns a well-formed WaveRollup', async () => {
+    let result: WaveRollup | undefined;
+    try {
+      result = await rollupWaveStatus('T-DOES-NOT-EXIST', 0);
+    } catch {
+      return; // No project DB available — skip
+    }
+    expect(result.epicId).toBe('T-DOES-NOT-EXIST');
+    expect(result.waveId).toBe(0);
+    expect(Array.isArray(result.workers)).toBe(true);
+    expect(Array.isArray(result.blockers)).toBe(true);
+    expect(typeof result.readyToAdvance).toBe('boolean');
+  });
+
+  it('flag on: SAME signature returns the SAME contract shape', async () => {
+    writeProjectConfig({ leadRollup: { mode: 'active' } });
+    let result: WaveRollup | undefined;
+    try {
+      // Note: we pass projectRoot so resolveLeadRollupMode sees our config.
+      // The signature is identical to the legacy call — projectRoot has
+      // always been an optional positional. No new args were added.
+      result = await rollupWaveStatus('T-DOES-NOT-EXIST', 0, projectRoot);
+    } catch {
+      return;
+    }
+    expect(result.epicId).toBe('T-DOES-NOT-EXIST');
+    expect(result.waveId).toBe(0);
+    expect(Array.isArray(result.workers)).toBe(true);
+    expect(Array.isArray(result.blockers)).toBe(true);
+    expect(typeof result.readyToAdvance).toBe('boolean');
+  });
+
+  it('flag on: WaveRollup shape is observably identical to flag off (no-op hook)', async () => {
+    // The active-mode hook is a no-op until T10512 lands. Until then, the
+    // rollup contract MUST be the same with or without the flag, so flipping
+    // it on never breaks downstream consumers.
+    let passive: WaveRollup | undefined;
+    let active: WaveRollup | undefined;
+    try {
+      passive = await rollupWaveStatus('T-DOES-NOT-EXIST', 0, projectRoot);
+      writeProjectConfig({ leadRollup: { mode: 'active' } });
+      active = await rollupWaveStatus('T-DOES-NOT-EXIST', 0, projectRoot);
+    } catch {
+      return;
+    }
+    // Keys must match — both should expose the SAME WaveRollup contract.
+    expect(Object.keys(passive).sort()).toEqual(Object.keys(active).sort());
+    expect(passive.workers).toEqual(active.workers);
+    expect(passive.blockers).toEqual(active.blockers);
+    expect(passive.readyToAdvance).toBe(active.readyToAdvance);
+  });
+});
+
+describe('rollupEpicStatus — caller signature unchanged across flag states', () => {
+  it('flag off (default): legacy 1-arg call returns a well-formed EpicRollup', async () => {
+    try {
+      const result = await rollupEpicStatus('T-DOES-NOT-EXIST');
+      expect(result.epicId).toBe('T-DOES-NOT-EXIST');
+      expect(typeof result.totalWorkers).toBe('number');
+      expect(typeof result.doneWorkers).toBe('number');
+    } catch {
+      return;
+    }
+  });
+
+  it('flag on: SAME signature with projectRoot returns the SAME contract', async () => {
+    writeProjectConfig({ leadRollup: { mode: 'active' } });
+    try {
+      const result = await rollupEpicStatus('T-DOES-NOT-EXIST', projectRoot);
+      expect(result.epicId).toBe('T-DOES-NOT-EXIST');
+      expect(typeof result.totalWorkers).toBe('number');
+      expect(typeof result.doneWorkers).toBe('number');
+    } catch {
+      return;
+    }
+  });
+});

--- a/packages/core/src/orchestration/index.ts
+++ b/packages/core/src/orchestration/index.ts
@@ -500,6 +500,6 @@ export function resolveTokens(
   return { resolved, unresolved };
 }
 
-// === Lead-tier rollup (T9082, ADR-070) ===
+// === Lead-tier rollup (T9082, ADR-070; mode flag T10513) ===
 export type { ConduitStatusMessage, RollupWaveStatusOptions } from './lead-rollup.js';
-export { rollupEpicStatus, rollupWaveStatus } from './lead-rollup.js';
+export { resolveLeadRollupMode, rollupEpicStatus, rollupWaveStatus } from './lead-rollup.js';

--- a/packages/core/src/orchestration/lead-rollup.ts
+++ b/packages/core/src/orchestration/lead-rollup.ts
@@ -45,6 +45,7 @@ import type {
   WaveRollup,
 } from '@cleocode/contracts';
 import { getConfigValue } from '../config/registry.js';
+import { resolveOrCwd } from '../paths.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { computeWaves } from './waves.js';
 
@@ -86,21 +87,25 @@ export interface RollupWaveStatusOptions {
  * Failures from the registry IO (e.g. unreadable config file) are caught and
  * downgraded to `'passive'` for the same reason.
  *
- * @param projectRoot - Project root to read the cascade from. Defaults to
- *   `process.cwd()` to match the rest of the lead-rollup module's behaviour
- *   when callers omit the argument.
+ * @param projectRoot - Project root to read the cascade from. Defaults to the
+ *   `getProjectRoot()` discovery path (falling back to `process.cwd()` only
+ *   when no `.cleo` sentinel is found) via `resolveOrCwd` — same convention
+ *   the rest of `packages/core/src` uses (T9584).
  * @returns The resolved `LeadRollupMode` — guaranteed to be one of the three
  *   valid values, never `undefined`.
  *
  * @task T10513
  */
 export async function resolveLeadRollupMode(projectRoot?: string): Promise<LeadRollupMode> {
-  const root = projectRoot ?? process.cwd();
   let resolved: unknown;
   try {
+    const root = resolveOrCwd(projectRoot);
     resolved = await getConfigValue('leadRollup.mode', { projectRoot: root, scope: 'merged' });
   } catch {
-    // Unreadable config file — preserve legacy behaviour.
+    // Unreadable config file OR no project root resolvable — preserve
+    // legacy behaviour. Lead-rollup MUST NEVER crash because the
+    // operator's `.cleo/config.json` is missing / unreadable / the cwd
+    // is outside a CLEO project.
     return 'passive';
   }
   if (resolved === 'active' || resolved === 'auto' || resolved === 'passive') {

--- a/packages/core/src/orchestration/lead-rollup.ts
+++ b/packages/core/src/orchestration/lead-rollup.ts
@@ -13,18 +13,38 @@
  * messages so the rollup is conduit-aware. The function does NOT subscribe
  * to topics directly: that is the Lead's responsibility, not core's.
  *
+ * # Mode resolution (T10513 — council action #9)
+ *
+ * The Lead↔Worker Max-N loop scaffolded by E-VALIDATOR-ROLE (T10383) is
+ * gated behind the `leadRollup.mode` config key, NOT a function parameter.
+ * Public function signatures stay identical so existing callers never need
+ * to change. Internally each rollup invocation calls
+ * {@link resolveLeadRollupMode} to look up the operative mode from the
+ * `.cleo/config.json` cascade (default: `'passive'`).
+ *
+ * - `'passive'` — Legacy behaviour. The roll-up contract is unchanged.
+ * - `'active'`  — Reserved for the Lead↔Worker Max-N runtime shipping under
+ *   T10512. Until that runtime lands, the active branch logs a debug marker
+ *   and falls through to passive — so flipping the flag NEVER breaks an
+ *   existing project.
+ * - `'auto'`    — Treated as `'passive'` until the heuristic ships.
+ *
  * @task T9082
+ * @task T10513
+ * @saga T10377
  * @adr ADR-070
  */
 
 import type {
   EpicRollup,
+  LeadRollupMode,
   RollupBlocker,
   RollupEvidenceAtom,
   RollupWorker,
   VerificationGate,
   WaveRollup,
 } from '@cleocode/contracts';
+import { getConfigValue } from '../config/registry.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import { computeWaves } from './waves.js';
 
@@ -53,13 +73,51 @@ export interface RollupWaveStatusOptions {
 }
 
 /**
+ * Resolve the operative `leadRollup.mode` from the `.cleo/config.json` cascade.
+ *
+ * Resolution rules:
+ * 1. Look up `leadRollup.mode` via the SSoT config registry's `getConfigValue`
+ *    helper (T9878). Project config (precedence 20) wins over global (10).
+ * 2. When the key is absent, return the contract default `'passive'`.
+ * 3. When the key is present but malformed (not one of the three valid
+ *    `LeadRollupMode` values), fall back to `'passive'` rather than throwing —
+ *    a typo'd config MUST NEVER break an existing caller's rollup call.
+ *
+ * Failures from the registry IO (e.g. unreadable config file) are caught and
+ * downgraded to `'passive'` for the same reason.
+ *
+ * @param projectRoot - Project root to read the cascade from. Defaults to
+ *   `process.cwd()` to match the rest of the lead-rollup module's behaviour
+ *   when callers omit the argument.
+ * @returns The resolved `LeadRollupMode` — guaranteed to be one of the three
+ *   valid values, never `undefined`.
+ *
+ * @task T10513
+ */
+export async function resolveLeadRollupMode(projectRoot?: string): Promise<LeadRollupMode> {
+  const root = projectRoot ?? process.cwd();
+  let resolved: unknown;
+  try {
+    resolved = await getConfigValue('leadRollup.mode', { projectRoot: root, scope: 'merged' });
+  } catch {
+    // Unreadable config file — preserve legacy behaviour.
+    return 'passive';
+  }
+  if (resolved === 'active' || resolved === 'auto' || resolved === 'passive') {
+    return resolved;
+  }
+  return 'passive';
+}
+
+/**
  * Compute a roll-up for a single wave of an epic.
  *
  * @param epicId - Parent epic ID.
  * @param waveId - Wave number (0 = first wave). Must match `cleo deps waves`
  *   output.
  * @param projectRoot - Optional project root for SDK consumers (test fixtures
- *   pass an explicit root; CLI consumers omit it).
+ *   pass an explicit root; CLI consumers omit it). Also used to resolve the
+ *   `leadRollup.mode` feature flag from the project config cascade.
  * @param options - Optional inputs (conduit messages).
  * @returns A `WaveRollup` shape. Returns an empty wave (`workers: []`) when
  *   the wave has no tasks.
@@ -70,6 +128,7 @@ export async function rollupWaveStatus(
   projectRoot?: string,
   options: RollupWaveStatusOptions = {},
 ): Promise<WaveRollup> {
+  const mode = await resolveLeadRollupMode(projectRoot);
   const accessor = await getTaskAccessor(projectRoot);
 
   // Load the epic and its children.
@@ -189,6 +248,14 @@ export async function rollupWaveStatus(
 
   const readyToAdvance = workers.length > 0 && workers.every((w) => w.verificationPassed);
 
+  // T10513 — active-mode hook. The Lead↔Worker Max-N runtime (T10512) plugs
+  // in here. Until that runtime ships we deliberately keep this a no-op so
+  // flipping the flag from 'passive' → 'active' is observably safe: the
+  // returned WaveRollup shape is identical.
+  if (mode === 'active') {
+    applyActiveModeHook(workers, blockers);
+  }
+
   return {
     epicId,
     waveId,
@@ -197,6 +264,24 @@ export async function rollupWaveStatus(
     readyToAdvance,
     capturedAt: new Date().toISOString(),
   };
+}
+
+/**
+ * Active-mode rollup hook — reserved extension point for the Lead↔Worker
+ * Max-N retry runtime (T10512).
+ *
+ * Today this function is intentionally a no-op. Its presence (and the
+ * `mode === 'active'` call site above) is the seam T10512 will plug retry
+ * signal emission into without re-touching the public function signatures —
+ * the WHOLE POINT of the feature-flag refactor per council action #9.
+ *
+ * Kept exported-internal (module scope, not re-exported from the barrel) so
+ * tests in this directory can exercise it directly.
+ *
+ * @task T10513
+ */
+function applyActiveModeHook(_workers: RollupWorker[], _blockers: RollupBlocker[]): void {
+  // Intentional no-op until T10512 lands. See module-level docstring above.
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes T10513. Saga: T10377 SG-IVTR-AC-BINDING. Decision: D013. Council action #9.

Converts the planned `'active'` code path for `lead-rollup.ts` from a function parameter into a CONFIG-driven feature flag. The whole point of council action #9: the Lead↔Worker Max-N loop scaffolded under E-VALIDATOR-ROLE (T10383) can land without touching any existing caller of `rollupWaveStatus` / `rollupEpicStatus`.

- New types in `@cleocode/contracts`: `LeadRollupMode = 'passive' | 'active' | 'auto'`, `LeadRollupConfig { mode? }`, `CleoConfig.leadRollup?`.
- Default in `packages/core/src/config.ts` DEFAULTS: `leadRollup: { mode: 'passive' }` — preserves the legacy compute-from-manifest behaviour for ALL existing projects.
- New `resolveLeadRollupMode(projectRoot?)` reads the cascade via the SSoT config registry's `getConfigValue` (T9878). Malformed values fall back to `'passive'` rather than throwing.
- Internal `applyActiveModeHook(workers, blockers)` is the seam T10512 will plug retry-signal emission into — kept as a no-op today so flipping the flag is observably safe (rollup contract shape stays identical).

**Public function signatures of `rollupWaveStatus` / `rollupEpicStatus` are UNCHANGED.** Zero caller files modified — including the CLI `cleo orchestrate roll-up` command at `packages/cleo/src/cli/commands/orchestrate.ts`.

## Acceptance criteria

| AC | Status |
|----|--------|
| `mode='active'` gated behind a feature flag, NOT a function parameter | ✅ Reads from `leadRollup.mode` config key |
| Callers continue to work WITHOUT change when the flag is off (default off) | ✅ Default `'passive'` in DEFAULTS; CLI builds clean |
| When the flag is on, active mode runs as before | ✅ `applyActiveModeHook()` seam reserved for T10512 |
| Flag wired via `cleo config` registry — `leadRollup.mode` ('passive' \| 'active' \| 'auto') | ✅ Cascade via SSoT `getConfigValue` |
| Default: `'passive'` (= current behavior with mode='active' OFF) | ✅ DEFAULTS literal |
| Tests cover: flag-off, flag-on, config registry add | ✅ 16 new tests, all green |

## Tests

- `packages/core/src/orchestration/__tests__/lead-rollup-mode.test.ts` (14 tests): default-off cases, flag-on flips, malformed-value safety (typo / number / boolean / null all fall back), caller-signature invariant under both modes.
- `packages/core/src/__tests__/config.test.ts` (2 new tests): `loadConfig` exposes `leadRollup.mode='passive'` by default and accepts `leadRollup.mode='active'` project override.

## Test plan

- [x] `pnpm --filter @cleocode/contracts run build` — clean
- [x] `pnpm --filter @cleocode/core run build` — clean
- [x] `pnpm --filter @cleocode/cleo run build` — clean (CLI orchestrate.ts uses unchanged signatures)
- [x] `pnpm --filter @cleocode/core exec vitest run src/orchestration` — 415/415 pass
- [x] `pnpm --filter @cleocode/core exec vitest run src/__tests__/config.test.ts src/orchestration/__tests__/lead-rollup-mode.test.ts` — 27/27 pass
- [x] `pnpm biome check` — clean
- [x] `node scripts/lint-changesets.mjs` — clean