### PR TITLE
feat(T10512): Lead↔Worker Max-N runtime for Validator round-trip

### DIFF
--- a/.changeset/t10512-validator-max-n-runtime.md
+++ b/.changeset/t10512-validator-max-n-runtime.md
@@ -1,0 +1,21 @@
+---
+id: t10512-validator-max-n-runtime
+tasks: [T10512]
+kind: feat
+summary: "runtime: Lead↔Worker Max-N retry loop for Validator round-trip (T10383 Wave 3b)"
+---
+
+Implements `runValidatorMaxN(workerTaskId, deps, opts)` — the Max-N retry runtime that orchestrates the canonical Lead↔Worker↔Validator round-trip defined by the `cleo-validator` SKILL.md (T10495 + T10496). Lives at `packages/core/src/lifecycle/validator/runtime.ts` with a barrel re-export from `packages/core/src/lifecycle/validator/index.ts`.
+
+Key design contracts:
+
+- **Dependency-injected** — the runtime never imports T10511's SDK tools directly. Callers pass `spawnValidator` and `respawnWorker` callbacks via the `ValidatorRuntimeDeps` contract. Tests stub them; production wiring (a follow-up task) supplies real adapters around `spawn.validator`, `validator.attest`, `validator.reject`, and `validator.evidence-run`. The runtime only depends on the verdict envelope types shipped by T10510 (`ValidatorVerdict`).
+- **Shared retry counter** — semantic faults (REJECT) and infra faults (`timeout`, `conduit-drop`, `validator-OOM`) share a single `validatorRetryAttempts` counter bounded by `validatorRetryMax` (default N=3). This prevents adversarial fault-kind alternation from bypassing the cap (VAL-007 in the SKILL.md).
+- **Canonical Max-N row catalogue** — `MAX_N_ROWS` table encodes per-fault retry counts, backoff strategies, and transient/permanent classification per the SKILL.md table. `permanent` rows short-circuit on first occurrence; `transient-then-permanent` (validator-OOM) escalates permanent after the per-row retry budget exhausts.
+- **Backoff strategies** — `immediate`, `exponential(firstMs, secondMs)`, and `immediate-downgrade` (zero delay + advisory `downgradeModelTier` flag on next spawn for context shrinkage).
+- **Append-only JSONL audit** — every retry attempt (semantic or infra) emits one row to `.cleo/audit/validator-retries.jsonl` with `timestamp`, `taskId`, `attemptNumber`, `faultFamily`, `faultKind`, `classification`, `backoffMs`, `retryDecision`, `message`, and optional `detail`. Matches the `force-bypass.jsonl` / `contract-violations.jsonl` convention. Suppressible via `suppressAudit: true` for tests.
+- **Defensive error handling** — thrown errors from `spawnValidator` are normalized to `timeout` infra-fault envelopes so the runtime never propagates unhandled rejections.
+
+20 unit tests cover happy path (attest first try, reject→fix→attest), each infra-fault row (timeout exponential backoff, conduit-drop immediate, validator-OOM downgrade + second-OOM permanent), shared-counter exhaustion via mixed fault kinds, adversarial REJECT↔timeout alternation, per-row counter exhaustion, custom `validatorRetryMax`, audit JSONL append behaviour, `suppressAudit`, Worker re-spawn failures, defensive thrown-error translation, and the discriminated-union result type narrowing.
+
+Saga: T10377 (SG-IVTR-AC-BINDING). Epic: T10383 (E-VALIDATOR-ROLE). Decision: D013.

--- a/packages/core/src/lifecycle/validator/__tests__/runtime.test.ts
+++ b/packages/core/src/lifecycle/validator/__tests__/runtime.test.ts
@@ -1,0 +1,633 @@
+/**
+ * Tests for the Validator Max-N runtime (T10512).
+ *
+ * Coverage matrix (AC6):
+ *   - Happy path: attest first try
+ *   - Happy path: reject → fix → attest
+ *   - Each infra-fault row:
+ *       * timeout (exponential backoff 5s/30s, retryCount=2)
+ *       * conduit-drop (immediate, retryCount=3)
+ *       * validator-OOM (immediate-downgrade, retryCount=1, transient-then-permanent)
+ *   - Counter exhaustion → escalate to Lead (shared cap)
+ *   - Shared-counter adversarial alternation (REJECT → timeout → REJECT → ...)
+ *   - Permanent classification short-circuits
+ *   - Audit JSONL append-only behaviour + suppressAudit
+ *   - Worker respawn failure handling
+ *
+ * @task T10512
+ * @epic T10383
+ * @saga T10377
+ */
+
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  ValidatorAttestation,
+  ValidatorRejection,
+  ValidatorVerdict,
+} from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  resolveBackoffMs,
+  runValidatorMaxN,
+  VALIDATOR_RETRIES_AUDIT_FILE,
+  type ValidatorRoundResult,
+  type ValidatorRuntimeDeps,
+  type ValidatorSpawnRequest,
+} from '../runtime.js';
+
+// ===========================================================================
+// Test fixtures
+// ===========================================================================
+
+const NOW = '2026-05-24T22:00:00.000Z';
+const TASK_ID = 'T1234';
+
+function fixedNow(): string {
+  return NOW;
+}
+
+function noopSleep(): Promise<void> {
+  return Promise.resolve();
+}
+
+function buildAttestation(): ValidatorAttestation {
+  return {
+    verdict: 'attest',
+    taskId: TASK_ID,
+    validatorId: 'validator-prime',
+    findings: [
+      {
+        acId: '11111111-2222-3333-4444-555555555555',
+        status: 'pass',
+        reasoning: 'AC1 passed: tool:test exit 0',
+        checkedAt: NOW,
+      },
+    ],
+    attestedAt: NOW,
+    schemaVersion: '1',
+  };
+}
+
+function buildRejection(summary = 'AC1 failed'): ValidatorRejection {
+  return {
+    verdict: 'reject',
+    taskId: TASK_ID,
+    validatorId: 'validator-prime',
+    findings: [
+      {
+        acId: '11111111-2222-3333-4444-555555555555',
+        status: 'fail',
+        reasoning: 'tool:test exited 1 with 3 test failures',
+        checkedAt: NOW,
+      },
+    ],
+    summary,
+    rejectedAt: NOW,
+    schemaVersion: '1',
+  };
+}
+
+interface ScriptedSpawn {
+  result: ValidatorRoundResult;
+  /** Optional assertion to run against the spawn request when invoked. */
+  expect?: (req: ValidatorSpawnRequest) => void;
+}
+
+function scriptedSpawnValidator(script: ScriptedSpawn[]): ValidatorRuntimeDeps['spawnValidator'] {
+  let i = 0;
+  return async (req) => {
+    const next = script[i++];
+    if (!next) {
+      throw new Error(`scriptedSpawnValidator: ran out of scripted responses (call #${i})`);
+    }
+    if (next.expect) next.expect(req);
+    return next.result;
+  };
+}
+
+function scriptedRespawnWorker(
+  results: Array<{ ok: true } | { ok: false; fault: { kind: 'timeout'; message: string } }>,
+): ValidatorRuntimeDeps['respawnWorker'] {
+  let i = 0;
+  return async () => {
+    const next = results[i++];
+    if (!next) {
+      throw new Error(`scriptedRespawnWorker: ran out of scripted responses (call #${i})`);
+    }
+    return next;
+  };
+}
+
+// ===========================================================================
+// Test setup / teardown
+// ===========================================================================
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'cleo-validator-runtime-'));
+  await mkdir(join(testDir, '.cleo'), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+// ===========================================================================
+// AC1 — Happy path: attest first try
+// ===========================================================================
+
+describe('runValidatorMaxN — happy path', () => {
+  it('AC1: returns attest on first round and writes one audit row', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        { result: { ok: true, verdict: buildAttestation() } },
+      ]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('attest');
+    expect(result.attempts).toHaveLength(1);
+    expect(result.attempts[0]?.retryDecision).toBe('attest');
+    expect(result.attempts[0]?.faultKind).toBeNull();
+
+    // Audit JSONL contains exactly one row.
+    const auditPath = join(testDir, VALIDATOR_RETRIES_AUDIT_FILE);
+    const contents = await readFile(auditPath, 'utf-8');
+    const lines = contents.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]!);
+    expect(parsed.taskId).toBe(TASK_ID);
+    expect(parsed.attemptNumber).toBe(1);
+    expect(parsed.retryDecision).toBe('attest');
+  });
+});
+
+// ===========================================================================
+// AC1 — Happy path: reject → fix → attest
+// ===========================================================================
+
+describe('runValidatorMaxN — reject then attest', () => {
+  it('AC1: re-spawns worker on reject, then attests on second round', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        { result: { ok: true, verdict: buildRejection('AC1 failed initial') } },
+        {
+          result: { ok: true, verdict: buildAttestation() },
+          expect: (req) => {
+            expect(req.attemptNumber).toBe(2);
+          },
+        },
+      ]),
+      respawnWorker: scriptedRespawnWorker([{ ok: true }]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('attest');
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts[0]?.retryDecision).toBe('retry-worker');
+    expect(result.attempts[0]?.faultKind).toBe('validator-partial');
+    expect(result.attempts[1]?.retryDecision).toBe('attest');
+  });
+});
+
+// ===========================================================================
+// AC4 + AC6 — Each infra-fault row
+// ===========================================================================
+
+describe('runValidatorMaxN — timeout row (exponential 5s/30s, retryCount=2)', () => {
+  it('AC4+AC6: retries with exponential backoff 5s then 30s, attests on 3rd attempt', async () => {
+    const sleeps: number[] = [];
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        { result: { ok: false, fault: { kind: 'timeout', message: 'subagent exceeded 300s' } } },
+        { result: { ok: false, fault: { kind: 'timeout', message: 'subagent exceeded 300s' } } },
+        { result: { ok: true, verdict: buildAttestation() } },
+      ]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('attest');
+    expect(sleeps).toEqual([5_000, 30_000]);
+    expect(result.attempts.map((a) => a.retryDecision)).toEqual([
+      'retry-validator',
+      'retry-validator',
+      'attest',
+    ]);
+    expect(result.attempts[0]?.backoffMs).toBe(5_000);
+    expect(result.attempts[1]?.backoffMs).toBe(30_000);
+  });
+});
+
+describe('runValidatorMaxN — conduit-drop row (immediate, retryCount=3)', () => {
+  it('AC4+AC6: zero backoff between retries; classification = transient', async () => {
+    const sleeps: number[] = [];
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        {
+          result: {
+            ok: false,
+            fault: { kind: 'conduit-drop', message: 'verdict lost on transport' },
+          },
+        },
+        {
+          result: {
+            ok: false,
+            fault: { kind: 'conduit-drop', message: 'verdict lost on transport' },
+          },
+        },
+        { result: { ok: true, verdict: buildAttestation() } },
+      ]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('attest');
+    // backoffMs is 0 → sleep never called (runtime skips sleep when backoffMs===0).
+    expect(sleeps).toEqual([]);
+    expect(result.attempts[0]?.backoffMs).toBe(0);
+    expect(result.attempts[1]?.backoffMs).toBe(0);
+    expect(result.attempts[0]?.classification).toBe('transient');
+  });
+});
+
+describe('runValidatorMaxN — validator-OOM row (immediate-downgrade, retryCount=1)', () => {
+  it('AC4+AC6: sets downgradeModelTier on retry; second OOM becomes permanent', async () => {
+    const downgradeFlags: Array<boolean | undefined> = [];
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        {
+          result: { ok: false, fault: { kind: 'validator-OOM', message: 'heap OOM' } },
+          expect: (req) => downgradeFlags.push(req.downgradeModelTier),
+        },
+        {
+          // Second attempt should request a downgrade.
+          result: { ok: false, fault: { kind: 'validator-OOM', message: 'heap OOM again' } },
+          expect: (req) => downgradeFlags.push(req.downgradeModelTier),
+        },
+      ]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    // First spawn: no downgrade. Second spawn: downgrade requested.
+    expect(downgradeFlags[0]).toBeUndefined();
+    expect(downgradeFlags[1]).toBe(true);
+
+    // Second OOM exhausts the per-row retryCount=1 of the
+    // transient-then-permanent row → escalate permanent.
+    expect(result.outcome).toBe('escalate-permanent');
+    if (result.outcome === 'escalate-permanent') {
+      expect(result.fault.kind).toBe('validator-OOM');
+    }
+  });
+});
+
+// ===========================================================================
+// AC3 + AC6 — Shared retry-counter accounting (adversarial alternation)
+// ===========================================================================
+
+describe('runValidatorMaxN — shared counter prevents adversarial alternation', () => {
+  it('AC3+AC6: REJECT → timeout → REJECT exhausts shared counter (N=3) and escalates', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        { result: { ok: true, verdict: buildRejection('round 1 reject') } },
+        { result: { ok: false, fault: { kind: 'timeout', message: 'round 2 timeout' } } },
+        { result: { ok: true, verdict: buildRejection('round 3 reject') } },
+      ]),
+      respawnWorker: scriptedRespawnWorker([{ ok: true }, { ok: true }]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('escalate-hitl');
+    // Shared counter incremented on EVERY fault — semantic + infra share the cap.
+    expect(result.attempts).toHaveLength(3);
+    expect(result.attempts.map((a) => a.faultKind)).toEqual([
+      'validator-partial',
+      'timeout',
+      'validator-partial',
+    ]);
+    expect(result.attempts.at(-1)?.retryDecision).toBe('escalate-hitl');
+  });
+
+  it('AC3+AC6: shared counter exhausts even with mixed transient infra faults', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        { result: { ok: false, fault: { kind: 'timeout', message: 't1' } } },
+        { result: { ok: false, fault: { kind: 'conduit-drop', message: 'c1' } } },
+        { result: { ok: false, fault: { kind: 'timeout', message: 't2' } } },
+      ]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('escalate-hitl');
+    expect(result.attempts).toHaveLength(3);
+    expect(result.attempts.at(-1)?.retryDecision).toBe('escalate-hitl');
+  });
+});
+
+// ===========================================================================
+// AC2 + AC6 — Permanent classification short-circuits
+// ===========================================================================
+
+describe('runValidatorMaxN — permanent classification', () => {
+  it('AC2+AC6: validator-rejected-no-acs short-circuits on first occurrence', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        {
+          result: {
+            ok: false,
+            fault: {
+              kind: 'validator-rejected-no-acs',
+              message: 'task has zero ACs',
+            },
+          },
+        },
+      ]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('escalate-permanent');
+    expect(result.attempts).toHaveLength(1);
+    expect(result.attempts[0]?.retryDecision).toBe('escalate-permanent');
+    expect(result.attempts[0]?.classification).toBe('permanent');
+  });
+
+  it('AC2+AC6: tool-not-resolved escalates permanent immediately', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        {
+          result: {
+            ok: false,
+            fault: { kind: 'tool-not-resolved', message: 'testing.command missing' },
+          },
+        },
+      ]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('escalate-permanent');
+  });
+});
+
+// ===========================================================================
+// AC6 — Counter exhaustion via single fault kind
+// ===========================================================================
+
+describe('runValidatorMaxN — counter exhaustion', () => {
+  it('AC6: timeout exhausts per-row cap (2 retries) then escalates HITL', async () => {
+    const sleeps: number[] = [];
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        { result: { ok: false, fault: { kind: 'timeout', message: 't1' } } },
+        { result: { ok: false, fault: { kind: 'timeout', message: 't2' } } },
+        { result: { ok: false, fault: { kind: 'timeout', message: 't3' } } },
+      ]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('escalate-hitl');
+    expect(result.attempts).toHaveLength(3);
+    expect(sleeps).toEqual([5_000, 30_000]);
+    expect(result.attempts.at(-1)?.retryDecision).toBe('escalate-hitl');
+  });
+
+  it('AC6: respects custom validatorRetryMax (N=2) — escalates on 2nd reject', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        { result: { ok: true, verdict: buildRejection('r1') } },
+        { result: { ok: true, verdict: buildRejection('r2') } },
+      ]),
+      respawnWorker: scriptedRespawnWorker([{ ok: true }]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, {
+      projectRoot: testDir,
+      validatorRetryMax: 2,
+    });
+
+    expect(result.outcome).toBe('escalate-hitl');
+    expect(result.attempts).toHaveLength(2);
+  });
+});
+
+// ===========================================================================
+// AC5 — Audit JSONL behaviour
+// ===========================================================================
+
+describe('runValidatorMaxN — audit JSONL', () => {
+  it('AC5: each retry attempt appends exactly one JSONL line', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        { result: { ok: false, fault: { kind: 'conduit-drop', message: 'd1' } } },
+        { result: { ok: false, fault: { kind: 'conduit-drop', message: 'd2' } } },
+        { result: { ok: true, verdict: buildAttestation() } },
+      ]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    const auditPath = join(testDir, VALIDATOR_RETRIES_AUDIT_FILE);
+    const contents = await readFile(auditPath, 'utf-8');
+    const lines = contents.trim().split('\n');
+    expect(lines).toHaveLength(3);
+    // Each line is standalone valid JSON.
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+    const parsed = lines.map((l) => JSON.parse(l));
+    expect(parsed[0].faultKind).toBe('conduit-drop');
+    expect(parsed[1].faultKind).toBe('conduit-drop');
+    expect(parsed[2].faultKind).toBeNull();
+    expect(parsed[2].retryDecision).toBe('attest');
+    // All rows carry timestamp + taskId.
+    for (const row of parsed) {
+      expect(row.timestamp).toBe(NOW);
+      expect(row.taskId).toBe(TASK_ID);
+    }
+  });
+
+  it('AC5: suppressAudit suppresses file writes entirely', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([
+        { result: { ok: true, verdict: buildAttestation() } },
+      ]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, {
+      projectRoot: testDir,
+      suppressAudit: true,
+    });
+
+    expect(result.outcome).toBe('attest');
+    // No audit file should exist.
+    await expect(readFile(join(testDir, VALIDATOR_RETRIES_AUDIT_FILE), 'utf-8')).rejects.toThrow();
+    // In-memory trail is still populated.
+    expect(result.attempts).toHaveLength(1);
+  });
+});
+
+// ===========================================================================
+// Worker-respawn failure handling
+// ===========================================================================
+
+describe('runValidatorMaxN — worker respawn failures', () => {
+  it('escalates HITL when respawnWorker returns ok=false', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([{ result: { ok: true, verdict: buildRejection() } }]),
+      respawnWorker: scriptedRespawnWorker([
+        { ok: false, fault: { kind: 'timeout', message: 'worker spawn timed out' } },
+      ]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('escalate-hitl');
+    if (result.outcome === 'escalate-hitl') {
+      expect(result.reason).toContain('Worker re-spawn failed');
+    }
+  });
+
+  it('escalates HITL when respawnWorker throws', async () => {
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([{ result: { ok: true, verdict: buildRejection() } }]),
+      respawnWorker: async () => {
+        throw new Error('worker spawn crashed');
+      },
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('escalate-hitl');
+  });
+});
+
+// ===========================================================================
+// Defensive: thrown errors from spawnValidator are translated to timeout
+// ===========================================================================
+
+describe('runValidatorMaxN — defensive error handling', () => {
+  it('treats thrown errors from spawnValidator as timeout faults', async () => {
+    let throws = 2;
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: async (): Promise<ValidatorRoundResult> => {
+        if (throws-- > 0) throw new Error('subagent ETIMEDOUT');
+        return { ok: true, verdict: buildAttestation() };
+      },
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, { projectRoot: testDir });
+
+    expect(result.outcome).toBe('attest');
+    expect(result.attempts).toHaveLength(3);
+    expect(result.attempts[0]?.faultKind).toBe('timeout');
+  });
+});
+
+// ===========================================================================
+// resolveBackoffMs unit tests
+// ===========================================================================
+
+describe('resolveBackoffMs', () => {
+  it('immediate strategy returns 0 regardless of attempt number', () => {
+    expect(resolveBackoffMs({ kind: 'immediate' }, 1)).toBe(0);
+    expect(resolveBackoffMs({ kind: 'immediate' }, 5)).toBe(0);
+  });
+
+  it('immediate-downgrade strategy returns 0', () => {
+    expect(resolveBackoffMs({ kind: 'immediate-downgrade' }, 1)).toBe(0);
+  });
+
+  it('exponential strategy returns firstMs on first retry, secondMs on subsequent', () => {
+    const s = { kind: 'exponential' as const, firstMs: 5_000, secondMs: 30_000 };
+    expect(resolveBackoffMs(s, 1)).toBe(5_000);
+    expect(resolveBackoffMs(s, 2)).toBe(30_000);
+    expect(resolveBackoffMs(s, 3)).toBe(30_000);
+  });
+});
+
+// ===========================================================================
+// Type/discriminant integrity — verdict types narrow correctly
+// ===========================================================================
+
+describe('runValidatorMaxN — result discriminant', () => {
+  it('attest outcome carries a typed attestation verdict', async () => {
+    const att = buildAttestation();
+    const deps: ValidatorRuntimeDeps = {
+      spawnValidator: scriptedSpawnValidator([{ result: { ok: true, verdict: att } }]),
+      respawnWorker: scriptedRespawnWorker([]),
+      sleep: noopSleep,
+      now: fixedNow,
+    };
+
+    const result = await runValidatorMaxN(TASK_ID, deps, {
+      projectRoot: testDir,
+      suppressAudit: true,
+    });
+
+    expect(result.outcome).toBe('attest');
+    if (result.outcome === 'attest') {
+      const narrowed: ValidatorVerdict = result.verdict;
+      expect(narrowed.verdict).toBe('attest');
+    }
+  });
+});

--- a/packages/core/src/lifecycle/validator/index.ts
+++ b/packages/core/src/lifecycle/validator/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Validator runtime barrel — re-exports the Max-N retry runtime that
+ * drives the Lead↔Worker↔Validator round-trip.
+ *
+ * @module lifecycle/validator
+ * @task T10512
+ * @epic T10383
+ * @saga T10377
+ */
+
+export type {
+  BackoffStrategy,
+  RunValidatorMaxNOptions,
+  ValidatorFault,
+  ValidatorFaultFamily,
+  ValidatorFaultKind,
+  ValidatorRetryAuditEntry,
+  ValidatorRoundResult,
+  ValidatorRuntimeDeps,
+  ValidatorRuntimeResult,
+  ValidatorSpawnRequest,
+  WorkerRespawnFn,
+} from './runtime.js';
+export {
+  DEFAULT_SUBAGENT_TIMEOUT_MS,
+  DEFAULT_VALIDATOR_RETRY_MAX,
+  MAX_N_ROWS,
+  resolveBackoffMs,
+  runValidatorMaxN,
+  VALIDATOR_RETRIES_AUDIT_FILE,
+} from './runtime.js';

--- a/packages/core/src/lifecycle/validator/runtime.ts
+++ b/packages/core/src/lifecycle/validator/runtime.ts
@@ -1,0 +1,865 @@
+/**
+ * Validator Max-N Runtime — Lead↔Worker round-trip orchestration.
+ *
+ * Drives the canonical Lead → Worker → Validator loop defined by the
+ * `cleo-validator` skill ({@link
+ * ../../../../../.cleo/skills/cleo-validator/SKILL.md}). For one Worker
+ * task, this runtime:
+ *
+ *  1. Spawns the Validator via the injected `spawnValidator` callback
+ *     (T10511's `spawn.validator` SDK tool).
+ *  2. Waits for the verdict (attest or reject) OR for an infra-fault to be
+ *     emitted by `spawnValidator` / `awaitVerdict`.
+ *  3. On `attest`: returns success.
+ *  4. On `reject` (semantic fault: the Worker's code is wrong): increments
+ *     the shared retry counter, re-spawns the Worker with rejection
+ *     findings, then re-spawns the Validator.
+ *  5. On infra-fault (timeout, conduit-drop, validator-OOM): increments
+ *     the SHARED retry counter, applies the canonical Max-N row (retry
+ *     count, backoff strategy, transient/permanent classification) and
+ *     either re-spawns a FRESH Validator or escalates to Lead.
+ *
+ * ## Design contract
+ *
+ * The runtime is decoupled from T10511's concrete SDK-tool implementations
+ * via the {@link ValidatorRuntimeDeps} injection contract — callers pass
+ * functions that produce verdicts / fault classifications. Unit tests stub
+ * those callbacks; production wiring (a follow-up task) supplies the real
+ * `spawn.validator`, `validator.attest`, `validator.reject`, and
+ * `validator.evidence-run` adapters.
+ *
+ * ## Shared retry-counter accounting (VAL-007 + Max-N table)
+ *
+ * Both semantic faults (REJECT) AND infra faults (timeout / conduit-drop /
+ * validator-OOM) increment the SAME `validatorRetryAttempts` counter,
+ * bounded by `validatorRetryMax` (default N=3). This prevents an
+ * adversarial alternation where a Worker flips between fault families to
+ * bypass the cap (e.g. REJECT → timeout → REJECT → timeout → ... forever).
+ *
+ * ## Audit trail
+ *
+ * Every retry attempt — semantic OR infra — appends ONE line to
+ * `<projectRoot>/.cleo/audit/validator-retries.jsonl`. Each line is
+ * standalone JSON ({@link ValidatorRetryAuditEntry}) and includes
+ * `timestamp`, `taskId`, `attemptNumber`, `faultKind`, `classification`,
+ * and `retryDecision`. The append-only convention matches
+ * `force-bypass.jsonl` and `contract-violations.jsonl`.
+ *
+ * @module lifecycle/validator/runtime
+ * @task T10512
+ * @epic T10383
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { ValidatorRejection, ValidatorVerdict } from '@cleocode/contracts';
+import { getLogger } from '../../logger.js';
+import { getProjectRoot } from '../../paths.js';
+
+const log = getLogger('lifecycle:validator:runtime');
+
+// =============================================================================
+// CONSTANTS — canonical Max-N table rows (SKILL.md §Success Criteria)
+// =============================================================================
+
+/**
+ * Default shared retry cap (semantic + infra). Configurable via the
+ * `validatorRetryMax` option on {@link runValidatorMaxN}. Mirrors
+ * `delegation.validatorRetryMax` from the SKILL.md.
+ *
+ * @task T10512
+ */
+export const DEFAULT_VALIDATOR_RETRY_MAX = 3;
+
+/**
+ * Default subagent timeout in milliseconds before a Validator spawn is
+ * classified as an infra-fault `timeout`. Mirrors `subagentTimeoutSeconds`
+ * (300 s) from the SKILL.md tier-1 default.
+ *
+ * @task T10512
+ */
+export const DEFAULT_SUBAGENT_TIMEOUT_MS = 300_000;
+
+/**
+ * Canonical Max-N row catalogue keyed by fault kind. Every fault produced
+ * by `spawnValidator` / `awaitVerdict` resolves to ONE of these rows.
+ *
+ * `retryCount` is the per-row cap (not the shared cap); the shared cap
+ * (`validatorRetryMax`) overrides per-row caps when reached first.
+ *
+ * `backoff` is the strategy applied BEFORE the next retry attempt:
+ *  - `exponential(b, m)` — sleeps `b` then `m` (clamped by maxDelayMs)
+ *  - `immediate` — zero delay
+ *  - `immediate-downgrade` — zero delay PLUS model-tier downgrade
+ *    (e.g. Sonnet → Haiku) requested via the spawn callback
+ *
+ * `classification`:
+ *  - `transient` — retryable; continues consuming the shared counter
+ *  - `permanent` — non-retryable; short-circuits to HITL on FIRST occurrence
+ *
+ * @task T10512
+ */
+export const MAX_N_ROWS = {
+  // ────────────────────────────────────────────────────────────────────────
+  // Semantic faults — Validator decided but couldn't reach a verdict
+  // ────────────────────────────────────────────────────────────────────────
+  'validator-rejected-no-acs': {
+    family: 'semantic' as const,
+    retryCount: 0,
+    backoff: { kind: 'immediate' as const },
+    classification: 'permanent' as const,
+    escalationAtom: 'E_VALIDATOR_NO_ACS',
+  },
+  'validator-partial': {
+    family: 'semantic' as const,
+    retryCount: 1,
+    backoff: { kind: 'immediate' as const },
+    classification: 'transient' as const,
+    escalationAtom: 'E_VALIDATOR_PARTIAL',
+  },
+  'validator-unreachable': {
+    family: 'semantic' as const,
+    retryCount: 2,
+    backoff: { kind: 'exponential' as const, firstMs: 10_000, secondMs: 30_000 },
+    classification: 'transient' as const,
+    escalationAtom: 'E_VALIDATOR_UNREACHABLE',
+  },
+  'tool-not-resolved': {
+    family: 'semantic' as const,
+    retryCount: 0,
+    backoff: { kind: 'immediate' as const },
+    classification: 'permanent' as const,
+    escalationAtom: 'E_TOOL_NOT_RESOLVED',
+  },
+  // ────────────────────────────────────────────────────────────────────────
+  // Infra faults — Validator process / transport itself failed
+  // ────────────────────────────────────────────────────────────────────────
+  timeout: {
+    family: 'infra' as const,
+    retryCount: 2,
+    backoff: { kind: 'exponential' as const, firstMs: 5_000, secondMs: 30_000 },
+    classification: 'transient' as const,
+    escalationAtom: 'E_VALIDATOR_TIMEOUT',
+  },
+  'conduit-drop': {
+    family: 'infra' as const,
+    retryCount: 3,
+    backoff: { kind: 'immediate' as const },
+    classification: 'transient' as const,
+    escalationAtom: 'E_VALIDATOR_VERDICT_DROPPED',
+  },
+  'validator-OOM': {
+    family: 'infra' as const,
+    retryCount: 1,
+    backoff: { kind: 'immediate-downgrade' as const },
+    classification: 'transient-then-permanent' as const,
+    escalationAtom: 'E_VALIDATOR_OOM',
+  },
+} as const;
+
+/**
+ * Canonical fault kinds — the keys of {@link MAX_N_ROWS}.
+ *
+ * @task T10512
+ */
+export type ValidatorFaultKind = keyof typeof MAX_N_ROWS;
+
+/**
+ * Canonical fault families. Semantic faults are decisions by the Validator
+ * (or its tools); infra faults are process/transport failures.
+ *
+ * @task T10512
+ */
+export type ValidatorFaultFamily = 'semantic' | 'infra';
+
+/**
+ * Backoff strategy applied between retries.
+ *
+ *  - `immediate` — zero delay
+ *  - `exponential` — `firstMs` before the first retry, `secondMs` before any
+ *    subsequent retries within the same row
+ *  - `immediate-downgrade` — zero delay AND the next spawn should request a
+ *    smaller model tier (e.g. Sonnet → Haiku) to fit a tighter context
+ *
+ * @task T10512
+ */
+export type BackoffStrategy =
+  | { kind: 'immediate' }
+  | { kind: 'exponential'; firstMs: number; secondMs: number }
+  | { kind: 'immediate-downgrade' };
+
+// =============================================================================
+// FAULT — uniform fault envelope returned by spawn / await callbacks
+// =============================================================================
+
+/**
+ * Uniform fault envelope returned by {@link ValidatorRuntimeDeps.spawnValidator}
+ * or {@link ValidatorRuntimeDeps.awaitVerdict} when something goes wrong.
+ *
+ * The runtime resolves `kind` against {@link MAX_N_ROWS} to pick the retry
+ * policy.
+ *
+ * @task T10512
+ */
+export interface ValidatorFault {
+  kind: ValidatorFaultKind;
+  /** Free-form diagnostic from the failing callback. */
+  message: string;
+  /**
+   * Optional structured detail — captured into the audit row's `detail`
+   * field for post-mortem analysis.
+   */
+  detail?: Record<string, unknown>;
+}
+
+// =============================================================================
+// DEPS — injectable contract that the runtime DRIVES
+// =============================================================================
+
+/**
+ * Spawn-request envelope passed to {@link ValidatorRuntimeDeps.spawnValidator}.
+ *
+ * @task T10512
+ */
+export interface ValidatorSpawnRequest {
+  /** Worker task being validated. */
+  workerTaskId: string;
+  /** Attempt number (1-based; resets to 1 on Worker re-spawn). */
+  attemptNumber: number;
+  /**
+   * When true (set after a `validator-OOM` infra fault) the spawner SHOULD
+   * downgrade the model tier (e.g. Sonnet → Haiku) for this attempt to
+   * shrink the context window. The spawner is responsible for the actual
+   * model selection; this flag is advisory.
+   */
+  downgradeModelTier?: boolean;
+  /**
+   * On Worker re-spawn after a REJECT, this carries the rejection envelope
+   * the Worker should use to fix the failing ACs. Absent on Validator-only
+   * spawns.
+   */
+  workerRespawnContext?: {
+    rejection: ValidatorRejection;
+  };
+}
+
+/**
+ * Result envelope returned by {@link ValidatorRuntimeDeps.spawnValidator} or
+ * {@link ValidatorRuntimeDeps.awaitVerdict}: either a verdict (success) or a
+ * fault classification.
+ *
+ * @task T10512
+ */
+export type ValidatorRoundResult =
+  | { ok: true; verdict: ValidatorVerdict }
+  | { ok: false; fault: ValidatorFault };
+
+/**
+ * Worker re-spawn callback — invoked when the Validator returns a
+ * REJECT verdict (semantic fault: the Worker's code is wrong, not an infra
+ * failure). The callback is responsible for re-dispatching the Worker with
+ * the rejection findings as feedback.
+ *
+ * Returns the new worker submission state OR a fault (e.g. the Worker
+ * itself crashed during re-spawn).
+ *
+ * @task T10512
+ */
+export type WorkerRespawnFn = (
+  workerTaskId: string,
+  rejection: ValidatorRejection,
+  attemptNumber: number,
+) => Promise<{ ok: true } | { ok: false; fault: ValidatorFault }>;
+
+/**
+ * Injectable dependency contract for the validator Max-N runtime. Callers
+ * (production wiring AND tests) supply functions that wrap the underlying
+ * T10511 SDK tools. The runtime never imports T10511 directly.
+ *
+ * @task T10512
+ */
+export interface ValidatorRuntimeDeps {
+  /**
+   * Spawn a Validator subagent and return either the verdict OR a fault.
+   * The implementer is responsible for the timeout budget — when the
+   * subagent exceeds `subagentTimeoutSeconds` the implementer MUST return
+   * `{ ok: false, fault: { kind: 'timeout', ... } }`.
+   */
+  spawnValidator(req: ValidatorSpawnRequest): Promise<ValidatorRoundResult>;
+  /**
+   * Re-spawn the Worker with rejection findings. The implementer is
+   * responsible for re-dispatching the Worker and feeding the rejection
+   * envelope into the Worker's spawn prompt.
+   */
+  respawnWorker: WorkerRespawnFn;
+  /**
+   * Sleep callback (injectable for deterministic tests). Receives the
+   * backoff delay in ms; in tests this can be a no-op.
+   */
+  sleep?: (ms: number) => Promise<void>;
+  /**
+   * Clock callback (injectable for deterministic tests). Returns ISO
+   * timestamps used in audit entries.
+   */
+  now?: () => string;
+}
+
+// =============================================================================
+// OPTIONS — caller-facing options
+// =============================================================================
+
+/**
+ * Options passed to {@link runValidatorMaxN}. All fields are optional with
+ * canonical defaults.
+ *
+ * @task T10512
+ */
+export interface RunValidatorMaxNOptions {
+  /**
+   * Shared retry cap (semantic + infra combined). Defaults to
+   * {@link DEFAULT_VALIDATOR_RETRY_MAX} (3).
+   */
+  validatorRetryMax?: number;
+  /**
+   * Project root used to write the audit JSONL. Defaults to the CLEO
+   * project root resolved via `getProjectRoot()`. Tests should pass an
+   * explicit temp dir.
+   */
+  projectRoot?: string;
+  /**
+   * When true, the audit appender is suppressed entirely (used by tests
+   * that want to assert behaviour WITHOUT touching the filesystem).
+   */
+  suppressAudit?: boolean;
+}
+
+// =============================================================================
+// RESULT — terminal outcome envelope
+// =============================================================================
+
+/**
+ * Terminal outcome of {@link runValidatorMaxN}. The runtime always reaches
+ * ONE of three terminal states:
+ *
+ *  - `attest` — happy path; Validator returned an attestation
+ *  - `escalate-hitl` — retry budget exhausted OR permanent fault; Lead must
+ *    take over (file a HITL approval gate)
+ *  - `escalate-permanent` — first-occurrence permanent fault (e.g. `no-acs`)
+ *
+ * The `attempts` array preserves the full audit trail in memory for the
+ * caller (in addition to the on-disk JSONL).
+ *
+ * @task T10512
+ */
+export type ValidatorRuntimeResult =
+  | {
+      outcome: 'attest';
+      taskId: string;
+      verdict: ValidatorVerdict & { verdict: 'attest' };
+      attempts: ValidatorRetryAuditEntry[];
+    }
+  | {
+      outcome: 'escalate-hitl';
+      taskId: string;
+      reason: string;
+      attempts: ValidatorRetryAuditEntry[];
+    }
+  | {
+      outcome: 'escalate-permanent';
+      taskId: string;
+      fault: ValidatorFault;
+      reason: string;
+      attempts: ValidatorRetryAuditEntry[];
+    };
+
+// =============================================================================
+// AUDIT — JSONL row shape
+// =============================================================================
+
+/**
+ * Canonical path (relative to project root) for the validator-retry audit
+ * log. Append-only JSONL — one row per retry attempt.
+ *
+ * @task T10512
+ */
+export const VALIDATOR_RETRIES_AUDIT_FILE = '.cleo/audit/validator-retries.jsonl';
+
+/**
+ * One row in `.cleo/audit/validator-retries.jsonl`. Append-only, one line
+ * per retry attempt (semantic OR infra). Matches the
+ * `force-bypass.jsonl` / `contract-violations.jsonl` append-only pattern.
+ *
+ * @task T10512
+ */
+export interface ValidatorRetryAuditEntry {
+  /** ISO-8601 timestamp at which this row was written. */
+  timestamp: string;
+  /** Worker task ID under validation. */
+  taskId: string;
+  /**
+   * 1-based attempt number against the SHARED retry counter. A run that
+   * succeeds first try emits exactly one row with `attemptNumber: 1` and
+   * `outcome: 'attest'`.
+   */
+  attemptNumber: number;
+  /** Family of the fault that triggered this row, or `null` on success. */
+  faultFamily: ValidatorFaultFamily | null;
+  /** Canonical fault kind, or `null` on success. */
+  faultKind: ValidatorFaultKind | null;
+  /** Transient / permanent classification, or `null` on success. */
+  classification: 'transient' | 'permanent' | 'transient-then-permanent' | null;
+  /** Backoff applied BEFORE the next attempt, or `null` if no next attempt. */
+  backoffMs: number | null;
+  /**
+   * Retry decision the runtime took at this row:
+   *   - `retry-validator`     — re-spawn a fresh Validator
+   *   - `retry-worker`        — Validator rejected; re-spawn Worker with findings
+   *   - `escalate-hitl`       — counter exhausted; Lead takes over
+   *   - `escalate-permanent`  — permanent fault; short-circuit to HITL
+   *   - `attest`              — happy path; Validator returned attestation
+   */
+  retryDecision:
+    | 'retry-validator'
+    | 'retry-worker'
+    | 'escalate-hitl'
+    | 'escalate-permanent'
+    | 'attest';
+  /** Free-form diagnostic carried from the underlying fault. */
+  message: string;
+  /** Structured detail captured for post-mortem analysis. */
+  detail?: Record<string, unknown>;
+}
+
+// =============================================================================
+// PUBLIC API — runValidatorMaxN
+// =============================================================================
+
+/**
+ * Run the Lead↔Worker↔Validator Max-N retry loop for one Worker task.
+ *
+ * @remarks
+ * Drives the canonical state machine documented in the `cleo-validator`
+ * SKILL.md "Execution Flow" + "Max-N infra-fault row catalogue" sections.
+ *
+ * The shared counter (`validatorRetryAttempts`) advances on EVERY fault
+ * regardless of family — this is the documented defence against
+ * adversarial fault-kind alternation (a Worker / Validator pairing that
+ * flips between REJECT and `timeout` would otherwise bypass the cap).
+ *
+ * The runtime is purely orchestration — it never calls `cleo verify`,
+ * never mutates the Worker's gate ledger, never modifies the worktree.
+ * All side effects flow through the injected {@link ValidatorRuntimeDeps}.
+ *
+ * @example
+ * ```ts
+ * import { runValidatorMaxN } from '@cleocode/core/lifecycle/validator/runtime';
+ *
+ * const result = await runValidatorMaxN('T1234', {
+ *   spawnValidator: async (req) => {
+ *     // Production: call spawn.validator from T10511 SDK tools.
+ *     return await sdk.spawn.validator(req);
+ *   },
+ *   respawnWorker: async (taskId, rejection, attemptNumber) => {
+ *     // Production: dispatch worker with rejection envelope.
+ *     return await sdk.spawn.worker({ taskId, rejection, attemptNumber });
+ *   },
+ * });
+ *
+ * if (result.outcome === 'attest') {
+ *   // Happy path — Lead can mark the task done.
+ * } else if (result.outcome === 'escalate-hitl') {
+ *   // Lead opens a HITL approval gate.
+ * } else {
+ *   // Permanent fault — Lead routes to AC-backfill or infra team.
+ * }
+ * ```
+ *
+ * @param workerTaskId - Worker task ID (e.g. `'T1234'`).
+ * @param deps - Injectable runtime dependencies (spawn / respawn / sleep / now).
+ * @param opts - Optional caller overrides (retry cap, audit path, etc.).
+ * @returns The terminal outcome envelope + in-memory audit trail.
+ *
+ * @task T10512
+ */
+export async function runValidatorMaxN(
+  workerTaskId: string,
+  deps: ValidatorRuntimeDeps,
+  opts: RunValidatorMaxNOptions = {},
+): Promise<ValidatorRuntimeResult> {
+  const validatorRetryMax = opts.validatorRetryMax ?? DEFAULT_VALIDATOR_RETRY_MAX;
+  const now = deps.now ?? (() => new Date().toISOString());
+  const sleep = deps.sleep ?? defaultSleep;
+  const attempts: ValidatorRetryAuditEntry[] = [];
+
+  // Counter increments on EVERY fault. Shared between semantic + infra
+  // families per Saga T10377 VAL-007 + SKILL.md Max-N table footnote.
+  let validatorRetryAttempts = 0;
+
+  // OOM-downgrade state — set to true after the first validator-OOM fault
+  // so the NEXT spawn requests a smaller model tier.
+  let downgradeNext = false;
+
+  // Per-row attempt counts — each row's own `retryCount` is the cap
+  // INSIDE the row. The shared counter is the OUTER cap.
+  const perRowAttempts: Partial<Record<ValidatorFaultKind, number>> = {};
+
+  while (true) {
+    const attemptNumber = validatorRetryAttempts + 1;
+
+    // 1. Spawn validator (single round).
+    const spawnReq: ValidatorSpawnRequest = {
+      workerTaskId,
+      attemptNumber,
+      ...(downgradeNext ? { downgradeModelTier: true } : {}),
+    };
+    downgradeNext = false; // consume the downgrade flag
+
+    let round: ValidatorRoundResult;
+    try {
+      round = await deps.spawnValidator(spawnReq);
+    } catch (err) {
+      // A throw from spawnValidator is treated as a `timeout` infra-fault —
+      // the implementer is supposed to translate timeouts into a fault
+      // envelope, but defence-in-depth handles thrown errors uniformly.
+      round = {
+        ok: false,
+        fault: {
+          kind: 'timeout',
+          message: err instanceof Error ? err.message : String(err),
+        },
+      };
+    }
+
+    // 2a. ATTEST — happy path; emit success audit row and return.
+    if (round.ok && round.verdict.verdict === 'attest') {
+      const entry: ValidatorRetryAuditEntry = {
+        timestamp: now(),
+        taskId: workerTaskId,
+        attemptNumber,
+        faultFamily: null,
+        faultKind: null,
+        classification: null,
+        backoffMs: null,
+        retryDecision: 'attest',
+        message: 'Validator attested all ACs',
+      };
+      attempts.push(entry);
+      writeAuditEntry(entry, opts);
+      return {
+        outcome: 'attest',
+        taskId: workerTaskId,
+        verdict: round.verdict,
+        attempts,
+      };
+    }
+
+    // 2b. REJECT — semantic fault; loop back to Worker.
+    if (round.ok && round.verdict.verdict === 'reject') {
+      validatorRetryAttempts += 1;
+
+      // Check shared counter cap BEFORE re-spawning Worker.
+      if (validatorRetryAttempts >= validatorRetryMax) {
+        const entry: ValidatorRetryAuditEntry = {
+          timestamp: now(),
+          taskId: workerTaskId,
+          attemptNumber,
+          faultFamily: 'semantic',
+          faultKind: 'validator-partial', // closest canonical kind for a REJECT
+          classification: 'transient',
+          backoffMs: null,
+          retryDecision: 'escalate-hitl',
+          message: `Validator REJECT — shared retry cap (${validatorRetryMax}) reached`,
+          detail: { summary: round.verdict.summary },
+        };
+        attempts.push(entry);
+        writeAuditEntry(entry, opts);
+        return {
+          outcome: 'escalate-hitl',
+          taskId: workerTaskId,
+          reason: `Validator rejected after ${validatorRetryAttempts} attempt(s); shared retry cap reached. Last summary: ${round.verdict.summary}`,
+          attempts,
+        };
+      }
+
+      // Under cap — emit audit row, re-spawn Worker, loop.
+      const entry: ValidatorRetryAuditEntry = {
+        timestamp: now(),
+        taskId: workerTaskId,
+        attemptNumber,
+        faultFamily: 'semantic',
+        faultKind: 'validator-partial',
+        classification: 'transient',
+        backoffMs: 0,
+        retryDecision: 'retry-worker',
+        message: `Validator REJECT — re-spawning Worker with rejection findings`,
+        detail: { summary: round.verdict.summary },
+      };
+      attempts.push(entry);
+      writeAuditEntry(entry, opts);
+
+      const respawn = await safeRespawnWorker(
+        deps.respawnWorker,
+        workerTaskId,
+        round.verdict,
+        attemptNumber,
+      );
+      if (!respawn.ok) {
+        // Worker re-spawn failed — treat as an infra fault on the worker side.
+        return classifyAndEscalateRespawnFailure(
+          workerTaskId,
+          respawn.fault,
+          attemptNumber,
+          attempts,
+          opts,
+          now,
+        );
+      }
+      // Continue loop; next iteration spawns a fresh Validator.
+      continue;
+    }
+
+    // 2c. INFRA / SEMANTIC fault from the Validator side.
+    const fault = round.ok ? null : round.fault;
+    if (!fault) {
+      // Defensive — round.ok===false MUST yield a fault; safety net.
+      const entry: ValidatorRetryAuditEntry = {
+        timestamp: now(),
+        taskId: workerTaskId,
+        attemptNumber,
+        faultFamily: 'infra',
+        faultKind: 'timeout',
+        classification: 'transient',
+        backoffMs: null,
+        retryDecision: 'escalate-hitl',
+        message: 'spawnValidator returned ok=false with no fault envelope',
+      };
+      attempts.push(entry);
+      writeAuditEntry(entry, opts);
+      return {
+        outcome: 'escalate-hitl',
+        taskId: workerTaskId,
+        reason: 'spawnValidator returned ok=false with no fault envelope',
+        attempts,
+      };
+    }
+
+    const row = MAX_N_ROWS[fault.kind];
+    perRowAttempts[fault.kind] = (perRowAttempts[fault.kind] ?? 0) + 1;
+    validatorRetryAttempts += 1;
+
+    // 2c-i. PERMANENT classification — short-circuit on first occurrence.
+    // For `transient-then-permanent`, the FIRST occurrence is still
+    // transient (we retry once with downgrade); the SECOND becomes permanent.
+    const isPermanentNow =
+      row.classification === 'permanent' ||
+      (row.classification === 'transient-then-permanent' &&
+        (perRowAttempts[fault.kind] ?? 0) > row.retryCount);
+
+    if (isPermanentNow) {
+      const entry: ValidatorRetryAuditEntry = {
+        timestamp: now(),
+        taskId: workerTaskId,
+        attemptNumber,
+        faultFamily: row.family,
+        faultKind: fault.kind,
+        classification: row.classification,
+        backoffMs: null,
+        retryDecision: 'escalate-permanent',
+        message: `Permanent fault (${row.escalationAtom}) — ${fault.message}`,
+        ...(fault.detail ? { detail: fault.detail } : {}),
+      };
+      attempts.push(entry);
+      writeAuditEntry(entry, opts);
+      return {
+        outcome: 'escalate-permanent',
+        taskId: workerTaskId,
+        fault,
+        reason: `Permanent fault: ${row.escalationAtom} — ${fault.message}`,
+        attempts,
+      };
+    }
+
+    // 2c-ii. Shared retry cap reached — escalate to HITL.
+    if (validatorRetryAttempts >= validatorRetryMax) {
+      const entry: ValidatorRetryAuditEntry = {
+        timestamp: now(),
+        taskId: workerTaskId,
+        attemptNumber,
+        faultFamily: row.family,
+        faultKind: fault.kind,
+        classification: row.classification,
+        backoffMs: null,
+        retryDecision: 'escalate-hitl',
+        message: `${fault.kind} — shared retry cap (${validatorRetryMax}) reached. ${fault.message}`,
+        ...(fault.detail ? { detail: fault.detail } : {}),
+      };
+      attempts.push(entry);
+      writeAuditEntry(entry, opts);
+      return {
+        outcome: 'escalate-hitl',
+        taskId: workerTaskId,
+        reason: `Shared retry cap reached after ${row.escalationAtom}: ${fault.message}`,
+        attempts,
+      };
+    }
+
+    // 2c-iii. Per-row cap reached (but shared cap not) — also escalate.
+    // This handles the case where ONLY this fault kind keeps recurring.
+    if ((perRowAttempts[fault.kind] ?? 0) > row.retryCount) {
+      const entry: ValidatorRetryAuditEntry = {
+        timestamp: now(),
+        taskId: workerTaskId,
+        attemptNumber,
+        faultFamily: row.family,
+        faultKind: fault.kind,
+        classification: row.classification,
+        backoffMs: null,
+        retryDecision: 'escalate-hitl',
+        message: `${fault.kind} — per-row retry cap (${row.retryCount}) reached. ${fault.message}`,
+        ...(fault.detail ? { detail: fault.detail } : {}),
+      };
+      attempts.push(entry);
+      writeAuditEntry(entry, opts);
+      return {
+        outcome: 'escalate-hitl',
+        taskId: workerTaskId,
+        reason: `Per-row retry cap reached for ${row.escalationAtom}: ${fault.message}`,
+        attempts,
+      };
+    }
+
+    // 2c-iv. Retry — compute backoff, set downgrade flag for OOM, emit audit, sleep.
+    const backoffMs = resolveBackoffMs(row.backoff, perRowAttempts[fault.kind] ?? 1);
+    if (row.backoff.kind === 'immediate-downgrade') {
+      downgradeNext = true;
+    }
+
+    const entry: ValidatorRetryAuditEntry = {
+      timestamp: now(),
+      taskId: workerTaskId,
+      attemptNumber,
+      faultFamily: row.family,
+      faultKind: fault.kind,
+      classification: row.classification,
+      backoffMs,
+      retryDecision: 'retry-validator',
+      message: fault.message,
+      ...(fault.detail ? { detail: fault.detail } : {}),
+    };
+    attempts.push(entry);
+    writeAuditEntry(entry, opts);
+
+    if (backoffMs > 0) {
+      await sleep(backoffMs);
+    }
+    // Loop continues — next iteration spawns a fresh Validator.
+  }
+}
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+/**
+ * Resolve the delay in milliseconds for a given backoff strategy and the
+ * 1-based per-row attempt number (1 = first retry, 2 = second retry, ...).
+ *
+ * Internal — exported for unit testing only.
+ *
+ * @task T10512
+ */
+export function resolveBackoffMs(strategy: BackoffStrategy, perRowAttempt: number): number {
+  if (strategy.kind === 'immediate' || strategy.kind === 'immediate-downgrade') return 0;
+  // exponential — first retry uses firstMs; any subsequent retry uses secondMs
+  return perRowAttempt <= 1 ? strategy.firstMs : strategy.secondMs;
+}
+
+/**
+ * Wrap the user-supplied `respawnWorker` callback in try/catch — a thrown
+ * error becomes a uniform `timeout` fault envelope so the runtime never
+ * propagates unhandled rejections.
+ */
+async function safeRespawnWorker(
+  fn: WorkerRespawnFn,
+  workerTaskId: string,
+  rejection: ValidatorRejection,
+  attemptNumber: number,
+): Promise<{ ok: true } | { ok: false; fault: ValidatorFault }> {
+  try {
+    return await fn(workerTaskId, rejection, attemptNumber);
+  } catch (err) {
+    return {
+      ok: false,
+      fault: {
+        kind: 'timeout',
+        message: `Worker respawn threw: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    };
+  }
+}
+
+/**
+ * Convert a Worker re-spawn failure into a terminal `escalate-hitl`
+ * outcome. The Worker side isn't subject to the same Max-N row catalogue
+ * (those are Validator-side failures); treat any Worker re-spawn failure
+ * as immediate HITL.
+ */
+function classifyAndEscalateRespawnFailure(
+  workerTaskId: string,
+  fault: ValidatorFault,
+  attemptNumber: number,
+  attempts: ValidatorRetryAuditEntry[],
+  opts: RunValidatorMaxNOptions,
+  now: () => string,
+): ValidatorRuntimeResult {
+  const entry: ValidatorRetryAuditEntry = {
+    timestamp: now(),
+    taskId: workerTaskId,
+    attemptNumber,
+    faultFamily: 'infra',
+    faultKind: fault.kind,
+    classification: 'transient',
+    backoffMs: null,
+    retryDecision: 'escalate-hitl',
+    message: `Worker respawn failed: ${fault.message}`,
+    ...(fault.detail ? { detail: fault.detail } : {}),
+  };
+  attempts.push(entry);
+  writeAuditEntry(entry, opts);
+  return {
+    outcome: 'escalate-hitl',
+    taskId: workerTaskId,
+    reason: `Worker re-spawn failed: ${fault.message}`,
+    attempts,
+  };
+}
+
+/**
+ * Append one entry to the audit JSONL. Best-effort — errors are logged but
+ * swallowed so audit writes never block the orchestration loop.
+ *
+ * Matches the append-only convention used by
+ * {@link appendContractViolation} and the legacy `force-bypass.jsonl`
+ * writer.
+ */
+function writeAuditEntry(entry: ValidatorRetryAuditEntry, opts: RunValidatorMaxNOptions): void {
+  if (opts.suppressAudit === true) return;
+  try {
+    const root = opts.projectRoot ?? getProjectRoot();
+    const filePath = join(root, VALIDATOR_RETRIES_AUDIT_FILE);
+    mkdirSync(dirname(filePath), { recursive: true });
+    appendFileSync(filePath, `${JSON.stringify(entry)}\n`, { encoding: 'utf-8' });
+  } catch (err) {
+    log.warn({ err }, 'Failed to append validator-retries audit entry');
+  }
+}
+
+/**
+ * Default sleep implementation — promisified `setTimeout`.
+ *
+ * Internal — overridable via {@link ValidatorRuntimeDeps.sleep} for tests.
+ */
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

Implements `runValidatorMaxN(workerTaskId, deps, opts)` — the Max-N retry runtime that orchestrates the canonical Lead↔Worker↔Validator round-trip defined by the `cleo-validator` SKILL.md (T10495 + T10496 infra-fault rows).

Lives at `packages/core/src/lifecycle/validator/runtime.ts` with a barrel re-export from `packages/core/src/lifecycle/validator/index.ts`.

## Acceptance Criteria

- **AC1** — `runValidatorMaxN` orchestrates spawn-validator → await-verdict → on-attest-return / on-reject-respawn-worker / on-infra-fault-apply-Max-N-row.
- **AC2** — Honours semantic-fault retry counts AND infra-fault retry counts per T10496.
- **AC3** — Shared retry-counter accounting (semantic + infra share `validatorRetryMax`) prevents adversarial fault-kind alternation.
- **AC4** — Backoff strategies: `exponential(5s, 30s)` for timeout, `immediate` for conduit-drop, `immediate-with-model-downgrade` for validator-OOM.
- **AC5** — Append-only JSONL audit at `.cleo/audit/validator-retries.jsonl` with timestamp, taskId, attemptNumber, faultKind, classification, retryDecision.
- **AC6** — 20 unit tests cover happy path (attest first try), reject→fix→attest, each infra-fault row, counter exhaustion, shared-counter adversarial alternation, permanent classification, audit JSONL, worker-respawn failures, defensive error translation, and result discriminant narrowing.

## Design contracts

- **Dependency-injected** — runtime never imports T10511's SDK tools directly; callers pass `spawnValidator` + `respawnWorker` callbacks via `ValidatorRuntimeDeps`. Tests stub them. Only contract dependency is `ValidatorVerdict` from T10510 (shipped).
- **Shared counter** — `validatorRetryAttempts` increments on EVERY fault (semantic REJECT or infra `timeout`/`conduit-drop`/`validator-OOM`), bounded by `validatorRetryMax` (default N=3) per VAL-007.
- **MAX_N_ROWS** — canonical table encoding family / retryCount / backoff / classification per SKILL.md. `permanent` short-circuits on first occurrence; `transient-then-permanent` (validator-OOM) escalates permanent after per-row retry budget exhausts.
- **Defensive** — thrown errors from `spawnValidator` are normalized to `timeout` faults so the runtime never propagates unhandled rejections.

## Test plan

- [x] `pnpm --filter @cleocode/core exec vitest run src/lifecycle/validator/` — 20/20 pass
- [x] `pnpm --filter @cleocode/core exec vitest run src/lifecycle/` — 385/385 pass (no regressions)
- [x] `pnpm --filter @cleocode/core run build` — clean tsc
- [x] `npx biome check --write packages/core/src/lifecycle/validator/ .changeset/` — green
- [x] `node scripts/lint-changesets.mjs` — 169/169 valid

Saga: T10377 (SG-IVTR-AC-BINDING). Epic: T10383 (E-VALIDATOR-ROLE). Decision: D013.

Coordinates with concurrent T10511 (SDK tools): the runtime CALLS the four `validator.*` tools through the injection contract, so this PR can land before/after T10511 without coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)