### PR TITLE
feat(T10511): 4 IVTR-feeding SDK tools — validator.attest/.reject/.ac-pull + spawn.validator

### DIFF
--- a/.changeset/t10511-ivtr-sdk-tools.md
+++ b/.changeset/t10511-ivtr-sdk-tools.md
@@ -1,0 +1,22 @@
+---
+id: t10511-ivtr-sdk-tools
+tasks: [T10511]
+kind: feat
+summary: "sdk-tools: validator.attest/reject/ac-pull + spawn.validator (T10383 Wave 3b)"
+---
+
+Ships the four IVTR-feeding SDK tools per T10511 (Saga T10377 SG-IVTR-AC-BINDING, Epic T10383 E-VALIDATOR-ROLE):
+
+1. **`validator.attest`** — terminal validator-role tool. Accepts a `ValidatorAttestation` envelope, schema-validates via `validatorAttestationSchema`, checks every `finding.acId` resolves to a real `task_acceptance_criteria` row, then transactionally writes one `evidence_ac_bindings` row per AC with `binding_type='coverage'`. UNIQUE (atom, ac, type) index collapses idempotent re-attests.
+
+2. **`validator.reject`** — terminal validator-role tool. Schema-validates a `ValidatorRejection` envelope and emits a structured echo envelope with `failingFindingCount` + `failingAcIds`. CRITICAL invariant — writes ZERO `evidence_ac_bindings` rows (rejection = absence of binding).
+
+3. **`validator.ac-pull`** — read-only tool. Returns `{ taskId, acs: [{ id, alias, ordinal, text, bindingStatus: 'satisfied' | 'unsatisfied' }] }` so a Validator can see at a glance which ACs already have coverage.
+
+4. **`spawn.validator`** — orchestrator-tier-1+ tool. Delegates to existing `orchestrateSpawn(taskId, 'validator', …)` after enforcing `caller.role==='orchestrator' && caller.tier>=1`. No parallel registry per council §3.1 ADR-D rejection.
+
+Per-tier scoping is enforced inside each tool's `fn` (no new SdkToolIdentity fields, no parallel registry). All four use the existing `defineSdkTool` factory at `packages/core/src/tools/task-tools/sdk-tool.ts`.
+
+Adds one new `TransactionAccessor` method — `insertAcBindings(rows)` — wired through `packages/contracts/src/data-accessor.ts` and `packages/core/src/store/sqlite-data-accessor.ts`. Idempotent via `ON CONFLICT DO NOTHING` against the existing `uq_evidence_ac_bindings_atom_ac_type` index.
+
+19 new unit tests in `packages/core/src/tools/__tests__/sdk/validator-tools.test.ts` cover: registration sanity, auth-path rejection (all three wrong roles), happy-path attestation, idempotent re-attest, E_VALIDATOR_AC_NOT_FOUND, E_VALIDATOR_ATTESTATION_INVALID, rejection envelope shape, NO-bindings-on-reject invariant, ac-pull empty/mixed/unknown-task paths, and spawn-validator role+tier gating.

--- a/packages/contracts/src/data-accessor.ts
+++ b/packages/contracts/src/data-accessor.ts
@@ -213,6 +213,25 @@ export interface TransactionAccessor {
    * @task T10509
    */
   getAcBindings(acIds: readonly string[]): Promise<AcBindingRow[]>;
+  /**
+   * Insert rows into `evidence_ac_bindings`. Used by the Validator SDK
+   * tools (T10511) to persist coverage bindings transactionally after a
+   * Validator attestation. The UNIQUE (evidence_atom_id, ac_id, binding_type)
+   * index collapses idempotent re-inserts via `ON CONFLICT DO NOTHING`.
+   *
+   * No-op when `rows` is empty.
+   *
+   * @task T10511
+   * @saga T10377 (SG-IVTR-AC-BINDING)
+   */
+  insertAcBindings(
+    rows: Array<{
+      id: string;
+      evidenceAtomId: string;
+      acId: string;
+      bindingType: 'direct' | 'satisfies' | 'coverage';
+    }>,
+  ): Promise<void>;
 }
 
 // Re-export AcRow at the module level for both transaction + outer accessor use.

--- a/packages/core/src/store/sqlite-data-accessor.ts
+++ b/packages/core/src/store/sqlite-data-accessor.ts
@@ -1151,6 +1151,37 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
               createdAt: r.createdAt,
             }));
           },
+          // ---- AC bindings — writer (T10511, Validator SDK tools) ----
+          async insertAcBindings(
+            rows: Array<{
+              id: string;
+              evidenceAtomId: string;
+              acId: string;
+              bindingType: 'direct' | 'satisfies' | 'coverage';
+            }>,
+          ): Promise<void> {
+            if (rows.length === 0) return;
+            // Idempotent insert — UNIQUE (evidence_atom_id, ac_id, binding_type)
+            // index collapses re-inserts of the same triple via DO NOTHING.
+            await db
+              .insert(schema.evidenceAcBindings)
+              .values(
+                rows.map((r) => ({
+                  id: r.id,
+                  evidenceAtomId: r.evidenceAtomId,
+                  acId: r.acId,
+                  bindingType: r.bindingType,
+                })),
+              )
+              .onConflictDoNothing({
+                target: [
+                  schema.evidenceAcBindings.evidenceAtomId,
+                  schema.evidenceAcBindings.acId,
+                  schema.evidenceAcBindings.bindingType,
+                ],
+              })
+              .run();
+          },
         };
 
         const result = await fn(tx);

--- a/packages/core/src/tools/__tests__/sdk/validator-tools.test.ts
+++ b/packages/core/src/tools/__tests__/sdk/validator-tools.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Validator SDK tools — unit tests (T10511).
+ *
+ * Covers all four tools shipped by T10511:
+ *   1. validator.attest    — auth path, happy path, AC-not-found path
+ *   2. validator.reject    — auth path, happy path, NO-bindings invariant
+ *   3. validator.ac-pull   — happy path with mixed binding status
+ *   4. spawn.validator     — auth (role + tier), input shape
+ *
+ * @task T10511
+ * @epic T10383 (E-VALIDATOR-ROLE)
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { AgentRole, ValidatorAttestation, ValidatorRejection } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDbEnv } from '../../../store/__tests__/test-db-helper.js';
+import type { DataAccessor } from '../../../store/data-accessor.js';
+import { resetDbState } from '../../../store/sqlite.js';
+import { addTask } from '../../../tasks/add.js';
+import { spawnValidator } from '../../sdk/spawn-validator.js';
+import { validatorAcPull } from '../../sdk/validator-ac-pull.js';
+import { validatorAttest } from '../../sdk/validator-attest.js';
+import { validatorReject } from '../../sdk/validator-reject.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeTaskWithAcs(
+  accessor: DataAccessor,
+  projectRoot: string,
+  title: string,
+  acceptance: string[],
+) {
+  const out = await addTask(
+    { title, description: `${title} — seeded fixture for T10511 tests`, acceptance },
+    projectRoot,
+    accessor,
+  );
+  const acRows = await accessor.getAcRows(out.task.id);
+  return { task: out.task, acRows };
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function buildAttestation(
+  taskId: string,
+  acIds: string[],
+  validatorId = 'validator-prime',
+): ValidatorAttestation {
+  return {
+    verdict: 'attest',
+    taskId,
+    validatorId,
+    findings: acIds.map((acId) => ({
+      acId,
+      status: 'pass',
+      reasoning: 'ok',
+      checkedAt: nowIso(),
+    })),
+    attestedAt: nowIso(),
+    schemaVersion: '1',
+  };
+}
+
+function buildRejection(
+  taskId: string,
+  acIds: string[],
+  validatorId = 'validator-prime',
+): ValidatorRejection {
+  return {
+    verdict: 'reject',
+    taskId,
+    validatorId,
+    findings: acIds.map((acId, idx) => ({
+      acId,
+      status: idx === 0 ? 'fail' : 'pass',
+      reasoning: idx === 0 ? 'test missing' : 'ok',
+      checkedAt: nowIso(),
+    })),
+    summary: 'AC1 unsatisfied — test missing.',
+    rejectedAt: nowIso(),
+    schemaVersion: '1',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration sanity (mirrors brain-tools.test.ts style)
+// ---------------------------------------------------------------------------
+
+describe('Validator SDK tools — registration sanity (T10511)', () => {
+  it('validatorAttest has stable identity + schemas', () => {
+    expect(validatorAttest.identity.name).toBe('validator-attest');
+    expect(validatorAttest.identity.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(validatorAttest.inputSchema.type).toBe('object');
+    expect(validatorAttest.outputSchema.type).toBe('object');
+    expect(validatorAttest.inputSchema.required).toEqual(['projectRoot', 'caller', 'attestation']);
+  });
+
+  it('validatorReject has stable identity + schemas', () => {
+    expect(validatorReject.identity.name).toBe('validator-reject');
+    expect(validatorReject.identity.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(validatorReject.inputSchema.required).toEqual(['projectRoot', 'caller', 'rejection']);
+  });
+
+  it('validatorAcPull has stable identity + schemas', () => {
+    expect(validatorAcPull.identity.name).toBe('validator-ac-pull');
+    expect(validatorAcPull.identity.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(validatorAcPull.inputSchema.required).toEqual(['projectRoot', 'taskId']);
+  });
+
+  it('spawnValidator has stable identity + schemas', () => {
+    expect(spawnValidator.identity.name).toBe('spawn-validator');
+    expect(spawnValidator.identity.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(spawnValidator.inputSchema.required).toEqual(['projectRoot', 'caller', 'taskId']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validator.attest
+// ---------------------------------------------------------------------------
+
+describe('validator.attest (T10511)', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  it('rejects callers that are not the validator role (auth)', async () => {
+    const { task, acRows } = await makeTaskWithAcs(accessor, env.tempDir, 'Auth test', ['A']);
+    const attestation = buildAttestation(
+      task.id,
+      acRows.map((r) => r.id),
+    );
+    const wrongRoles: AgentRole[] = ['orchestrator', 'lead', 'worker'];
+    for (const role of wrongRoles) {
+      const out = await validatorAttest.invoke({
+        projectRoot: env.tempDir,
+        caller: { role },
+        attestation,
+      });
+      expect(out.ok).toBe(false);
+      if (out.ok) throw new Error('unreachable');
+      expect(out.code).toBe('E_VALIDATOR_AUTH_ROLE');
+    }
+  });
+
+  it('writes one coverage binding per AC on happy path', async () => {
+    const { task, acRows } = await makeTaskWithAcs(accessor, env.tempDir, 'Happy', ['A', 'B', 'C']);
+    const out = await validatorAttest.invoke({
+      projectRoot: env.tempDir,
+      caller: { role: 'validator' },
+      attestation: buildAttestation(
+        task.id,
+        acRows.map((r) => r.id),
+      ),
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error('unreachable');
+    expect(out.bindingsWritten).toBe(3);
+    expect(out.bindingIds).toHaveLength(3);
+
+    const bindings = await accessor.getAcBindings(acRows.map((r) => r.id));
+    expect(bindings).toHaveLength(3);
+    expect(bindings.every((b) => b.bindingType === 'coverage')).toBe(true);
+  });
+
+  it('re-attest is idempotent — UNIQUE index collapses re-inserts', async () => {
+    const { task, acRows } = await makeTaskWithAcs(accessor, env.tempDir, 'Idempotent', ['A', 'B']);
+    const att = buildAttestation(
+      task.id,
+      acRows.map((r) => r.id),
+    );
+    await validatorAttest.invoke({
+      projectRoot: env.tempDir,
+      caller: { role: 'validator' },
+      attestation: att,
+    });
+    await validatorAttest.invoke({
+      projectRoot: env.tempDir,
+      caller: { role: 'validator' },
+      attestation: att,
+    });
+    const bindings = await accessor.getAcBindings(acRows.map((r) => r.id));
+    expect(bindings).toHaveLength(2); // not 4 — re-inserts collapsed
+  });
+
+  it('returns E_VALIDATOR_AC_NOT_FOUND when attestation references unknown AC ids', async () => {
+    const { task } = await makeTaskWithAcs(accessor, env.tempDir, 'Unknown', ['A']);
+    const bogus = randomUUID();
+    const out = await validatorAttest.invoke({
+      projectRoot: env.tempDir,
+      caller: { role: 'validator' },
+      attestation: buildAttestation(task.id, [bogus]),
+    });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error('unreachable');
+    expect(out.code).toBe('E_VALIDATOR_AC_NOT_FOUND');
+    expect(out.message).toContain(bogus);
+  });
+
+  it('returns E_VALIDATOR_ATTESTATION_INVALID for malformed envelopes', async () => {
+    const out = await validatorAttest.invoke({
+      projectRoot: env.tempDir,
+      caller: { role: 'validator' },
+      attestation: {
+        verdict: 'attest',
+        taskId: 'T1',
+      } as unknown as ValidatorAttestation,
+    });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error('unreachable');
+    expect(out.code).toBe('E_VALIDATOR_ATTESTATION_INVALID');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validator.reject
+// ---------------------------------------------------------------------------
+
+describe('validator.reject (T10511)', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  it('rejects callers that are not the validator role (auth)', async () => {
+    const { task, acRows } = await makeTaskWithAcs(accessor, env.tempDir, 'RejectAuth', ['A', 'B']);
+    const rejection = buildRejection(
+      task.id,
+      acRows.map((r) => r.id),
+    );
+    const out = await validatorReject.invoke({
+      projectRoot: env.tempDir,
+      caller: { role: 'worker' },
+      rejection,
+    });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error('unreachable');
+    expect(out.code).toBe('E_VALIDATOR_AUTH_ROLE');
+  });
+
+  it('emits structured envelope WITHOUT writing any bindings (negative invariant)', async () => {
+    const { task, acRows } = await makeTaskWithAcs(accessor, env.tempDir, 'NoBinds', ['A', 'B']);
+    const out = await validatorReject.invoke({
+      projectRoot: env.tempDir,
+      caller: { role: 'validator' },
+      rejection: buildRejection(
+        task.id,
+        acRows.map((r) => r.id),
+      ),
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error('unreachable');
+    expect(out.failingFindingCount).toBe(1);
+    expect(out.failingAcIds).toEqual([acRows[0]!.id]);
+    expect(out.rejection.verdict).toBe('reject');
+
+    // CRITICAL invariant — NO bindings exist after a rejection.
+    const bindings = await accessor.getAcBindings(acRows.map((r) => r.id));
+    expect(bindings).toHaveLength(0);
+  });
+
+  it('returns E_VALIDATOR_REJECTION_INVALID for malformed envelopes', async () => {
+    const out = await validatorReject.invoke({
+      projectRoot: env.tempDir,
+      caller: { role: 'validator' },
+      rejection: {
+        verdict: 'reject',
+        taskId: 'T1',
+      } as unknown as ValidatorRejection,
+    });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error('unreachable');
+    expect(out.code).toBe('E_VALIDATOR_REJECTION_INVALID');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validator.ac-pull
+// ---------------------------------------------------------------------------
+
+describe('validator.ac-pull (T10511)', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  it('returns ordered AC roster with bindingStatus=unsatisfied when no bindings exist', async () => {
+    const { task } = await makeTaskWithAcs(accessor, env.tempDir, 'PullEmpty', [
+      'first',
+      'second',
+      'third',
+    ]);
+    const out = await validatorAcPull.invoke({ projectRoot: env.tempDir, taskId: task.id });
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error('unreachable');
+    expect(out.acs).toHaveLength(3);
+    expect(out.acs.map((a) => a.alias)).toEqual(['AC1', 'AC2', 'AC3']);
+    expect(out.acs.map((a) => a.text)).toEqual(['first', 'second', 'third']);
+    expect(out.acs.every((a) => a.bindingStatus === 'unsatisfied')).toBe(true);
+  });
+
+  it('flips bindingStatus to satisfied for ACs that have at least one binding', async () => {
+    const { task, acRows } = await makeTaskWithAcs(accessor, env.tempDir, 'PullMixed', [
+      'A',
+      'B',
+      'C',
+    ]);
+    // Attest only AC1+AC3 via the validator-attest tool — leave AC2 uncovered.
+    await validatorAttest.invoke({
+      projectRoot: env.tempDir,
+      caller: { role: 'validator' },
+      attestation: buildAttestation(task.id, [acRows[0]!.id, acRows[2]!.id]),
+    });
+
+    const out = await validatorAcPull.invoke({ projectRoot: env.tempDir, taskId: task.id });
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error('unreachable');
+    const byAlias = new Map(out.acs.map((a) => [a.alias, a.bindingStatus]));
+    expect(byAlias.get('AC1')).toBe('satisfied');
+    expect(byAlias.get('AC2')).toBe('unsatisfied');
+    expect(byAlias.get('AC3')).toBe('satisfied');
+  });
+
+  it('returns empty acs array for an unknown taskId (no crash)', async () => {
+    const out = await validatorAcPull.invoke({
+      projectRoot: env.tempDir,
+      taskId: 'T-does-not-exist',
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error('unreachable');
+    expect(out.acs).toEqual([]);
+  });
+
+  it('returns E_INVALID_INPUT for empty taskId', async () => {
+    const out = await validatorAcPull.invoke({ projectRoot: env.tempDir, taskId: '' });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error('unreachable');
+    expect(out.code).toBe('E_INVALID_INPUT');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spawn.validator — auth-only tests (delegating to orchestrateSpawn is
+// integration-tested elsewhere; here we cover the gating logic).
+// ---------------------------------------------------------------------------
+
+describe('spawn.validator (T10511)', () => {
+  it('rejects non-orchestrator callers with E_VALIDATOR_SPAWN_AUTH_ROLE', async () => {
+    const wrongRoles: AgentRole[] = ['lead', 'worker', 'validator'];
+    for (const role of wrongRoles) {
+      const out = await spawnValidator.invoke({
+        projectRoot: '/tmp/does-not-matter',
+        caller: { role, tier: 1 },
+        taskId: 'T1234',
+      });
+      expect(out.ok).toBe(false);
+      if (out.ok) throw new Error('unreachable');
+      expect(out.code).toBe('E_VALIDATOR_SPAWN_AUTH_ROLE');
+    }
+  });
+
+  it('rejects tier-0 orchestrators with E_VALIDATOR_SPAWN_AUTH_TIER', async () => {
+    const out = await spawnValidator.invoke({
+      projectRoot: '/tmp/does-not-matter',
+      caller: { role: 'orchestrator', tier: 0 },
+      taskId: 'T1234',
+    });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error('unreachable');
+    expect(out.code).toBe('E_VALIDATOR_SPAWN_AUTH_TIER');
+  });
+
+  it('rejects empty taskId with E_INVALID_INPUT', async () => {
+    const out = await spawnValidator.invoke({
+      projectRoot: '/tmp/does-not-matter',
+      caller: { role: 'orchestrator', tier: 1 },
+      taskId: '',
+    });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error('unreachable');
+    expect(out.code).toBe('E_INVALID_INPUT');
+  });
+});

--- a/packages/core/src/tools/sdk/index.ts
+++ b/packages/core/src/tools/sdk/index.ts
@@ -42,6 +42,8 @@ export type { ManifestEntry } from './manifest.js';
 export { pipelineManifestAppend } from './manifest.js';
 // SpawnPrimitives SDK Tool
 export { buildAgentEnv, buildWorktreeSpawnResult } from './spawn-primitives.js';
+export type { SpawnValidatorInput, SpawnValidatorOutput } from './spawn-validator.js';
+export { spawnValidator } from './spawn-validator.js';
 export type {
   AcquireSlotOptions,
   ReleaseSlotFn,
@@ -59,3 +61,14 @@ export type {
 } from './tool-resolver.js';
 // ToolResolver SDK Tool
 export { CANONICAL_TOOLS, resolveToolCommand } from './tool-resolver.js';
+// Validator SDK Tools (T10511 — Saga T10377 SG-IVTR-AC-BINDING)
+export type {
+  ValidatorAcPullInput,
+  ValidatorAcPullOutput,
+  ValidatorAcRowView,
+} from './validator-ac-pull.js';
+export { validatorAcPull } from './validator-ac-pull.js';
+export type { ValidatorAttestInput, ValidatorAttestOutput } from './validator-attest.js';
+export { validatorAttest } from './validator-attest.js';
+export type { ValidatorRejectInput, ValidatorRejectOutput } from './validator-reject.js';
+export { validatorReject } from './validator-reject.js';

--- a/packages/core/src/tools/sdk/spawn-validator.ts
+++ b/packages/core/src/tools/sdk/spawn-validator.ts
@@ -1,0 +1,188 @@
+/**
+ * spawn.validator — SDK tool that spawns a Validator subagent.
+ *
+ * Auth model — orchestrator-tier-1+: only an agent with
+ * `caller.role === 'orchestrator'` AND `caller.tier >= 1` may invoke. This
+ * mirrors the existing spawn-tool tier model — workers / leads / tier-0
+ * orchestrators cannot directly spawn Validators.
+ *
+ * Delegates to the existing {@link orchestrateSpawn} pipeline with the
+ * Validator's task id (one task per Validator-review cycle). The spawn
+ * machinery provisions a worktree, builds the prompt preamble, and emits
+ * the same `WorktreeSpawnResult`-shaped envelope used by every other
+ * `cleo orchestrate spawn` call.
+ *
+ * Tier-protocol invariant: the resulting subagent runs with
+ * `CLEO_AGENT_ROLE=worker` at the harness level (Validator is a CANT-defined
+ * persona, NOT a separate harness role), but the spawned task's protocolType
+ * is set to `'validator'` so the prompt-builder applies the Validator stage
+ * guidance. See ADR-079-r* §validator-semantics.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, contracts-typed
+ * @task T10511
+ * @epic T10383 (E-VALIDATOR-ROLE)
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ */
+
+import type { AgentRole } from '@cleocode/contracts';
+import type { EngineResult } from '../../engine-result.js';
+import { orchestrateSpawn } from '../../orchestrate/spawn-ops.js';
+import type { JsonSchema, RegisteredSdkTool } from '../task-tools/sdk-tool.js';
+import { defineSdkTool } from '../task-tools/sdk-tool.js';
+
+/**
+ * Input envelope for the {@link spawnValidator} SDK tool.
+ *
+ * @task T10511
+ */
+export interface SpawnValidatorInput {
+  /** Absolute project root. */
+  projectRoot: string;
+  /** Caller identity — must be orchestrator at tier ≥ 1. */
+  caller: {
+    /** Canonical agent role — must be `'orchestrator'`. */
+    role: AgentRole;
+    /** Tier — must be ≥ 1. tier 0 orchestrators cannot spawn Validators. */
+    tier: 0 | 1 | 2;
+  };
+  /** Task ID the Validator will review. */
+  taskId: string;
+  /**
+   * Optional spawn-scope override. Defaults are inherited from the
+   * existing spawn pipeline.
+   */
+  spawnScope?: string;
+  /** Pass-through to {@link orchestrateSpawn} — defaults to false. */
+  noWorktree?: boolean;
+}
+
+/**
+ * Output envelope for the {@link spawnValidator} SDK tool.
+ *
+ * Discriminated by `ok`. On success, returns the underlying EngineResult
+ * (carrying the spawn prompt + worktree env-vars + cwd). On failure,
+ * returns a structured error code + message.
+ *
+ * @task T10511
+ */
+export type SpawnValidatorOutput =
+  | {
+      ok: true;
+      /** Raw EngineResult from `orchestrateSpawn`. */
+      result: EngineResult;
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+    };
+
+const INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    projectRoot: { type: 'string', description: 'Absolute project root.' },
+    caller: {
+      type: 'object',
+      properties: {
+        role: {
+          type: 'string',
+          description: "Agent role — must be 'orchestrator'.",
+        },
+        tier: { type: 'number', description: 'Orchestrator tier — must be ≥ 1.' },
+      },
+      required: ['role', 'tier'],
+    },
+    taskId: { type: 'string', description: 'Task the Validator will review.' },
+    spawnScope: { type: 'string' },
+    noWorktree: { type: 'boolean' },
+  },
+  required: ['projectRoot', 'caller', 'taskId'],
+};
+
+const OUTPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    ok: { type: 'boolean' },
+    result: { type: 'object', description: 'EngineResult from orchestrateSpawn (success only).' },
+    code: { type: 'string' },
+    message: { type: 'string' },
+  },
+  required: ['ok'],
+};
+
+/**
+ * Internal handler — auth + delegation to orchestrateSpawn.
+ *
+ * @task T10511
+ */
+async function spawnValidatorFn(input: SpawnValidatorInput): Promise<SpawnValidatorOutput> {
+  // 1. Role gate.
+  if (input.caller.role !== 'orchestrator') {
+    return {
+      ok: false,
+      code: 'E_VALIDATOR_SPAWN_AUTH_ROLE',
+      message: `spawn.validator requires caller.role='orchestrator' (got '${input.caller.role}')`,
+    };
+  }
+
+  // 2. Tier gate — orchestrator-tier-1+.
+  if (input.caller.tier < 1) {
+    return {
+      ok: false,
+      code: 'E_VALIDATOR_SPAWN_AUTH_TIER',
+      message: `spawn.validator requires caller.tier>=1 (got ${input.caller.tier})`,
+    };
+  }
+
+  // 3. Validate task id presence.
+  if (!input.taskId || input.taskId.trim().length === 0) {
+    return {
+      ok: false,
+      code: 'E_INVALID_INPUT',
+      message: 'taskId is required and must be non-empty',
+    };
+  }
+
+  // 4. Delegate to the existing spawn pipeline with protocolType='validator'.
+  // The downstream prompt-builder picks up the validator-stage guidance.
+  const result = await orchestrateSpawn(
+    input.taskId,
+    'validator',
+    input.projectRoot,
+    input.caller.tier,
+    input.noWorktree ?? false,
+    input.spawnScope,
+  );
+
+  return { ok: true, result };
+}
+
+/**
+ * Registered SDK tool: spawn.validator.
+ *
+ * @example
+ * ```typescript
+ * const out = await spawnValidator.invoke({
+ *   projectRoot: '/mnt/projects/cleocode',
+ *   caller: { role: 'orchestrator', tier: 1 },
+ *   taskId: 'T1234',
+ * });
+ * if (out.ok) console.log('validator spawned:', out.result);
+ * ```
+ *
+ * @task T10511
+ */
+export const spawnValidator: RegisteredSdkTool<
+  SpawnValidatorInput,
+  Promise<SpawnValidatorOutput>
+> = defineSdkTool({
+  identity: {
+    name: 'spawn-validator',
+    description:
+      'Orchestrator-tier-1+ SDK tool — spawns a Validator subagent via orchestrateSpawn.',
+    version: '1.0.0',
+  },
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OUTPUT_SCHEMA,
+  fn: spawnValidatorFn,
+});

--- a/packages/core/src/tools/sdk/validator-ac-pull.ts
+++ b/packages/core/src/tools/sdk/validator-ac-pull.ts
@@ -1,0 +1,176 @@
+/**
+ * validator.ac-pull — SDK tool that fetches a task's AC list plus current
+ * binding status, so a Validator can see at a glance which ACs already have
+ * coverage and which still need review.
+ *
+ * Returns the full AC roster with a derived `bindingStatus` field:
+ *   - `'satisfied'`   — at least one `evidence_ac_bindings` row exists for the AC
+ *   - `'unsatisfied'` — no bindings exist for the AC
+ *
+ * Read-only — no auth gate. Any role may invoke (the data is non-sensitive
+ * coverage metadata).
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, contracts-typed
+ * @task T10511
+ * @epic T10383 (E-VALIDATOR-ROLE)
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ */
+
+import { getTaskAccessor } from '../../store/data-accessor.js';
+import type { JsonSchema, RegisteredSdkTool } from '../task-tools/sdk-tool.js';
+import { defineSdkTool } from '../task-tools/sdk-tool.js';
+
+/**
+ * Input envelope for the {@link validatorAcPull} SDK tool.
+ *
+ * @task T10511
+ */
+export interface ValidatorAcPullInput {
+  /** Absolute project root. */
+  projectRoot: string;
+  /** Task ID to query — matches `tasks.id`. */
+  taskId: string;
+}
+
+/**
+ * Per-AC row in the {@link ValidatorAcPullOutput.acs} array.
+ *
+ * @task T10511
+ */
+export interface ValidatorAcRowView {
+  /** Stable UUID — matches `task_acceptance_criteria.id`. */
+  id: string;
+  /** Display alias — `AC<ordinal>`. */
+  alias: string;
+  /** 1-based ordinal. */
+  ordinal: number;
+  /** AC statement text. */
+  text: string;
+  /** Derived: at least one binding exists OR not. */
+  bindingStatus: 'satisfied' | 'unsatisfied';
+}
+
+/**
+ * Output envelope for the {@link validatorAcPull} SDK tool.
+ *
+ * Discriminated by `ok`. On success, returns the task id and ordered AC
+ * roster with binding status. On failure (e.g. unknown task id), returns
+ * a structured error code + message.
+ *
+ * @task T10511
+ */
+export type ValidatorAcPullOutput =
+  | {
+      ok: true;
+      taskId: string;
+      acs: ValidatorAcRowView[];
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+    };
+
+const INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    projectRoot: { type: 'string', description: 'Absolute project root.' },
+    taskId: { type: 'string', description: 'Task ID to query.' },
+  },
+  required: ['projectRoot', 'taskId'],
+};
+
+const OUTPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    ok: { type: 'boolean' },
+    taskId: { type: 'string' },
+    acs: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          alias: { type: 'string', description: 'Display alias AC<ordinal>.' },
+          ordinal: { type: 'number' },
+          text: { type: 'string' },
+          bindingStatus: {
+            type: 'string',
+            description: "'satisfied' | 'unsatisfied' — derived from binding rows.",
+          },
+        },
+        required: ['id', 'alias', 'ordinal', 'text', 'bindingStatus'],
+      },
+    },
+    code: { type: 'string' },
+    message: { type: 'string' },
+  },
+  required: ['ok'],
+};
+
+/**
+ * Internal handler — task-AC read + binding aggregation.
+ *
+ * @task T10511
+ */
+async function validatorAcPullFn(input: ValidatorAcPullInput): Promise<ValidatorAcPullOutput> {
+  if (!input.taskId || input.taskId.trim().length === 0) {
+    return {
+      ok: false,
+      code: 'E_INVALID_INPUT',
+      message: 'taskId is required and must be non-empty',
+    };
+  }
+
+  const accessor = await getTaskAccessor(input.projectRoot);
+  const acs = await accessor.getAcRows(input.taskId);
+
+  if (acs.length === 0) {
+    // Caller can disambiguate "task exists but no ACs" vs "unknown task" via
+    // taskExists if needed; we treat both as a valid empty result.
+    return { ok: true, taskId: input.taskId, acs: [] };
+  }
+
+  const bindings = await accessor.getAcBindings(acs.map((ac) => ac.id));
+  const satisfiedIds = new Set(bindings.map((b) => b.acId));
+
+  const acsView: ValidatorAcRowView[] = acs.map((ac) => ({
+    id: ac.id,
+    alias: `AC${ac.ordinal}`,
+    ordinal: ac.ordinal,
+    text: ac.text,
+    bindingStatus: satisfiedIds.has(ac.id) ? 'satisfied' : 'unsatisfied',
+  }));
+
+  return { ok: true, taskId: input.taskId, acs: acsView };
+}
+
+/**
+ * Registered SDK tool: validator.ac-pull.
+ *
+ * @example
+ * ```typescript
+ * const out = await validatorAcPull.invoke({
+ *   projectRoot: '/mnt/projects/cleocode',
+ *   taskId: 'T1234',
+ * });
+ * if (out.ok) {
+ *   for (const ac of out.acs) console.log(`${ac.alias}: ${ac.bindingStatus}`);
+ * }
+ * ```
+ *
+ * @task T10511
+ */
+export const validatorAcPull: RegisteredSdkTool<
+  ValidatorAcPullInput,
+  Promise<ValidatorAcPullOutput>
+> = defineSdkTool({
+  identity: {
+    name: 'validator-ac-pull',
+    description: 'Read-only SDK tool — fetches a task’s AC list with current binding status.',
+    version: '1.0.0',
+  },
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OUTPUT_SCHEMA,
+  fn: validatorAcPullFn,
+});

--- a/packages/core/src/tools/sdk/validator-attest.ts
+++ b/packages/core/src/tools/sdk/validator-attest.ts
@@ -1,0 +1,223 @@
+/**
+ * validator.attest — SDK tool wrapping the Validator's "attest" verdict path.
+ *
+ * Accepts a fully-formed {@link ValidatorAttestation} envelope (verdict='attest',
+ * one finding per AC, all with status='pass') and writes one
+ * `evidence_ac_bindings` row per AC with `binding_type='coverage'`. The write
+ * is wrapped in a transaction so partial-bindings cannot leak when the AC
+ * existence check fails mid-pass.
+ *
+ * Auth model — terminal: only an agent with `caller.role === 'validator'` may
+ * invoke this tool. Returns `E_VALIDATOR_AUTH_ROLE` otherwise.
+ *
+ * Per council §3.1 ADR-D rejection: NO new tool registry — uses the existing
+ * `defineSdkTool` factory. Tier scoping is enforced in the tool's `fn`.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, contracts-typed
+ * @task T10511
+ * @epic T10383 (E-VALIDATOR-ROLE)
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  type AgentRole,
+  type ValidatorAttestation,
+  validatorAttestationSchema,
+} from '@cleocode/contracts';
+import { getTaskAccessor } from '../../store/data-accessor.js';
+import type { JsonSchema, RegisteredSdkTool } from '../task-tools/sdk-tool.js';
+import { defineSdkTool } from '../task-tools/sdk-tool.js';
+
+/**
+ * Input envelope for the {@link validatorAttest} SDK tool.
+ *
+ * @task T10511
+ */
+export interface ValidatorAttestInput {
+  /** Absolute path to the project root. */
+  projectRoot: string;
+  /** Caller identity — used for role-based auth. */
+  caller: {
+    /** Canonical agent role; only `'validator'` may invoke. */
+    role: AgentRole;
+  };
+  /** Fully-formed attestation envelope to persist. */
+  attestation: ValidatorAttestation;
+}
+
+/**
+ * Output envelope for the {@link validatorAttest} SDK tool.
+ *
+ * Discriminated by `ok`. On success, contains the count of coverage bindings
+ * written. On failure, contains a structured error code + message.
+ *
+ * @task T10511
+ */
+export type ValidatorAttestOutput =
+  | {
+      ok: true;
+      /** Count of `evidence_ac_bindings` rows persisted (one per AC). */
+      bindingsWritten: number;
+      /** UUIDs assigned to each binding row. */
+      bindingIds: string[];
+      /** ISO-8601 timestamp the attestation was processed. */
+      processedAt: string;
+    }
+  | {
+      ok: false;
+      /** Structured error code (E_VALIDATOR_*). */
+      code: string;
+      /** Human-readable failure description. */
+      message: string;
+    };
+
+const INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    projectRoot: { type: 'string', description: 'Absolute project root.' },
+    caller: {
+      type: 'object',
+      properties: {
+        role: { type: 'string', description: "Agent role — only 'validator' authorized." },
+      },
+      required: ['role'],
+    },
+    attestation: {
+      type: 'object',
+      description: 'ValidatorAttestation envelope per validatorAttestationSchema.',
+    },
+  },
+  required: ['projectRoot', 'caller', 'attestation'],
+};
+
+const OUTPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    ok: { type: 'boolean', description: 'Discriminant — true on success.' },
+    bindingsWritten: { type: 'number', description: 'Coverage bindings persisted.' },
+    bindingIds: { type: 'array', items: { type: 'string' } },
+    processedAt: { type: 'string', description: 'ISO-8601 timestamp.' },
+    code: { type: 'string', description: 'Error code (failure only).' },
+    message: { type: 'string', description: 'Error message (failure only).' },
+  },
+  required: ['ok'],
+};
+
+/**
+ * Build a stable composite evidence-atom id for a Validator attestation.
+ *
+ * The atom id format is `validator:<validatorId>:<taskId>` so multiple
+ * Validators attesting the same task produce distinct binding rows, but
+ * the same Validator re-attesting collapses idempotently against the
+ * UNIQUE (evidence_atom_id, ac_id, binding_type) index.
+ *
+ * @task T10511
+ */
+function buildValidatorAtomId(validatorId: string, taskId: string): string {
+  return `validator:${validatorId}:${taskId}`;
+}
+
+/**
+ * Internal handler — auth, schema-validate, AC-existence check, transactional write.
+ *
+ * @task T10511
+ */
+async function validatorAttestFn(input: ValidatorAttestInput): Promise<ValidatorAttestOutput> {
+  // 1. Auth: terminal role check.
+  if (input.caller.role !== 'validator') {
+    return {
+      ok: false,
+      code: 'E_VALIDATOR_AUTH_ROLE',
+      message: `validator.attest requires caller.role='validator' (got '${input.caller.role}')`,
+    };
+  }
+
+  // 2. Runtime schema validation (defensive — the contract guards via Zod).
+  const parsed = validatorAttestationSchema.safeParse(input.attestation);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      code: 'E_VALIDATOR_ATTESTATION_INVALID',
+      message: `attestation failed schema validation: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
+    };
+  }
+
+  const attestation = parsed.data;
+  const accessor = await getTaskAccessor(input.projectRoot);
+  const atomId = buildValidatorAtomId(attestation.validatorId, attestation.taskId);
+
+  // 3. AC existence check — every finding.acId MUST resolve to a real
+  // task_acceptance_criteria row owned by attestation.taskId.
+  const acs = await accessor.getAcRows(attestation.taskId);
+  const acIdSet = new Set(acs.map((ac) => ac.id));
+  const findingAcIds = attestation.findings.map((f) => f.acId);
+  const missing = findingAcIds.filter((id) => !acIdSet.has(id));
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      code: 'E_VALIDATOR_AC_NOT_FOUND',
+      message: `attestation references unknown AC ids on task ${attestation.taskId}: ${missing.join(', ')}`,
+    };
+  }
+
+  // 4. Transactional write — coverage binding per AC.
+  const bindingIds: string[] = [];
+  await accessor.transaction(async (tx) => {
+    const rows = findingAcIds.map((acId) => {
+      const id = randomUUID();
+      bindingIds.push(id);
+      return {
+        id,
+        evidenceAtomId: atomId,
+        acId,
+        bindingType: 'coverage' as const,
+      };
+    });
+    await tx.insertAcBindings(rows);
+  });
+
+  return {
+    ok: true,
+    bindingsWritten: bindingIds.length,
+    bindingIds,
+    processedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Registered SDK tool: validator.attest.
+ *
+ * @example
+ * ```typescript
+ * const out = await validatorAttest.invoke({
+ *   projectRoot: '/mnt/projects/cleocode',
+ *   caller: { role: 'validator' },
+ *   attestation: {
+ *     verdict: 'attest',
+ *     taskId: 'T1234',
+ *     validatorId: 'validator-prime',
+ *     findings: [{ acId: 'uuid-1', status: 'pass', reasoning: 'ok', checkedAt: '...' }],
+ *     attestedAt: '2026-05-24T00:00:00Z',
+ *     schemaVersion: '1',
+ *   },
+ * });
+ * if (out.ok) console.log(`wrote ${out.bindingsWritten} coverage bindings`);
+ * ```
+ *
+ * @task T10511
+ */
+export const validatorAttest: RegisteredSdkTool<
+  ValidatorAttestInput,
+  Promise<ValidatorAttestOutput>
+> = defineSdkTool({
+  identity: {
+    name: 'validator-attest',
+    description:
+      'Validator-only SDK tool — writes coverage bindings for an attested ValidatorVerdict.',
+    version: '1.0.0',
+  },
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OUTPUT_SCHEMA,
+  fn: validatorAttestFn,
+});

--- a/packages/core/src/tools/sdk/validator-reject.ts
+++ b/packages/core/src/tools/sdk/validator-reject.ts
@@ -1,0 +1,185 @@
+/**
+ * validator.reject — SDK tool wrapping the Validator's "reject" verdict path.
+ *
+ * Accepts a fully-formed {@link ValidatorRejection} envelope (verdict='reject',
+ * at least one finding with status='fail' or 'inconclusive'), validates it
+ * against the Zod schema, and emits a structured rejection envelope.
+ *
+ * IMPORTANT: validator.reject does NOT write `evidence_ac_bindings` rows —
+ * rejection is the ABSENCE of binding. The downstream AC-coverage gate
+ * (T10509) sees no coverage rows for the rejected ACs and refuses
+ * `cleo complete` accordingly.
+ *
+ * Auth model — terminal: only an agent with `caller.role === 'validator'` may
+ * invoke this tool. Returns `E_VALIDATOR_AUTH_ROLE` otherwise.
+ *
+ * @arch SDK Tool (Category B) — harness-agnostic, contracts-typed
+ * @task T10511
+ * @epic T10383 (E-VALIDATOR-ROLE)
+ * @saga T10377 (SG-IVTR-AC-BINDING)
+ */
+
+import {
+  type AgentRole,
+  type ValidatorRejection,
+  validatorRejectionSchema,
+} from '@cleocode/contracts';
+import type { JsonSchema, RegisteredSdkTool } from '../task-tools/sdk-tool.js';
+import { defineSdkTool } from '../task-tools/sdk-tool.js';
+
+/**
+ * Input envelope for the {@link validatorReject} SDK tool.
+ *
+ * @task T10511
+ */
+export interface ValidatorRejectInput {
+  /** Absolute project root (kept for symmetry with attest; unused for reads). */
+  projectRoot: string;
+  /** Caller identity — used for role-based auth. */
+  caller: {
+    /** Canonical agent role; only `'validator'` may invoke. */
+    role: AgentRole;
+  };
+  /** Fully-formed rejection envelope. */
+  rejection: ValidatorRejection;
+}
+
+/**
+ * Output envelope for the {@link validatorReject} SDK tool.
+ *
+ * Discriminated by `ok`. On success, echoes the rejection envelope so
+ * downstream callers can persist or surface it. On failure, contains a
+ * structured error code + message. NO bindings are ever written.
+ *
+ * @task T10511
+ */
+export type ValidatorRejectOutput =
+  | {
+      ok: true;
+      /** Echo of the validated rejection envelope. */
+      rejection: ValidatorRejection;
+      /** Count of failing or inconclusive findings — for summary UIs. */
+      failingFindingCount: number;
+      /** AC ids that did not pass — useful for downstream remediation routing. */
+      failingAcIds: string[];
+      /** ISO-8601 timestamp the rejection was processed. */
+      processedAt: string;
+    }
+  | {
+      ok: false;
+      /** Structured error code (E_VALIDATOR_*). */
+      code: string;
+      /** Human-readable failure description. */
+      message: string;
+    };
+
+const INPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    projectRoot: { type: 'string', description: 'Absolute project root.' },
+    caller: {
+      type: 'object',
+      properties: {
+        role: { type: 'string', description: "Agent role — only 'validator' authorized." },
+      },
+      required: ['role'],
+    },
+    rejection: {
+      type: 'object',
+      description: 'ValidatorRejection envelope per validatorRejectionSchema.',
+    },
+  },
+  required: ['projectRoot', 'caller', 'rejection'],
+};
+
+const OUTPUT_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    ok: { type: 'boolean' },
+    rejection: { type: 'object', description: 'Echo of validated rejection (success only).' },
+    failingFindingCount: { type: 'number' },
+    failingAcIds: { type: 'array', items: { type: 'string' } },
+    processedAt: { type: 'string' },
+    code: { type: 'string', description: 'Error code (failure only).' },
+    message: { type: 'string', description: 'Error message (failure only).' },
+  },
+  required: ['ok'],
+};
+
+/**
+ * Internal handler — auth + schema validation. NO database writes.
+ *
+ * @task T10511
+ */
+async function validatorRejectFn(input: ValidatorRejectInput): Promise<ValidatorRejectOutput> {
+  // 1. Auth.
+  if (input.caller.role !== 'validator') {
+    return {
+      ok: false,
+      code: 'E_VALIDATOR_AUTH_ROLE',
+      message: `validator.reject requires caller.role='validator' (got '${input.caller.role}')`,
+    };
+  }
+
+  // 2. Schema validation.
+  const parsed = validatorRejectionSchema.safeParse(input.rejection);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      code: 'E_VALIDATOR_REJECTION_INVALID',
+      message: `rejection failed schema validation: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
+    };
+  }
+
+  const rejection = parsed.data;
+  const failing = rejection.findings.filter((f) => f.status !== 'pass');
+
+  // 3. Build structured echo envelope. NO bindings written.
+  return {
+    ok: true,
+    rejection,
+    failingFindingCount: failing.length,
+    failingAcIds: failing.map((f) => f.acId),
+    processedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Registered SDK tool: validator.reject.
+ *
+ * @example
+ * ```typescript
+ * const out = await validatorReject.invoke({
+ *   projectRoot: '/mnt/projects/cleocode',
+ *   caller: { role: 'validator' },
+ *   rejection: {
+ *     verdict: 'reject',
+ *     taskId: 'T1234',
+ *     validatorId: 'validator-prime',
+ *     findings: [
+ *       { acId: 'uuid-1', status: 'fail', reasoning: 'no test', checkedAt: '...' },
+ *     ],
+ *     summary: 'AC1 unsatisfied — test missing.',
+ *     rejectedAt: '2026-05-24T00:00:00Z',
+ *     schemaVersion: '1',
+ *   },
+ * });
+ * if (out.ok) console.log(`rejected ${out.failingFindingCount} ACs`);
+ * ```
+ *
+ * @task T10511
+ */
+export const validatorReject: RegisteredSdkTool<
+  ValidatorRejectInput,
+  Promise<ValidatorRejectOutput>
+> = defineSdkTool({
+  identity: {
+    name: 'validator-reject',
+    description:
+      'Validator-only SDK tool — emits structured rejection envelope. Writes no bindings.',
+    version: '1.0.0',
+  },
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OUTPUT_SCHEMA,
+  fn: validatorRejectFn,
+});


### PR DESCRIPTION
## Summary

Ships the four IVTR-feeding SDK tools per **T10511** (Saga T10377 SG-IVTR-AC-BINDING, Epic T10383 E-VALIDATOR-ROLE):

- **`validator.attest`** — terminal validator-role tool. Schema-validates a `ValidatorAttestation`, checks every finding.acId resolves to a real `task_acceptance_criteria` row, transactionally writes one `evidence_ac_bindings` row per AC with `binding_type='coverage'`. UNIQUE index collapses idempotent re-attests.
- **`validator.reject`** — terminal validator-role tool. Schema-validates a `ValidatorRejection`, emits structured echo envelope. **CRITICAL invariant** — writes ZERO `evidence_ac_bindings` rows.
- **`validator.ac-pull`** — read-only tool. Returns AC roster with `bindingStatus='satisfied'|'unsatisfied'` per AC.
- **`spawn.validator`** — orchestrator-tier-1+ tool. Delegates to `orchestrateSpawn(taskId, 'validator', …)` after role + tier auth.

Per-tier scoping is enforced inside each tool's `fn` — no new `SdkToolIdentity` fields, no parallel registry, no parallel tool-registration mechanism (per council §3.1 ADR-D rejection). All four use the existing `defineSdkTool` factory.

Adds one new `TransactionAccessor` method — `insertAcBindings(rows)` — to contracts + sqlite-data-accessor. Idempotent via `ON CONFLICT DO NOTHING` against the existing `uq_evidence_ac_bindings_atom_ac_type` index.

## Test plan

- [x] 19 new unit tests in `packages/core/src/tools/__tests__/sdk/validator-tools.test.ts` — all pass
- [x] Registration sanity: identity name + version regex + required input fields
- [x] `validator.attest` — rejects wrong role (orchestrator/lead/worker → `E_VALIDATOR_AUTH_ROLE`); writes 1 coverage binding per AC on happy path; idempotent re-attest collapses via UNIQUE index; `E_VALIDATOR_AC_NOT_FOUND` for unknown AC ids; `E_VALIDATOR_ATTESTATION_INVALID` for malformed envelopes
- [x] `validator.reject` — wrong-role rejection; happy-path returns failingFindingCount + failingAcIds; **NO bindings created after rejection** (negative invariant verified); `E_VALIDATOR_REJECTION_INVALID` for malformed
- [x] `validator.ac-pull` — empty-ACs returns `bindingStatus='unsatisfied'`; mixed-binding scenario (attest only AC1+AC3) flips status correctly; unknown taskId returns empty acs; empty taskId → `E_INVALID_INPUT`
- [x] `spawn.validator` — wrong role → `E_VALIDATOR_SPAWN_AUTH_ROLE`; tier-0 → `E_VALIDATOR_SPAWN_AUTH_TIER`; empty taskId → `E_INVALID_INPUT`
- [x] Adjacent regression suite (70 tests across validator-tools / ac-coverage-gate / satisfies-validator) — all pass
- [x] Biome clean, `pnpm --filter @cleocode/core run build` green
- [x] Architectural gates: `lint-no-direct-db-open` clean, `lint-contracts-fan-out` clean, `lint-no-raw-define-command --check` baseline-clean (138 ≤ baseline 139)

## Pre-existing failures (NOT caused by this PR)

- `src/store/__tests__/t10503-evidence-ac-bindings-schema.test.ts > honours the UNIQUE … constraint` (FOREIGN KEY constraint failed) — confirmed pre-existing via stash bisect on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)