### PR TITLE
fix(T10384): unblock release-prepare workflow + t9948 changeset hygiene

### DIFF
--- a/.changeset/t9948.md
+++ b/.changeset/t9948.md
@@ -1,5 +1,5 @@
 ---
-id: T9948
+id: t9948
 tasks: [T9948]
 kind: fix
 summary: "`cleo briefing` no longer holds DB writer lock for minutes (unref opportunistic dream timer + structured trace)"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -80,13 +80,13 @@ jobs:
     steps:
       # R-263: third-party Actions pinned to major+minor.
       - name: Checkout
-        uses: actions/checkout@v4.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
         timeout-minutes: 5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4.0
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
         timeout-minutes: 3
@@ -130,7 +130,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -151,7 +151,7 @@ jobs:
         timeout-minutes: 2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4.0
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
         timeout-minutes: 3
@@ -263,7 +263,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Two pre-existing blockers preventing `cleo release open` for
**v2026.5.122** (SG-IVTR-AC-BINDING saga close-out, T10384):

1. **`release-prepare.yml` action versions don't exist.** The workflow
   pinned `actions/checkout@v4.1` and `actions/setup-node@v4.0`. Neither
   tag exists in the upstream registry — only major-only `v4` or
   specific patches like `v4.1.7`. R-263 comment claims major+minor
   pinning, but in practice major pin is the only working form.
   Repins both to `@v4`.

2. **`.changeset/T9948.md` uses uppercase id.** The release changeset
   parser rejects with `E_CHANGESET_YAML_INVALID` — kebab-case (lowercase,
   digits, hyphens) is required. Renames to `t9948.md` and fixes the
   `id:` field. `lint-changesets.mjs` is more permissive than the
   release-plan parser; the divergence is pre-existing and not in
   scope for this hotfix.

## Why hotfix path

Both blockers were discovered mid-saga during T10384 close-out. Without
them, no release ships via the canonical pipeline. Filing as a hotfix
off main so the v2026.5.122 ship can proceed without waiting for the
T10500 reconcile cleanup.

## Saga reference

- Saga: T10377 (SG-IVTR-AC-BINDING)
- Epic: T10384 (E-IVTR-CLOSEOUT)
- Blocks resolved: closeout block 3 (release ship)

## Test plan

- [x] `actions/checkout@v4` resolves on GitHub Actions registry
- [x] `actions/setup-node@v4` resolves on GitHub Actions registry
- [x] `cleo release plan v2026.5.122 --epic T10377` parses all
      changesets cleanly post-rename
- [ ] Post-merge: re-dispatch `cleo release open v2026.5.122` and
      confirm Preflight job runs to completion