### PR TITLE
fix(T10384): add pnpm/action-setup to release-prepare.yml

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -85,6 +85,12 @@ jobs:
           fetch-depth: 0
         timeout-minutes: 5
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+        timeout-minutes: 2
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -148,6 +154,12 @@ jobs:
           BRANCH="release/${{ inputs.version }}"
           git checkout -b "$BRANCH"
           echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+        timeout-minutes: 2
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
         timeout-minutes: 2
 
       - name: Set up Node.js


### PR DESCRIPTION
## Summary

Second sequential blocker for `cleo release open v2026.5.122` (after
PR #795 fixed action versions). The release-prepare.yml workflow calls
`pnpm install --frozen-lockfile` in both Preflight and Prepare-bump-PR
jobs but never bootstraps pnpm itself. Result: `pnpm: command not found`
(exit 127) on every dispatch.

Adds `pnpm/action-setup@v4` with `version: 9` AFTER checkout and BEFORE
`actions/setup-node@v4` in both jobs. This is the standard pnpm + setup-node
ordering documented at https://pnpm.io/continuous-integration#github-actions.

## Test plan

- [x] `pnpm/action-setup@v4` resolves on GH Actions registry
- [x] Preflight job: checkout → pnpm setup → node setup → install
- [x] Prepare bump-PR job: checkout → branch cut → pnpm setup → node setup → install
- [ ] Post-merge: re-dispatch `cleo release open v2026.5.122` and confirm
      Preflight job reaches Test step

## Saga reference

- Saga: T10377 (SG-IVTR-AC-BINDING)
- Epic: T10384 (E-IVTR-CLOSEOUT)
- Block: closeout block 3 (release ship) — second blocker after PR #795