### PR TITLE
fix(T10384): pnpm/action-setup reads version from package.json

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -87,8 +87,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
         timeout-minutes: 2
 
       - name: Set up Node.js
@@ -158,8 +156,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
         timeout-minutes: 2
 
       - name: Set up Node.js


### PR DESCRIPTION
## Summary

Third sequential blocker. PR #796 added `pnpm/action-setup@v4` with
explicit `version: 9`, but the project's `package.json` already pins
`packageManager: pnpm@10.30.0`. Action-setup errors with
**ERR_PNPM_BAD_PM_VERSION** ("Multiple versions of pnpm specified")
on every dispatch.

Removes the explicit `with: version:` so action-setup reads from
`packageManager` per its default behaviour.

## Saga reference

- Saga: T10377 (SG-IVTR-AC-BINDING)
- Epic: T10384 (E-IVTR-CLOSEOUT)
- Block: closeout block 3 — third hotfix after PR #795 (action versions)
  and PR #796 (missing pnpm bootstrap).

## Test plan

- [x] action-setup default reads packageManager from package.json
- [ ] Re-dispatch `cleo release open v2026.5.122` post-merge