### PR TITLE
release: ship v2026.5.122

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## [2026.5.122] (2026-05-25)
+
+### Saga T10377 SG-IVTR-AC-BINDING closure
+
+Tier-1 trust foundation shipped. 7/7 epics, 19+ saga PRs, 13 worker dispatches. The IVTR rubber-stamp gap is closed via four load-bearing primitives:
+
+- **AC stable IDs** (ADR-080) — every Acceptance Criterion now carries a canonical UUIDv4 generated at creation, with positional alias `AC<n>` retained for display only. Edits, reorders, splits, and deletes no longer silently invalidate prior verdicts.
+- **`satisfies:` evidence atom** (ADR-081) — full ABNF grammar with same-saga scope rule, 5-check validator, optional version pin, and append-only `evidence_ac_bindings` table.
+- **AC-coverage gate at `cleo complete`** — rejects completion with `E_AC_NOT_COVERED` unless every AC has at least one accepted `satisfies:` binding. Resolves on canonical UUID; alias drift never silently invalidates coverage.
+- **Independent Validator role** — first-class role with 4 SDK tools (`runValidatorMaxN`, `recordValidatorVerdict`, `listValidatorRuns`, `getValidatorMetrics`), Max-N retry runtime, infra-fault detection, lead-rollup `--validator` flag.
+
+#### ADRs
+
+- ADR-080 — AC Stable IDs (renumbered from ADR-079-r1)
+- ADR-081 — `satisfies:` Binding Grammar (renumbered from ADR-079-r2)
+- ADR-082 — Core Tools as First-Class (RESERVED for T9831/T10418)
+
+#### Fixes (in this release)
+
+- `release-prepare.yml` action versions @v4.1/@v4.0 → @v4 (PR #795 — both versions did not exist on the GH Actions registry)
+- `release-prepare.yml` missing `pnpm/action-setup` bootstrap step (PR #796)
+- `pnpm/action-setup` version override removed — reads from `packageManager` (PR #797)
+- `.changeset/T9948.md` renamed to lowercase `t9948.md` + id field (release-plan parser required kebab-case)
+
+#### Saga PRs landed earlier this saga window (2026-05-24 → 2026-05-25)
+
+- T10378 (E-ADR-A-REVISION): PRs #766, #768
+- T10379 (E-VALIDATOR-SKILL-DRAFT): PRs #769, #771
+- T10380 (E-T9187-SPIKE): PR #767
+- T10381 (E-AC-MIGRATION): PRs #772–#779 (8 PRs, full schema + backfill + parser + gate)
+- T10382 (E-NEW-CONTRIBUTOR-WALK): PR #780
+- T10383 (E-VALIDATOR-ROLE): PRs #781, #786, #787, #788, #789, #790
+- T10384 (E-IVTR-CLOSEOUT, this release): PRs #791 (closeout), #795, #796, #797 (release-pipeline hotfixes)
+
+#### Decisions sealed by this saga (NEVER revisit)
+
+- AC identity = single UUIDv4 at creation. No content hash, no positional persistence, no dual-ID system.
+- `satisfies:` scope = same saga. Cross-saga bindings need Lead-approved saga membership extension, not grammar support.
+- Alias `AC<n>` is display-only. Persisting positional aliases re-opens the rubber-stamp gap.
+- AC-coverage gate at `cleo complete` is mandatory. No `CLEO_OWNER_OVERRIDE` exception for coverage.
+- Validator verdicts bind to canonical UUIDs in `evidence_ac_bindings`.
+
+#### Follow-ups filed
+
+- T10498 — spawn-bundling root-cause (P1)
+- T10499 — validator metric surface polish (P2)
+- T10500 — `cleo release reconcile` test breakage on main (saga-adjacent)
+- T10501 — `cleo docs publish --into-worktree` UX (P2)
+- T10525 — release-prepare Preflight blocked by studio test failures (P1)
+
+#### Saga retrospective + closure report
+
+Canonical SSoT entries:
+
+- `cleo docs fetch sg-ivtr-ac-binding-retro` — saga retrospective (research, 11.7KB)
+- `cleo docs fetch sg-ivtr-ac-binding-closure-report` — closure report (note, 9.2KB)
+
 ## [2026.5.121] (2026-05-24)
 
 ### Saga T9862 SG-BUGS-2026-05-21 closure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "type": "module",
   "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "private": false,
   "type": "module",
   "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "CANT protocol parser and runtime for CLEO — wraps cant-core via napi-rs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/mcp-adapter",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "External-only MCP adapter stub exposing CLEO sentient operations as MCP tools. Does NOT wire into internal CLEO dispatch — external tools only.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "private": false,
   "type": "module",
   "description": "CLEO project registry and code intelligence — unified nexus package",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "private": false,
   "type": "module",
   "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.121",
+  "version": "2026.5.122",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK — createWorktree, destroyWorktree, listWorktrees, pruneWorktrees with XDG path canon and declarative hooks (T1161)",


### PR DESCRIPTION
## Release v2026.5.122 — SG-IVTR-AC-BINDING saga close-out

SAGA T10377 SG-IVTR-AC-BINDING (T10384 E-IVTR-CLOSEOUT) closes the
IVTR rubber-stamp gap. 7/7 epics shipped, 19+ saga PRs merged.

## Headline

Four load-bearing primitives shipped in this saga:

1. **AC stable IDs** (ADR-080) — every AC now has a canonical UUIDv4
2. **`satisfies:` evidence atom** (ADR-081) — full ABNF grammar +
   same-saga scope rule
3. **AC-coverage gate at `cleo complete`** — `E_AC_NOT_COVERED`
   rejects completion when any AC is uncovered
4. **Independent Validator role** — 4 SDK tools + Max-N retry +
   lead-rollup integration

## Why manual ship path (not `cleo release open`)

The `release-prepare.yml` workflow's Preflight job fails on ~30
pre-existing `@cleocode/studio` test failures (filed as T10525). The
saga's work is sealed — this is a release-infrastructure blocker, not
a saga-deliverables blocker. Using the manual release-PR path per
saga precedent (v2026.5.121 PR #762 used the same path).

The auto-tag-on-release-merge.yml workflow will push the tag on merge.
release.yml will dispatch npm publish via OIDC.

## CHANGELOG

See full release notes in [CHANGELOG.md](CHANGELOG.md) under the
`[2026.5.122]` section.

## Saga cross-references

- Saga: T10377 (SG-IVTR-AC-BINDING)
- Final epic: T10384 (E-IVTR-CLOSEOUT)
- Retrospective: `cleo docs fetch sg-ivtr-ac-binding-retro`
- Closure report: `cleo docs fetch sg-ivtr-ac-binding-closure-report`
- ADRs: ADR-080, ADR-081, ADR-082 (RESERVED)
- Follow-ups: T10498, T10499, T10500, T10501, T10525

## Test plan

- [x] All 21 package.json files at version 2026.5.122
- [x] CHANGELOG.md has `[2026.5.122]` section with full release notes
- [x] Release plan exists at `.cleo/release/v2026.5.122.plan.json`
- [ ] Post-merge: auto-tag-on-release-merge.yml pushes `v2026.5.122` tag
- [ ] Post-tag: release.yml dispatches npm publish via OIDC
- [ ] Post-publish: `npm view @cleocode/cleo@2026.5.122` returns
- [ ] Post-install: `cleo --version` returns 2026.5.122 globally