### PR TITLE
feat(T10533): add ct-skill-validator v2 portability checks

### DIFF
--- a/packages/core/src/__tests__/t10079-primary-worktree-root.test.ts
+++ b/packages/core/src/__tests__/t10079-primary-worktree-root.test.ts
@@ -48,7 +48,7 @@ describe('T10079 primary worktree root routing', () => {
     const routing = resolveWorktreeRouting(secondarySubdir);
 
     expect(routing.isWorktree).toBe(true);
-    expect(routing.worktreePath).toBe(secondary);
+    expect(routing.worktreePath).toBe(realpathSync(secondary));
     expect(routing.canonicalRoot).toBe(realpathSync(primary));
   });
 });

--- a/packages/core/src/sentient/detectors/__tests__/context-staleness.test.ts
+++ b/packages/core/src/sentient/detectors/__tests__/context-staleness.test.ts
@@ -59,6 +59,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -117,7 +118,10 @@ describe('detectContextStaleness', () => {
 
   it('returns null exactly at the staleness boundary (age == threshold)', async () => {
     // Age strictly equal to the threshold is NOT stale; detector emits only when age > threshold.
-    const detectedAt = new Date(Date.now() - CONTEXT_STALENESS_MS).toISOString();
+    const now = new Date('2026-05-24T00:00:00.000Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const detectedAt = new Date(now.getTime() - CONTEXT_STALENESS_MS).toISOString();
     mockLoadProjectContext.mockResolvedValue(makeContext(detectedAt));
 
     const proposal = await detectContextStaleness(PROJECT_ROOT);

--- a/packages/skills/__tests__/skill-validator-v2.test.ts
+++ b/packages/skills/__tests__/skill-validator-v2.test.ts
@@ -1,0 +1,156 @@
+/**
+ * v2 foundation tests for ct-skill-validator.
+ *
+ * Covers CLEO overlays from Decision O-mpkoldtv-0: SKILL.md frontmatter must
+ * stay cross-harness portable, JSON-serializable, and only use explicitly
+ * allowlisted provider/runtime fields.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const thisFile = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(thisFile), '..', '..', '..');
+const validateScript = join(
+  repoRoot,
+  'packages/skills/skills/ct-skill-validator/scripts/validate.py',
+);
+
+type ValidationResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  report?: {
+    errors: number;
+    warnings: number;
+    passed: boolean;
+    results: Array<{ tier: number; severity: string; message: string }>;
+  };
+};
+
+const pythonHasPyYaml = (() => {
+  try {
+    execFileSync('python3', ['-c', 'import yaml'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const itIfPythonYaml = pythonHasPyYaml ? it : it.skip;
+
+let tmpRoot: string | undefined;
+
+function makeSkill(name: string, frontmatter: string): string {
+  tmpRoot = tmpRoot ?? mkdtempSync(join(tmpdir(), 'cleo-skill-validator-v2-'));
+  const skillDir = join(tmpRoot, name);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\n${frontmatter.trim()}\n---\n\n# ${name}\n\nUse this synthetic skill only for validator tests.\n`,
+  );
+  return skillDir;
+}
+
+function runValidate(skillDir: string): ValidationResult {
+  try {
+    const stdout = execFileSync('python3', [validateScript, skillDir, '--json'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { exitCode: 0, stdout, stderr: '', report: JSON.parse(stdout) };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    const stdout = e.stdout?.toString() ?? '';
+    return {
+      exitCode: e.status ?? 1,
+      stdout,
+      stderr: e.stderr?.toString() ?? '',
+      report: stdout ? JSON.parse(stdout) : undefined,
+    };
+  }
+}
+
+function messages(result: ValidationResult): string {
+  return result.report?.results.map((r) => r.message).join('\n') ?? result.stdout;
+}
+
+afterEach(() => {
+  if (tmpRoot) {
+    rmSync(tmpRoot, { recursive: true, force: true });
+    tmpRoot = undefined;
+  }
+});
+
+describe('ct-skill-validator v2 frontmatter portability', () => {
+  itIfPythonYaml('passes quoted metadata scalars and the explicit CLEO loomStage overlay', () => {
+    const skillDir = makeSkill(
+      'ct-portable-skill',
+      `name: ct-portable-skill
+description: Validates portable quoted metadata when auditing skill frontmatter across Python and JavaScript YAML parsers.
+loomStage: validation
+metadata:
+  author: cleo
+  version: "1.2.0"
+  last_updated: "2026-05-21 14:00:18"
+  build: "42"`,
+    );
+
+    const result = runValidate(skillDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.report?.passed).toBe(true);
+    expect(messages(result)).toContain('Frontmatter is JSON-serializable after YAML parsing');
+    expect(messages(result)).toContain(
+      'All frontmatter fields are in the explicit spec/provider allowlist',
+    );
+    expect(messages(result)).not.toContain('unquoted');
+  });
+
+  itIfPythonYaml('fails unquoted date-like, version, and numeric metadata scalars', () => {
+    const skillDir = makeSkill(
+      'ct-risky-metadata',
+      `name: ct-risky-metadata
+description: Validates that risky metadata scalars are rejected when auditing skill portability across runtimes.
+metadata:
+  author: cleo
+  version: 1.2
+  last_updated: 2026-05-21 14:00:18
+  build: 42`,
+    );
+
+    const result = runValidate(skillDir);
+    const text = messages(result);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.report?.passed).toBe(false);
+    expect(text).toContain('metadata.version');
+    expect(text).toContain('metadata.last_updated');
+    expect(text).toContain('metadata.build');
+    expect(text).toContain('quote it for Python/JS YAML parity and JSON portability');
+  });
+
+  itIfPythonYaml('fails provider-specific frontmatter fields unless explicitly allowlisted', () => {
+    const skillDir = makeSkill(
+      'ct-provider-leak',
+      `name: ct-provider-leak
+description: Validates that provider-specific fields cannot silently leak into portable skill frontmatter.
+openai-tool-policy: relaxed
+metadata:
+  author: cleo
+  version: "1.0.0"`,
+    );
+
+    const result = runValidate(skillDir);
+    const text = messages(result);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.report?.passed).toBe(false);
+    expect(text).toContain("Unknown frontmatter field 'openai-tool-policy'");
+    expect(text).toContain('explicit spec/provider allowlist');
+  });
+});

--- a/packages/skills/skills/ct-skill-validator/references/validation-rules.md
+++ b/packages/skills/skills/ct-skill-validator/references/validation-rules.md
@@ -67,6 +67,17 @@ either omit them or document the dependency in `compatibility`.
 | `agent` | string | No | Subagent type (Explore, Plan, etc.) |
 | `hooks` | dict | No | Skill-scoped lifecycle hooks |
 
+#### CLEO overlay extensions
+
+These are intentionally allowlisted CLEO runtime overlays that still live in
+`SKILL.md` because repo/runtime gates consume them directly. Do not add new
+provider- or runtime-specific top-level fields without adding them to the
+validator allowlist.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `loomStage` | string | No | RCASD-IVTR+C stage binding used by LOOM protocol skills |
+
 ### CLEO-only fields (forbidden in SKILL.md; belong in `manifest-entry.json`)
 
 These fields hold CLEO-specific structured data that the Claude runtime
@@ -99,7 +110,9 @@ the SKILL.md frontmatter or violate the agentskills.io spec.
 | T1-003 | Frontmatter block can be extracted (closing `---` found) | ERROR | Add closing `---` after frontmatter |
 | T1-004 | Frontmatter is valid YAML | ERROR | Fix YAML syntax errors |
 | T1-005 | Frontmatter parses to a dictionary | ERROR | Frontmatter must be key: value pairs, not a scalar or list |
-| T1-006 | No CLEO-only fields present in frontmatter | ERROR (per field) | Move the field to manifest-entry.json or manifest.json |
+| T1-006 | Frontmatter is JSON-serializable after YAML parsing | ERROR | Quote date/timestamp-like values and use string keys |
+| T1-007 | All top-level fields are in the explicit spec/provider allowlist | ERROR (per field) | Move custom data under `metadata` or add a deliberate allowlist entry |
+| T1-008 | No CLEO-only fields present in frontmatter | ERROR (per field) | Move the field to manifest-entry.json or manifest.json |
 
 ## Tier 2 — Frontmatter Quality Rules
 
@@ -138,6 +151,7 @@ the SKILL.md frontmatter or violate the agentskills.io spec.
 | T2-031 | `metadata` values are all strings (agentskills.io spec) | WARN | Quote numeric versions: `version: "1.0"` |
 | T2-032 | `metadata` includes at least one of: author, version, last_updated | WARN | Add recommended traceability keys |
 | T2-033 | `metadata.last_updated` (and `metadata.last_reviewed` if present) match `YYYY-MM-DD HH:MM:SS` | WARN | Use precise timestamp format, e.g. `"2026-05-21 14:00:18"` |
+| T2-034 | Date-like, timestamp, version, and numeric metadata scalars are quoted | ERROR | Quote metadata values so Python/JS YAML parsers and JSON serializers agree |
 
 ## Tier 3 — Body Quality Rules
 
@@ -173,7 +187,9 @@ the SKILL.md frontmatter or violate the agentskills.io spec.
 | T1-003 | 1 | Frontmatter extractable (closing `---`) | ERROR |
 | T1-004 | 1 | Frontmatter valid YAML | ERROR |
 | T1-005 | 1 | Frontmatter is a dict | ERROR |
-| T1-006 | 1 | No CLEO-only fields | ERROR |
+| T1-006 | 1 | Frontmatter JSON-serializable after YAML parsing | ERROR |
+| T1-007 | 1 | Top-level fields in explicit spec/provider allowlist | ERROR |
+| T1-008 | 1 | No CLEO-only fields | ERROR |
 | T2-001 | 2 | `name` present | ERROR |
 | T2-002 | 2 | `name` is string | ERROR |
 | T2-003 | 2 | `name` hyphen-case | ERROR |
@@ -207,6 +223,7 @@ the SKILL.md frontmatter or violate the agentskills.io spec.
 | T2-031 | 2 | `metadata` values are strings | WARN |
 | T2-032 | 2 | `metadata` has author/version/last_updated | WARN |
 | T2-033 | 2 | `metadata` timestamp keys match `YYYY-MM-DD HH:MM:SS` | WARN |
+| T2-034 | 2 | Risky metadata scalars are quoted | ERROR |
 | T3-001 | 3 | Body present | WARN |
 | T3-002 | 3 | Body under 600 lines | ERROR |
 | T3-003 | 3 | Body under 500 lines (spec) | WARN |

--- a/packages/skills/skills/ct-skill-validator/scripts/validate.py
+++ b/packages/skills/skills/ct-skill-validator/scripts/validate.py
@@ -48,7 +48,16 @@ HARNESS_EXTENSIONS = {
     "argument-hint", "disable-model-invocation", "user-invocable",
     "model", "context", "agent", "hooks",
 }
-ALLOWED_FRONTMATTER = SPEC_FRONTMATTER | HARNESS_EXTENSIONS
+
+# CLEO overlays that intentionally live in SKILL.md because existing runtime
+# gates read them from frontmatter. Keep this list small and explicit: all other
+# provider/runtime-specific fields must be added here deliberately instead of
+# silently passing through as unknown metadata.
+CLEO_OVERLAY_EXTENSIONS = {
+    "loomStage",
+}
+
+ALLOWED_FRONTMATTER = SPEC_FRONTMATTER | HARNESS_EXTENSIONS | CLEO_OVERLAY_EXTENSIONS
 
 CLEO_ONLY = {
     "version", "tier", "core", "category", "protocol",
@@ -61,6 +70,73 @@ MANIFEST_REQUIRED_FIELDS = [
     "name", "version", "description", "path", "status",
     "tier", "token_budget", "capabilities", "constraints",
 ]
+
+JSON_SCALAR_TYPES = (str, int, float, bool, type(None))
+DATE_LIKE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}(?:$|[T\s]\d{2}:\d{2}(?::\d{2})?(?:Z|[+-]\d{2}:?\d{2})?$)")
+NUMERIC_OR_VERSION_RE = re.compile(r"^[+-]?\d+(?:\.\d+)+(?:[-+][0-9A-Za-z.-]+)?$")
+INTEGER_RE = re.compile(r"^[+-]?\d+$")
+
+
+def _is_json_serializable(value):
+    """Return True when a PyYAML value can safely round-trip via JSON."""
+    if isinstance(value, JSON_SCALAR_TYPES):
+        return True
+    if isinstance(value, list):
+        return all(_is_json_serializable(item) for item in value)
+    if isinstance(value, dict):
+        return all(isinstance(k, str) and _is_json_serializable(v) for k, v in value.items())
+    return False
+
+
+def _metadata_unquoted_portability_findings(raw_frontmatter):
+    """Find metadata scalars that YAML parsers may coerce differently.
+
+    Decision O-mpkoldtv-0 requires SKILL.md frontmatter to be cross-harness
+    portable through JS/Python YAML parsers and JSON-serializable. The open skill
+    spec already treats metadata as string-to-string, so date-like, timestamp,
+    version, and numeric metadata values must be quoted.
+    """
+    findings = []
+    lines = raw_frontmatter.splitlines()
+    in_metadata = False
+    metadata_indent = None
+
+    for line_no, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        indent = len(line) - len(line.lstrip(" "))
+        if re.match(r"^metadata\s*:\s*$", stripped):
+            in_metadata = True
+            metadata_indent = indent
+            continue
+
+        if in_metadata and indent <= (metadata_indent or 0):
+            in_metadata = False
+            metadata_indent = None
+
+        if not in_metadata:
+            continue
+
+        match = re.match(r"^([A-Za-z0-9_.-]+)\s*:\s*(.+?)\s*(?:#.*)?$", stripped)
+        if not match:
+            continue
+
+        key, value = match.groups()
+        value = value.strip()
+        if not value or value[0] in {'\"', "'", "[", "{"}:
+            continue
+
+        if DATE_LIKE_RE.match(value):
+            findings.append((line_no, key, value, "date/timestamp-like"))
+        elif key in {"version", "last_updated", "last_reviewed"} and (
+                NUMERIC_OR_VERSION_RE.match(value) or INTEGER_RE.match(value)):
+            findings.append((line_no, key, value, "version/numeric"))
+        elif NUMERIC_OR_VERSION_RE.match(value) or INTEGER_RE.match(value):
+            findings.append((line_no, key, value, "numeric"))
+
+    return findings
 
 
 def validate_skill(skill_path, manifest_path=None, dispatch_config_path=None, provider_map_path=None):
@@ -128,11 +204,26 @@ def validate_skill(skill_path, manifest_path=None, dispatch_config_path=None, pr
 
     ok(tier, "Frontmatter is a dict")
 
+    if not _is_json_serializable(frontmatter):
+        error(tier, "Frontmatter must be JSON-serializable after YAML parsing (quote dates/timestamps and use string keys)")
+    else:
+        ok(tier, "Frontmatter is JSON-serializable after YAML parsing")
+
+    unknown_keys = sorted(key for key in frontmatter if key not in ALLOWED_FRONTMATTER and key not in CLEO_ONLY)
+    for key in unknown_keys:
+        error(tier, (
+            f"Unknown frontmatter field '{key}' is not in the explicit spec/provider allowlist; "
+            "move custom data under metadata or add an explicit validator allowlist entry"
+        ))
+
+    if not unknown_keys:
+        ok(tier, "All frontmatter fields are in the explicit spec/provider allowlist")
+
     for key in frontmatter:
         if key in CLEO_ONLY:
             error(tier, f"Move '{key}' to manifest.json (CLEO-only field)")
         else:
-            pass  # valid or unknown keys checked in tier 2
+            pass  # valid or unknown keys checked above
 
     if not any(r[1] == "ERROR" and "CLEO-only" in r[2] for r in results):
         ok(tier, "No CLEO-only fields in frontmatter")
@@ -265,6 +356,11 @@ def validate_skill(skill_path, manifest_path=None, dispatch_config_path=None, pr
                 warn(tier, (
                     f"'metadata' values should be strings per agentskills.io spec; "
                     f"non-string keys: {non_string_vals[:3]} (quote numeric versions: \"1.0\" not 1.0)"
+                ))
+            for line_no, key, value, kind in _metadata_unquoted_portability_findings(raw_frontmatter):
+                error(tier, (
+                    f"'metadata.{key}' uses unquoted {kind} scalar at frontmatter line {line_no}: {value!r}; "
+                    "quote it for Python/JS YAML parity and JSON portability"
                 ))
             present_recommended = RECOMMENDED_METADATA_KEYS & set(metadata_val.keys())
             if not present_recommended:


### PR DESCRIPTION
Closes T10533
Saga: T9799
Decision: O-mpkoldtv-0

## Summary
- Add ct-skill-validator v2 frontmatter portability checks.
- Enforce explicit spec/provider/CLEO overlay allowlist.
- Reject unquoted date-like/timestamp/version/numeric YAML metadata scalars.
- Add focused validator v2 tests and rule docs.

## Verification
- python3 -m py_compile packages/skills/skills/ct-skill-validator/scripts/validate.py
- python3 packages/skills/skills/ct-skill-validator/scripts/validate.py packages/skills/skills/ct-skill-validator --json
- manual Python smoke fixtures for pass/fail portability cases (worker)
- git diff --check

## Notes
Manual fallback used because `cleo orchestrate spawn T10533 --json` failed from the dirty orchestrator checkout with changeset hygiene timeout. Worker could not run Vitest locally due ENOSPC during dependency install; CI is the authoritative JS test gate.