### PR TITLE
fix(T10079,T10089): release root routing and severity docs

### DIFF
--- a/.changeset/t10079-t10089-release-root-severity.md
+++ b/.changeset/t10079-t10089-release-root-severity.md
@@ -1,7 +1,8 @@
 ---
-"@cleocode/cleo": patch
-"@cleocode/core": patch
-"@cleocode/contracts": patch
+id: t10079-t10089-release-root-severity
+tasks: [T10079, T10089]
+kind: fix
+summary: Fix release and verify project-root routing from secondary worktrees and document severity constraints for non-bug task kinds
 ---
 
 Fix release/verify project-root routing from secondary worktrees and align severity docs with the any-kind CHECK constraint.

--- a/.changeset/t10079-t10089-release-root-severity.md
+++ b/.changeset/t10079-t10089-release-root-severity.md
@@ -1,0 +1,7 @@
+---
+"@cleocode/cleo": patch
+"@cleocode/core": patch
+"@cleocode/contracts": patch
+---
+
+Fix release/verify project-root routing from secondary worktrees and align severity docs with the any-kind CHECK constraint.

--- a/packages/cleo/src/dispatch/domains/check.ts
+++ b/packages/cleo/src/dispatch/domains/check.ts
@@ -59,6 +59,7 @@ import {
   checkWorkflowCompliance,
   getLogger,
   getProjectRoot,
+  resolveWorktreeRouting,
   validateGateVerify,
   validateProtocolArchitectureDecision,
   validateProtocolArtifactPublish,
@@ -646,7 +647,10 @@ const _checkTypedHandler = defineTypedHandler<CheckOps>('check', {
   },
 
   'gate.set': async (params: ValidateGateParams) => {
-    const projectRoot = getProjectRoot();
+    // T10079: `cleo verify --gate implemented --evidence files:...` must
+    // validate file evidence against the primary worktree even when the caller
+    // is inside an XDG secondary worktree/subdir.
+    const projectRoot = resolveWorktreeRouting().canonicalRoot;
     if (!params.taskId) {
       return lafsError('E_INVALID_INPUT', 'taskId is required', 'gate.set');
     }

--- a/packages/cleo/src/dispatch/domains/release.ts
+++ b/packages/cleo/src/dispatch/domains/release.ts
@@ -42,7 +42,7 @@ import type {
   ReleasePlanOptions,
   ValidateChangelogOptions,
 } from '@cleocode/core/internal';
-import { getLogger, getProjectRoot } from '@cleocode/core/internal';
+import { getLogger, getProjectRoot, resolveWorktreeRouting } from '@cleocode/core/internal';
 import type { OpsFromCore } from '../adapters/typed.js';
 import {
   releaseGateCheck,
@@ -372,7 +372,10 @@ export class ReleaseHandler implements DomainHandler {
             dryRun: typeof params?.dryRun === 'boolean' ? params.dryRun : false,
             writeChangelog:
               typeof params?.writeChangelog === 'boolean' ? params.writeChangelog : true,
-            projectRoot: getProjectRoot(),
+            // T10079: release plan side effects are project-level. When invoked
+            // from an XDG secondary worktree/subdir, route .changeset/,
+            // CHANGELOG.md, and plan.json writes to the primary worktree.
+            projectRoot: resolveWorktreeRouting().canonicalRoot,
           };
           return wrapResult(await releasePlan(typed), 'mutate', 'release', operation, startTime);
         }

--- a/packages/contracts/src/task.ts
+++ b/packages/contracts/src/task.ts
@@ -81,14 +81,16 @@ export type TaskKind = 'work' | 'research' | 'experiment' | 'bug' | 'spike' | 'r
 export type TaskScope = 'project' | 'feature' | 'unit';
 
 /**
- * Bug severity axis. Only meaningful when `kind='bug'`; enforced by a DB-level
- * CHECK constraint on the `role` column (`severity IS NULL OR (severity IN (...) AND role='bug')`).
+ * Severity axis. Orthogonal to {@link TaskKind}; valid severities may be set
+ * on work/research/experiment/bug/spike/release tasks alike. The DB CHECK
+ * constraint only validates membership in P0-P3.
  *
  * OWNER-WRITE-ONLY: severity is intended to be set through owner-authenticated
  * paths only. This prevents a prompt-injection exploit where a compromised
  * Tier 3 agent could downgrade a P0 bug to P3 to force-ship.
  *
  * @task T944
+ * @task T10089
  */
 export type TaskSeverity = 'P0' | 'P1' | 'P2' | 'P3';
 
@@ -466,7 +468,7 @@ export interface Task {
   scope?: TaskScope;
 
   /**
-   * Bug severity. Only valid when {@link role} is `'bug'`. OWNER-WRITE-ONLY.
+   * Severity axis. Valid for any {@link kind}. OWNER-WRITE-ONLY.
    * @defaultValue undefined
    * @task T944
    */
@@ -638,7 +640,7 @@ export interface TaskCreate {
   scope?: TaskScope;
 
   /**
-   * Bug severity (OWNER-WRITE-ONLY). Only valid with `kind='bug'`.
+   * Severity axis (OWNER-WRITE-ONLY). Valid for any `kind`.
    * @defaultValue undefined
    * @task T944
    */

--- a/packages/core/src/__tests__/t10079-primary-worktree-root.test.ts
+++ b/packages/core/src/__tests__/t10079-primary-worktree-root.test.ts
@@ -1,0 +1,54 @@
+/**
+ * T10079 — release/verify project-level root resolution.
+ *
+ * `cleo release plan` and `cleo verify --gate implemented --evidence files:...`
+ * consume `resolveWorktreeRouting().canonicalRoot` at the dispatch boundary.
+ * This test locks the routing primitive to the primary worktree even when the
+ * caller is inside a subdirectory of a secondary XDG-style git worktree.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveWorktreeRouting } from '../paths.js';
+
+const fixtures: string[] = [];
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+describe('T10079 primary worktree root routing', () => {
+  afterEach(() => {
+    for (const fixture of fixtures.splice(0)) {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves canonicalRoot to the primary worktree from a secondary worktree subdir', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'cleo-t10079-'));
+    fixtures.push(tmp);
+
+    const primary = join(tmp, 'primary');
+    const secondary = join(tmp, 'xdg', 'cleo', 'worktrees', 'hash', 'T10079');
+    mkdirSync(join(primary, '.cleo'), { recursive: true });
+    mkdirSync(join(primary, 'packages'), { recursive: true });
+    writeFileSync(join(primary, 'packages', 'sentinel.ts'), 'export const primary = true;\n');
+
+    git(primary, ['init', '-b', 'main']);
+    git(primary, ['config', 'user.email', 'cleo@example.test']);
+    git(primary, ['config', 'user.name', 'Cleo Test']);
+    git(primary, ['add', '.']);
+    git(primary, ['commit', '-m', 'initial']);
+    git(primary, ['worktree', 'add', '-b', 'task/T10079', secondary, 'main']);
+
+    const secondarySubdir = join(secondary, 'packages');
+    const routing = resolveWorktreeRouting(secondarySubdir);
+
+    expect(routing.isWorktree).toBe(true);
+    expect(routing.worktreePath).toBe(secondary);
+    expect(routing.canonicalRoot).toBe(primary);
+  });
+});

--- a/packages/core/src/__tests__/t10079-primary-worktree-root.test.ts
+++ b/packages/core/src/__tests__/t10079-primary-worktree-root.test.ts
@@ -7,10 +7,10 @@
  * caller is inside a subdirectory of a secondary XDG-style git worktree.
  */
 
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { execFileSync } from 'node:child_process';
 import { afterEach, describe, expect, it } from 'vitest';
 import { resolveWorktreeRouting } from '../paths.js';
 


### PR DESCRIPTION
## Summary
- Route release plan and verify gate writes through primary worktree resolution when invoked from secondary XDG worktrees.
- Align TaskSeverity contract docs with the widened any-kind severity CHECK constraint.
- Add targeted regression coverage for secondary-worktree subdir routing.

## Tests
- pnpm test packages/core/src/__tests__/t10079-primary-worktree-root.test.ts packages/core/src/store/__tests__/t9073-severity-any-role-schema.test.ts

## Notes
- pnpm --filter @cleocode/core run build was attempted after a fresh install but failed because workspace dependency declaration outputs (for @cleocode/contracts, @cleocode/paths, etc.) were not built/resolvable in this isolated worktree; not caused by the changed files.