### PR TITLE
fix(core): preserve journal on migration SQL hash drift (regression from v128)

### DIFF
--- a/packages/core/src/store/__tests__/migration-hash-drift.test.ts
+++ b/packages/core/src/store/__tests__/migration-hash-drift.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression test for the migration journal hash-drift recovery.
+ *
+ * Pre-fix bug (v2026.5.128): when a release modifies an existing migration's
+ * SQL, drizzle's content-hash changes. reconcileJournal saw the DB's old hash
+ * as "orphaned" (not in local) and the local's new hash as "missing in DB",
+ * matched both conditions, and triggered Sub-case B which DELETEd the entire
+ * journal and re-probed every migration via DDL. Data-only migrations (UPDATEs,
+ * INSERTs) that couldn't be probed were left unjournaled and re-run by drizzle,
+ * crashing the migrate() call.
+ *
+ * Fix (v2026.5.129): partition orphans by NAME match. Entries whose name
+ * matches a local migration but whose hash differs are HASH DRIFT — UPDATE the
+ * entry's hash in place. Only entries with no name match are true orphans and
+ * fall through to the delete+probe path.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function getTasksMigrationsFolder(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+describe('reconcileJournal — hash-drift recovery', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-hash-drift-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('updates hash in place when a known migration name has a stale hash', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { reconcileJournal } = await import('../migration-manager.js');
+    const { readMigrationFiles } = await import('drizzle-orm/migrator');
+
+    const migrationsFolder = getTasksMigrationsFolder();
+    const localMigrations = readMigrationFiles({ migrationsFolder });
+
+    // Pick t033 — modified by v2026.5.128, so it's the canonical drift case.
+    const targetMig = localMigrations.find((m) => m.name?.includes('t033'));
+    expect(targetMig, 'expected t033 migration to exist').toBeDefined();
+    const newHash = targetMig!.hash;
+    const staleHash = 'b928367a3ec05fcc0ef24e36af5dbca5323a0a806eaf33f8860f2cded54e2b74';
+    expect(newHash).not.toBe(staleHash);
+
+    const dbPath = join(tempDir, 'drift.db');
+    const nativeDb = openNativeDatabase(dbPath);
+
+    nativeDb.exec(
+      `CREATE TABLE IF NOT EXISTS tasks (id text PRIMARY KEY, title text NOT NULL, status text DEFAULT 'pending' NOT NULL);`,
+    );
+
+    nativeDb.exec(`
+      CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        hash text NOT NULL,
+        created_at numeric,
+        name text,
+        applied_at TEXT
+      )
+    `);
+    for (const m of localMigrations) {
+      const hash = m === targetMig ? staleHash : m.hash;
+      nativeDb.exec(
+        `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${hash}', ${m.folderMillis}, '${m.name ?? ''}')`,
+      );
+    }
+
+    const journalSizeBefore = (
+      nativeDb.prepare('SELECT COUNT(*) AS n FROM "__drizzle_migrations"').get() as { n: number }
+    ).n;
+    expect(journalSizeBefore).toBe(localMigrations.length);
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+
+    const journalSizeAfter = (
+      nativeDb.prepare('SELECT COUNT(*) AS n FROM "__drizzle_migrations"').get() as { n: number }
+    ).n;
+    expect(
+      journalSizeAfter,
+      'reconcileJournal must NOT delete entries — drift entries should be updated in place',
+    ).toBe(journalSizeBefore);
+
+    const t033Row = nativeDb
+      .prepare('SELECT hash FROM "__drizzle_migrations" WHERE name = ?')
+      .get(targetMig!.name) as { hash: string } | undefined;
+    expect(t033Row?.hash, 'drifted entry must be updated to new hash').toBe(newHash);
+
+    nativeDb.close();
+  });
+
+  it('does NOT wipe the journal when SQL edits change one hash', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { reconcileJournal } = await import('../migration-manager.js');
+    const { readMigrationFiles } = await import('drizzle-orm/migrator');
+
+    const migrationsFolder = getTasksMigrationsFolder();
+    const localMigrations = readMigrationFiles({ migrationsFolder });
+    const targetMig = localMigrations.find((m) => m.name?.includes('t033'));
+
+    const dbPath = join(tempDir, 'no-wipe.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    nativeDb.exec(`CREATE TABLE tasks (id text PRIMARY KEY, title text NOT NULL);`);
+    nativeDb.exec(`
+      CREATE TABLE "__drizzle_migrations" (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        hash text NOT NULL,
+        created_at numeric,
+        name text,
+        applied_at TEXT
+      )
+    `);
+    for (const m of localMigrations) {
+      const hash =
+        m === targetMig
+          ? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          : m.hash;
+      nativeDb.exec(
+        `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${hash}', ${m.folderMillis}, '${m.name ?? ''}')`,
+      );
+    }
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+
+    // Every name-matched local migration's hash must end up in the journal.
+    const remainingHashes = new Set(
+      (
+        nativeDb.prepare('SELECT hash FROM "__drizzle_migrations"').all() as Array<{ hash: string }>
+      ).map((r) => r.hash),
+    );
+    for (const m of localMigrations) {
+      expect(
+        remainingHashes.has(m.hash),
+        `migration ${m.name} (hash ${m.hash.slice(0, 12)}) must remain journaled after reconcile`,
+      ).toBe(true);
+    }
+
+    nativeDb.close();
+  });
+
+  it('deletes true orphans (entry whose name has no local match) when some local hashes are missing too', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { reconcileJournal } = await import('../migration-manager.js');
+    const { readMigrationFiles } = await import('drizzle-orm/migrator');
+
+    const migrationsFolder = getTasksMigrationsFolder();
+    const localMigrations = readMigrationFiles({ migrationsFolder });
+
+    const dbPath = join(tempDir, 'true-orphan.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    nativeDb.exec(`CREATE TABLE tasks (id text PRIMARY KEY, title text NOT NULL);`);
+    nativeDb.exec(`
+      CREATE TABLE "__drizzle_migrations" (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        hash text NOT NULL,
+        created_at numeric,
+        name text,
+        applied_at TEXT
+      )
+    `);
+    // Seed every local migration EXCEPT the last one. This makes the DB look
+    // like a slightly-older install where one new migration hasn't run yet.
+    // Then add a true orphan with no name match. Because the last local
+    // migration's hash is absent, allLocalHashesPresentInDb is false → Sub-case
+    // B fires → true-orphan branch processes the orphan.
+    const seedMigrations = localMigrations.slice(0, -1);
+    for (const m of seedMigrations) {
+      nativeDb.exec(
+        `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${m.hash}', ${m.folderMillis}, '${m.name ?? ''}')`,
+      );
+    }
+    nativeDb.exec(
+      `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('deadbeef000000000000000000000000000000000000000000000000deadbeef', 0, '00000000000000_removed-from-disk-migration')`,
+    );
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+
+    const remaining = nativeDb.prepare('SELECT name FROM "__drizzle_migrations"').all() as Array<{
+      name: string | null;
+    }>;
+
+    // The true orphan must be gone.
+    expect(remaining.some((r) => r.name === '00000000000000_removed-from-disk-migration')).toBe(
+      false,
+    );
+    // Every seeded (i.e. previously-applied) local migration must remain.
+    for (const m of seedMigrations) {
+      expect(
+        remaining.some((r) => r.name === m.name),
+        `previously-applied local migration ${m.name} must remain journaled after true-orphan cleanup`,
+      ).toBe(true);
+    }
+
+    nativeDb.close();
+  });
+});

--- a/packages/core/src/store/migration-manager.ts
+++ b/packages/core/src/store/migration-manager.ts
@@ -284,7 +284,7 @@ export function reconcileJournal(
 
   // Scenario 2: Journal has orphaned entries from a previous CLEO version
   //
-  // Two distinct sub-cases require different handling:
+  // Three distinct sub-cases require different handling:
   //
   // A) DB is AHEAD of this install (forward-compatibility): all local hashes
   //    are present in the DB, but the DB also has additional entries for
@@ -296,16 +296,41 @@ export function reconcileJournal(
   //    them back — only for this install to delete them again on the next run.
   //    ACTION: skip reconciliation, log at debug only.
   //
-  // B) DB has stale hashes from a genuinely old CLEO version whose checksum
-  //    algorithm produced different hashes for the same migration files (i.e.,
-  //    at least one local hash is MISSING from the DB while other DB entries
-  //    are unrecognised). ACTION: delete and re-seed as before, log at warn.
+  // B) HASH DRIFT — orphan entries have a NAME that matches a local migration
+  //    but a different hash. This happens when a migration file's SQL is
+  //    modified in a release (e.g. v2026.5.128's t033 idempotency fix). The
+  //    migration was applied with the old SQL; the new SQL is logically the
+  //    same migration. Wiping the journal would force every migration to be
+  //    re-probed, which fails for data-only migrations whose DDL can't be
+  //    probed. ACTION: UPDATE the entry's hash in place. The migration stays
+  //    applied; only the hash is brought forward.
+  //
+  // C) TRUE ORPHANS — entries whose name has no local match (the migration
+  //    file was removed from disk, or the journal is from a fundamentally
+  //    different cleo lineage). ACTION: delete + re-probe via DDL.
   if (tableExists(nativeDb, '__drizzle_migrations') && tableExists(nativeDb, existenceTable)) {
     const localMigrations = readMigrationFiles({ migrationsFolder });
     const localHashes = new Set(localMigrations.map((m) => m.hash));
-    const dbEntries = nativeDb.prepare('SELECT hash FROM "__drizzle_migrations"').all() as Array<{
-      hash: string;
+    const localByName = new Map(localMigrations.map((m) => [m.name ?? '', m]));
+
+    // Read full entries with hash, name, id. Older journals may lack `name`;
+    // those entries fall through to true-orphan handling below.
+    const migCols = nativeDb.prepare('PRAGMA table_info("__drizzle_migrations")').all() as Array<{
+      name: string;
     }>;
+    const hasMigNameCol = migCols.some((c) => c.name === 'name');
+    type JournalRow = { id: number; hash: string; name: string | null };
+    const dbEntries: JournalRow[] = hasMigNameCol
+      ? (nativeDb
+          .prepare('SELECT id, hash, name FROM "__drizzle_migrations"')
+          .all() as JournalRow[])
+      : (
+          nativeDb.prepare('SELECT id, hash FROM "__drizzle_migrations"').all() as Array<{
+            id: number;
+            hash: string;
+          }>
+        ).map((r) => ({ ...r, name: null }));
+
     const orphanedEntries = dbEntries.filter((e) => !localHashes.has(e.hash));
     const hasOrphanedEntries = orphanedEntries.length > 0;
 
@@ -322,24 +347,64 @@ export function reconcileJournal(
           `Migration journal has ${orphanedEntries.length} entries for migrations not known to this install (DB is ahead). Skipping reconciliation.`,
         );
       } else {
-        // Sub-case B: Genuine stale hashes from an older CLEO version.
-        // ROOT-CAUSE FIX (T632): The previous implementation DELETEd the journal
-        // and INSERTed all local migrations as applied WITHOUT running their SQL.
-        // That meant ALTER TABLE migrations (T417 agent, T528 provenance, etc.)
-        // got marked applied but their columns were never added — forcing
-        // ensureColumns band-aids in memory-sqlite.ts to patch the missing schema.
-        //
-        // Real fix: clear orphaned entries, then PROBE each local migration's
-        // DDL. Mark applied ONLY if the DDL targets already exist in the schema.
-        // Drizzle's migrate() (called next) will run whatever remains unjournaled.
+        // Partition orphans into hash-drift (name-matched) vs true orphans.
+        const driftEntries: Array<{ row: JournalRow; newHash: string }> = [];
+        const trueOrphanEntries: JournalRow[] = [];
+        for (const orphan of orphanedEntries) {
+          const localMatch = orphan.name ? localByName.get(orphan.name) : undefined;
+          if (localMatch && localMatch.hash !== orphan.hash) {
+            driftEntries.push({ row: orphan, newHash: localMatch.hash });
+          } else {
+            trueOrphanEntries.push(orphan);
+          }
+        }
+
         const log = getLogger(logSubsystem);
-        log.warn(
-          { orphaned: orphanedEntries.length },
-          `Detected stale migration journal entries from a previous CLEO version. Reconciling via DDL probe.`,
-        );
-        nativeDb.exec('DELETE FROM "__drizzle_migrations"');
-        for (const m of localMigrations) {
-          probeAndMarkApplied(nativeDb, m, logSubsystem);
+
+        // Sub-case B: HASH DRIFT — UPDATE hash in place. The migration was
+        // applied; the SQL has been edited in a release; the journal entry
+        // is logically correct, only its hash is stale.
+        if (driftEntries.length > 0) {
+          log.warn(
+            {
+              drifted: driftEntries.length,
+              names: driftEntries.map((d) => d.row.name),
+            },
+            `Detected ${driftEntries.length} hash-drift journal entries (migration SQL edited in a release). Updating hashes in place.`,
+          );
+          const updateStmt = nativeDb.prepare(
+            'UPDATE "__drizzle_migrations" SET hash = ? WHERE id = ?',
+          );
+          for (const { row, newHash } of driftEntries) {
+            updateStmt.run(newHash, row.id);
+          }
+        }
+
+        // Sub-case C: TRUE ORPHANS — entries whose name has no local match.
+        // Only NOW do we fall back to the legacy delete+re-probe path, and
+        // only for the truly-orphaned entries.
+        if (trueOrphanEntries.length > 0) {
+          log.warn(
+            { orphaned: trueOrphanEntries.length },
+            `Detected ${trueOrphanEntries.length} true-orphan journal entries from a previous CLEO lineage. Reconciling via DDL probe.`,
+          );
+          const deleteStmt = nativeDb.prepare('DELETE FROM "__drizzle_migrations" WHERE id = ?');
+          for (const e of trueOrphanEntries) deleteStmt.run(e.id);
+          // Re-probe local migrations that may now have no journal entry.
+          // The previous implementation cleared the WHOLE journal here; the
+          // selective delete above keeps every applied migration journaled,
+          // so the probe only inserts entries for genuinely missing ones.
+          const journaledHashesAfter = new Set(
+            (
+              nativeDb.prepare('SELECT hash FROM "__drizzle_migrations"').all() as Array<{
+                hash: string;
+              }>
+            ).map((r) => r.hash),
+          );
+          for (const m of localMigrations) {
+            if (journaledHashesAfter.has(m.hash)) continue;
+            probeAndMarkApplied(nativeDb, m, logSubsystem);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

v2026.5.128 modified `t033-connection-health/migration.sql` to make the INSERT idempotent. Drizzle hashes migration content, so the SQL edit changed t033's hash. Every upgraded install hit a journal-wipe + migration-rerun crash on `cleo briefing` or any DB-touching command.

This PR adds NAME-based partitioning so SQL edits in released migrations are recovered gracefully.

## Root cause chain

1. `reconcileJournal` saw the DB's old t033 hash as **orphaned** (not in local migration set).
2. It saw the local's new t033 hash as **missing from DB**.
3. Both conditions met **Sub-case B**'s guard.
4. Sub-case B **DELETEd the entire journal** and re-probed every migration via DDL.
5. Data-only migrations (UPDATEs, INSERTs, t10505 backfills) cannot be DDL-probed, so they were left unjournaled.
6. Drizzle re-ran them, t877 hit "trigger already exists", the migration transaction rolled back, `briefing` crashed.

## Fix

Partition orphans by NAME match before the destructive path:

- **HASH DRIFT (new Sub-case B)** — orphan entry's name matches a local migration but hash differs. The migration WAS applied (just with old SQL). `UPDATE` the entry's hash in place; the journal stays whole.
- **TRUE ORPHANS (Sub-case C)** — orphan entry's name has no local match (file removed from disk, or install is from a different cleo lineage). Selective `DELETE` + DDL probe — never a wholesale journal wipe.
- **Sub-case A (DB is ahead)** — unchanged.

## Verified on the user's tasks.db

Before: 54 journal entries, briefing crashed on t877 (transaction rollback dropped journal to 35 entries on each invocation).
After: 54 journal entries, t033 entry's hash updated to the new value, briefing returns full session context including 4155 tasks, decisions, observations.

## Tests

`packages/core/src/store/__tests__/migration-hash-drift.test.ts` — 3 cases:
1. Drift entry's hash is updated in place.
2. Journal is NOT wiped when one hash drifts.
3. True orphans (no name match + at least one missing local hash) are deleted.

All 16 migration-reconcile + probe-trigger + hash-drift tests pass.

## Test plan

- [x] `pnpm --filter @cleocode/core build` clean
- [x] `npx vitest run src/store/__tests__/migration-{hash-drift,probe-trigger,reconcile}.test.ts` — 16/16 passing
- [x] Manual: restore user's 23:33 backup (54 entries with old t033 hash), run `cleo briefing` against v129 build — succeeds, journal preserved, t033 hash updated in place
- [ ] CI green
- [ ] Post-merge: tag v2026.5.129, release.yml publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)