### PR TITLE
feat(T11253): @cleocode/runtime/daemon submodule + frozen daemon-ipc v1.0 (R2 · SG-RUNTIME-UNIFICATION)

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -82,6 +82,18 @@
       "types": "./dist/nexus-tasks-bridge-ops.d.ts",
       "import": "./dist/nexus-tasks-bridge-ops.js"
     },
+    "./daemon": {
+      "types": "./dist/daemon/index.d.ts",
+      "import": "./dist/daemon/index.js"
+    },
+    "./daemon-ipc": {
+      "types": "./dist/daemon-ipc/index.d.ts",
+      "import": "./dist/daemon-ipc/index.js"
+    },
+    "./supervisor-ipc": {
+      "types": "./dist/supervisor-ipc/index.d.ts",
+      "import": "./dist/supervisor-ipc/index.js"
+    },
     "./dispatch/*": {
       "types": "./dist/dispatch/*.d.ts",
       "import": "./dist/dispatch/*.js"

--- a/packages/contracts/src/daemon-ipc/__tests__/daemon-ipc-freeze.test.ts
+++ b/packages/contracts/src/daemon-ipc/__tests__/daemon-ipc-freeze.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Freeze + AC8-alias guard for the `@cleocode/contracts/daemon-ipc` surface
+ * (T11369 — R2 gates R4-R7).
+ *
+ * Proves the AC8-named `daemon-ipc` barrel:
+ * 1. resolves and re-exports the FROZEN supervisor-ipc v1.0 schemas + version,
+ * 2. is byte-identical to the `supervisor-ipc` surface (one contract, two
+ *    names — no duplicate drift surface),
+ * 3. pins `DAEMON_IPC_PROTOCOL_VERSION === SUPERVISOR_IPC_PROTOCOL_VERSION ===
+ *    '1.0.0'` and the complete frozen message-kind tuple.
+ *
+ * @task T11369
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  SUPERVISOR_IPC_MESSAGE_KINDS,
+  SUPERVISOR_IPC_PROTOCOL_VERSION,
+  SupervisorIpcEnvelopeSchema as SupervisorEnvelopeFromRoot,
+} from '../../supervisor-ipc/index.js';
+import {
+  DAEMON_IPC_PROTOCOL_VERSION,
+  SUPERVISOR_IPC_MESSAGE_KINDS as MESSAGE_KINDS_VIA_DAEMON_IPC,
+  SupervisorIpcEnvelopeSchema as SupervisorEnvelopeFromDaemonIpc,
+  SUPERVISOR_IPC_PROTOCOL_VERSION as VERSION_VIA_DAEMON_IPC,
+} from '../index.js';
+
+describe('@cleocode/contracts/daemon-ipc AC8 alias surface (T11369)', () => {
+  it('re-exports the SAME frozen schema binding as supervisor-ipc', () => {
+    // Referential identity proves it is a re-export, not a duplicate schema.
+    expect(SupervisorEnvelopeFromDaemonIpc).toBe(SupervisorEnvelopeFromRoot);
+  });
+
+  it('pins the frozen protocol version through both names', () => {
+    expect(VERSION_VIA_DAEMON_IPC).toBe('1.0.0');
+    expect(DAEMON_IPC_PROTOCOL_VERSION).toBe('1.0.0');
+    expect(DAEMON_IPC_PROTOCOL_VERSION).toBe(SUPERVISOR_IPC_PROTOCOL_VERSION);
+  });
+
+  it('exposes the identical frozen message-kind set through the daemon-ipc name', () => {
+    expect([...MESSAGE_KINDS_VIA_DAEMON_IPC]).toEqual([...SUPERVISOR_IPC_MESSAGE_KINDS]);
+  });
+
+  it('validates a real Rust wire envelope through the daemon-ipc schema', () => {
+    const wire = {
+      protocol_version: '1.0.0',
+      id: 'abc',
+      direction: 'request',
+      request: { kind: 'health' },
+    };
+    expect(SupervisorEnvelopeFromDaemonIpc.safeParse(wire).success).toBe(true);
+  });
+});

--- a/packages/contracts/src/daemon-ipc/index.ts
+++ b/packages/contracts/src/daemon-ipc/index.ts
@@ -1,0 +1,90 @@
+/**
+ * `@cleocode/contracts/daemon-ipc` — the FROZEN v1.0 daemon-IPC surface
+ * R4-R7 adapt against (T11253 AC8).
+ *
+ * ## AC8 reconciliation (T11369)
+ *
+ * Epic T11253 AC8 specifies the frozen surface is published under the name
+ * `@cleocode/contracts/daemon-ipc/`. R1 (T11339) had already shipped the
+ * byte-for-byte Rust mirror under `@cleocode/contracts/supervisor-ipc/`. Rather
+ * than DUPLICATE the contract (which would create two drift surfaces), this
+ * module is a **thin re-export barrel**: `supervisor-ipc` IS the frozen v1.0
+ * contract, and `daemon-ipc` is the AC8-named alias the R2 epic promised.
+ *
+ * Both import sites resolve to the same FROZEN schemas + version constant:
+ *
+ * ```ts
+ * import { SupervisorIpcEnvelopeSchema } from '@cleocode/contracts/daemon-ipc';
+ * import { SupervisorIpcEnvelopeSchema } from '@cleocode/contracts/supervisor-ipc';
+ * // identical binding — one frozen contract, two names.
+ * ```
+ *
+ * R4-R7 are **pure adapters** against this frozen surface (see the
+ * contract-evolution policy doc, slug `daemon-ipc-contract-evolution-policy`).
+ * Breaking changes require a NEW versioned directory + a version-negotiation
+ * shim + an R2 amendment task — never an in-place edit to the v1.0 schemas.
+ *
+ * @packageDocumentation
+ * @module @cleocode/contracts/daemon-ipc
+ *
+ * @epic T11253 R2 — `@cleocode/runtime/daemon` submodule
+ * @task T11369 — freeze + publish v1.0 daemon-IPC contract surface (AC8 + AC9)
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+export type {
+  ChildState,
+  ChildStatus,
+  EnvPair,
+  ErrorResponse,
+  HealthRequest,
+  HealthResponse,
+  LifecycleEventKind,
+  LifecycleEventResponse,
+  MonitorRequest,
+  MonitorResponse,
+  RestartedResponse,
+  RestartRequest,
+  SpawnedResponse,
+  SpawnRequest,
+  SupervisorIpcEnvelope,
+  SupervisorIpcRequest,
+  SupervisorIpcRequestEnvelope,
+  SupervisorIpcResponse,
+  SupervisorIpcResponseEnvelope,
+} from '../supervisor-ipc/index.js';
+export {
+  ChildStateSchema,
+  ChildStatusSchema,
+  EnvPairSchema,
+  ErrorResponseSchema,
+  HealthRequestSchema,
+  HealthResponseSchema,
+  LifecycleEventKindSchema,
+  LifecycleEventResponseSchema,
+  MonitorRequestSchema,
+  MonitorResponseSchema,
+  RestartedResponseSchema,
+  RestartRequestSchema,
+  SpawnedResponseSchema,
+  SpawnRequestSchema,
+  SUPERVISOR_IPC_CHANNEL_BASENAME,
+  SUPERVISOR_IPC_MESSAGE_KINDS,
+  SUPERVISOR_IPC_PROTOCOL_VERSION,
+  SUPERVISOR_IPC_REQUEST_KINDS,
+  SUPERVISOR_IPC_RESPONSE_KINDS,
+  SupervisorIpcEnvelopeSchema,
+  SupervisorIpcRequestEnvelopeSchema,
+  SupervisorIpcRequestSchema,
+  SupervisorIpcResponseEnvelopeSchema,
+  SupervisorIpcResponseSchema,
+} from '../supervisor-ipc/index.js';
+
+/**
+ * The AC8-canonical name for the frozen daemon-IPC protocol version.
+ *
+ * Alias of `SUPERVISOR_IPC_PROTOCOL_VERSION` — re-exported so the freeze/drift
+ * test (T11369) can pin the value through the `daemon-ipc` surface name AC8
+ * specifies. Both constants are the SAME frozen `'1.0.0'`.
+ */
+export { SUPERVISOR_IPC_PROTOCOL_VERSION as DAEMON_IPC_PROTOCOL_VERSION } from '../supervisor-ipc/version.js';

--- a/packages/contracts/src/daemon/__tests__/health-roundtrip.test.ts
+++ b/packages/contracts/src/daemon/__tests__/health-roundtrip.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Round-trip guard for the daemon health contracts (T11366 AC5).
+ *
+ * Proves a {@link HealthStatus} aggregate projects onto the FROZEN
+ * `supervisor-ipc` {@link MonitorResponseSchema} shape **without a lossy cast**:
+ * `toMonitorChildren` yields rows that validate against the supervisor's own
+ * `MonitorResponse.children` schema, and a `monitor` response carrying them
+ * round-trips through `MonitorResponseSchema.parse`.
+ *
+ * @task T11366
+ */
+
+import {
+  type HealthStatus,
+  MonitorResponseSchema,
+  type SubsystemHealth,
+  SubsystemHealthSchema,
+  summarizeHealth,
+  toMonitorChildren,
+} from '../../index.js';
+
+import { describe, expect, it } from 'vitest';
+
+describe('daemon HealthStatus ↔ supervisor-ipc MonitorResponse (T11366)', () => {
+  const rows: SubsystemHealth[] = [
+    { child_id: 'studio', pid: 4242, state: 'running', restart_count: 0 },
+    {
+      child_id: 'gc-cron',
+      pid: 0,
+      state: 'stopped',
+      restart_count: 2,
+      detail: 'awaiting next scheduled run',
+    },
+  ];
+
+  it('summarizeHealth computes allHealthy from row states', () => {
+    expect(summarizeHealth(rows).allHealthy).toBe(false);
+    expect(
+      summarizeHealth([{ child_id: 'studio', pid: 1, state: 'running', restart_count: 0 }])
+        .allHealthy,
+    ).toBe(true);
+  });
+
+  it('toMonitorChildren projects onto MonitorResponse.children without lossy casts', () => {
+    const health: HealthStatus = summarizeHealth(rows);
+    const children = toMonitorChildren(health);
+
+    // Each projected row must validate against the FROZEN supervisor schema.
+    const monitor = {
+      kind: 'monitor' as const,
+      children,
+    };
+    const parsed = MonitorResponseSchema.safeParse(monitor);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.children).toHaveLength(2);
+      // The daemon-only `detail` field is stripped on projection.
+      expect(parsed.data.children[1]).not.toHaveProperty('detail');
+      expect(parsed.data.children[0]?.child_id).toBe('studio');
+    }
+  });
+
+  it('a SubsystemHealth row is a structural superset of a supervisor ChildStatus', () => {
+    // Validating with the daemon schema accepts the supervisor fields verbatim.
+    const row = SubsystemHealthSchema.parse({
+      child_id: 'web',
+      pid: 9000,
+      state: 'running',
+      restart_count: 0,
+    });
+    expect(row.child_id).toBe('web');
+    // detail is optional and absent here.
+    expect(row.detail).toBeUndefined();
+  });
+
+  it('rejects a health row with a state outside the frozen ChildState enum', () => {
+    const bad = SubsystemHealthSchema.safeParse({
+      child_id: 'x',
+      pid: 0,
+      state: 'paused',
+      restart_count: 0,
+    });
+    expect(bad.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/daemon/__tests__/health-roundtrip.test.ts
+++ b/packages/contracts/src/daemon/__tests__/health-roundtrip.test.ts
@@ -10,6 +10,7 @@
  * @task T11366
  */
 
+import { describe, expect, it } from 'vitest';
 import {
   type HealthStatus,
   MonitorResponseSchema,
@@ -18,8 +19,6 @@ import {
   summarizeHealth,
   toMonitorChildren,
 } from '../../index.js';
-
-import { describe, expect, it } from 'vitest';
 
 describe('daemon HealthStatus ↔ supervisor-ipc MonitorResponse (T11366)', () => {
   const rows: SubsystemHealth[] = [

--- a/packages/contracts/src/daemon/health.ts
+++ b/packages/contracts/src/daemon/health.ts
@@ -1,0 +1,121 @@
+/**
+ * Daemon health contracts — the aggregate shape a subsystem's `healthProbe`
+ * produces and the Rust supervisor consumes.
+ *
+ * These types **compose** the FROZEN `supervisor-ipc` v1.0 contract
+ * ({@link ChildState}, {@link ChildStatus}, {@link MonitorResponse}) rather than
+ * redeclaring it: a single subsystem health row maps onto a supervised
+ * {@link ChildStatus}, and a {@link HealthStatus} aggregate projects losslessly
+ * onto the {@link MonitorResponse} shape the supervisor already aggregates. This
+ * keeps the daemon submodule's probe output on the same wire vocabulary the
+ * supervisor monitors with — no parallel health taxonomy.
+ *
+ * @packageDocumentation
+ * @module @cleocode/contracts/daemon
+ *
+ * @epic T11253 R2 — `@cleocode/runtime/daemon` submodule
+ * @task T11366 — daemon lifecycle + subsystem contracts
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import { z } from 'zod';
+import {
+  type ChildState,
+  ChildStateSchema,
+  type ChildStatus,
+  ChildStatusSchema,
+} from '../supervisor-ipc/messages.js';
+
+/**
+ * The liveness state of a single subsystem.
+ *
+ * This is the FROZEN `supervisor-ipc` {@link ChildState} (`running` |
+ * `restarting` | `stopped`) re-exported under a daemon-facing name so subsystem
+ * authors do not reach across into the IPC module. A subsystem maps onto a
+ * supervised child, so the two states are deliberately identical.
+ */
+export type SubsystemState = ChildState;
+
+/**
+ * Zod schema for {@link SubsystemState}. Aliases the FROZEN
+ * {@link ChildStateSchema} — additive only; never edit the underlying enum.
+ */
+export const SubsystemStateSchema = ChildStateSchema;
+
+/**
+ * A single subsystem's health row.
+ *
+ * Structurally a superset of the supervisor's {@link ChildStatus}: it carries
+ * the same `child_id`/`pid`/`state`/`restart_count` fields (so it projects onto
+ * a {@link ChildStatus} without a lossy cast) plus an optional human-readable
+ * `detail` for diagnostics that never crosses the IPC wire.
+ *
+ * The `child_id` is the subsystem's logical name, matching the id the
+ * supervisor tracks the corresponding child under.
+ */
+export const SubsystemHealthSchema = ChildStatusSchema.extend({
+  /**
+   * Optional human-readable detail (e.g. last error message, queue depth).
+   * Diagnostic only — not part of the supervisor wire contract.
+   */
+  detail: z.string().optional(),
+}).strict();
+
+/** A single subsystem's health row (inferred from {@link SubsystemHealthSchema}). */
+export type SubsystemHealth = z.infer<typeof SubsystemHealthSchema>;
+
+/**
+ * The aggregate health snapshot across every registered subsystem.
+ *
+ * Projects losslessly onto the supervisor's `monitor` snapshot: each
+ * {@link SubsystemHealth} row's supervisor-visible fields ARE a
+ * {@link ChildStatus}, so {@link toMonitorChildren} can hand the supervisor a
+ * `MonitorResponse.children` array with zero casts.
+ */
+export const HealthStatusSchema = z
+  .object({
+    /** One health row per registered subsystem. */
+    subsystems: z.array(SubsystemHealthSchema),
+    /**
+     * `true` iff every subsystem is in the `running` state. A convenience roll-up
+     * derived from {@link HealthStatusSchema.shape.subsystems}; recomputed by
+     * {@link summarizeHealth} so producers cannot desync it.
+     */
+    allHealthy: z.boolean(),
+  })
+  .strict();
+
+/** The aggregate daemon health snapshot (inferred from {@link HealthStatusSchema}). */
+export type HealthStatus = z.infer<typeof HealthStatusSchema>;
+
+/**
+ * Project a {@link HealthStatus} onto the FROZEN supervisor `monitor` row array
+ * (`MonitorResponse['children']`) without a lossy cast.
+ *
+ * Each {@link SubsystemHealth} already carries the four supervisor-visible
+ * fields of a {@link ChildStatus}; this strips the daemon-only `detail` so the
+ * result is byte-compatible with what `cleo-supervisor` aggregates.
+ *
+ * @param health - The aggregate daemon health snapshot.
+ * @returns An array of {@link ChildStatus} rows for a `MonitorResponse`.
+ */
+export function toMonitorChildren(health: HealthStatus): ChildStatus[] {
+  return health.subsystems.map((row): ChildStatus => {
+    const { detail: _detail, ...childStatus } = row;
+    return childStatus;
+  });
+}
+
+/**
+ * Build the aggregate {@link HealthStatus} from per-subsystem rows, computing
+ * the `allHealthy` roll-up so it can never desync from the row states.
+ *
+ * @param subsystems - One {@link SubsystemHealth} row per registered subsystem.
+ * @returns The aggregate health snapshot.
+ */
+export function summarizeHealth(subsystems: SubsystemHealth[]): HealthStatus {
+  return {
+    subsystems,
+    allHealthy: subsystems.every((row) => row.state === 'running'),
+  };
+}

--- a/packages/contracts/src/daemon/index.ts
+++ b/packages/contracts/src/daemon/index.ts
@@ -1,0 +1,35 @@
+/**
+ * `@cleocode/contracts/daemon` — daemon lifecycle + subsystem type contracts.
+ *
+ * The shared, IO-free type vocabulary for the `@cleocode/runtime/daemon`
+ * submodule (R2, T11253): the {@link Subsystem} descriptor, the typed
+ * {@link DaemonLifecycleHooks}, and the {@link HealthStatus} aggregate that
+ * composes the FROZEN `supervisor-ipc` v1.0 contract.
+ *
+ * The implementation (`defineSubsystem`, registry, NDJSON client) lives in
+ * `@cleocode/runtime/daemon` and consumes these types — never redeclares them
+ * (Contracts Fan-Out gate, T10074).
+ *
+ * @packageDocumentation
+ * @module @cleocode/contracts/daemon
+ *
+ * @epic T11253 R2 — `@cleocode/runtime/daemon` submodule
+ * @task T11366 — daemon lifecycle + subsystem contracts
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+export type { HealthStatus, SubsystemHealth, SubsystemState } from './health.js';
+export {
+  HealthStatusSchema,
+  SubsystemHealthSchema,
+  SubsystemStateSchema,
+  summarizeHealth,
+  toMonitorChildren,
+} from './health.js';
+export type {
+  DaemonLifecycleHooks,
+  Subsystem,
+  SubsystemDefinition,
+  SubsystemLifecyclePhase,
+} from './subsystem.js';
+export { SUBSYSTEM_LIFECYCLE_PHASES } from './subsystem.js';

--- a/packages/contracts/src/daemon/subsystem.ts
+++ b/packages/contracts/src/daemon/subsystem.ts
@@ -1,0 +1,126 @@
+/**
+ * Daemon subsystem + lifecycle-hook contracts.
+ *
+ * A **subsystem** is one supervised unit of long-running work inside a CLEO
+ * daemon process — Studio supervision, the GC cron, the web server, the
+ * docs-viewer, the runtime poller. Each declares a uniform lifecycle
+ * (`start → healthProbe → shutdown`) so the `@cleocode/runtime/daemon`
+ * registry can drive them identically and the Rust `cleo-supervisor` can
+ * aggregate their health over the FROZEN `supervisor-ipc` v1.0 contract.
+ *
+ * These are **pure type contracts** (no runtime/IO). The implementation —
+ * `defineSubsystem()`, the registry, the NDJSON client — lives in
+ * `@cleocode/runtime/daemon` (R2 child T11367) and imports these types rather
+ * than redeclaring them (Contracts Fan-Out gate, T10074).
+ *
+ * @packageDocumentation
+ * @module @cleocode/contracts/daemon
+ *
+ * @epic T11253 R2 — `@cleocode/runtime/daemon` submodule
+ * @task T11366 — daemon lifecycle + subsystem contracts
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import type { SubsystemHealth } from './health.js';
+
+/**
+ * Lifecycle hooks fired by the subsystem registry around a subsystem's
+ * `start`/`shutdown` transitions.
+ *
+ * All hooks are optional and may be async. They are observational — a hook
+ * MUST NOT mutate registry state. `onError` is the single failure sink: a
+ * throwing `start` or `shutdown`, or a rejected `healthProbe`, surfaces here.
+ *
+ * Hooks fire in a defined order relative to the underlying transition:
+ * - `onStart`    — after the subsystem's `start()` resolves.
+ * - `onShutdown` — after the subsystem's `shutdown()` resolves.
+ * - `onError`    — when any lifecycle step throws/rejects (start, probe, or
+ *   shutdown), with the offending `error` and the `phase` it occurred in.
+ */
+export interface DaemonLifecycleHooks {
+  /**
+   * Fired after the subsystem has successfully started.
+   *
+   * @param name - The logical subsystem name.
+   */
+  onStart?: (name: string) => void | Promise<void>;
+  /**
+   * Fired after the subsystem has successfully shut down.
+   *
+   * @param name - The logical subsystem name.
+   */
+  onShutdown?: (name: string) => void | Promise<void>;
+  /**
+   * Fired when a lifecycle step throws or rejects. The single failure sink.
+   *
+   * @param name  - The logical subsystem name.
+   * @param error - The thrown value, normalized to an `Error`.
+   * @param phase - Which lifecycle step failed.
+   */
+  onError?: (name: string, error: Error, phase: SubsystemLifecyclePhase) => void | Promise<void>;
+}
+
+/**
+ * The lifecycle phase a subsystem transition is in, used to tag
+ * {@link DaemonLifecycleHooks.onError} and registry diagnostics.
+ */
+export type SubsystemLifecyclePhase = 'start' | 'healthProbe' | 'shutdown';
+
+/**
+ * The frozen, ordered set of lifecycle phases. Pinned by the daemon test suite
+ * so a phase cannot be silently added or removed.
+ */
+export const SUBSYSTEM_LIFECYCLE_PHASES = ['start', 'healthProbe', 'shutdown'] as const;
+
+/**
+ * A subsystem descriptor — the declarative unit `defineSubsystem()` produces
+ * and the registry drives.
+ *
+ * The three lifecycle methods are intentionally minimal and uniform so that
+ * every long-running concern (supervised child process, cron job, HTTP server)
+ * can be expressed identically:
+ *
+ * - `start`       — bring the subsystem up. May be async. Idempotent callers
+ *   should guard re-entry.
+ * - `healthProbe` — report current liveness as a {@link SubsystemHealth} row.
+ *   Maps onto a supervised `ChildStatus` the Rust supervisor aggregates.
+ * - `shutdown`    — bring the subsystem down gracefully. May be async.
+ *
+ * @typeParam TContext - Optional opaque context the registry threads through
+ *   `start`/`shutdown` (e.g. a resolved config or handle). Defaults to `void`.
+ */
+export interface Subsystem<TContext = void> {
+  /** Logical, stable subsystem name (matches the supervised `child_id`). */
+  readonly name: string;
+  /**
+   * Bring the subsystem up. The resolved value is threaded back into
+   * `shutdown` as its context argument.
+   *
+   * @returns The subsystem context (or `void`).
+   */
+  start: () => TContext | Promise<TContext>;
+  /**
+   * Report the subsystem's current health as a single
+   * {@link SubsystemHealth} row.
+   *
+   * @returns The current health row.
+   */
+  healthProbe: () => SubsystemHealth | Promise<SubsystemHealth>;
+  /**
+   * Bring the subsystem down gracefully.
+   *
+   * @param context - The value returned by `start`.
+   */
+  shutdown: (context: TContext) => void | Promise<void>;
+}
+
+/**
+ * The descriptor passed to `defineSubsystem()` — the same surface as
+ * {@link Subsystem} (a 1:1 mapping; `defineSubsystem` validates + freezes it).
+ *
+ * Exposed as a distinct name so call-sites can annotate the literal they pass
+ * without importing the post-construction {@link Subsystem} type.
+ *
+ * @typeParam TContext - See {@link Subsystem}.
+ */
+export type SubsystemDefinition<TContext = void> = Subsystem<TContext>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -288,6 +288,29 @@ export type {
   ParsedClaudeCodeCredential,
 } from './credentials.js';
 export { parseClaudeCodeCredentials } from './credentials.js';
+// === Daemon lifecycle + subsystem contracts (T11366 · SG-RUNTIME-UNIFICATION R2) ===
+export type {
+  DaemonLifecycleHooks,
+  HealthStatus,
+  Subsystem,
+  SubsystemDefinition,
+  SubsystemHealth,
+  SubsystemLifecyclePhase,
+  SubsystemState,
+} from './daemon/index.js';
+export {
+  HealthStatusSchema,
+  SUBSYSTEM_LIFECYCLE_PHASES,
+  SubsystemHealthSchema,
+  SubsystemStateSchema,
+  summarizeHealth,
+  toMonitorChildren,
+} from './daemon/index.js';
+// === Daemon-IPC v1.0 (AC8 alias of supervisor-ipc — T11369 · R2 gates R4-R7) ===
+// `daemon-ipc` is the AC8-named re-export barrel over the FROZEN supervisor-ipc
+// v1.0 contract — one contract, two names. The subpath
+// `@cleocode/contracts/daemon-ipc` resolves via the package `./*` export.
+export { DAEMON_IPC_PROTOCOL_VERSION } from './daemon-ipc/index.js';
 // === DataAccessor Interface ===
 export type {
   AcBindingRow,
@@ -1950,24 +1973,6 @@ export {
   SupervisorIpcResponseEnvelopeSchema,
   SupervisorIpcResponseSchema,
 } from './supervisor-ipc/index.js';
-// === Daemon lifecycle + subsystem contracts (T11366 · SG-RUNTIME-UNIFICATION R2) ===
-export type {
-  DaemonLifecycleHooks,
-  HealthStatus,
-  Subsystem,
-  SubsystemDefinition,
-  SubsystemHealth,
-  SubsystemLifecyclePhase,
-  SubsystemState,
-} from './daemon/index.js';
-export {
-  HealthStatusSchema,
-  SUBSYSTEM_LIFECYCLE_PHASES,
-  SubsystemHealthSchema,
-  SubsystemStateSchema,
-  summarizeHealth,
-  toMonitorChildren,
-} from './daemon/index.js';
 // === Task Types ===
 export type {
   AcceptanceItem,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1950,6 +1950,24 @@ export {
   SupervisorIpcResponseEnvelopeSchema,
   SupervisorIpcResponseSchema,
 } from './supervisor-ipc/index.js';
+// === Daemon lifecycle + subsystem contracts (T11366 · SG-RUNTIME-UNIFICATION R2) ===
+export type {
+  DaemonLifecycleHooks,
+  HealthStatus,
+  Subsystem,
+  SubsystemDefinition,
+  SubsystemHealth,
+  SubsystemLifecyclePhase,
+  SubsystemState,
+} from './daemon/index.js';
+export {
+  HealthStatusSchema,
+  SUBSYSTEM_LIFECYCLE_PHASES,
+  SubsystemHealthSchema,
+  SubsystemStateSchema,
+  summarizeHealth,
+  toMonitorChildren,
+} from './daemon/index.js';
 // === Task Types ===
 export type {
   AcceptanceItem,

--- a/packages/contracts/src/supervisor-ipc/__tests__/freeze.test.ts
+++ b/packages/contracts/src/supervisor-ipc/__tests__/freeze.test.ts
@@ -57,6 +57,26 @@ describe('supervisor-ipc v1.0 freeze guard (T11339)', () => {
       SUPERVISOR_IPC_REQUEST_KINDS.length + SUPERVISOR_IPC_RESPONSE_KINDS.length,
     );
   });
+
+  // T11369 (R2 AC8/AC9) — pin the EXACT complete message-kind tuple. Any
+  // in-place add/rename/remove to the v1.0 set fails here, forcing a new
+  // versioned directory + version-negotiation shim per the contract-evolution
+  // policy (doc slug `daemon-ipc-contract-evolution-policy`) rather than silent
+  // drift that would break R4-R7 adapters.
+  it('pins the EXACT complete frozen message-kind set (T11369)', () => {
+    expect([...SUPERVISOR_IPC_MESSAGE_KINDS]).toEqual([
+      'spawn',
+      'restart',
+      'monitor',
+      'health',
+      'spawned',
+      'restarted',
+      'monitor',
+      'health',
+      'event',
+      'error',
+    ]);
+  });
 });
 
 describe('supervisor-ipc v1.0 wire-shape parity with Rust serde (T11339 AC3)', () => {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./daemon": {
+      "types": "./dist/daemon/index.d.ts",
+      "import": "./dist/daemon/index.js"
     }
   },
   "scripts": {

--- a/packages/runtime/src/daemon/__tests__/logger.test.ts
+++ b/packages/runtime/src/daemon/__tests__/logger.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Log-routing primitive tests for the daemon submodule (T11368).
+ *
+ * Asserts:
+ * 1. createSubsystemLogger routes through the canonical pino factory
+ *    `getLogger` (spied) — never a raw stream or console.
+ * 2. Lines are namespaced per subsystem (a `daemonSubsystem` child binding).
+ * 3. ZERO `console.*` and ZERO `createWriteStream` in the daemon submodule
+ *    production paths (static grep over the non-test sources).
+ *
+ * @task T11368
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const daemonSrcDir = join(here, '..');
+
+// Mock the canonical core logger factory so we can prove routing without
+// initializing the real pino transport.
+const childLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+const baseLogger = {
+  child: vi.fn(() => childLogger),
+};
+const getLoggerMock = vi.fn(() => baseLogger);
+
+vi.mock('@cleocode/core', () => ({
+  getLogger: (subsystem: string) => getLoggerMock(subsystem),
+}));
+
+describe('createSubsystemLogger routing (T11368)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes through the canonical getLogger factory under the daemon root', async () => {
+    const { createSubsystemLogger } = await import('../logger.js');
+    createSubsystemLogger('studio');
+    expect(getLoggerMock).toHaveBeenCalledWith('daemon');
+  });
+
+  it('namespaces lines per subsystem via a daemonSubsystem child binding', async () => {
+    const { createSubsystemLogger } = await import('../logger.js');
+    createSubsystemLogger('gc');
+    expect(baseLogger.child).toHaveBeenCalledWith({ daemonSubsystem: 'gc' });
+  });
+
+  it('forwards each level to the underlying pino child logger', async () => {
+    const { createSubsystemLogger } = await import('../logger.js');
+    const log = createSubsystemLogger('web');
+    log.info({ pid: 1 }, 'started');
+    log.warn({ code: 'X' }, 'warned');
+    log.error({ err: 'e' }, 'failed');
+    log.debug({ d: 1 }, 'debugged');
+    expect(childLogger.info).toHaveBeenCalledWith({ pid: 1 }, 'started');
+    expect(childLogger.warn).toHaveBeenCalledWith({ code: 'X' }, 'warned');
+    expect(childLogger.error).toHaveBeenCalledWith({ err: 'e' }, 'failed');
+    expect(childLogger.debug).toHaveBeenCalledWith({ d: 1 }, 'debugged');
+  });
+});
+
+describe('daemon submodule logging discipline (T11368 AC3)', () => {
+  /** Recursively collect production .ts source files (excludes __tests__). */
+  function collectProductionSources(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === '__tests__') continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        out.push(...collectProductionSources(full));
+      } else if (entry.name.endsWith('.ts')) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  it('has zero console.* and zero createWriteStream in production paths', () => {
+    const sources = collectProductionSources(daemonSrcDir);
+    expect(sources.length).toBeGreaterThan(0);
+    const offenders: string[] = [];
+    for (const file of sources) {
+      const text = readFileSync(file, 'utf8');
+      // Match actual console method calls and raw file-stream opens, not the
+      // words appearing inside TSDoc prose (which describe what we DON'T do).
+      // Strip block comments first so doc-comment mentions don't false-positive.
+      const code = text.replace(/\/\*[\s\S]*?\*\//g, '');
+      if (/\bconsole\.(log|info|warn|error|debug)\s*\(/.test(code)) {
+        offenders.push(`${file}: console.*`);
+      }
+      if (/\bcreateWriteStream\s*\(/.test(code)) {
+        offenders.push(`${file}: createWriteStream`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/runtime/src/daemon/__tests__/migration-readiness.test.ts
+++ b/packages/runtime/src/daemon/__tests__/migration-readiness.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Migration-readiness adapter proof (T11370 — R2 AC7 validation).
+ *
+ * Proves the `defineSubsystem` API can express the FULL lifecycle of the two
+ * representative legacy daemons WITHOUT loss, so R4-R7 inherit a verified
+ * contract:
+ *
+ * 1. A **process-supervisor** adapter mirroring `StudioSupervisor`
+ *    (packages/core/src/sentient/daemon.ts): `start()` (sync spawn), `stop()`
+ *    (SIGTERM grace → SIGKILL), `status`/`pid` getters, and exponential-backoff
+ *    crash respawn.
+ * 2. A **scheduled (cron)** adapter mirroring `gc/daemon.ts`: spawn → persisted
+ *    pid + startedAt, cron schedule, crash recovery (resume pending prune), and
+ *    missed-run recovery (run immediately if elapsed > 24h).
+ *
+ * These adapters are TEST-ONLY fakes that reproduce the legacy lifecycle SHAPE
+ * (not the real process IO). NO production code in core/cleo is migrated here —
+ * R4-R7 own that. The goal is to validate the API surface and feed the
+ * gap-analysis note (doc slug `daemon-subsystem-api-gap-analysis`).
+ *
+ * @task T11370
+ */
+
+import type { SubsystemHealth } from '@cleocode/contracts';
+import { describe, expect, it, vi } from 'vitest';
+
+import { defineSubsystem } from '../define-subsystem.js';
+import { SubsystemRegistry } from '../registry.js';
+
+// ─── Adapter 1: process supervisor (StudioSupervisor shape) ──────────────────
+
+/** Liveness states a process supervisor reports — mirrors StudioStatus. */
+type StudioStatus = 'stopped' | 'running' | 'crashed' | 'not-available';
+
+/**
+ * A faithful in-memory fake of the StudioSupervisor lifecycle: synchronous
+ * `start()`, async `stop()` with a SIGTERM grace window, `status`/`pid`
+ * getters, and exponential-backoff respawn on crash. Mirrors the real class's
+ * observable surface without spawning a real child process.
+ */
+class FakeStudioSupervisor {
+  #status: StudioStatus = 'stopped';
+  #pid: number | null = null;
+  #stopped = false;
+  #currentDelay: number;
+  readonly #maxDelay: number;
+  #nextPid = 4242;
+
+  constructor(initialDelay = 1_000, maxDelay = 30_000) {
+    this.#currentDelay = initialDelay;
+    this.#maxDelay = maxDelay;
+  }
+
+  get status(): StudioStatus {
+    return this.#status;
+  }
+  get pid(): number | null {
+    return this.#pid;
+  }
+  /** Current backoff delay (exposed for the respawn assertion). */
+  get backoffMs(): number {
+    return this.#currentDelay;
+  }
+
+  start(): void {
+    if (this.#stopped || this.#pid !== null) return;
+    this.#pid = this.#nextPid++;
+    this.#status = 'running';
+  }
+
+  /** Simulate a crash → schedule respawn with exponential backoff. */
+  simulateCrash(): void {
+    this.#pid = null;
+    this.#status = 'crashed';
+    this.#currentDelay = Math.min(this.#currentDelay * 2, this.#maxDelay);
+  }
+
+  async stop(): Promise<void> {
+    this.#stopped = true;
+    this.#pid = null;
+    this.#status = 'stopped';
+    await Promise.resolve();
+  }
+}
+
+/** Map a StudioStatus onto a supervisor-ipc SubsystemHealth row. */
+function studioToHealth(name: string, sup: FakeStudioSupervisor): SubsystemHealth {
+  const state =
+    sup.status === 'running' ? 'running' : sup.status === 'crashed' ? 'restarting' : 'stopped';
+  return { child_id: name, pid: sup.pid ?? 0, state, restart_count: 0 };
+}
+
+// ─── Adapter 2: scheduled cron daemon (gc/daemon.ts shape) ───────────────────
+
+/** A faithful in-memory fake of the GC cron daemon lifecycle. */
+class FakeGcDaemon {
+  pid: number | null = null;
+  startedAt: string | null = null;
+  lastRunAt: string | null = null;
+  pendingPrune: string[] = [];
+  cronScheduled = false;
+  runs = 0;
+
+  /** spawn → persist pid + startedAt + schedule cron (mirrors spawnGCDaemon). */
+  async spawn(): Promise<number> {
+    this.pid = 9100;
+    this.startedAt = new Date().toISOString();
+    this.cronScheduled = true;
+    // Bootstrap recovery steps run at spawn:
+    await this.#crashRecovery();
+    await this.#missedRunRecovery();
+    return this.pid;
+  }
+
+  /** Resume a pending prune left by a prior crash (crash recovery). */
+  async #crashRecovery(): Promise<void> {
+    if (this.pendingPrune.length > 0) {
+      this.pendingPrune = [];
+      this.runs += 1;
+      this.lastRunAt = new Date().toISOString();
+    }
+    await Promise.resolve();
+  }
+
+  /** Run immediately if last run was > 24h ago (missed-run recovery). */
+  async #missedRunRecovery(): Promise<void> {
+    const elapsed = this.lastRunAt
+      ? Date.now() - Date.parse(this.lastRunAt)
+      : Number.POSITIVE_INFINITY;
+    if (elapsed > 24 * 60 * 60 * 1000) {
+      this.runs += 1;
+      this.lastRunAt = new Date().toISOString();
+    }
+    await Promise.resolve();
+  }
+
+  async stop(): Promise<{ stopped: boolean; pid: number | null }> {
+    const pid = this.pid;
+    this.pid = null;
+    this.cronScheduled = false;
+    return { stopped: pid !== null, pid };
+  }
+}
+
+describe('T11370 — StudioSupervisor lifecycle expressed via defineSubsystem', () => {
+  it('expresses start → healthProbe → shutdown without loss', async () => {
+    const sup = new FakeStudioSupervisor();
+    const subsystem = defineSubsystem({
+      name: 'studio',
+      start: () => {
+        sup.start();
+      },
+      healthProbe: () => studioToHealth('studio', sup),
+      shutdown: () => sup.stop(),
+    });
+
+    const registry = new SubsystemRegistry();
+    registry.register(subsystem);
+
+    await registry.startAll();
+    expect(sup.status).toBe('running');
+    expect(sup.pid).not.toBeNull();
+
+    const health = await registry.aggregateHealth();
+    expect(health.subsystems[0]?.state).toBe('running');
+    expect(health.subsystems[0]?.pid).toBe(sup.pid);
+
+    await registry.shutdownAll();
+    expect(sup.status).toBe('stopped');
+    expect(sup.pid).toBeNull();
+  });
+
+  it('surfaces a crashed supervisor as a restarting health row (backoff covered)', async () => {
+    const sup = new FakeStudioSupervisor(1_000, 30_000);
+    const subsystem = defineSubsystem({
+      name: 'studio',
+      start: () => sup.start(),
+      healthProbe: () => studioToHealth('studio', sup),
+      shutdown: () => sup.stop(),
+    });
+    const registry = new SubsystemRegistry();
+    registry.register(subsystem);
+    await registry.startAll();
+
+    // Crash → exponential backoff doubles the delay.
+    sup.simulateCrash();
+    expect(sup.backoffMs).toBe(2_000);
+
+    const health = await registry.aggregateHealth();
+    // The crashed/pending-respawn state maps to the supervisor 'restarting' state.
+    expect(health.subsystems[0]?.state).toBe('restarting');
+    expect(health.allHealthy).toBe(false);
+  });
+});
+
+describe('T11370 — GC cron daemon lifecycle expressed via defineSubsystem', () => {
+  it('expresses a scheduled (cron) subsystem with crash + missed-run recovery', async () => {
+    const gc = new FakeGcDaemon();
+    // Seed a pending prune to exercise crash recovery at spawn.
+    gc.pendingPrune = ['blob-a', 'blob-b'];
+
+    const subsystem = defineSubsystem({
+      name: 'gc',
+      start: () => gc.spawn(),
+      healthProbe: (): SubsystemHealth => ({
+        child_id: 'gc',
+        pid: gc.pid ?? 0,
+        state: gc.pid !== null ? 'running' : 'stopped',
+        restart_count: gc.runs,
+        detail: `cron=${gc.cronScheduled} runs=${gc.runs} lastRunAt=${gc.lastRunAt ?? 'never'}`,
+      }),
+      shutdown: () => gc.stop().then(() => undefined),
+    });
+
+    const registry = new SubsystemRegistry();
+    registry.register(subsystem);
+
+    await registry.startAll();
+    // spawn persisted pid + startedAt and scheduled cron.
+    expect(gc.pid).toBe(9100);
+    expect(gc.startedAt).not.toBeNull();
+    expect(gc.cronScheduled).toBe(true);
+    // Crash recovery (pending prune resumed) AND missed-run recovery both ran.
+    expect(gc.runs).toBeGreaterThanOrEqual(1);
+
+    const health = await registry.aggregateHealth();
+    expect(health.subsystems[0]?.state).toBe('running');
+    expect(health.subsystems[0]?.detail).toContain('cron=true');
+
+    await registry.shutdownAll();
+    expect(gc.pid).toBeNull();
+    expect(gc.cronScheduled).toBe(false);
+  });
+
+  it('drives both subsystems together with LIFO shutdown', async () => {
+    const sup = new FakeStudioSupervisor();
+    const gc = new FakeGcDaemon();
+    const shutdownOrder: string[] = [];
+    const onShutdown = vi.fn((name: string) => {
+      shutdownOrder.push(name);
+    });
+
+    const registry = new SubsystemRegistry({ onShutdown });
+    registry.register(
+      defineSubsystem({
+        name: 'studio',
+        start: () => sup.start(),
+        healthProbe: () => studioToHealth('studio', sup),
+        shutdown: () => sup.stop(),
+      }),
+    );
+    registry.register(
+      defineSubsystem({
+        name: 'gc',
+        start: () => gc.spawn(),
+        healthProbe: (): SubsystemHealth => ({
+          child_id: 'gc',
+          pid: gc.pid ?? 0,
+          state: gc.pid !== null ? 'running' : 'stopped',
+          restart_count: gc.runs,
+        }),
+        shutdown: () => gc.stop().then(() => undefined),
+      }),
+    );
+
+    await registry.startAll();
+    const health = await registry.aggregateHealth();
+    expect(health.subsystems).toHaveLength(2);
+    expect(health.allHealthy).toBe(true);
+
+    await registry.shutdownAll();
+    // Registration order studio, gc → LIFO shutdown gc, studio.
+    expect(shutdownOrder).toEqual(['gc', 'studio']);
+  });
+});

--- a/packages/runtime/src/daemon/__tests__/registry.test.ts
+++ b/packages/runtime/src/daemon/__tests__/registry.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Registry + lifecycle + IPC-client tests for the daemon submodule (T11367).
+ *
+ * Covers all five T11367 acceptance test requirements:
+ * 1. register two subsystems and start them
+ * 2. health aggregation into a HealthStatus that projects onto MonitorResponse
+ * 3. graceful shutdown ordering (LIFO)
+ * 4. lifecycle hooks fire in order; onError catches a throwing start
+ * 5. malformed-NDJSON-line rejection via the typed IPC client
+ *
+ * @task T11367
+ */
+
+import {
+  MonitorResponseSchema,
+  type SubsystemHealth,
+  toMonitorChildren,
+} from '@cleocode/contracts';
+import { describe, expect, it, vi } from 'vitest';
+
+import { defineSubsystem } from '../define-subsystem.js';
+import { SubsystemRegistry } from '../registry.js';
+import { createSupervisorIpcClient, MalformedIpcFrameError } from '../supervisor-client.js';
+
+/** Build a healthy probe row for a named subsystem. */
+function runningRow(name: string, pid: number): SubsystemHealth {
+  return { child_id: name, pid, state: 'running', restart_count: 0 };
+}
+
+describe('defineSubsystem (T11367)', () => {
+  it('returns a frozen registrable subsystem', () => {
+    const s = defineSubsystem({
+      name: 'alpha',
+      start: () => undefined,
+      healthProbe: () => runningRow('alpha', 1),
+      shutdown: () => undefined,
+    });
+    expect(s.name).toBe('alpha');
+    expect(Object.isFrozen(s)).toBe(true);
+  });
+
+  it('rejects an empty name and missing methods', () => {
+    expect(() =>
+      defineSubsystem({
+        name: '',
+        start: () => undefined,
+        healthProbe: () => runningRow('x', 1),
+        shutdown: () => undefined,
+      }),
+    ).toThrow(TypeError);
+  });
+});
+
+describe('SubsystemRegistry lifecycle (T11367)', () => {
+  it('registers two subsystems, starts them, and aggregates health', async () => {
+    const registry = new SubsystemRegistry();
+    registry.register(
+      defineSubsystem({
+        name: 'studio',
+        start: () => 'studio-ctx',
+        healthProbe: () => runningRow('studio', 100),
+        shutdown: () => undefined,
+      }),
+    );
+    registry.register(
+      defineSubsystem({
+        name: 'gc',
+        start: () => 42,
+        healthProbe: () => runningRow('gc', 200),
+        shutdown: () => undefined,
+      }),
+    );
+
+    expect(registry.names).toEqual(['studio', 'gc']);
+
+    await registry.startAll();
+    const health = await registry.aggregateHealth();
+
+    expect(health.subsystems).toHaveLength(2);
+    expect(health.allHealthy).toBe(true);
+
+    // AC4: the aggregate projects onto the FROZEN supervisor MonitorResponse.
+    const monitor = MonitorResponseSchema.safeParse({
+      kind: 'monitor',
+      children: toMonitorChildren(health),
+    });
+    expect(monitor.success).toBe(true);
+  });
+
+  it('rejects duplicate subsystem names', () => {
+    const registry = new SubsystemRegistry();
+    const make = (): ReturnType<typeof defineSubsystem> =>
+      defineSubsystem({
+        name: 'dup',
+        start: () => undefined,
+        healthProbe: () => runningRow('dup', 1),
+        shutdown: () => undefined,
+      });
+    registry.register(make());
+    expect(() => registry.register(make())).toThrow(/duplicate subsystem name/);
+  });
+
+  it('shuts down in reverse registration order (LIFO)', async () => {
+    const order: string[] = [];
+    const registry = new SubsystemRegistry();
+    registry.register(
+      defineSubsystem({
+        name: 'first',
+        start: () => undefined,
+        healthProbe: () => runningRow('first', 1),
+        shutdown: () => {
+          order.push('first');
+        },
+      }),
+    );
+    registry.register(
+      defineSubsystem({
+        name: 'second',
+        start: () => undefined,
+        healthProbe: () => runningRow('second', 2),
+        shutdown: () => {
+          order.push('second');
+        },
+      }),
+    );
+
+    await registry.startAll();
+    await registry.shutdownAll();
+
+    // Registration order: first, second → shutdown order: second, first.
+    expect(order).toEqual(['second', 'first']);
+  });
+
+  it('fires lifecycle hooks in order and onError catches a throwing start', async () => {
+    const events: string[] = [];
+    const onError = vi.fn();
+    const registry = new SubsystemRegistry({
+      onStart: (name) => {
+        events.push(`start:${name}`);
+      },
+      onShutdown: (name) => {
+        events.push(`shutdown:${name}`);
+      },
+      onError,
+    });
+
+    registry.register(
+      defineSubsystem({
+        name: 'good',
+        start: () => {
+          events.push('good.start()');
+          return undefined;
+        },
+        healthProbe: () => runningRow('good', 1),
+        shutdown: () => {
+          events.push('good.shutdown()');
+        },
+      }),
+    );
+    registry.register(
+      defineSubsystem({
+        name: 'bad',
+        start: () => {
+          throw new Error('boom');
+        },
+        healthProbe: () => runningRow('bad', 0),
+        shutdown: () => undefined,
+      }),
+    );
+
+    await expect(registry.startAll()).rejects.toThrow('boom');
+
+    // good started (start() ran, then onStart fired) before bad threw.
+    expect(events).toEqual(['good.start()', 'start:good']);
+    // onError fired with the throwing subsystem name, an Error, and phase=start.
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith('bad', expect.any(Error), 'start');
+
+    // shutdownAll only tears down started subsystems (good), not the failed bad.
+    await registry.shutdownAll();
+    expect(events).toContain('good.shutdown()');
+    expect(events).toContain('shutdown:good');
+  });
+
+  it('a failing healthProbe degrades to a stopped row without aborting the snapshot', async () => {
+    const registry = new SubsystemRegistry();
+    registry.register(
+      defineSubsystem({
+        name: 'healthy',
+        start: () => undefined,
+        healthProbe: () => runningRow('healthy', 1),
+        shutdown: () => undefined,
+      }),
+    );
+    registry.register(
+      defineSubsystem({
+        name: 'flaky',
+        start: () => undefined,
+        healthProbe: () => {
+          throw new Error('probe failed');
+        },
+        shutdown: () => undefined,
+      }),
+    );
+
+    await registry.startAll();
+    const health = await registry.aggregateHealth();
+
+    expect(health.subsystems).toHaveLength(2);
+    expect(health.allHealthy).toBe(false);
+    const flaky = health.subsystems.find((row) => row.child_id === 'flaky');
+    expect(flaky?.state).toBe('stopped');
+    expect(flaky?.detail).toContain('probe failed');
+  });
+});
+
+describe('SupervisorIpcClient NDJSON codec (T11367 AC2)', () => {
+  it('encodes a request envelope as a versioned, correlated NDJSON line', () => {
+    const client = createSupervisorIpcClient();
+    const { id, line } = client.encodeRequest({ kind: 'health' });
+
+    expect(line.endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(line.trimEnd());
+    expect(parsed.protocol_version).toBe('1.0.0');
+    expect(parsed.direction).toBe('request');
+    expect(parsed.id).toBe(id);
+    expect(parsed.request.kind).toBe('health');
+  });
+
+  it('decodes a well-formed response envelope', () => {
+    const client = createSupervisorIpcClient();
+    const wire = JSON.stringify({
+      protocol_version: '1.0.0',
+      id: 'abc',
+      direction: 'response',
+      response: { kind: 'spawned', child_id: 'w1', pid: 4242 },
+    });
+    const env = client.decodeResponseLine(wire);
+    expect(env.direction).toBe('response');
+    expect(env.response.kind).toBe('spawned');
+  });
+
+  it('rejects a non-JSON line with a typed MalformedIpcFrameError (never silently dropped)', () => {
+    const client = createSupervisorIpcClient();
+    expect(() => client.decodeResponseLine('{not json')).toThrow(MalformedIpcFrameError);
+  });
+
+  it('rejects a schema-violating frame with a typed MalformedIpcFrameError', () => {
+    const client = createSupervisorIpcClient();
+    // Valid JSON, invalid contract: unknown response kind.
+    const bad = JSON.stringify({
+      protocol_version: '1.0.0',
+      id: 'abc',
+      direction: 'response',
+      response: { kind: 'bogus' },
+    });
+    let caught: unknown;
+    try {
+      client.decodeResponseLine(bad);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MalformedIpcFrameError);
+    expect((caught as MalformedIpcFrameError).line).toBe(bad);
+  });
+});

--- a/packages/runtime/src/daemon/__tests__/subpath-export.test.ts
+++ b/packages/runtime/src/daemon/__tests__/subpath-export.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Import-smoke + subpath-export guard for `@cleocode/runtime/daemon` (T11365).
+ *
+ * Asserts that:
+ * 1. `package.json` declares a `./daemon` export distinct from the root `.`
+ *    export, both pointing at distinct `dist/**` artifacts.
+ * 2. The built `dist/daemon/index.js` + `dist/daemon/index.d.ts` exist (i.e.
+ *    tsup emits the subpath bundle).
+ * 3. The built daemon entrypoint is importable and structurally distinct from
+ *    the package root entrypoint (different exported surface).
+ *
+ * The build artifacts are produced by `pnpm --filter @cleocode/runtime run
+ * build` (run in CI + the worktree before this suite). When the dist is absent
+ * (e.g. a type-only check before build), the artifact assertions are skipped so
+ * the export-map contract still validates in isolation.
+ *
+ * @task T11365
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// src/daemon/__tests__ → package root is three levels up.
+const packageRoot = resolve(here, '..', '..', '..');
+
+interface SubpathTarget {
+  readonly types: string;
+  readonly import: string;
+}
+interface RuntimePackageJson {
+  readonly exports: Record<string, SubpathTarget>;
+}
+
+function readPackageJson(): RuntimePackageJson {
+  const raw = readFileSync(join(packageRoot, 'package.json'), 'utf8');
+  return JSON.parse(raw) as RuntimePackageJson;
+}
+
+describe('@cleocode/runtime/daemon subpath export (T11365)', () => {
+  it('declares a ./daemon export distinct from the root . export', () => {
+    const pkg = readPackageJson();
+    const root = pkg.exports['.'];
+    const daemon = pkg.exports['./daemon'];
+
+    expect(root).toBeDefined();
+    expect(daemon).toBeDefined();
+
+    // The subpath must resolve to a distinct artifact from the root.
+    expect(daemon?.import).toBe('./dist/daemon/index.js');
+    expect(daemon?.types).toBe('./dist/daemon/index.d.ts');
+    expect(daemon?.import).not.toBe(root?.import);
+    expect(daemon?.types).not.toBe(root?.types);
+  });
+
+  it('emits dist/daemon/index.{js,d.ts} when built', () => {
+    const js = join(packageRoot, 'dist', 'daemon', 'index.js');
+    const dts = join(packageRoot, 'dist', 'daemon', 'index.d.ts');
+    if (!existsSync(js)) {
+      // Build not yet run in this environment; export-map contract above still
+      // asserts the wiring. Skip the artifact existence check.
+      return;
+    }
+    expect(existsSync(js)).toBe(true);
+    expect(existsSync(dts)).toBe(true);
+  });
+
+  it('the built daemon entrypoint imports and is distinct from the root', async () => {
+    const daemonJs = join(packageRoot, 'dist', 'daemon', 'index.js');
+    const rootJs = join(packageRoot, 'dist', 'index.js');
+    if (!existsSync(daemonJs) || !existsSync(rootJs)) {
+      return; // dist not built in this environment — see note above.
+    }
+    const daemonMod = await import(pathToFileURL(daemonJs).href);
+    const rootMod = await import(pathToFileURL(rootJs).href);
+
+    // Both modules load.
+    expect(daemonMod).toBeTypeOf('object');
+    expect(rootMod).toBeTypeOf('object');
+
+    // The two entrypoints expose distinct surfaces: the root exports the legacy
+    // poller/SSE services; the daemon submodule does not.
+    expect(rootMod).toHaveProperty('createRuntime');
+    expect(daemonMod).not.toHaveProperty('createRuntime');
+  });
+});

--- a/packages/runtime/src/daemon/define-subsystem.ts
+++ b/packages/runtime/src/daemon/define-subsystem.ts
@@ -1,0 +1,67 @@
+/**
+ * `defineSubsystem()` — declare a supervised daemon subsystem.
+ *
+ * The single factory R4-R7 adapters call to express a long-running concern
+ * (Studio supervision, GC cron, web server, docs-viewer, runtime poller) as a
+ * uniform {@link Subsystem}. The returned descriptor is frozen so the registry
+ * can drive `start → healthProbe → shutdown` without the definition mutating
+ * underfoot.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/daemon
+ *
+ * @epic T11253 R2 — `@cleocode/runtime/daemon` submodule
+ * @task T11367 — defineSubsystem + lifecycle/health registry + IPC client
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import type { Subsystem, SubsystemDefinition } from '@cleocode/contracts';
+
+/**
+ * Declare a daemon subsystem.
+ *
+ * Validates that the four required surfaces (`name`, `start`, `healthProbe`,
+ * `shutdown`) are present and that `name` is a non-empty string, then returns a
+ * frozen {@link Subsystem} ready to register with a `SubsystemRegistry`.
+ *
+ * @typeParam TContext - Opaque context threaded from `start` into `shutdown`
+ *   (e.g. a child handle or resolved config). Defaults to `void`.
+ * @param definition - The subsystem descriptor.
+ * @returns A frozen, registrable {@link Subsystem}.
+ * @throws {TypeError} When `name` is empty or a required method is missing.
+ *
+ * @example
+ * ```ts
+ * const studio = defineSubsystem({
+ *   name: 'studio',
+ *   start: () => supervisor.start(),
+ *   healthProbe: () => ({ child_id: 'studio', pid: supervisor.pid ?? 0,
+ *                         state: supervisor.status === 'running' ? 'running' : 'stopped',
+ *                         restart_count: 0 }),
+ *   shutdown: () => supervisor.stop(),
+ * });
+ * ```
+ */
+export function defineSubsystem<TContext = void>(
+  definition: SubsystemDefinition<TContext>,
+): Subsystem<TContext> {
+  if (typeof definition.name !== 'string' || definition.name.length === 0) {
+    throw new TypeError('defineSubsystem: `name` must be a non-empty string');
+  }
+  if (typeof definition.start !== 'function') {
+    throw new TypeError(`defineSubsystem(${definition.name}): \`start\` must be a function`);
+  }
+  if (typeof definition.healthProbe !== 'function') {
+    throw new TypeError(`defineSubsystem(${definition.name}): \`healthProbe\` must be a function`);
+  }
+  if (typeof definition.shutdown !== 'function') {
+    throw new TypeError(`defineSubsystem(${definition.name}): \`shutdown\` must be a function`);
+  }
+
+  return Object.freeze({
+    name: definition.name,
+    start: definition.start,
+    healthProbe: definition.healthProbe,
+    shutdown: definition.shutdown,
+  });
+}

--- a/packages/runtime/src/daemon/index.ts
+++ b/packages/runtime/src/daemon/index.ts
@@ -38,3 +38,8 @@ export type {
   SubsystemLifecyclePhase,
   SubsystemState,
 } from '@cleocode/contracts';
+
+export { defineSubsystem } from './define-subsystem.js';
+export { SubsystemRegistry } from './registry.js';
+export type { SupervisorIpcClient } from './supervisor-client.js';
+export { createSupervisorIpcClient, MalformedIpcFrameError } from './supervisor-client.js';

--- a/packages/runtime/src/daemon/index.ts
+++ b/packages/runtime/src/daemon/index.ts
@@ -40,6 +40,8 @@ export type {
 } from '@cleocode/contracts';
 
 export { defineSubsystem } from './define-subsystem.js';
+export type { SubsystemLogFields, SubsystemLogger } from './logger.js';
+export { createSubsystemLogger } from './logger.js';
 export { SubsystemRegistry } from './registry.js';
 export type { SupervisorIpcClient } from './supervisor-client.js';
 export { createSupervisorIpcClient, MalformedIpcFrameError } from './supervisor-client.js';

--- a/packages/runtime/src/daemon/index.ts
+++ b/packages/runtime/src/daemon/index.ts
@@ -1,0 +1,40 @@
+/**
+ * `@cleocode/runtime/daemon` — the daemon submodule.
+ *
+ * A single, uniform lifecycle surface for every long-running CLEO concern
+ * (Studio supervision, the GC cron, the web server, the docs-viewer, the
+ * runtime poller). Subsystems declared via `defineSubsystem` are driven by a
+ * `SubsystemRegistry` through a uniform `start → healthProbe → shutdown`
+ * lifecycle, and their health is surfaced in the shape the Rust
+ * `cleo-supervisor` aggregates over the FROZEN `supervisor-ipc` v1.0 contract.
+ *
+ * This is a **subpath export of `@cleocode/runtime`** (D6 — NOT a separately
+ * published package): `import { defineSubsystem } from '@cleocode/runtime/daemon'`.
+ * It is intentionally distinct from the package root (`@cleocode/runtime`),
+ * which exposes the legacy agent-poller/SSE/heartbeat services.
+ *
+ * All daemon lifecycle + subsystem TYPES live in `@cleocode/contracts/daemon`
+ * (Contracts Fan-Out gate, T10074); this submodule consumes them and provides
+ * the runtime implementation.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/daemon
+ *
+ * @epic T11253 R2 — `@cleocode/runtime/daemon` submodule
+ * @task T11365 — scaffold submodule + ./daemon subpath export
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+// Re-export the daemon type contracts so consumers (and R4-R7 adapters) can
+// import both the API and its types from the single `@cleocode/runtime/daemon`
+// entrypoint. The types are OWNED by @cleocode/contracts/daemon — this is a
+// convenience re-export, not a redeclaration.
+export type {
+  DaemonLifecycleHooks,
+  HealthStatus,
+  Subsystem,
+  SubsystemDefinition,
+  SubsystemHealth,
+  SubsystemLifecyclePhase,
+  SubsystemState,
+} from '@cleocode/contracts';

--- a/packages/runtime/src/daemon/logger.ts
+++ b/packages/runtime/src/daemon/logger.ts
@@ -1,0 +1,101 @@
+/**
+ * Daemon subsystem log-routing primitive.
+ *
+ * `createSubsystemLogger(name)` is the **single** logging surface the
+ * `@cleocode/runtime/daemon` submodule exposes. It routes through the canonical
+ * pino factory `getLogger` (`packages/core/src/logger.ts`) — NOT raw
+ * `createWriteStream` and NOT `console.*` — so every daemon log line lands in
+ * the rotating, retention-managed CLEO log files with a consistent structured
+ * shape and a per-subsystem `subsystem` field.
+ *
+ * It supersedes the **5 ad-hoc logging conventions** the legacy daemons grew,
+ * which R4-R7 will migrate onto this primitive:
+ *
+ * 1. `sentient/daemon.ts` — `createWriteStream(sentient.log)` /
+ *    `createWriteStream(sentient.err)` + `process.stderr.write` lines.
+ * 2. `gc/daemon.ts` — `createWriteStream(gc.log)` / `createWriteStream(gc.err)`.
+ * 3. `web.ts` — `console.*`.
+ * 4. `docs-viewer.ts` — ad-hoc stdout/stderr writes.
+ * 5. the `runtime` services — bespoke per-service logging.
+ *
+ * ## Migration guidance for R4-R7 adapters
+ *
+ * Each adapter (Studio, GC, web, docs-viewer) replaces its bespoke sink with:
+ *
+ * ```ts
+ * import { createSubsystemLogger } from '@cleocode/runtime/daemon';
+ * const log = createSubsystemLogger('studio');
+ * log.info({ pid }, 'Studio started');   // not process.stderr.write(...)
+ * log.error({ err }, 'Studio crashed');  // not createWriteStream('sentient.err')
+ * ```
+ *
+ * Do not import pino directly and do not open file streams — the canonical
+ * factory owns rotation, retention, level, and the `projectHash` correlation
+ * field. Routing through it is what makes the daemon's logs observable via the
+ * same `cleo` log surface as the rest of the system.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/daemon
+ *
+ * @epic T11253 R2 — `@cleocode/runtime/daemon` submodule
+ * @task T11368 — log routing primitive (pino getLogger canonical sink)
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import { getLogger } from '@cleocode/core';
+
+/**
+ * A structured log payload — a plain object of serializable fields merged into
+ * the emitted log record (e.g. `{ pid, err }`).
+ */
+export type SubsystemLogFields = Record<string, unknown>;
+
+/**
+ * The narrow logging surface a daemon subsystem uses.
+ *
+ * Each method accepts an optional structured `fields` object followed by the
+ * message, mirroring pino's `(obj, msg)` call shape. This is intentionally
+ * smaller than the full pino `Logger` so the daemon submodule does not leak the
+ * pino type across its public boundary while still routing through the
+ * canonical pino sink.
+ */
+export interface SubsystemLogger {
+  /** Log at `debug` level. */
+  debug: (fields: SubsystemLogFields, msg: string) => void;
+  /** Log at `info` level. */
+  info: (fields: SubsystemLogFields, msg: string) => void;
+  /** Log at `warn` level. */
+  warn: (fields: SubsystemLogFields, msg: string) => void;
+  /** Log at `error` level. */
+  error: (fields: SubsystemLogFields, msg: string) => void;
+}
+
+/**
+ * Create the single per-subsystem logger for the daemon submodule.
+ *
+ * Routes through the canonical pino factory `getLogger('daemon')` and namespaces
+ * the result with a per-subsystem child binding (`{ subsystem: name }`), so all
+ * daemon log lines share the `daemon` subsystem root while remaining
+ * individually attributable. Never opens a file stream and never writes to
+ * `console`.
+ *
+ * @param name - The logical subsystem name (e.g. `'studio'`, `'gc'`, `'web'`).
+ * @returns A {@link SubsystemLogger} bound to `name`.
+ *
+ * @example
+ * ```ts
+ * const log = createSubsystemLogger('studio');
+ * log.info({ pid: 4242, port: 3456 }, 'Studio started');
+ * ```
+ */
+export function createSubsystemLogger(name: string): SubsystemLogger {
+  // Bind under the canonical 'daemon' root, then a per-subsystem child so each
+  // subsystem's lines carry `{ subsystem: 'daemon', daemonSubsystem: name }`.
+  const log = getLogger('daemon').child({ daemonSubsystem: name });
+  return {
+    debug: (fields, msg) => log.debug(fields, msg),
+    info: (fields, msg) => log.info(fields, msg),
+    warn: (fields, msg) => log.warn(fields, msg),
+    error: (fields, msg) => log.error(fields, msg),
+  };
+}

--- a/packages/runtime/src/daemon/registry.ts
+++ b/packages/runtime/src/daemon/registry.ts
@@ -1,0 +1,178 @@
+/**
+ * `SubsystemRegistry` — drives the uniform daemon subsystem lifecycle.
+ *
+ * Aggregates {@link Subsystem}s declared via `defineSubsystem` and runs them
+ * through a uniform `start → healthProbe → shutdown` lifecycle, firing the
+ * typed {@link DaemonLifecycleHooks} in order. Health probes are aggregated
+ * into a {@link HealthStatus} that projects onto the FROZEN `supervisor-ipc`
+ * `MonitorResponse` the Rust supervisor consumes (AC4).
+ *
+ * Shutdown runs in reverse registration order (LIFO) so dependants stop before
+ * their dependencies — the conventional supervised-process teardown ordering.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/daemon
+ *
+ * @epic T11253 R2 — `@cleocode/runtime/daemon` submodule
+ * @task T11367 — defineSubsystem + lifecycle/health registry + IPC client
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import {
+  type DaemonLifecycleHooks,
+  type HealthStatus,
+  type Subsystem,
+  type SubsystemHealth,
+  type SubsystemLifecyclePhase,
+  summarizeHealth,
+} from '@cleocode/contracts';
+
+/**
+ * A registered subsystem plus its runtime bookkeeping.
+ *
+ * The `context` is the value `start()` resolved to, threaded back into
+ * `shutdown()`. It is type-erased to `unknown` inside the registry because the
+ * registry holds subsystems of heterogeneous context types; each entry's
+ * `subsystem.shutdown` is the only consumer and re-narrows it at the call site
+ * via the subsystem's own typing — no `any`, and the erased value never escapes
+ * the registry surface.
+ */
+interface RegisteredSubsystem {
+  readonly subsystem: Subsystem<unknown>;
+  started: boolean;
+  context: unknown;
+}
+
+/** Normalize an unknown thrown value into an `Error`. */
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+/**
+ * The registry that owns and drives the daemon's subsystems.
+ *
+ * Construct with optional {@link DaemonLifecycleHooks}; register subsystems,
+ * then `startAll()` / `aggregateHealth()` / `shutdownAll()`.
+ */
+export class SubsystemRegistry {
+  readonly #entries: RegisteredSubsystem[] = [];
+  readonly #hooks: DaemonLifecycleHooks;
+
+  /**
+   * @param hooks - Optional lifecycle hooks fired around start/shutdown and on
+   *   any lifecycle error.
+   */
+  constructor(hooks: DaemonLifecycleHooks = {}) {
+    this.#hooks = hooks;
+  }
+
+  /**
+   * Register a subsystem. Registration order defines start order; shutdown runs
+   * in reverse.
+   *
+   * @typeParam TContext - The subsystem's start→shutdown context type.
+   * @param subsystem - A subsystem produced by `defineSubsystem`.
+   * @throws {Error} When a subsystem with the same `name` is already registered.
+   */
+  register<TContext>(subsystem: Subsystem<TContext>): void {
+    if (this.#entries.some((entry) => entry.subsystem.name === subsystem.name)) {
+      throw new Error(`SubsystemRegistry: duplicate subsystem name '${subsystem.name}'`);
+    }
+    // Widen the context type to `unknown` for heterogeneous storage. The
+    // subsystem's own `start`/`shutdown` remain individually well-typed; only
+    // the registry's internal handle is erased, and it never leaks out.
+    this.#entries.push({
+      subsystem: subsystem as Subsystem<unknown>,
+      started: false,
+      context: undefined,
+    });
+  }
+
+  /** The names of all registered subsystems, in registration order. */
+  get names(): readonly string[] {
+    return this.#entries.map((entry) => entry.subsystem.name);
+  }
+
+  /**
+   * Start every registered subsystem in registration order.
+   *
+   * For each subsystem: awaits `start()`, stores the resolved context, then
+   * fires `onStart`. If `start()` throws, fires `onError` with phase `start`
+   * and re-throws — a failed start is surfaced, never swallowed.
+   *
+   * @throws The first subsystem `start()` error (after firing `onError`).
+   */
+  async startAll(): Promise<void> {
+    for (const entry of this.#entries) {
+      try {
+        entry.context = await entry.subsystem.start();
+        entry.started = true;
+        await this.#hooks.onStart?.(entry.subsystem.name);
+      } catch (cause) {
+        await this.#fireError(entry.subsystem.name, cause, 'start');
+        throw toError(cause);
+      }
+    }
+  }
+
+  /**
+   * Probe every registered subsystem and aggregate into a {@link HealthStatus}.
+   *
+   * A subsystem whose `healthProbe()` rejects does not abort the aggregate:
+   * `onError` fires with phase `healthProbe` and the subsystem is reported as a
+   * `stopped` row carrying the error in its `detail`, so the supervisor still
+   * receives a complete snapshot.
+   *
+   * @returns The aggregate health snapshot (projects onto `MonitorResponse`).
+   */
+  async aggregateHealth(): Promise<HealthStatus> {
+    const rows: SubsystemHealth[] = [];
+    for (const entry of this.#entries) {
+      try {
+        rows.push(await entry.subsystem.healthProbe());
+      } catch (cause) {
+        await this.#fireError(entry.subsystem.name, cause, 'healthProbe');
+        rows.push({
+          child_id: entry.subsystem.name,
+          pid: 0,
+          state: 'stopped',
+          restart_count: 0,
+          detail: `healthProbe failed: ${toError(cause).message}`,
+        });
+      }
+    }
+    return summarizeHealth(rows);
+  }
+
+  /**
+   * Shut down every started subsystem in reverse registration order (LIFO).
+   *
+   * Each subsystem's `shutdown(context)` is awaited and `onShutdown` fires. A
+   * throwing `shutdown` fires `onError` with phase `shutdown` but does NOT
+   * abort the teardown of the remaining subsystems — best-effort graceful
+   * shutdown of the whole daemon.
+   */
+  async shutdownAll(): Promise<void> {
+    for (let i = this.#entries.length - 1; i >= 0; i -= 1) {
+      const entry = this.#entries[i];
+      if (entry === undefined || !entry.started) continue;
+      try {
+        await entry.subsystem.shutdown(entry.context);
+        entry.started = false;
+        await this.#hooks.onShutdown?.(entry.subsystem.name);
+      } catch (cause) {
+        await this.#fireError(entry.subsystem.name, cause, 'shutdown');
+        // Continue tearing down the rest — do not abort on one failure.
+      }
+    }
+  }
+
+  /** Fire the `onError` hook, swallowing any error the hook itself throws. */
+  async #fireError(name: string, cause: unknown, phase: SubsystemLifecyclePhase): Promise<void> {
+    try {
+      await this.#hooks.onError?.(name, toError(cause), phase);
+    } catch {
+      // A throwing error-hook must not mask the original failure.
+    }
+  }
+}

--- a/packages/runtime/src/daemon/supervisor-client.ts
+++ b/packages/runtime/src/daemon/supervisor-client.ts
@@ -1,0 +1,151 @@
+/**
+ * Typed NDJSON client for the FROZEN `supervisor-ipc` v1.0 contract.
+ *
+ * The Rust `cleo-supervisor` is the server; a CLEO daemon process is a client
+ * that sends {@link SupervisorIpcRequestEnvelope}s and receives
+ * {@link SupervisorIpcResponseEnvelope}s, one newline-delimited JSON
+ * (NDJSON) envelope per line. This module is a transport-agnostic codec: it
+ * encodes outbound envelopes to NDJSON lines and decodes inbound lines through
+ * the frozen Zod schemas. **Every inbound line is parsed** — a malformed or
+ * schema-violating frame is rejected with a typed {@link MalformedIpcFrameError}
+ * and never silently dropped (T11367 AC2).
+ *
+ * The codec does not own a socket — callers feed it raw lines from whatever
+ * transport (Unix socket, named pipe, test pair) they own, keeping the daemon
+ * submodule free of platform IO and trivially testable.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/daemon
+ *
+ * @epic T11253 R2 — `@cleocode/runtime/daemon` submodule
+ * @task T11367 — defineSubsystem + lifecycle/health registry + IPC client
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import {
+  SUPERVISOR_IPC_PROTOCOL_VERSION,
+  type SupervisorIpcRequest,
+  type SupervisorIpcRequestEnvelope,
+  SupervisorIpcRequestEnvelopeSchema,
+  type SupervisorIpcResponseEnvelope,
+  SupervisorIpcResponseEnvelopeSchema,
+} from '@cleocode/contracts';
+
+/**
+ * A typed error raised when an inbound NDJSON line cannot be decoded into a
+ * valid {@link SupervisorIpcResponseEnvelope}.
+ *
+ * Carries the offending raw `line` and the underlying `cause` (a JSON
+ * `SyntaxError` or a Zod validation error) so callers can log + correlate.
+ * Invalid frames are surfaced as this error — never silently dropped.
+ */
+export class MalformedIpcFrameError extends Error {
+  /** The raw NDJSON line that failed to decode. */
+  readonly line: string;
+
+  /**
+   * @param line  - The offending raw NDJSON line.
+   * @param cause - The underlying JSON or Zod error.
+   */
+  constructor(line: string, cause: unknown) {
+    super(`Malformed supervisor-ipc frame: ${cause instanceof Error ? cause.message : cause}`);
+    this.name = 'MalformedIpcFrameError';
+    this.line = line;
+    this.cause = cause;
+  }
+}
+
+/**
+ * A transport-agnostic codec for the FROZEN `supervisor-ipc` v1.0 wire format.
+ *
+ * Construct via {@link createSupervisorIpcClient}. The client is stateful only
+ * in its monotonic correlation-id counter; it owns no socket.
+ */
+export interface SupervisorIpcClient {
+  /**
+   * Encode a request body into a complete, newline-terminated NDJSON envelope
+   * line ready to write to the transport.
+   *
+   * Stamps the frozen protocol version and a fresh correlation `id`, validates
+   * the result against {@link SupervisorIpcRequestEnvelopeSchema}, and returns
+   * the serialized line (including the trailing `\n`).
+   *
+   * @param request - The request body (validated by the envelope schema).
+   * @returns `{ id, line }` — the correlation id and the NDJSON line to send.
+   */
+  encodeRequest: (request: SupervisorIpcRequest) => { id: string; line: string };
+
+  /**
+   * Decode a single inbound NDJSON line into a typed response envelope.
+   *
+   * Parses the line as JSON, then validates it against
+   * {@link SupervisorIpcResponseEnvelopeSchema}. A malformed or
+   * schema-violating line throws {@link MalformedIpcFrameError} — it is never
+   * silently dropped.
+   *
+   * @param line - A single NDJSON line (without the trailing newline).
+   * @returns The decoded {@link SupervisorIpcResponseEnvelope}.
+   * @throws {MalformedIpcFrameError} When the line is not a valid response frame.
+   */
+  decodeResponseLine: (line: string) => SupervisorIpcResponseEnvelope;
+}
+
+/**
+ * Generate a process-unique correlation id for an IPC request envelope.
+ *
+ * @param seq - The client's monotonic sequence number.
+ * @returns A correlation id of the form `c<seq>-<random>`.
+ */
+function nextCorrelationId(seq: number): string {
+  return `c${seq}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Create a typed NDJSON codec for the FROZEN `supervisor-ipc` v1.0 contract.
+ *
+ * @returns A {@link SupervisorIpcClient}.
+ *
+ * @example
+ * ```ts
+ * const client = createSupervisorIpcClient();
+ * const { id, line } = client.encodeRequest({ kind: 'health' });
+ * socket.write(line);
+ * socket.on('line', (raw) => {
+ *   const env = client.decodeResponseLine(raw); // throws MalformedIpcFrameError on bad frame
+ *   if (env.response.kind === 'health') { /* ... *\/ }
+ * });
+ * ```
+ */
+export function createSupervisorIpcClient(): SupervisorIpcClient {
+  let seq = 0;
+
+  return {
+    encodeRequest(request: SupervisorIpcRequest): { id: string; line: string } {
+      seq += 1;
+      const id = nextCorrelationId(seq);
+      const envelope: SupervisorIpcRequestEnvelope = {
+        protocol_version: SUPERVISOR_IPC_PROTOCOL_VERSION,
+        id,
+        direction: 'request',
+        request,
+      };
+      // Validate before serialization so we never emit an off-contract frame.
+      const parsed = SupervisorIpcRequestEnvelopeSchema.parse(envelope);
+      return { id, line: `${JSON.stringify(parsed)}\n` };
+    },
+
+    decodeResponseLine(line: string): SupervisorIpcResponseEnvelope {
+      let json: unknown;
+      try {
+        json = JSON.parse(line);
+      } catch (cause) {
+        throw new MalformedIpcFrameError(line, cause);
+      }
+      const result = SupervisorIpcResponseEnvelopeSchema.safeParse(json);
+      if (!result.success) {
+        throw new MalformedIpcFrameError(line, result.error);
+      }
+      return result.data;
+    },
+  };
+}

--- a/packages/runtime/tsup.config.ts
+++ b/packages/runtime/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
+    "daemon/index": "src/daemon/index.ts",
   },
   format: ["esm"],
   target: "node20",


### PR DESCRIPTION
## R2 (T11253) — @cleocode/runtime/daemon submodule — Wave-1 of SG-RUNTIME-UNIFICATION (T11243)

The fan-out hub that **unblocks R3–R7** (subsystem migrations). Consumes the frozen supervisor-ipc v1.0 contract from R1. Purely additive (20 files, +1849/−0).

### Surface (`@cleocode/runtime/daemon`)
- `defineSubsystem<TContext>({name,start,healthProbe,shutdown})` → frozen validated `Subsystem`
- `SubsystemRegistry` — `startAll` (registration order) / `aggregateHealth` / `shutdownAll` (LIFO) + `DaemonLifecycleHooks`
- `createSupervisorIpcClient()` — strict NDJSON over the **frozen supervisor-ipc v1.0** Zod schemas (`safeParse` every inbound line → typed `MalformedIpcFrameError`, never silently dropped)
- `createSubsystemLogger()` — routes via pino `getLogger` (zero `console.*`)

### Decisions
- **AC8 reconciliation**: AC named the surface `daemon-ipc/`; R1 shipped `supervisor-ipc/`. Resolved by making `@cleocode/contracts/daemon-ipc` a **thin re-export barrel** over `supervisor-ipc` — one contract, two names, no drift (referential-identity test). 
- All daemon lifecycle/subsystem/health TYPES live in `@cleocode/contracts` (Contracts Fan-Out gate); implementation in `@cleocode/runtime`.
- Contract-evolution policy doc (`daemon-ipc-contract-evolution-policy`): additive-optional OK; any kind/field add/rename/remove → new versioned dir + negotiation shim (freeze-test enforced).

### Validation
Full monorepo build PASS (74.9s) · contracts 696/696 · runtime 28/28 (22 new) · biome clean · Contracts Fan-Out + engines.node SSoT gates green · zero pre-existing failures touched (purely additive).

Child tasks: T11365 (scaffold) · T11366 (contracts) · T11367 (defineSubsystem+registry+IPC client) · T11368 (logger) · T11369 (freeze/publish — gates R4-R7) · T11370 (Studio+GC migration-readiness proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)