### PR TITLE
feat(T11290): CLEO-native evidence-gate-aware goal system (E5 · SG-COGNITIVE-SUBSTRATE)

### DIFF
--- a/packages/cleo/src/cli/__tests__/goal.test.ts
+++ b/packages/cleo/src/cli/__tests__/goal.test.ts
@@ -1,0 +1,216 @@
+/**
+ * End-to-end CLI integration tests for `cleo goal` (T11381).
+ *
+ * Spawns the compiled `cleo` CLI as a subprocess against an isolated tmp
+ * project per test so the LAFS envelope, per-agent scoping, and on-disk
+ * persistence are validated against the same surface external agents see.
+ *
+ * Coverage:
+ *  - Subcommand registration: `cleo goal` exposes set/status/subgoal/append.
+ *  - set → append → status round-trip (append persists; status reflects it).
+ *  - subgoal links parentGoalId to the active goal.
+ *  - status empty-state envelope ({ active: null }) when no goal exists.
+ *  - per-agent isolation: two CLEO_SESSION_ID/CLEO_AGENT_ID identities never
+ *    see each other's goal.
+ *
+ * @epic T11290
+ * @task T11381
+ * @saga T11283
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { goalCommand } from '../commands/goal.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Absolute path to `packages/cleo/` root. */
+const PKG_ROOT = resolve(__dirname, '..', '..', '..');
+
+/** Path to the compiled CLI entry point. */
+const CLI_DIST = resolve(PKG_ROOT, 'dist', 'cli', 'index.js');
+
+/** True when the compiled CLI dist bundle exists and can be spawned. */
+const CLI_DIST_AVAILABLE = existsSync(CLI_DIST);
+
+interface CliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number | null;
+}
+
+/**
+ * Run `node dist/cli/index.js <args>` against an isolated tmp project root,
+ * with an injectable per-agent identity (CLEO_SESSION_ID / CLEO_AGENT_ID).
+ */
+function runCli(
+  args: readonly string[],
+  projectRoot: string,
+  identity?: { sessionId: string; agentId: string },
+): CliResult {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    CLEO_PROJECT_ROOT: projectRoot,
+    CLEO_ROOT: projectRoot,
+    CLEO_DIR: join(projectRoot, '.cleo'),
+    CLEO_OUTPUT_FORMAT: 'json',
+  };
+  if (identity) {
+    env.CLEO_SESSION_ID = identity.sessionId;
+    env.CLEO_AGENT_ID = identity.agentId;
+  }
+  const result = spawnSync('node', [CLI_DIST, ...args], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+    timeout: 90_000,
+    cwd: projectRoot,
+    env,
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status,
+  };
+}
+
+interface LafsEnvelope<TData = unknown> {
+  readonly success: boolean;
+  readonly data?: TData;
+  readonly error?: { readonly codeName?: string; readonly message?: string };
+}
+
+/** Extract the JSON LAFS envelope from a CLI invocation's stdout. */
+function parseEnvelope<T = unknown>(stdout: string): LafsEnvelope<T> {
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+  for (const line of lines) {
+    if (!line.trim().startsWith('{')) continue;
+    try {
+      return JSON.parse(line) as LafsEnvelope<T>;
+    } catch {
+      /* keep scanning */
+    }
+  }
+  throw new Error(`parseEnvelope: no JSON envelope on stdout. Got:\n${stdout.slice(0, 2000)}`);
+}
+
+interface GoalData {
+  readonly id: string;
+  readonly intent: string;
+  readonly criteria: string[];
+  readonly status: string;
+  readonly parentGoalId: string | null;
+  readonly goalKind: { kind: string; targetTaskId?: string };
+}
+
+const AGENT_A = { sessionId: 'ses_20260530000000_aaa111', agentId: 'agent-A' };
+const AGENT_B = { sessionId: 'ses_20260530000000_bbb222', agentId: 'agent-B' };
+
+let projectRoot: string;
+
+beforeEach(async () => {
+  projectRoot = await mkdtemp(join(tmpdir(), 'cleo-T11381-cli-'));
+  // Initialize the project so tasks.db exists and migrations run.
+  if (CLI_DIST_AVAILABLE) runCli(['init'], projectRoot);
+});
+
+afterEach(async () => {
+  await rm(projectRoot, { recursive: true, force: true }).catch(() => {
+    /* never fail teardown */
+  });
+});
+
+// ─── Subcommand registration (no spawn) ──────────────────────────────────────
+
+interface CittyCommand {
+  meta?: unknown;
+  subCommands?: Record<string, CittyCommand>;
+}
+
+describe('cleo goal — subcommand registration', () => {
+  it('exposes set, status, subgoal, and append', () => {
+    const cmd = goalCommand as unknown as CittyCommand;
+    expect(cmd.subCommands).toBeDefined();
+    expect(Object.keys(cmd.subCommands ?? {}).sort()).toEqual([
+      'append',
+      'set',
+      'status',
+      'subgoal',
+    ]);
+  });
+});
+
+// ─── End-to-end (requires compiled dist) ─────────────────────────────────────
+
+describe.runIf(CLI_DIST_AVAILABLE)('cleo goal — end-to-end', () => {
+  it('status returns a clean empty-state envelope when no goal exists', () => {
+    const res = runCli(['goal', 'status'], projectRoot, AGENT_A);
+    const env = parseEnvelope<{ active: null }>(res.stdout);
+    expect(env.success).toBe(true);
+    expect(env.data).toEqual({ active: null });
+  });
+
+  it('set → append → status round-trip', () => {
+    const setRes = runCli(['goal', 'set', 'explore auth', '--turns', '5'], projectRoot, AGENT_A);
+    const setEnv = parseEnvelope<GoalData>(setRes.stdout);
+    expect(setEnv.success).toBe(true);
+    expect(setEnv.data?.intent).toBe('explore auth');
+    expect(setEnv.data?.status).toBe('active');
+
+    const appendRes = runCli(['goal', 'append', 'list the risks'], projectRoot, AGENT_A);
+    const appendEnv = parseEnvelope<GoalData>(appendRes.stdout);
+    expect(appendEnv.success).toBe(true);
+    expect(appendEnv.data?.criteria).toEqual(['list the risks']);
+
+    const statusRes = runCli(['goal', 'status'], projectRoot, AGENT_A);
+    const statusEnv = parseEnvelope<GoalData>(statusRes.stdout);
+    expect(statusEnv.data?.intent).toBe('explore auth');
+    expect(statusEnv.data?.criteria).toEqual(['list the risks']);
+  });
+
+  it('subgoal links parentGoalId to the active goal', () => {
+    const parentRes = runCli(['goal', 'set', 'parent goal'], projectRoot, AGENT_A);
+    const parentEnv = parseEnvelope<GoalData>(parentRes.stdout);
+    const parentId = parentEnv.data?.id;
+    expect(parentId).toBeTruthy();
+
+    const subRes = runCli(
+      ['goal', 'subgoal', 'child goal', '--task', 'T123'],
+      projectRoot,
+      AGENT_A,
+    );
+    const subEnv = parseEnvelope<GoalData>(subRes.stdout);
+    expect(subEnv.success).toBe(true);
+    expect(subEnv.data?.parentGoalId).toBe(parentId);
+    // --task makes it an evidence-judged task-completion goal.
+    expect(subEnv.data?.goalKind.kind).toBe('task-completion');
+    expect(subEnv.data?.goalKind.targetTaskId).toBe('T123');
+  });
+
+  it('set with an invalid --task is rejected', () => {
+    const res = runCli(['goal', 'set', 'g', '--task', 'not-a-task'], projectRoot, AGENT_A);
+    const env = parseEnvelope(res.stdout);
+    expect(env.success).toBe(false);
+    expect(env.error?.codeName).toBe('E_VALIDATION');
+  });
+
+  it("two agents never see each other's goal (per-agent isolation)", () => {
+    runCli(['goal', 'set', 'goal-A'], projectRoot, AGENT_A);
+    runCli(['goal', 'set', 'goal-B'], projectRoot, AGENT_B);
+
+    const aStatus = parseEnvelope<GoalData>(
+      runCli(['goal', 'status'], projectRoot, AGENT_A).stdout,
+    );
+    const bStatus = parseEnvelope<GoalData>(
+      runCli(['goal', 'status'], projectRoot, AGENT_B).stdout,
+    );
+
+    expect(aStatus.data?.intent).toBe('goal-A');
+    expect(bStatus.data?.intent).toBe('goal-B');
+  });
+});

--- a/packages/cleo/src/cli/commands/goal.ts
+++ b/packages/cleo/src/cli/commands/goal.ts
@@ -1,0 +1,206 @@
+/**
+ * CLI `cleo goal` — the agent-facing surface for CLEO's DB-persisted, per-agent,
+ * evidence-gate-aware goal loop (Layer 4 of SG-COGNITIVE-SUBSTRATE).
+ *
+ * Every handler is a THIN dispatch into the core `goal.*` ops
+ * (`@cleocode/core/goal`) — no business logic lives here, satisfying the CLI
+ * package-boundary gate. Each subcommand returns a single LAFS envelope to
+ * stdout (ADR-086) via `cliOutput`; diagnostics go to stderr via `cliError`.
+ *
+ * Subcommands:
+ *   - `cleo goal set <intent> [--task T###] [--turns N]` — create the agent's
+ *     goal. `--task` makes it an evidence-judged task-completion goal; without
+ *     it the goal is fuzzy (LLM-judge fallback).
+ *   - `cleo goal status` — the CURRENT agent's active goal (resolved per-agent
+ *     via the env identity, so concurrent agents see their own goal).
+ *   - `cleo goal subgoal <intent> [--task T###] [--turns N]` — create a child
+ *     goal linked to the active goal via `parentGoalId`.
+ *   - `cleo goal append <criterion>` — append an acceptance criterion to the
+ *     active goal.
+ *
+ * @epic T11290 EP-CLEO-GOAL-SYSTEM
+ * @task T11381
+ * @saga T11283 SG-COGNITIVE-SUBSTRATE
+ */
+
+import { ExitCode, type GoalKind, isValidGoalTargetTaskId } from '@cleocode/contracts';
+import { getProjectRoot, goal } from '@cleocode/core';
+import { defineCommand, showUsage } from '../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../renderers/index.js';
+
+/** Default turn budget when `--turns` is omitted. */
+const DEFAULT_TURN_BUDGET = 10;
+
+/**
+ * Resolve a goal-kind from the optional `--task` flag. A valid `T###` id yields
+ * an evidence-judged task-completion goal; absence yields a fuzzy goal.
+ *
+ * @internal
+ */
+function resolveGoalKind(task: unknown): { kind: GoalKind } | { error: string } {
+  if (typeof task === 'string' && task.length > 0) {
+    if (!isValidGoalTargetTaskId(task)) {
+      return { error: `--task must be a valid task id (T + 1-7 digits) — got '${task}'` };
+    }
+    return { kind: { kind: 'task-completion', targetTaskId: task } };
+  }
+  return { kind: { kind: 'fuzzy' } };
+}
+
+/**
+ * Parse the optional `--turns` flag into a positive integer budget.
+ *
+ * @internal
+ */
+function resolveTurnBudget(turns: unknown): number {
+  const n = typeof turns === 'string' ? Number.parseInt(turns, 10) : Number(turns);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_TURN_BUDGET;
+}
+
+const setCommand = defineCommand({
+  meta: {
+    name: 'set',
+    description: "Set the current agent's goal (evidence-judged when --task given).",
+  },
+  args: {
+    intent: { type: 'positional', description: 'What the agent is trying to achieve' },
+    task: { type: 'string', description: 'Target task id (T###) — makes it evidence-judged' },
+    turns: { type: 'string', description: 'Turn budget (default 10)' },
+  },
+  async run({ args }) {
+    const intent = String(args.intent ?? '').trim();
+    if (intent.length === 0) {
+      cliError('goal set requires an <intent>', ExitCode.VALIDATION_ERROR, {
+        name: 'E_VALIDATION',
+      });
+      return;
+    }
+    const kindResult = resolveGoalKind(args.task);
+    if ('error' in kindResult) {
+      cliError(kindResult.error, ExitCode.VALIDATION_ERROR, { name: 'E_VALIDATION' });
+      return;
+    }
+    const record = await goal.createGoal(
+      { goalKind: kindResult.kind, intent, turnBudget: resolveTurnBudget(args.turns) },
+      getProjectRoot(),
+    );
+    cliOutput(record, { command: 'goal set', operation: 'goal.set' });
+  },
+});
+
+const statusCommand = defineCommand({
+  meta: {
+    name: 'status',
+    description: "Show the current agent's active goal (per-agent scoped).",
+  },
+  async run() {
+    const record = await goal.getActiveGoal(getProjectRoot());
+    cliOutput(record ?? { active: null }, { command: 'goal status', operation: 'goal.status' });
+  },
+});
+
+const subgoalCommand = defineCommand({
+  meta: {
+    name: 'subgoal',
+    description: 'Create a sub-goal linked to the active goal via parentGoalId.',
+  },
+  args: {
+    intent: { type: 'positional', description: 'The sub-goal intent' },
+    task: { type: 'string', description: 'Target task id (T###) — makes it evidence-judged' },
+    turns: { type: 'string', description: 'Turn budget (default 10)' },
+  },
+  async run({ args }) {
+    const intent = String(args.intent ?? '').trim();
+    if (intent.length === 0) {
+      cliError('goal subgoal requires an <intent>', ExitCode.VALIDATION_ERROR, {
+        name: 'E_VALIDATION',
+      });
+      return;
+    }
+    const cwd = getProjectRoot();
+    const parent = await goal.getActiveGoal(cwd);
+    if (!parent) {
+      cliError(
+        'No active goal to attach a sub-goal to. Run `cleo goal set` first.',
+        ExitCode.NOT_FOUND,
+        {
+          name: 'E_NOT_FOUND',
+        },
+      );
+      return;
+    }
+    const kindResult = resolveGoalKind(args.task);
+    if ('error' in kindResult) {
+      cliError(kindResult.error, ExitCode.VALIDATION_ERROR, { name: 'E_VALIDATION' });
+      return;
+    }
+    const record = await goal.createGoal(
+      {
+        goalKind: kindResult.kind,
+        intent,
+        turnBudget: resolveTurnBudget(args.turns),
+        parentGoalId: parent.id,
+      },
+      cwd,
+    );
+    cliOutput(record, { command: 'goal subgoal', operation: 'goal.subgoal' });
+  },
+});
+
+const appendCommand = defineCommand({
+  meta: {
+    name: 'append',
+    description: 'Append an acceptance criterion to the active goal.',
+  },
+  args: {
+    criterion: { type: 'positional', description: 'The criterion text to append' },
+  },
+  async run({ args }) {
+    const criterion = String(args.criterion ?? '').trim();
+    if (criterion.length === 0) {
+      cliError('goal append requires a <criterion>', ExitCode.VALIDATION_ERROR, {
+        name: 'E_VALIDATION',
+      });
+      return;
+    }
+    const cwd = getProjectRoot();
+    const active = await goal.getActiveGoal(cwd);
+    if (!active) {
+      cliError(
+        'No active goal to append a criterion to. Run `cleo goal set` first.',
+        ExitCode.NOT_FOUND,
+        {
+          name: 'E_NOT_FOUND',
+        },
+      );
+      return;
+    }
+    const record = await goal.appendCriteria(active.id, criterion, cwd);
+    cliOutput(record ?? { active: null }, { command: 'goal append', operation: 'goal.append' });
+  },
+});
+
+/**
+ * Parent `cleo goal` command — routes to the set/status/subgoal/append
+ * subcommands; prints usage when invoked bare.
+ *
+ * @task T11381
+ */
+export const goalCommand = defineCommand({
+  meta: {
+    name: 'goal',
+    description:
+      'DB-persisted, per-agent, evidence-gate-aware goal loop (set/status/subgoal/append).',
+  },
+  subCommands: {
+    set: setCommand,
+    status: statusCommand,
+    subgoal: subgoalCommand,
+    append: appendCommand,
+  },
+  async run({ cmd, rawArgs }) {
+    const firstArg = rawArgs?.find((a) => !a.startsWith('-'));
+    if (firstArg && cmd.subCommands && firstArg in cmd.subCommands) return;
+    await showUsage(cmd);
+  },
+});

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -44,8 +45,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description:
-      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -84,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -102,31 +99,26 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description:
-      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () =>
-      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -149,8 +141,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -240,8 +231,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description:
-      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -260,8 +250,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -284,16 +273,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -317,8 +304,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -329,9 +315,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
+  },
+  {
+    exportName: '_llmOutputCommand',
+    name: 'llm-output',
+    description: 'Unified LLM output: task export (rich Markdown with frontmatter + body + attachments + memory refs) ',
+    load: async () => (await import('../commands/docs.js'))._llmOutputCommand as CommandDef,
   },
   {
     exportName: 'docsCommand',
@@ -343,33 +334,25 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () =>
-      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description:
-      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () =>
-      (await import('../commands/doctor-legacy-backups.js'))
-        .doctorLegacyBackupsCommand as CommandDef,
+    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorReleaseReadinessCommand',
     name: 'release-readiness',
-    description:
-      'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
-    load: async () =>
-      (await import('../commands/doctor-release-readiness.js'))
-        .doctorReleaseReadinessCommand as CommandDef,
+    description: 'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
+    load: async () => (await import('../commands/doctor-release-readiness.js')).doctorReleaseReadinessCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -405,8 +388,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -429,8 +411,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description:
-      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -438,6 +419,12 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'gc',
     description: 'Transcript garbage collection: manual trigger and status',
     load: async () => (await import('../commands/gc.js')).gcCommand as CommandDef,
+  },
+  {
+    exportName: 'goalCommand',
+    name: 'goal',
+    description: 'DB-persisted, per-agent, evidence-gate-aware goal loop (set/status/subgoal/append).',
+    load: async () => (await import('../commands/goal.js')).goalCommand as CommandDef,
   },
   {
     exportName: 'gradeCommand',
@@ -467,8 +454,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -491,17 +477,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -530,8 +513,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -567,24 +549,20 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'memoryCommand',
     name: 'memory',
-    description:
-      'BRAIN memory operations (patterns, learnings, decisions — use decision-store/-find for architectural decisions)',
+    description: 'BRAIN memory operations (patterns, learnings, decisions — use decision-store/-find for architectural decisions)',
     load: async () => (await import('../commands/memory.js')).memoryCommand as CommandDef,
   },
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -613,8 +591,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -626,15 +603,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -683,8 +658,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -695,8 +669,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description:
-      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -732,8 +705,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description:
-      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -745,8 +717,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -758,8 +729,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -807,15 +777,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
+    description: 'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -887,8 +855,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'templatesCommand',
     name: 'templates',
-    description:
-      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
     load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
   },
   {
@@ -900,8 +867,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -913,15 +879,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description:
-      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -45,7 +44,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description:
+      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,8 +63,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +84,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -99,26 +102,31 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description:
+      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () =>
+      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -141,7 +149,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -231,7 +240,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description:
+      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -250,7 +260,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -273,14 +284,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -304,7 +317,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -315,13 +329,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
     exportName: '_llmOutputCommand',
     name: 'llm-output',
-    description: 'Unified LLM output: task export (rich Markdown with frontmatter + body + attachments + memory refs) ',
+    description:
+      'Unified LLM output: task export (rich Markdown with frontmatter + body + attachments + memory refs) ',
     load: async () => (await import('../commands/docs.js'))._llmOutputCommand as CommandDef,
   },
   {
@@ -334,25 +350,33 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
+    description:
+      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () =>
+      (await import('../commands/doctor-legacy-backups.js'))
+        .doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorReleaseReadinessCommand',
     name: 'release-readiness',
-    description: 'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
-    load: async () => (await import('../commands/doctor-release-readiness.js')).doctorReleaseReadinessCommand as CommandDef,
+    description:
+      'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
+    load: async () =>
+      (await import('../commands/doctor-release-readiness.js'))
+        .doctorReleaseReadinessCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -388,7 +412,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -411,7 +436,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description:
+      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -423,7 +449,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'goalCommand',
     name: 'goal',
-    description: 'DB-persisted, per-agent, evidence-gate-aware goal loop (set/status/subgoal/append).',
+    description:
+      'DB-persisted, per-agent, evidence-gate-aware goal loop (set/status/subgoal/append).',
     load: async () => (await import('../commands/goal.js')).goalCommand as CommandDef,
   },
   {
@@ -454,7 +481,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -477,14 +505,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -513,7 +544,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -549,20 +581,24 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'memoryCommand',
     name: 'memory',
-    description: 'BRAIN memory operations (patterns, learnings, decisions — use decision-store/-find for architectural decisions)',
+    description:
+      'BRAIN memory operations (patterns, learnings, decisions — use decision-store/-find for architectural decisions)',
     load: async () => (await import('../commands/memory.js')).memoryCommand as CommandDef,
   },
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -591,7 +627,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -603,13 +640,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -658,7 +697,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -669,7 +709,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -705,7 +746,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description:
+      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -717,7 +759,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -729,7 +772,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -777,13 +821,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
+    description:
+      'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -855,7 +901,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'templatesCommand',
     name: 'templates',
-    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    description:
+      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
     load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
   },
   {
@@ -867,7 +914,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -879,13 +927,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description:
+      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/contracts/src/goal.ts
+++ b/packages/contracts/src/goal.ts
@@ -1,0 +1,348 @@
+/**
+ * CLEO-native goal-system contracts (Layer 4 of SG-COGNITIVE-SUBSTRATE).
+ *
+ * A *goal* is a DB-persisted, per-agent, turn-budgeted intent that CLEO drives
+ * to completion by judging progress after every agent turn. CLEO's goal loop is
+ * designed to beat two prior-art systems:
+ *
+ * - **Claude-Code** — a `Stop` hook + a Haiku *transcript judge* (the model
+ *   reads the conversation and guesses whether the task is done). It has no
+ *   turn budget and no persistence: a fresh process forgets the goal.
+ * - **Hermes** — a post-turn loop with a turn budget and parse-failure
+ *   auto-pause, but it still judges *fuzzy* intent against transcript text.
+ *
+ * CLEO's differentiator is the **evidence-gate-aware judge**: when a goal is to
+ * *complete a task* (`complete T123`), the judge does NOT read the transcript.
+ * It resolves the target task's actual `status` and re-uses the shipped ADR-051
+ * evidence infrastructure ({@link GateEvidenceRequirement} +
+ * `validateEvidenceForGate`) — the goal is satisfied ONLY when the task is
+ * `done` with its required gates backed by real, validated evidence atoms
+ * (commit reachable, file sha256 match, test-run hash match). Transcript text
+ * can never satisfy a task-completion goal. Fuzzy goals fall back to an
+ * injectable LLM judge (see {@link GoalJudge}) so the model is consulted only
+ * where no machine-checkable artifact exists.
+ *
+ * This module is the LEAF contract: it declares the persisted record shape
+ * ({@link GoalRecord}), the lifecycle status union ({@link GoalStatus}), the
+ * discriminated goal-kind union ({@link GoalKind}), and the judge verdict shape
+ * ({@link GoalJudgeVerdict}) that every layer (store, judge, loop, continuation,
+ * CLI) agrees on. It has ZERO runtime dependencies beyond sibling contracts.
+ *
+ * @packageDocumentation
+ * @module @cleocode/contracts/goal
+ *
+ * @epic T11290 EP-CLEO-GOAL-SYSTEM
+ * @task T11376
+ * @saga T11283 SG-COGNITIVE-SUBSTRATE
+ */
+
+/**
+ * Canonical task-id shape recognized by a {@link TaskCompletionGoal}.
+ *
+ * Mirrors the ADR-079-r2 `SATISFIES_TASK_ID_REGEX` / evidence-atom task-id
+ * grammar (`T` + 1–7 digits). Exported so the store, judge, and CLI layers
+ * validate target ids against ONE pattern rather than re-deriving it.
+ *
+ * @public
+ */
+export const GOAL_TARGET_TASK_ID_REGEX = /^T[0-9]{1,7}$/;
+
+/**
+ * Lifecycle status of a {@link GoalRecord}.
+ *
+ * Transitions are owned by the turn-budgeted loop (`advanceGoal`):
+ * - `active`     — the goal is being pursued; the loop consumes turns.
+ * - `paused`     — auto-paused after a judge/parse failure (Hermes pattern);
+ *   carries a {@link GoalRecord.pausedReason}. No turns are consumed while
+ *   paused; a human/agent must resume.
+ * - `satisfied`  — the judge returned `ok: true` (evidence-backed for task
+ *   goals, LLM-confirmed for fuzzy goals). Terminal.
+ * - `abandoned`  — the turn budget was exhausted before satisfaction. Terminal.
+ * - `impossible` — the judge proved the goal can never be satisfied
+ *   (e.g. the target task was cancelled/deleted). Terminal; no further turns.
+ *
+ * @public
+ */
+export type GoalStatus = 'active' | 'paused' | 'satisfied' | 'abandoned' | 'impossible';
+
+/**
+ * The set of all {@link GoalStatus} values, in lifecycle order.
+ *
+ * Use for runtime validation (`GOAL_STATUSES.includes(x)`) and to drive
+ * exhaustive switch checks without hand-maintaining a parallel array.
+ *
+ * @public
+ */
+export const GOAL_STATUSES: readonly GoalStatus[] = Object.freeze([
+  'active',
+  'paused',
+  'satisfied',
+  'abandoned',
+  'impossible',
+]);
+
+/**
+ * The terminal {@link GoalStatus} values a continuation builder must NOT nudge:
+ * a satisfied/abandoned/impossible goal yields no next-turn message.
+ *
+ * `paused` is intentionally absent — a paused goal CAN be resumed, so the
+ * continuation builder still emits a nudge for it (see `buildContinuation`).
+ *
+ * @public
+ */
+export const GOAL_TERMINAL_STATUSES: readonly GoalStatus[] = Object.freeze([
+  'satisfied',
+  'abandoned',
+  'impossible',
+]);
+
+/**
+ * Discriminant tag for the {@link GoalKind} union.
+ *
+ * @public
+ */
+export type GoalKindTag = 'task-completion' | 'fuzzy';
+
+/**
+ * A goal whose satisfaction is decided by the **evidence-gate-aware** judge.
+ *
+ * The judge resolves `targetTaskId`'s actual status and re-uses the ADR-051
+ * evidence path — NEVER transcript text. This is CLEO's core differentiator
+ * over Claude-Code and Hermes.
+ *
+ * @public
+ */
+export interface TaskCompletionGoal {
+  /** Discriminant: judged via task status + evidence atoms (ADR-051). */
+  readonly kind: 'task-completion';
+  /**
+   * The task to complete. MUST match {@link GOAL_TARGET_TASK_ID_REGEX}
+   * (`T` + 1–7 digits). The judge loads this task and inspects its real
+   * `status` and gate evidence.
+   */
+  readonly targetTaskId: string;
+}
+
+/**
+ * A goal with no machine-checkable completion artifact — satisfaction is
+ * decided by the injectable LLM judge ({@link GoalJudge}) as a fallback.
+ *
+ * The fuzzy path NEVER touches the evidence infrastructure; it exists only for
+ * intents that cannot be reduced to a task + gates (e.g. "explore the auth
+ * module and summarize the risks").
+ *
+ * @public
+ */
+export interface FuzzyGoal {
+  /** Discriminant: judged by the fallback LLM judge (no evidence path). */
+  readonly kind: 'fuzzy';
+}
+
+/**
+ * Discriminated union distinguishing an evidence-judged task-completion goal
+ * from an LLM-judged fuzzy goal. The `kind` tag routes the judge: see
+ * {@link TaskCompletionGoal} (evidence) vs {@link FuzzyGoal} (LLM fallback).
+ *
+ * @public
+ */
+export type GoalKind = TaskCompletionGoal | FuzzyGoal;
+
+/**
+ * A DB-persisted, per-agent goal record (survives process restart).
+ *
+ * Persisted in `tasks.db` under the `tasks_goal` table (Pattern A — single file
+ * per scope + domain-prefixed table). Keyed per agent by the resolved
+ * `sessionId` + `agentId` from E0 (`resolveSessionIdFromEnv` /
+ * `resolveAgentIdFromEnv`) so two concurrent agents never collide on one global
+ * row — the session-bleed class this saga exists to kill.
+ *
+ * @public
+ */
+export interface GoalRecord {
+  /**
+   * Stable, content-independent goal id (the idempotency key / primary key in
+   * the store). Generated by the store on create.
+   */
+  readonly id: string;
+  /**
+   * Resolved session id that owns this goal (from `resolveSessionIdFromEnv`).
+   * `null` only for the global-scope / no-session case.
+   */
+  readonly sessionId: string | null;
+  /**
+   * Resolved agent handle that owns this goal (from `resolveAgentIdFromEnv`).
+   * `null` when spawn did not inject an agent identity.
+   */
+  readonly agentId: string | null;
+  /**
+   * Parent goal id when this is a sub-goal, else `null`. Sub-goals let an agent
+   * decompose a large intent without losing the turn budget of the parent.
+   */
+  readonly parentGoalId: string | null;
+  /**
+   * The kind discriminator + its payload (target task id for task goals).
+   * Drives whether the judge takes the evidence path or the LLM-fallback path.
+   */
+  readonly goalKind: GoalKind;
+  /** Human-readable statement of what the agent is trying to achieve. */
+  readonly intent: string;
+  /**
+   * Outstanding, append-only acceptance criteria. The continuation builder
+   * embeds these so the agent knows what remains. Append via
+   * `appendCriteria` — never mutated in place.
+   */
+  readonly criteria: readonly string[];
+  /** Current lifecycle status. */
+  readonly status: GoalStatus;
+  /**
+   * Maximum number of turns the loop may consume before the goal is abandoned.
+   * A hard cap that bounds runaway loops (the protection Claude-Code lacks).
+   */
+  readonly turnBudget: number;
+  /** Turns consumed so far. Never exceeds {@link turnBudget}. */
+  readonly turnsUsed: number;
+  /**
+   * Why the goal was auto-paused, when `status === 'paused'`. `null` otherwise.
+   * Set on judge/parse failure so the resume path can surface the cause.
+   */
+  readonly pausedReason: string | null;
+  /**
+   * The most recent judge verdict, persisted so `cleo goal status` can show the
+   * last reason without re-running the judge. `null` before the first judge.
+   */
+  readonly lastVerdict: GoalJudgeVerdict | null;
+  /** ISO-8601 creation timestamp. */
+  readonly createdAt: string;
+  /** ISO-8601 last-update timestamp. */
+  readonly updatedAt: string;
+}
+
+/**
+ * The verdict returned by every judge path — evidence-gate-aware OR LLM
+ * fallback — for a single goal evaluation.
+ *
+ * The shape is uniform across both paths (the loop never branches on which
+ * judge produced it):
+ * - `ok`         — the goal is satisfied right now.
+ * - `reason`     — human-readable explanation (embedded into the continuation
+ *   nudge so the agent knows WHY it must continue, or why it succeeded).
+ * - `impossible` — the goal can NEVER be satisfied (e.g. target task cancelled);
+ *   the loop transitions the goal to `impossible` and stops consuming turns.
+ *   `impossible` implies `ok === false`.
+ * - `evidence`   — optional list of evidence-atom strings (ADR-051) the
+ *   evidence judge consulted, for audit/telemetry. Absent on the LLM path.
+ *
+ * @public
+ */
+export interface GoalJudgeVerdict {
+  /** True when the goal is satisfied. Mutually exclusive with `impossible`. */
+  readonly ok: boolean;
+  /** Human-readable explanation of the verdict (for the continuation nudge). */
+  readonly reason: string;
+  /** True when the goal can never be satisfied (terminal `impossible`). */
+  readonly impossible: boolean;
+  /**
+   * Evidence-atom strings the evidence judge inspected (ADR-051). Present only
+   * on the task-completion path; omitted by the LLM fallback.
+   */
+  readonly evidence?: readonly string[];
+}
+
+/**
+ * Injectable LLM-judge interface for {@link FuzzyGoal} evaluation.
+ *
+ * The goal judge depends on THIS interface, never on a concrete model client,
+ * so vitest can pass a deterministic mock and stay fully offline/hermetic — CI
+ * must never flake on a live model call. Production wires a real LLM-backed
+ * implementation; tests wire a stub that returns a canned verdict.
+ *
+ * @public
+ */
+export interface GoalJudge {
+  /**
+   * Judge a fuzzy goal from its record alone (no transcript dependency in the
+   * contract — an implementation MAY consult external context, but the
+   * interface keeps the judge a pure function of the goal for testability).
+   *
+   * @param goal - The goal record under evaluation.
+   * @returns The verdict (same shape as the evidence path).
+   */
+  judge(goal: GoalRecord): Promise<GoalJudgeVerdict>;
+}
+
+/**
+ * A single next-turn continuation message produced by the cache-safe builder.
+ *
+ * Critically, the role is ALWAYS `'user'`: the goal loop nudges the agent by
+ * appending a user-style message, NEVER by mutating the system prompt. A stable
+ * system-prompt prefix is what makes prompt-caching effective; rewriting it on
+ * every turn would bust the cache. See `buildContinuation` for the full
+ * prompt-cache-safety contract.
+ *
+ * @public
+ */
+export interface GoalContinuation {
+  /** Always `'user'` — the nudge is a user message, never a system mutation. */
+  readonly role: 'user';
+  /** The continuation text: goal intent + outstanding criteria + judge reason. */
+  readonly content: string;
+}
+
+/**
+ * Result of advancing a goal one turn through the turn-budgeted loop.
+ *
+ * @public
+ */
+export interface GoalAdvanceResult {
+  /** The verdict the judge returned this turn. */
+  readonly verdict: GoalJudgeVerdict;
+  /** The status the goal transitions to after this turn. */
+  readonly nextStatus: GoalStatus;
+  /** Turns left after this one. Never negative. */
+  readonly turnsRemaining: number;
+}
+
+/**
+ * Type guard: is this a {@link TaskCompletionGoal} (evidence-judged)?
+ *
+ * @param kind - A {@link GoalKind} discriminated union value.
+ * @returns `true` when the goal is judged via task status + evidence atoms.
+ * @public
+ */
+export function isTaskCompletionGoal(kind: GoalKind): kind is TaskCompletionGoal {
+  return kind.kind === 'task-completion';
+}
+
+/**
+ * Type guard: is this a {@link FuzzyGoal} (LLM-judged fallback)?
+ *
+ * @param kind - A {@link GoalKind} discriminated union value.
+ * @returns `true` when the goal is judged by the injectable LLM judge.
+ * @public
+ */
+export function isFuzzyGoal(kind: GoalKind): kind is FuzzyGoal {
+  return kind.kind === 'fuzzy';
+}
+
+/**
+ * Test whether a string is a valid goal target task id (`T` + 1–7 digits).
+ *
+ * @param value - Candidate task id.
+ * @returns `true` when `value` matches {@link GOAL_TARGET_TASK_ID_REGEX}.
+ * @public
+ */
+export function isValidGoalTargetTaskId(value: string): boolean {
+  return GOAL_TARGET_TASK_ID_REGEX.test(value);
+}
+
+/**
+ * Test whether a {@link GoalStatus} is terminal (no further turns / nudges that
+ * advance work). A terminal status yields NO continuation.
+ *
+ * @param status - A goal status.
+ * @returns `true` for `satisfied` / `abandoned` / `impossible`.
+ * @public
+ */
+export function isTerminalGoalStatus(status: GoalStatus): boolean {
+  return GOAL_TERMINAL_STATUSES.includes(status);
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -610,6 +610,28 @@ export {
   AGENT_TYPES,
   BRAIN_OBSERVATION_TYPES,
 } from './facade.js';
+// === CLEO-native Goal System (T11376 · Epic T11290 · Saga T11283) ===
+export type {
+  FuzzyGoal,
+  GoalAdvanceResult,
+  GoalContinuation,
+  GoalJudge,
+  GoalJudgeVerdict,
+  GoalKind,
+  GoalKindTag,
+  GoalRecord,
+  GoalStatus,
+  TaskCompletionGoal,
+} from './goal.js';
+export {
+  GOAL_STATUSES,
+  GOAL_TARGET_TASK_ID_REGEX,
+  GOAL_TERMINAL_STATUSES,
+  isFuzzyGoal,
+  isTaskCompletionGoal,
+  isTerminalGoalStatus,
+  isValidGoalTargetTaskId,
+} from './goal.js';
 // === Graph Intelligence Types (T512, T529, T1862, T9145) ===
 export type {
   AmbiguousProvenance,

--- a/packages/core/migrations/drizzle-tasks/20260530000003_t11377-tasks-goal-store/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260530000003_t11377-tasks-goal-store/migration.sql
@@ -1,0 +1,50 @@
+-- T11377 — DB-persisted per-agent goal store (tasks_goal table).
+--
+-- Layer 4 of SG-COGNITIVE-SUBSTRATE: a DB-persisted, per-agent, turn-budgeted
+-- goal record that survives process restart. Pattern A (ADR-068) — lives inside
+-- tasks.db (no new file), domain-prefixed table name, idempotency_key TEXT PK
+-- so a re-issued create coalesces via INSERT OR IGNORE / onConflictDoNothing.
+--
+-- Per-agent isolation: session_id + agent_id columns hold the resolved E0
+-- identity (resolveSessionIdFromEnv / resolveAgentIdFromEnv). The owner-active
+-- index serves the dominant "active goal for THIS agent" lookup so two
+-- concurrent agents never collide on one global row.
+--
+-- criteria + goal_kind + last_verdict are JSONB BLOBs (binary, in-SQL-queryable)
+-- written via the jsonb() constructor and read whole through json(col) — never
+-- JSON.parse-d raw (the on-disk JSONB encoding is version-unstable).
+--
+-- Changes (idempotent — safe to re-run; CREATE ... IF NOT EXISTS):
+--   1. CREATE TABLE tasks_goal — the per-agent goal record.
+--   2. CREATE INDEX idx_tasks_goal_owner_active — (session_id, agent_id, status)
+--      for getActiveGoal.
+--   3. CREATE INDEX idx_tasks_goal_parent — sub-goal traversal by parent_goal_id.
+--
+-- @task T11377
+-- @epic T11290
+-- @saga T11283
+
+CREATE TABLE IF NOT EXISTS `tasks_goal` (
+  `idempotency_key` text PRIMARY KEY NOT NULL,
+  `session_id` text,
+  `agent_id` text,
+  `parent_goal_id` text,
+  `goal_kind` blob NOT NULL,
+  `intent` text NOT NULL,
+  `criteria` blob DEFAULT (jsonb('[]')) NOT NULL,
+  `status` text DEFAULT 'active' NOT NULL,
+  `turn_budget` integer NOT NULL,
+  `turns_used` integer DEFAULT 0 NOT NULL,
+  `paused_reason` text,
+  `last_verdict` blob,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `idx_tasks_goal_owner_active`
+  ON `tasks_goal` (`session_id`, `agent_id`, `status`);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `idx_tasks_goal_parent`
+  ON `tasks_goal` (`parent_goal_id`);

--- a/packages/core/src/goal/__tests__/continuation.test.ts
+++ b/packages/core/src/goal/__tests__/continuation.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the prompt-cache-safe continuation builder (T11380).
+ *
+ * Proves:
+ *  - the builder returns role === 'user' and emits NO system-role field
+ *    (system prompt is never mutated → prompt-cache prefix stays valid);
+ *  - byte-stability: identical (goal, verdict) inputs yield identical content
+ *    across calls (deterministic — required for cache-prefix reuse);
+ *  - terminal verdicts (ok / impossible) and terminal statuses yield NO
+ *    continuation (null); only active/paused goals get a nudge;
+ *  - the content embeds intent + outstanding criteria + the judge reason;
+ *  - the content stays within the documented byte cap.
+ *
+ * @epic T11290
+ * @task T11380
+ * @saga T11283
+ */
+
+import type { GoalJudgeVerdict, GoalRecord } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { buildContinuation, CONTINUATION_MAX_BYTES } from '../continuation.js';
+
+function goal(overrides: Partial<GoalRecord> = {}): GoalRecord {
+  return {
+    id: 'g1',
+    sessionId: 'ses_A',
+    agentId: 'agent-A',
+    parentGoalId: null,
+    goalKind: { kind: 'fuzzy' },
+    intent: 'explore the auth module',
+    criteria: ['list the risks', 'note the entrypoints'],
+    status: 'active',
+    turnBudget: 5,
+    turnsUsed: 1,
+    pausedReason: null,
+    lastVerdict: null,
+    createdAt: '2026-05-30T00:00:00.000Z',
+    updatedAt: '2026-05-30T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const keepGoing: GoalJudgeVerdict = {
+  ok: false,
+  impossible: false,
+  reason: 'two criteria still outstanding',
+};
+
+describe('buildContinuation — cache-safety contract', () => {
+  it('returns a user-role message and emits no system-role field', () => {
+    const continuation = buildContinuation(goal(), keepGoing);
+    expect(continuation).not.toBeNull();
+    expect(continuation?.role).toBe('user');
+    // The object has exactly { role, content } — never a system field.
+    expect(Object.keys(continuation ?? {}).sort()).toEqual(['content', 'role']);
+    expect(continuation).not.toHaveProperty('system');
+  });
+
+  it('is byte-stable for identical (goal, verdict) inputs across calls', () => {
+    const g = goal();
+    const a = buildContinuation(g, keepGoing);
+    const b = buildContinuation(g, keepGoing);
+    expect(a?.content).toBe(b?.content);
+  });
+
+  it('embeds intent, outstanding criteria, and the judge reason', () => {
+    const continuation = buildContinuation(goal(), keepGoing);
+    expect(continuation?.content).toContain('explore the auth module');
+    expect(continuation?.content).toContain('list the risks');
+    expect(continuation?.content).toContain('note the entrypoints');
+    expect(continuation?.content).toContain('two criteria still outstanding');
+  });
+
+  it('stays within the documented byte cap', () => {
+    const longCriteria = Array.from({ length: 200 }, (_, i) => `criterion number ${i} is long`);
+    const continuation = buildContinuation(goal({ criteria: longCriteria }), keepGoing);
+    const bytes = new TextEncoder().encode(continuation?.content ?? '').length;
+    expect(bytes).toBeLessThanOrEqual(CONTINUATION_MAX_BYTES);
+  });
+});
+
+describe('buildContinuation — terminal yields null', () => {
+  it('returns null when the verdict is satisfied (ok)', () => {
+    const satisfied: GoalJudgeVerdict = { ok: true, impossible: false, reason: 'done' };
+    expect(buildContinuation(goal(), satisfied)).toBeNull();
+  });
+
+  it('returns null when the verdict is impossible', () => {
+    const impossible: GoalJudgeVerdict = {
+      ok: false,
+      impossible: true,
+      reason: 'task cancelled',
+    };
+    expect(buildContinuation(goal(), impossible)).toBeNull();
+  });
+
+  it('returns null for an abandoned goal status', () => {
+    expect(buildContinuation(goal({ status: 'abandoned' }), keepGoing)).toBeNull();
+  });
+
+  it('returns null for a satisfied goal status', () => {
+    expect(buildContinuation(goal({ status: 'satisfied' }), keepGoing)).toBeNull();
+  });
+
+  it('returns a continuation for an active goal', () => {
+    expect(buildContinuation(goal({ status: 'active' }), keepGoing)).not.toBeNull();
+  });
+
+  it('returns a continuation for a paused goal (resumable)', () => {
+    expect(buildContinuation(goal({ status: 'paused' }), keepGoing)).not.toBeNull();
+  });
+});

--- a/packages/core/src/goal/__tests__/judge.test.ts
+++ b/packages/core/src/goal/__tests__/judge.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the evidence-gate-aware goal judge (T11378).
+ *
+ * Fully hermetic — `getTaskAccessor` is mocked so no DB or network is touched,
+ * and the fuzzy path uses a deterministic injected judge so no model is called.
+ *
+ * Proves:
+ *  (a) a `complete T###` goal returns ok=false when the task is pending OR its
+ *      gates lack evidence atoms;
+ *  (b) returns ok=true when task=done with valid commit+files (implemented) AND
+ *      test-run (testsPassed) atoms;
+ *  (c) a missing/cancelled task returns impossible;
+ *  (d) a fuzzy goal routes to the (mocked) LLM judge and NEVER touches the
+ *      evidence path.
+ *
+ * @epic T11290
+ * @task T11378
+ * @saga T11283
+ */
+
+import type { GoalJudge, GoalJudgeVerdict, GoalRecord, Task } from '@cleocode/contracts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadSingleTaskMock = vi.fn();
+
+vi.mock('../../store/data-accessor.js', () => ({
+  getTaskAccessor: async () => ({ loadSingleTask: loadSingleTaskMock }),
+}));
+
+import { judgeGoal, StaticGoalJudge } from '../judge.js';
+
+/** Build a minimal goal record for a target-task goal. */
+function taskGoal(targetTaskId: string): GoalRecord {
+  return {
+    id: 'g1',
+    sessionId: 'ses_A',
+    agentId: 'agent-A',
+    parentGoalId: null,
+    goalKind: { kind: 'task-completion', targetTaskId },
+    intent: `complete ${targetTaskId}`,
+    criteria: [],
+    status: 'active',
+    turnBudget: 5,
+    turnsUsed: 0,
+    pausedReason: null,
+    lastVerdict: null,
+    createdAt: '2026-05-30T00:00:00.000Z',
+    updatedAt: '2026-05-30T00:00:00.000Z',
+  };
+}
+
+/** A judge that throws if called — proves the evidence path never delegates. */
+const FORBIDDEN_JUDGE: GoalJudge = {
+  judge: async () => {
+    throw new Error('LLM judge must NOT be called on the task-completion path');
+  },
+};
+
+/** A minimal Task stub with optional status + verification evidence. */
+function stubTask(overrides: Partial<Task>): Task {
+  return { id: 'T123', status: 'pending', ...overrides } as Task;
+}
+
+beforeEach(() => {
+  loadSingleTaskMock.mockReset();
+});
+
+describe('judgeGoal — task-completion (evidence path)', () => {
+  it('(a) returns ok=false when the task is pending', async () => {
+    loadSingleTaskMock.mockResolvedValue(stubTask({ status: 'pending' }));
+    const verdict = await judgeGoal(taskGoal('T123'), FORBIDDEN_JUDGE);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.impossible).toBe(false);
+    expect(verdict.reason).toContain('pending');
+  });
+
+  it('(a) returns ok=false when the task is done but gates lack evidence atoms', async () => {
+    loadSingleTaskMock.mockResolvedValue(
+      stubTask({
+        status: 'done',
+        verification: {
+          passed: true,
+          round: 1,
+          gates: { implemented: true, testsPassed: true },
+          evidence: {}, // done, but NO evidence atoms recorded
+          lastAgent: null,
+          lastUpdated: null,
+          failureLog: [],
+        },
+      }),
+    );
+    const verdict = await judgeGoal(taskGoal('T123'), FORBIDDEN_JUDGE);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('done but its evidence gates are not satisfied');
+  });
+
+  it('(b) returns ok=true when task=done with valid implemented + testsPassed atoms', async () => {
+    loadSingleTaskMock.mockResolvedValue(
+      stubTask({
+        status: 'done',
+        verification: {
+          passed: true,
+          round: 1,
+          gates: { implemented: true, testsPassed: true },
+          evidence: {
+            implemented: {
+              atoms: [
+                { kind: 'commit', sha: 'abc1234', shortSha: 'abc1234' },
+                { kind: 'files', files: [{ path: 'src/a.ts', sha256: 'deadbeef' }] },
+              ],
+              capturedAt: '2026-05-30T00:00:00.000Z',
+              capturedBy: 'agent-A',
+            },
+            testsPassed: {
+              atoms: [
+                {
+                  kind: 'test-run',
+                  path: 'run.json',
+                  sha256: 'cafe',
+                  passCount: 10,
+                  failCount: 0,
+                  skipCount: 0,
+                },
+              ],
+              capturedAt: '2026-05-30T00:00:00.000Z',
+              capturedBy: 'agent-A',
+            },
+          },
+          lastAgent: null,
+          lastUpdated: null,
+          failureLog: [],
+        },
+      }),
+    );
+    const verdict = await judgeGoal(taskGoal('T123'), FORBIDDEN_JUDGE);
+    expect(verdict.ok).toBe(true);
+    expect(verdict.impossible).toBe(false);
+    expect(verdict.evidence).toContain('implemented:commit');
+    expect(verdict.evidence).toContain('testsPassed:test-run');
+  });
+
+  it('(c) returns impossible when the target task does not exist', async () => {
+    loadSingleTaskMock.mockResolvedValue(null);
+    const verdict = await judgeGoal(taskGoal('T999'), FORBIDDEN_JUDGE);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.impossible).toBe(true);
+    expect(verdict.reason).toContain('does not exist');
+  });
+
+  it('(c) returns impossible when the target task is cancelled', async () => {
+    loadSingleTaskMock.mockResolvedValue(stubTask({ status: 'cancelled' }));
+    const verdict = await judgeGoal(taskGoal('T123'), FORBIDDEN_JUDGE);
+    expect(verdict.impossible).toBe(true);
+    expect(verdict.reason).toContain('cancelled');
+  });
+
+  it('rejects done-with-only-implemented (testsPassed unbacked)', async () => {
+    loadSingleTaskMock.mockResolvedValue(
+      stubTask({
+        status: 'done',
+        verification: {
+          passed: true,
+          round: 1,
+          gates: { implemented: true },
+          evidence: {
+            implemented: {
+              atoms: [
+                { kind: 'commit', sha: 'abc1234', shortSha: 'abc1234' },
+                { kind: 'files', files: [{ path: 'src/a.ts', sha256: 'deadbeef' }] },
+              ],
+              capturedAt: '2026-05-30T00:00:00.000Z',
+              capturedBy: 'agent-A',
+            },
+          },
+          lastAgent: null,
+          lastUpdated: null,
+          failureLog: [],
+        },
+      }),
+    );
+    const verdict = await judgeGoal(taskGoal('T123'), FORBIDDEN_JUDGE);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('testsPassed');
+  });
+});
+
+describe('judgeGoal — fuzzy (LLM fallback path)', () => {
+  it('(d) routes a fuzzy goal to the injected judge and never touches the accessor', async () => {
+    const expected: GoalJudgeVerdict = {
+      ok: true,
+      impossible: false,
+      reason: 'LLM says satisfied',
+    };
+    const llmJudge = new StaticGoalJudge(expected);
+    const judgeSpy = vi.spyOn(llmJudge, 'judge');
+
+    const fuzzy: GoalRecord = { ...taskGoal('T123'), goalKind: { kind: 'fuzzy' } };
+    const verdict = await judgeGoal(fuzzy, llmJudge);
+
+    expect(verdict).toEqual(expected);
+    expect(judgeSpy).toHaveBeenCalledOnce();
+    // The evidence path was never taken — the task accessor was not consulted.
+    expect(loadSingleTaskMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/goal/__tests__/loop.test.ts
+++ b/packages/core/src/goal/__tests__/loop.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the turn-budgeted goal loop (T11379).
+ *
+ * Proves the four AC-mandated transitions and the invariants:
+ *  - satisfied   (verdict.ok)
+ *  - impossible  (verdict.impossible, no turn consumed)
+ *  - abandoned   (turn budget exhausted)
+ *  - paused      (judge throws OR returns a malformed verdict — Hermes pattern)
+ *  - turnsRemaining never goes negative
+ *  - already-terminal goals are inert (no judge call, unchanged)
+ *
+ * Fully deterministic — the judge is injected, no I/O.
+ *
+ * @epic T11290
+ * @task T11379
+ * @saga T11283
+ */
+
+import type { GoalJudgeVerdict, GoalRecord } from '@cleocode/contracts';
+import { describe, expect, it, vi } from 'vitest';
+import { advanceGoal, isWellFormedVerdict } from '../loop.js';
+
+function goalAt(turnsUsed: number, turnBudget: number, status = 'active'): GoalRecord {
+  return {
+    id: 'g1',
+    sessionId: 'ses_A',
+    agentId: 'agent-A',
+    parentGoalId: null,
+    goalKind: { kind: 'fuzzy' },
+    intent: 'do the thing',
+    criteria: [],
+    status: status as GoalRecord['status'],
+    turnBudget,
+    turnsUsed,
+    pausedReason: null,
+    lastVerdict: null,
+    createdAt: '2026-05-30T00:00:00.000Z',
+    updatedAt: '2026-05-30T00:00:00.000Z',
+  };
+}
+
+const keepGoing: GoalJudgeVerdict = { ok: false, impossible: false, reason: 'not yet' };
+
+describe('advanceGoal — transitions', () => {
+  it('satisfied: verdict.ok → status satisfied, no turn consumed', async () => {
+    const result = await advanceGoal(goalAt(0, 5), async () => ({
+      ok: true,
+      impossible: false,
+      reason: 'done',
+    }));
+    expect(result.nextStatus).toBe('satisfied');
+    expect(result.turnsRemaining).toBe(5);
+  });
+
+  it('impossible: verdict.impossible → status impossible, no turn consumed', async () => {
+    const result = await advanceGoal(goalAt(2, 5), async () => ({
+      ok: false,
+      impossible: true,
+      reason: 'task cancelled',
+    }));
+    expect(result.nextStatus).toBe('impossible');
+    // No turn consumed: 5 - 2 = 3 remaining, unchanged.
+    expect(result.turnsRemaining).toBe(3);
+  });
+
+  it('abandoned: keep-going verdict on the LAST budgeted turn → status abandoned', async () => {
+    // 4 used of 5 → 1 remaining; this turn consumes it and exhausts the budget.
+    const result = await advanceGoal(goalAt(4, 5), async () => keepGoing);
+    expect(result.nextStatus).toBe('abandoned');
+    expect(result.turnsRemaining).toBe(0);
+    expect(result.verdict.reason).toContain('Turn budget exhausted');
+  });
+
+  it('active: keep-going verdict with budget left → status active, one turn consumed', async () => {
+    const result = await advanceGoal(goalAt(1, 5), async () => keepGoing);
+    expect(result.nextStatus).toBe('active');
+    expect(result.turnsRemaining).toBe(3); // (5-1) - 1
+  });
+
+  it('paused: judge THROWS → status paused with reason (auto-pause)', async () => {
+    const result = await advanceGoal(goalAt(0, 5), async () => {
+      throw new Error('network blip');
+    });
+    expect(result.nextStatus).toBe('paused');
+    expect(result.verdict.reason).toContain('network blip');
+    // No turn consumed on a pause — the goal can resume from here.
+    expect(result.turnsRemaining).toBe(5);
+  });
+
+  it('paused: judge returns a MALFORMED verdict → status paused (parse failure)', async () => {
+    const result = await advanceGoal(
+      goalAt(0, 5),
+      // Deliberately malformed (missing impossible/reason).
+      async () => ({ ok: false }) as unknown as GoalJudgeVerdict,
+    );
+    expect(result.nextStatus).toBe('paused');
+    expect(result.verdict.reason).toContain('malformed');
+  });
+});
+
+describe('advanceGoal — invariants', () => {
+  it('turnsRemaining never goes negative even past budget', async () => {
+    // turnsUsed already > budget (defensive) → remainingBefore floors at 0.
+    const result = await advanceGoal(goalAt(99, 5), async () => keepGoing);
+    expect(result.turnsRemaining).toBeGreaterThanOrEqual(0);
+    expect(result.nextStatus).toBe('abandoned');
+  });
+
+  it('already-terminal goal is inert — judge is never called', async () => {
+    const judge = vi.fn(async () => keepGoing);
+    const result = await advanceGoal(goalAt(3, 5, 'satisfied'), judge);
+    expect(result.nextStatus).toBe('satisfied');
+    expect(judge).not.toHaveBeenCalled();
+  });
+});
+
+describe('isWellFormedVerdict', () => {
+  it('accepts a complete verdict', () => {
+    expect(isWellFormedVerdict({ ok: true, impossible: false, reason: 'x' })).toBe(true);
+  });
+
+  it('rejects null, non-objects, and missing fields', () => {
+    expect(isWellFormedVerdict(null)).toBe(false);
+    expect(isWellFormedVerdict('nope')).toBe(false);
+    expect(isWellFormedVerdict({ ok: true })).toBe(false);
+    expect(isWellFormedVerdict({ ok: 'yes', impossible: false, reason: 'x' })).toBe(false);
+  });
+});

--- a/packages/core/src/goal/__tests__/store.test.ts
+++ b/packages/core/src/goal/__tests__/store.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the DB-persisted per-agent goal store (T11377).
+ *
+ * Proves the two load-bearing guarantees:
+ *  1. A goal SURVIVES a simulated process restart (closeDb → getDb re-opens the
+ *     file-backed tasks.db and the row is still there).
+ *  2. Two distinct owners (session/agent identities) yield ISOLATED
+ *     getActiveGoal results — no session-bleed.
+ *
+ * Plus CRUD coverage: criteria append, status update, sub-goal parent linkage,
+ * idempotent create, and JSONB round-trip (goal_kind / criteria read back
+ * through json(col), never raw BLOB).
+ *
+ * @epic T11290
+ * @task T11377
+ * @saga T11283
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { GoalKind } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb } from '../../store/sqlite.js';
+import {
+  appendCriteria,
+  createGoal,
+  type GoalOwner,
+  getActiveGoal,
+  getGoalById,
+  listGoals,
+  updateGoal,
+} from '../store.js';
+
+let projectRoot: string;
+
+const OWNER_A: GoalOwner = { sessionId: 'ses_A', agentId: 'agent-A' };
+const OWNER_B: GoalOwner = { sessionId: 'ses_B', agentId: 'agent-B' };
+const FUZZY: GoalKind = { kind: 'fuzzy' };
+const TASK_GOAL: GoalKind = { kind: 'task-completion', targetTaskId: 'T123' };
+
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), 'cleo-goal-store-'));
+  // Pre-create `.cleo/` so resolveCleoDir anchors to the temp dir.
+  mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+});
+
+afterEach(() => {
+  // Close the singleton so the next test opens a fresh file-backed DB.
+  closeDb();
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('goal store — persistence + restart', () => {
+  it('persists a goal that survives a simulated process restart', async () => {
+    const created = await createGoal(
+      { goalKind: TASK_GOAL, intent: 'complete T123', turnBudget: 8, owner: OWNER_A },
+      projectRoot,
+    );
+    expect(created.id).toBeTruthy();
+    expect(created.status).toBe('active');
+
+    // Simulate a process restart: drop the in-memory singleton, then re-open the
+    // file-backed DB from disk.
+    closeDb();
+
+    const reloaded = await getGoalById(created.id, projectRoot);
+    expect(reloaded).not.toBeNull();
+    expect(reloaded?.intent).toBe('complete T123');
+    // JSONB goal_kind round-trips through json(col) — never raw BLOB.
+    expect(reloaded?.goalKind).toEqual(TASK_GOAL);
+    expect(reloaded?.turnBudget).toBe(8);
+  });
+
+  it('round-trips JSONB columns (goalKind, criteria) through json(col)', async () => {
+    const created = await createGoal(
+      {
+        goalKind: FUZZY,
+        intent: 'explore auth',
+        turnBudget: 5,
+        criteria: ['c1', 'c2'],
+        owner: OWNER_A,
+      },
+      projectRoot,
+    );
+    const reloaded = await getGoalById(created.id, projectRoot);
+    expect(reloaded?.goalKind).toEqual(FUZZY);
+    expect(reloaded?.criteria).toEqual(['c1', 'c2']);
+    expect(reloaded?.lastVerdict).toBeNull();
+  });
+});
+
+describe('goal store — per-agent isolation (no session-bleed)', () => {
+  it('two distinct owners get isolated getActiveGoal results', async () => {
+    await createGoal(
+      { goalKind: FUZZY, intent: 'goal-A', turnBudget: 5, owner: OWNER_A },
+      projectRoot,
+    );
+    await createGoal(
+      { goalKind: FUZZY, intent: 'goal-B', turnBudget: 5, owner: OWNER_B },
+      projectRoot,
+    );
+
+    const aGoal = await getActiveGoal(projectRoot, OWNER_A);
+    const bGoal = await getActiveGoal(projectRoot, OWNER_B);
+
+    expect(aGoal?.intent).toBe('goal-A');
+    expect(bGoal?.intent).toBe('goal-B');
+    // The critical anti-bleed assertion: A never sees B's goal and vice-versa.
+    expect(aGoal?.intent).not.toBe('goal-B');
+    expect(bGoal?.intent).not.toBe('goal-A');
+  });
+
+  it('an owner with no goals sees null even when another agent has one', async () => {
+    await createGoal(
+      { goalKind: FUZZY, intent: 'only-A', turnBudget: 5, owner: OWNER_A },
+      projectRoot,
+    );
+    const bGoal = await getActiveGoal(projectRoot, OWNER_B);
+    expect(bGoal).toBeNull();
+  });
+
+  it('listGoals is scoped to the owner', async () => {
+    await createGoal({ goalKind: FUZZY, intent: 'a1', turnBudget: 5, owner: OWNER_A }, projectRoot);
+    await createGoal({ goalKind: FUZZY, intent: 'a2', turnBudget: 5, owner: OWNER_A }, projectRoot);
+    await createGoal({ goalKind: FUZZY, intent: 'b1', turnBudget: 5, owner: OWNER_B }, projectRoot);
+    const aList = await listGoals(projectRoot, OWNER_A);
+    const bList = await listGoals(projectRoot, OWNER_B);
+    expect(aList.map((g) => g.intent).sort()).toEqual(['a1', 'a2']);
+    expect(bList.map((g) => g.intent)).toEqual(['b1']);
+  });
+});
+
+describe('goal store — CRUD', () => {
+  it('appendCriteria appends without losing prior criteria', async () => {
+    const created = await createGoal(
+      { goalKind: FUZZY, intent: 'g', turnBudget: 5, criteria: ['first'], owner: OWNER_A },
+      projectRoot,
+    );
+    const after = await appendCriteria(created.id, 'second', projectRoot);
+    expect(after?.criteria).toEqual(['first', 'second']);
+  });
+
+  it('updateGoal patches status + turnsUsed + lastVerdict', async () => {
+    const created = await createGoal(
+      { goalKind: FUZZY, intent: 'g', turnBudget: 5, owner: OWNER_A },
+      projectRoot,
+    );
+    const updated = await updateGoal(
+      created.id,
+      {
+        status: 'paused',
+        turnsUsed: 2,
+        pausedReason: 'judge failed',
+        lastVerdict: { ok: false, impossible: false, reason: 'still working' },
+      },
+      projectRoot,
+    );
+    expect(updated?.status).toBe('paused');
+    expect(updated?.turnsUsed).toBe(2);
+    expect(updated?.pausedReason).toBe('judge failed');
+    expect(updated?.lastVerdict?.reason).toBe('still working');
+  });
+
+  it('a paused goal is still returned by getActiveGoal (resumable)', async () => {
+    const created = await createGoal(
+      { goalKind: FUZZY, intent: 'g', turnBudget: 5, owner: OWNER_A },
+      projectRoot,
+    );
+    await updateGoal(created.id, { status: 'paused' }, projectRoot);
+    const active = await getActiveGoal(projectRoot, OWNER_A);
+    expect(active?.id).toBe(created.id);
+  });
+
+  it('a satisfied goal is NOT returned by getActiveGoal (terminal)', async () => {
+    const created = await createGoal(
+      { goalKind: FUZZY, intent: 'g', turnBudget: 5, owner: OWNER_A },
+      projectRoot,
+    );
+    await updateGoal(created.id, { status: 'satisfied' }, projectRoot);
+    const active = await getActiveGoal(projectRoot, OWNER_A);
+    expect(active).toBeNull();
+  });
+
+  it('createGoal is idempotent on the idempotency key', async () => {
+    const first = await createGoal(
+      {
+        goalKind: FUZZY,
+        intent: 'g',
+        turnBudget: 5,
+        owner: OWNER_A,
+        idempotencyKey: 'stable-key',
+      },
+      projectRoot,
+    );
+    const second = await createGoal(
+      {
+        goalKind: FUZZY,
+        intent: 'DIFFERENT — should be ignored',
+        turnBudget: 99,
+        owner: OWNER_A,
+        idempotencyKey: 'stable-key',
+      },
+      projectRoot,
+    );
+    expect(second.id).toBe(first.id);
+    // The conflicting create was a no-op — the original values survive.
+    expect(second.intent).toBe('g');
+    expect(second.turnBudget).toBe(5);
+    const all = await listGoals(projectRoot, OWNER_A);
+    expect(all).toHaveLength(1);
+  });
+
+  it('a sub-goal links parentGoalId', async () => {
+    const parent = await createGoal(
+      { goalKind: FUZZY, intent: 'parent', turnBudget: 5, owner: OWNER_A },
+      projectRoot,
+    );
+    const child = await createGoal(
+      {
+        goalKind: TASK_GOAL,
+        intent: 'child',
+        turnBudget: 3,
+        parentGoalId: parent.id,
+        owner: OWNER_A,
+      },
+      projectRoot,
+    );
+    expect(child.parentGoalId).toBe(parent.id);
+  });
+});

--- a/packages/core/src/goal/continuation.ts
+++ b/packages/core/src/goal/continuation.ts
@@ -1,0 +1,128 @@
+/**
+ * Prompt-cache-safe goal continuation builder (Layer 4 of SG-COGNITIVE-SUBSTRATE).
+ *
+ * ## The prompt-cache-safety contract (why user-message, not system mutation)
+ *
+ * Prompt caching keys on a STABLE message prefix — most importantly the system
+ * prompt. The harness assembles `[system, ...history]` once and caches the long
+ * static prefix; every cache hit skips re-processing those tokens. If the goal
+ * loop nudged the agent by REWRITING the system prompt each turn, it would
+ * invalidate that cached prefix on every single turn — turning a cheap cache hit
+ * into a full re-encode and defeating the entire point of caching.
+ *
+ * {@link buildContinuation} therefore emits the nudge as a `role: 'user'`
+ * message that is APPENDED after the existing conversation. The system prompt is
+ * never touched, so the cached prefix stays valid and only the new (short) user
+ * message is processed. The builder is also byte-stable for identical
+ * `(goal, verdict)` inputs — the same continuation text is produced every call —
+ * which is required so a re-issued turn reuses the same cache prefix rather than
+ * minting a fresh, cache-busting string.
+ *
+ * ## Harness boundary (AC4)
+ *
+ * The CLI/SDK side (this builder) guarantees the continuation is a user message
+ * and never mutates the system prompt. The HARNESS owns final message-array
+ * assembly (it decides where to splice this user message and how the system
+ * prompt is cached). This module guarantees the CLI-side contract; the harness
+ * guarantees its own. The two together deliver end-to-end cache safety.
+ *
+ * @module @cleocode/core/goal/continuation
+ *
+ * @epic T11290 EP-CLEO-GOAL-SYSTEM
+ * @task T11380
+ * @saga T11283 SG-COGNITIVE-SUBSTRATE
+ */
+
+import {
+  type GoalContinuation,
+  type GoalJudgeVerdict,
+  type GoalRecord,
+  isTerminalGoalStatus,
+} from '@cleocode/contracts';
+
+/**
+ * Maximum byte length of a continuation's `content`. A continuation is a nudge,
+ * not a document — keeping it small bounds the per-turn token cost and keeps the
+ * appended user message cheap to (re)process. Criteria beyond what fits are
+ * truncated with an explicit marker so the cap is never silently exceeded.
+ *
+ * @task T11380
+ */
+export const CONTINUATION_MAX_BYTES = 1200;
+
+/**
+ * Build the next-turn continuation nudge for a goal, or `null` when no nudge is
+ * warranted.
+ *
+ * Returns `null` for a TERMINAL verdict/status — a `satisfied`, `abandoned`, or
+ * `impossible` goal has nothing left to nudge toward, so no user message is
+ * emitted. Only `active` and `paused` goals receive a continuation (`paused`
+ * because it can be resumed). The presence of `verdict.ok` or
+ * `verdict.impossible` ALSO short-circuits to `null` even if a stale status says
+ * otherwise — the verdict is the freshest signal.
+ *
+ * The continuation embeds the goal intent, the outstanding criteria, and the
+ * judge's reason (so the agent knows WHY it must continue), and is byte-stable
+ * for identical inputs (deterministic — required for prompt-cache prefix reuse).
+ *
+ * @param goal - The current goal record.
+ * @param verdict - The judge's latest verdict for this goal.
+ * @returns A `{ role: 'user', content }` continuation, or `null` when terminal.
+ * @task T11380
+ */
+export function buildContinuation(
+  goal: GoalRecord,
+  verdict: GoalJudgeVerdict,
+): GoalContinuation | null {
+  // The verdict is the freshest signal: a satisfied or impossible verdict means
+  // there is nothing to nudge toward, regardless of the persisted status.
+  if (verdict.ok || verdict.impossible) {
+    return null;
+  }
+  // A terminal status (satisfied/abandoned/impossible) likewise yields no nudge.
+  if (isTerminalGoalStatus(goal.status)) {
+    return null;
+  }
+
+  const lines: string[] = [];
+  lines.push(`[GOAL CONTINUATION] Your active goal is not yet satisfied.`);
+  lines.push(`Intent: ${goal.intent}`);
+
+  if (goal.criteria.length > 0) {
+    lines.push(`Outstanding criteria:`);
+    for (const criterion of goal.criteria) {
+      lines.push(`  - ${criterion}`);
+    }
+  }
+
+  lines.push(`Why continue: ${verdict.reason}`);
+  lines.push(
+    `Turns: ${goal.turnsUsed}/${goal.turnBudget} used. Keep working until the goal's gates are evidence-backed.`,
+  );
+
+  const content = clampToBytes(lines.join('\n'), CONTINUATION_MAX_BYTES);
+  return { role: 'user', content };
+}
+
+/**
+ * Clamp a string to at most `maxBytes` UTF-8 bytes, appending a truncation
+ * marker when it overflows. Deterministic — identical input yields identical
+ * output, preserving byte-stability for prompt-cache prefix reuse.
+ *
+ * @internal
+ */
+function clampToBytes(text: string, maxBytes: number): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(text).length <= maxBytes) {
+    return text;
+  }
+  const marker = '\n… [truncated]';
+  const budget = maxBytes - encoder.encode(marker).length;
+  // Walk back from the byte budget to a safe character boundary so we never
+  // split a multi-byte codepoint.
+  let sliced = text;
+  while (encoder.encode(sliced).length > budget && sliced.length > 0) {
+    sliced = sliced.slice(0, -1);
+  }
+  return sliced + marker;
+}

--- a/packages/core/src/goal/index.ts
+++ b/packages/core/src/goal/index.ts
@@ -1,0 +1,39 @@
+/**
+ * CLEO-native goal system — barrel (Layer 4 of SG-COGNITIVE-SUBSTRATE).
+ *
+ * Surfaces the DB-persisted per-agent goal store, the evidence-gate-aware judge
+ * (+ injectable LLM fallback), the turn-budgeted loop, and the prompt-cache-safe
+ * continuation builder. Re-exported from the core barrel as `goal.*` so the CLI
+ * layer dispatches into these ops without reaching past the package boundary.
+ *
+ * @module @cleocode/core/goal
+ *
+ * @epic T11290 EP-CLEO-GOAL-SYSTEM
+ * @saga T11283 SG-COGNITIVE-SUBSTRATE
+ */
+
+export { buildContinuation, CONTINUATION_MAX_BYTES } from './continuation.js';
+export {
+  CRITICAL_GATE_COUNT,
+  CRITICAL_GATES,
+  judgeGoal,
+  judgeTaskCompletion,
+  StaticGoalJudge,
+} from './judge.js';
+export {
+  advanceGoal,
+  type GoalJudgeFn,
+  isWellFormedVerdict,
+} from './loop.js';
+export {
+  appendCriteria,
+  type CreateGoalParams,
+  createGoal,
+  type GoalOwner,
+  getActiveGoal,
+  getGoalById,
+  listGoals,
+  resolveGoalOwner,
+  type UpdateGoalFields,
+  updateGoal,
+} from './store.js';

--- a/packages/core/src/goal/judge.ts
+++ b/packages/core/src/goal/judge.ts
@@ -1,0 +1,218 @@
+/**
+ * Evidence-gate-aware goal judge (Layer 4 of SG-COGNITIVE-SUBSTRATE).
+ *
+ * This is CLEO's core differentiator over Claude-Code (transcript judge) and
+ * Hermes (post-turn loop, still transcript-judged for fuzzy intent). For a
+ * `task-completion` goal, the judge NEVER reads the transcript: it resolves the
+ * target task's REAL status and re-uses the shipped ADR-051 evidence
+ * infrastructure ({@link validateEvidenceForGate} +
+ * {@link GATE_EVIDENCE_REQUIREMENTS} via `tasks/evidence.ts`). A goal is
+ * satisfied ONLY when the task is `status === 'done'` AND every required gate
+ * ({@link CRITICAL_GATES}) is backed by evidence atoms of the kinds ADR-051
+ * mandates. Transcript text can never satisfy a task-completion goal.
+ *
+ * `fuzzy` goals — those with no machine-checkable artifact — delegate to an
+ * INJECTABLE LLM judge ({@link GoalJudge}). The judge interface, not a concrete
+ * model client, is the dependency, so vitest passes a deterministic mock and
+ * stays fully offline/hermetic. The fuzzy path NEVER touches the evidence
+ * infrastructure.
+ *
+ * @module @cleocode/core/goal/judge
+ *
+ * @epic T11290 EP-CLEO-GOAL-SYSTEM
+ * @task T11378
+ * @saga T11283 SG-COGNITIVE-SUBSTRATE
+ * @adr ADR-051
+ */
+
+import type {
+  GoalJudge,
+  GoalJudgeVerdict,
+  GoalRecord,
+  VerificationGate,
+} from '@cleocode/contracts';
+// Re-use the EXISTING ADR-051 evidence path — do NOT re-implement atom parsing.
+// `validateEvidenceForGate` + `GATE_EVIDENCE_REQUIREMENTS` are the shipped SSoT
+// in @cleocode/contracts; `core/src/tasks/evidence.ts` is the matching core
+// surface (it imports the SAME two symbols and is the gate machinery's home).
+import { GATE_EVIDENCE_REQUIREMENTS, isTaskCompletionGoal } from '@cleocode/contracts';
+import { getTaskAccessor } from '../store/data-accessor.js';
+// Sourced from tasks/evidence.ts so the judge sits on the canonical core
+// evidence module rather than re-deriving validation (AC: no re-implementation).
+import { checkGateEvidenceMinimum } from '../tasks/evidence.js';
+
+/**
+ * The gates a task-completion goal demands be evidence-backed before it is
+ * judged satisfied. These are the ADR-051 critical gates that reject
+ * override-only evidence (`implemented` + `testsPassed`) — the same two gates
+ * `cleo complete` enforces hardest. A goal that says "complete T123" therefore
+ * means exactly what CLEO means by complete: code landed (commit+files) AND
+ * tests proven (test-run/tool/pr), with real, validated atoms.
+ *
+ * @task T11378
+ * @adr ADR-051
+ */
+export const CRITICAL_GATES: readonly VerificationGate[] = Object.freeze([
+  'implemented',
+  'testsPassed',
+]);
+
+/**
+ * Judge a goal and return a uniform {@link GoalJudgeVerdict}.
+ *
+ * Routing:
+ * - `task-completion` → {@link judgeTaskCompletion} (evidence path, no LLM).
+ * - `fuzzy`           → the injected {@link GoalJudge} (LLM fallback).
+ *
+ * The `llmJudge` is REQUIRED only for fuzzy goals; a task-completion goal never
+ * calls it. Passing the judge by parameter (dependency injection) is what keeps
+ * vitest hermetic.
+ *
+ * @param goal - The goal under evaluation.
+ * @param llmJudge - The injectable LLM judge used for fuzzy goals.
+ * @param cwd - Project root override for task lookup.
+ * @returns The verdict (same shape for both paths).
+ * @task T11378
+ */
+export async function judgeGoal(
+  goal: GoalRecord,
+  llmJudge: GoalJudge,
+  cwd?: string,
+): Promise<GoalJudgeVerdict> {
+  if (isTaskCompletionGoal(goal.goalKind)) {
+    return judgeTaskCompletion(goal.goalKind.targetTaskId, cwd);
+  }
+  // Fuzzy goal — delegate to the injected LLM judge. No evidence path touched.
+  return llmJudge.judge(goal);
+}
+
+/**
+ * Evidence-gate-aware judgement for a single task-completion goal.
+ *
+ * Decision table (first match wins):
+ * 1. Task not found → `impossible` (the goal references a task that no longer
+ *    exists).
+ * 2. Task `cancelled` / `archived` → `impossible` (terminal non-done state —
+ *    it can never become `done`).
+ * 3. Task not `done` → `ok: false` (still in flight; reason carries the real
+ *    status so the continuation tells the agent what remains).
+ * 4. Task `done` but a critical gate lacks the ADR-051-required evidence atoms
+ *    → `ok: false` (done-without-proof is NOT satisfied — the whole point).
+ * 5. Task `done` AND every critical gate is evidence-backed → `ok: true`.
+ *
+ * @param targetTaskId - The task the goal wants completed.
+ * @param cwd - Project root override.
+ * @returns The verdict, with `evidence[]` listing the atom kinds inspected.
+ * @task T11378
+ * @adr ADR-051
+ */
+export async function judgeTaskCompletion(
+  targetTaskId: string,
+  cwd?: string,
+): Promise<GoalJudgeVerdict> {
+  const accessor = await getTaskAccessor(cwd);
+  const task = await accessor.loadSingleTask(targetTaskId);
+
+  if (!task) {
+    return {
+      ok: false,
+      impossible: true,
+      reason: `Goal target ${targetTaskId} does not exist — it cannot be completed.`,
+    };
+  }
+
+  if (task.status === 'cancelled' || task.status === 'archived') {
+    return {
+      ok: false,
+      impossible: true,
+      reason: `Goal target ${targetTaskId} is ${task.status} — a terminal non-done state; it can never be completed.`,
+    };
+  }
+
+  if (task.status !== 'done') {
+    return {
+      ok: false,
+      impossible: false,
+      reason: `Goal target ${targetTaskId} is ${task.status}, not done. Continue working until it reaches done with evidence-backed gates.`,
+    };
+  }
+
+  // Task IS done — but "done" alone is not enough. Re-use the ADR-051 evidence
+  // path via the core-side `checkGateEvidenceMinimum`, which filters `override`
+  // atoms and delegates to `validateEvidenceForGate` (the contracts SSoT). Every
+  // critical gate MUST be backed by atoms of the required kinds.
+  const verification = task.verification;
+  const evidenceByGate = verification?.evidence ?? {};
+  const inspectedAtomKinds: string[] = [];
+  const unbacked: string[] = [];
+
+  for (const gate of CRITICAL_GATES) {
+    const gateEvidence = evidenceByGate[gate];
+    const atoms = gateEvidence?.atoms ?? [];
+    for (const atom of atoms) inspectedAtomKinds.push(`${gate}:${atom.kind}`);
+
+    const failure = checkGateEvidenceMinimum(gate, atoms);
+    if (failure !== null) {
+      unbacked.push(`${gate} (${failure})`);
+    }
+  }
+
+  if (unbacked.length > 0) {
+    return {
+      ok: false,
+      impossible: false,
+      reason:
+        `Goal target ${targetTaskId} is done but its evidence gates are not satisfied: ` +
+        `${unbacked.join('; ')}. A goal is satisfied only when the task is done AND its ` +
+        `critical gates (${CRITICAL_GATES.join(', ')}) carry valid ADR-051 evidence atoms.`,
+      evidence: inspectedAtomKinds,
+    };
+  }
+
+  return {
+    ok: true,
+    impossible: false,
+    reason: `Goal target ${targetTaskId} is done and its critical gates (${CRITICAL_GATES.join(', ')}) are evidence-backed.`,
+    evidence: inspectedAtomKinds,
+  };
+}
+
+/**
+ * A deterministic, offline {@link GoalJudge} that always returns a fixed
+ * verdict. Wired in tests (and as a safe default in non-LLM contexts) so the
+ * fuzzy path is fully exercised without a live model call.
+ *
+ * Production wires a real LLM-backed implementation of {@link GoalJudge}; this
+ * stub exists so the goal loop has a hermetic fallback and so the gate
+ * `GATE_EVIDENCE_REQUIREMENTS` import stays referenced for downstream tooling.
+ *
+ * @task T11378
+ */
+export class StaticGoalJudge implements GoalJudge {
+  /**
+   * @param verdict - The verdict every {@link judge} call returns.
+   */
+  constructor(private readonly verdict: GoalJudgeVerdict) {}
+
+  /**
+   * Return the configured verdict, ignoring the goal entirely (deterministic).
+   *
+   * @param _goal - The goal under evaluation (unused — deterministic stub).
+   * @returns The fixed verdict.
+   */
+  async judge(_goal: GoalRecord): Promise<GoalJudgeVerdict> {
+    return this.verdict;
+  }
+}
+
+/**
+ * The number of distinct critical gates the evidence judge inspects. Exposed so
+ * callers/tests can assert the judge consulted the full {@link CRITICAL_GATES}
+ * set without hard-coding the count, and to keep {@link GATE_EVIDENCE_REQUIREMENTS}
+ * referenced as the SSoT the judge validates against.
+ *
+ * @task T11378
+ */
+export const CRITICAL_GATE_COUNT: number = CRITICAL_GATES.filter(
+  (gate) => GATE_EVIDENCE_REQUIREMENTS[gate] !== undefined,
+).length;

--- a/packages/core/src/goal/loop.ts
+++ b/packages/core/src/goal/loop.ts
@@ -1,0 +1,162 @@
+/**
+ * Turn-budgeted goal loop (Layer 4 of SG-COGNITIVE-SUBSTRATE).
+ *
+ * The loop is the Hermes-style post-turn driver, hardened: it consumes one turn
+ * per advance, enforces a hard {@link GoalRecord.turnBudget}, surfaces
+ * `impossible` verdicts as a terminal state (no further turns), and — the Hermes
+ * pattern that prevents silent crashes — AUTO-PAUSES on a judge/parse failure
+ * rather than aborting.
+ *
+ * `advanceGoal` is PURE and DETERMINISTIC over `(goal, judgeFn)`: it performs no
+ * I/O itself (the judge is injected; persistence is the caller's job via the
+ * store's `updateGoal`). This makes every transition trivially unit-testable
+ * offline and keeps the budget/impossible/pause logic in one auditable place.
+ *
+ * Transition table (the four AC-mandated outcomes):
+ * - `verdict.ok`         → `satisfied` (terminal).
+ * - `verdict.impossible` → `impossible` (terminal; consumes NO turn).
+ * - judge/parse failure  → `paused` (auto-pause, `pausedReason` set).
+ * - turn budget reached  → `abandoned` (terminal).
+ * - otherwise            → `active` (one turn consumed; keep going).
+ *
+ * @module @cleocode/core/goal/loop
+ *
+ * @epic T11290 EP-CLEO-GOAL-SYSTEM
+ * @task T11379
+ * @saga T11283 SG-COGNITIVE-SUBSTRATE
+ */
+
+import type {
+  GoalAdvanceResult,
+  GoalJudgeVerdict,
+  GoalRecord,
+  GoalStatus,
+} from '@cleocode/contracts';
+
+/**
+ * A judge function the loop invokes once per advance. Injected so the loop is
+ * pure over `(goal, judgeFn)` — production passes a closure over `judgeGoal`,
+ * tests pass a deterministic stub.
+ *
+ * @param goal - The goal being advanced.
+ * @returns The verdict for this turn.
+ * @task T11379
+ */
+export type GoalJudgeFn = (goal: GoalRecord) => Promise<GoalJudgeVerdict>;
+
+/**
+ * A minimal, well-formed {@link GoalJudgeVerdict}-shaped object check.
+ *
+ * A judge that returns a malformed value (missing `ok`/`impossible`, wrong
+ * types) is treated as a PARSE FAILURE — the goal auto-pauses rather than
+ * trusting a garbage verdict. This is the structural half of the Hermes
+ * parse-failure pattern (the thrown-error half is handled by the try/catch in
+ * {@link advanceGoal}).
+ *
+ * @param value - The judge's return value.
+ * @returns `true` when `value` is a structurally-valid verdict.
+ * @task T11379
+ */
+export function isWellFormedVerdict(value: unknown): value is GoalJudgeVerdict {
+  if (value === null || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.ok === 'boolean' && typeof v.impossible === 'boolean' && typeof v.reason === 'string'
+  );
+}
+
+/**
+ * The malformed-verdict sentinel used as the verdict in an auto-pause result
+ * when the judge returned an unparseable value (vs. threw). Carries
+ * `impossible: false` so a resumed goal is not mistaken for terminal.
+ *
+ * @internal
+ */
+function pauseVerdict(reason: string): GoalJudgeVerdict {
+  return { ok: false, impossible: false, reason };
+}
+
+/**
+ * Advance a goal one turn through the budgeted loop.
+ *
+ * Pure and deterministic over `(goal, judgeFn)` — NO persistence here; the
+ * caller persists the returned `nextStatus` / `turnsRemaining` via the goal
+ * store's `updateGoal`. Already-terminal goals are returned unchanged (no turn
+ * is consumed, no judge is called) so the loop is idempotent at its boundaries.
+ *
+ * Ordering rationale:
+ * - The judge runs FIRST so a goal that became satisfiable/impossible since the
+ *   last turn is detected before a turn is "spent".
+ * - `impossible` consumes NO turn (the verdict is final regardless of budget).
+ * - `ok` consumes NO turn (work is done).
+ * - Only the "keep going" path consumes a turn, and the budget check fires AFTER
+ *   incrementing so `turnsRemaining` never goes negative.
+ *
+ * @param goal - The current goal record.
+ * @param judgeFn - The injected judge (see {@link GoalJudgeFn}).
+ * @returns The verdict, the next status, and the remaining turns.
+ * @task T11379
+ */
+export async function advanceGoal(
+  goal: GoalRecord,
+  judgeFn: GoalJudgeFn,
+): Promise<GoalAdvanceResult> {
+  const remainingBefore = Math.max(0, goal.turnBudget - goal.turnsUsed);
+
+  // Already-terminal goals are inert — return them unchanged.
+  if (goal.status === 'satisfied' || goal.status === 'abandoned' || goal.status === 'impossible') {
+    return {
+      verdict: goal.lastVerdict ?? pauseVerdict(`Goal already ${goal.status}; no further turns.`),
+      nextStatus: goal.status,
+      turnsRemaining: remainingBefore,
+    };
+  }
+
+  // Hermes auto-pause: a judge that THROWS (network blip, parse crash) must
+  // never abort the loop — pause the goal with the cause and let it resume.
+  let verdict: GoalJudgeVerdict;
+  try {
+    const raw = await judgeFn(goal);
+    if (!isWellFormedVerdict(raw)) {
+      return {
+        verdict: pauseVerdict('Judge returned a malformed verdict (auto-paused).'),
+        nextStatus: 'paused',
+        turnsRemaining: remainingBefore,
+      };
+    }
+    verdict = raw;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      verdict: pauseVerdict(`Judge failed: ${message} (auto-paused).`),
+      nextStatus: 'paused',
+      turnsRemaining: remainingBefore,
+    };
+  }
+
+  // Satisfied — terminal, no turn consumed.
+  if (verdict.ok) {
+    return { verdict, nextStatus: 'satisfied', turnsRemaining: remainingBefore };
+  }
+
+  // Impossible — terminal, no turn consumed (the verdict is final).
+  if (verdict.impossible) {
+    return { verdict, nextStatus: 'impossible', turnsRemaining: remainingBefore };
+  }
+
+  // Keep going: consume one turn. Budget is checked AFTER the increment so the
+  // turn that exhausts the budget is the one that triggers abandonment, and
+  // turnsRemaining floors at 0.
+  const turnsRemaining = Math.max(0, remainingBefore - 1);
+  const nextStatus: GoalStatus = turnsRemaining === 0 ? 'abandoned' : 'active';
+  const finalVerdict: GoalJudgeVerdict =
+    nextStatus === 'abandoned'
+      ? {
+          ok: false,
+          impossible: false,
+          reason: `Turn budget exhausted (${goal.turnBudget} turns) before satisfaction. Last judge reason: ${verdict.reason}`,
+        }
+      : verdict;
+
+  return { verdict: finalVerdict, nextStatus, turnsRemaining };
+}

--- a/packages/core/src/goal/store.ts
+++ b/packages/core/src/goal/store.ts
@@ -1,0 +1,379 @@
+/**
+ * DB-persisted, per-agent goal CRUD store (Layer 4 of SG-COGNITIVE-SUBSTRATE).
+ *
+ * Persists {@link GoalRecord}s in the `tasks_goal` table inside `tasks.db`
+ * (Pattern A — opened through the canonical `getDb` chokepoint, never a raw
+ * `new DatabaseSync`). Every read/write is keyed by the resolved per-agent
+ * identity from E0 (`resolveSessionIdFromEnv` / `resolveAgentIdFromEnv`) so two
+ * concurrent agents never collide on one global row — the session-bleed class
+ * this saga exists to kill.
+ *
+ * JSONB discipline: `goal_kind`, `criteria`, and `last_verdict` are JSONB BLOB
+ * columns. Writes go through the {@link jsonb} customType's `toDriver` (wraps in
+ * the SQL `jsonb()` constructor); whole-value reads MUST project `json(col)`
+ * (see {@link jsonbText}) because the raw-BLOB read path is intentionally
+ * rejected — the on-disk JSONB encoding is version-unstable.
+ *
+ * @module @cleocode/core/goal/store
+ *
+ * @epic T11290 EP-CLEO-GOAL-SYSTEM
+ * @task T11377
+ * @saga T11283 SG-COGNITIVE-SUBSTRATE
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { GoalJudgeVerdict, GoalKind, GoalRecord, GoalStatus } from '@cleocode/contracts';
+import { and, desc, eq, isNull, sql } from 'drizzle-orm';
+import type { NodeSQLiteDatabase } from 'drizzle-orm/node-sqlite';
+import { resolveAgentIdFromEnv, resolveSessionIdFromEnv } from '../sessions/session-id.js';
+import { tasksGoal } from '../store/schema/goal.js';
+import { jsonbText } from '../store/schema/jsonb.js';
+import { getDb } from '../store/sqlite.js';
+import type * as schema from '../store/tasks-schema.js';
+
+/** Drizzle handle for `tasks.db` (typed against the tasks schema). */
+type DrizzleTasksDb = NodeSQLiteDatabase<typeof schema>;
+
+/**
+ * The resolved per-agent ownership key for a goal row.
+ *
+ * Both fields come from E0's env-first resolvers. When spawn injected no
+ * session/agent identity they are `null` (the global-scope case), which still
+ * isolates correctly because every concurrent agent in a shell DOES carry its
+ * own injected identity.
+ *
+ * @task T11377
+ */
+export interface GoalOwner {
+  /** Resolved session id (`resolveSessionIdFromEnv`), or `null`. */
+  readonly sessionId: string | null;
+  /** Resolved agent handle (`resolveAgentIdFromEnv`), or `null`. */
+  readonly agentId: string | null;
+}
+
+/**
+ * Parameters for {@link createGoal}.
+ *
+ * @task T11377
+ */
+export interface CreateGoalParams {
+  /** The goal-kind discriminator + payload (task-completion vs fuzzy). */
+  readonly goalKind: GoalKind;
+  /** Human-readable intent statement. */
+  readonly intent: string;
+  /** Hard turn cap before the loop abandons the goal. */
+  readonly turnBudget: number;
+  /** Initial acceptance criteria (defaults to empty). */
+  readonly criteria?: readonly string[];
+  /** Parent goal id when this is a sub-goal. */
+  readonly parentGoalId?: string | null;
+  /**
+   * Explicit owner override. When omitted, the owner is resolved from the
+   * environment via {@link resolveGoalOwner}. Tests pass an explicit owner to
+   * simulate two distinct agents without mutating `process.env`.
+   */
+  readonly owner?: GoalOwner;
+  /**
+   * Idempotency key. When omitted a UUID is generated. Supplying a stable key
+   * makes a re-issued create a no-op (the row already exists).
+   */
+  readonly idempotencyKey?: string;
+}
+
+/**
+ * Mutable fields accepted by {@link updateGoal}.
+ *
+ * `criteria` is replaced wholesale here; use {@link appendCriteria} for the
+ * append-only path. All fields are optional — only the provided ones are
+ * written, and `updated_at` is always refreshed.
+ *
+ * @task T11377
+ */
+export interface UpdateGoalFields {
+  readonly status?: GoalStatus;
+  readonly turnsUsed?: number;
+  readonly pausedReason?: string | null;
+  readonly lastVerdict?: GoalJudgeVerdict | null;
+  readonly criteria?: readonly string[];
+}
+
+/**
+ * Resolve the current per-agent goal owner from the environment (E0).
+ *
+ * Reads `CLEO_SESSION_ID` (+ precedence) and `CLEO_AGENT_ID` via the canonical
+ * env-first resolvers so the goal store keys identity the SAME way every other
+ * hot path does. Never reads the DB.
+ *
+ * @returns The resolved {@link GoalOwner}.
+ * @task T11377
+ */
+export function resolveGoalOwner(): GoalOwner {
+  return { sessionId: resolveSessionIdFromEnv(), agentId: resolveAgentIdFromEnv() };
+}
+
+/**
+ * Project a `tasks_goal` row (with JSONB columns read through `json(col)`) into
+ * the typed {@link GoalRecord} contract.
+ *
+ * @internal
+ */
+interface GoalSelectRow {
+  idempotencyKey: string;
+  sessionId: string | null;
+  agentId: string | null;
+  parentGoalId: string | null;
+  goalKind: GoalKind;
+  intent: string;
+  criteria: string[];
+  status: string;
+  turnBudget: number;
+  turnsUsed: number;
+  pausedReason: string | null;
+  lastVerdict: GoalJudgeVerdict | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * The select projection that reads every JSONB column through `json(col)` so
+ * `fromDriver`'s raw-BLOB guard never fires. Shared by every read path.
+ *
+ * @internal
+ */
+const GOAL_SELECTION = {
+  idempotencyKey: tasksGoal.idempotencyKey,
+  sessionId: tasksGoal.sessionId,
+  agentId: tasksGoal.agentId,
+  parentGoalId: tasksGoal.parentGoalId,
+  // jsonbText projects `json(col)` so the version-unstable raw BLOB is never
+  // parsed. The column is interpolated through `sql` to satisfy jsonbText's
+  // `SQL | SQL.Aliased` parameter (a bare column ref is not an `SQL`).
+  goalKind: jsonbText<GoalKind>(sql`${tasksGoal.goalKind}`),
+  intent: tasksGoal.intent,
+  criteria: jsonbText<string[]>(sql`${tasksGoal.criteria}`),
+  status: tasksGoal.status,
+  turnBudget: tasksGoal.turnBudget,
+  turnsUsed: tasksGoal.turnsUsed,
+  pausedReason: tasksGoal.pausedReason,
+  lastVerdict: jsonbText<GoalJudgeVerdict | null>(sql`${tasksGoal.lastVerdict}`),
+  createdAt: tasksGoal.createdAt,
+  updatedAt: tasksGoal.updatedAt,
+};
+
+/**
+ * Map a JSONB-decoded select row to the immutable {@link GoalRecord} contract.
+ *
+ * @internal
+ */
+function toGoalRecord(row: GoalSelectRow): GoalRecord {
+  return {
+    id: row.idempotencyKey,
+    sessionId: row.sessionId,
+    agentId: row.agentId,
+    parentGoalId: row.parentGoalId,
+    goalKind: row.goalKind,
+    intent: row.intent,
+    criteria: row.criteria ?? [],
+    status: row.status as GoalStatus,
+    turnBudget: row.turnBudget,
+    turnsUsed: row.turnsUsed,
+    pausedReason: row.pausedReason,
+    // json(NULL) decodes to null — guard the array/object decode defensively.
+    lastVerdict: row.lastVerdict ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * Create a new goal, persisted in `tasks.db` and keyed to the resolved
+ * per-agent owner.
+ *
+ * Idempotent on the primary key: a re-issued create with the same
+ * `idempotencyKey` coalesces via `onConflictDoNothing` and returns the existing
+ * row rather than inserting a duplicate.
+ *
+ * @param params - Goal creation parameters.
+ * @param cwd - Project root override (defaults to the resolved CLEO project).
+ * @returns The created (or pre-existing) {@link GoalRecord}.
+ * @task T11377
+ */
+export async function createGoal(params: CreateGoalParams, cwd?: string): Promise<GoalRecord> {
+  const db = (await getDb(cwd)) as DrizzleTasksDb;
+  const owner = params.owner ?? resolveGoalOwner();
+  const id = params.idempotencyKey ?? randomUUID();
+  const now = new Date().toISOString();
+  const criteria: string[] = [...(params.criteria ?? [])];
+
+  await db
+    .insert(tasksGoal)
+    .values({
+      idempotencyKey: id,
+      sessionId: owner.sessionId,
+      agentId: owner.agentId,
+      parentGoalId: params.parentGoalId ?? null,
+      goalKind: params.goalKind,
+      intent: params.intent,
+      criteria,
+      status: 'active',
+      turnBudget: params.turnBudget,
+      turnsUsed: 0,
+      pausedReason: null,
+      lastVerdict: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+    .run();
+
+  const created = await getGoalById(id, cwd);
+  if (!created) {
+    // Unreachable in practice — the row was just inserted (or already existed).
+    throw new Error(`createGoal: row ${id} not found immediately after insert`);
+  }
+  return created;
+}
+
+/**
+ * Load a single goal by its id (idempotency key / primary key).
+ *
+ * @param id - The goal id.
+ * @param cwd - Project root override.
+ * @returns The {@link GoalRecord}, or `null` when absent.
+ * @task T11377
+ */
+export async function getGoalById(id: string, cwd?: string): Promise<GoalRecord | null> {
+  const db = (await getDb(cwd)) as DrizzleTasksDb;
+  const rows = (await db
+    .select(GOAL_SELECTION)
+    .from(tasksGoal)
+    .where(eq(tasksGoal.idempotencyKey, id))
+    .limit(1)
+    .all()) as GoalSelectRow[];
+  const row = rows[0];
+  return row ? toGoalRecord(row) : null;
+}
+
+/**
+ * Get the most-recently-updated ACTIVE or PAUSED goal owned by an agent.
+ *
+ * This is the dominant lookup ("what is THIS agent working on?") and is served
+ * by the `idx_tasks_goal_owner_active` index. Owner defaults to the
+ * environment-resolved identity so concurrent agents see their OWN goal — never
+ * each other's. Terminal goals (satisfied/abandoned/impossible) are excluded;
+ * an agent's active goal is the live one it can still advance.
+ *
+ * @param cwd - Project root override.
+ * @param owner - Explicit owner override (defaults to {@link resolveGoalOwner}).
+ * @returns The active/paused {@link GoalRecord}, or `null` when none.
+ * @task T11377
+ */
+export async function getActiveGoal(cwd?: string, owner?: GoalOwner): Promise<GoalRecord | null> {
+  const db = (await getDb(cwd)) as DrizzleTasksDb;
+  const resolved = owner ?? resolveGoalOwner();
+  const rows = (await db
+    .select(GOAL_SELECTION)
+    .from(tasksGoal)
+    .where(ownerScope(resolved))
+    .orderBy(desc(tasksGoal.updatedAt))
+    .all()) as GoalSelectRow[];
+  // Filter to live statuses in JS — keeps the WHERE clause a single index-hit
+  // on the owner columns and avoids an OR-of-statuses scan. The owner set is
+  // small (a handful of goals per agent), so this is O(few).
+  for (const row of rows) {
+    if (row.status === 'active' || row.status === 'paused') {
+      return toGoalRecord(row);
+    }
+  }
+  return null;
+}
+
+/**
+ * List all goals owned by an agent, newest first.
+ *
+ * @param cwd - Project root override.
+ * @param owner - Explicit owner override (defaults to {@link resolveGoalOwner}).
+ * @returns Every {@link GoalRecord} for the owner, ordered by `updatedAt` desc.
+ * @task T11377
+ */
+export async function listGoals(cwd?: string, owner?: GoalOwner): Promise<GoalRecord[]> {
+  const db = (await getDb(cwd)) as DrizzleTasksDb;
+  const resolved = owner ?? resolveGoalOwner();
+  const rows = (await db
+    .select(GOAL_SELECTION)
+    .from(tasksGoal)
+    .where(ownerScope(resolved))
+    .orderBy(desc(tasksGoal.updatedAt))
+    .all()) as GoalSelectRow[];
+  return rows.map(toGoalRecord);
+}
+
+/**
+ * Update mutable fields of a goal and refresh `updated_at`.
+ *
+ * Only the provided fields are written. Returns the updated record (re-read so
+ * JSONB columns round-trip through `json(col)`), or `null` if the goal is gone.
+ *
+ * @param id - The goal id.
+ * @param fields - The fields to update.
+ * @param cwd - Project root override.
+ * @returns The updated {@link GoalRecord}, or `null` when the goal is absent.
+ * @task T11377
+ */
+export async function updateGoal(
+  id: string,
+  fields: UpdateGoalFields,
+  cwd?: string,
+): Promise<GoalRecord | null> {
+  const db = (await getDb(cwd)) as DrizzleTasksDb;
+  const patch: Partial<typeof tasksGoal.$inferInsert> = { updatedAt: new Date().toISOString() };
+  if (fields.status !== undefined) patch.status = fields.status;
+  if (fields.turnsUsed !== undefined) patch.turnsUsed = fields.turnsUsed;
+  if (fields.pausedReason !== undefined) patch.pausedReason = fields.pausedReason;
+  if (fields.lastVerdict !== undefined) patch.lastVerdict = fields.lastVerdict;
+  if (fields.criteria !== undefined) patch.criteria = [...fields.criteria];
+
+  await db.update(tasksGoal).set(patch).where(eq(tasksGoal.idempotencyKey, id)).run();
+  return getGoalById(id, cwd);
+}
+
+/**
+ * Append a single criterion to a goal's criteria array (append-only).
+ *
+ * Reads the current criteria, appends, and writes the whole array back. The
+ * read round-trips through `json(col)` so no raw BLOB is ever parsed.
+ *
+ * @param id - The goal id.
+ * @param criterion - The criterion text to append.
+ * @param cwd - Project root override.
+ * @returns The updated {@link GoalRecord}, or `null` when the goal is absent.
+ * @task T11377
+ */
+export async function appendCriteria(
+  id: string,
+  criterion: string,
+  cwd?: string,
+): Promise<GoalRecord | null> {
+  const current = await getGoalById(id, cwd);
+  if (!current) return null;
+  const next = [...current.criteria, criterion];
+  return updateGoal(id, { criteria: next }, cwd);
+}
+
+/**
+ * Build the owner-scope WHERE predicate, handling the `null` (no-identity)
+ * case correctly: a `null` session/agent must match `IS NULL`, not `= NULL`
+ * (which SQLite evaluates to UNKNOWN and never matches). Without `isNull`, the
+ * global-scope/no-session owner would match ZERO rows and silently lose its own
+ * goal — the inverse of the bleed we are preventing.
+ *
+ * @internal
+ */
+function ownerScope(owner: GoalOwner) {
+  return and(
+    owner.sessionId === null
+      ? isNull(tasksGoal.sessionId)
+      : eq(tasksGoal.sessionId, owner.sessionId),
+    owner.agentId === null ? isNull(tasksGoal.agentId) : eq(tasksGoal.agentId, owner.agentId),
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,8 @@ export * as compliance from './compliance/index.js';
 export * as conduit from './conduit/index.js';
 export * as context from './context/index.js';
 export * as gc from './gc/index.js';
+// CLEO-native goal system (T11290 · Saga T11283 · SG-COGNITIVE-SUBSTRATE).
+export * as goal from './goal/index.js';
 export * as harness from './harness/index.js';
 export * as coreHooks from './hooks/index.js';
 export * as identity from './identity/index.js';

--- a/packages/core/src/store/schema/goal.ts
+++ b/packages/core/src/store/schema/goal.ts
@@ -1,0 +1,109 @@
+/**
+ * Drizzle schema for the `tasks_goal` table — CLEO's DB-persisted, per-agent
+ * goal store (Layer 4 of SG-COGNITIVE-SUBSTRATE).
+ *
+ * Pattern A (ADR-068 / the SQLite-consolidation decision): one file per scope
+ * (this table lives INSIDE `tasks.db`, opened via `openCleoDb('tasks', cwd)` /
+ * `getTasksDb`), domain-prefixed table name (`tasks_goal`), and an idempotency
+ * key as the natural primary key so a re-issued `create` coalesces via
+ * `onConflictDoNothing` rather than duplicating a row.
+ *
+ * Per-agent isolation: every row carries `session_id` + `agent_id` resolved
+ * from E0 (`resolveSessionIdFromEnv` / `resolveAgentIdFromEnv`). The
+ * `idx_tasks_goal_owner_active` index serves the dominant lookup —
+ * "the active goal for THIS agent" — so two concurrent agents never collide on
+ * one global row (the session-bleed class this saga exists to kill).
+ *
+ * `criteria` is a JSONB column (binary, queryable in-SQL) via the reusable
+ * {@link jsonb} customType. The load-bearing read rule applies: whole-value
+ * reads MUST project `json(col)` (see {@link jsonbText}) — never `JSON.parse`
+ * the raw BLOB bytes. `last_verdict` is whole-value-read-only structured state,
+ * so it uses JSONB too and is always read back through `json(col)`.
+ *
+ * @epic T11290 EP-CLEO-GOAL-SYSTEM
+ * @task T11377
+ * @saga T11283 SG-COGNITIVE-SUBSTRATE
+ * @adr ADR-068
+ */
+
+import type { GoalJudgeVerdict, GoalKind } from '@cleocode/contracts';
+import { sql } from 'drizzle-orm';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { jsonb } from './jsonb.js';
+
+/**
+ * Per-agent goal record, persisted in `tasks.db`.
+ *
+ * Survives process restart (the whole point — Claude-Code forgets the goal on a
+ * fresh process; CLEO does not). Keyed by `idempotency_key` so the create path
+ * is safe to retry. `goal_kind` is the serialized {@link GoalKind} discriminated
+ * union (whole-value JSONB read) that routes the judge: evidence path for
+ * `task-completion`, LLM fallback for `fuzzy`.
+ *
+ * @task T11377
+ */
+export const tasksGoal = sqliteTable(
+  'tasks_goal',
+  {
+    /**
+     * Idempotency key + primary identity. A re-issued create with the same key
+     * coalesces via `onConflictDoNothing` instead of inserting a duplicate.
+     */
+    idempotencyKey: text('idempotency_key').primaryKey(),
+    /**
+     * Resolved owning session id (`resolveSessionIdFromEnv`). `null` for the
+     * global-scope / no-session case. Half of the per-agent ownership key.
+     */
+    sessionId: text('session_id'),
+    /**
+     * Resolved owning agent handle (`resolveAgentIdFromEnv`). `null` when spawn
+     * injected no agent identity. The other half of the per-agent ownership key.
+     */
+    agentId: text('agent_id'),
+    /** Parent goal id when this is a sub-goal, else `null`. */
+    parentGoalId: text('parent_goal_id'),
+    /**
+     * Serialized {@link GoalKind} discriminated union (JSONB). Drives the judge
+     * route. Read whole via `json(col)` — never parse the raw BLOB.
+     */
+    goalKind: jsonb<GoalKind>('goal_kind').notNull(),
+    /** Human-readable statement of the agent's intent. */
+    intent: text('intent').notNull(),
+    /**
+     * Append-only acceptance criteria (JSONB array of strings). Appended via
+     * the store's `appendCriteria`; read whole via `json(col)`.
+     */
+    criteria: jsonb<string[]>('criteria').notNull().default(sql`jsonb('[]')`),
+    /** Current lifecycle status (GoalStatus). */
+    status: text('status').notNull().default('active'),
+    /** Hard turn cap before the loop abandons the goal. */
+    turnBudget: integer('turn_budget').notNull(),
+    /** Turns consumed so far (never exceeds `turn_budget`). */
+    turnsUsed: integer('turns_used').notNull().default(0),
+    /** Auto-pause reason when `status = 'paused'`, else `null`. */
+    pausedReason: text('paused_reason'),
+    /**
+     * Most recent {@link GoalJudgeVerdict} (JSONB), persisted so `cleo goal
+     * status` shows the last reason without re-judging. `null` before the first
+     * judge. Read whole via `json(col)`.
+     */
+    lastVerdict: jsonb<GoalJudgeVerdict>('last_verdict'),
+    /** ISO-8601 creation timestamp. */
+    createdAt: text('created_at').notNull(),
+    /** ISO-8601 last-update timestamp. */
+    updatedAt: text('updated_at').notNull(),
+  },
+  (table) => [
+    // Dominant lookup: "the active goal for THIS (session, agent)". Keying the
+    // index on (session_id, agent_id, status) lets getActiveGoal hit an index
+    // instead of scanning, and structurally scopes the read per agent.
+    index('idx_tasks_goal_owner_active').on(table.sessionId, table.agentId, table.status),
+    // Sub-goal traversal: find children of a parent goal.
+    index('idx_tasks_goal_parent').on(table.parentGoalId),
+  ],
+);
+
+/** Row type for `tasks_goal` SELECT queries (T11377). */
+export type TasksGoalRow = typeof tasksGoal.$inferSelect;
+/** Row type for `tasks_goal` INSERT operations (T11377). */
+export type NewTasksGoalRow = typeof tasksGoal.$inferInsert;

--- a/packages/core/src/store/schema/index.ts
+++ b/packages/core/src/store/schema/index.ts
@@ -27,6 +27,7 @@ export * from './audit.js';
 export * from './background-jobs.js';
 export * from './evidence-bindings.js';
 export * from './experiments.js';
+export * from './goal.js';
 export * from './jsonb.js';
 export * from './lifecycle.js';
 export * from './manifest.js';


### PR DESCRIPTION
## E5 (T11290) — DB-persisted, evidence-gate-aware goal loop — Wave-1 of SG-COGNITIVE-SUBSTRATE (T11283)

Beats Claude-Code (Stop-hook + transcript-judge) and Hermes (post-turn loop) with an **evidence-gate-aware judge**: a `complete T###` goal is satisfied only when the task is `status=done` AND its critical gates (`implemented`+`testsPassed`) carry valid ADR-051 evidence atoms — **a goal cannot be faked by the conversation claiming success**. Per-agent scoped via E0 identity. (18 files, +2616/−96.)

### What landed (6 child tasks)
- **T11376**: goal contracts (`GoalRecord`/`GoalStatus`/`GoalJudgeVerdict`/`GoalJudge`) in `@cleocode/contracts`.
- **T11377**: `tasks_goal` table (Pattern A: `idempotency_key` PK + onConflictDoNothing; JSONB criteria via the E4 `jsonb()` customType; per-agent `session_id`/`agent_id` owner key) + migration + store.
- **T11378**: evidence-gate-aware judge — **reuses** the shipped `validateEvidenceForGate`/`checkGateEvidenceMinimum` (NO re-implementation of atom parsing); injectable `GoalJudge` for fuzzy goals.
- **T11379**: pure `advanceGoal` loop (4 transitions + auto-pause on judge throw/malformed).
- **T11380**: cache-safe `buildContinuation` (user-message, never mutates the system prompt → prompt-cache prefix stays valid; byte-stable).
- **T11381**: `cleo goal set/status/subgoal/append` (registered via `gen:manifest`).

### Validation (merged-with-main, incl. R2 daemon)
Full build exit 0 · goal + migration suites **57/57** · agent's full sweep 44 core/CLI tests · migration 23/23 (pure idempotent CREATE TABLE, drift-safe) · all 5 `cleo check arch` gates + DB Open Guard + Fan-Out + CLI-boundary + migration-lint green · biome clean · end-to-end verified live (two-agent isolation, no bleed). LLM-judge is hermetic (injected interface + `vi.mock` + FORBIDDEN_JUDGE; zero network in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)