### PR TITLE
test(T11452): freeze gateway-contract v1.0 + spec (R3-T8 · SG-RUNTIME-UNIFICATION)

### DIFF
--- a/.changeset/t11452-freeze-gateway-contract.md
+++ b/.changeset/t11452-freeze-gateway-contract.md
@@ -1,0 +1,8 @@
+---
+id: t11452-freeze-gateway-contract
+tasks: [T11452, T11254]
+kind: test
+summary: Freeze gateway-contract v1.0 — lock the full contract surface (version + 4 transports + all frozen shapes) + spec doc
+---
+
+R3-T8. Adds the gateway-contract v1.0 FREEZE block to gateway-contract.test.ts locking GATEWAY_CONTRACT_VERSION=1.0.0 + GATEWAY_SOURCES + the frozen field sets of DispatchError/DispatchResponseMeta/GatewayStreamEvent (request/response already snapshotted in R3-T2). Any breaking change fails the snapshot + requires a version bump. Versioned spec registered (slug gateway-contract-v1) documenting the contract, 4 adapters (cli/mcp/rpc/http), process-per-scope, the supervisor-ipc-v1.0-separate-freeze boundary, and the freeze policy.

--- a/packages/contracts/src/__tests__/gateway-contract.test.ts
+++ b/packages/contracts/src/__tests__/gateway-contract.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from 'vitest';
 import {
   dispatchErrorSchema,
   dispatchRequestSchema,
+  dispatchResponseMetaSchema,
   dispatchResponseSchema,
   GATEWAY_CONTRACT_VERSION,
   GATEWAY_SOURCES,
@@ -152,6 +153,66 @@ describe('gateway contract — field-shape snapshot (drift guard)', () => {
         "page",
         "partial",
         "success",
+      ]
+    `);
+  });
+});
+
+// ─── gateway-contract v1.0 FREEZE (R3-T8 · T11452) ──────────────────────────
+// Locks the COMPLETE v1.0 contract surface (version + 4 transports + every
+// frozen shape's field set). Any change here is a breaking contract change and
+// REQUIRES a GATEWAY_CONTRACT_VERSION bump — mirrors the supervisor-ipc v1.0
+// freeze. The spec doc (slug `gateway-contract-v1`) is the human-readable SoT.
+describe('gateway-contract v1.0 FREEZE', () => {
+  it('version is pinned at 1.0.0', () => {
+    expect(GATEWAY_CONTRACT_VERSION).toBe('1.0.0');
+  });
+
+  it('the four transports are frozen', () => {
+    expect([...GATEWAY_SOURCES]).toEqual(['cli', 'mcp', 'rpc', 'http']);
+  });
+
+  it('error fields are frozen', () => {
+    expect(Object.keys(dispatchErrorSchema.shape).sort()).toMatchInlineSnapshot(`
+      [
+        "alternatives",
+        "code",
+        "details",
+        "exitCode",
+        "fix",
+        "message",
+        "problemDetails",
+      ]
+    `);
+  });
+
+  it('response meta fields are frozen (catchall preserves extensibility)', () => {
+    expect(Object.keys(dispatchResponseMetaSchema.shape).sort()).toMatchInlineSnapshot(`
+      [
+        "domain",
+        "duration_ms",
+        "executionSessionId",
+        "gateway",
+        "operation",
+        "originSessionId",
+        "rateLimit",
+        "requestId",
+        "sessionId",
+        "source",
+        "timestamp",
+        "version",
+      ]
+    `);
+  });
+
+  it('stream-event fields are frozen', () => {
+    expect(Object.keys(gatewayStreamEventSchema.shape).sort()).toMatchInlineSnapshot(`
+      [
+        "data",
+        "error",
+        "kind",
+        "requestId",
+        "seq",
       ]
     `);
   });


### PR DESCRIPTION
## R3-T8 (T11452) — freeze gateway-contract v1.0

Freezes the gateway contract (promoted in R3-T2, dispatcher relocated in R3-T3) at **v1.0**, mirroring the supervisor-ipc v1.0 freeze.

- **Freeze test** (`gateway-contract.test.ts` → `gateway-contract v1.0 FREEZE`): locks `GATEWAY_CONTRACT_VERSION=1.0.0`, the 4 transports (`GATEWAY_SOURCES`), and the frozen field sets of `DispatchError` / `DispatchResponseMeta` (+ catchall) / `GatewayStreamEvent` (request/response already snapshotted in R3-T2). Runs in CI — any field add/remove/rename fails + **requires a version bump**.
- **Versioned spec** in the docs SSoT (slug `gateway-contract-v1`): the frozen shapes, the four adapters (`cli` LIVE; `mcp`/`rpc`/`http` planned), the process-per-scope daemon model, the boundary that **supervisor-ipc v1.0 stays separately frozen** (CLI-RPC reuses the *pattern*, not the protocol), and the freeze/versioning policy.

Declaring `rpc`/`http` in v1.0 makes adding their adapters (R3-T4..T6) **non-breaking**.

### Verification
contracts build · gateway-contract test **18/18** · biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)