### PR TITLE
feat(T11358): dual-scope cleo.db drizzle configs (rc.3) + re-derived per-scope counts (E2 · SG-DB-SUBSTRATE-V2)

### DIFF
--- a/docs/migration/sqlite-schema-canonical.md
+++ b/docs/migration/sqlite-schema-canonical.md
@@ -105,29 +105,113 @@ Each column row in `sqlite-schema-columns.json` carries:
 
 ## 1. Consolidated dual-scope target shape (locked decisions)
 
-Per the locked SG-DB-SUBSTRATE-V2 decisions (D1' supersedes D1):
+> **D1″ supersedes D1′ (owner ratification 2026-05-30, session 2).** The split axis is
+> now **lifecycle (project vs global)**, NOT domain-cluster, and both files are named
+> **`cleo.db`**. The earlier D1′ domain-split into `.cleo/tasks.db` + `.cleo/brain.db`
+> is superseded: it conflated project- and global-tier domains in one file (e.g. global
+> `nexus`/`skills` were folded into a project `brain.db`) and did not match the owner's
+> "dual `cleo.db`, one project + one global" intent. The Pattern-A mechanics
+> (single-file-per-scope, domain-prefixed tables, idempotent prefixer, the column→table
+> attribution) are PRESERVED; only the scope axis + file naming change.
+
+Per the locked SG-DB-SUBSTRATE-V2 decisions (**D1″ supersedes D1′ supersedes D1**):
 
 - **Substrate:** SQLite consolidation, **Pattern A** — single-file-per-scope,
-  domain-prefixed tables. Two scopes survive: `.cleo/tasks.db` and
-  `.cleo/brain.db`.
+  domain-prefixed tables. **Two scopes survive, split by LIFECYCLE:**
+  the **project** DB `<projectRoot>/.cleo/cleo.db` and the **global** DB
+  `$XDG_DATA_HOME/cleo/cleo.db` (per-OS XDG path via `@cleocode/paths`).
 - **Driver:** `node:sqlite` 3.53.0. **ORM:** `drizzle-orm@1.0.0-rc.3`
   (`drizzle-orm/node-sqlite`).
-- **Table prefixes:** `tasks_*` / `conduit_*` / `docs_*` / `telemetry_*` collapse
-  into `.cleo/tasks.db`; `brain_*` / `nexus_*` / `signaldock_*` / `skills_*`
-  collapse into `.cleo/brain.db`.
+- **Table prefixes (lifecycle assignment):** **project** `cleo.db` holds every
+  project-tier domain — `tasks_*` / `brain_*` (this project's memory) / `conduit_*` /
+  `docs_*` / `telemetry_*` (+ lifecycle/provenance/chain/playbooks/agents). **global**
+  `cleo.db` holds every global/cross-project domain — `nexus_*` / `skills_*` /
+  `signaldock_*` (global agent identity) / `brain_*` + `tasks_*` for the global-tier
+  brain & task stores. `brain_*` and `tasks_*` thus appear in BOTH files, disambiguated
+  by which scope's `cleo.db` they live in (per-project state vs cross-project state).
 
 Every column in the inventory is attributed to its `targetTable` using the
-file → domain map plus an idempotent prefixer (a table already carrying a
-recognized domain prefix — e.g. `brain_observations`, `nexus_audit_log` — is NOT
-double-prefixed). The canonical task table `tasks` becomes `tasks_tasks` under
-Pattern A.
+domain map plus an idempotent prefixer (a table already carrying a recognized domain
+prefix — e.g. `brain_observations`, `nexus_audit_log` — is NOT double-prefixed). The
+canonical task table `tasks` becomes `tasks_tasks` under Pattern A. The exodus tool
+routes each table to the **project** or **global** `cleo.db` by its domain's lifecycle
+tier (a domain is project-scoped unless it is in the global set `{nexus, skills,
+signaldock-global, global-brain, global-tasks, telemetry-global}`).
 
-### Scope assignment summary
+### Scope assignment summary (D1″ — lifecycle)
 
-| Target scope | DB file | Source domains | Tables | Columns |
+| Target scope | DB file | Source domains | Note |
+|---|---|---|---|
+| **project** | `<projectRoot>/.cleo/cleo.db` | tasks / brain (this project's memory) / conduit / docs / telemetry / lifecycle / provenance / chain / playbooks / agents | all project-tier state |
+| **global** | `$XDG_DATA_HOME/cleo/cleo.db` | nexus / skills / signaldock (global identity) / global-brain / global-tasks / telemetry-global | all cross-project state |
+
+> **Exactly two `*.db` files survive per machine view** (one project `cleo.db` + one
+> global `cleo.db`). No `tasks.db` / `brain.db` / `nexus.db` / `skills.db` /
+> `signaldock.db` / `telemetry.db` / `manifest.db` / `llmtxt.db` / `attachments/index.db`
+> sidecar survives; content-addressed blob FILES (not `.db`) are exempt.
+
+### Per-scope re-derived counts (T11358 — supersedes 66/631 + 48/550)
+
+The prior domain-split figures (`tasks` 66t/631c + `brain` 48t/550c) are SUPERSEDED.
+Counts below are re-derived against the **lifecycle** split directly from the audit
+artifact `docs/migration/sqlite-schema-columns.json` (114 tables / 1181 columns),
+by classifying each table to its domain via `targetTable` prefix, then routing each
+domain to its lifecycle tier. The classification is reproducible — re-run:
+
+```bash
+node -e 'const j=require("./docs/migration/sqlite-schema-columns.json");
+const dom=tt=>{for(const p of["nexus","skills","signaldock","brain","conduit","telemetry","docs"])if(tt.startsWith(p+"_"))return p;return"tasks-core"};
+const a={};for(const t of j.tables){const d=dom(t.targetTable);(a[d]??=(a[d]={t:0,c:0}));a[d].t++;a[d].c+=t.columns.length}console.table(a)'
+```
+
+| Domain (prefix) | Tables | Columns | Lifecycle tier |
+|---|--:|--:|---|
+| `tasks_*` (incl. provenance / releases / lifecycle / playbooks / agents / chain) | 45 | 450 | project |
+| `conduit_*` | 14 | 116 | project |
+| `docs_*` (attachments / manifest) | 4 | 48 | project |
+| `telemetry_*` | 2 | 12 | project |
+| `brain_*` (memory) | 22 | 277 | **mirrored** (project + global) |
+| `nexus_*` | 10 | 109 | global |
+| `skills_*` | 4 | 36 | global |
+| `signaldock_*` | 13 | 133 | global |
+| **Total (distinct source tables)** | **114** | **1181** | |
+
+**Per-scope cleo.db totals** (the `brain_*` schema is SHARED — same DDL deployed to
+both files, data partitioned by scope; it is counted in each):
+
+| Scope | DB file | Composition | Tables | Columns |
 |---|---|---|--:|--:|
-| `tasks` | `.cleo/tasks.db` | tasks / conduit / docs / telemetry / lifecycle / provenance / chain / playbooks / agents | 66 | 631 |
-| `brain` | `.cleo/brain.db` | brain (memory) / nexus / signaldock / skills | 48 | 550 |
+| **project** | `<projectRoot>/.cleo/cleo.db` | tasks-core 45 + conduit 14 + docs 4 + telemetry 2 + brain 22 | **87** | **903** |
+| **global** | `$XDG_DATA_HOME/cleo/cleo.db` | nexus 10 + skills 4 + signaldock 13 + brain 22 (mirrored) | **49** | **555** |
+
+> **Scope-membership decision (T11358).** Only `brain_*` (memory) is mirrored into
+> both scopes (the global brain holds cross-project memory; the project brain holds
+> project-local memory). Project-tier `tasks_*` and its satellites (provenance,
+> releases, lifecycle, playbooks) are **not** mirrored into global — a release/PR/run
+> is intrinsically a project concern. `signaldock_*` folds under the **global**
+> `cleo.db` per D1 (no standalone `signaldock.db`).
+
+### Dual drizzle-kit configs (T11358 — target shape)
+
+The dual-scope target is authored as two drizzle-kit (rc.3) configs:
+
+| Config | Scope | `out` | Schema membership |
+|---|---|---|---|
+| `drizzle/cleo-project.config.ts` | project | `packages/core/migrations/drizzle-cleo-project` | 17 project-tier + mirrored-brain modules |
+| `drizzle/cleo-global.config.ts` | global | `packages/core/migrations/drizzle-cleo-global` | nexus / skills / signaldock + mirrored-brain modules |
+
+Wired into root `package.json` as `db:generate:cleo-project` / `db:generate:cleo-global`.
+
+> **Generation boundary.** These configs declare per-scope domain MEMBERSHIP, not a
+> generate-ready snapshot. Source modules carry UNPREFIXED physical table names, so
+> several collide across domains in one file (e.g. `schema/attachments.ts` and
+> `conduit-schema.ts` both define `attachments` → `tasks_attachments` vs
+> `conduit_attachments`). Pattern-A domain-prefixing that resolves the collisions is
+> applied by the **E3 exodus prefixer (T11248)**; running `drizzle-kit generate`
+> against the consolidated configs is therefore deferred until exodus emits the
+> prefixed schema. Until then `db:check` continues to validate the per-domain baseline
+> configs only; the two `cleo-*` configs join the check loop once their first prefixed
+> baseline migration exists.
 
 ---
 

--- a/drizzle/cleo-global.config.ts
+++ b/drizzle/cleo-global.config.ts
@@ -1,0 +1,63 @@
+/**
+ * Drizzle-kit config for the **global-scope** `cleo.db` (D1″ lifecycle split).
+ *
+ * Target shape for SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2). Owner
+ * decision D1″ (2026-05-30) partitions the consolidated SQLite substrate by
+ * LIFECYCLE: exactly two `cleo.db` files survive per machine view — this
+ * global-scope DB and the project-scope DB
+ * ({@link ./cleo-project.config.ts}).
+ *
+ * Global `cleo.db` holds every **global / cross-project** domain (Pattern A —
+ * single-file-per-scope, domain-prefixed tables):
+ *   `nexus_*` (cross-project code index) / `skills_*` / `signaldock_*`
+ *   (global agent identity — folded here per D1, no standalone `signaldock.db`
+ *   survives) / `brain_*` (the global cross-project memory store).
+ *
+ * Re-derived count (against the lifecycle split, superseding the prior 48/550
+ * domain-split figure): **49 tables / 555 columns** — nexus 10t/109c +
+ * skills 4t/36c + signaldock 13t/133c + brain (memory) 22t/277c. The `brain_*`
+ * schema modules are SHARED with the project config — same DDL, two DB files,
+ * data partitioned by scope (global = cross-project memory). Project-tier
+ * `tasks_*` (releases, provenance, lifecycle, playbooks) are intentionally NOT
+ * mirrored here — they are project concerns and live only in the project
+ * `cleo.db`.
+ *
+ * Runtime DB path resolves via `@cleocode/paths` to
+ * `$XDG_DATA_HOME/cleo/cleo.db` (per-OS XDG location); the `dbCredentials.url`
+ * below is the drizzle-kit baseline only.
+ *
+ * **Generation boundary (settles the file-split ambiguity).** The `schema` list
+ * declares per-scope DOMAIN MEMBERSHIP, not a generate-ready snapshot. Source
+ * modules carry UNPREFIXED physical table names; Pattern-A domain-prefixing is
+ * applied by the **E3 exodus prefixer (T11248)**, so `drizzle-kit generate`
+ * against this config is deferred until exodus emits the prefixed consolidated
+ * schema. This task (T11358) authors the target shape only.
+ *
+ * @task T11358
+ * @epic T11245
+ * @saga T11242
+ * @see docs/migration/sqlite-schema-canonical.md §1 (canonical per-scope counts)
+ */
+
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: [
+    // nexus (10 tables) — cross-project code-intelligence index
+    './packages/core/src/store/nexus-schema.ts',
+    './packages/nexus/src/schema/code-index.ts',
+    // skills (4 tables) — global skills catalog
+    './packages/core/src/store/skills-schema.ts',
+    // signaldock (13 tables) — global agent identity / capabilities (folded per D1)
+    './packages/core/src/store/signaldock-schema.ts',
+    // brain / memory (22 tables) — SHARED with cleo-project.config.ts (global cross-project memory)
+    './packages/core/src/store/memory-schema.ts',
+  ],
+  out: './packages/core/migrations/drizzle-cleo-global',
+  dialect: 'sqlite',
+  dbCredentials: {
+    url:
+      process.env.CLEO_DRIZZLE_BASELINE_CLEO_GLOBAL_DB ||
+      '/tmp/cleo-drizzle-baseline/cleo-global.db',
+  },
+});

--- a/drizzle/cleo-project.config.ts
+++ b/drizzle/cleo-project.config.ts
@@ -1,0 +1,76 @@
+/**
+ * Drizzle-kit config for the **project-scope** `cleo.db` (D1″ lifecycle split).
+ *
+ * Target shape for SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2). Owner
+ * decision D1″ (2026-05-30) partitions the consolidated SQLite substrate by
+ * LIFECYCLE, not domain-cluster: exactly two `cleo.db` files survive per machine
+ * view — this project-scope DB and the global-scope DB
+ * ({@link ./cleo-global.config.ts}).
+ *
+ * Project `cleo.db` holds every **project-tier** domain (Pattern A —
+ * single-file-per-scope, domain-prefixed tables):
+ *   `tasks_*` / `brain_*` (this project's memory) / `conduit_*` / `docs_*` /
+ *   `telemetry_*` (+ lifecycle / provenance / chain / playbooks / agents).
+ *
+ * Re-derived count (against the lifecycle split, superseding the prior 66/631
+ * domain-split figure): **87 tables / 903 columns** — tasks-core 45t/450c +
+ * conduit 14t/116c + docs 4t/48c + telemetry 2t/12c + brain (memory) 22t/277c.
+ * The `brain_*` schema modules are SHARED with the global config (the global
+ * brain holds cross-project memory; this project brain holds project-local
+ * memory) — same DDL, two DB files, data partitioned by scope.
+ *
+ * Runtime DB path resolves via `@cleocode/paths` to `<projectRoot>/.cleo/cleo.db`;
+ * the `dbCredentials.url` below is the drizzle-kit baseline only (generate/check),
+ * not the live runtime location.
+ *
+ * **Generation boundary (settles the file-split ambiguity).** The `schema` list
+ * below declares per-scope DOMAIN MEMBERSHIP, not a generate-ready snapshot. The
+ * source modules still carry UNPREFIXED physical table names, so several names
+ * collide across domains in a single file (e.g. `schema/attachments.ts` and
+ * `conduit-schema.ts` both define `attachments` → `tasks_attachments` vs
+ * `conduit_attachments`). Pattern-A domain-prefixing that resolves these
+ * collisions is applied by the **E3 exodus prefixer (T11248)**; `drizzle-kit
+ * generate` against this config is therefore deferred until exodus emits the
+ * prefixed consolidated schema. This task (T11358) authors the target shape
+ * (scope axis, file naming, membership, counts) only.
+ *
+ * @task T11358
+ * @epic T11245
+ * @saga T11242
+ * @see docs/migration/sqlite-schema-canonical.md §1 (canonical per-scope counts)
+ */
+
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: [
+    // tasks-core (45 tables) — task lifecycle, provenance, releases, playbooks, agents
+    './packages/core/src/store/schema/tasks.ts',
+    './packages/core/src/store/schema/attachments.ts',
+    './packages/core/src/store/schema/audit.ts',
+    './packages/core/src/store/schema/background-jobs.ts',
+    './packages/core/src/store/schema/evidence-bindings.ts',
+    './packages/core/src/store/schema/experiments.ts',
+    './packages/core/src/store/schema/lifecycle.ts',
+    './packages/core/src/store/schema/manifest.ts',
+    './packages/core/src/store/schema/provenance/commits.ts',
+    './packages/core/src/store/schema/provenance/pull-requests.ts',
+    './packages/core/src/store/schema/provenance/releases.ts',
+    './packages/core/src/store/chain-schema.ts',
+    './packages/core/src/agents/agent-schema.ts',
+    './packages/playbooks/src/schema.ts',
+    // conduit (14 tables) — project-local messaging / delivery / attachments
+    './packages/core/src/store/conduit-schema.ts',
+    // telemetry (2 tables) — project-tier telemetry counters
+    './packages/core/src/telemetry/schema.ts',
+    // brain / memory (22 tables) — SHARED with cleo-global.config.ts (project-local memory)
+    './packages/core/src/store/memory-schema.ts',
+  ],
+  out: './packages/core/migrations/drizzle-cleo-project',
+  dialect: 'sqlite',
+  dbCredentials: {
+    url:
+      process.env.CLEO_DRIZZLE_BASELINE_CLEO_PROJECT_DB ||
+      '/tmp/cleo-drizzle-baseline/cleo-project.db',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "db:generate": "drizzle-kit generate --config drizzle/tasks.config.ts",
     "db:generate:brain": "drizzle-kit generate --config drizzle/brain.config.ts",
     "db:generate:nexus": "drizzle-kit generate --config drizzle/nexus.config.ts",
+    "db:generate:cleo-project": "drizzle-kit generate --config drizzle/cleo-project.config.ts",
+    "db:generate:cleo-global": "drizzle-kit generate --config drizzle/cleo-global.config.ts",
     "db:generate:custom": "drizzle-kit generate --custom --config drizzle/tasks.config.ts",
     "db:new": "node scripts/new-migration.mjs",
     "db:check": "for cfg in drizzle/tasks.config.ts drizzle/brain.config.ts drizzle/nexus.config.ts drizzle/signaldock.config.ts drizzle/telemetry.config.ts; do node_modules/.bin/drizzle-kit check --config=$cfg || exit 1; done",


### PR DESCRIPTION
## Summary
Settles the **scope-axis vs file-split ambiguity** for the Gen-7 SQLite substrate (saga **T11242**, epic **T11245 / E2**) per owner decision **D1″** (partition by **lifecycle**, not domain-cluster). Exactly two `cleo.db` files survive per machine view: project `<root>/.cleo/cleo.db` and global `$XDG_DATA_HOME/cleo/cleo.db`.

## Changes (T11358)
- **`drizzle/cleo-project.config.ts`** + **`drizzle/cleo-global.config.ts`** — dual drizzle-kit (rc.3) configs, Pattern-A single-file-per-scope, wired into `package.json` as `db:generate:cleo-project` / `db:generate:cleo-global`.
- **signaldock folded under the global `cleo.db`** (AC4 / D1) — no standalone `signaldock.db` survives.
- **`docs/migration/sqlite-schema-canonical.md` §1** — prior `66/631 + 48/550` domain-split counts **SUPERSEDED**; re-derived from the audit JSON (`sqlite-schema-columns.json`, reproducible one-liner included) against the lifecycle split:
  - **project** `cleo.db`: **87 tables / 903 columns** (tasks-core 45 + conduit 14 + docs 4 + telemetry 2 + brain 22 mirrored)
  - **global** `cleo.db`: **49 tables / 555 columns** (nexus 10 + skills 4 + signaldock 13 + brain 22 mirrored)
  - 114 distinct source tables / 1181 columns; only `brain_*` is mirrored (project-local vs cross-project memory).

## Generation boundary (the settled finding)
The consolidated configs declare per-scope **domain membership**, not a generate-ready snapshot. Source modules carry **unprefixed** physical table names that collide across domains in one file (e.g. `schema/attachments.ts` and `conduit-schema.ts` both define `attachments` → `tasks_attachments` vs `conduit_attachments`). Pattern-A domain-prefixing that resolves the collisions is applied by the **E3 exodus prefixer (T11248)**, so `drizzle-kit generate` against the `cleo-*` configs is deferred until exodus emits the prefixed schema. Target-shape authoring only — no behavior change to live DBs.

## Acceptance
- AC1 ✅ scope axis = LIFECYCLE; both files named `cleo.db` (project + global XDG)
- AC2 ✅ dual `drizzle.config.ts` (rc.3), Pattern-A single-file-per-scope
- AC3 ✅ 66/48 counts superseded; per-scope counts re-derived + recorded in §1
- AC4 ✅ signaldock folded under the global `cleo.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)