### PR TITLE
feat(T11480): CORE self-tooling — CLI/contract fixes + meta-tools (DHQ-027..036)

### DIFF
--- a/.github/workflows/arch-boundary-check.yml
+++ b/.github/workflows/arch-boundary-check.yml
@@ -213,3 +213,28 @@ jobs:
           node-version: '24'
       - name: Lint crate publish=false (zero crates.io)
         run: node scripts/lint-no-crate-publish.mjs
+
+  contract-literal-enums:
+    # Gate 13 (T11483 · DHQ-035) · Epic T11480 SG-CORE-SELF-TOOLING
+    #
+    # JSON-Schema `enum: [...]` literals in packages/contracts/src/operations/*
+    # hand-duplicate the canonical task-axis enum SSoTs (TASK_KINDS, TASK_SCOPES,
+    # TASK_SEVERITIES, TASK_SIZES, TASK_STATUSES, TaskPriority, TaskType). A typo
+    # or drifted member sails past tsc (the literal is string[]) and then
+    # detonates as a cascade of red CI gates far from the edit. This gate parses
+    # the SSoT + the contract literals from SOURCE (never dist/, so a stale dist
+    # cannot hide the drift) and FAILS when any literal enum member is not in its
+    # canonical SSoT. Run locally before pushing: node
+    # scripts/lint-contract-literal-enums.mjs
+    #
+    # Pure static analysis of checked-in TS source — no untrusted user input.
+    name: Contract Literal Enum SSoT (T11483)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Lint contract-literal enums against canonical SSoT
+        run: node scripts/lint-contract-literal-enums.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -184,14 +184,18 @@ crates/worktree-napi/worktree-napi.*.node
 packages/worktree-napi-*/worktree-napi.*.node
 
 # ── Local-only artifacts — untracked from github, kept on disk (T11392) ──
-.bg-shell/
-.tmp-dashboard-test/
-T9220/
-tasks-batch-T10400.json
-graphify-out/
-scenarios/
-tools/
-dev/
-audit/
-tmp-doc-source/
-editors/
+# Anchored to the repo ROOT (leading `/`) so these scratch-dir names do NOT
+# shadow legitimate nested package dirs (e.g. packages/contracts/src/tools,
+# packages/*/dev, packages/*/scenarios). T11484: the bare `tools/` pattern was
+# silently ignoring new files under packages/contracts/src/tools/.
+/.bg-shell/
+/.tmp-dashboard-test/
+/T9220/
+/tasks-batch-T10400.json
+/graphify-out/
+/scenarios/
+/tools/
+/dev/
+/audit/
+/tmp-doc-source/
+/editors/

--- a/packages/cleo/src/cli/__tests__/add-batch.test.ts
+++ b/packages/cleo/src/cli/__tests__/add-batch.test.ts
@@ -297,3 +297,51 @@ describe('addBatchCommand dispatch behaviour (file input)', () => {
     expect(callArgs).not.toHaveProperty('dryRun');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — per-task acceptance as a JSON array (T11482 · DHQ-036)
+//
+// validateOperationInput runs for real here (only dispatch + fs are mocked),
+// so these assert the actual INPUT_CONTRACTS['tasks.add-batch'] schema accepts
+// a per-task `acceptance` array and rejects a pipe-delimited string with the
+// x-fix-hint. This locks the "acceptance must be a JSON array" contract.
+// ---------------------------------------------------------------------------
+
+describe('addBatchCommand — per-task acceptance array (T11482)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('passes validation and dispatches when acceptance is a multi-item JSON array', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileMock.mockResolvedValue(
+      JSON.stringify([{ title: 'Multi-AC task', acceptance: ['ac1', 'ac2', 'ac3'] }]),
+    );
+    dispatchRawMock.mockResolvedValueOnce(makeSuccessEnvelope([{ id: 'T100', title: 'Multi-AC' }]));
+
+    const result = await invokeAddBatch({ file: '/tmp/tasks.json' });
+
+    expect(result.exitCode).not.toBe(6);
+    expect(dispatchRawMock).toHaveBeenCalledTimes(1);
+    const callArgs = dispatchRawMock.mock.calls[0]?.[3] as {
+      tasks: Array<{ acceptance: string[] }>;
+    };
+    expect(callArgs.tasks[0]?.acceptance).toEqual(['ac1', 'ac2', 'ac3']);
+  });
+
+  it('rejects a pipe-delimited acceptance STRING with exit 6 (acceptance must be an array)', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileMock.mockResolvedValue(
+      JSON.stringify([{ title: 'Bad AC', acceptance: 'ac1|ac2|ac3' }]),
+    );
+
+    const result = await invokeAddBatch({ file: '/tmp/tasks.json' });
+
+    expect(dispatchRawMock).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(6);
+  });
+});

--- a/packages/cleo/src/cli/__tests__/output-context.test.ts
+++ b/packages/cleo/src/cli/__tests__/output-context.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for `--output` mode resolution, including the alias table
+ * (T11482 · DHQ-033).
+ *
+ * `resolveOutputMode` is the SSoT the global flag parser in `cli/index.ts`
+ * uses to map a raw `--output <value>` argument to a canonical
+ * {@link OutputMode}. The alias table lets natural requests like
+ * `--output json` resolve to the canonical `envelope` payload instead of
+ * being rejected with exit code 2.
+ *
+ * @task T11482
+ * @epic T11480
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isOutputMode, OUTPUT_MODES, resolveOutputMode } from '../output-context.js';
+
+describe('resolveOutputMode — canonical modes', () => {
+  it('resolves every canonical mode to itself', () => {
+    for (const mode of OUTPUT_MODES) {
+      expect(resolveOutputMode(mode)).toBe(mode);
+    }
+  });
+});
+
+describe('resolveOutputMode — aliases (T11482 · DHQ-033)', () => {
+  it('resolves `json` to the canonical `envelope` payload', () => {
+    expect(resolveOutputMode('json')).toBe('envelope');
+  });
+
+  it('does not list `json` as a canonical mode (it is an alias only)', () => {
+    expect(isOutputMode('json')).toBe(false);
+    expect((OUTPUT_MODES as readonly string[]).includes('json')).toBe(false);
+  });
+});
+
+describe('resolveOutputMode — rejection', () => {
+  it('returns undefined for a value that is neither a mode nor an alias', () => {
+    expect(resolveOutputMode('bogus')).toBeUndefined();
+    expect(resolveOutputMode('')).toBeUndefined();
+    expect(resolveOutputMode('JSON')).toBeUndefined(); // case-sensitive
+  });
+});

--- a/packages/cleo/src/cli/commands/__tests__/output-mode.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/output-mode.test.ts
@@ -60,12 +60,42 @@ describe('renderOutputMode — id', () => {
 });
 
 describe('renderOutputMode — count', () => {
+  // (T10599) When a listing carries no distinct `filtered` field, `total` wins
+  // over the returned-rows length. This preserves the documented pagination
+  // contract: a page of 2 returned rows out of a 17-match read reports 17.
   it('honours explicit `total` over array length', () => {
     const out = renderOutputMode('count', {
       tasks: [{ id: 'T1' }, { id: 'T2' }],
       total: 17,
     });
     expect(out.text).toBe('17');
+  });
+
+  // (T11481 · DHQ-034) Filtered-vs-total semantic. A `tasks.list` envelope is
+  // `{tasks, total, filtered}` where `total` is the GLOBAL project task count
+  // and `filtered` is the filter-aware match count. `--output count` on a
+  // filtered listing (`list --parent X`, `list --status Y`) MUST report the
+  // FILTERED match count — not the global total.
+  it('(T11481) prefers `filtered` over the global `total` for a filtered listing', () => {
+    const out = renderOutputMode('count', {
+      tasks: [{ id: 'T1' }, { id: 'T2' }],
+      total: 2554, // global project task count
+      filtered: 19, // filter-aware match count
+    });
+    expect(out.text).toBe('19');
+  });
+
+  // (T11481 · DHQ-034) Pagination must NOT be confused with the match count.
+  // A Saga `bindingSource:'saga.groups'` page can bind `tasks.length=10` while
+  // `filtered=19`; count mode reports the match count (19), not the page size.
+  it('(T11481) prefers `filtered` over the returned-rows length under pagination', () => {
+    const out = renderOutputMode('count', {
+      tasks: Array.from({ length: 10 }, (_, i) => ({ id: `T${i}` })),
+      total: 2554,
+      filtered: 19,
+      bindingSource: 'saga.groups',
+    });
+    expect(out.text).toBe('19');
   });
 
   it('(T10599 AC1) honours minimal mutate `count` for dry-run add-batch output', () => {

--- a/packages/cleo/src/cli/index.ts
+++ b/packages/cleo/src/cli/index.ts
@@ -51,7 +51,7 @@ import { lazyCommand } from './lazy-command.js';
 import { didYouMean } from './lib/did-you-mean.js';
 import { maybePromptFirstRun } from './lib/first-run-detection.js';
 import { resolveFormat } from './middleware/output-format.js';
-import { isOutputMode, type OutputMode, setOutputMode } from './output-context.js';
+import { resolveOutputMode, setOutputMode } from './output-context.js';
 import { setProjectionOptOut } from './projection-context.js';
 import { resolveSubCommandForHelp } from './resolve-subcommand.js';
 import { setSummaryMode } from './summary-context.js';
@@ -173,8 +173,11 @@ async function startCli(): Promise<void> {
   // mode here gives the operator/agent a deterministic stderr error with a
   // valid-modes list instead of silently falling through to the default.
   if (outputModeRaw !== undefined) {
-    if (!isOutputMode(outputModeRaw)) {
-      const validModes = ['envelope', 'id', 'table', 'count', 'silent'];
+    // T11482 (DHQ-033): `--output json` resolves to the canonical `envelope`
+    // payload via resolveOutputMode's alias table rather than being rejected.
+    const resolvedMode = resolveOutputMode(outputModeRaw);
+    if (resolvedMode === undefined) {
+      const validModes = ['envelope', 'json', 'id', 'table', 'count', 'silent'];
       const suggestions = didYouMean(outputModeRaw, validModes, 3);
       process.stderr.write(
         `Error: invalid --output mode "${outputModeRaw}"\n` +
@@ -185,7 +188,7 @@ async function startCli(): Promise<void> {
       }
       process.exit(2);
     }
-    setOutputMode(outputModeRaw as OutputMode);
+    setOutputMode(resolvedMode);
   }
 
   // T9932 — 1-line-per-record summary render. See summary-context.ts for the

--- a/packages/cleo/src/cli/output-context.ts
+++ b/packages/cleo/src/cli/output-context.ts
@@ -36,6 +36,30 @@ export const OUTPUT_MODES = ['envelope', 'id', 'table', 'count', 'silent'] as co
 /** Resolved `--output` mode for the current CLI invocation. */
 export type OutputMode = (typeof OUTPUT_MODES)[number];
 
+/**
+ * Accepted `--output` aliases that resolve to a canonical {@link OutputMode}.
+ *
+ * `json` is the natural request for the canonical LAFS JSON payload — operators
+ * and agents reach for `--output json` reflexively, and rejecting it (T11482 ·
+ * DHQ-033) is a needless papercut. It resolves to the default `envelope` mode.
+ */
+const OUTPUT_MODE_ALIASES: Readonly<Record<string, OutputMode>> = {
+  json: 'envelope',
+};
+
+/**
+ * Resolve a raw `--output` value to a canonical {@link OutputMode}, honouring
+ * the {@link OUTPUT_MODE_ALIASES} table (e.g. `json` → `envelope`).
+ *
+ * @param value - The raw `--output` argument as typed on the command line.
+ * @returns The canonical mode, or `undefined` when the value is neither a
+ *          canonical mode nor a known alias.
+ */
+export function resolveOutputMode(value: string): OutputMode | undefined {
+  if (isOutputMode(value)) return value;
+  return OUTPUT_MODE_ALIASES[value];
+}
+
 /** Current mode. Defaults to `'envelope'` (the canonical LAFS payload). */
 let currentMode: OutputMode = 'envelope';
 

--- a/packages/cleo/src/cli/renderers/output-mode.ts
+++ b/packages/cleo/src/cli/renderers/output-mode.ts
@@ -72,11 +72,22 @@ function extractIds(data: unknown): string[] {
 /**
  * Pick the row count from a dispatch envelope.
  *
- * Honours explicit count fields before array lengths. `total` wins for
- * paginated read payloads; `count` is the canonical minimal mutate envelope
- * field and is especially important for dry-run mutations where the raw
- * inserted/created count can be zero while the predicted affected count is
- * non-zero.
+ * Honours explicit count fields before array lengths. The precedence below
+ * settles the filtered-listing-vs-total semantic (T11481 · DHQ-034):
+ *
+ *   1. `filtered` — the filter-aware match count of a `tasks.list` envelope
+ *      (`{tasks, total, filtered}`). For a filtered listing
+ *      (`list --parent X`, `list --status Y`) this is the count the operator
+ *      asked about — NOT the global `total` (every task in the project) and
+ *      NOT the returned-rows length (which differs from the match count under
+ *      pagination, e.g. a Saga `bindingSource:'saga.groups'` page binding
+ *      `tasks.length=10` while `filtered=19`).
+ *   2. `total` — paginated read payloads that carry no distinct `filtered`
+ *      field. Preserves the documented total-first behaviour (T10599) where
+ *      there is no filter dimension.
+ *   3. `count` — the canonical minimal mutate envelope field, especially for
+ *      dry-run mutations where the raw inserted/created count can be zero while
+ *      the predicted affected count is non-zero.
  *
  * @returns `0` when the data shape carries neither a counted collection
  *          nor a recognisable count field.
@@ -84,6 +95,11 @@ function extractIds(data: unknown): string[] {
 function extractCount(data: unknown): number {
   if (data === null || typeof data !== 'object') return 0;
   const rec = data as Record<string, unknown>;
+
+  // 1. Filter-aware match count of a `tasks.list` envelope. Wins over `total`
+  // so a filtered listing reports the number of MATCHES, not the global total.
+  const filtered = rec['filtered'];
+  if (typeof filtered === 'number' && Number.isFinite(filtered)) return filtered;
 
   const total = rec['total'];
   if (typeof total === 'number' && Number.isFinite(total)) return total;

--- a/packages/cleo/src/dispatch/middleware/mutate-minimal-envelope.ts
+++ b/packages/cleo/src/dispatch/middleware/mutate-minimal-envelope.ts
@@ -48,6 +48,9 @@ type MutationBucket = 'created' | 'updated' | 'deleted';
 const OPERATION_BUCKETS: Readonly<Record<string, MutationBucket>> = {
   'tasks.add': 'created',
   'tasks.add-batch': 'created',
+  // T11482 (DHQ-036): saga.create now projects the created saga ID into the
+  // `created` bucket so `--field /data/created/0` resolves a parseable saga ID.
+  'tasks.saga.create': 'created',
   'tasks.update': 'updated',
   'tasks.complete': 'updated',
   'tasks.delete': 'deleted',

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -18,6 +18,10 @@
       "types": "./dist/tools/atomic.d.ts",
       "import": "./dist/tools/atomic.js"
     },
+    "./tools/composite": {
+      "types": "./dist/tools/composite.d.ts",
+      "import": "./dist/tools/composite.js"
+    },
     "./gateway.js": {
       "types": "./dist/gateway.d.ts",
       "import": "./dist/gateway.js"

--- a/packages/contracts/src/tools/__tests__/composite.test.ts
+++ b/packages/contracts/src/tools/__tests__/composite.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Contract-shape tests for the composite meta-tool contracts (T11484).
+ *
+ * The RUNTIME for `module-relocation` / `add-workspace-package` is deferred to
+ * epic T11456 (the TOOLS canonical structure that supplies their correct home,
+ * category enum, descriptor schema, and registry — see composite.ts header).
+ * These tests lock the CONTRACT surface that ships now: the breakage-class and
+ * wiring-point SoT arrays, and that the input/result shapes are constructible.
+ *
+ * @epic T11480
+ * @task T11484
+ */
+
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  ADD_WORKSPACE_PACKAGE_WIRING_POINTS,
+  type AddWorkspacePackageInput,
+  type AddWorkspacePackageResult,
+  MODULE_RELOCATION_BREAKAGE_CLASSES,
+  type ModuleRelocationInput,
+  type ModuleRelocationResult,
+} from '../composite.js';
+
+describe('module-relocation contract (DHQ-032)', () => {
+  it('enumerates exactly the seven breakage classes', () => {
+    expect([...MODULE_RELOCATION_BREAKAGE_CLASSES]).toEqual([
+      'relative-import-depth',
+      'barrels',
+      'js-form-and-dynamic-import',
+      'mirror-test-dirs',
+      'deprecations-yml',
+      'doc-comments',
+      'cross-package-importers',
+    ]);
+    expect(new Set(MODULE_RELOCATION_BREAKAGE_CLASSES).size).toBe(7);
+  });
+
+  it('has a constructible input + result shape', () => {
+    const input: ModuleRelocationInput = {
+      fromPath: 'packages/core/src/a.ts',
+      toPath: 'packages/core/src/sub/a.ts',
+      repoRoot: '/repo',
+    };
+    expect(input.fromPath).toBe('packages/core/src/a.ts');
+
+    const result: ModuleRelocationResult = {
+      toPath: input.toPath,
+      shimLeft: false,
+      dryRun: true,
+      classes: [{ class: 'barrels', files: ['packages/core/src/index.ts'], edits: 1 }],
+      filesTouched: ['packages/core/src/index.ts'],
+    };
+    expect(result.classes[0]?.class).toBe('barrels');
+    expectTypeOf(result.classes).items.toHaveProperty('class');
+  });
+});
+
+describe('add-workspace-package contract (DHQ-027)', () => {
+  it('enumerates exactly the six wiring points', () => {
+    expect([...ADD_WORKSPACE_PACKAGE_WIRING_POINTS]).toEqual([
+      'deps',
+      'tsconfig-refs',
+      'build-mjs-buildpkg',
+      'inline-maps',
+      'boundary-entry',
+      'private-no-readme',
+    ]);
+    expect(new Set(ADD_WORKSPACE_PACKAGE_WIRING_POINTS).size).toBe(6);
+  });
+
+  it('has a constructible input + result shape', () => {
+    const input: AddWorkspacePackageInput = {
+      packageName: '@cleocode/foo',
+      repoRoot: '/repo',
+      consumers: ['@cleocode/core'],
+    };
+    expect(input.packageName).toBe('@cleocode/foo');
+
+    const result: AddWorkspacePackageResult = {
+      packageName: input.packageName,
+      packageDir: 'packages/foo',
+      dryRun: true,
+      points: [{ point: 'deps', files: ['packages/core/package.json'] }],
+    };
+    expect(result.points[0]?.point).toBe('deps');
+    expectTypeOf(result.points).items.toHaveProperty('point');
+  });
+});

--- a/packages/contracts/src/tools/composite.ts
+++ b/packages/contracts/src/tools/composite.ts
@@ -1,0 +1,173 @@
+/**
+ * Composite meta-tool contracts — typed I/O shapes for repo-structure
+ * velocity-multiplier tools (T11484 · DHQ-027/032 · E-CORE-SELF-TOOLING).
+ *
+ * A **composite tool** COMPOSES atomic primitives (`@cleocode/contracts/tools/
+ * atomic` — fs/shell/search) plus repo-structure knowledge into one guarded,
+ * deterministic, multi-step operation that runs WITHOUT an LLM and returns a
+ * typed result. Per the TOOL-vs-SKILL discriminator (T11456 epic), that makes
+ * these TOOLs (typed return, no agent reasoning), NOT skills (`packages/skills`
+ * markdown capabilities).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * PLACEMENT STATUS (read before implementing the runtime)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * These are the CONTRACTS ONLY. The runtime implementations are intentionally
+ * DEFERRED to epic **T11456** (TOOLS canonical structure), because a composite
+ * tool cannot be CORRECTLY placed/named/registered until T11456 lands:
+ *
+ *   - The atomic-tool boundary (`ATOMIC_TOOL_BOUNDARY` in `boundary.ts`, CI
+ *     Gate 11) restricts `packages/core/src/tools/` to ATOMIC, STATELESS
+ *     primitives (the 5 `TOOL_CLASSES`: fs/shell/search/net/notebook). These
+ *     composites are multi-step and repo-structure-aware — NOT atomic primitives
+ *     — so that home is wrong for them.
+ *   - `packages/skills/` (the boundary's `skillsHome`) holds agent-facing
+ *     SKILL.md markdown, not executable TS — also wrong.
+ *   - T11456 defines the missing structure these tools NEED: a closed
+ *     `ToolCategory` enum (it reserves `vcs`/`workflow`/`agent` — the categories
+ *     these compose), strict `<scope>_<category>_<operation>` naming, a
+ *     `ToolDescriptor` zod schema, and a `ToolRegistry` with project>global>core
+ *     precedence. Authoring the runtime + a category BEFORE that epic would
+ *     force a placement T11456 must then rework.
+ *
+ * Shipping the contracts now is the sound, additive, non-blocked unit: it pins
+ * the I/O shape (and enumerates every breakage/wiring class each tool owns) so
+ * the T11456 registry has a stable surface to register against. Types-only — no
+ * runtime logic (CI Gate 10 `contracts-purity`).
+ *
+ * @epic T11480
+ * @task T11484
+ * @see T11456 — TOOLS canonical structure (runtime home + registry + naming)
+ */
+
+// ---------------------------------------------------------------------------
+// module-relocation (DHQ-032)
+// ---------------------------------------------------------------------------
+
+/**
+ * The seven breakage classes a module relocation MUST repair atomically. A
+ * naive `git mv` fixes none of these; leaving any one unrepaired is a red build.
+ * The runtime asserts each class is handled and reports per-class edit counts.
+ */
+export const MODULE_RELOCATION_BREAKAGE_CLASSES = [
+  /** Relative-import depth (`../` vs `../../`) of the moved file's own imports. */
+  'relative-import-depth',
+  /** Barrel (`index.ts`) re-exports that referenced the old path. */
+  'barrels',
+  /** `.js`-suffixed specifiers AND dynamic `import()` specifiers. */
+  'js-form-and-dynamic-import',
+  /** The mirrored `__tests__/` directory for the moved module. */
+  'mirror-test-dirs',
+  /** `deprecations.yml` entries that pointed at the old path. */
+  'deprecations-yml',
+  /** Doc comments / `@see` / `@module` references to the old path. */
+  'doc-comments',
+  /** Cross-package importers that consumed the module via its package path. */
+  'cross-package-importers',
+] as const;
+
+/** One of the {@link MODULE_RELOCATION_BREAKAGE_CLASSES}. */
+export type ModuleRelocationBreakageClass = (typeof MODULE_RELOCATION_BREAKAGE_CLASSES)[number];
+
+/** Input for the `module-relocation` composite tool. */
+export interface ModuleRelocationInput {
+  /** Absolute (or repo-root-relative) path of the module to move. */
+  readonly fromPath: string;
+  /** Destination path for the module. */
+  readonly toPath: string;
+  /** Repository root the operation is scoped to. */
+  readonly repoRoot: string;
+  /**
+   * Leave a re-export shim at {@link ModuleRelocationInput.fromPath} that
+   * re-exports from the new location (for a deprecation cycle) instead of
+   * rewriting every importer. Defaults to `false` (rewrite importers).
+   */
+  readonly leaveShim?: boolean;
+  /** Preview the edit plan without writing. Defaults to `false`. */
+  readonly dryRun?: boolean;
+}
+
+/** Per-class summary of the edits a relocation made (or would make). */
+export interface ModuleRelocationClassReport {
+  /** Which breakage class this entry summarises. */
+  readonly class: ModuleRelocationBreakageClass;
+  /** Repo-relative files edited for this class. */
+  readonly files: readonly string[];
+  /** Total number of edits applied across {@link ModuleRelocationClassReport.files}. */
+  readonly edits: number;
+}
+
+/** Result of a `module-relocation` run. */
+export interface ModuleRelocationResult {
+  /** The module's new path. */
+  readonly toPath: string;
+  /** Whether a re-export shim was left at the old path. */
+  readonly shimLeft: boolean;
+  /** Whether this was a dry-run (no writes performed). */
+  readonly dryRun: boolean;
+  /** Per-breakage-class edit report (one entry per class, even when empty). */
+  readonly classes: readonly ModuleRelocationClassReport[];
+  /** Total repo-relative files touched across every class. */
+  readonly filesTouched: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// add-workspace-package (DHQ-027)
+// ---------------------------------------------------------------------------
+
+/**
+ * The six wiring points a new workspace leaf MUST be threaded through. Missing
+ * any one yields a package that does not build, is not type-resolved, or is
+ * accidentally published. The runtime wires all six and reports each.
+ */
+export const ADD_WORKSPACE_PACKAGE_WIRING_POINTS = [
+  /** `dependencies` / `devDependencies` of consuming packages. */
+  'deps',
+  /** The three `tsconfig` references: root refs, build tsconfig, path mapping. */
+  'tsconfig-refs',
+  /** The `buildPkg(...)` entry in the root `build.mjs` topological wave plan. */
+  'build-mjs-buildpkg',
+  /** esbuild/tsc inline source-map wiring for the new leaf. */
+  'inline-maps',
+  /** The `BOUNDARY_REGISTRY` entry in `packages/contracts/src/boundary.ts`. */
+  'boundary-entry',
+  /** `private: true` + no published README (internal-leaf publish hygiene). */
+  'private-no-readme',
+] as const;
+
+/** One of the {@link ADD_WORKSPACE_PACKAGE_WIRING_POINTS}. */
+export type AddWorkspacePackageWiringPoint = (typeof ADD_WORKSPACE_PACKAGE_WIRING_POINTS)[number];
+
+/** Input for the `add-workspace-package` composite tool. */
+export interface AddWorkspacePackageInput {
+  /** Scoped package name, e.g. `@cleocode/foo`. */
+  readonly packageName: string;
+  /** Directory under `packages/` to create (defaults to the unscoped name). */
+  readonly dirName?: string;
+  /** Repository root the operation is scoped to. */
+  readonly repoRoot: string;
+  /** Packages that should depend on the new leaf (wires the `deps` point). */
+  readonly consumers?: readonly string[];
+  /** Preview the wiring plan without writing. Defaults to `false`. */
+  readonly dryRun?: boolean;
+}
+
+/** Per-point summary of how a wiring point was satisfied. */
+export interface AddWorkspacePackageWiringReport {
+  /** Which wiring point this entry summarises. */
+  readonly point: AddWorkspacePackageWiringPoint;
+  /** Repo-relative files created or edited for this point. */
+  readonly files: readonly string[];
+}
+
+/** Result of an `add-workspace-package` run. */
+export interface AddWorkspacePackageResult {
+  /** The created package's name. */
+  readonly packageName: string;
+  /** Repo-relative directory of the new leaf. */
+  readonly packageDir: string;
+  /** Whether this was a dry-run (no writes performed). */
+  readonly dryRun: boolean;
+  /** Per-wiring-point report (one entry per point, even when empty). */
+  readonly points: readonly AddWorkspacePackageWiringReport[];
+}

--- a/packages/core/src/dispatch/__tests__/mutate-projection.test.ts
+++ b/packages/core/src/dispatch/__tests__/mutate-projection.test.ts
@@ -399,6 +399,61 @@ describe('applyMutateProjection — tasks.delete', () => {
   });
 });
 
+describe('applyMutateProjection — tasks.saga.create (T11482 · DHQ-036)', () => {
+  it('declares a projection plan so saga.create surfaces a created ID', () => {
+    expect(MUTATE_PROJECTION_PLANS['tasks.saga.create']).toBeDefined();
+  });
+
+  it('projects the created saga ID into the `created` bucket', () => {
+    // saga.create returns `{task: TaskRecord, duplicate, ...}` — see
+    // core/sagas/create.ts. Without this plan `/data/created/0` was
+    // unresolvable, so `cleo saga create` surfaced no parseable saga ID.
+    const data = {
+      task: { ...FULL_TASK, id: 'T11480', type: 'saga', status: 'pending' },
+      duplicate: false,
+    };
+    const out = applyMutateProjection(data, 'tasks.saga.create', 'mvi') as Record<string, unknown>;
+    expect(out['count']).toBe(1);
+    expect(out['created']).toEqual(['T11480']);
+    expect(out['updated']).toEqual([]);
+    expect(out['deleted']).toEqual([]);
+    expect(out['ids']).toEqual(['T11480']);
+    expect(out['status']).toBe('pending');
+  });
+
+  it('projects the dry-run placeholder id and stamps dryRun metadata', () => {
+    // Dry-run synthesises a placeholder task id ("T???"), consistent with the
+    // tasks.add dry-run path. The projection surfaces that placeholder under
+    // `created` and stamps the dry-run summary fields so `--field` consumers
+    // and the count renderer behave identically to a live create.
+    const data = {
+      task: { id: 'T???', type: 'saga' },
+      duplicate: false,
+      dryRun: true,
+      wouldCreate: 1,
+      wouldAffect: 1,
+      validatedCount: 1,
+      insertedCount: 0,
+    };
+    const out = applyMutateProjection(data, 'tasks.saga.create', 'mvi') as Record<string, unknown>;
+    expect(out['count']).toBe(1);
+    expect(out['created']).toEqual(['T???']);
+    expect(out['dryRun']).toBe(true);
+    expect(out['wouldCreate']).toBe(1);
+    expect(out['insertedCount']).toBe(0);
+  });
+
+  it('surfaces the duplicate flag when the saga already exists', () => {
+    const data = {
+      task: { ...FULL_TASK, id: 'T11480', type: 'saga' },
+      duplicate: true,
+    };
+    const out = applyMutateProjection(data, 'tasks.saga.create', 'mvi') as Record<string, unknown>;
+    expect(out['created']).toEqual(['T11480']);
+    expect(out['duplicate']).toBe(true);
+  });
+});
+
 describe('applyMutateProjection — unknown ops + edge cases', () => {
   it('returns data unchanged when the op has no plan', () => {
     const data = { task: FULL_TASK };

--- a/packages/core/src/dispatch/mutate-projection.ts
+++ b/packages/core/src/dispatch/mutate-projection.ts
@@ -239,6 +239,36 @@ export const MUTATE_PROJECTION_PLANS: Readonly<Record<string, MutateProjectionPl
       return envelope;
     },
   },
+  'tasks.saga.create': {
+    operation: 'tasks.saga.create',
+    extract: (data) => {
+      // saga.create returns `{task: TaskRecord, duplicate, dryRun?, ...}` (see
+      // core/sagas/create.ts). Without a plan the full record flowed through and
+      // `/data/created/0` was unresolvable, so `cleo saga create` surfaced no
+      // parseable saga ID (T11482 · DHQ-036). Project the created saga ID into
+      // the standard `created` bucket exactly like `tasks.add`.
+      const task = data['task'];
+      const createdIds = readTaskIdsFromBucket(data, 'created');
+      const id = readTaskId(task) ?? createdIds[0];
+      const status =
+        task && typeof task === 'object' ? (task as Record<string, unknown>)['status'] : undefined;
+      const envelope = makeEnvelope('created', id ? [id] : []);
+      if (typeof status === 'string') envelope['status'] = status;
+      if (data['duplicate'] === true) envelope['duplicate'] = true;
+      if (data['dryRun'] === true) {
+        envelope['dryRun'] = true;
+        const wouldCreate = data['wouldCreate'];
+        if (typeof wouldCreate === 'number') envelope['wouldCreate'] = wouldCreate;
+        const wouldAffect = data['wouldAffect'];
+        if (typeof wouldAffect === 'number') envelope['wouldAffect'] = wouldAffect;
+        const validatedCount = data['validatedCount'];
+        if (typeof validatedCount === 'number') envelope['validatedCount'] = validatedCount;
+        const insertedCount = data['insertedCount'];
+        envelope['insertedCount'] = typeof insertedCount === 'number' ? insertedCount : 0;
+      }
+      return envelope;
+    },
+  },
   'tasks.update': {
     operation: 'tasks.update',
     extract: (data) => {

--- a/scripts/__tests__/lint-contract-literal-enums.test.mjs
+++ b/scripts/__tests__/lint-contract-literal-enums.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * Poison tests for scripts/lint-contract-literal-enums.mjs (T11483 · DHQ-035).
+ *
+ * Strategy: write a synthetic mini-tree under a tmpdir that mirrors the real
+ * SSoT + contract-literal layout (enums.ts, status-registry.ts, task.ts,
+ * operations/tasks.ts), point the script at it with `--root <tmp>`, and assert
+ * exit code + JSON report for clean vs drifted enums. This proves a bad enum is
+ * caught LOCALLY without touching the real contracts tree — and, because the
+ * checker reads SOURCE, that a stale `dist/` cannot hide the drift.
+ *
+ * @task T11483
+ * @epic T11480
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+const REPO_ROOT = resolve(__dirname, '../..');
+const SCRIPT = join(REPO_ROOT, 'scripts/lint-contract-literal-enums.mjs');
+
+/** @type {string} */
+let tmpRoot;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-enum-lint-'));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/**
+ * Materialise the SSoT source files the validator parses for canonical members.
+ */
+function writeSsotFiles() {
+  const contractsSrc = join(tmpRoot, 'packages/contracts/src');
+  mkdirSync(join(contractsSrc, 'operations'), { recursive: true });
+  writeFileSync(
+    join(contractsSrc, 'enums.ts'),
+    [
+      "export const TASK_KINDS = ['work', 'research', 'experiment', 'bug', 'spike', 'release'] as const;",
+      "export const TASK_SCOPES = ['project', 'feature', 'unit'] as const;",
+      "export const TASK_SEVERITIES = ['P0', 'P1', 'P2', 'P3'] as const;",
+      "export const TASK_SIZES = ['small', 'medium', 'large'] as const;",
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(
+    join(contractsSrc, 'status-registry.ts'),
+    "export const TASK_STATUSES = ['pending', 'active', 'blocked', 'done', 'cancelled', 'archived', 'proposed'] as const;\n",
+  );
+  writeFileSync(
+    join(contractsSrc, 'task.ts'),
+    [
+      "export type TaskPriority = 'critical' | 'high' | 'medium' | 'low';",
+      "export type TaskType = 'saga' | 'epic' | 'task' | 'subtask';",
+      '',
+    ].join('\n'),
+  );
+}
+
+/**
+ * Write the contract-literal file the validator scans for enum literals.
+ *
+ * @param {string} body Source body of operations/tasks.ts.
+ */
+function writeContractFile(body) {
+  writeFileSync(join(tmpRoot, 'packages/contracts/src/operations/tasks.ts'), body);
+}
+
+/** Run the validator with `--root <tmp> --json`. */
+function runLint(extraArgs = []) {
+  return spawnSync('node', [SCRIPT, '--root', tmpRoot, '--json', ...extraArgs], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: REPO_ROOT,
+  });
+}
+
+describe('lint-contract-literal-enums — clean tree', () => {
+  it('passes (exit 0) when every contract-literal enum is in its SSoT', () => {
+    writeSsotFiles();
+    writeContractFile(
+      [
+        'export const SCHEMA = {',
+        "  priority: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },",
+        "  type: { type: 'string', enum: ['saga', 'epic', 'task', 'subtask'] },",
+        "  kind: { type: 'string', enum: ['work', 'research', 'experiment', 'bug', 'spike', 'release'] },",
+        "  severity: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3'] },",
+        '};',
+        '',
+      ].join('\n'),
+    );
+    const r = runLint();
+    expect(r.status).toBe(0);
+    const report = JSON.parse(r.stdout);
+    expect(report.ok).toBe(true);
+    expect(report.violations).toEqual([]);
+  });
+
+  it('allows a deliberate SUBSET enum (status without archived/proposed)', () => {
+    writeSsotFiles();
+    // tasks.update legitimately omits archived/proposed — subset is OK.
+    writeContractFile(
+      "export const S = { status: { type: 'string', enum: ['pending', 'active', 'blocked', 'done', 'cancelled'] } };\n",
+    );
+    const r = runLint();
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).ok).toBe(true);
+  });
+});
+
+describe('lint-contract-literal-enums — drift detection', () => {
+  it('FAILS (exit 1) on a typo enum member (criticl)', () => {
+    writeSsotFiles();
+    writeContractFile(
+      "export const S = { priority: { type: 'string', enum: ['low', 'medium', 'high', 'criticl'] } };\n",
+    );
+    const r = runLint();
+    expect(r.status).toBe(1);
+    const report = JSON.parse(r.stdout);
+    expect(report.ok).toBe(false);
+    expect(report.violations).toHaveLength(1);
+    expect(report.violations[0]).toMatchObject({ axis: 'priority', value: 'criticl' });
+  });
+
+  it('FAILS on an out-of-range severity member (P4)', () => {
+    writeSsotFiles();
+    writeContractFile(
+      "export const S = { severity: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3', 'P4'] } };\n",
+    );
+    const r = runLint();
+    expect(r.status).toBe(1);
+    const v = JSON.parse(r.stdout).violations;
+    expect(v.some((x) => x.axis === 'severity' && x.value === 'P4')).toBe(true);
+  });
+
+  it('FAILS on a misspelled kind member and names the canonical SSoT', () => {
+    writeSsotFiles();
+    writeContractFile(
+      "export const S = { kind: { type: 'string', enum: ['work', 'reserch'] } };\n",
+    );
+    const r = runLint();
+    expect(r.status).toBe(1);
+    const v = JSON.parse(r.stdout).violations[0];
+    expect(v).toMatchObject({ axis: 'kind', value: 'reserch', ssot: 'TASK_KINDS' });
+    expect(v.canonical).toContain('research');
+  });
+});

--- a/scripts/lint-contract-literal-enums.mjs
+++ b/scripts/lint-contract-literal-enums.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * Lint rule: contract-literal enum SSoT pre-gate (T11483 · DHQ-035).
+ *
+ * JSON-Schema `enum: [...]` literals authored inside the input-contract
+ * documents in `packages/contracts/src/operations/*.ts` HAND-DUPLICATE the
+ * canonical task-axis enum SSoTs (`TASK_KINDS`, `TASK_SCOPES`,
+ * `TASK_SEVERITIES`, `TASK_SIZES`, `TASK_STATUSES`, `TaskPriority`, `TaskType`).
+ * A single typo or drifted member in one of those literals (`'criticl'`,
+ * `'P4'`, a dropped `'spike'`) sails past `tsc` — JSON-Schema literals are
+ * `string[]`, not the canonical union — and then detonates as a CASCADE of red
+ * CI gates (envelope-compliance, registry-parity, dispatch round-trips) far
+ * from the edit. This validator catches the bad enum LOCALLY, at the source,
+ * BEFORE it reaches CI.
+ *
+ * Why this also closes the stale-`dist/` false-pass class: the checker parses
+ * the canonical SSoT and the contract literals straight from `*.ts` SOURCE — it
+ * never reads `dist/`. So `rm -rf dist` (or a stale `dist/` that still type-
+ * checks against old declarations) cannot hide a freshly-introduced bad enum.
+ *
+ * Rule: every JSON-Schema `enum: [...]` literal attached to a recognised
+ * task-axis field name MUST be a SUBSET of that field's canonical enum SSoT.
+ * (Subset — not equality — because some operations deliberately expose a
+ * partial enum, e.g. `tasks.update` omits `'archived'`/`'proposed'` from
+ * `status`. Any value NOT in the canonical set is a typo/drift and fails.)
+ *
+ * Modes:
+ *   --check (default)  FAIL on any out-of-SSoT enum member.
+ *   --strict           alias for --check (kept for arch-gate symmetry).
+ *   --json             machine-readable report on stdout.
+ *   --root <dir>       point the scanner at a synthetic tree (unit tests).
+ *
+ * Exit 0 = clean; exit 1 = at least one out-of-SSoT enum member.
+ *
+ * @task T11483
+ * @epic T11480
+ * @saga T11387
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Recognised task-axis field names mapped to the SSoT that backs each one.
+ *
+ * `kind` declares the SSoT identifier so violation messages can point the
+ * author straight at the canonical definition to fix the drift.
+ *
+ * @typedef {object} AxisSsot
+ * @property {'const-array' | 'union'} kind   How the SSoT is declared in source.
+ * @property {string} file                    Repo-relative source file.
+ * @property {string} symbol                  `const`/`type` identifier in `file`.
+ */
+
+/** @type {Readonly<Record<string, AxisSsot>>} */
+const AXIS_SSOTS = {
+  kind: { kind: 'const-array', file: 'packages/contracts/src/enums.ts', symbol: 'TASK_KINDS' },
+  scope: { kind: 'const-array', file: 'packages/contracts/src/enums.ts', symbol: 'TASK_SCOPES' },
+  severity: {
+    kind: 'const-array',
+    file: 'packages/contracts/src/enums.ts',
+    symbol: 'TASK_SEVERITIES',
+  },
+  size: { kind: 'const-array', file: 'packages/contracts/src/enums.ts', symbol: 'TASK_SIZES' },
+  status: {
+    kind: 'const-array',
+    file: 'packages/contracts/src/status-registry.ts',
+    symbol: 'TASK_STATUSES',
+  },
+  priority: { kind: 'union', file: 'packages/contracts/src/task.ts', symbol: 'TaskPriority' },
+  type: { kind: 'union', file: 'packages/contracts/src/task.ts', symbol: 'TaskType' },
+};
+
+/** Contract-literal source files scanned for JSON-Schema `enum` literals. */
+const CONTRACT_LITERAL_FILES = ['packages/contracts/src/operations/tasks.ts'];
+
+/**
+ * Extract the string members of an `export const NAME = [ ... ] as const`
+ * array from a source file.
+ *
+ * @param {string} src    File contents.
+ * @param {string} symbol The const identifier.
+ * @returns {string[] | null} Ordered members, or `null` when not found.
+ */
+function parseConstArray(src, symbol) {
+  const re = new RegExp(`export const ${symbol}\\s*=\\s*\\[([\\s\\S]*?)\\]\\s*as const`, 'm');
+  const m = re.exec(src);
+  if (!m) return null;
+  return extractStringLiterals(m[1]);
+}
+
+/**
+ * Extract the string members of an `export type NAME = 'a' | 'b' | ...` union.
+ *
+ * @param {string} src    File contents.
+ * @param {string} symbol The type identifier.
+ * @returns {string[] | null} Ordered members, or `null` when not found.
+ */
+function parseUnion(src, symbol) {
+  const re = new RegExp(`export type ${symbol}\\s*=\\s*([^;]+);`, 'm');
+  const m = re.exec(src);
+  if (!m) return null;
+  return extractStringLiterals(m[1]);
+}
+
+/**
+ * Pull every single- or double-quoted string literal out of a text span.
+ *
+ * @param {string} span
+ * @returns {string[]}
+ */
+function extractStringLiterals(span) {
+  const out = [];
+  for (const m of span.matchAll(/'([^']*)'|"([^"]*)"/g)) {
+    out.push(m[1] ?? m[2]);
+  }
+  return out;
+}
+
+/**
+ * Load the canonical member set for every axis from its SSoT source.
+ *
+ * @param {string} root Repo root.
+ * @returns {Record<string, Set<string>>} axis → canonical members.
+ */
+function loadCanonicalSets(root) {
+  /** @type {Record<string, Set<string>>} */
+  const sets = {};
+  /** @type {Record<string, string>} */
+  const cache = {};
+  for (const [axis, ssot] of Object.entries(AXIS_SSOTS)) {
+    const abs = join(root, ssot.file);
+    if (!existsSync(abs)) {
+      throw new Error(`SSoT source missing for axis "${axis}": ${ssot.file}`);
+    }
+    if (cache[abs] === undefined) cache[abs] = readFileSync(abs, 'utf8');
+    const src = cache[abs];
+    const members =
+      ssot.kind === 'const-array'
+        ? parseConstArray(src, ssot.symbol)
+        : parseUnion(src, ssot.symbol);
+    if (!members || members.length === 0) {
+      throw new Error(`Could not parse SSoT ${ssot.symbol} in ${ssot.file} for axis "${axis}".`);
+    }
+    sets[axis] = new Set(members);
+  }
+  return sets;
+}
+
+/**
+ * A single out-of-SSoT enum member found in a contract literal.
+ *
+ * @typedef {object} EnumViolation
+ * @property {string} file    Repo-relative contract-literal file.
+ * @property {number} line    1-based line number of the enum literal.
+ * @property {string} axis    Recognised field name (kind/scope/...).
+ * @property {string} value   The drifted member.
+ * @property {string[]} canonical Sorted canonical members for the hint.
+ * @property {string} ssot    Canonical SSoT identifier to fix.
+ */
+
+/**
+ * Scan one contract-literal file for `<axis>: { ... enum: [ ... ] }` literals
+ * and return every member that is NOT in the axis's canonical set.
+ *
+ * @param {string} src   File contents.
+ * @param {string} rel   Repo-relative path (for reporting).
+ * @param {Record<string, Set<string>>} canonical axis → canonical members.
+ * @returns {EnumViolation[]}
+ */
+function scanContractFile(src, rel, canonical) {
+  /** @type {EnumViolation[]} */
+  const violations = [];
+  // Match `<field>: { ...enum: [ ... ] }` where <field> is a recognised axis.
+  // The property may carry a `type: 'string'` before `enum`; allow any chars up
+  // to the `enum:` token within the same object literal (no nested `}`).
+  const axisNames = Object.keys(canonical).join('|');
+  const re = new RegExp(`\\b(${axisNames})\\s*:\\s*\\{[^{}]*?\\benum\\s*:\\s*\\[([^\\]]*)\\]`, 'g');
+  for (const m of src.matchAll(re)) {
+    const axis = m[1];
+    const members = extractStringLiterals(m[2]);
+    const canonSet = canonical[axis];
+    const line = src.slice(0, m.index).split('\n').length;
+    for (const value of members) {
+      if (!canonSet.has(value)) {
+        violations.push({
+          file: rel,
+          line,
+          axis,
+          value,
+          canonical: [...canonSet].sort(),
+          ssot: AXIS_SSOTS[axis].symbol,
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+/**
+ * Run the full scan over the configured contract-literal files.
+ *
+ * @param {string} root Repo root.
+ * @returns {EnumViolation[]}
+ */
+export function scanContractLiteralEnums(root) {
+  const canonical = loadCanonicalSets(root);
+  /** @type {EnumViolation[]} */
+  const all = [];
+  for (const rel of CONTRACT_LITERAL_FILES) {
+    const abs = join(root, rel);
+    if (!existsSync(abs)) continue;
+    all.push(...scanContractFile(readFileSync(abs, 'utf8'), rel, canonical));
+  }
+  return all;
+}
+
+/** CLI entry. */
+function main() {
+  const argv = process.argv.slice(2);
+  const rootIdx = argv.indexOf('--root');
+  const root = rootIdx >= 0 && argv[rootIdx + 1] ? argv[rootIdx + 1] : process.cwd();
+  const asJson = argv.includes('--json');
+
+  let violations;
+  try {
+    violations = scanContractLiteralEnums(root);
+  } catch (err) {
+    console.error(`✗ lint-contract-literal-enums: ${err instanceof Error ? err.message : err}`);
+    return 1;
+  }
+
+  if (asJson) {
+    console.log(JSON.stringify({ ok: violations.length === 0, violations }, null, 2));
+    return violations.length === 0 ? 0 : 1;
+  }
+
+  if (violations.length === 0) {
+    console.log('✓ lint-contract-literal-enums: every contract-literal enum is in its SSoT.');
+    return 0;
+  }
+
+  console.error(
+    `\n✗ lint-contract-literal-enums: ${violations.length} out-of-SSoT enum member(s) in contract literals:\n`,
+  );
+  for (const v of violations) {
+    console.error(
+      `  - ${v.file}:${v.line} — field "${v.axis}" enum has "${v.value}", ` +
+        `not in ${v.ssot} {${v.canonical.join(', ')}}`,
+    );
+  }
+  console.error(
+    '\nFix the typo, or — if this is a genuine new member — add it to the canonical SSoT ' +
+      'FIRST, then mirror it in the contract literal. Contract-literal enums must be a subset ' +
+      'of the canonical enum SSoT.\n',
+  );
+  return 1;
+}
+
+if (process.argv[1]?.endsWith('lint-contract-literal-enums.mjs')) {
+  process.exit(main());
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -112,6 +112,17 @@ export default defineConfig({
         './packages/contracts/src/operations/docs.ts',
         import.meta.url,
       ).pathname,
+      // T11403 / T11484: atomic + composite tool contracts are subpath exports.
+      // Aliased to source so vitest resolves the runtime `as const` arrays
+      // (TOOL_CLASSES, MODULE_RELOCATION_BREAKAGE_CLASSES, …) without a build.
+      '@cleocode/contracts/tools/atomic': new URL(
+        './packages/contracts/src/tools/atomic.ts',
+        import.meta.url,
+      ).pathname,
+      '@cleocode/contracts/tools/composite': new URL(
+        './packages/contracts/src/tools/composite.ts',
+        import.meta.url,
+      ).pathname,
       '@cleocode/contracts': new URL('./packages/contracts/src/index.ts', import.meta.url).pathname,
       '@cleocode/core/internal': new URL('./packages/core/src/internal.ts', import.meta.url).pathname,
       // @cleocode/paths — workspace-local canonical path utilities (env-paths wrapper).


### PR DESCRIPTION
Epic **T11480 (SG-CORE-SELF-TOOLING)** — CLI/contract bug-fixes + meta-tool contracts surfaced by the dogfood ledger (DHQ-027..036). Four independent children, each its own commit.

## T11481 (DHQ-034) — `list --output count` returns the filter-aware count — DONE
`extractCount()` in `output-mode.ts` returned `total` first, so `cleo list --parent X --output count` emitted the GLOBAL project task total (e.g. 2554) instead of the filter match count. Settled the semantic: `filtered` (the `tasks.list` envelope's filter-aware match count) now wins over `total`; `total` still wins where there is no `filtered` field (preserves the documented T10599 pagination contract). Also fixes the Saga `saga.groups` pagination case (page binds `tasks.length=10` while `filtered=19` → reports 19).
- Regression: `packages/cleo/src/cli/commands/__tests__/output-mode.test.ts` (+3 cases, annotated T10599 vs T11481 semantic).

## T11482 (DHQ-036/033) — saga-create ID + `--output json` — DONE
1. `cleo saga create` had no mutate-projection plan, so the full `{task:{…}}` record flowed through and `--field /data/created/0` was unresolvable (T11480 itself was created with no id). Added a `tasks.saga.create` plan to `MUTATE_PROJECTION_PLANS` (+ the `OPERATION_BUCKETS` entry) that projects the created saga ID into the `created` bucket. **Verified live**: `cleo saga create --field /data/created/0` now prints the new saga ID; live envelope is `{count:1, created:["T…"], …}`.
2. `cleo --output json` was rejected with exit 2. Added an `OUTPUT_MODE_ALIASES` table + a `resolveOutputMode` SSoT helper mapping `json` → `envelope`. **Verified live**: `--output json` exits 0 and emits the canonical envelope.
3. `add-batch` already accepts per-task `acceptance` as a JSON array via the existing schema — locked it with a regression test (array passes, pipe-string rejected with the x-fix-hint).
- Regression: `mutate-projection.test.ts`, `output-context.test.ts` (new), `add-batch.test.ts`.

## T11483 (DHQ-035) — contract-literal enum pre-gate — DONE
JSON-Schema `enum:[…]` literals in `contracts/src/operations/*.ts` hand-duplicate the canonical task-axis enum SSoTs; a typo/drift sails past `tsc` (the literal is `string[]`) and detonates as a cascade of red CI gates far from the edit. Added `scripts/lint-contract-literal-enums.mjs` (standalone gate pattern) that parses the SSoT + the contract literals from **SOURCE** (never `dist/` → also closes the stale-dist false-pass class) and FAILS on any literal enum member not in its canonical set (subset rule for deliberately-partial enums). Wired as CI gate 13. **Verified end-to-end**: injecting `P9` into the real severity enum is caught at the exact line; clean after revert.
- Regression: `scripts/__tests__/lint-contract-literal-enums.test.mjs` (synthetic tree, 5 poison cases).

## T11484 (DHQ-027/032) — composite meta-tool contracts — PARTIAL (runtime deferred to T11456)
Shipped the typed I/O **contracts** for `module-relocation` (7 breakage classes) and `add-workspace-package` (6 wiring points) at `@cleocode/contracts/tools/composite`. **The runtime is deferred to epic T11456** and this is a deliberate, reported call — not a skip:
- `ATOMIC_TOOL_BOUNDARY` (CI Gate 11) reserves `core/src/tools/` for ATOMIC stateless primitives (fs/shell/search/net/notebook). These are composite, multi-step, repo-structure-aware TOOLs — not atomic primitives.
- `packages/skills/` (the boundary's `skillsHome`) holds SKILL.md markdown, no TS runtime.
- T11456 (PENDING) is the epic that DEFINES the missing structure these need: the closed `ToolCategory` enum (it reserves `vcs`/`workflow`/`agent` — the categories these compose, behind a deliberate contracts change), strict `<scope>_<category>_<operation>` naming, the `ToolDescriptor` zod schema, and the `ToolRegistry` with precedence. Writing the runtime now would force a placement/category/name T11456 must rework.

Shipping the contracts is the sound, additive, non-blocked unit: it pins the I/O surface (and enumerates every breakage/wiring class) for the T11456 registry to register against. Also fixed a latent `.gitignore` bug: T11392's unanchored `tools/`/`dev/`/`audit/`/… scratch entries silently ignored new files under `packages/contracts/src/tools/`; anchored the block to the repo root.
- Regression: `composite.test.ts` (locks the breakage-class + wiring-point SoT arrays + constructible shapes).

## Local validation
- **Build**: PASS — full `pnpm run build` (9-wave topo, all packages, ~33s).
- **Biome**: PASS — `biome check` on all 13 changed `.ts`/`.mjs` files, no fixes.
- **Tests**: PASS — 96 affected tests (52 cleo: output-mode/output-context/add-batch/mutate-minimal · 35 core: mutate-projection · 4 contracts: composite · 5 scripts: contract-literal-enums).
- **Arch**: PASS — `cleo check arch` 5/5; plus gates 9-13 + node-engine-ssot all green.

## Files changed
- `packages/cleo/src/cli/renderers/output-mode.ts`, `…/output-context.ts`, `…/index.ts`, `…/dispatch/middleware/mutate-minimal-envelope.ts` (+ 3 test files)
- `packages/core/src/dispatch/mutate-projection.ts` (+ test)
- `packages/contracts/src/tools/composite.ts` (new), `package.json` (+ subpath export), `vitest.config.ts` (alias) (+ test)
- `scripts/lint-contract-literal-enums.mjs` (new) (+ test), `.github/workflows/arch-boundary-check.yml` (gate 13), `.gitignore` (anchor scratch block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
