### PR TITLE
feat(T11360): author consolidated project cleo.db schema (domain-prefixed, E10-typed · E2 · SG-DB-SUBSTRATE-V2)

### DIFF
--- a/docs/migration/sqlite-schema-columns.md
+++ b/docs/migration/sqlite-schema-columns.md
@@ -1,6 +1,26 @@
 ### Scope: `brain` (target DB: `.cleo/brain.db`)
 
-#### `packages/core/src/store/memory-schema.ts`
+#### `packages/core/src/store/schema/code-index.ts`
+
+##### `code_index` → `nexus_code_index`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `id` | TEXT | id |  |  |  |  |  |  |
+| `project_id` | TEXT | id |  |  |  |  |  |  |
+| `file_path` | TEXT | text |  |  |  |  |  |  |
+| `symbol_name` | TEXT | text |  |  |  |  |  |  |
+| `kind` | TEXT | text |  |  |  |  |  | ⚠ enum-like TEXT 'kind' lacks { enum } / CHECK (col IN (...)) |
+| `start_line` | INTEGER | numeric |  |  |  |  |  |  |
+| `end_line` | INTEGER | numeric |  |  |  |  |  |  |
+| `language` | TEXT | text |  |  |  |  |  |  |
+| `exported` | INTEGER | boolean | ✓ |  |  |  | `false` |  |
+| `parent` | TEXT | text | ✓ |  |  |  |  |  |
+| `return_type` | TEXT | text | ✓ |  |  |  |  |  |
+| `doc_summary` | TEXT | text | ✓ |  |  |  |  |  |
+| `indexed_at` | TEXT | timestamp-text |  |  |  |  |  |  |
+
+#### `packages/core/src/store/schema/memory-schema.ts`
 
 ##### `brain_decisions` → `brain_decisions`
 
@@ -160,6 +180,28 @@
 | `color` | TEXT | enum | ✓ |  |  |  |  | `BRAIN_STICKY_COLORS` |
 | `priority` | TEXT | enum | ✓ |  |  |  |  | `BRAIN_STICKY_PRIORITIES` |
 | `source_type` | TEXT | text | ✓ |  |  |  | `'sticky-note'` |  |
+
+##### `sticky_tags` → `brain_sticky_tags`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `sticky_id` | TEXT | fk |  |  |  |  |  |  |
+| `tag` | TEXT | text |  |  |  |  |  |  |
+
+##### `brain_attention` → `brain_attention`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `id` | TEXT | id |  |  |  |  |  |  |
+| `content` | TEXT | text |  |  |  |  |  |  |
+| `session_id` | TEXT | id | ✓ |  |  |  |  |  |
+| `agent_id` | TEXT | id | ✓ |  |  |  |  |  |
+| `scope_kind` | TEXT | enum |  |  |  |  |  | `BRAIN_ATTENTION_SCOPE_KINDS` |
+| `scope_id` | TEXT | id |  |  |  |  |  |  |
+| `created_at` | INTEGER | timestamp-epoch |  |  |  |  | `sql`(unixepoch() * 1000)`` | ⚠ INTEGER epoch timestamp — target canonical form is TEXT ISO8601 + CHECK |
+| `expires_at` | INTEGER | timestamp-epoch | ✓ |  |  |  |  | ⚠ INTEGER epoch timestamp — target canonical form is TEXT ISO8601 + CHECK |
+| `decay_score` | REAL | real | ✓ |  |  |  |  |  |
+| `status` | TEXT | enum |  |  |  |  | `'open'` | `BRAIN_ATTENTION_STATUSES` |
 
 ##### `brain_memory_links` → `brain_memory_links`
 
@@ -379,7 +421,7 @@
 | `validation_status` | TEXT | text |  |  |  |  | `'pending'` |  |
 | `created_at` | TEXT | timestamp-text |  |  |  |  | `sql`(datetime('now'))`` |  |
 
-#### `packages/core/src/store/nexus-schema.ts`
+#### `packages/core/src/store/schema/nexus-schema.ts`
 
 ##### `project_registry` → `nexus_project_registry`
 
@@ -522,7 +564,7 @@
 | `created_at` | INTEGER | timestamp-date |  |  |  |  |  | ⚠ Drizzle { mode: "timestamp" } Date mapping — target canonical form is TEXT ISO8601 + CHECK |
 | `updated_at` | INTEGER | timestamp-date |  |  |  |  |  | ⚠ Drizzle { mode: "timestamp" } Date mapping — target canonical form is TEXT ISO8601 + CHECK |
 
-#### `packages/core/src/store/signaldock-schema.ts`
+#### `packages/core/src/store/schema/signaldock-schema.ts`
 
 ##### `users` → `signaldock_users`
 
@@ -722,7 +764,7 @@
 | `created_by` | TEXT | text |  |  |  |  |  |  |
 | `created_at` | INTEGER | timestamp-epoch |  |  |  |  |  | ⚠ INTEGER epoch timestamp — target canonical form is TEXT ISO8601 + CHECK |
 
-#### `packages/core/src/store/skills-schema.ts`
+#### `packages/core/src/store/schema/skills-schema.ts`
 
 ##### `skills` → `skills_skills`
 
@@ -780,29 +822,9 @@
 | `status` | TEXT | enum |  |  |  |  | `'proposed'` | `['proposed', 'applied', 'reverted', 'rejected']` |
 | `reverted_by_patch_id` | INTEGER | numeric | ✓ |  |  |  |  |  |
 
-#### `packages/nexus/src/schema/code-index.ts`
-
-##### `code_index` → `nexus_code_index`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `id` | TEXT | id |  |  |  |  |  |  |
-| `project_id` | TEXT | id |  |  |  |  |  |  |
-| `file_path` | TEXT | text |  |  |  |  |  |  |
-| `symbol_name` | TEXT | text |  |  |  |  |  |  |
-| `kind` | TEXT | text |  |  |  |  |  | ⚠ enum-like TEXT 'kind' lacks { enum } / CHECK (col IN (...)) |
-| `start_line` | INTEGER | numeric |  |  |  |  |  |  |
-| `end_line` | INTEGER | numeric |  |  |  |  |  |  |
-| `language` | TEXT | text |  |  |  |  |  |  |
-| `exported` | INTEGER | boolean | ✓ |  |  |  | `false` |  |
-| `parent` | TEXT | text | ✓ |  |  |  |  |  |
-| `return_type` | TEXT | text | ✓ |  |  |  |  |  |
-| `doc_summary` | TEXT | text | ✓ |  |  |  |  |  |
-| `indexed_at` | TEXT | timestamp-text |  |  |  |  |  |  |
-
 ### Scope: `tasks` (target DB: `.cleo/tasks.db`)
 
-#### `packages/core/src/agents/agent-schema.ts`
+#### `packages/core/src/store/schema/agent-schema.ts`
 
 ##### `agent_instances` → `tasks_agent_instances`
 
@@ -834,7 +856,165 @@
 | `occurred_at` | TEXT | timestamp-text |  |  |  |  | `sql`(datetime('now'))`` |  |
 | `resolved` | INTEGER | boolean |  |  |  |  | `false` |  |
 
-#### `packages/core/src/store/chain-schema.ts`
+#### `packages/core/src/store/schema/attachments.ts`
+
+##### `attachments` → `docs_attachments`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `id` | TEXT | id |  |  |  |  |  |  |
+| `sha256` | TEXT | text |  |  |  |  |  |  |
+| `attachment_json` | TEXT | json |  |  |  |  |  | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
+| `created_at` | TEXT | timestamp-text |  |  |  |  |  |  |
+| `ref_count` | INTEGER | numeric |  |  |  |  | `0` |  |
+| `slug` | TEXT | text | ✓ |  |  |  |  |  |
+| `type` | TEXT | text | ✓ |  |  |  |  | ⚠ enum-like TEXT 'type' lacks { enum } / CHECK (col IN (...)) |
+| `lifecycle_status` | TEXT | enum |  |  |  |  | `'draft'` | `ATTACHMENT_LIFECYCLE_STATUSES` |
+| `supersedes` | TEXT | fk | ✓ |  |  |  |  |  |
+| `superseded_by` | TEXT | fk | ✓ |  |  |  |  |  |
+| `summary` | TEXT | text | ✓ |  |  |  |  |  |
+| `keywords` | TEXT | text | ✓ |  |  |  |  |  |
+| `topics` | TEXT | text | ✓ |  |  |  |  |  |
+| `related_tasks` | TEXT | text | ✓ |  |  |  |  |  |
+| `owner_version` | TEXT | text | ✓ |  |  |  |  |  |
+| `doc_version` | INTEGER | numeric |  |  |  |  | `1` |  |
+
+##### `attachment_refs` → `docs_attachment_refs`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `attachment_id` | TEXT | id |  |  |  |  |  |  |
+| `owner_type` | TEXT | enum |  |  |  |  |  | `ATTACHMENT_OWNER_TYPES` |
+| `owner_id` | TEXT | id |  |  |  |  |  |  |
+| `attached_at` | TEXT | timestamp-text |  |  |  |  |  |  |
+| `attached_by` | TEXT | text | ✓ |  |  |  |  |  |
+
+#### `packages/core/src/store/schema/audit.ts`
+
+##### `schema_meta` → `tasks_schema_meta`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `key` | TEXT | text |  |  |  |  |  |  |
+| `value` | TEXT | text |  |  |  |  |  |  |
+
+##### `audit_log` → `tasks_audit_log`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `id` | TEXT | id |  |  |  |  |  |  |
+| `timestamp` | TEXT | text |  |  |  |  | `sql`(datetime('now'))`` |  |
+| `action` | TEXT | text |  |  |  |  |  |  |
+| `task_id` | TEXT | id |  |  |  |  |  |  |
+| `actor` | TEXT | text |  |  |  |  | `'system'` |  |
+| `details_json` | TEXT | json | ✓ |  |  |  | `'{}'` | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
+| `before_json` | TEXT | json | ✓ |  |  |  |  | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
+| `after_json` | TEXT | json | ✓ |  |  |  |  | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
+| `domain` | TEXT | text | ✓ |  |  |  |  |  |
+| `operation` | TEXT | text | ✓ |  |  |  |  |  |
+| `session_id` | TEXT | id | ✓ |  |  |  |  |  |
+| `request_id` | TEXT | id | ✓ |  |  |  |  |  |
+| `idempotency_key` | TEXT | text | ✓ |  |  |  |  |  |
+| `duration_ms` | INTEGER | numeric | ✓ |  |  |  |  |  |
+| `success` | INTEGER | numeric | ✓ |  |  |  |  |  |
+| `source` | TEXT | text | ✓ |  |  |  |  |  |
+| `gateway` | TEXT | text | ✓ |  |  |  |  |  |
+| `error_message` | TEXT | text | ✓ |  |  |  |  |  |
+| `project_hash` | TEXT | text | ✓ |  |  |  |  |  |
+
+##### `token_usage` → `tasks_token_usage`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `id` | TEXT | id |  |  |  |  |  |  |
+| `created_at` | TEXT | timestamp-text |  |  |  |  | `sql`(datetime('now'))`` |  |
+| `provider` | TEXT | text |  |  |  |  | `'unknown'` |  |
+| `model` | TEXT | text | ✓ |  |  |  |  |  |
+| `transport` | TEXT | enum |  |  |  |  | `'unknown'` | `TOKEN_USAGE_TRANSPORTS` |
+| `gateway` | TEXT | text | ✓ |  |  |  |  |  |
+| `domain` | TEXT | text | ✓ |  |  |  |  |  |
+| `operation` | TEXT | text | ✓ |  |  |  |  |  |
+| `session_id` | TEXT | fk | ✓ |  |  |  |  |  |
+| `task_id` | TEXT | fk | ✓ |  |  |  |  |  |
+| `request_id` | TEXT | id | ✓ |  |  |  |  |  |
+| `input_chars` | INTEGER | numeric |  |  |  |  | `0` |  |
+| `output_chars` | INTEGER | numeric |  |  |  |  | `0` |  |
+| `input_tokens` | INTEGER | numeric |  |  |  |  | `0` |  |
+| `output_tokens` | INTEGER | numeric |  |  |  |  | `0` |  |
+| `total_tokens` | INTEGER | numeric |  |  |  |  | `0` |  |
+| `method` | TEXT | enum |  |  |  |  | `'heuristic'` | `TOKEN_USAGE_METHODS` |
+| `confidence` | TEXT | enum |  |  |  |  | `'coarse'` | `TOKEN_USAGE_CONFIDENCE` |
+| `request_hash` | TEXT | text | ✓ |  |  |  |  |  |
+| `response_hash` | TEXT | text | ✓ |  |  |  |  |  |
+| `metadata_json` | TEXT | json |  |  |  |  | `'{}'` | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
+
+##### `architecture_decisions` → `tasks_architecture_decisions`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `id` | TEXT | id |  |  |  |  |  |  |
+| `title` | TEXT | text |  |  |  |  |  |  |
+| `status` | TEXT | enum |  |  |  |  | `'proposed'` | `ADR_STATUSES` |
+| `supersedes_id` | TEXT | fk | ✓ |  |  |  |  |  |
+| `superseded_by_id` | TEXT | fk | ✓ |  |  |  |  |  |
+| `consensus_manifest_id` | TEXT | fk | ✓ |  |  |  |  |  |
+| `content` | TEXT | text |  |  |  |  |  |  |
+| `created_at` | TEXT | timestamp-text |  |  |  |  | `sql`(datetime('now'))`` |  |
+| `updated_at` | TEXT | timestamp-text | ✓ |  |  |  |  |  |
+| `date` | TEXT | text |  |  |  |  | `''` |  |
+| `accepted_at` | TEXT | timestamp-text | ✓ |  |  |  |  |  |
+| `gate` | TEXT | enum | ✓ |  |  |  |  | `['HITL', 'automated']` |
+| `gate_status` | TEXT | enum | ✓ |  |  |  |  | `GATE_STATUSES` |
+| `amends_id` | TEXT | fk | ✓ |  |  |  |  |  |
+| `file_path` | TEXT | text |  |  |  |  | `''` |  |
+| `summary` | TEXT | text | ✓ |  |  |  |  |  |
+| `keywords` | TEXT | text | ✓ |  |  |  |  |  |
+| `topics` | TEXT | text | ✓ |  |  |  |  |  |
+
+##### `adr_task_links` → `tasks_adr_task_links`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `adr_id` | TEXT | fk |  |  |  |  |  |  |
+| `task_id` | TEXT | fk |  |  |  |  |  |  |
+| `link_type` | TEXT | enum |  |  |  |  | `'related'` | `['related', 'governed_by', 'implements']` |
+
+##### `adr_relations` → `tasks_adr_relations`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `from_adr_id` | TEXT | fk |  |  |  |  |  |  |
+| `to_adr_id` | TEXT | fk |  |  |  |  |  |  |
+| `relation_type` | TEXT | enum |  |  |  |  |  | `['supersedes', 'amends', 'related']` |
+
+##### `status_registry` → `tasks_status_registry`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `name` | TEXT | text |  |  |  |  |  |  |
+| `entity_type` | TEXT | enum |  |  |  |  |  | `['task', 'session', 'lifecycle_pipeline', 'lifecycle_stage', 'adr', 'gate', 'manifest']` |
+| `namespace` | TEXT | enum |  |  |  |  |  | `['workflow', 'governance', 'manifest']` |
+| `description` | TEXT | text |  |  |  |  |  |  |
+| `is_terminal` | INTEGER | boolean |  |  |  |  | `false` |  |
+
+#### `packages/core/src/store/schema/background-jobs.ts`
+
+##### `background_jobs` → `tasks_background_jobs`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `id` | TEXT | id |  |  |  |  |  |  |
+| `operation` | TEXT | text |  |  |  |  |  |  |
+| `status` | TEXT | enum |  |  |  |  | `'pending'` | `BACKGROUND_JOB_STATUSES` |
+| `started_at` | INTEGER | timestamp-epoch |  |  |  |  |  | ⚠ INTEGER epoch timestamp — target canonical form is TEXT ISO8601 + CHECK |
+| `completed_at` | INTEGER | timestamp-epoch | ✓ |  |  |  |  | ⚠ INTEGER epoch timestamp — target canonical form is TEXT ISO8601 + CHECK |
+| `result` | TEXT | text | ✓ |  |  |  |  |  |
+| `error` | TEXT | text | ✓ |  |  |  |  |  |
+| `progress` | INTEGER | numeric | ✓ |  |  |  |  |  |
+| `heartbeat_at` | INTEGER | timestamp-epoch |  |  |  |  |  | ⚠ INTEGER epoch timestamp — target canonical form is TEXT ISO8601 + CHECK |
+| `claimed_by` | TEXT | text | ✓ |  |  |  |  |  |
+
+#### `packages/core/src/store/schema/chain-schema.ts`
 
 ##### `warp_chains` → `tasks_warp_chains`
 
@@ -864,7 +1044,7 @@
 | `created_at` | TEXT | timestamp-text | ✓ |  |  |  | `sql`(datetime('now'))`` |  |
 | `updated_at` | TEXT | timestamp-text | ✓ |  |  |  | `sql`(datetime('now'))`` |  |
 
-#### `packages/core/src/store/conduit-schema.ts`
+#### `packages/core/src/store/schema/conduit-schema.ts`
 
 ##### `conversations` → `conduit_conversations`
 
@@ -1067,164 +1247,6 @@
 | `name` | TEXT | text |  |  |  |  |  |  |
 | `applied_at` | INTEGER | timestamp-epoch |  |  |  |  | `sql`(strftime('%s', 'now'))`` | ⚠ INTEGER epoch timestamp — target canonical form is TEXT ISO8601 + CHECK |
 
-#### `packages/core/src/store/schema/attachments.ts`
-
-##### `attachments` → `docs_attachments`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `id` | TEXT | id |  |  |  |  |  |  |
-| `sha256` | TEXT | text |  |  |  |  |  |  |
-| `attachment_json` | TEXT | json |  |  |  |  |  | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
-| `created_at` | TEXT | timestamp-text |  |  |  |  |  |  |
-| `ref_count` | INTEGER | numeric |  |  |  |  | `0` |  |
-| `slug` | TEXT | text | ✓ |  |  |  |  |  |
-| `type` | TEXT | text | ✓ |  |  |  |  | ⚠ enum-like TEXT 'type' lacks { enum } / CHECK (col IN (...)) |
-| `lifecycle_status` | TEXT | enum |  |  |  |  | `'draft'` | `ATTACHMENT_LIFECYCLE_STATUSES` |
-| `supersedes` | TEXT | fk | ✓ |  |  |  |  |  |
-| `superseded_by` | TEXT | fk | ✓ |  |  |  |  |  |
-| `summary` | TEXT | text | ✓ |  |  |  |  |  |
-| `keywords` | TEXT | text | ✓ |  |  |  |  |  |
-| `topics` | TEXT | text | ✓ |  |  |  |  |  |
-| `related_tasks` | TEXT | text | ✓ |  |  |  |  |  |
-| `owner_version` | TEXT | text | ✓ |  |  |  |  |  |
-| `doc_version` | INTEGER | numeric |  |  |  |  | `1` |  |
-
-##### `attachment_refs` → `docs_attachment_refs`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `attachment_id` | TEXT | id |  |  |  |  |  |  |
-| `owner_type` | TEXT | enum |  |  |  |  |  | `ATTACHMENT_OWNER_TYPES` |
-| `owner_id` | TEXT | id |  |  |  |  |  |  |
-| `attached_at` | TEXT | timestamp-text |  |  |  |  |  |  |
-| `attached_by` | TEXT | text | ✓ |  |  |  |  |  |
-
-#### `packages/core/src/store/schema/audit.ts`
-
-##### `schema_meta` → `tasks_schema_meta`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `key` | TEXT | text |  |  |  |  |  |  |
-| `value` | TEXT | text |  |  |  |  |  |  |
-
-##### `audit_log` → `tasks_audit_log`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `id` | TEXT | id |  |  |  |  |  |  |
-| `timestamp` | TEXT | text |  |  |  |  | `sql`(datetime('now'))`` |  |
-| `action` | TEXT | text |  |  |  |  |  |  |
-| `task_id` | TEXT | id |  |  |  |  |  |  |
-| `actor` | TEXT | text |  |  |  |  | `'system'` |  |
-| `details_json` | TEXT | json | ✓ |  |  |  | `'{}'` | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
-| `before_json` | TEXT | json | ✓ |  |  |  |  | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
-| `after_json` | TEXT | json | ✓ |  |  |  |  | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
-| `domain` | TEXT | text | ✓ |  |  |  |  |  |
-| `operation` | TEXT | text | ✓ |  |  |  |  |  |
-| `session_id` | TEXT | id | ✓ |  |  |  |  |  |
-| `request_id` | TEXT | id | ✓ |  |  |  |  |  |
-| `idempotency_key` | TEXT | text | ✓ |  |  |  |  |  |
-| `duration_ms` | INTEGER | numeric | ✓ |  |  |  |  |  |
-| `success` | INTEGER | numeric | ✓ |  |  |  |  |  |
-| `source` | TEXT | text | ✓ |  |  |  |  |  |
-| `gateway` | TEXT | text | ✓ |  |  |  |  |  |
-| `error_message` | TEXT | text | ✓ |  |  |  |  |  |
-| `project_hash` | TEXT | text | ✓ |  |  |  |  |  |
-
-##### `token_usage` → `tasks_token_usage`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `id` | TEXT | id |  |  |  |  |  |  |
-| `created_at` | TEXT | timestamp-text |  |  |  |  | `sql`(datetime('now'))`` |  |
-| `provider` | TEXT | text |  |  |  |  | `'unknown'` |  |
-| `model` | TEXT | text | ✓ |  |  |  |  |  |
-| `transport` | TEXT | enum |  |  |  |  | `'unknown'` | `TOKEN_USAGE_TRANSPORTS` |
-| `gateway` | TEXT | text | ✓ |  |  |  |  |  |
-| `domain` | TEXT | text | ✓ |  |  |  |  |  |
-| `operation` | TEXT | text | ✓ |  |  |  |  |  |
-| `session_id` | TEXT | fk | ✓ |  |  |  |  |  |
-| `task_id` | TEXT | fk | ✓ |  |  |  |  |  |
-| `request_id` | TEXT | id | ✓ |  |  |  |  |  |
-| `input_chars` | INTEGER | numeric |  |  |  |  | `0` |  |
-| `output_chars` | INTEGER | numeric |  |  |  |  | `0` |  |
-| `input_tokens` | INTEGER | numeric |  |  |  |  | `0` |  |
-| `output_tokens` | INTEGER | numeric |  |  |  |  | `0` |  |
-| `total_tokens` | INTEGER | numeric |  |  |  |  | `0` |  |
-| `method` | TEXT | enum |  |  |  |  | `'heuristic'` | `TOKEN_USAGE_METHODS` |
-| `confidence` | TEXT | enum |  |  |  |  | `'coarse'` | `TOKEN_USAGE_CONFIDENCE` |
-| `request_hash` | TEXT | text | ✓ |  |  |  |  |  |
-| `response_hash` | TEXT | text | ✓ |  |  |  |  |  |
-| `metadata_json` | TEXT | json |  |  |  |  | `'{}'` | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
-
-##### `architecture_decisions` → `tasks_architecture_decisions`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `id` | TEXT | id |  |  |  |  |  |  |
-| `title` | TEXT | text |  |  |  |  |  |  |
-| `status` | TEXT | enum |  |  |  |  | `'proposed'` | `ADR_STATUSES` |
-| `supersedes_id` | TEXT | fk | ✓ |  |  |  |  |  |
-| `superseded_by_id` | TEXT | fk | ✓ |  |  |  |  |  |
-| `consensus_manifest_id` | TEXT | fk | ✓ |  |  |  |  |  |
-| `content` | TEXT | text |  |  |  |  |  |  |
-| `created_at` | TEXT | timestamp-text |  |  |  |  | `sql`(datetime('now'))`` |  |
-| `updated_at` | TEXT | timestamp-text | ✓ |  |  |  |  |  |
-| `date` | TEXT | text |  |  |  |  | `''` |  |
-| `accepted_at` | TEXT | timestamp-text | ✓ |  |  |  |  |  |
-| `gate` | TEXT | enum | ✓ |  |  |  |  | `['HITL', 'automated']` |
-| `gate_status` | TEXT | enum | ✓ |  |  |  |  | `GATE_STATUSES` |
-| `amends_id` | TEXT | fk | ✓ |  |  |  |  |  |
-| `file_path` | TEXT | text |  |  |  |  | `''` |  |
-| `summary` | TEXT | text | ✓ |  |  |  |  |  |
-| `keywords` | TEXT | text | ✓ |  |  |  |  |  |
-| `topics` | TEXT | text | ✓ |  |  |  |  |  |
-
-##### `adr_task_links` → `tasks_adr_task_links`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `adr_id` | TEXT | fk |  |  |  |  |  |  |
-| `task_id` | TEXT | fk |  |  |  |  |  |  |
-| `link_type` | TEXT | enum |  |  |  |  | `'related'` | `['related', 'governed_by', 'implements']` |
-
-##### `adr_relations` → `tasks_adr_relations`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `from_adr_id` | TEXT | fk |  |  |  |  |  |  |
-| `to_adr_id` | TEXT | fk |  |  |  |  |  |  |
-| `relation_type` | TEXT | enum |  |  |  |  |  | `['supersedes', 'amends', 'related']` |
-
-##### `status_registry` → `tasks_status_registry`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `name` | TEXT | text |  |  |  |  |  |  |
-| `entity_type` | TEXT | enum |  |  |  |  |  | `['task', 'session', 'lifecycle_pipeline', 'lifecycle_stage', 'adr', 'gate', 'manifest']` |
-| `namespace` | TEXT | enum |  |  |  |  |  | `['workflow', 'governance', 'manifest']` |
-| `description` | TEXT | text |  |  |  |  |  |  |
-| `is_terminal` | INTEGER | boolean |  |  |  |  | `false` |  |
-
-#### `packages/core/src/store/schema/background-jobs.ts`
-
-##### `background_jobs` → `tasks_background_jobs`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `id` | TEXT | id |  |  |  |  |  |  |
-| `operation` | TEXT | text |  |  |  |  |  |  |
-| `status` | TEXT | enum |  |  |  |  | `'pending'` | `BACKGROUND_JOB_STATUSES` |
-| `started_at` | INTEGER | timestamp-epoch |  |  |  |  |  | ⚠ INTEGER epoch timestamp — target canonical form is TEXT ISO8601 + CHECK |
-| `completed_at` | INTEGER | timestamp-epoch | ✓ |  |  |  |  | ⚠ INTEGER epoch timestamp — target canonical form is TEXT ISO8601 + CHECK |
-| `result` | TEXT | text | ✓ |  |  |  |  |  |
-| `error` | TEXT | text | ✓ |  |  |  |  |  |
-| `progress` | INTEGER | numeric | ✓ |  |  |  |  |  |
-| `heartbeat_at` | INTEGER | timestamp-epoch |  |  |  |  |  | ⚠ INTEGER epoch timestamp — target canonical form is TEXT ISO8601 + CHECK |
-| `claimed_by` | TEXT | text | ✓ |  |  |  |  |  |
-
 #### `packages/core/src/store/schema/evidence-bindings.ts`
 
 ##### `evidence_ac_bindings` → `tasks_evidence_ac_bindings`
@@ -1366,6 +1388,40 @@
 | `metadata_json` | TEXT | json | ✓ |  |  |  |  | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
 | `created_at` | TEXT | timestamp-text |  |  |  |  |  |  |
 | `archived_at` | TEXT | timestamp-text | ✓ |  |  |  |  |  |
+
+#### `packages/core/src/store/schema/playbooks.ts`
+
+##### `playbook_runs` → `tasks_playbook_runs`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `run_id` | TEXT | id |  |  |  |  |  |  |
+| `playbook_name` | TEXT | text |  |  |  |  |  |  |
+| `playbook_hash` | TEXT | text |  |  |  |  |  |  |
+| `current_node` | TEXT | text | ✓ |  |  |  |  |  |
+| `bindings` | TEXT | json |  |  |  |  | `'{}'` | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
+| `error_context` | TEXT | text | ✓ |  |  |  |  |  |
+| `status` | TEXT | text |  |  |  |  | `'running'` | ⚠ enum-like TEXT 'status' lacks { enum } / CHECK (col IN (...)) |
+| `iteration_counts` | TEXT | json |  |  |  |  | `'{}'` | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
+| `epic_id` | TEXT | id | ✓ |  |  |  |  |  |
+| `session_id` | TEXT | id | ✓ |  |  |  |  |  |
+| `started_at` | TEXT | timestamp-text |  |  |  |  | `"(datetime('now'))"` |  |
+| `completed_at` | TEXT | timestamp-text | ✓ |  |  |  |  |  |
+
+##### `playbook_approvals` → `tasks_playbook_approvals`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `approval_id` | TEXT | id |  |  |  |  |  |  |
+| `run_id` | TEXT | id |  |  |  |  |  |  |
+| `node_id` | TEXT | id |  |  |  |  |  |  |
+| `token` | TEXT | text |  |  |  |  |  |  |
+| `requested_at` | TEXT | timestamp-text |  |  |  |  | `"(datetime('now'))"` |  |
+| `approved_at` | TEXT | timestamp-text | ✓ |  |  |  |  |  |
+| `approver` | TEXT | text | ✓ |  |  |  |  |  |
+| `reason` | TEXT | text | ✓ |  |  |  |  |  |
+| `status` | TEXT | text |  |  |  |  | `'pending'` | ⚠ enum-like TEXT 'status' lacks { enum } / CHECK (col IN (...)) |
+| `auto_passed` | INTEGER | boolean-untyped |  |  |  |  | `0` | ⚠ INTEGER boolean flag lacks { mode: "boolean" } + CHECK (col IN (0,1)) |
 
 #### `packages/core/src/store/schema/provenance/commits.ts`
 
@@ -1650,6 +1706,13 @@
 | `task_id` | TEXT | fk |  |  |  |  |  |  |
 | `depends_on` | TEXT | fk |  |  |  |  |  |  |
 
+##### `task_labels` → `tasks_task_labels`
+
+| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
+|---|---|---|:--:|:--:|:--:|:--:|---|---|
+| `task_id` | TEXT | fk |  |  |  |  |  |  |
+| `label` | TEXT | text |  |  |  |  |  |  |
+
 ##### `task_relations` → `tasks_task_relations`
 
 | column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
@@ -1737,7 +1800,7 @@
 | `linked_at` | TEXT | timestamp-text |  |  |  |  | `sql`(datetime('now'))`` |  |
 | `last_sync_at` | TEXT | timestamp-text | ✓ |  |  |  |  |  |
 
-#### `packages/core/src/telemetry/schema.ts`
+#### `packages/core/src/store/schema/telemetry-schema.ts`
 
 ##### `telemetry_events` → `telemetry_events`
 
@@ -1760,38 +1823,4 @@
 |---|---|---|:--:|:--:|:--:|:--:|---|---|
 | `key` | TEXT | text |  |  |  |  |  |  |
 | `value` | TEXT | text |  |  |  |  |  |  |
-
-#### `packages/playbooks/src/schema.ts`
-
-##### `playbook_runs` → `tasks_playbook_runs`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `run_id` | TEXT | id |  |  |  |  |  |  |
-| `playbook_name` | TEXT | text |  |  |  |  |  |  |
-| `playbook_hash` | TEXT | text |  |  |  |  |  |  |
-| `current_node` | TEXT | text | ✓ |  |  |  |  |  |
-| `bindings` | TEXT | json |  |  |  |  | `'{}'` | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
-| `error_context` | TEXT | text | ✓ |  |  |  |  |  |
-| `status` | TEXT | text |  |  |  |  | `'running'` | ⚠ enum-like TEXT 'status' lacks { enum } / CHECK (col IN (...)) |
-| `iteration_counts` | TEXT | json |  |  |  |  | `'{}'` | ⚠ JSON-in-TEXT — needs write-time validator or json1 read assertion (T11330) |
-| `epic_id` | TEXT | id | ✓ |  |  |  |  |  |
-| `session_id` | TEXT | id | ✓ |  |  |  |  |  |
-| `started_at` | TEXT | timestamp-text |  |  |  |  | `"(datetime('now'))"` |  |
-| `completed_at` | TEXT | timestamp-text | ✓ |  |  |  |  |  |
-
-##### `playbook_approvals` → `tasks_playbook_approvals`
-
-| column | affinity | semantic type | null | PK | UQ | FK | default | enum / non-conformer |
-|---|---|---|:--:|:--:|:--:|:--:|---|---|
-| `approval_id` | TEXT | id |  |  |  |  |  |  |
-| `run_id` | TEXT | id |  |  |  |  |  |  |
-| `node_id` | TEXT | id |  |  |  |  |  |  |
-| `token` | TEXT | text |  |  |  |  |  |  |
-| `requested_at` | TEXT | timestamp-text |  |  |  |  | `"(datetime('now'))"` |  |
-| `approved_at` | TEXT | timestamp-text | ✓ |  |  |  |  |  |
-| `approver` | TEXT | text | ✓ |  |  |  |  |  |
-| `reason` | TEXT | text | ✓ |  |  |  |  |  |
-| `status` | TEXT | text |  |  |  |  | `'pending'` | ⚠ enum-like TEXT 'status' lacks { enum } / CHECK (col IN (...)) |
-| `auto_passed` | INTEGER | boolean-untyped |  |  |  |  | `0` | ⚠ INTEGER boolean flag lacks { mode: "boolean" } + CHECK (col IN (0,1)) |
 

--- a/drizzle/cleo-project.config.ts
+++ b/drizzle/cleo-project.config.ts
@@ -34,10 +34,23 @@
  * prefixed consolidated schema. This task (T11358) authors the target shape
  * (scope axis, file naming, membership, counts) only.
  *
+ * **Domain-prefixed target modules (T11360).** The realized, E10-typed,
+ * domain-prefixed Pattern-A target shape is authored under
+ * `packages/core/src/store/schema/cleo-project/` (barrel `index.ts`). Those
+ * modules carry the FINAL prefixed physical names (`tasks_commits`,
+ * `docs_attachments`, `telemetry_events`, …) and the strict typing exodus
+ * deploys. They are intentionally NOT added to the `schema` list below: this
+ * config's list is the LIVE-module membership the audit derives `targetTable`
+ * from, and adding the prefixed twins would double-declare each table at
+ * generate time. The `cleo-project/` barrel is the generate-ready membership
+ * once exodus (T11248) swaps the substrate and the live modules are retired.
+ *
  * @task T11358
+ * @task T11360
  * @epic T11245
  * @saga T11242
  * @see docs/migration/sqlite-schema-canonical.md §1 (canonical per-scope counts)
+ * @see packages/core/src/store/schema/cleo-project/index.ts (target-shape barrel)
  */
 
 import { defineConfig } from 'drizzle-kit';

--- a/packages/core/src/store/schema/attachments.ts
+++ b/packages/core/src/store/schema/attachments.ts
@@ -14,7 +14,14 @@ import {
   text,
 } from 'drizzle-orm/sqlite-core';
 
-const ATTACHMENT_OWNER_TYPES = [
+/**
+ * Allowed owner-entity types for `attachment_refs.owner_type`.
+ *
+ * Exported as the SSoT const array so the consolidated docs target schema
+ * (`schema/cleo-project/docs.ts`, T11360) references this identifier rather
+ * than re-declaring the literal — per the canonical typing report §5a.
+ */
+export const ATTACHMENT_OWNER_TYPES = [
   'task',
   'observation',
   'session',

--- a/packages/core/src/store/schema/cleo-project/docs.ts
+++ b/packages/core/src/store/schema/cleo-project/docs.ts
@@ -1,0 +1,283 @@
+/**
+ * Project-scope `cleo.db` — consolidated **docs** domain (D11 collapse).
+ *
+ * Part of the consolidated PROJECT-scope `cleo.db` target shape authored for
+ * SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2, task T11360). This module is
+ * **target-shape authoring only** — it carries the domain-prefixed Pattern-A
+ * physical table names and the E10 strict typing the exodus migration
+ * (T11248) will deploy. The live runtime modules under
+ * `packages/core/src/store/schema/{attachments,manifest}.ts` keep their
+ * UNPREFIXED physical names until exodus swaps the substrate; do not point
+ * runtime accessors at this module.
+ *
+ * ## D11 — the docs collapse (AC3)
+ *
+ * The legacy `attachments` / `attachment_refs` (attachment store) and
+ * `manifest_entries` / `pipeline_manifest` (RCASD provenance manifest) table
+ * families collapse into ONE `docs_*` schema. There is no separate
+ * `attachments_*` or `llmtxt_*` family in the consolidated substrate — every
+ * document-bearing table lives under the `docs_` prefix:
+ *
+ *   - `docs_attachments`        ← `attachments`
+ *   - `docs_attachment_refs`    ← `attachment_refs`
+ *   - `docs_manifest_entries`   ← `manifest_entries`
+ *   - `docs_pipeline_manifest`  ← `pipeline_manifest`
+ *
+ * ## E10 typing applied (per docs/migration/sqlite-schema-canonical.md)
+ *
+ * - **§3b boolean non-conformer:** `pipeline_manifest.distilled` was already
+ *   `integer({ mode: 'boolean' })` — preserved.
+ * - **§4 timestamps:** every timestamp column is the canonical TEXT ISO8601
+ *   form (`datetime('now')`); none were epoch non-conformers in this domain.
+ * - **§5 enum-like bare TEXT:** `manifest_entries.status` already carries
+ *   `{ enum: MANIFEST_STATUSES }` (kept). `attachments.type` and
+ *   `pipeline_manifest.{type,status}` are §5b non-conformers whose legal value
+ *   set is **writer-derived / open taxonomy** (attachment `type` is a free
+ *   doc-kind tag validated at the dispatch layer; pipeline `type` is mapped
+ *   from phase-directory names and pipeline `status` is written dynamically).
+ *   Per §8.3 + the `attachments.ts` precedent (dispatch-layer validation so new
+ *   taxonomy needs no migration) these remain documented bare TEXT — the CHECK
+ *   list cannot be hand-frozen without rejecting valid writes. Flagged for the
+ *   exodus writer audit (T11248) rather than guessed here.
+ * - **§6a JSON-in-TEXT (AC4):** JSON columns use the existing E4 `jsonb<T>()`
+ *   pattern from `../jsonb.js` for the columns the JSON-Column Audit routes to
+ *   JSONB, and remain serialized TEXT (with a documented read rule) for the
+ *   columns that audit keeps as TEXT. No new JSON pattern is invented.
+ *
+ * @task T11360
+ * @epic T11245
+ * @saga T11242
+ * @see docs/migration/sqlite-schema-canonical.md §1 (D1″) · §3b · §5 · §6a
+ * @see docs/migration/sqlite-schema-columns.json (per-column affinity SSoT)
+ */
+
+import { sql } from 'drizzle-orm';
+import {
+  type AnySQLiteColumn,
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+} from 'drizzle-orm/sqlite-core';
+import { MANIFEST_STATUSES } from '../../status-registry.js';
+import { ATTACHMENT_LIFECYCLE_STATUSES, ATTACHMENT_OWNER_TYPES } from '../attachments.js';
+
+/**
+ * `docs_attachments` — content-addressed registry of stored documents/blobs.
+ *
+ * Domain-prefixed target of the legacy `attachments` table (D11 collapse).
+ *
+ * @task T11360 (target shape) · T796 (original)
+ */
+export const docsAttachments = sqliteTable(
+  'docs_attachments',
+  {
+    /** Unique attachment identifier (UUID v4). */
+    id: text('id').primaryKey(),
+    /** SHA-256 hex digest of the uncompressed content. Unique across the registry. */
+    sha256: text('sha256').notNull().unique(),
+    /**
+     * Serialised `Attachment` discriminated union (all kind-specific fields).
+     *
+     * JSON-in-TEXT (§6a). Kept as TEXT per the JSON-Column Audit disposition
+     * (not routed to JSONB); read-time validation lives in the dispatch layer.
+     */
+    attachmentJson: text('attachment_json').notNull(),
+    /** ISO-8601 UTC creation instant (canonical TEXT timestamp, §4). */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+    /** Number of `docs_attachment_refs` rows pointing here; GC-eligible at 0. */
+    refCount: integer('ref_count').notNull().default(0),
+    /** Optional human-friendly slug, unique per project. */
+    slug: text('slug'),
+    /**
+     * Optional doc-kind taxonomy tag (§5b non-conformer).
+     *
+     * Open taxonomy validated at the dispatch layer — see module docs. Left as
+     * bare TEXT; the exodus writer audit (T11248) enumerates the legal set.
+     */
+    type: text('type'),
+    /** Document workflow state — CHECK-backed via {@link ATTACHMENT_LIFECYCLE_STATUSES}. */
+    lifecycleStatus: text('lifecycle_status', { enum: ATTACHMENT_LIFECYCLE_STATUSES })
+      .notNull()
+      .default('draft'),
+    /** Forward supersession pointer (→ `docs_attachments.id`); NULL if none. */
+    supersedes: text('supersedes').references((): AnySQLiteColumn => docsAttachments.id),
+    /** Reverse supersession pointer (→ `docs_attachments.id`); NULL while active. */
+    supersededBy: text('superseded_by').references((): AnySQLiteColumn => docsAttachments.id),
+    /** Optional one-sentence human summary, distinct from the full body. */
+    summary: text('summary'),
+    /** Optional JSON array of free-form keyword strings (TEXT per JSON audit). */
+    keywords: text('keywords'),
+    /** Optional JSON array of canonical topic slugs (TEXT per JSON audit). */
+    topics: text('topics'),
+    /** Optional JSON array of related `T####` task IDs (TEXT per JSON audit). */
+    relatedTasks: text('related_tasks'),
+    /** CLEO release version that wrote this row (docs version SSoT anchor). */
+    ownerVersion: text('owner_version'),
+    /** Sequential doc-version counter for this slug; 1 for new rows. */
+    docVersion: integer('doc_version').notNull().default(1),
+  },
+  (table) => [
+    index('idx_docs_attachments_sha256').on(table.sha256),
+    index('idx_docs_attachments_lifecycle_status').on(table.lifecycleStatus),
+    index('idx_docs_attachments_supersedes').on(table.supersedes),
+  ],
+);
+
+/**
+ * `docs_attachment_refs` — ref-counted junction linking attachments to owners.
+ *
+ * Domain-prefixed target of the legacy `attachment_refs` table (D11 collapse).
+ *
+ * @task T11360 (target shape) · T796 (original)
+ */
+export const docsAttachmentRefs = sqliteTable(
+  'docs_attachment_refs',
+  {
+    /** ID of the attachment (→ `docs_attachments.id`). */
+    attachmentId: text('attachment_id').notNull(),
+    /** Domain entity type that owns this ref — CHECK-backed. */
+    ownerType: text('owner_type', { enum: ATTACHMENT_OWNER_TYPES }).notNull(),
+    /** The ID of the owning entity. */
+    ownerId: text('owner_id').notNull(),
+    /** ISO-8601 UTC instant when this ref was created (canonical TEXT, §4). */
+    attachedAt: text('attached_at').notNull(),
+    /** Agent identity (or `"human"`) that created this ref. */
+    attachedBy: text('attached_by'),
+  },
+  (table) => [
+    primaryKey({ columns: [table.attachmentId, table.ownerType, table.ownerId] }),
+    index('idx_docs_attachment_refs_attachment_id').on(table.attachmentId),
+    index('idx_docs_attachment_refs_owner').on(table.ownerType, table.ownerId),
+  ],
+);
+
+/**
+ * `docs_manifest_entries` — RCASD provenance manifest rows.
+ *
+ * Domain-prefixed target of the legacy `manifest_entries` table (D11 collapse).
+ * Cross-domain FKs (`pipeline_id`, `stage_id` → lifecycle tables) are resolved
+ * by the exodus prefixer against the consolidated single-file schema; this
+ * target module carries them as plain TEXT id columns (no in-module FK to the
+ * live lifecycle module, which keeps unprefixed names).
+ *
+ * @task T11360 (target shape) · T5100 (original)
+ */
+export const docsManifestEntries = sqliteTable(
+  'docs_manifest_entries',
+  {
+    /** Manifest entry id (UUID v4). */
+    id: text('id').primaryKey(),
+    /** FK → `tasks_lifecycle_pipelines.id` (resolved at exodus). */
+    pipelineId: text('pipeline_id'),
+    /** FK → `tasks_lifecycle_stages.id` (resolved at exodus). */
+    stageId: text('stage_id'),
+    /** Human-readable manifest title. */
+    title: text('title').notNull(),
+    /** Manifest date (display TEXT). */
+    date: text('date').notNull(),
+    /** Manifest lifecycle status — CHECK-backed via {@link MANIFEST_STATUSES}. */
+    status: text('status', { enum: MANIFEST_STATUSES }).notNull(),
+    /** Optional agent type that produced the entry. */
+    agentType: text('agent_type'),
+    /** Optional path to the produced output file. */
+    outputFile: text('output_file'),
+    /** JSON array of topic slugs (TEXT per JSON audit; empty-array default). */
+    topicsJson: text('topics_json').default('[]'),
+    /** JSON array of findings (TEXT per JSON audit; empty-array default). */
+    findingsJson: text('findings_json').default('[]'),
+    /** JSON array of linked task IDs (TEXT per JSON audit; empty-array default). */
+    linkedTasksJson: text('linked_tasks_json').default('[]'),
+    /** Agent identity (or `"human"`) that created the entry. */
+    createdBy: text('created_by'),
+    /** ISO-8601 UTC creation instant (canonical TEXT timestamp, §4). */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index('idx_docs_manifest_entries_pipeline_id').on(table.pipelineId),
+    index('idx_docs_manifest_entries_stage_id').on(table.stageId),
+    index('idx_docs_manifest_entries_status').on(table.status),
+  ],
+);
+
+/**
+ * `docs_pipeline_manifest` — distilled pipeline manifest (memory ingestion).
+ *
+ * Domain-prefixed target of the legacy `pipeline_manifest` table (D11 collapse).
+ * `session_id` / `task_id` / `epic_id` are cross-domain FKs into the
+ * `tasks_*` family resolved by the exodus prefixer; carried here as TEXT id
+ * columns.
+ *
+ * @task T11360 (target shape) · T5581 (original)
+ */
+export const docsPipelineManifest = sqliteTable(
+  'docs_pipeline_manifest',
+  {
+    /** Pipeline manifest id (UUID v4). */
+    id: text('id').primaryKey(),
+    /** FK → `tasks_sessions.id` (resolved at exodus). */
+    sessionId: text('session_id'),
+    /** FK → `tasks_tasks.id` (resolved at exodus). */
+    taskId: text('task_id'),
+    /** FK → `tasks_tasks.id` (epic, resolved at exodus). */
+    epicId: text('epic_id'),
+    /**
+     * Manifest entry type (§5b non-conformer).
+     *
+     * Mapped from phase-directory names by the ingestion writer — open
+     * taxonomy. Left as bare TEXT; legal set enumerated at the exodus writer
+     * audit (T11248).
+     */
+    type: text('type').notNull(),
+    /** Distilled content body. */
+    content: text('content').notNull(),
+    /** Optional content hash for dedup. */
+    contentHash: text('content_hash'),
+    /**
+     * Manifest status (§5b non-conformer).
+     *
+     * Written dynamically by the ingestion path (default `'active'`); not a
+     * frozen enum. Left as bare TEXT pending the exodus writer audit (T11248).
+     */
+    status: text('status').notNull().default('active'),
+    /** Whether the entry has been distilled into BRAIN — boolean (§3, kept typed). */
+    distilled: integer('distilled', { mode: 'boolean' }).notNull().default(false),
+    /** Optional id of the BRAIN observation this entry distilled into. */
+    brainObsId: text('brain_obs_id'),
+    /** Optional source file path. */
+    sourceFile: text('source_file'),
+    /** Optional serialized metadata (TEXT per JSON audit). */
+    metadataJson: text('metadata_json'),
+    /** ISO-8601 UTC creation instant (canonical TEXT timestamp, §4). */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 UTC archival instant; NULL while active (canonical TEXT, §4). */
+    archivedAt: text('archived_at'),
+  },
+  (table) => [
+    index('idx_docs_pipeline_manifest_task_id').on(table.taskId),
+    index('idx_docs_pipeline_manifest_session_id').on(table.sessionId),
+    index('idx_docs_pipeline_manifest_distilled').on(table.distilled),
+    index('idx_docs_pipeline_manifest_status').on(table.status),
+    index('idx_docs_pipeline_manifest_content_hash').on(table.contentHash),
+  ],
+);
+
+// === TYPE EXPORTS ===
+
+/** Row type for `docs_attachments` SELECT queries (target shape). */
+export type DocsAttachmentRow = typeof docsAttachments.$inferSelect;
+/** Row type for `docs_attachments` INSERT operations (target shape). */
+export type NewDocsAttachmentRow = typeof docsAttachments.$inferInsert;
+/** Row type for `docs_attachment_refs` SELECT queries (target shape). */
+export type DocsAttachmentRefRow = typeof docsAttachmentRefs.$inferSelect;
+/** Row type for `docs_attachment_refs` INSERT operations (target shape). */
+export type NewDocsAttachmentRefRow = typeof docsAttachmentRefs.$inferInsert;
+/** Row type for `docs_manifest_entries` SELECT queries (target shape). */
+export type DocsManifestEntryRow = typeof docsManifestEntries.$inferSelect;
+/** Row type for `docs_manifest_entries` INSERT operations (target shape). */
+export type NewDocsManifestEntryRow = typeof docsManifestEntries.$inferInsert;
+/** Row type for `docs_pipeline_manifest` SELECT queries (target shape). */
+export type DocsPipelineManifestRow = typeof docsPipelineManifest.$inferSelect;
+/** Row type for `docs_pipeline_manifest` INSERT operations (target shape). */
+export type NewDocsPipelineManifestRow = typeof docsPipelineManifest.$inferInsert;

--- a/packages/core/src/store/schema/cleo-project/index.ts
+++ b/packages/core/src/store/schema/cleo-project/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Consolidated **PROJECT-scope `cleo.db`** target schema — barrel.
+ *
+ * SG-DB-SUBSTRATE-V2 · saga T11242 · epic T11245 (E2) · task T11360.
+ *
+ * ## What this directory is
+ *
+ * The owner-ratified D1″ lifecycle split (2026-05-30) collapses the CLEO SQLite
+ * fleet into exactly two `cleo.db` files: a PROJECT-scope DB
+ * (`<projectRoot>/.cleo/cleo.db`) and a GLOBAL-scope DB
+ * (`$XDG_DATA_HOME/cleo/cleo.db`). The PROJECT-scope DB holds every project-tier
+ * domain — `tasks_*` / `brain_*` (this project's memory) / `conduit_*` /
+ * `docs_*` / `telemetry_*` — as domain-prefixed Pattern-A tables (87 tables /
+ * 903 columns per the canonical typing report §1).
+ *
+ * Modules under this directory author that **target shape**: domain-prefixed
+ * `sqliteTable` definitions with the E10 strict typing applied per
+ * `docs/migration/sqlite-schema-canonical.md`. They are NOT yet the runtime
+ * schema — the live runtime modules one level up
+ * (`packages/core/src/store/schema/*.ts`) keep their UNPREFIXED physical names
+ * (`tasks`, `commits`, `attachments`, …) because they back the live runtime
+ * queries and the journaled drizzle migrations (the migration-baseline test
+ * asserts the existence table `tasks`, not `tasks_tasks`). The **exodus
+ * migration (T11248)** swaps the substrate to this shape and renames the
+ * physical tables; pointing a runtime accessor at this module before exodus
+ * would read an empty / nonexistent table.
+ *
+ * ## Idempotent prefixer (AC1)
+ *
+ * Each table's physical name is its `targetTable` from
+ * `docs/migration/sqlite-schema-columns.json`. A table already carrying a
+ * recognized domain prefix (`telemetry_events`, `conduit_*`, `brain_*`, …) is
+ * NOT double-prefixed; bare tables (`tasks` → `tasks_tasks`, `attachments` →
+ * `docs_attachments`) gain their domain prefix.
+ *
+ * ## Coverage status (T11360 — partial, by design)
+ *
+ * Authored here (a coherent, fully-green slice — 9 tables):
+ *   - **docs** (D11 collapse, AC3): docs_attachments · docs_attachment_refs ·
+ *     docs_manifest_entries · docs_pipeline_manifest
+ *   - **telemetry**: telemetry_events · telemetry_schema_meta
+ *   - **provenance/commits** (E10 §3b boolean + §5b enum demonstrator):
+ *     tasks_commits · tasks_task_commits · tasks_commit_files
+ *
+ * Remaining for follow-on T11360 increments (NOT in this slice): the rest of
+ * tasks-core (tasks_tasks, tasks_sessions, lifecycle, releases, PRs,
+ * playbooks, agents, chain, audit, evidence, experiments, background-jobs,
+ * task_labels junction), the full conduit_* family (14 tables, incl. the 45
+ * epoch→ISO8601 timestamp conversions + idempotency keys), and the brain_*
+ * memory family (22 tables, mirrored project+global). Each follows the exact
+ * pattern established here.
+ *
+ * @task T11360
+ * @epic T11245
+ * @saga T11242
+ * @see docs/migration/sqlite-schema-canonical.md §1 (per-scope counts) · §3–§6 (typing rules)
+ * @see drizzle/cleo-project.config.ts (per-scope domain membership)
+ */
+
+export * from './docs.js';
+export * from './provenance-commits.js';
+export * from './telemetry.js';

--- a/packages/core/src/store/schema/cleo-project/provenance-commits.ts
+++ b/packages/core/src/store/schema/cleo-project/provenance-commits.ts
@@ -1,0 +1,207 @@
+/**
+ * Project-scope `cleo.db` — consolidated **provenance / commits** domain.
+ *
+ * Part of the consolidated PROJECT-scope `cleo.db` target shape authored for
+ * SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2, task T11360). Target-shape
+ * authoring only — physical names carry the `tasks_` domain prefix (provenance
+ * is a satellite of the project-tier tasks-core cluster per the canonical
+ * `targetTable` map). The live runtime module
+ * `schema/provenance/commits.ts` keeps its UNPREFIXED physical names
+ * (`commits` / `task_commits` / `commit_files`) until the exodus migration
+ * (T11248) deploys this shape; the migration-baseline test depends on the live
+ * names, so they must not change in-place.
+ *
+ * This module is the canonical demonstration of the E10 §3b boolean
+ * non-conformer transform within T11360's slice:
+ *
+ *   - `commits.is_release_commit`   INTEGER 0/1  → integer({ mode: 'boolean' })
+ *   - `commits.is_merge_commit`     INTEGER 0/1  → integer({ mode: 'boolean' })
+ *   - `commit_files.is_binary`      INTEGER 0/1  → integer({ mode: 'boolean' })
+ *
+ * The matching SQL `CHECK (col IN (0,1))` ships as raw DDL in the exodus
+ * migration (drizzle-orm sqlite-core surfaces no typed per-column CHECK DSL in
+ * rc.3); the `{ mode: 'boolean' }` builder guarantees the application only ever
+ * writes 0/1, so the row type narrows to `boolean`.
+ *
+ * ## E10 enum-like bare-TEXT transform (§5b)
+ *
+ * Four §5b enum-like bare-TEXT non-conformers gain `{ enum }` narrowing from
+ * the named const arrays already declared in the live module (referenced by
+ * identifier, never hand-typed literals — §5a):
+ *
+ *   - `commits.conventional_type`   → { enum: COMMIT_CONVENTIONAL_TYPES }
+ *   - `task_commits.link_kind`      → { enum: COMMIT_LINK_KINDS }
+ *   - `task_commits.link_source`    → { enum: COMMIT_LINK_SOURCES }
+ *   - `commit_files.change_type`    → { enum: COMMIT_FILE_CHANGE_TYPES }
+ *
+ * ## E10 timestamps (§4)
+ *
+ * All timestamp columns are already the canonical TEXT ISO8601 form
+ * (`authored_at`, `committed_at`, `created_at`); none were epoch non-conformers.
+ *
+ * @task T11360
+ * @epic T11245
+ * @saga T11242
+ * @see docs/migration/sqlite-schema-canonical.md §1 (D1″) · §3b · §5 · §4
+ * @see docs/migration/sqlite-schema-columns.json (per-column affinity SSoT)
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import {
+  COMMIT_CONVENTIONAL_TYPES,
+  COMMIT_FILE_CHANGE_TYPES,
+  COMMIT_LINK_KINDS,
+  COMMIT_LINK_SOURCES,
+} from '../provenance/commits.js';
+
+/**
+ * `tasks_commits` — domain-prefixed target of the legacy `commits` table.
+ *
+ * @task T11360 (target shape) · T9506 (original)
+ */
+export const tasksCommits = sqliteTable(
+  'tasks_commits',
+  {
+    /** Full 40-char git SHA — primary key. */
+    sha: text('sha').primaryKey(),
+    /** First 7 characters of the SHA for display purposes. */
+    shortSha: text('short_sha').notNull(),
+    /** Author display name (from `git log %an`). */
+    authorName: text('author_name'),
+    /** Author email (from `git log %ae`). */
+    authorEmail: text('author_email'),
+    /** ISO-8601 author timestamp (canonical TEXT, §4). */
+    authoredAt: text('authored_at').notNull(),
+    /** Committer display name (from `git log %cn`). */
+    committerName: text('committer_name'),
+    /** Committer email (from `git log %ce`). */
+    committerEmail: text('committer_email'),
+    /** ISO-8601 committer timestamp (canonical TEXT, §4). */
+    committedAt: text('committed_at').notNull(),
+    /** Full commit message body (subject + blank line + body if present). */
+    message: text('message').notNull(),
+    /** First line of the commit message (the subject). */
+    subject: text('subject').notNull(),
+    /**
+     * Conventional Commits type parsed from the subject; NULL when the commit
+     * does not follow Conventional Commits format. E10 §5b: now CHECK-backed
+     * via {@link COMMIT_CONVENTIONAL_TYPES}.
+     */
+    conventionalType: text('conventional_type', { enum: COMMIT_CONVENTIONAL_TYPES }),
+    /**
+     * Whether this commit matches the `chore(release): vX.Y.Z` release pattern.
+     * E10 §3b: untyped INTEGER 0/1 → typed boolean.
+     */
+    isReleaseCommit: integer('is_release_commit', { mode: 'boolean' }).notNull().default(false),
+    /**
+     * Whether the commit has more than one parent (merge commit).
+     * E10 §3b: untyped INTEGER 0/1 → typed boolean.
+     */
+    isMergeCommit: integer('is_merge_commit', { mode: 'boolean' }).notNull().default(false),
+    /** JSON array of parent SHA strings (TEXT per JSON audit; empty-array default). */
+    parentShas: text('parent_shas').notNull().default('[]'),
+    /**
+     * Signature verification tri-state: 0=absent/invalid, 1=verified,
+     * NULL=not checked. Tri-state, so NOT a 0/1 boolean — kept numeric.
+     */
+    signatureVerified: integer('signature_verified'),
+    /** Best-effort branch HEAD was on at commit time; NULL if unavailable. */
+    branchAtCommit: text('branch_at_commit'),
+    /** Project hash correlating commits to a specific CLEO project. */
+    projectHash: text('project_hash'),
+    /** ISO-8601 UTC insertion instant (canonical TEXT timestamp, §4). */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index('idx_tasks_commits_short_sha').on(table.shortSha),
+    index('idx_tasks_commits_author_email').on(table.authorEmail),
+    index('idx_tasks_commits_authored_at').on(table.authoredAt),
+    index('idx_tasks_commits_conventional_type').on(table.conventionalType),
+    index('idx_tasks_commits_is_release').on(table.isReleaseCommit),
+    index('idx_tasks_commits_project_hash').on(table.projectHash),
+  ],
+);
+
+/**
+ * `tasks_task_commits` — M:N junction between tasks and commits.
+ *
+ * Domain-prefixed target of the legacy `task_commits` table. `task_id` is a
+ * cross-table FK into `tasks_tasks` resolved by the exodus prefixer; carried
+ * here as a plain TEXT id. `commit_sha` references the in-module
+ * {@link tasksCommits}.
+ *
+ * @task T11360 (target shape) · T9506 (original)
+ */
+export const tasksTaskCommits = sqliteTable(
+  'tasks_task_commits',
+  {
+    /** FK → `tasks_tasks.id` (resolved at exodus); NULL = orphaned link. */
+    taskId: text('task_id'),
+    /** FK → `tasks_commits.sha`. ON DELETE CASCADE. */
+    commitSha: text('commit_sha')
+      .notNull()
+      .references(() => tasksCommits.sha, { onDelete: 'cascade' }),
+    /** Semantic task↔commit relationship — E10 §5b CHECK-backed. */
+    linkKind: text('link_kind', { enum: COMMIT_LINK_KINDS }).notNull(),
+    /** How this link was discovered — E10 §5b CHECK-backed. */
+    linkSource: text('link_source', { enum: COMMIT_LINK_SOURCES }).notNull(),
+    /** ISO-8601 UTC link-creation instant (canonical TEXT timestamp, §4). */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.taskId, table.commitSha, table.linkKind] }),
+    index('idx_tasks_task_commits_task_id').on(table.taskId),
+    index('idx_tasks_task_commits_commit_sha').on(table.commitSha),
+    index('idx_tasks_task_commits_link_kind').on(table.linkKind),
+  ],
+);
+
+/**
+ * `tasks_commit_files` — per-file × SHA materialization (blast-radius enabler).
+ *
+ * Domain-prefixed target of the legacy `commit_files` table.
+ *
+ * @task T11360 (target shape) · T9506 (original)
+ */
+export const tasksCommitFiles = sqliteTable(
+  'tasks_commit_files',
+  {
+    /** FK → `tasks_commits.sha`. ON DELETE CASCADE. */
+    commitSha: text('commit_sha')
+      .notNull()
+      .references(() => tasksCommits.sha, { onDelete: 'cascade' }),
+    /** Canonical repo-relative file path (after rename, if any). */
+    path: text('path').notNull(),
+    /** Previous path before a rename/copy; NULL for A/M/D change types. */
+    oldPath: text('old_path'),
+    /** Git status letter — E10 §5b CHECK-backed via {@link COMMIT_FILE_CHANGE_TYPES}. */
+    changeType: text('change_type', { enum: COMMIT_FILE_CHANGE_TYPES }).notNull(),
+    /** Lines added (0 for deletions and binary files). */
+    linesAdded: integer('lines_added').notNull().default(0),
+    /** Lines deleted (0 for additions and binary files). */
+    linesDeleted: integer('lines_deleted').notNull().default(0),
+    /** Whether the file is binary. E10 §3b: untyped INTEGER 0/1 → typed boolean. */
+    isBinary: integer('is_binary', { mode: 'boolean' }).notNull().default(false),
+  },
+  (table) => [
+    primaryKey({ columns: [table.commitSha, table.path] }),
+    index('idx_tasks_commit_files_path').on(table.path),
+    index('idx_tasks_commit_files_change_type').on(table.changeType),
+  ],
+);
+
+// === TYPE EXPORTS ===
+
+/** Row type for `tasks_commits` SELECT queries (target shape). */
+export type TasksCommitRow = typeof tasksCommits.$inferSelect;
+/** Row type for `tasks_commits` INSERT operations (target shape). */
+export type NewTasksCommitRow = typeof tasksCommits.$inferInsert;
+/** Row type for `tasks_task_commits` SELECT queries (target shape). */
+export type TasksTaskCommitRow = typeof tasksTaskCommits.$inferSelect;
+/** Row type for `tasks_task_commits` INSERT operations (target shape). */
+export type NewTasksTaskCommitRow = typeof tasksTaskCommits.$inferInsert;
+/** Row type for `tasks_commit_files` SELECT queries (target shape). */
+export type TasksCommitFileRow = typeof tasksCommitFiles.$inferSelect;
+/** Row type for `tasks_commit_files` INSERT operations (target shape). */
+export type NewTasksCommitFileRow = typeof tasksCommitFiles.$inferInsert;

--- a/packages/core/src/store/schema/cleo-project/telemetry.ts
+++ b/packages/core/src/store/schema/cleo-project/telemetry.ts
@@ -1,0 +1,90 @@
+/**
+ * Project-scope `cleo.db` — consolidated **telemetry** domain.
+ *
+ * Part of the consolidated PROJECT-scope `cleo.db` target shape authored for
+ * SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2, task T11360). Target-shape
+ * authoring only — physical names carry the `telemetry_` domain prefix (already
+ * present in the source, so the idempotent prefixer is a no-op here: a table
+ * already carrying a recognized domain prefix is NOT double-prefixed, per AC1).
+ * The live runtime module `schema/telemetry-schema.ts` is unchanged until the
+ * exodus migration (T11248) deploys this shape.
+ *
+ * ## E10 typing applied
+ *
+ * - **§4 timestamps:** `telemetry_events.timestamp` is the canonical TEXT
+ *   ISO8601 form (`datetime('now')`); no epoch non-conformer in this domain.
+ * - **No boolean / enum / JSON columns** — `exit_code` is a numeric LAFS code
+ *   (not a 0/1 boolean flag), so it stays plain `integer` per the audit.
+ *
+ * @task T11360
+ * @epic T11245
+ * @saga T11242
+ * @see docs/migration/sqlite-schema-canonical.md §1 (D1″) · §4
+ * @see docs/migration/sqlite-schema-columns.json (per-column affinity SSoT)
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/**
+ * `telemetry_events` — one row per command invocation captured by the
+ * telemetry middleware (anonymous, opt-in). Already domain-prefixed; the
+ * idempotent prefixer leaves the name as-is.
+ *
+ * @task T11360 (target shape) · T624 (original)
+ */
+export const telemetryEvents = sqliteTable(
+  'telemetry_events',
+  {
+    /** UUID primary key. */
+    id: text('id').primaryKey(),
+    /** Anonymous install identifier (UUIDv4, generated once on first enable). */
+    anonymousId: text('anonymous_id').notNull(),
+    /** Canonical domain (e.g. "tasks", "session", "memory", "admin"). */
+    domain: text('domain').notNull(),
+    /** CQRS gateway ("query" or "mutate"). */
+    gateway: text('gateway').notNull(),
+    /** Operation name (e.g. "show", "add", "complete"). */
+    operation: text('operation').notNull(),
+    /** Composed command string "{domain}.{operation}" for easy grouping. */
+    command: text('command').notNull(),
+    /** LAFS exit code (0 = success, non-zero = failure). Numeric, not boolean. */
+    exitCode: integer('exit_code').notNull().default(0),
+    /** Wall-clock duration in milliseconds. */
+    durationMs: integer('duration_ms').notNull(),
+    /** Machine-readable error code when exit_code != 0. NULL on success. */
+    errorCode: text('error_code'),
+    /** ISO-8601 UTC instant of the invocation (canonical TEXT timestamp, §4). */
+    timestamp: text('timestamp').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index('idx_telemetry_command').on(table.command),
+    index('idx_telemetry_domain').on(table.domain),
+    index('idx_telemetry_exit_code').on(table.exitCode),
+    index('idx_telemetry_timestamp').on(table.timestamp),
+    index('idx_telemetry_duration').on(table.durationMs),
+  ],
+);
+
+/**
+ * `telemetry_schema_meta` — key-value schema-version tracking (single row).
+ *
+ * @task T11360 (target shape) · T624 (original)
+ */
+export const telemetrySchemaMeta = sqliteTable('telemetry_schema_meta', {
+  /** Config key. */
+  key: text('key').primaryKey(),
+  /** Config value. */
+  value: text('value').notNull(),
+});
+
+// === TYPE EXPORTS ===
+
+/** Row type for `telemetry_events` SELECT queries (target shape). */
+export type TelemetryEventRow = typeof telemetryEvents.$inferSelect;
+/** Row type for `telemetry_events` INSERT operations (target shape). */
+export type NewTelemetryEventRow = typeof telemetryEvents.$inferInsert;
+/** Row type for `telemetry_schema_meta` SELECT queries (target shape). */
+export type TelemetrySchemaMetaRow = typeof telemetrySchemaMeta.$inferSelect;
+/** Row type for `telemetry_schema_meta` INSERT operations (target shape). */
+export type NewTelemetrySchemaMetaRow = typeof telemetrySchemaMeta.$inferInsert;


### PR DESCRIPTION
## What

Authors the consolidated **PROJECT-scope `cleo.db`** target shape (D1″ lifecycle split) as a self-contained domain-prefixed Pattern-A target schema family under `packages/core/src/store/schema/cleo-project/`, applying the E10 typing rules from `docs/migration/sqlite-schema-canonical.md`.

**Target-shape authoring only** (exodus is T11248). The live runtime modules keep their UNPREFIXED physical names (`tasks`, `commits`, `attachments`, …) because they back live runtime queries and journaled migrations — the `migration-baseline` test asserts the existence table `tasks`, not `tasks_tasks`. Renaming in-place would break runtime until exodus runs. The new `cleo-project/` family is the realized prefixed shape the exodus migration will deploy.

Per the scale guidance, this is a **correct, fully-green coherent slice** (9 tables across 3 self-contained domains) rather than a red 87-table sprawl. Remaining domains follow the identical pattern in follow-on increments.

## Per-AC checklist

- **AC1 — domain-prefixed `sqliteTable` in `store/schema/`** ✅ — 9 tables carry their `targetTable` physical names: `docs_attachments`, `docs_attachment_refs`, `docs_manifest_entries`, `docs_pipeline_manifest`, `tasks_commits`, `tasks_task_commits`, `tasks_commit_files`, `telemetry_events`, `telemetry_schema_meta`. Idempotent prefixer honored: `telemetry_*` (already prefixed) is a no-op; bare `commits`→`tasks_commits`, `attachments`→`docs_attachments` gain their prefix. Runtime-verified — all 9 load with the correct `drizzle:Name`.
- **AC2 — E10 typing** ✅ — §3b boolean non-conformers `is_release_commit` / `is_merge_commit` / `is_binary` → `integer({ mode: 'boolean' })`; `distilled` kept typed. §5b enum-like bare TEXT → `{ enum }` from named const arrays referenced by identifier (§5a): `conventional_type`, `link_kind`, `link_source`, `change_type`. Timestamps all canonical TEXT ISO8601 (no epoch non-conformers in this slice). `signature_verified` correctly kept numeric (tri-state, not 0/1 boolean). Open/writer-derived taxonomies (`attachments.type`, `pipeline_manifest.{type,status}`) documented as bare TEXT per §8.3 + the `attachments.ts` dispatch-layer-validation precedent.
- **AC3 — docs collapse (D11)** ✅ — `attachments` + `attachment_refs` + `manifest_entries` + `pipeline_manifest` collapse into one `docs_*` schema. No separate `attachments_*` / `llmtxt_*` family.
- **AC4 — JSON via existing E4 pattern** ✅ — JSON columns reuse the existing `jsonb<T>()` / TEXT dispositions from the JSON-Column Audit (no new JSON pattern). The columns that audit keeps as TEXT stay TEXT with a documented read rule.
- **AC5 — build green + zero `any`/`unknown`** ✅ — `tsc -b` exit 0; `grep` finds zero casts in the new family (only the word "any" inside a TSDoc comment).

## 5 mandatory validations (all PASS locally)

1. **`pnpm run typecheck` (tsc -b)** — ✅ PASS, exit 0, zero errors (`TC_EXIT: 0`).
2. **Cold runtime smoke** — ✅ PASS. `node build.mjs` (cold, 41s, exit 0) then `node packages/cleo/dist/cli/index.js version` → `{"success":true,"data":{"version":"2026.5.126"},...}`. No TDZ / circular-import bug.
3. **SSoT path-files** — ✅ No module FILE renamed/relocated (only additive), so `db-inventory.json` paths are unchanged and all resolve. Regenerated `docs/migration/sqlite-schema-columns.md` via the audit script (it was stale on main after T11359; the JSON SSoT was already current — md now matches it byte-for-byte). `cleo-project.config.ts` updated to document the target barrel.
4. **Specific test files** — ✅ `db-inventory` 10/10 · `migration-baseline` 13/13 · `commits-schema-parity` + `lifecycle`/`pr`/`release-artifacts`-parity + `memory-schema` 134/134 · `jsonb` 9/9.
5. **`cleo check arch` + biome** — ✅ arch 5/5 pass; `biome check --write .` clean (auto-fixed 1 import).

## What's staged

New: `store/schema/cleo-project/{docs,telemetry,provenance-commits,index}.ts` (9 tables). Modified: `attachments.ts` (export `ATTACHMENT_OWNER_TYPES` SSoT const), `cleo-project.config.ts` (target-barrel doc reference), `sqlite-schema-columns.md` (regenerated to match the already-current JSON).

## Remaining (follow-on T11360 increments)

Rest of tasks-core (`tasks_tasks`, sessions, lifecycle, releases, PRs, playbooks, agents, chain, audit, evidence, experiments, background-jobs, `task_labels` junction), full `conduit_*` (14 tables incl. 45 epoch→ISO8601 conversions + idempotency keys), and `brain_*` memory (22 tables, mirrored). Each follows the exact pattern established here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)