### PR TITLE
feat(T11449): CLI-RPC server under @cleocode/runtime/gateway/rpc — NDJSON over unix socket (R3-T5 · SG-RUNTIME-UNIFICATION)

### DIFF
--- a/packages/cleo/src/dispatch/__tests__/transport-inventory.test.ts
+++ b/packages/cleo/src/dispatch/__tests__/transport-inventory.test.ts
@@ -135,9 +135,12 @@ describe('R3-T1 transport inventory — topology invariants', () => {
     expect(JSON.parse(readFileSync(pkgPath, 'utf8')).name).toBe('@cleocode/adapters');
   });
 
-  it('rpc/http transports are contract-declared but have no adapter yet (R3-T5/T6)', () => {
+  it('the rpc transport now has its adapter (R3-T5 · T11449); http is still pending (R3-T6)', () => {
     expect(GATEWAY_SOURCES).toContain('rpc');
     expect(GATEWAY_SOURCES).toContain('http');
-    expect(existsSync(join(REPO_ROOT, 'packages/runtime/src/gateway/rpc'))).toBe(false);
+    // R3-T5 (T11449) landed the CLI-RPC adapter under the runtime gateway.
+    expect(existsSync(join(REPO_ROOT, 'packages/runtime/src/gateway/rpc'))).toBe(true);
+    // http remains contract-declared but adapter-less until R3-T6.
+    expect(existsSync(join(REPO_ROOT, 'packages/runtime/src/gateway/http'))).toBe(false);
   });
 });

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -14,6 +14,10 @@
       "types": "./dist/gateway.d.ts",
       "import": "./dist/gateway.js"
     },
+    "./gateway/rpc": {
+      "types": "./dist/gateway/rpc/index.d.ts",
+      "import": "./dist/gateway/rpc/index.js"
+    },
     "./tools/atomic": {
       "types": "./dist/tools/atomic.d.ts",
       "import": "./dist/tools/atomic.js"

--- a/packages/contracts/src/gateway/rpc/__tests__/freeze.test.ts
+++ b/packages/contracts/src/gateway/rpc/__tests__/freeze.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Schema-drift guard for the FROZEN `gateway/rpc` v1.0 contract (T11449 AC).
+ *
+ * Pins the v1.0 protocol version, the exact `direction` discriminator set, and
+ * the protocol-level transport error codes. If a future change adds, removes,
+ * or renames a direction/error code without bumping to a new contract revision,
+ * these assertions fail — forcing an explicit, reviewed decision rather than
+ * silent drift that would break the CLI-RPC adapter and its clients.
+ *
+ * Also asserts the NDJSON frame round-trips through the Zod schemas, proving
+ * the framing discipline borrowed from `supervisor-ipc` (versioned, correlated
+ * envelope discriminated by `direction`, one frame per line) holds for the
+ * gateway-dispatch payload.
+ *
+ * @task T11449
+ * @epic T11254
+ * @saga T11243
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  GATEWAY_RPC_CHANNEL_BASENAME,
+  GATEWAY_RPC_DIRECTIONS,
+  GATEWAY_RPC_ERROR_CODES,
+  GATEWAY_RPC_PROTOCOL_VERSION,
+  GatewayRpcFrameSchema,
+  isFrozenGatewayRpcVersion,
+} from '../index.js';
+
+describe('gateway/rpc v1.0 freeze guard (T11449)', () => {
+  it('pins the frozen protocol version', () => {
+    expect(GATEWAY_RPC_PROTOCOL_VERSION).toBe('1.0.0');
+  });
+
+  it('pins the default channel basename', () => {
+    expect(GATEWAY_RPC_CHANNEL_BASENAME).toBe('cleo-gateway-rpc');
+  });
+
+  it('pins the EXACT frozen direction set', () => {
+    expect([...GATEWAY_RPC_DIRECTIONS]).toEqual(['request', 'response', 'error']);
+  });
+
+  it('pins the EXACT frozen protocol-level error-code set', () => {
+    expect([...GATEWAY_RPC_ERROR_CODES]).toEqual([
+      'E_RPC_PARSE',
+      'E_RPC_BAD_VERSION',
+      'E_RPC_BAD_FRAME',
+      'E_RPC_INTERNAL',
+    ]);
+  });
+
+  it('isFrozenGatewayRpcVersion accepts only the frozen version', () => {
+    expect(isFrozenGatewayRpcVersion('1.0.0')).toBe(true);
+    expect(isFrozenGatewayRpcVersion('2.0.0')).toBe(false);
+    expect(isFrozenGatewayRpcVersion('0.9.0')).toBe(false);
+  });
+});
+
+describe('gateway/rpc v1.0 NDJSON frame round-trip', () => {
+  it('parses a request frame wrapping a source:rpc DispatchRequest', () => {
+    const wire = {
+      protocol_version: '1.0.0',
+      id: 'abc',
+      direction: 'request',
+      request: {
+        gateway: 'query',
+        domain: 'tasks',
+        operation: 'show',
+        params: { id: 'T1' },
+        source: 'rpc',
+        requestId: 'abc',
+      },
+    };
+    const parsed = GatewayRpcFrameSchema.safeParse(wire);
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.direction === 'request') {
+      expect(parsed.data.request.source).toBe('rpc');
+      expect(parsed.data.request.operation).toBe('show');
+    }
+  });
+
+  it('parses a response frame wrapping a LAFS DispatchResponse', () => {
+    const wire = {
+      protocol_version: '1.0.0',
+      id: 'abc',
+      direction: 'response',
+      response: {
+        meta: {
+          gateway: 'query',
+          domain: 'tasks',
+          operation: 'show',
+          timestamp: '2026-05-31T00:00:00.000Z',
+          duration_ms: 1,
+          source: 'rpc',
+          requestId: 'abc',
+        },
+        success: true,
+        data: { id: 'T1' },
+      },
+    };
+    expect(GatewayRpcFrameSchema.safeParse(wire).success).toBe(true);
+  });
+
+  it('parses a protocol-level error frame', () => {
+    const wire = {
+      protocol_version: '1.0.0',
+      id: '0',
+      direction: 'error',
+      error: { code: 'E_RPC_BAD_VERSION', message: 'unsupported protocol version' },
+    };
+    expect(GatewayRpcFrameSchema.safeParse(wire).success).toBe(true);
+  });
+
+  it('rejects an unknown direction (proves the union is closed)', () => {
+    const wire = {
+      protocol_version: '1.0.0',
+      id: 'abc',
+      direction: 'teleport',
+      request: {},
+    };
+    expect(GatewayRpcFrameSchema.safeParse(wire).success).toBe(false);
+  });
+
+  it('rejects a request frame whose source is NOT rpc-shaped enum member', () => {
+    const wire = {
+      protocol_version: '1.0.0',
+      id: 'abc',
+      direction: 'request',
+      request: {
+        gateway: 'query',
+        domain: 'tasks',
+        operation: 'show',
+        source: 'carrier-pigeon',
+        requestId: 'abc',
+      },
+    };
+    expect(GatewayRpcFrameSchema.safeParse(wire).success).toBe(false);
+  });
+});

--- a/packages/contracts/src/gateway/rpc/index.ts
+++ b/packages/contracts/src/gateway/rpc/index.ts
@@ -1,0 +1,43 @@
+/**
+ * `gateway/rpc` v1.0 — FROZEN CLI-RPC NDJSON contract barrel.
+ *
+ * Re-exports the version constants and Zod frame schemas + inferred types for
+ * the CLI-RPC transport (`@cleocode/runtime/gateway/rpc`): a long-lived
+ * unix-socket RPC server that decodes NDJSON {@link GatewayRpcFrame}s into a
+ * `source: 'rpc'` gateway request and routes them through the gateway handler.
+ *
+ * Mirrors the `supervisor-ipc` contract structure (version.ts + messages.ts +
+ * this barrel + a freeze guard test) but carries gateway dispatch traffic, not
+ * supervisor process-control messages. The request/response PAYLOADS are owned
+ * by `@cleocode/contracts/gateway` (R3-T2 · T11446) and re-validated here at
+ * the untrusted RPC boundary.
+ *
+ * @task T11449
+ * @epic T11254
+ * @saga T11243
+ * @packageDocumentation
+ */
+
+export type {
+  GatewayRpcDirection,
+  GatewayRpcError,
+  GatewayRpcErrorCode,
+  GatewayRpcErrorFrame,
+  GatewayRpcFrame,
+  GatewayRpcRequestFrame,
+  GatewayRpcResponseFrame,
+} from './messages.js';
+export {
+  GATEWAY_RPC_DIRECTIONS,
+  GATEWAY_RPC_ERROR_CODES,
+  GatewayRpcErrorFrameSchema,
+  GatewayRpcErrorSchema,
+  GatewayRpcFrameSchema,
+  GatewayRpcRequestFrameSchema,
+  GatewayRpcResponseFrameSchema,
+  isFrozenGatewayRpcVersion,
+} from './messages.js';
+export {
+  GATEWAY_RPC_CHANNEL_BASENAME,
+  GATEWAY_RPC_PROTOCOL_VERSION,
+} from './version.js';

--- a/packages/contracts/src/gateway/rpc/messages.ts
+++ b/packages/contracts/src/gateway/rpc/messages.ts
@@ -1,0 +1,187 @@
+/**
+ * `gateway/rpc` v1.0 — FROZEN NDJSON message contract (Zod schemas).
+ *
+ * The CLI-RPC transport carries gateway dispatch traffic over a long-lived
+ * unix-domain socket. The wire format is newline-delimited JSON (NDJSON): one
+ * {@link GatewayRpcFrame} per line — exactly the framing discipline used by the
+ * FROZEN `supervisor-ipc` v1.0 contract, REUSED here (not edited): a versioned,
+ * correlation-id'd envelope discriminated by `direction`.
+ *
+ * The difference from supervisor-ipc is the PAYLOAD: this contract wraps the
+ * frozen gateway shapes ({@link dispatchRequestSchema} /
+ * {@link dispatchResponseSchema} from `@cleocode/contracts/gateway`) rather
+ * than supervisor process-control messages. So:
+ *
+ * ```jsonc
+ * // request frame (client → server)
+ * { "protocol_version": "1.0.0", "id": "abc", "direction": "request",
+ *   "request": { "gateway": "query", "domain": "tasks", "operation": "show",
+ *                "params": { "id": "T1" }, "source": "rpc",
+ *                "requestId": "abc" } }
+ * // response frame (server → client)
+ * { "protocol_version": "1.0.0", "id": "abc", "direction": "response",
+ *   "response": { "success": true, "data": {…}, "meta": {…} } }
+ * // error frame (server → client) — protocol-level (bad version / parse / unknown)
+ * { "protocol_version": "1.0.0", "id": "abc", "direction": "error",
+ *   "error": { "code": "E_RPC_BAD_VERSION", "message": "…" } }
+ * ```
+ *
+ * FROZEN v1.0: the {@link GATEWAY_RPC_DIRECTIONS} set is pinned by the drift
+ * guard (`__tests__/freeze.test.ts`). Do not add/rename/remove directions in
+ * place — bump to a new versioned directory instead. The request/response
+ * PAYLOADS are owned by the gateway contract (R3-T2 · T11446) and re-validated
+ * here so an untrusted RPC boundary cannot inject a malformed dispatch request.
+ *
+ * @task T11449
+ * @epic T11254
+ * @saga T11243
+ * @packageDocumentation
+ */
+
+import { z } from 'zod';
+import { dispatchRequestSchema, dispatchResponseSchema } from '../../gateway.js';
+import { GATEWAY_RPC_PROTOCOL_VERSION } from './version.js';
+
+// ─── Protocol-level error payload ──────────────────────────────────────────────
+
+/**
+ * A protocol-level (transport) error returned when a frame cannot even reach
+ * the gateway: malformed JSON, a wrong `protocol_version`, or a frame the
+ * server cannot route. Distinct from a {@link dispatchResponseSchema} `error`
+ * field, which is a DOMAIN error produced by the handler itself.
+ */
+export const GatewayRpcErrorSchema = z
+  .object({
+    /** Machine-readable transport error code (e.g. `E_RPC_BAD_VERSION`). */
+    code: z.string().min(1),
+    /** Human-readable error message. */
+    message: z.string(),
+  })
+  .strict();
+
+/** Protocol-level RPC error payload (inferred from {@link GatewayRpcErrorSchema}). */
+export type GatewayRpcError = z.infer<typeof GatewayRpcErrorSchema>;
+
+// ─── Request frame (client → server) ───────────────────────────────────────────
+
+/**
+ * A client → server request frame: a versioned, correlated wrapper around a
+ * single frozen {@link dispatchRequestSchema}. The `direction` discriminator +
+ * flattened `request` payload mirror the supervisor-ipc envelope shape.
+ */
+export const GatewayRpcRequestFrameSchema = z
+  .object({
+    /** Frozen protocol version; rejected if it differs from the server's. */
+    protocol_version: z.string(),
+    /** Correlation id echoed back on the matching response/error frame. */
+    id: z.string().min(1),
+    /** Direction discriminator. */
+    direction: z.literal('request'),
+    /** The gateway dispatch request (re-validated at the untrusted boundary). */
+    request: dispatchRequestSchema,
+  })
+  .strict();
+
+/** Request frame (inferred from {@link GatewayRpcRequestFrameSchema}). */
+export type GatewayRpcRequestFrame = z.infer<typeof GatewayRpcRequestFrameSchema>;
+
+// ─── Response frame (server → client) ──────────────────────────────────────────
+
+/**
+ * A server → client response frame: a versioned, correlated wrapper around a
+ * single frozen {@link dispatchResponseSchema} (the LAFS envelope the handler
+ * produced).
+ */
+export const GatewayRpcResponseFrameSchema = z
+  .object({
+    /** Frozen protocol version. */
+    protocol_version: z.string(),
+    /** Correlation id echoed from the originating request. */
+    id: z.string().min(1),
+    /** Direction discriminator. */
+    direction: z.literal('response'),
+    /** The gateway dispatch response (LAFS envelope). */
+    response: dispatchResponseSchema,
+  })
+  .strict();
+
+/** Response frame (inferred from {@link GatewayRpcResponseFrameSchema}). */
+export type GatewayRpcResponseFrame = z.infer<typeof GatewayRpcResponseFrameSchema>;
+
+// ─── Error frame (server → client) ─────────────────────────────────────────────
+
+/**
+ * A server → client protocol-level error frame, emitted when a request frame
+ * cannot be decoded or routed. Correlation `id` is best-effort (`'0'` when the
+ * frame was so malformed the id could not be recovered).
+ */
+export const GatewayRpcErrorFrameSchema = z
+  .object({
+    /** Frozen protocol version. */
+    protocol_version: z.string(),
+    /** Correlation id (best-effort; `'0'` when unrecoverable). */
+    id: z.string().min(1),
+    /** Direction discriminator. */
+    direction: z.literal('error'),
+    /** The protocol-level error. */
+    error: GatewayRpcErrorSchema,
+  })
+  .strict();
+
+/** Error frame (inferred from {@link GatewayRpcErrorFrameSchema}). */
+export type GatewayRpcErrorFrame = z.infer<typeof GatewayRpcErrorFrameSchema>;
+
+// ─── Top-level frame union ─────────────────────────────────────────────────────
+
+/**
+ * The top-level RPC frame: a versioned, correlated wrapper that is a request,
+ * a response, or a protocol-level error, discriminated by `direction`. One
+ * frame per NDJSON line.
+ */
+export const GatewayRpcFrameSchema = z.discriminatedUnion('direction', [
+  GatewayRpcRequestFrameSchema,
+  GatewayRpcResponseFrameSchema,
+  GatewayRpcErrorFrameSchema,
+]);
+
+/** Any RPC frame (inferred from {@link GatewayRpcFrameSchema}). */
+export type GatewayRpcFrame = z.infer<typeof GatewayRpcFrameSchema>;
+
+// ─── Frozen direction-set guard ────────────────────────────────────────────────
+
+/**
+ * The FROZEN v1.0 `direction` discriminator values. The drift guard
+ * (`__tests__/freeze.test.ts`) pins this tuple; any addition/removal is a
+ * contract-breaking change requiring a new versioned directory.
+ */
+export const GATEWAY_RPC_DIRECTIONS = ['request', 'response', 'error'] as const;
+
+/** A single frozen RPC frame direction. */
+export type GatewayRpcDirection = (typeof GATEWAY_RPC_DIRECTIONS)[number];
+
+/**
+ * The FROZEN v1.0 protocol-level transport error codes the adapter emits in an
+ * {@link GatewayRpcErrorFrameSchema}. Pinned by the drift guard.
+ */
+export const GATEWAY_RPC_ERROR_CODES = [
+  'E_RPC_PARSE',
+  'E_RPC_BAD_VERSION',
+  'E_RPC_BAD_FRAME',
+  'E_RPC_INTERNAL',
+] as const;
+
+/** A single frozen RPC protocol-level error code. */
+export type GatewayRpcErrorCode = (typeof GATEWAY_RPC_ERROR_CODES)[number];
+
+/**
+ * Type guard: is `v` the frozen RPC protocol version this contract pins?
+ *
+ * Used by the adapter's version-negotiation step to reject mismatched frames
+ * with an `E_RPC_BAD_VERSION` error frame before any gateway routing.
+ *
+ * @param v - The candidate `protocol_version` string from an inbound frame.
+ * @returns `true` iff `v` equals {@link GATEWAY_RPC_PROTOCOL_VERSION}.
+ */
+export function isFrozenGatewayRpcVersion(v: string): v is typeof GATEWAY_RPC_PROTOCOL_VERSION {
+  return v === GATEWAY_RPC_PROTOCOL_VERSION;
+}

--- a/packages/contracts/src/gateway/rpc/version.ts
+++ b/packages/contracts/src/gateway/rpc/version.ts
@@ -1,0 +1,40 @@
+/**
+ * FROZEN protocol version for the `gateway/rpc` v1.0 wire contract.
+ *
+ * The CLI-RPC transport adapter (`@cleocode/runtime/gateway/rpc`) and any RPC
+ * client MUST agree on this value. The wire format is newline-delimited JSON
+ * (NDJSON): one {@link GatewayRpcFrame} per line over a unix-domain socket —
+ * the same framing discipline as the FROZEN `supervisor-ipc` v1.0 contract
+ * (`packages/contracts/src/supervisor-ipc/`), but a SEPARATE message set: this
+ * carries `DispatchRequest`/`DispatchResponse` over the gateway, not supervisor
+ * process-control messages.
+ *
+ * Bump only via a new major contract revision in a new directory, never edit
+ * this value in place — see {@link GATEWAY_RPC_MESSAGE_KINDS} for the frozen
+ * v1.0 message set.
+ *
+ * @see {@link https://datatracker.ietf.org/doc/html/rfc7464 | NDJSON framing}
+ * @task T11449
+ * @epic T11254
+ * @saga T11243
+ * @packageDocumentation
+ */
+
+/**
+ * The frozen `gateway/rpc` protocol version string.
+ *
+ * Both the TS drift test (`__tests__/freeze.test.ts`) and the adapter's
+ * version-negotiation handshake pin this exact value. A frame whose
+ * `protocol_version` differs from this is rejected with an `error` frame.
+ */
+export const GATEWAY_RPC_PROTOCOL_VERSION = '1.0.0' as const;
+
+/**
+ * Default base name for the RPC unix-socket channel.
+ *
+ * Callers resolve the concrete socket path under the CLEO home (e.g.
+ * `<cleoHome>/<basename>.sock`); the adapter itself takes the resolved path so
+ * the runtime stays free of any `@cleocode/paths` dependency. Mirrors
+ * {@link SUPERVISOR_IPC_CHANNEL_BASENAME} from the supervisor-ipc contract.
+ */
+export const GATEWAY_RPC_CHANNEL_BASENAME = 'cleo-gateway-rpc' as const;

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -21,6 +21,10 @@
     "./gateway/mcp": {
       "types": "./dist/gateway/mcp/index.d.ts",
       "import": "./dist/gateway/mcp/index.js"
+    },
+    "./gateway/rpc": {
+      "types": "./dist/gateway/rpc/index.d.ts",
+      "import": "./dist/gateway/rpc/index.js"
     }
   },
   "scripts": {

--- a/packages/runtime/src/gateway/index.ts
+++ b/packages/runtime/src/gateway/index.ts
@@ -88,6 +88,20 @@ export {
   resolve,
   validateRequiredParams,
 } from './registry.js';
+// CLI-RPC transport adapter (R3-T5 · T11449) — thin NDJSON-over-unix-socket
+// server over the gateway. Also reachable via the `@cleocode/runtime/gateway/rpc`
+// subpath. Reuses the FROZEN supervisor-ipc NDJSON framing discipline.
+export {
+  buildErrorFrame,
+  type DecodeResult,
+  decodeLine,
+  encodeFrame,
+  LineBuffer,
+  type RpcServerHandle,
+  type RpcServerOptions,
+  routeFrame,
+  startRpcServer,
+} from './rpc/index.js';
 
 /**
  * Transport-agnostic gateway entrypoint. Wraps a configured {@link Dispatcher}

--- a/packages/runtime/src/gateway/rpc/__tests__/rpc-adapter.test.ts
+++ b/packages/runtime/src/gateway/rpc/__tests__/rpc-adapter.test.ts
@@ -1,0 +1,247 @@
+/**
+ * CLI-RPC transport adapter tests (R3-T5 · T11449).
+ *
+ * Asserts:
+ *  1. The NDJSON codec decodes a valid request frame, and emits the correct
+ *     protocol-level error frame for parse errors, bad versions, malformed
+ *     frames, and wrong-direction frames — the supervisor-ipc framing pattern
+ *     applied to gateway frames.
+ *  2. The LineBuffer reassembles arbitrary chunk boundaries into complete lines.
+ *  3. routeFrame maps a request frame → a `source: 'rpc'` DispatchRequest routed
+ *     through the injected GatewayHandler, FORCING source even if the client
+ *     lied, and traps thrown handler errors as E_RPC_INTERNAL frames.
+ *  4. A full unix-socket round-trip: encode → socket → decode → dispatch →
+ *     response frame, proving no behavior change across transports.
+ *
+ * The core logger factory is mocked so the adapter can be exercised without
+ * initializing the real pino transport.
+ *
+ * @task T11449
+ * @epic T11254
+ * @saga T11243
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { connect } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DispatchRequest, DispatchResponse } from '@cleocode/contracts/gateway';
+import {
+  GATEWAY_RPC_PROTOCOL_VERSION,
+  type GatewayRpcErrorFrame,
+  type GatewayRpcFrame,
+  type GatewayRpcRequestFrame,
+  type GatewayRpcResponseFrame,
+} from '@cleocode/contracts/gateway/rpc';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import type { GatewayHandler } from '../../index.js';
+
+vi.mock('@cleocode/core', () => ({
+  getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const { decodeLine, encodeFrame, LineBuffer } = await import('../codec.js');
+const { routeFrame, startRpcServer } = await import('../server.js');
+
+/** A reusable valid request frame builder. */
+function requestFrame(overrides?: Partial<DispatchRequest>): GatewayRpcRequestFrame {
+  return {
+    protocol_version: GATEWAY_RPC_PROTOCOL_VERSION,
+    id: 'req-1',
+    direction: 'request',
+    request: {
+      gateway: 'query',
+      domain: 'tasks',
+      operation: 'show',
+      params: { id: 'T1' },
+      source: 'rpc',
+      requestId: 'req-1',
+      ...overrides,
+    },
+  };
+}
+
+/** A fake gateway handler that records the request and echoes a success envelope. */
+function fakeHandler(): { handler: GatewayHandler; calls: DispatchRequest[] } {
+  const calls: DispatchRequest[] = [];
+  const handler: GatewayHandler = {
+    handle(req: DispatchRequest): Promise<DispatchResponse> {
+      calls.push(req);
+      return Promise.resolve({
+        meta: {
+          gateway: req.gateway,
+          domain: req.domain,
+          operation: req.operation,
+          timestamp: '2026-05-31T00:00:00.000Z',
+          duration_ms: 1,
+          source: req.source,
+          requestId: req.requestId,
+        },
+        success: true,
+        data: { ok: true },
+      });
+    },
+  };
+  return { handler, calls };
+}
+
+describe('R3-T5 RPC codec — NDJSON decode (supervisor-ipc pattern)', () => {
+  it('decodes a valid request frame', () => {
+    const line = JSON.stringify(requestFrame());
+    const result = decodeLine(line);
+    expect(result.kind).toBe('request');
+    if (result.kind === 'request') {
+      expect(result.frame.request.operation).toBe('show');
+    }
+  });
+
+  it('emits E_RPC_PARSE for invalid JSON', () => {
+    const result = decodeLine('{not json');
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.frame.error.code).toBe('E_RPC_PARSE');
+      expect(result.frame.id).toBe('0');
+    }
+  });
+
+  it('emits E_RPC_BAD_VERSION for a mismatched protocol version (and correlates the id)', () => {
+    const frame = requestFrame();
+    const bad = { ...frame, protocol_version: '2.0.0' };
+    const result = decodeLine(JSON.stringify(bad));
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.frame.error.code).toBe('E_RPC_BAD_VERSION');
+      expect(result.frame.id).toBe('req-1');
+    }
+  });
+
+  it('emits E_RPC_BAD_FRAME for a schema-invalid frame', () => {
+    const result = decodeLine(JSON.stringify({ id: 'x', direction: 'request', request: {} }));
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.frame.error.code).toBe('E_RPC_BAD_FRAME');
+      expect(result.frame.id).toBe('x');
+    }
+  });
+
+  it('rejects a non-request direction reaching the server', () => {
+    const responseFrame = {
+      protocol_version: GATEWAY_RPC_PROTOCOL_VERSION,
+      id: 'r',
+      direction: 'response',
+      response: {
+        meta: {
+          gateway: 'query',
+          domain: 'tasks',
+          operation: 'show',
+          timestamp: 't',
+          duration_ms: 1,
+          source: 'rpc',
+          requestId: 'r',
+        },
+        success: true,
+      },
+    };
+    const result = decodeLine(JSON.stringify(responseFrame));
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.frame.error.code).toBe('E_RPC_BAD_FRAME');
+    }
+  });
+});
+
+describe('R3-T5 RPC codec — LineBuffer chunk reassembly', () => {
+  it('yields complete lines across arbitrary chunk boundaries', () => {
+    const buf = new LineBuffer();
+    expect(buf.push('{"a":1}\n{"b":')).toEqual(['{"a":1}']);
+    expect(buf.push('2}\n')).toEqual(['{"b":2}']);
+  });
+
+  it('skips blank lines and buffers a partial trailing line', () => {
+    const buf = new LineBuffer();
+    expect(buf.push('\n\n{"a":1}')).toEqual([]);
+    expect(buf.push('\n')).toEqual(['{"a":1}']);
+  });
+});
+
+describe('R3-T5 RPC routeFrame — gateway routing', () => {
+  it('maps a request frame → source:rpc DispatchRequest through the handler', async () => {
+    const { handler, calls } = fakeHandler();
+    const out = await routeFrame(handler, requestFrame());
+    expect(calls).toHaveLength(1);
+    expect(calls[0].source).toBe('rpc');
+    expect(calls[0].domain).toBe('tasks');
+    expect(out.direction).toBe('response');
+    if (out.direction === 'response') {
+      expect((out as GatewayRpcResponseFrame).response.success).toBe(true);
+    }
+  });
+
+  it('FORCES source to rpc even when the client claims a different transport', async () => {
+    const { handler, calls } = fakeHandler();
+    // Build a frame whose request.source lies as 'cli'.
+    const frame = requestFrame({ source: 'cli' });
+    await routeFrame(handler, frame);
+    expect(calls[0].source).toBe('rpc');
+  });
+
+  it('renders a thrown handler error as an E_RPC_INTERNAL frame (no throw / no exit)', async () => {
+    const handler: GatewayHandler = { handle: () => Promise.reject(new Error('boom')) };
+    const out = await routeFrame(handler, requestFrame());
+    expect(out.direction).toBe('error');
+    if (out.direction === 'error') {
+      expect((out as GatewayRpcErrorFrame).error.code).toBe('E_RPC_INTERNAL');
+      expect((out as GatewayRpcErrorFrame).error.message).toContain('boom');
+    }
+  });
+});
+
+describe('R3-T5 RPC server — full unix-socket round-trip', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'cleo-rpc-'));
+  const socketPath = join(dir, 'gw.sock');
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('encode → socket → decode → dispatch → response frame', async () => {
+    const { handler, calls } = fakeHandler();
+    const srv = await startRpcServer(handler, { socketPath });
+    try {
+      const response = await roundTrip(socketPath, requestFrame());
+      expect(response.direction).toBe('response');
+      if (response.direction === 'response') {
+        expect(response.id).toBe('req-1');
+        expect(response.response.success).toBe(true);
+        expect(response.response.meta.source).toBe('rpc');
+      }
+      expect(calls).toHaveLength(1);
+      expect(calls[0].source).toBe('rpc');
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+/**
+ * Open the socket, write one NDJSON request frame, and resolve with the first
+ * response frame the server writes back.
+ */
+function roundTrip(socketPath: string, frame: GatewayRpcRequestFrame): Promise<GatewayRpcFrame> {
+  return new Promise<GatewayRpcFrame>((resolve, reject) => {
+    const client = connect(socketPath);
+    const buf = new LineBuffer();
+    client.setEncoding('utf8');
+    client.on('connect', () => {
+      client.write(`${JSON.stringify(frame)}\n`);
+    });
+    client.on('data', (chunk: string) => {
+      for (const line of buf.push(chunk)) {
+        client.end();
+        resolve(JSON.parse(line) as GatewayRpcFrame);
+        return;
+      }
+    });
+    client.on('error', reject);
+  });
+}

--- a/packages/runtime/src/gateway/rpc/__tests__/rpc-bench.test.ts
+++ b/packages/runtime/src/gateway/rpc/__tests__/rpc-bench.test.ts
@@ -1,0 +1,117 @@
+/**
+ * CLI-RPC round-trip micro-benchmark (R3-T5 · T11449 · AC4).
+ *
+ * Measures the end-to-end latency of the NDJSON encode → unix-socket → decode →
+ * dispatch → response path against a trivial fake handler, isolating the
+ * TRANSPORT cost (framing + socket I/O + zod validation) from any real domain
+ * work. Asserts a generous ceiling so the bench stays green in slow CI yet
+ * still fails on a pathological regression (e.g. accidental per-frame sync
+ * fs work). The measured mean is logged to stderr for the PR report.
+ *
+ * @task T11449
+ * @epic T11254
+ * @saga T11243
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { connect } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DispatchRequest, DispatchResponse } from '@cleocode/contracts/gateway';
+import { GATEWAY_RPC_PROTOCOL_VERSION } from '@cleocode/contracts/gateway/rpc';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import type { GatewayHandler } from '../../index.js';
+
+vi.mock('@cleocode/core', () => ({
+  getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const { LineBuffer } = await import('../codec.js');
+const { startRpcServer } = await import('../server.js');
+
+/** A trivial echo handler — isolates transport cost from domain work. */
+const handler: GatewayHandler = {
+  handle(req: DispatchRequest): Promise<DispatchResponse> {
+    return Promise.resolve({
+      meta: {
+        gateway: req.gateway,
+        domain: req.domain,
+        operation: req.operation,
+        timestamp: '2026-05-31T00:00:00.000Z',
+        duration_ms: 0,
+        source: req.source,
+        requestId: req.requestId,
+      },
+      success: true,
+      data: { ok: true },
+    });
+  },
+};
+
+describe('R3-T5 RPC round-trip micro-benchmark (AC4)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'cleo-rpc-bench-'));
+  const socketPath = join(dir, 'bench.sock');
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('serial round-trips stay under the transport latency ceiling', async () => {
+    const srv = await startRpcServer(handler, { socketPath });
+    const ITERATIONS = 500;
+    try {
+      // Single persistent connection — the warm-daemon usage pattern.
+      const client = connect(socketPath);
+      const buf = new LineBuffer();
+      await new Promise<void>((resolve, reject) => {
+        client.setEncoding('utf8');
+        client.once('connect', resolve);
+        client.once('error', reject);
+      });
+
+      // A pending-resolver queue keyed by FIFO order (serial requests).
+      const pending: Array<() => void> = [];
+      client.on('data', (chunk: string) => {
+        for (const _line of buf.push(chunk)) {
+          const resolveNext = pending.shift();
+          if (resolveNext) resolveNext();
+        }
+      });
+
+      const start = process.hrtime.bigint();
+      for (let i = 0; i < ITERATIONS; i++) {
+        await new Promise<void>((resolve) => {
+          pending.push(resolve);
+          const frame = {
+            protocol_version: GATEWAY_RPC_PROTOCOL_VERSION,
+            id: `b-${i}`,
+            direction: 'request',
+            request: {
+              gateway: 'query',
+              domain: 'tasks',
+              operation: 'show',
+              params: { id: 'T1' },
+              source: 'rpc',
+              requestId: `b-${i}`,
+            },
+          };
+          client.write(`${JSON.stringify(frame)}\n`);
+        });
+      }
+      const elapsedNs = Number(process.hrtime.bigint() - start);
+      const meanMs = elapsedNs / 1e6 / ITERATIONS;
+      client.end();
+
+      // Report for the PR body.
+      process.stderr.write(
+        `\n[T11449 AC4] RPC round-trip mean: ${meanMs.toFixed(4)} ms/op over ${ITERATIONS} serial ops (single warm connection)\n`,
+      );
+
+      // Generous ceiling: a unix-socket round-trip with zod validate should be
+      // well under 5ms even on slow CI; a regression to sync-fs-per-frame blows past this.
+      expect(meanMs).toBeLessThan(5);
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/packages/runtime/src/gateway/rpc/codec.ts
+++ b/packages/runtime/src/gateway/rpc/codec.ts
@@ -1,0 +1,188 @@
+/**
+ * NDJSON codec for the CLI-RPC transport.
+ *
+ * Implements the SAME framing discipline as the FROZEN `supervisor-ipc` v1.0
+ * contract — one zod-validated JSON envelope per newline-delimited line, with
+ * an explicit `protocol_version` negotiation step — but for the gateway-RPC
+ * frame set (`@cleocode/contracts/gateway/rpc`). The supervisor-ipc module is
+ * frozen and is NOT edited; this codec re-applies its pattern.
+ *
+ * The codec is intentionally socket-agnostic: it owns line buffering, JSON
+ * parse, zod decode, and version negotiation, returning typed results the
+ * server maps onto `node:net` reads/writes. This keeps the parse/validate logic
+ * unit-testable without binding a real socket.
+ *
+ * @task T11449
+ * @epic T11254
+ * @saga T11243
+ */
+
+import {
+  GATEWAY_RPC_PROTOCOL_VERSION,
+  type GatewayRpcErrorCode,
+  type GatewayRpcErrorFrame,
+  type GatewayRpcFrame,
+  GatewayRpcFrameSchema,
+  type GatewayRpcRequestFrame,
+  type GatewayRpcResponseFrame,
+  isFrozenGatewayRpcVersion,
+} from '@cleocode/contracts/gateway/rpc';
+
+/** Newline delimiter for the NDJSON wire (mirrors supervisor-ipc). */
+const NEWLINE = '\n';
+
+/**
+ * Encode any RPC frame to a single NDJSON line (JSON + trailing `\n`).
+ *
+ * @param frame - The response or error frame to serialize.
+ * @returns A newline-terminated JSON string ready to write to the socket.
+ */
+export function encodeFrame(frame: GatewayRpcResponseFrame | GatewayRpcErrorFrame): string {
+  return `${JSON.stringify(frame)}${NEWLINE}`;
+}
+
+/**
+ * Build a protocol-level error frame.
+ *
+ * @param id - Correlation id (`'0'` when the originating frame's id is unknown).
+ * @param code - One of the frozen {@link GatewayRpcErrorCode} values.
+ * @param message - Human-readable detail.
+ * @returns A fully-formed {@link GatewayRpcErrorFrame}.
+ */
+export function buildErrorFrame(
+  id: string,
+  code: GatewayRpcErrorCode,
+  message: string,
+): GatewayRpcErrorFrame {
+  return {
+    protocol_version: GATEWAY_RPC_PROTOCOL_VERSION,
+    id,
+    direction: 'error',
+    error: { code, message },
+  };
+}
+
+/**
+ * The discriminated outcome of decoding a single inbound NDJSON line.
+ *
+ * - `request` — a valid, version-matched request frame ready to route.
+ * - `error`   — a protocol-level error frame the server should write straight
+ *               back (parse failure, version mismatch, or malformed frame). The
+ *               server never routes these to the gateway.
+ */
+export type DecodeResult =
+  | { kind: 'request'; frame: GatewayRpcRequestFrame }
+  | { kind: 'error'; frame: GatewayRpcErrorFrame };
+
+/**
+ * Decode + validate a single inbound NDJSON line into a routable request or a
+ * protocol-level error frame.
+ *
+ * Steps (the supervisor-ipc pattern, applied to gateway frames):
+ *  1. JSON parse — failure → `E_RPC_PARSE`.
+ *  2. zod decode against {@link GatewayRpcFrameSchema} — failure → `E_RPC_BAD_FRAME`.
+ *  3. version negotiation via {@link isFrozenGatewayRpcVersion} —
+ *     mismatch → `E_RPC_BAD_VERSION`.
+ *  4. direction must be `request` (a server never receives response/error
+ *     frames) — otherwise → `E_RPC_BAD_FRAME`.
+ *
+ * The best-effort correlation `id` is recovered from the raw JSON when possible
+ * so the client can match the error to its request even on a decode failure.
+ *
+ * @param line - One trimmed NDJSON line (no trailing newline).
+ * @returns A {@link DecodeResult}.
+ */
+export function decodeLine(line: string): DecodeResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(line);
+  } catch {
+    return { kind: 'error', frame: buildErrorFrame('0', 'E_RPC_PARSE', 'invalid JSON line') };
+  }
+
+  // Best-effort id recovery for error correlation before full validation.
+  const recoveredId = recoverId(raw);
+
+  const parsed = GatewayRpcFrameSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      kind: 'error',
+      frame: buildErrorFrame(recoveredId, 'E_RPC_BAD_FRAME', 'frame failed schema validation'),
+    };
+  }
+
+  const frame: GatewayRpcFrame = parsed.data;
+
+  if (!isFrozenGatewayRpcVersion(frame.protocol_version)) {
+    return {
+      kind: 'error',
+      frame: buildErrorFrame(
+        frame.id,
+        'E_RPC_BAD_VERSION',
+        `unsupported protocol version ${frame.protocol_version}; server speaks ${GATEWAY_RPC_PROTOCOL_VERSION}`,
+      ),
+    };
+  }
+
+  if (frame.direction !== 'request') {
+    return {
+      kind: 'error',
+      frame: buildErrorFrame(
+        frame.id,
+        'E_RPC_BAD_FRAME',
+        `server cannot accept a ${frame.direction} frame`,
+      ),
+    };
+  }
+
+  return { kind: 'request', frame };
+}
+
+/**
+ * Recover a best-effort correlation id from raw decoded JSON, used so a
+ * validation failure can still be correlated to the client's request.
+ *
+ * @param raw - The result of `JSON.parse` on the inbound line.
+ * @returns The string `id` if present and non-empty, else `'0'`.
+ */
+function recoverId(raw: unknown): string {
+  if (raw && typeof raw === 'object' && 'id' in raw) {
+    const id = (raw as { id: unknown }).id;
+    if (typeof id === 'string' && id.length > 0) return id;
+  }
+  return '0';
+}
+
+/**
+ * A streaming line splitter for the NDJSON wire.
+ *
+ * `node:net` sockets deliver arbitrary chunk boundaries; a single `data` event
+ * may carry a partial line or several lines. This buffer accumulates bytes and
+ * yields only complete lines (split on `\n`), matching the supervisor-ipc
+ * client's `readline`-style framing without depending on `readline` (so it can
+ * be driven directly off socket chunks).
+ */
+export class LineBuffer {
+  /** Pending bytes that have not yet completed a line. */
+  private buffer = '';
+
+  /**
+   * Push a decoded UTF-8 chunk; return every complete line it completes.
+   *
+   * @param chunk - A UTF-8 string chunk from the socket.
+   * @returns Zero or more complete lines (trailing newline stripped, blanks
+   *   skipped).
+   */
+  push(chunk: string): string[] {
+    this.buffer += chunk;
+    const lines: string[] = [];
+    let idx = this.buffer.indexOf(NEWLINE);
+    while (idx !== -1) {
+      const line = this.buffer.slice(0, idx).trim();
+      this.buffer = this.buffer.slice(idx + 1);
+      if (line.length > 0) lines.push(line);
+      idx = this.buffer.indexOf(NEWLINE);
+    }
+    return lines;
+  }
+}

--- a/packages/runtime/src/gateway/rpc/index.ts
+++ b/packages/runtime/src/gateway/rpc/index.ts
@@ -1,0 +1,31 @@
+/**
+ * `@cleocode/runtime/gateway/rpc` — the CLI-RPC transport adapter.
+ *
+ * A thin unix-socket RPC adapter over the unified gateway. It serves
+ * newline-delimited JSON (NDJSON) {@link GatewayRpcFrame}s over a long-lived
+ * unix-domain socket and maps every `request` frame onto a `source: 'rpc'`
+ * gateway request routed through an injected {@link GatewayHandler} (built with
+ * `createGatewayHandler`).
+ *
+ * Mirrors the `@cleocode/runtime/gateway/mcp` adapter structurally (server +
+ * codec + types + barrel) and reuses the FROZEN `supervisor-ipc` NDJSON framing
+ * discipline — versioned, correlated, one frame per line — without editing that
+ * frozen module. It carries NO `@cleocode/cleo` dependency and NO drizzle-orm.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/gateway/rpc
+ *
+ * @task T11449
+ * @epic T11254
+ * @saga T11243
+ */
+
+export {
+  buildErrorFrame,
+  type DecodeResult,
+  decodeLine,
+  encodeFrame,
+  LineBuffer,
+} from './codec.js';
+export { routeFrame, startRpcServer } from './server.js';
+export type { RpcServerHandle, RpcServerOptions } from './types.js';

--- a/packages/runtime/src/gateway/rpc/server.ts
+++ b/packages/runtime/src/gateway/rpc/server.ts
@@ -1,0 +1,202 @@
+/**
+ * CLI-RPC unix-socket transport adapter — routes NDJSON frames through the gateway.
+ *
+ * Serves the gateway over a long-lived unix-domain socket using newline-delimited
+ * JSON (NDJSON): one zod-validated {@link GatewayRpcFrame} per line. Any local
+ * client (the `cleo` CLI talking to a warm daemon, Studio's server process, a
+ * test harness) can open the socket, write `request` frames, and read back
+ * `response`/`error` frames — without paying the per-invocation cold-start of
+ * spawning a fresh `cleo` process.
+ *
+ * This is the THIRD transport adapter, mirroring the just-merged MCP stdio
+ * adapter (`packages/runtime/src/gateway/mcp/`):
+ *
+ *   RPC request frame { direction:'request', request:{…} }
+ *     → decode + validate (`@cleocode/contracts/gateway/rpc`)
+ *     → DispatchRequest { source: 'rpc', … }  (re-validated at the boundary)
+ *     → injected {@link GatewayHandler}.handle()
+ *     → DispatchResponse (LAFS envelope)  →  RPC response frame
+ *
+ * The adapter owns ONLY wire concerns: socket lifecycle, line framing, version
+ * negotiation, error rendering, and per-connection cleanup. All domain logic
+ * (resolution, validation, middleware, handler execution) lives behind the
+ * {@link GatewayHandler} — exactly mirroring the CLI and MCP adapters. There is
+ * NO `process.exit` and NO error-render inside the handlers (R3 contract); the
+ * adapter never calls `process.exit` at all (lifecycle is the caller's).
+ *
+ * The request `source` is forced to `'rpc'` regardless of what the client sent,
+ * so a client cannot impersonate another transport.
+ *
+ * @task T11449
+ * @epic T11254
+ * @saga T11243
+ */
+
+import { existsSync, unlinkSync } from 'node:fs';
+import { createServer, type Socket } from 'node:net';
+import type { DispatchRequest } from '@cleocode/contracts/gateway';
+import type {
+  GatewayRpcRequestFrame,
+  GatewayRpcResponseFrame,
+} from '@cleocode/contracts/gateway/rpc';
+import { GATEWAY_RPC_PROTOCOL_VERSION } from '@cleocode/contracts/gateway/rpc';
+import { getLogger } from '@cleocode/core';
+import type { GatewayHandler } from '../index.js';
+import { buildErrorFrame, decodeLine, encodeFrame, LineBuffer } from './codec.js';
+import type { RpcServerHandle, RpcServerOptions } from './types.js';
+
+/**
+ * Route a single decoded request frame through the gateway handler and build
+ * the correlated response frame.
+ *
+ * The request's `source` is forced to `'rpc'`; the frame `id` is reused as the
+ * response correlation id (and, when the client omitted a `requestId` shaped
+ * for tracing, the frame id flows through as the dispatch `requestId`). Thrown
+ * handler errors are caught and rendered as a protocol-level `E_RPC_INTERNAL`
+ * error frame — never propagated as an unhandled rejection or `process.exit`.
+ *
+ * @param handler - The injected transport-neutral gateway handler.
+ * @param frame - A validated, version-matched request frame.
+ * @returns The response or error frame to write back on the same connection.
+ */
+export async function routeFrame(
+  handler: GatewayHandler,
+  frame: GatewayRpcRequestFrame,
+): Promise<GatewayRpcResponseFrame | ReturnType<typeof buildErrorFrame>> {
+  const request: DispatchRequest = {
+    ...frame.request,
+    // Force the transport of origin — a client cannot impersonate cli/mcp/http.
+    source: 'rpc',
+    requestId: frame.request.requestId,
+  };
+
+  try {
+    const response = await handler.handle(request);
+    return {
+      protocol_version: GATEWAY_RPC_PROTOCOL_VERSION,
+      id: frame.id,
+      direction: 'response',
+      response,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return buildErrorFrame(frame.id, 'E_RPC_INTERNAL', message);
+  }
+}
+
+/**
+ * Handle a single client connection: buffer NDJSON lines, decode each, route
+ * request frames through the gateway, and write back response/error frames.
+ *
+ * Each connection owns its own {@link LineBuffer}, so partial-line chunk
+ * boundaries are reassembled per socket. Frames are processed concurrently;
+ * each correlated response carries the originating frame `id`, so the client
+ * can demultiplex out-of-order completions.
+ *
+ * @param handler - The injected gateway handler.
+ * @param socket - The accepted `node:net` connection.
+ * @param log - The adapter's pino logger.
+ */
+function handleConnection(
+  handler: GatewayHandler,
+  socket: Socket,
+  log: ReturnType<typeof getLogger>,
+): void {
+  socket.setEncoding('utf8');
+  const lines = new LineBuffer();
+
+  socket.on('data', (chunk: string) => {
+    for (const line of lines.push(chunk)) {
+      const decoded = decodeLine(line);
+      if (decoded.kind === 'error') {
+        socket.write(encodeFrame(decoded.frame));
+        continue;
+      }
+      routeFrame(handler, decoded.frame)
+        .then((out) => {
+          if (!socket.destroyed) socket.write(encodeFrame(out));
+        })
+        .catch((err: unknown) => {
+          // routeFrame already traps handler errors; this guards the framing path.
+          const message = err instanceof Error ? err.message : String(err);
+          log.warn({ err }, 'rpc frame routing failed');
+          if (!socket.destroyed) {
+            socket.write(encodeFrame(buildErrorFrame(decoded.frame.id, 'E_RPC_INTERNAL', message)));
+          }
+        });
+    }
+  });
+
+  socket.on('error', (err) => {
+    log.warn({ err }, 'rpc connection error');
+  });
+}
+
+/**
+ * Start the CLI-RPC unix-socket server over the gateway.
+ *
+ * Binds {@link RpcServerOptions.socketPath}, accepts connections, and routes
+ * each inbound NDJSON `request` frame through the injected {@link GatewayHandler}.
+ * The caller assembles the handler (via `createGatewayHandler` with its domain
+ * handlers + middleware) and injects it here — this adapter never builds
+ * handlers itself, keeping the runtime free of any `@cleocode/cleo` dependency.
+ *
+ * Returns once the socket is listening. The returned {@link RpcServerHandle}
+ * exposes an idempotent `close()` for deterministic teardown (daemon shutdown,
+ * tests). The adapter never calls `process.exit`.
+ *
+ * @param handler - The transport-neutral gateway handler to route through.
+ * @param opts - Socket path + lifecycle options.
+ * @returns A promise resolving to the live {@link RpcServerHandle}.
+ */
+export function startRpcServer(
+  handler: GatewayHandler,
+  opts: RpcServerOptions,
+): Promise<RpcServerHandle> {
+  const log = getLogger('gateway-rpc');
+  const removeStale = opts.removeStaleSocket ?? true;
+
+  if (removeStale && existsSync(opts.socketPath)) {
+    try {
+      unlinkSync(opts.socketPath);
+    } catch (err) {
+      log.warn({ err, socketPath: opts.socketPath }, 'failed to unlink stale rpc socket');
+    }
+  }
+
+  const server = createServer((socket) => handleConnection(handler, socket, log));
+
+  return new Promise<RpcServerHandle>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(opts.socketPath, () => {
+      server.removeListener('error', reject);
+      log.info(
+        { socketPath: opts.socketPath, version: GATEWAY_RPC_PROTOCOL_VERSION },
+        'rpc server listening',
+      );
+
+      let closed = false;
+      const handle: RpcServerHandle = {
+        server,
+        socketPath: opts.socketPath,
+        close(): Promise<void> {
+          if (closed) return Promise.resolve();
+          closed = true;
+          return new Promise<void>((res) => {
+            server.close(() => {
+              if (existsSync(opts.socketPath)) {
+                try {
+                  unlinkSync(opts.socketPath);
+                } catch {
+                  // best-effort cleanup; the OS reclaims the node on exit anyway.
+                }
+              }
+              res();
+            });
+          });
+        },
+      };
+      resolve(handle);
+    });
+  });
+}

--- a/packages/runtime/src/gateway/rpc/types.ts
+++ b/packages/runtime/src/gateway/rpc/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Wire + lifecycle types for the `@cleocode/runtime/gateway/rpc` adapter.
+ *
+ * The RPC wire frames themselves are defined (zod) in
+ * `@cleocode/contracts/gateway/rpc`; this module holds only the
+ * runtime-adapter-local option/handle shapes (no external dependency, mirroring
+ * the MCP adapter's `types.ts`).
+ *
+ * @task T11449
+ * @epic T11254
+ * @saga T11243
+ */
+
+import type { Server } from 'node:net';
+
+/**
+ * Options for {@link startRpcServer}.
+ *
+ * Mirrors the MCP adapter's `McpServerOptions` shape (a transport-local options
+ * bag), adapted for a connection-oriented unix-socket server rather than a
+ * single stdio stream.
+ */
+export interface RpcServerOptions {
+  /**
+   * Absolute path to the unix-domain socket to bind. The caller resolves this
+   * (e.g. under the CLEO home using
+   * {@link GATEWAY_RPC_CHANNEL_BASENAME}) so the runtime stays free of any
+   * `@cleocode/paths` dependency.
+   */
+  socketPath: string;
+  /**
+   * Whether to `unlink` a stale socket file at {@link socketPath} before
+   * binding. Defaults to `true` (a crashed prior server leaves a stale node).
+   */
+  removeStaleSocket?: boolean;
+}
+
+/**
+ * A live RPC server handle returned by {@link startRpcServer}.
+ *
+ * Exposes the bound {@link Server} and an idempotent {@link close} so callers
+ * (daemon, tests) can tear down deterministically. The adapter never calls
+ * `process.exit` — lifecycle stays with the caller (R3 contract).
+ */
+export interface RpcServerHandle {
+  /** The bound `node:net` server. */
+  server: Server;
+  /** Absolute path of the bound unix socket. */
+  socketPath: string;
+  /** Close the server + all live connections; resolves once fully closed. */
+  close(): Promise<void>;
+}

--- a/packages/runtime/tsup.config.ts
+++ b/packages/runtime/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "daemon/index": "src/daemon/index.ts",
     "gateway/index": "src/gateway/index.ts",
     "gateway/mcp/index": "src/gateway/mcp/index.ts",
+    "gateway/rpc/index": "src/gateway/rpc/index.ts",
   },
   format: ["esm"],
   target: "node20",


### PR DESCRIPTION
## R3-T5 · T11449 — CLI-RPC transport adapter

The **third transport adapter** over the unified gateway, structurally mirroring the just-merged MCP adapter (`packages/runtime/src/gateway/mcp/`). A long-lived **unix-socket RPC server** decodes zod-validated **NDJSON** frames into a `GatewayRequest{source:'rpc'}`, routes them through the injected gateway handler (`createGatewayHandler` in `@cleocode/runtime/gateway`), and writes NDJSON response frames back — letting a local client (a warm `cleo` daemon, Studio's server, a test harness) skip the per-invocation cold-start of spawning a fresh `cleo` process.

### How the rpc contract reuses the supervisor-ipc NDJSON pattern (without editing it)
The new `@cleocode/contracts/gateway/rpc` mirrors the FROZEN `supervisor-ipc` v1.0 contract's **structure** — `version.ts` (frozen `GATEWAY_RPC_PROTOCOL_VERSION='1.0.0'` + channel basename) + `messages.ts` (zod frame schemas) + `__tests__/freeze.test.ts` (drift guard) — and reapplies its **framing discipline**: a versioned, correlation-id'd envelope discriminated by `direction`, one frame per newline. The supervisor-ipc module is **untouched** (its `freeze.test.ts` stays green). The difference is the **payload**: rpc frames wrap the frozen gateway `DispatchRequest`/`DispatchResponse` (from `@cleocode/contracts/gateway`, R3-T2), re-validated at the untrusted RPC boundary, rather than supervisor process-control messages.

### Per-AC checklist
- [x] **Unix-socket RPC server** (`node:net`) under `@cleocode/runtime/gateway/rpc` — `startRpcServer(handler, {socketPath})` → idempotent `RpcServerHandle.close()`.
- [x] **NDJSON codec** reusing the supervisor-ipc pattern — `LineBuffer` chunk reassembly, `decodeLine` (parse → zod → version-negotiate → direction-check), `encodeFrame`.
- [x] **Routes through `createGatewayHandler`** — `routeFrame` builds `source:'rpc'` `DispatchRequest`, **forces** source (no transport impersonation), traps thrown handler errors as `E_RPC_INTERNAL` frames.
- [x] **Own rpc message contract in `@cleocode/contracts`** (`gateway/rpc/`) with a frozen version constant + freeze guard, mirroring supervisor-ipc; supervisor-ipc NOT edited.
- [x] **Runtime invariants** — NO `@cleocode/cleo` dep, NO drizzle-orm; `process.exit`/error-render stay in the adapter, not handlers (adapter never calls `process.exit`).
- [x] **Subpath wired** — exported from `gateway/index.ts`; `./gateway/rpc` added to runtime `package.json` + `tsup.config.ts` (mirrors MCP).
- [x] **AC4 benchmark** — see below.
- [x] **Transport-inventory golden test** updated: rpc adapter now exists, http still pending (R3-T6).

### AC4 benchmark
**0.0314 ms/op** mean round-trip (encode → unix-socket → decode → dispatch → response frame) over **500 serial ops on a single warm connection** (trivial echo handler, isolating transport cost). Runs in CI as `rpc-bench.test.ts` with a 5 ms regression ceiling; the measured mean is logged to stderr.

### Validation results
| Gate | Result | Key line |
|------|--------|----------|
| `pnpm run typecheck` (`tsc -b`) | **PASS** | exit 0, zero errors |
| Cold build + CLI smoke | **PASS** | `node build.mjs` clean → `cli/index.js version` → `{"success":true,...}` |
| Full `@cleocode/contracts` suite | **PASS** | 734 passed (50 files) — **no snapshot drift** |
| `@cleocode/contracts` rpc freeze | **PASS** | 10 passed |
| `@cleocode/runtime` rpc adapter + bench | **PASS** | 12 passed |
| transport-inventory golden | **PASS** | assertions verified standalone (cleo vitest config broken locally per briefing) |
| `cleo check arch` | **PASS** | 5/5 |
| contracts-purity (Gate 10) + contract-literal-enums | **PASS** | no net-new runtime helper; `isFrozenGatewayRpcVersion` is a type guard |
| tools-vs-skills + publish-surface + contracts-dep | **PASS** | unchanged baselines |
| `pnpm biome check` | **PASS** | clean |
| End-to-end real-socket run | **PASS** | source forced to rpc · params preserved · id correlated |

The 17 `@cleocode/core` failures are the **documented stale-napi `worktree-*` flakes** (`"integrateWorktree not available in test fallback"`) — CI-green, untouched by this change. No contract/gateway/dispatch/runtime test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)