### PR TITLE
feat(T11450): Studio HTTP+SSE adapter under @cleocode/runtime/gateway/http (R3-T6 · SG-RUNTIME-UNIFICATION)

### DIFF
--- a/.changeset/t11450-http-sse-gateway-adapter.md
+++ b/.changeset/t11450-http-sse-gateway-adapter.md
@@ -1,0 +1,15 @@
+---
+id: t11450-http-sse-gateway-adapter
+tasks: [T11450]
+kind: feat
+summary: Build @cleocode/runtime/gateway/http as the fourth and final gateway transport adapter — framework-agnostic unary (POST → JSON LAFS) + SSE (GatewayStreamEvent) over the unified gateway — and route the two Studio SSE endpoints through its shared abort-safe stream builder with a byte-identical wire
+---
+
+Add `@cleocode/runtime/gateway/http` — the HTTP transport adapter over the unified gateway (R3-T6), completing the four-transport set (CLI · MCP · RPC · HTTP). It serves two modes:
+
+- **Unary**: `routeUnary(handler, req)` builds a `source: 'http'` `DispatchRequest` from the embedder-resolved `(gateway, domain, operation, params)` triple, routes it through an injected `GatewayHandler` (built via `createGatewayHandler`), and returns `{ status, body }` — the LAFS envelope plus an HTTP status mapped from the LAFS error code (`statusForResponse`). The request `source` is always forced to `'http'`; thrown handler errors are trapped as a `500 E_HTTP_INTERNAL` envelope (no throw, no `process.exit`).
+- **SSE**: `createSseStream(source, signal?)` is a shared, abort-safe `ReadableStream` builder that streams `GatewayStreamEvent` frames (the streaming type from `@cleocode/contracts/gateway`) for long-running/subscription ops. Frames are dropped (never throw) after close, the source teardown runs exactly once, and the request `AbortSignal` closes the stream on client disconnect. `encodeStreamEvent` / `encodeSseFrame` own the SSE wire bytes.
+
+Unlike the connection-oriented MCP/RPC adapters, the HTTP adapter is **framework-agnostic**: it binds no port and owns no `Request`/`Response` lifecycle, so the embedder (a SvelteKit route, the daemon HTTP server, a test harness) supplies the operation coordinates and serializes the result. `@cleocode/runtime` retains NO `@cleocode/cleo` dependency, NO SvelteKit dependency, and NO drizzle-orm.
+
+The two live Studio SSE endpoints (`/api/brain/stream`, `/api/tasks/events`) now route their stream lifecycle through `createSseStream`, sharing one tested abort-safe builder while preserving their exact observable wire (brain/stream stays `data: <json>\n\n` via its own `sseEncode`; tasks/events keeps named `event:` frames). Event ordering and shape are unchanged — the existing brain/stream SSE handler test suite stays green.

--- a/packages/cleo/src/dispatch/__tests__/transport-inventory.test.ts
+++ b/packages/cleo/src/dispatch/__tests__/transport-inventory.test.ts
@@ -135,12 +135,12 @@ describe('R3-T1 transport inventory — topology invariants', () => {
     expect(JSON.parse(readFileSync(pkgPath, 'utf8')).name).toBe('@cleocode/adapters');
   });
 
-  it('the rpc transport now has its adapter (R3-T5 · T11449); http is still pending (R3-T6)', () => {
+  it('all four transports now have their adapters (R3-T4 mcp · T5 rpc · T6 http)', () => {
     expect(GATEWAY_SOURCES).toContain('rpc');
     expect(GATEWAY_SOURCES).toContain('http');
     // R3-T5 (T11449) landed the CLI-RPC adapter under the runtime gateway.
     expect(existsSync(join(REPO_ROOT, 'packages/runtime/src/gateway/rpc'))).toBe(true);
-    // http remains contract-declared but adapter-less until R3-T6.
-    expect(existsSync(join(REPO_ROOT, 'packages/runtime/src/gateway/http'))).toBe(false);
+    // R3-T6 (T11450) landed the HTTP unary + SSE adapter under the runtime gateway.
+    expect(existsSync(join(REPO_ROOT, 'packages/runtime/src/gateway/http'))).toBe(true);
   });
 });

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -25,6 +25,10 @@
     "./gateway/rpc": {
       "types": "./dist/gateway/rpc/index.d.ts",
       "import": "./dist/gateway/rpc/index.js"
+    },
+    "./gateway/http": {
+      "types": "./dist/gateway/http/index.d.ts",
+      "import": "./dist/gateway/http/index.js"
     }
   },
   "scripts": {

--- a/packages/runtime/src/gateway/http/__tests__/http-adapter.test.ts
+++ b/packages/runtime/src/gateway/http/__tests__/http-adapter.test.ts
@@ -1,0 +1,250 @@
+/**
+ * HTTP transport adapter tests (R3-T6 · T11450).
+ *
+ * Asserts:
+ *  1. routeUnary maps an HTTP request → a `source: 'http'` DispatchRequest routed
+ *     through the injected GatewayHandler, FORCING source even if the caller lied,
+ *     and traps thrown handler errors as a 500 E_HTTP_INTERNAL envelope (no throw,
+ *     no exit).
+ *  2. statusForResponse maps the LAFS error code → the correct HTTP status.
+ *  3. The SSE encoders produce the exact wire bytes for both the canonical
+ *     GatewayStreamEvent (`data:`-only) and a bespoke named-`event:` frame, so an
+ *     existing stream can adopt the plumbing without changing its bytes.
+ *  4. createSseStream drives an SseSource, drops frames after close, runs teardown
+ *     exactly once, and closes on the request AbortSignal.
+ *
+ * The core logger factory is not used by the HTTP adapter (framework-agnostic, no
+ * port binding) so no mock is required — mirroring the lean RPC adapter test.
+ *
+ * @task T11450
+ * @epic T11254
+ * @saga T11243
+ */
+
+import type {
+  DispatchRequest,
+  DispatchResponse,
+  GatewayStreamEvent,
+} from '@cleocode/contracts/gateway';
+import { describe, expect, it, vi } from 'vitest';
+import type { GatewayHandler } from '../../index.js';
+import { routeUnary, statusForResponse } from '../server.js';
+import { createSseStream, encodeSseFrame, encodeStreamEvent } from '../sse.js';
+import type { HttpUnaryRequest } from '../types.js';
+
+/** A reusable valid unary request builder. */
+function unaryRequest(overrides?: Partial<HttpUnaryRequest>): HttpUnaryRequest {
+  return {
+    gateway: 'query',
+    domain: 'tasks',
+    operation: 'show',
+    params: { id: 'T1' },
+    requestId: 'req-1',
+    ...overrides,
+  };
+}
+
+/** A fake gateway handler that records the request and echoes a success envelope. */
+function fakeHandler(): { handler: GatewayHandler; calls: DispatchRequest[] } {
+  const calls: DispatchRequest[] = [];
+  const handler: GatewayHandler = {
+    handle(req: DispatchRequest): Promise<DispatchResponse> {
+      calls.push(req);
+      return Promise.resolve({
+        meta: {
+          gateway: req.gateway,
+          domain: req.domain,
+          operation: req.operation,
+          timestamp: '2026-05-31T00:00:00.000Z',
+          duration_ms: 1,
+          source: req.source,
+          requestId: req.requestId,
+        },
+        success: true,
+        data: { ok: true },
+      });
+    },
+  };
+  return { handler, calls };
+}
+
+describe('R3-T6 HTTP routeUnary — gateway routing', () => {
+  it('maps a request → source:http DispatchRequest through the handler', async () => {
+    const { handler, calls } = fakeHandler();
+    const out = await routeUnary(handler, unaryRequest());
+    expect(calls).toHaveLength(1);
+    expect(calls[0].source).toBe('http');
+    expect(calls[0].domain).toBe('tasks');
+    expect(calls[0].requestId).toBe('req-1');
+    expect(out.status).toBe(200);
+    expect(out.body.success).toBe(true);
+  });
+
+  it('FORCES source to http even when the caller claims a different transport', async () => {
+    const { handler, calls } = fakeHandler();
+    // The HttpUnaryRequest has no `source` field, but the resulting dispatch
+    // request must always be http; assert the produced envelope's meta.source.
+    const out = await routeUnary(handler, unaryRequest());
+    expect(calls[0].source).toBe('http');
+    expect(out.body.meta.source).toBe('http');
+  });
+
+  it('mints a requestId when the caller omits one', async () => {
+    const { handler, calls } = fakeHandler();
+    await routeUnary(handler, unaryRequest({ requestId: undefined }));
+    expect(typeof calls[0].requestId).toBe('string');
+    expect(calls[0].requestId.length).toBeGreaterThan(0);
+  });
+
+  it('renders a thrown handler error as a 500 E_HTTP_INTERNAL envelope (no throw / no exit)', async () => {
+    const handler: GatewayHandler = { handle: () => Promise.reject(new Error('boom')) };
+    const out = await routeUnary(handler, unaryRequest());
+    expect(out.status).toBe(500);
+    expect(out.body.success).toBe(false);
+    expect(out.body.error?.code).toBe('E_HTTP_INTERNAL');
+    expect(out.body.error?.message).toContain('boom');
+  });
+});
+
+describe('R3-T6 HTTP statusForResponse — LAFS error → HTTP status', () => {
+  function errResponse(code: string): DispatchResponse {
+    return {
+      meta: {
+        gateway: 'query',
+        domain: 'd',
+        operation: 'o',
+        timestamp: 't',
+        duration_ms: 0,
+        source: 'http',
+        requestId: 'r',
+      },
+      success: false,
+      error: { code, message: 'x' },
+    };
+  }
+
+  it('200 on success', () => {
+    const ok = { ...errResponse('E_X'), success: true, error: undefined };
+    expect(statusForResponse(ok)).toBe(200);
+  });
+
+  it('404 for E_NOT_FOUND', () => {
+    expect(statusForResponse(errResponse('E_NOT_FOUND'))).toBe(404);
+  });
+
+  it('400 for validation errors', () => {
+    expect(statusForResponse(errResponse('E_VALIDATION_FAILED'))).toBe(400);
+  });
+
+  it('403 for E_FORBIDDEN', () => {
+    expect(statusForResponse(errResponse('E_FORBIDDEN'))).toBe(403);
+  });
+
+  it('429 for rate limiting', () => {
+    expect(statusForResponse(errResponse('E_RATE_LIMITED'))).toBe(429);
+  });
+
+  it('500 for an unmapped error code', () => {
+    expect(statusForResponse(errResponse('E_SOMETHING_ELSE'))).toBe(500);
+  });
+});
+
+describe('R3-T6 HTTP SSE encoders — exact wire bytes', () => {
+  it('encodes a GatewayStreamEvent as a data:-only record with seq as id', () => {
+    const ev: GatewayStreamEvent = { kind: 'data', seq: 3, data: { n: 1 }, requestId: 'r' };
+    const wire = encodeStreamEvent(ev);
+    expect(wire).toBe(`id: 3\ndata: ${JSON.stringify(ev)}\n\n`);
+  });
+
+  it('reproduces a named-event frame byte-for-byte (event: name\\ndata: json\\n\\n)', () => {
+    const wire = encodeSseFrame({ event: 'task-updated', data: { ts: 'x' } });
+    expect(wire).toBe('event: task-updated\ndata: {"ts":"x"}\n\n');
+  });
+
+  it('reproduces a data:-only frame byte-for-byte (no event field)', () => {
+    const wire = encodeSseFrame({ data: { type: 'hello', ts: 'x' } });
+    expect(wire).toBe('data: {"type":"hello","ts":"x"}\n\n');
+  });
+});
+
+describe('R3-T6 HTTP SSE createSseStream — lifecycle', () => {
+  /** Read the full text of a stream until it closes. */
+  async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let text = '';
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+    return text;
+  }
+
+  it('emits frames pushed by the source and runs teardown exactly once', async () => {
+    const teardown = vi.fn();
+    const stream = createSseStream((emitter) => {
+      emitter.sendStreamEvent({ kind: 'data', seq: 0, data: { a: 1 }, requestId: 'r' });
+      emitter.sendStreamEvent({ kind: 'done', seq: 1, data: { ok: true }, requestId: 'r' });
+      emitter.close();
+      return teardown;
+    });
+
+    const text = await drain(stream);
+    expect(text).toContain('"kind":"data"');
+    expect(text).toContain('"kind":"done"');
+    expect(text).toContain('id: 0');
+    expect(text).toContain('id: 1');
+    expect(teardown).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops frames pushed after close (no throw)', async () => {
+    let lateEmitter: { send: (f: { data: unknown }) => void } | undefined;
+    const stream = createSseStream((emitter) => {
+      emitter.send({ data: { first: true } });
+      emitter.close();
+      lateEmitter = emitter;
+      return undefined;
+    });
+
+    const text = await drain(stream);
+    expect(text).toContain('"first":true');
+    // Pushing after close is a silent no-op and never throws.
+    expect(() => lateEmitter?.send({ data: { late: true } })).not.toThrow();
+    expect(text).not.toContain('"late":true');
+  });
+
+  it('closes the stream on the request AbortSignal and runs teardown', async () => {
+    const teardown = vi.fn();
+    const controller = new AbortController();
+    const stream = createSseStream((emitter) => {
+      emitter.send({ data: { type: 'hello' } });
+      return teardown;
+    }, controller.signal);
+
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    const first = await reader.read();
+    expect(decoder.decode(first.value)).toContain('"hello"');
+
+    controller.abort();
+    const next = await reader.read();
+    expect(next.done).toBe(true);
+    expect(teardown).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes immediately if the signal is already aborted', async () => {
+    const teardown = vi.fn();
+    const controller = new AbortController();
+    controller.abort();
+    const stream = createSseStream((emitter) => {
+      emitter.send({ data: { type: 'hello' } });
+      return teardown;
+    }, controller.signal);
+
+    const text = await drain(stream);
+    // Source never ran (closed before start completed) → no frames, no teardown.
+    expect(text).toBe('');
+    expect(teardown).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime/src/gateway/http/index.ts
+++ b/packages/runtime/src/gateway/http/index.ts
@@ -1,0 +1,40 @@
+/**
+ * `@cleocode/runtime/gateway/http` — the HTTP transport adapter.
+ *
+ * The fourth and final gateway transport adapter (after CLI, MCP, RPC). Serves
+ * the unified gateway over HTTP in two modes:
+ *
+ *   - UNARY: a `POST <op>` with a JSON body → `source: 'http'` gateway request
+ *     routed through an injected {@link GatewayHandler} (built with
+ *     `createGatewayHandler`) → JSON LAFS envelope ({@link routeUnary}).
+ *   - SSE: a `GET` streaming endpoint that emits {@link GatewayStreamEvent}
+ *     frames (the streaming type in `@cleocode/contracts/gateway`) over a
+ *     `text/event-stream` body, built with the abort-safe {@link createSseStream}
+ *     primitive.
+ *
+ * Mirrors the `@cleocode/runtime/gateway/{mcp,rpc}` adapters structurally
+ * (server + wire helpers + types + barrel) but is framework-agnostic: it owns NO
+ * port binding and NO `Request`/`Response` lifecycle, so the embedder (a
+ * SvelteKit route, the daemon HTTP server, a test harness) supplies the resolved
+ * operation coordinates and serializes the result. It carries NO
+ * `@cleocode/cleo` dependency, NO SvelteKit dependency, and NO drizzle-orm.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/gateway/http
+ *
+ * @task T11450
+ * @epic T11254
+ * @saga T11243
+ */
+
+export { routeUnary, statusForResponse } from './server.js';
+export {
+  createSseStream,
+  encodeSseFrame,
+  encodeStreamEvent,
+  SSE_HEADERS,
+  type SseEmitter,
+  type SseFrame,
+  type SseSource,
+} from './sse.js';
+export type { HttpUnaryRequest, HttpUnaryResult } from './types.js';

--- a/packages/runtime/src/gateway/http/server.ts
+++ b/packages/runtime/src/gateway/http/server.ts
@@ -1,0 +1,116 @@
+/**
+ * HTTP transport adapter — serves gateway unary + SSE over HTTP.
+ *
+ * The fourth and final gateway transport (after CLI, MCP, RPC). Unlike the
+ * connection-oriented RPC/MCP adapters, the HTTP adapter is framework-agnostic
+ * by design: it does NOT bind a port or own a `Request`/`Response` lifecycle.
+ * Instead it exposes two pure routing primitives the embedder (a SvelteKit
+ * route handler, the daemon's HTTP server, a test harness) calls directly:
+ *
+ *   - {@link routeUnary} — one POST → `source: 'http'` {@link DispatchRequest}
+ *     → injected {@link GatewayHandler} → `{ status, body }` (LAFS envelope).
+ *   - the SSE primitives in `./sse.js` (`createSseStream`) for streaming ops.
+ *
+ * This keeps the runtime free of any HTTP-server / SvelteKit / `@cleocode/cleo`
+ * dependency: the embedder owns wire concerns (parsing the URL into a
+ * `(gateway, domain, operation)` triple, setting headers, `process.exit`,
+ * error-render at the edge), exactly mirroring how the CLI adapter wraps the
+ * same handler. There is NO `process.exit` and NO error-render in the handlers
+ * (R3 contract); the adapter never calls `process.exit` at all.
+ *
+ * The request `source` is forced to `'http'` regardless of what the embedder
+ * passes, so a client cannot impersonate another transport.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/gateway/http
+ *
+ * @task T11450
+ * @epic T11254
+ * @saga T11243
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { DispatchRequest, DispatchResponse } from '@cleocode/contracts/gateway';
+import type { GatewayHandler } from '../index.js';
+import type { HttpUnaryRequest, HttpUnaryResult } from './types.js';
+
+/**
+ * Map a LAFS dispatch error code to an HTTP status code.
+ *
+ * The canonical machine-readable error code (`E_NOT_FOUND`, `E_VALIDATION_…`,
+ * `E_FORBIDDEN`, …) is the source of truth; the numeric LAFS exit code is a
+ * secondary hint. Unknown error codes fall back to `500`. A successful envelope
+ * is always `200`.
+ *
+ * @param response - The dispatch response.
+ * @returns The HTTP status the embedder should set.
+ */
+export function statusForResponse(response: DispatchResponse): number {
+  if (response.success) return 200;
+  const code = response.error?.code ?? '';
+  if (code === 'E_NOT_FOUND' || code.endsWith('_NOT_FOUND')) return 404;
+  if (code === 'E_UNAUTHORIZED' || code === 'E_AUTH_REQUIRED') return 401;
+  if (code === 'E_FORBIDDEN') return 403;
+  if (code === 'E_RATE_LIMITED' || code === 'E_RATE_LIMIT_EXCEEDED') return 429;
+  if (
+    code === 'E_VALIDATION' ||
+    code.startsWith('E_VALIDATION') ||
+    code === 'E_INVALID_INPUT' ||
+    code === 'E_BAD_REQUEST'
+  ) {
+    return 400;
+  }
+  if (code === 'E_NOT_IMPLEMENTED' || code === 'E_UNSUPPORTED') return 501;
+  return 500;
+}
+
+/**
+ * Route a single HTTP unary request through the gateway handler.
+ *
+ * Builds a `source: 'http'` {@link DispatchRequest} from the embedder-resolved
+ * `(gateway, domain, operation, params)` triple and delegates to the injected
+ * {@link GatewayHandler}. A thrown handler error is trapped and rendered as a
+ * `500` LAFS error envelope — never propagated as an unhandled rejection or
+ * `process.exit`. The `source` is always forced to `'http'`.
+ *
+ * @param handler - The injected transport-neutral gateway handler.
+ * @param req - The embedder-resolved unary request coordinates + body params.
+ * @returns The HTTP status + LAFS response body for the embedder to serialize.
+ */
+export async function routeUnary(
+  handler: GatewayHandler,
+  req: HttpUnaryRequest,
+): Promise<HttpUnaryResult> {
+  const requestId = req.requestId ?? randomUUID();
+  const request: DispatchRequest = {
+    gateway: req.gateway,
+    domain: req.domain,
+    operation: req.operation,
+    params: req.params,
+    // Force the transport of origin — a client cannot impersonate cli/mcp/rpc.
+    source: 'http',
+    requestId,
+    sessionId: req.sessionId,
+  };
+
+  try {
+    const body = await handler.handle(request);
+    return { status: statusForResponse(body), body };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const body: DispatchResponse = {
+      meta: {
+        gateway: req.gateway,
+        domain: req.domain,
+        operation: req.operation,
+        timestamp: new Date().toISOString(),
+        duration_ms: 0,
+        source: 'http',
+        requestId,
+      },
+      success: false,
+      error: { code: 'E_HTTP_INTERNAL', message },
+    };
+    return { status: 500, body };
+  }
+}

--- a/packages/runtime/src/gateway/http/sse.ts
+++ b/packages/runtime/src/gateway/http/sse.ts
@@ -1,0 +1,251 @@
+/**
+ * Server-Sent Events (SSE) wire primitives for the `@cleocode/runtime/gateway/http`
+ * adapter.
+ *
+ * The HTTP transport is the only gateway transport that streams: long-running
+ * and subscription operations emit a sequence of {@link GatewayStreamEvent}
+ * frames terminated by a `done` or `error` frame. This module owns ONLY the SSE
+ * wire encoding + the `ReadableStream` lifecycle plumbing; the actual frame
+ * production (polling a DB, tailing a job, etc.) lives in the caller's async
+ * source. Keeping the encode/stream concern here lets BOTH the gateway-routed
+ * streaming ops AND the existing Studio SSE endpoints (which carry their own
+ * domain event shapes) share one tested, leak-free stream builder.
+ *
+ * Two encoders are provided so an existing stream can adopt this plumbing
+ * WITHOUT changing its observed bytes:
+ *  - {@link encodeStreamEvent} — the canonical `data: <json>\n\n` form for
+ *    {@link GatewayStreamEvent} frames (gateway-routed streaming ops).
+ *  - {@link encodeSseFrame} — a generic `event:`/`id:`/`data:` writer for any
+ *    payload, so endpoints with a bespoke wire (a named `event:` field, a
+ *    `data:`-only frame) keep an IDENTICAL byte stream while still routing their
+ *    lifecycle through the shared, abort-safe builder.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/gateway/http/sse
+ *
+ * @task T11450
+ * @epic T11254
+ * @saga T11243
+ */
+
+import type { GatewayStreamEvent } from '@cleocode/contracts/gateway';
+
+/** SSE field/record delimiter constants (the SSE wire is line-oriented). */
+const LF = '\n';
+/** A blank line terminates an SSE record (`\n\n`). */
+const RECORD_END = '\n\n';
+
+/**
+ * One generic SSE frame: an optional named `event`, an optional `id`, and a
+ * `data` payload that is JSON-serialized.
+ *
+ * This is intentionally NOT {@link GatewayStreamEvent} — it is the raw wire
+ * shape so a bespoke endpoint can reproduce its exact existing bytes (e.g. a
+ * named `event: task-updated` line, or a `data:`-only frame with no `event`).
+ */
+export interface SseFrame {
+  /** Optional SSE `event:` field name (omitted → a `data:`-only frame). */
+  event?: string;
+  /** Optional SSE `id:` field for client-side last-event-id resumption. */
+  id?: string;
+  /** The frame payload; JSON-serialized into the `data:` field. */
+  data: unknown;
+}
+
+/**
+ * Encode a generic {@link SseFrame} to its SSE wire bytes.
+ *
+ * Field order is `event:` (if present) → `id:` (if present) → `data:`, matching
+ * the SSE spec record layout, then a blank line. When `event` is omitted the
+ * frame is a `data:`-only record — byte-identical to a handwritten
+ * `data: <json>\n\n`.
+ *
+ * @param frame - The frame to serialize.
+ * @returns The SSE record as a string (UTF-8 caller-encoded).
+ */
+export function encodeSseFrame(frame: SseFrame): string {
+  let out = '';
+  if (frame.event !== undefined) out += `event: ${frame.event}${LF}`;
+  if (frame.id !== undefined) out += `id: ${frame.id}${LF}`;
+  out += `data: ${JSON.stringify(frame.data)}${RECORD_END}`;
+  return out;
+}
+
+/**
+ * Encode a canonical {@link GatewayStreamEvent} as a `data:`-only SSE record.
+ *
+ * Gateway-routed streaming ops carry the discriminator + sequence inside the
+ * JSON payload (`{ kind, seq, data, error, requestId }`), so no named SSE
+ * `event:` field is used — the client demultiplexes on `kind`/`seq`. The
+ * monotonic `seq` is also surfaced as the SSE `id:` so a reconnecting client can
+ * send `Last-Event-ID`.
+ *
+ * @param frame - The gateway stream event to serialize.
+ * @returns The SSE record as a string.
+ */
+export function encodeStreamEvent(frame: GatewayStreamEvent): string {
+  return encodeSseFrame({ id: String(frame.seq), data: frame });
+}
+
+/** The standard SSE response headers (no caching, no proxy buffering). */
+export const SSE_HEADERS: Readonly<Record<string, string>> = Object.freeze({
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  Connection: 'keep-alive',
+  'X-Accel-Buffering': 'no',
+});
+
+/**
+ * A push-style SSE controller handed to an {@link SseSource} so it can emit
+ * frames and close the stream without touching the underlying
+ * `ReadableStreamDefaultController`.
+ */
+export interface SseEmitter {
+  /** Emit one generic SSE frame; a no-op once the stream is closed. */
+  send(frame: SseFrame): void;
+  /** Emit one canonical {@link GatewayStreamEvent}; a no-op once closed. */
+  sendStreamEvent(frame: GatewayStreamEvent): void;
+  /**
+   * Emit a pre-encoded SSE record verbatim; a no-op once closed. For endpoints
+   * that own their own wire encoder (e.g. a bespoke `data: <json>\n\n`) and want
+   * to keep emitting byte-identical records while still routing lifecycle
+   * through this builder.
+   */
+  sendRaw(record: string): void;
+  /** Whether the stream has been closed (client disconnect or `close()`). */
+  readonly closed: boolean;
+  /** Close the stream; idempotent. */
+  close(): void;
+}
+
+/**
+ * A teardown callback returned by an {@link SseSource}, invoked exactly once when
+ * the stream ends (client disconnect, `emitter.close()`, or producer completion).
+ */
+export type SseTeardown = () => void;
+
+/**
+ * A frame source for {@link createSseStream}. Receives an {@link SseEmitter} and
+ * MAY return an {@link SseTeardown} callback (return nothing to skip teardown).
+ *
+ * The source is started SYNCHRONOUSLY inside `ReadableStream.start`, mirroring
+ * the existing Studio endpoints (which schedule timers inside `start`). A source
+ * may push frames immediately and/or schedule async work.
+ */
+export type SseSource = (emitter: SseEmitter) => SseTeardown | undefined;
+
+/**
+ * Build a `text/event-stream` {@link ReadableStream} driven by an
+ * {@link SseSource}.
+ *
+ * This is the shared, abort-safe stream builder every SSE endpoint routes
+ * through. It guarantees:
+ *  - frames are dropped (never throw) after the stream closes;
+ *  - the source's teardown callback runs exactly once;
+ *  - an optional {@link AbortSignal} (the request's) closes the stream on client
+ *    disconnect, with its listener removed on teardown.
+ *
+ * The byte output is fully controlled by what the source emits — so an endpoint
+ * adopting this builder reproduces its prior wire exactly by emitting the same
+ * frames in the same order.
+ *
+ * @param source - The frame producer.
+ * @param signal - Optional request abort signal that closes the stream on
+ *   client disconnect.
+ * @returns A ReadableStream of UTF-8 SSE bytes for a `Response` body.
+ */
+export function createSseStream(
+  source: SseSource,
+  signal?: AbortSignal,
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    start(controller): void {
+      let closed = false;
+      /** Set once the source returns; invoked exactly once when the stream ends. */
+      let teardown: (() => void) | undefined;
+      /** Guards against running the source teardown more than once. */
+      let teardownDone = false;
+      /** True while `source(emitter)` is still executing synchronously. */
+      let sourceRunning = false;
+
+      const onAbort = (): void => emitter.close();
+
+      /** Invoke the source teardown at most once (no-op until the source returns). */
+      const runTeardown = (): void => {
+        if (teardownDone) return;
+        teardownDone = true;
+        if (typeof teardown === 'function') teardown();
+      };
+
+      const emitter: SseEmitter = {
+        get closed(): boolean {
+          return closed;
+        },
+        send(frame: SseFrame): void {
+          if (closed) return;
+          try {
+            controller.enqueue(encoder.encode(encodeSseFrame(frame)));
+          } catch {
+            emitter.close();
+          }
+        },
+        sendStreamEvent(frame: GatewayStreamEvent): void {
+          if (closed) return;
+          try {
+            controller.enqueue(encoder.encode(encodeStreamEvent(frame)));
+          } catch {
+            emitter.close();
+          }
+        },
+        sendRaw(record: string): void {
+          if (closed) return;
+          try {
+            controller.enqueue(encoder.encode(record));
+          } catch {
+            emitter.close();
+          }
+        },
+        close(): void {
+          if (closed) return;
+          closed = true;
+          if (signal) signal.removeEventListener('abort', onAbort);
+          // If the source closed synchronously mid-body, it has not yet returned
+          // its teardown — defer it to the post-return reconciliation below.
+          if (!sourceRunning) runTeardown();
+          try {
+            controller.close();
+          } catch {
+            // already closed by the runtime — nothing to do.
+          }
+        },
+      };
+
+      if (signal) {
+        if (signal.aborted) {
+          // Client already gone before we started — close immediately. The
+          // source is never invoked, so there is no teardown to run.
+          closed = true;
+          teardownDone = true;
+          try {
+            controller.close();
+          } catch {
+            // already closed.
+          }
+          return;
+        }
+        signal.addEventListener('abort', onAbort);
+      }
+
+      sourceRunning = true;
+      const returned = source(emitter);
+      teardown = typeof returned === 'function' ? returned : undefined;
+      sourceRunning = false;
+
+      // The source may have called `emitter.close()` synchronously before
+      // returning its teardown; run it now that the callback is in hand.
+      if (closed) runTeardown();
+    },
+  });
+}

--- a/packages/runtime/src/gateway/http/types.ts
+++ b/packages/runtime/src/gateway/http/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Wire + lifecycle types for the `@cleocode/runtime/gateway/http` adapter.
+ *
+ * The HTTP transport carries the SAME gateway payloads as every other transport
+ * — request/response shapes are owned by `@cleocode/contracts/gateway` (R3-T2 ·
+ * T11446) and the streaming frame by `GatewayStreamEvent`. This module holds
+ * only the runtime-adapter-local option/handle shapes (mirroring the MCP and RPC
+ * adapters' `types.ts`), so the runtime stays framework-agnostic and free of any
+ * `@cleocode/cleo` / SvelteKit / drizzle dependency.
+ *
+ * @task T11450
+ * @epic T11254
+ * @saga T11243
+ */
+
+import type { DispatchResponse, Gateway } from '@cleocode/contracts/gateway';
+
+/**
+ * Where on the wire the `(gateway, domain, operation)` triple of an HTTP unary
+ * request is sourced from. The adapter is framework-agnostic, so the embedder
+ * (SvelteKit route, daemon HTTP server, test harness) supplies the resolved
+ * coordinates explicitly rather than the adapter parsing a URL itself.
+ */
+export interface HttpUnaryRequest {
+  /** CQRS gateway — `'mutate'` (write) or `'query'` (read). */
+  gateway: Gateway;
+  /** Target canonical domain (e.g. `'tasks'`). */
+  domain: string;
+  /** Domain operation name (e.g. `'show'`). */
+  operation: string;
+  /** Decoded JSON request body → operation params. */
+  params?: Record<string, unknown>;
+  /**
+   * Optional caller-supplied request id for tracing. When omitted the adapter
+   * mints a fresh UUID.
+   */
+  requestId?: string;
+  /** Bound session id, if any (forwarded into the dispatch request). */
+  sessionId?: string;
+}
+
+/**
+ * The result of routing one HTTP unary request through the gateway: the LAFS
+ * {@link DispatchResponse} JSON body plus the HTTP status the embedder should
+ * set (200 on success, 4xx/5xx mapped from the dispatch error).
+ *
+ * The adapter never writes the response itself (no framework coupling) — it
+ * returns this so the embedder serializes it onto its own `Response`.
+ */
+export interface HttpUnaryResult {
+  /** HTTP status code derived from the dispatch outcome. */
+  status: number;
+  /** The LAFS envelope to serialize as the JSON response body. */
+  body: DispatchResponse;
+}

--- a/packages/runtime/src/gateway/index.ts
+++ b/packages/runtime/src/gateway/index.ts
@@ -46,6 +46,21 @@ export {
   STRING_TO_EXIT,
 } from './engine-error.js';
 export { mapNumericExitCodeToString } from './exit-codes.js';
+// HTTP transport adapter (R3-T6 · T11450) — framework-agnostic unary + SSE over
+// the gateway. Also reachable via the `@cleocode/runtime/gateway/http` subpath.
+export {
+  createSseStream,
+  encodeSseFrame,
+  encodeStreamEvent,
+  type HttpUnaryRequest,
+  type HttpUnaryResult,
+  routeUnary,
+  SSE_HEADERS,
+  type SseEmitter,
+  type SseFrame,
+  type SseSource,
+  statusForResponse,
+} from './http/index.js';
 export { getJobManager, setJobManager } from './job-manager-accessor.js';
 // MCP transport adapter (R3-T4 · T11448) — thin stdio JSON-RPC over the
 // gateway. Also reachable via the `@cleocode/runtime/gateway/mcp` subpath.

--- a/packages/runtime/tsup.config.ts
+++ b/packages/runtime/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "gateway/index": "src/gateway/index.ts",
     "gateway/mcp/index": "src/gateway/mcp/index.ts",
     "gateway/rpc/index": "src/gateway/rpc/index.ts",
+    "gateway/http/index": "src/gateway/http/index.ts",
   },
   format: ["esm"],
   target: "node20",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -27,6 +27,7 @@
     "@cleocode/brain": "workspace:*",
     "@cleocode/contracts": "workspace:*",
     "@cleocode/core": "workspace:*",
+    "@cleocode/runtime": "workspace:*",
     "loro-crdt": "*",
     "llmtxt": "^2026.5.15",
     "@ai-sdk/anthropic": "*",

--- a/packages/studio/src/routes/api/brain/stream/+server.ts
+++ b/packages/studio/src/routes/api/brain/stream/+server.ts
@@ -23,6 +23,7 @@
  */
 
 import type { BrainNode, BrainStreamEvent } from '@cleocode/brain';
+import { createSseStream, encodeSseFrame, SSE_HEADERS } from '@cleocode/runtime/gateway/http';
 import { getBrainDb, getConduitDb, getTasksDb } from '$lib/server/db/connections.js';
 import type { ProjectContext } from '$lib/server/project-context.js';
 import type { RequestHandler } from './$types';
@@ -84,13 +85,19 @@ interface MsgRow {
 // ---------------------------------------------------------------------------
 
 /**
- * Serialises an `BrainStreamEvent` to the `data: …\n\n` SSE wire format.
+ * Serialises a `BrainStreamEvent` to the `data: …\n\n` SSE wire format.
+ *
+ * Delegates to the shared `encodeSseFrame` primitive from the gateway HTTP
+ * adapter (R3-T6 · T11450) so this Studio stream and every gateway-routed SSE
+ * stream share one tested encoder. A `data:`-only frame (no `event:` field) is
+ * byte-identical to the prior handwritten `data: <json>\n\n` form, preserving
+ * the observable wire exactly.
  *
  * @param event - The event to encode.
  * @returns SSE-formatted string ready for the stream.
  */
 function sseEncode(event: BrainStreamEvent): string {
-  return `data: ${JSON.stringify(event)}\n\n`;
+  return encodeSseFrame({ data: event });
 }
 
 // ---------------------------------------------------------------------------
@@ -398,97 +405,62 @@ export const GET: RequestHandler = ({ locals, request }) => {
   const signal = request.signal;
   const projectCtx = locals.projectCtx;
 
-  const stream = new ReadableStream({
-    start(controller) {
-      /** Whether the stream has been closed (prevent double-close). */
-      let closed = false;
+  // Route the stream lifecycle through the shared gateway HTTP SSE primitive
+  // (R3-T6 · T11450). The observable wire is unchanged: every frame is emitted
+  // via `sseEncode` (→ `encodeSseFrame`), producing the same `data: <json>\n\n`
+  // bytes in the same order (hello first, then heartbeat/poll frames). The
+  // builder owns abort-on-disconnect + run-once teardown.
+  const stream = createSseStream((emitter) => {
+    /** Emit one BrainStreamEvent on the wire (drops after close, never throws). */
+    function emit(event: BrainStreamEvent): void {
+      emitter.sendRaw(sseEncode(event));
+    }
 
-      function close(): void {
-        if (closed) return;
-        closed = true;
-        try {
-          controller.close();
-        } catch {
-          // Already closed
-        }
+    // Initialise per-connection watermarks
+    const watermarks = initWatermarks(projectCtx);
+
+    // Send hello immediately
+    emit({ type: 'hello', ts: new Date().toISOString() });
+
+    // ---------------------------------------------------------------------------
+    // Heartbeat timer
+    // ---------------------------------------------------------------------------
+    const heartbeatTimer = setInterval(() => {
+      if (emitter.closed) {
+        clearInterval(heartbeatTimer);
+        return;
+      }
+      emit({ type: 'heartbeat', ts: new Date().toISOString() });
+    }, HEARTBEAT_INTERVAL_MS);
+
+    // ---------------------------------------------------------------------------
+    // Poll timer
+    // ---------------------------------------------------------------------------
+    const pollTimer = setInterval(() => {
+      if (emitter.closed) {
+        clearInterval(pollTimer);
+        return;
       }
 
-      // Abort on client disconnect
-      signal.addEventListener('abort', close);
+      const events: BrainStreamEvent[] = [
+        ...detectNewObservations(watermarks, projectCtx),
+        ...detectEdgeWeightChanges(watermarks, projectCtx),
+        ...detectTaskStatusChanges(watermarks, projectCtx),
+        ...detectNewMessages(watermarks, projectCtx),
+      ];
 
-      // Initialise per-connection watermarks
-      const watermarks = initWatermarks(projectCtx);
+      for (const event of events) {
+        if (emitter.closed) break;
+        emit(event);
+      }
+    }, POLL_INTERVAL_MS);
 
-      // Send hello immediately
-      controller.enqueue(
-        new TextEncoder().encode(sseEncode({ type: 'hello', ts: new Date().toISOString() })),
-      );
+    // Teardown: clear timers when the stream ends (client disconnect / close).
+    return () => {
+      clearInterval(heartbeatTimer);
+      clearInterval(pollTimer);
+    };
+  }, signal);
 
-      // ---------------------------------------------------------------------------
-      // Heartbeat timer
-      // ---------------------------------------------------------------------------
-      const heartbeatTimer = setInterval(() => {
-        if (closed) {
-          clearInterval(heartbeatTimer);
-          return;
-        }
-        try {
-          controller.enqueue(
-            new TextEncoder().encode(
-              sseEncode({ type: 'heartbeat', ts: new Date().toISOString() }),
-            ),
-          );
-        } catch {
-          clearInterval(heartbeatTimer);
-          close();
-        }
-      }, HEARTBEAT_INTERVAL_MS);
-
-      // ---------------------------------------------------------------------------
-      // Poll timer
-      // ---------------------------------------------------------------------------
-      const pollTimer = setInterval(() => {
-        if (closed) {
-          clearInterval(pollTimer);
-          return;
-        }
-
-        const events: BrainStreamEvent[] = [
-          ...detectNewObservations(watermarks, projectCtx),
-          ...detectEdgeWeightChanges(watermarks, projectCtx),
-          ...detectTaskStatusChanges(watermarks, projectCtx),
-          ...detectNewMessages(watermarks, projectCtx),
-        ];
-
-        for (const event of events) {
-          if (closed) break;
-          try {
-            controller.enqueue(new TextEncoder().encode(sseEncode(event)));
-          } catch {
-            clearInterval(pollTimer);
-            clearInterval(heartbeatTimer);
-            close();
-            return;
-          }
-        }
-      }, POLL_INTERVAL_MS);
-
-      // Ensure timers are cleared when stream is cancelled externally
-      return () => {
-        clearInterval(heartbeatTimer);
-        clearInterval(pollTimer);
-        signal.removeEventListener('abort', close);
-        close();
-      };
-    },
-  });
-
-  return new Response(stream, {
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-      'X-Accel-Buffering': 'no',
-    },
-  });
+  return new Response(stream, { headers: { ...SSE_HEADERS } });
 };

--- a/packages/studio/src/routes/api/tasks/events/+server.ts
+++ b/packages/studio/src/routes/api/tasks/events/+server.ts
@@ -5,82 +5,73 @@
  * the last updated_at timestamp changes.
  */
 
+import { createSseStream, SSE_HEADERS } from '@cleocode/runtime/gateway/http';
 import { getTasksDb } from '$lib/server/db/connections.js';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = ({ locals }) => {
-  const encoder = new TextEncoder();
+/** Poll interval (ms) for the tasks-events change detector. */
+const POLL_INTERVAL_MS = 2000;
+
+export const GET: RequestHandler = ({ locals, request }) => {
   const projectCtx = locals.projectCtx;
 
-  const stream = new ReadableStream({
-    start(controller) {
-      let lastUpdated = '';
-      let lastCount = 0;
-      let closed = false;
+  // Route the stream lifecycle through the shared gateway HTTP SSE primitive
+  // (R3-T6 · T11450). The observable wire is unchanged: named `event:` frames
+  // in the same order (connected first, then task-updated/heartbeat). The
+  // builder owns abort-on-disconnect + run-once teardown.
+  const stream = createSseStream((emitter) => {
+    let lastUpdated = '';
+    let lastCount = 0;
 
-      function send(event: string, data: unknown): void {
-        if (closed) return;
-        const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-        try {
-          controller.enqueue(encoder.encode(payload));
-        } catch {
-          closed = true;
-        }
+    /** Emit one named SSE event (drops after close, never throws). */
+    function send(event: string, data: unknown): void {
+      emitter.send({ event, data });
+    }
+
+    // Send initial connection acknowledgement
+    send('connected', { ts: new Date().toISOString() });
+
+    const interval = setInterval(() => {
+      if (emitter.closed) {
+        clearInterval(interval);
+        return;
       }
 
-      // Send initial connection acknowledgement
-      send('connected', { ts: new Date().toISOString() });
+      try {
+        const db = getTasksDb(projectCtx);
+        if (!db) return;
 
-      const interval = setInterval(() => {
-        if (closed) {
-          clearInterval(interval);
-          return;
+        const row = db
+          .prepare(
+            `SELECT MAX(updated_at) as latest, COUNT(*) as cnt FROM tasks WHERE status != 'archived'`,
+          )
+          .get() as { latest: string | null; cnt: number };
+
+        const latest = row?.latest ?? '';
+        const cnt = row?.cnt ?? 0;
+
+        if (latest !== lastUpdated || cnt !== lastCount) {
+          lastUpdated = latest;
+          lastCount = cnt;
+          send('task-updated', {
+            ts: new Date().toISOString(),
+            latestChange: latest,
+            activeCount: cnt,
+          });
+        } else {
+          // Send heartbeat to keep connection alive
+          send('heartbeat', { ts: new Date().toISOString() });
         }
+      } catch {
+        // DB temporarily unavailable — skip this tick
+      }
+    }, POLL_INTERVAL_MS);
 
-        try {
-          const db = getTasksDb(projectCtx);
-          if (!db) return;
+    // Teardown: clear the poll timer when the stream ends.
+    return () => {
+      clearInterval(interval);
+    };
+  }, request.signal);
 
-          const row = db
-            .prepare(
-              `SELECT MAX(updated_at) as latest, COUNT(*) as cnt FROM tasks WHERE status != 'archived'`,
-            )
-            .get() as { latest: string | null; cnt: number };
-
-          const latest = row?.latest ?? '';
-          const cnt = row?.cnt ?? 0;
-
-          if (latest !== lastUpdated || cnt !== lastCount) {
-            lastUpdated = latest;
-            lastCount = cnt;
-            send('task-updated', {
-              ts: new Date().toISOString(),
-              latestChange: latest,
-              activeCount: cnt,
-            });
-          } else {
-            // Send heartbeat to keep connection alive
-            send('heartbeat', { ts: new Date().toISOString() });
-          }
-        } catch {
-          // DB temporarily unavailable — skip this tick
-        }
-      }, 2000);
-
-      // Cleanup when client disconnects
-      return () => {
-        closed = true;
-        clearInterval(interval);
-      };
-    },
-  });
-
-  return new Response(stream, {
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-      'X-Accel-Buffering': 'no',
-    },
-  });
+  return new Response(stream, { headers: { ...SSE_HEADERS } });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,6 +785,9 @@ importers:
       '@cleocode/core':
         specifier: workspace:*
         version: link:../core
+      '@cleocode/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       '@cosmograph/cosmos':
         specifier: ^2.0.0-beta.26
         version: 2.0.0-beta.26


### PR DESCRIPTION
## R3-T6 · T11450 — the fourth and final gateway transport adapter

Adds `@cleocode/runtime/gateway/http`, completing the four-transport set (CLI · MCP · RPC · **HTTP**). Mirrors the merged `mcp`/`rpc` adapters structurally but is **framework-agnostic** — binds no port, owns no `Request`/`Response` lifecycle — so the embedder supplies operation coordinates and serializes the result.

### Acceptance criteria

- [x] **Unary**: `routeUnary(handler, req)` → `source:'http'` `DispatchRequest` → injected `GatewayHandler` (`createGatewayHandler`) → `{ status, body }` JSON LAFS envelope. Source forced to `'http'`; thrown handler errors → `500 E_HTTP_INTERNAL` (no throw, no `process.exit`). `statusForResponse` maps LAFS error code → HTTP status (404/400/401/403/429/501/500).
- [x] **SSE**: `createSseStream(source, signal?)` streams `GatewayStreamEvent` frames (the streaming type added in T11446) over `text/event-stream`. Abort-safe: frames drop after close, teardown runs exactly once, request `AbortSignal` closes on disconnect. `encodeStreamEvent`/`encodeSseFrame` own the SSE wire.
- [x] **AC1 — existing Studio streams route through the adapter**: `/api/brain/stream` + `/api/tasks/events` now route their stream lifecycle through `createSseStream`, preserving the **exact observable wire** (brain/stream keeps `data:<json>\n\n` via its own `sseEncode`; tasks/events keeps named `event:` frames). Event ordering + shape unchanged — the existing brain/stream SSE handler test suite stays green (8/8).
- [x] Exported from `packages/runtime/src/gateway/index.ts`; `./gateway/http` subpath added to runtime `package.json` + `tsup.config.ts` (mirrors mcp/rpc).
- [x] transport-inventory golden flipped — `http` adapter now exists (pending marker removed, like rpc did).
- [x] **Invariant held**: `@cleocode/runtime` keeps NO `@cleocode/cleo` dep, NO SvelteKit dep, NO drizzle-orm. The HTTP adapter imports only `@cleocode/contracts/gateway` + `node:crypto`.

### How SSE uses GatewayStreamEvent

`encodeStreamEvent(frame: GatewayStreamEvent)` serializes the canonical `{ kind, seq, data, error, requestId }` frame as a `data:`-only SSE record with `seq` surfaced as the SSE `id:` (for `Last-Event-ID` resumption). The client demultiplexes on `kind`/`seq`. Gateway-routed streaming ops emit a sequence terminated by a `done` or `error` frame.

### Studio streams rewired (+ proof wire unchanged)

| Stream | Wire before | Wire after | Proof |
|--------|-------------|------------|-------|
| `/api/brain/stream` | `data: <json>\n\n` | identical (`sseEncode` → `encodeSseFrame({data})` → `emitter.sendRaw`) | brain/stream SSE handler tests **8/8 green** |
| `/api/tasks/events` | `event: <name>\ndata: <json>\n\n` | identical (`emitter.send({event,data})`) | golden source-content assertions hold (connected→task-updated→heartbeat order) |

### Validation

| Gate | Result | Key line |
|------|--------|----------|
| `tsc -b` (typecheck) | ✅ PASS | exit 0, zero errors |
| Cold smoke (`node build.mjs` + `cleo version`) | ✅ PASS | `{"success":true,...,"version":"2026.5.126"}` |
| Runtime HTTP adapter tests | ✅ PASS | 17/17 (`src/gateway/http`); full runtime suite 68/68 |
| Studio full test suite | ✅ PASS | 48 files, **659 passed** / 3 todo, 0 fail |
| Studio brain/stream + tasks SSE tests | ✅ PASS | 22/22 (event shape + ordering unchanged) |
| transport-inventory golden | ✅ PASS (verified standalone) | `httpExists=true`, both transports in `GATEWAY_SOURCES` — *cleo vitest config broken locally (known gotcha); CI runs it* |
| `cleo check arch` | ✅ 5/5 | gates 1-5 pass |
| contracts-purity (Gate 10) | ✅ PASS | no net-new runtime helpers (baseline 53) |
| contract-literal-enums | ✅ PASS | every contract-literal enum in SSoT |
| tools-vs-skills boundary (Gate 11) | ✅ PASS | no net-new out-of-home primitive (baseline 1) |
| publish-surface (Gate 9) | ✅ PASS | 18 publishes (expected 18) |
| contracts-dep lint | ✅ PASS | studio declares `@cleocode/runtime` |
| changeset lint | ✅ PASS | 208 entries validated |
| `pnpm biome check .` | ✅ PASS | no warnings, no fixes |

### Staged remainder / honest notes

- **Studio SvelteKit `vite build` fails LOCALLY** with `ERR_MODULE_NOT_FOUND: @cleocode/cant` during the SSR prerender step. **Proven pre-existing**: the identical failure reproduces on a baseline checkout with my Studio source changes stashed (transitive workspace dep `@cleocode/cant` is not hoisted/symlinked into this worktree's `node_modules` under the `--ignore-scripts` install). My `@cleocode/runtime` dep IS correctly symlinked and resolves. The full module transform (3246 modules, including both rewired SSE handlers) succeeds before the prerender resolution error. CI's full clean install hoists `@cleocode/cant` correctly. Studio **type-check + full 659-test suite + bundling all pass**.
- The HTTP adapter is intentionally a routing primitive (`routeUnary` + SSE builder) rather than a bound server, so the daemon HTTP server (R3 wiring) and SvelteKit routes both embed it without coupling the runtime to a framework. No daemon HTTP endpoint is wired in this PR — that is downstream R3 integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)