### PR TITLE
feat(T11361): consolidated global cleo.db schema — nexus/skills/signaldock + mirrored brain (E2 · SG-DB-SUBSTRATE-V2)

### DIFF
--- a/packages/core/src/store/schema/cleo-global/index.ts
+++ b/packages/core/src/store/schema/cleo-global/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Consolidated **GLOBAL-scope `cleo.db`** target schema — barrel.
+ *
+ * SG-DB-SUBSTRATE-V2 · saga T11242 · epic T11245 (E2) · task T11361.
+ *
+ * ## What this directory is
+ *
+ * The owner-ratified D1″ lifecycle split (2026-05-30) collapses the CLEO SQLite
+ * fleet into exactly two `cleo.db` files: a PROJECT-scope DB
+ * (`<projectRoot>/.cleo/cleo.db`, authored under `../cleo-project/`) and this
+ * GLOBAL-scope DB (`$XDG_DATA_HOME/cleo/cleo.db`). The GLOBAL-scope DB holds
+ * every CROSS-PROJECT domain — `nexus_*` (code-intelligence index) / `skills_*`
+ * (installed-skills registry) / `signaldock_*` (global agent identity — folded
+ * here per D1, no standalone `signaldock.db`) / `brain_*` (cross-project
+ * memory) — as domain-prefixed Pattern-A tables.
+ *
+ * Per the canonical typing report §1 (D1″), the GLOBAL `cleo.db` is
+ * **49 tables / 555 columns** = nexus 10 + skills 4 + signaldock 13 + brain 22
+ * (MIRRORED). This barrel composes exactly that set.
+ *
+ * Modules under this directory author the **target shape**: domain-prefixed
+ * `sqliteTable` definitions with the E10 strict typing applied per
+ * `docs/migration/sqlite-schema-canonical.md`. They are NOT yet the runtime
+ * schema — the live runtime modules one level up
+ * (`schema/{nexus-schema,code-index,skills-schema,signaldock-schema}.ts`) keep
+ * their UNPREFIXED physical names because they back live runtime queries and the
+ * journaled drizzle migrations. The **exodus migration (T11248)** swaps the
+ * substrate to this shape and renames the physical tables.
+ *
+ * ## brain_* is MIRRORED — REUSE, never duplicate
+ *
+ * The `brain_*` memory family (22 tables) is the ONE domain that lives in BOTH
+ * the project and global `cleo.db` (project-local vs cross-project memory) —
+ * same DDL, two physical DB files, data partitioned by scope. To avoid
+ * duplication it is authored ONCE under `../cleo-shared/brain.ts` and re-exported
+ * by BOTH scope barrels. This global barrel re-exports the SAME shared module —
+ * it does NOT copy or re-author any `brain_*` table. The project barrel
+ * (`../cleo-project/index.ts`) re-exports the identical shared module.
+ *
+ * ## Idempotent prefixer (AC1)
+ *
+ * Each table's physical name is its `targetTable` from
+ * `docs/migration/sqlite-schema-columns.json`. Tables already carrying a
+ * recognized domain prefix (`nexus_audit_log`, `nexus_nodes`, …) are NOT
+ * double-prefixed; bare tables gain their domain prefix (`project_registry` →
+ * `nexus_project_registry`, `code_index` → `nexus_code_index`, `skills` →
+ * `skills_skills`, `agents` → `signaldock_agents`, …).
+ *
+ * ## Coverage (T11361 — global-exclusive authoring COMPLETE · 27 tables + 22 mirrored brain)
+ *
+ * **Global-exclusive (authored here · 27 tables):**
+ *   - **nexus** (10 tables · `./nexus.ts`): nexus_project_registry ·
+ *     nexus_project_id_aliases · nexus_audit_log · nexus_schema_meta ·
+ *     nexus_nodes · nexus_relations · nexus_contracts · nexus_code_index ·
+ *     nexus_user_profile · nexus_sigils. E10: §4 Drizzle-Date → TEXT ISO8601 on
+ *     user_profile/sigils timestamps; §5b enums minted for `sigils.role`
+ *     (`SIGIL_ROLES`) and `code_index.kind` (`CODE_INDEX_KINDS`).
+ *   - **skills** (4 tables · `./skills.ts`): skills_skills · skills_skill_usage
+ *     · skills_skill_reviews · skills_skill_patches. Already E10-clean (named
+ *     enums + typed booleans + TEXT timestamps).
+ *   - **signaldock** (13 tables · `./signaldock.ts`): signaldock_users ·
+ *     signaldock_organization · signaldock_agents · signaldock_claim_codes ·
+ *     signaldock_capabilities · signaldock_skills · signaldock_agent_capabilities
+ *     · signaldock_agent_skills · signaldock_agent_connections ·
+ *     signaldock_accounts · signaldock_sessions · signaldock_verifications ·
+ *     signaldock_org_agent_keys. E10: §4 epoch → TEXT ISO8601 across cloud-sync
+ *     timestamps; §3b `agents.is_active` → typed boolean; §5b enums minted for
+ *     `users.role` (`SIGNALDOCK_USER_ROLES`) and `agents.status`
+ *     (`SIGNALDOCK_AGENT_STATUSES`). All FKs are intra-domain (single global
+ *     file) → kept native `.references()` (AC4).
+ *
+ * **Mirrored (re-exported · 22 tables):** the `brain_*` family from
+ * `../cleo-shared/index.ts` (same module the project barrel uses).
+ *
+ * **GLOBAL SCHEMA NOW COMPLETE.** 27 global-exclusive prefixed `sqliteTable`s +
+ * 22 mirrored brain tables = the canonical 49 (nexus 10 + skills 4 +
+ * signaldock 13 + brain 22). What remains for the saga is the exodus cutover
+ * (T11248).
+ *
+ * @task T11361
+ * @epic T11245
+ * @saga T11242
+ * @see docs/migration/sqlite-schema-canonical.md §1 (per-scope counts) · §3–§8 (typing rules)
+ * @see ../cleo-shared/brain.ts (the mirrored brain_* family — also imported by cleo-project, T11360)
+ * @see ../cleo-project/index.ts (the sibling project-scope barrel)
+ * @see drizzle/cleo-global.config.ts (per-scope domain membership)
+ */
+
+export * from '../cleo-shared/index.js';
+export * from './nexus.js';
+export * from './signaldock.js';
+export * from './skills.js';

--- a/packages/core/src/store/schema/cleo-global/nexus.ts
+++ b/packages/core/src/store/schema/cleo-global/nexus.ts
@@ -1,0 +1,716 @@
+/**
+ * Global-scope `cleo.db` — consolidated **nexus** domain (10 tables).
+ *
+ * Part of the consolidated GLOBAL-scope `cleo.db` target shape authored for
+ * SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2, task T11361). Target-shape
+ * authoring only — physical names carry the `nexus_` domain prefix. The live
+ * runtime modules `schema/nexus-schema.ts` + `schema/code-index.ts` keep their
+ * UNPREFIXED / partially-prefixed names until the exodus migration (T11248)
+ * swaps the substrate to this shape.
+ *
+ * ## Idempotent prefixer (AC1)
+ *
+ * Five source tables already carry the recognized `nexus_` prefix and are NOT
+ * double-prefixed: `nexus_audit_log` · `nexus_schema_meta` · `nexus_nodes` ·
+ * `nexus_relations` · `nexus_contracts`. The remaining five bare tables gain the
+ * domain prefix at exodus: `project_registry` → `nexus_project_registry` ·
+ * `project_id_aliases` → `nexus_project_id_aliases` · `user_profile` →
+ * `nexus_user_profile` · `sigils` → `nexus_sigils` · `code_index` →
+ * `nexus_code_index` (the relocated tree-sitter symbol index, formerly in
+ * `nexus.db` alongside the registry).
+ *
+ * ## E10 typing applied
+ *
+ * - **§4 timestamps (Drizzle-Date non-conformers → TEXT ISO8601):**
+ *   `nexus_user_profile.{first_observed_at,last_reinforced_at}` and
+ *   `nexus_sigils.{created_at,updated_at}` were `integer({ mode:'timestamp' })`
+ *   (the 4 Date non-conformers in §4). They become canonical `text` ISO8601;
+ *   the matching `CHECK (col GLOB 'YYYY-MM-DD*')` ships as raw DDL at exodus.
+ * - **§5b enum-like bare TEXT → `{ enum }`:** `nexus_sigils.role` →
+ *   `{ enum: SIGIL_ROLES }` and `nexus_code_index.kind` →
+ *   `{ enum: CODE_INDEX_KINDS }`. The const arrays below are minted in-module
+ *   (no cross-package contracts const exists for either) per §5b — the CHECK
+ *   list derives from the identifier, never a hand-typed literal.
+ * - **§3a already-conformant booleans:** `nexus_nodes.{is_exported,is_external}`
+ *   and `nexus_code_index.exported` keep `{ mode:'boolean' }`; only the SQL
+ *   `CHECK (col IN (0,1))` is added at exodus.
+ *
+ * ## FK reconciliation to single-file Pattern A (AC4)
+ *
+ * The nexus source used soft FKs (plain `text` + `@cross-db` annotations) for
+ * every cross-table reference; none crossed file boundaries via a real
+ * `.references()`. Under the consolidated GLOBAL `cleo.db` they remain plain
+ * `text` soft FKs:
+ *   - intra-nexus refs (`nexus_nodes.project_id` → `nexus_project_registry`,
+ *     `nexus_relations.{source_id,target_id}` → `nexus_nodes`, `parent_id`)
+ *     stay soft because the source never declared them as enforced FKs and the
+ *     graph stores unresolved external specifiers in the same column.
+ *   - cross-domain refs (`nexus_audit_log.session_id` → project-scope
+ *     `tasks_sessions`, `nexus_user_profile.derived_from_message_id` →
+ *     `conduit_session_messages`) point at the PROJECT-scope `cleo.db`, so they
+ *     CANNOT be native FKs — they remain soft TEXT, resolved by the nexus
+ *     accessor. No ATTACH; no cross-file FK.
+ *
+ * @task T11361
+ * @epic T11245
+ * @saga T11242
+ * @see docs/migration/sqlite-schema-canonical.md §1 (D1″ · global counts) · §4 · §5b
+ * @see docs/migration/sqlite-schema-columns.json (per-column affinity SSoT)
+ * @see ../nexus-schema.ts · ../code-index.ts (the runtime source modules)
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+// ---------------------------------------------------------------------------
+// E10 §5b — enum const arrays minted in-module (no cross-package contracts SSoT)
+// ---------------------------------------------------------------------------
+
+/**
+ * Legal `nexus_sigils.role` values — the `.cant` agent role taxonomy.
+ *
+ * E10 §5b: `sigils.role` was bare `text('role')` (default `''`). The value is
+ * the `role:` frontmatter field of a `.cant` agent file, parsed by
+ * `nexus/sigil-sync.ts`. The legal set enumerated from the writer + canonical
+ * seed roster (`project-orchestrator`, `project-dev-lead`, `project-*-worker`)
+ * and the parsed-sigil fixtures (`subagent`, `specialist`). `''` is retained
+ * because the column defaults to empty before a `.cant` role is associated.
+ *
+ * @task T11361
+ */
+export const SIGIL_ROLES = [
+  '',
+  'orchestrator',
+  'lead',
+  'worker',
+  'subagent',
+  'specialist',
+  'validator',
+] as const;
+
+/** TypeScript union derived from {@link SIGIL_ROLES}. */
+export type SigilRole = (typeof SIGIL_ROLES)[number];
+
+/**
+ * Legal `nexus_code_index.kind` values — tree-sitter symbol capture kinds.
+ *
+ * E10 §5b: `code_index.kind` was bare `text('kind')`. The legal set is the
+ * symbol-kind taxonomy documented on the source column (the tree-sitter capture
+ * groups): structural / module / callable / type-hierarchy / value-level
+ * constructs. Kept as an in-module const so the exodus CHECK derives from this
+ * identifier rather than a hand-typed literal.
+ *
+ * @task T11361
+ */
+export const CODE_INDEX_KINDS = [
+  'function',
+  'method',
+  'class',
+  'interface',
+  'type',
+  'enum',
+  'variable',
+  'constant',
+  'module',
+  'import',
+  'export',
+  'struct',
+  'trait',
+  'impl',
+] as const;
+
+/** TypeScript union derived from {@link CODE_INDEX_KINDS}. */
+export type CodeIndexKind = (typeof CODE_INDEX_KINDS)[number];
+
+// ---------------------------------------------------------------------------
+// Registry + aliases
+// ---------------------------------------------------------------------------
+
+/**
+ * `nexus_project_registry` — central registry of all CLEO projects known to the
+ * Nexus (one row per project). Bare `project_registry` → `nexus_project_registry`
+ * under the AC1 idempotent prefixer.
+ *
+ * @task T11361 (target shape) · T5365 / T529 (original)
+ */
+export const nexusProjectRegistry = sqliteTable(
+  'nexus_project_registry',
+  {
+    /** Canonical 12-hex-char project identifier (T9149 W5). Primary key. */
+    projectId: text('project_id').primaryKey(),
+    /** Stable project hash (unique). */
+    projectHash: text('project_hash').notNull().unique(),
+    /** Absolute filesystem path that owns this project_id (unique). */
+    projectPath: text('project_path').notNull().unique(),
+    /** Human-readable project name. */
+    name: text('name').notNull(),
+    /** ISO-8601 UTC registration instant (canonical TEXT, §4). */
+    registeredAt: text('registered_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 UTC last-seen instant (canonical TEXT, §4). */
+    lastSeen: text('last_seen').notNull().default(sql`(datetime('now'))`),
+    /** Health status string (e.g. "healthy", "warning", "unknown"). */
+    healthStatus: text('health_status').notNull().default('unknown'),
+    /** ISO-8601 UTC last health-check instant; NULL until first check. */
+    healthLastCheck: text('health_last_check'),
+    /** Permission level ("read" / "write"). */
+    permissions: text('permissions').notNull().default('read'),
+    /** ISO-8601 UTC last-sync instant (canonical TEXT, §4). */
+    lastSync: text('last_sync').notNull().default(sql`(datetime('now'))`),
+    /** Cached task count for the project. */
+    taskCount: integer('task_count').notNull().default(0),
+    /** JSON array of project labels (serialized TEXT per JSON-Column Audit). */
+    labelsJson: text('labels_json').notNull().default('[]'),
+    /** Absolute path to the project's project-scope `cleo.db` brain partition. */
+    brainDbPath: text('brain_db_path'),
+    /** Absolute path to the project's project-scope `cleo.db` tasks partition. */
+    tasksDbPath: text('tasks_db_path'),
+    /** ISO-8601 UTC last successful code-intelligence index run; NULL until indexed. */
+    lastIndexed: text('last_indexed'),
+    /** JSON object with per-project code-intelligence stats (serialized TEXT). */
+    statsJson: text('stats_json').notNull().default('{}'),
+  },
+  (table) => [
+    index('idx_nexus_project_registry_hash').on(table.projectHash),
+    index('idx_nexus_project_registry_health').on(table.healthStatus),
+    index('idx_nexus_project_registry_name').on(table.name),
+    index('idx_nexus_project_registry_last_indexed').on(table.lastIndexed),
+  ],
+);
+
+/**
+ * `nexus_project_id_aliases` — maps legacy base64url(path) project IDs to their
+ * canonical IDs (T9149 W5). Bare `project_id_aliases` → `nexus_project_id_aliases`.
+ *
+ * @task T11361 (target shape) · T9149 (original)
+ */
+export const nexusProjectIdAliases = sqliteTable(
+  'nexus_project_id_aliases',
+  {
+    /** Legacy base64url(path) ID. Primary key. */
+    legacyId: text('legacy_id').primaryKey(),
+    /** Canonical 12-hex-char ID this alias maps to (soft FK → nexus_project_registry). */
+    canonicalId: text('canonical_id').notNull(),
+    /** ISO-8601 UTC creation instant (canonical TEXT, §4). */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [index('idx_nexus_project_id_aliases_canonical').on(table.canonicalId)],
+);
+
+// ---------------------------------------------------------------------------
+// Audit + schema meta
+// ---------------------------------------------------------------------------
+
+/**
+ * `nexus_audit_log` — append-only audit log for all Nexus operations across
+ * projects. Already domain-prefixed; the idempotent prefixer is a no-op.
+ *
+ * @task T11361 (target shape) · T5365 (original)
+ */
+export const nexusAuditLog = sqliteTable(
+  'nexus_audit_log',
+  {
+    /** UUID primary key. */
+    id: text('id').primaryKey(),
+    /** ISO-8601 UTC instant of the audited operation (canonical TEXT, §4). */
+    timestamp: text('timestamp').notNull().default(sql`(datetime('now'))`),
+    /** Audited action name. */
+    action: text('action').notNull(),
+    /** Project hash context; NULL for global operations. */
+    projectHash: text('project_hash'),
+    /** Project id (soft FK → nexus_project_registry.project_id). */
+    projectId: text('project_id'),
+    /** Operation domain (e.g. "tasks", "memory"). */
+    domain: text('domain'),
+    /** Operation name. */
+    operation: text('operation'),
+    /**
+     * Project-tier session that issued the audited operation.
+     *
+     * Cross-domain soft FK → PROJECT-scope `cleo.db` `tasks_sessions.id`.
+     * CANNOT be a native FK (different scope DB file); resolved by the nexus
+     * accessor (AC4 — no ATTACH).
+     */
+    sessionId: text('session_id'),
+    /** Correlated request id. */
+    requestId: text('request_id'),
+    /** Originating source/process. */
+    source: text('source'),
+    /** CQRS gateway ("query" / "mutate"). */
+    gateway: text('gateway'),
+    /** Outcome flag (numeric LAFS code echo; not a strict 0/1 boolean). */
+    success: integer('success'),
+    /** Wall-clock duration in milliseconds. */
+    durationMs: integer('duration_ms'),
+    /** JSON detail blob (serialized TEXT). */
+    detailsJson: text('details_json').default('{}'),
+    /** Error message when the operation failed. */
+    errorMessage: text('error_message'),
+  },
+  (table) => [
+    index('idx_nexus_audit_timestamp').on(table.timestamp),
+    index('idx_nexus_audit_action').on(table.action),
+    index('idx_nexus_audit_project_hash').on(table.projectHash),
+    index('idx_nexus_audit_project_id').on(table.projectId),
+    index('idx_nexus_audit_session').on(table.sessionId),
+  ],
+);
+
+/**
+ * `nexus_schema_meta` — key-value schema-version tracking (single-table KV).
+ * Already domain-prefixed.
+ *
+ * @task T11361 (target shape) · T5365 (original)
+ */
+export const nexusSchemaMeta = sqliteTable('nexus_schema_meta', {
+  /** Config key. */
+  key: text('key').primaryKey(),
+  /** Config value. */
+  value: text('value').notNull(),
+});
+
+// ---------------------------------------------------------------------------
+// Code-intelligence graph
+// ---------------------------------------------------------------------------
+
+/**
+ * All node kind values — matches `GraphNodeKind` in `@cleocode/contracts`.
+ * Kept as a const tuple for the Drizzle enum column. Ordering intentional:
+ * structural → module → callable → type → value-level → language-specific →
+ * graph-level → legacy.
+ *
+ * @task T11361 (target shape) · T529 (original)
+ */
+export const NEXUS_NODE_KINDS = [
+  // Structural
+  'file',
+  'folder',
+  // Module-level
+  'module',
+  'namespace',
+  // Callable
+  'function',
+  'method',
+  'constructor',
+  // Type hierarchy
+  'class',
+  'interface',
+  'struct',
+  'trait',
+  'impl',
+  'type_alias',
+  'enum',
+  // Value-level
+  'property',
+  'constant',
+  'variable',
+  'static',
+  'record',
+  'delegate',
+  // Language-specific constructs
+  'macro',
+  'union',
+  'typedef',
+  'annotation',
+  'template',
+  // Graph-level (synthetic nodes from analysis phases)
+  'community',
+  'process',
+  'route',
+  // External references
+  'tool',
+  'section',
+  // Legacy (kept for T506 compatibility)
+  'import',
+  'export',
+  'type',
+] as const;
+
+/** TypeScript type derived from {@link NEXUS_NODE_KINDS}. */
+export type NexusNodeKind = (typeof NEXUS_NODE_KINDS)[number];
+
+/**
+ * `nexus_nodes` — one row per symbol or structural element in the code
+ * intelligence graph. Already domain-prefixed.
+ *
+ * @task T11361 (target shape) · T529 (original)
+ */
+export const nexusNodes = sqliteTable(
+  'nexus_nodes',
+  {
+    /** Stable node ID (`<filePath>::<name>` / `<filePath>` / `community:<n>` / `process:<slug>`). */
+    id: text('id').primaryKey(),
+    /** Owning project (soft FK → nexus_project_registry.project_id). */
+    projectId: text('project_id').notNull(),
+    /** Node kind from {@link NEXUS_NODE_KINDS} (E10 §5a — already enum-typed). */
+    kind: text('kind', { enum: NEXUS_NODE_KINDS }).notNull(),
+    /** Human-readable display label. */
+    label: text('label').notNull(),
+    /** Symbol name as it appears in source; NULL for file/folder nodes. */
+    name: text('name'),
+    /** File path relative to project root; NULL for community/process nodes. */
+    filePath: text('file_path'),
+    /** Start line (1-based); NULL for structural nodes. */
+    startLine: integer('start_line'),
+    /** End line (1-based); NULL for structural nodes. */
+    endLine: integer('end_line'),
+    /** Source language (typescript, python, go, rust, …). */
+    language: text('language'),
+    /** Whether the symbol is publicly exported (E10 §3a — typed boolean). */
+    isExported: integer('is_exported', { mode: 'boolean' }).notNull().default(false),
+    /** Parent node id for nested symbols (intra-nexus soft FK → nexus_nodes.id). */
+    parentId: text('parent_id'),
+    /** JSON array of parameter name strings (serialized TEXT). */
+    parametersJson: text('parameters_json'),
+    /** Return-type annotation text. */
+    returnType: text('return_type'),
+    /** First line of the leading TSDoc/JSDoc comment. */
+    docSummary: text('doc_summary'),
+    /** Community membership id (soft FK → the community node's nexus_nodes.id). */
+    communityId: text('community_id'),
+    /** JSON blob for kind-specific metadata (serialized TEXT). */
+    metaJson: text('meta_json'),
+    /** Whether this node is an external/unresolved module (E10 §3a — typed boolean). */
+    isExternal: integer('is_external', { mode: 'boolean' }).notNull().default(false),
+    /** ISO-8601 UTC last-indexed instant (canonical TEXT, §4). */
+    indexedAt: text('indexed_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index('idx_nexus_nodes_project').on(table.projectId),
+    index('idx_nexus_nodes_kind').on(table.kind),
+    index('idx_nexus_nodes_file').on(table.filePath),
+    index('idx_nexus_nodes_name').on(table.name),
+    index('idx_nexus_nodes_project_kind').on(table.projectId, table.kind),
+    index('idx_nexus_nodes_project_file').on(table.projectId, table.filePath),
+    index('idx_nexus_nodes_community').on(table.communityId),
+    index('idx_nexus_nodes_parent').on(table.parentId),
+    index('idx_nexus_nodes_exported').on(table.isExported),
+    index('idx_nexus_nodes_is_external').on(table.isExternal),
+  ],
+);
+
+/**
+ * All relation type values — matches `GraphRelationType` in `@cleocode/contracts`.
+ *
+ * @task T11361 (target shape) · T529 (original)
+ */
+export const NEXUS_RELATION_TYPES = [
+  // Structural
+  'contains',
+  // Definition / usage
+  'defines',
+  'imports',
+  'accesses',
+  // Callable
+  'calls',
+  // Type hierarchy
+  'extends',
+  'implements',
+  'method_overrides',
+  'method_implements',
+  // Class structure
+  'has_method',
+  'has_property',
+  // Graph-level (synthetic, from analysis phases)
+  'member_of',
+  'step_in_process',
+  // Web / API
+  'handles_route',
+  'fetches',
+  // Tool / agent
+  'handles_tool',
+  'entry_point_of',
+  // Wrapping / delegation
+  'wraps',
+  // Data access
+  'queries',
+  // Cross-graph (brain link)
+  'documents',
+  'applies_to',
+  // Plasticity co-access relations (T998)
+  'co_changed',
+  'co_cited_in_task',
+] as const;
+
+/** TypeScript type derived from {@link NEXUS_RELATION_TYPES}. */
+export type NexusRelationType = (typeof NEXUS_RELATION_TYPES)[number];
+
+/**
+ * `nexus_relations` — one row per directed graph edge. Already domain-prefixed.
+ *
+ * @task T11361 (target shape) · T529 (original)
+ */
+export const nexusRelations = sqliteTable(
+  'nexus_relations',
+  {
+    /** UUID v4 row identifier. */
+    id: text('id').primaryKey(),
+    /** Owning project (soft FK → nexus_project_registry.project_id). */
+    projectId: text('project_id').notNull(),
+    /** Source node id (intra-nexus soft FK → nexus_nodes.id). */
+    sourceId: text('source_id').notNull(),
+    /** Target node id or raw module specifier (intra-nexus soft FK → nexus_nodes.id). */
+    targetId: text('target_id').notNull(),
+    /** Semantic relation type from {@link NEXUS_RELATION_TYPES} (E10 §5a). */
+    type: text('type', { enum: NEXUS_RELATION_TYPES }).notNull(),
+    /** Extractor confidence [0.0, 1.0]. */
+    confidence: real('confidence').notNull(),
+    /** Human-readable note explaining why this relation was emitted. */
+    reason: text('reason'),
+    /** Step index within an execution flow (for step_in_process relations). */
+    step: integer('step'),
+    /** ISO-8601 UTC last-indexed instant (canonical TEXT, §4). */
+    indexedAt: text('indexed_at').notNull().default(sql`(datetime('now'))`),
+    /** Plasticity weight in [0.0, 1.0] (T998 Hebbian co-access strengthening). */
+    weight: real('weight').default(0.0),
+    /** ISO-8601 UTC last co-access strengthening instant; NULL until first strengthen. */
+    lastAccessedAt: text('last_accessed_at'),
+    /** Number of co-access strengthening events. */
+    coAccessedCount: integer('co_accessed_count').default(0),
+  },
+  (table) => [
+    index('idx_nexus_relations_project').on(table.projectId),
+    index('idx_nexus_relations_source').on(table.sourceId),
+    index('idx_nexus_relations_target').on(table.targetId),
+    index('idx_nexus_relations_type').on(table.type),
+    index('idx_nexus_relations_project_type').on(table.projectId, table.type),
+    index('idx_nexus_relations_source_type').on(table.sourceId, table.type),
+    index('idx_nexus_relations_target_type').on(table.targetId, table.type),
+    index('idx_nexus_relations_confidence').on(table.confidence),
+    index('idx_nexus_relations_last_accessed').on(table.lastAccessedAt),
+  ],
+);
+
+/**
+ * All contract type values for cross-project API extraction.
+ *
+ * @task T11361 (target shape) · T1065 (original)
+ */
+export const NEXUS_CONTRACT_TYPES = ['http', 'grpc', 'topic'] as const;
+
+/** TypeScript type derived from {@link NEXUS_CONTRACT_TYPES}. */
+export type NexusContractType = (typeof NEXUS_CONTRACT_TYPES)[number];
+
+/**
+ * `nexus_contracts` — cross-project HTTP/gRPC/topic contract registry. Already
+ * domain-prefixed.
+ *
+ * @task T11361 (target shape) · T1065 (original)
+ */
+export const nexusContracts = sqliteTable(
+  'nexus_contracts',
+  {
+    /** Unique contract id. Primary key. */
+    contractId: text('contract_id').primaryKey(),
+    /** Owning project (soft FK → nexus_project_registry.project_id). */
+    projectId: text('project_id').notNull(),
+    /** Contract type from {@link NEXUS_CONTRACT_TYPES} (E10 §5a). */
+    type: text('type', { enum: NEXUS_CONTRACT_TYPES }).notNull(),
+    /** Path or endpoint identifier. */
+    path: text('path').notNull(),
+    /** HTTP/gRPC method; NULL for topics. */
+    method: text('method'),
+    /** Request schema as JSON string (serialized TEXT). */
+    requestSchemaJson: text('request_schema_json').notNull().default('{}'),
+    /** Response schema as JSON string (serialized TEXT). */
+    responseSchemaJson: text('response_schema_json').notNull().default('{}'),
+    /** Source symbol id (soft FK → nexus_nodes.id). */
+    sourceSymbolId: text('source_symbol_id'),
+    /** Route node id (soft FK → nexus_nodes.id). */
+    routeNodeId: text('route_node_id'),
+    /** Extraction confidence [0..1]. */
+    confidence: real('confidence').notNull().default(1.0),
+    /** Human-readable description. */
+    description: text('description'),
+    /** ISO-8601 UTC creation instant (canonical TEXT, §4). */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 UTC last-update instant (canonical TEXT, §4). */
+    updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index('idx_nexus_contracts_project').on(table.projectId),
+    index('idx_nexus_contracts_type').on(table.type),
+    index('idx_nexus_contracts_path').on(table.path),
+    index('idx_nexus_contracts_method').on(table.method),
+    index('idx_nexus_contracts_project_type').on(table.projectId, table.type),
+    index('idx_nexus_contracts_source_symbol').on(table.sourceSymbolId),
+    index('idx_nexus_contracts_created').on(table.createdAt),
+  ],
+);
+
+/**
+ * `nexus_code_index` — persistent index of code symbols extracted by
+ * tree-sitter (one row per symbol per file). Bare `code_index` →
+ * `nexus_code_index` under the AC1 idempotent prefixer (the relocated
+ * code-intelligence index that lived in `nexus.db` alongside the registry).
+ *
+ * @task T11361 (target shape) · original `code-index.ts`
+ */
+export const nexusCodeIndex = sqliteTable(
+  'nexus_code_index',
+  {
+    /** Stable row identifier (UUID v4). Primary key. */
+    id: text('id').primaryKey(),
+    /** Owning project (soft FK → nexus_project_registry.project_id). */
+    projectId: text('project_id').notNull(),
+    /** Relative file path within the project root. */
+    filePath: text('file_path').notNull(),
+    /** Symbol name as extracted from the AST. */
+    symbolName: text('symbol_name').notNull(),
+    /** Symbol kind from {@link CODE_INDEX_KINDS} (E10 §5b — was bare TEXT). */
+    kind: text('kind', { enum: CODE_INDEX_KINDS }).notNull(),
+    /** Start line in the source file (1-based). */
+    startLine: integer('start_line').notNull(),
+    /** End line in the source file (1-based). */
+    endLine: integer('end_line').notNull(),
+    /** Source language detected from the file extension. */
+    language: text('language').notNull(),
+    /** Whether the symbol has an `export` modifier (E10 §3a — typed boolean). */
+    exported: integer('exported', { mode: 'boolean' }).default(false),
+    /** Parent symbol name for nested declarations; NULL at module scope. */
+    parent: text('parent'),
+    /** Return-type annotation extracted from the declaration. */
+    returnType: text('return_type'),
+    /** First line of the leading JSDoc/docstring comment. */
+    docSummary: text('doc_summary'),
+    /** ISO-8601 UTC last-indexed instant (canonical TEXT, §4). */
+    indexedAt: text('indexed_at').notNull(),
+  },
+  (table) => [
+    index('idx_nexus_code_index_project').on(table.projectId),
+    index('idx_nexus_code_index_file').on(table.filePath),
+    index('idx_nexus_code_index_symbol').on(table.symbolName),
+    index('idx_nexus_code_index_kind').on(table.kind),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Global identity / preference layers
+// ---------------------------------------------------------------------------
+
+/**
+ * `nexus_user_profile` — global user identity / preference profile (PSYCHE
+ * Wave 1, T1077). Bare `user_profile` → `nexus_user_profile`.
+ *
+ * E10 §4: `first_observed_at` / `last_reinforced_at` were
+ * `integer({ mode:'timestamp' })` (Drizzle-Date non-conformers) — now canonical
+ * TEXT ISO8601.
+ *
+ * @task T11361 (target shape) · T1077 (original)
+ */
+export const nexusUserProfile = sqliteTable(
+  'nexus_user_profile',
+  {
+    /** Stable semantic trait key. Primary key — traits are upserted by key. */
+    traitKey: text('trait_key').primaryKey(),
+    /** JSON-encoded trait value (serialized TEXT). */
+    traitValue: text('trait_value').notNull(),
+    /** Bayesian confidence in [0.0, 1.0]. */
+    confidence: real('confidence').notNull(),
+    /** Trait origin (e.g. "dialectic:<sessionId>", "import:...", "manual"). */
+    source: text('source').notNull(),
+    /**
+     * Source message id.
+     *
+     * Cross-domain soft FK → PROJECT-scope `cleo.db`
+     * `conduit_session_messages.id` (RESERVED — table ships in Wave 5 / T1145).
+     * CANNOT be a native FK (different scope DB file); resolved by the nexus
+     * accessor (AC4 — no ATTACH).
+     */
+    derivedFromMessageId: text('derived_from_message_id'),
+    /** ISO-8601 UTC first-observed instant (E10 §4: Drizzle-Date → TEXT ISO8601). */
+    firstObservedAt: text('first_observed_at').notNull(),
+    /** ISO-8601 UTC last-reinforced instant (E10 §4: Drizzle-Date → TEXT ISO8601). */
+    lastReinforcedAt: text('last_reinforced_at').notNull(),
+    /** Number of reinforcement events (starts at 1). */
+    reinforcementCount: integer('reinforcement_count').notNull().default(1),
+    /** traitKey of the trait that supersedes this one (T1139 supersession graph). */
+    supersededBy: text('superseded_by'),
+  },
+  (table) => [
+    index('idx_nexus_user_profile_confidence').on(table.confidence),
+    index('idx_nexus_user_profile_source').on(table.source),
+    index('idx_nexus_user_profile_last_reinforced').on(table.lastReinforcedAt),
+    index('idx_nexus_user_profile_superseded').on(table.supersededBy),
+  ],
+);
+
+/**
+ * `nexus_sigils` — peer-card sigil identity layer for CANT agents (PSYCHE
+ * Wave 8, T1148). Bare `sigils` → `nexus_sigils`.
+ *
+ * E10 §5b: `role` was bare `text('role')` → `{ enum: SIGIL_ROLES }`.
+ * E10 §4: `created_at` / `updated_at` were `integer({ mode:'timestamp' })`
+ * (Drizzle-Date non-conformers) — now canonical TEXT ISO8601.
+ *
+ * @task T11361 (target shape) · T1148 (original)
+ */
+export const nexusSigils = sqliteTable(
+  'nexus_sigils',
+  {
+    /** Stable peer id (matches `peer_id` on brain tables). Primary key. */
+    peerId: text('peer_id').primaryKey(),
+    /** Absolute/relative path to the CANT (.cant) agent file; NULL if unassociated. */
+    cantFile: text('cant_file'),
+    /** Human-readable display name. */
+    displayName: text('display_name').notNull().default(''),
+    /** Short role from {@link SIGIL_ROLES} (E10 §5b — was bare TEXT). */
+    role: text('role', { enum: SIGIL_ROLES }).notNull().default(''),
+    /** System-prompt fragment injected into spawn payloads; NULL if none. */
+    systemPromptFragment: text('system_prompt_fragment'),
+    /** JSON-encoded capability flags object (serialized TEXT); NULL until set. */
+    capabilityFlags: text('capability_flags'),
+    /** ISO-8601 UTC creation instant (E10 §4: Drizzle-Date → TEXT ISO8601). */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 UTC last-update instant (E10 §4: Drizzle-Date → TEXT ISO8601). */
+    updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index('idx_nexus_sigils_display_name').on(table.displayName),
+    index('idx_nexus_sigils_role').on(table.role),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Inferred row + insert types
+// ---------------------------------------------------------------------------
+
+/** Row type for `nexus_project_registry` SELECT (target shape). */
+export type NexusProjectRegistryRow = typeof nexusProjectRegistry.$inferSelect;
+/** Row type for `nexus_project_registry` INSERT (target shape). */
+export type NewNexusProjectRegistryRow = typeof nexusProjectRegistry.$inferInsert;
+/** Row type for `nexus_project_id_aliases` SELECT (target shape). */
+export type NexusProjectIdAliasRow = typeof nexusProjectIdAliases.$inferSelect;
+/** Row type for `nexus_project_id_aliases` INSERT (target shape). */
+export type NewNexusProjectIdAliasRow = typeof nexusProjectIdAliases.$inferInsert;
+/** Row type for `nexus_audit_log` SELECT (target shape). */
+export type NexusAuditLogRow = typeof nexusAuditLog.$inferSelect;
+/** Row type for `nexus_audit_log` INSERT (target shape). */
+export type NewNexusAuditLogRow = typeof nexusAuditLog.$inferInsert;
+/** Row type for `nexus_schema_meta` SELECT (target shape). */
+export type NexusSchemaMetaRow = typeof nexusSchemaMeta.$inferSelect;
+/** Row type for `nexus_schema_meta` INSERT (target shape). */
+export type NewNexusSchemaMetaRow = typeof nexusSchemaMeta.$inferInsert;
+/** Row type for `nexus_nodes` SELECT (target shape). */
+export type NexusNodeRow = typeof nexusNodes.$inferSelect;
+/** Row type for `nexus_nodes` INSERT (target shape). */
+export type NewNexusNodeRow = typeof nexusNodes.$inferInsert;
+/** Row type for `nexus_relations` SELECT (target shape). */
+export type NexusRelationRow = typeof nexusRelations.$inferSelect;
+/** Row type for `nexus_relations` INSERT (target shape). */
+export type NewNexusRelationRow = typeof nexusRelations.$inferInsert;
+/** Row type for `nexus_contracts` SELECT (target shape). */
+export type NexusContractRow = typeof nexusContracts.$inferSelect;
+/** Row type for `nexus_contracts` INSERT (target shape). */
+export type NewNexusContractRow = typeof nexusContracts.$inferInsert;
+/** Row type for `nexus_code_index` SELECT (target shape). */
+export type NexusCodeIndexRow = typeof nexusCodeIndex.$inferSelect;
+/** Row type for `nexus_code_index` INSERT (target shape). */
+export type NewNexusCodeIndexRow = typeof nexusCodeIndex.$inferInsert;
+/** Row type for `nexus_user_profile` SELECT (target shape). */
+export type NexusUserProfileRow = typeof nexusUserProfile.$inferSelect;
+/** Row type for `nexus_user_profile` INSERT (target shape). */
+export type NewNexusUserProfileRow = typeof nexusUserProfile.$inferInsert;
+/** Row type for `nexus_sigils` SELECT (target shape). */
+export type NexusSigilRow = typeof nexusSigils.$inferSelect;
+/** Row type for `nexus_sigils` INSERT (target shape). */
+export type NewNexusSigilRow = typeof nexusSigils.$inferInsert;

--- a/packages/core/src/store/schema/cleo-global/signaldock.ts
+++ b/packages/core/src/store/schema/cleo-global/signaldock.ts
@@ -1,0 +1,664 @@
+/**
+ * Global-scope `cleo.db` — consolidated **signaldock** domain (13 tables).
+ *
+ * Part of the consolidated GLOBAL-scope `cleo.db` target shape authored for
+ * SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2, task T11361). Signaldock is
+ * the global agent-identity tier — it FOLDS into the global `cleo.db` per D1
+ * (no standalone `signaldock.db` survives). Target-shape authoring only —
+ * physical names carry the `signaldock_` domain prefix. The live runtime module
+ * `schema/signaldock-schema.ts` keeps its UNPREFIXED names (`users`, `agents`,
+ * …) until the exodus migration (T11248) swaps the substrate.
+ *
+ * ## Idempotent prefixer (AC1)
+ *
+ * All 13 source tables are bare and gain the `signaldock_` prefix at exodus:
+ * `users` → `signaldock_users` · `organization` → `signaldock_organization` ·
+ * `agents` → `signaldock_agents` · `claim_codes` → `signaldock_claim_codes` ·
+ * `capabilities` → `signaldock_capabilities` · `skills` → `signaldock_skills`
+ * (the global agent CAPABILITY/SKILL catalog — distinct from the `skills_*`
+ * installed-skills registry) · `agent_capabilities` →
+ * `signaldock_agent_capabilities` · `agent_skills` → `signaldock_agent_skills`
+ * · `agent_connections` → `signaldock_agent_connections` · `accounts` →
+ * `signaldock_accounts` · `sessions` → `signaldock_sessions` · `verifications`
+ * → `signaldock_verifications` · `org_agent_keys` → `signaldock_org_agent_keys`.
+ *
+ * ## E10 typing applied
+ *
+ * - **§4 timestamps (INTEGER epoch non-conformers → TEXT ISO8601):** the
+ *   signaldock cloud-sync tables stored `created_at` / `updated_at` (and
+ *   `expires_at` / `used_at` / `last_seen` / `last_used_at` / `connected_at`)
+ *   as raw INTEGER epoch. Every column the audit flagged `timestamp-epoch`
+ *   becomes canonical `text` ISO8601; the matching `CHECK (col GLOB
+ *   'YYYY-MM-DD*')` ships at exodus. (`agent_connections.last_heartbeat` is
+ *   classified `numeric` by the audit — a heartbeat counter, NOT a flagged
+ *   timestamp — so it stays `integer`. The better-auth `accounts` / `sessions`
+ *   / `verifications` tables already use TEXT timestamps; left as-is.)
+ * - **§5b enum-like bare TEXT → `{ enum }`:** `signaldock_users.role` →
+ *   `{ enum: SIGNALDOCK_USER_ROLES }` and `signaldock_agents.status` →
+ *   `{ enum: SIGNALDOCK_AGENT_STATUSES }` (the two signaldock §5b
+ *   non-conformers; const arrays minted in-module per §8.3 from the cloud-sync
+ *   writer conventions — better-auth roles + the conduit presence set).
+ * - **§3b boolean non-conformer:** `signaldock_agents.is_active` was untyped
+ *   INTEGER 0/1 → `integer({ mode:'boolean' })`. The remaining 0/1 columns the
+ *   audit classified `numeric` (`email_verified`, `banned`, `two_factor_enabled`,
+ *   `requires_reauth`, `can_spawn`, `sessions.active`) are NOT flagged as
+ *   boolean non-conformers by the audit, so they keep their plain `integer`
+ *   affinity (faithful to the audit classification).
+ *
+ * ## FK reconciliation to single-file Pattern A (AC4)
+ *
+ * Every signaldock FK is INTRA-domain (all 13 tables now live in the SAME global
+ * `cleo.db` file), so the source `.references()` are preserved as native FKs:
+ * `agents.owner_id` → `signaldock_users.id`, `agents.organization_id` →
+ * `signaldock_organization.id`, `claim_codes.{agent_id,used_by}`,
+ * `agent_capabilities`/`agent_skills` composite-PK junctions,
+ * `accounts.user_id` / `sessions.user_id`, `org_agent_keys.{organization_id,
+ * agent_id}`. None of these crossed a file boundary, so no soft-FK downgrade is
+ * required (AC4 — no ATTACH).
+ *
+ * @task T11361
+ * @epic T11245
+ * @saga T11242
+ * @see docs/migration/sqlite-schema-canonical.md §1 (D1″ · global counts) · §3b · §4 · §5b
+ * @see docs/migration/sqlite-schema-columns.json (per-column affinity SSoT)
+ * @see ../signaldock-schema.ts (the runtime source module)
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, integer, primaryKey, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+
+// ---------------------------------------------------------------------------
+// E10 §5b — enum const arrays minted in-module (cloud-sync writer conventions)
+// ---------------------------------------------------------------------------
+
+/**
+ * Legal `signaldock_users.role` values — better-auth account roles.
+ *
+ * E10 §5b: `users.role` was bare `text('role')` (default `'user'`). The
+ * signaldock users table mirrors the api.signaldock.io better-auth admin-plugin
+ * role set; populated only on cloud sync. Default `'user'`.
+ *
+ * @task T11361
+ */
+export const SIGNALDOCK_USER_ROLES = ['user', 'admin'] as const;
+
+/** TypeScript union derived from {@link SIGNALDOCK_USER_ROLES}. */
+export type SignaldockUserRole = (typeof SIGNALDOCK_USER_ROLES)[number];
+
+/**
+ * Legal `signaldock_agents.status` values — agent presence.
+ *
+ * E10 §5b: `agents.status` was bare `text('status')` (default `'online'`). The
+ * presence set is the one the conduit client distinguishes (`status ===
+ * 'online'` for reachability) plus the standard presence states.
+ *
+ * @task T11361
+ */
+export const SIGNALDOCK_AGENT_STATUSES = ['online', 'offline', 'busy', 'away'] as const;
+
+/** TypeScript union derived from {@link SIGNALDOCK_AGENT_STATUSES}. */
+export type SignaldockAgentStatus = (typeof SIGNALDOCK_AGENT_STATUSES)[number];
+
+// ---------------------------------------------------------------------------
+// Cloud-sync: user accounts + organizations
+// ---------------------------------------------------------------------------
+
+/**
+ * `signaldock_users` — cloud-sync user accounts (zero rows in pure-local mode).
+ * Bare `users` → `signaldock_users` under the AC1 idempotent prefixer.
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockUsers = sqliteTable(
+  'signaldock_users',
+  {
+    /** User id. Primary key. */
+    id: text('id').primaryKey(),
+    /** Login email (unique). */
+    email: text('email').notNull().unique(),
+    /** Hashed password. */
+    passwordHash: text('password_hash').notNull(),
+    /** Display name. */
+    name: text('name'),
+    /** URL slug. */
+    slug: text('slug'),
+    /** Default agent id for this user (soft FK → signaldock_agents.agent_id). */
+    defaultAgentId: text('default_agent_id'),
+    /** Login username. */
+    username: text('username'),
+    /** Display username. */
+    displayUsername: text('display_username'),
+    /** Email-verified flag (0/1; audit-classified numeric, not a flagged boolean). */
+    emailVerified: integer('email_verified').notNull().default(0),
+    /** Avatar image URL. */
+    image: text('image'),
+    /** Account role from {@link SIGNALDOCK_USER_ROLES} (E10 §5b — was bare TEXT). */
+    role: text('role', { enum: SIGNALDOCK_USER_ROLES }).notNull().default('user'),
+    /** Banned flag (0/1; audit-classified numeric). */
+    banned: integer('banned').notNull().default(0),
+    /** Ban reason text. */
+    banReason: text('ban_reason'),
+    /** Ban-expiry timestamp text. */
+    banExpires: text('ban_expires'),
+    /** Two-factor-enabled flag (0/1; audit-classified numeric). */
+    twoFactorEnabled: integer('two_factor_enabled').notNull().default(0),
+    /** JSON metadata blob (serialized TEXT). */
+    metadata: text('metadata'),
+    /** ISO-8601 UTC creation instant (E10 §4: epoch → TEXT ISO8601). */
+    createdAt: text('created_at').notNull(),
+    /** ISO-8601 UTC last-update instant (E10 §4: epoch → TEXT ISO8601). */
+    updatedAt: text('updated_at').notNull(),
+  },
+  (table) => [index('idx_signaldock_users_slug').on(table.slug)],
+);
+
+/**
+ * `signaldock_organization` — cloud-sync org/team records (zero rows locally).
+ * Bare `organization` → `signaldock_organization`.
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockOrganization = sqliteTable(
+  'signaldock_organization',
+  {
+    /** Organization id. Primary key. */
+    id: text('id').primaryKey().notNull(),
+    /** Organization name. */
+    name: text('name').notNull(),
+    /** URL slug. */
+    slug: text('slug'),
+    /** Logo URL. */
+    logo: text('logo'),
+    /** JSON metadata blob (serialized TEXT). */
+    metadata: text('metadata'),
+    /** Owner user id (soft FK → signaldock_users.id). */
+    ownerId: text('owner_id'),
+    /** ISO-8601 UTC creation instant (E10 §4: epoch → TEXT ISO8601). */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 UTC last-update instant (E10 §4: epoch → TEXT ISO8601). */
+    updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [index('idx_signaldock_organization_slug').on(table.slug)],
+);
+
+// ---------------------------------------------------------------------------
+// Global identity: agent registry
+// ---------------------------------------------------------------------------
+
+/**
+ * `signaldock_agents` — canonical cross-project agent registry (global
+ * identity). Bare `agents` → `signaldock_agents`.
+ *
+ * T897 v3 columns: tier, can_spawn, orch_level, reports_to, cant_path,
+ * cant_sha256, installed_from, installed_at.
+ *
+ * @task T11361 (target shape) · T346 / T897 (original)
+ */
+export const signaldockAgents = sqliteTable(
+  'signaldock_agents',
+  {
+    /** Agent id. Primary key. */
+    id: text('id').primaryKey(),
+    /** Canonical agent identifier (unique). */
+    agentId: text('agent_id').notNull().unique(),
+    /** Agent display name. */
+    name: text('name').notNull(),
+    /** Agent description. */
+    description: text('description'),
+    /** Agent class. */
+    class: text('class').notNull().default('custom'),
+    /** Privacy tier ("public" / "private" / …). */
+    privacyTier: text('privacy_tier').notNull().default('public'),
+    /** Owner user id (intra-domain FK → signaldock_users.id). */
+    ownerId: text('owner_id').references(() => signaldockUsers.id),
+    /** Transport endpoint URL. */
+    endpoint: text('endpoint'),
+    /** Webhook signing secret. */
+    webhookSecret: text('webhook_secret'),
+    /** JSON array of capability slugs (serialized TEXT). */
+    capabilities: text('capabilities').notNull().default('[]'),
+    /** JSON array of skill slugs (serialized TEXT). */
+    skills: text('skills').notNull().default('[]'),
+    /** Avatar URL. */
+    avatar: text('avatar'),
+    /** Cumulative messages sent. */
+    messagesSent: integer('messages_sent').notNull().default(0),
+    /** Cumulative messages received. */
+    messagesReceived: integer('messages_received').notNull().default(0),
+    /** Conversation count. */
+    conversationCount: integer('conversation_count').notNull().default(0),
+    /** Friend count. */
+    friendCount: integer('friend_count').notNull().default(0),
+    /** Agent presence from {@link SIGNALDOCK_AGENT_STATUSES} (E10 §5b — was bare TEXT). */
+    status: text('status', { enum: SIGNALDOCK_AGENT_STATUSES }).notNull().default('online'),
+    /** Epoch-ms last-seen heartbeat (audit-classified numeric, not a flagged timestamp). */
+    lastSeen: integer('last_seen'),
+    /** JSON payment-config blob (serialized TEXT). */
+    paymentConfig: text('payment_config'),
+    /** Hashed API key. */
+    apiKeyHash: text('api_key_hash'),
+    /** Owning organization id (intra-domain FK → signaldock_organization.id). */
+    organizationId: text('organization_id').references(() => signaldockOrganization.id, {
+      onDelete: 'set null',
+    }),
+    /** ISO-8601 UTC creation instant (E10 §4: epoch → TEXT ISO8601). */
+    createdAt: text('created_at').notNull(),
+    /** ISO-8601 UTC last-update instant (E10 §4: epoch → TEXT ISO8601). */
+    updatedAt: text('updated_at').notNull(),
+    /** Transport type ("http" / …). */
+    transportType: text('transport_type').notNull().default('http'),
+    /** KDF-encrypted API key (ADR-037 §5). */
+    apiKeyEncrypted: text('api_key_encrypted'),
+    /** Cloud API base URL. */
+    apiBaseUrl: text('api_base_url').notNull().default('https://api.signaldock.io'),
+    /** Free-form classification label. */
+    classification: text('classification'),
+    /** JSON transport-config blob (serialized TEXT). */
+    transportConfig: text('transport_config').notNull().default('{}'),
+    /** Whether this agent is active (E10 §3b: untyped INTEGER 0/1 → typed boolean). */
+    isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
+    /** Epoch-ms last-used instant (E10 §4: epoch → TEXT ISO8601). */
+    lastUsedAt: text('last_used_at'),
+    /** Requires-reauth flag (0/1; audit-classified numeric). */
+    requiresReauth: integer('requires_reauth').notNull().default(0),
+    /** Tier taxonomy from ADR-044 (project / global / packaged / fallback). */
+    tier: text('tier').notNull().default('global'),
+    /** Whether this agent may spawn sub-agents (0/1; audit-classified numeric). */
+    canSpawn: integer('can_spawn').notNull().default(0),
+    /** Orchestration level: 0=worker, 1=lead, 2=orchestrator. */
+    orchLevel: integer('orch_level').notNull().default(2),
+    /** Agent id this agent reports to (soft FK → signaldock_agents.agent_id). */
+    reportsTo: text('reports_to'),
+    /** Absolute path to the agent's .cant definition file. */
+    cantPath: text('cant_path'),
+    /** SHA-256 checksum of the .cant file at install time. */
+    cantSha256: text('cant_sha256'),
+    /** Installation provenance (seed / user / manual). */
+    installedFrom: text('installed_from'),
+    /** ISO-8601 UTC install instant (already canonical TEXT, §4). */
+    installedAt: text('installed_at'),
+  },
+  (table) => [
+    index('idx_signaldock_agents_owner').on(table.ownerId),
+    index('idx_signaldock_agents_class').on(table.class),
+    index('idx_signaldock_agents_privacy').on(table.privacyTier),
+    index('idx_signaldock_agents_org').on(table.organizationId),
+    index('idx_signaldock_agents_transport_type').on(table.transportType),
+    index('idx_signaldock_agents_is_active').on(table.isActive),
+    index('idx_signaldock_agents_last_used').on(table.lastUsedAt),
+    index('idx_signaldock_agents_tier').on(table.tier),
+    index('idx_signaldock_agents_cant_path').on(table.cantPath),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Cloud-sync: claim codes
+// ---------------------------------------------------------------------------
+
+/**
+ * `signaldock_claim_codes` — one-time agent claim tokens (cloud provisioning).
+ * Bare `claim_codes` → `signaldock_claim_codes`.
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockClaimCodes = sqliteTable(
+  'signaldock_claim_codes',
+  {
+    /** Claim code id. Primary key. */
+    id: text('id').primaryKey(),
+    /** Agent being claimed (intra-domain FK → signaldock_agents.id). */
+    agentId: text('agent_id')
+      .notNull()
+      .references(() => signaldockAgents.id),
+    /** One-time claim code (unique). */
+    code: text('code').notNull().unique(),
+    /** ISO-8601 UTC expiry instant (E10 §4: epoch → TEXT ISO8601). */
+    expiresAt: text('expires_at').notNull(),
+    /** ISO-8601 UTC used instant; NULL until used (E10 §4: epoch → TEXT ISO8601). */
+    usedAt: text('used_at'),
+    /** User who used the code (intra-domain FK → signaldock_users.id). */
+    usedBy: text('used_by').references(() => signaldockUsers.id),
+    /** ISO-8601 UTC creation instant (E10 §4: epoch → TEXT ISO8601). */
+    createdAt: text('created_at').notNull(),
+  },
+  (table) => [index('idx_signaldock_claim_codes_agent').on(table.agentId)],
+);
+
+// ---------------------------------------------------------------------------
+// Identity catalog
+// ---------------------------------------------------------------------------
+
+/**
+ * `signaldock_capabilities` — pre-seeded capability-slug catalog. Bare
+ * `capabilities` → `signaldock_capabilities`.
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockCapabilities = sqliteTable('signaldock_capabilities', {
+  /** Capability id. Primary key. */
+  id: text('id').primaryKey(),
+  /** Capability slug (unique). */
+  slug: text('slug').notNull().unique(),
+  /** Capability display name. */
+  name: text('name').notNull(),
+  /** Capability description. */
+  description: text('description').notNull(),
+  /** Capability category. */
+  category: text('category').notNull(),
+  /** ISO-8601 UTC creation instant (E10 §4: epoch → TEXT ISO8601). */
+  createdAt: text('created_at').notNull(),
+});
+
+/**
+ * `signaldock_skills` — pre-seeded agent skill-slug catalog. Bare `skills` →
+ * `signaldock_skills`. (The agent CAPABILITY catalog — distinct from the
+ * installed-skills `skills_*` registry in `./skills.ts`.)
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockSkills = sqliteTable('signaldock_skills', {
+  /** Skill id. Primary key. */
+  id: text('id').primaryKey(),
+  /** Skill slug (unique). */
+  slug: text('slug').notNull().unique(),
+  /** Skill display name. */
+  name: text('name').notNull(),
+  /** Skill description. */
+  description: text('description').notNull(),
+  /** Skill category. */
+  category: text('category').notNull(),
+  /** ISO-8601 UTC creation instant (E10 §4: epoch → TEXT ISO8601). */
+  createdAt: text('created_at').notNull(),
+});
+
+// ---------------------------------------------------------------------------
+// Junction tables
+// ---------------------------------------------------------------------------
+
+/**
+ * `signaldock_agent_capabilities` — agent ↔ capability junction. Bare
+ * `agent_capabilities` → `signaldock_agent_capabilities`.
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockAgentCapabilities = sqliteTable(
+  'signaldock_agent_capabilities',
+  {
+    /** Agent id (intra-domain FK → signaldock_agents.id). */
+    agentId: text('agent_id')
+      .notNull()
+      .references(() => signaldockAgents.id),
+    /** Capability id (intra-domain FK → signaldock_capabilities.id). */
+    capabilityId: text('capability_id')
+      .notNull()
+      .references(() => signaldockCapabilities.id),
+  },
+  (table) => [primaryKey({ columns: [table.agentId, table.capabilityId] })],
+);
+
+/**
+ * `signaldock_agent_skills` — agent ↔ skill junction. Bare `agent_skills` →
+ * `signaldock_agent_skills`. T897 v3 columns: source, attached_at.
+ *
+ * @task T11361 (target shape) · T897 (original)
+ */
+export const signaldockAgentSkills = sqliteTable(
+  'signaldock_agent_skills',
+  {
+    /** Agent id (intra-domain FK → signaldock_agents.id). */
+    agentId: text('agent_id')
+      .notNull()
+      .references(() => signaldockAgents.id),
+    /** Skill id (intra-domain FK → signaldock_skills.id). */
+    skillId: text('skill_id')
+      .notNull()
+      .references(() => signaldockSkills.id),
+    /** Skill-attachment provenance (cant / manual / computed). */
+    source: text('source').notNull().default('manual'),
+    /** ISO-8601 UTC attachment instant (already canonical TEXT, §4). */
+    attachedAt: text('attached_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.agentId, table.skillId] }),
+    index('idx_signaldock_agent_skills_source').on(table.source),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Agent connections
+// ---------------------------------------------------------------------------
+
+/**
+ * `signaldock_agent_connections` — live transport connection tracking
+ * (heartbeat state). Bare `agent_connections` → `signaldock_agent_connections`.
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockAgentConnections = sqliteTable(
+  'signaldock_agent_connections',
+  {
+    /** Connection id. Primary key. */
+    id: text('id').primaryKey().notNull(),
+    /** Connected agent id (soft FK → signaldock_agents.agent_id). */
+    agentId: text('agent_id').notNull(),
+    /** Transport type ("http" / …). */
+    transportType: text('transport_type').notNull().default('http'),
+    /** Transport-specific connection identifier. */
+    connectionId: text('connection_id'),
+    /** ISO-8601 UTC connect instant (E10 §4: epoch → TEXT ISO8601). */
+    connectedAt: text('connected_at').notNull(),
+    /** Epoch-ms last heartbeat (audit-classified numeric, not a flagged timestamp). */
+    lastHeartbeat: integer('last_heartbeat').notNull(),
+    /** JSON connection-metadata blob (serialized TEXT). */
+    connectionMetadata: text('connection_metadata'),
+    /** ISO-8601 UTC creation instant (E10 §4: epoch → TEXT ISO8601). */
+    createdAt: text('created_at').notNull(),
+  },
+  (table) => [
+    index('idx_signaldock_agent_connections_agent').on(table.agentId),
+    index('idx_signaldock_agent_connections_transport').on(table.transportType),
+    index('idx_signaldock_agent_connections_heartbeat').on(table.lastHeartbeat),
+    unique().on(table.agentId, table.connectionId),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Cloud-sync: OAuth, sessions, verifications (better-auth — already TEXT ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * `signaldock_accounts` — cloud-sync OAuth/provider accounts. Bare `accounts` →
+ * `signaldock_accounts`. (better-auth timestamps already canonical TEXT, §4.)
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockAccounts = sqliteTable(
+  'signaldock_accounts',
+  {
+    /** Account row id. Primary key. */
+    id: text('id').primaryKey().notNull(),
+    /** Owning user (intra-domain FK → signaldock_users.id). */
+    userId: text('user_id')
+      .notNull()
+      .references(() => signaldockUsers.id, { onDelete: 'cascade' }),
+    /** Provider account id. */
+    accountId: text('account_id').notNull(),
+    /** OAuth provider id. */
+    providerId: text('provider_id').notNull(),
+    /** Access token. */
+    accessToken: text('access_token'),
+    /** Refresh token. */
+    refreshToken: text('refresh_token'),
+    /** ID token. */
+    idToken: text('id_token'),
+    /** ISO-8601 access-token expiry (canonical TEXT, §4). */
+    accessTokenExpiresAt: text('access_token_expires_at'),
+    /** ISO-8601 refresh-token expiry (canonical TEXT, §4). */
+    refreshTokenExpiresAt: text('refresh_token_expires_at'),
+    /** Granted scope string. */
+    scope: text('scope'),
+    /** Local password hash (credentials provider). */
+    password: text('password'),
+    /** ISO-8601 UTC creation instant (canonical TEXT, §4). */
+    createdAt: text('created_at').notNull(),
+    /** ISO-8601 UTC last-update instant (canonical TEXT, §4). */
+    updatedAt: text('updated_at').notNull(),
+  },
+  (table) => [
+    index('idx_signaldock_accounts_user_id').on(table.userId),
+    unique('idx_signaldock_accounts_provider').on(table.providerId, table.accountId),
+  ],
+);
+
+/**
+ * `signaldock_sessions` — cloud-sync authenticated sessions. Bare `sessions` →
+ * `signaldock_sessions`.
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockSessions = sqliteTable(
+  'signaldock_sessions',
+  {
+    /** Session id. Primary key. */
+    id: text('id').primaryKey().notNull(),
+    /** Owning user (intra-domain FK → signaldock_users.id). */
+    userId: text('user_id')
+      .notNull()
+      .references(() => signaldockUsers.id, { onDelete: 'cascade' }),
+    /** Session token (unique). */
+    token: text('token').notNull().unique(),
+    /** Client IP address. */
+    ipAddress: text('ip_address'),
+    /** Client user-agent string. */
+    userAgent: text('user_agent'),
+    /** ISO-8601 UTC expiry instant (canonical TEXT, §4). */
+    expiresAt: text('expires_at').notNull(),
+    /** Active organization id (soft FK → signaldock_organization.id). */
+    activeOrganizationId: text('active_organization_id'),
+    /** Impersonating admin user id, if any. */
+    impersonatedBy: text('impersonated_by'),
+    /** Active flag (0/1; audit-classified numeric). */
+    active: integer('active').notNull().default(1),
+    /** ISO-8601 UTC creation instant (canonical TEXT, §4). */
+    createdAt: text('created_at').notNull(),
+    /** ISO-8601 UTC last-update instant (canonical TEXT, §4). */
+    updatedAt: text('updated_at').notNull(),
+  },
+  (table) => [index('idx_signaldock_sessions_user_id').on(table.userId)],
+);
+
+/**
+ * `signaldock_verifications` — cloud-sync email/2FA verification tokens. Bare
+ * `verifications` → `signaldock_verifications`.
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockVerifications = sqliteTable(
+  'signaldock_verifications',
+  {
+    /** Verification id. Primary key. */
+    id: text('id').primaryKey().notNull(),
+    /** Identifier being verified (email / phone). */
+    identifier: text('identifier').notNull(),
+    /** Verification value/token. */
+    value: text('value').notNull(),
+    /** ISO-8601 UTC expiry instant (canonical TEXT, §4). */
+    expiresAt: text('expires_at').notNull(),
+    /** ISO-8601 UTC creation instant (canonical TEXT, §4). */
+    createdAt: text('created_at').notNull(),
+    /** ISO-8601 UTC last-update instant (canonical TEXT, §4). */
+    updatedAt: text('updated_at').notNull(),
+  },
+  (table) => [index('idx_signaldock_verifications_identifier').on(table.identifier)],
+);
+
+// ---------------------------------------------------------------------------
+// Cloud-sync: org agent keys
+// ---------------------------------------------------------------------------
+
+/**
+ * `signaldock_org_agent_keys` — org-scoped agent API keys (cloud use; zero rows
+ * locally). Bare `org_agent_keys` → `signaldock_org_agent_keys`.
+ *
+ * @task T11361 (target shape) · T346 (original)
+ */
+export const signaldockOrgAgentKeys = sqliteTable(
+  'signaldock_org_agent_keys',
+  {
+    /** Key row id. Primary key. */
+    id: text('id').primaryKey().notNull(),
+    /** Owning organization (intra-domain FK → signaldock_organization.id). */
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => signaldockOrganization.id, { onDelete: 'cascade' }),
+    /** Scoped agent (intra-domain FK → signaldock_agents.id). */
+    agentId: text('agent_id')
+      .notNull()
+      .references(() => signaldockAgents.id, { onDelete: 'cascade' }),
+    /** Creator user id. */
+    createdBy: text('created_by').notNull(),
+    /** ISO-8601 UTC creation instant (E10 §4: epoch → TEXT ISO8601). */
+    createdAt: text('created_at').notNull(),
+  },
+  (table) => [
+    index('idx_signaldock_org_agent_keys_org').on(table.organizationId),
+    index('idx_signaldock_org_agent_keys_agent').on(table.agentId),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Inferred row + insert types
+// ---------------------------------------------------------------------------
+
+/** Row type for `signaldock_users` SELECT (target shape). */
+export type SignaldockUserRow = typeof signaldockUsers.$inferSelect;
+/** Row type for `signaldock_users` INSERT (target shape). */
+export type NewSignaldockUserRow = typeof signaldockUsers.$inferInsert;
+/** Row type for `signaldock_organization` SELECT (target shape). */
+export type SignaldockOrganizationRow = typeof signaldockOrganization.$inferSelect;
+/** Row type for `signaldock_organization` INSERT (target shape). */
+export type NewSignaldockOrganizationRow = typeof signaldockOrganization.$inferInsert;
+/** Row type for `signaldock_agents` SELECT (target shape). */
+export type SignaldockAgentRow = typeof signaldockAgents.$inferSelect;
+/** Row type for `signaldock_agents` INSERT (target shape). */
+export type NewSignaldockAgentRow = typeof signaldockAgents.$inferInsert;
+/** Row type for `signaldock_claim_codes` SELECT (target shape). */
+export type SignaldockClaimCodeRow = typeof signaldockClaimCodes.$inferSelect;
+/** Row type for `signaldock_claim_codes` INSERT (target shape). */
+export type NewSignaldockClaimCodeRow = typeof signaldockClaimCodes.$inferInsert;
+/** Row type for `signaldock_capabilities` SELECT (target shape). */
+export type SignaldockCapabilityRow = typeof signaldockCapabilities.$inferSelect;
+/** Row type for `signaldock_capabilities` INSERT (target shape). */
+export type NewSignaldockCapabilityRow = typeof signaldockCapabilities.$inferInsert;
+/** Row type for `signaldock_skills` SELECT (target shape). */
+export type SignaldockSkillRow = typeof signaldockSkills.$inferSelect;
+/** Row type for `signaldock_skills` INSERT (target shape). */
+export type NewSignaldockSkillRow = typeof signaldockSkills.$inferInsert;
+/** Row type for `signaldock_agent_capabilities` SELECT (target shape). */
+export type SignaldockAgentCapabilityRow = typeof signaldockAgentCapabilities.$inferSelect;
+/** Row type for `signaldock_agent_capabilities` INSERT (target shape). */
+export type NewSignaldockAgentCapabilityRow = typeof signaldockAgentCapabilities.$inferInsert;
+/** Row type for `signaldock_agent_skills` SELECT (target shape). */
+export type SignaldockAgentSkillRow = typeof signaldockAgentSkills.$inferSelect;
+/** Row type for `signaldock_agent_skills` INSERT (target shape). */
+export type NewSignaldockAgentSkillRow = typeof signaldockAgentSkills.$inferInsert;
+/** Row type for `signaldock_agent_connections` SELECT (target shape). */
+export type SignaldockAgentConnectionRow = typeof signaldockAgentConnections.$inferSelect;
+/** Row type for `signaldock_agent_connections` INSERT (target shape). */
+export type NewSignaldockAgentConnectionRow = typeof signaldockAgentConnections.$inferInsert;
+/** Row type for `signaldock_accounts` SELECT (target shape). */
+export type SignaldockAccountRow = typeof signaldockAccounts.$inferSelect;
+/** Row type for `signaldock_accounts` INSERT (target shape). */
+export type NewSignaldockAccountRow = typeof signaldockAccounts.$inferInsert;
+/** Row type for `signaldock_sessions` SELECT (target shape). */
+export type SignaldockSessionRow = typeof signaldockSessions.$inferSelect;
+/** Row type for `signaldock_sessions` INSERT (target shape). */
+export type NewSignaldockSessionRow = typeof signaldockSessions.$inferInsert;
+/** Row type for `signaldock_verifications` SELECT (target shape). */
+export type SignaldockVerificationRow = typeof signaldockVerifications.$inferSelect;
+/** Row type for `signaldock_verifications` INSERT (target shape). */
+export type NewSignaldockVerificationRow = typeof signaldockVerifications.$inferInsert;
+/** Row type for `signaldock_org_agent_keys` SELECT (target shape). */
+export type SignaldockOrgAgentKeyRow = typeof signaldockOrgAgentKeys.$inferSelect;
+/** Row type for `signaldock_org_agent_keys` INSERT (target shape). */
+export type NewSignaldockOrgAgentKeyRow = typeof signaldockOrgAgentKeys.$inferInsert;

--- a/packages/core/src/store/schema/cleo-global/skills.ts
+++ b/packages/core/src/store/schema/cleo-global/skills.ts
@@ -1,0 +1,267 @@
+/**
+ * Global-scope `cleo.db` — consolidated **skills** domain (4 tables).
+ *
+ * Part of the consolidated GLOBAL-scope `cleo.db` target shape authored for
+ * SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2, task T11361). Target-shape
+ * authoring only — physical names carry the `skills_` domain prefix. The live
+ * runtime module `schema/skills-schema.ts` keeps its UNPREFIXED names
+ * (`skills`, `skill_usage`, …) until the exodus migration (T11248) swaps the
+ * substrate.
+ *
+ * ## Idempotent prefixer (AC1)
+ *
+ * All four source tables are bare and gain the `skills_` prefix at exodus:
+ * `skills` → `skills_skills` · `skill_usage` → `skills_skill_usage` ·
+ * `skill_reviews` → `skills_skill_reviews` · `skill_patches` →
+ * `skills_skill_patches`.
+ *
+ * ## E10 typing applied
+ *
+ * The skills source is already E10-clean — no non-conformers to remediate:
+ *   - **§5a enums:** `source_type` / `lifecycle_state` / `outcome` / `status`
+ *     already declare `text({ enum })` from in-module named const arrays
+ *     ({@link SKILL_SOURCE_TYPES} / {@link SKILL_LIFECYCLE_STATES} /
+ *     {@link SKILL_REVIEW_OUTCOMES} / {@link SKILL_PATCH_STATUSES}); the
+ *     matching `CHECK (col IN (...))` ships at exodus.
+ *   - **§3a booleans:** `skills.pinned` / `skills.is_agent_created` already
+ *     declare `{ mode:'boolean' }`.
+ *   - **§4 timestamps:** every timestamp is already canonical TEXT ISO8601
+ *     (`installed_at`, `observed_at`, `reviewed_at`, `proposed_at`, …) — no
+ *     epoch/Date non-conformer in this domain.
+ *
+ * ## FK reconciliation to single-file Pattern A (AC4)
+ *
+ * The skills source declares all relationships as LOGICAL (denormalized
+ * `skill_name` / `review_id` columns, no enforced `.references()`), so nothing
+ * crossed a file boundary. `skill_usage.task_id` is a cross-domain reference to
+ * the PROJECT-scope `cleo.db` and therefore stays a plain `text` soft FK
+ * (resolved by the skill-telemetry accessor; no ATTACH).
+ *
+ * @task T11361
+ * @epic T11245
+ * @saga T11242
+ * @see docs/migration/sqlite-schema-canonical.md §1 (D1″ · global counts) · §3a · §5a
+ * @see docs/migration/sqlite-schema-columns.json (per-column affinity SSoT)
+ * @see ../skills-schema.ts (the runtime source module)
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+// ---------------------------------------------------------------------------
+// E10 §5a — enum const arrays (in-module SSoT; no @cleocode/contracts dependency
+// in this leaf storage domain)
+// ---------------------------------------------------------------------------
+
+/**
+ * Provenance of a skill row (Sphere A canonical vs Sphere B authored).
+ *
+ * @architecture SG-CLEO-SKILLS v3 §4 `source_type` enum
+ * @task T11361 (target shape) · T9651 (original)
+ */
+export const SKILL_SOURCE_TYPES = ['canonical', 'user', 'community', 'agent-created'] as const;
+
+/** TypeScript union derived from {@link SKILL_SOURCE_TYPES}. */
+export type SkillSourceType = (typeof SKILL_SOURCE_TYPES)[number];
+
+/**
+ * Lifecycle state of a skill row.
+ *
+ * @architecture SG-CLEO-SKILLS v3 §4 `lifecycle_state` enum
+ * @task T11361 (target shape) · T9651 (original)
+ */
+export const SKILL_LIFECYCLE_STATES = ['active', 'stale', 'archived'] as const;
+
+/** TypeScript union derived from {@link SKILL_LIFECYCLE_STATES}. */
+export type SkillLifecycleState = (typeof SKILL_LIFECYCLE_STATES)[number];
+
+/**
+ * Skill review outcome (council and/or grade pipelines).
+ *
+ * @architecture SG-CLEO-SKILLS v3 §6/§7 (auto-improve)
+ * @task T11361 (target shape) · T9651 (original)
+ */
+export const SKILL_REVIEW_OUTCOMES = ['approved', 'rejected', 'needs-changes'] as const;
+
+/** TypeScript union derived from {@link SKILL_REVIEW_OUTCOMES}. */
+export type SkillReviewOutcome = (typeof SKILL_REVIEW_OUTCOMES)[number];
+
+/**
+ * Skill patch application state.
+ *
+ * @architecture SG-CLEO-SKILLS v3 §6/§7 (auto-improve)
+ * @task T11361 (target shape) · T9651 (original)
+ */
+export const SKILL_PATCH_STATUSES = ['proposed', 'applied', 'reverted', 'rejected'] as const;
+
+/** TypeScript union derived from {@link SKILL_PATCH_STATUSES}. */
+export type SkillPatchStatus = (typeof SKILL_PATCH_STATUSES)[number];
+
+// ---------------------------------------------------------------------------
+// Tables
+// ---------------------------------------------------------------------------
+
+/**
+ * `skills_skills` — per-user registry of installed skills (one row per name).
+ * Bare `skills` → `skills_skills` under the AC1 idempotent prefixer.
+ *
+ * @task T11361 (target shape) · T9651 (original)
+ */
+export const skillsSkills = sqliteTable(
+  'skills_skills',
+  {
+    /** Surrogate primary key — autoincrement integer. */
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    /** Skill identifier (e.g. `ct-orchestrator`). Globally unique. */
+    name: text('name').notNull().unique(),
+    /** Semver string parsed from the skill frontmatter, if present. */
+    version: text('version'),
+    /** Provenance from {@link SKILL_SOURCE_TYPES} (E10 §5a). */
+    sourceType: text('source_type', { enum: SKILL_SOURCE_TYPES }).notNull(),
+    /** Origin URL (GitHub / marketplace); NULL for user / agent-created. */
+    sourceUrl: text('source_url'),
+    /** Resolved on-disk path where the skill currently lives. */
+    installPath: text('install_path').notNull(),
+    /** XDG canonical path (Sphere A); NULL for Sphere B rows. */
+    canonicalPath: text('canonical_path'),
+    /** ISO-8601 install timestamp (canonical TEXT, §4). */
+    installedAt: text('installed_at').notNull(),
+    /** ISO-8601 last-updated timestamp (canonical TEXT, §4). */
+    lastUpdatedAt: text('last_updated_at'),
+    /** Lifecycle state from {@link SKILL_LIFECYCLE_STATES} (E10 §5a). */
+    lifecycleState: text('lifecycle_state', { enum: SKILL_LIFECYCLE_STATES })
+      .notNull()
+      .default('active'),
+    /** When true, auto-improve patches are refused (E10 §3a — typed boolean). */
+    pinned: integer('pinned', { mode: 'boolean' }).notNull().default(false),
+    /** True if generated by an agent at runtime (E10 §3a — typed boolean). */
+    isAgentCreated: integer('is_agent_created', { mode: 'boolean' }).notNull().default(false),
+    /** ISO-8601 archive timestamp; NULL while not archived (canonical TEXT, §4). */
+    archivedAt: text('archived_at'),
+    /** Path the row was archived FROM (so move-back is reproducible). */
+    archivedFromPath: text('archived_from_path'),
+  },
+  (table) => [
+    index('idx_skills_skills_state').on(table.lifecycleState),
+    index('idx_skills_skills_source').on(table.sourceType),
+  ],
+);
+
+/**
+ * `skills_skill_usage` — per-event telemetry row (load / invoke / error). Bare
+ * `skill_usage` → `skills_skill_usage`.
+ *
+ * @task T11361 (target shape) · T9651 (original)
+ */
+export const skillsSkillUsage = sqliteTable(
+  'skills_skill_usage',
+  {
+    /** Surrogate primary key — autoincrement integer. */
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    /** Logical FK to {@link skillsSkills}.name — denormalised for query speed. */
+    skillName: text('skill_name').notNull(),
+    /** ISO-8601 wall-clock timestamp of the load/invoke event (canonical TEXT, §4). */
+    observedAt: text('observed_at').notNull().default(sql`(datetime('now'))`),
+    /** Event kind — `load`, `invoke`, `error`, etc. */
+    eventKind: text('event_kind').notNull(),
+    /**
+     * Owning task context; NULL if not running inside a CLEO task.
+     *
+     * Cross-domain soft FK → PROJECT-scope `cleo.db` `tasks_tasks.id`. CANNOT
+     * be a native FK (different scope DB file); resolved by the skill-telemetry
+     * accessor (AC4 — no ATTACH).
+     */
+    taskId: text('task_id'),
+    /** Model identifier the calling agent was running under. */
+    modelId: text('model_id'),
+    /** Free-form JSON blob for forward-compatible event metadata (serialized TEXT). */
+    metadata: text('metadata').notNull().default('{}'),
+  },
+  (table) => [
+    index('idx_skills_skill_usage_name_observed').on(table.skillName, table.observedAt),
+    index('idx_skills_skill_usage_kind').on(table.eventKind),
+  ],
+);
+
+/**
+ * `skills_skill_reviews` — council + grade review outcomes (auto-improve quality
+ * gate). Bare `skill_reviews` → `skills_skill_reviews`.
+ *
+ * @task T11361 (target shape) · T9651 (original)
+ */
+export const skillsSkillReviews = sqliteTable(
+  'skills_skill_reviews',
+  {
+    /** Surrogate primary key — autoincrement integer. */
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    /** Logical FK to {@link skillsSkills}.name. */
+    skillName: text('skill_name').notNull(),
+    /** ISO-8601 timestamp of the review (canonical TEXT, §4). */
+    reviewedAt: text('reviewed_at').notNull().default(sql`(datetime('now'))`),
+    /** Outcome verdict from {@link SKILL_REVIEW_OUTCOMES} (E10 §5a). */
+    outcome: text('outcome', { enum: SKILL_REVIEW_OUTCOMES }).notNull(),
+    /** Numeric grade (0-100); NULL if review was council-only. */
+    score: integer('score'),
+    /** Identifier of the council/grade run (UUID, hash, or run-id). */
+    reviewRunId: text('review_run_id'),
+    /** Free-form summary / chairman verdict text. */
+    summary: text('summary'),
+  },
+  (table) => [
+    index('idx_skills_skill_reviews_name_reviewed').on(table.skillName, table.reviewedAt),
+    index('idx_skills_skill_reviews_outcome').on(table.outcome),
+  ],
+);
+
+/**
+ * `skills_skill_patches` — auto-improve patch payload (unified diff). Bare
+ * `skill_patches` → `skills_skill_patches`.
+ *
+ * @task T11361 (target shape) · T9651 (original)
+ */
+export const skillsSkillPatches = sqliteTable(
+  'skills_skill_patches',
+  {
+    /** Surrogate primary key — autoincrement integer. */
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    /** Logical FK to {@link skillsSkills}.name. */
+    skillName: text('skill_name').notNull(),
+    /** ISO-8601 timestamp the patch was proposed (canonical TEXT, §4). */
+    proposedAt: text('proposed_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 timestamp the patch was applied; NULL while proposed (canonical TEXT, §4). */
+    appliedAt: text('applied_at'),
+    /** Logical FK to {@link skillsSkillReviews}.id that gated this patch. */
+    reviewId: integer('review_id'),
+    /** Unified diff bytes (text, may be large — kept inline by design). */
+    diff: text('diff').notNull(),
+    /** Lifecycle from {@link SKILL_PATCH_STATUSES} (E10 §5a). */
+    status: text('status', { enum: SKILL_PATCH_STATUSES }).notNull().default('proposed'),
+    /** Revert pointer — id of the patch that reverted this one. */
+    revertedByPatchId: integer('reverted_by_patch_id'),
+  },
+  (table) => [
+    index('idx_skills_skill_patches_name_proposed').on(table.skillName, table.proposedAt),
+    index('idx_skills_skill_patches_status').on(table.status),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Inferred row + insert types
+// ---------------------------------------------------------------------------
+
+/** Row type for `skills_skills` SELECT (target shape). */
+export type SkillRow = typeof skillsSkills.$inferSelect;
+/** Row type for `skills_skills` INSERT (target shape). */
+export type NewSkillRow = typeof skillsSkills.$inferInsert;
+/** Row type for `skills_skill_usage` SELECT (target shape). */
+export type SkillUsageRow = typeof skillsSkillUsage.$inferSelect;
+/** Row type for `skills_skill_usage` INSERT (target shape). */
+export type NewSkillUsageRow = typeof skillsSkillUsage.$inferInsert;
+/** Row type for `skills_skill_reviews` SELECT (target shape). */
+export type SkillReviewRow = typeof skillsSkillReviews.$inferSelect;
+/** Row type for `skills_skill_reviews` INSERT (target shape). */
+export type NewSkillReviewRow = typeof skillsSkillReviews.$inferInsert;
+/** Row type for `skills_skill_patches` SELECT (target shape). */
+export type SkillPatchRow = typeof skillsSkillPatches.$inferSelect;
+/** Row type for `skills_skill_patches` INSERT (target shape). */
+export type NewSkillPatchRow = typeof skillsSkillPatches.$inferInsert;


### PR DESCRIPTION
## Summary

Authors the **GLOBAL-scope `cleo.db`** target schema as domain-prefixed
Pattern-A `sqliteTable` modules under a NEW
`packages/core/src/store/schema/cleo-global/` family, mirroring the
just-completed `cleo-project/` family (T11360). Per **D1″**, the global
`cleo.db` = **49 tables / 555 columns** = nexus 10 + skills 4 + signaldock 13 +
**brain 22 (MIRRORED)**.

**Purely additive** — `git diff HEAD` touches only the new `cleo-global/`
directory (4 files); zero modifications to any existing file.

### Modules authored (27 global-exclusive tables)
- **`nexus.ts`** (10): `nexus_project_registry` · `nexus_project_id_aliases` ·
  `nexus_audit_log` · `nexus_schema_meta` · `nexus_nodes` · `nexus_relations` ·
  `nexus_contracts` · `nexus_code_index` · `nexus_user_profile` · `nexus_sigils`.
- **`skills.ts`** (4): `skills_skills` · `skills_skill_usage` ·
  `skills_skill_reviews` · `skills_skill_patches`.
- **`signaldock.ts`** (13): all 13 signaldock tables, `signaldock_`-prefixed
  (folds into global per D1 — no standalone `signaldock.db`).
- **`index.ts`**: barrel composing the 27 above + re-exporting the shared brain.

## brain_* is MIRRORED — REUSED, NOT duplicated

The global barrel re-exports the **SAME** `../cleo-shared/brain.ts` module
(`export * from '../cleo-shared/index.js'`) that the `cleo-project/` barrel uses.
**Zero brain tables copied or re-authored.** Runtime barrel-load proof: the
compiled global barrel resolves **50 distinct physical tables (zero
duplicates)** = 23 `brain_*` (22 canonical + the `brain_sticky_tags` E4 junction
already on main, identical to the project family) + 10 `nexus_*` + 4 `skills_*` +
13 `signaldock_*`.

## Acceptance criteria

- [x] **AC1** — nexus/skills/signaldock authored as domain-prefixed
  `sqliteTable`s in `cleo-global/`; brain_* reused from `cleo-shared`. Idempotent
  prefixer applied (already-`nexus_` tables not double-prefixed; bare
  `project_registry`/`code_index`/`agents`/`users`/`skills`/… gain their domain
  prefix). signaldock folds here (global identity, no standalone signaldock.db).
- [x] **AC2** — E10 typing: §4 Drizzle-Date → TEXT ISO8601
  (`nexus_user_profile`/`nexus_sigils` timestamps); §4 epoch → TEXT ISO8601
  (signaldock cloud-sync timestamps); §5b enums minted (`SIGIL_ROLES`,
  `CODE_INDEX_KINDS`, `SIGNALDOCK_USER_ROLES`, `SIGNALDOCK_AGENT_STATUSES`); §3b
  `signaldock_agents.is_active` → `integer({ mode:'boolean' })`. (Columns the
  audit classifies `numeric` — `email_verified`, `banned`, `can_spawn`,
  `last_heartbeat`, … — kept plain `integer` faithful to the audit.)
- [x] **AC3** — JSON columns use existing E4 patterns (serialized TEXT per the
  JSON-Column Audit disposition); no new pattern introduced.
- [x] **AC4** — FK reconciliation to single-file Pattern A: signaldock
  intra-domain FKs stay native `.references()` (all 13 tables in one global
  file); nexus/skills cross-domain refs to the project-scope `cleo.db`
  (`nexus_audit_log.session_id`, `nexus_user_profile.derived_from_message_id`,
  `skills_skill_usage.task_id`) remain soft TEXT — no ATTACH, no cross-file FK.
- [x] **AC5** — `pnpm run typecheck` (tsc -b) green; zero `any`/`unknown`.

## Validation (all PASS locally)

1. **`pnpm run typecheck` (tsc -b)** → exit 0. **PASS**
2. **Cold smoke** — `node build.mjs` (Build complete) + `node
   packages/cleo/dist/cli/index.js version` → `{"success":true,...}`. **PASS**.
   Barrel loads 50 distinct prefixed tables, zero collisions, shared brain
   resolves.
3. **SSoT** — change is additive only; no path-file / inventory / config /
   columns.json touched. **PASS**.
4. **Vitest** — `--project @cleocode/contracts` 734/734 ✓ ; core
   `db-inventory` 10/10 ✓, `migration-baseline` 13/13 ✓,
   `sqlite-backup-global` 21/21 ✓. **PASS** (zero new failures). The 17 failing
   core tests are **pre-existing** worktree/git napi-fallback flakes
   (`worktree-merge/complete/audit/prune` → "integrateWorktree not available in
   test fallback"; `reconstruct`/`backfill` → repo-specific git history / "no
   git remotes") — unrelated to schema; `git diff HEAD` proves no existing file
   changed.
5. **`cleo check arch`** 5/5 ✓ + **biome** clean ✓. **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)