### PR TITLE
feat(T11451): run gateway as a daemon subsystem (R3-T7 · SG-RUNTIME-UNIFICATION)

### DIFF
--- a/packages/runtime/src/gateway/__tests__/daemon-subsystem.test.ts
+++ b/packages/runtime/src/gateway/__tests__/daemon-subsystem.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Gateway-as-daemon-subsystem tests (R3-T7 · T11451).
+ *
+ * Asserts the gateway is expressible as a supervised {@link Subsystem} that the
+ * R2 `SubsystemRegistry` drives end-to-end:
+ *  1. `defineGatewaySubsystem` produces a frozen, registrable subsystem named
+ *     per-scope (`gateway-<scope>`).
+ *  2. Registered + started, it binds the configured transports (RPC unix socket
+ *     + HTTP server) and a real client can dispatch through each.
+ *  3. `aggregateHealth()` reports the gateway as a `running` row that projects
+ *     onto the FROZEN supervisor `MonitorResponse`.
+ *  4. `shutdownAll()` closes every bound listener (socket file removed, port
+ *     freed).
+ *  5. Two scopes register as two distinct, non-colliding subsystems → one
+ *     external-facing process surface per scope.
+ *  6. A config with no transport is rejected; a mid-start bind failure rolls
+ *     back the already-bound listener (no half-open socket).
+ *
+ * @task T11451
+ * @epic T11254
+ * @saga T11243
+ */
+
+import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { request } from 'node:http';
+import { connect, createServer as createTcpServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  type DispatchRequest,
+  type DispatchResponse,
+  MonitorResponseSchema,
+  toMonitorChildren,
+} from '@cleocode/contracts';
+import { GATEWAY_RPC_PROTOCOL_VERSION } from '@cleocode/contracts/gateway/rpc';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SubsystemRegistry } from '../../daemon/index.js';
+import { defineGatewaySubsystem, gatewaySubsystemName } from '../daemon-subsystem.js';
+import type { GatewayHandler } from '../index.js';
+
+/** A success-echoing gateway handler that records every request it routed. */
+function fakeHandler(): { handler: GatewayHandler; calls: DispatchRequest[] } {
+  const calls: DispatchRequest[] = [];
+  const handler: GatewayHandler = {
+    handle(req: DispatchRequest): Promise<DispatchResponse> {
+      calls.push(req);
+      return Promise.resolve({
+        meta: {
+          gateway: req.gateway,
+          domain: req.domain,
+          operation: req.operation,
+          timestamp: '2026-05-31T00:00:00.000Z',
+          duration_ms: 1,
+          source: req.source,
+          requestId: req.requestId,
+        },
+        success: true,
+        data: { ok: true },
+      });
+    },
+  };
+  return { handler, calls };
+}
+
+/** Unique socket path under the OS tmpdir for an isolated test run. */
+function tmpSocket(): string {
+  return join(tmpdir(), `cleo-gw-${randomUUID()}.sock`);
+}
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const fn = cleanups.pop();
+    if (fn) await fn().catch(() => undefined);
+  }
+});
+
+describe('defineGatewaySubsystem (R3-T7 · T11451)', () => {
+  it('produces a frozen, registrable subsystem named per-scope', () => {
+    const { handler } = fakeHandler();
+    const sub = defineGatewaySubsystem({
+      scope: 'project',
+      handler,
+      rpc: { socketPath: tmpSocket() },
+    });
+    expect(sub.name).toBe('gateway-project');
+    expect(gatewaySubsystemName('global')).toBe('gateway-global');
+    expect(Object.isFrozen(sub)).toBe(true);
+  });
+
+  it('rejects a config with no transport configured', () => {
+    const { handler } = fakeHandler();
+    expect(() => defineGatewaySubsystem({ scope: 'project', handler })).toThrow(TypeError);
+  });
+});
+
+describe('gateway subsystem lifecycle through the daemon registry (AC1)', () => {
+  it('starts, hosts RPC + HTTP, reports running health, then shuts down', async () => {
+    const { handler, calls } = fakeHandler();
+    const socketPath = tmpSocket();
+    const registry = new SubsystemRegistry();
+    registry.register(
+      defineGatewaySubsystem({
+        scope: 'project',
+        handler,
+        rpc: { socketPath },
+        http: { port: 0 }, // ephemeral port
+      }),
+    );
+
+    await registry.startAll();
+    cleanups.push(() => registry.shutdownAll());
+
+    // The RPC unix socket is bound and a client can dispatch through it.
+    expect(existsSync(socketPath)).toBe(true);
+    const rpcResponse = await rpcRoundTrip(socketPath);
+    expect(rpcResponse.direction).toBe('response');
+    expect(calls.some((c) => c.source === 'rpc')).toBe(true);
+
+    // Health: the gateway reports a single running row that projects onto the
+    // FROZEN supervisor MonitorResponse (AC: lifecycle/health integration).
+    const health = await registry.aggregateHealth();
+    expect(health.subsystems).toHaveLength(1);
+    expect(health.allHealthy).toBe(true);
+    const row = health.subsystems[0];
+    expect(row.child_id).toBe('gateway-project');
+    expect(row.state).toBe('running');
+    expect(row.detail).toContain('rpc=');
+    expect(row.detail).toContain('http=');
+    const monitor = MonitorResponseSchema.safeParse({
+      kind: 'monitor',
+      children: toMonitorChildren(health),
+    });
+    expect(monitor.success).toBe(true);
+
+    // Shutdown closes the RPC listener — the stale socket node is removed.
+    await registry.shutdownAll();
+    cleanups.length = 0;
+    expect(existsSync(socketPath)).toBe(false);
+  });
+
+  it('hosts the HTTP transport and routes POST /<gateway>/<domain>/<op> (AC: external clients)', async () => {
+    const { handler, calls } = fakeHandler();
+    const registry = new SubsystemRegistry();
+    const sub = defineGatewaySubsystem({ scope: 'global', handler, http: { port: 0 } });
+    registry.register(sub);
+
+    const started = await sub.start();
+    cleanups.push(() => sub.shutdown(started));
+    const port = started.http?.port;
+    expect(typeof port).toBe('number');
+
+    const body = await httpRoundTrip(port as number, '/query/tasks/show', { id: 'T1' });
+    expect(body.success).toBe(true);
+    const httpCall = calls.find((c) => c.source === 'http');
+    expect(httpCall?.domain).toBe('tasks');
+    expect(httpCall?.operation).toBe('show');
+    expect(httpCall?.params).toEqual({ id: 'T1' });
+  });
+});
+
+describe('one external-facing process per scope (AC1)', () => {
+  it('registers project + global as two distinct, non-colliding subsystems', async () => {
+    const { handler } = fakeHandler();
+    const registry = new SubsystemRegistry();
+    registry.register(
+      defineGatewaySubsystem({ scope: 'project', handler, rpc: { socketPath: tmpSocket() } }),
+    );
+    registry.register(
+      defineGatewaySubsystem({ scope: 'global', handler, rpc: { socketPath: tmpSocket() } }),
+    );
+    expect(registry.names).toEqual(['gateway-project', 'gateway-global']);
+
+    await registry.startAll();
+    cleanups.push(() => registry.shutdownAll());
+    const health = await registry.aggregateHealth();
+    expect(health.subsystems.map((r) => r.child_id)).toEqual(['gateway-project', 'gateway-global']);
+    expect(health.allHealthy).toBe(true);
+  });
+});
+
+describe('mid-start rollback (no half-open listener)', () => {
+  it('closes the already-bound RPC socket when the HTTP bind fails', async () => {
+    const { handler } = fakeHandler();
+    const socketPath = tmpSocket();
+    // Bind a port, then ask the gateway to bind the SAME port for HTTP → EADDRINUSE.
+    const occupied = await occupyPort();
+    cleanups.push(() => occupied.close());
+
+    const sub = defineGatewaySubsystem({
+      scope: 'project',
+      handler,
+      rpc: { socketPath },
+      http: { port: occupied.port, host: '127.0.0.1' },
+    });
+
+    await expect(sub.start()).rejects.toBeDefined();
+    // The RPC socket bound first must have been rolled back — no half-open node.
+    expect(existsSync(socketPath)).toBe(false);
+  });
+});
+
+// ───────────────────────── test wire helpers ─────────────────────────
+
+/** Open the RPC socket, send one request frame, resolve the first reply frame. */
+function rpcRoundTrip(socketPath: string): Promise<{ direction: string }> {
+  return new Promise((resolve, reject) => {
+    const sock = connect(socketPath);
+    let buf = '';
+    sock.setEncoding('utf8');
+    sock.on('connect', () => {
+      const frame = {
+        protocol_version: GATEWAY_RPC_PROTOCOL_VERSION,
+        id: 'f1',
+        direction: 'request' as const,
+        request: {
+          gateway: 'query',
+          domain: 'tasks',
+          operation: 'show',
+          params: { id: 'T1' },
+          source: 'rpc',
+          requestId: 'r1',
+        },
+      };
+      sock.write(`${JSON.stringify(frame)}\n`);
+    });
+    sock.on('data', (chunk: string) => {
+      buf += chunk;
+      const nl = buf.indexOf('\n');
+      if (nl >= 0) {
+        const line = buf.slice(0, nl);
+        sock.end();
+        try {
+          resolve(JSON.parse(line));
+        } catch (err) {
+          reject(err);
+        }
+      }
+    });
+    sock.on('error', reject);
+  });
+}
+
+/** POST a JSON body to the HTTP gateway and resolve the parsed LAFS envelope. */
+function httpRoundTrip(
+  port: number,
+  path: string,
+  payload: Record<string, unknown>,
+): Promise<DispatchResponse> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(payload);
+    const req = request(
+      {
+        host: '127.0.0.1',
+        port,
+        path,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) },
+      },
+      (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (c: string) => {
+          body += c;
+        });
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(body));
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+/** Bind an ephemeral TCP port and return it + an idempotent closer. */
+function occupyPort(): Promise<{ port: number; close(): Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    const server = createTcpServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address !== null ? address.port : 0;
+      resolve({
+        port,
+        close: () =>
+          new Promise<void>((res) => {
+            server.close(() => res());
+          }),
+      });
+    });
+  });
+}

--- a/packages/runtime/src/gateway/daemon-subsystem.ts
+++ b/packages/runtime/src/gateway/daemon-subsystem.ts
@@ -1,0 +1,254 @@
+/**
+ * The gateway as a supervised **daemon subsystem**.
+ *
+ * R3-T7 (this task) closes the loop between the two R-track halves: the R3
+ * gateway (dispatcher + the four transport adapters) and the R2 daemon
+ * (`defineSubsystem` + the `SubsystemRegistry`). It expresses the
+ * external-facing gateway as a uniform {@link Subsystem} so the R2 daemon
+ * registry drives its `start → healthProbe → shutdown` lifecycle exactly like
+ * every other long-running concern (Studio supervision, the GC cron, …). One
+ * gateway subsystem is registered per scope (project / global) → one
+ * external-facing gateway process per scope.
+ *
+ * Which transports the daemon hosts:
+ *  - the **RPC unix socket** (`@cleocode/runtime/gateway/rpc`) — the canonical
+ *    local-client wire: the `cleo` CLI, Studio's server process, and test
+ *    harnesses open it to dispatch without paying a cold `cleo` spawn.
+ *  - the **HTTP server** (`@cleocode/runtime/gateway/http` via the daemon-local
+ *    `startHttpServer` embedder) — for external clients that speak HTTP rather
+ *    than the unix-socket NDJSON wire.
+ *
+ * The CLI and MCP adapters are intentionally NOT hosted by the daemon: the CLI
+ * adapter is in-process to the `cleo` binary, and the MCP adapter is a stdio
+ * server an MCP client spawns and owns — neither is a long-lived,
+ * daemon-supervised listener. The two external-facing listeners (RPC + HTTP)
+ * are the ones the daemon owns.
+ *
+ * This subsystem adds NO behavior to the adapters themselves — it only wires
+ * their existing `start*Server` / `close()` lifecycle (and their already-merged
+ * routing) into the daemon registry's uniform lifecycle. It carries NO
+ * `@cleocode/cleo` dependency and NO drizzle-orm (the runtime invariant): the
+ * caller injects the assembled {@link GatewayHandler} and the resolved bind
+ * coordinates; this module only orchestrates listeners.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/gateway
+ *
+ * @task T11451 (R3-T7)
+ * @epic T11254
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import type { Subsystem, SubsystemHealth, SubsystemState } from '@cleocode/contracts';
+import { getLogger } from '@cleocode/core';
+import { defineSubsystem } from '../daemon/index.js';
+import { type HttpServerHandle, type HttpServerOptions, startHttpServer } from './http/listen.js';
+import type { GatewayHandler } from './index.js';
+import { type RpcServerHandle, type RpcServerOptions, startRpcServer } from './rpc/index.js';
+
+/** The scope a single gateway process serves — one external-facing process per scope. */
+export type GatewayScope = 'project' | 'global';
+
+/**
+ * Configuration for one scoped gateway subsystem.
+ *
+ * The caller injects the assembled, transport-neutral {@link GatewayHandler}
+ * (built with `createGatewayHandler` from its domain handlers + middleware) and
+ * the resolved bind coordinates for each hosted transport. The runtime never
+ * resolves paths/ports itself — that keeps it free of `@cleocode/paths` and of
+ * any policy decision about where a scope's socket/port lives.
+ */
+export interface GatewaySubsystemOptions {
+  /** The scope this gateway process serves (`project` | `global`). */
+  scope: GatewayScope;
+  /** The transport-neutral gateway handler every hosted transport routes through. */
+  handler: GatewayHandler;
+  /**
+   * RPC unix-socket transport options. When omitted, the RPC transport is not
+   * hosted (a deployment that only wants HTTP). At least one transport MUST be
+   * configured.
+   */
+  rpc?: RpcServerOptions;
+  /**
+   * HTTP transport options. When omitted, the HTTP transport is not hosted (a
+   * deployment that only wants the local RPC socket). At least one transport
+   * MUST be configured.
+   */
+  http?: HttpServerOptions;
+}
+
+/**
+ * The live context a started gateway subsystem threads from `start` into
+ * `healthProbe`/`shutdown`: the bound transport handles plus the owning pid.
+ *
+ * `void`-typed contexts are common for subsystems, but the gateway needs to
+ * carry its bound handles so `shutdown` can close exactly what `start` opened
+ * (and `healthProbe` can report the bound coordinates).
+ */
+export interface GatewaySubsystemContext {
+  /** The OS pid hosting the listeners (this daemon process). */
+  readonly pid: number;
+  /** The bound RPC server handle, when the RPC transport is hosted. */
+  readonly rpc?: RpcServerHandle;
+  /** The bound HTTP server handle, when the HTTP transport is hosted. */
+  readonly http?: HttpServerHandle;
+}
+
+/**
+ * The stable subsystem name (and supervised `child_id`) of a scoped gateway.
+ *
+ * Suffixed with the scope so a single daemon process supervising both scopes
+ * (project + global) registers two distinct, non-colliding subsystems. The
+ * `child_id` matches the id the Rust supervisor tracks the listener under.
+ *
+ * @param scope - The gateway scope.
+ * @returns The subsystem name, e.g. `gateway-project`.
+ */
+export function gatewaySubsystemName(scope: GatewayScope): string {
+  return `gateway-${scope}`;
+}
+
+/**
+ * Declare the external-facing gateway as a supervised daemon {@link Subsystem}.
+ *
+ * The returned subsystem (frozen by {@link defineSubsystem}) is registered with
+ * a `SubsystemRegistry`, which then drives its lifecycle uniformly:
+ *
+ *  - `start()`       — binds the configured transports (RPC unix socket and/or
+ *    HTTP server) over the injected handler, in a fixed order (RPC then HTTP).
+ *    If the second listener fails to bind, the first is rolled back so a failed
+ *    start leaves no half-open listener — then the error is re-thrown for the
+ *    registry's `onError` sink.
+ *  - `healthProbe()` — reports a single {@link SubsystemHealth} row keyed on the
+ *    scoped `child_id`, `running` while the configured listeners are live, with
+ *    a `detail` summarizing the bound coordinates. Projects losslessly onto the
+ *    supervisor's `ChildStatus`.
+ *  - `shutdown()`    — closes every bound listener (best-effort, idempotent) in
+ *    reverse bind order (HTTP then RPC).
+ *
+ * One subsystem instance is declared per scope, so registering the project and
+ * global gateways yields two supervised listeners → one external-facing gateway
+ * process surface per scope (AC1).
+ *
+ * @param opts - The scoped gateway configuration (handler + per-transport bind
+ *   coordinates).
+ * @returns A frozen {@link Subsystem} ready to `register()` with a
+ *   `SubsystemRegistry`.
+ * @throws {TypeError} When neither the RPC nor the HTTP transport is configured
+ *   (a gateway with no hosted transport serves nothing).
+ *
+ * @example
+ * ```ts
+ * const registry = new SubsystemRegistry();
+ * registry.register(
+ *   defineGatewaySubsystem({
+ *     scope: 'project',
+ *     handler: createGatewayHandler(dispatcherConfig),
+ *     rpc: { socketPath: '/run/cleo/cleo-gateway-rpc-project.sock' },
+ *     http: { port: 7777 },
+ *   }),
+ * );
+ * await registry.startAll();        // binds the RPC socket + HTTP server
+ * const health = await registry.aggregateHealth();
+ * await registry.shutdownAll();     // closes both listeners
+ * ```
+ */
+export function defineGatewaySubsystem(
+  opts: GatewaySubsystemOptions,
+): Subsystem<GatewaySubsystemContext> {
+  if (opts.rpc === undefined && opts.http === undefined) {
+    throw new TypeError(
+      'defineGatewaySubsystem: at least one transport (rpc and/or http) must be configured',
+    );
+  }
+
+  const name = gatewaySubsystemName(opts.scope);
+  const log = getLogger(name);
+
+  // The `Subsystem.healthProbe` contract takes NO arguments — the registry only
+  // threads the start→shutdown context, not into the probe. We therefore hold
+  // the live context in a closure so `healthProbe()` can read the bound handles
+  // (and report `stopped` before `start()`/after `shutdown()`).
+  let live: GatewaySubsystemContext | undefined;
+
+  return defineSubsystem<GatewaySubsystemContext>({
+    name,
+
+    async start(): Promise<GatewaySubsystemContext> {
+      // Bind RPC first, then HTTP, so the unix socket is available before the
+      // HTTP listener (the canonical local wire comes up first). On an HTTP
+      // bind failure, roll back the RPC socket so start() never leaves a
+      // half-open listener for the registry's onError to clean up after.
+      let rpc: RpcServerHandle | undefined;
+      try {
+        if (opts.rpc !== undefined) {
+          rpc = await startRpcServer(opts.handler, opts.rpc);
+        }
+        let http: HttpServerHandle | undefined;
+        if (opts.http !== undefined) {
+          http = await startHttpServer(opts.handler, opts.http);
+        }
+        const context: GatewaySubsystemContext = { pid: process.pid, rpc, http };
+        live = context;
+        log.info(
+          { scope: opts.scope, rpc: rpc?.socketPath, httpPort: http?.port },
+          'gateway subsystem started',
+        );
+        return context;
+      } catch (cause) {
+        // Roll back any listener already bound before re-throwing.
+        if (rpc !== undefined) {
+          await rpc.close().catch(() => undefined);
+        }
+        live = undefined;
+        throw cause;
+      }
+    },
+
+    healthProbe(): SubsystemHealth {
+      // Not started (or already shut down) → report a stopped row so the
+      // aggregate `allHealthy` cannot be falsely true.
+      if (live === undefined) {
+        const stopped: SubsystemState = 'stopped';
+        return {
+          child_id: name,
+          pid: 0,
+          state: stopped,
+          restart_count: 0,
+          detail: `scope=${opts.scope} not started`,
+        };
+      }
+      const transports: string[] = [];
+      if (live.rpc !== undefined) transports.push(`rpc=${live.rpc.socketPath}`);
+      if (live.http !== undefined) {
+        transports.push(`http=${live.http.host}:${live.http.port}`);
+      }
+      const running: SubsystemState = 'running';
+      return {
+        child_id: name,
+        pid: live.pid,
+        state: running,
+        restart_count: 0,
+        detail: `scope=${opts.scope} ${transports.join(' ')}`.trim(),
+      };
+    },
+
+    async shutdown(context: GatewaySubsystemContext): Promise<void> {
+      // Reverse bind order: close HTTP before the RPC socket. Both close()
+      // calls are idempotent and best-effort — one failure must not block the
+      // other listener's teardown.
+      if (context.http !== undefined) {
+        await context.http.close().catch((err: unknown) => {
+          log.warn({ err }, 'gateway http close failed');
+        });
+      }
+      if (context.rpc !== undefined) {
+        await context.rpc.close().catch((err: unknown) => {
+          log.warn({ err }, 'gateway rpc close failed');
+        });
+      }
+      live = undefined;
+      log.info({ scope: opts.scope }, 'gateway subsystem stopped');
+    },
+  });
+}

--- a/packages/runtime/src/gateway/http/index.ts
+++ b/packages/runtime/src/gateway/http/index.ts
@@ -19,6 +19,12 @@
  * operation coordinates and serializes the result. It carries NO
  * `@cleocode/cleo` dependency, NO SvelteKit dependency, and NO drizzle-orm.
  *
+ * For the daemon — which IS the embedder — `startHttpServer` (`./listen.js`,
+ * R3-T7 · T11451) is a thin `node:http` binding that parses
+ * `POST /<gateway>/<domain>/<operation>` and routes through {@link routeUnary},
+ * so the gateway daemon subsystem can host external HTTP clients without
+ * reaching across a package boundary.
+ *
  * @packageDocumentation
  * @module @cleocode/runtime/gateway/http
  *
@@ -27,6 +33,12 @@
  * @saga T11243
  */
 
+export {
+  type HttpServerHandle,
+  type HttpServerOptions,
+  parseHttpRoute,
+  startHttpServer,
+} from './listen.js';
 export { routeUnary, statusForResponse } from './server.js';
 export {
   createSseStream,

--- a/packages/runtime/src/gateway/http/listen.ts
+++ b/packages/runtime/src/gateway/http/listen.ts
@@ -1,0 +1,321 @@
+/**
+ * `node:http` server binding for the framework-agnostic HTTP gateway adapter.
+ *
+ * The HTTP adapter ({@link routeUnary} + the SSE primitives) is deliberately
+ * framework-agnostic — it owns NO port binding and NO `Request`/`Response`
+ * lifecycle, so an embedder (a SvelteKit route, a test harness) can drive it
+ * directly. The **daemon**, however, is itself the embedder: it must expose the
+ * gateway to external HTTP clients over a real listening socket. This module is
+ * that thin embedder — a minimal `node:http` server that parses the request URL
+ * into a `(gateway, domain, operation)` triple, reads the JSON body, and routes
+ * it through {@link routeUnary}. It deliberately stays in the runtime (no
+ * SvelteKit / no `@cleocode/cleo` / no drizzle dependency) so the daemon can
+ * host the gateway without reaching across a package boundary.
+ *
+ * Routing contract (intentionally minimal — the wire vocabulary is the same as
+ * every other transport, only the framing differs):
+ *
+ *   `POST /<gateway>/<domain>/<operation>`  with a JSON body → operation params
+ *
+ * where `<gateway>` is `query` | `mutate`. A non-POST method, an unparseable
+ * path, or a body that is not a JSON object is rejected at the wire edge with a
+ * LAFS-shaped error envelope — the injected {@link GatewayHandler} is never
+ * invoked with a malformed request.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/gateway/http
+ *
+ * @task T11451
+ * @epic T11254
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { DispatchResponse, Gateway } from '@cleocode/contracts/gateway';
+import { getLogger } from '@cleocode/core';
+import type { GatewayHandler } from '../index.js';
+import { routeUnary } from './server.js';
+import type { HttpUnaryRequest } from './types.js';
+
+/** The two CQRS gateways a path segment may name. */
+const GATEWAYS: ReadonlySet<string> = new Set<Gateway>(['query', 'mutate']);
+
+/** Maximum accepted request-body size (1 MiB) — a crude DoS guard at the edge. */
+const MAX_BODY_BYTES = 1_048_576;
+
+/**
+ * Options for {@link startHttpServer}.
+ *
+ * Mirrors the connection-oriented {@link RpcServerOptions} shape: the caller
+ * resolves the bind coordinates so the runtime stays free of any
+ * `@cleocode/paths` dependency.
+ */
+export interface HttpServerOptions {
+  /**
+   * TCP port to bind. `0` selects an ephemeral port (the bound port is then
+   * readable from {@link HttpServerHandle.port}).
+   */
+  port: number;
+  /**
+   * Host/interface to bind. Defaults to `127.0.0.1` (loopback only) — the
+   * gateway is local-process-facing; exposing it on a public interface is an
+   * explicit caller decision.
+   */
+  host?: string;
+}
+
+/**
+ * A live HTTP server handle returned by {@link startHttpServer}.
+ *
+ * Exposes the bound {@link Server}, the actually-bound `port` (resolved even
+ * when `0` was requested), and an idempotent {@link close}. The adapter never
+ * calls `process.exit` — lifecycle stays with the caller (R3 contract).
+ */
+export interface HttpServerHandle {
+  /** The bound `node:http` server. */
+  server: Server;
+  /** The actually-bound TCP port (resolved when `0` was requested). */
+  port: number;
+  /** Host/interface the server is bound to. */
+  host: string;
+  /** Close the server + all live connections; resolves once fully closed. */
+  close(): Promise<void>;
+}
+
+/**
+ * The result of parsing a request line into routing coordinates: either a
+ * resolved unary triple or a rejection reason for the wire edge.
+ */
+type ParsedRoute =
+  | { ok: true; gateway: Gateway; domain: string; operation: string }
+  | { ok: false; status: number; code: string; message: string };
+
+/**
+ * Parse `POST /<gateway>/<domain>/<operation>` into a routing triple.
+ *
+ * Rejects a non-POST method (`405`) and any path that does not resolve to a
+ * known `(gateway, domain, operation)` triple (`404`). The gateway segment is
+ * validated against the two CQRS gateways so a client cannot smuggle an
+ * arbitrary value into the dispatch request.
+ *
+ * @param method - The HTTP request method.
+ * @param url - The HTTP request URL (path + query).
+ * @returns The parsed route, or a typed rejection for the wire edge.
+ */
+export function parseHttpRoute(method: string | undefined, url: string | undefined): ParsedRoute {
+  if (method !== 'POST') {
+    return {
+      ok: false,
+      status: 405,
+      code: 'E_HTTP_METHOD_NOT_ALLOWED',
+      message: `method ${method ?? '<none>'} not allowed; gateway accepts POST`,
+    };
+  }
+  // Parse against a dummy origin so only the path is consumed (query ignored).
+  const pathname = new URL(url ?? '/', 'http://localhost').pathname;
+  const segments = pathname.split('/').filter((s) => s.length > 0);
+  if (segments.length !== 3) {
+    return {
+      ok: false,
+      status: 404,
+      code: 'E_HTTP_NOT_FOUND',
+      message: `expected POST /<gateway>/<domain>/<operation>, got '${pathname}'`,
+    };
+  }
+  const [gateway, domain, operation] = segments;
+  if (!GATEWAYS.has(gateway)) {
+    return {
+      ok: false,
+      status: 404,
+      code: 'E_HTTP_NOT_FOUND',
+      message: `unknown gateway '${gateway}'; expected one of query, mutate`,
+    };
+  }
+  return { ok: true, gateway: gateway as Gateway, domain, operation };
+}
+
+/**
+ * Read the full request body as a string, enforcing {@link MAX_BODY_BYTES}.
+ *
+ * @param req - The inbound request stream.
+ * @returns The decoded UTF-8 body.
+ * @throws {Error} When the body exceeds the size cap (the connection is then
+ *   destroyed by the caller).
+ */
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error(`request body exceeds ${MAX_BODY_BYTES} bytes`));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+/**
+ * Write a LAFS-shaped error envelope to the response at the wire edge.
+ *
+ * Used for rejections that never reach the {@link GatewayHandler} (bad method,
+ * unroutable path, malformed body), so a client always sees a well-formed LAFS
+ * envelope rather than a bare HTTP error.
+ *
+ * @param res - The server response.
+ * @param status - The HTTP status to set.
+ * @param code - The machine-readable LAFS error code.
+ * @param message - A human-readable message.
+ */
+function writeEdgeError(res: ServerResponse, status: number, code: string, message: string): void {
+  const body: DispatchResponse = {
+    meta: {
+      gateway: 'query',
+      domain: '',
+      operation: '',
+      timestamp: new Date().toISOString(),
+      duration_ms: 0,
+      source: 'http',
+      requestId: '',
+    },
+    success: false,
+    error: { code, message },
+  };
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * Handle a single inbound HTTP request: parse the route, read + JSON-parse the
+ * body, route it through the gateway handler, and serialize the LAFS response.
+ *
+ * All failure modes are rendered as LAFS envelopes — a bad route or malformed
+ * body is rejected at the edge (handler never invoked); a thrown handler error
+ * is already trapped inside {@link routeUnary} as a `500`. The function never
+ * throws and never calls `process.exit`.
+ *
+ * @param handler - The injected transport-neutral gateway handler.
+ * @param req - The inbound request.
+ * @param res - The outbound response.
+ * @param log - The adapter's pino logger.
+ */
+async function handleHttpRequest(
+  handler: GatewayHandler,
+  req: IncomingMessage,
+  res: ServerResponse,
+  log: ReturnType<typeof getLogger>,
+): Promise<void> {
+  const route = parseHttpRoute(req.method, req.url);
+  if (!route.ok) {
+    writeEdgeError(res, route.status, route.code, route.message);
+    return;
+  }
+
+  let params: Record<string, unknown> | undefined;
+  try {
+    const raw = await readBody(req);
+    if (raw.trim().length > 0) {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        writeEdgeError(res, 400, 'E_HTTP_BAD_REQUEST', 'request body must be a JSON object');
+        return;
+      }
+      params = parsed as Record<string, unknown>;
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    writeEdgeError(res, 400, 'E_HTTP_BAD_REQUEST', `invalid request body: ${message}`);
+    return;
+  }
+
+  const unary: HttpUnaryRequest = {
+    gateway: route.gateway,
+    domain: route.domain,
+    operation: route.operation,
+    params,
+  };
+  const result = await routeUnary(handler, unary);
+  res.writeHead(result.status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(result.body));
+  log.debug(
+    {
+      gateway: route.gateway,
+      domain: route.domain,
+      operation: route.operation,
+      status: result.status,
+    },
+    'http request routed',
+  );
+}
+
+/**
+ * Start a `node:http` server that hosts the gateway over HTTP for external
+ * clients.
+ *
+ * Binds {@link HttpServerOptions.port} on {@link HttpServerOptions.host}
+ * (default loopback), routes every `POST /<gateway>/<domain>/<operation>`
+ * through the injected {@link GatewayHandler} via {@link routeUnary}, and
+ * resolves once listening. The returned {@link HttpServerHandle} exposes an
+ * idempotent `close()` for deterministic teardown (daemon shutdown, tests). The
+ * adapter never calls `process.exit`.
+ *
+ * The caller assembles the handler (via `createGatewayHandler` with its domain
+ * handlers + middleware) and injects it here — this server never builds
+ * handlers itself, keeping the runtime free of any `@cleocode/cleo` dependency.
+ *
+ * @param handler - The transport-neutral gateway handler to route through.
+ * @param opts - Bind coordinates.
+ * @returns A promise resolving to the live {@link HttpServerHandle}.
+ */
+export function startHttpServer(
+  handler: GatewayHandler,
+  opts: HttpServerOptions,
+): Promise<HttpServerHandle> {
+  const log = getLogger('gateway-http');
+  const host = opts.host ?? '127.0.0.1';
+
+  const server = createServer((req, res) => {
+    handleHttpRequest(handler, req, res, log).catch((err: unknown) => {
+      // handleHttpRequest traps its own failures; this guards the wire path.
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn({ err }, 'http request handling failed');
+      if (!res.headersSent) {
+        writeEdgeError(res, 500, 'E_HTTP_INTERNAL', message);
+      } else if (!res.writableEnded) {
+        res.end();
+      }
+    });
+  });
+
+  return new Promise<HttpServerHandle>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(opts.port, host, () => {
+      server.removeListener('error', reject);
+      const address = server.address();
+      const boundPort = typeof address === 'object' && address !== null ? address.port : opts.port;
+      log.info({ host, port: boundPort }, 'http gateway server listening');
+
+      let closed = false;
+      const handle: HttpServerHandle = {
+        server,
+        port: boundPort,
+        host,
+        close(): Promise<void> {
+          if (closed) return Promise.resolve();
+          closed = true;
+          return new Promise<void>((res) => {
+            server.close(() => res());
+            // Drop keep-alive connections so close() resolves promptly.
+            server.closeIdleConnections();
+          });
+        },
+      };
+      resolve(handle);
+    });
+  });
+}

--- a/packages/runtime/src/gateway/index.ts
+++ b/packages/runtime/src/gateway/index.ts
@@ -30,6 +30,16 @@ export {
   type BackgroundJobStatus,
   DurableJobStore,
 } from './background-jobs.js';
+// Gateway-as-daemon-subsystem (R3-T7 · T11451) — declare the external-facing
+// gateway (RPC unix socket + HTTP server) as a supervised `defineSubsystem`
+// unit so the R2 daemon registry drives its start/health/shutdown lifecycle.
+export {
+  defineGatewaySubsystem,
+  type GatewayScope,
+  type GatewaySubsystemContext,
+  type GatewaySubsystemOptions,
+  gatewaySubsystemName,
+} from './daemon-subsystem.js';
 export type { DispatcherConfig } from './dispatcher.js';
 export { Dispatcher } from './dispatcher.js';
 // Shared handler dependencies (R3-K1 · T11455) — relocated here so the runtime
@@ -48,17 +58,22 @@ export {
 export { mapNumericExitCodeToString } from './exit-codes.js';
 // HTTP transport adapter (R3-T6 · T11450) — framework-agnostic unary + SSE over
 // the gateway. Also reachable via the `@cleocode/runtime/gateway/http` subpath.
+// `startHttpServer` (R3-T7 · T11451) is the daemon-hostable `node:http` binding.
 export {
   createSseStream,
   encodeSseFrame,
   encodeStreamEvent,
+  type HttpServerHandle,
+  type HttpServerOptions,
   type HttpUnaryRequest,
   type HttpUnaryResult,
+  parseHttpRoute,
   routeUnary,
   SSE_HEADERS,
   type SseEmitter,
   type SseFrame,
   type SseSource,
+  startHttpServer,
   statusForResponse,
 } from './http/index.js';
 export { getJobManager, setJobManager } from './job-manager-accessor.js';


### PR DESCRIPTION
## What

Closes the loop between the two R-track halves: the **R3 gateway** (dispatcher + the four transport adapters) and the **R2 daemon** (`defineSubsystem` + `SubsystemRegistry`). Declares the external-facing gateway as a supervised `defineSubsystem()` unit so the R2 daemon registry drives its `start → healthProbe → shutdown` lifecycle uniformly, like every other long-running subsystem.

`@cleocode/runtime` task **T11451 (R3-T7)** · Epic T11254 · Saga T11243.

## How it's defined + which transports it hosts

`defineGatewaySubsystem({ scope, handler, rpc?, http? })` returns a frozen `Subsystem<GatewaySubsystemContext>` (via `defineSubsystem()`), hosting the two **external-facing** listeners:

- **RPC unix socket** (`@cleocode/runtime/gateway/rpc`) — the canonical local-client wire (CLI/Studio/test harness dispatch without a cold `cleo` spawn).
- **HTTP server** (`@cleocode/runtime/gateway/http` via the new daemon-local `startHttpServer` embedder) — for external clients that speak HTTP.

The **CLI** adapter (in-process to the `cleo` binary) and the **MCP** stdio adapter (spawned + owned by an MCP client) are intentionally NOT daemon-hosted — neither is a long-lived daemon-supervised listener.

Lifecycle:
- `start()` binds RPC→HTTP over the injected handler, with **mid-start rollback** (an HTTP bind failure closes the already-bound RPC socket → no half-open listener), then re-throws for the registry's `onError`.
- `healthProbe()` reports one `SubsystemHealth` row keyed on the scoped `child_id` (`gateway-<scope>`), projecting losslessly onto the FROZEN supervisor `MonitorResponse`.
- `shutdown()` closes both (HTTP→RPC), idempotent + best-effort.

One subsystem is declared per scope → **one external-facing gateway process per scope** (project/global). Adds **no behavior** to the adapters; only wires their existing `start*Server`/`close()` lifecycle into the registry.

New `startHttpServer()` is a thin `node:http` binding over the framework-agnostic HTTP adapter: parses `POST /<gateway>/<domain>/<operation>`, routes via `routeUnary`; loopback-default host, 1 MiB body cap, LAFS-shaped edge errors.

## Files changed

- `packages/runtime/src/gateway/daemon-subsystem.ts` (new) — `defineGatewaySubsystem` + `gatewaySubsystemName` + option/context types.
- `packages/runtime/src/gateway/http/listen.ts` (new) — daemon-hostable `node:http` server (`startHttpServer`, `parseHttpRoute`).
- `packages/runtime/src/gateway/__tests__/daemon-subsystem.test.ts` (new) — 6 tests (RPC+HTTP round-trip through the registry, health→MonitorResponse, two-scope registration, mid-start rollback).
- `packages/runtime/src/gateway/index.ts`, `http/index.ts` — barrel exports.

## Acceptance

- [x] **AC1** — gateway declared via `defineSubsystem()` and supervised by the daemon registry; one process per scope (`gateway-project` / `gateway-global` register as distinct non-colliding subsystems).
- [x] Lifecycle (start/stop/health) integrates with the R2 daemon registry; **no behavior change** to the adapters themselves (only their existing `start*Server`/`close()` is wired in).
- [x] **AC3** — `@cleocode/runtime` keeps NO `@cleocode/cleo` dep and NO drizzle-orm (verified: `bad deps: []`; all source mentions are TSDoc, not imports).

## Validation

- [x] `pnpm run typecheck` (`tsc -b`) → **exit 0, zero errors**.
- [x] Cold smoke: `node build.mjs` (exit 0) + `node packages/cleo/dist/cli/index.js version` → `{"success":true,"data":{"version":"2026.5.126"},...}` (no TDZ/load-order break).
- [x] `npx vitest run --project @cleocode/runtime` → **74/74 passed** (10 files), incl. 6 new daemon-subsystem tests.
- [x] `cleo check arch` → **5/5 pass**.
- [x] Gates: contracts-purity, contract-literal-enums, tools-vs-skills-boundary, publish-surface (18), no-crate-publish → **all green**.
- [x] `pnpm biome check --write .` → clean (3405 files, no fixes).
- Note: transport-inventory golden not runnable in isolation locally (documented vitest path-filter "No test files" gotcha); structurally unaffected — no op added/removed, no MCP tool, no Studio SSE, no `packages/gateway` dir. CI validates the `@cleocode/cleo` project.

## Scale

Medium — COMPLETE. Both scopes are supported by the same subsystem definition (register one instance per scope); a daemon supervising both registers `gateway-project` + `gateway-global`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)