### PR TITLE
feat(T11362): idempotency_key columns + (scope, idempotency_key) UNIQUE per canonical §7 (E2)

### DIFF
--- a/packages/core/src/store/schema/cleo-project/audit.ts
+++ b/packages/core/src/store/schema/cleo-project/audit.ts
@@ -23,7 +23,10 @@
  *   `adr_relations.relation_type`, `status_registry.entity_type`/`namespace`)
  *   are promoted to named const arrays here (§5a — identifier over literal).
  * - **§7 idempotency:** `audit_log.idempotency_key` is the CANONICAL model the
- *   report cites (§7) — preserved, with a UNIQUE-lookup composite index.
+ *   report cites (§7) — preserved. T11362 promotes its
+ *   `(project_hash, domain, operation, idempotency_key)` composite to a true
+ *   UNIQUE constraint (the dedup grain — the same key recurs across distinct
+ *   domain/operation tuples, so the bare key is NOT unique).
  * - **§6a JSON:** `details_json` / `before_json` / `after_json` /
  *   `metadata_json` stay serialized TEXT per the JSON-Column Audit.
  *
@@ -31,7 +34,7 @@
  * are carried as plain TEXT id columns (resolved by the exodus prefixer);
  * intra-table self-FKs (ADR supersedes/amends) are real `.references()`.
  *
- * @task T11360
+ * @task T11360 · T11362 (§7 idempotency UNIQUE)
  * @epic T11245
  * @saga T11242
  * @see docs/migration/sqlite-schema-canonical.md §3 · §4 · §5 · §6a · §7
@@ -46,6 +49,7 @@ import {
   primaryKey,
   sqliteTable,
   text,
+  unique,
 } from 'drizzle-orm/sqlite-core';
 import { ADR_STATUSES, GATE_STATUSES } from '../../status-registry.js';
 import { TOKEN_USAGE_CONFIDENCE, TOKEN_USAGE_METHODS, TOKEN_USAGE_TRANSPORTS } from '../audit.js';
@@ -118,7 +122,14 @@ export const tasksAuditLog = sqliteTable(
     sessionId: text('session_id'),
     /** Dispatch request id. */
     requestId: text('request_id'),
-    /** Caller-supplied idempotency key (§7 canonical model — preserved). */
+    /**
+     * Caller-supplied idempotency key (§7 canonical model — preserved). The
+     * dedup grain is the composite `(project_hash, domain, operation,
+     * idempotency_key)` — the same key is legitimately reused across distinct
+     * `(domain, operation)` tuples, so the UNIQUE constraint is on that tuple
+     * (see `uq_tasks_audit_log_idempotency_lookup`), NOT the bare key. UNIQUE
+     * ignores rows whose `idempotency_key` is NULL, so only keyed mutations dedup.
+     */
     idempotencyKey: text('idempotency_key'),
     /** Operation duration in ms. */
     durationMs: integer('duration_ms'),
@@ -144,7 +155,11 @@ export const tasksAuditLog = sqliteTable(
     index('idx_tasks_audit_log_actor').on(table.actor),
     index('idx_tasks_audit_log_session_timestamp').on(table.sessionId, table.timestamp),
     index('idx_tasks_audit_log_domain_operation').on(table.domain, table.operation),
-    index('idx_tasks_audit_log_idempotency_lookup').on(
+    // §7: audit_log dedup grain is the composite, not the bare key — the same
+    // idempotency_key is reused across distinct (domain, operation) tuples. The
+    // UNIQUE constraint ignores NULL-key rows in SQLite, so only keyed writes
+    // coalesce via onConflictDoNothing.
+    unique('uq_tasks_audit_log_idempotency_lookup').on(
       table.projectHash,
       table.domain,
       table.operation,

--- a/packages/core/src/store/schema/cleo-project/index.ts
+++ b/packages/core/src/store/schema/cleo-project/index.ts
@@ -48,7 +48,8 @@
  *
  * **Batch 3 (this increment — 38 tables, completing the project-tier non-brain set):**
  *   - **tasks-core** (11 tables · `tasks` → `tasks_tasks` AC1 example + §8.2
- *     `sessions.grade_mode` boolean RESOLVED as genuine 0/1): tasks_tasks ·
+ *     `sessions.grade_mode` boolean RESOLVED as genuine 0/1; T11362 adds the §7
+ *     `tasks_tasks.idempotency_key` + UNIQUE for sentient re-tick dedup): tasks_tasks ·
  *     tasks_task_acceptance_criteria · tasks_acceptance_projection_state ·
  *     tasks_acceptance_projection_dirty · tasks_task_dependencies ·
  *     tasks_task_relations · tasks_sessions · tasks_session_handoff_entries ·
@@ -56,7 +57,9 @@
  *     tasks_external_task_links.
  *   - **lifecycle** (5 tables): tasks_lifecycle_{pipelines,stages,gate_results,
  *     evidence,transitions}.
- *   - **audit/governance** (7 tables · §7 audit_log idempotency model preserved):
+ *   - **audit/governance** (7 tables · §7 audit_log idempotency model preserved —
+ *     its `(project_hash, domain, operation, idempotency_key)` lookup promoted to
+ *     a UNIQUE constraint by T11362 so the canonical retry-dedup is enforced):
  *     tasks_schema_meta · tasks_audit_log · tasks_token_usage ·
  *     tasks_architecture_decisions · tasks_adr_task_links · tasks_adr_relations ·
  *     tasks_status_registry.

--- a/packages/core/src/store/schema/cleo-project/tasks-core.ts
+++ b/packages/core/src/store/schema/cleo-project/tasks-core.ts
@@ -50,10 +50,16 @@
  * intra-domain FKs are real `.references()`; the live cross-domain references
  * resolve within this same file once exodus consolidates.
  *
- * @task T11360
+ * **§7 idempotency (Pattern A · T11362):** `tasks_tasks` gains a nullable
+ * `idempotency_key TEXT` + UNIQUE so a sentient propose / stage-drift re-tick
+ * create coalesces via `onConflictDoNothing` (replacing the interim
+ * `notes_json LIKE '%dedupHash%'` scan). UNIQUE ignores NULL keys, so only
+ * keyed writes dedup; the grain is the project `cleo.db`.
+ *
+ * @task T11360 · T11362 (§7 idempotency key)
  * @epic T11245
  * @saga T11242
- * @see docs/migration/sqlite-schema-canonical.md §3 · §4 · §5 · §6a · §8.2
+ * @see docs/migration/sqlite-schema-canonical.md §3 · §4 · §5 · §6a · §7 · §8.2
  * @see docs/migration/sqlite-schema-columns.json (per-column affinity SSoT)
  */
 
@@ -175,6 +181,14 @@ export const tasksTasks = sqliteTable(
     assignee: text('assignee'),
     /** JSON IVTR orchestration state (TEXT per JSON audit). */
     ivtrState: text('ivtr_state'),
+    /**
+     * Caller-supplied stable idempotency key (§7 Pattern A); NULL for legacy /
+     * non-agent task creates. Sentient propose / stage-drift re-ticks set it so
+     * a retried create is a no-op via `onConflictDoNothing` (replaces the interim
+     * `notes_json LIKE '%dedupHash%'` scan). UNIQUE ignores NULLs in SQLite, so
+     * only keyed writes dedup; the dedup scope is the project `cleo.db` file.
+     */
+    idempotencyKey: text('idempotency_key'),
   },
   (table) => [
     index('idx_tasks_tasks_status').on(table.status),
@@ -193,6 +207,7 @@ export const tasksTasks = sqliteTable(
     index('idx_tasks_tasks_scope').on(table.scope),
     index('idx_tasks_tasks_role_status').on(table.kind, table.status),
     index('idx_tasks_tasks_created_date').on(sql`date(${table.createdAt})`),
+    unique('uq_tasks_tasks_idempotency_key').on(table.idempotencyKey),
   ],
 );
 

--- a/packages/core/src/store/schema/cleo-shared/brain.ts
+++ b/packages/core/src/store/schema/cleo-shared/brain.ts
@@ -67,10 +67,17 @@
  * scopes are separate files); intra-domain self-FKs (decision supersession,
  * sticky→tags) are real `.references()`.
  *
- * @task T11360
+ * - **§7 idempotency (Pattern A · T11362):** `brain_observations` — the highest-
+ *   leverage retried-write target (`cleo memory observe` retries + the
+ *   graph-memory-bridge `setImmediate` observers re-emit on race) — gains a
+ *   nullable `idempotency_key TEXT` + UNIQUE so a redelivered observation is a
+ *   no-op via `onConflictDoNothing`. Because this family is mirrored, the dedup
+ *   grain is each scope's own physical `cleo.db`.
+ *
+ * @task T11360 · T11362 (§7 idempotency key)
  * @epic T11245
  * @saga T11242
- * @see docs/migration/sqlite-schema-canonical.md §1 (mirrored) · §3 · §4 · §5b · §6 · §8.1
+ * @see docs/migration/sqlite-schema-canonical.md §1 (mirrored) · §3 · §4 · §5b · §6 · §7 · §8.1
  * @see docs/migration/sqlite-schema-columns.json (per-column affinity SSoT)
  */
 
@@ -84,6 +91,7 @@ import {
   real,
   sqliteTable,
   text,
+  unique,
 } from 'drizzle-orm/sqlite-core';
 import { jsonb } from '../jsonb.js';
 import {
@@ -490,6 +498,16 @@ export const brainObservations = sqliteTable(
     validatedAt: text('validated_at'),
     /** JSON provenance chain (TEXT per JSON audit). */
     provenanceChain: text('provenance_chain'),
+    /**
+     * Caller-supplied stable idempotency key (§7 Pattern A · highest leverage);
+     * NULL for legacy / non-agent observations. `cleo memory observe` retries and
+     * the graph-memory-bridge `setImmediate` async observers re-emit on race — a
+     * redelivered write with the same key is a no-op via `onConflictDoNothing`.
+     * UNIQUE ignores NULLs in SQLite, so only keyed writes dedup; because the
+     * `brain_*` family is mirrored into BOTH cleo.db scopes, the dedup grain is
+     * each scope's own `cleo.db` file.
+     */
+    idempotencyKey: text('idempotency_key'),
   },
   (table) => [
     index('idx_brain_observations_type').on(table.type),
@@ -514,6 +532,7 @@ export const brainObservations = sqliteTable(
     index('idx_brain_observations_tree_id').on(table.treeId),
     index('idx_brain_observations_origin').on(table.origin),
     index('idx_brain_observations_validated_at').on(table.validatedAt),
+    unique('uq_brain_observations_idempotency_key').on(table.idempotencyKey),
   ],
 );
 


### PR DESCRIPTION
## Summary

Completes the **§7 idempotency-key set** in the consolidated dual-scope schema families (`store/schema/cleo-project/` + `cleo-shared/` mirrored into `cleo-global/`), per `docs/migration/sqlite-schema-canonical.md §7`. Additive / schema-only — exodus (T11248) owns deployment + writer wiring.

**Reconcile, not duplicate:** T11360 already added `idempotency_key` + UNIQUE to the conduit + background-job tables. This PR adds only the remaining §7 targets, using the **same Pattern-A** approach (nullable `idempotency_key TEXT` + a UNIQUE that ignores NULLs in SQLite → `onConflictDoNothing` coalesces only keyed writes).

## §7 table coverage (all 7 now have a UNIQUE idempotency constraint)

| Table | File | Status |
|---|---|---|
| `tasks_tasks` | `cleo-project/tasks-core.ts` | **Newly added** — `uq_tasks_tasks_idempotency_key` (sentient propose / stage-drift re-tick; replaces interim `notes_json LIKE '%dedupHash%'`) |
| `brain_observations` | `cleo-shared/brain.ts` | **Newly added** — `uq_brain_observations_idempotency_key` (highest leverage; `cleo memory observe` retries + graph-memory-bridge `setImmediate` race). Mirrored into BOTH project + global `cleo.db` scopes. |
| `tasks_audit_log` | `cleo-project/audit.ts` | **Promoted index→UNIQUE** — `uq_tasks_audit_log_idempotency_lookup` on `(project_hash, domain, operation, idempotency_key)`. The §7 canonical model's dedup grain is the composite (the same key recurs across distinct domain/operation tuples, so the bare key is **not** unique — the legacy header already described this composite as "UNIQUE-lookup"). |
| `conduit_messages` | `cleo-project/conduit.ts` | Already present (T11360) — untouched |
| `conduit_topic_messages` | `cleo-project/conduit.ts` | Already present (T11360) — untouched |
| `conduit_delivery_jobs` | `cleo-project/conduit.ts` | Already present (T11360) — untouched |
| `tasks_background_jobs` | `cleo-project/tasks-core-batch2.ts` | Already present (T11360) — untouched |

## Per-AC checklist
- [x] Full §7 idempotency-key set present across both consolidated families
- [x] Nullable `idempotency_key TEXT` columns on the newly-added agent-retried-write tables
- [x] `(scope, idempotency_key)` UNIQUE semantics — Pattern A; per-scope `cleo.db` file is the dedup partition (no literal `scope` column on these single-scope tables; `brain_observations` mirrored into both scopes via `cleo-shared`)
- [x] Reconciled against T11360 — no duplication, consistent across families
- [x] Additive / schema-only — no writer changes (T11248 exodus territory)
- [x] TSDoc on every new column + section docstrings updated to credit T11362 / §7

## Validation results
| Gate | Result | Key line |
|---|---|---|
| `pnpm run typecheck` (`tsc -b`) | **PASS** | exit 0, no diagnostics |
| Cold smoke (`node build.mjs` + `cli version`) | **PASS** | `Build complete (47215ms)` → `{"success":true,"data":{"version":"2026.5.126"}}` (all tables + indexes load) |
| `node scripts/audit-sqlite-schema.mjs` | **PASS** | 117 tables / 1195 columns — zero drift (no inventory/path-file touched) |
| `vitest --project @cleocode/{contracts,core}` | **PASS (schema)** | `db-inventory.test.ts` 10/10 green; no new failures from this change. The only failing files are **pre-existing/environmental flakes** — `worktree-*` napi (stale binary under `--ignore-scripts`, per task notes), the `createTestDb: config.json DELETED` harness-isolation race (passes in isolation), and `reconstruct.test.ts` (pins a git SHA absent from this worktree's history). No consolidated-schema snapshot exists to update. |
| `cleo check arch` | **PASS** | 5 passed, 0 failed |
| `pnpm biome check` | **PASS** | Checked 4 files — no fixes applied |

🤖 Generated with [Claude Code](https://claude.com/claude-code)