### PR TITLE
fix(T11487): pr:<n> atom satisfies implemented gate (DHQ-030/T9838)

### DIFF
--- a/packages/contracts/src/release/evidence-atoms.ts
+++ b/packages/contracts/src/release/evidence-atoms.ts
@@ -1,9 +1,10 @@
 /**
  * Zod schemas + helper types for the `pr:<number>` evidence atom.
  *
- * Closes the release-verb dogfood gap (T9764): tasks that ship via the
+ * Closes the release-verb dogfood gap (T9764 / T9838): tasks that ship via the
  * standard PR + admin-merge flow lacked a zero-friction way to record
- * `testsPassed` / `qaPassed` evidence retroactively. The release-verb
+ * `implemented` / `testsPassed` / `qaPassed` evidence retroactively. The
+ * release-verb
  * pipeline (`cleo release plan --epic <id>`) requires evidence atoms for
  * every child task before a plan can be built. `tool:test` is overkill
  * for one-line tasks (it re-runs the entire monorepo suite), and `note:`

--- a/packages/contracts/src/task.ts
+++ b/packages/contracts/src/task.ts
@@ -277,13 +277,13 @@ export type EvidenceAtom =
        *
        * Closes the release-verb dogfood gap (T9764): tasks that ship via the
        * standard PR + admin-merge flow lacked a zero-friction way to record
-       * `testsPassed` / `qaPassed` evidence after the fact. Re-running
-       * `tool:test` against the entire monorepo is overkill for one-line
-       * tasks, and `note:` is rejected for hard gates on critical
+       * `implemented` / `testsPassed` / `qaPassed` evidence after the fact.
+       * Re-running `tool:test` against the entire monorepo is overkill for
+       * one-line tasks, and `note:` is rejected for hard gates on critical
        * verifications.
        *
-       * A `pr:<number>` atom satisfies BOTH `testsPassed` and `qaPassed`
-       * simultaneously when:
+       * A `pr:<number>` atom satisfies `implemented`, `testsPassed`, and
+       * `qaPassed` simultaneously (T9838) when:
        *   1. `state === 'MERGED'` (PR was actually shipped to main)
        *   2. `mergedAt` is non-null (defends against API races)
        *   3. The status-check rollup contains ≥1 SUCCESS check and zero

--- a/packages/core/src/release/__tests__/evidence-pr-atom.test.ts
+++ b/packages/core/src/release/__tests__/evidence-pr-atom.test.ts
@@ -11,13 +11,14 @@
  *   - resolver returns E_EVIDENCE_TOOL_FAILED when `gh` is missing
  *   - cache hit on re-call avoids invoking `gh`
  *   - cache invalidates when mergedAt changes
- *   - gate-evidence-minimum accepts `pr` for testsPassed AND qaPassed
+ *   - gate-evidence-minimum accepts `pr` for implemented, testsPassed, AND qaPassed (T9838)
  *   - validateAtom dispatches `pr` through to the resolver
  *
  * Uses an injectable `FetchGhPrPayload` mock to keep tests hermetic — no
  * real network calls happen.
  *
  * @task T9764
+ * @task T9838
  * @epic T9762
  */
 

--- a/packages/core/src/release/pr-evidence.ts
+++ b/packages/core/src/release/pr-evidence.ts
@@ -2,9 +2,10 @@
  * `pr:<number>` evidence-atom validator.
  *
  * Resolves a GitHub pull request via the `gh` CLI and decides whether the PR
- * satisfies the `testsPassed` and `qaPassed` gates. Closes the release-verb
- * dogfood gap (T9764): tasks that ship via the standard PR + admin-merge flow
- * previously had no zero-friction way to record evidence retroactively —
+ * satisfies the `implemented`, `testsPassed`, and `qaPassed` gates (T9838).
+ * Closes the release-verb dogfood gap (T9764): tasks that ship via the
+ * standard PR + admin-merge flow previously had no zero-friction way to record
+ * evidence retroactively —
  * `tool:test` re-runs the entire monorepo suite and `note:` is rejected for
  * hard gates on critical verifications.
  *

--- a/packages/core/src/tasks/evidence.ts
+++ b/packages/core/src/tasks/evidence.ts
@@ -180,10 +180,11 @@ export type ParsedAtom =
       /**
        * Pull-request atom — references a GitHub PR by number. Validation
        * resolves the PR via `gh pr view` and checks state=MERGED plus
-       * all required-workflow checks green. Satisfies BOTH `testsPassed`
-       * and `qaPassed` simultaneously.
+       * all required-workflow checks green. Satisfies `implemented`,
+       * `testsPassed`, and `qaPassed` simultaneously (T9838).
        *
        * @task T9764
+       * @task T9838
        */
       kind: 'pr';
       /** PR number (positive integer). */

--- a/packages/core/templates/CLEO-INJECTION.md
+++ b/packages/core/templates/CLEO-INJECTION.md
@@ -285,7 +285,8 @@ cleo verify T### --gate testsPassed --evidence "tool:test"
 # qaPassed — lint + typecheck
 cleo verify T### --gate qaPassed --evidence "tool:lint;tool:typecheck"
 
-# retroactive PR atom (PR MERGED + CI green) satisfies testsPassed AND qaPassed
+# retroactive PR atom (PR MERGED + CI green) satisfies implemented + testsPassed + qaPassed
+cleo verify T### --gate implemented --evidence "pr:357"
 cleo verify T### --gate testsPassed --evidence "pr:357"
 cleo verify T### --gate qaPassed --evidence "pr:357"
 
@@ -325,7 +326,7 @@ All overrides append a line to `.cleo/audit/force-bypass.jsonl`. Use sparingly.
 
 ### `pr:<number>` retroactive atom (T9764)
 
-Accepts IFF PR `state=MERGED` AND required-workflow checks are `SUCCESS`/`SKIPPED`. Single atom satisfies BOTH `testsPassed` + `qaPassed`. Cache under `.cleo/cache/evidence/pr-<num>.json`.
+Accepts IFF PR `state=MERGED` AND required-workflow checks are `SUCCESS`/`SKIPPED`. Single atom satisfies `implemented` + `testsPassed` + `qaPassed` simultaneously (T9838). Cache under `.cleo/cache/evidence/pr-<num>.json`.
 
 ### Anti-patterns to avoid
 


### PR DESCRIPTION
## Summary

- The gate mapping in `GATE_EVIDENCE_REQUIREMENTS` already had `['pr']` in `implemented.oneOf` (shipped in T9838), but all documentation surfaces still said `pr:<n>` only satisfies `testsPassed + qaPassed`
- This was causing 6+ `CLEO_OWNER_OVERRIDE` invocations per session because agents read the stale docs and thought `pr:<n>` did not satisfy `implemented`
- Updated all 6 documentation surfaces to match the live code

## Files Changed

- `packages/core/templates/CLEO-INJECTION.md` — tier-0 protocol doc (added `implemented` to PR atom example + updated prose description)
- `packages/contracts/src/evidence-atom-schema.ts` — `prAtomSchema` TSDoc (already had T9838 reference; no change needed)
- `packages/contracts/src/task.ts` — `EvidenceAtom.pr` TSDoc (stale "BOTH testsPassed and qaPassed" → "implemented, testsPassed, and qaPassed")
- `packages/contracts/src/release/evidence-atoms.ts` — module TSDoc (stale mention)
- `packages/core/src/release/pr-evidence.ts` — module TSDoc (stale mention)
- `packages/core/src/tasks/evidence.ts` — `ParsedAtom.pr` TSDoc (stale mention)
- `packages/core/src/release/__tests__/evidence-pr-atom.test.ts` — test header comment

## Test plan

- [ ] All 43 existing tests in `evidence-pr-atom.test.ts` pass (verified locally; 43/43 ✓)
- [ ] The T9838 test suite (lines 566-600, 649-724) confirms `implemented` gate accepts `pr` atom
- [ ] `pnpm biome check` — no fixes needed (0 changes)
- [ ] `pnpm run typecheck` — passes
- [ ] `node build.mjs` — build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)