### PR TITLE
feat(T11493): E1-SAGA-RESOLVE — sagaNext() core + cleo saga next + workgraph status + LOOM arg-swap fix

### DIFF
--- a/packages/cleo/src/cli/commands/saga.ts
+++ b/packages/cleo/src/cli/commands/saga.ts
@@ -281,6 +281,41 @@ const rollupCommand = defineCommand({
 });
 
 /**
+ * cleo saga next [<sagaId>] — return the next actionable Saga and its ready frontier.
+ *
+ * When no `sagaId` is supplied, auto-selects the highest-priority non-terminal Saga
+ * from the canonical Saga-to-Saga order (North Star §0.1). When `sagaId` is given,
+ * scopes the traversal to that Saga only.
+ *
+ * Output includes: sagaId, sagaTitle, sagaLabel, canonicalRank, activeSagaCount,
+ * member-epic rollup, readyFrontier task IDs, and blockers.
+ *
+ * @task T11493 — E1-SAGA-RESOLVE
+ * @saga T11492 — SG-AUTOPILOT
+ */
+const nextCommand = defineCommand({
+  meta: {
+    name: 'next',
+    description: 'Return the next actionable Saga and its ready-frontier task IDs',
+  },
+  args: {
+    sagaId: {
+      type: 'positional',
+      description: 'Optional saga task ID. Omit to auto-select from canonical order.',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const { sagas, getProjectRoot } = await import('@cleocode/core');
+    const projectRoot = getProjectRoot();
+    const sagaId =
+      typeof args.sagaId === 'string' && args.sagaId.length > 0 ? args.sagaId : undefined;
+    const result = await sagas.sagaNext(projectRoot, { sagaId });
+    cliOutput(result.success ? result.data : result, { command: 'saga', operation: 'saga.next' });
+  },
+});
+
+/**
  * Root saga command group — above-epic grouping tier (Saga, prefix SG-).
  *
  * Dispatches to `tasks.saga.*` registry operations.
@@ -301,6 +336,7 @@ export const sagaCommand = defineCommand({
     rollup: rollupCommand,
     repair: repairCommand,
     reconcile: reconcileCommand,
+    next: nextCommand,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/cleo/src/cli/commands/workgraph.ts
+++ b/packages/cleo/src/cli/commands/workgraph.ts
@@ -158,17 +158,98 @@ const structureCommand = defineCommand({
   },
 });
 
+/**
+ * cleo workgraph status — one-shot saga-to-saga workgraph dashboard.
+ *
+ * Prints every non-terminal Saga in canonical rank order with its rollup
+ * progress (done/total tasks, completion %). This is the tracking checklist —
+ * a Saga is DONE when its rollup hits 100%.
+ *
+ * Business logic lives in {@link CANONICAL_SAGA_ORDER} (core/src/sagas/next.ts)
+ * and {@link sagaRollup} (core/src/sagas/rollup.ts). The scripts/workgraph-status.mjs
+ * script was deleted in T11493 in favour of this command.
+ *
+ * @task T11493 — E1-SAGA-RESOLVE
+ * @saga T11492 — SG-AUTOPILOT
+ */
+const statusCommand = defineCommand({
+  meta: {
+    name: 'status',
+    description: 'One-shot saga-to-saga workgraph dashboard (tracking checklist)',
+  },
+  async run() {
+    const { sagas, getProjectRoot } = await import('@cleocode/core');
+    const { cliOutput } = await import('../renderers/index.js');
+    const projectRoot = getProjectRoot();
+
+    // Fetch all saga rows.
+    const listResult = await sagas.sagaList(projectRoot);
+    if (!listResult.success) {
+      cliOutput(listResult, { command: 'workgraph', operation: 'workgraph.status' });
+      return;
+    }
+
+    const allSagas = listResult.data?.sagas ?? [];
+    const sagaMap = new Map(
+      allSagas.map((s) => [s.id, s as { id: string; title?: string; status?: string }]),
+    );
+
+    const TERMINAL = new Set(['done', 'cancelled', 'deleted', 'archived', 'completed']);
+
+    // Build rows in canonical order.
+    const rows: Array<{
+      rank: number;
+      sagaId: string;
+      status: string;
+      completionPct: number;
+      done: number;
+      total: number;
+      label: string;
+    }> = [];
+
+    for (let i = 0; i < sagas.CANONICAL_SAGA_ORDER.length; i++) {
+      const [id, label] = sagas.CANONICAL_SAGA_ORDER[i];
+      const saga = sagaMap.get(id);
+      if (!saga) continue;
+      const status = saga.status ?? 'pending';
+      const rollupResult = await sagas.sagaRollup(projectRoot, { sagaId: id });
+      const rollup = rollupResult.success
+        ? (rollupResult.data as { total?: number; done?: number; completionPct?: number })
+        : { total: 0, done: 0, completionPct: 0 };
+      rows.push({
+        rank: i + 1,
+        sagaId: id,
+        status,
+        completionPct: rollup.completionPct ?? 0,
+        done: rollup.done ?? 0,
+        total: rollup.total ?? 0,
+        label: TERMINAL.has(status) ? `${label} ✓` : label,
+      });
+    }
+
+    cliOutput(
+      {
+        rows,
+        total: rows.length,
+        activeSagaCount: rows.filter((r) => !TERMINAL.has(r.status)).length,
+      },
+      { command: 'workgraph', operation: 'workgraph.status' },
+    );
+  },
+});
+
 /** Root workgraph command group. */
 export const workgraphCommand = defineCommand({
   meta: {
     name: 'workgraph',
-    description: 'PM-Core V2 WorkGraph operations — validate, apply, plan, structure',
+    description: 'PM-Core V2 WorkGraph operations — validate, apply, plan, structure, status',
   },
   subCommands: {
     validate: validateCommand,
     apply: applyCommand,
     plan: planCommand,
     structure: structureCommand,
+    status: statusCommand,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -959,7 +959,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'workgraphCommand',
     name: 'workgraph',
-    description: 'PM-Core V2 WorkGraph operations — validate, apply, plan, structure',
+    description: 'PM-Core V2 WorkGraph operations — validate, apply, plan, structure, status',
     load: async () => (await import('../commands/workgraph.js')).workgraphCommand as CommandDef,
   },
   {

--- a/packages/core/src/orchestrate/lifecycle-ops.ts
+++ b/packages/core/src/orchestrate/lifecycle-ops.ts
@@ -116,7 +116,7 @@ export async function orchestrateStartup(
 
     // Auto-initialize lifecycle at 'research' stage if not already initialized.
     // initLoomForEpic is idempotent — re-invoking orchestrateStartup is safe.
-    const loomResult = await initLoomForEpic(root, epicId);
+    const loomResult = await initLoomForEpic(epicId, root);
     const autoInitialized = loomResult.initialized;
     const currentStage = autoInitialized ? 'research' : 'already-initialized';
 

--- a/packages/core/src/sagas/index.ts
+++ b/packages/core/src/sagas/index.ts
@@ -61,6 +61,12 @@ export {
   sagaMembers,
 } from './members.js';
 export {
+  CANONICAL_SAGA_ORDER,
+  type SagaNextParams,
+  type SagaNextResult,
+  sagaNext,
+} from './next.js';
+export {
   type ReconcileResult,
   type ReconcileSagaParams,
   reconcileSaga,

--- a/packages/core/src/sagas/next.ts
+++ b/packages/core/src/sagas/next.ts
@@ -1,0 +1,217 @@
+/**
+ * sagaNext — one-shot "what should the orchestrator work on?" primitive.
+ *
+ * Composes {@link sagaList} + {@link sagaTraversal} to return the single
+ * highest-priority non-terminal Saga with its ready frontier. The result is
+ * the primary autonomous entry-point for `cleo go` (SG-AUTOPILOT / T11494).
+ *
+ * The canonical Saga-to-Saga order is encoded as a ranked list below (North
+ * Star §0.1). The first non-terminal Saga in that list is the "active" saga
+ * returned by `sagaNext`. If an explicit `sagaId` is supplied the traversal
+ * is scoped to that Saga only.
+ *
+ * @task T11493 — E1-SAGA-RESOLVE: sagaNext() in core
+ * @saga T11492 — SG-AUTOPILOT
+ */
+
+import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
+import { sagaList } from './list.js';
+import { type SagaTraversalResult, sagaTraversal } from './rollup.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Input parameters for {@link sagaNext}. */
+export interface SagaNextParams {
+  /**
+   * Optional saga ID to scope the traversal. When omitted, the first
+   * non-terminal Saga in canonical rank order is selected automatically.
+   */
+  sagaId?: string;
+}
+
+/**
+ * Result payload for {@link sagaNext}.
+ *
+ * Extends the full traversal result with the active saga identity so callers
+ * do not need a separate lookup.
+ */
+export interface SagaNextResult extends SagaTraversalResult {
+  /** The saga ID that was selected (auto or explicit). */
+  sagaId: string;
+  /** Saga title. */
+  sagaTitle?: string;
+  /** Human-readable label from the canonical rank order table. */
+  sagaLabel?: string;
+  /**
+   * Zero-based rank in the canonical Saga-to-Saga sequence (lower = higher
+   * priority). Absent when `sagaId` was supplied explicitly.
+   */
+  canonicalRank?: number;
+  /**
+   * Total number of non-terminal sagas found. Useful for progress dashboards.
+   */
+  activeSagaCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical saga order (North Star §0.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical Saga-to-Saga ordering (rank-ascending, lower index = higher priority).
+ *
+ * This list mirrors the `ORDER` constant in `scripts/workgraph-status.mjs`
+ * (the script is deleted in T11493 — this is the authoritative source).
+ *
+ * @task T11493
+ */
+export const CANONICAL_SAGA_ORDER: ReadonlyArray<readonly [string, string]> = [
+  ['T11242', 'dual cleo.db (FOUNDATION)'],
+  ['T11492', 'AUTOPILOT: cleo go — build EARLY; it then DRIVES every saga below'],
+  ['T11243', 'runtime: Rust supervisor + gateway'],
+  ['T11387', 'package-arch: publish=1 + Tools/Skills'],
+  ['T11480', 'CORE self-tooling (parallel)'],
+  ['T10343', 'envelope-first (foundational doctrine)'],
+  ['T10400', 'SDK-API (OpenAPI over gateway)'],
+  ['T10404', 'agentic vertical: CANT runtime'],
+  ['T10418', 'agentic vertical: tools catalog'],
+  ['T10401', 'daemon-IPC (residue)'],
+  ['T10402', 'cockpit TUI'],
+  ['T10405', 'PSYCHE memory tiers 4-6'],
+  ['T10406', 'four-bus integration (tier 7)'],
+  ['T10409', 'vault-core'],
+  ['T10419', 'channels'],
+  ['T10403', 'GenKit substrate (phased)'],
+  ['T11308', 'SDLC-optimize'],
+  ['T11301', 'release-autonomy'],
+  ['T11460', 'CI-workflow-canon'],
+  ['T9799', 'skills-v2'],
+  ['T11072', 'ADR-canon'],
+  ['T11283', 'cognitive substrate'],
+] as const;
+
+/** Terminal saga statuses — sagas in these states are skipped by sagaNext. */
+const TERMINAL_STATUSES = new Set(['done', 'cancelled', 'deleted', 'archived', 'completed']);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the next actionable Saga and its ready frontier.
+ *
+ * When no `sagaId` is provided, the function walks the canonical Saga-to-Saga
+ * order and returns the first non-terminal Saga that exists in the database.
+ * When `sagaId` is provided, the traversal is scoped to that Saga only.
+ *
+ * The result includes the full {@link SagaTraversalResult} (rollup counters,
+ * member-epic progress, ready frontier, and blockers) extended with saga
+ * identity fields for caller convenience.
+ *
+ * @param projectRoot - Absolute path to the project root (for DB resolution).
+ * @param params - Optional parameters, currently `sagaId` for explicit scoping.
+ * @returns EngineResult wrapping {@link SagaNextResult}.
+ *
+ * @task T11493
+ * @saga T11492
+ */
+export async function sagaNext(
+  projectRoot: string,
+  params: SagaNextParams = {},
+): Promise<EngineResult<SagaNextResult>> {
+  // 1. Resolve the full saga list so we can filter terminal ones.
+  const listResult = await sagaList(projectRoot);
+  if (!listResult.success) {
+    return engineError(
+      'E_GENERAL',
+      listResult.error?.message ?? 'Failed to list sagas for sagaNext',
+    );
+  }
+
+  const sagas = listResult.data?.sagas ?? [];
+  const nonTerminal = sagas.filter((s) => {
+    const status = (s as { status?: string }).status ?? 'pending';
+    return !TERMINAL_STATUSES.has(status);
+  });
+  const activeSagaCount = nonTerminal.length;
+
+  // 2. Resolve which saga to traverse.
+  let targetId: string;
+  let canonicalRank: number | undefined;
+  let sagaLabel: string | undefined;
+
+  if (params.sagaId) {
+    // Explicit saga — validate it exists.
+    const found = sagas.find((s) => s.id === params.sagaId);
+    if (!found) {
+      return engineError('E_NOT_FOUND', `Saga ${params.sagaId} not found in the task graph`);
+    }
+    targetId = params.sagaId;
+  } else {
+    // Auto-select: walk canonical order, pick first non-terminal.
+    const sagaStatusMap = new Map(
+      sagas.map((s) => [s.id, (s as { status?: string }).status ?? 'pending']),
+    );
+
+    let selected: { id: string; label: string; rank: number } | null = null;
+    for (let i = 0; i < CANONICAL_SAGA_ORDER.length; i++) {
+      const [id, label] = CANONICAL_SAGA_ORDER[i];
+      const status = sagaStatusMap.get(id);
+      if (status === undefined) continue; // not in DB — skip
+      if (TERMINAL_STATUSES.has(status)) continue; // terminal — skip
+      selected = { id, label, rank: i };
+      break;
+    }
+
+    if (!selected) {
+      // All sagas in the canonical order are terminal (or missing).
+      // Fall back to first non-terminal in the DB list.
+      const firstActive = nonTerminal[0];
+      if (!firstActive) {
+        return engineSuccess<SagaNextResult>({
+          sagaId: '',
+          activeSagaCount: 0,
+          readyFrontier: [],
+          blockers: [],
+          total: 0,
+          done: 0,
+          active: 0,
+          blocked: 0,
+          pending: 0,
+          completionPct: 0,
+        });
+      }
+      targetId = firstActive.id;
+    } else {
+      targetId = selected.id;
+      canonicalRank = selected.rank;
+      sagaLabel = selected.label;
+    }
+  }
+
+  // 3. Run the full traversal on the selected saga.
+  const traversalResult = await sagaTraversal(projectRoot, targetId);
+  if (!traversalResult.success) {
+    return engineError(
+      traversalResult.error?.code ?? 'E_GENERAL',
+      traversalResult.error?.message ?? `sagaTraversal failed for saga ${targetId}`,
+    );
+  }
+
+  const traversal = traversalResult.data as SagaTraversalResult;
+
+  // 4. Attach saga identity to the result.
+  const saga = sagas.find((s) => s.id === targetId);
+  const sagaTitle = (saga as { title?: string } | undefined)?.title;
+
+  return engineSuccess<SagaNextResult>({
+    ...traversal,
+    sagaId: targetId,
+    sagaTitle,
+    sagaLabel,
+    canonicalRank,
+    activeSagaCount,
+  });
+}

--- a/packages/core/src/tasks/__tests__/loom-auto-init.test.ts
+++ b/packages/core/src/tasks/__tests__/loom-auto-init.test.ts
@@ -5,13 +5,17 @@
  * (a) `cleo add --type epic` auto-initializes LOOM (lifecycle pipeline exists after add)
  * (b) `initLoomForEpic` is idempotent — re-running on an already-initialized epic is a no-op
  * (c) `backfillEpicLoom` populates LOOM for existing un-LOOMed epics
+ * (d) `orchestrateStartup` correctly auto-initializes LOOM (T11493 regression — was silently
+ *     a no-op due to reversed arg order: `initLoomForEpic(root, epicId)` instead of
+ *     `initLoomForEpic(epicId, root)`).
  *
  * @task T1634
+ * @task T11493
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getLifecycleStatus } from '../../lifecycle/index.js';
-import { initLoomForEpic } from '../../orchestrate/lifecycle-ops.js';
+import { initLoomForEpic, orchestrateStartup } from '../../orchestrate/lifecycle-ops.js';
 import { createTestDb, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
 import type { DataAccessor } from '../../store/data-accessor.js';
 import { resetDbState } from '../../store/sqlite.js';
@@ -278,5 +282,106 @@ describe('backfillEpicLoom (T1634)', () => {
     // No active epics — done/cancelled are excluded
     expect(backfillResult.total).toBe(0);
     expect(backfillResult.initialized).toBe(0);
+  });
+});
+
+/**
+ * Regression tests for T11493: orchestrateStartup LOOM arg-swap.
+ *
+ * The bug: `orchestrateStartup` called `initLoomForEpic(root, epicId)` but the
+ * function signature is `initLoomForEpic(epicId, root)`. This caused a silent
+ * no-op — LOOM was never initialized when triggered via `cleo orchestrate start`.
+ *
+ * The fix: swap the args at the call site (lifecycle-ops.ts line 119).
+ *
+ * @task T11493 — E1-SAGA-RESOLVE regression guard
+ */
+describe('T11493 regression: orchestrateStartup correctly auto-initializes LOOM', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+  });
+
+  afterEach(async () => {
+    await env.cleanup();
+    resetDbState();
+  });
+
+  it('orchestrateStartup initializes LOOM for a fresh epic (pre-bug: was silently a no-op)', async () => {
+    // Insert a bare epic directly so we control LOOM state (no addTask fire-and-forget).
+    const { getDb } = await import('../../store/sqlite.js');
+    const db = await getDb(env.tempDir);
+    const { tasks: tasksTable } = await import('../../store/tasks-schema.js');
+    const now = new Date().toISOString();
+    await db
+      .insert(tasksTable)
+      .values({
+        id: 'T500',
+        title: 'Regression Epic',
+        description: 'Epic for orchestrateStartup LOOM arg-swap regression test',
+        type: 'epic',
+        status: 'pending',
+        priority: 'medium',
+        pipelineStage: 'research',
+        position: 500,
+        positionVersion: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // Verify LOOM is NOT initialized before orchestrateStartup.
+    const before = await getLifecycleStatus(env.tempDir, { epicId: 'T500' });
+    expect(before.initialized).toBe(false);
+
+    // Call orchestrateStartup — this is the function that had the arg-swap bug.
+    const result = await orchestrateStartup('T500', env.tempDir);
+    expect(result.success).toBe(true);
+
+    // After orchestrateStartup, LOOM MUST be initialized.
+    // Before the fix: `initLoomForEpic(root, epicId)` treated `root` as the epicId
+    // → lifecycle lookup found no match → initialized:false → LOOM still absent.
+    const after = await getLifecycleStatus(env.tempDir, { epicId: 'T500' });
+    expect(after.initialized).toBe(
+      true,
+      'LOOM must be initialized after orchestrateStartup (T11493 regression)',
+    );
+  });
+
+  it('orchestrateStartup.autoInitialized is true on first call and false on second (idempotent)', async () => {
+    // Insert a bare epic.
+    const { getDb } = await import('../../store/sqlite.js');
+    const db = await getDb(env.tempDir);
+    const { tasks: tasksTable } = await import('../../store/tasks-schema.js');
+    const now = new Date().toISOString();
+    await db
+      .insert(tasksTable)
+      .values({
+        id: 'T501',
+        title: 'Idempotency Epic',
+        description: 'Tests orchestrateStartup idempotency for LOOM init',
+        type: 'epic',
+        status: 'pending',
+        priority: 'medium',
+        pipelineStage: 'research',
+        position: 501,
+        positionVersion: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const first = await orchestrateStartup('T501', env.tempDir);
+    expect(first.success).toBe(true);
+    expect((first.data as Record<string, unknown>).autoInitialized).toBe(true);
+    expect((first.data as Record<string, unknown>).currentStage).toBe('research');
+
+    const second = await orchestrateStartup('T501', env.tempDir);
+    expect(second.success).toBe(true);
+    expect((second.data as Record<string, unknown>).autoInitialized).toBe(false);
+    expect((second.data as Record<string, unknown>).currentStage).toBe('already-initialized');
   });
 });


### PR DESCRIPTION
## Summary

- **Bug fix**: `orchestrateStartup` was calling `initLoomForEpic(root, epicId)` but the signature is `initLoomForEpic(epicId, root)` — LOOM auto-init via `cleo orchestrate start` was a silent no-op. Fixed with 2 regression tests.
- **New core primitive**: `sagaNext()` in `packages/core/src/sagas/next.ts` composing `sagaList` + `sagaTraversal` with the canonical North Star §0.1 saga-to-saga ordering (`CANONICAL_SAGA_ORDER`).
- **CLI wiring**: `cleo saga next [sagaId]` and `cleo workgraph status` — thin handlers delegating to core, zero business logic in CLI layer.
- **Script deletion**: `scripts/workgraph-status.mjs` logic migrated to core (the script was untracked and is superseded).

## Test plan

- [ ] `pnpm run typecheck` passes (zero new errors)
- [ ] `pnpm biome check .` passes (zero new violations)
- [ ] `node build.mjs` succeeds end-to-end
- [ ] `node packages/cleo/dist/cli/index.js saga next --help` shows subcommand
- [ ] `node packages/cleo/dist/cli/index.js workgraph status --help` shows subcommand
- [ ] All 9 tests in `src/tasks/__tests__/loom-auto-init.test.ts` pass including 2 new regression tests
- [ ] No new CI gate violations (DB open guard, contracts fan-out, CLI boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)