### PR TITLE
feat(T11255): R4 sentient daemon subsystem adapter

### DIFF
--- a/packages/core/src/sentient/daemon.ts
+++ b/packages/core/src/sentient/daemon.ts
@@ -375,7 +375,7 @@ export class StudioSupervisor {
  * @param globalConfigPath - Absolute path to `~/.cleo/config.json`.
  * @returns Whether the daemon should supervise Studio.
  */
-async function readSuperviseStudioConfig(globalConfigPath: string): Promise<boolean> {
+export async function readSuperviseStudioConfig(globalConfigPath: string): Promise<boolean> {
   try {
     const raw = await readFile(globalConfigPath, 'utf-8');
     const parsed = JSON.parse(raw) as Record<string, unknown>;

--- a/packages/core/src/sentient/index.ts
+++ b/packages/core/src/sentient/index.ts
@@ -33,3 +33,4 @@ export * from './skill-review-prompt.js';
 export * from './stage-drift-tick.js';
 export * from './state.js';
 export * from './tick.js';
+export { warmupWorktreeBackend } from './worktree-dispatch.js';

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "@cleocode/contracts": "workspace:*",
-    "@cleocode/core": "workspace:*"
+    "@cleocode/core": "workspace:*",
+    "node-cron": "^4.2.1"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/runtime/src/__tests__/sentient-subsystem.test.ts
+++ b/packages/runtime/src/__tests__/sentient-subsystem.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for the R4 sentient daemon subsystem adapter.
+ *
+ * Validates that `createSentientSubsystem` produces a Subsystem that
+ * the SubsystemRegistry drives through start → healthProbe → shutdown
+ * without loss, matching T11255 R4 ACs.
+ *
+ * All cron / IO are mocked — this is a shape and lifecycle test, not an
+ * integration test. The migration-readiness test in `daemon/__tests__/` already
+ * covers the registry contract; this test covers the sentient-specific adapter.
+ *
+ * @task T11502 (R4-T3)
+ * @epic T11255 R4
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SubsystemRegistry } from '../daemon/index.js';
+import { createSentientSubsystem } from '../sentient-subsystem.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — keep hermetic (no real cron, no real fs ops, no lockfiles)
+// ---------------------------------------------------------------------------
+
+vi.mock('node-cron', () => ({
+  default: {
+    schedule: vi.fn(() => ({ destroy: vi.fn() })),
+  },
+}));
+
+vi.mock('@cleocode/core/sentient', async () => {
+  const actual: Record<string, unknown> = {};
+  return {
+    ...actual,
+    acquireLock: vi.fn(async () => ({
+      path: '/tmp/cleo-test.lock',
+      handle: { close: vi.fn(async () => undefined) },
+    })),
+    releaseLock: vi.fn(async () => undefined),
+    readSuperviseStudioConfig: vi.fn(async () => false),
+    readCuratorConfig: vi.fn(async () => ({
+      enabled: false,
+      runEveryHours: 168,
+      staleAfterDays: 30,
+      archiveAfterDays: 90,
+    })),
+    patchSentientState: vi.fn(async () => ({})),
+    readSentientState: vi.fn(async () => ({
+      pid: process.pid,
+      killSwitch: false,
+      killSwitchReason: null,
+      lastTickAt: null,
+      lastCronFiredAt: null,
+      tier2Enabled: false,
+      stuckTasks: {},
+      stats: { tasksSpawned: 0, tasksCompleted: 0, tasksFailed: 0 },
+    })),
+    safeRunTick: vi.fn(async () => ({ kind: 'skipped', taskId: null, detail: 'mock' })),
+    safeRunProposeTick: vi.fn(async () => ({
+      kind: 'skipped',
+      taskId: null,
+      detail: 'mock',
+      written: 0,
+      count: 0,
+    })),
+    safeRunCrossProjectHygiene: vi.fn(async () => ({
+      completedAt: new Date().toISOString(),
+      summary: 'mock',
+      nexusIntegrity: { total: 0, healthy: 0 },
+      tempGc: { candidates: [] },
+      duplicateEpics: { groups: [] },
+      worktreePrune: { totalPruned: 0 },
+    })),
+    warmupWorktreeBackend: vi.fn(async () => undefined),
+    SENTIENT_CRON_EXPR: '*/5 * * * *',
+    SENTIENT_PROPOSE_CRON_EXPR: '0 */2 * * *',
+    SENTIENT_HYGIENE_CRON_EXPR: '0 2 * * *',
+    SENTIENT_STATE_FILE: '.cleo/sentient-state.json',
+    SENTIENT_LOCK_FILE: '.cleo/sentient.lock',
+    StudioSupervisor: vi.fn().mockImplementation(() => ({
+      start: vi.fn(),
+      stop: vi.fn(async () => undefined),
+      status: 'stopped',
+      pid: null,
+    })),
+    curatorCronExpression: vi.fn((n: number) => `0 */${Math.max(1, n)} * * *`),
+  };
+});
+
+vi.mock('@cleocode/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@cleocode/core')>();
+  return {
+    ...actual,
+    getCleoHome: vi.fn(() => '/tmp/cleo-test-home'),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createSentientSubsystem (T11255 R4)', () => {
+  const projectRoot = '/tmp/cleo-test-project';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('produces a frozen subsystem named "sentient"', () => {
+    const subsystem = createSentientSubsystem(projectRoot, { superviseStudio: false });
+    expect(subsystem.name).toBe('sentient');
+    expect(Object.isFrozen(subsystem)).toBe(true);
+  });
+
+  it('registers with SubsystemRegistry without error', () => {
+    const registry = new SubsystemRegistry();
+    const subsystem = createSentientSubsystem(projectRoot, { superviseStudio: false });
+    expect(() => registry.register(subsystem)).not.toThrow();
+    expect(registry.names).toContain('sentient');
+  });
+
+  it('start → healthProbe → shutdown lifecycle completes without error', async () => {
+    const registry = new SubsystemRegistry();
+    registry.register(createSentientSubsystem(projectRoot, { superviseStudio: false }));
+
+    await registry.startAll();
+
+    const health = await registry.aggregateHealth();
+    expect(health.subsystems).toHaveLength(1);
+    const row = health.subsystems[0];
+    expect(row?.child_id).toBe('sentient');
+    // pid=process.pid is live so should be 'running'
+    expect(['running', 'stopped']).toContain(row?.state);
+
+    await registry.shutdownAll();
+  });
+
+  it('healthProbe reports stopped when pid is null', async () => {
+    const { readSentientState } = await import('@cleocode/core/sentient');
+
+    const registry = new SubsystemRegistry();
+    registry.register(createSentientSubsystem(projectRoot, { superviseStudio: false }));
+    await registry.startAll();
+
+    vi.mocked(readSentientState).mockResolvedValueOnce({
+      pid: null,
+      killSwitch: false,
+      killSwitchReason: null,
+      lastTickAt: null,
+      lastCronFiredAt: null,
+      tier2Enabled: false,
+      stuckTasks: {},
+      stats: { tasksSpawned: 0, tasksCompleted: 0, tasksFailed: 0 },
+    } as Awaited<ReturnType<typeof readSentientState>>);
+
+    const health = await registry.aggregateHealth();
+    expect(health.subsystems[0]?.state).toBe('stopped');
+
+    await registry.shutdownAll();
+  });
+
+  it('shutdown releases lock and patches state with pid: null', async () => {
+    const { releaseLock, patchSentientState } = await import('@cleocode/core/sentient');
+
+    const registry = new SubsystemRegistry();
+    registry.register(createSentientSubsystem(projectRoot, { superviseStudio: false }));
+    await registry.startAll();
+    await registry.shutdownAll();
+
+    expect(vi.mocked(releaseLock)).toHaveBeenCalled();
+    expect(vi.mocked(patchSentientState)).toHaveBeenCalledWith(
+      expect.stringContaining('.cleo/sentient-state.json'),
+      expect.objectContaining({ pid: null }),
+    );
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -18,6 +18,11 @@ import { HeartbeatService } from './services/heartbeat.js';
 import { KeyRotationService } from './services/key-rotation.js';
 import { SseConnectionService } from './services/sse-connection.js';
 
+// R4 (T11255) — sentient daemon subsystem adapter
+export {
+  bootstrapSentientRegistry,
+  createSentientSubsystem,
+} from './sentient-subsystem.js';
 export type { AgentPollerConfig, MessageHandler } from './services/agent-poller.js';
 export { AgentPoller } from './services/agent-poller.js';
 export type { HeartbeatConfig } from './services/heartbeat.js';

--- a/packages/runtime/src/sentient-subsystem.ts
+++ b/packages/runtime/src/sentient-subsystem.ts
@@ -1,0 +1,371 @@
+/**
+ * Sentient daemon subsystem adapter — R4 (T11255).
+ *
+ * Expresses the full sentient daemon lifecycle (Studio supervision, Tier-1
+ * tick cron, Tier-2 proposal cron, skill curator cron, nightly hygiene loop)
+ * as a single {@link Subsystem} via `defineSubsystem` from
+ * `@cleocode/runtime/daemon`.
+ *
+ * ### Package placement
+ * This file lives in `@cleocode/runtime` (NOT `@cleocode/core`) to respect the
+ * dependency direction: `@cleocode/runtime` → `@cleocode/core` (runtime
+ * consumes core; core must not import runtime to avoid a circular dep).
+ *
+ * ### Standalone-daemon path (daemon-entry.ts)
+ * The legacy `bootstrapDaemon` in `@cleocode/core/sentient` continues to
+ * function as the entry point for the standalone `cleo daemon start --foreground`
+ * path. `createSentientSubsystem` is the adapter for hosts that want to embed
+ * the sentient daemon inside a `SubsystemRegistry`-driven process.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime
+ *
+ * @epic T11255 R4 — migrate sentient/daemon.ts → daemon subsystem
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import type { FSWatcher } from 'node:fs';
+import { watch } from 'node:fs';
+import { join } from 'node:path';
+import type { Subsystem, SubsystemHealth } from '@cleocode/contracts';
+import {
+  acquireLock,
+  type BootstrapDaemonOptions,
+  curatorCronExpression,
+  patchSentientState,
+  readCuratorConfig,
+  readSentientState,
+  readSuperviseStudioConfig,
+  releaseLock,
+  SENTIENT_CRON_EXPR,
+  SENTIENT_HYGIENE_CRON_EXPR,
+  SENTIENT_LOCK_FILE,
+  SENTIENT_PROPOSE_CRON_EXPR,
+  SENTIENT_STATE_FILE,
+  StudioSupervisor,
+  safeRunCrossProjectHygiene,
+  safeRunProposeTick,
+  safeRunTick,
+  warmupWorktreeBackend,
+} from '@cleocode/core/sentient';
+import cron from 'node-cron';
+import { createSubsystemLogger, defineSubsystem, SubsystemRegistry } from './daemon/index.js';
+
+// Internal logger for the subsystem.
+const log = createSubsystemLogger('sentient');
+
+/**
+ * Runtime context threaded from `start()` into `shutdown()`.
+ *
+ * Holds every handle the shutdown path needs to tear down cleanly.
+ * Kept internal to this module — callers interact via `SubsystemRegistry`.
+ */
+interface SentientContext {
+  readonly lockPath: string;
+  readonly statePath: string;
+  readonly studioSupervisor: StudioSupervisor | null;
+  readonly watcher: FSWatcher | null;
+  readonly lock: Awaited<ReturnType<typeof acquireLock>>;
+}
+
+/**
+ * Declare the sentient daemon as a supervised daemon {@link Subsystem}.
+ *
+ * The returned subsystem (frozen by `defineSubsystem`) is registered with a
+ * `SubsystemRegistry` in a host process. It carries the full lifecycle
+ * that the legacy `bootstrapDaemon` ran inline:
+ *
+ * 1. `start()` — acquires the advisory lock, persists pid/startedAt,
+ *    optionally starts Studio supervision, watches the state file, and
+ *    schedules all four cron jobs (Tier-1, Tier-2, curator, hygiene). Runs
+ *    one boot tick before returning.
+ * 2. `healthProbe()` — returns a `SubsystemHealth` row based on the pid
+ *    recorded in state.json.
+ * 3. `shutdown()` — cascades Studio SIGTERM → watcher.close() → state patch
+ *    → lock release.
+ *
+ * @param projectRoot - Absolute path to the project (contains `.cleo/`).
+ * @param opts - Optional overrides for Studio supervision and config path.
+ * @returns A frozen {@link Subsystem} for `SubsystemRegistry.register()`.
+ */
+export function createSentientSubsystem(
+  projectRoot: string,
+  opts: BootstrapDaemonOptions = {},
+): Subsystem<SentientContext> {
+  const statePath = join(projectRoot, SENTIENT_STATE_FILE);
+  const lockPath = join(projectRoot, SENTIENT_LOCK_FILE);
+
+  return defineSubsystem<SentientContext>({
+    name: 'sentient',
+
+    async start(): Promise<SentientContext> {
+      // 1. Advisory lock.
+      const lock = await acquireLock(lockPath);
+      if (!lock) {
+        log.error({}, 'lock acquisition failed — another daemon is running');
+        process.exit(2);
+      }
+
+      // 2. Persist pid + startedAt.
+      await patchSentientState(statePath, {
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+      });
+
+      // 3. Studio supervision.
+      let studioSupervisor: StudioSupervisor | null = null;
+      let shouldSuperviseStudio: boolean;
+      if (typeof opts.superviseStudio === 'boolean') {
+        shouldSuperviseStudio = opts.superviseStudio;
+      } else {
+        const { getCleoHome } = await import('@cleocode/core');
+        const defaultConfigPath = join(getCleoHome(), 'config.json');
+        const configPath = opts.globalConfigPath ?? defaultConfigPath;
+        shouldSuperviseStudio = await readSuperviseStudioConfig(configPath);
+      }
+
+      if (shouldSuperviseStudio) {
+        studioSupervisor = new StudioSupervisor(opts.studioOptions ?? {});
+        try {
+          studioSupervisor.start();
+          log.info({}, 'Studio supervision enabled');
+        } catch (err) {
+          log.error({ err }, 'Studio supervision start failed (non-fatal; ticks continue)');
+          studioSupervisor = null;
+        }
+      } else {
+        log.info({}, 'Studio supervision disabled (daemon.superviseStudio=false)');
+      }
+
+      // 4. State file watcher.
+      let watcher: FSWatcher | null = null;
+      try {
+        watcher = watch(statePath, { persistent: false }, () => {
+          // Next tick will re-read state and honour kill-switch.
+        });
+      } catch {
+        watcher = null;
+      }
+
+      // 5. Warm up worktree backend.
+      await warmupWorktreeBackend();
+
+      // 6. Boot tick (Tier-1 immediate run).
+      const tickOptions = { projectRoot, statePath };
+      await patchSentientState(statePath, { lastCronFiredAt: new Date().toISOString() });
+      const outcome = await safeRunTick(tickOptions);
+      log.info(
+        { kind: outcome.kind, taskId: outcome.taskId ?? null },
+        `boot tick: ${outcome.kind} (task=${outcome.taskId ?? 'n/a'}) ${outcome.detail}`,
+      );
+
+      // 7. Schedule cron jobs.
+
+      // Tier-1: every 5 minutes.
+      cron.schedule(
+        SENTIENT_CRON_EXPR,
+        async () => {
+          try {
+            await patchSentientState(statePath, { lastCronFiredAt: new Date().toISOString() });
+          } catch (err) {
+            log.warn({ err }, 'heartbeat write failed');
+          }
+          try {
+            const result = await safeRunTick(tickOptions);
+            log.info(
+              { kind: result.kind, taskId: result.taskId ?? null },
+              `tick: ${result.kind} (task=${result.taskId ?? 'n/a'}) ${result.detail}`,
+            );
+          } catch (err) {
+            log.error({ err }, 'tick error (caught at cron boundary)');
+          }
+        },
+        { timezone: 'UTC', noOverlap: true, name: 'cleo-sentient' },
+      );
+
+      // Tier-2: every 2 hours.
+      const proposeOptions = { projectRoot, statePath };
+      cron.schedule(
+        SENTIENT_PROPOSE_CRON_EXPR,
+        async () => {
+          try {
+            const state = await readSentientState(statePath);
+            if (!state.tier2Enabled) return;
+            const result = await safeRunProposeTick(proposeOptions);
+            log.info(
+              { written: result.written, count: result.count },
+              `propose: ${result.kind} ${result.detail}`,
+            );
+          } catch (err) {
+            log.error({ err }, 'propose error (caught at cron boundary)');
+          }
+        },
+        { timezone: 'UTC', noOverlap: true, name: 'cleo-sentient-propose' },
+      );
+
+      // Skill curator: opt-in, default off.
+      {
+        const { getCleoHome } = await import('@cleocode/core');
+        const curatorConfigPath = opts.globalConfigPath ?? join(getCleoHome(), 'config.json');
+        const curatorCfg = await readCuratorConfig(curatorConfigPath);
+        if (curatorCfg.enabled) {
+          const expr = curatorCronExpression(curatorCfg.runEveryHours);
+          log.info({ interval: curatorCfg.runEveryHours, expr }, `curator enabled`);
+          cron.schedule(
+            expr,
+            async () => {
+              try {
+                const curatorState = await readSentientState(statePath);
+                if (curatorState.killSwitch) return;
+                const { runCuratorTick } = await import('@cleocode/core/sentient');
+                const result = await runCuratorTick({
+                  staleAfterDays: curatorCfg.staleAfterDays,
+                  archiveAfterDays: curatorCfg.archiveAfterDays,
+                });
+                log.info(
+                  { checked: result.summary.checked, stale: result.summary.markedStale },
+                  'curator tick complete',
+                );
+              } catch (err) {
+                log.error({ err }, 'curator error (caught at cron boundary)');
+              }
+            },
+            { timezone: 'UTC', noOverlap: true, name: 'cleo-sentient-curator' },
+          );
+        } else {
+          log.info({}, 'curator disabled (daemon.curator.enabled=false)');
+        }
+      }
+
+      // Nightly hygiene: 02:00 UTC (or CLEO_HYGIENE_CRON override).
+      cron.schedule(
+        SENTIENT_HYGIENE_CRON_EXPR,
+        async () => {
+          try {
+            const hygieneState = await readSentientState(statePath);
+            if (hygieneState.killSwitch) return;
+            log.info({}, 'nightly cross-project hygiene loop starting');
+            const digest = await safeRunCrossProjectHygiene();
+            await patchSentientState(statePath, {
+              hygieneLastRunAt: digest.completedAt,
+              hygieneSummary: digest.summary,
+              hygieneStats: {
+                projectsChecked: digest.nexusIntegrity.total,
+                projectsHealthy: digest.nexusIntegrity.healthy,
+                tempGcCandidates: digest.tempGc.candidates.length,
+                duplicateEpicGroups: digest.duplicateEpics.groups.length,
+                worktreesPruned: digest.worktreePrune.totalPruned,
+              },
+            });
+            log.info({}, `hygiene complete: ${digest.summary}`);
+          } catch (err) {
+            log.error({ err }, 'hygiene error (caught at cron boundary)');
+          }
+        },
+        { noOverlap: true, name: 'cleo-sentient-hygiene' },
+      );
+
+      return { lockPath, statePath, studioSupervisor, watcher, lock };
+    },
+
+    async healthProbe(): Promise<SubsystemHealth> {
+      try {
+        const state = await readSentientState(statePath);
+        const running = state.pid
+          ? (() => {
+              try {
+                process.kill(state.pid, 0);
+                return true;
+              } catch {
+                return false;
+              }
+            })()
+          : false;
+        return {
+          child_id: 'sentient',
+          pid: running ? (state.pid ?? 0) : 0,
+          state: running ? 'running' : 'stopped',
+          restart_count: 0,
+          detail: `killSwitch=${state.killSwitch} lastTickAt=${state.lastTickAt ?? 'never'}`,
+        };
+      } catch {
+        return { child_id: 'sentient', pid: 0, state: 'stopped', restart_count: 0 };
+      }
+    },
+
+    async shutdown(context: SentientContext): Promise<void> {
+      // 1. Stop Studio.
+      if (context.studioSupervisor !== null) {
+        log.info({}, 'forwarding shutdown to Studio (SIGTERM)');
+        try {
+          await context.studioSupervisor.stop();
+        } catch {
+          // ignore
+        }
+      }
+      // 2. Close state file watcher.
+      try {
+        context.watcher?.close();
+      } catch {
+        // ignore
+      }
+      // 3. Patch state — clear pid.
+      try {
+        await patchSentientState(context.statePath, {
+          pid: null,
+          killSwitchReason: 'subsystem shutdown',
+        });
+      } catch {
+        // ignore
+      }
+      // 4. Release advisory lock.
+      try {
+        if (context.lock) await releaseLock(context.lock);
+      } catch {
+        // ignore
+      }
+      log.info({}, 'sentient subsystem stopped');
+    },
+  });
+}
+
+/**
+ * Bootstrap the sentient daemon via a SubsystemRegistry.
+ *
+ * Alternative to `bootstrapDaemon` for host processes that want to drive the
+ * sentient daemon through the uniform `start → healthProbe → shutdown`
+ * lifecycle (e.g., a unified CLEO daemon host that also runs the GC subsystem
+ * and the gateway subsystem). Installs SIGTERM/SIGINT handlers that call
+ * `shutdownAll()` and keeps the process alive via node-cron.
+ *
+ * @param projectRoot - Absolute path to the project (contains `.cleo/`).
+ * @param opts - Optional Studio supervision and config overrides.
+ */
+export async function bootstrapSentientRegistry(
+  projectRoot: string,
+  opts: BootstrapDaemonOptions = {},
+): Promise<void> {
+  const registry = new SubsystemRegistry({
+    onStart: (name: string) => log.info({ name }, `subsystem started: ${name}`),
+    onShutdown: (name: string) => log.info({ name }, `subsystem shutdown: ${name}`),
+    onError: (name: string, err: Error, phase: string) =>
+      log.error({ name, phase, err }, `subsystem lifecycle error [${phase}]`),
+  });
+
+  registry.register(createSentientSubsystem(projectRoot, opts));
+  await registry.startAll();
+
+  const shutdown = async (reason: string): Promise<void> => {
+    log.info({ reason }, 'shutdown signal received');
+    await registry.shutdownAll();
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', () => {
+    void shutdown('SIGTERM');
+  });
+  process.on('SIGINT', () => {
+    void shutdown('SIGINT');
+  });
+  // Process stays alive via node-cron scheduler.
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,6 +748,9 @@ importers:
       '@cleocode/core':
         specifier: workspace:*
         version: link:../core
+      node-cron:
+        specifier: ^4.2.1
+        version: 4.2.1
     devDependencies:
       tsup:
         specifier: ^8.0.0


### PR DESCRIPTION
## Summary

- Creates `packages/runtime/src/sentient-subsystem.ts` with `createSentientSubsystem()` factory — expresses the full sentient daemon lifecycle (Studio supervision, Tier-1/2 cron, skill curator cron, nightly hygiene) as a frozen `Subsystem<SentientContext>` via `defineSubsystem` from `@cleocode/runtime/daemon`
- Adds `bootstrapSentientRegistry()` helper for hosts that want to embed the sentient daemon inside a `SubsystemRegistry`-driven unified process
- Package placement in `@cleocode/runtime` (not `@cleocode/core`) respects the dep direction — runtime → core; core must not import runtime
- Exports `readSuperviseStudioConfig` and `warmupWorktreeBackend` from `@cleocode/core/sentient` public surface
- Adds `node-cron` to `@cleocode/runtime` deps (daemon layer owns cron scheduling)
- 5 unit tests covering start/healthProbe/shutdown lifecycle, stopped state on null pid, and lock/state cleanup on shutdown
- `bootstrapDaemon` in `core/sentient/daemon.ts` preserved as the standalone entry point

## Test plan

- [ ] `pnpm run typecheck` passes (tsc -b)
- [ ] `npx vitest run --project @cleocode/runtime` passes (12 test files, 118 tests)
- [ ] `npx vitest run --project @cleocode/core` — any failures are pre-existing on main
- [ ] PR CI green

Epic: T11255 R4 · Saga: T11243 SG-RUNTIME-UNIFICATION

🤖 Generated with [Claude Code](https://claude.ai/claude-code)