### PR TITLE
feat(T11494): E2-CLEO-GO — autopilot driver + cleo go command

### DIFF
--- a/packages/cleo/src/cli/commands/go.ts
+++ b/packages/cleo/src/cli/commands/go.ts
@@ -1,0 +1,66 @@
+/**
+ * CLI `cleo go` — SG-AUTOPILOT single-step driver.
+ *
+ * Thin dispatch over {@link cleoGo} in `packages/core/src/go/driver.ts`.
+ * All orchestration logic lives in core; this handler is PURE GLUE:
+ *   1. Parse flags.
+ *   2. Delegate to `go.cleoGo()`.
+ *   3. Emit one LAFS envelope via `cliOutput`.
+ *
+ * Usage:
+ *   cleo go [--saga <sagaId>] [--headless]
+ *
+ * Flags:
+ *   --saga <id>   Scope autopilot to a specific Saga (default: auto-select
+ *                 highest-priority non-terminal Saga from canonical order)
+ *   --headless    Suppress interactive annotations; suitable for daemon use.
+ *
+ * Output (one LAFS envelope):
+ *   { outcome: CleoGoAction, diagnostics: string[] }
+ *
+ * `outcome.action` is one of:
+ *   - `needsDecomposition` — active epic has no children; decompose first
+ *   - `lifecycleHop`       — pre-implementation stage; advance lifecycle
+ *   - `ivtrFanOut`         — IVTR started for tasks on the ready frontier
+ *   - `complete`           — no non-terminal sagas remain
+ *
+ * @task T11494 — E2-CLEO-GO
+ * @saga T11492 — SG-AUTOPILOT
+ */
+
+import { getProjectRoot, go } from '@cleocode/core';
+import { defineCommand } from '../lib/define-cli-command.js';
+import { cliOutput } from '../renderers/index.js';
+
+/**
+ * `cleo go` root command — runs one turn of the SG-AUTOPILOT pipeline.
+ *
+ * @task T11494
+ */
+export const goCommand = defineCommand({
+  meta: {
+    name: 'go',
+    description: 'SG-AUTOPILOT: run one turn of briefing→sagaNext→ready→stage-branch→ivtr loop',
+  },
+  args: {
+    saga: {
+      type: 'string',
+      description: 'Optional saga task ID to scope the autopilot run (default: auto-select)',
+      required: false,
+    },
+    headless: {
+      type: 'boolean',
+      description: 'Suppress interactive annotations; suitable for daemon / unattended use',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const projectRoot = getProjectRoot();
+    const result = await go.cleoGo({
+      sagaId: typeof args.saga === 'string' && args.saga.length > 0 ? args.saga : undefined,
+      headless: args.headless === true,
+      projectRoot,
+    });
+    cliOutput(result.success ? result.data : result, { command: 'go', operation: 'go.run' });
+  },
+});

--- a/packages/cleo/src/cli/commands/saga.ts
+++ b/packages/cleo/src/cli/commands/saga.ts
@@ -281,6 +281,41 @@ const rollupCommand = defineCommand({
 });
 
 /**
+ * cleo saga next [<sagaId>] — return the next actionable Saga and its ready frontier.
+ *
+ * When no `sagaId` is supplied, auto-selects the highest-priority non-terminal Saga
+ * from the canonical Saga-to-Saga order (North Star §0.1). When `sagaId` is given,
+ * scopes the traversal to that Saga only.
+ *
+ * Output includes: sagaId, sagaTitle, sagaLabel, canonicalRank, activeSagaCount,
+ * member-epic rollup, readyFrontier task IDs, and blockers.
+ *
+ * @task T11493 — E1-SAGA-RESOLVE
+ * @saga T11492 — SG-AUTOPILOT
+ */
+const nextCommand = defineCommand({
+  meta: {
+    name: 'next',
+    description: 'Return the next actionable Saga and its ready-frontier task IDs',
+  },
+  args: {
+    sagaId: {
+      type: 'positional',
+      description: 'Optional saga task ID. Omit to auto-select from canonical order.',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const { sagas, getProjectRoot } = await import('@cleocode/core');
+    const projectRoot = getProjectRoot();
+    const sagaId =
+      typeof args.sagaId === 'string' && args.sagaId.length > 0 ? args.sagaId : undefined;
+    const result = await sagas.sagaNext(projectRoot, { sagaId });
+    cliOutput(result.success ? result.data : result, { command: 'saga', operation: 'saga.next' });
+  },
+});
+
+/**
  * Root saga command group — above-epic grouping tier (Saga, prefix SG-).
  *
  * Dispatches to `tasks.saga.*` registry operations.
@@ -301,6 +336,7 @@ export const sagaCommand = defineCommand({
     rollup: rollupCommand,
     repair: repairCommand,
     reconcile: reconcileCommand,
+    next: nextCommand,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/cleo/src/cli/commands/workgraph.ts
+++ b/packages/cleo/src/cli/commands/workgraph.ts
@@ -158,17 +158,98 @@ const structureCommand = defineCommand({
   },
 });
 
+/**
+ * cleo workgraph status — one-shot saga-to-saga workgraph dashboard.
+ *
+ * Prints every non-terminal Saga in canonical rank order with its rollup
+ * progress (done/total tasks, completion %). This is the tracking checklist —
+ * a Saga is DONE when its rollup hits 100%.
+ *
+ * Business logic lives in {@link CANONICAL_SAGA_ORDER} (core/src/sagas/next.ts)
+ * and {@link sagaRollup} (core/src/sagas/rollup.ts). The scripts/workgraph-status.mjs
+ * script was deleted in T11493 in favour of this command.
+ *
+ * @task T11493 — E1-SAGA-RESOLVE
+ * @saga T11492 — SG-AUTOPILOT
+ */
+const statusCommand = defineCommand({
+  meta: {
+    name: 'status',
+    description: 'One-shot saga-to-saga workgraph dashboard (tracking checklist)',
+  },
+  async run() {
+    const { sagas, getProjectRoot } = await import('@cleocode/core');
+    const { cliOutput } = await import('../renderers/index.js');
+    const projectRoot = getProjectRoot();
+
+    // Fetch all saga rows.
+    const listResult = await sagas.sagaList(projectRoot);
+    if (!listResult.success) {
+      cliOutput(listResult, { command: 'workgraph', operation: 'workgraph.status' });
+      return;
+    }
+
+    const allSagas = listResult.data?.sagas ?? [];
+    const sagaMap = new Map(
+      allSagas.map((s) => [s.id, s as { id: string; title?: string; status?: string }]),
+    );
+
+    const TERMINAL = new Set(['done', 'cancelled', 'deleted', 'archived', 'completed']);
+
+    // Build rows in canonical order.
+    const rows: Array<{
+      rank: number;
+      sagaId: string;
+      status: string;
+      completionPct: number;
+      done: number;
+      total: number;
+      label: string;
+    }> = [];
+
+    for (let i = 0; i < sagas.CANONICAL_SAGA_ORDER.length; i++) {
+      const [id, label] = sagas.CANONICAL_SAGA_ORDER[i];
+      const saga = sagaMap.get(id);
+      if (!saga) continue;
+      const status = saga.status ?? 'pending';
+      const rollupResult = await sagas.sagaRollup(projectRoot, { sagaId: id });
+      const rollup = rollupResult.success
+        ? (rollupResult.data as { total?: number; done?: number; completionPct?: number })
+        : { total: 0, done: 0, completionPct: 0 };
+      rows.push({
+        rank: i + 1,
+        sagaId: id,
+        status,
+        completionPct: rollup.completionPct ?? 0,
+        done: rollup.done ?? 0,
+        total: rollup.total ?? 0,
+        label: TERMINAL.has(status) ? `${label} ✓` : label,
+      });
+    }
+
+    cliOutput(
+      {
+        rows,
+        total: rows.length,
+        activeSagaCount: rows.filter((r) => !TERMINAL.has(r.status)).length,
+      },
+      { command: 'workgraph', operation: 'workgraph.status' },
+    );
+  },
+});
+
 /** Root workgraph command group. */
 export const workgraphCommand = defineCommand({
   meta: {
     name: 'workgraph',
-    description: 'PM-Core V2 WorkGraph operations — validate, apply, plan, structure',
+    description: 'PM-Core V2 WorkGraph operations — validate, apply, plan, structure, status',
   },
   subCommands: {
     validate: validateCommand,
     apply: applyCommand,
     plan: planCommand,
     structure: structureCommand,
+    status: statusCommand,
   },
   async run({ cmd, rawArgs }) {
     const firstArg = rawArgs?.find((a) => !a.startsWith('-'));

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -959,7 +959,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'workgraphCommand',
     name: 'workgraph',
-    description: 'PM-Core V2 WorkGraph operations — validate, apply, plan, structure',
+    description: 'PM-Core V2 WorkGraph operations — validate, apply, plan, structure, status',
     load: async () => (await import('../commands/workgraph.js')).workgraphCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -453,6 +453,12 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     load: async () => (await import('../commands/gc.js')).gcCommand as CommandDef,
   },
   {
+    exportName: 'goCommand',
+    name: 'go',
+    description: 'SG-AUTOPILOT: run one turn of briefing→sagaNext→ready→stage-branch→ivtr loop',
+    load: async () => (await import('../commands/go.js')).goCommand as CommandDef,
+  },
+  {
     exportName: 'goalCommand',
     name: 'goal',
     description:

--- a/packages/core/src/go/__tests__/driver.test.ts
+++ b/packages/core/src/go/__tests__/driver.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Unit tests for the `cleo go` autopilot driver (T11494).
+ *
+ * Tests the four outcome branches of {@link cleoGo}:
+ * 1. `complete`           — no non-terminal sagas
+ * 2. `needsDecomposition` — empty ready frontier + zero descendants
+ * 3. `lifecycleHop`       — pre-implementation stage (research/specification/decomposition)
+ * 4. `ivtrFanOut`         — implementation stage, IVTR fan-out
+ *
+ * The test stubs out the three imported engines (sagaNext, orchestrateReady, startIvtr)
+ * so no DB or filesystem is touched.
+ *
+ * @task T11494 — E2-CLEO-GO
+ * @saga T11492 — SG-AUTOPILOT
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SagaNextResult } from '../../sagas/next.js';
+
+// ---------------------------------------------------------------------------
+// Module mocks — must come before importing the system-under-test
+// ---------------------------------------------------------------------------
+
+const mockSagaNext = vi.fn();
+const mockOrchestrateReady = vi.fn();
+const mockStartIvtr = vi.fn();
+
+vi.mock('../../sagas/next.js', () => ({
+  sagaNext: (...args: unknown[]) => mockSagaNext(...args),
+}));
+
+vi.mock('../../orchestrate/query-ops.js', () => ({
+  orchestrateReady: (...args: unknown[]) => mockOrchestrateReady(...args),
+}));
+
+vi.mock('../../lifecycle/ivtr-loop.js', () => ({
+  startIvtr: (...args: unknown[]) => mockStartIvtr(...args),
+}));
+
+vi.mock('../../paths.js', () => ({
+  getProjectRoot: (_p?: string) => _p ?? '/test/root',
+}));
+
+// ---------------------------------------------------------------------------
+// Import SUT after mocks are registered
+// ---------------------------------------------------------------------------
+
+const { cleoGo } = await import('../driver.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal SagaNextResult with sensible defaults. */
+function makeSagaNextResult(overrides: Partial<SagaNextResult> = {}): SagaNextResult {
+  return {
+    sagaId: 'T100',
+    sagaTitle: 'Test Saga',
+    sagaLabel: 'test (parallel)',
+    canonicalRank: 0,
+    activeSagaCount: 1,
+    readyFrontier: [],
+    blockers: [],
+    total: 1,
+    done: 0,
+    active: 1,
+    blocked: 0,
+    pending: 0,
+    completionPct: 0,
+    memberEpics: [],
+    ...overrides,
+  };
+}
+
+/** Build a minimal orchestrateReady result. */
+function makeReadyResult(
+  readyTasks: Array<{ id: string; pipelineStage?: string; parentId?: string }> = {},
+) {
+  return {
+    success: true,
+    data: { readyTasks: Array.isArray(readyTasks) ? readyTasks : [] },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('cleoGo driver (T11494)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartIvtr.mockResolvedValue({ taskId: 'T999', currentPhase: 'implement' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ---- Outcome: complete ---------------------------------------------------
+
+  describe('outcome: complete', () => {
+    it('returns complete when sagaNext returns an empty sagaId', async () => {
+      mockSagaNext.mockResolvedValue({
+        success: true,
+        data: makeSagaNextResult({ sagaId: '', activeSagaCount: 0 }),
+      });
+
+      const result = await cleoGo();
+      expect(result.success).toBe(true);
+      expect(result.data?.outcome.action).toBe('complete');
+    });
+  });
+
+  // ---- Outcome: needsDecomposition ----------------------------------------
+
+  describe('outcome: needsDecomposition', () => {
+    it('returns needsDecomposition when ready frontier is empty and no descendants', async () => {
+      mockSagaNext.mockResolvedValue({
+        success: true,
+        data: makeSagaNextResult({
+          sagaId: 'T100',
+          memberEpics: [
+            {
+              id: 'T101',
+              title: 'AC-only epic',
+              status: 'pending',
+              descendantTaskCount: 0,
+              descendantDone: 0,
+              descendantActive: 0,
+              descendantBlocked: 0,
+              descendantPending: 0,
+              descendantCompletionPct: 0,
+            },
+          ],
+        }),
+      });
+      mockOrchestrateReady.mockResolvedValue(makeReadyResult([]));
+
+      const result = await cleoGo({ sagaId: 'T100' });
+      expect(result.success).toBe(true);
+      const outcome = result.data?.outcome;
+      expect(outcome?.action).toBe('needsDecomposition');
+      if (outcome?.action === 'needsDecomposition') {
+        expect(outcome.sagaId).toBe('T100');
+        expect(outcome.epicId).toBe('T101');
+      }
+    });
+  });
+
+  // ---- Outcome: lifecycleHop -----------------------------------------------
+
+  describe('outcome: lifecycleHop', () => {
+    it.each([
+      ['research', 'research'],
+      ['specification', 'specification'],
+      ['decomposition', 'decomposition'],
+    ] as const)('returns lifecycleHop when pipelineStage is %s', async (_label, stage) => {
+      mockSagaNext.mockResolvedValue({
+        success: true,
+        data: makeSagaNextResult({
+          sagaId: 'T100',
+          memberEpics: [
+            {
+              id: 'T101',
+              title: 'Pre-impl epic',
+              status: 'active',
+              descendantTaskCount: 3,
+              descendantDone: 0,
+              descendantActive: 3,
+              descendantBlocked: 0,
+              descendantPending: 0,
+              descendantCompletionPct: 0,
+            },
+          ],
+        }),
+      });
+      mockOrchestrateReady.mockResolvedValue(
+        makeReadyResult([{ id: 'T102', pipelineStage: stage, parentId: 'T101' }]),
+      );
+
+      const result = await cleoGo({ sagaId: 'T100' });
+      expect(result.success).toBe(true);
+      const outcome = result.data?.outcome;
+      expect(outcome?.action).toBe('lifecycleHop');
+      if (outcome?.action === 'lifecycleHop') {
+        expect(outcome.currentStage).toBe(stage);
+        expect(outcome.sagaId).toBe('T100');
+      }
+    });
+  });
+
+  // ---- Outcome: ivtrFanOut ------------------------------------------------
+
+  describe('outcome: ivtrFanOut', () => {
+    it('returns ivtrFanOut and starts IVTR for each ready task at implementation stage', async () => {
+      mockSagaNext.mockResolvedValue({
+        success: true,
+        data: makeSagaNextResult({
+          sagaId: 'T100',
+          memberEpics: [
+            {
+              id: 'T101',
+              title: 'Implementation epic',
+              status: 'active',
+              descendantTaskCount: 2,
+              descendantDone: 0,
+              descendantActive: 2,
+              descendantBlocked: 0,
+              descendantPending: 0,
+              descendantCompletionPct: 0,
+            },
+          ],
+        }),
+      });
+      mockOrchestrateReady.mockResolvedValue(
+        makeReadyResult([
+          { id: 'T102', pipelineStage: 'implementation', parentId: 'T101' },
+          { id: 'T103', pipelineStage: 'implementation', parentId: 'T101' },
+        ]),
+      );
+      mockStartIvtr
+        .mockResolvedValueOnce({ taskId: 'T102', currentPhase: 'implement' })
+        .mockResolvedValueOnce({ taskId: 'T103', currentPhase: 'implement' });
+
+      const result = await cleoGo({ sagaId: 'T100' });
+      expect(result.success).toBe(true);
+      const outcome = result.data?.outcome;
+      expect(outcome?.action).toBe('ivtrFanOut');
+      if (outcome?.action === 'ivtrFanOut') {
+        expect(outcome.tasks).toEqual(['T102', 'T103']);
+        expect(outcome.currentStage).toBe('implementation');
+      }
+      expect(mockStartIvtr).toHaveBeenCalledTimes(2);
+    });
+
+    it('gracefully handles IVTR start failures and reports in diagnostics', async () => {
+      mockSagaNext.mockResolvedValue({
+        success: true,
+        data: makeSagaNextResult({
+          sagaId: 'T100',
+          memberEpics: [
+            {
+              id: 'T101',
+              title: 'Implementation epic',
+              status: 'active',
+              descendantTaskCount: 2,
+              descendantDone: 0,
+              descendantActive: 2,
+              descendantBlocked: 0,
+              descendantPending: 0,
+              descendantCompletionPct: 0,
+            },
+          ],
+        }),
+      });
+      mockOrchestrateReady.mockResolvedValue(
+        makeReadyResult([
+          { id: 'T102', pipelineStage: 'implementation', parentId: 'T101' },
+          { id: 'T103', pipelineStage: 'implementation', parentId: 'T101' },
+        ]),
+      );
+      mockStartIvtr
+        .mockResolvedValueOnce({ taskId: 'T102', currentPhase: 'implement' })
+        .mockRejectedValueOnce(new Error('E_IVTR_LOCKED'));
+
+      const result = await cleoGo({ sagaId: 'T100' });
+      expect(result.success).toBe(true);
+      const outcome = result.data?.outcome;
+      expect(outcome?.action).toBe('ivtrFanOut');
+      if (outcome?.action === 'ivtrFanOut') {
+        // Only T102 succeeded
+        expect(outcome.tasks).toEqual(['T102']);
+      }
+      // T103 failure is in diagnostics
+      expect(result.data?.diagnostics.some((d) => d.includes('T103'))).toBe(true);
+    });
+  });
+
+  // ---- Error propagation --------------------------------------------------
+
+  describe('error propagation', () => {
+    it('surfaces sagaNext failure as EngineFailure', async () => {
+      mockSagaNext.mockResolvedValue({
+        success: false,
+        error: { code: 'E_GENERAL', message: 'sagaNext exploded' },
+      });
+
+      const result = await cleoGo();
+      expect(result.success).toBe(false);
+    });
+
+    it('surfaces orchestrateReady failure as EngineFailure', async () => {
+      mockSagaNext.mockResolvedValue({
+        success: true,
+        data: makeSagaNextResult({ sagaId: 'T100' }),
+      });
+      mockOrchestrateReady.mockResolvedValue({
+        success: false,
+        error: { code: 'E_NOT_FOUND', message: 'epic T100 not found' },
+      });
+
+      const result = await cleoGo({ sagaId: 'T100' });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ---- AC2: one envelope per call -----------------------------------------
+
+  describe('AC2: ONE LAFS envelope per call', () => {
+    it('always returns exactly one EngineResult', async () => {
+      mockSagaNext.mockResolvedValue({
+        success: true,
+        data: makeSagaNextResult({ sagaId: '' }),
+      });
+
+      const result = await cleoGo();
+      // Shape check: has success + data (or error)
+      expect(typeof result.success).toBe('boolean');
+      if (result.success) {
+        expect(result.data).toBeDefined();
+        expect(result.data?.outcome).toBeDefined();
+        expect(Array.isArray(result.data?.diagnostics)).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/core/src/go/driver.ts
+++ b/packages/core/src/go/driver.ts
@@ -1,0 +1,277 @@
+/**
+ * `cleo go` autopilot driver — the thin orchestration sequencer.
+ *
+ * This is the canonical entry point for `cleo go` (SG-AUTOPILOT / T11492).
+ * It is PURE GLUE: it sequences existing core engines without adding new
+ * orchestration math.
+ *
+ * ## Pipeline (AC1)
+ *
+ * ```
+ * briefing (optional context anchor)
+ *   → sagaNext() — pick highest-priority non-terminal saga
+ *   → orchestrateReady(sagaId) — fetch readyFrontier
+ *   → branch on pipelineStage of the active epic:
+ *       AC-only (no children, research stage)
+ *         → { action: 'needsDecomposition', sagaId, epicId }
+ *       research | specification | decomposition
+ *         → { action: 'lifecycleHop', sagaId, epicId, currentStage }
+ *       implementation | validation | testing | release | contribution
+ *         → fan-out startIvtr over readyFrontier tasks
+ *         → { action: 'ivtrFanOut', sagaId, epicId, tasks: string[] }
+ *   → return ONE LAFS-compatible EngineResult envelope
+ * ```
+ *
+ * ## Design constraints
+ *
+ * - AC2: ONE LAFS envelope per call — all branching produces a single return.
+ * - AC3: empty ready-set + zero children → `needsDecomposition` (typed, not silent []).
+ * - No new orchestration math — only sequences ops from `sagas`, `orchestrate`,
+ *   and `lifecycle` modules.
+ * - CORE-FIRST: all logic here in `packages/core/src/go/`; CLI is a thin dispatch.
+ *
+ * @module @cleocode/core/go
+ *
+ * @task T11494 — E2-CLEO-GO
+ * @saga T11492 — SG-AUTOPILOT
+ */
+
+import type { TaskViewPipelineStage } from '@cleocode/contracts';
+import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
+import { startIvtr } from '../lifecycle/ivtr-loop.js';
+import { orchestrateReady } from '../orchestrate/query-ops.js';
+import { getProjectRoot } from '../paths.js';
+import { sagaNext } from '../sagas/next.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Input parameters for {@link cleoGo}.
+ *
+ * @task T11494
+ */
+export interface CleoGoParams {
+  /**
+   * Optional saga ID to scope the autopilot run. When omitted, `sagaNext`
+   * auto-selects the highest-priority non-terminal Saga in canonical order.
+   */
+  sagaId?: string;
+  /**
+   * When true, suppress any interactive output suitable for daemon / unattended
+   * runs. The result shape is identical; only side-channel logging is affected.
+   */
+  headless?: boolean;
+  /** Override project root (useful in tests). */
+  projectRoot?: string;
+}
+
+/**
+ * Discriminated union of the four action outcomes `cleoGo` can produce.
+ *
+ * Consumers pattern-match on `action` to route further processing.
+ *
+ * @task T11494
+ */
+export type CleoGoAction =
+  | {
+      /** No children + research stage — the epic needs decomposition before IVTR. */
+      action: 'needsDecomposition';
+      sagaId: string;
+      /** The AC-only epic that needs task children added. */
+      epicId: string;
+      /** Current pipelineStage (always `'research'` for AC-only epics). */
+      currentStage: TaskViewPipelineStage;
+    }
+  | {
+      /** Pre-implementation stage — lifecycle must hop before IVTR is valid. */
+      action: 'lifecycleHop';
+      sagaId: string;
+      epicId: string;
+      currentStage: TaskViewPipelineStage;
+      /** All ready-frontier task IDs (may be empty while lifecycle hops). */
+      readyFrontier: string[];
+    }
+  | {
+      /** Fan-out: IVTR started for each task on the ready frontier. */
+      action: 'ivtrFanOut';
+      sagaId: string;
+      epicId: string;
+      currentStage: TaskViewPipelineStage;
+      /** Task IDs for which IVTR was initiated (non-empty). */
+      tasks: string[];
+    }
+  | {
+      /** No non-terminal sagas remain — the workgraph is complete. */
+      action: 'complete';
+    };
+
+/**
+ * Result payload for {@link cleoGo}.
+ *
+ * @task T11494
+ */
+export interface CleoGoResult {
+  /** The action taken by the driver in this turn. */
+  outcome: CleoGoAction;
+  /**
+   * Structured diagnostics for display / logging. Always present; may be empty.
+   */
+  diagnostics: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Pre-implementation stage set
+// ---------------------------------------------------------------------------
+
+/**
+ * Pipeline stages that require a lifecycle hop before spawning IVTR workers.
+ *
+ * Tasks whose parent epic is still in one of these stages are not yet
+ * implementation-ready; the driver signals `lifecycleHop` instead of fanning
+ * out IVTR.
+ */
+const PRE_IMPLEMENTATION_STAGES = new Set<TaskViewPipelineStage>([
+  'research',
+  'specification',
+  'decomposition',
+]);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Run one turn of the `cleo go` autopilot pipeline.
+ *
+ * Returns a single LAFS-compatible {@link EngineResult} wrapping a
+ * {@link CleoGoResult}. Each call is stateless (side effects — IVTR writes,
+ * lifecycle progression — happen inside the called engines); the driver itself
+ * carries no mutable state.
+ *
+ * @param params - Input parameters controlling the saga scope and mode.
+ * @returns EngineResult with {@link CleoGoResult}.
+ *
+ * @task T11494
+ * @saga T11492
+ */
+export async function cleoGo(params: CleoGoParams = {}): Promise<EngineResult<CleoGoResult>> {
+  const root = getProjectRoot(params.projectRoot);
+  const diagnostics: string[] = [];
+
+  // 1. sagaNext — pick the next actionable saga (or the explicit one).
+  const nextResult = await sagaNext(root, { sagaId: params.sagaId });
+  if (!nextResult.success) {
+    return engineError(
+      nextResult.error?.code ?? 'E_GENERAL',
+      nextResult.error?.message ?? 'sagaNext failed',
+    );
+  }
+
+  const next = nextResult.data;
+
+  // 2. Workgraph complete guard: no active sagas.
+  if (!next.sagaId) {
+    return engineSuccess<CleoGoResult>({
+      outcome: { action: 'complete' },
+      diagnostics: ['No non-terminal sagas remain — workgraph is complete.'],
+    });
+  }
+
+  const sagaId = next.sagaId;
+  diagnostics.push(
+    `active saga: ${sagaId}${next.sagaTitle ? ` (${next.sagaTitle})` : ''} — ${next.completionPct ?? 0}% complete`,
+  );
+
+  // 3. orchestrateReady — get the ready frontier for the saga.
+  const readyResult = await orchestrateReady(sagaId, root);
+  if (!readyResult.success) {
+    return engineError(
+      readyResult.error?.code ?? 'E_GENERAL',
+      `orchestrateReady failed for saga ${sagaId}: ${readyResult.error?.message ?? 'unknown'}`,
+    );
+  }
+
+  const readyData = readyResult.data as {
+    readyTasks?: Array<{ id: string; pipelineStage?: string; parentId?: string }>;
+  };
+  const readyTasks = readyData.readyTasks ?? [];
+  const readyFrontier = readyTasks.map((t) => t.id);
+
+  // 4. Identify the "active epic" — the first ready task's parent, or the first
+  //    saga member if the frontier is empty.
+  //
+  //    We need the epicId to read its pipelineStage and decide the branch action.
+  const epicId = readyTasks[0]?.parentId ?? next.memberEpics?.[0]?.id ?? sagaId;
+  const rawStage =
+    (readyTasks[0] as { pipelineStage?: string } | undefined)?.pipelineStage ??
+    next.memberEpics?.[0]?.status ?? // fallback: treat member epic status as a proxy
+    'research';
+
+  // Normalise to a valid TaskViewPipelineStage, defaulting to 'research'.
+  const currentStage = (rawStage as TaskViewPipelineStage) ?? 'research';
+
+  // 5. AC-only detection: empty ready frontier + no descendant tasks under the
+  //    active epic signals that the epic has acceptance criteria only and needs
+  //    to be decomposed into subtasks (AC3 — fixes the silent [] dead-end).
+  const totalDescendants = next.memberEpics?.find((e) => e.id === epicId)?.descendantTaskCount ?? 0;
+  if (readyFrontier.length === 0 && totalDescendants === 0) {
+    diagnostics.push(`epic ${epicId} has no children and no ready tasks — needs decomposition`);
+    return engineSuccess<CleoGoResult>({
+      outcome: {
+        action: 'needsDecomposition',
+        sagaId,
+        epicId,
+        currentStage,
+      },
+      diagnostics,
+    });
+  }
+
+  // 6. Pre-implementation stage check → lifecycle hop signal.
+  if (PRE_IMPLEMENTATION_STAGES.has(currentStage)) {
+    diagnostics.push(
+      `epic ${epicId} is at stage '${currentStage}' — lifecycle hop required before IVTR`,
+    );
+    return engineSuccess<CleoGoResult>({
+      outcome: {
+        action: 'lifecycleHop',
+        sagaId,
+        epicId,
+        currentStage,
+        readyFrontier,
+      },
+      diagnostics,
+    });
+  }
+
+  // 7. Implementation+ → fan-out IVTR over the ready frontier.
+  const ivtrStarted: string[] = [];
+  for (const taskId of readyFrontier) {
+    try {
+      await startIvtr(taskId, { cwd: root });
+      ivtrStarted.push(taskId);
+    } catch (err: unknown) {
+      diagnostics.push(`IVTR start failed for ${taskId}: ${(err as Error).message}`);
+    }
+  }
+
+  if (ivtrStarted.length === 0 && readyFrontier.length > 0) {
+    // All IVTR starts failed — surface the errors but return gracefully.
+    diagnostics.push(`All ${readyFrontier.length} IVTR starts failed — see diagnostics`);
+  } else {
+    diagnostics.push(`IVTR started for ${ivtrStarted.length} task(s): ${ivtrStarted.join(', ')}`);
+  }
+
+  return engineSuccess<CleoGoResult>({
+    outcome: {
+      action: 'ivtrFanOut',
+      sagaId,
+      epicId,
+      currentStage,
+      tasks: ivtrStarted,
+    },
+    diagnostics,
+  });
+}

--- a/packages/core/src/go/index.ts
+++ b/packages/core/src/go/index.ts
@@ -1,0 +1,18 @@
+/**
+ * `cleo go` autopilot driver — public barrel.
+ *
+ * Re-exports the {@link cleoGo} orchestration sequencer and its result types.
+ * Consumed by the thin CLI handler in `packages/cleo/src/cli/commands/go.ts`.
+ *
+ * @module @cleocode/core/go
+ *
+ * @task T11494 — E2-CLEO-GO
+ * @saga T11492 — SG-AUTOPILOT
+ */
+
+export {
+  type CleoGoAction,
+  type CleoGoParams,
+  type CleoGoResult,
+  cleoGo,
+} from './driver.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,8 @@ export * as compliance from './compliance/index.js';
 export * as conduit from './conduit/index.js';
 export * as context from './context/index.js';
 export * as gc from './gc/index.js';
+// SG-AUTOPILOT — `cleo go` driver (T11494 · Saga T11492).
+export * as go from './go/index.js';
 // CLEO-native goal system (T11290 · Saga T11283 · SG-COGNITIVE-SUBSTRATE).
 export * as goal from './goal/index.js';
 export * as harness from './harness/index.js';

--- a/packages/core/src/orchestrate/lifecycle-ops.ts
+++ b/packages/core/src/orchestrate/lifecycle-ops.ts
@@ -116,7 +116,7 @@ export async function orchestrateStartup(
 
     // Auto-initialize lifecycle at 'research' stage if not already initialized.
     // initLoomForEpic is idempotent — re-invoking orchestrateStartup is safe.
-    const loomResult = await initLoomForEpic(root, epicId);
+    const loomResult = await initLoomForEpic(epicId, root);
     const autoInitialized = loomResult.initialized;
     const currentStage = autoInitialized ? 'research' : 'already-initialized';
 

--- a/packages/core/src/sagas/index.ts
+++ b/packages/core/src/sagas/index.ts
@@ -61,6 +61,12 @@ export {
   sagaMembers,
 } from './members.js';
 export {
+  CANONICAL_SAGA_ORDER,
+  type SagaNextParams,
+  type SagaNextResult,
+  sagaNext,
+} from './next.js';
+export {
   type ReconcileResult,
   type ReconcileSagaParams,
   reconcileSaga,

--- a/packages/core/src/sagas/next.ts
+++ b/packages/core/src/sagas/next.ts
@@ -1,0 +1,217 @@
+/**
+ * sagaNext — one-shot "what should the orchestrator work on?" primitive.
+ *
+ * Composes {@link sagaList} + {@link sagaTraversal} to return the single
+ * highest-priority non-terminal Saga with its ready frontier. The result is
+ * the primary autonomous entry-point for `cleo go` (SG-AUTOPILOT / T11494).
+ *
+ * The canonical Saga-to-Saga order is encoded as a ranked list below (North
+ * Star §0.1). The first non-terminal Saga in that list is the "active" saga
+ * returned by `sagaNext`. If an explicit `sagaId` is supplied the traversal
+ * is scoped to that Saga only.
+ *
+ * @task T11493 — E1-SAGA-RESOLVE: sagaNext() in core
+ * @saga T11492 — SG-AUTOPILOT
+ */
+
+import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
+import { sagaList } from './list.js';
+import { type SagaTraversalResult, sagaTraversal } from './rollup.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Input parameters for {@link sagaNext}. */
+export interface SagaNextParams {
+  /**
+   * Optional saga ID to scope the traversal. When omitted, the first
+   * non-terminal Saga in canonical rank order is selected automatically.
+   */
+  sagaId?: string;
+}
+
+/**
+ * Result payload for {@link sagaNext}.
+ *
+ * Extends the full traversal result with the active saga identity so callers
+ * do not need a separate lookup.
+ */
+export interface SagaNextResult extends SagaTraversalResult {
+  /** The saga ID that was selected (auto or explicit). */
+  sagaId: string;
+  /** Saga title. */
+  sagaTitle?: string;
+  /** Human-readable label from the canonical rank order table. */
+  sagaLabel?: string;
+  /**
+   * Zero-based rank in the canonical Saga-to-Saga sequence (lower = higher
+   * priority). Absent when `sagaId` was supplied explicitly.
+   */
+  canonicalRank?: number;
+  /**
+   * Total number of non-terminal sagas found. Useful for progress dashboards.
+   */
+  activeSagaCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical saga order (North Star §0.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical Saga-to-Saga ordering (rank-ascending, lower index = higher priority).
+ *
+ * This list mirrors the `ORDER` constant in `scripts/workgraph-status.mjs`
+ * (the script is deleted in T11493 — this is the authoritative source).
+ *
+ * @task T11493
+ */
+export const CANONICAL_SAGA_ORDER: ReadonlyArray<readonly [string, string]> = [
+  ['T11242', 'dual cleo.db (FOUNDATION)'],
+  ['T11492', 'AUTOPILOT: cleo go — build EARLY; it then DRIVES every saga below'],
+  ['T11243', 'runtime: Rust supervisor + gateway'],
+  ['T11387', 'package-arch: publish=1 + Tools/Skills'],
+  ['T11480', 'CORE self-tooling (parallel)'],
+  ['T10343', 'envelope-first (foundational doctrine)'],
+  ['T10400', 'SDK-API (OpenAPI over gateway)'],
+  ['T10404', 'agentic vertical: CANT runtime'],
+  ['T10418', 'agentic vertical: tools catalog'],
+  ['T10401', 'daemon-IPC (residue)'],
+  ['T10402', 'cockpit TUI'],
+  ['T10405', 'PSYCHE memory tiers 4-6'],
+  ['T10406', 'four-bus integration (tier 7)'],
+  ['T10409', 'vault-core'],
+  ['T10419', 'channels'],
+  ['T10403', 'GenKit substrate (phased)'],
+  ['T11308', 'SDLC-optimize'],
+  ['T11301', 'release-autonomy'],
+  ['T11460', 'CI-workflow-canon'],
+  ['T9799', 'skills-v2'],
+  ['T11072', 'ADR-canon'],
+  ['T11283', 'cognitive substrate'],
+] as const;
+
+/** Terminal saga statuses — sagas in these states are skipped by sagaNext. */
+const TERMINAL_STATUSES = new Set(['done', 'cancelled', 'deleted', 'archived', 'completed']);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the next actionable Saga and its ready frontier.
+ *
+ * When no `sagaId` is provided, the function walks the canonical Saga-to-Saga
+ * order and returns the first non-terminal Saga that exists in the database.
+ * When `sagaId` is provided, the traversal is scoped to that Saga only.
+ *
+ * The result includes the full {@link SagaTraversalResult} (rollup counters,
+ * member-epic progress, ready frontier, and blockers) extended with saga
+ * identity fields for caller convenience.
+ *
+ * @param projectRoot - Absolute path to the project root (for DB resolution).
+ * @param params - Optional parameters, currently `sagaId` for explicit scoping.
+ * @returns EngineResult wrapping {@link SagaNextResult}.
+ *
+ * @task T11493
+ * @saga T11492
+ */
+export async function sagaNext(
+  projectRoot: string,
+  params: SagaNextParams = {},
+): Promise<EngineResult<SagaNextResult>> {
+  // 1. Resolve the full saga list so we can filter terminal ones.
+  const listResult = await sagaList(projectRoot);
+  if (!listResult.success) {
+    return engineError(
+      'E_GENERAL',
+      listResult.error?.message ?? 'Failed to list sagas for sagaNext',
+    );
+  }
+
+  const sagas = listResult.data?.sagas ?? [];
+  const nonTerminal = sagas.filter((s) => {
+    const status = (s as { status?: string }).status ?? 'pending';
+    return !TERMINAL_STATUSES.has(status);
+  });
+  const activeSagaCount = nonTerminal.length;
+
+  // 2. Resolve which saga to traverse.
+  let targetId: string;
+  let canonicalRank: number | undefined;
+  let sagaLabel: string | undefined;
+
+  if (params.sagaId) {
+    // Explicit saga — validate it exists.
+    const found = sagas.find((s) => s.id === params.sagaId);
+    if (!found) {
+      return engineError('E_NOT_FOUND', `Saga ${params.sagaId} not found in the task graph`);
+    }
+    targetId = params.sagaId;
+  } else {
+    // Auto-select: walk canonical order, pick first non-terminal.
+    const sagaStatusMap = new Map(
+      sagas.map((s) => [s.id, (s as { status?: string }).status ?? 'pending']),
+    );
+
+    let selected: { id: string; label: string; rank: number } | null = null;
+    for (let i = 0; i < CANONICAL_SAGA_ORDER.length; i++) {
+      const [id, label] = CANONICAL_SAGA_ORDER[i];
+      const status = sagaStatusMap.get(id);
+      if (status === undefined) continue; // not in DB — skip
+      if (TERMINAL_STATUSES.has(status)) continue; // terminal — skip
+      selected = { id, label, rank: i };
+      break;
+    }
+
+    if (!selected) {
+      // All sagas in the canonical order are terminal (or missing).
+      // Fall back to first non-terminal in the DB list.
+      const firstActive = nonTerminal[0];
+      if (!firstActive) {
+        return engineSuccess<SagaNextResult>({
+          sagaId: '',
+          activeSagaCount: 0,
+          readyFrontier: [],
+          blockers: [],
+          total: 0,
+          done: 0,
+          active: 0,
+          blocked: 0,
+          pending: 0,
+          completionPct: 0,
+        });
+      }
+      targetId = firstActive.id;
+    } else {
+      targetId = selected.id;
+      canonicalRank = selected.rank;
+      sagaLabel = selected.label;
+    }
+  }
+
+  // 3. Run the full traversal on the selected saga.
+  const traversalResult = await sagaTraversal(projectRoot, targetId);
+  if (!traversalResult.success) {
+    return engineError(
+      traversalResult.error?.code ?? 'E_GENERAL',
+      traversalResult.error?.message ?? `sagaTraversal failed for saga ${targetId}`,
+    );
+  }
+
+  const traversal = traversalResult.data as SagaTraversalResult;
+
+  // 4. Attach saga identity to the result.
+  const saga = sagas.find((s) => s.id === targetId);
+  const sagaTitle = (saga as { title?: string } | undefined)?.title;
+
+  return engineSuccess<SagaNextResult>({
+    ...traversal,
+    sagaId: targetId,
+    sagaTitle,
+    sagaLabel,
+    canonicalRank,
+    activeSagaCount,
+  });
+}

--- a/packages/core/src/tasks/__tests__/loom-auto-init.test.ts
+++ b/packages/core/src/tasks/__tests__/loom-auto-init.test.ts
@@ -5,13 +5,17 @@
  * (a) `cleo add --type epic` auto-initializes LOOM (lifecycle pipeline exists after add)
  * (b) `initLoomForEpic` is idempotent — re-running on an already-initialized epic is a no-op
  * (c) `backfillEpicLoom` populates LOOM for existing un-LOOMed epics
+ * (d) `orchestrateStartup` correctly auto-initializes LOOM (T11493 regression — was silently
+ *     a no-op due to reversed arg order: `initLoomForEpic(root, epicId)` instead of
+ *     `initLoomForEpic(epicId, root)`).
  *
  * @task T1634
+ * @task T11493
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getLifecycleStatus } from '../../lifecycle/index.js';
-import { initLoomForEpic } from '../../orchestrate/lifecycle-ops.js';
+import { initLoomForEpic, orchestrateStartup } from '../../orchestrate/lifecycle-ops.js';
 import { createTestDb, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
 import type { DataAccessor } from '../../store/data-accessor.js';
 import { resetDbState } from '../../store/sqlite.js';
@@ -278,5 +282,106 @@ describe('backfillEpicLoom (T1634)', () => {
     // No active epics — done/cancelled are excluded
     expect(backfillResult.total).toBe(0);
     expect(backfillResult.initialized).toBe(0);
+  });
+});
+
+/**
+ * Regression tests for T11493: orchestrateStartup LOOM arg-swap.
+ *
+ * The bug: `orchestrateStartup` called `initLoomForEpic(root, epicId)` but the
+ * function signature is `initLoomForEpic(epicId, root)`. This caused a silent
+ * no-op — LOOM was never initialized when triggered via `cleo orchestrate start`.
+ *
+ * The fix: swap the args at the call site (lifecycle-ops.ts line 119).
+ *
+ * @task T11493 — E1-SAGA-RESOLVE regression guard
+ */
+describe('T11493 regression: orchestrateStartup correctly auto-initializes LOOM', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+  });
+
+  afterEach(async () => {
+    await env.cleanup();
+    resetDbState();
+  });
+
+  it('orchestrateStartup initializes LOOM for a fresh epic (pre-bug: was silently a no-op)', async () => {
+    // Insert a bare epic directly so we control LOOM state (no addTask fire-and-forget).
+    const { getDb } = await import('../../store/sqlite.js');
+    const db = await getDb(env.tempDir);
+    const { tasks: tasksTable } = await import('../../store/tasks-schema.js');
+    const now = new Date().toISOString();
+    await db
+      .insert(tasksTable)
+      .values({
+        id: 'T500',
+        title: 'Regression Epic',
+        description: 'Epic for orchestrateStartup LOOM arg-swap regression test',
+        type: 'epic',
+        status: 'pending',
+        priority: 'medium',
+        pipelineStage: 'research',
+        position: 500,
+        positionVersion: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // Verify LOOM is NOT initialized before orchestrateStartup.
+    const before = await getLifecycleStatus(env.tempDir, { epicId: 'T500' });
+    expect(before.initialized).toBe(false);
+
+    // Call orchestrateStartup — this is the function that had the arg-swap bug.
+    const result = await orchestrateStartup('T500', env.tempDir);
+    expect(result.success).toBe(true);
+
+    // After orchestrateStartup, LOOM MUST be initialized.
+    // Before the fix: `initLoomForEpic(root, epicId)` treated `root` as the epicId
+    // → lifecycle lookup found no match → initialized:false → LOOM still absent.
+    const after = await getLifecycleStatus(env.tempDir, { epicId: 'T500' });
+    expect(after.initialized).toBe(
+      true,
+      'LOOM must be initialized after orchestrateStartup (T11493 regression)',
+    );
+  });
+
+  it('orchestrateStartup.autoInitialized is true on first call and false on second (idempotent)', async () => {
+    // Insert a bare epic.
+    const { getDb } = await import('../../store/sqlite.js');
+    const db = await getDb(env.tempDir);
+    const { tasks: tasksTable } = await import('../../store/tasks-schema.js');
+    const now = new Date().toISOString();
+    await db
+      .insert(tasksTable)
+      .values({
+        id: 'T501',
+        title: 'Idempotency Epic',
+        description: 'Tests orchestrateStartup idempotency for LOOM init',
+        type: 'epic',
+        status: 'pending',
+        priority: 'medium',
+        pipelineStage: 'research',
+        position: 501,
+        positionVersion: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const first = await orchestrateStartup('T501', env.tempDir);
+    expect(first.success).toBe(true);
+    expect((first.data as Record<string, unknown>).autoInitialized).toBe(true);
+    expect((first.data as Record<string, unknown>).currentStage).toBe('research');
+
+    const second = await orchestrateStartup('T501', env.tempDir);
+    expect(second.success).toBe(true);
+    expect((second.data as Record<string, unknown>).autoInitialized).toBe(false);
+    expect((second.data as Record<string, unknown>).currentStage).toBe('already-initialized');
   });
 });


### PR DESCRIPTION
## Summary

- **New core primitive**: `cleoGo()` in `packages/core/src/go/driver.ts` — sequences `sagaNext → orchestrateReady → stage-branch → IVTR fan-out`. Pure glue; adds NO new orchestration math.
- **`cleo go` CLI command**: thin dispatch in `packages/cleo/src/cli/commands/go.ts`; exports `goCommand`.
- **4 outcome types**: `complete | needsDecomposition | lifecycleHop | ivtrFanOut`
- **AC3 fix**: empty ready-set + zero children emits typed `needsDecomposition` instead of silent `[]`.
- **10 unit tests** covering all 4 branches with mocked engines (no DB/filesystem).
- **ONE LAFS envelope per call** (AC2).

## Test plan

- [ ] `pnpm run typecheck` passes
- [ ] `pnpm biome check .` passes
- [ ] `node build.mjs` succeeds end-to-end
- [ ] `cleo go --help` shows saga/headless flags
- [ ] All 10 tests in `src/go/__tests__/driver.test.ts` pass
- [ ] No CI gate regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)