### PR TITLE
refactor(T11256): migrate gc daemon -> runtime daemon subsystem (R5)

### DIFF
--- a/packages/core/src/gc/__tests__/gc-subsystem.test.ts
+++ b/packages/core/src/gc/__tests__/gc-subsystem.test.ts
@@ -1,0 +1,261 @@
+/**
+ * GC Subsystem Tests (T11505 — R5-T3)
+ *
+ * Covers:
+ * - createGcSubsystem: returns a valid frozen Subsystem<GcSubsystemContext>
+ * - start(): registers daemon PID, runs crash recovery when pendingPrune is
+ *   non-empty, runs missed-run recovery when elapsed > 24h, schedules cron
+ * - healthProbe(): reports 'stopped' before start, 'running' after start
+ * - shutdown(): destroys the cron task so the process can exit cleanly
+ * - Full SubsystemRegistry integration: start → healthProbe → shutdown
+ *
+ * Uses real temp directories (mkdtemp). Mocks node-cron and runGC so tests
+ * do not actually perform GC or wait for cron ticks.
+ *
+ * @task T11505
+ * @epic T11256
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock node-cron so tests do not schedule real OS timers
+vi.mock('node-cron', () => {
+  const destroy = vi.fn();
+  const schedule = vi.fn().mockReturnValue({ destroy });
+  return { default: { schedule }, __destroy: destroy };
+});
+
+// Mock runGC so tests do not touch the real filesystem or disk-space
+vi.mock('../runner.js', () => ({
+  runGC: vi.fn().mockResolvedValue(undefined),
+}));
+
+import cron from 'node-cron';
+import { createGcSubsystem } from '../gc-subsystem.js';
+import { runGC } from '../runner.js';
+import { patchGCState, readGCState } from '../state.js';
+
+const mockSchedule = vi.mocked(cron.schedule);
+const mockRunGC = vi.mocked(runGC);
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Create a fresh temp directory with a .cleo/ layout for one test. */
+async function makeTmpCleoDir(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'cleo-gc-subsystem-test-'));
+  const cleoDir = join(root, '.cleo');
+  await mkdir(cleoDir, { recursive: true });
+  return cleoDir;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createGcSubsystem', () => {
+  let cleoDir: string;
+
+  beforeEach(async () => {
+    cleoDir = await makeTmpCleoDir();
+    vi.clearAllMocks();
+    // Default: cron.schedule returns a fresh destroy mock each test
+    const destroy = vi.fn();
+    mockSchedule.mockReturnValue({ destroy } as ReturnType<typeof cron.schedule>);
+  });
+
+  afterEach(async () => {
+    const root = join(cleoDir, '..');
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('returns a frozen subsystem named "gc"', () => {
+    const sub = createGcSubsystem(cleoDir);
+    expect(sub.name).toBe('gc');
+    expect(Object.isFrozen(sub)).toBe(true);
+    expect(typeof sub.start).toBe('function');
+    expect(typeof sub.healthProbe).toBe('function');
+    expect(typeof sub.shutdown).toBe('function');
+  });
+
+  it('healthProbe() returns stopped state before start()', () => {
+    const sub = createGcSubsystem(cleoDir);
+    const health = sub.healthProbe();
+    expect(health.child_id).toBe('gc');
+    expect(health.state).toBe('stopped');
+    expect(health.pid).toBe(0);
+  });
+
+  it('start() registers daemon PID in gc-state.json', async () => {
+    const sub = createGcSubsystem(cleoDir);
+    const ctx = await sub.start();
+    expect(ctx.pid).toBe(process.pid);
+    expect(ctx.startedAt).toBeTruthy();
+
+    const state = await readGCState(join(cleoDir, 'gc-state.json'));
+    expect(state.daemonPid).toBe(process.pid);
+  });
+
+  it('start() schedules the cron job', async () => {
+    const sub = createGcSubsystem(cleoDir);
+    await sub.start();
+    expect(mockSchedule).toHaveBeenCalledOnce();
+    const [expr, , opts] = mockSchedule.mock.calls[0]!;
+    expect(expr).toBe('0 3 * * *');
+    expect((opts as { timezone: string }).timezone).toBe('UTC');
+    expect((opts as { noOverlap: boolean }).noOverlap).toBe(true);
+  });
+
+  it('start() runs missed-run recovery when no lastRunAt is recorded', async () => {
+    // Default state has lastRunAt=null → elapsed is Infinity → recovery runs
+    const sub = createGcSubsystem(cleoDir);
+    await sub.start();
+    // At least one runGC call for missed-run recovery
+    expect(mockRunGC).toHaveBeenCalledWith({ cleoDir });
+  });
+
+  it('start() runs crash recovery when pendingPrune is non-empty', async () => {
+    // Seed a pending prune in state
+    await patchGCState(join(cleoDir, 'gc-state.json'), {
+      pendingPrune: ['blob-a', 'blob-b'],
+      // Set lastRunAt to now so missed-run recovery does NOT fire (avoids
+      // an extra runGC call that would make counting ambiguous)
+      lastRunAt: new Date().toISOString(),
+    });
+
+    const sub = createGcSubsystem(cleoDir);
+    await sub.start();
+    // Crash-recovery fires with resumeFrom
+    expect(mockRunGC).toHaveBeenCalledWith({ cleoDir, resumeFrom: ['blob-a', 'blob-b'] });
+  });
+
+  it('start() does NOT run missed-run recovery when last run was recent', async () => {
+    // Set lastRunAt to now — elapsed ≈ 0ms → no missed-run recovery
+    await patchGCState(join(cleoDir, 'gc-state.json'), {
+      lastRunAt: new Date().toISOString(),
+    });
+
+    const sub = createGcSubsystem(cleoDir);
+    await sub.start();
+    // No runGC call for missed-run recovery; crash recovery also skipped
+    // (pendingPrune defaults to null)
+    expect(mockRunGC).not.toHaveBeenCalled();
+  });
+
+  it('healthProbe() returns running state after start()', async () => {
+    const sub = createGcSubsystem(cleoDir);
+    await sub.start();
+    const health = sub.healthProbe();
+    expect(health.child_id).toBe('gc');
+    expect(health.state).toBe('running');
+    expect(health.pid).toBe(process.pid);
+  });
+
+  it('shutdown() destroys the cron task', async () => {
+    const destroy = vi.fn();
+    mockSchedule.mockReturnValue({ destroy } as ReturnType<typeof cron.schedule>);
+
+    const sub = createGcSubsystem(cleoDir);
+    const ctx = await sub.start();
+    sub.shutdown(ctx);
+
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it('healthProbe() returns stopped after shutdown()', async () => {
+    const sub = createGcSubsystem(cleoDir);
+    const ctx = await sub.start();
+    sub.shutdown(ctx);
+    const health = sub.healthProbe();
+    expect(health.state).toBe('stopped');
+  });
+
+  it('start() is crash-recovery non-fatal when runGC rejects for pendingPrune', async () => {
+    await patchGCState(join(cleoDir, 'gc-state.json'), {
+      pendingPrune: ['bad-blob'],
+      lastRunAt: new Date().toISOString(),
+    });
+    mockRunGC.mockRejectedValueOnce(new Error('crash recovery fail'));
+
+    const sub = createGcSubsystem(cleoDir);
+    // Should not throw — crash recovery failure is non-fatal
+    await expect(sub.start()).resolves.toBeDefined();
+  });
+
+  it('start() is missed-run recovery non-fatal when runGC rejects', async () => {
+    // lastRunAt = null → missed-run recovery fires; runGC will reject
+    mockRunGC.mockRejectedValueOnce(new Error('missed-run fail'));
+
+    const sub = createGcSubsystem(cleoDir);
+    // Should not throw — missed-run failure is non-fatal
+    await expect(sub.start()).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SubsystemRegistry integration (uses SubsystemRegistry duck-type manually to
+// avoid a @cleocode/runtime import in @cleocode/core tests)
+// ---------------------------------------------------------------------------
+
+describe('createGcSubsystem — manual lifecycle integration', () => {
+  let cleoDir: string;
+
+  beforeEach(async () => {
+    cleoDir = await makeTmpCleoDir();
+    vi.clearAllMocks();
+    const destroy = vi.fn();
+    mockSchedule.mockReturnValue({ destroy } as ReturnType<typeof cron.schedule>);
+    // Set lastRunAt to now so missed-run recovery does not fire by default
+    await patchGCState(join(cleoDir, 'gc-state.json'), {
+      lastRunAt: new Date().toISOString(),
+    });
+  });
+
+  afterEach(async () => {
+    const root = join(cleoDir, '..');
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('full start → healthProbe → shutdown lifecycle without loss', async () => {
+    const sub = createGcSubsystem(cleoDir);
+
+    // Pre-start: stopped
+    expect(sub.healthProbe().state).toBe('stopped');
+
+    // Start
+    const ctx = await sub.start();
+    expect(ctx.pid).toBe(process.pid);
+
+    // Health: running
+    const health = sub.healthProbe();
+    expect(health.state).toBe('running');
+    expect(health.pid).toBe(process.pid);
+    expect(health.child_id).toBe('gc');
+
+    // Shutdown
+    sub.shutdown(ctx);
+    expect(sub.healthProbe().state).toBe('stopped');
+  });
+
+  it('GcSubsystemContext.runs increments on crash + missed-run recovery', async () => {
+    // Seed pending prune AND stale lastRunAt so both recovery paths fire
+    await patchGCState(join(cleoDir, 'gc-state.json'), {
+      pendingPrune: ['x', 'y'],
+      lastRunAt: null,
+    });
+
+    const sub = createGcSubsystem(cleoDir);
+    const ctx = await sub.start();
+    // Both crash recovery AND missed-run recovery ran → runs >= 2
+    expect(ctx.runs).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/core/src/gc/daemon.ts
+++ b/packages/core/src/gc/daemon.ts
@@ -8,13 +8,21 @@
  * - Crash recovery via `.cleo/gc-state.json` startup-check
  * - node-cron v4 for scheduling (zero runtime deps, cross-platform)
  *
- * Startup algorithm (systemd `Persistent=true` semantics in pure Node.js):
- * 1. Read gc-state.json
- * 2. If pendingPrune non-empty → resume deletion (crash recovery)
- * 3. If lastRunAt null OR elapsed > 24h → run GC immediately (missed-run recovery)
- * 4. Schedule future runs via node-cron (daily at 03:00 UTC)
- * 5. Write daemonPid to state
+ * R5 migration (T11256)
+ * ----------------------
+ * The standalone cron loop that previously lived inside `bootstrapDaemon` has
+ * been migrated to the `@cleocode/runtime` subsystem framework
+ * (`gc-subsystem.ts`). `bootstrapDaemon` now delegates to
+ * `createGcSubsystem(cleoDir).start()` so the same startup algorithm (crash
+ * recovery → missed-run recovery → cron schedule) is expressed once, in the
+ * `Subsystem<GcSubsystemContext>` shape, and the standalone entry-point
+ * (`daemon-entry.ts`) drives it through the uniform lifecycle.
  *
+ * The spawn helpers (`spawnGCDaemon`, `stopGCDaemon`, `getGCDaemonStatus`) are
+ * preserved unchanged — they are the parent-process-side interface and are
+ * unaffected by the internal lifecycle migration.
+ *
+ * @see packages/core/src/gc/gc-subsystem.ts — subsystem adapter (R5-T1)
  * @see ADR-047 — Autonomous GC and Disk Safety
  * @see T751 §2.2 for sidecar daemon pattern rationale
  * @task T731
@@ -27,19 +35,8 @@ import { createWriteStream } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import cron from 'node-cron';
-import { runGC } from './runner.js';
+import { createGcSubsystem } from './gc-subsystem.js';
 import { patchGCState, readGCState } from './state.js';
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** Cron expression: daily at 03:00 UTC. */
-const GC_CRON_EXPR = '0 3 * * *';
-
-/** Interval for missed-run recovery check (24 hours in ms). */
-const GC_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Daemon Bootstrap (runs when this module is executed as a standalone script)
@@ -48,69 +45,19 @@ const GC_INTERVAL_MS = 24 * 60 * 60 * 1000;
 /**
  * Bootstrap the GC daemon process.
  *
- * Performs crash recovery, missed-run recovery, and schedules future GC runs.
- * This function runs in the long-lived daemon process.
+ * Delegates to `createGcSubsystem(cleoDir).start()` which performs crash
+ * recovery, missed-run recovery, and schedules future GC runs — the
+ * standalone cron loop no longer lives here (R5 migration, T11256).
  *
  * @param cleoDir - Absolute path to the `.cleo/` directory
  */
 export async function bootstrapDaemon(cleoDir: string): Promise<void> {
-  const statePath = join(cleoDir, 'gc-state.json');
-
-  // Register daemon PID in state file
-  await patchGCState(statePath, {
-    daemonPid: process.pid,
-    daemonStartedAt: new Date().toISOString(),
-  });
-
-  const state = await readGCState(statePath);
-
-  // Step 1: Crash recovery — resume pending prune from prior run
-  if (state.pendingPrune && state.pendingPrune.length > 0) {
-    try {
-      await runGC({ cleoDir, resumeFrom: state.pendingPrune });
-    } catch {
-      // Crash recovery failure is non-fatal; continue with scheduled runs
-    }
-  }
-
-  // Step 2: Missed-run recovery — if last run was > 24h ago, run immediately
-  const lastRunTs = state.lastRunAt ? new Date(state.lastRunAt).getTime() : 0;
-  const elapsed = Date.now() - lastRunTs;
-  if (elapsed > GC_INTERVAL_MS) {
-    try {
-      await runGC({ cleoDir });
-    } catch {
-      // Immediate GC failure is non-fatal; cron will retry next cycle
-    }
-  }
-
-  // Step 3: Schedule future runs via node-cron
-  // noOverlap: true prevents double-runs if a previous run exceeds 24h
-  cron.schedule(
-    GC_CRON_EXPR,
-    async () => {
-      try {
-        await runGC({ cleoDir });
-      } catch {
-        // Log failures via stderr (already redirected to gc.log by spawn)
-        const state2 = await readGCState(statePath);
-        await patchGCState(statePath, {
-          consecutiveFailures: state2.consecutiveFailures + 1,
-          lastRunResult: 'failed',
-          escalationNeeded: state2.consecutiveFailures + 1 >= 3,
-          escalationReason:
-            state2.consecutiveFailures + 1 >= 3
-              ? `GC daemon: ${state2.consecutiveFailures + 1} consecutive failures. Check logs.`
-              : state2.escalationReason,
-        });
-      }
-    },
-    {
-      timezone: 'UTC',
-      noOverlap: true,
-      name: 'cleo-gc',
-    },
-  );
+  const subsystem = createGcSubsystem(cleoDir);
+  // start() handles crash recovery, missed-run recovery, and cron scheduling.
+  // The returned context (cron task handle) keeps the cron alive for the
+  // lifetime of this process — we intentionally do not call shutdown() so the
+  // daemon continues running until the process receives SIGTERM.
+  await subsystem.start();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/gc/gc-subsystem.ts
+++ b/packages/core/src/gc/gc-subsystem.ts
@@ -1,0 +1,229 @@
+/**
+ * GC daemon expressed as a supervised daemon subsystem.
+ *
+ * Wraps the GC bootstrap logic (`bootstrapDaemon`, crash recovery, missed-run
+ * recovery, and the node-cron schedule) in the uniform
+ * `start → healthProbe → shutdown` lifecycle from `@cleocode/contracts/daemon`
+ * so the `@cleocode/runtime` `SubsystemRegistry` can drive it identically to
+ * every other long-running concern (Studio supervision, the web server, …).
+ *
+ * Design constraints
+ * ------------------
+ * `@cleocode/core` CANNOT depend on `@cleocode/runtime` (runtime already
+ * depends on core). To remain dependency-cycle free this module imports only
+ * the pure type contracts from `@cleocode/contracts` and returns a plain
+ * frozen object that satisfies the `Subsystem<GcSubsystemContext>` interface
+ * without calling `defineSubsystem()` (a runtime-layer factory). A caller that
+ * holds a `SubsystemRegistry` (from `@cleocode/runtime/daemon`) simply calls
+ * `registry.register(createGcSubsystem(cleoDir))` — the frozen shape is
+ * identical to what `defineSubsystem` returns and the registry types accept it.
+ *
+ * Thread-through context
+ * ----------------------
+ * `start()` returns a {@link GcSubsystemContext} that is threaded into
+ * `shutdown()` by the registry (same pattern as `GatewaySubsystemContext`
+ * in `@cleocode/runtime/gateway`). This lets `shutdown()` cancel the exact
+ * cron task that `start()` scheduled without requiring module-level mutable
+ * state.
+ *
+ * @see packages/core/src/gc/daemon.ts — standalone bootstrap / spawn helpers
+ * @see packages/runtime/src/daemon/define-subsystem.ts — `defineSubsystem` factory
+ * @see packages/runtime/src/gateway/daemon-subsystem.ts — reference implementation
+ *
+ * @packageDocumentation
+ * @module @cleocode/core/gc
+ *
+ * @task T11503 (R5-T1)
+ * @task T11504 (R5-T2)
+ * @epic T11256
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ */
+
+import { join } from 'node:path';
+import type { Subsystem, SubsystemHealth, SubsystemState } from '@cleocode/contracts';
+import cron from 'node-cron';
+import { runGC } from './runner.js';
+import { patchGCState, readGCState } from './state.js';
+
+// ---------------------------------------------------------------------------
+// Constants (mirrors daemon.ts — single authority is retained in daemon.ts)
+// ---------------------------------------------------------------------------
+
+/** Cron expression: daily at 03:00 UTC. Kept in sync with daemon.ts. */
+const GC_CRON_EXPR = '0 3 * * *';
+
+/** Interval for missed-run recovery check (24 hours in ms). */
+const GC_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+/**
+ * The live context `start()` returns and the registry threads into
+ * `shutdown()`. Carries the scheduled cron task so `shutdown()` can destroy
+ * exactly the task that `start()` created.
+ */
+export interface GcSubsystemContext {
+  /** The OS pid of this daemon process (set at subsystem start). */
+  readonly pid: number;
+  /** The ISO-8601 timestamp when this subsystem started. */
+  readonly startedAt: string;
+  /**
+   * The scheduled cron task. `ScheduledTask` is the node-cron return value.
+   * Typed as the minimal destroy surface so callers do not need to import
+   * node-cron types.
+   */
+  readonly cronTask: { destroy: () => void };
+  /** Count of GC runs performed since subsystem start. */
+  runs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a GC cron-daemon expressed as a uniform daemon subsystem.
+ *
+ * The returned object is a frozen `Subsystem<GcSubsystemContext>` that any
+ * `SubsystemRegistry` (from `@cleocode/runtime/daemon`) can `register()`.
+ *
+ * Lifecycle
+ * ---------
+ * - `start(cleoDir)` — reads gc-state.json, performs crash recovery
+ *   (resumes `pendingPrune` if non-empty), performs missed-run recovery (runs
+ *   GC immediately if elapsed > 24 h), then schedules the daily cron job.
+ *   Returns a {@link GcSubsystemContext} for health-probe and shutdown.
+ * - `healthProbe()` — reports a single {@link SubsystemHealth} row keyed on
+ *   `child_id: 'gc'`; `running` while the cron task is active, with a `detail`
+ *   summarising run count and last-run timestamp.
+ * - `shutdown(context)` — destroys the cron task so the daemon process can
+ *   exit cleanly.
+ *
+ * @param cleoDir - Absolute path to the `.cleo/` directory for this project.
+ * @returns A frozen `Subsystem<GcSubsystemContext>`.
+ *
+ * @example
+ * ```ts
+ * // In the daemon process:
+ * import { SubsystemRegistry } from '@cleocode/runtime/daemon';
+ * import { createGcSubsystem } from '@cleocode/core/gc/gc-subsystem.js';
+ *
+ * const registry = new SubsystemRegistry();
+ * registry.register(createGcSubsystem('/home/user/.local/share/cleo/project/abc/.cleo'));
+ * await registry.startAll();
+ * ```
+ */
+export function createGcSubsystem(cleoDir: string): Subsystem<GcSubsystemContext> {
+  const statePath = join(cleoDir, 'gc-state.json');
+
+  // Closure-held live context so `healthProbe()` (which receives no arguments
+  // per the Subsystem contract) can read the current state.
+  let live: GcSubsystemContext | undefined;
+
+  const subsystem: Subsystem<GcSubsystemContext> = {
+    name: 'gc',
+
+    async start(): Promise<GcSubsystemContext> {
+      // Register daemon PID in state file
+      await patchGCState(statePath, {
+        daemonPid: process.pid,
+        daemonStartedAt: new Date().toISOString(),
+      });
+
+      const state = await readGCState(statePath);
+      let runs = 0;
+
+      // Step 1: Crash recovery — resume pending prune from prior run
+      if (state.pendingPrune && state.pendingPrune.length > 0) {
+        try {
+          await runGC({ cleoDir, resumeFrom: state.pendingPrune });
+          runs += 1;
+        } catch {
+          // Crash-recovery failure is non-fatal; continue with scheduled runs
+        }
+      }
+
+      // Step 2: Missed-run recovery — if last run was > 24 h ago, run immediately
+      const lastRunTs = state.lastRunAt ? new Date(state.lastRunAt).getTime() : 0;
+      const elapsed = Date.now() - lastRunTs;
+      if (elapsed > GC_INTERVAL_MS) {
+        try {
+          await runGC({ cleoDir });
+          runs += 1;
+        } catch {
+          // Immediate GC failure is non-fatal; cron will retry next cycle
+        }
+      }
+
+      // Step 3: Schedule future runs via node-cron
+      // noOverlap: true prevents double-runs if a previous run exceeds 24 h
+      const cronTask = cron.schedule(
+        GC_CRON_EXPR,
+        async () => {
+          try {
+            await runGC({ cleoDir });
+            if (live !== undefined) {
+              live.runs += 1;
+            }
+          } catch {
+            // Log failures via stderr (redirected to gc.log by spawn)
+            const currentState = await readGCState(statePath);
+            await patchGCState(statePath, {
+              consecutiveFailures: currentState.consecutiveFailures + 1,
+              lastRunResult: 'failed',
+              escalationNeeded: currentState.consecutiveFailures + 1 >= 3,
+              escalationReason:
+                currentState.consecutiveFailures + 1 >= 3
+                  ? `GC daemon: ${currentState.consecutiveFailures + 1} consecutive failures. Check logs.`
+                  : currentState.escalationReason,
+            });
+          }
+        },
+        {
+          timezone: 'UTC',
+          noOverlap: true,
+          name: 'cleo-gc',
+        },
+      );
+
+      const context: GcSubsystemContext = {
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        cronTask,
+        runs,
+      };
+      live = context;
+      return context;
+    },
+
+    healthProbe(): SubsystemHealth {
+      if (live === undefined) {
+        const stopped: SubsystemState = 'stopped';
+        return {
+          child_id: 'gc',
+          pid: 0,
+          state: stopped,
+          restart_count: 0,
+          detail: 'gc subsystem not started',
+        };
+      }
+      const running: SubsystemState = 'running';
+      return {
+        child_id: 'gc',
+        pid: live.pid,
+        state: running,
+        restart_count: live.runs,
+        detail: `runs=${live.runs} startedAt=${live.startedAt}`,
+      };
+    },
+
+    shutdown(context: GcSubsystemContext): void {
+      context.cronTask.destroy();
+      live = undefined;
+    },
+  };
+
+  return Object.freeze(subsystem);
+}

--- a/packages/core/src/gc/index.ts
+++ b/packages/core/src/gc/index.ts
@@ -15,6 +15,7 @@ export {
   auditOrphanWorktrees,
 } from '../validation/doctor/checks.js';
 export * from './daemon.js';
+export * from './gc-subsystem.js';
 export * from './runner.js';
 export * from './state.js';
 export * from './transcript.js';


### PR DESCRIPTION
## Summary

- Introduces `packages/core/src/gc/gc-subsystem.ts` — a frozen `Subsystem<GcSubsystemContext>` adapter that wraps the full GC bootstrap algorithm (crash recovery → missed-run recovery → daily 03:00 UTC cron) so the `SubsystemRegistry` from `@cleocode/runtime/daemon` can drive it uniformly
- Refactors `gc/daemon.ts` — `bootstrapDaemon()` now delegates to `createGcSubsystem(cleoDir).start()`; the standalone cron scheduling loop (~77 LOC) is deleted (AC1)
- Exports `createGcSubsystem` + `GcSubsystemContext` from `@cleocode/core/gc` index
- Adds 14-test suite (`gc-subsystem.test.ts`) covering all lifecycle paths: start/healthProbe/shutdown, crash recovery, missed-run recovery, non-fatal failures

**Package placement note**: The adapter lives in `@cleocode/core` (not `@cleocode/runtime`) because runtime already depends on core — placing it in runtime would create a circular dependency. It only imports `@cleocode/contracts` types (`Subsystem`, `SubsystemHealth`, `SubsystemState`), matching the precedent set by R4/T11255 (sentient-subsystem in `@cleocode/runtime` consumes core; gc-subsystem in core consumes only contracts).

Spawn helpers (`spawnGCDaemon` / `stopGCDaemon` / `getGCDaemonStatus`) are preserved unchanged (AC3 from T11504). Daily 03:00 UTC schedule and gc-state.json crash-recovery are preserved (AC3/AC4 from T11256).

## Test plan

- [x] `pnpm biome check --write .` — no errors
- [x] `pnpm run typecheck` — zero errors (pre- and post-merge)
- [x] `node build.mjs` — build complete
- [x] `node packages/cleo/dist/cli/index.js version` — CLI functional
- [x] `npx vitest run packages/core/src/gc/__tests__/gc-subsystem.test.ts` — 14/14 passed
- [x] `npx vitest run --project @cleocode/runtime` — 113/113 passed
- [ ] Full CI (watching)

Closes T11256 (R5), T11503 (R5-T1), T11504 (R5-T2), T11505 (R5-T3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)