### PR TITLE
feat(T11495): classifyReadiness predicate (E3 grill-gate)

### DIFF
--- a/packages/core/src/orchestration/__tests__/classify-readiness.test.ts
+++ b/packages/core/src/orchestration/__tests__/classify-readiness.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Tests for the E3-GRILL-GATE classifyReadiness predicate — T11495.
+ *
+ * Verifies:
+ *  - MISSING_AC trigger: fires when no acceptance criteria present.
+ *  - OWNER_DECISION_REQUIRED trigger: fires on label or blockedBy text.
+ *  - IVTR_MAX_RETRIES trigger: fires when any phase hits MAX_LOOP_BACKS_PER_PHASE.
+ *  - RELEASE_GATE trigger: fires on release/publish stage without hitlApproved.
+ *  - AMBIGUOUS_SCOPE trigger: fires on bare epic with no children and no spec blob.
+ *  - Auto-proceed: all triggers clear → verdict 'proceed'.
+ *  - Auto-proceed: impl+ epic with non-empty ready frontier → verdict 'proceed'.
+ *  - Multi-trigger: multiple grill triggers fire simultaneously.
+ *
+ * @task T11495 E3-GRILL-GATE
+ * @epic T11492 SG-AUTOPILOT
+ */
+
+import type { Task } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import type { IvtrState } from '../../lifecycle/ivtr-loop.js';
+import { MAX_LOOP_BACKS_PER_PHASE } from '../../lifecycle/ivtr-loop.js';
+import type { ReadinessSignals } from '../classify-readiness.js';
+import { classifyReadiness } from '../classify-readiness.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal valid task with acceptance criteria — used as the "all-clear" base. */
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'T9000',
+    title: 'Default test task',
+    description: 'A clear, scoped test task.',
+    status: 'pending',
+    priority: 'medium',
+    type: 'task',
+    size: 'small',
+    createdAt: '2026-05-31T00:00:00Z',
+    acceptance: ['Implement the feature per spec.'],
+    ...overrides,
+  };
+}
+
+/** Build an IvtrState with specific loop-back counts per phase. */
+function makeIvtrState(loopBackCounts: Partial<Record<string, number>> = {}): IvtrState {
+  return {
+    taskId: 'T9000',
+    schemaVersion: 2,
+    currentPhase: 'implement',
+    phaseHistory: [],
+    startedAt: '2026-05-31T00:00:00Z',
+    loopBackCount: {
+      implement: loopBackCounts['implement'] ?? 0,
+      validate: loopBackCounts['validate'] ?? 0,
+      audit: loopBackCounts['audit'] ?? 0,
+      test: loopBackCounts['test'] ?? 0,
+      released: loopBackCounts['released'] ?? 0,
+    },
+  };
+}
+
+/** Build a child task for epic frontier tests. */
+function makeChild(id: string, status: Task['status'] = 'pending', depends: string[] = []): Task {
+  return makeTask({ id, status, depends, type: 'task', acceptance: ['done.'] });
+}
+
+// ---------------------------------------------------------------------------
+// 1. MISSING_AC trigger
+// ---------------------------------------------------------------------------
+
+describe('classifyReadiness — MISSING_AC', () => {
+  it('grills when acceptance is absent', () => {
+    const task = makeTask({ acceptance: undefined });
+    const result = classifyReadiness(task);
+    expect(result.verdict).toBe('grill');
+    expect(result.triggers).toContain('MISSING_AC');
+  });
+
+  it('grills when acceptance is empty array', () => {
+    const task = makeTask({ acceptance: [] });
+    const result = classifyReadiness(task);
+    expect(result.verdict).toBe('grill');
+    expect(result.triggers).toContain('MISSING_AC');
+  });
+
+  it('grills when all acceptance entries are blank strings', () => {
+    const task = makeTask({ acceptance: ['  ', ''] });
+    const result = classifyReadiness(task);
+    expect(result.verdict).toBe('grill');
+    expect(result.triggers).toContain('MISSING_AC');
+  });
+
+  it('proceeds when at least one non-empty acceptance criterion exists', () => {
+    const task = makeTask({ acceptance: ['AC1: implement the feature.'] });
+    const result = classifyReadiness(task);
+    expect(result.verdict).toBe('proceed');
+    expect(result.triggers).not.toContain('MISSING_AC');
+  });
+
+  it('proceeds when acceptance contains a structured gate object', () => {
+    const gate = { kind: 'test', command: 'pnpm test', expect: 'pass', description: 'Tests pass.' };
+    const task = makeTask({ acceptance: [gate as unknown as string] });
+    const result = classifyReadiness(task);
+    expect(result.triggers).not.toContain('MISSING_AC');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. OWNER_DECISION_REQUIRED trigger
+// ---------------------------------------------------------------------------
+
+describe('classifyReadiness — OWNER_DECISION_REQUIRED', () => {
+  it('grills when label "owner-decision" is present (exact match)', () => {
+    const task = makeTask({ labels: ['owner-decision'] });
+    const result = classifyReadiness(task);
+    expect(result.verdict).toBe('grill');
+    expect(result.triggers).toContain('OWNER_DECISION_REQUIRED');
+  });
+
+  it('grills when label "owner-decision" is mixed-case', () => {
+    const task = makeTask({ labels: ['Owner-Decision'] });
+    const result = classifyReadiness(task);
+    expect(result.triggers).toContain('OWNER_DECISION_REQUIRED');
+  });
+
+  it('grills when blockedBy mentions "owner"', () => {
+    const task = makeTask({ blockedBy: 'Waiting on owner to pick approach.' });
+    const result = classifyReadiness(task);
+    expect(result.triggers).toContain('OWNER_DECISION_REQUIRED');
+  });
+
+  it('grills when blockedBy mentions "decision"', () => {
+    const task = makeTask({ blockedBy: 'Pending architectural decision by Keaton.' });
+    const result = classifyReadiness(task);
+    expect(result.triggers).toContain('OWNER_DECISION_REQUIRED');
+  });
+
+  it('proceeds when labels do not contain owner-decision and blockedBy is unrelated', () => {
+    const task = makeTask({ labels: ['feature', 'backend'], blockedBy: 'CI fix needed.' });
+    const result = classifyReadiness(task);
+    expect(result.triggers).not.toContain('OWNER_DECISION_REQUIRED');
+  });
+
+  it('proceeds when no labels and blockedBy is absent', () => {
+    const task = makeTask({ labels: undefined, blockedBy: undefined });
+    const result = classifyReadiness(task);
+    expect(result.triggers).not.toContain('OWNER_DECISION_REQUIRED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. IVTR_MAX_RETRIES trigger
+// ---------------------------------------------------------------------------
+
+describe('classifyReadiness — IVTR_MAX_RETRIES', () => {
+  it('grills when any phase hits MAX_LOOP_BACKS_PER_PHASE', () => {
+    const ivtrState = makeIvtrState({ validate: MAX_LOOP_BACKS_PER_PHASE });
+    const result = classifyReadiness(makeTask(), { ivtrState });
+    expect(result.verdict).toBe('grill');
+    expect(result.triggers).toContain('IVTR_MAX_RETRIES');
+  });
+
+  it('grills when IMPLEMENT phase hits max retries', () => {
+    const ivtrState = makeIvtrState({ implement: MAX_LOOP_BACKS_PER_PHASE });
+    const result = classifyReadiness(makeTask(), { ivtrState });
+    expect(result.triggers).toContain('IVTR_MAX_RETRIES');
+  });
+
+  it('grills when TEST phase hits max retries', () => {
+    const ivtrState = makeIvtrState({ test: MAX_LOOP_BACKS_PER_PHASE });
+    const result = classifyReadiness(makeTask(), { ivtrState });
+    expect(result.triggers).toContain('IVTR_MAX_RETRIES');
+  });
+
+  it('proceeds when all phases are below max retries', () => {
+    const ivtrState = makeIvtrState({ validate: MAX_LOOP_BACKS_PER_PHASE - 1 });
+    const result = classifyReadiness(makeTask(), { ivtrState });
+    expect(result.triggers).not.toContain('IVTR_MAX_RETRIES');
+  });
+
+  it('proceeds when ivtrState is null (check skipped)', () => {
+    const result = classifyReadiness(makeTask(), { ivtrState: null });
+    expect(result.triggers).not.toContain('IVTR_MAX_RETRIES');
+  });
+
+  it('proceeds when ivtrState is absent (check skipped)', () => {
+    const result = classifyReadiness(makeTask(), {});
+    expect(result.triggers).not.toContain('IVTR_MAX_RETRIES');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. RELEASE_GATE trigger
+// ---------------------------------------------------------------------------
+
+describe('classifyReadiness — RELEASE_GATE', () => {
+  it('grills when pipelineStage is "release" and hitlApproved is false', () => {
+    const task = makeTask({ pipelineStage: 'release' });
+    const result = classifyReadiness(task, { hitlApproved: false });
+    expect(result.verdict).toBe('grill');
+    expect(result.triggers).toContain('RELEASE_GATE');
+  });
+
+  it('grills when pipelineStage is "publish" and hitlApproved is false', () => {
+    const task = makeTask({ pipelineStage: 'publish' });
+    const result = classifyReadiness(task, { hitlApproved: false });
+    expect(result.triggers).toContain('RELEASE_GATE');
+  });
+
+  it('proceeds when pipelineStage is "release" but hitlApproved is true', () => {
+    const task = makeTask({ pipelineStage: 'release' });
+    const result = classifyReadiness(task, { hitlApproved: true });
+    expect(result.triggers).not.toContain('RELEASE_GATE');
+  });
+
+  it('proceeds when pipelineStage is "implementation" (not a release gate)', () => {
+    const task = makeTask({ pipelineStage: 'implementation' });
+    const result = classifyReadiness(task);
+    expect(result.triggers).not.toContain('RELEASE_GATE');
+  });
+
+  it('proceeds when pipelineStage is absent', () => {
+    const task = makeTask({ pipelineStage: undefined });
+    const result = classifyReadiness(task);
+    expect(result.triggers).not.toContain('RELEASE_GATE');
+  });
+
+  it('defaults hitlApproved to false when signals are absent', () => {
+    const task = makeTask({ pipelineStage: 'release' });
+    const result = classifyReadiness(task);
+    expect(result.triggers).toContain('RELEASE_GATE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. AMBIGUOUS_SCOPE trigger
+// ---------------------------------------------------------------------------
+
+describe('classifyReadiness — AMBIGUOUS_SCOPE', () => {
+  it('grills on bare epic with no children and no blobs', () => {
+    const epic = makeTask({ type: 'epic', pipelineStage: 'research' });
+    const result = classifyReadiness(epic, { children: [], blobNames: [] });
+    expect(result.verdict).toBe('grill');
+    expect(result.triggers).toContain('AMBIGUOUS_SCOPE');
+  });
+
+  it('grills on epic with no children when signals are absent', () => {
+    const epic = makeTask({ type: 'epic', pipelineStage: 'research' });
+    const result = classifyReadiness(epic);
+    expect(result.triggers).toContain('AMBIGUOUS_SCOPE');
+  });
+
+  it('proceeds when epic has children', () => {
+    const epic = makeTask({ type: 'epic', pipelineStage: 'research' });
+    const children = [makeChild('T9001')];
+    const result = classifyReadiness(epic, { children });
+    expect(result.triggers).not.toContain('AMBIGUOUS_SCOPE');
+  });
+
+  it('proceeds when epic has a spec blob attachment', () => {
+    const epic = makeTask({ type: 'epic', pipelineStage: 'research' });
+    const result = classifyReadiness(epic, { children: [], blobNames: ['my-spec.md'] });
+    expect(result.triggers).not.toContain('AMBIGUOUS_SCOPE');
+  });
+
+  it('proceeds when epic has a research blob attachment', () => {
+    const epic = makeTask({ type: 'epic', pipelineStage: 'research' });
+    const result = classifyReadiness(epic, { children: [], blobNames: ['research-notes.md'] });
+    expect(result.triggers).not.toContain('AMBIGUOUS_SCOPE');
+  });
+
+  it('proceeds when epic has an adr blob attachment', () => {
+    const epic = makeTask({ type: 'epic', pipelineStage: 'research' });
+    const result = classifyReadiness(epic, { children: [], blobNames: ['adr-001.md'] });
+    expect(result.triggers).not.toContain('AMBIGUOUS_SCOPE');
+  });
+
+  it('proceeds when epic has a design blob attachment', () => {
+    const epic = makeTask({ type: 'epic', pipelineStage: 'research' });
+    const result = classifyReadiness(epic, { children: [], blobNames: ['design-overview.pdf'] });
+    expect(result.triggers).not.toContain('AMBIGUOUS_SCOPE');
+  });
+
+  it('proceeds on non-epic task (scope check skipped)', () => {
+    const task = makeTask({ type: 'task', pipelineStage: 'research' });
+    const result = classifyReadiness(task, { children: [], blobNames: [] });
+    expect(result.triggers).not.toContain('AMBIGUOUS_SCOPE');
+  });
+
+  it('proceeds on epic in implementation stage even with no children', () => {
+    const epic = makeTask({ type: 'epic', pipelineStage: 'implementation' });
+    const result = classifyReadiness(epic, { children: [], blobNames: [] });
+    expect(result.triggers).not.toContain('AMBIGUOUS_SCOPE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Auto-proceed — all-clear
+// ---------------------------------------------------------------------------
+
+describe('classifyReadiness — auto-proceed', () => {
+  it('proceeds when all triggers are clear (simple task)', () => {
+    const task = makeTask();
+    const result = classifyReadiness(task);
+    expect(result.verdict).toBe('proceed');
+    expect(result.triggers).toHaveLength(0);
+    expect(result.reason).toContain('cleared all readiness checks');
+  });
+
+  it('proceeds for impl+ epic with non-empty ready frontier (AC2)', () => {
+    const epic = makeTask({ id: 'T8000', type: 'epic', pipelineStage: 'implementation' });
+    const children = [
+      makeChild('T8001', 'pending', []), // ready: no deps
+      makeChild('T8002', 'done', []), // done
+    ];
+    const result = classifyReadiness(epic, { children });
+    expect(result.verdict).toBe('proceed');
+    expect(result.reason).toContain('non-empty ready frontier');
+  });
+
+  it('proceed reason mentions the task ID', () => {
+    const task = makeTask({ id: 'T7777' });
+    const result = classifyReadiness(task);
+    expect(result.reason).toContain('T7777');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Ready frontier logic
+// ---------------------------------------------------------------------------
+
+describe('classifyReadiness — ready frontier', () => {
+  it('proceeds when one child has satisfied deps (dep is done)', () => {
+    const epic = makeTask({ type: 'epic', pipelineStage: 'implementation' });
+    const children = [
+      makeChild('T9001', 'done', []),
+      makeChild('T9002', 'pending', ['T9001']), // T9001 is done → T9002 is ready
+    ];
+    const result = classifyReadiness(epic, { children });
+    expect(result.verdict).toBe('proceed');
+  });
+
+  it('grills (AMBIGUOUS_SCOPE not applicable) when all children are done and no pending', () => {
+    // No AMBIGUOUS_SCOPE since children are present; but verdict is still proceed
+    // because no grill trigger fires and epic is in implementation stage.
+    const epic = makeTask({ type: 'epic', pipelineStage: 'implementation' });
+    const children = [makeChild('T9001', 'done', [])];
+    const result = classifyReadiness(epic, { children });
+    // All triggers clear → proceed (even if frontier is empty, triggers are the gate)
+    expect(result.verdict).toBe('proceed');
+  });
+
+  it('grill reason mentions all active triggers', () => {
+    const task = makeTask({ acceptance: undefined, labels: ['owner-decision'] });
+    const result = classifyReadiness(task);
+    expect(result.verdict).toBe('grill');
+    expect(result.reason).toContain('MISSING_AC');
+    expect(result.reason).toContain('OWNER_DECISION_REQUIRED');
+    expect(result.triggers).toEqual(
+      expect.arrayContaining(['MISSING_AC', 'OWNER_DECISION_REQUIRED']),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Multi-trigger scenarios
+// ---------------------------------------------------------------------------
+
+describe('classifyReadiness — multi-trigger', () => {
+  it('reports multiple triggers simultaneously', () => {
+    const task = makeTask({
+      acceptance: undefined,
+      labels: ['owner-decision'],
+      pipelineStage: 'release',
+    });
+    const ivtrState = makeIvtrState({ validate: MAX_LOOP_BACKS_PER_PHASE });
+    const result = classifyReadiness(task, { ivtrState });
+
+    expect(result.verdict).toBe('grill');
+    expect(result.triggers).toContain('MISSING_AC');
+    expect(result.triggers).toContain('OWNER_DECISION_REQUIRED');
+    expect(result.triggers).toContain('IVTR_MAX_RETRIES');
+    expect(result.triggers).toContain('RELEASE_GATE');
+  });
+
+  it('four triggers fire for an epic at release stage (RELEASE_GATE suppresses AMBIGUOUS_SCOPE)', () => {
+    // RELEASE_GATE and AMBIGUOUS_SCOPE are mutually exclusive from pipelineStage:
+    // 'release' is in IMPLEMENTATION_STAGES so AMBIGUOUS_SCOPE is suppressed.
+    // This validates the remaining 4 can fire simultaneously.
+    const epic = makeTask({
+      type: 'epic',
+      acceptance: undefined,
+      labels: ['owner-decision'],
+      pipelineStage: 'release',
+      blockedBy: 'waiting on owner decision',
+    });
+    const ivtrState = makeIvtrState({ test: MAX_LOOP_BACKS_PER_PHASE });
+    const signals: ReadinessSignals = {
+      children: [],
+      blobNames: [],
+      ivtrState,
+      hitlApproved: false,
+    };
+    const result = classifyReadiness(epic, signals);
+    expect(result.verdict).toBe('grill');
+    expect(result.triggers).toContain('MISSING_AC');
+    expect(result.triggers).toContain('OWNER_DECISION_REQUIRED');
+    expect(result.triggers).toContain('IVTR_MAX_RETRIES');
+    expect(result.triggers).toContain('RELEASE_GATE');
+    expect(result.triggers).not.toContain('AMBIGUOUS_SCOPE'); // suppressed: release ∈ IMPLEMENTATION_STAGES
+    expect(result.triggers).toHaveLength(4);
+  });
+
+  it('AMBIGUOUS_SCOPE fires alongside MISSING_AC and OWNER_DECISION_REQUIRED for a bare pre-impl epic', () => {
+    // AMBIGUOUS_SCOPE requires pre-implementation stage — RELEASE_GATE cannot co-fire.
+    const epic = makeTask({
+      type: 'epic',
+      acceptance: undefined,
+      labels: ['owner-decision'],
+      pipelineStage: 'research',
+    });
+    const signals: ReadinessSignals = {
+      children: [],
+      blobNames: [],
+      hitlApproved: false,
+    };
+    const result = classifyReadiness(epic, signals);
+    expect(result.verdict).toBe('grill');
+    expect(result.triggers).toContain('MISSING_AC');
+    expect(result.triggers).toContain('OWNER_DECISION_REQUIRED');
+    expect(result.triggers).toContain('AMBIGUOUS_SCOPE');
+    expect(result.triggers).toHaveLength(3);
+  });
+});

--- a/packages/core/src/orchestration/classify-readiness.ts
+++ b/packages/core/src/orchestration/classify-readiness.ts
@@ -1,0 +1,500 @@
+/**
+ * Grill-Gate Predicate — E3-GRILL-GATE (T11495)
+ *
+ * Decides whether a task unit is ready to proceed autonomously (`proceed`)
+ * or needs human/orchestrator clarification before work starts (`grill`).
+ *
+ * The predicate is pure: it operates on pre-loaded task data + optional
+ * supporting signals and never opens a DB or calls the network directly.
+ * Callers (e.g. `cleo go`) supply the unit + signals; the predicate
+ * focuses solely on classification logic.
+ *
+ * ## Grill triggers (AC2)
+ * 1. Missing acceptance criteria — task has no `acceptance` entries.
+ * 2. Owner-decision required — task carries an `owner-decision` label OR
+ *    `blockedBy` contains "owner" / "decision" text.
+ * 3. IVTR max-retries exhausted — any phase in `ivtrLoopBackCount` has
+ *    reached {@link MAX_LOOP_BACKS_PER_PHASE} (requires HITL escalation).
+ * 4. Release/publish gate active — task `pipelineStage` is `'release'` and
+ *    no HITL approval token is present (reuses existing `orchestrate approve`
+ *    / `reject` / `pending` surface — no new HITL introduced).
+ * 5. Scope ambiguity — epic-type task with no children AND no attached spec
+ *    or research artifact (blob list) — cannot be safely autonomously worked.
+ *
+ * ## Auto-proceed condition (AC2)
+ * - Implementation-or-later epic (`pipelineStage` ∈ `implementation-stages`)
+ *   that has a non-empty ready frontier (at least one child task satisfies
+ *   all dependencies), or any concrete task/subtask that clears all GRILL
+ *   triggers.
+ *
+ * @module orchestration/classify-readiness
+ * @task T11495  E3-GRILL-GATE classifyReadiness predicate
+ * @epic T11492  SG-AUTOPILOT
+ * @see {@link classifyReadiness}
+ */
+
+import type { Task } from '@cleocode/contracts';
+import type { IvtrState } from '../lifecycle/ivtr-loop.js';
+import { MAX_LOOP_BACKS_PER_PHASE } from '../lifecycle/ivtr-loop.js';
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+/**
+ * Verdict returned by {@link classifyReadiness}.
+ *
+ * - `'proceed'` — the task is ready for autonomous execution.
+ * - `'grill'`   — the task needs clarification or escalation before work
+ *                 can safely begin. Callers surface this as
+ *                 `AskUserQuestion` (agent mode) or a pending-row
+ *                 (--headless mode).
+ */
+export type ReadinessVerdict = 'proceed' | 'grill';
+
+/**
+ * Grill trigger codes.  One or more codes appear in
+ * {@link ReadinessResult.triggers} when `verdict === 'grill'`.
+ */
+export type GrillTrigger =
+  /** Task has no acceptance criteria — work scope is undefined. */
+  | 'MISSING_AC'
+  /** Task carries an `owner-decision` label or its `blockedBy` field mentions owner/decision. */
+  | 'OWNER_DECISION_REQUIRED'
+  /** IVTR loop has exhausted loop-back retries for at least one phase. */
+  | 'IVTR_MAX_RETRIES'
+  /** Task is in `release` pipeline stage and no HITL approval has been granted. */
+  | 'RELEASE_GATE'
+  /** Epic with no children and no spec/research artifact — ambiguous scope. */
+  | 'AMBIGUOUS_SCOPE';
+
+/**
+ * Result returned by {@link classifyReadiness}.
+ */
+export interface ReadinessResult {
+  /** Whether the task should proceed or be grilled. */
+  verdict: ReadinessVerdict;
+  /**
+   * Human-readable summary of the verdict.
+   *
+   * For `proceed`: a brief confirmation.
+   * For `grill`: a concise description of what needs clarification.
+   */
+  reason: string;
+  /**
+   * Active grill triggers (empty when `verdict === 'proceed'`).
+   *
+   * Multiple triggers may fire simultaneously; callers should surface all of
+   * them in the question/pending-row so they can be resolved in one pass.
+   */
+  triggers: GrillTrigger[];
+}
+
+/**
+ * Optional signals that require async resolution by the caller.
+ *
+ * Pass a populated `ReadinessSignals` to {@link classifyReadiness} so the
+ * predicate can incorporate live state without opening any I/O itself.
+ * Every field is optional; omitting a field disables the corresponding check.
+ */
+export interface ReadinessSignals {
+  /**
+   * Child tasks of the unit under evaluation.
+   *
+   * Used to determine whether an epic has a non-empty ready frontier
+   * (at least one non-terminal child with all deps satisfied) and
+   * to suppress {@link GrillTrigger.AMBIGUOUS_SCOPE} when children exist.
+   */
+  children?: Task[];
+
+  /**
+   * IVTR state for the task as returned by `getIvtrState()`.
+   *
+   * When present, the predicate checks whether any phase's `loopBackCount`
+   * has reached {@link MAX_LOOP_BACKS_PER_PHASE}.  When absent the
+   * IVTR-max-retries check is skipped.
+   */
+  ivtrState?: IvtrState | null;
+
+  /**
+   * Names of blob attachments associated with the task (from `blobList()`).
+   *
+   * Used to detect whether an undecomposed epic has a spec or research
+   * artifact that justifies autonomous execution.  When absent the check
+   * falls back to the children-count alone.
+   */
+  blobNames?: string[];
+
+  /**
+   * Whether a HITL approval token has already been granted for the task.
+   *
+   * When `true` the {@link GrillTrigger.RELEASE_GATE} trigger is suppressed
+   * even if the task is in the `release` pipeline stage (the gate was already
+   * cleared via `cleo orchestrate approve`).
+   *
+   * Defaults to `false` when omitted.
+   */
+  hitlApproved?: boolean;
+}
+
+// ─── Internal constants ───────────────────────────────────────────────────────
+
+/**
+ * Label (case-insensitive) that marks a task as requiring an owner decision
+ * before work begins.
+ *
+ * Applied by convention via `cleo update --label owner-decision`.
+ */
+const OWNER_DECISION_LABEL = 'owner-decision';
+
+/**
+ * Keywords checked in `task.blockedBy` (free-text) to detect implicit
+ * owner-decision blocks.  Checked case-insensitively.
+ */
+const OWNER_DECISION_BLOCKED_BY_KEYWORDS = ['owner', 'decision'] as const;
+
+/**
+ * Pipeline stages that represent active release/publish gates.
+ *
+ * A task at one of these stages requires explicit HITL approval (via
+ * `cleo orchestrate approve`) before autonomous execution.  Reuses the
+ * existing `pending` / `approve` / `reject` surface — no new HITL path.
+ */
+const RELEASE_PIPELINE_STAGES = new Set(['release', 'publish'] as const);
+
+/**
+ * Blob attachment name patterns (lowercased) that signal a spec or research
+ * artifact is present for an undecomposed epic.
+ *
+ * Any blob whose name contains one of these substrings is treated as a
+ * sufficient spec artifact to suppress {@link GrillTrigger.AMBIGUOUS_SCOPE}.
+ */
+const SPEC_ARTIFACT_NAME_PATTERNS = ['spec', 'research', 'adr', 'rfc', 'design', 'plan'] as const;
+
+/**
+ * Pipeline stages at or beyond the implementation phase.
+ *
+ * An epic in one of these stages with a non-empty ready frontier is treated
+ * as safely proceeding — it has been planned and decomposed.
+ */
+const IMPLEMENTATION_STAGES = new Set([
+  'implementation',
+  'validation',
+  'audit',
+  'test',
+  'release',
+  'publish',
+  'contribution',
+] as const);
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Return `true` when the task is missing any meaningful acceptance criteria.
+ *
+ * A task is considered to have criteria when its `acceptance` array contains
+ * at least one entry — either a non-empty string or a structured
+ * {@link AcceptanceGate} object.
+ *
+ * @param task - Task record to inspect.
+ */
+function hasMissingAc(task: Task): boolean {
+  const ac = task.acceptance;
+  if (!ac || ac.length === 0) return true;
+  // Ensure every entry is non-empty (filter out blank-string artifacts).
+  const meaningful = ac.filter((item) =>
+    typeof item === 'string' ? item.trim().length > 0 : true,
+  );
+  return meaningful.length === 0;
+}
+
+/**
+ * Return `true` when the task requires an owner decision before work can start.
+ *
+ * Two signals are checked:
+ *  1. `task.labels` contains `'owner-decision'` (exact, case-insensitive).
+ *  2. `task.blockedBy` free-text mentions "owner" OR "decision"
+ *     (case-insensitive substring match).
+ *
+ * @param task - Task record to inspect.
+ */
+function requiresOwnerDecision(task: Task): boolean {
+  const labels = (task.labels ?? []).map((l) => l.toLowerCase());
+  if (labels.includes(OWNER_DECISION_LABEL)) return true;
+
+  const blockedBy = (task.blockedBy ?? '').toLowerCase();
+  if (blockedBy.length > 0) {
+    for (const kw of OWNER_DECISION_BLOCKED_BY_KEYWORDS) {
+      if (blockedBy.includes(kw)) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Return `true` when the IVTR loop has exhausted retries for any phase.
+ *
+ * Checks every phase's `loopBackCount` against {@link MAX_LOOP_BACKS_PER_PHASE}.
+ * A count equal to or greater than the limit means the next `loopBackIvtr`
+ * call would throw `E_IVTR_MAX_RETRIES` — the task must escalate to HITL.
+ *
+ * @param ivtrState - Resolved IVTR state or `null`/`undefined` when absent.
+ */
+function hasIvtrMaxRetries(ivtrState: IvtrState | null | undefined): boolean {
+  if (!ivtrState) return false;
+  const counts = ivtrState.loopBackCount;
+  if (!counts) return false;
+  return Object.values(counts).some((count) => count >= MAX_LOOP_BACKS_PER_PHASE);
+}
+
+/**
+ * Return `true` when the task is at an active release/publish gate without
+ * prior HITL approval.
+ *
+ * @param task        - Task record to inspect.
+ * @param hitlApproved - Whether approval was already granted.
+ */
+function hasReleaseGate(task: Task, hitlApproved: boolean): boolean {
+  const stage = task.pipelineStage ?? null;
+  if (!stage) return false;
+  return RELEASE_PIPELINE_STAGES.has(stage as 'release' | 'publish') && !hitlApproved;
+}
+
+/**
+ * Return `true` when an epic's scope is ambiguous (cannot proceed autonomously).
+ *
+ * Ambiguity is signalled by:
+ *  - The task is an `epic` type.
+ *  - It has no direct children (`children` is empty or absent).
+ *  - It has no attached spec/research artifact blobs.
+ *
+ * When the epic IS at `implementation` stage or beyond we do NOT mark it
+ * ambiguous — the implementation stage implies decomposition already happened.
+ *
+ * @param task      - Task record to inspect.
+ * @param children  - Direct child tasks (may be empty).
+ * @param blobNames - Names of attached blobs (may be empty).
+ */
+function hasAmbiguousScope(
+  task: Task,
+  children: Task[] | undefined,
+  blobNames: string[] | undefined,
+): boolean {
+  if (task.type !== 'epic') return false;
+
+  // If the epic is in an implementation-or-later stage it was already
+  // decomposed — no ambiguity.
+  const stage = task.pipelineStage ?? '';
+  if (IMPLEMENTATION_STAGES.has(stage as Parameters<typeof IMPLEMENTATION_STAGES.has>[0])) {
+    return false;
+  }
+
+  // Children exist → not ambiguous.
+  if (children && children.length > 0) return false;
+
+  // A spec/research artifact is sufficient to proceed.
+  const lowerBlobs = (blobNames ?? []).map((n) => n.toLowerCase());
+  const hasSpecArtifact = SPEC_ARTIFACT_NAME_PATTERNS.some((pattern) =>
+    lowerBlobs.some((name) => name.includes(pattern)),
+  );
+  if (hasSpecArtifact) return false;
+
+  return true;
+}
+
+/**
+ * Return `true` when an epic has a non-empty ready frontier.
+ *
+ * A task in the frontier is one that:
+ *  - has a non-terminal status (`pending` or `active`)
+ *  - has all its `depends` entries satisfied (status `done` or `archived`)
+ *
+ * @param children - Direct child tasks of the epic.
+ */
+function hasReadyFrontier(children: Task[]): boolean {
+  const terminalStatuses = new Set(['done', 'cancelled', 'archived']);
+  const satisfiedStatuses = new Set(['done', 'archived']);
+
+  const childMap = new Map(children.map((c) => [c.id, c]));
+
+  return children.some((child) => {
+    if (terminalStatuses.has(child.status)) return false;
+    const deps = child.depends ?? [];
+    return deps.every((depId) => {
+      const dep = childMap.get(depId);
+      return dep !== undefined && satisfiedStatuses.has(dep.status);
+    });
+  });
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Classify whether a task unit is ready to proceed autonomously or needs
+ * grilling (clarification / escalation) before work starts.
+ *
+ * **Pure function**: does not open any DB, file, or network connection.
+ * All live state (children, IVTR, blobs) is pre-fetched by the caller and
+ * passed via {@link ReadinessSignals}.
+ *
+ * ## Grill triggers (checked in order)
+ * 1. {@link GrillTrigger.MISSING_AC}              — `task.acceptance` is empty or absent.
+ * 2. {@link GrillTrigger.OWNER_DECISION_REQUIRED} — `owner-decision` label or blockedBy text.
+ * 3. {@link GrillTrigger.IVTR_MAX_RETRIES}        — IVTR loop-back count ≥ MAX per any phase.
+ * 4. {@link GrillTrigger.RELEASE_GATE}            — `pipelineStage` ∈ {release, publish} without approval.
+ * 5. {@link GrillTrigger.AMBIGUOUS_SCOPE}         — epic with no children and no spec artifact.
+ *
+ * ## Auto-proceed
+ * - All triggers clear.
+ * - OR: implementation-or-later epic with a non-empty ready frontier
+ *   (only possible when MISSING_AC is absent — an epic without ACs still grills).
+ *
+ * @param task    - Full task record to classify.
+ * @param signals - Optional pre-fetched supporting state. When omitted, checks
+ *                  that require live state are skipped gracefully.
+ * @returns {@link ReadinessResult} with `verdict`, `reason`, and `triggers`.
+ *
+ * @example Basic usage (no async signals):
+ * ```typescript
+ * const result = classifyReadiness(task);
+ * if (result.verdict === 'grill') {
+ *   console.warn(`Grill: ${result.reason}`);
+ * }
+ * ```
+ *
+ * @example With pre-fetched signals:
+ * ```typescript
+ * const children = await accessor.getChildren(task.id);
+ * const ivtrState = await getIvtrState(task.id);
+ * const blobNames = (await blobList(task.id)).map(b => b.name);
+ *
+ * const result = classifyReadiness(task, { children, ivtrState, blobNames });
+ * ```
+ *
+ * @task T11495 E3-GRILL-GATE
+ * @epic T11492 SG-AUTOPILOT
+ */
+export function classifyReadiness(task: Task, signals: ReadinessSignals = {}): ReadinessResult {
+  const { children, ivtrState, blobNames, hitlApproved = false } = signals;
+  const triggers: GrillTrigger[] = [];
+
+  // ── 1. Missing acceptance criteria ──────────────────────────────────────
+  if (hasMissingAc(task)) {
+    triggers.push('MISSING_AC');
+  }
+
+  // ── 2. Owner-decision required ───────────────────────────────────────────
+  if (requiresOwnerDecision(task)) {
+    triggers.push('OWNER_DECISION_REQUIRED');
+  }
+
+  // ── 3. IVTR max-retries exhausted ───────────────────────────────────────
+  if (hasIvtrMaxRetries(ivtrState)) {
+    triggers.push('IVTR_MAX_RETRIES');
+  }
+
+  // ── 4. Release / publish gate ────────────────────────────────────────────
+  if (hasReleaseGate(task, hitlApproved)) {
+    triggers.push('RELEASE_GATE');
+  }
+
+  // ── 5. Ambiguous scope ───────────────────────────────────────────────────
+  if (hasAmbiguousScope(task, children, blobNames)) {
+    triggers.push('AMBIGUOUS_SCOPE');
+  }
+
+  // ── Short-circuit: any trigger fires → grill ────────────────────────────
+  if (triggers.length > 0) {
+    const reason = buildGrillReason(task, triggers, children);
+    return { verdict: 'grill', reason, triggers };
+  }
+
+  // ── Auto-proceed check for impl+ epics ─────────────────────────────────
+  //   Epics in implementation-or-later stage with a non-empty ready frontier
+  //   are explicitly marked as auto-proceed (AC2).
+  const stage = task.pipelineStage ?? '';
+  if (
+    task.type === 'epic' &&
+    IMPLEMENTATION_STAGES.has(stage as Parameters<typeof IMPLEMENTATION_STAGES.has>[0]) &&
+    children &&
+    children.length > 0 &&
+    hasReadyFrontier(children)
+  ) {
+    return {
+      verdict: 'proceed',
+      reason: `Epic ${task.id} is in '${stage}' stage with a non-empty ready frontier — proceed autonomously.`,
+      triggers: [],
+    };
+  }
+
+  return {
+    verdict: 'proceed',
+    reason: `Task ${task.id} cleared all readiness checks — proceed autonomously.`,
+    triggers: [],
+  };
+}
+
+// ─── Internal: reason builder ─────────────────────────────────────────────────
+
+/**
+ * Build a human-readable reason string for a `grill` verdict.
+ *
+ * Lists every active trigger so the caller can surface all issues in a single
+ * `AskUserQuestion` / pending-row without a follow-up round-trip.
+ *
+ * @internal
+ */
+function buildGrillReason(
+  task: Task,
+  triggers: GrillTrigger[],
+  children: Task[] | undefined,
+): string {
+  const parts: string[] = [`Task ${task.id} (${task.title}) requires grilling:`];
+
+  for (const trigger of triggers) {
+    switch (trigger) {
+      case 'MISSING_AC':
+        parts.push(
+          '  • MISSING_AC — task has no acceptance criteria; define them before starting work.',
+        );
+        break;
+
+      case 'OWNER_DECISION_REQUIRED': {
+        const hasLabel = (task.labels ?? [])
+          .map((l) => l.toLowerCase())
+          .includes(OWNER_DECISION_LABEL);
+        if (hasLabel) {
+          parts.push(
+            `  • OWNER_DECISION_REQUIRED — label '${OWNER_DECISION_LABEL}' indicates an open owner decision.`,
+          );
+        } else {
+          parts.push(
+            `  • OWNER_DECISION_REQUIRED — blockedBy '${task.blockedBy}' indicates an owner/decision dependency.`,
+          );
+        }
+        break;
+      }
+
+      case 'IVTR_MAX_RETRIES':
+        parts.push(
+          '  • IVTR_MAX_RETRIES — IVTR loop-back retries exhausted; HITL escalation required.',
+        );
+        break;
+
+      case 'RELEASE_GATE':
+        parts.push(
+          `  • RELEASE_GATE — task is in '${task.pipelineStage}' stage; use 'cleo orchestrate approve' to unblock.`,
+        );
+        break;
+
+      case 'AMBIGUOUS_SCOPE': {
+        const childCount = children?.length ?? 0;
+        parts.push(
+          `  • AMBIGUOUS_SCOPE — epic has ${childCount} children and no spec artifact; decompose or attach a spec before work begins.`,
+        );
+        break;
+      }
+    }
+  }
+
+  return parts.join('\n');
+}

--- a/packages/core/src/orchestration/index.ts
+++ b/packages/core/src/orchestration/index.ts
@@ -39,6 +39,13 @@ export {
   getRegisteredAgentIds,
   validateClassifierRules,
 } from './classify.js';
+export type {
+  GrillTrigger,
+  ReadinessResult,
+  ReadinessSignals,
+  ReadinessVerdict,
+} from './classify-readiness.js';
+export { classifyReadiness } from './classify-readiness.js';
 export type { ContextEstimation } from './context.js';
 export { countManifestEntries, estimateContext } from './context.js';
 export type { DashboardRateMetric, OrchestrateDashboardMetrics } from './dashboard.js';


### PR DESCRIPTION
## Summary

- Adds `classifyReadiness(task, signals) -> { verdict, reason, triggers }` in `packages/core/src/orchestration/classify-readiness.ts`
- Pure predicate (no I/O): callers pre-fetch children/IVTR/blobs and pass via `ReadinessSignals`
- Five grill triggers: `MISSING_AC`, `OWNER_DECISION_REQUIRED`, `IVTR_MAX_RETRIES`, `RELEASE_GATE`, `AMBIGUOUS_SCOPE`
- Reuses `MAX_LOOP_BACKS_PER_PHASE` + `IvtrState.loopBackCount` for IVTR signal; reuses `orchestrate approve/reject/pending` for RELEASE_GATE (no new HITL surface)
- Auto-proceed on implementation-or-later epics with non-empty ready frontier (AC2)
- Exports added to `packages/core/src/orchestration/index.ts`
- 41 unit tests covering all triggers, edge cases, and multi-trigger scenarios

## Test plan
- [x] `pnpm biome check --write` — no issues
- [x] `pnpm run typecheck` — exit code 0
- [x] `node build.mjs` — Build complete
- [x] `node packages/cleo/dist/cli/index.js version` — v2026.5.126
- [x] `npx vitest run --project @cleocode/core src/orchestration/__tests__/classify-readiness.test.ts` — 41/41 passed
- [x] `git merge origin/main` + re-validate — all 41 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)