### PR TITLE
feat(T11498): required worker re-verification gate (E6 trustworthy-completion)

### DIFF
--- a/packages/core/src/sentient/__tests__/daemon.test.ts
+++ b/packages/core/src/sentient/__tests__/daemon.test.ts
@@ -70,6 +70,11 @@ function mkTickOptions(projectRoot: string, overrides: Partial<TickOptions> = {}
     statePath: join(projectRoot, SENTIENT_STATE_FILE),
     pickTask: async () => null,
     spawn: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    // T11498: skip the re-verify gate in non-gate-specific tests so that
+    // tests for other tick machinery (kill-switch, state transitions, etc.)
+    // are not broken by the now-mandatory re-verify step. Tests that cover
+    // the gate itself live in re-verify-gate.test.ts.
+    skipReVerify: true,
     ...overrides,
   };
 }

--- a/packages/core/src/sentient/__tests__/dream-tick.test.ts
+++ b/packages/core/src/sentient/__tests__/dream-tick.test.ts
@@ -62,6 +62,8 @@ function mkTickOpts(projectRoot: string, overrides: Partial<TickOptions> = {}): 
     statePath: join(projectRoot, SENTIENT_STATE_FILE),
     pickTask: async () => null,
     spawn: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    // T11498: skip re-verify gate in dream-tick tests (not testing gate behaviour).
+    skipReVerify: true,
     ...overrides,
   };
 }

--- a/packages/core/src/sentient/__tests__/re-verify-gate.test.ts
+++ b/packages/core/src/sentient/__tests__/re-verify-gate.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for the REQUIRED worker re-verification gate (T11498 · AC1).
+ *
+ * AC1: autopilot re-runs ADR-051 evidence gates against ground truth before
+ * accepting any worker exit=0 — NO autonomous completion trusts self-reported
+ * success.
+ *
+ * Covers:
+ *   RVG-1: Gate runs by default (no `reVerify` injected) — verifier stub
+ *           rejects → tick outcome is `failure`, not `success`.
+ *   RVG-2: Gate runs by default — verifier accepts → tick outcome is `success`.
+ *   RVG-3: Gate is skipped when `skipReVerify: true` → success even if the
+ *           verifier would reject (escape hatch for dry-run / legacy callers).
+ *   RVG-4: Gate is skipped when `dryRun: true` — implicit skip.
+ *   RVG-5: Injected `reVerify` is preferred over the built-in default.
+ *   RVG-6: Rejected report increments `tasksFailed` and schedules backoff.
+ *   RVG-7: Reject detail string contains the T1589/T11498 marker.
+ *
+ * All tests inject a `reVerify` stub (or set `skipReVerify`) to avoid
+ * spawning real `pnpm test` / `git status` processes.
+ *
+ * @task T11498
+ * @epic T11492
+ * @adr ADR-051
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Task } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SENTIENT_STATE_FILE } from '../daemon.js';
+import { DEFAULT_SENTIENT_STATE, readSentientState, writeSentientState } from '../state.js';
+import { runTick, type TickOptions } from '../tick.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTask(id: string): Task {
+  return {
+    id,
+    title: `Task ${id}`,
+    status: 'pending',
+    priority: 'medium',
+    createdAt: new Date().toISOString(),
+  } as Task;
+}
+
+/** Verifier stub that always accepts. */
+const alwaysAccept: NonNullable<TickOptions['reVerify']> = async () => ({
+  accepted: true,
+});
+
+/** Verifier stub that always rejects. */
+const alwaysReject: NonNullable<TickOptions['reVerify']> = async () => ({
+  accepted: false,
+});
+
+function mkTickOpts(projectRoot: string, overrides: Partial<TickOptions> = {}): TickOptions {
+  return {
+    projectRoot,
+    statePath: join(projectRoot, SENTIENT_STATE_FILE),
+    pickTask: async () => makeTask('T777'),
+    spawn: async () => ({ exitCode: 0, stdout: 'ok', stderr: '' }),
+    // Stage-drift / hygiene / dream are noisy in unit tests — disable.
+    stageDriftScan: null,
+    hygieneScan: null,
+    checkAndDream: async () => ({ triggered: false, tier: null }),
+    runDeriverBatch: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('re-verify gate — T11498 AC1', () => {
+  let root: string;
+  let statePath: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'cleo-reval-gate-'));
+    statePath = join(root, SENTIENT_STATE_FILE);
+    await writeSentientState(statePath, { ...DEFAULT_SENTIENT_STATE });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 500 });
+  });
+
+  // RVG-1: gate runs with built-in default (no reVerify injection); reject path
+  it('RVG-1: injected reject-stub produces failure outcome (gate is active by default)', async () => {
+    const outcome = await runTick(
+      mkTickOpts(root, {
+        // Injecting a reject stub exercises the same gate code path as the
+        // built-in reVerifyWorkerReport default — we can't use the real default
+        // in unit tests without spawning git/pnpm, so an injected stub is the
+        // canonical way to test the reject path.
+        reVerify: alwaysReject,
+      }),
+    );
+
+    expect(outcome.kind).toBe('failure');
+    expect(outcome.taskId).toBe('T777');
+  });
+
+  // RVG-2: gate runs; verifier accepts → success
+  it('RVG-2: injected accept-stub passes through to success outcome', async () => {
+    const outcome = await runTick(
+      mkTickOpts(root, {
+        reVerify: alwaysAccept,
+      }),
+    );
+
+    expect(outcome.kind).toBe('success');
+    expect(outcome.taskId).toBe('T777');
+  });
+
+  // RVG-3: skipReVerify bypasses the gate
+  it('RVG-3: skipReVerify=true bypasses the gate — success even with a rejecting verifier', async () => {
+    const outcome = await runTick(
+      mkTickOpts(root, {
+        reVerify: alwaysReject, // would reject if the gate ran
+        skipReVerify: true,
+      }),
+    );
+
+    expect(outcome.kind).toBe('success');
+  });
+
+  // RVG-4: dryRun implicitly skips the gate
+  it('RVG-4: dryRun=true implicitly skips the re-verify gate', async () => {
+    const outcome = await runTick(
+      mkTickOpts(root, {
+        reVerify: alwaysReject, // would reject if the gate ran
+        dryRun: true,
+      }),
+    );
+
+    expect(outcome.kind).toBe('success');
+  });
+
+  // RVG-5: injected reVerify is called (not silently ignored)
+  it('RVG-5: injected reVerify is invoked with the worker report', async () => {
+    const spy = vi.fn().mockResolvedValue({ accepted: true });
+
+    await runTick(
+      mkTickOpts(root, {
+        reVerify: spy,
+      }),
+    );
+
+    expect(spy).toHaveBeenCalledOnce();
+    const [report, opts] = spy.mock.calls[0] as Parameters<NonNullable<TickOptions['reVerify']>>;
+    expect(report.taskId).toBe('T777');
+    expect(report.selfReportSuccess).toBe(true);
+    expect(opts.projectRoot).toBe(root);
+  });
+
+  // RVG-6: rejected report increments tasksFailed + schedules backoff
+  it('RVG-6: rejected report increments tasksFailed and writes a stuck record', async () => {
+    await runTick(
+      mkTickOpts(root, {
+        reVerify: alwaysReject,
+      }),
+    );
+
+    const state = await readSentientState(statePath);
+    expect(state.stats.tasksFailed).toBe(1);
+    expect(state.stuckTasks['T777']).toBeDefined();
+    expect(state.stuckTasks['T777'].attempts).toBe(1);
+    // nextRetryAt should be in the future (backoff scheduled)
+    expect(state.stuckTasks['T777'].nextRetryAt).toBeGreaterThan(Date.now());
+  });
+
+  // RVG-7: failure detail carries task reference marker
+  it('RVG-7: failure detail contains the T1589/T11498 task reference marker', async () => {
+    const outcome = await runTick(
+      mkTickOpts(root, {
+        reVerify: alwaysReject,
+      }),
+    );
+
+    expect(outcome.kind).toBe('failure');
+    expect(outcome.detail).toMatch(/T1589\/T11498/);
+  });
+});

--- a/packages/core/src/sentient/tick.ts
+++ b/packages/core/src/sentient/tick.ts
@@ -708,24 +708,32 @@ export async function runTick(options: TickOptions): Promise<TickOutcome> {
 
   // -- Classify + record -----------------------------------------------------
   if (spawnResult.exitCode === 0) {
-    // T1589: orchestrator-side re-verification gate. Worker self-reports
-    // exit=0 but we MUST NOT trust it without re-running gates against
-    // ground truth (lie #4 in HONEST-HANDOFF-2026-04-28.md). The gate is
-    // skipped under --dry-run and when explicitly disabled; tests inject
-    // an `options.reVerify` stub instead of spawning real subprocesses.
+    // T1589 / T11498 (E6-TRUSTWORTHY-COMPLETION): orchestrator-side
+    // re-verification gate. Worker self-reports exit=0 but we MUST NOT trust
+    // it without re-running gates against ground truth (lie #4 in
+    // HONEST-HANDOFF-2026-04-28.md).
+    //
+    // REQUIRED (AC1): this gate is ALWAYS active in production unless the tick
+    // is running under `--dry-run` or `skipReVerify` is explicitly set to true.
+    // `options.reVerify` overrides the verifier for tests; production callers
+    // leave it unset and the real `reVerifyWorkerReport` fills in as the default.
+    // The previous conditional `options.reVerify !== undefined` made the gate a
+    // no-op when callers omitted the override — the `?? reVerifyWorkerReport`
+    // default makes it unconditional (T11498 AC1).
     const skipReVerify = options.skipReVerify === true || options.dryRun === true;
-    if (!skipReVerify && options.reVerify !== undefined) {
+    if (!skipReVerify) {
+      const verifier = options.reVerify ?? reVerifyWorkerReport;
       const report: WorkerReport = {
         taskId: task.id,
         selfReportSuccess: true,
         evidenceAtoms: ['tool:test'],
         touchedFiles: [],
       };
-      const verdict = await options.reVerify(report, { projectRoot });
+      const verdict = await verifier(report, { projectRoot });
       if (!verdict.accepted) {
         const currentAttempts = existingStuck?.attempts ?? 0;
         const nextAttempts = currentAttempts + 1;
-        const failureReason = `worker re-verify rejected (T1589): exit=0 but gates failed`;
+        const failureReason = `worker re-verify rejected (T1589/T11498): exit=0 but gates failed`;
         await writeFailureReceipt(
           projectRoot,
           task.id,
@@ -734,9 +742,21 @@ export async function runTick(options: TickOptions): Promise<TickOutcome> {
           failureReason,
         );
         await incrementStats(statePath, { tasksFailed: 1, ticksExecuted: 1 });
+        // Record backoff / stuck entry exactly like the normal failure path so
+        // the re-verify gate integrates into the existing retry machinery.
+        const backoff =
+          RETRY_BACKOFF_MS[nextAttempts - 1] ?? RETRY_BACKOFF_MS[RETRY_BACKOFF_MS.length - 1];
+        const stuckRecord: StuckTaskRecord = {
+          attempts: nextAttempts,
+          lastFailureAt: new Date(now).toISOString(),
+          nextRetryAt: nextAttempts >= MAX_TASK_ATTEMPTS ? Number.MAX_SAFE_INTEGER : now + backoff,
+          lastReason: failureReason,
+        };
+        const postReject = await readSentientState(statePath);
         await patchSentientState(statePath, {
+          stuckTasks: { ...postReject.stuckTasks, [task.id]: stuckRecord },
           activeTaskId: null,
-          lastTickAt: new Date(Date.now()).toISOString(),
+          lastTickAt: new Date(now).toISOString(),
         });
         return {
           kind: 'failure',
@@ -745,10 +765,6 @@ export async function runTick(options: TickOptions): Promise<TickOutcome> {
         };
       }
     }
-    // Reference reVerifyWorkerReport so the import is retained even when
-    // tests inject a stub via options.reVerify (production callers can
-    // assign options.reVerify = reVerifyWorkerReport).
-    void reVerifyWorkerReport;
 
     await writeSuccessReceipt(projectRoot, task.id, spawnResult.exitCode);
     // Clear stuck entry on success.


### PR DESCRIPTION
## Summary

- **AC1 fix**: The re-verification gate in `packages/core/src/sentient/tick.ts` was conditional on `options.reVerify !== undefined`, making it a dead no-op in production where callers never inject the override. Now uses `options.reVerify ?? reVerifyWorkerReport` so `reVerifyWorkerReport` (the real ADR-051 verifier) always runs on worker exit=0 unless `skipReVerify` or `dryRun` is set.
- **Reject path**: Wired the re-verify rejection into the existing backoff/retry machinery (`stuckTasks` entry + `nextRetryAt`) so rejected workers get retried exactly like normal failures.
- **Tests**: 7 new `RVG-*` tests in `re-verify-gate.test.ts` cover accept/reject/skip paths. Existing tick tests (`daemon.test.ts`, `dream-tick.test.ts`) set `skipReVerify: true` to isolate their concerns from the gate.

## AC coverage

- AC1 (REQUIRED gate): gate now unconditional in production — `reVerifyWorkerReport` is the default
- AC3 (release stages through HITL): unchanged, no release path touched
- AC4 (CORE-first): change is entirely in `packages/core/src/sentient/`

## Test plan

- [ ] `npx vitest run --project @cleocode/core` — zero new failures
- [ ] Typecheck (`pnpm run typecheck`) — clean
- [ ] Biome (`pnpm biome check`) — no issues
- [ ] `re-verify-gate.test.ts` RVG-1 through RVG-7 all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)