### PR TITLE
refactor(T11425-T11427): retire a2a + express from CLEO-core runtime closure; update boundary + ADR-039 (E7)

### DIFF
--- a/.changeset/t11425-t11427-e7-lafs-dep-rightsize.md
+++ b/.changeset/t11425-t11427-e7-lafs-dep-rightsize.md
@@ -1,0 +1,30 @@
+---
+id: t11425-t11427-e7-lafs-dep-rightsize
+tasks: [T11425, T11426, T11427]
+kind: refactor
+summary: "lafs: retire @a2a-js/sdk + express from CLEO-core runtime closure; update boundary.ts + ADR-039"
+---
+
+T11425: `@a2a-js/sdk` moved from `dependencies` to `devDependencies` + optional
+`peerDependencies` in `packages/lafs/package.json`. Runtime A2A value re-exports
+removed from the main `@cleocode/lafs` index; A2A types remain (compile-erased).
+The `/a2a` subpath is unchanged and fully usable for product-only consumers.
+Removes the `packages/cleo/vitest.config.ts` T9965 workaround that aliased
+`@a2a-js/sdk` to `lafs/node_modules` in worktrees.
+
+T11426: `express` moved from `dependencies` to `devDependencies` + optional
+`peerDependencies`. Express is only type-imported in `a2a/extensions.ts`
+(compile-erased) and referenced in JSDoc examples in `health/` and `shutdown/`
+— zero production CLEO consumers instantiate an Express app through lafs.
+T11243 daemon uses its own HTTP layer; no reuse intent confirmed.
+
+T11427: `packages/contracts/src/boundary.ts` lafs module entry updated to reflect
+the realized E7 design: contracts=type-SSoT, core=runtime+validate-SSoT,
+lafs=external-spec-SDK with lafs-napi hot-path wired, conformance-as-CI-gate,
+a2a/ops product-only with optional peer deps. ADR-039 amended (T11427 section)
+documenting the canonical role partitioning, hot-path validator, conformance gate,
+and A2A product-only isolation.
+
+No CLEO-core package (core, cleo, cleo-os, contracts, runtime) depends on
+`@a2a-js/sdk` or `express` at runtime. CI: build + test + `cleo check arch`
+must remain green.

--- a/.cleo/adrs/ADR-039-lafs-envelope-unification.md
+++ b/.cleo/adrs/ADR-039-lafs-envelope-unification.md
@@ -274,6 +274,30 @@ receive — no per-operation branching, no shape detection.
 
 ---
 
+## Amendment — T11427 (T11394 E7 / 2026-05-31) — Realized LAFS design
+
+Documents the realized design from the E7 LAFS canonical envelope epic (T11394, Saga T11387).
+
+**Role partitioning (canonical).**
+
+| Layer | Role |
+|-------|------|
+| `@cleocode/contracts` | Type SSoT — `CliEnvelope`, `CliMeta`, `LAFSPage`, `LAFSError` re-exported here; no runtime code |
+| `@cleocode/core` | Runtime + validate SSoT — `maybeValidateEnvelope()` wired into `formatSuccess()`/`formatError()` (T11420); validates in `CLEO_STRICT_ENVELOPE`/`CLEO_ENV=ci`/`NODE_ENV=test` mode |
+| `@cleocode/lafs` | External-spec SDK — `packages/lafs/` is the LAFS specification SDK; envelope.ts is the canonical type source; lafs-napi (Rust) is the hot-path validator wired via `native-loader.ts` with AJV fallback (T11421) |
+
+**Envelopes are validated (not trusted).** Per ADR-086 §3, every envelope received from an external source MUST be validated before consumption. `maybeValidateEnvelope()` is the canonical validation entry point; consumers MUST NOT bypass it.
+
+**Hot-path validator.** `packages/lafs/src/native-loader.ts` probes for the lafs-napi Rust binding and falls back to AJV when unavailable. The budget chokepoint (`applyBudgetEnforcement` / `checkBudget` / `BUDGET_EXCEEDED_CODE` from `@cleocode/lafs`) is green; regression test at `packages/cleo/src/dispatch/lib/__tests__/budget-regression.test.ts`.
+
+**Conformance as CI gate.** `scripts/lint-lafs-envelope-conformance.mjs` validates all `packages/lafs/fixtures/valid-cleo-cli-*.json` fixtures against `envelope.schema.json`; job `lafs-envelope-conformance` in `.github/workflows/ci.yml`.
+
+**A2A — product-only, not CLEO-core.** The A2A integration (`@a2a-js/sdk` + express HTTP primitives) is isolated to the published `@cleocode/lafs/a2a` subpath. Both are optional peer dependencies (T11425/T11426). The main `@cleocode/lafs` index exports A2A types only (compile-erased); runtime A2A values require `import ... from '@cleocode/lafs/a2a'`. No CLEO-core package depends on A2A at runtime.
+
+**ADR-086 conformance.** `CliEnvelope` is the canonical machine-readable CLI output shape. Writers MUST produce valid envelopes; readers MUST validate before trusting. The one-per-stdout-write discipline is enforced by `scripts/lint-stdout-write-allowlist.mjs`.
+
+---
+
 ## References
 
 - T335 — LAFS Envelope Remediation epic
@@ -295,3 +319,11 @@ receive — no per-operation branching, no shape detection.
 - `packages/cleo/src/dispatch/types.ts` — `DispatchResponse.meta` (renamed from `_meta`)
 - `scripts/lint-stdout-write-allowlist.mjs` — writer-allowlist CI gate
 - `scripts/lint-stdout-discipline.mjs` — console-write discipline CI gate
+- T11394 (Saga T11387 E7) — E7-LAFS-CANONICAL epic; T11419–T11427 leaves
+- T11425 — Retire a2a/* from CLEO-core dependency closure
+- T11426 — Right-size Express ops primitives out of CLEO-core
+- T11427 — Update ADR-039/ADR-086 + boundary.ts to realized LAFS design
+- `packages/contracts/src/boundary.ts` — lafs module entry (amendment T11425-T11427-e7-lafs-canonical)
+- `packages/lafs/src/native-loader.ts` — hot-path lafs-napi probe + AJV fallback
+- `packages/cleo/src/dispatch/lib/__tests__/budget-regression.test.ts` — budget chokepoint regression
+- `scripts/lint-lafs-envelope-conformance.mjs` — CI conformance gate (T11422)

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -366,12 +366,6 @@ export default defineConfig({
       ).pathname,
       '@cleocode/core': new URL('../../packages/core/src/index.ts', import.meta.url).pathname,
       '@cleocode/lafs': new URL('../../packages/lafs/src/index.ts', import.meta.url).pathname,
-      // T9965: @a2a-js/sdk is a dep of @cleocode/lafs; in worktrees it resolves
-      // through lafs/node_modules rather than root node_modules.
-      '@a2a-js/sdk': new URL(
-        '../../packages/lafs/node_modules/@a2a-js/sdk/dist/index.js',
-        import.meta.url,
-      ).pathname,
       // T9965: js-yaml + @iarna/toml are deps of @cleocode/caamp; in worktrees
       // they resolve through caamp/node_modules rather than root node_modules.
       '@iarna/toml': new URL(

--- a/packages/contracts/src/boundary.ts
+++ b/packages/contracts/src/boundary.ts
@@ -747,9 +747,9 @@ export const BOUNDARY_REGISTRY: readonly BoundaryEntry[] = [
       root_escape: 'forbidden',
       network_egress: 'allowed',
     },
-    amendments: [],
+    amendments: ['T11425-T11427-e7-lafs-canonical'],
     rationale:
-      'Envelope + A2A bridge (11,353 LOC) consumed by 6 packages. Rust core (lafs-core + lafs-napi) handles canonical envelope serialization; TS layer is A2A express bridge + envelope validation glue (2,600 LOC a2a/* uses JS-only @a2a-js/sdk).',
+      'LAFS envelope SDK consumed by 6 packages (T11394 E7). Rust core (lafs-core + lafs-napi) is the hot-path validator wired via native-loader.ts with AJV fallback. contracts=type-SSoT, core=runtime+validate-SSoT, lafs=external-spec-SDK. A2A integration (@a2a-js/sdk) and Express ops primitives (health/shutdown/discovery) are product-only: isolated to the published `@cleocode/lafs/a2a` subpath and optional peer deps — NOT in the CLEO-core runtime closure (T11425/T11426). Budget chokepoint (applyBudgetEnforcement) is green.',
   },
   {
     module: 'runtime/gateway/mcp',

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -74,18 +74,30 @@
   "author": "CLEO Code <hello@cleocode.dev> (https://cleocode.dev)",
   "license": "MIT",
   "devDependencies": {
+    "@a2a-js/sdk": "^0.3.10",
     "@types/express": "^5.0.6",
     "@types/node": "^24.3.0",
     "@types/supertest": "^7.2.0",
+    "express": "^5.2.1",
     "supertest": "^7.2.2",
     "tsx": "^4.20.5",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
   },
   "dependencies": {
-    "@a2a-js/sdk": "^0.3.10",
     "ajv": "^8.18.0",
-    "ajv-formats": "^3.0.1",
+    "ajv-formats": "^3.0.1"
+  },
+  "peerDependencies": {
+    "@a2a-js/sdk": "^0.3.10",
     "express": "^5.2.1"
+  },
+  "peerDependenciesMeta": {
+    "@a2a-js/sdk": {
+      "optional": true
+    },
+    "express": {
+      "optional": true
+    }
   }
 }

--- a/packages/lafs/src/index.ts
+++ b/packages/lafs/src/index.ts
@@ -6,11 +6,20 @@
  * @remarks
  * This is the main entry point for the `@cleocode/lafs` package. It re-exports all
  * public modules including envelope creation, validation, conformance checking,
- * error registry, flag resolution, MVI projection, A2A integration, and operational
- * primitives (health, shutdown, circuit breaker).
+ * error registry, flag resolution, MVI projection, and operational primitives
+ * (health, shutdown, circuit breaker).
+ *
+ * A2A integration is available as a product-only subpath: `@cleocode/lafs/a2a`.
+ * It requires `@a2a-js/sdk` (optional peer dependency) and is NOT part of the
+ * CLEO-core runtime closure. Import directly when needed:
+ * ```ts
+ * import { TaskManager } from '@cleocode/lafs/a2a';
+ * ```
  */
 
-// A2A SDK types (non-conflicting subset)
+// A2A type-only re-exports from main index (T11425: types are compile-erased;
+// runtime values moved to product-only subpath '@cleocode/lafs/a2a').
+// For runtime A2A symbols, import from '@cleocode/lafs/a2a'.
 export type {
   Artifact,
   BuildLafsExtensionOptions,
@@ -41,49 +50,6 @@ export type {
   TaskStatusUpdateEvent,
   TaskStreamEvent,
   TextPart,
-} from './a2a/index.js';
-// A2A Integration
-// Explicitly re-export to avoid naming conflicts with discovery types
-// (AgentCard, AgentSkill, AgentCapabilities, AgentExtension).
-// For full A2A types, import from '@cleocode/lafs/a2a'.
-export {
-  A2A_EXTENSIONS_HEADER,
-  AGENT_CARD_PATH,
-  attachLafsEnvelope,
-  buildLafsExtension,
-  createFileArtifact,
-  createLafsArtifact,
-  createTextArtifact,
-  ExtensionSupportRequiredError,
-  extensionNegotiationMiddleware,
-  formatExtensionsHeader,
-  getExtensionParams,
-  HTTP_EXTENSION_HEADER,
-  INTERRUPTED_STATES,
-  InvalidStateTransitionError,
-  isExtensionRequired,
-  isInterruptedState,
-  isTerminalState,
-  isValidTransition,
-  // Extensions (T098)
-  LAFS_EXTENSION_URI,
-  // Bridge
-  LafsA2AResult,
-  negotiateExtensions,
-  PushNotificationConfigStore,
-  PushNotificationDispatcher,
-  parseExtensionsHeader,
-  streamTaskEvents,
-  TaskArtifactAssembler,
-  // Streaming and Async (T101)
-  TaskEventBus,
-  TaskImmutabilityError,
-  TaskManager,
-  TaskNotFoundError,
-  TaskRefinementError,
-  // Task Lifecycle (T099)
-  TERMINAL_STATES,
-  VALID_TRANSITIONS,
 } from './a2a/index.js';
 export * from './budgetEnforcement.js';
 export * from './circuit-breaker/index.js';

--- a/packages/lafs/tests/a2aBridge.test.ts
+++ b/packages/lafs/tests/a2aBridge.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+// T11425: A2A runtime values moved to product-only subpath (not in CLEO-core closure)
 import {
   AGENT_CARD_PATH,
   HTTP_EXTENSION_HEADER,
@@ -6,7 +7,7 @@ import {
   createLafsArtifact,
   createTextArtifact,
   isExtensionRequired,
-} from "../src/index.js";
+} from "../src/a2a/index.js";
 
 describe("A2A bridge upstream SDK alignment (T102)", () => {
   it("exposes upstream path/header constants", () => {

--- a/packages/lafs/tests/streamingAsync.test.ts
+++ b/packages/lafs/tests/streamingAsync.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+// T11425: A2A runtime values moved to product-only subpath (not in CLEO-core closure)
 import {
   PushNotificationDispatcher,
   PushNotificationConfigStore,
   TaskArtifactAssembler,
   TaskEventBus,
   streamTaskEvents,
-} from "../src/index.js";
+} from "../src/a2a/index.js";
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -600,19 +600,16 @@ importers:
 
   packages/lafs:
     dependencies:
-      '@a2a-js/sdk':
-        specifier: ^0.3.10
-        version: 0.3.13(express@5.2.1)
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.18.0)
-      express:
-        specifier: ^5.2.1
-        version: 5.2.1
     devDependencies:
+      '@a2a-js/sdk':
+        specifier: ^0.3.10
+        version: 0.3.13(express@5.2.1)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -622,6 +619,9 @@ importers:
       '@types/supertest':
         specifier: ^7.2.0
         version: 7.2.0
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       supertest:
         specifier: ^7.2.2
         version: 7.2.2


### PR DESCRIPTION
## Summary

- **T11425**: `@a2a-js/sdk` moved from `dependencies` → `devDependencies` + optional `peerDependencies`. Runtime A2A value re-exports removed from main `@cleocode/lafs` index (types remain, compile-erased). Removes the T9965 vitest.config.ts workaround for `@a2a-js/sdk` in sparse worktrees. Test imports in `a2aBridge.test.ts` + `streamingAsync.test.ts` updated to import from `../src/a2a/index.js` directly. The `/a2a` subpath is unchanged.
- **T11426**: `express` moved from `dependencies` → `devDependencies` + optional `peerDependencies`. Express is only type-imported in `a2a/extensions.ts` (compile-erased) and referenced in JSDoc examples only. Zero production CLEO consumers instantiate Express through lafs; T11243 daemon confirmed to have no reuse intent.
- **T11427**: `packages/contracts/src/boundary.ts` lafs module entry updated with amendment `T11425-T11427-e7-lafs-canonical`. ADR-039 amended documenting the realized E7 design: contracts=type-SSoT, core=runtime+validate-SSoT, lafs=external-spec-SDK with lafs-napi hot-path wired, conformance-as-CI-gate, a2a/ops product-only with optional peer deps.

## Test plan

- [x] `pnpm run typecheck` — clean (0 errors)
- [x] `npx vitest run --project @cleocode/lafs` — 21 files, 439 tests pass
- [x] `npx vitest run --project @cleocode/contracts` — 50 files, 734 tests pass
- [x] `cleo check arch` — 5/5 gates pass
- [x] `node scripts/lint-lafs-envelope-conformance.mjs` — 2/2 fixtures pass
- [x] `node scripts/lint-no-runtime-in-contracts.mjs` — no net-new runtime helpers
- [x] `node scripts/lint-publish-surface.mjs` — 18 publishes (expected 18)
- [x] `node build.mjs` — full monorepo build clean
- [x] CLI smoke: `node packages/cleo/dist/cli/index.js version` returns envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)