### PR TITLE
fix(T11533): exodus FK-defer + column-safe copy (P0 data-loss)

### DIFF
--- a/packages/core/src/store/__tests__/exodus.test.ts
+++ b/packages/core/src/store/__tests__/exodus.test.ts
@@ -985,3 +985,380 @@ describe('T11532 regression — computeTableDigest does NOT crash on WITHOUT ROW
     expect(entry?.sourceCount).toBe(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// T11533 REGRESSION — FK-defer + NOT NULL coalesce + signaldock skills +
+//                     column-intersection digest
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a source DB with a PARENT table and a CHILD table that has a FK
+ * reference to the parent. Rows are inserted parent-first (correct order).
+ *
+ * The target DB schema has the same tables. When FK enforcement is ON during
+ * copy and the child is copied before the parent (or at the same time), the
+ * INSERT fails with "FOREIGN KEY constraint failed" and drops the child rows.
+ * With FK-defer (T11533), all rows survive regardless of copy order.
+ *
+ * DB Open Guard Gate 3: allowed in test files for fixture seeding.
+ */
+function createFkFixture(
+  sourcePath: string,
+  targetPath: string,
+  parentRowCount: number,
+  childRowCount: number,
+): void {
+  // Source: parent table + child table with FK
+  const src = new DatabaseSync(sourcePath);
+  try {
+    src.exec('PRAGMA foreign_keys = ON');
+    src.exec(`CREATE TABLE "parents" (id INTEGER PRIMARY KEY, name TEXT NOT NULL)`);
+    src.exec(`CREATE TABLE "children" (
+      id INTEGER PRIMARY KEY,
+      parent_id INTEGER NOT NULL REFERENCES "parents"(id),
+      val TEXT
+    )`);
+    for (let i = 1; i <= parentRowCount; i++) {
+      src.exec(`INSERT INTO "parents" (id, name) VALUES (${i}, 'parent-${i}')`);
+    }
+    for (let i = 1; i <= childRowCount; i++) {
+      const parentId = ((i - 1) % parentRowCount) + 1;
+      src.exec(
+        `INSERT INTO "children" (id, parent_id, val) VALUES (${i}, ${parentId}, 'child-${i}')`,
+      );
+    }
+  } finally {
+    src.close();
+  }
+
+  // Target: same schema but empty (migration fills it)
+  const tgt = new DatabaseSync(targetPath);
+  try {
+    tgt.exec('PRAGMA foreign_keys = ON');
+    tgt.exec(`CREATE TABLE "parents" (id INTEGER PRIMARY KEY, name TEXT NOT NULL)`);
+    tgt.exec(`CREATE TABLE "children" (
+      id INTEGER PRIMARY KEY,
+      parent_id INTEGER NOT NULL REFERENCES "parents"(id),
+      val TEXT
+    )`);
+  } finally {
+    tgt.close();
+  }
+}
+
+describe('T11533 regression — FK-defer: child rows survive when copied before parent', () => {
+  let tmpDir: string;
+  let sourcePath: string;
+  let targetProjectPath: string;
+  let targetGlobalPath: string;
+  let stagingDir: string;
+
+  const PARENT_ROWS = 5;
+  const CHILD_ROWS = 20;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    sourcePath = join(tmpDir, 'tasks.db');
+    targetProjectPath = join(tmpDir, 'target-project.db');
+    targetGlobalPath = join(tmpDir, 'target-global.db');
+    stagingDir = join(tmpDir, 'staging');
+    mkdirSync(stagingDir, { recursive: true });
+
+    createFkFixture(sourcePath, targetProjectPath, PARENT_ROWS, CHILD_ROWS);
+    createTargetDb(targetGlobalPath, []);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('migrates all child rows even with FK ON in target schema (FK-defer regression)', async () => {
+    const targetProjectDb = new DatabaseSync(targetProjectPath);
+    const targetGlobalDb = new DatabaseSync(targetGlobalPath);
+
+    const makeFakeHandle = (native: DatabaseSyncType) => ({
+      db: { $client: native },
+      close: () => {
+        /* keep open for assertions */
+      },
+    });
+
+    vi.mock('../dual-scope-db.js', () => ({
+      openDualScopeDb: vi.fn(),
+      resolveDualScopeDbPath: vi.fn(),
+    }));
+
+    const dualScopeModule = await import('../dual-scope-db.js');
+    vi.mocked(dualScopeModule.openDualScopeDb).mockImplementation((scope: string) => {
+      if (scope === 'project') return Promise.resolve(makeFakeHandle(targetProjectDb) as never);
+      return Promise.resolve(makeFakeHandle(targetGlobalDb) as never);
+    });
+    vi.mocked(dualScopeModule.resolveDualScopeDbPath).mockImplementation((scope: string) =>
+      scope === 'project' ? targetProjectPath : targetGlobalPath,
+    );
+
+    const { runExodusMigrate: migrate } = await import('../exodus/migrate.js');
+
+    // Use source name 'sourceA' (unrecognized → identity mapping) so tables
+    // 'parents' and 'children' map to themselves (identity fallback).
+    const sources: LegacyDbDescriptor[] = [
+      { name: 'sourceA', path: sourcePath, targetScope: 'project' },
+    ];
+
+    const plan: ExodusPlan = {
+      sources,
+      totalSourceBytes: 0,
+      availableBytes: 100_000_000,
+      diskPreflight: true,
+      stagingDir,
+      resumeFromStaging: false,
+      projectDbPath: targetProjectPath,
+      globalDbPath: targetGlobalPath,
+    };
+
+    const result = await migrate(plan, false, undefined);
+
+    expect(result.ok).toBe(true);
+
+    // PRIMARY ASSERTION: ALL parent and child rows must survive despite FK constraints.
+    const parentCount = countRows(targetProjectPath, 'parents');
+    const childCount = countRows(targetProjectPath, 'children');
+    expect(
+      parentCount,
+      `FK-defer regression: expected ${PARENT_ROWS} parent rows, got ${parentCount}`,
+    ).toBe(PARENT_ROWS);
+    expect(
+      childCount,
+      `FK-defer regression: expected ${CHILD_ROWS} child rows, got ${childCount} — children dropped due to FK constraint`,
+    ).toBe(CHILD_ROWS);
+
+    targetProjectDb.close();
+    targetGlobalDb.close();
+  });
+});
+
+describe('T11533 regression — NOT NULL coalesce: rows with NULL in target-only NOT NULL columns survive', () => {
+  let tmpDir: string;
+  let sourcePath: string;
+  let targetProjectPath: string;
+  let targetGlobalPath: string;
+  let stagingDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    sourcePath = join(tmpDir, 'tasks.db');
+    targetProjectPath = join(tmpDir, 'target-project.db');
+    targetGlobalPath = join(tmpDir, 'target-global.db');
+    stagingDir = join(tmpDir, 'staging');
+    mkdirSync(stagingDir, { recursive: true });
+    createTargetDb(targetGlobalPath, []);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('copies all rows even when source has NULL for a target-only NOT NULL column (COALESCE fix)', async () => {
+    // Source: table with id + val columns only
+    // Target: same table with id + val + required_col (NOT NULL, no default)
+    // Source rows have val=NULL for some rows — these would be silently dropped
+    // by INSERT OR IGNORE if required_col had no COALESCE treatment.
+    const src = new DatabaseSync(sourcePath);
+    try {
+      src.exec(`CREATE TABLE "tbl" (id INTEGER PRIMARY KEY, val TEXT)`);
+      // Insert 10 rows: 5 with val=NULL (would fail NOT NULL if val were the constrained col)
+      for (let i = 1; i <= 10; i++) {
+        if (i % 2 === 0) {
+          src.exec(`INSERT INTO "tbl" (id, val) VALUES (${i}, NULL)`);
+        } else {
+          src.exec(`INSERT INTO "tbl" (id, val) VALUES (${i}, 'val-${i}')`);
+        }
+      }
+    } finally {
+      src.close();
+    }
+
+    // Target: same table with an EXTRA required_col NOT NULL (no default)
+    const tgt = new DatabaseSync(targetProjectPath);
+    try {
+      tgt.exec(`CREATE TABLE "tbl" (id INTEGER PRIMARY KEY, val TEXT, required_col TEXT NOT NULL)`);
+    } finally {
+      tgt.close();
+    }
+
+    const targetProjectDb = new DatabaseSync(targetProjectPath);
+    const targetGlobalDb = new DatabaseSync(targetGlobalPath);
+
+    const makeFakeHandle = (native: DatabaseSyncType) => ({
+      db: { $client: native },
+      close: () => {
+        /* keep open */
+      },
+    });
+
+    vi.mock('../dual-scope-db.js', () => ({
+      openDualScopeDb: vi.fn(),
+      resolveDualScopeDbPath: vi.fn(),
+    }));
+
+    const dualScopeModule = await import('../dual-scope-db.js');
+    vi.mocked(dualScopeModule.openDualScopeDb).mockImplementation((scope: string) => {
+      if (scope === 'project') return Promise.resolve(makeFakeHandle(targetProjectDb) as never);
+      return Promise.resolve(makeFakeHandle(targetGlobalDb) as never);
+    });
+    vi.mocked(dualScopeModule.resolveDualScopeDbPath).mockImplementation((scope: string) =>
+      scope === 'project' ? targetProjectPath : targetGlobalPath,
+    );
+
+    const { runExodusMigrate: migrate } = await import('../exodus/migrate.js');
+
+    const sources: LegacyDbDescriptor[] = [
+      { name: 'sourceA', path: sourcePath, targetScope: 'project' },
+    ];
+
+    const plan: ExodusPlan = {
+      sources,
+      totalSourceBytes: 0,
+      availableBytes: 100_000_000,
+      diskPreflight: true,
+      stagingDir,
+      resumeFromStaging: false,
+      projectDbPath: targetProjectPath,
+      globalDbPath: targetGlobalPath,
+    };
+
+    const result = await migrate(plan, false, undefined);
+
+    expect(result.ok).toBe(true);
+
+    // PRIMARY ASSERTION: ALL 10 rows must be in the target.
+    // Before fix, rows with val=NULL would be silently dropped by INSERT OR IGNORE
+    // because required_col NOT NULL without a source value would cause a violation.
+    // With COALESCE fix, the intersection only copies shared columns (id, val),
+    // and required_col gets its NOT NULL obligation from the COALESCE('') default.
+    const rowCount = countRows(targetProjectPath, 'tbl');
+    expect(
+      rowCount,
+      `NOT NULL coalesce regression: expected 10 rows, got ${rowCount} — rows with NULL val were silently dropped`,
+    ).toBe(10);
+
+    targetProjectDb.close();
+    targetGlobalDb.close();
+  });
+});
+
+describe('T11533 regression — resolveConsolidatedTableName: signaldock skills mapping', () => {
+  it('maps signaldock.db skills → signaldock_skills (not identity fallback)', () => {
+    // Before T11533 fix: 'skills' was not in SIGNALDOCK_DB_MAP → identity fallback
+    // → 'skills' absent in global cleo.db → 0 rows. After fix: maps to 'signaldock_skills'.
+    expect(resolveConsolidatedTableName('signaldock', 'skills')).toEqual({
+      kind: 'mapped',
+      targetName: 'signaldock_skills',
+    });
+  });
+
+  it('maps signaldock.db capabilities → signaldock_capabilities', () => {
+    expect(resolveConsolidatedTableName('signaldock', 'capabilities')).toEqual({
+      kind: 'mapped',
+      targetName: 'signaldock_capabilities',
+    });
+  });
+
+  it('maps signaldock.db agents → signaldock_agents', () => {
+    expect(resolveConsolidatedTableName('signaldock', 'agents')).toEqual({
+      kind: 'mapped',
+      targetName: 'signaldock_agents',
+    });
+  });
+
+  it('maps brain.db session_narrative → brain_session_narrative (T11533 fix)', () => {
+    // Was missing from BRAIN_DB_MAP → identity fallback → 'session_narrative' absent
+    // in consolidated → 0 rows. After fix: maps to 'brain_session_narrative'.
+    expect(resolveConsolidatedTableName('brain (project)', 'session_narrative')).toEqual({
+      kind: 'mapped',
+      targetName: 'brain_session_narrative',
+    });
+  });
+
+  it('returns skip for brain.db brain_release_links (T11533 fix — not in consolidated)', () => {
+    // Before T11533: identity mapping → 'brain_release_links' absent → silent skip.
+    // After T11533: explicit null → logged skip with documented reason.
+    const r = resolveConsolidatedTableName('brain (project)', 'brain_release_links');
+    expect(r.kind).toBe('skip');
+  });
+
+  it('returns skip for brain.db agent_credentials (not in consolidated)', () => {
+    const r = resolveConsolidatedTableName('brain (project)', 'agent_credentials');
+    expect(r.kind).toBe('skip');
+  });
+});
+
+describe('T11533 regression — runExodusVerify: column-intersection digest (hashMatch stability)', () => {
+  let tmpDir: string;
+  let sourcePath: string;
+  let targetProjectPath: string;
+  let targetGlobalPath: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    sourcePath = join(tmpDir, 'tasks.db');
+    targetProjectPath = join(tmpDir, 'project.db');
+    targetGlobalPath = join(tmpDir, 'global.db');
+    createTargetDb(targetGlobalPath, []);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('hashMatch=true when same data exists but target has EXTRA columns (column-drift digest fix)', () => {
+    // Source: tasks.db table 'no_rowid_table' with (key, val) — use name that
+    // maps to 'no_rowid_table' via identity fallback (unrecognized tasks column).
+    // We use 'extra_col_test' to avoid name-map interference.
+    // Source schema: id INTEGER PRIMARY KEY, val TEXT
+    // Target schema: id INTEGER PRIMARY KEY, val TEXT, extra_tgt_col TEXT
+    // Verify MUST compute digest on intersection (id, val) only → hashMatch=true.
+    const src = new DatabaseSync(sourcePath);
+    try {
+      src.exec(`CREATE TABLE "nexus_nodes" (id INTEGER PRIMARY KEY, val TEXT)`);
+      for (let i = 1; i <= 5; i++) {
+        src.exec(`INSERT INTO "nexus_nodes" VALUES (${i}, 'v${i}')`);
+      }
+    } finally {
+      src.close();
+    }
+
+    // Target: same table with an EXTRA column (simulates consolidated schema drift)
+    const tgt = new DatabaseSync(targetProjectPath);
+    try {
+      tgt.exec(
+        `CREATE TABLE "nexus_nodes" (id INTEGER PRIMARY KEY, val TEXT, extra_tgt_col TEXT DEFAULT NULL)`,
+      );
+      // Same data as source
+      for (let i = 1; i <= 5; i++) {
+        tgt.exec(`INSERT INTO "nexus_nodes" (id, val) VALUES (${i}, 'v${i}')`);
+      }
+    } finally {
+      tgt.close();
+    }
+
+    // Use 'nexus' source so nexus_nodes maps to 'nexus_nodes' (identity in NEXUS_DB_MAP)
+    const sources: LegacyDbDescriptor[] = [
+      { name: 'nexus', path: sourcePath, targetScope: 'project' },
+    ];
+
+    const result = runExodusVerify(sources, targetProjectPath, targetGlobalPath, undefined);
+
+    expect(result.ok, `verify must pass: ${result.error ?? ''}`).toBe(true);
+
+    const entry = result.tables.find((t) => t.tableName === 'nexus_nodes');
+    expect(entry, 'must have nexus_nodes entry').toBeDefined();
+    expect(entry?.countMatch, 'count must match').toBe(true);
+    expect(
+      entry?.hashMatch,
+      'hashMatch must be true when data is same but target has extra column (T11533 column-intersection fix)',
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/store/exodus/migrate.ts
+++ b/packages/core/src/store/exodus/migrate.ts
@@ -27,6 +27,20 @@
  * attached, and every subsequent table for the same source threw
  * "database _exodus_src_ is already in use", causing ~80 % data loss.
  *
+ * ## FK-defer bulk copy (ROOT CAUSE 1 fix — T11533)
+ *
+ * Legacy tasks.db has self-referential FKs (`tasks.parent_id → tasks.id`),
+ * cross-table FKs, and ~18 tables with FK relationships. When FK enforcement
+ * is ON and tables are copied in arbitrary order (children before parents),
+ * each child INSERT fails with FOREIGN KEY constraint error (SQLite errcode 787)
+ * and the table is silently skipped — causing ~114K rows of data loss.
+ *
+ * Fix: set `PRAGMA foreign_keys = OFF` on the target connection before any
+ * bulk INSERT, then after all tables are committed run `PRAGMA foreign_key_check`
+ * to validate referential integrity. Genuine orphan rows surface as verify
+ * failures; child-before-parent ordering artifacts are NOT dropped.
+ * `PRAGMA foreign_keys = ON` is restored after the check.
+ *
  * ## Name-mapping (ROOT CAUSE 1 fix — T11532)
  *
  * Legacy source DBs use UNPREFIXED table names (`tasks`, `messages`, `skills`,
@@ -37,13 +51,21 @@
  * no consolidated home emit an explicit WARN journal entry rather than being
  * silently discarded.
  *
- * ## Column-drift tolerance (ROOT CAUSE 2 fix — T11532)
+ * ## Column-drift tolerance (ROOT CAUSE 2 fix — T11532, hardened T11533)
  *
  * When the source and target schemas differ (consolidated schema added/changed
  * columns vs legacy), the copy uses the INTERSECTION of source and target
  * column names. New target-only columns take their schema defaults; old
  * source-only columns are dropped. This is implemented by introspecting both
  * schemas via `PRAGMA table_info` and building an explicit column list.
+ *
+ * **NOT NULL / no-default hazard (T11533)**: target-only NOT NULL columns
+ * WITHOUT a schema default caused `INSERT OR IGNORE` to silently drop rows
+ * whose source value was NULL for that column (constraint violation → IGNORE).
+ * The fix: for each intersection column that is NOT NULL in the target AND
+ * has no `dflt_value`, the SELECT clause wraps the source reference in
+ * `COALESCE(src_col, type_default)` so no row is silently dropped.
+ * A type_default of `''` is used for TEXT affinity and `0` for numeric.
  *
  * ## Advisory file lock (AC4)
  *
@@ -57,6 +79,7 @@
  * @task T11248 (E5 · SG-DB-SUBSTRATE-V2)
  * @task T11531 (P0 attach-leak fix)
  * @task T11532 (P0 name-mapping + column-drift + verify-rowid fix)
+ * @task T11533 (P0 FK-defer + NOT NULL coalesce + signaldock-global map + nexus hash fix)
  * @saga T11242
  */
 
@@ -227,23 +250,42 @@ interface CopyTableResult {
 }
 
 /**
+ * Determine a safe SQL literal default for a NOT NULL column with no schema
+ * default, given its SQLite type affinity.
+ *
+ * Used to coalesce NULL source values for target-only NOT NULL columns so that
+ * rows are not silently dropped by `INSERT OR IGNORE` when a source value is
+ * NULL (T11533 ROOT CAUSE 2 fix).
+ *
+ * @param colType - Raw `type` string from `PRAGMA table_info` (e.g. `"INTEGER"`,
+ *   `"TEXT"`, `"REAL"`, `"BLOB"`, or compound forms like `"text NOT NULL"`).
+ * @returns A SQL literal string suitable for embedding in a `COALESCE()` call.
+ */
+function typeDefaultLiteral(colType: string): string {
+  const upper = colType.toUpperCase();
+  if (upper.includes('INT')) return '0';
+  if (upper.includes('REAL') || upper.includes('FLOAT') || upper.includes('DOUBLE')) return '0.0';
+  if (upper.includes('BLOB')) return "x''";
+  // TEXT and any other affinity (SQLite permissive) → empty string
+  return "''";
+}
+
+/**
  * Copy all rows from a legacy source table (in the already-attached alias) into
  * the corresponding consolidated target table.
  *
  * ## What changed in T11532 vs the T11531 version:
  *
- * 1. **Name mapping (ROOT CAUSE 1)**: `legacyTableName` is resolved to its
- *    consolidated name via `resolveConsolidatedTableName()`. Without this,
+ * 1. **Name mapping (ROOT CAUSE 1 — T11532)**: `legacyTableName` is resolved to
+ *    its consolidated name via `resolveConsolidatedTableName()`. Without this,
  *    `tasks` (legacy) was looked up as `main."tasks"` which doesn't exist in
  *    the consolidated schema (the real target is `tasks_tasks`).
  *
- * 2. **Column-drift tolerance (ROOT CAUSE 2)**: the INSERT uses the
- *    INTERSECTION of source and target column lists rather than the source
- *    columns verbatim. When the consolidated schema added new columns (e.g.
- *    `prune_candidate` on `brain_observations`), the old code failed with
- *    "table main.brain_X has no column named prune_candidate". New target-only
- *    columns take their schema defaults; old source-only columns are silently
- *    dropped.
+ * 2. **Column-drift tolerance (ROOT CAUSE 2 — T11532 + T11533)**: the INSERT
+ *    uses the INTERSECTION of source and target column lists rather than source
+ *    columns verbatim. When the consolidated schema added new columns, old code
+ *    failed. Target-only NOT NULL columns without defaults now get COALESCE()
+ *    wrapping in the SELECT so NULL source values don't cause silent row drops.
  *
  * 3. **Explicit skip (ROOT CAUSE 5)**: tables intentionally excluded from the
  *    consolidated schema (virtual tables, orphan telemetry, etc.) now return
@@ -251,9 +293,10 @@ interface CopyTableResult {
  *    found".
  *
  * **Pre-condition**: the caller has already executed
- * `ATTACH DATABASE '<path>' AS "<attachAlias>"` on `targetNativeDb`.
+ * `ATTACH DATABASE '<path>' AS "<attachAlias>"` on `targetNativeDb`, and
+ * `PRAGMA foreign_keys = OFF` has been set so FK ordering doesn't matter.
  *
- * @param targetNativeDb   - Writable target handle (mid-transaction).
+ * @param targetNativeDb   - Writable target handle (mid-transaction, FK OFF).
  * @param srcNativeDb      - Read-only source snapshot (for metadata queries).
  * @param attachAlias      - Alias under which the source is attached.
  * @param legacyTableName  - Physical table name in the legacy source DB.
@@ -279,9 +322,12 @@ function copyTableFromAttached(
 
   const targetTableName = resolution.targetName;
 
-  // --- Step 2: Get source column list ---
+  // --- Step 2: Get source column list (full pragma for type info) ---
   const srcPragma = srcNativeDb.prepare(`PRAGMA table_info("${legacyTableName}")`).all() as Array<{
     name: string;
+    type: string;
+    notnull: number;
+    dflt_value: string | null;
   }>;
   const srcColumns = new Set(srcPragma.map((r) => r.name));
   if (srcColumns.size === 0) return { rowsCopied: 0, skipped: false };
@@ -306,14 +352,16 @@ function copyTableFromAttached(
     return { rowsCopied: 0, skipped: true, reason };
   }
 
-  // --- Step 5: Compute column intersection (ROOT CAUSE 2) ---
+  // --- Step 5: Compute column intersection (ROOT CAUSE 2 — T11532 + T11533) ---
   const tgtPragma = targetNativeDb
     .prepare(`PRAGMA table_info("${targetTableName}")`)
-    .all() as Array<{ name: string }>;
-  const tgtColumns = new Set(tgtPragma.map((r) => r.name));
+    .all() as Array<{ name: string; type: string; notnull: number; dflt_value: string | null }>;
+
+  // Build a lookup for target columns (type + notNull + dflt_value)
+  const tgtColMap = new Map(tgtPragma.map((r) => [r.name, r]));
 
   // Only copy columns that exist in BOTH source and target.
-  const sharedColumns = srcPragma.map((r) => r.name).filter((col) => tgtColumns.has(col));
+  const sharedColumns = srcPragma.map((r) => r.name).filter((col) => tgtColMap.has(col));
 
   if (sharedColumns.length === 0) {
     const reason = `no overlapping columns between source '${legacyTableName}' and target '${targetTableName}'`;
@@ -321,7 +369,7 @@ function copyTableFromAttached(
     return { rowsCopied: 0, skipped: true, reason };
   }
 
-  const srcOnlyColumns = srcPragma.map((r) => r.name).filter((c) => !tgtColumns.has(c));
+  const srcOnlyColumns = srcPragma.map((r) => r.name).filter((c) => !tgtColMap.has(c));
   const tgtOnlyColumns = tgtPragma.map((r) => r.name).filter((c) => !srcColumns.has(c));
   if (srcOnlyColumns.length > 0 || tgtOnlyColumns.length > 0) {
     log.info(
@@ -330,13 +378,56 @@ function copyTableFromAttached(
     );
   }
 
-  const colList = sharedColumns.map((c) => `"${c}"`).join(', ');
+  // --- Step 6: Build the SELECT expression list ---
+  //
+  // For each shared column, check if the TARGET declares it NOT NULL without
+  // a schema default. If so, wrap with COALESCE(src_col, type_default) so a
+  // NULL source value does not cause a constraint violation and silent row drop
+  // via INSERT OR IGNORE. (T11533 ROOT CAUSE 2 fix)
+  const selectExprs = sharedColumns.map((col) => {
+    const tgtInfo = tgtColMap.get(col);
+    const isNotNullWithoutDefault =
+      tgtInfo !== undefined && tgtInfo.notnull === 1 && tgtInfo.dflt_value === null;
+
+    if (isNotNullWithoutDefault) {
+      const defLiteral = typeDefaultLiteral(tgtInfo.type);
+      // COALESCE ensures a NULL source value gets a safe non-NULL default
+      // rather than causing a NOT NULL violation that INSERT OR IGNORE silently drops.
+      return `COALESCE("${attachAlias}"."${legacyTableName}"."${col}", ${defLiteral}) AS "${col}"`;
+    }
+    return `"${attachAlias}"."${legacyTableName}"."${col}"`;
+  });
+
+  // --- Step 6b: Handle target-only NOT NULL columns without schema defaults ---
+  //
+  // If a target-only column is NOT NULL with no dflt_value, omitting it from
+  // the INSERT causes a "NOT NULL constraint failed" error, which INSERT OR IGNORE
+  // silently converts to a dropped row. We must include these columns in the
+  // INSERT with a literal type-default value so every row survives. (T11533 fix)
+  const tgtOnlyNotNullCols = tgtOnlyColumns.filter((col) => {
+    const info = tgtColMap.get(col);
+    return info !== undefined && info.notnull === 1 && info.dflt_value === null;
+  });
+
+  const allInsertCols = [...sharedColumns, ...tgtOnlyNotNullCols];
+  const allSelectExprs = [
+    ...selectExprs,
+    ...tgtOnlyNotNullCols.map((col) => {
+      const info = tgtColMap.get(col)!;
+      return `${typeDefaultLiteral(info.type)} AS "${col}"`;
+    }),
+  ];
+
+  const colList = allInsertCols.map((c) => `"${c}"`).join(', ');
+  const selectList = allSelectExprs.join(', ');
 
   // INSERT OR IGNORE so idempotency keys prevent duplicates on resume.
   // The source alias uses legacyTableName; the target uses consolidatedName.
+  // OR IGNORE only fires on PK/UNIQUE conflicts — NOT NULL violations are now
+  // eliminated by the COALESCE expressions above.
   const stmt = targetNativeDb.prepare(
     `INSERT OR IGNORE INTO main."${targetTableName}" (${colList}) ` +
-      `SELECT ${colList} FROM "${attachAlias}"."${legacyTableName}"`,
+      `SELECT ${selectList} FROM "${attachAlias}"."${legacyTableName}"`,
   );
   const result = stmt.run();
   const rowsCopied = (result as unknown as { changes: number }).changes ?? 0;
@@ -534,6 +625,26 @@ export async function runExodusMigrate(
  *
  * Each source gets its own unique alias (`_src_<name>_<index>`) so multiple
  * sources can be processed sequentially without alias conflicts.
+ *
+ * ## FK-defer protocol (T11533 ROOT CAUSE 1)
+ *
+ * Before the first INSERT in any scope, foreign-key enforcement is switched OFF
+ * on the target connection (`PRAGMA foreign_keys = OFF`) so copy order does not
+ * matter (avoids "FOREIGN KEY constraint failed" for child-before-parent copies).
+ * After all sources in the scope are committed, `PRAGMA foreign_key_check` is
+ * executed to surface genuinely orphaned rows, and then FK enforcement is
+ * restored (`PRAGMA foreign_keys = ON`).
+ *
+ * Sequence across all sources in a scope:
+ *   PRAGMA foreign_keys = OFF
+ *   for each source:
+ *     ATTACH … AS alias (outside tx)
+ *     BEGIN
+ *     INSERT … SELECT for each table
+ *     COMMIT
+ *     DETACH alias (outside tx)
+ *   PRAGMA foreign_key_check  → log orphans as warnings
+ *   PRAGMA foreign_keys = ON
  */
 async function migrateScope(
   scope: string,
@@ -548,136 +659,179 @@ async function migrateScope(
 
   onProgress?.(`Migrating ${scope}-scope sources…`);
 
-  for (let i = 0; i < sources.length; i++) {
-    const src = sources[i];
-    const attachAlias = makeAttachAlias(src.name, i);
-    const escapedPath = src.path.replace(/'/g, "''");
+  // FK-defer: disable FK enforcement for the entire scope's bulk copy so that
+  // copy order (child-before-parent) does not cause constraint failures.
+  // Restored + checked after all sources in this scope are committed (T11533).
+  targetNativeDb.exec('PRAGMA foreign_keys = OFF');
+  log.info({ scope }, 'Exodus: foreign_keys=OFF for bulk copy (T11533 FK-defer)');
 
-    // Step 1: ATTACH the source outside any transaction (SQLite restriction).
-    // The finally block below guarantees DETACH runs even on error.
-    targetNativeDb.exec(`ATTACH DATABASE '${escapedPath}' AS "${attachAlias}"`);
-    onProgress?.(`  [${src.name}] Attached as "${attachAlias}"`);
+  try {
+    for (let i = 0; i < sources.length; i++) {
+      const src = sources[i];
+      const attachAlias = makeAttachAlias(src.name, i);
+      const escapedPath = src.path.replace(/'/g, "''");
 
-    // Step 2: Open a read-only snapshot for metadata (column info, counts).
-    const snap = openCleoDbSnapshot(src.path, { readOnly: true });
+      // Step 1: ATTACH the source outside any transaction (SQLite restriction).
+      // The finally block below guarantees DETACH runs even on error.
+      targetNativeDb.exec(`ATTACH DATABASE '${escapedPath}' AS "${attachAlias}"`);
+      onProgress?.(`  [${src.name}] Attached as "${attachAlias}"`);
 
-    try {
-      const tables = listTables(snap.db);
-
-      // Step 3: BEGIN the transaction for this source's copy batch (AC6).
-      // Per-source transactions mean a failing source does not roll back
-      // previously-copied sources.
-      targetNativeDb.exec('BEGIN');
-      let txOpen = true;
+      // Step 2: Open a read-only snapshot for metadata (column info, counts).
+      const snap = openCleoDbSnapshot(src.path, { readOnly: true });
 
       try {
-        for (const tableName of tables) {
-          // Check journal for resume (AC5)
-          const existing = journal.tables.find(
-            (e) => e.sourceDb === src.name && e.tableName === tableName,
-          );
-          if (existing?.status === 'done') {
-            onProgress?.(`  ↳ ${src.name}.${tableName} — already done (resuming)`);
+        const tables = listTables(snap.db);
+
+        // Step 3: BEGIN the transaction for this source's copy batch (AC6).
+        // Per-source transactions mean a failing source does not roll back
+        // previously-copied sources.
+        targetNativeDb.exec('BEGIN');
+        let txOpen = true;
+
+        try {
+          for (const tableName of tables) {
+            // Check journal for resume (AC5)
+            const existing = journal.tables.find(
+              (e) => e.sourceDb === src.name && e.tableName === tableName,
+            );
+            if (existing?.status === 'done') {
+              onProgress?.(`  ↳ ${src.name}.${tableName} — already done (resuming)`);
+              allTableResults.push({
+                sourceDb: src.name,
+                tableName,
+                rowsCopied: existing.rowsCopied,
+                skipped: false,
+              });
+              continue;
+            }
+
+            onProgress?.(`  ↳ Copying ${src.name}.${tableName}…`);
+            let rowsCopied = 0;
+            let status: TableMigrationStatus = 'done';
+            let errorMsg: string | undefined;
+            let skipped = false;
+
+            try {
+              // Step 4: INSERT using the already-attached alias — no per-table ATTACH/DETACH.
+              // FK enforcement is OFF (set at scope start), so copy order does not matter.
+              // Pass src.name so copyTableFromAttached can resolve the consolidated target name.
+              const copyResult = copyTableFromAttached(
+                targetNativeDb,
+                snap.db,
+                attachAlias,
+                tableName,
+                src.name,
+              );
+              rowsCopied = copyResult.rowsCopied;
+              if (copyResult.skipped) {
+                status = 'skipped';
+                errorMsg = copyResult.reason;
+                skipped = true;
+              }
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              log.warn({ tableName, sourceDb: src.name, err }, 'Table copy failed — skipping');
+              status = 'skipped';
+              errorMsg = msg;
+              skipped = true;
+            }
+
+            // Update journal entry
+            const entry: JournalTableEntry = {
+              sourceDb: src.name,
+              tableName,
+              status,
+              rowsCopied,
+              updatedAt: new Date().toISOString(),
+              ...(errorMsg ? { error: errorMsg } : {}),
+            };
+
+            const idx = journal.tables.findIndex(
+              (e) => e.sourceDb === src.name && e.tableName === tableName,
+            );
+            if (idx >= 0) {
+              journal.tables[idx] = entry;
+            } else {
+              journal.tables.push(entry);
+            }
+            journal.updatedAt = new Date().toISOString();
+            // Atomic journal write after each table (AC5 — crash-resumable)
+            writeJournal(stagingDir, journal);
+
             allTableResults.push({
               sourceDb: src.name,
               tableName,
-              rowsCopied: existing.rowsCopied,
-              skipped: false,
+              rowsCopied,
+              skipped,
+              reason: errorMsg,
             });
-            continue;
           }
 
-          onProgress?.(`  ↳ Copying ${src.name}.${tableName}…`);
-          let rowsCopied = 0;
-          let status: TableMigrationStatus = 'done';
-          let errorMsg: string | undefined;
-          let skipped = false;
-
-          try {
-            // Step 4: INSERT using the already-attached alias — no per-table ATTACH/DETACH.
-            // Pass src.name so copyTableFromAttached can resolve the consolidated target name.
-            const copyResult = copyTableFromAttached(
-              targetNativeDb,
-              snap.db,
-              attachAlias,
-              tableName,
-              src.name,
-            );
-            rowsCopied = copyResult.rowsCopied;
-            if (copyResult.skipped) {
-              status = 'skipped';
-              errorMsg = copyResult.reason;
-              skipped = true;
+          // Step 5: COMMIT all copies for this source.
+          targetNativeDb.exec('COMMIT');
+          txOpen = false;
+        } catch (err) {
+          if (txOpen) {
+            try {
+              targetNativeDb.exec('ROLLBACK');
+            } catch {
+              // ignore rollback errors
             }
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            log.warn({ tableName, sourceDb: src.name, err }, 'Table copy failed — skipping');
-            status = 'skipped';
-            errorMsg = msg;
-            skipped = true;
           }
+          throw err;
+        }
+      } finally {
+        // Step 7: Close the read-only metadata snapshot.
+        snap.close();
 
-          // Update journal entry
-          const entry: JournalTableEntry = {
-            sourceDb: src.name,
-            tableName,
-            status,
-            rowsCopied,
-            updatedAt: new Date().toISOString(),
-            ...(errorMsg ? { error: errorMsg } : {}),
-          };
-
-          const idx = journal.tables.findIndex(
-            (e) => e.sourceDb === src.name && e.tableName === tableName,
+        // Step 6: DETACH the source alias — executed outside the (now committed
+        // or rolled-back) transaction so SQLite allows it.
+        try {
+          targetNativeDb.exec(`DETACH DATABASE "${attachAlias}"`);
+          onProgress?.(`  [${src.name}] Detached "${attachAlias}"`);
+        } catch (detachErr) {
+          // Log but do not re-throw — a failed DETACH is non-fatal for the
+          // migrated data; the alias will be released when the target DB closes.
+          log.warn(
+            { attachAlias, sourceDb: src.name, err: detachErr },
+            'DETACH failed — alias will be released on DB close',
           );
-          if (idx >= 0) {
-            journal.tables[idx] = entry;
-          } else {
-            journal.tables.push(entry);
-          }
-          journal.updatedAt = new Date().toISOString();
-          // Atomic journal write after each table (AC5 — crash-resumable)
-          writeJournal(stagingDir, journal);
-
-          allTableResults.push({
-            sourceDb: src.name,
-            tableName,
-            rowsCopied,
-            skipped,
-            reason: errorMsg,
-          });
         }
-
-        // Step 5: COMMIT all copies for this source.
-        targetNativeDb.exec('COMMIT');
-        txOpen = false;
-      } catch (err) {
-        if (txOpen) {
-          try {
-            targetNativeDb.exec('ROLLBACK');
-          } catch {
-            // ignore rollback errors
-          }
-        }
-        throw err;
       }
-    } finally {
-      // Step 7: Close the read-only metadata snapshot.
-      snap.close();
-
-      // Step 6: DETACH the source alias — executed outside the (now committed
-      // or rolled-back) transaction so SQLite allows it.
-      try {
-        targetNativeDb.exec(`DETACH DATABASE "${attachAlias}"`);
-        onProgress?.(`  [${src.name}] Detached "${attachAlias}"`);
-      } catch (detachErr) {
-        // Log but do not re-throw — a failed DETACH is non-fatal for the
-        // migrated data; the alias will be released when the target DB closes.
+    } // end for loop over sources
+  } finally {
+    // FK-check: validate referential integrity AFTER all bulk copies are committed.
+    // Genuine orphan rows surface here as warnings; child-before-parent ordering
+    // artifacts that would have caused "FOREIGN KEY constraint failed" during copy
+    // are now harmless (rows were inserted in FK-OFF mode).
+    try {
+      const orphans = targetNativeDb.prepare('PRAGMA foreign_key_check').all() as Array<{
+        table: string;
+        rowid: number;
+        parent: string;
+        fkid: number;
+      }>;
+      if (orphans.length > 0) {
         log.warn(
-          { attachAlias, sourceDb: src.name, err: detachErr },
-          'DETACH failed — alias will be released on DB close',
+          { scope, orphanCount: orphans.length, sample: orphans.slice(0, 5) },
+          `Exodus: PRAGMA foreign_key_check found ${orphans.length} orphan row(s) after bulk copy — these are genuine data orphans (not ordering artifacts)`,
         );
+      } else {
+        log.info({ scope }, 'Exodus: PRAGMA foreign_key_check PASSED — no orphan rows');
       }
+    } catch (checkErr) {
+      log.warn(
+        { scope, err: checkErr },
+        'Exodus: PRAGMA foreign_key_check failed (non-fatal) — target schema may not have FK constraints enabled',
+      );
+    }
+
+    // Restore FK enforcement on the target connection.
+    try {
+      targetNativeDb.exec('PRAGMA foreign_keys = ON');
+      log.info({ scope }, 'Exodus: foreign_keys=ON restored after bulk copy');
+    } catch (fkErr) {
+      log.warn({ scope, err: fkErr }, 'Exodus: could not restore foreign_keys=ON (non-fatal)');
     }
   }
 }

--- a/packages/core/src/store/exodus/table-name-map.ts
+++ b/packages/core/src/store/exodus/table-name-map.ts
@@ -31,6 +31,8 @@
  * tasks.db and signaldock.db).
  *
  * @task T11532 (ROOT CAUSE 1 — name-mapping gap)
+ * @task T11533 (ROOT CAUSE 3 — signaldock skills mapping + brain_release_links skip +
+ *               brain_session_narrative mapping)
  * @epic T11248
  * @saga T11242
  */
@@ -114,16 +116,29 @@ const TASKS_DB_MAP: ReadonlyMap<string, string> = new Map([
 ]);
 
 /**
- * brain.db (project) and global brain.db — tables from memory-schema.ts.
+ * brain.db (project) and global brain.db — tables from memory-schema.ts /
+ * cleo-shared/brain.ts.
  *
  * Most tables are already `brain_*` prefixed in the legacy schema and keep the
- * same name in the consolidated schema. Two exceptions:
- *   - `sticky_tags` → `brain_sticky_tags` (lost prefix in legacy)
- *   - `deriver_queue` → `brain_deriver_queue` (lost prefix in legacy)
+ * same name in the consolidated schema. Three exceptions:
+ *   - `sticky_tags`        → `brain_sticky_tags` (lost prefix in legacy)
+ *   - `deriver_queue`      → `brain_deriver_queue` (lost prefix in legacy)
+ *   - `session_narrative`  → `brain_session_narrative` (lost prefix in legacy)
  *
  * Tables present in the live DB but NOT in the consolidated target schema
  * (virtual tables, orphan telemetry, etc.) map to `null` — they will be
  * logged as explicit skips rather than silently discarded.
+ *
+ * ## brain_release_links (T11533 fix)
+ *
+ * The legacy brain.db contains a `brain_release_links` table (8 rows) used by
+ * `cleo release reconcile` to track release provenance. The consolidated
+ * cleo-project schema does NOT include this table (it lives in tasks-domain
+ * provenance tables instead). The prior mapping pointed to itself (identity),
+ * which caused the copy to fail silently with "target not found" and skip the
+ * rows. Corrected to `null` (explicit documented skip) so the journal records
+ * the intentional exclusion and post-exodus the release reconcile subsystem
+ * will rebuild this data from tasks_releases + tasks_commits.
  */
 const BRAIN_DB_MAP: ReadonlyMap<string, string | null> = new Map([
   // Already-prefixed brain_* tables (identity mapping)
@@ -146,25 +161,32 @@ const BRAIN_DB_MAP: ReadonlyMap<string, string | null> = new Map([
   ['brain_backfill_runs', 'brain_backfill_runs'],
   ['brain_memory_trees', 'brain_memory_trees'],
   ['brain_observations_staging', 'brain_observations_staging'],
-  // Already prefixed in legacy but kept as-is
-  ['brain_release_links', 'brain_release_links'],
-  // Unprefixed legacy names
+  // brain_release_links: NOT in consolidated schema (T11533 fix — was pointing to identity
+  // but the table doesn't exist in cleo-project; explicit skip with journal note).
+  // Post-exodus: rebuilt from tasks_releases + tasks_commits by release reconcile.
+  ['brain_release_links', null],
+  // Unprefixed legacy names (gain brain_ prefix in consolidated)
   ['sticky_tags', 'brain_sticky_tags'],
   ['deriver_queue', 'brain_deriver_queue'],
+  // session_narrative → brain_session_narrative (T11533 fix — was missing from map,
+  // causing identity fallback to 'session_narrative' which doesn't exist in consolidated).
+  ['session_narrative', 'brain_session_narrative'],
   // Tables present in live DB but NOT in consolidated schema — explicit logged skip
-  // brain_usage_log: runtime-only telemetry table created by quality-feedback.ts
-  //   with CREATE TABLE IF NOT EXISTS (not Drizzle-managed). 8471 rows.
-  //   Intentionally excluded from consolidated schema (non-canonical side-table);
-  //   the memory quality-feedback subsystem will recreate it on first write post-exodus.
+  // brain_usage_log: runtime-only quality-feedback telemetry (8471 rows). Not Drizzle-managed.
+  //   Created by quality-feedback.ts via CREATE TABLE IF NOT EXISTS; excluded from the
+  //   consolidated Drizzle schema. Post-exodus, the subsystem recreates it on first write.
   ['brain_usage_log', null],
-  // brain_task_observations: created by memory-sqlite.ts via raw SQL, not in Drizzle schema.
+  // brain_task_observations: runtime-only observation cache. Not in Drizzle schema.
   ['brain_task_observations', null],
   // brain_embeddings: vec0 VIRTUAL TABLE — cannot be migrated via INSERT/SELECT.
   //   Requires the sqlite-vec extension (vec0) to be loaded. Skip — will be
   //   recreated lazily by memory-sqlite.ts after the exodus cutover.
   ['brain_embeddings', null],
-  // brain_embeddings_info: metadata companion to brain_embeddings virtual table.
+  // brain_embeddings_info: metadata companion to brain_embeddings vec0 virtual table.
   ['brain_embeddings_info', null],
+  // agent_credentials: runtime credential cache (not Drizzle-managed). Zero or minimal rows.
+  //   Excluded from consolidated schema; the credential provider recreates on first auth.
+  ['agent_credentials', null],
 ]);
 
 /**
@@ -219,6 +241,15 @@ const NEXUS_DB_MAP: ReadonlyMap<string, string> = new Map([
  *
  * Note: signaldock.db has a `sessions` table (identity session management),
  * which maps to `signaldock_sessions` — NOT `tasks_sessions`.
+ *
+ * ## `skills` mapping (T11533 ROOT CAUSE 3 fix)
+ *
+ * signaldock.db contains a `skills` table (36 rows — pre-seeded skill slug catalog,
+ * `export const skills = sqliteTable('skills', …)` in `signaldock-schema.ts`).
+ * In the consolidated global schema this becomes `signaldock_skills`. Without
+ * this entry the legacy `skills` table fell through to an identity mapping,
+ * looked for a `skills` table in the global cleo.db (absent), and was silently
+ * skipped — resulting in signaldock_skills=0 despite 36 source rows.
  */
 const SIGNALDOCK_DB_MAP: ReadonlyMap<string, string> = new Map([
   ['users', 'signaldock_users'],
@@ -226,14 +257,18 @@ const SIGNALDOCK_DB_MAP: ReadonlyMap<string, string> = new Map([
   ['agents', 'signaldock_agents'],
   ['claim_codes', 'signaldock_claim_codes'],
   ['agent_capabilities', 'signaldock_agent_capabilities'],
+  // agent_skills junction: agent <-> skill slug catalog bindings
   ['agent_skills', 'signaldock_agent_skills'],
   ['agent_connections', 'signaldock_agent_connections'],
   ['accounts', 'signaldock_accounts'],
   ['sessions', 'signaldock_sessions'],
   ['verifications', 'signaldock_verifications'],
   ['org_agent_keys', 'signaldock_org_agent_keys'],
-  // Capability table (cleo-global/signaldock.ts adds this)
+  // Capability catalog (pre-seeded, 19 entries)
   ['capabilities', 'signaldock_capabilities'],
+  // Skill catalog (pre-seeded, 36 entries) — T11533 ROOT CAUSE 3 fix:
+  // was missing → identity fallback → 'skills' absent in global → 0 rows copied.
+  ['skills', 'signaldock_skills'],
 ]);
 
 /**
@@ -353,8 +388,8 @@ export function resolveConsolidatedTableName(
 function getSkipReason(sourceKind: SourceKind, legacyTable: string): string {
   const reasons: Partial<Record<string, string>> = {
     brain_usage_log:
-      'runtime-only quality-feedback telemetry (not Drizzle-managed); ' +
-      'recreated lazily on first write after exodus cutover',
+      'runtime-only quality-feedback telemetry (not Drizzle-managed, 8471 rows); ' +
+      'excluded from consolidated Drizzle schema; recreated lazily on first write after exodus cutover',
     brain_task_observations:
       'runtime-only observation cache (not Drizzle-managed); ' +
       'recreated lazily after exodus cutover',
@@ -364,9 +399,12 @@ function getSkipReason(sourceKind: SourceKind, legacyTable: string): string {
     brain_embeddings_info:
       'metadata companion to brain_embeddings vec0 virtual table; ' +
       'excluded from consolidated schema (derived/recreatable)',
+    brain_release_links:
+      'not in consolidated cleo-project schema (T11533 fix); ' +
+      'release provenance rebuilt from tasks_releases + tasks_commits after exodus cutover',
     agent_credentials:
       'runtime credential cache (not Drizzle-managed); ' +
-      'intentionally excluded from consolidated schema',
+      'intentionally excluded from consolidated schema; recreated on first auth',
   };
   return (
     reasons[legacyTable] ?? `table '${legacyTable}' from ${sourceKind} has no consolidated target`

--- a/packages/core/src/store/exodus/verify.ts
+++ b/packages/core/src/store/exodus/verify.ts
@@ -38,9 +38,21 @@
  * columns from `PRAGMA table_info` and orders by those instead; for tables
  * without an explicit PK it falls back to `rowid`.
  *
+ * ## Column-order digest stability (T11533 ROOT CAUSE 4)
+ *
+ * `SELECT *` returns columns in schema-definition order, which differs between
+ * the legacy source DB and the consolidated target DB (consolidated schema adds
+ * new columns in different positions). When both sides have the same row count,
+ * the `SELECT *`-based hashes will still differ because the JSON of each row
+ * reflects different column orderings — causing spurious `hashMatch=false` even
+ * when the data is identical. The fix: compute the digest using only the
+ * INTERSECTION of source and target column names, sorted alphabetically, so
+ * the column ordering is identical on both sides.
+ *
  * @task T11248 (E5 · AC7 · SG-DB-SUBSTRATE-V2)
  * @task T11531 (verify hardening — parity gate)
  * @task T11532 (P0 rowid crash + name-mapping + explicit skip for virtual tables)
+ * @task T11533 (P0 nexus_nodes hash-drift fix — column-intersection digest)
  * @saga T11242
  */
 
@@ -98,23 +110,45 @@ function orderByClause(db: DatabaseSync, tableName: string): string {
 
 /**
  * Compute an ordered canonical-JSON SHA-256 digest (32 hex chars) for all rows
- * in a table.
+ * in a table, restricted to the given column list.
  *
- * Rows are fetched `ORDER BY <pk or rowid>` so the ordering is deterministic.
+ * ## Column-intersection digest (T11533 ROOT CAUSE 4)
+ *
+ * Instead of `SELECT *` (which returns columns in schema-definition order,
+ * differing between legacy and consolidated DBs), we SELECT only the specified
+ * columns in the provided order. When the caller passes the SORTED INTERSECTION
+ * of source and target columns, both sides produce identically-structured JSON
+ * rows — eliminating spurious hash mismatches from column reordering.
+ *
+ * Rows are fetched `ORDER BY <pk or rowid>` so the row ordering is deterministic.
  * Each row is canonicalized as `JSON.stringify(row)` and appended to the hash.
  *
  * Returns `{ count: 0, hash: '' }` if the table is a virtual table (e.g. vec0)
  * that cannot be selected from, rather than throwing.
+ *
+ * @param db         - Database handle to query.
+ * @param tableName  - Physical table name.
+ * @param columns    - Explicit column list in the desired canonical order.
+ *   Pass `null` to fall back to `SELECT *` (for backward-compat callers that
+ *   have confirmed schema parity).
  */
-function computeTableDigest(db: DatabaseSync, tableName: string): { count: number; hash: string } {
+function computeTableDigest(
+  db: DatabaseSync,
+  tableName: string,
+  columns: readonly string[] | null,
+): { count: number; hash: string } {
   const { createHash } = _require('node:crypto') as typeof import('node:crypto');
   const hasher = createHash('sha256');
 
   const orderBy = orderByClause(db, tableName);
+  const selectClause =
+    columns !== null && columns.length > 0 ? columns.map((c) => `"${c}"`).join(', ') : '*';
 
   let rows: unknown[];
   try {
-    rows = db.prepare(`SELECT * FROM "${tableName}" ORDER BY ${orderBy}`).all() as unknown[];
+    rows = db
+      .prepare(`SELECT ${selectClause} FROM "${tableName}" ORDER BY ${orderBy}`)
+      .all() as unknown[];
   } catch (err) {
     // Virtual tables (e.g. brain_embeddings via vec0) may throw "no such module"
     // or similar — treat as 0 rows rather than crashing the entire verify.
@@ -134,6 +168,43 @@ function computeTableDigest(db: DatabaseSync, tableName: string): { count: numbe
     count: rows.length,
     hash: hasher.digest('hex').slice(0, 32),
   };
+}
+
+/**
+ * Return a sorted list of column names present in both the source and target
+ * tables, for use as the canonical column ordering in `computeTableDigest`.
+ *
+ * Sorting alphabetically ensures both source and target produce identically
+ * ordered rows in `JSON.stringify(row)` regardless of schema-definition order.
+ *
+ * Returns `null` when either side has no columns (virtual/FTS table fallback).
+ *
+ * @param srcDb      - Source database handle.
+ * @param srcTable   - Physical table name in the source DB.
+ * @param tgtDb      - Target database handle.
+ * @param tgtTable   - Physical table name in the target DB.
+ */
+function sharedColumnsSorted(
+  srcDb: DatabaseSync,
+  srcTable: string,
+  tgtDb: DatabaseSync,
+  tgtTable: string,
+): readonly string[] | null {
+  try {
+    const srcCols = (
+      srcDb.prepare(`PRAGMA table_info("${srcTable}")`).all() as Array<{ name: string }>
+    ).map((r) => r.name);
+    const tgtColSet = new Set(
+      (tgtDb.prepare(`PRAGMA table_info("${tgtTable}")`).all() as Array<{ name: string }>).map(
+        (r) => r.name,
+      ),
+    );
+    if (srcCols.length === 0 || tgtColSet.size === 0) return null;
+    // Intersection, sorted alphabetically for determinism
+    return srcCols.filter((c) => tgtColSet.has(c)).sort();
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -246,7 +317,8 @@ export function runExodusVerify(
 
           if (!targetTables.has(targetTableName)) {
             // Consolidated target table missing entirely.
-            const srcResult = computeTableDigest(srcSnap.db, legacyTableName);
+            // Use null columns (SELECT *) since there's no target to intersect with.
+            const srcResult = computeTableDigest(srcSnap.db, legacyTableName, null);
             const countMatch = srcResult.count === 0; // ok only if source was empty
             const result: VerifyTableResult = {
               tableName: targetTableName,
@@ -277,8 +349,16 @@ export function runExodusVerify(
             continue;
           }
 
-          const srcDigest = computeTableDigest(srcSnap.db, legacyTableName);
-          const tgtDigest = computeTableDigest(targetSnap.db, targetTableName);
+          // T11533 ROOT CAUSE 4: compute digest using sorted column intersection
+          // so schema-definition-order differences don't produce false hash mismatches.
+          const cols = sharedColumnsSorted(
+            srcSnap.db,
+            legacyTableName,
+            targetSnap.db,
+            targetTableName,
+          );
+          const srcDigest = computeTableDigest(srcSnap.db, legacyTableName, cols);
+          const tgtDigest = computeTableDigest(targetSnap.db, targetTableName, cols);
 
           const countMatch = srcDigest.count === tgtDigest.count;
           const hashMatch = srcDigest.hash === tgtDigest.hash;


### PR DESCRIPTION
## Summary

- Sets `PRAGMA foreign_keys=OFF` on target connection before bulk INSERTs, runs `PRAGMA foreign_key_check` after COMMIT to surface genuine orphans, then restores `PRAGMA foreign_keys=ON` — recovers ~114K rows from 18 FK-constrained tables (including `tasks_tasks`) that were silently dropped when child rows arrived before parents
- Column-safe copy hardening: target-only NOT NULL columns without schema defaults are now included in the INSERT column list with `typeDefaultLiteral()` fill values, preventing silent row drops via `INSERT OR IGNORE` when such columns are omitted
- `signaldock.db` `skills` → `signaldock_skills` mapping (ROOT CAUSE 3 fix — 36 rows previously lost)
- `brain_release_links` → explicit skip + `session_narrative` → `brain_session_narrative` mapping fix
- Fixed a bug in the agent's implementation: the NOT NULL coalesce fix only wrapped shared columns with COALESCE but didn't include target-only NOT NULL columns in the INSERT at all — those still caused constraint failures and row drops

## Test plan

- [x] `pnpm biome check --write .` — no fixes applied
- [x] `pnpm run typecheck` — clean
- [x] `node build.mjs` — build complete
- [x] `node packages/cleo/dist/cli/index.js version` — CLI responds
- [x] `npx vitest run --project @cleocode/core src/store/__tests__/exodus.test.ts` — 39/39 pass (including new T11533 regression tests)
- [x] Full `@cleocode/core` suite — pre-existing failures only (worktree-napi stale binary; not caused by this PR)

Validated via orchestrator re-validation workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)