### PR TITLE
feat(T11474): export atomic fs/shell/guard primitives through createToolGuard chokepoint (E-TOOLS-WIRE)

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1669,9 +1669,16 @@ export {
   parseIssueTemplates,
 } from './templates/parser.js';
 // Tool guard — deny-first guarded primitive surface (T11407) consumed by the
-// in-process skill executor (T11477).
+// in-process skill executor (T11477). The date-gated default-mode mechanism
+// (T11474 · AC4) is also surfaced so consumers can read/observe the flip state.
 export type { GuardMode, ToolGuard, ToolGuardPolicy } from './tools/guard.js';
-export { createToolGuard, GuardDeniedError } from './tools/guard.js';
+export {
+  createToolGuard,
+  GUARD_ENFORCE_DEADLINE,
+  GUARD_ENFORCE_FLIP_ENABLED,
+  GuardDeniedError,
+  resolveDefaultGuardMode,
+} from './tools/guard.js';
 export type { DiagnoseFinding, DiagnoseResult, UpgradeSummary } from './upgrade.js';
 // Upgrade
 export { diagnoseUpgrade, runUpgrade } from './upgrade.js';

--- a/packages/core/src/skills/__tests__/skill-executor-guard-wire.test.ts
+++ b/packages/core/src/skills/__tests__/skill-executor-guard-wire.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration test for the wired atomic-tool chain (T11474 · E-TOOLS-WIRE · AC3).
+ *
+ * Proves the END-TO-END joint the wire-or-revert rule requires: a `ct-*` skill
+ * node, run in-process by the {@link SkillExecutorAdapter} (T11477 · #897),
+ * reaches the atomic fs/shell primitives ONLY through a REAL
+ * {@link createToolGuard} deny-first chokepoint — not a stub. This closes the
+ * loop AC1 (barrel exports the guard) → AC2 (atomic calls funnel through the
+ * guard) → AC3 (a skill node calls `readFileText` / `executeShell` via the
+ * guard).
+ *
+ * Distinct from `skill-executor-adapter.test.ts`, which exercises the adapter
+ * against a recording STUB surface. Here the injected surface is the production
+ * `createToolGuard({ allowedRoots: [...] })` result, so the test also covers the
+ * guard's allow/deny behavior on the path AND command axes through the runner.
+ *
+ * @task T11474
+ * @epic T11391
+ * @saga T11387
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ExecuteShellResult } from '@cleocode/contracts/tools/atomic';
+import type { SkillExecuteInput } from '@cleocode/contracts/tools/skill-executor';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SkillExecutorAdapter } from '../../skills/skill-executor-adapter.js';
+import { createToolGuard, GuardDeniedError } from '../../tools/index.js';
+
+let projectRoot: string;
+let prevProjectRoot: string | undefined;
+
+/** Deterministic shell executor — never spawns a real subprocess. */
+const fakeExec = (): Promise<ExecuteShellResult> =>
+  Promise.resolve({ stdout: 'pong', stderr: '', code: 0 });
+
+/**
+ * Write a fixture `ct-*` skill into `<projectRoot>/.agents/skills/<id>/SKILL.md`
+ * so {@link SkillExecutorAdapter}'s `findSkill()` resolves it in-process.
+ */
+function createFixtureSkill(id: string): void {
+  const skillDir = join(projectRoot, '.agents', 'skills', id);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: ${id}\ndescription: probe\n---\nBody`);
+}
+
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), 'cleo-tools-wire-'));
+  prevProjectRoot = process.env['CLEO_PROJECT_ROOT'];
+  process.env['CLEO_PROJECT_ROOT'] = projectRoot;
+});
+
+afterEach(() => {
+  if (prevProjectRoot === undefined) {
+    delete process.env['CLEO_PROJECT_ROOT'];
+  } else {
+    process.env['CLEO_PROJECT_ROOT'] = prevProjectRoot;
+  }
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('atomic-tool wiring through the guard (T11474 · AC3)', () => {
+  it('a resolved skill node reads a file and runs a command via a REAL createToolGuard', async () => {
+    createFixtureSkill('ct-tools-wire-probe');
+    const tools = createToolGuard({ allowedRoots: [projectRoot] });
+    const target = join(projectRoot, 'note.txt');
+
+    const adapter = new SkillExecutorAdapter({
+      cwd: projectRoot,
+      // A model-phase runner stand-in: it sequences atomic primitives entirely
+      // through the injected guard (input.tools), never touching raw fs/shell.
+      runner: async (_skill, input: SkillExecuteInput) => {
+        await input.tools.writeFileAtomic({ path: target, content: 'hello' });
+        const { content } = await input.tools.readFileText({ path: target });
+        const { stdout, code } = await input.tools.executeShell(
+          { command: 'echo', args: ['ping'] },
+          fakeExec,
+        );
+        return { status: 'success', output: { content, stdout, code } };
+      },
+    });
+
+    const result = await adapter.execute({
+      skillId: 'ct-tools-wire-probe',
+      context: {},
+      tools,
+    });
+
+    // The skill resolved in-process and its runner reached readFileText +
+    // executeShell THROUGH the guard chokepoint (AC3) — the wire-or-revert joint.
+    expect(result.status).toBe('success');
+    expect(result.output['content']).toBe('hello');
+    expect(result.output['stdout']).toBe('pong');
+    expect(result.output['code']).toBe(0);
+  });
+
+  it('guard surface (as injected into a skill node) reads/writes/execs in-process', async () => {
+    const tools = createToolGuard({ allowedRoots: [projectRoot] });
+    const target = join(projectRoot, 'note.txt');
+
+    // Drive the guarded surface exactly as a SkillExecutorAdapter runner would
+    // (input.tools.*) — proving readFileText + executeShell are reachable via
+    // the guard chokepoint (AC3) with no raw-primitive import in sight.
+    await tools.writeFileAtomic({ path: target, content: 'hello' });
+    const { content } = await tools.readFileText({ path: target });
+    const { stdout, code } = await tools.executeShell(
+      { command: 'echo', args: ['ping'] },
+      fakeExec,
+    );
+
+    expect(content).toBe('hello');
+    expect(stdout).toBe('pong');
+    expect(code).toBe(0);
+  });
+
+  it('enforce-mode guard denies an out-of-root read before any fs touch (AC2)', async () => {
+    const tools = createToolGuard({ allowedRoots: [projectRoot], mode: 'enforce' });
+    await expect(tools.readFileText({ path: '/etc/cleo-should-not-exist' })).rejects.toBeInstanceOf(
+      GuardDeniedError,
+    );
+  });
+
+  it('enforce-mode guard denies a denylisted command before spawn (AC2)', async () => {
+    const tools = createToolGuard({
+      allowedRoots: [projectRoot],
+      deniedCommands: ['rm'],
+      mode: 'enforce',
+    });
+    await expect(
+      tools.executeShell({ command: 'rm', args: ['-rf', projectRoot] }, fakeExec),
+    ).rejects.toBeInstanceOf(GuardDeniedError);
+  });
+
+  it('the barrel exposes the guard, NOT the raw bypassable primitives (AC1 · AC2)', async () => {
+    const barrel = await import('../../tools/index.js');
+    // Guarded entrypoint + date-gated mechanism are public…
+    expect(typeof barrel.createToolGuard).toBe('function');
+    expect(typeof barrel.resolveDefaultGuardMode).toBe('function');
+    expect(typeof barrel.GUARD_ENFORCE_DEADLINE).toBe('string');
+    expect(barrel.GUARD_ENFORCE_FLIP_ENABLED).toBe(false);
+    // …but the raw side-effecting primitives are NOT re-exported from the barrel
+    // (no public bypass of the chokepoint).
+    const surfaced = Object.keys(barrel);
+    expect(surfaced).not.toContain('writeFileAtomic');
+    expect(surfaced).not.toContain('executeShell');
+    expect(surfaced).not.toContain('runGit');
+    expect(surfaced).not.toContain('readFileText');
+  });
+});
+
+describe('date-gated default mode mechanism (T11474 · AC4)', () => {
+  it('default mode is held at warn while the owner flip is disabled', async () => {
+    const { resolveDefaultGuardMode, GUARD_ENFORCE_FLIP_ENABLED } = await import(
+      '../../tools/guard.js'
+    );
+    // The flip is owner-gated and currently held off.
+    expect(GUARD_ENFORCE_FLIP_ENABLED).toBe(false);
+    // …so the date-gate yields warn regardless of the instant evaluated.
+    expect(resolveDefaultGuardMode(new Date('2000-01-01T00:00:00.000Z'))).toBe('warn');
+    expect(resolveDefaultGuardMode(new Date('2099-01-01T00:00:00.000Z'))).toBe('warn');
+  });
+
+  it('an unconfigured guard defaults to warn (no throw on an out-of-root path)', async () => {
+    const other = mkdtempSync(join(tmpdir(), 'cleo-tools-wire-other-'));
+    try {
+      const tools = createToolGuard({ allowedRoots: [projectRoot] }); // mode omitted
+      const res = await tools.writeFileAtomic({
+        path: join(other, 'x.txt'),
+        content: 'ok',
+      });
+      expect(res.bytesWritten).toBe(2); // warn-then-proceed (default held at warn)
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/tools/guard.ts
+++ b/packages/core/src/tools/guard.ts
@@ -15,6 +15,24 @@
  * effect. The boundary lint (T11409) later makes the guarded surface the only
  * public one.
  *
+ * ## Date-gated default flip (T11474 · AC4)
+ *
+ * The default posture is governed by {@link resolveDefaultGuardMode}, a
+ * date-gated mechanism keyed on {@link GUARD_ENFORCE_DEADLINE}. Until that
+ * deadline passes the default stays `warn`; on/after it the date-gate WOULD
+ * yield `enforce`.
+ *
+ * The flip is, however, an **owner-gated decision** and is NOT auto-applied.
+ * Per the owner-ratified self-shaping hard-gate (BRAIN `O-mpt8gjdx-0`,
+ * 2026-05-30), flipping this default to `enforce` is one of THREE gates that
+ * together unblock dynamic tool/skill forging; the other two — an approval-token
+ * CONDUIT gate and a discretion rate-limit (`DiscretionEvaluator`) — are NOT yet
+ * live. So the live default is held at `warn` behind
+ * {@link GUARD_ENFORCE_FLIP_ENABLED} (currently `false`); the mechanism is
+ * encoded but the flip awaits explicit owner confirmation that (a) the deadline
+ * has passed AND (b) the full suite is green with `enforce` on. Flip by setting
+ * `GUARD_ENFORCE_FLIP_ENABLED = true` once those conditions hold.
+ *
  * @epic T11390
  * @task T11407
  * @saga T11387
@@ -41,6 +59,60 @@ const log = getLogger('tool-guard');
 /** Enforcement posture for a {@link ToolGuard}. */
 export type GuardMode = 'warn' | 'enforce';
 
+/**
+ * Owner-set deadline (ISO-8601 date, UTC) after which the guard's DATE-GATE
+ * would yield `enforce` as the default posture.
+ *
+ * This is the date leg of the warn→enforce flip (T11474 · AC4). It is a single
+ * source of truth — change this one const to move the date. The flip is NOT
+ * applied on this date alone: it is additionally held behind
+ * {@link GUARD_ENFORCE_FLIP_ENABLED} (an owner-gated kill-switch), because the
+ * owner-ratified self-shaping hard-gate (BRAIN `O-mpt8gjdx-0`) requires two
+ * sibling systems (approval-token CONDUIT gate + discretion rate-limit) to be
+ * live before `enforce` becomes the default.
+ *
+ * @remarks Placeholder owner-TBD value held one year out — the live default
+ *   stays `warn` regardless via {@link GUARD_ENFORCE_FLIP_ENABLED}. Replace with
+ *   the real ratified date when the owner sets it.
+ */
+export const GUARD_ENFORCE_DEADLINE = '2027-01-01T00:00:00.000Z';
+
+/**
+ * Owner-gated master switch for the warn→enforce default flip.
+ *
+ * When `false` (the current, held state), the live default is ALWAYS `warn`
+ * regardless of {@link GUARD_ENFORCE_DEADLINE} — the date-gate is encoded but
+ * inert. Set to `true` ONLY when the owner confirms (a) the deadline has passed,
+ * (b) the full suite is green with `enforce` on, and (c) the sibling self-shaping
+ * gates are live (BRAIN `O-mpt8gjdx-0`). This indirection keeps the mechanism in
+ * source without a silent, date-triggered behavior change.
+ */
+export const GUARD_ENFORCE_FLIP_ENABLED = false;
+
+/**
+ * Resolve the date-gated default {@link GuardMode}.
+ *
+ * Returns `enforce` only when BOTH the owner master switch
+ * ({@link GUARD_ENFORCE_FLIP_ENABLED}) is on AND `now` is at/after
+ * {@link GUARD_ENFORCE_DEADLINE}; otherwise `warn`. Callers that pass an
+ * explicit `policy.mode` to {@link createToolGuard} bypass this entirely.
+ *
+ * @param now - The instant to evaluate the deadline against; defaults to the
+ *   current time. Injectable so unit tests can assert both sides of the gate
+ *   without clock manipulation.
+ * @returns `'enforce'` once the gate fully opens, else `'warn'`.
+ *
+ * @example
+ * ```ts
+ * // Today (switch off): always 'warn'
+ * resolveDefaultGuardMode(); // 'warn'
+ * ```
+ */
+export function resolveDefaultGuardMode(now: Date = new Date()): GuardMode {
+  if (!GUARD_ENFORCE_FLIP_ENABLED) return 'warn';
+  return now.getTime() >= Date.parse(GUARD_ENFORCE_DEADLINE) ? 'enforce' : 'warn';
+}
+
 /** Deny-first policy for the tool guard. */
 export interface ToolGuardPolicy {
   /**
@@ -55,7 +127,11 @@ export interface ToolGuardPolicy {
    * segment.
    */
   readonly deniedCommands?: readonly string[];
-  /** `'warn'` (default) logs + proceeds; `'enforce'` throws before the effect. */
+  /**
+   * `'warn'` logs + proceeds; `'enforce'` throws before the effect. When
+   * omitted, the default comes from the date-gated {@link resolveDefaultGuardMode}
+   * (held at `'warn'` until the owner-gated flip — see {@link GUARD_ENFORCE_DEADLINE}).
+   */
   readonly mode?: GuardMode;
 }
 
@@ -107,7 +183,9 @@ function deniedCommand(command: string, denied: readonly string[]): string | nul
  * ```
  */
 export function createToolGuard(policy: ToolGuardPolicy = {}): ToolGuard {
-  const mode: GuardMode = policy.mode ?? 'warn';
+  // Explicit policy.mode always wins; otherwise the date-gated default applies
+  // (held at 'warn' behind the owner-gated flip — T11474 · AC4).
+  const mode: GuardMode = policy.mode ?? resolveDefaultGuardMode();
 
   const denyFs = (op: string, path: string): boolean => {
     if (!policy.allowedRoots || policy.allowedRoots.length === 0) return false;

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -10,7 +10,26 @@
  *   provider.*   - CAAMP provider registry
  *   adapter.*    - Provider adapter management
  *
+ * ## Atomic-tool surface (T11474 · E-TOOLS-WIRE)
+ *
+ * The barrel ALSO exposes the atomic fs/shell tool layer (E3) — but ONLY through
+ * the deny-first {@link createToolGuard} chokepoint. The raw side-effecting
+ * primitives (`writeFileAtomic`, `executeShell`, `runGit`, …) are deliberately
+ * NOT re-exported here: a consumer obtains them by calling `createToolGuard()`
+ * and using the returned {@link ToolGuard} surface, so every fs/shell call is
+ * funnelled through one policy point and there is no public bypass (AC2). What
+ * is exported from the atomic layer:
+ *   - {@link createToolGuard} + {@link ToolGuard} / {@link ToolGuardPolicy} /
+ *     {@link GuardMode} / {@link GuardDeniedError} — the guarded entrypoint.
+ *   - {@link GUARD_ENFORCE_DEADLINE} / {@link GUARD_ENFORCE_FLIP_ENABLED} /
+ *     {@link resolveDefaultGuardMode} — the date-gated default-mode mechanism
+ *     (held at `warn` behind the owner-gated flip, AC4).
+ *   - {@link ShellExecutor} + {@link defaultShellExecutor} — the injectable
+ *     process layer threaded INTO the guard's `executeShell`/`runGit` (does not
+ *     bypass policy; it is the substitutable subprocess mechanism).
+ *
  * @task T1575 — ENG-MIG-8
+ * @task T11474 — E-TOOLS-WIRE (atomic-tool surface through the guard)
  * @epic T1566
  */
 
@@ -63,3 +82,18 @@ export { scaffoldProject } from '../scaffold/scaffold-project.js';
 export * from '../sdk/index.js';
 // TaskTools (Category B) — pure-functional task graph SDK tools (T10068 / T9835)
 export * from '../task-tools/index.js';
+// Atomic-tool guard chokepoint (E3 · T11407 · T11474) — the ONLY public route to
+// the fs/shell primitives. Raw primitives are intentionally not re-exported.
+export {
+  createToolGuard,
+  GUARD_ENFORCE_DEADLINE,
+  GUARD_ENFORCE_FLIP_ENABLED,
+  GuardDeniedError,
+  type GuardMode,
+  resolveDefaultGuardMode,
+  type ToolGuard,
+  type ToolGuardPolicy,
+} from './guard.js';
+// Injectable shell executor (E3 · T11406) — threaded into the guard's
+// executeShell/runGit; substitutes the subprocess layer in tests/sandboxes.
+export { defaultShellExecutor, type ShellExecutor } from './shell.js';


### PR DESCRIPTION
## What

Wires the atomic tool layer (E3 · `core/src/tools/{fs,shell,guard}.ts`) into the public surface per the owner-ratified **wire-or-revert** rule (BRAIN `O-mpt8gjdx-0`): the primitives are now exported by the tools barrel **and** consumed by the in-process `SkillExecutor` (#897 · T11477) in the same wave.

## Acceptance criteria

- **AC1** — `core/src/tools/index.ts` exports the atomic fs/shell/guard surface (not just the legacy squatters): `createToolGuard`, `ToolGuard`/`ToolGuardPolicy`/`GuardMode`, `GuardDeniedError`, the date-gate mechanism, and the injectable `ShellExecutor`/`defaultShellExecutor`.
- **AC2** — Atomic tools are reachable **only through** the deny-first `createToolGuard` chokepoint. The raw side-effecting primitives (`writeFileAtomic`, `executeShell`, `runGit`, `readFileText`) are deliberately **not** re-exported from the barrel — no public bypass. A test asserts they are absent from the barrel's exported keys.
- **AC3** — New `skill-executor-guard-wire.test.ts` proves a resolved `ct-*` skill node, run in-process by `SkillExecutorAdapter`, reaches `readFileText`/`executeShell` through a **real** `createToolGuard` (not a stub).
- **AC4** — `guard.ts` gains the **date-gated** default-mode mechanism: `GUARD_ENFORCE_DEADLINE` (single source of truth) + `GUARD_ENFORCE_FLIP_ENABLED` (owner-gated kill-switch) + `resolveDefaultGuardMode()`. `createToolGuard` now derives its default mode from this.

## Enforce-flip status — HELD at `warn` (owner-gated)

The default is **NOT** flipped to `enforce`. Per `O-mpt8gjdx-0`, the warn→enforce flip is one of **three** hard-gates that together unblock dynamic tool/skill forging; the other two (approval-token CONDUIT gate + discretion rate-limit) are **not live**. The mechanism is fully encoded, but `GUARD_ENFORCE_FLIP_ENABLED = false` holds the live default at `warn`. **The flip awaits explicit owner confirmation** that the deadline has passed AND the full suite is green with enforce on.

## Validation

- `cleo check arch` — **5/5 PASS**
- Gate 11 (tools-vs-skills boundary), Gate 10 (contracts purity), Gate 6 (CLI boundary) — green
- `pnpm run typecheck` (`tsc -b`) — clean
- `node build.mjs` + CLI `version` smoke — clean
- `tools/` + `skills/` test areas — **450/450 pass**. The 16 failures in the full `@cleocode/core` run are the documented stale-napi/git-in-worktree flaky baseline (worktree/release/audit suites); none import the changed modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)