### PR TITLE
refactor(T11523): route conduit-sqlite.ts through openDualScopeDb + DDL→Drizzle migration (E6-L3)

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/agent-install.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/agent-install.test.ts
@@ -150,7 +150,7 @@ async function makeTmpEnv(suffix: string): Promise<TmpEnv> {
     await import('@cleocode/core/internal');
   _resetGlobalSignaldockDb_TESTING_ONLY();
   await ensureGlobalSignaldockDb();
-  ensureConduitDb(projectRoot);
+  await ensureConduitDb(projectRoot);
 
   const dbPath = join(cleoHome, 'signaldock.db');
 

--- a/packages/cleo/src/cli/index.ts
+++ b/packages/cleo/src/cli/index.ts
@@ -516,7 +516,7 @@ export async function runStartupMaintenance(): Promise<void> {
     try {
       const _projectRootForMigration = getProjectRoot();
       if (needsSignaldockToConduitMigration(_projectRootForMigration)) {
-        const migrationResult = migrateSignaldockToConduit(_projectRootForMigration);
+        const migrationResult = await migrateSignaldockToConduit(_projectRootForMigration);
         if (migrationResult.status === 'failed') {
           _startupLog.error(
             { errors: migrationResult.errors, projectRoot: _projectRootForMigration },

--- a/packages/core/migrations/drizzle-conduit/20260601000003_t11523-conduit-inline-schema/migration.sql
+++ b/packages/core/migrations/drizzle-conduit/20260601000003_t11523-conduit-inline-schema/migration.sql
@@ -1,0 +1,331 @@
+-- T11523 (E6-L3): Forward Drizzle migration carrying the conduit-domain schema
+-- that previously lived ONLY as an inline `CREATE TABLE IF NOT EXISTS` blob
+-- (`CONDUIT_SCHEMA_SQL`) applied by `applyConduitSchema()` in conduit-sqlite.ts.
+--
+-- E6-L3 routes `ensureConduitDb()` through `openDualScopeDb('project')` (the
+-- consolidated `cleo.db` chokepoint, ADR-068/069). The inline DDL is removed and
+-- replaced by this migration (T11523 AC: inline DDL → forward Drizzle migration),
+-- matching the T1407 baseline marker + the L1/L2 precedent.
+--
+-- The conduit legacy physical table names are BARE (`conversations`, `messages`,
+-- `delivery_jobs`, …) while the consolidated schema (`cleo-project/conduit.ts`)
+-- carries the `conduit_` domain prefix (`conduit_conversations`, …). They are
+-- therefore DISJOINT physical names — the legacy runtime-shape tables co-exist
+-- harmlessly alongside the consolidated `conduit_*` tables in the same `cleo.db`,
+-- exactly like the tasks domain (legacy `tasks` ≠ consolidated `tasks_tasks`).
+-- No DROP/rebuild is needed (unlike the brain domain, E6-L2).
+--
+-- All DDL is reproduced VERBATIM from `CONDUIT_SCHEMA_SQL` (legacy runtime shape):
+-- 16 tables + indexes + FTS5 virtual table + 3 FTS5 triggers. Every statement is
+-- `IF NOT EXISTS`, so re-running on a DB that already has the tables is idempotent.
+-- The exodus migration (T11248 / T11553) later renames these to `conduit_*`.
+
+-- -------------------------------------------------------------------------
+-- Project-scoped conversations (LocalTransport DM threads).
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS conversations (
+    id TEXT PRIMARY KEY,
+    participants TEXT NOT NULL,
+    visibility TEXT NOT NULL DEFAULT 'private',
+    message_count INTEGER NOT NULL DEFAULT 0,
+    last_message_at INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- Project-scoped agent-to-agent messages (LocalTransport content).
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS messages (
+    id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL REFERENCES conversations(id),
+    from_agent_id TEXT NOT NULL,
+    to_agent_id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    content_type TEXT NOT NULL DEFAULT 'text',
+    status TEXT NOT NULL DEFAULT 'pending',
+    attachments TEXT NOT NULL DEFAULT '[]',
+    group_id TEXT,
+    metadata TEXT DEFAULT '{}',
+    reply_to TEXT,
+    created_at INTEGER NOT NULL,
+    delivered_at INTEGER,
+    read_at INTEGER
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS messages_conversation_idx ON messages(conversation_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS messages_from_agent_idx ON messages(from_agent_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS messages_to_agent_idx ON messages(to_agent_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS messages_created_at_idx ON messages(created_at);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_messages_group_id ON messages(group_id) WHERE group_id IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_messages_reply_to ON messages(reply_to) WHERE reply_to IS NOT NULL;
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- FTS5 virtual table for full-text search on message content.
+-- NOTE: Must be migrated using VACUUM INTO, not DDL-only copy, to preserve
+-- triggers. The INSERT INTO messages_fts(messages_fts) VALUES('rebuild')
+-- is idempotent — safe to run on every open.
+-- -------------------------------------------------------------------------
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts
+    USING fts5(content, from_agent_id, content='messages', content_rowid='rowid');
+--> statement-breakpoint
+INSERT INTO messages_fts(messages_fts) VALUES('rebuild');
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, content, from_agent_id)
+        VALUES (new.rowid, new.content, new.from_agent_id);
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content, from_agent_id)
+        VALUES('delete', old.rowid, old.content, old.from_agent_id);
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content, from_agent_id)
+        VALUES('delete', old.rowid, old.content, old.from_agent_id);
+    INSERT INTO messages_fts(rowid, content, from_agent_id)
+        VALUES (new.rowid, new.content, new.from_agent_id);
+END;
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- Async delivery queue for deferred message dispatch.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS delivery_jobs (
+    id TEXT PRIMARY KEY,
+    message_id TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 6,
+    next_attempt_at INTEGER NOT NULL,
+    last_error TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_delivery_jobs_status ON delivery_jobs(status, next_attempt_at);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- Dead-letter queue for messages that exceeded max delivery attempts.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS dead_letters (
+    id TEXT PRIMARY KEY,
+    message_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    attempts INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_dead_letters_message ON dead_letters(message_id);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- Pinned messages within a conversation.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS message_pins (
+    id TEXT PRIMARY KEY,
+    message_id TEXT NOT NULL,
+    conversation_id TEXT NOT NULL,
+    pinned_by TEXT NOT NULL,
+    note TEXT,
+    created_at INTEGER NOT NULL,
+    UNIQUE(message_id, pinned_by)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_pins_conversation ON message_pins(conversation_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_pins_agent ON message_pins(pinned_by);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- File/blob attachments associated with messages.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS attachments (
+    slug TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL,
+    from_agent_id TEXT NOT NULL,
+    content BLOB NOT NULL,
+    original_size INTEGER NOT NULL,
+    compressed_size INTEGER NOT NULL,
+    content_hash TEXT NOT NULL,
+    format TEXT NOT NULL DEFAULT 'text',
+    title TEXT,
+    tokens INTEGER NOT NULL DEFAULT 0,
+    expires_at INTEGER NOT NULL DEFAULT 0,
+    storage_key TEXT,
+    mode TEXT NOT NULL DEFAULT 'draft',
+    version_count INTEGER NOT NULL DEFAULT 1,
+    current_version INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS attachments_conversation_idx ON attachments(conversation_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS attachments_agent_idx ON attachments(from_agent_id);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- Version history for attachments (collaborative editing).
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS attachment_versions (
+    id TEXT PRIMARY KEY,
+    slug TEXT NOT NULL REFERENCES attachments(slug) ON DELETE CASCADE,
+    version_number INTEGER NOT NULL,
+    author_agent_id TEXT NOT NULL,
+    change_type TEXT NOT NULL DEFAULT 'patch',
+    patch_text TEXT,
+    storage_key TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    original_size INTEGER NOT NULL,
+    compressed_size INTEGER NOT NULL,
+    tokens INTEGER NOT NULL,
+    change_summary TEXT,
+    sections_modified TEXT NOT NULL DEFAULT '[]',
+    tokens_added INTEGER NOT NULL DEFAULT 0,
+    tokens_removed INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    UNIQUE(slug, version_number)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_attachment_versions_slug ON attachment_versions(slug);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_attachment_versions_author ON attachment_versions(author_agent_id);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- Approval records for attachment content review.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS attachment_approvals (
+    id TEXT PRIMARY KEY,
+    slug TEXT NOT NULL REFERENCES attachments(slug) ON DELETE CASCADE,
+    reviewer_agent_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    comment TEXT,
+    version_reviewed INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    UNIQUE(slug, reviewer_agent_id)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_attachment_approvals_slug ON attachment_approvals(slug);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- Contributor statistics per attachment (who edited, how much).
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS attachment_contributors (
+    slug TEXT NOT NULL REFERENCES attachments(slug) ON DELETE CASCADE,
+    agent_id TEXT NOT NULL,
+    version_count INTEGER NOT NULL DEFAULT 0,
+    total_tokens_added INTEGER NOT NULL DEFAULT 0,
+    total_tokens_removed INTEGER NOT NULL DEFAULT 0,
+    first_contribution_at INTEGER NOT NULL,
+    last_contribution_at INTEGER NOT NULL,
+    PRIMARY KEY (slug, agent_id)
+);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- NEW: Per-project agent reference overrides (ADR-037 §3, Q6=A).
+-- agent_id is a SOFT FK to global signaldock.db:agents.agent_id.
+-- Cross-DB FK enforcement is not possible in SQLite; the accessor layer
+-- (T355) validates on every cross-DB join.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS project_agent_refs (
+    agent_id TEXT PRIMARY KEY,
+    attached_at TEXT NOT NULL,
+    role TEXT,
+    capabilities_override TEXT,
+    last_used_at TEXT,
+    enabled INTEGER NOT NULL DEFAULT 1
+);
+--> statement-breakpoint
+-- Partial index: covers the dominant query path (list enabled agents).
+CREATE INDEX IF NOT EXISTS idx_project_agent_refs_enabled
+    ON project_agent_refs(enabled) WHERE enabled = 1;
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- A2A Topics (T1252 — Wave 9 Agent-to-Agent coordination pub-sub).
+-- Topics are named channels that agents can publish to / subscribe from.
+-- Topic names follow "<epicId>.<waveId>" or "<epicId>.coordination".
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS topics (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    epic_id TEXT NOT NULL,
+    wave_id INTEGER,
+    created_by TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_topics_epic ON topics(epic_id);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- A2A Topic subscriptions — links an agent_id to a topic_id.
+-- Created by subscribeTopic(); removed by unsubscribeTopic().
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS topic_subscriptions (
+    topic_id TEXT NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
+    agent_id TEXT NOT NULL,
+    subscribed_at INTEGER NOT NULL,
+    PRIMARY KEY (topic_id, agent_id)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_topic_subscriptions_agent ON topic_subscriptions(agent_id);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- A2A Topic messages — broadcast messages published to a topic.
+-- payload is stored as JSON text.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS topic_messages (
+    id TEXT PRIMARY KEY,
+    topic_id TEXT NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
+    from_agent_id TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'message',
+    content TEXT NOT NULL,
+    payload TEXT,
+    created_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_topic_messages_topic_created ON topic_messages(topic_id, created_at);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- A2A Topic message ACKs — per-subscriber delivery tracking.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS topic_message_acks (
+    message_id TEXT NOT NULL REFERENCES topic_messages(id) ON DELETE CASCADE,
+    subscriber_agent_id TEXT NOT NULL,
+    delivered_at INTEGER,
+    read_at INTEGER,
+    PRIMARY KEY (message_id, subscriber_agent_id)
+);
+--> statement-breakpoint
+
+-- -------------------------------------------------------------------------
+-- Schema tracking tables (mirrors _signaldock_meta / _signaldock_migrations).
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS _conduit_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS _conduit_migrations (
+    name TEXT PRIMARY KEY,
+    applied_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);

--- a/packages/core/src/conduit/__tests__/a2a-topic.test.ts
+++ b/packages/core/src/conduit/__tests__/a2a-topic.test.ts
@@ -31,10 +31,10 @@ let testDir: string;
 let originalCwd: string;
 
 /** Create a temporary directory with a valid conduit.db for testing. */
-function setupTestDb(): string {
+async function setupTestDb(): Promise<string> {
   const dir = join(tmpdir(), `a2a-topic-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(join(dir, '.cleo'), { recursive: true });
-  ensureConduitDb(dir);
+  await ensureConduitDb(dir);
   return dir;
 }
 
@@ -70,9 +70,9 @@ function makeCredential(agentId: string): AgentCredential {
 // ============================================================================
 
 describe('LocalTransport — A2A Topic Operations (T1252)', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     originalCwd = process.cwd();
-    testDir = setupTestDb();
+    testDir = await setupTestDb();
     process.chdir(testDir);
   });
 
@@ -308,9 +308,9 @@ describe('LocalTransport — A2A Topic Operations (T1252)', () => {
 // ============================================================================
 
 describe('ConduitClient — A2A Topic Delegation (T1252)', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     originalCwd = process.cwd();
-    testDir = setupTestDb();
+    testDir = await setupTestDb();
     process.chdir(testDir);
   });
 
@@ -412,9 +412,9 @@ describe('ConduitClient — A2A Topic Delegation (T1252)', () => {
 // ============================================================================
 
 describe('E2E — Two subagents coordinate via CONDUIT topics (T1149 atom 5)', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     originalCwd = process.cwd();
-    testDir = setupTestDb();
+    testDir = await setupTestDb();
     process.chdir(testDir);
   });
 

--- a/packages/core/src/conduit/__tests__/local-credential-flow.test.ts
+++ b/packages/core/src/conduit/__tests__/local-credential-flow.test.ts
@@ -61,22 +61,22 @@ describe('Local Credential Flow E2E', () => {
   // --------------------------------------------------------------------------
 
   describe('Step 1: conduit.db creation', () => {
-    it('ensureConduitDb creates the database file', () => {
-      const result = ensureConduitDb(testDir);
+    it('ensureConduitDb creates the database file', async () => {
+      const result = await ensureConduitDb(testDir);
       expect(result.action).toBe('created');
       expect(existsSync(result.path)).toBe(true);
     });
 
-    it('ensureConduitDb is idempotent', () => {
-      const first = ensureConduitDb(testDir);
-      const second = ensureConduitDb(testDir);
+    it('ensureConduitDb is idempotent', async () => {
+      const first = await ensureConduitDb(testDir);
+      const second = await ensureConduitDb(testDir);
       expect(first.action).toBe('created');
       expect(second.action).toBe('exists');
       expect(first.path).toBe(second.path);
     });
 
     it('conduit.db has the messages table', async () => {
-      ensureConduitDb(testDir);
+      await ensureConduitDb(testDir);
       const dbPath = getConduitDbPath(testDir);
       expect(existsSync(dbPath)).toBe(true);
 
@@ -96,15 +96,15 @@ describe('Local Credential Flow E2E', () => {
   // --------------------------------------------------------------------------
 
   describe('Step 2: LocalTransport availability', () => {
-    it('isAvailable returns false before init', () => {
+    it('isAvailable returns false before init', async () => {
       const emptyDir = join(tmpdir(), `no-init-${Date.now()}`);
       mkdirSync(join(emptyDir, '.cleo'), { recursive: true });
       expect(LocalTransport.isAvailable(emptyDir)).toBe(false);
       rmSync(emptyDir, { recursive: true, force: true });
     });
 
-    it('isAvailable returns true after init', () => {
-      ensureConduitDb(testDir);
+    it('isAvailable returns true after init', async () => {
+      await ensureConduitDb(testDir);
       expect(LocalTransport.isAvailable(testDir)).toBe(true);
     });
   });
@@ -116,7 +116,7 @@ describe('Local Credential Flow E2E', () => {
   describe('Step 3: messaging lifecycle', () => {
     it('complete flow: init → connect → push → poll → ack', async () => {
       // 1. Init conduit.db
-      ensureConduitDb(testDir);
+      await ensureConduitDb(testDir);
 
       // 2. Connect two agents
       const agent1 = new LocalTransport();
@@ -169,7 +169,7 @@ describe('Local Credential Flow E2E', () => {
     });
 
     it('messages persist across transport reconnections', async () => {
-      ensureConduitDb(testDir);
+      await ensureConduitDb(testDir);
 
       // Send a message
       const sender = new LocalTransport();
@@ -196,7 +196,7 @@ describe('Local Credential Flow E2E', () => {
     });
 
     it('multiple agents can communicate in the same conversation', async () => {
-      ensureConduitDb(testDir);
+      await ensureConduitDb(testDir);
 
       const prime = new LocalTransport();
       const rustLead = new LocalTransport();

--- a/packages/core/src/conduit/__tests__/local-transport.test.ts
+++ b/packages/core/src/conduit/__tests__/local-transport.test.ts
@@ -26,13 +26,13 @@ let testDir: string;
 let originalCwd: string;
 
 /** Create a temporary directory with a valid conduit.db for testing. */
-function setupTestDb(): string {
+async function setupTestDb(): Promise<string> {
   const dir = join(
     tmpdir(),
     `local-transport-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
   mkdirSync(join(dir, '.cleo'), { recursive: true });
-  ensureConduitDb(dir);
+  await ensureConduitDb(dir);
   return dir;
 }
 
@@ -50,9 +50,9 @@ function testConfig(agentId = 'test-agent') {
 // ============================================================================
 
 describe('LocalTransport', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     originalCwd = process.cwd();
-    testDir = setupTestDb();
+    testDir = await setupTestDb();
     process.chdir(testDir);
   });
 

--- a/packages/core/src/conduit/__tests__/messaging-e2e.test.ts
+++ b/packages/core/src/conduit/__tests__/messaging-e2e.test.ts
@@ -36,10 +36,10 @@ let testDir: string;
 let originalCwd: string;
 
 /** Create a temp directory with an initialised conduit.db. */
-function setupTestDb(): string {
+async function setupTestDb(): Promise<string> {
   const dir = join(tmpdir(), `messaging-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(join(dir, '.cleo'), { recursive: true });
-  ensureConduitDb(dir);
+  await ensureConduitDb(dir);
   return dir;
 }
 
@@ -70,9 +70,9 @@ function makeCred(agentId: string): AgentCredential {
 // Setup / teardown
 // ============================================================================
 
-beforeEach(() => {
+beforeEach(async () => {
   originalCwd = process.cwd();
-  testDir = setupTestDb();
+  testDir = await setupTestDb();
   process.chdir(testDir);
 });
 

--- a/packages/core/src/conduit/local-transport.ts
+++ b/packages/core/src/conduit/local-transport.ts
@@ -530,7 +530,16 @@ export class LocalTransport implements Transport {
    * @returns `true` if conduit.db exists at the expected path.
    */
   static isAvailable(cwd?: string): boolean {
-    const dbPath = getConduitDbPath(resolveOrCwd(cwd));
+    // E6-L3 (T11523): getConduitDbPath now resolves via resolveCleoDir(), which
+    // THROWS E_NO_PROJECT when the cwd is not under a `.cleo/` tree. The legacy
+    // contract is "false when the conduit DB is missing", so treat an
+    // unresolvable project as unavailable rather than propagating the throw.
+    let dbPath: string;
+    try {
+      dbPath = getConduitDbPath(resolveOrCwd(cwd));
+    } catch {
+      return false;
+    }
     return existsSync(dbPath);
   }
 

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -819,7 +819,7 @@ export async function initProject(opts: InitOptions = {}): Promise<InitResult> {
   // signaldock.db, which the CLI startup sequence ensures separately.
   try {
     const { ensureConduitDb } = await import('./store/conduit-sqlite.js');
-    const cdResult = ensureConduitDb(projRoot);
+    const cdResult = await ensureConduitDb(projRoot);
     if (cdResult.action === 'created') {
       created.push('conduit.db');
     }

--- a/packages/core/src/memory/__tests__/graph-memory-bridge-integration.test.ts
+++ b/packages/core/src/memory/__tests__/graph-memory-bridge-integration.test.ts
@@ -397,7 +397,7 @@ describe('graph-memory-bridge', () => {
       );
 
       // Initialize conduit.db
-      ensureConduitDb(tempDir);
+      await ensureConduitDb(tempDir);
 
       // Seed a nexus symbol
       await seedNexusNode('src/main.ts::initApp', 'initApp', 'initApp', 'src/main.ts', 'function');
@@ -419,7 +419,7 @@ describe('graph-memory-bridge', () => {
       const { getBrainNativeDb } = await import('../../store/memory-sqlite.js');
 
       // Initialize conduit.db and insert a test message
-      ensureConduitDb(tempDir);
+      await ensureConduitDb(tempDir);
       const conduitDb = getConduitNativeDb();
 
       const convId = 'conv-001';
@@ -478,7 +478,7 @@ describe('graph-memory-bridge', () => {
       );
       const { getBrainNativeDb } = await import('../../store/memory-sqlite.js');
 
-      ensureConduitDb(tempDir);
+      await ensureConduitDb(tempDir);
       const conduitDb = getConduitNativeDb();
 
       const convId = 'conv-002';

--- a/packages/core/src/store/__tests__/agent-registry-accessor.test.ts
+++ b/packages/core/src/store/__tests__/agent-registry-accessor.test.ts
@@ -86,7 +86,8 @@ function makeTmpEnv(suffix: string): {
   };
 
   const openConduit = (): DatabaseSync => {
-    const db = new DatabaseSync(join(projectRoot, '.cleo', 'conduit.db'));
+    // E6-L3 (T11523): the conduit domain consolidated into the project cleo.db.
+    const db = new DatabaseSync(join(projectRoot, '.cleo', 'cleo.db'));
     db.exec('PRAGMA foreign_keys = ON');
     db.exec('PRAGMA journal_mode = WAL');
     return db;
@@ -110,7 +111,10 @@ async function bootstrapDbs(
   ensureGlobal: () => Promise<void>;
   ensureConduit: () => void;
 }> {
-  vi.doMock('../../paths.js', () => ({ getCleoHome: () => cleoHome }));
+  vi.doMock('../../paths.js', () => ({
+    getCleoHome: () => cleoHome,
+    resolveCleoDir: (cwd) => join(cwd ?? projectRoot, '.cleo'),
+  }));
   // Write a deterministic machine-key and global-salt so KDF is testable
   const machineKey = Buffer.alloc(32, 0xab);
   const globalSalt = Buffer.alloc(32, 0xcd);
@@ -124,8 +128,8 @@ async function bootstrapDbs(
     ensureGlobal: async () => {
       await ensureGlobalSignaldockDb();
     },
-    ensureConduit: () => {
-      ensureConduitDb(projectRoot);
+    ensureConduit: async () => {
+      await ensureConduitDb(projectRoot);
       closeConduitDb();
     },
   };
@@ -153,7 +157,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('TC-050: lookupAgent returns null for unknown agentId', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -164,7 +171,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     const { lookupAgent } = await import('../agent-registry-accessor.js');
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
     const result = lookupAgent(env.projectRoot, 'nonexistent-agent');
@@ -176,7 +183,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('TC-051: lookupAgent returns merged agent when ref exists with enabled=1', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -187,11 +197,11 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     const { createProjectAgent, lookupAgent } = await import('../agent-registry-accessor.js');
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
     // Create agent (writes global + conduit ref)
-    const created = createProjectAgent(env.projectRoot, BASE_SPEC);
+    const created = await createProjectAgent(env.projectRoot, BASE_SPEC);
     expect(created.agentId).toBe(BASE_SPEC.agentId);
     expect(created.projectRef).not.toBeNull();
     expect(created.projectRef?.enabled).toBe(1);
@@ -210,7 +220,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('TC-052: lookupAgent returns null when project_agent_refs row has enabled=0', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -221,10 +234,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     const { createProjectAgent, lookupAgent } = await import('../agent-registry-accessor.js');
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     // Manually set enabled=0 in conduit.db
     const conduitDb = env.openConduit();
@@ -242,7 +255,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('TC-053: lookupAgent with includeGlobal=true returns global agent even without project ref', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -253,7 +269,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     const { lookupAgent } = await import('../agent-registry-accessor.js');
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
     // Insert directly into global signaldock.db without touching conduit.db
@@ -288,7 +304,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('TC-054: listAgentsForProject returns only project-attached agents by default', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -301,7 +320,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
     // Insert a global-only agent (no project ref)
@@ -319,7 +338,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     globalDb.close();
 
     // Create one project-attached agent
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     const list = listAgentsForProject(env.projectRoot);
     expect(list).toHaveLength(1);
@@ -332,7 +351,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('TC-055: listAgentsForProject with includeGlobal=true returns all global agents', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -345,7 +367,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
     // Insert a global-only agent
@@ -363,7 +385,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     globalDb.close();
 
     // Create one project-attached agent
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     const list = listAgentsForProject(env.projectRoot, { includeGlobal: true });
 
@@ -386,7 +408,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('TC-056: createProjectAgent writes to global signaldock.db AND project_agent_refs', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -397,10 +422,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     const { createProjectAgent } = await import('../agent-registry-accessor.js');
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
-    const result = createProjectAgent(env.projectRoot, BASE_SPEC);
+    const result = await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     // Verify return type
     expect(result.agentId).toBe(BASE_SPEC.agentId);
@@ -434,7 +459,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('TC-057: AgentRegistryAccessor.remove() sets project_agent_refs.enabled=0; global row intact', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -447,10 +475,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     const accessor = new AgentRegistryAccessor(env.projectRoot);
     await accessor.remove(BASE_SPEC.agentId);
@@ -478,7 +506,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('TC-058: AgentRegistryAccessor.removeGlobal() deletes row from global signaldock.db', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -491,10 +522,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     // First detach from project so removeGlobal succeeds without force
     const accessor = new AgentRegistryAccessor(env.projectRoot);
@@ -517,7 +548,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('TC-059: AgentRegistryAccessor.markUsed() updates last_used_at in both DBs', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -530,10 +564,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     const before = Date.now();
 
@@ -570,7 +604,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('lookupAgent logs warn and returns null for dangling soft-FK', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -581,7 +618,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     const { lookupAgent } = await import('../agent-registry-accessor.js');
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
     // Insert a project_agent_refs row without a corresponding global agent
@@ -608,7 +645,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('createProjectAgent re-enables a previously detached (enabled=0) project ref', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -621,11 +661,11 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
     // Create and then detach
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
     const accessor = new AgentRegistryAccessor(env.projectRoot);
     await accessor.remove(BASE_SPEC.agentId);
 
@@ -634,7 +674,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     expect(afterRemove).toBeNull();
 
     // Re-create should re-enable
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     const afterReCreate = lookupAgent(env.projectRoot, BASE_SPEC.agentId);
     expect(afterReCreate).not.toBeNull();
@@ -654,7 +694,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('listAgentsForProject with includeDisabled=true includes enabled=0 rows', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -667,10 +710,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     // Detach the agent
     const accessor = new AgentRegistryAccessor(env.projectRoot);
@@ -692,7 +735,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('AgentRegistryAccessor.list() returns only project-attached agents', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -705,7 +751,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
     // Add global-only agent
@@ -722,7 +768,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
       .run(crypto.randomUUID(), 'global-only-list', 'Global Only List', nowTs, nowTs);
     globalDb.close();
 
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     const accessor = new AgentRegistryAccessor(env.projectRoot);
     const list = await accessor.list();
@@ -735,7 +781,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('AgentRegistryAccessor.listGlobal() returns all global agents', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -748,7 +797,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
     // Add global-only agent
@@ -765,7 +814,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
       .run(crypto.randomUUID(), 'global-only-listg', 'Global Only ListG', nowTs, nowTs);
     globalDb.close();
 
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     const accessor = new AgentRegistryAccessor(env.projectRoot);
     const list = await accessor.listGlobal();
@@ -779,7 +828,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
   // -------------------------------------------------------------------------
 
   it('AgentRegistryAccessor.removeGlobal() throws when active project ref exists without force', async () => {
-    vi.doMock('../../paths.js', () => ({ getCleoHome: () => env.cleoHome }));
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
     const machineKey = Buffer.alloc(32, 0xab);
     const globalSalt = Buffer.alloc(32, 0xcd);
     writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
@@ -792,10 +844,10 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(env.projectRoot);
+    await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
-    createProjectAgent(env.projectRoot, BASE_SPEC);
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
 
     const accessor = new AgentRegistryAccessor(env.projectRoot);
     await expect(accessor.removeGlobal(BASE_SPEC.agentId)).rejects.toThrow(

--- a/packages/core/src/store/__tests__/conduit-idempotency.test.ts
+++ b/packages/core/src/store/__tests__/conduit-idempotency.test.ts
@@ -7,7 +7,7 @@
  * ({@link ensureConduitDb}) is idempotent across both open cycles and
  * write replays. The contract:
  *
- *   1. The first call to `ensureConduitDb(projectRoot)` returns
+ *   1. The first call to `await ensureConduitDb(projectRoot)` returns
  *      `action: 'created'`. The second call (after the singleton is
  *      closed to simulate a separate process) returns
  *      `action: 'exists'` — confirming the schema-version sentinel
@@ -34,7 +34,7 @@
  * @adr ADR-013
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -50,6 +50,10 @@ describe('conduit.db idempotency contract (T10314)', () => {
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'cleo-conduit-idempotency-'));
+    // E6-L3: getConduitDbPath now resolves via resolveCleoDir(tempDir), which
+    // needs a `.cleo/` directory present. Create it (cleo.db itself is created by
+    // ensureConduitDb).
+    mkdirSync(join(tempDir, '.cleo'), { recursive: true });
     closeConduitDb();
   });
 
@@ -58,21 +62,21 @@ describe('conduit.db idempotency contract (T10314)', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('ensureConduitDb returns created on first call and exists on second', () => {
-    const first = ensureConduitDb(tempDir);
+  it('ensureConduitDb returns created on first call and exists on second', async () => {
+    const first = await ensureConduitDb(tempDir);
     expect(first.action).toBe('created');
     expect(first.path).toBe(getConduitDbPath(tempDir));
 
     // Close singleton — simulates a second CLI process.
     closeConduitDb();
 
-    const second = ensureConduitDb(tempDir);
+    const second = await ensureConduitDb(tempDir);
     expect(second.action).toBe('exists');
     expect(second.path).toBe(first.path);
   });
 
-  it('identical agent attach writes do not duplicate rows', () => {
-    ensureConduitDb(tempDir);
+  it('identical agent attach writes do not duplicate rows', async () => {
+    await ensureConduitDb(tempDir);
     const dbFirst = getConduitNativeDb();
     expect(dbFirst).not.toBeNull();
 
@@ -93,7 +97,7 @@ describe('conduit.db idempotency contract (T10314)', () => {
 
     // Simulate a second process — close singleton, reopen.
     closeConduitDb();
-    const reopen = ensureConduitDb(tempDir);
+    const reopen = await ensureConduitDb(tempDir);
     expect(reopen.action).toBe('exists');
 
     const dbSecond = getConduitNativeDb();
@@ -116,8 +120,8 @@ describe('conduit.db idempotency contract (T10314)', () => {
     expect(row.enabled).toBe(1);
   });
 
-  it('schema version sentinel does not double-write on second open', () => {
-    ensureConduitDb(tempDir);
+  it('schema version sentinel does not double-write on second open', async () => {
+    await ensureConduitDb(tempDir);
     const dbFirst = getConduitNativeDb();
     expect(dbFirst).not.toBeNull();
 
@@ -126,7 +130,7 @@ describe('conduit.db idempotency contract (T10314)', () => {
     };
 
     closeConduitDb();
-    ensureConduitDb(tempDir);
+    await ensureConduitDb(tempDir);
 
     const dbSecond = getConduitNativeDb();
     expect(dbSecond).not.toBeNull();
@@ -140,8 +144,8 @@ describe('conduit.db idempotency contract (T10314)', () => {
     expect(metaCountSecond.n).toBe(metaCountFirst.n);
   });
 
-  it('PRAGMAs are stable across opens (WAL + foreign_keys)', () => {
-    ensureConduitDb(tempDir);
+  it('PRAGMAs are stable across opens (WAL + foreign_keys)', async () => {
+    await ensureConduitDb(tempDir);
     const dbFirst = getConduitNativeDb();
     expect(dbFirst).not.toBeNull();
 
@@ -153,7 +157,7 @@ describe('conduit.db idempotency contract (T10314)', () => {
     expect(fkFirst.foreign_keys).toBe(1);
 
     closeConduitDb();
-    ensureConduitDb(tempDir);
+    await ensureConduitDb(tempDir);
     const dbSecond = getConduitNativeDb();
     expect(dbSecond).not.toBeNull();
 

--- a/packages/core/src/store/__tests__/conduit-sqlite.test.ts
+++ b/packages/core/src/store/__tests__/conduit-sqlite.test.ts
@@ -1,15 +1,32 @@
 /**
- * Tests for conduit-sqlite.ts — project-tier conduit.db module.
+ * Tests for conduit-sqlite.ts — project-tier CONDUIT domain module.
  *
- * Covers path resolution, DDL creation, idempotent re-open, FTS5 triggers,
- * getConduitNativeDb, and integrity_check.
+ * ## E6-L3 (T11523)
+ *
+ * `ensureConduitDb()` now routes through `openDualScopeDb('project')` — the
+ * conduit domain lives inside the consolidated project `cleo.db`, not a standalone
+ * `conduit.db`. The 16-table inline DDL blob was converted to the forward Drizzle
+ * migration `drizzle-conduit/20260601000003_t11523-conduit-inline-schema`. The
+ * BARE legacy tables (`conversations`, `messages`, …) co-exist with the
+ * consolidated `conduit_*` tables (disjoint names — no drop/rebuild).
+ *
+ * These tests therefore:
+ * - await the now-async `ensureConduitDb`,
+ * - assert the consolidated `cleo.db` path,
+ * - assert the legacy BARE tables are PRESENT (via arrayContaining) rather than
+ *   the only tables (the shared cleo.db also holds `tasks_*` / `brain_*` /
+ *   `conduit_*` / etc.),
+ * - reset the shared dual-scope cache between cases for deterministic
+ *   created/exists semantics.
  *
  * Uses real node:sqlite DatabaseSync (genuine SQLite operations, not mocks).
  * All filesystem interactions occur in tmp directories; the real user's
  * project root is never touched.
  *
  * @task T344
+ * @task T11523
  * @epic T310
+ * @epic T11249
  */
 
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
@@ -20,7 +37,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   applyConduitSchema,
   attachAgentToProject,
-  CONDUIT_DB_FILENAME,
   CONDUIT_SCHEMA_VERSION,
   checkConduitDbHealth,
   closeConduitDb,
@@ -32,15 +48,20 @@ import {
   listProjectAgentRefs,
   updateProjectAgentLastUsed,
 } from '../conduit-sqlite.js';
+import { _resetDualScopeDbCache, resolveDualScopeDbPath } from '../dual-scope-db.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Expected project-local messaging + tracking table names in conduit.db. */
-const EXPECTED_TABLES = [
-  // Drizzle migration journal (T1407 — added by reconcileJournal/migrateSanitized).
-  '__drizzle_migrations',
+/**
+ * The legacy BARE conduit tables the forward migration creates. These now live
+ * INSIDE the consolidated `cleo.db` alongside the prefixed `conduit_*` tables and
+ * the `tasks_*` / `brain_*` domains, so we assert PRESENCE (arrayContaining)
+ * rather than equality. `_conduit_meta` / `_conduit_migrations` are the two legacy
+ * meta tables.
+ */
+const EXPECTED_LEGACY_TABLES = [
   '_conduit_meta',
   '_conduit_migrations',
   'attachment_approvals',
@@ -53,7 +74,6 @@ const EXPECTED_TABLES = [
   'message_pins',
   'messages',
   'project_agent_refs',
-  // A2A topic tables (T1252)
   'topic_message_acks',
   'topic_messages',
   'topic_subscriptions',
@@ -69,37 +89,45 @@ describe('conduit-sqlite', () => {
 
   beforeEach(() => {
     tmpRoot = mkdtempSync(join(tmpdir(), 'cleo-t344-'));
-    // Ensure each test starts with a clean singleton.
+    // E6-L3: the path now resolves via resolveCleoDir(tmpRoot), which requires a
+    // `.cleo/` directory to be present. Create it so the dual-scope resolver finds
+    // the project root (the `cleo.db` file itself is created by ensureConduitDb).
+    mkdirSync(join(tmpRoot, '.cleo'), { recursive: true });
+    // Ensure each test starts with a clean singleton AND a clean shared
+    // dual-scope cache so the consolidated cleo.db is re-opened per case
+    // (deterministic created/exists semantics).
     closeConduitDb();
+    _resetDualScopeDbCache();
   });
 
   afterEach(() => {
     closeConduitDb();
+    _resetDualScopeDbCache();
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  // TC-001 — path resolution
-  it('getConduitDbPath resolves to <projectRoot>/.cleo/conduit.db', () => {
-    const expected = join(tmpRoot, '.cleo', CONDUIT_DB_FILENAME);
+  // TC-001 — path resolution (E6-L3: consolidated cleo.db)
+  it('getConduitDbPath resolves to the consolidated <projectRoot>/.cleo/cleo.db', () => {
+    const expected = resolveDualScopeDbPath('project', tmpRoot);
     expect(getConduitDbPath(tmpRoot)).toBe(expected);
-    expect(getConduitDbPath(tmpRoot)).toMatch(/\.cleo[/\\]conduit\.db$/);
+    expect(getConduitDbPath(tmpRoot)).toMatch(/\.cleo[/\\]cleo\.db$/);
   });
 
-  // TC-002 — fresh install creates file + directory
-  it('ensureConduitDb creates .cleo/ dir and conduit.db on a fresh project root', () => {
-    expect(existsSync(join(tmpRoot, '.cleo'))).toBe(false);
+  // TC-002 — fresh install creates file + directory (in cleo.db)
+  it('ensureConduitDb creates .cleo/ dir and cleo.db on a fresh project root', async () => {
+    expect(existsSync(join(tmpRoot, '.cleo', 'cleo.db'))).toBe(false);
 
-    const result = ensureConduitDb(tmpRoot);
+    const result = await ensureConduitDb(tmpRoot);
 
     expect(result.path).toBe(getConduitDbPath(tmpRoot));
     expect(result.action).toBe('created');
     expect(existsSync(join(tmpRoot, '.cleo'))).toBe(true);
-    expect(existsSync(join(tmpRoot, '.cleo', 'conduit.db'))).toBe(true);
+    expect(existsSync(join(tmpRoot, '.cleo', 'cleo.db'))).toBe(true);
   });
 
-  // TC-002 continued — all 11 messaging tables + 2 tracking tables created
-  it('ensureConduitDb creates all expected tables on fresh install', () => {
-    ensureConduitDb(tmpRoot);
+  // TC-002 continued — all legacy messaging tables + 2 tracking tables present
+  it('ensureConduitDb creates all expected legacy tables on fresh install', async () => {
+    await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb();
     expect(db).not.toBeNull();
 
@@ -109,16 +137,15 @@ describe('conduit-sqlite', () => {
       )
       .all() as Array<{ name: string }>;
 
-    const tableNames = rows.map((r) => r.name).sort();
-    // messages_fts appears as a virtual table with shadow tables; the main
-    // virtual table itself is type='table' in sqlite_master.
-    const nonFts = tableNames.filter((n) => !n.startsWith('messages_fts'));
-    expect(nonFts).toEqual(EXPECTED_TABLES);
+    const tableNames = rows.map((r) => r.name);
+    // The consolidated cleo.db holds tasks_*/brain_*/conduit_* too, so assert the
+    // legacy BARE conduit tables are PRESENT rather than the only tables.
+    expect(tableNames).toEqual(expect.arrayContaining(EXPECTED_LEGACY_TABLES));
   });
 
   // TC-011 — messages_fts virtual table created
-  it('ensureConduitDb creates messages_fts virtual table', () => {
-    ensureConduitDb(tmpRoot);
+  it('ensureConduitDb creates messages_fts virtual table', async () => {
+    await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb();
     expect(db).not.toBeNull();
 
@@ -129,8 +156,8 @@ describe('conduit-sqlite', () => {
   });
 
   // TC-012 — FTS5 triggers created and functional
-  it('messages_fts triggers are created and FTS search works after insert', () => {
-    ensureConduitDb(tmpRoot);
+  it('messages_fts triggers are created and FTS search works after insert', async () => {
+    await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb();
     expect(db).not.toBeNull();
 
@@ -143,7 +170,8 @@ describe('conduit-sqlite', () => {
     expect(triggerNames).toContain('messages_ad');
     expect(triggerNames).toContain('messages_au');
 
-    // Insert a conversation first (FK constraint on messages).
+    // FK is enabled under the dual-scope pragma SSoT — insert a conversation
+    // first to satisfy the messages → conversations FK.
     db!.exec(`INSERT INTO conversations (id, participants, created_at, updated_at)
               VALUES ('conv-1', '["a","b"]', 1000, 1000)`);
 
@@ -159,26 +187,29 @@ describe('conduit-sqlite', () => {
   });
 
   // TC-003 — idempotent re-open
-  it('ensureConduitDb returns action=exists on second call for same project root', () => {
-    const first = ensureConduitDb(tmpRoot);
+  it('ensureConduitDb returns action=exists on second call for same project root', async () => {
+    const first = await ensureConduitDb(tmpRoot);
     expect(first.action).toBe('created');
 
-    // Close the singleton to simulate a second process open.
+    // Close the conduit singleton + evict the shared cache to simulate a second
+    // process open against the now-existing file.
     closeConduitDb();
+    _resetDualScopeDbCache();
 
-    const second = ensureConduitDb(tmpRoot);
+    const second = await ensureConduitDb(tmpRoot);
     expect(second.action).toBe('exists');
     expect(second.path).toBe(first.path);
   });
 
-  it('ensureConduitDb is idempotent: data survives across two opens', () => {
-    ensureConduitDb(tmpRoot);
+  it('ensureConduitDb is idempotent: data survives across two opens', async () => {
+    await ensureConduitDb(tmpRoot);
     const db1 = getConduitNativeDb()!;
     db1.exec(`INSERT INTO project_agent_refs (agent_id, attached_at)
               VALUES ('test-agent', '2026-04-12T00:00:00Z')`);
     closeConduitDb();
+    _resetDualScopeDbCache();
 
-    ensureConduitDb(tmpRoot);
+    await ensureConduitDb(tmpRoot);
     const db2 = getConduitNativeDb()!;
     const row = db2
       .prepare('SELECT agent_id FROM project_agent_refs WHERE agent_id = ?')
@@ -192,31 +223,31 @@ describe('conduit-sqlite', () => {
   });
 
   // getConduitNativeDb — returns live handle after init
-  it('getConduitNativeDb returns the live DatabaseSync handle after ensureConduitDb', () => {
-    ensureConduitDb(tmpRoot);
+  it('getConduitNativeDb returns the live DatabaseSync handle after ensureConduitDb', async () => {
+    await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb();
     expect(db).not.toBeNull();
     expect(db!.isOpen).toBe(true);
   });
 
-  // getConduitNativeDb — returns null after close
-  it('getConduitNativeDb returns null after closeConduitDb', () => {
-    ensureConduitDb(tmpRoot);
+  // getConduitNativeDb — returns null after close (drops conduit singleton ref)
+  it('getConduitNativeDb returns null after closeConduitDb', async () => {
+    await ensureConduitDb(tmpRoot);
     closeConduitDb();
     expect(getConduitNativeDb()).toBeNull();
   });
 
   // integrity_check
-  it('conduit.db passes PRAGMA integrity_check after creation', () => {
-    ensureConduitDb(tmpRoot);
+  it('cleo.db passes PRAGMA integrity_check after conduit creation', async () => {
+    await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb()!;
     const result = db.prepare('PRAGMA integrity_check').get() as { integrity_check: string };
     expect(result.integrity_check).toBe('ok');
   });
 
   // project_agent_refs schema
-  it('project_agent_refs has expected columns with correct constraints', () => {
-    ensureConduitDb(tmpRoot);
+  it('project_agent_refs has expected columns with correct constraints', async () => {
+    await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb()!;
 
     const cols = db.prepare('PRAGMA table_info(project_agent_refs)').all() as Array<{
@@ -247,8 +278,8 @@ describe('conduit-sqlite', () => {
   });
 
   // partial index on project_agent_refs
-  it('idx_project_agent_refs_enabled partial index exists on project_agent_refs', () => {
-    ensureConduitDb(tmpRoot);
+  it('idx_project_agent_refs_enabled partial index exists on project_agent_refs', async () => {
+    await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb()!;
 
     const indices = db.prepare('PRAGMA index_list(project_agent_refs)').all() as Array<{
@@ -263,7 +294,7 @@ describe('conduit-sqlite', () => {
     expect(enabledIdx?.partial).toBe(1);
   });
 
-  // applyConduitSchema — idempotent on existing db
+  // applyConduitSchema — idempotent on a caller-owned db
   it('applyConduitSchema is idempotent when called twice on the same db', () => {
     const dbPath = join(tmpRoot, 'manual.db');
     mkdirSync(tmpRoot, { recursive: true });
@@ -274,8 +305,8 @@ describe('conduit-sqlite', () => {
   });
 
   // schema version recorded in _conduit_meta
-  it('ensureConduitDb records CONDUIT_SCHEMA_VERSION in _conduit_meta', () => {
-    ensureConduitDb(tmpRoot);
+  it('ensureConduitDb records CONDUIT_SCHEMA_VERSION in _conduit_meta', async () => {
+    await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb()!;
     const meta = db.prepare("SELECT value FROM _conduit_meta WHERE key = 'schema_version'").get() as
       | { value: string }
@@ -283,9 +314,9 @@ describe('conduit-sqlite', () => {
     expect(meta?.value).toBe(CONDUIT_SCHEMA_VERSION);
   });
 
-  // migration row recorded in __drizzle_migrations (T1407 — Drizzle journal SSoT)
-  it('ensureConduitDb records initial baseline in __drizzle_migrations', () => {
-    ensureConduitDb(tmpRoot);
+  // migration row recorded in __drizzle_migrations (T1407 baseline marker)
+  it('ensureConduitDb records the conduit baseline in __drizzle_migrations', async () => {
+    await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb()!;
     const mig = db
       .prepare('SELECT name FROM "__drizzle_migrations" WHERE name = ?')
@@ -293,52 +324,36 @@ describe('conduit-sqlite', () => {
     expect(mig?.name).toBe('20260425000000_initial-conduit');
   });
 
-  // T9027 — schema-version sentinel fast path
-  describe('schema-version sentinel (T9027)', () => {
-    it('hit path: stamps schema_version on first ensure and second ensure short-circuits', () => {
-      const first = ensureConduitDb(tmpRoot);
-      expect(first.action).toBe('created');
-      // Sentinel stamped at end of first ensure().
-      let db = getConduitNativeDb()!;
-      const v1 = db
-        .prepare("SELECT value FROM _conduit_meta WHERE key = 'schema_version'")
-        .get() as { value: string };
-      expect(v1.value).toBe(CONDUIT_SCHEMA_VERSION);
+  // forward migration row recorded (E6-L3 conduit inline-schema migration)
+  it('ensureConduitDb records the E6-L3 conduit inline-schema migration', async () => {
+    await ensureConduitDb(tmpRoot);
+    const db = getConduitNativeDb()!;
+    const mig = db
+      .prepare('SELECT name FROM "__drizzle_migrations" WHERE name = ?')
+      .get('20260601000003_t11523-conduit-inline-schema') as { name: string } | undefined;
+    expect(mig?.name).toBe('20260601000003_t11523-conduit-inline-schema');
+  });
 
-      // Reset singleton so the next call re-opens the on-disk DB and exercises
-      // the sentinel branch (rather than the singleton-hit early return).
-      closeConduitDb();
-      const second = ensureConduitDb(tmpRoot);
-      expect(second.action).toBe('exists');
-      // Sentinel still present and unchanged after fast-path open.
-      db = getConduitNativeDb()!;
-      const v2 = db
-        .prepare("SELECT value FROM _conduit_meta WHERE key = 'schema_version'")
-        .get() as { value: string };
-      expect(v2.value).toBe(CONDUIT_SCHEMA_VERSION);
-    });
+  // re-stamp on stale sentinel (no longer a fast-path, but ensure() re-stamps)
+  it('ensureConduitDb re-stamps CONDUIT_SCHEMA_VERSION on a stale _conduit_meta sentinel', async () => {
+    await ensureConduitDb(tmpRoot);
+    let db = getConduitNativeDb()!;
+    // Corrupt the sentinel to an older version.
+    db.exec("UPDATE _conduit_meta SET value = '1900.0.0' WHERE key = 'schema_version'");
+    closeConduitDb();
+    _resetDualScopeDbCache();
 
-    it('miss path: stale sentinel triggers full migration replay and re-stamps current version', () => {
-      ensureConduitDb(tmpRoot);
-      let db = getConduitNativeDb()!;
-      // Corrupt the sentinel to an older version.
-      db.exec("UPDATE _conduit_meta SET value = '1900.0.0' WHERE key = 'schema_version'");
-      closeConduitDb();
-
-      // Fall-through path runs applyConduitSchema + runConduitMigrations,
-      // then re-stamps the current code version.
-      const result = ensureConduitDb(tmpRoot);
-      expect(result.action).toBe('exists');
-      db = getConduitNativeDb()!;
-      const after = db
-        .prepare("SELECT value FROM _conduit_meta WHERE key = 'schema_version'")
-        .get() as { value: string };
-      expect(after.value).toBe(CONDUIT_SCHEMA_VERSION);
-    });
+    const result = await ensureConduitDb(tmpRoot);
+    expect(result.action).toBe('exists');
+    db = getConduitNativeDb()!;
+    const after = db
+      .prepare("SELECT value FROM _conduit_meta WHERE key = 'schema_version'")
+      .get() as { value: string };
+    expect(after.value).toBe(CONDUIT_SCHEMA_VERSION);
   });
 
   // checkConduitDbHealth — db absent
-  it('checkConduitDbHealth returns exists=false when conduit.db does not exist', () => {
+  it('checkConduitDbHealth returns exists=false when cleo.db does not exist', () => {
     const health = checkConduitDbHealth(tmpRoot);
     expect(health.exists).toBe(false);
     expect(health.tableCount).toBe(0);
@@ -348,24 +363,25 @@ describe('conduit-sqlite', () => {
   });
 
   // checkConduitDbHealth — after creation
-  it('checkConduitDbHealth returns correct health after ensureConduitDb', () => {
-    ensureConduitDb(tmpRoot);
+  it('checkConduitDbHealth returns correct health after ensureConduitDb', async () => {
+    await ensureConduitDb(tmpRoot);
     closeConduitDb();
+    _resetDualScopeDbCache();
 
     const health = checkConduitDbHealth(tmpRoot);
     expect(health.exists).toBe(true);
     expect(health.walMode).toBe(true);
     expect(health.schemaVersion).toBe(CONDUIT_SCHEMA_VERSION);
     expect(health.foreignKeysEnabled).toBe(true);
-    // At minimum all non-FTS tables + FTS main table + meta tables.
-    expect(health.tableCount).toBeGreaterThanOrEqual(EXPECTED_TABLES.length);
+    // At minimum all legacy conduit tables (the consolidated cleo.db has more).
+    expect(health.tableCount).toBeGreaterThanOrEqual(EXPECTED_LEGACY_TABLES.length);
   });
 
   // ensureConduitDb with pre-existing .cleo/ dir
-  it('ensureConduitDb works when .cleo/ dir already exists', () => {
+  it('ensureConduitDb works when .cleo/ dir already exists', async () => {
     mkdirSync(join(tmpRoot, '.cleo'), { recursive: true });
-    expect(() => ensureConduitDb(tmpRoot)).not.toThrow();
-    expect(existsSync(join(tmpRoot, '.cleo', 'conduit.db'))).toBe(true);
+    await expect(ensureConduitDb(tmpRoot)).resolves.toBeDefined();
+    expect(existsSync(join(tmpRoot, '.cleo', 'cleo.db'))).toBe(true);
   });
 
   // ---------------------------------------------------------------------------
@@ -373,8 +389,8 @@ describe('conduit-sqlite', () => {
   // ---------------------------------------------------------------------------
 
   describe('project_agent_refs CRUD (T353)', () => {
-    it('TC-004: attachAgentToProject inserts a new row with enabled=1', () => {
-      ensureConduitDb(tmpRoot);
+    it('TC-004: attachAgentToProject inserts a new row with enabled=1', async () => {
+      await ensureConduitDb(tmpRoot);
       const db = getConduitNativeDb()!;
       attachAgentToProject(db, 'agent-1');
       const ref = getProjectAgentRef(db, 'agent-1');
@@ -386,8 +402,8 @@ describe('conduit-sqlite', () => {
       expect(ref?.lastUsedAt).toBeNull();
     });
 
-    it('TC-005: attachAgentToProject re-enables an existing enabled=0 row without duplicate', () => {
-      ensureConduitDb(tmpRoot);
+    it('TC-005: attachAgentToProject re-enables an existing enabled=0 row without duplicate', async () => {
+      await ensureConduitDb(tmpRoot);
       const db = getConduitNativeDb()!;
       attachAgentToProject(db, 'agent-1');
       detachAgentFromProject(db, 'agent-1');
@@ -407,8 +423,8 @@ describe('conduit-sqlite', () => {
       expect(count).toBe(1);
     });
 
-    it('TC-006: detachAgentFromProject sets enabled=0 without deleting', () => {
-      ensureConduitDb(tmpRoot);
+    it('TC-006: detachAgentFromProject sets enabled=0 without deleting', async () => {
+      await ensureConduitDb(tmpRoot);
       const db = getConduitNativeDb()!;
       attachAgentToProject(db, 'agent-1');
       detachAgentFromProject(db, 'agent-1');
@@ -417,8 +433,8 @@ describe('conduit-sqlite', () => {
       expect(ref?.enabled).toBe(0);
     });
 
-    it('TC-007: listProjectAgentRefs returns only enabled=1 rows by default', () => {
-      ensureConduitDb(tmpRoot);
+    it('TC-007: listProjectAgentRefs returns only enabled=1 rows by default', async () => {
+      await ensureConduitDb(tmpRoot);
       const db = getConduitNativeDb()!;
       attachAgentToProject(db, 'agent-1');
       attachAgentToProject(db, 'agent-2');
@@ -429,8 +445,8 @@ describe('conduit-sqlite', () => {
       expect(enabled.map((r) => r.agentId).sort()).toEqual(['agent-1', 'agent-3']);
     });
 
-    it('TC-008: listProjectAgentRefs returns all rows when enabledOnly=false', () => {
-      ensureConduitDb(tmpRoot);
+    it('TC-008: listProjectAgentRefs returns all rows when enabledOnly=false', async () => {
+      await ensureConduitDb(tmpRoot);
       const db = getConduitNativeDb()!;
       attachAgentToProject(db, 'agent-1');
       attachAgentToProject(db, 'agent-2');
@@ -439,15 +455,15 @@ describe('conduit-sqlite', () => {
       expect(all.length).toBe(2);
     });
 
-    it('TC-009: getProjectAgentRef returns null for unknown agent', () => {
-      ensureConduitDb(tmpRoot);
+    it('TC-009: getProjectAgentRef returns null for unknown agent', async () => {
+      await ensureConduitDb(tmpRoot);
       const db = getConduitNativeDb()!;
       const ref = getProjectAgentRef(db, 'nonexistent');
       expect(ref).toBeNull();
     });
 
-    it('TC-010: updateProjectAgentLastUsed sets last_used_at to current ISO timestamp', () => {
-      ensureConduitDb(tmpRoot);
+    it('TC-010: updateProjectAgentLastUsed sets last_used_at to current ISO timestamp', async () => {
+      await ensureConduitDb(tmpRoot);
       const db = getConduitNativeDb()!;
       attachAgentToProject(db, 'agent-1');
       const before = new Date().toISOString();

--- a/packages/core/src/store/__tests__/migrate-signaldock-to-conduit.test.ts
+++ b/packages/core/src/store/__tests__/migrate-signaldock-to-conduit.test.ts
@@ -330,6 +330,9 @@ async function runMigration(
   vi.doMock('../../paths.js', () => ({
     getCleoHome: () => home,
     getProjectRoot: () => projectRoot,
+    // E6-L3 (T11523): conduit consolidated into the project cleo.db; the path now
+    // resolves via resolveCleoDir(cwd). Pin it to <projectRoot>/.cleo for tests.
+    resolveCleoDir: (cwd?: string) => join(cwd ?? projectRoot, '.cleo'),
   }));
   vi.doMock('../global-salt.js', () => ({
     getGlobalSalt: () => Buffer.alloc(32, 0xab),
@@ -343,7 +346,7 @@ async function runMigration(
     getGlobalSignaldockDbPath: () => join(home, 'signaldock.db'),
   }));
   const { migrateSignaldockToConduit } = await import('../migrate-signaldock-to-conduit.js');
-  return migrateSignaldockToConduit(projectRoot);
+  return await migrateSignaldockToConduit(projectRoot);
 }
 
 async function getNeedsMigration(projectRoot: string, home: string): Promise<boolean> {
@@ -351,6 +354,8 @@ async function getNeedsMigration(projectRoot: string, home: string): Promise<boo
   vi.doMock('../../paths.js', () => ({
     getCleoHome: () => home,
     getProjectRoot: () => projectRoot,
+    // E6-L3 (T11523): see runMigration mock — resolveCleoDir pins the project DB.
+    resolveCleoDir: (cwd?: string) => join(cwd ?? projectRoot, '.cleo'),
   }));
   const { needsSignaldockToConduitMigration } = await import('../migrate-signaldock-to-conduit.js');
   return needsSignaldockToConduitMigration(projectRoot);
@@ -382,7 +387,7 @@ describe('migrate-signaldock-to-conduit', () => {
     });
 
     it('TC-060: returns false when conduit.db exists (migration already done)', async () => {
-      writeFileSync(join(dirs.projectRoot, '.cleo', 'conduit.db'), '');
+      writeFileSync(join(dirs.projectRoot, '.cleo', 'cleo.db'), '');
       const result = await getNeedsMigration(dirs.projectRoot, dirs.home);
       expect(result).toBe(false);
     });
@@ -403,7 +408,7 @@ describe('migrate-signaldock-to-conduit', () => {
     expect(result.agentsCopied).toBe(0);
     expect(result.bakPath).toBeNull();
     expect(result.errors).toHaveLength(0);
-    expect(existsSync(join(dirs.projectRoot, '.cleo', 'conduit.db'))).toBe(false);
+    expect(existsSync(join(dirs.projectRoot, '.cleo', 'cleo.db'))).toBe(false);
   });
 
   // -------------------------------------------------------------------------
@@ -419,7 +424,7 @@ describe('migrate-signaldock-to-conduit', () => {
     expect(result.agentsCopied).toBe(0);
     expect(result.bakPath).not.toBeNull();
     expect(result.errors).toHaveLength(0);
-    expect(existsSync(join(dirs.projectRoot, '.cleo', 'conduit.db'))).toBe(true);
+    expect(existsSync(join(dirs.projectRoot, '.cleo', 'cleo.db'))).toBe(true);
     expect(existsSync(join(dirs.projectRoot, '.cleo', 'signaldock.db.pre-t310.bak'))).toBe(true);
     expect(existsSync(join(dirs.projectRoot, '.cleo', 'signaldock.db'))).toBe(false);
   });
@@ -443,7 +448,7 @@ describe('migrate-signaldock-to-conduit', () => {
     expect(result.errors).toHaveLength(0);
 
     // Verify project_agent_refs in conduit.db
-    const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'conduit.db'));
+    const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'cleo.db'));
     const refs = conduitDb
       .prepare('SELECT agent_id FROM project_agent_refs ORDER BY agent_id')
       .all() as Array<{ agent_id: string }>;
@@ -506,7 +511,7 @@ describe('migrate-signaldock-to-conduit', () => {
     globalDb.close();
 
     // conduit.db should have a project_agent_refs row for agent-x
-    const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'conduit.db'));
+    const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'cleo.db'));
     const refs = conduitDb
       .prepare("SELECT agent_id FROM project_agent_refs WHERE agent_id = 'agent-x'")
       .all() as Array<{ agent_id: string }>;
@@ -574,7 +579,7 @@ describe('migrate-signaldock-to-conduit', () => {
     expect(result.status).toBe('migrated');
     expect(result.errors).toHaveLength(0);
 
-    const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'conduit.db'));
+    const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'cleo.db'));
 
     const convRows = conduitDb.prepare('SELECT id FROM conversations ORDER BY id').all() as Array<{
       id: string;
@@ -614,7 +619,7 @@ describe('migrate-signaldock-to-conduit', () => {
     const result = await runMigration(dirs.projectRoot, dirs.home);
     expect(result.status).toBe('migrated');
 
-    const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'conduit.db'));
+    const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'cleo.db'));
     const ftsResults = conduitDb
       .prepare("SELECT rowid FROM messages_fts WHERE messages_fts MATCH 'migration'")
       .all() as Array<{ rowid: number }>;
@@ -636,7 +641,7 @@ describe('migrate-signaldock-to-conduit', () => {
     expect(result.status).toBe('failed');
     expect(result.errors.length).toBeGreaterThan(0);
     // No conduit.db created
-    expect(existsSync(join(dirs.projectRoot, '.cleo', 'conduit.db'))).toBe(false);
+    expect(existsSync(join(dirs.projectRoot, '.cleo', 'cleo.db'))).toBe(false);
     // No .pre-t310.bak created
     expect(existsSync(legacyPath + '.pre-t310.bak')).toBe(false);
   });
@@ -662,7 +667,7 @@ describe('migrate-signaldock-to-conduit', () => {
   // Scenario 9: .pre-t310.bak alongside conduit.db
   // -------------------------------------------------------------------------
   it('needsMigration returns false when conduit.db exists alongside .pre-t310.bak', async () => {
-    writeFileSync(join(dirs.projectRoot, '.cleo', 'conduit.db'), '');
+    writeFileSync(join(dirs.projectRoot, '.cleo', 'cleo.db'), '');
     writeFileSync(join(dirs.projectRoot, '.cleo', 'signaldock.db.pre-t310.bak'), '');
 
     const result = await getNeedsMigration(dirs.projectRoot, dirs.home);

--- a/packages/core/src/store/__tests__/t310-integration.test.ts
+++ b/packages/core/src/store/__tests__/t310-integration.test.ts
@@ -389,7 +389,7 @@ async function runMigration(
     getGlobalSignaldockDbPath: () => join(cleoHome, 'signaldock.db'),
   }));
   const { migrateSignaldockToConduit } = await import('../migrate-signaldock-to-conduit.js');
-  return migrateSignaldockToConduit(projectRoot);
+  return await migrateSignaldockToConduit(projectRoot);
 }
 
 // ---------------------------------------------------------------------------
@@ -427,7 +427,7 @@ describe('T310: conduit + signaldock integration', () => {
     const { ensureConduitDb } = await import('../conduit-sqlite.js');
     const { ensureGlobalSignaldockDb } = await import('../signaldock-sqlite.js');
 
-    const conduitResult = ensureConduitDb(projectRoot);
+    const conduitResult = await ensureConduitDb(projectRoot);
     expect(conduitResult.action).toBe('created');
     expect(existsSync(conduitResult.path)).toBe(true);
 
@@ -474,7 +474,7 @@ describe('T310: conduit + signaldock integration', () => {
     const { deriveApiKey } = await import('../api-key-kdf.js');
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(projectRoot);
+    await ensureConduitDb(projectRoot);
     closeConduitDb();
 
     const spec = {
@@ -490,7 +490,7 @@ describe('T310: conduit + signaldock integration', () => {
       isActive: true,
     };
 
-    const result = createProjectAgent(projectRoot, spec);
+    const result = await createProjectAgent(projectRoot, spec);
     expect(result.agentId).toBe(spec.agentId);
     expect(result.projectRef).not.toBeNull();
     expect(result.projectRef?.enabled).toBe(1);
@@ -544,7 +544,7 @@ describe('T310: conduit + signaldock integration', () => {
     const { lookupAgent } = await import('../agent-registry-accessor.js');
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(projectRoot);
+    await ensureConduitDb(projectRoot);
     closeConduitDb();
 
     // Seed agent X into global only (no project ref)
@@ -583,7 +583,7 @@ describe('T310: conduit + signaldock integration', () => {
     const { listAgentsForProject } = await import('../agent-registry-accessor.js');
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(projectRoot);
+    await ensureConduitDb(projectRoot);
     closeConduitDb();
 
     // Seed 3 global agents
@@ -649,13 +649,13 @@ describe('T310: conduit + signaldock integration', () => {
     );
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(projectA);
+    await ensureConduitDb(projectA);
     closeConduitDb();
-    ensureConduitDb(projectB);
+    await ensureConduitDb(projectB);
     closeConduitDb();
 
     // Create agent in A
-    createProjectAgent(projectA, {
+    await createProjectAgent(projectA, {
       agentId: 'cross-project-agent',
       displayName: 'Cross Project Agent',
       apiKey: 'sk_test_cross',
@@ -711,13 +711,13 @@ describe('T310: conduit + signaldock integration', () => {
     } = await import('../agent-registry-accessor.js');
 
     await ensureGlobalSignaldockDb();
-    ensureConduitDb(projectA);
+    await ensureConduitDb(projectA);
     closeConduitDb();
-    ensureConduitDb(projectB);
+    await ensureConduitDb(projectB);
     closeConduitDb();
 
     // Create agent in A
-    createProjectAgent(projectA, {
+    await createProjectAgent(projectA, {
       agentId: 'attach-detach-agent',
       displayName: 'Attach Detach Agent',
       apiKey: 'sk_test_ad',

--- a/packages/core/src/store/agent-registry-accessor.ts
+++ b/packages/core/src/store/agent-registry-accessor.ts
@@ -555,12 +555,15 @@ export function listAgentsForProject(
  * @task T355
  * @epic T310
  */
-export function createProjectAgent(
+export async function createProjectAgent(
   projectRoot: string,
   spec: Omit<AgentCredential, 'createdAt' | 'updatedAt'>,
-): AgentWithProjectOverride {
-  ensureGlobalSignaldockDb();
-  ensureConduitDb(projectRoot);
+): Promise<AgentWithProjectOverride> {
+  // E6-L3 (T11523): ensureConduitDb is now async (routes through the dual-scope
+  // cleo.db chokepoint). ensureGlobalSignaldockDb is already async. Await both so
+  // the bare schema exists before the short-lived raw handles below read/write it.
+  await ensureGlobalSignaldockDb();
+  await ensureConduitDb(projectRoot);
 
   const nowTs = Math.floor(Date.now() / 1000);
   const nowIso = new Date(nowTs * 1000).toISOString();
@@ -816,9 +819,11 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    * @task T355
    * @epic T310
    */
-  private ensureDbs(): void {
-    ensureGlobalSignaldockDb();
-    ensureConduitDb(this.projectPath);
+  private async ensureDbs(): Promise<void> {
+    // E6-L3 (T11523): ensureConduitDb is now async (dual-scope cleo.db
+    // chokepoint); ensureGlobalSignaldockDb is already async. Await both.
+    await ensureGlobalSignaldockDb();
+    await ensureConduitDb(this.projectPath);
   }
 
   /**
@@ -833,7 +838,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
   async register(
     credential: Omit<AgentCredential, 'createdAt' | 'updatedAt'>,
   ): Promise<AgentCredential> {
-    this.ensureDbs();
+    await this.ensureDbs();
     return createProjectAgent(this.projectPath, credential);
   }
 
@@ -847,7 +852,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    * @epic T310
    */
   async get(agentId: string, opts?: { includeGlobal?: boolean }): Promise<AgentCredential | null> {
-    this.ensureDbs();
+    await this.ensureDbs();
     return lookupAgent(this.projectPath, agentId, opts);
   }
 
@@ -860,7 +865,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    * @epic T310
    */
   async list(filter?: AgentListFilter): Promise<AgentCredential[]> {
-    this.ensureDbs();
+    await this.ensureDbs();
     const results = listAgentsForProject(this.projectPath, { includeGlobal: false });
     if (filter?.active !== undefined) {
       return results.filter((a) => a.isActive === filter.active);
@@ -877,7 +882,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    * @epic T310
    */
   async listGlobal(filter?: AgentListFilter): Promise<AgentCredential[]> {
-    this.ensureDbs();
+    await this.ensureDbs();
     const globalDb = openGlobalDb();
     try {
       const rows =
@@ -909,7 +914,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
     agentId: string,
     updates: Partial<Omit<AgentCredential, 'agentId' | 'createdAt'>>,
   ): Promise<AgentCredential> {
-    this.ensureDbs();
+    await this.ensureDbs();
     const existing = await this.get(agentId, { includeGlobal: true });
     if (!existing) throw new Error(`Agent not found: ${agentId}`);
 
@@ -1001,7 +1006,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    * @epic T310
    */
   async remove(agentId: string): Promise<void> {
-    this.ensureDbs();
+    await this.ensureDbs();
 
     const conduitDb = openConduitDb(this.projectPath);
     try {
@@ -1029,7 +1034,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    * @epic T310
    */
   async removeGlobal(agentId: string, opts?: { force?: boolean }): Promise<void> {
-    this.ensureDbs();
+    await this.ensureDbs();
     const globalDb = openGlobalDb();
     try {
       const existing = globalDb.prepare('SELECT id FROM agents WHERE agent_id = ?').get(agentId) as
@@ -1073,7 +1078,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    * @epic T310
    */
   async rotateKey(agentId: string): Promise<{ agentId: string; newApiKey: string }> {
-    this.ensureDbs();
+    await this.ensureDbs();
     const credential = await this.get(agentId, { includeGlobal: true });
     if (!credential) throw new Error(`Agent not found: ${agentId}`);
 
@@ -1121,7 +1126,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    * @epic T310
    */
   async getActive(): Promise<AgentCredential | null> {
-    this.ensureDbs();
+    await this.ensureDbs();
 
     const globalDb = openGlobalDb();
     const conduitDb = openConduitDb(this.projectPath);
@@ -1163,7 +1168,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    * @epic T310
    */
   async markUsed(agentId: string): Promise<void> {
-    this.ensureDbs();
+    await this.ensureDbs();
     const nowTs = Math.floor(Date.now() / 1000);
     const nowIso = new Date(nowTs * 1000).toISOString();
 

--- a/packages/core/src/store/backup-pack.ts
+++ b/packages/core/src/store/backup-pack.ts
@@ -33,7 +33,6 @@ import type { BackupManifest, BackupScope } from '@cleocode/contracts';
 import { create as tarCreate } from 'tar';
 import { getCleoHome, getProjectRoot } from '../paths.js';
 import { encryptBundle } from './backup-crypto.js';
-import { getConduitDbPath } from './conduit-sqlite.js';
 import { getGlobalSaltPath } from './global-salt.js';
 import { getNexusDbPath } from './nexus-sqlite.js';
 import { getGlobalSignaldockDbPath } from './signaldock-sqlite.js';
@@ -457,7 +456,14 @@ export async function packBundle(input: PackBundleInput): Promise<PackBundleResu
         }
       }
       // conduit.db
-      const conduitSrc = getConduitDbPath(resolvedProjectRoot);
+      // E6-L3 (T11523): backup-pack reads the legacy on-disk filenames uniformly
+      // (tasks.db / brain.db above use the literal name, NOT the dual-scope
+      // resolver). Keep conduit consistent — read the literal legacy `conduit.db`
+      // rather than `getConduitDbPath()` (which now resolves to the consolidated
+      // `cleo.db` and would duplicate the tasks/brain snapshot + diverge from the
+      // bundle's `databases/conduit.db` staging name). The exodus (T11248) is what
+      // reconciles these on-disk files into `cleo.db`.
+      const conduitSrc = path.join(cleoDir, 'conduit.db');
       const conduitDest = path.join(stagingDir, 'databases', 'conduit.db');
       const conduitSnapped = vacuumIntoStaging(conduitSrc, conduitDest);
       if (conduitSnapped) {

--- a/packages/core/src/store/conduit-sqlite.ts
+++ b/packages/core/src/store/conduit-sqlite.ts
@@ -1,46 +1,85 @@
 /**
- * SQLite store for conduit.db — project-tier messaging and agent-ref database.
+ * SQLite store for the project-scope CONDUIT domain — agent-to-agent messaging,
+ * delivery queue, attachments, A2A topics, and per-project agent refs.
  *
- * Creates and manages .cleo/conduit.db using node:sqlite directly.
+ * ## E6-L3 — thin-facade migration (T11523)
  *
- * Schema definitions live in `conduit-schema.ts` (Drizzle ORM table objects).
- * On open, the legacy DDL bootstrap (`applyConduitSchema`, retained as a
- * `CREATE TABLE IF NOT EXISTS` fallback that also handles the FTS5 virtual
- * table + triggers which Drizzle cannot model) creates any missing tables,
- * then the canonical `migration-manager.ts` runner reconciles the Drizzle
- * journal and applies any pending migrations from
- * `packages/core/migrations/drizzle-conduit/`. This brings conduit.db into
- * the same SSoT pattern as tasks/brain/nexus/signaldock/telemetry.
+ * `ensureConduitDb()` is now a thin facade that delegates the database open to
+ * {@link openDualScopeDb}('project', cwd) — the canonical dual-scope chokepoint
+ * introduced by E3/E4 (T11512/T11517) and already adopted by the tasks domain
+ * (E6-L1, T11521) and brain domain (E6-L2, T11522). This ensures:
+ *
+ * - Every conduit-domain open flows through the single pragma SSoT (ADR-068/069).
+ * - The conduit tables now live inside the consolidated project `cleo.db` — NOT a
+ *   separate `conduit.db` file — co-existing with `tasks_*` / `brain_*` / etc.
+ * - DB Open Guard Gate 3 (`scripts/lint-no-direct-db-open.mjs`) stays green: the
+ *   only native open is inside `dual-scope-db.ts`.
+ *
+ * ## Inline DDL → forward migration (T11523 acceptance criteria)
+ *
+ * The 16-table inline `CONDUIT_SCHEMA_SQL` blob (formerly applied by
+ * `applyConduitSchema()`) has been removed and converted to a forward Drizzle
+ * migration under
+ * `migrations/drizzle-conduit/20260601000003_t11523-conduit-inline-schema`,
+ * matching the T1407 baseline marker and the L1/L2 precedent. The migration is
+ * reproduced VERBATIM (legacy runtime shape) — 16 tables + indexes + the
+ * `messages_fts` FTS5 virtual table + its 3 triggers — so the LocalTransport and
+ * accessor writers keep working unchanged.
+ *
+ * ## Disjoint physical names (no DROP/rebuild)
+ *
+ * The conduit legacy physical tables are BARE (`conversations`, `messages`,
+ * `delivery_jobs`, …) while the consolidated schema (`cleo-project/conduit.ts`)
+ * carries the `conduit_` domain prefix (`conduit_conversations`, …). They are
+ * therefore DISJOINT names — the legacy runtime-shape tables co-exist harmlessly
+ * with the consolidated `conduit_*` tables in the same `cleo.db`, exactly like the
+ * tasks domain (legacy `tasks` ≠ consolidated `tasks_tasks`). Unlike the brain
+ * domain (E6-L2, same prefixed names → drop + rebuild), the conduit facade needs
+ * no teardown. The exodus migration (T11248 / T11553) renames the legacy tables to
+ * `conduit_*`.
  *
  * Architecture (ADR-037):
- *   conduit.db   — project-scoped (this module) — messaging, delivery, attachments,
+ *   conduit (this module) — project-scoped — messaging, delivery, attachments,
  *                  project_agent_refs
  *   signaldock.db — global-scoped (T346) — agents, capabilities, cloud-sync tables
  *
  * @task T344
  * @task T1407
+ * @task T11523 - E6-L3: route ensureConduitDb through openDualScopeDb (SG-DB-SUBSTRATE-V2)
  * @epic T310
- * @why ADR-037 splits single signaldock.db into project-tier conduit.db
+ * @epic T11249
+ * @why ADR-037 splits single signaldock.db into project-tier conduit
  *      (this module) and global-tier signaldock.db (T346). T1407 unifies
- *      conduit.db under the canonical Drizzle migration runner.
- * @what Path helper, database initializer, Drizzle migration runner wiring,
- *       legacy schema applier (bootstrap + FTS5 fallback), health check,
- *       and native DB accessor.
+ *      conduit under the canonical Drizzle migration runner; T11523 routes it
+ *      through the consolidated `cleo.db` dual-scope chokepoint.
+ * @what Path helper, database initializer (dual-scope facade), Drizzle migration
+ *       runner wiring, health check, native DB accessor, and project_agent_refs
+ *       CRUD accessors.
  */
 
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, join } from 'node:path';
 // underscore-import: node:sqlite type alias required for createRequire interop.
-// Vitest/Vite cannot resolve `node:sqlite` as an ESM import (strips `node:` prefix).
-// Use createRequire as the runtime loader; keep type-only import for annotations.
+// The runtime node:sqlite loading is handled by openDualScopeDb() /
+// openNativeDatabase() in their respective leaf modules. The type import is
+// erased at runtime and is safe.
 import type { DatabaseSync as _DatabaseSyncType } from 'node:sqlite';
 import type { ProjectAgentRef } from '@cleocode/contracts';
-import { drizzle } from 'drizzle-orm/node-sqlite';
+// Lazy-loaded drizzle factory (see _getDrizzle). drizzle-orm/node-sqlite
+// statically imports node:sqlite, so a top-level value import would pull the
+// native binding at module-load — defeating the lazy-init invariant. The type
+// import is erased at runtime and is safe.
+import type { drizzle as drizzleFn } from 'drizzle-orm/node-sqlite';
+// E6-L3 (T11523): dual-scope chokepoint — the conduit domain now opens the
+// consolidated project `cleo.db` through here. openDualScopeDb manages the
+// DatabaseSync lifecycle, pragmas, and consolidated migrations. We extract the
+// native handle and re-wrap it with the legacy conduit-schema drizzle instance so
+// existing callers compile and run without change.
+import { openDualScopeDb, resolveDualScopeDbPath } from './dual-scope-db.js';
 import { migrateSanitized, reconcileJournal } from './migration-manager.js';
 import { resolveCorePackageMigrationsFolder } from './resolve-migrations-folder.js';
 import * as conduitSchema from './schema/conduit-schema.js';
-import { applyPerfPragmas, optimizeBeforeClose } from './sqlite-pragmas.js';
+import { applyPerfPragmas } from './sqlite-pragmas.js';
 
 const _require = createRequire(import.meta.url);
 type DatabaseSync = _DatabaseSyncType;
@@ -48,15 +87,49 @@ const { DatabaseSync } = _require('node:sqlite') as {
   DatabaseSync: new (...args: ConstructorParameters<typeof _DatabaseSyncType>) => DatabaseSync;
 };
 
-/** Database file name within .cleo/ directory. */
+/**
+ * Cached `drizzle` factory from `drizzle-orm/node-sqlite`, loaded on first use.
+ *
+ * Loaded via `createRequire` rather than a top-level import so that importing
+ * `conduit-sqlite.ts` does not eagerly pull in `node:sqlite` (which the drizzle
+ * driver statically imports). Memoized after the first call. Mirrors the
+ * `_getDrizzle` lazy pattern in sqlite.ts / memory-sqlite.ts (T11280/T11521/T11522).
+ *
+ * @internal
+ * @task T11523
+ */
+let _drizzle: typeof drizzleFn | null = null;
+
+/**
+ * Returns the `drizzle` factory, loading `drizzle-orm/node-sqlite` on first call.
+ *
+ * @internal
+ * @task T11523
+ */
+function _getDrizzle(): typeof drizzleFn {
+  if (_drizzle === null) {
+    const mod = _require('drizzle-orm/node-sqlite') as { drizzle: typeof drizzleFn };
+    _drizzle = mod.drizzle;
+  }
+  return _drizzle;
+}
+
+/**
+ * Legacy database file name. Retained as an export for backwards compatibility
+ * with callers that still reference the constant; the conduit domain now lives
+ * inside the consolidated project `cleo.db` (E6-L3, T11523).
+ *
+ * @deprecated The conduit domain no longer has a standalone `conduit.db` file —
+ *   it is served from the project `cleo.db`. Use {@link getConduitDbPath}.
+ */
 export const CONDUIT_DB_FILENAME = 'conduit.db';
 
 /**
- * Schema version for conduit.db.
+ * Schema version for the conduit domain.
  *
- * Bumped only when the Drizzle schema changes. T1407 refactor preserved the
- * 2026.4.23 schema verbatim (DDL representation only — no semantic changes),
- * so the version remains pinned at the post-T1252 A2A topics value.
+ * Bumped only when the conduit Drizzle schema changes. Pinned at the post-T1252
+ * A2A topics value; retained for backwards compatibility with pre-T1407 health
+ * checks that read `_conduit_meta.schema_version`.
  */
 export const CONDUIT_SCHEMA_VERSION = '2026.4.23';
 
@@ -66,359 +139,35 @@ export const CONDUIT_SCHEMA_VERSION = '2026.4.23';
 
 let _conduitNativeDb: DatabaseSync | null = null;
 let _conduitDbPath: string | null = null;
-
-// ---------------------------------------------------------------------------
-// DDL
-// ---------------------------------------------------------------------------
-
-/**
- * Full conduit.db schema SQL.
- *
- * All tables use CREATE TABLE IF NOT EXISTS / CREATE INDEX IF NOT EXISTS /
- * CREATE TRIGGER IF NOT EXISTS for idempotency. Carried over verbatim from
- * the project-local tables in signaldock-sqlite.ts (migration
- * `2026-03-28-000000_initial` + subsequent migrations), minus the global-
- * identity tables (agents, capabilities, skills, agent_capabilities,
- * agent_skills, agent_connections, users, organization, accounts, sessions,
- * verifications, claim_codes, org_agent_keys) which move to global-tier
- * signaldock.db (T346).
- *
- * Additional new table: project_agent_refs (ADR-037 §3, Q6=A).
- *
- * NOTE: The `connections` table from the original migration is a cross-agent
- * social graph that references `agents(id)` — it is a global-identity
- * concern and stays with signaldock.db (T346). It is NOT included here.
- */
-const CONDUIT_SCHEMA_SQL = `
--- -------------------------------------------------------------------------
--- Project-scoped conversations (LocalTransport DM threads).
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS conversations (
-    id TEXT PRIMARY KEY,
-    participants TEXT NOT NULL,
-    visibility TEXT NOT NULL DEFAULT 'private',
-    message_count INTEGER NOT NULL DEFAULT 0,
-    last_message_at INTEGER,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
-);
-
--- -------------------------------------------------------------------------
--- Project-scoped agent-to-agent messages (LocalTransport content).
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS messages (
-    id TEXT PRIMARY KEY,
-    conversation_id TEXT NOT NULL REFERENCES conversations(id),
-    from_agent_id TEXT NOT NULL,
-    to_agent_id TEXT NOT NULL,
-    content TEXT NOT NULL,
-    content_type TEXT NOT NULL DEFAULT 'text',
-    status TEXT NOT NULL DEFAULT 'pending',
-    attachments TEXT NOT NULL DEFAULT '[]',
-    group_id TEXT,
-    metadata TEXT DEFAULT '{}',
-    reply_to TEXT,
-    created_at INTEGER NOT NULL,
-    delivered_at INTEGER,
-    read_at INTEGER
-);
-CREATE INDEX IF NOT EXISTS messages_conversation_idx ON messages(conversation_id);
-CREATE INDEX IF NOT EXISTS messages_from_agent_idx ON messages(from_agent_id);
-CREATE INDEX IF NOT EXISTS messages_to_agent_idx ON messages(to_agent_id);
-CREATE INDEX IF NOT EXISTS messages_created_at_idx ON messages(created_at);
-CREATE INDEX IF NOT EXISTS idx_messages_group_id ON messages(group_id) WHERE group_id IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_messages_reply_to ON messages(reply_to) WHERE reply_to IS NOT NULL;
-
--- -------------------------------------------------------------------------
--- FTS5 virtual table for full-text search on message content.
--- NOTE: Must be migrated using VACUUM INTO, not DDL-only copy, to preserve
--- triggers. The INSERT INTO messages_fts(messages_fts) VALUES('rebuild')
--- is idempotent — safe to run on every open.
--- -------------------------------------------------------------------------
-CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts
-    USING fts5(content, from_agent_id, content='messages', content_rowid='rowid');
-INSERT INTO messages_fts(messages_fts) VALUES('rebuild');
-CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
-    INSERT INTO messages_fts(rowid, content, from_agent_id)
-        VALUES (new.rowid, new.content, new.from_agent_id);
-END;
-CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
-    INSERT INTO messages_fts(messages_fts, rowid, content, from_agent_id)
-        VALUES('delete', old.rowid, old.content, old.from_agent_id);
-END;
-CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
-    INSERT INTO messages_fts(messages_fts, rowid, content, from_agent_id)
-        VALUES('delete', old.rowid, old.content, old.from_agent_id);
-    INSERT INTO messages_fts(rowid, content, from_agent_id)
-        VALUES (new.rowid, new.content, new.from_agent_id);
-END;
-
--- -------------------------------------------------------------------------
--- Async delivery queue for deferred message dispatch.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS delivery_jobs (
-    id TEXT PRIMARY KEY,
-    message_id TEXT NOT NULL,
-    payload TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending',
-    attempts INTEGER NOT NULL DEFAULT 0,
-    max_attempts INTEGER NOT NULL DEFAULT 6,
-    next_attempt_at INTEGER NOT NULL,
-    last_error TEXT,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_delivery_jobs_status ON delivery_jobs(status, next_attempt_at);
-
--- -------------------------------------------------------------------------
--- Dead-letter queue for messages that exceeded max delivery attempts.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS dead_letters (
-    id TEXT PRIMARY KEY,
-    message_id TEXT NOT NULL,
-    job_id TEXT NOT NULL,
-    reason TEXT NOT NULL,
-    attempts INTEGER NOT NULL,
-    created_at INTEGER NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_dead_letters_message ON dead_letters(message_id);
-
--- -------------------------------------------------------------------------
--- Pinned messages within a conversation.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS message_pins (
-    id TEXT PRIMARY KEY,
-    message_id TEXT NOT NULL,
-    conversation_id TEXT NOT NULL,
-    pinned_by TEXT NOT NULL,
-    note TEXT,
-    created_at INTEGER NOT NULL,
-    UNIQUE(message_id, pinned_by)
-);
-CREATE INDEX IF NOT EXISTS idx_pins_conversation ON message_pins(conversation_id);
-CREATE INDEX IF NOT EXISTS idx_pins_agent ON message_pins(pinned_by);
-
--- -------------------------------------------------------------------------
--- File/blob attachments associated with messages.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS attachments (
-    slug TEXT PRIMARY KEY,
-    conversation_id TEXT NOT NULL,
-    from_agent_id TEXT NOT NULL,
-    content BLOB NOT NULL,
-    original_size INTEGER NOT NULL,
-    compressed_size INTEGER NOT NULL,
-    content_hash TEXT NOT NULL,
-    format TEXT NOT NULL DEFAULT 'text',
-    title TEXT,
-    tokens INTEGER NOT NULL DEFAULT 0,
-    expires_at INTEGER NOT NULL DEFAULT 0,
-    storage_key TEXT,
-    mode TEXT NOT NULL DEFAULT 'draft',
-    version_count INTEGER NOT NULL DEFAULT 1,
-    current_version INTEGER NOT NULL DEFAULT 1,
-    created_at INTEGER NOT NULL
-);
-CREATE INDEX IF NOT EXISTS attachments_conversation_idx ON attachments(conversation_id);
-CREATE INDEX IF NOT EXISTS attachments_agent_idx ON attachments(from_agent_id);
-
--- -------------------------------------------------------------------------
--- Version history for attachments (collaborative editing).
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS attachment_versions (
-    id TEXT PRIMARY KEY,
-    slug TEXT NOT NULL REFERENCES attachments(slug) ON DELETE CASCADE,
-    version_number INTEGER NOT NULL,
-    author_agent_id TEXT NOT NULL,
-    change_type TEXT NOT NULL DEFAULT 'patch',
-    patch_text TEXT,
-    storage_key TEXT NOT NULL,
-    content_hash TEXT NOT NULL,
-    original_size INTEGER NOT NULL,
-    compressed_size INTEGER NOT NULL,
-    tokens INTEGER NOT NULL,
-    change_summary TEXT,
-    sections_modified TEXT NOT NULL DEFAULT '[]',
-    tokens_added INTEGER NOT NULL DEFAULT 0,
-    tokens_removed INTEGER NOT NULL DEFAULT 0,
-    created_at INTEGER NOT NULL,
-    UNIQUE(slug, version_number)
-);
-CREATE INDEX IF NOT EXISTS idx_attachment_versions_slug ON attachment_versions(slug);
-CREATE INDEX IF NOT EXISTS idx_attachment_versions_author ON attachment_versions(author_agent_id);
-
--- -------------------------------------------------------------------------
--- Approval records for attachment content review.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS attachment_approvals (
-    id TEXT PRIMARY KEY,
-    slug TEXT NOT NULL REFERENCES attachments(slug) ON DELETE CASCADE,
-    reviewer_agent_id TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending',
-    comment TEXT,
-    version_reviewed INTEGER NOT NULL,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL,
-    UNIQUE(slug, reviewer_agent_id)
-);
-CREATE INDEX IF NOT EXISTS idx_attachment_approvals_slug ON attachment_approvals(slug);
-
--- -------------------------------------------------------------------------
--- Contributor statistics per attachment (who edited, how much).
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS attachment_contributors (
-    slug TEXT NOT NULL REFERENCES attachments(slug) ON DELETE CASCADE,
-    agent_id TEXT NOT NULL,
-    version_count INTEGER NOT NULL DEFAULT 0,
-    total_tokens_added INTEGER NOT NULL DEFAULT 0,
-    total_tokens_removed INTEGER NOT NULL DEFAULT 0,
-    first_contribution_at INTEGER NOT NULL,
-    last_contribution_at INTEGER NOT NULL,
-    PRIMARY KEY (slug, agent_id)
-);
-
--- -------------------------------------------------------------------------
--- NEW: Per-project agent reference overrides (ADR-037 §3, Q6=A).
--- agent_id is a SOFT FK to global signaldock.db:agents.agent_id.
--- Cross-DB FK enforcement is not possible in SQLite; the accessor layer
--- (T355) validates on every cross-DB join.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS project_agent_refs (
-    agent_id TEXT PRIMARY KEY,
-    attached_at TEXT NOT NULL,
-    role TEXT,
-    capabilities_override TEXT,
-    last_used_at TEXT,
-    enabled INTEGER NOT NULL DEFAULT 1
-);
--- Partial index: covers the dominant query path (list enabled agents).
-CREATE INDEX IF NOT EXISTS idx_project_agent_refs_enabled
-    ON project_agent_refs(enabled) WHERE enabled = 1;
-
--- -------------------------------------------------------------------------
--- A2A Topics (T1252 — Wave 9 Agent-to-Agent coordination pub-sub).
--- Topics are named channels that agents can publish to / subscribe from.
--- Topic names follow "<epicId>.<waveId>" or "<epicId>.coordination".
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS topics (
-    id TEXT PRIMARY KEY,
-    name TEXT NOT NULL UNIQUE,
-    epic_id TEXT NOT NULL,
-    wave_id INTEGER,
-    created_by TEXT NOT NULL,
-    created_at INTEGER NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_topics_epic ON topics(epic_id);
-
--- -------------------------------------------------------------------------
--- A2A Topic subscriptions — links an agent_id to a topic_id.
--- Created by subscribeTopic(); removed by unsubscribeTopic().
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS topic_subscriptions (
-    topic_id TEXT NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
-    agent_id TEXT NOT NULL,
-    subscribed_at INTEGER NOT NULL,
-    PRIMARY KEY (topic_id, agent_id)
-);
-CREATE INDEX IF NOT EXISTS idx_topic_subscriptions_agent ON topic_subscriptions(agent_id);
-
--- -------------------------------------------------------------------------
--- A2A Topic messages — broadcast messages published to a topic.
--- payload is stored as JSON text.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS topic_messages (
-    id TEXT PRIMARY KEY,
-    topic_id TEXT NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
-    from_agent_id TEXT NOT NULL,
-    kind TEXT NOT NULL DEFAULT 'message',
-    content TEXT NOT NULL,
-    payload TEXT,
-    created_at INTEGER NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_topic_messages_topic_created ON topic_messages(topic_id, created_at);
-
--- -------------------------------------------------------------------------
--- A2A Topic message ACKs — per-subscriber delivery tracking.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS topic_message_acks (
-    message_id TEXT NOT NULL REFERENCES topic_messages(id) ON DELETE CASCADE,
-    subscriber_agent_id TEXT NOT NULL,
-    delivered_at INTEGER,
-    read_at INTEGER,
-    PRIMARY KEY (message_id, subscriber_agent_id)
-);
-
--- -------------------------------------------------------------------------
--- Schema tracking tables (mirrors _signaldock_meta / _signaldock_migrations).
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS _conduit_meta (
-    key TEXT PRIMARY KEY,
-    value TEXT NOT NULL,
-    updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
-);
-CREATE TABLE IF NOT EXISTS _conduit_migrations (
-    name TEXT PRIMARY KEY,
-    applied_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
-);
-`;
+/** Guard against concurrent initialization (async dual-scope open). */
+let _initPromise: Promise<{ action: 'created' | 'exists'; path: string }> | null = null;
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /**
- * Returns the project-tier conduit.db path.
+ * Returns the project-scope conduit database path.
  *
- * Always resolves to `<projectRoot>/.cleo/conduit.db`. The caller is
- * responsible for supplying the absolute project root (e.g. via
- * `getProjectRoot()` from `../paths.js`).
+ * ## E6-L3 (T11523)
+ *
+ * After the dual-scope migration, `ensureConduitDb()` opens the consolidated
+ * project `cleo.db` via {@link openDualScopeDb} — not the legacy standalone
+ * `conduit.db`. This function therefore returns the dual-scope `cleo.db` path so
+ * that callers checking for the file `ensureConduitDb()` created (existence /
+ * backup / health probes) point at the correct file.
+ *
+ * The supplied `projectRoot` is passed through as the `cwd` for the SSoT
+ * resolver, which walks up to find the `.cleo/` directory.
  *
  * @task T344
+ * @task T11523
  * @epic T310
  * @param projectRoot - Absolute path to the project root directory.
- * @returns Absolute path to `<projectRoot>/.cleo/conduit.db`.
+ * @returns Absolute path to the project `cleo.db`.
  */
 export function getConduitDbPath(projectRoot: string): string {
-  return join(projectRoot, '.cleo', CONDUIT_DB_FILENAME);
-}
-
-/**
- * Applies the conduit.db schema idempotently using CREATE TABLE IF NOT EXISTS.
- *
- * Used as a bootstrap path for fresh conduit.db files BEFORE the Drizzle
- * migration runner takes over. The DDL is `CREATE TABLE IF NOT EXISTS` /
- * `CREATE INDEX IF NOT EXISTS` / `CREATE TRIGGER IF NOT EXISTS` /
- * `CREATE VIRTUAL TABLE IF NOT EXISTS` for full idempotency, so calling this
- * on an already-populated DB is a no-op.
- *
- * Two reasons this raw-SQL applier is retained alongside the Drizzle
- * runner (T1407):
- *
- * 1. **FTS5 + triggers** — drizzle-orm sqlite-core does not model FTS5
- *    virtual tables or AFTER INSERT/DELETE/UPDATE triggers. The
- *    `messages_fts` virtual table and its 3 triggers can only live in
- *    raw SQL. They MUST be present after init for full-text message
- *    search to work.
- *
- * 2. **Comment-only baseline migration** — the Drizzle baseline marker at
- *    `packages/core/migrations/drizzle-conduit/20260425000000_initial-conduit/migration.sql`
- *    is intentionally comment-only (T1165 Hybrid Path A+ pattern) so that
- *    existing conduit.db files in the wild detect the schema via
- *    `reconcileJournal()` and mark the baseline applied without re-running
- *    DDL. Fresh DBs therefore need a separate bootstrap path — that is
- *    this function.
- *
- * Exposed for the migration executor (T358) which needs to apply the schema
- * to a newly created conduit.db during the signaldock.db → conduit.db
- * migration. Also called internally by `ensureConduitDb` on every open.
- *
- * @task T344
- * @task T1407
- * @epic T310
- * @param db - An open node:sqlite DatabaseSync instance.
- */
-export function applyConduitSchema(db: DatabaseSync): void {
-  db.exec(CONDUIT_SCHEMA_SQL);
+  return resolveDualScopeDbPath('project', projectRoot);
 }
 
 /**
@@ -433,189 +182,167 @@ export function resolveConduitMigrationsFolder(): string {
 }
 
 /**
- * Run Drizzle migrations to reconcile and update conduit.db.
+ * Apply the conduit-domain schema to an arbitrary open `DatabaseSync` handle by
+ * running the `drizzle-conduit` migration set against it.
+ *
+ * ## E6-L3 (T11523)
+ *
+ * Previously this executed the inline `CONDUIT_SCHEMA_SQL` blob directly. That
+ * blob has been moved into the forward migration
+ * `20260601000003_t11523-conduit-inline-schema`, so this helper now reconciles
+ * the journal and runs the conduit migrations — the same path `ensureConduitDb`
+ * uses internally. It remains exported for the signaldock→conduit migration
+ * executor (T358) and characterization tests that need to seed the conduit schema
+ * onto a caller-owned handle.
+ *
+ * Idempotent: every migration statement uses `IF NOT EXISTS`, so applying it onto
+ * an already-populated DB is a no-op (the journal reconciler marks it applied).
+ *
+ * @task T344
+ * @task T1407
+ * @task T11523
+ * @epic T310
+ * @param db - An open node:sqlite DatabaseSync instance.
+ */
+export function applyConduitSchema(db: DatabaseSync): void {
+  runConduitMigrations(db);
+}
+
+/**
+ * Run Drizzle migrations to reconcile and update the conduit schema on the given
+ * native handle.
  *
  * Uses `reconcileJournal()` + `migrateSanitized()` from migration-manager.ts —
  * the canonical SSoT for SQLite migration semantics shared with tasks/brain/
- * nexus/signaldock/telemetry.
+ * nexus/signaldock/telemetry. The conduit `__drizzle_migrations` journal lives in
+ * the same `cleo.db` as the consolidated cleo-project journal; the hashes are
+ * disjoint, so the conduit migrations reconcile/apply independently.
  *
- * Reconciliation handles:
- *   - Scenario 1: existing DB with schema present but no `__drizzle_migrations`
- *     table → bootstrap baseline as applied.
- *   - Scenario 3: comment-only baseline marker on a populated DB → marked
- *     applied immediately without running DDL.
- *   - Scenario 4: backfill `name` on null journal entries (Drizzle v1 beta).
- *
- * The existence sentinel is `conversations` — the first table created by
- * `applyConduitSchema()` (always present on any conduit.db that has been
- * through a successful init).
+ * The existence sentinel is `conversations` — the first table created by the
+ * conduit schema migration (always present on any conduit-initialized DB).
  *
  * @task T1407
+ * @task T11523
  * @epic T310
  */
 function runConduitMigrations(nativeDb: DatabaseSync): void {
   const migrationsFolder = resolveConduitMigrationsFolder();
 
-  // Reconcile the Drizzle journal first so existing DBs don't try to re-run
-  // the comment-only baseline marker (Scenario 3 marks it applied immediately
-  // when the schema already matches).
+  // Reconcile the Drizzle journal first so existing DBs don't try to re-run the
+  // comment-only baseline marker (Scenario 3 marks it applied immediately when
+  // the schema already matches).
   reconcileJournal(nativeDb, migrationsFolder, 'conversations', 'conduit');
 
-  const db = drizzle({ client: nativeDb, schema: conduitSchema });
+  const db = _getDrizzle()({ client: nativeDb, schema: conduitSchema });
   migrateSanitized(db, { migrationsFolder });
 }
 
 /**
- * Opens or creates conduit.db for the given project root.
+ * Initialize the project-scope CONDUIT domain SQLite database (lazy, singleton).
  *
- * On first call for a given projectRoot:
- *   1. Creates `<projectRoot>/.cleo/` directory if missing.
- *   2. Opens (or creates) the SQLite file.
- *   3. Sets WAL mode and enables foreign keys.
- *   4. Bootstraps schema via `applyConduitSchema` (idempotent CREATE
- *      TABLE/INDEX/TRIGGER/VIRTUAL TABLE IF NOT EXISTS — the only path
- *      that creates the FTS5 virtual table + triggers Drizzle cannot
- *      model).
- *   5. Runs Drizzle migration reconciliation + apply pending migrations
- *      via `runConduitMigrations()` (canonical migration-manager.ts SSoT).
- *   6. Records `schema_version` in `_conduit_meta` (legacy, retained for
- *      backwards compatibility with pre-T1407 health checks).
- *   7. Stores the open handle in the module singleton.
+ * ## E6-L3 façade (T11523)
+ *
+ * Delegates the physical DB open to {@link openDualScopeDb}('project', cwd) — the
+ * canonical dual-scope chokepoint. openDualScopeDb applies the pragma SSoT,
+ * creates the directory, runs the consolidated cleo-project migrations (which
+ * create the `conduit_*` tables), and manages the singleton cache. We extract its
+ * native handle (`$client`) and run the legacy `drizzle-conduit` migrations on it
+ * to (idempotently) create the BARE legacy runtime-shape tables (`conversations`,
+ * `messages`, FTS5, …) that the LocalTransport + accessor writers query. The
+ * legacy and consolidated `conduit_*` tables co-exist (disjoint names) — the
+ * exodus migration (T11248 / T11553) renames the legacy ones.
  *
  * On subsequent calls the existing singleton is returned immediately if the
- * resolved path matches; otherwise the previous handle is closed and a new
- * one is opened (test-isolation safety).
+ * resolved path matches AND the shared handle is still live (liveness guard);
+ * otherwise it re-derives from the live dual-scope cache.
  *
- * Caller MUST call `closeConduitDb()` when done to release the handle.
+ * Uses a promise guard so concurrent callers wait for the same initialization to
+ * complete (the dual-scope open is async).
  *
  * @task T344
  * @task T1407
+ * @task T11523
  * @epic T310
  * @param projectRoot - Absolute path to the project root directory.
  * @returns Object with `action` (`'created'` | `'exists'`) and `path`.
  */
-/**
- * Read the `schema_version` row from `_conduit_meta` if it exists.
- *
- * Used by {@link ensureConduitDb} as a fast-path sentinel: when the value
- * matches {@link CONDUIT_SCHEMA_VERSION} we know the DB is fully bootstrapped
- * and migrated to the in-process code version, so we can skip the full
- * `applyConduitSchema()` + `runConduitMigrations()` pipeline on every CLI
- * invocation (T9027 — epic T9026, CLI startup tax reduction).
- *
- * Defensive: returns `null` if the meta table is missing (pre-T1407 layout)
- * or the row is absent. Any throw is swallowed — a sentinel miss simply
- * forces the fall-through full-init path which is always safe.
- *
- * @param db - An open conduit.db handle (post-pragmas).
- * @returns The schema_version string, or `null` if absent / unreadable.
- * @task T9027
- * @epic T9026
- */
-function readSchemaVersionSentinel(db: DatabaseSync): string | null {
-  try {
-    const row = db.prepare("SELECT value FROM _conduit_meta WHERE key = 'schema_version'").get() as
-      | { value: string }
-      | undefined;
-    return row?.value ?? null;
-  } catch {
-    return null;
-  }
-}
-
-export function ensureConduitDb(projectRoot: string): {
-  action: 'created' | 'exists';
-  path: string;
-} {
+export async function ensureConduitDb(
+  projectRoot: string,
+): Promise<{ action: 'created' | 'exists'; path: string }> {
   const dbPath = getConduitDbPath(projectRoot);
 
-  // If singleton already open at the same path, skip re-initialization.
+  // Liveness guard (T11523): the conduit domain SHARES the consolidated cleo.db
+  // handle with the tasks + brain domains. Another domain may have closed +
+  // re-opened the shared `DatabaseSync` (e.g. its reset / auto-recovery path)
+  // while our conduit singleton still references the now-closed handle. Detect a
+  // stale (closed) handle, or a singleton bound to a different path, and drop it
+  // so we re-derive from the live openDualScopeDb cache below.
+  if (_conduitNativeDb && (!_conduitNativeDb.isOpen || _conduitDbPath !== dbPath)) {
+    resetConduitDbState();
+  }
+
+  // If singleton already open at the same path and live, skip re-initialization.
   if (_conduitNativeDb && _conduitDbPath === dbPath) {
     return { action: 'exists', path: dbPath };
   }
 
-  // Close any stale singleton pointing at a different path (e.g. between tests).
-  if (_conduitNativeDb) {
-    closeConduitDb();
-  }
+  // If already initializing, wait for the in-flight init.
+  if (_initPromise) return _initPromise;
 
-  const alreadyExists = existsSync(dbPath);
+  _initPromise = (async (): Promise<{ action: 'created' | 'exists'; path: string }> => {
+    const alreadyExists = existsSync(dbPath);
 
-  // Ensure parent .cleo/ directory exists.
-  mkdirSync(dirname(dbPath), { recursive: true });
+    // ── Dual-scope chokepoint delegation (T11523 · E6-L3) ──────────────────
+    // openDualScopeDb applies the pragma SSoT, creates the directory, runs the
+    // consolidated cleo-project migrations (which create the `conduit_*` tables),
+    // and manages the singleton cache. We extract its native handle so we can run
+    // the legacy `drizzle-conduit` migrations for caller compatibility.
+    const dualHandle = await openDualScopeDb('project', projectRoot);
 
-  const db = new DatabaseSync(dbPath);
-
-  // Canonical CLEO pragma set (WAL, busy_timeout, synchronous=NORMAL, FK on,
-  // 64MB cache, 256MB mmap, MEMORY temp store, wal_autocheckpoint).
-  applyPerfPragmas(db);
-
-  // Check whether the schema sentinel table already exists before applying DDL.
-  const hasSchema = (() => {
-    try {
-      const result = db
-        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='conversations'")
-        .get() as { name: string } | undefined;
-      return !!result;
-    } catch {
-      return false;
+    // Extract the underlying DatabaseSync. Drizzle exposes it via `$client`.
+    const nativeDb = (dualHandle.db as { $client?: DatabaseSync }).$client ?? null;
+    if (!nativeDb) {
+      throw new Error(
+        'E6-L3: openDualScopeDb returned a handle without $client — ' +
+          'cannot extract DatabaseSync for legacy conduit-schema wrapping.',
+      );
     }
+
+    // Establish the LEGACY conduit-domain schema inside the consolidated cleo.db.
+    // The consolidated migrations created the prefixed `conduit_*` tables; the
+    // runtime writers query the BARE legacy tables (`conversations`, `messages`,
+    // FTS5, …). Running the `drizzle-conduit` set creates those bare tables. They
+    // are disjoint from the consolidated names, so no drop is needed (unlike the
+    // brain domain, E6-L2). Idempotent: a no-op once the tables already exist.
+    runConduitMigrations(nativeDb);
+
+    // Record schema version in the legacy `_conduit_meta` table for backwards-
+    // compatible health-check consumers (checkConduitDbHealth and any external
+    // tooling that grepped the meta table prior to T1407). The Drizzle journal
+    // (`__drizzle_migrations`) is the canonical migration source-of-truth.
+    nativeDb.exec(
+      `INSERT OR REPLACE INTO _conduit_meta (key, value, updated_at)
+       VALUES ('schema_version', '${CONDUIT_SCHEMA_VERSION}', strftime('%s', 'now'))`,
+    );
+
+    _conduitNativeDb = nativeDb;
+    _conduitDbPath = dbPath;
+
+    return { action: alreadyExists ? 'exists' : 'created', path: dbPath };
   })();
 
-  // T9027 — Schema-version sentinel fast path (epic T9026, CLI startup tax).
-  //
-  // If the DB already has the conduit schema applied AND its
-  // `_conduit_meta.schema_version` row exactly equals the in-process
-  // `CONDUIT_SCHEMA_VERSION` constant, we know:
-  //   1. All DDL is already in place (CREATE TABLE IF NOT EXISTS would no-op).
-  //   2. All Drizzle migrations up to this version have already been replayed
-  //      (the meta row is only written at the tail of a successful ensure()).
-  //
-  // In that case skip applyConduitSchema() and runConduitMigrations() entirely
-  // — both perform non-trivial work (DDL string parse for the former, journal
-  // SELECT + reconciler for the latter) on every CLI invocation. Pragmas are
-  // already applied above.
-  //
-  // Fall-through (sentinel missing, stale, or mismatched) preserves the full
-  // bootstrap + migration replay path so fresh DBs and version bumps work.
-  if (alreadyExists && hasSchema && readSchemaVersionSentinel(db) === CONDUIT_SCHEMA_VERSION) {
-    _conduitNativeDb = db;
-    _conduitDbPath = dbPath;
-    return { action: 'exists', path: dbPath };
+  try {
+    return await _initPromise;
+  } finally {
+    _initPromise = null;
   }
-
-  // Bootstrap schema (idempotent — all statements use IF NOT EXISTS). For fresh
-  // DBs this creates every conduit table, the FTS5 virtual table, and its 3
-  // triggers. For populated DBs this is a no-op.
-  applyConduitSchema(db);
-
-  // Run Drizzle migration reconciliation + apply any pending migrations
-  // (T1407 unification — canonical migration-manager.ts runner).
-  runConduitMigrations(db);
-
-  // Record schema version in the legacy `_conduit_meta` table for backwards-
-  // compatible health-check consumers (checkConduitDbHealth and any external
-  // tooling that grepped the meta table prior to T1407). The Drizzle journal
-  // (`__drizzle_migrations`) is now the canonical migration source-of-truth.
-  db.exec(
-    `INSERT OR REPLACE INTO _conduit_meta (key, value, updated_at)
-     VALUES ('schema_version', '${CONDUIT_SCHEMA_VERSION}', strftime('%s', 'now'))`,
-  );
-
-  _conduitNativeDb = db;
-  _conduitDbPath = dbPath;
-
-  return {
-    action: alreadyExists && hasSchema ? 'exists' : 'created',
-    path: dbPath,
-  };
 }
 
 /**
- * Returns the live node:sqlite DatabaseSync handle for conduit.db.
+ * Returns the live node:sqlite DatabaseSync handle for the conduit domain.
  *
- * Returns `null` if `ensureConduitDb` has not been called yet for this
- * process, or if `closeConduitDb` has been called since the last open.
+ * Returns `null` if `ensureConduitDb` has not been called yet for this process,
+ * or if the shared handle has been closed since the last open.
  *
  * @task T344
  * @epic T310
@@ -626,28 +353,48 @@ export function getConduitNativeDb(): DatabaseSync | null {
 }
 
 /**
- * Closes the conduit.db connection and resets the module singleton.
+ * Close the conduit-domain database connection and reset the module singleton.
  *
- * Safe to call multiple times. No-op if the database is already closed.
+ * ## E6-L3 (T11523)
+ *
+ * The conduit domain now SHARES the consolidated project `cleo.db` handle with
+ * the tasks + brain domains (all open it via {@link openDualScopeDb}, same cache
+ * key). This function therefore must NOT close the underlying `DatabaseSync` nor
+ * evict the dual-scope cache — doing so would break in-flight tasks/brain-domain
+ * queries with "database is not open". It only drops the conduit-domain singleton
+ * references; the shared handle's lifecycle is owned by `openDualScopeDb` and torn
+ * down by a coordinated reset (`closeAllDatabases` → `_resetDualScopeDbCache`).
+ *
+ * Safe to call multiple times.
  *
  * @task T344
+ * @task T11523
  * @epic T310
  */
 export function closeConduitDb(): void {
-  if (_conduitNativeDb) {
-    try {
-      if (_conduitNativeDb.isOpen) {
-        // PRAGMA optimize before close so the next process inherits up-to-date
-        // table statistics for query planning (SQLite-recommended pattern).
-        optimizeBeforeClose(_conduitNativeDb);
-        _conduitNativeDb.close();
-      }
-    } catch {
-      // Ignore close errors — the handle is being discarded regardless.
-    }
-    _conduitNativeDb = null;
-  }
+  // Drop only the conduit singleton references. Do NOT close `_conduitNativeDb`
+  // — it is the shared dual-scope handle, possibly still in use by tasks/brain.
+  _conduitNativeDb = null;
   _conduitDbPath = null;
+  _initPromise = null;
+}
+
+/**
+ * Reset conduit-domain singleton state without saving.
+ *
+ * Used during tests or when the shared database handle is recreated. Drops only
+ * the conduit-domain singleton references — does NOT close the shared dual-scope
+ * `cleo.db` handle nor evict the dual-scope cache (that handle is shared with the
+ * tasks + brain domains). Mirrors {@link closeConduitDb}. Safe to call multiple
+ * times.
+ *
+ * @task T11523
+ * @epic T310
+ */
+export function resetConduitDbState(): void {
+  _conduitNativeDb = null;
+  _conduitDbPath = null;
+  _initPromise = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -659,7 +406,7 @@ export function closeConduitDb(): void {
  * re-enables it (update attached_at timestamp). If a row exists with enabled=1,
  * no-op. Inserts a new row otherwise.
  *
- * @param db - conduit.db handle (from ensureConduitDb).
+ * @param db - conduit handle (from ensureConduitDb).
  * @param agentId - Global signaldock.db:agents.id (soft FK, not validated here).
  * @param opts - Optional role and capabilities override.
  * @task T353
@@ -686,7 +433,7 @@ export function attachAgentToProject(
  * Detaches an agent from the current project by setting enabled=0.
  * Does NOT delete the row (preserves attachment history for audit).
  *
- * @param db - conduit.db handle (from ensureConduitDb).
+ * @param db - conduit handle (from ensureConduitDb).
  * @param agentId - Agent ID to detach.
  * @task T353
  * @epic T310
@@ -699,7 +446,7 @@ export function detachAgentFromProject(db: DatabaseSync, agentId: string): void 
  * Lists project_agent_refs rows. By default returns only enabled=1 rows.
  * Pass enabledOnly=false to return all rows regardless of enabled state.
  *
- * @param db - conduit.db handle (from ensureConduitDb).
+ * @param db - conduit handle (from ensureConduitDb).
  * @param opts - Filter options. Defaults to `{ enabledOnly: true }`.
  * @returns Array of ProjectAgentRef rows ordered by attached_at DESC.
  * @task T353
@@ -738,7 +485,7 @@ export function listProjectAgentRefs(
 /**
  * Returns a single project_agent_refs row by agentId, or null if not found.
  *
- * @param db - conduit.db handle (from ensureConduitDb).
+ * @param db - conduit handle (from ensureConduitDb).
  * @param agentId - Agent ID to look up.
  * @returns The ProjectAgentRef row, or null if the agent is not attached.
  * @task T353
@@ -775,7 +522,7 @@ export function getProjectAgentRef(db: DatabaseSync, agentId: string): ProjectAg
  * Updates the last_used_at timestamp for an agent to now.
  * No-op if the agent_id does not exist in project_agent_refs.
  *
- * @param db - conduit.db handle (from ensureConduitDb).
+ * @param db - conduit handle (from ensureConduitDb).
  * @param agentId - Agent ID to update.
  * @task T353
  * @epic T310
@@ -788,16 +535,21 @@ export function updateProjectAgentLastUsed(db: DatabaseSync, agentId: string): v
 }
 
 /**
- * Checks conduit.db health — table count, WAL mode, schema version, and
+ * Checks conduit-domain health — table count, WAL mode, schema version, and
  * foreign keys status.
  *
- * Used by `cleo doctor` to verify conduit.db integrity. Does NOT require
- * `ensureConduitDb` to have been called; opens and closes the DB internally.
+ * ## E6-L3 (T11523)
+ *
+ * The conduit domain now lives in the consolidated project `cleo.db`. This probe
+ * opens that file (read-only inspection of pragma + sqlite_master state) — it does
+ * NOT require `ensureConduitDb` to have been called and opens/closes its own
+ * short-lived connection. Used by `cleo doctor` to verify conduit integrity.
  *
  * @task T344
+ * @task T11523
  * @epic T310
  * @param projectRoot - Absolute path to the project root directory.
- * @returns Health report object. `exists: false` when conduit.db is absent.
+ * @returns Health report object. `exists: false` when the DB is absent.
  */
 export function checkConduitDbHealth(projectRoot: string): {
   exists: boolean;
@@ -860,17 +612,24 @@ export function checkConduitDbHealth(projectRoot: string): {
 }
 
 /**
- * Open a fresh (non-singleton) conduit.db connection with pragmas applied.
+ * Open a fresh (non-singleton) connection to the conduit-domain DB with pragmas
+ * applied.
  *
- * Unlike `ensureConduitDb`, this creates an independent connection that the
- * caller owns and must close. Intended for callers that manage connection
- * lifecycle explicitly (e.g. LocalTransport connect/disconnect cycle).
+ * ## E6-L3 (T11523)
+ *
+ * The conduit domain now lives in the consolidated project `cleo.db`. This opens
+ * an independent connection to that file (WAL mode permits concurrent
+ * connections) that the caller owns and must close. Intended for callers that
+ * manage connection lifecycle explicitly (e.g. LocalTransport connect/disconnect
+ * cycle). The caller is responsible for ensuring `ensureConduitDb` has run first
+ * so the bare conduit tables exist.
  *
  * Applies the pragma SSoT from `specs/sqlite-pragmas.json` (T9047, T9189).
  *
- * @param projectRoot - Project root for resolving conduit.db path.
+ * @param projectRoot - Project root for resolving the conduit DB path.
  * @returns An open DatabaseSync connection (caller must close).
  * @task T9189
+ * @task T11523
  */
 export function openFreshConduitDb(projectRoot: string): DatabaseSync {
   const dbPath = getConduitDbPath(projectRoot);

--- a/packages/core/src/store/migrate-signaldock-to-conduit.ts
+++ b/packages/core/src/store/migrate-signaldock-to-conduit.ts
@@ -27,7 +27,7 @@ import { join } from 'node:path';
 import type { DatabaseSync as _DatabaseSyncType, SQLInputValue } from 'node:sqlite';
 import { getLogger } from '../logger.js';
 import { getCleoHome } from '../paths.js';
-import { ensureConduitDb } from './conduit-sqlite.js';
+import { ensureConduitDb, getConduitDbPath } from './conduit-sqlite.js';
 import { getGlobalSalt } from './global-salt.js';
 import { ensureGlobalSignaldockDb } from './signaldock-sqlite.js';
 import { applyPerfPragmas } from './sqlite-pragmas.js';
@@ -119,7 +119,12 @@ const GLOBAL_IDENTITY_TABLES = [
  */
 export function needsSignaldockToConduitMigration(projectRoot: string): boolean {
   const legacyPath = join(projectRoot, '.cleo', 'signaldock.db');
-  const conduitPath = join(projectRoot, '.cleo', 'conduit.db');
+  // E6-L3 (T11523): the conduit domain consolidated into the project `cleo.db`.
+  // Probe the consolidated DB path (via getConduitDbPath) rather than the literal
+  // legacy `conduit.db` — otherwise this one-shot legacy migration would believe
+  // it is perpetually un-run on any post-consolidation project (`conduit.db` is
+  // never created) and re-fire on every CLI startup.
+  const conduitPath = getConduitDbPath(projectRoot);
   return existsSync(legacyPath) && !existsSync(conduitPath);
 }
 
@@ -251,10 +256,12 @@ function brokenTimestamp(): string {
  * @task T358
  * @epic T310
  */
-export function migrateSignaldockToConduit(projectRoot: string): MigrationResult {
+export async function migrateSignaldockToConduit(projectRoot: string): Promise<MigrationResult> {
   const log = getLogger('migrate-signaldock-to-conduit');
   const legacyPath = join(projectRoot, '.cleo', 'signaldock.db');
-  const conduitPath = join(projectRoot, '.cleo', 'conduit.db');
+  // E6-L3 (T11523): the conduit domain now lives in the consolidated project
+  // `cleo.db`. Report that path as the migration target.
+  const conduitPath = getConduitDbPath(projectRoot);
   const globalSignaldockPath = join(getCleoHome(), 'signaldock.db');
   const bakPath = `${legacyPath}.pre-t310.bak`;
 
@@ -354,7 +361,7 @@ export function migrateSignaldockToConduit(projectRoot: string): MigrationResult
   // -----------------------------------------------------------------------
   let conduit: DatabaseSync | null = null;
   try {
-    const ensureResult = ensureConduitDb(projectRoot);
+    const ensureResult = await ensureConduitDb(projectRoot);
     // Open a direct handle for migration writes (ensureConduitDb returns singleton;
     // we open a fresh handle to avoid interfering with any singleton state).
     conduit = new DatabaseSync(ensureResult.path);

--- a/packages/core/src/store/open-cleo-db.ts
+++ b/packages/core/src/store/open-cleo-db.ts
@@ -126,7 +126,7 @@ async function openSignaldockDb(_cwd?: string): Promise<unknown> {
 /** Open the conduit.db for the given project (or current process). */
 async function openConduitDb(cwd?: string): Promise<unknown> {
   const { ensureConduitDb } = await import('./conduit-sqlite.js');
-  ensureConduitDb(resolveOrCwd(cwd));
+  await ensureConduitDb(resolveOrCwd(cwd));
   return getConduitNativeDb();
 }
 

--- a/packages/core/src/store/role-accessors-impl.ts
+++ b/packages/core/src/store/role-accessors-impl.ts
@@ -37,7 +37,7 @@ export function createConduitAccessor(projectRoot?: string): ConduitAccessor {
   return {
     async publish(topic: string, payload: unknown): Promise<void> {
       const { ensureConduitDb, getConduitNativeDb } = await import('./conduit-sqlite.js');
-      ensureConduitDb(cwd);
+      await ensureConduitDb(cwd);
       const db = getConduitNativeDb();
       if (!db) throw new Error('ConduitAccessor: conduit.db not initialized');
 
@@ -67,7 +67,7 @@ export function createConduitAccessor(projectRoot?: string): ConduitAccessor {
     async ping(): Promise<boolean> {
       try {
         const { ensureConduitDb, getConduitNativeDb } = await import('./conduit-sqlite.js');
-        ensureConduitDb(cwd);
+        await ensureConduitDb(cwd);
         const db = getConduitNativeDb();
         if (!db) return false;
         db.prepare('SELECT 1').get();

--- a/packages/core/src/store/sqlite-backup.ts
+++ b/packages/core/src/store/sqlite-backup.ts
@@ -217,8 +217,9 @@ async function openTasksDbForSnapshot(cwd?: string): Promise<SnapshotDbHandle | 
  * (sync) and return its native handle.
  */
 async function openConduitDbForSnapshot(cwd?: string): Promise<SnapshotDbHandle | null> {
-  // ensureConduitDb requires an absolute project root.
-  ensureConduitDb(resolveOrCwd(cwd));
+  // ensureConduitDb requires an absolute project root. E6-L3 (T11523): it is now
+  // async (routes through the dual-scope cleo.db chokepoint).
+  await ensureConduitDb(resolveOrCwd(cwd));
   return getConduitNativeDb();
 }
 

--- a/packages/core/src/system/project-health.ts
+++ b/packages/core/src/system/project-health.ts
@@ -63,11 +63,13 @@ function getDatabaseSyncCtor(): DatabaseSyncModule['DatabaseSync'] | null {
 // `cleo.db` (opened via openDualScopeDb('project')), not the legacy `tasks.db`.
 // E6-L2 (T11522): the brain domain ALSO consolidated into the same `cleo.db`
 // (getBrainDb → openDualScopeDb('project')), so the `dbs.brain` probe now
-// targets `cleo.db` too — the brain tables live in the shared project DB. The
-// conduit probe still targets its per-domain file until E6-L3 consolidates it.
+// targets `cleo.db` too — the brain tables live in the shared project DB.
+// E6-L3 (T11523): the conduit domain consolidated into the SAME `cleo.db`
+// (ensureConduitDb → openDualScopeDb('project')), so the `dbs.conduit` probe now
+// targets `cleo.db` too. All three project-tier domains share one physical file.
 const TASKS_DB = 'cleo.db' as const;
 const BRAIN_DB = 'cleo.db' as const;
-const CONDUIT_DB = 'conduit.db' as const;
+const CONDUIT_DB = 'cleo.db' as const;
 const NEXUS_DB = 'nexus.db' as const;
 const SIGNALDOCK_DB = 'signaldock.db' as const;
 const CONFIG_JSON = 'config.json' as const;
@@ -255,17 +257,18 @@ export interface CheckAllOptions {
  * surfaces the affected project as `degraded`.
  */
 export const DB_EXPECTED_VERSIONS: Readonly<Record<string, number>> = {
-  // E6-L1 (T11521) / E6-L2 (T11522): TASKS_DB and BRAIN_DB both resolve to
-  // `cleo.db`. The consolidated project schema is tracked by the
-  // `drizzle-cleo-project` migration set (3 entries); the brain domain adds its
-  // own `drizzle-brain` entries to the SAME `__drizzle_migrations` journal, so
-  // the live count is strictly ≥ 3. We keep the conservative cleo-project floor
-  // (3) here — drift fires only when the count drops BELOW it, which the merged
-  // journal never does. (TASKS_DB === BRAIN_DB === 'cleo.db'.)
+  // E6-L1 (T11521) / E6-L2 (T11522) / E6-L3 (T11523): TASKS_DB, BRAIN_DB, and
+  // CONDUIT_DB ALL resolve to `cleo.db`. The consolidated project schema is
+  // tracked by the `drizzle-cleo-project` migration set (3 entries); the brain
+  // (`drizzle-brain`) and conduit (`drizzle-conduit`) domains add their own
+  // entries to the SAME `__drizzle_migrations` journal, so the live count is
+  // strictly ≥ 3. We keep the conservative cleo-project floor (3) here — drift
+  // fires only when the count drops BELOW it, which the merged journal never
+  // does. NOTE: do NOT add a separate `[CONDUIT_DB]` entry — it is the same key
+  // as `[TASKS_DB]` ('cleo.db') and would clobber the floor of 3.
   [TASKS_DB]: 3,
   [NEXUS_DB]: 3,
   [SIGNALDOCK_DB]: 1,
-  [CONDUIT_DB]: 1,
 };
 
 /**

--- a/packages/core/src/upgrade.ts
+++ b/packages/core/src/upgrade.ts
@@ -879,7 +879,7 @@ export async function runUpgrade(
     // Initialize conduit.db for project-tier agent messaging (T310)
     try {
       const { ensureConduitDb } = await import('./store/conduit-sqlite.js');
-      const cdResult = ensureConduitDb(projectRootForMaint);
+      const cdResult = await ensureConduitDb(projectRootForMaint);
       if (cdResult.action === 'created') {
         actions.push({
           action: 'ensure_conduit_db',

--- a/packages/runtime/src/__tests__/lifecycle-e2e.test.ts
+++ b/packages/runtime/src/__tests__/lifecycle-e2e.test.ts
@@ -9,7 +9,7 @@
  *
  * @task T249
  * @task T344 — migrated from ensureSignaldockDb(cwd) (project-tier) to
- *               ensureConduitDb(cwd) after T310 moved messaging to conduit.db.
+ *               await ensureConduitDb(cwd) after T310 moved messaging to conduit.db.
  */
 
 import { mkdir, rm } from 'node:fs/promises';
@@ -36,7 +36,7 @@ describe('Agent Lifecycle E2E', () => {
 
   it('should create conduit.db via ensureConduitDb', async () => {
     const { ensureConduitDb } = await import('@cleocode/core/internal');
-    const result = ensureConduitDb(tempDir);
+    const result = await ensureConduitDb(tempDir);
     expect(result.action).toBe('created');
     expect(result.path).toContain('conduit.db');
 
@@ -49,7 +49,7 @@ describe('Agent Lifecycle E2E', () => {
     const { ensureConduitDb, checkConduitDbHealth, CONDUIT_SCHEMA_VERSION } = await import(
       '@cleocode/core/internal'
     );
-    ensureConduitDb(tempDir);
+    await ensureConduitDb(tempDir);
 
     const health = checkConduitDbHealth(tempDir);
     expect(health.exists).toBe(true);
@@ -66,17 +66,17 @@ describe('Agent Lifecycle E2E', () => {
 
   it('should be idempotent — second call returns exists', async () => {
     const { ensureConduitDb } = await import('@cleocode/core/internal');
-    const first = ensureConduitDb(tempDir);
+    const first = await ensureConduitDb(tempDir);
     expect(first.action).toBe('created');
 
-    const second = ensureConduitDb(tempDir);
+    const second = await ensureConduitDb(tempDir);
     expect(second.action).toBe('exists');
     expect(second.path).toBe(first.path);
   });
 
   it('should register project_agent_refs and query them back', async () => {
     const { ensureConduitDb, getConduitDbPath } = await import('@cleocode/core/internal');
-    ensureConduitDb(tempDir);
+    await ensureConduitDb(tempDir);
 
     // Insert agent refs directly into conduit.db. The `agents` table lives in
     // global-tier signaldock.db (T346); project-tier only stores soft FKs.
@@ -110,7 +110,7 @@ describe('Agent Lifecycle E2E', () => {
 
   it('should store and retrieve messages through conduit.db', async () => {
     const { ensureConduitDb, getConduitDbPath } = await import('@cleocode/core/internal');
-    ensureConduitDb(tempDir);
+    await ensureConduitDb(tempDir);
 
     const { createRequire } = await import('node:module');
     const _require = createRequire(import.meta.url);
@@ -168,7 +168,7 @@ describe('Agent Lifecycle E2E', () => {
     );
 
     // 1. Create DB.
-    const { action, path } = ensureConduitDb(tempDir);
+    const { action, path } = await ensureConduitDb(tempDir);
     expect(action).toBe('created');
     expect(path).toBe(getConduitDbPath(tempDir));
 

--- a/packages/runtime/src/__tests__/lifecycle-e2e.test.ts
+++ b/packages/runtime/src/__tests__/lifecycle-e2e.test.ts
@@ -34,11 +34,12 @@ describe('Agent Lifecycle E2E', () => {
     await rm(tempDir, { recursive: true, force: true }).catch(() => {});
   });
 
-  it('should create conduit.db via ensureConduitDb', async () => {
+  it('should create the conduit domain (consolidated cleo.db) via ensureConduitDb', async () => {
     const { ensureConduitDb } = await import('@cleocode/core/internal');
     const result = await ensureConduitDb(tempDir);
     expect(result.action).toBe('created');
-    expect(result.path).toContain('conduit.db');
+    // E6-L3 (T11523): the conduit domain consolidated into the project cleo.db.
+    expect(result.path).toContain('cleo.db');
 
     // Verify file was written to disk
     const { existsSync } = await import('node:fs');


### PR DESCRIPTION
## E6-L3 — conduit domain → consolidated cleo.db (T11523)

Routes the conduit domain through the `openDualScopeDb('project')` dual-scope chokepoint, mirroring E6-L1 (tasks, #884) and E6-L2 (brain, #899). Critical sequential-path leaf 3.

### Same-name vs differ-prefix outcome
**DIFFER-PREFIX (SIMPLE facade — like tasks, NOT like brain).** Conduit legacy physical tables are BARE (`conversations`, `messages`, `delivery_jobs`, …) while the consolidated schema (`cleo-project/conduit.ts`) carries the `conduit_` prefix (`conduit_conversations`, …). Disjoint names → legacy + consolidated co-exist harmlessly in the same `cleo.db`. **No drop/rebuild needed** (unlike brain L2, which shared prefixed names).

### Changes
- `ensureConduitDb()` → **async**, delegates open to `openDualScopeDb('project', cwd)`, extracts `$client` native handle, runs the legacy `drizzle-conduit` migration set on it.
- `getConduitDbPath()` → `resolveDualScopeDbPath('project')` (`.cleo/cleo.db`).
- **Deleted the 16-table inline `CONDUIT_SCHEMA_SQL` blob** (21 `CREATE TABLE`/index/FTS5/trigger statements) → converted to forward Drizzle migration `migrations/drizzle-conduit/20260601000003_t11523-conduit-inline-schema/migration.sql` (verbatim, `IF NOT EXISTS`, `--> statement-breakpoint`).
- `closeConduitDb`/`resetConduitDbState`: shared-handle safety (do NOT close the co-owned dual-scope handle) + liveness guard (re-derive singleton if another domain closed the shared handle).
- `await ensureConduitDb` at all callers (init, upgrade, open-cleo-db, sqlite-backup, role-accessors).
- `createProjectAgent` + `AgentRegistryAccessor.ensureDbs` → async; `migrateSignaldockToConduit` → async; `needsSignaldockToConduitMigration` probes the consolidated `cleo.db` path so the one-shot legacy path can't perpetually re-fire.
- `project-health.ts`: `CONDUIT_DB` → `cleo.db`; removed the `[CONDUIT_DB]` expected-version entry (same key as `[TASKS_DB]`, would clobber the floor of 3).
- `LocalTransport.isAvailable()`: catch `resolveCleoDir` E_NO_PROJECT → return false (preserves "false when missing" contract).

### Validation
- `pnpm run typecheck` ✅ clean
- `cleo check arch` ✅ 5/5 gates pass (Gate 2 DB-open-guard green — only `dual-scope-db.ts` opens native handles)
- `node build.mjs` ✅ + `cleo version` smoke ✅
- Dedicated conduit tests (conduit-sqlite, conduit-idempotency, migrate-signaldock, agent-registry-accessor, local-transport, local-credential-flow, a2a-topic, messaging-e2e) all pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)