### PR TITLE
refactor(T11524): route nexus-sqlite.ts through openDualScopeDb('global') (E6-L4)

### DIFF
--- a/packages/core/src/memory/__tests__/brain-reasoning-symbol.test.ts
+++ b/packages/core/src/memory/__tests__/brain-reasoning-symbol.test.ts
@@ -32,8 +32,14 @@ describe('brain-reasoning-symbol', () => {
     tempDir = await mkdtemp(join(tmpdir(), 'cleo-brs-'));
     await mkdir(join(tempDir, '.cleo'), { recursive: true });
     process.env['CLEO_DIR'] = join(tempDir, '.cleo');
-    // nexus.db is global (ADR-036) — redirect to temp dir
-    process.env['CLEO_HOME'] = join(tempDir, '.cleo');
+    // E6-L4 (T11524): nexus is global (ADR-036) and now consolidates into
+    // `<CLEO_HOME>/cleo.db`. Point CLEO_HOME at a SEPARATE global dir, not the
+    // project `.cleo` — sharing one dir collapses the project (brain/tasks) and
+    // global (nexus) `cleo.db` onto a single file and the global consolidation
+    // migration would re-create `brain_attention` (present in both scope schemas)
+    // → "table already exists". Production always separates these dirs.
+    await mkdir(join(tempDir, 'cleo-home'), { recursive: true });
+    process.env['CLEO_HOME'] = join(tempDir, 'cleo-home');
   });
 
   afterEach(async () => {

--- a/packages/core/src/memory/__tests__/graph-auto-populate.test.ts
+++ b/packages/core/src/memory/__tests__/graph-auto-populate.test.ts
@@ -37,7 +37,16 @@ beforeEach(async () => {
   cleoDir = join(tempDir, '.cleo');
   await mkdir(cleoDir, { recursive: true });
   process.env['CLEO_DIR'] = cleoDir;
-  process.env['CLEO_HOME'] = cleoDir;
+  // E6-L4 (T11524): point CLEO_HOME at a SEPARATE global dir, not the project
+  // `.cleo`. The global nexus domain now consolidates into `<CLEO_HOME>/cleo.db`
+  // (openDualScopeDb('global')) while the project brain/tasks domains use
+  // `<CLEO_DIR>/cleo.db` (openDualScopeDb('project')). Pointing both at the same
+  // dir collapses them onto ONE physical `cleo.db`, where the global consolidation
+  // migration would re-create `brain_attention` (present in both scope schemas)
+  // and throw "table already exists". Production always separates these dirs.
+  const homeDir = join(tempDir, 'cleo-home');
+  await mkdir(homeDir, { recursive: true });
+  process.env['CLEO_HOME'] = homeDir;
   // Create project-info.json and register in nexus so resolveProjectByCwd validates.
   const { canonicalProjectId } = await import('../../nexus/identity.js');
   const { id: projectId } = await canonicalProjectId(tempDir);

--- a/packages/core/src/nexus/__tests__/nexus-e2e-registry.test.ts
+++ b/packages/core/src/nexus/__tests__/nexus-e2e-registry.test.ts
@@ -496,9 +496,11 @@ describe('schema integrity', () => {
     expect(byName).not.toBeNull();
   });
 
-  it('nexus.db file is created on disk', async () => {
+  it('nexus consolidated cleo.db file is created on disk', async () => {
+    // E6-L4 (T11524): nexus consolidated into the GLOBAL `cleo.db` under
+    // getCleoHome() (here CLEO_HOME=registryDir), not a standalone `nexus.db`.
     await nexusInit();
-    const dbPath = join(registryDir, 'nexus.db');
+    const dbPath = join(registryDir, 'cleo.db');
     expect(existsSync(dbPath)).toBe(true);
   });
 

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -2230,11 +2230,15 @@ export interface ProjectRegistryEntry {
 
 /** Look up a project by canonical or legacy projectId (AC1, AC4). */
 export async function resolveProjectById(projectId: string): Promise<ProjectRegistryEntry | null> {
-  const cleoHome = getCleoHome();
-  const nexusDbPath = join(cleoHome, 'nexus.db');
-  if (!existsSync(nexusDbPath)) return null;
   try {
-    const { getNexusDb } = await import('./store/nexus-sqlite.js');
+    // E6-L4 (T11524): the nexus domain now lives in the GLOBAL consolidated
+    // `cleo.db` (getNexusDbPath() → <cleoHome>/cleo.db). Gate on that file's
+    // existence — NOT the legacy standalone `nexus.db` — so the lookup keeps
+    // working post-cutover when only `cleo.db` is present. We avoid creating the
+    // DB here: if the consolidated file does not exist yet there is nothing to
+    // resolve, so return null rather than letting getNexusDb() bootstrap it.
+    const { getNexusDb, getNexusDbPath } = await import('./store/nexus-sqlite.js');
+    if (!existsSync(getNexusDbPath())) return null;
     const { eq } = await import('drizzle-orm');
     const { projectRegistry, projectIdAliases } = await import('./store/schema/nexus-schema.js');
     const db = await getNexusDb();

--- a/packages/core/src/store/__tests__/migration-fresh-no-repair.nexus.test.ts
+++ b/packages/core/src/store/__tests__/migration-fresh-no-repair.nexus.test.ts
@@ -65,12 +65,17 @@ describe('nexus.db fresh init — zero "Adding missing column" warnings', () => 
     mkdirSync(cleoHome, { recursive: true });
 
     // ------------------------------------------------------------------
-    // 2. Mock paths.js so nexus.db is written to our isolated tmpdir.
+    // 2. Mock paths.js so the consolidated GLOBAL cleo.db is written to our
+    //    isolated tmpdir. E6-L4 (T11524): nexus opens via openDualScopeDb('global'),
+    //    which resolves getCleoHome()+'cleo.db'. resolveCleoDir is included for
+    //    the project-scope resolver path (dual-scope-db.ts imports it), though the
+    //    global scope only consults getCleoHome().
     // ------------------------------------------------------------------
     vi.doMock('../../paths.js', () => ({
       getCleoHome: () => cleoHome,
       getCleoDirAbsolute: (cwd?: string) => (cwd ? join(cwd, '.cleo') : join(tempDir, '.cleo')),
       getProjectRoot: () => tempDir,
+      resolveCleoDir: (cwd?: string) => (cwd ? join(cwd, '.cleo') : join(tempDir, '.cleo')),
     }));
 
     // ------------------------------------------------------------------
@@ -127,8 +132,9 @@ describe('nexus.db fresh init — zero "Adding missing column" warnings', () => 
 
       // ------------------------------------------------------------------
       // 7. SECONDARY: verify required columns exist via PRAGMA table_info.
+      //    E6-L4 (T11524): the nexus tables now live in the GLOBAL `cleo.db`.
       // ------------------------------------------------------------------
-      const dbPath = join(cleoHome, 'nexus.db');
+      const dbPath = join(cleoHome, 'cleo.db');
       const nativeDb = new DatabaseSync(dbPath, { readonly: true });
 
       try {

--- a/packages/core/src/store/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/store/__tests__/migration-smoke.test.ts
@@ -150,14 +150,17 @@ describe('Test 1: fresh init — all 5 DBs migrate clean', () => {
       getProjectRoot: () => tempDir,
     }));
 
-    const { getNexusDb, resetNexusDbState } = await import('../nexus-sqlite.js');
+    const { getNexusDb, getNexusDbPath, resetNexusDbState } = await import('../nexus-sqlite.js');
     resetNexusDbState();
 
     try {
       const db = await getNexusDb();
       expect(db).toBeTruthy();
 
-      const dbPath = join(cleoHome, 'nexus.db');
+      // E6-L4 (T11524): the nexus domain consolidated into the GLOBAL `cleo.db`
+      // under getCleoHome(); getNexusDbPath() resolves to `<cleoHome>/cleo.db`.
+      const dbPath = getNexusDbPath();
+      expect(dbPath).toBe(join(cleoHome, 'cleo.db'));
       expect(existsSync(dbPath)).toBe(true);
 
       // nexus initial migration creates project_registry (not nexus_projects)

--- a/packages/core/src/store/backup-pack.ts
+++ b/packages/core/src/store/backup-pack.ts
@@ -34,7 +34,6 @@ import { create as tarCreate } from 'tar';
 import { getCleoHome, getProjectRoot } from '../paths.js';
 import { encryptBundle } from './backup-crypto.js';
 import { getGlobalSaltPath } from './global-salt.js';
-import { getNexusDbPath } from './nexus-sqlite.js';
 import { getGlobalSignaldockDbPath } from './signaldock-sqlite.js';
 import { applyPerfPragmas } from './sqlite-pragmas.js';
 import { assertT310Ready } from './t310-readiness.js';
@@ -476,8 +475,14 @@ export async function packBundle(input: PackBundleInput): Promise<PackBundleResu
     }
 
     if (includesGlobal) {
-      // nexus.db
-      const nexusSrc = getNexusDbPath();
+      // nexus.db — E6-L4 (T11524): the live nexus domain now consolidates into
+      // the GLOBAL `cleo.db` (getNexusDbPath() → <cleoHome>/cleo.db), but the
+      // backup snapshot intentionally keeps reading the LEGACY standalone
+      // `<cleoHome>/nexus.db` literal during the E6 cutover. Rerouting the backup
+      // read to the consolidated resolver mid-cutover would double-snapshot the
+      // shared cleo.db (also taken by the project-tier path) and skip any
+      // un-migrated legacy nexus.db that still holds the only copy of the graph.
+      const nexusSrc = path.join(getCleoHome(), 'nexus.db');
       const nexusDest = path.join(stagingDir, 'databases', 'nexus.db');
       const nexusSnapped = vacuumIntoStaging(nexusSrc, nexusDest);
       if (nexusSnapped) {

--- a/packages/core/src/store/dual-scope-db.ts
+++ b/packages/core/src/store/dual-scope-db.ts
@@ -353,13 +353,30 @@ export async function openDualScopeDb(scope: DualScope, cwd?: string): Promise<D
 }
 
 /**
- * Reset all cached handles. Primarily for use in tests between test cases.
- * Closes all open handles before evicting from the cache.
+ * Reset cached dual-scope handles. Primarily for use in tests between test
+ * cases and by domain `closeDb()`/`resetDbState()` paths. Closes the targeted
+ * open handles before evicting them from the cache.
  *
+ * ## Scope filter (E6-L4 · T11524)
+ *
+ * Pass `scope` to evict ONLY that scope's entries. This matters because the
+ * `'project'` and `'global'` scopes now share this cache: the tasks/brain/conduit
+ * domains hold the project-scope `cleo.db`, while nexus/signaldock/skills hold the
+ * global-scope `cleo.db`. A project-domain reset (`closeDb`/`resetDbState` in
+ * sqlite.ts) must NOT close the global handle out from under an in-flight nexus
+ * query — and vice-versa. When `scope` is omitted, ALL entries are evicted (the
+ * coordinated full teardown used by `closeAllDatabases` and test global resets).
+ *
+ * @param scope - When provided, only entries opened against this scope are
+ *   closed + evicted. When omitted, every cached handle is reset.
  * @internal
  */
-export function _resetDualScopeDbCache(): void {
-  for (const entry of _cache.values()) {
+export function _resetDualScopeDbCache(scope?: DualScope): void {
+  for (const [key, entry] of _cache) {
+    // Skip entries that belong to a different scope when a scope filter is set.
+    // A mid-init placeholder (handle === null) cannot be scope-matched, so it is
+    // only evicted on a full (unscoped) reset.
+    if (scope !== undefined && entry.handle?.scope !== scope) continue;
     if (entry.handle) {
       try {
         entry.handle.close();
@@ -367,11 +384,16 @@ export function _resetDualScopeDbCache(): void {
         // ignore
       }
     }
+    // handle.close() already deletes the key for the targeted entry; delete
+    // defensively in case the handle was a mid-init placeholder.
+    _cache.delete(key);
   }
-  _cache.clear();
-  // Also reset schema caches so tests can reload fresh schemas.
-  _projectSchema = null;
-  _globalSchema = null;
+  // Only reset the schema caches on a full (unscoped) reset — a scoped reset must
+  // not force the OTHER scope to reload its schema barrel mid-flight.
+  if (scope === undefined) {
+    _projectSchema = null;
+    _globalSchema = null;
+  }
 }
 
 // ── Idempotent write helpers (E4-T2 · T11513) ───────────────────────────────

--- a/packages/core/src/store/nexus-sqlite.ts
+++ b/packages/core/src/store/nexus-sqlite.ts
@@ -1,31 +1,69 @@
 /**
- * SQLite store for nexus.db via drizzle-orm/node-sqlite + node:sqlite (DatabaseSync).
+ * SQLite store for the global-scope NEXUS domain via drizzle-orm/node-sqlite +
+ * node:sqlite (DatabaseSync).
  *
- * Separate database from tasks.db and brain.db for cross-project registry
- * and audit infrastructure. Follows the same singleton + WAL + migration
- * pattern as memory-sqlite.ts.
+ * ## E6-L4 — thin-facade migration (T11524)
  *
- * nexus.db lives in ~/.cleo/ (global home) rather than per-project .cleo/,
- * since it stores cross-project data.
+ * `getNexusDb()` is now a thin facade that delegates the database open to
+ * {@link openDualScopeDb}('global') — the canonical dual-scope chokepoint
+ * introduced by E3/E4 (T11512/T11517) and already adopted by the tasks domain
+ * (E6-L1, T11521), the brain domain (E6-L2, T11522), and the conduit domain
+ * (E6-L3, T11523). This is the GLOBAL-scope variant: nexus is a cross-project
+ * registry and stays GLOBAL — its tables live inside the consolidated GLOBAL
+ * `cleo.db` under {@link getCleoHome}, NOT a per-project `.cleo/` file.
  *
+ * This ensures:
+ *
+ * - Every nexus-domain open flows through the single pragma SSoT (ADR-068/069).
+ * - The nexus tables now live inside the consolidated GLOBAL `cleo.db` — NOT a
+ *   separate `nexus.db` file — co-existing with `signaldock_*` / `skills_*` /
+ *   global `brain_*`.
+ * - DB Open Guard Gate 3 (`scripts/lint-no-direct-db-open.mjs`) stays green: the
+ *   only native open is inside `dual-scope-db.ts`. The remaining raw opens in
+ *   `nexus/**` migration scripts are the allowlisted migration paths.
+ *
+ * The legacy `drizzle-nexus` migrations are still applied to this handle during
+ * the E3→E6 transition. They create the legacy runtime-queried physical tables
+ * (`nexus_nodes`, `nexus_relations`, `nexus_contracts`, `project_registry`,
+ * `project_id_aliases`, `nexus_audit_log`, `nexus_schema_meta`, `user_profile`,
+ * `sigils`) plus the FTS5 virtual table + triggers (`nexus_symbols_fts`) that
+ * Drizzle cannot model. The consolidated GLOBAL schema (`drizzle-cleo-global`)
+ * creates a domain-prefixed subset (`nexus_nodes` / `nexus_relations` /
+ * `nexus_contracts` / `nexus_audit_log` / `nexus_schema_meta` collide by name
+ * but carry the exodus-TARGET shape — ISO-8601 timestamps + enum/format CHECK
+ * constraints) which the runtime nexus writers cannot use. On first open we drop
+ * those consolidated-target collisions and run the legacy `drizzle-nexus`
+ * migrations to recreate them in the runtime shape — exactly mirroring the brain
+ * domain (E6-L2). The residency MOVE of the nexus graph tables global→project is
+ * a SEPARATE later task (T11538, post-E6) — this task keeps the ADR-036
+ * global-only invariant intact.
+ *
+ * @adr ADR-036 — nexus.db (now the global `cleo.db`) is global-only.
  * @task T5365
+ * @task T11524 - E6-L4: route getNexusDb through openDualScopeDb('global') (SG-DB-SUBSTRATE-V2)
  */
 
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { copyFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import { readMigrationFiles } from 'drizzle-orm/migrator';
 import type { NodeSQLiteDatabase } from 'drizzle-orm/node-sqlite';
 import { drizzle } from 'drizzle-orm/node-sqlite';
 import { getLogger } from '../logger.js';
 import { getCleoHome } from '../paths.js';
+// E6-L4 (T11524): dual-scope chokepoint — the nexus domain now opens the
+// consolidated GLOBAL `cleo.db` through here. openDualScopeDb manages the
+// DatabaseSync lifecycle, pragmas, and consolidated migrations. We extract the
+// native handle and re-wrap it with the legacy nexus-schema drizzle instance so
+// existing callers (nexusSchema.* queries) compile and run without change.
+import { openDualScopeDb, resolveDualScopeDbPath } from './dual-scope-db.js';
 import { ensureColumns, migrateWithRetry, reconcileJournal } from './migration-manager.js';
 import { resolveCorePackageMigrationsFolder } from './resolve-migrations-folder.js';
 import * as nexusSchema from './schema/nexus-schema.js';
-import { isSqliteBusy, openNativeDatabase } from './sqlite.js';
-
-/** Database file name within ~/.cleo/ directory. */
-const DB_FILENAME = 'nexus.db';
+// isSqliteBusy is a pure predicate with no node:sqlite dependency — import it
+// from its canonical leaf home (with-retry.ts) rather than sqlite.ts so this
+// module no longer pulls the native open path.
+import { isSqliteBusy } from './with-retry.js';
 
 /** Schema version for newly created nexus databases. Single source of truth. */
 export const NEXUS_SCHEMA_VERSION = '1.0.0';
@@ -38,34 +76,37 @@ let _nexusDbPath: string | null = null;
 let _nexusInitPromise: Promise<NodeSQLiteDatabase<typeof nexusSchema>> | null = null;
 
 /**
- * Returns the global-tier nexus.db path. ALWAYS under `getCleoHome()`.
+ * Returns the global-tier nexus DB path — the consolidated GLOBAL `cleo.db`.
  *
- * nexus.db is a cross-project registry and must live in the global CLEO
- * home directory (`~/.local/share/cleo/` on Linux via XDG). It is NEVER
- * written to a per-project `.cleo/` directory.
+ * E6-L4 (T11524): delegates to {@link resolveDualScopeDbPath}('global'), which
+ * resolves `getCleoHome()` + `cleo.db`. nexus is a cross-project registry and
+ * must live in the global CLEO home directory (`~/.local/share/cleo/` on Linux
+ * via XDG). It is NEVER written to a per-project `.cleo/` directory.
  *
  * @task T307
  * @epic T299
- * @why ADR-036 §Decision/Global-Tier: nexus.db is global-only. This guard
+ * @why ADR-036 §Decision/Global-Tier: nexus is global-only. This guard
  *   throws immediately if path resolution ever drifts outside getCleoHome(),
- *   preventing silent creation of project-tier stray nexus.db files.
+ *   preventing silent creation of project-tier stray DB files. The dual-scope
+ *   global resolver builds the path from getCleoHome() so the invariant holds;
+ *   the assertion is retained as defence-in-depth against future regressions.
  * @throws {Error} If the resolved path is not under `getCleoHome()` — this
  *   indicates a code path that bypasses canonical path resolution and is a
  *   bug that must be fixed rather than silently tolerated.
  */
 export function getNexusDbPath(): string {
   const cleoHome = getCleoHome();
-  const nexusPath = join(cleoHome, DB_FILENAME);
+  const nexusPath = resolveDualScopeDbPath('global');
 
-  // Guard: the resolved path MUST be under the global tier.
-  // Under normal operation this invariant is always satisfied because we
-  // build nexusPath from cleoHome above. The assertion catches hypothetical
-  // future regressions where getCleoHome() is monkey-patched or join()
-  // produces an unexpected result on exotic platforms.
+  // Guard: the resolved path MUST be under the global tier (ADR-036). The
+  // dual-scope global resolver joins getCleoHome() with 'cleo.db', so the
+  // invariant is always satisfied under normal operation. The assertion catches
+  // hypothetical future regressions where getCleoHome() is monkey-patched or the
+  // resolver drifts.
   if (!nexusPath.startsWith(cleoHome)) {
     throw new Error(
       `BUG: getNexusDbPath() resolved to "${nexusPath}" which is NOT under ` +
-        `getCleoHome() ("${cleoHome}"). nexus.db is global-only per ADR-036. ` +
+        `getCleoHome() ("${cleoHome}"). nexus is global-only per ADR-036. ` +
         `This indicates a code path that bypasses canonical path resolution — ` +
         `fix the caller, do not suppress this error.`,
     );
@@ -126,9 +167,8 @@ export function getNestedNexusSentinelPath(): string {
  * warning via the canonical pino logger if found.
  *
  * The function is non-blocking and non-throwing — it never alters the
- * outcome of the surrounding `getNexusDb()` open. The canonical flat
- * `nexus.db` open proceeds normally regardless of whether the nested debris
- * is present.
+ * outcome of the surrounding `getNexusDb()` open. The canonical consolidated
+ * open proceeds normally regardless of whether the nested debris is present.
  *
  * Idempotency: the first call for a given nested path emits the warning;
  * subsequent calls within the same process are no-ops. Tests can reset the
@@ -163,7 +203,7 @@ export function detectAndWarnOnNestedNexus(): boolean {
       adr: 'ADR-086',
       task: 'T10321',
     },
-    'Detected nested-nexus structural bug — canonical flat nexus.db is in use; ' +
+    'Detected nested-nexus structural bug — canonical consolidated cleo.db is in use; ' +
       'nested duplicates at <cleoHome>/nexus/ are migration debris. Run the ' +
       'migration script to remove them.',
   );
@@ -202,6 +242,61 @@ function objectExists(nativeDb: DatabaseSync, type: string, name: string): boole
     .prepare('SELECT name FROM sqlite_master WHERE type=? AND name=?')
     .get(type, name) as Record<string, unknown> | undefined;
   return !!result;
+}
+
+/**
+ * The consolidated (exodus-target) nexus tables that COLLIDE with the legacy
+ * `drizzle-nexus` schema by physical name. The {@link openDualScopeDb}('global')
+ * consolidation migration (`drizzle-cleo-global`, T11363) creates these in the
+ * exodus-target shape (ISO-8601 `text` timestamps + enum/format `CHECK`
+ * constraints — e.g. `nexus_nodes.kind IN (…)`, `nexus_relations.indexed_at
+ * GLOB '[0-9]…'`). The runtime nexus writers and `nexusSchema`
+ * (`nexus-schema.ts`) use the legacy shape — no CHECKs — so on first open we
+ * drop these and let the legacy `CREATE TABLE IF NOT EXISTS` migrations recreate
+ * them.
+ *
+ * The non-colliding consolidated tables (`nexus_project_registry`,
+ * `nexus_project_id_aliases`, `nexus_user_profile`, `nexus_sigils`,
+ * `nexus_code_index`) carry DIFFERENT physical names than the legacy bare names
+ * (`project_registry`, `project_id_aliases`, `user_profile`, `sigils`) so they
+ * co-exist harmlessly — like the tasks domain (`tasks` ≠ `tasks_tasks`). The
+ * exodus (T11248 / T11553) and the nexus residency move (T11538) reconcile them.
+ *
+ * @internal
+ * @task T11524
+ */
+const CONSOLIDATED_NEXUS_TABLES = [
+  'nexus_nodes',
+  'nexus_relations',
+  'nexus_contracts',
+  'nexus_audit_log',
+  'nexus_schema_meta',
+] as const;
+
+/**
+ * Detect whether the colliding nexus tables in the open handle carry the
+ * CONSOLIDATED (exodus-target) shape rather than the LEGACY runtime shape.
+ *
+ * The consolidation migration (T11363) adds enum/format `CHECK` constraints to
+ * `nexus_nodes` (`kind IN (…)`, `indexed_at GLOB '[0-9]…'`); the legacy runtime
+ * schema (`nexus-schema.ts`) has none. The colliding tables share the SAME
+ * physical name AND the same column affinities (both `indexed_at text`), so the
+ * column type is not a discriminator — instead we inspect the stored DDL in
+ * `sqlite_master` for the consolidation CHECK marker.
+ *
+ * @internal
+ * @task T11524
+ */
+function nexusTablesAreConsolidatedShape(nativeDb: DatabaseSync): boolean {
+  if (!tableExists(nativeDb, 'nexus_nodes')) return false;
+  const row = nativeDb
+    .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='nexus_nodes'")
+    .get() as { sql?: string } | undefined;
+  const sql = row?.sql ?? '';
+  // Legacy `nexus_nodes` has NO CHECK constraint; the consolidated target carries
+  // `CHECK ("kind" IN (…))`. Presence of a CHECK clause means the handle holds the
+  // consolidated (exodus-target) shape and must be rebuilt to the legacy shape.
+  return /\bCHECK\b/i.test(sql);
 }
 
 /**
@@ -283,7 +378,8 @@ function ensureNexusFts5(nativeDb: DatabaseSync): void {
 }
 
 /**
- * Run drizzle migrations to create/update nexus.db tables.
+ * Run drizzle migrations to create/update the legacy nexus tables inside the
+ * consolidated GLOBAL `cleo.db`.
  *
  * Uses IMMEDIATE transactions to prevent concurrent migration races.
  * Follows the same pattern as memory-sqlite.ts runBrainMigrations().
@@ -329,7 +425,7 @@ function runNexusMigrations(
   }
 
   // T998: idempotent safety net for plasticity columns — covers pre-migration
-  // nexus.db instances that were created before the drizzle migration runs.
+  // nexus instances that were created before the drizzle migration runs.
   // ensureColumns is a no-op when the columns already exist.
   ensureColumns(
     nativeDb,
@@ -343,7 +439,7 @@ function runNexusMigrations(
   );
 
   // T1062: idempotent safety net for external module nodes — covers pre-migration
-  // nexus.db instances that were created before the drizzle migration runs.
+  // nexus instances that were created before the drizzle migration runs.
   // Unresolved imports are persisted as ExternalModule nodes with is_external=true.
   ensureColumns(
     nativeDb,
@@ -353,7 +449,7 @@ function runNexusMigrations(
   );
 
   // T1065: idempotent safety net for contracts table — covers pre-migration
-  // nexus.db instances that were created before contracts extraction.
+  // nexus instances that were created before contracts extraction.
   // If the table doesn't exist after migrations, it will be created here.
   if (!tableExists(nativeDb, 'nexus_contracts')) {
     nativeDb
@@ -409,13 +505,13 @@ function runNexusMigrations(
   }
 
   // T1839: idempotent safety net for FTS5 virtual table + triggers.
-  // Covers existing nexus.db instances that were created before this migration.
+  // Covers existing nexus instances that were created before this migration.
   // Each statement uses nativeDb.exec() (not prepare().run()) so that the entire
   // DDL block executes atomically without the node:sqlite first-statement-only limit.
   ensureNexusFts5(nativeDb);
 
   // T9183: Reconcile partial migrations before running migrate (matches brain.db
-  // pattern in memory-sqlite.ts). When a legacy nexus.db has columns from prior
+  // pattern in memory-sqlite.ts). When a legacy nexus DB has columns from prior
   // ensureColumns() repair but no journal entries, reconcileJournal Scenario 3
   // marks those migrations applied via DDL probe so migrateWithRetry doesn't
   // hit duplicate-column errors on the legacy-upgrade path.
@@ -456,9 +552,97 @@ function runNexusMigrations(
 }
 
 /**
- * Initialize the nexus.db SQLite database (lazy, singleton).
- * Creates the database file and tables if they don't exist.
- * Returns the drizzle ORM instance (async via sqlite-proxy).
+ * Establish the LEGACY nexus-domain schema inside the consolidated GLOBAL
+ * `cleo.db`, replacing the consolidated (exodus-target) nexus tables that
+ * collide by name.
+ *
+ * ## Why (T11524 · E6-L4)
+ *
+ * Routing `getNexusDb()` through {@link openDualScopeDb}('global') runs the
+ * T11363 consolidation migration, which creates the colliding `nexus_*` tables
+ * (see {@link CONSOLIDATED_NEXUS_TABLES}) in their **exodus-target** shape:
+ * ISO-8601 `text` timestamps and enum/format `CHECK` constraints (e.g.
+ * `nexus_nodes.kind IN (…)`, `nexus_relations.indexed_at GLOB '[0-9]…'`). The
+ * runtime nexus writers and `nexusSchema` (`nexus-schema.ts`) use the **legacy**
+ * shape — no enum/format CHECKs — exactly as the brain domain keeps using the
+ * legacy shape after E6-L2.
+ *
+ * The legacy and consolidated tables share the SAME physical names, so they
+ * cannot co-exist. The runtime must win, so on first open we drop the
+ * consolidated colliding tables and run the legacy `drizzle-nexus` migrations
+ * (all `CREATE TABLE IF NOT EXISTS`) to recreate them in the runtime shape. The
+ * consolidated-target cutover and the nexus residency move (global→project) are
+ * separate exodus jobs — see T11248 / T11553 / T11538.
+ *
+ * Idempotent: after the first rebuild the colliding tables are already
+ * legacy-shaped, so {@link nexusTablesAreConsolidatedShape} returns `false` and
+ * this only reconciles/applies the `drizzle-nexus` journal (nothing is dropped).
+ *
+ * @internal
+ * @task T11524
+ */
+function establishLegacyNexusSchema(
+  nativeDb: DatabaseSync,
+  db: NodeSQLiteDatabase<typeof nexusSchema>,
+): void {
+  const log = getLogger('nexus-schema');
+
+  if (nexusTablesAreConsolidatedShape(nativeDb)) {
+    // Drop the consolidated (exodus-target) colliding nexus tables so the legacy
+    // `drizzle-nexus` migrations can recreate them in the runtime shape. The
+    // FTS5 virtual table + triggers (`nexus_symbols_fts`) reference `nexus_nodes`;
+    // dropping `nexus_nodes` orphans them, so drop the FTS5 artifacts too and let
+    // `ensureNexusFts5` (called by `runNexusMigrations`) rebuild them cleanly.
+    // Disable FKs during the drop so cross-table references do not block the
+    // teardown — then RESTORE the prior pragma state (the dual-scope pragma SSoT
+    // enables foreign_keys; leaving it OFF would break the idempotent-pragma
+    // contract, T10314).
+    const fkRow = nativeDb.prepare('PRAGMA foreign_keys').get() as
+      | { foreign_keys?: number }
+      | undefined;
+    const fkWasOn = fkRow?.foreign_keys === 1;
+    nativeDb.exec('PRAGMA foreign_keys=OFF');
+    try {
+      // FTS5 triggers + virtual table first (they reference nexus_nodes).
+      nativeDb.exec('DROP TRIGGER IF EXISTS nexus_nodes_fts_ai');
+      nativeDb.exec('DROP TRIGGER IF EXISTS nexus_nodes_fts_ad');
+      nativeDb.exec('DROP TRIGGER IF EXISTS nexus_nodes_fts_au');
+      nativeDb.exec('DROP TABLE IF EXISTS nexus_symbols_fts');
+      for (const table of CONSOLIDATED_NEXUS_TABLES) {
+        try {
+          nativeDb.exec(`DROP TABLE IF EXISTS \`${table}\``);
+        } catch (err) {
+          log.warn(
+            { table, err },
+            'Failed to drop consolidated nexus table during legacy rebuild.',
+          );
+        }
+      }
+    } finally {
+      // Restore the pragma to its pre-drop state (ON under the dual-scope SSoT).
+      nativeDb.exec(`PRAGMA foreign_keys=${fkWasOn ? 'ON' : 'OFF'}`);
+    }
+    log.debug(
+      { count: CONSOLIDATED_NEXUS_TABLES.length },
+      'Dropped consolidated (exodus-target) nexus tables — rebuilding in legacy runtime shape.',
+    );
+  }
+
+  // Run the legacy `drizzle-nexus` migrations to (re)create the runtime-shaped
+  // nexus tables + FTS5 artifacts. Their `__drizzle_migrations` journal is shared
+  // with the cleo-global journal in the same `cleo.db`; the hashes are disjoint so
+  // the nexus migrations are reconciled/applied independently.
+  runNexusMigrations(nativeDb, db);
+}
+
+/**
+ * Initialize the consolidated GLOBAL `cleo.db` and the legacy nexus tables
+ * within it (lazy, singleton).
+ *
+ * E6-L4 (T11524): delegates the physical open to {@link openDualScopeDb}('global')
+ * — the canonical dual-scope chokepoint — and re-wraps its native handle with the
+ * legacy `nexusSchema` drizzle instance so existing callers compile unchanged.
+ * Returns the drizzle ORM instance (async via the dual-scope migration step).
  *
  * Uses a promise guard so concurrent callers wait for the same
  * initialization to complete (migrations are async).
@@ -466,8 +650,19 @@ function runNexusMigrations(
 export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchema>> {
   const requestedPath = getNexusDbPath();
 
-  // If singleton exists but points to different path, reset it
+  // If singleton exists but points to a different path (e.g. CLEO_HOME changed
+  // between tests), reset it.
   if (_nexusDb && _nexusDbPath !== requestedPath) {
+    resetNexusDbState();
+  }
+
+  // Liveness guard (T11524): nexus shares the consolidated GLOBAL `cleo.db`
+  // handle with the other global-tier domains (signaldock/skills, E6-L5). Another
+  // domain may have closed + re-opened the shared `DatabaseSync` while our nexus
+  // singleton still references the now-closed handle. Detect a stale (closed)
+  // handle and drop the singleton so we re-derive from the live openDualScopeDb
+  // cache below.
+  if (_nexusDb && (_nexusNativeDb === null || !_nexusNativeDb.isOpen)) {
     resetNexusDbState();
   }
 
@@ -484,18 +679,37 @@ export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchem
     // carries the nested-nexus migration debris. Does not alter the open.
     detectAndWarnOnNestedNexus();
 
-    // Ensure directory exists
-    mkdirSync(dirname(dbPath), { recursive: true });
+    // ── Dual-scope chokepoint delegation (T11524 · E6-L4) ─────────────────
+    // openDualScopeDb('global') applies the pragma SSoT, creates the directory,
+    // runs the consolidated cleo-global migrations (which create the colliding
+    // `nexus_*` tables in exodus-target shape), and manages the singleton cache.
+    // We extract its native handle so we can re-wrap it with the legacy
+    // nexus-schema and rebuild the runtime-shaped nexus tables.
+    const dualHandle = await openDualScopeDb('global');
 
-    // Open file-backed SQLite via node:sqlite with WAL mode.
-    const nativeDb = openNativeDatabase(dbPath);
+    // Extract the underlying DatabaseSync. Drizzle exposes it via `$client`.
+    const nativeDb = (dualHandle.db as { $client?: DatabaseSync }).$client ?? null;
+    if (!nativeDb) {
+      throw new Error(
+        'E6-L4: openDualScopeDb returned a handle without $client — ' +
+          'cannot extract DatabaseSync for legacy nexus-schema wrapping.',
+      );
+    }
     _nexusNativeDb = nativeDb;
 
-    // Create drizzle ORM wrapper via node-sqlite
+    // Wrap the native handle with the legacy nexus-schema drizzle instance so
+    // existing callers (nexusSchema.* queries) continue to work unchanged.
     const db = drizzle({ client: nativeDb, schema: nexusSchema });
 
-    // Run drizzle migrations (creates/updates tables)
-    runNexusMigrations(nativeDb, db);
+    // Establish the LEGACY nexus-domain schema inside the consolidated GLOBAL
+    // cleo.db. openDualScopeDb created the colliding nexus tables in their
+    // exodus-TARGET shape (ISO-8601 timestamps + enum/format CHECK constraints),
+    // which the runtime nexus writers cannot use. This drops those and runs the
+    // legacy `drizzle-nexus` migrations to recreate them in the runtime shape
+    // (plus the FTS5 virtual table + triggers). Idempotent once already-legacy.
+    // The consolidated-target cutover + residency move are exodus jobs (T11248 /
+    // T11553 / T11538). (T11524)
+    establishLegacyNexusSchema(nativeDb, db);
 
     // Seed schema version for new databases (no-op if already set)
     nativeDb
@@ -517,46 +731,48 @@ export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchem
 }
 
 /**
- * Close the nexus.db database connection and release resources.
+ * Close the nexus-domain database connection and release resources.
+ *
+ * ## E6-L4 (T11524)
+ *
+ * The nexus domain now SHARES the consolidated GLOBAL `cleo.db` handle with the
+ * other global-tier domains (signaldock/skills, E6-L5 — all open it via
+ * {@link openDualScopeDb}('global'), same cache key). This function therefore must
+ * NOT close the underlying `DatabaseSync` nor evict the dual-scope cache — doing
+ * so would break in-flight queries from those siblings with "database is not
+ * open". It only drops the nexus-domain singleton references; the shared handle's
+ * lifecycle is owned by `openDualScopeDb` and torn down by a coordinated reset
+ * (`closeAllDatabases` → `_resetDualScopeDbCache`).
  */
 export function closeNexusDb(): void {
-  if (_nexusNativeDb) {
-    try {
-      if (_nexusNativeDb.isOpen) {
-        _nexusNativeDb.close();
-      }
-    } catch {
-      // Ignore close errors
-    }
-    _nexusNativeDb = null;
-  }
-  _nexusDb = null;
-  _nexusDbPath = null;
-}
-
-/**
- * Reset nexus.db singleton state without saving.
- * Used during tests or when database file is recreated.
- * Safe to call multiple times.
- */
-export function resetNexusDbState(): void {
-  if (_nexusNativeDb) {
-    try {
-      if (_nexusNativeDb.isOpen) {
-        _nexusNativeDb.close();
-      }
-    } catch {
-      // Ignore close errors
-    }
-    _nexusNativeDb = null;
-  }
+  // Drop only the nexus singleton references. Do NOT close `_nexusNativeDb` — it
+  // is the shared dual-scope handle, possibly still in use by global siblings.
+  _nexusNativeDb = null;
   _nexusDb = null;
   _nexusDbPath = null;
   _nexusInitPromise = null;
 }
 
 /**
- * Get the underlying node:sqlite DatabaseSync instance for nexus.db.
+ * Reset nexus singleton state without saving.
+ * Used during tests or when the database file is recreated.
+ * Safe to call multiple times.
+ *
+ * ## E6-L4 (T11524)
+ *
+ * Drops only the nexus-domain singleton references — does NOT close the shared
+ * dual-scope GLOBAL `cleo.db` handle nor evict the dual-scope cache (that handle
+ * is shared with the other global-tier domains). Mirrors {@link closeNexusDb}.
+ */
+export function resetNexusDbState(): void {
+  _nexusNativeDb = null;
+  _nexusDb = null;
+  _nexusDbPath = null;
+  _nexusInitPromise = null;
+}
+
+/**
+ * Get the underlying node:sqlite DatabaseSync instance for the nexus domain.
  * Useful for direct PRAGMA calls or raw SQL operations.
  * Returns null if the database hasn't been initialized.
  */

--- a/packages/core/src/store/sqlite.ts
+++ b/packages/core/src/store/sqlite.ts
@@ -463,10 +463,16 @@ function runMigrations(nativeDb: DatabaseSync, db: NodeSQLiteDatabase<typeof sch
  * in `runMigrations → tableExists` for the very next `getDb()` caller.
  */
 export function closeDb(): void {
-  // Evict ALL dual-scope cache entries so the next openDualScopeDb() call
-  // opens a fresh DatabaseSync. Without this, the cache would return the
+  // Evict the PROJECT-scope dual-scope cache entries so the next openDualScopeDb()
+  // call opens a fresh DatabaseSync. Without this, the cache would return the
   // stale handle whose nativeDb we're about to close below.
-  _resetDualScopeDbCache();
+  //
+  // E6-L4 (T11524): scope the eviction to `'project'`. The GLOBAL `cleo.db`
+  // handle (nexus/signaldock/skills) now shares this same cache; an unscoped
+  // reset here would close the global handle out from under an in-flight nexus
+  // query (e.g. nexusSyncAll holding a handle while readProjectMeta opens + closes
+  // a project accessor). Global teardown is the job of closeAllDatabases().
+  _resetDualScopeDbCache('project');
   if (_nativeDb) {
     try {
       if (_nativeDb.isOpen) {
@@ -492,9 +498,12 @@ export function closeDb(): void {
  * Also resets the dual-scope cache via {@link _resetDualScopeDbCache} so the
  * next `getDb()` opens a fresh handle rather than reusing a stale one.
  * Mirrors the cache-eviction logic in {@link closeDb}.
+ *
+ * E6-L4 (T11524): scoped to `'project'` so it does not close the shared GLOBAL
+ * `cleo.db` handle (nexus/signaldock/skills) — see {@link closeDb}.
  */
 export function resetDbState(): void {
-  _resetDualScopeDbCache();
+  _resetDualScopeDbCache('project');
   if (_nativeDb) {
     try {
       if (_nativeDb.isOpen) {

--- a/packages/core/src/system/__tests__/project-health.test.ts
+++ b/packages/core/src/system/__tests__/project-health.test.ts
@@ -226,7 +226,9 @@ describe('checkGlobalHealth', () => {
 
   it('returns overall=healthy when both global DBs are valid', async () => {
     const cleoHome = process.env['CLEO_HOME'] as string;
-    makeHealthyDb(join(cleoHome, 'nexus.db'), 1);
+    // E6-L4 (T11524): the nexus domain probes the GLOBAL consolidated `cleo.db`
+    // under getCleoHome() (getNexusDb → openDualScopeDb('global')), not `nexus.db`.
+    makeHealthyDb(join(cleoHome, 'cleo.db'), 1);
     makeHealthyDb(join(cleoHome, 'signaldock.db'), 1);
 
     const report = await checkGlobalHealth();

--- a/packages/core/src/system/project-health.ts
+++ b/packages/core/src/system/project-health.ts
@@ -67,11 +67,28 @@ function getDatabaseSyncCtor(): DatabaseSyncModule['DatabaseSync'] | null {
 // E6-L3 (T11523): the conduit domain consolidated into the SAME `cleo.db`
 // (ensureConduitDb → openDualScopeDb('project')), so the `dbs.conduit` probe now
 // targets `cleo.db` too. All three project-tier domains share one physical file.
+// E6-L4 (T11524): the nexus domain consolidated into the GLOBAL `cleo.db` under
+// getCleoHome() (getNexusDb → openDualScopeDb('global')), so the global-tier
+// `dbs.nexus` probe now targets that file. This is a DIFFERENT physical file
+// than the project `cleo.db` above (different directory) — it just shares the
+// filename. Its expected migration floor is the global cleo-global set, NOT the
+// project floor of 3, so it uses NEXUS_GLOBAL_DB_FLOOR (passed inline at the
+// probe site) instead of a `[NEXUS_DB]` map entry that would clobber `[TASKS_DB]`.
 const TASKS_DB = 'cleo.db' as const;
 const BRAIN_DB = 'cleo.db' as const;
 const CONDUIT_DB = 'cleo.db' as const;
-const NEXUS_DB = 'nexus.db' as const;
+const NEXUS_DB = 'cleo.db' as const;
 const SIGNALDOCK_DB = 'signaldock.db' as const;
+
+/**
+ * Expected applied-migration floor for the GLOBAL consolidated `cleo.db`
+ * (`drizzle-cleo-global`). E6-L4 (T11524): the nexus domain shares this file
+ * with the other global-tier domains and adds its own `drizzle-nexus` journal
+ * entries to the SAME `__drizzle_migrations` table, so the live count is
+ * strictly ≥ this conservative floor. Kept separate from the project floor (3)
+ * because the global file uses a distinct migration set.
+ */
+const NEXUS_GLOBAL_DB_FLOOR = 2 as const;
 const CONFIG_JSON = 'config.json' as const;
 const PROJECT_INFO_JSON = 'project-info.json' as const;
 
@@ -266,8 +283,10 @@ export const DB_EXPECTED_VERSIONS: Readonly<Record<string, number>> = {
   // fires only when the count drops BELOW it, which the merged journal never
   // does. NOTE: do NOT add a separate `[CONDUIT_DB]` entry — it is the same key
   // as `[TASKS_DB]` ('cleo.db') and would clobber the floor of 3.
+  // E6-L4 (T11524): NEXUS_DB is also `'cleo.db'` now (the GLOBAL file), so it
+  // would clobber `[TASKS_DB]` here too — the nexus probe therefore passes
+  // NEXUS_GLOBAL_DB_FLOOR inline at its probe site instead of via this map.
   [TASKS_DB]: 3,
-  [NEXUS_DB]: 3,
   [SIGNALDOCK_DB]: 1,
 };
 
@@ -755,7 +774,9 @@ export async function checkProjectHealth(
 export async function checkGlobalHealth(): Promise<GlobalHealthReport> {
   const cleoHome = getCleoHome();
   const [nexus, signaldock] = await Promise.all([
-    probeDb(join(cleoHome, NEXUS_DB), DB_EXPECTED_VERSIONS[NEXUS_DB]),
+    // E6-L4 (T11524): the GLOBAL `cleo.db` floor comes from NEXUS_GLOBAL_DB_FLOOR,
+    // not DB_EXPECTED_VERSIONS[NEXUS_DB] (which would alias the project-tier key).
+    probeDb(join(cleoHome, NEXUS_DB), NEXUS_GLOBAL_DB_FLOOR),
     probeDb(join(cleoHome, SIGNALDOCK_DB), DB_EXPECTED_VERSIONS[SIGNALDOCK_DB]),
   ]);
   const dbs = { nexus, signaldock };


### PR DESCRIPTION
## E6-L4 (T11524) — nexus domain dual-scope facade (GLOBAL scope)

Routes `getNexusDb()` through `openDualScopeDb('global')`, mirroring the tasks (L1), brain (L2), and conduit (L3) facades but for the **GLOBAL** scope. nexus stays global-only (ADR-036) — its tables now live in the consolidated GLOBAL `cleo.db` under `getCleoHome()`. The graph-table residency move (global→project) is the separate later task T11538.

### Changes
- **`nexus-sqlite.ts`**: `getNexusDb()` delegates open to `openDualScopeDb('global')`, extracts `$client`, re-wraps with legacy `nexusSchema`, runs legacy `drizzle-nexus` migrations + FTS5. `getNexusDbPath()` → `resolveDualScopeDbPath('global')` (`<cleoHome>/cleo.db`) with the ADR-036 `startsWith(getCleoHome())` guard intact. Raw `new DatabaseSync()` removed (was an indirect `openNativeDatabase` from `sqlite.js`).
- **`establishLegacyNexusSchema()`**: drops the 5 colliding consolidated (exodus-target) tables (`nexus_nodes`/`nexus_relations`/`nexus_contracts`/`nexus_audit_log`/`nexus_schema_meta` carry enum/format CHECK constraints the runtime writers cannot use) + FTS5 artifacts, then the legacy `CREATE TABLE IF NOT EXISTS` migrations rebuild them in runtime shape. Idempotent. Disjoint legacy bare-name tables (`project_registry`/`user_profile`/`sigils`) co-exist with the prefixed consolidated ones (like tasks).
- **Shared-handle safety**: `close/resetNexusDbState` no longer close the shared global handle; a liveness guard re-derives a stale closed handle.
- **Shared-cache regression fix**: `_resetDualScopeDbCache(scope?)` is now scope-filtered; `sqlite.ts` `closeDb`/`resetDbState` pass `'project'` so a tasks/brain reset no longer closes the GLOBAL nexus handle out from under an in-flight query (`nexusSyncAll` → `readProjectMeta`).
- **`project-health.ts`**: `NEXUS_DB` → `cleo.db` with `NEXUS_GLOBAL_DB_FLOOR` passed inline (avoids clobbering the `[TASKS_DB]` project floor). **`backup-pack.ts`** keeps the literal `nexus.db` read (no mid-cutover reroute). `resolveProjectById` gates on the consolidated path.
- **Tests**: `graph-auto-populate` + `brain-reasoning-symbol` separate `CLEO_HOME` from `CLEO_DIR` (collapsing them put global+project on one `cleo.db` → `brain_attention` double-create); migration-smoke / migration-fresh / nexus-e2e-registry / project-health assert `cleo.db`.

### Validation
- `pnpm run typecheck` ✅ · `node build.mjs` ✅ · `cleo check arch` (5/5) ✅ · DB Open Guard 0 violations ✅
- `@cleocode/core`: 15 failures, all pre-existing baseline (worktree/napi env flakes + reconstruct) confirmed on clean origin/main; **deterministic** (run1 == run2). The 5 nexus/brain/graph regressions introduced mid-work are fixed.
- `@cleocode/runtime` (the L3 trap): 12 files / 120 tests ✅
- Smoke: `cleo nexus list` returns `scope: global`, creates `<cleoHome>/cleo.db` (no standalone `nexus.db`), legacy tables present + legacy-shaped (no CHECK), FTS5 rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)