### PR TITLE
refactor(T11543): makeSchemaMetaTable() factory — DRY identical schema-meta tables (zero drift)

### DIFF
--- a/packages/core/src/store/schema/cleo-global/nexus.ts
+++ b/packages/core/src/store/schema/cleo-global/nexus.ts
@@ -61,6 +61,7 @@
 
 import { sql } from 'drizzle-orm';
 import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { makeSchemaMetaTable } from '../schema-utils.js';
 
 // ---------------------------------------------------------------------------
 // E10 §5b — enum const arrays minted in-module (no cross-package contracts SSoT)
@@ -261,12 +262,7 @@ export const nexusAuditLog = sqliteTable(
  *
  * @task T11361 (target shape) · T5365 (original)
  */
-export const nexusSchemaMeta = sqliteTable('nexus_schema_meta', {
-  /** Config key. */
-  key: text('key').primaryKey(),
-  /** Config value. */
-  value: text('value').notNull(),
-});
+export const nexusSchemaMeta = makeSchemaMetaTable('nexus_schema_meta');
 
 // ---------------------------------------------------------------------------
 // Code-intelligence graph

--- a/packages/core/src/store/schema/cleo-project/audit.ts
+++ b/packages/core/src/store/schema/cleo-project/audit.ts
@@ -53,6 +53,7 @@ import {
 } from 'drizzle-orm/sqlite-core';
 import { ADR_STATUSES, GATE_STATUSES } from '../../status-registry.js';
 import { TOKEN_USAGE_CONFIDENCE, TOKEN_USAGE_METHODS, TOKEN_USAGE_TRANSPORTS } from '../audit.js';
+import { makeSchemaMetaTable } from '../schema-utils.js';
 
 /** ADR governance-gate kinds — promoted from inline literal (§5a). */
 export const ADR_GATE_KINDS = ['HITL', 'automated'] as const;
@@ -82,12 +83,7 @@ export const STATUS_REGISTRY_NAMESPACES = ['workflow', 'governance', 'manifest']
  *
  * @task T11360 (target shape)
  */
-export const tasksSchemaMeta = sqliteTable('tasks_schema_meta', {
-  /** Config key. */
-  key: text('key').primaryKey(),
-  /** Config value. */
-  value: text('value').notNull(),
-});
+export const tasksSchemaMeta = makeSchemaMetaTable('tasks_schema_meta');
 
 /**
  * `tasks_audit_log` — task-change audit log. No FK on task_id (entries outlive

--- a/packages/core/src/store/schema/cleo-shared/brain.ts
+++ b/packages/core/src/store/schema/cleo-shared/brain.ts
@@ -118,6 +118,7 @@ import {
   DERIVER_QUEUE_ITEM_TYPES,
   DERIVER_QUEUE_STATUSES,
 } from '../memory-schema.js';
+import { makeSchemaMetaTable } from '../schema-utils.js';
 
 // ---------------------------------------------------------------------------
 // §5b enum const arrays minted here (CHECK derivation references identifiers)
@@ -751,12 +752,7 @@ export const brainMemoryLinks = sqliteTable(
  *
  * @task T11360 (target shape)
  */
-export const brainSchemaMeta = sqliteTable('brain_schema_meta', {
-  /** Config key. */
-  key: text('key').primaryKey(),
-  /** Config value. */
-  value: text('value').notNull(),
-});
+export const brainSchemaMeta = makeSchemaMetaTable('brain_schema_meta');
 
 // ---------------------------------------------------------------------------
 // Quality-feedback telemetry (T11546 — no-home table migration)

--- a/packages/core/src/store/schema/index.ts
+++ b/packages/core/src/store/schema/index.ts
@@ -32,5 +32,6 @@ export * from './jsonb.js';
 export * from './lifecycle.js';
 export * from './manifest.js';
 export * from './provenance/index.js';
+export * from './schema-utils.js';
 export * from './sqlite-feature-expressiveness.js';
 export * from './tasks.js';

--- a/packages/core/src/store/schema/schema-utils.ts
+++ b/packages/core/src/store/schema/schema-utils.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared Drizzle schema-construction helpers (SOLID/DRY groundwork).
+ *
+ * This module hosts column-group and table factories that eliminate verbatim
+ * duplication across the consolidated residency-split schema modules
+ * (`cleo-project/`, `cleo-global/`, `cleo-shared/`). Factories here are
+ * **physical-schema-preserving**: they emit exactly the same DDL the inline
+ * definitions did, so applying them produces zero migration drift.
+ *
+ * @see .cleo/rcasd/adr-090-nexus-graph-residency-split.md §5 (SOLID/DRY groundwork)
+ * @task T11543
+ * @epic T11535
+ * @saga T11242
+ */
+
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/**
+ * The canonical two-column shape of a `*_schema_meta` key-value table:
+ * `key` (`TEXT PRIMARY KEY`) + `value` (`TEXT NOT NULL`), in that order.
+ *
+ * Factored into a single builder so every domain's `*_schema_meta` table is
+ * constructed from the identical column map — the source of the zero-drift
+ * guarantee. Spread into {@link makeSchemaMetaTable}'s `sqliteTable` call.
+ */
+const schemaMetaColumns = {
+  /** Config key. */
+  key: text('key').primaryKey(),
+  /** Config value. */
+  value: text('value').notNull(),
+} as const;
+
+/**
+ * Physical column shape of a canonical `*_schema_meta` key-value table.
+ *
+ * Derived from {@link makeSchemaMetaTable}'s return so the explicit table type
+ * (column names, affinities, PK/NOT-NULL flags) stays in lockstep with the
+ * factory body — no hand-maintained column generics to drift.
+ */
+export type SchemaMetaTable = ReturnType<typeof makeSchemaMetaTable>;
+
+/**
+ * Factory for the canonical schema-version key-value table.
+ *
+ * Every CLEO domain DB carries a `*_schema_meta` table with the byte-identical
+ * `{ key TEXT PRIMARY KEY, value TEXT NOT NULL }` shape. This factory is the
+ * single source of truth for that shape so the columns never drift apart across
+ * domains. The emitted DDL is identical to the prior inline definitions.
+ *
+ * @param tableName Fully-qualified physical table name, e.g. `'nexus_schema_meta'`.
+ * @returns A Drizzle SQLite table with `key` (PK) and `value` (NOT NULL) text columns.
+ *
+ * @example
+ * ```ts
+ * export const nexusSchemaMeta = makeSchemaMetaTable('nexus_schema_meta');
+ * ```
+ */
+export function makeSchemaMetaTable(tableName: string) {
+  return sqliteTable(tableName, schemaMetaColumns);
+}


### PR DESCRIPTION
## Summary

Implements **T11543** (ADR-090 §5.2, part of EP-SCOPING-OPTIMIZATION T11535): a `makeSchemaMetaTable(tableName)` factory that DRYs the byte-identical `*_schema_meta` key-value tables.

- New `packages/core/src/store/schema/schema-utils.ts`:
  - `makeSchemaMetaTable(tableName)` → SQLite table `{ key TEXT PRIMARY KEY, value TEXT NOT NULL }` built from a single shared column builder (the source of the zero-drift guarantee).
  - `SchemaMetaTable` type derived from the factory return (no hand-maintained column generics to drift).
- Applied to the **3** residency-split tables named in ADR-090 §5.2 / AC2:
  - `tasks_schema_meta` (`cleo-project/audit.ts`)
  - `nexus_schema_meta` (`cleo-global/nexus.ts`)
  - `brain_schema_meta` (`cleo-shared/brain.ts`)
- Exported from the schema barrel (`index.ts`).

### Intentionally left unchanged
- `telemetry_schema_meta` (`cleo-project/telemetry.ts`) — ADR-090 §2.3 defers it to **T11540** (GLOBAL relocation); out of scope.
- Legacy flat runtime modules (`audit.ts`, `nexus-schema.ts`, `memory-schema.ts`, `telemetry-schema.ts`) — keep their names until the exodus migration per their contract.

## Zero-drift proof
- Extracted each table's Drizzle column config (name / affinity / notNull / primary / default / enumValues, sorted) **before vs after** → **identical**.
- Non-aliasing verified: each table owns distinct column instances bound to its own table; emitted names `tasks_schema_meta` / `nexus_schema_meta` / `brain_schema_meta` correct.
- `consolidated-schema-parity` + `schema-meta` tests (40) green.
- `pnpm run typecheck` (tsc -b) ✓ · `node build.mjs` ✓ · biome ✓ · `cleo check arch` 5/5 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)