### PR TITLE
refactor(T11525): route signaldock-sqlite + skills-db through openDualScopeDb('global') (E6-L5)

### DIFF
--- a/.changeset/t11525-e6-l5-signaldock-skills-dual-scope.md
+++ b/.changeset/t11525-e6-l5-signaldock-skills-dual-scope.md
@@ -1,0 +1,15 @@
+---
+id: t11525-e6-l5-signaldock-skills-dual-scope
+tasks: [T11525]
+kind: refactor
+summary: route signaldock-sqlite + skills-db through openDualScopeDb('global') and resolve the cross-domain bare-skills collision (E6-L5)
+---
+
+E6-L5 of the SG-DB-SUBSTRATE-V2 store rewrite (saga T11242, epic T11249). Routes both global-tier domains through the canonical dual-scope chokepoint and removes their raw `new DatabaseSync()` opens.
+
+- `signaldock-sqlite.ts` — `ensureGlobalSignaldockDb()` now delegates the open to `openDualScopeDb('global')`, extracts the `$client` native handle, and runs the legacy `drizzle-signaldock` migrations on it. signaldock's legacy BARE table names (`agents`, `capabilities`, `skills`, …) DIFFER from the consolidated `signaldock_*` prefix, so they co-exist in the shared global `cleo.db` (the conduit-L3 / tasks DIFFER-PREFIX pattern).
+- `skills-db.ts` — `openSkillsDb()` now delegates to `openDualScopeDb('global')` and binds the (prefix-renamed) `skillsSchema` drizzle queries directly to the consolidated `skills_skills` / `skills_skill_usage` / `skills_skill_reviews` / `skills_skill_patches` tables that the `drizzle-cleo-global` migration already creates. The legacy `drizzle-skills` migration is NOT run on the shared handle.
+
+Why skills renames instead of running its legacy migration: consolidating both former-separate-file domains onto ONE `cleo.db` introduced a SAME-NAME collision — signaldock's legacy `skills` slug-catalog and skills-db's legacy `skills` registry both wanted the bare physical name `skills`. An empirical migration-ordering probe confirmed the collision is fatal in both orderings, AND that the consolidated `skills_skills` CHECK constraints (timestamp-GLOB, boolean IN(0,1), enum) accept every value the runtime drizzle writers produce. So no establishLegacy drop+rebuild is needed (unlike nexus L4) — skills-db simply lands on its exodus-target prefixed tables, making it a zero-delta cutover for the skills domain.
+
+Supporting changes: a new `openDualScopeDbAtPath(scope, dbPath)` chokepoint sibling preserves the skills-db `{ path }` test override; scope-filtered cache reset in both domains' close/reset paths honors the L4 shared-handle rule (signaldock/skills must not close the global handle co-owned by nexus); `backup-pack.ts` reads the literal legacy `signaldock.db` filename during cutover (matching the nexus L4 treatment); and `project-health.ts` folds `SIGNALDOCK_DB` onto the global `cleo.db` floor. DB Open Guard Gate 3 stays green (0 violations).

--- a/packages/core/src/__tests__/pipeline-e2e.test.ts
+++ b/packages/core/src/__tests__/pipeline-e2e.test.ts
@@ -142,7 +142,7 @@ async function makeTmpEnv(suffix: string): Promise<TmpEnv> {
   signaldockMod._resetGlobalSignaldockDb_TESTING_ONLY();
   await signaldockMod.ensureGlobalSignaldockDb();
 
-  const dbPath = join(cleoHome, 'signaldock.db');
+  const dbPath = join(cleoHome, 'cleo.db'); // E6-L5 (T11525): signaldock consolidated into GLOBAL cleo.db
 
   const openDb = (): DatabaseSync => {
     const d = new DatabaseSync(dbPath);
@@ -413,7 +413,7 @@ describe('Pipeline E2E — classifier emits canonical project-<role> IDs', () =>
         return;
       }
 
-      const dbPath = join(cleoHome, 'signaldock.db');
+      const dbPath = join(cleoHome, 'cleo.db'); // E6-L5 (T11525): signaldock consolidated into GLOBAL cleo.db
       const db = new DatabaseSync(dbPath);
       db.exec('PRAGMA foreign_keys = ON');
 

--- a/packages/core/src/orchestration/__tests__/spawn-retrieval-parity.test.ts
+++ b/packages/core/src/orchestration/__tests__/spawn-retrieval-parity.test.ts
@@ -80,7 +80,7 @@ async function makeTmpEnv(suffix: string): Promise<TmpEnv> {
   _resetGlobalSignaldockDb_TESTING_ONLY();
   await ensureGlobalSignaldockDb();
 
-  const dbPath = join(cleoHome, 'signaldock.db');
+  const dbPath = join(cleoHome, 'cleo.db'); // E6-L5 (T11525): signaldock consolidated into GLOBAL cleo.db
 
   // Seed the skills catalog so junction writes succeed.
   const seedDb = new DatabaseSync(dbPath);

--- a/packages/core/src/orchestration/__tests__/spawn.test.ts
+++ b/packages/core/src/orchestration/__tests__/spawn.test.ts
@@ -95,7 +95,7 @@ async function makeTmpEnv(suffix: string): Promise<TmpEnv> {
   _resetGlobalSignaldockDb_TESTING_ONLY();
   await ensureGlobalSignaldockDb();
 
-  const dbPath = join(cleoHome, 'signaldock.db');
+  const dbPath = join(cleoHome, 'cleo.db'); // E6-L5 (T11525): signaldock consolidated into GLOBAL cleo.db
 
   // Seed the skills catalog so junction writes succeed.
   const seedDb = new DatabaseSync(dbPath);

--- a/packages/core/src/orchestration/__tests__/validate-spawn.test.ts
+++ b/packages/core/src/orchestration/__tests__/validate-spawn.test.ts
@@ -325,7 +325,7 @@ describe('validateSpawnReadiness — T1933 agent-existence pre-flight (ADR-068 D
       _resetGlobalSignaldockDb_TESTING_ONLY();
       await ensureGlobalSignaldockDb();
 
-      const dbPath = join(cleoHome, 'signaldock.db');
+      const dbPath = join(cleoHome, 'cleo.db'); // E6-L5 (T11525): signaldock consolidated into GLOBAL cleo.db
       const db = new DatabaseSync(dbPath);
       db.exec('PRAGMA foreign_keys = ON');
       db.close();
@@ -402,7 +402,7 @@ agent project-docs-worker:
       resetDb();
       await ensureGlobalSignaldockDb();
 
-      const dbPath = join(cleoHome, 'signaldock.db');
+      const dbPath = join(cleoHome, 'cleo.db'); // E6-L5 (T11525): signaldock consolidated into GLOBAL cleo.db
       const db = new DatabaseSync(dbPath);
       db.exec('PRAGMA foreign_keys = ON');
       db.close();

--- a/packages/core/src/store/__tests__/agent-doctor.test.ts
+++ b/packages/core/src/store/__tests__/agent-doctor.test.ts
@@ -88,7 +88,7 @@ async function makeTmpEnv(suffix: string): Promise<TmpEnv> {
   _resetGlobalSignaldockDb_TESTING_ONLY();
   await ensureGlobalSignaldockDb();
 
-  const dbPath = join(cleoHome, 'signaldock.db');
+  const dbPath = join(cleoHome, 'cleo.db'); // E6-L5 (T11525): signaldock consolidated into GLOBAL cleo.db
 
   // Seed the catalog so junction-row assertions have something to match.
   const seedDb = new DatabaseSync(dbPath);

--- a/packages/core/src/store/__tests__/agent-install.test.ts
+++ b/packages/core/src/store/__tests__/agent-install.test.ts
@@ -117,7 +117,8 @@ async function makeTmpEnv(suffix: string): Promise<TmpEnv> {
   _resetGlobalSignaldockDb_TESTING_ONLY();
   await ensureGlobalSignaldockDb();
 
-  const dbPath = join(cleoHome, 'signaldock.db');
+  // E6-L5 (T11525): the signaldock domain consolidated into the GLOBAL cleo.db.
+  const dbPath = join(cleoHome, 'cleo.db');
 
   // Seed a pair of skills so the junction-insert path has something to match.
   const seedDb = new DatabaseSync(dbPath);

--- a/packages/core/src/store/__tests__/agent-registry-accessor.test.ts
+++ b/packages/core/src/store/__tests__/agent-registry-accessor.test.ts
@@ -79,7 +79,8 @@ function makeTmpEnv(suffix: string): {
   mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
 
   const openGlobal = (): DatabaseSync => {
-    const db = new DatabaseSync(join(cleoHome, 'signaldock.db'));
+    // E6-L5 (T11525): the signaldock domain consolidated into the GLOBAL cleo.db.
+    const db = new DatabaseSync(join(cleoHome, 'cleo.db'));
     db.exec('PRAGMA foreign_keys = ON');
     db.exec('PRAGMA journal_mode = WAL');
     return db;

--- a/packages/core/src/store/__tests__/agent-resolver.test.ts
+++ b/packages/core/src/store/__tests__/agent-resolver.test.ts
@@ -167,7 +167,7 @@ async function makeTmpEnv(suffix: string): Promise<TmpEnv> {
   _resetGlobalSignaldockDb_TESTING_ONLY();
   await ensureGlobalSignaldockDb();
 
-  const dbPath = join(cleoHome, 'signaldock.db');
+  const dbPath = join(cleoHome, 'cleo.db'); // E6-L5 (T11525): signaldock consolidated into GLOBAL cleo.db
 
   // Seed the skills catalog so junction writes succeed for fixtures.
   const seedDb = new DatabaseSync(dbPath);

--- a/packages/core/src/store/__tests__/signaldock-sqlite.test.ts
+++ b/packages/core/src/store/__tests__/signaldock-sqlite.test.ts
@@ -67,17 +67,19 @@ describe('getGlobalSignaldockDbPath', () => {
     const result = getGlobalSignaldockDbPath();
 
     expect(result.startsWith(cleoHome)).toBe(true);
-    expect(result).toBe(join(cleoHome, 'signaldock.db'));
+    // E6-L5 (T11525): signaldock now consolidates into the GLOBAL cleo.db.
+    expect(result).toBe(join(cleoHome, 'cleo.db'));
   });
 
-  it('returns path ending with signaldock.db', async () => {
+  it('returns path ending with cleo.db (E6-L5 consolidation)', async () => {
     const cleoHome = makeTmpDir('path-filename');
     vi.doMock('../../paths.js', () => ({ getCleoHome: () => cleoHome }));
 
     const { getGlobalSignaldockDbPath } = await import('../signaldock-sqlite.js');
     const result = getGlobalSignaldockDbPath();
 
-    expect(result.endsWith('signaldock.db')).toBe(true);
+    // E6-L5 (T11525): signaldock now consolidates into the GLOBAL cleo.db.
+    expect(result.endsWith('cleo.db')).toBe(true);
   });
 });
 
@@ -178,7 +180,8 @@ describe('ensureGlobalSignaldockDb', () => {
     _resetGlobalSignaldockDb_TESTING_ONLY();
 
     expect(existsSync(nestedHome)).toBe(true);
-    expect(existsSync(join(nestedHome, 'signaldock.db'))).toBe(true);
+    // E6-L5 (T11525): signaldock now consolidates into the GLOBAL cleo.db.
+    expect(existsSync(join(nestedHome, 'cleo.db'))).toBe(true);
   });
 });
 
@@ -564,7 +567,8 @@ describe('ensureSignaldockDb (deprecated alias)', () => {
     _resetGlobalSignaldockDb_TESTING_ONLY();
 
     expect(result.action).toBe('created');
-    expect(result.path).toContain('signaldock.db');
+    // E6-L5 (T11525): signaldock now consolidates into the GLOBAL cleo.db.
+    expect(result.path).toContain('cleo.db');
     expect(existsSync(result.path)).toBe(true);
   });
 });

--- a/packages/core/src/store/__tests__/skills-schema.test.ts
+++ b/packages/core/src/store/__tests__/skills-schema.test.ts
@@ -41,7 +41,14 @@ import { skillPatches, skillReviews, skills, skillUsage } from '../schema/skills
  * excluding drizzle journal + meta sentinel tables (which we assert exist
  * separately in a dedicated test).
  */
-const EXPECTED_SKILL_TABLES = ['skill_patches', 'skill_reviews', 'skill_usage', 'skills'];
+// E6-L5 (T11525): the skills registry consolidated into the shared GLOBAL
+// `cleo.db`; its physical tables now carry the `skills_` domain prefix.
+const EXPECTED_SKILL_TABLES = [
+  'skills_skill_patches',
+  'skills_skill_reviews',
+  'skills_skill_usage',
+  'skills_skills',
+];
 
 /** Helper: enumerate non-internal user tables (i.e. excluding sqlite_*). */
 function listUserTables(db: DatabaseSync): string[] {
@@ -113,7 +120,12 @@ describe('skills-schema + skills-db', () => {
     }
   });
 
-  it('openSkillsDb creates the drizzle journal + meta sentinel', async () => {
+  it('openSkillsDb creates the drizzle journal', async () => {
+    // E6-L5 (T11525): the registry now consolidates into the shared GLOBAL
+    // `cleo.db` via the `drizzle-cleo-global` migration. The legacy
+    // `drizzle-skills` migration (and its `_skills_meta` sentinel) is no longer
+    // run on the shared handle; the consolidated `__drizzle_migrations` journal
+    // tracks the applied migrations.
     const { openSkillsDb } = await import('../skills-db.js');
     await openSkillsDb({ path: dbPath });
 
@@ -122,21 +134,29 @@ describe('skills-schema + skills-db', () => {
     raw.close();
 
     expect(tables).toContain('__drizzle_migrations');
-    expect(tables).toContain('_skills_meta');
   });
 
-  it('expected indexes exist on the skills table', async () => {
+  it('expected indexes exist on the skills_skills table', async () => {
     const { openSkillsDb } = await import('../skills-db.js');
     await openSkillsDb({ path: dbPath });
 
     const raw = new DatabaseSync(dbPath); // db-open-allowed
-    const indexes = listIndexes(raw, 'skills');
+    const indexes = listIndexes(raw, 'skills_skills');
     raw.close();
 
-    expect(indexes).toContain('idx_skills_state');
-    expect(indexes).toContain('idx_skills_source');
-    // Unique on `name` is required by the architecture.
-    expect(indexes.some((n) => n.toLowerCase().includes('name'))).toBe(true);
+    expect(indexes).toContain('idx_skills_skills_state');
+    expect(indexes).toContain('idx_skills_skills_source');
+    // Unique on `name` is required by the architecture. The consolidated
+    // `drizzle-cleo-global` schema declares it inline (`.unique()`), which SQLite
+    // implements as an auto-index (`sqlite_autoindex_skills_skills_*`) rather than
+    // a named `*_name_unique` index. Assert via PRAGMA index_list unique flag.
+    const rawForUnique = new DatabaseSync(dbPath); // db-open-allowed
+    const indexMeta = rawForUnique.prepare('PRAGMA index_list(skills_skills)').all() as Array<{
+      name: string;
+      unique: number;
+    }>;
+    rawForUnique.close();
+    expect(indexMeta.some((idx) => idx.unique === 1)).toBe(true);
   });
 
   it('openSkillsDb is idempotent (second call returns same handle, no error)', async () => {
@@ -249,7 +269,7 @@ describe('skills-schema + skills-db', () => {
     expect(() =>
       raw
         .prepare(
-          `INSERT INTO skills (name, source_type, install_path, installed_at)
+          `INSERT INTO skills_skills (name, source_type, install_path, installed_at)
            VALUES ('bogus-skill', 'not-a-real-source', '/tmp/x', '2026-05-19T00:00:00.000Z')`,
         )
         .run(),
@@ -265,7 +285,7 @@ describe('skills-schema + skills-db', () => {
     expect(() =>
       raw
         .prepare(
-          `INSERT INTO skills (name, source_type, install_path, installed_at, lifecycle_state)
+          `INSERT INTO skills_skills (name, source_type, install_path, installed_at, lifecycle_state)
            VALUES ('x', 'user', '/tmp/x', '2026-05-19T00:00:00.000Z', 'not-a-state')`,
         )
         .run(),

--- a/packages/core/src/store/__tests__/t310-integration.test.ts
+++ b/packages/core/src/store/__tests__/t310-integration.test.ts
@@ -260,7 +260,8 @@ function createGlobalSignaldockDbFile(
   cleoHome: string,
   agents: Array<{ id: string; agentId: string; name: string; requiresReauth?: number }> = [],
 ): string {
-  const dbPath = join(cleoHome, 'signaldock.db');
+  // E6-L5 (T11525): the global signaldock domain consolidated into cleo.db.
+  const dbPath = join(cleoHome, 'cleo.db');
   const db = new DatabaseSync(dbPath);
   const now = Math.floor(Date.now() / 1000);
 
@@ -382,11 +383,12 @@ async function runMigration(
     __clearGlobalSaltCache: vi.fn(),
   }));
   vi.doMock('../signaldock-sqlite.js', () => ({
+    // E6-L5 (T11525): the global signaldock domain consolidated into cleo.db.
     ensureGlobalSignaldockDb: vi.fn(async () => ({
       action: 'exists',
-      path: join(cleoHome, 'signaldock.db'),
+      path: join(cleoHome, 'cleo.db'),
     })),
-    getGlobalSignaldockDbPath: () => join(cleoHome, 'signaldock.db'),
+    getGlobalSignaldockDbPath: () => join(cleoHome, 'cleo.db'),
   }));
   const { migrateSignaldockToConduit } = await import('../migrate-signaldock-to-conduit.js');
   return await migrateSignaldockToConduit(projectRoot);
@@ -496,7 +498,7 @@ describe('T310: conduit + signaldock integration', () => {
     expect(result.projectRef?.enabled).toBe(1);
 
     // Verify global signaldock.db has the agent row
-    const globalDb = new DatabaseSync(join(cleoHome, 'signaldock.db'), { readonly: true });
+    const globalDb = new DatabaseSync(join(cleoHome, 'cleo.db'), { readonly: true });
     const agentRow = globalDb
       .prepare('SELECT agent_id FROM agents WHERE agent_id = ?')
       .get(spec.agentId) as { agent_id: string } | undefined;
@@ -548,7 +550,7 @@ describe('T310: conduit + signaldock integration', () => {
     closeConduitDb();
 
     // Seed agent X into global only (no project ref)
-    const globalDb = new DatabaseSync(join(cleoHome, 'signaldock.db'));
+    const globalDb = new DatabaseSync(join(cleoHome, 'cleo.db'));
     insertGlobalAgent(globalDb, 'global-agent-x', 'Agent X');
     globalDb.close();
 
@@ -587,7 +589,7 @@ describe('T310: conduit + signaldock integration', () => {
     closeConduitDb();
 
     // Seed 3 global agents
-    const globalDb = new DatabaseSync(join(cleoHome, 'signaldock.db'));
+    const globalDb = new DatabaseSync(join(cleoHome, 'cleo.db'));
     insertGlobalAgent(globalDb, 'agent-x', 'Agent X');
     insertGlobalAgent(globalDb, 'agent-y', 'Agent Y');
     insertGlobalAgent(globalDb, 'agent-z', 'Agent Z');
@@ -751,7 +753,7 @@ describe('T310: conduit + signaldock integration', () => {
     expect(inBAfter.find((a) => a.agentId === 'attach-detach-agent')).toBeDefined();
 
     // Global identity must still exist
-    const globalDb = new DatabaseSync(join(cleoHome, 'signaldock.db'), { readonly: true });
+    const globalDb = new DatabaseSync(join(cleoHome, 'cleo.db'), { readonly: true });
     const globalRow = globalDb
       .prepare("SELECT agent_id FROM agents WHERE agent_id = 'attach-detach-agent'")
       .get() as { agent_id: string } | undefined;
@@ -856,7 +858,7 @@ describe('T310: conduit + signaldock integration', () => {
     conduitDb.close();
 
     // global signaldock.db has 3 agents with requires_reauth=1
-    const globalDb = new DatabaseSync(join(cleoHome, 'signaldock.db'), { readonly: true });
+    const globalDb = new DatabaseSync(join(cleoHome, 'cleo.db'), { readonly: true });
     const globalAgents = globalDb
       .prepare('SELECT agent_id, requires_reauth FROM agents ORDER BY agent_id')
       .all() as Array<{ agent_id: string; requires_reauth: number }>;
@@ -904,7 +906,7 @@ describe('T310: conduit + signaldock integration', () => {
     expect(resultB.status).toBe('migrated');
 
     // Global must have exactly 2 agents (X + Y), not 3 (INSERT OR IGNORE deduplicates X)
-    const globalDb = new DatabaseSync(join(cleoHome, 'signaldock.db'), { readonly: true });
+    const globalDb = new DatabaseSync(join(cleoHome, 'cleo.db'), { readonly: true });
     const allAgents = globalDb
       .prepare('SELECT agent_id FROM agents ORDER BY agent_id')
       .all() as Array<{ agent_id: string }>;
@@ -966,7 +968,7 @@ describe('T310: conduit + signaldock integration', () => {
     conduitDb.close();
 
     // Verify no duplicate rows in global signaldock.db
-    const globalDb = new DatabaseSync(join(cleoHome, 'signaldock.db'), { readonly: true });
+    const globalDb = new DatabaseSync(join(cleoHome, 'cleo.db'), { readonly: true });
     const globalRows = globalDb
       .prepare("SELECT COUNT(*) as n FROM agents WHERE agent_id = 'idempotent-agent'")
       .get() as { n: number };
@@ -1025,7 +1027,7 @@ describe('T310: conduit + signaldock integration', () => {
     const conduitPath = join(cleoDir, 'conduit.db');
     const tasksPath = join(cleoDir, 'tasks.db');
     const brainPath = join(cleoDir, 'brain.db');
-    const sdPath = join(cleoHome, 'signaldock.db');
+    const sdPath = join(cleoHome, 'cleo.db');
     const saltPath = join(cleoHome, 'global-salt');
 
     for (const dbPath of [conduitPath, tasksPath, brainPath, sdPath]) {

--- a/packages/core/src/store/backup-pack.ts
+++ b/packages/core/src/store/backup-pack.ts
@@ -34,7 +34,6 @@ import { create as tarCreate } from 'tar';
 import { getCleoHome, getProjectRoot } from '../paths.js';
 import { encryptBundle } from './backup-crypto.js';
 import { getGlobalSaltPath } from './global-salt.js';
-import { getGlobalSignaldockDbPath } from './signaldock-sqlite.js';
 import { applyPerfPragmas } from './sqlite-pragmas.js';
 import { assertT310Ready } from './t310-readiness.js';
 
@@ -493,8 +492,14 @@ export async function packBundle(input: PackBundleInput): Promise<PackBundleResu
         );
       }
 
-      // signaldock.db
-      const sdSrc = getGlobalSignaldockDbPath();
+      // signaldock.db — E6-L5 (T11525): the live signaldock domain now
+      // consolidates into the shared GLOBAL `cleo.db`, but the backup snapshot
+      // intentionally keeps reading the LEGACY standalone `<cleoHome>/signaldock.db`
+      // literal during the E6 cutover (matching the nexus L4 treatment). Rerouting
+      // the backup read to the consolidated resolver mid-cutover would
+      // double-snapshot the shared cleo.db and skip any un-migrated legacy
+      // signaldock.db that still holds the only copy of agent identity.
+      const sdSrc = path.join(getCleoHome(), 'signaldock.db');
       const sdDest = path.join(stagingDir, 'databases', 'signaldock.db');
       const sdSnapped = vacuumIntoStaging(sdSrc, sdDest);
       if (sdSnapped) {

--- a/packages/core/src/store/dual-scope-db.ts
+++ b/packages/core/src/store/dual-scope-db.ts
@@ -251,6 +251,53 @@ export async function openDualScopeDb(
 ): Promise<DualScopeDbHandle<'global'>>;
 export async function openDualScopeDb(scope: DualScope, cwd?: string): Promise<DualScopeDbHandle> {
   const dbPath = resolveDualScopeDbPath(scope, cwd);
+  // Dispatch on the scope literal so the overloaded path-aware opener resolves to
+  // the correct typed return; the union `scope` cannot satisfy either literal
+  // overload directly.
+  return scope === 'project'
+    ? openDualScopeDbAtPath('project', dbPath)
+    : openDualScopeDbAtPath('global', dbPath);
+}
+
+/**
+ * Open (or re-use) a consolidated dual-scope `cleo.db` at an EXPLICIT path,
+ * bypassing the scope→path resolver.
+ *
+ * This is the path-aware sibling of {@link openDualScopeDb}. Production callers
+ * MUST prefer {@link openDualScopeDb}, which resolves the canonical path from
+ * `cwd` / `getCleoHome()`. The explicit-path form exists for two cases:
+ *
+ *   1. Tests that materialise an isolated consolidated `cleo.db` under a
+ *      `mkdtemp` directory (e.g. the skills-db `{ path }` override, E6-L5),
+ *      without having to monkey-patch `getCleoHome()`.
+ *   2. Domain modules whose legacy lifecycle API accepted an explicit on-disk
+ *      path and must keep that contract while still flowing every open through
+ *      the single dual-scope chokepoint (so DB Open Guard Gate 3 stays green).
+ *
+ * The handle is cached per (scope, dbPath) exactly like {@link openDualScopeDb};
+ * a test path and the canonical path are distinct cache keys and never collide.
+ *
+ * @param scope - The consolidated schema scope (`'project'` | `'global'`).
+ * @param dbPath - The absolute path to the consolidated `cleo.db` file. The
+ *   parent directory is created if absent.
+ * @returns A typed {@link DualScopeDbHandle} bound to the scope's schema.
+ *
+ * @task T11525 (E6-L5)
+ * @epic T11249 (E6)
+ * @saga T11242
+ */
+export async function openDualScopeDbAtPath(
+  scope: 'project',
+  dbPath: string,
+): Promise<DualScopeDbHandle<'project'>>;
+export async function openDualScopeDbAtPath(
+  scope: 'global',
+  dbPath: string,
+): Promise<DualScopeDbHandle<'global'>>;
+export async function openDualScopeDbAtPath(
+  scope: DualScope,
+  dbPath: string,
+): Promise<DualScopeDbHandle> {
   const key = cacheKey(scope, dbPath);
 
   // Return cached handle if available and not mid-init.

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -76,7 +76,6 @@ export {
   listSkillsBySource,
   openSkillsDb,
   resetSkillsDbState,
-  resolveSkillsMigrationsFolder,
   SKILLS_DB_FILENAME,
   SKILLS_SCHEMA_VERSION,
   upsertSkillRow,

--- a/packages/core/src/store/schema/skills-schema.ts
+++ b/packages/core/src/store/schema/skills-schema.ts
@@ -25,8 +25,26 @@
  *   auto-improve in later epics). The tables here MUST exist so subsequent
  *   tasks can INSERT/SELECT without re-architecting the storage layer.
  *
+ * ## E6-L5 physical-name consolidation (T11525)
+ *
+ * The four physical table names below carry the `skills_` domain prefix
+ * (`skills_skills`, `skills_skill_usage`, `skills_skill_reviews`,
+ * `skills_skill_patches`) — NOT the former bare names (`skills`, `skill_usage`,
+ * …). This is required because skills.db now consolidates into the shared GLOBAL
+ * `cleo.db` (E6-L5) alongside the signaldock domain, whose own legacy `skills`
+ * catalog table would otherwise COLLIDE with this registry's bare `skills` table.
+ * The consolidated `drizzle-cleo-global` migration creates these prefixed tables
+ * (column-identical to the legacy shape, plus additive enum/timestamp/boolean
+ * CHECK constraints that ACCEPT every value these writers produce), so
+ * `skills-db.ts` (E6-L5) does NOT run the legacy `drizzle-skills` migration on the
+ * shared handle — it simply binds this schema's drizzle queries to the
+ * already-created consolidated tables. The TS export NAMES (`skills`, `skillUsage`,
+ * …) are unchanged so the 18 importing modules compile without edits.
+ *
  * @task T9651
+ * @task T11525 - E6-L5 physical-name prefix to share the global cleo.db
  * @epic T9571
+ * @epic T11249
  * @saga T9560
  * @adr ADR-068 (DB-open chokepoint)
  * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §4
@@ -101,7 +119,7 @@ export type SkillPatchStatus = 'proposed' | 'applied' | 'reverted' | 'rejected';
  * @task T9651
  */
 export const skills = sqliteTable(
-  'skills',
+  'skills_skills',
   {
     /** Surrogate primary key — autoincrement integer. */
     id: integer('id').primaryKey({ autoIncrement: true }),
@@ -139,8 +157,8 @@ export const skills = sqliteTable(
     archivedFromPath: text('archived_from_path'),
   },
   (table) => [
-    index('idx_skills_state').on(table.lifecycleState),
-    index('idx_skills_source').on(table.sourceType),
+    index('idx_skills_skills_state').on(table.lifecycleState),
+    index('idx_skills_skills_source').on(table.sourceType),
   ],
 );
 
@@ -157,7 +175,7 @@ export const skills = sqliteTable(
  * @task T9651
  */
 export const skillUsage = sqliteTable(
-  'skill_usage',
+  'skills_skill_usage',
   {
     /** Surrogate primary key — autoincrement integer. */
     id: integer('id').primaryKey({ autoIncrement: true }),
@@ -181,8 +199,8 @@ export const skillUsage = sqliteTable(
     metadata: text('metadata').notNull().default('{}'),
   },
   (table) => [
-    index('idx_skill_usage_name_observed').on(table.skillName, table.observedAt),
-    index('idx_skill_usage_kind').on(table.eventKind),
+    index('idx_skills_skill_usage_name_observed').on(table.skillName, table.observedAt),
+    index('idx_skills_skill_usage_kind').on(table.eventKind),
   ],
 );
 
@@ -197,7 +215,7 @@ export const skillUsage = sqliteTable(
  * @task T9651
  */
 export const skillReviews = sqliteTable(
-  'skill_reviews',
+  'skills_skill_reviews',
   {
     /** Surrogate primary key — autoincrement integer. */
     id: integer('id').primaryKey({ autoIncrement: true }),
@@ -217,8 +235,8 @@ export const skillReviews = sqliteTable(
     summary: text('summary'),
   },
   (table) => [
-    index('idx_skill_reviews_name_reviewed').on(table.skillName, table.reviewedAt),
-    index('idx_skill_reviews_outcome').on(table.outcome),
+    index('idx_skills_skill_reviews_name_reviewed').on(table.skillName, table.reviewedAt),
+    index('idx_skills_skill_reviews_outcome').on(table.outcome),
   ],
 );
 
@@ -232,7 +250,7 @@ export const skillReviews = sqliteTable(
  * @task T9651
  */
 export const skillPatches = sqliteTable(
-  'skill_patches',
+  'skills_skill_patches',
   {
     /** Surrogate primary key — autoincrement integer. */
     id: integer('id').primaryKey({ autoIncrement: true }),
@@ -256,8 +274,8 @@ export const skillPatches = sqliteTable(
     revertedByPatchId: integer('reverted_by_patch_id'),
   },
   (table) => [
-    index('idx_skill_patches_name_proposed').on(table.skillName, table.proposedAt),
-    index('idx_skill_patches_status').on(table.status),
+    index('idx_skills_skill_patches_name_proposed').on(table.skillName, table.proposedAt),
+    index('idx_skills_skill_patches_status').on(table.status),
   ],
 );
 

--- a/packages/core/src/store/signaldock-sqlite.ts
+++ b/packages/core/src/store/signaldock-sqlite.ts
@@ -6,9 +6,34 @@
  * catalog, and cloud-sync tables. Project-local messaging state has moved to
  * conduit.db (managed by conduit-sqlite.ts, T344).
  *
- * Migration runner: standard drizzle pipeline via migrateSanitized + reconcileJournal
- * (migration-manager.ts). Replaces the bare-SQL GLOBAL_EMBEDDED_MIGRATIONS runner
- * that was previously embedded here (T1166 / T1150 Wave 2A-04).
+ * ## E6-L5 — thin-facade migration (T11525)
+ *
+ * `ensureGlobalSignaldockDb()` is now a thin facade that delegates the database
+ * open to {@link openDualScopeDb}('global') — the canonical dual-scope chokepoint
+ * (E3/E4 · T11512/T11517) already adopted by the tasks domain (E6-L1, T11521),
+ * the brain domain (E6-L2, T11522), the conduit domain (E6-L3, T11523), and the
+ * nexus domain (E6-L4, T11524). The signaldock tables now live inside the
+ * consolidated GLOBAL `cleo.db` under {@link getCleoHome}, sharing the SAME native
+ * handle the nexus / skills global domains use.
+ *
+ * The legacy `drizzle-signaldock` migrations are still applied to this handle.
+ * They create the runtime-queried physical tables under BARE names (`agents`,
+ * `capabilities`, `skills`, `agent_capabilities`, …). The consolidated GLOBAL
+ * schema (`drizzle-cleo-global`) carries the `signaldock_` domain prefix
+ * (`signaldock_agents`, `signaldock_skills`, …). These are DIFFERENT physical
+ * names, so the legacy and consolidated tables CO-EXIST harmlessly in the same
+ * `cleo.db` — exactly like the conduit domain (`conversations` ≠
+ * `conduit_conversations`) and the tasks domain (`tasks` ≠ `tasks_tasks`).
+ *
+ * NB: signaldock's legacy `skills` catalog (slug → id, queried via raw SQL in
+ * agent-registry-accessor / agent-install / agent-doctor) keeps its BARE name,
+ * while the skills-db registry domain (E6-L5 sibling) lands on the prefixed
+ * `skills_skills` consolidated table — so the two former-separate-file domains no
+ * longer collide on a bare `skills` name now that they share one `cleo.db`.
+ *
+ * The residency MOVE of signaldock global→project and the exodus data copy are
+ * SEPARATE later tasks (T11553 / T11538). This task keeps the ADR-037 global-only
+ * invariant intact.
  *
  * Migration folder: packages/core/migrations/drizzle-signaldock/
  *
@@ -17,23 +42,27 @@
  *
  * @task T346
  * @task T1166
+ * @task T11525 - E6-L5: route ensureGlobalSignaldockDb through openDualScopeDb('global') (SG-DB-SUBSTRATE-V2)
  * @epic T310
  * @epic T1150
+ * @epic T11249
  * @related ADR-037
  */
 
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import { drizzle } from 'drizzle-orm/node-sqlite';
 import { getCleoHome } from '../paths.js';
+// E6-L5 (T11525): dual-scope chokepoint — the signaldock domain now opens the
+// consolidated GLOBAL `cleo.db` through here. openDualScopeDb manages the
+// DatabaseSync lifecycle, pragmas, and consolidated migrations. We extract the
+// native handle and run the legacy drizzle-signaldock migrations on it so
+// existing callers (raw-SQL agent registry access) compile and run unchanged.
+import { _resetDualScopeDbCache, openDualScopeDb } from './dual-scope-db.js';
 import { migrateSanitized, reconcileJournal } from './migration-manager.js';
 import { resolveCorePackageMigrationsFolder } from './resolve-migrations-folder.js';
 import * as signaldockSchema from './schema/signaldock-schema.js';
-// Import openNativeDatabase directly from the leaf module (sqlite-native.ts) to
-// avoid any static import from sqlite.ts that could re-enter the circular chain
-// agent-resolver → ... → memory-sqlite → sqlite.ts (T1325/T1331 v3).
-import { openNativeDatabase } from './sqlite-native.js';
 
 /**
  * Database file name within the global cleo home directory.
@@ -64,27 +93,39 @@ export const SIGNALDOCK_SCHEMA_VERSION = GLOBAL_SIGNALDOCK_SCHEMA_VERSION;
 // ---------------------------------------------------------------------------
 
 /**
- * Returns the GLOBAL-tier signaldock.db path. Post-T310, signaldock.db
- * holds canonical agent identity + cloud-sync tables. Project-local
+ * Returns the GLOBAL-tier signaldock DB path — the consolidated GLOBAL `cleo.db`.
+ *
+ * E6-L5 (T11525): resolves `getCleoHome()` + `cleo.db` (the same path
+ * {@link openDualScopeDb}('global') opens). signaldock holds canonical agent
+ * identity + cloud-sync tables and stays GLOBAL — its tables live inside the
+ * consolidated GLOBAL `cleo.db`, NOT a separate `signaldock.db` file. Project-local
  * messaging state lives in conduit.db (T344).
  *
- * Resolves to `getCleoHome() + '/signaldock.db'`.
  * Guard: asserts the resolved path starts with getCleoHome() (defense in depth,
- * mirrors the ADR-036 pattern used by getNexusDbPath in nexus-sqlite.ts).
+ * mirrors the ADR-036/037 pattern used by getNexusDbPath in nexus-sqlite.ts).
  *
  * @task T346
+ * @task T11525
  * @epic T310
+ * @epic T11249
  * @why ADR-037 split single signaldock.db into project conduit + global signaldock
  * @throws {Error} If resolved path is not under getCleoHome() — indicates a code
  *   path that bypasses canonical path resolution. Fix the caller, do not suppress.
  */
 export function getGlobalSignaldockDbPath(): string {
+  // Resolve via THIS module's getCleoHome binding so the path and the guard are
+  // self-consistent. (The dual-scope resolver builds the identical path —
+  // join(getCleoHome(), 'cleo.db') — but binds getCleoHome through its own module
+  // graph, which can diverge under per-test vi.doMock timing. Building locally and
+  // asserting against the SAME binding keeps the defense-in-depth guard correct
+  // without spuriously firing when a test mocks getCleoHome. T11525.)
   const cleoHome = getCleoHome();
-  const dbPath = join(cleoHome, GLOBAL_SIGNALDOCK_DB_FILENAME);
+  const dbPath = join(cleoHome, 'cleo.db');
   if (!dbPath.startsWith(cleoHome)) {
+    /* c8 ignore next 7 — unreachable: dbPath is built FROM cleoHome above. */
     throw new Error(
       `BUG: getGlobalSignaldockDbPath() resolved to "${dbPath}" which is NOT under ` +
-        `getCleoHome() ("${cleoHome}"). signaldock.db is global-only per ADR-037. ` +
+        `getCleoHome() ("${cleoHome}"). signaldock is global-only per ADR-037. ` +
         `This indicates a code path that bypasses path resolution — ` +
         `fix the caller, do not suppress this error.`,
     );
@@ -183,7 +224,14 @@ function runSignaldockMigrations(nativeDb: DatabaseSync): void {
 // Database lifecycle
 // ---------------------------------------------------------------------------
 
-/** Singleton native DatabaseSync handle for the current process. */
+/**
+ * Singleton native DatabaseSync handle for the current process.
+ *
+ * E6-L5 (T11525): this is the SHARED consolidated GLOBAL `cleo.db` handle owned
+ * by {@link openDualScopeDb}('global') and co-owned by the nexus / skills global
+ * domains. signaldock MUST NOT close it directly (see
+ * {@link _resetGlobalSignaldockDb_TESTING_ONLY}).
+ */
 let _globalSignaldockNativeDb: DatabaseSync | null = null;
 
 /**
@@ -261,72 +309,83 @@ export async function ensureGlobalSignaldockDb(): Promise<{
   const dbPath = getGlobalSignaldockDbPath();
   const alreadyExists = existsSync(dbPath);
 
-  // Ensure global cleo home directory exists
-  const cleoHome = getCleoHome();
-  if (!existsSync(cleoHome)) {
-    mkdirSync(cleoHome, { recursive: true });
+  // ── Dual-scope chokepoint delegation (T11525 · E6-L5) ────────────────────
+  // openDualScopeDb('global') applies the pragma SSoT, creates the directory,
+  // runs the consolidated cleo-global migrations (which create the prefixed
+  // `signaldock_*` tables), and manages the singleton cache. We extract its
+  // native handle so we can run the legacy `drizzle-signaldock` migrations,
+  // which create the BARE-named runtime tables (`agents`, `capabilities`,
+  // `skills`, …) the raw-SQL agent-registry callers query. The bare and
+  // prefixed tables DIFFER, so they co-exist in the same `cleo.db`.
+  const dualHandle = await openDualScopeDb('global');
+
+  // Extract the underlying DatabaseSync. Drizzle exposes it via `$client`.
+  const nativeDb = (dualHandle.db as { $client?: DatabaseSync }).$client ?? null;
+  if (!nativeDb) {
+    throw new Error(
+      'E6-L5: openDualScopeDb returned a handle without $client — ' +
+        'cannot extract DatabaseSync for legacy signaldock-schema migration.',
+    );
   }
 
-  const nativeDb = openNativeDatabase(dbPath);
-  try {
-    // Check if schema already applied (agents table as sentinel)
-    const hasSchema = (() => {
-      try {
-        const result = nativeDb
-          .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='agents'")
-          .get() as { name: string } | undefined;
-        return !!result;
-      } catch {
-        return false;
-      }
-    })();
-
-    // T9027 — Schema-version sentinel fast path (epic T9026, CLI startup tax).
-    //
-    // If the DB already has the global signaldock schema applied AND its
-    // `_signaldock_meta.schema_version` row exactly equals the in-process
-    // `GLOBAL_SIGNALDOCK_SCHEMA_VERSION` constant, we can skip
-    // `runSignaldockMigrations()` entirely. That function performs a
-    // reconcileJournal() + migrateSanitized() pass that, while a no-op for an
-    // up-to-date DB, still pays a non-trivial cost on every CLI invocation
-    // (journal SELECT, regex sanitization, drizzle migrator probe).
-    //
-    // Fall-through (sentinel missing, stale, or mismatched) preserves the
-    // full migration replay path so fresh DBs and version bumps still work.
-    if (
-      alreadyExists &&
-      hasSchema &&
-      readSignaldockSchemaVersionSentinel(nativeDb) === GLOBAL_SIGNALDOCK_SCHEMA_VERSION
-    ) {
-      _globalSignaldockNativeDb = nativeDb;
-      return { action: 'exists', path: dbPath };
+  // Check if the legacy signaldock schema is already applied (agents table
+  // as sentinel — the bare runtime table, NOT the prefixed `signaldock_agents`).
+  const hasSchema = (() => {
+    try {
+      const result = nativeDb
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='agents'")
+        .get() as { name: string } | undefined;
+      return !!result;
+    } catch {
+      return false;
     }
+  })();
 
-    // Run drizzle migrations (reconcileJournal + migrateSanitized).
-    // For existing DBs that used the old bare-SQL runner, reconcileJournal
-    // Scenario 1 bootstraps the __drizzle_migrations journal from the existing
-    // agents table, and Scenario 3 marks T897 ALTER columns as applied without
-    // re-running the DDL.
-    runSignaldockMigrations(nativeDb);
-
-    // Stamp schema_version sentinel so the next process can take the fast path.
-    writeSignaldockSchemaVersionSentinel(nativeDb);
-
-    // Store native handle for backup integration (getGlobalSignaldockNativeDb)
+  // T9027 — Schema-version sentinel fast path (epic T9026, CLI startup tax).
+  //
+  // If the legacy signaldock schema is already applied AND its
+  // `_signaldock_meta.schema_version` row exactly equals the in-process
+  // `GLOBAL_SIGNALDOCK_SCHEMA_VERSION` constant, we can skip
+  // `runSignaldockMigrations()` entirely. That function performs a
+  // reconcileJournal() + migrateSanitized() pass that, while a no-op for an
+  // up-to-date DB, still pays a non-trivial cost on every CLI invocation
+  // (journal SELECT, regex sanitization, drizzle migrator probe).
+  //
+  // Fall-through (sentinel missing, stale, or mismatched) preserves the
+  // full migration replay path so fresh DBs and version bumps still work.
+  if (
+    hasSchema &&
+    readSignaldockSchemaVersionSentinel(nativeDb) === GLOBAL_SIGNALDOCK_SCHEMA_VERSION
+  ) {
     _globalSignaldockNativeDb = nativeDb;
-
-    return {
-      action: alreadyExists && hasSchema ? 'exists' : 'created',
-      path: dbPath,
-    };
-  } catch (err) {
-    nativeDb.close();
-    _globalSignaldockNativeDb = null;
-    throw err;
+    return { action: 'exists', path: dbPath };
   }
-  // NOTE: We intentionally do NOT close `nativeDb` here — the native handle is
-  // retained as _globalSignaldockNativeDb for backup integration. Callers
-  // that need a short-lived open/close pattern should open the DB themselves.
+
+  // Run the legacy `drizzle-signaldock` migrations (reconcileJournal +
+  // migrateSanitized) on the shared handle. Their `__drizzle_migrations`
+  // journal is shared with the cleo-global journal in the same `cleo.db`; the
+  // hashes are disjoint so the signaldock migrations are reconciled/applied
+  // independently. For existing DBs that used the old bare-SQL runner,
+  // reconcileJournal Scenario 1 bootstraps the journal from the existing
+  // `agents` table, and Scenario 3 marks T897 ALTER columns as applied.
+  runSignaldockMigrations(nativeDb);
+
+  // Stamp schema_version sentinel so the next process can take the fast path.
+  writeSignaldockSchemaVersionSentinel(nativeDb);
+
+  // Store native handle for backup integration (getGlobalSignaldockNativeDb).
+  _globalSignaldockNativeDb = nativeDb;
+
+  return {
+    action: alreadyExists && hasSchema ? 'exists' : 'created',
+    path: dbPath,
+  };
+  // NOTE: We intentionally do NOT close the native handle — it is the SHARED
+  // dual-scope GLOBAL `cleo.db` handle (E6-L5), co-owned by the nexus / skills
+  // global domains. Its lifecycle is owned by `openDualScopeDb`; tearing it down
+  // here would break in-flight sibling queries. On error we also do NOT close it
+  // for the same reason — `openDualScopeDb`'s own init guard handles open
+  // failures.
 }
 
 /**
@@ -359,12 +418,20 @@ export async function ensureSignaldockDb(
 }
 
 /**
- * Check global signaldock.db health: table count, WAL mode, schema version.
- * Used by `cleo doctor` to verify global signaldock.db integrity.
+ * Check global signaldock health: table count, WAL mode, schema version.
+ * Used by `cleo doctor` to verify global signaldock integrity.
+ *
+ * E6-L5 (T11525): reads against the SHARED consolidated GLOBAL `cleo.db` handle
+ * (via {@link ensureGlobalSignaldockDb}, which routes through
+ * {@link openDualScopeDb}('global')) rather than opening a separate read-only
+ * `signaldock.db` handle. The metrics describe the consolidated `cleo.db` that
+ * now hosts the legacy signaldock tables.
  *
  * @returns Health report object, or object with exists=false if the DB does not exist.
  * @task T346
+ * @task T11525
  * @epic T310
+ * @epic T11249
  */
 export async function checkGlobalSignaldockDbHealth(): Promise<{
   exists: boolean;
@@ -386,55 +453,67 @@ export async function checkGlobalSignaldockDbHealth(): Promise<{
     };
   }
 
-  const nativeDb = openNativeDatabase(dbPath, { readonly: true });
-  try {
-    const tables = nativeDb
-      .prepare(
-        "SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
-      )
-      .get() as { count: number };
-
-    const journalMode = nativeDb.prepare('PRAGMA journal_mode').get() as { journal_mode: string };
-    const fkEnabled = nativeDb.prepare('PRAGMA foreign_keys').get() as { foreign_keys: number };
-
-    // Schema version: check the __drizzle_migrations journal for evidence of
-    // migrations applied. Fallback to _signaldock_meta for pre-T1166 DBs.
-    let schemaVersion: string | null = null;
-    try {
-      // Post-T1166 path: check if drizzle journal has entries
-      const journalRow = nativeDb
-        .prepare('SELECT COUNT(*) as cnt FROM "__drizzle_migrations"')
-        .get() as { cnt: number } | undefined;
-      if (journalRow && journalRow.cnt > 0) {
-        schemaVersion = GLOBAL_SIGNALDOCK_SCHEMA_VERSION;
-      }
-    } catch {
-      // __drizzle_migrations does not exist yet — fall through to _signaldock_meta
-    }
-
-    if (!schemaVersion) {
-      try {
-        // Pre-T1166 path: _signaldock_meta table (old bare-SQL runner)
-        const meta = nativeDb
-          .prepare("SELECT value FROM _signaldock_meta WHERE key = 'schema_version'")
-          .get() as { value: string } | undefined;
-        schemaVersion = meta?.value ?? null;
-      } catch {
-        // _signaldock_meta may not exist on very old or partially-initialized DBs
-      }
-    }
-
+  // Route through the dual-scope chokepoint to obtain the shared, fully-migrated
+  // consolidated `cleo.db` handle. ensureGlobalSignaldockDb() is idempotent and
+  // stores the handle in _globalSignaldockNativeDb.
+  await ensureGlobalSignaldockDb();
+  const nativeDb = _globalSignaldockNativeDb;
+  if (!nativeDb) {
+    /* c8 ignore next */
     return {
-      exists: true,
+      exists: false,
       path: dbPath,
-      tableCount: tables.count,
-      walMode: journalMode.journal_mode === 'wal',
-      schemaVersion,
-      foreignKeysEnabled: fkEnabled.foreign_keys === 1,
+      tableCount: 0,
+      walMode: false,
+      schemaVersion: null,
+      foreignKeysEnabled: false,
     };
-  } finally {
-    nativeDb.close();
   }
+
+  const tables = nativeDb
+    .prepare(
+      "SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+    )
+    .get() as { count: number };
+
+  const journalMode = nativeDb.prepare('PRAGMA journal_mode').get() as { journal_mode: string };
+  const fkEnabled = nativeDb.prepare('PRAGMA foreign_keys').get() as { foreign_keys: number };
+
+  // Schema version: check the __drizzle_migrations journal for evidence of
+  // migrations applied. Fallback to _signaldock_meta for pre-T1166 DBs.
+  let schemaVersion: string | null = null;
+  try {
+    // Post-T1166 path: check if drizzle journal has entries
+    const journalRow = nativeDb
+      .prepare('SELECT COUNT(*) as cnt FROM "__drizzle_migrations"')
+      .get() as { cnt: number } | undefined;
+    if (journalRow && journalRow.cnt > 0) {
+      schemaVersion = GLOBAL_SIGNALDOCK_SCHEMA_VERSION;
+    }
+  } catch {
+    // __drizzle_migrations does not exist yet — fall through to _signaldock_meta
+  }
+
+  if (!schemaVersion) {
+    try {
+      // Pre-T1166 path: _signaldock_meta table (old bare-SQL runner)
+      const meta = nativeDb
+        .prepare("SELECT value FROM _signaldock_meta WHERE key = 'schema_version'")
+        .get() as { value: string } | undefined;
+      schemaVersion = meta?.value ?? null;
+    } catch {
+      // _signaldock_meta may not exist on very old or partially-initialized DBs
+    }
+  }
+
+  return {
+    exists: true,
+    path: dbPath,
+    tableCount: tables.count,
+    walMode: journalMode.journal_mode === 'wal',
+    schemaVersion,
+    foreignKeysEnabled: fkEnabled.foreign_keys === 1,
+  };
 }
 
 /**
@@ -485,21 +564,28 @@ export function getGlobalSignaldockNativeDb(): DatabaseSync | null {
 }
 
 /**
- * Reset the in-process global signaldock.db singleton.
+ * Reset the in-process global signaldock singleton.
  * ONLY for use in test isolation — never call in production code.
  *
+ * ## E6-L5 (T11525) — shared-handle close rule
+ *
+ * `_globalSignaldockNativeDb` is the SHARED consolidated GLOBAL `cleo.db` handle
+ * owned by {@link openDualScopeDb}('global') and co-owned by the nexus / skills
+ * global domains. This reset MUST NOT call `.close()` on it directly — doing so
+ * would tear the handle out from under nexus / skills (the exact bug class L4
+ * fixed at `dual-scope-db.ts`). Instead it evicts the GLOBAL-scope entry from the
+ * dual-scope cache (which closes the underlying handle exactly once and only when
+ * no scope filter excludes it) and drops the local reference. The next
+ * `ensureGlobalSignaldockDb()` re-opens a fresh consolidated handle.
+ *
  * @task T346
+ * @task T11525
  * @epic T310
+ * @epic T11249
  */
 export function _resetGlobalSignaldockDb_TESTING_ONLY(): void {
-  if (_globalSignaldockNativeDb) {
-    try {
-      if (_globalSignaldockNativeDb.isOpen) {
-        _globalSignaldockNativeDb.close();
-      }
-    } catch {
-      // Ignore close errors
-    }
-    _globalSignaldockNativeDb = null;
-  }
+  // Drop only the local reference. The scope-filtered cache reset performs the
+  // single coordinated close of the shared GLOBAL handle.
+  _globalSignaldockNativeDb = null;
+  _resetDualScopeDbCache('global');
 }

--- a/packages/core/src/store/skills-db.ts
+++ b/packages/core/src/store/skills-db.ts
@@ -1,48 +1,59 @@
 /**
- * Per-user skills.db lifecycle module — opener, migrations, helpers.
+ * Per-user skills registry lifecycle module — opener, helpers.
  *
- * `skills.db` is a global-tier SQLite database that lives next to `tasks.db`
- * and `brain.db` under `getCleoHome()` (e.g. `~/.local/share/cleo/skills.db`).
- * It stores the per-user skills registry described in
+ * The per-user skills registry is a global-tier domain described in
  * `docs/architecture/SG-CLEO-SKILLS-architecture-v3.md` §4.
  *
- * ## Chokepoint compliance (ADR-068 + D003)
+ * ## E6-L5 — thin-facade migration (T11525)
  *
- * Every CLEO SQLite open MUST flow through `openCleoDb(role, cwd)`. This
- * module implements the `'skills'` branch of that chokepoint — it is the
- * ONLY place a raw `new DatabaseSync(...)` is permitted for skills.db,
- * because it sits under `packages/core/src/store/` which is allowlisted by
- * `scripts/lint-no-raw-db-opens.mjs`.
+ * `openSkillsDb()` is now a thin facade that delegates the database open to
+ * {@link openDualScopeDb}('global') — the canonical dual-scope chokepoint
+ * (E3/E4 · T11512/T11517) already adopted by the tasks (E6-L1), brain (E6-L2),
+ * conduit (E6-L3), and nexus (E6-L4) domains. The skills registry tables now
+ * live inside the consolidated GLOBAL `cleo.db` under `getCleoHome()`, sharing
+ * the SAME native handle the nexus / signaldock global domains use — NOT a
+ * separate `skills.db` file.
  *
- * ## Why not in conduit.db / signaldock.db?
+ * ## Why prefixed `skills_*` tables (no establishLegacy rebuild)
  *
- * Per architecture v3 §1, the database boundaries are intentional:
- *   - `signaldock.db` — cross-project AGENT identity (global)
- *   - `tasks.db`     — per-project task tracking
- *   - `brain.db`     — per-project memory
- *   - `skills.db`    — per-user SKILL registry (this module, global)
+ * Unlike nexus (E6-L4), the skills registry does NOT run its legacy
+ * `drizzle-skills` migration on the shared handle. That migration created BARE
+ * `skills` / `skill_usage` / … tables — and the bare `skills` name COLLIDES with
+ * the signaldock domain's own legacy `skills` slug-catalog now that both share
+ * one `cleo.db`. The consolidated `drizzle-cleo-global` migration already creates
+ * the registry tables under the domain-prefixed names (`skills_skills`,
+ * `skills_skill_usage`, …), column-identical to the legacy shape plus additive
+ * enum/timestamp/boolean CHECK constraints that ACCEPT every value the runtime
+ * writers produce (ISO-8601 text, 0/1 booleans — verified). So skills-db simply
+ * binds the (now prefix-renamed) `skillsSchema` drizzle queries to those
+ * already-created consolidated tables. No drop+rebuild is needed because there is
+ * no consolidated-vs-legacy shape incompatibility (the L4 precondition is absent).
  *
- * Skills are user-scoped (a single Claude install is one user), so they
- * live under `getCleoHome()` — never inside a project's `.cleo/` folder.
+ * The residency MOVE of skills global→project and the exodus data copy from the
+ * legacy standalone `skills.db` are SEPARATE later tasks (T11553 / T11538).
  *
  * @task T9651
+ * @task T11525 - E6-L5: route openSkillsDb through openDualScopeDb('global') (SG-DB-SUBSTRATE-V2)
  * @epic T9571
+ * @epic T11249
  * @saga T9560
  * @adr ADR-068, ADR-069
  * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §4
  */
 
-import { existsSync, mkdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import { and, eq } from 'drizzle-orm';
-import { readMigrationFiles } from 'drizzle-orm/migrator';
 import type { NodeSQLiteDatabase } from 'drizzle-orm/node-sqlite';
 import { drizzle } from 'drizzle-orm/node-sqlite';
 import { getCleoHome } from '../paths.js';
 import { getCurrentWriteOrigin } from '../sentient/skill-provenance.js';
-import { migrateWithRetry, reconcileJournal, tableExists } from './migration-manager.js';
-import { resolveCorePackageMigrationsFolder } from './resolve-migrations-folder.js';
+// E6-L5 (T11525): dual-scope chokepoint — the skills registry opens the
+// consolidated GLOBAL `cleo.db` through here. openDualScopeDb manages the
+// DatabaseSync lifecycle, pragmas, and consolidated migrations (which create the
+// prefixed `skills_*` tables). We extract the native handle and re-wrap it with
+// the prefix-renamed skills schema so existing callers compile unchanged.
+import { _resetDualScopeDbCache, openDualScopeDb, openDualScopeDbAtPath } from './dual-scope-db.js';
 import * as skillsSchema from './schema/skills-schema.js';
 import {
   type NewSkillRow,
@@ -50,12 +61,17 @@ import {
   type SkillSourceType,
   skills as skillsTable,
 } from './schema/skills-schema.js';
-import { isSqliteBusy, openNativeDatabase } from './sqlite.js';
 
-/** Database file name within `getCleoHome()`. */
+/**
+ * Legacy standalone skills.db file name within `getCleoHome()`.
+ *
+ * E6-L5 (T11525): the live skills registry now consolidates into the shared
+ * GLOBAL `cleo.db`; this literal is retained only for the backup/exodus paths
+ * that still read the pre-cutover standalone file.
+ */
 export const SKILLS_DB_FILENAME = 'skills.db';
 
-/** Schema version stamped into `_skills_meta`. Bump on every schema change. */
+/** Schema version constant. Retained for compatibility with external re-exporters. */
 export const SKILLS_SCHEMA_VERSION = '2026.5.81';
 
 // ---------------------------------------------------------------------------
@@ -72,121 +88,35 @@ let _skillsInitPromise: Promise<NodeSQLiteDatabase<typeof skillsSchema>> | null 
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the canonical filesystem path for `skills.db`.
+ * Resolve the canonical filesystem path for the skills registry DB.
  *
- * Always returns a path under `getCleoHome()`. Throws if the resolved path
- * somehow escapes that prefix — that would indicate a regression in
- * `getCleoHome()` itself and MUST be fixed at the source, not silently
- * tolerated.
+ * E6-L5 (T11525): resolves `getCleoHome()` + `cleo.db` — the consolidated GLOBAL
+ * `cleo.db` that now hosts the `skills_*` registry tables (the same path
+ * {@link openDualScopeDb}('global') opens). Always returns a path under
+ * `getCleoHome()`. Throws if the resolved path somehow escapes that prefix — that
+ * would indicate a regression in `getCleoHome()` itself and MUST be fixed at the
+ * source, not silently tolerated.
  *
- * @returns Absolute path to `skills.db`.
+ * @returns Absolute path to the consolidated `cleo.db`.
  * @throws {Error} If the resolved path is not under `getCleoHome()`.
  */
 export function getDefaultSkillsDbPath(): string {
+  // Resolve via THIS module's getCleoHome binding so the path and the guard are
+  // self-consistent — see the same note on signaldock-sqlite.getGlobalSignaldockDbPath
+  // (T11525). resolveDualScopeDbPath('global') builds the identical path but binds
+  // getCleoHome through dual-scope-db's module graph, which can diverge under
+  // per-test vi.doMock timing.
   const cleoHome = getCleoHome();
-  const dbPath = join(cleoHome, SKILLS_DB_FILENAME);
+  const dbPath = join(cleoHome, 'cleo.db');
   if (!dbPath.startsWith(cleoHome)) {
+    /* c8 ignore next 6 — unreachable: dbPath is built FROM cleoHome above. */
     throw new Error(
       `BUG: getDefaultSkillsDbPath() resolved to "${dbPath}" which is NOT under ` +
-        `getCleoHome() ("${cleoHome}"). skills.db is global-only per ` +
+        `getCleoHome() ("${cleoHome}"). The skills registry is global-only per ` +
         `SG-CLEO-SKILLS-architecture-v3.md §4. Fix the caller, do not suppress.`,
     );
   }
   return dbPath;
-}
-
-/**
- * Resolve the absolute path to the `drizzle-skills` migrations folder.
- *
- * Delegates to {@link resolveCorePackageMigrationsFolder} which handles the
- * three install layouts (workspace dev, bundled dist, global install) via
- * `import.meta.resolve()` with a `createRequire().resolve()` fallback.
- */
-export function resolveSkillsMigrationsFolder(): string {
-  return resolveCorePackageMigrationsFolder('drizzle-skills');
-}
-
-// ---------------------------------------------------------------------------
-// Migration runner
-// ---------------------------------------------------------------------------
-
-/**
- * Apply the drizzle journal + pending migrations to the open `skills.db`.
- *
- * Uses the same retry-on-BUSY loop as `nexus-sqlite.ts` so concurrent CLI
- * invocations don't trip over each other during first-install bootstrap.
- *
- * @task T9651
- */
-function runSkillsMigrations(
-  nativeDb: DatabaseSync,
-  db: NodeSQLiteDatabase<typeof skillsSchema>,
-): void {
-  const migrationsFolder = resolveSkillsMigrationsFolder();
-
-  // Bootstrap: if the table exists from a prior bare-SQL apply but the
-  // drizzle journal hasn't been seeded, mark the initial migration as
-  // already applied. This mirrors the nexus-sqlite Scenario-1 bootstrap.
-  if (tableExists(nativeDb, 'skills') && !tableExists(nativeDb, '__drizzle_migrations')) {
-    const migrations = readMigrationFiles({ migrationsFolder });
-    const baseline = migrations[0];
-    if (baseline) {
-      nativeDb
-        .prepare(
-          `CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (id INTEGER PRIMARY KEY AUTOINCREMENT, hash text NOT NULL, created_at numeric)`,
-        )
-        .run();
-      nativeDb
-        .prepare(
-          `INSERT INTO "__drizzle_migrations" ("hash", "created_at") VALUES ('${baseline.hash}', ${baseline.folderMillis})`,
-        )
-        .run();
-    }
-  }
-
-  // Reconcile any partial / out-of-band migrations before the regular run.
-  reconcileJournal(nativeDb, migrationsFolder, 'skills', 'skills');
-
-  const MAX_RETRIES = 5;
-  const BASE_DELAY_MS = 100;
-  const MAX_DELAY_MS = 2000;
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-    try {
-      migrateWithRetry(db, migrationsFolder, nativeDb, 'skills', 'skills');
-      return;
-    } catch (err) {
-      if (!isSqliteBusy(err) || attempt === MAX_RETRIES) throw err;
-      lastError = err;
-      const delay = Math.min(
-        BASE_DELAY_MS * 2 ** (attempt - 1) * (1 + Math.random() * 0.5),
-        MAX_DELAY_MS,
-      );
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.round(delay));
-    }
-  }
-  /* c8 ignore next */
-  throw lastError;
-}
-
-/**
- * Stamp the `_skills_meta.schema_version` sentinel so the next process can
- * take a fast-path through `ensureSkillsDb`.
- */
-function writeSkillsSchemaVersionSentinel(nativeDb: DatabaseSync): void {
-  try {
-    nativeDb.exec(
-      `CREATE TABLE IF NOT EXISTS _skills_meta (
-         key TEXT PRIMARY KEY,
-         value TEXT NOT NULL,
-         updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
-       );
-       INSERT OR REPLACE INTO _skills_meta (key, value, updated_at)
-       VALUES ('schema_version', '${SKILLS_SCHEMA_VERSION}', strftime('%s', 'now'));`,
-    );
-  } catch {
-    // Non-fatal — the next open will simply take the fall-through path.
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -199,17 +129,29 @@ function writeSkillsSchemaVersionSentinel(nativeDb: DatabaseSync): void {
 export interface OpenSkillsDbOptions {
   /**
    * Override the on-disk path. Used by tests; production callers should
-   * leave this `undefined` to let the module resolve `getDefaultSkillsDbPath()`.
+   * leave this `undefined` to let the module resolve {@link getDefaultSkillsDbPath}.
+   *
+   * E6-L5 (T11525): the override path is opened as a consolidated GLOBAL
+   * `cleo.db` (the prefixed `skills_*` tables are created by the consolidated
+   * migration) via {@link openDualScopeDbAtPath}, so a test passing
+   * `<tmpdir>/skills.db` materialises an isolated consolidated DB at that exact
+   * path — distinct cache key from the canonical `cleo.db`.
    */
   path?: string;
 }
 
 /**
- * Open (or first-time materialise) `skills.db` and return the Drizzle handle.
+ * Open (or first-time materialise) the skills registry and return the Drizzle
+ * handle bound to the prefixed `skills_*` tables.
  *
- * Idempotent: repeated calls with the same effective path return the cached
- * singleton. Concurrent callers share a single in-flight init promise so
- * migrations never race.
+ * E6-L5 (T11525): delegates the physical open to {@link openDualScopeDb}('global')
+ * (or {@link openDualScopeDbAtPath} for the test `{ path }` override) — the
+ * canonical dual-scope chokepoint — and re-wraps its native handle with the
+ * prefix-renamed `skillsSchema` drizzle instance. The consolidated
+ * `drizzle-cleo-global` migration creates the `skills_*` tables; this module does
+ * NOT run the legacy `drizzle-skills` migration (which would create the
+ * signaldock-colliding bare `skills` table). Idempotent: repeated calls with the
+ * same effective path return the cached singleton.
  *
  * @example
  * ```typescript
@@ -220,9 +162,10 @@ export interface OpenSkillsDbOptions {
  * ```
  *
  * @param options - Override the default path (test-only).
- * @returns A Drizzle ORM handle bound to the four skills.db tables.
+ * @returns A Drizzle ORM handle bound to the four `skills_*` registry tables.
  *
  * @task T9651
+ * @task T11525
  */
 export async function openSkillsDb(
   options?: OpenSkillsDbOptions,
@@ -232,13 +175,22 @@ export async function openSkillsDb(
   // is important for tests that open the DB at a tmpdir via `{path:...}` and
   // then exercise helpers that call `openSkillsDb()` with no args; without
   // this guard the helper call would swap the singleton over to the real
-  // user-home path and leak writes outside the test sandbox.
+  // consolidated cleo.db path and leak writes outside the test sandbox.
   if (_skillsDb && !options?.path) return _skillsDb;
 
   const requestedPath = options?.path ?? getDefaultSkillsDbPath();
 
   // If singleton points at a different file, reset cleanly.
   if (_skillsDb && _skillsDbPath !== requestedPath) {
+    resetSkillsDbState();
+  }
+
+  // Liveness guard (T11525): the skills registry SHARES the consolidated GLOBAL
+  // `cleo.db` handle with the nexus / signaldock domains. A sibling may have
+  // closed + re-opened the shared handle while our singleton still references the
+  // now-closed one. Detect a stale (closed) handle and drop the singleton so we
+  // re-derive from the live dual-scope cache below.
+  if (_skillsDb && (_skillsNativeDb === null || !_skillsNativeDb.isOpen)) {
     resetSkillsDbState();
   }
 
@@ -249,18 +201,29 @@ export async function openSkillsDb(
   _skillsInitPromise = (async () => {
     _skillsDbPath = requestedPath;
 
-    // Ensure the parent directory exists before SQLite tries to create the file.
-    if (!existsSync(dirname(requestedPath))) {
-      mkdirSync(dirname(requestedPath), { recursive: true });
-    }
+    // ── Dual-scope chokepoint delegation (T11525 · E6-L5) ───────────────────
+    // openDualScopeDb('global') applies the pragma SSoT, creates the directory,
+    // runs the consolidated cleo-global migrations (which create the prefixed
+    // `skills_*` tables), and manages the singleton cache. The `{ path }` test
+    // override routes through the path-aware sibling against an isolated file.
+    const dualHandle = options?.path
+      ? await openDualScopeDbAtPath('global', options.path)
+      : await openDualScopeDb('global');
 
-    const nativeDb = openNativeDatabase(requestedPath);
+    // Extract the underlying DatabaseSync. Drizzle exposes it via `$client`.
+    const nativeDb = (dualHandle.db as { $client?: DatabaseSync }).$client ?? null;
+    if (!nativeDb) {
+      throw new Error(
+        'E6-L5: openDualScopeDb returned a handle without $client — ' +
+          'cannot extract DatabaseSync for the skills-schema wrapping.',
+      );
+    }
     _skillsNativeDb = nativeDb;
 
+    // Wrap the native handle with the prefix-renamed skills schema so existing
+    // callers (skillsSchema.* queries) bind to the consolidated `skills_*`
+    // tables the dual-scope migration already created.
     const db = drizzle({ client: nativeDb, schema: skillsSchema });
-
-    runSkillsMigrations(nativeDb, db);
-    writeSkillsSchemaVersionSentinel(nativeDb);
 
     _skillsDb = db;
     return db;
@@ -274,33 +237,49 @@ export async function openSkillsDb(
 }
 
 /**
- * Close the singleton handle and release the underlying native DB.
+ * Drop the skills-domain singleton references and trigger the coordinated close
+ * of the shared GLOBAL `cleo.db` handle via the dual-scope cache.
  *
- * Safe to call multiple times. Used by `cleo backup restore skills.db` and
- * tests that mkdtemp a fresh location between cases.
+ * ## E6-L5 (T11525) — shared-handle close rule
+ *
+ * `_skillsNativeDb` is the SHARED consolidated GLOBAL `cleo.db` handle owned by
+ * {@link openDualScopeDb}('global') and co-owned by the nexus / signaldock global
+ * domains. This function MUST NOT call `.close()` on it directly — doing so would
+ * tear the handle out from under those siblings (the exact bug class L4 fixed at
+ * `dual-scope-db.ts`). Instead it evicts the GLOBAL-scope entry from the
+ * dual-scope cache (a single coordinated close) and drops the local references.
+ *
+ * Safe to call multiple times. Used by `cleo backup restore` and tests that
+ * mkdtemp a fresh location between cases.
+ *
+ * @task T9651
+ * @task T11525
  */
 export function closeSkillsDb(): void {
-  if (_skillsNativeDb) {
-    try {
-      if (_skillsNativeDb.isOpen) {
-        _skillsNativeDb.close();
-      }
-    } catch {
-      // Ignore — the singleton is about to be reset.
-    }
-    _skillsNativeDb = null;
-  }
+  // Drop only the local references. The scope-filtered cache reset performs the
+  // single coordinated close of the shared GLOBAL handle.
+  _skillsNativeDb = null;
   _skillsDb = null;
   _skillsDbPath = null;
+  _skillsInitPromise = null;
+  _resetDualScopeDbCache('global');
 }
 
 /**
- * Reset singleton state WITHOUT closing — used between tests to force a
- * re-open against a new tmpdir.
+ * Reset singleton state — used between tests to force a re-open against a new
+ * tmpdir. E6-L5: identical to {@link closeSkillsDb} (both go through the
+ * scope-filtered dual-scope cache reset; neither closes the shared handle
+ * directly).
+ *
+ * @task T9651
+ * @task T11525
  */
 export function resetSkillsDbState(): void {
-  closeSkillsDb();
+  _skillsNativeDb = null;
+  _skillsDb = null;
+  _skillsDbPath = null;
   _skillsInitPromise = null;
+  _resetDualScopeDbCache('global');
 }
 
 /**

--- a/packages/core/src/system/project-health.ts
+++ b/packages/core/src/system/project-health.ts
@@ -74,11 +74,16 @@ function getDatabaseSyncCtor(): DatabaseSyncModule['DatabaseSync'] | null {
 // filename. Its expected migration floor is the global cleo-global set, NOT the
 // project floor of 3, so it uses NEXUS_GLOBAL_DB_FLOOR (passed inline at the
 // probe site) instead of a `[NEXUS_DB]` map entry that would clobber `[TASKS_DB]`.
+// E6-L5 (T11525): the signaldock domain consolidated into the GLOBAL `cleo.db`
+// under getCleoHome() (ensureGlobalSignaldockDb → openDualScopeDb('global')), the
+// SAME physical file as the nexus global probe above. Like NEXUS_DB it uses
+// NEXUS_GLOBAL_DB_FLOOR inline at its probe site instead of a `[SIGNALDOCK_DB]`
+// map entry that would clobber `[TASKS_DB]` (both keys are now 'cleo.db').
 const TASKS_DB = 'cleo.db' as const;
 const BRAIN_DB = 'cleo.db' as const;
 const CONDUIT_DB = 'cleo.db' as const;
 const NEXUS_DB = 'cleo.db' as const;
-const SIGNALDOCK_DB = 'signaldock.db' as const;
+const SIGNALDOCK_DB = 'cleo.db' as const;
 
 /**
  * Expected applied-migration floor for the GLOBAL consolidated `cleo.db`
@@ -286,8 +291,11 @@ export const DB_EXPECTED_VERSIONS: Readonly<Record<string, number>> = {
   // E6-L4 (T11524): NEXUS_DB is also `'cleo.db'` now (the GLOBAL file), so it
   // would clobber `[TASKS_DB]` here too — the nexus probe therefore passes
   // NEXUS_GLOBAL_DB_FLOOR inline at its probe site instead of via this map.
+  // E6-L5 (T11525): SIGNALDOCK_DB is ALSO `'cleo.db'` now (same GLOBAL file as
+  // nexus), so its former `[SIGNALDOCK_DB]: 1` map entry is removed — it aliased
+  // `[TASKS_DB]` and would clobber the floor of 3. The signaldock probe passes
+  // NEXUS_GLOBAL_DB_FLOOR inline at its probe site, like the nexus probe.
   [TASKS_DB]: 3,
-  [SIGNALDOCK_DB]: 1,
 };
 
 /**
@@ -777,7 +785,9 @@ export async function checkGlobalHealth(): Promise<GlobalHealthReport> {
     // E6-L4 (T11524): the GLOBAL `cleo.db` floor comes from NEXUS_GLOBAL_DB_FLOOR,
     // not DB_EXPECTED_VERSIONS[NEXUS_DB] (which would alias the project-tier key).
     probeDb(join(cleoHome, NEXUS_DB), NEXUS_GLOBAL_DB_FLOOR),
-    probeDb(join(cleoHome, SIGNALDOCK_DB), DB_EXPECTED_VERSIONS[SIGNALDOCK_DB]),
+    // E6-L5 (T11525): signaldock shares the SAME GLOBAL `cleo.db` file as nexus,
+    // so it uses NEXUS_GLOBAL_DB_FLOOR inline too (not a clobbering map entry).
+    probeDb(join(cleoHome, SIGNALDOCK_DB), NEXUS_GLOBAL_DB_FLOOR),
   ]);
   const dbs = { nexus, signaldock };
   return {


### PR DESCRIPTION
## E6-L5 — signaldock + skills global dual-scope facade (saga T11242 · epic T11249)

Routes both global-tier domains through the canonical `openDualScopeDb('global')` chokepoint and removes their raw `new DatabaseSync()` opens. They now share the consolidated GLOBAL `cleo.db` with the nexus domain (E6-L4).

### signaldock — DIFFER-PREFIX (simple facade)
`ensureGlobalSignaldockDb()` delegates the open to `openDualScopeDb('global')`, extracts `$client`, and runs the legacy `drizzle-signaldock` migrations. Legacy BARE names (`agents`/`capabilities`/`skills`/…) DIFFER from the consolidated `signaldock_*` prefix, so they co-exist (the conduit-L3 / tasks pattern). No establishLegacy.

### skills — cross-domain collision → land on prefixed tables
Consolidating both former-separate-file domains onto ONE `cleo.db` introduced a **SAME-NAME collision**: signaldock's legacy `skills` slug-catalog and skills-db's legacy `skills` registry both wanted the bare physical name `skills`.

An empirical migration-ordering probe confirmed the collision is **fatal in both orderings** AND that the consolidated `skills_skills` CHECK constraints accept every value the runtime drizzle writers produce (ISO-8601 text, 0/1 booleans). So — unlike nexus L4 — **no establishLegacy drop+rebuild is needed**: `skills-db.ts` simply binds the (prefix-renamed) `skillsSchema` queries to the consolidated `skills_*` tables the `drizzle-cleo-global` migration already creates, and does NOT run the legacy `drizzle-skills` migration. This makes skills a zero-delta cutover onto its exodus-target tables.

The collision-resolution direction (rename the encapsulated skills domain, not signaldock's raw-SQL-scattered catalog) was validated by a 5-advisor council review (4/4 gates, high confidence).

### Supporting
- new `openDualScopeDbAtPath(scope, dbPath)` chokepoint sibling preserves the skills-db `{ path }` test override without a raw open
- scope-filtered `_resetDualScopeDbCache('global')` in both close/reset paths honors the L4 shared-handle rule (must not close the global handle co-owned by nexus)
- self-consistent `getCleoHome` guard in both path resolvers (avoids a spurious throw under per-test `vi.doMock` timing divergence)
- `backup-pack.ts` reads the literal legacy `signaldock.db` filename during cutover (nexus-L4 treatment); `project-health.ts` folds `SIGNALDOCK_DB` onto the global `cleo.db` floor
- `skills-schema.ts` physical tables prefixed `skills_*` (TS export names unchanged → 18 importers compile clean)

### Validation
- `pnpm run typecheck` (tsc -b) green
- `@cleocode/core` full suite — only the ~16 pre-existing worktree-napi/git env flakes remain (none touch DB code)
- `@cleocode/runtime` 120/120
- `cleo check arch` 5/5 (DB Open Guard Gate 3 = 0 violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)