### PR TITLE
feat(T11544): add nullable project_id to skills_skill_usage + populate from ProjectContext

### DIFF
--- a/packages/core/migrations/drizzle-cleo-global/20260601000001_t11544-skills-usage-project-id/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-global/20260601000001_t11544-skills-usage-project-id/migration.sql
@@ -1,0 +1,12 @@
+-- T11544: Add nullable `project_id` to `skills_skill_usage` (consolidated
+-- GLOBAL cleo.db, drizzle-cleo-global scope).
+--
+-- Cross-project skill-usage attribution: the active ProjectContext's canonical
+-- project_id is stamped onto each telemetry row so analytics can group skill
+-- usage by project. Nullable so existing rows and project-less global usage
+-- (skill loaded outside any resolvable CLEO repo) stay valid.
+--
+-- No CHECK constraint: `project_id` is a plain free-text soft FK (not a
+-- timestamp `_at`, boolean, or enum), so the T11363 consolidation-check
+-- injector contributes nothing for it.
+ALTER TABLE `skills_skill_usage` ADD COLUMN `project_id` text;

--- a/packages/core/src/skills/usage-recorder.ts
+++ b/packages/core/src/skills/usage-recorder.ts
@@ -18,8 +18,35 @@
  * @architecture docs/architecture/SG-CLEO-SKILLS-architecture-v3.md §5
  */
 
+import { resolveProjectByCwd } from '@cleocode/paths';
 import type { NewSkillUsageRow } from '../store/skills-store.js';
 import { enqueueSkillUsage } from '../store/skills-usage-queue.js';
+
+/**
+ * Best-effort resolution of the active project's canonical ID from `cwd`.
+ *
+ * Stamped onto every usage row (`project_id`) so cross-project skill-usage
+ * analytics can attribute usage to the project the skill was loaded under
+ * (T11544). Returns `null` whenever there is no resolvable CLEO project
+ * (global usage outside any repo, corrupt `project-info.json`, etc.) — the
+ * column is nullable by design, and telemetry MUST NOT throw on the hot path.
+ *
+ * The paths-package resolver is itself non-throwing (returns `null`), but the
+ * `try/catch` guards against any unexpected fs/parse error so the recorder
+ * contract (never break skill loading) holds unconditionally.
+ *
+ * @returns The canonical projectId, or `null` when no project context exists.
+ *
+ * @task T11544
+ */
+function resolveActiveProjectId(): string | null {
+  try {
+    return resolveProjectByCwd()?.projectId ?? null;
+  } catch {
+    /* swallowed — telemetry MUST NOT block skill loading (architecture v3 §5) */
+    return null;
+  }
+}
 
 /**
  * Discriminated-union of actions the recorder accepts.
@@ -116,6 +143,9 @@ export function recordSkillUsage(
     skillName: name,
     eventKind: action,
     taskId: context?.taskId ?? null,
+    // T11544: attribute the usage event to the active project (null when
+    // running outside any resolvable CLEO project — global usage stays valid).
+    projectId: resolveActiveProjectId(),
     modelId: context?.modelId ?? null,
     metadata: JSON.stringify(metadataObj),
   };

--- a/packages/core/src/store/schema/cleo-global/skills.ts
+++ b/packages/core/src/store/schema/cleo-global/skills.ts
@@ -172,6 +172,17 @@ export const skillsSkillUsage = sqliteTable(
      * accessor (AC4 — no ATTACH).
      */
     taskId: text('task_id'),
+    /**
+     * Owning project context; NULL if not running inside a resolvable CLEO
+     * project (global usage outside any repo).
+     *
+     * Cross-domain soft FK → the project registry's canonical `project_id`. Like
+     * {@link taskId} this is a plain `text` soft FK (no native cross-scope FK);
+     * resolved by the skill-telemetry recorder from the active ProjectContext.
+     * Nullable so existing rows + project-less usage stay valid (T11544 — the
+     * cross-project skill-usage attribution column).
+     */
+    projectId: text('project_id'),
     /** Model identifier the calling agent was running under. */
     modelId: text('model_id'),
     /** Free-form JSON blob for forward-compatible event metadata (serialized TEXT). */

--- a/packages/core/src/store/schema/skills-schema.ts
+++ b/packages/core/src/store/schema/skills-schema.ts
@@ -14,10 +14,13 @@
  *   - `skill_patches`   — diff payload for auto-improve dry-runs/applied
  *
  * Database lifecycle:
- *   - Path: `<getCleoHome()>/skills.db` (per-user global, NOT per-project)
- *   - Opened via the `openCleoDb('skills')` chokepoint (ADR-068 + D003)
- *   - Migrations live in `packages/core/migrations/drizzle-skills/`
- *   - First-read materialization: see `skills-sqlite.ts#ensureSkillsDb`
+ *   - Path: consolidated GLOBAL `<getCleoHome()>/cleo.db` (per-user global, NOT
+ *     per-project) — shared with the nexus / signaldock domains since E6-L5.
+ *   - Opened via the `openDualScopeDb('global')` chokepoint (ADR-068 + D003)
+ *   - Migrations live in `packages/core/migrations/drizzle-cleo-global/` (the
+ *     legacy `drizzle-skills/` set is dead weight post-E6-L5 — NOT run on the
+ *     shared handle; see `skills-db.ts`).
+ *   - First-read materialization: see `skills-db.ts#openSkillsDb`
  *
  * Scope note for T9651:
  *   This module is schema-only — the runtime (CLI surface) is wired in
@@ -193,6 +196,18 @@ export const skillUsage = sqliteTable(
      * accessor; no DB-level FK (skills.db is global; tasks.db is project-tier).
      */
     taskId: text('task_id'),
+    /**
+     * Optional canonical project ID context (null if not running inside a
+     * resolvable CLEO project — e.g. global usage outside any repo).
+     *
+     * @cross-db nexus.project_registry.project_id — skills→project soft FK
+     * (the cross-project attribution key so skill-usage analytics can group by
+     * the project the skill was loaded under). Populated by the skill telemetry
+     * recorder from the active {@link ProjectContext}; no DB-level FK
+     * (skills.db is global; the project registry is its own scope). Nullable so
+     * existing rows and project-less global usage stay valid (T11544).
+     */
+    projectId: text('project_id'),
     /** Optional model identifier the calling agent was running under. */
     modelId: text('model_id'),
     /** Free-form JSON blob for forward-compatible event metadata. */


### PR DESCRIPTION
## Summary

Part of **EP-SCOPING-OPTIMIZATION (T11535)**. Adds a nullable `project_id` column to `skills_skill_usage` so cross-project skill-usage analytics can attribute each usage event to the project the skill was loaded under.

Builds on E6-L5 (#905), which consolidated the skills registry into the GLOBAL `cleo.db` (physical table `skills_skill_usage`).

## Changes

- **Schema** — `project_id text` (NULLABLE) added to the `skill_usage` table in both the runtime schema (`store/schema/skills-schema.ts`) and the consolidated target-shape schema (`store/schema/cleo-global/skills.ts`). Nullable so existing rows + project-less global usage stay valid.
- **Migration** — `drizzle-cleo-global/20260601000001_t11544-skills-usage-project-id/migration.sql`: `ALTER TABLE skills_skill_usage ADD COLUMN project_id text`. Lands in the consolidated cleo-global set (the live open path via `openDualScopeDb('global')`). The legacy `drizzle-skills` set is dead weight post-L5 and is not run on the shared handle. No CHECK constraint (not a timestamp/boolean/enum).
- **Writer** — `skills/usage-recorder.ts` populates `project_id` from the active ProjectContext via the non-throwing `@cleocode/paths` `resolveProjectByCwd()`; `null` when no project context. Best-effort — telemetry never throws on the skill-load hot path.

## Validation

- `pnpm biome check`, `pnpm run typecheck` (tsc -b), `node build.mjs`, CLI smoke — all green
- `cleo check arch` — 5/5 gates pass
- Targeted suites green: consolidated-schema-parity-fk, skills-schema, exodus, usage-recorder, discovery, dual-scope-db, migration-baseline
- Full `@cleocode/core` suite (x2, deterministic): 16 pre-existing worktree/git-env flakes only, **ZERO new failures**
- Manual migration-apply probe confirms the column materializes nullable (null + value inserts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)