### PR TITLE
fix(T11562): route agent-registry openGlobalDb to consolidated cleo.db — align agents read/write path (P1 regression)

### DIFF
--- a/packages/cleo/src/cli/commands/agent.ts
+++ b/packages/cleo/src/cli/commands/agent.ts
@@ -1076,7 +1076,7 @@ const listCommand = defineCommand({
       const includeGlobal = args.global === true;
       const includeDisabled = args['include-disabled'] === true;
 
-      const agents = listAgentsForProject(getProjectRoot(), {
+      const agents = await listAgentsForProject(getProjectRoot(), {
         includeGlobal,
         includeDisabled,
       });
@@ -1144,7 +1144,7 @@ const getCommand = defineCommand({
       await openCleoDb('project');
 
       const includeGlobal = args.global === true;
-      const agent = lookupAgent(getProjectRoot(), args.agentId, { includeGlobal });
+      const agent = await lookupAgent(getProjectRoot(), args.agentId, { includeGlobal });
 
       if (!agent) {
         cliOutput(
@@ -1233,7 +1233,7 @@ const attachCommand = defineCommand({
       void _registry;
 
       // Verify agent exists globally
-      const globalAgent = lookupAgent(projectRoot, args.agentId, { includeGlobal: true });
+      const globalAgent = await lookupAgent(projectRoot, args.agentId, { includeGlobal: true });
       if (!globalAgent) {
         cliOutput(
           {

--- a/packages/core/src/store/__tests__/agent-registry-accessor.test.ts
+++ b/packages/core/src/store/__tests__/agent-registry-accessor.test.ts
@@ -175,7 +175,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     await ensureConduitDb(env.projectRoot);
     closeConduitDb();
 
-    const result = lookupAgent(env.projectRoot, 'nonexistent-agent');
+    const result = await lookupAgent(env.projectRoot, 'nonexistent-agent');
     expect(result).toBeNull();
   });
 
@@ -208,7 +208,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     expect(created.projectRef?.enabled).toBe(1);
 
     // Lookup should return the merged record
-    const found = lookupAgent(env.projectRoot, BASE_SPEC.agentId);
+    const found = await lookupAgent(env.projectRoot, BASE_SPEC.agentId);
     expect(found).not.toBeNull();
     expect(found?.agentId).toBe(BASE_SPEC.agentId);
     expect(found?.displayName).toBe(BASE_SPEC.displayName);
@@ -247,7 +247,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
       .run(BASE_SPEC.agentId);
     conduitDb.close();
 
-    const result = lookupAgent(env.projectRoot, BASE_SPEC.agentId);
+    const result = await lookupAgent(env.projectRoot, BASE_SPEC.agentId);
     expect(result).toBeNull();
   });
 
@@ -288,11 +288,11 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     globalDb.close();
 
     // Default (includeGlobal=false): should return null because no project ref
-    const defaultResult = lookupAgent(env.projectRoot, 'global-only-agent');
+    const defaultResult = await lookupAgent(env.projectRoot, 'global-only-agent');
     expect(defaultResult).toBeNull();
 
     // includeGlobal=true: should return the global agent with projectRef=null
-    const globalResult = lookupAgent(env.projectRoot, 'global-only-agent', {
+    const globalResult = await lookupAgent(env.projectRoot, 'global-only-agent', {
       includeGlobal: true,
     });
     expect(globalResult).not.toBeNull();
@@ -341,7 +341,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     // Create one project-attached agent
     await createProjectAgent(env.projectRoot, BASE_SPEC);
 
-    const list = listAgentsForProject(env.projectRoot);
+    const list = await listAgentsForProject(env.projectRoot);
     expect(list).toHaveLength(1);
     expect(list[0]?.agentId).toBe(BASE_SPEC.agentId);
     expect(list[0]?.projectRef).not.toBeNull();
@@ -388,7 +388,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     // Create one project-attached agent
     await createProjectAgent(env.projectRoot, BASE_SPEC);
 
-    const list = listAgentsForProject(env.projectRoot, { includeGlobal: true });
+    const list = await listAgentsForProject(env.projectRoot, { includeGlobal: true });
 
     // Should return both agents
     expect(list.length).toBeGreaterThanOrEqual(2);
@@ -633,7 +633,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     conduitDb.close();
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const result = lookupAgent(env.projectRoot, 'dangling-agent');
+    const result = await lookupAgent(env.projectRoot, 'dangling-agent');
     expect(result).toBeNull();
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('dangling project_agent_refs row'),
@@ -671,13 +671,13 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     await accessor.remove(BASE_SPEC.agentId);
 
     // Confirm detached
-    const afterRemove = lookupAgent(env.projectRoot, BASE_SPEC.agentId);
+    const afterRemove = await lookupAgent(env.projectRoot, BASE_SPEC.agentId);
     expect(afterRemove).toBeNull();
 
     // Re-create should re-enable
     await createProjectAgent(env.projectRoot, BASE_SPEC);
 
-    const afterReCreate = lookupAgent(env.projectRoot, BASE_SPEC.agentId);
+    const afterReCreate = await lookupAgent(env.projectRoot, BASE_SPEC.agentId);
     expect(afterReCreate).not.toBeNull();
     expect(afterReCreate?.projectRef?.enabled).toBe(1);
 
@@ -721,11 +721,11 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     await accessor.remove(BASE_SPEC.agentId);
 
     // Default: should not include disabled
-    const defaultList = listAgentsForProject(env.projectRoot);
+    const defaultList = await listAgentsForProject(env.projectRoot);
     expect(defaultList).toHaveLength(0);
 
     // includeDisabled=true: should include disabled
-    const disabledList = listAgentsForProject(env.projectRoot, { includeDisabled: true });
+    const disabledList = await listAgentsForProject(env.projectRoot, { includeDisabled: true });
     expect(disabledList).toHaveLength(1);
     expect(disabledList[0]?.agentId).toBe(BASE_SPEC.agentId);
     expect(disabledList[0]?.projectRef?.enabled).toBe(0);
@@ -857,5 +857,120 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
 
     // With force=true: should succeed
     await expect(accessor.removeGlobal(BASE_SPEC.agentId, { force: true })).resolves.not.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // T11562 regression: agents read/write path alignment to the consolidated
+  // global cleo.db.
+  //
+  // Before the fix, openGlobalDb() raw-opened the legacy signaldock path WITHOUT
+  // running ensureGlobalSignaldockDb() first, so the BARE `agents` runtime table
+  // (materialized only by the legacy drizzle-signaldock migrations) did not exist
+  // in cleo.db on a clean build whose read path was hit first — the standalone
+  // read functions threw `no such table: agents`, diverging from the write path
+  // (E6-L5 routes writes to cleo.db). This test asserts that a write through the
+  // consolidated cleo.db is read back through the SAME consolidated cleo.db.
+  // -------------------------------------------------------------------------
+
+  it('T11562: write-then-read round-trips through the consolidated global cleo.db (read/write aligned)', async () => {
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
+    const machineKey = Buffer.alloc(32, 0xab);
+    const globalSalt = Buffer.alloc(32, 0xcd);
+    writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
+    writeFileSync(join(env.cleoHome, 'global-salt'), globalSalt, { mode: 0o600 });
+
+    const { ensureGlobalSignaldockDb } = await import('../signaldock-sqlite.js');
+    const { ensureConduitDb, closeConduitDb } = await import('../conduit-sqlite.js');
+    const { AgentRegistryAccessor, createProjectAgent, listAgentsForProject, lookupAgent } =
+      await import('../agent-registry-accessor.js');
+
+    await ensureGlobalSignaldockDb();
+    await ensureConduitDb(env.projectRoot);
+    closeConduitDb();
+
+    // WRITE path: createProjectAgent writes the identity row into the global cleo.db.
+    await createProjectAgent(env.projectRoot, BASE_SPEC);
+
+    // The write must land in the consolidated global `cleo.db` (NOT a legacy
+    // `signaldock.db`), in the BARE `agents` table.
+    const globalDb = env.openGlobal();
+    const writtenRow = globalDb
+      .prepare('SELECT agent_id FROM agents WHERE agent_id = ?')
+      .get(BASE_SPEC.agentId) as { agent_id: string } | undefined;
+    globalDb.close();
+    expect(writtenRow?.agent_id).toBe(BASE_SPEC.agentId);
+
+    // READ path through the registry accessor — must hit the SAME cleo.db.
+    const accessor = new AgentRegistryAccessor(env.projectRoot);
+    const globalList = await accessor.listGlobal();
+    expect(globalList.map((a) => a.agentId)).toContain(BASE_SPEC.agentId);
+
+    // Standalone read functions (the ones that previously raw-opened without
+    // ensure) must also resolve the agent.
+    const looked = await lookupAgent(env.projectRoot, BASE_SPEC.agentId, { includeGlobal: true });
+    expect(looked?.agentId).toBe(BASE_SPEC.agentId);
+
+    const listed = await listAgentsForProject(env.projectRoot, { includeGlobal: true });
+    expect(listed.map((a) => a.agentId)).toContain(BASE_SPEC.agentId);
+  });
+
+  it('T11562: read-first standalone read materializes the bare `agents` table (no "no such table: agents")', async () => {
+    vi.doMock('../../paths.js', () => ({
+      getCleoHome: () => env.cleoHome,
+      resolveCleoDir: (cwd) => join(cwd ?? env.projectRoot, '.cleo'),
+    }));
+    const machineKey = Buffer.alloc(32, 0xab);
+    const globalSalt = Buffer.alloc(32, 0xcd);
+    writeFileSync(join(env.cleoHome, 'machine-key'), machineKey, { mode: 0o600 });
+    writeFileSync(join(env.cleoHome, 'global-salt'), globalSalt, { mode: 0o600 });
+
+    const { openDualScopeDb, _resetDualScopeDbCache } = await import('../dual-scope-db.js');
+    const { _resetGlobalSignaldockDb_TESTING_ONLY } = await import('../signaldock-sqlite.js');
+    const { ensureConduitDb, closeConduitDb } = await import('../conduit-sqlite.js');
+    const { listAgentsForProject } = await import('../agent-registry-accessor.js');
+
+    // Simulate the clean-build / read-first state: the consolidated global
+    // cleo.db has been opened by the dual-scope chokepoint (creating ONLY the
+    // prefixed `signaldock_*` tables) but the legacy signaldock migrations that
+    // create the BARE `agents` table have NOT run yet.
+    await openDualScopeDb('global');
+    await ensureConduitDb(env.projectRoot);
+    closeConduitDb();
+
+    // Confirm the bare `agents` table does NOT exist yet — this is the exact
+    // precondition that produced `no such table: agents` before the fix.
+    const probe = env.openGlobal();
+    const bareAgents = probe
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='agents'")
+      .get() as { name: string } | undefined;
+    const prefixedAgents = probe
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='signaldock_agents'")
+      .get() as { name: string } | undefined;
+    probe.close();
+    expect(bareAgents).toBeUndefined();
+    expect(prefixedAgents).toBeDefined();
+
+    // Reset the in-process signaldock singleton so the read path must re-ensure
+    // (the read-first scenario in a fresh process).
+    _resetGlobalSignaldockDb_TESTING_ONLY();
+    _resetDualScopeDbCache();
+
+    // The standalone read used to throw `no such table: agents`; post-fix it
+    // routes through ensureGlobalSignaldockDb() (materializing the bare table)
+    // and returns an empty list without throwing.
+    await expect(listAgentsForProject(env.projectRoot, { includeGlobal: true })).resolves.toEqual(
+      [],
+    );
+
+    // And the bare `agents` table now exists in the consolidated cleo.db.
+    const after = env.openGlobal();
+    const bareAgentsAfter = after
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='agents'")
+      .get() as { name: string } | undefined;
+    after.close();
+    expect(bareAgentsAfter).toBeDefined();
   });
 });

--- a/packages/core/src/store/__tests__/t310-integration.test.ts
+++ b/packages/core/src/store/__tests__/t310-integration.test.ts
@@ -555,11 +555,11 @@ describe('T310: conduit + signaldock integration', () => {
     globalDb.close();
 
     // Default (INNER JOIN): must return null because no project_agent_refs row
-    const defaultResult = lookupAgent(projectRoot, 'global-agent-x');
+    const defaultResult = await lookupAgent(projectRoot, 'global-agent-x');
     expect(defaultResult).toBeNull();
 
     // includeGlobal=true: must return the agent with projectRef: null
-    const globalResult = lookupAgent(projectRoot, 'global-agent-x', { includeGlobal: true });
+    const globalResult = await lookupAgent(projectRoot, 'global-agent-x', { includeGlobal: true });
     expect(globalResult).not.toBeNull();
     expect(globalResult?.agentId).toBe('global-agent-x');
     expect(globalResult?.projectRef).toBeNull();
@@ -602,7 +602,7 @@ describe('T310: conduit + signaldock integration', () => {
     conduitDb.close();
 
     // Default INNER join: should return only Y and Z
-    const innerResult = listAgentsForProject(projectRoot);
+    const innerResult = await listAgentsForProject(projectRoot);
     expect(innerResult).toHaveLength(2);
     const innerIds = innerResult.map((a) => a.agentId).sort();
     expect(innerIds).toEqual(['agent-y', 'agent-z']);
@@ -612,7 +612,7 @@ describe('T310: conduit + signaldock integration', () => {
     }
 
     // includeGlobal=true: should return all 3 agents
-    const globalResult = listAgentsForProject(projectRoot, { includeGlobal: true });
+    const globalResult = await listAgentsForProject(projectRoot, { includeGlobal: true });
     expect(globalResult).toHaveLength(3);
     const globalIds = globalResult.map((a) => a.agentId).sort();
     expect(globalIds).toEqual(['agent-x', 'agent-y', 'agent-z']);
@@ -671,17 +671,17 @@ describe('T310: conduit + signaldock integration', () => {
     });
 
     // A must see the agent
-    const inA = listAgentsForProject(projectA);
+    const inA = await listAgentsForProject(projectA);
     const agentInA = inA.find((a) => a.agentId === 'cross-project-agent');
     expect(agentInA).toBeDefined();
 
     // B must NOT see the agent by default (INNER JOIN — no project_agent_refs row in B)
-    const inB = listAgentsForProject(projectB);
+    const inB = await listAgentsForProject(projectB);
     const agentInB = inB.find((a) => a.agentId === 'cross-project-agent');
     expect(agentInB).toBeUndefined();
 
     // B with includeGlobal=true should see the agent but with projectRef: null
-    const inBGlobal = listAgentsForProject(projectB, { includeGlobal: true });
+    const inBGlobal = await listAgentsForProject(projectB, { includeGlobal: true });
     const agentInBGlobal = inBGlobal.find((a) => a.agentId === 'cross-project-agent');
     expect(agentInBGlobal).toBeDefined();
     expect(agentInBGlobal?.projectRef).toBeNull();
@@ -736,20 +736,20 @@ describe('T310: conduit + signaldock integration', () => {
     attachAgentToProject(projectB, 'attach-detach-agent');
 
     // Now both A and B should see the agent
-    const inA = listAgentsForProject(projectA);
+    const inA = await listAgentsForProject(projectA);
     expect(inA.find((a) => a.agentId === 'attach-detach-agent')).toBeDefined();
-    const inB = listAgentsForProject(projectB);
+    const inB = await listAgentsForProject(projectB);
     expect(inB.find((a) => a.agentId === 'attach-detach-agent')).toBeDefined();
 
     // Detach from A
     detachAgentFromProject(projectA, 'attach-detach-agent');
 
     // A must no longer see it
-    const inAAfter = listAgentsForProject(projectA);
+    const inAAfter = await listAgentsForProject(projectA);
     expect(inAAfter.find((a) => a.agentId === 'attach-detach-agent')).toBeUndefined();
 
     // B must still see it
-    const inBAfter = listAgentsForProject(projectB);
+    const inBAfter = await listAgentsForProject(projectB);
     expect(inBAfter.find((a) => a.agentId === 'attach-detach-agent')).toBeDefined();
 
     // Global identity must still exist

--- a/packages/core/src/store/agent-registry-accessor.ts
+++ b/packages/core/src/store/agent-registry-accessor.ts
@@ -1,24 +1,35 @@
 /**
  * Agent Registry Accessor — cross-DB CRUD for agent data.
  *
- * Post-T310 (ADR-037), agent identity lives in the GLOBAL
- * `$XDG_DATA_HOME/cleo/signaldock.db:agents` table; per-project
- * visibility and overrides live in the PROJECT
- * `.cleo/conduit.db:project_agent_refs` table.
+ * Post-T310 (ADR-037), agent identity lives in the GLOBAL `agents` table;
+ * per-project visibility and overrides live in the PROJECT
+ * `project_agent_refs` table.
+ *
+ * Post-E6-L5 (T11525) / E6-L6 (T11526), both tables are hosted inside the
+ * CONSOLIDATED dual-scope `cleo.db` files (global `$XDG_DATA_HOME/cleo/cleo.db`
+ * and project `.cleo/cleo.db`) — the standalone `signaldock.db` / `conduit.db`
+ * files are gone. The bare `agents` / `project_agent_refs` runtime tables are
+ * materialized into `cleo.db` by `ensureGlobalSignaldockDb()` /
+ * `ensureConduitDb()` (legacy drizzle migrations), which co-exist with the
+ * prefixed `signaldock_*` / `conduit_*` consolidated tables. The read path MUST
+ * therefore go through those `ensure*` calls so it shares the same handle as the
+ * write path (T11562 — agents read/write path divergence regression).
  *
  * This module provides three module-level functions that perform the
  * in-memory cross-DB join, plus the backward-compatible
  * `AgentRegistryAccessor` class that wraps them.
  *
  * Architecture:
- *   global  signaldock.db — canonical identity (openGlobalDb)
- *   project conduit.db    — project_agent_refs  (openConduitDb)
+ *   global  cleo.db — canonical identity `agents` (openGlobalDb → ensureGlobalSignaldockDb)
+ *   project cleo.db — `project_agent_refs`        (openConduitDb)
  *   Join performed in Node (SQLite cannot cross-file-handle JOIN).
  *
  * @see .cleo/rcasd/T310/specification/T310-specification.md §3.5
  * @see .cleo/adrs/ADR-037-conduit-signaldock-separation.md
  * @task T355
+ * @task T11562
  * @epic T310
+ * @epic T11249
  */
 
 import { randomBytes } from 'node:crypto';
@@ -41,7 +52,7 @@ import { getCleoHome } from '../paths.js';
 import { deriveApiKey } from './api-key-kdf.js';
 import { ensureConduitDb, getConduitDbPath } from './conduit-sqlite.js';
 import { getGlobalSalt } from './global-salt.js';
-import { ensureGlobalSignaldockDb, getGlobalSignaldockDbPath } from './signaldock-sqlite.js';
+import { ensureGlobalSignaldockDb, getGlobalSignaldockNativeDb } from './signaldock-sqlite.js';
 import { applyPerfPragmas } from './sqlite-pragmas.js';
 
 // ---------------------------------------------------------------------------
@@ -323,16 +334,47 @@ function mergeToAgentWithOverride(
 // ---------------------------------------------------------------------------
 
 /**
- * Open a short-lived read/write handle to the GLOBAL signaldock.db.
- * Caller MUST call `db.close()` when done.
+ * Acquire the SHARED, fully-migrated handle to the GLOBAL agent identity DB —
+ * the consolidated dual-scope global `cleo.db` (post-E6-L5 / T11525).
  *
+ * Routes through {@link ensureGlobalSignaldockDb}, which opens the consolidated
+ * `cleo.db` via `openDualScopeDb('global')`, runs the legacy `drizzle-signaldock`
+ * migrations that materialize the BARE `agents` runtime table (the table this
+ * accessor's raw SQL queries), and stores the native handle for reuse. The
+ * returned handle is the SAME one the write path uses — reads and writes are now
+ * aligned to `cleo.db` (T11562).
+ *
+ * Replaces the previous `new DatabaseSync(getGlobalSignaldockDbPath())` raw-open,
+ * which diverged from the write path: it opened `cleo.db` WITHOUT first running
+ * the legacy migrations, so the bare `agents` table did not exist on a clean
+ * build (`no such table: agents`).
+ *
+ * The handle is SHARED and co-owned by the nexus / skills global domains — its
+ * lifecycle is owned by `openDualScopeDb`. Callers MUST NOT call `db.close()` on
+ * it (doing so would break in-flight sibling queries). This is why every former
+ * `globalDb.close()` in this module was removed (T11562).
+ *
+ * @returns The shared consolidated global `cleo.db` native handle.
+ * @throws {Error} If the shared handle is unexpectedly absent after ensure.
  * @task T355
+ * @task T11562
  * @epic T310
+ * @epic T11249
  */
-function openGlobalDb(): DatabaseSync {
-  const dbPath = getGlobalSignaldockDbPath();
-  const db = new DatabaseSync(dbPath);
-  applyPerfPragmas(db); // replaces inline PRAGMA calls with SSoT set (T9023)
+async function openGlobalDb(): Promise<DatabaseSync> {
+  // Idempotent: opens the consolidated global cleo.db, runs the legacy
+  // signaldock migrations (creates the bare `agents` table), and caches the
+  // shared native handle in _globalSignaldockNativeDb.
+  await ensureGlobalSignaldockDb();
+  const db = getGlobalSignaldockNativeDb();
+  if (!db) {
+    throw new Error(
+      'openGlobalDb: ensureGlobalSignaldockDb() did not yield a shared global ' +
+        'cleo.db handle (getGlobalSignaldockNativeDb() returned null). This indicates ' +
+        'the dual-scope global chokepoint failed to initialize — fix the caller, do ' +
+        'not suppress.',
+    );
+  }
   return db;
 }
 
@@ -416,22 +458,36 @@ function syncJunctionTables(
  * Dangling soft-FK detection: if a project_agent_refs row exists but the
  * referenced global agent does not, logs a WARN and returns null.
  *
+ * Both `agents` (global) and `project_agent_refs` (project) tables are
+ * materialized into their consolidated `cleo.db` files lazily, so this function
+ * ensures both DBs (via the shared `openGlobalDb` / `ensureConduitDb`
+ * chokepoints) before reading — keeping the read path aligned with the write
+ * path (T11562). It is therefore async.
+ *
  * @param projectRoot     - Absolute path to the project root directory.
  * @param agentId         - Agent business identifier.
  * @param opts.includeGlobal - When true, returns global identity even without project ref.
  * @returns Merged agent record or null if not found.
  *
  * @task T355
+ * @task T11562
  * @epic T310
+ * @epic T11249
  */
-export function lookupAgent(
+export async function lookupAgent(
   projectRoot: string,
   agentId: string,
   opts?: { includeGlobal?: boolean },
-): AgentWithProjectOverride | null {
+): Promise<AgentWithProjectOverride | null> {
   const includeGlobal = opts?.includeGlobal ?? false;
 
-  const globalDb = openGlobalDb();
+  // Ensure the consolidated project cleo.db has the bare `project_agent_refs`
+  // table before the raw-open read below (mirrors the global side, which is
+  // ensured inside openGlobalDb).
+  await ensureConduitDb(projectRoot);
+
+  // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
+  const globalDb = await openGlobalDb();
   const conduitDb = openConduitDb(projectRoot);
 
   try {
@@ -447,7 +503,7 @@ export function lookupAgent(
     if (refRow && !agentRow) {
       console.warn(
         `[agent-registry-accessor] WARN: dangling project_agent_refs row for agent_id="${agentId}". ` +
-          `No matching row in global signaldock.db:agents. Row will be ignored.`,
+          `No matching row in global cleo.db:agents. Row will be ignored.`,
       );
       return null;
     }
@@ -465,7 +521,7 @@ export function lookupAgent(
     const effectiveRef = refRow && refRow.enabled === 1 ? refRow : null;
     return mergeToAgentWithOverride(agentRow, effectiveRef);
   } finally {
-    globalDb.close();
+    // NOTE: globalDb is the SHARED dual-scope handle — never close it (T11562).
     conduitDb.close();
   }
 }
@@ -482,22 +538,36 @@ export function lookupAgent(
  * includeDisabled=true: also returns agents with enabled=0 in project_agent_refs.
  * Ignored when includeGlobal=true (all global agents are returned regardless).
  *
+ * Both `agents` (global) and `project_agent_refs` (project) tables are
+ * materialized into their consolidated `cleo.db` files lazily, so this function
+ * ensures both DBs (via the shared `openGlobalDb` / `ensureConduitDb`
+ * chokepoints) before reading — keeping the read path aligned with the write
+ * path (T11562). It is therefore async.
+ *
  * @param projectRoot            - Absolute path to the project root directory.
  * @param opts.includeGlobal     - Include all global agents (bypasses project filter).
  * @param opts.includeDisabled   - Include agents with enabled=0 in project_agent_refs.
  * @returns Array of merged agent records.
  *
  * @task T355
+ * @task T11562
  * @epic T310
+ * @epic T11249
  */
-export function listAgentsForProject(
+export async function listAgentsForProject(
   projectRoot: string,
   opts?: { includeGlobal?: boolean; includeDisabled?: boolean },
-): AgentWithProjectOverride[] {
+): Promise<AgentWithProjectOverride[]> {
   const includeGlobal = opts?.includeGlobal ?? false;
   const includeDisabled = opts?.includeDisabled ?? false;
 
-  const globalDb = openGlobalDb();
+  // Ensure the consolidated project cleo.db has the bare `project_agent_refs`
+  // table before the raw-open read below (mirrors the global side, which is
+  // ensured inside openGlobalDb).
+  await ensureConduitDb(projectRoot);
+
+  // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
+  const globalDb = await openGlobalDb();
   const conduitDb = openConduitDb(projectRoot);
 
   try {
@@ -534,7 +604,7 @@ export function listAgentsForProject(
 
     return result;
   } finally {
-    globalDb.close();
+    // NOTE: globalDb is the SHARED dual-scope handle — never close it (T11562).
     conduitDb.close();
   }
 }
@@ -579,8 +649,9 @@ export async function createProjectAgent(
   // Store as hex string in the encrypted column
   const apiKeyEncrypted = derivedKey.toString('hex');
 
-  const globalDb = openGlobalDb();
-  try {
+  // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
+  const globalDb = await openGlobalDb();
+  {
     const existing = globalDb
       .prepare('SELECT id FROM agents WHERE agent_id = ?')
       .get(spec.agentId) as { id: string } | undefined;
@@ -641,9 +712,8 @@ export async function createProjectAgent(
         );
       syncJunctionTables(globalDb, agentUuid, spec.capabilities, spec.skills);
     }
-  } finally {
-    globalDb.close();
   }
+  // NOTE: globalDb is the SHARED dual-scope handle — never close it (T11562).
 
   // Attach to project via conduit.db:project_agent_refs
   const conduitDb = openConduitDb(projectRoot);
@@ -670,7 +740,7 @@ export async function createProjectAgent(
     conduitDb.close();
   }
 
-  const result = lookupAgent(projectRoot, spec.agentId, { includeGlobal: false });
+  const result = await lookupAgent(projectRoot, spec.agentId, { includeGlobal: false });
   if (!result) {
     throw new Error(`createProjectAgent: failed to retrieve agent after creation: ${spec.agentId}`);
   }
@@ -866,7 +936,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    */
   async list(filter?: AgentListFilter): Promise<AgentCredential[]> {
     await this.ensureDbs();
-    const results = listAgentsForProject(this.projectPath, { includeGlobal: false });
+    const results = await listAgentsForProject(this.projectPath, { includeGlobal: false });
     if (filter?.active !== undefined) {
       return results.filter((a) => a.isActive === filter.active);
     }
@@ -883,20 +953,17 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    */
   async listGlobal(filter?: AgentListFilter): Promise<AgentCredential[]> {
     await this.ensureDbs();
-    const globalDb = openGlobalDb();
-    try {
-      const rows =
-        filter?.active !== undefined
-          ? (globalDb
-              .prepare('SELECT * FROM agents WHERE is_active = ? ORDER BY name ASC')
-              .all(filter.active ? 1 : 0) as unknown as AgentDbRow[])
-          : (globalDb
-              .prepare('SELECT * FROM agents ORDER BY name ASC')
-              .all() as unknown as AgentDbRow[]);
-      return rows.map(rowToCredential);
-    } finally {
-      globalDb.close();
-    }
+    // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
+    const globalDb = await openGlobalDb();
+    const rows =
+      filter?.active !== undefined
+        ? (globalDb
+            .prepare('SELECT * FROM agents WHERE is_active = ? ORDER BY name ASC')
+            .all(filter.active ? 1 : 0) as unknown as AgentDbRow[])
+        : (globalDb
+            .prepare('SELECT * FROM agents ORDER BY name ASC')
+            .all() as unknown as AgentDbRow[]);
+    return rows.map(rowToCredential);
   }
 
   /**
@@ -919,8 +986,9 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
     if (!existing) throw new Error(`Agent not found: ${agentId}`);
 
     const nowTs = Math.floor(Date.now() / 1000);
-    const globalDb = openGlobalDb();
-    try {
+    // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
+    const globalDb = await openGlobalDb();
+    {
       const sets: string[] = ['updated_at = ?'];
       const params: unknown[] = [nowTs];
 
@@ -988,9 +1056,8 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
           );
         }
       }
-    } finally {
-      globalDb.close();
     }
+    // NOTE: globalDb is the SHARED dual-scope handle — never close it (T11562).
 
     const result = await this.get(agentId, { includeGlobal: true });
     if (!result) throw new Error(`Agent not found after update: ${agentId}`);
@@ -1035,37 +1102,35 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
    */
   async removeGlobal(agentId: string, opts?: { force?: boolean }): Promise<void> {
     await this.ensureDbs();
-    const globalDb = openGlobalDb();
-    try {
-      const existing = globalDb.prepare('SELECT id FROM agents WHERE agent_id = ?').get(agentId) as
-        | { id: string }
-        | undefined;
-      if (!existing) {
-        throw new Error(`Agent not found globally: ${agentId}`);
-      }
-
-      if (!opts?.force) {
-        // Best-effort cross-project scan: check the current project's conduit.db
-        const conduitDb = openConduitDb(this.projectPath);
-        try {
-          const ref = conduitDb
-            .prepare('SELECT agent_id FROM project_agent_refs WHERE agent_id = ? AND enabled = 1')
-            .get(agentId) as { agent_id: string } | undefined;
-          if (ref) {
-            throw new Error(
-              `Agent "${agentId}" still has project references in the current project. ` +
-                `Use removeGlobal(id, { force: true }) to skip this check.`,
-            );
-          }
-        } finally {
-          conduitDb.close();
-        }
-      }
-
-      globalDb.prepare('DELETE FROM agents WHERE agent_id = ?').run(agentId);
-    } finally {
-      globalDb.close();
+    // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
+    const globalDb = await openGlobalDb();
+    const existing = globalDb.prepare('SELECT id FROM agents WHERE agent_id = ?').get(agentId) as
+      | { id: string }
+      | undefined;
+    if (!existing) {
+      throw new Error(`Agent not found globally: ${agentId}`);
     }
+
+    if (!opts?.force) {
+      // Best-effort cross-project scan: check the current project's conduit.db
+      const conduitDb = openConduitDb(this.projectPath);
+      try {
+        const ref = conduitDb
+          .prepare('SELECT agent_id FROM project_agent_refs WHERE agent_id = ? AND enabled = 1')
+          .get(agentId) as { agent_id: string } | undefined;
+        if (ref) {
+          throw new Error(
+            `Agent "${agentId}" still has project references in the current project. ` +
+              `Use removeGlobal(id, { force: true }) to skip this check.`,
+          );
+        }
+      } finally {
+        conduitDb.close();
+      }
+    }
+
+    globalDb.prepare('DELETE FROM agents WHERE agent_id = ?').run(agentId);
+    // NOTE: globalDb is the SHARED dual-scope handle — never close it (T11562).
   }
 
   /**
@@ -1104,16 +1169,14 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
     const derivedKey = deriveApiKey({ machineKey, globalSalt, agentId });
     const nowTs = Math.floor(Date.now() / 1000);
 
-    const globalDb = openGlobalDb();
-    try {
-      globalDb
-        .prepare(
-          'UPDATE agents SET api_key_encrypted = ?, updated_at = ?, requires_reauth = 0 WHERE agent_id = ?',
-        )
-        .run(derivedKey.toString('hex'), nowTs, agentId);
-    } finally {
-      globalDb.close();
-    }
+    // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
+    const globalDb = await openGlobalDb();
+    globalDb
+      .prepare(
+        'UPDATE agents SET api_key_encrypted = ?, updated_at = ?, requires_reauth = 0 WHERE agent_id = ?',
+      )
+      .run(derivedKey.toString('hex'), nowTs, agentId);
+    // NOTE: globalDb is the SHARED dual-scope handle — never close it (T11562).
 
     return { agentId, newApiKey: `${newApiKey.substring(0, 8)}...rotated` };
   }
@@ -1128,7 +1191,8 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
   async getActive(): Promise<AgentCredential | null> {
     await this.ensureDbs();
 
-    const globalDb = openGlobalDb();
+    // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
+    const globalDb = await openGlobalDb();
     const conduitDb = openConduitDb(this.projectPath);
     try {
       // Get all project-attached, enabled agent IDs ordered by project last_used_at
@@ -1154,7 +1218,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
       if (!row) return null;
       return rowToCredential(row);
     } finally {
-      globalDb.close();
+      // NOTE: globalDb is the SHARED dual-scope handle — never close it (T11562).
       conduitDb.close();
     }
   }
@@ -1172,14 +1236,12 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
     const nowTs = Math.floor(Date.now() / 1000);
     const nowIso = new Date(nowTs * 1000).toISOString();
 
-    const globalDb = openGlobalDb();
-    try {
-      globalDb
-        .prepare('UPDATE agents SET last_used_at = ?, updated_at = ? WHERE agent_id = ?')
-        .run(nowTs, nowTs, agentId);
-    } finally {
-      globalDb.close();
-    }
+    // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
+    const globalDb = await openGlobalDb();
+    globalDb
+      .prepare('UPDATE agents SET last_used_at = ?, updated_at = ? WHERE agent_id = ?')
+      .run(nowTs, nowTs, agentId);
+    // NOTE: globalDb is the SHARED dual-scope handle — never close it (T11562).
 
     const conduitDb = openConduitDb(this.projectPath);
     try {


### PR DESCRIPTION
## Problem (P1 regression — found by E6-L6 #907)

E6-L5 (#905) routed signaldock **writes** through `openDualScopeDb('global')` into the consolidated global `cleo.db`, but `agent-registry-accessor.ts::openGlobalDb()` still raw-opened `cleo.db` directly **without** running `ensureGlobalSignaldockDb()` first.

The bare `agents` runtime table is materialized into `cleo.db` **only** by the legacy `drizzle-signaldock` migrations that `ensureGlobalSignaldockDb()` runs. So on a clean build whose read path is hit first, `cleo.db` has only the prefixed `signaldock_*` tables and the read throws `no such table: agents`. The agents **read** path had diverged from the **write** path.

Reproduced live: the installed CLI throws `Error: no such table: agents` for `cleo agent list --global` on a clean `XDG_DATA_HOME`.

## Fix

`openGlobalDb()` now `await ensureGlobalSignaldockDb()` and returns the **shared** `getGlobalSignaldockNativeDb()` handle — reads + writes both hit the consolidated `cleo.db`. The shared dual-scope handle is co-owned by the nexus/skills domains, so every former `globalDb.close()` was removed (lifecycle owned by `openDualScopeDb`).

The standalone `lookupAgent` / `listAgentsForProject` become async and also `ensureConduitDb()` before raw-opening the project `cleo.db`, mirroring the global side. Three `agent.ts` CLI callers updated to `await`.

## Acceptance

- [x] `openGlobalDb` routes to consolidated `cleo.db` (reads+writes aligned)
- [x] legacy `getGlobalSignaldockDbPath()` raw-open removed from the live read path
- [x] regression tests: write→read round-trip on consolidated `cleo.db` + read-first scenario asserting the bare `agents` table is materialized (no `no such table: agents`)
- [x] FULL vitest `@cleocode/core` + `@cleocode/runtime`: zero new failures (16 pre-existing worktree-napi/conduit-fallback env flakes, identical on stashed `origin/main` baseline)
- [x] `cleo check arch`: 5/5 gates pass (incl. Gate 2 no-direct-db-open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)