### PR TITLE
refactor(T11528): remove obsolete migration-manager hash-drift Sub-case B (E6-L8)

### DIFF
--- a/.changeset/t11528-e6-l8-migration-manager-hash-drift.md
+++ b/.changeset/t11528-e6-l8-migration-manager-hash-drift.md
@@ -1,0 +1,8 @@
+---
+id: t11528-e6-l8-migration-manager-hash-drift
+tasks: [T11528]
+kind: refactor
+summary: remove obsolete migration-manager hash-drift Sub-case B (E6-L8) now that all DDL is owned by immutable Drizzle forward migrations
+---
+
+E6-L8 of the SG-DB-SUBSTRATE-V2 store rewrite (saga T11242, epic T11249). Removes the post-hoc hash-drift repair sub-case in reconcileJournal that UPDATEd a journal entry hash in place when its name matched a local migration but its hash differed. Migration files are immutable post-release (Drizzle v1.0.0-rc.3 contract, E6 L1-L7), so name-matched hash drift can no longer occur. reconcileJournal now has exactly two Scenario-2 sub-cases: A (DB-ahead skip) and B (true-orphan delete + re-probe). Tests rewritten to pin the two-sub-case contract.

--- a/packages/core/src/store/__tests__/migration-hash-drift.test.ts
+++ b/packages/core/src/store/__tests__/migration-hash-drift.test.ts
@@ -1,18 +1,20 @@
 /**
- * Regression test for the migration journal hash-drift recovery.
+ * Regression test for reconcileJournal orphan handling.
  *
- * Pre-fix bug (v2026.5.128): when a release modifies an existing migration's
- * SQL, drizzle's content-hash changes. reconcileJournal saw the DB's old hash
- * as "orphaned" (not in local) and the local's new hash as "missing in DB",
- * matched both conditions, and triggered Sub-case B which DELETEd the entire
- * journal and re-probed every migration via DDL. Data-only migrations (UPDATEs,
- * INSERTs) that couldn't be probed were left unjournaled and re-run by drizzle,
- * crashing the migrate() call.
+ * History: an earlier release (v2026.5.128) introduced a "hash-drift" recovery
+ * path that, when a journal entry's NAME matched a local migration but its hash
+ * differed (because the migration file's SQL was edited in a release), UPDATEd
+ * the journal entry's hash in place rather than deleting it.
  *
- * Fix (v2026.5.129): partition orphans by NAME match. Entries whose name
- * matches a local migration but whose hash differs are HASH DRIFT — UPDATE the
- * entry's hash in place. Only entries with no name match are true orphans and
- * fall through to the delete+probe path.
+ * T11528 (E6-L8): that hash-drift sub-case was removed. All DDL is now owned by
+ * immutable Drizzle forward migrations (v1.0.0-rc.3 contract, E6 L1-L7);
+ * migration files are never edited post-release, so name-matched hash drift can
+ * no longer occur. reconcileJournal now has exactly two Scenario-2 sub-cases:
+ *
+ *   A) DB AHEAD — all local hashes present plus extra orphans → skip (no mutation).
+ *   B) TRUE ORPHANS — orphan hashes with no local match → delete + re-probe via DDL.
+ *
+ * These tests pin that two-sub-case contract.
  */
 
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -28,18 +30,18 @@ function getTasksMigrationsFolder(): string {
   return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
 }
 
-describe('reconcileJournal — hash-drift recovery', () => {
+describe('reconcileJournal — orphan reconciliation (post hash-drift removal)', () => {
   let tempDir: string;
 
   beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), 'cleo-hash-drift-'));
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-orphan-reconcile-'));
   });
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('updates hash in place when a known migration name has a stale hash', async () => {
+  it('Sub-case A: skips reconciliation (no mutation) when the DB is ahead of this install', async () => {
     const { openNativeDatabase } = await import('../sqlite.js');
     const { reconcileJournal } = await import('../migration-manager.js');
     const { readMigrationFiles } = await import('drizzle-orm/migrator');
@@ -47,69 +49,7 @@ describe('reconcileJournal — hash-drift recovery', () => {
     const migrationsFolder = getTasksMigrationsFolder();
     const localMigrations = readMigrationFiles({ migrationsFolder });
 
-    // Pick t033 — modified by v2026.5.128, so it's the canonical drift case.
-    const targetMig = localMigrations.find((m) => m.name?.includes('t033'));
-    expect(targetMig, 'expected t033 migration to exist').toBeDefined();
-    const newHash = targetMig!.hash;
-    const staleHash = 'b928367a3ec05fcc0ef24e36af5dbca5323a0a806eaf33f8860f2cded54e2b74';
-    expect(newHash).not.toBe(staleHash);
-
-    const dbPath = join(tempDir, 'drift.db');
-    const nativeDb = openNativeDatabase(dbPath);
-
-    nativeDb.exec(
-      `CREATE TABLE IF NOT EXISTS tasks (id text PRIMARY KEY, title text NOT NULL, status text DEFAULT 'pending' NOT NULL);`,
-    );
-
-    nativeDb.exec(`
-      CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        hash text NOT NULL,
-        created_at numeric,
-        name text,
-        applied_at TEXT
-      )
-    `);
-    for (const m of localMigrations) {
-      const hash = m === targetMig ? staleHash : m.hash;
-      nativeDb.exec(
-        `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${hash}', ${m.folderMillis}, '${m.name ?? ''}')`,
-      );
-    }
-
-    const journalSizeBefore = (
-      nativeDb.prepare('SELECT COUNT(*) AS n FROM "__drizzle_migrations"').get() as { n: number }
-    ).n;
-    expect(journalSizeBefore).toBe(localMigrations.length);
-
-    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
-
-    const journalSizeAfter = (
-      nativeDb.prepare('SELECT COUNT(*) AS n FROM "__drizzle_migrations"').get() as { n: number }
-    ).n;
-    expect(
-      journalSizeAfter,
-      'reconcileJournal must NOT delete entries — drift entries should be updated in place',
-    ).toBe(journalSizeBefore);
-
-    const t033Row = nativeDb
-      .prepare('SELECT hash FROM "__drizzle_migrations" WHERE name = ?')
-      .get(targetMig!.name) as { hash: string } | undefined;
-    expect(t033Row?.hash, 'drifted entry must be updated to new hash').toBe(newHash);
-
-    nativeDb.close();
-  });
-
-  it('does NOT wipe the journal when SQL edits change one hash', async () => {
-    const { openNativeDatabase } = await import('../sqlite.js');
-    const { reconcileJournal } = await import('../migration-manager.js');
-    const { readMigrationFiles } = await import('drizzle-orm/migrator');
-
-    const migrationsFolder = getTasksMigrationsFolder();
-    const localMigrations = readMigrationFiles({ migrationsFolder });
-    const targetMig = localMigrations.find((m) => m.name?.includes('t033'));
-
-    const dbPath = join(tempDir, 'no-wipe.db');
+    const dbPath = join(tempDir, 'db-ahead.db');
     const nativeDb = openNativeDatabase(dbPath);
     nativeDb.exec(`CREATE TABLE tasks (id text PRIMARY KEY, title text NOT NULL);`);
     nativeDb.exec(`
@@ -121,11 +61,64 @@ describe('reconcileJournal — hash-drift recovery', () => {
         applied_at TEXT
       )
     `);
+    // Seed every local migration (all local hashes present in DB) PLUS one extra
+    // entry for a future migration this install does not know about. This is the
+    // "DB ahead" / forward-compatibility case → reconcileJournal must NOT touch it.
     for (const m of localMigrations) {
-      const hash =
-        m === targetMig
-          ? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-          : m.hash;
+      nativeDb.exec(
+        `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${m.hash}', ${m.folderMillis}, '${m.name ?? ''}')`,
+      );
+    }
+    nativeDb.exec(
+      `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('feedface000000000000000000000000000000000000000000000000feedface', 99999999999999, '99999999999999_future-migration-from-newer-cleo')`,
+    );
+
+    const before = nativeDb.prepare('SELECT id, hash, name FROM "__drizzle_migrations"').all();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+
+    const after = nativeDb.prepare('SELECT id, hash, name FROM "__drizzle_migrations"').all();
+    expect(after, 'DB-ahead reconciliation must be a no-op (journal untouched)').toEqual(before);
+
+    nativeDb.close();
+  });
+
+  it('Sub-case B: a name-matched stale hash is treated as a true orphan and deleted (NOT updated in place)', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { reconcileJournal } = await import('../migration-manager.js');
+    const { readMigrationFiles } = await import('drizzle-orm/migrator');
+
+    const migrationsFolder = getTasksMigrationsFolder();
+    const localMigrations = readMigrationFiles({ migrationsFolder });
+
+    // Pick t033 — the migration that, historically, the hash-drift path targeted.
+    const targetMig = localMigrations.find((m) => m.name?.includes('t033'));
+    expect(targetMig, 'expected t033 migration to exist').toBeDefined();
+    const newHash = targetMig!.hash;
+    const staleHash = 'b928367a3ec05fcc0ef24e36af5dbca5323a0a806eaf33f8860f2cded54e2b74';
+    expect(newHash).not.toBe(staleHash);
+
+    const dbPath = join(tempDir, 'stale-hash.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    // Minimal schema: t033's DDL targets are absent, so probeAndMarkApplied cannot
+    // re-journal it. This makes the deletion observable.
+    nativeDb.exec(
+      `CREATE TABLE IF NOT EXISTS tasks (id text PRIMARY KEY, title text NOT NULL, status text DEFAULT 'pending' NOT NULL);`,
+    );
+    nativeDb.exec(`
+      CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        hash text NOT NULL,
+        created_at numeric,
+        name text,
+        applied_at TEXT
+      )
+    `);
+    // Seed every local migration; give t033 a stale hash so it is name-matched
+    // but hash-orphaned. Because t033's NEW hash is absent from the DB,
+    // allLocalHashesPresentInDb is false → Sub-case B (true orphan) fires.
+    for (const m of localMigrations) {
+      const hash = m === targetMig ? staleHash : m.hash;
       nativeDb.exec(
         `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${hash}', ${m.folderMillis}, '${m.name ?? ''}')`,
       );
@@ -133,23 +126,26 @@ describe('reconcileJournal — hash-drift recovery', () => {
 
     reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
 
-    // Every name-matched local migration's hash must end up in the journal.
-    const remainingHashes = new Set(
+    // The stale-hash entry must be DELETED (the removed hash-drift path would have
+    // UPDATEd it to newHash in place). With the DDL targets absent, t033 cannot be
+    // re-probed, so no row carries either the stale or the new hash.
+    const hashesAfter = new Set(
       (
         nativeDb.prepare('SELECT hash FROM "__drizzle_migrations"').all() as Array<{ hash: string }>
       ).map((r) => r.hash),
     );
-    for (const m of localMigrations) {
-      expect(
-        remainingHashes.has(m.hash),
-        `migration ${m.name} (hash ${m.hash.slice(0, 12)}) must remain journaled after reconcile`,
-      ).toBe(true);
-    }
+    expect(hashesAfter.has(staleHash), 'stale-hash orphan must be deleted, not retained').toBe(
+      false,
+    );
+    expect(
+      hashesAfter.has(newHash),
+      'hash drift is no longer repaired in place — t033 is not re-journaled when its DDL is absent',
+    ).toBe(false);
 
     nativeDb.close();
   });
 
-  it('deletes true orphans (entry whose name has no local match) when some local hashes are missing too', async () => {
+  it('Sub-case B: deletes a true orphan (name with no local match) and preserves applied local migrations', async () => {
     const { openNativeDatabase } = await import('../sqlite.js');
     const { reconcileJournal } = await import('../migration-manager.js');
     const { readMigrationFiles } = await import('drizzle-orm/migrator');
@@ -171,9 +167,9 @@ describe('reconcileJournal — hash-drift recovery', () => {
     `);
     // Seed every local migration EXCEPT the last one. This makes the DB look
     // like a slightly-older install where one new migration hasn't run yet.
-    // Then add a true orphan with no name match. Because the last local
-    // migration's hash is absent, allLocalHashesPresentInDb is false → Sub-case
-    // B fires → true-orphan branch processes the orphan.
+    // Then add a true orphan whose hash has no local match. Because the last
+    // local migration's hash is absent, allLocalHashesPresentInDb is false →
+    // Sub-case B fires → the orphan is deleted.
     const seedMigrations = localMigrations.slice(0, -1);
     for (const m of seedMigrations) {
       nativeDb.exec(

--- a/packages/core/src/store/migration-manager.ts
+++ b/packages/core/src/store/migration-manager.ts
@@ -300,7 +300,7 @@ export function reconcileJournal(
 
   // Scenario 2: Journal has orphaned entries from a previous CLEO version
   //
-  // Three distinct sub-cases require different handling:
+  // Two distinct sub-cases require different handling:
   //
   // A) DB is AHEAD of this install (forward-compatibility): all local hashes
   //    are present in the DB, but the DB also has additional entries for
@@ -312,40 +312,25 @@ export function reconcileJournal(
   //    them back — only for this install to delete them again on the next run.
   //    ACTION: skip reconciliation, log at debug only.
   //
-  // B) HASH DRIFT — orphan entries have a NAME that matches a local migration
-  //    but a different hash. This happens when a migration file's SQL is
-  //    modified in a release (e.g. v2026.5.128's t033 idempotency fix). The
-  //    migration was applied with the old SQL; the new SQL is logically the
-  //    same migration. Wiping the journal would force every migration to be
-  //    re-probed, which fails for data-only migrations whose DDL can't be
-  //    probed. ACTION: UPDATE the entry's hash in place. The migration stays
-  //    applied; only the hash is brought forward.
+  // B) TRUE ORPHANS — orphan entries that do not correspond to any local
+  //    migration hash (the migration file was removed from disk, or the journal
+  //    is from a fundamentally different cleo lineage). ACTION: delete the
+  //    orphaned entries and re-probe local migrations via DDL.
   //
-  // C) TRUE ORPHANS — entries whose name has no local match (the migration
-  //    file was removed from disk, or the journal is from a fundamentally
-  //    different cleo lineage). ACTION: delete + re-probe via DDL.
+  // NOTE (T11528): the former hash-drift sub-case — which UPDATEd a journal
+  // entry's hash in place when its NAME matched a local migration but its hash
+  // differed — was removed once all DDL became owned by immutable Drizzle
+  // forward migrations (v1.0.0-rc.3 contract, E6 L1-L7). Migrations are no
+  // longer edited post-release, so name-matched hash drift can no longer occur;
+  // any remaining orphan is a true orphan handled by Sub-case B below.
   if (tableExists(nativeDb, '__drizzle_migrations') && tableExists(nativeDb, existenceTable)) {
     const localMigrations = readMigrationFiles({ migrationsFolder });
     const localHashes = new Set(localMigrations.map((m) => m.hash));
-    const localByName = new Map(localMigrations.map((m) => [m.name ?? '', m]));
 
-    // Read full entries with hash, name, id. Older journals may lack `name`;
-    // those entries fall through to true-orphan handling below.
-    const migCols = nativeDb.prepare('PRAGMA table_info("__drizzle_migrations")').all() as Array<{
-      name: string;
-    }>;
-    const hasMigNameCol = migCols.some((c) => c.name === 'name');
-    type JournalRow = { id: number; hash: string; name: string | null };
-    const dbEntries: JournalRow[] = hasMigNameCol
-      ? (nativeDb
-          .prepare('SELECT id, hash, name FROM "__drizzle_migrations"')
-          .all() as JournalRow[])
-      : (
-          nativeDb.prepare('SELECT id, hash FROM "__drizzle_migrations"').all() as Array<{
-            id: number;
-            hash: string;
-          }>
-        ).map((r) => ({ ...r, name: null }));
+    type JournalRow = { id: number; hash: string };
+    const dbEntries = nativeDb
+      .prepare('SELECT id, hash FROM "__drizzle_migrations"')
+      .all() as JournalRow[];
 
     const orphanedEntries = dbEntries.filter((e) => !localHashes.has(e.hash));
     const hasOrphanedEntries = orphanedEntries.length > 0;
@@ -354,73 +339,37 @@ export function reconcileJournal(
       const dbHashes = new Set(dbEntries.map((e) => e.hash));
       const allLocalHashesPresentInDb = localMigrations.every((m) => dbHashes.has(m.hash));
 
+      const log = getLogger(logSubsystem);
+
       if (allLocalHashesPresentInDb) {
         // Sub-case A: DB is ahead — this install is older than the DB.
         // Do NOT modify the journal; log at debug so we can trace if needed.
-        const log = getLogger(logSubsystem);
         log.debug(
           { extra: orphanedEntries.length },
           `Migration journal has ${orphanedEntries.length} entries for migrations not known to this install (DB is ahead). Skipping reconciliation.`,
         );
       } else {
-        // Partition orphans into hash-drift (name-matched) vs true orphans.
-        const driftEntries: Array<{ row: JournalRow; newHash: string }> = [];
-        const trueOrphanEntries: JournalRow[] = [];
-        for (const orphan of orphanedEntries) {
-          const localMatch = orphan.name ? localByName.get(orphan.name) : undefined;
-          if (localMatch && localMatch.hash !== orphan.hash) {
-            driftEntries.push({ row: orphan, newHash: localMatch.hash });
-          } else {
-            trueOrphanEntries.push(orphan);
-          }
-        }
-
-        const log = getLogger(logSubsystem);
-
-        // Sub-case B: HASH DRIFT — UPDATE hash in place. The migration was
-        // applied; the SQL has been edited in a release; the journal entry
-        // is logically correct, only its hash is stale.
-        if (driftEntries.length > 0) {
-          log.warn(
-            {
-              drifted: driftEntries.length,
-              names: driftEntries.map((d) => d.row.name),
-            },
-            `Detected ${driftEntries.length} hash-drift journal entries (migration SQL edited in a release). Updating hashes in place.`,
-          );
-          const updateStmt = nativeDb.prepare(
-            'UPDATE "__drizzle_migrations" SET hash = ? WHERE id = ?',
-          );
-          for (const { row, newHash } of driftEntries) {
-            updateStmt.run(newHash, row.id);
-          }
-        }
-
-        // Sub-case C: TRUE ORPHANS — entries whose name has no local match.
-        // Only NOW do we fall back to the legacy delete+re-probe path, and
-        // only for the truly-orphaned entries.
-        if (trueOrphanEntries.length > 0) {
-          log.warn(
-            { orphaned: trueOrphanEntries.length },
-            `Detected ${trueOrphanEntries.length} true-orphan journal entries from a previous CLEO lineage. Reconciling via DDL probe.`,
-          );
-          const deleteStmt = nativeDb.prepare('DELETE FROM "__drizzle_migrations" WHERE id = ?');
-          for (const e of trueOrphanEntries) deleteStmt.run(e.id);
-          // Re-probe local migrations that may now have no journal entry.
-          // The previous implementation cleared the WHOLE journal here; the
-          // selective delete above keeps every applied migration journaled,
-          // so the probe only inserts entries for genuinely missing ones.
-          const journaledHashesAfter = new Set(
-            (
-              nativeDb.prepare('SELECT hash FROM "__drizzle_migrations"').all() as Array<{
-                hash: string;
-              }>
-            ).map((r) => r.hash),
-          );
-          for (const m of localMigrations) {
-            if (journaledHashesAfter.has(m.hash)) continue;
-            probeAndMarkApplied(nativeDb, m, logSubsystem);
-          }
+        // Sub-case B: TRUE ORPHANS — entries whose hash has no local match.
+        // Delete them and re-probe local migrations via DDL.
+        log.warn(
+          { orphaned: orphanedEntries.length },
+          `Detected ${orphanedEntries.length} true-orphan journal entries from a previous CLEO lineage. Reconciling via DDL probe.`,
+        );
+        const deleteStmt = nativeDb.prepare('DELETE FROM "__drizzle_migrations" WHERE id = ?');
+        for (const e of orphanedEntries) deleteStmt.run(e.id);
+        // Re-probe local migrations that may now have no journal entry.
+        // The selective delete above keeps every applied migration journaled,
+        // so the probe only inserts entries for genuinely missing ones.
+        const journaledHashesAfter = new Set(
+          (
+            nativeDb.prepare('SELECT hash FROM "__drizzle_migrations"').all() as Array<{
+              hash: string;
+            }>
+          ).map((r) => r.hash),
+        );
+        for (const m of localMigrations) {
+          if (journaledHashesAfter.has(m.hash)) continue;
+          probeAndMarkApplied(nativeDb, m, logSubsystem);
         }
       }
     }


### PR DESCRIPTION
## Summary

E6-L8 of the SG-DB-SUBSTRATE-V2 store rewrite (saga T11242, epic T11249).

Removes the post-hoc **hash-drift repair** sub-case in `reconcileJournal` (`migration-manager.ts`). That logic UPDATEd a journal entry's hash *in place* when its NAME matched a local migration but its hash differed — a workaround for migration SQL being edited in a release.

All DDL is now owned by **immutable Drizzle forward migrations** (v1.0.0-rc.3 contract, E6 L1-L7). Migration files are never edited post-release, so name-matched hash drift can no longer occur. Any remaining orphan is a true orphan.

## Changes

- `reconcileJournal` now has exactly **two** Scenario-2 sub-cases:
  - **A** — DB-ahead (forward-compat): skip, no mutation.
  - **B** — true orphans (no local hash match): delete + re-probe via DDL.
- Drops the now-dead `localByName` map, the `hasMigNameCol` branch, the `driftEntries` partition, and the journal `name` column read (`dbEntries` now selects only `id, hash`).
- `migration-hash-drift.test.ts` rewritten to pin the two-sub-case contract (incl. a test asserting a name-matched stale hash is now treated as a true orphan and **deleted**, not updated in place).

## Acceptance criteria
- [x] AC1: Sub-case B (hash-drift UPDATE in place) removed from `reconcileJournal`
- [x] AC2: Only the true-orphan delete path and the DB-ahead skip path remain; tests updated
- [x] AC3: `pnpm run typecheck` passes (zero errors)
- [x] AC4: FULL `vitest run --project @cleocode/core` — zero new failures (store suite 1474/1474 green; the ~15 failures are pre-existing napi-stale worktree env flakes, unrelated to this change)

## Validation
- `pnpm biome check` clean · `pnpm run typecheck` zero errors · `node build.mjs` + CLI smoke OK
- `cleo check arch` 5/5 gates pass (incl. gate-2 DB-Open-Guard baseline 0)
- `@cleocode/runtime` 120/120 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)