### PR TITLE
chore(T11529): reduce DB-Open-Guard allowlist 14→3 + flip CI to --strict (E6-L9)

### DIFF
--- a/.github/workflows/arch-boundary-check.yml
+++ b/.github/workflows/arch-boundary-check.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Run lint-no-direct-db-open (baseline mode)
-        run: node scripts/lint-no-direct-db-open.mjs
+      - name: Run lint-no-direct-db-open (strict mode — T11529 · E6-L9)
+        run: node scripts/lint-no-direct-db-open.mjs --strict
 
       - name: Run lint-node-engine-ssot (T11281)
         run: node scripts/lint-node-engine-ssot.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ CI job: `Architectural Boundary Check (SG-ARCH-SOLID T9837)` (baseline mode by d
 |---|---------------------------------------|-------------------------------------------------|---------------------------------------------------|---------------------------------------------------------------------------------------|
 | 1 | `defineCommand` factory SSoT (T10072) | `scripts/lint-no-raw-define-command.mjs`        | `.cleo/define-command-ssot-baseline.json`         | Only `packages/cleo/src/cli/lib/define-cli-command.ts` may import from `'citty'`.    |
 | 2 | Paths SSoT (T9802 · D009)             | `scripts/lint-paths-ssot.mjs`                   | inline                                            | `env-paths`, `XDG_DATA_HOME` reads, `'/cleo/worktrees'` strings live in `packages/paths/` only. |
-| 3 | DB Open Guard (T10073 · ADR-068)      | `scripts/lint-no-direct-db-open.mjs`            | inline                                            | `new DatabaseSync(`/`new Database(` only inside `packages/core/src/store/` — others use `openCleoDb(role, cwd)`. |
+| 3 | DB Open Guard (T10073 · ADR-068 · T11529) | `scripts/lint-no-direct-db-open.mjs --strict` | inline (3-entry allowlist)                        | **STRICT (zero tolerance).** `new DatabaseSync(`/`new Database(` only inside the 3 canonical allowlist entries (store/, migration/, studio connections.ts) — everything else uses `openDualScopeDb`/`openCleoDb` or an inline `// db-open-allowed` marker. |
 | 4 | Contracts Fan-Out (T10074)            | `scripts/lint-contracts-fan-out.mjs`            | `scripts/.lint-contracts-fan-out-baseline.json`   | `export interface`/`type` in `cleo/` or `core/` imported by >2 packages must move to `packages/contracts/`. |
 | 5 | `SSoT-EXEMPT` linkage (T10075)        | `scripts/lint-no-ssot-exempt.mjs`               | inline                                            | Every `// SSoT-EXEMPT` comment must reference an open `T####` task.                  |
 | 6 | CLI package boundary (T9837e)         | `scripts/lint-cli-package-boundary.mjs`         | `scripts/.lint-cli-boundary-baseline.json`        | No standalone named function >30 LOC in `packages/cleo/src/cli/commands/**/*.ts` — move helpers to `core/`. |
@@ -84,20 +84,15 @@ CI job: `Architectural Boundary Check (SG-ARCH-SOLID T9837)` (baseline mode by d
 
 ### DB Open Guard — canonical allowlist (Gate 3)
 
+Reduced to **3 path entries** after the E6 store-rewrite cascade (T11521–T11528) routed every per-domain accessor through `openDualScopeDb` (T11529 · E6-L9). The gate now runs in `--strict` mode (zero tolerance).
+
 | Location                                              | Reason                                          |
 |-------------------------------------------------------|-------------------------------------------------|
-| `packages/core/src/store/**`                          | The chokepoint                                  |
-| `packages/core/src/migration/**`                      | Schema bootstrapping                            |
-| `packages/core/src/memory/claude-mem-migration.ts`    | One-shot memory migration                       |
-| `packages/core/src/memory/graph-memory-bridge.ts`     | Hot-path conduit open                           |
-| `packages/core/src/conduit/**`                        | Core-owned conduit infrastructure               |
-| `packages/core/src/upgrade.ts`                        | One-shot historical migration                   |
-| `packages/core/src/init.ts`                           | Bootstrap before chokepoint exists              |
-| `packages/core/src/agents/seed-install.ts`            | One-shot global install                         |
-| `packages/core/src/orchestration/classify.ts`         | JSDoc `@example` blocks only                    |
-| `packages/core/src/nexus/**`                          | Per-project graph DBs (non-CLEO metadata)       |
-| `packages/studio/src/lib/server/db/connections.ts`    | Per-project ProjectContext opens                |
-| Test files (`__tests__/`, `.test.ts`, `.spec.ts`)     | May open raw for seeding                        |
+| `packages/core/src/store/**`                          | The chokepoint (incl. `dual-scope-db.ts`)       |
+| `packages/core/src/migration/**`                      | Schema bootstrapping (pre-chokepoint)           |
+| `packages/studio/src/lib/server/db/connections.ts`    | Per-project ProjectContext opens (pre-port)     |
+
+Test files (`__tests__/`, `.test.ts`, `.spec.ts`) may open raw for seeding and are matched by a regex, not the canonical allowlist. Every other legitimate raw open (external claude-mem migration source, hot-path conduit, per-project nexus graph DBs) now carries an inline `// db-open-allowed: <reason>` marker at the call site instead of a directory-wide entry.
 
 Bypassing the chokepoint causes pragma drift (vs `specs/sqlite-pragmas.json`), WAL/lock contention, and topology opacity (`cleo health` cannot enumerate the handle).
 

--- a/packages/core/src/memory/claude-mem-migration.ts
+++ b/packages/core/src/memory/claude-mem-migration.ts
@@ -165,9 +165,7 @@ export async function migrateClaudeMem(
   // Open source DB read-only
   let sourceDb: DatabaseSync;
   try {
-    sourceDb = new DatabaseSync(sourcePath, {
-      readOnly: true,
-    });
+    sourceDb = new DatabaseSync(sourcePath, { readOnly: true }); // db-open-allowed: one-shot migration reads an EXTERNAL ~/.claude-mem/claude-mem.db source (not a CLEO metadata DB)
     applyPerfPragmas(sourceDb, { enableWal: false }); // read-only: WAL cannot be set (T9022)
   } catch (err) {
     throw new Error(

--- a/packages/core/src/memory/graph-memory-bridge.ts
+++ b/packages/core/src/memory/graph-memory-bridge.ts
@@ -1313,7 +1313,7 @@ export async function linkConduitMessagesToSymbols(
     }
 
     // Open conduit.db for this operation — apply pragma SSoT (T9023)
-    const conduitDb = new DatabaseSync(conduitDbPath);
+    const conduitDb = new DatabaseSync(conduitDbPath); // db-open-allowed: hot-path conduit.db open with full pragma SSoT (T9023); core-owned conduit infrastructure
     applyPerfPragmas(conduitDb); // hot-path; full pragma set (WAL, busy_timeout, cache)
     try {
       // Ensure brain.db is available for edge writes

--- a/scripts/lint-no-direct-db-open.mjs
+++ b/scripts/lint-no-direct-db-open.mjs
@@ -20,21 +20,24 @@
  *   1. `new DatabaseSync(` — Node.js built-in `node:sqlite` direct construction.
  *   2. `new Database(` — better-sqlite3 or other synchronous SQLite wrappers.
  *
- * Allowlisted locations (legitimate raw DB open sites):
+ * Allowlisted locations (legitimate raw DB open sites) — reduced to 3 canonical
+ * path entries after the E6 store-rewrite cascade (T11521-T11528) routed every
+ * per-domain accessor through `openDualScopeDb` (T11529 · E6-L9):
  *
- *   - `packages/core/src/store/**` — canonical open site; everything routes here
- *   - `packages/core/src/migration/**` — migration runner (schema bootstrapping)
- *   - `packages/core/src/memory/claude-mem-migration.ts` — one-shot memory migration
- *   - `packages/core/src/memory/graph-memory-bridge.ts` — hot-path conduit open
- *   - `packages/core/src/conduit/**` — conduit-sqlite is core-owned infrastructure
- *   - `packages/core/src/upgrade.ts` — one-shot signaldock migration
- *   - `packages/core/src/init.ts` — bootstrap open before chokepoint is available
- *   - `packages/core/src/agents/seed-install.ts` — one-shot global install
- *   - `packages/core/src/orchestration/classify.ts` — JSDoc @example blocks (false-positives)
- *   - `packages/core/src/nexus/**` — nexus graph per-project opens (non-CLEO-metadata DBs)
- *   - `packages/studio/src/lib/server/db/connections.ts` — per-project ProjectContext-driven opens
- *   - Test files (`__tests__/`, `.test.ts`, `.spec.ts`) — may open raw for seeding
- *   - Test factory/helper paths (see TEST_FACTORY_PREFIXES)
+ *   1. `packages/core/src/store/**` — the chokepoint itself (incl. `dual-scope-db.ts`);
+ *      everything routes here.
+ *   2. `packages/core/src/migration/**` — migration runner (schema bootstrapping,
+ *      runs before the chokepoint is available).
+ *   3. `packages/studio/src/lib/server/db/connections.ts` — per-project
+ *      ProjectContext-driven opens; pre-port (cannot route through `openCleoDb`,
+ *      applies pragma SSoT via `applyPerfPragmas`).
+ *
+ * Test files (`__tests__/`, `.test.ts`, `.spec.ts`) may open raw for seeding and
+ * are matched by ALLOW_PATH_REGEXES, not the canonical allowlist.
+ *
+ * Every other legitimate raw open (external claude-mem source, hot-path conduit,
+ * per-project nexus graph DBs) now carries an inline `// db-open-allowed` marker at
+ * the call site instead of a directory-wide allowlist entry.
  *
  * Per-line opt-out: append `// db-open-allowed` on the line with a brief rationale.
  *
@@ -82,29 +85,21 @@ const TEST_FILE_SUFFIXES = ['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx', '.
  * These correspond to the canonical exception sites documented above.
  */
 const ALLOW_PATH_PREFIXES = [
-  // Canonical chokepoint + all core/store sub-modules
+  // 1. Canonical chokepoint + all core/store sub-modules (incl. dual-scope-db.ts).
   'packages/core/src/store/',
-  // Migration runner — owns schema bootstrapping
+  // 2. Migration runner — owns schema bootstrapping (runs before the chokepoint).
   'packages/core/src/migration/',
-  // One-shot memory migration
-  'packages/core/src/memory/claude-mem-migration.ts',
-  // Hot-path conduit open (T9023 sweep complete)
-  'packages/core/src/memory/graph-memory-bridge.ts',
-  // Conduit infrastructure is core-owned
-  'packages/core/src/conduit/',
-  // One-shot signaldock migration (T9023 sweep complete)
-  'packages/core/src/upgrade.ts',
-  // Bootstrap open before chokepoint is available
-  'packages/core/src/init.ts',
-  // One-shot global install (T9023 sweep complete)
-  'packages/core/src/agents/seed-install.ts',
-  // classify.ts — JSDoc @example blocks with DatabaseSync (not actual code)
-  'packages/core/src/orchestration/classify.ts',
-  // Nexus graph DB — per-project non-CLEO-metadata files (nexus/store.ts uses db-open-allowed)
-  'packages/core/src/nexus/',
-  // Studio per-project getters take a ProjectContext and cannot route through openCleoDb;
-  // they do apply pragma SSoT via applyPerfPragmas.
+  // 3. Studio per-project getters take a ProjectContext and cannot route through
+  //    openCleoDb; they apply pragma SSoT via applyPerfPragmas (pre-port).
   'packages/studio/src/lib/server/db/connections.ts',
+  //
+  // E6-L9 (T11529): the per-domain entries below were removed after the store
+  // rewrite cascade (T11521-T11528) routed every accessor through openDualScopeDb.
+  // conduit/, upgrade.ts, init.ts, seed-install.ts no longer open raw; classify.ts
+  // only had JSDoc @example blocks (skipped by the comment-line filter); the
+  // remaining legitimate opens (claude-mem external source, graph-memory-bridge
+  // hot-path conduit, nexus per-project graph DBs) now carry inline
+  // `// db-open-allowed` markers at the call site.
 ];
 
 /** Regex patterns tested against the POSIX-relative path — always allowed. */


### PR DESCRIPTION
## T11529 — E6-L9 (FINAL leaf of the E6 cascade · epic T11249)

After the E6 store-rewrite cascade (T11521–T11528) routed every per-domain DB accessor through `openDualScopeDb`, the DB-Open-Guard no longer needs per-domain directory allowlist entries.

### Changes
- **AGENTS.md Gate 3 table:** 14 rows → **3 canonical entries** — `store/` (chokepoint, incl. `dual-scope-db.ts`) · `migration/` (bootstrap) · `studio connections.ts` (pre-port). Gate-3 summary row updated to `--strict`.
- **`scripts/lint-no-direct-db-open.mjs`** `ALLOW_PATH_PREFIXES`: collapsed to those 3 entries. Removed `conduit/` `upgrade.ts` `init.ts` `seed-install.ts` (no raw opens remain after L1–L8), `classify.ts` (JSDoc-only `@example`), `nexus/` (already inline-annotated).
- **`claude-mem-migration.ts` + `graph-memory-bridge.ts`:** added inline `// db-open-allowed` markers (external `~/.claude-mem` source / hot-path conduit) so their directory entries could drop without a strict violation.
- **`.github/workflows/arch-boundary-check.yml`** `db-open-guard` job: flipped baseline → `--strict`.

### Validation
- `node scripts/lint-no-direct-db-open.mjs --strict` → **zero violations**.
- `cleo check arch` → 5/5 gates pass (gate-2 db-open = 0 violations; strict-mode gate-2 also passes — pre-existing gate-1/gate-5 strict debt is unrelated and baselined under T9837a/T9837e).
- `pnpm run typecheck` (tsc -b) clean · `node build.mjs` clean · biome clean.
- Not a shipped template (cleocode-dev-only job) → no Gate-7 deployed-template-parity impact.

Closes the E6 L1–L9 cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)